### PR TITLE
[fix] fix Linux Alt+F4 exit handling

### DIFF
--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -144,10 +144,11 @@ test("external SQL file paths persist with open query tabs", async () => {
     const tabId = store.createTab("conn-1", "db", "draft.sql");
     store.updateSql(tabId, "select 1;");
     store.linkExternalSqlPath(tabId, "/tmp/draft.sql", "draft.sql");
-    store.flushPendingPersist();
+    await store.flushPendingPersist();
 
     setActivePinia(createPinia());
     store = useQueryStore();
+    await store.initOpenTabs();
     const tab = store.tabs.find((item) => item.id === tabId);
 
     assert.equal(tab?.externalSqlPath, "/tmp/draft.sql");
@@ -177,13 +178,14 @@ test("clean saved SQL tabs persist without duplicating SQL text", async () => {
       createdAt: "2026-06-27T00:00:00.000Z",
       updatedAt: "2026-06-27T00:00:00.000Z",
     });
-    store.flushPendingPersist();
+    await store.flushPendingPersist();
 
-    const rawTabs = localStorage.getItem("dbx-open-tabs") ?? "";
+    const rawTabs = localStorage.getItem("dbx-app-state:open_tabs") ?? "";
     assert.equal(rawTabs.includes("large_table"), false);
 
     setActivePinia(createPinia());
     store = useQueryStore();
+    await store.initOpenTabs();
     const tab = store.tabs.find((item) => item.savedSqlId === "saved-1");
 
     assert.equal(tab?.sql, "");
@@ -209,13 +211,14 @@ test("dirty saved SQL tabs keep unsaved edits in open tab persistence", async ()
       updatedAt: "2026-06-27T00:00:00.000Z",
     });
     store.updateSql(tabId, "SELECT 2;");
-    store.flushPendingPersist();
+    await store.flushPendingPersist();
 
-    const rawTabs = localStorage.getItem("dbx-open-tabs") ?? "";
+    const rawTabs = localStorage.getItem("dbx-app-state:open_tabs") ?? "";
     assert.equal(rawTabs.includes("SELECT 2;"), true);
 
     setActivePinia(createPinia());
     store = useQueryStore();
+    await store.initOpenTabs();
     const tab = store.tabs.find((item) => item.savedSqlId === "saved-1");
 
     assert.equal(tab?.sql, "SELECT 2;");
@@ -452,7 +455,7 @@ test("close other fixed tabs does not close regular tabs", () => {
   );
 });
 
-test("close other tabs pauses on restored unsaved query tabs", () => {
+test("close other tabs pauses on restored unsaved query tabs", async () => {
   const restoreStorage = installMemoryStorage();
   try {
     localStorage.setItem(
@@ -479,6 +482,7 @@ test("close other tabs pauses on restored unsaved query tabs", () => {
     localStorage.setItem("dbx-active-tab", "b");
     setActivePinia(createPinia());
     const store = useQueryStore();
+    await store.initOpenTabs();
 
     store.closeOtherTabs("b");
 

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -9,7 +9,7 @@ import { AI_PROVIDER_PRESETS, DEFAULT_EDITOR_SETTINGS, normalizeAiConfig, normal
 
 const OLD_FONT_SIZE_KEY = "dbx-query-editor-font-size";
 
-function withMockLocalStorage(initial: Record<string, string>, run: () => void) {
+async function withMockLocalStorage(initial: Record<string, string>, run: () => void | Promise<void>) {
   const previousDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
   const values = new Map(Object.entries(initial));
   const localStorageMock = {
@@ -31,7 +31,7 @@ function withMockLocalStorage(initial: Record<string, string>, run: () => void) 
   });
 
   try {
-    run();
+    await run();
   } finally {
     if (previousDescriptor) {
       Object.defineProperty(globalThis, "localStorage", previousDescriptor);
@@ -60,26 +60,28 @@ test("defaults export batch size to 2000 rows", () => {
   assert.equal(normalizeEditorSettings({ exportBatchSize: 2000 }).exportBatchSize, 2000);
 });
 
-test("migrates the legacy saved export batch default to 2000 once", () => {
-  withMockLocalStorage({ "dbx-editor-settings": JSON.stringify({ exportBatchSize: 10000 }) }, () => {
+test("migrates the legacy saved export batch default to 2000 once", async () => {
+  await withMockLocalStorage({ "dbx-editor-settings": JSON.stringify({ exportBatchSize: 10000 }) }, async () => {
     setActivePinia(createPinia());
     const store = useSettingsStore();
+    await store.initEditorSettings();
 
     assert.equal(store.editorSettings.exportBatchSize, 2000);
-    assert.equal(localStorage.getItem("dbx-export-batch-size-default-migrated-v1"), "1");
-    assert.equal(JSON.parse(localStorage.getItem("dbx-editor-settings") || "{}").exportBatchSize, 2000);
+    assert.equal(localStorage.getItem("dbx-editor-settings"), null);
+    assert.equal(JSON.parse(localStorage.getItem("dbx-app-state:editor_settings") || "{}").exportBatchSize, 2000);
   });
 });
 
-test("keeps a manually saved 10000 export batch size after migration", () => {
-  withMockLocalStorage(
+test("keeps a manually saved 10000 export batch size after migration", async () => {
+  await withMockLocalStorage(
     {
       "dbx-editor-settings": JSON.stringify({ exportBatchSize: 10000 }),
       "dbx-export-batch-size-default-migrated-v1": "1",
     },
-    () => {
+    async () => {
       setActivePinia(createPinia());
       const store = useSettingsStore();
+      await store.initEditorSettings();
 
       assert.equal(store.editorSettings.exportBatchSize, 10000);
     },
@@ -441,8 +443,8 @@ test("keeps SQL formatter default objects distinct", () => {
   assert.notEqual(normalized.sqlFormatter, DEFAULT_SQL_FORMATTER_SETTINGS);
 });
 
-test("does not leak default-loaded SQL formatter mutations into defaults", () => {
-  withMockLocalStorage({}, () => {
+test("does not leak default-loaded SQL formatter mutations into defaults", async () => {
+  await withMockLocalStorage({}, async () => {
     setActivePinia(createPinia());
     const store = useSettingsStore();
     const editorDefaultKeywordCase = DEFAULT_EDITOR_SETTINGS.sqlFormatter.keywordCase;
@@ -462,10 +464,11 @@ test("does not leak default-loaded SQL formatter mutations into defaults", () =>
   });
 });
 
-test("does not leak migrated SQL formatter mutations into defaults", () => {
-  withMockLocalStorage({ [OLD_FONT_SIZE_KEY]: "18" }, () => {
+test("does not leak migrated SQL formatter mutations into defaults", async () => {
+  await withMockLocalStorage({ [OLD_FONT_SIZE_KEY]: "18" }, async () => {
     setActivePinia(createPinia());
     const store = useSettingsStore();
+    await store.initEditorSettings();
     const editorDefaultKeywordCase = DEFAULT_EDITOR_SETTINGS.sqlFormatter.keywordCase;
     const formatterDefaultKeywordCase = DEFAULT_SQL_FORMATTER_SETTINGS.keywordCase;
 

--- a/packages/app-tests/useDataGridExport.test.ts
+++ b/packages/app-tests/useDataGridExport.test.ts
@@ -9,6 +9,7 @@ const apiMock = vi.hoisted(() => ({
   cancelQueryResultExport: vi.fn(),
   startTableExport: vi.fn(),
   cancelTableExport: vi.fn(),
+  saveEditorSettings: vi.fn(async () => {}),
   exportQueryResultCsv: vi.fn(),
   exportQueryResultXlsx: vi.fn(),
   exportQueryResultJson: vi.fn(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,10 +12,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 #[cfg(target_os = "macos")]
+use tauri::menu::Menu;
+#[cfg(target_os = "macos")]
 use tauri::menu::{AboutMetadata, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::RunEvent;
 use tauri::{
-    menu::{Menu, MenuBuilder},
+    menu::MenuBuilder,
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 };
 use tauri::{Emitter, Manager};
@@ -24,6 +26,7 @@ use tauri_plugin_deep_link::DeepLinkExt;
 
 const DESKTOP_TRAY_ID: &str = "main-tray";
 const APP_CLOSE_REQUESTED_EVENT: &str = "dbx-app-close-requested";
+#[cfg(target_os = "macos")]
 const APP_MENU_QUIT_ID: &str = "app-menu-quit";
 
 pub struct CloseBehaviorState {
@@ -37,10 +40,6 @@ impl CloseBehaviorState {
 
     pub(crate) fn allow_next_exit(&self) {
         self.confirmed_exit.store(true, Ordering::Relaxed);
-    }
-
-    pub(crate) fn is_exit_confirmed(&self) -> bool {
-        self.confirmed_exit.load(Ordering::Relaxed)
     }
 
     fn take_confirmed_exit(&self) -> bool {
@@ -67,8 +66,8 @@ fn should_show_main_window_after_setup() -> bool {
     true
 }
 
-fn should_confirm_app_exit_request(exit_code: Option<i32>, confirmed_exit: bool) -> bool {
-    exit_code != Some(tauri::RESTART_EXIT_CODE) && !confirmed_exit
+fn should_confirm_app_exit_request(target_os: &str, exit_code: Option<i32>, confirmed_exit: bool) -> bool {
+    should_hide_window_on_close(target_os) && exit_code != Some(tauri::RESTART_EXIT_CODE) && !confirmed_exit
 }
 
 fn native_window_decorations_override(target_os: &str) -> Option<bool> {
@@ -449,10 +448,11 @@ mod tests {
 
     #[test]
     fn only_user_requested_app_exit_needs_frontend_confirmation() {
-        assert!(should_confirm_app_exit_request(None, false));
-        assert!(should_confirm_app_exit_request(Some(0), false));
-        assert!(!should_confirm_app_exit_request(Some(0), true));
-        assert!(!should_confirm_app_exit_request(Some(tauri::RESTART_EXIT_CODE), false));
+        assert!(should_confirm_app_exit_request("windows", None, false));
+        assert!(should_confirm_app_exit_request("macos", Some(0), false));
+        assert!(!should_confirm_app_exit_request("windows", Some(0), true));
+        assert!(!should_confirm_app_exit_request("windows", Some(tauri::RESTART_EXIT_CODE), false));
+        assert!(!should_confirm_app_exit_request("linux", Some(0), false));
     }
 
     #[test]
@@ -1114,7 +1114,7 @@ pub fn run() {
                     .try_state::<CloseBehaviorState>()
                     .map(|state| state.take_confirmed_exit())
                     .unwrap_or(false);
-                if should_confirm_app_exit_request(*code, confirmed_exit) {
+                if should_confirm_app_exit_request(std::env::consts::OS, *code, confirmed_exit) {
                     api.prevent_exit();
                     request_app_close(app_handle, "quit");
                 }


### PR DESCRIPTION
## 变更说明

修复 Linux 下使用 `Alt+F4` 关闭 DBX 后进程未正常退出、导致应用无法再次打开的问题。

同时补充并对齐了相关测试：
- Rust 单测覆盖 Linux 不应拦截 `ExitRequested` 的行为
- 前端测试改为等待当前异步持久化流程，避免因为测试假设过时而误报失败

根本原因：桌面端在 `RunEvent::ExitRequested` 中把所有平台的退出请求都统一拦截成前端关闭确认流程，但实际只有 Windows / macOS 采用“关闭窗口时隐藏到后台”的交互模型。Linux 并不走这套隐藏逻辑，却仍被拦截，导致 `Alt+F4` 后退出流程没有正常完成，从而留下残留进程。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本次没有用户可见的前端 UI 改动；测试文件调整仅用于对齐现有异步持久化实现。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过


手动验证建议：
1. 在 Linux 桌面环境启动 DBX
2. 使用 `Alt+F4` 关闭主窗口
3. 确认没有残留 DBX 进程
4. 再次启动 DBX，确认可以正常打开

## 关联 Issue

Close #2572
