### PR TITLE
[Fix]: fix kafka icon contrast in dark theme

### DIFF
--- a/apps/desktop/public/icons/database/kafka.svg
+++ b/apps/desktop/public/icons/database/kafka.svg
@@ -1,21 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
   <!-- Kafka network topology icon (symbol only, no text) -->
   <!-- Central node (larger) -->
-  <circle cx="24" cy="24" r="5" fill="#231F20"/>
+  <circle cx="24" cy="24" r="5" fill="#231F20" stroke="#F8FAFC" stroke-width="2"/>
   <!-- Top node -->
-  <circle cx="24" cy="6" r="3.5" fill="#231F20"/>
+  <circle cx="24" cy="6" r="3.5" fill="#231F20" stroke="#F8FAFC" stroke-width="2"/>
   <!-- Bottom node -->
-  <circle cx="24" cy="42" r="3.5" fill="#231F20"/>
+  <circle cx="24" cy="42" r="3.5" fill="#231F20" stroke="#F8FAFC" stroke-width="2"/>
   <!-- Upper-left node -->
-  <circle cx="8" cy="14" r="3.5" fill="#231F20"/>
+  <circle cx="8" cy="14" r="3.5" fill="#231F20" stroke="#F8FAFC" stroke-width="2"/>
   <!-- Lower-left node -->
-  <circle cx="8" cy="34" r="3.5" fill="#231F20"/>
+  <circle cx="8" cy="34" r="3.5" fill="#231F20" stroke="#F8FAFC" stroke-width="2"/>
   <!-- Right node -->
-  <circle cx="40" cy="24" r="3.5" fill="#231F20"/>
+  <circle cx="40" cy="24" r="3.5" fill="#231F20" stroke="#F8FAFC" stroke-width="2"/>
   <!-- Connecting lines -->
+  <line x1="24" y1="19" x2="24" y2="9.5" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round"/>
   <line x1="24" y1="19" x2="24" y2="9.5" stroke="#231F20" stroke-width="1.5"/>
+  <line x1="24" y1="29" x2="24" y2="38.5" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round"/>
   <line x1="24" y1="29" x2="24" y2="38.5" stroke="#231F20" stroke-width="1.5"/>
+  <line x1="20.5" y1="21.5" x2="11" y2="16" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round"/>
   <line x1="20.5" y1="21.5" x2="11" y2="16" stroke="#231F20" stroke-width="1.5"/>
+  <line x1="20.5" y1="26.5" x2="11" y2="32" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round"/>
   <line x1="20.5" y1="26.5" x2="11" y2="32" stroke="#231F20" stroke-width="1.5"/>
+  <line x1="29" y1="24" x2="36.5" y2="24" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round"/>
   <line x1="29" y1="24" x2="36.5" y2="24" stroke="#231F20" stroke-width="1.5"/>
 </svg>

--- a/packages/app-tests/databaseIconAssets.test.ts
+++ b/packages/app-tests/databaseIconAssets.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+
+test("Kafka database icon includes a light contrast stroke for dark themes", () => {
+  const svg = readFileSync(path.resolve("apps/desktop/public/icons/database/kafka.svg"), "utf8");
+
+  assert.match(svg, /stroke="#(?:F8FAFC|E5E7EB|FFFFFF)"/i);
+  assert.match(svg, /fill="#231F20"/i);
+});


### PR DESCRIPTION
## 变更说明

暗黑模式下kafka 驱动图标全黑色，看不见

## 变更类型

- [ ] 新功能
- [X] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1296" height="278" alt="image" src="https://github.com/user-attachments/assets/2dd91bc6-7ed9-4374-b084-2ea09a6399d1" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
