### PR TITLE
fix(redis): resolve protected mode UI issues

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1660,6 +1660,7 @@ onUnmounted(() => {
                     :format-sql-request="formatSqlRequest"
                     :selected-sql="selectedSql"
                     :cursor-pos="cursorPos"
+                    :block-dangerous-redis-commands="blockDangerousRedisCommands"
                     @update:active-output-view="activeOutputView = $event"
                     @fix-with-ai="fixWithAi"
                     @execute="tryExecute($event)"

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -110,6 +110,7 @@ const props = defineProps<{
   formatSqlRequest: { id: number; tabId: string } | null;
   selectedSql: string;
   cursorPos: number;
+  blockDangerousRedisCommands: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -1249,7 +1250,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
     <!-- Redis mode: key browser -->
     <template v-else-if="activeTab.mode === 'redis'">
       <div class="flex-1 min-h-0">
-        <RedisKeyBrowser ref="redisKeyBrowserRef" :key="activeTab.id" :connection-id="activeTab.connectionId" :db="Number(activeTab.database)" />
+        <RedisKeyBrowser ref="redisKeyBrowserRef" :key="activeTab.id" :connection-id="activeTab.connectionId" :db="Number(activeTab.database)" :block-dangerous-redis-commands="props.blockDangerousRedisCommands" />
       </div>
     </template>
 

--- a/apps/desktop/src/components/redis/RedisKeyBrowser.vue
+++ b/apps/desktop/src/components/redis/RedisKeyBrowser.vue
@@ -58,6 +58,7 @@ type RedisCommandHistoryEntry = {
 const props = defineProps<{
   connectionId: string;
   db: number;
+  blockDangerousRedisCommands: boolean;
 }>();
 
 const flatKeys = ref<RedisKeyInfo[]>([]);
@@ -473,7 +474,7 @@ async function runRedisCommand(command: string) {
   const prompt = commandPrompt.value;
   commandRunning.value = true;
   try {
-    const result = await api.redisExecuteCommand(props.connectionId, commandDb.value, command);
+    const result = await api.redisExecuteCommand(props.connectionId, commandDb.value, command, !props.blockDangerousRedisCommands);
     appendCommandHistory({
       prompt,
       command,
@@ -743,6 +744,13 @@ async function executeCommand() {
 
   const safety = classifyRedisCommandSafety(command);
   if (safety === "blocked") {
+    if (!props.blockDangerousRedisCommands) {
+      // 安全模式已关闭，放行 blocked 命令
+      commandText.value = "";
+      commandHistoryIndex.value = -1;
+      await runRedisCommand(command);
+      return;
+    }
     appendCommandHistory({
       prompt: commandPrompt.value,
       command,
@@ -754,6 +762,13 @@ async function executeCommand() {
     return;
   }
   if (safety === "confirm") {
+    if (!props.blockDangerousRedisCommands) {
+      // 安全模式已关闭，跳过确认弹窗直接执行
+      commandText.value = "";
+      commandHistoryIndex.value = -1;
+      await runRedisCommand(command);
+      return;
+    }
     pendingDanger.value = { kind: "command", command };
     showDangerConfirm.value = true;
     commandText.value = "";


### PR DESCRIPTION
## 变更说明

修复 Redis 浏览器命令控制台在关闭“拦截危险命令”（盾牌）后仍弹窗或阻止命令执行的问题。

-  将 App.vue 中的全局安全状态 blockDangerousRedisCommands 透传给 RedisKeyBrowser.vue 组件。
- 在 RedisKeyBrowser.vue 的命令提交逻辑中，针对 blocked 和 confirm 两类命令分别判断：若盾牌关闭，则跳过前端的 Toast 拦截或确认弹窗，直接调用后端执行，并向后端传递 skip_safety_check = true。
- 后端已原生支持该参数，无需额外改动。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）



## 验证


- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue
Close #2362 
