### PR TITLE
Fix：修复 macOS 全屏关闭窗口异常

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,6 +177,62 @@ fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     }
 }
 
+fn clear_main_webview_focus<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.eval(
+            r#"
+            (() => {
+              const active = document.activeElement;
+              if (active instanceof HTMLElement) active.blur();
+              if (document.body) {
+                if (!document.body.hasAttribute("tabindex")) {
+                  document.body.setAttribute("tabindex", "-1");
+                }
+                document.body.focus({ preventScroll: true });
+              }
+            })();
+            "#,
+        );
+    }
+}
+
+fn hide_main_window_for_close<R: tauri::Runtime>(app: &tauri::AppHandle<R>, window: &tauri::Window<R>) {
+    clear_main_webview_focus(app);
+
+    #[cfg(target_os = "macos")]
+    {
+        if window.is_fullscreen().unwrap_or(false) {
+            let app = app.clone();
+            let window = window.clone();
+            let _ = window.set_fullscreen(false);
+            tauri::async_runtime::spawn(async move {
+                for _ in 0..40 {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    if !window.is_fullscreen().unwrap_or(false) {
+                        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+                        let app_to_hide = app.clone();
+                        let window_to_hide = window.clone();
+                        let _ = app.run_on_main_thread(move || {
+                            let _ = window_to_hide.hide();
+                            let _ = app_to_hide.hide();
+                        });
+                        return;
+                    }
+                }
+                let app_to_hide = app.clone();
+                let window_to_hide = window.clone();
+                let _ = app.run_on_main_thread(move || {
+                    let _ = window_to_hide.hide();
+                    let _ = app_to_hide.hide();
+                });
+            });
+            return;
+        }
+    }
+
+    let _ = window.hide();
+}
+
 fn open_connection_deep_links(app: &tauri::AppHandle, links: Vec<String>) {
     if links.is_empty() {
         return;
@@ -548,8 +604,8 @@ pub fn run() {
                 }
                 let app = window.app_handle();
                 let Some(state) = app.try_state::<CloseBehaviorState>() else {
-                    let _ = window.hide();
                     api.prevent_close();
+                    hide_main_window_for_close(&app, window);
                     return;
                 };
                 if !state.prompted() {
@@ -561,8 +617,8 @@ pub fn run() {
                     app.exit(0);
                     return;
                 }
-                let _ = window.hide();
                 api.prevent_close();
+                hide_main_window_for_close(&app, window);
             }
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## 背景
macOS 全屏状态下点击窗口关闭按钮时，如果未开启“关闭窗口时退出程序”，窗口可能只退出全屏或恢复后残留异常焦点。

## 修改
- 关闭窗口并隐藏到后台前，先清理 WebView 当前焦点，避免恢复窗口后焦点落到“新建连接”等按钮上。
- macOS 全屏关闭时，先退出全屏，等待全屏切换完成后再在主线程隐藏窗口和应用。
- 普通窗口关闭仍保持原有隐藏到后台行为，“关闭窗口时退出程序”设置不受影响。

## 验证
- macOS实际手动操作 全屏/退出全屏/全部全屏等
- rustfmt --check src-tauri/src/lib.rs
- cargo test -p dbx --lib hides_window_on_close_for_windows_and_macos -- --nocapture