### PR TITLE
Fix: 修复 Windows 窗口顶部边框缺失

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -31,6 +31,7 @@ import { useTauriEvents } from "@/composables/useTauriEvents";
 import { useCloseActionPrompt, type AppCloseAction, type AppCloseRequestOptions } from "@/composables/useCloseActionPrompt";
 import { useVisibilityChange } from "@/composables/useVisibilityChange";
 import { useWebDavAutoUpload } from "@/composables/useWebDavAutoUpload";
+import { shouldDrawDesktopWindowFrame } from "@/composables/useWindowControls";
 import "@/i18n";
 import { translateBackendError } from "@/i18n/backend-errors";
 import * as api from "@/lib/backend/api";
@@ -113,6 +114,7 @@ const { checkingUpdates, updateInfo, updateCheckMessage, showUpdateDialog, isDow
 const { setupFileDrop } = useFileDrop();
 
 const isDesktop = isTauriRuntime();
+const drawDesktopWindowFrame = shouldDrawDesktopWindowFrame(isMacOS(), isDesktop);
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 let updateCheckTimer: ReturnType<typeof setInterval> | undefined;
 const needsAuth = ref(!isDesktop);
@@ -1719,7 +1721,7 @@ onUnmounted(() => {
   <LoginPage v-if="setupRequired || (needsAuth && !authenticated)" :setup-mode="setupRequired" @authenticated="onLoginSuccess" />
   <div v-show="!setupRequired && (!needsAuth || authenticated)" class="fixed inset-0 h-screen w-screen overflow-hidden">
     <TooltipProvider :delay-duration="300">
-      <div class="h-screen w-screen max-w-full min-w-[760px] min-h-[600px] flex flex-col bg-background text-foreground overflow-hidden" :style="appUiFontFamilyStyle">
+      <div class="h-screen w-screen max-w-full min-w-[760px] min-h-[600px] flex flex-col bg-background text-foreground overflow-hidden" :class="{ 'dbx-desktop-window-frame': drawDesktopWindowFrame }" :style="appUiFontFamilyStyle">
         <AppToolbar
           :is-dark="isDark"
           :theme-mode="themeMode"

--- a/apps/desktop/src/composables/__tests__/useWindowControls.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useWindowControls.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldReserveMacTrafficLightInset, shouldShowWindowControls } from "@/composables/useWindowControls";
+import { shouldDrawDesktopWindowFrame, shouldReserveMacTrafficLightInset, shouldShowWindowControls } from "@/composables/useWindowControls";
 
 describe("window controls", () => {
   it("shows custom controls for non-macOS desktop windows", () => {
@@ -12,6 +12,12 @@ describe("window controls", () => {
 
   it("does not show desktop controls in web runtime", () => {
     expect(shouldShowWindowControls(false, false)).toBe(false);
+  });
+
+  it("draws an app frame only for self-decorated desktop windows", () => {
+    expect(shouldDrawDesktopWindowFrame(false, true)).toBe(true);
+    expect(shouldDrawDesktopWindowFrame(true, true)).toBe(false);
+    expect(shouldDrawDesktopWindowFrame(false, false)).toBe(false);
   });
 
   it("reserves traffic light inset only for non-fullscreen macOS desktop windows", () => {

--- a/apps/desktop/src/composables/useWindowControls.ts
+++ b/apps/desktop/src/composables/useWindowControls.ts
@@ -11,6 +11,10 @@ export function shouldShowWindowControls(isMac: boolean, isDesktop = true): bool
   return isDesktop && !isMac;
 }
 
+export function shouldDrawDesktopWindowFrame(isMac: boolean, isDesktop = true): boolean {
+  return isDesktop && !isMac;
+}
+
 export function useWindowControls() {
   const isMaximized = ref(false);
   const isFullscreen = ref(false);

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -119,6 +119,7 @@
   --sidebar-accent-foreground: rgb(23 23 23);
   --sidebar-border: rgb(229 229 229);
   --sidebar-ring: rgb(161 161 161);
+  --dbx-window-top-border: rgb(0 0 0 / 0.35);
 }
 
 .dark {
@@ -154,6 +155,7 @@
   --sidebar-accent-foreground: rgb(221 221 226);
   --sidebar-border: rgb(110 110 114 / 0.28);
   --sidebar-ring: rgb(133 134 139);
+  --dbx-window-top-border: rgb(255 255 255 / 0.18);
 }
 
 html.theme-soft {
@@ -1312,6 +1314,22 @@ body.dbx-table-reference-dragging * {
     cursor: pointer;
     user-select: none;
   }
+}
+
+.dbx-desktop-window-frame {
+  position: relative;
+}
+
+.dbx-desktop-window-frame::before {
+  content: "";
+  position: absolute;
+  z-index: 80;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 1px;
+  pointer-events: none;
+  background: var(--dbx-window-top-border);
 }
 
 .dbx-editor-font-family {


### PR DESCRIPTION
## 背景
Windows/Linux 桌面端当前关闭了原生窗口装饰，窗口外框需要应用自己绘制。顶部工具栏只有底部分割线，窗口最顶部没有自绘边线，导致 Windows 版顶部边缘缺少黑线。

## 修改
- 为桌面端非 macOS 窗口增加应用自绘顶部 1px 边线。
- macOS 保持原生窗口装饰/红黄绿逻辑，不应用该样式。
- 补充窗口控制相关判断的单元测试。

## 验证
- pnpm test --run apps/desktop/src/composables/__tests__/useWindowControls.spec.ts
- pnpm exec oxlint --vue-plugin apps/desktop/src/App.vue apps/desktop/src/composables/useWindowControls.ts apps/desktop/src/composables/__tests__/useWindowControls.spec.ts
- pnpm typecheck
- pnpm build
- Windows 测试构建通过：https://github.com/zipg/dbx/actions/runs/28946300799

## 平台影响
- Windows：补齐顶部边线。
- Linux：同样是自绘窗口，补齐顶部边线，和 Windows 保持一致。
- macOS：不会添加该 class，不影响原生窗口样式。