### PR TITLE
fix: 修复 canvas 模式下横向滚动条闪烁问题

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -3414,6 +3414,16 @@ const canvasDevicePixelRatio = ref(typeof window === "undefined" ? 1 : window.de
 const canvasBackingPixelRatio = computed(() => Math.min(4, Math.max(1, canvasDevicePixelRatio.value * settingsStore.editorSettings.uiScale)));
 const useCanvasGridRows = computed(() => dataGridRenderMode.value === "canvas");
 const canvasContentHeight = computed(() => Math.max(1, displayRowCount.value * CANVAS_DATA_GRID_ROW_HEIGHT));
+// Clamp the sticky canvas/overlay to the content width. A viewport-wide sticky surface inflates the
+// scroller's scrollWidth up to clientWidth, so with few columns it sits right on the overflow threshold
+// and the custom horizontal scrollbar flickers while the pane shrinks (canvas width lags clientWidth).
+const canvasSurfaceWidth = computed(() => {
+  const total = totalWidth.value;
+  const vw = canvasViewportWidth.value;
+  if (total <= 0) return Math.max(0, vw);
+  if (vw <= 0) return total;
+  return Math.min(vw, total);
+});
 const canvasRenderStyleKey = computed(() => `${settingsStore.editorSettings.theme}:${settingsStore.editorSettings.uiScale}:${canvasBackingPixelRatio.value}:${isDark.value}`);
 const CANVAS_MOUSE_WHEEL_SCROLL_MULTIPLIER = 1.5;
 const CANVAS_TRACKPAD_DELTA_THRESHOLD = 40;
@@ -3774,10 +3784,9 @@ function canvasEffectiveViewportHeight(): number {
 }
 
 const canvasOverlayStyle = computed(() => {
-  const vw = canvasEffectiveViewportWidth();
   const vh = canvasEffectiveViewportHeight();
   return {
-    width: `${vw}px`,
+    width: `${canvasSurfaceWidth.value}px`,
     height: `${vh}px`,
     marginTop: `-${vh}px`,
   };
@@ -3833,7 +3842,7 @@ function drawCanvasGrid() {
   drawCanvasDataGrid({
     canvas,
     scroller,
-    width: Math.max(1, canvasViewportWidth.value || scroller.clientWidth),
+    width: Math.max(1, canvasSurfaceWidth.value || scroller.clientWidth),
     height: Math.max(1, canvasViewportHeight.value || scroller.clientHeight),
     pixelRatio: canvasBackingPixelRatio.value,
     isDark: isDark.value,
@@ -6716,7 +6725,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   <canvas
                     ref="canvasRef"
                     class="canvas-grid-surface sticky left-0 top-0 z-0 block text-xs font-sans font-normal"
-                    :style="{ width: `${canvasViewportWidth}px`, height: `${canvasViewportHeight}px` }"
+                    :style="{ width: `${canvasSurfaceWidth}px`, height: `${canvasViewportHeight}px` }"
                     @mousemove="onCanvasMouseMove"
                     @mouseleave="onCanvasMouseLeave"
                     @mousedown="onCanvasMouseDown"


### PR DESCRIPTION

#  解决 canvas 模式滚动条闪烁，统一行列背景视觉表现

#925 

https://github.com/user-attachments/assets/fcfafcde-1eca-47f8-929f-eb011fbdcd79



## 问题描述
Canvas 渲染模式下，`canvas` 与 `overlay` 固定定位元素宽度始终等于视口宽度。当表格列数较少时，占位元素会将滚动容器 `scrollWidth` 顶至 `clientWidth`，刚好处于**横向溢出判定临界点**。

面板缩小时，Canvas 宽度更新异步滞后于视口尺寸，导致 `scrollWidth - clientWidth` 在 1px 区间反复波动，最终引发自定义横向滚动条频繁闪烁。

## 解决方案

新增计算属性 `canvasSurfaceWidth`，将画布表面宽度**钳位为「视口宽度 / 内容总宽度」二者较小值**：
1. 列数少、内容总宽度 < 视口宽度：画布宽度跟随内容宽度，保证 `scrollWidth < clientWidth`，横向溢出判定稳定为 false，彻底消除滚动条抖动；
2. 列数多、内容总宽度 > 视口宽度：画布仍使用视口宽度，横向滚动逻辑正常生效。

同时优化渲染逻辑，避免内部代码重新覆盖画布宽度，并让斑马纹、行背景仅绘制至最后一列，与 DOM 模式视觉保持一致。

