### PR TITLE
Feature: SQL 编辑器右键支持编辑表结构

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1110,6 +1110,12 @@ function onViewTableDdl(tableName: string) {
   showQueryEditorDdlDialog.value = true;
 }
 
+function onEditTableStructure(tableName: string) {
+  const target = tableTargetFromActiveTab(tableName);
+  if (!target) return;
+  queryStore.openTableStructure(target.connectionId, target.database, target.schema, target.tableName);
+}
+
 async function changeActiveConnection(connectionId: string) {
   const tab = activeTab.value;
   if (!tab) return;
@@ -1814,6 +1820,7 @@ onUnmounted(() => {
                     @execute-sql="onExecuteSql"
                     @click-table="onClickTable"
                     @view-table-data="onViewTableData"
+                    @edit-table-structure="onEditTableStructure"
                     @view-table-ddl="onViewTableDdl"
                     @open-object-table="
                       (target) =>

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, onActivated, onDeactivated, watch, shallowRef, computed, nextTick } from "vue";
-import { CaseLower, CaseUpper, FileCode, Play, Copy, Table2, TextSelect } from "@lucide/vue";
+import { CaseLower, CaseUpper, FileCode, PencilRuler, Play, Copy, Table2, TextSelect } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import type { CompletionContext } from "@codemirror/autocomplete";
 import type { EditorView as EditorViewType } from "@codemirror/view";
@@ -89,6 +89,7 @@ const emit = defineEmits<{
   clickTable: [tableName: string];
   viewTableData: [tableName: string];
   viewTableDdl: [tableName: string];
+  editTableStructure: [tableName: string];
   clickColumn: [columns: Array<{ name: string; table: string; schema?: string }>, error?: string | undefined];
   closeColumnPanel: [];
   viewportChange: [viewport: { scrollTop: number; scrollLeft: number }];
@@ -581,6 +582,12 @@ function openTableFromContextMenu() {
   focusEditor();
 }
 
+function editTableStructureFromContextMenu() {
+  if (!contextTableName.value) return;
+  emit("editTableStructure", contextTableName.value);
+  focusEditor();
+}
+
 function openTableDdlFromContextMenu() {
   if (!contextTableName.value) return;
   emit("viewTableDdl", contextTableName.value);
@@ -629,6 +636,12 @@ const contextMenuItems = computed<ContextMenuItem[]>(() => [
     action: openTableFromContextMenu,
     disabled: !contextTableName.value,
     icon: Table2,
+  },
+  {
+    label: t("contextMenu.editStructure"),
+    action: editTableStructureFromContextMenu,
+    disabled: !contextTableName.value,
+    icon: PencilRuler,
   },
   {
     label: t("contextMenu.viewDdl"),

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -133,6 +133,7 @@ const emit = defineEmits<{
   clickTable: [tableName: string];
   viewTableData: [tableName: string];
   viewTableDdl: [tableName: string];
+  editTableStructure: [tableName: string];
   openObjectTable: [target: { tableName: string; schema?: string }];
   objectSchemaChange: [schema: string | undefined];
   structureEditorSaved: [commentChanged: boolean];
@@ -561,6 +562,10 @@ function onHandleViewTableDdl(tableName: string) {
   emit("viewTableDdl", tableName);
 }
 
+function onHandleEditTableStructure(tableName: string) {
+  emit("editTableStructure", tableName);
+}
+
 function onHandleCloseColumnPanel() {
   showColumnInfo.value = false;
   columnInfoColumns.value = [];
@@ -681,6 +686,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
               @save="emit('saveSql')"
               @click-table="onHandleClickTable"
               @view-table-data="onHandleViewTableData"
+              @edit-table-structure="onHandleEditTableStructure"
               @view-table-ddl="onHandleViewTableDdl"
               @click-column="onHandleClickColumn"
               @close-column-panel="onHandleCloseColumnPanel"


### PR DESCRIPTION
## 变更说明
- 在 SQL 编辑器右键表名时新增「编辑表结构」菜单项，位置放在「查看 DDL」上方
- 复用现有表名识别逻辑，识别不到表名候选时菜单项置灰
- 点击后复用当前查询 tab 的连接、库和 schema，直接打开编辑表结构 tab

## 关联 issue
- #2422

## 测试
- pnpm typecheck
- pnpm lint（仅存在仓库既有 warning）