### PR TITLE
feat: 支持 AI 引用 SQL 库文件

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -4,6 +4,7 @@ import { uuid } from "@/lib/common/utils";
 import { useI18n } from "vue-i18n";
 import { translateBackendError } from "@/i18n/backend-errors";
 import {
+  ArrowDown,
   ArrowUp,
   ArrowRightLeft,
   AlertTriangle,
@@ -13,6 +14,7 @@ import {
   CircleSlash,
   Copy,
   Database,
+  FileCode,
   GitBranch,
   HelpCircle,
   History,
@@ -44,11 +46,13 @@ import { useTheme } from "@/composables/useTheme";
 import { useSettingsStore, AI_PROVIDER_PRESETS, type AiProvider } from "@/stores/settingsStore";
 import AiProviderLogo from "@/components/icons/AiProviderLogo.vue";
 import { useConnectionStore } from "@/stores/connectionStore";
+import { useSavedSqlStore } from "@/stores/savedSqlStore";
 import { connectionIconType } from "@/lib/connection/connectionPresentation";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
 import { useQueryStore } from "@/stores/queryStore";
 import { useToast } from "@/composables/useToast";
-import { buildAiContext, runAgentStream, isVectorDbType, defaultActionForMode, isValidActionForMode, type AiAction, type AiAssistantMode } from "@/lib/ai/ai";
+import { useNavigationTargets } from "@/composables/useNavigationTargets";
+import { buildAiContext, runAgentStream, isVectorDbType, defaultActionForMode, isValidActionForMode, type AiAction, type AiAssistantMode, type AiSqlFileContext } from "@/lib/ai/ai";
 import { formatAiModelOption } from "@/lib/ai/aiModelPresentation";
 import type { AgentEvent } from "@/lib/backend/tauri";
 import { buildAiAgentPlan } from "@/lib/ai/aiAgentPlan";
@@ -58,7 +62,7 @@ import { createAiMessageRenderer } from "@/lib/ai/aiMessageRender";
 import { formatAiInlineMarkdown, handleAiMarkdownLinkClick } from "@/lib/ai/aiMarkdown";
 import { aiCancelStream, aiListModels, saveAiConversation, loadAiConversations, deleteAiConversation, listSchemas, listTables, type AiConversation, type AiModelInfo } from "@/lib/backend/api";
 import type { AiMessage } from "@/lib/backend/api";
-import type { ConnectionConfig, QueryTab, TableInfo } from "@/types/database";
+import type { ConnectionConfig, QueryTab, SavedSqlFile, TableInfo } from "@/types/database";
 import { useDatabaseOptions } from "@/composables/useDatabaseOptions";
 import { decodeSelectableDatabaseValue, encodeSelectableDatabaseValue, formatDatabaseLabel, resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
 import { isSchemaAware } from "@/lib/database/databaseCapabilities";
@@ -73,13 +77,36 @@ import { visibleToActualIndex } from "@/lib/ai/aiMessageEdit";
 const { t } = useI18n();
 const settings = useSettingsStore();
 const connectionStore = useConnectionStore();
+const savedSqlStore = useSavedSqlStore();
 const queryStore = useQueryStore();
+const { openTableTarget } = useNavigationTargets({
+  showFieldLineageDialog: ref(false),
+  showDatabaseSearchDialog: ref(false),
+});
 const { toast } = useToast();
 const { isDark } = useTheme();
+
+type AiMessageMention =
+  | {
+      kind: "table";
+      raw: string;
+      connectionId: string;
+      database: string;
+      schema?: string;
+      table: string;
+    }
+  | {
+      kind: "sqlFile";
+      raw: string;
+      connectionId: string;
+      id: string;
+      name: string;
+    };
 
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
+  mentions?: AiMessageMention[];
   reasoning?: string;
   isThinking?: boolean;
   agentSteps?: AiAgentStepItem[];
@@ -111,6 +138,9 @@ const conversationId = ref("");
 const conversations = ref<AiConversation[]>([]);
 const showConversationList = ref(false);
 const promptTextareaRef = ref<HTMLTextAreaElement | null>(null);
+const shouldAutoScroll = ref(true);
+const userPausedAutoScroll = ref(false);
+const showScrollToBottom = ref(false);
 const promptCompositionActive = ref(false);
 const shikiCodeHighlighter = ref<AiCodeHighlighter>();
 const agentTokens = ref<{ input: number; output: number } | null>(null);
@@ -120,12 +150,21 @@ const draftBeforeHistory = ref("");
 
 const editingMessageIndex = ref<number | null>(null);
 const editingContent = ref("");
+const editingMentions = ref<AiPromptMentionChip[]>([]);
 const editCompositionActive = ref(false);
+const MESSAGE_SCROLL_RESUME_THRESHOLD_PX = 16;
+const MESSAGE_SCROLL_BUTTON_SHOW_THRESHOLD_PX = 120;
+const MESSAGE_SCROLL_BUTTON_HIDE_THRESHOLD_PX = 48;
+let messageScrollViewport: HTMLElement | null = null;
+let messageTouchStartY: number | null = null;
+let lastMessageScrollTop = 0;
 
 function startEditMessage(visibleIndex: number) {
   if (isGenerating.value) return;
   editingMessageIndex.value = visibleIndex;
-  editingContent.value = visibleMessages.value[visibleIndex].content;
+  const msg = visibleMessages.value[visibleIndex];
+  editingContent.value = msg.content;
+  editingMentions.value = promptMentionChipsFromMessage(msg);
   nextTick(() => {
     const el = document.querySelector<HTMLTextAreaElement>("[data-edit-textarea]");
     if (el) {
@@ -138,11 +177,12 @@ function startEditMessage(visibleIndex: number) {
 function cancelEdit() {
   editingMessageIndex.value = null;
   editingContent.value = "";
+  editingMentions.value = [];
 }
 
 function submitEdit(visibleIndex: number) {
   const content = editingContent.value.trim();
-  if (!content) return;
+  if (!content && !editingMentions.value.length) return;
   const actualIndex = visibleToActualIndex(messages.value, visibleIndex);
   if (actualIndex < 0) return;
   if (!props.connection || !props.tab) return;
@@ -153,7 +193,9 @@ function submitEdit(visibleIndex: number) {
   messages.value = messages.value.slice(0, actualIndex);
   editingMessageIndex.value = null;
   editingContent.value = "";
-  selectedMentions.value = [];
+  selectedMentions.value = editingMentions.value.filter((mention): mention is AiTableMention & { kind: "table" } => mention.kind === "table").map(({ raw, schema, table }) => ({ raw, schema, table }));
+  selectedSqlFileMentions.value = editingMentions.value.filter((mention): mention is AiSqlFileMention => mention.kind === "sqlFile");
+  editingMentions.value = [];
   prompt.value = content;
   send();
 }
@@ -254,11 +296,30 @@ let resizeStartY = 0;
 let resizeStartHeight = 0;
 let promptPanelResizeObserver: ResizeObserver | undefined;
 
-interface AiMentionCandidate {
+interface AiTableMentionCandidate {
+  kind: "table";
   schema?: string;
   name: string;
   tableType: string;
 }
+
+interface AiSqlFileMentionCandidate {
+  kind: "sqlFile";
+  id: string;
+  name: string;
+  folderPath?: string;
+}
+
+type AiMentionCandidate = AiTableMentionCandidate | AiSqlFileMentionCandidate;
+
+interface AiSqlFileMention {
+  kind: "sqlFile";
+  raw: string;
+  id: string;
+  name: string;
+}
+
+type AiPromptMentionChip = (AiTableMention & { kind: "table" }) | AiSqlFileMention;
 
 const mentionOpen = ref(false);
 const mentionLoading = ref(false);
@@ -269,8 +330,12 @@ const mentionCandidates = ref<AiMentionCandidate[]>([]);
 const mentionCache = ref<Record<string, AiMentionCandidate[]>>({});
 const mentionListRef = ref<HTMLElement | null>(null);
 const selectedMentions = ref<AiTableMention[]>([]);
+const selectedSqlFileMentions = ref<AiSqlFileMention[]>([]);
 let mentionTimer: ReturnType<typeof setTimeout> | undefined;
 let mentionRequestId = 0;
+
+const AI_SQL_FILE_MENTION_CANDIDATE_LIMIT = 50;
+const AI_SQL_FILE_CONTEXT_MAX_CHARS = 12_000;
 
 interface AiActionButton {
   action: AiAction;
@@ -348,22 +413,35 @@ function messagesForAgentHistory(historyMessages: ChatMessage[]): AiMessage[] {
     }
   }
   if (latestSummaryIndex < 0) {
-    return historyMessages.map((m) => ({ role: m.role, content: m.content }));
+    return historyMessages.map((m) => ({ role: m.role, content: messageContentForModel(m) }));
   }
   const compactedHistory = historyMessages.slice(latestSummaryIndex);
   const firstMsg = historyMessages[0];
   if (firstMsg && firstMsg.role === "user" && firstMsg.kind !== "contextSummary") {
-    return [{ role: "user" as const, content: firstMsg.content }, ...compactedHistory.map((m) => ({ role: m.role, content: m.content }))];
+    return [{ role: "user" as const, content: messageContentForModel(firstMsg) }, ...compactedHistory.map((m) => ({ role: m.role, content: messageContentForModel(m) }))];
   }
-  return compactedHistory.map((m) => ({ role: m.role, content: m.content }));
+  return compactedHistory.map((m) => ({ role: m.role, content: messageContentForModel(m) }));
 }
 
 const chatTitle = computed(() => {
   const first = messages.value.find((m) => m.role === "user" && m.kind !== "contextSummary");
-  return first ? first.content.slice(0, 30) : t("ai.newChat");
+  return first ? messageTitle(first).slice(0, 30) : t("ai.newChat");
 });
 
-const promptMentionChips = computed(() => selectedMentions.value);
+const promptMentionChips = computed<AiPromptMentionChip[]>(() => [...selectedMentions.value.map((mention) => ({ ...mention, kind: "table" as const })), ...selectedSqlFileMentions.value]);
+
+function messageMentionLabels(message: ChatMessage): string[] {
+  return promptMentionChipsFromMessage(message).map((mention) => mention.raw);
+}
+
+function messageContentForModel(message: ChatMessage): string {
+  if (message.kind === "contextSummary") return message.content;
+  return [...messageMentionLabels(message), message.content].filter(Boolean).join(" ");
+}
+
+function messageTitle(message: ChatMessage): string {
+  return [promptMentionChipsFromMessage(message).map(mentionDisplayName).join(" "), message.content].filter(Boolean).join(" ") || t("ai.newChat");
+}
 
 const isWaitingForFirstDelta = computed(() => {
   const last = messages.value[messages.value.length - 1];
@@ -511,7 +589,7 @@ function appendAssistantReasoning(assistantIdx: number, delta: string) {
   scrollToBottom();
 }
 
-const reasoningExpanded = ref(false);
+const expandedReasoning = ref<Set<number>>(new Set());
 const expandedSteps = ref<Set<string>>(new Set());
 
 function toggleStep(key: string) {
@@ -626,23 +704,169 @@ function agentEventToStep(event: AgentEvent, index: number): AiAgentStepItem | u
   };
 }
 
-function toggleReasoning() {
-  reasoningExpanded.value = !reasoningExpanded.value;
+function toggleReasoning(index: number) {
+  const next = new Set(expandedReasoning.value);
+  if (next.has(index)) {
+    next.delete(index);
+  } else {
+    next.add(index);
+  }
+  expandedReasoning.value = next;
 }
 
-function scrollToBottom() {
+function getMessageScrollViewport(): HTMLElement | null {
+  const root = scrollRef.value?.$el as HTMLElement | undefined;
+  return root?.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
+}
+
+function messageBottomDistance(el: HTMLElement) {
+  return Math.max(0, el.scrollHeight - el.scrollTop - el.clientHeight);
+}
+
+function isAtMessageBottom(el: HTMLElement) {
+  return messageBottomDistance(el) <= MESSAGE_SCROLL_RESUME_THRESHOLD_PX;
+}
+
+function messageCanScroll(el: HTMLElement) {
+  return el.scrollHeight > el.clientHeight + MESSAGE_SCROLL_RESUME_THRESHOLD_PX;
+}
+
+function shouldShowMessageScrollButton(el: HTMLElement) {
+  if (!messageCanScroll(el)) return false;
+  const distance = messageBottomDistance(el);
+  return distance > (showScrollToBottom.value ? MESSAGE_SCROLL_BUTTON_HIDE_THRESHOLD_PX : MESSAGE_SCROLL_BUTTON_SHOW_THRESHOLD_PX);
+}
+
+function updateMessageScrollButtonVisibility() {
+  const el = getMessageScrollViewport();
+  showScrollToBottom.value = !!el && shouldShowMessageScrollButton(el);
+}
+
+function pauseMessageAutoScroll() {
+  userPausedAutoScroll.value = true;
+  shouldAutoScroll.value = false;
+  updateMessageScrollButtonVisibility();
+}
+
+function updateMessageScrollState() {
+  const el = getMessageScrollViewport();
+  if (!el) {
+    showScrollToBottom.value = false;
+    return;
+  }
+  if (isAtMessageBottom(el)) {
+    userPausedAutoScroll.value = false;
+    shouldAutoScroll.value = true;
+    showScrollToBottom.value = false;
+    return;
+  }
+  if (userPausedAutoScroll.value) {
+    shouldAutoScroll.value = false;
+    showScrollToBottom.value = shouldShowMessageScrollButton(el);
+    return;
+  }
+  shouldAutoScroll.value = false;
+  showScrollToBottom.value = shouldShowMessageScrollButton(el);
+}
+
+function handleMessageScroll() {
+  const el = getMessageScrollViewport();
+  if (!el) return;
+  if (el.scrollTop < lastMessageScrollTop - 2) {
+    userPausedAutoScroll.value = true;
+  }
+  lastMessageScrollTop = el.scrollTop;
+  updateMessageScrollState();
+}
+
+function handleMessageWheel(event: WheelEvent) {
+  if (event.deltaY < 0) pauseMessageAutoScroll();
+}
+
+function handleMessageTouchStart(event: TouchEvent) {
+  messageTouchStartY = event.touches[0]?.clientY ?? null;
+}
+
+function handleMessageTouchMove(event: TouchEvent) {
+  if (messageTouchStartY == null) return;
+  const currentY = event.touches[0]?.clientY ?? messageTouchStartY;
+  if (currentY - messageTouchStartY > 4) pauseMessageAutoScroll();
+}
+
+function handleMessageKeydown(event: KeyboardEvent) {
+  if (["ArrowUp", "PageUp", "Home"].includes(event.key)) pauseMessageAutoScroll();
+}
+
+function detachMessageScrollListener() {
+  if (!messageScrollViewport) return;
+  messageScrollViewport.removeEventListener("scroll", handleMessageScroll);
+  messageScrollViewport.removeEventListener("wheel", handleMessageWheel);
+  messageScrollViewport.removeEventListener("touchstart", handleMessageTouchStart);
+  messageScrollViewport.removeEventListener("touchmove", handleMessageTouchMove);
+  messageScrollViewport.removeEventListener("keydown", handleMessageKeydown);
+  messageScrollViewport = null;
+}
+
+function attachMessageScrollListener() {
   nextTick(() => {
-    const root = scrollRef.value?.$el as HTMLElement | undefined;
-    const el = root?.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement | null;
+    const el = getMessageScrollViewport();
+    if (el === messageScrollViewport) return;
+    detachMessageScrollListener();
+    messageScrollViewport = el;
+    if (!el) return;
+    el.addEventListener("scroll", handleMessageScroll, { passive: true });
+    el.addEventListener("wheel", handleMessageWheel, { passive: true });
+    el.addEventListener("touchstart", handleMessageTouchStart, { passive: true });
+    el.addEventListener("touchmove", handleMessageTouchMove, { passive: true });
+    el.addEventListener("keydown", handleMessageKeydown);
+    lastMessageScrollTop = el.scrollTop;
+    updateMessageScrollState();
+  });
+}
+
+function scrollToBottom(options: { force?: boolean } = {}) {
+  if (options.force) {
+    userPausedAutoScroll.value = false;
+    shouldAutoScroll.value = true;
+  }
+  if (!options.force && (userPausedAutoScroll.value || !shouldAutoScroll.value)) {
+    updateMessageScrollButtonVisibility();
+    return;
+  }
+  nextTick(() => {
+    const el = getMessageScrollViewport();
     if (!el) return;
     requestAnimationFrame(() => {
+      if (!options.force && (userPausedAutoScroll.value || !shouldAutoScroll.value)) {
+        updateMessageScrollButtonVisibility();
+        return;
+      }
       el.scrollTop = el.scrollHeight;
+      lastMessageScrollTop = el.scrollTop;
+      userPausedAutoScroll.value = false;
+      shouldAutoScroll.value = true;
+      showScrollToBottom.value = false;
     });
   });
 }
 
+watch(
+  () => messages.value.length,
+  (length) => {
+    if (length) {
+      attachMessageScrollListener();
+      return;
+    }
+    detachMessageScrollListener();
+    userPausedAutoScroll.value = false;
+    shouldAutoScroll.value = true;
+    showScrollToBottom.value = false;
+  },
+  { flush: "post" },
+);
+
 function mentionCacheKey(connectionId: string, database: string, query: string) {
-  return `${connectionId}:${database}:${query.toLowerCase()}`;
+  return `${connectionId}:${database}:${savedSqlStore.version}:${query.toLowerCase()}`;
 }
 
 function mentionSchemaOrder(schemas: string[]): string[] {
@@ -688,10 +912,12 @@ async function loadMentionCandidates(query: string) {
   mentionLoading.value = true;
   mentionError.value = "";
   const { schemaPrefix, tableFilter } = normalizeMentionQuery(query);
+  let sqlFileCandidates: AiSqlFileMentionCandidate[] = [];
 
   try {
+    sqlFileCandidates = await loadSqlFileMentionCandidates(query);
     await connectionStore.ensureConnected(props.tab.connectionId);
-    let candidates: AiMentionCandidate[] = [];
+    let tableCandidates: AiMentionCandidate[] = [];
     if (isSchemaAware(props.connection.db_type)) {
       const schemas = mentionSchemaOrder(await listSchemas(props.tab.connectionId, props.tab.database));
       const filteredSchemas = schemaPrefix ? schemas.filter((schema) => schema.toLowerCase().includes(schemaPrefix.toLowerCase())) : schemas;
@@ -705,11 +931,11 @@ async function loadMentionCandidates(query: string) {
           );
         }),
       );
-      candidates = filterAiTableMentionCandidates(results.flat(), "", AI_TABLE_MENTION_CANDIDATE_LIMIT);
+      tableCandidates = filterAiTableMentionCandidates(results.flat(), "", AI_TABLE_MENTION_CANDIDATE_LIMIT);
     } else {
       const schema = props.tab.database || props.connection.database || "main";
       const tables = await listTables(props.tab.connectionId, props.tab.database, schema, tableFilter || undefined, AI_TABLE_MENTION_CANDIDATE_LIMIT);
-      candidates = filterAiTableMentionCandidates(
+      tableCandidates = filterAiTableMentionCandidates(
         tables.map((table) => mentionCandidateFromTable(table)),
         tableFilter,
         AI_TABLE_MENTION_CANDIDATE_LIMIT,
@@ -717,11 +943,18 @@ async function loadMentionCandidates(query: string) {
     }
 
     if (requestId !== mentionRequestId) return;
-    mentionCache.value[key] = candidates.slice(0, AI_TABLE_MENTION_CANDIDATE_LIMIT);
+    mentionCache.value[key] = [...tableCandidates, ...sqlFileCandidates];
     mentionCandidates.value = mentionCache.value[key];
     setMentionSelectedIndex(0);
   } catch (e: unknown) {
     if (requestId !== mentionRequestId) return;
+    if (sqlFileCandidates.length) {
+      mentionCache.value[key] = sqlFileCandidates;
+      mentionCandidates.value = sqlFileCandidates;
+      mentionError.value = "";
+      setMentionSelectedIndex(0);
+      return;
+    }
     const message = e instanceof Error ? e.message : String(e);
     mentionError.value = translateBackendError(t, message);
     mentionCandidates.value = [];
@@ -730,24 +963,140 @@ async function loadMentionCandidates(query: string) {
   }
 }
 
-function mentionCandidateFromTable(table: TableInfo, schema?: string): AiMentionCandidate {
-  return { schema, name: table.name, tableType: table.table_type };
+async function loadSqlFileMentionCandidates(query: string): Promise<AiSqlFileMentionCandidate[]> {
+  const connectionId = props.tab?.connectionId;
+  if (!connectionId) return [];
+  await savedSqlStore.initFromStorage();
+  const normalizedQuery = normalizeSqlFileMentionQuery(query);
+  return savedSqlStore.allFiles
+    .filter((file) => file.connectionId === connectionId)
+    .map((file) => ({ file, folderPath: savedSqlFolderPath(file) }))
+    .filter(({ file, folderPath }) => sqlFileMatchesQuery(file, folderPath, normalizedQuery))
+    .slice(0, AI_SQL_FILE_MENTION_CANDIDATE_LIMIT)
+    .map(({ file, folderPath }) => ({
+      kind: "sqlFile",
+      id: file.id,
+      name: file.name,
+      folderPath,
+    }));
 }
 
-function mentionDisplayName(mention: AiTableMention) {
+function normalizeSqlFileMentionQuery(query: string) {
+  return query.replace(/^["`{]+|["`}]+$/g, "").toLowerCase();
+}
+
+function sqlFileMatchesQuery(file: SavedSqlFile, folderPath: string | undefined, query: string) {
+  if (!query) return true;
+  return [file.name, folderPath || ""].some((value) => value.toLowerCase().includes(query));
+}
+
+function savedSqlFolderPath(file: SavedSqlFile): string | undefined {
+  if (!file.folderId) return undefined;
+  const foldersById = new Map(savedSqlStore.allFolders.map((folder) => [folder.id, folder]));
+  const names: string[] = [];
+  let current = foldersById.get(file.folderId);
+  while (current) {
+    names.unshift(current.name);
+    current = current.parentFolderId ? foldersById.get(current.parentFolderId) : undefined;
+  }
+  return names.length ? names.join(" / ") : undefined;
+}
+
+function mentionCandidateFromTable(table: TableInfo, schema?: string): AiTableMentionCandidate {
+  return { kind: "table", schema, name: table.name, tableType: table.table_type };
+}
+
+function mentionCandidateName(candidate: AiMentionCandidate) {
+  if (candidate.kind === "sqlFile") return candidate.name;
+  return [candidate.schema, candidate.name].filter(Boolean).join(".");
+}
+
+function mentionDisplayName(mention: AiPromptMentionChip) {
+  if (mention.kind === "sqlFile") return mention.name;
   return [mention.schema, mention.table].filter(Boolean).join(".");
 }
 
-function removeMentionChip(mention: AiTableMention) {
-  selectedMentions.value = selectedMentions.value.filter((item) => item.raw !== mention.raw);
+function promptMentionChipsFromMessage(message: ChatMessage): AiPromptMentionChip[] {
+  return (message.mentions || []).map((mention) => {
+    if (mention.kind === "sqlFile") return { kind: "sqlFile", raw: mention.raw, id: mention.id, name: mention.name };
+    return { kind: "table", raw: mention.raw, schema: mention.schema, table: mention.table };
+  });
+}
+
+function removeMentionChip(mention: AiPromptMentionChip) {
+  if (mention.kind === "sqlFile") {
+    selectedSqlFileMentions.value = selectedSqlFileMentions.value.filter((item) => item.id !== mention.id);
+  } else {
+    selectedMentions.value = selectedMentions.value.filter((item) => item.raw !== mention.raw);
+  }
   nextTick(() => promptTextareaRef.value?.focus());
 }
 
+function removeEditingMentionChip(index: number) {
+  editingMentions.value = editingMentions.value.filter((_, itemIndex) => itemIndex !== index);
+  nextTick(() => {
+    const el = document.querySelector<HTMLTextAreaElement>("[data-edit-textarea]");
+    el?.focus();
+  });
+}
+
 function addSelectedMention(candidate: AiMentionCandidate) {
+  if (candidate.kind === "sqlFile") {
+    const raw = `@{${candidate.name}}`;
+    if (selectedSqlFileMentions.value.some((mention) => mention.id === candidate.id)) return;
+    selectedSqlFileMentions.value.push({ kind: "sqlFile", raw, id: candidate.id, name: candidate.name });
+    return;
+  }
   const raw = formatAiTableMention(candidate.schema, candidate.name);
   const key = `${candidate.schema || ""}.${candidate.name}`.toLowerCase();
   if (selectedMentions.value.some((mention) => `${mention.schema || ""}.${mention.table}`.toLowerCase() === key)) return;
   selectedMentions.value.push({ raw, schema: candidate.schema, table: candidate.name });
+}
+
+function formatMentionCandidateType(candidate: AiMentionCandidate) {
+  if (candidate.kind === "sqlFile") return candidate.folderPath || "SQL";
+  return formatMentionTableType(candidate.tableType);
+}
+
+function selectedMessageMentions(tableMentions: AiTableMention[], sqlFileMentions: AiSqlFileMention[]): AiMessageMention[] {
+  const connectionId = props.tab?.connectionId || props.connection?.id || "";
+  const database = props.tab?.database || props.connection?.database || "";
+  return [
+    ...tableMentions.map((mention) => ({
+      kind: "table" as const,
+      raw: mention.raw,
+      connectionId,
+      database,
+      schema: mention.schema,
+      table: mention.table,
+    })),
+    ...sqlFileMentions.map((mention) => ({
+      kind: "sqlFile" as const,
+      raw: mention.raw,
+      connectionId,
+      id: mention.id,
+      name: mention.name,
+    })),
+  ];
+}
+
+async function openMessageMention(mention: AiMessageMention) {
+  try {
+    if (mention.kind === "sqlFile") {
+      const file = await savedSqlStore.ensureFileContent(mention.id);
+      if (file) queryStore.openSavedSql(file);
+      return;
+    }
+    await openTableTarget({
+      connectionId: mention.connectionId || props.tab?.connectionId || props.connection?.id || "",
+      database: mention.database || props.tab?.database || props.connection?.database || "",
+      schema: mention.schema,
+      tableName: mention.table,
+    });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    toast(translateBackendError(t, message), 5000);
+  }
 }
 
 function formatMentionTableType(tableType: string) {
@@ -889,9 +1238,27 @@ function onPromptKeydown(event: KeyboardEvent) {
   }
 }
 
+async function loadReferencedSqlFiles(mentions: AiSqlFileMention[]): Promise<AiSqlFileContext[]> {
+  if (!mentions.length) return [];
+  const results: AiSqlFileContext[] = [];
+  for (const mention of mentions) {
+    const file = await savedSqlStore.ensureFileContent(mention.id).catch(() => undefined);
+    if (!file) continue;
+    const sql = file.sql || "";
+    const truncated = sql.length > AI_SQL_FILE_CONTEXT_MAX_CHARS;
+    results.push({
+      id: file.id,
+      name: file.name,
+      sql: truncated ? `${sql.slice(0, AI_SQL_FILE_CONTEXT_MAX_CHARS)}\n-- ... truncated ...` : sql,
+      truncated,
+    });
+  }
+  return results;
+}
+
 async function send() {
   const text = prompt.value.trim();
-  if ((!text && !selectedMentions.value.length) || isGenerating.value) return;
+  if ((!text && !selectedMentions.value.length && !selectedSqlFileMentions.value.length) || isGenerating.value) return;
 
   if (!props.connection || !props.tab) return;
   if (!settings.isConfigured()) {
@@ -899,20 +1266,23 @@ async function send() {
     return;
   }
 
-  const mentionedTables = [...selectedMentions.value, ...parseAiTableMentions(text)];
-  const displayText = [selectedMentions.value.map((mention) => mention.raw).join(" "), text].filter(Boolean).join(" ");
+  const selectedTableMentions = [...selectedMentions.value];
+  const selectedSqlFiles = [...selectedSqlFileMentions.value];
+  const mentionedTables = [...selectedTableMentions, ...parseAiTableMentions(text)];
+  const modelInstruction = [selectedTableMentions.map((mention) => mention.raw).join(" "), selectedSqlFiles.map((mention) => mention.raw).join(" "), text].filter(Boolean).join(" ");
 
-  messages.value.push({ role: "user", content: displayText });
+  messages.value.push({ role: "user", content: text, mentions: selectedMessageMentions(selectedTableMentions, selectedSqlFiles) });
   // Save to prompt history (deduplicate consecutive duplicates)
-  if (displayText && promptHistory.value[0] !== displayText) {
-    promptHistory.value.unshift(displayText);
+  if (text && promptHistory.value[0] !== text) {
+    promptHistory.value.unshift(text);
     if (promptHistory.value.length > 100) promptHistory.value.length = 100;
   }
   historyIndex.value = -1;
   draftBeforeHistory.value = "";
   prompt.value = "";
   selectedMentions.value = [];
-  scrollToBottom();
+  selectedSqlFileMentions.value = [];
+  scrollToBottom({ force: true });
 
   const requestedAction = activeAction.value;
   const requestedMode = assistantMode.value;
@@ -924,8 +1294,10 @@ async function send() {
   const agentEvents: AgentEvent[] = [];
   agentTokens.value = null;
   try {
+    const sqlFiles = await loadReferencedSqlFiles(selectedSqlFiles);
     const context = await buildAiContext(props.tab, props.connection, {
       mentionedTables,
+      sqlFiles,
     });
     const history: AiMessage[] = messagesForAgentHistory(messages.value.slice(0, -2));
     await runAgentStream(
@@ -933,7 +1305,7 @@ async function send() {
         config: settings.aiConfig,
         action: activeAction.value,
         mode: requestedMode,
-        instruction: displayText,
+        instruction: modelInstruction,
         context,
       },
       history,
@@ -993,7 +1365,7 @@ async function send() {
       const agentPlan = buildAiAgentPlan({
         mode: requestedMode,
         action: requestedAction,
-        instruction: displayText,
+        instruction: modelInstruction,
         assistantContent: msg?.content || "",
         connection: props.connection,
       });
@@ -1064,12 +1436,13 @@ async function persistConversation() {
   const first = messages.value.find((m) => m.role === "user" && m.kind !== "contextSummary");
   await saveAiConversation({
     id: conversationId.value,
-    title: first ? first.content.slice(0, 50) : "Untitled",
+    title: first ? messageTitle(first).slice(0, 50) : "Untitled",
     connectionName: props.connection.name,
     database: props.tab?.database || "",
     messages: messages.value.map((m) => ({
       role: m.role,
       content: m.content,
+      ...(m.mentions?.length ? { mentions: m.mentions } : {}),
       ...(m.reasoning ? { reasoning: m.reasoning } : {}),
       ...(m.kind ? { kind: m.kind } : {}),
     })),
@@ -1088,13 +1461,14 @@ function selectConversation(conv: AiConversation) {
   messages.value = conv.messages.map((m) => ({
     role: m.role as "user" | "assistant",
     content: m.content,
+    mentions: Array.isArray(m.mentions) ? (m.mentions as AiMessageMention[]) : undefined,
     reasoning: m.reasoning,
     kind: m.kind,
   }));
   agentTokens.value = null;
   pendingCompaction.value = null;
   showConversationList.value = false;
-  scrollToBottom();
+  scrollToBottom({ force: true });
 }
 
 async function deleteConversation(id: string) {
@@ -1185,6 +1559,7 @@ function stopResize() {
 onUnmounted(() => {
   clearTimeout(mentionTimer);
   cancelStream();
+  detachMessageScrollListener();
   // 清理拖拽事件监听，防止内存泄漏
   document.removeEventListener("mousemove", handleResize);
   document.removeEventListener("mouseup", stopResize);
@@ -1282,133 +1657,174 @@ async function openExternalUrl(url: string) {
       <Bot class="h-10 w-10 mb-3 opacity-30" />
       <p class="text-sm">{{ t("ai.welcome") }}</p>
     </div>
-    <ScrollArea v-else ref="scrollRef" class="min-h-0 flex-1 overflow-hidden">
-      <div class="flex flex-col gap-3 p-3">
-        <template v-for="(msg, i) in visibleMessages" :key="i">
-          <div v-if="msg.role === 'user'" class="group flex justify-end">
-            <div class="max-w-[85%]">
-              <template v-if="editingMessageIndex === i">
-                <textarea
-                  data-edit-textarea
-                  v-model="editingContent"
-                  rows="3"
-                  class="w-full resize-none rounded-lg border bg-background px-3 py-2 text-xs outline-none focus:ring-1 focus:ring-primary"
-                  @keydown="onEditKeydown($event, i)"
-                  @compositionstart="editCompositionActive = true"
-                  @compositionend="editCompositionActive = false"
-                />
-                <div class="mt-1.5 flex justify-end gap-1.5">
-                  <Button size="sm" variant="ghost" class="h-6 px-2 text-[11px]" @click="cancelEdit">{{ t("ai.editCancel") }}</Button>
-                  <Button size="sm" class="h-6 px-2 text-[11px]" @click="submitEdit(i)">{{ t("ai.editResend") }}</Button>
-                </div>
-              </template>
-              <template v-else>
-                <div class="flex items-start gap-1">
-                  <button v-if="!isGenerating" class="mt-1 hidden h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground group-hover:flex" :title="t('ai.editMessage')" @click="startEditMessage(i)">
-                    <Pencil class="h-3 w-3" />
-                  </button>
-                  <div class="whitespace-pre-wrap rounded-lg bg-primary px-3 py-2 text-xs text-primary-foreground">
-                    {{ msg.content }}
+    <div v-else class="relative min-h-0 flex-1">
+      <ScrollArea ref="scrollRef" class="ai-message-scroll h-full overflow-hidden">
+        <div class="flex flex-col gap-3 p-3">
+          <template v-for="(msg, i) in visibleMessages" :key="i">
+            <div v-if="msg.role === 'user'" class="group flex justify-end">
+              <div class="max-w-[85%]">
+                <template v-if="editingMessageIndex === i">
+                  <div v-if="editingMentions.length" class="mb-1.5 flex flex-wrap justify-end gap-1">
+                    <button
+                      v-for="(mention, mentionIndex) in editingMentions"
+                      :key="`${mention.kind}:${mention.raw}:${mentionIndex}`"
+                      type="button"
+                      class="group inline-flex max-w-full items-center gap-1 rounded border border-border/80 bg-muted/70 px-1.5 py-0.5 text-[11px] text-foreground/90 hover:bg-muted"
+                      :title="mentionDisplayName(mention)"
+                      @click="removeEditingMentionChip(mentionIndex)"
+                    >
+                      <FileCode v-if="mention.kind === 'sqlFile'" class="h-3 w-3 shrink-0 text-primary" />
+                      <Table2 v-else class="h-3 w-3 shrink-0 text-primary" />
+                      <span class="truncate">{{ mentionDisplayName(mention) }}</span>
+                      <X class="h-3 w-3 shrink-0 text-muted-foreground group-hover:text-foreground" />
+                    </button>
                   </div>
-                </div>
-              </template>
-            </div>
-          </div>
-
-          <div v-else-if="msg.content || msg.reasoning || msg.isThinking" class="flex">
-            <div class="max-w-[95%] min-w-0 rounded-lg bg-muted px-3 py-2 text-xs leading-relaxed">
-              <div v-if="msg.reasoning || msg.isThinking" class="mb-2">
-                <button class="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors" @click="toggleReasoning()">
-                  <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': reasoningExpanded }" />
-                  <Loader2 v-if="msg.isThinking" class="h-3 w-3 animate-spin" />
-                  <span>{{ t("ai.reasoningProcess") }}</span>
-                </button>
-                <div
-                  class="overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out"
-                  :style="{
-                    maxHeight: reasoningExpanded ? '20000px' : '0px',
-                    opacity: reasoningExpanded ? '1' : '0',
-                  }"
-                >
-                  <div class="mt-1.5 pl-4 border-l-2 border-muted-foreground/20 text-[11px] text-muted-foreground whitespace-pre-wrap">
-                    {{ msg.reasoning }}
+                  <textarea
+                    data-edit-textarea
+                    v-model="editingContent"
+                    rows="3"
+                    class="w-full resize-none rounded-lg border bg-background px-3 py-2 text-xs outline-none focus:ring-1 focus:ring-primary"
+                    @keydown="onEditKeydown($event, i)"
+                    @compositionstart="editCompositionActive = true"
+                    @compositionend="editCompositionActive = false"
+                  />
+                  <div class="mt-1.5 flex justify-end gap-1.5">
+                    <Button size="sm" variant="ghost" class="h-6 px-2 text-[11px]" @click="cancelEdit">{{ t("ai.editCancel") }}</Button>
+                    <Button size="sm" class="h-6 px-2 text-[11px]" @click="submitEdit(i)">{{ t("ai.editResend") }}</Button>
                   </div>
-                </div>
-              </div>
-              <div v-if="msg.agentSteps?.length" class="mb-2 space-y-1">
-                <div v-for="step in msg.agentSteps" :key="step.key" class="rounded border text-[10px]" :class="agentStepClass(step.tone)">
-                  <button class="flex w-full items-center gap-1 px-2 py-1.5 text-left" @click="step.toolResult || step.toolArgs?.sql ? toggleStep(step.key) : undefined">
-                    <component :is="agentStepIcon(step.tone)" class="h-3 w-3 shrink-0" />
-                    <span class="font-medium">{{ t(step.labelKey) }}</span>
-                    <span v-if="step.toolName" class="text-muted-foreground">: {{ step.toolName }}</span>
-                    <ChevronRight v-if="step.toolResult || step.toolArgs?.sql" class="ml-auto h-3 w-3 shrink-0 transition-transform duration-150" :class="{ 'rotate-90': expandedSteps.has(step.key) }" />
-                  </button>
-                  <div v-if="expandedSteps.has(step.key)" class="border-t border-current/10 px-2 pb-2 pt-1">
-                    <div v-if="step.toolArgs?.sql" class="mb-1 rounded bg-background/50 px-2 py-1 font-mono text-[10px] text-foreground/80 whitespace-pre-wrap">{{ step.toolArgs.sql }}</div>
-                    <Button v-if="step.toolName === 'explain_query' && step.toolArgs?.sql" size="sm" variant="outline" class="mb-1 h-6 gap-1 text-[10px]" @click="emit('openExplainPlan', step.toolArgs.sql as string)">
-                      <GitBranch class="h-3 w-3" />
-                      {{ t("explain.title") }}
-                    </Button>
-                    <div v-if="step.toolName === 'explain_query' && step.explainData && connection?.db_type" class="mb-1">
-                      <ExplainPlanViewer :plan="parseExplainFromData(step.explainData, connection.db_type)" class="max-h-64" />
-                    </div>
-                    <div v-else-if="step.isError && step.toolResult" class="text-[10px] text-red-600 dark:text-red-400">{{ step.toolResult }}</div>
-                    <div v-else-if="step.toolResult" class="max-h-48 overflow-auto text-[10px] text-muted-foreground whitespace-pre-wrap">{{ step.toolResult }}</div>
-                  </div>
-                </div>
-              </div>
-              <template v-for="(seg, j) in messageRenderer.render(msg.content)" :key="j">
-                <div v-if="seg.type === 'text'" class="ai-markdown whitespace-normal" @click.capture="onMarkdownClick">
-                  <div v-html="seg.html" />
-                </div>
-                <div v-else class="my-2 overflow-hidden rounded-md border border-zinc-200 bg-zinc-50 dark:border-zinc-700/50 dark:bg-zinc-900">
-                  <div class="flex items-center border-b border-zinc-200 px-3 py-1.5 text-[10px] font-medium text-zinc-600 dark:border-zinc-700/50 dark:text-zinc-400">
-                    <component :is="seg.isSql ? Database : Terminal" class="h-3 w-3 mr-1.5" />
-                    <span>{{ seg.lang }}</span>
-                    <span class="flex-1" />
-                    <div class="flex items-center gap-1.5">
-                      <button v-if="seg.isSql" class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.executeSql')" @click="executeSql(seg.content)">
-                        <Play class="h-3.5 w-3.5" />
-                      </button>
-                      <button v-if="seg.isSql" class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.apply')" @click="applySql(seg.content)">
-                        <Replace class="h-3.5 w-3.5" />
-                      </button>
-                      <button
-                        class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
-                        :title="copiedIndex === `${i}-${j}` ? t('ai.copied') : t(seg.isSql ? 'ai.copySql' : 'ai.copyCode')"
-                        @click="copyCode(seg.content, `${i}-${j}`)"
-                      >
-                        <Check v-if="copiedIndex === `${i}-${j}`" class="h-3.5 w-3.5 text-green-400" />
-                        <Copy v-else class="h-3.5 w-3.5" />
-                      </button>
+                </template>
+                <template v-else>
+                  <div class="flex items-start gap-1">
+                    <button v-if="!isGenerating" class="mt-1 hidden h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground group-hover:flex" :title="t('ai.editMessage')" @click="startEditMessage(i)">
+                      <Pencil class="h-3 w-3" />
+                    </button>
+                    <div class="min-w-0 rounded-lg bg-primary px-3 py-2 text-xs text-primary-foreground">
+                      <div v-if="msg.mentions?.length" class="mb-1.5 flex flex-wrap justify-end gap-1">
+                        <button
+                          v-for="mention in msg.mentions"
+                          :key="`${mention.kind}:${mention.raw}`"
+                          type="button"
+                          class="inline-flex max-w-full items-center gap-1 rounded border border-primary-foreground/25 bg-primary-foreground/15 px-1.5 py-0.5 text-[11px] text-primary-foreground hover:bg-primary-foreground/25"
+                          :title="mention.kind === 'sqlFile' ? mention.name : [mention.schema, mention.table].filter(Boolean).join('.')"
+                          @click.stop="openMessageMention(mention)"
+                        >
+                          <FileCode v-if="mention.kind === 'sqlFile'" class="h-3 w-3 shrink-0" />
+                          <Table2 v-else class="h-3 w-3 shrink-0" />
+                          <span class="truncate">{{ mention.kind === "sqlFile" ? mention.name : [mention.schema, mention.table].filter(Boolean).join(".") }}</span>
+                        </button>
+                      </div>
+                      <div v-if="msg.content" class="whitespace-pre-wrap">{{ msg.content }}</div>
                     </div>
                   </div>
-                  <pre class="ai-code-block whitespace-pre-wrap break-words p-3 text-xs leading-relaxed text-zinc-900 dark:text-zinc-100"><code v-html="seg.html"></code></pre>
-                </div>
-              </template>
-              <div v-if="msg === proposalConfirmMessage" class="mt-2 flex gap-2" :title="t('ai.proposalConfirmTitle')">
-                <Button size="sm" variant="default" class="h-7 gap-1 text-[11px]" @click="sendProposalReply(true)">
-                  <Check class="h-3 w-3" />
-                  {{ t("ai.proposalConfirmYes") }}
-                </Button>
-                <Button size="sm" variant="outline" class="h-7 gap-1 text-[11px]" @click="sendProposalReply(false)">
-                  <X class="h-3 w-3" />
-                  {{ t("ai.proposalConfirmNo") }}
-                </Button>
+                </template>
               </div>
             </div>
-          </div>
-        </template>
 
-        <div v-if="isWaitingForFirstDelta" class="flex items-center gap-2 text-xs text-muted-foreground">
-          <Loader2 class="h-3.5 w-3.5 animate-spin" />
-          <span>{{ t("ai.thinking") }}</span>
+            <div v-else-if="msg.content || msg.reasoning || msg.isThinking" class="flex">
+              <div class="max-w-[95%] min-w-0 rounded-lg bg-muted px-3 py-2 text-xs leading-relaxed">
+                <div v-if="msg.reasoning || msg.isThinking" class="mb-2">
+                  <button class="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors" @click="toggleReasoning(i)">
+                    <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': expandedReasoning.has(i) || msg.isThinking }" />
+                    <Loader2 v-if="msg.isThinking" class="h-3 w-3 animate-spin" />
+                    <span>{{ t("ai.reasoningProcess") }}</span>
+                  </button>
+                  <div
+                    class="overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out"
+                    :style="{
+                      maxHeight: expandedReasoning.has(i) || msg.isThinking ? '20000px' : '0px',
+                      opacity: expandedReasoning.has(i) || msg.isThinking ? '1' : '0',
+                    }"
+                  >
+                    <div class="mt-1.5 pl-4 border-l-2 border-muted-foreground/20 text-[11px] text-muted-foreground whitespace-pre-wrap">
+                      {{ msg.reasoning }}
+                    </div>
+                  </div>
+                </div>
+                <div v-if="msg.agentSteps?.length" class="mb-2 space-y-1">
+                  <div v-for="step in msg.agentSteps" :key="step.key" class="rounded border text-[10px]" :class="agentStepClass(step.tone)">
+                    <button class="flex w-full items-center gap-1 px-2 py-1.5 text-left" @click="step.toolResult || step.toolArgs?.sql ? toggleStep(step.key) : undefined">
+                      <component :is="agentStepIcon(step.tone)" class="h-3 w-3 shrink-0" />
+                      <span class="font-medium">{{ t(step.labelKey) }}</span>
+                      <span v-if="step.toolName" class="text-muted-foreground">: {{ step.toolName }}</span>
+                      <ChevronRight v-if="step.toolResult || step.toolArgs?.sql" class="ml-auto h-3 w-3 shrink-0 transition-transform duration-150" :class="{ 'rotate-90': expandedSteps.has(step.key) }" />
+                    </button>
+                    <div v-if="expandedSteps.has(step.key)" class="border-t border-current/10 px-2 pb-2 pt-1">
+                      <div v-if="step.toolArgs?.sql" class="mb-1 rounded bg-background/50 px-2 py-1 font-mono text-[10px] text-foreground/80 whitespace-pre-wrap">{{ step.toolArgs.sql }}</div>
+                      <Button v-if="step.toolName === 'explain_query' && step.toolArgs?.sql" size="sm" variant="outline" class="mb-1 h-6 gap-1 text-[10px]" @click="emit('openExplainPlan', step.toolArgs.sql as string)">
+                        <GitBranch class="h-3 w-3" />
+                        {{ t("explain.title") }}
+                      </Button>
+                      <div v-if="step.toolName === 'explain_query' && step.explainData && connection?.db_type" class="mb-1">
+                        <ExplainPlanViewer :plan="parseExplainFromData(step.explainData, connection.db_type)" class="max-h-64" />
+                      </div>
+                      <div v-else-if="step.isError && step.toolResult" class="text-[10px] text-red-600 dark:text-red-400">{{ step.toolResult }}</div>
+                      <div v-else-if="step.toolResult" class="max-h-48 overflow-auto text-[10px] text-muted-foreground whitespace-pre-wrap">{{ step.toolResult }}</div>
+                    </div>
+                  </div>
+                </div>
+                <template v-for="(seg, j) in messageRenderer.render(msg.content)" :key="j">
+                  <div v-if="seg.type === 'text'" class="ai-markdown whitespace-normal" @click.capture="onMarkdownClick">
+                    <div v-html="seg.html" />
+                  </div>
+                  <div v-else class="my-2 overflow-hidden rounded-md border border-zinc-200 bg-zinc-50 dark:border-zinc-700/50 dark:bg-zinc-900">
+                    <div class="flex items-center border-b border-zinc-200 px-3 py-1.5 text-[10px] font-medium text-zinc-600 dark:border-zinc-700/50 dark:text-zinc-400">
+                      <component :is="seg.isSql ? Database : Terminal" class="h-3 w-3 mr-1.5" />
+                      <span>{{ seg.lang }}</span>
+                      <span class="flex-1" />
+                      <div class="flex items-center gap-1.5">
+                        <button v-if="seg.isSql" class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.executeSql')" @click="executeSql(seg.content)">
+                          <Play class="h-3.5 w-3.5" />
+                        </button>
+                        <button v-if="seg.isSql" class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.apply')" @click="applySql(seg.content)">
+                          <Replace class="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                          :title="copiedIndex === `${i}-${j}` ? t('ai.copied') : t(seg.isSql ? 'ai.copySql' : 'ai.copyCode')"
+                          @click="copyCode(seg.content, `${i}-${j}`)"
+                        >
+                          <Check v-if="copiedIndex === `${i}-${j}`" class="h-3.5 w-3.5 text-green-400" />
+                          <Copy v-else class="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                    <pre class="ai-code-block whitespace-pre-wrap break-words p-3 text-xs leading-relaxed text-zinc-900 dark:text-zinc-100"><code v-html="seg.html"></code></pre>
+                  </div>
+                </template>
+                <div v-if="msg === proposalConfirmMessage" class="mt-2 flex gap-2" :title="t('ai.proposalConfirmTitle')">
+                  <Button size="sm" variant="default" class="h-7 gap-1 text-[11px]" @click="sendProposalReply(true)">
+                    <Check class="h-3 w-3" />
+                    {{ t("ai.proposalConfirmYes") }}
+                  </Button>
+                  <Button size="sm" variant="outline" class="h-7 gap-1 text-[11px]" @click="sendProposalReply(false)">
+                    <X class="h-3 w-3" />
+                    {{ t("ai.proposalConfirmNo") }}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <div v-if="isWaitingForFirstDelta" class="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 class="h-3.5 w-3.5 animate-spin" />
+            <span>{{ t("ai.thinking") }}</span>
+          </div>
+          <div v-if="agentTokens && !isGenerating" class="flex items-center gap-1 text-[10px] text-muted-foreground px-2 pb-1">
+            <span>&#8593;{{ agentTokens.input.toLocaleString() }} &#8595;{{ agentTokens.output.toLocaleString() }} tokens</span>
+          </div>
         </div>
-        <div v-if="agentTokens && !isGenerating" class="flex items-center gap-1 text-[10px] text-muted-foreground px-2 pb-1">
-          <span>&#8593;{{ agentTokens.input.toLocaleString() }} &#8595;{{ agentTokens.output.toLocaleString() }} tokens</span>
-        </div>
-      </div>
-    </ScrollArea>
+      </ScrollArea>
+      <button
+        v-if="showScrollToBottom"
+        type="button"
+        class="absolute bottom-3 right-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full border bg-background/95 text-foreground shadow-md backdrop-blur hover:bg-muted"
+        :title="t('ai.scrollToBottom')"
+        @click="scrollToBottom({ force: true })"
+      >
+        <ArrowDown class="h-4 w-4" />
+        <span class="sr-only">{{ t("ai.scrollToBottom") }}</span>
+      </button>
+    </div>
 
     <div class="p-2">
       <div ref="promptPanelRef" class="relative rounded-[6px] border bg-background">
@@ -1476,7 +1892,7 @@ async function openExternalUrl(url: string) {
             <div v-else ref="mentionListRef" class="max-h-56 overflow-auto p-1">
               <button
                 v-for="(candidate, index) in mentionCandidates"
-                :key="`${candidate.schema || ''}.${candidate.name}`"
+                :key="candidate.kind === 'sqlFile' ? `sql-file:${candidate.id}` : `table:${candidate.schema || ''}.${candidate.name}`"
                 type="button"
                 :data-mention-index="index"
                 class="flex w-full min-w-0 items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-muted"
@@ -1484,11 +1900,12 @@ async function openExternalUrl(url: string) {
                 @mousedown.prevent="insertMention(candidate)"
                 @mouseenter="setMentionSelectedIndex(index, false)"
               >
-                <Table2 class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <FileCode v-if="candidate.kind === 'sqlFile'" class="h-3.5 w-3.5 shrink-0 text-primary" />
+                <Table2 v-else class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 <span class="min-w-0 flex-1 truncate">
-                  <template v-if="candidate.schema">{{ candidate.schema }}.</template>{{ candidate.name }}
+                  {{ mentionCandidateName(candidate) }}
                 </span>
-                <span class="shrink-0 text-[10px] text-muted-foreground">{{ formatMentionTableType(candidate.tableType) }}</span>
+                <span class="max-w-[45%] shrink-0 truncate text-[10px] text-muted-foreground">{{ formatMentionCandidateType(candidate) }}</span>
               </button>
             </div>
           </div>
@@ -1501,7 +1918,8 @@ async function openExternalUrl(url: string) {
               :title="mentionDisplayName(mention)"
               @click="removeMentionChip(mention)"
             >
-              <Table2 class="h-3 w-3 shrink-0 text-primary" />
+              <FileCode v-if="mention.kind === 'sqlFile'" class="h-3 w-3 shrink-0 text-primary" />
+              <Table2 v-else class="h-3 w-3 shrink-0 text-primary" />
               <span class="truncate">{{ mentionDisplayName(mention) }}</span>
               <X class="h-3 w-3 shrink-0 text-muted-foreground group-hover:text-foreground" />
             </button>
@@ -1594,7 +2012,7 @@ async function openExternalUrl(url: string) {
             <button v-if="isGenerating" class="h-7 w-7 shrink-0 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center" :title="t('ai.stopGenerating')" @click="cancelStream">
               <Square class="h-3.5 w-3.5" />
             </button>
-            <button v-else class="h-7 w-7 shrink-0 rounded-full bg-foreground text-background flex items-center justify-center disabled:opacity-30" :disabled="!prompt.trim() || !props.tab?.database" @click="send">
+            <button v-else class="h-7 w-7 shrink-0 rounded-full bg-foreground text-background flex items-center justify-center disabled:opacity-30" :disabled="(!prompt.trim() && !selectedMentions.length && !selectedSqlFileMentions.length) || !props.tab?.database" @click="send">
               <ArrowUp class="h-4 w-4" />
             </button>
           </div>
@@ -1703,6 +2121,10 @@ async function openExternalUrl(url: string) {
 }
 .ai-code-block :deep(.line) {
   min-height: 1lh;
+}
+
+.ai-message-scroll :deep([data-slot="scroll-area-viewport"]) {
+  overflow-anchor: none;
 }
 
 .resize-handle {

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1205,8 +1205,9 @@ export default {
     thinking: "Thinking...",
     reasoningProcess: "Thinking process",
     stopGenerating: "Stop generating",
-    tableMentionEmpty: "No matching tables",
-    tableMentionPlaceholderHint: "Type {'@'} to mention tables for context",
+    scrollToBottom: "Back to bottom",
+    tableMentionEmpty: "No matching tables or SQL files",
+    tableMentionPlaceholderHint: "Type {'@'} to mention tables or SQL files for context",
     tableMentionTypes: {
       table: "Table",
       view: "View",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1178,8 +1178,9 @@ export default withEnglishFallback({
     thinking: "Procesando...",
     reasoningProcess: "Proceso de razonamiento",
     stopGenerating: "Detener generación",
-    tableMentionEmpty: "Sin tablas coincidentes",
-    tableMentionPlaceholderHint: "Escribe {'@'} para mencionar tablas como contexto",
+    scrollToBottom: "Volver al final",
+    tableMentionEmpty: "Sin tablas ni archivos SQL coincidentes",
+    tableMentionPlaceholderHint: "Escribe {'@'} para mencionar tablas o archivos SQL como contexto",
     tableMentionTypes: {
       table: "Tabla",
       view: "Vista",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1159,8 +1159,9 @@ export default withEnglishFallback({
     thinking: "Riflessione...",
     reasoningProcess: "Processo di riflessione",
     stopGenerating: "Interrompi generazione",
-    tableMentionEmpty: "Nessuna tabella corrispondente",
-    tableMentionPlaceholderHint: "Digita {'@'} per menzionare le tabelle per il contesto",
+    scrollToBottom: "Torna in fondo",
+    tableMentionEmpty: "Nessuna tabella o file SQL corrispondente",
+    tableMentionPlaceholderHint: "Digita {'@'} per menzionare tabelle o file SQL per il contesto",
     tableMentionTypes: {
       table: "Tabella",
       view: "Vista",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1181,8 +1181,9 @@ export default withEnglishFallback({
     thinking: "思考中...",
     reasoningProcess: "思考プロセス",
     stopGenerating: "生成を停止",
-    tableMentionEmpty: "一致するテーブルがありません",
-    tableMentionPlaceholderHint: "{'@'}を入力してコンテキスト用のテーブルを指定",
+    scrollToBottom: "一番下へ戻る",
+    tableMentionEmpty: "一致するテーブルまたは SQL ファイルがありません",
+    tableMentionPlaceholderHint: "{'@'}を入力してコンテキスト用のテーブルまたは SQL ファイルを指定",
     tableMentionTypes: {
       table: "テーブル",
       view: "ビュー",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1179,8 +1179,9 @@ export default withEnglishFallback({
     thinking: "Pensando...",
     reasoningProcess: "Processo de raciocínio",
     stopGenerating: "Parar geração",
-    tableMentionEmpty: "Nenhuma tabela correspondente",
-    tableMentionPlaceholderHint: "Digite {'@'} para mencionar tabelas como contexto",
+    scrollToBottom: "Voltar ao fim",
+    tableMentionEmpty: "Nenhuma tabela ou arquivo SQL correspondente",
+    tableMentionPlaceholderHint: "Digite {'@'} para mencionar tabelas ou arquivos SQL como contexto",
     tableMentionTypes: {
       table: "Tabela",
       view: "Visão",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1207,8 +1207,9 @@ export default withEnglishFallback({
     thinking: "思考中...",
     reasoningProcess: "思考过程",
     stopGenerating: "停止生成",
-    tableMentionEmpty: "没有匹配的表",
-    tableMentionPlaceholderHint: "输入 {'@'} 可选择表并带入上下文",
+    scrollToBottom: "回到底部",
+    tableMentionEmpty: "没有匹配的表或 SQL 文件",
+    tableMentionPlaceholderHint: "输入 {'@'} 可选择表或 SQL 文件并带入上下文",
     tableMentionTypes: {
       table: "表",
       view: "视图",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1160,8 +1160,9 @@ export default withEnglishFallback({
     thinking: "思考中……",
     reasoningProcess: "思考過程",
     stopGenerating: "停止產生",
-    tableMentionEmpty: "沒有相符的資料表",
-    tableMentionPlaceholderHint: "輸入 {'@'} 可提及資料表作為脈絡",
+    scrollToBottom: "回到底部",
+    tableMentionEmpty: "沒有相符的資料表或 SQL 檔案",
+    tableMentionPlaceholderHint: "輸入 {'@'} 可提及資料表或 SQL 檔案作為脈絡",
     tableMentionTypes: {
       table: "資料表",
       view: "檢視",

--- a/apps/desktop/src/lib/__tests__/ai/ai.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai/ai.spec.ts
@@ -10,6 +10,7 @@ function context(overrides: Partial<AiContext> = {}): AiContext {
     database: "app",
     currentSql: "",
     tables: [],
+    sqlFiles: [],
     truncated: false,
     ...overrides,
   };

--- a/apps/desktop/src/lib/ai/ai.ts
+++ b/apps/desktop/src/lib/ai/ai.ts
@@ -66,6 +66,13 @@ export interface AiSchemaTable {
   foreignKeys?: ForeignKeyInfo[];
 }
 
+export interface AiSqlFileContext {
+  id: string;
+  name: string;
+  sql: string;
+  truncated?: boolean;
+}
+
 export interface AiContext {
   connectionId: string;
   connectionName: string;
@@ -75,6 +82,7 @@ export interface AiContext {
   lastError?: string;
   lastResultPreview?: string;
   tables: AiSchemaTable[];
+  sqlFiles: AiSqlFileContext[];
   schemaScope?: "focused_table" | "database";
   truncated: boolean;
 }
@@ -196,6 +204,7 @@ export function buildSystemPrompt(action: AiAction, context: AiContext, mode: Ai
   const schema = formatSchema(context);
   const resultPreview = context.lastResultPreview ? `\nLast result preview:\n${context.lastResultPreview}\n` : "";
   const lastError = context.lastError ? `\nLast error:\n${context.lastError}\n` : "";
+  const referencedSqlFiles = formatReferencedSqlFiles(context);
   const schemaScope = context.schemaScope ?? "database";
 
   const isZh = isChineseLocale(currentLocale());
@@ -225,6 +234,7 @@ export function buildSystemPrompt(action: AiAction, context: AiContext, mode: Ai
     schemaCoverageLine(context, isZh),
     "",
     `Current SQL:\n${context.currentSql.trim() || "(empty)"}`,
+    referencedSqlFiles,
     lastError,
     resultPreview,
     `Schema:\n${schema}`,
@@ -251,6 +261,7 @@ function buildBasePromptLines(isZh: boolean): string[] {
     isZh ? "当用户要求分析或查看某个表时，生成 SELECT 查询获取数据，而不是查询元数据。" : "When the user asks to 'analyze' or 'look at' a table, generate a SELECT query to retrieve data, not a metadata query.",
     isZh ? "不要编造 Schema 中不存在的表或列。" : "Never invent tables or columns that are not in the schema context.",
     isZh ? "用户输入中的 @schema.table 或 @table 表示用户明确提到的表；这些表已优先放入 Schema 上下文。" : "User input may contain @schema.table or @table mentions. Treat them as explicit table references; mentioned tables are prioritized in the schema context.",
+    isZh ? "用户引用的 SQL 库文件是额外上下文；可参考其中的查询意图、业务过滤条件和 SQL 写法，但不要把它当作当前编辑器内容。" : "Referenced SQL library files are additional context. Use them for query intent, business filters, and SQL style, but do not treat them as the current editor content.",
     isZh ? "不要生成多语句 SQL，除非用户明确要求。不要在同一个回答里混合 SELECT 和写操作。" : "Do not generate multi-statement SQL unless the user explicitly asks for it. Do not mix SELECT statements and write operations in the same answer.",
     isZh ? "对于 DROP、DELETE、TRUNCATE、ALTER 或没有 WHERE 的 UPDATE，简要警告并优先提供安全的 SELECT 预览。" : "For destructive statements (DROP, DELETE, TRUNCATE, ALTER, UPDATE without WHERE), warn briefly and prefer a safer SELECT preview.",
     isZh ? "对于 UPDATE 或 DELETE，必须带 WHERE 并说明影响范围；生产库写操作只给建议，不主动建议执行。" : "For UPDATE or DELETE, require a WHERE clause and explain the affected scope; for production writes, provide guidance but do not proactively suggest execution.",
@@ -263,6 +274,7 @@ function buildVectorSystemPrompt(context: AiContext, mode: AiAssistantMode): str
   const schema = formatSchema(context);
   const resultPreview = context.lastResultPreview ? `\nLast result preview:\n${context.lastResultPreview}\n` : "";
   const lastError = context.lastError ? `\nLast error:\n${context.lastError}\n` : "";
+  const referencedSqlFiles = formatReferencedSqlFiles(context);
   const lines: string[] = [
     isZh ? `你是 DBX 内置的向量数据库助手。当前连接的是 ${dbLabel(context.databaseType)} 数据库。用中文回复。` : `You are DBX's vector database assistant. Connected to ${dbLabel(context.databaseType)}. Reply in English.`,
     isZh ? "数据存储在集合（collections）中，每条记录包含唯一标识及可选的元数据负载（payload/metadata）。" : "Data is stored in collections. Each record has a unique identifier and optional metadata payload.",
@@ -274,6 +286,7 @@ function buildVectorSystemPrompt(context: AiContext, mode: AiAssistantMode): str
     schemaCoverageLine(context, isZh),
     "",
     `Current collection:\n${context.currentSql.trim() || "(none)"}`,
+    referencedSqlFiles,
     lastError,
     resultPreview,
     "",
@@ -369,7 +382,20 @@ function formatSchema(context: AiContext): string {
     .join("\n\n");
 }
 
-export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig, options: { maxTables?: number; maxColumnsPerTable?: number; maxIndexesPerTable?: number; maxFksPerTable?: number; mentionedTables?: AiTableMention[] } = {}): Promise<AiContext> {
+function formatReferencedSqlFiles(context: AiContext): string {
+  if (!context.sqlFiles.length) return "";
+
+  return [
+    "Referenced SQL library files:",
+    ...context.sqlFiles.map((file) => {
+      const sql = file.sql.trim() || "(empty)";
+      const suffix = file.truncated ? " (truncated)" : "";
+      return `File: ${file.name}${suffix}\nSQL:\n${sql}`;
+    }),
+  ].join("\n\n");
+}
+
+export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig, options: { maxTables?: number; maxColumnsPerTable?: number; maxIndexesPerTable?: number; maxFksPerTable?: number; mentionedTables?: AiTableMention[]; sqlFiles?: AiSqlFileContext[] } = {}): Promise<AiContext> {
   const maxTables = options.maxTables ?? 50;
   const maxColumnsPerTable = options.maxColumnsPerTable ?? 40;
   const maxIndexesPerTable = options.maxIndexesPerTable ?? 10;
@@ -496,6 +522,7 @@ export async function buildAiContext(tab: QueryTab, connection: ConnectionConfig
     lastError: extractLastError(tab.result),
     lastResultPreview: formatResultPreview(tab.result),
     tables,
+    sqlFiles: options.sqlFiles ?? [],
     schemaScope,
     truncated,
   };

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -538,6 +538,7 @@ export async function listSqlFilesInFolder(folderPath: string): Promise<SqlFileE
 export interface AiChatMessage {
   role: string;
   content: string;
+  mentions?: unknown[];
   reasoning?: string;
   kind?: "contextSummary";
 }

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -194,6 +194,8 @@ pub struct AiChatMessage {
     pub role: String,
     pub content: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mentions: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,

--- a/packages/app-tests/aiPrompt.test.ts
+++ b/packages/app-tests/aiPrompt.test.ts
@@ -34,6 +34,7 @@ const { buildSystemPrompt, isVectorDbType, buildUserPrompt } = await import("../
 
 function context(overrides: Partial<AiContext> = {}): AiContext {
   return {
+    connectionId: "conn-1",
     connectionName: "prod-analytics",
     databaseType: "postgres",
     database: "app",
@@ -52,6 +53,7 @@ function context(overrides: Partial<AiContext> = {}): AiContext {
         foreignKeys: [{ column: "user_id", ref_table: "users", ref_column: "id" }],
       },
     ],
+    sqlFiles: [],
     truncated: false,
     ...overrides,
   };
@@ -99,10 +101,32 @@ test("prompt enforces database dialect and single executable statement safety", 
   assert.match(prompt, /不要在同一个回答里混合 SELECT 和写操作/);
 });
 
+test("prompt includes referenced SQL library files as additional context", () => {
+  const prompt = buildSystemPrompt(
+    "generate",
+    context({
+      sqlFiles: [
+        {
+          id: "sql-1",
+          name: "monthly-orders.sql",
+          sql: "select date_trunc('month', created_at) as month, count(*) from public.orders group by 1",
+        },
+      ],
+    }),
+    "ask",
+  );
+
+  assert.match(prompt, /SQL 库文件是额外上下文/);
+  assert.match(prompt, /Referenced SQL library files:/);
+  assert.match(prompt, /File: monthly-orders\.sql/);
+  assert.match(prompt, /date_trunc\('month', created_at\)/);
+});
+
 // Vector database tests
 
 function vectorContext(overrides: Partial<AiContext> = {}): AiContext {
   return {
+    connectionId: "conn-1",
     connectionName: "my-qdrant",
     databaseType: "qdrant",
     database: "default",
@@ -115,6 +139,7 @@ function vectorContext(overrides: Partial<AiContext> = {}): AiContext {
         columns: [],
       },
     ],
+    sqlFiles: [],
     truncated: false,
     ...overrides,
   };

--- a/packages/app-tests/aiPromptEval.test.ts
+++ b/packages/app-tests/aiPromptEval.test.ts
@@ -34,6 +34,7 @@ const { buildSystemPrompt } = await import("../../apps/desktop/src/lib/ai/ai.ts"
 
 function baseContext(overrides: Partial<AiContext> = {}): AiContext {
   return {
+    connectionId: "conn-1",
     connectionName: "prod-analytics",
     databaseType: "postgres",
     database: "warehouse",
@@ -67,6 +68,7 @@ function baseContext(overrides: Partial<AiContext> = {}): AiContext {
         ],
       },
     ],
+    sqlFiles: [],
     truncated: false,
     ...overrides,
   };

--- a/packages/app-tests/aiSchemaComments.test.ts
+++ b/packages/app-tests/aiSchemaComments.test.ts
@@ -4,6 +4,7 @@ import { test } from "vitest";
 import { buildSystemPrompt, type AiContext } from "../../apps/desktop/src/lib/ai/ai.ts";
 
 const BASE_CONTEXT: AiContext = {
+  connectionId: "conn-1",
   connectionName: "local",
   databaseType: "mysql",
   database: "app",
@@ -35,6 +36,7 @@ const BASE_CONTEXT: AiContext = {
       ],
     },
   ],
+  sqlFiles: [],
   truncated: false,
 };
 


### PR DESCRIPTION
## 变更内容
- AI 对话 `@` 引用支持 SQL 库文件，并将文件内容作为额外上下文传给模型
- 引用内容在消息中以高亮块展示，可点击跳转，重新编辑消息时可整块删除
- 优化流式输出时的滚动行为，用户上滑后显示回到底部按钮，避免按钮在底部附近反复闪烁

## 验证
- `pnpm exec oxlint apps/desktop/src/components/editor/AiAssistant.vue`
- `pnpm typecheck`
- `cargo check -p dbx-core -p dbx-web`
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/ai/ai.spec.ts packages/app-tests/aiPrompt.test.ts packages/app-tests/aiPromptEval.test.ts packages/app-tests/aiSchemaComments.test.ts`

Fixes #2738
