### PR TITLE
feat(editor): 单条 SQL 直接执行

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1548,7 +1548,7 @@ onUnmounted(() => {
       </div>
       <Teleport to="body">
         <Transition name="toast">
-          <div v-if="toastVisible" class="fixed bottom-6 inset-x-0 w-max mx-auto z-99999 px-4 py-2 rounded-lg bg-foreground text-background text-sm shadow-lg select-text">
+          <div v-if="toastVisible" class="fixed bottom-6 inset-x-0 w-max max-w-[90vw] sm:max-w-3xl mx-auto z-99999 px-4 py-2 rounded-lg bg-foreground text-background text-sm shadow-lg select-text whitespace-pre-wrap break-words">
             {{ toastMessage }}
           </div>
         </Transition>

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -10,7 +10,7 @@ import SqlExecutionTargetPicker from "./SqlExecutionTargetPicker.vue";
 import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomContextMenu.vue";
 import { copyToClipboard } from "@/lib/clipboard";
 import { resolveExecutableSql, type SqlExecutionSnapshot, type SqlExecutionOverride, type SqlExecutionCandidate } from "@/lib/sqlExecutionTarget";
-import { buildExecutionCandidates, supportsExecutionTargetPicker } from "@/lib/sqlStatementRanges";
+import { buildExecutionCandidates, hasMultipleExecutionTargets, supportsExecutionTargetPicker } from "@/lib/sqlStatementRanges";
 import { formatSqlText, type SqlFormatDialect } from "@/lib/sqlFormatter";
 import { formatMongoShellText } from "@/lib/mongoFormatter";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -319,7 +319,7 @@ function requestExecute() {
   const cursorPos = selection.head;
   const candidates = buildExecutionCandidates(doc, cursorPos, props.databaseType);
   if (candidates.length === 0) return false;
-  if (!settingsStore.editorSettings.showExecutionTargetPicker) {
+  if (!settingsStore.editorSettings.showExecutionTargetPicker || !hasMultipleExecutionTargets(doc, props.databaseType)) {
     const preferredKind = settingsStore.editorSettings.executeMode === "current" ? "cursor" : "all";
     const candidate = candidates.find((item) => item.kind === preferredKind) ?? candidates[0];
     emit("execute", candidate.sql);

--- a/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildExecutionCandidates, fullSqlRange, splitSqlStatementRanges, statementRangeAtCursor, supportsExecutionTargetPicker } from "../sqlStatementRanges";
+import { buildExecutionCandidates, fullSqlRange, hasMultipleExecutionTargets, splitSqlStatementRanges, statementRangeAtCursor, supportsExecutionTargetPicker } from "../sqlStatementRanges";
 
 function indexOf(sql: string, needle: string, occurrence = 1): number {
   let from = 0;
@@ -282,6 +282,25 @@ describe("buildExecutionCandidates", () => {
     const sql = "SELECT 1;\nSELECT 2;\n";
     const candidates = buildExecutionCandidates(sql, sql.length);
     expect(candidateKinds(candidates)).toEqual(["all"]);
+  });
+});
+
+describe("hasMultipleExecutionTargets", () => {
+  it("returns false for a single SQL statement", () => {
+    expect(hasMultipleExecutionTargets("SELECT 1;")).toBe(false);
+  });
+
+  it("returns true for multiple SQL statements", () => {
+    expect(hasMultipleExecutionTargets("SELECT 1;\nSELECT 2;")).toBe(true);
+  });
+
+  it("ignores comments when counting SQL statements", () => {
+    expect(hasMultipleExecutionTargets("-- check one thing\nSELECT 1;")).toBe(false);
+  });
+
+  it("counts executable Redis command lines", () => {
+    expect(hasMultipleExecutionTargets("GET user:1", "redis")).toBe(false);
+    expect(hasMultipleExecutionTargets("GET user:1\n# comment\nDEL user:2", "redis")).toBe(true);
   });
 });
 

--- a/apps/desktop/src/lib/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sqlStatementRanges.ts
@@ -17,6 +17,13 @@ export function supportsExecutionTargetPicker(databaseType?: DatabaseType): bool
   return !!databaseType && (databaseType === "redis" || !NON_SQL_EXECUTION_TARGET_TYPES.has(databaseType));
 }
 
+export function hasMultipleExecutionTargets(sql: string, databaseType?: DatabaseType): boolean {
+  if (databaseType === "redis") {
+    return redisExecutableCommandCount(sql) > 1;
+  }
+  return splitSqlStatementRanges(sql).length > 1;
+}
+
 interface RawStatement {
   /** Start offset (inclusive) of whitespace that can still target this statement. */
   hitFrom: number;
@@ -823,6 +830,17 @@ function candidateFromRange(range: SqlTextRange, kind: SqlExecutionCandidate["ki
     from: range.from,
     to: range.to,
   };
+}
+
+function redisExecutableCommandCount(sql: string): number {
+  let count = 0;
+  for (const line of sql.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    count += 1;
+    if (count > 1) return count;
+  }
+  return count;
 }
 
 function redisCommandRangeAtCursor(sql: string, cursorPos: number): SqlTextRange | null {


### PR DESCRIPTION
## 变更说明
- 当编辑器中只有一条可执行 SQL 时，即使开启执行目标选择器，也直接执行，不再弹出执行目标选择。
- 当存在多条 SQL 或 Redis 多条命令时，仍保留执行目标选择器。
- 增加执行目标数量判断及对应单元测试，覆盖单条、多条、注释和 Redis 命令场景。

Closes #1549

## 验证
- pnpm exec vitest run apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
- pnpm check