### PR TITLE
Fix：优化 Oracle 当前用户对象列表查询

### DIFF
--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -75,6 +75,21 @@ FROM ALL_OBJECTS o
 WHERE o.OWNER = :2
   AND o.OBJECT_TYPE = 'VIEW'
 )`
+const oracleListTablesSessionUserBaseSQL = `
+SELECT OBJECT_NAME, TABLE_TYPE, COMMENTS
+FROM (
+SELECT t.TABLE_NAME AS OBJECT_NAME,
+       'TABLE' AS TABLE_TYPE,
+       CAST(NULL AS VARCHAR2(4000)) AS COMMENTS
+FROM USER_TABLES t
+WHERE t.NESTED = 'NO'
+UNION ALL
+SELECT o.OBJECT_NAME,
+       'VIEW' AS TABLE_TYPE,
+       CAST(NULL AS VARCHAR2(4000)) AS COMMENTS
+FROM USER_OBJECTS o
+WHERE o.OBJECT_TYPE = 'VIEW'
+)`
 const oracleListTablesOrderSQL = `ORDER BY OBJECT_NAME`
 const oracleListTablesSQL = oracleListTablesBaseSQL + "\n" + oracleListTablesOrderSQL
 const oracleListObjectsBaseSQL = `
@@ -93,6 +108,21 @@ SELECT o.OBJECT_NAME,
 FROM ALL_OBJECTS o
 WHERE o.OWNER = :2
   AND o.OBJECT_TYPE IN ('VIEW', 'PROCEDURE', 'FUNCTION', 'PACKAGE', 'PACKAGE BODY')
+)`
+const oracleListObjectsSessionUserBaseSQL = `
+SELECT OBJECT_NAME, OBJECT_TYPE, COMMENTS
+FROM (
+SELECT t.TABLE_NAME AS OBJECT_NAME,
+       'TABLE' AS OBJECT_TYPE,
+       CAST(NULL AS VARCHAR2(4000)) AS COMMENTS
+FROM USER_TABLES t
+WHERE t.NESTED = 'NO'
+UNION ALL
+SELECT o.OBJECT_NAME,
+       CASE o.OBJECT_TYPE WHEN 'PACKAGE BODY' THEN 'PACKAGE_BODY' ELSE o.OBJECT_TYPE END AS OBJECT_TYPE,
+       CAST(NULL AS VARCHAR2(4000)) AS COMMENTS
+FROM USER_OBJECTS o
+WHERE o.OBJECT_TYPE IN ('VIEW', 'PROCEDURE', 'FUNCTION', 'PACKAGE', 'PACKAGE BODY')
 )`
 const oracleListObjectsOrderSQL = `ORDER BY CASE OBJECT_TYPE
   WHEN 'TABLE' THEN 0
@@ -785,6 +815,23 @@ func (s *server) normalizeSchema(schema string) (string, error) {
 	return strings.ToUpper(schema), nil
 }
 
+func (s *server) sessionUser() (string, error) {
+	db, err := s.requireDB()
+	if err != nil {
+		return "", err
+	}
+	var username string
+	if err := db.QueryRow("SELECT SYS_CONTEXT('USERENV', 'SESSION_USER') FROM DUAL").Scan(&username); err != nil {
+		return "", err
+	}
+	return strings.ToUpper(username), nil
+}
+
+func (s *server) schemaIsSessionUser(schema string) bool {
+	username, err := s.sessionUser()
+	return err == nil && strings.EqualFold(schema, username)
+}
+
 type oracleMetadataListQuery struct {
 	SQL  string
 	Args []any
@@ -822,6 +869,17 @@ func oracleListTablesQuery(schema string, constraints metadataListConstraints) o
 	)
 }
 
+func oracleListSessionUserTablesQuery(constraints metadataListConstraints) oracleMetadataListQuery {
+	return oracleConstrainedMetadataListQuery(
+		oracleListTablesSessionUserBaseSQL,
+		"OBJECT_NAME, TABLE_TYPE, COMMENTS",
+		"TABLE_TYPE",
+		oracleListTablesOrderSQL,
+		nil,
+		constraints,
+	)
+}
+
 func oracleListObjectsQuery(schema string, constraints metadataListConstraints) oracleMetadataListQuery {
 	return oracleConstrainedMetadataListQuery(
 		oracleListObjectsBaseSQL,
@@ -829,6 +887,17 @@ func oracleListObjectsQuery(schema string, constraints metadataListConstraints) 
 		"OBJECT_TYPE",
 		oracleListObjectsOrderSQL,
 		[]any{schema, schema},
+		constraints,
+	)
+}
+
+func oracleListSessionUserObjectsQuery(constraints metadataListConstraints) oracleMetadataListQuery {
+	return oracleConstrainedMetadataListQuery(
+		oracleListObjectsSessionUserBaseSQL,
+		"OBJECT_NAME, OBJECT_TYPE, COMMENTS",
+		"OBJECT_TYPE",
+		oracleListObjectsOrderSQL,
+		nil,
 		constraints,
 	)
 }
@@ -923,6 +992,9 @@ func (s *server) listTables(schema string, constraints metadataListConstraints) 
 		return nil, err
 	}
 	query := oracleListTablesQuery(schema, constraints)
+	if s.schemaIsSessionUser(schema) {
+		query = oracleListSessionUserTablesQuery(constraints)
+	}
 	rows, err := s.queryRows(query.SQL, query.Args)
 	if err != nil {
 		if isOraclePGALimitError(err) {
@@ -948,6 +1020,9 @@ func (s *server) listObjects(schema string, constraints metadataListConstraints)
 		return nil, err
 	}
 	query := oracleListObjectsQuery(schema, constraints)
+	if s.schemaIsSessionUser(schema) {
+		query = oracleListSessionUserObjectsQuery(constraints)
+	}
 	rows, err := s.queryRows(query.SQL, query.Args)
 	if err != nil {
 		if isOraclePGALimitError(err) {

--- a/agents/drivers/oracle-go/main_test.go
+++ b/agents/drivers/oracle-go/main_test.go
@@ -474,6 +474,41 @@ func TestListTablesQueryAppliesMetadataConstraints(t *testing.T) {
 	}
 }
 
+func TestListSessionUserTablesQueryUsesUserDictionary(t *testing.T) {
+	query := oracleListSessionUserTablesQuery(metadataListConstraints{
+		Filter:      "u_r",
+		Limit:       501,
+		Offset:      10,
+		ObjectTypes: []string{"view", "TABLE", "TABLE"},
+	})
+	sqlText := strings.ToUpper(query.SQL)
+
+	if !strings.Contains(sqlText, "USER_TABLES") || !strings.Contains(sqlText, "USER_OBJECTS") {
+		t.Fatalf("session-user table listing should use USER_* dictionaries, got: %s", query.SQL)
+	}
+	if strings.Contains(sqlText, "ALL_TABLES") || strings.Contains(sqlText, "ALL_OBJECTS") {
+		t.Fatalf("session-user table listing should avoid ALL_* dictionaries, got: %s", query.SQL)
+	}
+	if strings.Contains(sqlText, "OWNER =") {
+		t.Fatalf("session-user table listing should not add owner predicates, got: %s", query.SQL)
+	}
+	if !strings.Contains(sqlText, "UPPER(OBJECT_NAME) LIKE :1 ESCAPE '\\'") {
+		t.Fatalf("table listing should push filter predicate, got: %s", query.SQL)
+	}
+	if !strings.Contains(sqlText, "TABLE_TYPE IN (:2,:3)") {
+		t.Fatalf("table listing should push table type predicate, got: %s", query.SQL)
+	}
+	if !strings.Contains(sqlText, "ROWNUM <= :4") || !strings.Contains(sqlText, "DBX_RN > :5") {
+		t.Fatalf("table listing should use rownum pagination, got: %s", query.SQL)
+	}
+	if len(query.Args) != 5 {
+		t.Fatalf("unexpected args: %#v", query.Args)
+	}
+	if query.Args[0] != "%U%\\_%R%" || query.Args[1] != "TABLE" || query.Args[2] != "VIEW" || query.Args[3] != 511 || query.Args[4] != 10 {
+		t.Fatalf("constraints args were not normalized: %#v", query.Args)
+	}
+}
+
 func TestListObjectsSQLUsesSplitDictionaryQuery(t *testing.T) {
 	sqlText := strings.ToUpper(oracleListObjectsSQL)
 
@@ -512,6 +547,40 @@ func TestListObjectsQueryAppliesMetadataConstraints(t *testing.T) {
 		t.Fatalf("unexpected args: %#v", query.Args)
 	}
 	if query.Args[2] != "%P%K%G%\\%%" || query.Args[3] != "FUNCTION" || query.Args[4] != "PACKAGE" || query.Args[5] != 25 || query.Args[6] != 0 {
+		t.Fatalf("object constraints args were not normalized: %#v", query.Args)
+	}
+}
+
+func TestListSessionUserObjectsQueryUsesUserDictionary(t *testing.T) {
+	query := oracleListSessionUserObjectsQuery(metadataListConstraints{
+		Filter:      "pkg%",
+		Limit:       25,
+		ObjectTypes: []string{"FUNCTION", "package"},
+	})
+	sqlText := strings.ToUpper(query.SQL)
+
+	if !strings.Contains(sqlText, "USER_TABLES") || !strings.Contains(sqlText, "USER_OBJECTS") {
+		t.Fatalf("session-user object listing should use USER_* dictionaries, got: %s", query.SQL)
+	}
+	if strings.Contains(sqlText, "ALL_TABLES") || strings.Contains(sqlText, "ALL_OBJECTS") {
+		t.Fatalf("session-user object listing should avoid ALL_* dictionaries, got: %s", query.SQL)
+	}
+	if strings.Contains(sqlText, "OWNER =") {
+		t.Fatalf("session-user object listing should not add owner predicates, got: %s", query.SQL)
+	}
+	if !strings.Contains(sqlText, "UPPER(OBJECT_NAME) LIKE :1 ESCAPE '\\'") {
+		t.Fatalf("object listing should push filter predicate, got: %s", query.SQL)
+	}
+	if !strings.Contains(sqlText, "OBJECT_TYPE IN (:2,:3)") {
+		t.Fatalf("object listing should push object type predicate, got: %s", query.SQL)
+	}
+	if !strings.Contains(sqlText, "ROWNUM <= :4") || !strings.Contains(sqlText, "DBX_RN > :5") {
+		t.Fatalf("object listing should use rownum pagination, got: %s", query.SQL)
+	}
+	if len(query.Args) != 5 {
+		t.Fatalf("unexpected args: %#v", query.Args)
+	}
+	if query.Args[0] != "%P%K%G%\\%%" || query.Args[1] != "FUNCTION" || query.Args[2] != "PACKAGE" || query.Args[3] != 25 || query.Args[4] != 0 {
 		t.Fatalf("object constraints args were not normalized: %#v", query.Args)
 	}
 }


### PR DESCRIPTION
## 变更说明
- Oracle 当前登录用户的表/对象列表改为查询 USER_TABLES / USER_OBJECTS，避免在 18c/19c 上访问 ALL_TABLES / ALL_OBJECTS 时出现长时间卡住或超时
- 非当前用户 schema 仍保留原来的 ALL_* 查询逻辑

## 验证
- go test ./... （agents/drivers/oracle-go）
- python3 scripts/validate_agents.py .
- git diff --check
- 网页预览中 Oracle 11g / 18c 连接验证通过