### PR TITLE
fix(sidebar): locate-in-sidebar reaches the table after a stale tree cache (#715)

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -230,7 +230,15 @@ async function locateActiveTabInSidebar() {
     clearSearchScopeFilter();
   }
 
-  const nodePath = findNodePathForActiveTab(tab, store.treeNodes);
+  let nodePath = findNodePathForActiveTab(tab, store.treeNodes);
+  if (!nodePath) {
+    // The first load may have served a stale schema cache whose async refresh
+    // replaced the database node before its tables finished loading, so the
+    // table isn't in the tree yet. Force a synchronous reload and retry once so
+    // locate reaches the table, not just the database (issue #715).
+    await ensureTreeLoadedForTab(tab, { force: true });
+    nodePath = findNodePathForActiveTab(tab, store.treeNodes);
+  }
   if (!nodePath) return;
 
   for (const ancestor of nodePath) {
@@ -256,23 +264,30 @@ async function locateActiveTabInSidebar() {
   await scrollToSidebarNode(match.id);
 }
 
-async function ensureTreeLoadedForTab(tab: QueryTab) {
+async function ensureTreeLoadedForTab(tab: QueryTab, opts?: { force?: boolean }) {
   const connId = tab.connectionId;
   if (!connId) return;
 
   const config = store.getConfig(connId);
   if (!config) return;
 
+  // When forcing, bypass the cached children check so we reload from the
+  // source. A stale schema cache otherwise serves children and triggers an
+  // async background refresh that can replace nodes mid-flight, leaving the
+  // tree without the target table by the time we search for it (issue #715).
+  const force = opts?.force ?? false;
+  const loadOptions = force ? { force: true } : undefined;
+
   // Ensure databases are loaded under the connection
   const connNode = store.treeNodes.find((n) => n.id === connId);
-  if (connNode && (!connNode.children || connNode.children.length === 0)) {
+  if (connNode && (force || !connNode.children || connNode.children.length === 0)) {
     try {
       if (config.db_type === "redis") {
         await store.loadRedisDatabases(connId);
       } else if (config.db_type === "mongodb" || config.db_type === "elasticsearch") {
         await store.loadMongoDatabases(connId);
       } else {
-        await store.loadDatabases(connId);
+        await store.loadDatabases(connId, loadOptions);
       }
     } catch {
       return;
@@ -283,23 +298,24 @@ async function ensureTreeLoadedForTab(tab: QueryTab) {
 
   // Find the database node
   const dbNode = findDatabaseNode(store.treeNodes, connId, tab.database);
-  if (!dbNode || (dbNode.children && dbNode.children.length > 0)) return;
+  if (!dbNode) return;
+  if (!force && dbNode.children && dbNode.children.length > 0) return;
 
   // Load database contents
   try {
     if (config.db_type === "sqlserver") {
-      await store.loadSqlServerDatabaseObjects(connId, tab.database);
+      await store.loadSqlServerDatabaseObjects(connId, tab.database, loadOptions);
     } else if (usesTreeSchemaMode(config.db_type) && !connectionUsesDatabaseObjectTreeMode(config)) {
-      await store.loadSchemas(connId, tab.database);
+      await store.loadSchemas(connId, tab.database, loadOptions);
       // If we have a schema, also load tables under that schema
       if (tab.schema) {
         const schemaNode = findSchemaNode(store.treeNodes, connId, tab.database, tab.schema);
-        if (schemaNode && (!schemaNode.children || schemaNode.children.length === 0)) {
-          await store.loadTables(connId, tab.database, tab.schema);
+        if (schemaNode && (force || !schemaNode.children || schemaNode.children.length === 0)) {
+          await store.loadTables(connId, tab.database, tab.schema, loadOptions);
         }
       }
     } else {
-      await store.loadTables(connId, tab.database);
+      await store.loadTables(connId, tab.database, undefined, loadOptions);
     }
   } catch {
     // Node just won't have children loaded


### PR DESCRIPTION
## 关联 issue

Closes #715 — 每次版本更新后,在已打开的表点「在侧边栏中定位」只能跳到库、定位不到表;重启应用后又恢复正常。

## 根因

定位依赖侧边栏树已加载到表节点。问题出在**磁盘 schema 树缓存的过期(stale)路径**:

- 应用版本更新(下载 + 安装)通常距上次使用 **> 15 分钟**,而 schema 树缓存 TTL 正是 15 分钟 → 缓存判定为 stale。
- 点定位时 `ensureTreeLoadedForTab` 加载连接下的库,`loadDatabases`/`loadTables` 命中 stale 缓存:**同步 `setChildren` 返回 stale 数据,同时 fire-and-forget 触发 `refreshStaleTreeNode` 后台强制重载**。
- 后台 `refreshStaleTreeNode` 完成时 `setChildren(连接, 全新库节点)`,把刚被 `loadTables` 填上表的旧库节点**替换出树**,而新库节点的表还没加载完。
- 紧接着同步执行的 `findNodePathForActiveTab` 遍历到新库节点 → 没有表 → 只能定位到库。
- 重启后(距上次 < 15 分钟)缓存 fresh,不触发 `refreshStaleTreeNode`,树稳定 → 定位正常。这正好解释了「版本更新后异常、重启后正常」。

## 改动(仅 `ConnectionTree.vue`)

1. `ensureTreeLoadedForTab` 新增 `{ force?: boolean }`:force 时全部走 `await` 的加载调用,**绕过 stale 缓存的 fire-and-forget 异步刷新**,返回时树已稳定到表层。
2. `locateActiveTabInSidebar`:第一次 `findNodePath` 找不到表时,用 `{ force: true }` 同步重载一次再重试。

特性:
- **fresh 场景第一次就命中、不触发 force(零回归)**;
- stale 场景兜底救回;对「树没加载到表」的任何成因都有效(鲁棒);
- **不改 `refreshStaleTreeNode`**,不影响其他刷新场景。

## 验证

- `pnpm check`(format / lint / typecheck / test)全绿。
- 端到端(把 `SCHEMA_TREE_CACHE_TTL_MS` 临时改 0 模拟全 stale + 刷新模拟版本更新后启动):
  - 控制台日志确认**第一次 `findNodePath` 失败**(复现「只到库」)、随后 **force 兜底触发**;
  - 定位最终精确到表节点(`snapshot_data` 高亮选中),不是只到库。
  - 验证用的 TTL/日志改动已还原,复跑 `pnpm check` 仍全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)