### PR TITLE
fix(mysql): handle 1045 Access Denied for strict ProxySQL/MyCat handshakes

### DIFF
--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -289,6 +289,22 @@ pub async fn connect_mysql_metadata_pool(
                     )
                     .await
                     .map(|pool| (pool, MysqlMode::Bare))
+                } else if let Some(db) = db_config.effective_database() {
+                    let mut unscoped_config = db_config.clone();
+                    unscoped_config.database = None;
+                    let unscoped_url = connection_url_for_endpoint(&unscoped_config, host, port);
+                    let mut retry_setup_queries = extra_setup_queries.clone();
+                    retry_setup_queries.insert(0, format!("USE `{}`", db.replace('`', "``")));
+                    log::info!("MySQL connection with database in URL failed ({err}); retrying without database in URL and using USE statement.");
+                    connect_bare_mysql_pool_with_setup(
+                        &unscoped_config,
+                        &unscoped_url,
+                        connect_timeout,
+                        max_connections,
+                        &retry_setup_queries,
+                    )
+                    .await
+                    .map(|pool| (pool, MysqlMode::Bare))
                 } else {
                     Err(err)
                 }
@@ -323,6 +339,24 @@ pub async fn connect_mysql_metadata_pool(
                     max_connections,
                     idle_timeout_secs,
                     &extra_setup_queries,
+                )
+                .await?;
+                let mode = detect_ob_oracle_mode(config, &pool).await;
+                Ok((pool, mode))
+            } else if let Some(db) = db_config.effective_database() {
+                let mut unscoped_config = db_config.clone();
+                unscoped_config.database = None;
+                let unscoped_url = connection_url_for_endpoint(&unscoped_config, host, port);
+                let mut retry_setup_queries = extra_setup_queries.clone();
+                retry_setup_queries.insert(0, format!("USE `{}`", db.replace('`', "``")));
+                log::info!("MySQL connection with database in URL failed ({err}); retrying without database in URL and using USE statement.");
+                let pool = db::mysql::connect_with_ca_cert_pool_limit_idle_and_setup(
+                    &unscoped_url,
+                    Some(&config.ca_cert_path),
+                    connect_timeout,
+                    max_connections,
+                    idle_timeout_secs,
+                    &retry_setup_queries,
                 )
                 .await?;
                 let mode = detect_ob_oracle_mode(config, &pool).await;

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -293,15 +293,14 @@ pub async fn connect_mysql_metadata_pool(
                     let mut unscoped_config = db_config.clone();
                     unscoped_config.database = None;
                     let unscoped_url = connection_url_for_endpoint(&unscoped_config, host, port);
-                    let mut retry_setup_queries = extra_setup_queries.clone();
-                    retry_setup_queries.insert(0, format!("USE `{}`", db.replace('`', "``")));
                     log::info!("MySQL connection with database in URL failed ({err}); retrying without database in URL and using USE statement.");
-                    connect_bare_mysql_pool_with_setup(
+                    connect_bare_mysql_pool_with_setup_database(
                         &unscoped_config,
                         &unscoped_url,
                         connect_timeout,
                         max_connections,
-                        &retry_setup_queries,
+                        db,
+                        &extra_setup_queries,
                     )
                     .await
                     .map(|pool| (pool, MysqlMode::Bare))
@@ -347,16 +346,15 @@ pub async fn connect_mysql_metadata_pool(
                 let mut unscoped_config = db_config.clone();
                 unscoped_config.database = None;
                 let unscoped_url = connection_url_for_endpoint(&unscoped_config, host, port);
-                let mut retry_setup_queries = extra_setup_queries.clone();
-                retry_setup_queries.insert(0, format!("USE `{}`", db.replace('`', "``")));
                 log::info!("MySQL connection with database in URL failed ({err}); retrying without database in URL and using USE statement.");
-                let pool = db::mysql::connect_with_ca_cert_pool_limit_idle_and_setup(
+                let pool = db::mysql::connect_with_ca_cert_pool_limit_idle_and_setup_database(
                     &unscoped_url,
                     Some(&config.ca_cert_path),
                     connect_timeout,
                     max_connections,
                     idle_timeout_secs,
-                    &retry_setup_queries,
+                    Some(db),
+                    &extra_setup_queries,
                 )
                 .await?;
                 let mode = detect_ob_oracle_mode(config, &pool).await;
@@ -457,6 +455,40 @@ async fn connect_bare_mysql_pool_with_setup(
     } else {
         db::mysql::connect_bare_with_pool_limit_and_setup(url, connect_timeout, max_connections, extra_setup_queries)
             .await
+    }
+}
+
+async fn connect_bare_mysql_pool_with_setup_database(
+    db_config: &ConnectionConfig,
+    url: &str,
+    connect_timeout: std::time::Duration,
+    max_connections: usize,
+    setup_database: &str,
+    extra_setup_queries: &[String],
+) -> Result<db::mysql::MySqlPool, String> {
+    // Some MySQL proxies reject the default database in the handshake; pass it
+    // separately so DB-layer setup keeps the normal charset/catalog/USE order.
+    if db_config.bare_mysql_uses_tls() {
+        let idle_timeout_secs = Some(db_config.idle_timeout_secs);
+        db::mysql::connect_with_ca_cert_pool_limit_idle_and_setup_database(
+            url,
+            Some(&db_config.ca_cert_path),
+            connect_timeout,
+            max_connections,
+            idle_timeout_secs,
+            Some(setup_database),
+            extra_setup_queries,
+        )
+        .await
+    } else {
+        db::mysql::connect_bare_with_pool_limit_and_setup_database(
+            url,
+            connect_timeout,
+            max_connections,
+            Some(setup_database),
+            extra_setup_queries,
+        )
+        .await
     }
 }
 

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -426,16 +426,43 @@ pub async fn connect_with_ca_cert_pool_limit_idle_and_setup(
     idle_timeout_secs: Option<u64>,
     extra_setup_queries: &[String],
 ) -> Result<MySqlPool, String> {
+    connect_with_ca_cert_pool_limit_idle_and_setup_database(
+        url,
+        ca_cert_path,
+        fallback_timeout,
+        max_connections,
+        idle_timeout_secs,
+        None,
+        extra_setup_queries,
+    )
+    .await
+}
+
+pub async fn connect_with_ca_cert_pool_limit_idle_and_setup_database(
+    url: &str,
+    ca_cert_path: Option<&str>,
+    fallback_timeout: Duration,
+    max_connections: usize,
+    idle_timeout_secs: Option<u64>,
+    setup_database: Option<&str>,
+    extra_setup_queries: &[String],
+) -> Result<MySqlPool, String> {
     let timeout = super::parse_connect_timeout_with_fallback(url, fallback_timeout);
-    let pool = create_pool(url, ca_cert_path, max_connections, idle_timeout_secs, extra_setup_queries)?;
+    let pool = create_pool(url, ca_cert_path, max_connections, idle_timeout_secs, setup_database, extra_setup_queries)?;
     let result = verify_pool_connection(&pool, timeout).await;
 
     if let Err(ref e) = result {
         if mysql_error_should_retry_without_ssl(e) {
             if let Some(fallback_url) = ssl_fallback_url(url) {
                 log::info!("SSL handshake failed, retrying with ssl-mode=disabled");
-                let fallback_pool =
-                    create_pool(&fallback_url, None, max_connections, idle_timeout_secs, extra_setup_queries)?;
+                let fallback_pool = create_pool(
+                    &fallback_url,
+                    None,
+                    max_connections,
+                    idle_timeout_secs,
+                    setup_database,
+                    extra_setup_queries,
+                )?;
                 return match verify_pool_connection(&fallback_pool, timeout).await {
                     Ok(()) => Ok(fallback_pool),
                     Err(e) => Err(e),
@@ -458,6 +485,7 @@ fn create_pool(
     ca_cert_path: Option<&str>,
     max_connections: usize,
     idle_timeout_secs: Option<u64>,
+    setup_database: Option<&str>,
     extra_setup_queries: &[String],
 ) -> Result<MySqlPool, String> {
     let tls_url = mysql_tls_url(url)?;
@@ -474,12 +502,16 @@ fn create_pool(
         .with_constraints(mysql_async::PoolConstraints::new(1, max_connections).unwrap())
         .with_inactive_connection_ttl(inactive_ttl)
         .with_reset_connection(max_connections > 1);
+    let setup_queries = match setup_database {
+        Some(database) => mysql_setup_queries_for_database(url, Some(database), extra_setup_queries),
+        None => mysql_setup_queries(url, extra_setup_queries),
+    };
     let mut builder = mysql_async::OptsBuilder::from_opts(opts)
         .stmt_cache_size(0)
         .prefer_socket(false)
         .pool_opts(Some(pool_opts))
         .tcp_keepalive(Some(MYSQL_TCP_KEEPALIVE_MS))
-        .setup(mysql_setup_queries(url, extra_setup_queries));
+        .setup(setup_queries);
     if let Some(ssl_opts) = mysql_ssl_opts(base_ssl_opts, url, ca_cert_path, &tls_url.files)? {
         builder = builder.ssl_opts(ssl_opts);
     }
@@ -584,9 +616,17 @@ fn mysql_ssl_opts(
 }
 
 fn mysql_setup_queries(url: &str, extra_setup_queries: &[String]) -> Vec<String> {
+    mysql_setup_queries_for_database(url, None, extra_setup_queries)
+}
+
+fn mysql_setup_queries_for_database(
+    url: &str,
+    setup_database: Option<&str>,
+    extra_setup_queries: &[String],
+) -> Vec<String> {
     let charset = mysql_connection_charset(url).unwrap_or("utf8mb4");
     let catalog = mysql_connection_catalog(url);
-    let database = mysql_connection_database(url);
+    let database = setup_database.map(ToOwned::to_owned).or_else(|| mysql_connection_database(url));
     let mut queries = Vec::new();
     if let Some(database) = database.as_deref() {
         queries.push(format!("USE {}", quote_identifier(database)));
@@ -1142,8 +1182,19 @@ pub async fn connect_bare_with_pool_limit_and_setup(
     max_connections: usize,
     extra_setup_queries: &[String],
 ) -> Result<MySqlPool, String> {
+    connect_bare_with_pool_limit_and_setup_database(url, fallback_timeout, max_connections, None, extra_setup_queries)
+        .await
+}
+
+pub async fn connect_bare_with_pool_limit_and_setup_database(
+    url: &str,
+    fallback_timeout: Duration,
+    max_connections: usize,
+    setup_database: Option<&str>,
+    extra_setup_queries: &[String],
+) -> Result<MySqlPool, String> {
     let timeout = super::parse_connect_timeout_with_fallback(url, fallback_timeout);
-    let pool = create_pool(url, None, max_connections, None, extra_setup_queries)?;
+    let pool = create_pool(url, None, max_connections, None, setup_database, extra_setup_queries)?;
     verify_pool_connection(&pool, timeout).await.map(|_| pool)
 }
 
@@ -3716,6 +3767,17 @@ UNIQUE KEY(`tenant_id`, `name``part`)
         let queries = mysql_setup_queries("mysql://root:secret@localhost:3306/db%2Fname?charset=utf8mb4", &[]);
 
         assert_eq!(queries, vec!["USE `db/name`", "SET NAMES utf8mb4"]);
+    }
+
+    #[test]
+    fn mysql_setup_queries_can_select_database_without_url_path() {
+        let queries = mysql_setup_queries_for_database(
+            "mysql://root:secret@localhost:3306?charset=utf8mb4",
+            Some("app`proxy"),
+            &[],
+        );
+
+        assert_eq!(queries, vec!["USE `app``proxy`", "SET NAMES utf8mb4"]);
     }
 
     #[test]


### PR DESCRIPTION
**Problem:**
When connecting to MySQL through certain strict proxies (like ProxySQL or MyCat), passing the database name directly in the initial handshake URL results in an immediate `1045 Access Denied` error when trying to expand tables and fetch schema metadata.

**Solution:**
Modified `connect_mysql_metadata_pool` to include a fallback mechanism. If the initial scoped connection fails, it automatically retries with an unscoped (bare) URL and immediately executes `USE \`dbname\`;` as a setup query. This successfully bypasses proxy handshake limitations while maintaining the strictly scoped session context for table expansion and queries.

---

### 📸 Screenshots

**Before (Fails to expand tables due to ProxySQL handshake rejection):**
<img width="1544" height="739" alt="image" src="https://github.com/user-attachments/assets/7557d010-17e0-410b-b7c4-a8413ac18303" />
<img width="1571" height="721" alt="image" src="https://github.com/user-attachments/assets/dd4b3910-ad56-43ee-8e1d-1eb2e0df9517" />


**After (Successfully bypasses the proxy restriction and lists tables):**
<img width="612" height="423" alt="image" src="https://github.com/user-attachments/assets/0f282cb7-4178-4e05-a3b7-f4f22efbbe37" />
<img width="557" height="420" alt="image" src="https://github.com/user-attachments/assets/5690a4f8-458d-4787-9587-9c859f4f43af" />


---

**Testing Strategy:**
Due to the complexity of simulating a strict ProxySQL/MyCat environment that explicitly rejects database schemas during the initial TCP handshake, a reliable automated unit test for this specific fallback is difficult to mock.

However, I have manually tested this in our production proxy environment. Before this patch, the connection consistently failed with `ERROR 1045` when extracting metadata schemas. With this patch, the connection successfully falls back to the bare connection and cleanly scopes the session via `USE db`, resolving the issue entirely.