### PR TITLE
Fix: 修复对象浏览器标签页切回后布局异常

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1311,15 +1311,17 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
 
     <!-- Objects mode: virtualized database object browser -->
     <template v-else-if="activeTab.mode === 'objects' && activeConnection">
-      <ObjectBrowser
-        ref="objectBrowserRef"
-        :key="`${activeTab.id}-${activeTab.objectBrowser?.schema || ''}`"
-        :connection="activeConnection"
-        :database="activeTab.database"
-        :schema="activeTab.objectBrowser?.schema"
-        @open-table="emit('openObjectTable', $event)"
-        @schema-change="emit('objectSchemaChange', $event)"
-      />
+      <div class="flex-1 min-h-0">
+        <ObjectBrowser
+          ref="objectBrowserRef"
+          :key="`${activeTab.id}-${activeTab.objectBrowser?.schema || ''}`"
+          :connection="activeConnection"
+          :database="activeTab.database"
+          :schema="activeTab.objectBrowser?.schema"
+          @open-table="emit('openObjectTable', $event)"
+          @schema-change="emit('objectSchemaChange', $event)"
+        />
+      </div>
     </template>
 
     <!-- Structure mode: table structure editor -->


### PR DESCRIPTION
## 修复内容
- 给对象浏览器标签页补齐 flex-1 min-h-0 外层容器
- 让对象浏览器与 Redis、Mongo、Nacos 等浏览器类标签页保持一致的 flex 高度约束
- 修复从表数据或编辑表结构标签页切回对象浏览器后，内容区域尺寸异常、被侧边栏遮挡或右侧留白的问题

## 验证
- pnpm typecheck
- 本地预览按复现路径验证通过