### PR TITLE
feat: Persist MongoDB browser view mode preference

### DIFF
--- a/apps/desktop/src/components/mongo/MongoDocBrowser.vue
+++ b/apps/desktop/src/components/mongo/MongoDocBrowser.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted } from "vue";
+import { computed, ref, onMounted, watch } from "vue";
 import { uuid } from "@/lib/utils";
 import { useI18n } from "vue-i18n";
 import { RefreshCw, Trash2, Plus, Save, ChevronLeft, ChevronRight, Table2, Braces, X } from "lucide-vue-next";
@@ -23,6 +23,14 @@ const props = defineProps<{
 }>();
 
 type JsonRecord = Record<string, unknown>;
+type ViewMode = "document" | "table";
+
+const VIEW_MODE_STORAGE_KEY = "dbx-mongo-view-mode";
+
+function loadViewModePreference(): ViewMode {
+  if (typeof localStorage === "undefined") return "document";
+  return localStorage.getItem(VIEW_MODE_STORAGE_KEY) === "table" ? "table" : "document";
+}
 
 const documents = ref<JsonRecord[]>([]);
 const total = ref(0);
@@ -36,7 +44,7 @@ const isNew = ref(false);
 const error = ref("");
 const editFields = ref<EditNode[]>([]);
 const showDeleteConfirm = ref(false);
-const viewMode = ref<"document" | "table">("document");
+const viewMode = ref<ViewMode>(loadViewModePreference());
 const filterInput = ref("");
 const sortInput = ref("");
 
@@ -420,6 +428,11 @@ function highlightedJson(json: string): string {
     },
   );
 }
+
+watch(viewMode, (value) => {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(VIEW_MODE_STORAGE_KEY, value);
+});
 
 onMounted(load);
 </script>

--- a/apps/desktop/src/components/mongo/MongoDocBrowser.vue
+++ b/apps/desktop/src/components/mongo/MongoDocBrowser.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { uuid } from "@/lib/utils";
 import { useI18n } from "vue-i18n";
 import { RefreshCw, Trash2, Plus, Save, ChevronLeft, ChevronRight, Table2, Braces, X } from "lucide-vue-next";
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import DangerConfirmDialog from "@/components/editor/DangerConfirmDialog.vue";
 import DataGrid from "@/components/grid/DataGrid.vue";
 import * as api from "@/lib/api";
+import { useSettingsStore } from "@/stores/settingsStore";
 import JsonEditNode from "./JsonEditNode.vue";
 import type { EditNode } from "@/types/editor";
 import type { QueryResult } from "@/types/database";
@@ -15,6 +16,7 @@ import { Splitpanes, Pane } from "splitpanes";
 import "splitpanes/dist/splitpanes.css";
 
 const { t } = useI18n();
+const settingsStore = useSettingsStore();
 
 const props = defineProps<{
   connectionId: string;
@@ -24,13 +26,6 @@ const props = defineProps<{
 
 type JsonRecord = Record<string, unknown>;
 type ViewMode = "document" | "table";
-
-const VIEW_MODE_STORAGE_KEY = "dbx-mongo-view-mode";
-
-function loadViewModePreference(): ViewMode {
-  if (typeof localStorage === "undefined") return "document";
-  return localStorage.getItem(VIEW_MODE_STORAGE_KEY) === "table" ? "table" : "document";
-}
 
 const documents = ref<JsonRecord[]>([]);
 const total = ref(0);
@@ -44,7 +39,10 @@ const isNew = ref(false);
 const error = ref("");
 const editFields = ref<EditNode[]>([]);
 const showDeleteConfirm = ref(false);
-const viewMode = ref<ViewMode>(loadViewModePreference());
+const viewMode = computed<ViewMode>({
+  get: () => settingsStore.editorSettings.mongoViewMode,
+  set: (value) => settingsStore.updateEditorSettings({ mongoViewMode: value }),
+});
 const filterInput = ref("");
 const sortInput = ref("");
 
@@ -428,11 +426,6 @@ function highlightedJson(json: string): string {
     },
   );
 }
-
-watch(viewMode, (value) => {
-  if (typeof localStorage === "undefined") return;
-  localStorage.setItem(VIEW_MODE_STORAGE_KEY, value);
-});
 
 onMounted(load);
 </script>

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -166,6 +166,7 @@ export interface EditorSettings {
   appLayout: "separated" | "classic";
   pageSize: number;
   redisScanPageSize: number;
+  mongoViewMode: "document" | "table";
   shortcuts: ShortcutSettings;
   sidebarActivation: SidebarActivation;
   columnFormatters: Record<string, ColumnFormatterConfig>;
@@ -203,6 +204,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   appLayout: "classic",
   pageSize: 100,
   redisScanPageSize: 1000,
+  mongoViewMode: "document",
   shortcuts: normalizeShortcutSettings(),
   sidebarActivation: "single",
   columnFormatters: {},
@@ -242,6 +244,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>): Edit
     appLayout: settings.appLayout ?? DEFAULT_EDITOR_SETTINGS.appLayout,
     pageSize: normalizeResultPageSize(settings.pageSize),
     redisScanPageSize: settings.redisScanPageSize ?? DEFAULT_EDITOR_SETTINGS.redisScanPageSize,
+    mongoViewMode: settings.mongoViewMode === "table" ? "table" : DEFAULT_EDITOR_SETTINGS.mongoViewMode,
     shortcuts: normalizeShortcutSettings(settings.shortcuts),
     sidebarActivation:
       settings.sidebarActivation === "single" || settings.sidebarActivation === "double"


### PR DESCRIPTION
每一次切换表之后需要重复选择视图模式，需要持久化Mongodb浏览视图