### PR TITLE
Fix: 补充查询超时按钮多语言文案

### DIFF
--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -387,6 +387,7 @@ export default withEnglishFallback({
     pressToExecute: "Presiona {mod}+Enter para ejecutar",
     pressToSaveSql: "Presiona {mod}+S para guardar el SQL",
     queryTimeoutError: "La consulta agotó el tiempo ({seconds}s). Comprueba la conexión a la base de datos.",
+    changeQueryTimeout: "Cambiar tiempo de espera de consulta",
     connectionMayBeLost: "Es posible que la conexión se haya perdido. Actualiza los datos e inténtalo de nuevo.",
     showResultsPane: "Mostrar resultados",
     hideResultsPane: "Ocultar resultados",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -390,6 +390,7 @@ export default withEnglishFallback({
     pressToExecute: "Premi {mod}+Enter per eseguire",
     pressToSaveSql: "Premi {mod}+S per salvare SQL",
     queryTimeoutError: "Timeout della query ({seconds}s). Verifica se la connessione al database è integra.",
+    changeQueryTimeout: "Modifica timeout query",
     connectionMayBeLost: "La connessione potrebbe essere andata perduta. Aggiorna i dati e riprova.",
     showResultsPane: "Mostra risultati",
     hideResultsPane: "Nascondi risultati",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -386,6 +386,7 @@ export default withEnglishFallback({
     pressToExecute: "{mod}+Enter で実行",
     pressToSaveSql: "{mod}+S でSQLを保存",
     queryTimeoutError: "クエリがタイムアウトしました（{seconds}秒）。データベース接続が正常か確認してください。",
+    changeQueryTimeout: "クエリタイムアウトを変更",
     connectionMayBeLost: "接続が失われた可能性があります。データを更新して再試行してください。",
     showResultsPane: "結果を表示",
     hideResultsPane: "結果を非表示",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -399,6 +399,7 @@ export default withEnglishFallback({
     pressToExecute: "Pressione {mod}+Enter para executar",
     pressToSaveSql: "Pressione {mod}+S para salvar o SQL",
     queryTimeoutError: "A consulta expirou ({seconds}s). Verifique se a conexão com o banco de dados está saudável.",
+    changeQueryTimeout: "Alterar tempo limite da consulta",
     connectionMayBeLost: "A conexão pode ter sido perdida. Atualize os dados e tente novamente.",
     showResultsPane: "Mostrar resultados",
     hideResultsPane: "Ocultar resultados",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -387,6 +387,7 @@ export default withEnglishFallback({
     pressToExecute: "按 {mod}+Enter 執行查詢",
     pressToSaveSql: "按 {mod}+S 儲存 SQL",
     queryTimeoutError: "查詢逾時 ({seconds}s)，請檢查資料庫連線是否正常",
+    changeQueryTimeout: "修改查詢逾時時間",
     connectionMayBeLost: "連線可能已斷開，請重新整理資料重試",
     showResultsPane: "顯示結果",
     hideResultsPane: "收起結果",


### PR DESCRIPTION
## 变更说明
- 补充 PR #2237 新增的 `editor.changeQueryTimeout` 文案。
- 覆盖 es、it、ja、pt-BR、zh-TW 语言包，避免非中英文界面缺失该按钮翻译。

## 验证
- pnpm fmt
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json
- git diff --check