### PR TITLE
修复导出表结构缺少语句分号

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -60,6 +60,7 @@ import { isTauriRuntime } from "@/lib/tauriRuntime";
 import { generateDatabaseExportId } from "@/lib/databaseExport";
 import { copyToClipboard } from "@/lib/clipboard";
 import { formatSqlInsert } from "@/lib/exportFormats";
+import { buildSingleDdlExportFileContent } from "@/lib/ddlExport";
 import { fetchTableDataForExport } from "@/lib/tableDataExport";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useExportTracker, type ExportTask } from "@/composables/useExportTracker";
@@ -799,7 +800,7 @@ async function exportStructure(row: ObjectBrowserRow) {
   try {
     const schema = row.schema || selectedSchema.value || props.database;
     const ddl = await api.getTableDdl(props.connection.id, props.database, schema, row.name, tableDdlObjectType(row.type));
-    await saveFileContent(ddl + "\n", `${row.name}.sql`, "SQL", "sql");
+    await saveFileContent(buildSingleDdlExportFileContent(ddl), `${row.name}.sql`, "SQL", "sql");
   } catch (e: any) {
     console.error("Export structure failed:", e);
   }

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -77,6 +77,7 @@ import { editableRowIdentifierColumns, usesSyntheticRowIdKey } from "@/lib/table
 import { supportsDatabaseCreation, supportsDatabaseSearch, supportsFieldLineage, supportsObjectBrowserTreeNode, supportsSchemaDiagram, supportsSqlFileExecution, supportsTableImport, supportsTableTruncate, supportsTableStructureEditing, usesTreeSchemaMode } from "@/lib/databaseCapabilities";
 import { copyNameForTreeNode, objectSourceKindForTreeNode, sidebarSelectionCopyAction, treeNodeRowAction, treeNodeRowDoubleClickAction } from "@/lib/treeNodeClick";
 import { formatSqlInsert } from "@/lib/exportFormats";
+import { joinExportedDdls } from "@/lib/ddlExport";
 import { fetchTableDataForExport } from "@/lib/tableDataExport";
 import { buildCreateDatabaseSql, buildDuckDbAttachDatabaseSql, duckDbAttachedDatabaseNameFromPath, supportsCreateDatabaseCharset, uniqueDuckDbAttachedDatabaseName } from "@/lib/createDatabaseSql";
 import {
@@ -2592,7 +2593,7 @@ async function exportStructure() {
       const ddl = await api.getTableDdl(target.connectionId, target.database, target.schema || target.database, target.label, tableDdlObjectTypeForNode(target.type));
       parts.push(ddl.trim());
     }
-    structurePreviewSql.value = `${parts.filter(Boolean).join("\n\n")}\n`;
+    structurePreviewSql.value = joinExportedDdls(parts);
   } catch (e: any) {
     structurePreviewError.value = e?.message || String(e);
     console.error("Export structure failed:", e);

--- a/apps/desktop/src/lib/ddlExport.ts
+++ b/apps/desktop/src/lib/ddlExport.ts
@@ -1,0 +1,15 @@
+export function ensureSqlStatementTerminator(sql: string): string {
+  const trimmed = sql.trim();
+  if (!trimmed) return "";
+  return trimmed.endsWith(";") ? trimmed : `${trimmed};`;
+}
+
+export function buildSingleDdlExportFileContent(sql: string): string {
+  const statement = ensureSqlStatementTerminator(sql);
+  return statement ? `${statement}\n` : "";
+}
+
+export function joinExportedDdls(ddls: readonly string[]): string {
+  const statements = ddls.map(ensureSqlStatementTerminator).filter(Boolean);
+  return statements.length ? `${statements.join("\n\n")}\n` : "";
+}

--- a/packages/app-tests/ddlExport.test.ts
+++ b/packages/app-tests/ddlExport.test.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { buildSingleDdlExportFileContent, ensureSqlStatementTerminator, joinExportedDdls } from "../../apps/desktop/src/lib/ddlExport.ts";
+
+test("ensureSqlStatementTerminator appends a trailing semicolon when missing", () => {
+  assert.equal(ensureSqlStatementTerminator("CREATE TABLE `users` (\n  `id` int\n) ENGINE=InnoDB"), "CREATE TABLE `users` (\n  `id` int\n) ENGINE=InnoDB;");
+});
+
+test("ensureSqlStatementTerminator does not duplicate an existing trailing semicolon", () => {
+  assert.equal(ensureSqlStatementTerminator("CREATE VIEW v AS SELECT 1;"), "CREATE VIEW v AS SELECT 1;");
+});
+
+test("joinExportedDdls separates exported objects with blank lines and terminates each statement", () => {
+  assert.equal(
+    joinExportedDdls([
+      "CREATE TABLE `users` (`id` int)",
+      "CREATE TABLE `posts` (`id` int);",
+    ]),
+    "CREATE TABLE `users` (`id` int);\n\nCREATE TABLE `posts` (`id` int);\n",
+  );
+});
+
+test("buildSingleDdlExportFileContent emits a single importable statement with one trailing newline", () => {
+  assert.equal(
+    buildSingleDdlExportFileContent("  CREATE TABLE `users` (`id` int)  "),
+    "CREATE TABLE `users` (`id` int);\n",
+  );
+});


### PR DESCRIPTION
## 变更说明

- 新增共享 DDL 导出 helper，统一为导出的表结构语句补齐结尾分号
- 修复侧边栏多对象“导出表结构”路径，确保拼接后的多段 DDL 可直接导入执行
- 修复对象浏览器单对象“导出结构”路径，确保保存到文件的 SQL 是完整可导入语句
- 增加回归测试，覆盖缺少分号、已有分号、多段拼接，以及单对象文件导出内容

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

说明：本次修改影响前端导出逻辑与导出文件内容，但不引入新的可视化 UI 变化，因此未附截图/录屏。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：
- `make check`
- `make cargo-check-fast`
- `pnpm test -- packages/app-tests/ddlExport.test.ts`
- `pnpm typecheck`

手动验证思路：
- 导出单个表结构时，生成的 `.sql` 文件末尾带分号
- 导出多个表结构时，每条 DDL 都带分号，且可继续拼接后续 `INSERT` 执行

## 关联 Issue

Close #2115
