### PR TITLE
fix(postgres): use quote_ident for case-sensitive table names

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -198,7 +198,7 @@ pub async fn get_columns(pool: &PgPool, schema: &str, table: &str) -> Result<Vec
          FROM pg_attribute a \
          JOIN pg_type t ON t.oid = a.atttypid \
          LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum \
-         WHERE a.attrelid = ($1 || '.' || $2)::regclass \
+         WHERE a.attrelid = (quote_ident($1) || '.' || quote_ident($2))::regclass \
          AND a.attnum > 0 AND NOT a.attisdropped \
          ORDER BY a.attnum",
     )


### PR DESCRIPTION
#109 fix
## 背景说明
PostgreSQL 会将未加引号的标识符自动折叠为小写，导致使用大写表名（如 "Agent"）
查询时因匹配不到小写版本而报错：relation "agent" does not exist。

## 修改内容
- 在 get_columns 的系统目录查询中，对 schema 和 table 标识符使用 quote_ident() 包裹，
  确保大写/混合大小写的表名能正确匹配。

## 测试
- 小写表名：兼容，行为不变
- 大写表名（"Agent"）：修复后可正常查询