### PR TITLE
Fix: 修复 MySQL 存储过程 SELECT 结果未显示

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -2180,6 +2180,19 @@ async fn execute_result_set_with_text_protocol_on_conn(
     start: Instant,
 ) -> Result<QueryResult, String> {
     let mut result = conn.query_iter(sql).await.map_err(|e| e.to_string())?;
+    if !advance_to_result_set_with_columns(&mut result).await? {
+        return Ok(QueryResult {
+            columns: vec![],
+            column_types: Vec::new(),
+            column_sortables: vec![],
+            rows: vec![],
+            affected_rows: result.affected_rows(),
+            execution_time_ms: start.elapsed().as_millis(),
+            truncated: false,
+            session_id: None,
+            has_more: false,
+        });
+    }
     let columns: Vec<String> = result.columns_ref().iter().map(|c| c.name_str().to_string()).collect();
     let column_types: Vec<String> =
         result.columns_ref().iter().map(|c| mysql_column_type_name(c.column_type())).collect();
@@ -2238,6 +2251,18 @@ async fn execute_result_set_with_text_protocol_on_conn(
         session_id: None,
         has_more: false,
     })
+}
+
+async fn advance_to_result_set_with_columns(
+    result: &mut mysql_async::QueryResult<'_, '_, mysql_async::TextProtocol>,
+) -> Result<bool, String> {
+    while result.columns_ref().is_empty() {
+        if result.is_empty() {
+            return Ok(false);
+        }
+        let _: Vec<mysql_async::Row> = result.collect().await.map_err(|e| e.to_string())?;
+    }
+    Ok(!result.columns_ref().is_empty())
 }
 
 async fn execute_result_set_with_prepared_protocol_on_conn(
@@ -2502,7 +2527,7 @@ fn prefers_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
 }
 
 fn is_result_set_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
-    starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH"])
+    starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL"])
         || dialect.supports_admin_show_results && is_admin_show_query(sql)
 }
 
@@ -3011,6 +3036,14 @@ mod tests {
     #[test]
     fn mysql_desc_queries_are_treated_as_result_sets() {
         assert!(is_result_set_query("DESC users", MySqlQueryDialect::default()));
+    }
+
+    #[test]
+    fn mysql_call_queries_are_treated_as_text_result_sets() {
+        let dialect = MySqlQueryDialect::default();
+
+        assert!(is_result_set_query("CALL proc_test1()", dialect));
+        assert!(prefers_text_protocol_query("CALL proc_test1()", dialect));
     }
 
     #[test]

--- a/crates/dbx-core/tests/live_mysql57.rs
+++ b/crates/dbx-core/tests/live_mysql57.rs
@@ -35,6 +35,66 @@ async fn live_mysql_compatible_limited_text_protocol_query_succeeds() {
 }
 
 #[tokio::test]
+#[ignore = "requires a remote MySQL endpoint"]
+async fn live_mysql_call_procedure_returns_select_result_set() {
+    let url = std::env::var("DBX_LIVE_MYSQL_PROCEDURE_URL").expect("DBX_LIVE_MYSQL_PROCEDURE_URL");
+
+    let pool = dbx_core::db::mysql::connect(&url, std::time::Duration::from_secs(10)).await.unwrap();
+    dbx_core::db::mysql::execute_query_with_max_rows(
+        &pool,
+        "DROP PROCEDURE IF EXISTS proc_test1",
+        false,
+        Some(10),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    dbx_core::db::mysql::execute_query_with_max_rows(
+        &pool,
+        r#"
+CREATE PROCEDURE proc_test1()
+READS SQL DATA
+BEGIN
+    DROP TEMPORARY TABLE IF EXISTS tb_tmp_001;
+    CREATE TEMPORARY TABLE tb_tmp_001(
+        id INT,
+        NAME VARCHAR(32) DEFAULT ''
+    );
+    INSERT INTO tb_tmp_001(id, NAME) VALUES(1, '测试数据001');
+    SELECT * FROM tb_tmp_001;
+END
+"#,
+        false,
+        Some(10),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    let result = dbx_core::db::mysql::execute_query_with_max_rows(
+        &pool,
+        "CALL proc_test1()",
+        false,
+        Some(10),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    dbx_core::db::mysql::execute_query_with_max_rows(
+        &pool,
+        "DROP PROCEDURE IF EXISTS proc_test1",
+        false,
+        Some(10),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.columns, vec!["id", "NAME"]);
+    assert_eq!(result.rows, vec![vec![serde_json::json!("1"), serde_json::json!("测试数据001")]]);
+}
+
+#[tokio::test]
 #[ignore = "requires a remote OceanBase MySQL-compatible endpoint"]
 async fn live_oceanbase_mysql_setup_applies_query_timeout() {
     let url = std::env::var("DBX_LIVE_OCEANBASE_MYSQL_URL").expect("DBX_LIVE_OCEANBASE_MYSQL_URL");


### PR DESCRIPTION
## 变更说明
- 将 MySQL `CALL` 语句纳入结果集查询路径，避免按普通更新语句只返回 affected rows。
- 执行 text protocol 查询时跳过存储过程调用前置的无列 OK result set，继续读取后续真正包含列的 SELECT 结果集。
- 增加 MySQL 存储过程返回 SELECT 结果的 live 回归测试入口。

## 验证
- `cargo fmt --check`
- `cargo test -p dbx-core db::mysql::tests`
- `cargo test -p dbx-core`

## 关联 Issue
Fixes #2231
Fixes #2233