### PR TITLE
fix(vector): use specified database for Milvus collection listing (#2073)

### DIFF
--- a/apps/desktop/src/lib/ai.ts
+++ b/apps/desktop/src/lib/ai.ts
@@ -393,7 +393,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
   // Vector databases: load collections instead of SQL tables
   if (isVectorDbType(databaseType)) {
     try {
-      const collections = await api.vectorListCollections(tab.connectionId);
+      const collections = await api.vectorListCollections(tab.connectionId, tab.database);
 
       // Find the currently opened collection (tab.sql is UUID for ChromaDB, name for others)
       const currentCollection = collections.find((c) => c.id === tab.sql || c.name === tab.sql);

--- a/apps/desktop/src/lib/http.ts
+++ b/apps/desktop/src/lib/http.ts
@@ -1736,8 +1736,8 @@ export async function elasticsearchListIndices(connectionId: string): Promise<st
   return collections.map((c) => c.name);
 }
 
-export async function vectorListCollections(connectionId: string): Promise<CollectionInfo[]> {
-  return mongoListCollections(connectionId, "default");
+export async function vectorListCollections(connectionId: string, database?: string): Promise<CollectionInfo[]> {
+  return mongoListCollections(connectionId, database || "default");
 }
 
 export async function mongoFindDocuments(connectionId: string, database: string, collection: string, skip: number, limit: number, filter?: string, projection?: string, sort?: string, executionId?: string): Promise<MongoDocumentResult> {

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1465,8 +1465,8 @@ export async function elasticsearchListIndices(connectionId: string): Promise<st
   return collections.map((c) => c.name);
 }
 
-export async function vectorListCollections(connectionId: string): Promise<CollectionInfo[]> {
-  return mongoListCollections(connectionId, "default");
+export async function vectorListCollections(connectionId: string, database?: string): Promise<CollectionInfo[]> {
+  return mongoListCollections(connectionId, database || "default");
 }
 
 export async function mongoFindDocuments(connectionId: string, database: string, collection: string, skip: number, limit: number, filter?: string, projection?: string, sort?: string, executionId?: string): Promise<MongoDocumentResult> {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1707,10 +1707,12 @@ export const useConnectionStore = defineStore("connection", () => {
     const node = findNode(treeNodes.value, connectionId);
     if (!node) return;
 
+    const config = getConfig(connectionId);
+    const database = config?.database || "default";
     node.isLoading = true;
     try {
       await ensureConnected(connectionId);
-      const collections = await withMetadataLoadTimeout(connectionId, api.vectorListCollections(connectionId), "vector collections");
+      const collections = await withMetadataLoadTimeout(connectionId, api.vectorListCollections(connectionId, database), "vector collections");
       const sorted = [...collections].sort((a, b) => a.name.localeCompare(b.name));
       setChildren(
         node,
@@ -1721,7 +1723,7 @@ export const useConnectionStore = defineStore("connection", () => {
             label: info.name,
             type: "vector-collection" as const,
             connectionId,
-            database: "default",
+            database,
             isExpanded: false,
             meta: info.dimension != null ? { dimension: info.dimension } : undefined,
           })),

--- a/crates/dbx-core/src/mongo_ops.rs
+++ b/crates/dbx-core/src/mongo_ops.rs
@@ -78,7 +78,7 @@ pub async fn mongo_list_collections_core(
             let names = sort_names(elasticsearch_driver::list_indices(client).await?);
             Ok(names.into_iter().map(|n| CollectionInfo { name: n.clone(), id: n, dimension: None }).collect())
         }
-        PoolKind::VectorDb(client) => vector_driver::list_collections(client).await,
+        PoolKind::VectorDb(client) => vector_driver::list_collections_with_db(&client, database).await,
         PoolKind::Agent(client) => {
             let mut client = client.lock().await;
             let names = sort_names(client.mongo_list_collections(database).await?);


### PR DESCRIPTION
## Problem

Closes #2073

连接 Milvus 时指定了数据库，但展示的集合始终来自默认数据库（default），而非用户指定的数据库。

根因：`vectorListCollections` 在前端硬编码 `"default"` 作为数据库名，后端 `mongo_list_collections_core` 的 VectorDb 分支也丢弃了 database 参数，始终调用 `list_collections(client)`（空字符串 → fallback 到 "default"）。

## Changes

- `tauri.ts` / `http.ts`：`vectorListCollections` 接受可选 `database` 参数，默认 `"default"`
- `connectionStore.ts`：`loadVectorCollections` 从连接配置读取 `config.database` 传入 API 和树节点
- `ai.ts`：AI 上下文加载传 `tab.database` 给 `vectorListCollections`
- `mongo_ops.rs`：VectorDb 分支改用 `list_collections_with_db(client, database)` 替代 `list_collections(client)`

## Verification

- [x] `cargo check -p dbx-core` 编译通过
- [x] 本地验证：连接 Milvus 指定非默认数据库，集合列表正确展示对应数据库的内容