### PR TITLE
Fix：泛化查询超时错误的设置入口提示

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -54,6 +54,7 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import { TABLE_FONT_SIZE_MAX, TABLE_FONT_SIZE_MIN, useSettingsStore, type DataGridSearchMode } from "@/stores/settingsStore";
 import { useToast } from "@/composables/useToast";
 import { canCancelQueryExecution, queryExecutionLabelKey } from "@/lib/sql/queryExecutionState";
+import { isQueryTimeoutErrorMessage } from "@/lib/sql/queryError";
 import { databaseDisplayNameForTab, executionSummaryItems, nextExecutionSummaryView, resultGridCacheKey, resultRunItems, resultSqlForGrid, tabularResultItems } from "@/lib/tabs/tabPresentation";
 import { defaultQueryResultArchiveFileName } from "@/lib/query/queryResultArchive";
 import { saveQueryResultArchiveFile } from "@/lib/query/queryResultArchiveFile";
@@ -185,10 +186,6 @@ const dataGridSearchMode = computed(() => settingsStore.editorSettings.dataGridS
 const tableFontSize = computed(() => settingsStore.editorSettings.tableFontSize);
 const redisKeyBrowserRef = ref<SearchableBrowserHandle>();
 
-function isQueryTimeoutError(message: string): boolean {
-  const lower = message.toLowerCase();
-  return lower.includes("query timed out") || lower.includes("查询超时");
-}
 const etcdKeyBrowserRef = ref<SearchableBrowserHandle>();
 const zookeeperKeyBrowserRef = ref<SearchableBrowserHandle>();
 const objectBrowserRef = ref<SearchableBrowserHandle>();
@@ -1112,7 +1109,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
                 @sort="(column: string, columnIndex: number, direction: 'asc' | 'desc' | null, whereInput?: string, mode?: DataGridSortMode) => emit('sort', column, columnIndex, direction, whereInput, mode)"
               >
                 <template v-if="activeTab.result?.columns.includes('Error')" #error-actions="{ errorMessage }">
-                  <Button v-if="activeTab.connectionId && isQueryTimeoutError(String(errorMessage))" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('openConnectionSettings', activeTab.connectionId, 'advanced')">
+                  <Button v-if="activeTab.connectionId && isQueryTimeoutErrorMessage(String(errorMessage))" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('openConnectionSettings', activeTab.connectionId, 'advanced')">
                     <Wrench class="h-3.5 w-3.5" />
                     {{ t("editor.changeQueryTimeout") }}
                   </Button>

--- a/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
@@ -20,6 +20,11 @@ describe("isQueryTimeoutErrorMessage", () => {
     expect(isQueryTimeoutErrorMessage("Query exceeded maximum execution time")).toBe(true);
   });
 
+  it("detects agent RPC client-side timeout", () => {
+    expect(isQueryTimeoutErrorMessage("Agent RPC call timed out (30s)")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("Agent RPC call timed out (120s)")).toBe(true);
+  });
+
   it("does not classify unrelated errors as query timeouts", () => {
     expect(isQueryTimeoutErrorMessage('syntax error at or near "select"')).toBe(false);
     expect(isQueryTimeoutErrorMessage("Connection timed out while loading databases")).toBe(false);
@@ -27,5 +32,7 @@ describe("isQueryTimeoutErrorMessage", () => {
     expect(isQueryTimeoutErrorMessage("Cancel request timed out after 10s.")).toBe(false);
     expect(isQueryTimeoutErrorMessage("HTTP tunnel script read timed out")).toBe(false);
     expect(isQueryTimeoutErrorMessage('invalid value for parameter "statement_timeout"')).toBe(false);
+    // Agent RPC errors that are not timeouts must not trigger the action.
+    expect(isQueryTimeoutErrorMessage('Agent RPC error (-1): syntax error at or near "select"')).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isQueryTimeoutErrorMessage } from "@/lib/sql/queryError";
+
+describe("isQueryTimeoutErrorMessage", () => {
+  it("detects DBX query timeout messages", () => {
+    expect(isQueryTimeoutErrorMessage("Query timed out after 30 seconds")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("查询超时 (60s)，请检查数据库连接是否正常")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("查詢逾時 (60s)，請檢查資料庫連線是否正常")).toBe(true);
+  });
+
+  it("detects statement timeout messages", () => {
+    expect(isQueryTimeoutErrorMessage("ERROR: canceling statement due to statement timeout")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("ERROR: cancelling statement due to statement timeout")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("Statement timed out after 10 seconds")).toBe(true);
+  });
+
+  it("detects generic query execution timeout messages", () => {
+    expect(isQueryTimeoutErrorMessage("SQL execution timed out after 30s")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("Execution Timeout Expired. The timeout period elapsed prior to completion of the operation.")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("Query exceeded maximum execution time")).toBe(true);
+  });
+
+  it("does not classify unrelated errors as query timeouts", () => {
+    expect(isQueryTimeoutErrorMessage('syntax error at or near "select"')).toBe(false);
+    expect(isQueryTimeoutErrorMessage("Connection timed out while loading databases")).toBe(false);
+    expect(isQueryTimeoutErrorMessage("PostgreSQL connection pool checkout timed out (5s)")).toBe(false);
+    expect(isQueryTimeoutErrorMessage("Cancel request timed out after 10s.")).toBe(false);
+    expect(isQueryTimeoutErrorMessage("HTTP tunnel script read timed out")).toBe(false);
+    expect(isQueryTimeoutErrorMessage('invalid value for parameter "statement_timeout"')).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/sql/queryError.ts
+++ b/apps/desktop/src/lib/sql/queryError.ts
@@ -1,6 +1,11 @@
 export function isQueryTimeoutErrorMessage(message: string): boolean {
   const lower = message.toLowerCase();
   if (lower.includes("query timed out") || lower.includes("查询超时") || lower.includes("查詢逾時")) return true;
+  // Agent RPC client-side timeout (tokio::time::timeout in agent_driver.rs). This is the
+  // fallback when JDBC setQueryTimeout never fires (unsupported/unresponsive driver), so the
+  // backend already treats it as a query timeout (is_agent_rpc_timeout_error in query.rs) —
+  // surface the same action here to stay consistent with the backend.
+  if (lower.startsWith("agent rpc call timed out")) return true;
   if (/\b(?:canceling|cancelling|canceled|cancelled)\b[\s\S]{0,80}\bstatement\b[\s\S]{0,80}\btimeout\b/.test(lower)) return true;
   if (/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower)) return false;
   return (

--- a/apps/desktop/src/lib/sql/queryError.ts
+++ b/apps/desktop/src/lib/sql/queryError.ts
@@ -1,0 +1,11 @@
+export function isQueryTimeoutErrorMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  if (lower.includes("query timed out") || lower.includes("查询超时") || lower.includes("查詢逾時")) return true;
+  if (/\b(?:canceling|cancelling|canceled|cancelled)\b[\s\S]{0,80}\bstatement\b[\s\S]{0,80}\btimeout\b/.test(lower)) return true;
+  if (/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower)) return false;
+  return (
+    /\b(?:query|statement|sql|execution|execute|executing)\b[\s\S]{0,80}\b(?:timed out|timeout expired|timeout exceeded|time-out)\b/.test(lower) ||
+    /\b(?:timed out|timeout expired|timeout exceeded|time-out)\b[\s\S]{0,80}\b(?:query|statement|sql|execution|execute|executing)\b/.test(lower) ||
+    /\bquery\b[\s\S]{0,80}\bexceeded\b[\s\S]{0,80}\b(?:execution\s+)?time\b/.test(lower)
+  );
+}


### PR DESCRIPTION
## 变更

- 将结果页错误中的查询超时判断抽到 `queryError` helper，供超时操作按钮复用。
- 泛化 SQL 执行超时识别，不再只依赖 DBX 自身的 `Query timed out` 文案。
- 支持 PostgreSQL `statement_timeout`、SQL Server 风格 `Execution Timeout Expired`、以及通用 `SQL/query/statement execution timed out` 文案。
- 排除连接、连接池、元数据加载、取消请求、SSH/HTTP tunnel 等非查询执行超时，避免误显示“修改查询超时时间”。
- 补充回归测试覆盖命中和排除场景。

## 验证

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/sql/queryError.spec.ts --reporter=dot`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm exec oxfmt --check apps/desktop/src/components/layout/ContentArea.vue apps/desktop/src/lib/sql/queryError.ts apps/desktop/src/lib/__tests__/sql/queryError.spec.ts`