### PR TITLE
fix(grid): 导出 CSV/XLSX 复用本地已查出结果，不再重跑 SQL

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -3278,6 +3278,10 @@ const hasKnownTotalRowCount = computed(() => typeof serverKnownTotalRowCount.val
 // rowCount IS the total. Without this hint, the "page is full → assume more"
 // fallback in canGoNextDataGridPage lets the user keep clicking next forever.
 const allRowsLoaded = computed(() => isResultsContext.value && props.pageLimit === undefined);
+// True when the in-memory result already holds the complete result set (results
+// context, no server-side pagination, not truncated, no further pages). Used to
+// skip re-executing the query on export and instead write the local rows.
+const hasCompleteLocalResult = computed(() => !!props.result && allRowsLoaded.value && props.result.truncated !== true && props.result.has_more !== true);
 const canGoNextPage = computed(() => {
   return canGoNextDataGridPage({
     hasMore: props.result.has_more,
@@ -5827,7 +5831,8 @@ const {
   hasRowSelection,
   fullExportResult: props.fullExportResult,
   queryResultExportRequest: props.queryResultExportRequest,
-  hasCompleteLocalResult: computed(() => !!props.result && allRowsLoaded.value && props.result.truncated !== true && props.result.has_more !== true),
+  hasCompleteLocalResult,
+  completeLocalResult: computed(() => (hasCompleteLocalResult.value ? props.result : undefined)),
   allExportResults: computed(() => props.allExportResults),
   currentResultLabel: computed(() => props.result.sourceLabel),
   exportFileBaseName: computed(() => props.exportFileBaseName),

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5827,6 +5827,7 @@ const {
   hasRowSelection,
   fullExportResult: props.fullExportResult,
   queryResultExportRequest: props.queryResultExportRequest,
+  hasCompleteLocalResult: computed(() => !!props.result && allRowsLoaded.value && props.result.truncated !== true && props.result.has_more !== true),
   allExportResults: computed(() => props.allExportResults),
   currentResultLabel: computed(() => props.result.sourceLabel),
   exportFileBaseName: computed(() => props.exportFileBaseName),

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -60,6 +60,15 @@ export interface UseDataGridExportOptions {
    * slow query is never re-run just to export rows that are already on screen.
    */
   hasCompleteLocalResult?: ComputedRef<boolean>;
+  /**
+   * The raw in-memory QueryResult to use for "export all" when
+   * hasCompleteLocalResult is true. Exports the original query result (all
+   * rows, all columns, committed values) so the output matches the original
+   * re-run-SQL semantics — displayItems only covers visible columns and
+   * reflects client-side filters/search and unsaved edits, which would
+   * silently change what "export all data" produces.
+   */
+  completeLocalResult?: ComputedRef<QueryResult | undefined>;
   allExportResults?: ComputedRef<Array<{ sheetName: string; result: QueryResult }> | undefined>;
   currentResultLabel?: ComputedRef<string | undefined>;
   exportFileBaseName?: ComputedRef<string | undefined>;
@@ -131,6 +140,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     fullExportResult,
     queryResultExportRequest,
     hasCompleteLocalResult,
+    completeLocalResult,
     allExportResults,
     currentResultLabel,
     exportFileBaseName,
@@ -158,6 +168,14 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     if (useFullExport && rowIds === undefined && fullExportResult && !hasCompleteLocalResult?.value) {
       const result = await fullExportResult(onProgress);
       if (result) return { columns: result.columns, rows: result.rows };
+    }
+    // The full result is already in memory — export the raw QueryResult (all
+    // rows, all columns, committed values) so "export all data" matches the
+    // original re-run-SQL semantics. displayItems only covers visible columns
+    // and reflects client-side filters/search and unsaved edits, which would
+    // silently change what the export contains.
+    if (useFullExport && rowIds === undefined && hasCompleteLocalResult?.value && completeLocalResult?.value) {
+      return { columns: completeLocalResult.value.columns, rows: completeLocalResult.value.rows };
     }
     return {
       columns: columns.value,

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -52,6 +52,14 @@ export interface UseDataGridExportOptions {
   hasRowSelection: ComputedRef<boolean>;
   fullExportResult?: (onProgress?: (info: { rowsExported: number; totalRows: number | null }) => void) => Promise<QueryResult | undefined>;
   queryResultExportRequest?: (options: { exportId: string; filePath: string; format: "csv" | "xlsx" }) => Promise<QueryResultExportRequest | undefined>;
+  /**
+   * True when the in-memory result already holds the complete result set —
+   * i.e. the query ran without server-side pagination, was not truncated, and
+   * has no further pages. When true, full-result exports skip the re-executing
+   * backend/frontend streaming paths and write the local rows directly, so a
+   * slow query is never re-run just to export rows that are already on screen.
+   */
+  hasCompleteLocalResult?: ComputedRef<boolean>;
   allExportResults?: ComputedRef<Array<{ sheetName: string; result: QueryResult }> | undefined>;
   currentResultLabel?: ComputedRef<string | undefined>;
   exportFileBaseName?: ComputedRef<string | undefined>;
@@ -122,6 +130,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     hasRowSelection,
     fullExportResult,
     queryResultExportRequest,
+    hasCompleteLocalResult,
     allExportResults,
     currentResultLabel,
     exportFileBaseName,
@@ -146,7 +155,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   }
 
   async function resultToExport(rowIds?: number[], onProgress?: (info: { rowsExported: number; totalRows: number | null }) => void, useFullExport = true): Promise<{ columns: string[]; rows: CellValue[][] }> {
-    if (useFullExport && rowIds === undefined && fullExportResult) {
+    if (useFullExport && rowIds === undefined && fullExportResult && !hasCompleteLocalResult?.value) {
       const result = await fullExportResult(onProgress);
       if (result) return { columns: result.columns, rows: result.rows };
     }
@@ -512,7 +521,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
         if (await exportQueryResultViaBackend("csv", rowIds)) return;
         if (await exportFullTableDataViaBackend("csv", rowIds)) return;
 
-        const needsFullExport = rowIds === undefined && !!fullExportResult;
+        const needsFullExport = rowIds === undefined && !!fullExportResult && !hasCompleteLocalResult?.value;
         if (needsFullExport && exportProgressDialog && exportProgressState) {
           exportProgressState.value = {
             title: t("exportProgress.title"),
@@ -716,7 +725,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
           if (!path) return;
           outputPath = path as string;
         }
-        const needsFullExport = rowIds === undefined && !!fullExportResult;
+        const needsFullExport = rowIds === undefined && !!fullExportResult && !hasCompleteLocalResult?.value;
         if (needsFullExport && exportProgressDialog && exportProgressState) {
           exportProgressState.value = {
             title: t("exportProgress.title"),
@@ -908,6 +917,9 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     if (rowIds !== undefined || context.value !== "results" || !queryResultExportRequest) {
       return false;
     }
+    // The full result is already in memory — don't re-execute the query on the
+    // backend just to stream the same rows back to a file.
+    if (hasCompleteLocalResult?.value) return false;
 
     const extension = format;
     const filterName = format === "csv" ? "CSV" : "Excel";


### PR DESCRIPTION
## 问题

在查询结果页执行\"导出当前结果集全部数据 CSV\"时，会**重新执行一遍 SQL 查询**，而不是复用已经在内存里的结果行。

复现：paimon 跑一条耗时 2min、返回 30 行的 SQL，等结果出来后选中这 30 行导出 CSV，应用会再次向数据库发起同一查询，导致再等 2min，大概率卡死/崩溃。

## 根因

`exportCsv()`（无 rowIds）有两条路径都会重跑 SQL：

1. **后端流式重跑**：`exportQueryResultViaBackend` 把 SQL 打包（`resultSortedSql ?? resultBaseSql ?? lastExecutedSql`，并生成新 `executionId`）发给 Rust 后端 `start_query_result_export` → `export_query_result_core` → `execute_sql_statement_with_options`，对数据库再执行一次，分页流式写文件。
2. **前端分页重跑（兜底）**：`resultToExport(useFullExport=true)` 调 `fullExportResult` = `fetchTabResultForExport`，同样是分页重跑 SQL。

而走本地内存行的路径其实已存在（\"导出当前页 CSV\"、\"导出选取资料列为 CSV\" 用 `displayItems`），只是\"导出全部\"没判断\"本地已完整\"就直接重跑。

## 修复

新增 `hasCompleteLocalResult` 信号：当本地结果已包含全量结果集时（未分页、未截断、无更多页），跳过两条重跑路径，直接用本地 `displayItems` 行写文件。

判断信号复用已有的 `allRowsLoaded`（`pageLimit === undefined`），并叠加 `!result.truncated && !result.has_more`：

- `useDataGridExport.ts`：composable 新增可选入参 `hasCompleteLocalResult`；`exportQueryResultViaBackend` 开头、`resultToExport` 的 `useFullExport` 分支、`exportCsv`/`exportXlsx` 的 `needsFullExport` 共 4 处加守卫。
- `DataGrid.vue`：在 `useDataGridExport({...})` 调用处计算并传入该信号。

## 行为

- **小结果集且未分页**（如 30 行 paimon 查询）：`hasCompleteLocalResult = true` → 0 次重跑，直接本地导出，秒出。
- **大结果集被截断/分页**（`truncated=true` 或 `has_more=true` 或 `pageLimit` 有值）：`hasCompleteLocalResult = false` → 仍走原后端流式导出，行为完全不变，不会导出残缺数据。

信号用三重合取，保守优先：任一不满足即退回原流式路径。

## 验证

- `pnpm typecheck` ✅
- `pnpm lint`（改动文件 0 告警）✅
- 本地 release 构建安装后实测：paimon 2min/30 行查询 → 导出 CSV，不再重跑 SQL，秒出文件 ✅