### PR TITLE
fix: allow mysql timestamp default null ddl

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -273,18 +273,12 @@ fn explicit_timestamp_defaults_sql(enabled: bool) -> &'static str {
     }
 }
 
-async fn enable_explicit_timestamp_defaults_for_query(
-    conn: &mut mysql_async::Conn,
-    sql: &str,
-) -> Option<bool> {
+async fn enable_explicit_timestamp_defaults_for_query(conn: &mut mysql_async::Conn, sql: &str) -> Option<bool> {
     if !should_enable_explicit_timestamp_defaults(sql) {
         return None;
     }
 
-    let previous = match conn
-        .query_first::<u8, _>("SELECT @@SESSION.explicit_defaults_for_timestamp")
-        .await
-    {
+    let previous = match conn.query_first::<u8, _>("SELECT @@SESSION.explicit_defaults_for_timestamp").await {
         Ok(Some(value)) => value != 0,
         Ok(None) => {
             log::debug!("Skipping MySQL explicit timestamp defaults compatibility setting: variable was empty");
@@ -308,10 +302,7 @@ async fn enable_explicit_timestamp_defaults_for_query(
     Some(previous)
 }
 
-async fn restore_explicit_timestamp_defaults_for_query(
-    conn: &mut mysql_async::Conn,
-    previous: Option<bool>,
-) {
+async fn restore_explicit_timestamp_defaults_for_query(conn: &mut mysql_async::Conn, previous: Option<bool>) {
     if let Some(previous) = previous {
         if let Err(err) = conn.query_drop(explicit_timestamp_defaults_sql(previous)).await {
             log::warn!("Failed to restore MySQL explicit timestamp defaults session setting: {err}");
@@ -723,26 +714,17 @@ pub async fn execute_query_with_max_rows(
         }
     } else {
         let mut conn = pool.get_conn().await.map_err(|e| e.to_string())?;
-        let previous_explicit_timestamp_defaults =
-            enable_explicit_timestamp_defaults_for_query(&mut conn, sql).await;
+        let previous_explicit_timestamp_defaults = enable_explicit_timestamp_defaults_for_query(&mut conn, sql).await;
         let result = match conn.query_iter(sql).await {
             Ok(result) => result,
             Err(err) => {
-                restore_explicit_timestamp_defaults_for_query(
-                    &mut conn,
-                    previous_explicit_timestamp_defaults,
-                )
-                .await;
+                restore_explicit_timestamp_defaults_for_query(&mut conn, previous_explicit_timestamp_defaults).await;
                 return Err(err.to_string());
             }
         };
         let affected_rows = result.affected_rows();
         let drop_result = result.drop_result().await;
-        restore_explicit_timestamp_defaults_for_query(
-            &mut conn,
-            previous_explicit_timestamp_defaults,
-        )
-        .await;
+        restore_explicit_timestamp_defaults_for_query(&mut conn, previous_explicit_timestamp_defaults).await;
         drop_result.map_err(|e| e.to_string())?;
 
         Ok(QueryResult {
@@ -976,14 +958,8 @@ mod tests {
         ));
         assert!(!should_enable_explicit_timestamp_defaults("CREATE TABLE t (deleted_at DATETIME(6) DEFAULT NULL)"));
         assert!(!should_enable_explicit_timestamp_defaults("SELECT 'TIMESTAMP DEFAULT NULL'"));
-        assert_eq!(
-            explicit_timestamp_defaults_sql(true),
-            "SET SESSION explicit_defaults_for_timestamp = ON"
-        );
-        assert_eq!(
-            explicit_timestamp_defaults_sql(false),
-            "SET SESSION explicit_defaults_for_timestamp = OFF"
-        );
+        assert_eq!(explicit_timestamp_defaults_sql(true), "SET SESSION explicit_defaults_for_timestamp = ON");
+        assert_eq!(explicit_timestamp_defaults_sql(false), "SET SESSION explicit_defaults_for_timestamp = OFF");
     }
 
     #[test]

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -265,12 +265,57 @@ fn should_enable_explicit_timestamp_defaults(sql: &str) -> bool {
     lower.contains("timestamp") && lower.contains("default null")
 }
 
-async fn enable_explicit_timestamp_defaults_for_query(conn: &mut mysql_async::Conn, sql: &str) {
-    if !should_enable_explicit_timestamp_defaults(sql) {
-        return;
+fn explicit_timestamp_defaults_sql(enabled: bool) -> &'static str {
+    if enabled {
+        "SET SESSION explicit_defaults_for_timestamp = ON"
+    } else {
+        "SET SESSION explicit_defaults_for_timestamp = OFF"
     }
-    if let Err(err) = conn.query_drop("SET SESSION explicit_defaults_for_timestamp = ON").await {
+}
+
+async fn enable_explicit_timestamp_defaults_for_query(
+    conn: &mut mysql_async::Conn,
+    sql: &str,
+) -> Option<bool> {
+    if !should_enable_explicit_timestamp_defaults(sql) {
+        return None;
+    }
+
+    let previous = match conn
+        .query_first::<u8, _>("SELECT @@SESSION.explicit_defaults_for_timestamp")
+        .await
+    {
+        Ok(Some(value)) => value != 0,
+        Ok(None) => {
+            log::debug!("Skipping MySQL explicit timestamp defaults compatibility setting: variable was empty");
+            return None;
+        }
+        Err(err) => {
+            log::debug!("Skipping MySQL explicit timestamp defaults compatibility setting: {err}");
+            return None;
+        }
+    };
+
+    if previous {
+        return None;
+    }
+
+    if let Err(err) = conn.query_drop(explicit_timestamp_defaults_sql(true)).await {
         log::debug!("Skipping MySQL explicit timestamp defaults compatibility setting: {err}");
+        return None;
+    }
+
+    Some(previous)
+}
+
+async fn restore_explicit_timestamp_defaults_for_query(
+    conn: &mut mysql_async::Conn,
+    previous: Option<bool>,
+) {
+    if let Some(previous) = previous {
+        if let Err(err) = conn.query_drop(explicit_timestamp_defaults_sql(previous)).await {
+            log::warn!("Failed to restore MySQL explicit timestamp defaults session setting: {err}");
+        }
     }
 }
 
@@ -678,10 +723,27 @@ pub async fn execute_query_with_max_rows(
         }
     } else {
         let mut conn = pool.get_conn().await.map_err(|e| e.to_string())?;
-        enable_explicit_timestamp_defaults_for_query(&mut conn, sql).await;
-        let result = conn.query_iter(sql).await.map_err(|e| e.to_string())?;
+        let previous_explicit_timestamp_defaults =
+            enable_explicit_timestamp_defaults_for_query(&mut conn, sql).await;
+        let result = match conn.query_iter(sql).await {
+            Ok(result) => result,
+            Err(err) => {
+                restore_explicit_timestamp_defaults_for_query(
+                    &mut conn,
+                    previous_explicit_timestamp_defaults,
+                )
+                .await;
+                return Err(err.to_string());
+            }
+        };
         let affected_rows = result.affected_rows();
-        result.drop_result().await.map_err(|e| e.to_string())?;
+        let drop_result = result.drop_result().await;
+        restore_explicit_timestamp_defaults_for_query(
+            &mut conn,
+            previous_explicit_timestamp_defaults,
+        )
+        .await;
+        drop_result.map_err(|e| e.to_string())?;
 
         Ok(QueryResult {
             columns: vec![],
@@ -914,6 +976,14 @@ mod tests {
         ));
         assert!(!should_enable_explicit_timestamp_defaults("CREATE TABLE t (deleted_at DATETIME(6) DEFAULT NULL)"));
         assert!(!should_enable_explicit_timestamp_defaults("SELECT 'TIMESTAMP DEFAULT NULL'"));
+        assert_eq!(
+            explicit_timestamp_defaults_sql(true),
+            "SET SESSION explicit_defaults_for_timestamp = ON"
+        );
+        assert_eq!(
+            explicit_timestamp_defaults_sql(false),
+            "SET SESSION explicit_defaults_for_timestamp = OFF"
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -257,6 +257,23 @@ fn mysql_setup_queries(url: &str) -> Vec<String> {
     vec![format!("SET NAMES {charset}")]
 }
 
+fn should_enable_explicit_timestamp_defaults(sql: &str) -> bool {
+    if !starts_with_executable_sql_keyword(sql, &["CREATE", "ALTER"]) {
+        return false;
+    }
+    let lower = sql.split_whitespace().collect::<Vec<_>>().join(" ").to_ascii_lowercase();
+    lower.contains("timestamp") && lower.contains("default null")
+}
+
+async fn enable_explicit_timestamp_defaults_for_query(conn: &mut mysql_async::Conn, sql: &str) {
+    if !should_enable_explicit_timestamp_defaults(sql) {
+        return;
+    }
+    if let Err(err) = conn.query_drop("SET SESSION explicit_defaults_for_timestamp = ON").await {
+        log::debug!("Skipping MySQL explicit timestamp defaults compatibility setting: {err}");
+    }
+}
+
 fn mysql_connection_charset(url: &str) -> Option<&str> {
     let (_, query) = url.split_once('?')?;
     query.split('&').find_map(|segment| {
@@ -661,6 +678,7 @@ pub async fn execute_query_with_max_rows(
         }
     } else {
         let mut conn = pool.get_conn().await.map_err(|e| e.to_string())?;
+        enable_explicit_timestamp_defaults_for_query(&mut conn, sql).await;
         let result = conn.query_iter(sql).await.map_err(|e| e.to_string())?;
         let affected_rows = result.affected_rows();
         result.drop_result().await.map_err(|e| e.to_string())?;
@@ -876,6 +894,26 @@ mod tests {
         assert!(requires_text_protocol_query("SHOW GRANTS FOR 'repl'@'%'"));
         assert!(!requires_text_protocol_query("SHOW TABLES"));
         assert!(!requires_text_protocol_query("SELECT * FROM users"));
+    }
+
+    #[test]
+    fn mysql_timestamp_default_null_ddl_enables_explicit_defaults() {
+        let create_sql = r#"
+            CREATE TABLE `referral_record` (
+                `id` BINARY(16) NOT NULL,
+                `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                `deleted_at` TIMESTAMP(6) DEFAULT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE = InnoDB
+        "#;
+
+        assert!(should_enable_explicit_timestamp_defaults(create_sql));
+        assert!(should_enable_explicit_timestamp_defaults(
+            "ALTER TABLE referral_record ADD deleted_at TIMESTAMP DEFAULT NULL"
+        ));
+        assert!(!should_enable_explicit_timestamp_defaults("CREATE TABLE t (deleted_at DATETIME(6) DEFAULT NULL)"));
+        assert!(!should_enable_explicit_timestamp_defaults("SELECT 'TIMESTAMP DEFAULT NULL'"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enable MySQL `explicit_defaults_for_timestamp` for DDL statements that define `TIMESTAMP ... DEFAULT NULL` columns.
- Prevent valid MySQL `CREATE TABLE` / `ALTER TABLE` statements from failing with `ERROR 42000 (1067): Invalid default value` on older/session-strict timestamp defaults.
- Add focused coverage for the referral-record style DDL detection.

## Test plan
- `git diff --check -- crates/dbx-core/src/db/mysql.rs`
- `cd /tmp/dbx-src && pnpm test`

Note: Rust checks were not run locally because `cargo`/`rustc` are not available in this environment.