### PR TITLE
fix(milvus): send empty JSON body to databases/list endpoint

### DIFF
--- a/crates/dbx-core/src/db/vector_driver.rs
+++ b/crates/dbx-core/src/db/vector_driver.rs
@@ -183,7 +183,11 @@ pub async fn list_databases(client: &VectorClient) -> Result<Vec<String>, String
 async fn list_milvus_databases(client: &VectorClient) -> Result<Vec<String>, String> {
     // Older Milvus versions (pre-2.2) do not expose the databases endpoint; fall back to "default"
     // so the connection stays browsable instead of failing the whole tree load.
-    let body = match send_json(client.post("/v2/vectordb/databases/list"), "Milvus").await {
+    //
+    // The endpoint rejects a bodyless POST with `{"code":1801,...}` (HTTP 200, no `data` field),
+    // so send an empty JSON object like every other Milvus v2 endpoint.
+    let body = match send_json(client.post("/v2/vectordb/databases/list").json(&serde_json::json!({})), "Milvus").await
+    {
         Ok(body) => body,
         Err(_) => return Ok(vec!["default".to_string()]),
     };


### PR DESCRIPTION
## Summary

Follow-up to #2698.

`list_milvus_databases()` called `/v2/vectordb/databases/list` with no request body. This is accepted by the Milvus demo cluster used during testing, but production Milvus rejects a bodyless POST: it returns HTTP 200 with `{"code":1801,...}` and omits the `data` field. Because the success check only inspects the HTTP status, the function parsed zero names and silently fell back to `["default"]`, hiding every non-default database in the sidebar.

## Fix

Send an empty JSON object `{}` as the body, matching every other Milvus v2 endpoint. With the body, the endpoint returns code 0 and the full database list on both demo and production clusters.

## Verification

- Confirmed against a production Milvus cluster: bodyless POST → `{"code":1801,...}` (no `data`); `{}` body → code 0 with the full database list.
- Runtime-checked in both the Tauri desktop and web builds: non-default databases now appear in the sidebar.

Ref #2693
