### PR TITLE
Fix：修复 Oracle 大量对象时表名补全缺失

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2439,6 +2439,9 @@ mod tests {
             "Agent RPC error (-1): Unknown method: completion_assistant_search_v1"
         ));
         assert!(super::is_agent_completion_assistant_unsupported(
+            "Agent RPC error (-1): unknown method: completion_assistant_search_v1"
+        ));
+        assert!(super::is_agent_completion_assistant_unsupported(
             "Agent RPC error (-1): Completion assistant search is not supported by this agent"
         ));
         assert!(!super::is_agent_completion_assistant_unsupported("Agent RPC error (-1): Connection failed"));
@@ -2932,10 +2935,10 @@ pub async fn completion_assistant_search_core(
 }
 
 fn is_agent_completion_assistant_unsupported(error: &str) -> bool {
-    error.contains("Unknown method: completion_assistant_search_v1")
-        || error.contains("Method not found: completion_assistant_search_v1")
+    let error = error.to_ascii_lowercase();
+    error.contains("unknown method: completion_assistant_search_v1")
         || error.contains("method not found: completion_assistant_search_v1")
-        || error.contains("Completion assistant search is not supported")
+        || error.contains("completion assistant search is not supported")
 }
 
 async fn completion_assistant_fallback_core(


### PR DESCRIPTION
## 修复内容
- 修复 Oracle agent 返回小写 `unknown method: completion_assistant_search_v1` 时未触发补全 fallback 的问题。
- 将 agent 补全接口不支持的错误识别改为大小写无关，确保 Oracle 等未实现新补全接口的 agent 能降级到 `list_tables`。
- 补充回归测试覆盖 Oracle agent 当前返回的小写 unknown method 场景。

## 验证
- 在本地 Oracle 实例造 1600 张表和 20 个视图，修复前 `/api/schema/completion-assistant` 返回 500；修复后能返回表/视图候选，`fallback_used=true`。
- 已在前端预览中确认 `DBX_2510_T_` / `DBX_2510_V_` 能出现补全候选。
- `cargo test -p dbx-core detects_unsupported_agent_completion_assistant_errors`
- `cargo fmt --check`

Fixes #2510