### PR TITLE
Fix: 修复 SQLServer 表结构 DDL 缺少 IDENTITY

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -5410,6 +5410,18 @@ mod ddl_tests {
     }
 
     #[test]
+    fn sqlserver_table_ddl_includes_identity_clause() {
+        let mut id = column("FIDS", "int");
+        id.is_nullable = false;
+        id.is_primary_key = true;
+        id.extra = Some("identity(1,1)".to_string());
+
+        let ddl = render_sqlserver_table_ddl("dbo", "ZHLSBS", &[id], &[], &[]);
+
+        assert!(ddl.contains("[FIDS] int IDENTITY(1,1) NOT NULL"), "ddl: {ddl}");
+    }
+
+    #[test]
     fn opengauss_table_ddl_uses_native_tabledef_function() {
         assert_eq!(
             opengauss_table_ddl_sql("tenant's schema", "active users"),
@@ -5598,6 +5610,23 @@ pub fn render_postgres_table_ddl(
     ddl
 }
 
+fn sqlserver_identity_clause(extra: Option<&str>) -> Option<String> {
+    let extra = extra?.trim();
+    let lower = extra.to_ascii_lowercase();
+    if !lower.starts_with("identity") {
+        return None;
+    }
+
+    let rest = extra["identity".len()..].trim_start();
+    if rest.is_empty() {
+        return Some("IDENTITY".to_string());
+    }
+
+    let args = rest.strip_prefix('(')?;
+    let end = args.find(')')?;
+    Some(format!("IDENTITY({})", args[..end].trim()))
+}
+
 fn group_foreign_keys_by_name(fkeys: &[db::ForeignKeyInfo]) -> Vec<Vec<&db::ForeignKeyInfo>> {
     let mut groups: Vec<Vec<&db::ForeignKeyInfo>> = Vec::new();
     for fk in fkeys {
@@ -5635,6 +5664,9 @@ pub fn render_sqlserver_table_ddl(
         .iter()
         .map(|c| {
             let mut line = format!("  {} {}", sqlserver_ident(&c.name), c.data_type);
+            if let Some(identity) = sqlserver_identity_clause(c.extra.as_deref()) {
+                line.push_str(&format!(" {identity}"));
+            }
             if !c.is_nullable {
                 line.push_str(" NOT NULL");
             }


### PR DESCRIPTION
## 修复内容
- 在 SQLServer 表结构 DDL 渲染时补充 IDENTITY 列属性
- 仅识别并渲染 identity(...)，避免把其它 extra 元数据误拼到列定义中
- 补充 SQLServer IDENTITY 导出单元测试

## 验证
- rustfmt --check crates/dbx-core/src/schema.rs
- cargo test -p dbx-core sqlserver_table_ddl --locked
- git diff --check

Fixes： #2863 