### PR TITLE
feat(grid): show selection summary

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -129,7 +129,7 @@ import { MAX_RESULT_PAGE_SIZE, MIN_RESULT_PAGE_SIZE, normalizeResultPageSize, re
 import { allNullColumnIndexes, filterColumnVisibilityOptions, hiddenColumnIndexesWithAllNullColumns, invertedHiddenColumnIndexes, nextHiddenColumnIndexes, removeAutoHiddenColumnIndexes, visibleColumnIndexesForFilter } from "@/lib/dataGridColumnVisibility";
 import { columnOrderKeysForIndexes, isDefaultColumnOrder, moveVisibleColumnIndex, orderedColumnIndexes, uniqueDataGridColumnOrderKeys } from "@/lib/dataGridColumnOrder";
 import { dataGridColumnLayoutScopeKey, loadDataGridColumnOrder, removeDataGridColumnOrder, saveDataGridColumnOrder } from "@/lib/dataGridColumnLayoutStorage";
-import { parseClipboardTable } from "@/lib/gridSelection";
+import { parseClipboardTable, summarizeSelection } from "@/lib/gridSelection";
 
 import { useToast } from "@/composables/useToast";
 import { useDataGridExport } from "@/composables/useDataGridExport";
@@ -3242,6 +3242,14 @@ const multiRowCount = computed(() => {
   const range = selectedRange.value;
   if (range && range.startRow !== range.endRow) return range.endRow - range.startRow + 1;
   return 1;
+});
+
+const selectionSummary = computed(() => (hasCellSelection.value ? summarizeSelection(selectedCells.value) : null));
+const selectionSummarySumText = computed(() => {
+  const summary = selectionSummary.value;
+  if (!summary) return "0";
+  const sum = Object.is(summary.sum, -0) ? 0 : summary.sum;
+  return Number.isInteger(sum) ? String(sum) : sum.toLocaleString(undefined, { maximumFractionDigits: 12 });
 });
 
 const isMultiRow = computed(() => multiRowCount.value > 1);
@@ -8180,6 +8188,13 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
       <span v-else class="min-w-0" />
 
       <div class="flex min-w-max items-center justify-end gap-1">
+        <div v-if="selectionSummary" class="flex shrink-0 items-center gap-3 tabular-nums">
+          <span class="shrink-0">{{ t("grid.selectionSum", { value: selectionSummarySumText }) }}</span>
+          <div class="flex shrink-0 items-center gap-1">
+            <span class="shrink-0">{{ t("grid.selectionCells", { count: selectionSummary.cellCount }) }}</span>
+            <span class="shrink-0">{{ t("grid.rows", { count: selectionSummary.rowCount }) }}</span>
+          </div>
+        </div>
         <Loader2 v-if="loading" class="w-3 h-3 animate-spin text-muted-foreground" />
         <template v-if="infiniteScrollEnabled">
           <span v-if="infiniteScrollAllLoaded" class="text-xs text-muted-foreground shrink-0">

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -560,6 +560,8 @@ export default {
     copyRowUpdate: "Copy as UPDATE",
     copyAll: "Copy All (TSV)",
     selection: "Selection",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} cells",
     copySelectionTsv: "Copy Selection (TSV)",
     copySelectionTsvWithHeaders: "Copy Selection with Headers (TSV)",
     copySelectionCsv: "Copy Selection (CSV)",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -494,6 +494,8 @@ export default {
     copyRowUpdate: "Copiar como UPDATE",
     copyAll: "Copiar todo (TSV)",
     selection: "Selección",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} celdas",
     copySelectionTsv: "Copiar selección (TSV)",
     copySelectionTsvWithHeaders: "Copiar selección con encabezados (TSV)",
     copySelectionCsv: "Copiar selección (CSV)",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -499,6 +499,8 @@ export default {
     copyRowUpdate: "Copia come UPDATE",
     copyAll: "Copia Tutto (TSV)",
     selection: "Selezione",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} celle",
     copySelectionTsv: "Copia Selezione (TSV)",
     copySelectionTsvWithHeaders: "Copia Selezione con Intestazioni (TSV)",
     copySelectionCsv: "Copia Selezione (CSV)",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -549,6 +549,8 @@ export default {
     copyRowUpdate: "UPDATEとしてコピー",
     copyAll: "すべてコピー (TSV)",
     selection: "選択範囲",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} 個のセル",
     copySelectionTsv: "選択範囲をコピー (TSV)",
     copySelectionTsvWithHeaders: "ヘッダー付きで選択範囲をコピー (TSV)",
     copySelectionCsv: "選択範囲をコピー (CSV)",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -499,6 +499,8 @@ export default {
     copyRowUpdate: "Copiar como UPDATE",
     copyAll: "Copiar Tudo (TSV)",
     selection: "Seleção",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} células",
     copySelectionTsv: "Copiar Seleção (TSV)",
     copySelectionTsvWithHeaders: "Copiar Seleção com Cabeçalhos (TSV)",
     copySelectionCsv: "Copiar Seleção (CSV)",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -561,6 +561,8 @@ export default {
     copyRowUpdate: "复制为 UPDATE 语句",
     copyAll: "复制全部 (TSV)",
     selection: "选区",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} 个单元",
     copySelectionTsv: "复制选区 (TSV)",
     copySelectionTsvWithHeaders: "复制选区含表头 (TSV)",
     copySelectionCsv: "复制选区 (CSV)",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -500,6 +500,8 @@ export default {
     copyRowUpdate: "複製為 UPDATE 語句",
     copyAll: "複製全部 (TSV)",
     selection: "選區",
+    selectionSum: "SUM: {value}",
+    selectionCells: "{count} 個儲存格",
     copySelectionTsv: "複製選區 (TSV)",
     copySelectionTsvWithHeaders: "複製選區含表頭 (TSV)",
     copySelectionCsv: "複製選區 (CSV)",

--- a/apps/desktop/src/lib/__tests__/gridSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/gridSelection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatSelectionAsTsv } from "@/lib/gridSelection";
+import { formatSelectionAsTsv, summarizeSelection } from "@/lib/gridSelection";
 
 describe("gridSelection", () => {
   it("formats TSV selections without headers by default", () => {
@@ -27,5 +27,48 @@ describe("gridSelection", () => {
         true,
       ),
     ).toBe("id\tname\n1\tAda\n2\tLin");
+  });
+
+  it("summarizes empty selections", () => {
+    expect(summarizeSelection({ columns: [], rows: [] })).toEqual({
+      cellCount: 0,
+      rowCount: 0,
+      numericCount: 0,
+      sum: 0,
+    });
+  });
+
+  it("summarizes numeric selections", () => {
+    expect(
+      summarizeSelection({
+        columns: ["a", "b"],
+        rows: [
+          [1, 2],
+          [3, 4],
+        ],
+      }),
+    ).toEqual({
+      cellCount: 4,
+      rowCount: 2,
+      numericCount: 4,
+      sum: 10,
+    });
+  });
+
+  it("summarizes numeric strings and ignores non-numeric values", () => {
+    expect(
+      summarizeSelection({
+        columns: ["id", "value", "flag"],
+        rows: [
+          ["100", 2.5, true],
+          [null, "not a number", 3],
+        ],
+      }),
+    ).toEqual({
+      cellCount: 6,
+      rowCount: 2,
+      numericCount: 3,
+      sum: 105.5,
+    });
   });
 });

--- a/apps/desktop/src/lib/gridSelection.ts
+++ b/apps/desktop/src/lib/gridSelection.ts
@@ -17,6 +17,13 @@ export interface SelectionData {
   rows: GridCellValue[][];
 }
 
+export interface SelectionSummary {
+  cellCount: number;
+  rowCount: number;
+  numericCount: number;
+  sum: number;
+}
+
 export function parseClipboardTable(text: string): string[][] {
   const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n$/, "");
   if (!normalized) return [[""]];
@@ -82,6 +89,28 @@ export function extractColumnsSelection(columns: readonly string[], rows: readon
   return {
     columns: normalizedIndexes.map((index) => columns[index]),
     rows: rows.map((row) => normalizedIndexes.map((index) => row[index] ?? null)),
+  };
+}
+
+export function summarizeSelection(selection: SelectionData): SelectionSummary {
+  let numericCount = 0;
+  let sum = 0;
+
+  for (const row of selection.rows) {
+    for (const value of row) {
+      const numericValue = typeof value === "number" ? value : typeof value === "string" && value.trim() !== "" ? Number(value) : Number.NaN;
+      if (Number.isFinite(numericValue)) {
+        numericCount += 1;
+        sum += numericValue;
+      }
+    }
+  }
+
+  return {
+    cellCount: selection.rows.reduce((count, row) => count + row.length, 0),
+    rowCount: selection.rows.length,
+    numericCount,
+    sum,
   };
 }
 


### PR DESCRIPTION
## 变更说明

- 为数据网格选中单元格增加状态栏汇总，展示 `SUM`、单元格数量和行数
- 支持数据库常见的数值字符串参与求和
- 补充多语言文案和选区汇总单测

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

![选中单元格汇总](https://gist.githubusercontent.com/linjianlin/d296bfeb22c9c95f58e4a163f79c8b19/raw/b3e729edd852d79c6f8ccdc4a5ef30ef3de01b4a/selection-summary-pr-screenshot.svg)

## 验证

- [x] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过

已执行：

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/gridSelection.spec.ts`
- `pnpm lint`

## 关联 Issue

Close #1886

