### PR TITLE
feat(mongodb): support direct URL connection string

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,8 +1,9 @@
 name: Publish Packages
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -14,13 +15,13 @@ env:
 jobs:
   publish:
     name: Publish to Homebrew & Scoop
-    if: github.event_name == 'release'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Extract version from tag
         id: version
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ github.event.workflow_run.head_branch }}"
           VERSION="${TAG#v}"
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "::error::Tag '${TAG}' does not look like a semver version."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dbx",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbx"
-version = "0.2.0"
+version = "0.2.1"
 description = "Open-source database management tool"
 authors = ["skyler"]
 license = "MIT"

--- a/src-tauri/src/models/connection.rs
+++ b/src-tauri/src/models/connection.rs
@@ -33,6 +33,8 @@ pub struct ConnectionConfig {
     pub ssh_key_path: String,
     #[serde(default)]
     pub ssl: bool,
+    #[serde(default)]
+    pub connection_string: Option<String>,
 }
 
 fn default_ssh_port() -> u16 {
@@ -98,7 +100,12 @@ impl ConnectionConfig {
                 "server=tcp:{host},{port};database={}",
                 self.database.as_deref().unwrap_or("master")
             ),
-            DatabaseType::MongoDb => format!("mongodb://{host}:{port}{db_part}"),
+            DatabaseType::MongoDb => {
+                if let Some(cs) = self.connection_string.as_deref().filter(|s| !s.is_empty()) {
+                    return cs.to_string();
+                }
+                format!("mongodb://{host}:{port}{db_part}")
+            }
             DatabaseType::Oracle => format!("oracle://{host}:{port}{db_part}"),
         }
     }
@@ -151,6 +158,9 @@ impl ConnectionConfig {
                 self.database.as_deref().unwrap_or("master")
             ),
             DatabaseType::MongoDb => {
+                if let Some(cs) = self.connection_string.as_deref().filter(|s| !s.is_empty()) {
+                    return cs.to_string();
+                }
                 if self.username.is_empty() {
                     format!("mongodb://{host}:{port}{db_part}")
                 } else {
@@ -210,6 +220,7 @@ mod tests {
             ssh_password: String::new(),
             ssh_key_path: String::new(),
             ssl: false,
+            connection_string: None,
         }
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "dbx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.dbx.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/connection/ConnectionDialog.vue
+++ b/src/components/connection/ConnectionDialog.vue
@@ -54,11 +54,13 @@ const defaultForm = (): Omit<ConnectionConfig, "id"> => ({
   ssh_password: "",
   ssh_key_path: "",
   ssl: false,
+  connection_string: undefined,
 });
 
 const form = ref(defaultForm());
 const selectedType = ref("mysql");
 const customDriverName = ref("");
+const mongoUseUrl = ref(false);
 
 const colorOptions = [
   { value: "", class: "bg-transparent border-dashed", labelKey: "connection.colorNone" },
@@ -146,8 +148,10 @@ watch(() => props.editConfig, (config) => {
       ssh_password: config.ssh_password || "",
       ssh_key_path: config.ssh_key_path || "",
       ssl: config.ssl || false,
+      connection_string: config.connection_string,
     };
     selectedType.value = profile;
+    mongoUseUrl.value = !!config.connection_string;
     customDriverName.value = isCustomCompatibleProfile() ? (config.driver_label || "") : "";
   } else {
     editingId.value = null;
@@ -227,6 +231,7 @@ function resetForm() {
   editingId.value = null;
   form.value = defaultForm();
   selectedType.value = "mysql";
+  mongoUseUrl.value = false;
   testResult.value = null;
 }
 
@@ -377,6 +382,46 @@ watch([() => editingId.value, () => open.value], () => {
           </div>
         </template>
 
+        <!-- MongoDB: URL or form -->
+        <template v-else-if="form.db_type === 'mongodb'">
+          <div class="grid grid-cols-4 items-center gap-4">
+            <Label class="text-right text-xs">{{ t('connection.mode') }}</Label>
+            <div class="col-span-3 flex gap-2">
+              <Button size="sm" :variant="mongoUseUrl ? 'outline' : 'default'" @click="mongoUseUrl = false">{{ t('connection.modeForm') }}</Button>
+              <Button size="sm" :variant="mongoUseUrl ? 'default' : 'outline'" @click="mongoUseUrl = true">URL</Button>
+            </div>
+          </div>
+          <template v-if="mongoUseUrl">
+            <div class="grid grid-cols-4 items-start gap-4">
+              <Label class="text-right mt-2">URL</Label>
+              <textarea
+                v-model="form.connection_string"
+                class="col-span-3 flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                placeholder="mongodb+srv://user:pass@cluster.mongodb.net/mydb"
+              />
+            </div>
+          </template>
+          <template v-else>
+            <div class="grid grid-cols-4 items-center gap-4">
+              <Label class="text-right">{{ t('connection.host') }}</Label>
+              <Input v-model="form.host" class="col-span-2" />
+              <Input v-model.number="form.port" type="number" class="col-span-1" />
+            </div>
+            <div class="grid grid-cols-4 items-center gap-4">
+              <Label class="text-right">{{ t('connection.user') }}</Label>
+              <Input v-model="form.username" class="col-span-3" />
+            </div>
+            <div class="grid grid-cols-4 items-center gap-4">
+              <Label class="text-right">{{ t('connection.password') }}</Label>
+              <Input v-model="form.password" type="password" class="col-span-3" />
+            </div>
+            <div class="grid grid-cols-4 items-center gap-4">
+              <Label class="text-right">{{ t('connection.database') }}</Label>
+              <Input v-model="form.database" class="col-span-3" :placeholder="t('connection.databasePlaceholder')" />
+            </div>
+          </template>
+        </template>
+
         <!-- MySQL / PostgreSQL: host, port, user, password, database -->
         <template v-else>
           <div class="grid grid-cols-4 items-center gap-4">
@@ -444,7 +489,7 @@ watch([() => editingId.value, () => open.value], () => {
         <Button variant="outline" :disabled="isTesting || isSaving" @click="testConnection">
           {{ isTesting ? t('connection.testing') : t('connection.test') }}
         </Button>
-        <Button @click="save" :disabled="isSaving || !form.name || !form.host">
+        <Button @click="save" :disabled="isSaving || !form.name || (!form.host && !(mongoUseUrl && form.connection_string))">
           {{ isSaving ? t('common.loading') : (editingId ? t('connection.save') : t('connection.saveAndConnect')) }}
         </Button>
       </DialogFooter>

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -41,6 +41,8 @@ export default {
     driverName: "驱动名称",
     driverNamePlaceholder: "厂商或环境名称",
     urlParams: "URL 参数",
+    mode: "连接方式",
+    modeForm: "表单",
     test: "测试",
     testing: "测试中...",
     saveAndConnect: "保存并连接",

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -20,6 +20,7 @@ export interface ConnectionConfig {
   ssh_password?: string;
   ssh_key_path?: string;
   ssl?: boolean;
+  connection_string?: string;
 }
 
 export interface DatabaseInfo {


### PR DESCRIPTION
## Summary
- MongoDB 连接对话框新增「表单 / URL」模式切换
- URL 模式下可直接粘贴完整连接字符串（`mongodb+srv://`、副本集等）
- 后端 `connection_url()` 优先使用 `connection_string` 字段

## Test plan
- [ ] 用 `mongodb+srv://...` 连接 Atlas 集群
- [ ] 用 `mongodb://host1,host2/db?replicaSet=rs0` 连接副本集
- [ ] 表单模式仍正常工作
- [ ] 编辑已有 URL 模式连接时正确回显