### PR TITLE
✨feat(nacos): 增强配置编辑器功能，支持文本选择和tab 按键

### DIFF
--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -17,6 +17,7 @@ import { useI18n } from "vue-i18n";
 import * as api from "@/lib/api";
 import { buildNacosConfigDeleteConfirm, buildNacosConfigExportFileName, buildNacosConfigHistoryRollbackConfirm, buildNacosInstanceConfirm, createNacosSaveAsCopy, resolveNacosConfigCopyText } from "@/lib/nacosAdmin";
 import { copyToClipboard, readTextFromClipboard } from "@/lib/clipboard";
+import { trimmedSelectionLayer } from "@/lib/codemirrorTrimmedSelectionLayer";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/safeStorage";
 import { editorFontTheme, loadEditorTheme } from "@/lib/editorThemes";
 import { isTauriRuntime } from "@/lib/tauriRuntime";
@@ -178,7 +179,7 @@ async function configLanguageExtension(format: string): Promise<Extension[]> {
 async function mountConfigEditor() {
   await nextTick();
   if (!configEditorHost.value || configEditorView.value || !selectedConfig.value) return;
-  const [{ EditorState, Prec }, { EditorView, keymap }, { basicSetup }, { defaultKeymap, historyKeymap }, { search: cmSearch }, language] = await Promise.all([
+  const [{ EditorState, Prec }, { EditorView, keymap }, { basicSetup }, { defaultKeymap, historyKeymap, indentWithTab }, { search: cmSearch }, language] = await Promise.all([
     import("@codemirror/state"),
     import("@codemirror/view"),
     import("codemirror"),
@@ -202,17 +203,14 @@ async function mountConfigEditor() {
           },
         }),
         basicSetup,
-        Prec.highest(
-          keymap.of([
-            { key: "Mod-f", run: () => configSearchPanelRef.value?.openSearch() ?? false, preventDefault: true },
-            { key: "Mod-h", run: () => configSearchPanelRef.value?.openReplace() ?? false, preventDefault: true },
-          ]),
-        ),
+        trimmedSelectionLayer(),
+        Prec.highest(keymap.of([{ key: "Mod-f", run: () => configSearchPanelRef.value?.openSearch() ?? false, preventDefault: true }, { key: "Mod-h", run: () => configSearchPanelRef.value?.openReplace() ?? false, preventDefault: true }, indentWithTab])),
         keymap.of([...defaultKeymap, ...historyKeymap]),
         configEditorLanguage.of(language),
         configEditorTheme.of(theme),
         configEditorFontTheme.of(editorFontTheme(EditorView, editorSettings.fontSize, editorSettings.fontFamily, { fixedHeight: true, scrollable: true })),
         EditorView.lineWrapping,
+        EditorState.readOnly.of(!!props.readOnly),
         EditorView.editable.of(!props.readOnly),
         EditorView.updateListener.of((update) => {
           if (!update.docChanged) return;
@@ -228,6 +226,8 @@ async function mountConfigEditor() {
           },
           ".cm-content": {
             minHeight: "100%",
+            userSelect: "text",
+            WebkitUserSelect: "text",
           },
           ".cm-lineNumbers .cm-gutterElement": {
             padding: "0 10px 0 8px",


### PR DESCRIPTION
- 添加 trimmedSelectionLayer 以支持文本选择
- 修复键盘快捷键配置，确保功能正常
- 更新样式以改善用户体验

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #1932 