### PR TITLE
fix(web): persist agent drivers under data dir

### DIFF
--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -32,6 +32,14 @@ fn web_body_limit_bytes() -> usize {
     mb.saturating_mul(1024 * 1024)
 }
 
+fn web_agent_dir(data_dir: &std::path::Path) -> std::path::PathBuf {
+    web_agent_dir_from_env(data_dir, std::env::var("DBX_AGENT_DIR").ok())
+}
+
+fn web_agent_dir_from_env(data_dir: &std::path::Path, agent_dir: Option<String>) -> std::path::PathBuf {
+    agent_dir.map(std::path::PathBuf::from).unwrap_or_else(|| data_dir.join("agents"))
+}
+
 fn normalize_public_base_path(value: Option<String>) -> String {
     let trimmed = value
         .unwrap_or_else(|| "/".to_string())
@@ -53,7 +61,7 @@ fn normalize_public_base_path(value: Option<String>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_public_base_path;
+    use super::{normalize_public_base_path, web_agent_dir_from_env};
 
     #[test]
     fn normalize_public_base_path_defaults_to_root() {
@@ -73,6 +81,21 @@ mod tests {
     #[should_panic(expected = "DBX_PUBLIC_BASE_PATH contains invalid characters")]
     fn normalize_public_base_path_rejects_invalid_characters() {
         normalize_public_base_path(Some("/dbx admin".to_string()));
+    }
+
+    #[test]
+    fn web_agent_dir_defaults_under_data_dir() {
+        let data_dir = std::path::PathBuf::from("/app/data");
+        assert_eq!(web_agent_dir_from_env(&data_dir, None), data_dir.join("agents"));
+    }
+
+    #[test]
+    fn web_agent_dir_uses_explicit_env_override() {
+        let data_dir = std::path::PathBuf::from("/app/data");
+        assert_eq!(
+            web_agent_dir_from_env(&data_dir, Some("/custom/agents".to_string())),
+            std::path::PathBuf::from("/custom/agents")
+        );
     }
 }
 
@@ -148,9 +171,10 @@ async fn main() {
         let db_path = data_dir.join("dbx.db");
         let storage = Storage::open(&db_path).await.expect("Failed to open storage");
         storage.migrate_from_json(&data_dir).await.expect("Failed to migrate JSON data");
-        Arc::new(AppState::new_with_plugin_dir_and_app_version(
+        Arc::new(AppState::new_with_plugin_and_agent_dir_and_app_version(
             storage,
             data_dir.join("plugins"),
+            web_agent_dir(&data_dir),
             env!("CARGO_PKG_VERSION"),
         ))
     };


### PR DESCRIPTION
## 变更说明

修复 Web / Docker 部署中 Agent 驱动目录未随 `DBX_DATA_DIR` 持久化的问题。

- Web 启动时默认将 Agent 驱动、托管 JRE 和下载状态放到 `DBX_DATA_DIR/agents`。
- 保持 JDBC 插件目录仍使用 `DBX_DATA_DIR/plugins`。
- 新增可选环境变量 `DBX_AGENT_DIR`，允许高级用户自定义 Agent 驱动目录。
- 补充 Web Agent 目录解析的单元测试，覆盖默认目录和环境变量覆盖路径。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 只涉及 Web / Docker 后端启动路径配置，不涉及前端 UI。

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo fmt --check`
- `cargo test -p dbx-web --no-default-features`
- `cargo check -p dbx-web --no-default-features`
- `cargo check --workspace --no-default-features`

手动验证：

- 使用同一个 `DBX_DATA_DIR` 模拟 Docker 持久化数据目录。
- 分别用两个不同的 `HOME` 模拟镜像升级前后的容器可写层。
- 修复后两次启动均能从 `DBX_DATA_DIR/agents` 读取到已安装的 Agent driver，`agent_driver_bytes` 不再归零。

## 关联 Issue

Close #2127
