### PR TITLE
fix(editor): avoid run gutter for MySQL REPLACE function

### DIFF
--- a/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
@@ -273,6 +273,22 @@ describe("statementRangeAtCursor", () => {
     expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
   });
 
+  it("keeps MySQL REPLACE function calls inside UPDATE assignments", () => {
+    const sql = `UPDATE ecm_archive_prepare_pool
+SET
+  request_json =
+    REPLACE(
+      request_json,
+      '"paperFlag":null',
+      '"paperFlag":false'
+    ),
+  process_flag = 0
+WHERE request_json LIKE '%"paperFlag":null%';`;
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "REPLACE"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
   it("does not merge a plain MySQL DESC table statement with the next query", () => {
     const sql = "DESC users\nSELECT * FROM users;";
     expect(statementRangeAtCursor(sql, indexOf(sql, "DESC"), "mysql")?.sql.trim()).toBe("DESC users");
@@ -347,6 +363,11 @@ describe("executableStatementRanges", () => {
     const ranges = executableStatementRanges(sql, "redis");
     expect(rangeSqlTexts(ranges)).toEqual(["GET user:1", "DEL user:2"]);
     expect(ranges.map((range) => range.from)).toEqual([0, sql.indexOf("DEL")]);
+  });
+
+  it("keeps MySQL REPLACE INTO as an executable statement start", () => {
+    const sql = "SELECT 1\nREPLACE INTO users (id, name) VALUES (1, 'a');";
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual(["SELECT 1", "REPLACE INTO users (id, name) VALUES (1, 'a')"]);
   });
 
   it("returns MongoDB command ranges for newline-separated shell commands", () => {

--- a/apps/desktop/src/lib/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sqlStatementRanges.ts
@@ -651,11 +651,18 @@ function softStatementKeywordAt(sql: string, pos: number, databaseType?: Databas
   const match = /^[A-Za-z_][\w$]*/.exec(sql.slice(pos));
   if (!match) return null;
   const keyword = match[0].toUpperCase();
+  if (keyword === "REPLACE" && nextNonWhitespaceChar(sql, pos + match[0].length) === "(") return null;
   return softStatementStartKeywords(databaseType).has(keyword) ? keyword : null;
 }
 
 function softStatementStartKeywords(databaseType?: DatabaseType): Set<string> {
   return new Set([...COMMON_SOFT_STATEMENT_START_KEYWORDS, ...(databaseType ? (DATABASE_SOFT_STATEMENT_KEYWORDS[databaseType] ?? []) : [])]);
+}
+
+function nextNonWhitespaceChar(sql: string, pos: number): string | null {
+  let i = pos;
+  while (i < sql.length && isSqlWhitespace(sql[i])) i += 1;
+  return i < sql.length ? sql[i] : null;
 }
 
 function isExplainLikeKeyword(keyword: string | null): boolean {


### PR DESCRIPTION
## Summary
- Do not treat `REPLACE(` as a soft statement start when parsing SQL editor execution ranges.
- Keep MySQL `REPLACE INTO` recognized as an executable statement start.
- Add regression coverage for both MySQL `REPLACE(...)` function calls and `REPLACE INTO` statements.

## Testing
- pnpm exec oxfmt apps/desktop/src/lib/sqlStatementRanges.ts apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
- pnpm oxlint apps/desktop/src/lib/sqlStatementRanges.ts apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
- pnpm vitest run apps/desktop/src/lib/__tests__/sqlStatementRanges.spec.ts
- pnpm typecheck
