### PR TITLE
fix(app): 修复可见对象过滤器候选列表

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -38,7 +38,7 @@ import { SQLITE_DATABASE_FILE_EXTENSIONS } from "@/lib/databaseFileDetection";
 import { connectionAttemptOriginalErrorMessage, connectionAttemptTimeoutMessage, connectionAttemptTimeoutMs } from "@/lib/connectionAttemptTimeout";
 import { ArrowLeft, ArrowDown, ArrowUp, CheckSquare, ChevronRight, CircleHelp, Copy, ExternalLink, FilePlus2, FolderOpen, GripVertical, Grid3X3, KeyRound, Link2, List, ListFilter, Loader2, Pipette, Plus, Search, ShieldCheck, Square, Trash2 } from "@lucide/vue";
 import { buildDraftVisibleDatabasesConnectionId, connectionCanChooseVisibleDatabases, initialVisibleDatabaseSelection, visibleDatabaseSelectionIsStale } from "@/lib/connectionVisibleDatabases";
-import { canSaveVisibleDatabaseSelection, connectionUsesVisibleSchemaFilter, filterDatabaseNamesForConnection, isSystemDatabaseName, normalizeVisibleDatabaseSelection, buildDraftVisibleSchemasConnectionId, normalizeVisibleSchemaSelection } from "@/lib/visibleDatabases";
+import { canSaveVisibleDatabaseSelection, connectionUsesVisibleSchemaFilter, filterDatabaseNamesForVisiblePicker, isSystemDatabaseName, normalizeVisibleDatabaseSelection, buildDraftVisibleSchemasConnectionId, normalizeVisibleSchemaSelection } from "@/lib/visibleDatabases";
 import { isSchemaAware } from "@/lib/databaseFeatureSupport";
 import VisibleSchemasDialog from "@/components/sidebar/VisibleSchemasDialog.vue";
 import { oceanbaseModeConnectionPatch, oceanbaseSubModeFromConfig } from "@/lib/oceanbaseConnectionMode";
@@ -1582,7 +1582,7 @@ const listedVisibleDatabaseNames = computed(() => {
   if (visibleFilterUsesSchemas.value) return visibleDatabaseNames.value;
   const connection = connectionConfigSnapshotForVisibleDatabases();
   if (visibleDatabaseShowSystem.value) return visibleDatabaseNames.value;
-  return filterDatabaseNamesForConnection(visibleDatabaseNames.value, connection);
+  return filterDatabaseNamesForVisiblePicker(visibleDatabaseNames.value, connection);
 });
 const filteredVisibleDatabaseNames = computed(() => {
   const query = visibleDatabaseSearchText.value.trim().toLowerCase();

--- a/apps/desktop/src/components/sidebar/VisibleDatabasesDialog.vue
+++ b/apps/desktop/src/components/sidebar/VisibleDatabasesDialog.vue
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useConnectionStore } from "@/stores/connectionStore";
-import { canSaveVisibleDatabaseSelection, connectionUsesVisibleSchemaFilter, filterDatabaseNamesForConnection, isSystemDatabaseName, normalizeVisibleDatabaseSelection } from "@/lib/visibleDatabases";
+import { canSaveVisibleDatabaseSelection, connectionUsesVisibleSchemaFilter, filterDatabaseNamesForVisiblePicker, isSystemDatabaseName, normalizeVisibleDatabaseSelection } from "@/lib/visibleDatabases";
 import * as api from "@/lib/api";
 
 const props = defineProps<{
@@ -43,7 +43,7 @@ const loadFailedKey = computed(() => (isSchemaFilterMode.value ? "visibleSchemas
 const listedObjectNames = computed(() => {
   if (isSchemaFilterMode.value) return objectNames.value;
   if (showSystemDatabases.value) return objectNames.value;
-  return filterDatabaseNamesForConnection(objectNames.value, connection.value);
+  return filterDatabaseNamesForVisiblePicker(objectNames.value, connection.value);
 });
 const filteredObjectNames = computed(() => {
   const query = searchText.value.trim().toLowerCase();

--- a/apps/desktop/src/lib/connectionVisibleDatabases.ts
+++ b/apps/desktop/src/lib/connectionVisibleDatabases.ts
@@ -1,5 +1,5 @@
 import type { ConnectionConfig, DatabaseType } from "@/types/database";
-import { filterDatabaseNamesForConnection, normalizeVisibleDatabaseSelection } from "@/lib/visibleDatabases";
+import { filterDatabaseNamesForVisiblePicker, normalizeVisibleDatabaseSelection } from "@/lib/visibleDatabases";
 
 const DRAFT_VISIBLE_DATABASES_PREFIX = "__visible_draft_";
 
@@ -22,7 +22,7 @@ export function initialVisibleDatabaseSelection(databaseNames: string[], visible
   if (Array.isArray(visibleDatabases)) {
     return normalizeVisibleDatabaseSelection(visibleDatabases, databaseNames);
   }
-  return filterDatabaseNamesForConnection(databaseNames, connection);
+  return filterDatabaseNamesForVisiblePicker(databaseNames, connection);
 }
 
 export function visibleDatabaseSelectionIsStale(previous: VisibleDatabaseConnectionFields, current: VisibleDatabaseConnectionFields): boolean {

--- a/apps/desktop/src/lib/visibleDatabases.ts
+++ b/apps/desktop/src/lib/visibleDatabases.ts
@@ -93,6 +93,10 @@ export function filterDatabaseNamesForConnection(databaseNames: string[], connec
   if (visibleDatabaseFilterIsEnabled(visibleDatabases)) {
     return filterVisibleDatabaseNames(databaseNames, visibleDatabases);
   }
+  return filterDatabaseNamesForVisiblePicker(databaseNames, connection);
+}
+
+export function filterDatabaseNamesForVisiblePicker(databaseNames: string[], connection: Pick<ConnectionConfig, "db_type" | "driver_profile"> | undefined): string[] {
   if (connection?.db_type === "gbase" && connection.driver_profile === "gbase8s") {
     return databaseNames;
   }

--- a/packages/app-tests/connectionVisibleDatabases.test.ts
+++ b/packages/app-tests/connectionVisibleDatabases.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { buildDraftVisibleDatabasesConnectionId, connectionCanChooseVisibleDatabases, visibleDatabaseSelectionIsStale, initialVisibleDatabaseSelection } from "../../apps/desktop/src/lib/connectionVisibleDatabases.ts";
-import { connectionUsesVisibleSchemaFilter, filterDatabaseNamesForConnection } from "../../apps/desktop/src/lib/visibleDatabases.ts";
+import { connectionUsesVisibleSchemaFilter, filterDatabaseNamesForConnection, filterDatabaseNamesForVisiblePicker } from "../../apps/desktop/src/lib/visibleDatabases.ts";
 import type { ConnectionConfig } from "../../apps/desktop/src/types/database.ts";
 
 function config(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
@@ -47,6 +47,24 @@ test("initial selection uses configured visible databases when available", () =>
 
 test("initial selection uses default visible database names when no filter is configured", () => {
   assert.deepEqual(initialVisibleDatabaseSelection(["app", "mysql", "sys"], undefined, config()), ["app"]);
+});
+
+test("visible database picker ignores saved filters while keeping default system database hiding", () => {
+  const databaseNames = ["app", "analytics", "mysql", "sys"];
+  const connection = config({ visible_databases: ["app"] });
+  assert.deepEqual(filterDatabaseNamesForVisiblePicker(databaseNames, connection), ["app", "analytics"]);
+  assert.deepEqual(initialVisibleDatabaseSelection(databaseNames, connection.visible_databases, connection), ["app"]);
+});
+
+test("Redis visible database picker keeps every database and initial selection uses saved filters", () => {
+  const databaseNames = ["0", "1", "2"];
+  const connection = config({ db_type: "redis", driver_profile: "redis", visible_databases: ["0"] });
+  assert.deepEqual(filterDatabaseNamesForVisiblePicker(databaseNames, connection), ["0", "1", "2"]);
+  assert.deepEqual(initialVisibleDatabaseSelection(databaseNames, connection.visible_databases, connection), ["0"]);
+});
+
+test("connection database filtering still applies saved visible database filters for sidebar display", () => {
+  assert.deepEqual(filterDatabaseNamesForConnection(["app", "analytics", "mysql", "sys"], config({ visible_databases: ["app"] })), ["app"]);
 });
 
 test("ZooKeeper connections do not offer visible database selection", () => {


### PR DESCRIPTION
## 说明

修复 #2272：可见对象过滤器已保存配置后，再次打开编辑弹窗时只显示已勾选对象，导致无法重新选择未勾选对象的问题。

本次调整后，过滤器编辑弹窗始终加载当前连接可用对象全集；已保存的 `visible_databases` / `visible_schemas` 只影响初始勾选状态，不再影响候选列表。

## 主要改动

- 新增 picker 专用的数据库名称过滤 helper，忽略已保存的 `visible_databases`，但保留默认隐藏系统库规则。
- 右键连接打开的可见对象弹窗改用 picker 语义加载候选列表。
- 新建/编辑连接表单里的可见对象选择弹窗改用 picker 语义加载候选列表。
- 保持侧边栏 / tree 展示过滤行为不变，已配置 visible filter 时仍只展示已选对象。
- 补充 MySQL、Redis 以及 sidebar 展示语义的回归测试。

## 验证

- `CI=true pnpm exec vitest run packages/app-tests/connectionVisibleDatabases.test.ts`
- `git diff --check`
- `CI=true pnpm check`
