### PR TITLE
feat(sidebar): pin database row while scrolling the tree

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -97,6 +97,12 @@ const SEARCH_SCOPE_TO_NODE_TYPES: Record<SearchScope, TreeNodeType[]> = {
   view: ["view"],
 };
 
+// Database-level container types. When browsing a large number of children
+// under one of these (e.g. hundreds of tables) and scrolling down, the row is
+// kept pinned at the top of the tree so the active database stays visible and
+// can be collapsed with one click. Mirrors the `database` search scope above.
+const DATABASE_LEVEL_TYPES = new Set<TreeNodeType>(SEARCH_SCOPE_TO_NODE_TYPES.database);
+
 const searchScopeOptions = computed(() => {
   return [
     { scope: "connection", label: t("sidebar.searchScopeConnection"), icon: Server },
@@ -178,6 +184,56 @@ const visibleNodeIndexById = computed(() => {
 });
 const useVirtualTree = computed(() => shouldVirtualizeFlatTree(flatNodes.value.length));
 const activeTab = computed(() => queryStore.tabs.find((tab) => tab.id === queryStore.activeTabId));
+
+// --- Sticky database header ---
+// RecycleScroller positions each row absolutely, so CSS `position: sticky` on
+// a database row can't work. Instead we overlay a pinned row from this parent
+// component, tracking scroll offset to find the topmost visible database-level
+// ancestor. The overlay reuses <TreeItem>, so collapse/expand comes for free.
+const stickyScrollTop = ref(0);
+
+function onTreeScroll() {
+  const scroller = (treeScrollerRef.value?.$el as HTMLElement | undefined) ?? null;
+  if (scroller) stickyScrollTop.value = scroller.scrollTop;
+}
+
+// RecycleScroller only emits scrollStart/scrollEnd, not continuous scroll, so
+// attach a native passive listener on its root element once it mounts.
+watch(
+  treeScrollerRef,
+  (scroller, _old, onCleanup) => {
+    const el = (scroller?.$el as HTMLElement | undefined) ?? null;
+    if (!el) return;
+    el.addEventListener("scroll", onTreeScroll, { passive: true });
+    onCleanup(() => el.removeEventListener("scroll", onTreeScroll));
+  },
+  { flush: "post" },
+);
+
+const stickyNode = computed<FlatTreeNode | null>(() => {
+  if (!useVirtualTree.value || isFiltering.value) return null;
+  const nodes = flatNodes.value;
+  const len = nodes.length;
+  if (len === 0) return null;
+
+  const topIndex = Math.min(Math.floor(stickyScrollTop.value / SIDEBAR_TREE_ROW_HEIGHT), len - 1);
+  // Walk UP from the topmost visible row to the nearest database-level ancestor.
+  // If the topmost row is itself a database node (it hasn't scrolled past the
+  // viewport yet), return null so the overlay doesn't duplicate the real row.
+  for (let i = topIndex; i >= 0; i--) {
+    const item = nodes[i];
+    if (!DATABASE_LEVEL_TYPES.has(item.type)) continue;
+    return i === topIndex ? null : item;
+  }
+  return null;
+});
+
+// Reset tracking when the tree rebuilds (connect/disconnect/collapse) so a
+// stale scrollTop doesn't keep the overlay mounted after a structural change.
+watch(flatNodes, () => {
+  stickyScrollTop.value = 0;
+});
+
 const sidebarTreeOverflowClass = computed(() => (settingsStore.editorSettings.sidebarAllowHorizontalScroll ? "overflow-x-auto sidebar-tree-horizontal-scroll" : "overflow-x-hidden"));
 
 provide(sidebarTreeContextKey, {
@@ -601,6 +657,9 @@ defineExpose({ focusSearch, createNewGroup });
         />
       </div>
     </div>
+    <div v-if="stickyNode" class="sticky-database-header relative z-[5] border-b border-border/60">
+      <TreeItem :node="stickyNode.node" :depth="stickyNode.depth" :drag-disabled="true" @search-toggle="onSearchToggle" />
+    </div>
     <RecycleScroller
       v-if="flatNodes.length > 0 && useVirtualTree"
       ref="treeScrollerRef"
@@ -640,6 +699,10 @@ defineExpose({ focusSearch, createNewGroup });
 </template>
 
 <style scoped>
+.sticky-database-header {
+  background-color: var(--background);
+}
+
 .connection-tree-scroller {
   will-change: scroll-position;
   contain: content;


### PR DESCRIPTION
When a database holds many tables and the tree is scrolled far down, the active database row scrolls out of view, making it hard to see which database is active or to collapse it and switch to another.

Pin the topmost visible database-level ancestor (database, redis-db, mongo-db, mq-tenant, nacos-namespace) above the virtualized scroller. RecycleScroller positions rows absolutely, so CSS sticky can't apply directly; instead a native scroll listener computes the topmost row and renders an overlay <TreeItem>. The overlay hides when the real database row is still in view to avoid duplication.

## 变更说明

吸顶浮层：在搜索框下方、虚拟列表上方插入一个常驻行，滚动时始终显示当前可视区对应的数据库（含图标、名称、折叠按钮、连接色背景）。
生效范围：所有数据库级容器 —— database / redis-db / mongo-db / mq-tenant / nacos-namespace。
复用现有行组件：顶栏直接渲染 <TreeItem>，点击折叠按钮即可一键收起当前库，无需额外交互代码。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="894" height="1306" alt="image" src="https://github.com/user-attachments/assets/1db05781-7b6d-425e-a5eb-29c6cd65fbdb" />

## 验证

手动验证通过，参见截图
<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `pnpm check` 通过
`pnpm check` 未通过是因为nacosAdmin.ts的原因，非本次修改导致
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过
## 关联 Issue

Close #1747 

