### PR TITLE
fix(mysql): require TLS for TiDB Cloud connections

### DIFF
--- a/apps/desktop/src/lib/connectionUrl.ts
+++ b/apps/desktop/src/lib/connectionUrl.ts
@@ -205,6 +205,10 @@ function urlParamsRequireTls(dbType: DatabaseType, params: string): boolean {
   return false;
 }
 
+function isTidbCloudHost(host: string): boolean {
+  return host.toLowerCase().endsWith(".tidbcloud.com");
+}
+
 export function connectionProfileForScheme(scheme: string, preferredProfile?: string): ConnectionProfile | undefined {
   if ((scheme === "http" || scheme === "https") && preferredProfile) {
     return HTTP_SELECTED_PROFILES[preferredProfile];
@@ -433,7 +437,11 @@ export function parseConnectionUrl(value: string, preferredProfile?: string): Pa
     password: mysqlCredentials?.password ?? decodeUrlPart(parsed.password),
     database: databaseFromPath(parsed.pathname),
     urlParams: effectiveUrlParams,
-    ssl: scheme === "rediss" || scheme === "https" || urlParamsRequireTls(profile.type, effectiveUrlParams),
+    ssl:
+      scheme === "rediss" ||
+      scheme === "https" ||
+      urlParamsRequireTls(profile.type, effectiveUrlParams) ||
+      (profile.type === "mysql" && isTidbCloudHost(parsed.hostname)),
   };
 }
 

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -921,7 +921,9 @@ impl ConnectionConfig {
             return normalize_bare_mysql_url_params(value);
         }
         match self.db_type {
-            DatabaseType::Mysql => normalize_mysql_url_params(value, self.ssl, self.ca_cert_path.trim().is_empty()),
+            DatabaseType::Mysql => {
+                normalize_mysql_url_params(value, self.mysql_uses_tls(), self.ca_cert_path.trim().is_empty())
+            }
             DatabaseType::Doris | DatabaseType::StarRocks | DatabaseType::Databend => {
                 normalize_bare_mysql_url_params(value)
             }
@@ -933,6 +935,10 @@ impl ConnectionConfig {
 
     pub fn clickhouse_uses_tls(&self) -> bool {
         self.ssl || url_params_contains_flag(self.url_params.as_deref(), "secure", "true")
+    }
+
+    fn mysql_uses_tls(&self) -> bool {
+        self.ssl || self.host.to_ascii_lowercase().ends_with(".tidbcloud.com")
     }
 
     fn redis_tls_insecure_fragment(&self) -> &'static str {
@@ -987,10 +993,12 @@ fn normalize_mysql_url_params(value: &str, force_tls: bool, accept_invalid_certs
     let mut parts: Vec<String> = value.split('&').filter(|part| !part.is_empty()).map(str::to_string).collect();
 
     if force_tls {
-        parts.retain(|part| !url_param_key_is(part, "ssl-mode") && !url_param_key_is(part, "sslmode"));
-        if !parts.iter().any(|part| url_param_key_is(part, "require_ssl")) {
-            parts.insert(0, "require_ssl=true".to_string());
-        }
+        parts.retain(|part| {
+            !url_param_key_is(part, "ssl-mode")
+                && !url_param_key_is(part, "sslmode")
+                && !url_param_key_is(part, "require_ssl")
+        });
+        parts.insert(0, "require_ssl=true".to_string());
         if accept_invalid_certs && !parts.iter().any(|part| url_param_key_is(part, "verify_ca")) {
             parts.push("verify_ca=false".to_string());
         }
@@ -1664,6 +1672,19 @@ mod tests {
         assert_eq!(
             config.connection_url(),
             "mysql://root:secret@10.1.2.3:2883/test?require_ssl=true&verify_identity=false&charset=utf8mb4"
+        );
+    }
+
+    #[test]
+    fn tidb_cloud_mysql_url_requires_tls() {
+        let mut config = mysql_config("root", "secret", Some("test"));
+        config.host = "gateway01.us-west-2.prod.aws.tidbcloud.com".to_string();
+        config.port = 4000;
+        config.url_params = Some("require_ssl=false&charset=utf8mb4".to_string());
+
+        assert_eq!(
+            config.connection_url(),
+            "mysql://root:secret@gateway01.us-west-2.prod.aws.tidbcloud.com:4000/test?require_ssl=true&verify_ca=false&verify_identity=false&charset=utf8mb4"
         );
     }
 

--- a/packages/app-tests/connectionUrl.test.ts
+++ b/packages/app-tests/connectionUrl.test.ts
@@ -50,6 +50,15 @@ test("parses mysql TLS URL params into the SSL switch state", () => {
   assert.equal(parseConnectionUrl("mysql://root@tidb.example.com:4000/test?require_ssl=true").ssl, true);
 });
 
+test("parses TiDB Cloud MySQL URLs as TLS connections", () => {
+  const parsed = parseConnectionUrl(
+    "mysql://root:secret@gateway01.us-west-2.prod.aws.tidbcloud.com:4000/test",
+  );
+
+  assert.equal(parsed.dbType, "mysql");
+  assert.equal(parsed.ssl, true);
+});
+
 test("parses MySQL JDBC user and password URL params as credentials", () => {
   const parsed = parseConnectionUrl(
     "jdbc:mysql://127.0.0.1:1234/example?user=admin&password=pwd&useUnicode=true&characterEncoding=UTF8&useSSL=false",


### PR DESCRIPTION
## 摘要

修复 #906。

根据 issue 中的讨论，TiDB Cloud Serverless 会拒绝非安全传输，因此 dbx 应该对 TiDB Cloud 的 MySQL 兼容连接自动处理 TLS 兼容性。

这个 PR 会在 MySQL 连接 host 以 `.tidbcloud.com` 结尾时自动强制启用 TLS。

TiDB Cloud 控制台复制出来的连接 URL 通常是普通的 `mysql://...tidbcloud.com:4000/...` 形式。此前 dbx 会把它作为普通 MySQL 连接处理，只有当 URL 参数中已经包含 `require_ssl=true` 或 `ssl-mode=require` 时才会启用强制 TLS，因此 TiDB Cloud Serverless 会报错：

```text
ERROR HY000 (1105): Connections using insecure transport are prohibited
```

## 变更内容

- 在连接 URL 导入时识别 TiDB Cloud host，并自动打开 MySQL SSL 开关状态。
- 在 Rust core 生成 MySQL 连接 URL 时，对 `.tidbcloud.com` host 强制启用 TLS。
- 在强制 TLS 的场景下，先移除已有的 `ssl-mode`、`sslmode`、`require_ssl` 参数，再写入 `require_ssl=true`，避免旧参数如 `require_ssl=false` 抵消强制 TLS。
- 增加回归测试，覆盖：
  - TiDB Cloud MySQL URL 导入后应被识别为 TLS 连接。
  - TiDB Cloud MySQL 连接 URL 应生成 `require_ssl=true`。

## 兼容性说明

普通 MySQL / MariaDB 连接的默认行为保持不变，仍沿用现有逻辑。

自动强制 TLS 仅应用于 MySQL 类型且 host 以 `.tidbcloud.com` 结尾的连接。