### PR TITLE
fix(web): respect base path for icon assets

### DIFF
--- a/apps/desktop/src/components/icons/AiProviderLogo.vue
+++ b/apps/desktop/src/components/icons/AiProviderLogo.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from "vue";
 import { Settings2 } from "@lucide/vue";
 import type { AiProvider } from "@/stores/settingsStore";
 import { useTheme } from "@/composables/useTheme";
+import { webPath } from "@/lib/webPath";
 
 const props = defineProps<{
   provider: AiProvider;
@@ -22,8 +23,8 @@ watch(
 
 const usesWhiteDarkIcon = computed(() => props.provider === "claude" || props.provider === "ollama" || props.provider === "openai" || props.provider === "openai-compatible");
 const localIconUrl = computed(() => {
-  if (props.provider === "openai-compatible") return "/icons/ai/openai.svg";
-  return props.iconSlug ? `/icons/ai/${props.iconSlug}.svg` : "";
+  if (props.provider === "openai-compatible") return webPath("/icons/ai/openai.svg");
+  return props.iconSlug ? webPath(`/icons/ai/${props.iconSlug}.svg`) : "";
 });
 const fallbackText = computed(() => {
   if (props.provider === "openai-compatible") return "OC";

--- a/apps/desktop/src/components/icons/DatabaseIcon.vue
+++ b/apps/desktop/src/components/icons/DatabaseIcon.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { Database } from "@lucide/vue";
+import { webPath } from "@/lib/webPath";
 
 const props = defineProps<{
   dbType: string;
@@ -96,7 +97,7 @@ const normalizedType = computed(() => props.dbType.toLowerCase().replace(/[\s-]+
 const assetName = computed(() => assetIcons[normalizedType.value]);
 const assetSrc = computed(() => {
   if (!assetName.value) return "";
-  return assetName.value.includes(".") ? `/icons/database/${assetName.value}` : `/icons/database/${assetName.value}.svg`;
+  return webPath(assetName.value.includes(".") ? `/icons/database/${assetName.value}` : `/icons/database/${assetName.value}.svg`);
 });
 const letter = computed(() => letterIcons[normalizedType.value]);
 </script>

--- a/apps/desktop/src/lib/__tests__/webPath.spec.ts
+++ b/apps/desktop/src/lib/__tests__/webPath.spec.ts
@@ -11,6 +11,8 @@ describe("webPath", () => {
     expect(dbxWebBasePath("/", "/dbx/")).toBe("/dbx");
     expect(webPath("/login", "/dbx")).toBe("/dbx/login");
     expect(webPath("/", "/dbx")).toBe("/dbx/");
+    expect(webPath("/icons/database/mysql.svg", "/dbx")).toBe("/dbx/icons/database/mysql.svg");
+    expect(webPath("/icons/ai/openai.svg", "/dbx")).toBe("/dbx/icons/ai/openai.svg");
     expect(apiUrl("/auth/check", "/dbx")).toBe("/dbx/api/auth/check");
     expect(apiUrl("/api/auth/check", "/dbx")).toBe("/dbx/api/auth/check");
     expect(apiUrl("api/auth/check", "/dbx")).toBe("/dbx/api/auth/check");


### PR DESCRIPTION
## 变更说明

修复 Web 版部署在 `DBX_PUBLIC_BASE_PATH` 子路径下时，数据库图标和 AI Provider 图标仍请求根路径 `/icons/...` 导致 404 的问题。

本 PR 将本地图标资源路径统一接入已有的 `webPath()`，使图标请求能够正确携带配置的 base path，例如 `/dbx/icons/database/mysql.svg`。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

修复后在 `DBX_PUBLIC_BASE_PATH=/dbx` 下打开“新建连接”对话框，数据库图标请求均为 `/dbx/icons/database/...` 并返回 200。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm vitest run apps/desktop/src/lib/__tests__/webPath.spec.ts`
- `pnpm exec oxlint apps/desktop/src/components/icons/DatabaseIcon.vue apps/desktop/src/components/icons/AiProviderLogo.vue apps/desktop/src/lib/__tests__/webPath.spec.ts`
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/components/icons/DatabaseIcon.vue apps/desktop/src/components/icons/AiProviderLogo.vue apps/desktop/src/lib/__tests__/webPath.spec.ts`
- `pnpm check`

手动验证：

- 启动 Web 版并配置 `DBX_PUBLIC_BASE_PATH=/dbx`。
- 访问 `http://localhost:5173/dbx/`。
- 打开“新建连接”对话框。
- 修复前图标请求为 `/icons/database/...` 且返回 404。
- 修复后图标请求为 `/dbx/icons/database/...` 且返回 200。

## 关联 Issue

Close #2172
