### PR TITLE
fix: correct CAST completion signature

### DIFF
--- a/apps/desktop/src/lib/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sqlCompletion.ts
@@ -786,7 +786,7 @@ const SQL_FUNCTION_SIGNATURES = new Map<string, string[]>([
   ["COALESCE", ["value", "...values"]],
   ["IFNULL", ["expression", "fallback"]],
   ["NULLIF", ["expression1", "expression2"]],
-  ["CAST", ["expression", "type"]],
+  ["CAST", ["expression AS type"]],
   ["CONVERT", ["expression", "type"]],
   ["GREATEST", ["...values"]],
   ["LEAST", ["...values"]],

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -974,6 +974,18 @@ test("returns function signature help inside function arguments", () => {
   });
 });
 
+test("returns cast signature with AS syntax", () => {
+  const sql = "select cast(created_at ";
+  const signature = getSqlFunctionSignatureHelp(sql, sql.length);
+
+  assert.deepEqual(signature, {
+    name: "CAST",
+    signature: "CAST(expression AS type)",
+    activeParameter: 0,
+    parameters: ["expression AS type"],
+  });
+});
+
 test("returns null signature help outside function calls", () => {
   assert.equal(getSqlFunctionSignatureHelp("select created_at from users", "select created_at".length), null);
 });


### PR DESCRIPTION
## Summary
- correct CAST signature help to use standard AS syntax
- add test coverage for CAST signature rendering

Closes #1813

## Tests
- node_modules/.bin/oxfmt --check apps/desktop/src/lib/sqlCompletion.ts packages/app-tests/sqlCompletion.test.ts
- node_modules/.bin/vitest run packages/app-tests/sqlCompletion.test.ts

Note: vue-tsc is currently blocked on main by missing Nacos CodeMirror language packages (@codemirror/lang-yaml, @codemirror/lang-xml, @codemirror/lang-html, @codemirror/legacy-modes).