### PR TITLE
fix(data-tab): fall back to LIMIT 0 preview for snapshot-less lake tables

### DIFF
--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -1,5 +1,6 @@
 import * as api from "@/lib/api";
 import { effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from "@/lib/jdbcDialect";
+import { isNoSnapshotErrorResult } from "@/lib/queryResultError";
 import { buildTableSelectSql } from "@/lib/tableSelectSql";
 import { editableRowIdentifierColumns, usesSyntheticRowIdKey } from "@/lib/tableEditing";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -92,6 +93,24 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
       primaryKeys: [],
     });
     await queryStore.executeTabSql(tabId, sql);
+    // executeTabSql surfaces query failures as an "Error" result instead of throwing.
+    // A snapshot-less lake table fails the data preview above but its metadata still
+    // reads fine — retry with LIMIT 0 so the user sees the table structure (columns +
+    // empty grid) rather than a cryptic server error. The flag also skips the
+    // synthetic-row-id re-query below, which is another data read that would fail
+    // the same way on a snapshot-less table.
+    const fellBackToLimitZero = isNoSnapshotErrorResult(queryStore.tabs.find((tab) => tab.id === tabId)?.result);
+    if (fellBackToLimitZero) {
+      const emptySql = await buildTableSelectSql({
+        databaseType: effectiveDbType,
+        schema: target.schema,
+        tableName: target.tableName,
+        whereInput: target.whereInput,
+        limit: 0,
+      });
+      queryStore.updateSql(tabId, emptySql);
+      await queryStore.executeTabSql(tabId, emptySql);
+    }
     try {
       const columns = await api.getColumns(target.connectionId, target.database, querySchema, target.tableName);
       const indexes = await api.listIndexes(target.connectionId, target.database, querySchema, target.tableName).catch(() => []);
@@ -104,7 +123,7 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
         columns,
         primaryKeys,
       });
-      if (useRowId || config.db_type === "tdengine") {
+      if (!fellBackToLimitZero && (useRowId || config.db_type === "tdengine")) {
         const newSql = await buildTableSelectSql({
           databaseType: effectiveDbType,
           schema: target.schema,

--- a/apps/desktop/src/lib/__tests__/queryResultError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/queryResultError.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { QueryResult } from "@/types/database";
+
+import { isNoSnapshotErrorResult } from "@/lib/queryResultError";
+
+function errorResult(message: string): QueryResult {
+  return { columns: ["Error"], rows: [[message]], affected_rows: 0, execution_time_ms: 0 };
+}
+
+function dataResult(columns: string[]): QueryResult {
+  return { columns, rows: [], affected_rows: 0, execution_time_ms: 0 };
+}
+
+describe("isNoSnapshotErrorResult", () => {
+  it("matches the StarRocks Paimon no-snapshot error surfaced via executeTabSql", () => {
+    const result = errorResult("Server error: `ERROR HY000 (1064): There is currently no snapshot.`");
+    expect(isNoSnapshotErrorResult(result)).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    const result = errorResult("there IS currently NO snapshot");
+    expect(isNoSnapshotErrorResult(result)).toBe(true);
+  });
+
+  it("does not match unrelated query errors", () => {
+    expect(isNoSnapshotErrorResult(errorResult("Unknown table 'tag_test.record_tag_t'"))).toBe(false);
+    expect(isNoSnapshotErrorResult(errorResult("ERROR 1142: SELECT command denied"))).toBe(false);
+  });
+
+  it("does not match successful data results", () => {
+    expect(isNoSnapshotErrorResult(dataResult(["id", "name"]))).toBe(false);
+    expect(isNoSnapshotErrorResult(dataResult(["Error"]))).toBe(false); // data column literally named Error, no rows
+  });
+
+  it("returns false for missing or empty results", () => {
+    expect(isNoSnapshotErrorResult(undefined)).toBe(false);
+    expect(isNoSnapshotErrorResult(null)).toBe(false);
+    expect(isNoSnapshotErrorResult({ ...errorResult("There is currently no snapshot."), rows: [] })).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/queryResultError.ts
+++ b/apps/desktop/src/lib/queryResultError.ts
@@ -1,0 +1,13 @@
+import type { QueryResult } from "@/types/database";
+
+// Lake/external tables (e.g. Paimon in StarRocks) return this error on a data
+// read when no snapshot exists yet, while metadata reads (DESC/SHOW CREATE)
+// still succeed. executeTabSql surfaces query failures as an "Error" result, so
+// callers can detect this case and fall back to a structure-only (LIMIT 0)
+// preview instead of showing a cryptic server error.
+const NO_SNAPSHOT_ERROR_PATTERN = /there is currently no snapshot/i;
+
+export function isNoSnapshotErrorResult(result: QueryResult | undefined | null): boolean {
+  if (!result || !result.columns.includes("Error") || result.rows.length === 0) return false;
+  return NO_SNAPSHOT_ERROR_PATTERN.test(String(result.rows[0]?.[0] ?? ""));
+}


### PR DESCRIPTION
## 变更说明

Lake/外部表（如 StarRocks 中的 Paimon 表）在没有快照时，数据读取会返回 `There is currently no snapshot` 错误，但元数据读取（DESC/SHOW CREATE）仍能成功。打开这类表时会直接展示原始服务器错误，因为 `executeTabSql` 将该失败存为 `Error` 结果，导致后续列信息获取流程无法继续。

### 修复

- 检测到该错误结果时，用 `LIMIT 0` 重试预览查询，返回表结构（列 + 空表格）。
- 在此路径上跳过合成的行 ID 重查（row-id re-query），因为那也是数据读取，会以同样方式失败。
- 新增 `queryResultError.ts` 封装错误结果检测逻辑，附带单元测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

涉及数据标签页打开表时的错误处理逻辑，无 UI/样式/交互改动。

## 验证

- [x] 新增单元测试 `queryResultError.spec.ts` 通过
- [ ] `make check` 通过