### PR TITLE
fix(core): 修复 MySQL 数值导出字面量

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -482,7 +482,9 @@ fn looks_like_numeric_literal(raw: &str) -> bool {
     if trimmed.is_empty() {
         return false;
     }
-    trimmed.parse::<i64>().is_ok() || trimmed.parse::<u64>().is_ok() || trimmed.parse::<f64>().is_ok()
+    trimmed.parse::<i64>().is_ok()
+        || trimmed.parse::<u64>().is_ok()
+        || trimmed.parse::<f64>().is_ok_and(|value| value.is_finite())
 }
 
 fn format_mysql_default_literal(raw: &str, data_type: &str) -> String {
@@ -971,6 +973,9 @@ pub fn escape_value_typed(val: &serde_json::Value, db_type: &DatabaseType, colum
             if let Some(binary_literal) = format_postgres_binary_sql_literal(s, db_type, column_type) {
                 return binary_literal;
             }
+            if let Some(numeric_literal) = format_mysql_numeric_string_literal(s, db_type, column_type) {
+                return numeric_literal;
+            }
 
             let literal = format_literal_string(s, db_type, column_type);
             let escaped = if is_postgres_family_target(db_type) {
@@ -1003,6 +1008,37 @@ fn is_mysql_bit_type(column_type: &str) -> bool {
     let trimmed = column_type.trim();
     let lower = trimmed.to_ascii_lowercase();
     lower == "bit" || lower.starts_with("bit(") || lower.starts_with("bit ")
+}
+
+fn is_mysql_numeric_string_literal_database(db_type: &DatabaseType) -> bool {
+    matches!(
+        db_type,
+        DatabaseType::Mysql
+            | DatabaseType::Doris
+            | DatabaseType::StarRocks
+            | DatabaseType::Goldendb
+            | DatabaseType::Sundb
+    )
+}
+
+fn is_mysql_non_bit_numeric_type(column_type: &str) -> bool {
+    is_mysql_numeric_base_type(column_type) && !is_mysql_bit_type(column_type)
+}
+
+fn format_mysql_numeric_string_literal(
+    value: &str,
+    db_type: &DatabaseType,
+    column_type: Option<&str>,
+) -> Option<String> {
+    if !is_mysql_numeric_string_literal_database(db_type) || !column_type.is_some_and(is_mysql_non_bit_numeric_type) {
+        return None;
+    }
+    let trimmed = value.trim();
+    if looks_like_numeric_literal(trimmed) {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
 }
 
 fn is_binary_transfer_column_type(column_type: &str) -> bool {
@@ -5458,6 +5494,62 @@ mod tests {
         assert_eq!(
             sql,
             "INSERT INTO `policies` (`dt`, `raw_text`, `d`, `t`) VALUES\n('2026-05-12 00:00:00', '2026-05-12T00:00:00+00:00', '2026-05-12', '09:30:45')"
+        );
+    }
+
+    #[test]
+    fn mysql_insert_formats_numeric_strings_from_numeric_columns_as_numeric_literals() {
+        let sql = generate_insert_typed(
+            &[
+                String::from("id"),
+                String::from("amount"),
+                String::from("quantity"),
+                String::from("text_id"),
+                String::from("bad_number"),
+                String::from("missing"),
+            ],
+            &[
+                Some(String::from("bigint(20)")),
+                Some(String::from("decimal(10,2)")),
+                Some(String::from("int unsigned")),
+                Some(String::from("varchar(64)")),
+                Some(String::from("bigint(20)")),
+                Some(String::from("bigint(20)")),
+            ],
+            &[vec![
+                json!("1234567890123"),
+                json!("12.34"),
+                json!("42"),
+                json!("123"),
+                json!("not-a-number"),
+                serde_json::Value::Null,
+            ]],
+            "orders",
+            "",
+            &DatabaseType::Mysql,
+        );
+
+        assert_eq!(
+            sql,
+            "INSERT INTO `orders` (`id`, `amount`, `quantity`, `text_id`, `bad_number`, `missing`) VALUES\n(1234567890123, 12.34, 42, '123', 'not-a-number', NULL)"
+        );
+    }
+
+    #[test]
+    fn mysql_upsert_formats_numeric_strings_from_numeric_columns_as_numeric_literals() {
+        let sql = generate_upsert_typed(
+            &[String::from("id"), String::from("amount")],
+            &[Some(String::from("bigint(20)")), Some(String::from("decimal(10,2)"))],
+            &[vec![json!("1234567890123"), json!("12.34")]],
+            "orders",
+            "",
+            &DatabaseType::Mysql,
+            &[String::from("id")],
+        );
+
+        assert_eq!(
+            sql,
+            "INSERT INTO `orders` (`id`, `amount`) VALUES\n(1234567890123, 12.34)\nON DUPLICATE KEY UPDATE `amount` = VALUES(`amount`)"
         );
     }
 

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -304,7 +304,6 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
-            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -202,7 +202,6 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
-            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }


### PR DESCRIPTION
Fixes #2865

## 变更说明
- MySQL-family SQL 导出时，数值列里的字符串数值会按列类型输出为裸数值字面量，避免 bigint(20) 等字段导成字符串。
- 保留文本列字符串行为，例如 varchar 中的 "123" 仍输出为 '123'。
- 保留 NULL、非数值字符串、bit 字段和其他数据库现有行为。
- 排除非有限浮点值，避免 NaN/Infinity 被误判为可直接输出的 SQL 数值。

## 测试
- mise exec rust@latest -- cargo test -p dbx-core transfer::tests::mysql
- mise exec rust@latest -- cargo test -p dbx-core transfer
- mise exec rust@latest -- cargo fmt --check
- git diff --check