### PR TITLE
Chore/ai agent i18n and fix bug

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -355,6 +355,7 @@ function agentEventToStep(event: AgentEvent, index: number): AiAgentStepItem | u
     toolName: event.tool_name,
     toolArgs: event.type === "tool_call_start" ? (event.args as Record<string, unknown>) : undefined,
     toolResult: event.type === "tool_call_end" && !event.is_error ? extractToolResultContent(event.result) : undefined,
+    explainData: event.type === "tool_call_end" ? extractExplainData(event.result) : undefined,
     isError: event.type === "tool_call_end" ? event.is_error : undefined,
   };
 }

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -928,6 +928,10 @@
       autoExecute: "Pronto per l'esecuzione",
       notRequested: "Esecuzione non richiesta",
       skipped: "Non eseguito",
+      callingTool: "Chiamata strumento...",
+      toolDone: "Strumento completato",
+      toolError: "Errore strumento",
+      contextCompacted: "Contesto compresso",
     },
     agentStepTitles: {
       riskCheck: "Controllo rischi: {action} · {category} · {environment} · {reasons}",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -981,6 +981,7 @@ export default {
       callingTool: "ツールを呼び出し中...",
       toolDone: "ツール完了",
       toolError: "ツールエラー",
+      contextCompacted: "コンテキストを圧縮しました",
     },
     agentStepTitles: {
       riskCheck: "リスクチェック: {action} · {category} · {environment} · {reasons}",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -928,6 +928,10 @@
       autoExecute: "Pronto para executar",
       notRequested: "Execução não solicitada",
       skipped: "Não executado",
+      callingTool: "Chamando ferramenta...",
+      toolDone: "Ferramenta concluída",
+      toolError: "Erro da ferramenta",
+      contextCompacted: "Contexto compactado",
     },
     agentStepTitles: {
       riskCheck: "Verificação de risco: {action} · {category} · {environment} · {reasons}",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -907,6 +907,10 @@
       autoExecute: "準備執行",
       notRequested: "未請求執行",
       skipped: "未執行",
+      callingTool: "正在調用工具...",
+      toolDone: "工具調用完成",
+      toolError: "工具調用出錯",
+      contextCompacted: "上下文已壓縮",
     },
     agentStepTitles: {
       riskCheck: "風險檢查：{action} · {category} · {environment} · {reasons}",


### PR DESCRIPTION
## Summary

Two fixes for the AI Agent Loop + Tool Calling Upgrade:

1. i18n: Add missing agent tool step translations across 4 locales
2. Bug fix: Propagate explainData to agent step items for ExplainPlanViewer rendering

## Changes

1. i18n — Missing agent tool step translations

The callingTool, toolDone, toolError, and contextCompacted keys were missing from zh-TW, pt-BR, it, and ja locales. ja was also missing contextCompacted.

┌────────────────────────────────────────┬───────────┐
│                  File                  │ Additions │
├────────────────────────────────────────┼───────────┤
│ apps/desktop/src/i18n/locales/zh-TW.ts │ +4 lines  │
├────────────────────────────────────────┼───────────┤
│ apps/desktop/src/i18n/locales/pt-BR.ts │ +4 lines  │
├────────────────────────────────────────┼───────────┤
│ apps/desktop/src/i18n/locales/it.ts    │ +4 lines  │
├────────────────────────────────────────┼───────────┤
│ apps/desktop/src/i18n/locales/ja.ts    │ +1 line   │
└────────────────────────────────────────┴───────────┘

2. Bug fix — explainData not propagated

The explain_query tool correctly generates and executes EXPLAIN SQL on the backend, but the frontend's agentEventToStep() never extracted explain_data from the event, so <ExplainPlanViewer> never rendered. Users only saw raw text instead of the execution plan visualization.

┌────────────────────────────────────────────────────┬─────────┐
│                        File                        │ Change  │
├────────────────────────────────────────────────────┼─────────┤
│ apps/desktop/src/components/editor/AiAssistant.vue │ +1 line │
└────────────────────────────────────────────────────┴─────────┘

## Testing

- Switch locale to zh-TW / pt-BR / it / ja — agent tool call steps in AI assistant should display translated labels instead of falling back to English
- Trigger explain_query via the AI agent — the ExplainPlanViewer should now render the structured execution plan