### PR TITLE
fix(sidebar): multi-select drag, blank-click deselect, empty group name (#681)

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -188,6 +188,15 @@ async function scrollToSidebarNode(nodeId: string) {
   }
 }
 
+function clearSidebarSelection() {
+  // Clicking the blank area of the tree clears the current selection. Row
+  // clicks call event.stopPropagation(), so this only fires for blank clicks
+  // (issue #681 — selection wasn't cleared in double-click activation mode).
+  store.selectedTreeNodeId = null;
+  store.selectedTreeNodeIds = [];
+  store.treeSelectionAnchorId = null;
+}
+
 async function createNewGroup() {
   const groupId = store.createConnectionGroup(t("connectionGroup.newGroupDefault"));
   pendingRenameGroupId.value = groupId;
@@ -490,6 +499,7 @@ defineExpose({ focusSearch, createNewGroup });
       ref="treeScrollerRef"
       class="sidebar-tree connection-tree-scroller min-h-0 flex-1 overflow-y-auto"
       :class="sidebarTreeOverflowClass"
+      @click="clearSidebarSelection"
       :items="flatNodes"
       :item-size="SIDEBAR_TREE_ROW_HEIGHT"
       :buffer="SIDEBAR_TREE_SCROLL_BUFFER"
@@ -517,6 +527,7 @@ defineExpose({ focusSearch, createNewGroup });
       ref="plainTreeScrollerRef"
       class="sidebar-tree min-h-0 flex-1 overflow-y-auto"
       :class="sidebarTreeOverflowClass"
+      @click="clearSidebarSelection"
     >
       <TreeItem
         v-for="item in flatNodes"

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -523,6 +523,9 @@ function onClick(event: MouseEvent) {
     event.stopPropagation();
     return;
   }
+  // Row clicks must not bubble to the tree container, whose click handler
+  // clears the selection when the blank area is clicked (issue #681).
+  event.stopPropagation();
   if (event.shiftKey) {
     selectTreeNodeRange(props.node);
     rowRef.value?.focus({ preventScroll: true });
@@ -2584,15 +2587,18 @@ watch(
 );
 
 function finishRenameGroup() {
+  // Guard against double invocation: pressing Enter sets isRenamingGroup=false
+  // and unmounts the input, which then fires @blur -> finishRenameGroup again.
+  // The first call can rebuild the tree and recycle props.node onto a different
+  // group, so a second run would act on the wrong group and cascade across
+  // groups (issue #681).
+  if (!isRenamingGroup.value) return;
   isRenamingGroup.value = false;
   const trimmed = renameInput.value.trim();
-  if (!trimmed) {
-    connectionStore.deleteConnectionGroup(props.node.id);
-    return;
-  }
-  if (trimmed !== props.node.label) {
-    connectionStore.renameConnectionGroup(props.node.id, trimmed);
-  }
+  // An empty name cancels the rename and keeps the group as-is — never delete
+  // here. Deleting a group is done explicitly via the context menu (issue #681).
+  if (!trimmed || trimmed === props.node.label) return;
+  connectionStore.renameConnectionGroup(props.node.id, trimmed);
 }
 
 function deleteConnectionGroup() {
@@ -2718,7 +2724,13 @@ const {
   startDrag,
   updateTarget,
   clearTarget,
-} = useDragSort((draggedId, targetId, position) => connectionStore.reorderSidebarEntry(draggedId, targetId, position));
+} = useDragSort((draggedId, targetId, position) => {
+  // If the grabbed row is part of a multi-selection, move all selected rows
+  // together; otherwise just the grabbed one (issue #681).
+  const selected = connectionStore.selectedTreeNodeIds;
+  const draggedIds = selected.length > 1 && selected.includes(draggedId) ? [...selected] : [draggedId];
+  connectionStore.reorderSidebarEntries(draggedIds, targetId, position);
+});
 
 const isDraggable = computed(() => {
   if (props.dragDisabled) return false;

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -2304,5 +2304,17 @@ export const useConnectionStore = defineStore("connection", () => {
     reorderSidebarEntry(draggedId: string, targetId: string, position: DropPosition) {
       updateLayoutAndRebuild(reorderEntryOp(sidebarLayout.value, draggedId, targetId, position));
     },
+    reorderSidebarEntries(draggedIds: string[], targetId: string, position: DropPosition) {
+      // Apply each dragged entry in turn so a multi-selection moves together,
+      // not just the single grabbed row (issue #681).
+      let layout = sidebarLayout.value;
+      let changed = false;
+      for (const id of draggedIds) {
+        if (id === targetId) continue;
+        layout = reorderEntryOp(layout, id, targetId, position);
+        changed = true;
+      }
+      if (changed) updateLayoutAndRebuild(layout);
+    },
   };
 });


### PR DESCRIPTION
## 关联 issue

Closes #681 — 连接列表的三个交互 bug(多选拖拽 / 点空白不取消选中 / 空名称解散分组)。

## 子问题 1:多选拖拽只拖了一条

**根因**:拖拽系统(`useDragSort`)只记录单个 `draggedId`,完全忽略 `selectedTreeNodeIds`,drop 只移动正在拖的那一条。

**修复**:
- `TreeItem.vue` 的 onDrop 回调:当被拖的行属于当前多选时,展开为整个 `selectedTreeNodeIds` 一起移动。
- `connectionStore` 新增 `reorderSidebarEntries(draggedIds, targetId, position)`,逐个应用 `reorderEntry`,让多选整体移动。

## 子问题 2:点空白不取消选中(双击打开模式下)

**根因**:侧边栏树容器没有处理空白点击来清除选中。

**修复**:行点击 `event.stopPropagation()`(不冒泡到容器),两个树容器(虚拟/普通)`@click` 时清空 `selectedTreeNodeId/Ids/anchorId`——这样只有点空白才会清选中。

## 子问题 3:新建分组、清空名称回车,已有分组全部被解散

**根因**:`@keydown.enter` 和随后的 `@blur` **双触发** `finishRenameGroup`;第一次调用 `deleteConnectionGroup` 触发 `rebuildTreeNodes`,把 `props.node` 复用到了另一个分组上,第二次便删错了分组,连锁解散。

**修复**:`finishRenameGroup` 加双触发 guard(`isRenamingGroup` 已 false 直接返回);空名称改为**取消重命名(保留分组,不删除)**——删除分组仍走右键菜单。

## 验证

- `pnpm check`(format / lint / typecheck / test)全绿。
- web 版端到端逐条验证:
  1. 多选 2 个连接拖入分组,**两个都进组**(截图);
  2. 选中后点空白,**选中清除**;
  3. 建多个分组、最后一个空名回车,**所有分组保留、未解散**。
- 不破坏现有:fresh 单选/单条拖拽行为不变。

![多选拖入分组](https://raw.githubusercontent.com/serenez/dbx/issue-669-assets/verify681-multidrag.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)