### PR TITLE
Fix: 修复 Windows nvm 下 Codex CLI 路径解析失败

### DIFF
--- a/crates/dbx-core/src/ai_codex_cli.rs
+++ b/crates/dbx-core/src/ai_codex_cli.rs
@@ -101,14 +101,29 @@ async fn resolve_program_path(program: &str) -> Option<String> {
 
 fn direct_program_path(program: &str) -> Option<String> {
     let path = Path::new(program);
-    if path.is_absolute() && path.is_file() {
+    if !path.is_absolute() {
+        return None;
+    }
+
+    if path.is_dir() {
+        return launchable_program_in_dir(path, "codex");
+    }
+
+    if path.is_file() {
         #[cfg(windows)]
         return windows_launchable_program_path(path);
         #[cfg(not(windows))]
         return Some(path.to_string_lossy().to_string());
-    } else {
-        None
     }
+
+    None
+}
+
+fn launchable_program_in_dir(dir: &Path, program: &str) -> Option<String> {
+    program_path_candidates(dir, program)
+        .into_iter()
+        .find(|candidate| is_launchable_program_path(candidate) && candidate.is_file())
+        .map(|path| path.to_string_lossy().to_string())
 }
 
 #[cfg(windows)]
@@ -312,6 +327,13 @@ fn validate_codex_program(config: &AiConfig) -> Result<String, String> {
     let program = codex_program(config);
     if starts_with_env_assignment(&program) {
         return Err("[codexCliPathInvalid] Codex CLI path should contain only the executable path. Add environment variables in the Codex CLI environment variables section.".to_string());
+    }
+    if is_path_like_program(&program) {
+        let expanded = expand_tilde(&program);
+        let path = Path::new(&expanded);
+        if path.is_dir() && direct_program_path(&expanded).is_none() {
+            return Err("[codexCliPathInvalid] Codex CLI path should point to the Codex executable or a directory containing codex.".to_string());
+        }
     }
     Ok(program)
 }
@@ -558,7 +580,8 @@ mod tests {
     use super::{codex_process_env, common_executable_dirs, merged_path_with_dir};
     #[cfg(windows)]
     use super::{
-        direct_program_path, first_windows_program_path, program_path_candidates, windows_npm_codex_shim_command,
+        direct_program_path, first_windows_program_path, program_path_candidates, resolve_codex_command,
+        windows_npm_codex_shim_command,
     };
     use crate::agent_events::AgentEvent;
     use crate::ai::{AiApiStyle, AiAuthMethod, AiConfig, AiProvider, AiReasoningLevel};
@@ -714,6 +737,50 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
+    fn windows_direct_directory_path_uses_codex_cmd_inside() {
+        let dir = std::env::temp_dir().join(format!("dbx-codex-direct-dir-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let extensionless = dir.join("codex");
+        let cmd = dir.join("codex.cmd");
+        std::fs::write(&extensionless, "#!/bin/sh\n").unwrap();
+        std::fs::write(&cmd, "@echo off\n").unwrap();
+
+        let resolved = direct_program_path(dir.to_string_lossy().as_ref()).unwrap();
+
+        assert_eq!(resolved, cmd.to_string_lossy().as_ref());
+        let _ = std::fs::remove_file(extensionless);
+        let _ = std::fs::remove_file(cmd);
+        let _ = std::fs::remove_dir(dir);
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn windows_configured_nvm_directory_resolves_codex_cmd_shim() {
+        let dir = std::env::temp_dir().join(format!("dbx-codex-nvm-dir-test-{}", std::process::id()));
+        let bin_dir = dir.join("node_modules").join("@openai").join("codex").join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let cmd = dir.join("codex.cmd");
+        let node = dir.join("node.exe");
+        let codex_js = bin_dir.join("codex.js");
+        std::fs::write(&cmd, "@echo off\nnode codex.js %*\n").unwrap();
+        std::fs::write(&node, "").unwrap();
+        std::fs::write(&codex_js, "#!/usr/bin/env node\n").unwrap();
+
+        let mut config = codex_config("default");
+        config.codex_cli_path = Some(dir.to_string_lossy().to_string());
+
+        let command = resolve_codex_command(&config).await;
+
+        assert_eq!(command.program, node.to_string_lossy().as_ref());
+        assert_eq!(command.args, vec![codex_js.to_string_lossy().to_string()]);
+        let _ = std::fs::remove_file(cmd);
+        let _ = std::fs::remove_file(node);
+        let _ = std::fs::remove_file(codex_js);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    #[cfg(windows)]
     fn windows_npm_codex_cmd_shim_uses_node_directly() {
         let dir = std::env::temp_dir().join(format!("dbx-codex-npm-shim-test-{}", std::process::id()));
         let bin_dir = dir.join("node_modules").join("@openai").join("codex").join("bin");
@@ -842,6 +909,19 @@ mod tests {
 
         assert!(err.contains("[codexCliPathInvalid]"));
         assert!(err.contains("environment variables section"));
+    }
+
+    #[test]
+    fn rejects_directory_without_codex_in_codex_cli_path() {
+        let dir = std::env::temp_dir().join(format!("dbx-codex-empty-dir-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut config = codex_config("default");
+        config.codex_cli_path = Some(dir.to_string_lossy().to_string());
+
+        let err = validate_codex_program(&config).unwrap_err();
+
+        assert!(err.contains("[codexCliPathInvalid]"));
+        let _ = std::fs::remove_dir(dir);
     }
 
     #[test]


### PR DESCRIPTION
## 变更内容

- 修复 Windows 用户将 Codex CLI 路径配置为 nvm Node 版本目录时，DBX 直接启动目录导致 `os error 193` 的问题
- 当配置值是绝对目录时，自动在目录内查找 `codex.cmd`、`codex.exe` 等可启动文件
- 保留现有 Windows npm shim 处理逻辑，将 nvm/npm 全局安装的 `codex.cmd` 解析为 `node.exe codex.js` 启动
- 当目录中不存在 Codex 可执行文件时，返回明确的 `[codexCliPathInvalid]` 错误，避免底层启动失败信息

## macOS 影响确认

- 留空使用 PATH 中的 `codex` 逻辑未改动
- 配置 `/opt/homebrew/bin/codex`、`/usr/local/bin/codex` 等可执行文件路径的逻辑未改动
- 新增的目录解析只在用户配置目录路径时生效；macOS 下如果目录内存在 `codex` 会正常解析，不存在则返回更明确的路径错误

## 验证

- 已通过 `cargo fmt --check`
- 已通过 `cargo test -p dbx-core ai_codex_cli --lib`
- 已通过 `git diff --check -- crates/dbx-core/src/ai_codex_cli.rs`

Closes #1969