### PR TITLE
fix: 修复Postgres的UUID类型字段被显示为NULL的问题

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -73,6 +73,7 @@ fn pg_value_to_json(row: &PgRow, idx: usize, type_name: &str) -> serde_json::Val
             })
         })
         .or_else(|_| row.try_get::<bool, _>(idx).map(serde_json::Value::Bool))
+        .or_else(|_| row.try_get::<uuid::Uuid, _>(idx).map(|v| serde_json::Value::String(v.to_string())))
         .or_else(|e| pg_temporal_to_json_value(row, idx).ok_or(e))
         .unwrap_or(serde_json::Value::Null)
 }


### PR DESCRIPTION
在当前版本中，访问Postgres数据库并且表中有UUID类型字段时，该类型字段的值全部显示为NULL，原因是没有处理该类型。
PostgreSQL 的 UUID 类型是二进制格式，sqlx 不会自动将其转为 String。原代码的 fallback 链（String -> i64 -> i32 -> f64 -> bool -> temporal）全部失败后直接返回了 Null，所以 UUID 列全部显示为 NULL。
修复方案：在 fallback 链中 bool 之后、temporal 之前，加入了对 uuid::Uuid 的尝试。