### PR TITLE
Fix：避免达梦表结构导出被截断

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -19,6 +19,7 @@ import com.dbx.agent.QueryResult;
 import com.dbx.agent.TableInfo;
 import com.dbx.agent.TriggerInfo;
 import java.io.PrintStream;
+import java.io.Reader;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -593,7 +594,7 @@ public final class DamengAgent extends BaseDatabaseAgent {
                 stmt.setString(2, name);
                 stmt.setString(3, schema);
                 try (ResultSet rs = stmt.executeQuery()) {
-                    source = rs.next() ? coalesce(rs.getString(1)) : "";
+                    source = rs.next() ? coalesce(readTextColumn(rs, 1)) : "";
                 }
             }
             return new ObjectSource(name, objectType, schema, source);
@@ -610,7 +611,7 @@ public final class DamengAgent extends BaseDatabaseAgent {
                 stmt.setString(3, schema);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
-                        String ddl = appendTableAndColumnComments(coalesce(rs.getString(1)), schema, table);
+                        String ddl = appendTableAndColumnComments(coalesce(readTextColumn(rs, 1)), schema, table);
                         return appendIndependentIndexDdl(ddl, schema, table);
                     }
                 }
@@ -913,6 +914,24 @@ public final class DamengAgent extends BaseDatabaseAgent {
         return value == null ? null : unchecked(value::getString);
     }
 
+    private static String readTextColumn(ResultSet rs, int columnIndex) throws Exception {
+        try (Reader reader = rs.getCharacterStream(columnIndex)) {
+            String value = readAll(reader);
+            if (value != null) {
+                return value;
+            }
+        } catch (Exception ignored) {
+        }
+        try {
+            Clob clob = rs.getClob(columnIndex);
+            if (clob != null) {
+                return clob.getSubString(1, Math.toIntExact(clob.length()));
+            }
+        } catch (Exception ignored) {
+        }
+        return rs.getString(columnIndex);
+    }
+
     private static String bytesToHex(byte[] bytes) {
         if (bytes == null) {
             return null;
@@ -965,18 +984,22 @@ public final class DamengAgent extends BaseDatabaseAgent {
             }
         } catch (Exception ignored) {
         }
-        try (java.io.Reader reader = rs.getCharacterStream(column)) {
-            if (reader == null) {
-                return null;
-            }
-            StringBuilder sb = new StringBuilder();
-            char[] buf = new char[4096];
-            int n;
-            while ((n = reader.read(buf)) != -1) {
-                sb.append(buf, 0, n);
-            }
-            return sb.toString();
+        try (Reader reader = rs.getCharacterStream(column)) {
+            return readAll(reader);
         }
+    }
+
+    private static String readAll(Reader reader) throws Exception {
+        if (reader == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        char[] buf = new char[4096];
+        int n;
+        while ((n = reader.read(buf)) != -1) {
+            sb.append(buf, 0, n);
+        }
+        return sb.toString();
     }
 
     private static List<String> splitNonEmpty(String value, String delimiter) {

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -189,6 +190,26 @@ class DamengAgentMetadataTest {
     }
 
     @Test
+    void readsFullTableDdlFromCharacterStreamWhenGetStringIsTruncated() {
+        DamengAgent agent = new DamengAgent();
+        String fullDdl = "CREATE TABLE \"APP\".\"USERS\" (\n  \"ID\" NUMBER,\n  \"PAYLOAD\" VARCHAR2(2000)\n);\n-- "
+            + "x".repeat(5000)
+            + "\n-- DBX_FULL_DDL_END";
+        TestSupport.setPrivateConnection(agent, metadataConnection(
+            "id comment",
+            null,
+            false,
+            List.of(),
+            null,
+            fullDdl
+        ));
+
+        String ddl = agent.getTableDdl("APP", "USERS");
+
+        Assertions.assertTrue(ddl.contains("DBX_FULL_DDL_END"), ddl);
+    }
+
+    @Test
     void appendsIndependentIndexesToTableDdl() {
         DamengAgent agent = new DamengAgent();
         List<String> sqls = new ArrayList<>();
@@ -270,6 +291,17 @@ class DamengAgentMetadataTest {
         List<List<Object>> independentIndexes,
         List<String> sqls
     ) {
+        return metadataConnection(allColumnComment, fallbackColumnComment, includeMaterializedView, independentIndexes, sqls, "CREATE TABLE \"APP\".\"USERS\" (\n  \"ID\" NUMBER\n);");
+    }
+
+    private static Connection metadataConnection(
+        String allColumnComment,
+        String fallbackColumnComment,
+        boolean includeMaterializedView,
+        List<List<Object>> independentIndexes,
+        List<String> sqls,
+        String dbmsMetadataDdl
+    ) {
         return proxy(Connection.class, (method, args) -> {
             String name = method.getName();
             if ("prepareStatement".equals(name)) {
@@ -278,7 +310,7 @@ class DamengAgentMetadataTest {
                     sqls.add(sql);
                 }
                 if (sql.contains("DBMS_METADATA.GET_DDL")) {
-                    return dbmsMetadataStatement();
+                    return dbmsMetadataStatement(dbmsMetadataDdl);
                 }
                 if (sql.contains("ALL_CONS_COLUMNS")) {
                     return metadataStatement(List.of(List.of("ID")));
@@ -361,7 +393,7 @@ class DamengAgentMetadataTest {
         return List.of(name, columns, uniqueness, indexType);
     }
 
-    private static PreparedStatement dbmsMetadataStatement() {
+    private static PreparedStatement dbmsMetadataStatement(String ddl) {
         List<String> params = new ArrayList<>();
         return proxy(PreparedStatement.class, (method, args) -> {
             String name = method.getName();
@@ -370,7 +402,7 @@ class DamengAgentMetadataTest {
                 if ("INDEX".equals(objectType)) {
                     throw new AssertionError("Dameng table DDL should generate index DDL from metadata");
                 }
-                return metadataResultSet(List.of(List.of("CREATE TABLE \"APP\".\"USERS\" (\n  \"ID\" NUMBER\n);")));
+                return metadataResultSet(List.of(List.of(new LongText(ddl, ddl.substring(0, Math.min(ddl.length(), 64))))));
             }
             if ("setString".equals(name)) {
                 int index = ((Integer) args[0]) - 1;
@@ -447,6 +479,9 @@ class DamengAgentMetadataTest {
             if ("getString".equals(name)) {
                 if (args[0] instanceof Integer columnIndex) {
                     Object value = rows.get(index[0]).get(columnIndex - 1);
+                    if (value instanceof LongText longText) {
+                        return longText.truncated;
+                    }
                     return value == null ? null : value.toString();
                 }
                 return switch (((String) args[0]).toUpperCase()) {
@@ -458,6 +493,12 @@ class DamengAgentMetadataTest {
                     case "COLNAME" -> string(rows, index[0], 0);
                     default -> null;
                 };
+            }
+            if ("getCharacterStream".equals(name) && args[0] instanceof Integer columnIndex) {
+                Object value = rows.get(index[0]).get(columnIndex - 1);
+                if (value instanceof LongText longText) {
+                    return new StringReader(longText.full);
+                }
             }
             if ("getObject".equals(name)) {
                 return switch (((String) args[0]).toUpperCase()) {
@@ -477,7 +518,20 @@ class DamengAgentMetadataTest {
 
     private static String string(List<List<Object>> rows, int rowIndex, int columnIndex) {
         Object value = rows.get(rowIndex).get(columnIndex);
+        if (value instanceof LongText longText) {
+            return longText.full;
+        }
         return value == null ? null : value.toString();
+    }
+
+    private static final class LongText {
+        private final String full;
+        private final String truncated;
+
+        private LongText(String full, String truncated) {
+            this.full = full;
+            this.truncated = truncated;
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## 变更内容

- 修复达梦 `DBMS_METADATA.GET_DDL` 结果直接通过 `ResultSet#getString` 读取时可能被 JDBC 驱动截断的问题。
- 表结构导出和对象源码读取改为优先通过字符流/CLOB 读取完整文本，最后再回退到 `getString`。
- 增加达梦元数据测试，模拟 `getString` 返回截断文本、`getCharacterStream` 返回完整 DDL 的场景。

## 验证

- `git diff --check`
- 未能本地执行 `./gradlew :dameng:test --tests com.dbx.agent.dameng.DamengAgentMetadataTest`：当前机器只有 JDK 17/21，Gradle 解析 `:common` 依赖时要求 Java 8 toolchain，且未配置自动下载。
