### PR TITLE
fix(i18n): add missing ai.copyTestResult key (#1582)

### DIFF
--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1010,6 +1010,7 @@ export default {
     executeSql: "Execute SQL",
     copyAll: "Copy All",
     copied: "Copied",
+    copyTestResult: "Copy test result",
     replace: "Replace Editor",
     append: "Append to Editor",
     apply: "Apply to Editor",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -902,6 +902,7 @@ export default {
     executeSql: "Ejecutar SQL",
     copyAll: "Copiar todo",
     copied: "Copiado",
+    copyTestResult: "Copiar resultado de prueba",
     replace: "Reemplazar en el editor",
     append: "Agregar al editor",
     apply: "Aplicar al editor",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -963,6 +963,7 @@ export default {
     executeSql: "Esegui SQL",
     copyAll: "Copia Tutto",
     copied: "Copiato",
+    copyTestResult: "Copia risultato test",
     replace: "Sostituisci Editor",
     append: "Accoda all'Editor",
     apply: "Applica all'Editor",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1015,6 +1015,7 @@ export default {
     executeSql: "SQLを実行",
     copyAll: "すべてコピー",
     copied: "コピーしました",
+    copyTestResult: "テスト結果をコピー",
     replace: "エディタを置換",
     append: "エディタに追加",
     apply: "エディタに適用",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -963,6 +963,7 @@ export default {
     executeSql: "Executar SQL",
     copyAll: "Copiar Tudo",
     copied: "Copiado",
+    copyTestResult: "Copiar resultado do teste",
     replace: "Substituir Editor",
     append: "Anexar ao Editor",
     apply: "Aplicar ao Editor",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1009,6 +1009,7 @@ export default {
     executeSql: "立即执行",
     copyAll: "复制全部",
     copied: "已复制",
+    copyTestResult: "复制测试结果",
     replace: "替换编辑器",
     append: "追加到编辑器",
     apply: "应用到编辑器",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -934,6 +934,7 @@ export default {
     executeSql: "立即執行",
     copyAll: "複製全部",
     copied: "已複製",
+    copyTestResult: "複製測試結果",
     replace: "取代編輯器",
     append: "追加到編輯器",
     apply: "套用到編輯器",


### PR DESCRIPTION
## Problem

Closes #1582

The button tooltip in the AI connection test area shows the raw i18n key `ai.copyTestResult` instead of the translated text, because the key only existed under the `connection` namespace while the code references `t('ai.copyTestResult')`.

## Changes

- Add `copyTestResult` key to the `ai` namespace in all 7 locale files (zh-CN, en, es, it, ja, pt-BR, zh-TW), with values matching the existing `connection.copyTestResult`.

## Verification

- [x] `vue-tsc` type check passes
- [x] `oxlint` reports 0 errors
- [x] The key value in each locale matches `connection.copyTestResult`