### PR TITLE
Fix：调整 AI 历史消息编辑框宽度

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -1663,7 +1663,7 @@ async function openExternalUrl(url: string) {
         <div class="flex flex-col gap-3 p-3">
           <template v-for="(msg, i) in visibleMessages" :key="i">
             <div v-if="msg.role === 'user'" class="group flex justify-end">
-              <div class="max-w-[85%]">
+              <div class="min-w-0 max-w-[85%]" :class="{ 'w-[85%]': editingMessageIndex === i }">
                 <template v-if="editingMessageIndex === i">
                   <div v-if="editingMentions.length" class="mb-1.5 flex flex-wrap justify-end gap-1">
                     <button


### PR DESCRIPTION
## 变更说明
- AI 对话中编辑用户历史消息时，编辑框使用完整消息区域宽度，避免长文本被挤在右侧窄列中。
- 普通消息气泡仍保持原有自适应宽度。

## 验证
- pnpm lint
- git diff --check
- 本地免密预览验证通过