### PR TITLE
fix(ui): 关闭连接的时候，关闭标签页

### DIFF
--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -45,6 +45,7 @@ import {
 import { decodeSchemaTreeCache, encodeSchemaTreeCache } from "@/lib/schemaTreeCache";
 import { prunePinnedTreeNodeIdsForConnection } from "@/lib/pinnedTreeNodeIds";
 import { useSavedSqlStore } from "@/stores/savedSqlStore";
+import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 
 const PINNED_TREE_NODES_STORAGE_KEY = "dbx-pinned-tree-nodes";
@@ -659,6 +660,8 @@ export const useConnectionStore = defineStore("connection", () => {
 
   async function disconnect(connectionId: string) {
     const shouldRemoveOneTimeConnection = getConfig(connectionId)?.one_time === true;
+    // Close tabs first — always clean up frontend state even if the backend call fails
+    useQueryStore().closeTabsForConnection(connectionId);
     await api.disconnectDb(connectionId);
     connectedIds.value.delete(connectionId);
     const node = findNode(treeNodes.value, connectionId);
@@ -677,6 +680,8 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   async function closeDatabaseConnection(connectionId: string, database: string) {
+    // Close tabs first — always clean up frontend state even if the backend call fails
+    useQueryStore().closeTabsForConnection(connectionId, database);
     await api.closeDatabaseConnection(connectionId, database);
     const node = findDatabaseTreeNode(treeNodes.value, connectionId, database);
     if (node) {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -299,6 +299,31 @@ export const useQueryStore = defineStore("query", () => {
     activeTabId.value = next.activeTabId;
   }
 
+  function closeTabsForConnection(connectionId: string, database?: string) {
+    const idsToClose = new Set(
+      tabs.value
+        .filter((t) => t.connectionId === connectionId && (database == null || t.database === database))
+        .map((t) => t.id),
+    );
+    if (idsToClose.size === 0) return;
+
+    tabs.value
+      .filter((t) => idsToClose.has(t.id))
+      .forEach((tab) => {
+        if (tab.isExecuting) void cancelTabExecution(tab.id);
+        if (tab.isExplaining) void cancelTabExplain(tab.id);
+        void closeResultSession(tab);
+        void closeClientConnectionSession(tab);
+        clearResultPayload(tab);
+      });
+
+    tabs.value = tabs.value.filter((t) => !idsToClose.has(t.id));
+
+    if (activeTabId.value && idsToClose.has(activeTabId.value)) {
+      activeTabId.value = tabs.value[tabs.value.length - 1]?.id ?? null;
+    }
+  }
+
   function updateSql(id: string, sql: string) {
     const tab = tabs.value.find((t) => t.id === id);
     if (tab) {
@@ -1064,6 +1089,7 @@ export const useQueryStore = defineStore("query", () => {
     closeTab,
     closeOtherTabs,
     closeAllTabs,
+    closeTabsForConnection,
     updateSql,
     openObjectBrowser,
     openTableStructure,


### PR DESCRIPTION
## Summary

When disconnecting or closing a database connection, the associated query tabs were not being cleaned up. 

## Changes

- **`queryStore.ts`** — Added `closeTabsForConnection(connectionId, database?)` method that:
  - Finds all query tabs belonging to the given connection (optionally filtered by database)
  - Cancels any in-flight execution or explain operations
  - Closes result sessions and client connection sessions
  - Removes the tabs and updates `activeTabId` if needed

- **`connectionStore.ts`** — Calls `closeTabsForConnection` in two places:
  - `disconnect()` — before the backend `api.disconnectDb` call
  - `closeDatabaseConnection()` — before the backend `api.closeDatabaseConnection` call

## Key Design Decision

Tabs are closed **before** the backend API call, so the UI state is cleaned up even if the backend request fails (e.g. network error, server timeout).

## Testing

- [x] Disconnect a connection → verify all query tabs for that connection are closed
- [x] Close a specific database → verify only tabs for that database are closed
- [x] Verify tabs for other connections are unaffected
- [x] Verify in-flight queries are properly cancelled before tab removal