### PR TITLE
fix(check): run pnpm checks on Windows

### DIFF
--- a/scripts/run-check.mjs
+++ b/scripts/run-check.mjs
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { performance } from "node:perf_hooks";
+import { delimiter, join } from "node:path";
 
 const tasks = [
   {
@@ -26,9 +27,10 @@ const tasks = [
 
 function runTask(task) {
   const startedAt = performance.now();
-  const child = spawn(task.command, task.args, {
+  const command = commandSpec(task);
+  const child = spawn(command.program, command.args, {
     cwd: process.cwd(),
-    env: process.env,
+    env: commandEnv(),
     stdio: ["ignore", "pipe", "pipe"],
   });
   const stdout = [];
@@ -58,6 +60,19 @@ function runTask(task) {
       });
     });
   });
+}
+
+function commandSpec(task) {
+  if (process.platform !== "win32") return { program: task.command, args: task.args };
+  const command = join(process.cwd(), "node_modules", ".bin", `${task.command}.CMD`);
+  return { program: "cmd.exe", args: ["/d", "/c", "call", command, ...task.args] };
+}
+
+function commandEnv() {
+  return {
+    ...process.env,
+    PATH: [join(process.cwd(), "node_modules", ".bin"), process.env.PATH].filter(Boolean).join(delimiter),
+  };
 }
 
 function outputFailureExcerpt(output) {


### PR DESCRIPTION
## 变更说明

- 修复 Windows 下 `scripts/run-check.mjs` 通过 Node `spawn("oxfmt")` 等命令时无法解析 pnpm 生成的 `.CMD` shim，导致 `pnpm check` 报 `ENOENT` 的问题。
- Windows 下显式通过 `cmd.exe /d /c call node_modules/.bin/<tool>.CMD` 启动本地工具，同时把 `node_modules/.bin` 注入 PATH。
- 非 Windows 平台保持原有直接启动命令行为。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

不涉及前端改动。

## 验证

- [ ] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [ ] 相关测试通过

已执行：

```bash
pnpm check
cargo check --no-default-features
```

说明：

- `pnpm check` 已能在 Windows 下启动 `oxfmt`、`oxlint`、`vue-tsc`、`vitest`，不再出现工具 `ENOENT`。
- 当前 `pnpm check` 仍失败于仓库既有检查项：前端文件 `oxfmt --check` 格式不一致，以及若干 Windows/环境相关测试失败（如 symlink 权限、Linux 路径断言等），与本次脚本启动修复无关。

## 关联 Issue

无
