### PR TITLE
fix(connection): reload database children when updating expanded connection (#1441)

### DIFF
--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -719,6 +719,10 @@ export const useConnectionStore = defineStore("connection", () => {
     connectedIds.value.delete(config.id);
     invalidateCompletionCache(config.id);
     clearLoadedChildrenCache(config.id);
+    const node = findNode(treeNodes.value, config.id);
+    if (node?.isExpanded) {
+      await reloadConnectionDatabaseChildren(config.id);
+    }
   }
 
   async function setDefaultDatabase(connectionId: string, database: string) {


### PR DESCRIPTION
## Problem

Closes #1441

编辑连接弹窗中修改「选择可见数据库」的配置后保存，左侧侧边栏树中的数据库列表不会自动刷新，仍然显示编辑前的旧数据。

**原因：** `updateConnection` 函数在清除 `loadedChildrenCache` 后未对已展开的节点重新加载子节点。

## Changes

- 在 `updateConnection` 中增加判断：如果连接节点在树中处于展开状态，保存配置后自动重新加载数据库列表

## Verification

- [x] 编辑连接 → 修改可见数据库 → 保存 → 树节点自动刷新
- [x] 编辑连接 → 仅修改名称 → 保存 → 树节点不重新加载（仅在展开时加载）
- [x] vue-tsc 类型检查通过