### PR TITLE
Keep first inserted grid row visible while editing

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4620,7 +4620,16 @@ function drawCanvasGrid() {
   });
 }
 
-watch(useCanvasGridRows, () => nextTick(attachCanvasResizeObserver), { immediate: true });
+watch(
+  [useCanvasGridRows, hasVisibleRows],
+  () => {
+    // When an empty table gets its first pending row, the canvas scroller is created by
+    // the v-if branch after the original mount-time observer attempt has already no-op'd.
+    // Reattach after that branch mounts so the canvas/overlay get real viewport dimensions.
+    nextTick(attachCanvasResizeObserver);
+  },
+  { immediate: true },
+);
 watch(showDataGridTopbar, () => nextTick(observeDataGridTopbarWidth), { immediate: true });
 watch(
   [


### PR DESCRIPTION
An empty table renders the placeholder branch before the first pending row exists, so the canvas scroller is not mounted when the original observer setup runs. Watching the visible-row transition reattaches the canvas observer after Vue mounts the scroller and gives the canvas/editor overlay real viewport dimensions.

Constraint: Default grid rendering mode is canvas and the scroller is gated behind hasVisibleRows.

Rejected: Force DOM row rendering for empty-table inserts | broader behavior change and bypasses the canvas rendering path.

Confidence: high

Scope-risk: narrow

Directive: Keep canvas observer lifecycle tied to both render mode and row-branch mounting; do not reduce it to render mode only without testing empty-table insertion.

Tested: pnpm exec vitest run packages/app-tests/canvasDataGridRenderer.test.ts packages/app-tests/dataGridEditor.test.ts

Tested: pnpm typecheck

Tested: pnpm lint

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
