### PR TITLE
Fix：修复左侧导航加载更多表无反应

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -575,16 +575,14 @@ async function toggle() {
 
 function runRowClickAction() {
   const node = props.node;
-  if (node.type === "load-more") {
-    void loadMoreObjectGroupChildren();
-    return;
-  }
   if (node.type === "object-browser") {
     void openObjectBrowser();
     return;
   }
   const action = treeNodeRowAction(node.type, canExpand.value, settingsStore.editorSettings.sidebarActivation);
-  if (action === "open-data") {
+  if (action === "load-more") {
+    void loadMoreObjectGroupChildren();
+  } else if (action === "open-data") {
     openData();
   } else if (node.type === "mongo-collection") {
     openMongoCollectionData(node);

--- a/apps/desktop/src/lib/treeNodeClick.ts
+++ b/apps/desktop/src/lib/treeNodeClick.ts
@@ -1,7 +1,7 @@
 import type { ObjectSourceKind, TreeNode, TreeNodeType } from "@/types/database";
 import { matchesShortcut, type ShortcutLikeEvent } from "@/lib/keyboardShortcuts";
 
-export type TreeNodeRowAction = "open-data" | "toggle" | "none";
+export type TreeNodeRowAction = "open-data" | "toggle" | "load-more" | "none";
 export type TreeNodeRowDoubleClickAction = "open-data" | "open-object-browser" | "open-object-browser-and-expand" | "open-source" | "open-saved-sql" | "toggle" | "none";
 export type SidebarSelectionCopyAction = "copy-name" | "none";
 export type SidebarActivation = "single" | "double";
@@ -26,6 +26,7 @@ export function objectSourceKindForTreeNode(type: TreeNodeType): ObjectSourceKin
 }
 
 export function treeNodeRowAction(type: TreeNodeType, canExpand: boolean, activation: SidebarActivation = "single"): TreeNodeRowAction {
+  if (type === "load-more") return "load-more";
   if (activation === "double") return "none";
   if (dataNodeTypes.has(type)) return "open-data";
   if (toggleLeafNodeTypes.has(type)) return "toggle";

--- a/packages/app-tests/treeNodeClick.test.ts
+++ b/packages/app-tests/treeNodeClick.test.ts
@@ -14,6 +14,11 @@ test("double click navigation mode selects rows on single click", () => {
   assert.equal(treeNodeRowAction("saved-sql-file", false, "double"), "none");
 });
 
+test("load more rows always run from a single click", () => {
+  assert.equal(treeNodeRowAction("load-more", false), "load-more");
+  assert.equal(treeNodeRowAction("load-more", false, "double"), "load-more");
+});
+
 test("double click navigation mode opens actionable rows on double click", () => {
   assert.equal(treeNodeRowDoubleClickAction("table", true, "double"), "open-data");
   assert.equal(treeNodeRowDoubleClickAction("view", true, "double"), "open-data");


### PR DESCRIPTION
## 变更说明
- 将左侧导航的“加载更多”节点明确作为单击动作处理
- 避免它受到“左侧导航双击激活”设置影响，导致点击后只选中节点但不触发加载
- 补充点击行为测试，覆盖双击激活模式下的加载更多动作

Fixes #2068

## 验证
- pnpm vitest run packages/app-tests/treeNodeClick.test.ts
- oxfmt --check apps/desktop/src/lib/treeNodeClick.ts apps/desktop/src/components/sidebar/TreeItem.vue packages/app-tests/treeNodeClick.test.ts
- oxlint --vue-plugin apps/desktop/src/lib/treeNodeClick.ts apps/desktop/src/components/sidebar/TreeItem.vue packages/app-tests/treeNodeClick.test.ts
- git diff --check