### PR TITLE
fix：修复高级视图侧边栏表搜索范围

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -33,6 +33,7 @@ const plainTreeScrollerRef = ref<HTMLElement | null>(null);
 type SearchScope = "connection" | "database" | "schema" | "table" | "view";
 const selectedSearchScopes = ref<SearchScope[]>([]);
 const searchCollapsedIds = ref<Set<string>>(new Set());
+const searchRefreshedGroupIds = new Set<string>();
 let searchTimer: number | undefined;
 
 watch(
@@ -53,25 +54,34 @@ watch(
   { flush: "sync" },
 );
 
-watch(deferredSearchQuery, (newQuery) => {
+watch(deferredSearchQuery, (newQuery, oldQuery) => {
   store.sidebarSearchQuery = newQuery;
   const tasks: Promise<void>[] = [];
   for (const root of store.treeNodes) {
-    findExpandedTableParents(root, tasks);
+    collectExpandedObjectGroups(root, tasks, newQuery ? searchRefreshedGroupIds : undefined);
+  }
+  if (!newQuery && oldQuery) {
+    searchRefreshedGroupIds.clear();
   }
   Promise.all(tasks).catch(() => {});
 });
 
-function findExpandedTableParents(node: TreeNode, tasks: Promise<void>[]) {
-  if (node.isExpanded && node.connectionId && (node.type === "database" || node.type === "schema")) {
-    const groupTypes = new Set(["group-tables", "group-views", "group-procedures", "group-functions", "group-sequences", "group-packages"]);
-    if (node.children?.some((child) => groupTypes.has(child.type))) {
-      tasks.push(store.loadObjectGroupChildren(node, { force: true }));
+const searchableObjectGroupTypes = new Set<TreeNodeType>(["group-tables", "group-views", "group-materialized-views"]);
+
+function collectExpandedObjectGroups(node: TreeNode, tasks: Promise<void>[], refreshedGroupIds?: Set<string>) {
+  if (refreshedGroupIds && node.isExpanded && node.children) {
+    for (const child of node.children) {
+      if (child.connectionId && searchableObjectGroupTypes.has(child.type)) {
+        refreshedGroupIds.add(child.id);
+        tasks.push(store.loadObjectGroupChildren(child, { force: true }));
+      }
     }
+  } else if (!refreshedGroupIds && searchRefreshedGroupIds.has(node.id)) {
+    tasks.push(store.loadObjectGroupChildren(node, { force: true }));
   }
   if (node.children) {
     for (const child of node.children) {
-      findExpandedTableParents(child, tasks);
+      collectExpandedObjectGroups(child, tasks, refreshedGroupIds);
     }
   }
 }

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1833,9 +1833,9 @@ mod tests {
         assert_eq!(
             result.statements,
             vec![
-                "ALTER TABLE \"people\" UPDATE \"name\" = 'Linus' WHERE \"id\" = 1;",
-                "ALTER TABLE \"people\" DELETE WHERE \"id\" = 1;",
-                "INSERT INTO \"people\" (\"id\", \"name\") VALUES (2, 'Grace');",
+                "ALTER TABLE `people` UPDATE `name` = 'Linus' WHERE `id` = 1;",
+                "ALTER TABLE `people` DELETE WHERE `id` = 1;",
+                "INSERT INTO `people` (`id`, `name`) VALUES (2, 'Grace');",
             ]
         );
         assert!(result.rollback_statements.is_empty());
@@ -1896,7 +1896,7 @@ mod tests {
         });
 
         assert_eq!(result.validation_error, None);
-        assert_eq!(result.statements, vec!["ALTER TABLE \"events\" UPDATE \"name\" = 'Linus' WHERE \"id\" = 1;"]);
+        assert_eq!(result.statements, vec!["ALTER TABLE `events` UPDATE `name` = 'Linus' WHERE `id` = 1;"]);
     }
 
     #[test]
@@ -1946,7 +1946,7 @@ mod tests {
             rows: vec![vec![json!(1), json!("Ada")]],
         });
 
-        assert_eq!(statements, vec!["ALTER TABLE \"people\" UPDATE \"name\" = 'Ada' WHERE \"id\" = 1;"]);
+        assert_eq!(statements, vec!["ALTER TABLE `people` UPDATE `name` = 'Ada' WHERE `id` = 1;"]);
     }
 
     #[test]

--- a/crates/dbx-core/src/db_admin_sql.rs
+++ b/crates/dbx-core/src/db_admin_sql.rs
@@ -562,7 +562,7 @@ mod tests {
                 schema: None,
                 table_name: "PresetSubjectInfo".to_string(),
             }),
-            "ALTER TABLE \"PresetSubjectInfo\" DELETE WHERE 1 = 1;"
+            "ALTER TABLE `PresetSubjectInfo` DELETE WHERE 1 = 1;"
         );
         assert_eq!(
             build_truncate_table_sql(TableAdminSqlOptions {
@@ -570,7 +570,7 @@ mod tests {
                 schema: None,
                 table_name: "PresetSubjectInfo".to_string(),
             }),
-            "TRUNCATE TABLE \"PresetSubjectInfo\";"
+            "TRUNCATE TABLE `PresetSubjectInfo`;"
         );
         assert_eq!(
             build_empty_table_sql(TableAdminSqlOptions {


### PR DESCRIPTION
## 背景

高级视图下侧边栏对象按分组分页加载，默认每页 1000 个对象。搜索表名时，原逻辑把数据库/Schema 节点传给对象分组加载函数，导致远端 filter 分支没有实际执行，1000 条之外的表无法被搜索到。

## 修改

- 搜索时收集已展开节点下的表、视图、物化视图分组，并对这些分组执行强制刷新。
- 复用现有搜索态远端 filter 逻辑，搜索时不传分页 limit，允许命中 1000 条之外的对象。
- 记录搜索期间刷新过的分组，清空搜索后恢复正常分页加载结果，避免搜索结果污染普通侧边栏树。

## 验证

- pnpm typecheck
- 本地浏览器验证通过：高级视图下可搜索到超过默认分页范围的表。