### PR TITLE
fix(mongodb): route find result sorting through shell sort clauses

### DIFF
--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -16,7 +16,18 @@ import * as api from "@/lib/api";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { clampSearchSplitWidth } from "@/lib/dataGridSearchSplit";
 import { documentViewerFontStyle } from "@/lib/documentViewerFontStyle";
-import { buildDocumentFilterCondition, combineDocumentFilterConditions, currentDocumentFilterJson, defaultDocumentFilterRule, documentFilterModeNeedsValue, documentFilterModeOptions, documentStoreProviderFor, type DocumentFilterMode, type DocumentFilterRule } from "@/lib/documentStoreProvider";
+import {
+  buildDocumentFilterCondition,
+  combineDocumentFilterConditions,
+  currentDocumentFilterJson,
+  currentDocumentSortJson,
+  defaultDocumentFilterRule,
+  documentFilterModeNeedsValue,
+  documentFilterModeOptions,
+  documentStoreProviderFor,
+  type DocumentFilterMode,
+  type DocumentFilterRule,
+} from "@/lib/documentStoreProvider";
 import { buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, parseMongoDocumentInputValue, type MongoInputValue } from "@/lib/mongoDocumentValues";
 import { normalizeResultPageSize } from "@/lib/paginationPageSize";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -433,7 +444,7 @@ async function load() {
   const previousSelectedId = previousSelectedIdx === null ? null : documentIdentity(documents.value[previousSelectedIdx]);
   try {
     const filter = currentDocumentFilter();
-    const sort = sortInput.value.trim() || undefined;
+    const sort = currentDocumentSortJson(sortInput.value);
     const result = await api.documentFindDocuments(props.connectionId, props.database, props.collection, page.value * pageSize.value, pageSize.value, filter, undefined, sort, executionId);
     if (documentLoadExecutionId.value !== executionId) return;
     const nextDocuments = result.documents.map(asRecord);

--- a/apps/desktop/src/composables/useDataGridActions.ts
+++ b/apps/desktop/src/composables/useDataGridActions.ts
@@ -10,6 +10,7 @@ import * as api from "@/lib/api";
 import type { QueryTab } from "@/types/database";
 import { useToast } from "@/composables/useToast";
 import { effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from "@/lib/jdbcDialect";
+import { applyMongoFindSort } from "@/lib/mongoShellCommand";
 import { uuid } from "@/lib/utils";
 import type { DataGridSortMode } from "@/lib/dataGridSort";
 
@@ -235,6 +236,22 @@ export function useDataGridActions(activeTab: ComputedRef<QueryTab | undefined>)
     }
 
     const config = connectionStore.getConfig(tab.connectionId);
+    if (effectiveDatabaseTypeForConnection(config) === "mongodb") {
+      const sortedSql = applyMongoFindSort(baseSql, column, direction);
+      if (!sortedSql) {
+        toast(t("grid.sortUnsupported"), 5000);
+        return;
+      }
+      queryStore.updateSql(tab.id, sortedSql);
+      await queryStore.executeTabSql(tab.id, sortedSql, {
+        resultBaseSql: baseSql,
+        resultSortedSql: sortedSql,
+        preserveResultDuringExecution: true,
+        preserveTotalRowCountDuringExecution: true,
+      });
+      return;
+    }
+
     const built = await api.buildSortedQuerySql({
       originalSql: baseSql,
       databaseType: effectiveDatabaseTypeForConnection(config),

--- a/apps/desktop/src/lib/documentStoreProvider.ts
+++ b/apps/desktop/src/lib/documentStoreProvider.ts
@@ -151,6 +151,11 @@ export function currentDocumentFilterJson(input: string, structured: Record<stri
   return Object.keys(filter).length ? JSON.stringify(filter) : undefined;
 }
 
+export function currentDocumentSortJson(input: string): string | undefined {
+  const sort = parseDocumentFilterInput(input);
+  return Object.keys(sort).length ? JSON.stringify(sort) : undefined;
+}
+
 function parseDocumentFilterValue(raw: string): unknown {
   const trimmed = raw.trim();
   if (!trimmed) return "";

--- a/apps/desktop/src/lib/mongoShellCommand.ts
+++ b/apps/desktop/src/lib/mongoShellCommand.ts
@@ -112,6 +112,27 @@ export function parseMongoFindCommand(input: string): MongoFindCommand | null {
   };
 }
 
+export function applyMongoFindSort(input: string, column: string, direction: "asc" | "desc"): string | null {
+  const source = input.trim().replace(/;$/, "").trim();
+  const parsed = parseMongoFindCommand(source);
+  if (!parsed) return null;
+
+  const target = parseFindTarget(source);
+  if (!target) return null;
+
+  const findOpenIndex = source.indexOf("(", target.findCallIndex);
+  const findCloseIndex = findMatchingParen(source, findOpenIndex);
+  if (findCloseIndex < 0) return null;
+
+  const prefix = source.slice(0, findCloseIndex + 1);
+  const chainSource = source.slice(findCloseIndex + 1).trim();
+  if (chainSource && !chainSource.startsWith(".")) return null;
+
+  const chain = removeChainedMethodCall(chainSource, "sort");
+  const sortCall = `.sort(${JSON.stringify({ [column]: direction === "asc" ? 1 : -1 })})`;
+  return `${prefix}${sortCall}${chain}`;
+}
+
 export function parseMongoCountDocumentsCommand(input: string): MongoCountDocumentsCommand | null {
   const source = input.trim().replace(/;$/, "").trim();
   // Accept deprecated Mongo shell count helpers for old server workflows, but
@@ -932,6 +953,21 @@ function readChainedIntegerArgument(source: string, name: string, fallback: numb
   const value = Number(raw.trim());
   if (!Number.isSafeInteger(value) || value < 0) return null;
   return value;
+}
+
+function removeChainedMethodCall(chain: string, name: string): string {
+  if (!chain.trim()) return "";
+  let result = chain.trim();
+  const pattern = chainedMethodCallPattern(name);
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(result)) !== null) {
+    const openIndex = result.indexOf("(", match.index);
+    const closeIndex = findMatchingParen(result, openIndex);
+    if (closeIndex < 0) break;
+    result = `${result.slice(0, match.index)}${result.slice(closeIndex + 1)}`.trim();
+    pattern.lastIndex = 0;
+  }
+  return result;
 }
 
 function readChainedCallArgument(source: string, name: string): string | undefined {


### PR DESCRIPTION
## 变更说明

修复 MongoDB 连接后 sort 无效 的问题，涉及两处：
1.
查询编辑器结果表排序
原先 MongoDB 查询结果点击表头「按数据库排序」时，会误走 SQL 的 buildSortedQuerySql（要求 SELECT 语句），对 db.collection.find() 无效。
现改为通过 applyMongoFindSort() 在 find 命令链上插入/替换 .sort({...})，再重新执行。
2.
集合浏览器 sort 输入
原先 sort 输入框内容原样传给后端，shell 写法如 {name: -1} 不是合法 JSON，会导致排序失败。
现新增 currentDocumentSortJson()，与 filter 一样复用 parseDocumentFilterInput 做 JSON 规范化。
改动文件：
•apps/desktop/src/lib/mongoShellCommand.ts — 新增 applyMongoFindSort
•apps/desktop/src/composables/useDataGridActions.ts — MongoDB 专用排序分支
•apps/desktop/src/lib/documentStoreProvider.ts — 新增 currentDocumentSortJson
•apps/desktop/src/components/document/DocumentBrowser.vue — 使用规范化后的 sort 输入
影响范围： 仅 MongoDB / DocumentBrowser，不影响其他数据库的 SQL 排序逻辑。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端
本 PR 为既有 UI 上的行为修复，无新增组件、样式或文案。交互路径不变（表头排序、sort 输入框），仅修复排序实际生效


- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证
1.连接 MongoDB，执行 db.<collection>.find({})，在结果表点击列头「按数据库升序/降序排序」，确认结果顺序变化且编辑器 SQL 出现 .sort({...})。
2.打开集合浏览器，在 sort 输入框填写 {field: -1} 或 {"field": -1}，刷新后确认按该字段排序。
3.对已有 .sort() 的 find 命令再点表头换列排序，确认旧 sort 被替换且 skip/limit 保留。


- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
