### PR TITLE
fix(ci): fix YAML parsing error in publish-packages workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -92,42 +92,44 @@ jobs:
           mkdir -p Casks
 
           cat > Casks/dbx.rb <<'RUBY_EOF'
-cask "dbx" do
-  version "__VERSION__"
+          cask "dbx" do
+            version "__VERSION__"
 
-  on_arm do
-    url "https://github.com/__OWNER__/__APP__/releases/download/v#{version}/__APP___#{version}_aarch64.dmg",
-        verified: "github.com/__OWNER__/__APP__/"
-    sha256 "__SHA_ARM64__"
-  end
+            on_arm do
+              url "https://github.com/__OWNER__/__APP__/releases/download/v#{version}/__APP___#{version}_aarch64.dmg",
+                  verified: "github.com/__OWNER__/__APP__/"
+              sha256 "__SHA_ARM64__"
+            end
 
-  on_intel do
-    url "https://github.com/__OWNER__/__APP__/releases/download/v#{version}/__APP___#{version}_x64.dmg",
-        verified: "github.com/__OWNER__/__APP__/"
-    sha256 "__SHA_X64__"
-  end
+            on_intel do
+              url "https://github.com/__OWNER__/__APP__/releases/download/v#{version}/__APP___#{version}_x64.dmg",
+                  verified: "github.com/__OWNER__/__APP__/"
+              sha256 "__SHA_X64__"
+            end
 
-  name "DBX"
-  desc "Open-source database management tool"
-  homepage "https://github.com/__OWNER__/__APP__"
+            name "DBX"
+            desc "Open-source database management tool"
+            homepage "https://github.com/__OWNER__/__APP__"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+            livecheck do
+              url :url
+              strategy :github_latest
+            end
 
-  depends_on macos: ">= :big_sur"
+            depends_on macos: ">= :big_sur"
 
-  app "dbx.app"
+            app "dbx.app"
 
-  zap trash: [
-    "~/Library/Application Support/com.dbx.app",
-    "~/Library/Caches/com.dbx.app",
-    "~/Library/Preferences/com.dbx.app.plist",
-    "~/Library/Logs/com.dbx.app",
-  ]
-end
-RUBY_EOF
+            zap trash: [
+              "~/Library/Application Support/com.dbx.app",
+              "~/Library/Caches/com.dbx.app",
+              "~/Library/Preferences/com.dbx.app.plist",
+              "~/Library/Logs/com.dbx.app",
+            ]
+          end
+          RUBY_EOF
+
+          sed -i 's/^          //' Casks/dbx.rb
 
           sed -i "s/__VERSION__/${VERSION}/g" Casks/dbx.rb
           sed -i "s/__OWNER__/${REPO_OWNER}/g" Casks/dbx.rb


### PR DESCRIPTION
## Summary
- Homebrew 的 Ruby heredoc 内容未缩进，导致 YAML `run: |` 块解析失败
- 每次 push 都触发 workflow 解析错误（所有 publish-packages 运行均失败）
- 缩进 heredoc 内容并添加 `sed` 去除前缀空格，与 Scoop 部分保持一致

## Test plan
- [x] YAML lint 验证通过
- [ ] 下次创建 release 时验证 Homebrew/Scoop 发布正常