### PR TITLE
fix(ui): avoid dropdown open updates during unmount

### DIFF
--- a/apps/desktop/src/components/ui/LightDropdownMenu.vue
+++ b/apps/desktop/src/components/ui/LightDropdownMenu.vue
@@ -89,6 +89,7 @@ const internalOpen = ref(false);
 const x = ref(0);
 const y = ref(0);
 const minWidth = ref(0);
+let listenersAttached = false;
 
 const isOpen = computed(() => props.open ?? internalOpen.value);
 
@@ -108,10 +109,12 @@ function setOpen(value: boolean) {
 }
 
 function removeMenuListeners() {
+  if (!listenersAttached) return;
   document.removeEventListener("pointerdown", onOutsidePointerDown, true);
   document.removeEventListener("keydown", onKeydown);
   window.removeEventListener("scroll", close, true);
   window.removeEventListener("resize", close);
+  listenersAttached = false;
 }
 
 function close() {
@@ -152,10 +155,12 @@ function openMenu() {
   updatePosition();
   setOpen(true);
   nextTick(fitPositionToViewport);
+  removeMenuListeners();
   document.addEventListener("pointerdown", onOutsidePointerDown, true);
   document.addEventListener("keydown", onKeydown);
   window.addEventListener("scroll", close, true);
   window.addEventListener("resize", close);
+  listenersAttached = true;
 }
 
 function toggle() {
@@ -227,7 +232,9 @@ function selectItem(item: LightDropdownMenuItem) {
   }
 }
 
-onBeforeUnmount(close);
+onBeforeUnmount(() => {
+  removeMenuListeners();
+});
 
 watch(
   () => props.open,


### PR DESCRIPTION
## Summary

修复 `LightDropdownMenu` 在组件卸载阶段仍通过 `close()` 触发 open 状态更新的问题。

## Background

这个问题是在实现和验证 #1453 过程中发现的。

在为二进制数据单元格详情补充 Hex Viewer 时，相关入口会复用既有的轻量下拉菜单组件。测试过程中发现，某些下拉菜单相关组件在 Tauri 桌面端被卸载时，原先的 `onBeforeUnmount(close)` 会继续触发 open 状态更新，可能导致 Vue patch 阶段出现异常，并表现为界面冻结。

这个问题并不是 Hex Viewer 功能本身的实现逻辑导致的，而是既有 UI 组件在 unmount 阶段仍修改状态的行为被新功能路径暴露出来。为了避免把通用组件稳定性修复和 #1453 的功能实现揉在同一个 PR 里，本 PR 单独修复该问题。

## Changes

- 为 `LightDropdownMenu` 记录全局事件监听器是否已注册。
- 在打开菜单前先清理可能残留的监听器，避免重复注册。
- 在组件卸载时只移除全局事件监听器，不再通过 `close()` 触发 open 状态更新。

## Test

- `pnpm exec oxfmt --check apps/desktop/src/components/ui/LightDropdownMenu.vue`
