### PR TITLE
Fix：修复 PostgreSQL 字段名高亮异常

### DIFF
--- a/apps/desktop/src/lib/__tests__/codemirrorSqlDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/codemirrorSqlDialect.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { PostgreSQL } from "@codemirror/lang-sql";
+import { postgresKeywordSyntaxTerms } from "@/lib/codemirrorSqlDialect";
+
+describe("codemirrorSqlDialect", () => {
+  it("keeps common PostgreSQL identifier names out of keyword highlighting", () => {
+    const keywords = new Set(postgresKeywordSyntaxTerms(PostgreSQL.spec.keywords || "").split(/\s+/));
+
+    expect(keywords.has("select")).toBe(true);
+    expect(keywords.has("from")).toBe(true);
+    expect(keywords.has("where")).toBe(true);
+    expect(keywords.has("id")).toBe(false);
+    expect(keywords.has("name")).toBe(false);
+    expect(keywords.has("user")).toBe(false);
+    expect(keywords.has("count")).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/codemirrorSqlDialect.ts
@@ -40,18 +40,27 @@ const DBX_COMMON_SQL_KEYWORDS = [
 const POSTGRES_PLPGSQL_KEYWORDS = "PERFORM";
 const POSTGRES_PLPGSQL_TYPES = "RECORD JSON JSONB";
 const POSTGRES_PLPGSQL_BUILTIN = "SQLERRM TG_NAME TG_WHEN TG_LEVEL TG_OP TG_RELID TG_RELNAME TG_TABLE_NAME TG_TABLE_SCHEMA TG_NARGS TG_ARGV";
+const POSTGRES_IDENTIFIER_LIKE_KEYWORDS = new Set("COMMENT COUNT DATA DAY HOUR ID KEY LEVEL MINUTE MONTH NAME OWNER PASSWORD POSITION ROLE SECOND TYPE USER VALUE YEAR".split(" "));
 
 // SQL Server table-valued parameters require READONLY in procedure/function declarations.
 const SQLSERVER_KEYWORDS = "readonly";
+
+export function postgresKeywordSyntaxTerms(keywords: string): string {
+  return keywords
+    .split(/\s+/)
+    .filter((keyword) => keyword && !POSTGRES_IDENTIFIER_LIKE_KEYWORDS.has(keyword.toUpperCase()))
+    .join(" ");
+}
 
 export function createDbxCodeMirrorSqlDialect(langSql: CodeMirrorSqlLanguageModule, dialectName: CodeMirrorSqlDialectName = "mysql"): SQLDialect {
   const baseDialect = dialectName === "postgres" ? langSql.PostgreSQL : dialectName === "sqlserver" ? langSql.MSSQL : langSql.MySQL;
   const isPostgres = dialectName === "postgres";
   const isSqlServer = dialectName === "sqlserver";
+  const baseKeywords = isPostgres ? postgresKeywordSyntaxTerms(baseDialect.spec.keywords || "") : baseDialect.spec.keywords || "";
 
   return langSql.SQLDialect.define({
     ...baseDialect.spec,
-    keywords: [baseDialect.spec.keywords || "", DBX_COMMON_SQL_KEYWORDS, isPostgres ? POSTGRES_PLPGSQL_KEYWORDS : "", isSqlServer ? SQLSERVER_KEYWORDS : ""].filter(Boolean).join(" "),
+    keywords: [baseKeywords, DBX_COMMON_SQL_KEYWORDS, isPostgres ? POSTGRES_PLPGSQL_KEYWORDS : "", isSqlServer ? SQLSERVER_KEYWORDS : ""].filter(Boolean).join(" "),
     types: [baseDialect.spec.types || "", isPostgres ? POSTGRES_PLPGSQL_TYPES : ""].filter(Boolean).join(" ") || undefined,
     builtin: [baseDialect.spec.builtin || "", isPostgres ? POSTGRES_PLPGSQL_BUILTIN : ""].filter(Boolean).join(" ") || undefined,
     doubleDollarQuotedStrings: false,

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -286,6 +286,7 @@ mod tests {
             redis_sentinel_tls: false,
             redis_cluster_nodes: String::new(),
             redis_key_separator: dbx_core::models::connection::default_redis_key_separator(),
+            redis_scan_page_size: None,
             etcd_endpoints: String::new(),
             gbase_server: String::new(),
             informix_server: String::new(),

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -248,6 +248,7 @@ mod tests {
             redis_sentinel_tls: false,
             redis_cluster_nodes: String::new(),
             redis_key_separator: dbx_core::models::connection::default_redis_key_separator(),
+            redis_scan_page_size: None,
             etcd_endpoints: String::new(),
             gbase_server: String::new(),
             informix_server: String::new(),


### PR DESCRIPTION
## 变更

- 过滤 CodeMirror PostgreSQL dialect 中容易作为字段名使用的非保留词，避免 `id`、`name`、`user`、`count` 等字段被当作 keyword 高亮。
- 保留 `SELECT`、`FROM`、`WHERE` 等真正 SQL 语法关键字的高亮。
- 补充单测覆盖 PostgreSQL keyword 过滤行为。

## 验证

- `vitest run apps/desktop/src/lib/__tests__/codemirrorSqlDialect.spec.ts`
- `oxlint apps/desktop/src/lib/codemirrorSqlDialect.ts apps/desktop/src/lib/__tests__/codemirrorSqlDialect.spec.ts`
- `vue-tsc --noEmit --project apps/desktop/tsconfig.json`