### PR TITLE
✨feat(connection): 复制连接时保持在同一组内

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1458,7 +1458,7 @@ async function duplicateConnection() {
   const config = connectionStore.getConfig(connId);
   if (!config) return;
   const newConfig = { ...config, id: uuid(), name: `${config.name} (Copy)` };
-  await connectionStore.addConnection(newConfig);
+  await connectionStore.addConnection(newConfig, connectionStore.groupIdForConnection(connId));
   toast(t("connection.duplicated"), 2000);
 }
 

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -9,6 +9,7 @@ import {
   emptyLayout,
   appendConnectionToLayout,
   removeConnectionFromSidebarLayout,
+  findConnectionLocation,
   createGroup as createGroupOp,
   renameGroup as renameGroupOp,
   deleteGroup as deleteGroupOp,
@@ -994,7 +995,7 @@ export const useConnectionStore = defineStore("connection", () => {
     if (scope === "root") rebuildTreeNodes();
   }
 
-  async function addConnection(config: ConnectionConfig) {
+  async function addConnection(config: ConnectionConfig, targetGroupId?: string | null) {
     const normalized = normalizeConnection(config);
     const existing = connections.value.findIndex((c) => c.id === normalized.id);
     const nextConnections = [...connections.value];
@@ -1002,7 +1003,8 @@ export const useConnectionStore = defineStore("connection", () => {
       nextConnections[existing] = normalized;
     } else {
       nextConnections.push(normalized);
-      sidebarLayout.value = appendConnectionToLayout(sidebarLayout.value, normalized.id, newConnectionGroupId.value);
+      const groupId = targetGroupId !== undefined ? targetGroupId : newConnectionGroupId.value;
+      sidebarLayout.value = appendConnectionToLayout(sidebarLayout.value, normalized.id, groupId);
     }
     await persistConnections(nextConnections);
     connections.value = nextConnections;
@@ -4056,6 +4058,9 @@ export const useConnectionStore = defineStore("connection", () => {
     },
     moveConnectionToGroup(connectionId: string, groupId: string | null) {
       updateLayoutAndRebuild(moveConnectionToGroupOp(sidebarLayout.value, connectionId, groupId));
+    },
+    groupIdForConnection(connectionId: string): string | null {
+      return findConnectionLocation(sidebarLayout.value, connectionId)?.groupId ?? null;
     },
     reorderSidebarEntry(draggedId: string, targetId: string, position: DropPosition) {
       updateLayoutAndRebuild(reorderEntryOp(sidebarLayout.value, draggedId, targetId, position));

--- a/packages/app-tests/connectionStoreGroupedConnect.test.ts
+++ b/packages/app-tests/connectionStoreGroupedConnect.test.ts
@@ -100,6 +100,59 @@ test("connecting a grouped connection updates it in place instead of adding a ro
   }
 });
 
+test("duplicating a grouped connection keeps the copy in the same group", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = installMemoryStorage();
+  const originalConnection = conn("conn-1", "Grouped MySQL");
+  let savedConnections: ConnectionConfig[] = [originalConnection];
+  let savedLayout: SidebarLayout | null = {
+    groups: [{ id: "group-1", name: "Group", collapsed: false }],
+    order: [{ type: "group", id: "group-1", connectionIds: ["conn-1"] }],
+  };
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url === "/api/connection/list") {
+      return new Response(JSON.stringify(savedConnections), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/layout/sidebar") {
+      if (init?.method === "POST") {
+        savedLayout = JSON.parse(String(init.body ?? "null"));
+        return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify(savedLayout), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/connection/save") {
+      savedConnections = JSON.parse(String(init?.body ?? "[]"));
+      return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    setActivePinia(createPinia());
+    const store = useConnectionStore();
+    await store.initFromDisk();
+
+    const copy = { ...originalConnection, id: "conn-copy", name: "Grouped MySQL (Copy)" };
+    await store.addConnection(copy, store.groupIdForConnection(originalConnection.id));
+
+    assert.deepEqual(
+      store.treeNodes.map((node) => node.id),
+      ["group-1"],
+    );
+    assert.equal(store.treeNodes[0].type, "connection-group");
+    assert.deepEqual(
+      store.treeNodes[0].children?.map((node) => node.id),
+      ["conn-1", "conn-copy"],
+    );
+    assert.equal(countConnectionNodes(store.treeNodes, "conn-copy"), 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    storage.restore();
+  }
+});
+
 test("importing grouped dbx connections remaps exported layout to new connection ids", async () => {
   const originalFetch = globalThis.fetch;
   const storage = installMemoryStorage();


### PR DESCRIPTION
- 修复文件夹下复制连接，复制到跟目录下的问题

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="264" height="132" alt="image" src="https://github.com/user-attachments/assets/15872796-c0ab-49a4-91e0-76fae219d4a2" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2350