### PR TITLE
fix(sqlite): reject missing database files on connect

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -2227,6 +2227,13 @@ async function createSqliteFilePath() {
   if (!selected) return;
 
   const path = ensureSqliteFileExtension(selected);
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("create_sqlite_database_file", { path });
+  } catch (e: any) {
+    toast(t("connection.saveFailed", { message: e?.message || String(e) }), 5000);
+    return;
+  }
   form.value.host = path;
 }
 

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -608,11 +608,7 @@ impl AppState {
                     })
                     .collect();
                 PoolKind::Sqlite(
-                    db::sqlite::connect_path_create_if_missing_with_extensions(
-                        &expand_tilde(&db_config.host),
-                        extensions,
-                    )
-                    .await?,
+                    db::sqlite::connect_path_with_extensions(&expand_tilde(&db_config.host), extensions).await?,
                 )
             }
             DatabaseType::Rqlite => {
@@ -3035,6 +3031,26 @@ mod tests {
         let databases = schema::list_databases_core(&state, "sqlite-conn").await.unwrap();
         assert_eq!(databases.len(), 1);
         assert_eq!(databases[0].name, "main");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn sqlite_get_or_create_pool_rejects_missing_database_file() {
+        let (state, dir) = test_app_state().await;
+        let db_path = dir.join("missing.db");
+        let mut config = mysql_config(None);
+        config.id = "sqlite-missing".to_string();
+        config.name = "SQLite".to_string();
+        config.db_type = DatabaseType::Sqlite;
+        config.host = db_path.to_string_lossy().to_string();
+        config.port = 0;
+
+        state.configs.write().await.insert(config.id.clone(), config);
+
+        let result = state.get_or_create_pool("sqlite-missing", None).await;
+        assert!(result.is_err());
+        assert!(!db_path.exists());
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -583,12 +583,7 @@ pub async fn test_connection(state: State<'_, Arc<AppState>>, config: Connection
                         extension
                     })
                     .collect();
-                match db::sqlite::connect_path_create_if_missing_with_extensions(
-                    &expand_tilde(&config.host),
-                    extensions,
-                )
-                .await
-                {
+                match db::sqlite::connect_path_with_extensions(&expand_tilde(&config.host), extensions).await {
                     Ok(_) => Ok("Connection successful".to_string()),
                     Err(e) => Err(e),
                 }
@@ -843,8 +838,7 @@ pub async fn connect_db(state: State<'_, Arc<AppState>>, config: ConnectionConfi
                 })
                 .collect();
             PoolKind::Sqlite(
-                db::sqlite::connect_path_create_if_missing_with_extensions(&expand_tilde(&db_config.host), extensions)
-                    .await?,
+                db::sqlite::connect_path_with_extensions(&expand_tilde(&db_config.host), extensions).await?,
             )
         }
         DatabaseType::Redis => {

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -199,7 +199,8 @@ async fn connect_agent_pool(
 #[cfg(test)]
 mod tests {
     use super::{
-        mark_mongo_legacy_driver, mongo_legacy_connect_params, MONGO_LEGACY_DRIVER_LABEL, MONGO_LEGACY_DRIVER_PROFILE,
+        create_sqlite_database_file, mark_mongo_legacy_driver, mongo_legacy_connect_params, MONGO_LEGACY_DRIVER_LABEL,
+        MONGO_LEGACY_DRIVER_PROFILE,
     };
     use dbx_core::models::connection::{ConnectionConfig, DatabaseType};
     #[cfg(feature = "mq-admin")]
@@ -304,6 +305,21 @@ mod tests {
         assert_eq!(config.driver_profile.as_deref(), Some(MONGO_LEGACY_DRIVER_PROFILE));
         assert_eq!(config.driver_label.as_deref(), Some(MONGO_LEGACY_DRIVER_LABEL));
         assert!(!mark_mongo_legacy_driver(&mut config));
+    }
+
+    #[tokio::test]
+    async fn create_sqlite_database_file_initializes_missing_file() {
+        let dir = std::env::temp_dir().join(format!("dbx-tauri-sqlite-create-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("created.db");
+        let path_str = path.to_string_lossy().to_string();
+
+        create_sqlite_database_file(path_str.clone()).await.unwrap();
+
+        assert!(path.is_file());
+        dbx_core::db::sqlite::connect_path(&path_str).await.unwrap();
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[cfg(feature = "mq-admin")]
@@ -519,6 +535,13 @@ pub async fn save_sidebar_layout(state: State<'_, Arc<AppState>>, layout: serde_
 #[tauri::command]
 pub async fn load_sidebar_layout(state: State<'_, Arc<AppState>>) -> Result<Option<serde_json::Value>, String> {
     state.storage.load_sidebar_layout().await
+}
+
+#[tauri::command]
+pub async fn create_sqlite_database_file(path: String) -> Result<(), String> {
+    let handle = db::sqlite::connect_path_create_if_missing(&expand_tilde(&path)).await?;
+    drop(handle);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -432,6 +432,7 @@ pub fn run() {
             commands::connection::load_connections,
             commands::connection::save_sidebar_layout,
             commands::connection::load_sidebar_layout,
+            commands::connection::create_sqlite_database_file,
             commands::plugins::list_plugins,
             commands::plugins::list_jdbc_drivers,
             commands::plugins::list_jdbc_maven_bundles,


### PR DESCRIPTION
## 变更说明

修复 SQLite 连接路径不存在时仍会自动创建空数据库文件的问题。现在连接用户配置的 SQLite 文件时会要求文件已存在，避免 Docker/Web 场景下路径填错或文件未挂载时显示“连接成功但表为空”。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过

相关测试：

```bash
cargo test -p dbx-core sqlite_get_or_create_pool_rejects_missing_database_file
```

手动验证：

- 使用 Web API 连接不存在的 SQLite 路径，返回 `File does not exist`，且不会创建空 `.db` 文件
- 使用已有 SQLite 文件连接，仍可正常列出表

## 关联 Issue

Close #1584