### PR TITLE
fix: 修复 SQL 前导空白下执行按钮不显示

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
@@ -27,6 +27,25 @@ describe("executableStatementRangeCacheForDoc", () => {
     expect(executableStatementRangeStartingAt(cache, secondStatementLine.from)?.sql).toBe("SELECT *\nFROM menus AS mn\nLIMIT 100");
   });
 
+  it("resolves statements with leading whitespace for gutter run buttons", () => {
+    const doc = Text.of([" SELECT 1;", "  SELECT 2;", "\t SELECT 3;", "", "    "]);
+    const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");
+
+    expect(executableStatementRangeStartingAt(cache, doc.line(1).from)?.sql).toBe("SELECT 1");
+    expect(executableStatementRangeStartingAt(cache, doc.line(2).from)?.sql).toBe("SELECT 2");
+    expect(executableStatementRangeStartingAt(cache, doc.line(3).from)?.sql).toBe("SELECT 3");
+    expect(executableStatementRangeStartingAt(cache, doc.line(4).from)).toBeNull();
+    expect(executableStatementRangeStartingAt(cache, doc.line(5).from)).toBeNull();
+  });
+
+  it("does not resolve gutter run buttons when non-whitespace precedes the statement on the same line", () => {
+    const doc = Text.of(["/* comment */ SELECT 1;"]);
+    const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");
+
+    expect(executableStatementRangeStartingAt(cache, doc.line(1).from)).toBeNull();
+    expect(executableStatementRangeStartingAt(cache, doc.toString().indexOf("SELECT"))?.sql).toBe("SELECT 1");
+  });
+
   it("resolves the current statement from a cursor inside a continuation line", () => {
     const doc = Text.of(["SELECT *", "FROM apis AS ap", "LIMIT 100;", "", "SELECT *", "FROM menus AS mn", "LIMIT 100;"]);
     const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");

--- a/apps/desktop/src/lib/sql/executableStatementRangeCache.ts
+++ b/apps/desktop/src/lib/sql/executableStatementRangeCache.ts
@@ -6,6 +6,7 @@ export interface ExecutableStatementRangeCache {
   doc: Text;
   databaseType?: DatabaseType;
   byStart: Map<number, SqlTextRange>;
+  byExecutableLineStart: Map<number, SqlTextRange>;
   ranges: SqlTextRange[];
 }
 
@@ -15,15 +16,20 @@ export function executableStatementRangeCacheForDoc(cache: ExecutableStatementRa
   if (cache?.doc === doc && cache.databaseType === databaseType) return cache;
 
   const byStart = new Map<number, SqlTextRange>();
+  const byExecutableLineStart = new Map<number, SqlTextRange>();
   const ranges = parse(doc.toString(), databaseType);
   for (const range of ranges) {
     byStart.set(range.from, range);
+    const line = doc.lineAt(range.from);
+    if (doc.sliceString(line.from, range.from).trim() === "") {
+      byExecutableLineStart.set(line.from, range);
+    }
   }
-  return { doc, databaseType, byStart, ranges };
+  return { doc, databaseType, byStart, byExecutableLineStart, ranges };
 }
 
 export function executableStatementRangeStartingAt(cache: ExecutableStatementRangeCache, lineFrom: number): SqlTextRange | null {
-  return cache.byStart.get(lineFrom) ?? null;
+  return cache.byStart.get(lineFrom) ?? cache.byExecutableLineStart.get(lineFrom) ?? null;
 }
 
 export function executableStatementRangeAtCursor(cache: ExecutableStatementRangeCache, cursorPos: number): SqlTextRange | null {


### PR DESCRIPTION
## 变更
- 修复 SQL 编辑器行首存在空格或 tab 时，左侧执行按钮不显示的问题。
- 在可执行语句缓存中增加行首到语句起点仅为空白时的映射，避免每次渲染时扫描语句列表。
- 补充前导空白和非空白前缀场景的回归测试。

## 验证
- pnpm exec vitest run apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json
- git diff --check