### PR TITLE
feat: prompt input history navigation with ↑/↓ arrow keys in AI assistant

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -79,6 +79,9 @@ const promptTextareaRef = ref<HTMLTextAreaElement | null>(null);
 const promptCompositionActive = ref(false);
 const shikiCodeHighlighter = ref<AiCodeHighlighter>();
 const agentTokens = ref<{ input: number; output: number } | null>(null);
+const promptHistory = ref<string[]>([]);
+const historyIndex = ref(-1);
+const draftBeforeHistory = ref("");
 
 // Inline model selector
 const modelOptions = ref<AiModelInfo[]>([]);
@@ -622,6 +625,43 @@ function onPromptKeydown(event: KeyboardEvent) {
     }
   }
 
+  // Prompt history navigation (↑/↓ when not in @mention dropdown)
+  if (event.key === "ArrowUp" && promptHistory.value.length > 0) {
+    const textarea = promptTextareaRef.value;
+    // Only enter history when cursor is on the first line
+    if (textarea && textarea.selectionStart === 0 && textarea.selectionEnd === 0) {
+      event.preventDefault();
+      if (historyIndex.value === -1) {
+        draftBeforeHistory.value = prompt.value;
+      }
+      const nextIndex = historyIndex.value + 1;
+      if (nextIndex < promptHistory.value.length) {
+        historyIndex.value = nextIndex;
+        prompt.value = promptHistory.value[nextIndex];
+        nextTick(() => {
+          textarea.selectionStart = textarea.selectionEnd = prompt.value.length;
+        });
+      }
+      return;
+    }
+  }
+  if (event.key === "ArrowDown" && historyIndex.value >= 0) {
+    event.preventDefault();
+    const nextIndex = historyIndex.value - 1;
+    if (nextIndex >= 0) {
+      historyIndex.value = nextIndex;
+      prompt.value = promptHistory.value[nextIndex];
+    } else {
+      historyIndex.value = -1;
+      prompt.value = draftBeforeHistory.value;
+    }
+    nextTick(() => {
+      const textarea = promptTextareaRef.value;
+      if (textarea) textarea.selectionStart = textarea.selectionEnd = prompt.value.length;
+    });
+    return;
+  }
+
   if (shouldSubmitAiPromptOnKeydown(event, promptCompositionActive.value)) {
     event.preventDefault();
     send();
@@ -642,6 +682,13 @@ async function send() {
   const displayText = [selectedMentions.value.map((mention) => mention.raw).join(" "), text].filter(Boolean).join(" ");
 
   messages.value.push({ role: "user", content: displayText });
+  // Save to prompt history (deduplicate consecutive duplicates)
+  if (displayText && promptHistory.value[0] !== displayText) {
+    promptHistory.value.unshift(displayText);
+    if (promptHistory.value.length > 100) promptHistory.value.length = 100;
+  }
+  historyIndex.value = -1;
+  draftBeforeHistory.value = "";
   prompt.value = "";
   selectedMentions.value = [];
   scrollToBottom();
@@ -781,6 +828,8 @@ async function copyCode(code: string, key: string) {
 function clearMessages() {
   messages.value = [];
   conversationId.value = "";
+  historyIndex.value = -1;
+  draftBeforeHistory.value = "";
 }
 
 async function persistConversation() {


### PR DESCRIPTION
## 变更说明

Add terminal-style up/down arrow key history navigation to the AI assistant prompt input. Users can now cycle through previously sent messages by pressing ↑/↓,
eliminating the need to retype repeated queries.

## Motivation

> "比如我发过了一个问题，过两分钟我想再发一次，但是我按上下键没有历史，需要我再写一遍文案"

When users want to resend or slightly modify a previous AI prompt, they currently have to retype the entire message from memory. This is a common pain point, especially
for users who interact with the AI assistant frequently to generate SQL queries.

## How it works

### Keyboard behavior

| Key | Condition | Action |
|-----|-----------|--------|
| ↑ | Cursor at first line, history exists | Navigate to previous history entry; save current draft |
| ↓ | Currently browsing history | Navigate to next entry; restore draft at the end |
| ↑ / ↓ | @mention dropdown is open | Handled by mention dropdown (no conflict) |

### Lifecycle

- Save: On each successful send, the prompt text is prepended to history (consecutive duplicates deduplicated, max 100 entries).
- Browse: ↑ enters history from newest → oldest; ↓ goes back toward newest → restores draft.
- Draft preservation: The in-progress input is saved before entering history and restored when the user navigates past the end.
- Clear chat: Resets the browsing index; history entries persist for the session lifetime.
- Multi-line guard: ↑ only enters history when the cursor is at position 0 (first line), so users can still navigate within multi-line text normally.

## Changes

apps/desktop/src/components/editor/AiAssistant.vue   +49 lines


- Added `promptHistory`, `historyIndex`, `draftBeforeHistory` refs
- Extended `onPromptKeydown` with ArrowUp/ArrowDown history navigation (after @mention check, before Enter submit)
- Added history save logic in `send()`
- Added history index reset in `clearMessages()`

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="1298" height="804" alt="g1" src="https://github.com/user-attachments/assets/2a861a92-f757-43cb-84fb-4d6f7605f22a" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] Type check passes (`pnpm typecheck`)
- [ ] Send a few prompts, then press ↑ to cycle back through history
- [ ] Press ↓ to cycle forward and verify draft restoration
- [ ] Verify @mention dropdown ↑/↓ still works correctly when open
- [ ] Verify multi-line input ↑/↓ cursor movement is unaffected
- [ ] Verify "New Chat" resets browsing state but preserves history entries
- [ ] Verify consecutive duplicate messages are not stored twice

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

Related #1032 

