### PR TITLE
Improve: 优化侧栏注释字体渲染

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -4089,8 +4089,8 @@ function treeItemMenuItems(): ContextMenuItem[] {
           <Badge v-if="isNodeDefaultDatabase" variant="secondary" class="h-4 px-1.5 text-[10px]">
             {{ t("editor.defaultDatabase") }}
           </Badge>
-          <span v-if="columnComment" class="ml-auto truncate text-muted-foreground/60 text-[10px] max-w-[20%] shrink-0 text-right">{{ columnComment }}</span>
-          <span v-if="tableComment" class="ml-auto truncate text-muted-foreground/60 text-[10px] max-w-[20%] shrink-0 text-right">{{ tableComment }}</span>
+          <span v-if="columnComment" class="sidebar-object-comment ml-auto max-w-[20%] shrink-0 truncate text-right">{{ columnComment }}</span>
+          <span v-if="tableComment" class="sidebar-object-comment ml-auto max-w-[20%] shrink-0 truncate text-right">{{ tableComment }}</span>
           <span v-if="node.type === 'connection' && node.connectionId && connectionStore.connectedIds.has(node.connectionId)" class="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
           <Badge v-if="isConnectionReadonly" variant="secondary" class="h-4 px-1.5 text-[10px] gap-0.5"><Lock class="w-2.5 h-2.5" />{{ t("connection.readOnlyBadge") }}</Badge>
           <ConnectionErrorIndicator v-if="node.type === 'connection'" :connection-id="node.connectionId" trigger-class="h-4 w-4" />
@@ -4455,6 +4455,16 @@ function treeItemMenuItems(): ContextMenuItem[] {
 </template>
 
 <style>
+.sidebar-object-comment {
+  color: var(--muted-foreground);
+  font-family: "Microsoft YaHei UI", "Microsoft YaHei", "Segoe UI", system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  opacity: 1;
+  text-rendering: optimizeLegibility;
+}
+
 .tree-item-connection-tint {
   isolation: isolate;
   background-color: transparent !important;


### PR DESCRIPTION
## 变更说明

修复 Windows / Chromium 环境下左侧连接树对象注释文字发虚的问题。

原先表/列注释使用 `10px` 字号和 `text-muted-foreground/60` 透明灰色，在 Windows 字体栅格化下容易出现笔画发虚、可读性偏弱的问题。本次将侧栏对象注释抽成 `sidebar-object-comment` 样式：

- 使用不透明的 `var(--muted-foreground)` 颜色
- 字号调整为 `12px`
- 字重调整为 `500`
- Windows 下优先使用 `Microsoft YaHei UI`

影响范围仅限左侧连接树中的对象注释展示，不影响表名、字段名、编辑器和数据网格。

## 验证

- `corepack pnpm typecheck`
- `corepack pnpm exec oxfmt apps/desktop/src/components/sidebar/TreeItem.vue --check`
- 本地 Web dev 环境手动检查侧栏 MySQL 表注释显示效果