### PR TITLE
fix(sql-library): restore Ctrl+click multi-select on Windows

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -41,6 +41,7 @@ import { findTreeNodeById, resolveNewQueryTarget } from "@/lib/newQueryContext";
 import { buildExecutableObjectSourceStatements, objectSourceSaveExecutionMode } from "@/lib/objectSourceEditor";
 import { resolveExecutableSql, resolveExecutableSqlWithBackend, type SqlExecutionSnapshot } from "@/lib/sqlExecutionTarget";
 import { uuid } from "@/lib/utils";
+import { isMacOS } from "@/lib/platform";
 import { isTauriRuntime } from "@/lib/tauriRuntime";
 import { openQueryResultArchiveFile } from "@/lib/queryResultArchiveFile";
 import { sqlFileTitleFromPath } from "@/lib/sqlFileOpen";
@@ -1639,10 +1640,11 @@ onMounted(async () => {
   }
   // macOS: Ctrl+click fires both click and contextmenu.
   // Intercept click in capture phase to prevent unwanted navigation.
+  // Windows/Linux use Ctrl+click for multi-select; do not block there.
   document.addEventListener(
     "click",
     (e) => {
-      if (e.ctrlKey) e.stopPropagation();
+      if (e.ctrlKey && isMacOS()) e.stopPropagation();
     },
     true,
   );


### PR DESCRIPTION
## Summary

- Fix SQL Library (and sidebar tree) multi-select on Windows: **Ctrl + click** now toggles selection instead of being swallowed by a global click interceptor.
- Scope the existing macOS-only workaround: only block `Ctrl+click` propagation on macOS, where it triggers both click and contextmenu.
- macOS behavior unchanged — **Cmd + click** / **Shift + click** multi-select continues to work as before.

Fixes #2219 (Windows platform)

## Root cause

`App.vue` registers a document-level capture listener intended for macOS:

```js
if (e.ctrlKey) e.stopPropagation();
```

On Windows, Ctrl+click is the standard multi-select gesture. Because propagation was stopped for all platforms, click events never reached SqlLibraryPanel / TreeItem handlers.

Changes
Import isMacOS from @/lib/platform
Change condition to if (e.ctrlKey && isMacOS()) e.stopPropagation()

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="486" height="474" alt="图片" src="https://github.com/user-attachments/assets/5e302380-cea6-4269-bb33-9622795e39d5" />
