### PR TITLE
fix(query): reduce retained result memory

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -696,9 +696,9 @@ function toggleExecutionSummary() {
   emit("update:activeOutputView", nextExecutionSummaryView(props.activeOutputView, canShowResultOutput.value));
 }
 
-function removeResultRun(runId: string) {
+async function removeResultRun(runId: string) {
   const removedActiveRun = props.activeTab.activeResultRunId === runId;
-  const removed = queryStore.removeResultRun(props.activeTab.id, runId);
+  const removed = await queryStore.removeResultRun(props.activeTab.id, runId);
   if (removed && removedActiveRun) emit("update:activeOutputView", "result");
 }
 

--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -185,4 +185,49 @@ describe("connectionStore completion assistant", () => {
     await Promise.all(requests);
     expect(maxActiveColumns).toBe(2);
   });
+
+  it("evicts old completion database entries", async () => {
+    const listDatabases = vi.fn(async (connectionId: string) => [{ name: `db_${connectionId}` }]);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      listDatabases,
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+
+    for (let index = 0; index < 51; index++) {
+      const id = `pg-${index}`;
+      store.addEphemeralConnection({ ...postgresConnection(), id, name: `Postgres ${index}` });
+      await store.listCompletionDatabases(id);
+    }
+
+    await store.listCompletionDatabases("pg-0");
+
+    expect(listDatabases).toHaveBeenCalledTimes(52);
+  });
+
+  it("evicts old completion schema entries", async () => {
+    const listSchemas = vi.fn(async (_connectionId: string, database: string) => [`schema_${database}`]);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      listSchemas,
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.addEphemeralConnection(postgresConnection());
+
+    for (let index = 0; index < 51; index++) {
+      await store.listCompletionSchemas("pg-1", `db_${index}`);
+    }
+
+    await store.listCompletionSchemas("pg-1", "db_0");
+
+    expect(listSchemas).toHaveBeenCalledTimes(52);
+  });
 });

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -4091,6 +4091,7 @@ export const useConnectionStore = defineStore("connection", () => {
           databases.map((database) => database.name),
           config,
         );
+        evictOldestCacheEntries(completionDatabasesCache.value, COMPLETION_CACHE_MAX);
         return completionDatabasesCache.value[connectionId];
       },
       { scope: completionLimiterScope(connectionId), kind: "databases" },
@@ -4105,6 +4106,7 @@ export const useConnectionStore = defineStore("connection", () => {
     return withCompletionInFlight(`${cacheKey}:schemas`, async () => {
       const schemas = await api.listSchemas(connectionId, database);
       schemaListCache.value[cacheKey] = schemas;
+      evictOldestCacheEntries(schemaListCache.value, COMPLETION_CACHE_MAX);
       return schemas;
     });
   }

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -487,7 +487,7 @@ export const useQueryStore = defineStore("query", () => {
     return true;
   }
 
-  function removeResultRun(id: string, runId: string) {
+  async function removeResultRun(id: string, runId: string) {
     const tab = tabs.value.find((t) => t.id === id);
     const runIndex = tab?.resultRuns?.findIndex((run) => run.id === runId) ?? -1;
     if (!tab || !tab.resultRuns || runIndex < 0) return false;
@@ -502,7 +502,7 @@ export const useQueryStore = defineStore("query", () => {
 
     const nextRun = remainingRuns[Math.min(runIndex, remainingRuns.length - 1)];
     if (nextRun) {
-      projectResultRun(tab, nextRun);
+      await setActiveResultRun(id, nextRun.id);
       return true;
     }
 

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -500,10 +500,11 @@ export const useQueryStore = defineStore("query", () => {
 
     if (!wasActive) return true;
 
-    const nextRun = remainingRuns[Math.min(runIndex, remainingRuns.length - 1)];
-    if (nextRun) {
-      await setActiveResultRun(id, nextRun.id);
-      return true;
+    const adjacentIndex = Math.min(runIndex, remainingRuns.length - 1);
+    for (let offset = 0; offset < remainingRuns.length; offset += 1) {
+      const candidate = remainingRuns[(adjacentIndex + offset) % remainingRuns.length];
+      // Disk-backed runs may have missing or unreadable snapshots; keep searching before clearing output.
+      if (candidate && (await setActiveResultRun(id, candidate.id))) return true;
     }
 
     tab.activeResultRunId = undefined;

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -408,6 +408,20 @@ export const useQueryStore = defineStore("query", () => {
     }
   }
 
+  function clearResultRunPayload(run: NonNullable<QueryTab["resultRuns"]>[number], options: { evicted?: boolean } = {}) {
+    run.result = undefined;
+    run.results = undefined;
+    run.resultLocalSortOriginalRows = undefined;
+    run.resultSessionId = undefined;
+    run.queryAnalysis = undefined;
+    run.querySourceColumns = undefined;
+    run.queryEditabilityReason = undefined;
+    run.mongoEditTarget = undefined;
+    run.tableMeta = undefined;
+    run.resultEvicted = options.evicted ? true : undefined;
+    run.resultCacheState = options.evicted ? "disk" : undefined;
+  }
+
   function projectResultRun(tab: QueryTab, run: NonNullable<QueryTab["resultRuns"]>[number]) {
     const activeIndex = run.activeResultIndex ?? 0;
     tab.activeResultRunId = run.id;
@@ -469,6 +483,7 @@ export const useQueryStore = defineStore("query", () => {
     const run = await restoreResultRunPayload(tab, runId);
     if (!run?.result && !run?.results?.length) return false;
     projectResultRun(tab, run);
+    evictInactiveResultRunPayloads(tab);
     return true;
   }
 
@@ -500,11 +515,11 @@ export const useQueryStore = defineStore("query", () => {
     return (tab.resultRuns?.reduce((max, run) => Math.max(max, run.sequence), 0) ?? 0) + 1;
   }
 
-  function persistResultRun(tab: QueryTab, run: NonNullable<QueryTab["resultRuns"]>[number]) {
+  function persistResultRun(tab: QueryTab, run: NonNullable<QueryTab["resultRuns"]>[number]): Promise<boolean> {
     const key = run.resultCacheKey ?? resultRunCacheKey(tab.id, run.id);
     run.resultCacheKey = key;
     run.resultCacheState = "memory";
-    void writeTabResultSnapshot(key, {
+    return writeTabResultSnapshot(key, {
       result: run.result,
       results: run.results,
       activeResultIndex: run.activeResultIndex,
@@ -521,6 +536,22 @@ export const useQueryStore = defineStore("query", () => {
       resultTotalRowCount: run.resultTotalRowCount,
       cachedAt: Date.now(),
     });
+  }
+
+  function evictInactiveResultRunPayloads(tab: QueryTab) {
+    const activeRunId = tab.activeResultRunId;
+    if (!activeRunId || !tab.resultRuns?.length) return;
+
+    for (const run of tab.resultRuns) {
+      if (run.id === activeRunId || !resultRunHasPayload(run)) continue;
+      const runId = run.id;
+      void persistResultRun(tab, run).then((cached) => {
+        const currentRun = tab.resultRuns?.find((item) => item.id === runId);
+        if (!cached || !currentRun || currentRun.id === tab.activeResultRunId || !resultRunHasPayload(currentRun)) return;
+        if (tab.result === currentRun.result || (currentRun.results && tab.results === currentRun.results)) return;
+        clearResultRunPayload(currentRun, { evicted: true });
+      });
+    }
   }
 
   function captureDisplayedResultRun(tab: QueryTab, sql: string, createdAt = Date.now()) {
@@ -559,9 +590,10 @@ export const useQueryStore = defineStore("query", () => {
       mongoEditTarget: tab.mongoEditTarget,
       tableMeta: tab.tableMeta,
     };
-    persistResultRun(tab, run);
+    void persistResultRun(tab, run);
     tab.resultRuns = [...(tab.resultRuns ?? []), run];
     tab.activeResultRunId = run.id;
+    evictInactiveResultRunPayloads(tab);
   }
 
   function toggleResultAutoSave(id: string): boolean {
@@ -607,7 +639,7 @@ export const useQueryStore = defineStore("query", () => {
       mongoEditTarget: tab.mongoEditTarget,
       tableMeta: tab.tableMeta,
     };
-    persistResultRun(tab, run);
+    void persistResultRun(tab, run);
     tab.resultRuns[index] = run;
   }
 
@@ -2984,11 +3016,26 @@ export const useQueryStore = defineStore("query", () => {
     return true;
   }
 
+  async function hydrateResultRunsForArchive(tab: QueryTab, snapshot: NonNullable<ReturnType<typeof buildTabResultSnapshot>>) {
+    if (!snapshot.resultRuns?.length) return snapshot;
+    const resultRuns = await Promise.all(
+      snapshot.resultRuns.map(async (run) => {
+        if (resultRunHasPayload(run)) return run;
+        const cacheKey = run.resultCacheKey ?? tab.resultRuns?.find((item) => item.id === run.id)?.resultCacheKey;
+        if (!cacheKey) return run;
+        const cached = await readTabResultSnapshot(cacheKey);
+        return cached?.resultRuns?.find((item) => item.id === run.id) ?? run;
+      }),
+    );
+    return { ...snapshot, resultRuns };
+  }
+
   async function resultArchiveSnapshotForTab(tab: QueryTab) {
     let snapshot = buildTabResultSnapshot(tab);
     if (tab.resultCacheKey && (!snapshot || tab.resultEvicted || !resultSnapshotHasPayload(snapshot))) {
       snapshot = (await readTabResultSnapshot(tab.resultCacheKey)) ?? snapshot;
     }
+    if (snapshot) snapshot = await hydrateResultRunsForArchive(tab, snapshot);
     return snapshot && resultSnapshotHasPayload(snapshot) ? snapshot : undefined;
   }
 

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -803,7 +803,7 @@ test("removing the active result run selects an adjacent run", async () => {
   ];
   await store.setActiveResultRun(tabId, "run-2");
 
-  assert.equal(store.removeResultRun(tabId, "run-2"), true);
+  assert.equal(await store.removeResultRun(tabId, "run-2"), true);
 
   assert.deepEqual(
     tab.resultRuns?.map((run) => run.id),
@@ -814,7 +814,7 @@ test("removing the active result run selects an adjacent run", async () => {
   assert.deepEqual(tab.result?.rows, [[3]]);
   assert.equal(tab.sql, "select draft");
 
-  assert.equal(store.removeResultRun(tabId, "run-3"), true);
+  assert.equal(await store.removeResultRun(tabId, "run-3"), true);
 
   assert.deepEqual(
     tab.resultRuns?.map((run) => run.id),
@@ -852,9 +852,9 @@ test("removed result runs are excluded from result archives", async () => {
       resultBaseSql: "select 2",
     },
   ];
-  store.setActiveResultRun(tabId, "run-2");
+  await store.setActiveResultRun(tabId, "run-2");
 
-  assert.equal(store.removeResultRun(tabId, "run-1"), true);
+  assert.equal(await store.removeResultRun(tabId, "run-1"), true);
   const archive = await store.exportResultArchive(tabId);
   assert.ok(archive);
   const decoded = await decodeQueryResultArchive(archive);
@@ -885,9 +885,9 @@ test("removing the last result run clears output and makes result archive unavai
       resultBaseSql: "select 1",
     },
   ];
-  store.setActiveResultRun(tabId, "run-1");
+  await store.setActiveResultRun(tabId, "run-1");
 
-  assert.equal(store.removeResultRun(tabId, "run-1"), true);
+  assert.equal(await store.removeResultRun(tabId, "run-1"), true);
 
   assert.deepEqual(tab.resultRuns, []);
   assert.equal(tab.activeResultRunId, undefined);
@@ -1077,6 +1077,74 @@ test("kept result runs evict inactive payloads without losing switch or archive 
       decoded?.snapshot.resultRuns?.map((run) => run.result?.rows),
       [[[1]], [[2]]],
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("removing the active result run restores a disk-backed adjacent run", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const runtimeCache = new Map<string, string>();
+  let executeCount = 0;
+
+  connectionStore.addEphemeralConnection(conn("conn-1"));
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/query/execute-multi") {
+      executeCount++;
+      return new Response(JSON.stringify([{ columns: [`run_${executeCount}`], rows: [[executeCount]], affected_rows: 0, execution_time_ms: 1 }]), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/query/analyze-editability") {
+      return new Response(JSON.stringify({ editable: false, reason: "complex-source" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/tab-runtime-cache" && init?.method === "POST") {
+      const body = JSON.parse(String(init.body ?? "{}")) as { key: string; payloadBase64: string };
+      runtimeCache.set(body.key, body.payloadBase64);
+      return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.startsWith("/api/tab-runtime-cache?")) {
+      const key = new URL(url, "http://localhost").searchParams.get("key") ?? "";
+      if (init?.method === "DELETE") {
+        runtimeCache.delete(key);
+        return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ payloadBase64: runtimeCache.get(key) }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const tabId = store.createTab("conn-1", "db", "Query");
+    store.toggleResultAutoSave(tabId);
+    await store.executeTabSql(tabId, "select 1");
+    await store.executeTabSql(tabId, "select 2");
+
+    const tab = store.tabs.find((item) => item.id === tabId);
+    assert.ok(tab?.resultRuns?.[0]);
+    assert.ok(tab.resultRuns[1]);
+    await waitFor(() => tab.resultRuns?.[0]?.result === undefined && tab.resultRuns?.[0]?.resultCacheState === "disk");
+
+    assert.equal(await store.removeResultRun(tabId, tab.resultRuns[1].id), true);
+
+    assert.equal(tab.activeResultRunId, tab.resultRuns[0]?.id);
+    assert.deepEqual(tab.result?.columns, ["run_1"]);
+    assert.deepEqual(tab.result?.rows, [[1]]);
+    assert.deepEqual(tab.resultRuns[0]?.result?.columns, ["run_1"]);
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -824,6 +824,42 @@ test("removing the active result run selects an adjacent run", async () => {
   assert.deepEqual(tab.result?.columns, ["one"]);
 });
 
+test("removing the active result run clears output when remaining caches are unavailable", async () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+  const tabId = store.createTab("conn-1", "db");
+  const tab = store.tabs.find((item) => item.id === tabId);
+  assert.ok(tab);
+
+  tab.resultRuns = [
+    {
+      id: "run-1",
+      title: "Run 1",
+      sequence: 1,
+      sql: "select 1",
+      createdAt: 1,
+      result: { columns: ["one"], rows: [[1]], affected_rows: 0, execution_time_ms: 1 },
+    },
+    {
+      id: "run-2",
+      title: "Run 2",
+      sequence: 2,
+      sql: "select 2",
+      createdAt: 2,
+      resultCacheKey: `missing-result-run-${Date.now()}`,
+      resultCacheState: "disk",
+      resultEvicted: true,
+    },
+  ];
+  await store.setActiveResultRun(tabId, "run-1");
+
+  assert.equal(await store.removeResultRun(tabId, "run-1"), true);
+  assert.equal(tab.activeResultRunId, undefined);
+  assert.equal(tab.result, undefined);
+  assert.equal(tab.results, undefined);
+  assert.deepEqual(tab.resultRuns?.map((run) => run.id), ["run-2"]);
+});
+
 test("removed result runs are excluded from result archives", async () => {
   setActivePinia(createPinia());
   const store = useQueryStore();

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -1007,6 +1007,82 @@ test("completed query executions append result runs and select the latest run", 
   }
 });
 
+test("kept result runs evict inactive payloads without losing switch or archive data", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const runtimeCache = new Map<string, string>();
+  let executeCount = 0;
+
+  connectionStore.addEphemeralConnection(conn("conn-1"));
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/query/execute-multi") {
+      executeCount++;
+      return new Response(JSON.stringify([{ columns: [`run_${executeCount}`], rows: [[executeCount]], affected_rows: 0, execution_time_ms: 1 }]), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/query/analyze-editability") {
+      return new Response(JSON.stringify({ editable: false, reason: "complex-source" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/tab-runtime-cache" && init?.method === "POST") {
+      const body = JSON.parse(String(init.body ?? "{}")) as { key: string; payloadBase64: string };
+      runtimeCache.set(body.key, body.payloadBase64);
+      return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url.startsWith("/api/tab-runtime-cache?")) {
+      const key = new URL(url, "http://localhost").searchParams.get("key") ?? "";
+      if (init?.method === "DELETE") {
+        runtimeCache.delete(key);
+        return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ payloadBase64: runtimeCache.get(key) }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const tabId = store.createTab("conn-1", "db", "Query");
+    store.toggleResultAutoSave(tabId);
+    await store.executeTabSql(tabId, "select 1");
+    await store.executeTabSql(tabId, "select 2");
+
+    const tab = store.tabs.find((item) => item.id === tabId);
+    assert.ok(tab?.resultRuns?.[0]);
+    assert.ok(tab.resultRuns[1]);
+    await waitFor(() => tab.resultRuns?.[0]?.result === undefined && tab.resultRuns?.[0]?.resultCacheState === "disk");
+    assert.deepEqual(tab.result?.columns, ["run_2"]);
+    assert.deepEqual(tab.resultRuns[1]?.result?.columns, ["run_2"]);
+
+    await store.setActiveResultRun(tabId, tab.resultRuns[0].id);
+    assert.deepEqual(tab.result?.columns, ["run_1"]);
+    assert.deepEqual(tab.result?.rows, [[1]]);
+    assert.deepEqual(tab.resultRuns[0]?.result?.columns, ["run_1"]);
+
+    const archive = await store.exportResultArchive(tabId);
+    assert.ok(archive);
+    const decoded = await decodeQueryResultArchive(archive);
+    assert.deepEqual(
+      decoded?.snapshot.resultRuns?.map((run) => run.result?.rows),
+      [[[1]], [[2]]],
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test("failed query executions append switchable error result runs", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());


### PR DESCRIPTION
## Summary
- Spill inactive saved query result runs to the runtime result cache after they are persisted, keeping only the active run payload in memory.
- Restore evicted run payloads when users switch runs and hydrate them for result archive export.
- Bound database and schema completion caches to the existing completion cache limit.

## Test Plan
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build