### PR TITLE
chore(nix): bump packaging to 0.5.44

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782875958,
-        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
+        "lastModified": 1782962170,
+        "narHash": "sha256-HsaK9yDDypMB2TPxAYz0mPKtmYhgNwFQa72b3Ko6kRE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
+        "rev": "e3fa5cf86b93914b8f312b2a1ca14fbb139c655c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -165,7 +165,7 @@
         # ------------------------------------------------------------------ #
         packages.dbx-desktop = pkgs.stdenv.mkDerivation (finalAttrs: {
           pname = "dbx-desktop";
-          version = "0.5.42";
+          version = "0.5.44";
 
           src = pkgs.lib.cleanSource ./.;
 
@@ -178,7 +178,7 @@
             fetcherVersion = 3;
             # Replace with the correct hash after the first failed build:
             #   nix build .#dbx-desktop 2>&1 | grep 'got:'
-            hash = "sha256-dzGQuZAv+z7+fha7J180bqfFtJhH0DFDZ/nXy8U4ChM=";
+            hash = "sha256-DDPnQEuAsns7q7mxd2mPGyipIZXvFkrEGZlMh56YirE=";
           };
 
           # ── Step 2: vendor Cargo dependencies ───────────────────────────── #


### PR DESCRIPTION
## 变更说明

upgrade bump packaging to 0.5.44

## 变更类型

- 构建

## 涉及前端

无

## 验证

- 相关测试通过

## 关联 Issue

无
