### PR TITLE
fix(app): extract numeric Windows version to avoid mojibake in support info

### DIFF
--- a/src-tauri/src/commands/support_info.rs
+++ b/src-tauri/src/commands/support_info.rs
@@ -101,8 +101,18 @@ fn platform_product_name() -> Option<String> {
 
 #[cfg(target_os = "windows")]
 fn platform_product_version() -> Option<String> {
-    command_first_line("cmd", &["/C", "ver"])
-        .map(|line| line.trim_matches(|ch| ch == '\r' || ch == '\n').trim().to_string())
+    command_first_line("cmd", &["/C", "ver"]).and_then(|line| extract_windows_version(&line))
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn extract_windows_version(line: &str) -> Option<String> {
+    line.split(|ch: char| !ch.is_ascii_digit() && ch != '.')
+        .filter(|token| {
+            token.contains('.')
+                && token.split('.').all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        })
+        .max_by_key(|token| token.len())
+        .map(ToOwned::to_owned)
 }
 
 #[cfg(target_os = "linux")]
@@ -175,8 +185,8 @@ fn unquote_os_release_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_support_info_for_clipboard, format_support_info_for_native_about, normalize_app_version,
-        parse_os_release_value, unknown_if_empty, unquote_os_release_value,
+        extract_windows_version, format_support_info_for_clipboard, format_support_info_for_native_about,
+        normalize_app_version, parse_os_release_value, unknown_if_empty, unquote_os_release_value,
     };
 
     #[test]
@@ -225,6 +235,62 @@ PRETTY_NAME="Ubuntu 24.04.1 LTS"
     #[test]
     fn returns_none_for_missing_linux_os_release_value() {
         assert_eq!(parse_os_release_value("NAME=Ubuntu\n", "PRETTY_NAME"), None);
+    }
+
+    #[test]
+    fn extracts_windows_version_from_english_output() {
+        assert_eq!(
+            extract_windows_version("Microsoft Windows [Version 10.0.26200.8655]").as_deref(),
+            Some("10.0.26200.8655")
+        );
+    }
+
+    #[test]
+    fn extracts_windows_version_from_lossy_output() {
+        assert_eq!(
+            extract_windows_version("Microsoft Windows [�汾 10.0.26200.8655]").as_deref(),
+            Some("10.0.26200.8655")
+        );
+    }
+
+    #[test]
+    fn returns_none_for_missing_windows_version() {
+        assert_eq!(extract_windows_version("Microsoft Windows"), None);
+    }
+
+    #[test]
+    fn rejects_malformed_windows_version_tokens() {
+        assert_eq!(extract_windows_version(""), None);
+        assert_eq!(extract_windows_version("10."), None);
+        assert_eq!(extract_windows_version(".10"), None);
+        assert_eq!(extract_windows_version("1..2"), None);
+        assert_eq!(extract_windows_version("..."), None);
+    }
+
+    #[test]
+    fn picks_longest_windows_version_candidate() {
+        assert_eq!(extract_windows_version("cmd 1.0 build 10.0.26200.8655").as_deref(), Some("10.0.26200.8655"));
+    }
+
+    #[test]
+    fn extracts_windows_version_from_gbk_bytes_decoded_lossily() {
+        let mut raw = b"Microsoft Windows [".to_vec();
+        raw.extend_from_slice(&[0xB0, 0xE6, 0xB1, 0xBE]);
+        raw.extend_from_slice(b" 10.0.26200.8655]");
+        let line = String::from_utf8_lossy(&raw);
+        assert_eq!(extract_windows_version(&line).as_deref(), Some("10.0.26200.8655"));
+    }
+
+    #[test]
+    fn formats_windows_operating_system_without_duplicated_name() {
+        let info = super::AppSupportInfo {
+            app_version: "0.5.52".to_string(),
+            runtime: "desktop",
+            os_name: "Windows".to_string(),
+            os_version: Some("10.0.26200.8655".to_string()),
+            arch: "x86_64".to_string(),
+        };
+        assert_eq!(super::format_operating_system(&info), "Windows 10.0.26200.8655");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Fixes #3056

在中文 Windows 系统上，支持信息中的操作系统版本显示乱码：

```
操作系统: Windows Microsoft Windows [�汾 10.0.26200.8655]
```

## 根因

`src-tauri/src/commands/support_info.rs` 中 Windows 分支通过 `cmd /C ver` 获取版本信息。中文 Windows 上该命令输出 **GBK 编码**的 `Microsoft Windows [版本 10.0.26200.8655]`，而 `command_first_line` 用 `String::from_utf8_lossy` 按 UTF-8 解码，导致「版本」变成「�汾」。此外整行输出拼接在 `os_name()`（已返回 "Windows"）之后，产生 `Windows Microsoft Windows [...]` 的冗余前缀。

## 修复方案

不再使用 `ver` 输出中的本地化文本，新增纯函数 `extract_windows_version()` 从输出中仅提取 ASCII 数字版本号 token（要求每个 `.` 分段非空且全为数字，取最长候选）。数字和点是 ASCII 字符，不受 GBK/UTF-8 编码差异影响，因此无需引入 `encoding_rs` 或调用 Windows API。

修复后显示效果（与 macOS 分支 `sw_vers -productVersion` 风格一致）：

```
操作系统: Windows 10.0.26200.8655
```

- 提取函数用 `#[cfg(any(target_os = "windows", test))]` 门控，跨平台可单测（参照同文件 `parse_os_release_value` 的做法）
- 提取失败返回 `None`，维持现有 `Option` 语义

## 验证

- `cargo test -p dbx support_info` — 14 passed, 0 failed，新增用例覆盖：
  - 英文/乱码输出的版本提取
  - 真实 GBK 字节（`B0 E6 B1 BE` = "版本"）经 `from_utf8_lossy` 解码后的回归测试
  - 畸形 token 拒绝（`10.`、`.10`、`1..2`、`...`、空串）
  - 多候选时取最长版本号
  - 最终格式 `Windows 10.0.26200.8655` 无重复名称
- `cargo fmt --check` — 通过
- `cargo check -p dbx --locked` — 通过

> 说明：本地为 macOS 环境，未在真实中文 Windows 上端到端验证，但 GBK 字节序列回归测试完整模拟了 issue 中的场景。