### PR TITLE
fix(milvus): list all databases and their collections in sidebar

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -230,7 +230,9 @@ function increaseTableFontSize() {
 const activeTabDimension = computed(() => {
   const tab = props.activeTab;
   if (!tab.connectionId || tab.mode !== "vector") return undefined;
-  const nodeId = `${tab.connectionId}:__vector_collection:${tab.sql}`;
+  const isMilvus = connectionStore.getConfig(tab.connectionId)?.db_type === "milvus";
+  const suffix = isMilvus && tab.database ? `${tab.database}:${tab.sql}` : tab.sql;
+  const nodeId = `${tab.connectionId}:__vector_collection:${suffix}`;
   const meta = findNodeInTree(connectionStore.treeNodes, nodeId)?.meta;
   return meta && "dimension" in meta ? (meta as VectorCollectionMeta).dimension : undefined;
 });

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -580,7 +580,9 @@ async function toggle() {
         await connectionStore.loadMongoDatabases(node.connectionId);
       } else if (config?.db_type === "elasticsearch") {
         await connectionStore.loadElasticsearchIndices(node.connectionId);
-      } else if (config?.db_type === "qdrant" || config?.db_type === "milvus" || config?.db_type === "weaviate" || config?.db_type === "chromadb") {
+      } else if (config?.db_type === "milvus") {
+        await connectionStore.loadMilvusDatabases(node.connectionId);
+      } else if (config?.db_type === "qdrant" || config?.db_type === "weaviate" || config?.db_type === "chromadb") {
         await connectionStore.loadVectorCollections(node.connectionId);
       } else if (config?.db_type === "mq") {
         await connectionStore.loadMqTenants(node.connectionId);
@@ -614,6 +616,8 @@ async function toggle() {
       queryStore.openUserAdmin(node.connectionId);
     } else if (node.type === "mongo-db" && node.connectionId && node.database) {
       await connectionStore.loadMongoCollections(node.connectionId, node.database);
+    } else if (node.type === "vector-database" && node.connectionId && node.database) {
+      await connectionStore.loadVectorCollections(node.connectionId, node.database);
     } else if (node.type === "mongo-collection" && node.connectionId && node.database) {
       await connectionStore.loadTableGroups(node.connectionId, node.database, node.label, node.schema, node.id);
     } else if (node.type === "elasticsearch-index" && node.connectionId) {
@@ -622,7 +626,7 @@ async function toggle() {
       queryStore.updateSql(tab, node.label);
     } else if (node.type === "vector-collection" && node.connectionId) {
       await connectionStore.ensureConnected(node.connectionId);
-      const collectionRef = node.id.includes("__vector_collection:") ? node.id.split("__vector_collection:").pop() || node.label : node.label;
+      const collectionRef = (node.meta as { collectionId?: string } | undefined)?.collectionId ?? node.label;
       const tab = queryStore.createTab(node.connectionId, node.database || "default", node.label, "vector");
       queryStore.updateSql(tab, collectionRef);
       api

--- a/apps/desktop/src/lib/sidebar/sidebarActiveTabTarget.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarActiveTabTarget.ts
@@ -23,6 +23,7 @@ export type ActiveTabSidebarTarget =
   | {
       type: "vector-collection";
       connectionId: string;
+      database: string;
       collectionName: string;
     }
   | {
@@ -102,6 +103,7 @@ export function activeTabSidebarTarget(tab: QueryTab | undefined | null): Active
     return {
       type: "vector-collection",
       connectionId: tab.connectionId,
+      database: tab.database,
       collectionName,
     };
   }
@@ -157,7 +159,7 @@ export function matchesTarget(node: TreeNode, target: ActiveTabSidebarTarget): b
   }
 
   if (target.type === "vector-collection") {
-    return node.type === "vector-collection" && node.connectionId === target.connectionId && node.label === target.collectionName;
+    return node.type === "vector-collection" && node.connectionId === target.connectionId && node.database === target.database && node.label === target.collectionName;
   }
 
   if (target.type === "query-context") {

--- a/apps/desktop/src/lib/sidebar/sidebarDatabaseOpenState.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarDatabaseOpenState.ts
@@ -1,7 +1,7 @@
 import type { TreeNode } from "@/types/database";
 
 export function isSidebarDatabaseOpened(node: TreeNode, isTreeNodeChildrenLoaded: (nodeId: string) => boolean): boolean {
-  return (node.type === "database" || node.type === "mongo-db") && !!node.connectionId && node.database != null && isTreeNodeChildrenLoaded(node.id);
+  return (node.type === "database" || node.type === "mongo-db" || node.type === "vector-database") && !!node.connectionId && node.database != null && isTreeNodeChildrenLoaded(node.id);
 }
 
 export function canCloseSidebarDatabaseConnection(node: TreeNode, isTreeNodeChildrenLoaded: (nodeId: string) => boolean): boolean {

--- a/apps/desktop/src/lib/sidebar/sidebarNodeOrdering.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarNodeOrdering.ts
@@ -26,6 +26,10 @@ export function sortSidebarTreeChildrenForParent(parent: Pick<TreeNode, "type">,
     return [...gridFsNodes, ...sortByLabel(collections)];
   }
 
+  if (parent.type === "vector-database") {
+    return sortByLabel(normalized);
+  }
+
   if (parent.type === "mongo-buckets") {
     return sortByLabel(normalized);
   }

--- a/apps/desktop/src/lib/sidebar/treeNodeIcon.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeIcon.ts
@@ -15,6 +15,8 @@ export function getTreeNodeIconInfo(node: TreeNode): TreeNodeIconInfo | null {
     case "database":
     case "mongo-db":
       return { icon: Database, colorClass: "text-yellow-500" };
+    case "vector-database":
+      return { icon: Database, colorClass: "text-cyan-500" };
     case "linked-server-root":
       return { icon: Network, colorClass: "text-blue-500" };
     case "linked-server":

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { uuid } from "@/lib/common/utils";
 import { ref, computed, watch } from "vue";
-import type { ColumnInfo, CompletionAssistantCandidate, CompletionAssistantObjectKind, CompletionAssistantRequest, ConnectionConfig, ForeignKeyInfo, ObjectInfo, SchemaInfo, SidebarLayout, TableInfo, TreeNode } from "@/types/database";
+import type { ColumnInfo, CompletionAssistantCandidate, CompletionAssistantObjectKind, CompletionAssistantRequest, ConnectionConfig, ForeignKeyInfo, ObjectInfo, SchemaInfo, SidebarLayout, TableInfo, TreeNode, VectorCollectionMeta } from "@/types/database";
 import { applyPinnedTreeNodeState, updatePinnedTreeNodeInPlace } from "@/lib/app/pinnedItems";
 import {
   reconcileLayout,
@@ -1683,7 +1683,9 @@ export const useConnectionStore = defineStore("connection", () => {
       await loadMongoDatabases(connectionId);
     } else if (config.db_type === "elasticsearch") {
       await loadElasticsearchIndices(connectionId);
-    } else if (config.db_type === "qdrant" || config.db_type === "milvus" || config.db_type === "weaviate" || config.db_type === "chromadb") {
+    } else if (config.db_type === "milvus") {
+      await loadMilvusDatabases(connectionId);
+    } else if (config.db_type === "qdrant" || config.db_type === "weaviate" || config.db_type === "chromadb") {
       await loadVectorCollections(connectionId);
     } else if (config.db_type === "mq") {
       await loadMqTenants(connectionId, { force: true });
@@ -2305,33 +2307,63 @@ export const useConnectionStore = defineStore("connection", () => {
     }
   }
 
-  async function loadVectorCollections(connectionId: string) {
+  async function loadMilvusDatabases(connectionId: string) {
     const node = findNode(treeNodes.value, connectionId);
     if (!node) return;
 
-    const config = getConfig(connectionId);
-    const database = config?.database || "default";
     node.isLoading = true;
     try {
       await ensureConnected(connectionId);
-      const collections = await withMetadataLoadTimeout(connectionId, api.vectorListCollections(connectionId, database), "vector collections");
-      const sorted = [...collections].sort((a, b) => a.name.localeCompare(b.name));
+      const dbs = await withMetadataLoadTimeout(connectionId, api.documentListDatabases(connectionId), "Milvus databases");
       setChildren(
         node,
         withSavedSqlRoot(
           connectionId,
-          sorted.map((info) => ({
-            id: `${connectionId}:__vector_collection:${info.id}`,
-            label: info.name,
-            type: "vector-collection" as const,
+          sortSidebarNames(dbs).map((db) => ({
+            id: `${connectionId}:${db}`,
+            label: db,
+            type: "vector-database" as const,
             connectionId,
-            database,
+            database: db,
             isExpanded: false,
-            meta: info.dimension != null ? { dimension: info.dimension } : undefined,
+            children: [],
           })),
           node,
         ),
       );
+      node.isExpanded = true;
+    } catch (e) {
+      recordMetadataLoadError(connectionId, e);
+      throw e;
+    } finally {
+      node.isLoading = false;
+    }
+  }
+
+  async function loadVectorCollections(connectionId: string, database?: string) {
+    const config = getConfig(connectionId);
+    const isMilvus = config?.db_type === "milvus";
+    const effectiveDb = database || config?.database || "default";
+    // Milvus groups collections under a per-database node; other vector stores stay flat under the connection.
+    const node = isMilvus && database ? findNode(treeNodes.value, `${connectionId}:${database}`) : findNode(treeNodes.value, connectionId);
+    if (!node) return;
+
+    node.isLoading = true;
+    try {
+      await ensureConnected(connectionId);
+      const collections = await withMetadataLoadTimeout(connectionId, api.vectorListCollections(connectionId, effectiveDb), "vector collections");
+      const sorted = [...collections].sort((a, b) => a.name.localeCompare(b.name));
+      const collectionChildren = sorted.map((info) => ({
+        // Include the database for Milvus so same-named collections across databases don't collide.
+        id: `${connectionId}:__vector_collection:${isMilvus ? `${effectiveDb}:${info.id}` : info.id}`,
+        label: info.name,
+        type: "vector-collection" as const,
+        connectionId,
+        database: effectiveDb,
+        isExpanded: false,
+        meta: { dimension: info.dimension, collectionId: info.id } as VectorCollectionMeta,
+      }));
+      setChildren(node, isMilvus && database ? collectionChildren : withSavedSqlRoot(connectionId, collectionChildren, node));
       node.isExpanded = true;
     } catch (e) {
       recordMetadataLoadError(connectionId, e);
@@ -3343,7 +3375,9 @@ export const useConnectionStore = defineStore("connection", () => {
         await loadMongoDatabases(node.connectionId);
       } else if (config?.db_type === "elasticsearch") {
         await loadElasticsearchIndices(node.connectionId);
-      } else if (config?.db_type === "qdrant" || config?.db_type === "milvus" || config?.db_type === "weaviate" || config?.db_type === "chromadb") {
+      } else if (config?.db_type === "milvus") {
+        await loadMilvusDatabases(node.connectionId);
+      } else if (config?.db_type === "qdrant" || config?.db_type === "weaviate" || config?.db_type === "chromadb") {
         await loadVectorCollections(node.connectionId);
       } else if (config?.db_type === "mq") {
         await loadMqTenants(node.connectionId, options);
@@ -3354,6 +3388,8 @@ export const useConnectionStore = defineStore("connection", () => {
       }
     } else if (node.type === "mongo-db" && node.connectionId && node.database) {
       await loadMongoCollections(node.connectionId, node.database);
+    } else if (node.type === "vector-database" && node.connectionId && node.database) {
+      await loadVectorCollections(node.connectionId, node.database);
     } else if (node.type === "mongo-collection" && node.connectionId && node.database) {
       await loadTableGroups(node.connectionId, node.database, node.label, node.schema, node.id);
     } else if (node.type === "mongo-gridfs") {
@@ -4716,6 +4752,7 @@ export const useConnectionStore = defineStore("connection", () => {
     loadNacosNamespaces,
     updateRedisDbKeyStats,
     loadMongoDatabases,
+    loadMilvusDatabases,
     loadElasticsearchIndices,
     loadVectorCollections,
     loadMongoCollections,

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -556,6 +556,7 @@ export type TreeNodeType =
   | "mongo-buckets"
   | "mongo-bucket"
   | "mongo-collection"
+  | "vector-database"
   | "vector-collection"
   | "elasticsearch-index";
 
@@ -780,6 +781,7 @@ export interface SavedSqlLibrary {
 
 export interface VectorCollectionMeta {
   dimension?: number;
+  collectionId?: string;
 }
 
 export interface CollectionInfo {

--- a/crates/dbx-core/src/db/vector_driver.rs
+++ b/crates/dbx-core/src/db/vector_driver.rs
@@ -171,6 +171,40 @@ pub(crate) async fn list_collections_with_db(
     }
 }
 
+/// List databases for a vector connection.
+/// Milvus supports multiple databases; other vector stores expose a single "default" namespace.
+pub async fn list_databases(client: &VectorClient) -> Result<Vec<String>, String> {
+    match client.kind {
+        VectorDbKind::Milvus => list_milvus_databases(client).await,
+        _ => Ok(vec!["default".to_string()]),
+    }
+}
+
+async fn list_milvus_databases(client: &VectorClient) -> Result<Vec<String>, String> {
+    // Older Milvus versions (pre-2.2) do not expose the databases endpoint; fall back to "default"
+    // so the connection stays browsable instead of failing the whole tree load.
+    let body = match send_json(client.post("/v2/vectordb/databases/list"), "Milvus").await {
+        Ok(body) => body,
+        Err(_) => return Ok(vec!["default".to_string()]),
+    };
+    let mut names: Vec<String> = match body.get("data") {
+        Some(Value::Array(items)) => items.iter().filter_map(milvus_database_name_from_item).collect(),
+        _ => Vec::new(),
+    };
+    if !names.iter().any(|name| name == "default") {
+        names.push("default".to_string());
+    }
+    names.sort_by(|a, b| a.cmp(b));
+    Ok(names)
+}
+
+fn milvus_database_name_from_item(item: &Value) -> Option<String> {
+    item.as_str()
+        .map(str::to_string)
+        .or_else(|| item.get("dbName").and_then(Value::as_str).map(str::to_string))
+        .or_else(|| item.get("name").and_then(Value::as_str).map(str::to_string))
+}
+
 async fn list_qdrant_collections(client: &VectorClient) -> Result<Vec<CollectionInfo>, String> {
     let body = send_json(client.get("/collections"), "Qdrant").await?;
     let mut infos: Vec<CollectionInfo> = body
@@ -441,6 +475,7 @@ fn weaviate_collection_names_from_schema(body: &Value) -> Vec<String> {
 
 pub async fn find_documents(
     client: &VectorClient,
+    database: &str,
     collection: &str,
     skip: u64,
     limit: i64,
@@ -498,7 +533,7 @@ pub async fn find_documents(
         VectorDbKind::Milvus => format!(
             "POST /v2/vectordb/entities/query\n{}",
             serde_json::json!({
-                "dbName": "default",
+                "dbName": if database.is_empty() { "default" } else { database },
                 "collectionName": collection,
                 "filter": "",
                 "limit": limit.max(1) as u64,

--- a/crates/dbx-core/src/document_ops.rs
+++ b/crates/dbx-core/src/document_ops.rs
@@ -52,7 +52,8 @@ pub async fn list_databases_core(state: &AppState, connection_id: &str) -> Resul
             }
             Err(error) => Err(error),
         },
-        PoolKind::Elasticsearch(_) | PoolKind::VectorDb(_) => Ok(vec!["default".to_string()]),
+        PoolKind::Elasticsearch(_) => Ok(vec!["default".to_string()]),
+        PoolKind::VectorDb(client) => vector_driver::list_databases(&client).await,
         PoolKind::Agent(client) => {
             let mut client = client.lock().await;
             match client.mongo_list_databases::<Vec<serde_json::Value>>().await {
@@ -376,8 +377,8 @@ pub async fn find_documents_core(
         PoolKind::VectorDb(client) => {
             let client = client.clone();
             drop(connections);
-            let _ = (database, filter, sort);
-            vector_driver::find_documents(&client, collection, skip, limit).await
+            let _ = (filter, sort);
+            vector_driver::find_documents(&client, database, collection, skip, limit).await
         }
         PoolKind::Agent(client) => {
             let mut client = client.lock().await;


### PR DESCRIPTION
## 变更说明

修复 Milvus 连接只展示默认 `default` 库下 collection 的问题，使其能在侧边栏展示所有 database 及各自的 collection。

**根因**：后端对所有向量库都硬编码返回 `["default"]`；前端只按单个库加载 collection 并平铺在连接节点下，未区分多库。

**改动**：
- 后端 `vector_driver`：新增 `list_databases()`，调用 Milvus `POST /v2/vectordb/databases/list`（旧版 Milvus 或非 Milvus 向量库回退到 `default`）；`find_documents()` 增加 `database` 参数，不再硬编码 `"default"`。
- `document_ops`：`list_databases_core` 对 `VectorDb` 委托给 `list_databases()`；`find_documents_core` 透传选中的 database。
- 前端：新增 `vector-database` 树节点类型。Milvus 连接展开为 database 节点，database 节点再展开为各自的 collection；collection 节点 id 按库命名空间化以避免跨库同名冲突，并将 collection id 存入 `meta`，激活时不再解析节点 id。

仅影响 Milvus；Qdrant / Weaviate / ChromaDb / Elasticsearch 行为不变。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
> 待补充：Milvus 连接展开后多 database → 各自 collection 的侧边栏截图（连接前为单层 default collection，连接后为 database 节点展开）。

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过（`cargo check -p dbx-core --no-default-features`）
- [x] 相关测试通过（`cargo test -p dbx-core vector_driver` 9/9；前端相关测试 21/21）
- [x] `cargo fmt --check` 通过
- [x] `pnpm vue-tsc` 类型检查通过（EXIT_CODE=0）
- [x] `pnpm oxlint` 通过（仅存量告警）

> 说明：`make check`（完整 `cargo check`，默认启用 `sqlite-sqlcipher`/vendored openssl）因本机 Git Bash 的 Perl 缺少 `Locale::Maketext::Simple` 模块导致 `openssl-src` 构建失败，属环境问题，与本次改动无关；改动未触及任何 feature-gated 代码，故使用项目文档中的 `cargo-check-fast` 替代验证。

## 关联 Issue

Fixes #2693