### PR TITLE
fix(ui): settings page not deactivated when switching tabs from sidebar (#3137)

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -127,7 +127,6 @@ const showConnectionDialog = ref(false);
 const connectionDialogPrefill = ref<ConnectionDeepLinkDraft | null>(null);
 const connectionDialogInitialTab = ref<ConfigTab | undefined>(undefined);
 const settingsPageTabOpen = ref(false);
-const settingsPageActive = ref(false);
 const settingsInitialTab = ref("appearance");
 const settingsInitialSection = ref<string | undefined>(undefined);
 const showQueryEditorDdlDialog = ref(false);
@@ -135,7 +134,7 @@ const driverStoreTabOpen = ref(false);
 const driverStoreActive = ref(false);
 const settingsReturnSurface = ref<"query" | "driverStore" | "welcome">("welcome");
 const showDriverStore = computed(() => driverStoreTabOpen.value && driverStoreActive.value);
-const showSettingsPage = computed(() => settingsPageTabOpen.value && settingsPageActive.value);
+const showSettingsPage = computed(() => settingsPageTabOpen.value && settingsStore.settingsPageActive);
 const showQuickOpen = ref(false);
 const agentDriverUpdateCount = ref(0);
 const showHistory = ref(false);
@@ -276,7 +275,7 @@ const updateNotificationsEnabled = computed(() => settingsStore.editorSettings.u
 function openSettings(initialTab = "appearance", initialSection?: string) {
   settingsInitialTab.value = initialTab;
   settingsInitialSection.value = initialSection;
-  if (!settingsPageActive.value) {
+  if (!settingsStore.settingsPageActive) {
     settingsReturnSurface.value = showDriverStore.value ? "driverStore" : activeTab.value ? "query" : "welcome";
   }
   activateSettingsPage();
@@ -284,13 +283,13 @@ function openSettings(initialTab = "appearance", initialSection?: string) {
 
 function activateSettingsPage() {
   settingsPageTabOpen.value = true;
-  settingsPageActive.value = true;
+  settingsStore.settingsPageActive = true;
   driverStoreActive.value = false;
 }
 
 function closeSettingsPage() {
   settingsPageTabOpen.value = false;
-  settingsPageActive.value = false;
+  settingsStore.settingsPageActive = false;
   if (settingsReturnSurface.value === "driverStore" && driverStoreTabOpen.value) {
     driverStoreActive.value = true;
     return;
@@ -301,7 +300,7 @@ function closeSettingsPage() {
 function openDriverStorePage() {
   driverStoreTabOpen.value = true;
   driverStoreActive.value = true;
-  settingsPageActive.value = false;
+  settingsStore.settingsPageActive = false;
 }
 
 function closeDriverStorePage() {
@@ -432,7 +431,7 @@ watch(
     }
     if (id) newQueryContextSource.value = "tab";
     if (id && driverStoreActive.value) driverStoreActive.value = false;
-    if (id && settingsPageActive.value) settingsPageActive.value = false;
+    if (id && settingsStore.settingsPageActive) settingsStore.settingsPageActive = false;
     selectedSql.value = "";
     activeOutputView.value = "result";
     if (id) queryStore.reloadEvictedTab(id);
@@ -1422,7 +1421,7 @@ function activateQueryTab(tabId: string): boolean {
   dispatchBeforeTabSwitch(tabId);
   queryStore.activeTabId = tabId;
   driverStoreActive.value = false;
-  settingsPageActive.value = false;
+  settingsStore.settingsPageActive = false;
   return true;
 }
 
@@ -1798,13 +1797,13 @@ onUnmounted(() => {
                 :driver-store-open="driverStoreTabOpen"
                 :driver-store-active="driverStoreActive"
                 :settings-page-open="settingsPageTabOpen"
-                :settings-page-active="settingsPageActive"
+                :settings-page-active="settingsStore.settingsPageActive"
                 :agent-driver-update-count="toolbarAgentDriverUpdateCount"
                 @activate-driver-store="openDriverStorePage"
                 @activate-settings-page="activateSettingsPage"
                 @activate-tab="
                   driverStoreActive = false;
-                  settingsPageActive = false;
+                  settingsStore.settingsPageActive = false;
                 "
                 @close-driver-store="closeDriverStorePage"
                 @close-settings-page="closeSettingsPage"
@@ -1817,7 +1816,7 @@ onUnmounted(() => {
               <DriverStorePage v-if="driverStoreTabOpen" v-show="driverStoreActive" class="flex-1 min-h-0" :update-notifications-enabled="updateNotificationsEnabled" @update-count-change="updateAgentDriverUpdateCount" />
               <EditorSettingsPage
                 v-if="settingsPageTabOpen"
-                v-show="settingsPageActive"
+                v-show="settingsStore.settingsPageActive"
                 variant="page"
                 :open="settingsPageTabOpen"
                 :initial-tab="settingsInitialTab"
@@ -1826,7 +1825,7 @@ onUnmounted(() => {
                 class="flex-1 min-h-0"
                 @update:open="(open: boolean) => (open ? activateSettingsPage() : closeSettingsPage())"
               />
-              <div v-if="activeTab" v-show="!driverStoreActive && !settingsPageActive" class="flex flex-col flex-1 min-h-0">
+              <div v-if="activeTab" v-show="!driverStoreActive && !settingsStore.settingsPageActive" class="flex flex-col flex-1 min-h-0">
                 <EditorToolbar
                   v-if="activeTab.mode === 'query' && !isPreviewTab(activeTab)"
                   :active-tab="activeTab"
@@ -1932,7 +1931,7 @@ onUnmounted(() => {
                 </KeepAlive>
               </div>
               <WelcomeScreen
-                v-else-if="!driverStoreActive && !settingsPageActive"
+                v-else-if="!driverStoreActive && !settingsStore.settingsPageActive"
                 :connection-stats="connectionStats"
                 :recent-connections="recentConnections"
                 :saved-sql-history-items="savedSqlHistoryItems"

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1214,21 +1214,21 @@ async function openData() {
   };
 
   if (existingSameTableTab && canActivateExistingDataTableTab(existingSameTableTab)) {
-    queryStore.activeTabId = existingSameTableTab.id;
+    queryStore.switchTab(existingSameTableTab.id);
     logPhase("existing-tab-activated", { table: node.label });
     return;
   }
 
   const tabId = (() => {
     if (existingSameTableTab) {
-      queryStore.activeTabId = existingSameTableTab.id;
+      queryStore.switchTab(existingSameTableTab.id);
       resetReusedDataTabState(existingSameTableTab);
       return existingSameTableTab.id;
     }
     if (settingsStore.editorSettings.reuseDataTab) {
       const existing = queryStore.tabs.find((tab) => tab.mode === "data" && tab.connectionId === node.connectionId && tab.database === node.database);
       if (existing) {
-        queryStore.activeTabId = existing.id;
+        queryStore.switchTab(existing.id);
         resetReusedDataTabState(existing);
         return existing.id;
       }

--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -41,7 +41,7 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
         existing.title = tabTitle;
         existing.schema = target.schema;
         existing.tableInfoTab = options.tableInfoTab;
-        queryStore.activeTabId = existing.id;
+        queryStore.switchTab(existing.id);
         return existing.id;
       }
     }

--- a/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
@@ -52,4 +52,20 @@ describe("queryStore switchTab", () => {
     // Active tab should be the new tab
     expect(queryStore.activeTabId).toBe(tab2Id);
   });
+
+  it("deactivates settings page when reopening an existing special tab", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const queryStore = useQueryStore();
+    const settingsStore = useSettingsStore();
+
+    const tabId = queryStore.openObjectBrowser("pg-1", "app", "public");
+    settingsStore.settingsPageActive = true;
+
+    const reopenedTabId = queryStore.openObjectBrowser("pg-1", "app", "public");
+
+    expect(reopenedTabId).toBe(tabId);
+    expect(queryStore.activeTabId).toBe(tabId);
+    expect(settingsStore.settingsPageActive).toBe(false);
+  });
 });

--- a/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
@@ -1,0 +1,55 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("queryStore switchTab", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    setActivePinia(createPinia());
+  });
+
+  it("deactivates settings page when switching to the same tab", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const queryStore = useQueryStore();
+    const settingsStore = useSettingsStore();
+
+    // Create a data tab
+    const tabId = queryStore.createTab("pg-1", "app", "users", "data", "public");
+    queryStore.activeTabId = tabId;
+
+    // Simulate settings page being active
+    settingsStore.settingsPageActive = true;
+
+    // Switch to the same tab (simulating reuseDataTab scenario)
+    queryStore.switchTab(tabId);
+
+    // Settings page should be deactivated
+    expect(settingsStore.settingsPageActive).toBe(false);
+    // Active tab should still be the same
+    expect(queryStore.activeTabId).toBe(tabId);
+  });
+
+  it("deactivates settings page when switching to a different tab", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const queryStore = useQueryStore();
+    const settingsStore = useSettingsStore();
+
+    // Create two data tabs
+    const tab1Id = queryStore.createTab("pg-1", "app", "users", "data", "public");
+    const tab2Id = queryStore.createTab("pg-1", "app", "orders", "data", "public");
+    queryStore.activeTabId = tab1Id;
+
+    // Simulate settings page being active
+    settingsStore.settingsPageActive = true;
+
+    // Switch to a different tab
+    queryStore.switchTab(tab2Id);
+
+    // Settings page should be deactivated
+    expect(settingsStore.settingsPageActive).toBe(false);
+    // Active tab should be the new tab
+    expect(queryStore.activeTabId).toBe(tab2Id);
+  });
+});

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -303,6 +303,7 @@ function getI18nT() {
 
 export const useQueryStore = defineStore("query", () => {
   const t = getI18nT();
+  const settingsStore = useSettingsStore();
   const tabs = ref<QueryTab[]>([]);
   const activeTabId = ref<string | null>(null);
   const isOpenTabsLoaded = ref(false);
@@ -836,6 +837,11 @@ export const useQueryStore = defineStore("query", () => {
     tabs.value.push(tab);
     activeTabId.value = id;
     return id;
+  }
+
+  function switchTab(tabId: string) {
+    activeTabId.value = tabId;
+    settingsStore.settingsPageActive = false;
   }
 
   function openUserAdmin(connectionId: string) {
@@ -3278,6 +3284,7 @@ export const useQueryStore = defineStore("query", () => {
     hasDirtyTabs,
     isConfirmingAppClose,
     createTab,
+    switchTab,
     closeTab,
     forceClosePendingTab,
     forceCloseAllPendingTabs,

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -784,7 +784,7 @@ export const useQueryStore = defineStore("query", () => {
     if (title) {
       const existing = findTabByIdentity(connectionId, database, title, mode, schema);
       if (existing) {
-        activeTabId.value = existing.id;
+        switchTab(existing.id);
         return existing.id;
       }
     }
@@ -813,7 +813,7 @@ export const useQueryStore = defineStore("query", () => {
     const title = schema ? `${schema} objects` : `${database} objects`;
     const existing = tabs.value.find((tab) => tab.mode === "objects" && tab.connectionId === connectionId && tab.database === database && (tab.objectBrowser?.schema || "") === (schema || ""));
     if (existing) {
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -847,7 +847,7 @@ export const useQueryStore = defineStore("query", () => {
   function openUserAdmin(connectionId: string) {
     const existing = tabs.value.find((tab) => tab.mode === "users" && tab.connectionId === connectionId);
     if (existing) {
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -872,7 +872,7 @@ export const useQueryStore = defineStore("query", () => {
   function openDamengJobAdmin(connectionId: string) {
     const existing = tabs.value.find((tab) => tab.mode === "dameng-jobs" && tab.connectionId === connectionId);
     if (existing) {
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -898,7 +898,7 @@ export const useQueryStore = defineStore("query", () => {
     const title = `${database}.${bucketName}`;
     const existing = tabs.value.find((tab) => tab.mode === "mongo-bucket" && tab.connectionId === connectionId && tab.database === database && tab.mongoBucket?.bucketName === bucketName);
     if (existing) {
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -925,7 +925,7 @@ export const useQueryStore = defineStore("query", () => {
   function openMongoGridFs(connectionId: string, database: string) {
     const existing = tabs.value.find((tab) => tab.mode === "mongo-gridfs" && tab.connectionId === connectionId && tab.database === database);
     if (existing) {
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -951,7 +951,7 @@ export const useQueryStore = defineStore("query", () => {
     if (existing) {
       if (target?.tenant) existing.mqTenant = target.tenant;
       if (target?.initialTab) existing.mqInitialTab = target.initialTab;
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -982,7 +982,7 @@ export const useQueryStore = defineStore("query", () => {
     if (existing) {
       existing.nacosNamespaceName = namespaceName;
       if (!existing.customTitle) existing.title = `${useConnectionStore().getConfig(connectionId)?.name || "Nacos"}:${namespaceName}`;
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 
@@ -1019,7 +1019,7 @@ export const useQueryStore = defineStore("query", () => {
       const existing = tabs.value.find((tab) => tab.mode === "structure" && tab.connectionId === connectionId && tab.database === database && (tab.structureTableName || "") === resolvedTableName);
       if (existing) {
         applyTableStructureInitialTab(existing, initialTab, initialTarget);
-        activeTabId.value = existing.id;
+        switchTab(existing.id);
         return existing.id;
       }
     }
@@ -1645,7 +1645,7 @@ export const useQueryStore = defineStore("query", () => {
         existing.editorSelection = restored.selection;
         existing.editorViewport = restored.viewport;
       }
-      activeTabId.value = existing.id;
+      switchTab(existing.id);
       return existing.id;
     }
 

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -816,6 +816,7 @@ function saveEditorSettings(settings: EditorSettings) {
 }
 
 export const useSettingsStore = defineStore("settings", () => {
+  const settingsPageActive = ref(false);
   const aiConfig = ref<AiConfig>(normalizeAiConfig({ provider: "claude" }));
   const isAiConfigLoaded = ref(false);
   const aiProviderConfigs = ref<Partial<Record<AiProvider, AiConfig>>>({});
@@ -1062,6 +1063,7 @@ export const useSettingsStore = defineStore("settings", () => {
   }
 
   return {
+    settingsPageActive,
     aiConfig,
     isAiConfigLoaded,
     aiProviderConfigs,


### PR DESCRIPTION
## 变更说明

修复设置页打开时，从侧边栏切换到同数据库的其他表，标签页不会聚焦的问题。

**问题根因：** 当 `activeTabId` 值不变时（复用同一个 tab），Vue watcher 不会触发，导致 `settingsPageActive` 不会被关闭。

**解决方案：** 将 `settingsPageActive` 移入 `settingsStore` 集中管理，新增 `queryStore.switchTab()` 方法，在设置 `activeTabId` 的同时关闭设置页。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

涉及前端，但无需录屏。

## 验证

- [x] `npx vue-tsc --noEmit --project apps/desktop/tsconfig.json` 通过
- [x] `npx oxlint --vue-plugin apps/desktop/src` 通过
- [x] 相关测试通过

## 关联 Issue

Closes #3137