### PR TITLE
fix(desktop): scale multi-statement query timeout

### DIFF
--- a/apps/desktop/src/lib/queryTimeout.ts
+++ b/apps/desktop/src/lib/queryTimeout.ts
@@ -1,8 +1,17 @@
-import type { ConnectionConfig } from "@/types/database";
+import { splitSqlStatementRanges } from "@/lib/sqlStatementRanges";
+import type { ConnectionConfig, DatabaseType } from "@/types/database";
 
 export const DEFAULT_QUERY_TIMEOUT_SECS = 30;
 
 export function queryTimeoutSecsForConnection(connection?: Pick<ConnectionConfig, "query_timeout_secs"> | null): number {
   const value = Number(connection?.query_timeout_secs);
   return Number.isFinite(value) && value >= 0 ? value : DEFAULT_QUERY_TIMEOUT_SECS;
+}
+
+export function frontendQueryTimeoutSecsForSql(sql: string, databaseType: DatabaseType | undefined, queryTimeoutSecs: number): number {
+  if (queryTimeoutSecs === 0) return 0;
+
+  const baseTimeoutSecs = Math.max(queryTimeoutSecs * 2, 60);
+  const statementCount = Math.max(splitSqlStatementRanges(sql, databaseType).length, 1);
+  return baseTimeoutSecs * statementCount;
 }

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -33,7 +33,7 @@ import { tableMetaForDataTab } from "@/lib/tableDataTabMeta";
 import { tableOpenPageLimit } from "@/lib/tableOpenPageLimit";
 import { quoteTableIdentifier } from "@/lib/tableSelectSql";
 import { connectionUsesDatabaseObjectTreeMode, connectionUsesSchemaExecutionContext, effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from "@/lib/jdbcDialect";
-import { queryTimeoutSecsForConnection } from "@/lib/queryTimeout";
+import { frontendQueryTimeoutSecsForSql, queryTimeoutSecsForConnection } from "@/lib/queryTimeout";
 import { sortDataGridRows, type DataGridSortDirection } from "@/lib/dataGridSort";
 import { normalizeResultPageSize } from "@/lib/paginationPageSize";
 import { splitSqlStatementRanges } from "@/lib/sqlStatementRanges";
@@ -2135,7 +2135,7 @@ export const useQueryStore = defineStore("query", () => {
       }
 
       const executionSchema = connectionUsesSchemaExecutionContext(conn) ? tab.schema || tab.database : tab.mode === "data" || connectionUsesDatabaseObjectTreeMode(conn) ? undefined : tab.schema;
-      const frontendTimeoutSecs = Math.max(queryTimeoutSecs * 2, 60);
+      const frontendTimeoutSecs = frontendQueryTimeoutSecsForSql(sqlToExecute, effectiveDbType, queryTimeoutSecs);
       const sourceLabelDatabase = tab.database || conn?.database;
 
       let executionPromise: Promise<QueryResult[]>;
@@ -2174,7 +2174,7 @@ export const useQueryStore = defineStore("query", () => {
         });
         executionPromise = api.executeMulti(tab.connectionId, tab.database, sqlToExecute, executionSchema, executionId, executionOptions);
       }
-      const results = annotateQueryResultSources(markQueryResultsRowsRaw(await withFrontendQueryTimeout(executionPromise, queryTimeoutSecs === 0 ? 0 : frontendTimeoutSecs, t("editor.queryTimeoutError", { seconds: frontendTimeoutSecs }))), queryBaseSql, sourceLabelDatabase, effectiveDbType);
+      const results = annotateQueryResultSources(markQueryResultsRowsRaw(await withFrontendQueryTimeout(executionPromise, frontendTimeoutSecs, t("editor.queryTimeoutError", { seconds: frontendTimeoutSecs }))), queryBaseSql, sourceLabelDatabase, effectiveDbType);
       console.info("[DBX][executeTabSql:execute-multi:done]", {
         traceId,
         resultCount: results.length,

--- a/packages/app-tests/queryTimeout.test.ts
+++ b/packages/app-tests/queryTimeout.test.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { DEFAULT_QUERY_TIMEOUT_SECS, frontendQueryTimeoutSecsForSql, queryTimeoutSecsForConnection } from "../../apps/desktop/src/lib/queryTimeout.ts";
+
+test("queryTimeoutSecsForConnection falls back to the default timeout", () => {
+  assert.equal(queryTimeoutSecsForConnection(undefined), DEFAULT_QUERY_TIMEOUT_SECS);
+  assert.equal(queryTimeoutSecsForConnection({ query_timeout_secs: -1 }), DEFAULT_QUERY_TIMEOUT_SECS);
+  assert.equal(queryTimeoutSecsForConnection({ query_timeout_secs: 0 }), 0);
+  assert.equal(queryTimeoutSecsForConnection({ query_timeout_secs: 15 }), 15);
+});
+
+test("frontend query timeout scales with SQL statement count", () => {
+  assert.equal(frontendQueryTimeoutSecsForSql("INSERT INTO users VALUES (1)", "mysql", 30), 60);
+  assert.equal(frontendQueryTimeoutSecsForSql("INSERT INTO users VALUES (1); INSERT INTO users VALUES (2);", "mysql", 30), 120);
+  assert.equal(frontendQueryTimeoutSecsForSql("INSERT INTO users VALUES (1); INSERT INTO users VALUES (2); INSERT INTO users VALUES (3);", "mysql", 10), 180);
+  assert.equal(frontendQueryTimeoutSecsForSql("/* prep */\nINSERT INTO users VALUES (1);\n-- keep batching\nINSERT INTO users VALUES (2);", "mysql", 30), 120);
+  assert.equal(frontendQueryTimeoutSecsForSql("INSERT INTO users VALUES (1); INSERT INTO users VALUES (2);", "mysql", 0), 0);
+});


### PR DESCRIPTION
## 变更说明

修复多条 SQL 顺序执行时被前端固定兜底超时误判为查询超时的问题。

此前 `executeMulti` 会把整批 SQL 包在一个固定的前端超时中：默认查询超时 30 秒时，前端最多等待 60 秒。对于 #2455 中这类上千条 `INSERT` 顺序执行的场景，后端会按单条 statement 正常执行并最终完成，但前端会先在 60 秒时报 `查询超时`。

本 PR 将前端兜底超时按实际 SQL statement 数量扩展，使其与后端逐条执行、逐条应用查询超时的语义保持一致。单条 SQL 的前端超时行为保持不变，`query_timeout_secs = 0` 仍表示不启用前端兜底超时。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不调整 UI 展示，仅修复查询执行超时控制逻辑。已通过 Web UI 路径验证：执行 1000 条带 `SLEEP(0.08)` 的 MySQL `INSERT`，修复后约 88 秒正常完成，不再在 60 秒时报错。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm vitest run packages/app-tests/queryTimeout.test.ts`
- `pnpm vitest run packages/app-tests/queryStore.test.ts packages/app-tests/queryTimeout.test.ts`
- `pnpm typecheck`
- `pnpm exec oxlint apps/desktop/src/lib/queryTimeout.ts apps/desktop/src/stores/queryStore.ts packages/app-tests/queryTimeout.test.ts`
- `pnpm exec oxfmt --check apps/desktop/src/lib/queryTimeout.ts apps/desktop/src/stores/queryStore.ts packages/app-tests/queryTimeout.test.ts`
- `pnpm check`
- `make check`
- `make cargo-check-fast`

手动验证：

- 使用 Web UI 连接 MySQL 8 测试库。
- 执行 1000 条顺序 `INSERT`，每条包含 `SLEEP(0.08)`。
- 修复前前端约 60 秒提示 `查询超时 (60s)`，但数据库最终插入成功。
- 修复后前端等待整批执行完成，并正常收到 `execute-multi:done`；数据库确认 `COUNT(*) = 1000`。

## 关联 Issue

Close #2455
