### PR TITLE
Fix: 兼容 MySQL 代理 packet out of order

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -1068,6 +1068,9 @@ fn mysql_error_should_retry_without_ssl(error: &str) -> bool {
         || error.contains("handshake")
         || error.contains("tls connection")
         || error.contains("server closed session")
+        // Some older MySQL proxies report a failed preferred-TLS probe as a
+        // protocol packet error instead of a TLS handshake error.
+        || error.contains("packet out of order")
         // Some MySQL-compatible servers report a preferred-TLS attempt as a
         // normal server error instead of a TLS handshake error.
         || (error.contains("client asked for ssl") && error.contains("server does not have this capability"))
@@ -4202,6 +4205,13 @@ UNIQUE KEY(`tenant_id`, `name``part`)
     fn mysql_server_without_ssl_capability_retries_without_ssl() {
         let error =
             "MySQL connection failed: Driver error: `Client asked for SSL but server does not have this capability'";
+
+        assert!(mysql_error_should_retry_without_ssl(error));
+    }
+
+    #[test]
+    fn mysql_packet_out_of_order_can_retry_without_ssl() {
+        let error = "MySQL connection failed: Input/output error: Input/output error: packet out of order";
 
         assert!(mysql_error_should_retry_without_ssl(error));
     }


### PR DESCRIPTION
## 变更说明
- 将 MySQL `packet out of order` 识别为 preferred TLS 探测失败的一种兼容错误
- 在可降级场景下复用现有逻辑重试 `ssl-mode=disabled`
- 保持 `require_ssl=true`、`ssl-mode=required/verify_ca/verify_identity` 不会被降级

## 验证
- `CARGO_TARGET_DIR=/Users/staff/dbx/target CARGO_INCREMENTAL=0 cargo test -p dbx-core mysql_packet_out_of_order_can_retry_without_ssl --lib -- --nocapture`
- `git diff --check`

Fix: #3031
