### PR TITLE
Fix: 修复内置驱动搜索结果重复

### DIFF
--- a/crates/dbx-core/src/agent_catalog.rs
+++ b/crates/dbx-core/src/agent_catalog.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::models::connection::DatabaseType;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -290,12 +292,19 @@ pub fn is_agent_type(db_type: &DatabaseType) -> bool {
 }
 
 pub fn driver_store_entries() -> impl Iterator<Item = (&'static str, &'static str)> {
-    entries().iter().flat_map(|entry| {
-        let base = entry.store_visible.then_some((entry.key, entry.label));
-        let profiles =
-            entry.profiles.iter().filter(|profile| profile.store_visible).map(|profile| (profile.key, profile.label));
-        base.into_iter().chain(profiles)
-    })
+    let mut seen = HashSet::new();
+    entries()
+        .iter()
+        .flat_map(move |entry| {
+            let base = entry.store_visible.then_some((entry.key, entry.label));
+            let profiles = entry
+                .profiles
+                .iter()
+                .filter(|profile| profile.store_visible)
+                .map(|profile| (profile.key, profile.label));
+            base.into_iter().chain(profiles)
+        })
+        .filter(move |(key, _)| seen.insert(*key))
 }
 
 pub fn label_for_key(agent_key: &str) -> Option<&'static str> {

--- a/crates/dbx-core/tests/database_capabilities.rs
+++ b/crates/dbx-core/tests/database_capabilities.rs
@@ -4,6 +4,7 @@ use dbx_core::database_capabilities::{
 };
 use dbx_core::models::connection::DatabaseType;
 use serde::Deserialize;
+use std::collections::HashSet;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -116,6 +117,17 @@ fn maps_agent_database_types_to_driver_keys() {
     assert_eq!(agent_key(&DatabaseType::Oracle, Some("oracle-legacy")), Some("oracle"));
     assert_eq!(agent_key(&DatabaseType::Oracle, Some("oracle-10g")), Some("oracle"));
     assert_eq!(agent_key(&DatabaseType::Postgres, None), None);
+}
+
+#[test]
+fn driver_store_entries_do_not_repeat_agent_keys() {
+    let entries: Vec<_> = agent_catalog::driver_store_entries().collect();
+    let mut seen = HashSet::new();
+    let duplicate_keys: Vec<_> = entries.iter().map(|(key, _)| *key).filter(|key| !seen.insert(*key)).collect();
+
+    assert!(duplicate_keys.is_empty(), "driver store agent keys should be unique: {duplicate_keys:?}");
+    assert_eq!(entries.iter().filter(|(key, _)| *key == "gbase8a").count(), 1);
+    assert_eq!(entries.iter().filter(|(key, _)| *key == "gbase8s").count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## 问题

内置驱动页搜索 `gbase`、`gb`、`8a` 等关键词并反复清空/搜索时，搜索结果里可能出现越来越多雷同的 GBase 8a。根因是驱动商店数据源展开 catalog 时，GBase 主条目本身使用 `gbase8a`，同时可见 profile 列表里也包含 `gbase8a`，最终返回给前端的内置驱动列表存在重复 key，搜索过滤切换时会触发不稳定渲染。

## 修复

- 在 `driver_store_entries()` 输出内置驱动商店条目时按 agent key 去重
- 保留原有 catalog 顺序和主条目标签
- 增加回归测试，确保驱动商店条目 key 不重复，且 `gbase8a` / `gbase8s` 各只出现一次

## 验证

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/staff/dbx/target cargo test -p dbx-core --test database_capabilities --locked`
- `CARGO_TARGET_DIR=/Users/staff/dbx/target cargo test -p dbx-core driver_store_entries_do_not_repeat_agent_keys --locked`
- 临时启动 `DBX_DISABLE_PASSWORD=1 DBX_PORT=4226 cargo run -p dbx-web`，请求 `/api/agents/installed-local` 确认 `gbase8a` 和 `gbase8s` 各 1 条