### PR TITLE
fix(postgres): render internal "char" type as character, not ASCII code (#669)

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -488,6 +488,20 @@ fn format_pg_timestamptz(value: DateTime<Local>) -> String {
     value.to_rfc3339()
 }
 
+/// Render PostgreSQL's internal `"char"` type (OID 18) as the character it
+/// stores, matching psql's `charout`. The driver decodes this single-byte type
+/// as i8; emitting the numeric value would leak the raw ASCII code (issue #669).
+/// A zero byte maps to an empty string; any other byte is interpreted as a
+/// Latin-1 code point so the result is always valid UTF-8 and never panics.
+fn pg_char_to_json(byte: i8) -> serde_json::Value {
+    let b = byte as u8;
+    if b == 0 {
+        serde_json::Value::String(String::new())
+    } else {
+        serde_json::Value::String(char::from(b).to_string())
+    }
+}
+
 fn pg_value_to_json(row: &Row, idx: usize, type_name: &str) -> serde_json::Value {
     let upper = type_name.to_uppercase();
 
@@ -539,6 +553,14 @@ fn pg_value_to_json(row: &Row, idx: usize, type_name: &str) -> serde_json::Value
 
     if matches!(upper.as_str(), "OID" | "XID" | "CID") {
         return pg_system_u32_to_json(row, idx).unwrap_or(serde_json::Value::Null);
+    }
+
+    // PostgreSQL's internal "char" type (OID 18, e.g. pg_depend.deptype) is a
+    // single byte the driver decodes as i8. Without this branch it falls through
+    // to the i8 arm below and surfaces the raw ASCII code (110 for 'n') instead
+    // of the character. SQL CHAR(n) is a different type ("bpchar"), unaffected.
+    if upper == "CHAR" {
+        return row.try_get::<_, i8>(idx).map(pg_char_to_json).unwrap_or(serde_json::Value::Null);
     }
 
     if upper.starts_with('_') {
@@ -1738,6 +1760,25 @@ mod tests {
         assert!(PgSystemU32::accepts(&Type::CID));
         assert!(!PgSystemU32::accepts(&Type::OID));
         assert!(!PgSystemU32::accepts(&Type::INT4));
+    }
+
+    #[test]
+    fn pg_char_type_renders_byte_as_character() {
+        // The internal "char" type (OID 18, e.g. pg_depend.deptype) is decoded
+        // as i8; we must surface the character, not the ASCII code (issue #669).
+        assert_eq!(Type::CHAR.name(), "char");
+        assert!(i8::accepts(&Type::CHAR));
+        // SQL CHAR(n)/character(n) is a different type ("bpchar") and must not
+        // be routed through the "char" branch.
+        assert_eq!(Type::BPCHAR.name(), "bpchar");
+
+        assert_eq!(pg_char_to_json(b'n' as i8), serde_json::Value::String("n".into()));
+        assert_eq!(pg_char_to_json(b'a' as i8), serde_json::Value::String("a".into()));
+        assert_eq!(pg_char_to_json(b'i' as i8), serde_json::Value::String("i".into()));
+        // A zero byte renders as an empty string (matches psql's charout).
+        assert_eq!(pg_char_to_json(0), serde_json::Value::String(String::new()));
+        // High bytes stay valid UTF-8 (Latin-1) and never panic.
+        assert_eq!(pg_char_to_json(-1), serde_json::Value::String("\u{00ff}".into()));
     }
 
     #[test]


### PR DESCRIPTION
## 关联 issue

#669 的**核心 bug**:PostgreSQL 系统表(`pg_depend`、`pg_shdepend` 等)里 `"char"` 类型字段被显示成 ASCII 数字而非字符。

> issue 里附带的「表头增加数据类型展示」是独立的 enhancement(需改后端核心 `QueryResult` + 多个驱动 + 前端表头),**不在本 PR 范围**,将另行单独提交。本 PR 因此不自动关闭 #669。

## 问题

执行 `select * from pg_depend` 时,`deptype` 列(`"char"` 类型)显示为 `97/101/105/110` 这样的 ASCII 数字,而 psql 正确显示为 `a/e/i/n` 字符。

## 根因

PostgreSQL 的内部 `"char"` 类型(OID = 18,注意是带引号的单字节类型,**不同于** SQL 标准的 `CHAR(n)`=`bpchar`)由驱动解码为 `i8`。`pg_value_to_json` 里没有它的专门分支,于是落到末尾 fallback 链的 `i8` 分支 —— 直接把字节当数字返回,泄露了原始 ASCII 码。

## 改动

`crates/dbx-core/src/db/postgres.rs`:

1. 新增纯函数 `pg_char_to_json(byte: i8)`:把字节渲染成字符(对齐 psql 的 `charout`)。`0` 字节 → 空字符串;其余字节按 Latin-1 码位解释,保证输出始终是合法 UTF-8、永不 panic。
2. 在 `pg_value_to_json` 增加 `upper == "CHAR"` 分支,优先用上述函数处理。SQL 标准 `CHAR(n)`(`bpchar`)走的是别的路径,**不受影响**。

```rust
if upper == "CHAR" {
    return row.try_get::<_, i8>(idx).map(pg_char_to_json).unwrap_or(serde_json::Value::Null);
}
```

## 验证

- 新增单测 `pg_char_type_renders_byte_as_character`:断言 `Type::CHAR.name() == "char"`、`i8::accepts(&Type::CHAR)`、`Type::BPCHAR.name() == "bpchar"`(确保不误伤标准 CHAR),以及字节→字符、零字节→空串、高位字节不 panic。
- `cargo test -p dbx-core --lib`:**664 passed / 0 failed**。
- 端到端:本机 PostgreSQL 16 跑 `select deptype, ascii(deptype::text) from pg_depend group by deptype`,修复后 `deptype` 列正确显示 `a/e/i/n`(对照 ascii 列 `97/101/105/110`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)