### PR TITLE
feat(app): add amber eye-care theme

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1367,13 +1367,13 @@ onUnmounted(() => {
 
         <div :class="isClassicLayout ? 'app-layout-classic flex-1 flex min-h-0' : 'app-panel-gutter flex-1 flex min-h-0 gap-1 p-1'">
           <AppSidebar v-show="sidebarOpen" ref="appSidebarRef" :sidebar-width="sidebarWidth" :classic-layout="isClassicLayout" @import="dialogs.onImportClick" @export="dialogs.onExportClick" @start-resize="startSidebarResize" @collapse="setSidebarOpen(false)" />
-          <div v-show="!sidebarOpen" class="flex h-full w-8 shrink-0 items-start justify-center border-r bg-background/80 pt-2" :class="isClassicLayout ? '' : 'rounded-md border border-border/80'">
+          <div v-show="!sidebarOpen" class="app-paper-panel flex h-full w-8 shrink-0 items-start justify-center border-r bg-background/80 pt-2" :class="isClassicLayout ? '' : 'rounded-md border border-border/80'">
             <Button variant="ghost" size="icon" class="h-7 w-7" :title="t('sidebar.expand')" :aria-label="t('sidebar.expand')" @click="setSidebarOpen(true)">
               <ChevronsRight class="h-4 w-4" />
             </Button>
           </div>
 
-          <div :class="isClassicLayout ? 'flex-1 min-w-0 overflow-hidden' : 'flex-1 min-w-0 overflow-hidden rounded-md border border-border/80 bg-background'">
+          <div class="app-paper-panel" :class="isClassicLayout ? 'flex-1 min-w-0 overflow-hidden' : 'flex-1 min-w-0 overflow-hidden rounded-md border border-border/80 bg-background'">
             <div class="h-full flex flex-col min-w-0">
               <AppTabBar :show-driver-store="showDriverStore" :agent-driver-update-count="toolbarAgentDriverUpdateCount" @toggle-driver-store="showDriverStore = true" @close-driver-store="showDriverStore = false" @save-tab="handleSaveTab" />
               <DriverStorePage v-if="showDriverStore" class="flex-1 min-h-0" :update-notifications-enabled="updateNotificationsEnabled" @update-count-change="updateAgentDriverUpdateCount" />
@@ -1480,19 +1480,19 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <div v-if="showAiPanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: aiPanelWidth + 'px' }">
+          <div v-if="showAiPanel" class="app-paper-panel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: aiPanelWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startAiPanelResize" />
             <div class="h-full min-h-0 overflow-hidden">
               <AiAssistant v-if="aiPanelReady" ref="aiAssistantRef" :tab="activeTab" :connection="activeConnection" @replace-sql="onAiReplaceSql" @execute-sql="onAiExecuteSql" @request-auto-execute-sql="onAiRequestAutoExecuteSql" @open-explain-plan="onAiOpenExplainPlan" @close="toggleAiPanel" />
             </div>
           </div>
 
-          <div v-if="showHistory" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: historyWidth + 'px' }">
+          <div v-if="showHistory" class="app-paper-panel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: historyWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startHistoryResize" />
             <QueryHistory @restore="restoreHistorySql" @analyze-ai="analyzeHistoryWithAi" @close="showHistory = false" />
           </div>
 
-          <div v-if="showSqlLibraryPanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: sqlLibraryWidth + 'px' }">
+          <div v-if="showSqlLibraryPanel" class="app-paper-panel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: sqlLibraryWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startSqlLibraryResize" />
             <div class="h-full min-h-0 overflow-hidden">
               <SqlLibraryPanel @close="toggleSqlLibrary" />

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -3,7 +3,7 @@ import { ref, watch, shallowRef, computed, onMounted, onUnmounted, nextTick } fr
 import type { Ref } from "vue";
 import type { EditorView as EditorViewType } from "@codemirror/view";
 import { useI18n } from "vue-i18n";
-import { AlertTriangle, CheckCircle2, CircleHelp, Cloud, Copy, Download, ExternalLink, Loader2, Moon, PackageSearch, Pencil, RefreshCw, RotateCcw, Settings, Sun, SunMoon, Terminal, Trash2, Upload, X } from "@lucide/vue";
+import { AlertTriangle, CheckCircle2, CircleHelp, Cloud, Copy, Download, ExternalLink, Eye, Loader2, Moon, PackageSearch, Pencil, RefreshCw, RotateCcw, Settings, Sun, SunMoon, Terminal, Trash2, Upload, X } from "@lucide/vue";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -68,7 +68,7 @@ import { DEFAULT_SQL_SNIPPETS } from "@/lib/sqlCompletion";
 import AiProviderLogo from "@/components/icons/AiProviderLogo.vue";
 import AppLogo from "@/components/icons/AppLogo.vue";
 import SqlFormatterSettingsPanel from "./SqlFormatterSettingsPanel.vue";
-import type { AppThemeAppearance } from "@/lib/appTheme";
+import type { AppThemeAppearance, AppThemeMode } from "@/lib/appTheme";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useSavedSqlStore } from "@/stores/savedSqlStore";
 import { currentLocale, setLocale, type Locale } from "@/i18n";
@@ -78,7 +78,7 @@ const { t } = useI18n();
 const settingsStore = useSettingsStore();
 const connectionStore = useConnectionStore();
 const savedSqlStore = useSavedSqlStore();
-const { isDark, themeMode, setThemeMode } = useTheme();
+const { appAppearance, themeMode, setThemeMode } = useTheme();
 
 let cachedSystemFonts: string[] | null = null;
 let pendingSystemFonts: Promise<string[]> | null = null;
@@ -1491,7 +1491,7 @@ const previewSettings = computed<{
   fontFamily: editFontFamily.value,
   fontSize: editFontSize.value,
   theme: editTheme.value,
-  appAppearance: isDark.value ? "dark" : "light",
+  appAppearance: appAppearance.value,
   customColors: getPreviewCustomThemeColors(),
 }));
 
@@ -1803,6 +1803,7 @@ watch(
                     v-for="option in [
                       { value: 'light', label: t('toolbar.themeLight'), icon: Sun },
                       { value: 'dark', label: t('toolbar.themeDark'), icon: Moon },
+                      { value: 'amber-paper', label: t('toolbar.themeAmberPaper'), icon: Eye },
                       { value: 'system', label: t('toolbar.themeSystem'), icon: SunMoon },
                     ]"
                     :key="option.value"
@@ -1811,7 +1812,7 @@ watch(
                     size="sm"
                     class="h-auto gap-1.5 px-3 py-1.5"
                     :class="themeMode === option.value ? 'border-blue-300 ring-2 ring-blue-300/50' : ''"
-                    @click="setThemeMode(option.value as 'light' | 'dark' | 'system')"
+                    @click="setThemeMode(option.value as AppThemeMode)"
                   >
                     <component :is="option.icon" class="h-3.5 w-3.5" />
                     {{ option.label }}

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -86,7 +86,7 @@ let latestViewport: { scrollTop: number; scrollLeft: number } | undefined = prop
 let latestSelection: { anchor: number; head: number } | undefined = props.initialSelection;
 const connectionStore = useConnectionStore();
 const settingsStore = useSettingsStore();
-const { isDark } = useTheme();
+const { isDark, themeMode } = useTheme();
 const { t } = useI18n();
 const { toast } = useToast();
 
@@ -206,6 +206,7 @@ let pendingImeModelEmit = false;
 const tableNavigationHoverClass = "query-editor--table-navigation-hover";
 
 function editorThemeAppearance() {
+  if (themeMode.value === "amber-paper") return "amber-paper";
   return isDark.value ? "dark" : "light";
 }
 
@@ -2185,7 +2186,7 @@ function getCurrentCustomThemeColors() {
 
 // Reactively apply editor settings changes
 watch(
-  [() => settingsStore.editorSettings, () => isDark.value],
+  [() => settingsStore.editorSettings, () => isDark.value, () => themeMode.value],
   async ([ss]) => {
     if (!view.value || !codeMirrorTheme || !fontThemeComp || !wordWrapComp || !runKeymapComp || !editorViewModule) {
       return;

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -147,7 +147,7 @@ const SqlPreviewPanel = defineAsyncComponent(() => import("@/components/editor/S
 const { t } = useI18n();
 const slots = useSlots();
 const settingsStore = useSettingsStore();
-const { isDark } = useTheme();
+const { isDark, themeMode } = useTheme();
 const { toast } = useToast();
 const { highlight } = useSqlHighlighter();
 const binaryCellDownloadMenuItems = computed(() =>
@@ -3488,7 +3488,7 @@ let detailsDetailEditor: UseCellDetailEditorReturn | null = null;
 let valueDetailEditor: UseCellDetailEditorReturn | null = null;
 
 const editorThemeAccessor = () => settingsStore.editorSettings.theme;
-const editorAppAppearance = () => (isDark.value ? "dark" : "light") as import("@/lib/appTheme").AppThemeAppearance;
+const editorAppAppearance = () => (themeMode.value === "amber-paper" ? "amber-paper" : isDark.value ? "dark" : "light") as import("@/lib/appTheme").AppThemeAppearance;
 const editorFontSize = () => settingsStore.editorSettings.fontSize;
 const editorFontFamily = () => settingsStore.editorSettings.fontFamily;
 

--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -53,7 +53,7 @@ defineExpose({ focusSearch });
 </script>
 
 <template>
-  <div class="h-full shrink-0 relative select-none" :class="classicLayout ? '' : 'rounded-md border border-border/80 bg-background'" :style="{ width: sidebarWidth + 'px' }">
+  <div class="app-sidebar-panel h-full shrink-0 relative select-none" :class="classicLayout ? '' : 'rounded-md border border-border/80 bg-background'" :style="{ width: sidebarWidth + 'px' }">
     <div class="h-full flex flex-col overflow-hidden">
       <div class="flex items-center gap-px px-3 text-xs font-medium text-muted-foreground border-b bg-muted/20" :class="classicLayout ? 'h-9' : 'h-10'">
         <span class="flex self-stretch items-center truncate" data-tauri-drag-region>{{ t("sidebar.connections") }}</span>

--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -298,7 +298,7 @@ function activateTab(tabId: string) {
 </script>
 
 <template>
-  <div v-if="queryStore.tabs.length > 0 || showDriverStore" class="relative flex border-b shrink-0" :class="settingsStore.editorSettings.appLayout === 'classic' ? 'h-9 items-stretch bg-muted' : 'h-10 items-center bg-background px-2'">
+  <div v-if="queryStore.tabs.length > 0 || showDriverStore" class="app-tab-bar relative flex border-b shrink-0" :class="settingsStore.editorSettings.appLayout === 'classic' ? 'h-9 items-stretch bg-muted' : 'h-10 items-center bg-background px-2'">
     <div class="app-tab-strip relative h-full min-w-0 flex-1">
       <div v-if="showTabOverflowControls" class="app-tab-scrollbar" :class="{ 'app-tab-scrollbar--dragging': isScrollbarDragging }" @pointerdown="startScrollbarDrag">
         <div class="app-tab-scrollbar__thumb" :style="tabScrollbarThumbStyle" />

--- a/apps/desktop/src/components/layout/AppToolbar.vue
+++ b/apps/desktop/src/components/layout/AppToolbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onBeforeUnmount, h } from "vue";
 import { useI18n } from "vue-i18n";
-import { DatabaseZap, FilePlus2, Loader2, Moon, Sun, SunMoon, History, Bot, ArrowLeftRight, FileCode, BookMarked, GitCompareArrows, TableProperties, Settings, CloudDownload, Package, FileDown } from "@lucide/vue";
+import { DatabaseZap, Eye, FilePlus2, Loader2, Moon, Sun, SunMoon, History, Bot, ArrowLeftRight, FileCode, BookMarked, GitCompareArrows, TableProperties, Settings, CloudDownload, Package, FileDown } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import LightDropdown from "@/components/ui/LightDropdown.vue";
@@ -60,10 +60,12 @@ const { isMac, isDesktop, showControls, isMaximized, isFullscreen, minimize, tog
 const themeItems = computed(() => [
   { value: "light", label: t("toolbar.themeLight"), icon: Sun },
   { value: "dark", label: t("toolbar.themeDark"), icon: Moon },
+  { value: "amber-paper", label: t("toolbar.themeAmberPaper"), icon: Eye },
   { value: "system", label: t("toolbar.themeSystem"), icon: SunMoon },
 ]);
 const themeTriggerIcon = computed(() => {
   if (props.themeMode === "system") return SunMoon;
+  if (props.themeMode === "amber-paper") return Eye;
   return props.isDark ? Moon : Sun;
 });
 
@@ -332,7 +334,7 @@ const checkingUpdates = computed(() => props.checkingUpdates);
 </script>
 
 <template>
-  <div ref="toolbarEl" class="h-10 flex items-center gap-1 px-2 border-b bg-muted/30 shrink-0 overflow-hidden" :class="{ 'pl-17.5': shouldReserveMacTrafficLightInset(isMac, isFullscreen, isDesktop) }" data-tauri-drag-region @dblclick="onToolbarDblClick">
+  <div ref="toolbarEl" class="app-toolbar h-10 flex items-center gap-1 px-2 border-b bg-muted/30 shrink-0 overflow-hidden" :class="{ 'pl-17.5': shouldReserveMacTrafficLightInset(isMac, isFullscreen, isDesktop) }" data-tauri-drag-region @dblclick="onToolbarDblClick">
     <Button variant="ghost" size="sm" class="h-8 px-2 text-xs gap-1" @click="emit('new-connection')">
       <DatabaseZap class="h-3.5 w-3.5" />
       {{ t("toolbar.newConnection") }}

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -525,7 +525,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
 </script>
 
 <template>
-  <div class="flex flex-col flex-1 min-h-0">
+  <div class="app-content-area flex flex-col flex-1 min-h-0">
     <!-- Query mode: editor + results -->
     <template v-if="activeTab.mode === 'query'">
       <Splitpanes horizontal class="query-output-splitpanes flex-1 min-h-0 overflow-hidden">

--- a/apps/desktop/src/composables/useTheme.ts
+++ b/apps/desktop/src/composables/useTheme.ts
@@ -5,7 +5,8 @@ import { isTauriRuntime } from "@/lib/tauriRuntime";
 
 const themeMode = ref<AppThemeMode>(normalizeAppThemeMode(safeLocalStorageGet(APP_THEME_STORAGE_KEY)));
 const systemPrefersDark = ref(readSystemPrefersDark());
-const isDark = computed(() => resolveAppThemeAppearance(themeMode.value, systemPrefersDark.value) === "dark");
+const appAppearance = computed(() => (themeMode.value === "amber-paper" ? "amber-paper" : resolveAppThemeAppearance(themeMode.value, systemPrefersDark.value)));
+const isDark = computed(() => appAppearance.value === "dark");
 
 let mediaQuery: MediaQueryList | null = null;
 let isListeningForSystemTheme = false;
@@ -33,9 +34,11 @@ function applyTheme() {
 
   const doc = document.documentElement;
   const dark = isDark.value;
+  const amberPaper = themeMode.value === "amber-paper";
 
   doc.classList.add("disable-transitions");
   doc.classList.toggle("dark", dark);
+  doc.classList.toggle("amber-paper", amberPaper);
   doc.style.colorScheme = dark ? "dark" : "light";
 
   // force reflow so the class toggle takes effect before re-enabling transitions
@@ -72,5 +75,5 @@ export function useTheme() {
     setThemeMode(isDark.value ? "light" : "dark");
   }
 
-  return { isDark, themeMode, applyTheme, setThemeMode, toggleTheme };
+  return { appAppearance, isDark, themeMode, applyTheme, setThemeMode, toggleTheme };
 }

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -41,6 +41,7 @@ export default {
     theme: "Theme",
     themeLight: "Light",
     themeDark: "Dark",
+    themeAmberPaper: "Eye Care",
     themeSystem: "Follow System",
     sqlSaved: "SQL saved",
     sqlOpenFailed: "Failed to open file: {message}",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -39,6 +39,7 @@ export default {
     theme: "Tema",
     themeLight: "Claro",
     themeDark: "Oscuro",
+    themeAmberPaper: "Cuidado visual",
     themeSystem: "Seguir sistema",
     sqlSaved: "SQL guardado",
     sqlOpenFailed: "Error al abrir el archivo: {message}",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -39,6 +39,7 @@ export default {
     theme: "Tema",
     themeLight: "Chiaro",
     themeDark: "Scuro",
+    themeAmberPaper: "Comfort visivo",
     themeSystem: "Segui Sistema",
     sqlSaved: "SQL salvato",
     sqlOpenFailed: "Impossibile aprire il file: {message}",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -41,6 +41,7 @@ export default {
     theme: "テーマ",
     themeLight: "ライト",
     themeDark: "ダーク",
+    themeAmberPaper: "アイケア",
     themeSystem: "システム設定に従う",
     sqlSaved: "SQLを保存しました",
     sqlOpenFailed: "ファイルを開けませんでした: {message}",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -39,6 +39,7 @@ export default {
     theme: "Tema",
     themeLight: "Claro",
     themeDark: "Escuro",
+    themeAmberPaper: "Conforto visual",
     themeSystem: "Seguir o sistema",
     sqlSaved: "SQL salvo",
     sqlOpenFailed: "Falha ao abrir o arquivo: {message}",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -41,6 +41,7 @@ export default {
     theme: "主题",
     themeLight: "亮色",
     themeDark: "暗色",
+    themeAmberPaper: "护眼",
     themeSystem: "跟随系统",
     sqlSaved: "SQL 已保存",
     sqlOpenFailed: "打开文件失败：{message}",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -39,6 +39,7 @@ export default {
     theme: "主題",
     themeLight: "亮色",
     themeDark: "暗色",
+    themeAmberPaper: "護眼",
     themeSystem: "跟隨系統",
     sqlSaved: "SQL 已儲存",
     sqlOpenFailed: "開啟檔案失敗：{message}",

--- a/apps/desktop/src/lib/aiCodeHighlighter.ts
+++ b/apps/desktop/src/lib/aiCodeHighlighter.ts
@@ -1,4 +1,4 @@
-import type { AppThemeAppearance } from "@/lib/appTheme";
+import { resolveAppThemeColorScheme, type AppThemeAppearance } from "@/lib/appTheme";
 
 export type AiCodeHighlighter = (content: string, lang: string, appearance?: AppThemeAppearance) => string;
 
@@ -54,7 +54,7 @@ export async function createAiShikiCodeHighlighter(options: AiShikiCodeHighlight
     highlighter.codeToHtml(content, {
       lang: resolveShikiLanguage(lang),
       structure: "inline",
-      theme: SHIKI_THEMES[appearance],
+      theme: SHIKI_THEMES[resolveAppThemeColorScheme(appearance)],
     });
 }
 

--- a/apps/desktop/src/lib/appTheme.ts
+++ b/apps/desktop/src/lib/appTheme.ts
@@ -2,19 +2,26 @@ import type { Theme } from "@tauri-apps/api/window";
 
 export const APP_THEME_STORAGE_KEY = "dbx-theme";
 
-export type AppThemeMode = "light" | "dark" | "system";
-export type AppThemeAppearance = "light" | "dark";
+export type AppThemeMode = "light" | "dark" | "amber-paper" | "system";
+export type AppThemeAppearance = "light" | "dark" | "amber-paper";
+export type AppThemeColorScheme = "light" | "dark";
 
 export function normalizeAppThemeMode(value: string | null): AppThemeMode {
-  if (value === "dark" || value === "light" || value === "system") return value;
+  if (value === "dark" || value === "light" || value === "amber-paper" || value === "system") return value;
   return "light";
 }
 
 export function resolveAppThemeAppearance(mode: AppThemeMode, systemPrefersDark: boolean): AppThemeAppearance {
   if (mode === "system") return systemPrefersDark ? "dark" : "light";
+  if (mode === "amber-paper") return "light";
   return mode;
 }
 
 export function getTauriThemeForMode(mode: AppThemeMode): Theme | null {
+  if (mode === "amber-paper") return "light";
   return mode === "system" ? null : mode;
+}
+
+export function resolveAppThemeColorScheme(appearance: AppThemeAppearance): AppThemeColorScheme {
+  return appearance === "dark" ? "dark" : "light";
 }

--- a/apps/desktop/src/lib/editorThemes.ts
+++ b/apps/desktop/src/lib/editorThemes.ts
@@ -242,8 +242,100 @@ export function cellDetailActiveLineColor(): string {
   return colorMixValue("var(--accent)", "color-mix(in oklch, var(--foreground) 4%, transparent)");
 }
 
+function createAmberPaperTheme(EditorView: typeof import("@codemirror/view").EditorView): Extension {
+  const theme = EditorView.theme(
+    {
+      "&": {
+        backgroundColor: "#f4ead1",
+        color: "#5f4a2b",
+        [EDITOR_SELECTION_BACKGROUND_CSS_VAR]: "rgb(213 184 120 / 0.55)",
+      },
+      "&.cm-focused": {
+        outline: "none",
+      },
+      ".cm-scroller": {
+        backgroundColor: "#f4ead1",
+        backgroundImage:
+          "radial-gradient(circle at 22% 8%, rgb(255 246 219 / 0.72), transparent 32%), radial-gradient(circle at 88% 78%, rgb(190 126 40 / 0.12), transparent 38%), repeating-linear-gradient(0deg, rgb(95 74 43 / 0.026) 0 1px, transparent 1px 5px), repeating-linear-gradient(92deg, rgb(255 250 232 / 0.24) 0 1px, transparent 1px 8px)",
+      },
+      ".cm-content": {
+        backgroundColor: "transparent",
+        caretColor: "#7c5527",
+      },
+      ".cm-cursor": {
+        borderLeftColor: "#7c5527",
+      },
+      "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+        backgroundColor: "rgb(213 184 120 / 0.55)",
+      },
+      ".cm-activeLine": {
+        backgroundColor: "rgb(224 204 161 / 0.46)",
+      },
+      ".cm-gutters": {
+        backgroundColor: "#eadbb5",
+        color: "#856f4a",
+        borderRight: "1px solid #d6c09c",
+      },
+      ".cm-gutters:after": {
+        background: "#c7aa73 !important",
+      },
+      ".cm-activeLineGutter": {
+        backgroundColor: "#dfcb9b",
+        color: "#5f4a2b",
+      },
+      ".cm-matchingBracket": {
+        backgroundColor: "rgb(183 129 64 / 0.2)",
+        outline: "1px solid rgb(183 129 64 / 0.4)",
+      },
+      ".cm-panels, .cm-search": {
+        backgroundColor: "#f2e6c9",
+        color: "#5f4a2b",
+      },
+      ".cm-tooltip": {
+        backgroundColor: "#f6ecd5",
+        borderColor: "#d6c09c",
+        color: "#5f4a2b",
+      },
+    },
+    { dark: false },
+  );
+
+  const highlightStyle = HighlightStyle.define([
+    { tag: tags.keyword, color: "#0f60c4", fontWeight: "600" },
+    { tag: tags.controlKeyword, color: "#0f60c4", fontWeight: "600" },
+    { tag: tags.definitionKeyword, color: "#0f60c4", fontWeight: "600" },
+    { tag: tags.operatorKeyword, color: "#0f60c4", fontWeight: "600" },
+    { tag: tags.string, color: "#b22f2f" },
+    { tag: tags.special(tags.string), color: "#b22f2f" },
+    { tag: tags.number, color: "#9b5b19" },
+    { tag: tags.integer, color: "#9b5b19" },
+    { tag: tags.float, color: "#9b5b19" },
+    { tag: tags.comment, color: "#1f7a1f", fontStyle: "italic" },
+    { tag: tags.lineComment, color: "#1f7a1f", fontStyle: "italic" },
+    { tag: tags.blockComment, color: "#1f7a1f", fontStyle: "italic" },
+    { tag: tags.typeName, color: "#537aa4" },
+    { tag: tags.variableName, color: "#1d78c9" },
+    { tag: tags.name, color: "#1d78c9" },
+    { tag: tags.definition(tags.variableName), color: "#1d78c9" },
+    { tag: tags.function(tags.variableName), color: "#7a4d9b" },
+    { tag: tags.propertyName, color: "#1d78c9" },
+    { tag: tags.operator, color: "#6c5738" },
+    { tag: tags.compareOperator, color: "#6c5738" },
+    { tag: tags.logicOperator, color: "#6c5738" },
+    { tag: tags.punctuation, color: "#6f5a3a" },
+    { tag: tags.paren, color: "#6f5a3a" },
+    { tag: tags.bracket, color: "#6f5a3a" },
+    { tag: tags.bool, color: "#0f60c4", fontWeight: "600" },
+    { tag: tags.null, color: "#0f60c4", fontWeight: "600" },
+    { tag: tags.invalid, color: "#a84032" },
+  ]);
+
+  return [theme, syntaxHighlighting(highlightStyle)];
+}
+
 /** Load a CodeMirror theme extension by theme name. */
-export function resolveEditorTheme(theme: EditorTheme, appAppearance: AppThemeAppearance): Exclude<EditorTheme, "app"> {
+export function resolveEditorTheme(theme: EditorTheme, appAppearance: AppThemeAppearance): Exclude<EditorTheme, "app"> | "amber-paper" {
+  if (theme === "app" && appAppearance === "amber-paper") return "amber-paper";
   if (theme === "app") return appAppearance === "dark" ? "one-dark" : "vscode-light";
   return theme;
 }
@@ -252,6 +344,8 @@ export function resolveEditorTheme(theme: EditorTheme, appAppearance: AppThemeAp
 export async function loadEditorTheme(theme: EditorTheme, appAppearance: AppThemeAppearance = "dark", customColors?: CustomThemeColors): Promise<Extension> {
   const resolvedTheme = resolveEditorTheme(theme, appAppearance);
   switch (resolvedTheme) {
+    case "amber-paper":
+      return createAmberPaperTheme((await import("@codemirror/view")).EditorView);
     case "one-dark":
       return (await import("@codemirror/theme-one-dark")).oneDark;
     case "vscode-dark":

--- a/apps/desktop/src/lib/redisJsonHighlighter.ts
+++ b/apps/desktop/src/lib/redisJsonHighlighter.ts
@@ -1,4 +1,4 @@
-import type { AppThemeAppearance } from "@/lib/appTheme";
+import { resolveAppThemeColorScheme, type AppThemeAppearance } from "@/lib/appTheme";
 
 export type RedisJsonHighlighter = (content: string, appearance?: AppThemeAppearance) => string;
 
@@ -21,7 +21,7 @@ export async function createRedisShikiJsonHighlighter(options: RedisShikiJsonHig
     highlighter.codeToHtml(content, {
       lang: "json",
       structure: "inline",
-      theme: SHIKI_THEMES[appearance],
+      theme: SHIKI_THEMES[resolveAppThemeColorScheme(appearance)],
     });
 }
 

--- a/apps/desktop/src/lib/sqlHighlighter.ts
+++ b/apps/desktop/src/lib/sqlHighlighter.ts
@@ -1,4 +1,4 @@
-import type { AppThemeAppearance } from "@/lib/appTheme";
+import { resolveAppThemeColorScheme, type AppThemeAppearance } from "@/lib/appTheme";
 
 export type SqlHighlighter = (content: string, appearance?: AppThemeAppearance) => string;
 
@@ -21,7 +21,7 @@ export async function createShikiSqlHighlighter(options: ShikiSqlHighlighterOpti
     highlighter.codeToHtml(content, {
       lang: "sql",
       structure: "inline",
-      theme: SHIKI_THEMES[appearance],
+      theme: SHIKI_THEMES[resolveAppThemeColorScheme(appearance)],
     });
 }
 

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -224,6 +224,365 @@
   }
 }
 
+html.amber-paper {
+  --bg-main: rgb(239 227 197);
+  --bg-panel: rgb(244 234 209);
+  --bg-hover: rgb(234 219 181);
+  --bg-active: rgb(224 204 161);
+  --text-primary: rgb(95 74 43);
+  --text-secondary: rgb(133 112 82);
+  --border-color: rgb(214 192 156);
+  --accent-blue: rgb(83 122 164);
+  --accent-green: rgb(95 141 93);
+  --accent-orange: rgb(183 129 64);
+
+  --background: var(--bg-main);
+  --foreground: var(--text-primary);
+  --card: rgb(246 236 213);
+  --card-foreground: var(--text-primary);
+  --popover: rgb(246 236 213);
+  --popover-foreground: var(--text-primary);
+  --primary: rgb(96 62 28);
+  --primary-foreground: rgb(255 248 232);
+  --secondary: rgb(235 220 180);
+  --secondary-foreground: var(--text-primary);
+  --muted: rgb(234 219 181);
+  --muted-foreground: var(--text-secondary);
+  --accent: rgb(224 204 161);
+  --accent-foreground: rgb(70 49 25);
+  --destructive: rgb(168 64 50);
+  --border: var(--border-color);
+  --input: rgb(210 185 143);
+  --ring: rgb(163 123 69);
+  --chart-1: rgb(83 122 164);
+  --chart-2: rgb(95 141 93);
+  --chart-3: rgb(183 129 64);
+  --chart-4: rgb(151 94 55);
+  --chart-5: rgb(111 84 49);
+  --radius: 0.75rem;
+  --sidebar: rgb(242 230 201);
+  --sidebar-foreground: var(--text-primary);
+  --sidebar-primary: rgb(96 62 28);
+  --sidebar-primary-foreground: rgb(255 248 232);
+  --sidebar-accent: rgb(223 203 155);
+  --sidebar-accent-foreground: rgb(70 49 25);
+  --sidebar-border: rgb(214 192 156);
+  --sidebar-ring: rgb(163 123 69);
+  --font-sans: "Inter", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Geist Variable", "Segoe UI", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  --dbx-data-grid-font-family: "Inter", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Geist Variable Tabular", sans-serif;
+  --data-grid-row-number-default-bg: rgb(241 229 200);
+  --data-grid-row-muted-bg: rgb(246 236 213);
+  --data-grid-row-new-bg: rgb(229 237 206);
+  --data-grid-row-deleted-bg: rgb(244 222 203);
+  --data-grid-cell-active-bg: rgb(224 204 161);
+  --data-grid-cell-dirty-bg: rgb(249 230 176);
+  --data-grid-cell-selected-bg: rgb(226 209 166);
+  --data-grid-cell-selected-dirty-bg: rgb(232 207 143);
+  --data-grid-cell-selected-border: rgb(132 95 47);
+  --data-grid-cell-selected-single-bg: rgb(215 190 139);
+  --data-grid-cell-selected-single-border: rgb(96 62 28);
+  --data-grid-cell-hover-bg: rgb(232 215 172);
+  --data-grid-cell-search-bg: rgb(250 227 146);
+  --data-grid-cell-current-search-bg: rgb(237 181 74 / 0.42);
+  --data-grid-cell-current-search-border: rgb(177 119 42 / 0.82);
+  --tree-connection-active-bg: rgb(223 203 155);
+  --tree-connection-active-focus-bg: rgb(212 188 132);
+  --amber-paper-fiber-image:
+    repeating-linear-gradient(0deg, rgb(95 74 43 / 0.04) 0 1px, transparent 1px 5px),
+    repeating-linear-gradient(91deg, rgb(255 250 232 / 0.28) 0 1px, transparent 1px 8px),
+    repeating-linear-gradient(24deg, transparent 0 9px, rgb(120 87 43 / 0.034) 9px 10px, transparent 10px 20px);
+  --amber-paper-noise-image:
+    radial-gradient(circle at 13% 17%, rgb(112 76 31 / 0.08) 0 1px, transparent 1px 6px),
+    radial-gradient(circle at 57% 31%, rgb(255 248 225 / 0.18) 0 1px, transparent 1px 5px),
+    radial-gradient(circle at 81% 74%, rgb(122 82 34 / 0.07) 0 1px, transparent 1px 7px),
+    radial-gradient(circle at 28% 83%, rgb(255 248 225 / 0.16) 0 1px, transparent 1px 6px);
+  --amber-paper-surface-image:
+    radial-gradient(circle at 42% 7%, rgb(255 246 218 / 0.68), transparent 34%),
+    radial-gradient(circle at 88% 86%, rgb(188 126 42 / 0.13), transparent 38%),
+    linear-gradient(90deg, rgb(159 92 28 / 0.14), transparent 1.35rem, transparent calc(100% - 1.35rem), rgb(159 92 28 / 0.13)),
+    var(--amber-paper-fiber-image),
+    var(--amber-paper-noise-image);
+  --amber-paper-edge-clip: polygon(
+    0.12% 0.24%,
+    2.6% 0.1%,
+    5.4% 0.22%,
+    8.1% 0.08%,
+    10.9% 0.2%,
+    14.2% 0.07%,
+    17.6% 0.21%,
+    21.4% 0.09%,
+    25.2% 0.19%,
+    29.1% 0.06%,
+    33.5% 0.21%,
+    37.9% 0.08%,
+    42.2% 0.2%,
+    46.6% 0.07%,
+    51.1% 0.22%,
+    55.7% 0.09%,
+    60.3% 0.19%,
+    64.8% 0.06%,
+    69.5% 0.21%,
+    74.3% 0.08%,
+    79.2% 0.2%,
+    84.1% 0.07%,
+    89.2% 0.21%,
+    94.3% 0.09%,
+    99.88% 0.16%,
+    99.78% 3.2%,
+    99.94% 6.8%,
+    99.75% 10.6%,
+    99.92% 14.5%,
+    99.76% 18.9%,
+    99.93% 23.3%,
+    99.74% 27.7%,
+    99.9% 32.2%,
+    99.76% 36.8%,
+    99.94% 41.5%,
+    99.75% 46.1%,
+    99.92% 51.2%,
+    99.73% 56.1%,
+    99.91% 61.4%,
+    99.74% 66.7%,
+    99.93% 72.2%,
+    99.72% 77.6%,
+    99.9% 83.1%,
+    99.74% 88.7%,
+    99.92% 94.4%,
+    99.82% 99.86%,
+    96.2% 99.72%,
+    92.5% 99.9%,
+    88.7% 99.74%,
+    84.6% 99.91%,
+    80.4% 99.73%,
+    76.1% 99.9%,
+    71.8% 99.74%,
+    67.2% 99.92%,
+    62.6% 99.75%,
+    57.8% 99.91%,
+    53.1% 99.73%,
+    48.2% 99.9%,
+    43.3% 99.74%,
+    38.1% 99.92%,
+    33.0% 99.75%,
+    27.8% 99.91%,
+    22.4% 99.73%,
+    17.0% 99.9%,
+    11.6% 99.74%,
+    6.0% 99.92%,
+    0.18% 99.78%,
+    0.28% 96.1%,
+    0.08% 92.4%,
+    0.25% 88.5%,
+    0.09% 84.3%,
+    0.27% 80.1%,
+    0.08% 75.6%,
+    0.24% 71.0%,
+    0.1% 66.2%,
+    0.26% 61.3%,
+    0.07% 56.2%,
+    0.25% 51.0%,
+    0.09% 45.8%,
+    0.27% 40.4%,
+    0.08% 35.0%,
+    0.24% 29.4%,
+    0.1% 23.7%,
+    0.26% 18.0%,
+    0.07% 12.1%,
+    0.24% 6.1%
+  );
+}
+
+html.amber-paper body {
+  background:
+    radial-gradient(circle at 34% 6%, rgb(255 247 222 / 0.9), transparent 30%),
+    radial-gradient(circle at 84% 76%, rgb(190 126 40 / 0.18), transparent 38%),
+    radial-gradient(circle at 0 48%, rgb(164 93 28 / 0.2), transparent 22%),
+    radial-gradient(circle at 100% 52%, rgb(164 93 28 / 0.18), transparent 24%),
+    linear-gradient(90deg, rgb(209 161 88 / 0.34), transparent 9%, transparent 91%, rgb(171 112 47 / 0.28)),
+    linear-gradient(180deg, rgb(251 239 205), rgb(239 227 197));
+}
+
+html.amber-paper body::before,
+html.amber-paper body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 2147483646;
+  pointer-events: none;
+}
+
+html.amber-paper body::before {
+  opacity: 0.68;
+  mix-blend-mode: multiply;
+  background-image:
+    var(--amber-paper-fiber-image),
+    var(--amber-paper-noise-image);
+  background-size: auto, auto, auto, 17px 19px, 23px 29px;
+}
+
+html.amber-paper body::after {
+  opacity: 0.58;
+  background:
+    radial-gradient(ellipse at center, transparent 49%, rgb(136 84 29 / 0.24) 100%),
+    linear-gradient(90deg, rgb(139 82 25 / 0.24), transparent 1.6rem, transparent calc(100% - 1.6rem), rgb(139 82 25 / 0.22)),
+    linear-gradient(180deg, rgb(139 82 25 / 0.16), transparent 1.45rem, transparent calc(100% - 1.45rem), rgb(139 82 25 / 0.2));
+}
+
+html.amber-paper .app-toolbar,
+html.amber-paper .app-tab-bar,
+html.amber-paper .app-sidebar-panel,
+html.amber-paper .app-paper-panel,
+html.amber-paper .app-content-area,
+html.amber-paper [data-query-editor-root],
+html.amber-paper .bg-background,
+html.amber-paper .bg-card,
+html.amber-paper .bg-popover {
+  background-image: var(--amber-paper-surface-image);
+  background-blend-mode: multiply, multiply, multiply, multiply, multiply, normal, normal, normal, normal;
+}
+
+html.amber-paper .app-toolbar {
+  background-color: rgb(232 211 169) !important;
+  border-bottom-color: rgb(198 170 115) !important;
+  box-shadow: inset 0 -1px 0 rgb(124 83 32 / 0.12) !important;
+}
+
+html.amber-paper .app-tab-bar {
+  background-color: rgb(238 224 191) !important;
+  border-bottom-color: rgb(203 174 123) !important;
+}
+
+html.amber-paper .app-sidebar-panel {
+  background-color: rgb(242 230 201) !important;
+  border-color: rgb(207 177 122) !important;
+  box-shadow:
+    inset 10px 0 18px rgb(143 84 29 / 0.08),
+    inset -10px 0 18px rgb(143 84 29 / 0.07),
+    inset 0 1px 0 rgb(255 250 232 / 0.65) !important;
+}
+
+html.amber-paper .app-sidebar-panel,
+html.amber-paper .app-paper-panel {
+  clip-path: var(--amber-paper-edge-clip);
+  filter: drop-shadow(0 2px 1px rgb(95 57 16 / 0.18)) drop-shadow(0 10px 16px rgb(95 57 16 / 0.24));
+  isolation: isolate;
+  position: relative;
+}
+
+html.amber-paper .app-sidebar-panel::after,
+html.amber-paper .app-paper-panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 60;
+  pointer-events: none;
+  clip-path: var(--amber-paper-edge-clip);
+  background:
+    linear-gradient(90deg, rgb(111 66 19 / 0.24), transparent 12px, transparent calc(100% - 12px), rgb(111 66 19 / 0.2)),
+    linear-gradient(180deg, rgb(111 66 19 / 0.2), transparent 10px, transparent calc(100% - 10px), rgb(111 66 19 / 0.24)),
+    radial-gradient(circle at 8% 4%, rgb(255 246 215 / 0.45), transparent 11%),
+    radial-gradient(circle at 94% 96%, rgb(129 75 22 / 0.14), transparent 15%),
+    repeating-linear-gradient(96deg, transparent 0 13px, rgb(109 69 25 / 0.035) 13px 14px, transparent 14px 27px);
+  -webkit-mask:
+    linear-gradient(#000 0 0) top / 100% 16px no-repeat,
+    linear-gradient(#000 0 0) bottom / 100% 16px no-repeat,
+    linear-gradient(#000 0 0) left / 16px 100% no-repeat,
+    linear-gradient(#000 0 0) right / 16px 100% no-repeat;
+  mask:
+    linear-gradient(#000 0 0) top / 100% 16px no-repeat,
+    linear-gradient(#000 0 0) bottom / 100% 16px no-repeat,
+    linear-gradient(#000 0 0) left / 16px 100% no-repeat,
+    linear-gradient(#000 0 0) right / 16px 100% no-repeat;
+}
+
+html.amber-paper .app-content-area {
+  background-color: rgb(239 227 197);
+}
+
+html.amber-paper .rounded-md.border,
+html.amber-paper .rounded-lg.border,
+html.amber-paper .rounded-xl.border {
+  border-color: rgb(214 192 156);
+}
+
+html.amber-paper input,
+html.amber-paper textarea,
+html.amber-paper select,
+html.amber-paper [role="combobox"] {
+  background-color: rgb(246 236 213 / 0.72);
+  border-color: rgb(214 192 156);
+}
+
+html.amber-paper input:focus,
+html.amber-paper textarea:focus,
+html.amber-paper select:focus,
+html.amber-paper [role="combobox"]:focus {
+  border-color: rgb(163 123 69);
+}
+
+html.amber-paper * {
+  scrollbar-color: rgb(198 170 115) rgb(231 214 178);
+}
+
+html.amber-paper ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+html.amber-paper ::-webkit-scrollbar-track {
+  background: rgb(231 214 178);
+}
+
+html.amber-paper ::-webkit-scrollbar-thumb {
+  background: rgb(198 170 115);
+  border: 2px solid rgb(231 214 178);
+  border-radius: 999px;
+}
+
+html.amber-paper ::selection {
+  color: rgb(70 49 25);
+  background: rgb(222 190 120);
+}
+
+html.amber-paper .app-panel-gutter {
+  background:
+    radial-gradient(circle at 25% 12%, rgb(255 238 195 / 0.22), transparent 28%),
+    radial-gradient(circle at 82% 88%, rgb(95 57 16 / 0.18), transparent 36%),
+    rgb(199 169 111);
+}
+
+html.amber-paper .splitpanes--vertical > .splitpanes__splitter,
+html.amber-paper .splitpanes--horizontal > .splitpanes__splitter {
+  border-color: rgb(196 164 111);
+}
+
+html.amber-paper .splitpanes__splitter:hover,
+html.amber-paper .app-layout-classic .panel-resize-handle:hover,
+html.amber-paper .app-layout-classic .panel-resize-handle:active {
+  background: rgb(198 170 115) !important;
+}
+
+html.amber-paper .cn-menu-translucent {
+  background-color: rgb(246 236 213 / 0.94) !important;
+  border-color: rgb(180 139 78 / 0.35) !important;
+  box-shadow: none !important;
+}
+
+html.amber-paper .shadow-lg,
+html.amber-paper .shadow-md,
+html.amber-paper .shadow-sm {
+  box-shadow: none !important;
+}
+
+html.amber-paper .bg-\[rgb\(239_239_239\)\] {
+  background-color: rgb(235 220 180) !important;
+}
+
+html.amber-paper .hover\:bg-gray-200:hover {
+  background-color: rgb(232 215 172) !important;
+}
+
 html.disable-transitions,
 html.disable-transitions *,
 html.disable-transitions *::before,


### PR DESCRIPTION
Add amber/warm paper theme as third appearance mode alongside light/dark.

- Extend AppThemeMode type with 'amber' option and themeAppearance helper
- Add .amber CSS custom properties (rgb + oklch fallbacks) for warm paper tones
- Add createAmberPaperTheme() for CodeMirror amber syntax highlighting
- Add app-paper-panel / app-sidebar-panel / app-tab-bar / app-content-area CSS class hooks to layout components for theme-aware panel styling
- Replace isDark binary checks with themeAppearance ternary across all components (EditorSettings, AiAssistant, QueryEditor, DataGrid, DdlView, RedisValueViewer, TableStructureEditor, SchemaDiffDeploy)
- Add Eye icon and amber option to theme switcher in AppToolbar and EditorSettingsDialog
- Add themeAmber i18n key across 8 locales (en/es/it/ja/pt-BR/zh-CN/zh-TW)
- Map amber appearance to github-light for Shiki highlighters (SQL, AI code, Redis JSON)

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1512" height="890" alt="image" src="https://github.com/user-attachments/assets/a38e56d0-37eb-4f61-99af-5dba2858c422" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `pnpm check` 通过
- [ ] `cargo check --no-default-features` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

