### PR TITLE
fix(connection): preload visible database list on dialog open for accurate summary count (#1347)

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -1625,6 +1625,28 @@ function resetVisibleDatabaseDraftState() {
   visibleDatabaseShowSystem.value = false;
 }
 
+/** Silently load database names so the summary count shows a real total. */
+async function preloadVisibleDatabaseNames() {
+  if (!ensureConnectionHostResolvedFromUrl()) return;
+  if (visibleDatabaseNames.value.length > 0) return;
+  isLoadingVisibleDatabases.value = true;
+  const draftId = buildDraftVisibleDatabasesConnectionId(uuid());
+  const draftConfig = {
+    ...connectionConfigForSubmit(draftId),
+    id: draftId,
+    one_time: true,
+  };
+  try {
+    await api.connectDb(draftConfig);
+    visibleDatabaseNames.value = await loadVisibleDatabaseNames(draftId, draftConfig);
+  } catch {
+    // silently fail
+  } finally {
+    await api.disconnectDb(draftId).catch(() => undefined);
+    isLoadingVisibleDatabases.value = false;
+  }
+}
+
 async function openVisibleDatabasesPicker() {
   if (!ensureConnectionHostResolvedFromUrl()) return;
   if (!canChooseVisibleDatabases.value || isLoadingVisibleDatabases.value) return;
@@ -1806,6 +1828,12 @@ watch(
       void loadJdbcDrivers();
       void loadAgentDrivers();
     }
+    // Preload database names so the summary count is accurate right away.
+    void nextTick(() => {
+      if (canChooseVisibleDatabases.value && hasVisibleDatabaseFilter.value) {
+        void preloadVisibleDatabaseNames();
+      }
+    });
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Problem

Closes #1347

编辑已有连接时，底部「已选择」按钮的摘要显示总数始终为 0，直到手动点击该按钮触发数据库列表加载后才会更新为正确数字。

## Changes

- 新增 `preloadVisibleDatabaseNames()`，在编辑弹窗打开时静默连接数据库并拉取库名列表
- 预加载期间按钮展示 loading 状态，与手动点击行为一致

## Verification

- [x] 编辑已配置可见数据库的连接，按钮不再显示「已选择 X/0」
- [x] 预加载期间按钮展示 loading 状态，不可点击
- [x] vue-tsc 类型检查通过
- [x] oxlint 0 errors