### PR TITLE
fix(jdbc): recover primary keys via catalog fallback

### DIFF
--- a/agents/common/src/main/java/com/dbx/agent/StandardJdbcMetadata.java
+++ b/agents/common/src/main/java/com/dbx/agent/StandardJdbcMetadata.java
@@ -168,7 +168,11 @@ public final class StandardJdbcMetadata {
             Set<String> primaryKeys = primaryKeys(meta, null, schema, table);
             List<ColumnInfo> result = new ArrayList<>();
             appendColumns(result, meta, null, schema, table, primaryKeys);
-            if (result.isEmpty() && profile.getCatalogFallbackEnabled() && !configuredDatabase.trim().isEmpty()) {
+            if (!result.isEmpty() && primaryKeys.isEmpty() && profile.getCatalogFallbackEnabled() && hasConfiguredDatabase(configuredDatabase)) {
+                Set<String> fallbackPrimaryKeys = primaryKeys(meta, configuredDatabase, schema, table);
+                markPrimaryKeys(result, fallbackPrimaryKeys);
+            }
+            if (result.isEmpty() && profile.getCatalogFallbackEnabled() && hasConfiguredDatabase(configuredDatabase)) {
                 Set<String> fallbackPrimaryKeys = primaryKeys(meta, configuredDatabase, schema, table);
                 appendColumns(result, meta, configuredDatabase, schema, table, fallbackPrimaryKeys);
             }
@@ -520,6 +524,21 @@ public final class StandardJdbcMetadata {
         } catch (Exception ignored) {
         }
         return keys;
+    }
+
+    private static boolean hasConfiguredDatabase(String configuredDatabase) {
+        return configuredDatabase != null && !configuredDatabase.trim().isEmpty();
+    }
+
+    private static void markPrimaryKeys(List<ColumnInfo> columns, Set<String> primaryKeys) {
+        if (primaryKeys.isEmpty()) {
+            return;
+        }
+        for (ColumnInfo column : columns) {
+            if (primaryKeys.contains(column.getName())) {
+                column.setIs_primary_key(true);
+            }
+        }
     }
 
     private static void appendSchemas(Set<String> names, ResultSet rs) throws Exception {

--- a/agents/common/src/test/java/com/dbx/agent/StandardJdbcMetadataTest.java
+++ b/agents/common/src/test/java/com/dbx/agent/StandardJdbcMetadataTest.java
@@ -231,6 +231,64 @@ class StandardJdbcMetadataTest {
     }
 
     @Test
+    void marksPrimaryKeysFromConfiguredCatalogWhenColumnsAlreadyLoaded() {
+        Connection conn = catalogPrimaryKeyFallbackConnection(
+            "TENANTDB",
+            rows(),
+            rows(row("COLUMN_NAME", "ID")),
+            orderColumns()
+        );
+
+        List<ColumnInfo> columns = StandardJdbcMetadata.INSTANCE.getColumns(conn, profile, "TENANTDB", "APP", "ORDERS");
+
+        assertEquals("ID", columns.get(0).getName());
+        assertTrue(columns.get(0).getIs_primary_key());
+        assertFalse(columns.get(0).getIs_nullable());
+        assertEquals("NAME", columns.get(1).getName());
+        assertFalse(columns.get(1).getIs_primary_key());
+        assertEquals(Integer.valueOf(64), columns.get(1).getCharacter_maximum_length());
+    }
+
+    @Test
+    void doesNotMarkPrimaryKeysFromConfiguredCatalogWhenFallbackUnavailable() {
+        JdbcAgentProfile fallbackDisabledProfile = new JdbcAgentProfile(
+            "example.Driver",
+            "jdbc:example://{host}:{port}/{database}",
+            0,
+            false,
+            Collections.emptySet(),
+            Collections.singletonList("TABLE"),
+            "\"",
+            "SET SCHEMA",
+            false,
+            false,
+            false,
+            false
+        );
+        Connection disabledConn = catalogPrimaryKeyFallbackConnection(
+            "TENANTDB",
+            rows(),
+            rows(row("COLUMN_NAME", "ID")),
+            orderColumns()
+        );
+
+        List<ColumnInfo> disabledColumns = StandardJdbcMetadata.INSTANCE.getColumns(disabledConn, fallbackDisabledProfile, "TENANTDB", "APP", "ORDERS");
+
+        assertFalse(disabledColumns.get(0).getIs_primary_key());
+
+        Connection emptyCatalogConn = catalogPrimaryKeyFallbackConnection(
+            "TENANTDB",
+            rows(),
+            rows(row("COLUMN_NAME", "ID")),
+            orderColumns()
+        );
+
+        List<ColumnInfo> emptyCatalogColumns = StandardJdbcMetadata.INSTANCE.getColumns(emptyCatalogConn, profile, " ", "APP", "ORDERS");
+
+        assertFalse(emptyCatalogColumns.get(0).getIs_primary_key());
+    }
+
+    @Test
     void groupsIndexColumnsInOrdinalOrder() {
         Connection conn = connection(
             rows(),
@@ -488,6 +546,59 @@ class StandardJdbcMetadataTest {
                 return defaultValue(method.getReturnType());
             }
         });
+    }
+
+    private static Connection catalogPrimaryKeyFallbackConnection(
+        String fallbackCatalog,
+        ResultSet defaultPrimaryKeys,
+        ResultSet fallbackPrimaryKeys,
+        ResultSet columns
+    ) {
+        DatabaseMetaData meta = proxy(DatabaseMetaData.class, new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                String name = method.getName();
+                if ("getPrimaryKeys".equals(name)) {
+                    return fallbackCatalog.equals(args[0]) ? fallbackPrimaryKeys : defaultPrimaryKeys;
+                }
+                if ("getColumns".equals(name)) {
+                    return columns;
+                }
+                if ("getCatalogs".equals(name)) {
+                    return rows();
+                }
+                return defaultValue(method.getReturnType());
+            }
+        });
+        return proxy(Connection.class, new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                if ("getMetaData".equals(method.getName())) {
+                    return meta;
+                }
+                return defaultValue(method.getReturnType());
+            }
+        });
+    }
+
+    private static ResultSet orderColumns() {
+        return rows(row(
+            "COLUMN_NAME", "ID",
+            "TYPE_NAME", "INTEGER",
+            "NULLABLE", DatabaseMetaData.columnNoNulls,
+            "COLUMN_DEF", null,
+            "REMARKS", "identifier",
+            "COLUMN_SIZE", 10,
+            "DECIMAL_DIGITS", 0
+        ), row(
+            "COLUMN_NAME", "NAME",
+            "TYPE_NAME", "VARCHAR",
+            "NULLABLE", DatabaseMetaData.columnNullable,
+            "COLUMN_DEF", null,
+            "REMARKS", null,
+            "COLUMN_SIZE", 64,
+            "DECIMAL_DIGITS", 0
+        ));
     }
 
     private static ResultSet rows(Map<String, Object>... rows) {


### PR DESCRIPTION
## 背景

Fixes #2709。

HANA 多租户场景下，JDBC metadata 可能出现 `getColumns(null, schema, table)` 能返回列，但 `getPrimaryKeys(null, schema, table)` 返回空的情况。此前只有列为空时才会用 configured database 作为 catalog fallback，导致已有列全部被标记为非主键，表数据页判断无主键后无法双击编辑。

## 变更

- 当列已成功加载但主键集合为空时，如果 profile 允许 catalog fallback 且 configured database 非空，再用 configured database 作为 catalog 查询 primary keys。
- fallback 查到主键后只补充已有列的 `is_primary_key` 标记，不重新拉取列，也不改变列顺序和其他列属性。
- 保留原有列为空时用 configured database 重新查询列和主键的 fallback 行为。
- 补充 JDBC metadata mock 回归测试，覆盖 HANA 报告中的路径，以及禁用 fallback / configured database 为空时不应补主键的负向路径。

## 验证

已通过：

- `cd agents && ./gradlew :common:test`
- `git diff --check`
- GitHub CI `changes` / `agents` 通过

未进行真实环境测试：

- 本地没有 SAP HANA 多租户环境，因此没有进行真实 HANA 连接和表格编辑手动验证。

建议真实环境验证步骤：

1. 使用本 PR 分支构建或安装测试包，连接 SAP HANA 多租户环境。
2. 打开一个已知包含主键、且在 v0.5.48 中无法双击编辑字段的 HANA 表。
3. 进入表数据视图，确认 DBX 能加载表结构和数据。
4. 双击一列非主键字段单元格，期望单元格进入编辑状态，不再因为识别不到主键而禁用编辑。
5. 修改一个安全测试值并保存，期望更新能按主键定位到当前行并成功提交。
6. 再打开一个确实没有主键的 HANA 表，期望仍然不会被误判为可编辑。