### PR TITLE
🐛 fix(grid): 修复右键菜单选择时的单元格清理逻辑

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5178,6 +5178,7 @@ function onCellContext(rowId: number, rowIndex: number, colIdx: number, visibleC
   contextHeaderColumnIndex.value = null;
   contextCell.value = { rowId, rowIndex, col: colIdx };
   if (hasRowSelection.value && isRowSelected(rowId)) {
+    clearCellSelection();
     void prefetchCopyStatements();
     return;
   }
@@ -5192,6 +5193,9 @@ function onRowContext(rowId: number, rowIndex: number) {
   contextHeaderColumn.value = null;
   contextHeaderColumnIndex.value = null;
   contextCell.value = { rowId, rowIndex, col: -1 };
+  if (hasRowSelection.value && isRowSelected(rowId)) {
+    clearCellSelection();
+  }
   if (!isRowSelected(rowId)) {
     clearCellSelection();
     selectedRowIds.value = new Set([rowId]);

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -516,7 +516,9 @@ defineExpose({ focusSearch, refreshData, handleModRTarget });
                     variant="ghost"
                     size="icon"
                     class="ml-auto h-6 w-7 shrink-0 text-foreground hover:bg-accent"
-                    :class="{ 'bg-accent text-foreground': dataGridRef?.nullColumnsHidden }"
+                    :class="{
+                      'bg-accent text-foreground': dataGridRef?.nullColumnsHidden || dataGridRef?.multiRowTranspose,
+                    }"
                     :title="t('grid.viewOptions')"
                     :aria-label="t('grid.viewOptions')"
                   >
@@ -532,6 +534,32 @@ defineExpose({ focusSearch, refreshData, handleModRTarget });
                   <div class="border-b bg-muted/40 px-3 py-2">
                     <div class="text-xs font-semibold">{{ t("grid.viewOptions") }}</div>
                   </div>
+                  <LightTooltip
+                    :text="t('grid.transposeMultiRowHint')"
+                    side="left"
+                    :side-offset="6"
+                    :delay="0"
+                    :open-on-focus="false"
+                  >
+                    <label
+                      class="flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-xs hover:bg-accent"
+                    >
+                      <span class="min-w-0 flex items-center gap-1.5 font-medium">
+                        {{ t("grid.transposeMultiRowToggle") }}
+                        <span class="text-muted-foreground">
+                          {{
+                            dataGridRef?.multiRowTranspose ? t("grid.transposeMultiRow") : t("grid.transposeSingleRow")
+                          }}
+                        </span>
+                      </span>
+                      <Switch
+                        size="sm"
+                        :model-value="!!dataGridRef?.multiRowTranspose"
+                        :aria-label="t('grid.transposeMultiRow')"
+                        @update:model-value="(value: boolean) => dataGridRef?.setMultiRowTranspose(value)"
+                      />
+                    </label>
+                  </LightTooltip>
                   <label
                     class="flex cursor-pointer items-center gap-2 px-3 py-2 text-xs hover:bg-accent"
                     :class="{ 'cursor-not-allowed opacity-60': !dataGridRef?.canToggleAllNullColumns }"


### PR DESCRIPTION
- 在 onCellContext 和 onRowContext 中增加逻辑，当行已被选中时，清除单元格选择状态，确保选择状态的一致性。

✨ feat(grid): 增加多行转置视图切换功能

- 在网格视图选项中新增切换开关，支持在单行和多行转置模式之间切换，并更新选项按钮的高亮状态。

close #921 

修复了如上问题，同时前边转置位覆盖搜索后列表，也补齐了。