### PR TITLE
✨feat(data-tab): 增强数据标签页管理功能，支持复用和新建标签页

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -73,6 +73,7 @@ import { rankSavedSqlHistory } from "@/lib/savedSqlHistory";
 import { isSchemaAware, isSingleDatabase, usesTreeSchemaMode } from "@/lib/databaseFeatureSupport";
 import { codeMirrorSqlDialect, connectionUsesDatabaseObjectTreeMode, effectiveDatabaseTypeForConnection } from "@/lib/jdbcDialect";
 import { detectDatabaseFileType } from "@/lib/databaseFileDetection";
+import { isMacOS } from "@/lib/platform";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -1381,7 +1382,7 @@ onMounted(async () => {
   document.addEventListener(
     "click",
     (e) => {
-      if (e.ctrlKey) e.stopPropagation();
+      if (isMacOS() && e.ctrlKey) e.stopPropagation();
     },
     true,
   );

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -76,6 +76,7 @@ import { clearActiveTableReferencePayload, createTableReferencePayload, createTa
 import { editableRowIdentifierColumns, usesSyntheticRowIdKey } from "@/lib/tableEditing";
 import { supportsDatabaseCreation, supportsDatabaseSearch, supportsFieldLineage, supportsObjectBrowserTreeNode, supportsSchemaDiagram, supportsSqlFileExecution, supportsTableImport, supportsTableTruncate, supportsTableStructureEditing, usesTreeSchemaMode } from "@/lib/databaseCapabilities";
 import { copyNameForTreeNode, objectSourceKindForTreeNode, sidebarSelectionCopyAction, treeNodeRowAction, treeNodeRowDoubleClickAction } from "@/lib/treeNodeClick";
+import { dataTabOpenModeFromTreeClick, findReusableDataTab, findSameDataTableTab, shouldReuseDataTab, type DataTabOpenMode } from "@/lib/dataTabOpenPolicy";
 import { formatSqlInsert } from "@/lib/exportFormats";
 import { fetchTableDataForExport } from "@/lib/tableDataExport";
 import { buildCreateDatabaseSql, buildDuckDbAttachDatabaseSql, duckDbAttachedDatabaseNameFromPath, supportsCreateDatabaseCharset, uniqueDuckDbAttachedDatabaseName } from "@/lib/createDatabaseSql";
@@ -573,7 +574,7 @@ async function toggle() {
   }
 }
 
-function runRowClickAction() {
+function runRowClickAction(openMode: DataTabOpenMode = "reuse") {
   const node = props.node;
   if (node.type === "load-more") {
     void loadMoreObjectGroupChildren();
@@ -585,7 +586,7 @@ function runRowClickAction() {
   }
   const action = treeNodeRowAction(node.type, canExpand.value, settingsStore.editorSettings.sidebarActivation);
   if (action === "open-data") {
-    openData();
+    openData(openMode);
   } else if (node.type === "mongo-collection") {
     openMongoCollectionData(node);
   } else if (node.type === "procedure" || node.type === "function" || node.type === "sequence" || node.type === "package" || node.type === "package-body") {
@@ -673,6 +674,14 @@ function onClick(event: MouseEvent) {
   // Row clicks must not bubble to the tree container, whose click handler
   // clears the selection when the blank area is clicked (issue #681).
   event.stopPropagation();
+  const shortcutOpenMode = dataTabOpenModeFromTreeClick(props.node.type, event);
+  if (shortcutOpenMode === "new-tab") {
+    event.preventDefault();
+    selectSingleTreeNode(props.node);
+    rowRef.value?.focus({ preventScroll: true });
+    runRowClickAction(shortcutOpenMode);
+    return;
+  }
   if (event.shiftKey) {
     selectTreeNodeRange(props.node);
     rowRef.value?.focus({ preventScroll: true });
@@ -895,7 +904,7 @@ async function openUserAdmin() {
   }
 }
 
-async function openData() {
+async function openData(openMode: DataTabOpenMode = "reuse") {
   const node = props.node;
   if (!(node.type === "table" || node.type === "view" || node.type === "materialized_view") || !hasNodeDatabaseContext(node)) return;
   const config = connectionStore.getConfig(node.connectionId);
@@ -925,9 +934,15 @@ async function openData() {
   });
   const tableSchema = connectionObjectTreeNodeSchema(config, node.database, node.schema);
   const tableType = node.type === "view" ? "VIEW" : node.type === "materialized_view" ? "MATERIALIZED_VIEW" : (node.tableType ?? "TABLE");
-  const isSameDataTableTab = (tab: (typeof queryStore.tabs)[number]) => tab.mode === "data" && tab.connectionId === node.connectionId && tab.database === node.database && (tab.schema || "") === (tableSchema || "") && (tab.tableMeta?.tableName || tab.title) === node.label;
+  const dataTabTarget = {
+    connectionId: node.connectionId,
+    database: node.database,
+    schema: tableSchema,
+    tableName: node.label,
+    title: node.label,
+  };
   const activateExistingSameTableTab = () => {
-    const existing = queryStore.tabs.find(isSameDataTableTab);
+    const existing = findSameDataTableTab(queryStore.tabs, dataTabTarget);
     if (!existing) return false;
     queryStore.activeTabId = existing.id;
     return true;
@@ -960,8 +975,8 @@ async function openData() {
   }
 
   const tabId = (() => {
-    if (settingsStore.editorSettings.reuseDataTab) {
-      const existing = queryStore.tabs.find((tab) => tab.mode === "data" && tab.connectionId === node.connectionId && tab.database === node.database);
+    if (shouldReuseDataTab(openMode, settingsStore.editorSettings.reuseDataTab)) {
+      const existing = findReusableDataTab(queryStore.tabs, dataTabTarget, queryStore.activeTabId);
       if (existing) {
         queryStore.activeTabId = existing.id;
         resetReusedDataTabState(existing);

--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -2,6 +2,7 @@ import * as api from "@/lib/api";
 import { connectionObjectTreeQuerySchema, effectiveDatabaseTypeForConnection } from "@/lib/jdbcDialect";
 import { buildTableSelectSql } from "@/lib/tableSelectSql";
 import { editableRowIdentifierColumns, usesSyntheticRowIdKey } from "@/lib/tableEditing";
+import { findReusableDataTab, shouldReuseDataTab, type DataTabOpenMode } from "@/lib/dataTabOpenPolicy";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -16,11 +17,14 @@ export type NavigationTarget = {
   whereInput?: string;
 };
 
-async function openTableTarget(target: NavigationTarget, options: { tableInfoTab?: TableInfoTab } = {}) {
+type OpenTableTargetOptions = { tableInfoTab?: TableInfoTab; openMode?: DataTabOpenMode };
+
+async function openTableTarget(target: NavigationTarget, options: OpenTableTargetOptions = {}) {
   const connectionStore = useConnectionStore();
   const queryStore = useQueryStore();
   const settingsStore = useSettingsStore();
   const pageLimit = settingsStore.editorSettings.pageSize;
+  const openMode = options.openMode ?? "reuse";
 
   connectionStore.activeConnectionId = target.connectionId;
   const config = connectionStore.getConfig(target.connectionId);
@@ -32,8 +36,8 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
     return;
   }
   const tabId = (() => {
-    if (settingsStore.editorSettings.reuseDataTab) {
-      const existing = queryStore.tabs.find((tab) => tab.mode === "data" && tab.connectionId === target.connectionId && tab.database === target.database);
+    if (shouldReuseDataTab(openMode, settingsStore.editorSettings.reuseDataTab)) {
+      const existing = findReusableDataTab(queryStore.tabs, target, queryStore.activeTabId);
       if (existing) {
         existing.title = tabTitle;
         existing.schema = target.schema;

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2587,7 +2587,7 @@ export default {
     disconnectTabHandlingModeKeepTabsKeepResults: "Do not close related tabs",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "Keep related tabs, SQL text, and current results without extra cleanup.",
     reuseDataTab: "Reuse data tab",
-    reuseDataTabDescription: "When clicking a table in the sidebar, reuse the existing data tab instead of creating a new one each time.",
+    reuseDataTabDescription: "Clicking a table in the sidebar reuses the current data tab. Use Cmd/Ctrl+click to open a new tab.",
     sidebarHiddenTablePrefixes: "Hidden table name prefixes",
     sidebarHiddenTablePrefixesDescription: "One prefix per line. Only sidebar table, view, and collection labels are shortened; tooltips and actions still use the full name.",
     sidebarHiddenTablePrefixesPlaceholder: "Example:\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2581,7 +2581,7 @@ export default withEnglishFallback({
     disconnectTabHandlingModeKeepTabsKeepResults: "No cerrar pestañas relacionadas",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "Conserva las pestañas relacionadas, el texto SQL y los resultados actuales sin limpieza adicional.",
     reuseDataTab: "Reutilizar pestaña de datos",
-    reuseDataTabDescription: "Al hacer clic en una tabla en la barra lateral, reutiliza la pestaña de datos existente en lugar de crear una nueva cada vez.",
+    reuseDataTabDescription: "Al hacer clic en una tabla en la barra lateral se reutiliza la pestaña de datos actual. Usa Cmd/Ctrl+clic para abrir una nueva pestaña.",
     sidebarHiddenTablePrefixes: "Prefijos ocultos de tablas",
     sidebarHiddenTablePrefixesDescription: "Un prefijo por linea. Solo acorta etiquetas de tablas, vistas y colecciones en la barra lateral; las acciones y ayudas usan el nombre completo.",
     sidebarHiddenTablePrefixesPlaceholder: "Ejemplo:\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2584,7 +2584,7 @@ export default withEnglishFallback({
     disconnectTabHandlingModeKeepTabsKeepResults: "Non chiudere le schede correlate",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "Mantieni le schede correlate, il testo SQL e i risultati correnti senza ulteriore pulizia.",
     reuseDataTab: "Riusa scheda dati",
-    reuseDataTabDescription: "Quando fai clic su una tabella nella barra laterale, riutilizza la scheda dati esistente invece di crearne una nuova ogni volta.",
+    reuseDataTabDescription: "Facendo clic su una tabella nella barra laterale si riutilizza la scheda dati corrente. Usa Cmd/Ctrl+clic per aprire una nuova scheda.",
     sidebarHiddenTablePrefixes: "Prefissi dei nomi delle tabelle nascosti",
     sidebarHiddenTablePrefixesDescription: "Un prefisso per riga. Solo le etichette di tabelle, viste e collezioni della barra laterale vengono abbreviate; i suggerimenti e le azioni utilizzano ancora il nome completo.",
     sidebarHiddenTablePrefixesPlaceholder: "Esempio:\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2574,7 +2574,7 @@ export default withEnglishFallback({
     disconnectTabHandlingModeKeepTabsKeepResults: "関連タブを閉じない",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "関連タブ、SQLテキスト、現在の結果を追加のクリーンアップなしで保持します。",
     reuseDataTab: "データタブを再利用",
-    reuseDataTabDescription: "サイドバーでテーブルをクリックした際、毎回新しいタブを作成せずに既存のデータタブを再利用します。",
+    reuseDataTabDescription: "サイドバーでテーブルをクリックすると現在のデータタブを再利用します。Cmd/Ctrl+クリックで新しいタブを開きます。",
     sidebarHiddenTablePrefixes: "非表示テーブル名プレフィックス",
     sidebarHiddenTablePrefixesDescription: "1行に1つのプレフィックス。サイドバーのテーブル、ビュー、コレクションラベルのみ短縮されます。ツールチップと操作は完全な名前を使用します。",
     sidebarHiddenTablePrefixesPlaceholder: "Example:\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2593,7 +2593,7 @@ export default withEnglishFallback({
     disconnectTabHandlingModeKeepTabsKeepResults: "Não fechar abas relacionadas",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "Manter abas relacionadas, texto SQL e resultados atuais sem limpeza adicional.",
     reuseDataTab: "Reutilizar aba de dados",
-    reuseDataTabDescription: "Ao clicar em uma tabela na barra lateral, reutilizar a aba de dados existente em vez de criar uma nova a cada vez.",
+    reuseDataTabDescription: "Ao clicar em uma tabela na barra lateral, a aba de dados atual é reutilizada. Use Cmd/Ctrl+clique para abrir uma nova aba.",
     sidebarHiddenTablePrefixes: "Prefixos de nome de tabela ocultos",
     sidebarHiddenTablePrefixesDescription: "Um prefixo por linha. Apenas os rótulos de tabela, view e coleção da barra lateral são encurtados; tooltips e ações ainda usam o nome completo.",
     sidebarHiddenTablePrefixesPlaceholder: "Exemplo:\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2594,7 +2594,7 @@ export default withEnglishFallback({
     disconnectTabHandlingModeKeepTabsKeepResults: "不关闭相关页签",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "保留相关页签、SQL 文本和当前结果，不做额外处理。",
     reuseDataTab: "复用数据标签页",
-    reuseDataTabDescription: "单击侧边栏表名时，复用已有的数据标签页而不是创建新标签页，避免打开过多标签。",
+    reuseDataTabDescription: "单击侧边栏表名时复用当前数据标签页，按住 Cmd/Ctrl 单击可新建标签页。",
     sidebarHiddenTablePrefixes: "隐藏表名前缀",
     sidebarHiddenTablePrefixesDescription: "每行一个前缀，仅影响侧边栏表、视图和集合的显示名称，悬浮提示和实际操作仍使用完整名称。",
     sidebarHiddenTablePrefixesPlaceholder: "例如：\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2481,7 +2481,7 @@ export default withEnglishFallback({
     disconnectTabHandlingModeKeepTabsKeepResults: "不關閉相關分頁",
     disconnectTabHandlingModeKeepTabsKeepResultsDescription: "保留相關分頁、SQL 文字與目前結果，不另外做清理。",
     reuseDataTab: "重複使用資料分頁",
-    reuseDataTabDescription: "點擊側邊欄資料表名稱時，重複使用現有的資料分頁而不是建立新分頁，避免開啟過多分頁。",
+    reuseDataTabDescription: "點擊側邊欄資料表名稱時重複使用目前資料分頁，按住 Cmd/Ctrl 點擊可建立新分頁。",
     sidebarHiddenTablePrefixes: "隱藏資料表名稱字首",
     sidebarHiddenTablePrefixesDescription: "每行一個字首。只縮短側邊欄中的資料表、檢視和集合標籤；工具提示和實際操作仍使用完整名稱。",
     sidebarHiddenTablePrefixesPlaceholder: "範例：\nODS_\nT8Y2_LONG_",

--- a/apps/desktop/src/lib/__tests__/dataTabOpenPolicy.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataTabOpenPolicy.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { dataTabOpenModeFromTreeClick, findReusableDataTab, findSameDataTableTab, shouldReuseDataTab } from "@/lib/dataTabOpenPolicy";
+import type { QueryTab } from "@/types/database";
+
+function mouseEvent(modifiers: Partial<Pick<MouseEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">> = {}): Pick<MouseEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey"> {
+  return {
+    metaKey: modifiers.metaKey ?? false,
+    ctrlKey: modifiers.ctrlKey ?? false,
+    altKey: modifiers.altKey ?? false,
+    shiftKey: modifiers.shiftKey ?? false,
+  };
+}
+
+function dataTab(id: string, title: string, connectionId = "conn", database = "app", schema?: string): QueryTab {
+  return {
+    id,
+    title,
+    connectionId,
+    database,
+    schema,
+    sql: "",
+    isExecuting: false,
+    mode: "data",
+  };
+}
+
+describe("dataTabOpenPolicy", () => {
+  it("maps Cmd/Ctrl table clicks to new data tabs", () => {
+    expect(dataTabOpenModeFromTreeClick("table", mouseEvent({ metaKey: true }))).toBe("new-tab");
+    expect(dataTabOpenModeFromTreeClick("view", mouseEvent({ ctrlKey: true }))).toBe("new-tab");
+    expect(dataTabOpenModeFromTreeClick("materialized_view", mouseEvent({ metaKey: true }))).toBe("new-tab");
+  });
+
+  it("leaves non-data nodes and selection modifiers available for tree selection", () => {
+    expect(dataTabOpenModeFromTreeClick("database", mouseEvent({ metaKey: true }))).toBeNull();
+    expect(dataTabOpenModeFromTreeClick("table", mouseEvent({ shiftKey: true }))).toBeNull();
+    expect(dataTabOpenModeFromTreeClick("table", mouseEvent({ metaKey: true, shiftKey: true }))).toBeNull();
+  });
+
+  it("disables data tab reuse only for explicit new-tab mode", () => {
+    expect(shouldReuseDataTab("reuse", true)).toBe(true);
+    expect(shouldReuseDataTab("reuse", false)).toBe(false);
+    expect(shouldReuseDataTab("new-tab", true)).toBe(false);
+  });
+
+  it("prefers the active matching data tab when reusing a table tab", () => {
+    const tabs = [dataTab("first", "orders"), dataTab("active", "users")];
+
+    expect(findReusableDataTab(tabs, { connectionId: "conn", database: "app" }, "active")?.id).toBe("active");
+  });
+
+  it("finds existing same-table tabs by metadata or title", () => {
+    const tabWithMetadata = dataTab("meta", "public.users", "conn", "app", "public");
+    tabWithMetadata.tableMeta = { schema: "public", tableName: "users", columns: [], primaryKeys: [] };
+    const tabWithTitle = dataTab("title", "public.orders", "conn", "app", "public");
+
+    expect(findSameDataTableTab([tabWithMetadata], { connectionId: "conn", database: "app", schema: "public", tableName: "users", title: "public.users" })?.id).toBe("meta");
+    expect(findSameDataTableTab([tabWithTitle], { connectionId: "conn", database: "app", schema: "public", tableName: "orders", title: "public.orders" })?.id).toBe("title");
+  });
+});

--- a/apps/desktop/src/lib/dataTabOpenPolicy.ts
+++ b/apps/desktop/src/lib/dataTabOpenPolicy.ts
@@ -1,0 +1,58 @@
+import type { QueryTab, TreeNodeType } from "@/types/database";
+
+export type DataTabOpenMode = "reuse" | "new-tab";
+
+export type DataTabTarget = {
+  connectionId: string;
+  database: string;
+  schema?: string;
+  tableName: string;
+  title?: string;
+};
+
+type DataTabLike = Pick<QueryTab, "id" | "mode" | "connectionId" | "database" | "schema" | "title" | "tableMeta">;
+
+type ShortcutLikeMouseEvent = Pick<MouseEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">;
+
+const dataTreeNodeTypes = new Set<TreeNodeType>(["table", "view", "materialized_view"]);
+
+export function isDataTreeNodeType(type: TreeNodeType): boolean {
+  return dataTreeNodeTypes.has(type);
+}
+
+export function dataTabOpenModeFromTreeClick(type: TreeNodeType, event: ShortcutLikeMouseEvent): DataTabOpenMode | null {
+  if (!isDataTreeNodeType(type)) return null;
+  if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey) return "new-tab";
+  return null;
+}
+
+export function shouldReuseDataTab(openMode: DataTabOpenMode, reuseDataTab: boolean): boolean {
+  return openMode !== "new-tab" && reuseDataTab;
+}
+
+function sameDatabase(tab: DataTabLike, target: Pick<DataTabTarget, "connectionId" | "database">): boolean {
+  return tab.mode === "data" && tab.connectionId === target.connectionId && tab.database === target.database;
+}
+
+function sameSchema(tab: DataTabLike, target: Pick<DataTabTarget, "schema">): boolean {
+  return (tab.schema || "") === (target.schema || "");
+}
+
+function sameTableName(tab: DataTabLike, target: Pick<DataTabTarget, "tableName" | "title">): boolean {
+  const metaTableName = tab.tableMeta?.tableName;
+  if (metaTableName) return metaTableName === target.tableName;
+  return tab.title === target.tableName || (!!target.title && tab.title === target.title);
+}
+
+export function isSameDataTableTab(tab: DataTabLike, target: DataTabTarget): boolean {
+  return sameDatabase(tab, target) && sameSchema(tab, target) && sameTableName(tab, target);
+}
+
+export function findSameDataTableTab<T extends DataTabLike>(tabs: T[], target: DataTabTarget): T | undefined {
+  return tabs.find((tab) => isSameDataTableTab(tab, target));
+}
+
+export function findReusableDataTab<T extends DataTabLike>(tabs: T[], target: Pick<DataTabTarget, "connectionId" | "database">, activeTabId?: string | null): T | undefined {
+  const activeTab = activeTabId ? tabs.find((tab) => tab.id === activeTabId && sameDatabase(tab, target)) : undefined;
+  return activeTab ?? tabs.find((tab) => sameDatabase(tab, target));
+}

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -10,6 +10,11 @@ describe("normalizeEditorSettings", () => {
     expect(normalizeEditorSettings({ autoAliasTables: false }).autoAliasTables).toBe(false);
   });
 
+  it("reuses data tabs by default and preserves explicit opt-out", () => {
+    expect(normalizeEditorSettings({}).reuseDataTab).toBe(true);
+    expect(normalizeEditorSettings({ reuseDataTab: false }).reuseDataTab).toBe(false);
+  });
+
   it("defaults update downloads to the official source", () => {
     expect(normalizeEditorSettings({}).updateDownloadSource).toBe("official");
   });

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -452,7 +452,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   sidebarObjectDisplay: "grouped",
   autoSelectActiveSidebarNode: false,
   disconnectTabHandlingMode: "close-tabs",
-  reuseDataTab: false,
+  reuseDataTab: true,
   updateNotificationsEnabled: true,
   sidebarHiddenTablePrefixes: [],
   sidebarHideTableComments: false,


### PR DESCRIPTION
- 添加数据标签页打开策略，支持通过 Cmd/Ctrl 点击新建标签页
- 更新默认设置为复用数据标签页
- 修改相关文档描述，明确复用行为

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1938" height="908" alt="626BFC6D-607B-4BFD-8E31-465E4738D955" src="https://github.com/user-attachments/assets/392123f8-8cbe-425c-beaf-2986f61a1ebe" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2141 