### PR TITLE
修复 macOS 下 Cmd+Enter 执行 SQL 无效且会换行的问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import * as api from "@/lib/tauri";
 import { resolveExecutableSql } from "@/lib/sqlExecutionTarget";
 import type { SqlFormatDialect } from "@/lib/sqlFormatter";
+import { isCloseTabShortcut, isExecuteSqlShortcut } from "@/lib/keyboardShortcuts";
 
 const { t } = useI18n();
 const connectionStore = useConnectionStore();
@@ -508,12 +509,27 @@ function openLatestRelease() {
   open(url);
 }
 
+function isQueryEditorTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && !!target.closest("[data-query-editor-root]");
+}
+
 function handleKeydown(e: KeyboardEvent) {
-  if (e.metaKey && e.key === "w") {
+  if (isCloseTabShortcut(e)) {
     e.preventDefault();
     if (queryStore.activeTabId) {
       queryStore.closeTab(queryStore.activeTabId);
     }
+    return;
+  }
+
+  if (
+    activeTab.value?.mode === "query"
+    && isExecuteSqlShortcut(e)
+    && isQueryEditorTarget(e.target)
+  ) {
+    e.preventDefault();
+    e.stopPropagation();
+    tryExecute();
   }
 }
 
@@ -521,13 +537,13 @@ onMounted(() => {
   applyTheme();
   connectionStore.initFromDisk();
   settingsStore.initAiConfig();
-  window.addEventListener("keydown", handleKeydown);
+  window.addEventListener("keydown", handleKeydown, true);
   setupFileDrop();
   checkUpdates({ silent: true });
 });
 
 onUnmounted(() => {
-  window.removeEventListener("keydown", handleKeydown);
+  window.removeEventListener("keydown", handleKeydown, true);
 });
 
 const DB_EXTENSIONS = [".db", ".sqlite", ".sqlite3", ".duckdb"];

--- a/src/components/editor/QueryEditor.vue
+++ b/src/components/editor/QueryEditor.vue
@@ -212,5 +212,5 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="editorRef" class="h-full w-full overflow-hidden" />
+  <div ref="editorRef" data-query-editor-root class="h-full w-full overflow-hidden" />
 </template>

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -1,0 +1,20 @@
+export interface ShortcutLikeEvent {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  isComposing?: boolean;
+}
+
+export function isExecuteSqlShortcut(event: ShortcutLikeEvent): boolean {
+  if (event.isComposing) return false;
+  if (event.altKey) return false;
+  if (!event.metaKey && !event.ctrlKey) return false;
+  return event.key === "Enter";
+}
+
+export function isCloseTabShortcut(event: ShortcutLikeEvent): boolean {
+  if (event.isComposing) return false;
+  if (!event.metaKey) return false;
+  return event.key.toLowerCase() === "w";
+}

--- a/tests/keyboardShortcuts.test.ts
+++ b/tests/keyboardShortcuts.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { isCloseTabShortcut, isExecuteSqlShortcut } from "../src/lib/keyboardShortcuts.ts";
+
+test("matches Cmd+Enter for SQL execution", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter", metaKey: true }), true);
+});
+
+test("matches Ctrl+Enter for SQL execution", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter", ctrlKey: true }), true);
+});
+
+test("ignores Enter without modifier", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter" }), false);
+});
+
+test("ignores composing input events", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter", metaKey: true, isComposing: true }), false);
+});
+
+test("matches Cmd+W for closing query tabs", () => {
+  assert.equal(isCloseTabShortcut({ key: "w", metaKey: true }), true);
+});
+
+test("ignores Ctrl+W for closing query tabs", () => {
+  assert.equal(isCloseTabShortcut({ key: "w", ctrlKey: true }), false);
+});


### PR DESCRIPTION
## 问题说明
在 macOS 环境下，查询编辑器中的 `Cmd+Enter` 存在两个问题：
- 无法稳定执行 SQL
- 触发执行时，编辑器仍会插入换行，导致交互行为异常

## 解决方案
- 将 SQL 执行快捷键从编辑器内部处理调整为窗口级统一处理
- 限制快捷键仅在查询编辑器获得焦点时生效，避免影响其他区域
- 在事件捕获阶段拦截 `Cmd+Enter`，先执行 SQL，再阻止默认换行行为
- 保留 `Ctrl+Enter` 的执行能力，兼容现有使用习惯

## 验证结果
- `node --test tests/*.test.ts`
- `npm run build`