### PR TITLE
fix(mysql): fix garbled Chinese in sidebar table comment (double enco…

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -992,7 +992,9 @@ pub async fn list_tables(pool: &MySqlPool, database: &str) -> Result<Vec<TableIn
             (!name.is_empty()).then_some(TableInfo {
                 name,
                 table_type: get_str_by_name(row, "TABLE_TYPE"),
-                comment: get_opt_str(row, "TABLE_COMMENT").filter(|s| !s.is_empty()),
+                comment: get_opt_str(row, "TABLE_COMMENT")
+                    .map(|s| fix_potential_double_encoding(&s))
+                    .filter(|s| !s.is_empty()),
                 parent_schema: None,
                 parent_name: None,
             })
@@ -1029,7 +1031,9 @@ async fn list_table_status_show(pool: &MySqlPool, database: &str) -> Result<Hash
             (
                 get_str_by_name(row, "Name"),
                 TableStatusMeta {
-                    comment: get_opt_metadata_string(row, "Comment").filter(|s| !s.is_empty()),
+                    comment: get_opt_metadata_string(row, "Comment")
+                        .map(|s| fix_potential_double_encoding(&s))
+                        .filter(|s| !s.is_empty()),
                     created_at: get_opt_metadata_string(row, "Create_time"),
                     updated_at: get_opt_metadata_string(row, "Update_time"),
                 },
@@ -1152,7 +1156,9 @@ fn row_to_object(row: &mysql_async::Row, database: &str) -> ObjectInfo {
         name: get_str_by_name(row, "object_name"),
         object_type: get_str_by_name(row, "object_type"),
         schema: Some(database.to_string()),
-        comment: get_opt_str(row, "object_comment").filter(|s| !s.is_empty()),
+        comment: get_opt_str(row, "object_comment")
+            .map(|s| fix_potential_double_encoding(&s))
+            .filter(|s| !s.is_empty()),
         created_at: get_opt_str(row, "created_at"),
         updated_at: get_opt_str(row, "updated_at"),
         parent_schema: get_opt_str(row, "parent_schema"),


### PR DESCRIPTION
## Problem

When connecting to a MySQL database with Latin1 charset settings, the sidebar tree displays garbled Chinese text for table comments. For example, `OA部门同步表` renders as `OAéƒ¨é—¨åŒæ­¥è¡¨`.

This is the same UTF-8 double-encoding issue that was previously fixed for column comments in c21b5d0, but the table-level comment fields in the sidebar were not covered by that fix.

## Root Cause

MySQL may return `TABLE_COMMENT` / `Comment` / `object_comment` values as Latin1-decoded bytes instead of proper UTF-8. The sidebar tree reads these comment fields directly via `list_tables()`, `list_table_status_show()`, and `row_to_object()`, none of which applied `fix_potential_double_encoding()`.

## Fix

Apply the existing `fix_potential_double_encoding()` helper to the 3 remaining comment fields in `crates/dbx-core/src/db/mysql.rs`:| Function | Field | Line || --- | --- | --- |
| `list_tables()` | `TABLE_COMMENT` | 992 |
| `list_table_status_show()` | `Comment` | 1031 |
| `row_to_object()` | `object_comment` | 1156 |

This is consistent with the approach already used for column comments.

## Screenshots

Before (sidebar):

<img width="568" height="546" alt="ScreenShot_2026-06-17_185836_803" src="https://github.com/user-attachments/assets/4d212818-7427-4f3b-8303-febe1ddaa1c1" />

```text
OAéƒ¨é—¨åŒæ­¥è¡¨
```

After (sidebar):

<img width="497" height="735" alt="ScreenShot_2026-06-17_191315_695" src="https://github.com/user-attachments/assets/66e533ff-df52-4fc5-b5fd-6a60ca1bfdd4" />

```text
OA部门同步表
```

## Testing

- Connected to MySQL 5.7 database with Chinese table comments
- Verified sidebar tree now displays Chinese comments correctly
- Verified table structure panel (previously fixed) still works correctly
