### PR TITLE
fix(ai): make reasoning expand/collapse consistent across messages

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -511,7 +511,7 @@ function appendAssistantReasoning(assistantIdx: number, delta: string) {
   scrollToBottom();
 }
 
-const expandedReasoning = ref<Set<number>>(new Set());
+const reasoningExpanded = ref(false);
 const expandedSteps = ref<Set<string>>(new Set());
 
 function toggleStep(key: string) {
@@ -626,14 +626,8 @@ function agentEventToStep(event: AgentEvent, index: number): AiAgentStepItem | u
   };
 }
 
-function toggleReasoning(index: number) {
-  const next = new Set(expandedReasoning.value);
-  if (next.has(index)) {
-    next.delete(index);
-  } else {
-    next.add(index);
-  }
-  expandedReasoning.value = next;
+function toggleReasoning() {
+  reasoningExpanded.value = !reasoningExpanded.value;
 }
 
 function scrollToBottom() {
@@ -1324,16 +1318,16 @@ async function openExternalUrl(url: string) {
           <div v-else-if="msg.content || msg.reasoning || msg.isThinking" class="flex">
             <div class="max-w-[95%] min-w-0 rounded-lg bg-muted px-3 py-2 text-xs leading-relaxed">
               <div v-if="msg.reasoning || msg.isThinking" class="mb-2">
-                <button class="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors" @click="toggleReasoning(i)">
-                  <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': expandedReasoning.has(i) || msg.isThinking }" />
+                <button class="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors" @click="toggleReasoning()">
+                  <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': reasoningExpanded }" />
                   <Loader2 v-if="msg.isThinking" class="h-3 w-3 animate-spin" />
                   <span>{{ t("ai.reasoningProcess") }}</span>
                 </button>
                 <div
                   class="overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out"
                   :style="{
-                    maxHeight: expandedReasoning.has(i) || msg.isThinking ? '20000px' : '0px',
-                    opacity: expandedReasoning.has(i) || msg.isThinking ? '1' : '0',
+                    maxHeight: reasoningExpanded ? '20000px' : '0px',
+                    opacity: reasoningExpanded ? '1' : '0',
                   }"
                 >
                   <div class="mt-1.5 pl-4 border-l-2 border-muted-foreground/20 text-[11px] text-muted-foreground whitespace-pre-wrap">


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

The AI assistant's reasoning panel had inconsistent expand/collapse behavior: it auto-expanded during streaming (when isThinking was true) and auto-collapsed after the stream ended, requiring users to repeatedly toggle it for every new message.

Change

Replaced the per-message expandedReasoning: Set<number> with a single global reasoningExpanded: boolean ref. The toggle now affects all messages uniformly — both past and future — so the user sets it once and it stays. Defaults to collapsed.

Before

- Each message tracked its own expand state independently
- Streaming forced auto-expand (|| msg.isThinking), then collapsed after
- Inconsistent: users had to re-toggle every new message

After

- Single global toggle shared by all messages
- No auto-expand/auto-collapse — purely user-controlled
- Default collapsed (user clicks to expand when they want to see the reasoning)
- Consistent behavior across the entire conversation

Diff

apps/desktop/src/components/editor/AiAssistant.vue — 1 file, −13 / +7 lines

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
