### PR TITLE
fix(desktop): clear connection error after successful test

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -1918,6 +1918,7 @@ async function testConnection() {
       mongoDriverMode.value = "legacy";
     }
     testResult.value = { ok: true, message: msg };
+    clearEditedConnectionErrorAfterSuccessfulTest();
   } catch (e: any) {
     if (runId !== testRunId) return;
     const message = connectionErrorWithDriverUpdateHint(config, mongodbAuthFailureHint(String(e)));
@@ -1928,7 +1929,9 @@ async function testConnection() {
       configTab.value = "advanced";
     }
     testResult.value = fallbackMessage ? { ok: true, message: fallbackMessage } : { ok: false, message };
-    if (!fallbackMessage) {
+    if (fallbackMessage) {
+      clearEditedConnectionErrorAfterSuccessfulTest();
+    } else {
       showConnectionError(message);
     }
   } finally {
@@ -1936,6 +1939,10 @@ async function testConnection() {
       isTesting.value = false;
     }
   }
+}
+
+function clearEditedConnectionErrorAfterSuccessfulTest() {
+  if (editingId.value) store.clearConnectionError(editingId.value);
 }
 
 function applyConnectionUrlToForm(input: string): boolean {


### PR DESCRIPTION
## 变更说明

修复 #2591：编辑已有连接并点击「测试连接」成功后，同步清理该连接在侧边栏中的历史连接错误状态。

问题本质是连接失败后错误信息保存在 `connectionStore.connectionErrors` 中，而连接编辑弹窗的「测试连接」成功只更新了弹窗内的测试结果，没有清理同一连接的旧错误状态，导致侧边栏 warning 图标仍然保留。

本 PR 仅在已有连接的测试成功路径清理对应连接错误，不会把连接标记为已连接，也不会影响新建连接草稿测试或其他连接的错误状态。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

无新增 UI，仅修复已有连接测试成功后的侧边栏错误状态同步。已在本地 GUI 按 #2591 复现路径手动验证：错误端口触发 warning 后，编辑连接改回正确端口并测试成功，侧边栏 warning 会立即消失。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm exec oxlint apps/desktop/src/components/connection/ConnectionDialog.vue`
- `pnpm exec oxfmt --check apps/desktop/src/components/connection/ConnectionDialog.vue`
- `pnpm typecheck`
- `pnpm vitest run apps/desktop/src/stores/__tests__/connectionStore.timeout.spec.ts apps/desktop/src/stores/__tests__/connectionStore.mq.spec.ts`
- 本地 GUI 手动验证 #2591 复现路径，确认修复有效。

补充：本地执行 `pnpm check` 时，format/lint/typecheck 通过，但全量 test 被本地 `better-sqlite3` 原生模块 Node ABI 不匹配阻塞：当前二进制为 `NODE_MODULE_VERSION 127`，本机 Node 需要 `NODE_MODULE_VERSION 147`。该失败与本 PR 的 Vue 状态同步改动无关。

## 关联 Issue

Close #2591
