### PR TITLE
Feature：支持达梦新建 Schema

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -106,38 +106,48 @@ public final class DamengAgent extends BaseDatabaseAgent {
 
     @Override
     public List<DatabaseInfo> listDatabases() {
-        return unchecked(() -> {
-            List<DatabaseInfo> result = new ArrayList<>();
-            String placeholders = String.join(",", SYSTEM_USERS.stream().map(user -> "?").toList());
-            String sql = "SELECT USERNAME FROM ALL_USERS WHERE USERNAME NOT IN (" + placeholders + ") ORDER BY USERNAME";
-            try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
-                int index = 1;
-                for (String user : SYSTEM_USERS) {
-                    stmt.setString(index++, user);
-                }
-                try (ResultSet rs = stmt.executeQuery()) {
-                    while (rs.next()) {
-                        result.add(new DatabaseInfo(rs.getString(1)));
-                    }
-                }
-            }
-            return result;
-        });
+        return unchecked(() -> listVisibleUsers().stream().map(DatabaseInfo::new).toList());
     }
 
     @Override
     public List<String> listSchemas() {
-        return unchecked(() -> {
-            List<String> result = new ArrayList<>();
-            String sql = "SELECT DISTINCT OWNER FROM ALL_OBJECTS ORDER BY OWNER";
-            try (java.sql.Statement stmt = requireConnected().createStatement();
-                 ResultSet rs = stmt.executeQuery(sql)) {
+        return unchecked(this::listVisibleSchemas);
+    }
+
+    private List<String> listVisibleUsers() throws Exception {
+        List<String> result = new ArrayList<>();
+        String placeholders = String.join(",", SYSTEM_USERS.stream().map(user -> "?").toList());
+        String sql = "SELECT USERNAME FROM ALL_USERS WHERE USERNAME NOT IN (" + placeholders + ") ORDER BY USERNAME";
+        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
+            int index = 1;
+            for (String user : SYSTEM_USERS) {
+                stmt.setString(index++, user);
+            }
+            try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     result.add(rs.getString(1));
                 }
             }
-            return result;
-        });
+        }
+        return result;
+    }
+
+    private List<String> listVisibleSchemas() throws Exception {
+        List<String> result = new ArrayList<>();
+        String placeholders = String.join(",", SYSTEM_USERS.stream().map(user -> "?").toList());
+        String sql = "SELECT NAME FROM SYS.SYSOBJECTS WHERE TYPE$ = 'SCH' AND NAME NOT IN (" + placeholders + ") ORDER BY NAME";
+        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
+            int index = 1;
+            for (String user : SYSTEM_USERS) {
+                stmt.setString(index++, user);
+            }
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    result.add(rs.getString(1));
+                }
+            }
+        }
+        return result;
     }
 
     @Override

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -81,6 +81,20 @@ class DamengAgentMetadataTest {
     }
 
     @Test
+    void listSchemasIncludesSchemaObjectsWithoutChildren() {
+        DamengAgent agent = new DamengAgent();
+        List<String> sqls = new ArrayList<>();
+        TestSupport.setPrivateConnection(agent, metadataConnection("id comment", null, false, List.of(), sqls, ""));
+
+        List<String> schemas = agent.listSchemas();
+
+        Assertions.assertEquals(List.of("APP", "EMPTY_SCHEMA"), schemas);
+        Assertions.assertTrue(sqls.stream().anyMatch(sql -> sql.contains("SYS.SYSOBJECTS") && sql.contains("TYPE$ = 'SCH'")), String.join("\n", sqls));
+        Assertions.assertTrue(sqls.stream().noneMatch(sql -> sql.contains("ALL_USERS")), String.join("\n", sqls));
+        Assertions.assertTrue(sqls.stream().noneMatch(sql -> sql.contains("ALL_OBJECTS")), String.join("\n", sqls));
+    }
+
+    @Test
     void mapsMaterializedViewsFromMetadata() {
         DamengAgent agent = new DamengAgent();
         TestSupport.setPrivateConnection(agent, metadataConnection("id comment", null, true));
@@ -311,6 +325,9 @@ class DamengAgentMetadataTest {
                 }
                 if (sql.contains("DBMS_METADATA.GET_DDL")) {
                     return dbmsMetadataStatement(dbmsMetadataDdl);
+                }
+                if (sql.contains("SYS.SYSOBJECTS") && sql.contains("TYPE$ = 'SCH'")) {
+                    return metadataStatement(List.of(List.of("APP"), List.of("EMPTY_SCHEMA")));
                 }
                 if (sql.contains("ALL_CONS_COLUMNS")) {
                     return metadataStatement(List.of(List.of("ID")));

--- a/agents/versions.json
+++ b/agents/versions.json
@@ -2,7 +2,7 @@
   "access": "0.1.26",
   "bigquery": "0.1.30",
   "cassandra": "0.1.29",
-  "dameng": "0.1.32",
+  "dameng": "0.1.33",
   "databend": "0.1.17",
   "databricks": "0.1.24",
   "db2": "0.1.29",

--- a/agents/versions.json
+++ b/agents/versions.json
@@ -2,7 +2,7 @@
   "access": "0.1.26",
   "bigquery": "0.1.30",
   "cassandra": "0.1.29",
-  "dameng": "0.1.33",
+  "dameng": "0.1.32",
   "databend": "0.1.17",
   "databricks": "0.1.24",
   "db2": "0.1.29",

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -2419,6 +2419,11 @@ const isDuckDbConnection = computed(() => {
   return props.node.type === "connection" && connectionNamespaceCreationTarget(config) === "attach";
 });
 
+const isConnectionSchemaCreation = computed(() => {
+  const config = props.node.connectionId ? connectionStore.getConfig(props.node.connectionId) : undefined;
+  return props.node.type === "connection" && connectionNamespaceCreationTarget(config) === "schema";
+});
+
 const canSetCreateDatabaseCharset = computed(() => {
   const config = props.node.connectionId ? connectionStore.getConfig(props.node.connectionId) : undefined;
   return connectionNamespaceCreationTarget(config) === "database" && supportsCreateDatabaseCharset(config?.db_type, config?.driver_profile);
@@ -2831,6 +2836,20 @@ function openCreateDatabaseDialog() {
   }
 }
 
+function openConnectionNamespaceCreation() {
+  if (isConnectionSchemaCreation.value) {
+    openCreateSchemaDialog();
+    return;
+  }
+  void openCreateDatabase();
+}
+
+function connectionNamespaceCreationLabel() {
+  if (isDuckDbConnection.value) return t("contextMenu.createDuckDbFile");
+  if (isConnectionSchemaCreation.value) return t("contextMenu.createSchema");
+  return t("contextMenu.createDatabase");
+}
+
 function updateCreateDatabaseCharset(value: string) {
   const previousCharset = createDatabaseCharset.value;
   createDatabaseCharset.value = value;
@@ -2857,7 +2876,11 @@ async function loadCreateDatabaseCharsetMetadata(target: "create" | "edit" = "cr
     createDatabaseCollationsByCharset.value = metadata.collationsByCharset;
     const selectedCharset = target === "create" ? createDatabaseCharset.value : editDatabaseCharset.value;
     if (!createDatabaseCharsetOptions.value.includes(selectedCharset) && createDatabaseCharsetOptions.value.length) {
-      target === "create" ? updateCreateDatabaseCharset(createDatabaseCharsetOptions.value[0]) : updateEditDatabaseCharset(createDatabaseCharsetOptions.value[0]);
+      if (target === "create") {
+        updateCreateDatabaseCharset(createDatabaseCharsetOptions.value[0]);
+      } else {
+        updateEditDatabaseCharset(createDatabaseCharsetOptions.value[0]);
+      }
     } else {
       if (target === "create") {
         createDatabaseCollation.value = nextCreateDatabaseCollation(createDatabaseCharset.value, createDatabaseCharset.value, createDatabaseCollation.value, createDatabaseCollationsByCharset.value);
@@ -3149,21 +3172,25 @@ function openCreateSchemaDialog() {
 async function confirmCreateSchema() {
   const node = props.node;
   const name = createSchemaName.value.trim();
-  if (!name || !node.connectionId || !node.database) return;
+  const config = node.connectionId ? connectionStore.getConfig(node.connectionId) : undefined;
+  const isConnectionLevelSchemaCreation = node.type === "connection" && connectionNamespaceCreationTarget(config) === "schema";
+  const targetDatabase = isConnectionLevelSchemaCreation ? "" : node.database;
+  if (!name || !node.connectionId || (!targetDatabase && !isConnectionLevelSchemaCreation)) return;
   showCreateSchemaDialog.value = false;
   try {
     await connectionStore.ensureConnected(node.connectionId);
     const sql = await buildCreateSchemaSql({
-      databaseType: currentDatabaseType(),
+      databaseType: effectiveDatabaseTypeForConnection(config),
       name,
     });
-    await api.executeQuery(node.connectionId, node.database, sql);
+    await api.executeQuery(node.connectionId, targetDatabase || "", sql);
     toast(t("contextMenu.createSchemaSuccess", { name }), 3000);
-    const config = connectionStore.getConfig(node.connectionId);
-    if (config?.db_type === "sqlserver") {
-      await connectionStore.loadSqlServerDatabaseObjects(node.connectionId, node.database, { force: true });
+    if (isConnectionLevelSchemaCreation) {
+      await connectionStore.loadDatabases(node.connectionId, { force: true });
+    } else if (config?.db_type === "sqlserver") {
+      await connectionStore.loadSqlServerDatabaseObjects(node.connectionId, targetDatabase || "", { force: true });
     } else {
-      await connectionStore.loadSchemas(node.connectionId, node.database, { force: true });
+      await connectionStore.loadSchemas(node.connectionId, targetDatabase || "", { force: true });
     }
   } catch (e: any) {
     toast(t("contextMenu.tableOperationFailed", { message: e?.message || String(e) }), 5000);
@@ -4483,8 +4510,8 @@ function treeItemMenuItems(): ContextMenuItem[] {
     }
     if (canCreateDatabase.value) {
       items.push({
-        label: isDuckDbConnection.value ? t("contextMenu.createDuckDbFile") : t("contextMenu.createDatabase"),
-        action: openCreateDatabase,
+        label: connectionNamespaceCreationLabel(),
+        action: openConnectionNamespaceCreation,
         icon: Plus,
       });
     }

--- a/apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts
@@ -101,7 +101,8 @@ describe("database namespace creation", () => {
     expect(connectionNamespaceCreationTarget({ db_type: "tdengine" })).toBe("database");
   });
 
-  it("keeps special creation flows explicit", () => {
+  it("keeps non-database creation flows explicit", () => {
+    expect(connectionNamespaceCreationTarget({ db_type: "dameng" })).toBe("schema");
     expect(connectionNamespaceCreationTarget({ db_type: "duckdb" })).toBe("attach");
     expect(connectionNamespaceCreationTarget({ db_type: "mongodb" })).toBe("special");
     expect(connectionNamespaceCreationTarget({ db_type: "mongodb", driver_profile: "mongodb-legacy" })).toBeNull();

--- a/apps/desktop/src/lib/database/databaseNamespaceCreation.ts
+++ b/apps/desktop/src/lib/database/databaseNamespaceCreation.ts
@@ -2,7 +2,7 @@ import type { ConnectionConfig, DatabaseType, TreeNodeType } from "@/types/datab
 
 export type DatabaseNamespaceCreationTarget = "database" | "schema" | "attach" | "special";
 
-type ConnectionCreationTarget = Extract<DatabaseNamespaceCreationTarget, "database" | "attach" | "special">;
+type ConnectionCreationTarget = Extract<DatabaseNamespaceCreationTarget, "database" | "schema" | "attach" | "special">;
 type DatabaseNodeCreationTarget = Extract<DatabaseNamespaceCreationTarget, "schema">;
 
 export interface DatabaseNamespaceCreationMatrixEntry {
@@ -36,7 +36,7 @@ export const DATABASE_NAMESPACE_CREATION_MATRIX = {
   manticoresearch: { deferred: "index/table creation is not database creation" },
   databend: { connection: "database" },
   redshift: { connection: "database", database: "schema" },
-  dameng: { deferred: "schema/user creation requires a dedicated user workflow" },
+  dameng: { connection: "schema" },
   gaussdb: { connection: "database", database: "schema" },
   kingbase: { connection: "database", database: "schema" },
   highgo: { connection: "database", database: "schema" },

--- a/crates/dbx-core/src/db_admin_sql.rs
+++ b/crates/dbx-core/src/db_admin_sql.rs
@@ -251,6 +251,7 @@ pub fn supports_create_schema_target(database_type: Option<DatabaseType>) -> boo
                 | DatabaseType::Highgo
                 | DatabaseType::Vastbase
                 | DatabaseType::Yashandb
+                | DatabaseType::Dameng
                 | DatabaseType::Databricks
                 | DatabaseType::SapHana
                 | DatabaseType::Teradata
@@ -1230,6 +1231,14 @@ mod tests {
             })
             .unwrap(),
             "CREATE SCHEMA [analytics];"
+        );
+        assert_eq!(
+            build_create_schema_sql(SchemaNameSqlOptions {
+                database_type: Some(DatabaseType::Dameng),
+                name: "analytics".to_string(),
+            })
+            .unwrap(),
+            "CREATE SCHEMA \"analytics\";"
         );
         assert_eq!(
             build_create_schema_sql(SchemaNameSqlOptions {

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -304,7 +304,6 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
-            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -202,7 +202,6 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
-            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }


### PR DESCRIPTION
## 概述
- 在达梦连接节点增加新建 Schema 入口，复用已有的新建 Schema 弹窗和多语言文案。
- 支持达梦 `CREATE SCHEMA` SQL 构造，并补充对应单元测试。
- 修复达梦 Schema 列表读取方式，改为从 `SYS.SYSOBJECTS` 读取 `TYPE$ = 'SCH'`，确保刚创建且暂无对象的 Schema 也能显示。
- 更新 Dameng agent 版本到 `0.1.33`。
- 清理最新 main 合入后两个 Rust 测试 fixture 中重复的 `agent_java_options` 字段，恢复 workspace Rust CI 编译。

## i18n
- 本次没有新增用户可见文案 key，复用现有 `contextMenu.createSchema`、`contextMenu.createSchemaSuccess`、`contextMenu.createSchemaNamePlaceholder`，这些 key 已覆盖现有 locale。

## 验证
- 用户已在本地验证达梦新建 Schema 和新建表正常。
- `pnpm exec oxlint apps/desktop/src/components/sidebar/TreeItem.vue apps/desktop/src/lib/database/databaseNamespaceCreation.ts apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts`
- `pnpm typecheck`
- `pnpm test apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts`
- `cargo fmt --check`
- `cargo clippy --workspace --locked --all-targets`
- `cargo test --workspace --locked`
- `cargo test -p dbx-core db_admin_sql`
- `./gradlew -I <java21 init> :dameng:test`
- `git diff --check`
