### PR TITLE
Fix: 修复 SQL Server TOP 查询分页排序列绑定错误

### DIFF
--- a/crates/dbx-core/src/query_result_sql.rs
+++ b/crates/dbx-core/src/query_result_sql.rs
@@ -441,10 +441,10 @@ fn add_sql_server_existing_top_pagination(statement: &str, limit: usize, offset:
 }
 
 fn sql_server_default_pagination_order(statement: &str) -> String {
-    first_simple_sqlserver_projection(statement).unwrap_or_else(|| "(SELECT NULL)".to_string())
+    first_simple_sqlserver_projection_order_column(statement).unwrap_or_else(|| "(SELECT NULL)".to_string())
 }
 
-fn first_simple_sqlserver_projection(statement: &str) -> Option<String> {
+fn first_simple_sqlserver_projection_order_column(statement: &str) -> Option<String> {
     let sql = statement.trim();
     let sql = &sql[skip_leading_sql_comments(sql, 0)..];
     if sql.len() < 6 || !sql[..6].eq_ignore_ascii_case("SELECT") {
@@ -463,11 +463,7 @@ fn first_simple_sqlserver_projection(statement: &str) -> Option<String> {
     let projection_start = skip_sql_whitespace(sql, index);
     let projection_end = find_first_projection_end(sql, projection_start)?;
     let projection = sql[projection_start..projection_end].trim();
-    if is_simple_sqlserver_order_projection(projection) {
-        Some(projection.to_string())
-    } else {
-        None
-    }
+    sql_server_derived_order_column_from_projection(projection)
 }
 
 fn skip_leading_sql_comments(sql: &str, mut index: usize) -> usize {
@@ -605,6 +601,37 @@ fn is_simple_sqlserver_order_projection(projection: &str) -> bool {
         return false;
     }
     saw_part && !expect_part
+}
+
+fn sql_server_derived_order_column_from_projection(projection: &str) -> Option<String> {
+    if !is_simple_sqlserver_order_projection(projection) {
+        return None;
+    }
+
+    let last_part = last_sqlserver_identifier_part(projection);
+    if last_part.starts_with('[') {
+        return Some(last_part.to_string());
+    }
+    Some(quote_table_identifier(Some(DatabaseType::SqlServer), last_part))
+}
+
+fn last_sqlserver_identifier_part(projection: &str) -> &str {
+    let mut last_start = 0;
+    let mut index = 0;
+    while index < projection.len() {
+        let ch = next_char(projection, index);
+        if ch == '[' {
+            index = skip_sql_bracket_identifier(projection, index);
+            continue;
+        }
+        if ch == '.' {
+            last_start = index + 1;
+            index += 1;
+            continue;
+        }
+        index += ch.len_utf8();
+    }
+    projection[last_start..].trim()
 }
 
 fn skip_sql_whitespace(sql: &str, mut index: usize) -> usize {
@@ -1427,6 +1454,50 @@ mod tests {
         assert_eq!(
             second_page.sql.unwrap(),
             "SELECT * FROM (SELECT dbx_page_source.*, ROW_NUMBER() OVER (ORDER BY [id]) AS [__dbx_row_num] FROM (SELECT TOP (500) [id], [order_no], [store_id], [product_id], [customer_name], [quantity], [amount], [order_status], [created_at] FROM [sales].[orders_10k]) dbx_page_source) dbx_page WHERE [__dbx_row_num] > 100 AND [__dbx_row_num] <= 200 ORDER BY [__dbx_row_num];"
+        );
+    }
+
+    #[test]
+    fn paginates_sqlserver_top_query_with_qualified_first_projection_by_exposed_column() {
+        let sql = "select top 1  t1.FSUPPLIERID,  kh.FNAME gysnm   from  GDWORKOUT t1 join  SUPPLIER kh on t1.FSUPPLIERID=kh.FITEMID join GDWORKOUTS t2 on t1.fid=t2.fid";
+        let first_page = build_paginated_query_sql(PaginatedQuerySqlOptions {
+            original_sql: sql.to_string(),
+            database_type: Some(DatabaseType::SqlServer),
+            limit: 100,
+            offset: 0,
+        });
+        let second_page = build_paginated_query_sql(PaginatedQuerySqlOptions {
+            original_sql: sql.to_string(),
+            database_type: Some(DatabaseType::SqlServer),
+            limit: 100,
+            offset: 100,
+        });
+
+        assert!(first_page.ok);
+        assert!(second_page.ok);
+        assert_eq!(
+            first_page.sql.unwrap(),
+            "SELECT TOP (100) * FROM (select top 1  t1.FSUPPLIERID,  kh.FNAME gysnm   from  GDWORKOUT t1 join  SUPPLIER kh on t1.FSUPPLIERID=kh.FITEMID join GDWORKOUTS t2 on t1.fid=t2.fid) [dbx_page] ORDER BY [FSUPPLIERID];"
+        );
+        assert_eq!(
+            second_page.sql.unwrap(),
+            "SELECT * FROM (SELECT dbx_page_source.*, ROW_NUMBER() OVER (ORDER BY [FSUPPLIERID]) AS [__dbx_row_num] FROM (select top 1  t1.FSUPPLIERID,  kh.FNAME gysnm   from  GDWORKOUT t1 join  SUPPLIER kh on t1.FSUPPLIERID=kh.FITEMID join GDWORKOUTS t2 on t1.fid=t2.fid) dbx_page_source) dbx_page WHERE [__dbx_row_num] > 100 AND [__dbx_row_num] <= 200 ORDER BY [__dbx_row_num];"
+        );
+    }
+
+    #[test]
+    fn paginates_sqlserver_top_query_with_dotted_bracket_identifier() {
+        let result = build_paginated_query_sql(PaginatedQuerySqlOptions {
+            original_sql: "SELECT TOP 1000 [order.id] FROM TicketInfo".to_string(),
+            database_type: Some(DatabaseType::SqlServer),
+            limit: 100,
+            offset: 0,
+        });
+
+        assert!(result.ok);
+        assert_eq!(
+            result.sql.unwrap(),
+            "SELECT TOP (100) * FROM (SELECT TOP 1000 [order.id] FROM TicketInfo) [dbx_page] ORDER BY [order.id];"
         );
     }
 


### PR DESCRIPTION
## 变更
- 修复 SQL Server `SELECT TOP` 查询被分页包装后，外层 `ORDER BY` 继续引用内层表别名导致无法执行的问题。
- 将默认分页排序列转换为派生表实际暴露的列名，并保留 SQL Server 方括号标识符。
- 增加 `TOP + JOIN + qualified projection` 和括号标识符包含点号的回归测试。

## 验证
- `cargo fmt`
- `cargo test -p dbx-core query_result_sql --lib`
- 使用 macmini-sqlserver-demo 手动验证修复后的 TOP 分页 SQL 可执行。