### PR TITLE
fix(toolbar): sync SQL file tree visibility setting

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -3000,6 +3000,7 @@ onUnmounted(cleanupPreviewEditor);
                       { key: 'dataCompare', label: t('dataCompare.title') },
                       { key: 'checkUpdates', label: t('updates.check') },
                       { key: 'sqlLibrary', label: t('sqlLibrary.title') },
+                      { key: 'sqlFileTree', label: t('sqlFileTree.title') },
                       { key: 'history', label: t('history.title') },
                       { key: 'ai', label: 'AI' },
                       { key: 'theme', label: t('toolbar.theme') },

--- a/apps/desktop/src/components/layout/AppToolbar.vue
+++ b/apps/desktop/src/components/layout/AppToolbar.vue
@@ -146,6 +146,15 @@ const collapsibleRightItemDefs = computed(() => {
       disabled: false,
     });
   }
+  if (toolbarItems.value.sqlFileTree) {
+    items.push({
+      key: "sqlFileTree",
+      label: t("sqlFileTree.title"),
+      icon: FolderTree,
+      action: () => emit("toggle-sql-file-panel"),
+      disabled: false,
+    });
+  }
   if (toolbarItems.value.history) {
     items.push({
       key: "history",
@@ -451,9 +460,9 @@ const toolbarDropdownTriggerClass = `inline-flex h-8 items-center gap-1 rounded-
         <TooltipContent>{{ t("sqlLibrary.title") }}</TooltipContent>
       </Tooltip>
 
-      <Tooltip>
+      <Tooltip v-if="toolbarItems.sqlFileTree">
         <TooltipTrigger as-child>
-          <Button variant="ghost" size="icon" class="h-8 w-8 shrink-0" :class="{ 'bg-accent': showSqlFilePanel }" @click="emit('toggle-sql-file-panel')">
+          <Button v-show="isRightItemVisible('sqlFileTree')" variant="ghost" size="icon" class="h-8 w-8 shrink-0" :class="{ 'bg-accent': showSqlFilePanel }" @click="emit('toggle-sql-file-panel')">
             <FolderTree class="h-4 w-4" />
           </Button>
         </TooltipTrigger>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2784,7 +2784,7 @@ export default {
     languageTitle: "Language / 语言",
     fontSize: "Font Size",
     toolbarTitle: "Toolbar",
-    toolbarHiddenHint: 'Hidden left-side buttons will appear in the "More" dropdown.',
+    toolbarHiddenHint: 'Some hidden or overflowed buttons appear in the "More" dropdown.',
     uiScale: "UI Scale",
     uiScaleDescription: "Scale the entire desktop UI for high-DPI displays. Changes apply immediately and are restored on next launch.",
     theme: "Theme",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2709,7 +2709,7 @@ export default withEnglishFallback({
     languageTitle: "Idioma / Language",
     fontSize: "Tamaño de fuente",
     toolbarTitle: "Barra de herramientas",
-    toolbarHiddenHint: "Los botones ocultos de la izquierda aparecerán en el menú «Más».",
+    toolbarHiddenHint: "Algunos botones ocultos o desbordados aparecerán en el menú «Más».",
     uiScale: "Escala de interfaz",
     uiScaleDescription: "Escala toda la interfaz de escritorio para pantallas de alta densidad. Los cambios se aplican al instante y se restauran al volver a abrir.",
     theme: "Tema",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2707,7 +2707,7 @@ export default withEnglishFallback({
     languageTitle: "Lingua / Language",
     fontSize: "Dimensione Carattere",
     toolbarTitle: "Barra degli strumenti",
-    toolbarHiddenHint: "I pulsanti nascosti a sinistra appariranno nel menu «Altro».",
+    toolbarHiddenHint: "Alcuni pulsanti nascosti o in eccesso appariranno nel menu «Altro».",
     uiScale: "Scala UI",
     uiScaleDescription: "Scala l'intera interfaccia utente desktop per display ad alta densità (High-DPI). Le modifiche si applicano immediatamente e vengono ripristinate al prossimo avvio.",
     theme: "Tema",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2707,7 +2707,7 @@ export default withEnglishFallback({
     languageTitle: "言語 / Language",
     fontSize: "フォントサイズ",
     toolbarTitle: "ツールバー",
-    toolbarHiddenHint: "非表示にした左側のボタンは、「もっと見る」ドロップダウン内に表示されます。",
+    toolbarHiddenHint: "非表示または幅が足りない一部のボタンは、「もっと見る」ドロップダウン内に表示されます。",
     uiScale: "UIスケール",
     uiScaleDescription: "高DPIディスプレイ向けにデスクトップUI全体をスケーリングします。変更は即座に適用され、次回起動時に復元されます。",
     theme: "テーマ",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2708,7 +2708,7 @@ export default withEnglishFallback({
     languageTitle: "Idioma / 语言",
     fontSize: "Tamanho da fonte",
     toolbarTitle: "Barra de ferramentas",
-    toolbarHiddenHint: "Os botões ocultos à esquerda aparecerão no menu «Mais».",
+    toolbarHiddenHint: "Alguns botões ocultos ou excedentes aparecerão no menu «Mais».",
     uiScale: "Escala da UI",
     uiScaleDescription: "Dimensione toda a UI do desktop para telas de alta resolução (high-DPI). As alterações são aplicadas imediatamente e restauradas na próxima inicialização.",
     theme: "Tema",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2784,7 +2784,7 @@ export default withEnglishFallback({
     languageTitle: "语言 / Language",
     fontSize: "字号",
     toolbarTitle: "工具栏",
-    toolbarHiddenHint: '关闭的左侧按钮会自动收进"更多"下拉菜单。',
+    toolbarHiddenHint: '部分关闭或空间不足的按钮会自动收进"更多"下拉菜单。',
     uiScale: "界面缩放",
     uiScaleDescription: "按比例缩放整个桌面端界面，适合高清屏；修改后立即生效，并在下次启动时恢复。",
     theme: "主题",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2610,7 +2610,7 @@ export default withEnglishFallback({
     languageTitle: "語言 / Language",
     fontSize: "字級",
     toolbarTitle: "工具列",
-    toolbarHiddenHint: "關閉的左側按鈕會自動收進「更多」下拉選單。",
+    toolbarHiddenHint: "部分關閉或空間不足的按鈕會自動收進「更多」下拉選單。",
     uiScale: "介面縮放",
     uiScaleDescription: "按比例縮放整個桌面端介面，適合高 DPI 螢幕；修改後立即生效，並在下次啟動時復原。",
     theme: "主題",

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -70,6 +70,19 @@ describe("normalizeEditorSettings", () => {
     expect(normalizeEditorSettings({ dataGridSearchMode: "highlight" }).dataGridSearchMode).toBe("highlight");
     expect(normalizeEditorSettings({ dataGridSearchMode: "invalid" as any }).dataGridSearchMode).toBe("filter");
   });
+
+  it("normalizes toolbar item settings from older saved settings", () => {
+    const settings = normalizeEditorSettings({
+      toolbarItems: {
+        sqlFileTree: false,
+        history: false,
+      } as any,
+    });
+
+    expect(settings.toolbarItems.sqlFileTree).toBe(false);
+    expect(settings.toolbarItems.history).toBe(false);
+    expect(settings.toolbarItems.sqlLibrary).toBe(true);
+  });
 });
 
 describe("normalizeDesktopSettings", () => {

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -430,6 +430,7 @@ export interface ToolbarItems {
   dataCompare: boolean;
   checkUpdates: boolean;
   sqlLibrary: boolean;
+  sqlFileTree: boolean;
   history: boolean;
   ai: boolean;
   theme: boolean;
@@ -444,6 +445,7 @@ export const DEFAULT_TOOLBAR_ITEMS: ToolbarItems = {
   dataCompare: true,
   checkUpdates: true,
   sqlLibrary: true,
+  sqlFileTree: true,
   history: true,
   ai: true,
   theme: true,
@@ -675,6 +677,7 @@ function normalizeToolbarItems(items: Partial<ToolbarItems> | undefined): Toolba
     dataCompare: items.dataCompare ?? defaults.dataCompare,
     checkUpdates: items.checkUpdates ?? defaults.checkUpdates,
     sqlLibrary: items.sqlLibrary ?? defaults.sqlLibrary,
+    sqlFileTree: items.sqlFileTree ?? defaults.sqlFileTree,
     history: items.history ?? defaults.history,
     ai: items.ai ?? defaults.ai,
     theme: items.theme ?? defaults.theme,


### PR DESCRIPTION
## Summary
- add a dedicated toolbar visibility setting for the SQL file tree button
- make the SQL file tree toolbar button and overflow menu entry follow that setting
- normalize older saved toolbar settings and clarify toolbar hint copy across locales

Fixes #2722

## Tests
- `PATH=/Users/zero/.local/share/mise/installs/node/24.16.0/bin:$PATH pnpm vitest run apps/desktop/src/stores/__tests__/settingsStore.spec.ts`
- `PATH=/Users/zero/.local/share/mise/installs/node/24.16.0/bin:$PATH pnpm typecheck`
- desktop manual verification