### PR TITLE
fix(mysql): health-check pooled connection before DDL query

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -3436,7 +3436,12 @@ mod ddl_tests {
 pub async fn mysql_ddl(pool: &db::mysql::MySqlPool, table: &str) -> Result<String, String> {
     use mysql_async::prelude::*;
     let sql = format!("SHOW CREATE TABLE `{}`", table.replace('`', "``"));
-    let mut conn = pool.get_conn().await.map_err(|e| e.to_string())?;
+    // Use the health-checked getter so a stale pooled connection (server closed
+    // it after an idle timeout, NAT/firewall dropped the TCP state, etc.) is
+    // detected and replaced before issuing the query. Without this, the first
+    // DDL request after a period of inactivity could surface a low-level
+    // connection error that a manual refresh would have masked.
+    let mut conn = db::mysql::get_conn_with_health_check(pool).await?;
     let result = conn.query_iter(&sql).await.map_err(|e| e.to_string())?;
     let rows: Vec<mysql_async::Row> = result.collect_and_drop().await.map_err(|e| e.to_string())?;
     let row = rows.first().ok_or("DDL not found")?;

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -286,6 +286,7 @@ mod tests {
             redis_sentinel_tls: false,
             redis_cluster_nodes: String::new(),
             redis_key_separator: dbx_core::models::connection::default_redis_key_separator(),
+            redis_scan_page_size: None,
             etcd_endpoints: String::new(),
             gbase_server: String::new(),
             informix_server: String::new(),

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -248,6 +248,7 @@ mod tests {
             redis_sentinel_tls: false,
             redis_cluster_nodes: String::new(),
             redis_key_separator: dbx_core::models::connection::default_redis_key_separator(),
+            redis_scan_page_size: None,
             etcd_endpoints: String::new(),
             gbase_server: String::new(),
             informix_server: String::new(),


### PR DESCRIPTION
## 变更说明

查看表 DDL 时，首次请求（尤其闲置一段时间后）偶发 `Input/output error: Connection refused (os error 61)`，手动刷新后恢复。

**根因**：`mysql_ddl` 用裸 `pool.get_conn()` 获取连接后直接执行 `SHOW CREATE TABLE`，未走 `get_conn_with_health_check`，与 `get_columns`、`list_indexes` 等其他读取路径不一致。连接池中失效的连接（服务端空闲超时关闭、NAT/防火墙丢弃 TCP 状态等）不会被预先探测替换，导致首次 DDL 请求可能抛出底层连接错误。

**修复**：`mysql_ddl` 改用 `get_conn_with_health_check`，与其它 MySQL 元数据路径保持一致；失效连接会在查询前被 ping 探测并替换。

> 说明：`Connection refused`（ECONNREFUSED）本身是连接建立时被拒，健康检查主要解决的是失效连接（ECONNRESET 类）。因此该改动提升一致性与失效连接鲁棒性，但不一定能根治所有 ECONNREFUSED 场景（若为服务端连接数限制 / 瞬时不可达，需服务端配合）。作为低风险一致性改进提交。

## 变更类型

- [x] Bug 修复

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

纯后端（Rust）改动，不涉及前端。

## 验证

- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过（`cargo test -p dbx-core --lib schema::` / `db::mysql` 全过）
- `pnpm check` 不适用（本 PR 仅改动 Rust）

## 关联 Issue

暂无对应 issue，搜索上游未发现相同问题报告。
