### PR TITLE
fix(ui): 修复LightTooltip三角样式与主体不一致的问题

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -5066,7 +5066,7 @@ function treeItemMenuItems(): ContextMenuItem[] {
 
   <CustomContextMenu v-else :items="treeItemMenuItems()" v-slot="contextMenuSlot">
     <div @contextmenu="onTreeItemContextMenu($event, contextMenuSlot.onContextMenu)">
-      <LightTooltip :text="displayLabel(node)" :disabled="isTooltipDisabled()" side="right" :side-offset="8" :delay="0" :close-delay="0">
+      <LightTooltip :text="displayLabel(node)" :disabled="isTooltipDisabled()" side="right" :side-offset="8" :delay="0" :close-delay="0" :surface="detailTooltip ? 'popover' : 'foreground'">
         <div
           ref="rowRef"
           class="group flex items-center gap-1.5 py-1 px-2 cursor-pointer relative outline-none"

--- a/apps/desktop/src/components/ui/LightTooltip.vue
+++ b/apps/desktop/src/components/ui/LightTooltip.vue
@@ -62,14 +62,14 @@ const tooltipTransformClass = computed(() => {
 const arrowClass = computed(() => {
   switch (props.side) {
     case "right":
-      return "absolute -left-1 top-1/2 -translate-y-1/2";
+      return "absolute -left-1.25 top-1/2 -translate-y-1/2 border-b border-l";
     case "left":
-      return "absolute -right-1 top-1/2 -translate-y-1/2";
+      return "absolute -right-1.25 top-1/2 -translate-y-1/2 border-t border-r";
     case "bottom":
-      return "absolute -top-1 left-1/2 -translate-x-1/2";
+      return "absolute -top-1.25 left-1/2 -translate-x-1/2 border-t border-l";
     case "top":
     default:
-      return "absolute -bottom-1 left-1/2 -translate-x-1/2";
+      return "absolute -bottom-1.25 left-1/2 -translate-x-1/2 border-b border-r";
   }
 });
 
@@ -241,7 +241,7 @@ watch(
     <div
       v-if="show"
       ref="tooltipRef"
-      class="fixed z-50 rounded-md bg-foreground text-xs text-background"
+      class="fixed z-50 rounded-md text-xs text-background"
       :class="[slots.content ? '' : ['inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', nowrap ? 'whitespace-nowrap' : ''], tooltipTransformClass]"
       :style="{ left: `${x}px`, top: `${y}px` }"
       role="tooltip"
@@ -249,7 +249,7 @@ watch(
       @mouseleave="scheduleClose"
     >
       <slot name="content">{{ text }}</slot>
-      <span :class="[arrowClass, 'size-2.5 rotate-45 rounded-[2px] bg-foreground']" aria-hidden="true" />
+      <span :class="[arrowClass, 'size-2.5 rotate-45 rounded-[2px] bg-popover border-border']" aria-hidden="true" />
     </div>
   </Teleport>
 </template>

--- a/apps/desktop/src/components/ui/LightTooltip.vue
+++ b/apps/desktop/src/components/ui/LightTooltip.vue
@@ -11,6 +11,7 @@ const props = withDefaults(
     closeDelay?: number;
     openOnFocus?: boolean;
     nowrap?: boolean;
+    surface?: "foreground" | "popover";
   }>(),
   {
     disabled: false,
@@ -20,6 +21,7 @@ const props = withDefaults(
     closeDelay: 100,
     openOnFocus: true,
     nowrap: false,
+    surface: "foreground",
   },
 );
 
@@ -72,6 +74,10 @@ const arrowClass = computed(() => {
       return "absolute -bottom-1.25 left-1/2 -translate-x-1/2 border-b border-r";
   }
 });
+
+const tooltipSurfaceClass = computed(() => (props.surface === "popover" ? "bg-popover text-popover-foreground" : "bg-foreground text-background"));
+
+const arrowSurfaceClass = computed(() => (props.surface === "popover" ? "bg-popover border-border" : "bg-foreground border-foreground"));
 
 function clearTimer() {
   if (!timer) return;
@@ -241,15 +247,15 @@ watch(
     <div
       v-if="show"
       ref="tooltipRef"
-      class="fixed z-50 rounded-md text-xs text-background"
-      :class="[slots.content ? '' : ['inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', nowrap ? 'whitespace-nowrap' : ''], tooltipTransformClass]"
+      class="fixed z-50 rounded-md text-xs"
+      :class="[tooltipSurfaceClass, slots.content ? '' : ['inline-flex w-fit max-w-xs items-center gap-1.5 px-3 py-1.5', nowrap ? 'whitespace-nowrap' : ''], tooltipTransformClass]"
       :style="{ left: `${x}px`, top: `${y}px` }"
       role="tooltip"
       @mouseenter="clearCloseTimer"
       @mouseleave="scheduleClose"
     >
       <slot name="content">{{ text }}</slot>
-      <span :class="[arrowClass, 'size-2.5 rotate-45 rounded-[2px] bg-popover border-border']" aria-hidden="true" />
+      <span :class="[arrowClass, arrowSurfaceClass, 'size-2.5 rotate-45 rounded-[2px]']" aria-hidden="true" />
     </div>
   </Teleport>
 </template>


### PR DESCRIPTION
## 变更说明

- 修复LightTooltip样式错误问题

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

变更前：
<img width="642" height="209" alt="origin-dark" src="https://github.com/user-attachments/assets/24e65d13-874f-4a4c-951b-5b9ab86f0991" />
<img width="636" height="204" alt="origin-light" src="https://github.com/user-attachments/assets/5bbe77e4-fcac-4620-8456-829c92c7d161" />
变更后：
<img width="517" height="193" alt="fixed-dark" src="https://github.com/user-attachments/assets/fc38edba-2b3d-49ae-a6df-6e3233fd929c" />
<img width="526" height="223" alt="fixed-light" src="https://github.com/user-attachments/assets/a36c1264-dc0b-4724-9c10-893d070a9f55" />

## 验证

- [x] `make check` 通过
