### PR TITLE
fix: preserve large integer precision when formatting JSON in value editor

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -82,6 +82,7 @@ const queryStore = useQueryStore();
 const { openTableTarget } = useNavigationTargets({
   showFieldLineageDialog: ref(false),
   showDatabaseSearchDialog: ref(false),
+  showDiagramDialog: ref(false),
 });
 const { toast } = useToast();
 const { isDark } = useTheme();

--- a/apps/desktop/src/components/mq/RawApiPanel.vue
+++ b/apps/desktop/src/components/mq/RawApiPanel.vue
@@ -3,6 +3,7 @@ import { formatError } from "@/lib/backend/errorUtils";
 import { computed, ref } from "vue";
 import type { MqRawResponse, TopicInfo } from "@/types/mq";
 import { mqRawRequest } from "@/lib/backend/api";
+import { safeJsonFormat } from "@/lib/common/safeJsonFormat";
 
 interface Props {
   connectionId: string;
@@ -156,7 +157,7 @@ function formatJsonBody() {
   const text = bodyText.value.trim();
   if (!text) return;
   try {
-    bodyText.value = JSON.stringify(JSON.parse(text), null, 2);
+    bodyText.value = safeJsonFormat(text, 2);
     error.value = undefined;
   } catch (e: unknown) {
     error.value = `JSON Body 格式错误: ${formatError(e)}`;

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -19,6 +19,7 @@ import { useEditorFontFamilyStyle } from "@/composables/useEditorFontFamilyStyle
 import { createRedisShikiJsonHighlighter, type RedisJsonHighlighter } from "@/lib/redis/redisJsonHighlighter";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatTtl } from "@/lib/common/ttlFormat";
+import { safeJsonFormat } from "@/lib/common/safeJsonFormat";
 import { canEditRedisMemberDetail, clampRedisMemberDetailSheetWidth, formatRedisMemberDetail, getRedisMemberSelectionKey } from "@/lib/redis/redisValuePresentation";
 
 const { t } = useI18n();
@@ -347,8 +348,7 @@ function handleStringInput() {
 
 function formatJsonText(raw: string): string | null {
   try {
-    const parsed = JSON.parse(raw);
-    return JSON.stringify(parsed, null, 2);
+    return safeJsonFormat(raw, 2);
   } catch {
     return null;
   }
@@ -356,8 +356,7 @@ function formatJsonText(raw: string): string | null {
 
 function compressJsonText(raw: string): string | null {
   try {
-    const parsed = JSON.parse(raw);
-    return JSON.stringify(parsed);
+    return safeJsonFormat(raw);
   } catch {
     return null;
   }

--- a/apps/desktop/src/lib/common/__tests__/safeJsonFormat.spec.ts
+++ b/apps/desktop/src/lib/common/__tests__/safeJsonFormat.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { safeJsonFormat } from "../safeJsonFormat";
+
+describe("safeJsonFormat", () => {
+  it("preserves large integers exceeding MAX_SAFE_INTEGER", () => {
+    const input = '{"id":87712409002717401}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "id": 87712409002717401\n}');
+  });
+
+  it("preserves negative large integers exceeding MIN_SAFE_INTEGER", () => {
+    const input = '{"value":-87712409002717401}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "value": -87712409002717401\n}');
+  });
+
+  it("preserves multiple large integers in the same JSON", () => {
+    const input = '{"a":87712409002717401,"b":9007199254740992}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "a": 87712409002717401,\n  "b": 9007199254740992\n}');
+  });
+
+  it("does not modify integers within MAX_SAFE_INTEGER", () => {
+    const input = '{"id":12345}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "id": 12345\n}');
+  });
+
+  it("does not modify integers exactly at MAX_SAFE_INTEGER", () => {
+    const input = `{"id":${Number.MAX_SAFE_INTEGER}}`;
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe(`{\n  "id": ${Number.MAX_SAFE_INTEGER}\n}`);
+  });
+
+  it("preserves floating point numbers with large integer parts", () => {
+    const input = '{"value":87712409002717401.5}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "value": 87712409002717401.5\n}');
+  });
+
+  it("compacts JSON without indent", () => {
+    const input = '{\n  "id":  87712409002717401\n}';
+    const result = safeJsonFormat(input);
+    expect(result).toBe('{"id":87712409002717401}');
+  });
+
+  it("preserves large integers in nested JSON", () => {
+    const input = '{"data":{"id":87712409002717401}}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "data": {\n    "id": 87712409002717401\n  }\n}');
+  });
+
+  it("preserves large integers in arrays", () => {
+    const input = '{"ids":[87712409002717401,87712409002717402]}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "ids": [\n    87712409002717401,\n    87712409002717402\n  ]\n}');
+  });
+
+  it("handles string values that look like numbers", () => {
+    const input = '{"id":"87712409002717401"}';
+    const result = safeJsonFormat(input, 2);
+    expect(result).toBe('{\n  "id": "87712409002717401"\n}');
+  });
+});

--- a/apps/desktop/src/lib/common/safeJsonFormat.ts
+++ b/apps/desktop/src/lib/common/safeJsonFormat.ts
@@ -1,0 +1,40 @@
+/**
+ * Parse and re-stringify JSON while preserving integer values that exceed
+ * Number.MAX_SAFE_INTEGER (2^53 - 1). JavaScript's JSON.parse loses
+ * precision on such values (e.g. 87712409002717401 → 87712409002717400),
+ * so we replace large integer literals with string placeholders before
+ * parsing and restore them after stringifying.
+ */
+export function safeJsonFormat(text: string, indent?: number): string {
+  const MAX_SAFE_INT = String(Number.MAX_SAFE_INTEGER);
+  const MIN_SAFE_INT = String(-Number.MAX_SAFE_INTEGER);
+  const largeInts = new Map<string, string>();
+  const placeholderPrefix = '"__DBX_BIGINT_';
+
+  // Replace large numeric literals (integers or floats with large integer parts)
+  // with string placeholders to avoid precision loss.
+  // Matches: optional minus, 16+ digits, optional decimal part, followed by
+  // a JSON delimiter (comma, ], }, or end-of-string after whitespace).
+  const replaced = text.replace(/(-?\d{16,}(?:\.\d+)?)(\s*(?:,|\]|}|$))/g, (_match, digits: string, tail: string) => {
+    // Extract the integer part (before any decimal point) for comparison
+    const integerPart = digits.split(".")[0];
+    const isNegative = integerPart.startsWith("-");
+    const absInteger = isNegative ? integerPart.slice(1) : integerPart;
+    const threshold = isNegative ? MIN_SAFE_INT.slice(1) : MAX_SAFE_INT;
+    if (absInteger.length < threshold.length) return _match;
+    if (absInteger.length === threshold.length && absInteger <= threshold) return _match;
+
+    const key = String(largeInts.size);
+    largeInts.set(key, digits);
+    return `${placeholderPrefix}${key}"${tail}`;
+  });
+
+  const parsed = JSON.parse(replaced);
+  let result = JSON.stringify(parsed, null, indent ?? undefined);
+
+  for (const [key, digits] of largeInts) {
+    result = result.replace(`${placeholderPrefix}${key}"`, digits);
+  }
+
+  return result;
+}

--- a/apps/desktop/src/lib/dataGrid/cellDetailPresentation.ts
+++ b/apps/desktop/src/lib/dataGrid/cellDetailPresentation.ts
@@ -1,3 +1,5 @@
+import { safeJsonFormat } from "@/lib/common/safeJsonFormat";
+
 export type CellDetailTab = "details" | "hexViewer" | "valueEditor";
 export type ValueEditorAction = "formatJson" | "setNull" | "restoreOriginal";
 
@@ -90,7 +92,7 @@ export function formatJsonText(text: string): string | undefined {
   if (!trimmed) return undefined;
   if (trimmed.length > CELL_DETAIL_JSON_FORMAT_MAX_LENGTH) return undefined;
   try {
-    return JSON.stringify(JSON.parse(trimmed), null, 2);
+    return safeJsonFormat(trimmed, 2);
   } catch {
     return undefined;
   }
@@ -101,7 +103,7 @@ export function compactJsonText(text: string): string | undefined {
   if (!trimmed) return undefined;
   if (trimmed.length > CELL_DETAIL_JSON_FORMAT_MAX_LENGTH) return undefined;
   try {
-    return JSON.stringify(JSON.parse(trimmed));
+    return safeJsonFormat(trimmed);
   } catch {
     return undefined;
   }

--- a/apps/desktop/src/lib/kv/kvValueDisplay.ts
+++ b/apps/desktop/src/lib/kv/kvValueDisplay.ts
@@ -1,5 +1,7 @@
 import type { KvKeyMetadata } from "@/lib/backend/api";
 
+import { safeJsonFormat } from "@/lib/common/safeJsonFormat";
+
 export interface PrettyPrintJsonResult {
   ok: boolean;
   value?: string;
@@ -20,7 +22,7 @@ export interface ZooKeeperSummaryLabels {
 
 export function prettyPrintJsonText(text: string): PrettyPrintJsonResult {
   try {
-    return { ok: true, value: JSON.stringify(JSON.parse(text), null, 2) };
+    return { ok: true, value: safeJsonFormat(text, 2) };
   } catch {
     return { ok: false, error: "invalid_json" };
   }


### PR DESCRIPTION
## Problem
When clicking "Format JSON" in the value editor, large integers exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) lose precision. For example, `87712409002717401` becomes `87712409002717400`.

## Root Cause
JavaScript's `JSON.parse()` converts all JSON numbers to `number` type, which uses IEEE 754 double-precision floating point. Integers beyond 2^53 - 1 cannot be represented exactly, causing silent precision loss.

The affected code paths all used the pattern:
```js
JSON.stringify(JSON.parse(text), null, 2)
```

## Fix
Introduced a `safeJsonFormat()` utility function that:
1. Pre-processes the JSON text with a regex to replace numeric literals whose integer part exceeds `MAX_SAFE_INTEGER` with string placeholders
2. Runs `JSON.parse()` + `JSON.stringify()` normally
3. Restores the original numeric literals from placeholders in the output

This preserves the original digit sequences exactly while still getting proper JSON formatting (indentation, whitespace normalization).

### Affected locations (all fixed)
- **Value editor** (`cellDetailPresentation.ts`) — format/compact JSON
- **Redis value viewer** (`RedisValueViewer.vue`) — format/compress JSON
- **KV value display** (`kvValueDisplay.ts`) — pretty-print JSON
- **MQ raw API panel** (`RawApiPanel.vue`) — format JSON body

## Testing
- Added 10 test cases covering: large positive/negative integers, MAX_SAFE_INTEGER boundary, floating point with large integer parts, nested JSON, arrays, string values that look like numbers
- `pnpm check` passes (format, lint, typecheck, test)

## Link
[#2765](https://github.com/t8y2/dbx/issues/2765)