### PR TITLE
fix(ui): prevent Ctrl+right-click from closing context menu immediately on macOS

### DIFF
--- a/apps/desktop/src/components/ui/CustomContextMenu.vue
+++ b/apps/desktop/src/components/ui/CustomContextMenu.vue
@@ -54,7 +54,12 @@ function close() {
   show.value = false;
 }
 
-function onClickOutside(e: MouseEvent) {
+function onPointerDownOutside(e: PointerEvent) {
+  // Only respond to primary (left) button presses. This avoids a macOS
+  // issue where Ctrl+right-click generates a synthetic click event on
+  // mouseup. By using pointerdown (which fires on press, before
+  // contextmenu) instead of click, we never see that synthetic event.
+  if (e.button !== 0) return;
   const target = e.target as Node;
   const inMenu = menuRef.value?.contains(target);
   const inSub = subRef.value?.contains(target);
@@ -78,13 +83,13 @@ function onResize() {
 watch(show, (val) => {
   if (val) {
     openMenus.add(close);
-    document.addEventListener("click", onClickOutside, true);
+    document.addEventListener("pointerdown", onPointerDownOutside, true);
     document.addEventListener("keydown", onKeydown);
     document.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", onResize);
   } else {
     openMenus.delete(close);
-    document.removeEventListener("click", onClickOutside, true);
+    document.removeEventListener("pointerdown", onPointerDownOutside, true);
     document.removeEventListener("keydown", onKeydown);
     document.removeEventListener("scroll", onScroll, true);
     window.removeEventListener("resize", onResize);
@@ -229,7 +234,7 @@ function shortcutKeys(shortcut?: string): string[] {
 
 onBeforeUnmount(() => {
   openMenus.delete(close);
-  document.removeEventListener("click", onClickOutside, true);
+  document.removeEventListener("pointerdown", onPointerDownOutside, true);
   document.removeEventListener("keydown", onKeydown);
   document.removeEventListener("scroll", onScroll, true);
   window.removeEventListener("resize", onResize);


### PR DESCRIPTION
Fixes #920

## Problem

On macOS, when holding Control and right-clicking (or using two-finger tap on trackpad), the context menu appears but immediately closes when the right mouse button is released. This makes it impossible to select any menu item.

## Root Cause

macOS emits a synthetic `click` event when the right mouse button is released while holding the Control key. The `CustomContextMenu` was listening for `click` events in capture phase for outside-dismiss detection. This synthetic event was caught by `onClickOutside`, which determined the click target (the tree item) was outside the menu and closed it.

## Fix

Replaced the `click` event listener with `pointerdown` (with `event.button === 0` guard) for outside-dismiss detection. The key difference:

- `pointerdown` fires on **press**, before `contextmenu` opens the menu
- The right-click `pointerdown(button: 2)` is filtered by `event.button !== 0` before the menu even opens
- The synthetic macOS `click` fires on **release**, which we no longer listen for

This is the standard approach used by Radix UI, Floating UI, and Popper.js for outside-dismiss detection. It works consistently across macOS, Windows, and Linux.