### PR TITLE
fix(ui): fix dialog stacking order conflict with close action prompt (#1594)

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1543,7 +1543,7 @@ onUnmounted(() => {
           @download-and-install="downloadAndInstallUpdate"
           @restart="restartApp"
         />
-        <CloseActionPromptDialog v-if="isDesktop" v-model:open="showCloseActionPrompt" @quit="chooseQuit" @minimize="chooseMinimize" />
+        <CloseActionPromptDialog v-if="isDesktop && showCloseActionPrompt" v-model:open="showCloseActionPrompt" @quit="chooseQuit" @minimize="chooseMinimize" />
         <QuickOpenDialog :open="showQuickOpen" @update:open="showQuickOpen = $event" @select="handleQuickOpenSelect" />
       </div>
       <Teleport to="body">


### PR DESCRIPTION
## Problem

Closes #1594

When the settings dialog is open and the user clicks the macOS close button, the close action prompt dialog appears behind the settings dialog, making it impossible to interact with either dialog.

Root cause: `CloseActionPromptDialog` was mounted at app startup via `v-if="isDesktop"`, so its Reka UI portal content was fixed at the front of `<body>`. `EditorSettingsDialog` is mounted later (via `v-if="showSettingsDialog"`), so its portal content was appended after in `<body>`. Both use z-50, and the later DOM element wins — the settings dialog covers the prompt.

## Changes

- Change `CloseActionPromptDialog` rendering in `App.vue` from `v-if="isDesktop"` to `v-if="isDesktop && showCloseActionPrompt"`, so the dialog only mounts when needed. Its portal content will always be appended last in `<body>`, ensuring correct stacking.

## Verification

- [x] Open settings → Click OS close button → Close action prompt appears on top, not behind settings
- [x] Click "Minimize" → window minimizes correctly
- [x] Click "Quit" → app exits correctly
- [x] Settings → Appearance → toggle close behavior → works normally without prompt