### PR TITLE
Fix: 修复 SQL Server 旧版 TLS 兼容连接初始化失败

### DIFF
--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -45,11 +45,13 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
 
     public SqlServerLegacyAgent() {
         super(PROFILE);
+        // AbstractJdbcAgent loads the JDBC driver before building the URL, so relax
+        // the legacy TLS policy here before the driver can initialize JSSE.
+        enableLegacyTlsAlgorithms();
     }
 
     @Override
     protected String buildJdbcUrl(ConnectParams params) {
-        enableLegacyTlsAlgorithms();
         return legacyTlsUrl(params);
     }
 

--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -6,6 +6,10 @@ import com.dbx.agent.JdbcAgentProfile;
 import com.dbx.agent.JsonRpcServer;
 
 import java.security.Security;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -55,6 +59,15 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
         return legacyTlsUrl(params);
     }
 
+    @Override
+    protected Connection openConnection(ConnectParams params) throws Exception {
+        try {
+            return super.openConnection(params);
+        } catch (SQLException error) {
+            throw withLegacyTlsDiagnostics(error);
+        }
+    }
+
     static String legacyTlsUrl(ConnectParams params) {
         Map<String, String> properties = baseConnectionProperties(params);
         properties.put("encrypt", "true");
@@ -79,6 +92,53 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
             }
         }
         return String.join(", ", kept);
+    }
+
+    static String legacyTlsDiagnostics() {
+        String disabledAlgorithms = Security.getProperty(TLS_DISABLED_ALGORITHMS_KEY);
+        return "DBX SQL Server legacy TLS diagnostics: java=" + System.getProperty("java.version", "unknown")
+            + ", javaVendor=" + System.getProperty("java.vendor", "unknown")
+            + ", jdbc=" + jdbcDriverVersion()
+            + ", sslProtocol=TLSv1"
+            + ", tlsV1Disabled=" + isDisabled(disabledAlgorithms, "TLSV1")
+            + ", 3desDisabled=" + isDisabled(disabledAlgorithms, "3DES_EDE_CBC")
+            + ", rc4Disabled=" + isDisabled(disabledAlgorithms, "RC4");
+    }
+
+    static SQLException withLegacyTlsDiagnostics(SQLException error) {
+        String message = error.getMessage() == null ? error.toString() : error.getMessage();
+        return new SQLException(
+            message + "\n\n" + legacyTlsDiagnostics(),
+            error.getSQLState(),
+            error.getErrorCode(),
+            error
+        );
+    }
+
+    private static boolean isDisabled(String disabledAlgorithms, String algorithm) {
+        if (disabledAlgorithms == null || disabledAlgorithms.trim().isEmpty()) {
+            return false;
+        }
+        for (String rawPart : disabledAlgorithms.split(",")) {
+            if (algorithm.equals(rawPart.trim().toUpperCase(Locale.ROOT))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String jdbcDriverVersion() {
+        try {
+            Driver driver = DriverManager.getDriver("jdbc:sqlserver://localhost");
+            Package driverPackage = driver.getClass().getPackage();
+            String implementationVersion = driverPackage == null ? null : driverPackage.getImplementationVersion();
+            if (implementationVersion != null && !implementationVersion.trim().isEmpty()) {
+                return implementationVersion;
+            }
+            return driver.getMajorVersion() + "." + driver.getMinorVersion();
+        } catch (SQLException ignored) {
+            return "unknown";
+        }
     }
 
     private static void enableLegacyTlsAlgorithms() {

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -4,7 +4,24 @@ import com.dbx.agent.ConnectParams;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.security.Security;
+
 class SqlServerLegacyAgentTest {
+    @Test
+    void constructorRelaxesLegacyTlsPolicyBeforeDriverLoading() {
+        String key = "jdk.tls.disabledAlgorithms";
+        String original = Security.getProperty(key);
+        try {
+            Security.setProperty(key, "TLSv1, TLSv1.1, 3DES_EDE_CBC, EC keySize < 224");
+
+            new SqlServerLegacyAgent();
+
+            Assertions.assertEquals("EC keySize < 224", Security.getProperty(key));
+        } finally {
+            Security.setProperty(key, original == null ? "" : original);
+        }
+    }
+
     @Test
     void legacyTlsUrlUsesSqlServerTlsV1Properties() {
         ConnectParams params = new ConnectParams(

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.security.Security;
+import java.sql.SQLException;
 
 class SqlServerLegacyAgentTest {
     @Test
@@ -17,9 +18,27 @@ class SqlServerLegacyAgentTest {
             new SqlServerLegacyAgent();
 
             Assertions.assertEquals("EC keySize < 224", Security.getProperty(key));
+            String diagnostics = SqlServerLegacyAgent.legacyTlsDiagnostics();
+            Assertions.assertTrue(diagnostics.contains("sslProtocol=TLSv1"));
+            Assertions.assertTrue(diagnostics.contains("tlsV1Disabled=false"));
+            Assertions.assertTrue(diagnostics.contains("3desDisabled=false"));
+            Assertions.assertTrue(diagnostics.contains("rc4Disabled=false"));
         } finally {
             Security.setProperty(key, original == null ? "" : original);
         }
+    }
+
+    @Test
+    void connectionErrorsPreserveDetailsAndIncludeRuntimeDiagnostics() {
+        SQLException original = new SQLException("TLS handshake failed", "08001", 1234);
+
+        SQLException error = SqlServerLegacyAgent.withLegacyTlsDiagnostics(original);
+
+        Assertions.assertEquals("08001", error.getSQLState());
+        Assertions.assertEquals(1234, error.getErrorCode());
+        Assertions.assertSame(original, error.getCause());
+        Assertions.assertTrue(error.getMessage().contains("TLS handshake failed"));
+        Assertions.assertTrue(error.getMessage().contains("DBX SQL Server legacy TLS diagnostics:"));
     }
 
     @Test


### PR DESCRIPTION
## 变更
- 在 Microsoft JDBC 驱动加载前放宽旧版 TLS 算法限制，避免 JSSE 提前缓存安全策略导致 TLS 1.0 仍然握手失败
- 兼容连接失败时附加 Java、JDBC、TLS 算法状态等安全诊断信息，便于后续定位，不包含连接凭据
- 改动仅作用于独立的 `sqlserver-legacy` Agent 进程，不影响普通 SQL Server 和其他数据库连接

## 连接行为
- 勾选旧版兼容模式后，测试连接和正式连接使用相同策略：先尝试原生连接，失败后回退到 `sqlserver-legacy`
- TLS 1.0 强制加密实例会进入兼容 Agent；原生路径可用时仍保留完整原生能力

## 验证
- `./gradlew test shadowJar --continue`
- `./gradlew :sqlserver-legacy:test :sqlserver-legacy:shadowJar --rerun-tasks`
- `cargo test --workspace --locked`
- `pnpm test`（310 files，2444 tests）
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- Agent 校验脚本及 fat jar JSON-RPC smoke test