### PR TITLE
Fix: TDengine 超级表按层级展示子表

### DIFF
--- a/agents/common/src/main/java/com/dbx/agent/MetadataListConstraints.java
+++ b/agents/common/src/main/java/com/dbx/agent/MetadataListConstraints.java
@@ -197,7 +197,7 @@ public final class MetadataListConstraints {
         if (upper.contains("MATERIALIZED") && upper.contains("VIEW")) {
             return "MATERIALIZED_VIEW";
         }
-        if (upper.equals("BASE_TABLE") || upper.contains("TABLE")) {
+        if (upper.equals("STABLE") || upper.equals("BASE_TABLE") || upper.contains("TABLE")) {
             return "TABLE";
         }
         if (upper.contains("VIEW")) {

--- a/agents/common/src/main/java/com/dbx/agent/TableInfo.java
+++ b/agents/common/src/main/java/com/dbx/agent/TableInfo.java
@@ -6,6 +6,8 @@ public final class TableInfo {
     private String name;
     private String table_type;
     private String comment;
+    private String parent_schema;
+    private String parent_name;
 
     public TableInfo() {
         this("", "", null);
@@ -16,9 +18,15 @@ public final class TableInfo {
     }
 
     public TableInfo(String name, String table_type, String comment) {
+        this(name, table_type, comment, null, null);
+    }
+
+    public TableInfo(String name, String table_type, String comment, String parent_schema, String parent_name) {
         this.name = name;
         this.table_type = table_type;
         this.comment = comment;
+        this.parent_schema = parent_schema;
+        this.parent_name = parent_name;
     }
 
     public String getName() {
@@ -33,6 +41,14 @@ public final class TableInfo {
         return comment;
     }
 
+    public String getParent_schema() {
+        return parent_schema;
+    }
+
+    public String getParent_name() {
+        return parent_name;
+    }
+
     public void setName(String name) {
         this.name = name;
     }
@@ -45,6 +61,14 @@ public final class TableInfo {
         this.comment = comment;
     }
 
+    public void setParent_schema(String parent_schema) {
+        this.parent_schema = parent_schema;
+    }
+
+    public void setParent_name(String parent_name) {
+        this.parent_name = parent_name;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
@@ -52,16 +76,23 @@ public final class TableInfo {
         TableInfo that = (TableInfo) other;
         return Objects.equals(name, that.name)
             && Objects.equals(table_type, that.table_type)
-            && Objects.equals(comment, that.comment);
+            && Objects.equals(comment, that.comment)
+            && Objects.equals(parent_schema, that.parent_schema)
+            && Objects.equals(parent_name, that.parent_name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, table_type, comment);
+        return Objects.hash(name, table_type, comment, parent_schema, parent_name);
     }
 
     @Override
     public String toString() {
-        return "TableInfo(name=" + name + ", table_type=" + table_type + ", comment=" + comment + ")";
+        return "TableInfo(name=" + name
+            + ", table_type=" + table_type
+            + ", comment=" + comment
+            + ", parent_schema=" + parent_schema
+            + ", parent_name=" + parent_name
+            + ")";
     }
 }

--- a/agents/common/src/test/java/com/dbx/agent/CommonJavaCompatibilityTest.java
+++ b/agents/common/src/test/java/com/dbx/agent/CommonJavaCompatibilityTest.java
@@ -303,6 +303,17 @@ class CommonJavaCompatibilityTest {
     }
 
     @Test
+    void metadataConstraintsTreatTdengineStableAsTable() {
+        MetadataListConstraints constraints =
+            new MetadataListConstraints(null, null, null, Collections.singletonList("TABLE"));
+        TableInfo stable = new TableInfo("meters", "STABLE", null, null, null);
+
+        List<TableInfo> tables = constraints.filterTables(Collections.singletonList(stable));
+
+        assertEquals(Collections.singletonList(stable), tables);
+    }
+
+    @Test
     void metadataConstraintsMatchTableAndObjectComments() {
         MetadataListConstraints tableConstraints =
             new MetadataListConstraints("account", null, null, Collections.singletonList("TABLE"));

--- a/agents/drivers/tdengine/src/main/java/com/dbx/agent/tdengine/TDengineAgent.java
+++ b/agents/drivers/tdengine/src/main/java/com/dbx/agent/tdengine/TDengineAgent.java
@@ -9,6 +9,8 @@ import com.dbx.agent.ForeignKeyInfo;
 import com.dbx.agent.IndexInfo;
 import com.dbx.agent.JdbcExecutor;
 import com.dbx.agent.JsonRpcServer;
+import com.dbx.agent.MetadataListConstraints;
+import com.dbx.agent.MetadataSqlSupport;
 import com.dbx.agent.ObjectInfo;
 import com.dbx.agent.ObjectSource;
 import com.dbx.agent.QueryPageOptions;
@@ -97,15 +99,28 @@ public final class TDengineAgent extends BaseDatabaseAgent {
 
     @Override
     public List<TableInfo> listTables(String schema) {
+        return listTables(schema, MetadataListConstraints.NONE);
+    }
+
+    @Override
+    public List<TableInfo> listTables(String schema, MetadataListConstraints constraints) {
+        MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
+        if (!normalized.tableTypeAllowed("TABLE")) {
+            return Collections.emptyList();
+        }
+        try {
+            return queryConstrainedTables(schema, normalized);
+        } catch (RuntimeException ignored) {
+            // TDengine 2.x does not expose information_schema.ins_stables/ins_tables.
+            return normalized.filterTables(listTablesLegacy(schema));
+        }
+    }
+
+    private List<TableInfo> listTablesLegacy(String schema) {
         return unchecked(() -> {
             List<TableInfo> result = new ArrayList<>();
             result.addAll(queryTables("SHOW " + quoteQualifiedPrefix(schema) + "STABLES", "STABLE"));
-            try {
-                result.addAll(queryTablesWithStableParents());
-            } catch (Exception ignored) {
-                // TDengine 2.x does not expose information_schema.ins_tables.
-                result.addAll(queryTables("SHOW " + quoteQualifiedPrefix(schema) + "TABLES", "TABLE"));
-            }
+            result.addAll(queryTables("SHOW " + quoteQualifiedPrefix(schema) + "TABLES", "TABLE"));
 
             Map<String, TableInfo> distinct = new LinkedHashMap<>();
             for (TableInfo table : result) {
@@ -236,23 +251,84 @@ public final class TDengineAgent extends BaseDatabaseAgent {
         return result;
     }
 
-    private List<TableInfo> queryTablesWithStableParents() throws Exception {
-        List<TableInfo> result = new ArrayList<>();
-        String sql = "SELECT table_name, stable_name, table_comment "
-            + "FROM information_schema.ins_tables WHERE db_name = DATABASE()";
-        try (java.sql.Statement stmt = requireConnected().createStatement();
-             ResultSet rs = stmt.executeQuery(sql)) {
-            while (rs.next()) {
-                result.add(new TableInfo(
-                    rs.getString(1),
-                    "TABLE",
-                    optionalString(rs, 3),
-                    null,
-                    optionalString(rs, 2)
-                ));
+    private List<TableInfo> queryConstrainedTables(String database, MetadataListConstraints constraints) {
+        return unchecked(() -> {
+            TableMetadataQuery query = buildTableMetadataQuery(database, constraints);
+            List<TableInfo> result = new ArrayList<>();
+            try (java.sql.PreparedStatement stmt = requireConnected().prepareStatement(query.sql())) {
+                MetadataSqlSupport.bind(stmt, query.args());
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        result.add(new TableInfo(
+                            rs.getString(1),
+                            rs.getString(2),
+                            optionalString(rs, 3),
+                            null,
+                            optionalString(rs, 4)
+                        ));
+                    }
+                }
             }
+            MetadataListConstraints postFilter = constraints.hasLimit() ? constraints.withoutPaging() : constraints;
+            return postFilter.filterTables(result);
+        });
+    }
+
+    static TableMetadataQuery buildTableMetadataQuery(String database, MetadataListConstraints constraints) {
+        MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
+        List<Object> args = new ArrayList<>();
+        StringBuilder sql = new StringBuilder("""
+            SELECT table_name, table_type, table_comment, parent_name
+            FROM (
+                SELECT stable_name AS table_name,
+                       'STABLE' AS table_type,
+                       table_comment,
+                       CAST(NULL AS VARCHAR(192)) AS parent_name,
+                       stable_name AS hierarchy_name,
+                       0 AS hierarchy_rank
+                FROM information_schema.ins_stables
+                WHERE db_name = ?
+                UNION ALL
+                SELECT table_name,
+                       'TABLE' AS table_type,
+                       table_comment,
+                       stable_name AS parent_name,
+                       CASE WHEN stable_name IS NULL THEN table_name ELSE stable_name END AS hierarchy_name,
+                       1 AS hierarchy_rank
+                FROM information_schema.ins_tables
+                WHERE db_name = ?
+            ) metadata
+            WHERE 1 = 1
+            """.stripIndent().trim());
+        args.add(database);
+        args.add(database);
+        if (normalized.hasFilter()) {
+            String pattern = normalized.fuzzyLikePattern();
+            sql.append(" AND (table_name LIKE ? OR table_comment LIKE ?)");
+            args.add(pattern);
+            args.add(pattern);
         }
-        return result;
+        sql.append(" ORDER BY hierarchy_name, hierarchy_rank, table_name");
+        MetadataSqlSupport.appendLiteralLimitOffset(sql, normalized);
+        return new TableMetadataQuery(sql.toString(), args);
+    }
+
+    static final class TableMetadataQuery {
+        private final String sql;
+        private final List<Object> args;
+
+        TableMetadataQuery(String sql, List<Object> args) {
+            this.sql = sql;
+            this.args = args;
+        }
+
+        String sql() {
+            return sql;
+        }
+
+        List<Object> args() {
+            return args;
+        }
     }
 
     static void sortTablesForHierarchy(List<TableInfo> tables) {

--- a/agents/drivers/tdengine/src/main/java/com/dbx/agent/tdengine/TDengineAgent.java
+++ b/agents/drivers/tdengine/src/main/java/com/dbx/agent/tdengine/TDengineAgent.java
@@ -25,7 +25,6 @@ import java.sql.Types;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -101,14 +100,19 @@ public final class TDengineAgent extends BaseDatabaseAgent {
         return unchecked(() -> {
             List<TableInfo> result = new ArrayList<>();
             result.addAll(queryTables("SHOW " + quoteQualifiedPrefix(schema) + "STABLES", "STABLE"));
-            result.addAll(queryTables("SHOW " + quoteQualifiedPrefix(schema) + "TABLES", "TABLE"));
+            try {
+                result.addAll(queryTablesWithStableParents());
+            } catch (Exception ignored) {
+                // TDengine 2.x does not expose information_schema.ins_tables.
+                result.addAll(queryTables("SHOW " + quoteQualifiedPrefix(schema) + "TABLES", "TABLE"));
+            }
 
             Map<String, TableInfo> distinct = new LinkedHashMap<>();
             for (TableInfo table : result) {
                 distinct.putIfAbsent(table.getTable_type() + ":" + table.getName(), table);
             }
             List<TableInfo> sorted = new ArrayList<>(distinct.values());
-            sorted.sort(Comparator.comparing(table -> table.getName().toLowerCase(Locale.ROOT)));
+            sortTablesForHierarchy(sorted);
             return sorted;
         });
     }
@@ -230,6 +234,49 @@ public final class TDengineAgent extends BaseDatabaseAgent {
             }
         }
         return result;
+    }
+
+    private List<TableInfo> queryTablesWithStableParents() throws Exception {
+        List<TableInfo> result = new ArrayList<>();
+        String sql = "SELECT table_name, stable_name, table_comment "
+            + "FROM information_schema.ins_tables WHERE db_name = DATABASE()";
+        try (java.sql.Statement stmt = requireConnected().createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                result.add(new TableInfo(
+                    rs.getString(1),
+                    "TABLE",
+                    optionalString(rs, 3),
+                    null,
+                    optionalString(rs, 2)
+                ));
+            }
+        }
+        return result;
+    }
+
+    static void sortTablesForHierarchy(List<TableInfo> tables) {
+        tables.sort((left, right) -> {
+            String leftGroup = hierarchyGroupName(left);
+            String rightGroup = hierarchyGroupName(right);
+            int groupCompared = leftGroup.compareTo(rightGroup);
+            if (groupCompared != 0) {
+                return groupCompared;
+            }
+
+            boolean leftIsParent = left.getParent_name() == null;
+            boolean rightIsParent = right.getParent_name() == null;
+            if (leftIsParent != rightIsParent) {
+                return leftIsParent ? -1 : 1;
+            }
+            return left.getName().toLowerCase(Locale.ROOT).compareTo(right.getName().toLowerCase(Locale.ROOT));
+        });
+    }
+
+    private static String hierarchyGroupName(TableInfo table) {
+        String parentName = table.getParent_name();
+        String groupName = parentName == null || parentName.trim().isEmpty() ? table.getName() : parentName;
+        return groupName.toLowerCase(Locale.ROOT);
     }
 
     private static List<ColumnInfo> readDescribeColumns(ResultSet rs) throws Exception {

--- a/agents/drivers/tdengine/src/test/java/com/dbx/agent/tdengine/TDengineAgentTest.java
+++ b/agents/drivers/tdengine/src/test/java/com/dbx/agent/tdengine/TDengineAgentTest.java
@@ -4,12 +4,15 @@ import com.dbx.agent.test.TestSupport;
 import com.dbx.agent.ConnectParams;
 import com.dbx.agent.DatabaseAgent;
 import com.dbx.agent.ExecuteQueryOptions;
+import com.dbx.agent.TableInfo;
 import com.dbx.agent.test.JdbcAgentFake;
 import com.dbx.agent.test.JdbcFakeExecutionBehaviorTest;
 import com.dbx.agent.test.JdbcMetadataSqlFake;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -75,11 +78,29 @@ class TDengineAgentMetadataTest {
             Arrays.asList(
                 "SHOW DATABASES",
                 "SHOW `power`.STABLES",
-                "SHOW `power`.TABLES",
+                "SELECT table_name, stable_name, table_comment FROM information_schema.ins_tables WHERE db_name = DATABASE()",
                 "DESCRIBE `power`.`meters`"
             ),
             JdbcMetadataSqlFake.statements
         );
+    }
+
+    @Test
+    void sortsSupertablesBeforeTheirChildTables() {
+        List<TableInfo> tables = new ArrayList<>(Arrays.asList(
+            new TableInfo("device_b", "TABLE", null, null, "meters"),
+            new TableInfo("standalone", "TABLE", null),
+            new TableInfo("meters", "STABLE", null),
+            new TableInfo("device_a", "TABLE", null, null, "meters")
+        ));
+
+        TDengineAgent.sortTablesForHierarchy(tables);
+
+        Assertions.assertEquals(
+            Arrays.asList("meters", "device_a", "device_b", "standalone"),
+            tables.stream().map(TableInfo::getName).toList()
+        );
+        Assertions.assertEquals("meters", tables.get(1).getParent_name());
     }
 
     @Test

--- a/agents/drivers/tdengine/src/test/java/com/dbx/agent/tdengine/TDengineAgentTest.java
+++ b/agents/drivers/tdengine/src/test/java/com/dbx/agent/tdengine/TDengineAgentTest.java
@@ -4,15 +4,25 @@ import com.dbx.agent.test.TestSupport;
 import com.dbx.agent.ConnectParams;
 import com.dbx.agent.DatabaseAgent;
 import com.dbx.agent.ExecuteQueryOptions;
+import com.dbx.agent.MetadataListConstraints;
 import com.dbx.agent.TableInfo;
 import com.dbx.agent.test.JdbcAgentFake;
 import com.dbx.agent.test.JdbcFakeExecutionBehaviorTest;
 import com.dbx.agent.test.JdbcMetadataSqlFake;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -74,15 +84,67 @@ class TDengineAgentMetadataTest {
         agent.listTables("power");
         agent.getColumns("power", "meters");
 
-        Assertions.assertEquals(
-            Arrays.asList(
-                "SHOW DATABASES",
-                "SHOW `power`.STABLES",
-                "SELECT table_name, stable_name, table_comment FROM information_schema.ins_tables WHERE db_name = DATABASE()",
-                "DESCRIBE `power`.`meters`"
-            ),
-            JdbcMetadataSqlFake.statements
+        Assertions.assertEquals("SHOW DATABASES", JdbcMetadataSqlFake.statements.get(0));
+        Assertions.assertTrue(JdbcMetadataSqlFake.statements.get(1).contains("FROM information_schema.ins_stables"));
+        Assertions.assertTrue(JdbcMetadataSqlFake.statements.get(1).contains("FROM information_schema.ins_tables"));
+        Assertions.assertEquals("param:1=power", JdbcMetadataSqlFake.statements.get(2));
+        Assertions.assertEquals("param:2=power", JdbcMetadataSqlFake.statements.get(3));
+        Assertions.assertEquals("DESCRIBE `power`.`meters`", JdbcMetadataSqlFake.statements.get(4));
+    }
+
+    @Test
+    void constrainedMetadataUsesRequestedDatabaseAndPushesFilterAndPaging() {
+        TDengineAgent agent = new TDengineAgent();
+        TestSupport.setPrivateConnection(agent, JdbcMetadataSqlFake.connection());
+
+        agent.listTables(
+            "dbx_alpha",
+            new MetadataListConstraints("ord", 25, 50, List.of("TABLE"))
         );
+
+        String sql = JdbcMetadataSqlFake.statements.get(0);
+        Assertions.assertFalse(sql.contains("DATABASE()"), sql);
+        Assertions.assertTrue(sql.contains("FROM information_schema.ins_stables"), sql);
+        Assertions.assertTrue(sql.contains("FROM information_schema.ins_tables"), sql);
+        Assertions.assertTrue(sql.contains("WHERE db_name = ?"), sql);
+        Assertions.assertTrue(sql.contains("table_name LIKE ? OR table_comment LIKE ?"), sql);
+        Assertions.assertTrue(sql.contains("ORDER BY hierarchy_name, hierarchy_rank, table_name"), sql);
+        Assertions.assertTrue(sql.endsWith("LIMIT 25 OFFSET 50"), sql);
+        Assertions.assertEquals(
+            List.of(
+                "param:1=dbx_alpha",
+                "param:2=dbx_alpha",
+                "param:3=%o%r%d%",
+                "param:4=%o%r%d%"
+            ),
+            JdbcMetadataSqlFake.statements.subList(1, 5)
+        );
+    }
+
+    @Test
+    void constrainedMetadataPagesDoNotRepeatOrSkipTables() {
+        List<TableInfo> metadata = List.of(
+            new TableInfo("meters", "STABLE", null),
+            new TableInfo("device_a", "TABLE", null, null, "meters"),
+            new TableInfo("device_b", "TABLE", null, null, "meters"),
+            new TableInfo("standalone", "TABLE", null),
+            new TableInfo("weather", "STABLE", null)
+        );
+        List<String> statements = new ArrayList<>();
+        TDengineAgent agent = new TDengineAgent();
+        TestSupport.setPrivateConnection(agent, pagedMetadataConnection(metadata, statements));
+
+        List<TableInfo> combined = new ArrayList<>();
+        combined.addAll(agent.listTables("dbx_alpha", new MetadataListConstraints(null, 2, null, List.of("TABLE"))));
+        combined.addAll(agent.listTables("dbx_alpha", new MetadataListConstraints(null, 2, 2, List.of("TABLE"))));
+        combined.addAll(agent.listTables("dbx_alpha", new MetadataListConstraints(null, 2, 4, List.of("TABLE"))));
+
+        Assertions.assertEquals(metadata.stream().map(TableInfo::getName).toList(), combined.stream().map(TableInfo::getName).toList());
+        Set<String> distinctNames = new HashSet<>(combined.stream().map(TableInfo::getName).toList());
+        Assertions.assertEquals(metadata.size(), distinctNames.size());
+        Assertions.assertTrue(statements.get(0).endsWith("LIMIT 2"), statements.get(0));
+        Assertions.assertTrue(statements.get(1).endsWith("LIMIT 2 OFFSET 2"), statements.get(1));
+        Assertions.assertTrue(statements.get(2).endsWith("LIMIT 2 OFFSET 4"), statements.get(2));
     }
 
     @Test
@@ -110,6 +172,77 @@ class TDengineAgentMetadataTest {
 
         Assertions.assertTrue(agent.listSchemas().isEmpty());
         Assertions.assertTrue(JdbcMetadataSqlFake.statements.isEmpty());
+    }
+
+    private static Connection pagedMetadataConnection(List<TableInfo> metadata, List<String> statements) {
+        return proxy(Connection.class, (proxy, method, args) -> {
+            String name = method.getName();
+            if ("prepareStatement".equals(name)) {
+                String sql = (String) args[0];
+                statements.add(sql);
+                return pagedMetadataStatement(sql, metadata);
+            }
+            if ("isClosed".equals(name)) return false;
+            if ("close".equals(name)) return null;
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static PreparedStatement pagedMetadataStatement(String sql, List<TableInfo> metadata) {
+        return proxy(PreparedStatement.class, (proxy, method, args) -> {
+            String name = method.getName();
+            if ("executeQuery".equals(name)) {
+                int limit = sqlClauseValue(sql, "LIMIT", metadata.size());
+                int offset = sqlClauseValue(sql, "OFFSET", 0);
+                int from = Math.min(offset, metadata.size());
+                int to = Math.min(from + limit, metadata.size());
+                return tableInfoResultSet(metadata.subList(from, to));
+            }
+            if ("setString".equals(name) || "setInt".equals(name) || "setObject".equals(name) || "close".equals(name)) return null;
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static ResultSet tableInfoResultSet(List<TableInfo> tables) {
+        int[] index = {-1};
+        return proxy(ResultSet.class, (proxy, method, args) -> {
+            String name = method.getName();
+            if ("next".equals(name)) {
+                index[0] += 1;
+                return index[0] < tables.size();
+            }
+            if ("getString".equals(name)) {
+                TableInfo table = tables.get(index[0]);
+                int column = (Integer) args[0];
+                if (column == 1) return table.getName();
+                if (column == 2) return table.getTable_type();
+                if (column == 3) return table.getComment();
+                if (column == 4) return table.getParent_name();
+            }
+            if ("close".equals(name)) return null;
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static int sqlClauseValue(String sql, String clause, int fallback) {
+        Matcher matcher = Pattern.compile("\\b" + clause + "\\s+(\\d+)").matcher(sql);
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : fallback;
+    }
+
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return type.cast(Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler));
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (Boolean.TYPE.equals(type)) return false;
+        if (Integer.TYPE.equals(type)) return 0;
+        if (Long.TYPE.equals(type)) return 0L;
+        if (Double.TYPE.equals(type)) return 0.0d;
+        if (Float.TYPE.equals(type)) return 0.0f;
+        if (Short.TYPE.equals(type)) return (short) 0;
+        if (Byte.TYPE.equals(type)) return (byte) 0;
+        if (Character.TYPE.equals(type)) return '\0';
+        return null;
     }
 
     @Test

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1642,6 +1642,7 @@ export default {
     gridfs: "GridFS",
     buckets: "Buckets",
     partitions: "Partitions",
+    childTables: "Subtables",
     loadMore: "Load more...",
     objectBrowser: "Browse in Object Browser ({count})",
     extensions: "Extensions",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1585,6 +1585,7 @@ export default withEnglishFallback({
     sequences: "Secuencias",
     packages: "Paquetes",
     partitions: "Particiones",
+    childTables: "Subtablas",
     loadMore: "Cargar más...",
     objectBrowser: "Explorar en el navegador de objetos ({count})",
     extensions: "Extensiones",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1583,6 +1583,7 @@ export default withEnglishFallback({
     sequences: "Sequenze",
     packages: "Pacchetti",
     partitions: "Partizioni",
+    childTables: "Sottotabelle",
     loadMore: "Carica altro...",
     objectBrowser: "Sfoglia in Esplora Oggetti ({count})",
     extensions: "Estensioni",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1581,6 +1581,7 @@ export default withEnglishFallback({
     sequences: "シーケンス",
     packages: "パッケージ",
     partitions: "パーティション",
+    childTables: "子テーブル",
     loadMore: "もっと読み込む...",
     objectBrowser: "オブジェクトブラウザで参照（{count}件）",
     linkedServers: "リンクサーバー",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1584,6 +1584,7 @@ export default withEnglishFallback({
     sequences: "Sequências",
     packages: "Pacotes",
     partitions: "Partições",
+    childTables: "Subtabelas",
     loadMore: "Carregar mais...",
     objectBrowser: "Navegar no Navegador de Objetos ({count})",
     extensions: "Extensões",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1641,6 +1641,7 @@ export default withEnglishFallback({
     sequences: "序列",
     packages: "包",
     partitions: "分区",
+    childTables: "子表",
     loadMore: "加载更多...",
     objectBrowser: "在对象浏览器中查看 ({count})",
     extensions: "扩展",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1583,6 +1583,7 @@ export default withEnglishFallback({
     sequences: "序列",
     packages: "套件",
     partitions: "分割區",
+    childTables: "子表",
     loadMore: "載入更多...",
     objectBrowser: "在物件瀏覽器中檢視 ({count})",
     extensions: "擴展",

--- a/apps/desktop/src/lib/__tests__/table/tableTree.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableTree.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { appendTableTreeLoadMoreNode, buildTableTreeNodes, mergeTableTreePageChildren, tablePartitionGroups, withoutTableTreeLoadMoreNodes } from "@/lib/table/tableTree";
+import type { TableInfo, TreeNode } from "@/types/database";
+
+const context = {
+  nodeId: "connection:db",
+  connectionId: "connection",
+  database: "db",
+};
+
+describe("TDengine table hierarchy", () => {
+  it("groups child tables under their supertable and keeps ordinary tables flat", () => {
+    const tables: TableInfo[] = [
+      { name: "meters", table_type: "STABLE", comment: null },
+      { name: "device_b", table_type: "TABLE", comment: null, parent_name: "meters" },
+      { name: "standalone", table_type: "TABLE", comment: null },
+      { name: "device_a", table_type: "TABLE", comment: null, parent_name: "meters" },
+    ];
+
+    const nodes = buildTableTreeNodes({ ...context, tables });
+
+    expect(nodes.map((node) => node.label)).toEqual(["meters", "standalone"]);
+    expect(nodes[0].children).toHaveLength(1);
+    expect(nodes[0].children?.[0]).toMatchObject({
+      type: "group-partitions",
+      label: "tree.childTables",
+      objectCount: 2,
+      isExpanded: true,
+    });
+    expect(nodes[0].children?.[0].children?.map((node) => node.label)).toEqual(["device_a", "device_b"]);
+  });
+
+  it("attaches child tables loaded on later pages to the existing supertable", () => {
+    const firstPage = buildTableTreeNodes({
+      ...context,
+      tables: [{ name: "meters", table_type: "STABLE", comment: null }],
+    });
+    const secondPage = buildTableTreeNodes({
+      ...context,
+      tables: [{ name: "device_a", table_type: "TABLE", comment: null, parent_name: "meters" }],
+    });
+
+    const merged = mergeTableTreePageChildren(firstPage, secondPage, context.connectionId, context.database);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].children?.[0]).toMatchObject({
+      type: "group-partitions",
+      label: "tree.childTables",
+      objectCount: 1,
+      isExpanded: true,
+    });
+    expect(merged[0].children?.[0].children?.[0].label).toBe("device_a");
+  });
+
+  it("keeps pagination inside the child table group across pages", () => {
+    const firstPage = buildTableTreeNodes({
+      ...context,
+      tables: [
+        { name: "meters", table_type: "STABLE", comment: null },
+        { name: "device_a", table_type: "TABLE", comment: null, parent_name: "meters" },
+      ],
+    });
+    const firstLoadMore: TreeNode = {
+      id: "load-more:1",
+      label: "tree.loadMore",
+      type: "load-more",
+      connectionId: context.connectionId,
+      database: context.database,
+      loadMore: { parentId: "connection:db:__tables", offset: 2, pageSize: 2 },
+    };
+
+    appendTableTreeLoadMoreNode(firstPage, firstLoadMore, { name: "meters" });
+
+    expect(firstPage.map((node) => node.type)).toEqual(["table"]);
+    expect(tablePartitionGroups(firstPage[0])[0].children?.map((node) => node.type)).toEqual(["table", "load-more"]);
+
+    const secondPage = buildTableTreeNodes({
+      ...context,
+      tables: [{ name: "device_b", table_type: "TABLE", comment: null, parent_name: "meters" }],
+    });
+    const withoutLoadMore = withoutTableTreeLoadMoreNodes(firstPage);
+    const merged = mergeTableTreePageChildren(withoutLoadMore, secondPage, context.connectionId, context.database);
+    const secondLoadMore = { ...firstLoadMore, id: "load-more:2", loadMore: { ...firstLoadMore.loadMore!, offset: 4 } };
+
+    appendTableTreeLoadMoreNode(merged, secondLoadMore, { name: "meters" });
+
+    expect(merged).toHaveLength(1);
+    expect(tablePartitionGroups(merged[0])[0]).toMatchObject({ objectCount: 2 });
+    expect(tablePartitionGroups(merged[0])[0].children?.map((node) => node.label)).toEqual(["device_a", "device_b", "tree.loadMore"]);
+  });
+
+  it("keeps the partition label for non-TDengine parent tables", () => {
+    const nodes = buildTableTreeNodes({
+      ...context,
+      schema: "public",
+      tables: [
+        { name: "orders", table_type: "PARTITIONED TABLE", comment: null },
+        { name: "orders_2026", table_type: "TABLE", comment: null, parent_schema: "public", parent_name: "orders" },
+      ],
+    });
+
+    expect(nodes[0].children?.[0]).toMatchObject({ label: "tree.partitions", isExpanded: false });
+  });
+});

--- a/apps/desktop/src/lib/table/tableTree.ts
+++ b/apps/desktop/src/lib/table/tableTree.ts
@@ -292,7 +292,7 @@ function buildPartitionTree(entries: TableTreeEntry[], connectionId: string, dat
 
     const partitionGroup: TreeNode = {
       id: `${entry.node.id}:__partitions`,
-      label: "tree.partitions",
+      label: childTableGroupLabel(entry.node),
       type: "group-partitions",
       connectionId,
       database,
@@ -300,7 +300,7 @@ function buildPartitionTree(entries: TableTreeEntry[], connectionId: string, dat
       catalog: entry.node.catalog,
       tableName: entry.node.label,
       objectCount: partitionChildren.length,
-      isExpanded: false,
+      isExpanded: isSuperTable(entry.node),
       children: partitionChildren.map(materialize),
     };
     entry.node.children = [partitionGroup];
@@ -309,6 +309,14 @@ function buildPartitionTree(entries: TableTreeEntry[], connectionId: string, dat
   };
 
   return orderedEntries.filter((entry) => !childKeys.has(entry.key)).map(materialize);
+}
+
+function isSuperTable(parent: TreeNode): boolean {
+  return parent.tableType?.trim().toUpperCase() === "STABLE";
+}
+
+function childTableGroupLabel(parent: TreeNode): string {
+  return isSuperTable(parent) ? "tree.childTables" : "tree.partitions";
 }
 
 function partitionGroupChildren(node: TreeNode): TreeNode[] {
@@ -323,6 +331,43 @@ export function tablePartitionGroups(node: TreeNode): TreeNode[] {
 
 export function hasTablePartitionGroups(node: TreeNode): boolean {
   return partitionGroupChildren(node).length > 0;
+}
+
+export type TableTreeLoadMoreParent = {
+  schema?: string | null;
+  name: string;
+};
+
+function findTableTreeNode(nodes: readonly TreeNode[], parent: TableTreeLoadMoreParent): TreeNode | undefined {
+  for (const node of nodes) {
+    const sameSchema = !parent.schema || (node.schema || "").toLowerCase() === parent.schema.toLowerCase();
+    if (node.type === "table" && sameSchema && node.label.toLowerCase() === parent.name.toLowerCase()) return node;
+
+    const child = findTableTreeNode(node.children ?? [], parent);
+    if (child) return child;
+    const hiddenChild = findTableTreeNode(node.hiddenChildren?.filter((item) => !(node.children ?? []).includes(item)) ?? [], parent);
+    if (hiddenChild) return hiddenChild;
+  }
+  return undefined;
+}
+
+export function appendTableTreeLoadMoreNode(children: TreeNode[], loadMoreNode: TreeNode, parent?: TableTreeLoadMoreParent): TreeNode[] {
+  const parentNode = parent ? findTableTreeNode(children, parent) : undefined;
+  const childGroup = parentNode ? tablePartitionGroups(parentNode)[0] : undefined;
+  if (!childGroup) return [...children, loadMoreNode];
+
+  childGroup.children = [...(childGroup.children ?? []), loadMoreNode];
+  return children;
+}
+
+export function withoutTableTreeLoadMoreNodes(nodes: TreeNode[] | undefined): TreeNode[] {
+  return (nodes ?? [])
+    .filter((node) => node.type !== "load-more")
+    .map((node) => {
+      if (node.children) node.children = withoutTableTreeLoadMoreNodes(node.children);
+      if (node.hiddenChildren) node.hiddenChildren = withoutTableTreeLoadMoreNodes(node.hiddenChildren);
+      return node;
+    });
 }
 
 export function mergeTableTreePageChildren(currentChildren: TreeNode[], pageChildren: TreeNode[], connectionId: string, database: string): TreeNode[] {
@@ -351,14 +396,14 @@ export function mergeTableTreePageChildren(currentChildren: TreeNode[], pageChil
     if (existing) return existing;
     const group: TreeNode = {
       id: `${parent.id}:__partitions`,
-      label: "tree.partitions",
+      label: childTableGroupLabel(parent),
       type: "group-partitions",
       connectionId,
       database,
       schema: parent.schema,
       tableName: parent.label,
       objectCount: 0,
-      isExpanded: false,
+      isExpanded: isSuperTable(parent),
       children: [],
     };
     parent.children = [...(parent.children ?? []), group];

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -38,6 +38,7 @@ import {
   buildGroupedObjectTreeNodes,
   buildSimpleObjectTreeNodes,
   buildTableTreeNodes,
+  appendTableTreeLoadMoreNode,
   expandCachedObjectBrowserNodes,
   filterSimpleSidebarSupplementalObjects,
   mergeTableInfosIntoObjects,
@@ -46,6 +47,8 @@ import {
   objectTypesForGroupNode,
   sortDatabaseObjectsByName,
   tablePartitionGroups,
+  withoutTableTreeLoadMoreNodes,
+  type TableTreeLoadMoreParent,
   type DatabaseObjectTreeKind,
 } from "@/lib/table/tableTree";
 import { hasTreeNodeDatabaseContext, normalizeCataloglessDatabaseNodes, treeNodeSchemaCachePrefix } from "@/lib/sidebar/treeNodeContext";
@@ -1159,7 +1162,7 @@ export const useConnectionStore = defineStore("connection", () => {
     pageSize: number;
     searchFilter?: string;
     force?: boolean;
-  }): Promise<{ children: TreeNode[]; objectCount: number; hasMore: boolean; nextOffset: number }> {
+  }): Promise<{ children: TreeNode[]; objectCount: number; hasMore: boolean; nextOffset: number; loadMoreParent?: TableTreeLoadMoreParent }> {
     if (!options.node.connectionId || !options.node.database) {
       return { children: [], objectCount: 0, hasMore: false, nextOffset: options.offset };
     }
@@ -1186,18 +1189,20 @@ export const useConnectionStore = defineStore("connection", () => {
     const pageTables = hasMore ? tables.slice(0, options.pageSize) : tables;
     indexCompletionTables(options.node.connectionId, options.node.database, options.effectiveSchema, tableInfosToCompletionTables(pageTables, options.effectiveSchema));
     const objects = mergeTableInfosIntoObjects([], pageTables, options.effectiveSchema);
-    const visibleObjectCount = objects.filter((object) => options.objectTypes.includes(normalizedObjectTreeKind(object.object_type))).length;
+    const children = objectGroupChildrenFromObjects({
+      node: options.node,
+      parentNodeId: options.parentNodeId,
+      effectiveSchema: options.effectiveSchema,
+      objectTypes: options.objectTypes,
+      objects,
+    });
+    const lastTable = pageTables[pageTables.length - 1];
     return {
-      children: objectGroupChildrenFromObjects({
-        node: options.node,
-        parentNodeId: options.parentNodeId,
-        effectiveSchema: options.effectiveSchema,
-        objectTypes: options.objectTypes,
-        objects,
-      }),
-      objectCount: visibleObjectCount,
+      children,
+      objectCount: children.length,
       hasMore,
       nextOffset: options.offset + pageTables.length,
+      loadMoreParent: lastTable?.parent_name ? { schema: lastTable.parent_schema, name: lastTable.parent_name } : undefined,
     };
   }
 
@@ -1212,7 +1217,7 @@ export const useConnectionStore = defineStore("connection", () => {
     pageSize: number;
     searchFilter?: string;
     force?: boolean;
-  }): Promise<{ children: TreeNode[]; objectCount: number; hasMore: boolean; nextOffset: number }> {
+  }): Promise<{ children: TreeNode[]; objectCount: number; hasMore: boolean; nextOffset: number; loadMoreParent?: TableTreeLoadMoreParent }> {
     const searchFilter = (options.searchFilter ?? sidebarSearchQuery.value) || undefined;
     const fetchLimit = searchFilter ? options.pageSize : options.pageSize + 1;
     const fetchOffset = searchFilter ? undefined : options.offset;
@@ -1242,11 +1247,13 @@ export const useConnectionStore = defineStore("connection", () => {
       schema: options.effectiveSchema,
       tables: pageTables,
     });
+    const lastTable = pageTables[pageTables.length - 1];
     return {
       children,
       objectCount: children.length,
       hasMore,
       nextOffset: options.offset + pageTables.length,
+      loadMoreParent: lastTable?.parent_name ? { schema: lastTable.parent_schema, name: lastTable.parent_name } : undefined,
     };
   }
 
@@ -2938,7 +2945,7 @@ export const useConnectionStore = defineStore("connection", () => {
               searchFilter: searchFilter || undefined,
               force: options?.force,
             });
-            children = page.hasMore && !searchFilter ? [...page.children, buildLoadMoreNode(node, page.nextOffset, pageSize)] : page.children;
+            children = page.hasMore && !searchFilter ? appendTableTreeLoadMoreNode(page.children, buildLoadMoreNode(node, page.nextOffset, pageSize), page.loadMoreParent) : page.children;
             nextObjectCount = page.objectCount;
           } else {
             children = buildObjectGroupPlaceholderNodes({
@@ -3050,7 +3057,7 @@ export const useConnectionStore = defineStore("connection", () => {
               searchFilter: searchFilter || undefined,
               force: options?.force,
             });
-            children = page.hasMore && !searchFilter ? [...page.children, buildLoadMoreNode(node, page.nextOffset, sidebarObjectGroupPageSize())] : page.children;
+            children = page.hasMore && !searchFilter ? appendTableTreeLoadMoreNode(page.children, buildLoadMoreNode(node, page.nextOffset, sidebarObjectGroupPageSize()), page.loadMoreParent) : page.children;
             nextObjectCount = page.objectCount;
           } else {
             const objects = await loadCachedMetadataListPage<ObjectInfo[]>(
@@ -3166,11 +3173,11 @@ export const useConnectionStore = defineStore("connection", () => {
               pageSize: loadMore.pageSize,
               force: false,
             });
-            const currentChildren = withoutLoadMoreNodes(parent.children);
+            const currentChildren = withoutTableTreeLoadMoreNodes(parent.children);
             const mergedChildren = mergeTableTreePageChildren(currentChildren, page.children, parentConnectionId, parentDatabase);
-            const nextChildren = page.hasMore ? [...mergedChildren, buildLoadMoreNode(parent, page.nextOffset, loadMore.pageSize)] : mergedChildren;
+            const nextChildren = page.hasMore ? appendTableTreeLoadMoreNode(mergedChildren, buildLoadMoreNode(parent, page.nextOffset, loadMore.pageSize), page.loadMoreParent) : mergedChildren;
             if (!canApplyTreeMetadataResult(parent)) return;
-            parent.objectCount = (parent.objectCount ?? currentChildren.length) + page.objectCount;
+            parent.objectCount = mergedChildren.length;
             setChildren(parent, nextChildren);
             await savePersistedTreeChildren(schemaCacheKey(parentConnectionId, parentDatabase, parent.schema || "", "objects-simple-v3"), nextChildren);
             parent.isExpanded = true;
@@ -3196,11 +3203,11 @@ export const useConnectionStore = defineStore("connection", () => {
             pageSize: loadMore.pageSize,
             force: false,
           });
-          const currentChildren = withoutLoadMoreNodes(parent.children);
+          const currentChildren = withoutTableTreeLoadMoreNodes(parent.children);
           const mergedChildren = mergeTableTreePageChildren(currentChildren, page.children, parentConnectionId, parentDatabase);
-          const nextChildren = page.hasMore ? [...mergedChildren, buildLoadMoreNode(parent, page.nextOffset, loadMore.pageSize)] : mergedChildren;
+          const nextChildren = page.hasMore ? appendTableTreeLoadMoreNode(mergedChildren, buildLoadMoreNode(parent, page.nextOffset, loadMore.pageSize), page.loadMoreParent) : mergedChildren;
           if (!canApplyTreeMetadataResult(parent)) return;
-          parent.objectCount = (parent.objectCount ?? currentChildren.length) + page.objectCount;
+          parent.objectCount = mergedChildren.length;
           setChildren(parent, nextChildren);
           await savePersistedTreeChildren(objectGroupCacheKey(parent), nextChildren);
           parent.isExpanded = true;
@@ -3313,11 +3320,11 @@ export const useConnectionStore = defineStore("connection", () => {
         await loadObjectGroupChildren(parent);
       }
 
-      let loadMoreNode = parent.children?.find((child) => child.type === "load-more");
+      let loadMoreNode = findTreeNodes(parent.children ?? [], (child) => child.type === "load-more")[0];
       while (loadMoreNode?.loadMore) {
         loadMoreNode.isLoading = true;
         await loadMoreObjectGroupChildren(loadMoreNode);
-        loadMoreNode = parent.children?.find((child) => child.type === "load-more");
+        loadMoreNode = findTreeNodes(parent.children ?? [], (child) => child.type === "load-more")[0];
       }
       parent.isExpanded = true;
     } catch (e) {


### PR DESCRIPTION
## 修改内容

- 从 TDengine 元数据中读取 `stable_name`，将子表关联到所属超级表
- 在连接树中按“超级表 -> 子表”层级展示，普通表保持平铺
- 展开超级表时默认展开子表分组，减少一层操作
- 修正大量子表分页时的根级计数和“加载更多”位置，后续页继续合并到同一超级表
- TDengine 2.x 无 `information_schema.ins_tables` 时回退到原有 `SHOW TABLES`
- 补充 `tree.childTables` 的英语、西班牙语、意大利语、日语、葡萄牙语、简体中文和繁体中文翻译

## 验证

- `pnpm check`
- Java common/TDengine agent 单元测试
- 使用真实 TDengine 测试库验证普通表、超级表、子表和 10000 个子表的多页加载

Fixes #3121