### PR TITLE
fix: use local timezone for desktop logs

### DIFF
--- a/apps/desktop/src/lib/backend/__tests__/debugLog.spec.ts
+++ b/apps/desktop/src/lib/backend/__tests__/debugLog.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendDebugLog, formatLocalTimestamp, formatLocalTimestampForFilename, formatLocalTimezoneOffset, getDebugLogText, padNumber } from "@/lib/backend/debugLog";
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>();
+
+  get length() {
+    return this.data.size;
+  }
+
+  clear() {
+    this.data.clear();
+  }
+
+  getItem(key: string) {
+    return this.data.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.data.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.data.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.data.set(key, value);
+  }
+}
+
+const DEBUG_LOG_ENABLED_KEY = "dbx-debug-logging-enabled";
+
+let originalLocalStorage: PropertyDescriptor | undefined;
+
+function expectedLocalOffset(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  return `${sign}${String(Math.floor(absoluteMinutes / 60)).padStart(2, "0")}:${String(absoluteMinutes % 60).padStart(2, "0")}`;
+}
+
+beforeEach(() => {
+  originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalLocalStorage) Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+  else Reflect.deleteProperty(globalThis, "localStorage");
+});
+
+describe("debug log local timestamps", () => {
+  it("pads date and time parts", () => {
+    expect(padNumber(7)).toBe("07");
+    expect(padNumber(35)).toBe("35");
+    expect(padNumber(8, 3)).toBe("008");
+  });
+
+  it("formats timezone offsets in RFC 3339 style", () => {
+    const east = new Date(0);
+    const west = new Date(0);
+    vi.spyOn(east, "getTimezoneOffset").mockReturnValue(-480);
+    vi.spyOn(west, "getTimezoneOffset").mockReturnValue(420);
+
+    expect(formatLocalTimezoneOffset(east)).toBe("+08:00");
+    expect(formatLocalTimezoneOffset(west)).toBe("-07:00");
+  });
+
+  it("formats local timestamps with milliseconds and timezone", () => {
+    const date = new Date(2026, 6, 8, 9, 50, 35, 882);
+
+    expect(formatLocalTimestamp(date)).toBe(`2026-07-08T09:50:35.882${expectedLocalOffset(date)}`);
+  });
+
+  it("formats Windows-safe filename timestamp tokens", () => {
+    const date = new Date(2026, 6, 8, 9, 50, 35, 882);
+    const filenameToken = formatLocalTimestampForFilename(date);
+
+    expect(filenameToken).toBe(`2026-07-08T09-50-35-882${expectedLocalOffset(date).replace(":", "-")}`);
+    expect(filenameToken).not.toMatch(/[:.]/);
+  });
+
+  it("uses local timestamps in exported debug log text", () => {
+    const date = new Date(2026, 6, 8, 9, 50, 35, 882);
+    const timestamp = formatLocalTimestamp(date);
+    vi.useFakeTimers();
+    vi.setSystemTime(date);
+    localStorage.setItem(DEBUG_LOG_ENABLED_KEY, "1");
+
+    appendDebugLog("info", "hello");
+
+    const text = getDebugLogText();
+    expect(text).toContain(`Exported: ${timestamp}`);
+    expect(text).toContain(`[${timestamp}] [INFO] hello`);
+    expect(text).not.toContain(".882Z");
+  });
+});

--- a/apps/desktop/src/lib/backend/debugLog.ts
+++ b/apps/desktop/src/lib/backend/debugLog.ts
@@ -81,22 +81,26 @@ function formatArgs(args: unknown[]): string {
   return message.length > MAX_TEXT_LENGTH ? `${message.slice(0, MAX_TEXT_LENGTH)}...` : message;
 }
 
-function padNumber(value: number, length = 2): string {
+// Pads date/time parts to keep timestamps width-stable.
+export function padNumber(value: number, length = 2): string {
   return String(value).padStart(length, "0");
 }
 
-function formatLocalTimezoneOffset(date: Date): string {
+// Formats the local UTC offset in RFC 3339 style.
+export function formatLocalTimezoneOffset(date: Date): string {
   const offsetMinutes = -date.getTimezoneOffset();
   const sign = offsetMinutes >= 0 ? "+" : "-";
   const absoluteMinutes = Math.abs(offsetMinutes);
   return `${sign}${padNumber(Math.floor(absoluteMinutes / 60))}:${padNumber(absoluteMinutes % 60)}`;
 }
 
-function formatLocalTimestamp(date = new Date()): string {
+// Formats a local timestamp with milliseconds and timezone.
+export function formatLocalTimestamp(date = new Date()): string {
   return `${date.getFullYear()}-${padNumber(date.getMonth() + 1)}-${padNumber(date.getDate())}T${padNumber(date.getHours())}:${padNumber(date.getMinutes())}:${padNumber(date.getSeconds())}.${padNumber(date.getMilliseconds(), 3)}${formatLocalTimezoneOffset(date)}`;
 }
 
-function formatLocalTimestampForFilename(date = new Date()): string {
+// Converts the local timestamp into a Windows-safe filename token.
+export function formatLocalTimestampForFilename(date = new Date()): string {
   return formatLocalTimestamp(date).replace(/[:.]/g, "-");
 }
 

--- a/apps/desktop/src/lib/backend/debugLog.ts
+++ b/apps/desktop/src/lib/backend/debugLog.ts
@@ -81,11 +81,30 @@ function formatArgs(args: unknown[]): string {
   return message.length > MAX_TEXT_LENGTH ? `${message.slice(0, MAX_TEXT_LENGTH)}...` : message;
 }
 
+function padNumber(value: number, length = 2): string {
+  return String(value).padStart(length, "0");
+}
+
+function formatLocalTimezoneOffset(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  return `${sign}${padNumber(Math.floor(absoluteMinutes / 60))}:${padNumber(absoluteMinutes % 60)}`;
+}
+
+function formatLocalTimestamp(date = new Date()): string {
+  return `${date.getFullYear()}-${padNumber(date.getMonth() + 1)}-${padNumber(date.getDate())}T${padNumber(date.getHours())}:${padNumber(date.getMinutes())}:${padNumber(date.getSeconds())}.${padNumber(date.getMilliseconds(), 3)}${formatLocalTimezoneOffset(date)}`;
+}
+
+function formatLocalTimestampForFilename(date = new Date()): string {
+  return formatLocalTimestamp(date).replace(/[:.]/g, "-");
+}
+
 export function appendDebugLog(level: DebugLogLevel, ...args: unknown[]) {
   if (!isDebugLoggingEnabled()) return;
   const entries = readEntries();
   entries.push({
-    timestamp: new Date().toISOString(),
+    timestamp: formatLocalTimestamp(),
     level,
     message: formatArgs(args),
   });
@@ -111,14 +130,14 @@ export function clearDebugLogs() {
 
 export function getDebugLogText(): string {
   const entries = readEntries();
-  const header = [`DBX debug log`, `Exported: ${new Date().toISOString()}`, `User agent: ${navigator.userAgent}`, `Platform: ${navigator.platform}`, `Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone || "unknown"}`, ""];
+  const header = [`DBX debug log`, `Exported: ${formatLocalTimestamp()}`, `User agent: ${navigator.userAgent}`, `Platform: ${navigator.platform}`, `Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone || "unknown"}`, ""];
   const body = entries.map((entry) => `[${entry.timestamp}] [${entry.level.toUpperCase()}] ${entry.message}`);
   return [...header, ...body].join("\n");
 }
 
 export async function downloadDebugLogs() {
   const text = await getDebugLogBundleText();
-  const filename = `dbx-debug-log-${new Date().toISOString().replace(/[:.]/g, "-")}.txt`;
+  const filename = `dbx-debug-log-${formatLocalTimestampForFilename()}.txt`;
   if (typeof window !== "undefined" && isTauriRuntimeLike()) {
     const [{ save }, { writeTextFile }] = await Promise.all([import("@tauri-apps/plugin-dialog"), import("@tauri-apps/plugin-fs")]);
     const path = await save({

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -656,7 +656,21 @@ pub fn run() {
                 s
             });
             let desktop_settings = tauri::async_runtime::block_on(storage.load_desktop_settings()).unwrap_or_default();
-            app.handle().plugin(tauri_plugin_log::Builder::default().level(log::LevelFilter::Debug).build())?;
+            app.handle().plugin(
+                tauri_plugin_log::Builder::default()
+                    .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
+                    .format(|out, message, record| {
+                        out.finish(format_args!(
+                            "[{}][{}][{}] {}",
+                            chrono::Local::now().format("%Y-%m-%d][%H:%M:%S%.3f"),
+                            record.level(),
+                            record.target(),
+                            message
+                        ));
+                    })
+                    .level(log::LevelFilter::Debug)
+                    .build(),
+            )?;
             apply_debug_log_level(desktop_settings.debug_logging_enabled);
             eprintln!("[STARTUP] storage ready in {:?}", t.elapsed());
 


### PR DESCRIPTION
## 变更说明

修复桌面端调试日志时间显示与本地时区不一致的问题。

本 PR 将桌面端原生日志、前端调试日志导出内容以及调试日志下载文件名统一调整为本地时区时间，并保留毫秒信息，避免日志时间仍显示为 UTC 或 `Z` 时区导致排查问题时产生误解。

主要变更：

- Tauri 原生日志使用本地时区输出
- 原生日志时间增加毫秒精度
- 调试日志导出中的 `Exported` 时间使用本地时区
- 调试日志条目时间使用本地时区
- 调试日志下载文件名使用本地时区时间
- 为调试日志本地时间格式化逻辑补充单元测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #2777 