### PR TITLE
Fix：更新 OceanBase 默认连接端口

### DIFF
--- a/agents/drivers/oceanbase-oracle/src/main/java/com/dbx/agent/oceanbaseoracle/OceanBaseOracleAgent.java
+++ b/agents/drivers/oceanbase-oracle/src/main/java/com/dbx/agent/oceanbaseoracle/OceanBaseOracleAgent.java
@@ -42,7 +42,7 @@ public final class OceanBaseOracleAgent extends ConfiguredJdbcAgent {
     public static final JdbcAgentProfile OCEANBASE_ORACLE_PROFILE = new JdbcAgentProfile(
         "com.oceanbase.jdbc.Driver",
         "jdbc:oceanbase://{host}:{port}/{database}",
-        2881,
+        2883,
         false,
         SYSTEM_SCHEMAS,
         List.of("TABLE", "VIEW", "BASE TABLE")

--- a/agents/drivers/oceanbase-oracle/src/test/java/com/dbx/agent/oceanbaseoracle/OceanBaseOracleAgentTest.java
+++ b/agents/drivers/oceanbase-oracle/src/test/java/com/dbx/agent/oceanbaseoracle/OceanBaseOracleAgentTest.java
@@ -27,7 +27,7 @@ class OceanBaseOracleAgentTest {
         params.setDatabase("sys");
 
         Assertions.assertEquals(
-            "jdbc:oceanbase://oceanbase.example.com:2881/sys?compatibleOjdbcVersion=8",
+            "jdbc:oceanbase://oceanbase.example.com:2883/sys?compatibleOjdbcVersion=8",
             OceanBaseOracleAgent.buildUrl(params)
         );
     }

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -537,10 +537,10 @@ const driverProfiles: Record<
   chromadb: { type: "chromadb", port: 8000, user: "", label: "ChromaDB", icon: "chromadb" },
   mariadb: { type: "mysql", port: 3306, user: "root", label: "MariaDB", icon: "mariadb" },
   tidb: { type: "mysql", port: 4000, user: "root", label: "TiDB", icon: "tidb" },
-  oceanbase: { type: "mysql", port: 2881, user: "root", label: "OceanBase", icon: "oceanbase" },
+  oceanbase: { type: "mysql", port: 2883, user: "root", label: "OceanBase", icon: "oceanbase" },
   "oceanbase-oracle": {
     type: "oceanbase-oracle",
-    port: 2881,
+    port: 2883,
     user: "SYS",
     label: "OceanBase Oracle Mode",
     icon: "oceanbase",

--- a/apps/desktop/src/lib/imports/navicatImport.ts
+++ b/apps/desktop/src/lib/imports/navicatImport.ts
@@ -28,7 +28,7 @@ const typeMap: Record<string, { dbType: DatabaseType; profile: string; label: st
   kingbase: { dbType: "kingbase", profile: "kingbase", label: "KingbaseES", port: 54321, user: "SYSTEM" },
   kingbasees: { dbType: "kingbase", profile: "kingbase", label: "KingbaseES", port: 54321, user: "SYSTEM" },
   gaussdb: { dbType: "gaussdb", profile: "gaussdb", label: "GaussDB", port: 8000, user: "root" },
-  oceanbase: { dbType: "oceanbase-oracle", profile: "oceanbase", label: "OceanBase", port: 2881, user: "root" },
+  oceanbase: { dbType: "oceanbase-oracle", profile: "oceanbase", label: "OceanBase", port: 2883, user: "root" },
   // Numeric type codes (Navicat uses numeric ConnType for some exports)
   "1": { dbType: "mysql", profile: "mysql", label: "MySQL", port: 3306, user: "root" },
   "2": { dbType: "postgres", profile: "postgres", label: "PostgreSQL", port: 5432, user: "postgres" },
@@ -175,7 +175,7 @@ async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | nul
     const sp = serviceProvider.toLowerCase();
     if (sp.includes("oceanbase")) {
       const oceanbaseOracleMode = normalizeKey(rawType).includes("oracle") || profile.dbType === "oracle";
-      effectiveProfile = oceanbaseOracleMode ? { ...profile, dbType: "oceanbase-oracle", profile: "oceanbase-oracle", label: "OceanBase Oracle Mode", port: 2881 } : { ...profile, dbType: "mysql", profile: "oceanbase", label: "OceanBase", port: 2881 };
+      effectiveProfile = oceanbaseOracleMode ? { ...profile, dbType: "oceanbase-oracle", profile: "oceanbase-oracle", label: "OceanBase Oracle Mode", port: 2883 } : { ...profile, dbType: "mysql", profile: "oceanbase", label: "OceanBase", port: 2883 };
     } else if (sp.includes("gaussdb") || sp.includes("huaweicloudgauss")) {
       effectiveProfile = { ...profile, dbType: "gaussdb", profile: "gaussdb", label: "GaussDB", port: 8000 };
     }

--- a/crates/dbx-core/assets/database-drivers.manifest.json
+++ b/crates/dbx-core/assets/database-drivers.manifest.json
@@ -1067,7 +1067,7 @@
       "singleConnectionPool": true,
       "metadataConnectionScoped": false,
       "skipTcpProbe": true,
-      "defaultPort": 2881,
+      "defaultPort": 2883,
       "supportLevel": "operate",
       "capabilities": {
         "queryExecution": true,


### PR DESCRIPTION
## 变更内容
- 将新建连接弹窗中的 OceanBase MySQL/Oracle 模式默认端口从 2881 调整为 2883
- 将 OceanBase Oracle agent 与驱动 manifest 的默认端口调整为 2883
- 将 Navicat 导入中 OceanBase 端口缺失时的兜底值调整为 2883

## 背景
OceanBase 直连 OBServer 的 SQL 端口通常是 2881，但 ODP/OBProxy 对外 SQL 服务默认端口是 2883，客户端连接默认走 ODP 更符合常见使用方式。

参考：
- https://en.oceanbase.com/docs/common-odp-doc-en-10000000002135904
- https://en.oceanbase.com/docs/common-oceanbase-database-10000000000829739

## 验证
- pnpm exec oxlint apps/desktop/src/components/connection/ConnectionDialog.vue apps/desktop/src/lib/imports/navicatImport.ts
- pnpm typecheck
- pnpm test packages/app-tests/oceanbaseConnectionMode.test.ts packages/app-tests/connectionLevelDatabaseBootstrap.test.ts
- cargo test -p dbx-core agent_connection::tests::oceanbase_oracle_uses_oceanbase_jdbc_connection_string_for_agent_protocol
- cargo test -p dbx-core --test database_capabilities
- git diff --check

## 未完成验证
- ./gradlew :oceanbase-oracle:test 未能在本机执行：当前机器缺少 Java 8 toolchain，Gradle 无法解析 languageVersion=8 的编译器。