### PR TITLE
feat(ssh): probe none authentication before credentials

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -2139,9 +2139,9 @@ function validateTransportLayers(config: LegacyConnectionConfig) {
     }
     if (layer.type === "ssh") {
       if (!layer.user?.trim()) throw new Error(t("connection.sshHopInvalidUser", { hop: label }));
-      if (!layer.password?.trim() && !layer.key_path?.trim() && !layer.use_ssh_agent) {
-        throw new Error(t("connection.sshHopInvalidAuth", { hop: label }));
-      }
+      // Auth credentials are optional: the backend probes "none" authentication
+      // first, so hops that require no credential (e.g. passwordless SSH proxies)
+      // are valid with password, key, and agent all left empty.
       const timeout = Number(layer.connect_timeout_secs);
       if (!Number.isFinite(timeout) || timeout < 1 || timeout > 300) {
         throw new Error(t("connection.sshHopInvalidTimeout", { hop: label }));

--- a/crates/dbx-core/src/db/ssh_tunnel.rs
+++ b/crates/dbx-core/src/db/ssh_tunnel.rs
@@ -77,6 +77,18 @@ async fn connect_and_authenticate(
             .map_err(|_| format!("SSH connection timed out ({connect_timeout_secs}s)"))?
             .map_err(|e| format!("SSH connection failed: {e}"))?;
 
+    // Probe with "none" authentication first. Some SSH proxies and jump-hosts
+    // accept connections without any credential, and this is also the standard
+    // SSH probe used to discover the auth methods the server supports.
+    let none_res = tokio::time::timeout(connect_timeout, session.authenticate_none(ssh_user))
+        .await
+        .map_err(|_| format!("SSH auth probe timed out ({connect_timeout_secs}s)"))?
+        .map_err(|e| format!("SSH auth probe failed: {e}"))?;
+    if none_res.success() {
+        return Ok(session);
+    }
+
+    // "none" was rejected — fall back to the configured credential method.
     if !ssh_key_path.is_empty() {
         // Validate SSH key file path
         validate_file_path(ssh_key_path, |_| false)?;
@@ -114,7 +126,10 @@ async fn connect_and_authenticate(
             Err(agent_err) => return Err(agent_err),
         }
     } else {
-        return Err("No SSH authentication method provided (password, key, or ssh-agent)".to_string());
+        return Err(
+            "SSH authentication failed: \"none\" was rejected and no password, key, or ssh-agent is configured"
+                .to_string(),
+        );
     }
 
     Ok(session)


### PR DESCRIPTION
## 背景

Closes #1628（仅第一部分：支持 "none" 认证方式；第二部分"复用本地 ~/.ssh/config"本次不涉及）

使用 dbx 通过多层 SSH 跳板机连接内网数据库时，第一层跳板机是使用 **"none" 认证方式**的 SSH 代理（特定用户无需密钥/密码直接放行）。系统 `ssh` 和 DataGrip 都能连，但 dbx 内置 SSH 客户端只尝试 `publickey` / `password`，且前端强制要求至少填写一种凭证，导致用户被迫填入密钥后报 `SSH public key authentication failed`。

## 改动

### 后端 `crates/dbx-core/src/db/ssh_tunnel.rs`
在 `connect_and_authenticate()` 中，**先探测 `none` 认证**，成功则直接返回；被拒再回落到原有的 `publickey` / `password` / `ssh-agent` 链。这是系统 `ssh` 客户端的标准行为（首次以 `none` 探测服务端支持的方法），因此：

- none 认证跳板机：探测成功，1 个往返完成认证
- 普通密钥/密码跳板机：`none` 被拒，照旧走凭证方法，行为不变
- 无凭证且 `none` 也被拒：返回清晰错误信息

兜底错误信息同步更新为更贴合实际的描述。

### 前端 `apps/desktop/src/components/connection/ConnectionDialog.vue`
放宽 `validateTransportLayers()` 的凭证强校验——移除"必须填密码/密钥/agent"的判断（host/port/user 仍必填）。该校验同时拦住「测试连接」和「保存」，移除后 none 认证 hop 可合法留空凭证。

## 验证
- `cargo check -p dbx-core` 编译通过（russh 0.60.3 的 `authenticate_none` 可用）
- `cargo test -p dbx-core --lib ssh_tunnel` 6 个测试全过
- 本地 debug 构建安装后，按实际多层跳板拓扑验证：第一跳仅填 host/port/user、凭证全留空，连接成功