### PR TITLE
✨ feat(temporal-editor): 数据库修改datatime字段时支持手动输入数据

### DIFF
--- a/apps/desktop/src/components/grid/TemporalCellEditor.vue
+++ b/apps/desktop/src/components/grid/TemporalCellEditor.vue
@@ -28,10 +28,12 @@ const emit = defineEmits<{
 }>();
 
 const open = ref(false);
+const editorRootRef = ref<HTMLDivElement | null>(null);
 const inputRef = ref<HTMLInputElement | null>(null);
 const localValue = ref(props.modelValue);
 let closeHandled = false;
 let isCommitting = false;
+let skipCommitOnClose = false;
 
 const hasDate = computed(() => props.kind !== "time");
 const hasTime = computed(() => props.kind !== "date");
@@ -82,7 +84,7 @@ watch(
 
 function setOpen(value: boolean) {
   open.value = value;
-  if (!value && props.commitOnClose && !closeHandled) finishCommit();
+  if (!value && props.commitOnClose && !closeHandled && !skipCommitOnClose) finishCommit();
 }
 
 function setModelValue(value: string) {
@@ -187,15 +189,33 @@ function onKeydown(event: KeyboardEvent) {
 }
 
 function onInputBlur() {
-  if (!props.commitOnClose || open.value || closeHandled) return;
+  if (!props.commitOnClose || open.value || closeHandled || skipCommitOnClose) return;
   finishCommit();
 }
 
 function onPopoverInteractOutside(event: PointerDownOutsideEvent | FocusOutsideEvent) {
   const originalEvent = event.detail.originalEvent;
+  if (isEditorInteractionTarget(originalEvent.target)) {
+    event.preventDefault();
+    closePickerOnly();
+    return;
+  }
   if (isSelectInteractionTarget(originalEvent.target)) {
     event.preventDefault();
   }
+}
+
+function closePickerOnly() {
+  if (!open.value) return;
+  skipCommitOnClose = true;
+  setOpen(false);
+  nextTick(() => {
+    skipCommitOnClose = false;
+  });
+}
+
+function isEditorInteractionTarget(target: EventTarget | null): boolean {
+  return target instanceof Node && !!editorRootRef.value?.contains(target);
 }
 
 function isSelectInteractionTarget(target: EventTarget | null): boolean {
@@ -225,7 +245,7 @@ function twoDigit(value: string | number): string {
 
 <template>
   <Popover :open="open" :modal="false" @update:open="setOpen">
-    <div :class="editorRootClass" @click.stop>
+    <div ref="editorRootRef" :class="editorRootClass" @click.stop>
       <PopoverAnchor as-child>
         <input ref="inputRef" :value="localValue" :class="inputClass" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="NULL" @blur="onInputBlur" @click.stop @input="updateTextInput" @keydown.stop="onKeydown" />
       </PopoverAnchor>

--- a/apps/desktop/src/components/grid/TemporalCellEditor.vue
+++ b/apps/desktop/src/components/grid/TemporalCellEditor.vue
@@ -3,8 +3,8 @@ import { computed, nextTick, onMounted, ref, watch } from "vue";
 import type { FocusOutsideEvent, PointerDownOutsideEvent } from "reka-ui";
 import { CalendarClock, ChevronDown, ChevronUp, CircleSlash } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { formatTemporalInputValue, stepTemporalInputValue, type TemporalCellEditorKind } from "@/lib/dataGrid/dataGridTemporalEditor";
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { formatTemporalInputValue, parseTemporalInputValue, stepTemporalInputValue, type TemporalCellEditorKind } from "@/lib/dataGrid/dataGridTemporalEditor";
 
 const props = withDefaults(
   defineProps<{
@@ -27,19 +27,24 @@ const emit = defineEmits<{
   cancel: [];
 }>();
 
-const open = ref(true);
-const triggerRef = ref<HTMLButtonElement | null>(null);
+const open = ref(false);
+const inputRef = ref<HTMLInputElement | null>(null);
 const localValue = ref(props.modelValue);
 let closeHandled = false;
 let isCommitting = false;
 
 const hasDate = computed(() => props.kind !== "time");
 const hasTime = computed(() => props.kind !== "date");
-const displayValue = computed(() => localValue.value || "NULL");
-const triggerClass = computed(() =>
+const editorRootClass = computed(() => (props.variant === "inline" ? "relative h-9 w-full" : "absolute inset-0 z-10"));
+const inputClass = computed(() =>
   props.variant === "inline"
-    ? "cell-edit-input flex h-9 w-full items-center gap-2 rounded border bg-background px-2 text-left text-xs outline-none hover:border-primary/60 focus:border-primary"
-    : ["cell-edit-input absolute inset-0 z-10 flex items-center gap-1 border-2 border-primary bg-background py-0 text-left text-xs outline-none", props.cellLayout === "transpose" ? "px-1.5" : "px-2.5"],
+    ? "cell-edit-input h-9 w-full rounded border bg-background py-0 pl-2 pr-8 text-left text-xs outline-none hover:border-primary/60 focus:border-primary"
+    : ["cell-edit-input absolute inset-0 z-10 border-2 border-primary bg-background py-0 text-left text-xs outline-none", props.cellLayout === "transpose" ? "pl-1.5 pr-6" : "pl-2.5 pr-7"],
+);
+const triggerButtonClass = computed(() =>
+  props.variant === "inline"
+    ? "absolute right-1 top-1/2 z-20 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+    : "absolute right-0.5 top-1/2 z-20 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground",
 );
 const dateParts = computed(() => {
   const text = formatTemporalInputValue(localValue.value, "date");
@@ -62,7 +67,10 @@ const timeParts = computed(() => {
 });
 
 onMounted(() => {
-  nextTick(() => triggerRef.value?.focus());
+  nextTick(() => {
+    inputRef.value?.focus();
+    inputRef.value?.select();
+  });
 });
 
 watch(
@@ -80,6 +88,10 @@ function setOpen(value: boolean) {
 function setModelValue(value: string) {
   localValue.value = value;
   emit("update:modelValue", value);
+}
+
+function updateTextInput(event: Event) {
+  setModelValue((event.target as HTMLInputElement).value);
 }
 
 function updateDate(part: "day" | "month" | "year", rawValue: string | number) {
@@ -130,6 +142,10 @@ function flushInputValue(target: EventTarget | null) {
   }
 }
 
+function normalizeTextInputValue() {
+  setModelValue(parseTemporalInputValue(localValue.value, props.kind) ?? "");
+}
+
 function setNull() {
   setModelValue("NULL");
 }
@@ -145,6 +161,7 @@ function setNow() {
 
 function finishCommit() {
   if (isCommitting) return;
+  normalizeTextInputValue();
   closeHandled = true;
   isCommitting = true;
   emit("commit");
@@ -169,9 +186,14 @@ function onKeydown(event: KeyboardEvent) {
   }
 }
 
+function onInputBlur() {
+  if (!props.commitOnClose || open.value || closeHandled) return;
+  finishCommit();
+}
+
 function onPopoverInteractOutside(event: PointerDownOutsideEvent | FocusOutsideEvent) {
   const originalEvent = event.detail.originalEvent;
-  if (originalEvent instanceof FocusEvent || isSelectInteractionTarget(originalEvent.target)) {
+  if (isSelectInteractionTarget(originalEvent.target)) {
     event.preventDefault();
   }
 }
@@ -202,14 +224,19 @@ function twoDigit(value: string | number): string {
 </script>
 
 <template>
-  <Popover :open="open" @update:open="setOpen">
-    <PopoverTrigger as-child>
-      <button ref="triggerRef" type="button" :class="triggerClass" @keydown.stop="onKeydown" @click.stop>
-        <CalendarClock class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        <span class="min-w-0 flex-1 truncate">{{ displayValue }}</span>
-      </button>
-    </PopoverTrigger>
-    <PopoverContent align="start" side="bottom" class="w-auto gap-1.5 rounded-md p-1.5" @click.stop @keydown.stop="onKeydown" @interact-outside="onPopoverInteractOutside">
+  <Popover :open="open" :modal="false" @update:open="setOpen">
+    <div :class="editorRootClass" @click.stop>
+      <PopoverAnchor as-child>
+        <input ref="inputRef" :value="localValue" :class="inputClass" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" placeholder="NULL" @blur="onInputBlur" @click.stop @input="updateTextInput" @keydown.stop="onKeydown" />
+      </PopoverAnchor>
+      <PopoverTrigger as-child>
+        <button type="button" :class="triggerButtonClass" @mousedown.prevent @click.stop>
+          <CalendarClock class="h-3.5 w-3.5" />
+          <span class="sr-only">Open temporal picker</span>
+        </button>
+      </PopoverTrigger>
+    </div>
+    <PopoverContent align="start" side="bottom" class="w-auto gap-1.5 rounded-md p-1.5" @click.stop @keydown.stop="onKeydown" @open-auto-focus.prevent @close-auto-focus.prevent @interact-outside="onPopoverInteractOutside">
       <div v-if="hasDate" class="grid grid-cols-[4.5rem_4.5rem_4.5rem] gap-1.5">
         <div class="grid h-7 min-w-0 grid-cols-[1fr_1.35rem] overflow-hidden rounded-md border border-input bg-background">
           <input :value="dateParts.year" data-temporal-part="year" inputmode="numeric" class="min-w-0 bg-transparent px-1 text-center text-[13px] tabular-nums outline-none" @input="updateDateFromInput('year', $event)" />

--- a/apps/desktop/src/lib/dataGrid/dataGridTemporalEditor.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTemporalEditor.ts
@@ -36,11 +36,11 @@ export function parseTemporalInputValue(value: string, kind: TemporalCellEditorK
   const text = value.trim();
   if (!text) return null;
   if (kind === "date") return text;
-  if (kind === "time") return normalizeTimeInput(text) || null;
+  if (kind === "time") return normalizeTimeInput(text) || text;
 
-  const [date, time = ""] = text.split("T");
-  const normalizedTime = normalizeTimeInput(time);
-  return date && normalizedTime ? `${date} ${normalizedTime}` : text.replace("T", " ");
+  const datetime = text.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})(?::(\d{2}))?$/);
+  if (!datetime) return text;
+  return `${datetime[1]} ${datetime[2]}:${datetime[3] ?? "00"}`;
 }
 
 export type TemporalCellEditorPart = "year" | "month" | "day" | "hour" | "minute" | "second";

--- a/packages/app-tests/dataGridTemporalEditor.test.ts
+++ b/packages/app-tests/dataGridTemporalEditor.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { stepTemporalInputValue } from "../../apps/desktop/src/lib/dataGrid/dataGridTemporalEditor.ts";
+import { parseTemporalInputValue, stepTemporalInputValue } from "../../apps/desktop/src/lib/dataGrid/dataGridTemporalEditor.ts";
 
 test("steps datetime date and time parts", () => {
   assert.equal(stepTemporalInputValue("2025-07-01 13:41:49", "datetime", "day", 1), "2025-07-02 13:41:49");
@@ -19,4 +19,11 @@ test("wraps stepped time values", () => {
   assert.equal(stepTemporalInputValue("23:59:59", "time", "hour", 1), "00:59:59");
   assert.equal(stepTemporalInputValue("23:59:59", "time", "minute", 1), "23:00:59");
   assert.equal(stepTemporalInputValue("23:59:59", "time", "second", 1), "23:59:00");
+});
+
+test("parses directly typed datetime values for MySQL-compatible editing", () => {
+  assert.equal(parseTemporalInputValue("2026-07-08 12:34:56", "datetime"), "2026-07-08 12:34:56");
+  assert.equal(parseTemporalInputValue("2026-07-08T12:34", "datetime"), "2026-07-08 12:34:00");
+  assert.equal(parseTemporalInputValue("not-a-date", "datetime"), "not-a-date");
+  assert.equal(parseTemporalInputValue("not-a-dateT12:34", "datetime"), "not-a-dateT12:34");
 });


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="581" height="145" alt="image" src="https://github.com/user-attachments/assets/c38ac140-c3c9-42fa-803a-919a0f3d1132" />

- 默认双击手动输入
- 点击右侧 icon 进入选择格式

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #2818