### PR TITLE
fix(jdbc): decode URL credentials for multi-at usernames

### DIFF
--- a/packages/app-tests/connectionUrl.test.ts
+++ b/packages/app-tests/connectionUrl.test.ts
@@ -96,6 +96,18 @@ test("parses MySQL JDBC user and password URL params as credentials", () => {
   assert.equal(parsed.urlParams, "useUnicode=true&characterEncoding=UTF8&useSSL=false");
 });
 
+test("parses MySQL JDBC URL params with ProxySQL multi-at usernames", () => {
+  const parsed = parseConnectionUrl("jdbc:mysql://127.0.0.1:6033/example?user=xxxxx%40db_readonly%40127.0.0.1&password=p%40wd&useSSL=false");
+
+  assert.equal(parsed.dbType, "mysql");
+  assert.equal(parsed.host, "127.0.0.1");
+  assert.equal(parsed.port, 6033);
+  assert.equal(parsed.username, "xxxxx@db_readonly@127.0.0.1");
+  assert.equal(parsed.password, "p@wd");
+  assert.equal(parsed.database, "example");
+  assert.equal(parsed.urlParams, "useSSL=false");
+});
+
 test("leaves non-JDBC MySQL user and password URL params untouched", () => {
   const parsed = parseConnectionUrl("mysql://127.0.0.1:1234/example?user=admin&password=pwd&charset=utf8mb4");
 

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -45,6 +45,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public final class DbxJdbcPlugin {
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -335,14 +336,14 @@ public final class DbxJdbcPlugin {
         if (url == null) {
             throw new IllegalArgumentException("JDBC URL is required.");
         }
-        JdbcUrlCredentials urlCredentials = extractJdbcUrlCredentials(url);
-        url = urlCredentials.url;
         String key = connectionKey(connection);
         if (sharedConnection != null && key.equals(sharedConnectionKey) && !sharedConnection.isClosed()) {
             return sharedConnection;
         }
         closeSharedConnection();
 
+        JdbcUrlCredentials urlCredentials = extractJdbcUrlCredentials(url);
+        url = urlCredentials.url;
         Properties properties = new Properties();
         String username = optionalText(connection, "username");
         String password = optionalText(connection, "password");
@@ -1662,8 +1663,6 @@ public final class DbxJdbcPlugin {
 
     private record JdbcUrlCredentials(String url, String username, String password) {}
 
-    private record JdbcUrlParam(String separator, String text) {}
-
     static JdbcUrlCredentials extractJdbcUrlCredentials(String url) {
         if (url == null) {
             return new JdbcUrlCredentials(null, null, null);
@@ -1681,15 +1680,15 @@ public final class DbxJdbcPlugin {
         String username = null;
         String password = null;
         boolean foundCredential = false;
-        List<JdbcUrlParam> keptParams = new ArrayList<>();
-        for (JdbcUrlParam part : splitJdbcUrlParams(query)) {
-            String name = partName(part.text());
+        List<String> keptParams = new ArrayList<>();
+        for (String part : splitJdbcUrlParams(query)) {
+            String name = partName(part);
             String key = decodeQueryPart(name).trim().toLowerCase(Locale.ROOT);
             if ("user".equals(key)) {
-                username = emptyToNull(decodeQueryPart(partValue(part.text())).trim());
+                username = decodeQueryPart(partValue(part));
                 foundCredential = true;
             } else if ("password".equals(key)) {
-                password = emptyToNull(decodeQueryPart(partValue(part.text())).trim());
+                password = decodeQueryPart(partValue(part));
                 foundCredential = true;
             } else {
                 keptParams.add(part);
@@ -1704,34 +1703,22 @@ public final class DbxJdbcPlugin {
         return new JdbcUrlCredentials(sanitizedUrl, username, password);
     }
 
-    private static List<JdbcUrlParam> splitJdbcUrlParams(String query) {
-        List<JdbcUrlParam> result = new ArrayList<>();
-        String separator = "";
+    private static List<String> splitJdbcUrlParams(String query) {
+        List<String> result = new ArrayList<>();
         int start = 0;
         for (int i = 0; i < query.length(); i++) {
             char ch = query.charAt(i);
-            if (ch == '&' || ch == ';') {
-                result.add(new JdbcUrlParam(separator, query.substring(start, i)));
-                separator = String.valueOf(ch);
+            if (ch == '&') {
+                result.add(query.substring(start, i));
                 start = i + 1;
             }
         }
-        result.add(new JdbcUrlParam(separator, query.substring(start)));
+        result.add(query.substring(start));
         return result;
     }
 
-    private static String joinJdbcUrlParams(List<JdbcUrlParam> params) {
-        StringBuilder result = new StringBuilder();
-        for (JdbcUrlParam param : params) {
-            if (param.text().isEmpty()) {
-                continue;
-            }
-            if (result.length() > 0) {
-                result.append(param.separator().isEmpty() ? "&" : param.separator());
-            }
-            result.append(param.text());
-        }
-        return result.toString();
+    private static String joinJdbcUrlParams(List<String> params) {
+        return params.stream().filter(param -> !param.isEmpty()).collect(Collectors.joining("&"));
     }
 
     private static String partName(String part) {

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.math.BigDecimal;
 import java.net.URL;
@@ -334,6 +335,8 @@ public final class DbxJdbcPlugin {
         if (url == null) {
             throw new IllegalArgumentException("JDBC URL is required.");
         }
+        JdbcUrlCredentials urlCredentials = extractJdbcUrlCredentials(url);
+        url = urlCredentials.url;
         String key = connectionKey(connection);
         if (sharedConnection != null && key.equals(sharedConnectionKey) && !sharedConnection.isClosed()) {
             return sharedConnection;
@@ -343,6 +346,12 @@ public final class DbxJdbcPlugin {
         Properties properties = new Properties();
         String username = optionalText(connection, "username");
         String password = optionalText(connection, "password");
+        if (username == null) {
+            username = urlCredentials.username;
+        }
+        if (password == null) {
+            password = urlCredentials.password;
+        }
         if (username != null) {
             properties.setProperty("user", username);
         }
@@ -1649,6 +1658,98 @@ public final class DbxJdbcPlugin {
     static String jdbcUrl(JsonNode connection) {
         String url = appendJdbcUrlParams(optionalText(connection, "connection_string"), optionalText(connection, "url_params"));
         return jdbcUrlWithPasswordKey(url, optionalText(connection, "password"));
+    }
+
+    private record JdbcUrlCredentials(String url, String username, String password) {}
+
+    private record JdbcUrlParam(String separator, String text) {}
+
+    static JdbcUrlCredentials extractJdbcUrlCredentials(String url) {
+        if (url == null) {
+            return new JdbcUrlCredentials(null, null, null);
+        }
+        int queryStart = url.indexOf('?');
+        if (queryStart < 0) {
+            return new JdbcUrlCredentials(url, null, null);
+        }
+
+        int fragmentStart = url.indexOf('#', queryStart + 1);
+        String base = url.substring(0, queryStart);
+        String query = fragmentStart < 0 ? url.substring(queryStart + 1) : url.substring(queryStart + 1, fragmentStart);
+        String fragment = fragmentStart < 0 ? "" : url.substring(fragmentStart);
+
+        String username = null;
+        String password = null;
+        boolean foundCredential = false;
+        List<JdbcUrlParam> keptParams = new ArrayList<>();
+        for (JdbcUrlParam part : splitJdbcUrlParams(query)) {
+            String name = partName(part.text());
+            String key = decodeQueryPart(name).trim().toLowerCase(Locale.ROOT);
+            if ("user".equals(key)) {
+                username = emptyToNull(decodeQueryPart(partValue(part.text())).trim());
+                foundCredential = true;
+            } else if ("password".equals(key)) {
+                password = emptyToNull(decodeQueryPart(partValue(part.text())).trim());
+                foundCredential = true;
+            } else {
+                keptParams.add(part);
+            }
+        }
+
+        if (!foundCredential) {
+            return new JdbcUrlCredentials(url, null, null);
+        }
+        String sanitizedQuery = joinJdbcUrlParams(keptParams);
+        String sanitizedUrl = sanitizedQuery.isEmpty() ? base + fragment : base + "?" + sanitizedQuery + fragment;
+        return new JdbcUrlCredentials(sanitizedUrl, username, password);
+    }
+
+    private static List<JdbcUrlParam> splitJdbcUrlParams(String query) {
+        List<JdbcUrlParam> result = new ArrayList<>();
+        String separator = "";
+        int start = 0;
+        for (int i = 0; i < query.length(); i++) {
+            char ch = query.charAt(i);
+            if (ch == '&' || ch == ';') {
+                result.add(new JdbcUrlParam(separator, query.substring(start, i)));
+                separator = String.valueOf(ch);
+                start = i + 1;
+            }
+        }
+        result.add(new JdbcUrlParam(separator, query.substring(start)));
+        return result;
+    }
+
+    private static String joinJdbcUrlParams(List<JdbcUrlParam> params) {
+        StringBuilder result = new StringBuilder();
+        for (JdbcUrlParam param : params) {
+            if (param.text().isEmpty()) {
+                continue;
+            }
+            if (result.length() > 0) {
+                result.append(param.separator().isEmpty() ? "&" : param.separator());
+            }
+            result.append(param.text());
+        }
+        return result.toString();
+    }
+
+    private static String partName(String part) {
+        int equals = part.indexOf('=');
+        return equals < 0 ? part : part.substring(0, equals);
+    }
+
+    private static String partValue(String part) {
+        int equals = part.indexOf('=');
+        return equals < 0 ? "" : part.substring(equals + 1);
+    }
+
+    private static String decodeQueryPart(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ignored) {
+            return value;
+        }
     }
 
     private static boolean isSqliteUrl(String url) {

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -256,6 +256,79 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void connectionUsernameWithMultipleAtSignsIsPassedToDriverProperties() throws Exception {
+        RecordingConnectDriver driver = new RecordingConnectDriver("jdbc:dbx-proxysql-form:");
+        DriverManager.registerDriver(driver);
+        try {
+            JsonNode response = request("testConnection", """
+                {
+                  "connection": {
+                    "connection_string": "jdbc:dbx-proxysql-form://127.0.0.1:6033/example",
+                    "username": "xxxxx@db_readonly@127.0.0.1",
+                    "password": "p@wd",
+                    "connect_timeout_secs": 30
+                  }
+                }
+                """);
+
+            assertFalse(response.has("error"), response.toString());
+            assertEquals("jdbc:dbx-proxysql-form://127.0.0.1:6033/example", driver.urls.get(0));
+            assertEquals("xxxxx@db_readonly@127.0.0.1", driver.properties.get(0).getProperty("user"));
+            assertEquals("p@wd", driver.properties.get(0).getProperty("password"));
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void jdbcUrlUserParamsWithMultipleAtSignsAreDecodedIntoDriverProperties() throws Exception {
+        RecordingConnectDriver driver = new RecordingConnectDriver("jdbc:dbx-proxysql-url:");
+        DriverManager.registerDriver(driver);
+        try {
+            JsonNode response = request("testConnection", """
+                {
+                  "connection": {
+                    "connection_string": "jdbc:dbx-proxysql-url://127.0.0.1:6033/example?socketTimeout=5;user=xxxxx%40db_readonly%40127.0.0.1;password=p%40wd&useSSL=false",
+                    "connect_timeout_secs": 30
+                  }
+                }
+                """);
+
+            assertFalse(response.has("error"), response.toString());
+            assertEquals("jdbc:dbx-proxysql-url://127.0.0.1:6033/example?socketTimeout=5&useSSL=false", driver.urls.get(0));
+            assertEquals("xxxxx@db_readonly@127.0.0.1", driver.properties.get(0).getProperty("user"));
+            assertEquals("p@wd", driver.properties.get(0).getProperty("password"));
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void explicitConnectionCredentialsOverrideJdbcUrlCredentialParams() throws Exception {
+        RecordingConnectDriver driver = new RecordingConnectDriver("jdbc:dbx-proxysql-override:");
+        DriverManager.registerDriver(driver);
+        try {
+            JsonNode response = request("testConnection", """
+                {
+                  "connection": {
+                    "connection_string": "jdbc:dbx-proxysql-override://127.0.0.1:6033/example?user=url%40tenant&password=url-secret&useSSL=false",
+                    "username": "form@tenant@host",
+                    "password": "form-secret",
+                    "connect_timeout_secs": 30
+                  }
+                }
+                """);
+
+            assertFalse(response.has("error"), response.toString());
+            assertEquals("jdbc:dbx-proxysql-override://127.0.0.1:6033/example?useSSL=false", driver.urls.get(0));
+            assertEquals("form@tenant@host", driver.properties.get(0).getProperty("user"));
+            assertEquals("form-secret", driver.properties.get(0).getProperty("password"));
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
     void connectTimeoutIsMappedToDriverProperties() throws Exception {
         Method method = DbxJdbcPlugin.class.getDeclaredMethod("applyConnectTimeout", JsonNode.class, Properties.class);
         method.setAccessible(true);
@@ -1252,6 +1325,71 @@ final class DbxJdbcPluginTest {
                         default -> defaultValue(method.getReturnType());
                     };
                 }
+            }
+        );
+    }
+
+    private static final class RecordingConnectDriver implements Driver {
+        private final String urlPrefix;
+        private final List<String> urls = new ArrayList<>();
+        private final List<Properties> properties = new ArrayList<>();
+
+        private RecordingConnectDriver(String urlPrefix) {
+            this.urlPrefix = urlPrefix;
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            if (!acceptsURL(url)) {
+                return null;
+            }
+            urls.add(url);
+            Properties copy = new Properties();
+            copy.putAll(info);
+            properties.add(copy);
+            return recordingConnection();
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return url != null && url.startsWith(urlPrefix);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public java.util.logging.Logger getParentLogger() {
+            return java.util.logging.Logger.getGlobal();
+        }
+    }
+
+    private static Connection recordingConnection() {
+        return (Connection) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Connection.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "isClosed" -> false;
+                case "isValid" -> true;
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
             }
         );
     }

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -288,7 +288,7 @@ final class DbxJdbcPluginTest {
             JsonNode response = request("testConnection", """
                 {
                   "connection": {
-                    "connection_string": "jdbc:dbx-proxysql-url://127.0.0.1:6033/example?socketTimeout=5;user=xxxxx%40db_readonly%40127.0.0.1;password=p%40wd&useSSL=false",
+                    "connection_string": "jdbc:dbx-proxysql-url://127.0.0.1:6033/example?socketTimeout=5&user=xxxxx%40db_readonly%40127.0.0.1&password=p%40wd&useSSL=false",
                     "connect_timeout_secs": 30
                   }
                 }
@@ -298,6 +298,51 @@ final class DbxJdbcPluginTest {
             assertEquals("jdbc:dbx-proxysql-url://127.0.0.1:6033/example?socketTimeout=5&useSSL=false", driver.urls.get(0));
             assertEquals("xxxxx@db_readonly@127.0.0.1", driver.properties.get(0).getProperty("user"));
             assertEquals("p@wd", driver.properties.get(0).getProperty("password"));
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void jdbcUrlCredentialExtractionKeepsSemicolonInsidePasswordValue() throws Exception {
+        RecordingConnectDriver driver = new RecordingConnectDriver("jdbc:dbx-proxysql-semicolon-password:");
+        DriverManager.registerDriver(driver);
+        try {
+            JsonNode response = request("testConnection", """
+                {
+                  "connection": {
+                    "connection_string": "jdbc:dbx-proxysql-semicolon-password://127.0.0.1:6033/example?password=p;ss&useSSL=false",
+                    "connect_timeout_secs": 30
+                  }
+                }
+                """);
+
+            assertFalse(response.has("error"), response.toString());
+            assertEquals("jdbc:dbx-proxysql-semicolon-password://127.0.0.1:6033/example?useSSL=false", driver.urls.get(0));
+            assertEquals("p;ss", driver.properties.get(0).getProperty("password"));
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void jdbcUrlCredentialExtractionPreservesDecodedWhitespace() throws Exception {
+        RecordingConnectDriver driver = new RecordingConnectDriver("jdbc:dbx-proxysql-space-password:");
+        DriverManager.registerDriver(driver);
+        try {
+            JsonNode response = request("testConnection", """
+                {
+                  "connection": {
+                    "connection_string": "jdbc:dbx-proxysql-space-password://127.0.0.1:6033/example?user=tenant%40host&password=%20secret%20&useSSL=false",
+                    "connect_timeout_secs": 30
+                  }
+                }
+                """);
+
+            assertFalse(response.has("error"), response.toString());
+            assertEquals("jdbc:dbx-proxysql-space-password://127.0.0.1:6033/example?useSSL=false", driver.urls.get(0));
+            assertEquals("tenant@host", driver.properties.get(0).getProperty("user"));
+            assertEquals(" secret ", driver.properties.get(0).getProperty("password"));
         } finally {
             DriverManager.deregisterDriver(driver);
         }


### PR DESCRIPTION
## 变更说明
- 在 JDBC 插件打开连接前，从 JDBC URL 中提取并解码 user/password 参数，放入 JDBC driver properties
- 支持 ProxySQL 多租户用户名中的多个 @，例如 xxxxx@db_readonly@127.0.0.1
- 表单中的用户名/密码优先于 URL 中的 user/password 参数
- 增加前端 URL 解析和 JDBC fake driver 回归测试

## 验证
- CI=true pnpm exec vitest run packages/app-tests/connectionUrl.test.ts packages/app-tests/connectionDeepLink.test.ts
- git diff --check
- CI=true pnpm check
- 桌面手测：MySQL/ProxySQL 返回 Access denied for user 'xxxxx@db_readonly@127.0.0.1'@'10.189.111.61'，确认完整多 @ 用户名已经到达服务端

## 备注
- 本地环境有 Java 21，但没有 mvn/mvnw，因此未运行 JDBC Maven 测试。