### PR TITLE
fix(app): unify import/export icons and clarify result archive tooltip

### DIFF
--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -65,7 +65,7 @@ defineExpose({ focusSearch });
                 model-value=""
                 :items="importSourceItems"
                 :aria-label="t('sidebar.import')"
-                :trigger-icon="Download"
+                :trigger-icon="Upload"
                 trigger-class="inline-flex h-6 w-5 items-center justify-center rounded-md outline-none hover:bg-muted hover:text-foreground focus-visible:ring-0"
                 trigger-icon-class="h-4 w-4"
                 content-class="w-44"
@@ -83,7 +83,7 @@ defineExpose({ focusSearch });
         <Tooltip>
           <TooltipTrigger as-child>
             <Button variant="ghost" size="icon" class="h-5 w-5" @click="emit('export')">
-              <Upload class="h-3 w-3" />
+              <Download class="h-3 w-3" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>{{ t("sidebar.export") }}</TooltipContent>

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1081,7 +1081,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
                 </DropdownMenuItem>
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger class="gap-2">
-                    <FileUp class="h-4 w-4" />
+                    <Download class="h-4 w-4" />
                     {{ t("tableToolbox.exportData") }}
                   </DropdownMenuSubTrigger>
                   <DropdownMenuPortal>

--- a/apps/desktop/src/components/layout/WelcomeScreen.vue
+++ b/apps/desktop/src/components/layout/WelcomeScreen.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
-import { FilePlus2, Plus, History, Download, Database, Search, ShieldCheck, Sparkles } from "@lucide/vue";
+import { FilePlus2, Plus, History, Upload, Database, Search, ShieldCheck, Sparkles } from "@lucide/vue";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
 import { connectionDriverLabel, connectionIconType, connectionRedactedNameLabel, connectionRedactedOptionSubtitle } from "@/lib/connectionPresentation";
 import type { ConnectionConfig } from "@/types/database";
@@ -85,7 +85,7 @@ const { t } = useI18n();
             <button class="flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50" @click="emit('new-connection')"><Plus class="h-4 w-4" /> {{ t("toolbar.newConnection") }}</button>
             <button class="flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50" :disabled="!hasConnections" @click="emit('new-query')"><FilePlus2 class="h-4 w-4" /> {{ t("toolbar.newQuery") }}</button>
             <button class="flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50" @click="emit('show-history')"><History class="h-4 w-4" /> {{ t("history.title") }}</button>
-            <button class="flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50" @click="emit('import-config')"><Download class="h-4 w-4" /> {{ t("sidebar.import") }}</button>
+            <button class="flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50" @click="emit('import-config')"><Upload class="h-4 w-4" /> {{ t("sidebar.import") }}</button>
             <div class="mt-2 rounded-md bg-muted/30 px-3 py-2 text-xs leading-5 text-muted-foreground">
               <Search class="mr-1 inline h-3.5 w-3.5" />
               {{ t("welcome.tip") }}

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -1393,7 +1393,7 @@ watch(
 function exportDataSubmenu(item: ObjectBrowserRow): ContextMenuItem {
   return {
     label: t("contextMenu.exportData"),
-    icon: Upload,
+    icon: Download,
     children: [
       { label: "CSV", action: () => exportData(item, "csv") },
       { label: "JSON", action: () => exportData(item, "json") },
@@ -1418,11 +1418,11 @@ function getTableMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
     ...(canRename(item) ? [{ label: t("contextMenu.renameObject"), action: () => requestRename(item), icon: Pencil }] : []),
     { label: t("contextMenu.newQuery"), action: () => openNewQuery(item), icon: TerminalSquare },
     ...(canOpenDiagram.value ? [{ label: t("diagram.open"), action: () => openDiagram(item), icon: Network }] : []),
-    ...(canOpenTableImport.value ? [{ label: t("contextMenu.importData"), action: () => openTableImport(item), icon: Download }] : []),
+    ...(canOpenTableImport.value ? [{ label: t("contextMenu.importData"), action: () => openTableImport(item), icon: Upload }] : []),
     { label: t("dataCompare.title"), action: () => openDataCompare(item), icon: ArrowRightLeft },
     { label: "", separator: true },
     exportDataSubmenu(item),
-    { label: t("contextMenu.exportDatabase"), action: () => openDatabaseExport(item), icon: Upload },
+    { label: t("contextMenu.exportDatabase"), action: () => openDatabaseExport(item), icon: Download },
     { label: t("contextMenu.exportStructure"), action: () => exportStructure(item), icon: FileCode },
     { label: "", separator: true },
     { label: t("contextMenu.duplicateStructure"), action: () => requestDuplicateStructure(item), icon: CopyPlus },
@@ -1466,7 +1466,7 @@ function getViewMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
     ...(canOpenDiagram.value ? [{ label: t("diagram.open"), action: () => openDiagram(item), icon: Network }] : []),
     { label: "", separator: true },
     exportDataSubmenu(item),
-    { label: t("contextMenu.exportDatabase"), action: () => openDatabaseExport(item), icon: Upload },
+    { label: t("contextMenu.exportDatabase"), action: () => openDatabaseExport(item), icon: Download },
     { label: t("contextMenu.exportStructure"), action: () => exportStructure(item), icon: FileCode },
     { label: "", separator: true },
     {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -3799,7 +3799,7 @@ const shortcutDelete = "Delete";
 function exportDataSubmenu(): ContextMenuItem {
   return {
     label: t("contextMenu.exportData"),
-    icon: Upload,
+    icon: Download,
     children: [
       { label: "CSV", action: () => exportData("csv") },
       { label: "JSON", action: () => exportData("json") },
@@ -4086,7 +4086,7 @@ function treeItemMenuItems(): ContextMenuItem[] {
     items.push({ label: t("transfer.dataTransfer"), action: openTransfer, icon: ArrowRightLeft });
     items.push({ label: t("diff.title"), action: openSchemaDiff, icon: ArrowRightLeft });
     items.push({ label: t("dataCompare.title"), action: openDataCompare, icon: ArrowRightLeft });
-    items.push({ label: t("contextMenu.exportDatabase"), action: openDatabaseExport, icon: Upload });
+    items.push({ label: t("contextMenu.exportDatabase"), action: openDatabaseExport, icon: Download });
     const destructiveActions: ContextMenuItem[] = [];
     if (canDropDatabase.value) {
       destructiveActions.push({
@@ -4263,14 +4263,14 @@ function treeItemMenuItems(): ContextMenuItem[] {
       items.push({ label: t("diagram.open"), action: openDiagram, icon: Network });
     }
     if (canOpenTableImport.value) {
-      items.push({ label: t("contextMenu.importData"), action: openTableImport, icon: Download });
+      items.push({ label: t("contextMenu.importData"), action: openTableImport, icon: Upload });
     }
     if (isTableNotView.value) {
       items.push({ label: t("dataCompare.title"), action: openDataCompare, icon: ArrowRightLeft });
     }
     items.push({ label: "", separator: true });
     items.push(exportDataSubmenu());
-    items.push({ label: t("contextMenu.exportDatabase"), action: openDatabaseExport, icon: Upload });
+    items.push({ label: t("contextMenu.exportDatabase"), action: openDatabaseExport, icon: Download });
     items.push({ label: t("contextMenu.exportStructure"), action: exportStructure, icon: FileCode });
     items.push(copyStructureAsSubmenu());
     if (isTableNotView.value) {

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -517,7 +517,7 @@ export default {
     autoKeepResultsDisabled: "Auto-keep results disabled",
     missingResultRun: "This result is no longer available",
     exportResultArchive: "Save Result Archive",
-    importResultArchive: "Import Results",
+    importResultArchive: "Import Result Archive",
     importedResultArchive: "Imported results",
     resultArchiveExported: "Results exported",
     resultArchiveImported: "Results imported",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -514,7 +514,7 @@ export default withEnglishFallback({
     autoKeepResultsDisabled: "Conservación automática desactivada",
     missingResultRun: "Este resultado ya no está disponible",
     exportResultArchive: "Guardar archivo de resultados",
-    importResultArchive: "Importar resultados",
+    importResultArchive: "Importar archivo de resultados",
     importedResultArchive: "Resultados importados",
     resultArchiveExported: "Resultados exportados",
     resultArchiveImported: "Resultados importados",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -518,7 +518,7 @@ export default withEnglishFallback({
     autoKeepResultsDisabled: "Mantieni risultati disabilitato",
     missingResultRun: "Questo risultato non e piu disponibile",
     exportResultArchive: "Salva Archivio Risultati",
-    importResultArchive: "Importa Risultati",
+    importResultArchive: "Importa Archivio Risultati",
     importedResultArchive: "Risultati importati",
     resultArchiveExported: "Risultati esportati",
     resultArchiveImported: "Risultati importati",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -511,7 +511,7 @@ export default withEnglishFallback({
     autoKeepResultsDisabled: "結果の自動保持をオフにしました",
     missingResultRun: "この結果は利用できなくなりました",
     exportResultArchive: "結果アーカイブを保存",
-    importResultArchive: "結果をインポート",
+    importResultArchive: "結果アーカイブをインポート",
     importedResultArchive: "結果をインポートしました",
     resultArchiveExported: "結果をエクスポートしました",
     resultArchiveImported: "結果をインポートしました",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -526,7 +526,7 @@ export default withEnglishFallback({
     autoKeepResultsDisabled: "Manutenção automática de resultados desativada",
     missingResultRun: "Este resultado não está mais disponível",
     exportResultArchive: "Salvar Arquivo de Resultados",
-    importResultArchive: "Importar Resultados",
+    importResultArchive: "Importar Arquivo de Resultados",
     importedResultArchive: "Resultados importados",
     resultArchiveExported: "Resultados exportados",
     resultArchiveImported: "Resultados importados",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -520,7 +520,7 @@ export default withEnglishFallback({
     autoKeepResultsDisabled: "已关闭自动保留结果",
     missingResultRun: "此结果已不可用",
     exportResultArchive: "保存结果归档",
-    importResultArchive: "导入结果",
+    importResultArchive: "导入结果归档",
     importedResultArchive: "导入的结果",
     resultArchiveExported: "结果已导出",
     resultArchiveImported: "结果已导入",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -514,7 +514,7 @@ export default withEnglishFallback({
     autoKeepResultsDisabled: "自動保留結果已停用",
     missingResultRun: "此結果已不再可用",
     exportResultArchive: "儲存結果封存",
-    importResultArchive: "匯入結果",
+    importResultArchive: "匯入結果封存",
     importedResultArchive: "已匯入的結果",
     resultArchiveExported: "結果已匯出",
     resultArchiveImported: "結果已匯入",


### PR DESCRIPTION
## Summary
- Align import/export icons across the connection sidebar, object browser, connection tree menus, welcome screen, and table toolbox: `Upload` for import, `Download` for export.
- Rename the editor toolbar label from "Import Results" to "Import Result Archive" so it pairs clearly with "Save Result Archive".

Fixes #2392

## Test plan
- [x] Connection sidebar: import uses Upload, export uses Download
- [x] Object browser / connection tree context menus: import data and export database/data icons match semantics
- [x] Editor toolbar: tooltip shows "导入结果归档" (zh-CN) alongside "保存结果归档"
- [x] Local desktop dev build verified (`--no-default-features`)
