### PR TITLE
fix(postgres): 修复 GaussDB Schema 浏览对象报错 #1641

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -1652,17 +1652,30 @@ async fn postgres_proc_has_prokind(client: &deadpool_postgres::Client) -> Result
     Ok(row.get(0))
 }
 
+async fn list_objects_rows(
+    client: &deadpool_postgres::Client,
+    schema: &str,
+    include_timestamps: bool,
+    has_proc_prokind: bool,
+) -> Result<Vec<Row>, String> {
+    let sql = list_objects_sql(include_timestamps, has_proc_prokind);
+    let stmt = client.prepare_cached(&sql).await.map_err(|e| e.to_string())?;
+    client.query(&stmt, &[&schema]).await.map_err(|e| e.to_string())
+}
+
 pub async fn list_objects(pool: &Pool, schema: &str) -> Result<Vec<ObjectInfo>, String> {
     let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
     let has_proc_prokind = postgres_proc_has_prokind(&client).await?;
-    let sql = list_objects_sql(true, has_proc_prokind);
-    let stmt = client.prepare_cached(&sql).await.map_err(|e| e.to_string())?;
-    let rows = match client.query(&stmt, &[&schema]).await {
+    let rows = match list_objects_rows(&client, schema, true, has_proc_prokind).await {
         Ok(rows) => rows,
-        Err(_) => {
-            let fallback_sql = list_objects_sql(false, has_proc_prokind);
-            let stmt = client.prepare_cached(&fallback_sql).await.map_err(|e| e.to_string())?;
-            client.query(&stmt, &[&schema]).await.map_err(|e| e.to_string())?
+        Err(primary_error) => {
+            log::debug!("[postgres][list_objects:timestamp-fallback] primary_error={}", primary_error);
+            match list_objects_rows(&client, schema, false, has_proc_prokind).await {
+                Ok(rows) => rows,
+                Err(fallback_error) => {
+                    return Err(format!("{primary_error}; timestamp fallback failed: {fallback_error}"));
+                }
+            }
         }
     };
 


### PR DESCRIPTION
## 变更说明

- 修复 GaussDB Schema 点击「浏览对象」时右侧面板显示 `db error` 的问题。
- 原因是 GaussDB 复用 PostgreSQL 对象浏览查询，但带时间戳的元数据 SQL 在 `prepare` 阶段失败，导致原有 fallback 无法触发。
- 让 fallback 覆盖 `prepare_cached` 和 `query` 阶段。
- 查询失败时降级到无时间戳查询，保证表、视图、函数、序列仍可正常展示。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] ~~本 PR 涉及前端改动，已附截图/录屏~~

不涉及前端改动。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已通过：

- `pnpm buid tauri`

## 关联 Issue

Related #1641