### PR TITLE
Fix：避免 SQL 预览高亮失败导致白屏

### DIFF
--- a/apps/desktop/src/lib/__tests__/sqlHighlighter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sqlHighlighter.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSafeSqlHighlighter, escapeHtml } from "@/lib/sqlHighlighter";
+
+describe("escapeHtml", () => {
+  it("escapes SQL text for v-html fallback rendering", () => {
+    expect(escapeHtml(`SELECT '<tag>' AS "name" & col`)).toBe("SELECT &#39;&lt;tag&gt;&#39; AS &quot;name&quot; &amp; col");
+  });
+});
+
+describe("createSafeSqlHighlighter", () => {
+  it("falls back to escaped SQL when Shiki highlighting fails", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const highlighter = createSafeSqlHighlighter(
+      {
+        codeToHtml: () => {
+          throw new SyntaxError("Invalid regular expression: invalid group specifier name");
+        },
+      },
+      { appearance: () => "light" },
+    );
+
+    expect(highlighter(`ALTER TABLE t ADD "<x>" INT;`)).toBe("ALTER TABLE t ADD &quot;&lt;x&gt;&quot; INT;");
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
+  });
+});

--- a/apps/desktop/src/lib/sqlHighlighter.ts
+++ b/apps/desktop/src/lib/sqlHighlighter.ts
@@ -12,17 +12,50 @@ const SHIKI_THEMES = {
 } as const;
 
 type ShikiHighlighter = Awaited<ReturnType<typeof import("shiki/core").createHighlighterCore>>;
+type ShikiCodeHighlighter = Pick<ShikiHighlighter, "codeToHtml">;
 
 let highlighterPromise: Promise<ShikiHighlighter> | undefined;
 
 export async function createShikiSqlHighlighter(options: ShikiSqlHighlighterOptions): Promise<SqlHighlighter> {
-  const highlighter = await getShikiSqlHighlighter();
-  return (content, appearance = options.appearance()) =>
-    highlighter.codeToHtml(content, {
-      lang: "sql",
-      structure: "inline",
-      theme: SHIKI_THEMES[appearance],
-    });
+  try {
+    const highlighter = await getShikiSqlHighlighter();
+    return createSafeSqlHighlighter(highlighter, options);
+  } catch (error) {
+    console.warn("[DBX][sqlHighlighter] Failed to initialize SQL highlighter:", error);
+    return escapeHtml;
+  }
+}
+
+export function createSafeSqlHighlighter(highlighter: ShikiCodeHighlighter, options: ShikiSqlHighlighterOptions): SqlHighlighter {
+  return (content, appearance = options.appearance()) => {
+    try {
+      return highlighter.codeToHtml(content, {
+        lang: "sql",
+        structure: "inline",
+        theme: SHIKI_THEMES[appearance],
+      });
+    } catch (error) {
+      console.warn("[DBX][sqlHighlighter] Failed to highlight SQL:", error);
+      return escapeHtml(content);
+    }
+  };
+}
+
+export function escapeHtml(content: string): string {
+  return content.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
 }
 
 function getShikiSqlHighlighter(): Promise<ShikiHighlighter> {


### PR DESCRIPTION
## 变更说明
- 为共享 SQL 高亮器增加初始化失败和高亮执行失败的兜底处理
- 当 Shiki 或运行环境正则兼容性异常时，SQL 预览退回到安全转义后的纯文本显示，避免页面白屏
- 补充单测覆盖高亮异常时的 fallback 行为

## 验证
- pnpm vitest run apps/desktop/src/lib/__tests__/sqlHighlighter.spec.ts
- oxfmt --check apps/desktop/src/lib/sqlHighlighter.ts apps/desktop/src/lib/__tests__/sqlHighlighter.spec.ts
- oxlint --vue-plugin apps/desktop/src/lib/sqlHighlighter.ts apps/desktop/src/lib/__tests__/sqlHighlighter.spec.ts
- git diff --check