### PR TITLE
fix(redis): stop duplicating pubsub messages

### DIFF
--- a/apps/desktop/src/components/redis/RedisPubSubPanel.vue
+++ b/apps/desktop/src/components/redis/RedisPubSubPanel.vue
@@ -65,21 +65,24 @@ async function connect() {
   if (ws && ws.readyState === WebSocket.OPEN) return;
   connecting.value = true;
   try {
-    ws = await api.redisPubSubConnect(props.connectionId);
+    const socket = await api.redisPubSubConnect(props.connectionId);
+    ws = socket;
 
-    ws.onopen = () => {
+    socket.onopen = () => {
+      if (ws !== socket) return;
       connected.value = true;
       connecting.value = false;
       // Re-subscribe existing channels
       if (channels.value.length > 0) {
-        ws!.send(JSON.stringify({ type: "subscribe", channels: channels.value }));
+        socket.send(JSON.stringify({ type: "subscribe", channels: channels.value }));
       }
       if (patterns.value.length > 0) {
-        ws!.send(JSON.stringify({ type: "psubscribe", patterns: patterns.value }));
+        socket.send(JSON.stringify({ type: "psubscribe", patterns: patterns.value }));
       }
     };
 
-    ws.onmessage = (event) => {
+    socket.onmessage = (event) => {
+      if (ws !== socket) return;
       try {
         const data = JSON.parse(event.data as string);
         if (data.error) {
@@ -92,13 +95,15 @@ async function connect() {
       }
     };
 
-    ws.onclose = () => {
+    socket.onclose = () => {
+      if (ws !== socket) return;
       connected.value = false;
       connecting.value = false;
       ws = null;
     };
 
-    ws.onerror = () => {
+    socket.onerror = () => {
+      if (ws !== socket) return;
       connected.value = false;
       connecting.value = false;
       ws = null;
@@ -110,11 +115,11 @@ async function connect() {
 }
 
 function disconnect() {
-  if (ws) {
-    ws.close();
-    ws = null;
-    connected.value = false;
-  }
+  const socket = ws;
+  ws = null;
+  connected.value = false;
+  connecting.value = false;
+  if (socket) socket.close();
 }
 
 function subscribe() {
@@ -159,11 +164,6 @@ async function publish() {
   if (!ch || !msg) return;
   try {
     await api.redisPubSubPublish(props.connectionId, props.db, ch, msg);
-    // Echo locally only if subscribed — Redis PubSub doesn't deliver to publisher
-    const isSubscribed = channels.value.includes(ch) || patterns.value.some((p) => new RegExp("^" + p.replace(/\*/g, ".*") + "$").test(ch));
-    if (isSubscribed) {
-      addMessage(ch, null, msg);
-    }
     publishMessage.value = "";
   } catch (e) {
     toast(t("redis.pubsubPublishFailed", { error: e instanceof Error ? e.message : String(e) }), 3000);


### PR DESCRIPTION
## 变更说明

- 修复 Redis 发布/订阅面板中每条消息重复显示两次的问题
- 删除 `publish()` 成功后的前端本地回显，消息面板只展示真实订阅流收到的消息
- 修复 PubSub WebSocket 断开/重连时旧 socket 仍可能回写消息的竞态

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）


## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

手动验证：
1. 订阅 Redis 频道后发送消息，消息面板仅显示一条
2. 断开订阅连接后发送消息，消息面板不再新增显示

## 关联 Issue

Close #2587
