### PR TITLE
✨ feat(ai-table-mentions): 增加AI表格提及候选项的过滤和格式化功能

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -35,7 +35,7 @@ import { isSchemaAware } from "@/lib/databaseCapabilities";
 import ExplainPlanViewer from "@/components/explain/ExplainPlanViewer.vue";
 import { parseExplainResult, type ParsedExplainPlan } from "@/lib/explainPlan";
 import { copyToClipboard } from "@/lib/clipboard";
-import { formatAiTableMention, parseAiTableMentions, type AiTableMention } from "@/lib/aiTableMentions";
+import { AI_TABLE_MENTION_CANDIDATE_LIMIT, AI_TABLE_MENTION_SCHEMA_LIMIT, filterAiTableMentionCandidates, formatAiTableMention, parseAiTableMentions, type AiTableMention } from "@/lib/aiTableMentions";
 import { isAiPromptImeCompositionEvent, shouldSubmitAiPromptOnKeydown } from "@/lib/aiPromptKeyboard";
 import { looksLikeActionProposal, containsChinese } from "@/lib/aiProposalDetect";
 
@@ -184,6 +184,7 @@ const mentionStart = ref(0);
 const mentionSelectedIndex = ref(0);
 const mentionCandidates = ref<AiMentionCandidate[]>([]);
 const mentionCache = ref<Record<string, AiMentionCandidate[]>>({});
+const mentionListRef = ref<HTMLElement | null>(null);
 const selectedMentions = ref<AiTableMention[]>([]);
 let mentionTimer: ReturnType<typeof setTimeout> | undefined;
 let mentionRequestId = 0;
@@ -574,30 +575,30 @@ async function loadMentionCandidates(query: string) {
       const schemas = mentionSchemaOrder(await listSchemas(props.tab.connectionId, props.tab.database));
       const filteredSchemas = schemaPrefix ? schemas.filter((schema) => schema.toLowerCase().includes(schemaPrefix.toLowerCase())) : schemas;
       const results = await Promise.all(
-        filteredSchemas.slice(0, 8).map(async (schema) => {
-          const tables = await listTables(props.tab!.connectionId, props.tab!.database, schema, tableFilter || undefined, 20);
-          return filterMentionCandidates(
+        filteredSchemas.slice(0, AI_TABLE_MENTION_SCHEMA_LIMIT).map(async (schema) => {
+          const tables = await listTables(props.tab!.connectionId, props.tab!.database, schema, tableFilter || undefined, AI_TABLE_MENTION_CANDIDATE_LIMIT);
+          return filterAiTableMentionCandidates(
             tables.map((table) => mentionCandidateFromTable(table, schema)),
             tableFilter,
-            20,
+            AI_TABLE_MENTION_CANDIDATE_LIMIT,
           );
         }),
       );
-      candidates = results.flat();
+      candidates = filterAiTableMentionCandidates(results.flat(), "", AI_TABLE_MENTION_CANDIDATE_LIMIT);
     } else {
       const schema = props.tab.database || props.connection.database || "main";
-      const tables = await listTables(props.tab.connectionId, props.tab.database, schema, tableFilter || undefined, 40);
-      candidates = filterMentionCandidates(
+      const tables = await listTables(props.tab.connectionId, props.tab.database, schema, tableFilter || undefined, AI_TABLE_MENTION_CANDIDATE_LIMIT);
+      candidates = filterAiTableMentionCandidates(
         tables.map((table) => mentionCandidateFromTable(table)),
         tableFilter,
-        40,
+        AI_TABLE_MENTION_CANDIDATE_LIMIT,
       );
     }
 
     if (requestId !== mentionRequestId) return;
-    mentionCache.value[key] = candidates.slice(0, 40);
+    mentionCache.value[key] = candidates.slice(0, AI_TABLE_MENTION_CANDIDATE_LIMIT);
     mentionCandidates.value = mentionCache.value[key];
-    mentionSelectedIndex.value = 0;
+    setMentionSelectedIndex(0);
   } catch (e: unknown) {
     if (requestId !== mentionRequestId) return;
     const message = e instanceof Error ? e.message : String(e);
@@ -636,9 +637,31 @@ function formatMentionTableType(tableType: string) {
   return t("ai.tableMentionTypes.table");
 }
 
-function filterMentionCandidates(candidates: AiMentionCandidate[], tableFilter: string, limit: number): AiMentionCandidate[] {
-  const normalizedFilter = tableFilter.toLowerCase();
-  return candidates.filter((candidate) => !normalizedFilter || candidate.name.toLowerCase().includes(normalizedFilter)).slice(0, limit);
+function setMentionSelectedIndex(index: number, keepVisible = true) {
+  mentionSelectedIndex.value = Math.max(0, Math.min(index, Math.max(mentionCandidates.value.length - 1, 0)));
+  if (keepVisible) scrollMentionSelectedIntoView();
+}
+
+function scrollMentionSelectedIntoView() {
+  nextTick(() => {
+    const list = mentionListRef.value;
+    if (!list) return;
+    const item = list.querySelector<HTMLElement>(`[data-mention-index="${mentionSelectedIndex.value}"]`);
+    if (!item) return;
+
+    const listRect = list.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect();
+    const itemTop = itemRect.top - listRect.top + list.scrollTop;
+    const itemBottom = itemTop + itemRect.height;
+    const visibleTop = list.scrollTop;
+    const visibleBottom = visibleTop + list.clientHeight;
+
+    if (itemTop < visibleTop) {
+      list.scrollTop = itemTop;
+    } else if (itemBottom > visibleBottom) {
+      list.scrollTop = itemBottom - list.clientHeight;
+    }
+  });
 }
 
 function refreshMentionState() {
@@ -654,6 +677,11 @@ function refreshMentionState() {
   mentionTimer = setTimeout(() => {
     loadMentionCandidates(mention.query).catch(() => {});
   }, 120);
+}
+
+function onPromptKeyup(event: KeyboardEvent) {
+  if (["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"].includes(event.key)) return;
+  refreshMentionState();
 }
 
 function insertMention(candidate: AiMentionCandidate) {
@@ -677,12 +705,12 @@ function onPromptKeydown(event: KeyboardEvent) {
   if (mentionOpen.value) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      mentionSelectedIndex.value = Math.min(mentionSelectedIndex.value + 1, Math.max(mentionCandidates.value.length - 1, 0));
+      setMentionSelectedIndex(mentionSelectedIndex.value + 1);
       return;
     }
     if (event.key === "ArrowUp") {
       event.preventDefault();
-      mentionSelectedIndex.value = Math.max(mentionSelectedIndex.value - 1, 0);
+      setMentionSelectedIndex(mentionSelectedIndex.value - 1);
       return;
     }
     if ((event.key === "Enter" || event.key === "Tab") && mentionCandidates.value[mentionSelectedIndex.value]) {
@@ -1291,15 +1319,16 @@ async function openExternalUrl(url: string) {
             <div v-else-if="!mentionCandidates.length" class="px-2 py-2 text-xs text-muted-foreground">
               {{ t("ai.tableMentionEmpty") }}
             </div>
-            <div v-else class="max-h-56 overflow-auto p-1">
+            <div v-else ref="mentionListRef" class="max-h-56 overflow-auto p-1">
               <button
                 v-for="(candidate, index) in mentionCandidates"
                 :key="`${candidate.schema || ''}.${candidate.name}`"
                 type="button"
+                :data-mention-index="index"
                 class="flex w-full min-w-0 items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-muted"
                 :class="{ 'bg-muted': index === mentionSelectedIndex }"
                 @mousedown.prevent="insertMention(candidate)"
-                @mouseenter="mentionSelectedIndex = index"
+                @mouseenter="setMentionSelectedIndex(index, false)"
               >
                 <Table2 class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 <span class="min-w-0 flex-1 truncate">
@@ -1331,7 +1360,7 @@ async function openExternalUrl(url: string) {
             :placeholder="activePlaceholder"
             @input="refreshMentionState"
             @click="refreshMentionState"
-            @keyup="refreshMentionState"
+            @keyup="onPromptKeyup"
             @compositionstart="promptCompositionActive = true"
             @compositionend="promptCompositionActive = false"
             @keydown="onPromptKeydown"

--- a/apps/desktop/src/lib/__tests__/aiTableMentions.spec.ts
+++ b/apps/desktop/src/lib/__tests__/aiTableMentions.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { AI_TABLE_MENTION_CANDIDATE_LIMIT, filterAiTableMentionCandidates, formatAiTableMention, parseAiTableMentions } from "@/lib/aiTableMentions";
+
+describe("AI table mention parsing", () => {
+  it("parses plain and schema-qualified table mentions", () => {
+    expect(parseAiTableMentions("explain @public.users and @orders")).toEqual([
+      { raw: "@public.users", schema: "public", table: "users" },
+      { raw: "@orders", schema: undefined, table: "orders" },
+    ]);
+  });
+
+  it("formats quoted table mentions when identifiers need escaping", () => {
+    expect(formatAiTableMention("public", "order items")).toBe('@public."order items"');
+  });
+});
+
+describe("AI table mention candidates", () => {
+  it("keeps more than the old 20 item cap for a single schema", () => {
+    const candidates = tables(40);
+
+    expect(filterAiTableMentionCandidates(candidates, "")).toHaveLength(40);
+  });
+
+  it("filters by table name and can return matches after the first 20 entries", () => {
+    const candidates = [...tables(25, "order_"), ...tables(30, "audit_")];
+    const filtered = filterAiTableMentionCandidates(candidates, "audit_");
+
+    expect(filtered).toHaveLength(30);
+    expect(filtered[0].name).toBe("audit_000");
+    expect(filtered.at(-1)?.name).toBe("audit_029");
+  });
+
+  it("applies the global candidate cap after multi-schema results are merged", () => {
+    const merged = [...tables(120, "public_"), ...tables(120, "archive_")];
+    const filtered = filterAiTableMentionCandidates(merged, "");
+
+    expect(filtered).toHaveLength(AI_TABLE_MENTION_CANDIDATE_LIMIT);
+    expect(filtered[0].name).toBe("public_000");
+    expect(filtered.at(-1)?.name).toBe("archive_079");
+  });
+});
+
+function tables(count: number, prefix = "table_") {
+  return Array.from({ length: count }, (_, index) => ({ name: `${prefix}${String(index).padStart(3, "0")}` }));
+}

--- a/apps/desktop/src/lib/aiTableMentions.ts
+++ b/apps/desktop/src/lib/aiTableMentions.ts
@@ -4,6 +4,9 @@ export interface AiTableMention {
   table: string;
 }
 
+export const AI_TABLE_MENTION_SCHEMA_LIMIT = 8;
+export const AI_TABLE_MENTION_CANDIDATE_LIMIT = 200;
+
 const SIMPLE_IDENTIFIER_RE = /^[\p{L}_][\p{L}\p{N}_$]*$/u;
 
 function isMentionBoundary(char: string | undefined): boolean {
@@ -100,4 +103,9 @@ function formatMentionPart(part: string): string {
 
 export function aiTableMentionKey(schema: string | undefined, table: string): string {
   return `${schema || ""}.${table}`.toLowerCase();
+}
+
+export function filterAiTableMentionCandidates<T extends { name: string }>(candidates: T[], tableFilter: string, limit = AI_TABLE_MENTION_CANDIDATE_LIMIT): T[] {
+  const normalizedFilter = tableFilter.toLowerCase();
+  return candidates.filter((candidate) => !normalizedFilter || candidate.name.toLowerCase().includes(normalizedFilter)).slice(0, limit);
 }


### PR DESCRIPTION
- 将原来AI对话艾特的上限改为200，覆盖大部分表格数量，再多恐怕影响性能。
- 修复了艾特表格列表上下翻不会滚动的bug


## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）
<img width="364" height="366" alt="image" src="https://github.com/user-attachments/assets/02e3ff32-48fd-473d-b6c1-070c72e76d22" />

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2466