### PR TITLE
Fix：修复 MySQL 索引注释回填

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -2594,7 +2594,7 @@ pub async fn list_indexes(pool: &MySqlPool, database: &str, table: &str) -> Resu
     let sql = format!(
         "SELECT INDEX_NAME, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS columns, \
          MIN(NON_UNIQUE) = 0 AS is_unique, INDEX_NAME = 'PRIMARY' AS is_primary, \
-         INDEX_TYPE \
+         INDEX_TYPE, MAX(NULLIF(INDEX_COMMENT, '')) AS INDEX_COMMENT \
          FROM information_schema.STATISTICS \
          WHERE TABLE_SCHEMA = {} AND TABLE_NAME = {} \
          GROUP BY INDEX_NAME, INDEX_TYPE \
@@ -2618,7 +2618,7 @@ pub async fn list_indexes(pool: &MySqlPool, database: &str, table: &str) -> Resu
                 filter: None,
                 index_type: Some(get_str_by_name(row, "INDEX_TYPE")),
                 included_columns: None,
-                comment: None,
+                comment: get_opt_str(row, "INDEX_COMMENT").filter(|value| !value.is_empty()),
             }
         })
         .collect())


### PR DESCRIPTION
## 变更说明
- MySQL 索引元数据查询补充读取 `information_schema.STATISTICS.INDEX_COMMENT`
- 将非空索引注释映射到 `IndexInfo.comment`，让表结构编辑器重新打开索引时能回填注释栏

Fixes #2203

## 验证
- cargo fmt --check
- cargo check -p dbx-core
- 本地 Web 预览验证：创建带注释索引后重新打开编辑索引，注释栏可正常回填
