### PR TITLE
fix(agents): add url params for cassandra driver

### DIFF
--- a/agents/drivers/cassandra/src/main/java/com/dbx/agent/cassandra/CassandraAgent.java
+++ b/agents/drivers/cassandra/src/main/java/com/dbx/agent/cassandra/CassandraAgent.java
@@ -163,7 +163,13 @@ public final class CassandraAgent extends AbstractJdbcAgent {
         String baseUrl = "jdbc:cassandra://" + params.getHost() + ":" + params.getPort();
         String keyspace = coalesce(params.getDatabase()).trim();
         // Cassandra rejects an empty keyspace path; omit it so DBX can connect first and list keyspaces.
-        return keyspace.isEmpty() ? baseUrl : baseUrl + "/" + keyspace;
+        String url = keyspace.isEmpty() ? baseUrl : baseUrl + "/" + keyspace;
+        // Multi-DC clusters require localdatacenter=<dc>
+        String extraParams = coalesce(params.getUrl_params()).trim();
+        while (extraParams.startsWith("?") || extraParams.startsWith("&")) {
+            extraParams = extraParams.substring(1);
+        }
+        return extraParams.isEmpty() ? url : url + "?" + extraParams;
     }
 
     private static List<String> targetColumns(String options) {

--- a/agents/drivers/cassandra/src/test/java/com/dbx/agent/cassandra/CassandraAgentTest.java
+++ b/agents/drivers/cassandra/src/test/java/com/dbx/agent/cassandra/CassandraAgentTest.java
@@ -31,4 +31,22 @@ class CassandraAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         assertEquals("jdbc:cassandra://127.0.0.1:9042/app_keyspace", CassandraAgent.buildUrl(params));
     }
+
+    @Test
+    void appendsUrlParamsForMultiDcLocalDatacenter() {
+        ConnectParams params = new ConnectParams(
+            "127.0.0.1", 9042, "app_keyspace", "cassandra", "cassandra", "localdatacenter=dc1", "", false
+        );
+
+        assertEquals("jdbc:cassandra://127.0.0.1:9042/app_keyspace?localdatacenter=dc1", CassandraAgent.buildUrl(params));
+    }
+
+    @Test
+    void stripsLeadingQuestionMarkFromUrlParams() {
+        ConnectParams params = new ConnectParams(
+            "127.0.0.1", 9042, "", "cassandra", "cassandra", "?localdatacenter=dc1", "", false
+        );
+
+        assertEquals("jdbc:cassandra://127.0.0.1:9042?localdatacenter=dc1", CassandraAgent.buildUrl(params));
+    }
 }

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -4575,7 +4575,9 @@ function openExternalUrl(url: string) {
                                   ? 'CLIENT_LOCALE=en_US.utf8;DB_LOCALE=en_US.utf8'
                                   : form.db_type === 'spark'
                                     ? 'catalog=paimon_catalog'
-                                    : 'sslmode=disable'
+                                    : form.db_type === 'cassandra'
+                                      ? 'localdatacenter=dc1'
+                                      : 'sslmode=disable'
                       "
                     />
                   </div>


### PR DESCRIPTION
## Change Description

<!-- Briefly describe what this PR does -->
This pr adds url params to cassandra connection. If cassandra contains multiple DC - driver should know `localdatacenter` param otherwise it fails with an unobvious error
## Change Type

- [x] New Feature

- [x] Bug Fix

- [ ] Performance Optimization

- [ ] Code Refactoring

- [ ] Documentation Update

- [ ] CI / Build

## Front-end Involvement

<!-- If the PR involves any front-end changes (UI components, styles, interactions, copy, etc.), screenshots or screen recordings must be attached -->

- [ ] This PR involves front-end changes, screenshots/screen recordings are attached (see below)

<!-- Screenshot area -->

## Verification

<!-- Explain how you verified your changes, for example: commands, test cases, manual steps -->

- [x] `make check` passed

- [x] `make cargo-check-fast` passed

- [x] Related tests passed

## Related Issue

<!-- If applicable, fill in `Close` #xxx` or `Related #xxx` -->

Error before fix
```
Agent RPC error (-1): java.sql.SQLNonTransientConnectionException: Unexpected error while creating connection.. recent stderr:
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Jul 08, 2026 6:19:50 PM io.netty.util.internal.PlatformDependent <clinit>
INFO: Your platform does not provide complete low-level API for accessing direct buffers reliably. Unless explicitly requested, heap buffer will always be preferred to avoid potential system instability.
```