### PR TITLE
fix(postgres): filter out system temp schemas

### DIFF
--- a/src-tauri/src/db/postgres.rs
+++ b/src-tauri/src/db/postgres.rs
@@ -52,6 +52,8 @@ pub async fn list_schemas(pool: &PgPool) -> Result<Vec<String>, String> {
     let rows: Vec<PgRow> = sqlx::query(
         "SELECT schema_name FROM information_schema.schemata \
          WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast') \
+         AND schema_name NOT LIKE 'pg_toast_temp_%' \
+         AND schema_name NOT LIKE 'pg_temp_%' \
          ORDER BY schema_name",
     )
     .fetch_all(pool)


### PR DESCRIPTION
## Summary
- 过滤 `pg_toast_temp_*` 和 `pg_temp_*` 系统临时 schema，避免侧边栏显示几百个无用节点

## Test plan
- [ ] PostgreSQL 数据库展开后只显示用户 schema（如 public、sde）