### PR TITLE
Allow concurrent DBX Web query execution

### DIFF
--- a/packages/node-core/src/web-backend.ts
+++ b/packages/node-core/src/web-backend.ts
@@ -204,7 +204,6 @@ export async function describeTable(config: ConnectionConfig, table: string, sch
 }
 
 export async function executeQuery(config: ConnectionConfig, sql: string, options?: QueryOptions): Promise<QueryResult> {
-  await ensureConnected(config);
   if (config.db_type === "mongodb") {
     if (parseMongoVersionCommand(sql)) {
       const res = await apiFetch("/api/mongo/server-version", {

--- a/packages/node-core/tests/web-backend.test.ts
+++ b/packages/node-core/tests/web-backend.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "vitest";
 
-import { loadConnections, resetWebAuthForTests } from "../src/web-backend.js";
+import { executeQuery, loadConnections, resetWebAuthForTests } from "../src/web-backend.js";
 
 const originalFetch = globalThis.fetch;
 const originalWebUrl = process.env.DBX_WEB_URL;
@@ -122,4 +122,50 @@ test("web backend still allows DBX Web instances with password auth disabled", a
   }) as typeof fetch;
 
   assert.deepEqual(await loadConnections(), []);
+});
+
+test("web backend executes concurrent SQL queries without pre-connecting", async () => {
+  process.env.DBX_WEB_URL = "http://127.0.0.1:4224";
+  delete process.env.DBX_WEB_PASSWORD;
+  const calls: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.endsWith("/api/auth/check")) {
+      return jsonResponse({ authenticated: true, required: false, setup_required: false });
+    }
+    if (url.endsWith("/api/connection/connect")) {
+      throw new Error("query execution should not call /api/connection/connect");
+    }
+    if (url.endsWith("/api/query/execute")) {
+      const body = JSON.parse(String(init?.body)) as { sql: string };
+      const n = Number(body.sql.match(/select\s+(\d+)/i)?.[1] ?? 0);
+      return jsonResponse({
+        columns: ["n"],
+        rows: [[n]],
+      });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  const config = {
+    id: "oracle-1",
+    name: "Oracle",
+    db_type: "oracle",
+    host: "127.0.0.1",
+    port: 1521,
+    username: "app",
+    password: "",
+    database: "orcl",
+    ssh_enabled: false,
+    ssl: false,
+  } as const;
+  const results = await Promise.all([1, 2, 3, 4].map((n) => executeQuery(config, `select ${n} as n from dual`)));
+
+  assert.deepEqual(
+    results.map((result) => result.rows[0]?.n),
+    [1, 2, 3, 4],
+  );
+  assert.equal(calls.filter((url) => url.endsWith("/api/connection/connect")).length, 0);
+  assert.equal(calls.filter((url) => url.endsWith("/api/query/execute")).length, 4);
 });


### PR DESCRIPTION
## Summary

This change lets the Node Web backend execute SQL queries through `/api/query/execute` without first calling `/api/connection/connect`.

## Why

When `DBX_WEB_URL` is set, both the CLI and MCP server use `@dbx-app/node-core`'s Web backend. The current `executeQuery()` path calls `/api/connection/connect` before every `/api/query/execute`.

That pre-connect step makes concurrent CLI/MCP queries unreliable. Multiple simultaneous requests for the same connection can supersede one another during the connection attempt phase and fail with:

```text
Connection attempt was superseded by a newer attempt
```

The Web query endpoint already accepts `connectionId` and creates or reuses a pool through the query execution path, so SQL queries do not need this UI-style connect step first.

## Change

- Removed the pre-query `ensureConnected(config)` call from `packages/node-core/src/web-backend.ts`.
- Added a Web backend regression test that runs concurrent SQL queries and asserts that `/api/connection/connect` is not called.

## Validation

```text
pnpm --filter @dbx-app/node-core test
pnpm --filter @dbx-app/node-core build
pnpm --filter @dbx-app/cli test
pnpm --filter @dbx-app/mcp-server test
```

Observed locally:

- node-core: 18 test files passed, 86 tests passed
- CLI: 3 test files passed, 42 tests passed
- MCP server: 3 test files passed, 36 tests passed

## Reproduction Context

With `DBX_WEB_URL` pointing at DBX Web, direct `/api/query/execute` calls can run concurrent Oracle queries successfully, but concurrent CLI/MCP queries fail before execution because they each call `/api/connection/connect` first.
