### PR TITLE
fix：修复 GaussDB 查询分页限制

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1564,7 +1564,7 @@ onUnmounted(() => {
                 </KeepAlive>
               </div>
               <WelcomeScreen
-                v-else
+                v-else-if="!driverStoreActive"
                 :connection-stats="connectionStats"
                 :recent-connections="recentConnections"
                 :saved-sql-history-items="savedSqlHistoryItems"

--- a/apps/desktop/src/lib/__tests__/databaseDriverManifest.spec.ts
+++ b/apps/desktop/src/lib/__tests__/databaseDriverManifest.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { databaseRuntimeMode, usesAgentCursorForQuery } from "@/lib/databaseDriverManifest";
+
+describe("databaseDriverManifest", () => {
+  it("uses agent cursor only for agent or external runtimes", () => {
+    expect(databaseRuntimeMode("gaussdb")).toBe("native");
+    expect(usesAgentCursorForQuery("gaussdb")).toBe(false);
+    expect(usesAgentCursorForQuery("mysql")).toBe(false);
+    expect(usesAgentCursorForQuery("jdbc")).toBe(true);
+    expect(usesAgentCursorForQuery("prestosql")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/databaseDriverManifest.ts
+++ b/apps/desktop/src/lib/databaseDriverManifest.ts
@@ -2,6 +2,7 @@ import type { DatabaseType } from "@/types/database";
 import driverManifest from "../../../../crates/dbx-core/assets/database-drivers.manifest.json";
 
 export type DatabaseSupportLevel = "connect" | "browse" | "understand" | "operate";
+export type DatabaseRuntimeMode = "native" | "file" | "agent" | "external";
 
 export const DATABASE_PRODUCT_CAPABILITY_KEYS = [
   "queryExecution",
@@ -27,6 +28,7 @@ export type DatabaseProductCapabilities = Record<DatabaseProductCapability, bool
 
 interface DatabaseDriverManifestEntry {
   dbType: DatabaseType;
+  runtimeMode: DatabaseRuntimeMode;
   supportLevel: DatabaseSupportLevel;
   capabilities: Partial<DatabaseProductCapabilities>;
 }
@@ -72,6 +74,10 @@ export function databaseSupportLevel(dbType?: DatabaseType): DatabaseSupportLeve
   return dbType ? DATABASE_DRIVER_BY_TYPE.get(dbType)?.supportLevel : undefined;
 }
 
+export function databaseRuntimeMode(dbType?: DatabaseType): DatabaseRuntimeMode | undefined {
+  return dbType ? DATABASE_DRIVER_BY_TYPE.get(dbType)?.runtimeMode : undefined;
+}
+
 export function databaseProductCapabilities(dbType?: DatabaseType): DatabaseProductCapabilities {
   if (!dbType) return DEFAULT_CAPABILITIES;
   return (DATABASE_DRIVER_BY_TYPE.get(dbType)?.capabilities ?? DEFAULT_CAPABILITIES) as DatabaseProductCapabilities;
@@ -83,6 +89,11 @@ export function supportsDatabaseFeature(dbType: DatabaseType | undefined, capabi
 
 export function manifestDatabaseTypes(): DatabaseType[] {
   return DATABASE_DRIVER_ENTRIES.map((entry) => entry.dbType);
+}
+
+export function usesAgentCursorForQuery(dbType?: DatabaseType): boolean {
+  const runtimeMode = databaseRuntimeMode(dbType);
+  return runtimeMode === "agent" || runtimeMode === "external";
 }
 
 function productCapabilities(overrides: Partial<DatabaseProductCapabilities>): DatabaseProductCapabilities {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -27,7 +27,7 @@ import {
 import { redisCommandResultToQueryResult } from "@/lib/redisQueryResult";
 import { nextRedisCommandDb } from "@/lib/redisCommandSession";
 import { isRedisMutatingCommand } from "@/lib/redisCommandTable";
-import { supportsDatabaseFeature } from "@/lib/databaseCapabilities";
+import { usesAgentCursorForQuery } from "@/lib/databaseDriverManifest";
 import { canUseKeylessRowPredicate, editableRowIdentifierColumns } from "@/lib/tableEditing";
 import { TABLE_DATA_EXPORT_PAGE_SIZE } from "@/lib/tableDataExport";
 import { tableMetaForDataTab } from "@/lib/tableDataTabMeta";
@@ -1428,7 +1428,7 @@ export const useQueryStore = defineStore("query", () => {
       }
       const conn = connStore.getConfig(tab.connectionId);
       const effectiveDbType = effectiveDatabaseTypeForConnection(conn);
-      const useAgentCursor = conn?.db_type === "jdbc" || supportsDatabaseFeature(conn?.db_type, "driverManagement");
+      const useAgentCursor = usesAgentCursorForQuery(conn?.db_type);
       const queryTimeoutSecs = queryTimeoutSecsForConnection(conn);
       const settingsStore = useSettingsStore();
       console.info("[DBX][executeTabSql:previous-session-close:start]", { traceId, elapsed: elapsed() });
@@ -2218,7 +2218,7 @@ export const useQueryStore = defineStore("query", () => {
     const conn = connStore.getConfig(tab.connectionId);
     const effectiveDbType = effectiveDatabaseTypeForConnection(conn);
     const queryTimeoutSecs = queryTimeoutSecsForConnection(conn);
-    const useAgentCursor = conn?.db_type === "jdbc" || supportsDatabaseFeature(conn?.db_type, "driverManagement");
+    const useAgentCursor = usesAgentCursorForQuery(conn?.db_type);
     const queryBaseSql = tab.resultBaseSql ?? sql;
     const exportRowLimit = useSettingsStore().editorSettings.exportRowLimit;
     // Use the already-computed total row count as a progress estimate so the
@@ -2296,7 +2296,7 @@ export const useQueryStore = defineStore("query", () => {
     const settings = useSettingsStore().editorSettings;
     const effectiveDbType = effectiveDatabaseTypeForConnection(conn);
     if (!effectiveDbType) return undefined;
-    const useAgentCursor = conn?.db_type === "jdbc" || supportsDatabaseFeature(conn?.db_type, "driverManagement");
+    const useAgentCursor = usesAgentCursorForQuery(conn?.db_type);
     const queryBaseSql = tab.resultBaseSql ?? sql;
     const totalRows = typeof tab.resultTotalRowCount === "number" ? tab.resultTotalRowCount : null;
     const clientSessionId = tabClientSessionId(tab, "export");


### PR DESCRIPTION
## 变更说明

- 修复 GaussDB 无 LIMIT 查询时结果按默认 10000 行截断，而不是按分页设置限制的问题
- 将查询游标分页判断改为基于驱动运行模式，避免 native 类型误走 agent cursor

## 验证

- pnpm typecheck
- pnpm vitest run apps/desktop/src/lib/__tests__/databaseDriverManifest.spec.ts
- 本地浏览器验证通过