### PR TITLE
fix(spark,hive): use small fetchSize to prevent Thrift FetchResults failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ DBX_*_x64-portable.zip
 .pnpm-store/*
 .dbx-web
 _dev
+_repro_ddl*.mjs

--- a/agents/drivers/hive/src/main/java/com/dbx/agent/hive/HiveAgent.java
+++ b/agents/drivers/hive/src/main/java/com/dbx/agent/hive/HiveAgent.java
@@ -10,6 +10,8 @@ import com.dbx.agent.JdbcIdentifiers;
 import com.dbx.agent.JsonRpcServer;
 import com.dbx.agent.TableInfo;
 import com.dbx.agent.TriggerInfo;
+import com.dbx.agent.ExecuteQueryOptions;
+import com.dbx.agent.QueryResult;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -100,6 +102,19 @@ public final class HiveAgent extends AbstractJdbcAgent {
     @Override
     public String setSchemaSQL(String schema) {
         return "USE " + JdbcIdentifiers.INSTANCE.backtick(schema);
+    }
+
+    @Override
+    public QueryResult executeQuery(String sql, String schema, ExecuteQueryOptions options) {
+        // Hive JDBC fetches rows via Thrift FetchResults in batches controlled
+        // by fetchSize. A large fetchSize can fail with "Error retrieving next
+        // row" when the result contains large binary/struct columns. Use a
+        // small fetchSize (50) so each Thrift batch stays within limits.
+        return super.executeQuery(sql, schema, new ExecuteQueryOptions(
+            options.getMaxRows(),
+            50,
+            options.getTimeoutSecs()
+        ));
     }
 
     @Override

--- a/agents/drivers/hive/src/test/java/com/dbx/agent/hive/HiveAgentExecutionTest.java
+++ b/agents/drivers/hive/src/test/java/com/dbx/agent/hive/HiveAgentExecutionTest.java
@@ -1,7 +1,17 @@
 package com.dbx.agent.hive;
 
 import com.dbx.agent.DatabaseAgent;
+import com.dbx.agent.ExecuteQueryOptions;
+import com.dbx.agent.QueryResult;
+import com.dbx.agent.test.JdbcAgentFake;
 import com.dbx.agent.test.JdbcFakeExecutionBehaviorTest;
+import com.dbx.agent.test.TestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HiveAgentExecutionTest extends JdbcFakeExecutionBehaviorTest {
     @Override
@@ -12,5 +22,33 @@ class HiveAgentExecutionTest extends JdbcFakeExecutionBehaviorTest {
     @Override
     protected String resultSetSql() {
         return "MSCK REPAIR TABLE sample";
+    }
+
+    // Override: HiveAgent.executeQuery forces fetchSize=50 to keep Thrift
+    // FetchResults batches small (prevents "Error retrieving next row" on
+    // tables with large binary/struct columns).
+    @Override
+    @Test
+    void executesNonSelectStatementsThatReturnResultSets() {
+        DatabaseAgent agent = createAgent();
+        TestSupport.setPrivateConnection(agent, JdbcAgentFake.connection());
+
+        QueryResult result = agent.executeQuery(resultSetSql(), null, new ExecuteQueryOptions());
+
+        assertEquals(Collections.singletonList("VALUE"), result.getColumns());
+        assertEquals(Collections.singletonList(Collections.singletonList("row-value")), result.getRows());
+        assertEquals(Arrays.asList("setMaxRows:10001", "setFetchSize:50", "execute"), JdbcAgentFake.calls);
+    }
+
+    @Override
+    @Test
+    void appliesExecutionRowAndFetchLimitsToJdbcStatements() {
+        DatabaseAgent agent = createAgent();
+        TestSupport.setPrivateConnection(agent, JdbcAgentFake.connection());
+
+        QueryResult result = agent.executeQuery(resultSetSql(), null, new ExecuteQueryOptions(1, 25));
+
+        assertEquals(Collections.singletonList(Collections.singletonList("row-value")), result.getRows());
+        assertEquals(Arrays.asList("setMaxRows:2", "setFetchSize:50", "execute"), JdbcAgentFake.calls);
     }
 }

--- a/agents/drivers/spark/src/main/java/com/dbx/agent/spark/SparkAgent.java
+++ b/agents/drivers/spark/src/main/java/com/dbx/agent/spark/SparkAgent.java
@@ -10,6 +10,8 @@ import com.dbx.agent.JdbcIdentifiers;
 import com.dbx.agent.JsonRpcServer;
 import com.dbx.agent.TableInfo;
 import com.dbx.agent.TriggerInfo;
+import com.dbx.agent.ExecuteQueryOptions;
+import com.dbx.agent.QueryResult;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -30,6 +32,19 @@ import java.util.Locale;
 // at the catalog root with no databases (Lance). Mirrors the StarRocks catalog flow.
 public final class SparkAgent extends AbstractJdbcAgent {
     private String configuredCatalog;
+
+    @Override
+    public QueryResult executeQuery(String sql, String schema, ExecuteQueryOptions options) {
+        // Hive JDBC fetches rows via Thrift FetchResults in batches controlled
+        // by fetchSize. A large fetchSize can fail with "Error retrieving next
+        // row" when the result contains large binary/struct columns. Use a
+        // small fetchSize (50) so each Thrift batch stays within limits.
+        return super.executeQuery(sql, schema, new ExecuteQueryOptions(
+            options.getMaxRows(),
+            50,
+            options.getTimeoutSecs()
+        ));
+    }
 
     @Override
     protected String driverClass() {


### PR DESCRIPTION
## Problem

Opening tables with large binary/struct columns (e.g., Spark Lance tables with protobuf blobs) via DBX fails with:

```
Agent RPC error (-1): java.sql.SQLException: Error retrieving next row
```

## Root Cause

Hive JDBC (used by both Spark and Hive agents) fetches rows via Thrift `FetchResults` RPC in batches controlled by `fetchSize`. DBX passes `fetchSize=500`, which causes the driver to try serializing all 500 rows (including large `binary` columns) in a single Thrift batch. When the total data exceeds Thrift serialization limits, the batch fails.

## Fix

Override `executeQuery` in `SparkAgent` and `HiveAgent` to set `fetchSize=50`. Each Thrift `FetchResults` call now only serializes 50 rows, staying within limits. The driver makes multiple calls to fetch all rows — no data loss, no LIMIT cap.

| | Before | After |
|---|---|---|
| fetchSize | 500 (from DBX) | 50 (overridden) |
| Thrift batch | 500 rows × binary cols = GB-level | 50 rows × binary cols = manageable |
| Result | ❌ serialization failure | ✅ multiple small batches succeed |

## Scope

Only affects Spark and Hive agents (both use Hive JDBC + Thrift). Other drivers (Oracle, Trino, etc.) use different protocols and are not affected. No common module changes.

## Testing

- `SELECT * FROM lance_clip10w.feature_v2 LIMIT 500` (35 cols, 7 binary) — was failing, now succeeds ✅
- Hive agent tests updated to expect fetchSize=50 ✅
- No common module changes (no impact on other agents) ✅