### PR TITLE
fix(ai): preserve tool name when OpenAI-compatible provider re-sends empty id

### DIFF
--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -1692,7 +1692,22 @@ impl StreamingToolCallAccumulator {
         match event {
             StreamToolEvent::Chunk(chunk) => on_chunk(chunk),
             StreamToolEvent::ToolCallStart { index, id, name } => {
-                self.calls.insert(index, PartialToolCall { id, name, arguments: String::new() });
+                // Merge with any existing entry for this index instead of
+                // overwriting it. Some OpenAI-compatible providers (e.g. GLM)
+                // re-send `id` (as an empty string) or omit `name` on
+                // subsequent delta chunks; a blind insert would wipe a
+                // previously-correct name and reset accumulated arguments,
+                // producing "Unknown tool:" errors.
+                if let Some(existing) = self.calls.get_mut(&index) {
+                    if !id.is_empty() {
+                        existing.id = id;
+                    }
+                    if !name.is_empty() {
+                        existing.name = name;
+                    }
+                } else {
+                    self.calls.insert(index, PartialToolCall { id, name, arguments: String::new() });
+                }
                 if !self.ordered_indices.contains(&index) {
                     self.ordered_indices.push(index);
                 }
@@ -2025,8 +2040,11 @@ async fn stream_openai_with_tools(
                         if let Some(tool_calls) = event["choices"].get(0).and_then(|c| c["delta"]["tool_calls"].as_array()) {
                             for tc in tool_calls {
                                 let idx = tc["index"].as_u64().unwrap_or(0) as u32;
-                                // First chunk for this tool call has id and name
-                                if let Some(id) = tc["id"].as_str() {
+                                // The first delta carries the tool call id and
+                                // function name. Some OpenAI-compatible providers
+                                // (e.g. GLM) send id="" on subsequent deltas, so
+                                // only a non-empty id marks a genuine start.
+                                if let Some(id) = tc["id"].as_str().filter(|s| !s.is_empty()) {
                                     let name = tc["function"]["name"].as_str().unwrap_or_default().to_string();
                                     on_event(StreamToolEvent::ToolCallStart { index: idx, id: id.to_string(), name });
                                 }
@@ -2447,6 +2465,38 @@ mod tests {
         AiModelInfo, AiProvider, AiReasoningLevel, StreamToolEvent, StreamingToolCallAccumulator, ToolCallRef,
         AUTHORIZATION, CLAUDE_DEFAULT_SYSTEM, TEST_PROMPT,
     };
+
+    /// Reproduce the "Unknown tool:" bug: some OpenAI-compatible providers
+    /// (e.g. GLM via proxy) re-send the `id` field in every tool-call delta.
+    /// The second delta carries `id` but omits `function.name`, so the OpenAI
+    /// parser emits a second ToolCallStart with an empty name. The
+    /// accumulator's `insert` then overwrites the previously-correct name.
+    #[test]
+    fn accumulator_preserves_name_when_provider_resends_id() {
+        let mut acc = StreamingToolCallAccumulator::new();
+        let noop = |_chunk| {};
+
+        // First chunk: id + name present (standard OpenAI first delta)
+        acc.process(
+            StreamToolEvent::ToolCallStart { index: 0, id: "call_1".to_string(), name: "get_columns".to_string() },
+            &noop,
+        );
+        acc.process(StreamToolEvent::ToolCallDelta { index: 0, fragment: "{\"table\":".to_string() }, &noop);
+
+        // Second chunk: provider re-sends `id` but omits `function.name`.
+        // The OpenAI parser sees `id` is Some and emits ToolCallStart with
+        // name = "" (from unwrap_or_default()).
+        acc.process(StreamToolEvent::ToolCallStart { index: 0, id: "call_1".to_string(), name: String::new() }, &noop);
+        acc.process(StreamToolEvent::ToolCallDelta { index: 0, fragment: "\"record_trip_id_t\"}".to_string() }, &noop);
+
+        let calls = acc.finalize();
+        assert_eq!(calls.len(), 1, "expected exactly one accumulated tool call");
+        assert_eq!(
+            calls[0].name, "get_columns",
+            "tool name was wiped to empty by a re-sent ToolCallStart — this is the \"Unknown tool:\" bug"
+        );
+        assert_eq!(calls[0].arguments["table"], "record_trip_id_t", "arguments were reset by a re-sent ToolCallStart");
+    }
 
     #[test]
     fn stream_line_decoder_preserves_split_multibyte_utf8() {


### PR DESCRIPTION
## 变更说明

修复 AI Agent 在使用 GLM-5.2 等 OpenAI 兼容 provider 时反复报 `Error: Unknown tool:`（工具名为空）并跑满 30 轮上限的问题。

### 根因

GLM-5.2（经 OpenAI 兼容代理流式返回）在 tool_call delta 中，首个 chunk 正确携带 `id="call_xxx"` + `function.name`，但**后续每个 chunk** 发送 `id=""`（空字符串，非字段缺失）。解析器 `tc["id"].as_str()` 对 `""` 返回 `Some("")`，导致每个 chunk 都触发 `ToolCallStart`；累加器的 `insert` 反复覆盖，把第一轮正确的工具名清成 `""`，arguments 也被反复重置。

```
第1个 chunk: id=Some("call_xxx") name=Some("get_columns") → accumulator 存入 name="get_columns" ✅
第2个 chunk: id=Some("")       name=None                 → accumulator 覆盖 name="" ❌
第3个 chunk: id=Some("")       name=None                 → accumulator 覆盖 name="" ❌
finalize: name="" → execute_tool 命中 "Unknown tool:" ❌
```

### 修复（两处，互为防御）

1. **OpenAI 解析器**（`stream_openai_with_tools`）：`tc["id"].as_str()` → `.filter(|s| !s.is_empty())`，空 id 不再触发 `ToolCallStart`。
2. **累加器**（`StreamingToolCallAccumulator::process`）：`ToolCallStart` 对已存在的 index 做**合并**而非 `insert` 覆盖——新 name 非空才覆盖，保留已累积的 arguments。纵深防御其他 provider 变体。

### 回归测试

新增 `accumulator_preserves_name_when_provider_resends_id`：模拟重复 `ToolCallStart` + 空 name，断言 name 和 arguments 保留。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

不涉及前端 UI、样式、交互或文案改动。

## 验证

- [x] 相关测试通过：`cargo test -p dbx-core --lib accumulator_preserves_name`
- [x] 端到端验证：使用真实 GLM-5.2 provider，`Unknown tool` 次数从 12+ 降到 0，agent 从跑满 30 轮变为 3 轮完成，工具名正确解析为 `get_columns` 并到达执行层。

## 影响范围

仅影响 OpenAI 兼容 provider 的流式 tool_call 解析路径（`stream_openai_with_tools` + `StreamingToolCallAccumulator`）。Claude / Gemini 路径不受影响。