### PR TITLE
fix(desktop): preserve sidebar groups on reload

### DIFF
--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -4627,9 +4627,10 @@ export const useConnectionStore = defineStore("connection", () => {
         const saved = await api.loadConnections();
         connections.value = saved.map(normalizeConnection);
         const savedLayout = await api.loadSidebarLayout();
+        const currentLayout = sidebarLayout.value.groups.length || sidebarLayout.value.order.length ? sidebarLayout.value : null;
         sidebarLayout.value = reconcileLayout(
           connections.value.map((c) => c.id),
-          savedLayout,
+          savedLayout ?? currentLayout,
         );
         rebuildTreeNodes();
       })().finally(() => {

--- a/packages/app-tests/connectionStoreGroupedConnect.test.ts
+++ b/packages/app-tests/connectionStoreGroupedConnect.test.ts
@@ -153,6 +153,64 @@ test("duplicating a grouped connection keeps the copy in the same group", async 
   }
 });
 
+test("reloading connections preserves the current grouped layout when the saved layout is temporarily unavailable", async () => {
+  const originalFetch = globalThis.fetch;
+  const storage = installMemoryStorage();
+  const savedConnections: ConnectionConfig[] = [
+    conn("pg", "pg"),
+    conn("pg2", "pg2"),
+    conn("pg3", "pg3"),
+    conn("pg4", "pg4"),
+  ];
+  let savedLayout: SidebarLayout | null = {
+    groups: [
+      { id: "group-a", name: "dir[a]", collapsed: false },
+      { id: "group-b", name: "dir[b]", collapsed: false },
+    ],
+    order: [
+      { type: "group", id: "group-a", connectionIds: ["pg", "pg2"] },
+      { type: "group", id: "group-b", connectionIds: ["pg3", "pg4"] },
+    ],
+  };
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url === "/api/connection/list") {
+      return new Response(JSON.stringify(savedConnections), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/layout/sidebar") {
+      if (init?.method === "POST") {
+        savedLayout = JSON.parse(String(init.body ?? "null"));
+        return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify(savedLayout), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+
+  try {
+    setActivePinia(createPinia());
+    const store = useConnectionStore();
+    await store.initFromDisk();
+
+    assert.deepEqual(
+      store.treeNodes.map((node) => node.label),
+      ["dir[a]", "dir[b]"],
+    );
+
+    savedLayout = null;
+    await store.initFromDisk();
+
+    assert.deepEqual(
+      store.treeNodes.map((node) => node.label),
+      ["dir[a]", "dir[b]"],
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    storage.restore();
+  }
+});
+
 test("importing grouped dbx connections remaps exported layout to new connection ids", async () => {
   const originalFetch = globalThis.fetch;
   const storage = installMemoryStorage();


### PR DESCRIPTION
## 变更说明

修复连接树在运行中重新加载连接时，若本次 `sidebar_layout` 暂时不可用，会把当前已有连接目录打散的问题。

根因是 `connectionStore.initFromDisk()` 在每次 reload 时都会直接用 `loadSidebarLayout()` 的结果重建 sidebar layout。当运行中的某次加载拿到 `null` layout 时，`reconcileLayout()` 会按“无布局”处理，把所有连接展开到根层，导致原本的连接目录在 UI 中消失。重启后如果磁盘 layout 恢复，则目录又会重新出现。

本 PR 在当前内存中已有有效 layout、但本次加载到的 layout 为 `null` 时，复用当前 layout 作为 fallback，再用最新连接列表进行 reconcile。首次启动、正常保存布局、正常删除连接仍保持原逻辑。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

Draft 状态先用于 #2144 作者复测。该改动影响左侧连接树状态恢复逻辑；如果复测通过，ready for review 前可补充截图或录屏。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm vitest run packages/app-tests/connectionStoreGroupedConnect.test.ts packages/app-tests/sidebarLayout.test.ts packages/app-tests/sidebarLayoutNested.test.ts`
- `pnpm typecheck`
- `pnpm exec oxlint apps/desktop/src/stores/connectionStore.ts packages/app-tests/connectionStoreGroupedConnect.test.ts`（通过；仅有既有 warning：`connectionStore.ts:1637`）

手动验证：

- 使用 `DBX_DATA_DIR=/tmp/dbx-2144 pnpm dev:tauri` 启动本地源码版 DBX Desktop。
- 准备 4 个测试连接，并分组为 `dir[a]`、`dir[b]`。
- 删除 `sidebar_layout` 后，通过 MCP bridge `POST /reload-connections` 触发运行中 reload。
- 修复前：连接目录消失，连接浮到根层。
- 修复后：`dir[a]`、`dir[b]` 仍保持显示。

## 关联 Issue

Related #2144
