### PR TITLE
fix(editor): 修复 SQL 查找转义与匹配计数更新

### DIFF
--- a/apps/desktop/src/components/editor/EditorSearchPanel.vue
+++ b/apps/desktop/src/components/editor/EditorSearchPanel.vue
@@ -3,8 +3,9 @@ import { ref, nextTick, onBeforeUnmount, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { EditorView } from "@codemirror/view";
 import { EditorSelection } from "@codemirror/state";
-import { SearchQuery, setSearchQuery, openSearchPanel as cmOpenSearchPanel, findNext as cmFindNext, findPrevious as cmFindPrevious, replaceNext as cmReplaceNext, replaceAll as cmReplaceAll } from "@codemirror/search";
+import { setSearchQuery, openSearchPanel as cmOpenSearchPanel, findNext as cmFindNext, findPrevious as cmFindPrevious, replaceNext as cmReplaceNext, replaceAll as cmReplaceAll } from "@codemirror/search";
 import { ChevronUp, ChevronDown, ChevronRight, X } from "@lucide/vue";
+import { createEditorSearchQuery } from "@/lib/editor/editorSearchQuery";
 
 const props = defineProps<{
   view: EditorView | null;
@@ -26,17 +27,25 @@ const replaceInputRef = ref<HTMLInputElement>();
 const matchCountLimited = ref(false);
 
 const SEARCH_UPDATE_DELAY_MS = 120;
+const DOCUMENT_SEARCH_UPDATE_DELAY_MS = 500;
 const MATCH_COUNT_LIMIT = 1000;
 
 let searchUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+let documentSearchUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearDocumentSearchUpdate() {
+  if (!documentSearchUpdateTimer) return;
+  clearTimeout(documentSearchUpdateTimer);
+  documentSearchUpdateTimer = null;
+}
 
 function dispatchSearchQuery() {
   const v = props.view;
   if (!v) return;
-  const q = new SearchQuery({
+  const q = createEditorSearchQuery({
     search: searchText.value,
     caseSensitive: caseSensitive.value,
-    regexp: useRegex.value,
+    useRegex: useRegex.value,
     replace: replaceText.value,
   });
   v.dispatch({ effects: setSearchQuery.of(q) });
@@ -48,7 +57,7 @@ function clearSearchQuery() {
   const selection = v.state.selection.main;
   v.dispatch({
     selection: EditorSelection.single(selection.head),
-    effects: setSearchQuery.of(new SearchQuery({ search: "" })),
+    effects: setSearchQuery.of(createEditorSearchQuery({ search: "", caseSensitive: false, useRegex: false })),
   });
   matchCount.value = 0;
   currentMatchIndex.value = 0;
@@ -64,10 +73,10 @@ function updateMatchInfo(autoSelect = false) {
     return;
   }
   try {
-    const q = new SearchQuery({
+    const q = createEditorSearchQuery({
       search: searchText.value,
       caseSensitive: caseSensitive.value,
-      regexp: useRegex.value,
+      useRegex: useRegex.value,
     });
     if (!q.valid) {
       matchCount.value = 0;
@@ -101,6 +110,7 @@ function updateMatchInfo(autoSelect = false) {
 }
 
 function scheduleSearchUpdate(autoSelect = false) {
+  clearDocumentSearchUpdate();
   if (searchUpdateTimer) {
     clearTimeout(searchUpdateTimer);
     searchUpdateTimer = null;
@@ -114,6 +124,15 @@ function scheduleSearchUpdate(autoSelect = false) {
     searchUpdateTimer = null;
     updateMatchInfo(autoSelect);
   }, SEARCH_UPDATE_DELAY_MS);
+}
+
+function scheduleDocumentSearchUpdate() {
+  if (!searchVisible.value || !searchText.value) return;
+  clearDocumentSearchUpdate();
+  documentSearchUpdateTimer = setTimeout(() => {
+    documentSearchUpdateTimer = null;
+    updateMatchInfo();
+  }, DOCUMENT_SEARCH_UPDATE_DELAY_MS);
 }
 
 function openSearch(): boolean {
@@ -146,6 +165,7 @@ function closeSearch() {
   const wasVisible = searchVisible.value;
   searchVisible.value = false;
   showReplace.value = false;
+  clearDocumentSearchUpdate();
   const v = props.view;
   if (v) {
     clearSearchQuery();
@@ -204,13 +224,14 @@ watch(replaceText, () => {
 });
 
 onBeforeUnmount(() => {
+  clearDocumentSearchUpdate();
   if (searchUpdateTimer) {
     clearTimeout(searchUpdateTimer);
     searchUpdateTimer = null;
   }
 });
 
-defineExpose({ openSearch, openReplace, closeSearch });
+defineExpose({ openSearch, openReplace, closeSearch, scheduleDocumentSearchUpdate });
 </script>
 
 <template>

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -2827,6 +2827,7 @@ onMounted(async () => {
       rectangularSelection({ eventFilter: (e: MouseEvent) => e.altKey || e.button === 1 }),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
+          searchPanelRef.value?.scheduleDocumentSearchUpdate();
           if (isEditorComposing(update.view)) {
             pendingImeModelEmit = true;
             completionEpoch++;

--- a/apps/desktop/src/lib/__tests__/editor/editorSearchQuery.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/editorSearchQuery.spec.ts
@@ -1,0 +1,28 @@
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { createEditorSearchQuery } from "@/lib/editor/editorSearchQuery";
+
+function matchedText(search: string, useRegex: boolean): string[] {
+  const state = EditorState.create({
+    doc: String.raw`SELECT '\n' AS escaped;
+SELECT 1 AS actual_line_break;`,
+  });
+  const cursor = createEditorSearchQuery({ search, caseSensitive: false, useRegex }).getCursor(state);
+  const matches: string[] = [];
+
+  for (let result = cursor.next(); !result.done; result = cursor.next()) {
+    matches.push(state.sliceDoc(result.value.from, result.value.to));
+  }
+
+  return matches;
+}
+
+describe("editorSearchQuery", () => {
+  it("treats escape sequences literally in normal search mode", () => {
+    expect(matchedText(String.raw`\n`, false)).toEqual([String.raw`\n`]);
+  });
+
+  it("allows regular expression mode to match actual line breaks", () => {
+    expect(matchedText(String.raw`\n`, true)).toEqual(["\n"]);
+  });
+});

--- a/apps/desktop/src/lib/editor/editorSearchQuery.ts
+++ b/apps/desktop/src/lib/editor/editorSearchQuery.ts
@@ -1,0 +1,18 @@
+import { SearchQuery } from "@codemirror/search";
+
+export interface EditorSearchQueryOptions {
+  search: string;
+  replace?: string;
+  caseSensitive: boolean;
+  useRegex: boolean;
+}
+
+export function createEditorSearchQuery(options: EditorSearchQueryOptions): SearchQuery {
+  return new SearchQuery({
+    search: options.search,
+    replace: options.replace ?? "",
+    caseSensitive: options.caseSensitive,
+    regexp: options.useRegex,
+    literal: !options.useRegex,
+  });
+}


### PR DESCRIPTION
## 变更

- 普通查找按字面量匹配 `\n`，正则模式下仍可使用 `\n` 匹配实际换行
- 监听编辑器文档变化，在停止编辑 500ms 后重新统计匹配数量
- 连续编辑会重置计时器，避免大 SQL 文件在输入过程中反复执行全文统计
- 计数刷新不移动当前匹配项或编辑器选区
- 提取统一的搜索查询构造逻辑并补充回归测试

## 验证

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/editorSearchQuery.spec.ts`（2 个测试通过）
- `pnpm typecheck`
- `pnpm exec oxlint apps/desktop/src/components/editor/EditorSearchPanel.vue apps/desktop/src/components/editor/QueryEditor.vue apps/desktop/src/lib/editor/editorSearchQuery.ts apps/desktop/src/lib/__tests__/editor/editorSearchQuery.spec.ts`
- `git diff --check`
- `make dev-fast`
- 本地免密预览验证：连续编辑时计数保持稳定，停止编辑后正确更新
