### PR TITLE
feat(redis): enable auto-refresh countdown for key TTL by default

### DIFF
--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -102,7 +102,7 @@ const redisJsonWordWrap = ref(readRedisJsonWordWrap());
 const redisJsonHighlighter = ref<RedisJsonHighlighter>();
 
 // Auto-refresh
-const autoRefreshEnabled = ref(false);
+const autoRefreshEnabled = ref(true);
 const countdownTtl = ref(0);
 let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -130,10 +130,7 @@ function startAutoRefresh() {
       load()
         .then(() => {
           if (!autoRefreshEnabled.value) return;
-          if (data.value && !shouldStopAutoRefresh(data.value.ttl)) {
-            countdownTtl.value = data.value.ttl;
-          } else {
-            // Key expired or has no TTL — stop auto-refresh to avoid infinite loop
+          if (!data.value || shouldStopAutoRefresh(data.value.ttl)) {
             stopAutoRefresh();
             autoRefreshEnabled.value = false;
           }
@@ -492,10 +489,6 @@ async function load(options: { selectDefaultMember?: boolean } = {}) {
   try {
     const loadedValue = await api.redisGetValue(props.connectionId, props.db, props.keyRaw);
     data.value = loadedValue;
-    // Reset auto-refresh countdown if active
-    if (autoRefreshEnabled.value) {
-      countdownTtl.value = shouldStopAutoRefresh(loadedValue.ttl) ? 0 : loadedValue.ttl;
-    }
     emit("loaded", loadedValue);
     scanCursor.value = redisValueCollectionScanCursor(loadedValue);
     collectionItems.value = redisValueCollectionItems(loadedValue);
@@ -519,6 +512,9 @@ async function load(options: { selectDefaultMember?: boolean } = {}) {
     }
   } finally {
     loading.value = false;
+    if (autoRefreshEnabled.value && data.value && data.value.ttl > 0) {
+      startAutoRefresh();
+    }
   }
 }
 


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## Summary

Redis Key Value Viewer now defaults auto-refresh **ON** for keys with TTL. Previously the countdown and auto-refresh were opt-in — users had to click a Clock button to see a live TTL countdown. With this change, the TTL badge shows a real-time countdown immediately.

## Motivation

When a user opens a Redis key with `EXPIRE 300`, the TTL badge displayed a static snapshot ("TTL: 5m"). That number became stale the moment it was rendered. The user had to manually click the Clock icon to see the live countdown — an unnecessary step that many users didn't discover.

The auto-refresh overhead is minimal: `setInterval(1000ms)` runs a pure in-memory decrement. A network request fires only when the countdown reaches zero, at a frequency of **1 request per TTL duration** — e.g. once every 5 minutes for a 300-second TTL.

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/components/redis/RedisValueViewer.vue` | 3 logical changes, net -4 lines |

**1. Default ON** — `ref(false)` → `ref(true)`

**2. Single entry point** — removed the duplicate `countdownTtl` reset from the timer callback's `.then()`. The `finally` block of `load()` now calls `startAutoRefresh()` uniformly for all code paths (initial load, manual refresh, save, auto-refresh tick). The `.then()` / `.catch()` in `startAutoRefresh` only serve as a safety net to stop the timer when the key expires or the connection fails.

**3. Bootstrap on load** — `load()`'s `finally` block starts the timer automatically for keys with `ttl > 0`, so the first load triggers the countdown without user interaction.

## Clock button behavior

The Clock button is unchanged. Users can click it to toggle auto-refresh off at any time.

## Checklist

- [x] Type-check passes (`vue-tsc --noEmit`)
- [x] Pre-commit hooks pass (oxfmt)
- [x] No new dependencies

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
