### PR TITLE
Fix: 修复 Oracle 注释开头查询不返回结果表

### DIFF
--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -1539,8 +1539,42 @@ func trimStatementSQL(sqlText string) string {
 }
 
 func isQuerySQL(sqlText string) bool {
-	lower := strings.ToLower(strings.TrimSpace(sqlText))
-	return strings.HasPrefix(lower, "select") || strings.HasPrefix(lower, "with")
+	executable := trimLeadingSQLComments(sqlText)
+	return startsWithSQLKeyword(executable, "select") || startsWithSQLKeyword(executable, "with")
+}
+
+func trimLeadingSQLComments(sqlText string) string {
+	remaining := strings.TrimSpace(sqlText)
+	for {
+		switch {
+		case strings.HasPrefix(remaining, "--"):
+			lineEnd := strings.IndexAny(remaining, "\r\n")
+			if lineEnd < 0 {
+				return ""
+			}
+			remaining = strings.TrimSpace(remaining[lineEnd+1:])
+		case strings.HasPrefix(remaining, "/*"):
+			commentEnd := strings.Index(remaining[2:], "*/")
+			if commentEnd < 0 {
+				return ""
+			}
+			remaining = strings.TrimSpace(remaining[commentEnd+4:])
+		default:
+			return remaining
+		}
+	}
+}
+
+func startsWithSQLKeyword(sqlText, keyword string) bool {
+	sqlText = strings.TrimSpace(sqlText)
+	if len(sqlText) < len(keyword) || !strings.EqualFold(sqlText[:len(keyword)], keyword) {
+		return false
+	}
+	if len(sqlText) == len(keyword) {
+		return true
+	}
+	next := sqlText[len(keyword)]
+	return !((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') || (next >= '0' && next <= '9') || next == '_' || next == '$')
 }
 
 func quoteIdentifier(value string) string {

--- a/agents/drivers/oracle-go/main_test.go
+++ b/agents/drivers/oracle-go/main_test.go
@@ -141,6 +141,33 @@ func TestNormalizeDDLObjectType(t *testing.T) {
 	}
 }
 
+func TestIsQuerySQLSkipsLeadingComments(t *testing.T) {
+	tests := []string{
+		"-- 测试\nSELECT * FROM (SELECT * FROM \"DBX_TEST\".\"ORDERS_10K\") WHERE ROWNUM <= 100",
+		"/* explain */\nSELECT * FROM dual",
+		"-- comment\r\nWITH rows AS (SELECT 1 FROM dual) SELECT * FROM rows",
+	}
+	for _, sqlText := range tests {
+		if !isQuerySQL(sqlText) {
+			t.Fatalf("expected SQL to be treated as query: %s", sqlText)
+		}
+	}
+}
+
+func TestIsQuerySQLRequiresKeywordBoundary(t *testing.T) {
+	tests := []string{
+		"-- comment only",
+		"selectivity FROM stats",
+		"withdraw FROM account",
+		"/* unterminated comment",
+	}
+	for _, sqlText := range tests {
+		if isQuerySQL(sqlText) {
+			t.Fatalf("expected SQL not to be treated as query: %s", sqlText)
+		}
+	}
+}
+
 func protocolContract(t *testing.T) struct {
 	ProtocolVersion int      `json:"protocolVersion"`
 	AllCapabilities []string `json:"allCapabilities"`


### PR DESCRIPTION
## 变更说明
- 修复 Oracle Go agent 对查询 SQL 的判断，跳过开头的空白、`--` 行注释和 `/* ... */` 块注释后再识别 `SELECT` / `WITH`
- 避免 `-- 测试` 开头的 Oracle 查询被误判为非查询语句，导致执行全部后显示未返回结果表
- 增加单测覆盖用户反馈的 `-- 测试
SELECT ... ROWNUM <= 100` 场景，以及关键字边界判断

## 验证
- `git diff --check`
- `go test ./...` 未运行：当前环境未安装 Go（`go: command not found`）