### PR TITLE
[Enhance] add comments in SQL Server DDL output

### DIFF
--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -853,9 +853,10 @@ fn sqlserver_indexes_sql(schema: &str, table: &str) -> String {
                 WHERE ic3.object_id = i.object_id AND ic3.index_id = i.index_id AND ic3.is_included_column = 1 \
                 ORDER BY ic3.index_column_id \
                 FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, '') AS included_cols, \
-         i.filter_definition \
-         OUTER APPLY (SELECT CAST(ep.value AS NVARCHAR(MAX)) AS value FROM sys.extended_properties ep WHERE ep.major_id = i.object_id AND ep.minor_id = i.index_id AND ep.name = N'MS_Description' AND ep.class = 7) ep \
+         i.filter_definition, \
+         ep.value AS index_comment \
          FROM sys.indexes i \
+         OUTER APPLY (SELECT CAST(ep.value AS NVARCHAR(MAX)) AS value FROM sys.extended_properties ep WHERE ep.major_id = i.object_id AND ep.minor_id = i.index_id AND ep.name = N'MS_Description' AND ep.class = 7) ep \
          WHERE i.object_id = OBJECT_ID('{s}.{t}') AND i.name IS NOT NULL \
          ORDER BY i.name",
         s = schema.replace('\'', "''"),

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -831,7 +831,7 @@ pub async fn list_indexes(client: &mut SqlServerClient, schema: &str, table: &st
                 } else {
                     Some(inc_str.split(',').map(|s| s.to_string()).collect())
                 },
-                comment: None,
+                comment: row.get::<&str, _>(7).filter(|s: &&str| !s.is_empty()).map(|s: &str| s.to_string()),
             }
         })
         .collect())
@@ -854,6 +854,7 @@ fn sqlserver_indexes_sql(schema: &str, table: &str) -> String {
                 ORDER BY ic3.index_column_id \
                 FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 1, '') AS included_cols, \
          i.filter_definition \
+         OUTER APPLY (SELECT CAST(ep.value AS NVARCHAR(MAX)) AS value FROM sys.extended_properties ep WHERE ep.major_id = i.object_id AND ep.minor_id = i.index_id AND ep.name = N'MS_Description' AND ep.class = 7) ep \
          FROM sys.indexes i \
          WHERE i.object_id = OBJECT_ID('{s}.{t}') AND i.name IS NOT NULL \
          ORDER BY i.name",
@@ -891,6 +892,29 @@ pub async fn list_foreign_keys(
             ref_column: row.get::<&str, _>(4).unwrap_or("").to_string(),
         })
         .collect())
+}
+
+pub async fn get_table_comment(
+    client: &mut SqlServerClient,
+    schema: &str,
+    table: &str,
+) -> Result<Option<String>, String> {
+    let sql = sqlserver_table_comment_sql(schema, table);
+    let stream = client.query(&*sql, &[]).await.map_err(|e| e.to_string())?;
+    let rows = stream.into_first_result().await.map_err(|e| e.to_string())?;
+    Ok(rows.first().and_then(|row| row.get::<&str, _>(0)).filter(|s| !s.is_empty()).map(|s| s.to_string()))
+}
+
+fn sqlserver_table_comment_sql(schema: &str, table: &str) -> String {
+    let s = schema.replace('\'', "''");
+    let t = table.replace('\'', "''");
+    format!(
+        "SELECT CAST(ep.value AS NVARCHAR(MAX)) \
+         FROM sys.extended_properties ep \
+         WHERE ep.major_id = OBJECT_ID(QUOTENAME('{s}') + '.' + QUOTENAME('{t}')) \
+           AND ep.minor_id = 0 \
+           AND ep.name = N'MS_Description'"
+    )
 }
 
 pub async fn list_triggers(
@@ -1084,7 +1108,7 @@ mod tests {
     use super::{
         build_spatial_safe_sqlserver_query, is_sqlserver_spatial_column, requires_simple_query_batch,
         sqlserver_cell_to_json, sqlserver_columns_sql, sqlserver_indexes_sql, sqlserver_list_objects_sql,
-        SqlServerDescribedColumn, SqlServerResultSet,
+        sqlserver_table_comment_sql, SqlServerDescribedColumn, SqlServerResultSet,
     };
     use chrono::NaiveDate;
     use std::time::Instant;
@@ -1158,6 +1182,26 @@ mod tests {
         assert!(!sql.contains("STRING_AGG"));
         assert!(sql.contains("FOR XML PATH"));
         assert!(sql.contains("OBJECT_ID('dbo.DF_Rule')"));
+    }
+
+    #[test]
+    fn sqlserver_indexes_sql_includes_index_comment_via_extended_properties() {
+        let sql = sqlserver_indexes_sql("dbo", "orders");
+
+        assert!(sql.contains("sys.extended_properties ep"));
+        assert!(sql.contains("ep.minor_id = i.index_id"));
+        assert!(sql.contains("MS_Description"));
+    }
+
+    #[test]
+    fn sqlserver_table_comment_sql_queries_extended_properties() {
+        let sql = sqlserver_table_comment_sql("dbo", "users");
+
+        assert!(sql.contains("sys.extended_properties ep"));
+        assert!(sql.contains("ep.minor_id = 0"));
+        assert!(sql.contains("MS_Description"));
+        assert!(sql.contains("QUOTENAME('dbo')"));
+        assert!(sql.contains("QUOTENAME('users')"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/turso_driver.rs
+++ b/crates/dbx-core/src/db/turso_driver.rs
@@ -634,7 +634,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn split_sql_statements_splits_on_semicolons() {
         assert_eq!(split_sql_statements("SELECT 1"), vec!["SELECT 1"]);
         assert_eq!(

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2303,42 +2303,10 @@ pub async fn build_sqlserver_ddl(
         ));
     }
 
-    let escaped_schema = schema.replace('\'', "''");
-    let escaped_table = table.replace('\'', "''");
-
-    if let Some(comment) = table_comment.as_deref().filter(|s| !s.is_empty()) {
-        let escaped_comment = comment.replace('\'', "''");
-        ddl.push_str(&format!(
-            "\nEXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
-             @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
-             @level1type=N'TABLE', @level1name=N'{escaped_table}';"
-        ));
-    }
-
-    for col in &columns {
-        if let Some(comment) = col.comment.as_deref().filter(|s| !s.is_empty()) {
-            let escaped_comment = comment.replace('\'', "''");
-            let escaped_col = col.name.replace('\'', "''");
-            ddl.push_str(&format!(
-                "\nEXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
-                 @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
-                 @level1type=N'TABLE', @level1name=N'{escaped_table}', \
-                 @level2type=N'COLUMN', @level2name=N'{escaped_col}';"
-            ));
-        }
-    }
-
-    for idx in &indexes {
-        if let Some(comment) = idx.comment.as_deref().filter(|s| !s.is_empty()) {
-            let escaped_comment = comment.replace('\'', "''");
-            let escaped_idx = idx.name.replace('\'', "''");
-            ddl.push_str(&format!(
-                "\nEXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
-                 @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
-                 @level1type=N'TABLE', @level1name=N'{escaped_table}', \
-                 @level2type=N'INDEX', @level2name=N'{escaped_idx}';"
-            ));
-        }
+    let comment_ddl = render_sqlserver_comment_ddl(schema, table, table_comment.as_deref(), &columns, &indexes);
+    if !comment_ddl.is_empty() {
+        ddl.push('\n');
+        ddl.push_str(comment_ddl.trim_end());
     }
 
     Ok(ddl)

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2049,6 +2049,67 @@ mod ddl_tests {
             "SELECT pg_get_tabledef('\"tenant''s schema\".\"active users\"')"
         );
     }
+
+    #[test]
+    fn sqlserver_comment_ddl_includes_table_comment() {
+        let ddl = render_sqlserver_comment_ddl("dbo", "users", Some("User accounts table"), &[], &[]);
+
+        assert!(ddl.contains("EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'User accounts table'"));
+        assert!(ddl.contains("@level0type=N'SCHEMA', @level0name=N'dbo'"));
+        assert!(ddl.contains("@level1type=N'TABLE', @level1name=N'users'"));
+    }
+
+    #[test]
+    fn sqlserver_comment_ddl_includes_column_comments() {
+        let mut email_col = column("email", "nvarchar(255)");
+        email_col.comment = Some("User's email address".to_string());
+        let mut name_col = column("name", "nvarchar(100)");
+        name_col.comment = Some("User's display name".to_string());
+        let columns = vec![email_col, name_col];
+
+        let ddl = render_sqlserver_comment_ddl("dbo", "users", None, &columns, &[]);
+
+        assert!(ddl.contains("@level2type=N'COLUMN', @level2name=N'email'"));
+        assert!(ddl.contains("@value=N'User''s email address'"));
+        assert!(ddl.contains("@level2type=N'COLUMN', @level2name=N'name'"));
+        assert!(ddl.contains("@value=N'User''s display name'"));
+    }
+
+    #[test]
+    fn sqlserver_comment_ddl_includes_index_comments() {
+        let idx = db::IndexInfo {
+            name: "IX_users_email".to_string(),
+            columns: vec!["email".to_string()],
+            is_unique: true,
+            is_primary: false,
+            filter: None,
+            index_type: Some("NONCLUSTERED".to_string()),
+            included_columns: None,
+            comment: Some("Unique email index".to_string()),
+        };
+        let indexes = vec![idx];
+
+        let ddl = render_sqlserver_comment_ddl("dbo", "users", None, &[], &indexes);
+
+        assert!(ddl.contains("@level2type=N'INDEX', @level2name=N'IX_users_email'"));
+        assert!(ddl.contains("@value=N'Unique email index'"));
+    }
+
+    #[test]
+    fn sqlserver_comment_ddl_skips_empty_comments() {
+        let ddl = render_sqlserver_comment_ddl("dbo", "users", Some(""), &[], &[]);
+        assert!(ddl.is_empty());
+
+        let ddl = render_sqlserver_comment_ddl("dbo", "users", None, &[], &[]);
+        assert!(ddl.is_empty());
+    }
+
+    #[test]
+    fn sqlserver_comment_ddl_escapes_single_quotes() {
+        let ddl = render_sqlserver_comment_ddl("dbo", "users", Some("User's table for 'admin'"), &[], &[]);
+
+        assert!(ddl.contains("@value=N'User''s table for ''admin'''"));
+    }
 }
 
 pub async fn mysql_ddl(pool: &db::mysql::MySqlPool, table: &str) -> Result<String, String> {
@@ -2189,6 +2250,7 @@ pub async fn build_sqlserver_ddl(
     let columns = db::sqlserver::get_columns(client, schema, table).await?;
     let indexes = db::sqlserver::list_indexes(client, schema, table).await?;
     let fkeys = db::sqlserver::list_foreign_keys(client, schema, table).await?;
+    let table_comment = db::sqlserver::get_table_comment(client, schema, table).await?;
 
     let mut ddl = format!("CREATE TABLE [{schema}].[{table}] (\n");
     let col_lines: Vec<String> = columns
@@ -2240,5 +2302,93 @@ pub async fn build_sqlserver_ddl(
             idx.name
         ));
     }
+
+    let escaped_schema = schema.replace('\'', "''");
+    let escaped_table = table.replace('\'', "''");
+
+    if let Some(comment) = table_comment.as_deref().filter(|s| !s.is_empty()) {
+        let escaped_comment = comment.replace('\'', "''");
+        ddl.push_str(&format!(
+            "\nEXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
+             @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
+             @level1type=N'TABLE', @level1name=N'{escaped_table}';"
+        ));
+    }
+
+    for col in &columns {
+        if let Some(comment) = col.comment.as_deref().filter(|s| !s.is_empty()) {
+            let escaped_comment = comment.replace('\'', "''");
+            let escaped_col = col.name.replace('\'', "''");
+            ddl.push_str(&format!(
+                "\nEXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
+                 @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
+                 @level1type=N'TABLE', @level1name=N'{escaped_table}', \
+                 @level2type=N'COLUMN', @level2name=N'{escaped_col}';"
+            ));
+        }
+    }
+
+    for idx in &indexes {
+        if let Some(comment) = idx.comment.as_deref().filter(|s| !s.is_empty()) {
+            let escaped_comment = comment.replace('\'', "''");
+            let escaped_idx = idx.name.replace('\'', "''");
+            ddl.push_str(&format!(
+                "\nEXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
+                 @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
+                 @level1type=N'TABLE', @level1name=N'{escaped_table}', \
+                 @level2type=N'INDEX', @level2name=N'{escaped_idx}';"
+            ));
+        }
+    }
+
     Ok(ddl)
+}
+
+fn render_sqlserver_comment_ddl(
+    schema: &str,
+    table: &str,
+    table_comment: Option<&str>,
+    columns: &[db::ColumnInfo],
+    indexes: &[db::IndexInfo],
+) -> String {
+    let mut ddl = String::new();
+    let escaped_schema = schema.replace('\'', "''");
+    let escaped_table = table.replace('\'', "''");
+
+    if let Some(comment) = table_comment.filter(|s| !s.is_empty()) {
+        let escaped_comment = comment.replace('\'', "''");
+        ddl.push_str(&format!(
+            "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
+             @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
+             @level1type=N'TABLE', @level1name=N'{escaped_table}';\n"
+        ));
+    }
+
+    for col in columns {
+        if let Some(comment) = col.comment.as_deref().filter(|s| !s.is_empty()) {
+            let escaped_comment = comment.replace('\'', "''");
+            let escaped_col = col.name.replace('\'', "''");
+            ddl.push_str(&format!(
+                "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
+                 @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
+                 @level1type=N'TABLE', @level1name=N'{escaped_table}', \
+                 @level2type=N'COLUMN', @level2name=N'{escaped_col}';\n"
+            ));
+        }
+    }
+
+    for idx in indexes {
+        if let Some(comment) = idx.comment.as_deref().filter(|s| !s.is_empty()) {
+            let escaped_comment = comment.replace('\'', "''");
+            let escaped_idx = idx.name.replace('\'', "''");
+            ddl.push_str(&format!(
+                "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'{escaped_comment}', \
+                 @level0type=N'SCHEMA', @level0name=N'{escaped_schema}', \
+                 @level1type=N'TABLE', @level1name=N'{escaped_table}', \
+                 @level2type=N'INDEX', @level2name=N'{escaped_idx}';\n"
+            ));
+        }
+    }
+
+    ddl
 }


### PR DESCRIPTION

## feat: include table, column, and index comments in SQL Server DDL output

### Problem

When viewing the DDL of a SQL Server table (via Table Properties → DDL), the generated SQL was missing all comment information. SQL Server stores comments as extended properties (`MS_Description` in `sys.extended_properties`), but the DDL generator did not query or render them.

This affected three levels of comments:
- **Table comments** — not fetched or generated at all
- **Column comments** — data was already fetched by `get_columns()` but never included in the DDL output
- **Index comments** — not fetched (`IndexInfo.comment` was hardcoded to `None`) and not generated

### Solution

Modified the SQL Server metadata queries and DDL builder to query `sys.extended_properties` and emit `EXEC sys.sp_addextendedproperty` statements after the `CREATE TABLE` / `CREATE INDEX` blocks.

### Changes

#### `crates/dbx-core/src/db/sqlserver.rs`

- **`sqlserver_indexes_sql()`** — Added `OUTER APPLY` on `sys.extended_properties` (class = 7 for INDEX level, `minor_id = i.index_id`) to fetch index comments. Added `ep.value AS index_comment` column to the SELECT list.
- **`list_indexes()`** — Changed `comment: None` to read from the new column index (7).
- **`get_table_comment()`** *(new)* — Async function that queries the table-level `MS_Description` extended property (`minor_id = 0`).
- **`sqlserver_table_comment_sql()`** *(new)* — Helper that builds the table comment query using `QUOTENAME()` for safe identifier escaping.

#### `crates/dbx-core/src/schema.rs`

- **`build_sqlserver_ddl()`** — Now calls `get_table_comment()` and appends three sections of `sp_addextendedproperty` calls after the existing CREATE TABLE + CREATE INDEX output:
  1. Table comment (`@level1type = TABLE`)
  2. Column comments (`@level2type = COLUMN`)
  3. Index comments (`@level2type = INDEX`)

  All comment values and identifiers are properly escaped (single quotes doubled). Empty or `None` comments are silently skipped.

- **`render_sqlserver_comment_ddl()`** *(new)* — Pure-function variant for unit testing without a live database connection.

### Example output

```sql
CREATE TABLE [dbo].[users] (
  [id] int NOT NULL,
  [email] nvarchar(255) NOT NULL,
  [name] nvarchar(100),
  PRIMARY KEY ([id])
);

CREATE NONCLUSTERED INDEX [IX_users_email] ON [dbo].[users] ([email]);

EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'User accounts table', @level0type=N'SCHEMA', @level0name=N'dbo', @level1type=N'TABLE', @level1name=N'users';
EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Primary key', @level0type=N'SCHEMA', @level0name=N'dbo', @level1type=N'TABLE', @level1name=N'users', @level2type=N'COLUMN', @level2name=N'id';
EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Unique email index', @level0type=N'SCHEMA', @level0name=N'dbo', @level1type=N'TABLE', @level1name=N'users', @level2type=N'INDEX', @level2name=N'IX_users_email';
```

### Tests

7 new unit tests added, all passing:

| Test | Coverage |
|------|----------|
| `sqlserver_indexes_sql_includes_index_comment_via_extended_properties` | Index query includes `sys.extended_properties` join |
| `sqlserver_table_comment_sql_queries_extended_properties` | Table comment query structure and escaping |
| `sqlserver_comment_ddl_includes_table_comment` | Table comment DDL generation |
| `sqlserver_comment_ddl_includes_column_comments` | Column comment DDL generation |
| `sqlserver_comment_ddl_includes_index_comments` | Index comment DDL generation |
| `sqlserver_comment_ddl_skips_empty_comments` | Empty/None comments produce no output |
| `sqlserver_comment_ddl_escapes_single_quotes` | Single quotes in comments are doubled |

Run with: `cargo test -p dbx-core --lib -- ddl_tests sqlserver`

### Impact

- **No breaking changes.** The DDL output only gains additional `EXEC` statements when comments exist. Tables without comments produce identical output to before.
- Existing `list_indexes()` callers are unaffected — the `comment` field was already part of `IndexInfo` but always `None` for SQL Server; it now carries real data.
- The change is limited to the SQL Server native driver path; agent-based (JDBC) connections are not affected.
