### PR TITLE
Fix: 修复 MongoDB 默认库影响认证库

### DIFF
--- a/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
+++ b/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
@@ -257,7 +257,7 @@ public final class MongoAgent {
         if (authSource != null && !authSource.isBlank()) {
             return authSource;
         }
-        return defaultString(stringOrNull(connObj, "database"), "admin");
+        return "admin";
     }
 
     private static String urlParam(String urlParams, String key) {

--- a/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
+++ b/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
@@ -135,11 +135,11 @@ class MongoAgentTest {
     }
 
     @Test
-    void fallsBackToDefaultDatabaseWhenAuthSourceIsMissing() {
+    void fallsBackToAdminWhenAuthSourceIsMissing() {
         JsonObject connection = new JsonObject();
         connection.addProperty("database", "gray_lite_twin_fat");
 
-        assertEquals("gray_lite_twin_fat", MongoAgent.authenticationDatabase(connection));
+        assertEquals("admin", MongoAgent.authenticationDatabase(connection));
     }
 
     // ─── TLS: configureBuilder JSON parsing ───

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -1080,7 +1080,7 @@ impl ConnectionConfig {
             }
             DatabaseType::Databend => normalize_bare_mysql_url_params(value),
             DatabaseType::Postgres | DatabaseType::Redshift => normalize_postgres_url_params(value, self.ssl),
-            DatabaseType::MongoDb => normalize_mongo_url_params(value, self.ssl),
+            DatabaseType::MongoDb => normalize_mongo_url_params(value, self.ssl, !self.username.trim().is_empty()),
             _ => value.trim_start_matches('?').to_string(),
         }
     }
@@ -1170,13 +1170,17 @@ fn normalize_mysql_url_params(value: &str, force_tls: bool, accept_invalid_certs
     parts.join("&")
 }
 
-fn normalize_mongo_url_params(value: &str, force_tls: bool) -> String {
+fn normalize_mongo_url_params(value: &str, force_tls: bool, default_auth_source: bool) -> String {
     let value = value.trim_start_matches('?');
     let mut parts: Vec<String> = value.split('&').filter(|part| !part.is_empty()).map(str::to_string).collect();
 
     if force_tls {
         parts.retain(|part| !url_param_key_is(part, "tls") && !url_param_key_is(part, "ssl"));
         parts.insert(0, "tls=true".to_string());
+    }
+
+    if default_auth_source && !parts.iter().any(|part| url_param_key_is(part, "authSource")) {
+        parts.push("authSource=admin".to_string());
     }
 
     parts.join("&")
@@ -2137,10 +2141,32 @@ mod tests {
     }
 
     #[test]
-    fn mongodb_form_url_without_params_does_not_force_topology_or_auth() {
+    fn mongodb_form_url_without_params_defaults_auth_source_to_admin() {
         let config = mongodb_config("root", "secret", Some("admin"));
 
-        assert_eq!(config.connection_url(), "mongodb://root:secret@10.1.2.3:17000/admin");
+        assert_eq!(config.connection_url(), "mongodb://root:secret@10.1.2.3:17000/admin?authSource=admin");
+    }
+
+    #[test]
+    fn mongodb_form_url_default_database_does_not_change_auth_source() {
+        let config = mongodb_config("root", "secret", Some("app"));
+
+        assert_eq!(config.connection_url(), "mongodb://root:secret@10.1.2.3:17000/app?authSource=admin");
+    }
+
+    #[test]
+    fn mongodb_form_url_without_username_does_not_default_auth_source() {
+        let config = mongodb_config("", "", Some("app"));
+
+        assert_eq!(config.connection_url(), "mongodb://10.1.2.3:17000/app");
+    }
+
+    #[test]
+    fn mongodb_form_url_preserves_explicit_auth_source() {
+        let mut config = mongodb_config("root", "secret", Some("app"));
+        config.url_params = Some("authSource=app".to_string());
+
+        assert_eq!(config.connection_url(), "mongodb://root:secret@10.1.2.3:17000/app?authSource=app");
     }
 
     #[test]
@@ -2228,8 +2254,8 @@ mod tests {
         let mut config = mongodb_config("root", "secret", Some("admin"));
         config.ssl = true;
 
-        assert_eq!(config.connection_url(), "mongodb://root:secret@10.1.2.3:17000/admin?tls=true");
-        assert_eq!(config.redacted_connection_url(), "mongodb://10.1.2.3:17000/admin?tls=true");
+        assert_eq!(config.connection_url(), "mongodb://root:secret@10.1.2.3:17000/admin?tls=true&authSource=admin");
+        assert_eq!(config.redacted_connection_url(), "mongodb://10.1.2.3:17000/admin?tls=true&authSource=admin");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

MongoDB 表单连接在填写默认库后，连接串路径会变成该默认库。MongoDB driver 会把路径库作为 SCRAM 认证库，导致账号实际创建在 admin 时出现 Authentication failed。

## 修复

- 表单模式下有用户名且未显式配置 authSource 时，默认追加 authSource=admin
- 保留用户显式填写的 authSource，不覆盖自定义认证库
- 同步调整 legacy MongoDB agent 的默认认证库逻辑
- 补充默认库、显式 authSource、无用户名和 TLS 参数组合的 URL 测试

## 验证

- cargo test -p dbx-core mongo --locked
- cargo test -p dbx-core mongodb_form_url --locked
- 本地 DBX 现有 MongoDB 连接验证：默认库为空测试成功；临时填写 test、dbx_default_auth_probe、admin 作为默认库测试均成功；保存配置未被修改

## 未执行

- ./gradlew :drivers:mongodb:test --tests com.dbx.agent.mongodb.MongoAgentTest --no-daemon：Gradle wrapper 下载 gradle-9.5.0-bin.zip 连接 services.gradle.org 10 秒超时，未进入测试阶段