### PR TITLE
修复弹窗遮罩阻塞窗口拖回的问题

### DIFF
--- a/apps/desktop/src/components/ui/dialog/DialogOverlay.vue
+++ b/apps/desktop/src/components/ui/dialog/DialogOverlay.vue
@@ -4,14 +4,30 @@ import type { HTMLAttributes } from "vue";
 import { reactiveOmit } from "@vueuse/core";
 import { DialogOverlay } from "reka-ui";
 import { cn } from "@/lib/utils";
+import { isTauriRuntime } from "@/lib/tauriRuntime";
 
 const props = defineProps<DialogOverlayProps & { class?: HTMLAttributes["class"] }>();
 
 const delegatedProps = reactiveOmit(props, "class");
+const isDesktop = isTauriRuntime();
+
+async function startWindowDrag(event: PointerEvent) {
+  if (!isDesktop || event.button !== 0) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const { getCurrentWindow } = await import("@tauri-apps/api/window");
+  const currentWindow = getCurrentWindow();
+  if (event.detail >= 2) {
+    await currentWindow.toggleMaximize().catch(() => {});
+    return;
+  }
+  await currentWindow.startDragging().catch(() => {});
+}
 </script>
 
 <template>
   <DialogOverlay data-slot="dialog-overlay" v-bind="delegatedProps" :class="cn('data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-open:supports-backdrop-filter:backdrop-blur-xs bg-black/10 duration-100 fixed inset-0 isolate z-50', props.class)">
+    <div v-if="isDesktop" aria-hidden="true" class="fixed inset-x-0 top-0 h-10 pointer-events-auto" data-tauri-drag-region @pointerdown="startWindowDrag" />
     <slot />
   </DialogOverlay>
 </template>


### PR DESCRIPTION
## 变更
- 在桌面端弹窗遮罩顶部增加透明窗口拖拽区域
- 支持在该区域拖动窗口，并支持双击最大化/恢复
- 仅在 Tauri 桌面端启用，避免影响 Web 端弹窗行为

## 验证
- pnpm typecheck
- pnpm exec oxlint apps/desktop/src/components/ui/dialog/DialogOverlay.vue
- pnpm tauri build --debug --bundles app --no-sign --config '{"productName":"DBX 2334","identifier":"com.dbx.issue2334"}'\n\nFixes #2334