### PR TITLE
fix：避免过期连接尝试残留错误提示

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.mq.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.mq.spec.ts
@@ -83,6 +83,38 @@ describe("connectionStore MQ sidebar tree", () => {
     expect(node.isExpanded).toBe(true);
   });
 
+  it("reuses an in-flight connection attempt instead of recording stale superseded errors", async () => {
+    let resolveConnect: ((value: string) => void) | undefined;
+    const connectDb = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveConnect = resolve;
+        }),
+    );
+
+    vi.doMock("@/lib/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      connectDb,
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    const connection = mqConnection();
+    store.connections = [connection];
+
+    const first = store.ensureConnected(connection.id);
+    const second = store.ensureConnected(connection.id);
+    await Promise.resolve();
+
+    expect(connectDb).toHaveBeenCalledTimes(1);
+    resolveConnect?.(connection.id);
+    await Promise.all([first, second]);
+
+    expect(store.connectedIds.has(connection.id)).toBe(true);
+    expect(store.connectionErrors[connection.id]).toBeUndefined();
+  });
+
   it("stores the selected tenant when opening an MQ admin tab", async () => {
     const { useConnectionStore } = await import("@/stores/connectionStore");
     const { useQueryStore } = await import("@/stores/queryStore");

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -63,6 +63,7 @@ const METADATA_LOAD_DISABLED_QUERY_TIMEOUT_MS = 60_000;
 const DISCONNECT_REQUEST_TIMEOUT_MS = 5_000;
 const MONGO_LEGACY_DRIVER_PROFILE = "mongodb-legacy";
 const MONGO_LEGACY_DRIVER_LABEL = "MongoDB (Legacy)";
+const SUPERSEDED_CONNECTION_ATTEMPT_MESSAGE = "Connection attempt was superseded by a newer attempt";
 function sidebarObjectGroupPageSize(): number {
   const settingsStore = useSettingsStore();
   const size = settingsStore.desktopSettings.sidebar_table_page_size;
@@ -224,6 +225,7 @@ export const useConnectionStore = defineStore("connection", () => {
   const sidebarLayout = ref<SidebarLayout>(emptyLayout());
   let layoutPersistTimer: ReturnType<typeof setTimeout> | null = null;
   const staleTreeRefreshIds = new Set<string>();
+  const connectInFlight = new Map<string, Promise<void>>();
   let beforeConnectHandler: BeforeConnectHandler | null = null;
   let initFromDiskPromise: Promise<void> | null = null;
 
@@ -253,6 +255,10 @@ export const useConnectionStore = defineStore("connection", () => {
   function connectionErrorMessage(error: unknown): string {
     if (error instanceof Error) return error.message;
     return String(error);
+  }
+
+  function isSupersededConnectionAttempt(error: unknown): boolean {
+    return connectionErrorMessage(error).includes(SUPERSEDED_CONNECTION_ATTEMPT_MESSAGE);
   }
 
   function setConnectionError(connectionId: string, message: string) {
@@ -1196,7 +1202,12 @@ export const useConnectionStore = defineStore("connection", () => {
       recordConnectionError(connectionId, error);
       throw error;
     }
-    try {
+    const existingConnect = connectInFlight.get(connectionId);
+    if (existingConnect) {
+      await existingConnect;
+      return;
+    }
+    const connectPromise = (async () => {
       await beforeConnectHandler?.(config);
       await withConnectionAttemptTimeout(api.connectDb(config), config);
       await syncMongoLegacyDriverFallback(connectionId, config);
@@ -1204,9 +1215,21 @@ export const useConnectionStore = defineStore("connection", () => {
       markConnectionHealthChecked(connectionId);
       activeConnectionId.value = connectionId;
       clearConnectionError(connectionId);
+    })();
+    connectInFlight.set(connectionId, connectPromise);
+    try {
+      await connectPromise;
     } catch (e) {
+      if (isSupersededConnectionAttempt(e) && connectedIds.value.has(connectionId)) {
+        clearConnectionError(connectionId);
+        return;
+      }
       recordConnectionError(connectionId, e);
       throw e;
+    } finally {
+      if (connectInFlight.get(connectionId) === connectPromise) {
+        connectInFlight.delete(connectionId);
+      }
     }
   }
 


### PR DESCRIPTION
## 变更说明
- 复用同一连接的进行中连接请求，避免并发触发重复 connect。
- 对已被新连接尝试取代的旧请求，不再残留连接错误提示。
- 增加回归测试覆盖并发 ensureConnected 不会留下 stale error。

## 验证
- ./node_modules/.bin/vitest run apps/desktop/src/stores/__tests__/connectionStore.mq.spec.ts
- ./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json
- ./node_modules/.bin/oxfmt apps/desktop/src/stores/connectionStore.ts apps/desktop/src/stores/__tests__/connectionStore.mq.spec.ts --check