### PR TITLE
Fix: 修复 Oracle 时间字段编辑和表结构修改报错

### DIFF
--- a/apps/desktop/src/components/grid/TemporalCellEditor.vue
+++ b/apps/desktop/src/components/grid/TemporalCellEditor.vue
@@ -214,10 +214,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="dateParts.year" data-temporal-part="year" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('year', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepDate('year', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepDate('year', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepDate('year', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepDate('year', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -226,10 +226,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(dateParts.month)" data-temporal-part="month" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('month', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepDate('month', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepDate('month', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepDate('month', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepDate('month', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -238,10 +238,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(dateParts.day)" data-temporal-part="day" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('day', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepDate('day', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepDate('day', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepDate('day', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepDate('day', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -252,10 +252,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(timeParts.hour)" data-temporal-part="hour" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateTimeFromInput('hour', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepTime('hour', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepTime('hour', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepTime('hour', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepTime('hour', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -264,10 +264,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(timeParts.minute)" data-temporal-part="minute" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateTimeFromInput('minute', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepTime('minute', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepTime('minute', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepTime('minute', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepTime('minute', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -276,10 +276,10 @@ function twoDigit(value: string | number): string {
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="twoDigit(timeParts.second)" data-temporal-part="second" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateTimeFromInput('second', $event)" />
           <div class="grid border-l">
-            <button type="button" class="flex items-center justify-center hover:bg-muted" @click="stepTime('second', 1)">
+            <button type="button" class="flex items-center justify-center hover:bg-muted" @mousedown.prevent @click="stepTime('second', 1)">
               <ChevronUp class="h-3 w-3" />
             </button>
-            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @click="stepTime('second', -1)">
+            <button type="button" class="flex items-center justify-center border-t hover:bg-muted" @mousedown.prevent @click="stepTime('second', -1)">
               <ChevronDown class="h-3 w-3" />
             </button>
           </div>
@@ -287,11 +287,11 @@ function twoDigit(value: string | number): string {
       </div>
 
       <div class="flex items-center justify-between gap-1">
-        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @click="setNull">
+        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @mousedown.prevent @click="setNull">
           <CircleSlash class="h-3 w-3" />
           NULL
         </Button>
-        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @click="setNow">Now</Button>
+        <Button type="button" variant="ghost" size="xs" class="h-6 px-1.5 text-[11px]" @mousedown.prevent @click="setNow">Now</Button>
       </div>
     </PopoverContent>
   </Popover>

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1104,7 +1104,7 @@ fn is_oracle_temporal_literal_database(database_type: Option<DatabaseType>) -> b
 
 fn format_oracle_temporal_literal(text: &str, data_type: Option<&str>) -> Option<String> {
     let kind = oracle_temporal_column_kind(data_type?)?;
-    let parts = regex_like_rfc3339(text)?;
+    let parts = regex_like_oracle_temporal(text)?;
     let fraction = parts.fraction.unwrap_or_default();
     let datetime = format!("{} {}{}", parts.date, parts.time, fraction);
     match kind {
@@ -1114,6 +1114,10 @@ fn format_oracle_temporal_literal(text: &str, data_type: Option<&str>) -> Option
             Some(format!("TO_TIMESTAMP('{datetime}', '{mask}')"))
         }
         OracleTemporalKind::TimestampWithTimeZone => {
+            if parts.zone.is_empty() {
+                let mask = oracle_timestamp_format_mask(datetime.contains('.'));
+                return Some(format!("TO_TIMESTAMP('{datetime}', '{mask}')"));
+            }
             let zone = oracle_timezone_suffix(&parts.zone);
             let mask = oracle_timestamp_format_mask(datetime.contains('.'));
             Some(format!("TO_TIMESTAMP_TZ('{datetime} {zone}', '{mask} TZH:TZM')"))
@@ -1148,6 +1152,50 @@ fn oracle_timezone_suffix(zone: &str) -> String {
     } else {
         zone.to_string()
     }
+}
+
+fn regex_like_oracle_temporal(text: &str) -> Option<Rfc3339Parts> {
+    if let Some(parts) = regex_like_rfc3339(text) {
+        return Some(parts);
+    }
+    regex_like_local_datetime(text)
+}
+
+fn regex_like_local_datetime(text: &str) -> Option<Rfc3339Parts> {
+    let bytes = text.as_bytes();
+    if bytes.len() < 10 || bytes.get(4) != Some(&b'-') || bytes.get(7) != Some(&b'-') {
+        return None;
+    }
+    let date = &text[0..10];
+    if bytes.len() == 10 {
+        return Some(Rfc3339Parts {
+            date: date.to_string(),
+            time: "00:00:00".to_string(),
+            fraction: None,
+            zone: String::new(),
+        });
+    }
+    let separator = *bytes.get(10)?;
+    if separator != b'T' && separator != b' ' {
+        return None;
+    }
+    if bytes.len() < 19 || bytes.get(13) != Some(&b':') || bytes.get(16) != Some(&b':') {
+        return None;
+    }
+    let time = &text[11..19];
+    let rest = &text[19..];
+    let fraction = if let Some(rest) = rest.strip_prefix('.') {
+        let digit_count = rest.chars().take_while(|ch| ch.is_ascii_digit()).count();
+        if digit_count == 0 || digit_count > 9 || digit_count != rest.len() {
+            return None;
+        }
+        Some(format!(".{}", &rest[..digit_count]))
+    } else if rest.is_empty() {
+        None
+    } else {
+        return None;
+    };
+    Some(Rfc3339Parts { date: date.to_string(), time: time.to_string(), fraction, zone: String::new() })
 }
 
 fn is_mysql_bit_literal_column(database_type: Option<DatabaseType>, column_info: Option<&DataGridColumnInfo>) -> bool {
@@ -2242,6 +2290,25 @@ mod tests {
         assert_eq!(
             format_grid_sql_literal(&json!("2022-08-25T09:58:43Z"), Some(DatabaseType::Oracle), Some(&text)),
             "'2022-08-25T09:58:43Z'"
+        );
+    }
+
+    #[test]
+    fn formats_oracle_temporal_literals_from_editor_values_without_nls_parsing() {
+        let timestamp = column("created_at", "TIMESTAMP(6)", true, None);
+        let date = column("event_day", "DATE", true, None);
+
+        assert_eq!(
+            format_grid_sql_literal(&json!("2022-08-25 09:58:43"), Some(DatabaseType::Oracle), Some(&timestamp)),
+            "TO_TIMESTAMP('2022-08-25 09:58:43', 'YYYY-MM-DD HH24:MI:SS')"
+        );
+        assert_eq!(
+            format_grid_sql_literal(&json!("2022-08-25 09:58:43.123456"), Some(DatabaseType::Oracle), Some(&timestamp)),
+            "TO_TIMESTAMP('2022-08-25 09:58:43.123456', 'YYYY-MM-DD HH24:MI:SS.FF')"
+        );
+        assert_eq!(
+            format_grid_sql_literal(&json!("2022-08-25 09:58:43"), Some(DatabaseType::Oracle), Some(&date)),
+            "TO_DATE('2022-08-25 09:58:43', 'YYYY-MM-DD HH24:MI:SS')"
         );
     }
 

--- a/crates/dbx-core/src/table_structure_sql/column_alter.rs
+++ b/crates/dbx-core/src/table_structure_sql/column_alter.rs
@@ -360,18 +360,19 @@ pub(super) fn build_oracle_like_existing_column_sql(
     if type_changed || nullable_changed || default_changed {
         let data_type = column_data_type(dialect, column);
         let mut parts = vec![quote_ident(dialect, &current_name), data_type];
-        // Always include nullability so the statement is self-contained (required by Dameng).
-        if !column.is_nullable {
-            parts.push("NOT NULL".to_string());
-        } else {
-            parts.push("NULL".to_string());
-        }
         let default_value = normalize_default(Some(&column.default_value));
         if !default_value.is_empty() {
             parts.push(format!("DEFAULT {}", format_default_for_sql(dialect, &column.data_type, &default_value)));
         } else if default_changed {
             // User cleared the default — explicitly drop it.
             parts.push("DEFAULT NULL".to_string());
+        }
+        if nullable_changed {
+            if column.is_nullable {
+                parts.push("NULL".to_string());
+            } else {
+                parts.push("NOT NULL".to_string());
+            }
         }
         statements.push(format!("ALTER TABLE {table} MODIFY ({});", parts.join(" ")));
     }

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -293,6 +293,60 @@ fn oracle_does_not_generate_drop_sql_for_all_columns() {
 }
 
 #[test]
+fn oracle_timestamp_default_precedes_nullability_in_modify_sql() {
+    let mut col = column("time");
+    col.data_type = "TIMESTAMP(6)".to_string();
+    col.default_value = "CURRENT_TIMESTAMP".to_string();
+    col.original = Some(ColumnInfo {
+        name: "time".to_string(),
+        data_type: "TIMESTAMP(6)".to_string(),
+        is_nullable: true,
+        column_default: None,
+        is_primary_key: false,
+        extra: None,
+        comment: Some(String::new()),
+    });
+
+    let result = build_single_column_alter_sql(SingleColumnAlterSqlOptions {
+        database_type: Some(DatabaseType::Oracle),
+        schema: Some("DBX_TEST".to_string()),
+        table_name: "test".to_string(),
+        column: col,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(
+        result.statements,
+        vec!["ALTER TABLE \"DBX_TEST\".\"test\" MODIFY (\"time\" TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP);"]
+    );
+}
+
+#[test]
+fn oracle_timestamp_precision_change_does_not_repeat_unchanged_nullability() {
+    let mut col = column("time");
+    col.data_type = "TIMESTAMP(9)".to_string();
+    col.original = Some(ColumnInfo {
+        name: "time".to_string(),
+        data_type: "TIMESTAMP(6)".to_string(),
+        is_nullable: true,
+        column_default: None,
+        is_primary_key: false,
+        extra: None,
+        comment: Some(String::new()),
+    });
+
+    let result = build_single_column_alter_sql(SingleColumnAlterSqlOptions {
+        database_type: Some(DatabaseType::Oracle),
+        schema: Some("DBX_TEST".to_string()),
+        table_name: "test".to_string(),
+        column: col,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.statements, vec!["ALTER TABLE \"DBX_TEST\".\"test\" MODIFY (\"time\" TIMESTAMP(9));"]);
+}
+
+#[test]
 fn iris_drop_index_includes_table_name() {
     let mut old_index = index("index_id", &["ID"]);
     old_index.marked_for_drop = true;


### PR DESCRIPTION
## 修改内容
- 修复 Oracle 查询结果中 DATE/TIMESTAMP 编辑后保存时生成普通字符串，导致 ORA-01861 的问题；编辑器输出的本地时间格式现在会转换为 TO_DATE/TO_TIMESTAMP。
- 修复 Oracle 编辑表结构修改 TIMESTAMP 默认值时 DEFAULT 与 NULL 顺序不正确，导致 ORA-00907 的问题。
- 修复仅修改 TIMESTAMP 精度时重复生成未变化的 NULL 子句，导致 ORA-01451 的问题。
- 避免时间控件按钮点击时因焦点丢失提前提交编辑，导致箭头/NULL/Now 看起来无响应。

## 验证
- cargo test -p dbx-core data_grid_sql::tests::formats_oracle_temporal_literals -- --nocapture
- cargo test -p dbx-core table_structure_sql::tests::oracle_timestamp -- --nocapture
- pnpm vitest run packages/app-tests/dataGridTemporalEditor.test.ts
- 本地 Oracle 临时表验证 TO_DATE 更新、TO_TIMESTAMP 更新、DEFAULT CURRENT_TIMESTAMP、TIMESTAMP(9) 修改均执行成功，临时表已删除。