### PR TITLE
Fix：连接异常后重建失效的 Agent 连接池

### DIFF
--- a/apps/desktop/src/lib/connection/__tests__/connectionHealth.spec.ts
+++ b/apps/desktop/src/lib/connection/__tests__/connectionHealth.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { shouldMarkDisconnected } from "@/lib/connection/connectionHealth";
+
+describe("connectionHealth", () => {
+  it("marks localized and JDBC communication errors as disconnected", () => {
+    expect(shouldMarkDisconnected("Agent RPC error (-1): dm.jdbc.driver.DMException: 网络通信异常")).toBe(true);
+    expect(shouldMarkDisconnected("Agent RPC error (-1): com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure")).toBe(true);
+    expect(shouldMarkDisconnected("Agent RPC error (-1): java.sql.SQLRecoverableException: IO 错误: Got minus one from a read call")).toBe(true);
+  });
+
+  it("does not mark ordinary SQL or authentication errors as disconnected", () => {
+    expect(shouldMarkDisconnected("syntax error at or near SELECT")).toBe(false);
+    expect(shouldMarkDisconnected("Access denied for user root")).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/connection/connectionHealth.ts
+++ b/apps/desktop/src/lib/connection/connectionHealth.ts
@@ -24,6 +24,12 @@ const CONNECTION_ERROR_PATTERNS = [
   "input/output error",
   "关闭的连接",
   "连接已关闭",
+  "网络通信异常",
+  "通信异常",
+  "communications link failure",
+  "sqlrecoverableexception",
+  "sqlnontransientconnectionexception",
+  "sqltransientconnectionexception",
   "i/o error",
   "no route to host",
 ];

--- a/crates/dbx-core/src/db/agent_driver.rs
+++ b/crates/dbx-core/src/db/agent_driver.rs
@@ -1424,11 +1424,9 @@ fn format_agent_startup_error(base: &str, child: &mut Child, stderr_tail: &Arc<M
 
 impl AgentDriverClient {
     fn format_agent_process_error(&mut self, base: &str) -> String {
-        format_agent_process_error(
-            base,
-            child_exit_status_after_short_wait(&mut self.child),
-            &stderr_tail_snapshot(&self.stderr_tail),
-        )
+        // Runtime RPC errors are common SQL/driver paths. Do not wait for the
+        // child to exit unless startup diagnostics already expect the process to die.
+        format_agent_process_error(base, child_exit_status(&mut self.child), &stderr_tail_snapshot(&self.stderr_tail))
     }
 }
 
@@ -1615,6 +1613,33 @@ mod tests {
         assert!(message.contains("Agent requires Java 21"));
         assert!(message.contains("details: Failed to read startup line from agent: end of stream"));
         assert!(message.contains("UnsupportedClassVersionError"));
+    }
+
+    #[test]
+    fn runtime_agent_process_error_does_not_wait_for_live_child() {
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 2")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("child should start");
+        let mut client = AgentDriverClient {
+            child,
+            stdin: None,
+            stdout: None,
+            stderr_tail: Arc::new(Mutex::new(StderrTail::default())),
+            handshake: None,
+            next_id: 0,
+        };
+
+        let started_at = std::time::Instant::now();
+        let message = client.format_agent_process_error("Agent RPC error (-1): syntax error");
+
+        assert!(started_at.elapsed() < std::time::Duration::from_millis(500));
+        assert!(message.contains("Agent RPC error (-1): syntax error"));
+        assert!(!message.contains("agent process exited"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/agent_driver.rs
+++ b/crates/dbx-core/src/db/agent_driver.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,8 @@ pub const AGENT_PROTOCOL_VERSION: u32 = 1;
 const RPC_TIMEOUT_SECS: u64 = 30;
 const STARTUP_TIMEOUT_SECS: u64 = 15;
 const STDERR_TAIL_LINES: usize = 20;
-const AGENT_EXIT_DIAGNOSTIC_WAIT_MS: u64 = 200;
+const AGENT_EXIT_DIAGNOSTIC_WAIT_MS: u64 = 1_000;
+const AGENT_EXIT_DIAGNOSTIC_POLL_MS: u64 = 10;
 const AGENT_JAVA_OPTS_ENV: &str = "DBX_AGENT_JAVA_OPTS";
 const AGENT_JAVA_TOO_OLD_MESSAGE: &str =
     "Agent requires Java 21, but DBX started it with an older Java runtime. Use DBX managed JRE 21 or select a Java 21 executable in Driver Manager.";
@@ -1368,12 +1369,16 @@ fn child_exit_status(child: &mut Child) -> Option<String> {
 }
 
 fn child_exit_status_after_short_wait(child: &mut Child) -> Option<String> {
-    let status = child_exit_status(child);
-    if status.is_some() {
-        return status;
+    let deadline = Instant::now() + Duration::from_millis(AGENT_EXIT_DIAGNOSTIC_WAIT_MS);
+    loop {
+        if let Some(status) = child_exit_status(child) {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(AGENT_EXIT_DIAGNOSTIC_POLL_MS));
     }
-    std::thread::sleep(Duration::from_millis(AGENT_EXIT_DIAGNOSTIC_WAIT_MS));
-    child_exit_status(child)
 }
 
 fn stderr_tail_snapshot(stderr_tail: &Arc<Mutex<StderrTail>>) -> StderrTail {

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -745,8 +745,15 @@ pub fn is_connection_error(err: &str) -> bool {
         || lower.contains("closed")
         || lower.contains("关闭的连接")
         || lower.contains("连接已关闭")
+        || lower.contains("网络通信异常")
+        || lower.contains("通信异常")
+        || lower.contains("communications link failure")
+        || lower.contains("sqlrecoverableexception")
+        || lower.contains("sqlnontransientconnectionexception")
+        || lower.contains("sqltransientconnectionexception")
         || lower.contains("eof")
         || lower.contains("i/o error")
+        || lower.contains("input/output error")
         || lower.contains("not connected")
         || lower.contains("end-of-file")
         || lower.contains("idle")
@@ -3296,6 +3303,13 @@ mod tests {
         assert!(is_connection_error(
             "I/O error: 由于连接方在一段时间后没有正确答复或连接的主机没有反应，连接尝试失败。 (os error 10060)"
         ));
+        assert!(is_connection_error("Agent RPC error (-1): dm.jdbc.driver.DMException: 网络通信异常"));
+        assert!(is_connection_error(
+            "Agent RPC error (-1): java.sql.SQLRecoverableException: IO 错误: Got minus one from a read call"
+        ));
+        assert!(is_connection_error(
+            "Agent RPC error (-1): com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure"
+        ));
     }
 
     #[test]
@@ -3365,6 +3379,9 @@ mod tests {
 
         assert_eq!(pool_error_action(Some(DatabaseType::SqlServer), err), PoolErrorAction::ReconnectAndRetry);
         assert_eq!(pool_error_action(Some(DatabaseType::Postgres), err), PoolErrorAction::ReconnectAndRetry);
+
+        let dameng_err = "Agent RPC error (-1): dm.jdbc.driver.DMException: 网络通信异常";
+        assert_eq!(pool_error_action(Some(DatabaseType::Dameng), dameng_err), PoolErrorAction::ReconnectAndRetry);
     }
 
     #[cfg(feature = "duckdb-bundled")]

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2357,6 +2357,7 @@ mod tests {
     fn metadata_retry_recovers_missing_pool_only_as_transient_state() {
         assert!(is_retryable_metadata_error("Pool not found"));
         assert!(is_retryable_metadata_error("connection reset by peer"));
+        assert!(is_retryable_metadata_error("Agent RPC error (-1): dm.jdbc.driver.DMException: 网络通信异常"));
         assert!(!is_retryable_metadata_error("Unknown column 'email' in 'field list'"));
         assert!(!is_retryable_metadata_error("Access denied for user"));
     }


### PR DESCRIPTION
## 原因

部分 JDBC/Agent 驱动在连接断开后返回的是本地化或 JDBC 标准通信异常，例如达梦的 `网络通信异常`、MySQL JDBC 的 `Communications link failure`、Oracle 等驱动可能返回的 `SQLRecoverableException`。这些错误之前没有被统一识别为连接断开，导致旧连接池没有被丢弃；用户再次点击连接时仍可能复用失效连接，必须重启客户端才恢复。

## 修改

- 将明确的 JDBC/Agent 通信断开错误纳入后端连接错误识别，触发现有 `ReconnectAndRetry` 流程
- metadata 加载遇到这类错误时会先重建连接池再重试
- 前端连接树同步识别这些错误为连接断开，避免继续把失效连接当作健康连接复用
- 补充前后端单测覆盖达梦中文网络异常和常见 JDBC 通信异常

## 验证

- `pnpm vitest run apps/desktop/src/lib/connection/__tests__/connectionHealth.spec.ts`
- `cargo test -p dbx-core --no-default-features query::tests::is_connection_error_detects_localized_io_errors`
- `cargo test -p dbx-core --no-default-features query::tests::pool_error_action_reconnects_connection_errors`
- `cargo test -p dbx-core --no-default-features schema::tests::metadata_retry_recovers_missing_pool_only_as_transient_state`
- `cargo fmt --check`