### PR TITLE
fix: avoid moving InfluxDB url params during connection test

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -779,7 +779,7 @@ pub async fn test_connection(state: State<'_, Arc<AppState>>, config: Connection
                     &url,
                     username,
                     password,
-                    config.url_params,
+                    config.url_params.clone(),
                     Some(&config.ca_cert_path),
                     connect_timeout,
                 )?;


### PR DESCRIPTION
## 变更说明

修复 InfluxDB 测试连接分支移动 `config.url_params` 后，后续在传输层重置逻辑中再次借用 `config` 导致的 Rust 编译错误：

- 将 `config.url_params` 改为 `config.url_params.clone()` 传入 InfluxDB client 构造函数，避免对 `config` 发生部分移动。
- 引入该问题的 commit：0bd07ccf46bd07dab7177bc590e149aa17d6d5dc (`feat: add InfluxDB support (#980)`)。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [ ] 相关测试通过

## 关联 Issue

