### PR TITLE
fix: prevent implicit database creation on connection for SQLite and …

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -2561,6 +2561,13 @@ async function createDuckDbFilePath() {
 
   const path = ensureDuckDbFileExtension(selected);
   form.value.host = path;
+
+  try {
+    const { writeTextFile } = await import("@tauri-apps/plugin-fs");
+    await writeTextFile(path, "");
+  } catch (e) {
+    console.error("Failed to create DuckDB file:", e);
+  }
 }
 
 function ensureSqliteFileExtension(path: string): string {
@@ -2580,6 +2587,13 @@ async function createSqliteFilePath() {
 
   const path = ensureSqliteFileExtension(selected);
   form.value.host = path;
+
+  try {
+    const { writeTextFile } = await import("@tauri-apps/plugin-fs");
+    await writeTextFile(path, "");
+  } catch (e) {
+    console.error("Failed to create SQLite file:", e);
+  }
 }
 
 async function browseJdbcDriverPaths() {

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -712,11 +712,7 @@ impl AppState {
                     })
                     .collect();
                 PoolKind::Sqlite(
-                    db::sqlite::connect_path_create_if_missing_with_extensions(
-                        &expand_tilde(&db_config.host),
-                        extensions,
-                    )
-                    .await?,
+                    db::sqlite::connect_path_with_extensions(&expand_tilde(&db_config.host), extensions).await?,
                 )
             }
             DatabaseType::Rqlite => {

--- a/crates/dbx-core/src/db/duckdb_driver.rs
+++ b/crates/dbx-core/src/db/duckdb_driver.rs
@@ -39,11 +39,7 @@ fn validate_duckdb_path(path: &str) -> Result<(), String> {
         return Err(format!("Database file path is a directory, not a file: {}", path));
     }
     if !path_obj.exists() {
-        if let Some(parent) = path_obj.parent() {
-            if !parent.as_os_str().is_empty() && !parent.exists() {
-                return Err(format!("Parent directory does not exist: {}", parent.display()));
-            }
-        }
+        return Err(format!("Database file does not exist: {}", path));
     }
     Ok(())
 }

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -605,12 +605,7 @@ pub async fn test_connection(state: State<'_, Arc<AppState>>, config: Connection
                         extension
                     })
                     .collect();
-                match db::sqlite::connect_path_create_if_missing_with_extensions(
-                    &expand_tilde(&config.host),
-                    extensions,
-                )
-                .await
-                {
+                match db::sqlite::connect_path_with_extensions(&expand_tilde(&config.host), extensions).await {
                     Ok(_) => Ok("Connection successful".to_string()),
                     Err(e) => Err(e),
                 }
@@ -875,8 +870,7 @@ pub async fn connect_db(state: State<'_, Arc<AppState>>, config: ConnectionConfi
                 })
                 .collect();
             PoolKind::Sqlite(
-                db::sqlite::connect_path_create_if_missing_with_extensions(&expand_tilde(&db_config.host), extensions)
-                    .await?,
+                db::sqlite::connect_path_with_extensions(&expand_tilde(&db_config.host), extensions).await?,
             )
         }
         DatabaseType::Redis => {


### PR DESCRIPTION
fix: prevent implicit database creation on connection for SQLite and DuckDB

## 变更说明

此前，如果用户在发起 SQLite 或 DuckDB 连接时拼错了数据库文件路径，系统会静默地在该错误路径下自动创建一个全新的空数据库，而不是报错拦截。这会导致用户误以为连接成功，但界面中没有任何数据。

本 PR 通过强制执行“显式创建策略”彻底修复了该问题：
1. **Rust 后端**：移除了 SQLite 建立常规连接时的 `SQLITE_OPEN_CREATE` 标志，并为 DuckDB 补齐了前置的严格 `exists()` 路径检查。现在如果文件不存在，连接将立即报错。
2. **Vue 前端**：更新了“新建 SQLite/DuckDB 数据库”按钮的交互逻辑。当用户主动选择新建并确认路径后，前端会通过 Tauri FS API 显式在本地创建一个 0 字节的空文件，确保用户合法的新建请求能够顺畅执行。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
修改前
<img width="2226" height="1380" alt="image" src="https://github.com/user-attachments/assets/a0d75548-ba72-4ddc-a6ed-b8d6d15e80e6" />
<img width="1830" height="868" alt="image" src="https://github.com/user-attachments/assets/f8c8c2b5-7d05-4fc7-b6f4-1fb6307cbb15" />
修改后
<img width="2240" height="1374" alt="image" src="https://github.com/user-attachments/assets/cfd69e88-7641-4bec-88aa-c3c656792a7f" />


## 验证

- [x] `pnpm check` 通过
- [x] `cargo check --no-default-features` 通过
- [x] 相关测试通过（后端连接逻辑测试）

## 关联 Issue

Close #1584
