### PR TITLE
Fix: 修复 MySQL enum 字段长度显示异常

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -67,7 +67,7 @@ import { normalizeSidebarHiddenTablePrefixes } from "@/lib/sidebarTableNameDispl
 import { normalizeSqlFormatterSettings, type SqlFormatterSettings } from "@/lib/sqlFormatterConfig";
 import { EMPTY_TABLE_COLUMN_TEMPLATE_DATA_TYPE, parseTableColumnTemplateFields, TABLE_COLUMN_TEMPLATE_DATABASE_TYPES } from "@/lib/tableColumnTemplates";
 import { buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpVsCodeConfig, type McpEnvEntry } from "@/lib/mcpConfigTemplates";
-import { combineDataTypeForDatabase, getDataTypeOptions, getDefaultLengthForType, isDataTypeLengthDisabled, splitDataType } from "@/lib/tableStructureEditorState";
+import { combineDataTypeForDatabase, dataTypeLengthInputValue, getDataTypeOptions, getDefaultLengthForType, isDataTypeLengthDisabled, splitDataType } from "@/lib/tableStructureEditorState";
 import type { DatabaseType, SqlSnippet } from "@/types/database";
 import { uuid } from "@/lib/utils";
 import { DEFAULT_SQL_SNIPPETS } from "@/lib/sqlCompletion";
@@ -815,7 +815,7 @@ function tableColumnTemplateBaseTypeForSelectedDatabase(row: TableColumnTemplate
 }
 
 function tableColumnTemplateLengthForSelectedDatabase(row: TableColumnTemplateGridRow): string {
-  return splitDataType(tableColumnTemplateDataTypeForSelectedDatabase(row)).params;
+  return dataTypeLengthInputValue(editTableColumnTemplateDatabaseType.value, tableColumnTemplateDataTypeForSelectedDatabase(row));
 }
 
 function setTableColumnTemplateDataTypeForSelectedDatabase(row: TableColumnTemplateGridRow, value: string) {

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -1507,7 +1507,12 @@ watch(activeTab, (tab) => {
                     <Input v-else :model-value="splitDataType(column.dataType).baseType" :class="[structureMonoControlClass, 'w-full']" disabled />
                   </td>
                   <td v-if="columnEditorControls.length" :class="structureCellClass">
-                    <Input :model-value="dataTypeLengthInputValue(databaseType, column.dataType)" :class="structureMonoControlClass" :disabled="isColumnLengthDisabled(column)" @update:model-value="column.dataType = combineDataTypeForDatabase(databaseType, splitDataType(column.dataType).baseType, String($event))" />
+                    <Input
+                      :model-value="dataTypeLengthInputValue(databaseType, column.dataType)"
+                      :class="structureMonoControlClass"
+                      :disabled="isColumnLengthDisabled(column)"
+                      @update:model-value="column.dataType = combineDataTypeForDatabase(databaseType, splitDataType(column.dataType).baseType, String($event))"
+                    />
                   </td>
                   <td v-if="columnEditorControls.nullable" :class="structureCellClass">
                     <label class="flex items-center gap-1.5">

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -34,6 +34,7 @@ import {
   createForeignKeyDrafts,
   createIndexDrafts,
   createTriggerDrafts,
+  dataTypeLengthInputValue,
   generateIndexName,
   generateUniqueIndexName,
   getColumnEditorControls,
@@ -1506,7 +1507,7 @@ watch(activeTab, (tab) => {
                     <Input v-else :model-value="splitDataType(column.dataType).baseType" :class="[structureMonoControlClass, 'w-full']" disabled />
                   </td>
                   <td v-if="columnEditorControls.length" :class="structureCellClass">
-                    <Input :model-value="splitDataType(column.dataType).params" :class="structureMonoControlClass" :disabled="isColumnLengthDisabled(column)" @update:model-value="column.dataType = combineDataTypeForDatabase(databaseType, splitDataType(column.dataType).baseType, String($event))" />
+                    <Input :model-value="dataTypeLengthInputValue(databaseType, column.dataType)" :class="structureMonoControlClass" :disabled="isColumnLengthDisabled(column)" @update:model-value="column.dataType = combineDataTypeForDatabase(databaseType, splitDataType(column.dataType).baseType, String($event))" />
                   </td>
                   <td v-if="columnEditorControls.nullable" :class="structureCellClass">
                     <label class="flex items-center gap-1.5">

--- a/apps/desktop/src/lib/__tests__/tableStructureEditorState.spec.ts
+++ b/apps/desktop/src/lib/__tests__/tableStructureEditorState.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { combineDataTypeForDatabase, splitDataType } from "../tableStructureEditorState";
+import { combineDataTypeForDatabase, dataTypeLengthInputValue, isDataTypeLengthDisabled, splitDataType } from "../tableStructureEditorState";
 
 describe("tableStructureEditorState", () => {
   it("keeps mysql unsigned attributes in the editable base type", () => {
@@ -13,5 +13,18 @@ describe("tableStructureEditorState", () => {
   it("combines mysql unsigned type choices with the length field", () => {
     expect(combineDataTypeForDatabase("mysql", "int unsigned", "11")).toBe("int(11) unsigned");
     expect(combineDataTypeForDatabase("mysql", "bigint unsigned zerofill", "20")).toBe("bigint(20) unsigned zerofill");
+  });
+
+  it("does not expose mysql enum or set values as editable length", () => {
+    const dataType = "enum('purchase_in','sale_out','return_in','adjustment_out','transfer_in','transfer_out')";
+
+    expect(splitDataType(dataType)).toEqual({
+      baseType: "enum",
+      params: "'purchase_in','sale_out','return_in','adjustment_out','transfer_in','transfer_out'",
+    });
+    expect(isDataTypeLengthDisabled("mysql", "enum")).toBe(true);
+    expect(isDataTypeLengthDisabled("mysql", "set")).toBe(true);
+    expect(dataTypeLengthInputValue("mysql", dataType)).toBe("");
+    expect(dataTypeLengthInputValue("mysql", "set('manual','auto')")).toBe("");
   });
 });

--- a/apps/desktop/src/lib/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/tableStructureEditorState.ts
@@ -693,6 +693,11 @@ export function combineDataTypeForDatabase(dbType: DatabaseType | undefined, bas
   return combineDataType(baseType, normalizedParams);
 }
 
+export function dataTypeLengthInputValue(dbType: DatabaseType | undefined, rawDataType: string): string {
+  const parsed = splitDataType(rawDataType);
+  return isDataTypeLengthDisabled(dbType, parsed.baseType) ? "" : parsed.params;
+}
+
 export function normalizeDataTypeParams(dbType: DatabaseType | undefined, baseType: string, params: string): string {
   const p = params.trim();
   if (!p) return "";
@@ -770,6 +775,8 @@ export function isDataTypeLengthDisabled(_dbType: DatabaseType | undefined, base
     return key !== "bit" && key !== "float_vector";
   } else if (_dbType === "postgres" || _dbType === "gaussdb" || _dbType === "kwdb" || _dbType === "opengauss" || _dbType === "highgo" || _dbType === "vastbase" || _dbType === "kingbase") {
     return POSTGRES_TYPE_LENGTH_DISABLES.includes(key);
+  } else if (isMysqlLikeStructureType(_dbType)) {
+    return key === "enum" || key === "set";
   } else {
     return DEFAULT_TYPE_LENGTH_DISABLES.includes(key);
   }


### PR DESCRIPTION
## 变更说明

- 修复 MySQL 表结构编辑器中 enum/set 字段把枚举值显示到长度输入框的问题
- 复用统一的长度输入展示逻辑，保持表结构编辑器和字段模板设置行为一致
- 补充 enum/set 类型长度输入展示的回归测试

## 验证

- ./node_modules/.bin/vitest run apps/desktop/src/lib/__tests__/tableStructureEditorState.spec.ts
- ./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json