### PR TITLE
fix(nacos): improve config selection and separators

### DIFF
--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -913,21 +913,29 @@ onBeforeUnmount(() => {
           <div class="min-h-0 flex-1 overflow-auto">
             <div class="min-w-max" :style="{ minWidth: configListMinWidth }">
               <div class="sticky top-0 z-20 grid border-b bg-muted px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground shadow-sm" :style="{ gridTemplateColumns: configListGridTemplate }">
-                <div class="relative min-w-0 truncate pr-4">
-                  <span class="truncate">dataID</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30" :class="configListResizingColumnIndex === 0 ? 'bg-primary/30' : ''" @mousedown="onConfigListColumnResizeStart(0, $event)" />
+                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                  <span class="block truncate">dataID</span>
+                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(0, $event)">
+                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 0 ? 'bg-primary' : ''" />
+                  </div>
                 </div>
-                <div class="relative min-w-0 truncate pr-4">
-                  <span class="truncate">{{ t("nacos.group") }}</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30" :class="configListResizingColumnIndex === 1 ? 'bg-primary/30' : ''" @mousedown="onConfigListColumnResizeStart(1, $event)" />
+                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                  <span class="block truncate">{{ t("nacos.group") }}</span>
+                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(1, $event)">
+                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 1 ? 'bg-primary' : ''" />
+                  </div>
                 </div>
-                <div class="relative min-w-0 truncate pr-4">
-                  <span class="truncate">{{ t("nacos.application") }}</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30" :class="configListResizingColumnIndex === 2 ? 'bg-primary/30' : ''" @mousedown="onConfigListColumnResizeStart(2, $event)" />
+                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                  <span class="block truncate">{{ t("nacos.application") }}</span>
+                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(2, $event)">
+                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 2 ? 'bg-primary' : ''" />
+                  </div>
                 </div>
-                <div class="relative min-w-0 truncate pr-4">
-                  <span class="truncate">{{ t("nacos.format") }}</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30" :class="configListResizingColumnIndex === 3 ? 'bg-primary/30' : ''" @mousedown="onConfigListColumnResizeStart(3, $event)" />
+                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                  <span class="block truncate">{{ t("nacos.format") }}</span>
+                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(3, $event)">
+                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 3 ? 'bg-primary' : ''" />
+                  </div>
                 </div>
               </div>
               <button
@@ -939,12 +947,12 @@ onBeforeUnmount(() => {
                 :style="{ gridTemplateColumns: configListGridTemplate }"
                 @click="selectConfig(item)"
               >
-                <span class="flex min-w-0 items-center gap-2 pr-3" :title="item.dataId">
+                <span class="flex min-w-0 items-center gap-2 border-r border-border/50 pr-3 last:border-r-0" :title="item.dataId">
                   <FileText class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   <span class="truncate font-medium text-foreground">{{ item.dataId }}</span>
                 </span>
-                <span class="truncate pr-3 text-xs text-muted-foreground" :title="item.group || 'DEFAULT_GROUP'">{{ item.group || "DEFAULT_GROUP" }}</span>
-                <span class="truncate pr-3 text-xs text-muted-foreground" :title="item.appName || '-'">{{ item.appName || "-" }}</span>
+                <span class="truncate border-r border-border/50 pr-3 text-xs text-muted-foreground last:border-r-0" :title="item.group || 'DEFAULT_GROUP'">{{ item.group || "DEFAULT_GROUP" }}</span>
+                <span class="truncate border-r border-border/50 pr-3 text-xs text-muted-foreground last:border-r-0" :title="item.appName || '-'">{{ item.appName || "-" }}</span>
                 <span class="truncate text-xs text-muted-foreground" :title="configFormatLabel(item)">{{ configFormatLabel(item) }}</span>
               </button>
             </div>
@@ -1049,7 +1057,7 @@ onBeforeUnmount(() => {
             </div>
           </div>
           <div v-if="selectedConfig" class="relative min-h-0 flex-1 overflow-hidden bg-background">
-            <div ref="configEditorHost" class="h-full min-h-0 overflow-hidden" />
+            <div ref="configEditorHost" class="nacos-config-editor h-full min-h-0 overflow-hidden" />
             <EditorSearchPanel ref="configSearchPanelRef" :view="configEditorView" tone="editor" />
           </div>
           <div v-else class="flex h-full items-center justify-center text-sm text-muted-foreground">{{ t("nacos.selectConfig") }}</div>
@@ -1253,6 +1261,24 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
+.nacos-config-editor :deep(.cm-content),
+.nacos-config-editor :deep(.cm-line) {
+  cursor: text;
+  user-select: text !important;
+  -webkit-user-select: text !important;
+}
+
+.nacos-config-editor :deep(.cm-selectionBackground),
+.nacos-config-editor :deep(.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground),
+.nacos-config-editor :deep(.cm-trimmedSelection) {
+  display: block !important;
+  background: var(--dbx-editor-selection-background, rgba(59, 130, 246, 0.35)) !important;
+}
+
+.nacos-config-editor :deep(.cm-content ::selection) {
+  background: var(--dbx-editor-selection-background, rgba(59, 130, 246, 0.35)) !important;
+}
+
 .nacos-admin-splitpanes :deep(.splitpanes--vertical > .splitpanes__splitter) {
   width: 4px !important;
   border-left: 1px solid var(--border);

--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -913,29 +913,21 @@ onBeforeUnmount(() => {
           <div class="min-h-0 flex-1 overflow-auto">
             <div class="min-w-max" :style="{ minWidth: configListMinWidth }">
               <div class="sticky top-0 z-20 grid border-b bg-muted px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground shadow-sm" :style="{ gridTemplateColumns: configListGridTemplate }">
-                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                <div class="relative min-w-0 border-r border-border/70 pr-3 last:border-r-0">
                   <span class="block truncate">dataID</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(0, $event)">
-                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 0 ? 'bg-primary' : ''" />
-                  </div>
+                  <div data-column-resize-handle class="absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize" :class="configListResizingColumnIndex === 0 ? 'bg-primary/10' : ''" @mousedown="onConfigListColumnResizeStart(0, $event)" />
                 </div>
-                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                <div class="relative min-w-0 border-r border-border/70 pr-3 last:border-r-0">
                   <span class="block truncate">{{ t("nacos.group") }}</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(1, $event)">
-                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 1 ? 'bg-primary' : ''" />
-                  </div>
+                  <div data-column-resize-handle class="absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize" :class="configListResizingColumnIndex === 1 ? 'bg-primary/10' : ''" @mousedown="onConfigListColumnResizeStart(1, $event)" />
                 </div>
-                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                <div class="relative min-w-0 border-r border-border/70 pr-3 last:border-r-0">
                   <span class="block truncate">{{ t("nacos.application") }}</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(2, $event)">
-                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 2 ? 'bg-primary' : ''" />
-                  </div>
+                  <div data-column-resize-handle class="absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize" :class="configListResizingColumnIndex === 2 ? 'bg-primary/10' : ''" @mousedown="onConfigListColumnResizeStart(2, $event)" />
                 </div>
-                <div class="relative min-w-0 overflow-visible border-r border-border/70 pr-4 last:border-r-0">
+                <div class="relative min-w-0 border-r border-border/70 pr-3 last:border-r-0">
                   <span class="block truncate">{{ t("nacos.format") }}</span>
-                  <div data-column-resize-handle class="absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize items-center justify-center" @mousedown="onConfigListColumnResizeStart(3, $event)">
-                    <span class="pointer-events-none absolute left-1/2 top-1/2 h-4 w-px -translate-x-1/2 -translate-y-1/2 bg-border/80" :class="configListResizingColumnIndex === 3 ? 'bg-primary' : ''" />
-                  </div>
+                  <div data-column-resize-handle class="absolute -right-1 top-0 z-10 h-full w-2 cursor-col-resize" :class="configListResizingColumnIndex === 3 ? 'bg-primary/10' : ''" @mousedown="onConfigListColumnResizeStart(3, $event)" />
                 </div>
               </div>
               <button


### PR DESCRIPTION
Refs #3065

## 变更说明

- 修复 Nacos 配置编辑器中文本选区不高亮的问题，补齐编辑器选中态背景样式。
- 优化 Nacos 配置列表的列分隔视觉，在保持列宽可拖动的前提下，将分隔提示调整为简短竖线，避免遮挡列标题文字。
- 配置列表行内补充轻量列分隔，提升列边界辨识度。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）
<img width="781" height="141" alt="image" src="https://github.com/user-attachments/assets/70fb5870-0f01-409d-b396-bc32a5f49285" />


## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

补充：
- [x] `pnpm build` 通过

## 关联 Issue

Refs #3065