### PR TITLE
fix(codex): send exec prompt through stdin to avoid Windows   command-line length limit

### DIFF
--- a/crates/dbx-core/src/ai_cli_agent.rs
+++ b/crates/dbx-core/src/ai_cli_agent.rs
@@ -4,7 +4,7 @@ use crate::token_usage::TokenUsage;
 use serde_json::Value;
 use std::ffi::OsStr;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::Notify;
 
@@ -34,6 +34,7 @@ pub enum CliAgentJsonlDialect {
 pub struct CliAgentProcessSpec {
     pub command: CliAgentCommandSpec,
     pub env: Vec<(String, String)>,
+    pub stdin: Option<String>,
     pub dialect: CliAgentJsonlDialect,
     pub classify_spawn_error: fn(&str) -> String,
     pub classify_run_error: fn(&str) -> String,
@@ -361,10 +362,17 @@ pub async fn run_cli_jsonl_agent(
     let mut child = command
         .args(&spec.command.args)
         .envs(spec.env.iter().map(|(key, value)| (key.as_str(), value.as_str())))
+        .stdin(if spec.stdin.is_some() { Stdio::piped() } else { Stdio::null() })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| (spec.classify_spawn_error)(&e.to_string()))?;
+
+    if let Some(input) = spec.stdin {
+        let mut stdin = child.stdin.take().ok_or_else(|| "CLI agent stdin not available".to_string())?;
+        stdin.write_all(input.as_bytes()).await.map_err(|e| format!("Failed to write CLI agent stdin: {e}"))?;
+        stdin.shutdown().await.map_err(|e| format!("Failed to close CLI agent stdin: {e}"))?;
+    }
 
     let stdout = child.stdout.take().ok_or_else(|| "Failed to capture CLI agent stdout".to_string())?;
     let stderr = child.stderr.take().ok_or_else(|| "Failed to capture CLI agent stderr".to_string())?;
@@ -470,6 +478,7 @@ mod tests {
                 ],
             },
             env: vec![("DBX_TEST_ENV".to_string(), "from-env".to_string())],
+            stdin: None,
             dialect: CliAgentJsonlDialect::CodexExec,
             classify_spawn_error,
             classify_run_error,
@@ -478,6 +487,28 @@ mod tests {
         let result = run_cli_jsonl_agent(spec, &Notify::new(), |_| {}).await.unwrap();
 
         assert_eq!(result, "from-env");
+    }
+
+    #[tokio::test]
+    async fn jsonl_agent_writes_stdin_to_child() {
+        let spec = CliAgentProcessSpec {
+            command: CliAgentCommandSpec {
+                program: "sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "input=$(cat); printf '%s\n' \"{\\\"type\\\":\\\"item.completed\\\",\\\"item\\\":{\\\"type\\\":\\\"agent_message\\\",\\\"text\\\":\\\"$input\\\"}}\" \"{\\\"type\\\":\\\"turn.completed\\\"}\"".to_string(),
+                ],
+            },
+            env: Vec::new(),
+            stdin: Some("prompt from stdin".to_string()),
+            dialect: CliAgentJsonlDialect::CodexExec,
+            classify_spawn_error,
+            classify_run_error,
+        };
+
+        let result = run_cli_jsonl_agent(spec, &Notify::new(), |_| {}).await.unwrap();
+
+        assert_eq!(result, "prompt from stdin");
     }
 
     #[tokio::test]
@@ -495,6 +526,7 @@ mod tests {
         let spec = CliAgentProcessSpec {
             command: CliAgentCommandSpec { program: "sh".to_string(), args: vec!["-c".to_string(), script] },
             env: Vec::new(),
+            stdin: None,
             dialect: CliAgentJsonlDialect::CodexExec,
             classify_spawn_error,
             classify_run_error,

--- a/crates/dbx-core/src/ai_codex_cli.rs
+++ b/crates/dbx-core/src/ai_codex_cli.rs
@@ -409,7 +409,7 @@ fn codex_mcp_config_overrides(options: &CodexRunOptions) -> Vec<String> {
     overrides
 }
 
-pub fn build_codex_exec_command(config: &AiConfig, prompt: &str, options: &CodexRunOptions) -> CodexCommandSpec {
+pub fn build_codex_exec_command(config: &AiConfig, _prompt: &str, options: &CodexRunOptions) -> CodexCommandSpec {
     let mut args = vec![
         "exec".to_string(),
         "--json".to_string(),
@@ -429,7 +429,7 @@ pub fn build_codex_exec_command(config: &AiConfig, prompt: &str, options: &Codex
         args.push(model.to_string());
     }
 
-    args.push(prompt.to_string());
+    args.push("-".to_string());
 
     CodexCommandSpec { program: codex_program(config), args }
 }
@@ -519,9 +519,20 @@ fn classify_codex_spawn_error(message: &str) -> String {
     if message.contains("No such file") || message.contains("not found") {
         "[codexNotInstalled] Codex CLI was not found. Install Codex CLI or set the Codex CLI path in DBX AI settings."
             .to_string()
+    } else if is_command_line_too_long_error(message) {
+        "[codexCommandLineTooLong] Codex CLI command line is too long. Update DBX so Codex prompts are sent through stdin instead of process arguments."
+            .to_string()
     } else {
         format!("[codexRunFailed] Failed to start Codex CLI: {message}")
     }
+}
+
+fn is_command_line_too_long_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    message.contains("os error 206")
+        || message.contains("文件名或扩展名太长")
+        || lower.contains("filename or extension is too long")
+        || lower.contains("the filename or extension is too long")
 }
 
 fn classify_codex_run_error(stderr: &str) -> String {
@@ -558,6 +569,7 @@ pub async fn run_codex_agent(
         CliAgentProcessSpec {
             command,
             env,
+            stdin: Some(prompt.to_string()),
             dialect: CliAgentJsonlDialect::CodexExec,
             classify_spawn_error: classify_codex_spawn_error,
             classify_run_error: classify_codex_run_error,
@@ -621,6 +633,8 @@ mod tests {
 
         assert_eq!(spec.program, "codex");
         assert!(spec.args.contains(&"--json".to_string()));
+        assert_eq!(spec.args.last().map(String::as_str), Some("-"));
+        assert!(!spec.args.contains(&"hello".to_string()));
         assert!(!spec.args.contains(&"--model".to_string()));
         assert!(!spec.args.contains(&"--ask-for-approval".to_string()));
         assert!(spec.args.contains(&"mcp_servers.dbx.command=\"dbx-mcp-server\"".to_string()));
@@ -937,6 +951,13 @@ mod tests {
         );
         assert_eq!(models[1].display_name.as_deref(), Some("GPT-5.5"));
         assert!(!models.iter().any(|model| model.id == "priority" || model.id == "Priority"));
+    }
+
+    #[test]
+    fn classifies_windows_command_line_too_long_spawn_error() {
+        let err = classify_codex_spawn_error("文件名或扩展名太长。 (os error 206)");
+
+        assert!(err.contains("[codexCommandLineTooLong]"));
     }
 
     #[test]

--- a/crates/dbx-core/src/ai_codex_cli.rs
+++ b/crates/dbx-core/src/ai_codex_cli.rs
@@ -585,8 +585,8 @@ mod tests {
     #[cfg(not(windows))]
     use super::shell_quote;
     use super::{
-        build_codex_exec_command, codex_cli_env, codex_enabled_tools, is_path_like_program, parse_codex_jsonl_event,
-        parse_codex_models, validate_codex_program, CodexRunOptions, DEFAULT_CODEX_MODELS,
+        build_codex_exec_command, classify_codex_spawn_error, codex_cli_env, codex_enabled_tools, is_path_like_program,
+        parse_codex_jsonl_event, parse_codex_models, validate_codex_program, CodexRunOptions, DEFAULT_CODEX_MODELS,
     };
     #[cfg(not(windows))]
     use super::{codex_process_env, common_executable_dirs, merged_path_with_dir};


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
### Problem

  On Windows, Codex CLI sessions (ask / agent) fail with:

  Error: [codexRunFailed] Failed to start Codex CLI: 文件名或扩展名太长。
  (os error 206)

  This happens because `build_codex_exec_command` appends the full prompt
  (system prompt, conversation history, schema context, MCP config
  overrides,
  and user question) as a CLI argument to `codex exec`.  Windows
  `CreateProcess`
  caps the command line at 32,768 characters, and real-world prompts
  routinely
  exceed that.

  Model listing (`codex debug models`) and connection testing (`codex login
  status`)
  still work because their arguments are short.

  ### Fix

  Use `codex exec`'s built-in stdin support instead of passing the prompt on
  the
  command line.  `codex exec` treats `-` as the prompt placeholder, reading
  the
  actual prompt from stdin:

  ```text
  codex exec --json --sandbox read-only ... -

  Two files changed:

  - ai_codex_cli.rs — build_codex_exec_command now emits "-" as the
  final argument instead of the prompt string.  run_codex_agent passes the
  prompt through the new CliAgentProcessSpec.stdin field.  A new
  is_command_line_too_long_error helper classifies os error 206 with the
  clearer [codexCommandLineTooLong] error code as a safety net.
  - ai_cli_agent.rs — CliAgentProcessSpec gains an optional stdin:
  Option<String>
  field.  run_cli_jsonl_agent pipes stdin to the child process when present
  and
  closes it before reading stdout.  A new jsonl_agent_writes_stdin_to_child
  integration test validates end-to-end stdin delivery.

  Verification

  - cargo fmt passes cleanly.
  - New unit tests cover:
    - - placeholder is the last argument and the prompt string is absent
  from args.
    - os error 206 / 文件名或扩展名太长 maps to [codexCommandLineTooLong].
    - Stdin content reaches the child process and appears in the agent's
  output.
  - Existing tests for command construction and JSONL event parsing still
  pass.
  - windows_npm_codex_shim_command (.cmd → node codex.js rewrite) is
  unaffected — stdin is piped directly to the node process by tokio.
```

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2019 
