### PR TITLE
feat: add query editor view data context action

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -762,9 +762,9 @@ function openSavedSqlFromWelcome(fileId: string) {
   toast(t("welcome.fileOpened", { name: file.name }), 2000);
 }
 
-async function onClickTable(tableName: string) {
+function tableTargetFromActiveTab(tableName: string) {
   const tab = activeTab.value;
-  if (!tab) return;
+  if (!tab) return null;
   const connectionId = tab.connectionId;
   let database = tab.database;
   let schema = tab.schema;
@@ -784,8 +784,24 @@ async function onClickTable(tableName: string) {
     }
   }
 
+  return { connectionId, database, schema, tableName: rawTableName };
+}
+
+async function onClickTable(tableName: string) {
+  const target = tableTargetFromActiveTab(tableName);
+  if (!target) return;
   try {
-    await openTableTarget({ connectionId, database, schema, tableName: rawTableName }, { tableInfoTab: "ddl" });
+    await openTableTarget(target, { tableInfoTab: "ddl" });
+  } catch (e: any) {
+    toast(t("connection.connectFailed", { message: translateBackendError(t, e?.message || String(e)) }), 5000);
+  }
+}
+
+async function onViewTableData(tableName: string) {
+  const target = tableTargetFromActiveTab(tableName);
+  if (!target) return;
+  try {
+    await openTableTarget(target);
   } catch (e: any) {
     toast(t("connection.connectFailed", { message: translateBackendError(t, e?.message || String(e)) }), 5000);
   }
@@ -1255,6 +1271,7 @@ onUnmounted(() => {
                     @sort="onSort"
                     @execute-sql="onExecuteSql"
                     @click-table="onClickTable"
+                    @view-table-data="onViewTableData"
                     @open-object-table="
                       (target) =>
                         activeTab &&

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, onActivated, onDeactivated, watch, shallowRef, computed, nextTick } from "vue";
-import { Play, Copy, TextSelect } from "@lucide/vue";
+import { Play, Copy, Table2, TextSelect } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import type { CompletionContext } from "@codemirror/autocomplete";
 import type { EditorView as EditorViewType } from "@codemirror/view";
@@ -35,6 +35,7 @@ import { normalizeShortcutSettings, shortcutToCodeMirrorKey } from "@/lib/shortc
 import { trimmedSelectionLayer } from "@/lib/codemirrorTrimmedSelectionLayer";
 import { selectionMatchOccurrences } from "@/lib/codemirrorSelectionMatches";
 import { isSchemaAware, isSingleDatabase } from "@/lib/databaseFeatureSupport";
+import { qualifiedTableNameAtSqlPosition } from "@/lib/queryCursorTableTarget";
 import * as api from "@/lib/api";
 import { areSqlSemanticDiagnosticsEqual, buildSqlParserErrorDiagnostic, buildSqlSemanticDiagnostics, shouldRunSqlSemanticDiagnostics, type SqlSemanticDiagnostic } from "@/lib/sqlSemanticDiagnostics";
 import { buildRedisSyntaxDiagnostics, shouldRunRedisDiagnostics } from "@/lib/redisSyntaxDiagnostics";
@@ -66,6 +67,7 @@ const emit = defineEmits<{
   execute: [sql: string];
   save: [];
   clickTable: [tableName: string];
+  viewTableData: [tableName: string];
   clickColumn: [columns: Array<{ name: string; table: string; schema?: string }>, error?: string | undefined];
   closeColumnPanel: [];
   viewportChange: [viewport: { scrollTop: number; scrollLeft: number }];
@@ -141,6 +143,7 @@ const isGestureZooming = ref(false);
 const searchPanelRef = ref<InstanceType<typeof EditorSearchPanel>>();
 const selectedSql = ref("");
 const executableSql = ref("");
+const contextTableName = ref<string | null>(null);
 
 const hasSelectedSql = computed(() => selectedSql.value.trim().length > 0);
 const canCopySelectedSql = computed(() => selectedSql.value.length > 0);
@@ -294,6 +297,12 @@ function syncContextMenuState(currentView: EditorViewType) {
   executableSql.value = executableSqlFromView(currentView);
 }
 
+function syncContextMenuStateAtEvent(currentView: EditorViewType, event: MouseEvent) {
+  syncContextMenuState(currentView);
+  const pos = currentView.posAtCoords({ x: event.clientX, y: event.clientY });
+  contextTableName.value = pos == null ? null : qualifiedTableNameAtSqlPosition(currentView.state.doc.toString(), pos);
+}
+
 function focusEditor() {
   view.value?.focus();
 }
@@ -352,6 +361,12 @@ function selectAllSqlFromContextMenu() {
   focusEditor();
 }
 
+function openTableFromContextMenu() {
+  if (!contextTableName.value) return;
+  emit("viewTableData", contextTableName.value);
+  focusEditor();
+}
+
 function selectSqlLineFromGutter(currentView: EditorViewType, line: { from: number; to: number }, event: Event): boolean {
   if (!(event instanceof MouseEvent) || event.button !== 0) return false;
   event.preventDefault();
@@ -370,6 +385,12 @@ const contextMenuItems = computed<ContextMenuItem[]>(() => [
     action: executeFromContextMenu,
     disabled: !canExecuteContextSql.value,
     icon: Play,
+  },
+  {
+    label: t("contextMenu.viewData"),
+    action: openTableFromContextMenu,
+    disabled: !contextTableName.value,
+    icon: Table2,
   },
   { label: "", separator: true },
   {
@@ -2205,7 +2226,7 @@ defineExpose({ openSearch, openReplace, scrollCursorIntoView });
         class="h-full w-full overflow-hidden"
         @contextmenu="
           (e: MouseEvent) => {
-            if (view) syncContextMenuState(view);
+            if (view) syncContextMenuStateAtEvent(view, e);
             onContextMenu(e);
           }
         "

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -116,6 +116,7 @@ const emit = defineEmits<{
   sort: [column: string, columnIndex: number, direction: "asc" | "desc" | null, whereInput?: string];
   executeSql: [sql: string];
   clickTable: [tableName: string];
+  viewTableData: [tableName: string];
   openObjectTable: [target: { tableName: string; schema?: string }];
   objectSchemaChange: [schema: string | undefined];
   structureEditorSaved: [commentChanged: boolean];
@@ -428,6 +429,10 @@ function onHandleClickTable(tableName: string) {
   emit("clickTable", tableName);
 }
 
+function onHandleViewTableData(tableName: string) {
+  emit("viewTableData", tableName);
+}
+
 function onHandleCloseColumnPanel() {
   showColumnInfo.value = false;
   columnInfoColumns.value = [];
@@ -520,6 +525,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget });
               @execute="emit('execute')"
               @save="emit('saveSql')"
               @click-table="onHandleClickTable"
+              @view-table-data="onHandleViewTableData"
               @click-column="onHandleClickColumn"
               @close-column-panel="onHandleCloseColumnPanel"
             />

--- a/apps/desktop/src/lib/queryCursorTableTarget.ts
+++ b/apps/desktop/src/lib/queryCursorTableTarget.ts
@@ -134,6 +134,12 @@ export function queryCursorTableCandidate(tab: QueryTab | undefined | null, data
   return { connectionId: tab.connectionId, database, schema, tableName };
 }
 
+export function qualifiedTableNameAtSqlPosition(sql: string, pos: number): string | null {
+  const parts = extractQualifiedIdentifierPartsAt(sql, pos).map((part) => part.value);
+  if (parts.length === 0) return null;
+  return parts.join(".");
+}
+
 export function queryContextTargetFromCandidate(tab: QueryTab | undefined | null, candidate?: QueryCursorTableCandidate | null): ActiveTabSidebarTarget | null {
   if (!tab || tab.mode !== "query" || !tab.connectionId || !tab.database) return null;
   return {

--- a/packages/app-tests/queryCursorTableTarget.test.ts
+++ b/packages/app-tests/queryCursorTableTarget.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { extractQualifiedIdentifierPartsAt, findLoadedTableTargetForCandidate, queryContextTargetFromCandidate, queryCursorTableCandidate } from "../../apps/desktop/src/lib/queryCursorTableTarget.ts";
+import { extractQualifiedIdentifierPartsAt, findLoadedTableTargetForCandidate, qualifiedTableNameAtSqlPosition, queryContextTargetFromCandidate, queryCursorTableCandidate } from "../../apps/desktop/src/lib/queryCursorTableTarget.ts";
 import type { QueryTab, TreeNode } from "../../apps/desktop/src/types/database.ts";
 
 function queryTab(sql: string, head: number, schema = "public"): QueryTab {
@@ -31,6 +31,14 @@ test("extracts the qualified identifier under or after the cursor", () => {
     extractQualifiedIdentifierPartsAt('select * from "public"."order"', 26).map((part) => part.value),
     ["public", "order"],
   );
+});
+
+test("resolves the table name at a context-menu position", () => {
+  const sql = "select * from reporting.users where id = 1";
+
+  assert.equal(qualifiedTableNameAtSqlPosition(sql, sql.indexOf("users") + 2), "reporting.users");
+  assert.equal(qualifiedTableNameAtSqlPosition("select * from users", "select * from users".length), "users");
+  assert.equal(qualifiedTableNameAtSqlPosition(sql, sql.indexOf("where") + 1), null);
 });
 
 test("builds schema-aware cursor table candidates", () => {


### PR DESCRIPTION
## Summary
- add a View Data action to the query editor context menu when right-clicking a table identifier
- route the action through the existing table data navigation flow while keeping Ctrl/Cmd-click table navigation unchanged
- add coverage for resolving qualified table names at a context-menu position

## Tests
- ./node_modules/.bin/vitest run packages/app-tests/queryCursorTableTarget.test.ts
- ./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json
- ./node_modules/.bin/oxfmt --check apps/desktop/src/App.vue apps/desktop/src/components/layout/ContentArea.vue apps/desktop/src/components/editor/QueryEditor.vue apps/desktop/src/lib/queryCursorTableTarget.ts packages/app-tests/queryCursorTableTarget.test.ts
- ./node_modules/.bin/oxlint --vue-plugin apps/desktop/src/App.vue apps/desktop/src/components/layout/ContentArea.vue apps/desktop/src/components/editor/QueryEditor.vue apps/desktop/src/lib/queryCursorTableTarget.ts
- env PATH=/Users/spencerchang/rust-lab/dbx/node_modules/.bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/bin/node scripts/run-check.mjs