### PR TITLE
change brew cask installation to brew casks standard tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Download the latest release from the [Releases](https://github.com/t8y2/dbx/rele
 **Homebrew (macOS):**
 
 ```bash
-brew install --cask t8y2/tap/dbx
+brew install --cask dbx
 ```
 
 **Scoop (Windows):**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,7 +167,7 @@ dbx query local "select 1" --json
 **Homebrew (macOS)：**
 
 ```bash
-brew install --cask t8y2/tap/dbx
+brew install --cask dbx
 ```
 
 **Scoop (Windows)：**


### PR DESCRIPTION
Since the cask has been accepted and merged into the Homebrew Casks repo, your tap isn't necessary anymore. I updated the brew installation method in both README files to reflect these changes. The cask now also supports the auto-update feature you added in DBX, as described in this [chapter](https://github.com/t8y2/dbx#polished-ui); see this [PR](https://github.com/Homebrew/homebrew-cask/pull/267015)