### PR TITLE
fix: add MongoDB data transfer entry

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -4069,6 +4069,10 @@ function treeItemMenuItems(): ContextMenuItem[] {
     } else {
       items.push({ label: t("contextMenu.clearDefaultDatabase"), action: clearNodeDefaultDatabase, icon: Database });
     }
+    if (node.type === "mongo-db") {
+      items.push({ label: "", separator: true });
+      items.push({ label: t("transfer.dataTransfer"), action: openTransfer, icon: ArrowRightLeft });
+    }
     if (node.type === "redis-db") {
       items.push({ label: "", separator: true });
       items.push({ label: t("redis.flushDb"), action: flushRedisDb, icon: Eraser, variant: "destructive" as const });


### PR DESCRIPTION
## 变更说明

- 为 MongoDB 数据库节点的右键菜单补上“数据传输”入口
- 复用现有 `openTransfer` 逻辑，避免 MongoDB 菜单与普通数据库菜单能力不一致
- 修复 MongoDB 右键菜单缺少数据传输按钮的问题

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）
<img width="279" height="242" alt="截屏2026-07-02 09 17 55" src="https://github.com/user-attachments/assets/abdf93dc-4a99-4f65-83e1-c24d4250eee1" />



## 验证


- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：
- `pnpm test:packages`
- `pnpm publish:dry-run`
- `cargo fmt --check`
- `cargo clippy --workspace --locked --all-targets`
- `cargo test --workspace --locked`

## 关联 Issue

- None
