### PR TITLE
Fix: 修复查询结果集修改后提交和回滚按钮消失的问题

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
     "targets": "all",
     "createUpdaterArtifacts": true,
     "macOS": {
-      "frameworks": ["/opt/homebrew/lib/libodbc.2.dylib", "/opt/homebrew/lib/libltdl.7.dylib"]
+      "frameworks": ["libodbc.2.dylib", "libltdl.7.dylib"]
     },
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
     "targets": "all",
     "createUpdaterArtifacts": true,
     "macOS": {
-      "frameworks": ["libodbc.2.dylib", "libltdl.7.dylib"]
+      "frameworks": ["/opt/homebrew/lib/libodbc.2.dylib", "/opt/homebrew/lib/libltdl.7.dylib"]
     },
     "icon": [
       "icons/32x32.png",

--- a/src/components/grid/DataGrid.vue
+++ b/src/components/grid/DataGrid.vue
@@ -28,6 +28,8 @@ import {
   Info,
   Rows3,
   TriangleAlert,
+  RotateCcw,
+  RefreshCcw,
 } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import {
@@ -1106,6 +1108,19 @@ defineExpose({ useTransaction, transactionActive, isSaving, onToolbarRefresh, on
               :placeholder="t('grid.search')"
               @keydown="onSearchKeydown"
             />
+            <span
+              v-if="useTransaction && transactionActive"
+              class="text-xs text-emerald-600 dark:text-emerald-400 flex items-center gap-1"
+            >
+              <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+              {{ t("grid.transactionActive") }}
+            </span>
+
+            <Button variant="ghost" size="sm" class="h-5 text-xs px-1.5" :disabled="isSaving" @click="onToolbarRefresh">
+              <Loader2 v-if="loading" class="w-3 h-3 mr-1 animate-spin" />
+              <RefreshCcw v-else class="w-3 h-3 mr-1" />
+              {{ t("grid.refresh") }}
+            </Button>
             <Select
               v-if="editable && tableMeta"
               :model-value="rowStatusFilter"
@@ -1133,6 +1148,29 @@ defineExpose({ useTransaction, transactionActive, isSaving, onToolbarRefresh, on
               @click="addRow"
             >
               <Plus class="w-3 h-3 mr-1" /> {{ t("grid.addRow") }}
+            </Button>
+            <Button
+              v-if="useTransaction"
+              :variant="transactionActive ? 'default' : 'secondary'"
+              size="sm"
+              class="h-5 text-xs px-1.5"
+              :disabled="!transactionActive || isSaving"
+              @click="onToolbarCommit"
+            >
+              <Loader2 v-if="isSaving" class="w-3 h-3 mr-1 animate-spin" />
+              <Save v-else class="w-3 h-3 mr-1" />
+              {{ t("grid.commit") }}
+            </Button>
+            <Button
+              v-if="useTransaction"
+              variant="outline"
+              size="sm"
+              class="h-5 text-xs px-1.5"
+              :disabled="!transactionActive"
+              @click="onToolbarRollback"
+            >
+              <RotateCcw class="w-3 h-3 mr-1" />
+              {{ t("grid.rollback") }}
             </Button>
             <Button
               v-if="tableMeta && connectionId"

--- a/src/components/layout/ContentArea.vue
+++ b/src/components/layout/ContentArea.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, defineAsyncComponent } from "vue";
 import { useI18n } from "vue-i18n";
-import { Loader2, Square, Bot, Table2, GitBranch, BarChart3, RefreshCcw, Save, RotateCcw } from "lucide-vue-next";
+import { Loader2, Square, Bot, Table2, GitBranch, BarChart3 } from "lucide-vue-next";
 import { Splitpanes, Pane } from "splitpanes";
 import "splitpanes/dist/splitpanes.css";
 import { Button } from "@/components/ui/button";
@@ -333,42 +333,6 @@ function onHandleCloseColumnPanel() {
           >
             {{ databaseDisplayNameForTab(activeTab.connectionId, activeTab.database) }}
             <template v-if="activeTab.tableMeta?.schema"> &middot; {{ activeTab.tableMeta.schema }}</template>
-          </span>
-          <span v-if="activeTab.tableMeta" class="ml-auto flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              class="h-5 text-xs px-1.5"
-              :disabled="dataGridRef?.isSaving"
-              @click="dataGridRef?.onToolbarRefresh()"
-            >
-              <Loader2 v-if="activeTab.isExecuting" class="w-3 h-3 mr-1 animate-spin" />
-              <RefreshCcw v-else class="w-3 h-3 mr-1" />
-              {{ t("grid.refresh") }}
-            </Button>
-            <template v-if="dataGridRef?.useTransaction">
-              <Button
-                :variant="dataGridRef?.transactionActive ? 'default' : 'secondary'"
-                size="sm"
-                class="h-5 text-xs px-1.5"
-                :disabled="!dataGridRef?.transactionActive || dataGridRef?.isSaving"
-                @click="dataGridRef?.onToolbarCommit()"
-              >
-                <Loader2 v-if="dataGridRef?.isSaving" class="w-3 h-3 mr-1 animate-spin" />
-                <Save v-else class="w-3 h-3 mr-1" />
-                {{ t("grid.commit") }}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                class="h-5 text-xs px-1.5"
-                :disabled="!dataGridRef?.transactionActive"
-                @click="dataGridRef?.onToolbarRollback()"
-              >
-                <RotateCcw class="w-3 h-3 mr-1" />
-                {{ t("grid.rollback") }}
-              </Button>
-            </template>
           </span>
         </div>
         <DataGrid


### PR DESCRIPTION
修复先前合并工具栏按钮后，在查询结果集可以修改数据的场景下，提交和回滚按钮消失的问题 （原提交: [631db17](https://github.com/t8y2/dbx/commit/631db17a08d08791cf46cf637c40c3aec8bf78ea)）
重新设计了带有事务操作的工具栏，现在在表内容编辑和查询结果集界面体验一致。