### PR TITLE
✨ feat(newQuery): 数据库表右键增加新建查询选项，并支持自动填充查询语句

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -36,7 +36,7 @@ import * as api from "@/lib/api";
 import { connectionRedactedNameLabel } from "@/lib/connectionPresentation";
 import { quickConnectionOpenTarget } from "@/lib/connectionOpenTarget";
 import { resolveDefaultDatabase } from "@/lib/defaultDatabase";
-import { findTreeNodeById, resolveNewQueryTarget } from "@/lib/newQueryContext";
+import { buildNewQueryTableSelectSql, findTreeNodeById, resolveNewQueryTarget } from "@/lib/newQueryContext";
 import { buildExecutableObjectSourceStatements, objectSourceSaveExecutionMode } from "@/lib/objectSourceEditor";
 import { resolveExecutableSql, resolveExecutableSqlWithBackend, type SqlExecutionSnapshot } from "@/lib/sqlExecutionTarget";
 import { uuid } from "@/lib/utils";
@@ -813,6 +813,15 @@ async function newQuery() {
   const tabId = queryStore.createTab(conn.id, target.database, undefined, "query", target.schema);
   try {
     await connectionStore.ensureConnected(target.connectionId);
+    if (target.kind === "table-select") {
+      const sql = await buildNewQueryTableSelectSql({
+        databaseType: effectiveDatabaseTypeForConnection(conn),
+        schema: target.schema,
+        tableName: target.tableName,
+      });
+      queryStore.updateSql(tabId, sql);
+      return;
+    }
     if (target.shouldRefreshDefaultDatabase) {
       const options = await getDatabaseOptions(target.connectionId);
       queryStore.updateDatabase(tabId, resolveDefaultDatabase(conn, options));

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -50,7 +50,7 @@ import { sortTablesByFkDependency, type TableWithFk } from "@/lib/tableDependenc
 import { isSchemaAware } from "@/lib/databaseCapabilities";
 import { supportsSchemaDiagram, supportsTableImport, supportsTableStructureEditing, supportsTableTruncate } from "@/lib/databaseFeatureSupport";
 import { codeMirrorSqlDialect, connectionUsesDatabaseObjectTreeMode, effectiveDatabaseTypeForConnection, tableStructureDatabaseTypeForConnection } from "@/lib/jdbcDialect";
-import { buildTableSelectSql } from "@/lib/tableSelectSql";
+import { buildNewQueryTableSelectSql } from "@/lib/newQueryContext";
 import { buildDropObjectSql, buildDuplicateTableStructureSql, buildEmptyTableSql, buildTruncateTableSql, type TableAdminSqlOptions } from "@/lib/dbAdminSql";
 import { useToast } from "@/composables/useToast";
 import { buildExecutableObjectSourceStatements, buildRoutineRenameObjectSourceStatements, objectSourceSaveExecutionMode, supportsSourceBackedRoutineRename } from "@/lib/objectSourceEditor";
@@ -458,14 +458,13 @@ async function openViewDdl(row: ObjectBrowserRow) {
 }
 
 async function openNewQuery(row: ObjectBrowserRow) {
-  const tabId = queryStore.createTab(props.connection.id, props.database, row.name);
+  const tabId = queryStore.createTab(props.connection.id, props.database, undefined, "query", row.schema || selectedSchema.value);
   queryStore.updateSql(
     tabId,
-    await buildTableSelectSql({
+    await buildNewQueryTableSelectSql({
       databaseType: effectiveDatabaseType.value,
       schema: row.schema || selectedSchema.value,
       tableName: row.name,
-      limit: 100,
     }),
   );
 }

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -67,6 +67,7 @@ import type { ColumnInfo, ConnectionConfig, DatabaseType, ObjectSourceKind, Tree
 import * as api from "@/lib/api";
 import { uuid } from "@/lib/utils";
 import { resolveDefaultDatabase } from "@/lib/defaultDatabase";
+import { buildNewQueryTableSelectSql } from "@/lib/newQueryContext";
 import { canTreeNodePin, canTreeNodeShowExpander, treeItemPaddingLeft, usesFullWidthTreeLabel } from "@/lib/sidebarTreeItemLayout";
 import { buildTableSelectSql } from "@/lib/tableSelectSql";
 import { buildTableDeleteTemplate, buildTableInsertTemplate, buildTableSelectTemplate, buildTableUpdateTemplate } from "@/lib/tableSqlTemplates";
@@ -1136,7 +1137,7 @@ async function newQuery() {
     connectionStore.activeConnectionId = node.connectionId;
     if (hasTreeNodeDatabaseContext(node)) {
       if (node.type === "table" || node.type === "view" || node.type === "materialized_view") {
-        await newSelectTemplate();
+        await openTableSelectNewQuery();
         return;
       }
       queryStore.createTab(node.connectionId, node.database, undefined, "query", node.schema);
@@ -1216,6 +1217,21 @@ async function newSelectTemplate() {
       columns: context.columns,
     });
     openSqlTemplateTab(context.node.connectionId!, context.node.database!, context.node.schema, sql);
+  } catch (e: any) {
+    toast(t("connection.connectFailed", { message: translateBackendError(t, e?.message || String(e)) }), 5000);
+  }
+}
+
+async function openTableSelectNewQuery() {
+  const node = props.node;
+  if (!node.connectionId || !node.database) return;
+  try {
+    const sql = await buildNewQueryTableSelectSql({
+      databaseType: currentDatabaseType(),
+      schema: node.schema,
+      tableName: node.tableName || node.label,
+    });
+    openSqlTemplateTab(node.connectionId, node.database, node.schema, sql);
   } catch (e: any) {
     toast(t("connection.connectFailed", { message: translateBackendError(t, e?.message || String(e)) }), 5000);
   }
@@ -3821,6 +3837,7 @@ function treeItemMenuItems(): ContextMenuItem[] {
     items.push({ label: t("contextMenu.copyName"), action: copyName, icon: Copy, shortcut: shortcutCopyName.value });
     items.push({ label: "", separator: true });
     items.push({ label: t("contextMenu.viewData"), action: openData, icon: TableProperties });
+    items.push({ label: t("contextMenu.newQuery"), action: newQuery, icon: TerminalSquare });
     if (node.type === "table") {
       items.push({
         label: t("contextMenu.viewDdl"),

--- a/apps/desktop/src/lib/__tests__/newQueryContext.spec.ts
+++ b/apps/desktop/src/lib/__tests__/newQueryContext.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildNewQueryTableSelectSql, resolveNewQueryTarget } from "@/lib/newQueryContext";
+import type { ConnectionConfig, QueryTab, TreeNode } from "@/types/database";
+
+const mocks = vi.hoisted(() => ({
+  buildTableSelectSql: vi.fn(async (options) => `select:${options.databaseType}:${options.schema ?? ""}:${options.tableName}:${options.limit}`),
+}));
+
+vi.mock("@/lib/api", () => ({
+  buildTableSelectSql: mocks.buildTableSelectSql,
+}));
+
+function connection(id = "conn"): Pick<ConnectionConfig, "id" | "database"> {
+  return { id, database: "app" };
+}
+
+describe("newQueryContext", () => {
+  it("uses the active data tab as a table-select query target", () => {
+    const activeTab = {
+      connectionId: "conn",
+      database: "app",
+      schema: "public",
+      mode: "data",
+      tableMeta: {
+        schema: "public",
+        tableName: "users",
+        columns: [],
+        primaryKeys: [],
+      },
+    } as Pick<QueryTab, "connectionId" | "database" | "schema" | "mode" | "tableMeta">;
+
+    expect(resolveNewQueryTarget({ activeTab, connections: [connection()], preferredSource: "tab" })).toEqual({
+      kind: "table-select",
+      connectionId: "conn",
+      database: "app",
+      schema: "public",
+      tableName: "users",
+      shouldRefreshDefaultDatabase: false,
+    });
+  });
+
+  it("uses selected table-like sidebar nodes as table-select query targets", () => {
+    const selectedTreeNode = {
+      id: "node",
+      label: "orders",
+      type: "view",
+      connectionId: "conn",
+      database: "app",
+      schema: "reporting",
+    } as Pick<TreeNode, "id" | "label" | "type" | "connectionId" | "database" | "schema">;
+
+    expect(resolveNewQueryTarget({ selectedTreeNode, connections: [connection()], preferredSource: "sidebar" })).toEqual({
+      kind: "table-select",
+      connectionId: "conn",
+      database: "app",
+      schema: "reporting",
+      tableName: "orders",
+      shouldRefreshDefaultDatabase: false,
+    });
+  });
+
+  it("keeps query tabs and database nodes as blank query targets", () => {
+    const activeTab = {
+      connectionId: "conn",
+      database: "app",
+      schema: "public",
+      mode: "query",
+    } as Pick<QueryTab, "connectionId" | "database" | "schema" | "mode" | "tableMeta">;
+    const selectedTreeNode = {
+      id: "db",
+      label: "app",
+      type: "database",
+      connectionId: "conn",
+      database: "app",
+    } as Pick<TreeNode, "id" | "label" | "type" | "connectionId" | "database" | "schema">;
+
+    expect(resolveNewQueryTarget({ activeTab, selectedTreeNode, connections: [connection()], preferredSource: "tab" })).toEqual({
+      kind: "blank",
+      connectionId: "conn",
+      database: "app",
+      schema: "public",
+      shouldRefreshDefaultDatabase: false,
+    });
+    expect(resolveNewQueryTarget({ activeTab, selectedTreeNode, connections: [connection()], preferredSource: "sidebar" })).toEqual({
+      kind: "blank",
+      connectionId: "conn",
+      database: "app",
+      schema: undefined,
+      shouldRefreshDefaultDatabase: false,
+    });
+  });
+
+  it("builds table-select SQL with a 100 row limit", async () => {
+    await expect(buildNewQueryTableSelectSql({ databaseType: "mysql", schema: "public", tableName: "users" })).resolves.toBe("select:mysql:public:users:100");
+
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith({
+      databaseType: "mysql",
+      schema: "public",
+      tableName: "users",
+      limit: 100,
+    });
+  });
+});

--- a/apps/desktop/src/lib/newQueryContext.ts
+++ b/apps/desktop/src/lib/newQueryContext.ts
@@ -1,22 +1,45 @@
 import { resolveDefaultDatabase } from "@/lib/defaultDatabase";
+import { buildTableSelectSql } from "@/lib/tableSelectSql";
 import type { ConnectionConfig, QueryTab, TreeNode } from "@/types/database";
 
-export interface NewQueryTarget {
+interface NewQueryBaseTarget {
   connectionId: string;
   database: string;
   schema?: string;
+}
+
+export interface BlankNewQueryTarget extends NewQueryBaseTarget {
+  kind: "blank";
   shouldRefreshDefaultDatabase: boolean;
 }
+
+export interface TableSelectNewQueryTarget extends NewQueryBaseTarget {
+  kind: "table-select";
+  tableName: string;
+  shouldRefreshDefaultDatabase: false;
+}
+
+export type NewQueryTarget = BlankNewQueryTarget | TableSelectNewQueryTarget;
 
 export type NewQueryContextSource = "tab" | "sidebar";
 
 interface ResolveNewQueryTargetInput {
-  activeTab?: Pick<QueryTab, "connectionId" | "database" | "schema">;
-  selectedTreeNode?: Pick<TreeNode, "connectionId" | "database" | "schema"> | null;
+  activeTab?: Pick<QueryTab, "connectionId" | "database" | "schema" | "mode" | "tableMeta">;
+  selectedTreeNode?: Pick<TreeNode, "connectionId" | "database" | "schema" | "tableName" | "type" | "label"> | null;
   activeConnectionId?: string | null;
   connections: Pick<ConnectionConfig, "id" | "database">[];
   preferredSource?: NewQueryContextSource;
 }
+
+interface BuildNewQueryTableSelectSqlInput {
+  databaseType?: Parameters<typeof buildTableSelectSql>[0]["databaseType"];
+  schema?: string;
+  tableName: string;
+}
+
+type NewQueryContext = NonNullable<ResolveNewQueryTargetInput["activeTab"]> | NonNullable<ResolveNewQueryTargetInput["selectedTreeNode"]>;
+
+const TABLE_SELECT_NEW_QUERY_LIMIT = 100;
 
 export function findTreeNodeById(nodes: TreeNode[], id: string | null | undefined): TreeNode | null {
   if (!id) return null;
@@ -40,6 +63,7 @@ export function resolveNewQueryTarget(input: ResolveNewQueryTargetInput): NewQue
   const fallbackConnection = activeConnection || input.connections[0];
   return fallbackConnection
     ? {
+        kind: "blank",
         connectionId: fallbackConnection.id,
         database: resolveDefaultDatabase(fallbackConnection, []),
         shouldRefreshDefaultDatabase: true,
@@ -47,15 +71,46 @@ export function resolveNewQueryTarget(input: ResolveNewQueryTargetInput): NewQue
     : null;
 }
 
-function targetFromContext(context: Pick<QueryTab | TreeNode, "connectionId" | "database" | "schema"> | undefined, connections: Pick<ConnectionConfig, "id" | "database">[]): NewQueryTarget | null {
+export function buildNewQueryTableSelectSql(input: BuildNewQueryTableSelectSqlInput): Promise<string> {
+  return buildTableSelectSql({
+    databaseType: input.databaseType,
+    schema: input.schema,
+    tableName: input.tableName,
+    limit: TABLE_SELECT_NEW_QUERY_LIMIT,
+  });
+}
+
+function targetFromContext(context: NewQueryContext | undefined, connections: Pick<ConnectionConfig, "id" | "database">[]): NewQueryTarget | null {
   if (!context?.connectionId) return null;
   const connection = connections.find((item) => item.id === context.connectionId);
   if (!connection) return null;
   const database = context.database || resolveDefaultDatabase(connection, []);
+  const tableName = tableNameFromContext(context);
+  if (tableName) {
+    return {
+      kind: "table-select",
+      connectionId: context.connectionId,
+      database,
+      schema: context.schema,
+      tableName,
+      shouldRefreshDefaultDatabase: false,
+    };
+  }
   return {
+    kind: "blank",
     connectionId: context.connectionId,
     database,
-    schema: "schema" in context ? (context as { schema?: string }).schema : undefined,
+    schema: context.schema,
     shouldRefreshDefaultDatabase: !context.database,
   };
+}
+
+function tableNameFromContext(context: NewQueryContext): string | null {
+  if ("mode" in context) {
+    return context.mode === "data" ? context.tableMeta?.tableName || null : null;
+  }
+  if (context.type === "table" || context.type === "view" || context.type === "materialized_view") {
+    return context.tableName || context.label || null;
+  }
+  return null;
 }


### PR DESCRIPTION
- 数据库表右键增加新建查询选项，并支持自动填充查询语句。

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="655" height="390" alt="image" src="https://github.com/user-attachments/assets/3b5a98b1-d887-4714-bc31-a6882d2c9d62" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2101 