### PR TITLE
fix(zookeeper): show system znodes in root listing

### DIFF
--- a/agents/drivers/zookeeper/src/main/java/com/dbx/agent/zookeeper/ZooKeeperAgent.java
+++ b/agents/drivers/zookeeper/src/main/java/com/dbx/agent/zookeeper/ZooKeeperAgent.java
@@ -140,7 +140,6 @@ public final class ZooKeeperAgent {
         }
 
         List<String> paths = recursive ? listRecursive(active, root) : listDirectChildren(active, root);
-        paths.removeIf(path -> shouldHideFromRootListing(root, path));
         Collections.sort(paths);
         int offset = cursor == null ? 0 : Math.max(0, cursor.offset);
         int end = Math.min(paths.size(), offset + limit);
@@ -478,10 +477,6 @@ public final class ZooKeeperAgent {
         } catch (KeeperException.NoNodeException e) {
             return 0;
         }
-    }
-
-    private static boolean shouldHideFromRootListing(String root, String path) {
-        return "/".equals(root) && ("/zookeeper".equals(path) || path.startsWith("/zookeeper/"));
     }
 
     private static boolean hasTlsOptions(JsonObject connection) {

--- a/agents/drivers/zookeeper/src/test/java/com/dbx/agent/zookeeper/ZooKeeperAgentTest.java
+++ b/agents/drivers/zookeeper/src/test/java/com/dbx/agent/zookeeper/ZooKeeperAgentTest.java
@@ -398,7 +398,7 @@ final class ZooKeeperAgentTest {
 
             JsonObject list = result(request(5, "kv_list_prefix", "{\"prefix\":\"/\",\"recursive\":false}"));
 
-            Assertions.assertEquals(List.of("/app", "/config"), listedKeys(list));
+            Assertions.assertEquals(List.of("/app", "/config", "/zookeeper"), listedKeys(list));
             Assertions.assertTrue(list.get("continuation").isJsonNull());
         }
     }
@@ -412,7 +412,10 @@ final class ZooKeeperAgentTest {
 
             JsonObject list = result(request(5, "kv_list_prefix", "{\"prefix\":\"/\"}"));
 
-            Assertions.assertEquals(List.of("/app", "/app/name", "/config"), listedKeys(list));
+            Assertions.assertEquals(
+                List.of("/app", "/app/name", "/config", "/zookeeper", "/zookeeper/config", "/zookeeper/quota"),
+                listedKeys(list)
+            );
             Assertions.assertTrue(list.get("continuation").isJsonNull());
         }
     }
@@ -426,7 +429,10 @@ final class ZooKeeperAgentTest {
 
             JsonObject list = result(request(6, "kv_list_prefix", "{\"prefix\":\"/\",\"recursive\":true}"));
 
-            Assertions.assertEquals(List.of("/app", "/app/name", "/config"), listedKeys(list));
+            Assertions.assertEquals(
+                List.of("/app", "/app/name", "/config", "/zookeeper", "/zookeeper/config", "/zookeeper/quota"),
+                listedKeys(list)
+            );
         }
     }
 
@@ -457,11 +463,19 @@ final class ZooKeeperAgentTest {
                 "kv_list_prefix",
                 "{\"prefix\":\"/\",\"limit\":2,\"continuation\":\"" + continuation + "\"}"
             ));
+            String secondContinuation = second.get("continuation").getAsString();
+            JsonObject third = result(request(
+                7,
+                "kv_list_prefix",
+                "{\"prefix\":\"/\",\"limit\":2,\"continuation\":\"" + secondContinuation + "\"}"
+            ));
 
             Assertions.assertEquals(List.of("/a", "/b"), listedKeys(first));
             Assertions.assertFalse(continuation.isBlank());
-            Assertions.assertEquals(List.of("/c"), listedKeys(second));
-            Assertions.assertTrue(second.get("continuation").isJsonNull());
+            Assertions.assertEquals(List.of("/c", "/zookeeper"), listedKeys(second));
+            Assertions.assertFalse(secondContinuation.isBlank());
+            Assertions.assertEquals(List.of("/zookeeper/config", "/zookeeper/quota"), listedKeys(third));
+            Assertions.assertTrue(third.get("continuation").isJsonNull());
         }
     }
 


### PR DESCRIPTION
## 变更说明

修复 ZooKeeper 根路径浏览时 `/zookeeper` 系统节点被隐藏的问题。

此前 ZooKeeper agent 在列举 `/` 时会硬编码过滤 `/zookeeper` 及其子节点，导致 DBX UI 展示的根节点列表与 `zkCli ls /` 不一致。现在移除这段过滤逻辑，让根路径浏览结果完整反映 ZooKeeper 实际返回的 znode。

同时补充 ZooKeeper agent 测试，覆盖：

- 根路径非递归列举包含 `/zookeeper`
- 根路径递归列举包含 `/zookeeper/config`、`/zookeeper/quota`
- 根路径分页时不会跳过 `/zookeeper` 系统节点

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `./gradlew :zookeeper:test :zookeeper:shadowJar`
- `pnpm build`
- `git diff --check`

手动验证：

- 使用 `zookeeper:3.4.10` 容器准备 `/jodis`、`/codis3`，并确认 `zkCli ls /` 返回 `[jodis, codis3, zookeeper]`
- 通过 ZooKeeper agent JSON-RPC 调用 `kv_list_prefix`，确认 `/` 的非递归结果包含 `/zookeeper`
- 通过 Web UI 打开 ZooKeeper key browser，确认根列表显示 `codis3`、`jodis`、`zookeeper`，展开 `zookeeper` 后显示 `quota`

## 关联 Issue

Close #2871
