### PR TITLE
fix(sql): rank referenced-table columns above keywords in completion (#801)

### DIFF
--- a/apps/desktop/src/lib/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sqlCompletion.ts
@@ -2265,6 +2265,12 @@ function buildColumnItems(
     }
   }
 
+  // When the query already references concrete tables (or we are after a
+  // "table." qualifier / in an INSERT column list), the columns of those
+  // tables are what the user is most likely picking — boost them above plain
+  // keywords so they rank at the top instead of being interleaved.
+  const relevanceBoost = context.referencedTables.length > 0 || !!context.qualifier || !!context.insertTable ? 2000 : 0;
+
   return uniqueColumns
     .filter((column) => matchesPrefix(column.displayLabel, context.prefix))
     .map((column) => {
@@ -2275,7 +2281,7 @@ function buildColumnItems(
         detail: buildColumnDetail(column),
         info: buildColumnInfo(column),
         apply: buildColumnApply(column, context, dialect),
-        boost: computeBoost(column.displayLabel, context.prefix) + keyBoost,
+        boost: computeBoost(column.displayLabel, context.prefix) + keyBoost + relevanceBoost,
       };
     })
     .sort(compareCompletionItems);

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -838,6 +838,21 @@ test("key columns get priority boost in column suggestions", () => {
   assert.ok(idItem.boost > nameItem.boost, "id column should have higher boost than name");
 });
 
+test("referenced-table columns rank above keywords (#801)", () => {
+  const items = buildSqlCompletionItems("select  from public.users u", "select ".length, {
+    tables,
+    columnsByTable,
+  });
+  const column = items.find((item) => item.type === "column");
+  assert.ok(column, "should suggest columns when a table is referenced");
+  assert.ok(column.boost >= 2000, "referenced-table columns should be boosted above plain keywords");
+  const columnIdx = items.findIndex((item) => item.type === "column");
+  const keywordIdx = items.findIndex((item) => item.type === "keyword");
+  if (keywordIdx >= 0) {
+    assert.ok(columnIdx < keywordIdx, "columns should appear before keywords in a referenced-table context");
+  }
+});
+
 // --- Schema name completion ---
 
 test("suggests schema names alongside tables in FROM context", () => {


### PR DESCRIPTION
## 关联 issue

Closes #801 — MySQL 编辑 SQL 时字段属性提示「排序异常及缺失」。

## 问题

用户在已经引用了具体表的上下文里写 SQL(`SELECT ... FROM users`、`table.` 限定、`INSERT INTO t (...)` 列清单),触发补全后:

1. **排序乱**:该表的字段没有置顶,而是穿插在关键词列表中间;
2. **看起来缺失**:有时「直接点不出属性」,但敲一个空格再点又出来了。

## 根因(单一)

列补全项的 boost 太低,只有 `computeBoost(0~几百) + keyBoost(0/500)`,而 SQL 关键词的 boost 是 **1200–1900**。于是在「已引用表」的上下文里,这张表本应最相关的字段被排到了所有关键词之后:

- CodeMirror 补全弹窗只展示顶部一截、需要滚动 → 字段被埋在底部 → 用户看到的就是「字段穿插在中间」甚至「点了好像没有字段提示」;
- 「敲个空格再点就出」是因为空格后进入**纯列上下文**(`exclusiveColumnSuggestions`,只出列、不混关键词),字段才干净地冒出来——这反证了「列与关键词混排时被压到下面」正是病根。

所以两个症状是**同一个根因**:列的优先级不够高。

## 改动

`apps/desktop/src/lib/sqlCompletion.ts` — `buildColumnItems`:当上下文「已引用具体表 / 有 `table.` 限定 / 处于 INSERT 列清单」时,给列补全项加 `relevanceBoost = 2000`:

```ts
const relevanceBoost =
  context.referencedTables.length > 0 || !!context.qualifier || !!context.insertTable ? 2000 : 0;
// boost: computeBoost(displayLabel, prefix) + keyBoost + relevanceBoost
```

列的最低 boost 因此为 2000,高于关键词上限 1900,**保证已引用表的字段始终排在关键词之上**;同时仍保留 `computeBoost`(前缀匹配)与 `keyBoost`(主键/外键列加权)的相对排序。未引用任何表的普通上下文不加此 boost,行为不变。

## 验证

- `packages/app-tests/sqlCompletion.test.ts` 新增用例 `referenced-table columns rank above keywords (#801)`,断言:引用表后字段 boost ≥ 2000 且排在关键词之前。
- `pnpm test` 全绿(874 passed),`pnpm typecheck` / `pnpm lint` / `pnpm fmt` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)