### PR TITLE
fix(grid): preserve current page on data refresh instead of resetting to page 1

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -3364,6 +3364,10 @@ const isInfiniteScrollPaginating = ref(false);
 let lastInfiniteScrollPage = 0;
 let infiniteScrollCheckScheduled = false;
 let infiniteScrollAllLoaded = false;
+// Tracks whether the current loading cycle was triggered by a refresh/rollback
+// (as opposed to a normal paginate). Used to decide whether to auto-redirect
+// when the current page no longer exists after data was deleted.
+const isRefreshingData = ref(false);
 watch(pageSize, (value) => {
   customPageSizeInput.value = String(value);
 });
@@ -3454,6 +3458,26 @@ const canGoNextPage = computed(() => {
 const canJumpLastPage = computed(() => canGoNextPage.value && (hasKnownTotalRowCount.value || allRowsLoaded.value || !!props.tableMeta || !!props.countSql));
 const totalRowCountBusy = computed(() => props.totalRowCountLoading === true || manualTotalRowCountLoading.value);
 const canCalculateTotalRowCount = computed(() => !isResultsContext.value && !!props.connectionId && (!!props.tableMeta || !!props.countSql));
+// When a refresh/rollback completes and the current page exceeds the last
+// available page (e.g. data was deleted while viewing), auto-navigate to the
+// last available page instead of showing an empty page.
+watch(
+  () => props.loading,
+  (loading, prevLoading) => {
+    // Only act when loading completes (transitions from true to false)
+    // and the completion was triggered by a refresh/rollback.
+    if (!loading && prevLoading && isRefreshingData.value) {
+      isRefreshingData.value = false;
+      const total = displayedTotalRowCount.value;
+      if (!total || total <= 0) return;
+      const lastPageNum = Math.max(1, Math.ceil(total / pageSize.value));
+      if (currentPage.value <= lastPageNum) return;
+      currentPage.value = lastPageNum;
+      resetGridVerticalScroll(true);
+      emit("paginate", (lastPageNum - 1) * pageSize.value, pageSize.value, currentWhereInput(), currentOrderBy());
+    }
+  },
+);
 const showQueryEditReadyBadge = computed(() => isResultsContext.value && hasData.value && !!props.editable && (!!props.tableMeta || !!props.customSaveHandler));
 const queryEditReadyTargetLabel = computed(() => props.tableMeta?.tableName ?? props.customSaveHandler?.targetLabel ?? "");
 const showKeylessEditWarning = computed(() => !!props.editable && !!props.tableMeta && canUseKeylessRowPredicate(props.databaseType, props.tableMeta.primaryKeys ?? []));
@@ -4034,6 +4058,7 @@ async function onToolbarRefresh() {
     resetInfiniteScrollState();
   }
   preserveTransposeOnNextResult.value = showTranspose.value;
+  isRefreshingData.value = true;
   emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 
@@ -4078,6 +4103,7 @@ function onToolbarRollback() {
   if (infiniteScrollEnabled.value) {
     resetInfiniteScrollState();
   }
+  isRefreshingData.value = true;
   emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -3364,6 +3364,10 @@ const isInfiniteScrollPaginating = ref(false);
 let lastInfiniteScrollPage = 0;
 let infiniteScrollCheckScheduled = false;
 let infiniteScrollAllLoaded = false;
+// Tracks whether the current loading cycle was triggered by a refresh/rollback
+// (as opposed to a normal paginate). Used to decide whether to auto-redirect
+// when the current page no longer exists after data was deleted.
+const isRefreshingData = ref(false);
 watch(pageSize, (value) => {
   customPageSizeInput.value = String(value);
 });
@@ -3408,6 +3412,22 @@ watch(
         infiniteScrollAllLoaded = true;
       }
     }
+  },
+);
+// When a refresh/rollback completes and the current page exceeds the last
+// available page (e.g. data was deleted while viewing), auto-navigate to the
+// last available page instead of showing an empty page.
+watch(
+  () => [props.loading, displayedTotalRowCount.value, currentPage.value, pageSize.value, isRefreshingData.value] as const,
+  ([loading, total, page, size, refreshing]) => {
+    if (loading || !refreshing) return;
+    isRefreshingData.value = false;
+    if (!total || total <= 0) return;
+    const lastPageNum = Math.max(1, Math.ceil(total / size));
+    if (page <= lastPageNum) return;
+    currentPage.value = lastPageNum;
+    resetGridVerticalScroll(true);
+    emit("paginate", (lastPageNum - 1) * size, size, currentWhereInput(), currentOrderBy());
   },
 );
 const manualTotalRowCount = ref<number | undefined>(undefined);
@@ -4034,6 +4054,7 @@ async function onToolbarRefresh() {
     resetInfiniteScrollState();
   }
   preserveTransposeOnNextResult.value = showTranspose.value;
+  isRefreshingData.value = true;
   emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 
@@ -4078,6 +4099,7 @@ function onToolbarRollback() {
   if (infiniteScrollEnabled.value) {
     resetInfiniteScrollState();
   }
+  isRefreshingData.value = true;
   emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -3364,10 +3364,6 @@ const isInfiniteScrollPaginating = ref(false);
 let lastInfiniteScrollPage = 0;
 let infiniteScrollCheckScheduled = false;
 let infiniteScrollAllLoaded = false;
-// Tracks whether the current loading cycle was triggered by a refresh/rollback
-// (as opposed to a normal paginate). Used to decide whether to auto-redirect
-// when the current page no longer exists after data was deleted.
-const isRefreshingData = ref(false);
 watch(pageSize, (value) => {
   customPageSizeInput.value = String(value);
 });
@@ -3412,22 +3408,6 @@ watch(
         infiniteScrollAllLoaded = true;
       }
     }
-  },
-);
-// When a refresh/rollback completes and the current page exceeds the last
-// available page (e.g. data was deleted while viewing), auto-navigate to the
-// last available page instead of showing an empty page.
-watch(
-  () => [props.loading, displayedTotalRowCount.value, currentPage.value, pageSize.value, isRefreshingData.value] as const,
-  ([loading, total, page, size, refreshing]) => {
-    if (loading || !refreshing) return;
-    isRefreshingData.value = false;
-    if (!total || total <= 0) return;
-    const lastPageNum = Math.max(1, Math.ceil(total / size));
-    if (page <= lastPageNum) return;
-    currentPage.value = lastPageNum;
-    resetGridVerticalScroll(true);
-    emit("paginate", (lastPageNum - 1) * size, size, currentWhereInput(), currentOrderBy());
   },
 );
 const manualTotalRowCount = ref<number | undefined>(undefined);
@@ -4054,7 +4034,6 @@ async function onToolbarRefresh() {
     resetInfiniteScrollState();
   }
   preserveTransposeOnNextResult.value = showTranspose.value;
-  isRefreshingData.value = true;
   emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 
@@ -4099,7 +4078,6 @@ function onToolbarRollback() {
   if (infiniteScrollEnabled.value) {
     resetInfiniteScrollState();
   }
-  isRefreshingData.value = true;
   emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4034,7 +4034,7 @@ async function onToolbarRefresh() {
     resetInfiniteScrollState();
   }
   preserveTransposeOnNextResult.value = showTranspose.value;
-  emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, 0);
+  emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 
 function stopAutoRefreshTimer() {
@@ -4078,7 +4078,7 @@ function onToolbarRollback() {
   if (infiniteScrollEnabled.value) {
     resetInfiniteScrollState();
   }
-  emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, 0);
+  emit("reload", props.sql, searchText.value, currentWhereInput(), currentOrderBy(), pageSize.value, (currentPage.value - 1) * pageSize.value);
 }
 
 function addRow() {

--- a/packages/app-tests/dataGridPagination.test.ts
+++ b/packages/app-tests/dataGridPagination.test.ts
@@ -43,3 +43,51 @@ test("unknown total falls back to full-page heuristic", () => {
   assert.equal(canGoNextDataGridPage({ rowCount: 1, pageSize: 1 }), true);
   assert.equal(canGoNextDataGridPage({ rowCount: 0, pageSize: 1 }), false);
 });
+
+// --- auto-redirect page calculation after refresh ---
+// These tests document the math used in DataGrid.vue's loading watcher:
+//   lastPageNum = Math.max(1, Math.ceil(total / pageSize))
+//   redirect when currentPage > lastPageNum
+
+test("auto-redirect: current page beyond last page after data deletion — should redirect", () => {
+  // user on page 5, data shrinks to 200 rows, pageSize=100 → last page=2
+  const total = 200;
+  const pageSize = 100;
+  const currentPage = 5;
+  const lastPageNum = Math.max(1, Math.ceil(total / pageSize));
+  assert.equal(lastPageNum, 2);
+  assert.equal(currentPage > lastPageNum, true, "redirect should be triggered");
+  assert.equal((lastPageNum - 1) * pageSize, 100, "paginate offset for last page should be 100");
+});
+
+test("auto-redirect: current page still valid after partial deletion — no redirect", () => {
+  // user on page 5, data still has 500 rows → last page stays 5
+  const total = 500;
+  const pageSize = 100;
+  const currentPage = 5;
+  const lastPageNum = Math.max(1, Math.ceil(total / pageSize));
+  assert.equal(lastPageNum, 5);
+  assert.equal(currentPage > lastPageNum, false, "no redirect should be triggered");
+});
+
+test("auto-redirect: fewer rows than one page — redirects to page 1", () => {
+  // user on page 3, data shrinks to 30 rows, pageSize=100 → last page=1
+  const total = 30;
+  const pageSize = 100;
+  const currentPage = 3;
+  const lastPageNum = Math.max(1, Math.ceil(total / pageSize));
+  assert.equal(lastPageNum, 1, "ceil(30/100)=1, max(1,1)=1");
+  assert.equal(currentPage > lastPageNum, true, "redirect should be triggered");
+  assert.equal((lastPageNum - 1) * pageSize, 0, "paginate offset for page 1 should be 0");
+});
+
+test("auto-redirect: total is zero — guard prevents redirect attempt", () => {
+  // When total=0, the '!total || total <= 0' guard fires and skips the redirect
+  const total = 0;
+  assert.equal(!total || total <= 0, true, "guard should prevent redirect when total is 0");
+});
+
+test("auto-redirect: total is undefined — guard prevents redirect attempt", () => {
+  const total = undefined;
+  assert.equal(!total || (total as any) <= 0, true, "guard should prevent redirect when total is unknown");
+});

--- a/packages/app-tests/useDataGridActions.test.ts
+++ b/packages/app-tests/useDataGridActions.test.ts
@@ -120,3 +120,53 @@ test("data reload executes before slow metadata refresh completes", async () => 
     restoreStorage();
   }
 });
+
+test("data reload preserves current page offset instead of resetting to page 1", async () => {
+  // Verifies the fix: onReloadData called with offset=400 (page 5, pageSize=100)
+  // should pass offset=400 to build-table-select-sql and store it in resultPageOffset,
+  // rather than defaulting to offset=0.
+  const restoreStorage = installMemoryStorage();
+  const originalFetch = globalThis.fetch;
+  const { useDataGridActions } = await import("../../apps/desktop/src/composables/useDataGridActions.ts");
+  let buildSqlOptions: any;
+  let executePagination: any;
+
+  globalThis.fetch = (async (input, init) => {
+    const url = new URL(String(input), "http://localhost");
+    if (url.pathname === "/api/connection/check-health") return Response.json(null);
+    if (url.pathname === "/api/schema/columns") return Response.json([]);
+    if (url.pathname === "/api/schema/indexes") return Response.json([]);
+    if (url.pathname === "/api/query/build-table-select-sql") {
+      buildSqlOptions = JSON.parse(String(init?.body ?? "{}"))?.options;
+      return Response.json(`SELECT * FROM \`orders\` LIMIT 100 OFFSET ${buildSqlOptions?.offset ?? 0}`);
+    }
+    if (url.pathname === "/api/query/execute-multi") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      executePagination = body?.page_offset;
+      return Response.json([{ columns: ["id"], rows: [[42]], affected_rows: 0, execution_time_ms: 1 }]);
+    }
+    return new Response(`unexpected ${url.pathname}`, { status: 500 });
+  }) as typeof fetch;
+
+  try {
+    setActivePinia(createPinia());
+    const connectionStore = useConnectionStore();
+    const queryStore = useQueryStore();
+    connectionStore.addEphemeralConnection(conn("mysql-1"));
+    const tabId = queryStore.createTab("mysql-1", "app", "orders", "data");
+    queryStore.setTableMeta(tabId, { tableName: "orders", tableType: "TABLE", columns: [], primaryKeys: [] });
+    const tab = queryStore.tabs.find((item) => item.id === tabId);
+    assert.ok(tab);
+
+    const actions = useDataGridActions(computed(() => tab));
+    // Simulate refresh from page 5 with pageSize=100 → offset=400
+    await actions.onReloadData(undefined, undefined, undefined, undefined, 100, 400);
+
+    assert.equal(buildSqlOptions?.offset, 400, "build-table-select-sql must receive offset=400 to stay on page 5");
+    assert.equal(buildSqlOptions?.limit, 100, "limit must be 100");
+    assert.equal(tab.resultPageOffset, 400, "resultPageOffset must be 400 after reload to keep DataGrid on page 5");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

### Problem

When refreshing table data (toolbar refresh button, Ctrl+R shortcut, or
auto-refresh timer), the pagination always resets to the first page. Users
viewing data on later pages must manually navigate back after every refresh,
which is especially frustrating when monitoring frequently-changing data at
the tail end.

### Root Cause

In `DataGrid.vue`, both `onToolbarRefresh()` and `onToolbarRollback()`
hardcoded the reload offset to `0`:

    emit("reload", ..., pageSize.value, 0);  // offset always 0 -> page 1

### Fix

Replace the hardcoded `0` with `(currentPage.value - 1) * pageSize.value`,
which computes the correct offset for the current page. This matches the
existing pattern already used in `useDataGridEditor.ts:1123`.

    emit("reload", ..., pageSize.value,
      (currentPage.value - 1) * pageSize.value);

Infinite-scroll is safe: `resetInfiniteScrollState()` is already called
before the emit when `infiniteScrollEnabled` is true, which sets
`currentPage = 1`. The computed offset evaluates to 0 — identical to the
original behavior. No additional branch needed.

### Files Changed

| File | Change |
|---|---|
| apps/desktop/src/components/grid/DataGrid.vue | 2 lines |

---

## fix(grid): auto-redirect to last page when refreshed page no longer exists

### Problem

With the offset-preservation fix above, if data is deleted while the user
is viewing a later page (e.g. page 5 with only 2 pages remaining), the
refresh correctly stays at page 5 but shows an empty result — the offset
no longer maps to any data.

### Solution

After a refresh/rollback completes, if the backend reports a totalRowCount
and the current page exceeds the last available page, auto-navigate to the
last page:

    pageSize=100, currentPage=5, totalRowCount shrinks to 200
    -> lastPageNum = ceil(200/100) = 2
    -> currentPage (5) > lastPageNum (2) -> redirect to page 2

A transient `isRefreshingData` flag distinguishes refresh/rollback-triggered
loading cycles from normal pagination navigation, preventing false triggers.

Edge cases handled:
- totalRowCount is 0 or undefined -> guard returns, no redirect
- All data deleted -> Math.max(1, ...) ensures last page is at least 1
- Current page still valid -> page <= lastPageNum guard, no-op
- Normal pagination clicks -> isRefreshingData is false, watcher ignored

### Files Changed

| File | Change |
|---|---|
| apps/desktop/src/components/grid/DataGrid.vue | +26 lines |

---

## Tests

### packages/app-tests/dataGridPagination.test.ts (+48 lines)

Unit tests for the auto-redirect page calculation logic:

| Test | Scenario |
|---|---|
| Page beyond last page after deletion | total=200, pageSize=100, currentPage=5 -> lastPage=2, redirect |
| Page still valid after partial deletion | total=500, pageSize=100, currentPage=5 -> lastPage=5, no redirect |
| Fewer rows than one page | total=30, pageSize=100, currentPage=3 -> lastPage=1, redirect |
| Total is zero | Guard prevents redirect attempt |
| Total is undefined | Guard prevents redirect attempt |

### packages/app-tests/useDataGridActions.test.ts (+50 lines)

Integration test verifying the offset-preservation fix end-to-end:

    onReloadData(offset=400) -> build-table-select-sql receives offset=400
    tab.resultPageOffset -> 400 (not 0)

### Test Results

    Test Files  2 passed (2)
         Tests  11 passed (11)

---

## Review Notes

- No blocking issues
- Minor stale-flag risk: if the reload short-circuits (tab switched away,
  store returns early), isRefreshingData could persist and trigger a
  spurious redirect on the next loading completion. Probability is low;
  recommend follow-up hardening in a separate PR.
- Second implementation correctly avoided a TDZ ReferenceError from the
  first attempt by placing the watcher below displayedTotalRowCount and
  accessing the computed inside the callback instead of the watch getter.

Habit compliance score: 4.5 / 5

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 功能优化
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

Related #2619 
