### PR TITLE
fix(mysql): use milliseconds for tcp keepalive

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -23,6 +23,7 @@ use crate::types::{
 use super::file_validator::validate_file_path;
 
 pub type MySqlPool = mysql_async::Pool;
+const MYSQL_TCP_KEEPALIVE_MS: u32 = 30_000;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct MySqlQueryDialect {
@@ -456,7 +457,7 @@ fn create_pool(
         .stmt_cache_size(0)
         .prefer_socket(false)
         .pool_opts(Some(pool_opts))
-        .tcp_keepalive(Some(30u32))
+        .tcp_keepalive(Some(MYSQL_TCP_KEEPALIVE_MS))
         .setup(mysql_setup_queries(url));
     if let Some(ssl_opts) = mysql_ssl_opts(base_ssl_opts, url, ca_cert_path, &tls_url.files)? {
         builder = builder.ssl_opts(ssl_opts);
@@ -3417,6 +3418,12 @@ UNIQUE KEY(`tenant_id`, `name``part`)
             server closed session with no notification";
 
         assert!(mysql_error_should_retry_without_ssl(error));
+    }
+
+    #[test]
+    fn mysql_tcp_keepalive_uses_milliseconds_not_seconds() {
+        assert_eq!(MYSQL_TCP_KEEPALIVE_MS, 30_000);
+        assert!(MYSQL_TCP_KEEPALIVE_MS >= 1_000);
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复 MySQL 连接池 TCP keepalive 参数单位错误：`mysql_async` 接收的是毫秒，原先传入 `30` 实际为 30ms，在 Linux 上会被转换为 `TCP_KEEPIDLE=0` 并触发 `Invalid argument (os error 22)`。

本 PR 将该值改为明确的 `30_000ms`，并补充回归测试避免再次误用单位。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

- [ ] `pnpm check` 通过
- [ ] `cargo check --no-default-features` 通过
- [x] 相关测试通过

已执行：

- `cargo fmt --check`
- `cargo test -p dbx-core mysql_tcp_keepalive_uses_milliseconds_not_seconds --no-default-features`
- `cargo check -p dbx-core --no-default-features`
- `cargo check -p dbx-web --no-default-features`

## 关联 Issue

Related #2021
