### PR TITLE
Improve: 增加 Windows WebView2 离线安装包产物

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,37 @@ jobs:
           Compress-Archive -Path (Join-Path $portableDir "*") -DestinationPath $zipName -Force
           gh release upload "${env:GITHUB_REF_NAME}" $zipName --repo "${env:GITHUB_REPOSITORY}" --clobber
 
+      - name: Upload Windows WebView2 offline installer
+        if: matrix.arch == 'x64' || matrix.arch == 'arm64'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = "${env:GITHUB_REF_NAME}".TrimStart("v")
+          $arch = "${{ matrix.arch }}"
+          $bundleDir = "target/${{ matrix.target }}/release/bundle/nsis"
+          $offlineName = "DBX_${version}_${arch}-webview2-offline-setup.exe"
+          $before = @{}
+
+          if (Test-Path $bundleDir) {
+            Get-ChildItem $bundleDir -Filter "*.exe" | ForEach-Object { $before[$_.FullName] = $_.LastWriteTimeUtc }
+          }
+
+          pnpm tauri bundle --bundles nsis --target ${{ matrix.target }} --config src-tauri/tauri.webview2-offline.conf.json
+
+          $installer = Get-ChildItem $bundleDir -Filter "*.exe" |
+            Where-Object { !$before.ContainsKey($_.FullName) -or $_.LastWriteTimeUtc -gt $before[$_.FullName] } |
+            Sort-Object LastWriteTimeUtc -Descending |
+            Select-Object -First 1
+
+          if (!$installer) {
+            Write-Error "Missing WebView2 offline installer in ${bundleDir}"
+            exit 1
+          }
+
+          Copy-Item $installer.FullName $offlineName -Force
+          gh release upload "${env:GITHUB_REF_NAME}" $offlineName --repo "${env:GITHUB_REPOSITORY}" --clobber
+
   cleanup-release-signatures:
     needs: build
     runs-on: ubuntu-latest

--- a/src-tauri/tauri.webview2-offline.conf.json
+++ b/src-tauri/tauri.webview2-offline.conf.json
@@ -1,0 +1,10 @@
+{
+  "bundle": {
+    "windows": {
+      "webviewInstallMode": {
+        "silent": true,
+        "type": "offlineInstaller"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 变更说明
- 新增 `src-tauri/tauri.webview2-offline.conf.json`，为 Windows NSIS bundle 启用 WebView2 `offlineInstaller` 模式。
- Release Windows job 在保留默认安装包和 portable zip 的基础上，额外生成并上传 `DBX_<version>_<arch>-webview2-offline-setup.exe`。
- 离线包用于缺少 WebView2 且无法联网安装的旧版 Windows 10 环境，默认安装包体积和更新路径不受影响。

## 验证
- `node -e "JSON.parse(require('fs').readFileSync('src-tauri/tauri.webview2-offline.conf.json','utf8')); console.log('json ok')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"`
- `git diff --check`

说明：本地 macOS 环境无法实际生成 Windows NSIS 安装包，最终离线安装包产物需要 release workflow 的 Windows job 验证。