### PR TITLE
feat(mcp): add OpenCode config guide in settings (#1887)

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -1068,8 +1068,8 @@ async function exportDebugLogs() {
 const mcpStatus = ref<McpServerStatus | null>(null);
 const mcpStatusLoading = ref(false);
 const mcpStatusError = ref("");
-const mcpCopied = ref<"" | "install" | "claude-config" | "codex-config">("");
-const mcpConfigTab = ref<"claude" | "codex">("claude");
+const mcpCopied = ref<"" | "install" | "claude-config" | "codex-config" | "opencode-config">("");
+const mcpConfigTab = ref<"claude" | "codex" | "opencode">("claude");
 const mcpReadonlyMode = ref(false);
 const mcpAllowDangerous = ref(false);
 const mcpInstalling = ref(false);
@@ -1114,6 +1114,22 @@ const mcpCodexRecommendedConfig = computed(() => {
   return lines.join("\n");
 });
 
+const mcpOpenCodeRecommendedConfig = computed(() => {
+  const config: Record<string, unknown> = {
+    mcp: {
+      dbx: {
+        type: "local",
+        command: ["dbx-mcp-server"],
+      } as Record<string, unknown>,
+    },
+  };
+  if (mcpEnvEntries.value.length > 0) {
+    const env = Object.fromEntries(mcpEnvEntries.value);
+    ((config.mcp as Record<string, unknown>).dbx as Record<string, unknown>).environment = env;
+  }
+  return JSON.stringify(config, null, 2);
+});
+
 const mcpStatusTone = computed<"ok" | "warning" | "muted">(() => {
   if (!mcpStatus.value) return "muted";
   if (!mcpStatus.value.installed || mcpStatus.value.update_available || mcpStatus.value.error) return "warning";
@@ -1151,7 +1167,7 @@ async function refreshMcpStatus() {
   }
 }
 
-async function copyMcpText(kind: "install" | "claude-config" | "codex-config", value: string) {
+async function copyMcpText(kind: "install" | "claude-config" | "codex-config" | "opencode-config", value: string) {
   mcpCopied.value = kind;
   try {
     await copyToClipboard(value);
@@ -3285,6 +3301,7 @@ watch(
                   <TabsList>
                     <TabsTrigger value="claude">Claude Code</TabsTrigger>
                     <TabsTrigger value="codex">Codex</TabsTrigger>
+                    <TabsTrigger value="opencode">OpenCode</TabsTrigger>
                   </TabsList>
 
                   <TabsContent value="claude" class="m-0">
@@ -3306,6 +3323,21 @@ watch(
                         <pre class="overflow-x-auto whitespace-pre text-xs leading-relaxed"><code>{{ mcpCodexRecommendedConfig }}</code></pre>
                         <Button type="button" variant="outline" size="icon" class="absolute right-2 top-2 h-7 w-7" :title="t('common.copy')" @click="copyMcpText('codex-config', mcpCodexRecommendedConfig)">
                           <CheckCircle2 v-if="mcpCopied === 'codex-config'" class="h-3.5 w-3.5 text-green-500" />
+                          <Copy v-else class="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </TabsContent>
+
+                  <TabsContent value="opencode" class="m-0">
+                    <div class="space-y-2">
+                      <div class="rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                        {{ t("settings.mcpOpenCodeConfigPath") }}
+                      </div>
+                      <div class="relative rounded-md border bg-background p-3">
+                        <pre class="overflow-x-auto whitespace-pre text-xs leading-relaxed"><code>{{ mcpOpenCodeRecommendedConfig }}</code></pre>
+                        <Button type="button" variant="outline" size="icon" class="absolute right-2 top-2 h-7 w-7" :title="t('common.copy')" @click="copyMcpText('opencode-config', mcpOpenCodeRecommendedConfig)">
+                          <CheckCircle2 v-if="mcpCopied === 'opencode-config'" class="h-3.5 w-3.5 text-green-500" />
                           <Copy v-else class="h-3.5 w-3.5" />
                         </Button>
                       </div>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2677,6 +2677,7 @@ export default {
     mcpConfig: "MCP config",
     mcpCodexConfig: "Codex config",
     mcpCodexConfigPath: "Codex can use ~/.codex/config.toml or a project-level .codex/config.toml.",
+    mcpOpenCodeConfigPath: "~/.config/opencode/opencode.json globally, or opencode.json at the project level.",
     mcpReadonlyMode: "Read-only mode",
     mcpReadonlyModeDescription: "Adds DBX_MCP_ALLOW_WRITES=0 to the sample config so the MCP session stays query-only.",
     mcpAllowDangerous: "Allow dangerous SQL",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2278,6 +2278,7 @@ export default {
     mcpConfig: "Configuración de MCP",
     mcpCodexConfig: "Configuración de Codex",
     mcpCodexConfigPath: "Codex puede usar ~/.codex/config.toml o .codex/config.toml dentro del proyecto.",
+    mcpOpenCodeConfigPath: "~/.config/opencode/opencode.json global, o opencode.json a nivel de proyecto.",
     mcpReadonlyMode: "Modo solo lectura",
     mcpReadonlyModeDescription: "Añade DBX_MCP_ALLOW_WRITES=0 al ejemplo de configuración para que la sesión MCP solo permita consultas.",
     mcpAllowDangerous: "Permitir SQL peligroso",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2346,6 +2346,7 @@ export default {
     mcpConfig: "Configurazione MCP",
     mcpCodexConfig: "Configurazione Codex",
     mcpCodexConfigPath: "Codex può utilizzare ~/.codex/config.toml o un .codex/config.toml a livello di progetto.",
+    mcpOpenCodeConfigPath: "~/.config/opencode/opencode.json globalmente, o opencode.json a livello di progetto.",
     mcpReadonlyMode: "Modalità sola lettura",
     mcpReadonlyModeDescription: "Aggiunge DBX_MCP_ALLOW_WRITES=0 alla configurazione di esempio in modo che la sessione MCP rimanga di sola query.",
     mcpAllowDangerous: "Consenti SQL pericoloso",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2579,6 +2579,7 @@ export default {
     mcpConfig: "MCP設定",
     mcpCodexConfig: "Codex設定",
     mcpCodexConfigPath: "Codexは ~/.codex/config.toml またはプロジェクトレベルの .codex/config.toml を使用できます。",
+    mcpOpenCodeConfigPath: "グローバル ~/.config/opencode/opencode.json、プロジェクト opencode.json。",
     mcpReadonlyMode: "読み取り専用モード",
     mcpReadonlyModeDescription: "サンプル設定にDBX_MCP_ALLOW_WRITES=0を追加し、MCPセッションをクエリのみに制限します。",
     mcpAllowDangerous: "危険なSQLを許可",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2357,6 +2357,7 @@ export default {
     mcpConfig: "Configuração do MCP",
     mcpCodexConfig: "Configuração do Codex",
     mcpCodexConfigPath: "O Codex pode usar ~/.codex/config.toml ou um .codex/config.toml no nível do projeto.",
+    mcpOpenCodeConfigPath: "~/.config/opencode/opencode.json globalmente, ou opencode.json no nível do projeto.",
     mcpReadonlyMode: "Modo somente leitura",
     mcpReadonlyModeDescription: "Adiciona DBX_MCP_ALLOW_WRITES=0 à configuração de exemplo para que a sessão MCP permaneça apenas para consultas.",
     mcpAllowDangerous: "Permitir SQL perigoso",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2701,6 +2701,7 @@ export default {
     mcpConfig: "MCP 配置",
     mcpCodexConfig: "Codex 配置",
     mcpCodexConfigPath: "Codex 可放在 ~/.codex/config.toml 或项目级 .codex/config.toml。",
+    mcpOpenCodeConfigPath: "全局 ~/.config/opencode/opencode.json，项目级 opencode.json。",
     mcpReadonlyMode: "只读模式",
     mcpReadonlyModeDescription: "开启后会为示例配置附加 DBX_MCP_ALLOW_WRITES=0，MCP 会话只允许查询。",
     mcpAllowDangerous: "允许危险 SQL",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2414,6 +2414,7 @@ export default {
     mcpConfig: "MCP 設定",
     mcpCodexConfig: "Codex 設定",
     mcpCodexConfigPath: "Codex 可放在 ~/.codex/config.toml 或專案級 .codex/config.toml。",
+    mcpOpenCodeConfigPath: "全域 ~/.config/opencode/opencode.json，專案級 opencode.json。",
     mcpReadonlyMode: "唯讀模式",
     mcpReadonlyModeDescription: "開啟後會為示例配置附加 DBX_MCP_ALLOW_WRITES=0，MCP 會話只允許查詢。",
     mcpAllowDangerous: "允許危險 SQL",


### PR DESCRIPTION
## Problem

Closes #1887

Settings → MCP → MCP Config only provided configuration guides for Claude Code and Codex. OpenCode uses a different config format (`opencode.json`, `command` as array, `type: "local"`) and users had no reference for it in DBX.

## Changes

- `EditorSettingsDialog.vue`: add "OpenCode" tab to MCP config section with config template (JSON) and copy button
- 7 locale files: add `mcpOpenCodeConfigPath` i18n key with file path hints

## Verification

- [x] `vue-tsc --noEmit` type check passes
- [x] OpenCode tab shows correct JSON config template with `dbx-mcp-server` as command array
- [x] Copy button works
- [x] Read-only / dangerous SQL toggles reflect in the OpenCode template
- [x] Existing Claude Code and Codex tabs unaffected