### PR TITLE
fix(redis): unify aggregated INFO output format in console

### DIFF
--- a/apps/desktop/src/components/redis/RedisKeyBrowser.vue
+++ b/apps/desktop/src/components/redis/RedisKeyBrowser.vue
@@ -25,7 +25,7 @@ import { buildRedisKeyTree, collectExpandedGroupIds, collectRedisGroupKeyRaws, f
 import { classifyRedisCommandSafety } from "@/lib/redisCommandSafety";
 import { isRedisMutatingCommand } from "@/lib/redisCommandTable";
 import { isRedisClearScreenCommand, nextRedisCommandDb, redisKeyTextToRaw } from "@/lib/redisCommandSession";
-import { formatRedisCommandResult, formatRedisStringValue } from "@/lib/redisValuePresentation";
+import { formatRedisConsoleValue, formatRedisStringValue } from "@/lib/redisValuePresentation";
 import { isCancelSearchShortcut } from "@/lib/keyboardShortcuts";
 import { useEditorFontFamilyStyle } from "@/composables/useEditorFontFamilyStyle";
 import { useToast } from "@/composables/useToast";
@@ -434,7 +434,7 @@ async function runRedisCommand(command: string) {
     appendCommandHistory({
       prompt,
       command,
-      output: formatRedisCommandResult(result.value),
+      output: formatRedisConsoleValue(result.value),
       error: false,
     });
     // The db this command ran on — capture before nextRedisCommandDb() advances it.

--- a/apps/desktop/src/lib/redisValuePresentation.ts
+++ b/apps/desktop/src/lib/redisValuePresentation.ts
@@ -57,6 +57,34 @@ export function formatRedisCommandResult(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
+/**
+ * Detect if a value is a cluster-aggregated INFO response:
+ * `[[addr, infoText], ...]` where each `infoText` starts with `"# "`
+ * (the INFO section marker). This is the format produced by the backend
+ * in `redis_driver.rs::execute_command` for cluster-mode INFO.
+ */
+function isRedisClusterInfoValue(value: unknown): value is [string, string][] {
+  return Array.isArray(value) && value.length > 0 && (value as unknown[]).every((item) => Array.isArray(item) && item.length === 2 && typeof item[0] === "string" && typeof item[1] === "string" && item[1].startsWith("# "));
+}
+
+/**
+ * Format a Redis command result for the **command console terminal** (RedisKeyBrowser.vue).
+ * Unlike `formatRedisCommandResult` (used by the query result table UI), this function
+ * renders cluster-aggregated INFO output as plain text (not JSON), matching the native
+ * redis-cli display style.
+ *
+ * - Cluster INFO `[[addr, infoText], ...]` → `"{addr}\n{infoText}"` per node, joined by newlines.
+ * - Plain string → passthrough (handles single-node INFO text correctly).
+ * - Everything else → JSON.stringify (arrays, objects, etc.).
+ */
+export function formatRedisConsoleValue(value: unknown): string {
+  if (isRedisClusterInfoValue(value)) {
+    return value.map(([addr, info]) => `${addr}\n${info}`).join("\n");
+  }
+  if (typeof value === "string") return formatRedisStringValue(value);
+  return JSON.stringify(value, null, 2);
+}
+
 function formatRedisJsonString(value: string): string | null {
   return parseRedisJsonDetail(value)?.formattedText ?? null;
 }

--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -1014,6 +1014,7 @@ where
     // Special handling for INFO command in cluster mode.
     // redis-rs ClusterConnection routes INFO to all primaries and
     // aggregates the results as a Map(node_addr → full_info_text).
+
     // We detect this pattern and return it as an array of
     // [node_addr, info_text] pairs, which the frontend renders
     // as a two-column (index → node_addr, value → info_text) table.
@@ -1036,6 +1037,7 @@ where
                     })
                     .collect();
                 return Ok(RedisCommandResult { command, safety, value: serde_json::Value::Array(pairs) });
+
             }
         }
     }


### PR DESCRIPTION
## Purpose
unify aggregated INFO output format in console

## Changes
- **`apps/desktop/src/components/redis/RedisKeyBrowser.vue`**  
- **`apps/desktop/src/lib/redisValuePresentation.ts`**  
