### PR TITLE
Fix: 修复 PostgreSQL 默认权限语句诊断误报

### DIFF
--- a/crates/dbx-core/src/sql_analysis.rs
+++ b/crates/dbx-core/src/sql_analysis.rs
@@ -19,6 +19,9 @@ static CLICKHOUSE_STRICTNESS_FIRST_JOIN_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(ANY|ALL|SEMI|ANTI|ASOF)\s+(LEFT|RIGHT|FULL|INNER|CROSS)(\s+OUTER)?\s+JOIN\b")
         .expect("valid ClickHouse join strictness regex")
 });
+static POSTGRES_DEFAULT_PRIVILEGES_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^\s*ALTER\s+DEFAULT\s+PRIVILEGES\b").expect("valid PostgreSQL default privileges regex")
+});
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SqlReferenceAnalysis {
@@ -71,6 +74,9 @@ pub fn analyze_sql_references(sql: &str, dialect: Option<&str>) -> Result<SqlRef
     if normalized_dialect == "duckdb" && starts_with_duckdb_parser_gap_sql(sql) {
         return Ok(SqlReferenceAnalysis { tables: vec![], columns: vec![] });
     }
+    if normalized_dialect == "postgres" && starts_with_postgres_parser_gap_sql(sql) {
+        return Ok(SqlReferenceAnalysis { tables: vec![], columns: vec![] });
+    }
     let parser_sql = if normalized_dialect == "clickhouse" {
         normalize_clickhouse_join_order_for_parser(sql)
     } else {
@@ -99,6 +105,10 @@ pub fn analyze_sql_references(sql: &str, dialect: Option<&str>) -> Result<SqlRef
 fn starts_with_duckdb_parser_gap_sql(sql: &str) -> bool {
     starts_with_duckdb_result_sql_keyword(sql)
         && starts_with_executable_sql_keyword(sql, &["FROM", "SUMMARIZE", "SUMMARISE", "PIVOT", "UNPIVOT"])
+}
+
+fn starts_with_postgres_parser_gap_sql(sql: &str) -> bool {
+    POSTGRES_DEFAULT_PRIVILEGES_RE.is_match(sql)
 }
 
 fn normalize_clickhouse_join_order_for_parser(sql: &str) -> String {

--- a/crates/dbx-core/tests/sql_analysis.rs
+++ b/crates/dbx-core/tests/sql_analysis.rs
@@ -45,6 +45,19 @@ fn extracts_mysql_single_quoted_table_references() {
 }
 
 #[test]
+fn postgres_default_privileges_statements_do_not_raise_syntax_errors() {
+    let sql = "\
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER ON TABLES TO app_user;";
+
+    let analysis = analyze_sql_references(sql, Some("postgres"))
+        .unwrap_or_else(|error| panic!("PostgreSQL ALTER DEFAULT PRIVILEGES should analyze: {error}"));
+
+    assert!(analysis.tables.is_empty());
+    assert!(analysis.columns.is_empty());
+}
+
+#[test]
 fn extracts_unqualified_order_by_columns_for_sqlserver_queries() {
     let analysis =
         analyze_sql_references("SELECT * FROM Evt_GCM_Qop_Info ORDER BY PDReceiveDatePartInfo DESC", Some("sqlserver"))


### PR DESCRIPTION
## 修复内容
- 在 SQL 引用分析中识别 PostgreSQL ALTER DEFAULT PRIVILEGES 语句
- 对该类 sqlparser 暂不支持的授权 DDL 返回空引用分析，避免编辑器把合法语句标红
- 添加回归测试覆盖 ALTER DEFAULT PRIVILEGES IN SCHEMA ... GRANT ... ON TABLES ... 场景

## 验证
- cargo fmt --check
- cargo test -p dbx-core --test sql_analysis