### PR TITLE
fix(browser): ensure connection is active before API calls on mount

### DIFF
--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -13,6 +13,7 @@ import ErrorBanner from "@/components/ui/ErrorBanner.vue";
 import DataGrid from "@/components/grid/DataGrid.vue";
 import QueryLoadingState from "@/components/common/QueryLoadingState.vue";
 import * as api from "@/lib/api";
+import { useConnectionStore } from "@/stores/connectionStore";
 import { clampSearchSplitWidth } from "@/lib/dataGridSearchSplit";
 import { documentViewerFontStyle } from "@/lib/documentViewerFontStyle";
 import { buildDocumentFilterCondition, combineDocumentFilterConditions, currentDocumentFilterJson, defaultDocumentFilterRule, documentFilterModeNeedsValue, documentFilterModeOptions, documentStoreProviderFor, type DocumentFilterMode, type DocumentFilterRule } from "@/lib/documentStoreProvider";
@@ -28,6 +29,7 @@ import "splitpanes/dist/splitpanes.css";
 
 const { t } = useI18n();
 const settingsStore = useSettingsStore();
+const connectionStore = useConnectionStore();
 
 const props = defineProps<{
   connectionId: string;
@@ -714,7 +716,14 @@ function highlightedJson(json: string): string {
   });
 }
 
-onMounted(load);
+onMounted(async () => {
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
+  load();
+});
 onBeforeUnmount(() => {
   if (documentLoadExecutionId.value) void api.cancelQuery(documentLoadExecutionId.value);
   stopDocumentLoadingTimer();

--- a/apps/desktop/src/components/kv/KvKeyBrowser.vue
+++ b/apps/desktop/src/components/kv/KvKeyBrowser.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
+import { useConnectionStore } from "@/stores/connectionStore";
 import { ChevronDown, ChevronRight, FolderClosed, FolderOpen, KeyRound, Loader2, Plus, RefreshCw, Search, Trash2 } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -84,6 +85,7 @@ const props = withDefaults(
 
 const { t } = useI18n();
 const { toast } = useToast();
+const connectionStore = useConnectionStore();
 const searchInputRef = ref<HTMLInputElement>();
 const prefix = ref("");
 const keys = ref<KvKeySummary[]>([]);
@@ -539,7 +541,14 @@ function refresh(): boolean {
 
 watch(
   () => props.connectionId,
-  () => void loadKeys(true),
+  async () => {
+    try {
+      await connectionStore.ensureConnected(props.connectionId);
+    } catch {
+      // Connection failed — loadKeys will show the error state
+    }
+    void loadKeys(true);
+  },
 );
 
 watch(
@@ -552,7 +561,14 @@ watch(
   { immediate: true },
 );
 
-onMounted(() => void loadKeys(true));
+onMounted(async () => {
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
+  void loadKeys(true);
+});
 defineExpose({ focusSearch, refresh });
 </script>
 

--- a/apps/desktop/src/components/mq/MqAdminConsole.vue
+++ b/apps/desktop/src/components/mq/MqAdminConsole.vue
@@ -3,6 +3,7 @@ import { formatError } from "@/lib/errorUtils";
 import { ref, computed, onMounted, watch } from "vue";
 import type { MqClusterInfo, TopicInfo } from "@/types/mq";
 import { mqTestConnection } from "@/lib/api";
+import { useConnectionStore } from "@/stores/connectionStore";
 import { mqClusterOptionsFromExtra } from "@/lib/mqTenantForm";
 import TenantsPanel from "./TenantsPanel.vue";
 import NamespacesPanel from "./NamespacesPanel.vue";
@@ -21,6 +22,7 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const connectionStore = useConnectionStore();
 
 type MqTab = "tenants" | "namespaces" | "topics" | "subscriptions" | "monitoring" | "clients" | "policies" | "permissions" | "raw";
 
@@ -168,7 +170,12 @@ watch(
 );
 
 // Lifecycle
-onMounted(() => {
+onMounted(async () => {
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
   loadClusterInfo();
 });
 </script>

--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -13,6 +13,7 @@ import EditorSearchPanel from "@/components/editor/EditorSearchPanel.vue";
 import NacosConfigDiffDialog from "@/components/nacos/NacosConfigDiffDialog.vue";
 import NacosConfigHistoryDialog from "@/components/nacos/NacosConfigHistoryDialog.vue";
 import { useToast } from "@/composables/useToast";
+import { useConnectionStore } from "@/stores/connectionStore";
 import { useI18n } from "vue-i18n";
 import * as api from "@/lib/api";
 import { buildNacosConfigDeleteConfirm, buildNacosConfigExportFileName, buildNacosConfigHistoryRollbackConfirm, buildNacosInstanceConfirm, createNacosSaveAsCopy, resolveNacosConfigCopyText } from "@/lib/nacosAdmin";
@@ -39,6 +40,7 @@ type AdminTab = "configs" | "services";
 const { toast } = useToast();
 const { t } = useI18n();
 const settingsStore = useSettingsStore();
+const connectionStore = useConnectionStore();
 const { isDark } = useTheme();
 const activeTab = ref<AdminTab>("configs");
 const connectionInfo = ref<NacosConnectionInfo | null>(null);
@@ -839,12 +841,22 @@ watch(
     originalConfigContent.value = "";
     destroyConfigEditor();
     selectedService.value = null;
+    try {
+      await connectionStore.ensureConnected(props.connectionId);
+    } catch (e) {
+      console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+    }
     await loadInfo();
     await Promise.all([loadConfigsWithRetry(1), loadServicesWithRetry(1)]);
   },
 );
 
 onMounted(async () => {
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
   await loadInfo();
   await Promise.all([loadConfigsWithRetry(1), loadServicesWithRetry(1)]);
 });

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -1236,11 +1236,16 @@ onBeforeUnmount(() => {
 
 watch(
   () => [props.connection.id, props.database, props.schema] as const,
-  () => {
+  async () => {
     selectedSchema.value = props.schema;
     userHasSelectedFilter.value = false;
     objectFilter.value = "all";
     clearTableSelection();
+    try {
+      await connectionStore.ensureConnected(props.connection.id);
+    } catch (e) {
+      console.warn("[DBX] ensureConnected failed for", props.connection.id, e);
+    }
     void reload();
   },
   { immediate: true },

--- a/apps/desktop/src/components/redis/RedisDashboard.vue
+++ b/apps/desktop/src/components/redis/RedisDashboard.vue
@@ -255,6 +255,11 @@ watch(autoRefreshInterval, () => {
 // Lifecycle
 // ---------------------------------------------------------------------------
 onMounted(async () => {
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
   await fetchClusterNodes();
   await fetchInfo();
 });

--- a/apps/desktop/src/components/redis/RedisKeyBrowser.vue
+++ b/apps/desktop/src/components/redis/RedisKeyBrowser.vue
@@ -921,12 +921,29 @@ function onCommandInputKeydown(event: KeyboardEvent) {
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
   resumeRedisBrowserBackgroundWork();
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
   void loadKeys();
 });
 
-onActivated(resumeRedisBrowserBackgroundWork);
+onActivated(async () => {
+  resumeRedisBrowserBackgroundWork();
+  // Ensure the connection is still alive after reactivation (e.g. tab switch).
+  // If keys failed to load previously (empty list), retry loading.
+  try {
+    await connectionStore.ensureConnected(props.connectionId);
+  } catch (e) {
+    console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
+  }
+  if (flatKeys.value.length === 0 && !loading.value) {
+    void loadKeys();
+  }
+});
 
 onDeactivated(pauseRedisBrowserBackgroundWork);
 

--- a/apps/desktop/src/components/redis/RedisSlowlogPanel.vue
+++ b/apps/desktop/src/components/redis/RedisSlowlogPanel.vue
@@ -59,9 +59,10 @@ const showClientColumns = computed(() => {
 onMounted(async () => {
   if (connectionMode.value === "cluster") {
     try {
+      await connectionStore.ensureConnected(props.connectionId);
       nodes.value = await api.redisClusterMasterNodes(props.connectionId);
-    } catch {
-      // Silently fail — nodes list is best-effort
+    } catch (e) {
+      console.warn("[DBX] ensureConnected failed for", props.connectionId, e);
     }
   }
 });

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -494,30 +494,38 @@ async function toggle() {
         await connectionStore.loadDatabases(node.connectionId);
       }
     } else if (node.type === "redis-db" && node.connectionId && node.database) {
+      await connectionStore.ensureConnected(node.connectionId);
       const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "Redis"}:db${node.database}`;
       queryStore.createTab(node.connectionId, node.database, tabTitle, "redis");
     } else if (node.type === "mq-tenant" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       queryStore.openMqAdmin(node.connectionId, { tenant: node.mqTenant || node.label });
     } else if (node.type === "nacos-namespace" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       queryStore.openNacosAdmin(node.connectionId, { namespace: node.nacosNamespace || "", namespaceName: node.nacosNamespaceName || node.label });
     } else if (node.type === "etcd-root" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "etcd"}:keys`;
       queryStore.createTab(node.connectionId, "", tabTitle, "etcd");
       refreshActiveKvBrowserAfterOpen("etcd", node.connectionId);
     } else if (node.type === "zookeeper-root" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "ZooKeeper"}:keys`;
       queryStore.createTab(node.connectionId, "", tabTitle, "zookeeper");
       refreshActiveKvBrowserAfterOpen("zookeeper", node.connectionId);
     } else if (node.type === "user-admin" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       queryStore.openUserAdmin(node.connectionId);
     } else if (node.type === "mongo-db" && node.connectionId && node.database) {
       await connectionStore.loadMongoCollections(node.connectionId, node.database);
     } else if (node.type === "mongo-collection" && node.connectionId && node.database) {
       await connectionStore.loadTableGroups(node.connectionId, node.database, node.label, node.schema, node.id);
     } else if (node.type === "elasticsearch-index" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       const tab = queryStore.createTab(node.connectionId, node.database || "default", node.label, "mongo");
       queryStore.updateSql(tab, node.label);
     } else if (node.type === "vector-collection" && node.connectionId) {
+      await connectionStore.ensureConnected(node.connectionId);
       const collectionRef = node.id.includes("__vector_collection:") ? node.id.split("__vector_collection:").pop() || node.label : node.label;
       const tab = queryStore.createTab(node.connectionId, node.database || "default", node.label, "vector");
       queryStore.updateSql(tab, collectionRef);


### PR DESCRIPTION
## 背景说明
应用重启后，各数据库浏览器组件在 onMounted 中直接发起 API 请求，
但连接池在重启后已失效，导致数据无法加载（如 Redis 显示"未找到 key"）。
需手动点击刷新按钮才能恢复。

## 修改内容
- RedisKeyBrowser: onMounted + onActivated 各添加 ensureConnected， onActivated 仅在 keys 为空时重载（保留滚动/展开状态）
- RedisDashboard / RedisSlowlogPanel: onMounted 添加 ensureConnected
- KvKeyBrowser (etcd/ZooKeeper): onMounted + watch(connectionId) 添加 ensureConnected
- DocumentBrowser: onMounted 添加 ensureConnected
- MqAdminConsole: onMounted 添加 ensureConnected
- NacosAdminConsole: onMounted + watch([connectionId,namespace]) 添加 ensureConnected
- ObjectBrowser: immediate watch 添加 ensureConnected
- TreeItem: 8 种 sidebar 入口节点在创建 tab 前添加 ensureConnected (redis-db, etcd-root, zookeeper-root, mq-tenant, nacos-namespace, elasticsearch-index, vector-collection, user-admin)
- 所有 catch 块添加 console.warn 便于排查连接失败根因

## 修复的问题
- 应用重启 / tab 恢复后，数据库浏览器组件显示空状态，需手动刷新
- 适用于：Redis / MongoDB / etcd / ZooKeeper / MQ / Nacos / Objects 等所有浏览器

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

打开redis的某个db展开所有key，然后关闭应用再重新打开应用，能看到数据key还被加载回来

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2063 
