### PR TITLE
Fix: 修复 SQL 编辑器单引号重复输入

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -15,6 +15,7 @@ import { executableStatementRangeAtCursor, executableStatementRangeCacheForDoc, 
 import { currentStatementFrameRangeTo, visualSqlColumns } from "@/lib/sql/currentStatementFrame";
 import { formatSqlText, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
 import { buildSqlInConditionFromPasteSource, insertTextForSqlInCondition } from "@/lib/sql/sqlInListPaste";
+import { resolveSqlSingleQuoteKeyAction } from "@/lib/sql/sqlQuoteCaret";
 import { formatMongoShellText } from "@/lib/mongo/mongoFormatter";
 import { useConnectionStore, COMPLETION_METADATA_CONCURRENCY } from "@/stores/connectionStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -430,14 +431,28 @@ function requestExecuteFromView(currentView: EditorViewType, cursorPos: number, 
   return true;
 }
 
+function sqlSingleQuoteKeyActionAt(state: EditorViewType["state"], position: number) {
+  return resolveSqlSingleQuoteKeyAction({
+    previousChar: position > 0 ? state.doc.sliceString(position - 1, position) : "",
+    nextChar: position < state.doc.length ? state.doc.sliceString(position, position + 1) : "",
+    autoCloseBrackets: settingsStore.editorSettings.autoCloseBrackets,
+  });
+}
+
 function handleSqlSingleQuote(view: EditorViewType): boolean {
   const { state } = view;
-  if (state.readOnly) return false;
-  if (state.selection.ranges.some((range) => !range.empty || range.from === 0 || state.doc.sliceString(range.from - 1, range.from) !== "'")) return false;
-  const transaction = state.changeByRange((range) => ({
-    changes: { from: range.from, insert: "'" },
-    range,
-  }));
+  const EditorSelection = codeMirrorEditorSelection;
+  if (state.readOnly || !EditorSelection) return false;
+  if (state.selection.ranges.some((range) => !range.empty)) return false;
+  if (state.selection.ranges.some((range) => sqlSingleQuoteKeyActionAt(state, range.from) === "pass")) return false;
+  const transaction = state.changeByRange((range) => {
+    const nextRange = EditorSelection.cursor(range.from + 1);
+    if (sqlSingleQuoteKeyActionAt(state, range.from) !== "insertEscapedQuote") return { range: nextRange };
+    return {
+      changes: { from: range.from, insert: "'" },
+      range: nextRange,
+    };
+  });
   view.dispatch(transaction, { userEvent: "input.type" });
   return true;
 }

--- a/apps/desktop/src/lib/__tests__/sql/sqlQuoteCaret.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlQuoteCaret.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveSqlSingleQuoteKeyAction } from "@/lib/sql/sqlQuoteCaret";
+
+describe("resolveSqlSingleQuoteKeyAction", () => {
+  it("skips over the auto-inserted closing single quote", () => {
+    expect(resolveSqlSingleQuoteKeyAction({ previousChar: "'", nextChar: "'" })).toBe("skipClosingQuote");
+  });
+
+  it("keeps escaped quote insertion when there is no closing quote to skip", () => {
+    expect(resolveSqlSingleQuoteKeyAction({ previousChar: "'", nextChar: "" })).toBe("insertEscapedQuote");
+  });
+
+  it("lets CodeMirror handle ordinary single quote input", () => {
+    expect(resolveSqlSingleQuoteKeyAction({ previousChar: "a", nextChar: "" })).toBe("pass");
+  });
+
+  it("does not skip an existing string opening quote after whitespace", () => {
+    expect(resolveSqlSingleQuoteKeyAction({ previousChar: " ", nextChar: "'" })).toBe("pass");
+  });
+
+  it("does not skip an existing string opening quote at the start of the document", () => {
+    expect(resolveSqlSingleQuoteKeyAction({ previousChar: "", nextChar: "'" })).toBe("pass");
+  });
+
+  it("does not intercept input when auto-close brackets is disabled", () => {
+    expect(resolveSqlSingleQuoteKeyAction({ previousChar: "'", nextChar: "'", autoCloseBrackets: false })).toBe("pass");
+  });
+});

--- a/apps/desktop/src/lib/sql/sqlQuoteCaret.ts
+++ b/apps/desktop/src/lib/sql/sqlQuoteCaret.ts
@@ -4,6 +4,16 @@ export interface SqlSingleQuoteCaretOptions {
   selectionStart: number | null | undefined;
 }
 
+export type SqlSingleQuoteKeyAction = "pass" | "skipClosingQuote" | "insertEscapedQuote";
+
+export function resolveSqlSingleQuoteKeyAction(options: { previousChar?: string; nextChar?: string; autoCloseBrackets?: boolean }): SqlSingleQuoteKeyAction {
+  const { previousChar = "", nextChar = "", autoCloseBrackets = true } = options;
+  if (!autoCloseBrackets) return "pass";
+  if (previousChar === "'" && nextChar === "'") return "skipClosingQuote";
+  if (previousChar === "'") return "insertEscapedQuote";
+  return "pass";
+}
+
 export function insertedSqlSingleQuoteAtCaret(options: SqlSingleQuoteCaretOptions): boolean {
   const { previousValue, nextValue, selectionStart } = options;
   if (typeof selectionStart !== "number" || selectionStart < 1) return false;


### PR DESCRIPTION
## 背景
SQL 编辑器启用自动补全引号时，输入单引号会生成一对 `''`，但第二次按单引号会被 DBX 的自定义单引号处理逻辑拦截，继续插入第三个单引号，而不是像双引号一样跳过右侧引号。

## 修改
- 单引号按键处理优先判断光标右侧是否已有自动补出的右单引号；如果有，则只移动光标到右单引号后面。
- 保留原有 SQL 字符串内继续输入转义单引号的能力。
- 尊重“自动补全括号/引号”设置，关闭后不拦截单引号输入。
- 补充单元测试覆盖跳过右引号、转义插入和关闭自动补全等场景。

## 验证
- pnpm test --run apps/desktop/src/lib/__tests__/sql/sqlQuoteCaret.spec.ts
- pnpm exec oxlint --vue-plugin apps/desktop/src/components/editor/QueryEditor.vue apps/desktop/src/lib/sql/sqlQuoteCaret.ts apps/desktop/src/lib/__tests__/sql/sqlQuoteCaret.spec.ts
- pnpm typecheck
- git diff --check