### PR TITLE
fix(sql): quote all IN-list values uniformly in expaste

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlInListPaste.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlInListPaste.spec.ts
@@ -21,7 +21,7 @@ describe("sqlInListPaste", () => {
   it("splits simple slash-separated value lists", () => {
     expect(buildSqlInConditionFromPasteSource("1/2/3")).toEqual({
       ok: true,
-      sql: "IN (1, 2, 3)",
+      sql: "IN ('1', '2', '3')",
       valueCount: 3,
     });
     expect(buildSqlInConditionFromPasteSource("A/B/C")).toEqual({
@@ -37,10 +37,10 @@ describe("sqlInListPaste", () => {
     expect(buildSqlInConditionFromPasteSource("/Users/staff/dbx")).toEqual({ ok: false, reason: "not-list" });
   });
 
-  it("preserves numeric and NULL literals while quoting strings", () => {
+  it("quotes all non-NULL values uniformly including numbers", () => {
     expect(buildSqlInConditionFromPasteSource("1\n-2.5\n001\nnull\nA1")).toEqual({
       ok: true,
-      sql: "IN (1, -2.5, '001', NULL, 'A1')",
+      sql: "IN ('1', '-2.5', '001', NULL, 'A1')",
       valueCount: 5,
     });
   });

--- a/apps/desktop/src/lib/sql/sqlInListPaste.ts
+++ b/apps/desktop/src/lib/sql/sqlInListPaste.ts
@@ -25,7 +25,6 @@ interface ParsedPasteValues {
   explicitList: boolean;
 }
 
-const SQL_NUMBER_LITERAL_RE = /^[+-]?(?:(?:0|[1-9]\d*)(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
 const SIMPLE_SLASH_LIST_VALUE_RE = /^[A-Za-z0-9_.:-]+$/;
 
 export function buildSqlInConditionFromPasteSource(source: string): SqlInListPasteResult {
@@ -195,6 +194,5 @@ function hasSingleWrappingParentheses(value: string): boolean {
 
 function formatSqlLiteral(token: ParsedPasteValue): string {
   if (!token.quoted && /^null$/i.test(token.value)) return "NULL";
-  if (!token.quoted && SQL_NUMBER_LITERAL_RE.test(token.value)) return token.value;
   return `'${token.value.replace(/'/g, "''")}'`;
 }


### PR DESCRIPTION
Previously, pure numeric values (e.g. 90001543) in the IN clause were not quoted while values with leading zeros (e.g. 00040787) were, causing inconsistent quoting. Now all non-NULL values are uniformly quoted.

## 处理
移除 formatSqlLiteral 中数字不加引号的逻辑，所有非 NULL 值统一加单引号

## 关联 Issue
Related #2817
