### PR TITLE
修复 MongoDB 修改/删除文档时 `_id` 非标准 ObjectId 格式时 `Invalid ObjectId` 报错的问题

### DIFF
--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -149,14 +149,16 @@ pub async fn update_document(
     id: &str,
     doc_json: &str,
 ) -> Result<u64, String> {
-    let oid = mongodb::bson::oid::ObjectId::parse_str(id)
-        .map(Bson::ObjectId)
-        .unwrap_or_else(|_| Bson::String(id.to_string()));
     let mut new_doc: Document = serde_json::from_str(doc_json).map_err(|e| format!("Invalid JSON: {e}"))?;
     new_doc.remove("_id");
     let col = client.database(database).collection::<Document>(collection);
-    let result = col.replace_one(doc! { "_id": oid }, new_doc).await.map_err(|e| e.to_string())?;
-    Ok(result.modified_count)
+    for filter in document_id_filters(id) {
+        let result = col.replace_one(filter, new_doc.clone()).await.map_err(|e| e.to_string())?;
+        if result.matched_count > 0 {
+            return Ok(result.modified_count);
+        }
+    }
+    Ok(0)
 }
 
 pub async fn update_documents(
@@ -183,12 +185,22 @@ pub async fn update_documents(
 }
 
 pub async fn delete_document(client: &Client, database: &str, collection: &str, id: &str) -> Result<u64, String> {
-    let oid = mongodb::bson::oid::ObjectId::parse_str(id)
-        .map(Bson::ObjectId)
-        .unwrap_or_else(|_| Bson::String(id.to_string()));
     let col = client.database(database).collection::<Document>(collection);
-    let result = col.delete_one(doc! { "_id": oid }).await.map_err(|e| e.to_string())?;
-    Ok(result.deleted_count)
+    for filter in document_id_filters(id) {
+        let result = col.delete_one(filter).await.map_err(|e| e.to_string())?;
+        if result.deleted_count > 0 {
+            return Ok(result.deleted_count);
+        }
+    }
+    Ok(0)
+}
+
+fn document_id_filters(id: &str) -> Vec<Document> {
+    let string_filter = doc! { "_id": Bson::String(id.to_string()) };
+    match ObjectId::parse_str(id) {
+        Ok(oid) => vec![doc! { "_id": Bson::ObjectId(oid) }, string_filter],
+        Err(_) => vec![string_filter],
+    }
 }
 
 pub async fn delete_documents(
@@ -268,5 +280,29 @@ fn json_value_to_bson(value: &serde_json::Value) -> Bson {
             let doc: Document = obj.iter().map(|(k, v)| (k.clone(), json_value_to_bson(v))).collect();
             Bson::Document(doc)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn document_id_filters_try_object_id_then_string_for_hex_ids() {
+        let id = "507f1f77bcf86cd799439011";
+        let filters = document_id_filters(id);
+
+        assert_eq!(filters.len(), 2);
+        assert!(matches!(filters[0].get("_id"), Some(Bson::ObjectId(_))));
+        assert!(matches!(filters[1].get("_id"), Some(Bson::String(value)) if value == id));
+    }
+
+    #[test]
+    fn document_id_filters_use_string_only_for_non_hex_ids() {
+        let id = "customer-42";
+        let filters = document_id_filters(id);
+
+        assert_eq!(filters.len(), 1);
+        assert!(matches!(filters[0].get("_id"), Some(Bson::String(value)) if value == id));
     }
 }

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -149,7 +149,9 @@ pub async fn update_document(
     id: &str,
     doc_json: &str,
 ) -> Result<u64, String> {
-    let oid = mongodb::bson::oid::ObjectId::parse_str(id).map_err(|e| format!("Invalid ObjectId: {e}"))?;
+    let oid = mongodb::bson::oid::ObjectId::parse_str(id)
+        .map(Bson::ObjectId)
+        .unwrap_or_else(|_| Bson::String(id.to_string()));
     let mut new_doc: Document = serde_json::from_str(doc_json).map_err(|e| format!("Invalid JSON: {e}"))?;
     new_doc.remove("_id");
     let col = client.database(database).collection::<Document>(collection);
@@ -181,7 +183,9 @@ pub async fn update_documents(
 }
 
 pub async fn delete_document(client: &Client, database: &str, collection: &str, id: &str) -> Result<u64, String> {
-    let oid = mongodb::bson::oid::ObjectId::parse_str(id).map_err(|e| format!("Invalid ObjectId: {e}"))?;
+    let oid = mongodb::bson::oid::ObjectId::parse_str(id)
+        .map(Bson::ObjectId)
+        .unwrap_or_else(|_| Bson::String(id.to_string()));
     let col = client.database(database).collection::<Document>(collection);
     let result = col.delete_one(doc! { "_id": oid }).await.map_err(|e| e.to_string())?;
     Ok(result.deleted_count)


### PR DESCRIPTION
## Background

`update_document` 和 `delete_document` 对 `_id` 强制使用 `ObjectId::parse_str()` 解析，当集合的 `_id` 字段是字符串等非 ObjectId 类型时会直接报错。

## Changes

`crates/dbx-core/src/db/mongo_driver.rs` 中两个函数：

- `update_document` — 替换为：先尝试解析为 ObjectId，失败则按 `Bson::String` 查询
- `delete_document` — 同上

## Compatibility

| `_id` 类型 | 修复前 | 修复后 |
|---|---|---|
| ObjectId (hex string) | ✅ | ✅ |
| String | ❌ Invalid ObjectId | ✅ |
| Number | ❌ Invalid ObjectId | ⚠️ 目前无法正确处理 |

> **已知限制**：`_id` 为 Number 类型的场景暂时无法处理。因为调用链统一传入 `_id: &str`，客户端侧也未区分类型，无法确定是否应作为数值查询。后续需要客户端配合传类型信息或扩展接口来解决。