### PR TITLE
fix(sqlserver): prevent crash on sql_variant columns by auto-casting to NVARCHAR

### DIFF
--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -288,20 +288,20 @@ async fn describe_sqlserver_result_set(
         .collect())
 }
 
-async fn spatial_safe_sqlserver_query(client: &mut SqlServerClient, sql: &str) -> Result<Option<String>, String> {
+async fn sqlserver_unsafe_type_query(client: &mut SqlServerClient, sql: &str) -> Result<Option<String>, String> {
     if !is_single_sqlserver_select(sql) {
         return Ok(None);
     }
     let columns = describe_sqlserver_result_set(client, sql).await?;
-    Ok(build_spatial_safe_sqlserver_query(sql, &columns))
+    Ok(build_sqlserver_unsafe_type_query(sql, &columns))
 }
 
-fn build_spatial_safe_sqlserver_query(sql: &str, columns: &[SqlServerDescribedColumn]) -> Option<String> {
-    if columns.is_empty() || !columns.iter().any(is_sqlserver_spatial_column) {
+fn build_sqlserver_unsafe_type_query(sql: &str, columns: &[SqlServerDescribedColumn]) -> Option<String> {
+    if columns.is_empty() || !columns.iter().any(is_sqlserver_unsafe_column) {
         return None;
     }
     let statement = normalized_sqlserver_select_statement(sql)?;
-    let source_alias = quote_sqlserver_identifier("dbx_spatial_source");
+    let source_alias = quote_sqlserver_identifier("dbx_unsafe_source");
     let source_columns = (0..columns.len()).map(sqlserver_source_column_name).collect::<Vec<_>>();
     let source_alias_list =
         source_columns.iter().map(|name| quote_sqlserver_identifier(name)).collect::<Vec<_>>().join(", ");
@@ -315,6 +315,8 @@ fn build_spatial_safe_sqlserver_query(sql: &str, columns: &[SqlServerDescribedCo
             let value_ref = format!("{source_alias}.{source_column}");
             if is_sqlserver_spatial_column(column) {
                 format!("{quoted_output} = CASE WHEN {value_ref} IS NULL THEN NULL ELSE {value_ref}.STAsText() END")
+            } else if is_sqlserver_variant_column(column) {
+                format!("{quoted_output} = CAST({value_ref} AS NVARCHAR(MAX))")
             } else {
                 format!("{quoted_output} = {value_ref}")
             }
@@ -325,6 +327,10 @@ fn build_spatial_safe_sqlserver_query(sql: &str, columns: &[SqlServerDescribedCo
     Some(format!("SELECT {select_list} FROM ({statement}) AS {source_alias}({source_alias_list})"))
 }
 
+fn is_sqlserver_unsafe_column(column: &SqlServerDescribedColumn) -> bool {
+    is_sqlserver_spatial_column(column) || is_sqlserver_variant_column(column)
+}
+
 fn is_sqlserver_spatial_column(column: &SqlServerDescribedColumn) -> bool {
     [&column.system_type_name, &column.user_type_name].into_iter().flatten().any(|name| {
         let normalized = name.trim().trim_matches(['[', ']']).to_ascii_lowercase();
@@ -332,6 +338,13 @@ fn is_sqlserver_spatial_column(column: &SqlServerDescribedColumn) -> bool {
             || normalized == "geography"
             || normalized.ends_with(".geometry")
             || normalized.ends_with(".geography")
+    })
+}
+
+fn is_sqlserver_variant_column(column: &SqlServerDescribedColumn) -> bool {
+    [&column.system_type_name, &column.user_type_name].into_iter().flatten().any(|name| {
+        let normalized = name.trim().trim_matches(['[', ']']).to_ascii_lowercase();
+        normalized == "sql_variant" || normalized.ends_with(".sql_variant")
     })
 }
 
@@ -597,7 +610,7 @@ pub async fn stream_first_result_set(
     cancel_token: Option<CancellationToken>,
     mut on_item: impl for<'a> FnMut(SqlServerStreamItem<'a>) -> Result<(), String>,
 ) -> Result<SqlServerStreamExportSummary, String> {
-    let query_sql = match spatial_safe_sqlserver_query(client, sql).await {
+    let query_sql = match sqlserver_unsafe_type_query(client, sql).await {
         Ok(Some(sql)) => sql,
         Ok(None) | Err(_) => sql.to_string(),
     };
@@ -1618,7 +1631,7 @@ pub async fn execute_query_with_max_rows(
     let start = Instant::now();
 
     if starts_with_executable_sql_keyword(sql, &["SELECT", "EXEC", "WITH", "TABLE"]) {
-        let query_sql = match spatial_safe_sqlserver_query(client, sql).await {
+        let query_sql = match sqlserver_unsafe_type_query(client, sql).await {
             Ok(Some(sql)) => sql,
             Ok(None) | Err(_) => sql.to_string(),
         };
@@ -1682,7 +1695,7 @@ pub async fn execute_batch_with_max_rows(
     }
 
     if is_single_sqlserver_select(sql) {
-        if let Ok(Some(query_sql)) = spatial_safe_sqlserver_query(client, sql).await {
+        if let Ok(Some(query_sql)) = sqlserver_unsafe_type_query(client, sql).await {
             let stream = sqlserver_driver_result(client.query(query_sql.as_str(), &[])).await?;
             return sqlserver_driver_result(collect_first_result_limited(stream, start, max_rows)).await.map(
                 |mut result| {
@@ -1841,8 +1854,8 @@ fn first_sql_tokens(sql: &str, limit: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_spatial_safe_sqlserver_query, is_sqlserver_spatial_column, requires_simple_query_batch,
-        sqlserver_batch_can_use_execute, sqlserver_cell_to_json, sqlserver_columns_sql,
+        build_sqlserver_unsafe_type_query, is_sqlserver_spatial_column, is_sqlserver_variant_column,
+        requires_simple_query_batch, sqlserver_batch_can_use_execute, sqlserver_cell_to_json, sqlserver_columns_sql,
         sqlserver_completion_assistant_sql, sqlserver_dml_output_returns_rows, sqlserver_hidden_schema_names,
         sqlserver_indexes_sql, sqlserver_list_objects_sql, sqlserver_list_schemas_sql, sqlserver_list_tables_sql,
         sqlserver_table_comment_sql, sqlserver_visible_object_predicate, strip_dbx_sqlserver_row_number_column,
@@ -2323,7 +2336,7 @@ mod tests {
 
     #[test]
     fn sqlserver_wraps_geometry_columns_as_text() {
-        let rewritten = build_spatial_safe_sqlserver_query(
+        let rewritten = build_sqlserver_unsafe_type_query(
             "SELECT * FROM dbo.tLandPolygon;",
             &[
                 SqlServerDescribedColumn {
@@ -2344,14 +2357,14 @@ mod tests {
 
         assert_eq!(
             rewritten,
-            "SELECT [landId] = [dbx_spatial_source].[dbx_col_1], [polygon] = CASE WHEN [dbx_spatial_source].[dbx_col_2] IS NULL THEN NULL ELSE [dbx_spatial_source].[dbx_col_2].STAsText() END FROM (SELECT * FROM dbo.tLandPolygon) AS [dbx_spatial_source]([dbx_col_1], [dbx_col_2])"
+            "SELECT [landId] = [dbx_unsafe_source].[dbx_col_1], [polygon] = CASE WHEN [dbx_unsafe_source].[dbx_col_2] IS NULL THEN NULL ELSE [dbx_unsafe_source].[dbx_col_2].STAsText() END FROM (SELECT * FROM dbo.tLandPolygon) AS [dbx_unsafe_source]([dbx_col_1], [dbx_col_2])"
         );
     }
 
     #[test]
     fn sqlserver_does_not_wrap_non_spatial_columns() {
         assert_eq!(
-            build_spatial_safe_sqlserver_query(
+            build_sqlserver_unsafe_type_query(
                 "SELECT landId FROM dbo.tLandPolygon",
                 &[SqlServerDescribedColumn {
                     name: Some("landId".to_string()),
@@ -2366,7 +2379,7 @@ mod tests {
 
     #[test]
     fn sqlserver_preserves_order_by_when_wrapping_geometry_columns() {
-        let rewritten = build_spatial_safe_sqlserver_query(
+        let rewritten = build_sqlserver_unsafe_type_query(
             "SELECT landId, polygon FROM dbo.tLandPolygon ORDER BY landId DESC",
             &[
                 SqlServerDescribedColumn {
@@ -2421,5 +2434,104 @@ mod tests {
         );
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn sqlserver_detects_sql_variant_columns() {
+        assert!(is_sqlserver_variant_column(&SqlServerDescribedColumn {
+            name: Some("value".to_string()),
+            system_type_name: Some("sql_variant".to_string()),
+            user_type_schema: None,
+            user_type_name: None,
+        }));
+        assert!(is_sqlserver_variant_column(&SqlServerDescribedColumn {
+            name: Some("value".to_string()),
+            system_type_name: None,
+            user_type_schema: None,
+            user_type_name: Some("sql_variant".to_string()),
+        }));
+        assert!(!is_sqlserver_variant_column(&SqlServerDescribedColumn {
+            name: Some("name".to_string()),
+            system_type_name: Some("nvarchar(128)".to_string()),
+            user_type_schema: None,
+            user_type_name: None,
+        }));
+    }
+
+    #[test]
+    fn sqlserver_wraps_sql_variant_columns_as_nvarchar() {
+        let rewritten = build_sqlserver_unsafe_type_query(
+            "SELECT name, value FROM sys.extended_properties;",
+            &[
+                SqlServerDescribedColumn {
+                    name: Some("name".to_string()),
+                    system_type_name: Some("sysname".to_string()),
+                    user_type_schema: None,
+                    user_type_name: None,
+                },
+                SqlServerDescribedColumn {
+                    name: Some("value".to_string()),
+                    system_type_name: Some("sql_variant".to_string()),
+                    user_type_schema: None,
+                    user_type_name: None,
+                },
+            ],
+        )
+        .unwrap();
+
+        assert!(rewritten.contains("CAST("));
+        assert!(rewritten.contains("AS NVARCHAR(MAX))"));
+        assert!(rewritten.contains("FROM sys.extended_properties"));
+        // The name column should not be cast
+        assert_eq!(rewritten.matches("CAST(").count(), 1);
+    }
+
+    #[test]
+    fn sqlserver_does_not_wrap_non_variant_columns() {
+        assert_eq!(
+            build_sqlserver_unsafe_type_query(
+                "SELECT name FROM sys.extended_properties",
+                &[SqlServerDescribedColumn {
+                    name: Some("name".to_string()),
+                    system_type_name: Some("sysname".to_string()),
+                    user_type_schema: None,
+                    user_type_name: None,
+                }]
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn sqlserver_wraps_both_spatial_and_variant_columns() {
+        let rewritten = build_sqlserver_unsafe_type_query(
+            "SELECT id, shape, metadata FROM dbo.t;",
+            &[
+                SqlServerDescribedColumn {
+                    name: Some("id".to_string()),
+                    system_type_name: Some("int".to_string()),
+                    user_type_schema: None,
+                    user_type_name: None,
+                },
+                SqlServerDescribedColumn {
+                    name: Some("shape".to_string()),
+                    system_type_name: Some("geometry".to_string()),
+                    user_type_schema: Some("sys".to_string()),
+                    user_type_name: Some("geometry".to_string()),
+                },
+                SqlServerDescribedColumn {
+                    name: Some("metadata".to_string()),
+                    system_type_name: Some("sql_variant".to_string()),
+                    user_type_schema: None,
+                    user_type_name: None,
+                },
+            ],
+        )
+        .unwrap();
+
+        assert!(rewritten.contains(".STAsText()"));
+        assert!(rewritten.contains("CAST("));
+        assert!(rewritten.contains("AS NVARCHAR(MAX))"));
+        assert!(rewritten.contains("FROM dbo.t"));
     }
 }

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -304,7 +304,6 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
-            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -202,7 +202,6 @@ mod tests {
             external_config: None,
             jdbc_driver_class: None,
             jdbc_driver_paths: Vec::new(),
-            agent_java_options: Vec::new(),
             one_time: false,
             read_only: false,
         }


### PR DESCRIPTION
## 分析原因
sys.extended_properties.value 列类型为 sql_variant，tiberius TDS 驱动不支持该类型，解码时 panic。而项目 Cargo.toml 设置了 panic = "abort"，导致 catch_unwind 无法捕获，整个进程直接终止。

## 修复内容
将现有的 spatial 列安全包装机制（仅处理 geometry/geography）泛化为 unsafe type query，新增 sql_variant 类型检测，自动在查询前通过 sys.dm_exec_describe_first_result_set 识别 sql_variant 列，并将其包裹为 CAST(... AS NVARCHAR(MAX))：

新增 is_sqlserver_variant_column() 检测 sql_variant 列
新增 is_sqlserver_unsafe_column() 统一检测 spatial + variant
重命名 spatial_safe_sqlserver_query → sqlserver_unsafe_type_query
重命名 build_spatial_safe_sqlserver_query → build_sqlserver_unsafe_type_query
新增 4 个测试用例验证 sql_variant 检测和包装

## Issue
#2894 