### PR TITLE
fix(driver): hide uninstall action for uninstalled PrestoSQL

### DIFF
--- a/apps/desktop/src/components/config/DriverStoreDialog.vue
+++ b/apps/desktop/src/components/config/DriverStoreDialog.vue
@@ -1151,7 +1151,7 @@ watch(driverStoreTab, (tab) => {
                   >
                     <FileUp class="h-3.5 w-3.5" />
                   </Button>
-                  <template v-else>
+                  <template v-if="driver.installed">
                     <Check v-if="!(driver.update_available && isDriverProgressActive(driver.db_type))" class="h-4 w-4 text-green-600" />
                     <Button
                       v-if="driver.update_available && isDriverQueued(driver.db_type)"


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

Fix PrestoSQL driver actions when not installed

## Summary

This PR fixes the driver management UI for the built-in PrestoSQL driver.

Previously, when PrestoSQL was not installed, the row could show both the **Install** and **Uninstall** actions at the same time. This happened because the installed-state action template was tied to the `v-else` branch of the local JAR import button, rather than being explicitly gated by the driver's installed state.

## Changes

- Update the driver action rendering logic in `DriverStoreDialog.vue`
- Only render the installed-state actions when `driver.installed` is `true`
- Prevent the PrestoSQL row from showing the uninstall action before installation

## Why

PrestoSQL is handled as a built-in JDBC driver and does not use the local JAR import action. Because the import button is hidden for PrestoSQL, the previous `v-else` branch incorrectly rendered the installed-state actions even when the driver was not installed.

## Testing

- Verified the changed conditional rendering logic
- Ran `git diff --check` for the modified file
- Commit hook ran `oxfmt` successfully

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="970" height="950" alt="fbafc334-2e32-43fb-8104-19804b3de967" src="https://github.com/user-attachments/assets/b956ff90-681b-4d0e-af2e-d40f272c89ad" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2306 