### PR TITLE
Fix: Prioritize Navicat ConnType When Importing Connections

### DIFF
--- a/apps/desktop/src/lib/__tests__/navicatImport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/navicatImport.spec.ts
@@ -84,4 +84,17 @@ describe("parseNavicatConnections", () => {
     expect(connection?.database).toBe("appdb");
     expect(connection?.port).toBe(15432);
   });
+
+  it("prefers Navicat ConnType over Redis deployment Type", async () => {
+    const [connection] = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="[Sealos] dev-redis-01" ConnType="REDIS" ServiceProvider="Default" Type="Standalone" Host="dbconn.sealosgzg.site" Port="46836" AuthenticationMode="UsernamePassword" UserName="default" />
+</Connections>`);
+
+    expect(connection?.db_type).toBe("redis");
+    expect(connection?.driver_profile).toBe("redis");
+    expect(connection?.name).toBe("[Sealos] dev-redis-01");
+    expect(connection?.host).toBe("dbconn.sealosgzg.site");
+    expect(connection?.port).toBe(46836);
+    expect(connection?.username).toBe("default");
+  });
 });

--- a/apps/desktop/src/lib/navicatImport.ts
+++ b/apps/desktop/src/lib/navicatImport.ts
@@ -146,7 +146,7 @@ function valuesFromElement(element: Element) {
 }
 
 function isConnectionCandidate(node: ParsedNode) {
-  const type = getAny(node.values, ["type", "connType", "connectionType", "databaseType", "driver"]);
+  const type = getAny(node.values, ["connType", "databaseType", "driver", "connectionType", "type"]);
   const name = getAny(node.values, ["name", "connectionName", "connName", "caption", "title"]);
   const host = getAny(node.values, ["host", "server", "hostname", "serverHost", "address"]);
   const file = getSqlitePath(node.values);
@@ -154,7 +154,7 @@ function isConnectionCandidate(node: ParsedNode) {
 }
 
 async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | null> {
-  const rawType = getAny(node.values, ["type", "connType", "connectionType", "databaseType", "driver", "dbType"]);
+  const rawType = getAny(node.values, ["connType", "databaseType", "driver", "dbType", "connectionType", "type"]);
   const portValue = Number(getAny(node.values, ["port", "serverPort"]));
   const port = Number.isFinite(portValue) && portValue > 0 ? portValue : undefined;
   const profile = inferProfile(rawType, node.tag, port);


### PR DESCRIPTION
## BUG 原因

Navicat Redis 导出的 `.ncx` 中同时存在：

```xml
ConnType="REDIS"
Type="Standalone"
```

原解析逻辑优先读取通用 `Type` 字段，导致连接类型被识别为 `Standalone`，无法匹配 `redis` 类型映射，最终被跳过，界面显示“没有新的连接需要导入”。

## 复现

1. 使用包含 `ConnType="REDIS"` 与 `Type="Standalone"` 的 Navicat `.ncx` 文件。
2. 在侧边栏选择导入 Navicat NCX。
3. 选择该文件。
4. 导入结果显示“没有新的连接需要导入”。

关键复现字段：

```xml
<Connection
  ConnectionName="[Sealos] dev-redis-01"
  ConnType="REDIS"
  Type="Standalone"
  Host="redis.example.com"
  Port="6379"
/>
```

## 修复思路

Navicat 的数据库类型应以 `ConnType` 为优先来源。`Type` 在 Redis 导出中表示部署模式，如 `Standalone`，不是数据库类型。

## 实现

- 调整 `apps/desktop/src/lib/navicatImport.ts` 的类型字段读取顺序。
- 连接候选判断优先读取 `connType`。
- 实际解析类型优先读取 `connType`。
- 将 `type` 降级为最后兜底字段。
- 新增 `apps/desktop/src/lib/__tests__/navicatImport.spec.ts` 回归测试。
- 覆盖 `ConnType="REDIS"` + `Type="Standalone"` 场景。
- 校验 Redis 连接的名称、host、port、username 映射。

## 变更文件

- `apps/desktop/src/lib/navicatImport.ts`
- `apps/desktop/src/lib/__tests__/navicatImport.spec.ts`