### PR TITLE
完善 AI 模型选择控件细节

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -1287,6 +1287,7 @@ const messageRenderer = computed(() => {
               item-class="text-xs px-2"
               @update:model-value="(value) => selectAction(value as AiAction)"
             />
+            <span class="min-w-0 flex-1" />
             <SearchableSelect
               v-if="settings.isConfigured()"
               :model-value="settings.aiConfig.model"
@@ -1297,7 +1298,7 @@ const messageRenderer = computed(() => {
               :loading-text="t('ai.loadingModels')"
               :loading="modelLoading"
               :display-name="displayModelName"
-              trigger-class="min-w-0 flex-1 shrink justify-end rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+              trigger-class="min-w-0 w-auto max-w-[220px] shrink justify-end rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
               content-class="w-72"
               item-class="text-xs px-2"
               @update:model-value="handleModelSelect"

--- a/apps/desktop/src/components/ui/searchable-select/SearchableSelect.vue
+++ b/apps/desktop/src/components/ui/searchable-select/SearchableSelect.vue
@@ -57,6 +57,20 @@ function highlightSelectedOption() {
   highlightIndex.value = selectedIndex >= 0 ? selectedIndex : 0;
 }
 
+async function scrollHighlightedOptionIntoView() {
+  await nextTick();
+  const container = listContainer.value;
+  if (!container || highlightIndex.value < 0) return;
+  const buttons = container.querySelectorAll("button");
+  const target = buttons[highlightIndex.value];
+  target?.scrollIntoView({ block: "nearest" });
+}
+
+function highlightAndScrollSelectedOption() {
+  highlightSelectedOption();
+  void scrollHighlightedOptionIntoView();
+}
+
 watch(open, async (value) => {
   emit("update:open", value);
   if (!value) {
@@ -67,7 +81,7 @@ watch(open, async (value) => {
   await nextTick();
   const input = searchInput.value?.$el as HTMLInputElement | undefined;
   input?.focus();
-  highlightSelectedOption();
+  highlightAndScrollSelectedOption();
 });
 
 watch(searchText, () => {
@@ -78,19 +92,12 @@ watch(
   () => [props.modelValue, props.options],
   () => {
     if (!open.value || searchText.value) return;
-    highlightSelectedOption();
+    highlightAndScrollSelectedOption();
   },
   { deep: true },
 );
 
-watch(highlightIndex, async () => {
-  await nextTick();
-  const container = listContainer.value;
-  if (!container || highlightIndex.value < 0) return;
-  const buttons = container.querySelectorAll("button");
-  const target = buttons[highlightIndex.value];
-  target?.scrollIntoView({ block: "nearest" });
-});
+watch(highlightIndex, scrollHighlightedOptionIntoView);
 
 function selectOption(option: string) {
   emit("update:modelValue", option);


### PR DESCRIPTION
## 变更说明

补充已合并的 #1668，继续收敛 AI 模型选择控件的细节体验：

- 聊天窗口模型选择按钮改为按模型名称长度自适应，最大宽度限制为 220px，避免在宽面板中占满中间区域
- 保留模型按钮靠右展示，短模型名不会贴左侧；长模型名仍会优先省略
- 展开模型列表时自动高亮并滚动到当前选中的模型
- 如果模型列表在弹出后异步加载完成，也会重新定位到当前选中模型

## 验证

- `pnpm typecheck`
- `git diff --check`
- `pnpm dev:tauri` 本地验证聊天窗口模型选择按钮和模型列表定位
