### PR TITLE
✨feat(sidebar): 添加连接 ID 重映射功能以支持导入布局

### DIFF
--- a/apps/desktop/src/lib/sidebarLayout.ts
+++ b/apps/desktop/src/lib/sidebarLayout.ts
@@ -59,6 +59,24 @@ export function reconcileLayout(connectionIds: string[], layout: SidebarLayout |
   return { groups, order };
 }
 
+export function remapSidebarLayoutConnectionIds(layout: SidebarLayout, connectionIdMap: Map<string, string>): SidebarLayout {
+  const remapEntries = (entries: SidebarOrderEntry[]): SidebarOrderEntry[] =>
+    entries.flatMap((entry): SidebarOrderEntry[] => {
+      if (entry.type === "connection") {
+        const id = connectionIdMap.get(entry.id);
+        return id ? [{ type: "connection", id }] : [];
+      }
+
+      const children = entryChildren(entry).flatMap((child): SidebarOrderEntry[] => remapEntries([child]));
+      return [{ type: "group", id: entry.id, children }];
+    });
+
+  return {
+    groups: layout.groups.map((group) => ({ ...group })),
+    order: remapEntries(layout.order),
+  };
+}
+
 function makeConnectionNode(config: ConnectionConfig, pinned: boolean): TreeNode {
   return {
     id: config.id,

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -14,6 +14,7 @@ import {
   deleteGroup as deleteGroupOp,
   toggleGroupCollapsed as toggleGroupCollapsedOp,
   moveConnectionToGroup as moveConnectionToGroupOp,
+  remapSidebarLayoutConnectionIds,
   reorderEntry as reorderEntryOp,
   type DropPosition,
 } from "@/lib/sidebarLayout";
@@ -2407,14 +2408,22 @@ export const useConnectionStore = defineStore("connection", () => {
     }
 
     let count = 0;
+    const importedConnectionIdMap = new Map<string, string>();
     for (const config of imported) {
       const duplicate = connections.value.find((c) => c.name === config.name && c.host === config.host && c.port === config.port);
       if (!duplicate) {
+        const importedId = config.id;
         config.id = uuid();
+        if (typeof importedId === "string") importedConnectionIdMap.set(importedId, config.id);
         const normalized = normalizeConnection(config);
         await addConnection(normalized);
         count++;
+      } else if (typeof config.id === "string") {
+        importedConnectionIdMap.set(config.id, duplicate.id);
       }
+    }
+    if (importedLayout) {
+      importedLayout = remapSidebarLayoutConnectionIds(importedLayout, importedConnectionIdMap);
     }
     return { count, layout: importedLayout };
   }

--- a/packages/app-tests/connectionStoreGroupedConnect.test.ts
+++ b/packages/app-tests/connectionStoreGroupedConnect.test.ts
@@ -99,3 +99,64 @@ test("connecting a grouped connection updates it in place instead of adding a ro
     storage.restore();
   }
 });
+
+test("importing grouped dbx connections remaps exported layout to new connection ids", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = installMemoryStorage();
+  let savedConnections: ConnectionConfig[] = [];
+  let savedLayout: SidebarLayout | null = null;
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url === "/api/connection/list") {
+      return new Response(JSON.stringify(savedConnections), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/layout/sidebar") {
+      if (init?.method === "POST") {
+        savedLayout = JSON.parse(String(init.body ?? "null"));
+        return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify(savedLayout), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/connection/save") {
+      savedConnections = JSON.parse(String(init?.body ?? "[]"));
+      return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    setActivePinia(createPinia());
+    const store = useConnectionStore();
+    await store.initFromDisk();
+
+    const exportedLayout: SidebarLayout = {
+      groups: [{ id: "group-1", name: "Imported Group", collapsed: false }],
+      order: [{ type: "group", id: "group-1", connectionIds: ["old-conn-1", "old-conn-2"] }],
+    };
+    const content = JSON.stringify({
+      connections: [conn("old-conn-1", "Grouped A"), conn("old-conn-2", "Grouped B")],
+      layout: exportedLayout,
+    });
+
+    const result = await store.importConnectionsFromFile(content, null);
+    assert.equal(result.count, 2);
+    assert.ok(result.layout);
+    store.applySidebarLayout(result.layout!);
+
+    const group = store.treeNodes[0];
+    assert.equal(group.type, "connection-group");
+    assert.equal(group.label, "Imported Group");
+    assert.deepEqual(
+      group.children?.map((node) => node.label),
+      ["Grouped A", "Grouped B"],
+    );
+    assert.notDeepEqual(
+      group.children?.map((node) => node.id),
+      ["old-conn-1", "old-conn-2"],
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    storage.restore();
+  }
+});

--- a/packages/app-tests/sidebarLayout.test.ts
+++ b/packages/app-tests/sidebarLayout.test.ts
@@ -1,6 +1,19 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
-import { reconcileLayout, buildTreeNodesFromLayout, createGroup, deleteGroup, renameGroup, moveConnectionToGroup, reorderEntry, toggleGroupCollapsed, appendConnectionToLayout, removeConnectionFromSidebarLayout, emptyLayout } from "../../apps/desktop/src/lib/sidebarLayout.ts";
+import {
+  reconcileLayout,
+  buildTreeNodesFromLayout,
+  createGroup,
+  deleteGroup,
+  renameGroup,
+  moveConnectionToGroup,
+  reorderEntry,
+  toggleGroupCollapsed,
+  appendConnectionToLayout,
+  removeConnectionFromSidebarLayout,
+  emptyLayout,
+  remapSidebarLayoutConnectionIds,
+} from "../../apps/desktop/src/lib/sidebarLayout.ts";
 import type { ConnectionConfig, SidebarLayout } from "../../apps/desktop/src/types/database.ts";
 
 function conn(id: string, name?: string): ConnectionConfig {
@@ -68,6 +81,38 @@ test("reconcileLayout removes groups with no order entry", () => {
   const result = reconcileLayout(["a"], layout);
   assert.equal(result.groups.length, 1);
   assert.equal(result.groups[0].id, "g1");
+});
+
+test("remapSidebarLayoutConnectionIds preserves imported grouping with new connection ids", () => {
+  const layout: SidebarLayout = {
+    groups: [{ id: "g1", name: "Imported", collapsed: false }],
+    order: [
+      { type: "connection", id: "old-root" },
+      { type: "group", id: "g1", connectionIds: ["old-a", "old-b"] },
+    ],
+  };
+
+  const remapped = remapSidebarLayoutConnectionIds(
+    layout,
+    new Map([
+      ["old-root", "new-root"],
+      ["old-a", "new-a"],
+      ["old-b", "new-b"],
+    ]),
+  );
+  const reconciled = reconcileLayout(["new-root", "new-a", "new-b"], remapped);
+
+  assert.deepEqual(reconciled.order, [
+    { type: "connection", id: "new-root" },
+    {
+      type: "group",
+      id: "g1",
+      children: [
+        { type: "connection", id: "new-a" },
+        { type: "connection", id: "new-b" },
+      ],
+    },
+  ]);
 });
 
 // --- buildTreeNodesFromLayout ---


### PR DESCRIPTION
- 实现了 remapSidebarLayoutConnectionIds 函数，用于根据连接 ID 映射更新侧边栏布局
- 在连接存储中集成了该功能，以确保导入的布局与新连接 ID 一致
- 增加了相应的单元测试，确保重映射逻辑的正确性

close #1121
