### PR TITLE
fix(clickhouse): bypass system proxy to prevent connection failure

### DIFF
--- a/crates/dbx-core/src/db/clickhouse_driver.rs
+++ b/crates/dbx-core/src/db/clickhouse_driver.rs
@@ -17,7 +17,8 @@ pub struct ChClient {
 
 impl ChClient {
     pub fn new(url: &str, username: Option<String>, password: Option<String>, timeout: Duration) -> Self {
-        let http = HttpClient::builder().connect_timeout(timeout).build().unwrap_or_else(|_| HttpClient::new());
+        let http =
+            HttpClient::builder().connect_timeout(timeout).no_proxy().build().unwrap_or_else(|_| HttpClient::new());
         Self { http, base_url: url.trim_end_matches('/').to_string(), username, password }
     }
 
@@ -28,7 +29,7 @@ impl ChClient {
         ca_cert_path: Option<&str>,
         timeout: Duration,
     ) -> Result<Self, String> {
-        let mut builder = HttpClient::builder().connect_timeout(timeout);
+        let mut builder = HttpClient::builder().connect_timeout(timeout).no_proxy();
         if let Some(path) = ca_cert_path.map(str::trim).filter(|path| !path.is_empty()) {
             let path = expand_cert_path(path);
             let cert_bytes =


### PR DESCRIPTION

# Summary
ClickHouse 连接在系统代理（如 Clash Verge）开启时会失败，即使已将目标域名加入代理的绕过列表。
# Problem
reqwest 的 HttpClient::builder() 默认会读取 http_proxy / https_proxy 环境变量。虽然 Clash Verge 等代理工具自身维护了绕过规则，但 reqwest 仅识别 NO_PROXY 环境变量，导致 ClickHouse 的 HTTP 请求仍然被发送到代理服务器，返回 502 Bad Gateway 或连接失败。
# Changes
在 ChClient::new 和 ChClient::new_with_ca_cert 中为 HttpClient::builder() 添加 .no_proxy() 调用，确保 ClickHouse 的 HTTP 请求始终直连，不受系统代理影响。这与项目中 Elasticsearch 驱动（elasticsearch_driver.rs）和 rqlite 驱动（rqlite_driver.rs）的做法保持一致，它们已实现了类似的代理绕过逻辑。
# Testing
开启 Clash Verge 代理，连接 ClickHouse 成功
关闭代理，连接 ClickHouse 成功
查询、列出数据库/表等操作正常