### PR TITLE
issue #88 , #86 fix 

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -157,7 +157,7 @@ fn mysql_value_to_json(row: &MySqlRow, idx: usize, type_name: &str) -> serde_jso
 pub async fn connect(url: &str) -> Result<MySqlPool, String> {
     MySqlPoolOptions::new()
         .max_connections(5)
-        .acquire_timeout(Duration::from_secs(10))
+        .acquire_timeout(Duration::from_secs(5))
         .idle_timeout(Duration::from_secs(300))
         .connect(url)
         .await
@@ -174,7 +174,7 @@ pub async fn connect_bare(url: &str) -> Result<MySqlPool, String> {
         .timezone(None);
     MySqlPoolOptions::new()
         .max_connections(5)
-        .acquire_timeout(Duration::from_secs(10))
+        .acquire_timeout(Duration::from_secs(5))
         .idle_timeout(Duration::from_secs(300))
         .connect_with(options)
         .await

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -89,7 +89,7 @@ fn pg_value_to_json(row: &PgRow, idx: usize, type_name: &str) -> serde_json::Val
 pub async fn connect(url: &str) -> Result<PgPool, String> {
     PgPoolOptions::new()
         .max_connections(5)
-        .acquire_timeout(Duration::from_secs(10))
+        .acquire_timeout(Duration::from_secs(5))
         .idle_timeout(Duration::from_secs(300))
         .connect(url)
         .await

--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -28,11 +28,11 @@ pub struct RedisValue {
 pub async fn connect(url: &str) -> Result<redis::aio::MultiplexedConnection, String> {
     let client = redis::Client::open(url).map_err(|e| format!("Redis connection failed: {e}"))?;
     let mut con = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
+        std::time::Duration::from_secs(5),
         client.get_multiplexed_async_connection(),
     )
     .await
-    .map_err(|_| "Redis connection timed out (10s)".to_string())?
+    .map_err(|_| "Redis connection timed out (5s)".to_string())?
     .map_err(|e| format!("Redis connection failed: {e}"))?;
 
     redis::cmd("PING")

--- a/crates/dbx-core/src/db/sqlite.rs
+++ b/crates/dbx-core/src/db/sqlite.rs
@@ -5,9 +5,14 @@ use std::time::{Duration, Instant};
 use crate::types::{ColumnInfo, DatabaseInfo, ForeignKeyInfo, IndexInfo, QueryResult, TableInfo, TriggerInfo};
 
 pub async fn connect_path(path: &str) -> Result<SqlitePool, String> {
+    // Check if the file exists (for non-memory databases)
+    if path != ":memory:" && !std::path::Path::new(path).exists() {
+        return Err(format!("SQLite database file not found: {}", path));
+    }
+
     let mut options = SqliteConnectOptions::new()
         .filename(path)
-        .create_if_missing(true);
+        .create_if_missing(false);
 
     if is_network_path(path) {
         options = options.vfs("unix-nolock");

--- a/crates/dbx-core/src/db/sqlite.rs
+++ b/crates/dbx-core/src/db/sqlite.rs
@@ -20,7 +20,7 @@ pub async fn connect_path(path: &str) -> Result<SqlitePool, String> {
 
     SqlitePoolOptions::new()
         .max_connections(5)
-        .acquire_timeout(Duration::from_secs(10))
+        .acquire_timeout(Duration::from_secs(5))
         .idle_timeout(Duration::from_secs(300))
         .connect_with(options)
         .await


### PR DESCRIPTION
1.Changed .create_if_missing(true) to .create_if_missing(false)
2.Added a file existence check before attempting to connect — if the database file doesn't exist (and it's not an in-memory database), the connection now fails with a clear error message: "SQLite database file not found"
3. Reduced Timeout to 5 seconds 