### PR TITLE
fix(postgre): Fix the data type syntax when creating tables

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1485,7 +1485,7 @@ onUnmounted(() => {
           <div v-if="showSqlLibraryPanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: sqlLibraryWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startSqlLibraryResize" />
             <div class="h-full min-h-0 overflow-hidden">
-              <SqlLibraryPanel @close="showSqlLibraryPanel = false" />
+              <SqlLibraryPanel @close="toggleSqlLibrary" />
             </div>
           </div>
         </div>

--- a/apps/desktop/src/components/layout/SqlLibraryPanel.vue
+++ b/apps/desktop/src/components/layout/SqlLibraryPanel.vue
@@ -779,6 +779,7 @@ function showDropInside(targetId: string) {
         <template #default="{ onContextMenu }">
           <div
             class="h-full"
+            @contextmenu.capture="contextTarget = 'panel'"
             @contextmenu.prevent="
               contextTarget = 'panel';
               onContextMenu($event);
@@ -794,6 +795,7 @@ function showDropInside(targetId: string) {
                 @mousemove="updateDropTarget($event, row.folder.id, 'folder')"
                 @mouseleave="clearDropTarget(row.folder.id)"
                 @click="toggleFolder(row.folder.id)"
+                @contextmenu.capture="contextTarget = row.folder"
                 @contextmenu.prevent="
                   contextTarget = row.folder;
                   onContextMenu($event);
@@ -829,6 +831,7 @@ function showDropInside(targetId: string) {
                 @mousemove="updateDropTarget($event, row.file.id, 'file')"
                 @mouseleave="clearDropTarget(row.file.id)"
                 @click="openFile(row.file)"
+                @contextmenu.capture="contextTarget = row.file"
                 @contextmenu.prevent="
                   contextTarget = row.file;
                   onContextMenu($event);
@@ -872,6 +875,7 @@ function showDropInside(targetId: string) {
                 @mousemove="updateDropTarget($event, file.id, 'file')"
                 @mouseleave="clearDropTarget(file.id)"
                 @click="openFile(file)"
+                @contextmenu.capture="contextTarget = file"
                 @contextmenu.prevent="
                   contextTarget = file;
                   onContextMenu($event);

--- a/apps/desktop/src/components/ui/dialog/DialogDescription.vue
+++ b/apps/desktop/src/components/ui/dialog/DialogDescription.vue
@@ -13,7 +13,7 @@ const forwardedProps = useForwardProps(delegatedProps);
 </script>
 
 <template>
-  <DialogDescription data-slot="dialog-description" v-bind="forwardedProps" :class="cn('text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3', props.class)">
+  <DialogDescription data-slot="dialog-description" v-bind="forwardedProps" :style="{ wordBreak: 'break-all' }" :class="cn('text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3', props.class)">
     <slot />
   </DialogDescription>
 </template>

--- a/apps/desktop/src/lib/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/tableStructureEditorState.ts
@@ -374,6 +374,53 @@ export const QUESTDB_TYPE_LENGTHS: Record<string, string> = {
 
 export const DEFAULT_TYPE_LENGTH_DISABLES: string[] = [];
 
+export const POSTGRES_TYPE_LENGTH_DISABLES: string[] = [
+  "bigint",
+  "int8",
+  "bigserial",
+  "serial8",
+  "boolean",
+  "bool",
+  "box",
+  "bytea",
+  "cidr",
+  "circle",
+  "date",
+  "double precision",
+  "float",
+  "float8",
+  "inet",
+  "integer",
+  "int",
+  "int4",
+  "json",
+  "jsonb",
+  "line",
+  "lseg",
+  "macaddr",
+  "macaddr8",
+  "money",
+  "path",
+  "pg_lsn",
+  "pg_snapshot",
+  "point",
+  "polygon",
+  "real",
+  "float4",
+  "smallint",
+  "int2",
+  "smallserial",
+  "serial2",
+  "serial",
+  "serial4",
+  "text",
+  "tsquery",
+  "tsvector",
+  "txid_snapshot",
+  "uuid",
+  "xml",
+];
+
 export function parseExtraToColumnExtra(extra: string | null | undefined, databaseType?: DatabaseType): ColumnExtra {
   const result: ColumnExtra = {};
   if (!extra) return result;
@@ -610,6 +657,9 @@ export function combineDataType(baseType: string, params: string): string {
 }
 
 export function combineDataTypeForDatabase(dbType: DatabaseType | undefined, baseType: string, params: string): string {
+  if (isDataTypeLengthDisabled(dbType, baseType)) {
+    return baseType;
+  }
   return combineDataType(baseType, normalizeDataTypeParams(dbType, baseType, params));
 }
 
@@ -673,6 +723,8 @@ export function isDataTypeLengthDisabled(_dbType: DatabaseType | undefined, base
     return key !== "geohash" && key !== "decimal";
   } else if (_dbType === "manticoresearch") {
     return key !== "bit" && key !== "float_vector";
+  } else if (_dbType === "postgres" || _dbType === "gaussdb" || _dbType === "kwdb" || _dbType === "opengauss" || _dbType === "highgo" || _dbType === "vastbase" || _dbType === "kingbase") {
+    return POSTGRES_TYPE_LENGTH_DISABLES.includes(key);
   } else {
     return DEFAULT_TYPE_LENGTH_DISABLES.includes(key);
   }


### PR DESCRIPTION
修复 Postgresq 里面编辑表结构时定长字段包含长度导致语法错误的问题；
例如：
```sql
CREATE TABLE "public"."ttt" (
  "id" bigint(20),
  "name" varchar(255) NOT NULL,
  PRIMARY KEY ("id")
);
```
由于 BIGINT 为固定长度, 上述语句会报错。 `bigint(20)` 改为 `bigint` 后即正常。

其他修复:
1、修复Sql库删除脚本提示框长名称不换行的问题 (#1469)
2、修复Sql库面板右键菜单不匹配问题（首次打开Sql库面板， 右键点击SQL文件项目）
3、修复通过关闭按钮关闭SQL库时未保存面板状态的问题