### PR TITLE
fix(mysql): degrade gracefully when routines lookup fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "dbx"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "anyhow",
  "calamine",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "dbx-web"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "argon2",
  "async-stream",

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -292,7 +292,7 @@ pub async fn list_tables(pool: &MySqlPool, database: &str) -> Result<Vec<TableIn
         .collect())
 }
 
-fn list_objects_sql(database: &str) -> String {
+fn list_tables_objects_sql(database: &str) -> String {
     format!(
         "SELECT TABLE_NAME AS object_name, \
            CASE WHEN TABLE_TYPE = 'VIEW' THEN 'VIEW' ELSE 'TABLE' END AS object_type, \
@@ -302,8 +302,14 @@ fn list_objects_sql(database: &str) -> String {
            CASE WHEN TABLE_TYPE = 'VIEW' THEN 1 ELSE 0 END AS sort_order \
          FROM information_schema.TABLES \
          WHERE TABLE_SCHEMA = {db} \
-         UNION ALL \
-         SELECT ROUTINE_NAME AS object_name, ROUTINE_TYPE AS object_type, NULL AS object_comment, \
+         ORDER BY sort_order, object_name",
+        db = quote_value(database),
+    )
+}
+
+fn list_routines_sql(database: &str) -> String {
+    format!(
+        "SELECT ROUTINE_NAME AS object_name, ROUTINE_TYPE AS object_type, NULL AS object_comment, \
            NULL AS created_at, NULL AS updated_at, \
            CASE WHEN ROUTINE_TYPE = 'PROCEDURE' THEN 2 ELSE 3 END AS sort_order \
          FROM information_schema.ROUTINES \
@@ -313,23 +319,44 @@ fn list_objects_sql(database: &str) -> String {
     )
 }
 
-pub async fn list_objects(pool: &MySqlPool, database: &str) -> Result<Vec<ObjectInfo>, String> {
-    let sql = list_objects_sql(database);
-    let mut conn = pool.get_conn().await.map_err(|e| e.to_string())?;
-    let result = conn.query_iter(&sql).await.map_err(|e| e.to_string())?;
-    let rows: Vec<mysql_async::Row> = result.collect_and_drop().await.map_err(|e| e.to_string())?;
+fn row_to_object(row: &mysql_async::Row, database: &str) -> ObjectInfo {
+    ObjectInfo {
+        name: get_str_by_name(row, "object_name"),
+        object_type: get_str_by_name(row, "object_type"),
+        schema: Some(database.to_string()),
+        comment: get_opt_str(row, "object_comment").filter(|s| !s.is_empty()),
+        created_at: get_opt_str(row, "created_at"),
+        updated_at: get_opt_str(row, "updated_at"),
+    }
+}
 
-    Ok(rows
-        .iter()
-        .map(|row| ObjectInfo {
-            name: get_str_by_name(row, "object_name"),
-            object_type: get_str_by_name(row, "object_type"),
-            schema: Some(database.to_string()),
-            comment: get_opt_str(row, "object_comment").filter(|s| !s.is_empty()),
-            created_at: get_opt_str(row, "created_at"),
-            updated_at: get_opt_str(row, "updated_at"),
-        })
-        .collect())
+pub async fn list_objects(pool: &MySqlPool, database: &str) -> Result<Vec<ObjectInfo>, String> {
+    let mut conn = pool.get_conn().await.map_err(|e| e.to_string())?;
+
+    let tables_sql = list_tables_objects_sql(database);
+    let result = conn.query_iter(&tables_sql).await.map_err(|e| e.to_string())?;
+    let table_rows: Vec<mysql_async::Row> = result.collect_and_drop().await.map_err(|e| e.to_string())?;
+    let mut objects: Vec<ObjectInfo> = table_rows.iter().map(|row| row_to_object(row, database)).collect();
+
+    // Routines are queried separately: some MySQL-compatible servers (sharding proxies,
+    // OceanBase/TiDB variants, restricted accounts) reject information_schema.ROUTINES with
+    // ER_UNKNOWN_ERROR (1105). Degrading gracefully keeps tables/views usable.
+    let routines_sql = list_routines_sql(database);
+    match conn.query_iter(&routines_sql).await {
+        Ok(result) => match result.collect_and_drop::<mysql_async::Row>().await {
+            Ok(routine_rows) => {
+                objects.extend(routine_rows.iter().map(|row| row_to_object(row, database)));
+            }
+            Err(e) => {
+                log::warn!("Skipping routines for database `{}` in object browser: {}", database, e);
+            }
+        },
+        Err(e) => {
+            log::warn!("Skipping routines for database `{}` in object browser: {}", database, e);
+        }
+    }
+
+    Ok(objects)
 }
 
 fn columns_sql(database: &str, table: &str) -> String {
@@ -653,13 +680,23 @@ mod tests {
     }
 
     #[test]
-    fn mysql_list_objects_sql_includes_routines() {
-        let sql = list_objects_sql("app");
+    fn mysql_list_tables_objects_sql_includes_timestamps() {
+        let sql = list_tables_objects_sql("app");
 
         assert!(sql.contains("information_schema.TABLES"));
-        assert!(sql.contains("information_schema.ROUTINES"));
+        assert!(!sql.contains("information_schema.ROUTINES"));
+        assert!(!sql.contains("UNION"));
         assert!(sql.contains("CREATE_TIME"));
         assert!(sql.contains("UPDATE_TIME"));
+    }
+
+    #[test]
+    fn mysql_list_routines_sql_is_independent_of_tables() {
+        let sql = list_routines_sql("app");
+
+        assert!(sql.contains("information_schema.ROUTINES"));
+        assert!(!sql.contains("information_schema.TABLES"));
+        assert!(!sql.contains("UNION"));
         assert!(sql.contains("'PROCEDURE'"));
         assert!(sql.contains("'FUNCTION'"));
         assert!(!sql.contains("LAST_ALTERED"));

--- a/crates/dbx-web/Cargo.toml
+++ b/crates/dbx-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbx-web"
-version = "0.5.19"
+version = "0.5.20"
 edition = "2021"
 
 [[bin]]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dbx",
   "private": true,
-  "version": "0.5.19",
+  "version": "0.5.20",
   "type": "module",
   "packageManager": "pnpm@10.27.0",
   "engines": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbx"
-version = "0.5.19"
+version = "0.5.20"
 description = "Open-source database management tool"
 authors = ["skyler"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBX",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "identifier": "com.dbx.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 概要

- 把 MySQL 对象浏览器的查询从一条 `UNION ALL` 拆成 TABLES 和 ROUTINES 两条独立 SQL。
- ROUTINES 查询失败时只记 warn 日志，并返回已经拿到的表 / 视图，而不是让整个对象浏览器报错。

## 背景

部分 MySQL 兼容服务端（分片代理、权限受限账户、较老的 OceanBase / TiDB 变种、SPIDER 引擎库等）会对 `information_schema.ROUTINES` 直接返回 `ER_UNKNOWN_ERROR (1105 HY000): Unknown error`。

旧实现用 `UNION ALL` 把 TABLES + ROUTINES 绑在一条 SQL 里，ROUTINES 一挂，即便用户只关心表和视图，整个对象浏览器都拿不到任何结果。

复现步骤：
- 连一台上面这种服务端（我这边是 SPIDER 后端的库）。
- 打开对象浏览器 → 红字 `Server error: ERROR HY000 (1105): Unknown error`。
- 单独执行 `SELECT ... FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA = ...` 同样返回 1105；而对应的 TABLES 查询（带或不带 `CREATE_TIME` / `UPDATE_TIME`）都正常。
- 之前的 `mysql_async` 迁移（#3e051d6）以及 legacy routine metadata 修复（#56aeed7）都没覆盖 ROUTINES 整体不可用这种情况。

## 行为变化

- 健康服务端：结果完全一致，顺序保留（tables → views → procedures → functions）。原来的一条 `UNION ALL` 换成两条简单查询，复用同一个池化连接。
- 故障服务端：依然能渲染表 / 视图；routine 列表为空；底层错误会有一条 `log::warn!` 方便排查。
- 公共 API 没变 —— `list_objects` 签名不变。

## 测试计划

- [x] `cargo test -p dbx-core mysql_list` —— 新增两个 SQL builder 单测覆盖拆分逻辑（`mysql_list_tables_objects_sql_includes_timestamps`、`mysql_list_routines_sql_is_independent_of_tables`）。
- [x] `cargo check --workspace --locked`
- [x] `cargo fmt --check`
- [ ] 手测：在受影响的 MySQL 兼容服务端打开对象浏览器；表 / 视图正常显示；procedures 段为空；日志里有 warn。
- [ ] 手测：在带存储过程的健康 MySQL 上打开对象浏览器；procedures 仍列出，顺序与改动前一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)