### PR TITLE
Fix：修复左侧运行多条 SQL 只执行首条

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -335,15 +335,20 @@ function handleTab(view: EditorViewType): boolean {
   return true;
 }
 
-function requestExecute(options: { forceCurrent?: boolean } = {}) {
+interface RequestExecuteOptions {
+  forceCurrent?: boolean;
+  ignoreSelection?: boolean;
+}
+
+function requestExecute(options: RequestExecuteOptions = {}) {
   const currentView = view.value;
   if (!currentView) return false;
   return requestExecuteFromView(currentView, currentView.state.selection.main.head, options);
 }
 
-function requestExecuteFromView(currentView: EditorViewType, cursorPos: number, options: { forceCurrent?: boolean } = {}) {
+function requestExecuteFromView(currentView: EditorViewType, cursorPos: number, options: RequestExecuteOptions = {}) {
   const selection = currentView.state.selection.main;
-  if (!selection.empty) {
+  if (!options.ignoreSelection && !selection.empty) {
     // Has manual selection → execute directly, skip picker.
     emit("execute", sqlExecutionSnapshotFromView(currentView));
     return true;
@@ -524,7 +529,7 @@ function executeSqlStatementFromGutter(currentView: EditorViewType, line: { from
   if (!statementRange) return false;
   event.preventDefault();
   event.stopPropagation();
-  emit("execute", statementRange.sql);
+  requestExecuteFromView(currentView, line.from, { ignoreSelection: true });
   currentView.focus();
   return true;
 }


### PR DESCRIPTION
## 问题原因

左侧 gutter 运行按钮会直接取点击行开头的单条 SQL 并触发执行，绕过了编辑器已有的执行目标解析逻辑。用户粘贴多条 `ALTER TABLE ... ADD COLUMN ...` 后，从第一行左侧按钮执行时，前端只把第一条 ALTER 传给后端，所以最终只有第一个字段生效。

## 修改内容

- 将 gutter 运行入口接回统一的执行目标解析流程，复用“执行全部/执行当前/执行目标选择器”的现有设置。
- gutter 点击时忽略编辑器中已有选区，确保以点击行作为执行目标定位点。

## 验证

- `pnpm typecheck`
- `pnpm test -- apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts`
- `pnpm lint apps/desktop/src/components/editor/QueryEditor.vue`
- `pnpm build`

Fixes #2255