### PR TITLE
Fix JSON cell display in data grid

### DIFF
--- a/src/components/grid/DataGrid.vue
+++ b/src/components/grid/DataGrid.vue
@@ -60,7 +60,8 @@ import {
   type CellSelectionRange,
 } from "@/lib/gridSelection";
 import { buildTableSelectSql, normalizeWhereInput, quoteTableIdentifier } from "@/lib/tableSelectSql";
-import { buildDataGridSaveStatements, formatGridSqlLiteral } from "@/lib/dataGridSql";
+import { buildDataGridSaveStatements, formatGridSqlLiteral, type GridCellValue } from "@/lib/dataGridSql";
+import { formatGridCellDisplay, formatGridCellJsonPreview } from "@/lib/gridCell";
 import { formatMarkdownTable } from "@/lib/markdownTable";
 import {
   matchesRowStatusFilter,
@@ -442,7 +443,7 @@ function changePageSize(size: number) {
 }
 
 // --- Editing ---
-type CellValue = string | number | boolean | null;
+type CellValue = GridCellValue;
 const editingCell = ref<{ rowId: number; col: number } | null>(null);
 const editValue = ref("");
 const scrollerRef = ref<HTMLElement | { $el?: HTMLElement; el?: HTMLElement | { value?: HTMLElement } } | null>(null);
@@ -462,7 +463,7 @@ const sortedRows = computed(() => {
     const q = clientSearchText.value.toLowerCase();
     rows = rows.filter(({ row, sourceIndex }) => {
       const data = rowDataWithChanges(row, sourceIndex);
-      return data.some((cell) => cell !== null && String(cell).toLowerCase().includes(q));
+      return data.some((cell) => cell !== null && formatCell(cell).toLowerCase().includes(q));
     });
   }
   return rows;
@@ -494,7 +495,7 @@ const displayItems = computed<RowItem[]>(() => {
     const status: RowStatus = isDeleted ? "deleted" : dirty ? "edited" : "clean";
     return { id: sourceIndex, sourceIndex, data, isNew: false, isDeleted, isDirtyCol, status };
   });
-  newRows.value.forEach((row, i) => {
+  newRows.value.forEach((row: CellValue[], i: number) => {
     items.push({
       id: -(i + 1),
       newIndex: i,
@@ -534,17 +535,7 @@ const activeCellDetail = computed(() => {
   if (!item || !column) return null;
   const value = item.data[cell.col] ?? null;
   const rawValue = formatCell(value);
-  const valueText = value === null ? "" : String(value);
-  const trimmed = valueText.trim();
-  const maybeJson = typeof value === "string" && (trimmed.startsWith("{") || trimmed.startsWith("["));
-  let formattedJson = "";
-  if (maybeJson) {
-    try {
-      formattedJson = JSON.stringify(JSON.parse(value), null, 2);
-    } catch {
-      formattedJson = "";
-    }
-  }
+  const formattedJson = formatGridCellJsonPreview(value);
   return {
     rowNumber: cell.rowIndex + 1,
     colIndex: cell.col,
@@ -553,7 +544,7 @@ const activeCellDetail = computed(() => {
     comment: columnCommentMap.value.get(column) || "",
     value,
     rawValue,
-    length: value === null ? 0 : String(value).length,
+    length: value === null ? 0 : rawValue.length,
     formattedJson,
   };
 });
@@ -606,10 +597,7 @@ async function applyWhereSearch() {
 }
 
 function formatCell(value: CellValue): string {
-  if (value === null) return "NULL";
-  if (typeof value === "boolean") return value ? "true" : "false";
-  if (typeof value === "object") return JSON.stringify(value);
-  return String(value);
+  return formatGridCellDisplay(value);
 }
 
 function quoteIdent(name: string): string {
@@ -713,7 +701,7 @@ function startEdit(rowId: number, colIdx: number) {
   isCancelling = false;
   editingCell.value = { rowId, col: colIdx };
   const val = item?.data[colIdx] ?? null;
-  editValue.value = val === null ? "" : String(val);
+  editValue.value = val === null ? "" : formatGridCellDisplay(val, "");
   nextTick(() => {
     const input = document.querySelector(".cell-edit-input") as HTMLInputElement;
     input?.focus();

--- a/src/lib/dataGridSql.ts
+++ b/src/lib/dataGridSql.ts
@@ -1,7 +1,8 @@
 import type { DatabaseType } from "@/types/database";
+import { formatGridCellDisplay, type GridCellValue } from "./gridCell.ts";
 import { qualifiedTableName, quoteTableIdentifier } from "./tableSelectSql.ts";
 
-export type GridCellValue = string | number | boolean | null;
+export type { GridCellValue };
 
 export interface DataGridTableMeta {
   schema?: string;
@@ -60,7 +61,7 @@ export function formatGridSqlLiteral(value: GridCellValue): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
-  const text = String(value);
+  const text = formatGridCellDisplay(value);
   if (text === "") return "''";
   return `'${text.replace(/\\/g, "\\\\").replace(/'/g, "''")}'`;
 }

--- a/src/lib/gridCell.ts
+++ b/src/lib/gridCell.ts
@@ -1,0 +1,36 @@
+export type GridCellValue = string | number | boolean | null | Record<string, unknown> | unknown[];
+
+export function formatGridCellDisplay(value: GridCellValue, nullText = "NULL"): string {
+  if (value === null) return nullText;
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "object") return stringifyJsonCell(value);
+  return String(value);
+}
+
+export function stringifyJsonCell(value: object): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatGridCellJsonPreview(value: GridCellValue): string {
+  if (value && typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return "";
+    }
+  }
+
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return "";
+
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return "";
+  }
+}

--- a/src/lib/gridSelection.ts
+++ b/src/lib/gridSelection.ts
@@ -1,4 +1,6 @@
-export type GridCellValue = string | number | boolean | null;
+import { formatGridCellDisplay, type GridCellValue } from "./gridCell.ts";
+
+export type { GridCellValue };
 
 export interface CellPosition {
   rowIndex: number;
@@ -49,9 +51,7 @@ export function extractSelection(
 }
 
 function displayValue(value: GridCellValue): string {
-  if (value === null) return "NULL";
-  if (typeof value === "boolean") return value ? "true" : "false";
-  return String(value);
+  return formatGridCellDisplay(value);
 }
 
 function csvValue(value: GridCellValue | string): string {
@@ -63,7 +63,7 @@ function sqlValue(value: GridCellValue): string {
   if (value === null) return "NULL";
   if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
   if (typeof value === "number" && Number.isFinite(value)) return String(value);
-  return `'${String(value).replace(/'/g, "''")}'`;
+  return `'${displayValue(value).replace(/'/g, "''")}'`;
 }
 
 export function formatSelectionAsTsv(selection: SelectionData): string {

--- a/src/lib/markdownTable.ts
+++ b/src/lib/markdownTable.ts
@@ -1,4 +1,4 @@
-import type { GridCellValue } from "./dataGridSql.ts";
+import { formatGridCellDisplay, type GridCellValue } from "./gridCell.ts";
 
 export interface MarkdownTableData {
   columns: string[];
@@ -20,9 +20,7 @@ export function formatMarkdownTable(data: MarkdownTableData): string {
 }
 
 function displayCell(value: GridCellValue): string {
-  if (value === null) return "NULL";
-  if (typeof value === "boolean") return value ? "true" : "false";
-  return String(value);
+  return formatGridCellDisplay(value);
 }
 
 function markdownCell(value: string): string {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -87,7 +87,7 @@ export interface TriggerInfo {
 
 export interface QueryResult {
   columns: string[];
-  rows: (string | number | boolean | null)[][];
+  rows: import("@/lib/gridCell").GridCellValue[][];
   affected_rows: number;
   execution_time_ms: number;
   truncated?: boolean;

--- a/tests/gridSelection.test.ts
+++ b/tests/gridSelection.test.ts
@@ -11,10 +11,7 @@ import {
 } from "../src/lib/gridSelection.ts";
 
 test("normalizes a dragged cell range in either direction", () => {
-  const range = normalizeSelectionRange(
-    { rowIndex: 4, colIndex: 3 },
-    { rowIndex: 1, colIndex: 0 },
-  );
+  const range = normalizeSelectionRange({ rowIndex: 4, colIndex: 3 }, { rowIndex: 1, colIndex: 0 });
 
   assert.deepEqual(range, {
     startRow: 1,
@@ -49,20 +46,41 @@ test("formats selected cells as TSV, CSV, JSON, and SQL values", () => {
     columns: ["name", "note"],
     rows: [
       ["Ada", "math"],
-      ["Bob", "quote \"here\""],
+      ["Bob", 'quote "here"'],
       ["O'Hara", null],
     ],
   };
 
-  assert.equal(formatSelectionAsTsv(selection), "name\tnote\nAda\tmath\nBob\tquote \"here\"\nO'Hara\tNULL");
-  assert.equal(formatSelectionAsCsv(selection), "\"name\",\"note\"\n\"Ada\",\"math\"\n\"Bob\",\"quote \"\"here\"\"\"\n\"O'Hara\",\"NULL\"");
+  assert.equal(formatSelectionAsTsv(selection), 'name\tnote\nAda\tmath\nBob\tquote "here"\nO\'Hara\tNULL');
+  assert.equal(
+    formatSelectionAsCsv(selection),
+    '"name","note"\n"Ada","math"\n"Bob","quote ""here"""\n"O\'Hara","NULL"',
+  );
   assert.equal(
     formatSelectionAsJson(selection),
-    JSON.stringify([
-      { name: "Ada", note: "math" },
-      { name: "Bob", note: "quote \"here\"" },
-      { name: "O'Hara", note: null },
-    ], null, 2),
+    JSON.stringify(
+      [
+        { name: "Ada", note: "math" },
+        { name: "Bob", note: 'quote "here"' },
+        { name: "O'Hara", note: null },
+      ],
+      null,
+      2,
+    ),
   );
   assert.equal(formatSelectionAsSqlInList(selection), "('Ada', 'math', 'Bob', 'quote \"here\"', 'O''Hara', NULL)");
+});
+
+test("formats object cells as JSON text for selection exports", () => {
+  const selection = {
+    columns: ["id", "source_config"],
+    rows: [[1, { region: "cn", enabled: true }]],
+  };
+
+  assert.equal(formatSelectionAsTsv(selection as any), 'id\tsource_config\n1\t{"region":"cn","enabled":true}');
+  assert.equal(
+    formatSelectionAsCsv(selection as any),
+    '"id","source_config"\n"1","{""region"":""cn"",""enabled"":true}"',
+  );
+  assert.equal(formatSelectionAsSqlInList(selection as any), '(1, \'{"region":"cn","enabled":true}\')');
 });


### PR DESCRIPTION
## Summary
- Add a shared grid cell formatter for JSON object and array values.
- Use JSON display text in DataGrid rendering, search, cell details, edits, exports, and SQL literals.
- Add regression coverage for object cells in grid selection exports.

## Test Plan
- node --test tests/gridSelection.test.ts tests/markdownTable.test.ts tests/dataGridSql.test.ts
- ./node_modules/.bin/vue-tsc --noEmit
- ./node_modules/.bin/oxlint --vue-plugin src