### PR TITLE
fix(postgres): cast owner relkind before reading as text

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -1460,6 +1460,26 @@ const POSTGRES_INDEXES_COMPAT_SQL: &str = "SELECT i.relname AS index_name, \
              GROUP BY i.relname, i.oid, ix.indisunique, ix.indisprimary, ix.indpred, ix.indrelid, am.amname, ix.indkey \
              ORDER BY i.relname";
 
+const POSTGRES_OWNERS_SQL: &str =
+    "SELECT n.nspname, c.relname, c.relkind::text AS relkind, pg_get_userbyid(c.relowner) \
+     FROM pg_class c \
+     JOIN pg_namespace n ON n.oid = c.relnamespace \
+     WHERE n.nspname = $1 \
+       AND c.relkind IN ('r', 'v', 'm', 'S', 'f', 'p')";
+
+fn postgres_owner_object_type(relkind: &str) -> &str {
+    match relkind {
+        "r" => "TABLE",
+        "v" => "VIEW",
+        "m" => "MATERIALIZED_VIEW",
+        "S" => "SEQUENCE",
+        "f" => "FOREIGN TABLE",
+        "p" => "PARTITIONED TABLE",
+        "I" => "PARTITIONED INDEX",
+        _ => relkind,
+    }
+}
+
 async fn list_indexes_with_sql(
     client: &deadpool_postgres::Client,
     sql: &str,
@@ -1703,37 +1723,16 @@ pub async fn list_rules(pool: &Pool, schema: &str) -> Result<Vec<RuleInfo>, Stri
 
 pub async fn list_owners(pool: &Pool, schema: &str) -> Result<Vec<OwnerInfo>, String> {
     let client = pool.get().await.map_err(|e| e.to_string())?;
-    // Filter relkind to exclude indexes, toast tables, and other system objects
-    // for better performance on large databases
-    let stmt = client
-        .prepare_cached(
-            "SELECT n.nspname, c.relname, c.relkind, pg_get_userbyid(c.relowner) \
-             FROM pg_class c \
-             JOIN pg_namespace n ON n.oid = c.relnamespace \
-             WHERE n.nspname = $1 \
-               AND c.relkind IN ('r', 'v', 'm', 'S', 'f', 'p')",
-        )
-        .await
-        .map_err(|e| e.to_string())?;
+    let stmt = client.prepare_cached(POSTGRES_OWNERS_SQL).await.map_err(|e| e.to_string())?;
     let rows = client.query(&stmt, &[&schema]).await.map_err(|e| e.to_string())?;
 
     Ok(rows
         .iter()
         .map(|row| {
             let relkind: String = row.get(2);
-            let object_type = match relkind.as_str() {
-                "r" => "TABLE",
-                "v" => "VIEW",
-                "m" => "MATERIALIZED_VIEW",
-                "S" => "SEQUENCE",
-                "f" => "FOREIGN TABLE",
-                "p" => "PARTITIONED TABLE",
-                "I" => "PARTITIONED INDEX",
-                _ => &relkind,
-            };
             OwnerInfo {
                 object_name: row.get::<_, String>(1),
-                object_type: object_type.to_string(),
+                object_type: postgres_owner_object_type(&relkind).to_string(),
                 owner: row.get::<_, String>(3),
             }
         })
@@ -2178,6 +2177,23 @@ mod tests {
         assert!(POSTGRES_INDEXES_SQL.contains("ix.indnkeyatts"));
         assert!(!POSTGRES_INDEXES_COMPAT_SQL.contains("ix.indnkeyatts"));
         assert!(POSTGRES_INDEXES_COMPAT_SQL.contains("NULL::smallint AS nkeyatts"));
+    }
+
+    #[test]
+    fn postgres_owner_metadata_casts_relkind_to_text() {
+        assert!(POSTGRES_OWNERS_SQL.contains("c.relkind::text AS relkind"));
+        assert!(POSTGRES_OWNERS_SQL.contains("c.relkind IN ('r', 'v', 'm', 'S', 'f', 'p')"));
+    }
+
+    #[test]
+    fn postgres_owner_object_type_maps_relkind_codes() {
+        assert_eq!(postgres_owner_object_type("r"), "TABLE");
+        assert_eq!(postgres_owner_object_type("v"), "VIEW");
+        assert_eq!(postgres_owner_object_type("m"), "MATERIALIZED_VIEW");
+        assert_eq!(postgres_owner_object_type("S"), "SEQUENCE");
+        assert_eq!(postgres_owner_object_type("f"), "FOREIGN TABLE");
+        assert_eq!(postgres_owner_object_type("p"), "PARTITIONED TABLE");
+        assert_eq!(postgres_owner_object_type("?"), "?");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

修复 PostgreSQL Schema Diff 在读取对象所有者信息时可能触发的后端 panic。该问题会导致比较架构流程卡在加载状态，部分环境下表现为 DBX Desktop 崩溃。

## Background

在尝试复现 #1483 时，使用同一个 PostgreSQL 16 实例中的两个数据库进行架构比较，可以稳定触发后端 panic：

```text
error retrieving column 2: error deserializing column 2
```

根因是 owner metadata 查询直接返回了 `pg_class.relkind`。该列是 PostgreSQL 内部 `"char"` 类型，不能直接按 Rust `String` 反序列化。

## Changes

- 将 PostgreSQL owner metadata 查询中的 `c.relkind` 显式转换为 `text`。
- 保留原有 relkind 到对象类型的映射行为。
- 增加单元测试覆盖 SQL cast 和 relkind 映射。

## Test

- `cargo fmt --check`
- `cargo test -p dbx-core postgres_owner --lib`
- `cargo check -p dbx-core -p dbx-web`
- `cargo test -p dbx-core postgres_ --lib`
- 本地 PostgreSQL 16 双数据库 Schema Diff 手动验证：修复前卡住并输出 panic，修复后正常展示比较结果。
