### PR TITLE
修复 macOS 下 Cmd+Enter 执行 SQL 无效且会换行的问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import * as api from "@/lib/tauri";
 import { resolveExecutableSql } from "@/lib/sqlExecutionTarget";
 import type { SqlFormatDialect } from "@/lib/sqlFormatter";
+import { isCloseTabShortcut, isExecuteSqlShortcut } from "@/lib/keyboardShortcuts";
 
 const { t } = useI18n();
 const connectionStore = useConnectionStore();
@@ -508,12 +509,27 @@ function openLatestRelease() {
   open(url);
 }
 
+function isQueryEditorTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && !!target.closest("[data-query-editor-root]");
+}
+
 function handleKeydown(e: KeyboardEvent) {
-  if (e.metaKey && e.key === "w") {
+  if (isCloseTabShortcut(e)) {
     e.preventDefault();
     if (queryStore.activeTabId) {
       queryStore.closeTab(queryStore.activeTabId);
     }
+    return;
+  }
+
+  if (
+    activeTab.value?.mode === "query"
+    && isExecuteSqlShortcut(e)
+    && isQueryEditorTarget(e.target)
+  ) {
+    e.preventDefault();
+    e.stopPropagation();
+    tryExecute();
   }
 }
 
@@ -521,13 +537,13 @@ onMounted(() => {
   applyTheme();
   connectionStore.initFromDisk();
   settingsStore.initAiConfig();
-  window.addEventListener("keydown", handleKeydown);
+  window.addEventListener("keydown", handleKeydown, true);
   setupFileDrop();
   checkUpdates({ silent: true });
 });
 
 onUnmounted(() => {
-  window.removeEventListener("keydown", handleKeydown);
+  window.removeEventListener("keydown", handleKeydown, true);
 });
 
 const DB_EXTENSIONS = [".db", ".sqlite", ".sqlite3", ".duckdb"];

--- a/src/components/editor/QueryEditor.vue
+++ b/src/components/editor/QueryEditor.vue
@@ -212,5 +212,5 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="editorRef" class="h-full w-full overflow-hidden" />
+  <div ref="editorRef" data-query-editor-root class="h-full w-full overflow-hidden" />
 </template>

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -1,0 +1,20 @@
+export interface ShortcutLikeEvent {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  isComposing?: boolean;
+}
+
+export function isExecuteSqlShortcut(event: ShortcutLikeEvent): boolean {
+  if (event.isComposing) return false;
+  if (event.altKey) return false;
+  if (!event.metaKey && !event.ctrlKey) return false;
+  return event.key === "Enter";
+}
+
+export function isCloseTabShortcut(event: ShortcutLikeEvent): boolean {
+  if (event.isComposing) return false;
+  if (!event.metaKey) return false;
+  return event.key.toLowerCase() === "w";
+}

--- a/tests/keyboardShortcuts.test.ts
+++ b/tests/keyboardShortcuts.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { isCloseTabShortcut, isExecuteSqlShortcut } from "../src/lib/keyboardShortcuts.ts";
+
+test("matches Cmd+Enter for SQL execution", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter", metaKey: true }), true);
+});
+
+test("matches Ctrl+Enter for SQL execution", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter", ctrlKey: true }), true);
+});
+
+test("ignores Enter without modifier", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter" }), false);
+});
+
+test("ignores composing input events", () => {
+  assert.equal(isExecuteSqlShortcut({ key: "Enter", metaKey: true, isComposing: true }), false);
+});
+
+test("matches Cmd+W for closing query tabs", () => {
+  assert.equal(isCloseTabShortcut({ key: "w", metaKey: true }), true);
+});
+
+test("ignores Ctrl+W for closing query tabs", () => {
+  assert.equal(isCloseTabShortcut({ key: "w", ctrlKey: true }), false);
+});


### PR DESCRIPTION
## 说明
- 修复 macOS 下 `Cmd+Enter` 执行 SQL 无效的问题
- 修复 `Cmd+Enter` 被编辑器当作换行处理的问题
- 保留现有的选中 SQL 执行能力与 SQL 格式化相关逻辑

## 验证
- `node --test tests/keyboardShortcuts.test.ts`
- `npm run build`
