### PR TITLE
fix(mysql): preserve binary literals during transfer

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1011,6 +1011,9 @@ pub fn escape_value_typed(val: &serde_json::Value, db_type: &DatabaseType, colum
             if let Some(binary_literal) = format_postgres_binary_sql_literal(s, db_type, column_type) {
                 return binary_literal;
             }
+            if let Some(binary_literal) = format_mysql_binary_sql_literal(s, db_type, column_type) {
+                return binary_literal;
+            }
             if let Some(numeric_literal) = format_mysql_numeric_string_literal(s, db_type, column_type) {
                 return numeric_literal;
             }
@@ -1103,6 +1106,20 @@ fn format_postgres_binary_sql_literal(
     }
 
     Some(format!("decode('{hex}', 'hex')"))
+}
+
+fn format_mysql_binary_sql_literal(value: &str, db_type: &DatabaseType, column_type: Option<&str>) -> Option<String> {
+    if !matches!(db_type, DatabaseType::Mysql) || !column_type.is_some_and(is_binary_transfer_column_type) {
+        return None;
+    }
+
+    let trimmed = value.trim();
+    let hex = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X"))?;
+    if hex.as_bytes().iter().all(|byte| byte.is_ascii_hexdigit()) {
+        Some(if hex.is_empty() { "X''".to_string() } else { format!("0x{hex}") })
+    } else {
+        None
+    }
 }
 
 fn format_oracle_date_sql_literal(value: &str, db_type: &DatabaseType, column_type: Option<&str>) -> Option<String> {
@@ -5924,6 +5941,47 @@ mod tests {
             sql,
             r#"INSERT INTO "public"."files" ("id", "payload", "note") VALUES
 (1, decode('48656c6c6f', 'hex'), '0x48656c6c6f')"#
+        );
+    }
+
+    #[test]
+    fn mysql_insert_formats_blob_prefixed_hex_as_binary_literal() {
+        let sql = generate_insert_typed(
+            &[String::from("id"), String::from("payload"), String::from("empty_blob"), String::from("note")],
+            &[
+                Some(String::from("int")),
+                Some(String::from("MEDIUMBLOB")),
+                Some(String::from("blob")),
+                Some(String::from("varchar(64)")),
+            ],
+            &[vec![json!(1), json!("0x0001ABff"), json!("0X"), json!("0x0001ABff")]],
+            "files",
+            "",
+            &DatabaseType::Mysql,
+        );
+
+        assert_eq!(
+            sql,
+            r#"INSERT INTO `files` (`id`, `payload`, `empty_blob`, `note`) VALUES
+(1, 0x0001ABff, X'', '0x0001ABff')"#
+        );
+    }
+
+    #[test]
+    fn mysql_insert_keeps_invalid_blob_hex_as_string_literal() {
+        let sql = generate_insert_typed(
+            &[String::from("id"), String::from("payload")],
+            &[Some(String::from("int")), Some(String::from("mediumblob"))],
+            &[vec![json!(1), json!("0xnothex")]],
+            "files",
+            "",
+            &DatabaseType::Mysql,
+        );
+
+        assert_eq!(
+            sql,
+            r#"INSERT INTO `files` (`id`, `payload`) VALUES
+(1, '0xnothex')"#
         );
     }
 


### PR DESCRIPTION
## 变更说明

修复 MySQL 数据传输时 BLOB/MEDIUMBLOB 等二进制列被写成文本 `0x...` 的问题。

- MySQL 查询结果中的二进制列会以 `0x...` 形式传入传输写入逻辑。
- 传输到 MySQL 目标库时，如果目标列是 binary/blob 类型，保留合法 `0x...` 为 MySQL hex literal，避免写成普通字符串。
- 普通文本列中的 `0x...` 仍按字符串写入，不改变既有行为。
- 补充 MySQL BLOB 传输 INSERT 生成逻辑的回归测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

不涉及前端改动。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo fmt --check`
- `cargo test -p dbx-core --no-default-features mysql_insert_`
- `cargo test -p dbx-core --no-default-features transfer::tests::`
- `cargo check -p dbx-core --no-default-features`
- `cargo check --workspace --no-default-features`
- `cargo test --workspace --no-default-features`
- `make check`
- `make cargo-check-fast`

手动验证：

- 使用本地 MySQL 5.7 source/target 容器，通过 DBX Desktop 数据传输复制包含 `MEDIUMBLOB` 的 `blob_samples` 表。
- 传输后 source/target 的 `OCTET_LENGTH(payload)`、`MD5(payload)`、`LEFT(HEX(payload), 32)` 完全一致。

## 关联 Issue

Close #2829