### PR TITLE
feat(editor): 添加自动成对补全设置开关

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -244,6 +244,7 @@ const editShowCurrentStatementFrame = ref(settingsStore.editorSettings.showCurre
 const editAutoAliasTables = ref(settingsStore.editorSettings.autoAliasTables);
 const editWordWrap = ref(settingsStore.editorSettings.wordWrap);
 const editVimModeEnabled = ref(settingsStore.editorSettings.vimModeEnabled);
+const editAutoCloseBrackets = ref(settingsStore.editorSettings.autoCloseBrackets);
 const editSqlSemanticDiagnosticsMode = ref<SqlSemanticDiagnosticsMode>(settingsStore.editorSettings.sqlSemanticDiagnosticsMode);
 const editSqlSemanticDiagnosticsEnabled = ref(settingsStore.editorSettings.sqlSemanticDiagnosticsEnabled);
 const editConfirmDangerousSqlExecution = ref(settingsStore.editorSettings.confirmDangerousSqlExecution);
@@ -567,6 +568,7 @@ watch(
       editAutoAliasTables.value = settingsStore.editorSettings.autoAliasTables;
       editWordWrap.value = settingsStore.editorSettings.wordWrap;
       editVimModeEnabled.value = settingsStore.editorSettings.vimModeEnabled;
+      editAutoCloseBrackets.value = settingsStore.editorSettings.autoCloseBrackets;
       editSqlSemanticDiagnosticsMode.value = settingsStore.editorSettings.sqlSemanticDiagnosticsMode;
       editSqlSemanticDiagnosticsEnabled.value = settingsStore.editorSettings.sqlSemanticDiagnosticsEnabled;
       editConfirmDangerousSqlExecution.value = settingsStore.editorSettings.confirmDangerousSqlExecution;
@@ -672,6 +674,7 @@ function hasChanges(): boolean {
     editAutoAliasTables.value !== settingsStore.editorSettings.autoAliasTables ||
     editWordWrap.value !== settingsStore.editorSettings.wordWrap ||
     editVimModeEnabled.value !== settingsStore.editorSettings.vimModeEnabled ||
+    editAutoCloseBrackets.value !== settingsStore.editorSettings.autoCloseBrackets ||
     editSqlSemanticDiagnosticsMode.value !== settingsStore.editorSettings.sqlSemanticDiagnosticsMode ||
     editSqlSemanticDiagnosticsEnabled.value !== settingsStore.editorSettings.sqlSemanticDiagnosticsEnabled ||
     editConfirmDangerousSqlExecution.value !== settingsStore.editorSettings.confirmDangerousSqlExecution ||
@@ -733,6 +736,7 @@ async function persistSettings() {
     autoAliasTables: editAutoAliasTables.value,
     wordWrap: editWordWrap.value,
     vimModeEnabled: editVimModeEnabled.value,
+    autoCloseBrackets: editAutoCloseBrackets.value,
     sqlSemanticDiagnosticsMode: editSqlSemanticDiagnosticsMode.value,
     confirmDangerousSqlExecution: editConfirmDangerousSqlExecution.value,
     confirmUnsavedSqlClose: editConfirmUnsavedSqlClose.value,
@@ -817,6 +821,7 @@ function resetDefaultsForTab(tab: SettingsCategory) {
     editAutoAliasTables.value = DEFAULT_EDITOR_SETTINGS.autoAliasTables;
     editWordWrap.value = DEFAULT_EDITOR_SETTINGS.wordWrap;
     editVimModeEnabled.value = DEFAULT_EDITOR_SETTINGS.vimModeEnabled;
+    editAutoCloseBrackets.value = DEFAULT_EDITOR_SETTINGS.autoCloseBrackets;
     editSqlSemanticDiagnosticsMode.value = DEFAULT_EDITOR_SETTINGS.sqlSemanticDiagnosticsMode;
     editSqlSemanticDiagnosticsEnabled.value = DEFAULT_EDITOR_SETTINGS.sqlSemanticDiagnosticsEnabled;
     editConfirmDangerousSqlExecution.value = DEFAULT_EDITOR_SETTINGS.confirmDangerousSqlExecution;
@@ -888,6 +893,7 @@ function resetAllDefaults() {
   editAutoAliasTables.value = DEFAULT_EDITOR_SETTINGS.autoAliasTables;
   editWordWrap.value = DEFAULT_EDITOR_SETTINGS.wordWrap;
   editVimModeEnabled.value = DEFAULT_EDITOR_SETTINGS.vimModeEnabled;
+  editAutoCloseBrackets.value = DEFAULT_EDITOR_SETTINGS.autoCloseBrackets;
   editSqlSemanticDiagnosticsMode.value = DEFAULT_EDITOR_SETTINGS.sqlSemanticDiagnosticsMode;
   editSqlSemanticDiagnosticsEnabled.value = DEFAULT_EDITOR_SETTINGS.sqlSemanticDiagnosticsEnabled;
   editConfirmDangerousSqlExecution.value = DEFAULT_EDITOR_SETTINGS.confirmDangerousSqlExecution;
@@ -2531,6 +2537,14 @@ onUnmounted(cleanupPreviewEditor);
                     <p class="text-xs text-muted-foreground">{{ t("settings.vimModeDescription") }}</p>
                   </div>
                   <Switch id="editor-vim-mode" v-model="editVimModeEnabled" class="mt-0.5" />
+                </div>
+
+                <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
+                  <div class="space-y-1">
+                    <Label for="editor-auto-close-brackets">{{ t("settings.autoCloseBrackets") }}</Label>
+                    <p class="text-xs text-muted-foreground">{{ t("settings.autoCloseBracketsDescription") }}</p>
+                  </div>
+                  <Switch id="editor-auto-close-brackets" v-model="editAutoCloseBrackets" class="mt-0.5" />
                 </div>
 
                 <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -202,6 +202,8 @@ let fontThemeComp: import("@codemirror/state").Compartment | null = null;
 let codeMirrorTheme: import("@codemirror/state").Compartment | null = null;
 let wordWrapComp: import("@codemirror/state").Compartment | null = null;
 let vimModeComp: import("@codemirror/state").Compartment | null = null;
+let closeBracketsComp: import("@codemirror/state").Compartment | null = null;
+let codeMirrorCloseBrackets: typeof import("@codemirror/autocomplete").closeBrackets | null = null;
 let readOnlyComp: import("@codemirror/state").Compartment | null = null;
 let runGutterComp: import("@codemirror/state").Compartment | null = null;
 let runKeymapComp: import("@codemirror/state").Compartment | null = null;
@@ -287,6 +289,7 @@ const queryEditorAppearanceSettings = computed(() => {
     activeCustomThemeId: settings.activeCustomThemeId,
     wordWrap: settings.wordWrap,
     vimModeEnabled: settings.vimModeEnabled,
+    autoCloseBrackets: settings.autoCloseBrackets,
     showCurrentStatementFrame: settings.showCurrentStatementFrame,
     shortcuts: settings.shortcuts,
     showStatementRunButtons: settings.showStatementRunButtons,
@@ -963,6 +966,11 @@ function acceptCompletionOrNextSnippetField(view: EditorViewType): boolean {
 function wordWrapExtension() {
   if (!editorViewModule) return [];
   return props.forceWordWrap || settingsStore.editorSettings.wordWrap ? editorViewModule.EditorView.lineWrapping : [];
+}
+
+function closeBracketsExtension(enabled = settingsStore.editorSettings.autoCloseBrackets) {
+  if (!enabled || !codeMirrorCloseBrackets) return [];
+  return codeMirrorCloseBrackets();
 }
 
 function vimModeExtension(enabled = settingsStore.editorSettings.vimModeEnabled) {
@@ -2492,6 +2500,8 @@ onMounted(async () => {
   codeMirrorTheme = new Compartment();
   wordWrapComp = new Compartment();
   vimModeComp = new Compartment();
+  closeBracketsComp = new Compartment();
+  codeMirrorCloseBrackets = closeBrackets;
   readOnlyComp = new Compartment();
   runGutterComp = new Compartment();
   runKeymapComp = new Compartment();
@@ -2755,7 +2765,7 @@ onMounted(async () => {
       completionComp.of(buildSqlCompletionExtension()),
       sqlCompletionTheme(EditorView),
       codeMirrorTheme.of(theme),
-      closeBrackets(),
+      closeBracketsComp.of(closeBracketsExtension(initialSettings.autoCloseBrackets)),
       bracketMatching(),
       hoverTooltip((currentView, pos) => resolveSqlHoverTooltip(currentView, pos)),
       buildSqlSignatureExtension(),
@@ -3099,7 +3109,7 @@ function getCurrentCustomThemeColors() {
 watch(
   [queryEditorAppearanceSettings, () => isDark.value, () => themePalette.value],
   async ([ss]) => {
-    if (!view.value || !codeMirrorTheme || !fontThemeComp || !wordWrapComp || !vimModeComp || !runGutterComp || !runKeymapComp || !editorViewModule) {
+    if (!view.value || !codeMirrorTheme || !fontThemeComp || !wordWrapComp || !vimModeComp || !closeBracketsComp || !runGutterComp || !runKeymapComp || !editorViewModule) {
       return;
     }
     if (!isGestureZooming.value && !zoomCommitScheduler.hasPendingCommit() && liveFontSize.value !== ss.fontSize) {
@@ -3108,7 +3118,7 @@ watch(
     syncEditorFontCssVars(liveFontSize.value, ss.fontFamily);
     const themeColors = getCurrentCustomThemeColors();
     const [themeExt] = await Promise.all([loadEditorTheme(ss.theme, editorThemeAppearance(), themeColors, themePalette.value), ss.vimModeEnabled ? ensureCodeMirrorVim() : Promise.resolve(false)]);
-    if (!view.value || !codeMirrorTheme || !wordWrapComp || !vimModeComp || !runGutterComp || !runKeymapComp || !editorViewModule) {
+    if (!view.value || !codeMirrorTheme || !wordWrapComp || !vimModeComp || !closeBracketsComp || !runGutterComp || !runKeymapComp || !editorViewModule) {
       return;
     }
     view.value.dispatch({
@@ -3116,6 +3126,7 @@ watch(
         codeMirrorTheme.reconfigure(themeExt),
         wordWrapComp.reconfigure(props.forceWordWrap || ss.wordWrap ? editorViewModule.EditorView.lineWrapping : []),
         vimModeComp.reconfigure(vimModeExtension(settingsStore.editorSettings.vimModeEnabled)),
+        closeBracketsComp.reconfigure(closeBracketsExtension(settingsStore.editorSettings.autoCloseBrackets)),
         runGutterComp.reconfigure(props.hideExecutionControls ? [] : (buildRunStatementGutterExtension?.() ?? [])),
         runKeymapComp.reconfigure(runKeymapExtension(editorViewModule.keymap)),
       ],

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -972,8 +972,8 @@ function wordWrapExtension() {
 function closeBracketsExtension(enabled = settingsStore.editorSettings.autoCloseBrackets) {
   if (!enabled || !codeMirrorCloseBrackets) return [];
   const exts: import("@codemirror/state").Extension[] = [codeMirrorCloseBrackets()];
-  if (codeMirrorCloseBracketsKeymap?.length) {
-    exts.push(editorViewModule!.Prec.highest(editorViewModule!.keymap.of([...codeMirrorCloseBracketsKeymap])));
+  if (codeMirrorCloseBracketsKeymap?.length && codeMirrorPrec && editorViewModule) {
+    exts.push(codeMirrorPrec.highest(editorViewModule.keymap.of([...codeMirrorCloseBracketsKeymap])));
   }
   return exts;
 }

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -204,6 +204,7 @@ let wordWrapComp: import("@codemirror/state").Compartment | null = null;
 let vimModeComp: import("@codemirror/state").Compartment | null = null;
 let closeBracketsComp: import("@codemirror/state").Compartment | null = null;
 let codeMirrorCloseBrackets: typeof import("@codemirror/autocomplete").closeBrackets | null = null;
+let codeMirrorCloseBracketsKeymap: readonly import("@codemirror/view").KeyBinding[] | null = null;
 let readOnlyComp: import("@codemirror/state").Compartment | null = null;
 let runGutterComp: import("@codemirror/state").Compartment | null = null;
 let runKeymapComp: import("@codemirror/state").Compartment | null = null;
@@ -970,7 +971,11 @@ function wordWrapExtension() {
 
 function closeBracketsExtension(enabled = settingsStore.editorSettings.autoCloseBrackets) {
   if (!enabled || !codeMirrorCloseBrackets) return [];
-  return codeMirrorCloseBrackets();
+  const exts: import("@codemirror/state").Extension[] = [codeMirrorCloseBrackets()];
+  if (codeMirrorCloseBracketsKeymap?.length) {
+    exts.push(editorViewModule!.Prec.highest(editorViewModule!.keymap.of([...codeMirrorCloseBracketsKeymap])));
+  }
+  return exts;
 }
 
 function vimModeExtension(enabled = settingsStore.editorSettings.vimModeEnabled) {
@@ -2502,6 +2507,7 @@ onMounted(async () => {
   vimModeComp = new Compartment();
   closeBracketsComp = new Compartment();
   codeMirrorCloseBrackets = closeBrackets;
+  codeMirrorCloseBracketsKeymap = closeBracketsKeymap;
   readOnlyComp = new Compartment();
   runGutterComp = new Compartment();
   runKeymapComp = new Compartment();
@@ -2774,7 +2780,6 @@ onMounted(async () => {
       Prec.highest(
         keymap.of([
           { key: "'", run: handleSqlSingleQuote },
-          ...closeBracketsKeymap,
           { key: "Tab", run: handleTab },
           {
             key: "Escape",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -3032,6 +3032,8 @@ export default {
     wordWrapDescription: "Wrap long SQL lines within the editor width",
     vimMode: "Vim mode",
     vimModeDescription: "Use Vim-style modal editing in the SQL editor",
+    autoCloseBrackets: "Auto-close brackets",
+    autoCloseBracketsDescription: "Automatically insert closing brackets and quotes when typing an opening one",
     sqlSemanticDiagnosticsEnabled: "SQL semantic diagnostics",
     sqlSemanticDiagnosticsEnabledDescription: "When enabled, the editor reports semantic issues such as unknown tables and columns. Disable it to reduce parsing and metadata checks for large SQL.",
     confirmDangerousSqlExecution: "Confirm before dangerous SQL",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2933,6 +2933,8 @@ export default withEnglishFallback({
     wordWrapDescription: "Ajustar las líneas largas de SQL al ancho del editor",
     vimMode: "Modo Vim",
     vimModeDescription: "Usar edición modal estilo Vim en el editor SQL",
+    autoCloseBrackets: "Cerrar paréntesis automáticamente",
+    autoCloseBracketsDescription: "Insertar automáticamente paréntesis y comillas de cierre al escribir los de apertura",
     sqlSemanticDiagnosticsEnabled: "Diagnóstico semántico de SQL",
     sqlSemanticDiagnosticsEnabledDescription: "Al activarse, el editor informa de problemas semánticos como tablas y columnas desconocidas. Desactívalo para reducir el análisis y las comprobaciones de metadatos en SQL grandes.",
     confirmDangerousSqlExecution: "Confirmar antes de SQL peligroso",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2931,6 +2931,8 @@ export default withEnglishFallback({
     wordWrapDescription: "Incolonna le righe SQL lunghe entro la larghezza dell'editor",
     vimMode: "Modalita Vim",
     vimModeDescription: "Usa la modifica modale in stile Vim nell'editor SQL",
+    autoCloseBrackets: "Chiusura automatica parentesi",
+    autoCloseBracketsDescription: "Inserisci automaticamente parentesi e virgolette di chiusura quando digiti quelle di apertura",
     sqlSemanticDiagnosticsEnabled: "Diagnostica semantica SQL",
     sqlSemanticDiagnosticsEnabledDescription: "Se abilitata, l'editor segnala problemi semantici come tabelle e colonne sconosciute. Disabilitala per ridurre l'analisi e i controlli dei metadati per file SQL di grandi dimensioni.",
     confirmDangerousSqlExecution: "Conferma prima di SQL pericoloso",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2922,6 +2922,8 @@ export default withEnglishFallback({
     wordWrapDescription: "長いSQL行をエディタ幅内で折り返します",
     vimMode: "Vimモード",
     vimModeDescription: "SQLエディタでVim形式のモーダル編集を使用します",
+    autoCloseBrackets: "自動括弧補完",
+    autoCloseBracketsDescription: "左括弧や左引用符を入力すると、対応する右括弧や右引用符を自動的に挿入します",
     sqlSemanticDiagnosticsEnabled: "SQLセマンティック診断",
     sqlSemanticDiagnosticsEnabledDescription: "有効時、エディタは不明なテーブルや列などの意味的な問題を表示します。大きなSQLの解析とメタデータ確認の負荷を減らすには無効にします。",
     confirmDangerousSqlExecution: "危険なSQLの前に確認",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2932,6 +2932,8 @@ export default withEnglishFallback({
     wordWrapDescription: "Quebrar linhas SQL longas dentro da largura do editor",
     vimMode: "Modo Vim",
     vimModeDescription: "Usar edição modal no estilo Vim no editor SQL",
+    autoCloseBrackets: "Fechar parênteses automaticamente",
+    autoCloseBracketsDescription: "Inserir automaticamente parênteses e aspas de fechamento ao digitar os de abertura",
     sqlSemanticDiagnosticsEnabled: "Diagnóstico semântico de SQL",
     sqlSemanticDiagnosticsEnabledDescription: "Quando ativado, o editor relata problemas semânticos como tabelas e colunas desconhecidas. Desative para reduzir a análise e verificações de metadados em SQL grande.",
     confirmDangerousSqlExecution: "Confirmar antes de SQL perigoso",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -3032,6 +3032,8 @@ export default withEnglishFallback({
     wordWrapDescription: "长 SQL 在编辑器宽度内自动折行显示",
     vimMode: "Vim 模式",
     vimModeDescription: "在 SQL 编辑器中使用 Vim 风格的模态编辑",
+    autoCloseBrackets: "自动成对补全",
+    autoCloseBracketsDescription: "输入左括号或左引号时自动补全对应的右括号或右引号",
     sqlSemanticDiagnosticsEnabled: "SQL 语义诊断",
     sqlSemanticDiagnosticsEnabledDescription: "开启后，编辑器会提示未知表、字段等语义问题；关闭可减少 SQL 解析和元数据检查的性能开销。",
     confirmDangerousSqlExecution: "执行危险 SQL 前弹出确认",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2828,6 +2828,8 @@ export default withEnglishFallback({
     wordWrapDescription: "長 SQL 在編輯器寬度內自動折行顯示",
     vimMode: "Vim 模式",
     vimModeDescription: "在 SQL 編輯器中使用 Vim 風格的模態編輯",
+    autoCloseBrackets: "自動成對補全",
+    autoCloseBracketsDescription: "輸入左括號或左引號時自動補全對應的右括號或右引號",
     sqlSemanticDiagnosticsEnabled: "SQL 語意診斷",
     sqlSemanticDiagnosticsEnabledDescription: "開啟後，編輯器會提示未知資料表、欄位等語意問題；關閉可減少 SQL 解析和中繼資料檢查的效能負擔。",
     confirmDangerousSqlExecution: "執行危險 SQL 前彈出確認",

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -375,6 +375,7 @@ export interface EditorSettings {
   autoAliasTables: boolean;
   wordWrap: boolean;
   vimModeEnabled: boolean;
+  autoCloseBrackets: boolean;
   sqlSemanticDiagnosticsMode: SqlSemanticDiagnosticsMode;
   sqlSemanticDiagnosticsEnabled: boolean;
   confirmDangerousSqlExecution: boolean;
@@ -503,6 +504,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   autoAliasTables: true,
   wordWrap: false,
   vimModeEnabled: false,
+  autoCloseBrackets: true,
   sqlSemanticDiagnosticsMode: "auto",
   sqlSemanticDiagnosticsEnabled: SQL_SEMANTIC_DIAGNOSTICS_AUTO_ENABLED,
   confirmDangerousSqlExecution: true,
@@ -728,6 +730,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
     autoAliasTables: settings.autoAliasTables ?? DEFAULT_EDITOR_SETTINGS.autoAliasTables,
     wordWrap: settings.wordWrap ?? DEFAULT_EDITOR_SETTINGS.wordWrap,
     vimModeEnabled: typeof settings.vimModeEnabled === "boolean" ? settings.vimModeEnabled : DEFAULT_EDITOR_SETTINGS.vimModeEnabled,
+    autoCloseBrackets: typeof settings.autoCloseBrackets === "boolean" ? settings.autoCloseBrackets : DEFAULT_EDITOR_SETTINGS.autoCloseBrackets,
     sqlSemanticDiagnosticsMode,
     sqlSemanticDiagnosticsEnabled: sqlSemanticDiagnosticsEnabledForMode(sqlSemanticDiagnosticsMode),
     confirmDangerousSqlExecution: settings.confirmDangerousSqlExecution ?? DEFAULT_EDITOR_SETTINGS.confirmDangerousSqlExecution,
@@ -963,6 +966,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.autoAliasTables !== undefined) editorSettings.value.autoAliasTables = partial.autoAliasTables;
     if (partial.wordWrap !== undefined) editorSettings.value.wordWrap = partial.wordWrap;
     if (partial.vimModeEnabled !== undefined) editorSettings.value.vimModeEnabled = partial.vimModeEnabled === true;
+    if (partial.autoCloseBrackets !== undefined) editorSettings.value.autoCloseBrackets = partial.autoCloseBrackets === true;
     if (partial.sqlSemanticDiagnosticsMode !== undefined || partial.sqlSemanticDiagnosticsEnabled !== undefined) {
       const nextMode = normalizeSqlSemanticDiagnosticsMode(partial.sqlSemanticDiagnosticsMode, partial.sqlSemanticDiagnosticsEnabled);
       editorSettings.value.sqlSemanticDiagnosticsMode = nextMode;

--- a/packages/app-tests/closeBracketsExtension.test.ts
+++ b/packages/app-tests/closeBracketsExtension.test.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { EditorState, Compartment } from "@codemirror/state";
+import { keymap } from "@codemirror/view";
+
+/**
+ * Replicates the closeBracketsExtension logic from QueryEditor.vue so we can
+ * verify that the Compartment-based toggle correctly includes/excludes both
+ * the closeBrackets() extension and the closeBracketsKeymap.
+ */
+function closeBracketsExtension(enabled: boolean) {
+  if (!enabled) return [];
+  const exts: any[] = [closeBrackets()];
+  if (closeBracketsKeymap.length) {
+    exts.push(keymap.of([...closeBracketsKeymap]));
+  }
+  return exts;
+}
+
+test("closeBracketsExtension returns empty array when disabled", () => {
+  const exts = closeBracketsExtension(false);
+
+  assert.deepEqual(exts, []);
+});
+
+test("closeBracketsExtension includes closeBrackets and its keymap when enabled", () => {
+  const exts = closeBracketsExtension(true);
+
+  assert.equal(exts.length, 2, "should contain closeBrackets() and keymap");
+});
+
+test("closeBracketsKeymap is non-empty so the keymap entry is always included when enabled", () => {
+  assert.ok(closeBracketsKeymap.length > 0, "closeBracketsKeymap should have bindings");
+});
+
+test("Compartment can create EditorState with closeBrackets enabled", () => {
+  const comp = new Compartment();
+  const state = EditorState.create({
+    doc: "select 1",
+    extensions: [comp.of(closeBracketsExtension(true))],
+  });
+
+  assert.ok(state.toJSON().doc, "state should be created with closeBrackets enabled");
+});
+
+test("Compartment reconfigure from enabled to disabled succeeds", () => {
+  const comp = new Compartment();
+  const stateOn = EditorState.create({
+    doc: "select 1",
+    extensions: [comp.of(closeBracketsExtension(true))],
+  });
+
+  // Toggle off — this verifies that closeBracketsExtension(false) returns []
+  // which means both the extension and the keymap are removed
+  const stateOff = stateOn.update({ effects: comp.reconfigure(closeBracketsExtension(false)) }).state;
+
+  assert.equal(stateOff.toJSON().doc, "select 1", "state should still be valid after reconfigure to disabled");
+});
+
+test("Compartment reconfigure from disabled to enabled succeeds", () => {
+  const comp = new Compartment();
+  const stateOff = EditorState.create({
+    doc: "select 1",
+    extensions: [comp.of(closeBracketsExtension(false))],
+  });
+
+  // Toggle on — this verifies that closeBracketsExtension(true) returns both
+  // the closeBrackets() extension and the keymap
+  const stateOn = stateOff.update({ effects: comp.reconfigure(closeBracketsExtension(true)) }).state;
+
+  assert.equal(stateOn.toJSON().doc, "select 1", "state should still be valid after reconfigure to enabled");
+});
+
+test("closeBracketsExtension(false) produces zero extensions", () => {
+  // The key assertion: when disabled, both closeBrackets() and
+  // closeBracketsKeymap are absent — no partial keymap leakage
+  const exts = closeBracketsExtension(false);
+  assert.equal(exts.length, 0);
+});
+
+test("closeBracketsExtension(true) produces exactly two extension groups", () => {
+  // When enabled, both closeBrackets() and the keymap are present
+  const exts = closeBracketsExtension(true);
+  assert.equal(exts.length, 2);
+});

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -165,6 +165,13 @@ test("defaults Vim mode to off and preserves saved booleans", () => {
   assert.equal(normalizeEditorSettings({ vimModeEnabled: "yes" as any }).vimModeEnabled, false);
 });
 
+test("defaults auto-close brackets to on and preserves saved booleans", () => {
+  assert.equal(DEFAULT_EDITOR_SETTINGS.autoCloseBrackets, true);
+  assert.equal(normalizeEditorSettings({}).autoCloseBrackets, true);
+  assert.equal(normalizeEditorSettings({ autoCloseBrackets: false }).autoCloseBrackets, false);
+  assert.equal(normalizeEditorSettings({ autoCloseBrackets: "nope" as any }).autoCloseBrackets, true);
+});
+
 test("defaults update notifications to enabled", () => {
   assert.equal(DEFAULT_EDITOR_SETTINGS.updateNotificationsEnabled, true);
   assert.equal(normalizeEditorSettings({}).updateNotificationsEnabled, true);


### PR DESCRIPTION
## 概述

在编辑器设置的「Vim 模式」下方新增「自动成对补全」开关，控制输入左括号或左引号时是否自动补全对应的右括号或右引号。默认开启。

<img width="1014" height="745" alt="d2b4d6a7-e69d-4cda-a390-05da1a441815" src="https://github.com/user-attachments/assets/013be898-5264-4fb6-919c-c5c57ef0c475" />

## 改动内容

- **settingsStore**: `EditorSettings` 接口新增 `autoCloseBrackets` 字段，默认值 `true`；`normalizeEditorSettings` 和 `updateEditorSettings` 同步支持
- **EditorSettingsDialog**: 添加开关 UI 组件，包含保存、重置、变更检测逻辑
- **QueryEditor**: 使用 CodeMirror `Compartment` 动态切换 `closeBrackets()` 扩展，修复之前直接调用动态 `import()` 局部变量导致的 `ReferenceError: closeBrackets is not defined`
- **i18n**: 补充 en / zh-CN / zh-TW / ja / pt-BR / it / es 七种语言翻译

## Issue
#2892 
