### PR TITLE
feat: 新增 tab 右键批量关闭能力

### DIFF
--- a/src/components/layout/AppTabBar.vue
+++ b/src/components/layout/AppTabBar.vue
@@ -20,6 +20,21 @@ const queryStore = useQueryStore();
 const tabsContainerRef = ref<HTMLElement | null>(null);
 const { canScrollLeft, canScrollRight, updateScrollButtons, scrollTabs } = useTabScroll(tabsContainerRef);
 
+function hasTabsToLeft(tabId: string) {
+  return queryStore.tabs.findIndex((tab) => tab.id === tabId) > 0;
+}
+
+function hasTabsToRight(tabId: string) {
+  const index = queryStore.tabs.findIndex((tab) => tab.id === tabId);
+  return index >= 0 && index < queryStore.tabs.length - 1;
+}
+
+function tabTitle(tab: (typeof queryStore.tabs)[number]) {
+  return tabTooltipLines(tab)
+    .map((line) => `${line.label} ${line.value}`)
+    .join("\n");
+}
+
 watch(
   () => queryStore.tabs.length,
   () => {
@@ -61,63 +76,53 @@ watch(
     >
       <ContextMenu v-for="tab in queryStore.tabs" :key="tab.id">
         <ContextMenuTrigger as-child>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <div
-                class="group flex min-w-38 items-center gap-1 px-2 h-full text-xs cursor-pointer transition-colors whitespace-nowrap border-r border-border/50"
-                :class="
-                  tab.id === queryStore.activeTabId
-                    ? 'bg-background text-foreground font-medium'
-                    : 'text-foreground/70 hover:text-foreground/90'
-                "
-                :style="
-                  tab.id === queryStore.activeTabId ? { boxShadow: '0 1px 0 0 var(--color-background)' } : undefined
-                "
-                :data-active-tab="tab.id === queryStore.activeTabId"
-                @click="queryStore.activeTabId = tab.id"
-              >
-                <span
-                  class="h-1.5 w-1.5 rounded-full shrink-0"
-                  :style="{ backgroundColor: connectionColor(tab.connectionId) || '#9ca3af' }"
-                />
-                <span class="min-w-0 truncate flex-1">{{ tabDisplayTitle(tab) }}</span>
-                <Tooltip>
-                  <TooltipTrigger as-child>
-                    <button
-                      class="inline-flex rounded p-0.5 text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground focus:opacity-100"
-                      :class="tab.pinned ? 'visible text-primary' : 'invisible group-hover:visible'"
-                      @click.stop="queryStore.togglePinnedTab(tab.id)"
-                    >
-                      <Pin class="h-3 w-3" :class="{ 'fill-current': tab.pinned }" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>{{ tab.pinned ? t("contextMenu.unpin") : t("contextMenu.pin") }}</TooltipContent>
-                </Tooltip>
-                <span
-                  class="shrink-0 rounded border px-1 text-[10px] leading-4"
-                  :class="
-                    tab.mode === 'data'
-                      ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300'
-                      : 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-300'
-                  "
-                >
-                  {{ tabModeLabel(tab) }}
-                </span>
+          <div
+            class="group flex min-w-38 items-center gap-1 px-2 h-full text-xs cursor-pointer transition-colors whitespace-nowrap border-r border-border/50 select-none"
+            :class="
+              tab.id === queryStore.activeTabId
+                ? 'bg-background text-foreground font-medium'
+                : 'text-foreground/70 hover:text-foreground/90'
+            "
+            :style="tab.id === queryStore.activeTabId ? { boxShadow: '0 1px 0 0 var(--color-background)' } : undefined"
+            :data-active-tab="tab.id === queryStore.activeTabId"
+            :title="tabTitle(tab)"
+            @click="queryStore.activeTabId = tab.id"
+            @mousedown.right="queryStore.activeTabId = tab.id"
+          >
+            <span
+              class="h-1.5 w-1.5 rounded-full shrink-0"
+              :style="{ backgroundColor: connectionColor(tab.connectionId) || '#9ca3af' }"
+            />
+            <span class="min-w-0 truncate flex-1">{{ tabDisplayTitle(tab) }}</span>
+            <Tooltip>
+              <TooltipTrigger as-child>
                 <button
-                  class="rounded hover:bg-muted-foreground/20 p-0.5 shrink-0"
-                  @click.stop="queryStore.closeTab(tab.id)"
+                  class="inline-flex rounded p-0.5 text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground focus:opacity-100"
+                  :class="tab.pinned ? 'visible text-primary' : 'invisible group-hover:visible'"
+                  @click.stop="queryStore.togglePinnedTab(tab.id)"
                 >
-                  <X class="h-3 w-3" />
+                  <Pin class="h-3 w-3" :class="{ 'fill-current': tab.pinned }" />
                 </button>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" class="text-xs grid grid-cols-[auto_1fr] gap-x-2">
-              <template v-for="line in tabTooltipLines(tab)" :key="line.label">
-                <span class="text-muted-foreground">{{ line.label }}</span>
-                <span>{{ line.value }}</span>
-              </template>
-            </TooltipContent>
-          </Tooltip>
+              </TooltipTrigger>
+              <TooltipContent>{{ tab.pinned ? t("contextMenu.unpin") : t("contextMenu.pin") }}</TooltipContent>
+            </Tooltip>
+            <span
+              class="shrink-0 rounded border px-1 text-[10px] leading-4"
+              :class="
+                tab.mode === 'data'
+                  ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300'
+                  : 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-300'
+              "
+            >
+              {{ tabModeLabel(tab) }}
+            </span>
+            <button
+              class="rounded hover:bg-muted-foreground/20 p-0.5 shrink-0"
+              @click.stop="queryStore.closeTab(tab.id)"
+            >
+              <X class="h-3 w-3" />
+            </button>
+          </div>
         </ContextMenuTrigger>
 
         <ContextMenuContent class="w-44">
@@ -129,6 +134,14 @@ watch(
           <ContextMenuItem @click="queryStore.closeTab(tab.id)">
             <X class="w-3.5 h-3.5 mr-2" />
             {{ t("contextMenu.closeTab") }}
+          </ContextMenuItem>
+          <ContextMenuItem :disabled="!hasTabsToLeft(tab.id)" @click="queryStore.closeLeftTabs(tab.id)">
+            <X class="w-3.5 h-3.5 mr-2" />
+            {{ t("contextMenu.closeLeftTabs") }}
+          </ContextMenuItem>
+          <ContextMenuItem :disabled="!hasTabsToRight(tab.id)" @click="queryStore.closeRightTabs(tab.id)">
+            <X class="w-3.5 h-3.5 mr-2" />
+            {{ t("contextMenu.closeRightTabs") }}
           </ContextMenuItem>
           <ContextMenuItem :disabled="queryStore.tabs.length <= 1" @click="queryStore.closeOtherTabs(tab.id)">
             <X class="w-3.5 h-3.5 mr-2" />

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -418,6 +418,8 @@ export default {
     pin: "Pin",
     unpin: "Unpin",
     closeTab: "Close Tab",
+    closeLeftTabs: "Close Left Tabs",
+    closeRightTabs: "Close Right Tabs",
     closeOtherTabs: "Close Other Tabs",
     closeAllTabs: "Close All Tabs",
     copyName: "Copy Name",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -410,6 +410,8 @@ export default {
     pin: "置顶",
     unpin: "取消置顶",
     closeTab: "关闭标签页",
+    closeLeftTabs: "关闭左侧标签页",
+    closeRightTabs: "关闭右侧标签页",
     closeOtherTabs: "关闭其他标签页",
     closeAllTabs: "关闭全部标签页",
     copyName: "复制名称",

--- a/src/lib/tabCloseActions.ts
+++ b/src/lib/tabCloseActions.ts
@@ -7,6 +7,15 @@ export interface TabCloseState<T extends TabLike> {
   activeTabId: string | null;
 }
 
+function resolveActiveTabId<T extends TabLike>(
+  nextTabs: readonly T[],
+  activeTabId: string | null,
+  targetTabId: string,
+): string | null {
+  if (activeTabId && nextTabs.some((tab) => tab.id === activeTabId)) return activeTabId;
+  return nextTabs.some((tab) => tab.id === targetTabId) ? targetTabId : (nextTabs[0]?.id ?? null);
+}
+
 export function closeOtherTabsState<T extends TabLike>(
   tabs: readonly T[],
   activeTabId: string | null,
@@ -16,6 +25,36 @@ export function closeOtherTabsState<T extends TabLike>(
   if (!target) return { tabs: [...tabs], activeTabId };
 
   return { tabs: [target], activeTabId: target.id };
+}
+
+export function closeLeftTabsState<T extends TabLike>(
+  tabs: readonly T[],
+  activeTabId: string | null,
+  targetTabId: string,
+): TabCloseState<T> {
+  const targetIndex = tabs.findIndex((tab) => tab.id === targetTabId);
+  if (targetIndex < 0) return { tabs: [...tabs], activeTabId };
+
+  const nextTabs = tabs.slice(targetIndex);
+  return {
+    tabs: nextTabs,
+    activeTabId: resolveActiveTabId(nextTabs, activeTabId, targetTabId),
+  };
+}
+
+export function closeRightTabsState<T extends TabLike>(
+  tabs: readonly T[],
+  activeTabId: string | null,
+  targetTabId: string,
+): TabCloseState<T> {
+  const targetIndex = tabs.findIndex((tab) => tab.id === targetTabId);
+  if (targetIndex < 0) return { tabs: [...tabs], activeTabId };
+
+  const nextTabs = tabs.slice(0, targetIndex + 1);
+  return {
+    tabs: nextTabs,
+    activeTabId: resolveActiveTabId(nextTabs, activeTabId, targetTabId),
+  };
 }
 
 export function closeAllTabsState<T extends TabLike>(

--- a/src/stores/queryStore.ts
+++ b/src/stores/queryStore.ts
@@ -4,7 +4,7 @@ import { ref, watch } from "vue";
 import type { DatabaseType, QueryTab } from "@/types/database";
 import { orderPinnedFirst } from "@/lib/pinnedItems";
 import { canCancelQueryExecution } from "@/lib/queryExecutionState";
-import { closeAllTabsState, closeOtherTabsState } from "@/lib/tabCloseActions";
+import { closeAllTabsState, closeLeftTabsState, closeOtherTabsState, closeRightTabsState } from "@/lib/tabCloseActions";
 import { buildExplainSql, parseExplainResult } from "@/lib/explainPlan";
 import { analyzeEditableQuery, allPrimaryKeysPresent } from "@/lib/sqlAnalysis";
 import * as api from "@/lib/api";
@@ -122,6 +122,38 @@ export const useQueryStore = defineStore("query", () => {
     tabs.value.filter((tab) => tab.id !== id && tab.isExecuting).forEach((tab) => void cancelTabExecution(tab.id));
     tabs.value.filter((tab) => tab.id !== id && tab.isExplaining).forEach((tab) => void cancelTabExplain(tab.id));
     const next = closeOtherTabsState(tabs.value, activeTabId.value, id);
+    tabs.value = next.tabs;
+    activeTabId.value = next.activeTabId;
+  }
+
+  function closeLeftTabs(id: string) {
+    const targetIndex = tabs.value.findIndex((tab) => tab.id === id);
+    if (targetIndex < 0) return;
+    tabs.value
+      .slice(0, targetIndex)
+      .filter((tab) => tab.isExecuting)
+      .forEach((tab) => void cancelTabExecution(tab.id));
+    tabs.value
+      .slice(0, targetIndex)
+      .filter((tab) => tab.isExplaining)
+      .forEach((tab) => void cancelTabExplain(tab.id));
+    const next = closeLeftTabsState(tabs.value, activeTabId.value, id);
+    tabs.value = next.tabs;
+    activeTabId.value = next.activeTabId;
+  }
+
+  function closeRightTabs(id: string) {
+    const targetIndex = tabs.value.findIndex((tab) => tab.id === id);
+    if (targetIndex < 0) return;
+    tabs.value
+      .slice(targetIndex + 1)
+      .filter((tab) => tab.isExecuting)
+      .forEach((tab) => void cancelTabExecution(tab.id));
+    tabs.value
+      .slice(targetIndex + 1)
+      .filter((tab) => tab.isExplaining)
+      .forEach((tab) => void cancelTabExplain(tab.id));
+    const next = closeRightTabsState(tabs.value, activeTabId.value, id);
     tabs.value = next.tabs;
     activeTabId.value = next.activeTabId;
   }
@@ -446,6 +478,8 @@ export const useQueryStore = defineStore("query", () => {
     activeTabId,
     createTab,
     closeTab,
+    closeLeftTabs,
+    closeRightTabs,
     closeOtherTabs,
     closeAllTabs,
     updateSql,

--- a/tests/tabCloseActions.test.ts
+++ b/tests/tabCloseActions.test.ts
@@ -1,15 +1,26 @@
 import { strict as assert } from "node:assert";
 import test from "node:test";
-import { closeAllTabsState, closeOtherTabsState } from "../src/lib/tabCloseActions.ts";
+import {
+  closeAllTabsState,
+  closeLeftTabsState,
+  closeOtherTabsState,
+  closeRightTabsState,
+} from "../src/lib/tabCloseActions.ts";
 
 test("close other tabs keeps the target tab and makes it active", () => {
   const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
   const result = closeOtherTabsState(tabs, "a", "b");
 
-  assert.deepEqual(result.tabs.map((tab) => tab.id), ["b"]);
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    ["b"],
+  );
   assert.equal(result.activeTabId, "b");
-  assert.deepEqual(tabs.map((tab) => tab.id), ["a", "b", "c"]);
+  assert.deepEqual(
+    tabs.map((tab) => tab.id),
+    ["a", "b", "c"],
+  );
 });
 
 test("close other tabs is a no-op when the target tab is missing", () => {
@@ -17,8 +28,85 @@ test("close other tabs is a no-op when the target tab is missing", () => {
 
   const result = closeOtherTabsState(tabs, "a", "missing");
 
-  assert.deepEqual(result.tabs.map((tab) => tab.id), ["a", "b"]);
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    ["a", "b"],
+  );
   assert.equal(result.activeTabId, "a");
+});
+
+test("close left tabs keeps target and right side tabs", () => {
+  const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+
+  const result = closeLeftTabsState(tabs, "c", "b");
+
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    ["b", "c", "d"],
+  );
+  assert.equal(result.activeTabId, "c");
+  assert.deepEqual(
+    tabs.map((tab) => tab.id),
+    ["a", "b", "c", "d"],
+  );
+});
+
+test("close left tabs activates target when current active tab is closed", () => {
+  const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+
+  const result = closeLeftTabsState(tabs, "a", "c");
+
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    ["c", "d"],
+  );
+  assert.equal(result.activeTabId, "c");
+});
+
+test("close right tabs keeps target and left side tabs", () => {
+  const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+
+  const result = closeRightTabsState(tabs, "b", "c");
+
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    ["a", "b", "c"],
+  );
+  assert.equal(result.activeTabId, "b");
+  assert.deepEqual(
+    tabs.map((tab) => tab.id),
+    ["a", "b", "c", "d"],
+  );
+});
+
+test("close right tabs activates target when current active tab is closed", () => {
+  const tabs = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+
+  const result = closeRightTabsState(tabs, "d", "b");
+
+  assert.deepEqual(
+    result.tabs.map((tab) => tab.id),
+    ["a", "b"],
+  );
+  assert.equal(result.activeTabId, "b");
+});
+
+test("close left and right tabs are no-ops when the target tab is missing", () => {
+  const tabs = [{ id: "a" }, { id: "b" }];
+
+  const leftResult = closeLeftTabsState(tabs, "a", "missing");
+  const rightResult = closeRightTabsState(tabs, "a", "missing");
+
+  assert.deepEqual(
+    leftResult.tabs.map((tab) => tab.id),
+    ["a", "b"],
+  );
+  assert.equal(leftResult.activeTabId, "a");
+  assert.deepEqual(
+    rightResult.tabs.map((tab) => tab.id),
+    ["a", "b"],
+  );
+  assert.equal(rightResult.activeTabId, "a");
 });
 
 test("close all tabs clears every tab and active tab", () => {


### PR DESCRIPTION
## 变更背景

当前 tab 栏右键能力只有“关闭标签页 / 关闭其他 / 关闭全部”中的部分能力，缺少桌面类标签页常见的批量关闭操作：

- 关闭左侧标签页
- 关闭右侧标签页
- 关闭其他标签页
- 关闭全部标签页

在 macOS Tauri/WebKit 环境下，tab 项右键还存在触发链不稳定的问题：

- 一开始会弹出系统原生菜单，而不是应用内菜单
- 调整后如果错误地拦截 `contextmenu` 事件，又会导致右键完全无响应

这次 PR 一并补齐批量关闭能力，并修复 macOS 下 tab 右键菜单的触发方式。

## 主要改动

### 1. 扩展 tab 关闭状态计算

在 `src/lib/tabCloseActions.ts` 中新增：

- `closeLeftTabsState`
- `closeRightTabsState`
- `resolveActiveTabId`

规则统一为：

- 所有批量关闭动作都以“被右键的 tab”作为基准
- 关闭左侧/右侧时保留目标 tab 本身
- 如果当前激活 tab 在关闭后仍存在，则保持激活不变
- 如果当前激活 tab 被关闭，则自动切换到目标 tab
- 目标 tab 不存在时返回 no-op 结果

### 2. 扩展 queryStore 行为

在 `src/stores/queryStore.ts` 中新增：

- `closeLeftTabs(id)`
- `closeRightTabs(id)`

并复用现有逻辑处理批量关闭前的执行态清理：

- 正在执行 SQL 的 tab 会先触发取消
- 正在执行 explain 的 tab 会先触发取消

这样可以避免被关闭 tab 留下悬挂执行状态。

### 3. 更新 tab 右键菜单

在 `src/components/layout/AppTabBar.vue` 中：

- 新增“关闭左侧标签页”菜单项
- 新增“关闭右侧标签页”菜单项
- 保留“关闭其他标签页”与“关闭全部标签页”
- 根据目标 tab 位置动态禁用左/右关闭动作

同时调整了 tab 右键交互实现：

- 取消外层 tab tooltip 对右键触发链的干扰
- 用原生 `title` 保留连接/数据库信息提示
- 通过 `@mousedown.right` 先切换 active tab，再交给 `ContextMenuTrigger` 处理真正的右键菜单打开

这部分是为了解决 macOS WebKit/Tauri 下：

- 原生系统菜单抢占右键
- 或者手动 `preventDefault` 后把组件库自己的右键菜单也一起拦掉

### 4. 补齐中英文文案

新增 i18n 文案：

- `closeLeftTabs`
- `closeRightTabs`

更新文件：

- `src/i18n/locales/zh-CN.ts`
- `src/i18n/locales/en.ts`

### 5. 补充测试

在 `tests/tabCloseActions.test.ts` 中新增覆盖：

- 关闭左侧后保留目标及右侧
- 关闭右侧后保留目标及左侧
- 当前激活 tab 被关闭时，激活项回退到目标 tab
- 当前激活 tab 未被关闭时，激活项保持不变
- 目标 tab 不存在时 no-op
- 原数组不被修改

## 影响范围

本次变更集中在 tab 栏相关逻辑，不涉及数据库执行、结果渲染或其它业务流程。

影响文件：

- `src/components/layout/AppTabBar.vue`
- `src/lib/tabCloseActions.ts`
- `src/stores/queryStore.ts`
- `src/i18n/locales/zh-CN.ts`
- `src/i18n/locales/en.ts`
- `tests/tabCloseActions.test.ts`

## 验证方式

已执行：

- `pnpm exec vue-tsc --noEmit`
- `node --experimental-strip-types --test tests/tabCloseActions.test.ts`

手工验证关注点：

- 右键首个 tab：左侧关闭禁用
- 右键末尾 tab：右侧关闭禁用
- 右键中间 tab：左侧 / 右侧 / 其他 / 全部关闭行为正确
- 右键目标 tab 不是当前激活 tab 时，仍按右键目标计算关闭范围
- macOS Tauri/WebKit 下右键弹出应用内菜单，而不是系统原生菜单

## 风险与说明

- 这次为保证 tab 右键稳定，去掉了整块 tab 项的自定义 tooltip 浮层，改为使用原生 `title` 展示连接/数据库信息
- pin 按钮自身 tooltip 仍然保留
- 如果后续需要恢复更丰富的 tab 浮层展示，建议基于不干扰 `ContextMenuTrigger` 的结构重新设计触发层级
