### PR TITLE
fix(kafka): clamp peek offset to available range

### DIFF
--- a/agents/drivers/kafka/src/main/java/com/dbx/agent/kafka/KafkaAgent.java
+++ b/agents/drivers/kafka/src/main/java/com/dbx/agent/kafka/KafkaAgent.java
@@ -753,7 +753,17 @@ public final class KafkaAgent {
         TopicPartition tp = new TopicPartition(topic, partition);
         try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(props)) {
             consumer.assign(Collections.singletonList(tp));
-            consumer.seek(tp, offset);
+            Map<TopicPartition, Long> beginningOffsets =
+                consumer.beginningOffsets(Collections.singletonList(tp), Duration.ofSeconds(5));
+            Map<TopicPartition, Long> endOffsets =
+                consumer.endOffsets(Collections.singletonList(tp), Duration.ofSeconds(5));
+            long beginningOffset = beginningOffsets.getOrDefault(tp, 0L);
+            long endOffset = endOffsets.getOrDefault(tp, beginningOffset);
+            Long seekOffset = normalizePeekOffset(offset, beginningOffset, endOffset);
+            if (seekOffset == null) {
+                return Collections.singletonMap("messages", Collections.emptyList());
+            }
+            consumer.seek(tp, seekOffset);
 
             List<Map<String, Object>> messages = new ArrayList<>();
             ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofSeconds(5));
@@ -1122,6 +1132,19 @@ public final class KafkaAgent {
             }
         } catch (Exception ignored) {}
         return null;
+    }
+
+    static Long normalizePeekOffset(long requestedOffset, long beginningOffset, long endOffset) {
+        if (endOffset <= beginningOffset) {
+            return null;
+        }
+        if (requestedOffset < beginningOffset) {
+            return beginningOffset;
+        }
+        if (requestedOffset >= endOffset) {
+            return null;
+        }
+        return requestedOffset;
     }
 
     private static String stringOrNull(JsonObject object, String key) {

--- a/agents/drivers/kafka/src/test/java/com/dbx/agent/kafka/KafkaAgentTest.java
+++ b/agents/drivers/kafka/src/test/java/com/dbx/agent/kafka/KafkaAgentTest.java
@@ -1,0 +1,33 @@
+package com.dbx.agent.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaAgentTest {
+    @Test
+    void normalizesPeekOffsetToEarliestAvailableOffset() {
+        assertEquals(5L, KafkaAgent.normalizePeekOffset(0, 5, 10));
+    }
+
+    @Test
+    void normalizesNegativePeekOffsetToEarliestAvailableOffset() {
+        assertEquals(0L, KafkaAgent.normalizePeekOffset(-1, 0, 10));
+    }
+
+    @Test
+    void keepsPeekOffsetWhenItIsWithinAvailableRange() {
+        assertEquals(7L, KafkaAgent.normalizePeekOffset(7, 5, 10));
+    }
+
+    @Test
+    void returnsNoSeekOffsetWhenRequestedOffsetIsAtOrAfterEnd() {
+        assertNull(KafkaAgent.normalizePeekOffset(10, 5, 10));
+    }
+
+    @Test
+    void returnsNoSeekOffsetWhenTopicHasNoReadableMessages() {
+        assertNull(KafkaAgent.normalizePeekOffset(0, 5, 5));
+    }
+}


### PR DESCRIPTION
## 变更说明

修复 Kafka topic 的最早可读 offset 大于 0 时，消息列表仍从 offset 0 读取导致加载失败的问题。

- 在 Kafka agent 执行 peek 前读取 partition 当前的 earliest/latest offset。
- 当请求 offset 小于 earliest offset 时，自动从当前 earliest offset 开始读取。
- 当 topic 当前没有可读消息，或请求 offset 已经不在可读范围内时，返回空消息列表，避免触发 `OffsetOutOfRange`。
- 补充 Kafka peek offset 归一化的单元测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端改动。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `./gradlew :kafka:test :kafka:shadowJar`
- `python3 scripts/validate_agents.py`
- 使用本地 Kafka 容器验证：topic earliest offset 为 5 时，通过 Kafka agent 以 offset 0 加载消息，可正常返回 offset 5 起的消息。

## 关联 Issue

Close #2834
