### PR TITLE
fix(mcp): route ssh transport layers through desktop bridge

### DIFF
--- a/packages/node-core/src/database.ts
+++ b/packages/node-core/src/database.ts
@@ -149,6 +149,10 @@ async function getMysqlPool(config: ConnectionConfig): Promise<import("mysql2/pr
 
 type ProxyLayer = { type: "proxy" } & ProxyTunnelConfig;
 
+function hasActiveSshLayer(config: ConnectionConfig): boolean {
+  return config.transport_layers?.some((layer) => layer.type === "ssh" && layer.enabled !== false && !!layer.host) ?? false;
+}
+
 function firstProxyLayer(config: ConnectionConfig): ProxyLayer | undefined {
   return config.transport_layers?.find((layer): layer is ProxyLayer => layer.type === "proxy" && layer.enabled !== false && !!layer.host);
 }
@@ -502,6 +506,17 @@ async function rqliteRequest(config: ConnectionConfig, endpoint: "/db/query" | "
 }
 
 export async function executeQuery(config: ConnectionConfig, sql: string, options?: QueryOptions): Promise<QueryResult> {
+  if (hasActiveSshLayer(config)) {
+    const result = await withTimeout(
+      bridgeDataRequest<BridgeQueryResult>("/data/execute-query", {
+        connection_name: config.name,
+        database: config.database || "",
+        sql,
+      }),
+      resolveTimeoutMs(options),
+    );
+    return convertBridgeQueryResult(result, options);
+  }
   if (config.db_type === "mongodb") {
     const find = parseMongoFindCommand(sql);
     if (find) {
@@ -561,7 +576,7 @@ export async function listTables(config: ConnectionConfig, schema?: string): Pro
     const result = await query(config, `SELECT name, type FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' ORDER BY name`);
     return result.rows.map((r) => ({ name: String(r.name || ""), type: String(r.type || "table") }));
   }
-  if (!isDirectQueryType(config.db_type)) {
+  if (hasActiveSshLayer(config) || !isDirectQueryType(config.db_type)) {
     const tables = await bridgeDataRequest<BridgeTableInfo[]>("/data/list-tables", {
       connection_name: config.name,
       database: config.database || "",
@@ -594,7 +609,7 @@ export async function describeTable(config: ConnectionConfig, table: string, sch
       comment: null,
     }));
   }
-  if (!isDirectQueryType(config.db_type)) {
+  if (hasActiveSshLayer(config) || !isDirectQueryType(config.db_type)) {
     const columns = await bridgeDataRequest<BridgeColumnInfo[]>("/data/describe-table", {
       connection_name: config.name,
       database: config.database || "",

--- a/packages/node-core/tests/sqlite-direct.test.ts
+++ b/packages/node-core/tests/sqlite-direct.test.ts
@@ -21,6 +21,30 @@ function sqliteConfig(path: string): ConnectionConfig {
   };
 }
 
+function mysqlSshConfig(): ConnectionConfig {
+  return {
+    id: "mysql-ssh-test",
+    name: "mysql-over-ssh",
+    db_type: "mysql",
+    host: "10.0.0.10",
+    port: 3306,
+    username: "root",
+    password: "secret",
+    ssl: false,
+    transport_layers: [
+      {
+        type: "ssh",
+        id: "bastion",
+        enabled: true,
+        host: "bastion.example.com",
+        port: 22,
+        user: "root",
+        password: "ssh-secret",
+      },
+    ],
+  };
+}
+
 test("queries SQLite connections without the DBX bridge", async () => {
   const dir = mkdtempSync(join(tmpdir(), "dbx-mcp-sqlite-"));
   const path = join(dir, "app.db");
@@ -82,6 +106,22 @@ test("lists and describes SQLite tables without the DBX bridge", async () => {
       ],
     );
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("routes SSH transport layer connections through the DBX bridge", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "dbx-mcp-bridge-home-"));
+  const originalHome = process.env.HOME;
+  process.env.HOME = dir;
+
+  try {
+    await assert.rejects(() => executeQuery(mysqlSshConfig(), "select 1"), /DBX desktop app is not running/);
+    await assert.rejects(() => listTables(mysqlSshConfig()), /DBX desktop app is not running/);
+    await assert.rejects(() => describeTable(mysqlSshConfig(), "users"), /DBX desktop app is not running/);
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

This is a conservative patch for MCP connections that use SSH `transport_layers`.

The MCP Node backend currently runs direct-query database types such as MySQL through Node clients. That direct path supports proxy layers but does not establish SSH transport layers, while the DBX desktop/Rust bridge already owns the SSH tunnel implementation used by the UI.

This change routes connections with an active SSH transport layer through the DBX desktop bridge for query, table listing, and table description. Non-SSH direct connections keep using the existing direct Node path.

Fixes #1329.

## Tests

- `pnpm --filter @dbx-app/node-core exec vitest run tests/sqlite-direct.test.ts`
- `pnpm --filter @dbx-app/node-core build`
- `pnpm --filter @dbx-app/node-core test`