### PR TITLE
fix(mysql): preserve temporary tables in client session pools

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -417,9 +417,13 @@ fn create_pool(url: &str, ca_cert_path: Option<&str>, max_connections: usize) ->
         mysql_async::Opts::from_url(&mysql_async_url(&tls_url.url)).map_err(|e| format!("Invalid MySQL URL: {e}"))?;
     let base_ssl_opts = opts.ssl_opts().cloned();
     let max_connections = max_connections.max(1);
+    // Single-connection pools (max_connections == 1) are client session pools that
+    // must preserve session state (e.g. TEMPORARY TABLEs) across queries.
+    // Disable COM_RESET_CONNECTION for these pools to avoid clearing that state.
     let pool_opts = mysql_async::PoolOpts::new()
         .with_constraints(mysql_async::PoolConstraints::new(1, max_connections).unwrap())
-        .with_inactive_connection_ttl(Duration::from_secs(300));
+        .with_inactive_connection_ttl(Duration::from_secs(300))
+        .with_reset_connection(max_connections > 1);
     let mut builder = mysql_async::OptsBuilder::from_opts(opts)
         .stmt_cache_size(0)
         .prefer_socket(false)


### PR DESCRIPTION
Disable COM_RESET_CONNECTION for single-connection session pools (max_connections == 1) so that MySQL session state such as TEMPORARY TABLEs is not cleared when a connection is returned to the pool.

Closes #1509

## 变更说明

在同一个 client session 中分步执行 SQL 时，创建的临时表在后续查询中报不存在。

根因：`mysql_async` 连接池默认在连接归还时发送 `COM_RESET_CONNECTION`，该命令会清除所有临时表及 session 状态。即使 session 池已限制 `max_connections = 1`（确保复用同一物理连接），reset 仍会销毁临时表。

修复：在 `create_pool` 中，当 `max_connections == 1`（即 client session 池）时，设置 `.with_reset_connection(false)` 跳过 `COM_RESET_CONNECTION`，保留临时表等 session 状态。非 session 池（`max_connections > 1`）行为不变。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- 本 PR 不涉及前端改动

## 验证

- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过（`cargo test -p dbx-core`：1037 passed, 0 failed）

## 关联 Issue

Close #1509
