### PR TITLE
Fix: 修复 ZooKeeper 根节点新建子节点失败

### DIFF
--- a/apps/desktop/src/components/kv/KvKeyBrowser.vue
+++ b/apps/desktop/src/components/kv/KvKeyBrowser.vue
@@ -15,7 +15,19 @@ import type { KvCreateMode, KvGetResponse, KvKeySummary, KvListPrefixOptions, Kv
 import { buildKvKeyTree, flattenVisibleKvKeyTree, preserveKvExpandedGroupIds, type KvKeyTreeNode } from "@/lib/kv/kvKeyTree";
 import { refreshedKvSelectionKey } from "@/lib/kv/kvRefreshSelection";
 import { formatZooKeeperMetadataRows, formatZooKeeperSummaryBadges, prettyPrintJsonText } from "@/lib/kv/kvValueDisplay";
-import { createLazyKvKeyTreeState, flattenLazyKvKeyTree, lazyExpandedKeyFromId, normalizeZooKeeperPath, parentZooKeeperPath, replaceLazyKvChildren, replaceLazyKvFocusedRoot, resetLazyKvKeyTree, type LazyKvKeyTreeNode, type LazyKvKeyTreeRow } from "@/lib/zookeeper/zookeeperLazyKeyTree";
+import {
+  createLazyKvKeyTreeState,
+  createZooKeeperChildPathDraft,
+  flattenLazyKvKeyTree,
+  lazyExpandedKeyFromId,
+  normalizeZooKeeperPath,
+  parentZooKeeperPath,
+  replaceLazyKvChildren,
+  replaceLazyKvFocusedRoot,
+  resetLazyKvKeyTree,
+  type LazyKvKeyTreeNode,
+  type LazyKvKeyTreeRow,
+} from "@/lib/zookeeper/zookeeperLazyKeyTree";
 import { useToast } from "@/composables/useToast";
 
 interface KvKeyBrowserLabels {
@@ -33,6 +45,7 @@ interface KvKeyBrowserLabels {
   deleteTitle: string;
   keyPlaceholder: string;
   keyRequired: string;
+  rootReadonly?: string;
   saved: string;
   deleted: string;
   base64Readonly: string;
@@ -233,7 +246,7 @@ async function loadLazyRoot(reset = true, options: LoadKeysOptions = {}) {
 async function loadLazyRootSummary(rootPath: string, children: KvKeySummary[], continuation?: string | null): Promise<KvKeySummary | null> {
   try {
     const rootValue = await props.api.get(props.connectionId, rootPath);
-    if (rootValue.found) return { key: rootValue.key || rootPath, ...(rootValue.metadata ?? {}) };
+    if (rootValue.found) return { key: rootValue.key || rootPath, ...rootValue.metadata };
     if (children.length === 0 && !continuation) return null;
   } catch {
     if (children.length === 0 && !continuation) return null;
@@ -377,7 +390,8 @@ function onRowDoubleClick(node: BrowserTreeNode) {
 }
 
 function createKeyPrefix(parentPath?: string): string {
-  const path = props.lazyHierarchy ? normalizeZooKeeperPath(parentPath ?? prefix.value) : (parentPath ?? prefix.value.trim());
+  if (props.lazyHierarchy) return createZooKeeperChildPathDraft(parentPath ?? prefix.value);
+  const path = parentPath ?? prefix.value.trim();
   if (!path) return "";
   if (path === "/") return "/";
   return path.endsWith("/") ? path : `${path}/`;
@@ -410,11 +424,16 @@ function putOptions(): KvPutOptions | undefined {
 }
 
 async function saveKey() {
-  const key = editKey.value.trim();
-  if (!key) {
+  const rawKey = editKey.value.trim();
+  if (!rawKey) {
     editError.value = props.labels.keyRequired;
     return;
   }
+  if (props.lazyHierarchy && normalizeZooKeeperPath(rawKey) === "/") {
+    editError.value = props.labels.rootReadonly || props.labels.keyRequired;
+    return;
+  }
+  const key = props.lazyHierarchy ? normalizeZooKeeperPath(rawKey) : rawKey;
   saving.value = true;
   editError.value = "";
   try {

--- a/apps/desktop/src/components/zookeeper/ZooKeeperKeyBrowser.vue
+++ b/apps/desktop/src/components/zookeeper/ZooKeeperKeyBrowser.vue
@@ -39,6 +39,7 @@ const labels = computed(() => ({
   deleteTitle: t("zookeeper.deleteTitle"),
   keyPlaceholder: t("zookeeper.keyPlaceholder"),
   keyRequired: t("zookeeper.keyRequired"),
+  rootReadonly: t("zookeeper.rootReadonly"),
   saved: t("zookeeper.saved"),
   deleted: t("zookeeper.deleted"),
   base64Readonly: t("zookeeper.base64Readonly"),

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1879,6 +1879,7 @@ export default {
     deleteTitle: "Delete ZooKeeper znode",
     keyPlaceholder: "/path/to/znode",
     keyRequired: "Znode path is required",
+    rootReadonly: "Root znode cannot be modified. Enter a child znode path.",
     saved: "Znode saved",
     deleted: "Znode deleted",
     base64Readonly: "Base64 values are read-only in this version.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1821,6 +1821,7 @@ export default withEnglishFallback({
     deleteTitle: "Eliminar znode de ZooKeeper",
     keyPlaceholder: "/ruta/a/znode",
     keyRequired: "La ruta del znode es obligatoria",
+    rootReadonly: "El znode raíz no se puede modificar. Introduce una ruta de znode hijo.",
     saved: "Znode guardado",
     deleted: "Znode eliminado",
     base64Readonly: "Los valores Base64 son de solo lectura en esta versión.",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1819,6 +1819,7 @@ export default withEnglishFallback({
     deleteTitle: "Elimina znode ZooKeeper",
     keyPlaceholder: "/percorso/per/znode",
     keyRequired: "Il percorso znode e obbligatorio",
+    rootReadonly: "Lo znode radice non può essere modificato. Inserisci il percorso di uno znode figlio.",
     saved: "Znode salvato",
     deleted: "Znode eliminato",
     base64Readonly: "I valori Base64 sono in sola lettura in questa versione.",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1572,6 +1572,7 @@ export default withEnglishFallback({
     deleteTitle: "ZooKeeper znodeを削除",
     keyPlaceholder: "/path/to/znode",
     keyRequired: "Znodeパスは必須です",
+    rootReadonly: "ルートznodeは変更できません。子znodeのパスを入力してください。",
     saved: "Znodeを保存しました",
     deleted: "Znodeを削除しました",
     base64Readonly: "Base64値はこのバージョンでは読み取り専用です。",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1820,6 +1820,7 @@ export default withEnglishFallback({
     deleteTitle: "Excluir znode do ZooKeeper",
     keyPlaceholder: "/caminho/para/znode",
     keyRequired: "Caminho do znode é obrigatório",
+    rootReadonly: "O znode raiz não pode ser modificado. Informe o caminho de um znode filho.",
     saved: "Znode salvo",
     deleted: "Znode excluído",
     base64Readonly: "Valores Base64 são somente leitura nesta versão.",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1879,6 +1879,7 @@ export default withEnglishFallback({
     deleteTitle: "删除 ZooKeeper znode",
     keyPlaceholder: "/path/to/znode",
     keyRequired: "Znode 路径不能为空",
+    rootReadonly: "根 znode 不能被修改，请填写子节点路径",
     saved: "Znode 已保存",
     deleted: "Znode 已删除",
     base64Readonly: "Base64 值当前版本只读。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -3374,6 +3374,7 @@ export default withEnglishFallback({
     summaryVersion: "版本",
     summaryLease: "租約",
     summarySize: "大小",
+    rootReadonly: "根 znode 不能被修改，請填寫子節點路徑",
   },
   gridfsBrowser: {
     bucketCount: "儲存桶",

--- a/apps/desktop/src/lib/__tests__/zookeeper/zookeeperLazyKeyTree.spec.ts
+++ b/apps/desktop/src/lib/__tests__/zookeeper/zookeeperLazyKeyTree.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createLazyKvKeyTreeState, flattenLazyKvKeyTree, replaceLazyKvChildren, resetLazyKvKeyTree } from "@/lib/zookeeper/zookeeperLazyKeyTree";
+import { createLazyKvKeyTreeState, createZooKeeperChildPathDraft, flattenLazyKvKeyTree, replaceLazyKvChildren, resetLazyKvKeyTree } from "@/lib/zookeeper/zookeeperLazyKeyTree";
 
 describe("zookeeper lazy key tree", () => {
   it("stores only the current path direct children on reset", () => {
@@ -41,5 +41,12 @@ describe("zookeeper lazy key tree", () => {
 
     expect(state.rootContinuation).toBe("root-next");
     expect(app?.continuation).toBe("child-next");
+  });
+
+  it("does not prefill root as a creatable znode path", () => {
+    expect(createZooKeeperChildPathDraft("")).toBe("");
+    expect(createZooKeeperChildPathDraft("/")).toBe("");
+    expect(createZooKeeperChildPathDraft("/app")).toBe("/app/");
+    expect(createZooKeeperChildPathDraft("app/")).toBe("/app/");
   });
 });

--- a/apps/desktop/src/lib/zookeeper/zookeeperLazyKeyTree.ts
+++ b/apps/desktop/src/lib/zookeeper/zookeeperLazyKeyTree.ts
@@ -48,6 +48,12 @@ export function parentZooKeeperPath(path: string): string {
   return parent || "/";
 }
 
+export function createZooKeeperChildPathDraft(parentPath: string): string {
+  const normalized = normalizeZooKeeperPath(parentPath);
+  if (normalized === "/") return "";
+  return `${normalized}/`;
+}
+
 export function createLazyKvKeyTreeState(rootPath = "/"): LazyKvKeyTreeState {
   return {
     rootPath: normalizeZooKeeperPath(rootPath),


### PR DESCRIPTION
## 概述
- 修复 ZooKeeper 在根节点下新建 znode 时默认路径为 / 导致被后端拒绝的问题
- 根节点新建时不再预填 /，保存前校验并规范化 ZooKeeper 路径
- 补充根节点只读提示的多语言文案和路径草稿单测

## 验证
- pnpm exec vitest run apps/desktop/src/lib/__tests__/zookeeper/zookeeperLazyKeyTree.spec.ts
- pnpm typecheck
- pnpm lint
- git diff --check