### PR TITLE
fix(ui): prevent click handler from firing on macOS Ctrl+click (#1188)

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -999,6 +999,15 @@ onMounted(async () => {
   if (isDesktop) {
     document.addEventListener("contextmenu", handleContextMenu);
   }
+  // macOS: Ctrl+click fires both click and contextmenu.
+  // Intercept click in capture phase to prevent unwanted navigation.
+  document.addEventListener(
+    "click",
+    (e) => {
+      if (e.ctrlKey) e.stopPropagation();
+    },
+    true,
+  );
   if (!isDesktop) {
     try {
       const res = await fetch("/api/auth/check");

--- a/apps/desktop/src/components/ui/LightTooltip.vue
+++ b/apps/desktop/src/components/ui/LightTooltip.vue
@@ -20,10 +20,18 @@ const props = withDefaults(
 );
 
 const triggerRef = ref<HTMLElement>();
+const tooltipRef = ref<HTMLElement>();
 const show = ref(false);
 const x = ref(0);
 const y = ref(0);
 let timer: ReturnType<typeof setTimeout> | null = null;
+let closeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearCloseTimer() {
+  if (!closeTimer) return;
+  clearTimeout(closeTimer);
+  closeTimer = null;
+}
 
 function triggerElement(): HTMLElement | undefined {
   const root = triggerRef.value;
@@ -69,7 +77,7 @@ function isTriggerActive(): boolean {
   const el = triggerElement();
   if (!el || !el.isConnected) return false;
   const active = document.activeElement;
-  return el.matches(":hover") || (active instanceof Node && el.contains(active));
+  return el.matches(":hover") || tooltipRef.value?.matches(":hover") || (active instanceof Node && el.contains(active));
 }
 
 function isDisabled(): boolean {
@@ -104,12 +112,30 @@ function updatePosition() {
 
 function close() {
   clearTimer();
+  clearCloseTimer();
   show.value = false;
   removeGlobalListeners();
 }
 
 function closeIfTriggerInactive() {
-  if (!isTriggerActive()) close();
+  if (isTriggerActive()) {
+    clearCloseTimer();
+  } else {
+    scheduleClose();
+  }
+}
+
+function scheduleClose() {
+  if (closeTimer) return;
+  closeTimer = setTimeout(() => {
+    closeTimer = null;
+    if (!isTriggerActive()) close();
+  }, 100);
+}
+
+function onPointerDown(e: PointerEvent) {
+  if (tooltipRef.value?.contains(e.target as Node)) return;
+  close();
 }
 
 function addGlobalListeners() {
@@ -118,7 +144,7 @@ function addGlobalListeners() {
   window.addEventListener("blur", close);
   document.addEventListener("visibilitychange", close);
   document.addEventListener("pointermove", closeIfTriggerInactive, true);
-  document.addEventListener("pointerdown", close, true);
+  document.addEventListener("pointerdown", onPointerDown, true);
   document.addEventListener("contextmenu", close, true);
 }
 
@@ -128,7 +154,7 @@ function removeGlobalListeners() {
   window.removeEventListener("blur", close);
   document.removeEventListener("visibilitychange", close);
   document.removeEventListener("pointermove", closeIfTriggerInactive, true);
-  document.removeEventListener("pointerdown", close, true);
+  document.removeEventListener("pointerdown", onPointerDown, true);
   document.removeEventListener("contextmenu", close, true);
 }
 
@@ -166,11 +192,20 @@ watch(
 </script>
 
 <template>
-  <span ref="triggerRef" class="contents" @mouseenter="scheduleOpen" @mouseleave="close" @focusin="scheduleFocusOpen" @focusout="close">
+  <span ref="triggerRef" class="contents" @mouseenter="scheduleOpen" @mouseleave="scheduleClose" @focusin="scheduleFocusOpen" @focusout="close">
     <slot />
   </span>
   <Teleport to="body">
-    <div v-if="show" class="pointer-events-none fixed z-50 rounded-md bg-foreground text-xs text-background" :class="[slots.content ? '' : 'inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', tooltipTransformClass]" :style="{ left: `${x}px`, top: `${y}px` }" role="tooltip">
+    <div
+      v-if="show"
+      ref="tooltipRef"
+      class="fixed z-50 rounded-md bg-foreground text-xs text-background"
+      :class="[slots.content ? '' : 'inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', tooltipTransformClass]"
+      :style="{ left: `${x}px`, top: `${y}px` }"
+      role="tooltip"
+      @mouseenter="clearCloseTimer"
+      @mouseleave="scheduleClose"
+    >
       <slot name="content">{{ text }}</slot>
       <span :class="[arrowClass, 'size-2.5 rotate-45 rounded-[2px] bg-foreground']" aria-hidden="true" />
     </div>


### PR DESCRIPTION
## Problem

Closes #1188

macOS 上 `Ctrl+click`（标准右键替代操作）会同时触发 `click` 和 `contextmenu` 事件。以下三个组件的行/条目元素同时绑定了 `@click` 和 `@contextmenu`，导致不必要的导航/操作与右键菜单同时触发：

1. **ObjectBrowser** — 右键表行时跳转表详情
2. **SqlLibraryPanel** — 右键文件夹/文件时切换/打开
3. **QueryHistory** — 右键历史记录时打开详情弹窗

**DataGrid 为什么没这个问题：** DataGrid 的三个 `@contextmenu` 处理函数内部已经自行执行了选中逻辑（如 `onHeaderContext` 内调用 `selectColumn`），`@click` 和 `@contextmenu` 双发时执行的是同一个选中操作，无副作用。

## Changes

`apps/desktop/src/App.vue` — 添加 capture 阶段 click 拦截

```ts
document.addEventListener("click", (e) => {
  if (e.ctrlKey) e.stopPropagation();
}, true);
```

利用浏览器事件机制：capture 阶段在 bubble 阶段之前执行，`stopPropagation()` 阻止事件到达目标元素，使得 Vue 的 `@click` 处理函数不触发，而独立的 `contextmenu` 事件不受影响。

## Verification

- [x] ObjectBrowser 表行右键 → 表详情不跳转，右键菜单正常
- [x] SqlLibraryPanel 文件右键 → 文件不打开，右键菜单正常
- [x] QueryHistory 历史记录右键 → 详情弹窗不打开，右键菜单正常
- [x] DataGrid 列标题/行号/转置单元格 → 行为不变（原无此问题）
- [x] 普通左键点击 → 所有组件行为不变
- [x] Pre-commit hooks (oxfmt, lint-staged) pass