### PR TITLE
fix(mongo): support ISODate() and new Date() in MongoDB queries

### DIFF
--- a/apps/desktop/src/lib/mongo/mongoShellCommand.ts
+++ b/apps/desktop/src/lib/mongo/mongoShellCommand.ts
@@ -618,7 +618,14 @@ function parseCollectionMethodTarget(source: string, method: string): { collecti
 function normalizeJsonArgument(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) return "{}";
-  const preprocessed = quoteUnquotedObjectKeys(convertSingleQuotedStrings(trimmed.replace(/ObjectId\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$oid":"$1"}')));
+  // Rewrite mongo shell constructors that are not valid JSON into the extended
+  // JSON the backend understands (mongo_driver::json_value_to_bson): ObjectId(x)
+  // -> {"$oid":x} and ISODate(x)/new Date(x) -> {"$date":x}. Without this a
+  // filter such as { createdAt: { $gte: ISODate("...") } } fails JSON.parse,
+  // the command is left unrecognized and falls through to the SQL executor,
+  // which rejects it with "Use MongoDB-specific commands".
+  const withExtendedJson = trimmed.replace(/ObjectId\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$oid":"$1"}').replace(/(?:ISODate|new\s+Date)\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$date":"$1"}');
+  const preprocessed = quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson));
   try {
     JSON.parse(preprocessed);
     return preprocessed;

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -1144,6 +1144,13 @@ fn json_filter_value_to_bson(value: &serde_json::Value, field_name: Option<&str>
                         return Bson::ObjectId(oid);
                     }
                 }
+                // Extended JSON dates must be decoded in filters too, otherwise
+                // {"$date": ...} reaches the server as a raw document: a bare
+                // { field: {"$date": ...} } fails with "unknown operator: $date"
+                // and { field: {"$gte": {"$date": ...}} } silently matches nothing.
+                if let Some(date) = parse_extended_json_date(obj) {
+                    return Bson::DateTime(date);
+                }
             }
 
             if field_name == Some("_id") && obj.keys().all(|key| key.starts_with('$')) {
@@ -1325,6 +1332,27 @@ mod tests {
         let doc = json_filter_to_document(&filter).unwrap();
 
         assert!(matches!(doc.get("owner_id"), Some(Bson::String(value)) if value == id));
+    }
+
+    #[test]
+    fn json_filter_to_document_decodes_extended_json_dates() {
+        let iso = "2025-02-25T04:57:39.965Z";
+        let expected = DateTime::parse_rfc3339_str(iso).unwrap();
+
+        // Direct equality must yield a BSON DateTime, not a raw { "$date": ... }
+        // document that the server rejects with "unknown operator: $date".
+        let filter = serde_json::json!({ "createdAt": { "$date": iso } });
+        let doc = json_filter_to_document(&filter).unwrap();
+        assert_eq!(doc.get("createdAt"), Some(&Bson::DateTime(expected)));
+
+        // Range operands must be decoded too, otherwise $gte compares against a
+        // sub-document and silently matches nothing.
+        let range = serde_json::json!({ "createdAt": { "$gte": { "$date": iso } } });
+        let range_doc = json_filter_to_document(&range).unwrap();
+        let Some(Bson::Document(op)) = range_doc.get("createdAt") else {
+            panic!("expected operator document");
+        };
+        assert_eq!(op.get("$gte"), Some(&Bson::DateTime(expected)));
     }
 
     #[test]

--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -65,6 +65,23 @@ test("parseMongoFindCommand accepts Compass-style unquoted keys and ObjectId", (
   assert.deepEqual(JSON.parse(command.filter), { _id: { $oid: "6a045a92d2971e44243771a1" } });
 });
 
+test("parseMongoFindCommand rewrites ISODate into extended JSON $date", () => {
+  const command = parseMongoFindCommand(`db.trainingdocuments.find({
+    createdAt: { $gte: ISODate("2025-02-25T04:57:39.965Z") }
+  })`);
+  assert.ok(command);
+  assert.equal(command.collection, "trainingdocuments");
+  assert.deepEqual(JSON.parse(command.filter), { createdAt: { $gte: { $date: "2025-02-25T04:57:39.965Z" } } });
+});
+
+test("parseMongoFindCommand rewrites new Date and single-quoted ISODate", () => {
+  const command = parseMongoFindCommand("db.events.find({ at: { $lt: new Date('2025-01-01T00:00:00Z'), $gte: ISODate('2024-01-01T00:00:00Z') } })");
+  assert.ok(command);
+  assert.deepEqual(JSON.parse(command.filter), {
+    at: { $lt: { $date: "2025-01-01T00:00:00Z" }, $gte: { $date: "2024-01-01T00:00:00Z" } },
+  });
+});
+
 test("parseMongoFindCommand accepts single-quoted string values and unquoted sort keys", () => {
   const command = parseMongoFindCommand("db.products.find({category: 'Electronics'}).sort({price: -1}).limit(2)");
   assert.ok(command);


### PR DESCRIPTION
## Problem

MongoDB shell queries using `ISODate(...)` (or `new Date(...)`) in the filter fail. Depending on position:

```js
// 1) Rejected outright
db.trainingdocuments.find({ createdAt: ISODate("2025-02-25T04:57:39.965Z") })
//    -> Query Error — Use MongoDB-specific commands   (before this PR)
//    -> unknown operator: $date                        (frontend-only fix)

// 2) Silently returns nothing
db.trainingdocuments.find({ createdAt: { $gte: ISODate("2025-02-25T04:57:39.965Z") } })
```

## Root cause (two layers)

**Frontend parser** — MongoDB queries are parsed by `apps/desktop/src/lib/mongo/mongoShellCommand.ts` before dispatch; when it fails, the query falls through to the generic SQL executor, which rejects it for MongoDB connections (`crates/dbx-core/src/query.rs`, `"Use MongoDB-specific commands"`). `normalizeJsonArgument()` only rewrote `ObjectId(...)` into extended JSON, so a bare `ISODate("...")` was invalid JSON, `JSON.parse` threw, and the command was treated as unrecognized.

**Backend filter conversion** — even once `{"$date":...}` reaches the backend, the *filter* path (`json_filter_value_to_bson`) only decoded `{"$oid":...}`, not `{"$date":...}` — unlike `json_value_to_bson` (used for inserts/aggregate/sort, which already handles `$date`). So `{"$date":...}` reached the server verbatim: as a top-level field value it became the invalid query operator `$date`, and inside `$gte` it compared against a raw sub-document and matched nothing.

## Fix

1. `normalizeJsonArgument()` also rewrites `ISODate(x)` / `new Date(x)` → `{"$date":x}`, mirroring the existing `ObjectId(x)` → `{"$oid":x}` rewrite.
2. `json_filter_value_to_bson` decodes `{"$date":...}` extended JSON into a BSON `DateTime`, mirroring `json_value_to_bson`. This fixes both direct equality and range operators, and also benefits anyone typing `{"$date":...}` directly.

## Testing

- Frontend: 2 tests in `packages/app-tests/mongoShellCommand.test.ts` (`ISODate` filter, `new Date` + single-quoted). `vitest run` → all pass. `pnpm typecheck` passes.
- Backend: `json_filter_to_document_decodes_extended_json_dates` in `crates/dbx-core/src/db/mongo_driver.rs` covers direct equality and `$gte`. `cargo test -p dbx-core` passes.
- Built the desktop app and confirmed the reported queries (`ISODate` equality and `$gte`) now return correct results.

Existing `ObjectId(...)` and plain-filter parsing are unchanged (covered by existing tests).