### PR TITLE
Fix：修复表结构字段拖拽排序交互

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -418,6 +418,7 @@ watch(
 watch(localStructureDensity, (density, previousDensity) => {
   if (density === previousDensity) return;
   applyStructureDensityWidths(density);
+  persistStructureDensity(density);
 });
 
 function onColResize(e: MouseEvent, col: number) {
@@ -969,10 +970,13 @@ function removeNewColumn(column: EditableStructureColumn) {
 type ColumnDragState = {
   columnId: string;
   sourceIndex: number;
-  insertionIndex: number;
+  insertionIndex: number | null;
 };
 
 const columnDragState = ref<ColumnDragState | null>(null);
+let columnDragPreviousBodyUserSelect = "";
+let columnDragPreviousBodyCursor = "";
+let columnDragTracking = false;
 
 function canDragColumn(index: number): boolean {
   if (loading.value || saving.value) return false;
@@ -1008,6 +1012,82 @@ function moveColumnTo(index: number, insertionIndex: number) {
   columns.value = nextColumns;
 }
 
+function onColumnDragPointerDown(index: number, event: PointerEvent) {
+  if (event.button !== 0 || !canDragColumn(index)) return;
+  const column = columns.value[index];
+  if (!column) return;
+  event.preventDefault();
+  event.stopPropagation();
+  columnDragState.value = {
+    columnId: column.id,
+    sourceIndex: index,
+    insertionIndex: null,
+  };
+  columnDragPreviousBodyUserSelect = document.body.style.userSelect;
+  columnDragPreviousBodyCursor = document.body.style.cursor;
+  columnDragTracking = true;
+  document.body.style.userSelect = "none";
+  document.body.style.cursor = "grabbing";
+  updateColumnDragInsertion(event.clientY);
+  window.addEventListener("pointermove", onColumnDragPointerMove, true);
+  window.addEventListener("pointerup", onColumnDragPointerUp, true);
+  window.addEventListener("pointercancel", onColumnDragPointerCancel, true);
+}
+
+function onColumnDragPointerMove(event: PointerEvent) {
+  if (!columnDragState.value) return;
+  event.preventDefault();
+  updateColumnDragInsertion(event.clientY);
+}
+
+function onColumnDragPointerUp(event: PointerEvent) {
+  event.preventDefault();
+  const state = columnDragState.value;
+  stopColumnDragTracking();
+  if (state && state.insertionIndex !== null && canDropColumnAt(state.sourceIndex, state.insertionIndex)) {
+    moveColumnTo(state.sourceIndex, state.insertionIndex);
+  }
+  columnDragState.value = null;
+}
+
+function onColumnDragPointerCancel() {
+  stopColumnDragTracking();
+  columnDragState.value = null;
+}
+
+function stopColumnDragTracking() {
+  if (!columnDragTracking) return;
+  columnDragTracking = false;
+  window.removeEventListener("pointermove", onColumnDragPointerMove, true);
+  window.removeEventListener("pointerup", onColumnDragPointerUp, true);
+  window.removeEventListener("pointercancel", onColumnDragPointerCancel, true);
+  document.body.style.userSelect = columnDragPreviousBodyUserSelect;
+  document.body.style.cursor = columnDragPreviousBodyCursor;
+}
+
+function updateColumnDragInsertion(clientY: number) {
+  const state = columnDragState.value;
+  if (!state) return;
+  const insertionIndex = columnDragInsertionIndexFromPoint(clientY);
+  state.insertionIndex = insertionIndex !== null && canDropColumnAt(state.sourceIndex, insertionIndex) ? insertionIndex : null;
+}
+
+function columnDragInsertionIndexFromPoint(clientY: number): number | null {
+  const rows = Array.from(rootRef.value?.querySelectorAll<HTMLElement>("[data-column-row-index]") ?? []);
+  if (!rows.length) return null;
+  const firstRect = rows[0].getBoundingClientRect();
+  if (clientY < firstRect.top) return 0;
+  for (const row of rows) {
+    const rowIndex = Number(row.dataset.columnRowIndex);
+    if (!Number.isInteger(rowIndex)) continue;
+    const rect = row.getBoundingClientRect();
+    if (clientY <= rect.bottom) {
+      return clientY > rect.top + rect.height / 2 ? rowIndex + 1 : rowIndex;
+    }
+  }
+  return rows.length;
+}
+
 function onColumnDragStart(index: number, event: DragEvent) {
   if (!canDragColumn(index)) {
     event.preventDefault();
@@ -1018,7 +1098,7 @@ function onColumnDragStart(index: number, event: DragEvent) {
   columnDragState.value = {
     columnId: column.id,
     sourceIndex: index,
-    insertionIndex: index,
+    insertionIndex: null,
   };
   if (event.dataTransfer) {
     event.dataTransfer.effectAllowed = "move";
@@ -1053,8 +1133,9 @@ function columnRowClass(column: EditableStructureColumn, index: number) {
   return {
     "bg-destructive/5 opacity-60": column.markedForDrop,
     "opacity-55": dragState?.columnId === column.id,
-    "bg-primary/5 shadow-[inset_0_2px_0_var(--primary)]": dragState && canDropColumnAt(dragState.sourceIndex, index) && dragState.insertionIndex === index,
-    "bg-primary/5 shadow-[inset_0_-2px_0_var(--primary)]": dragState && canDropColumnAt(dragState.sourceIndex, index + 1) && dragState.insertionIndex === index + 1,
+    "bg-primary/5": dragState && (dragState.insertionIndex === index || dragState.insertionIndex === index + 1),
+    "[&>td]:border-t-2 [&>td]:border-t-primary": dragState?.insertionIndex === index,
+    "[&>td]:border-b-2 [&>td]:border-b-primary": dragState?.insertionIndex === index + 1,
   };
 }
 
@@ -1441,6 +1522,7 @@ onActivated(() => {
 });
 onDeactivated(unregisterStructureEditorShortcuts);
 onBeforeUnmount(() => {
+  stopColumnDragTracking();
   unregisterStructureEditorShortcuts();
   clearSqlPreviewState();
   persistStructureDensity();
@@ -1637,7 +1719,7 @@ watch(activeTab, (tab) => {
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="(column, index) in columns" :key="column.id" :class="columnRowClass(column, index)" :data-new-column-row="!column.original ? 'true' : undefined" @dragover="onColumnDragOver(index, $event)" @drop="onColumnDrop(index, $event)">
+                <tr v-for="(column, index) in columns" :key="column.id" :class="columnRowClass(column, index)" :data-new-column-row="!column.original ? 'true' : undefined" :data-column-row-index="index" @dragover="onColumnDragOver(index, $event)" @drop="onColumnDrop(index, $event)">
                   <td :class="[structureCellClass, 'text-muted-foreground']">
                     <div class="flex items-center gap-1">
                       <span>{{ index + 1 }}</span>
@@ -1872,7 +1954,8 @@ watch(activeTab, (tab) => {
                         :disabled="!canDragColumn(index)"
                         :title="t('structureEditor.dragColumn')"
                         :aria-label="t('structureEditor.dragColumn')"
-                        draggable="true"
+                        :draggable="canDragColumn(index)"
+                        @pointerdown="onColumnDragPointerDown(index, $event)"
                         @dragstart="onColumnDragStart(index, $event)"
                         @dragend="onColumnDragEnd"
                       >


### PR DESCRIPTION
## 变更
- 将编辑表结构的字段排序从依赖原生 HTML5 drag 补强为 pointer 拖拽跟踪，修复发布版 App 中拖拽按钮拖不动的问题。
- 拖拽过程中显示目标插入位置的高亮和上/下边线，避免只能在松手后才知道落点。
- 紧凑 / 标准 / 宽松密度切换后立即持久化，重开编辑页或重启 App 后保持用户选择。

## 原因
发布版桌面 WebView 中，原先绑定在按钮上的原生拖拽事件不稳定，可能导致拖拽状态没有正确建立，最终 drop 不生效。改为 pointer 事件后由组件自己维护拖拽移动和释放位置，同时保留原有 drag/drop 作为兼容路径。

## 验证
- ./node_modules/.bin/oxfmt --check apps/desktop/src/components/structure/TableStructureEditor.vue
- ./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json
- ./node_modules/.bin/vitest run apps/desktop/src/stores/__tests__/settingsStore.spec.ts packages/app-tests/tableStructureEditorState.test.ts apps/desktop/src/lib/__tests__/tableStructureEditorState.spec.ts
- ./node_modules/.bin/vite build --config apps/desktop/vite.config.ts
- ./node_modules/.bin/tauri build --bundles app --no-sign --ci --config /tmp/dbx-tauri-skip-build.XXXXXX.json
- 已打包桌面 App 并本地验证可拖拽、可看到插入提示、密度设置可持久化。