### PR TITLE
fix(ai): bound schema context and result preview to prevent oversized AI payloads

### DIFF
--- a/apps/desktop/src/lib/ai.ts
+++ b/apps/desktop/src/lib/ai.ts
@@ -349,9 +349,11 @@ function formatSchema(context: AiContext): string {
     .join("\n\n");
 }
 
-export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig, options: { maxTables?: number; maxColumnsPerTable?: number; mentionedTables?: AiTableMention[] } = {}): Promise<AiContext> {
+export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig, options: { maxTables?: number; maxColumnsPerTable?: number; maxIndexesPerTable?: number; maxFksPerTable?: number; mentionedTables?: AiTableMention[] } = {}): Promise<AiContext> {
   const maxTables = options.maxTables ?? 50;
   const maxColumnsPerTable = options.maxColumnsPerTable ?? 40;
+  const maxIndexesPerTable = options.maxIndexesPerTable ?? 10;
+  const maxFksPerTable = options.maxFksPerTable ?? 10;
   const databaseType = aiDatabaseTypeForConnection(connection);
   const tables: AiSchemaTable[] = [];
   const tableKeys = new Set<string>();
@@ -371,8 +373,8 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
       tableType: "TABLE",
       comment: tableComment,
       columns: tab.tableMeta.columns.slice(0, maxColumnsPerTable),
-      indexes,
-      foreignKeys,
+      indexes: indexes.slice(0, maxIndexesPerTable),
+      foreignKeys: foreignKeys.slice(0, maxFksPerTable),
     });
     tableKeys.add(aiTableMentionKey(tab.tableMeta.schema, tName));
     truncated = tab.tableMeta.columns.length > maxColumnsPerTable;
@@ -381,7 +383,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
   for (const mention of options.mentionedTables ?? []) {
     const key = aiTableMentionKey(mention.schema, mention.table);
     if (tableKeys.has(key)) continue;
-    const entry = await loadMentionedTableContext(tab, connection, mention, maxColumnsPerTable).catch(() => undefined);
+    const entry = await loadMentionedTableContext(tab, connection, mention, maxColumnsPerTable, maxIndexesPerTable, maxFksPerTable).catch(() => undefined);
     if (!entry) continue;
     tableKeys.add(aiTableMentionKey(entry.schema, entry.name));
     tables.push(entry);
@@ -443,8 +445,8 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
               tableType: table.table_type,
               comment: table.comment,
               columns: columns.slice(0, maxColumnsPerTable),
-              indexes,
-              foreignKeys,
+              indexes: indexes.slice(0, maxIndexesPerTable),
+              foreignKeys: foreignKeys.slice(0, maxFksPerTable),
               _truncatedCols: columns.length > maxColumnsPerTable,
             })),
           ),
@@ -479,7 +481,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
   };
 }
 
-async function loadMentionedTableContext(tab: QueryTab, connection: ConnectionConfig, mention: AiTableMention, maxColumnsPerTable: number): Promise<AiSchemaTable | undefined> {
+async function loadMentionedTableContext(tab: QueryTab, connection: ConnectionConfig, mention: AiTableMention, maxColumnsPerTable: number, maxIndexesPerTable: number, maxFksPerTable: number): Promise<AiSchemaTable | undefined> {
   const databaseType = aiDatabaseTypeForConnection(connection);
   const schema = await resolveMentionedTableSchema(tab, connection, mention);
   const [columns, indexes, foreignKeys, tableComment] = await Promise.all([
@@ -494,8 +496,8 @@ async function loadMentionedTableContext(tab: QueryTab, connection: ConnectionCo
     tableType: "TABLE",
     comment: tableComment,
     columns: columns.slice(0, maxColumnsPerTable),
-    indexes,
-    foreignKeys,
+    indexes: indexes.slice(0, maxIndexesPerTable),
+    foreignKeys: foreignKeys.slice(0, maxFksPerTable),
   };
 }
 

--- a/apps/desktop/src/lib/ai.ts
+++ b/apps/desktop/src/lib/ai.ts
@@ -550,8 +550,15 @@ function extractLastError(result?: QueryResult): string | undefined {
 
 function formatResultPreview(result?: QueryResult): string | undefined {
   if (!result || result.columns.includes("Error") || !result.rows.length) return undefined;
+  const MAX_VALUE_CHARS = 200;
   const rows = result.rows.slice(0, 5).map((row) => {
-    return result.columns.map((column, index) => `${column}=${JSON.stringify(row[index] ?? null)}`).join(", ");
+    return result.columns
+      .map((column, index) => {
+        const raw = JSON.stringify(row[index] ?? null);
+        const val = raw.length > MAX_VALUE_CHARS ? raw.slice(0, MAX_VALUE_CHARS) + "…" : raw;
+        return `${column}=${val}`;
+      })
+      .join(", ");
   });
   return rows.join("\n");
 }


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

Two fixes to prevent oversized context payloads in the DB Assistant's schema and result preview, which could otherwise exceed token limits or degrade AI response quality.

Changes

1. Limit indexes and foreign keys per table in schema context

When a table has a large number of indexes or foreign keys (common in legacy/wide schemas), the full lists were included verbatim in the AI context, consuming excessive tokens. This change introduces configurable caps (maxIndexesPerTable, maxFksPerTable), both defaulting to 10, to keep the schema payload bounded.

- buildAiContext now accepts maxIndexesPerTable and maxFksPerTable options
- Both open tabs and mentioned tables respect these limits
- loadMentionedTableContext is updated to pass the limits through

2. Truncate large column values in result preview

Query result previews (shown to the AI as context) could contain enormous cell values — e.g. JSON blobs, base64-encoded data, or long text columns. A single oversized row could blow past token budgets. This change caps each column value at 200 characters in the formatted preview, appendi

Files changed

| File | Δ |
|------|---|
| apps/desktop/src/lib/ai.ts | +19 / −10 |

Testing

- Verified schema context with 50+ indexes/FKs per table — context payload stays bound
- Verified result preview with large JSON/text columns — values are truncated at 200 chars
- Existing behavior unaffected when tables have fewer indexes/FKs than the defaults

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
