### PR TITLE
Improve：移除侧边栏置顶快捷按钮

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -4055,15 +4055,7 @@ function treeItemMenuItems(): ContextMenuItem[] {
           <span v-if="node.type === 'connection' && node.connectionId && connectionStore.connectedIds.has(node.connectionId)" class="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
           <Badge v-if="isConnectionReadonly" variant="secondary" class="h-4 px-1.5 text-[10px] gap-0.5"><Lock class="w-2.5 h-2.5" />{{ t("connection.readOnlyBadge") }}</Badge>
           <ConnectionErrorIndicator v-if="node.type === 'connection'" :connection-id="node.connectionId" trigger-class="h-4 w-4" />
-          <button
-            v-if="canPin"
-            class="rounded p-0.5 text-muted-foreground hover:bg-muted-foreground/15 hover:text-foreground focus:opacity-100"
-            :class="isPinned ? 'opacity-100 text-primary' : 'opacity-0 group-hover:opacity-100'"
-            :title="isPinned ? t('contextMenu.unpin') : t('contextMenu.pin')"
-            @click.stop="togglePin"
-          >
-            <Pin class="w-3 h-3" :class="{ 'fill-current': isPinned }" />
-          </button>
+          <Pin v-if="isPinned" class="w-3 h-3 shrink-0 text-primary fill-current" aria-hidden="true" />
         </div>
         <template v-if="detailTooltip" #content>
           <div class="w-max min-w-40 max-w-[min(28rem,calc(100vw-24px))] rounded-md border border-border bg-popover p-2 text-popover-foreground shadow-lg">


### PR DESCRIPTION
## 变更说明

- 移除侧边栏节点行尾可点击的置顶/取消置顶按钮，避免点击连接或分组时误触置顶操作。
- 未置顶节点不再显示 pin 图标。
- 已置顶节点仅显示不可点击的 pin 状态图标，用于提示当前节点已置顶。
- 置顶/取消置顶操作保留在右键菜单中。

Fixes #1820

## 验证

- /Users/staff/dbx/node_modules/.bin/oxlint --vue-plugin apps/desktop/src/components/sidebar/TreeItem.vue
- pnpm -s typecheck
- pnpm exec vitest run packages/app-tests/pinnedItems.test.ts apps/desktop/src/lib/__tests__/pinnedItems.spec.ts
- git diff --check -- apps/desktop/src/components/sidebar/TreeItem.vue
