### PR TITLE
✨feat(queryStore): 添加数据库打开状态跟踪功能

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -3127,6 +3127,7 @@ const paddingLeft = computed(() => treeItemPaddingLeft(props.depth));
 const isConnected = computed(() => props.node.type === "connection" && !!props.node.connectionId && connectionStore.connectedIds.has(props.node.connectionId));
 const isConnectionReadonly = computed(() => props.node.type === "connection" && !!props.node.connectionId && (connectionStore.getConfig(props.node.connectionId)?.read_only ?? false));
 const isOpenedDatabase = computed(() => isSidebarDatabaseOpened(props.node, connectionStore.isTreeNodeChildrenLoaded));
+const showsDatabaseOpenIndicator = computed(() => props.node.type === "database" && (isOpenedDatabase.value || (!!props.node.connectionId && props.node.database != null && queryStore.isDatabaseOpen(props.node.connectionId, props.node.database))));
 const canCloseDatabaseConnection = computed(() => canCloseSidebarDatabaseConnection(props.node, connectionStore.isTreeNodeChildrenLoaded));
 const nodeIconClass = computed(() => {
   const infoClass = getIconInfo(props.node)?.colorClass;
@@ -4135,6 +4136,7 @@ function treeItemMenuItems(): ContextMenuItem[] {
           <span v-if="columnComment" class="sidebar-object-comment ml-auto max-w-[20%] shrink-0 truncate text-right">{{ columnComment }}</span>
           <span v-if="tableComment" class="sidebar-object-comment ml-auto max-w-[20%] shrink-0 truncate text-right">{{ tableComment }}</span>
           <span v-if="node.type === 'connection' && node.connectionId && connectionStore.connectedIds.has(node.connectionId)" class="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+          <span v-if="showsDatabaseOpenIndicator" class="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
           <Badge v-if="isConnectionReadonly" variant="secondary" class="h-4 px-1.5 text-[10px] gap-0.5"><Lock class="w-2.5 h-2.5" />{{ t("connection.readOnlyBadge") }}</Badge>
           <ConnectionErrorIndicator v-if="node.type === 'connection'" :connection-id="node.connectionId" trigger-class="h-4 w-4" />
           <Pin v-if="isPinned" class="w-3 h-3 shrink-0 text-primary fill-current" aria-hidden="true" />

--- a/apps/desktop/src/stores/__tests__/queryStore.database-open.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.database-open.spec.ts
@@ -1,0 +1,40 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function installLocalStorage() {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => data.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => data.set(key, value)),
+    removeItem: vi.fn((key: string) => data.delete(key)),
+  });
+}
+
+describe("queryStore database open state", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    installLocalStorage();
+    setActivePinia(createPinia());
+  });
+
+  it("tracks whether a connection database has open tabs", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+
+    const tabId = store.createTab("pg-1", "app", "query_1");
+
+    expect(store.isDatabaseOpen("pg-1", "app")).toBe(true);
+    expect(store.isDatabaseOpen("pg-1", "analytics")).toBe(false);
+    expect(store.isDatabaseOpen("pg-2", "app")).toBe(false);
+
+    store.updateDatabase(tabId, "analytics");
+
+    expect(store.isDatabaseOpen("pg-1", "app")).toBe(false);
+    expect(store.isDatabaseOpen("pg-1", "analytics")).toBe(true);
+
+    store.closeTab(tabId);
+
+    expect(store.isDatabaseOpen("pg-1", "analytics")).toBe(false);
+  });
+});

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -984,6 +984,10 @@ export const useQueryStore = defineStore("query", () => {
     releaseTabsWhere((tab) => tab.connectionId === connectionId && tab.database === database);
   }
 
+  function isDatabaseOpen(connectionId: string, database: string) {
+    return tabs.value.some((tab) => tab.connectionId === connectionId && tab.database === database);
+  }
+
   function updateSql(id: string, sql: string) {
     const tab = tabs.value.find((t) => t.id === id);
     if (tab) {
@@ -2484,6 +2488,7 @@ export const useQueryStore = defineStore("query", () => {
     closeDatabaseTabs,
     releaseConnectionTabs,
     releaseDatabaseTabs,
+    isDatabaseOpen,
     updateSql,
     updateEditorViewport,
     updateEditorSelection,


### PR DESCRIPTION
- 新增 isDatabaseOpen 方法，用于检查特定连接的数据库是否处于打开状态
- 在 TreeItem 组件中显示数据库打开指示器
- 添加 queryStore.database-open.spec.ts 测试文件，验证数据库打开状态的逻辑

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="262" height="147" alt="image" src="https://github.com/user-attachments/assets/38c1785b-3d7c-44c6-8db4-366783c6ac85" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2238