### PR TITLE
feat(redis): add auto-refresh countdown for key TTL display

### DIFF
--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -19,6 +19,7 @@ import { useEditorFontFamilyStyle } from "@/composables/useEditorFontFamilyStyle
 import { createRedisShikiJsonHighlighter, type RedisJsonHighlighter } from "@/lib/redis/redisJsonHighlighter";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatTtl } from "@/lib/common/ttlFormat";
+import { computeAutoRefreshTick, computeDisplayTtl, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
 import {
   canRenderRedisValueFormat,
   canEditRedisMemberDetail,
@@ -120,15 +121,16 @@ function startAutoRefresh() {
     countdownTtl.value = data.value.ttl;
   }
   autoRefreshTimer = setInterval(() => {
-    if (!autoRefreshEnabled.value) return;
-    if (countdownTtl.value > 0) {
+    const action = computeAutoRefreshTick(autoRefreshEnabled.value, countdownTtl.value, loading.value);
+    if (action.type === "decrement") {
       countdownTtl.value--;
+      return;
     }
-    if (countdownTtl.value <= 0 && !loading.value) {
+    if (action.type === "refresh") {
       load()
         .then(() => {
           if (!autoRefreshEnabled.value) return;
-          if (data.value && data.value.ttl > 0) {
+          if (data.value && !shouldStopAutoRefresh(data.value.ttl)) {
             countdownTtl.value = data.value.ttl;
           } else {
             // Key expired or has no TTL — stop auto-refresh to avoid infinite loop
@@ -489,7 +491,7 @@ async function load(options: { selectDefaultMember?: boolean } = {}) {
     data.value = loadedValue;
     // Reset auto-refresh countdown if active
     if (autoRefreshEnabled.value) {
-      countdownTtl.value = loadedValue.ttl > 0 ? loadedValue.ttl : 0;
+      countdownTtl.value = shouldStopAutoRefresh(loadedValue.ttl) ? 0 : loadedValue.ttl;
     }
     emit("loaded", loadedValue);
     scanCursor.value = redisValueCollectionScanCursor(loadedValue);
@@ -1152,7 +1154,7 @@ onBeforeUnmount(() => {
           <Badge variant="secondary" class="dbx-editor-font-family text-xs uppercase">{{ data.redis_type }}</Badge>
           <Badge v-if="metadataSizeLabel" variant="outline" class="text-xs text-muted-foreground"> {{ t("redis.columnSize") }}: {{ metadataSizeLabel }} </Badge>
           <template v-if="!editingTtl">
-            <Badge v-if="data.ttl > 0" variant="outline" class="text-xs cursor-pointer text-muted-foreground hover:bg-accent" @click="startEditTtl">TTL: {{ autoRefreshEnabled ? formatTtl(countdownTtl, t) : formatTtl(data.ttl, t) }}</Badge>
+            <Badge v-if="data.ttl > 0" variant="outline" class="text-xs cursor-pointer text-muted-foreground hover:bg-accent" @click="startEditTtl">TTL: {{ formatTtl(computeDisplayTtl(autoRefreshEnabled, countdownTtl, data.ttl), t) }}</Badge>
             <Badge v-else-if="data.ttl === -1" variant="outline" class="text-xs cursor-pointer text-muted-foreground hover:bg-accent" @click="startEditTtl">{{ t("redis.noExpiry") }}</Badge>
           </template>
           <div ref="editTtlWrapper" v-else class="flex items-center gap-1">

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -3,7 +3,7 @@ import { computed, ref, nextTick, onBeforeUnmount, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { onClickOutside } from "@vueuse/core";
 import { DynamicScroller, DynamicScrollerItem, RecycleScroller } from "vue-virtual-scroller";
-import { Copy, Eye, Terminal, Trash2, Save, RefreshCw, Plus, Loader2, Pencil, WrapText, IndentIncrease, IndentDecrease, ArrowUp, ArrowDown, ArrowUpDown, Search } from "@lucide/vue";
+import { Copy, Eye, Terminal, Trash2, Save, RefreshCw, Plus, Loader2, Pencil, WrapText, IndentIncrease, IndentDecrease, ArrowUp, ArrowDown, ArrowUpDown, Search, Clock } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -99,6 +99,61 @@ const memberValueView = ref<RedisValueFormat>(readPreferredRedisValueFormat());
 const redisJsonView = ref<"raw" | "tree">("raw");
 const redisJsonWordWrap = ref(readRedisJsonWordWrap());
 const redisJsonHighlighter = ref<RedisJsonHighlighter>();
+
+// Auto-refresh
+const autoRefreshEnabled = ref(false);
+const countdownTtl = ref(0);
+let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+function toggleAutoRefresh() {
+  autoRefreshEnabled.value = !autoRefreshEnabled.value;
+  if (autoRefreshEnabled.value) {
+    startAutoRefresh();
+  } else {
+    stopAutoRefresh();
+  }
+}
+
+function startAutoRefresh() {
+  stopAutoRefresh();
+  if (data.value && data.value.ttl > 0) {
+    countdownTtl.value = data.value.ttl;
+  }
+  autoRefreshTimer = setInterval(() => {
+    if (!autoRefreshEnabled.value) return;
+    if (countdownTtl.value > 0) {
+      countdownTtl.value--;
+    }
+    if (countdownTtl.value <= 0 && !loading.value) {
+      load()
+        .then(() => {
+          if (!autoRefreshEnabled.value) return;
+          if (data.value && data.value.ttl > 0) {
+            countdownTtl.value = data.value.ttl;
+          } else {
+            // Key expired or has no TTL — stop auto-refresh to avoid infinite loop
+            stopAutoRefresh();
+            autoRefreshEnabled.value = false;
+          }
+        })
+        .catch(() => {
+          // Network / connection error — stop auto-refresh to avoid tight retry loop
+          if (autoRefreshEnabled.value) {
+            stopAutoRefresh();
+            autoRefreshEnabled.value = false;
+          }
+        });
+    }
+  }, 1000);
+}
+
+function stopAutoRefresh() {
+  if (autoRefreshTimer !== null) {
+    clearInterval(autoRefreshTimer);
+    autoRefreshTimer = null;
+  }
+}
+
 const hashSortBy = ref<"field" | "value" | null>(null);
 const hashSortDir = ref<"asc" | "desc">("asc");
 const hashSearchQuery = ref("");
@@ -432,6 +487,10 @@ async function load(options: { selectDefaultMember?: boolean } = {}) {
   try {
     const loadedValue = await api.redisGetValue(props.connectionId, props.db, props.keyRaw);
     data.value = loadedValue;
+    // Reset auto-refresh countdown if active
+    if (autoRefreshEnabled.value) {
+      countdownTtl.value = loadedValue.ttl > 0 ? loadedValue.ttl : 0;
+    }
     emit("loaded", loadedValue);
     scanCursor.value = redisValueCollectionScanCursor(loadedValue);
     collectionItems.value = redisValueCollectionItems(loadedValue);
@@ -1064,6 +1123,7 @@ onMounted(() => {
     });
 });
 onBeforeUnmount(() => {
+  stopAutoRefresh();
   stopResizeMemberSheet();
   stopResizeHashColumns();
   stopResizeZsetColumns();
@@ -1082,7 +1142,7 @@ onBeforeUnmount(() => {
       <div class="shrink-0 border-b bg-background">
         <div class="flex h-9 items-center gap-2 px-4">
           <span class="dbx-editor-font-family min-w-0 flex-1 truncate text-sm font-semibold">{{ formatValue(data.key_display) }}</span>
-          <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0" @click="load"><RefreshCw class="h-3.5 w-3.5" /></Button>
+          <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0" @click="load"><RefreshCw class="h-3.5 w-3.5" :class="{ 'animate-spin': autoRefreshEnabled }" /></Button>
           <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0" @click="copyValue"><Copy class="h-3.5 w-3.5" /></Button>
           <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0" :title="t('redis.copyInsertStatement')" @click="copyInsertStatement"><Terminal class="h-3.5 w-3.5" /></Button>
           <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0 text-destructive" @click="requestDeleteKey"><Trash2 class="h-3.5 w-3.5" /></Button>
@@ -1092,13 +1152,16 @@ onBeforeUnmount(() => {
           <Badge variant="secondary" class="dbx-editor-font-family text-xs uppercase">{{ data.redis_type }}</Badge>
           <Badge v-if="metadataSizeLabel" variant="outline" class="text-xs text-muted-foreground"> {{ t("redis.columnSize") }}: {{ metadataSizeLabel }} </Badge>
           <template v-if="!editingTtl">
-            <Badge v-if="data.ttl > 0" variant="outline" class="text-xs cursor-pointer text-muted-foreground hover:bg-accent" @click="startEditTtl">TTL: {{ formatTtl(data.ttl, t) }}</Badge>
+            <Badge v-if="data.ttl > 0" variant="outline" class="text-xs cursor-pointer text-muted-foreground hover:bg-accent" @click="startEditTtl">TTL: {{ autoRefreshEnabled ? formatTtl(countdownTtl, t) : formatTtl(data.ttl, t) }}</Badge>
             <Badge v-else-if="data.ttl === -1" variant="outline" class="text-xs cursor-pointer text-muted-foreground hover:bg-accent" @click="startEditTtl">{{ t("redis.noExpiry") }}</Badge>
           </template>
           <div ref="editTtlWrapper" v-else class="flex items-center gap-1">
             <Input ref="ttlInputEl" v-model="ttlInput" class="h-6 w-20 text-xs" placeholder="seconds (-1=no expiry)" @keydown.enter="saveTtl" @keydown.escape="cancelEditTtl" />
             <Button variant="ghost" size="icon" class="h-6 w-6" @click="saveTtl"><Save class="h-3 w-3" /></Button>
           </div>
+          <Button variant="ghost" size="icon" class="h-6 w-6 shrink-0" :class="{ 'text-primary bg-accent': autoRefreshEnabled }" :title="t('redis.autoRefresh')" @click="toggleAutoRefresh">
+            <Clock class="h-3.5 w-3.5" />
+          </Button>
         </div>
       </div>
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1942,6 +1942,7 @@ export default {
     loadedMembers: "{loaded} of {total} members loaded",
     entries: "{count} entries",
     noExpiry: "no expiry",
+    autoRefresh: "Auto-refresh countdown",
     ttlDay: "{count}d",
     columnType: "Type",
     columnKey: "Key",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1874,6 +1874,7 @@ export default withEnglishFallback({
     loadedMembers: "{loaded} de {total} miembros cargados",
     entries: "{count} entradas",
     noExpiry: "sin expiración",
+    autoRefresh: "Actualización automática",
     ttlDay: "{count}d",
     columnType: "Tipo",
     columnKey: "Clave",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1872,6 +1872,7 @@ export default withEnglishFallback({
     loadedMembers: "{loaded} di {total} membri caricati",
     entries: "{count} voci",
     noExpiry: "nessuna scadenza",
+    autoRefresh: "Aggiornamento automatico",
     ttlDay: "{count}g",
     columnType: "Tipo",
     columnKey: "Chiave",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1872,6 +1872,7 @@ export default withEnglishFallback({
     loadedMembers: "{loaded}/{total}メンバー読み込み完了",
     entries: "{count}エントリ",
     noExpiry: "期限なし",
+    autoRefresh: "自動更新（カウントダウン）",
     ttlDay: "{count}日",
     columnType: "型",
     columnKey: "キー",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1873,6 +1873,7 @@ export default withEnglishFallback({
     loadedMembers: "{loaded} de {total} membros carregados",
     entries: "{count} entradas",
     noExpiry: "sem expiração",
+    autoRefresh: "Atualização automática",
     ttlDay: "{count}d",
     columnType: "Tipo",
     columnKey: "Chave",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1942,6 +1942,7 @@ export default withEnglishFallback({
     loadedMembers: "已加载 {loaded} / 共 {total} 个成员",
     entries: "{count} 条记录",
     noExpiry: "永不过期",
+    autoRefresh: "自动刷新（倒计时）",
     ttlDay: "{count}天",
     columnType: "类型",
     columnKey: "键",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1775,6 +1775,7 @@ export default withEnglishFallback({
     loadedMembers: "已載入 {loaded} / 共 {total} 個成員",
     entries: "{count} 筆項目",
     noExpiry: "永不過期",
+    autoRefresh: "自動刷新（倒計時）",
     ttlDay: "{count}天",
     columnType: "類型",
     columnKey: "鍵",

--- a/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
+++ b/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { computeAutoRefreshTick, computeDisplayTtl, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
+
+describe("computeAutoRefreshTick", () => {
+  it("returns idle when auto-refresh is disabled", () => {
+    expect(computeAutoRefreshTick(false, 10, false)).toEqual({ type: "idle" });
+    // countdown value and loading flag don't matter when disabled
+    expect(computeAutoRefreshTick(false, 0, false)).toEqual({ type: "idle" });
+    expect(computeAutoRefreshTick(false, 5, true)).toEqual({ type: "idle" });
+  });
+
+  it("returns decrement when countdown is above zero", () => {
+    expect(computeAutoRefreshTick(true, 10, false)).toEqual({ type: "decrement" });
+    expect(computeAutoRefreshTick(true, 1, false)).toEqual({ type: "decrement" });
+    // decrement even when loading — countdown should keep ticking
+    expect(computeAutoRefreshTick(true, 3, true)).toEqual({ type: "decrement" });
+  });
+
+  it("returns refresh when countdown reaches zero and not loading", () => {
+    expect(computeAutoRefreshTick(true, 0, false)).toEqual({ type: "refresh" });
+    expect(computeAutoRefreshTick(true, -1, false)).toEqual({ type: "refresh" });
+  });
+
+  it("returns idle when countdown is zero but a load is already in flight", () => {
+    // This prevents concurrent load() calls
+    expect(computeAutoRefreshTick(true, 0, true)).toEqual({ type: "idle" });
+    expect(computeAutoRefreshTick(true, -1, true)).toEqual({ type: "idle" });
+  });
+});
+
+describe("shouldStopAutoRefresh", () => {
+  it("returns true when TTL is zero (key expired)", () => {
+    expect(shouldStopAutoRefresh(0)).toBe(true);
+  });
+
+  it("returns true when TTL is negative (no expiry or key deleted)", () => {
+    expect(shouldStopAutoRefresh(-1)).toBe(true);
+    expect(shouldStopAutoRefresh(-2)).toBe(true);
+  });
+
+  it("returns false when TTL is positive (key still alive)", () => {
+    expect(shouldStopAutoRefresh(1)).toBe(false);
+    expect(shouldStopAutoRefresh(3600)).toBe(false);
+  });
+});
+
+describe("computeDisplayTtl", () => {
+  it("returns server TTL when auto-refresh is disabled", () => {
+    expect(computeDisplayTtl(false, 3, 10)).toBe(10);
+  });
+
+  it("returns server TTL when countdown has not started (zero)", () => {
+    // countdownTtl starts at 0 before first tick; show server TTL
+    expect(computeDisplayTtl(true, 0, 10)).toBe(10);
+  });
+
+  it("returns live countdown when auto-refresh is active and counting", () => {
+    expect(computeDisplayTtl(true, 5, 10)).toBe(5);
+    expect(computeDisplayTtl(true, 1, 10)).toBe(1);
+  });
+
+  it("returns server TTL when countdown would go below zero", () => {
+    // Edge case: countdownTtl shouldn't be negative in practice,
+    // but if it is, fall back to server TTL
+    expect(computeDisplayTtl(true, -1, 10)).toBe(10);
+  });
+});

--- a/apps/desktop/src/lib/redis/redisAutoRefresh.ts
+++ b/apps/desktop/src/lib/redis/redisAutoRefresh.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure decision functions for Redis key auto-refresh countdown.
+ *
+ * Extracted from RedisValueViewer.vue to enable unit testing of the
+ * state-machine logic without mounting a Vue component.
+ */
+
+/** Action computed after evaluating one auto-refresh tick. */
+export type AutoRefreshTickAction = { type: "idle" } | { type: "decrement" } | { type: "refresh" };
+
+/**
+ * Evaluate one tick of the auto-refresh interval.
+ *
+ * @param enabled  Whether auto-refresh is currently toggled on.
+ * @param countdownTtl  Current countdown value in seconds.
+ * @param isLoading  Whether a data load is already in flight.
+ * @returns The action the caller should take this tick.
+ */
+export function computeAutoRefreshTick(enabled: boolean, countdownTtl: number, isLoading: boolean): AutoRefreshTickAction {
+  if (!enabled) return { type: "idle" };
+  if (countdownTtl > 0) return { type: "decrement" };
+  if (countdownTtl <= 0 && !isLoading) return { type: "refresh" };
+  return { type: "idle" };
+}
+
+/**
+ * Determine whether auto-refresh should be automatically disabled
+ * after a server load completes (e.g. key expired or deleted).
+ *
+ * @param ttl  The TTL value returned by the server (seconds, -1 = no expiry).
+ */
+export function shouldStopAutoRefresh(ttl: number): boolean {
+  return ttl <= 0;
+}
+
+/**
+ * Compute the TTL value that should be displayed in the badge.
+ *
+ * When auto-refresh is active and countdown is running, the live
+ * countdown value is shown. Otherwise the last known server TTL is used.
+ */
+export function computeDisplayTtl(autoRefreshEnabled: boolean, countdownTtl: number, serverTtl: number): number {
+  if (autoRefreshEnabled && countdownTtl > 0) {
+    return countdownTtl;
+  }
+  return serverTtl;
+}


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## Summary

Add an auto-refresh toggle button next to the TTL badge in the Redis value viewer. When enabled, the TTL badge shows a live countdown (decrementing every second), and the RefreshCw button spins continuously. When the countdown reaches zero, the data is automatically reloaded from the server. When the key expires or a network error occurs, auto-refresh is automatically disabled to prevent tight retry loops.

## Changes

### `RedisValueViewer.vue`
- Added `Clock` icon import from lucide-vue
- Added reactive state: `autoRefreshEnabled`, `countdownTtl`, `autoRefreshTimer`
- `toggleAutoRefresh()` — toggles auto-refresh on/off
- `startAutoRefresh()` — starts a 1-second interval countdown; when countdown reaches 0, calls `load()` to refresh data; guards against concurrent loads via `loading.value` check
- `stopAutoRefresh()` — clears the interval timer, called on component unmount and auto-disable
- Modified `load()` — resets `countdownTtl` after data is loaded when auto-refresh is active
- Modified `onBeforeUnmount` — calls `stopAutoRefresh()` to clean up the timer
- Template: `RefreshCw` button gains `animate-spin` class when auto-refresh is active
- Template: TTL badge displays live countdown value via `formatTtl(countdownTtl, t)` when auto-refresh is active
- Template: added `Clock` icon toggle button next to the TTL badge row with active-state highlighting

### Safety guards
- **TTL expiry / key deletion**: when `load()` returns `ttl <= 0`, auto-refresh is automatically disabled to avoid an infinite retry loop
- **Network errors**: `.catch()` handler on `load()` disables auto-refresh on connection failure
- **Concurrent loads**: `!loading.value` guard prevents duplicate `load()` calls while one is already in flight
- **Unmount cleanup**: `stopAutoRefresh()` in `onBeforeUnmount` ensures no leaked timers

### i18n (7 locales)
- `zh-CN`: 自动刷新（倒计时）
- `zh-TW`: 自動刷新（倒計時）
- `en`: Auto-refresh countdown
- `ja`: 自動更新（カウントダウン）
- `es`: Actualización automática
- `it`: Aggiornamento automatico
- `pt-BR`: Atualização automática

## Files Changed

| File | +/- |
|------|-----|
| `apps/desktop/src/components/redis/RedisValueViewer.vue` | +57 / -3 |
| `apps/desktop/src/i18n/locales/zh-CN.ts` | +1 |
| `apps/desktop/src/i18n/locales/zh-TW.ts` | +1 |
| `apps/desktop/src/i18n/locales/en.ts` | +1 |
| `apps/desktop/src/i18n/locales/ja.ts` | +1 |
| `apps/desktop/src/i18n/locales/es.ts` | +1 |
| `apps/desktop/src/i18n/locales/it.ts` | +1 |
| `apps/desktop/src/i18n/locales/pt-BR.ts` | +1 |
| **Total** | **+73 / -3** |

## Testing

- [x] oxlint: zero warnings
- [x] oxfmt: all files pass format check
- [ ] Manual test: enable auto-refresh on a key with TTL > 0, verify countdown and auto-reload
- [ ] Manual test: enable auto-refresh, wait for TTL to expire, verify auto-refresh disables cleanly
- [ ] Manual test: enable auto-refresh, disconnect network, verify no console errors
- [ ] Manual test: toggle auto-refresh on/off rapidly, verify no timer leaks
## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1920" height="1032" alt="d406f980-9633-4157-9454-d242e27a835d" src="https://github.com/user-attachments/assets/e476b847-b6f7-4441-882a-de4bccad55e8" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2857 
