### PR TITLE
fix(core): quote StarRocks identifiers with backticks

### DIFF
--- a/crates/dbx-core/src/sql_dialect.rs
+++ b/crates/dbx-core/src/sql_dialect.rs
@@ -212,6 +212,7 @@ pub fn quote_table_identifier(database_type: Option<DatabaseType>, name: &str) -
         Some(DatabaseType::Jdbc) => format!("`{}`", name.replace('`', "``")),
         Some(
             DatabaseType::Mysql
+            | DatabaseType::StarRocks
             | DatabaseType::Hive
             | DatabaseType::Tdengine
             | DatabaseType::Access
@@ -459,6 +460,7 @@ mod tests {
     #[test]
     fn quotes_identifiers_by_database_type() {
         assert_eq!(quote_table_identifier(Some(DatabaseType::Mysql), "user`name"), "`user``name`");
+        assert_eq!(quote_table_identifier(Some(DatabaseType::StarRocks), "user`name"), "`user``name`");
         assert_eq!(quote_table_identifier(Some(DatabaseType::SqlServer), "user]name"), "[user]]name]");
         assert_eq!(quote_table_identifier(Some(DatabaseType::Postgres), "user\"name"), "\"user\"\"name\"");
         assert_eq!(quote_table_identifier(Some(DatabaseType::Informix), "users_1"), "users_1");
@@ -542,6 +544,17 @@ mod tests {
         );
         assert_eq!(
             build_table_select_sql(TableSelectSqlOptions {
+                database_type: Some(DatabaseType::StarRocks),
+                schema: None,
+                table_name: "sales_report",
+                columns: &["customer_name".to_string()],
+                order_columns: &[],
+                limit: 100,
+            }),
+            "SELECT `customer_name` FROM `sales_report` LIMIT 100;"
+        );
+        assert_eq!(
+            build_table_select_sql(TableSelectSqlOptions {
                 database_type: Some(DatabaseType::Iris),
                 schema: Some("Ens"),
                 table_name: "AlarmResponse",
@@ -597,6 +610,22 @@ mod tests {
                 include_row_id: false,
             }),
             "SELECT * FROM \"public\".\"orders\" WHERE (amount > 10) LIMIT 50 OFFSET 100;"
+        );
+        assert_eq!(
+            build_table_data_select_sql(TableDataSelectSqlOptions {
+                database_type: Some(DatabaseType::StarRocks),
+                schema: None,
+                table_name: "sales_report".to_string(),
+                primary_keys: Vec::new(),
+                columns: vec!["customer_name".to_string(), "amount".to_string()],
+                fallback_order_columns: Vec::new(),
+                order_by: None,
+                limit: Some(100),
+                offset: None,
+                where_input: Some("`customer_name` = 'Acme'".to_string()),
+                include_row_id: false,
+            }),
+            "SELECT * FROM `sales_report` WHERE (`customer_name` = 'Acme') LIMIT 100;"
         );
         assert_eq!(
             build_table_data_select_sql(TableDataSelectSqlOptions {


### PR DESCRIPTION
## Summary

- 将 StarRocks 的表名、列名等标识符改为使用 MySQL 风格的反引号引用。
- 补充 StarRocks 标识符引用、表数据查询 SQL 生成相关的回归测试。

## Background

我在排查 #726 时发现了一个独立的 StarRocks SQL 生成问题：DBX 在表/视图数据查询路径中可能会生成使用双引号引用标识符的 SQL，例如：

```sql
SELECT * FROM "order_view" LIMIT 100;
```

在我测试的 StarRocks 表/视图数据查询场景中，这种写法会被 StarRocks 拒绝并返回语法错误。由于 StarRocks 在这个标识符引用行为上兼容 MySQL，因此这里生成的 SQL 应该使用反引号：

```sql
SELECT * FROM `order_view` LIMIT 100;
```

这个 PR 只处理 StarRocks SQL 生成中的标识符引用问题，不包含 #726 中已经合并的闪退修复。

## Testing

```bash
cargo fmt --check
cargo test -p dbx-core sql_dialect
```

另外，我也用本地 StarRocks 容器和包含中文字段名的视图进行了手动验证。
