### PR TITLE
fix(i18n): add missing common.done key used by SchemaDiffOptionsPanel (#1292)

### DIFF
--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -804,6 +804,7 @@
     cancel: "Cancel",
     save: "Save",
     more: "More",
+    done: "Done",
   },
   explain: {
     title: "Explain Plan",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -691,6 +691,7 @@
     stopping: "Deteniendo...",
     close: "Cerrar",
     more: "Más",
+    done: "Listo",
   },
   explain: {
     title: "Plan de ejecución",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -751,6 +751,7 @@
     stopping: "Interruzione...",
     close: "Chiudi",
     more: "Altro",
+    done: "Fatto",
   },
   explain: {
     title: "Piano di Spiegazione",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -751,6 +751,7 @@
     stopping: "Parando...",
     close: "Fechar",
     more: "Mais",
+    done: "Concluído",
   },
   explain: {
     title: "Plano de Execução",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -803,6 +803,7 @@
     cancel: "取消",
     save: "保存",
     more: "更多",
+    done: "完成",
   },
   explain: {
     title: "执行计划",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -730,6 +730,7 @@
     stopping: "正在停止……",
     close: "關閉",
     more: "更多",
+    done: "完成",
   },
   explain: {
     title: "執行計畫",


### PR DESCRIPTION
## Problem

Closes #1292

「比较架构-选项」窗口的「完成」按钮显示 `common.done` 裸 key，因为 `common.done` 在所有语言文件中都缺失。

## Changes

在 6 个语言文件的 `common` 分区新增 `done` key。

## Verification

- [x] 按钮不再显示 raw key
- [x] vue-tsc 类型检查通过