### PR TITLE
fix(starrocks): detect primary keys via information_schema.COLUMNS

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2442,7 +2442,15 @@ pub async fn get_columns_core(
             }
             PoolKind::Mysql(p, _) if db_config.as_ref().is_some_and(is_doris_family_config) => {
                 let metadata_database = mysql_show_metadata_database_for_config(db_config.as_ref(), database);
-                db::mysql::get_columns_show(p, metadata_database, table).await.map(deduplicate_column_infos)
+                // Doris/StarRocks previously went straight to `SHOW COLUMNS` for
+                // speed (see perf(doris) commit), but `SHOW COLUMNS` reports the
+                // `Key` column as `YES`/`NO` rather than MySQL's `PRI`, so primary
+                // keys were never detected. `get_columns` queries
+                // information_schema.COLUMNS first — where `COLUMN_KEY = 'PRI'`
+                // correctly identifies primary keys (and only real primary keys,
+                // not duplicate-key sort columns) — and falls back to `SHOW COLUMNS`
+                // automatically when information_schema is unavailable.
+                db::mysql::get_columns(p, metadata_database, table).await.map(deduplicate_column_infos)
             }
             PoolKind::Mysql(p, mode) => {
                 dispatch_mysql!(p, mode, db::mysql::get_columns, db::ob_oracle::get_columns, database, table)

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -286,6 +286,7 @@ mod tests {
             redis_sentinel_tls: false,
             redis_cluster_nodes: String::new(),
             redis_key_separator: dbx_core::models::connection::default_redis_key_separator(),
+            redis_scan_page_size: None,
             etcd_endpoints: String::new(),
             gbase_server: String::new(),
             informix_server: String::new(),

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -248,6 +248,7 @@ mod tests {
             redis_sentinel_tls: false,
             redis_cluster_nodes: String::new(),
             redis_key_separator: dbx_core::models::connection::default_redis_key_separator(),
+            redis_scan_page_size: None,
             etcd_endpoints: String::new(),
             gbase_server: String::new(),
             informix_server: String::new(),


### PR DESCRIPTION
## 变更说明

StarRocks/Doris（Doris 家族）打开表数据时始终提示"无主键定位"，即使表本身有 primary key。

**根因**：Doris 家族为加速元数据浏览，列信息强制走 `SHOW COLUMNS` 路径（`get_columns_show`，见 `perf(doris)` 提交 69ecde8f）。但 StarRocks 的 `SHOW COLUMNS` 对主键列返回 `Key = YES`（不是 MySQL 的 `PRI`），而代码判断的是 `Key == "PRI"`，导致 `is_primary_key` 恒为 false。

**修复**：Doris 家族改用 `get_columns`（先查 `information_schema.COLUMNS`，失败自动回退 `SHOW COLUMNS`）。`information_schema.COLUMNS.COLUMN_KEY = 'PRI'` 能正确识别主键，且只对真正的 PRIMARY KEY 表生效——不会把 DUPLICATE KEY 表的排序列误判为主键（而 SHOW 的 `Key=YES` 无法区分两者）。

## 变更类型

- [x] Bug 修复

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

纯后端（Rust）改动，不涉及前端。

## 验证

对 StarRocks 连接实测：
- `information_schema.COLUMNS` 对 bi 库主键表返回 `COLUMN_KEY = 'PRI'` ✅
- `SHOW COLUMNS` 对主键列返回 `Key = YES`（未被旧代码识别）❌
- paimon catalog 外部表：两条路径都拿不到主键（无回归）

- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过（`cargo test -p dbx-core --lib schema::` 33 项、`db::mysql` 74 项全过）
- `pnpm check` 不适用（本 PR 仅改动 Rust）

## 关联 Issue

暂无对应 issue，搜索上游未发现相同问题报告。
