### PR TITLE
fix: allow default database for tree-schema databases

### DIFF
--- a/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
@@ -58,4 +58,16 @@ describe("requiresDatabaseSelection", () => {
   it("still requires a database for ordinary MySQL queries", () => {
     expect(requiresDatabaseSelection(queryTab(), connection("mysql"), "SELECT * FROM users")).toBe(true);
   });
+
+  it("allows HANA with default database (empty string) to execute queries", () => {
+    expect(requiresDatabaseSelection(queryTab(""), connection("saphana"), "SELECT * FROM MOMX_MES.Z_SHIPMENT_INFORMATION")).toBe(false);
+  });
+
+  it("allows JDBC with default database (empty string) to execute queries", () => {
+    expect(requiresDatabaseSelection(queryTab(""), connection("jdbc"), "SELECT * FROM users")).toBe(false);
+  });
+
+  it("allows PostgreSQL with default database (empty string) to execute queries", () => {
+    expect(requiresDatabaseSelection(queryTab(""), connection("postgres"), "SELECT * FROM public.users")).toBe(false);
+  });
 });

--- a/apps/desktop/src/composables/useSqlExecution.ts
+++ b/apps/desktop/src/composables/useSqlExecution.ts
@@ -5,7 +5,7 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useToast } from "@/composables/useToast";
-import { isSingleDatabase } from "@/lib/database/databaseCapabilities";
+import { isSingleDatabase, usesTreeSchemaMode } from "@/lib/database/databaseCapabilities";
 import { canExecuteWithoutSelectedDatabase } from "@/lib/connection/connectionLevelDatabaseBootstrap";
 import { classifySqlActivityKind } from "@/lib/history/historyActivityKind";
 import { sqlMetadataRefreshTarget } from "@/lib/sql/sqlMetadataRefresh";
@@ -229,7 +229,9 @@ function supportsSqlTemplateParameters(connection: ConnectionConfig | undefined)
 
 export function requiresDatabaseSelection(tab: QueryTab, connection: ConnectionConfig | undefined, sql = ""): boolean {
   if (tab.mode !== "query") return false;
-  if (!connection || tab.database) return false;
+  if (!connection) return false;
+  if (tab.database) return false;
+  if (tab.database === "" && usesTreeSchemaMode(connection.db_type)) return false;
   if (isSingleDatabase(connection.db_type)) return false;
   if (canExecuteWithoutSelectedDatabase(connection, sql)) return false;
   return !["elasticsearch", "qdrant", "milvus", "weaviate", "chromadb", "zookeeper"].includes(connection.db_type);


### PR DESCRIPTION
TREE_SCHEMA mode databases (saphana, jdbc, postgres, etc.) use an empty string to represent the default database selection. The previous check treated empty string as no database selected and incorrectly blocked query execution.

## Reproduction

1. Connect to SAP HANA (or any tree-schema database via JDBC, e.g., Megajay)
2. Select "Default" in the database dropdown
3. Execute any query: `SELECT * FROM MOMX_MES.Z_SHIPMENT_INFORMATION`
4. Error: **"请先选择数据库 / Select a database first"**


