### PR TITLE
feat: add Arch Linux PKGBUILD and packaging for dbx and dbx-bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,12 @@ tmp/
 
 # Logs
 *.log
+/packaging/arch/pkg
+/packaging/arch/src
+/packaging/arch/*.tar.zst
+/packaging/arch/*.tar.gz
+/packaging/arch/dbx-bin/pkg/dbx-bin
+/packaging/arch/dbx-bin/src
+/packaging/arch/dbx-bin/*.tar.zst
+/packaging/arch/dbx-bin/*.deb
+/packaging/arch/dbx-bin/LICENSE-*

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,109 @@
+# Maintainer: jinzhongjia <jinzhongjia@manus.ai>
+pkgname=dbx
+pkgver=0.4.3
+pkgrel=1
+pkgdesc="Open-source database management tool (Tauri-based)"
+arch=('x86_64')
+url="https://github.com/t8y2/dbx"
+license=('AGPL-3.0-only')
+depends=(
+    'webkit2gtk-4.1'
+    'gtk3'
+    'sqlite'
+    'unixodbc'
+    'openssl'
+    'hicolor-icon-theme'
+)
+makedepends=(
+    'rust'
+    'cargo'
+    'nodejs'
+    'pnpm'
+    'pkgconf'
+    'git'
+)
+provides=("$pkgname")
+conflicts=("$pkgname-bin")
+# makepkg's global LTO option injects -flto=auto / -C linker-plugin-lto, which
+# breaks final-link symbol resolution against several bundled native static
+# archives in our dep tree (ring, aws-lc-sys). Disable for this package.
+options=('!lto')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+prepare() {
+    cd "$pkgname-$pkgver"
+
+    # Keep all build state inside $srcdir, never touch user $HOME
+    export CARGO_HOME="$srcdir/.cargo"
+    export npm_config_cache="$srcdir/.npm"
+    pnpm config --location project set store-dir "$srcdir/.pnpm-store"
+
+    # Pre-fetch JS and Rust deps so build() can run without network.
+    pnpm install --frozen-lockfile
+    (
+        cd src-tauri
+        cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+    )
+}
+
+build() {
+    cd "$pkgname-$pkgver"
+
+    export CARGO_HOME="$srcdir/.cargo"
+    export RUSTUP_TOOLCHAIN=stable
+
+    # Force libsqlite3-sys to use system sqlite via pkg-config rather than
+    # bundling. sqlx 0.8 unconditionally enables sqlx-sqlite/bundled when
+    # the `sqlite` feature is on, but cargo fails to link the resulting
+    # static libsqlite3.a into both the proc-macro cdylib (sqlx_macros.so)
+    # and the final binary, leaving sqlite3_* symbols undefined. The env
+    # var is checked first in libsqlite3-sys's build.rs and overrides the
+    # bundled code path.
+    export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+
+    # Disable LTO. With lto="thin" (set in workspace Cargo.toml) plus rust-lld,
+    # native static libs from build scripts (aws-lc-sys, ring, etc.) end up
+    # with undefined symbols at final link. Disabling LTO restores normal
+    # static-archive resolution.
+    export CARGO_PROFILE_RELEASE_LTO=false
+
+    # Frontend + backend in one step; skip bundling, we install files ourselves
+    pnpm exec tauri build --no-bundle
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+
+    # Binary (workspace target dir is at repo root, not under src-tauri/)
+    install -Dm755 "target/release/dbx" \
+        "$pkgdir/usr/bin/dbx"
+
+    # Icons (hicolor)
+    install -Dm644 "src-tauri/icons/32x32.png" \
+        "$pkgdir/usr/share/icons/hicolor/32x32/apps/dbx.png"
+    install -Dm644 "src-tauri/icons/128x128.png" \
+        "$pkgdir/usr/share/icons/hicolor/128x128/apps/dbx.png"
+    install -Dm644 "src-tauri/icons/128x128@2x.png" \
+        "$pkgdir/usr/share/icons/hicolor/256x256/apps/dbx.png"
+    install -Dm644 "src-tauri/icons/icon.png" \
+        "$pkgdir/usr/share/pixmaps/dbx.png"
+
+    # Desktop entry
+    install -dm755 "$pkgdir/usr/share/applications"
+    cat > "$pkgdir/usr/share/applications/dbx.desktop" <<EOF
+[Desktop Entry]
+Name=DBX
+Comment=$pkgdesc
+Exec=dbx %U
+Icon=dbx
+Terminal=false
+Type=Application
+Categories=Development;Database;
+StartupWMClass=DBX
+EOF
+
+    # License
+    install -Dm644 LICENSE \
+        "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,0 +1,27 @@
+# Arch Linux 源码包
+
+源码版 PKGBUILD，从 GitHub Release 的 tarball 构建。
+
+## 本地构建并安装
+
+```bash
+cd packaging/arch
+# 生成正确的 sha256sums 后再正式发布
+updpkgsums
+# 构建并安装
+makepkg -si
+```
+
+只构建不安装：`makepkg`，产物为 `dbx-<ver>-<rel>-x86_64.pkg.tar.zst`。
+
+## 升级版本
+
+1. 改 `pkgver`（必要时把 `pkgrel` 重置为 `1`）。
+2. `updpkgsums` 重新生成 `sha256sums`。
+3. `makepkg --printsrcinfo > .SRCINFO`（提交到 AUR 时需要）。
+
+## 备注
+
+- 编译耗时较长（duckdb / arrow / aws-lc-sys 都是大件），首次构建预计 10–20 分钟。
+- 不需要 ODBC 的话，可以在 `crates/dbx-core/Cargo.toml` 把 `odbc-api` 改成可选 feature，并从 `depends` 移除 `unixodbc`。
+- 当前 `tauri.conf.json` 启用了内置 updater；走 pacman 安装的用户应该用 `pacman -Syu` 升级，建议未来给 AUR 构建关闭 `createUpdaterArtifacts`。

--- a/packaging/arch/dbx-bin/PKGBUILD
+++ b/packaging/arch/dbx-bin/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: jinzhongjia <jinzhongjia@manus.ai>
+pkgname=dbx-bin
+_pkgname=dbx
+pkgver=0.4.3
+pkgrel=1
+pkgdesc="Open-source database management tool (Tauri-based) — prebuilt binary"
+arch=('x86_64')
+url="https://github.com/t8y2/dbx"
+license=('AGPL-3.0-only')
+depends=(
+    'webkit2gtk-4.1'
+    'gtk3'
+    'sqlite'
+    'unixodbc'
+    'openssl'
+    'hicolor-icon-theme'
+)
+provides=("$_pkgname")
+conflicts=("$_pkgname")
+source=(
+    "$pkgname-$pkgver.deb::$url/releases/download/v$pkgver/DBX_${pkgver}_amd64.deb"
+    "LICENSE-$pkgver::$url/raw/v$pkgver/LICENSE"
+)
+sha256sums=(
+    '654297e04ecc794baf160c4a19da134c059d5bbcbb619481c6ba9175fb275605'
+    '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0'
+)
+options=('!strip' '!emptydirs' '!debug')
+
+package() {
+    # Tauri's .deb is a regular debian archive: ar(1) wrapping
+    # debian-binary + control.tar.* + data.tar.*. Extract data straight
+    # into $pkgdir.
+    local deb="$srcdir/$pkgname-$pkgver.deb"
+    mkdir -p "$srcdir/extract" && cd "$srcdir/extract"
+    bsdtar -xf "$deb"
+    bsdtar -xf data.tar.* -C "$pkgdir/"
+
+    # Tauri ships icons under a non-standard `256x256@2` directory; rename
+    # it to the conventional `512x512` so hicolor picks it up.
+    if [ -d "$pkgdir/usr/share/icons/hicolor/256x256@2" ]; then
+        mv "$pkgdir/usr/share/icons/hicolor/256x256@2" \
+           "$pkgdir/usr/share/icons/hicolor/512x512"
+    fi
+
+    # AGPL: ship the upstream LICENSE alongside the binary.
+    install -Dm644 "$srcdir/LICENSE-$pkgver" \
+        "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+}


### PR DESCRIPTION
- Provide source-based and prebuilt Arch packages for dbx, supporting both local builds and binary installs
- Add package-specific .gitignore rules to avoid checking in build artifacts
- Document build and upgrade instructions for maintainers and users

Enables easy installation and distribution of dbx for Arch Linux users via AUR or manual packaging workflows.