### PR TITLE
Improve dark mode palette with IDEA-style theme

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -38,8 +38,8 @@ import {
 import {
   EDITOR_FONT_FAMILY_CSS_VAR,
   EDITOR_FONT_SIZE_CSS_VAR,
-  loadEditorTheme,
   editorFontTheme,
+  loadSqlEditorTheme,
   sqlCompletionTheme,
 } from "@/lib/editorThemes";
 import {
@@ -1209,7 +1209,7 @@ onMounted(async () => {
     keywords: (baseDialect.spec.keywords || "") + " " + extraKeywords,
   });
 
-  const theme = await loadEditorTheme(ss.theme, editorThemeAppearance());
+  const theme = await loadSqlEditorTheme(ss.theme, editorThemeAppearance());
 
   const activeLineHighlighter = ViewPlugin.fromClass(
     class {
@@ -1538,7 +1538,7 @@ watch(
       liveFontSize.value = ss.fontSize;
     }
     syncEditorFontCssVars(liveFontSize.value, ss.fontFamily);
-    const themeExt = await loadEditorTheme(ss.theme, editorThemeAppearance());
+    const themeExt = await loadSqlEditorTheme(ss.theme, editorThemeAppearance());
     view.value.dispatch({
       effects: [
         codeMirrorTheme.reconfigure(themeExt),

--- a/apps/desktop/src/lib/editorThemes.ts
+++ b/apps/desktop/src/lib/editorThemes.ts
@@ -4,6 +4,23 @@ import type { AppThemeAppearance } from "@/lib/appTheme";
 
 type CodeMirrorStyleSpec = Parameters<typeof import("@codemirror/view").EditorView.theme>[0];
 type LucideIconNode = Array<[string, Record<string, string>]>;
+type IdeaDarkSqlTokenKind =
+  | "comment"
+  | "function"
+  | "identifier"
+  | "keyword"
+  | "number"
+  | "operator"
+  | "source"
+  | "string"
+  | "type"
+  | "variable";
+
+export interface IdeaDarkSqlTokenStyle {
+  from: number;
+  to: number;
+  kind: IdeaDarkSqlTokenKind;
+}
 
 export const EDITOR_FONT_SIZE_CSS_VAR = "--dbx-editor-font-size";
 export const EDITOR_FONT_FAMILY_CSS_VAR = "--dbx-editor-font-family";
@@ -59,9 +76,566 @@ function lucideCompletionIconMask(iconNode: LucideIconNode) {
   };
 }
 
+const IDEA_DARK_EDITOR_COLORS = {
+  background: "#1e1f22",
+  foreground: "#bcbec4",
+  mutedForeground: "#7a7e85",
+  panel: "#252629",
+  panelBorder: "#323438",
+  activeLine: "#25272c",
+  selection: "#2f4f7f",
+  cursor: "#bcbec4",
+  keyword: "#cf8e6d",
+  name: "#d286bf",
+  function: "#56a8f5",
+  constant: "#c89f66",
+  definition: "#bcbec4",
+  type: "#c9a86a",
+  operator: "#56a8a8",
+  string: "#6aab73",
+  comment: "#7a7e85",
+  invalid: "#ff6b68",
+};
+
+const IDEA_DARK_SQL_TOKEN_CLASS: Record<IdeaDarkSqlTokenKind, string> = {
+  comment: "cm-dbxi-sql-comment",
+  function: "cm-dbxi-sql-function",
+  identifier: "cm-dbxi-sql-identifier",
+  keyword: "cm-dbxi-sql-keyword",
+  number: "cm-dbxi-sql-number",
+  operator: "cm-dbxi-sql-operator",
+  source: "cm-dbxi-sql-source",
+  string: "cm-dbxi-sql-string",
+  type: "cm-dbxi-sql-type",
+  variable: "cm-dbxi-sql-variable",
+};
+
+const ONE_DARK_TO_IDEA_DARK_COLORS: Record<string, string> = {
+  "#c678dd": IDEA_DARK_EDITOR_COLORS.keyword,
+  "#e06c75": IDEA_DARK_EDITOR_COLORS.name,
+  "#61afef": IDEA_DARK_EDITOR_COLORS.function,
+  "#d19a66": IDEA_DARK_EDITOR_COLORS.constant,
+  "#abb2bf": IDEA_DARK_EDITOR_COLORS.definition,
+  "#e5c07b": IDEA_DARK_EDITOR_COLORS.type,
+  "#56b6c2": IDEA_DARK_EDITOR_COLORS.operator,
+  "#7d8799": IDEA_DARK_EDITOR_COLORS.comment,
+  "#98c379": IDEA_DARK_EDITOR_COLORS.string,
+  "#ffffff": IDEA_DARK_EDITOR_COLORS.invalid,
+};
+
+const SQL_KEYWORDS = new Set([
+  "add",
+  "all",
+  "alter",
+  "and",
+  "any",
+  "as",
+  "asc",
+  "begin",
+  "between",
+  "by",
+  "cascade",
+  "case",
+  "check",
+  "collate",
+  "column",
+  "comment",
+  "commit",
+  "conflict",
+  "constraint",
+  "create",
+  "cross",
+  "current_date",
+  "current_time",
+  "current_timestamp",
+  "database",
+  "default",
+  "delete",
+  "desc",
+  "describe",
+  "distinct",
+  "drop",
+  "else",
+  "end",
+  "escape",
+  "except",
+  "exclude",
+  "explain",
+  "exists",
+  "false",
+  "fetch",
+  "for",
+  "foreign",
+  "from",
+  "full",
+  "function",
+  "grant",
+  "group",
+  "having",
+  "in",
+  "index",
+  "inner",
+  "insert",
+  "intersect",
+  "into",
+  "is",
+  "join",
+  "key",
+  "left",
+  "like",
+  "limit",
+  "merge",
+  "not",
+  "null",
+  "of",
+  "offset",
+  "on",
+  "only",
+  "or",
+  "order",
+  "outer",
+  "over",
+  "partition",
+  "primary",
+  "procedure",
+  "range",
+  "recursive",
+  "references",
+  "replace",
+  "restrict",
+  "returning",
+  "revoke",
+  "right",
+  "rollback",
+  "row",
+  "rows",
+  "schema",
+  "select",
+  "set",
+  "some",
+  "table",
+  "temporary",
+  "then",
+  "to",
+  "trigger",
+  "true",
+  "truncate",
+  "union",
+  "unique",
+  "update",
+  "using",
+  "values",
+  "view",
+  "when",
+  "where",
+  "window",
+  "with",
+]);
+
+const SQL_SOURCE_KEYWORDS = new Set(["delete", "describe", "from", "into", "join", "table", "update"]);
+
+const SQL_FUNCTIONS = new Set([
+  "abs",
+  "acos",
+  "avg",
+  "cast",
+  "ceil",
+  "ceiling",
+  "coalesce",
+  "concat",
+  "count",
+  "date",
+  "date_add",
+  "date_format",
+  "date_sub",
+  "datediff",
+  "day",
+  "dayofmonth",
+  "dayofweek",
+  "dayofyear",
+  "dense_rank",
+  "extract",
+  "floor",
+  "greatest",
+  "hour",
+  "ifnull",
+  "json_array",
+  "json_build_object",
+  "json_each",
+  "json_extract",
+  "json_object",
+  "json_query",
+  "json_value",
+  "least",
+  "length",
+  "lower",
+  "ltrim",
+  "max",
+  "min",
+  "minute",
+  "month",
+  "now",
+  "nullif",
+  "rank",
+  "regexp_replace",
+  "replace",
+  "row_number",
+  "round",
+  "rtrim",
+  "second",
+  "substring",
+  "sum",
+  "to_char",
+  "to_date",
+  "to_timestamp",
+  "trim",
+  "upper",
+  "year",
+]);
+
+const SQL_TYPES = new Set([
+  "array",
+  "bigint",
+  "bigserial",
+  "binary",
+  "bit",
+  "blob",
+  "bool",
+  "boolean",
+  "box",
+  "bytea",
+  "char",
+  "character",
+  "cidr",
+  "circle",
+  "clob",
+  "date",
+  "datetime",
+  "datetime2",
+  "decimal",
+  "double",
+  "enum",
+  "float",
+  "float4",
+  "float8",
+  "inet",
+  "int",
+  "int2",
+  "int4",
+  "int8",
+  "integer",
+  "interval",
+  "json",
+  "jsonb",
+  "line",
+  "longblob",
+  "longtext",
+  "macaddr",
+  "mediumblob",
+  "mediumint",
+  "mediumtext",
+  "money",
+  "nchar",
+  "ntext",
+  "numeric",
+  "nvarchar",
+  "path",
+  "point",
+  "polygon",
+  "real",
+  "serial",
+  "serial2",
+  "serial4",
+  "serial8",
+  "smallint",
+  "smallserial",
+  "text",
+  "time",
+  "timestamp",
+  "timestamptz",
+  "tinyblob",
+  "tinyint",
+  "tinytext",
+  "tsquery",
+  "tsvector",
+  "uuid",
+  "varbinary",
+  "varchar",
+  "varying",
+  "xml",
+  "year",
+]);
+
+interface SqlWordToken {
+  from: number;
+  to: number;
+  type: "comment" | "number" | "operator" | "punctuation" | "string" | "variable" | "word";
+  value: string;
+}
+
+function readSqlToken(text: string, from: number): SqlWordToken | undefined {
+  const rest = text.slice(from);
+  const stringMatch = rest.match(/^'(?:''|[^'])*'/);
+  if (stringMatch) return { from, to: from + stringMatch[0].length, type: "string", value: stringMatch[0] };
+
+  const lineCommentMatch = rest.match(/^--[^\n\r]*/);
+  if (lineCommentMatch)
+    return { from, to: from + lineCommentMatch[0].length, type: "comment", value: lineCommentMatch[0] };
+
+  const blockCommentMatch = rest.match(/^\/\*[\s\S]*?\*\//);
+  if (blockCommentMatch)
+    return { from, to: from + blockCommentMatch[0].length, type: "comment", value: blockCommentMatch[0] };
+
+  const variableMatch = rest.match(/^@[A-Za-z_][\w$]*/);
+  if (variableMatch) return { from, to: from + variableMatch[0].length, type: "variable", value: variableMatch[0] };
+
+  const quotedIdentifierMatch = rest.match(/^(?:"[^"]+"|`[^`]+`|\[[^\]]+\])/);
+  if (quotedIdentifierMatch) {
+    return { from, to: from + quotedIdentifierMatch[0].length, type: "word", value: quotedIdentifierMatch[0] };
+  }
+
+  const numberMatch = rest.match(/^\b\d+(?:\.\d+)?\b/);
+  if (numberMatch) return { from, to: from + numberMatch[0].length, type: "number", value: numberMatch[0] };
+
+  const wordMatch = rest.match(/^[A-Za-z_][\w$]*/);
+  if (wordMatch) return { from, to: from + wordMatch[0].length, type: "word", value: wordMatch[0] };
+
+  const operatorMatch = rest.match(/^(?:<>|!=|<=|>=|:=|::|[-+*/%<>=|&^~!]+)/);
+  if (operatorMatch) return { from, to: from + operatorMatch[0].length, type: "operator", value: operatorMatch[0] };
+
+  const punctuationMatch = rest.match(/^[()[\]{},.;.]/);
+  if (punctuationMatch) {
+    return { from, to: from + punctuationMatch[0].length, type: "punctuation", value: punctuationMatch[0] };
+  }
+
+  return undefined;
+}
+
+function nextSqlToken(tokens: SqlWordToken[], index: number): SqlWordToken | undefined {
+  return tokens.slice(index + 1).find((token) => token.type !== "comment");
+}
+
+export function classifyIdeaDarkSqlTokens(text: string): IdeaDarkSqlTokenStyle[] {
+  const tokens: SqlWordToken[] = [];
+  for (let index = 0; index < text.length; ) {
+    if (/\s/.test(text[index])) {
+      index++;
+      continue;
+    }
+
+    const token = readSqlToken(text, index);
+    if (!token) {
+      index++;
+      continue;
+    }
+
+    tokens.push(token);
+    index = token.to;
+  }
+
+  const styles: IdeaDarkSqlTokenStyle[] = [];
+  let expectSource = false;
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    if (token.type === "comment" || token.type === "string" || token.type === "number" || token.type === "variable") {
+      styles.push({ from: token.from, to: token.to, kind: token.type });
+      continue;
+    }
+
+    if (token.type === "operator") {
+      styles.push({ from: token.from, to: token.to, kind: "operator" });
+      continue;
+    }
+
+    if (token.type !== "word") continue;
+
+    const value = token.value.replace(/^["`\[]|["`\]]$/g, "");
+    const lowerValue = value.toLowerCase();
+    const nextToken = nextSqlToken(tokens, index);
+    const isFunctionCall = nextToken?.type === "punctuation" && nextToken.value === "(";
+
+    if (expectSource) {
+      styles.push({ from: token.from, to: token.to, kind: "source" });
+      expectSource = nextToken?.value === ".";
+      continue;
+    }
+
+    if (SQL_TYPES.has(lowerValue) && !(isFunctionCall && SQL_FUNCTIONS.has(lowerValue))) {
+      styles.push({ from: token.from, to: token.to, kind: "type" });
+      continue;
+    }
+
+    if (
+      (SQL_FUNCTIONS.has(lowerValue) || (isFunctionCall && !SQL_KEYWORDS.has(lowerValue))) &&
+      lowerValue !== "select"
+    ) {
+      styles.push({ from: token.from, to: token.to, kind: "function" });
+      continue;
+    }
+
+    if (SQL_KEYWORDS.has(lowerValue)) {
+      styles.push({ from: token.from, to: token.to, kind: "keyword" });
+      expectSource = SQL_SOURCE_KEYWORDS.has(lowerValue);
+      continue;
+    }
+
+    styles.push({ from: token.from, to: token.to, kind: "identifier" });
+  }
+
+  return styles;
+}
+
+export async function loadIdeaDarkEditorTheme(): Promise<Extension> {
+  const [{ EditorView }, { HighlightStyle, syntaxHighlighting }, { oneDarkHighlightStyle }] = await Promise.all([
+    import("@codemirror/view"),
+    import("@codemirror/language"),
+    import("@codemirror/theme-one-dark"),
+  ]);
+
+  const theme = EditorView.theme(
+    {
+      "&": {
+        "--dbx-editor-gutter-divider": IDEA_DARK_EDITOR_COLORS.panelBorder,
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.background,
+        color: IDEA_DARK_EDITOR_COLORS.foreground,
+      },
+      ".cm-scroller": {
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.background,
+      },
+      ".cm-content": {
+        caretColor: IDEA_DARK_EDITOR_COLORS.cursor,
+      },
+      ".cm-cursor, .cm-dropCursor": {
+        borderLeftColor: IDEA_DARK_EDITOR_COLORS.cursor,
+      },
+      "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+        backgroundColor: `${IDEA_DARK_EDITOR_COLORS.selection} !important`,
+      },
+      ".cm-activeLine": {
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.activeLine,
+      },
+      ".cm-gutters": {
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.background,
+        color: IDEA_DARK_EDITOR_COLORS.mutedForeground,
+      },
+      ".cm-activeLineGutter": {
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.activeLine,
+        color: IDEA_DARK_EDITOR_COLORS.foreground,
+      },
+      ".cm-foldPlaceholder": {
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.panel,
+        borderColor: IDEA_DARK_EDITOR_COLORS.panelBorder,
+        color: IDEA_DARK_EDITOR_COLORS.mutedForeground,
+      },
+      ".cm-tooltip": {
+        backgroundColor: IDEA_DARK_EDITOR_COLORS.panel,
+        borderColor: IDEA_DARK_EDITOR_COLORS.panelBorder,
+        color: IDEA_DARK_EDITOR_COLORS.foreground,
+      },
+      ".cm-tooltip-autocomplete ul li[aria-selected]": {
+        backgroundColor: "#2d3a4d",
+        color: IDEA_DARK_EDITOR_COLORS.foreground,
+      },
+      ".cm-searchMatch": {
+        backgroundColor: "#5a4a23",
+      },
+      ".cm-searchMatch-selected": {
+        backgroundColor: "#6b5425",
+      },
+      ".cm-matchingBracket, .cm-nonmatchingBracket": {
+        backgroundColor: "#3b3f45",
+        outline: "1px solid #5f6368",
+      },
+      ".cm-dbxi-sql-comment, .cm-dbxi-sql-comment *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.comment} !important`,
+      },
+      ".cm-dbxi-sql-function, .cm-dbxi-sql-function *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.function} !important`,
+        fontStyle: "italic",
+      },
+      ".cm-dbxi-sql-identifier, .cm-dbxi-sql-identifier *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.name} !important`,
+      },
+      ".cm-dbxi-sql-keyword, .cm-dbxi-sql-keyword *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.keyword} !important`,
+      },
+      ".cm-dbxi-sql-number, .cm-dbxi-sql-number *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.operator} !important`,
+      },
+      ".cm-dbxi-sql-operator, .cm-dbxi-sql-operator *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.foreground} !important`,
+      },
+      ".cm-dbxi-sql-source, .cm-dbxi-sql-source *, .cm-dbxi-sql-variable, .cm-dbxi-sql-variable *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.foreground} !important`,
+      },
+      ".cm-dbxi-sql-string, .cm-dbxi-sql-string *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.string} !important`,
+      },
+      ".cm-dbxi-sql-type, .cm-dbxi-sql-type *": {
+        color: `${IDEA_DARK_EDITOR_COLORS.type} !important`,
+      },
+    },
+    { dark: true },
+  );
+
+  const highlightSpecs = oneDarkHighlightStyle.specs.map((spec) => {
+    if (!spec.color) return spec;
+    return {
+      ...spec,
+      color: ONE_DARK_TO_IDEA_DARK_COLORS[spec.color] ?? spec.color,
+    };
+  });
+
+  const highlight = syntaxHighlighting(HighlightStyle.define(highlightSpecs, { themeType: "dark" }));
+
+  return [theme, highlight];
+}
+
+export async function loadIdeaDarkSqlHighlightOverlay(): Promise<Extension> {
+  const [{ RangeSetBuilder }, { Decoration, ViewPlugin }] = await Promise.all([
+    import("@codemirror/state"),
+    import("@codemirror/view"),
+  ]);
+
+  function buildDecorations(view: import("@codemirror/view").EditorView) {
+    const builder = new RangeSetBuilder<import("@codemirror/view").Decoration>();
+    for (const token of classifyIdeaDarkSqlTokens(view.state.doc.toString())) {
+      builder.add(token.from, token.to, Decoration.mark({ class: IDEA_DARK_SQL_TOKEN_CLASS[token.kind] }));
+    }
+    return builder.finish();
+  }
+
+  return ViewPlugin.fromClass(
+    class {
+      decorations: import("@codemirror/view").DecorationSet;
+      constructor(view: import("@codemirror/view").EditorView) {
+        this.decorations = buildDecorations(view);
+      }
+      update(update: import("@codemirror/view").ViewUpdate) {
+        if (update.docChanged) this.decorations = buildDecorations(update.view);
+      }
+    },
+    { decorations: (plugin) => plugin.decorations },
+  );
+}
+
+export function shouldUseIdeaDarkSqlHighlight(theme: EditorTheme, appAppearance: AppThemeAppearance): boolean {
+  return resolveEditorTheme(theme, appAppearance) === "idea-dark";
+}
+
+export async function loadSqlEditorTheme(
+  theme: EditorTheme,
+  appAppearance: AppThemeAppearance = "dark",
+): Promise<Extension> {
+  const editorTheme = await loadEditorTheme(theme, appAppearance);
+  if (!shouldUseIdeaDarkSqlHighlight(theme, appAppearance)) return editorTheme;
+  return [editorTheme, await loadIdeaDarkSqlHighlightOverlay()];
+}
+
 /** Load a CodeMirror theme extension by theme name. */
 export function resolveEditorTheme(theme: EditorTheme, appAppearance: AppThemeAppearance): Exclude<EditorTheme, "app"> {
-  if (theme === "app") return appAppearance === "dark" ? "one-dark" : "vscode-light";
+  if (theme === "app") return appAppearance === "dark" ? "idea-dark" : "vscode-light";
   return theme;
 }
 
@@ -72,6 +646,8 @@ export async function loadEditorTheme(
 ): Promise<Extension> {
   const resolvedTheme = resolveEditorTheme(theme, appAppearance);
   switch (resolvedTheme) {
+    case "idea-dark":
+      return loadIdeaDarkEditorTheme();
     case "one-dark":
       return (await import("@codemirror/theme-one-dark")).oneDark;
     case "vscode-dark":
@@ -91,7 +667,7 @@ export async function loadEditorTheme(
     case "xcode":
       return (await import("@uiw/codemirror-theme-xcode")).xcodeLight;
     default:
-      return (await import("@codemirror/theme-one-dark")).oneDark;
+      return loadIdeaDarkEditorTheme();
   }
 }
 
@@ -132,7 +708,7 @@ export function buildEditorFontThemeRules(
       userSelect: "none",
     },
     ".cm-gutters:after": {
-      background: "rgba(148, 163, 184, 0.38)",
+      background: "var(--dbx-editor-gutter-divider, rgba(148, 163, 184, 0.38))",
       bottom: "0",
       content: "''",
       pointerEvents: "none",

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -159,6 +159,7 @@ function inferAiProviderFromConfig(config: Partial<AiConfig> | null | undefined)
 
 export type EditorTheme =
   | "app"
+  | "idea-dark"
   | "one-dark"
   | "vscode-dark"
   | "vscode-light"
@@ -202,6 +203,7 @@ export interface EditorSettings {
 
 export const EDITOR_THEMES: { value: EditorTheme; label: string; dark: boolean }[] = [
   { value: "app", label: "Follow app theme", dark: false },
+  { value: "idea-dark", label: "IDEA Dark", dark: true },
   { value: "one-dark", label: "One Dark", dark: true },
   { value: "vscode-dark", label: "VS Dark+", dark: true },
   { value: "vscode-light", label: "VS Light+", dark: false },

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -5,8 +5,8 @@
   font-weight: 100 900;
   src: url("/fonts/geist-latin-ext-wght-normal.woff2") format("woff2-variations");
   unicode-range:
-    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF,
-    U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F,
+    U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -16,8 +16,8 @@
   font-weight: 100 900;
   src: url("/fonts/geist-latin-wght-normal.woff2") format("woff2-variations");
   unicode-range:
-    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F,
-    U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC,
+    U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @import "tailwindcss";
@@ -106,37 +106,38 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* IDEA Darcula-inspired defaults: warm gray panels with softened text contrast. */
+  --background: #2b2d30;
+  --foreground: #c9d1d9;
+  --card: #313335;
+  --card-foreground: #c9d1d9;
+  --popover: #313335;
+  --popover-foreground: #c9d1d9;
+  --primary: #6aa9ff;
+  --primary-foreground: #1f2329;
+  --secondary: #3a3d40;
+  --secondary-foreground: #c9d1d9;
+  --muted: #3a3d40;
+  --muted-foreground: #9aa0a6;
+  --accent: #3d4652;
+  --accent-foreground: #d7dde5;
+  --destructive: #ff6b68;
+  --border: #45484a;
+  --input: #3c3f41;
+  --ring: #5f8fd5;
+  --chart-1: #6aa9ff;
+  --chart-2: #73d0ff;
+  --chart-3: #c191ff;
+  --chart-4: #8ccf7e;
+  --chart-5: #ffb86c;
+  --sidebar: #252629;
+  --sidebar-foreground: #c9d1d9;
+  --sidebar-primary: #6aa9ff;
+  --sidebar-primary-foreground: #1f2329;
+  --sidebar-accent: #34373a;
+  --sidebar-accent-foreground: #d7dde5;
+  --sidebar-border: #3c3f41;
+  --sidebar-ring: #5f8fd5;
 }
 
 html.disable-transitions,
@@ -207,7 +208,7 @@ body.dbx-table-reference-dragging * {
   background: oklch(0.965 0 0);
 }
 .dark .app-panel-gutter {
-  background: oklch(0.18 0 0);
+  background: #252629;
 }
 .app-layout-classic .panel-resize-handle {
   width: 3px;
@@ -254,6 +255,6 @@ body.dbx-table-reference-dragging * {
   --tw-ring-shadow: none !important;
 }
 .dark .cn-menu-translucent {
-  background-color: oklch(0.205 0 0 / 0.82) !important;
-  border-color: oklch(1 0 0 / 0.1) !important;
+  background-color: color-mix(in srgb, var(--popover) 86%, transparent) !important;
+  border-color: color-mix(in srgb, var(--border) 82%, transparent) !important;
 }

--- a/packages/app-tests/appThemePalette.test.ts
+++ b/packages/app-tests/appThemePalette.test.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const globalsCss = readFileSync(new URL("../../apps/desktop/src/styles/globals.css", import.meta.url), "utf8");
+
+function readDarkPalette() {
+  const match = globalsCss.match(/\.dark\s*\{(?<body>[\s\S]*?)\n\}/);
+  assert.ok(match?.groups?.body, "expected globals.css to define a .dark palette");
+
+  return Object.fromEntries(
+    [...match.groups.body.matchAll(/--([\w-]+):\s*([^;]+);/g)].map(([, name, value]) => [name, value.trim()]),
+  );
+}
+
+test("dark app palette uses IDEA-style low-glare surfaces", () => {
+  const palette = readDarkPalette();
+
+  assert.equal(palette.background, "#2b2d30");
+  assert.equal(palette.foreground, "#c9d1d9");
+  assert.equal(palette.card, "#313335");
+  assert.equal(palette.popover, "#313335");
+  assert.equal(palette.border, "#45484a");
+  assert.equal(palette.sidebar, "#252629");
+  assert.equal(palette["muted-foreground"], "#9aa0a6");
+});

--- a/packages/app-tests/editorThemeResolution.test.ts
+++ b/packages/app-tests/editorThemeResolution.test.ts
@@ -1,13 +1,59 @@
 import { strict as assert } from "node:assert";
 import test from "node:test";
-import { resolveEditorTheme } from "../../apps/desktop/src/lib/editorThemes.ts";
+import {
+  classifyIdeaDarkSqlTokens,
+  loadEditorTheme,
+  loadSqlEditorTheme,
+  resolveEditorTheme,
+} from "../../apps/desktop/src/lib/editorThemes.ts";
 
 test("editor theme follows the resolved app appearance when configured to follow app theme", () => {
   assert.equal(resolveEditorTheme("app", "light"), "vscode-light");
-  assert.equal(resolveEditorTheme("app", "dark"), "one-dark");
+  assert.equal(resolveEditorTheme("app", "dark"), "idea-dark");
 });
 
 test("editor theme keeps explicit CodeMirror theme selections", () => {
+  assert.equal(resolveEditorTheme("idea-dark", "light"), "idea-dark");
   assert.equal(resolveEditorTheme("nord", "light"), "nord");
   assert.equal(resolveEditorTheme("xcode", "dark"), "xcode");
+});
+
+test("loads the IDEA dark editor theme used by the app dark appearance", async () => {
+  const theme = await loadEditorTheme("app", "dark");
+  assert.ok(theme);
+});
+
+test("loads the SQL-specific IDEA dark editor theme overlay", async () => {
+  const theme = await loadSqlEditorTheme("app", "dark");
+  assert.ok(theme);
+});
+
+test("classifies IDEA dark SQL tokens with function and source context", () => {
+  const text = "SELECT COALESCE((SELECT id FROM la_system_menu WHERE paths = 'finance' AND type = 'menu'), 0)";
+  const tokens = classifyIdeaDarkSqlTokens(text);
+  const matchingToken = (value: string, kind: string) =>
+    tokens.find((token) => token.kind === kind && text.slice(token.from, token.to) === value);
+
+  assert.ok(matchingToken("SELECT", "keyword"));
+  assert.ok(matchingToken("COALESCE", "function"));
+  assert.ok(matchingToken("id", "identifier"));
+  assert.ok(matchingToken("la_system_menu", "source"));
+  assert.ok(matchingToken("paths", "identifier"));
+  assert.ok(matchingToken("'finance'", "string"));
+  assert.ok(matchingToken("0", "number"));
+});
+
+test("classifies IDEA dark SQL type tokens separately from function calls", () => {
+  const text = "CREATE TABLE user_account (id BIGINT, name VARCHAR(255), created_at TIMESTAMP DEFAULT NOW())";
+  const tokens = classifyIdeaDarkSqlTokens(text);
+  const matchingToken = (value: string, kind: string) =>
+    tokens.find((token) => token.kind === kind && text.slice(token.from, token.to) === value);
+
+  assert.ok(matchingToken("CREATE", "keyword"));
+  assert.ok(matchingToken("TABLE", "keyword"));
+  assert.ok(matchingToken("user_account", "source"));
+  assert.ok(matchingToken("BIGINT", "type"));
+  assert.ok(matchingToken("VARCHAR", "type"));
+  assert.ok(matchingToken("TIMESTAMP", "type"));
+  assert.ok(matchingToken("NOW", "function"));
 });

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -27,6 +27,7 @@ test("normalizes editor theme settings", () => {
   assert.equal(DEFAULT_EDITOR_SETTINGS.theme, "app");
   assert.equal(normalizeEditorSettings({}).theme, "app");
   assert.equal(normalizeEditorSettings({ theme: "app" }).theme, "app");
+  assert.equal(normalizeEditorSettings({ theme: "idea-dark" }).theme, "idea-dark");
   assert.equal(normalizeEditorSettings({ theme: "vscode-light" }).theme, "vscode-light");
   assert.equal(normalizeEditorSettings({ theme: "invalid" as any }).theme, DEFAULT_EDITOR_SETTINGS.theme);
 });


### PR DESCRIPTION
## Summary
- Adjust the desktop dark palette to a lower-glare IDEA/Darcula-style surface and foreground set.
- Add an explicit IDEA Dark editor theme and make app-following dark mode resolve to it.
- Add SQL-specific IDEA-style semantic highlighting for keywords, functions, identifiers, sources, strings, numbers, types, variables, and operators.

## Screenshot
![IDEA Dark SQL editor](https://raw.githubusercontent.com/serenez/dbx/codex-issue-545-assets/dbx-issue-545-idea-editor-sql-overlay-final.png)

## Validation
- pnpm exec tsx --tsconfig apps/desktop/tsconfig.json --test packages/app-tests/appTheme.test.ts packages/app-tests/appThemePalette.test.ts packages/app-tests/editorThemeResolution.test.ts packages/app-tests/settingsStore.test.ts
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm exec vite build --config apps/desktop/vite.config.ts --mode web
- git diff --check

Closes #545
