### PR TITLE
 fix(sqlserver): strip display width from float type in DDL generation

### DIFF
--- a/crates/dbx-core/src/table_structure_sql/column_format.rs
+++ b/crates/dbx-core/src/table_structure_sql/column_format.rs
@@ -148,6 +148,12 @@ pub(super) fn normalize_column_data_type(dialect: StructureDialect, data_type: &
         return base_type.to_string();
     }
 
+    if dialect == StructureDialect::SqlServer && is_sqlserver_float_with_scale(base_type, params) {
+        // SQL Server float only accepts a single integer mantissa bit count (1–53),
+        // not comma-separated precision/scale like float(10,2).
+        return base_type.to_string();
+    }
+
     if is_temporal_precision_type(dialect, base_type) {
         return if is_valid_temporal_precision(params, dialect) {
             format!("{base_type}({params})")
@@ -209,6 +215,13 @@ fn is_sqlserver_lengthless_type(base_type: &str) -> bool {
             | "uniqueidentifier"
             | "xml"
     )
+}
+
+/// SQL Server `float` accepts a single integer mantissa bit count (1–53)
+/// but rejects comma-separated precision/scale like `float(10,2)`.
+fn is_sqlserver_float_with_scale(base_type: &str, params: &str) -> bool {
+    let normalized = base_type.split_whitespace().collect::<Vec<_>>().join(" ").to_ascii_lowercase();
+    normalized == "float" && params.contains(',')
 }
 
 fn normalize_mysql_numeric_attribute_type(base_type: &str, params: &str) -> Option<String> {

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -1292,6 +1292,50 @@ fn sqlserver_strips_mysql_display_width_from_fixed_integer_types() {
 }
 
 #[test]
+fn sqlserver_strips_scale_from_float() {
+    let mut amount = column("amount");
+    amount.data_type = "float(10,2)".to_string();
+    amount.is_nullable = true;
+
+    let result = build_table_structure_change_sql(TableStructureSqlOptions {
+        database_type: Some(DatabaseType::SqlServer),
+        schema: Some("dbo".to_string()),
+        table_name: "orders".to_string(),
+        columns: vec![amount],
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        triggers: Vec::new(),
+        table_comment: None,
+        original_table_comment: None,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.statements, vec!["ALTER TABLE [dbo].[orders] ADD [amount] float;"]);
+}
+
+#[test]
+fn sqlserver_preserves_float_mantissa_bits() {
+    let mut value = column("value");
+    value.data_type = "float(53)".to_string();
+    value.is_nullable = false;
+
+    let result = build_table_structure_change_sql(TableStructureSqlOptions {
+        database_type: Some(DatabaseType::SqlServer),
+        schema: Some("dbo".to_string()),
+        table_name: "measurements".to_string(),
+        columns: vec![value],
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        triggers: Vec::new(),
+        table_comment: None,
+        original_table_comment: None,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(result.statements, vec!["ALTER TABLE [dbo].[measurements] ADD [value] float(53) NOT NULL;"]);
+}
+
+#[test]
 fn sqlserver_default_changes_drop_old_constraints_with_isolated_batches() {
     let mut sku = column("sku");
     sku.data_type = "nvarchar(64)".to_string();

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -303,6 +303,7 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
+            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -201,6 +201,7 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
+            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }


### PR DESCRIPTION
### 问题
SQL Server 建表 SQL 生成时，float 类型会错误地带上设计器里的长度如 float(10,2)，导致执行报错。

### 修复
SQL Server float(10,2) → float（去掉逗号参数），保留合法的 float(53)

### Issue
#2851 


