### PR TITLE
Fix: 修复旧版 StarRocks 连接初始化失败

### DIFF
--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -448,7 +448,7 @@ async fn connect_bare_mysql_pool_with_setup(
 ) -> Result<db::mysql::MySqlPool, String> {
     if db_config.bare_mysql_uses_tls() {
         let idle_timeout_secs = Some(db_config.idle_timeout_secs);
-        db::mysql::connect_with_ca_cert_pool_limit_idle_and_setup(
+        db::mysql::connect_compatible_with_ca_cert_pool_limit_idle_and_setup(
             url,
             Some(&db_config.ca_cert_path),
             connect_timeout,
@@ -475,7 +475,7 @@ async fn connect_bare_mysql_pool_with_setup_database(
     // separately so DB-layer setup keeps the normal charset/catalog/USE order.
     if db_config.bare_mysql_uses_tls() {
         let idle_timeout_secs = Some(db_config.idle_timeout_secs);
-        db::mysql::connect_with_ca_cert_pool_limit_idle_and_setup_database(
+        db::mysql::connect_compatible_with_ca_cert_pool_limit_idle_and_setup_database(
             url,
             Some(&db_config.ca_cert_path),
             connect_timeout,

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -452,8 +452,81 @@ pub async fn connect_with_ca_cert_pool_limit_idle_and_setup_database(
     setup_database: Option<&str>,
     extra_setup_queries: &[String],
 ) -> Result<MySqlPool, String> {
+    connect_with_ca_cert_pool_limit_idle_setup_database_with_mode(
+        url,
+        ca_cert_path,
+        fallback_timeout,
+        max_connections,
+        idle_timeout_secs,
+        setup_database,
+        extra_setup_queries,
+        MySqlSetupMode::Standard,
+    )
+    .await
+}
+
+pub async fn connect_compatible_with_ca_cert_pool_limit_idle_and_setup(
+    url: &str,
+    ca_cert_path: Option<&str>,
+    fallback_timeout: Duration,
+    max_connections: usize,
+    idle_timeout_secs: Option<u64>,
+    extra_setup_queries: &[String],
+) -> Result<MySqlPool, String> {
+    connect_compatible_with_ca_cert_pool_limit_idle_and_setup_database(
+        url,
+        ca_cert_path,
+        fallback_timeout,
+        max_connections,
+        idle_timeout_secs,
+        None,
+        extra_setup_queries,
+    )
+    .await
+}
+
+pub async fn connect_compatible_with_ca_cert_pool_limit_idle_and_setup_database(
+    url: &str,
+    ca_cert_path: Option<&str>,
+    fallback_timeout: Duration,
+    max_connections: usize,
+    idle_timeout_secs: Option<u64>,
+    setup_database: Option<&str>,
+    extra_setup_queries: &[String],
+) -> Result<MySqlPool, String> {
+    connect_with_ca_cert_pool_limit_idle_setup_database_with_mode(
+        url,
+        ca_cert_path,
+        fallback_timeout,
+        max_connections,
+        idle_timeout_secs,
+        setup_database,
+        extra_setup_queries,
+        MySqlSetupMode::Compatible,
+    )
+    .await
+}
+
+async fn connect_with_ca_cert_pool_limit_idle_setup_database_with_mode(
+    url: &str,
+    ca_cert_path: Option<&str>,
+    fallback_timeout: Duration,
+    max_connections: usize,
+    idle_timeout_secs: Option<u64>,
+    setup_database: Option<&str>,
+    extra_setup_queries: &[String],
+    setup_mode: MySqlSetupMode,
+) -> Result<MySqlPool, String> {
     let timeout = super::parse_connect_timeout_with_fallback(url, fallback_timeout);
-    let pool = create_pool(url, ca_cert_path, max_connections, idle_timeout_secs, setup_database, extra_setup_queries)?;
+    let pool = create_pool(
+        url,
+        ca_cert_path,
+        max_connections,
+        idle_timeout_secs,
+        setup_database,
+        extra_setup_queries,
+        setup_mode,
+    )?;
     let result = verify_pool_connection(&pool, timeout).await;
 
     if let Err(ref e) = result {
@@ -467,6 +540,7 @@ pub async fn connect_with_ca_cert_pool_limit_idle_and_setup_database(
                     idle_timeout_secs,
                     setup_database,
                     extra_setup_queries,
+                    setup_mode,
                 )?;
                 return match verify_pool_connection(&fallback_pool, timeout).await {
                     Ok(()) => Ok(fallback_pool),
@@ -485,6 +559,18 @@ struct MySqlTlsFiles {
     sslkey: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MySqlSetupMode {
+    Standard,
+    Compatible,
+}
+
+impl MySqlSetupMode {
+    fn set_group_concat_max_len(self) -> bool {
+        self == Self::Standard
+    }
+}
+
 fn create_pool(
     url: &str,
     ca_cert_path: Option<&str>,
@@ -492,6 +578,7 @@ fn create_pool(
     idle_timeout_secs: Option<u64>,
     setup_database: Option<&str>,
     extra_setup_queries: &[String],
+    setup_mode: MySqlSetupMode,
 ) -> Result<MySqlPool, String> {
     let tls_url = mysql_tls_url(url)?;
     let opts =
@@ -508,9 +595,15 @@ fn create_pool(
         .with_constraints(mysql_async::PoolConstraints::new(1, max_connections).unwrap())
         .with_inactive_connection_ttl(inactive_ttl)
         .with_reset_connection(max_connections > 1);
-    let setup_queries = match setup_database {
-        Some(database) => mysql_setup_queries_for_database(url, Some(database), extra_setup_queries),
-        None => mysql_setup_queries(url, extra_setup_queries),
+    let setup_queries = match (setup_database, setup_mode) {
+        (Some(database), MySqlSetupMode::Standard) => {
+            mysql_setup_queries_for_database(url, Some(database), extra_setup_queries)
+        }
+        (None, MySqlSetupMode::Standard) => mysql_setup_queries(url, extra_setup_queries),
+        (Some(database), MySqlSetupMode::Compatible) => {
+            mysql_setup_queries_for_database_with_mode(url, Some(database), extra_setup_queries, setup_mode)
+        }
+        (None, MySqlSetupMode::Compatible) => mysql_setup_queries_with_mode(url, extra_setup_queries, setup_mode),
     };
     let mut builder = mysql_async::OptsBuilder::from_opts(opts)
         .ip_or_hostname(tcp_host)
@@ -634,13 +727,26 @@ fn mysql_ssl_opts(
 }
 
 fn mysql_setup_queries(url: &str, extra_setup_queries: &[String]) -> Vec<String> {
-    mysql_setup_queries_for_database(url, None, extra_setup_queries)
+    mysql_setup_queries_with_mode(url, extra_setup_queries, MySqlSetupMode::Standard)
 }
 
 fn mysql_setup_queries_for_database(
     url: &str,
     setup_database: Option<&str>,
     extra_setup_queries: &[String],
+) -> Vec<String> {
+    mysql_setup_queries_for_database_with_mode(url, setup_database, extra_setup_queries, MySqlSetupMode::Standard)
+}
+
+fn mysql_setup_queries_with_mode(url: &str, extra_setup_queries: &[String], setup_mode: MySqlSetupMode) -> Vec<String> {
+    mysql_setup_queries_for_database_with_mode(url, None, extra_setup_queries, setup_mode)
+}
+
+fn mysql_setup_queries_for_database_with_mode(
+    url: &str,
+    setup_database: Option<&str>,
+    extra_setup_queries: &[String],
+    setup_mode: MySqlSetupMode,
 ) -> Vec<String> {
     let charset = mysql_connection_charset(url).unwrap_or("utf8mb4");
     let catalog = mysql_connection_catalog(url);
@@ -654,9 +760,11 @@ fn mysql_setup_queries_for_database(
     }
     queries.push(format!("SET NAMES {charset}"));
     // MySQL defaults group_concat_max_len to 1024, which silently truncates
-    // GROUP_CONCAT results. Use @@ syntax because Manticore accepts it as a
-    // compatibility no-op while `SET SESSION` fails during connection setup.
-    queries.push("SET @@group_concat_max_len = 1048576".to_string());
+    // GROUP_CONCAT results. Skip it for MySQL protocol-compatible databases
+    // such as old StarRocks versions that reject unknown MySQL variables.
+    if setup_mode.set_group_concat_max_len() {
+        queries.push("SET @@group_concat_max_len = 1048576".to_string());
+    }
     // StarRocks/Doris expose external storage (Paimon, Hive, ...) through a
     // catalog. `SET catalog` must run *before* `USE <database>` (the database
     // lives in the external catalog and is unknown to the default one).
@@ -1219,7 +1327,8 @@ pub async fn connect_bare_with_pool_limit_and_setup_database(
     extra_setup_queries: &[String],
 ) -> Result<MySqlPool, String> {
     let timeout = super::parse_connect_timeout_with_fallback(url, fallback_timeout);
-    let pool = create_pool(url, None, max_connections, None, setup_database, extra_setup_queries)?;
+    let pool =
+        create_pool(url, None, max_connections, None, setup_database, extra_setup_queries, MySqlSetupMode::Compatible)?;
     verify_pool_connection(&pool, timeout).await.map(|_| pool)
 }
 
@@ -3848,6 +3957,37 @@ UNIQUE KEY(`tenant_id`, `name``part`)
         let queries = mysql_setup_queries("mysql://root:secret@localhost:3306?charset=utf8mb4", &[]);
 
         assert_eq!(queries, vec!["SET NAMES utf8mb4", "SET @@group_concat_max_len = 1048576"]);
+    }
+
+    #[test]
+    fn mysql_compatible_setup_queries_skip_group_concat_variable() {
+        let queries = mysql_setup_queries_with_mode(
+            "mysql://root:secret@localhost:9030/analytics?charset=utf8mb4",
+            &[],
+            MySqlSetupMode::Compatible,
+        );
+
+        assert_eq!(queries, vec!["USE `analytics`", "SET NAMES utf8mb4"]);
+    }
+
+    #[test]
+    fn mysql_compatible_setup_queries_keep_catalog_and_extra_queries() {
+        let extra = vec!["SET ob_query_timeout = 30000000".to_string()];
+        let queries = mysql_setup_queries_with_mode(
+            "mysql://root:secret@localhost:9030/clip?catalog=paimon_catalog",
+            &extra,
+            MySqlSetupMode::Compatible,
+        );
+
+        assert_eq!(
+            queries,
+            vec![
+                "USE `clip`",
+                "SET NAMES utf8mb4",
+                "SET catalog = `paimon_catalog`",
+                "SET ob_query_timeout = 30000000"
+            ]
+        );
     }
 
     #[test]

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -267,6 +267,7 @@ mod tests {
             driver_profile: None,
             driver_label: None,
             url_params: None,
+            agent_java_options: Vec::new(),
             host: path.to_string(),
             port: 0,
             username: String::new(),

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -163,6 +163,7 @@ mod tests {
             driver_profile: Some("mongodb".to_string()),
             driver_label: Some("MongoDB".to_string()),
             url_params: Some("authSource=admin&authMechanism=SCRAM-SHA-1".to_string()),
+            agent_java_options: Vec::new(),
             host: "172.22.4.42".to_string(),
             port: 27017,
             username: "mongouser".to_string(),
@@ -596,7 +597,16 @@ pub async fn test_connection(state: State<'_, Arc<AppState>>, config: Connection
                 }
             }
             DatabaseType::Mysql if config.needs_bare_mysql() && config.bare_mysql_uses_tls() => {
-                match db::mysql::connect_with_ca_cert(&url, Some(&config.ca_cert_path), connect_timeout).await {
+                match db::mysql::connect_compatible_with_ca_cert_pool_limit_idle_and_setup(
+                    &url,
+                    Some(&config.ca_cert_path),
+                    connect_timeout,
+                    10,
+                    None,
+                    &[],
+                )
+                .await
+                {
                     Ok(pool) => {
                         let _ = pool.disconnect().await;
                         Ok("Connection successful".to_string())
@@ -624,7 +634,15 @@ pub async fn test_connection(state: State<'_, Arc<AppState>>, config: Connection
             }
             DatabaseType::StarRocks => {
                 let connect = if config.bare_mysql_uses_tls() {
-                    db::mysql::connect_with_ca_cert(&url, Some(&config.ca_cert_path), connect_timeout).await
+                    db::mysql::connect_compatible_with_ca_cert_pool_limit_idle_and_setup(
+                        &url,
+                        Some(&config.ca_cert_path),
+                        connect_timeout,
+                        10,
+                        None,
+                        &[],
+                    )
+                    .await
                 } else {
                     db::mysql::connect_bare(&url, connect_timeout).await
                 };


### PR DESCRIPTION
## 变更说明
- 将 MySQL 连接初始化拆分为标准模式和兼容模式。
- 标准 MySQL 连接继续执行 `SET @@group_concat_max_len = 1048576`，避免 `GROUP_CONCAT` 结果被默认长度截断。
- StarRocks/Doris/Manticore 等 MySQL 协议兼容连接跳过该 MySQL 专有变量，避免旧版 StarRocks 报 `Unknown system variable 'group_concat_max_len'`。
- 补齐 TLS 测试连接路径，确保加密连接也使用兼容初始化逻辑。

Fixes #2841

## 验证
- `git diff --check`
- `rustfmt --check crates/dbx-core/src/db/mysql.rs crates/dbx-core/src/connection.rs src-tauri/src/commands/connection.rs`
- `cargo test -p dbx-core mysql_setup_queries`
- `cargo test -p dbx-core mysql_compatible_setup_queries`
- `cargo check -p dbx`

## 备注
- 本地没有旧版 StarRocks 实例，未做真实连接验证。