### PR TITLE
fix(mongodb): honor current command execution mode

### DIFF
--- a/apps/desktop/src/lib/sql/sqlExecutionTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlExecutionTarget.ts
@@ -1,4 +1,5 @@
 import * as api from "@/lib/backend/api";
+import { mongoCommandRangeAtCursor } from "@/lib/sql/sqlStatementRanges";
 import type { DatabaseType } from "@/types/database";
 
 export type ExecuteMode = "all" | "current";
@@ -52,10 +53,12 @@ export async function resolveExecutableSqlWithBackend(fullSql: string, selectedS
   const trimmedSelection = selectedSql.trim();
   if (trimmedSelection) return trimmedSelection;
 
-  // MongoDB uses dedicated per-command gutter actions for "current command";
-  // the main editor execute action keeps its long-standing "run all text"
-  // behavior when nothing is selected.
-  if (options?.databaseType === "mongodb") return fullSql;
+  if (options?.databaseType === "mongodb") {
+    if (options.mode === "current" && options.cursorPos !== undefined) {
+      return mongoCommandRangeAtCursor(fullSql, options.cursorPos)?.sql ?? fullSql;
+    }
+    return fullSql;
+  }
 
   if (options?.mode === "current" && options.cursorPos !== undefined) {
     return await api.findStatementAtCursor(fullSql, options.cursorPos, options.databaseType);

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -401,6 +401,26 @@ export function statementRangeAtCursor(sql: string, cursorPos: number, databaseT
   return null;
 }
 
+export function mongoCommandRangeAtCursor(sql: string, cursorPos: number): SqlTextRange | null {
+  const pos = clampCursor(sql, cursorPos);
+  if (isCursorOnBlankLine(sql, pos)) return null;
+
+  const commands = splitMongoCommandRanges(sql);
+  for (let index = 0; index < commands.length; index += 1) {
+    const command = commands[index];
+    const range = { from: command.from, to: command.to, sql: command.text };
+
+    if (pos >= command.from && pos <= command.to) return range;
+
+    const next = commands[index + 1];
+    if (pos > command.to && (!next || pos < next.from) && isCursorInSameLineDelimiterGap(sql, command.to, pos)) return range;
+
+    if (pos < command.from && sql.slice(pos, command.from).trim() === "" && isCursorOnStatementLine(sql, pos, command)) return range;
+  }
+
+  return null;
+}
+
 function isCursorInSameLineDelimiterGap(sql: string, previousStatementEnd: number, cursorPos: number): boolean {
   if (cursorPos <= previousStatementEnd) return false;
   const between = sql.slice(previousStatementEnd, cursorPos);
@@ -1433,7 +1453,7 @@ function isCursorOnBlankLine(sql: string, pos: number): boolean {
   return sql.slice(lineStart, lineEnd).trim() === "";
 }
 
-function isCursorOnStatementLine(sql: string, pos: number, statement: RawStatement): boolean {
+function isCursorOnStatementLine(sql: string, pos: number, statement: Pick<RawStatement, "from">): boolean {
   const lineStart = sql.lastIndexOf("\n", pos - 1) + 1;
   let lineEnd = sql.indexOf("\n", pos);
   if (lineEnd === -1) lineEnd = sql.length;

--- a/packages/app-tests/sqlExecutionTarget.test.ts
+++ b/packages/app-tests/sqlExecutionTarget.test.ts
@@ -13,17 +13,42 @@ beforeEach(() => {
   apiMock.findStatementAtCursor.mockReset();
 });
 
-test("mongodb backend resolution keeps the full text when nothing is selected", async () => {
+test("mongodb backend resolution uses the current command when configured", async () => {
   apiMock.findStatementAtCursor.mockResolvedValue("db.users.insertOne({ name: 'ignored' })");
 
-  const fullSql = "db.users.insertOne({ name: 'Ada' });\ndb.users.insertOne({ name: 'Grace' });";
+  const fullSql = 'db.users.find({ name: "Ada" });\ndb.users.find({ name: "Grace" });\ndb.users.find({ name: "Linus" });';
   const resolved = await resolveExecutableSqlWithBackend(fullSql, "", {
     mode: "current",
     cursorPos: fullSql.indexOf("Grace"),
     databaseType: "mongodb",
   });
 
+  assert.equal(resolved, 'db.users.find({ name: "Grace" })');
+  assert.equal(apiMock.findStatementAtCursor.mock.calls.length, 0);
+});
+
+test("mongodb backend resolution keeps the full text in all mode", async () => {
+  const fullSql = 'db.users.find({ name: "Ada" });\ndb.users.find({ name: "Grace" });';
+  const resolved = await resolveExecutableSqlWithBackend(fullSql, "", {
+    mode: "all",
+    cursorPos: fullSql.indexOf("Grace"),
+    databaseType: "mongodb",
+  });
+
   assert.equal(resolved, fullSql);
+  assert.equal(apiMock.findStatementAtCursor.mock.calls.length, 0);
+});
+
+test("mongodb backend resolution prefers the manual selection", async () => {
+  const fullSql = 'db.users.find({ name: "Ada" });\ndb.users.find({ name: "Grace" });';
+  const selectedSql = 'db.users.find({ name: "Ada" })';
+  const resolved = await resolveExecutableSqlWithBackend(fullSql, selectedSql, {
+    mode: "current",
+    cursorPos: fullSql.indexOf("Grace"),
+    databaseType: "mongodb",
+  });
+
+  assert.equal(resolved, selectedSql);
   assert.equal(apiMock.findStatementAtCursor.mock.calls.length, 0);
 });
 


### PR DESCRIPTION
## 变更说明

修复 MongoDB 查询编辑器在执行模式配置为“执行光标所在语句”时，主执行按钮仍然执行全文的问题。

- MongoDB current 模式下复用现有 `splitMongoCommandRanges` 结果定位光标所在命令。
- 保留手动选区优先执行的行为。
- 保留 `执行全部 SQL` 模式继续执行全文的行为。
- 更新 `sqlExecutionTarget` 回归测试，覆盖 MongoDB current/all/selection 三条路径。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

本 PR 不涉及视觉 UI 改动；行为变化可通过 MongoDB 查询编辑器执行摘要验证。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm vitest run packages/app-tests/sqlExecutionTarget.test.ts`
- `pnpm vitest run apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts`
- `pnpm exec oxlint apps/desktop/src/lib/sql/sqlExecutionTarget.ts apps/desktop/src/lib/sql/sqlStatementRanges.ts packages/app-tests/sqlExecutionTarget.test.ts`
- `pnpm exec oxfmt --check apps/desktop/src/lib/sql/sqlExecutionTarget.ts apps/desktop/src/lib/sql/sqlStatementRanges.ts packages/app-tests/sqlExecutionTarget.test.ts`
- `pnpm typecheck`

补充：本地执行 `pnpm check` 时，format/lint/typecheck 均通过，但 test 阶段已有的 `better-sqlite3` native ABI 不匹配导致 node-core SQLite 相关测试失败（`NODE_MODULE_VERSION 127` vs 当前 Node `147`），与本 PR 的 MongoDB 执行范围变更无关。

手动验证：

- 启动 MongoDB 3.4 测试容器。
- 在 DBX Desktop 中将执行模式设置为“执行光标所在语句”。
- 在 MongoDB 查询编辑器中输入多条 `db.users.find(...)` 命令。
- 光标放在第二条命令并点击主执行按钮。
- 修复后执行摘要只出现 1 条执行记录，不再执行全文中的所有命令。

## 关联 Issue

Close #2613
