### PR TITLE
实现 Redis 的查询功能

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -185,12 +185,15 @@ async function resolveActiveExecutableSql() {
     : "";
 }
 
+const blockDangerousRedisCommands = ref(true);
+
 const { dangerSql, pendingDangerSql, showDangerDialog, suppressDangerConfirm, tryExecute, doExecute, cancelActiveExecution, tryExplain, onDangerConfirm, explainMode } = useSqlExecution({
   activeTab,
   activeConnection,
   executableSql,
   resolveExecutableSql: resolveActiveExecutableSql,
   activeOutputView,
+  blockDangerousRedisCommands,
 });
 
 const dialogs = useDialogSources();
@@ -1038,7 +1041,9 @@ onUnmounted(() => {
                   :active-connection="activeConnection"
                   :executable-sql="executableSql"
                   :explain-mode="explainMode"
+                  :block-dangerous-redis-commands="blockDangerousRedisCommands"
                   @update:explain-mode="(m: 'explain' | 'autotrace') => (explainMode = m)"
+                  @update:block-dangerous-redis-commands="(v: boolean) => (blockDangerousRedisCommands = v)"
                   @execute="tryExecute()"
                   @cancel="cancelActiveExecution()"
                   @explain="tryExplain()"

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -682,7 +682,7 @@ async function refreshSemanticDiagnostics() {
     setSemanticDiagnostics([]);
     return;
   }
-  if (props.databaseType === "mongodb" || props.databaseType === "elasticsearch") {
+  if (props.databaseType === "mongodb" || props.databaseType === "elasticsearch" || props.databaseType === "redis") {
     setSemanticDiagnostics([]);
     return;
   }

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
-import { Play, Loader2, Square, Database, Check, Table2, AlignLeft, GitBranch, Save, FolderOpen, Layers, X } from "@lucide/vue";
+import { Play, Loader2, Square, Database, Check, Table2, AlignLeft, GitBranch, Save, FolderOpen, Layers, X, Shield } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { SearchableSelect } from "@/components/ui/searchable-select";
@@ -23,6 +23,7 @@ const props = defineProps<{
   activeConnection?: ConnectionConfig;
   executableSql: string;
   explainMode?: string;
+  blockDangerousRedisCommands?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -38,6 +39,7 @@ const emit = defineEmits<{
   changeSchema: [schema: string | undefined];
   setDefaultDatabase: [];
   clearDefaultDatabase: [];
+  "update:blockDangerousRedisCommands": [value: boolean];
 }>();
 
 const { t } = useI18n();
@@ -154,6 +156,20 @@ function connectionById(connectionId: string): ConnectionConfig | undefined {
           </Button>
         </TooltipTrigger>
         <TooltipContent>{{ t("toolbar.formatSql") }}</TooltipContent>
+      </Tooltip>
+      <Tooltip v-if="activeConnection?.db_type === 'redis'">
+        <TooltipTrigger as-child>
+          <Button
+            variant="ghost"
+            size="icon"
+            class="h-6 w-6"
+            :class="blockDangerousRedisCommands !== false ? 'text-orange-600 bg-orange-100 dark:text-orange-300 dark:bg-orange-900/30' : 'text-muted-foreground/50'"
+            @click="emit('update:blockDangerousRedisCommands', blockDangerousRedisCommands === false)"
+          >
+            <Shield class="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{{ t("toolbar.blockDangerousRedisCommands") }}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger as-child>

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -56,6 +56,10 @@ const connectionOptionIds = computed(() => connectionStore.connections.map((conn
 const activeDatabaseValue = computed(() => props.activeTab.database || "");
 const activeConnectionValue = computed(() => props.activeConnection?.id || "");
 const activeSchemaValue = computed(() => props.activeTab.schema || "");
+const supportsExplain = computed(() => {
+  const dbType = props.activeConnection?.db_type;
+  return dbType !== "redis" && dbType !== "mongodb" && dbType !== "elasticsearch" && dbType !== "etcd";
+});
 const isSingleDb = computed(() => isSingleDatabase(props.activeConnection?.db_type));
 const hasDefaultDatabaseOption = computed(() => activeDatabaseOptions.value.includes(""));
 const schemaDatabaseKey = computed(() => props.activeTab.database || (isSingleDb.value ? "_" : ""));
@@ -121,7 +125,7 @@ function connectionById(connectionId: string): ConnectionConfig | undefined {
         </TooltipTrigger>
         <TooltipContent>{{ activeTab.isExecuting ? t("toolbar.stopQuery") : t("toolbar.executeShortcut") }}</TooltipContent>
       </Tooltip>
-      <Tooltip>
+      <Tooltip v-if="supportsExplain">
         <TooltipTrigger as-child>
           <Button
             :variant="activeTab.isExplaining ? 'destructive' : 'ghost'"

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -2697,6 +2697,8 @@ function treeItemMenuItems(): ContextMenuItem[] {
 
   // 3. Connection Group
   if (node.type === "connection-group") {
+    items.push({ label: t("contextMenu.copyName"), action: copyName, icon: Copy, shortcut: shortcutCopyName.value });
+    items.push({ label: "", separator: true });
     items.push({ label: t("toolbar.newConnection"), action: newConnectionInGroup, icon: Plus });
     items.push({ label: "", separator: true });
     items.push({
@@ -2718,6 +2720,8 @@ function treeItemMenuItems(): ContextMenuItem[] {
 
   // 4. Database / Schema
   if (node.type === "database" || node.type === "schema") {
+    items.push({ label: t("contextMenu.copyName"), action: copyName, icon: Copy, shortcut: shortcutCopyName.value });
+    items.push({ label: "", separator: true });
     if (canOpenObjectBrowser.value) {
       items.push({ label: t("contextMenu.openObjectBrowser"), action: openObjectBrowser, icon: TableProperties });
     }

--- a/apps/desktop/src/composables/useSqlExecution.ts
+++ b/apps/desktop/src/composables/useSqlExecution.ts
@@ -7,6 +7,7 @@ import { useSettingsStore } from "@/stores/settingsStore";
 import { useToast } from "@/composables/useToast";
 import { classifySqlActivityKind } from "@/lib/historyActivityKind";
 import { sqlMetadataRefreshTarget } from "@/lib/sqlMetadataRefresh";
+import { classifyRedisCommandSafety, firstRedisCommandToken } from "@/lib/redisCommandSafety";
 import type { ConnectionConfig, QueryTab } from "@/types/database";
 
 const DANGER_RE = /^\s*(DROP|DELETE|TRUNCATE|ALTER|UPDATE|MERGE|REPLACE)\b/i;
@@ -32,7 +33,14 @@ function primarySqlOperation(sql: string): string {
   return statement?.match(/^([a-z]+)/i)?.[1]?.toUpperCase() || "SQL";
 }
 
-export function useSqlExecution(deps: { activeTab: ComputedRef<QueryTab | undefined>; activeConnection: ComputedRef<ConnectionConfig | undefined>; executableSql: ComputedRef<string>; resolveExecutableSql?: () => Promise<string>; activeOutputView: Ref<"result" | "summary" | "explain" | "chart"> }) {
+export function useSqlExecution(deps: {
+  activeTab: ComputedRef<QueryTab | undefined>;
+  activeConnection: ComputedRef<ConnectionConfig | undefined>;
+  executableSql: ComputedRef<string>;
+  resolveExecutableSql?: () => Promise<string>;
+  activeOutputView: Ref<"result" | "summary" | "explain" | "chart">;
+  blockDangerousRedisCommands?: Ref<boolean>;
+}) {
   const { t } = useI18n();
   const queryStore = useQueryStore();
   const historyStore = useHistoryStore();
@@ -54,6 +62,14 @@ export function useSqlExecution(deps: { activeTab: ComputedRef<QueryTab | undefi
     const tab = deps.activeTab.value;
     const sql = sqlOverride ?? (await resolvedExecutableSql());
     if (!tab || !sql.trim()) return;
+    // Redis: block dangerous commands when toggle is on
+    if (deps.activeConnection.value?.db_type === "redis" && deps.blockDangerousRedisCommands?.value !== false) {
+      const safety = classifyRedisCommandSafety(sql);
+      if (safety === "blocked") {
+        toast(t("redis.blockedCommand", { command: firstRedisCommandToken(sql) }), 5000);
+        return;
+      }
+    }
     if (isDangerousSql(sql) && settingsStore.editorSettings.confirmDangerousSqlExecution) {
       dangerSql.value = sql;
       pendingDangerSql.value = sql;
@@ -71,7 +87,8 @@ export function useSqlExecution(deps: { activeTab: ComputedRef<QueryTab | undefi
     deps.activeOutputView.value = "result";
     const connName = connectionStore.getConfig(tab.connectionId)?.name || "";
     const start = Date.now();
-    await queryStore.executeCurrentSql(sql);
+    const isRedis = deps.activeConnection.value?.db_type === "redis";
+    await queryStore.executeCurrentSql(sql, isRedis ? { skipRedisSafetyCheck: deps.blockDangerousRedisCommands?.value === false } : undefined);
     if (tab.result && !tab.result.columns.length && !tab.results?.some((result) => result.columns.length > 0)) {
       deps.activeOutputView.value = "summary";
     }

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -45,6 +45,7 @@
     sqlSaveFailed: "Failed to save file: {message}",
     driverManager: "Driver Manager",
     updatableDriverCount: "Updatable driver count",
+    blockDangerousRedisCommands: "Block dangerous commands",
   },
   updates: {
     title: "Updates",
@@ -1465,6 +1466,7 @@
     jsonFormatError: "Invalid JSON format",
     clearHistory: "Clear command history",
     historyCleared: "Redis command history cleared",
+    blockedCommand: "Command {command} is blocked for safety. Disable the shield icon in the toolbar to allow.",
   },
   mongo: {
     documents: "{count} documents",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -43,6 +43,7 @@
     sqlSaveFailed: "Error al guardar el archivo: {message}",
     driverManager: "Administrador de drivers",
     updatableDriverCount: "Cantidad de drivers actualizables",
+    blockDangerousRedisCommands: "Bloquear comandos peligrosos",
   },
   updates: {
     title: "Actualizaciones",
@@ -1249,6 +1250,7 @@
     wordWrap: "Ajuste de línea",
     clearHistory: "Borrar historial de comandos",
     historyCleared: "Historial de comandos Redis borrado",
+    blockedCommand: "El comando {command} está bloqueado por seguridad. Desactiva el icono de escudo en la barra de herramientas para permitirlo.",
   },
   mongo: {
     documents: "{count} documentos",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -43,6 +43,7 @@
     sqlSaveFailed: "Impossibile salvare il file: {message}",
     driverManager: "Gestione Driver",
     updatableDriverCount: "Driver aggiornabili",
+    blockDangerousRedisCommands: "Blocca comandi pericolosi",
   },
   updates: {
     title: "Aggiornamenti",
@@ -1361,6 +1362,7 @@
     wordWrap: "A capo automatico",
     clearHistory: "Cancella cronologia comandi",
     historyCleared: "Cronologia comandi Redis cancellata",
+    blockedCommand: "Il comando {command} è bloccato per sicurezza. Disattiva l'icona scudo nella barra degli strumenti per consentirlo.",
   },
   mongo: {
     documents: "{count} documenti",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -43,6 +43,7 @@
     sqlSaveFailed: "Falha ao salvar o arquivo: {message}",
     driverManager: "Gerenciador de Drivers",
     updatableDriverCount: "Quantidade de drivers atualizáveis",
+    blockDangerousRedisCommands: "Bloquear comandos perigosos",
   },
   updates: {
     title: "Atualizações",
@@ -1361,6 +1362,7 @@
     wordWrap: "Quebra de linha",
     clearHistory: "Limpar histórico de comandos",
     historyCleared: "Histórico de comandos Redis limpo",
+    blockedCommand: "O comando {command} está bloqueado por segurança. Desative o ícone de escudo na barra de ferramentas para permiti-lo.",
   },
   mongo: {
     documents: "{count} documentos",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -45,6 +45,7 @@
     sqlSaveFailed: "保存文件失败：{message}",
     driverManager: "驱动管理",
     updatableDriverCount: "可更新驱动数量",
+    blockDangerousRedisCommands: "拦截危险命令",
   },
   updates: {
     title: "更新",
@@ -1464,6 +1465,7 @@
     jsonFormatError: "JSON 格式不合法",
     clearHistory: "清除命令历史",
     historyCleared: "Redis 命令历史已清除",
+    blockedCommand: "命令 {command} 因安全原因已被拦截。点击工具栏盾牌图标可关闭拦截。",
   },
   mongo: {
     documents: "{count} 个文档",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -43,6 +43,7 @@
     sqlSaveFailed: "儲存檔案失敗：{message}",
     driverManager: "驅動程式管理器",
     updatableDriverCount: "可更新驅動程式數量",
+    blockDangerousRedisCommands: "攔截危險命令",
   },
   updates: {
     title: "更新",
@@ -1338,6 +1339,7 @@
     wordWrap: "自動換行",
     clearHistory: "清除命令歷史",
     historyCleared: "Redis 命令歷史已清除",
+    blockedCommand: "命令 {command} 因安全原因已被攔截。點擊工具列盾牌圖示可關閉攔截。",
   },
   mongo: {
     documents: "{count} 個文件",

--- a/apps/desktop/src/lib/http.ts
+++ b/apps/desktop/src/lib/http.ts
@@ -1211,8 +1211,8 @@ export async function redisFlushDb(connectionId: string, db: number): Promise<vo
   return post("/api/redis/flush-db", { connectionId, db });
 }
 
-export async function redisExecuteCommand(connectionId: string, db: number, command: string): Promise<RedisCommandResult> {
-  return post("/api/redis/execute-command", { connectionId, db, command });
+export async function redisExecuteCommand(connectionId: string, db: number, command: string, skipSafetyCheck?: boolean): Promise<RedisCommandResult> {
+  return post("/api/redis/execute-command", { connectionId, db, command, skipSafetyCheck: skipSafetyCheck ?? false });
 }
 
 export async function redisLoadMore(connectionId: string, db: number, keyRaw: string, keyType: string, cursor: number, count: number): Promise<RedisValue> {

--- a/apps/desktop/src/lib/redisQueryResult.ts
+++ b/apps/desktop/src/lib/redisQueryResult.ts
@@ -1,0 +1,20 @@
+import type { QueryResult } from "@/types/database";
+import { formatRedisCommandResult } from "@/lib/redisValuePresentation";
+
+export function redisCommandResultToQueryResult(value: unknown, elapsedMs: number): QueryResult {
+  if (Array.isArray(value)) {
+    const rows = value.map((item) => [formatRedisCommandResult(item)]);
+    return {
+      columns: ["(index)", "value"],
+      rows: rows.map((row, i) => [i + 1, row[0]!]),
+      affected_rows: value.length,
+      execution_time_ms: Math.max(0, Math.round(elapsedMs)),
+    };
+  }
+  return {
+    columns: ["result"],
+    rows: [[formatRedisCommandResult(value)]],
+    affected_rows: 0,
+    execution_time_ms: Math.max(0, Math.round(elapsedMs)),
+  };
+}

--- a/apps/desktop/src/lib/redisQueryResult.ts
+++ b/apps/desktop/src/lib/redisQueryResult.ts
@@ -1,12 +1,30 @@
 import type { QueryResult } from "@/types/database";
 import { formatRedisCommandResult } from "@/lib/redisValuePresentation";
 
-export function redisCommandResultToQueryResult(value: unknown, elapsedMs: number): QueryResult {
+const KEY_VALUE_COMMANDS = new Set(["HGETALL"]);
+
+function isKeyValueCommand(command: string): boolean {
+  return KEY_VALUE_COMMANDS.has(command.toUpperCase().trim());
+}
+
+export function redisCommandResultToQueryResult(value: unknown, elapsedMs: number, command?: string): QueryResult {
+  if (Array.isArray(value) && command && isKeyValueCommand(command)) {
+    const rows: (string | number | boolean | null)[][] = [];
+    for (let i = 0; i + 1 < value.length; i += 2) {
+      rows.push([formatRedisCommandResult(value[i]), formatRedisCommandResult(value[i + 1])]);
+    }
+    return {
+      columns: ["field", "value"],
+      rows,
+      affected_rows: value.length / 2,
+      execution_time_ms: Math.max(0, Math.round(elapsedMs)),
+    };
+  }
   if (Array.isArray(value)) {
-    const rows = value.map((item) => [formatRedisCommandResult(item)]);
+    const rows: (string | number | boolean | null)[][] = value.map((item, i) => [i + 1, formatRedisCommandResult(item)]);
     return {
       columns: ["(index)", "value"],
-      rows: rows.map((row, i) => [i + 1, row[0]!]),
+      rows,
       affected_rows: value.length,
       execution_time_ms: Math.max(0, Math.round(elapsedMs)),
     };

--- a/apps/desktop/src/lib/sqlSemanticDiagnostics.ts
+++ b/apps/desktop/src/lib/sqlSemanticDiagnostics.ts
@@ -80,7 +80,7 @@ export function areSqlSemanticDiagnosticsEqual(left: readonly SqlSemanticDiagnos
 }
 
 export function shouldRunSqlSemanticDiagnostics(sql: string, cursor: number, options: { databaseType?: DatabaseType } = {}): boolean {
-  if (options.databaseType === "mongodb" || options.databaseType === "elasticsearch") return false;
+  if (options.databaseType === "mongodb" || options.databaseType === "elasticsearch" || options.databaseType === "redis") return false;
   const context = getSqlCompletionContext(sql, cursor);
   if (context.suggestTables || context.exclusiveTableSuggestions || context.exclusiveColumnSuggestions) return false;
   if (context.qualifier) return false;

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1070,8 +1070,8 @@ export async function redisFlushDb(connectionId: string, db: number): Promise<vo
   return invoke("redis_flush_db", { connectionId, db });
 }
 
-export async function redisExecuteCommand(connectionId: string, db: number, command: string): Promise<RedisCommandResult> {
-  return invoke("redis_execute_command", { connectionId, db, command });
+export async function redisExecuteCommand(connectionId: string, db: number, command: string, skipSafetyCheck?: boolean): Promise<RedisCommandResult> {
+  return invoke("redis_execute_command", { connectionId, db, command, skipSafetyCheck: skipSafetyCheck ?? false });
 }
 
 export async function redisLoadMore(connectionId: string, db: number, keyRaw: string, keyType: string, cursor: number, count: number): Promise<RedisValue> {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -957,7 +957,7 @@ export const useQueryStore = defineStore("query", () => {
         if (current?.executionId === executionId) {
           current.results = undefined;
           current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(redisCommandResultToQueryResult(result.value, performance.now() - startedAt));
+          current.result = markQueryResultRowsRaw(redisCommandResultToQueryResult(result.value, performance.now() - startedAt, result.command));
           touchResult(current);
           current.queryAnalysis = undefined;
           current.querySourceColumns = undefined;

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -22,6 +22,7 @@ import {
   parseMongoWriteCommand,
   type MongoAggregateSafetyOptions,
 } from "@/lib/mongoShellCommand";
+import { redisCommandResultToQueryResult } from "@/lib/redisQueryResult";
 import { supportsDatabaseFeature } from "@/lib/databaseCapabilities";
 import { editablePrimaryKeys } from "@/lib/tableEditing";
 import { TABLE_DATA_EXPORT_PAGE_SIZE } from "@/lib/tableDataExport";
@@ -693,9 +694,9 @@ export const useQueryStore = defineStore("query", () => {
     await executeCurrentSql(tab.sql);
   }
 
-  async function executeCurrentSql(sql: string) {
+  async function executeCurrentSql(sql: string, options?: { skipRedisSafetyCheck?: boolean }) {
     if (!activeTabId.value) return;
-    await executeTabSql(activeTabId.value, sql, { resultBaseSql: sql, resultSortedSql: undefined });
+    await executeTabSql(activeTabId.value, sql, { resultBaseSql: sql, resultSortedSql: undefined, ...options });
   }
 
   type QueryMetadataPatch = Pick<QueryTab, "queryAnalysis" | "querySourceColumns" | "queryEditabilityReason" | "tableMeta">;
@@ -896,6 +897,7 @@ export const useQueryStore = defineStore("query", () => {
       mongoSafety?: MongoAggregateSafetyOptions;
       preserveResultDuringExecution?: boolean;
       preserveTotalRowCountDuringExecution?: boolean;
+      skipRedisSafetyCheck?: boolean;
     },
   ) {
     const tab = tabs.value.find((t) => t.id === id);
@@ -943,6 +945,30 @@ export const useQueryStore = defineStore("query", () => {
       const queryTimeoutSecs = queryTimeoutSecsForConnection(conn);
       const settingsStore = useSettingsStore();
       await previousResultSessionClose;
+
+      // Redis command execution
+      if (conn?.db_type === "redis") {
+        await connStore.ensureConnected(tab.connectionId);
+        const redisDb = Number(tab.database) || 0;
+        console.info("[DBX][executeTabSql:redis:start]", { traceId, db: redisDb, sql });
+        const result = await api.redisExecuteCommand(tab.connectionId, redisDb, sql, options?.skipRedisSafetyCheck);
+        console.info("[DBX][executeTabSql:redis:done]", { traceId, elapsed: elapsed() });
+        const current = tabs.value.find((t) => t.id === id);
+        if (current?.executionId === executionId) {
+          current.results = undefined;
+          current.activeResultIndex = undefined;
+          current.result = markQueryResultRowsRaw(redisCommandResultToQueryResult(result.value, performance.now() - startedAt));
+          touchResult(current);
+          current.queryAnalysis = undefined;
+          current.querySourceColumns = undefined;
+          current.queryEditabilityReason = undefined;
+          current.tableMeta = undefined;
+          current.resultBaseSql = options?.resultBaseSql ?? sql;
+          current.resultSortedSql = options?.resultSortedSql;
+        }
+        return;
+      }
+
       if (tab.mode === "query") {
         const pagination = options?.pagination ?? { limit: settingsStore.editorSettings.pageSize, offset: 0 };
         const plan = await api.prepareQueryPaginationExecutionPlan({

--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -797,14 +797,18 @@ where
     redis::cmd("FLUSHDB").query_async::<()>(con).await.map_err(|e| e.to_string())
 }
 
-pub async fn execute_command<C>(con: &mut C, command_text: &str) -> Result<RedisCommandResult, String>
+pub async fn execute_command<C>(
+    con: &mut C,
+    command_text: &str,
+    skip_safety_check: bool,
+) -> Result<RedisCommandResult, String>
 where
     C: ConnectionLike + Send + Sync + Unpin,
 {
     let argv = parse_command_argv(command_text)?;
     let command = argv[0].to_ascii_uppercase();
     let safety = classify_command(&command);
-    if safety == RedisCommandSafety::Blocked {
+    if !skip_safety_check && safety == RedisCommandSafety::Blocked {
         return Err(format!("Redis command is blocked for safety: {command}"));
     }
 

--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -635,6 +635,8 @@ fn parse_cluster_slot_master(value: RedisRawValue, fallback_host: &str) -> Resul
 }
 
 pub fn parse_command_argv(command_text: &str) -> Result<Vec<String>, String> {
+    // Strip trailing semicolons so commands like "HGETALL aaa;" work naturally
+    let command_text = command_text.trim_end().trim_end_matches(';');
     let mut argv = Vec::new();
     let mut current = String::new();
     let mut chars = command_text.chars().peekable();

--- a/crates/dbx-core/src/redis_ops.rs
+++ b/crates/dbx-core/src/redis_ops.rs
@@ -656,6 +656,7 @@ pub async fn redis_execute_command_core(
     connection_id: &str,
     db: u32,
     command: &str,
+    skip_safety_check: bool,
 ) -> Result<RedisCommandResult, String> {
     let connections = state.connections.read().await;
     match connections.get(connection_id).ok_or("Not found")? {
@@ -663,7 +664,7 @@ pub async fn redis_execute_command_core(
             RedisConnection::Direct(con) => {
                 let mut con = con.lock().await;
                 redis_driver::select_db(&mut *con, db).await?;
-                redis_driver::execute_command(&mut *con, command).await
+                redis_driver::execute_command(&mut *con, command, skip_safety_check).await
             }
             RedisConnection::Cluster(cluster) => {
                 redis_driver::ensure_cluster_db(db)?;
@@ -673,7 +674,7 @@ pub async fn redis_execute_command_core(
                     }
                 }
                 let mut con = cluster.connection.lock().await;
-                redis_driver::execute_command(&mut *con, command).await
+                redis_driver::execute_command(&mut *con, command, skip_safety_check).await
             }
         },
         _ => Err("Not a Redis connection".to_string()),

--- a/crates/dbx-web/src/routes/redis.rs
+++ b/crates/dbx-web/src/routes/redis.rs
@@ -152,6 +152,7 @@ pub struct RedisCommandRequest {
     pub connection_id: String,
     pub db: u32,
     pub command: String,
+    pub skip_safety_check: Option<bool>,
 }
 
 pub async fn list_databases(
@@ -438,8 +439,14 @@ pub async fn execute_command(
             )));
         }
     }
-    let result = dbx_core::redis_ops::redis_execute_command_core(&state.app, &req.connection_id, req.db, &req.command)
-        .await
-        .map_err(AppError)?;
+    let result = dbx_core::redis_ops::redis_execute_command_core(
+        &state.app,
+        &req.connection_id,
+        req.db,
+        &req.command,
+        req.skip_safety_check.unwrap_or(false),
+    )
+    .await
+    .map_err(AppError)?;
     Ok(Json(serde_json::to_value(result).map_err(|e| AppError(e.to_string()))?))
 }

--- a/src-tauri/src/commands/redis_cmd.rs
+++ b/src-tauri/src/commands/redis_cmd.rs
@@ -257,6 +257,7 @@ pub async fn redis_execute_command(
     connection_id: String,
     db: u32,
     command: String,
+    skip_safety_check: Option<bool>,
 ) -> Result<RedisCommandResult, String> {
     // In read-only mode, only allow safe read commands through the raw command interface
     if let Some(name) = dbx_core::query::connection_readonly_name(&state, &connection_id).await {
@@ -268,7 +269,14 @@ pub async fn redis_execute_command(
             ));
         }
     }
-    dbx_core::redis_ops::redis_execute_command_core(&state, &connection_id, db, &command).await
+    dbx_core::redis_ops::redis_execute_command_core(
+        &state,
+        &connection_id,
+        db,
+        &command,
+        skip_safety_check.unwrap_or(false),
+    )
+    .await
 }
 
 #[tauri::command]


### PR DESCRIPTION
1. 实现了在查询窗口执行 Redis 指令的功能
2. **隐藏 Redis 等非 SQL 数据库的 Explain 按钮** — Redis/MongoDB/Elasticsearch/etcd 不支持执行计划
3. **去掉 Redis 命令末尾分号** — 支持 `HGETALL aaa;` 这种带分号的写法
4. **HGETALL 结果以 key-value 表格展示** — 不再是扁平的索引列表，而是 field | value 两列
5. **禁用 Redis 连接的 SQL 语法诊断** — 不再对 Redis 命令标红报 "SQL parse error"