### PR TITLE
Change default locale fallback from zh-CN to en

### DIFF
--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -1,5 +1,5 @@
 import { createI18n } from "vue-i18n";
-import zhCN from "./locales/zh-CN";
+import en from "./locales/en";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/safeStorage";
 
 export type Locale = "en" | "es" | "it" | "pt-BR" | "zh-CN" | "zh-TW";
@@ -10,13 +10,13 @@ type I18nGlobal = {
 };
 
 const supportedLocales: Locale[] = ["en", "es", "it", "pt-BR", "zh-CN", "zh-TW"];
-const defaultLocale: Locale = "zh-CN";
+const defaultLocale: Locale = "en";
 const loadedLocales = new Set<Locale>([defaultLocale]);
-const localeLoaders: Record<Exclude<Locale, "zh-CN">, () => Promise<{ default: LocaleMessages }>> = {
-  en: () => import("./locales/en"),
+const localeLoaders: Record<Exclude<Locale, "en">, () => Promise<{ default: LocaleMessages }>> = {
   es: () => import("./locales/es"),
   it: () => import("./locales/it"),
   "pt-BR": () => import("./locales/pt-BR"),
+  "zh-CN": () => import("./locales/zh-CN"),
   "zh-TW": () => import("./locales/zh-TW"),
 };
 
@@ -71,14 +71,14 @@ const i18n = createI18n({
   locale: initialLocale,
   fallbackLocale: defaultLocale,
   messages: {
-    "zh-CN": zhCN,
+    en,
   },
 });
 const i18nGlobal = i18n.global as unknown as I18nGlobal;
 
 export async function loadLocaleMessages(locale: Locale) {
   if (loadedLocales.has(locale)) return;
-  const loader = localeLoaders[locale as Exclude<Locale, "zh-CN">];
+  const loader = localeLoaders[locale as Exclude<Locale, "en">];
   if (!loader) return;
   const messages = await loader();
   i18nGlobal.setLocaleMessage(locale, messages.default);


### PR DESCRIPTION
## Problem

When a user's system language is not in the supported locales list (e.g. French, German, Japanese…), the app falls back to `zh-CN` (Simplified Chinese). This is unintuitive for an international open-source project — a user who doesn't read Chinese gets an interface in a language they can't understand.

## Current behavior

1. App detects system locale via `navigator.languages` / `navigator.language`
2. If no supported locale matches (e.g. `fr`, `de`, `ja`), `localeFromLanguageTag()` returns `null`
3. `detectLocaleFromLanguages()` falls back to `defaultLocale`, which is `"zh-CN"`

## Solution

Change the default fallback locale from `"zh-CN"` to `"en"` in `apps/desktop/src/i18n/index.ts`.

- Users with unsupported locales get English instead of Chinese
- The `en` locale bundle is eagerly loaded instead of `zh-CN` (also a small perf win)
- Chinese users are unaffected (their locale is still detected correctly via `navigator.language`)

## Impact

- **1 file changed**: `apps/desktop/src/i18n/index.ts` (~6 lines)
- No behavior change for users whose system locale is already supported
- No new dependencies

Closes #1158