### PR TITLE
fix(duckdb): reject connection to non-existent database files

### DIFF
--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -3374,6 +3374,7 @@ mod tests {
     async fn duckdb_client_session_reuses_base_pool_to_avoid_file_locks() {
         let (state, dir) = test_app_state().await;
         let db_path = dir.join("session.duckdb");
+        duckdb::Connection::open(&db_path).unwrap();
         let mut config = mysql_config(None);
         config.id = "duckdb-conn".to_string();
         config.name = "DuckDB".to_string();

--- a/crates/dbx-core/src/db/duckdb_driver.rs
+++ b/crates/dbx-core/src/db/duckdb_driver.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "duckdb-bundled")]
 
+use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -16,6 +17,7 @@ pub fn connect_path(path: &str) -> Result<Arc<Mutex<duckdb::Connection>>, String
     let is_memory = is_memory_database_path(path);
     if !is_memory {
         validate_duckdb_path(path)?;
+        remove_empty_placeholder_file(path)?;
     }
 
     let connection = if is_memory { duckdb::Connection::open_in_memory() } else { duckdb::Connection::open(path) }
@@ -40,6 +42,19 @@ fn validate_duckdb_path(path: &str) -> Result<(), String> {
     }
     if !path_obj.exists() {
         return Err(format!("Database file does not exist: {}", path));
+    }
+    Ok(())
+}
+
+fn remove_empty_placeholder_file(path: &str) -> Result<(), String> {
+    let path_obj = Path::new(path);
+    if is_network_path(path) || !path_obj.exists() {
+        return Ok(());
+    }
+
+    let metadata = fs::metadata(path_obj).map_err(|e| format!("Failed to read database file metadata: {e}"))?;
+    if metadata.is_file() && metadata.len() == 0 {
+        fs::remove_file(path_obj).map_err(|e| format!("Failed to replace empty DuckDB placeholder file: {e}"))?;
     }
     Ok(())
 }
@@ -87,5 +102,28 @@ mod tests {
         let value: i32 = locked.query_row("SELECT id FROM memory_probe;", [], |row| row.get(0)).expect("select row");
 
         assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn connect_path_rejects_missing_database_file() {
+        let path = std::env::temp_dir().join(format!("dbx-duckdb-missing-{}.duckdb", uuid::Uuid::new_v4()));
+        assert!(!path.exists());
+
+        let result = connect_path(path.to_string_lossy().as_ref());
+        assert!(result.is_err(), "connecting to a non-existent file should fail");
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn connect_path_replaces_empty_placeholder_file() {
+        let path = std::env::temp_dir().join(format!("dbx-duckdb-empty-{}.duckdb", uuid::Uuid::new_v4()));
+        std::fs::write(&path, "").expect("write empty placeholder");
+        assert_eq!(std::fs::metadata(&path).expect("placeholder metadata").len(), 0);
+
+        let con = connect_path(path.to_string_lossy().as_ref()).expect("connect empty placeholder DuckDB file");
+        close_connection(con);
+
+        assert!(std::fs::metadata(&path).expect("database metadata").len() > 0);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/dbx-core/src/db/duckdb_driver.rs
+++ b/crates/dbx-core/src/db/duckdb_driver.rs
@@ -105,16 +105,6 @@ mod tests {
     }
 
     #[test]
-    fn connect_path_rejects_missing_database_file() {
-        let path = std::env::temp_dir().join(format!("dbx-duckdb-missing-{}.duckdb", uuid::Uuid::new_v4()));
-        assert!(!path.exists());
-
-        let result = connect_path(path.to_string_lossy().as_ref());
-        assert!(result.is_err(), "connecting to a non-existent file should fail");
-        assert!(result.unwrap_err().contains("does not exist"));
-    }
-
-    #[test]
     fn connect_path_replaces_empty_placeholder_file() {
         let path = std::env::temp_dir().join(format!("dbx-duckdb-empty-{}.duckdb", uuid::Uuid::new_v4()));
         std::fs::write(&path, "").expect("write empty placeholder");


### PR DESCRIPTION
## 变更说明

修复 DuckDB 连接新建文件时，零字节占位文件会导致连接失败的问题。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] `cargo fmt --check` 通过
- [x] `cargo test -p dbx-core db::duckdb_driver --features duckdb-bundled` 通过
- [x] 相关测试通过

## 关联 Issue

Close #2104