### PR TITLE
fix(ai): make stop button actually cancel the agent stream

### DIFF
--- a/crates/dbx-core/src/agent_loop.rs
+++ b/crates/dbx-core/src/agent_loop.rs
@@ -16,7 +16,6 @@ use crate::token_usage::TokenUsage;
 
 /// Maximum number of agent loop turns to prevent infinite loops.
 const MAX_AGENT_TURNS: u32 = 30;
-const AGENT_CANCELLED_ERROR: &str = "Agent loop cancelled";
 const MAX_TOOL_RESULT_CONTEXT_CHARS: usize = 12_000;
 const TOOL_RESULT_HEAD_CHARS: usize = 4_000;
 const TOOL_RESULT_TAIL_CHARS: usize = 4_000;
@@ -254,7 +253,7 @@ pub async fn run_agent_loop(
                     }
                     break;
                 }
-                Err(err) if err == AGENT_CANCELLED_ERROR => {
+                Err(err) if err == ai::AGENT_CANCELLED_ERROR => {
                     final_text = take_text(&accumulated_text);
                     loop_exit = LoopExit::Cancelled;
                     break;
@@ -319,6 +318,14 @@ pub async fn run_agent_loop(
                     break;
                 }
             }
+        }
+
+        // Honor a cancellation that arrived after the stream finished but before we
+        // run the requested tools; otherwise a long execute_query would keep running.
+        if cancelled.notified().now_or_never().is_some() {
+            final_text = accumulated_text;
+            loop_exit = LoopExit::Cancelled;
+            break;
         }
 
         // Execute each tool call
@@ -631,7 +638,7 @@ async fn stream_with_tools(
 ) -> Result<(Vec<ToolCall>, Option<TokenUsage>), String> {
     // Return early if the user cancelled before the LLM call started.
     if cancelled.notified().now_or_never().is_some() {
-        return Err(AGENT_CANCELLED_ERROR.to_string());
+        return Err(ai::AGENT_CANCELLED_ERROR.to_string());
     }
 
     ai::stream_with_tools(config, request, session_id, tools, cancelled, on_chunk).await
@@ -665,13 +672,19 @@ async fn run_agent_loop_text_only(
     messages: &[AiMessage],
     agent_ctx: &AgentLoopContext,
     on_event: impl Fn(AgentEvent) + Send + Sync + 'static,
-    _cancelled: &Notify,
+    cancelled: &Notify,
     max_tokens: Option<u32>,
     task_contract: Option<&AiTaskContract>,
 ) -> Result<String, String> {
     // Build a schema-enriched system prompt so the LLM can answer schema questions
     // even without tool access.
     let enriched_prompt = build_schema_prompt(agent_ctx, system_prompt).await;
+
+    // Honor a cancellation requested while loading schema context.
+    if cancelled.notified().now_or_never().is_some() {
+        on_event(AgentEvent::AgentEnd { input_tokens: None, output_tokens: None });
+        return Ok("Agent run was cancelled before producing output.".to_string());
+    }
 
     let mut request = AiCompletionRequest {
         config: config.clone(),
@@ -683,7 +696,14 @@ async fn run_agent_loop_text_only(
 
     for attempt in 0..=MAX_CONTRACT_REPAIR_ATTEMPTS {
         // Use non-streaming completions so contract repair can suppress incomplete drafts.
-        let result = ai::complete(&request).await?;
+        // Race the (non-cancellable) HTTP call against cancellation so Stop still works.
+        let result = tokio::select! {
+            result = ai::complete(&request) => result?,
+            _ = cancelled.notified() => {
+                on_event(AgentEvent::AgentEnd { input_tokens: None, output_tokens: None });
+                return Ok("Agent run was cancelled before producing output.".to_string());
+            }
+        };
         match validate_final_answer(task_contract, &result) {
             FinalAnswerCheck::Satisfied => {
                 on_event(AgentEvent::TextDelta { delta: result.clone() });

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -34,6 +34,14 @@ pub async fn unregister_stream(session_id: &str) {
     AI_STREAMS.write().await.remove(session_id);
 }
 
+/// Error returned by streaming functions when the user cancels mid-stream.
+///
+/// `run_agent_loop` matches on this exact string to distinguish a cancellation
+/// from a normal completion and stop the loop cleanly. Streaming functions MUST
+/// return this (not `Ok`) when `cancelled` fires, otherwise the agent loop
+/// treats the truncated turn as a normal completion and keeps going.
+pub const AGENT_CANCELLED_ERROR: &str = "Agent loop cancelled";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -1909,7 +1917,9 @@ async fn stream_claude_with_tools(
 
                 if finished { break; }
             }
-            _ = cancelled.notified() => { break; }
+            _ = cancelled.notified() => {
+                return Err(AGENT_CANCELLED_ERROR.to_string());
+            }
         }
     }
 
@@ -2049,7 +2059,9 @@ async fn stream_openai_with_tools(
 
                 if finished { break; }
             }
-            _ = cancelled.notified() => { break; }
+            _ = cancelled.notified() => {
+                return Err(AGENT_CANCELLED_ERROR.to_string());
+            }
         }
     }
 
@@ -2175,7 +2187,9 @@ async fn stream_responses_with_tools(
 
                 if finished { break; }
             }
-            _ = cancelled.notified() => { break; }
+            _ = cancelled.notified() => {
+                return Err(AGENT_CANCELLED_ERROR.to_string());
+            }
         }
     }
 
@@ -2321,7 +2335,9 @@ async fn stream_gemini_with_tools(
                     }
                 }
             }
-            _ = cancelled.notified() => { break; }
+            _ = cancelled.notified() => {
+                return Err(AGENT_CANCELLED_ERROR.to_string());
+            }
         }
     }
 


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## Description

### Problem

Clicking the stop button during an AI conversation had no effect — the agent kept generating. The stop button called `aiCancelStream` → `notify_one()`, but the four `stream_*_with_tools` SSE loops only `break`ed and returned `Ok(token_usage)` when the cancel token fired. `run_agent_loop` treated `Ok` as a normal completed turn and kept going (often into contract-repair or the next turn), so `isGenerating` stayed `true` and the UI never exited the generating state.

### Fix

- **Return `Err(AGENT_CANCELLED_ERROR)`** from all four `stream_*_with_tools` cancel branches instead of `break` → `Ok(token_usage)`. The existing `Err`-cancel match arm in `run_agent_loop` now correctly catches this and sets `loop_exit = LoopExit::Cancelled`.
- **Promote the error constant to a shared `pub const`** in `ai.rs` (`ai::AGENT_CANCELLED_ERROR`) so both `ai.rs` and `agent_loop.rs` reference the same canonical string.
- **Check cancellation before executing requested tools** — a stop landing in the narrow window between stream-end and tool-execution is now honored, preventing a long `execute_query` from starting.
- **Wire cancellation into the text-only fallback** (`run_agent_loop_text_only`) — previously the `_cancelled` parameter was ignored. Now uses `tokio::select!` to race `ai::complete` against `cancelled.notified()`, and also checks after `build_schema_prompt`.

### Known limitation

In-flight tool execution (e.g., `execute_query`) is still not interruptible mid-call. The cancel signal is checked before tool execution begins, but once a tool starts, it runs to completion.

### Files changed

- `crates/dbx-core/src/ai.rs` — added `pub const AGENT_CANCELLED_ERROR`; changed 4 cancel branches from `break` to `return Err(...)`
- `crates/dbx-core/src/agent_loop.rs` — uses `ai::AGENT_CANCELLED_ERROR`; added cancel check before tool execution; wired cancellation into text-only fallback

### Testing

- [x] `cargo test -p dbx-core agent_loop` — 18/18 pass
- [x] `cargo clippy -p dbx-core` — no new warnings introduced
- [ ] Manual smoke test: stop button during streaming, tool calls, and text-only fallback

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2893 