### PR TITLE
fix(influxdb): Incompatible result sets with older versions(#1130)

### DIFF
--- a/crates/dbx-core/src/db/influxdb_driver.rs
+++ b/crates/dbx-core/src/db/influxdb_driver.rs
@@ -93,6 +93,9 @@ struct InfluxJsonResult {
 #[derive(Deserialize)]
 #[allow(dead_code)]
 struct InfluxQueryResult {
+    /// The `statement_id` field may not be included in older versions (such as 1.1)
+    #[serde(default)]
+    #[allow(dead_code)]
     statement_id: usize,
     #[serde(default)]
     #[allow(dead_code)]


### PR DESCRIPTION
修复结果集解析未兼容老版本的问题。
See: #1130

Bug 原因:
部分字段不存在于老版本的查询结果响应体内。

在 InfluxDB v1.1 及 v1.8下 测试通过。