### PR TITLE
fix(mysql): 查询结果中正确序列化 DATETIME 等时间类型，避免显示为 null

### DIFF
--- a/src-tauri/src/db/mysql.rs
+++ b/src-tauri/src/db/mysql.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::mysql::{MySqlPool, MySqlPoolOptions, MySqlRow};
 use sqlx::{Column, Executor, Row, TypeInfo, ValueRef};
 use std::time::{Duration, Instant};
@@ -26,6 +27,22 @@ fn get_opt_str(row: &MySqlRow, name: &str) -> Option<String> {
                 .flatten()
                 .map(|b| String::from_utf8_lossy(&b).to_string())
         })
+}
+
+fn mysql_temporal_to_json_value(row: &MySqlRow, idx: usize) -> Option<serde_json::Value> {
+    if let Ok(v) = row.try_get::<NaiveDateTime, _>(idx) {
+        return Some(serde_json::Value::String(v.to_string()));
+    }
+    if let Ok(v) = row.try_get::<DateTime<Utc>, _>(idx) {
+        return Some(serde_json::Value::String(v.to_rfc3339()));
+    }
+    if let Ok(v) = row.try_get::<NaiveDate, _>(idx) {
+        return Some(serde_json::Value::String(v.to_string()));
+    }
+    if let Ok(v) = row.try_get::<NaiveTime, _>(idx) {
+        return Some(serde_json::Value::String(v.to_string()));
+    }
+    None
 }
 
 fn mysql_value_to_json(row: &MySqlRow, idx: usize, type_name: &str) -> serde_json::Value {
@@ -60,6 +77,17 @@ fn mysql_value_to_json(row: &MySqlRow, idx: usize, type_name: &str) -> serde_jso
             .unwrap_or(serde_json::Value::Null);
     }
 
+    if upper_type.starts_with("DATETIME")
+        || upper_type.starts_with("TIMESTAMP")
+        || upper_type == "DATE"
+        || upper_type == "TIME"
+        || upper_type.starts_with("TIME(")
+    {
+        if let Some(v) = mysql_temporal_to_json_value(row, idx) {
+            return v;
+        }
+    }
+
     row.try_get::<String, _>(idx)
         .map(serde_json::Value::String)
         .or_else(|_| row.try_get::<i64, _>(idx).map(|v| serde_json::Value::Number(v.into())))
@@ -74,6 +102,7 @@ fn mysql_value_to_json(row: &MySqlRow, idx: usize, type_name: &str) -> serde_jso
             row.try_get::<Vec<u8>, _>(idx)
                 .map(|b| serde_json::Value::String(String::from_utf8_lossy(&b).to_string()))
         })
+        .or_else(|e| mysql_temporal_to_json_value(row, idx).ok_or(e))
         .unwrap_or(serde_json::Value::Null)
 }
 


### PR DESCRIPTION
# 主要工作
修复 MySQL 查询结果中 DATETIME / TIMESTAMP / DATE / TIME 有值却显示为 null 的问题。

# 原因

execute_query 将行映射为 JSON 时，仅尝试 String、数值、Vec<u8> 等类型。在启用 sqlx 的 chrono 特性后，上述时间列由驱动解码为 chrono 类型（如 NaiveDateTime、NaiveDate 等），无法用 try_get::<String> 取出，导致一路回落为 serde_json::Null，与库内实际有值无关。

# 改动

- 按列类型（及未知类型名的兜底）对时间列做 chrono 解码，再格式化为字符串写入 JSON。
- DateTime<Utc> 使用 to_rfc3339()，保留时区语义；其余时间类型仍以字符串形式展示，与现有结果集展示方式一致。

# 验证

对含 DATETIME、TIMESTAMP、DATE、TIME 的表执行 SELECT，确认结果显示中不再出现无意义的 null。

##  修复前：
<img width="1280" height="794" alt="image" src="https://github.com/user-attachments/assets/fcd3b566-dd53-4364-9c6a-3151c558fbdd" />

## 修复后：
<img width="1280" height="830" alt="image" src="https://github.com/user-attachments/assets/c781bc20-eb79-4f17-93b3-e255b48aa5dc" />
