### PR TITLE
fix(desktop): prevent app layout from shifting on editor focus

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -963,7 +963,7 @@ onUnmounted(() => {
 
 <template>
   <LoginPage v-if="setupRequired || (needsAuth && !authenticated)" :setup-mode="setupRequired" @authenticated="onLoginSuccess" />
-  <div v-show="!setupRequired && (!needsAuth || authenticated)" class="h-screen w-screen overflow-hidden">
+  <div v-show="!setupRequired && (!needsAuth || authenticated)" class="fixed inset-0 h-screen w-screen overflow-hidden">
     <TooltipProvider :delay-duration="300">
       <div class="h-screen w-screen max-w-full min-w-[760px] min-h-[600px] flex flex-col bg-background text-foreground overflow-hidden">
         <AppToolbar


### PR DESCRIPTION
# Summary

- 将 DBX 主应用壳固定在 viewport 内，避免编辑器交互后页面级滚动导致顶部工具栏和查询区域被窗口上边缘裁切。
- 该问题是在尝试复现 #853 时发现的：为了制造多个查询结果 tab，我在 SQL 编辑器中框选并执行了若干个 `SELECT` 语句，随后鼠标意外点击到刚才被框选执行的 SQL 文本区域内，触发了和 #853 截图相似的界面上移/裁切问题。

<img width="1352" height="878" alt="image" src="https://github.com/user-attachments/assets/e3992ef3-a078-4ccd-a88a-66e29d53c2cd" />

- 在我的 macOS 环境中，暂时无法通过 #853 中描述的 `Cmd+Tab` 快速切换窗口路径复现；但通过上述“执行框选 SQL 后点击框选区域内文本”的路径可以稳定触发相似的 UI 异常。

# Notes

目前这个 PR 只能确认修复了我本地可复现的触发路径。由于 #853 原始触发路径在我的 macOS 环境下无法复现，如果该 PR 没有问题，合并后我会在 #853 下回复 issue 作者，请他从最新源码启动 DBX Desktop，并验证这个修复是否也能覆盖他的 `Cmd+Tab` 触发路径。若后续 issue 作者验证了 `Cmd+Tab` 触发路径在最新源码启动的 DBX Desktop 中不会再产生此问题，我会 @ 维护者进行 issue 的关闭。

# Test

- `pnpm check`
- 本地源码版 DBX Desktop 手动验证：
  - 选中并执行多条 `SELECT` SQL。
  - 执行后点击刚才被框选执行的 SQL 文本区域。
  - 顶部工具栏和查询区域不再被窗口上边缘裁切。
