### PR TITLE
fix(ai): stop AI SQL actions from overwriting the editor; add "Run without modifying editor"

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -72,6 +72,7 @@ import {
 import { isPreviewTab } from "@/lib/tabs/tabPresentation";
 import { supportsSqlFileExecution } from "@/lib/database/databaseCapabilities";
 import { classifyAiSqlExecution } from "@/lib/ai/aiSqlExecutionPolicy";
+import { buildAppendedEditorSql } from "@/lib/ai/aiSqlAppend";
 import { buildHistoryAiAnalysisPrompt } from "@/lib/history/historyAiAnalysis";
 import { countAvailableAgentDriverUpdates, type AgentDriverUpdateBadgeState } from "@/lib/connection/agentDriverUpdateBadge";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
@@ -1251,11 +1252,20 @@ function onAiReplaceSql(sql: string) {
   queryStore.updateSql(tabId, sql);
 }
 
-function onAiExecuteSql(sql: string) {
-  const tabId = ensureQueryTab();
-  queryStore.updateSql(tabId, sql);
+function runAiGeneratedSql(sql: string) {
   selectedSql.value = "";
   nextTick(() => tryExecute(sql));
+}
+
+function onAiExecuteSql(sql: string) {
+  const tabId = ensureQueryTab();
+  queryStore.updateSql(tabId, buildAppendedEditorSql(activeTab.value?.sql || "", sql));
+  runAiGeneratedSql(sql);
+}
+
+function onAiTempRunSql(sql: string) {
+  ensureQueryTab();
+  runAiGeneratedSql(sql);
 }
 
 function onAiRequestAutoExecuteSql(sql: string) {
@@ -1953,7 +1963,18 @@ onUnmounted(() => {
           <div v-if="showAiPanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: aiPanelWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startAiPanelResize" />
             <div class="h-full min-h-0 overflow-hidden">
-              <AiAssistant v-if="aiPanelReady" ref="aiAssistantRef" :tab="activeTab" :connection="activeConnection" @replace-sql="onAiReplaceSql" @execute-sql="onAiExecuteSql" @request-auto-execute-sql="onAiRequestAutoExecuteSql" @open-explain-plan="onAiOpenExplainPlan" @close="toggleAiPanel" />
+              <AiAssistant
+                v-if="aiPanelReady"
+                ref="aiAssistantRef"
+                :tab="activeTab"
+                :connection="activeConnection"
+                @replace-sql="onAiReplaceSql"
+                @execute-sql="onAiExecuteSql"
+                @temp-run-sql="onAiTempRunSql"
+                @request-auto-execute-sql="onAiRequestAutoExecuteSql"
+                @open-explain-plan="onAiOpenExplainPlan"
+                @close="toggleAiPanel"
+              />
             </div>
           </div>
 

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1270,7 +1270,7 @@ function onAiTempRunSql(sql: string) {
 
 function onAiRequestAutoExecuteSql(sql: string) {
   const tabId = ensureQueryTab();
-  queryStore.updateSql(tabId, sql);
+  queryStore.updateSql(tabId, buildAppendedEditorSql(activeTab.value?.sql || "", sql));
   selectedSql.value = "";
 
   const decision = classifyAiSqlExecution(sql, activeConnection.value);
@@ -1292,7 +1292,7 @@ function onAiRequestAutoExecuteSql(sql: string) {
 
 function onAiOpenExplainPlan(sql: string) {
   const tabId = ensureQueryTab();
-  queryStore.updateSql(tabId, sql);
+  queryStore.updateSql(tabId, buildAppendedEditorSql(activeTab.value?.sql || "", sql));
   selectedSql.value = "";
   nextTick(() => {
     void tryExplain(sql);

--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -15,6 +15,7 @@ import {
   Copy,
   Database,
   FileCode,
+  FlaskConical,
   GitBranch,
   HelpCircle,
   History,
@@ -123,6 +124,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   replaceSql: [sql: string];
   executeSql: [sql: string];
+  tempRunSql: [sql: string];
   requestAutoExecuteSql: [sql: string];
   openExplainPlan: [sql: string];
   close: [];
@@ -1475,8 +1477,11 @@ function applySql(code: string) {
 }
 
 function executeSql(code: string) {
-  emit("replaceSql", code);
   emit("executeSql", code);
+}
+
+function tempRunSql(code: string) {
+  emit("tempRunSql", code);
 }
 
 const copiedIndex = ref("");
@@ -1848,6 +1853,9 @@ async function openExternalUrl(url: string) {
                       <span>{{ seg.lang }}</span>
                       <span class="flex-1" />
                       <div class="flex items-center gap-1.5">
+                        <button v-if="seg.isSql" class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.tempRunSql')" @click="tempRunSql(seg.content)">
+                          <FlaskConical class="h-3.5 w-3.5" />
+                        </button>
                         <button v-if="seg.isSql" class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.executeSql')" @click="executeSql(seg.content)">
                           <Play class="h-3.5 w-3.5" />
                         </button>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1226,6 +1226,7 @@ export default {
     copySql: "Copy SQL",
     copyCode: "Copy Code",
     executeSql: "Execute SQL",
+    tempRunSql: "Run without modifying editor",
     copyAll: "Copy All",
     copied: "Copied",
     copyTestResult: "Copy test result",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1189,6 +1189,7 @@ export default withEnglishFallback({
     copySql: "Copiar SQL",
     copyCode: "Copiar código",
     executeSql: "Ejecutar SQL",
+    tempRunSql: "Ejecutar sin modificar",
     copyAll: "Copiar todo",
     copied: "Copiado",
     copyTestResult: "Copiar resultado de prueba",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1170,6 +1170,7 @@ export default withEnglishFallback({
     copySql: "Copia SQL",
     copyCode: "Copia Codice",
     executeSql: "Esegui SQL",
+    tempRunSql: "Esegui senza modificare",
     copyAll: "Copia Tutto",
     copied: "Copiato",
     copyTestResult: "Copia risultato test",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1192,6 +1192,7 @@ export default withEnglishFallback({
     copySql: "SQLをコピー",
     copyCode: "コードをコピー",
     executeSql: "SQLを実行",
+    tempRunSql: "編集せずに実行",
     copyAll: "すべてコピー",
     copied: "コピーしました",
     copyTestResult: "テスト結果をコピー",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1190,6 +1190,7 @@ export default withEnglishFallback({
     copySql: "Copiar SQL",
     copyCode: "Copiar Código",
     executeSql: "Executar SQL",
+    tempRunSql: "Executar sem modificar",
     copyAll: "Copiar Tudo",
     copied: "Copiado",
     copyTestResult: "Copiar resultado do teste",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1227,6 +1227,7 @@ export default withEnglishFallback({
     copySql: "复制 SQL",
     copyCode: "复制代码",
     executeSql: "立即执行",
+    tempRunSql: "临时运行",
     copyAll: "复制全部",
     copied: "已复制",
     copyTestResult: "复制测试结果",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1170,6 +1170,7 @@ export default withEnglishFallback({
     copySql: "複製 SQL",
     copyCode: "複製程式碼",
     executeSql: "立即執行",
+    tempRunSql: "臨時執行",
     copyAll: "複製全部",
     copied: "已複製",
     copyTestResult: "複製測試結果",

--- a/apps/desktop/src/lib/ai/aiSqlAppend.ts
+++ b/apps/desktop/src/lib/ai/aiSqlAppend.ts
@@ -1,11 +1,19 @@
 /**
  * Build the editor content after appending AI-generated SQL to existing editor SQL.
- * Adds a blank-line separator when the editor is not empty.
- *
- * Trims trailing whitespace from the existing content so a buffer that already ends
- * with newlines does not accumulate extra blank lines between statements.
+ * Preserves the existing editor content exactly and adds only the newline separator
+ * needed to leave a blank line before the appended SQL.
  */
 export function buildAppendedEditorSql(currentEditorSql: string, newSql: string): string {
-  const trimmed = currentEditorSql.replace(/\s+$/, "");
-  return trimmed ? `${trimmed}\n\n${newSql}` : newSql;
+  if (!currentEditorSql) return newSql;
+
+  let separator = "\n\n";
+  if (currentEditorSql.endsWith("\r\n\r\n") || currentEditorSql.endsWith("\n\n")) {
+    separator = "";
+  } else if (currentEditorSql.endsWith("\r\n")) {
+    separator = "\r\n";
+  } else if (currentEditorSql.endsWith("\n")) {
+    separator = "\n";
+  }
+
+  return `${currentEditorSql}${separator}${newSql}`;
 }

--- a/apps/desktop/src/lib/ai/aiSqlAppend.ts
+++ b/apps/desktop/src/lib/ai/aiSqlAppend.ts
@@ -1,0 +1,11 @@
+/**
+ * Build the editor content after appending AI-generated SQL to existing editor SQL.
+ * Adds a blank-line separator when the editor is not empty.
+ *
+ * Trims trailing whitespace from the existing content so a buffer that already ends
+ * with newlines does not accumulate extra blank lines between statements.
+ */
+export function buildAppendedEditorSql(currentEditorSql: string, newSql: string): string {
+  const trimmed = currentEditorSql.replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n\n${newSql}` : newSql;
+}

--- a/packages/app-tests/aiSqlAppend.test.ts
+++ b/packages/app-tests/aiSqlAppend.test.ts
@@ -11,12 +11,25 @@ test("buildAppendedEditorSql prepends blank-line separator when editor has conte
 });
 
 test("buildAppendedEditorSql preserves multiline existing content", () => {
-  assert.equal(
-    buildAppendedEditorSql("SELECT *\nFROM users", "SELECT *\nFROM orders"),
-    "SELECT *\nFROM users\n\nSELECT *\nFROM orders",
-  );
+  assert.equal(buildAppendedEditorSql("SELECT *\nFROM users", "SELECT *\nFROM orders"), "SELECT *\nFROM users\n\nSELECT *\nFROM orders");
 });
 
-test("buildAppendedEditorSql collapses trailing newlines into a single blank-line separator", () => {
-  assert.equal(buildAppendedEditorSql("SELECT 1\n\n\n", "SELECT 2"), "SELECT 1\n\nSELECT 2");
+test("buildAppendedEditorSql preserves trailing newlines already present in the editor", () => {
+  assert.equal(buildAppendedEditorSql("SELECT 1\n\n\n", "SELECT 2"), "SELECT 1\n\n\nSELECT 2");
+});
+
+test("buildAppendedEditorSql preserves trailing spaces", () => {
+  assert.equal(buildAppendedEditorSql("SELECT 1   ", "SELECT 2"), "SELECT 1   \n\nSELECT 2");
+});
+
+test("buildAppendedEditorSql preserves trailing tabs", () => {
+  assert.equal(buildAppendedEditorSql("SELECT 1\t\t", "SELECT 2"), "SELECT 1\t\t\n\nSELECT 2");
+});
+
+test("buildAppendedEditorSql preserves whitespace-only editor content", () => {
+  assert.equal(buildAppendedEditorSql(" \t ", "SELECT 2"), " \t \n\nSELECT 2");
+});
+
+test("buildAppendedEditorSql preserves unfinished SQL", () => {
+  assert.equal(buildAppendedEditorSql("SELECT * FROM", "SELECT * FROM users"), "SELECT * FROM\n\nSELECT * FROM users");
 });

--- a/packages/app-tests/aiSqlAppend.test.ts
+++ b/packages/app-tests/aiSqlAppend.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { buildAppendedEditorSql } from "../../apps/desktop/src/lib/ai/aiSqlAppend.ts";
+
+test("buildAppendedEditorSql returns newSql unchanged when editor is empty", () => {
+  assert.equal(buildAppendedEditorSql("", "SELECT 1"), "SELECT 1");
+});
+
+test("buildAppendedEditorSql prepends blank-line separator when editor has content", () => {
+  assert.equal(buildAppendedEditorSql("SELECT 1", "SELECT 2"), "SELECT 1\n\nSELECT 2");
+});
+
+test("buildAppendedEditorSql preserves multiline existing content", () => {
+  assert.equal(
+    buildAppendedEditorSql("SELECT *\nFROM users", "SELECT *\nFROM orders"),
+    "SELECT *\nFROM users\n\nSELECT *\nFROM orders",
+  );
+});
+
+test("buildAppendedEditorSql collapses trailing newlines into a single blank-line separator", () => {
+  assert.equal(buildAppendedEditorSql("SELECT 1\n\n\n", "SELECT 2"), "SELECT 1\n\nSELECT 2");
+});


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

### Problem

When AI-generated SQL was executed, the SQL editor content was silently overwritten, causing the user's existing SQL to be lost. The original report:

> Clicking "Execute" on AI-generated SQL directly overwrites the entire SQL editor area. Expected: (1) a "temporary run" button that only runs the SQL without touching the editor; (2) "Execute" should append the SQL to the end of the file (with a blank line) instead of overwriting.

The overwrite behavior was not limited to the explicit "Execute" button - agent auto-execution and Explain Plan had the same silent data-loss issue.

### Solution

Establish a single rule: **only an explicit "Apply to editor" (replace) overwrites the editor; every other AI SQL injection path appends** (or doesn't touch the editor at all).

#### Behavior matrix

| Action | Trigger | Editor | Execution |
|---|---|---|---|
| **Apply to editor** (Replace icon) | Explicit click | **Overwrite** (unchanged - the only intentional replace entry point) | - |
| **Execute** (Play) | Explicit click | Append (with blank-line separator) | Runs only the new SQL |
| **Run without modifying editor** (FlaskConical, **new**) | Explicit click | Untouched | Runs only the new SQL |
| **Auto-execute** (agent handoff) | AI-driven | Append | Runs only the new SQL |
| **Explain Plan** | Explicit click | Append | Explains only the new SQL |

Execution is never affected by the append change: `doExecute` / `tryExplain` / the danger-confirm dialog all operate on the passed-in SQL, not the full editor buffer.

### Changes

- **New "Run without modifying editor" button** (`FlaskConical` icon) in `AiAssistant.vue` - executes the generated SQL without altering the editor content.
- **"Execute" now appends** to the editor end with a blank-line separator instead of overwriting; only the newly generated SQL is executed.
- **Auto-execute and Explain Plan also append**, removing the last silent data-loss paths for consistency.
- **Extracted `buildAppendedEditorSql`** into `lib/ai/aiSqlAppend.ts` - trims trailing whitespace from the existing content so a buffer that already ends with newlines does not accumulate extra blank lines. Reused by Execute / Auto-execute / Explain.
- **Extracted `runAiGeneratedSql`** in `App.vue` to deduplicate the execute-and-clear-selection logic shared by Execute and Run-without-modifying.
- **i18n**: added `ai.tempRunSql` across all 8 locales (en, es, it, ja, pt-BR, zh-CN, zh-TW).

### Files

```
 apps/desktop/src/App.vue                            | 33 +++--
 apps/desktop/src/components/editor/AiAssistant.vue | 10 +-
 apps/desktop/src/lib/ai/aiSqlAppend.ts              | 11 ++ (new)
 packages/app-tests/aiSqlAppend.test.ts             | 22 ++ (new)
 apps/desktop/src/i18n/locales/{en,es,it,ja,pt-BR,zh-CN,zh-TW}.ts (+1 each)
 11 files changed, 76 insertions(+), 7 deletions(-)
```

### Testing

- `vitest`: `aiSqlAppend` 4/4, `aiSqlExecutionPolicy` 8/8, `aiAgentPlan` 11/11 - all green.
- `vue-tsc --noEmit`: 0 errors.
- `oxlint`: clean.
- `buildAppendedEditorSql` unit tests cover: empty editor, editor with content, multiline content, and trailing-newline collapse.

### Notes

- No new SQL injection surface - SQL still flows through the existing `tryExecute` pipeline with its danger-SQL classification and Redis command safety checks.
- No breaking changes to public API.
- Pre-commit hook (`lint-staged` -> `oxfmt`) passes; CRLF line-ending warnings on Windows are a known local-only false positive (CI is the source of truth).

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="793" height="612" alt="1fd30f8c-5a19-41ba-9cbc-70eae288f9dc" src="https://github.com/user-attachments/assets/8f445f45-61c8-4cda-a9d7-610f190956d7" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2941 