### PR TITLE
修复 MongoDB 筛选查询预览语法

### DIFF
--- a/apps/desktop/src/lib/documentStoreProvider.ts
+++ b/apps/desktop/src/lib/documentStoreProvider.ts
@@ -47,7 +47,8 @@ const mongoDocumentProvider: DocumentStoreProvider = {
   sortInputLabel: "sort",
   documentsLabel: ({ total, t }) => t("mongo.documents", { count: total }),
   queryPreview: ({ collection, filterJson, sortJson, skip, limit }) => {
-    const parts = [`db.${collection}.find(${filterJson || "{}"})`];
+    const collectionRef = `db.getCollection(${JSON.stringify(collection)})`;
+    const parts = [`${collectionRef}.find(${filterJson || "{}"})`];
     if (sortJson?.trim()) parts.push(`.sort(${sortJson.trim()})`);
     parts.push(`.skip(${skip}).limit(${limit})`);
     return parts.join("");

--- a/packages/app-tests/documentStoreProvider.test.ts
+++ b/packages/app-tests/documentStoreProvider.test.ts
@@ -24,7 +24,8 @@ test("providers build store-specific query previews", () => {
   const elasticsearch = documentStoreProviderFor("elasticsearch");
 
   assert.equal(mongo.documentsLabel({ total: 7, t }), "mongo.documents:7");
-  assert.equal(mongo.queryPreview({ collection: "orders", filterJson: '{"city":"长治"}', sortJson: '{"createdAt":-1}', skip: 20, limit: 10 }), 'db.orders.find({"city":"长治"}).sort({"createdAt":-1}).skip(20).limit(10)');
+  assert.equal(mongo.queryPreview({ collection: "orders", filterJson: '{"city":"长治"}', sortJson: '{"createdAt":-1}', skip: 20, limit: 10 }), 'db.getCollection("orders").find({"city":"长治"}).sort({"createdAt":-1}).skip(20).limit(10)');
+  assert.equal(mongo.queryPreview({ collection: "order-events", filterJson: '{"city":"长治"}', sortJson: undefined, skip: 0, limit: 100 }), 'db.getCollection("order-events").find({"city":"长治"}).skip(0).limit(100)');
   assert.equal(elasticsearch.documentsLabel({ total: 7, t }), "Documents");
   assert.equal(elasticsearch.filterInputLabel, "filter");
   assert.equal(


### PR DESCRIPTION
## 变更说明
- MongoDB 查询预览统一使用 `db.getCollection(...)` 生成集合引用
- 修复集合名包含 `-` 等特殊字符时，筛选条件生成的查询语句语法错误
- 补充普通集合名和特殊集合名的查询预览测试

Fixes #1957

## 验证
- `./node_modules/.bin/vitest run packages/app-tests/documentStoreProvider.test.ts --config vitest.config.ts`
- `./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json --pretty false`