### PR TITLE
Fix: 统一驱动管理页 Tab 宽度

### DIFF
--- a/apps/desktop/src/components/config/DriverStoreDialog.vue
+++ b/apps/desktop/src/components/config/DriverStoreDialog.vue
@@ -1006,7 +1006,7 @@ watch(driverStoreTab, (tab) => {
       <div class="max-w-4xl mx-auto px-6 py-6">
         <Tabs v-model="driverStoreTab" default-value="agent">
           <div class="flex items-center justify-between">
-            <TabsList class="w-fit">
+            <TabsList class="grid w-[360px] grid-cols-3">
               <TabsTrigger value="agent" class="gap-1.5 relative">
                 {{ t("driverStore.agentDrivers") }}
                 <span v-if="agentTabUpdateCount > 0" class="inline-block h-2 w-2 rounded-full bg-red-500" />


### PR DESCRIPTION
## 变更内容
- 将驱动管理页面的 TabList 改为三列固定宽度布局
- 统一“内置驱动”、“JDBC 驱动”和“存储位置”三个 Tab 的显示宽度

## 修改原因
原先 TabList 使用 `w-fit` 按文案内容自适应宽度，“内置驱动”与另外两个 Tab 的文本宽度不同，切换时选中态宽度变化会产生轻微跳动。改为固定三列后，三个 Tab 的宽度保持一致，切换状态更稳定。

## 验证
- `/Users/staff/dbx/node_modules/.bin/oxlint --vue-plugin apps/desktop/src/components/config/DriverStoreDialog.vue`