### PR TITLE
Fix/disable table comment for unsupported db

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -12,6 +12,7 @@ import {
   ChevronDown,
   ChevronUp,
   Database,
+  Info,
   KeyRound,
   Loader2,
   Maximize2,
@@ -28,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -134,6 +136,7 @@ function onIndexColResize(e: MouseEvent, col: number) {
 const connection = computed(() => (props.connectionId ? store.getConfig(props.connectionId) : undefined));
 const databaseType = computed(() => connection.value?.db_type);
 const structureCapabilities = computed(() => getTableStructureCapabilities(databaseType.value));
+const isTableCommentDisabled = computed(() => !structureCapabilities.value.comment);
 const dataTypeOptions = computed(() => DATA_TYPE_OPTIONS[databaseType.value ?? ""] ?? []);
 
 const indexTypesByDb: Record<string, string[]> = {
@@ -509,7 +512,14 @@ watch(
         v-model="tableComment"
         :placeholder="t('structureEditor.tableCommentPlaceholder')"
         class="h-6 max-w-[320px] text-[11px]"
+        :disabled="isTableCommentDisabled"
       />
+      <Tooltip v-if="isTableCommentDisabled">
+        <TooltipTrigger as-child>
+          <Info class="h-4 w-4 shrink-0 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>{{ t("structureEditor.tableCommentUnsupported") }}</TooltipContent>
+      </Tooltip>
     </div>
 
     <div v-if="loading" class="flex min-h-0 flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -989,6 +989,7 @@ export default {
     editComment: "Edit comment",
     commentPlaceholder: "Enter column comment...",
     tableCommentPlaceholder: "Enter table comment...",
+    tableCommentUnsupported: "Table comments are not supported by this database",
     actions: "Actions",
     indexName: "Index",
     indexColumns: "Columns",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -883,6 +883,7 @@ export default {
     editComment: "Editar comentario",
     commentPlaceholder: "Ingresar comentario de columna...",
     tableCommentPlaceholder: "Ingresar comentario de tabla...",
+    tableCommentUnsupported: "La base de datos no admite comentarios de tabla",
     actions: "Acciones",
     indexName: "Índice",
     indexColumns: "Columnas",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -967,6 +967,7 @@ export default {
     editComment: "编辑注释",
     commentPlaceholder: "输入字段注释...",
     tableCommentPlaceholder: "输入表注释...",
+    tableCommentUnsupported: "当前数据库不支持表注释",
     actions: "操作",
     indexName: "索引名",
     indexColumns: "字段列表",

--- a/packages/app-tests/tableStructureCapabilities.test.ts
+++ b/packages/app-tests/tableStructureCapabilities.test.ts
@@ -5,6 +5,14 @@ import {
   getTableStructureCapabilities,
 } from "../../apps/desktop/src/lib/tableStructureCapabilities.ts";
 
+test("sqlite and duckdb do not support table comments", () => {
+  for (const dbType of ["sqlite", "duckdb"] as const) {
+    const caps = getTableStructureCapabilities(dbType);
+    assert.equal(caps.comment, false, `${dbType} should not support comments`);
+    assert.equal(caps.createTable, true, `${dbType} should still support creating tables`);
+  }
+});
+
 test("postgres-like databases expose safe structure editing capabilities", () => {
   for (const dbType of ["postgres", "gaussdb", "opengauss", "highgo", "vastbase", "kingbase"] as const) {
     const caps = getTableStructureCapabilities(dbType);

--- a/packages/app-tests/tableStructureEditorPresentation.test.ts
+++ b/packages/app-tests/tableStructureEditorPresentation.test.ts
@@ -80,3 +80,11 @@ test("new column input is focused after adding a field", () => {
   assert.match(source, /data-column-name-input/);
   assert.match(source, /input\?\.focus\(\)/);
 });
+
+test("table comment input is disabled and shows tooltip when database does not support comments", () => {
+  assert.match(source, /isTableCommentDisabled/);
+  assert.match(source, /:disabled="isTableCommentDisabled"/);
+  assert.match(source, /v-if="isTableCommentDisabled"/);
+  assert.match(source, /Tooltip/);
+  assert.match(source, /tableCommentUnsupported/);
+});


### PR DESCRIPTION
# fix: disable table comment input for databases that don't support comments

## Problem

SQLite does not support table comments (COMMENT ON TABLE), but the table comment input in the structure editor remains editable. When users modify the comment and click
"Apply Changes", the SQL preview shows "No changes" and the apply button stays disabled — a confusing UX that wastes user time.

Before:

- Input is always editable regardless of database type
- Editing the comment produces no SQL output
- No explanation is provided to the user

## Solution

Disable the table comment input when the connected database doesn't support comments, and display an informational tooltip explaining why.

After:

- Input is automatically disabled (greyed out) for SQLite, DuckDB, and other unsupported databases
- An ⓘ icon appears next to the input; hovering reveals "Table comments are not supported by this database"
- MySQL, PostgreSQL, ClickHouse, and other supported databases remain fully unaffected

The implementation reuses the existing structureCapabilities.comment flag, which is already false for SQLite/DuckDB in the capabilities layer. The backend
(generate_comment_ddl) also has a matching guard that only emits COMMENT ON TABLE for Postgres, Oracle, and ClickHouse.

## Changes

┌──────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ File                                     │ Change                                                                                                 │
├──────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ TableStructureEditor.vue                 │ Add isTableCommentDisabled computed; bind :disabled on input; render Tooltip + Info icon when disabled │
│ zh-CN.ts                                 │ Add tableCommentUnsupported translation                                                                │
│ en.ts                                    │ Add tableCommentUnsupported translation                                                                │
│ es.ts                                    │ Add tableCommentUnsupported translation                                                                │
│ tableStructureCapabilities.test.ts       │ New test: SQLite/DuckDB comment === false                                                              │
│ tableStructureEditorPresentation.test.ts │ New test: source contains disabled binding, Tooltip, and i18n key                                      │
└──────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────┘

## Impact on other databases

┌────────────────────────────────────────────────────────────────────────────┬────────────────────┬──────────────────────────┐
│ Database family                                                            │ comment capability │ Impact                   │
├────────────────────────────────────────────────────────────────────────────┼────────────────────┼──────────────────────────┤
│ MySQL / Doris / StarRocks / Goldendb / Sundb                               │ true               │ ✅ None                  │
│ PostgreSQL / GaussDB / OpenGauss / Redshift / Highgo / Vastbase / KingBase │ true               │ ✅ None                  │
│ SQL Server                                                                 │ true               │ ✅ None                  │
│ Oracle / Dameng / OceanBase-Oracle                                         │ true               │ ✅ None                  │
│ H2                                                                         │ true               │ ✅ None                  │
│ ClickHouse                                                                 │ true               │ ✅ None                  │
│ SQLite / DuckDB                                                            │ false              │ Input disabled + tooltip │
│ Unknown / unsupported                                                      │ false              │ Safe degradation         │
└────────────────────────────────────────────────────────────────────────────┴────────────────────┴──────────────────────────┘

## Testing

- ✅ All 17 tests pass (pnpm test)
- ✅ New: sqlite and duckdb do not support table comments — capability layer
- ✅ New: table comment input is disabled and shows tooltip when database does not support comments — source structure verification
- ✅ Pre-commit hooks (oxfmt, lint-staged) pass

## Checklist

- [x] No breaking changes for existing database types
- [x] i18n strings added for all 3 locales (zh-CN, en, es)
- [x] Implementation aligns with existing isColumnCommentDisabled pattern
- [x] Frontend guard + backend generate_comment_ddl guard are consistent
- [x] Tests added and passing