### PR TITLE
Fix SQLite UNC path connections

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -93,7 +93,7 @@ impl AppState {
             DatabaseType::Mysql => PoolKind::Mysql(db::mysql::connect(&url).await?, false),
             DatabaseType::Doris | DatabaseType::StarRocks => PoolKind::Mysql(db::mysql::connect_bare(&url).await?, true),
             DatabaseType::Postgres | DatabaseType::Redshift => PoolKind::Postgres(db::postgres::connect(&url).await?),
-            DatabaseType::Sqlite => PoolKind::Sqlite(db::sqlite::connect(&url).await?),
+            DatabaseType::Sqlite => PoolKind::Sqlite(db::sqlite::connect_path(&db_config.host).await?),
             DatabaseType::Redis => {
                 let con = db::redis_driver::connect(&url).await?;
                 PoolKind::Redis(tokio::sync::Mutex::new(con))
@@ -302,7 +302,7 @@ pub async fn test_connection(
             }
             Err(e) => Err(e),
         },
-        DatabaseType::Sqlite => match db::sqlite::connect(&url).await {
+        DatabaseType::Sqlite => match db::sqlite::connect_path(&config.host).await {
             Ok(pool) => {
                 pool.close().await;
                 Ok("Connection successful".to_string())
@@ -387,7 +387,7 @@ pub async fn connect_db(
         DatabaseType::Mysql => PoolKind::Mysql(db::mysql::connect(&url).await?, false),
         DatabaseType::Doris | DatabaseType::StarRocks => PoolKind::Mysql(db::mysql::connect_bare(&url).await?, true),
         DatabaseType::Postgres | DatabaseType::Redshift => PoolKind::Postgres(db::postgres::connect(&url).await?),
-        DatabaseType::Sqlite => PoolKind::Sqlite(db::sqlite::connect(&url).await?),
+        DatabaseType::Sqlite => PoolKind::Sqlite(db::sqlite::connect_path(&config.host).await?),
         DatabaseType::Redis => {
             let con = db::redis_driver::connect(&url).await?;
             PoolKind::Redis(tokio::sync::Mutex::new(con))

--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -1,4 +1,4 @@
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions, SqliteRow};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions, SqliteRow};
 use sqlx::{Column, Executor, Row};
 use std::time::{Duration, Instant};
 
@@ -10,6 +10,20 @@ pub async fn connect(url: &str) -> Result<SqlitePool, String> {
         .acquire_timeout(Duration::from_secs(10))
         .idle_timeout(Duration::from_secs(300))
         .connect(url)
+        .await
+        .map_err(|e| format!("SQLite connection failed: {e}"))
+}
+
+pub async fn connect_path(path: &str) -> Result<SqlitePool, String> {
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true);
+
+    SqlitePoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(10))
+        .idle_timeout(Duration::from_secs(300))
+        .connect_with(options)
         .await
         .map_err(|e| format!("SQLite connection failed: {e}"))
 }


### PR DESCRIPTION
## Summary
- Open SQLite files with `SqliteConnectOptions::filename(...)`
- Avoid appending `?mode=rwc` directly to UNC/WSL/SMB filesystem paths