### PR TITLE
Fix：补全表和视图数据页的超时错误操作

### DIFF
--- a/apps/desktop/src/components/common/QueryErrorActions.vue
+++ b/apps/desktop/src/components/common/QueryErrorActions.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { Bot, Wrench } from "@lucide/vue";
+import { useI18n } from "vue-i18n";
+import { Button } from "@/components/ui/button";
+import { isQueryTimeoutErrorMessage } from "@/lib/sql/queryError";
+
+const props = defineProps<{
+  errorMessage: string;
+  connectionId?: string;
+}>();
+
+const emit = defineEmits<{
+  changeQueryTimeout: [];
+  fixWithAi: [errorMessage: string];
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Button v-if="connectionId && isQueryTimeoutErrorMessage(errorMessage)" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeQueryTimeout')">
+    <Wrench class="h-3.5 w-3.5" />
+    {{ t("editor.changeQueryTimeout") }}
+  </Button>
+  <Button variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('fixWithAi', errorMessage)">
+    <Bot class="h-3.5 w-3.5" />
+    {{ t("ai.fixWithAi") }}
+  </Button>
+</template>

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -3,7 +3,7 @@ import { computed, ref, defineAsyncComponent, watch, nextTick, onMounted, onUnmo
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import type { CSSProperties } from "vue";
 import { useI18n } from "vue-i18n";
-import { Check, Columns3, EyeOff, Loader2, Search, Bot, GitBranch, BarChart3, TableProperties, ChevronDown, ChevronUp, Inbox, RefreshCcw, Timer, Wrench, Toolbox, ListChecks, Database, Download, Upload, X, Pin, Rows3, SquareDashed, Minus, Plus } from "@lucide/vue";
+import { Check, Columns3, EyeOff, Loader2, Search, GitBranch, BarChart3, TableProperties, ChevronDown, ChevronUp, Inbox, RefreshCcw, Timer, Wrench, Toolbox, ListChecks, Database, Download, Upload, X, Pin, Rows3, SquareDashed, Minus, Plus } from "@lucide/vue";
 import { Splitpanes, Pane } from "splitpanes";
 import "splitpanes/dist/splitpanes.css";
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,7 @@ import LightTooltip from "@/components/ui/LightTooltip.vue";
 import QueryEditor from "@/components/editor/QueryEditor.vue";
 import ColumnInfoPanel from "@/components/editor/ColumnInfoPanel.vue";
 import QueryLoadingState from "@/components/common/QueryLoadingState.vue";
+import QueryErrorActions from "@/components/common/QueryErrorActions.vue";
 import type { ColumnInfo } from "@/components/editor/ColumnInfoPanel.vue";
 let dataGridComponentPromise: Promise<typeof import("@/components/grid/DataGrid.vue")> | undefined;
 function loadDataGridComponent() {
@@ -54,7 +55,6 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import { TABLE_FONT_SIZE_MAX, TABLE_FONT_SIZE_MIN, useSettingsStore, type DataGridSearchMode } from "@/stores/settingsStore";
 import { useToast } from "@/composables/useToast";
 import { canCancelQueryExecution, queryExecutionLabelKey } from "@/lib/sql/queryExecutionState";
-import { isQueryTimeoutErrorMessage } from "@/lib/sql/queryError";
 import { databaseDisplayNameForTab, executionSummaryItems, nextExecutionSummaryView, resultGridCacheKey, resultRunItems, resultSqlForGrid, tabularResultItems } from "@/lib/tabs/tabPresentation";
 import { defaultQueryResultArchiveFileName } from "@/lib/query/queryResultArchive";
 import { saveQueryResultArchiveFile } from "@/lib/query/queryResultArchiveFile";
@@ -1113,14 +1113,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
                 @sort="(column: string, columnIndex: number, direction: 'asc' | 'desc' | null, whereInput?: string, mode?: DataGridSortMode) => emit('sort', column, columnIndex, direction, whereInput, mode)"
               >
                 <template v-if="activeTab.result?.columns.includes('Error')" #error-actions="{ errorMessage }">
-                  <Button v-if="activeTab.connectionId && isQueryTimeoutErrorMessage(String(errorMessage))" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('openConnectionSettings', activeTab.connectionId, 'advanced')">
-                    <Wrench class="h-3.5 w-3.5" />
-                    {{ t("editor.changeQueryTimeout") }}
-                  </Button>
-                  <Button variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('fixWithAi', String(errorMessage))">
-                    <Bot class="h-3.5 w-3.5" />
-                    {{ t("ai.fixWithAi") }}
-                  </Button>
+                  <QueryErrorActions :error-message="String(errorMessage)" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
                 </template>
               </DataGrid>
               <QueryLoadingState
@@ -1394,7 +1387,11 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
           @reload="(sql?: string, searchText?: string, whereInput?: string, orderBy?: string, limit?: number, offset?: number) => emit('reload', sql, searchText, whereInput, orderBy, limit, offset)"
           @paginate="(offset: number, limit: number, whereInput?: string, orderBy?: string) => emit('paginate', offset, limit, whereInput, orderBy)"
           @sort="(column: string, columnIndex: number, direction: 'asc' | 'desc' | null, whereInput?: string, mode?: DataGridSortMode) => emit('sort', column, columnIndex, direction, whereInput, mode)"
-        />
+        >
+          <template v-if="activeTab.result?.columns.includes('Error')" #error-actions="{ errorMessage }">
+            <QueryErrorActions :error-message="String(errorMessage)" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
+          </template>
+        </DataGrid>
         <QueryLoadingState v-else-if="activeTab.isExecuting" class="h-full" :label-key="queryExecutionLabelKey(activeTab)" :elapsed-seconds="queryRunningElapsedSeconds" show-cancel :cancel-disabled="!canCancelQueryExecution(activeTab)" :cancelling="activeTab.isCancelling" @cancel="emit('cancel')" />
         <div v-else class="h-full flex flex-col items-center justify-center gap-3 text-muted-foreground text-sm">
           <Inbox class="h-8 w-8 opacity-60" />

--- a/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
@@ -23,6 +23,7 @@ describe("isQueryTimeoutErrorMessage", () => {
   it("detects agent RPC client-side timeout", () => {
     expect(isQueryTimeoutErrorMessage("Agent RPC call timed out (30s)")).toBe(true);
     expect(isQueryTimeoutErrorMessage("Agent RPC call timed out (120s)")).toBe(true);
+    expect(isQueryTimeoutErrorMessage("Agent RPC error (-1): Agent RPC call timed out (120s)")).toBe(true);
   });
 
   it("does not classify unrelated errors as query timeouts", () => {

--- a/apps/desktop/src/lib/sql/queryError.ts
+++ b/apps/desktop/src/lib/sql/queryError.ts
@@ -5,7 +5,7 @@ export function isQueryTimeoutErrorMessage(message: string): boolean {
   // fallback when JDBC setQueryTimeout never fires (unsupported/unresponsive driver), so the
   // backend already treats it as a query timeout (is_agent_rpc_timeout_error in query.rs) —
   // surface the same action here to stay consistent with the backend.
-  if (lower.startsWith("agent rpc call timed out")) return true;
+  if (/\bagent rpc call timed out\b/.test(lower)) return true;
   if (/\b(?:canceling|cancelling|canceled|cancelled)\b[\s\S]{0,80}\bstatement\b[\s\S]{0,80}\btimeout\b/.test(lower)) return true;
   if (/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower)) return false;
   return (


### PR DESCRIPTION
## 概述
- 抽出通用的查询错误操作组件，统一展示“修改查询超时时间”和“用 AI 修复”。
- SQL 查询结果页和表/视图数据页共用同一套错误操作，避免表或视图查询超时时只显示复制按钮。
- 放宽 agent RPC 超时识别，兼容 `Agent RPC error (-1): Agent RPC call timed out (...)` 这类包装后的错误文案。

## i18n
- 未新增用户可见文案 key，复用已有 `editor.changeQueryTimeout` 和 `ai.fixWithAi`。

## 验证
- `pnpm exec oxlint apps/desktop/src/components/layout/ContentArea.vue apps/desktop/src/components/common/QueryErrorActions.vue apps/desktop/src/lib/sql/queryError.ts apps/desktop/src/lib/__tests__/sql/queryError.spec.ts`
- `pnpm test apps/desktop/src/lib/__tests__/sql/queryError.spec.ts`
- `pnpm typecheck`
- `git diff --check`
