### PR TITLE
Fix：修复 Kingbase 新增字段 SQL 语法

### DIFF
--- a/crates/dbx-core/src/table_structure_sql/columns.rs
+++ b/crates/dbx-core/src/table_structure_sql/columns.rs
@@ -65,6 +65,7 @@ pub(super) fn build_column_sql(options: &TableStructureSqlOptions, warnings: &mu
             }
             statements.extend(build_add_column_sql(
                 dialect,
+                options.database_type,
                 &table,
                 column,
                 &position_clause,
@@ -200,6 +201,7 @@ pub(super) fn build_primary_key_sql(
 
 pub(super) fn build_add_column_sql(
     dialect: StructureDialect,
+    database_type: Option<crate::models::connection::DatabaseType>,
     table: &str,
     column: &EditableStructureColumn,
     position_clause: &str,
@@ -210,7 +212,13 @@ pub(super) fn build_add_column_sql(
     let mut statements = if dialect == StructureDialect::Oracle || dialect == StructureDialect::Informix {
         vec![format!("ALTER TABLE {table} ADD ({definition});")]
     } else {
-        let add_keyword = if dialect == StructureDialect::SqlServer { "ADD" } else { "ADD COLUMN" };
+        let add_keyword = if dialect == StructureDialect::SqlServer
+            || database_type == Some(crate::models::connection::DatabaseType::Kingbase)
+        {
+            "ADD"
+        } else {
+            "ADD COLUMN"
+        };
         vec![format!("ALTER TABLE {table} {add_keyword} {definition}{position_clause};")]
     };
     if matches!(dialect, StructureDialect::Postgres | StructureDialect::Oracle) && !clean(&column.comment).is_empty() {

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -803,6 +803,27 @@ fn builds_rqlite_changes_with_sqlite_dialect() {
 }
 
 #[test]
+fn builds_kingbase_add_column_without_column_keyword() {
+    let mut flag = column("flag");
+    flag.data_type = "varchar(100)".to_string();
+
+    let result = build_table_structure_change_sql(TableStructureSqlOptions {
+        database_type: Some(DatabaseType::Kingbase),
+        schema: Some("dbo".to_string()),
+        table_name: "dw_bill_info_copy".to_string(),
+        columns: vec![flag],
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        triggers: Vec::new(),
+        table_comment: None,
+        original_table_comment: None,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.statements, vec!["ALTER TABLE \"dbo\".\"dw_bill_info_copy\" ADD \"flag\" varchar(100);"]);
+}
+
+#[test]
 fn builds_mysql_column_reorder_statements() {
     let mut id = column("id");
     id.data_type = "int".to_string();


### PR DESCRIPTION
## 变更内容
- Kingbase 表结构编辑新增字段时，生成 `ALTER TABLE ... ADD ...`，避免在 SQL Server 兼容模式下使用不支持的 `ADD COLUMN`
- 保持其它 PostgreSQL-like 数据库原有 `ADD COLUMN` 生成逻辑不变
- 补充 Kingbase 新增字段 SQL 生成回归测试

## 验证
- `cargo test -p dbx-core builds_kingbase_add_column_without_column_keyword`
- `cargo test -p dbx-core table_structure_sql`
- `cargo test -p dbx-core`
- `cargo fmt --check`
- `git diff --check`
- `pnpm vitest run packages/app-tests/tableStructureEditorState.test.ts apps/desktop/src/lib/__tests__/tableStructureEditorState.spec.ts`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `cargo clippy -p dbx-core --all-targets`

补充：`cargo clippy -p dbx-core --all-targets -- -D warnings` 会被当前 main 上既有 clippy warning 拦住，本次改动文件无新增 clippy error；Kingbase agent Java 测试未执行成功，原因是 Gradle wrapper 下载 `gradle-9.5.0-bin.zip` 超时。

Fixes #2164