### PR TITLE
fix(redis): connect pubsub to desktop websocket server

### DIFF
--- a/apps/desktop/src/components/redis/RedisPubSubPanel.vue
+++ b/apps/desktop/src/components/redis/RedisPubSubPanel.vue
@@ -65,7 +65,7 @@ async function connect() {
   if (ws && ws.readyState === WebSocket.OPEN) return;
   connecting.value = true;
   try {
-    ws = api.redisPubSubConnect(props.connectionId);
+    ws = await api.redisPubSubConnect(props.connectionId);
 
     ws.onopen = () => {
       connected.value = true;

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1,7 +1,6 @@
 import { isTauriRuntime } from "./tauriRuntime";
 import type * as TauriModule from "./tauri";
 import { appendDebugLog } from "./debugLog";
-import { apiWebSocketUrl } from "./webPath";
 
 // ---------------------------------------------------------------------------
 // Lazy backend resolution (avoids top-level await)
@@ -311,12 +310,9 @@ export const redisFlushDb = forward("redisFlushDb");
 export const redisExecuteCommand = forward("redisExecuteCommand");
 export const redisLoadMore = forward("redisLoadMore");
 export const redisPubSubPublish = forward("redisPubSubPublish");
+export const redisPubSubConnect = forward("redisPubSubConnect");
 export const redisSlowlogGet = forward("redisSlowlogGet");
 export const redisClusterMasterNodes = forward("redisClusterMasterNodes");
-
-export function redisPubSubConnect(connectionId: string): WebSocket {
-  return new WebSocket(apiWebSocketUrl(`/api/redis/pubsub/ws?connectionId=${encodeURIComponent(connectionId)}`));
-}
 
 // etcd
 export const etcdListPrefix = forward("etcdListPrefix");

--- a/apps/desktop/src/lib/http.ts
+++ b/apps/desktop/src/lib/http.ts
@@ -111,7 +111,7 @@ import type { CreateDatabaseSqlOptions } from "@/lib/createDatabaseSql";
 import type { DatabaseNameSqlOptions, DropTableChildObjectSqlOptions, DropObjectSqlOptions, DuplicateTableStructureSqlOptions, CopyTableDataSqlOptions, SchemaNameSqlOptions, TableAdminSqlOptions } from "@/lib/dbAdminSql";
 import type { BuildDatabaseSqlExportOptions, BuildExportInsertStatementsOptions } from "@/lib/databaseExport";
 import type { DataCompareFromTablesOptions, DataCompareFromTablesPreparation, DataCompareSyncPlan, DataCompareSyncPlanOptions, DataComparePreparation, DataComparePreparationOptions } from "@/lib/dataCompare";
-import { apiUrl } from "@/lib/webPath";
+import { apiUrl, apiWebSocketUrl } from "@/lib/webPath";
 import type { DataGridSavePreparation } from "./tauri";
 import type {
   NacosConfigHistoryKey,
@@ -1629,6 +1629,10 @@ export async function redisLoadMore(connectionId: string, db: number, keyRaw: st
 
 export async function redisPubSubPublish(connectionId: string, db: number, channel: string, message: string): Promise<{ subscribers: number }> {
   return post("/api/redis/pubsub/publish", { connectionId, db, channel, message });
+}
+
+export async function redisPubSubConnect(connectionId: string): Promise<WebSocket> {
+  return new WebSocket(apiWebSocketUrl(`/api/redis/pubsub/ws?connectionId=${encodeURIComponent(connectionId)}`));
 }
 
 export async function redisSlowlogGet(connectionId: string, count: number, nodeHost?: string, nodePort?: number): Promise<RedisSlowlogEntry[]> {

--- a/apps/desktop/src/lib/tauri.ts
+++ b/apps/desktop/src/lib/tauri.ts
@@ -1364,6 +1364,11 @@ export async function redisPubSubPublish(connectionId: string, db: number, chann
   return invoke("redis_pubsub_publish", { connectionId, db, channel, message });
 }
 
+export async function redisPubSubConnect(connectionId: string): Promise<WebSocket> {
+  const port = await invoke<number>("redis_pubsub_server_port");
+  return new WebSocket(`ws://127.0.0.1:${port}/api/redis/pubsub/ws?connectionId=${encodeURIComponent(connectionId)}`);
+}
+
 export async function redisSlowlogGet(connectionId: string, count: number, nodeHost?: string, nodePort?: number): Promise<RedisSlowlogEntry[]> {
   return invoke("redis_slowlog_get", { connectionId, count, nodeHost, nodePort });
 }

--- a/src-tauri/src/commands/redis_pubsub_server.rs
+++ b/src-tauri/src/commands/redis_pubsub_server.rs
@@ -10,6 +10,8 @@ use serde::Deserialize;
 
 use dbx_core::connection::AppState;
 
+const DEFAULT_PUBSUB_PORT: u16 = 4224;
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PubSubWsParams {
@@ -18,6 +20,15 @@ struct PubSubWsParams {
 
 pub fn build_pubsub_router(state: Arc<AppState>) -> Router {
     Router::new().route("/api/redis/pubsub/ws", get(ws_handler)).with_state(state)
+}
+
+fn pubsub_server_port() -> u16 {
+    std::env::var("DBX_PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(DEFAULT_PUBSUB_PORT)
+}
+
+#[tauri::command]
+pub fn redis_pubsub_server_port() -> u16 {
+    pubsub_server_port()
 }
 
 async fn ws_handler(
@@ -136,7 +147,7 @@ async fn handle_command(sink: &mut redis::aio::PubSubSink, text: &str) -> Result
 pub fn start_pubsub_server(state: Arc<AppState>) {
     let router = build_pubsub_router(state);
     tauri::async_runtime::spawn(async move {
-        let port: u16 = std::env::var("DBX_PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(4224);
+        let port = pubsub_server_port();
         let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
         let listener = match tokio::net::TcpListener::bind(addr).await {
             Ok(listener) => listener,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -896,6 +896,7 @@ pub fn run() {
             commands::redis_cmd::redis_execute_command,
             commands::redis_cmd::redis_load_more,
             commands::redis_cmd::redis_pubsub_publish,
+            commands::redis_pubsub_server::redis_pubsub_server_port,
             commands::redis_cmd::redis_slowlog_get,
             commands::redis_cmd::redis_cluster_master_nodes,
             commands::etcd_cmd::etcd_list_prefix,


### PR DESCRIPTION
## 变更说明

修复 DBX Desktop release/便携版中 Redis Pub/Sub 无法连接的问题。

问题原因是桌面端 Pub/Sub 面板复用了 Web 端基于当前页面 host 拼接 WebSocket URL 的逻辑。在开发模式下该路径会被 dev server 环境掩盖，但 release/便携版中页面 host 并不等于 DBX 本机 Pub/Sub server，导致 UI 点击连接时连错目标。

本 PR 做了以下调整：

- 将 `redisPubSubConnect` 下沉到 Web/Tauri 各自的 backend 实现中。
- Web 端继续使用当前 host 拼接 Pub/Sub WebSocket URL。
- Tauri 桌面端通过 command 获取实际 Pub/Sub server port，并连接本机 `127.0.0.1:<port>` 的 Pub/Sub WebSocket 服务。
- 将 Pub/Sub 面板连接流程调整为异步获取 WebSocket 实例。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

无视觉变化。已通过 macOS 便携版 DBX Desktop 手动验证 Redis Pub/Sub UI 可以订阅并收到消息。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm typecheck`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/lib/api.ts apps/desktop/src/lib/http.ts apps/desktop/src/lib/tauri.ts apps/desktop/src/components/redis/RedisPubSubPanel.vue`
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features duckdb-bundled,mq-admin`
- `pnpm tauri build --bundles app --no-sign --config '{"bundle":{"createUpdaterArtifacts":false}}'`
- 使用便携版 DBX Desktop 连接本地 Redis 8.4 容器，订阅 `portable-ui-channel` 后通过 `redis-cli PUBLISH portable-ui-channel hello-from-portable-ui` 验证 UI 收到消息。

## 关联 Issue

Fixes #2420
