### PR TITLE
feat(ai): support custom Anthropic messages API

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -1437,6 +1437,7 @@ const aiModelLoadedSignature = ref("");
 let aiModelRequestToken = 0;
 
 const aiCompletionsMode = computed(() => aiEditApiStyle.value === "completions");
+const aiAnthropicMessagesMode = computed(() => aiEditApiStyle.value === "anthropic-messages");
 const aiReasoningLevelOptions: Array<{ value: AiReasoningLevel; labelKey: string }> = [
   { value: "default", labelKey: "ai.reasoningLevelDefault" },
   { value: "minimal", labelKey: "ai.reasoningLevelMinimal" },
@@ -1455,7 +1456,7 @@ watch(aiIsCodexCli, (isCodex) => {
   if (isCodex) void ensureCodexMcpStatus();
 });
 const aiRequiresApiKey = computed(() => AI_PROVIDER_PRESETS[aiEditProvider.value].requiresApiKey);
-const aiSupportsAuthMethod = computed(() => aiEditProvider.value === "claude");
+const aiSupportsAuthMethod = computed(() => aiEditProvider.value === "claude" || (aiEditProvider.value === "custom" && aiAnthropicMessagesMode.value));
 const aiCredentialLabel = computed(() => (aiSupportsAuthMethod.value && aiEditAuthMethod.value === "bearer" ? "Auth Token" : "API Key"));
 const aiCredentialPlaceholder = computed(() => {
   if (!aiRequiresApiKey.value) return "Optional";
@@ -1463,18 +1464,25 @@ const aiCredentialPlaceholder = computed(() => {
   return "";
 });
 const aiEndpointPlaceholder = computed(() => {
+  if (aiEditProvider.value === "custom" && aiAnthropicMessagesMode.value) {
+    return "https://api.example.com/v1/messages";
+  }
   if (aiEditProvider.value === "openai-compatible" || aiEditProvider.value === "custom") {
     return "https://api.example.com/v1";
   }
   return "https://api.openai.com/v1";
 });
 const aiEndpointHint = computed(() => {
+  if (aiEditProvider.value === "custom" && aiAnthropicMessagesMode.value) {
+    return t("ai.anthropicMessagesHint");
+  }
   if (aiEditProvider.value === "openai-compatible" || aiEditProvider.value === "custom") {
     return "大多数 OpenAI 兼容 API 需要 /v1 路径前缀";
   }
   return "";
 });
 const aiSupportsApiStyle = computed(() => !aiIsCodexCli.value && (aiEditProvider.value === "openai" || aiEditProvider.value === "openai-compatible" || aiEditProvider.value === "custom"));
+const aiSupportsAnthropicApiStyle = computed(() => aiEditProvider.value === "custom");
 const aiCodexMcpNeedsInstall = computed(() => aiIsCodexCli.value && (!mcpStatus.value || !mcpStatus.value.installed));
 const aiCodexMcpCanInstall = computed(() => {
   const status = mcpStatus.value;
@@ -1686,6 +1694,13 @@ function aiSelectProvider(provider: AiProvider) {
   aiTestErrorCopied.value = false;
   clearAiModelOptions();
   if (provider === "codex-cli") void ensureCodexMcpStatus();
+}
+
+function aiSelectApiStyle(style: AiApiStyle) {
+  aiEditApiStyle.value = style;
+  if (aiEditProvider.value === "custom") {
+    aiEditAuthMethod.value = style === "anthropic-messages" ? "api-key" : "bearer";
+  }
 }
 
 function aiHasChanges(): boolean {
@@ -3058,8 +3073,9 @@ watch(
                 <div v-if="aiSupportsApiStyle" class="grid grid-cols-3 items-center gap-3">
                   <Label class="text-right text-xs">API</Label>
                   <div class="col-span-2 flex gap-2">
-                    <Button size="sm" variant="outline" class="h-8 flex-1 text-xs" :class="{ 'border-blue-300 border-2 ring-2 ring-blue-300/50': aiEditApiStyle === 'completions' }" @click="aiEditApiStyle = 'completions'">/chat/completions</Button>
-                    <Button size="sm" variant="outline" class="h-8 flex-1 text-xs" :class="{ 'border-blue-300 border-2 ring-2 ring-blue-300/50': aiEditApiStyle === 'responses' }" @click="aiEditApiStyle = 'responses'">/responses</Button>
+                    <Button size="sm" variant="outline" class="h-8 flex-1 text-xs" :class="{ 'border-blue-300 border-2 ring-2 ring-blue-300/50': aiEditApiStyle === 'completions' }" @click="aiSelectApiStyle('completions')">/chat/completions</Button>
+                    <Button size="sm" variant="outline" class="h-8 flex-1 text-xs" :class="{ 'border-blue-300 border-2 ring-2 ring-blue-300/50': aiEditApiStyle === 'responses' }" @click="aiSelectApiStyle('responses')">/responses</Button>
+                    <Button v-if="aiSupportsAnthropicApiStyle" size="sm" variant="outline" class="h-8 flex-1 text-xs" :class="{ 'border-blue-300 border-2 ring-2 ring-blue-300/50': aiEditApiStyle === 'anthropic-messages' }" @click="aiSelectApiStyle('anthropic-messages')">/messages</Button>
                   </div>
                 </div>
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1115,6 +1115,7 @@ export default {
     enableThinkingOn: "Enabled",
     enableThinkingOff: "Disabled",
     enableThinkingHint: "This option only takes effect on /chat/completions APIs and supported models. When disabled, it can significantly reduce token usage, but the quality of generated results may decrease slightly.",
+    anthropicMessagesHint: "Anthropic Messages compatible APIs usually use /v1/messages.",
     contextWindow: "Context Window",
     contextWindowAuto: "Auto (detect from model name)",
     contextWindowHint: "Tokens. Leave empty to auto-detect. Set manually for local/custom models.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -951,6 +951,7 @@ export default {
     proxy: "Proxy",
     proxyEnable: "Enviar solicitudes de IA mediante proxy",
     proxyUrl: "URL del proxy",
+    anthropicMessagesHint: "Las API compatibles con Anthropic Messages suelen usar /v1/messages.",
     actions: {
       generate: "Generar SQL",
       explain: "Explicar SQL",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1054,6 +1054,7 @@ export default {
     proxy: "Proxy",
     proxyEnable: "Invia richieste AI tramite proxy",
     proxyUrl: "URL Proxy",
+    anthropicMessagesHint: "Le API compatibili con Anthropic Messages di solito usano /v1/messages.",
     enableThinking: "Pensiero (Thinking)",
     enableThinkingOn: "Abilitato",
     enableThinkingOff: "Disabilitato",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1110,6 +1110,7 @@ export default {
     enableThinkingOn: "有効",
     enableThinkingOff: "無効",
     enableThinkingHint: "このオプションは/chat/completions APIとサポートされているモデルでのみ有効です。無効にするとトークン使用量を大幅に削減できますが、生成結果の品質が若干低下する可能性があります。",
+    anthropicMessagesHint: "Anthropic Messages 互換 API は通常 /v1/messages を使用します。",
     actions: {
       generate: "SQLを生成",
       explain: "SQLを説明",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1054,6 +1054,7 @@ export default {
     proxy: "Proxy",
     proxyEnable: "Enviar requisições de AI através do proxy",
     proxyUrl: "URL do Proxy",
+    anthropicMessagesHint: "APIs compatíveis com Anthropic Messages geralmente usam /v1/messages.",
     enableThinking: "Raciocínio",
     enableThinkingOn: "Ativado",
     enableThinkingOff: "Desativado",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1114,6 +1114,7 @@ export default {
     enableThinkingOn: "已启用",
     enableThinkingOff: "已禁用",
     enableThinkingHint: "此选项仅对 /chat/completions API 且部分支持的模型生效。设为禁用后可大幅节省 token，但生成结果质量可能会略微下降。",
+    anthropicMessagesHint: "Anthropic Messages 兼容 API 通常使用 /v1/messages。",
     contextWindow: "上下文窗口",
     contextWindowAuto: "自动（根据模型名称推断）",
     contextWindowHint: "单位：token。留空自动推断，本地/自定义模型建议手动设置。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1021,6 +1021,7 @@ export default {
     enableThinkingOn: "已啟用",
     enableThinkingOff: "已停用",
     enableThinkingHint: "此選項僅對 /chat/completions API 且部分支援的模型生效。設為停用後可大幅節省 token，但產生結果品質可能會略微下降。",
+    anthropicMessagesHint: "Anthropic Messages 相容 API 通常使用 /v1/messages。",
     codexMcpRequiredTitle: "需要 DBX MCP Server",
     codexMcpRequiredDescription: "Codex CLI 會透過 DBX MCP Server 存取資料庫結構與查詢工具。請先安裝後再於 AI 助理中使用 Codex。",
     codexCliPathEnvError: "Codex CLI 路徑只能填寫可執行檔路徑。請在下方新增環境變數。",

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -13,7 +13,7 @@ import { setDebugLoggingEnabled } from "@/lib/debugLog";
 import { DEFAULT_TABLE_COLUMN_TEMPLATE_FIELDS, normalizeTableColumnTemplateFields } from "@/lib/tableColumnTemplates";
 
 export type AiProvider = "claude" | "openai" | "gemini" | "deepseek" | "qwen" | "ollama" | "openai-compatible" | "codex-cli" | "custom";
-export type AiApiStyle = "completions" | "responses";
+export type AiApiStyle = "completions" | "responses" | "anthropic-messages";
 export type AiAuthMethod = "api-key" | "bearer";
 export type AiReasoningLevel = "default" | "minimal" | "low" | "medium" | "high";
 

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -61,6 +61,8 @@ pub enum AiApiStyle {
     #[default]
     Completions,
     Responses,
+    #[serde(rename = "anthropic-messages")]
+    AnthropicMessages,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -264,6 +266,15 @@ fn ensure_openai_version_prefix(endpoint: &str) -> String {
     }
 }
 
+fn ensure_anthropic_version_prefix(endpoint: &str) -> String {
+    let ep = endpoint.trim().trim_end_matches('/');
+    if ep.ends_with("/v1") {
+        ep.to_string()
+    } else {
+        format!("{ep}/v1")
+    }
+}
+
 pub fn resolve_endpoint(config: &AiConfig) -> String {
     let ep = config.endpoint.trim().trim_end_matches('/');
     if matches!(config.provider, AiProvider::Gemini) {
@@ -276,9 +287,11 @@ pub fn resolve_endpoint(config: &AiConfig) -> String {
     if ep.ends_with("/chat/completions") || ep.ends_with("/responses") || ep.ends_with("/messages") {
         return ep.to_string();
     }
+    if uses_anthropic_messages_api(config) {
+        let base = ensure_anthropic_version_prefix(ep);
+        return format!("{base}/messages");
+    }
     match config.provider {
-        AiProvider::Claude => format!("{ep}/messages"),
-        AiProvider::CodexCli => unreachable!(),
         AiProvider::Openai
         | AiProvider::Deepseek
         | AiProvider::Qwen
@@ -292,8 +305,13 @@ pub fn resolve_endpoint(config: &AiConfig) -> String {
                 format!("{base}/chat/completions")
             }
         }
-        AiProvider::Gemini => unreachable!(),
+        AiProvider::Claude | AiProvider::CodexCli | AiProvider::Gemini => unreachable!(),
     }
+}
+
+pub fn uses_anthropic_messages_api(config: &AiConfig) -> bool {
+    matches!(config.provider, AiProvider::Claude)
+        || matches!(config.provider, AiProvider::Custom) && config.api_style == AiApiStyle::AnthropicMessages
 }
 
 fn resolve_gemini_stream_endpoint(config: &AiConfig) -> String {
@@ -324,6 +342,11 @@ pub fn resolve_model_list_endpoint(config: &AiConfig) -> Result<String, String> 
         .or_else(|| ep.strip_suffix("/messages"))
         .unwrap_or(ep)
         .trim_end_matches('/');
+
+    if uses_anthropic_messages_api(config) {
+        let base = ensure_anthropic_version_prefix(base);
+        return Ok(format!("{base}/models"));
+    }
 
     let base = ensure_openai_version_prefix(base);
 
@@ -684,8 +707,14 @@ pub async fn list_models_core(config: &AiConfig) -> Result<Vec<AiModelInfo>, Str
         | AiProvider::Deepseek
         | AiProvider::Qwen
         | AiProvider::Ollama
-        | AiProvider::OpenaiCompatible
-        | AiProvider::Custom => list_openai_compatible_models(&client, config).await,
+        | AiProvider::OpenaiCompatible => list_openai_compatible_models(&client, config).await,
+        AiProvider::Custom => {
+            if uses_anthropic_messages_api(config) {
+                list_claude_models(&client, config).await
+            } else {
+                list_openai_compatible_models(&client, config).await
+            }
+        }
         AiProvider::CodexCli => unreachable!(),
         AiProvider::Gemini => {
             Err("Model listing is only supported for OpenAI-compatible and Claude providers".to_string())
@@ -916,7 +945,7 @@ pub async fn test_connection_core(config: &AiConfig) -> Result<AiTestConnectionR
     let client = build_ai_http_client(config, 15)?;
     let start = std::time::Instant::now();
 
-    let is_claude = matches!(config.provider, AiProvider::Claude);
+    let is_claude = uses_anthropic_messages_api(config);
     let is_gemini = matches!(config.provider, AiProvider::Gemini);
     let model = config.model.clone();
 
@@ -957,6 +986,28 @@ pub async fn test_connection_core(config: &AiConfig) -> Result<AiTestConnectionR
                 .send()
                 .await
                 .map_err(|e| format!("Gemini request failed: {e}"))?;
+            if !res.status().is_success() {
+                let data: serde_json::Value = res.json().await.map_err(|e| e.to_string())?;
+                return Err(categorize_error(&data, config));
+            }
+            res.bytes_stream()
+        }
+        AiProvider::Custom if uses_anthropic_messages_api(config) => {
+            let body = json!({
+                "model": &model,
+                "max_tokens": 16,
+                "temperature": temperature_value(Some(0.0)),
+                "system": CLAUDE_DEFAULT_SYSTEM,
+                "messages": [{ "role": "user", "content": TEST_PROMPT }],
+                "stream": true,
+            });
+            let res = client
+                .post(resolve_endpoint(config))
+                .headers(claude_headers(config)?)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| format!("Claude request failed: {e}"))?;
             if !res.status().is_success() {
                 let data: serde_json::Value = res.json().await.map_err(|e| e.to_string())?;
                 return Err(categorize_error(&data, config));
@@ -1071,9 +1122,17 @@ pub async fn complete(request: &AiCompletionRequest) -> Result<String, String> {
         | AiProvider::Deepseek
         | AiProvider::Qwen
         | AiProvider::Ollama
-        | AiProvider::OpenaiCompatible
-        | AiProvider::Custom => {
+        | AiProvider::OpenaiCompatible => {
             if request.config.api_style == AiApiStyle::Responses {
+                call_responses_api(&client, request.clone()).await
+            } else {
+                call_openai_compatible(&client, request.clone()).await
+            }
+        }
+        AiProvider::Custom => {
+            if uses_anthropic_messages_api(&request.config) {
+                call_claude(&client, request.clone()).await
+            } else if request.config.api_style == AiApiStyle::Responses {
                 call_responses_api(&client, request.clone()).await
             } else {
                 call_openai_compatible(&client, request.clone()).await
@@ -1109,9 +1168,17 @@ pub async fn stream(
         | AiProvider::Deepseek
         | AiProvider::Qwen
         | AiProvider::Ollama
-        | AiProvider::OpenaiCompatible
-        | AiProvider::Custom => {
+        | AiProvider::OpenaiCompatible => {
             if request.config.api_style == AiApiStyle::Responses {
+                stream_responses_api(&client, session_id, request, cancelled, &on_chunk).await
+            } else {
+                stream_openai(&client, session_id, request, cancelled, &on_chunk).await
+            }
+        }
+        AiProvider::Custom => {
+            if uses_anthropic_messages_api(&request.config) {
+                stream_claude(&client, session_id, request, cancelled, &on_chunk).await
+            } else if request.config.api_style == AiApiStyle::Responses {
                 stream_responses_api(&client, session_id, request, cancelled, &on_chunk).await
             } else {
                 stream_openai(&client, session_id, request, cancelled, &on_chunk).await
@@ -2044,6 +2111,12 @@ pub async fn stream_with_tools(
             })
             .await?
         }
+        AiProvider::Custom if uses_anthropic_messages_api(config) => {
+            stream_claude_with_tools(&client, session_id, request, tools, cancelled, &|event| {
+                accumulator.lock().unwrap().process(event, &on_chunk);
+            })
+            .await?
+        }
         _ => {
             stream_openai_with_tools(&client, session_id, request, tools, cancelled, &|event| {
                 accumulator.lock().unwrap().process(event, &on_chunk);
@@ -2119,8 +2192,9 @@ mod tests {
         add_temperature_if_supported_for_config, build_ai_http_client, claude_headers, claude_system_prompt,
         gemini_text, is_kimi_model, openai_response_text, openai_stream_reasoning, openai_stream_text,
         parse_model_list_response, resolve_endpoint, resolve_model_list_endpoint, responses_max_output_tokens,
-        responses_text, supports_temperature, temperature_value, validate_config, AiApiStyle, AiAuthMethod, AiConfig,
-        AiModelInfo, AiProvider, AiReasoningLevel, AUTHORIZATION, CLAUDE_DEFAULT_SYSTEM, TEST_PROMPT,
+        responses_text, supports_temperature, temperature_value, uses_anthropic_messages_api, validate_config,
+        AiApiStyle, AiAuthMethod, AiConfig, AiModelInfo, AiProvider, AiReasoningLevel, AUTHORIZATION,
+        CLAUDE_DEFAULT_SYSTEM, TEST_PROMPT,
     };
 
     #[test]
@@ -2284,6 +2358,49 @@ mod tests {
             codex_cli_env: Default::default(),
         };
         assert_eq!(resolve_model_list_endpoint(&claude).unwrap(), "https://api.anthropic.com/v1/models");
+    }
+
+    #[test]
+    fn custom_anthropic_messages_style_uses_claude_endpoints() {
+        let config = AiConfig {
+            provider: AiProvider::Custom,
+            api_key: "key".to_string(),
+            auth_method: AiAuthMethod::ApiKey,
+            endpoint: "https://gateway.example.com/anthropic/v1".to_string(),
+            model: "claude-sonnet-4-20250514".to_string(),
+            api_style: AiApiStyle::AnthropicMessages,
+            proxy_enabled: false,
+            proxy_url: String::new(),
+            enable_thinking: true,
+            reasoning_level: AiReasoningLevel::Default,
+            context_window: None,
+            codex_cli_path: None,
+            codex_cli_env: Default::default(),
+        };
+
+        assert!(uses_anthropic_messages_api(&config));
+        assert_eq!(resolve_endpoint(&config), "https://gateway.example.com/anthropic/v1/messages");
+        assert_eq!(resolve_model_list_endpoint(&config).unwrap(), "https://gateway.example.com/anthropic/v1/models");
+
+        let full_messages =
+            AiConfig { endpoint: "https://gateway.example.com/anthropic/v1/messages".to_string(), ..config.clone() };
+        assert_eq!(resolve_endpoint(&full_messages), "https://gateway.example.com/anthropic/v1/messages");
+        assert_eq!(
+            resolve_model_list_endpoint(&full_messages).unwrap(),
+            "https://gateway.example.com/anthropic/v1/models"
+        );
+
+        let bare_origin = AiConfig { endpoint: "https://gateway.example.com".to_string(), ..config.clone() };
+        assert_eq!(resolve_endpoint(&bare_origin), "https://gateway.example.com/v1/messages");
+        assert_eq!(resolve_model_list_endpoint(&bare_origin).unwrap(), "https://gateway.example.com/v1/models");
+
+        let kimi_coding = AiConfig {
+            endpoint: "https://api.kimi.com/coding/".to_string(),
+            model: "kimi-for-coding".to_string(),
+            ..config.clone()
+        };
+        assert_eq!(resolve_endpoint(&kimi_coding), "https://api.kimi.com/coding/v1/messages");
+        assert_eq!(resolve_model_list_endpoint(&kimi_coding).unwrap(), "https://api.kimi.com/coding/v1/models");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Custom AI support for Anthropic Messages-compatible providers
- normalize Kimi Coding endpoint bases such as https://api.kimi.com/coding/ to /coding/v1/messages
- add UI option and localized hint for /messages

## Checks
- `cargo fmt --check`
- `cargo check --workspace --locked`
- `cargo test -p dbx-core custom_anthropic_messages_style_uses_claude_endpoints`
- `node scripts/run-check.mjs` partially passes: format/lint/typecheck pass; vitest has local/pre-existing failures from missing better-sqlite3 native binding and an AI prompt assertion.

## Notes
`pnpm check` is blocked locally by pnpm build-script approval before project checks run.
