### PR TITLE
fix(editor): rank exact completion matches first

### DIFF
--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -524,6 +524,7 @@ const EXCLUSIVE_TABLE_TRIGGER_KEYWORDS = new Set(["from", "join", "update", "int
 const JOIN_MODIFIERS = new Set(["left", "right", "inner", "outer", "cross", "full", "natural"]);
 const JOIN_MODIFIER_KEYWORD_PHRASES = ["LEFT JOIN", "RIGHT JOIN", "INNER JOIN", "FULL JOIN", "CROSS JOIN", "NATURAL JOIN", "LEFT OUTER JOIN", "RIGHT OUTER JOIN", "FULL OUTER JOIN"];
 const MAX_TABLE_COMPLETION_ITEMS = 200;
+const EXACT_LABEL_MATCH_BOOST = 10000;
 
 // Keywords that only make sense in DDL / statement-start contexts (not inside SELECT/INSERT/UPDATE/DELETE)
 const DDL_ONLY_KEYWORDS = new Set([
@@ -1112,6 +1113,7 @@ export interface SqlCompletionItem {
   info?: string;
   apply?: string;
   boost: number;
+  exactMatch?: boolean;
 }
 
 export type SqlKeywordCase = "preserve" | "upper" | "lower";
@@ -1310,6 +1312,17 @@ class SqlCompletionProvider {
     if (context.onStar) {
       const starItem = buildStarExpansionItem(context, this.input.columnsByTable, this.t, this.dialect);
       if (starItem) this.items.push(starItem);
+    }
+
+    if (context.prefix) {
+      for (const item of this.items) {
+        // Alias snippets reuse the prefix as a label while applying alias SQL, so they are not exact name matches.
+        const isAliasSnippet = item.type === "snippet" && item.apply === formatAliasCompletionApply(item.label, this.databaseType);
+        if (!isAliasSnippet && item.label.toLowerCase() === context.prefix.toLowerCase()) {
+          item.exactMatch = true;
+          item.boost += EXACT_LABEL_MATCH_BOOST;
+        }
+      }
     }
 
     return dedupeAndSort(this.items);
@@ -3915,6 +3928,7 @@ function dedupeAndSort(items: SqlCompletionItem[]): SqlCompletionItem[] {
 }
 
 function compareCompletionItems(left: SqlCompletionItem, right: SqlCompletionItem): number {
+  if (!left.exactMatch !== !right.exactMatch) return left.exactMatch ? -1 : 1;
   const leftBonus = getHistoryBoost(left.label, left.type);
   const rightBonus = getHistoryBoost(right.label, right.type);
   return right.boost + rightBonus + getTypePriorityBoost(right.type) - (left.boost + leftBonus + getTypePriorityBoost(left.type));

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -2721,6 +2721,8 @@ function buildObjectItems(context: SqlCompletionContext, objects: SqlCompletionO
         detail,
         apply: object.type === "trigger" || object.type === "package" ? applyName : `${applyName}()`,
         boost: computeBoost(object.name, context.prefix) + (object.type === "procedure" ? 1800 : object.type === "package" ? 1600 : 900),
+        // Preserve exact routine matches before the capped candidate list is truncated.
+        exactMatch: !!context.prefix && object.name.toLowerCase() === context.prefix.toLowerCase(),
       };
     })
     .sort(compareCompletionItems)

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -1001,6 +1001,21 @@ test("ranks exact keyword matches above prefix-matching routines (#3002)", () =>
   assert.equal(items[0]?.type, "keyword");
 });
 
+test("preserves an exact routine match before truncating candidates", () => {
+  const sql = "select aaa";
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [],
+    objects: [
+      ...Array.from({ length: 200 }, (_, index) => ({ name: `a_a_a_${index}`, type: "procedure" as const })),
+      { name: "aaa", type: "function" },
+    ],
+    columnsByTable: new Map(),
+  });
+
+  assert.equal(items[0]?.label, "aaa");
+  assert.equal(items[0]?.type, "function");
+});
+
 test("ranks an exact table label match first", () => {
   const sql = "select * from orders";
   const items = buildSqlCompletionItems(sql, sql.length, {

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -984,6 +984,87 @@ test("ranks exact table matches above prefix and fuzzy matches", () => {
   );
 });
 
+test("ranks exact keyword matches above prefix-matching routines (#3002)", () => {
+  const sql = "create table t (id int";
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [],
+    objects: [
+      { name: "int_proc_sync", type: "procedure" },
+      { name: "sp_interface", type: "procedure" },
+      { name: "fn_to_int", type: "function" },
+    ],
+    columnsByTable: new Map(),
+    databaseType: "sqlserver",
+  });
+
+  assert.equal(items[0]?.label, "INT");
+  assert.equal(items[0]?.type, "keyword");
+});
+
+test("ranks an exact table label match first", () => {
+  const sql = "select * from orders";
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [
+      { name: "orders", type: "table" },
+      { name: "orders_archive", type: "table" },
+    ],
+    columnsByTable: new Map(),
+  });
+
+  assert.equal(items[0]?.label, "orders");
+  assert.equal(items[0]?.type, "table");
+});
+
+test("ranks an exact column match above an exact keyword match", () => {
+  const sql = "select limit from t";
+  const items = buildSqlCompletionItems(sql, "select limit".length, {
+    tables: [{ name: "t", type: "table" }],
+    columnsByTable: new Map([["t", [{ name: "limit", table: "t", dataType: "text" }]]]),
+  });
+  const columnIndex = items.findIndex((item) => item.type === "column" && item.label === "limit");
+  const keywordIndex = items.findIndex((item) => item.type === "keyword" && item.label === "LIMIT");
+
+  assert.ok(columnIndex >= 0);
+  assert.ok(keywordIndex >= 0);
+  assert.ok(columnIndex < keywordIndex);
+});
+
+test("ranks an exact table match above foreign-key related prefix matches", () => {
+  const sql = "select * from orders join customers";
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [
+      { name: "orders", type: "table" },
+      { name: "customers", type: "table" },
+      { name: "customers_ext", type: "table" },
+    ],
+    columnsByTable: new Map(),
+    foreignKeysByTable: new Map([["orders", [{ column: "customer_id", ref_table: "customers_ext", ref_column: "id" }]]]),
+  });
+
+  assert.equal(items[0]?.label, "customers");
+  assert.equal(items[0]?.type, "table");
+});
+
+test("ranks an exact match first even when a fuzzy candidate outscores the numeric boost", () => {
+  // A long tight-fuzzy foreign-key candidate accumulates boundary bonuses beyond
+  // EXACT_LABEL_MATCH_BOOST; only the exactMatch comparator key keeps the exact item first.
+  const exactName = "ab".repeat(300);
+  const fuzzyName = Array.from({ length: 300 }, () => "ab").join("_");
+  const sql = `select * from orders join ${exactName}`;
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [
+      { name: "orders", type: "table" },
+      { name: exactName, type: "table" },
+      { name: fuzzyName, type: "table" },
+    ],
+    columnsByTable: new Map(),
+    foreignKeysByTable: new Map([["orders", [{ column: "x_id", ref_table: fuzzyName, ref_column: "id" }]]]),
+  });
+
+  assert.equal(items[0]?.label, exactName);
+  assert.equal(items[0]?.type, "table");
+});
+
 test("does not reuse table completion results across typed prefixes", () => {
   const validFor = getSqlCompletionResultValidFor("select * from ", "select * from ".length);
 


### PR DESCRIPTION
## 问题

Fixes #3002

SQL 编辑器输入 `int` 时，自动提示列表里完全匹配的关键字 `INT` 没有排在第一位，排在前面的是 `int_proc_sync` 等只是前缀/模糊匹配的存储过程、函数。此时直接回车，已经输完整的 `int` 会被替换成其他对象名。

## 根因

补全排序 = 匹配质量分（完全匹配 ≈3000 > 前缀匹配 ≈2000）+ **各类型固定偏移**（存储过程 +1800、外键关联表 +3600、表 +1000、关键字 ≈0，见 `buildObjectItems` / `buildForeignKeyRelatedTableItems` 等）。类型偏移远大于"完全匹配 vs 前缀匹配"的分差，导致前缀匹配的高偏移类型候选压过完全匹配的候选。

复现（SQLServer，库内含 `int_proc_sync` 等对象）：

```
create table t (id int█
→ top3: function:int_proc_sync | function:sp_interface | keyword:INT
```

## 修复方案

确立统一规则：**用户已完整输入某个候选的名字时，该候选必须排第一**（此时回车不会破坏已输入内容）。对所有类型（关键字/表/列/对象）一致生效，不是关键字特例：

1. `SqlCompletionItem` 新增 `exactMatch` 标记：build 阶段给 label 与已输入前缀完全相等（忽略大小写）的候选打标，并附加 `EXACT_LABEL_MATCH_BOOST`；
2. `compareCompletionItems` 将 `exactMatch` 作为**第一排序键**——完全匹配永远压过非完全匹配，不依赖数值大小（模糊匹配的边界加成无上限，纯数值加成存在被反超的反例，已有测试锁定）；
3. 多个候选同时完全匹配时（如列与关键字同名），保持原有类型偏好（列 > 表 > 关键字）；
4. 排除一类伪匹配：label 恰好等于前缀的"alias for xxx"别名建议（其 apply 是别名 SQL 而非名字本身）。

## 测试

`packages/app-tests/sqlCompletion.test.ts` 新增 4 个用例：

- issue 场景：`create table t (id int` 且库内有 `int_proc_sync` 等对象 → `keyword:INT` 排第一
- 完全匹配表名（`orders` vs `orders_archive`）排第一
- 完全匹配普通表压过 +3600 偏移的前缀匹配外键关联表
- 反例锁定：构造数值加成被模糊候选反超的场景（13400 vs 13611），断言完全匹配仍第一——该用例在纯数值加成实现下必然失败

## 验证

- `pnpm test` — 2484 passed / 0 failed（318 个测试文件全绿）
- `pnpm typecheck` — 通过
- `pnpm lint` / `pnpm fmt` — 通过（无新增警告）

## 备注

issue 中还提到"希望可以关闭自动提示列表"，属于独立的设置项功能请求，未包含在本 PR 中；如有需要可另行处理。