### PR TITLE
 fix MongoDB multi-command execution

### DIFF
--- a/.github/scripts/bump-agent-versions.mjs
+++ b/.github/scripts/bump-agent-versions.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+
+const VERSIONS_PATH = "agents/versions.json";
+
+function bumpPatchVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(.*)$/.exec(version);
+  if (!match) {
+    throw new Error(`Agent version '${version}' is not a patchable semver version.`);
+  }
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}${match[4]}`;
+}
+
+function pathChanged(changedFiles, pathPrefix) {
+  const normalized = pathPrefix.endsWith("/") ? pathPrefix : `${pathPrefix}/`;
+  return changedFiles.some((file) => file === pathPrefix || file.startsWith(normalized));
+}
+
+function isCommonRuntimeChange(file) {
+  return file === "agents/common/build.gradle" || file.startsWith("agents/common/src/main/");
+}
+
+function parseLegacyStandaloneProjects(buildGradle) {
+  const match = /legacyStandaloneProjects\s*=\s*\[([^\]]*)\]/m.exec(buildGradle);
+  if (!match) return new Set();
+
+  return new Set(
+    [...match[1].matchAll(/['"]([^'"]+)['"]/g)]
+      .map((entry) => entry[1])
+      .filter(Boolean),
+  );
+}
+
+function fileContainsCommonDependency(path, moduleExists, readModuleFile) {
+  if (!moduleExists(path)) return false;
+  const source = readModuleFile(path);
+  return /project\(\s*['"]:common['"]\s*\)/.test(source);
+}
+
+function resolveAgentModule(moduleName, { legacyStandaloneModules, moduleExists, readModuleFile }) {
+  let checkDir = null;
+  if (moduleName === "oracle" && moduleExists("agents/drivers/oracle-go")) {
+    checkDir = "drivers/oracle-go";
+  } else if (moduleExists(`agents/drivers/${moduleName}`)) {
+    checkDir = `drivers/${moduleName}`;
+  } else if (moduleExists(`agents/${moduleName}`) || moduleName === "common") {
+    checkDir = moduleName;
+  }
+
+  if (!checkDir) return null;
+
+  const modulePath = `agents/${checkDir}`;
+  const buildGradlePath = `${modulePath}/build.gradle`;
+  const hasBuildGradle = moduleExists(buildGradlePath);
+  const explicitlyDependsOnCommon = fileContainsCommonDependency(buildGradlePath, moduleExists, readModuleFile);
+
+  return {
+    checkDir,
+    modulePath,
+    commonDependent: hasBuildGradle && (explicitlyDependsOnCommon || !legacyStandaloneModules.has(moduleName)),
+  };
+}
+
+export function evaluateAgentVersionBump({
+  versions,
+  prevVersions = versions,
+  changedFiles,
+  legacyStandaloneModules = new Set(),
+  moduleExists = existsSync,
+  readModuleFile = (path) => readFileSync(path, "utf8"),
+  skipBump = false,
+  manualVersionsChanged = changedFiles.includes(VERSIONS_PATH),
+}) {
+  const nextVersions = { ...versions };
+  const logs = [];
+  let changed = false;
+
+  if (manualVersionsChanged && !skipBump) {
+    logs.push("Manual agents/versions.json changes detected; preserving manually changed module versions and auto-bumping the rest.");
+  }
+
+  if (skipBump) {
+    logs.push("Skipping automatic module version bump for migrated first release; versions.json was carried over from dbx-agents.");
+    return { changed, versions: nextVersions, prevVersions, logs };
+  }
+
+  const commonChanged = changedFiles.some(isCommonRuntimeChange);
+  if (commonChanged) {
+    logs.push("Common agent runtime changes detected; common-triggered bumps are limited to modules that package agents/common.");
+  }
+
+  for (const moduleName of Object.keys(versions)) {
+    const module = resolveAgentModule(moduleName, { legacyStandaloneModules, moduleExists, readModuleFile });
+    if (!module) continue;
+
+    const moduleChanged = pathChanged(changedFiles, module.modulePath);
+    // Only modules that package agents/common need installer-visible updates
+    // for shared Java runtime changes; native and standalone agents do not.
+    const commonAffectsModule = commonChanged && module.commonDependent;
+    const oldVersion = nextVersions[moduleName] ?? "0.1.0";
+    const prevVersion = prevVersions[moduleName] ?? "";
+    const manuallyVersioned = manualVersionsChanged && (!prevVersion || prevVersion !== oldVersion);
+
+    if (!moduleChanged && !commonAffectsModule) {
+      logs.push(`  ${moduleName}: no changes`);
+    } else if (manuallyVersioned) {
+      if (!prevVersion) {
+        logs.push(`  ${moduleName}: CHANGED, new module version kept at ${oldVersion}`);
+      } else {
+        logs.push(`  ${moduleName}: CHANGED, manual version ${prevVersion} -> ${oldVersion}`);
+      }
+    } else {
+      const newVersion = bumpPatchVersion(oldVersion);
+      nextVersions[moduleName] = newVersion;
+      changed = true;
+      logs.push(`  ${moduleName}: CHANGED`);
+      logs.push(`  ${moduleName}: ${oldVersion} -> ${newVersion}`);
+    }
+  }
+
+  return { changed, versions: nextVersions, prevVersions, logs };
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function parseArgs(argv) {
+  const options = {
+    migratedFirstRelease: false,
+    prevTag: "",
+    prevVersionsFile: "",
+    skipBump: false,
+    write: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--write") {
+      options.write = true;
+    } else if (arg === "--skip-bump") {
+      options.skipBump = true;
+    } else if (arg === "--prev-tag") {
+      options.prevTag = argv[++index] ?? "";
+    } else if (arg === "--prev-versions-file") {
+      options.prevVersionsFile = argv[++index] ?? "";
+    } else if (arg === "--migrated-first-release") {
+      options.migratedFirstRelease = (argv[++index] ?? "") === "true";
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+  }
+
+  if (!options.prevTag) {
+    throw new Error("--prev-tag is required.");
+  }
+  return options;
+}
+
+function outputStepValues(result, prevTag, migratedFirstRelease) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+
+  appendFileSync(
+    outputPath,
+    [
+      `versions=${JSON.stringify(result.versions)}`,
+      `prev_versions=${JSON.stringify(result.prevVersions)}`,
+      `prev_tag=${prevTag}`,
+      `migrated_first_release=${migratedFirstRelease}`,
+      "",
+    ].join("\n"),
+  );
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const versions = JSON.parse(readFileSync(VERSIONS_PATH, "utf8"));
+  const legacyStandaloneModules = parseLegacyStandaloneProjects(readFileSync("agents/build.gradle", "utf8"));
+  const changedFiles = options.skipBump ? [] : git(["diff", "--name-only", `${options.prevTag}..HEAD`]).split("\n").filter(Boolean);
+  const manualVersionsChanged = changedFiles.includes(VERSIONS_PATH);
+  const prevVersions = options.prevVersionsFile
+    ? JSON.parse(readFileSync(options.prevVersionsFile, "utf8"))
+    : manualVersionsChanged
+      ? JSON.parse(git(["show", `${options.prevTag}:${VERSIONS_PATH}`]))
+      : versions;
+
+  const result = evaluateAgentVersionBump({
+    versions,
+    prevVersions,
+    changedFiles,
+    legacyStandaloneModules,
+    skipBump: options.skipBump,
+    manualVersionsChanged,
+  });
+
+  for (const line of result.logs) {
+    console.log(line);
+  }
+
+  const versionsJson = `${JSON.stringify(result.versions, null, 2)}\n`;
+  if (options.write) {
+    writeFileSync(VERSIONS_PATH, versionsJson);
+  }
+  console.log(versionsJson);
+  outputStepValues(result, options.prevTag, options.migratedFirstRelease);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/workflows/agents-release.yml
+++ b/.github/workflows/agents-release.yml
@@ -31,10 +31,7 @@ jobs:
           PREV_TAG=$(git tag --sort=-creatordate | grep '^agents-v' | sed -n '2p')
           SKIP_BUMP=false
           MIGRATED_FIRST_RELEASE=false
-
-          VERSIONS=$(cat agents/versions.json)
-          PREV_VERSIONS="$VERSIONS"
-          MANUAL_VERSIONS_CHANGED=false
+          PREV_VERSIONS_FILE=""
 
           if [ -z "$PREV_TAG" ]; then
             echo "No previous agents-v tag found; treating this as the first migrated agents release"
@@ -42,7 +39,8 @@ jobs:
 
             TMP_LEGACY="$(mktemp -d)"
             git clone --depth 1 --branch "$LEGACY_BASE_TAG" "$LEGACY_REPO" "$TMP_LEGACY"
-            PREV_VERSIONS=$(cat "$TMP_LEGACY/versions.json")
+            PREV_VERSIONS_FILE="$(mktemp)"
+            cp "$TMP_LEGACY/versions.json" "$PREV_VERSIONS_FILE"
             rm -rf "$TMP_LEGACY"
 
             SKIP_BUMP=true
@@ -50,79 +48,17 @@ jobs:
           fi
           echo "Comparing $PREV_TAG..HEAD"
 
-          if [ "$SKIP_BUMP" != "true" ] && ! git diff --quiet "$PREV_TAG"..HEAD -- agents/versions.json 2>/dev/null; then
-            echo "Manual agents/versions.json changes detected; preserving manually changed module versions and auto-bumping the rest."
-            PREV_VERSIONS=$(git show "${PREV_TAG}:agents/versions.json")
-            MANUAL_VERSIONS_CHANGED=true
-          fi
-
-          CHANGED=false
-
+          ARGS=(--prev-tag "$PREV_TAG" --migrated-first-release "$MIGRATED_FIRST_RELEASE" --write)
           if [ "$SKIP_BUMP" = "true" ]; then
-            echo "Skipping automatic module version bump for migrated first release; versions.json was carried over from dbx-agents."
-          else
-            if git diff --quiet "$PREV_TAG"..HEAD -- agents/common/ 2>/dev/null; then
-              COMMON_CHANGED=false
-            else
-              COMMON_CHANGED=true
-            fi
-
-            for dir in $(echo "$VERSIONS" | python3 -c "import sys,json; [print(k) for k in json.load(sys.stdin)]"); do
-              if [ "$dir" = "oracle" ] && [ -d "agents/drivers/oracle-go" ]; then
-                CHECK_DIR="drivers/oracle-go"
-              elif [ -d "agents/drivers/$dir" ]; then
-                CHECK_DIR="drivers/$dir"
-              elif [ -d "agents/$dir" ] || [ "$dir" = "common" ]; then
-                CHECK_DIR="$dir"
-              else
-                continue
-              fi
-              DIFF_PATHS=("agents/$CHECK_DIR/")
-              OLD_VER=$(echo "$VERSIONS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('$dir','0.1.0'))")
-              PREV_VER=$(PREV_VERSIONS_JSON="$PREV_VERSIONS" MODULE_NAME="$dir" python3 - <<'PY'
-          import json, os
-          versions = json.loads(os.environ["PREV_VERSIONS_JSON"])
-          print(versions.get(os.environ["MODULE_NAME"], ""))
-          PY
-          )
-              MANUALLY_VERSIONED=false
-              if [ "$MANUAL_VERSIONS_CHANGED" = "true" ] && { [ -z "$PREV_VER" ] || [ "$PREV_VER" != "$OLD_VER" ]; }; then
-                MANUALLY_VERSIONED=true
-              fi
-
-              if git diff --quiet "$PREV_TAG"..HEAD -- "${DIFF_PATHS[@]}" 2>/dev/null && [ "$COMMON_CHANGED" = "false" ]; then
-                echo "  $dir: no changes"
-              elif [ "$MANUALLY_VERSIONED" = "true" ]; then
-                if [ -z "$PREV_VER" ]; then
-                  echo "  $dir: CHANGED, new module version kept at $OLD_VER"
-                else
-                  echo "  $dir: CHANGED, manual version $PREV_VER -> $OLD_VER"
-                fi
-              else
-                echo "  $dir: CHANGED"
-                IFS='.' read -r major minor patch <<< "$OLD_VER"
-                NEW_VER="$major.$minor.$((patch + 1))"
-                VERSIONS=$(echo "$VERSIONS" | python3 -c "
-          import sys, json
-          d = json.load(sys.stdin)
-          d['$dir'] = '$NEW_VER'
-          json.dump(d, sys.stdout, indent=2)
-          print()
-          ")
-                CHANGED=true
-                echo "  $dir: $OLD_VER -> $NEW_VER"
-              fi
-            done
+            ARGS+=(--skip-bump)
+          fi
+          if [ -n "$PREV_VERSIONS_FILE" ]; then
+            ARGS+=(--prev-versions-file "$PREV_VERSIONS_FILE")
           fi
 
-          echo "$VERSIONS" > agents/versions.json
-          cat agents/versions.json
-          echo "versions=$(cat agents/versions.json | python3 -c 'import sys,json; print(json.dumps(json.load(sys.stdin)))')" >> "$GITHUB_OUTPUT"
-          echo "prev_versions=$(echo "$PREV_VERSIONS" | python3 -c 'import sys,json; print(json.dumps(json.load(sys.stdin)))')" >> "$GITHUB_OUTPUT"
-          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
-          echo "migrated_first_release=$MIGRATED_FIRST_RELEASE" >> "$GITHUB_OUTPUT"
+          node .github/scripts/bump-agent-versions.mjs "${ARGS[@]}"
 
-          if [ "$CHANGED" = "true" ]; then
+          if ! git diff --quiet -- agents/versions.json; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add agents/versions.json

--- a/agents/common/src/main/java/com/dbx/agent/JdbcExecutor.java
+++ b/agents/common/src/main/java/com/dbx/agent/JdbcExecutor.java
@@ -67,23 +67,7 @@ public final class JdbcExecutor {
     ) {
         return unchecked(() -> {
             String trimmedSql = trimSql(sql);
-            String upperSql = trimmedSql.toUpperCase(Locale.ROOT).trim();
             long start = System.currentTimeMillis();
-
-            if ("BEGIN".equals(upperSql) || "BEGIN TRANSACTION".equals(upperSql)) {
-                conn.setAutoCommit(false);
-                return emptyQueryResult(start);
-            }
-            if ("COMMIT".equals(upperSql)) {
-                conn.commit();
-                conn.setAutoCommit(true);
-                return emptyQueryResult(start);
-            }
-            if ("ROLLBACK".equals(upperSql)) {
-                conn.rollback();
-                conn.setAutoCommit(true);
-                return emptyQueryResult(start);
-            }
 
             applySchema(conn, schema, setSchemaSql);
 
@@ -94,6 +78,8 @@ public final class JdbcExecutor {
                 if (fetchSize != null && fetchSize > 0) {
                     stmt.setFetchSize(fetchSize);
                 }
+                // SQL dumps often contain BEGIN/COMMIT/ROLLBACK as executable statements.
+                // Do not translate them to Connection.commit(), which requires autoCommit=false.
                 boolean hasResultSet = stmt.execute(trimmedSql);
                 long elapsed = System.currentTimeMillis() - start;
                 if (hasResultSet) {
@@ -204,23 +190,7 @@ public final class JdbcExecutor {
         return unchecked(() -> {
             expireIdleSessions(targetSessions, System.currentTimeMillis(), QUERY_SESSION_IDLE_TIMEOUT_MILLIS);
             String trimmedSql = trimSql(sql);
-            String upperSql = trimmedSql.toUpperCase(Locale.ROOT).trim();
             long start = System.currentTimeMillis();
-
-            if ("BEGIN".equals(upperSql) || "BEGIN TRANSACTION".equals(upperSql)) {
-                conn.setAutoCommit(false);
-                return emptyQueryPageResult(start);
-            }
-            if ("COMMIT".equals(upperSql)) {
-                conn.commit();
-                conn.setAutoCommit(true);
-                return emptyQueryPageResult(start);
-            }
-            if ("ROLLBACK".equals(upperSql)) {
-                conn.rollback();
-                conn.setAutoCommit(true);
-                return emptyQueryPageResult(start);
-            }
 
             applySchema(conn, schema, setSchemaSql);
 
@@ -230,6 +200,8 @@ public final class JdbcExecutor {
                 if (options.getFetchSize() != null && options.getFetchSize() > 0) {
                     stmt.setFetchSize(options.getFetchSize());
                 }
+                // Keep script transaction-control statements in the SQL stream.
+                // JDBC transaction APIs are reserved for executeTransaction.
                 boolean hasResultSet = stmt.execute(trimmedSql);
                 long elapsed = System.currentTimeMillis() - start;
                 if (!hasResultSet) {

--- a/agents/common/src/test/java/com/dbx/agent/AbstractJdbcAgentTest.java
+++ b/agents/common/src/test/java/com/dbx/agent/AbstractJdbcAgentTest.java
@@ -104,6 +104,44 @@ class AbstractJdbcAgentTest {
     }
 
     @Test
+    void executesTransactionControlSqlThroughStatements() {
+        TrackingConnection tracking = new TrackingConnection();
+        TestAgent agent = new TestAgent(tracking);
+        agent.connect(new ConnectParams());
+
+        // Dump files can contain explicit transaction SQL while the JDBC connection is in auto-commit mode.
+        agent.executeQuery("BEGIN;", null, new ExecuteQueryOptions());
+        agent.executeQuery("BEGIN TRANSACTION;", null, new ExecuteQueryOptions());
+        agent.executeQuery("COMMIT;", null, new ExecuteQueryOptions());
+        agent.executeQuery("ROLLBACK;", null, new ExecuteQueryOptions());
+
+        assertEquals(
+            Arrays.asList(
+                "setMaxRows:10001",
+                "execute:BEGIN",
+                "setMaxRows:10001",
+                "execute:BEGIN TRANSACTION",
+                "setMaxRows:10001",
+                "execute:COMMIT",
+                "setMaxRows:10001",
+                "execute:ROLLBACK"
+            ),
+            tracking.calls
+        );
+    }
+
+    @Test
+    void executesPagedTransactionControlSqlThroughStatements() {
+        TrackingConnection tracking = new TrackingConnection();
+        TestAgent agent = new TestAgent(tracking);
+        agent.connect(new ConnectParams());
+
+        agent.executeQueryPage("COMMIT;", null, new QueryPageOptions());
+
+        assertEquals(Collections.singletonList("execute:COMMIT"), tracking.calls);
+    }
+
+    @Test
     void delegatesTransactionsThroughSharedFoundation() {
         TrackingConnection tracking = new TrackingConnection();
         TestAgent agent = new TestAgent(tracking);

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, onActivated, onDeactivated, watch, shallowRef, computed, nextTick } from "vue";
-import { FileCode, Play, Copy, Table2, TextSelect } from "@lucide/vue";
+import { CaseLower, CaseUpper, FileCode, Play, Copy, Table2, TextSelect } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import type { CompletionContext } from "@codemirror/autocomplete";
 import type { EditorView as EditorViewType } from "@codemirror/view";
@@ -187,6 +187,7 @@ interface EditorGestureEvent extends Event {
 
 let editorViewModule: typeof import("@codemirror/view") | null = null;
 let codeMirrorPrec: typeof import("@codemirror/state").Prec | null = null;
+let codeMirrorEditorSelection: typeof import("@codemirror/state").EditorSelection | null = null;
 let fontThemeComp: import("@codemirror/state").Compartment | null = null;
 let codeMirrorTheme: import("@codemirror/state").Compartment | null = null;
 let wordWrapComp: import("@codemirror/state").Compartment | null = null;
@@ -228,6 +229,8 @@ let editorIsActive = true;
 let tableReferenceDropListenerRegistered = false;
 let imeCompositionActive = false;
 let pendingImeModelEmit = false;
+
+type SelectionCaseMode = "upper" | "lower";
 let executableStatementRangeCache: ExecutableStatementRangeCache | null = null;
 let editorScrollbarPointerCleanup: (() => void) | null = null;
 const EDITOR_SCROLLBAR_POINTER_GUTTER_PX = 18;
@@ -549,6 +552,29 @@ function selectAllSqlFromContextMenu() {
   focusEditor();
 }
 
+function convertSelectedSqlCaseFromContextMenu(mode: SelectionCaseMode) {
+  const currentView = view.value;
+  const EditorSelection = codeMirrorEditorSelection;
+  if (!currentView || !EditorSelection || !canCopySelectedSql.value) return;
+
+  const state = currentView.state;
+  const transaction = state.changeByRange((range) => {
+    if (range.empty) return { range };
+
+    const selectedText = state.sliceDoc(range.from, range.to);
+    const convertedText = mode === "upper" ? selectedText.toUpperCase() : selectedText.toLowerCase();
+    return {
+      changes: { from: range.from, to: range.to, insert: convertedText },
+      range: EditorSelection.range(range.from, range.from + convertedText.length),
+    };
+  });
+
+  if (!transaction.changes.empty) {
+    currentView.dispatch({ ...transaction, scrollIntoView: true, userEvent: "input" });
+  }
+  focusEditor();
+}
+
 function openTableFromContextMenu() {
   if (!contextTableName.value) return;
   emit("viewTableData", contextTableName.value);
@@ -614,6 +640,18 @@ const contextMenuItems = computed<ContextMenuItem[]>(() => [
     action: copySelectedSqlFromContextMenu,
     disabled: !canCopySelectedSql.value,
     icon: Copy,
+  },
+  {
+    label: t("editor.contextMenu.uppercaseSelection"),
+    action: () => convertSelectedSqlCaseFromContextMenu("upper"),
+    disabled: !canCopySelectedSql.value,
+    icon: CaseUpper,
+  },
+  {
+    label: t("editor.contextMenu.lowercaseSelection"),
+    action: () => convertSelectedSqlCaseFromContextMenu("lower"),
+    disabled: !canCopySelectedSql.value,
+    icon: CaseLower,
   },
   { label: t("editor.contextMenu.selectAll"), action: selectAllSqlFromContextMenu, icon: TextSelect },
 ]);
@@ -2022,7 +2060,7 @@ onMounted(async () => {
 
   const [
     { EditorView, keymap, rectangularSelection, hoverTooltip, showTooltip, Decoration, tooltips, gutter, GutterMarker, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, crosshairCursor, ViewPlugin },
-    { EditorState, Compartment, Prec, StateEffect, StateField },
+    { EditorState, EditorSelection, Compartment, Prec, StateEffect, StateField },
     langSql,
     { autocompletion, startCompletion, acceptCompletion, closeBrackets, closeBracketsKeymap, snippetCompletion, completionStatus, completionKeymap, insertCompletionText, nextSnippetField },
     { copyLineDown, copyLineUp, deleteLine, indentLess, indentMore, insertNewlineKeepIndent, moveLineDown, moveLineUp, redo, selectAll, undo, history, defaultKeymap, historyKeymap },
@@ -2031,6 +2069,7 @@ onMounted(async () => {
   ] = await Promise.all([import("@codemirror/view"), import("@codemirror/state"), import("@codemirror/lang-sql"), import("@codemirror/autocomplete"), import("@codemirror/commands"), import("@codemirror/language"), import("@codemirror/search")]);
   editorViewModule = { EditorView, keymap, rectangularSelection } as typeof import("@codemirror/view");
   codeMirrorPrec = Prec;
+  codeMirrorEditorSelection = EditorSelection;
   codeMirrorSnippetCompletion = snippetCompletion;
   fontThemeComp = new Compartment();
   codeMirrorTheme = new Compartment();

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -598,7 +598,7 @@ function executeSqlStatementFromGutter(currentView: EditorViewType, line: { from
   if (!statementRange) return false;
   event.preventDefault();
   event.stopPropagation();
-  requestExecuteFromView(currentView, line.from, { ignoreSelection: true });
+  emit("execute", statementRange.sql);
   currentView.focus();
   return true;
 }

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -572,7 +572,9 @@ function executeSqlStatementFromGutter(currentView: EditorViewType, line: { from
   if (!statementRange) return false;
   event.preventDefault();
   event.stopPropagation();
-  requestExecuteFromView(currentView, line.from, { ignoreSelection: true });
+  // Gutter play is always scoped to the statement/command for that line, even
+  // when the main editor execute action would run the full document.
+  emit("execute", statementRange.sql);
   currentView.focus();
   return true;
 }

--- a/apps/desktop/src/components/grid/TemporalCellEditor.vue
+++ b/apps/desktop/src/components/grid/TemporalCellEditor.vue
@@ -214,10 +214,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="dateParts.year" data-temporal-part="year" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('year', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepDate('year', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepDate('year', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepDate('year', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepDate('year', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -226,10 +226,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(dateParts.month)" data-temporal-part="month" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('month', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepDate('month', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepDate('month', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepDate('month', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepDate('month', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -238,10 +238,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(dateParts.day)" data-temporal-part="day" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('day', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepDate('day', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepDate('day', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepDate('day', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepDate('day', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -252,10 +252,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(timeParts.hour)" data-temporal-part="hour" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateTimeFromInput('hour', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepTime('hour', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepTime('hour', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepTime('hour', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepTime('hour', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -264,10 +264,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(timeParts.minute)" data-temporal-part="minute" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateTimeFromInput('minute', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepTime('minute', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepTime('minute', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepTime('minute', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepTime('minute', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -276,10 +276,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(timeParts.second)" data-temporal-part="second" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateTimeFromInput('second', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepTime('second', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepTime('second', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepTime('second', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepTime('second', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -287,11 +287,11 @@ function twoDigit(value: string | number): string {
       </div>
 
       <div class="flex items-center justify-between gap-1">
-        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @click="setNull">
+        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @mousedown.prevent @click="setNull">
           <CircleSlash class="h-3 w-3" />
           NULL
         </Button>
-        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @click="setNow">Now</Button>
+        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @mousedown.prevent @click="setNow">Now</Button>
       </div>
     </PopoverContent>
   </Popover>

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -578,6 +578,18 @@ async function toggle() {
       const collectionRef = node.id.includes("__vector_collection:") ? node.id.split("__vector_collection:").pop() || node.label : node.label;
       const tab = queryStore.createTab(node.connectionId, node.database || "default", node.label, "vector");
       queryStore.updateSql(tab, collectionRef);
+      api
+        .vectorGetCollectionDetail(node.connectionId, node.database || "default", collectionRef)
+        .then((info) => {
+          if (info.dimension != null) {
+            if (node.meta) {
+              (node.meta as Record<string, unknown>).dimension = info.dimension;
+            } else {
+              node.meta = { dimension: info.dimension } as any;
+            }
+          }
+        })
+        .catch(() => {});
     } else if (node.type === "database" && node.connectionId && hasTreeNodeDatabaseContext(node)) {
       const config = connectionStore.getConfig(node.connectionId);
       const effectiveDbType = effectiveDatabaseTypeForConnection(config);

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1459,7 +1459,7 @@ async function duplicateConnection() {
   const config = connectionStore.getConfig(connId);
   if (!config) return;
   const newConfig = { ...config, id: uuid(), name: `${config.name} (Copy)` };
-  await connectionStore.addConnection(newConfig);
+  await connectionStore.addConnection(newConfig, connectionStore.groupIdForConnection(connId));
   toast(t("connection.duplicated"), 2000);
 }
 

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -4932,12 +4932,11 @@ function treeItemMenuItems(): ContextMenuItem[] {
 <style>
 .sidebar-object-comment {
   color: var(--muted-foreground);
-  font-family: "Microsoft YaHei UI", "Microsoft YaHei", "Segoe UI", system-ui, sans-serif;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 16px;
-  opacity: 1;
-  text-rendering: optimizeLegibility;
+  font-size: 10px;
+  line-height: 1rem;
+  opacity: 0.6;
+  /* Sidebar rows repaint on hover; avoid heavier font shaping and fallback here. */
+  text-rendering: auto;
 }
 
 .tree-item-connection-tint {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -4071,6 +4071,10 @@ function treeItemMenuItems(): ContextMenuItem[] {
     } else {
       items.push({ label: t("contextMenu.clearDefaultDatabase"), action: clearNodeDefaultDatabase, icon: Database });
     }
+    if (node.type === "mongo-db") {
+      items.push({ label: "", separator: true });
+      items.push({ label: t("transfer.dataTransfer"), action: openTransfer, icon: ArrowRightLeft });
+    }
     if (node.type === "redis-db") {
       items.push({ label: "", separator: true });
       items.push({ label: t("redis.flushDb"), action: flushRedisDb, icon: Eraser, variant: "destructive" as const });

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -113,6 +113,7 @@ import { focusSidebarRenameInput } from "@/lib/sidebarRenameFocus";
 import { hasTreeNodeDatabaseContext } from "@/lib/treeNodeContext";
 import { defaultPasteTableMode, pasteTableModeCopiesData, supportsWholeRowTableDataCopy, tableClipboardMatchesTarget, tableDataCopyColumnOptions, type PasteTableMode, type TableClipboardContext } from "@/lib/tableClipboard";
 import { sidebarDisplayTableName } from "@/lib/sidebarTableNameDisplay";
+import { shouldMeasureSidebarLabelOverflow } from "@/lib/sidebarLabelTooltip";
 import { selectedTreeNodesInVisibleOrder as orderSelectedTreeNodes, treeSelectionRangeIdsByIndex, treeSelectionRangeIds } from "@/lib/sidebarTreeSelection";
 import { selectedConnectionDeleteTargets } from "@/lib/sidebarConnectionSelection";
 import { supportsDatabaseUserAdmin } from "@/lib/databaseUserAdmin";
@@ -144,12 +145,54 @@ import { createDatabaseCollationOptionsForCharset, fallbackCreateDatabaseCharset
 const { t } = useI18n();
 const labelRef = ref<HTMLElement>();
 const rowRef = ref<HTMLElement>();
-function isLabelTruncated(): boolean {
+const labelOverflowing = ref(false);
+let labelResizeObserver: ResizeObserver | null = null;
+let labelMeasureFrame = 0;
+
+function cancelLabelOverflowMeasure() {
+  if (!labelMeasureFrame) return;
+  window.cancelAnimationFrame(labelMeasureFrame);
+  labelMeasureFrame = 0;
+}
+
+function measureLabelOverflow(): boolean {
   const el = labelRef.value;
-  if (!el) return false;
+  if (!el || !shouldMeasureLabelOverflow()) return false;
   const style = window.getComputedStyle(el);
   if (style.overflowX === "visible" || style.textOverflow !== "ellipsis") return false;
   return el.scrollWidth - el.clientWidth > 2;
+}
+
+function updateLabelOverflow() {
+  labelOverflowing.value = measureLabelOverflow();
+}
+
+function scheduleLabelOverflowMeasure() {
+  if (typeof window === "undefined") {
+    updateLabelOverflow();
+    return;
+  }
+  cancelLabelOverflowMeasure();
+  // Keep synchronous layout reads out of the hover path; they are expensive in
+  // large virtualized sidebar trees, especially on Linux WebKitGTK without GPU help.
+  labelMeasureFrame = window.requestAnimationFrame(() => {
+    labelMeasureFrame = 0;
+    updateLabelOverflow();
+  });
+}
+
+function observeLabelOverflow() {
+  labelResizeObserver?.disconnect();
+  labelResizeObserver = null;
+  if (!shouldMeasureLabelOverflow()) {
+    labelOverflowing.value = false;
+    return;
+  }
+  if (typeof ResizeObserver !== "undefined" && labelRef.value) {
+    labelResizeObserver = new ResizeObserver(scheduleLabelOverflowMeasure);
+    labelResizeObserver.observe(labelRef.value);
+  }
+  scheduleLabelOverflowMeasure();
 }
 const connectionStore = useConnectionStore();
 const queryStore = useQueryStore();
@@ -439,7 +482,7 @@ const detailTooltip = computed(() => connectionInfoTooltip.value ?? objectCommen
 
 function isTooltipDisabled(): boolean {
   if (detailTooltip.value?.rows.length) return isRenamingGroup.value;
-  return isRenamingGroup.value || !isLabelTruncated();
+  return isRenamingGroup.value || !labelOverflowing.value;
 }
 
 async function toggle() {
@@ -3478,6 +3521,14 @@ const isRenamingGroup = ref(false);
 const renameInput = ref("");
 const renameInputRef = ref<HTMLInputElement>();
 
+function shouldMeasureLabelOverflow(): boolean {
+  return shouldMeasureSidebarLabelOverflow({
+    hasDetailTooltip: !!detailTooltip.value?.rows.length,
+    isRenaming: isRenamingGroup.value,
+    usesFullWidthLabel: usesFullWidthLabel.value,
+  });
+}
+
 function startRenameGroup() {
   renameInput.value = props.node.label;
   isRenamingGroup.value = true;
@@ -3495,6 +3546,14 @@ watch(
     }
   },
   { immediate: true },
+);
+
+watch(
+  [() => props.node.id, () => visibleLabel(props.node), () => usesFullWidthLabel.value, () => detailTooltip.value?.rows.length ?? 0, isRenamingGroup],
+  () => {
+    nextTick(observeLabelOverflow);
+  },
+  { flush: "post", immediate: true },
 );
 
 function finishRenameGroup() {
@@ -3718,10 +3777,14 @@ function onRowMouseDown(event: MouseEvent) {
 }
 
 onMounted(() => {
+  observeLabelOverflow();
   window.addEventListener("dbx:sidebar-request-paste-table", onSidebarRequestPasteTable);
 });
 
 onBeforeUnmount(() => {
+  labelResizeObserver?.disconnect();
+  labelResizeObserver = null;
+  cancelLabelOverflowMeasure();
   window.removeEventListener("dbx:sidebar-request-paste-table", onSidebarRequestPasteTable);
   finishTableReferenceDrag();
 });

--- a/apps/desktop/src/components/ui/dialog/DialogOverlay.vue
+++ b/apps/desktop/src/components/ui/dialog/DialogOverlay.vue
@@ -4,14 +4,30 @@ import type { HTMLAttributes } from "vue";
 import { reactiveOmit } from "@vueuse/core";
 import { DialogOverlay } from "reka-ui";
 import { cn } from "@/lib/utils";
+import { isTauriRuntime } from "@/lib/tauriRuntime";
 
 const props = defineProps<DialogOverlayProps & { class?: HTMLAttributes["class"] }>();
 
 const delegatedProps = reactiveOmit(props, "class");
+const isDesktop = isTauriRuntime();
+
+async function startWindowDrag(event: PointerEvent) {
+  if (!isDesktop || event.button !== 0) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const { getCurrentWindow } = await import("@tauri-apps/api/window");
+  const currentWindow = getCurrentWindow();
+  if (event.detail >= 2) {
+    await currentWindow.toggleMaximize().catch(() => {});
+    return;
+  }
+  await currentWindow.startDragging().catch(() => {});
+}
 </script>
 
 <template>
   <DialogOverlay data-slot="dialog-overlay" v-bind="delegatedProps" :class="cn('data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-open:supports-backdrop-filter:backdrop-blur-xs bg-black/10 duration-100 fixed inset-0 isolate z-50', props.class)">
+    <div v-if="isDesktop" aria-hidden="true" class="fixed inset-x-0 top-0 h-10 pointer-events-auto" data-tauri-drag-region @pointerdown="startWindowDrag" />
     <slot />
   </DialogOverlay>
 </template>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -465,6 +465,8 @@ export default {
       executeSelection: "Execute selection",
       executeCurrent: "Execute SQL",
       copySelection: "Copy selection",
+      uppercaseSelection: "Convert to uppercase",
+      lowercaseSelection: "Convert to lowercase",
       selectAll: "Select all",
     },
     search: {

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -462,6 +462,8 @@ export default withEnglishFallback({
       executeSelection: "Ejecutar seleccion",
       executeCurrent: "Ejecutar SQL",
       copySelection: "Copiar seleccion",
+      uppercaseSelection: "Convertir a mayusculas",
+      lowercaseSelection: "Convertir a minusculas",
       selectAll: "Seleccionar todo",
     },
     search: {

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -466,6 +466,8 @@ export default withEnglishFallback({
       executeSelection: "Esegui selezione",
       executeCurrent: "Esegui SQL",
       copySelection: "Copia selezione",
+      uppercaseSelection: "Converti in maiuscolo",
+      lowercaseSelection: "Converti in minuscolo",
       selectAll: "Seleziona tutto",
     },
     search: {

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -460,6 +460,8 @@ export default withEnglishFallback({
       executeSelection: "選択範囲を実行",
       executeCurrent: "SQLを実行",
       copySelection: "選択範囲をコピー",
+      uppercaseSelection: "大文字に変換",
+      lowercaseSelection: "小文字に変換",
       selectAll: "すべて選択",
     },
     search: {

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -474,6 +474,8 @@ export default withEnglishFallback({
       executeSelection: "Executar seleção",
       executeCurrent: "Executar SQL",
       copySelection: "Copiar seleção",
+      uppercaseSelection: "Converter para maiúsculas",
+      lowercaseSelection: "Converter para minúsculas",
       selectAll: "Selecionar tudo",
     },
     search: {

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -468,6 +468,8 @@ export default withEnglishFallback({
       executeSelection: "执行选中 SQL",
       executeCurrent: "执行 SQL",
       copySelection: "复制选中内容",
+      uppercaseSelection: "转为大写",
+      lowercaseSelection: "转为小写",
       selectAll: "全选",
     },
     search: {

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -462,6 +462,8 @@ export default withEnglishFallback({
       executeSelection: "執行選取 SQL",
       executeCurrent: "執行 SQL",
       copySelection: "複製選取內容",
+      uppercaseSelection: "轉為大寫",
+      lowercaseSelection: "轉為小寫",
       selectAll: "全選",
     },
     search: {

--- a/apps/desktop/src/lib/__tests__/executableStatementRangeCache.spec.ts
+++ b/apps/desktop/src/lib/__tests__/executableStatementRangeCache.spec.ts
@@ -18,6 +18,15 @@ describe("executableStatementRangeCacheForDoc", () => {
     expect(executableStatementRangeStartingAt(second, 10)?.sql).toBe("SELECT 2");
   });
 
+  it("resolves the exact multi-line statement for a gutter run button", () => {
+    const doc = Text.of(["SELECT *", "FROM apis AS ap", "LIMIT 100;", "", "SELECT *", "FROM menus AS mn", "LIMIT 100;"]);
+
+    const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");
+    const secondStatementLine = doc.line(5);
+
+    expect(executableStatementRangeStartingAt(cache, secondStatementLine.from)?.sql).toBe("SELECT *\nFROM menus AS mn\nLIMIT 100");
+  });
+
   it("rebuilds the cache when the document instance changes", () => {
     const firstDoc = Text.of(["SELECT 1;"]);
     const secondDoc = Text.of(["SELECT 1;"]);

--- a/apps/desktop/src/lib/__tests__/sidebarLabelTooltip.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebarLabelTooltip.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { shouldMeasureSidebarLabelOverflow } from "@/lib/sidebarLabelTooltip";
+
+describe("shouldMeasureSidebarLabelOverflow", () => {
+  it("measures only plain truncated-label tooltip candidates", () => {
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: false })).toBe(true);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: true, isRenaming: false, usesFullWidthLabel: false })).toBe(false);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: true, usesFullWidthLabel: false })).toBe(false);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: true })).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
@@ -216,6 +216,31 @@ describe("statementRangeAtCursor", () => {
     expect(range?.sql.trim()).toBe("UPDATE users\nSET name = 'a'\nWHERE id = 1");
   });
 
+  it("keeps MySQL ALTER TABLE column comments with the column definition", () => {
+    const sql =
+      "ALTER TABLE `yb_course_order`\n  ADD COLUMN `audit_status` tinyint(4) DEFAULT NULL\n    COMMENT '审核状态：0-待审核，1-已通过，2-已拒绝',\n  ADD COLUMN `close_reason` varchar(30) DEFAULT NULL\n    COMMENT '关闭原因：timeout-超时关闭，cancel-取消关闭，refund-退款关闭',\n  ADD COLUMN `paid_completion_time` datetime DEFAULT NULL\n    COMMENT '订单完成支付(付清)时间 首次全额支付完成时记录，全部退款后不重置';";
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "ALTER"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(statementRangeAtCursor(sql, indexOf(sql, "close_reason"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
+  it("keeps MySQL ALTER TABLE drop column clauses with the statement", () => {
+    const sql = "ALTER TABLE t\n  DROP COLUMN a,\n  DROP COLUMN b;";
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "ALTER"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(statementRangeAtCursor(sql, indexOf(sql, "DROP COLUMN b"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
+  it("keeps MySQL ALTER TABLE alter column clauses with the statement", () => {
+    const sql = "ALTER TABLE t\n  ALTER COLUMN name SET NOT NULL;";
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "ALTER"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(statementRangeAtCursor(sql, indexOf(sql, "ALTER COLUMN"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
   it("keeps insert-select with the INSERT statement", () => {
     const sql = "INSERT INTO archived_users (id, name)\nSELECT id, name FROM users\nUPDATE users SET archived = 1;";
     const range = statementRangeAtCursor(sql, indexOf(sql, "archived_users"));

--- a/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
@@ -317,6 +317,14 @@ describe("executableStatementRanges", () => {
     expect(ranges.map((range) => range.from)).toEqual([0, sql.indexOf("DEL")]);
   });
 
+  it("returns MongoDB command ranges for newline-separated shell commands", () => {
+    const sql = 'use archive\ndb.users.find({ status: "open" })\n  .limit(5)';
+    const ranges = executableStatementRanges(sql, "mongodb");
+
+    expect(rangeSqlTexts(ranges)).toEqual(["use archive", 'db.users.find({ status: "open" })\n  .limit(5)']);
+    expect(ranges.map((range) => range.from)).toEqual([0, sql.indexOf("db.users.find")]);
+  });
+
   it("does not split executable Oracle PL/SQL ranges at inner statement starts", () => {
     expect(rangeSqlTexts(executableStatementRanges(oraclePlSqlFixture, "oracle"))).toEqual([oraclePlSqlFixture.slice(0, oraclePlSqlFixture.indexOf("\n/")), "SELECT 1"]);
   });

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -375,6 +375,7 @@ export const documentListDatabases = forward("documentListDatabases");
 export const mongoListDatabases = forward("mongoListDatabases");
 export const documentListCollections = forward("documentListCollections");
 export const mongoListCollections = forward("mongoListCollections");
+export const vectorGetCollectionDetail = forward("vectorGetCollectionDetail");
 export const mongoCreateDatabase = forward("mongoCreateDatabase");
 export const mongoDropDatabase = forward("mongoDropDatabase");
 export const mongoDropCollection = forward("mongoDropCollection");

--- a/apps/desktop/src/lib/http.ts
+++ b/apps/desktop/src/lib/http.ts
@@ -1768,6 +1768,10 @@ export async function vectorListCollections(connectionId: string, database?: str
   return documentListCollections(connectionId, database || "default");
 }
 
+export async function vectorGetCollectionDetail(connectionId: string, database: string, collection: string): Promise<CollectionInfo> {
+  return post("/api/mongo/vector-collection-detail", { connectionId, database, collection });
+}
+
 export async function mongoFindDocuments(connectionId: string, database: string, collection: string, skip: number, limit: number, filter?: string, projection?: string, sort?: string, executionId?: string): Promise<MongoDocumentResult> {
   return documentFindDocuments(connectionId, database, collection, skip, limit, filter, projection, sort, executionId);
 }

--- a/apps/desktop/src/lib/mongoShellCommand.ts
+++ b/apps/desktop/src/lib/mongoShellCommand.ts
@@ -31,13 +31,33 @@ export interface MongoVersionCommand {
   kind: "version";
 }
 
-export type MongoWriteCommand =
+type MongoWriteKind = "insert" | "update" | "delete" | "createIndex" | "dropIndex" | "dropIndexes";
+
+export type MongoCommand =
+  | ({ kind: "find" } & MongoFindCommand)
+  | MongoVersionCommand
+  | ({ kind: "countDocuments" } & MongoCountDocumentsCommand)
+  | ({ kind: "aggregate" } & MongoAggregateCommand)
+  | ({ kind: "getIndexes" } & MongoGetIndexesCommand)
+  | ({ kind: "use" } & MongoUseCommand)
   | { kind: "insert"; collection: string; docsJson: string }
   | { kind: "update"; collection: string; filter: string; update: string; many: boolean }
   | { kind: "delete"; collection: string; filter: string; many: boolean }
   | { kind: "createIndex"; collection: string; keys: string; options?: string }
   | { kind: "dropIndex"; collection: string; index: string }
   | { kind: "dropIndexes"; collection: string; indexes?: string };
+
+export type MongoWriteCommand = Extract<MongoCommand, { kind: MongoWriteKind }>;
+
+export interface ParsedMongoCommand {
+  text: string;
+  command: MongoCommand;
+}
+
+export interface ParsedMongoCommandRange extends ParsedMongoCommand {
+  from: number;
+  to: number;
+}
 
 export interface MongoAggregateSafetyOptions {
   allowWrites?: boolean;
@@ -239,6 +259,65 @@ export function parseMongoWriteCommand(input: string): MongoWriteCommand | null 
   }
 
   return null;
+}
+
+export function parseMongoCommand(input: string): ParsedMongoCommand | null {
+  const text = trimMongoOuterComments(input);
+  if (!text) return null;
+
+  // Keep the more specific readers ahead of generic write parsing so the
+  // returned kind matches the result renderer we want to use downstream.
+  const parsers: Array<(source: string) => MongoCommand | null> = [
+    (source) => {
+      const find = parseMongoFindCommand(source);
+      return find ? { kind: "find", ...find } : null;
+    },
+    (source) => {
+      const version = parseMongoVersionCommand(source);
+      return version ?? null;
+    },
+    (source) => {
+      const count = parseMongoCountDocumentsCommand(source);
+      return count ? { kind: "countDocuments", ...count } : null;
+    },
+    (source) => {
+      const aggregate = parseMongoAggregateCommand(source);
+      return aggregate ? { kind: "aggregate", ...aggregate } : null;
+    },
+    (source) => {
+      const getIndexes = parseMongoGetIndexesCommand(source);
+      return getIndexes ? { kind: "getIndexes", ...getIndexes } : null;
+    },
+    (source) => {
+      const write = parseMongoWriteCommand(source);
+      return write ?? null;
+    },
+    (source) => {
+      const use = parseMongoUseCommand(source);
+      return use ? { kind: "use", ...use } : null;
+    },
+  ];
+
+  for (const parse of parsers) {
+    const command = parse(text);
+    if (command) return { text, command };
+  }
+
+  return null;
+}
+
+export function splitMongoCommands(input: string): ParsedMongoCommand[] {
+  return splitMongoCommandRanges(input).map(({ from: _from, to: _to, ...command }) => command);
+}
+
+export function splitMongoCommandRanges(input: string): ParsedMongoCommandRange[] {
+  const commands: ParsedMongoCommandRange[] = [];
+  for (const segment of splitMongoCommandTextRanges(input)) {
+    const parsed = parseMongoCommand(segment.text);
+    if (!parsed) return [];
+    commands.push({ from: segment.from, to: segment.to, ...parsed });
+  }
+  return commands;
 }
 
 export function evaluateMongoWriteSafety(command: MongoWriteCommand, options: MongoAggregateSafetyOptions): { allowed: boolean; reason?: string } {
@@ -445,6 +524,263 @@ function parseMethodArgs(source: string, methodCallIndex: number): string[] | nu
   const closeIndex = findMatchingParen(source, openIndex);
   if (closeIndex < 0 || source.slice(closeIndex + 1).trim()) return null;
   return splitTopLevel(source.slice(openIndex + 1, closeIndex));
+}
+
+interface MongoTextRange {
+  from: number;
+  to: number;
+  text: string;
+}
+
+function splitMongoCommandTextRanges(input: string): MongoTextRange[] {
+  const commands: MongoTextRange[] = [];
+  for (const segment of splitMongoSemicolonSeparatedSegments(input)) {
+    const parsed = parseMongoCommand(segment.text);
+    if (parsed) {
+      commands.push({ ...segment, text: parsed.text });
+      continue;
+    }
+
+    // Mongo shell users often omit semicolons and rely on one top-level
+    // command per line, so fall back to a conservative newline split.
+    const softSplit = splitMongoSegmentAtSoftStarts(segment);
+    if (softSplit.length > 1) {
+      commands.push(...softSplit);
+      continue;
+    }
+
+    commands.push(segment);
+  }
+  return commands;
+}
+
+function splitMongoSemicolonSeparatedSegments(input: string): MongoTextRange[] {
+  const segments: MongoTextRange[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote: string | null = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  // Respect semicolons only when they appear at the top level; JSON literals,
+  // strings and comments are allowed to contain semicolons verbatim.
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i] ?? "";
+    const next = input[i + 1] ?? "";
+
+    if (lineComment) {
+      if (char === "\n") lineComment = false;
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "{" || char === "[" || char === "(") depth += 1;
+    else if ((char === "}" || char === "]" || char === ")") && depth > 0) depth -= 1;
+    else if (char === ";" && depth === 0) {
+      pushMongoSegment(segments, input, start, i);
+      start = i + 1;
+    }
+  }
+
+  pushMongoSegment(segments, input, start, input.length);
+  return segments;
+}
+
+function splitMongoSegmentAtSoftStarts(segment: MongoTextRange): MongoTextRange[] {
+  const boundaries = mongoTopLevelCommandLineStarts(segment.text);
+  if (boundaries.length <= 1) return [segment];
+
+  const segments: MongoTextRange[] = [];
+  let start = boundaries[0] ?? 0;
+  for (let index = 1; index < boundaries.length; index += 1) {
+    const boundary = boundaries[index] ?? 0;
+    const candidate = trimMongoOuterCommentRange(segment.text, start, boundary);
+    // Only accept newline-based splitting when every slice is a valid command;
+    // otherwise keep the original text intact and let normal parsing reject it.
+    if (!candidate || !parseMongoCommand(candidate.text)) return [segment];
+    segments.push({
+      from: segment.from + candidate.from,
+      to: segment.from + candidate.to,
+      text: candidate.text,
+    });
+    start = boundary;
+  }
+
+  const last = trimMongoOuterCommentRange(segment.text, start, segment.text.length);
+  if (!last || !parseMongoCommand(last.text)) return [segment];
+  segments.push({
+    from: segment.from + last.from,
+    to: segment.from + last.to,
+    text: last.text,
+  });
+  return segments;
+}
+
+function mongoTopLevelCommandLineStarts(segment: string): number[] {
+  const starts: number[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  let lineStart = 0;
+  let firstNonWhitespaceOnLine = -1;
+
+  for (let i = 0; i < segment.length; i += 1) {
+    const char = segment[i] ?? "";
+    const next = segment[i + 1] ?? "";
+
+    if (char === "\n") {
+      if (lineComment) lineComment = false;
+      lineStart = i + 1;
+      firstNonWhitespaceOnLine = -1;
+      continue;
+    }
+
+    if (lineComment) continue;
+
+    if (blockComment) {
+      if (char === "*" && next === "/") {
+        blockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      lineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      blockComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      if (firstNonWhitespaceOnLine === -1 && !/\s/.test(char)) firstNonWhitespaceOnLine = i;
+      quote = char;
+      continue;
+    }
+
+    if (char === "{" || char === "[" || char === "(") depth += 1;
+    else if ((char === "}" || char === "]" || char === ")") && depth > 0) depth -= 1;
+
+    if (firstNonWhitespaceOnLine === -1 && !/\s/.test(char)) {
+      firstNonWhitespaceOnLine = i;
+      if (depth === 0 && char !== "." && isMongoCommandLineStart(segment, i)) starts.push(i);
+    }
+  }
+
+  return starts.length > 0 ? starts : [lineStart];
+}
+
+function isMongoCommandLineStart(segment: string, index: number): boolean {
+  const rest = segment.slice(index);
+  return /^use\b/i.test(rest) || /^db(?:\s*\.|\b)/i.test(rest);
+}
+
+function pushMongoSegment(segments: MongoTextRange[], source: string, from: number, to: number) {
+  const trimmed = trimMongoOuterCommentRange(source, from, to);
+  if (trimmed) segments.push(trimmed);
+}
+
+function trimMongoOuterComments(source: string): string {
+  let value = source.trim();
+  while (value) {
+    const next = value.replace(/^(?:\/\/[^\n]*(?:\n|$)|\/\*[\s\S]*?\*\/)\s*/u, "");
+    if (next === value) break;
+    value = next.trimStart();
+  }
+  while (value) {
+    const next = value.replace(/\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/)\s*$/u, "");
+    if (next === value) break;
+    value = next.trimEnd();
+  }
+  return value.trim();
+}
+
+function trimMongoOuterCommentRange(source: string, from: number, to: number): MongoTextRange | null {
+  let start = from;
+  let end = to;
+
+  while (start < end) {
+    const value = source.slice(start, end);
+    const trimmed = value.trimStart();
+    if (trimmed !== value) {
+      start += value.length - trimmed.length;
+      continue;
+    }
+    const next = value.replace(/^(?:\/\/[^\n]*(?:\n|$)|\/\*[\s\S]*?\*\/)\s*/u, "");
+    if (next !== value) {
+      start += value.length - next.length;
+      continue;
+    }
+    break;
+  }
+
+  while (start < end) {
+    const value = source.slice(start, end);
+    const trimmed = value.trimEnd();
+    if (trimmed !== value) {
+      end -= value.length - trimmed.length;
+      continue;
+    }
+    const next = value.replace(/\s*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/)\s*$/u, "");
+    if (next !== value) {
+      end -= value.length - next.length;
+      continue;
+    }
+    break;
+  }
+
+  if (start >= end) return null;
+  return {
+    from: start,
+    to: end,
+    text: source.slice(start, end),
+  };
 }
 
 function convertSingleQuotedStrings(source: string): string {

--- a/apps/desktop/src/lib/sidebarLabelTooltip.ts
+++ b/apps/desktop/src/lib/sidebarLabelTooltip.ts
@@ -1,0 +1,3 @@
+export function shouldMeasureSidebarLabelOverflow(options: { hasDetailTooltip: boolean; isRenaming: boolean; usesFullWidthLabel: boolean }): boolean {
+  return !options.isRenaming && !options.hasDetailTooltip && !options.usesFullWidthLabel;
+}

--- a/apps/desktop/src/lib/sqlExecutionTarget.ts
+++ b/apps/desktop/src/lib/sqlExecutionTarget.ts
@@ -52,6 +52,11 @@ export async function resolveExecutableSqlWithBackend(fullSql: string, selectedS
   const trimmedSelection = selectedSql.trim();
   if (trimmedSelection) return trimmedSelection;
 
+  // MongoDB uses dedicated per-command gutter actions for "current command";
+  // the main editor execute action keeps its long-standing "run all text"
+  // behavior when nothing is selected.
+  if (options?.databaseType === "mongodb") return fullSql;
+
   if (options?.mode === "current" && options.cursorPos !== undefined) {
     return await api.findStatementAtCursor(fullSql, options.cursorPos, options.databaseType);
   }

--- a/apps/desktop/src/lib/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sqlStatementRanges.ts
@@ -99,6 +99,7 @@ const WITH_MAIN_STATEMENT_KEYWORDS = new Set(["SELECT", "INSERT", "UPDATE", "DEL
 const EXPLAIN_STATEMENT_KEYWORDS = new Set(["SELECT", "WITH", "INSERT", "UPDATE", "DELETE", "MERGE", "CREATE", "ALTER", "DROP"]);
 const CREATE_BODY_KEYWORDS = new Set(["SELECT", "WITH", "BEGIN", "DECLARE"]);
 const INSERT_BODY_KEYWORDS = new Set(["SELECT", "WITH"]);
+const ALTER_BODY_KEYWORDS = new Set(["ADD", "ALTER", "COMMENT", "DROP", "MODIFY", "RENAME", "SET"]);
 const ORACLE_LIKE_PL_SQL_DATABASES: ReadonlySet<DatabaseType> = new Set(["oracle", "dameng", "gaussdb", "yashandb", "oscar", "oceanbase-oracle"]);
 const ORACLE_PL_SQL_BLOCK_STARTERS = new Set(["DECLARE", "BEGIN"]);
 const ORACLE_PL_SQL_CREATE_OBJECT_TYPES = new Set(["FUNCTION", "PROCEDURE", "TRIGGER", "PACKAGE", "PACKAGE BODY", "TYPE", "TYPE BODY"]);
@@ -441,6 +442,10 @@ function splitStatementRangeAtSoftStarts(sql: string, statement: RawStatement, d
     }
 
     if (currentBodyKeyword === "UPDATE" && lineStart.keyword === "SET") {
+      continue;
+    }
+
+    if (currentBodyKeyword === "ALTER" && ALTER_BODY_KEYWORDS.has(lineStart.keyword)) {
       continue;
     }
 

--- a/apps/desktop/src/lib/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sqlStatementRanges.ts
@@ -1,4 +1,5 @@
 import type { SqlExecutionCandidate } from "./sqlExecutionTarget";
+import { splitMongoCommandRanges } from "./mongoShellCommand";
 import type { DatabaseType } from "@/types/database";
 
 /**
@@ -1098,6 +1099,7 @@ function normalizeSql(sql: string): string {
  */
 export function executableStatementRanges(sql: string, databaseType?: DatabaseType): SqlTextRange[] {
   if (databaseType === "redis") return redisExecutableCommandRanges(sql);
+  if (databaseType === "mongodb") return splitMongoCommandRanges(sql).map(({ from, to, text }) => ({ from, to, sql: text }));
   return splitSqlStatementRanges(sql, databaseType).flatMap((statement) => splitStatementRangeAtSoftStarts(sql, statement, databaseType).map((range) => rangeFor(range, sql)));
 }
 

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1480,6 +1480,10 @@ export async function mongoListCollections(connectionId: string, database: strin
   return documentListCollections(connectionId, database);
 }
 
+export async function vectorGetCollectionDetail(connectionId: string, database: string, collection: string): Promise<CollectionInfo> {
+  return invoke("vector_collection_detail", { connectionId, database, collection });
+}
+
 export async function mongoCreateDatabase(connectionId: string, database: string): Promise<void> {
   return invoke("mongo_create_database", { connectionId, database });
 }

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -9,6 +9,7 @@ import {
   emptyLayout,
   appendConnectionToLayout,
   removeConnectionFromSidebarLayout,
+  findConnectionLocation,
   createGroup as createGroupOp,
   renameGroup as renameGroupOp,
   deleteGroup as deleteGroupOp,
@@ -994,7 +995,7 @@ export const useConnectionStore = defineStore("connection", () => {
     if (scope === "root") rebuildTreeNodes();
   }
 
-  async function addConnection(config: ConnectionConfig) {
+  async function addConnection(config: ConnectionConfig, targetGroupId?: string | null) {
     const normalized = normalizeConnection(config);
     const existing = connections.value.findIndex((c) => c.id === normalized.id);
     const nextConnections = [...connections.value];
@@ -1002,7 +1003,8 @@ export const useConnectionStore = defineStore("connection", () => {
       nextConnections[existing] = normalized;
     } else {
       nextConnections.push(normalized);
-      sidebarLayout.value = appendConnectionToLayout(sidebarLayout.value, normalized.id, newConnectionGroupId.value);
+      const groupId = targetGroupId !== undefined ? targetGroupId : newConnectionGroupId.value;
+      sidebarLayout.value = appendConnectionToLayout(sidebarLayout.value, normalized.id, groupId);
     }
     await persistConnections(nextConnections);
     connections.value = nextConnections;
@@ -4056,6 +4058,9 @@ export const useConnectionStore = defineStore("connection", () => {
     },
     moveConnectionToGroup(connectionId: string, groupId: string | null) {
       updateLayoutAndRebuild(moveConnectionToGroupOp(sidebarLayout.value, connectionId, groupId));
+    },
+    groupIdForConnection(connectionId: string): string | null {
+      return findConnectionLocation(sidebarLayout.value, connectionId)?.groupId ?? null;
     },
     reorderSidebarEntry(draggedId: string, targetId: string, position: DropPosition) {
       updateLayoutAndRebuild(reorderEntryOp(sidebarLayout.value, draggedId, targetId, position));

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -19,13 +19,7 @@ import {
   mongoUseToQueryResult,
   mongoVersionToQueryResult,
   mongoWriteToQueryResult,
-  parseMongoAggregateCommand,
-  parseMongoCountDocumentsCommand,
-  parseMongoFindCommand,
-  parseMongoGetIndexesCommand,
-  parseMongoWriteCommand,
-  parseMongoUseCommand,
-  parseMongoVersionCommand,
+  splitMongoCommands,
   type MongoAggregateSafetyOptions,
 } from "@/lib/mongoShellCommand";
 import { redisCommandResultToQueryResult } from "@/lib/redisQueryResult";
@@ -1605,14 +1599,24 @@ export const useQueryStore = defineStore("query", () => {
     let useAgentResultSession = false;
     try {
       const connStore = useConnectionStore();
+      let conn = connStore.getConfig(tab.connectionId);
+      const parsedMongoCommands = conn?.db_type === "mongodb" ? splitMongoCommands(sql) : undefined;
+      let mongoCommands = parsedMongoCommands ?? [];
+      const mongoNeedsConnection = mongoCommands.some(({ command }) => command.kind !== "use");
+
       if (options?.skipEnsureConnected) {
         console.info("[DBX][executeTabSql:ensure-connected:skip]", { traceId, elapsed: elapsed(), reason: "caller" });
+      } else if (conn?.db_type === "mongodb" && mongoCommands.length > 0 && !mongoNeedsConnection) {
+        console.info("[DBX][executeTabSql:ensure-connected:skip]", { traceId, elapsed: elapsed(), reason: "mongo-use-only" });
       } else {
         console.info("[DBX][executeTabSql:ensure-connected:start]", { traceId, elapsed: elapsed() });
         await connStore.ensureConnected(tab.connectionId);
         console.info("[DBX][executeTabSql:ensure-connected:done]", { traceId, elapsed: elapsed() });
       }
-      const conn = connStore.getConfig(tab.connectionId);
+      conn = connStore.getConfig(tab.connectionId);
+      if (parsedMongoCommands === undefined && conn?.db_type === "mongodb") {
+        mongoCommands = splitMongoCommands(sql);
+      }
       const effectiveDbType = effectiveDatabaseTypeForConnection(conn);
       const useAgentCursor = usesAgentCursorForQuery(conn?.db_type);
       const queryTimeoutSecs = queryTimeoutSecsForConnection(conn);
@@ -1690,6 +1694,195 @@ export const useQueryStore = defineStore("query", () => {
         return;
       }
 
+      if (mongoCommands.length > 0) {
+        console.info("[DBX][executeTabSql:mongo:start]", { traceId, database: tab.database, commandCount: mongoCommands.length, sql });
+
+        const allResults: QueryResult[] = [];
+        // Track the effective db as we walk the batch so later commands observe
+        // earlier `use ...` statements in the same editor selection.
+        let currentDatabase = tab.database;
+        let mongoEditTarget: QueryTab["mongoEditTarget"] | undefined;
+
+        for (const parsedCommand of mongoCommands) {
+          const mongoCommand = parsedCommand.command;
+          const commandStartedAt = performance.now();
+          try {
+            switch (mongoCommand.kind) {
+              case "find": {
+                console.info("[DBX][executeTabSql:mongo-find:start]", { traceId, collection: mongoCommand.collection, database: currentDatabase });
+                const result = await api.mongoFindDocuments(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.skip, mongoCommand.limit, mongoCommand.filter, mongoCommand.projection, mongoCommand.sort, executionId);
+                const queryResult = markQueryResultRowsRaw(mongoDocumentsToQueryResult(result.documents, performance.now() - commandStartedAt, result.total));
+                allResults.push(queryResult);
+                mongoEditTarget = mongoCommands.length === 1 && queryResult.columns.includes("_id") ? { collection: mongoCommand.collection, idColumn: "_id" } : undefined;
+                console.info("[DBX][executeTabSql:mongo-find:done]", {
+                  traceId,
+                  collection: mongoCommand.collection,
+                  database: currentDatabase,
+                  rowCount: result.documents.length,
+                  total: result.total,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+              case "version": {
+                console.info("[DBX][executeTabSql:mongo-version:start]", { traceId, database: currentDatabase });
+                const version = await api.mongoServerVersion(tab.connectionId, currentDatabase, executionId);
+                allResults.push(markQueryResultRowsRaw(mongoVersionToQueryResult(version, performance.now() - commandStartedAt)));
+                mongoEditTarget = undefined;
+                console.info("[DBX][executeTabSql:mongo-version:done]", {
+                  traceId,
+                  database: currentDatabase,
+                  version,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+              case "countDocuments": {
+                console.info("[DBX][executeTabSql:mongo-count:start]", { traceId, collection: mongoCommand.collection, database: currentDatabase });
+                const result = await api.mongoFindDocuments(tab.connectionId, currentDatabase, mongoCommand.collection, 0, 1, mongoCommand.filter, undefined, undefined, executionId);
+                allResults.push(markQueryResultRowsRaw(mongoCountToQueryResult(result.total, performance.now() - commandStartedAt)));
+                mongoEditTarget = undefined;
+                console.info("[DBX][executeTabSql:mongo-count:done]", {
+                  traceId,
+                  collection: mongoCommand.collection,
+                  database: currentDatabase,
+                  total: result.total,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+              case "aggregate": {
+                if (options?.mongoSafety) {
+                  const safety = evaluateMongoAggregateSafety(mongoCommand, options.mongoSafety);
+                  if (!safety.allowed) throw new Error(safety.reason);
+                }
+                console.info("[DBX][executeTabSql:mongo-aggregate:start]", { traceId, collection: mongoCommand.collection, database: currentDatabase });
+                const aggregateMaxRows = normalizeResultPageSize(pageLimit ?? options?.pagination?.limit ?? settingsStore.editorSettings.pageSize);
+                const result = await api.mongoAggregateDocuments(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.pipeline, aggregateMaxRows, executionId);
+                allResults.push(markQueryResultRowsRaw(mongoDocumentsToQueryResult(result.documents, performance.now() - commandStartedAt, result.total)));
+                mongoEditTarget = undefined;
+                console.info("[DBX][executeTabSql:mongo-aggregate:done]", {
+                  traceId,
+                  collection: mongoCommand.collection,
+                  database: currentDatabase,
+                  rowCount: result.documents.length,
+                  total: result.total,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+              case "getIndexes": {
+                console.info("[DBX][executeTabSql:mongo-indexes:start]", { traceId, collection: mongoCommand.collection, database: currentDatabase });
+                const indexes = await api.listIndexes(tab.connectionId, currentDatabase, "", mongoCommand.collection);
+                allResults.push(markQueryResultRowsRaw(mongoIndexesToQueryResult(indexes, performance.now() - commandStartedAt)));
+                mongoEditTarget = undefined;
+                console.info("[DBX][executeTabSql:mongo-indexes:done]", {
+                  traceId,
+                  collection: mongoCommand.collection,
+                  database: currentDatabase,
+                  indexCount: indexes.length,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+              case "insert":
+              case "update":
+              case "delete":
+              case "createIndex":
+              case "dropIndex":
+              case "dropIndexes": {
+                if (options?.mongoSafety) {
+                  const safety = evaluateMongoWriteSafety(mongoCommand, options.mongoSafety);
+                  if (!safety.allowed) throw new Error(safety.reason);
+                }
+                console.info("[DBX][executeTabSql:mongo-write:start]", {
+                  traceId,
+                  database: currentDatabase,
+                  kind: mongoCommand.kind,
+                  collection: mongoCommand.collection,
+                });
+                mongoEditTarget = undefined;
+                if (mongoCommand.kind === "insert") {
+                  const result = await api.mongoInsertDocuments(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.docsJson);
+                  allResults.push(markQueryResultRowsRaw(mongoWriteToQueryResult(result.affected_rows, performance.now() - commandStartedAt)));
+                } else if (mongoCommand.kind === "update") {
+                  const result = await api.mongoUpdateDocuments(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.filter, mongoCommand.update, mongoCommand.many);
+                  allResults.push(markQueryResultRowsRaw(mongoWriteToQueryResult(result.affected_rows, performance.now() - commandStartedAt)));
+                } else if (mongoCommand.kind === "createIndex") {
+                  const result = await api.mongoCreateIndex(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.keys, mongoCommand.options);
+                  allResults.push(markQueryResultRowsRaw(mongoCreateIndexToQueryResult(result.name, performance.now() - commandStartedAt)));
+                } else if (mongoCommand.kind === "dropIndex" || mongoCommand.kind === "dropIndexes") {
+                  const result = await api.mongoDropIndexes(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.kind === "dropIndex" ? mongoCommand.index : mongoCommand.indexes, mongoCommand.kind === "dropIndex");
+                  allResults.push(markQueryResultRowsRaw(mongoDroppedIndexesToQueryResult(result.dropped_names, performance.now() - commandStartedAt)));
+                } else {
+                  const result = await api.mongoDeleteDocuments(tab.connectionId, currentDatabase, mongoCommand.collection, mongoCommand.filter, mongoCommand.many);
+                  allResults.push(markQueryResultRowsRaw(mongoWriteToQueryResult(result.affected_rows, performance.now() - commandStartedAt)));
+                }
+                console.info("[DBX][executeTabSql:mongo-write:done]", {
+                  traceId,
+                  database: currentDatabase,
+                  kind: mongoCommand.kind,
+                  collection: mongoCommand.collection,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+              case "use": {
+                currentDatabase = mongoCommand.database;
+                allResults.push(markQueryResultRowsRaw(mongoUseToQueryResult(currentDatabase, performance.now() - commandStartedAt)));
+                mongoEditTarget = undefined;
+                console.info("[DBX][executeTabSql:mongo-use:done]", {
+                  traceId,
+                  database: currentDatabase,
+                  elapsed: elapsed(),
+                });
+                break;
+              }
+            }
+          } catch (error: any) {
+            // Surface per-command failures inline and continue collecting results
+            // for the rest of the batch, matching the grouped-result UX.
+            allResults.push(toErrorResult(error));
+            mongoEditTarget = undefined;
+          }
+        }
+
+        console.info("[DBX][executeTabSql:mongo:done]", {
+          traceId,
+          database: currentDatabase,
+          commandCount: mongoCommands.length,
+          elapsed: elapsed(),
+        });
+
+        const current = tabs.value.find((t) => t.id === id);
+        if (current?.executionId === executionId) {
+          if (allResults.length > 1) {
+            // Open grouped output on the first non-error result when possible so
+            // mixed success/error batches land on the most useful table first.
+            const activeResultIndex = allResults.findIndex((result) => !result.columns.includes("Error"));
+            const resultIndex = activeResultIndex >= 0 ? activeResultIndex : 0;
+            current.results = allResults;
+            current.activeResultIndex = resultIndex;
+            current.result = allResults[resultIndex];
+          } else {
+            current.results = undefined;
+            current.activeResultIndex = undefined;
+            current.result = allResults[0];
+          }
+          touchResult(current);
+          current.queryAnalysis = undefined;
+          current.querySourceColumns = undefined;
+          current.queryEditabilityReason = undefined;
+          current.mongoEditTarget = mongoCommands.length === 1 ? mongoEditTarget : undefined;
+          current.tableMeta = undefined;
+          current.resultBaseSql = options?.resultBaseSql ?? sql;
+          current.resultSortedSql = options?.resultSortedSql;
+          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
+          if (current.database !== currentDatabase) current.database = currentDatabase;
+        }
+        return;
+      }
+
       if (tab.mode === "query") {
         const pagination = options?.pagination ?? { limit: settingsStore.editorSettings.pageSize, offset: 0 };
         const plan = await api.prepareQueryPaginationExecutionPlan({
@@ -1708,269 +1901,6 @@ export const useQueryStore = defineStore("query", () => {
       } else if (tab.mode === "data") {
         pageLimit = options?.pagination?.limit ?? tableOpenPageLimit();
         pageOffset = options?.pagination?.offset ?? 0;
-      }
-      const mongoFind = conn?.db_type === "mongodb" ? parseMongoFindCommand(sql) : null;
-      if (mongoFind) {
-        await connStore.ensureConnected(tab.connectionId);
-        console.info("[DBX][executeTabSql:mongo-find:start]", { traceId, collection: mongoFind.collection });
-        const result = await api.mongoFindDocuments(tab.connectionId, tab.database, mongoFind.collection, mongoFind.skip, mongoFind.limit, mongoFind.filter, mongoFind.projection, mongoFind.sort, executionId);
-        console.info("[DBX][executeTabSql:mongo-find:done]", {
-          traceId,
-          rowCount: result.documents.length,
-          total: result.total,
-          elapsed: elapsed(),
-        });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoDocumentsToQueryResult(result.documents, performance.now() - startedAt, result.total));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = current.result.columns.includes("_id") ? { collection: mongoFind.collection, idColumn: "_id" } : undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        return;
-      }
-      const mongoVersion = conn?.db_type === "mongodb" ? parseMongoVersionCommand(sql) : null;
-      if (mongoVersion) {
-        await connStore.ensureConnected(tab.connectionId);
-        console.info("[DBX][executeTabSql:mongo-version:start]", { traceId });
-        const version = await api.mongoServerVersion(tab.connectionId, tab.database, executionId);
-        console.info("[DBX][executeTabSql:mongo-version:done]", {
-          traceId,
-          version,
-          elapsed: elapsed(),
-        });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoVersionToQueryResult(version, performance.now() - startedAt));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        return;
-      }
-      const mongoCount = conn?.db_type === "mongodb" ? parseMongoCountDocumentsCommand(sql) : null;
-      if (mongoCount) {
-        await connStore.ensureConnected(tab.connectionId);
-        console.info("[DBX][executeTabSql:mongo-count:start]", { traceId, collection: mongoCount.collection });
-        const result = await api.mongoFindDocuments(tab.connectionId, tab.database, mongoCount.collection, 0, 1, mongoCount.filter, undefined, undefined, executionId);
-        console.info("[DBX][executeTabSql:mongo-count:done]", {
-          traceId,
-          total: result.total,
-          elapsed: elapsed(),
-        });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoCountToQueryResult(result.total, performance.now() - startedAt));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        return;
-      }
-
-      const mongoAggregate = conn?.db_type === "mongodb" ? parseMongoAggregateCommand(sql) : null;
-      if (mongoAggregate) {
-        if (options?.mongoSafety) {
-          const safety = evaluateMongoAggregateSafety(mongoAggregate, options.mongoSafety);
-          if (!safety.allowed) throw new Error(safety.reason);
-        }
-        await connStore.ensureConnected(tab.connectionId);
-        console.info("[DBX][executeTabSql:mongo-aggregate:start]", { traceId, collection: mongoAggregate.collection });
-        const aggregateMaxRows = normalizeResultPageSize(pageLimit ?? options?.pagination?.limit ?? settingsStore.editorSettings.pageSize);
-        const result = await api.mongoAggregateDocuments(tab.connectionId, tab.database, mongoAggregate.collection, mongoAggregate.pipeline, aggregateMaxRows, executionId);
-        console.info("[DBX][executeTabSql:mongo-aggregate:done]", {
-          traceId,
-          rowCount: result.documents.length,
-          total: result.total,
-          elapsed: elapsed(),
-        });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoDocumentsToQueryResult(result.documents, performance.now() - startedAt, result.total));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        return;
-      }
-
-      const mongoGetIndexes = conn?.db_type === "mongodb" ? parseMongoGetIndexesCommand(sql) : null;
-      if (mongoGetIndexes) {
-        await connStore.ensureConnected(tab.connectionId);
-        console.info("[DBX][executeTabSql:mongo-indexes:start]", { traceId, collection: mongoGetIndexes.collection });
-        const indexes = await api.listIndexes(tab.connectionId, tab.database, "", mongoGetIndexes.collection);
-        console.info("[DBX][executeTabSql:mongo-indexes:done]", {
-          traceId,
-          indexCount: indexes.length,
-          elapsed: elapsed(),
-        });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoIndexesToQueryResult(indexes, performance.now() - startedAt));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        return;
-      }
-
-      const mongoWrite = conn?.db_type === "mongodb" ? parseMongoWriteCommand(sql) : null;
-      if (mongoWrite) {
-        if (options?.mongoSafety) {
-          const safety = evaluateMongoWriteSafety(mongoWrite, options.mongoSafety);
-          if (!safety.allowed) throw new Error(safety.reason);
-        }
-        await connStore.ensureConnected(tab.connectionId);
-        console.info("[DBX][executeTabSql:mongo-write:start]", {
-          traceId,
-          kind: mongoWrite.kind,
-          collection: mongoWrite.collection,
-        });
-        let affectedRows = 0;
-        if (mongoWrite.kind === "insert") {
-          const result = await api.mongoInsertDocuments(tab.connectionId, tab.database, mongoWrite.collection, mongoWrite.docsJson);
-          affectedRows = result.affected_rows;
-        } else if (mongoWrite.kind === "update") {
-          const result = await api.mongoUpdateDocuments(tab.connectionId, tab.database, mongoWrite.collection, mongoWrite.filter, mongoWrite.update, mongoWrite.many);
-          affectedRows = result.affected_rows;
-        } else if (mongoWrite.kind === "createIndex") {
-          const result = await api.mongoCreateIndex(tab.connectionId, tab.database, mongoWrite.collection, mongoWrite.keys, mongoWrite.options);
-          console.info("[DBX][executeTabSql:mongo-write:done]", {
-            traceId,
-            indexName: result.name,
-            elapsed: elapsed(),
-          });
-          const current = tabs.value.find((t) => t.id === id);
-          if (current?.executionId === executionId) {
-            current.results = undefined;
-            current.activeResultIndex = undefined;
-            current.result = markQueryResultRowsRaw(mongoCreateIndexToQueryResult(result.name, performance.now() - startedAt));
-            touchResult(current);
-            current.queryAnalysis = undefined;
-            current.querySourceColumns = undefined;
-            current.queryEditabilityReason = undefined;
-            current.mongoEditTarget = undefined;
-            current.tableMeta = undefined;
-            current.resultBaseSql = options?.resultBaseSql ?? sql;
-            current.resultSortedSql = options?.resultSortedSql;
-            syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-          }
-          return;
-        } else if (mongoWrite.kind === "dropIndex" || mongoWrite.kind === "dropIndexes") {
-          const result = await api.mongoDropIndexes(tab.connectionId, tab.database, mongoWrite.collection, mongoWrite.kind === "dropIndex" ? mongoWrite.index : mongoWrite.indexes, mongoWrite.kind === "dropIndex");
-          console.info("[DBX][executeTabSql:mongo-write:done]", {
-            traceId,
-            droppedNames: result.dropped_names,
-            elapsed: elapsed(),
-          });
-          const current = tabs.value.find((t) => t.id === id);
-          if (current?.executionId === executionId) {
-            current.results = undefined;
-            current.activeResultIndex = undefined;
-            current.result = markQueryResultRowsRaw(mongoDroppedIndexesToQueryResult(result.dropped_names, performance.now() - startedAt));
-            touchResult(current);
-            current.queryAnalysis = undefined;
-            current.querySourceColumns = undefined;
-            current.queryEditabilityReason = undefined;
-            current.mongoEditTarget = undefined;
-            current.tableMeta = undefined;
-            current.resultBaseSql = options?.resultBaseSql ?? sql;
-            current.resultSortedSql = options?.resultSortedSql;
-            syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-          }
-          return;
-        } else {
-          const result = await api.mongoDeleteDocuments(tab.connectionId, tab.database, mongoWrite.collection, mongoWrite.filter, mongoWrite.many);
-          affectedRows = result.affected_rows;
-        }
-        console.info("[DBX][executeTabSql:mongo-write:done]", {
-          traceId,
-          affectedRows,
-          elapsed: elapsed(),
-        });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoWriteToQueryResult(affectedRows, performance.now() - startedAt));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        return;
-      }
-
-      const mongoUse = conn?.db_type === "mongodb" ? parseMongoUseCommand(sql) : null;
-      if (mongoUse) {
-        console.info("[DBX][executeTabSql:mongo-use:start]", { traceId, database: mongoUse.database });
-        const current = tabs.value.find((t) => t.id === id);
-        if (current?.executionId === executionId) {
-          current.database = mongoUse.database;
-          current.results = undefined;
-          current.activeResultIndex = undefined;
-          current.result = markQueryResultRowsRaw(mongoUseToQueryResult(mongoUse.database, performance.now() - startedAt));
-          touchResult(current);
-          current.queryAnalysis = undefined;
-          current.querySourceColumns = undefined;
-          current.queryEditabilityReason = undefined;
-          current.mongoEditTarget = undefined;
-          current.tableMeta = undefined;
-          current.resultBaseSql = options?.resultBaseSql ?? sql;
-          current.resultSortedSql = options?.resultSortedSql;
-          syncDisplayedResultRun(current, options?.resultBaseSql ?? sql);
-        }
-        console.info("[DBX][executeTabSql:mongo-use:done]", {
-          traceId,
-          database: mongoUse.database,
-          elapsed: elapsed(),
-        });
-        return;
       }
 
       const executionSchema = connectionUsesSchemaExecutionContext(conn) ? tab.schema || tab.database : tab.mode === "data" || connectionUsesDatabaseObjectTreeMode(conn) ? undefined : tab.schema;

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -1988,7 +1988,9 @@ export const useQueryStore = defineStore("query", () => {
         executionPromise = api.executeInManualTransaction(tab.txnSessionId, sqlToExecute, tab.database, executionSchema, pageLimit);
       } else {
         console.info("[DBX][executeTabSql:execute-multi:start]", { traceId, elapsed: elapsed() });
-        const clientSessionId = tab.mode === "query" || tab.mode === "data" ? tabClientSessionId(tab) : undefined;
+        // Data tabs should reuse the already-open pool; session pools are reserved
+        // for query tabs/background tasks that need connection-local state isolation.
+        const clientSessionId = tab.mode === "query" ? tabClientSessionId(tab) : undefined;
         const executionOptions = {
           ...(typeof pageLimit === "number"
             ? useAgentResultSession

--- a/apps/desktop/src/stores/savedSqlStore.ts
+++ b/apps/desktop/src/stores/savedSqlStore.ts
@@ -13,6 +13,16 @@ interface SavedSqlState {
   files: SavedSqlFile[];
 }
 
+interface SaveFileInput {
+  id?: string;
+  connectionId: string;
+  folderId?: string;
+  name: string;
+  database: string;
+  schema?: string;
+  sql: string;
+}
+
 function nowIso() {
   return new Date().toISOString();
 }
@@ -206,13 +216,16 @@ export const useSavedSqlStore = defineStore("savedSql", () => {
     await syncToLocalDirectory();
   }
 
-  async function saveFile(input: { id?: string; connectionId: string; folderId?: string; name: string; database: string; schema?: string; sql: string }) {
+  async function saveFile(input: SaveFileInput) {
     const timestamp = nowIso();
     const existing = input.id ? getFile(input.id) : undefined;
+    const hasFolderIdInput = Object.prototype.hasOwnProperty.call(input, "folderId");
     const file: SavedSqlFile = existing
       ? {
           ...existing,
-          folderId: input.folderId || undefined,
+          // Partial metadata updates should not move files out of their folder.
+          // Callers that intentionally move to root pass `folderId: undefined`.
+          folderId: hasFolderIdInput ? input.folderId || undefined : existing.folderId,
           name: input.name,
           database: input.database,
           schema: input.schema,

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1104,7 +1104,7 @@ fn is_oracle_temporal_literal_database(database_type: Option<DatabaseType>) -> b
 
 fn format_oracle_temporal_literal(text: &str, data_type: Option<&str>) -> Option<String> {
     let kind = oracle_temporal_column_kind(data_type?)?;
-    let parts = regex_like_rfc3339(text)?;
+    let parts = regex_like_oracle_temporal(text)?;
     let fraction = parts.fraction.unwrap_or_default();
     let datetime = format!("{} {}{}", parts.date, parts.time, fraction);
     match kind {
@@ -1114,6 +1114,10 @@ fn format_oracle_temporal_literal(text: &str, data_type: Option<&str>) -> Option
             Some(format!("TO_TIMESTAMP('{datetime}', '{mask}')"))
         }
         OracleTemporalKind::TimestampWithTimeZone => {
+            if parts.zone.is_empty() {
+                let mask = oracle_timestamp_format_mask(datetime.contains('.'));
+                return Some(format!("TO_TIMESTAMP('{datetime}', '{mask}')"));
+            }
             let zone = oracle_timezone_suffix(&parts.zone);
             let mask = oracle_timestamp_format_mask(datetime.contains('.'));
             Some(format!("TO_TIMESTAMP_TZ('{datetime} {zone}', '{mask} TZH:TZM')"))
@@ -1148,6 +1152,50 @@ fn oracle_timezone_suffix(zone: &str) -> String {
     } else {
         zone.to_string()
     }
+}
+
+fn regex_like_oracle_temporal(text: &str) -> Option<Rfc3339Parts> {
+    if let Some(parts) = regex_like_rfc3339(text) {
+        return Some(parts);
+    }
+    regex_like_local_datetime(text)
+}
+
+fn regex_like_local_datetime(text: &str) -> Option<Rfc3339Parts> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 10 || bytes.get(4) != Some(&b'-') || bytes.get(7) != Some(&b'-') {
+        return None;
+    }
+    let date = &text[0..10];
+    if bytes.len() == 10 {
+        return Some(Rfc3339Parts {
+            date: date.to_string(),
+            time: "00:00:00".to_string(),
+            fraction: None,
+            zone: String::new(),
+        });
+    }
+    let separator = *bytes.get(10)?;
+    if separator != b'T' && separator != b' ' {
+        return None;
+    }
+    if bytes.len() < 19 || bytes.get(13) != Some(&b':') || bytes.get(16) != Some(&b':') {
+        return None;
+    }
+    let time = &text[11..19];
+    let rest = &text[19..];
+    let fraction = if let Some(rest) = rest.strip_prefix('.') {
+        let digit_count = rest.chars().take_while(|ch| ch.is_ascii_digit()).count();
+        if digit_count == 0 || digit_count > 9 || digit_count != rest.len() {
+            return None;
+        }
+        Some(format!(".{}", &rest[..digit_count]))
+    } else if rest.is_empty() {
+        None
+    } else {
+        return None;
+    };
+    Some(Rfc3339Parts { date: date.to_string(), time: time.to_string(), fraction, zone: String::new() })
 }
 
 fn is_mysql_bit_literal_column(database_type: Option<DatabaseType>, column_info: Option<&DataGridColumnInfo>) -> bool {
@@ -2242,6 +2290,25 @@ mod tests {
         assert_eq!(
             format_grid_sql_literal(&json!("2022-08-25T09:58:43Z"), Some(DatabaseType::Oracle), Some(&text)),
             "'2022-08-25T09:58:43Z'"
+        );
+    }
+
+    #[test]
+    fn formats_oracle_temporal_literals_from_editor_values_without_nls_parsing() {
+        let timestamp = column("created_at", "TIMESTAMP(6)", true, None);
+        let date = column("event_day", "DATE", true, None);
+
+        assert_eq!(
+            format_grid_sql_literal(&json!("2022-08-25 09:58:43"), Some(DatabaseType::Oracle), Some(&timestamp)),
+            "TO_TIMESTAMP('2022-08-25 09:58:43', 'YYYY-MM-DD HH24:MI:SS')"
+        );
+        assert_eq!(
+            format_grid_sql_literal(&json!("2022-08-25 09:58:43.123456"), Some(DatabaseType::Oracle), Some(&timestamp)),
+            "TO_TIMESTAMP('2022-08-25 09:58:43.123456', 'YYYY-MM-DD HH24:MI:SS.FF')"
+        );
+        assert_eq!(
+            format_grid_sql_literal(&json!("2022-08-25 09:58:43"), Some(DatabaseType::Oracle), Some(&date)),
+            "TO_DATE('2022-08-25 09:58:43', 'YYYY-MM-DD HH24:MI:SS')"
         );
     }
 

--- a/crates/dbx-core/src/db/vector_driver.rs
+++ b/crates/dbx-core/src/db/vector_driver.rs
@@ -241,6 +241,102 @@ async fn list_chroma_collections(client: &VectorClient) -> Result<Vec<Collection
     Ok(infos)
 }
 
+pub async fn get_collection_detail(
+    client: &VectorClient,
+    database: &str,
+    collection: &str,
+) -> Result<CollectionInfo, String> {
+    match client.kind {
+        VectorDbKind::Qdrant => get_qdrant_collection_detail(client, collection).await,
+        VectorDbKind::Milvus => get_milvus_collection_detail(client, database, collection).await,
+        VectorDbKind::Weaviate => {
+            // Weaviate REST API does not expose vector dimension
+            Ok(CollectionInfo { name: collection.to_string(), id: collection.to_string(), dimension: None })
+        }
+        VectorDbKind::ChromaDb => get_chroma_collection_detail(client, collection).await,
+    }
+}
+
+async fn get_qdrant_collection_detail(client: &VectorClient, collection: &str) -> Result<CollectionInfo, String> {
+    let body = send_json(client.get(&format!("/collections/{}", path_segment(collection))), "Qdrant").await?;
+    let dim = body
+        .pointer("/result/config/params/vectors/size")
+        .and_then(Value::as_u64)
+        .or_else(|| {
+            body.pointer("/result/config/params/vectors")
+                .and_then(Value::as_object)
+                .and_then(|obj| obj.values().find_map(|v| v.get("size").and_then(|s| s.as_u64())))
+        })
+        .map(|d| d as u32);
+    Ok(CollectionInfo { name: collection.to_string(), id: collection.to_string(), dimension: dim })
+}
+
+fn milvus_vector_dim_from_field(field: &Value) -> Option<u32> {
+    if let Some(dim) = field.pointer("/params/dim").and_then(Value::as_u64) {
+        return Some(dim as u32);
+    }
+    if let Some(params) = field.get("params").and_then(Value::as_array) {
+        for param in params {
+            if param.get("key").and_then(Value::as_str) == Some("dim") {
+                if let Some(v) = param.get("value").and_then(Value::as_str) {
+                    return v.parse().ok();
+                }
+                if let Some(v) = param.get("value").and_then(Value::as_u64) {
+                    return Some(v as u32);
+                }
+            }
+        }
+    }
+    None
+}
+
+async fn get_milvus_collection_detail(
+    client: &VectorClient,
+    database: &str,
+    collection: &str,
+) -> Result<CollectionInfo, String> {
+    let db_name = if database.is_empty() { "default" } else { database };
+    let body = send_json(
+        client
+            .post("/v2/vectordb/collections/describe")
+            .json(&serde_json::json!({ "dbName": db_name, "collectionName": collection })),
+        "Milvus",
+    )
+    .await?;
+    if body.get("code").and_then(Value::as_i64) != Some(0) {
+        let msg = body.get("message").and_then(Value::as_str).unwrap_or("unknown error");
+        return Err(format!("Milvus collection detail error: {msg}"));
+    }
+    let fields = body.pointer("/data/fields").and_then(Value::as_array);
+    let dim = fields
+        .and_then(|f| {
+            f.iter().find(|f| {
+                let t = f.get("type");
+                t.and_then(Value::as_str) == Some("FloatVector")
+                    || t.and_then(Value::as_str) == Some("BinaryVector")
+                    || t.and_then(Value::as_i64) == Some(101)
+                    || t.and_then(Value::as_i64) == Some(102)
+            })
+        })
+        .and_then(milvus_vector_dim_from_field);
+    Ok(CollectionInfo { name: collection.to_string(), id: collection.to_string(), dimension: dim })
+}
+
+async fn get_chroma_collection_detail(client: &VectorClient, collection: &str) -> Result<CollectionInfo, String> {
+    let body = send_json(
+        client.get(&format!(
+            "/api/v2/tenants/default_tenant/databases/default_database/collections/{}",
+            path_segment(collection)
+        )),
+        "ChromaDB",
+    )
+    .await?;
+    let name = body.get("name").and_then(Value::as_str).unwrap_or(collection);
+    let id = body.get("id").and_then(Value::as_str).unwrap_or(collection);
+    let dimension = body.get("dimension").and_then(|v| v.as_u64()).map(|d| d as u32);
+    Ok(CollectionInfo { name: name.to_string(), id: id.to_string(), dimension })
+}
+
 fn chroma_get_response_to_rows(body: &Value) -> Vec<Value> {
     let ids = body.get("ids").and_then(Value::as_array).cloned().unwrap_or_default();
     let docs = body.get("documents").and_then(Value::as_array).cloned().unwrap_or_default();

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -844,6 +844,25 @@ pub async fn list_vector_collections_core(
     db::vector_driver::list_collections_with_db(&client, database).await
 }
 
+/// Get detailed metadata for a single vector collection (dimension, config, etc).
+pub async fn get_vector_collection_detail_core(
+    state: &AppState,
+    connection_id: &str,
+    database: &str,
+    collection: &str,
+) -> Result<db::vector_driver::CollectionInfo, String> {
+    let pool_key =
+        state.get_or_create_pool(connection_id, if database.is_empty() { None } else { Some(database) }).await?;
+    let client = {
+        let connections = state.connections.read().await;
+        match connections.get(&pool_key) {
+            Some(PoolKind::VectorDb(client)) => client.clone(),
+            _ => return Err("Not a vector database connection".to_string()),
+        }
+    };
+    db::vector_driver::get_collection_detail(&client, database, collection).await
+}
+
 pub async fn get_table_comment_core(
     state: &AppState,
     connection_id: &str,

--- a/crates/dbx-core/src/table_structure_sql/column_alter.rs
+++ b/crates/dbx-core/src/table_structure_sql/column_alter.rs
@@ -360,18 +360,19 @@ pub(super) fn build_oracle_like_existing_column_sql(
     if type_changed || nullable_changed || default_changed {
         let data_type = column_data_type(dialect, column);
         let mut parts = vec![quote_ident(dialect, &current_name), data_type];
-        // Always include nullability so the statement is self-contained (required by Dameng).
-        if !column.is_nullable {
-            parts.push("NOT NULL".to_string());
-        } else {
-            parts.push("NULL".to_string());
-        }
         let default_value = normalize_default(Some(&column.default_value));
         if !default_value.is_empty() {
             parts.push(format!("DEFAULT {}", format_default_for_sql(dialect, &column.data_type, &default_value)));
         } else if default_changed {
             // User cleared the default — explicitly drop it.
             parts.push("DEFAULT NULL".to_string());
+        }
+        if nullable_changed {
+            if column.is_nullable {
+                parts.push("NULL".to_string());
+            } else {
+                parts.push("NOT NULL".to_string());
+            }
         }
         statements.push(format!("ALTER TABLE {table} MODIFY ({});", parts.join(" ")));
     }

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -293,6 +293,60 @@ fn oracle_does_not_generate_drop_sql_for_all_columns() {
 }
 
 #[test]
+fn oracle_timestamp_default_precedes_nullability_in_modify_sql() {
+    let mut col = column("time");
+    col.data_type = "TIMESTAMP(6)".to_string();
+    col.default_value = "CURRENT_TIMESTAMP".to_string();
+    col.original = Some(ColumnInfo {
+        name: "time".to_string(),
+        data_type: "TIMESTAMP(6)".to_string(),
+        is_nullable: true,
+        column_default: None,
+        is_primary_key: false,
+        extra: None,
+        comment: Some(String::new()),
+    });
+
+    let result = build_single_column_alter_sql(SingleColumnAlterSqlOptions {
+        database_type: Some(DatabaseType::Oracle),
+        schema: Some("DBX_TEST".to_string()),
+        table_name: "test".to_string(),
+        column: col,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(
+        result.statements,
+        vec!["ALTER TABLE \"DBX_TEST\".\"test\" MODIFY (\"time\" TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP);"]
+    );
+}
+
+#[test]
+fn oracle_timestamp_precision_change_does_not_repeat_unchanged_nullability() {
+    let mut col = column("time");
+    col.data_type = "TIMESTAMP(9)".to_string();
+    col.original = Some(ColumnInfo {
+        name: "time".to_string(),
+        data_type: "TIMESTAMP(6)".to_string(),
+        is_nullable: true,
+        column_default: None,
+        is_primary_key: false,
+        extra: None,
+        comment: Some(String::new()),
+    });
+
+    let result = build_single_column_alter_sql(SingleColumnAlterSqlOptions {
+        database_type: Some(DatabaseType::Oracle),
+        schema: Some("DBX_TEST".to_string()),
+        table_name: "test".to_string(),
+        column: col,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.statements, vec!["ALTER TABLE \"DBX_TEST\".\"test\" MODIFY (\"time\" TIMESTAMP(9));"]);
+}
+
+#[test]
 fn iris_drop_index_includes_table_name() {
     let mut old_index = index("index_id", &["ID"]);
     old_index.marked_for_drop = true;

--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -442,6 +442,7 @@ async fn main() {
         // MongoDB
         .route("/mongo/list-databases", post(routes::mongo::list_databases))
         .route("/mongo/list-collections", post(routes::mongo::list_collections))
+        .route("/mongo/vector-collection-detail", post(routes::mongo::vector_collection_detail))
         .route("/mongo/create-database", post(routes::mongo::create_database))
         .route("/mongo/drop-database", post(routes::mongo::drop_database))
         .route("/mongo/drop-collection", post(routes::mongo::drop_collection))

--- a/crates/dbx-web/src/routes/mongo.rs
+++ b/crates/dbx-web/src/routes/mongo.rs
@@ -196,6 +196,29 @@ pub async fn list_collections(
     Ok(Json(result))
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VectorCollectionDetailRequest {
+    pub connection_id: String,
+    pub database: String,
+    pub collection: String,
+}
+
+pub async fn vector_collection_detail(
+    State(state): State<Arc<WebState>>,
+    Json(req): Json<VectorCollectionDetailRequest>,
+) -> Result<Json<dbx_core::db::vector_driver::CollectionInfo>, AppError> {
+    let result = dbx_core::schema::get_vector_collection_detail_core(
+        &state.app,
+        &req.connection_id,
+        &req.database,
+        &req.collection,
+    )
+    .await
+    .map_err(AppError)?;
+    Ok(Json(result))
+}
+
 pub async fn create_database(
     State(state): State<Arc<WebState>>,
     Json(req): Json<MongoCollectionRequest>,

--- a/packages/app-tests/agentVersionBump.test.ts
+++ b/packages/app-tests/agentVersionBump.test.ts
@@ -1,0 +1,130 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test } from "vitest";
+
+const { evaluateAgentVersionBump } = await importScript(".github/scripts/bump-agent-versions.mjs");
+
+function importScript(path: string): Promise<Record<string, any>> {
+  const source = readFileSync(resolve(path), "utf8").replace(/^#!.*\r?\n/, "");
+  return import(`data:text/javascript;base64,${Buffer.from(source).toString("base64")}`);
+}
+
+function moduleFixture(paths: string[], files: Record<string, string> = {}) {
+  const existing = new Set(paths);
+  return {
+    moduleExists: (path: string) => existing.has(path),
+    readModuleFile: (path: string) => files[path] ?? "",
+  };
+}
+
+test("common agent runtime changes bump only modules that package common", () => {
+  const fixture = moduleFixture(
+    [
+      "agents/drivers/access",
+      "agents/drivers/access/build.gradle",
+      "agents/drivers/kafka",
+      "agents/drivers/kafka/build.gradle",
+      "agents/drivers/mongodb",
+      "agents/drivers/mongodb/build.gradle",
+      "agents/drivers/oracle-go",
+      "agents/drivers/xugu",
+    ],
+    {
+      "agents/drivers/mongodb/build.gradle": "dependencies { implementation project(':common') }",
+    },
+  );
+
+  const result = evaluateAgentVersionBump({
+    versions: {
+      access: "0.1.0",
+      kafka: "0.1.0",
+      mongodb: "0.1.0",
+      oracle: "0.1.0",
+      xugu: "0.1.0",
+    },
+    changedFiles: ["agents/common/src/main/resources/agent-protocol-v1.json"],
+    legacyStandaloneModules: new Set(["kafka", "mongodb"]),
+    ...fixture,
+  });
+
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.versions, {
+    access: "0.1.1",
+    kafka: "0.1.0",
+    mongodb: "0.1.1",
+    oracle: "0.1.0",
+    xugu: "0.1.0",
+  });
+});
+
+test("common agent test changes do not bump driver versions", () => {
+  const fixture = moduleFixture(["agents/drivers/access", "agents/drivers/access/build.gradle"]);
+
+  const result = evaluateAgentVersionBump({
+    versions: {
+      access: "0.1.0",
+    },
+    changedFiles: ["agents/common/src/test/java/com/dbx/agent/AbstractJdbcAgentTest.java"],
+    ...fixture,
+  });
+
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.versions, {
+    access: "0.1.0",
+  });
+});
+
+test("native agent source changes still bump native module versions", () => {
+  const fixture = moduleFixture([
+    "agents/drivers/access",
+    "agents/drivers/access/build.gradle",
+    "agents/drivers/oracle-go",
+    "agents/drivers/xugu",
+  ]);
+
+  const result = evaluateAgentVersionBump({
+    versions: {
+      access: "0.1.0",
+      oracle: "0.1.0",
+      xugu: "0.1.0",
+    },
+    changedFiles: ["agents/drivers/oracle-go/main.go", "agents/drivers/xugu/main.go"],
+    ...fixture,
+  });
+
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.versions, {
+    access: "0.1.0",
+    oracle: "0.1.1",
+    xugu: "0.1.1",
+  });
+});
+
+test("manual agent versions are preserved while other changed modules auto bump", () => {
+  const fixture = moduleFixture([
+    "agents/drivers/access",
+    "agents/drivers/access/build.gradle",
+    "agents/drivers/dameng",
+    "agents/drivers/dameng/build.gradle",
+  ]);
+
+  const result = evaluateAgentVersionBump({
+    versions: {
+      access: "0.1.2",
+      dameng: "0.1.0",
+    },
+    prevVersions: {
+      access: "0.1.1",
+      dameng: "0.1.0",
+    },
+    changedFiles: ["agents/common/src/main/java/com/dbx/agent/JdbcExecutor.java", "agents/versions.json"],
+    ...fixture,
+  });
+
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.versions, {
+    access: "0.1.2",
+    dameng: "0.1.1",
+  });
+});

--- a/packages/app-tests/connectionStoreGroupedConnect.test.ts
+++ b/packages/app-tests/connectionStoreGroupedConnect.test.ts
@@ -100,6 +100,59 @@ test("connecting a grouped connection updates it in place instead of adding a ro
   }
 });
 
+test("duplicating a grouped connection keeps the copy in the same group", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = installMemoryStorage();
+  const originalConnection = conn("conn-1", "Grouped MySQL");
+  let savedConnections: ConnectionConfig[] = [originalConnection];
+  let savedLayout: SidebarLayout | null = {
+    groups: [{ id: "group-1", name: "Group", collapsed: false }],
+    order: [{ type: "group", id: "group-1", connectionIds: ["conn-1"] }],
+  };
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url === "/api/connection/list") {
+      return new Response(JSON.stringify(savedConnections), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/layout/sidebar") {
+      if (init?.method === "POST") {
+        savedLayout = JSON.parse(String(init.body ?? "null"));
+        return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify(savedLayout), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/connection/save") {
+      savedConnections = JSON.parse(String(init?.body ?? "[]"));
+      return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    setActivePinia(createPinia());
+    const store = useConnectionStore();
+    await store.initFromDisk();
+
+    const copy = { ...originalConnection, id: "conn-copy", name: "Grouped MySQL (Copy)" };
+    await store.addConnection(copy, store.groupIdForConnection(originalConnection.id));
+
+    assert.deepEqual(
+      store.treeNodes.map((node) => node.id),
+      ["group-1"],
+    );
+    assert.equal(store.treeNodes[0].type, "connection-group");
+    assert.deepEqual(
+      store.treeNodes[0].children?.map((node) => node.id),
+      ["conn-1", "conn-copy"],
+    );
+    assert.equal(countConnectionNodes(store.treeNodes, "conn-copy"), 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    storage.restore();
+  }
+});
+
 test("importing grouped dbx connections remaps exported layout to new connection ids", async () => {
   const originalFetch = globalThis.fetch;
   const storage = installMemoryStorage();

--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -8,11 +8,14 @@ import {
   mongoDocumentsToQueryResult,
   mongoIndexesToQueryResult,
   parseMongoAggregateCommand,
+  parseMongoCommand,
   parseMongoCountDocumentsCommand,
   parseMongoFindCommand,
   parseMongoGetIndexesCommand,
   parseMongoVersionCommand,
   parseMongoWriteCommand,
+  splitMongoCommands,
+  splitMongoCommandRanges,
 } from "../../apps/desktop/src/lib/mongoShellCommand.ts";
 import { buildMongoUpdateDocument as buildMongoDocumentUpdate, formatMongoShellLiteral as formatMongoDocumentShellLiteral } from "../../apps/desktop/src/lib/mongoDocumentValues.ts";
 
@@ -89,6 +92,21 @@ test("parseMongoFindCommand rejects unsupported mongo shell commands", () => {
 test("parseMongoVersionCommand parses db.version", () => {
   assert.deepEqual(parseMongoVersionCommand("db.version();"), { kind: "version" });
   assert.equal(parseMongoVersionCommand("db.jobs.version()"), null);
+});
+
+test("parseMongoCommand normalizes outer comments around a command", () => {
+  const parsed = parseMongoCommand(`
+    // current database
+    use accounting;
+    // keep working here
+  `);
+  assert.deepEqual(parsed, {
+    text: "use accounting;",
+    command: {
+      kind: "use",
+      database: "accounting",
+    },
+  });
 });
 
 test("parseMongoWriteCommand accepts unquoted insert and update commands", () => {
@@ -209,6 +227,69 @@ test("parseMongoGetIndexesCommand parses collection index commands", () => {
     collection: "audit.logs",
   });
   assert.equal(parseMongoGetIndexesCommand("db.web_log.getIndexes({})"), null);
+});
+
+test("splitMongoCommands keeps semicolon-separated mongo commands in order", () => {
+  const commands = splitMongoCommands(`
+    db.users.insertOne({ name: "A" });
+    db.users.insertOne({ name: "B" });
+  `);
+  assert.deepEqual(
+    commands.map(({ text, command }) => ({ kind: command.kind, text })),
+    [
+      { kind: "insert", text: 'db.users.insertOne({ name: "A" })' },
+      { kind: "insert", text: 'db.users.insertOne({ name: "B" })' },
+    ],
+  );
+});
+
+test("splitMongoCommands splits top-level line starts without semicolons", () => {
+  const commands = splitMongoCommands(`
+    use accounting
+    db.getCollection("entries")
+      .find({ status: "open" })
+      .limit(5)
+  `);
+  assert.deepEqual(
+    commands.map(({ text, command }) => ({ kind: command.kind, text })),
+    [
+      { kind: "use", text: "use accounting" },
+      { kind: "find", text: 'db.getCollection("entries")\n      .find({ status: "open" })\n      .limit(5)' },
+    ],
+  );
+});
+
+test("splitMongoCommandRanges preserve document offsets for newline-separated commands", () => {
+  const source = `
+    use accounting
+    db.getCollection("entries")
+      .find({ status: "open" })
+      .limit(5)
+  `;
+  const commands = splitMongoCommandRanges(source);
+
+  assert.deepEqual(
+    commands.map(({ from, to, text, command }) => ({
+      from,
+      to,
+      text,
+      kind: command.kind,
+    })),
+    [
+      {
+        from: source.indexOf("use accounting"),
+        to: source.indexOf("use accounting") + "use accounting".length,
+        text: "use accounting",
+        kind: "use",
+      },
+      {
+        from: source.indexOf('db.getCollection("entries")'),
+        to: source.indexOf('      .limit(5)') + "      .limit(5)".length,
+        text: 'db.getCollection("entries")\n      .find({ status: "open" })\n      .limit(5)',
+        kind: "find",
+      },
+    ],
+  );
 });
 
 test("evaluateMongoAggregateSafety blocks write stages unless MCP write flags allow them", () => {

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -2120,6 +2120,189 @@ test("mongo dropIndexes execution returns dropped index names", async () => {
   }
 });
 
+test("mongo multi-command execution runs writes sequentially and keeps grouped results", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const insertBodies: any[] = [];
+
+  connectionStore.addEphemeralConnection({
+    ...conn("mongo-1"),
+    db_type: "mongodb",
+    port: 27017,
+  });
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/mongo/insert-documents") {
+      insertBodies.push(JSON.parse(String(init?.body ?? "{}")));
+      return new Response(JSON.stringify({ affected_rows: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const tabId = store.createTab("mongo-1", "accounting", "Query", "query", "");
+    await store.executeTabSql(
+      tabId,
+      `
+        db.users.insertOne({ name: "Ada" });
+        db.users.insertOne({ name: "Grace" });
+      `,
+    );
+    const tab = store.tabs.find((item) => item.id === tabId);
+
+    assert.equal(insertBodies.length, 2);
+    assert.deepEqual(
+      insertBodies.map((body) => ({ database: body.database, collection: body.collection, docsJson: body.docsJson })),
+      [
+        { database: "accounting", collection: "users", docsJson: '{ "name": "Ada" }' },
+        { database: "accounting", collection: "users", docsJson: '{ "name": "Grace" }' },
+      ],
+    );
+    assert.equal(tab?.results?.length, 2);
+    assert.equal(tab?.activeResultIndex, 0);
+    assert.equal(tab?.result?.affected_rows, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("mongo multi-command execution reconnects before running commands", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const requests: string[] = [];
+
+  connectionStore.addEphemeralConnection({
+    ...conn("mongo-1"),
+    db_type: "mongodb",
+    port: 27017,
+  });
+  connectionStore.connectedIds.delete("mongo-1");
+
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url === "/api/connection/connect") {
+      requests.push(url);
+      return new Response(JSON.stringify("connected"), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/mongo/insert-documents") {
+      requests.push(url);
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      assert.equal(body.database, "accounting");
+      return new Response(JSON.stringify({ affected_rows: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  };
+
+  try {
+    const tabId = store.createTab("mongo-1", "accounting", "Query", "query", "");
+    await store.executeTabSql(tabId, 'db.users.insertOne({ name: "Ada" })');
+
+    assert.deepEqual(requests, ["/api/connection/connect", "/api/mongo/insert-documents"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("mongo multi-command execution applies use database before later commands", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const insertBodies: any[] = [];
+
+  connectionStore.addEphemeralConnection({
+    ...conn("mongo-1"),
+    db_type: "mongodb",
+    port: 27017,
+  });
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/mongo/insert-documents") {
+      insertBodies.push(JSON.parse(String(init?.body ?? "{}")));
+      return new Response(JSON.stringify({ affected_rows: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const tabId = store.createTab("mongo-1", "accounting", "Query", "query", "");
+    await store.executeTabSql(
+      tabId,
+      `
+        use archive
+        db.users.insertOne({ name: "Ada" })
+      `,
+    );
+    const tab = store.tabs.find((item) => item.id === tabId);
+
+    assert.equal(insertBodies.length, 1);
+    assert.equal(insertBodies[0]?.database, "archive");
+    assert.equal(tab?.database, "archive");
+    assert.equal(tab?.results?.length, 2);
+    assert.deepEqual(tab?.results?.[0]?.rows, [["switched to db archive"]]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("mongo use-only execution updates the tab without reconnecting", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const requests: string[] = [];
+
+  connectionStore.addEphemeralConnection({
+    ...conn("mongo-1"),
+    db_type: "mongodb",
+    port: 27017,
+  });
+  connectionStore.connectedIds.delete("mongo-1");
+
+  globalThis.fetch = async (input) => {
+    requests.push(String(input));
+    return new Response("unexpected request", { status: 500 });
+  };
+
+  try {
+    const tabId = store.createTab("mongo-1", "accounting", "Query", "query", "");
+    await store.executeTabSql(tabId, "use archive");
+    const tab = store.tabs.find((item) => item.id === tabId);
+
+    assert.deepEqual(requests, []);
+    assert.equal(tab?.database, "archive");
+    assert.deepEqual(tab?.result?.rows, [["switched to db archive"]]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test("table data export fetches every filtered page", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -2628,7 +2628,7 @@ test("query execution is scoped to the tab client session", async () => {
   }
 });
 
-test("data tab execution is scoped to the tab client session", async () => {
+test("data tab execution reuses the shared connection pool", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());
   const connectionStore = useConnectionStore();
@@ -2654,7 +2654,7 @@ test("data tab execution is scoped to the tab client session", async () => {
   try {
     await store.executeTabSql(tabId, "select * from users");
 
-    assert.equal(executeBody.clientSessionId, tabId);
+    assert.equal(executeBody.clientSessionId, undefined);
     assert.equal(executeBody.timeoutSecs, 30);
   } finally {
     globalThis.fetch = originalFetch;

--- a/packages/app-tests/savedSqlStore.test.ts
+++ b/packages/app-tests/savedSqlStore.test.ts
@@ -8,6 +8,7 @@ const apiMock = vi.hoisted(() => ({
   loadSavedSqlLibrary: vi.fn<() => Promise<SavedSqlLibrary>>(),
   loadSavedSqlFile: vi.fn<(id: string) => Promise<SavedSqlFile | null>>(),
   saveSavedSqlFolder: vi.fn<(folder: SavedSqlFolder) => Promise<SavedSqlFolder>>(),
+  saveSavedSqlFile: vi.fn<(file: SavedSqlFile) => Promise<SavedSqlFile>>(),
   syncSavedSqlDirectory: vi.fn<() => Promise<void>>(),
 }));
 
@@ -18,6 +19,7 @@ beforeEach(() => {
   apiMock.loadSavedSqlLibrary.mockResolvedValue({ folders: [], files: [] });
   apiMock.loadSavedSqlFile.mockResolvedValue(null);
   apiMock.saveSavedSqlFolder.mockImplementation(async (folder) => folder);
+  apiMock.saveSavedSqlFile.mockImplementation(async (file) => file);
   apiMock.syncSavedSqlDirectory.mockResolvedValue();
   vi.clearAllMocks();
 });
@@ -71,4 +73,65 @@ test("saved SQL summaries load file content on demand", async () => {
   assert.equal(hydrated?.sql, "SELECT 1;");
   assert.equal(store.files[0]?.sql, "SELECT 1;");
   assert.equal(apiMock.loadSavedSqlFile.mock.calls.length, 1);
+});
+
+test("saving an existing SQL file without folderId keeps its folder", async () => {
+  const file: SavedSqlFile = {
+    id: "sql-1",
+    connectionId: "conn-1",
+    folderId: "folder-1",
+    name: "query.sql",
+    database: "db",
+    sql: "SELECT 1;",
+    sqlLoaded: true,
+    createdAt: "2026-06-27T00:00:00.000Z",
+    updatedAt: "2026-06-27T00:00:00.000Z",
+  };
+  apiMock.loadSavedSqlLibrary.mockResolvedValue({ folders: [], files: [file] });
+
+  const store = useSavedSqlStore();
+  await store.initFromStorage();
+
+  const saved = await store.saveFile({
+    id: "sql-1",
+    connectionId: "conn-2",
+    name: "query.sql",
+    database: "other_db",
+    sql: "SELECT 1;",
+  });
+
+  assert.equal(saved.folderId, "folder-1");
+  assert.equal(apiMock.saveSavedSqlFile.mock.calls[0]?.[0].folderId, "folder-1");
+  assert.equal(store.getFile("sql-1")?.folderId, "folder-1");
+});
+
+test("saving an existing SQL file with root folder explicitly moves it to root", async () => {
+  const file: SavedSqlFile = {
+    id: "sql-1",
+    connectionId: "conn-1",
+    folderId: "folder-1",
+    name: "query.sql",
+    database: "db",
+    sql: "SELECT 1;",
+    sqlLoaded: true,
+    createdAt: "2026-06-27T00:00:00.000Z",
+    updatedAt: "2026-06-27T00:00:00.000Z",
+  };
+  apiMock.loadSavedSqlLibrary.mockResolvedValue({ folders: [], files: [file] });
+
+  const store = useSavedSqlStore();
+  await store.initFromStorage();
+
+  const saved = await store.saveFile({
+    id: "sql-1",
+    connectionId: "conn-1",
+    folderId: undefined,
+    name: "query.sql",
+    database: "db",
+    sql: "SELECT 1;",
+  });
+
+  assert.equal(saved.folderId, undefined);
+  assert.equal(apiMock.saveSavedSqlFile.mock.calls[0]?.[0].folderId, undefined);
+  assert.equal(store.getFile("sql-1")?.folderId, undefined);
 });

--- a/packages/app-tests/sqlExecutionTarget.test.ts
+++ b/packages/app-tests/sqlExecutionTarget.test.ts
@@ -1,0 +1,42 @@
+import { strict as assert } from "node:assert";
+import { beforeEach, test, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => ({
+  findStatementAtCursor: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => apiMock);
+
+const { resolveExecutableSqlWithBackend } = await import("../../apps/desktop/src/lib/sqlExecutionTarget.ts");
+
+beforeEach(() => {
+  apiMock.findStatementAtCursor.mockReset();
+});
+
+test("mongodb backend resolution keeps the full text when nothing is selected", async () => {
+  apiMock.findStatementAtCursor.mockResolvedValue("db.users.insertOne({ name: 'ignored' })");
+
+  const fullSql = "db.users.insertOne({ name: 'Ada' });\ndb.users.insertOne({ name: 'Grace' });";
+  const resolved = await resolveExecutableSqlWithBackend(fullSql, "", {
+    mode: "current",
+    cursorPos: fullSql.indexOf("Grace"),
+    databaseType: "mongodb",
+  });
+
+  assert.equal(resolved, fullSql);
+  assert.equal(apiMock.findStatementAtCursor.mock.calls.length, 0);
+});
+
+test("non-mongodb backend resolution still asks the backend for the current statement", async () => {
+  apiMock.findStatementAtCursor.mockResolvedValue("SELECT 2");
+
+  const fullSql = "SELECT 1;\nSELECT 2;";
+  const resolved = await resolveExecutableSqlWithBackend(fullSql, "", {
+    mode: "current",
+    cursorPos: fullSql.indexOf("2"),
+    databaseType: "postgres",
+  });
+
+  assert.equal(resolved, "SELECT 2");
+  assert.deepEqual(apiMock.findStatementAtCursor.mock.calls[0], [fullSql, fullSql.indexOf("2"), "postgres"]);
+});

--- a/packages/app-tests/useDataGridActions.test.ts
+++ b/packages/app-tests/useDataGridActions.test.ts
@@ -98,7 +98,7 @@ test("data reload executes before slow metadata refresh completes", async () => 
     const reload = actions.onReloadData(undefined, undefined, undefined, undefined, 50, 0);
 
     await waitFor(() => !!executeBody);
-    assert.equal(executeBody.clientSessionId, tabId);
+    assert.equal(executeBody.clientSessionId, undefined);
     assert.deepEqual(tab.result?.rows, [[1]]);
 
     await waitFor(() => typeof resolveColumns === "function");

--- a/src-tauri/src/commands/mongo_cmd.rs
+++ b/src-tauri/src/commands/mongo_cmd.rs
@@ -41,6 +41,16 @@ pub async fn mongo_list_collections(
 }
 
 #[tauri::command]
+pub async fn vector_collection_detail(
+    state: State<'_, Arc<AppState>>,
+    connection_id: String,
+    database: String,
+    collection: String,
+) -> Result<dbx_core::db::vector_driver::CollectionInfo, String> {
+    dbx_core::schema::get_vector_collection_detail_core(&state, &connection_id, &database, &collection).await
+}
+
+#[tauri::command]
 pub async fn mongo_create_database(
     state: State<'_, Arc<AppState>>,
     connection_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -848,6 +848,7 @@ pub fn run() {
             commands::sqlite_backup::backup_sqlite_database,
             commands::mongo_cmd::mongo_list_databases,
             commands::mongo_cmd::mongo_list_collections,
+            commands::mongo_cmd::vector_collection_detail,
             commands::mongo_cmd::mongo_create_database,
             commands::mongo_cmd::mongo_drop_database,
             commands::mongo_cmd::mongo_drop_collection,


### PR DESCRIPTION
## 变更说明

修复 MongoDB 查询编辑器在“未选中文本”时执行多条 shell 命令会走错执行路径的问题。此前顶部执行在 MongoDB 下会被后端的“当前语句”解析截断，导致只有手动选中后才能稳定执行；同时侧边栏 gutter 的执行入口也没有严格限定为当前语句。

这次改动保持功能最小化，只收敛现有行为：
- 顶部执行按钮在 MongoDB 下无选区时继续执行全文，支持一段文本里的多条 Mongo shell 命令顺序执行。
- 左侧 gutter 执行按钮只执行当前这一条 Mongo 命令，不再误跑整段文本。
- Mongo 命令解析收敛为 `ParsedMongoCommand = { text, command }`，并补齐命令范围拆分，供批量执行和 gutter 定位复用。
- 批量执行会按顺序处理 `use` / `find` / `aggregate` / 写命令，并让同一批次里的 `use xxx` 影响后续命令的数据库上下文。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [x] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

说明：本次属于编辑器执行语义修复，没有新增视觉样式；当前主要通过自动化测试覆盖“顶部运行全部 / 侧边栏运行当前语句”的行为。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已运行：



结果：4 个测试文件，162 个测试全部通过。

## 关联 Issue
Related  #2293
