### PR TITLE
Improve：移除标签页置顶快捷按钮

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -356,14 +356,7 @@ function activateTab(tabId: string) {
                     </TooltipTrigger>
                     <TooltipContent>{{ t("connection.readOnlyBadge") }}</TooltipContent>
                   </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger as-child>
-                      <button class="inline-flex rounded p-0.5 text-muted-foreground hover:bg-muted-foreground/20 hover:text-foreground focus:opacity-100" :class="tab.pinned ? 'visible text-primary' : 'invisible group-hover:visible'" @click.stop="queryStore.togglePinnedTab(tab.id)">
-                        <Pin class="h-3 w-3" :class="{ 'fill-current': tab.pinned }" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>{{ tab.pinned ? t("contextMenu.unpin") : t("contextMenu.pin") }}</TooltipContent>
-                  </Tooltip>
+                  <Pin v-if="tab.pinned" class="h-3 w-3 shrink-0 text-primary fill-current" aria-hidden="true" />
                   <button class="rounded hover:bg-muted-foreground/20 p-0.5 shrink-0" @click.stop="queryStore.closeTab(tab.id)">
                     <X class="h-3 w-3" />
                   </button>


### PR DESCRIPTION
## 变更说明
- 移除标签页标题上的置顶/取消置顶快捷按钮
- 已置顶标签页仅保留 pin 图标作为状态展示，不再响应点击
- 置顶和取消置顶操作继续通过标签页右键菜单完成，和侧边栏节点置顶交互保持一致

## 验证
- `oxfmt --check apps/desktop/src/components/layout/AppTabBar.vue`
- `oxlint --vue-plugin apps/desktop/src/components/layout/AppTabBar.vue`
- `vue-tsc --noEmit --project apps/desktop/tsconfig.json`