### PR TITLE
feat(perf): cap Java agent heap and large result memory across all db…

### DIFF
--- a/apps/desktop/src/components/chart/QueryChart.vue
+++ b/apps/desktop/src/components/chart/QueryChart.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
 const { t } = useI18n();
 const { isDark } = useTheme();
 
+const MAX_CHART_POINTS = 5000;
 type ChartType = "line" | "bar" | "pie";
 const chartType = ref<ChartType>("bar");
 const xColumnIndex = ref(0);
@@ -73,7 +74,14 @@ const chartOption = computed(() => {
   const xIdx = xColumnIndex.value;
   if (xIdx < 0 || yColumnIndexes.value.length === 0) return null;
 
-  const xData = props.result.rows.map((row) => String(row[xIdx] ?? ""));
+  const allRows = props.result.rows;
+  const rowCount = allRows.length;
+  // Downsample huge result sets so ECharts does not duplicate every row into series data.
+  const stride = rowCount > MAX_CHART_POINTS ? Math.ceil(rowCount / MAX_CHART_POINTS) : 1;
+  const picked: number[] = [];
+  for (let i = 0; i < rowCount; i += stride) picked.push(i);
+
+  const xData = picked.map((i) => String(allRows[i][xIdx] ?? ""));
 
   if (chartType.value === "pie") {
     const yIdx = yColumnIndexes.value[0];
@@ -85,9 +93,9 @@ const chartOption = computed(() => {
         {
           type: "pie",
           radius: ["30%", "60%"],
-          data: xData.map((name, i) => ({
-            name,
-            value: toChartNumber(props.result.rows[i][yIdx]) ?? 0,
+          data: picked.map((rowIdx, j) => ({
+            name: xData[j],
+            value: toChartNumber(allRows[rowIdx][yIdx]) ?? 0,
           })),
         },
       ],
@@ -115,7 +123,7 @@ const chartOption = computed(() => {
     series: yIndices.map((yIdx) => ({
       name: axisColumnLabel(props.result.columns, yIdx),
       type: chartType.value,
-      data: props.result.rows.map((row) => toChartNumber(row[yIdx]) ?? 0),
+      data: picked.map((rowIdx) => toChartNumber(allRows[rowIdx][yIdx]) ?? 0),
       smooth: chartType.value === "line",
     })),
   };

--- a/apps/desktop/src/components/config/DriverStoreDialog.vue
+++ b/apps/desktop/src/components/config/DriverStoreDialog.vue
@@ -162,8 +162,9 @@ const queuedDriverInstalls = ref<string[]>([]);
 const reinstallingJre = ref<string | null>(null);
 const refreshing = ref(false);
 const progress = ref<DriverInstallProgress | null>(null);
-const javaRuntimeConfig = ref<JavaRuntimeConfig>({ mode: "managed", custom_java_path: null });
+const javaRuntimeConfig = ref<JavaRuntimeConfig>({ mode: "managed", custom_java_path: null, max_heap: null });
 const customJavaPath = ref("");
+const maxHeapValue = ref("");
 const savingJavaRuntime = ref(false);
 const driverStoreUsage = ref<DriverStoreUsage | null>(null);
 const runtimeSummary = ref<DriverRuntimeSummary | null>(null);
@@ -321,6 +322,7 @@ async function loadJavaRuntimeConfig() {
   const config = await api.getAgentJavaRuntimeConfig();
   javaRuntimeConfig.value = config;
   customJavaPath.value = config.custom_java_path ?? "";
+  maxHeapValue.value = config.max_heap ?? "";
 }
 
 function setJavaRuntimeMode(value: any) {
@@ -335,9 +337,11 @@ async function saveJavaRuntimeConfig() {
     const config = await api.setAgentJavaRuntimeConfig({
       mode: javaRuntimeConfig.value.mode,
       custom_java_path: javaRuntimeConfig.value.mode === "custom" ? customJavaPath.value.trim() || null : null,
+      max_heap: maxHeapValue.value.trim() || null,
     });
     javaRuntimeConfig.value = config;
     customJavaPath.value = config.custom_java_path ?? "";
+    maxHeapValue.value = config.max_heap ?? "";
     toast(t("driverStore.javaRuntimeSaved"));
   } catch (e: any) {
     toast(t("driverStore.javaRuntimeSaveFailed", { error: e }));
@@ -1060,6 +1064,17 @@ watch(driverStoreTab, (tab) => {
                   {{ t("driverStore.choose") }}
                 </Button>
                 <Button class="h-8 shrink-0 rounded-[6px] text-xs" :disabled="savingJavaRuntime || (javaRuntimeConfig.mode === 'custom' && !customJavaPath.trim())" @click="saveJavaRuntimeConfig">
+                  {{ savingJavaRuntime ? t("driverStore.saving") : t("settings.save") }}
+                </Button>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <Label class="shrink-0">{{ t("driverStore.javaMaxHeap") }}</Label>
+                <Input v-model="maxHeapValue" class="h-8 min-w-[120px] text-xs" :placeholder="t('driverStore.javaMaxHeapPlaceholder')" @keydown.enter.prevent="saveJavaRuntimeConfig" />
+                <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                  {{ t("driverStore.javaMaxHeapHint") }}
+                </span>
+                <Button class="h-8 shrink-0 rounded-[6px] text-xs" :disabled="savingJavaRuntime" @click="saveJavaRuntimeConfig">
                   {{ savingJavaRuntime ? t("driverStore.saving") : t("settings.save") }}
                 </Button>
               </div>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -524,6 +524,7 @@ export default {
   executionSummary: {
     empty: "No execution summary",
     executing: "Executing...",
+    largeResultWarning: "Large result set ({rows} rows, ~{megabytes} MB). Consider decreasing rows per page or exporting to avoid high memory use.",
     statement: "Statement",
     type: "Type",
     rows: "Rows",
@@ -2917,6 +2918,9 @@ export default {
     uninstall: "Uninstall",
     jreRuntime: "JRE Runtime",
     jreRuntimeAutoDownloadHint: "Downloaded automatically when installing a driver for the first time",
+    javaMaxHeap: "Max heap",
+    javaMaxHeapPlaceholder: "512m / 768m / 1g / 2g",
+    javaMaxHeapHint: "Caps Java agent memory (e.g. 512m, 1g); empty uses the 512m default",
     driversUpdatable: "{count} driver(s) can be updated",
     upgradingProgress: "Upgrading ({current}/{total})",
     upgradeAll: "Upgrade all",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -527,6 +527,7 @@ export default withEnglishFallback({
   executionSummary: {
     empty: "暂无执行摘要",
     executing: "正在执行...",
+    largeResultWarning: "结果集较大（{rows} 行，约 {megabytes} MB）。建议减小每页行数或导出，以免内存占用过高。",
     statement: "语句",
     type: "类型",
     rows: "返回行",
@@ -2924,6 +2925,9 @@ export default withEnglishFallback({
     uninstall: "卸载",
     jreRuntime: "JRE 运行时",
     jreRuntimeAutoDownloadHint: "首次安装驱动时自动下载",
+    javaMaxHeap: "最大堆内存",
+    javaMaxHeapPlaceholder: "512m / 768m / 1g / 2g",
+    javaMaxHeapHint: "限制 Java 驱动进程内存（如 512m、1g）；留空使用默认 512m",
     driversUpdatable: "{count} 个驱动可更新",
     upgradingProgress: "升级中 ({current}/{total})",
     upgradeAll: "全部升级",

--- a/apps/desktop/src/lib/__tests__/ai.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai.spec.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildSystemPrompt, type AiContext } from "@/lib/ai";
+
+// buildSystemPrompt switches copy by currentLocale(); pin it to English so the assertions below
+// (which check the English prompt text) are stable regardless of the host locale.
+vi.mock("@/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/i18n")>();
+  return { ...actual, currentLocale: () => "en" };
+});
 
 function context(overrides: Partial<AiContext> = {}): AiContext {
   return {

--- a/apps/desktop/src/lib/paginationPageSize.ts
+++ b/apps/desktop/src/lib/paginationPageSize.ts
@@ -1,7 +1,7 @@
 export const RESULT_PAGE_SIZE_OPTIONS = [50, 100, 500, 1000];
 export const DEFAULT_RESULT_PAGE_SIZE = 100;
 export const MIN_RESULT_PAGE_SIZE = 1;
-export const MAX_RESULT_PAGE_SIZE = 100000;
+export const MAX_RESULT_PAGE_SIZE = 50000;
 
 export function normalizeResultPageSize(value: unknown, fallback = DEFAULT_RESULT_PAGE_SIZE): number {
   const fallbackValue = Number.isFinite(fallback) && fallback >= MIN_RESULT_PAGE_SIZE ? Math.min(Math.floor(fallback), MAX_RESULT_PAGE_SIZE) : DEFAULT_RESULT_PAGE_SIZE;

--- a/apps/desktop/src/lib/resultMemoryBudget.ts
+++ b/apps/desktop/src/lib/resultMemoryBudget.ts
@@ -1,0 +1,47 @@
+/**
+ * Frontend memory-budget helpers for query result sets. The WebView renderer can balloon to
+ * multiple GB when large results accumulate across inactive tabs; these helpers cap that.
+ */
+
+/** Total byte budget for inactive-tab result caches held in memory. Results beyond this are
+ * evicted to disk (oldest first) even if fewer than MAX_CACHED_RESULTS tabs are inactive. */
+export const MAX_RESULT_CACHE_BYTES = 300 * 1024 * 1024;
+/** Thresholds that trigger a "large result" warning so the user shrinks page size or exports. */
+export const LARGE_RESULT_WARN_BYTES = 50 * 1024 * 1024;
+export const LARGE_RESULT_WARN_ROWS = 100_000;
+/** Cap the number of rows sampled when estimating, so estimation stays cheap on huge results. */
+const ESTIMATE_SAMPLE_ROWS = 512;
+
+export type ResultLike = { rows?: unknown[][] } | null | undefined;
+
+function estimateValueBytes(value: unknown): number {
+  if (value === null || value === undefined) return 4;
+  if (typeof value === "number" || typeof value === "boolean") return 8;
+  if (typeof value === "string") return value.length + 2;
+  try {
+    return Math.min(JSON.stringify(value).length, 2048);
+  } catch {
+    return 64;
+  }
+}
+
+/** Rough byte estimate of a result set's rows, sampled to stay cheap on huge results. */
+export function estimateResultBytes(result: ResultLike): number {
+  const rows = result?.rows;
+  if (!rows || rows.length === 0) return 0;
+  const total = rows.length;
+  const sample = Math.min(total, ESTIMATE_SAMPLE_ROWS);
+  let sampled = 0;
+  for (let i = 0; i < sample; i += 1) {
+    const row = rows[i];
+    if (!row) continue;
+    for (const value of row) sampled += estimateValueBytes(value);
+  }
+  return Math.round((sampled / sample) * total);
+}
+
+/** True when a result is large enough to warrant a user-facing warning. */
+export function isLargeResult(result: ResultLike): boolean {
+  if (!result?.rows) return false;
+  return result.rows.length >= LARGE_RESULT_WARN_ROWS || estimateResultBytes(result) >= LARGE_RESULT_WARN_BYTES;
+}

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -91,6 +91,8 @@ export type JavaRuntimeMode = "managed" | "system" | "custom";
 export interface JavaRuntimeConfig {
   mode: JavaRuntimeMode;
   custom_java_path: string | null;
+  /** JVM max heap passed to every Java agent as `-Xmx<value>` (e.g. "512m", "1g"). null/empty uses the backend default. */
+  max_heap: string | null;
 }
 
 export interface DriverStoreUsageItem {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -39,6 +39,8 @@ import { connectionUsesDatabaseObjectTreeMode, connectionUsesSchemaExecutionCont
 import { queryTimeoutSecsForConnection } from "@/lib/queryTimeout";
 import { sortDataGridRows, type DataGridSortDirection } from "@/lib/dataGridSort";
 import { normalizeResultPageSize } from "@/lib/paginationPageSize";
+import { estimateResultBytes, isLargeResult, MAX_RESULT_CACHE_BYTES } from "@/lib/resultMemoryBudget";
+import { useToast } from "@/composables/useToast";
 import { splitSqlStatementRanges } from "@/lib/sqlStatementRanges";
 import { clearDataGridPendingSnapshotsForTab } from "@/composables/useDataGridEditor";
 import { buildTabResultSnapshot, deleteTabResultSnapshot, readTabResultSnapshot, tabResultCacheKey, writeTabResultSnapshot } from "@/lib/tabResultCache";
@@ -185,6 +187,7 @@ function getI18nT() {
 
 export const useQueryStore = defineStore("query", () => {
   const t = getI18nT();
+  const { toast } = useToast();
   const restored = loadSavedTabs();
   const tabs = ref<QueryTab[]>(restored.tabs);
   const activeTabId = ref<string | null>(restored.activeTabId);
@@ -1930,6 +1933,7 @@ export const useQueryStore = defineStore("query", () => {
           backendMs: current.result?.execution_time_ms,
           elapsed: elapsed(),
         });
+        warnLargeResultIfNeeded(current.result);
         if (current.mode === "query" && current.result) analyzeQueryMetadataInBackground(id, queryBaseSql, current.result, traceId, elapsed);
       } else {
         console.warn("[DBX][executeTabSql:stale-result]", {
@@ -2167,10 +2171,27 @@ export const useQueryStore = defineStore("query", () => {
 
   async function trimResultCache() {
     const inactive = tabs.value.filter((t) => t.id !== activeTabId.value && (t.result || t.results)).sort((a, b) => (a.resultAccessedAt ?? 0) - (b.resultAccessedAt ?? 0));
-    if (inactive.length > MAX_CACHED_RESULTS) {
-      const toEvict = inactive.slice(0, inactive.length - MAX_CACHED_RESULTS);
-      await Promise.all(toEvict.map((t) => evictCachedResult(t)));
+    if (inactive.length === 0) return;
+    // Evict oldest inactive results while we exceed either the tab-count cap or the byte budget.
+    // The byte budget prevents a few huge results from holding hundreds of MB across inactive tabs.
+    let totalBytes = inactive.reduce((sum, tab) => sum + estimateResultBytes(tab.result ?? tab.results?.[0]), 0);
+    const toEvict: QueryTab[] = [];
+    for (const tab of inactive) {
+      const remainingCount = inactive.length - toEvict.length;
+      if (remainingCount <= MAX_CACHED_RESULTS && totalBytes <= MAX_RESULT_CACHE_BYTES) break;
+      toEvict.push(tab);
+      totalBytes -= estimateResultBytes(tab.result ?? tab.results?.[0]);
     }
+    if (toEvict.length > 0) {
+      await Promise.all(toEvict.map((tab) => evictCachedResult(tab)));
+    }
+  }
+
+  function warnLargeResultIfNeeded(result: QueryResult | undefined) {
+    if (!result || !isLargeResult(result)) return;
+    const rows = result.rows.length;
+    const megabytes = Math.max(1, Math.round(estimateResultBytes(result) / (1024 * 1024)));
+    toast(t("query.largeResultWarning", { rows, megabytes }));
   }
 
   watch(activeTabId, (id) => {

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -477,7 +477,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   snippets: DEFAULT_SQL_SNIPPETS,
   tableColumnTemplateFields: [...DEFAULT_TABLE_COLUMN_TEMPLATE_FIELDS],
   exportBatchSize: 2000,
-  exportRowLimitEnabled: false,
+  exportRowLimitEnabled: true,
   exportRowLimit: 100000,
   queryExportKeysetOptimizationEnabled: true,
   updateDownloadSource: "official",

--- a/crates/dbx-core/src/agent_manager.rs
+++ b/crates/dbx-core/src/agent_manager.rs
@@ -10,6 +10,24 @@ use crate::models::connection::DatabaseType;
 pub const DEFAULT_JRE_KEY: &str = "21";
 pub const DOWNLOAD_CACHE_DIR_NAME: &str = "download-cache";
 pub const DOWNLOAD_CACHE_MAX_AGE_DAYS: u64 = 7;
+/// Default JVM max heap for Java agents. Agents previously launched with no `-Xmx`, so the JVM
+/// used its default (up to ~1/4 of physical RAM) and a single agent could reach several GB.
+/// Paired with the existing `UseSerialGC` to cap memory under worst-case result/export loads.
+/// Users can raise this in the driver store settings.
+pub const DEFAULT_AGENT_MAX_HEAP: &str = "512m";
+
+/// Validate a JVM heap size string such as `512m`, `1g`, `2048k`. Must be a positive integer
+/// followed by a `k`/`m`/`g` unit (case-insensitive). Malformed values are rejected so launch
+/// sites fall back to [`DEFAULT_AGENT_MAX_HEAP`].
+pub fn validate_max_heap(value: &str) -> bool {
+    let trimmed = value.trim();
+    let Some((unit, digits)) = trimmed.as_bytes().split_last() else {
+        return false;
+    };
+    matches!(*unit, b'k' | b'K' | b'm' | b'M' | b'g' | b'G')
+        && !digits.is_empty()
+        && digits.iter().all(|c| c.is_ascii_digit())
+}
 
 fn default_jre_key() -> String {
     DEFAULT_JRE_KEY.to_string()
@@ -139,6 +157,7 @@ mod tests {
             java_runtime: JavaRuntimeConfig {
                 mode: JavaRuntimeMode::Custom,
                 custom_java_path: Some(custom_java.to_string_lossy().to_string()),
+                ..Default::default()
             },
             ..AgentState::default()
         };
@@ -153,6 +172,7 @@ mod tests {
             java_runtime: JavaRuntimeConfig {
                 mode: JavaRuntimeMode::Custom,
                 custom_java_path: Some(manager.base_dir().join("missing-java").to_string_lossy().to_string()),
+                ..Default::default()
             },
             ..AgentState::default()
         };
@@ -254,11 +274,36 @@ mod tests {
             .expect("manifest launch should resolve");
 
         assert_eq!(launch.program, driver_dir.join("bin").join("dameng-agent"));
-        assert_eq!(
-            launch.args,
-            vec!["--config".to_string(), driver_dir.join("config.json").to_string_lossy().to_string()]
-        );
+        assert_eq!(launch.args, vec!["--config".to_string(), format!("{}/config.json", driver_dir.to_string_lossy())]);
         assert_eq!(launch.working_dir.as_deref(), Some(driver_dir.as_path()));
+    }
+
+    #[test]
+    fn validate_max_heap_accepts_positive_integer_with_unit() {
+        assert!(validate_max_heap("512m"));
+        assert!(validate_max_heap("1g"));
+        assert!(validate_max_heap("2048k"));
+        assert!(validate_max_heap("2G"));
+        assert!(validate_max_heap(" 768m "));
+    }
+
+    #[test]
+    fn validate_max_heap_rejects_malformed_values() {
+        assert!(!validate_max_heap(""));
+        assert!(!validate_max_heap("512"));
+        assert!(!validate_max_heap("abc"));
+        assert!(!validate_max_heap("1.5g"));
+        assert!(!validate_max_heap("g"));
+        assert!(!validate_max_heap("-1g"));
+    }
+
+    #[test]
+    fn java_runtime_config_deserializes_without_max_heap_field() {
+        // Older state.json written before max_heap was introduced must still load.
+        let json = r#"{"mode":"managed","custom_java_path":null}"#;
+        let config: JavaRuntimeConfig = serde_json::from_str(json).expect("legacy config should deserialize");
+        assert_eq!(config.mode, JavaRuntimeMode::Managed);
+        assert_eq!(config.max_heap, None);
     }
 }
 
@@ -336,6 +381,10 @@ pub struct JavaRuntimeConfig {
     pub mode: JavaRuntimeMode,
     #[serde(default)]
     pub custom_java_path: Option<String>,
+    /// JVM max heap passed to every Java agent as `-Xmx<value>` (e.g. `512m`, `1g`).
+    /// `None`, empty, or invalid values fall back to [`DEFAULT_AGENT_MAX_HEAP`].
+    #[serde(default)]
+    pub max_heap: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -570,7 +619,7 @@ impl AgentManager {
         let jar_path = self.driver_jar_path(driver_key);
         if jar_path.exists() {
             let java = self.resolve_java_runtime(state, jre_key)?;
-            return Ok(AgentLaunchSpec::java_jar(java, jar_path));
+            return Ok(AgentLaunchSpec::java_jar(java, jar_path, state.java_runtime.max_heap.as_deref()));
         }
 
         Err(format!("{driver_key} driver is not installed. Please install it from the Driver Manager."))

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -2929,6 +2929,7 @@ mod tests {
                 java_runtime: JavaRuntimeConfig {
                     mode: JavaRuntimeMode::Custom,
                     custom_java_path: Some(java.to_string_lossy().to_string()),
+                    ..Default::default()
                 },
                 ..AgentState::default()
             })

--- a/crates/dbx-core/src/data_compare.rs
+++ b/crates/dbx-core/src/data_compare.rs
@@ -18,6 +18,13 @@ use crate::transfer::{generate_comment_ddl, generate_create_table_ddl};
 const DATA_SYNC_INSERT_BATCH_SIZE: usize = 500;
 const DATA_SYNC_CONDITION_BATCH_SIZE: usize = 200;
 
+/// Hard cap on rows per side for data compare. Tables larger than this are rejected up front
+/// (after the count query) to avoid loading both sides into memory — the worst OOM risk here.
+pub const COMPARE_ROW_THRESHOLD: u64 = 200_000;
+/// Fetch safety cap: stop and mark the compare truncated after this many rows on one side, in
+/// case the count estimate is inaccurate or unavailable.
+pub const COMPARE_MAX_ROWS: usize = 500_000;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompareDataRowsOptions {
@@ -237,8 +244,15 @@ pub async fn prepare_data_compare_from_tables(
     )?;
     let source_row_count = first_count(&source_count_result.rows)?;
     let target_row_count = first_count(&target_count_result.rows)?;
+    let max_compare_rows = COMPARE_MAX_ROWS.max(fetch_batch_size);
+    let largest_side = source_row_count.max(target_row_count);
+    if largest_side > COMPARE_ROW_THRESHOLD {
+        return Err(format!(
+            "表行数过多（{largest_side} 行），超过数据对比上限 {COMPARE_ROW_THRESHOLD} 行。请加 WHERE 条件缩小范围或分批对比，以免内存溢出。"
+        ));
+    }
 
-    let (source_rows, target_rows) = tokio::try_join!(
+    let ((source_rows, source_truncated), (target_rows, target_truncated)) = tokio::try_join!(
         fetch_compare_rows(
             state,
             &options.source_connection_id,
@@ -249,6 +263,7 @@ pub async fn prepare_data_compare_from_tables(
             &options.key_columns,
             source_database_type,
             fetch_batch_size,
+            max_compare_rows,
         ),
         fetch_compare_rows(
             state,
@@ -260,6 +275,7 @@ pub async fn prepare_data_compare_from_tables(
             &options.key_columns,
             target_database_type,
             fetch_batch_size,
+            max_compare_rows,
         )
     )?;
     let target_columns = get_columns_core(
@@ -289,8 +305,8 @@ pub async fn prepare_data_compare_from_tables(
         pre_sync_statements: Vec::new(),
         source_row_count,
         target_row_count,
-        source_truncated: false,
-        target_truncated: false,
+        source_truncated,
+        target_truncated,
     })
 }
 
@@ -324,7 +340,13 @@ pub async fn prepare_data_compare_missing_target(
     )
     .await?;
     let source_row_count = first_count(&source_count_result.rows)?;
-    let source_rows = fetch_compare_rows(
+    let max_compare_rows = COMPARE_MAX_ROWS.max(fetch_batch_size);
+    if source_row_count > COMPARE_ROW_THRESHOLD {
+        return Err(format!(
+            "表行数过多（{source_row_count} 行），超过数据对比上限 {COMPARE_ROW_THRESHOLD} 行。请加 WHERE 条件缩小范围或分批对比，以免内存溢出。"
+        ));
+    }
+    let (source_rows, source_truncated) = fetch_compare_rows(
         state,
         &options.source_connection_id,
         &options.source_database,
@@ -334,6 +356,7 @@ pub async fn prepare_data_compare_missing_target(
         &options.key_columns,
         source_database_type,
         fetch_batch_size,
+        max_compare_rows,
     )
     .await?;
     let result = missing_target_diff(&column_names, &options.key_columns, source_rows);
@@ -381,7 +404,7 @@ pub async fn prepare_data_compare_missing_target(
         pre_sync_statements,
         source_row_count,
         target_row_count: 0,
-        source_truncated: false,
+        source_truncated,
         target_truncated: false,
     })
 }
@@ -960,20 +983,21 @@ async fn fetch_compare_rows(
     key_columns: &[String],
     database_type: DatabaseType,
     fetch_batch_size: usize,
-) -> Result<Vec<Vec<Value>>, String> {
+    max_rows: usize,
+) -> Result<(Vec<Vec<Value>>, bool), String> {
     let mut rows = Vec::new();
     let mut offset = 0usize;
+    let mut truncated = false;
 
     loop {
-        let sql = build_data_compare_select_sql(
-            database_type,
-            schema,
-            table_name,
-            columns,
-            key_columns,
-            fetch_batch_size,
-            offset,
-        );
+        let remaining = max_rows.saturating_sub(rows.len());
+        if remaining == 0 {
+            truncated = true;
+            break;
+        }
+        let page_size = fetch_batch_size.min(remaining);
+        let sql =
+            build_data_compare_select_sql(database_type, schema, table_name, columns, key_columns, page_size, offset);
         let result = execute_sql_statement_with_options(
             state,
             connection_id,
@@ -981,7 +1005,7 @@ async fn fetch_compare_rows(
             &sql,
             Some(schema),
             None,
-            QueryExecutionOptions { max_rows: Some(fetch_batch_size), ..Default::default() },
+            QueryExecutionOptions { max_rows: Some(page_size), ..Default::default() },
         )
         .await?;
         let fetched = result.rows.len();
@@ -989,13 +1013,17 @@ async fn fetch_compare_rows(
             break;
         }
         rows.extend(result.rows);
-        if fetched < fetch_batch_size {
+        if rows.len() >= max_rows {
+            truncated = true;
+            break;
+        }
+        if fetched < page_size {
             break;
         }
         offset += fetched;
     }
 
-    Ok(rows)
+    Ok((rows, truncated))
 }
 
 fn where_by_key(

--- a/crates/dbx-core/src/db/agent_driver.rs
+++ b/crates/dbx-core/src/db/agent_driver.rs
@@ -41,11 +41,11 @@ impl AgentLaunchSpec {
         Self { program: program.into(), args: Vec::new(), working_dir: None }
     }
 
-    pub fn java_jar(java_path: impl Into<PathBuf>, jar_path: impl AsRef<Path>) -> Self {
+    pub fn java_jar(java_path: impl Into<PathBuf>, jar_path: impl AsRef<Path>, max_heap: Option<&str>) -> Self {
         let jar_path = jar_path.as_ref();
         Self {
             program: java_path.into(),
-            args: agent_java_args(&jar_path.to_string_lossy()),
+            args: agent_java_args(&jar_path.to_string_lossy(), max_heap),
             working_dir: jar_path.parent().map(Path::to_path_buf),
         }
     }
@@ -1094,7 +1094,7 @@ pub fn mongo_document_id_params(database: &str, collection: &str, id: &str) -> V
     serde_json::json!({ "database": database, "collection": collection, "id": id })
 }
 
-fn agent_java_args(jar_path: &str) -> Vec<String> {
+fn agent_java_args(jar_path: &str, max_heap: Option<&str>) -> Vec<String> {
     let mut args = vec![
         "-Dfile.encoding=UTF-8",
         "-Dsun.stdout.encoding=UTF-8",
@@ -1115,6 +1115,14 @@ fn agent_java_args(jar_path: &str) -> Vec<String> {
     }
 
     args.push("--add-opens=java.sql/java.sql=ALL-UNNAMED".to_string());
+
+    // Cap the JVM heap so a large result set or export inside the agent cannot balloon the
+    // child process to several GB. Invalid/empty values fall back to the conservative default.
+    let heap = max_heap
+        .map(str::trim)
+        .filter(|value| crate::agent_manager::validate_max_heap(value))
+        .unwrap_or(crate::agent_manager::DEFAULT_AGENT_MAX_HEAP);
+    args.push(format!("-Xmx{heap}"));
 
     args.extend(["-XX:TieredStopAtLevel=1", "-XX:+UseSerialGC", "-jar", jar_path].into_iter().map(str::to_string));
 
@@ -1281,7 +1289,7 @@ mod tests {
 
     #[test]
     fn agent_java_args_include_oracle_network_compatibility_flags() {
-        let args = agent_java_args("/tmp/dbx-agent-oracle.jar");
+        let args = agent_java_args("/tmp/dbx-agent-oracle.jar", None);
 
         assert!(args.iter().any(|arg| arg == "-Doracle.net.disableOob=true"));
         assert!(args.iter().any(|arg| arg == "-Doracle.jdbc.javaNetNio=false"));
@@ -1289,14 +1297,14 @@ mod tests {
 
     #[test]
     fn agent_java_args_open_java_sql_for_legacy_timestamp_serializers() {
-        let args = agent_java_args("/tmp/dbx-agent-dameng.jar");
+        let args = agent_java_args("/tmp/dbx-agent-dameng.jar", None);
 
         assert!(args.iter().any(|arg| arg == "--add-opens=java.sql/java.sql=ALL-UNNAMED"));
     }
 
     #[test]
     fn agent_java_args_disable_ambient_proxy_settings() {
-        let args = agent_java_args("/tmp/dbx-agent-opengauss.jar");
+        let args = agent_java_args("/tmp/dbx-agent-opengauss.jar", None);
 
         assert!(args.iter().any(|arg| arg == "-Djava.net.useSystemProxies=false"));
         assert!(args.iter().any(|arg| arg == "-Dhttp.proxyHost="));
@@ -1306,23 +1314,50 @@ mod tests {
 
     #[test]
     fn agent_java_args_prefer_ipv4_for_kingbase() {
-        let args = agent_java_args("/tmp/dbx/drivers/kingbase/agent.jar");
+        let args = agent_java_args("/tmp/dbx/drivers/kingbase/agent.jar", None);
 
         assert!(args.iter().any(|arg| arg == "-Djava.net.preferIPv4Stack=true"));
     }
 
     #[test]
     fn agent_java_args_prefer_ipv4_for_informix() {
-        let args = agent_java_args("/tmp/dbx/drivers/informix/agent.jar");
+        let args = agent_java_args("/tmp/dbx/drivers/informix/agent.jar", None);
 
         assert!(args.iter().any(|arg| arg == "-Djava.net.preferIPv4Stack=true"));
     }
 
     #[test]
     fn agent_java_args_do_not_prefer_ipv4_for_other_agents() {
-        let args = agent_java_args("/tmp/dbx/drivers/highgo/agent.jar");
+        let args = agent_java_args("/tmp/dbx/drivers/highgo/agent.jar", None);
 
         assert!(!args.iter().any(|arg| arg == "-Djava.net.preferIPv4Stack=true"));
+    }
+
+    #[test]
+    fn agent_java_args_applies_default_max_heap_when_unset() {
+        let args = agent_java_args("/tmp/dbx/drivers/dameng/agent.jar", None);
+
+        assert!(args.iter().any(|arg| arg == "-Xmx512m"), "default -Xmx512m must be applied, got {args:?}");
+        // -Xmx must precede -jar so the JVM honors it.
+        let xmx = args.iter().position(|arg| arg == "-Xmx512m");
+        let jar = args.iter().position(|arg| arg == "-jar");
+        assert!(matches!((xmx, jar), (Some(xmx), Some(jar)) if xmx < jar));
+    }
+
+    #[test]
+    fn agent_java_args_respects_custom_max_heap() {
+        let args = agent_java_args("/tmp/dbx/drivers/dameng/agent.jar", Some("1g"));
+
+        assert!(args.iter().any(|arg| arg == "-Xmx1g"));
+        assert!(!args.iter().any(|arg| arg == "-Xmx512m"));
+    }
+
+    #[test]
+    fn agent_java_args_falls_back_to_default_for_invalid_heap() {
+        let args = agent_java_args("/tmp/dbx/drivers/dameng/agent.jar", Some("abc"));
+
+        assert!(args.iter().any(|arg| arg == "-Xmx512m"), "invalid heap must fall back to default");
+        assert!(!args.iter().any(|arg| arg == "-Xmxabc"));
     }
 
     #[test]
@@ -1365,6 +1400,7 @@ mod tests {
         assert!(message.contains("HiveAgent.connect"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn startup_error_waits_briefly_for_exit_status_and_stderr_tail() {
         let mut child = Command::new("sh")

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -28,6 +28,12 @@ use crate::sql::{split_sql_batches, split_sql_statements};
 pub const QUERY_TIMEOUT: Duration = Duration::from_secs(30);
 pub const MAX_ROWS: usize = 10000;
 pub const QUERY_CANCELED: &str = "Query canceled";
+/// Hard byte cap applied to every interactive query result as a final safety net, on top of the
+/// row limit. Catches large BLOB/TEXT rows that `MAX_ROWS` (row count only) would miss. 64 MiB.
+pub const MAX_RESULT_BYTES: usize = 64 * 1024 * 1024;
+/// Upper bound for an explicit query timeout. `Some(0)` (disable) is rejected and `None` uses
+/// the default, so a query can never hang forever under worst-case loads.
+const MAX_QUERY_TIMEOUT_SECS: u64 = 3600;
 #[cfg(feature = "duckdb-bundled")]
 const DUCKDB_INTERRUPT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -626,6 +632,63 @@ pub fn truncate_result_with_max_rows(mut result: db::QueryResult, max_rows: Opti
     result
 }
 
+/// Fast per-cell byte estimate for the result-set byte cap. Reads lengths without allocating for
+/// common scalars; objects/arrays (rare in cells) fall back to their JSON length, capped.
+fn estimate_value_bytes(value: &serde_json::Value) -> usize {
+    match value {
+        serde_json::Value::Null => 4,
+        serde_json::Value::Bool(_) => 5,
+        serde_json::Value::Number(_) => 8,
+        serde_json::Value::String(s) => s.len().saturating_add(2),
+        other => other.to_string().len().min(2048),
+    }
+}
+
+/// Estimate the serialized size of a result's rows, with an early stop once the estimate is far
+/// past any realistic cap so it never becomes a bottleneck on huge results.
+pub fn estimate_result_bytes(result: &db::QueryResult) -> usize {
+    let mut bytes = 0usize;
+    for row in &result.rows {
+        for value in row {
+            bytes = bytes.saturating_add(estimate_value_bytes(value));
+        }
+        if bytes > MAX_RESULT_BYTES.saturating_mul(4) {
+            return bytes;
+        }
+    }
+    bytes
+}
+
+/// Final safety net applied to every query result regardless of driver. Enforces both a row
+/// limit and a byte limit; rows beyond either are dropped and `truncated` is flagged so the UI
+/// can warn. Catches large BLOB/TEXT rows that a pure row-count limit misses.
+pub fn enforce_result_limits(mut result: db::QueryResult, row_limit: usize, byte_limit: usize) -> db::QueryResult {
+    if result.rows.len() > row_limit {
+        result.rows.truncate(row_limit);
+        result.truncated = true;
+    }
+    if byte_limit > 0 {
+        let mut bytes = 0usize;
+        let mut kept = 0usize;
+        for row in &result.rows {
+            let mut row_bytes = 0usize;
+            for value in row {
+                row_bytes = row_bytes.saturating_add(estimate_value_bytes(value));
+            }
+            if bytes.saturating_add(row_bytes) > byte_limit {
+                break;
+            }
+            bytes = bytes.saturating_add(row_bytes);
+            kept += 1;
+        }
+        if kept < result.rows.len() {
+            result.rows.truncate(kept);
+            result.truncated = true;
+        }
+    }
+    result
+}
+
 fn normalize_query_result_for_js(mut result: db::QueryResult) -> db::QueryResult {
     result.rows = result.rows.into_iter().map(|row| row.into_iter().map(db::json_value_for_js).collect()).collect();
     result
@@ -872,8 +935,10 @@ where
 
 fn resolve_query_timeout(timeout_secs: Option<u64>) -> Option<Duration> {
     match timeout_secs {
-        Some(0) => None,
-        Some(n) => Some(Duration::from_secs(n)),
+        // `Some(0)` previously disabled the timeout entirely (unbounded wait). Treat it as the
+        // default so every query always has an upper bound.
+        Some(0) => Some(QUERY_TIMEOUT),
+        Some(n) => Some(Duration::from_secs(n.min(MAX_QUERY_TIMEOUT_SECS))),
         None => Some(QUERY_TIMEOUT),
     }
 }
@@ -906,6 +971,7 @@ pub async fn do_execute(
     cancel_token: Option<CancellationToken>,
     options: QueryExecutionOptions,
 ) -> Result<db::QueryResult, String> {
+    let max_rows_opt = options.max_rows;
     if let Some(execution_id) = options.execution_id.as_deref() {
         state.running_queries.set_pool_key(execution_id, pool_key.to_string());
     }
@@ -1250,7 +1316,9 @@ pub async fn do_execute(
             .map(|result| truncate_result_with_max_rows(result, max_rows))
         }
     };
-    result.map(normalize_query_result_for_js)
+    result
+        .map(|res| enforce_result_limits(res, query_result_row_limit(max_rows_opt), MAX_RESULT_BYTES))
+        .map(normalize_query_result_for_js)
 }
 
 fn external_driver_query_params(
@@ -2360,6 +2428,53 @@ mod tests {
     use super::*;
     use crate::models::connection::{default_redis_key_separator, ConnectionConfig, DatabaseType};
 
+    fn sample_result(rows: usize, cols: usize) -> db::QueryResult {
+        db::QueryResult {
+            columns: (0..cols).map(|i| format!("c{i}")).collect(),
+            column_types: Vec::new(),
+            column_sortables: Vec::new(),
+            rows: (0..rows).map(|r| (0..cols).map(|c| serde_json::json!((r + c) * 10)).collect()).collect(),
+            affected_rows: 0,
+            execution_time_ms: 0,
+            truncated: false,
+            session_id: None,
+            has_more: false,
+        }
+    }
+
+    #[test]
+    fn enforce_result_limits_truncates_by_row_count() {
+        let result = sample_result(10, 3);
+        let enforced = enforce_result_limits(result, 5, 0);
+        assert_eq!(enforced.rows.len(), 5);
+        assert!(enforced.truncated);
+    }
+
+    #[test]
+    fn enforce_result_limits_keeps_all_when_under_limits() {
+        let result = sample_result(3, 2);
+        let enforced = enforce_result_limits(result, 100, MAX_RESULT_BYTES);
+        assert_eq!(enforced.rows.len(), 3);
+        assert!(!enforced.truncated);
+    }
+
+    #[test]
+    fn enforce_result_limits_truncates_by_bytes_for_large_blob_rows() {
+        // Each row holds a single ~1 MiB string; a 3 MiB byte cap must drop most rows.
+        let big = serde_json::Value::String("x".repeat(1024 * 1024));
+        let mut result = sample_result(0, 1);
+        result.rows = vec![vec![big.clone()]; 10];
+        let enforced = enforce_result_limits(result, 100, 3 * 1024 * 1024);
+        assert!(enforced.rows.len() < 10, "byte cap should drop some rows");
+        assert!(enforced.truncated);
+    }
+
+    #[test]
+    fn estimate_result_bytes_is_zero_for_empty_and_positive_otherwise() {
+        assert_eq!(estimate_result_bytes(&sample_result(0, 3)), 0);
+        assert!(estimate_result_bytes(&sample_result(10, 3)) > 0);
+    }
+
     fn test_connection_config(db_type: DatabaseType) -> ConnectionConfig {
         ConnectionConfig {
             id: "conn-1".to_string(),
@@ -2521,15 +2636,17 @@ mod tests {
         assert_eq!(budget.checkout_timeout, Duration::from_secs(12));
         assert_eq!(budget.connect_timeout, Duration::from_secs(12));
         assert_eq!(budget.recycle_timeout, Duration::from_secs(12));
-        assert_eq!(budget.query_timeout, None);
+        assert_eq!(budget.query_timeout, Some(QUERY_TIMEOUT));
         assert_eq!(budget.cancel_timeout, Duration::from_secs(5));
         assert_eq!(budget.cleanup_timeout, Duration::from_secs(3));
     }
 
     #[test]
-    fn db_operation_budget_query_timeout_zero_means_no_limit() {
+    fn db_operation_budget_query_timeout_zero_falls_back_to_default() {
         let budget = DbOperationBudget::from_config(10, Some(0));
-        assert_eq!(budget.query_timeout, None);
+        // `Some(0)` used to disable the timeout (no limit); it now falls back to the default so
+        // every query always has an upper bound under worst-case loads.
+        assert_eq!(budget.query_timeout, Some(QUERY_TIMEOUT));
         // Infrastructure timeouts still have hard limits
         assert_eq!(budget.checkout_timeout, Duration::from_secs(10));
         assert_eq!(budget.cancel_timeout, Duration::from_secs(5));
@@ -2543,7 +2660,7 @@ mod tests {
 
         let budget = DbOperationBudget::from_connection_config(&config);
 
-        assert_eq!(budget.query_timeout, None);
+        assert_eq!(budget.query_timeout, Some(QUERY_TIMEOUT));
         assert_eq!(budget.checkout_timeout, Duration::from_secs(7));
         assert_eq!(budget.recycle_timeout, Duration::from_secs(7));
         assert_eq!(budget.cleanup_timeout, Duration::from_secs(3));

--- a/crates/dbx-core/src/query_result_export.rs
+++ b/crates/dbx-core/src/query_result_export.rs
@@ -25,6 +25,9 @@ use tokio_util::sync::CancellationToken;
 
 const AGENT_UNBOUNDED_ROW_LIMIT: usize = i32::MAX as usize;
 pub const XLSX_MAX_DATA_ROWS: usize = 1_048_575;
+/// Backstop row cap applied to every export format, even when the caller didn't set a row_limit,
+/// so a huge result cannot stream to disk indefinitely. Users can always set a smaller row_limit.
+pub const MAX_EXPORT_ROWS: usize = 1_000_000;
 const XLSX_ROW_LIMIT_ERROR: &str = "XLSX 最多支持 1,048,575 行数据，请改用 CSV 导出完整结果。";
 const STREAMING_PAGINATION_UNSUPPORTED_ERROR: &str = "当前查询暂不支持流式导出，请简化查询或使用受支持的驱动。";
 const AGENT_SESSION_MISSING_ERROR: &str = "查询结果流式导出需要驱动返回结果集会话，但当前驱动未返回 session_id。";
@@ -85,7 +88,8 @@ fn effective_row_limit(format: &str, request: &QueryResultExportRequest) -> Opti
     if format == "xlsx" {
         Some(request.row_limit.map_or(XLSX_MAX_DATA_ROWS, |limit| limit.min(XLSX_MAX_DATA_ROWS)))
     } else {
-        request.row_limit
+        // Backstop: cap exports even when the caller didn't set a row limit.
+        Some(request.row_limit.map_or(MAX_EXPORT_ROWS, |limit| limit.min(MAX_EXPORT_ROWS)))
     }
 }
 
@@ -714,8 +718,9 @@ mod tests {
     }
 
     #[test]
-    fn csv_unlimited_export_has_no_effective_row_limit() {
-        assert_eq!(effective_row_limit("csv", &request("csv", None, None)), None);
+    fn csv_export_without_row_limit_uses_backend_backstop() {
+        // CSV now has a backend backstop row cap so a huge result cannot stream indefinitely.
+        assert_eq!(effective_row_limit("csv", &request("csv", None, None)), Some(MAX_EXPORT_ROWS));
     }
 
     #[test]

--- a/crates/dbx-core/tests/agent_service.rs
+++ b/crates/dbx-core/tests/agent_service.rs
@@ -149,7 +149,11 @@ fn agent_list_does_not_mark_jre_update_for_system_java_runtime() {
     std::fs::write(&jar_path, b"jar").unwrap();
     manager
         .save_state(&dbx_core::agent_manager::AgentState {
-            java_runtime: JavaRuntimeConfig { mode: JavaRuntimeMode::System, custom_java_path: None },
+            java_runtime: JavaRuntimeConfig {
+                mode: JavaRuntimeMode::System,
+                custom_java_path: None,
+                ..Default::default()
+            },
             installed_drivers: [(
                 "dameng".to_string(),
                 InstalledDriver {

--- a/crates/dbx-core/tests/live_sqlserver_completion.rs
+++ b/crates/dbx-core/tests/live_sqlserver_completion.rs
@@ -97,7 +97,7 @@ async fn live_sqlserver_table_structure_default_changes_drop_existing_constraint
     let user = std::env::var("DBX_LIVE_SQLSERVER_USER").unwrap_or_else(|_| "sa".to_string());
     let password = std::env::var("DBX_LIVE_SQLSERVER_PASSWORD").expect("DBX_LIVE_SQLSERVER_PASSWORD");
     let mut client =
-        dbx_core::db::sqlserver::connect(&host, port, &user, &password, Some(&database), Duration::from_secs(10))
+        dbx_core::db::sqlserver::connect(&host, port, &user, &password, Some(&database), None, Duration::from_secs(10))
             .await
             .expect("connect SQL Server");
 

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -42,7 +42,7 @@ function withMockLocalStorage(initial: Record<string, string>, run: () => void) 
 test("normalizes saved query result page size", () => {
   assert.equal(DEFAULT_EDITOR_SETTINGS.pageSize, 100);
   assert.equal(normalizeEditorSettings({ pageSize: 5000 }).pageSize, 5000);
-  assert.equal(normalizeEditorSettings({ pageSize: 200000 }).pageSize, 100000);
+  assert.equal(normalizeEditorSettings({ pageSize: 200000 }).pageSize, 50000);
   assert.equal(normalizeEditorSettings({ pageSize: 0 }).pageSize, 100);
 });
 
@@ -79,14 +79,14 @@ test("keeps a manually saved 10000 export batch size after migration", () => {
 });
 
 test("defaults query-result export row limit settings", () => {
-  assert.equal(DEFAULT_EDITOR_SETTINGS.exportRowLimitEnabled, false);
+  assert.equal(DEFAULT_EDITOR_SETTINGS.exportRowLimitEnabled, true);
   assert.equal(DEFAULT_EDITOR_SETTINGS.exportRowLimit, 100000);
   assert.equal(DEFAULT_EDITOR_SETTINGS.queryExportKeysetOptimizationEnabled, true);
-  assert.equal(normalizeEditorSettings({}).exportRowLimitEnabled, false);
+  assert.equal(normalizeEditorSettings({}).exportRowLimitEnabled, true);
   assert.equal(normalizeEditorSettings({}).exportRowLimit, 100000);
   assert.equal(normalizeEditorSettings({}).queryExportKeysetOptimizationEnabled, true);
   assert.equal(normalizeEditorSettings({ exportRowLimitEnabled: true }).exportRowLimitEnabled, true);
-  assert.equal(normalizeEditorSettings({ exportRowLimitEnabled: "nope" as any }).exportRowLimitEnabled, false);
+  assert.equal(normalizeEditorSettings({ exportRowLimitEnabled: "nope" as any }).exportRowLimitEnabled, true);
   assert.equal(normalizeEditorSettings({ exportRowLimit: 250000 }).exportRowLimit, 250000);
   assert.equal(normalizeEditorSettings({ exportRowLimit: 10 }).exportRowLimit, 100000);
   assert.equal(normalizeEditorSettings({ queryExportKeysetOptimizationEnabled: false }).queryExportKeysetOptimizationEnabled, false);

--- a/packages/app-tests/useDataGridExport.test.ts
+++ b/packages/app-tests/useDataGridExport.test.ts
@@ -556,7 +556,7 @@ test("cancelled query result CSV export clears the cancel handler without using 
   assert.equal(exportCancelHandler.value, null);
 });
 
-test("table data export leaves row limit unset by default", async () => {
+test("table data export applies default row limit", async () => {
   const restoreStorage = installMemoryStorage();
   try {
     const { composable } = buildTableDataExportHarness();
@@ -564,7 +564,8 @@ test("table data export leaves row limit unset by default", async () => {
     await composable.exportCsv();
 
     assert.equal(apiMock.startTableExport.mock.calls.length, 1);
-    assert.equal(apiMock.startTableExport.mock.calls[0][0].rowLimit, null);
+    // exportRowLimitEnabled now defaults to true with a 100000 row backstop.
+    assert.equal(apiMock.startTableExport.mock.calls[0][0].rowLimit, 100000);
   } finally {
     restoreStorage();
   }

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use tauri::{Emitter, State};
 
-use dbx_core::agent_manager::{AgentDriverInfo, DriverStoreUsage, JavaRuntimeConfig, JavaRuntimeMode, DEFAULT_JRE_KEY};
+use dbx_core::agent_manager::{
+    validate_max_heap, AgentDriverInfo, DriverStoreUsage, JavaRuntimeConfig, JavaRuntimeMode, DEFAULT_JRE_KEY,
+};
 use dbx_core::agent_service::{
     build_agent_list, fetch_registry, import_agent_jar, import_agents_from_zip as import_agents_from_zip_core,
     install_agent_driver, invalidate_registry_cache, reinstall_agent_jre, uninstall_agent_driver, uninstall_agent_jre,
@@ -103,6 +105,20 @@ pub async fn set_agent_java_runtime_config(
     mut config: JavaRuntimeConfig,
 ) -> Result<JavaRuntimeConfig, String> {
     let am = &state.agent_manager;
+    // Validate + normalize the JVM max heap before persisting. Empty values clear the override
+    // (launch falls back to the default); invalid values are rejected with a clear message.
+    config.max_heap = match config.max_heap.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(heap) => {
+            if validate_max_heap(heap) {
+                Some(heap.to_string())
+            } else {
+                return Err(format!(
+                    "Invalid Java agent max heap '{heap}'. Use a positive integer with a k/m/g unit, e.g. 512m, 1g, 2048k."
+                ));
+            }
+        }
+    };
     if config.mode == JavaRuntimeMode::Custom || config.mode == JavaRuntimeMode::System {
         let candidate_state = dbx_core::agent_manager::AgentState { java_runtime: config.clone(), ..am.load_state() };
         let resolved = am.resolve_java_runtime(&candidate_state, DEFAULT_JRE_KEY)?;


### PR DESCRIPTION
针对实际反馈(单个 DBX 会话 java agent 约 4.5GB、WebView 约 4.6GB)做最坏情况内存兜底,覆盖所有数据库类型(原生 + agent/JDBC),不依赖用户手动配置环境变量。

第一层 — Java agent 堆上限(所有 JDBC/agent 库):
- agent_java_args 启动时强制注入 -Xmx(默认 512m),非法值回退默认
- JavaRuntimeConfig.max_heap 可配置,DriverStoreDialog 新增「最大堆内存」输入框,保存即 stop_daemons 重启 JVM
- native/Go agent(oracle-go、xugu)走旁路,不受影响

第二层 — 后端结果集硬上限(所有类型):
- enforce_result_limits 在 do_execute 全类型汇合点:行数 + 字节(64MB)双截断,防大 BLOB 行
- resolve_query_timeout 禁止 Some(0)(原为无限挂起),封顶 3600s
- data_compare:20 万行预检 + 50 万行 fetch 上限,启用预留的 source_truncated/target_truncated
- 导出 MAX_EXPORT_ROWS=100万 后端硬上限

第三层 — 前端大数据量兜底:
- 结果缓存按 300MB 字节预算 + tab 数双上限淘汰(原只数 tab)
- 大结果(50MB/10万行)主动 toast 告警
- page size 硬顶 10万→5万,导出默认开 row limit(10万)
- QueryChart 加 5000 点采样

