### PR TITLE
Feature: 查询超时错误页支持跳转修改超时时间

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -12,6 +12,7 @@ import ContentArea from "@/components/layout/ContentArea.vue";
 import AppDialogs from "@/components/layout/AppDialogs.vue";
 import WelcomeScreen from "@/components/layout/WelcomeScreen.vue";
 import DdlViewDialog from "@/components/objects/DdlViewDialog.vue";
+import type { ConfigTab } from "@/components/connection/ConnectionDialog.vue";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -115,6 +116,7 @@ const setupRequired = ref(false);
 
 const showConnectionDialog = ref(false);
 const connectionDialogPrefill = ref<ConnectionDeepLinkDraft | null>(null);
+const connectionDialogInitialTab = ref<ConfigTab | undefined>(undefined);
 const showSettingsDialog = ref(false);
 const settingsInitialTab = ref("editor");
 const settingsInitialSection = ref<string | undefined>(undefined);
@@ -798,7 +800,17 @@ async function openPendingConnectionLinks() {
 
 function setConnectionDialogOpen(value: boolean) {
   showConnectionDialog.value = value;
-  if (!value) connectionDialogPrefill.value = null;
+  if (!value) {
+    connectionDialogPrefill.value = null;
+    connectionDialogInitialTab.value = undefined;
+  }
+}
+
+function openConnectionSettings(connectionId: string, initialTab: ConfigTab = "connection") {
+  if (!connectionStore.getConfig(connectionId)) return;
+  connectionDialogInitialTab.value = initialTab;
+  connectionStore.startEditing(connectionId);
+  showConnectionDialog.value = true;
 }
 
 async function newQuery() {
@@ -1638,6 +1650,7 @@ onUnmounted(() => {
                     "
                     @structure-editor-close="activeTab && queryStore.closeTab(activeTab.id)"
                     @open-settings="openSettings"
+                    @open-connection-settings="openConnectionSettings"
                   />
                 </KeepAlive>
               </div>
@@ -1683,6 +1696,7 @@ onUnmounted(() => {
         <AppDialogs
           :show-connection-dialog="showConnectionDialog"
           :connection-prefill="connectionDialogPrefill"
+          :connection-initial-tab="connectionDialogInitialTab"
           :show-settings-dialog="showSettingsDialog"
           :settings-initial-tab="settingsInitialTab"
           :settings-initial-section="settingsInitialSection"

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -48,7 +48,7 @@ type DbOption = { value: string; label: string };
 type DbCategory = { key: string; title: string; options: DbOption[] };
 type DialogStep = "select" | "config";
 type DbPickerView = "icon" | "list";
-type ConfigTab = "connection" | "advanced" | "tls" | "transport";
+export type ConfigTab = "connection" | "advanced" | "tls" | "transport";
 type MqTokenSigningMode = "none" | "hs256" | "rs256";
 type NacosAuthKind = NacosAuthConfig["kind"];
 type DremioConnectionMode = "arrow-flight-sql" | "legacy";
@@ -97,6 +97,7 @@ const isDesktop = isTauriRuntime();
 const props = defineProps<{
   editConfig?: ConnectionConfig;
   prefillConfig?: ConnectionDeepLinkDraft | null;
+  initialTab?: ConfigTab;
 }>();
 
 const emit = defineEmits<{
@@ -124,6 +125,10 @@ const visibleSchemaNames = ref<string[]>([]);
 const visibleSchemaInitialSelection = ref<string[]>([]);
 const visibleSchemaError = ref("");
 let testRunId = 0;
+
+function initialConfigTab(): ConfigTab {
+  return props.initialTab ?? "connection";
+}
 
 const defaultForm = (): ConnectionForm => ({
   name: "",
@@ -1051,7 +1056,7 @@ watch(
       jdbcManualClasspathOpen.value = config.db_type === "prestosql" || (config.jdbc_driver_paths || []).length > 0;
       customDriverName.value = isCustomCompatibleProfile() ? config.driver_label || "" : "";
       dialogStep.value = "config";
-      configTab.value = "connection";
+      configTab.value = initialConfigTab();
     } else {
       editingId.value = null;
       form.value = defaultForm();

--- a/apps/desktop/src/components/layout/AppDialogs.vue
+++ b/apps/desktop/src/components/layout/AppDialogs.vue
@@ -21,10 +21,12 @@ const DataGenerateDialog = defineAsyncComponent(() => import("@/components/gener
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useDialogSources } from "@/composables/useDialogSources";
 import type { ConnectionDeepLinkDraft } from "@/lib/connectionDeepLink";
+import type { ConfigTab } from "@/components/connection/ConnectionDialog.vue";
 
 const props = defineProps<{
   showConnectionDialog: boolean;
   connectionPrefill?: ConnectionDeepLinkDraft | null;
+  connectionInitialTab?: ConfigTab;
   showSettingsDialog: boolean;
   settingsInitialTab?: string;
   settingsInitialSection?: string;
@@ -108,6 +110,7 @@ watch(
     :open="shouldShowConnectionDialog"
     :edit-config="editConfig"
     :prefill-config="connectionPrefill"
+    :initial-tab="connectionInitialTab"
     @update:open="emit('update:showConnectionDialog', $event)"
     @connect-started="emit('connectStarted', $event)"
     @connect-succeeded="emit('connectSucceeded', $event)"

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -137,6 +137,7 @@ const emit = defineEmits<{
   structureEditorSaved: [commentChanged: boolean];
   structureEditorClose: [];
   openSettings: [initialTab?: string, initialSection?: string];
+  openConnectionSettings: [connectionId: string, initialTab: "advanced"];
 }>();
 
 const { t } = useI18n();
@@ -178,6 +179,11 @@ const dataGridRenderMode = computed(() => settingsStore.editorSettings.dataGridR
 const tableFontSize = computed(() => settingsStore.editorSettings.tableFontSize);
 const dataGridViewOptionsActive = computed(() => dataGridRef.value?.nullColumnsHidden || dataGridRef.value?.multiRowTranspose || dataGridRenderMode.value === "dom" || tableFontSize.value !== TABLE_FONT_SIZE_DEFAULT);
 const redisKeyBrowserRef = ref<SearchableBrowserHandle>();
+
+function isQueryTimeoutError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return lower.includes("query timed out") || lower.includes("查询超时");
+}
 const etcdKeyBrowserRef = ref<SearchableBrowserHandle>();
 const zookeeperKeyBrowserRef = ref<SearchableBrowserHandle>();
 const objectBrowserRef = ref<SearchableBrowserHandle>();
@@ -977,6 +983,10 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
                 @sort="(column: string, columnIndex: number, direction: 'asc' | 'desc' | null, whereInput?: string, mode?: DataGridSortMode) => emit('sort', column, columnIndex, direction, whereInput, mode)"
               >
                 <template v-if="activeTab.result?.columns.includes('Error')" #error-actions="{ errorMessage }">
+                  <Button v-if="activeTab.connectionId && isQueryTimeoutError(String(errorMessage))" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('openConnectionSettings', activeTab.connectionId, 'advanced')">
+                    <Wrench class="h-3.5 w-3.5" />
+                    {{ t("editor.changeQueryTimeout") }}
+                  </Button>
                   <Button variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('fixWithAi', String(errorMessage))">
                     <Bot class="h-3.5 w-3.5" />
                     {{ t("ai.fixWithAi") }}

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -386,6 +386,7 @@ export default {
     pressToExecute: "Press {mod}+Enter to execute",
     pressToSaveSql: "Press {mod}+S to save SQL",
     queryTimeoutError: "Query timed out ({seconds}s). Check whether the database connection is healthy.",
+    changeQueryTimeout: "Change query timeout",
     connectionMayBeLost: "The connection may have been lost. Refresh data and try again.",
     showResultsPane: "Show results",
     hideResultsPane: "Hide results",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -389,6 +389,7 @@ export default withEnglishFallback({
     pressToExecute: "按 {mod}+Enter 执行查询",
     pressToSaveSql: "按 {mod}+S 保存 SQL",
     queryTimeoutError: "查询超时 ({seconds}s)，请检查数据库连接是否正常",
+    changeQueryTimeout: "修改查询超时时间",
     connectionMayBeLost: "连接可能已断开，请刷新数据重试",
     showResultsPane: "显示结果",
     hideResultsPane: "收起结果",


### PR DESCRIPTION
## 变更说明
- 查询结果为超时错误时，在错误操作区增加「修改查询超时时间」按钮。
- 点击按钮后打开当前连接的编辑弹窗，并自动切到「高级」页。
- 支持连接弹窗通过 initialTab 指定初始配置页签。

## 验证
- pnpm fmt
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json
- git diff --check
- 本地预览模拟查询超时，确认按钮出现并能跳转到连接设置高级页。