### PR TITLE
fix(mongodb): remove duplicate refresh button in document browser

### DIFF
--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -2,7 +2,7 @@
 import { computed, ref, onMounted, onBeforeUnmount } from "vue";
 import { uuid } from "@/lib/common/utils";
 import { useI18n } from "vue-i18n";
-import { RefreshCw, RefreshCcw, Loader2, Trash2, Plus, Save, ChevronLeft, ChevronRight, Table2, Braces, X, Columns3, Check, Search, Wrench, Filter } from "@lucide/vue";
+import { RefreshCw, Trash2, Plus, Save, ChevronLeft, ChevronRight, Table2, Braces, X, Columns3, Check, Search, Wrench, Filter } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -1123,13 +1123,6 @@ function resetTableSearchSplitWidth() {
               <X class="w-3 h-3" />
             </button>
           </div>
-        </div>
-        <div class="flex shrink-0 items-center gap-1 border-l px-1">
-          <Button variant="ghost" size="sm" class="h-5 shrink-0 gap-1 px-1.5 text-xs" :disabled="loading" @click="load">
-            <Loader2 v-if="loading" class="h-3 w-3 animate-spin" />
-            <RefreshCcw v-else class="h-3 w-3" />
-            {{ t("grid.refresh") }}
-          </Button>
         </div>
       </template>
     </DataGrid>

--- a/packages/app-tests/documentBrowser.test.ts
+++ b/packages/app-tests/documentBrowser.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+
+function searchBarSlotSource(): string {
+  const source = readFileSync(path.resolve("apps/desktop/src/components/document/DocumentBrowser.vue"), "utf8");
+  const start = source.indexOf('<template #search-bar');
+  const end = source.indexOf("\n    </DataGrid>", start);
+  assert.notEqual(start, -1, "expected DocumentBrowser search-bar slot");
+  assert.notEqual(end, -1, "expected DocumentBrowser DataGrid closing tag");
+  return source.slice(start, end);
+}
+
+test("mongo document result search bar does not render a duplicate refresh button", () => {
+  const slot = searchBarSlotSource();
+  assert.equal(slot.includes('{{ t("grid.refresh") }}'), false);
+  assert.equal(slot.includes("RefreshCcw"), false);
+});


### PR DESCRIPTION
## 变更说明

移除 Mongo 文档结果页重复显示的刷新按钮，避免同一视图里出现两个语义相同的刷新入口，简化操作区交互。
同时补充对应回归测试，确保页面只渲染一个刷新按钮。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）
<img width="2134" height="103" alt="image" src="https://github.com/user-attachments/assets/1ab57e81-91cd-4249-a01d-5b88180f9410" />

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：
- `pnpm vitest run packages/app-tests/documentBrowser.test.ts`
- `pnpm typecheck`

手动验证：
1. 打开 Mongo 文档浏览页
2. 检查结果工具栏中仅保留一个刷新按钮
3. 点击刷新按钮，确认文档列表可以正常刷新

## 关联 Issue

Close #2671