### PR TITLE
fix(grid): release table data memory after close

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -851,58 +851,56 @@ onUnmounted(() => {
                   @set-default-database="setActiveDatabaseAsDefault"
                   @clear-default-database="clearActiveDefaultDatabase"
                 />
-                <KeepAlive :max="20">
-                  <ContentArea
-                    ref="contentAreaRef"
-                    :key="activeTab.id"
-                    :active-tab="activeTab"
-                    :active-connection="activeConnection"
-                    :executable-sql="executableSql"
-                    :active-output-view="activeOutputView"
-                    :format-sql-request-id="formatSqlRequestId"
-                    :selected-sql="selectedSql"
-                    :cursor-pos="cursorPos"
-                    @update:active-output-view="activeOutputView = $event"
-                    @fix-with-ai="fixWithAi"
-                    @execute="tryExecute()"
-                    @cancel="cancelActiveExecution()"
-                    @explain="tryExplain()"
-                    @editor-update="
-                      (v: string) => {
-                        if (queryStore.activeTabId) queryStore.updateSql(queryStore.activeTabId, v);
-                      }
-                    "
-                    @editor-selection-change="(v: string) => (selectedSql = v)"
-                    @editor-cursor-change="(p: number) => (cursorPos = p)"
-                    @format-error="toast(t('toolbar.formatSqlFailed'))"
-                    @save-sql="void openSaveSqlDialog()"
-                    @reload="
-                      (
-                        sql?: string,
-                        searchText?: string,
-                        whereInput?: string,
-                        orderBy?: string,
-                        limit?: number,
-                        offset?: number,
-                      ) => onReloadData(sql, searchText, whereInput, orderBy, limit, offset)
-                    "
-                    @paginate="onPaginate"
-                    @sort="onSort"
-                    @execute-sql="onExecuteSql"
-                    @click-table="onClickTable"
-                    @open-object-table="
-                      (target) =>
-                        activeTab &&
-                        openTableTarget({
-                          connectionId: activeTab.connectionId,
-                          database: activeTab.database,
-                          schema: target.schema,
-                          tableName: target.tableName,
-                        })
-                    "
-                    @object-schema-change="(schema) => activeTab && queryStore.updateSchema(activeTab.id, schema)"
-                  />
-                </KeepAlive>
+                <ContentArea
+                  ref="contentAreaRef"
+                  :key="activeTab.id"
+                  :active-tab="activeTab"
+                  :active-connection="activeConnection"
+                  :executable-sql="executableSql"
+                  :active-output-view="activeOutputView"
+                  :format-sql-request-id="formatSqlRequestId"
+                  :selected-sql="selectedSql"
+                  :cursor-pos="cursorPos"
+                  @update:active-output-view="activeOutputView = $event"
+                  @fix-with-ai="fixWithAi"
+                  @execute="tryExecute()"
+                  @cancel="cancelActiveExecution()"
+                  @explain="tryExplain()"
+                  @editor-update="
+                    (v: string) => {
+                      if (queryStore.activeTabId) queryStore.updateSql(queryStore.activeTabId, v);
+                    }
+                  "
+                  @editor-selection-change="(v: string) => (selectedSql = v)"
+                  @editor-cursor-change="(p: number) => (cursorPos = p)"
+                  @format-error="toast(t('toolbar.formatSqlFailed'))"
+                  @save-sql="void openSaveSqlDialog()"
+                  @reload="
+                    (
+                      sql?: string,
+                      searchText?: string,
+                      whereInput?: string,
+                      orderBy?: string,
+                      limit?: number,
+                      offset?: number,
+                    ) => onReloadData(sql, searchText, whereInput, orderBy, limit, offset)
+                  "
+                  @paginate="onPaginate"
+                  @sort="onSort"
+                  @execute-sql="onExecuteSql"
+                  @click-table="onClickTable"
+                  @open-object-table="
+                    (target) =>
+                      activeTab &&
+                      openTableTarget({
+                        connectionId: activeTab.connectionId,
+                        database: activeTab.database,
+                        schema: target.schema,
+                        tableName: target.tableName,
+                      })
+                  "
+                  @object-schema-change="(schema) => activeTab && queryStore.updateSchema(activeTab.id, schema)"
+                />
               </div>
               <WelcomeScreen
                 v-else

--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -750,7 +750,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
     const k = cacheKey?.value;
     if (k && hasPendingChanges.value) {
       pendingChangesCache.set(k, {
-        newRows: [...newRows.value.map((r) => [...r])],
+        newRows: newRows.value.map((r) => [...r]),
         dirtyRows: new Map([...dirtyRows.value].map(([i, m]) => [i, new Map(m)])),
         deletedRows: new Set(deletedRows.value),
         columnCount: result.value.columns.length,

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -602,6 +602,12 @@ export const useConnectionStore = defineStore("connection", () => {
 
   async function disconnect(connectionId: string) {
     const shouldRemoveOneTimeConnection = getConfig(connectionId)?.one_time === true;
+    try {
+      const { useQueryStore } = await import("@/stores/queryStore");
+      await useQueryStore().clearConnectionRuntimeState(connectionId);
+    } catch (error) {
+      console.warn("[DBX] failed to clear connection query state", error);
+    }
     await api.disconnectDb(connectionId);
     connectedIds.value.delete(connectionId);
     const node = treeNodes.value.find((n) => n.connectionId === connectionId);

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -164,8 +164,7 @@ export const useQueryStore = defineStore("query", () => {
     if (tabs.value[idx].isExecuting) void cancelTabExecution(id);
     if (tabs.value[idx].isExplaining) void cancelTabExplain(id);
     void closeResultSession(tabs.value[idx]);
-    tabs.value[idx].result = undefined;
-    tabs.value[idx].results = undefined;
+    clearTabResultState(tabs.value[idx], { keepTableMeta: false });
     tabs.value.splice(idx, 1);
     if (activeTabId.value === id) {
       activeTabId.value = tabs.value[Math.min(idx, tabs.value.length - 1)]?.id ?? null;
@@ -175,7 +174,12 @@ export const useQueryStore = defineStore("query", () => {
   function closeOtherTabs(id: string) {
     tabs.value.filter((tab) => tab.id !== id && tab.isExecuting).forEach((tab) => void cancelTabExecution(tab.id));
     tabs.value.filter((tab) => tab.id !== id && tab.isExplaining).forEach((tab) => void cancelTabExplain(tab.id));
-    tabs.value.filter((tab) => tab.id !== id).forEach((tab) => void closeResultSession(tab));
+    tabs.value
+      .filter((tab) => tab.id !== id)
+      .forEach((tab) => {
+        void closeResultSession(tab);
+        clearTabResultState(tab, { keepTableMeta: false });
+      });
     const next = closeOtherTabsState(tabs.value, activeTabId.value, id);
     tabs.value = next.tabs;
     activeTabId.value = next.activeTabId;
@@ -184,7 +188,10 @@ export const useQueryStore = defineStore("query", () => {
   function closeAllTabs() {
     tabs.value.filter((tab) => tab.isExecuting).forEach((tab) => void cancelTabExecution(tab.id));
     tabs.value.filter((tab) => tab.isExplaining).forEach((tab) => void cancelTabExplain(tab.id));
-    tabs.value.forEach((tab) => void closeResultSession(tab));
+    tabs.value.forEach((tab) => {
+      void closeResultSession(tab);
+      clearTabResultState(tab, { keepTableMeta: false });
+    });
     const next = closeAllTabsState(tabs.value, activeTabId.value);
     tabs.value = next.tabs;
     activeTabId.value = next.activeTabId;
@@ -199,6 +206,7 @@ export const useQueryStore = defineStore("query", () => {
       tab.queryAnalysis = undefined;
       tab.querySourceColumns = undefined;
       tab.queryEditabilityReason = undefined;
+      tab.resultEvicted = undefined;
     }
   }
 
@@ -245,18 +253,13 @@ export const useQueryStore = defineStore("query", () => {
   function updateDatabase(id: string, database: string) {
     const tab = tabs.value.find((t) => t.id === id);
     if (!tab || tab.database === database) return;
+    void closeResultSession(tab);
     tab.database = database;
     tab.schema = undefined;
     tab.objectBrowser = undefined;
-    tab.result = undefined;
+    clearTabResultState(tab, { keepTableMeta: false });
     tab.lastExecutedSql = undefined;
-    tab.resultBaseSql = undefined;
-    tab.resultSortedSql = undefined;
-    tab.queryAnalysis = undefined;
-    tab.querySourceColumns = undefined;
-    tab.queryEditabilityReason = undefined;
     clearExplain(tab);
-    tab.tableMeta = undefined;
   }
 
   function updateSchema(id: string, schema: string | undefined) {
@@ -269,18 +272,13 @@ export const useQueryStore = defineStore("query", () => {
   function updateConnection(id: string, connectionId: string, database = "") {
     const tab = tabs.value.find((t) => t.id === id);
     if (!tab || tab.connectionId === connectionId) return;
+    void closeResultSession(tab);
     tab.connectionId = connectionId;
     tab.database = database;
     tab.schema = undefined;
-    tab.result = undefined;
+    clearTabResultState(tab, { keepTableMeta: false });
     tab.lastExecutedSql = undefined;
-    tab.resultBaseSql = undefined;
-    tab.resultSortedSql = undefined;
-    tab.queryAnalysis = undefined;
-    tab.querySourceColumns = undefined;
-    tab.queryEditabilityReason = undefined;
     clearExplain(tab);
-    tab.tableMeta = undefined;
   }
 
   function setTableMeta(id: string, meta: NonNullable<QueryTab["tableMeta"]>) {
@@ -328,6 +326,27 @@ export const useQueryStore = defineStore("query", () => {
     tab.isExecuting = false;
     tab.isCancelling = false;
     tab.executionId = undefined;
+  }
+
+  function clearTabResultState(
+    tab: QueryTab,
+    options: { markEvicted?: boolean; keepTableMeta?: boolean } = { keepTableMeta: true },
+  ) {
+    tab.result = undefined;
+    tab.results = undefined;
+    tab.activeResultIndex = undefined;
+    tab.resultSessionId = undefined;
+    tab.resultBaseSql = undefined;
+    tab.resultSortedSql = undefined;
+    tab.resultPageSql = undefined;
+    tab.resultPageLimit = undefined;
+    tab.resultPageOffset = undefined;
+    tab.resultCountSql = undefined;
+    tab.queryAnalysis = undefined;
+    tab.querySourceColumns = undefined;
+    tab.queryEditabilityReason = undefined;
+    tab.resultEvicted = options.markEvicted;
+    if (options.keepTableMeta === false) tab.tableMeta = undefined;
   }
 
   async function executeCurrentTab() {
@@ -708,17 +727,25 @@ export const useQueryStore = defineStore("query", () => {
   }
 
   function trimResultCache() {
-    const inactive = tabs.value.filter((t) => t.id !== activeTabId.value && t.result);
+    const inactive = tabs.value.filter((t) => t.id !== activeTabId.value && (t.result || t.results));
     if (inactive.length > MAX_CACHED_RESULTS) {
       const toEvict = inactive.slice(0, inactive.length - MAX_CACHED_RESULTS);
       toEvict.forEach((t) => {
-        t.result = undefined;
-        t.resultEvicted = true;
-        t.queryAnalysis = undefined;
-        t.querySourceColumns = undefined;
-        t.queryEditabilityReason = undefined;
+        void closeResultSession(t);
+        clearTabResultState(t, { markEvicted: true });
       });
     }
+  }
+
+  async function clearConnectionRuntimeState(connectionId: string) {
+    const connectionTabs = tabs.value.filter((tab) => tab.connectionId === connectionId);
+    await Promise.all(connectionTabs.map((tab) => closeResultSession(tab)));
+    connectionTabs.forEach((tab) => {
+      if (tab.isExecuting) void cancelTabExecution(tab.id);
+      if (tab.isExplaining) void cancelTabExplain(tab.id);
+      clearTabResultState(tab);
+      clearExplain(tab);
+    });
   }
 
   async function reloadEvictedTab(id: string) {
@@ -759,6 +786,7 @@ export const useQueryStore = defineStore("query", () => {
     explainTabSql,
     cancelTabExecution,
     cancelTabExplain,
+    clearConnectionRuntimeState,
     reloadEvictedTab,
   };
 });


### PR DESCRIPTION
## Summary

- Clear table/query result state more completely when tabs are closed, switched, evicted, or their connection is disconnected.
- Remove `KeepAlive` around `ContentArea` so closed or inactive grid instances do not keep large table data alive.
- Close result sessions during result eviction and connection disconnect to avoid retaining backend-side query resources.

## Test plan

- [x] `pnpm fmt`
- [x] `pnpm lint`
- [x] `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- [x] `pnpm test`
- [x] Manually verified memory usage improves after opening, browsing, closing table and disconnecting.
