### PR TITLE
Fix：优化 GBase 8a agent 启动错误提示

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -193,12 +193,13 @@ public final class DamengAgent extends BaseDatabaseAgent {
     }
 
     private void loadTableOrViewFromComments(String schema, String tableType, Map<String, TableInfo> tablesByName) {
+        String tableNameFilter = "TABLE".equals(tableType) ? " AND TABLE_NAME NOT LIKE 'MTAB$_%'" : "";
         String sql = ("""
             SELECT TABLE_NAME, COMMENTS
             FROM ALL_TAB_COMMENTS
-            WHERE OWNER = ? AND TABLE_TYPE = '%s' AND ( (o.OBJECT_TYPE = 'TABLE' AND o.OBJECT_NAME NOT LIKE 'MTAB$_%') OR o.OBJECT_TYPE = 'VIEW')
+            WHERE OWNER = ? AND TABLE_TYPE = '%s'%s
             ORDER BY TABLE_NAME
-            """).formatted(tableType).stripIndent().trim();
+            """).formatted(tableType, tableNameFilter).stripIndent().trim();
         try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
             stmt.setString(1, schema);
             try (ResultSet rs = stmt.executeQuery()) {
@@ -213,7 +214,6 @@ public final class DamengAgent extends BaseDatabaseAgent {
 
     private void loadMaterializedViews(String schema, Map<String, TableInfo> tablesByName) {
         loadMaterializedViewsFromAllObjects(schema, tablesByName);
-        //loadMaterializedViewsFromUserMviews(schema, tablesByName);
     }
 
     private void loadMaterializedViewsFromAllObjects(String schema, Map<String, TableInfo> tablesByName) {

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -229,11 +229,9 @@ class DamengAgentMetadataTest {
                             : List.of()
                     );
                 }
-                if (sql.contains("ALL_OBJECTS") && sql.contains("MATERIALIZED VIEW")) {
+                if (sql.contains("USER_MVIEWS") && sql.contains("ALL_OBJECTS")) {
                     return metadataStatement(
-                        includeMaterializedView
-                            ? List.of(Arrays.asList("USER_SUMMARY_MV", "mv comment"))
-                            : List.of()
+                        includeMaterializedView ? List.of(Arrays.asList("USER_SUMMARY_MV", "mv comment")) : List.of()
                     );
                 }
                 if (sql.contains("ALL_OBJECTS")) {

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -49,7 +49,7 @@ class DamengAgentMetadataTest {
         String allTablesSql = String.join("\n", JdbcMetadataSqlFake.statements);
         Assertions.assertTrue(tablesSql.contains("COMMENTS"), tablesSql);
         Assertions.assertTrue(allTablesSql.contains("ALL_OBJECTS"), allTablesSql);
-        Assertions.assertTrue(allTablesSql.contains("MATERIALIZED_VIEW"), allTablesSql);
+        Assertions.assertTrue(allTablesSql.contains("USER_MVIEWS"), allTablesSql);
         Assertions.assertFalse(allTablesSql.contains("ALL_MVIEWS"), allTablesSql);
         Assertions.assertFalse(tablesSql.contains("ALL_TABLES"), tablesSql);
         Assertions.assertFalse(tablesSql.contains("ALL_VIEWS"), tablesSql);

--- a/agents/drivers/gbase8a/src/main/java/com/dbx/agent/gbase8a/Gbase8aAgent.java
+++ b/agents/drivers/gbase8a/src/main/java/com/dbx/agent/gbase8a/Gbase8aAgent.java
@@ -1,8 +1,12 @@
 package com.dbx.agent.gbase8a;
 
 import com.dbx.agent.ConfiguredJdbcAgent;
+import com.dbx.agent.ExecuteQueryOptions;
 import com.dbx.agent.JdbcAgentProfile;
 import com.dbx.agent.JsonRpcServer;
+import com.dbx.agent.QueryPageOptions;
+import com.dbx.agent.QueryPageResult;
+import com.dbx.agent.QueryResult;
 import com.dbx.agent.TableInfo;
 
 import java.sql.PreparedStatement;
@@ -32,6 +36,21 @@ public final class Gbase8aAgent extends ConfiguredJdbcAgent {
     }
 
     @Override
+    public QueryResult executeQuery(String sql, String schema, ExecuteQueryOptions options) {
+        return super.executeQuery(sql, schema, withoutFetchSize(options));
+    }
+
+    @Override
+    public QueryPageResult executeQueryPage(String sql, String schema, QueryPageOptions options) {
+        return super.executeQueryPage(sql, schema, withoutFetchSize(options));
+    }
+
+    @Override
+    public QueryPageResult startTableRead(String sql, String schema, QueryPageOptions options) {
+        return super.startTableRead(sql, schema, withoutFetchSize(options));
+    }
+
+    @Override
     public List<TableInfo> listTables(String schema) {
         return unchecked(() -> {
             List<TableInfo> result = new ArrayList<>();
@@ -58,6 +77,14 @@ public final class Gbase8aAgent extends ConfiguredJdbcAgent {
             result.sort(Comparator.comparing(TableInfo::getName));
             return result;
         });
+    }
+
+    private static ExecuteQueryOptions withoutFetchSize(ExecuteQueryOptions options) {
+        return new ExecuteQueryOptions(options.getMaxRows(), null, options.getTimeoutSecs());
+    }
+
+    private static QueryPageOptions withoutFetchSize(QueryPageOptions options) {
+        return new QueryPageOptions(options.getPageSize(), null, options.getMaxRows(), options.getTimeoutSecs());
     }
 
     public static void main(String[] args) {

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -42,6 +42,7 @@ import { canSaveVisibleDatabaseSelection, connectionUsesVisibleSchemaFilter, fil
 import { isSchemaAware } from "@/lib/databaseFeatureSupport";
 import VisibleSchemasDialog from "@/components/sidebar/VisibleSchemasDialog.vue";
 import { oceanbaseModeConnectionPatch, oceanbaseSubModeFromConfig } from "@/lib/oceanbaseConnectionMode";
+import { translateBackendError } from "@/i18n/backend-errors";
 
 type DbOption = { value: string; label: string };
 type DbCategory = { key: string; title: string; options: DbOption[] };
@@ -1479,7 +1480,7 @@ const visibleObjectLoadFailedKey = computed(() => (visibleFilterUsesSchemas.valu
 const visibleObjectSaveKey = computed(() => (visibleFilterUsesSchemas.value ? "visibleSchemas.save" : "visibleDatabases.save"));
 const testResultMessage = computed(() => {
   if (!testResult.value) return "";
-  return testResult.value.ok ? t("connection.testSuccess") : testResult.value.message;
+  return testResult.value.ok ? t("connection.testSuccess") : translateBackendError(t, testResult.value.message);
 });
 const shouldUseWideConnectionDialog = computed(() => dialogStep.value === "config" && (canChooseVisibleDatabases.value || (canChooseVisibleSchemas.value && !visibleFilterUsesSchemas.value)));
 const connectionDialogContentClass = computed(() => {

--- a/apps/desktop/src/i18n/backend-errors.ts
+++ b/apps/desktop/src/i18n/backend-errors.ts
@@ -5,6 +5,7 @@ const patterns: [RegExp, string][] = [
   [/^JRE (.+?) runtime is not installed\. Please install it from the Driver Manager\.$/, "connection.jreNotInstalled"],
   [/^System Java runtime was not found on PATH\. Please install Java or choose a custom Java executable\.$/, "connection.systemJavaNotFound"],
   [/^Custom Java runtime path is empty\. Please choose a Java executable\.$/, "connection.customJavaPathEmpty"],
+  [/^Agent requires Java 21, but DBX started it with an older Java runtime\. Use DBX managed JRE 21 or select a Java 21 executable in Driver Manager\./, "connection.agentJavaTooOld"],
   [/^JDBC plugin is not installed\. Install the optional JDBC plugin to use this connection\.$/, "connection.jdbcPluginNotInstalled"],
 ];
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -294,6 +294,7 @@ export default {
     jreNotInstalled: "JRE {jre} runtime is not installed. Please install it from the Driver Manager.",
     systemJavaNotFound: "System Java runtime was not found on PATH. Please install Java or choose a custom Java executable.",
     customJavaPathEmpty: "Custom Java runtime path is empty. Please choose a Java executable.",
+    agentJavaTooOld: "This driver requires Java 21. Use DBX managed JRE 21 or select a Java 21 executable in Driver Manager.",
     jdbcPluginNotInstalled: "JDBC plugin is not installed. Install the optional JDBC plugin to use this connection.",
     lastError: "Connection error",
     clearError: "Clear connection error",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -296,6 +296,7 @@ export default withEnglishFallback({
     jreNotInstalled: "El entorno JRE {jre} no está instalado. Instálelo desde el Administrador de controladores.",
     systemJavaNotFound: "No se encontró Java en el PATH del sistema. Instale Java o elija un ejecutable personalizado.",
     customJavaPathEmpty: "La ruta de Java personalizada está vacía. Elija un ejecutable de Java.",
+    agentJavaTooOld: "Este controlador requiere Java 21. Use el JRE 21 administrado por DBX o seleccione un ejecutable Java 21 en el Administrador de controladores.",
     jdbcPluginNotInstalled: "El plugin JDBC no está instalado. Instale el plugin JDBC opcional para usar esta conexión.",
     lastError: "Error de conexión",
     clearError: "Limpiar error de conexión",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -299,6 +299,7 @@ export default withEnglishFallback({
     jreNotInstalled: "Il runtime JRE {jre} non è installato. Installalo da Gestione Driver.",
     systemJavaNotFound: "Runtime Java di sistema non trovato in PATH. Installa Java o scegli un eseguibile Java personalizzato.",
     customJavaPathEmpty: "Il percorso del runtime Java personalizzato è vuoto. Scegli un eseguibile Java.",
+    agentJavaTooOld: "Questo driver richiede Java 21. Usa il JRE 21 gestito da DBX o seleziona un eseguibile Java 21 in Gestione Driver.",
     jdbcPluginNotInstalled: "Il plugin JDBC non è installato. Installa il plugin JDBC opzionale per utilizzare questa connessione.",
     lastError: "Errore di connessione",
     clearError: "Cancella errore di connessione",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -289,6 +289,7 @@ export default withEnglishFallback({
     jreNotInstalled: "JRE {jre} ランタイムがインストールされていません。ドライバーマネージャーからインストールしてください。",
     systemJavaNotFound: "システムJavaランタイムがPATHに見つかりませんでした。Javaをインストールするか、カスタムJava実行ファイルを選択してください。",
     customJavaPathEmpty: "カスタムJavaランタイムのパスが空です。Java実行ファイルを選択してください。",
+    agentJavaTooOld: "このドライバーにはJava 21が必要です。ドライバーマネージャーでDBX管理JRE 21を使用するか、Java 21実行ファイルを選択してください。",
     jdbcPluginNotInstalled: "JDBCプラグインがインストールされていません。この接続を使用するにはオプションのJDBCプラグインをインストールしてください。",
     lastError: "接続エラー",
     clearError: "接続エラーをクリア",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -296,6 +296,7 @@ export default withEnglishFallback({
     jreNotInstalled: "O runtime JRE {jre} não está instalado. Instale-o pelo Gerenciador de Drivers.",
     systemJavaNotFound: "O runtime Java do sistema não foi encontrado no PATH. Instale o Java ou escolha um executável Java personalizado.",
     customJavaPathEmpty: "O caminho do runtime Java personalizado está vazio. Escolha um executável Java.",
+    agentJavaTooOld: "Este driver requer Java 21. Use o JRE 21 gerenciado pelo DBX ou selecione um executável Java 21 no Gerenciador de Drivers.",
     jdbcPluginNotInstalled: "O plugin JDBC não está instalado. Instale o plugin JDBC opcional para usar esta conexão.",
     lastError: "Erro de conexão",
     clearError: "Limpar erro de conexão",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -297,6 +297,7 @@ export default withEnglishFallback({
     jreNotInstalled: "JRE {jre} 运行环境未安装，请在驱动管理器中安装。",
     systemJavaNotFound: "未在 PATH 中找到系统 Java 运行环境，请安装 Java 或选择自定义 Java 可执行文件。",
     customJavaPathEmpty: "自定义 Java 运行环境路径为空，请选择 Java 可执行文件。",
+    agentJavaTooOld: "该驱动需要 Java 21。请在驱动管理器中使用 DBX 托管 JRE 21，或选择 Java 21 可执行文件。",
     jdbcPluginNotInstalled: "JDBC 插件未安装，请先安装 JDBC 插件再使用此连接。",
     lastError: "连接错误",
     clearError: "清除连接错误",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -296,6 +296,7 @@ export default withEnglishFallback({
     jreNotInstalled: "JRE {jre} 執行環境未安裝，請在驅動程式管理器中安裝。",
     systemJavaNotFound: "未在 PATH 中找到系統 Java 執行環境，請安裝 Java 或選擇自訂 Java 可執行檔。",
     customJavaPathEmpty: "自訂 Java 執行環境路徑為空，請選擇 Java 可執行檔。",
+    agentJavaTooOld: "此驅動程式需要 Java 21。請在驅動程式管理器中使用 DBX 託管 JRE 21，或選擇 Java 21 可執行檔。",
     jdbcPluginNotInstalled: "JDBC 外掛程式未安裝，請先安裝 JDBC 外掛程式再使用此連線。",
     lastError: "連線錯誤",
     clearError: "清除連線錯誤",

--- a/crates/dbx-core/src/db/agent_driver.rs
+++ b/crates/dbx-core/src/db/agent_driver.rs
@@ -14,6 +14,9 @@ pub const AGENT_PROTOCOL_VERSION: u32 = 1;
 const RPC_TIMEOUT_SECS: u64 = 30;
 const STARTUP_TIMEOUT_SECS: u64 = 15;
 const STDERR_TAIL_LINES: usize = 20;
+const AGENT_EXIT_DIAGNOSTIC_WAIT_MS: u64 = 200;
+const AGENT_JAVA_TOO_OLD_MESSAGE: &str =
+    "Agent requires Java 21, but DBX started it with an older Java runtime. Use DBX managed JRE 21 or select a Java 21 executable in Driver Manager.";
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -378,24 +381,20 @@ impl AgentDriverClient {
         let ready_stdout = match startup_result {
             Ok(Ok(Ok(stdout))) => stdout,
             Ok(Ok(Err(e))) => {
-                return Err(format_agent_process_error(
-                    &e,
-                    child_exit_status(&mut child),
-                    &stderr_tail_snapshot(&stderr_tail),
-                ));
+                return Err(format_agent_startup_error(&e, &mut child, &stderr_tail));
             }
             Ok(Err(e)) => {
-                return Err(format_agent_process_error(
+                return Err(format_agent_startup_error(
                     &format!("Agent startup task failed: {e}"),
-                    child_exit_status(&mut child),
-                    &stderr_tail_snapshot(&stderr_tail),
+                    &mut child,
+                    &stderr_tail,
                 ));
             }
             Err(_) => {
-                return Err(format_agent_process_error(
+                return Err(format_agent_startup_error(
                     &format!("Agent startup timed out ({STARTUP_TIMEOUT_SECS}s)"),
-                    child_exit_status(&mut child),
-                    &stderr_tail_snapshot(&stderr_tail),
+                    &mut child,
+                    &stderr_tail,
                 ));
             }
         };
@@ -1191,6 +1190,15 @@ fn child_exit_status(child: &mut Child) -> Option<String> {
     }
 }
 
+fn child_exit_status_after_short_wait(child: &mut Child) -> Option<String> {
+    let status = child_exit_status(child);
+    if status.is_some() {
+        return status;
+    }
+    std::thread::sleep(Duration::from_millis(AGENT_EXIT_DIAGNOSTIC_WAIT_MS));
+    child_exit_status(child)
+}
+
 fn stderr_tail_snapshot(stderr_tail: &Arc<Mutex<StderrTail>>) -> StderrTail {
     let snapshot = stderr_tail.lock().map(|tail| tail.snapshot()).unwrap_or_default();
     let mut tail = StderrTail::with_capacity(STDERR_TAIL_LINES);
@@ -1201,20 +1209,44 @@ fn stderr_tail_snapshot(stderr_tail: &Arc<Mutex<StderrTail>>) -> StderrTail {
 }
 
 fn format_agent_process_error(base: &str, exit_status: Option<String>, stderr_tail: &StderrTail) -> String {
-    let mut parts = vec![base.to_string()];
+    let stderr = stderr_tail.snapshot();
+    let mut parts = Vec::new();
+    if let Some(hint) = agent_process_error_hint(&stderr) {
+        parts.push(hint.to_string());
+        parts.push(format!("details: {base}"));
+    } else {
+        parts.push(base.to_string());
+    }
     if let Some(status) = exit_status {
         parts.push(format!("agent process exited with {status}"));
     }
-    let stderr = stderr_tail.snapshot();
     if !stderr.is_empty() {
         parts.push(format!("recent stderr:\n{stderr}"));
     }
     parts.join(". ")
 }
 
+fn agent_process_error_hint(stderr: &str) -> Option<&'static str> {
+    let lower = stderr.to_ascii_lowercase();
+    if lower.contains("unsupportedclassversionerror")
+        && (lower.contains("class file version 65.0") || lower.contains("only recognizes class file versions up to"))
+    {
+        return Some(AGENT_JAVA_TOO_OLD_MESSAGE);
+    }
+    None
+}
+
+fn format_agent_startup_error(base: &str, child: &mut Child, stderr_tail: &Arc<Mutex<StderrTail>>) -> String {
+    format_agent_process_error(base, child_exit_status_after_short_wait(child), &stderr_tail_snapshot(stderr_tail))
+}
+
 impl AgentDriverClient {
     fn format_agent_process_error(&mut self, base: &str) -> String {
-        format_agent_process_error(base, child_exit_status(&mut self.child), &stderr_tail_snapshot(&self.stderr_tail))
+        format_agent_process_error(
+            base,
+            child_exit_status_after_short_wait(&mut self.child),
+            &stderr_tail_snapshot(&self.stderr_tail),
+        )
     }
 }
 
@@ -1229,12 +1261,15 @@ mod tests {
     use super::{
         agent_close_query_session_params, agent_handshake_params, agent_java_args, agent_object_source_params,
         agent_proxy_env_vars, agent_schema_params, agent_schema_table_params, agent_supports_capability,
-        agent_transaction_params, format_agent_process_error, is_unsupported_handshake_error, mongo_collection_params,
-        mongo_database_params, mongo_document_id_params, read_agent_line, AgentCapability, AgentDriverClient,
-        AgentHandshake, AgentKvMethod, AgentMethod, AgentTableReadCloseParams, AgentTableReadPageParams,
-        AgentTableReadStartParams, MongoAgentMethod, StderrTail, AGENT_PROTOCOL_VERSION,
+        agent_transaction_params, format_agent_process_error, format_agent_startup_error,
+        is_unsupported_handshake_error, mongo_collection_params, mongo_database_params, mongo_document_id_params,
+        read_agent_line, start_stderr_collector, AgentCapability, AgentDriverClient, AgentHandshake, AgentKvMethod,
+        AgentMethod, AgentTableReadCloseParams, AgentTableReadPageParams, AgentTableReadStartParams, MongoAgentMethod,
+        StderrTail, AGENT_PROTOCOL_VERSION,
     };
     use std::io::Cursor;
+    use std::process::{Command, Stdio};
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn agent_java_args_include_oracle_network_compatibility_flags() {
@@ -1327,6 +1362,30 @@ mod tests {
         assert!(message.contains("recent stderr:"));
         assert!(message.contains("NoClassDefFoundError"));
         assert!(message.contains("HiveAgent.connect"));
+    }
+
+    #[test]
+    fn startup_error_waits_briefly_for_exit_status_and_stderr_tail() {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 0.05; echo 'java.lang.UnsupportedClassVersionError: class file version 65.0' >&2; exit 1")
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("child should start");
+        let stderr_tail = Arc::new(Mutex::new(StderrTail::default()));
+        start_stderr_collector(child.stderr.take().expect("stderr should be piped"), Arc::clone(&stderr_tail));
+
+        let message = format_agent_startup_error(
+            "Failed to read startup line from agent: end of stream",
+            &mut child,
+            &stderr_tail,
+        );
+
+        assert!(message.contains("Failed to read startup line from agent: end of stream"));
+        assert!(message.contains("agent process exited with exit status: 1"));
+        assert!(message.contains("Agent requires Java 21"));
+        assert!(message.contains("details: Failed to read startup line from agent: end of stream"));
+        assert!(message.contains("UnsupportedClassVersionError"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明
- 将 agent 启动阶段的 Java 版本不兼容错误转换为更明确的提示，并接入前端 i18n。
- 新建连接测试失败结果也复用后端错误翻译，避免直接展示底层英文错误。
- 兼容 GBase 8a JDBC 不支持正数 fetchSize 的行为，查询和分页查询会忽略 fetchSize。

## 验证
- cargo fmt --check
- cargo test -p dbx-core db::agent_driver
- ./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json
- ./node_modules/.bin/oxfmt --check apps/desktop/src/i18n/backend-errors.ts apps/desktop/src/components/connection/ConnectionDialog.vue apps/desktop/src/i18n/locales/en.ts apps/desktop/src/i18n/locales/zh-CN.ts apps/desktop/src/i18n/locales/zh-TW.ts apps/desktop/src/i18n/locales/ja.ts apps/desktop/src/i18n/locales/es.ts apps/desktop/src/i18n/locales/it.ts apps/desktop/src/i18n/locales/pt-BR.ts
- python3 scripts/validate_agents.py .
- 使用 GBase 8a 8.6.2.43-R7-free.110605 实例验证 test_connection、SELECT VERSION()、分页查询和翻页

## 备注
- ./gradlew :gbase8a:shadowJar 本地仍因 Gradle 9.5.0 分发包下载超时未完成。