### PR TITLE
fix: resolve issue #1817

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -1744,7 +1744,10 @@ pub async fn execute_query_with_schema_and_max_rows(
     }
 
     let set_schema_start = Instant::now();
-    client.execute(&format!("SET search_path TO {}", pg_quote_ident(schema)), &[]).await.map_err(pg_error_to_string)?;
+    client
+        .execute(&format!("SET search_path TO {}, public", pg_quote_ident(schema)), &[])
+        .await
+        .map_err(pg_error_to_string)?;
     log::info!(
         "[postgres][execute_with_schema:set-search-path:done] elapsed_ms={} total_ms={}",
         set_schema_start.elapsed().as_millis(),
@@ -1808,7 +1811,10 @@ pub async fn execute_query_with_schema_and_max_rows_and_cancel(
     }
 
     let set_schema_start = Instant::now();
-    client.execute(&format!("SET search_path TO {}", pg_quote_ident(schema)), &[]).await.map_err(pg_error_to_string)?;
+    client
+        .execute(&format!("SET search_path TO {}, public", pg_quote_ident(schema)), &[])
+        .await
+        .map_err(pg_error_to_string)?;
     log::info!(
         "[postgres][execute_with_schema:set-search-path:done] elapsed_ms={} total_ms={}",
         set_schema_start.elapsed().as_millis(),


### PR DESCRIPTION
 Title:                                                                                                                
  fix(postgres): include public schema in search_path for PostGIS functions                                             
                                                                                                                        
  Body:                                                                                                                 
                                                                                                                        
  ## 变更说明                                                                                                           
                                                                                                                        
  PostgreSQL 执行带 schema 的查询时，`SET search_path TO "schema"` 会替换默认的 `"$user", public` 搜索路径，导致 PostGIS
   扩展安装在 `public` schema 中的函数（如 `ST_SRID`、`ST_AsText`、`ST_Transform` 等）无法被找到。                      
                                                                                                                        
  修复方式：将 `SET search_path TO "schema"` 改为 `SET search_path TO "schema", public`，确保用户 schema                
  优先解析的同时，`public` 中的扩展函数仍然可用。                                                                       
                                                                                                                        
  ## 变更类型                                                                                                           
                                                                                                                        
  - [x] Bug 修复                                                                                                        
                                                                                                                        
  ## 涉及前端                                                                                                           
                                                                                                                        
  - [ ] 本 PR 涉及前端改动                                                                                              
                                                                                                                        
  ## 验证                                                                                                               
                                                                                                                        
  - [x] `cargo check --no-default-features` 通过                                                                        
  - [x] 连接 PostgreSQL 后执行 `SELECT ST_SRID(geom) FROM "table"` 不再报 function does not exist                       
  - [x] `SELECT PostGIS_Version()` 正常返回版本号                                                                       
                                                                                                                        
  ## 关联 Issue                                                                                                         
                                                                                                                        
  Related #1817 