### PR TITLE
feat(ai): support editing sent user messages

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -38,6 +38,7 @@ import { copyToClipboard } from "@/lib/clipboard";
 import { formatAiTableMention, parseAiTableMentions, type AiTableMention } from "@/lib/aiTableMentions";
 import { isAiPromptImeCompositionEvent, shouldSubmitAiPromptOnKeydown } from "@/lib/aiPromptKeyboard";
 import { looksLikeActionProposal, containsChinese } from "@/lib/aiProposalDetect";
+import { visibleToActualIndex } from "@/lib/aiMessageEdit";
 
 const { t } = useI18n();
 const settings = useSettingsStore();
@@ -89,11 +90,19 @@ const draftBeforeHistory = ref("");
 
 const editingMessageIndex = ref<number | null>(null);
 const editingContent = ref("");
+const editCompositionActive = ref(false);
 
 function startEditMessage(visibleIndex: number) {
   if (isGenerating.value) return;
   editingMessageIndex.value = visibleIndex;
   editingContent.value = visibleMessages.value[visibleIndex].content;
+  nextTick(() => {
+    const el = document.querySelector<HTMLTextAreaElement>("[data-edit-textarea]");
+    if (el) {
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    }
+  });
 }
 
 function cancelEdit() {
@@ -104,17 +113,7 @@ function cancelEdit() {
 function submitEdit(visibleIndex: number) {
   const content = editingContent.value.trim();
   if (!content) return;
-  let vi = 0;
-  let actualIndex = -1;
-  for (let i = 0; i < messages.value.length; i++) {
-    if (messages.value[i].kind !== "contextSummary") {
-      if (vi === visibleIndex) {
-        actualIndex = i;
-        break;
-      }
-      vi++;
-    }
-  }
+  const actualIndex = visibleToActualIndex(messages.value, visibleIndex);
   if (actualIndex < 0) return;
   messages.value = messages.value.slice(0, actualIndex);
   editingMessageIndex.value = null;
@@ -124,6 +123,7 @@ function submitEdit(visibleIndex: number) {
 }
 
 function onEditKeydown(event: KeyboardEvent, visibleIndex: number) {
+  if (isAiPromptImeCompositionEvent(event, editCompositionActive.value)) return;
   if (event.key === "Escape") {
     cancelEdit();
     return;
@@ -1178,15 +1178,13 @@ async function openExternalUrl(url: string) {
             <div class="max-w-[85%]">
               <template v-if="editingMessageIndex === i">
                 <textarea
-                  :ref="
-                    (el) => {
-                      if (el) (el as HTMLTextAreaElement).focus();
-                    }
-                  "
+                  data-edit-textarea
                   v-model="editingContent"
                   rows="3"
                   class="w-full resize-none rounded-lg border bg-background px-3 py-2 text-xs outline-none focus:ring-1 focus:ring-primary"
                   @keydown="onEditKeydown($event, i)"
+                  @compositionstart="editCompositionActive = true"
+                  @compositionend="editCompositionActive = false"
                 />
                 <div class="mt-1.5 flex justify-end gap-1.5">
                   <Button size="sm" variant="ghost" class="h-6 px-2 text-[11px]" @click="cancelEdit">{{ t("ai.editCancel") }}</Button>

--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -115,9 +115,15 @@ function submitEdit(visibleIndex: number) {
   if (!content) return;
   const actualIndex = visibleToActualIndex(messages.value, visibleIndex);
   if (actualIndex < 0) return;
+  if (!props.connection || !props.tab) return;
+  if (!settings.isConfigured()) {
+    toast(t("ai.noConfig"));
+    return;
+  }
   messages.value = messages.value.slice(0, actualIndex);
   editingMessageIndex.value = null;
   editingContent.value = "";
+  selectedMentions.value = [];
   prompt.value = content;
   send();
 }

--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -3,7 +3,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref, type Component } from 
 import { uuid } from "@/lib/utils";
 import { useI18n } from "vue-i18n";
 import { translateBackendError } from "@/i18n/backend-errors";
-import { ArrowUp, ArrowRightLeft, AlertTriangle, Bot, Check, ChevronRight, CircleSlash, Copy, Database, GitBranch, HelpCircle, History, Loader2, MessageSquarePlus, Replace, Server, ShieldCheck, Table2, Play, Square, Trash2, Terminal, Wand2, Wrench, X, Zap, TestTube } from "@lucide/vue";
+import { ArrowUp, ArrowRightLeft, AlertTriangle, Bot, Check, ChevronRight, CircleSlash, Copy, Database, GitBranch, HelpCircle, History, Loader2, MessageSquarePlus, Pencil, Replace, Server, ShieldCheck, Table2, Play, Square, Trash2, Terminal, Wand2, Wrench, X, Zap, TestTube } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -86,6 +86,53 @@ const agentTokens = ref<{ input: number; output: number } | null>(null);
 const promptHistory = ref<string[]>([]);
 const historyIndex = ref(-1);
 const draftBeforeHistory = ref("");
+
+const editingMessageIndex = ref<number | null>(null);
+const editingContent = ref("");
+
+function startEditMessage(visibleIndex: number) {
+  if (isGenerating.value) return;
+  editingMessageIndex.value = visibleIndex;
+  editingContent.value = visibleMessages.value[visibleIndex].content;
+}
+
+function cancelEdit() {
+  editingMessageIndex.value = null;
+  editingContent.value = "";
+}
+
+function submitEdit(visibleIndex: number) {
+  const content = editingContent.value.trim();
+  if (!content) return;
+  let vi = 0;
+  let actualIndex = -1;
+  for (let i = 0; i < messages.value.length; i++) {
+    if (messages.value[i].kind !== "contextSummary") {
+      if (vi === visibleIndex) {
+        actualIndex = i;
+        break;
+      }
+      vi++;
+    }
+  }
+  if (actualIndex < 0) return;
+  messages.value = messages.value.slice(0, actualIndex);
+  editingMessageIndex.value = null;
+  editingContent.value = "";
+  prompt.value = content;
+  send();
+}
+
+function onEditKeydown(event: KeyboardEvent, visibleIndex: number) {
+  if (event.key === "Escape") {
+    cancelEdit();
+    return;
+  }
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    submitEdit(visibleIndex);
+  }
+}
 
 // Inline model selector
 const modelOptions = ref<AiModelInfo[]>([]);
@@ -1127,9 +1174,35 @@ async function openExternalUrl(url: string) {
     <ScrollArea v-else ref="scrollRef" class="min-h-0 flex-1 overflow-hidden">
       <div class="flex flex-col gap-3 p-3">
         <template v-for="(msg, i) in visibleMessages" :key="i">
-          <div v-if="msg.role === 'user'" class="flex justify-end">
-            <div class="max-w-[85%] whitespace-pre-wrap rounded-lg bg-primary px-3 py-2 text-xs text-primary-foreground">
-              {{ msg.content }}
+          <div v-if="msg.role === 'user'" class="group flex justify-end">
+            <div class="max-w-[85%]">
+              <template v-if="editingMessageIndex === i">
+                <textarea
+                  :ref="
+                    (el) => {
+                      if (el) (el as HTMLTextAreaElement).focus();
+                    }
+                  "
+                  v-model="editingContent"
+                  rows="3"
+                  class="w-full resize-none rounded-lg border bg-background px-3 py-2 text-xs outline-none focus:ring-1 focus:ring-primary"
+                  @keydown="onEditKeydown($event, i)"
+                />
+                <div class="mt-1.5 flex justify-end gap-1.5">
+                  <Button size="sm" variant="ghost" class="h-6 px-2 text-[11px]" @click="cancelEdit">{{ t("ai.editCancel") }}</Button>
+                  <Button size="sm" class="h-6 px-2 text-[11px]" @click="submitEdit(i)">{{ t("ai.editResend") }}</Button>
+                </div>
+              </template>
+              <template v-else>
+                <div class="flex items-start gap-1">
+                  <button v-if="!isGenerating" class="mt-1 hidden h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground group-hover:flex" :title="t('ai.editMessage')" @click="startEditMessage(i)">
+                    <Pencil class="h-3 w-3" />
+                  </button>
+                  <div class="whitespace-pre-wrap rounded-lg bg-primary px-3 py-2 text-xs text-primary-foreground">
+                    {{ msg.content }}
+                  </div>
+                </div>
+              </template>
             </div>
           </div>
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1216,6 +1216,9 @@ export default {
       convert: "e.g. convert to PostgreSQL / MySQL / SQL Server",
       sampleData: "Describe the sample data or test statements to generate",
     },
+    editMessage: "Edit message",
+    editResend: "Resend",
+    editCancel: "Cancel",
   },
   contextMenu: {
     openConnection: "Open Connection",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1219,6 +1219,9 @@ export default withEnglishFallback({
       convert: "P. ej. convertir a PostgreSQL / MySQL / SQL Server",
       sampleData: "Describe los datos de ejemplo o sentencias de prueba a generar",
     },
+    editMessage: "Editar mensaje",
+    editResend: "Reenviar",
+    editCancel: "Cancelar",
   },
   contextMenu: {
     openConnection: "Abrir conexión",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1217,6 +1217,9 @@ export default withEnglishFallback({
       convert: "es. converti in PostgreSQL / MySQL / SQL Server",
       sampleData: "Descrivi i dati di esempio o le istruzioni di test da generare",
     },
+    editMessage: "Modifica messaggio",
+    editResend: "Invia di nuovo",
+    editCancel: "Annulla",
   },
   contextMenu: {
     openConnection: "Apri Connessione",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1217,6 +1217,9 @@ export default withEnglishFallback({
       convert: "例: PostgreSQL / MySQL / SQL Serverに変換",
       sampleData: "生成するサンプルデータやテスト文を説明してください",
     },
+    editMessage: "メッセージを編集",
+    editResend: "再送信",
+    editCancel: "キャンセル",
   },
   contextMenu: {
     openConnection: "接続を開く",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1218,6 +1218,9 @@ export default withEnglishFallback({
       convert: "por exemplo, converter para PostgreSQL / MySQL / SQL Server",
       sampleData: "Descreva os dados de exemplo ou instruções de teste a gerar",
     },
+    editMessage: "Editar mensagem",
+    editResend: "Reenviar",
+    editCancel: "Cancelar",
   },
   contextMenu: {
     openConnection: "Abrir Conexão",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1218,6 +1218,9 @@ export default withEnglishFallback({
       convert: "例如：转换成 PostgreSQL / MySQL / SQL Server",
       sampleData: "描述要生成的样例数据或测试语句",
     },
+    editMessage: "编辑消息",
+    editResend: "重新发送",
+    editCancel: "取消",
   },
   contextMenu: {
     openConnection: "打开连接",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1218,6 +1218,9 @@ export default withEnglishFallback({
       convert: "例如：轉換成 PostgreSQL / MySQL / SQL Server",
       sampleData: "描述要產生的範例資料或測試語句",
     },
+    editMessage: "編輯訊息",
+    editResend: "重新傳送",
+    editCancel: "取消",
   },
   contextMenu: {
     openConnection: "開啟連線",

--- a/apps/desktop/src/lib/__tests__/aiMessageEdit.spec.ts
+++ b/apps/desktop/src/lib/__tests__/aiMessageEdit.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { visibleToActualIndex } from "@/lib/aiMessageEdit";
+
+describe("visibleToActualIndex", () => {
+  it("maps visible index 0 to first non-summary message", () => {
+    const messages = [{ kind: undefined }, { kind: undefined }, { kind: undefined }];
+    expect(visibleToActualIndex(messages, 0)).toBe(0);
+  });
+
+  it("maps visible index 1 correctly with no summaries", () => {
+    const messages = [{ kind: undefined }, { kind: undefined }, { kind: undefined }];
+    expect(visibleToActualIndex(messages, 1)).toBe(1);
+  });
+
+  it("skips contextSummary messages when computing visible index", () => {
+    const messages = [{ kind: undefined }, { kind: "contextSummary" }, { kind: undefined }, { kind: undefined }];
+    // visible[0] → actual[0], visible[1] → actual[2], visible[2] → actual[3]
+    expect(visibleToActualIndex(messages, 0)).toBe(0);
+    expect(visibleToActualIndex(messages, 1)).toBe(2);
+    expect(visibleToActualIndex(messages, 2)).toBe(3);
+  });
+
+  it("skips multiple consecutive contextSummary messages", () => {
+    const messages = [{ kind: "contextSummary" }, { kind: "contextSummary" }, { kind: undefined }, { kind: undefined }];
+    expect(visibleToActualIndex(messages, 0)).toBe(2);
+    expect(visibleToActualIndex(messages, 1)).toBe(3);
+  });
+
+  it("returns -1 when visibleIndex is out of range", () => {
+    const messages = [{ kind: undefined }, { kind: undefined }];
+    expect(visibleToActualIndex(messages, 5)).toBe(-1);
+  });
+
+  it("returns -1 for empty messages array", () => {
+    expect(visibleToActualIndex([], 0)).toBe(-1);
+  });
+
+  it("returns -1 when all messages are contextSummary", () => {
+    const messages = [{ kind: "contextSummary" }, { kind: "contextSummary" }];
+    expect(visibleToActualIndex(messages, 0)).toBe(-1);
+  });
+
+  it("handles last visible message correctly", () => {
+    const messages = [{ kind: undefined }, { kind: "contextSummary" }, { kind: undefined }];
+    expect(visibleToActualIndex(messages, 1)).toBe(2);
+    expect(visibleToActualIndex(messages, 2)).toBe(-1);
+  });
+});

--- a/apps/desktop/src/lib/aiMessageEdit.ts
+++ b/apps/desktop/src/lib/aiMessageEdit.ts
@@ -1,0 +1,19 @@
+export interface MessageWithKind {
+  kind?: string;
+}
+
+/**
+ * Maps a visible message index (contextSummary messages excluded) to the
+ * actual index in the full messages array.
+ * Returns -1 if not found.
+ */
+export function visibleToActualIndex(messages: MessageWithKind[], visibleIndex: number): number {
+  let vi = 0;
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].kind !== "contextSummary") {
+      if (vi === visibleIndex) return i;
+      vi++;
+    }
+  }
+  return -1;
+}


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## Summary

Adds ChatGPT-style "edit and resend" to the AI assistant: hovering a sent user
message reveals a pencil button that opens an inline editor. Submitting truncates
the conversation from that point and regenerates the response with the edited text.

This PR also ships two follow-up fixes that harden the feature against data loss
and content pollution, plus an extracted, unit-tested helper for index mapping.

## Motivation

Users sometimes send a prompt with a typo or wrong table reference. Previously the
only option was to retype the whole message, which left the original (and the
assistant's reply) in history, polluting context for the next turn. Editing an
existing user message and regenerating keeps the conversation coherent.

## Changes

- **Inline message editor** — a hover-revealed pencil button on each user message
  opens a `<textarea>` pre-filled with the original content. Edit, th
  `Enter` (send) or `Esc` (cancel).
- **`visibleToActualIndex` helper** — extracted to `src/lib/aiMessage
  Maps a visible-message index (which excludes `contextSummary` entries) back to
  the real index in the `messages` array. Pure function, fully unit-tested.
- **IME-safe key handling** — `onEditKeydown` reuses the shared
  `isAiPromptImeCompositionEvent` helper so `Enter` during CJK candidate
  selection no longer accidentally submits.
- **One-shot focus** — replaced the per-render `:ref` focus callback (which reset
  the cursor on every keystroke) with a `nextTick` + `data-edit-textarea` query.
- **Two robustness fixes** (see *Bug Fixes* below).
- **i18n** — added `ai.editMessage`, `ai.editResend`, `ai.editCancel` to all 8
  supported locales.

## Commits

| Commit | Type | Description |
|--------|------|-------------|
| `09617395` | feat | support editing sent user messages |
| `681aacee` | fix | fix IME composition and ref-focus regression in message edit |
| `4940b214` | fix | prevent data loss and mention pollution in message edit |

## Bug Fixes

### 1. Data loss when `send()` bails early (medium)

`submitEdit` truncated `messages` (`messages.value.slice(0, actualIndex)`)
*before* calling `send()`. If `send()` then returned early — no conne
tab, or AI not configured — the conversation history from the edited message
onward was permanently destroyed and nothing was sent.

**Fix:** replicate `send()`'s connection/config guards in `submitEdit` *before*
truncating. If a guard fails, return without touching `messages`.

### 2. Stale table mentions polluting the resent message (low)

`submitEdit` set `prompt.value` but never cleared `selectedMentions`.
user had selected table `@`-mention chips in the main input without sending,
then edited and resent a history message, those stale chips were prepended to
the edited message's `displayText` and injected into the AI context.

**Fix:** `selectedMentions.value = []` before `send()`.

## Files Changed

| File | Change |
|------|--------|
| `apps/desktop/src/components/editor/AiAssistant.vue` | Editor UI, edit/cancel/submit logic, IME handling, focus |
| `apps/desktop/src/lib/aiMessageEdit.ts` | New — `visibleToActualInd
| `apps/desktop/src/lib/__tests__/aiMessageEdit.spec.ts` | New — 8 unit tests for index mapping |
| `apps/desktop/src/i18n/locales/{en,es,it,ja,pt-BR,zh-CN,zh-TW}.ts` | 3 new keys each |

**Diffstat:** 10 files changed, 169 insertions(+), 4 deletions(-)

## Testing

- `npx vitest run src/lib/__tests__/aiMessageEdit.spec.ts` → 8/8 passed
- `npx vue-tsc --noEmit --project apps/desktop/tsconfig.json` → clean
- `npx oxlint --vue-plugin` on changed files → clean
- Pre-commit hook (`oxfmt`) ran on commit.

> Note: `apps/desktop/src/lib/__tests__/ai.spec.ts` has one pre-existing
> locale-dependent failure (`buildSystemPrompt` returns the Chinese branch under
> a Chinese locale, so the English `'double quotes "name"'` assertion fails).
> It is unrelated to this branch — `ai.ts` / `ai.spec.ts` are not touched here.

## Manual Verification

| Scenario | Steps | Expected |
|----------|-------|----------|
| Normal edit & resend | Configure AI, chat, hover a user message, click pencil, edit, `Enter` | Conversation truncated at edited message, new response generated |
| Edit when AI unconfigured | Clear API key, edit a message, resend | Toast "no config", history fully preserved, editor stays open |
| Edit with stale mention chips | Select a table `@`-chip in input, dnd a history message | Resent message contains only edited text; inputchips cleared |
| IME composition | Use a CJK IME, type in edit box, press `Enter` during candidate selection | Does NOT submit |
| Cancel edit | Press `Esc` while editing | Original message unchanged |
| No edit during generation | Hover a message while AI is replying | Pencil button hidden |

## Checklist

- [x] Feature implemented end-to-end
- [x] Pure helper extracted & unit-tested
- [x] IME composition handled
- [x] i18n keys added to all locales
- [x] Type check passes
- [x] Lint passes
- [x] Data-loss and mention-pollution edge cases fixed
- [ ] Manual UI verification (pending)

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="694" height="338" alt="ed516f3c-96dc-4dd1-a3ae-0270bd81f112" src="https://github.com/user-attachments/assets/868d583d-c1c0-4972-a5b0-66785dc59d46" />


<img width="696" height="556" alt="5d7591b5-5bea-4b28-a404-138339b57cdd" src="https://github.com/user-attachments/assets/18c9ac00-0124-48d8-8652-cb9d7ff4cc6c" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
