### PR TITLE
fix(sql): Fix the failure of SQL keyword detection caused by leading parentheses

### DIFF
--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -1596,7 +1596,7 @@ fn first_executable_sql_token_with_options(sql: &str, options: SqlParsingOptions
     let mut i = 0;
 
     while i < bytes.len() {
-        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        while i < bytes.len() && (bytes[i].is_ascii_whitespace() || bytes[i] == b'(') {
             i += 1;
         }
 
@@ -2121,6 +2121,16 @@ mod tests {
     fn describe_keyword_detection_accepts_desc_shorthand() {
         assert!(starts_with_executable_sql_keyword("DESC users", &["DESCRIBE"]));
         assert!(starts_with_executable_sql_keyword("-- comment\nDESC users", &["DESCRIBE"]));
+    }
+
+    #[test]
+    fn detects_keyword_after_parentheses() {
+        assert!(starts_with_executable_sql_keyword("(SELECT 1)", &["SELECT"]));
+        assert!(starts_with_executable_sql_keyword("  (  SELECT 1  )", &["SELECT"]));
+        assert!(starts_with_executable_sql_keyword("((SELECT 1))", &["SELECT"]));
+        assert!(starts_with_executable_sql_keyword("(SELECT * FROM users)", &["SELECT"]));
+        assert!(starts_with_executable_sql_keyword("(INSERT INTO users VALUES (1))", &["INSERT"]));
+        assert!(starts_with_executable_sql_keyword("/* comment */(UPDATE users SET name = 'test')", &["UPDATE"]));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复前置括号导致SQL关键字检测失败的问题， 例如
```sql
(SELECT 1)
```
新增了相关的测试用例。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

无

## 验证

在 MYSQL 数据库中，执行如下查询
```sql
(SELECT 1)
```

- [ ] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

