### PR TITLE
Fix: 修复 Ctrl 点选单元格变成区间选择

### DIFF
--- a/apps/desktop/src/composables/useDataGridSelection.ts
+++ b/apps/desktop/src/composables/useDataGridSelection.ts
@@ -31,6 +31,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   const isSelectingCells = ref(false);
 
   const isSelectingAll = ref(false);
+  const selectedCellKeys = ref<Set<string>>(new Set());
   const selectedRowIds = ref<Set<number>>(new Set());
   const selectedColumnIndexes = ref<Set<number>>(new Set());
   const lastClickedRowIndex = ref<number | null>(null);
@@ -50,17 +51,21 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     if (hasColumnSelection.value) {
       return extractColumnsSelection(columns.value, visibleSelectionRows.value, selectedColumnIndexes.value);
     }
+    if (selectedCellKeys.value.size > 0) {
+      return extractSelectedCellKeys(columns.value, visibleSelectionRows.value, selectedCellKeys.value);
+    }
     const range = selectedRange.value;
     if (!range) return { columns: [], rows: [] };
     return extractSelection(columns.value, visibleSelectionRows.value, range);
   });
 
-  const selectedCellCount = computed(() => selectedCells.value.columns.length * selectedCells.value.rows.length);
+  const selectedCellCount = computed(() => (selectedCellKeys.value.size > 0 ? selectedCellKeys.value.size : selectedCells.value.columns.length * selectedCells.value.rows.length));
   const hasCellSelection = computed(() => selectedCellCount.value > 0);
 
   function clearCellSelection() {
     selectionAnchor.value = null;
     selectionFocus.value = null;
+    selectedCellKeys.value = new Set();
     selectedColumnIndexes.value = new Set();
     isSelectingCells.value = false;
     isSelectingAll.value = false;
@@ -74,6 +79,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
 
   function selectSingleCell(rowIndex: number, colIndex: number) {
     const cell = { rowIndex, colIndex };
+    selectedCellKeys.value = new Set();
     selectionAnchor.value = cell;
     selectionFocus.value = cell;
   }
@@ -81,6 +87,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   function selectRow(rowIndex: number) {
     const range = rowSelectionRange(rowIndex, columns.value.length);
     if (!range) return;
+    selectedCellKeys.value = new Set();
     selectionAnchor.value = { rowIndex: range.startRow, colIndex: range.startCol };
     selectionFocus.value = { rowIndex: range.endRow, colIndex: range.endCol };
   }
@@ -88,6 +95,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   function selectRows(startRow: number, endRow: number) {
     const range = rowSelectionRange(startRow, columns.value.length, endRow);
     if (!range) return;
+    selectedCellKeys.value = new Set();
     selectionAnchor.value = { rowIndex: range.startRow, colIndex: range.startCol };
     selectionFocus.value = { rowIndex: range.endRow, colIndex: range.endCol };
   }
@@ -96,6 +104,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     const normalizedColumns = normalizeSelectedColumnIndexes(Array.from({ length: Math.abs(endCol - startCol) + 1 }, (_, index) => Math.min(startCol, endCol) + index));
     if (normalizedColumns.length === 0 || displayItems.value.length <= 0) return;
     clearRowSelection();
+    selectedCellKeys.value = new Set();
     selectionAnchor.value = null;
     selectionFocus.value = null;
     const next = options?.merge ? new Set(selectedColumnIndexes.value) : new Set<number>();
@@ -113,6 +122,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
       clearRowSelection();
       selectionAnchor.value = null;
       selectionFocus.value = null;
+      selectedCellKeys.value = new Set();
       const next = new Set(selectedColumnIndexes.value);
       if (next.has(colIndex)) {
         next.delete(colIndex);
@@ -132,6 +142,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     if (!range) return;
     clearRowSelection();
     selectedColumnIndexes.value = new Set();
+    selectedCellKeys.value = new Set();
     lastClickedColumnIndex.value = null;
     selectionAnchor.value = { rowIndex: range.startRow, colIndex: range.startCol };
     selectionFocus.value = { rowIndex: range.endRow, colIndex: range.endCol };
@@ -140,11 +151,35 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   }
 
   function extendCellSelectionTo(rowIndex: number, colIndex: number) {
+    selectedCellKeys.value = new Set();
     if (!selectionAnchor.value) {
       selectSingleCell(rowIndex, colIndex);
       return;
     }
     selectionFocus.value = { rowIndex, colIndex };
+  }
+
+  function toggleCellSelection(rowIndex: number, colIndex: number) {
+    const key = cellKey(rowIndex, colIndex);
+    const next = selectedCellKeys.value.size > 0 ? new Set(selectedCellKeys.value) : selectedRangeToCellKeys(selectedRange.value);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    selectedCellKeys.value = next;
+    selectedColumnIndexes.value = new Set();
+    if (next.size > 0) {
+      selectionAnchor.value = { rowIndex, colIndex };
+      selectionFocus.value = null;
+    } else {
+      selectionAnchor.value = null;
+      selectionFocus.value = null;
+    }
+    isSelectingCells.value = false;
+    isSelectingAll.value = false;
+    lastClickedColumnIndex.value = colIndex;
+    if (showTranspose.value) transposeRowIndex.value = rowIndex;
   }
 
   function handleRowClick(rowIndex: number, rowId: number, event: MouseEvent) {
@@ -213,11 +248,18 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     const isMeta = event.metaKey || event.ctrlKey;
     const isShift = event.shiftKey;
 
-    if (isMeta || isShift) {
+    if (isMeta) {
       event.preventDefault();
       focusGridWithoutScrolling();
       clearRowSelection();
-      if (hasColumnSelection.value) clearCellSelection();
+      toggleCellSelection(rowIndex, colIndex);
+      return;
+    }
+
+    if (isShift) {
+      event.preventDefault();
+      focusGridWithoutScrolling();
+      clearRowSelection();
       extendCellSelectionTo(rowIndex, colIndex);
       return;
     }
@@ -231,6 +273,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   }
 
   function cellIsSelected(rowIndex: number, colIndex: number): boolean {
+    if (selectedCellKeys.value.size > 0) return selectedCellKeys.value.has(cellKey(rowIndex, colIndex));
     if (hasColumnSelection.value) return rowIndex >= 0 && rowIndex < displayItems.value.length && selectedColumnIndexes.value.has(colIndex);
     return isCellInSelection(rowIndex, colIndex, selectedRange.value);
   }
@@ -257,6 +300,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     selectedCellCount,
     hasCellSelection,
     isSelectingAll,
+    selectedCellKeys,
     clearCellSelection,
     selectSingleCell,
     selectRow,
@@ -280,5 +324,50 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     handleRowClick,
     handleDataCellMousedown,
     isRowSelected,
+  };
+}
+
+function cellKey(rowIndex: number, colIndex: number): string {
+  return `${rowIndex}:${colIndex}`;
+}
+
+function parseCellKey(key: string): CellPosition | null {
+  const [row, col] = key.split(":");
+  const rowIndex = Number(row);
+  const colIndex = Number(col);
+  if (!Number.isInteger(rowIndex) || !Number.isInteger(colIndex) || rowIndex < 0 || colIndex < 0) return null;
+  return { rowIndex, colIndex };
+}
+
+function selectedRangeToCellKeys(range: CellSelectionRange | null): Set<string> {
+  const keys = new Set<string>();
+  if (!range) return keys;
+  for (let rowIndex = range.startRow; rowIndex <= range.endRow; rowIndex++) {
+    for (let colIndex = range.startCol; colIndex <= range.endCol; colIndex++) {
+      keys.add(cellKey(rowIndex, colIndex));
+    }
+  }
+  return keys;
+}
+
+function extractSelectedCellKeys(columns: readonly string[], rows: readonly CellValue[][], keys: Iterable<string>): SelectionData {
+  const positions = [...keys]
+    .map(parseCellKey)
+    .filter((position): position is CellPosition => !!position && position.rowIndex < rows.length && position.colIndex < columns.length)
+    .sort((a, b) => a.rowIndex - b.rowIndex || a.colIndex - b.colIndex);
+  const selectedColumnIndexes = normalizeSelectedColumnIndexes(positions.map((position) => position.colIndex)).filter((index) => index < columns.length);
+  const rowsByIndex = new Map<number, CellValue[]>();
+
+  for (const position of positions) {
+    const row = rows[position.rowIndex];
+    if (!row) continue;
+    const values = rowsByIndex.get(position.rowIndex) ?? [];
+    values.push(row[position.colIndex] ?? null);
+    rowsByIndex.set(position.rowIndex, values);
+  }
+
+  return {
+    columns: selectedColumnIndexes.map((index) => columns[index]),
+    rows: [...rowsByIndex.values()],
   };
 }

--- a/packages/app-tests/dataGridSelection.test.ts
+++ b/packages/app-tests/dataGridSelection.test.ts
@@ -3,6 +3,53 @@ import { test } from "vitest";
 import { computed, ref } from "vue";
 import { useDataGridSelection } from "../../apps/desktop/src/composables/useDataGridSelection.ts";
 
+function createSelection() {
+  return useDataGridSelection({
+    columns: computed(() => ["id", "name", "note"]),
+    displayItems: computed(() => [
+      {
+        id: 0,
+        sourceIndex: 0,
+        data: [1, "Ada", "math"],
+        isNew: false,
+        isDeleted: false,
+        isDirtyCol: [false, false, false],
+        status: "clean",
+      },
+      {
+        id: 1,
+        sourceIndex: 1,
+        data: [2, "Bob", "quote"],
+        isNew: false,
+        isDeleted: false,
+        isDirtyCol: [false, false, false],
+        status: "clean",
+      },
+      {
+        id: 2,
+        sourceIndex: 2,
+        data: [3, "O'Hara", null],
+        isNew: false,
+        isDeleted: false,
+        isDirtyCol: [false, false, false],
+        status: "clean",
+      },
+    ]),
+    editingCell: ref(null),
+    showTranspose: ref(false),
+    transposeRowIndex: ref(null),
+    gridRef: ref(undefined),
+  });
+}
+
+function mouseEvent(options: Partial<MouseEvent> = {}): MouseEvent {
+  return {
+    button: 0,
+    preventDefault() {},
+    ...options,
+  } as MouseEvent;
+}
+
 test("cell selection does not read row data before a range exists", () => {
   let displayItemsReads = 0;
   const selection = useDataGridSelection({
@@ -29,4 +76,28 @@ test("cell selection does not read row data before a range exists", () => {
 
   assert.equal(selection.hasCellSelection.value, false);
   assert.equal(displayItemsReads, 0);
+});
+
+test("ctrl clicking cells toggles only the clicked cells", () => {
+  const selection = createSelection();
+
+  selection.selectSingleCell(0, 0);
+  selection.handleDataCellMousedown(2, 2, 2, mouseEvent({ ctrlKey: true }));
+
+  assert.equal(selection.cellIsSelected(0, 0), true);
+  assert.equal(selection.cellIsSelected(2, 2), true);
+  assert.equal(selection.cellIsSelected(1, 1), false);
+  assert.equal(selection.selectedCellCount.value, 2);
+});
+
+test("shift clicking cells keeps range selection", () => {
+  const selection = createSelection();
+
+  selection.selectSingleCell(0, 0);
+  selection.handleDataCellMousedown(2, 2, 2, mouseEvent({ shiftKey: true }));
+
+  assert.equal(selection.cellIsSelected(0, 0), true);
+  assert.equal(selection.cellIsSelected(1, 1), true);
+  assert.equal(selection.cellIsSelected(2, 2), true);
+  assert.equal(selection.selectedCellCount.value, 9);
 });


### PR DESCRIPTION
## 变更说明

- 修复数据表格中 Ctrl/Cmd 点选单元格时误触发区间选择的问题
- 新增离散单元格选择状态，使 Ctrl/Cmd 点选只切换当前单元格
- 保持 Shift 点选继续按锚点进行区间选择
- 补充 Ctrl/Cmd 单元格点选和 Shift 区间选择的回归测试

Fixes #1777

## 验证

- ./node_modules/.bin/vitest run packages/app-tests/dataGridSelection.test.ts packages/app-tests/useDataGridExport.test.ts
- ./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json
- ./node_modules/.bin/oxfmt --check apps/desktop/src/composables/useDataGridSelection.ts packages/app-tests/dataGridSelection.test.ts