### PR TITLE
feat(ui): 支持预览postgres的Geometry数据为图形

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -34,6 +34,7 @@ import {
   SearchX,
   Code2,
   Copy,
+  Eye,
   Loader2,
   X,
   Undo2,
@@ -56,7 +57,6 @@ import {
   PanelBottom,
   PanelRight,
   TableProperties,
-  Map as MapIcon,
 } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomContextMenu.vue";
@@ -129,7 +129,7 @@ import {
   visibleCellDetailTabs,
   type CellDetailTab,
 } from "@/lib/cellDetailPresentation";
-import { renderWktOnCanvas } from "@/lib/geometryPreview";
+import { renderWktOnCanvas, isHexGeometry } from "@/lib/geometryPreview";
 import {
   buildDataGridCellDetail,
   buildDataGridColumnDetail,
@@ -7410,6 +7410,31 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
+                        <!-- Skip hex fallback from backend (unsupported geometry types like TIN/Triangle) -->
+                        <Popover
+                          v-if="
+                            isGeometryColumnType(activeCellDetail.type) &&
+                            activeCellDetail.value !== null &&
+                            !isEditingDetail &&
+                            !isHexGeometry(activeCellDetail.value as string)
+                          "
+                          v-model:open="sideGeometryPreviewOpen"
+                        >
+                          <PopoverTrigger as-child>
+                            <Button variant="ghost" size="icon" class="h-6 w-6" :title="t('grid.geometryPreview')">
+                              <Eye class="h-3 w-3" />
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent class="w-auto p-1.5" align="end">
+                            <canvas
+                              v-show="sideGeometryPreviewOpen"
+                              ref="sideGeometryCanvas"
+                              width="400"
+                              height="280"
+                              class="block rounded"
+                            />
+                          </PopoverContent>
+                        </Popover>
                       </div>
                     </div>
                     <div v-if="activeCellDetail.imagePreviewUrl && !isEditingDetail" class="space-y-1.5">
@@ -7429,33 +7454,6 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           class="max-h-72 w-full object-contain"
                         />
                       </a>
-                    </div>
-                    <div
-                      v-if="
-                        isGeometryColumnType(activeCellDetail.type) &&
-                        activeCellDetail.value !== null &&
-                        !isEditingDetail
-                      "
-                      class="space-y-1.5"
-                    >
-                      <div class="text-muted-foreground">{{ t("grid.geometryPreview") }}</div>
-                      <Popover v-model:open="sideGeometryPreviewOpen">
-                        <PopoverTrigger as-child>
-                          <Button variant="outline" size="sm" class="h-7 gap-1.5 text-xs">
-                            <MapIcon class="h-3.5 w-3.5" />
-                            {{ t("grid.geometryPreview") }}
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent class="w-auto p-1.5" align="start">
-                          <canvas
-                            v-show="sideGeometryPreviewOpen"
-                            ref="sideGeometryCanvas"
-                            width="400"
-                            height="280"
-                            class="block rounded"
-                          />
-                        </PopoverContent>
-                      </Popover>
                     </div>
                     <template v-if="isEditingDetail">
                       <TemporalCellEditor
@@ -7828,6 +7826,30 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
+                <!-- Skip hex fallback from backend (unsupported geometry types like TIN/Triangle) -->
+                <Popover
+                  v-if="
+                    isGeometryColumnType(dialogCellDetail.type) &&
+                    dialogCellDetail.value !== null &&
+                    !isHexGeometry(dialogCellDetail.value as string)
+                  "
+                  v-model:open="dialogGeometryPreviewOpen"
+                >
+                  <PopoverTrigger as-child>
+                    <Button variant="ghost" size="icon" class="h-6 w-6" :title="t('grid.geometryPreview')">
+                      <Eye class="h-3 w-3" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent class="w-auto p-1.5" align="end">
+                    <canvas
+                      v-show="dialogGeometryPreviewOpen"
+                      ref="dialogGeometryCanvas"
+                      width="400"
+                      height="280"
+                      class="block rounded"
+                    />
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
             <a
@@ -7846,29 +7868,6 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 class="max-h-72 w-full object-contain"
               />
             </a>
-            <div
-              v-if="isGeometryColumnType(dialogCellDetail.type) && dialogCellDetail.value !== null"
-              class="flex items-center gap-2"
-            >
-              <div class="text-muted-foreground">{{ t("grid.geometryPreview") }}</div>
-              <Popover v-model:open="dialogGeometryPreviewOpen">
-                <PopoverTrigger as-child>
-                  <Button variant="outline" size="sm" class="h-7 gap-1.5 text-xs">
-                    <MapIcon class="h-3.5 w-3.5" />
-                    {{ t("grid.geometryPreview") }}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent class="w-auto p-1.5" align="start">
-                  <canvas
-                    v-show="dialogGeometryPreviewOpen"
-                    ref="dialogGeometryCanvas"
-                    width="400"
-                    height="280"
-                    class="block rounded"
-                  />
-                </PopoverContent>
-              </Popover>
-            </div>
             <pre
               class="max-h-[44vh] overflow-auto rounded border bg-muted/20 p-3 font-mono text-xs whitespace-pre-wrap break-words"
               :class="{ 'italic text-muted-foreground': dialogCellDetail.value === null }"

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -56,6 +56,7 @@ import {
   PanelBottom,
   PanelRight,
   TableProperties,
+  Map as MapIcon,
 } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomContextMenu.vue";
@@ -122,11 +123,13 @@ import {
   cellDetailEditorText,
   defaultCellDetailTab,
   formatJsonText,
+  isGeometryColumnType,
   linkedCellDetailTarget,
   valueEditorActions,
   visibleCellDetailTabs,
   type CellDetailTab,
 } from "@/lib/cellDetailPresentation";
+import { renderWktOnCanvas } from "@/lib/geometryPreview";
 import {
   buildDataGridCellDetail,
   buildDataGridColumnDetail,
@@ -404,6 +407,7 @@ function typeColorClass(t: string): string {
   if (["json", "jsonb", "xml", "array"].includes(base)) return "text-pink-500";
   if (["uuid", "uniqueidentifier"].includes(base)) return "text-amber-500";
   if (["bytea", "blob", "binary", "varbinary", "image"].includes(base)) return "text-red-400";
+  if (["geometry", "geography"].includes(base)) return "text-emerald-500";
   return "text-muted-foreground";
 }
 const contextCell = ref<{ rowId: number; rowIndex: number; col: number } | null>(null);
@@ -426,6 +430,10 @@ const isResizingDetail = ref(false);
 const imagePreviewOpen = ref(false);
 const imagePreviewSrc = ref("");
 const imagePreviewTitle = ref("");
+const sideGeometryPreviewOpen = ref(false);
+const dialogGeometryPreviewOpen = ref(false);
+const sideGeometryCanvas = ref<HTMLCanvasElement | null>(null);
+const dialogGeometryCanvas = ref<HTMLCanvasElement | null>(null);
 const transposeRowIndex = ref<number | null>(null);
 const showTranspose = ref(false);
 const preserveTransposeOnNextResult = ref(false);
@@ -2586,6 +2594,28 @@ watch(rowDetailDialogOpen, (open) => {
 
 watch(columnDetailDialogOpen, (open) => {
   if (!open) columnDetailDialogColumnIndex.value = null;
+});
+
+watch(sideGeometryPreviewOpen, async (open) => {
+  if (open) {
+    await nextTick();
+    const canvas = sideGeometryCanvas.value;
+    const detail = activeCellDetail.value;
+    if (canvas && detail && detail.value !== null) {
+      renderWktOnCanvas(canvas, String(detail.value));
+    }
+  }
+});
+
+watch(dialogGeometryPreviewOpen, async (open) => {
+  if (open) {
+    await nextTick();
+    const canvas = dialogGeometryCanvas.value;
+    const detail = dialogCellDetail.value;
+    if (canvas && detail && detail.value !== null) {
+      renderWktOnCanvas(canvas, String(detail.value));
+    }
+  }
 });
 
 const activeCellDetailTabs = computed(() => {
@@ -7400,6 +7430,33 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                         />
                       </a>
                     </div>
+                    <div
+                      v-if="
+                        isGeometryColumnType(activeCellDetail.type) &&
+                        activeCellDetail.value !== null &&
+                        !isEditingDetail
+                      "
+                      class="space-y-1.5"
+                    >
+                      <div class="text-muted-foreground">{{ t("grid.geometryPreview") }}</div>
+                      <Popover v-model:open="sideGeometryPreviewOpen">
+                        <PopoverTrigger as-child>
+                          <Button variant="outline" size="sm" class="h-7 gap-1.5 text-xs">
+                            <MapIcon class="h-3.5 w-3.5" />
+                            {{ t("grid.geometryPreview") }}
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent class="w-auto p-1.5" align="start">
+                          <canvas
+                            v-show="sideGeometryPreviewOpen"
+                            ref="sideGeometryCanvas"
+                            width="400"
+                            height="280"
+                            class="block rounded"
+                          />
+                        </PopoverContent>
+                      </Popover>
+                    </div>
                     <template v-if="isEditingDetail">
                       <TemporalCellEditor
                         v-if="detailTemporalEditorKind"
@@ -7789,6 +7846,29 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 class="max-h-72 w-full object-contain"
               />
             </a>
+            <div
+              v-if="isGeometryColumnType(dialogCellDetail.type) && dialogCellDetail.value !== null"
+              class="flex items-center gap-2"
+            >
+              <div class="text-muted-foreground">{{ t("grid.geometryPreview") }}</div>
+              <Popover v-model:open="dialogGeometryPreviewOpen">
+                <PopoverTrigger as-child>
+                  <Button variant="outline" size="sm" class="h-7 gap-1.5 text-xs">
+                    <MapIcon class="h-3.5 w-3.5" />
+                    {{ t("grid.geometryPreview") }}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent class="w-auto p-1.5" align="start">
+                  <canvas
+                    v-show="dialogGeometryPreviewOpen"
+                    ref="dialogGeometryCanvas"
+                    width="400"
+                    height="280"
+                    class="block rounded"
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
             <pre
               class="max-h-[44vh] overflow-auto rounded border bg-muted/20 p-3 font-mono text-xs whitespace-pre-wrap break-words"
               :class="{ 'italic text-muted-foreground': dialogCellDetail.value === null }"

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -574,6 +574,7 @@ export default {
     valueEditor: "Value Editor",
     imagePreview: "Image Preview",
     imageLoadFailed: "Image failed to load",
+    geometryPreview: "Geometry Preview",
     zoomIn: "Zoom In",
     zoomOut: "Zoom Out",
     fitImage: "Fit to Window",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -540,6 +540,7 @@ export default {
     valueEditor: "Editor de valor",
     imagePreview: "Vista previa de imagen",
     imageLoadFailed: "No se pudo cargar la imagen",
+    geometryPreview: "Vista previa de geometría",
     zoomIn: "Acercar",
     zoomOut: "Alejar",
     fitImage: "Ajustar a ventana",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -569,6 +569,7 @@ export default {
     valueEditor: "值编辑器",
     imagePreview: "图片预览",
     imageLoadFailed: "图片加载失败",
+    geometryPreview: "图形预览",
     zoomIn: "放大",
     zoomOut: "缩小",
     fitImage: "适应窗口",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -569,6 +569,7 @@ export default {
     valueEditor: "儲存格編輯器",
     imagePreview: "圖片預覽",
     imageLoadFailed: "圖片載入失敗",
+    geometryPreview: "圖形預覽",
     zoomIn: "放大",
     zoomOut: "縮小",
     fitImage: "適應視窗",

--- a/apps/desktop/src/lib/cellDetailPresentation.ts
+++ b/apps/desktop/src/lib/cellDetailPresentation.ts
@@ -65,6 +65,14 @@ export function isJsonColumnType(columnType: string | undefined): boolean {
   return base === "json" || base === "jsonb";
 }
 
+export function isGeometryColumnType(columnType: string | undefined): boolean {
+  const base = (columnType ?? "")
+    .trim()
+    .toLowerCase()
+    .split(/[(:\s]/)[0];
+  return base === "geometry" || base === "geography";
+}
+
 export function canFormatCellDetailJson(value: unknown, columnType?: string): boolean {
   if (value === null || value === undefined) return false;
   const text = cellDetailRawEditorText(value);

--- a/apps/desktop/src/lib/geometryPreview.ts
+++ b/apps/desktop/src/lib/geometryPreview.ts
@@ -1,0 +1,271 @@
+type Coord = [number, number];
+
+interface GeometryGroup {
+  coords: Coord[];
+  children: GeometryGroup[];
+}
+
+function tokenize(wkt: string): (string | number)[] {
+  const tokens: (string | number)[] = [];
+  let i = 0;
+  while (i < wkt.length) {
+    const ch = wkt[i];
+    if (ch === "(" || ch === ")" || ch === ",") {
+      tokens.push(ch);
+      i++;
+    } else if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+    } else if ((ch >= "0" && ch <= "9") || ch === "-" || ch === "+" || ch === ".") {
+      const m = wkt.slice(i).match(/^[+-]?\d*\.?\d+(?:[eE][+-]?\d+)?/);
+      if (m) {
+        tokens.push(parseFloat(m[0]));
+        i += m[0].length;
+      } else {
+        i++;
+      }
+    } else {
+      // skip alphabetic keywords (type names, EMPTY, Z, M, etc.)
+      const word = wkt.slice(i).match(/^[A-Za-z]+/);
+      if (word) {
+        i += word[0].length;
+      } else {
+        i++;
+      }
+    }
+  }
+  return tokens;
+}
+
+function parseCoordSequence(tokens: (string | number)[], start: number): { coords: Coord[]; end: number } {
+  const coords: Coord[] = [];
+  let i = start;
+  while (i < tokens.length) {
+    if (typeof tokens[i] === "number") {
+      const x = tokens[i] as number;
+      i++;
+      const y = i < tokens.length && typeof tokens[i] === "number" ? (tokens[i] as number) : 0;
+      i++;
+      coords.push([x, y]);
+      // skip Z/M values
+      while (i < tokens.length && typeof tokens[i] === "number") i++;
+    } else if (tokens[i] === ",") {
+      i++;
+    } else {
+      break;
+    }
+  }
+  return { coords, end: i };
+}
+
+function parseGroups(tokens: (string | number)[], start: number): { groups: GeometryGroup[]; end: number } {
+  const groups: GeometryGroup[] = [];
+  let i = start;
+  while (i < tokens.length) {
+    if (tokens[i] === "(") {
+      const inner = parseGroups(tokens, i + 1);
+      if (inner.groups.length === 0) {
+        // leaf group: parse as coordinate sequence
+        const seq = parseCoordSequence(tokens, i + 1);
+        groups.push({ coords: seq.coords, children: [] });
+        i = seq.end;
+      } else {
+        groups.push({ coords: [], children: inner.groups });
+        i = inner.end;
+      }
+      if (i < tokens.length && tokens[i] === ")") i++;
+    } else if (tokens[i] === ")" || tokens[i] === ",") {
+      break;
+    } else if (typeof tokens[i] === "number") {
+      const seq = parseCoordSequence(tokens, i);
+      groups.push({ coords: seq.coords, children: [] });
+      i = seq.end;
+    } else {
+      i++;
+    }
+  }
+  return { groups, end: i };
+}
+
+function flattenCoords(groups: GeometryGroup[]): Coord[] {
+  const result: Coord[] = [];
+  for (const g of groups) {
+    for (const c of g.coords) result.push(c);
+    const childCoords = flattenCoords(g.children);
+    for (const c of childCoords) result.push(c);
+  }
+  return result;
+}
+
+// Walk a group recursively and return the first non-empty coordinate sequence found
+function extractCoords(g: GeometryGroup): Coord[] {
+  if (g.coords.length > 0) return g.coords;
+  for (const child of g.children) {
+    const found = extractCoords(child);
+    if (found.length > 0) return found;
+  }
+  return [];
+}
+
+// Draw polygon exterior + holes from a group structure
+function drawPolygonRings(
+  ctx: CanvasRenderingContext2D,
+  group: GeometryGroup,
+  mapX: (v: number) => number,
+  mapY: (v: number) => number,
+) {
+  // group.children contains ring groups
+  const rings = group.children.length > 0 ? group.children : [group];
+  let ringIndex = 0;
+  for (const ringGroup of rings) {
+    const coords = extractCoords(ringGroup);
+    if (coords.length < 2) continue;
+    ctx.beginPath();
+    ctx.moveTo(mapX(coords[0][0]), mapY(coords[0][1]));
+    for (let j = 1; j < coords.length; j++) {
+      ctx.lineTo(mapX(coords[j][0]), mapY(coords[j][1]));
+    }
+    ctx.closePath();
+    if (ringIndex === 0) ctx.fill();
+    ctx.stroke();
+    ringIndex++;
+  }
+}
+
+function drawGroups(
+  ctx: CanvasRenderingContext2D,
+  groups: GeometryGroup[],
+  type: string,
+  mapX: (v: number) => number,
+  mapY: (v: number) => number,
+) {
+  if (type === "POINT" || type === "MULTIPOINT") {
+    const allCoords = flattenCoords(groups);
+    for (const [x, y] of allCoords) {
+      ctx.beginPath();
+      ctx.arc(mapX(x), mapY(y), 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    return;
+  }
+
+  if (type === "LINESTRING" || type === "MULTILINESTRING") {
+    for (const g of groups) {
+      const coords = extractCoords(g);
+      if (coords.length >= 2) {
+        ctx.beginPath();
+        ctx.moveTo(mapX(coords[0][0]), mapY(coords[0][1]));
+        for (let i = 1; i < coords.length; i++) {
+          ctx.lineTo(mapX(coords[i][0]), mapY(coords[i][1]));
+        }
+        ctx.stroke();
+      }
+    }
+    return;
+  }
+
+  if (type === "POLYGON") {
+    for (const g of groups) {
+      drawPolygonRings(ctx, g, mapX, mapY);
+    }
+    return;
+  }
+
+  if (type === "MULTIPOLYGON") {
+    for (const g of groups) {
+      if (g.children.length > 0) {
+        for (const polyChild of g.children) {
+          drawPolygonRings(ctx, polyChild, mapX, mapY);
+        }
+      }
+    }
+    return;
+  }
+
+  // GEOMETRYCOLLECTION or unknown: draw all coordinate sequences
+  for (const g of groups) {
+    const coords = extractCoords(g);
+    if (coords.length >= 2) {
+      ctx.beginPath();
+      ctx.moveTo(mapX(coords[0][0]), mapY(coords[0][1]));
+      for (let i = 1; i < coords.length; i++) {
+        ctx.lineTo(mapX(coords[i][0]), mapY(coords[i][1]));
+      }
+      ctx.stroke();
+    } else if (coords.length === 1) {
+      const [x, y] = coords[0];
+      ctx.beginPath();
+      ctx.arc(mapX(x), mapY(y), 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // recurse for type-less children
+    if (coords.length === 0) {
+      drawGroups(ctx, g.children, "", mapX, mapY);
+    }
+  }
+}
+
+function detectWktType(wkt: string): string {
+  const m = wkt.trim().match(/^([A-Za-z]+)/);
+  return m ? m[1].toUpperCase() : "GEOMETRYCOLLECTION";
+}
+
+export function renderWktOnCanvas(canvas: HTMLCanvasElement, wkt: string): void {
+  const type = detectWktType(wkt);
+  const tokens = tokenize(wkt);
+  const { groups } = parseGroups(tokens, 0);
+  const allCoords = flattenCoords(groups);
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const W = canvas.width;
+  const H = canvas.height;
+  const pad = 20;
+
+  ctx.clearRect(0, 0, W, H);
+
+  if (allCoords.length === 0) {
+    ctx.fillStyle = "#888";
+    ctx.font = "12px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Empty geometry", W / 2, H / 2);
+    return;
+  }
+
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity;
+  for (const [x, y] of allCoords) {
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+
+  if (minX === maxX && minY === maxY) {
+    minX -= 1;
+    maxX += 1;
+    minY -= 1;
+    maxY += 1;
+  }
+
+  const rangeX = maxX - minX || 1;
+  const rangeY = maxY - minY || 1;
+  const scale = Math.min((W - pad * 2) / rangeX, (H - pad * 2) / rangeY);
+
+  const midX = (minX + maxX) / 2;
+  const midY = (minY + maxY) / 2;
+
+  const mapX = (x: number) => (x - midX) * scale + W / 2;
+  const mapY = (y: number) => -(y - midY) * scale + H / 2;
+
+  ctx.strokeStyle = "#3b82f6";
+  ctx.fillStyle = "rgba(59, 130, 246, 0.15)";
+  ctx.lineWidth = 1.5;
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+
+  drawGroups(ctx, groups, type, mapX, mapY);
+}

--- a/apps/desktop/src/lib/geometryPreview.ts
+++ b/apps/desktop/src/lib/geometryPreview.ts
@@ -210,7 +210,24 @@ function detectWktType(wkt: string): string {
   return m ? m[1].toUpperCase() : "GEOMETRYCOLLECTION";
 }
 
+// EWKB parsing on the backend can fall back to hex for unsupported geometry types
+// (e.g. TIN, Triangle, CircularString). Don't attempt to render hex as WKT.
+export function isHexGeometry(value: string): boolean {
+  return value.startsWith("0x");
+}
+
 export function renderWktOnCanvas(canvas: HTMLCanvasElement, wkt: string): void {
+  if (isHexGeometry(wkt)) {
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#888";
+    ctx.font = "12px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Preview not available for binary format", canvas.width / 2, canvas.height / 2);
+    return;
+  }
+
   const type = detectWktType(wkt);
   const tokens = tokenize(wkt);
   const { groups } = parseGroups(tokens, 0);


### PR DESCRIPTION
 ## Summary

  - 为 cell detail 面板中的 PostGIS geometry/geography 列添加基于 Canvas 的几何图形预览弹窗
  - 处理后端 hex 回退情况（不支持的几何类型如 TIN/Triangle）

  ## Details

  - **WKT 解析器 + Canvas 渲染** (`geometryPreview.ts`)：解析 WKT 字符串，在 Canvas 上渲染
  Point、LineString、Polygon、Multi* 和 GeometryCollection，坐标自动缩放适配画布
  - **Hex 回退检测**：后端 EWKB 解析失败时，cell value 会回退为 hex 字符串 (`0x...`)。`isHexGeometry()` 阻止
   WKT 解析，改为显示 "Preview not available" 提示
  - **isGeometryColumnType 工具函数**：识别 geometry/geography 列类型
  - **i18n**：添加 en/es/zh-CN/zh-TW 多语言 "Geometry Preview" 词条
