### PR TITLE
Fix: 修复图片预览弹窗层级

### DIFF
--- a/apps/desktop/src/components/grid/ImagePreviewDialog.vue
+++ b/apps/desktop/src/components/grid/ImagePreviewDialog.vue
@@ -180,7 +180,14 @@ onUnmounted(() => {
 
 <template>
   <Dialog :open="open" @update:open="(value) => emit('update:open', value)">
-    <DialogContent :show-close-button="false" class="image-preview-dialog !flex !max-w-[92vw] flex-col gap-0 overflow-hidden rounded-xl border-white/10 bg-[#090b0f] p-0 text-white shadow-2xl sm:!max-w-[92vw]" :style="dialogStyle" @escape-key-down="close">
+    <DialogContent
+      :show-close-button="false"
+      overlay-class="!z-[80]"
+      portal-class="!z-[81]"
+      class="image-preview-dialog !flex !max-w-[92vw] flex-col gap-0 overflow-hidden rounded-xl border-white/10 bg-[#090b0f] p-0 text-white shadow-2xl sm:!max-w-[92vw]"
+      :style="dialogStyle"
+      @escape-key-down="close"
+    >
       <div class="flex h-12 shrink-0 items-center gap-3 border-b border-white/10 bg-white/[0.035] px-4">
         <div class="min-w-0 flex-1">
           <DialogTitle class="truncate text-sm font-semibold text-white">{{ imageTitle }}</DialogTitle>

--- a/apps/desktop/src/components/ui/dialog/DialogContent.vue
+++ b/apps/desktop/src/components/ui/dialog/DialogContent.vue
@@ -13,20 +13,30 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = withDefaults(defineProps<DialogContentProps & { class?: HTMLAttributes["class"]; showCloseButton?: boolean }>(), {
-  showCloseButton: true,
-});
+const props = withDefaults(
+  defineProps<
+    DialogContentProps & {
+      class?: HTMLAttributes["class"];
+      overlayClass?: HTMLAttributes["class"];
+      portalClass?: HTMLAttributes["class"];
+      showCloseButton?: boolean;
+    }
+  >(),
+  {
+    showCloseButton: true,
+  },
+);
 const emits = defineEmits<DialogContentEmits>();
 
-const delegatedProps = reactiveOmit(props, "class");
+const delegatedProps = reactiveOmit(props, "class", "overlayClass", "portalClass");
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits);
 </script>
 
 <template>
   <DialogPortal>
-    <DialogOverlay />
-    <div class="fixed inset-0 z-50 grid place-items-center p-4 pointer-events-none">
+    <DialogOverlay :class="props.overlayClass" />
+    <div :class="cn('fixed inset-0 z-50 grid place-items-center p-4 pointer-events-none', props.portalClass)">
       <DialogContent
         data-slot="dialog-content"
         v-bind="{ ...$attrs, ...forwarded }"


### PR DESCRIPTION
## 修复内容
- 为通用 DialogContent 增加可选的 overlayClass 和 portalClass，允许特定弹窗覆盖遮罩和内容容器层级。
- 将图片预览弹窗提升到高于普通 Dialog 的层级，避免从独立单元格详情弹窗中预览图片时被详情弹窗遮挡。
- 普通弹窗默认层级保持不变。

## 验证
- `./node_modules/.bin/oxfmt apps/desktop/src/components/ui/dialog/DialogContent.vue apps/desktop/src/components/grid/ImagePreviewDialog.vue --check`
- `./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `./node_modules/.bin/vitest run packages/app-tests/imagePreviewViewer.test.ts packages/app-tests/cellImageUrl.test.ts packages/app-tests/dataGridDetail.test.ts`
- Vite 运行时检查确认 ImagePreviewDialog 输出 `!z-[80]` / `!z-[81]` 层级配置