### PR TITLE
✨feat(connection): 添加子组时支持定义组名称

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -447,9 +447,12 @@ function clearSidebarSelection() {
 
 async function createNewGroup() {
   const groupId = store.createConnectionGroup(t("connectionGroup.newGroupDefault"));
+  await startRenamingCreatedGroup(groupId);
+}
+
+async function startRenamingCreatedGroup(groupId: string) {
   pendingRenameGroupId.value = groupId;
   store.selectedTreeNodeId = groupId;
-
   if (isFiltering.value) {
     searchQuery.value = "";
     deferredSearchQuery.value = "";
@@ -921,7 +924,16 @@ defineExpose({ focusSearch, createNewGroup });
         flow-mode
       >
         <template #default="{ item }">
-          <TreeItem :node="item.node" :depth="item.depth" :drag-disabled="isFiltering" :pending-rename="pendingRenameGroupId === item.node.id" :highlighted="highlightedNodeId === item.node.id" @search-toggle="onSearchToggle" @rename-started="pendingRenameGroupId = null" />
+          <TreeItem
+            :node="item.node"
+            :depth="item.depth"
+            :drag-disabled="isFiltering"
+            :pending-rename="pendingRenameGroupId === item.node.id"
+            :highlighted="highlightedNodeId === item.node.id"
+            @search-toggle="onSearchToggle"
+            @rename-started="pendingRenameGroupId = null"
+            @group-created="startRenamingCreatedGroup"
+          />
         </template>
       </RecycleScroller>
       <div v-if="stickyNode" class="sticky-database-header pointer-events-auto absolute inset-x-0 top-0 z-[5] border-b border-border/60" :style="stickyHeaderStyle">
@@ -943,6 +955,7 @@ defineExpose({ focusSearch, createNewGroup });
           :highlighted="highlightedNodeId === item.id"
           @search-toggle="onSearchToggle"
           @rename-started="pendingRenameGroupId = null"
+          @group-created="startRenamingCreatedGroup"
         />
       </div>
       <div v-if="hasSidebarVerticalOverflow" ref="sidebarScrollbarTrackRef" class="sidebar-tree-scrollbar" :class="{ 'sidebar-tree-scrollbar--scrolling': isScrollingSidebar, 'sidebar-tree-scrollbar--dragging': isDraggingSidebarScrollbar }" @pointerdown="onSidebarScrollbarTrackPointerDown">

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -176,6 +176,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   "rename-started": [];
+  "group-created": [groupId: string];
   "node-toggled": [node: TreeNode, wasExpanded: boolean];
   "search-toggle": [node: TreeNode];
 }>();
@@ -3522,6 +3523,7 @@ function newConnectionInGroup() {
 function newSubgroup() {
   const groupId = connectionStore.createConnectionGroup(t("connectionGroup.newGroupDefault"), props.node.id);
   connectionStore.selectedTreeNodeId = groupId;
+  emit("group-created", groupId);
 }
 
 function confirmDeleteGroup() {

--- a/apps/desktop/src/lib/sidebarLayout.ts
+++ b/apps/desktop/src/lib/sidebarLayout.ts
@@ -248,11 +248,13 @@ export function createGroup(layout: SidebarLayout, name: string, parentGroupId?:
   const group: ConnectionGroup = { id: groupId, name, collapsed: false };
   const order = cloneEntries(layout.order);
   const entry: SidebarOrderEntry = { type: "group", id: groupId, children: [] };
+  let parentFound = false;
 
   if (parentGroupId) {
     const parent = findGroupEntry(order, parentGroupId);
     if (parent) {
       parent.children = [...(parent.children ?? []), entry];
+      parentFound = true;
     } else {
       order.push(entry);
     }
@@ -263,7 +265,7 @@ export function createGroup(layout: SidebarLayout, name: string, parentGroupId?:
   return {
     groupId,
     layout: {
-      groups: [...layout.groups, group],
+      groups: [...layout.groups, group].map((current) => (parentFound && current.id === parentGroupId ? { ...current, collapsed: false } : current)),
       order,
     },
   };

--- a/packages/app-tests/sidebarLayout.test.ts
+++ b/packages/app-tests/sidebarLayout.test.ts
@@ -168,6 +168,21 @@ test("createGroup adds a new empty group", () => {
   assert.ok(result.layout.order[0].type === "group");
 });
 
+test("createGroup expands parent group when adding a subgroup", () => {
+  const layout: SidebarLayout = {
+    groups: [{ id: "g1", name: "Parent", collapsed: true }],
+    order: [{ type: "group", id: "g1", children: [] }],
+  };
+
+  const result = createGroup(layout, "Child", "g1");
+  const parentGroup = result.layout.groups.find((group) => group.id === "g1");
+  const parentEntry = result.layout.order[0];
+
+  assert.equal(parentGroup?.collapsed, false);
+  assert.equal(parentEntry.type, "group");
+  assert.deepEqual(parentEntry.type === "group" ? parentEntry.children : undefined, [{ type: "group", id: result.groupId, children: [] }]);
+});
+
 // --- renameGroup ---
 
 test("renameGroup updates group name", () => {


### PR DESCRIPTION
- 在创建新子组时，自动展开其父组，支持自定义组名

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="265" height="178" alt="DBX 2026-07-02 10 14 43" src="https://github.com/user-attachments/assets/775d6bb2-b0ef-4ffa-ba05-6be426900c49" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2367 