### PR TITLE
fix(navicatImport): 修复 OceanBase NCX 连接导入模式

### DIFF
--- a/apps/desktop/src/lib/navicatImport.ts
+++ b/apps/desktop/src/lib/navicatImport.ts
@@ -164,15 +164,18 @@ async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | nul
     return null;
   }
 
-  // Navicat NCX uses ServiceProvider to distinguish vendor-specific database types.
-  // e.g. OceanBase Oracle reports ConnType="ORACLE" ServiceProvider="AliyunOceanBase"
+  // Navicat NCX uses ServiceProvider to distinguish vendor-specific database providers.
+  // e.g. OceanBase MySQL reports ConnType="MYSQL" ServiceProvider="AliyunOceanBase"
+  //      OceanBase Oracle reports ConnType="ORACLE" ServiceProvider="AliyunOceanBase"
   //      GaussDB reports ConnType="POSTGRESQL" ServiceProvider="HuaweiCloudGaussDB"
+  // For OceanBase, ConnType remains the source of truth for the compatibility mode.
   const serviceProvider = getAny(node.values, ["serviceprovider"]);
   let effectiveProfile = profile;
   if (serviceProvider) {
     const sp = serviceProvider.toLowerCase();
     if (sp.includes("oceanbase")) {
-      effectiveProfile = { ...profile, dbType: "oceanbase-oracle", profile: "oceanbase", label: "OceanBase", port: 2881 };
+      const oceanbaseOracleMode = normalizeKey(rawType).includes("oracle") || profile.dbType === "oracle";
+      effectiveProfile = oceanbaseOracleMode ? { ...profile, dbType: "oceanbase-oracle", profile: "oceanbase-oracle", label: "OceanBase Oracle Mode", port: 2881 } : { ...profile, dbType: "mysql", profile: "oceanbase", label: "OceanBase", port: 2881 };
     } else if (sp.includes("gaussdb") || sp.includes("huaweicloudgauss")) {
       effectiveProfile = { ...profile, dbType: "gaussdb", profile: "gaussdb", label: "GaussDB", port: 8000 };
     }
@@ -181,7 +184,8 @@ async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | nul
   const sqlitePath = effectiveProfile.dbType === "sqlite" ? getSqlitePath(node.values) : "";
   const name = getAny(node.values, ["name", "connectionName", "connName", "caption", "title"]) || getAny(node.values, ["host", "server", "hostname"]) || sqlitePath || effectiveProfile.label;
   const host = sqlitePath || getAny(node.values, ["host", "server", "hostname", "serverHost", "address"]) || (effectiveProfile.dbType === "sqlite" ? "" : "127.0.0.1");
-  const database = effectiveProfile.dbType === "sqlite" ? sqlitePath : getAny(node.values, ["database", "databaseName", "initialDatabase", "serviceName", "sid", "schema"]);
+  // Navicat exports OceanBase Oracle connections with Database="ORCL", but OceanBase resolves the target from the username.
+  const database = effectiveProfile.dbType === "sqlite" ? sqlitePath : effectiveProfile.dbType === "oceanbase-oracle" ? "" : getAny(node.values, ["database", "databaseName", "initialDatabase", "serviceName", "sid", "schema"]);
   const isOracleLike = effectiveProfile.dbType === "oracle" || effectiveProfile.dbType === "oceanbase-oracle";
   const oracleConnectionType = isOracleLike && getAny(node.values, ["sid"]) ? "sid" : isOracleLike ? "service_name" : undefined;
   const username = getAny(node.values, ["user", "username", "userName", "uid"]) || profile.user;


### PR DESCRIPTION
## 变更说明

修复 Navicat NCX 导入 OceanBase 连接时模式识别不完整的问题。

- 根据 Navicat NCX 的 `ConnType` 区分 OceanBase MySQL 和 Oracle 模式：
  - `ConnType="MYSQL"` 导入为 DBX 的 OceanBase MySQL 模式
  - `ConnType="ORACLE"` 导入为 `oceanbase-oracle`
- 同时忽略 OceanBase Oracle 连接中的 `Database="ORCL"` 占位数据库，避免生成错误连接配置。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] ~~本 PR 涉及前端改动，已附截图/录屏（见下方）~~

本 PR 不涉及 UI 组件、样式、交互或文案改动，仅修复 Navicat NCX 连接导入逻辑。

## 验证

- [x] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过
  - `pnpm test -- apps/desktop/src/lib/__tests__/navicatImport.spec.ts`
  - `pnpm typecheck`
1. 在 Navicat 中导出包含 OceanBase MySQL 和 OceanBase Oracle 模式的 .ncx 文件
2. 在 DBX 中导入该文件，查看连接类型是否正确，测试是否能正确连接

## 关联 Issue

Related #1282 该 issue 此前修复不完整