### PR TITLE
fix(ui): allow mouse interaction with LightTooltip interactive content (#1120)

### DIFF
--- a/apps/desktop/src/components/ui/LightTooltip.vue
+++ b/apps/desktop/src/components/ui/LightTooltip.vue
@@ -20,10 +20,18 @@ const props = withDefaults(
 );
 
 const triggerRef = ref<HTMLElement>();
+const tooltipRef = ref<HTMLElement>();
 const show = ref(false);
 const x = ref(0);
 const y = ref(0);
 let timer: ReturnType<typeof setTimeout> | null = null;
+let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearCloseTimer() {
+  if (!closeTimer) return;
+  clearTimeout(closeTimer);
+  closeTimer = null;
+}
 
 function triggerElement(): HTMLElement | undefined {
   const root = triggerRef.value;
@@ -69,7 +77,7 @@ function isTriggerActive(): boolean {
   const el = triggerElement();
   if (!el || !el.isConnected) return false;
   const active = document.activeElement;
-  return el.matches(":hover") || (active instanceof Node && el.contains(active));
+  return el.matches(":hover") || tooltipRef.value?.matches(":hover") || (active instanceof Node && el.contains(active));
 }
 
 function isDisabled(): boolean {
@@ -104,12 +112,30 @@ function updatePosition() {
 
 function close() {
   clearTimer();
+  clearCloseTimer();
   show.value = false;
   removeGlobalListeners();
 }
 
 function closeIfTriggerInactive() {
-  if (!isTriggerActive()) close();
+  if (isTriggerActive()) {
+    clearCloseTimer();
+  } else {
+    scheduleClose();
+  }
+}
+
+function scheduleClose() {
+  if (closeTimer) return;
+  closeTimer = setTimeout(() => {
+    closeTimer = null;
+    if (!isTriggerActive()) close();
+  }, 100);
+}
+
+function onPointerDown(e: PointerEvent) {
+  if (tooltipRef.value?.contains(e.target as Node)) return;
+  close();
 }
 
 function addGlobalListeners() {
@@ -118,7 +144,7 @@ function addGlobalListeners() {
   window.addEventListener("blur", close);
   document.addEventListener("visibilitychange", close);
   document.addEventListener("pointermove", closeIfTriggerInactive, true);
-  document.addEventListener("pointerdown", close, true);
+  document.addEventListener("pointerdown", onPointerDown, true);
   document.addEventListener("contextmenu", close, true);
 }
 
@@ -128,7 +154,7 @@ function removeGlobalListeners() {
   window.removeEventListener("blur", close);
   document.removeEventListener("visibilitychange", close);
   document.removeEventListener("pointermove", closeIfTriggerInactive, true);
-  document.removeEventListener("pointerdown", close, true);
+  document.removeEventListener("pointerdown", onPointerDown, true);
   document.removeEventListener("contextmenu", close, true);
 }
 
@@ -166,11 +192,20 @@ watch(
 </script>
 
 <template>
-  <span ref="triggerRef" class="contents" @mouseenter="scheduleOpen" @mouseleave="close" @focusin="scheduleFocusOpen" @focusout="close">
+  <span ref="triggerRef" class="contents" @mouseenter="scheduleOpen" @mouseleave="scheduleClose" @focusin="scheduleFocusOpen" @focusout="close">
     <slot />
   </span>
   <Teleport to="body">
-    <div v-if="show" class="pointer-events-none fixed z-50 rounded-md bg-foreground text-xs text-background" :class="[slots.content ? '' : 'inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', tooltipTransformClass]" :style="{ left: `${x}px`, top: `${y}px` }" role="tooltip">
+    <div
+      v-if="show"
+      ref="tooltipRef"
+      class="fixed z-50 rounded-md bg-foreground text-xs text-background"
+      :class="[slots.content ? '' : 'inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', tooltipTransformClass]"
+      :style="{ left: `${x}px`, top: `${y}px` }"
+      role="tooltip"
+      @mouseenter="clearCloseTimer"
+      @mouseleave="scheduleClose"
+    >
       <slot name="content">{{ text }}</slot>
       <span :class="[arrowClass, 'size-2.5 rotate-45 rounded-[2px] bg-foreground']" aria-hidden="true" />
     </div>


### PR DESCRIPTION
## Problem

Closes #1120

表头字段信息 Tooltip 内的复制按钮无法使用——鼠标一旦离开表头移向 Tooltip，Tooltip 立即消失，无法点击内部的复制按钮。

Root cause: `c8539bcc` 将列标题从 shadcn-vue `<Tooltip>`（Reka UI）替换为手写的 `LightTooltip` 以优化性能。但 `LightTooltip` 最初是为侧边栏纯文本场景设计的，存在以下三个问题：

1. **`pointer-events-none`** — Tooltip 内容不接收鼠标事件，鼠标无法进入
2. **`@mouseleave="close"` 立即关闭** — 没有延迟缓冲，鼠标离开 trigger 瞬间 tooltip 消失
3. **`pointerdown` 无差别关闭** — capture 阶段拦截了 tooltip 内部的点击事件

## Changes

`apps/desktop/src/components/ui/LightTooltip.vue`

| Change | Purpose |
|--------|---------|
| Add `tooltipRef` + `closeTimer` + `clearCloseTimer()` | Track tooltip DOM element and close delay |
| `isTriggerActive()`: add `tooltipRef?.matches(":hover")` | Keep tooltip open when hovering over it |
| `close()`: add `clearCloseTimer()` | Clean up on close |
| `closeIfTriggerInactive()`: cancel if active, delay if not | 100ms buffer for trigger→tooltip transition |
| Add `scheduleClose()` (100ms `setTimeout`) | Give mouse time to cross the gap into tooltip |
| Add `onPointerDown()`: skip close for clicks inside tooltip | Allow copy button to receive clicks |
| Template: `@mouseleave="close"` → `scheduleClose` | No longer close immediately on leave |
| Template: remove `pointer-events-none`, add `ref`, `@mouseenter`/`@mouseleave` | Allow mouse to enter and interact with tooltip |

## Verification

- [x] Hover column header → tooltip appears
- [x] Move mouse from header into tooltip → tooltip stays open
- [x] Click copy button inside tooltip → copies column name successfully
- [x] Tooltip closes when mouse leaves both header and tooltip
- [x] Pre-commit hooks (oxfmt, lint-staged) pass