### PR TITLE
fix(postgres): load foreign key referential actions

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -2786,32 +2786,42 @@ pub async fn list_indexes(pool: &Pool, schema: &str, table: &str) -> Result<Vec<
     }
 }
 
+fn postgres_foreign_keys_sql() -> &'static str {
+    "SELECT fk.constraint_name, fk.column_name, \
+     pk.table_schema AS ref_schema, pk.table_name AS ref_table, pk.column_name AS ref_column, \
+     rc.update_rule AS on_update, rc.delete_rule AS on_delete \
+     FROM information_schema.table_constraints tc \
+     JOIN information_schema.key_column_usage fk \
+       ON fk.constraint_name = tc.constraint_name \
+       AND fk.constraint_schema = tc.constraint_schema \
+       AND fk.table_schema = tc.table_schema \
+       AND fk.table_name = tc.table_name \
+     JOIN information_schema.referential_constraints rc \
+       ON rc.constraint_name = tc.constraint_name \
+       AND rc.constraint_schema = tc.constraint_schema \
+     JOIN information_schema.key_column_usage pk \
+       ON pk.constraint_name = rc.unique_constraint_name \
+       AND pk.constraint_schema = rc.unique_constraint_schema \
+       AND pk.ordinal_position = fk.position_in_unique_constraint \
+     WHERE tc.constraint_type = 'FOREIGN KEY' \
+       AND fk.table_schema = $1 AND fk.table_name = $2 \
+     ORDER BY fk.constraint_name, fk.ordinal_position"
+}
+
+fn postgres_foreign_key_action(value: String) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
 pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ForeignKeyInfo>, String> {
     let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
-    let rows = postgres_query_cached(
-        &client,
-        "SELECT fk.constraint_name, fk.column_name, \
-         pk.table_schema AS ref_schema, pk.table_name AS ref_table, pk.column_name AS ref_column \
-         FROM information_schema.table_constraints tc \
-         JOIN information_schema.key_column_usage fk \
-           ON fk.constraint_name = tc.constraint_name \
-           AND fk.constraint_schema = tc.constraint_schema \
-           AND fk.table_schema = tc.table_schema \
-           AND fk.table_name = tc.table_name \
-         JOIN information_schema.referential_constraints rc \
-           ON rc.constraint_name = tc.constraint_name \
-           AND rc.constraint_schema = tc.constraint_schema \
-         JOIN information_schema.key_column_usage pk \
-           ON pk.constraint_name = rc.unique_constraint_name \
-           AND pk.constraint_schema = rc.unique_constraint_schema \
-           AND pk.ordinal_position = fk.position_in_unique_constraint \
-         WHERE tc.constraint_type = 'FOREIGN KEY' \
-           AND fk.table_schema = $1 AND fk.table_name = $2 \
-         ORDER BY fk.constraint_name, fk.ordinal_position",
-        &[&schema, &table],
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = postgres_query_cached(&client, postgres_foreign_keys_sql(), &[&schema, &table])
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .iter()
@@ -2821,8 +2831,8 @@ pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result
             ref_schema: Some(row.get::<_, String>(2)),
             ref_table: row.get::<_, String>(3),
             ref_column: row.get::<_, String>(4),
-            on_update: None,
-            on_delete: None,
+            on_update: postgres_foreign_key_action(row.get::<_, String>(5)),
+            on_delete: postgres_foreign_key_action(row.get::<_, String>(6)),
         })
         .collect())
 }
@@ -3175,6 +3185,23 @@ mod tests {
 
         let raw = PgRawBytes::from_sql(&Type::UNKNOWN, &[0x01, 0xAB, 0xFF]).unwrap();
         assert_eq!(raw.0, vec![0x01, 0xAB, 0xFF]);
+    }
+
+    #[test]
+    fn postgres_foreign_keys_sql_selects_referential_actions() {
+        let sql = postgres_foreign_keys_sql();
+
+        assert!(sql.contains("rc.update_rule AS on_update"));
+        assert!(sql.contains("rc.delete_rule AS on_delete"));
+        assert!(sql.contains("information_schema.referential_constraints rc"));
+    }
+
+    #[test]
+    fn postgres_foreign_key_action_keeps_non_empty_action() {
+        assert_eq!(postgres_foreign_key_action("CASCADE".to_string()), Some("CASCADE".to_string()));
+        assert_eq!(postgres_foreign_key_action(" SET NULL ".to_string()), Some("SET NULL".to_string()));
+        assert_eq!(postgres_foreign_key_action("".to_string()), None);
+        assert_eq!(postgres_foreign_key_action("  ".to_string()), None);
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复 PostgreSQL 表结构编辑中外键级联动作不回显的问题：

- PostgreSQL 外键元数据查询补充读取 `update_rule` 和 `delete_rule`。
- 将 `ON UPDATE` / `ON DELETE` 动作返回到已有的 `ForeignKeyInfo.on_update` / `on_delete` 字段。
- 表结构编辑器可正确回显已有外键的 `CASCADE`、`SET NULL` 等动作。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 未修改前端代码；修复的是后端 PostgreSQL 外键元数据返回字段缺失。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo fmt --check`
- `cargo test -p dbx-core postgres_foreign_key --no-default-features`
- `cargo check -p dbx-core --no-default-features`
- 使用 PostgreSQL 16 复现库验证 `/api/schema/foreign-keys` 返回 `on_update: "CASCADE"`、`on_delete: "SET NULL"`
- 本地 DBX Desktop 手动验证外键页签可正确回显级联动作

## 关联 Issue

Close #2760
