### PR TITLE
Fix: 修复根层 SQL 文件点击后未高亮

### DIFF
--- a/apps/desktop/src/components/layout/SqlLibraryPanel.vue
+++ b/apps/desktop/src/components/layout/SqlLibraryPanel.vue
@@ -1186,7 +1186,7 @@ function showDropInside(targetId: string) {
                   v-for="file in visibleFiles"
                   :key="file.id"
                   class="relative flex items-center gap-1 rounded px-2 py-1.5 text-[13px] cursor-pointer group"
-                  :class="[isDraggingItem(file.id) ? 'opacity-50' : isFileSelected(file.id) ? 'bg-primary/10' : 'hover:bg-accent']"
+                  :class="[isDraggingItem(file.id) ? 'opacity-50' : isFileSelected(file.id) ? 'bg-primary/10' : isFileActive(file.id) ? 'bg-accent' : 'hover:bg-accent']"
                   @mousedown="handleDragMouseDown($event, file.id, 'file')"
                   @mousemove="updateDropTarget($event, file.id, 'file')"
                   @mouseleave="clearDropTarget(file.id)"


### PR DESCRIPTION
## 变更说明
- 补齐 SQL 库树形视图中根层 SQL 文件的 active 高亮判断
- 让根层文件点击后的选中效果与文件夹内文件保持一致

Fixes #2227 
## 验证
- pnpm fmt
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json
- git diff --check