### PR TITLE
fix(sidebar): restore SQL Server object browser entry

### DIFF
--- a/apps/desktop/src/lib/databaseFeatureSupport.ts
+++ b/apps/desktop/src/lib/databaseFeatureSupport.ts
@@ -74,7 +74,7 @@ export function supportsObjectBrowser(dbType?: DatabaseType): boolean {
 
 export function supportsObjectBrowserTreeNode(dbType: DatabaseType | undefined, nodeType: TreeNodeType): boolean {
   if (!supportsObjectBrowser(dbType)) return false;
-  if (nodeType === "database" && isSchemaAware(dbType)) return false;
+  if (nodeType === "database" && isSchemaAware(dbType) && dbType !== "sqlserver") return false;
   return nodeType === "database" || nodeType === "schema" || nodeType === "object-browser";
 }
 

--- a/packages/app-tests/databaseCapabilities.test.ts
+++ b/packages/app-tests/databaseCapabilities.test.ts
@@ -204,9 +204,11 @@ test("describes feature support through capability helpers", () => {
   assert.equal(supportsTableTruncate("duckdb"), false);
 });
 
-test("schema-aware database nodes do not open an object browser tab", () => {
+test("object browser entry follows database tree shape", () => {
   assert.equal(supportsObjectBrowserTreeNode("postgres", "database"), false);
   assert.equal(supportsObjectBrowserTreeNode("postgres", "schema"), true);
+  assert.equal(supportsObjectBrowserTreeNode("sqlserver", "database"), true);
+  assert.equal(supportsObjectBrowserTreeNode("sqlserver", "schema"), true);
   assert.equal(supportsObjectBrowserTreeNode("mysql", "database"), true);
   assert.equal(supportsObjectBrowserTreeNode("mongodb", "database"), false);
 });


### PR DESCRIPTION
## Summary
- allow SQL Server database tree nodes to open the object browser
- keep schema-aware database nodes such as PostgreSQL restricted to schema-level object browsing
- add capability coverage for SQL Server database and schema object browser entries

Fixes #538

## Tests
- pnpm exec oxfmt --check apps/desktop/src/lib/databaseFeatureSupport.ts packages/app-tests/databaseCapabilities.test.ts
- pnpm exec tsx --tsconfig apps/desktop/tsconfig.json --test packages/app-tests/databaseCapabilities.test.ts
- pnpm exec tsx --tsconfig apps/desktop/tsconfig.json --test packages/app-tests/treeNodeClick.test.ts
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm lint
- pnpm test
- pnpm build
- git diff --check
