### PR TITLE
fix(mysql): strip allowMultiQueries URL param

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -1157,6 +1157,7 @@ fn is_jdbc_param(key: &str) -> bool {
             | "transformedbitisboolean"
             | "yearisdatetype"
             | "createdatabaseifnotexist"
+            | "allowmultiqueries"
             | "noaccesstoprocedurebodies"
             | "nullcatalogmeanscurrent"
             | "nullnamepatternmatchesall"
@@ -4127,7 +4128,7 @@ UNIQUE KEY(`tenant_id`, `name``part`)
 
     #[test]
     fn mysql_async_url_keeps_valid_params_while_stripping_jdbc() {
-        let url = "mysql://host:3306/db?useUnicode=true&characterEncoding=utf8&require_ssl=true&charset=utf8mb4&autoReconnect=true";
+        let url = "mysql://host:3306/db?useUnicode=true&characterEncoding=utf8&require_ssl=true&charset=utf8mb4&autoReconnect=true&allowMultiQueries=true";
         assert_eq!(mysql_async_url(url).as_ref(), "mysql://host:3306/db?require_ssl=true");
     }
 


### PR DESCRIPTION
## 变更说明

兼容从 JDBC、配置中心或其它 MySQL 客户端复制过来的连接 URL：在交给底层 `mysql_async` 驱动前过滤 `allowMultiQueries` 参数，避免连接测试失败并报：

```text
Invalid MySQL URL: Unknown connection URL parameter `allowMultiQueries`
```

该参数仍可以保留在 DBX 连接配置的 URL 参数字段中；修复只影响后端实际建立 MySQL 连接前的 URL 规范化流程。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端改动。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo fmt --check`
- `cargo test -p dbx-core --no-default-features mysql_async_url_keeps_valid_params_while_stripping_jdbc`
- `cargo check -p dbx-core --no-default-features`

手动验证：

- 使用 `mysql://root:dbx@127.0.0.1:12910/dbx_issue_2910?allowMultiQueries=true` 创建 MySQL 连接。
- 修复前测试连接失败，报 unknown `allowMultiQueries` URL 参数。
- 修复后保留该 URL 参数时测试连接成功。

## 关联 Issue

Close #2910