### PR TITLE
Fix: 修复 AI SQL 方言上下文

### DIFF
--- a/apps/desktop/src/lib/__tests__/ai.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildSystemPrompt, type AiContext } from "@/lib/ai";
+
+function context(overrides: Partial<AiContext> = {}): AiContext {
+  return {
+    connectionId: "conn-1",
+    connectionName: "Postgres",
+    databaseType: "postgres",
+    database: "app",
+    currentSql: "",
+    tables: [],
+    truncated: false,
+    ...overrides,
+  };
+}
+
+describe("AI SQL dialect prompt", () => {
+  it("pins identifier quoting to the active database type", () => {
+    const prompt = buildSystemPrompt("generate", context(), "ask");
+
+    expect(prompt).toContain("Database type: postgres");
+    expect(prompt).toContain("PostgreSQL/SQLite/Oracle");
+    expect(prompt).toContain('double quotes "name"');
+    expect(prompt).toContain("Do not switch dialects merely because the user mentions another database in prose.");
+  });
+});

--- a/apps/desktop/src/lib/ai.ts
+++ b/apps/desktop/src/lib/ai.ts
@@ -6,6 +6,7 @@ import { currentLocale, type Locale } from "@/i18n";
 import { aiTableMentionKey, type AiTableMention } from "@/lib/aiTableMentions";
 import { aiSkillForAction } from "@/lib/aiSkills";
 import { isSchemaAware } from "@/lib/databaseCapabilities";
+import { effectiveDatabaseTypeForConnection } from "@/lib/jdbcDialect";
 
 import type { AgentEvent } from "@/lib/tauri";
 
@@ -187,6 +188,9 @@ function buildBasePromptLines(isZh: boolean): string[] {
     isZh ? "精确、保守，根据当前数据库方言生成 SQL。" : "Be precise, conservative, and adapt SQL to the active database dialect.",
     isZh ? "严格使用当前数据库方言；标识符引用、分页、日期函数、字符串拼接、LIMIT/TOP/OFFSET 语法必须匹配数据库类型。" : "Strictly use the active database dialect; identifier quoting, pagination, date functions, string concatenation, and LIMIT/TOP/OFFSET syntax must match the database type.",
     isZh
+      ? '标识符引用必须匹配当前连接类型：MySQL/MariaDB 用反引号 `name`，PostgreSQL/SQLite/Oracle 等用双引号 "name"，SQL Server 用方括号 [name]；不要因为用户口头提到其他数据库而切换方言。'
+      : 'Identifier quoting must match the active connection type: MySQL/MariaDB use backticks `name`, PostgreSQL/SQLite/Oracle and similar dialects use double quotes "name", and SQL Server uses brackets [name]. Do not switch dialects merely because the user mentions another database in prose.',
+    isZh
       ? "对于普通数据查询，优先使用下面已加载的 Schema 上下文，不要为了重复确认已给出的结构而查询 information_schema 或系统表。但当用户询问某表的字段详情、列信息时，应使用 get_columns 工具获取最权威完整的定义。"
       : "For ordinary data queries, prefer the loaded schema context below. Do not query information_schema or system tables merely to rediscover structure already provided. However, when the user asks for detailed column/field information of a specific table, use the get_columns tool for the authoritative and complete definition.",
     isZh
@@ -270,6 +274,7 @@ function formatSchema(context: AiContext): string {
 export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig, options: { maxTables?: number; maxColumnsPerTable?: number; mentionedTables?: AiTableMention[] } = {}): Promise<AiContext> {
   const maxTables = options.maxTables ?? 50;
   const maxColumnsPerTable = options.maxColumnsPerTable ?? 40;
+  const databaseType = aiDatabaseTypeForConnection(connection);
   const tables: AiSchemaTable[] = [];
   const tableKeys = new Set<string>();
   let truncated = false;
@@ -318,7 +323,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
               api.listIndexes(tab.connectionId, tab.database, schema, table.name).catch(() => [] as IndexInfo[]),
               api.listForeignKeys(tab.connectionId, tab.database, schema, table.name).catch(() => [] as ForeignKeyInfo[]),
             ]).then(([columns, indexes, foreignKeys]) => ({
-              schema: schema === tab.database && !isSchemaAware(connection.db_type) ? undefined : schema,
+              schema: schema === tab.database && !isSchemaAware(databaseType) ? undefined : schema,
               name: table.name,
               tableType: table.table_type,
               comment: table.comment,
@@ -348,7 +353,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
   return {
     connectionId: tab.connectionId,
     connectionName: connection.name,
-    databaseType: connection.db_type,
+    databaseType,
     database: tab.database,
     currentSql: tab.sql,
     lastError: extractLastError(tab.result),
@@ -360,6 +365,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
 }
 
 async function loadMentionedTableContext(tab: QueryTab, connection: ConnectionConfig, mention: AiTableMention, maxColumnsPerTable: number): Promise<AiSchemaTable | undefined> {
+  const databaseType = aiDatabaseTypeForConnection(connection);
   const schema = await resolveMentionedTableSchema(tab, connection, mention);
   const [columns, indexes, foreignKeys, tableComment] = await Promise.all([
     api.getColumns(tab.connectionId, tab.database, schema, mention.table),
@@ -368,7 +374,7 @@ async function loadMentionedTableContext(tab: QueryTab, connection: ConnectionCo
     loadTableComment(tab.connectionId, tab.database, schema, mention.table).catch(() => undefined),
   ]);
   return {
-    schema: schema === tab.database && !isSchemaAware(connection.db_type) ? undefined : schema,
+    schema: schema === tab.database && !isSchemaAware(databaseType) ? undefined : schema,
     name: mention.table,
     tableType: "TABLE",
     comment: tableComment,
@@ -388,7 +394,7 @@ async function resolveMentionedTableSchema(tab: QueryTab, connection: Connection
   if (tab.tableMeta?.tableName.toLowerCase() === mention.table.toLowerCase() && tab.tableMeta.schema) {
     return tab.tableMeta.schema;
   }
-  if (isSchemaAware(connection.db_type)) {
+  if (isSchemaAware(aiDatabaseTypeForConnection(connection))) {
     const schemas = await loadCandidateSchemas(tab, connection);
     for (const schema of schemas) {
       const tables = await api.listTables(tab.connectionId, tab.database, schema, mention.table, 10).catch(() => []);
@@ -399,11 +405,15 @@ async function resolveMentionedTableSchema(tab: QueryTab, connection: Connection
 }
 
 async function loadCandidateSchemas(tab: QueryTab, connection: ConnectionConfig): Promise<string[]> {
-  if (isSchemaAware(connection.db_type)) {
+  if (isSchemaAware(aiDatabaseTypeForConnection(connection))) {
     const schemas = await api.listSchemas(tab.connectionId, tab.database);
     return prioritizeSchemas(schemas);
   }
   return [tab.database || connection.database || "main"];
+}
+
+function aiDatabaseTypeForConnection(connection: ConnectionConfig): DatabaseType {
+  return effectiveDatabaseTypeForConnection(connection) ?? connection.db_type;
 }
 
 function prioritizeSchemas(schemas: string[]): string[] {


### PR DESCRIPTION
## 变更说明

- AI 上下文改用 `effectiveDatabaseTypeForConnection`，避免 JDBC/GBase 等连接把原始 `db_type` 误传给模型
- Schema-aware 判断同步使用有效数据库类型，保持上下文和 SQL 方言一致
- 强化 AI prompt，明确 MySQL/MariaDB 使用反引号、PostgreSQL/SQLite/Oracle 等使用双引号、SQL Server 使用方括号，避免用户口头提到其他数据库时切换方言
- 增加 prompt 单测覆盖当前连接方言规则

## 验证

- `/Users/staff/dbx/node_modules/.bin/oxfmt apps/desktop/src/lib/ai.ts apps/desktop/src/lib/__tests__/ai.spec.ts`
- `/Users/staff/dbx/node_modules/.bin/vitest run apps/desktop/src/lib/__tests__/ai.spec.ts apps/desktop/src/lib/__tests__/jdbcDialect.spec.ts`
- `git diff --check`