### PR TITLE
fix(ai): use correct DeepSeek API format to disable thinking (#3028)

### DIFF
--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -1976,6 +1976,11 @@ async fn stream_openai_with_tools(
     });
     set_chat_completion_token_limit(&mut body, &request.config, request.max_tokens.unwrap_or(4096));
 
+    // DeepSeek API requires {"thinking": {"type": "disabled"}} to disable thinking
+    if !request.config.enable_thinking && matches!(request.config.provider, AiProvider::Deepseek) {
+        body["thinking"] = json!({ "type": "disabled" });
+    }
+
     let res = client
         .post(resolve_endpoint(&request.config))
         .headers(headers)


### PR DESCRIPTION
## Problem

DeepSeek Provider 的 Thinking 开关无法生效。取消勾选 Thinking 后，模型仍然输出思考内容。

Closes #3028

## Changes

- 在 `stream_openai_with_tools` 函数中，针对 DeepSeek Provider 使用正确的 API 参数格式 `{"thinking": {"type": "disabled"}}` 来禁用 thinking

## Verification

- [x] 设置 AI Provider 为 DeepSeek，取消勾选 Thinking，确认模型不再输出思考内容
- [x] `cargo check` 通过