### PR TITLE
fix(ai): restore global reasoning toggle accidentally reverted by d90847bb

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -590,7 +590,7 @@ function appendAssistantReasoning(assistantIdx: number, delta: string) {
   scrollToBottom();
 }
 
-const expandedReasoning = ref<Set<number>>(new Set());
+const reasoningExpanded = ref(false);
 const expandedSteps = ref<Set<string>>(new Set());
 
 function toggleStep(key: string) {
@@ -705,14 +705,8 @@ function agentEventToStep(event: AgentEvent, index: number): AiAgentStepItem | u
   };
 }
 
-function toggleReasoning(index: number) {
-  const next = new Set(expandedReasoning.value);
-  if (next.has(index)) {
-    next.delete(index);
-  } else {
-    next.add(index);
-  }
-  expandedReasoning.value = next;
+function toggleReasoning() {
+  reasoningExpanded.value = !reasoningExpanded.value;
 }
 
 function getMessageScrollViewport(): HTMLElement | null {
@@ -1724,16 +1718,16 @@ async function openExternalUrl(url: string) {
             <div v-else-if="msg.content || msg.reasoning || msg.isThinking" class="flex">
               <div class="max-w-[95%] min-w-0 rounded-lg bg-muted px-3 py-2 text-xs leading-relaxed">
                 <div v-if="msg.reasoning || msg.isThinking" class="mb-2">
-                  <button class="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors" @click="toggleReasoning(i)">
-                    <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': expandedReasoning.has(i) || msg.isThinking }" />
+                  <button class="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors" @click="toggleReasoning()">
+                    <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': reasoningExpanded }" />
                     <Loader2 v-if="msg.isThinking" class="h-3 w-3 animate-spin" />
                     <span>{{ t("ai.reasoningProcess") }}</span>
                   </button>
                   <div
                     class="overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out"
                     :style="{
-                      maxHeight: expandedReasoning.has(i) || msg.isThinking ? '20000px' : '0px',
-                      opacity: expandedReasoning.has(i) || msg.isThinking ? '1' : '0',
+                      maxHeight: reasoningExpanded ? '20000px' : '0px',
+                      opacity: reasoningExpanded ? '1' : '0',
                     }"
                   >
                     <div class="mt-1.5 pl-4 border-l-2 border-muted-foreground/20 text-[11px] text-muted-foreground whitespace-pre-wrap">


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## Summary

Restores the global reasoning toggle from commit `09f9e446` that was accidentally reverted by `d90847bb` (SQL file references feature) during merge conflict resolution.

## Problem

`09f9e446` replaced per-message reasoning expand/collapse with a single global toggle (`reasoningExpanded: ref(false)`), defaulting to collapsed. This fixed an annoying UX flip-flop where the reasoning section auto-expanded during streaming and collapsed immediately afterward.

`d90847bb` inadvertently reverted this change back to the old per-message `Set<number>` approach while resolving conflicts in its large template restructure.

## What Changed

Three mechanical changes in `AiAssistant.vue`, all matching `09f9e446` exactly:

| Before (per-message) | After (global) |
|---|---|
| `expandedReasoning = ref<Set<number>>(new Set())` | `reasoningExpanded = ref(false)` |
| `toggleReasoning(index)` with Set add/delete | `toggleReasoning()` with boolean flip |
| `expandedReasoning.has(i) \|\| msg.isThinking` | `reasoningExpanded` |

## Behavior

- **Default**: all reasoning sections collapsed
- **Toggle**: one click expands/collapses reasoning for ALL messages
- **Spinner**: still shows per-message when thinking is in progress (loader icon on the collapsed header)

## Review

- ✅ No new logic introduced — pure revert to a previously-reviewed commit
- ✅ No remaining references to `expandedReasoning` in the codebase
- ✅ Pre-commit hooks pass (oxfmt)

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建
- [x] 代码还原 (Revert / 恢复之前被覆盖的改动)

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
