### PR TITLE
Chore: 将 Oracle agent 版本提升到 0.1.30

### DIFF
--- a/agents/versions.json
+++ b/agents/versions.json
@@ -18,7 +18,7 @@
   "kylin": "0.1.25",
   "neo4j": "0.1.25",
   "oceanbase-oracle": "0.1.20",
-  "oracle": "0.1.29",
+  "oracle": "0.1.30",
   "snowflake": "0.1.25",
   "saphana": "0.1.20",
   "sundb": "0.1.25",


### PR DESCRIPTION
## 变更

- 将 Oracle agent 版本从 `0.1.29` 提升到 `0.1.30`

## 背景

之前 Oracle 注释开头查询的修复已经进入 agent 代码，但远端 registry 仍然使用 `0.1.29`。已安装旧 `0.1.29` 的客户端不会识别到可更新，可能继续运行旧的 Oracle agent。

这次 bump 版本用于触发后续 agents release 生成新的 registry，让客户端能正常提示并安装包含修复的 Oracle agent。

## 验证

- `python3 -m json.tool agents/versions.json >/dev/null`