### PR TITLE
fix(ci): wait for Release workflow before publishing packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,8 +1,9 @@
 name: Publish Packages
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -14,13 +15,13 @@ env:
 jobs:
   publish:
     name: Publish to Homebrew & Scoop
-    if: github.event_name == 'release'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Extract version from tag
         id: version
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ github.event.workflow_run.head_branch }}"
           VERSION="${TAG#v}"
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::Tag '${TAG}' does not look like a semver version."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dbx",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbx"
-version = "0.2.0"
+version = "0.2.1"
 description = "Open-source database management tool"
 authors = ["skyler"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "dbx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.dbx.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- publish-packages 之前在 release 发布时立即触发，此时构建还没完成，下载不到安装包
- 改为 `workflow_run` 触发，等 Release 构建完成后再发布到 Homebrew/Scoop