### PR TITLE
Fix: 修复点击表格默认查询行数受 SQL 结果行数影响

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1305,7 +1305,7 @@ async function openData() {
     logPhase("ensure-connected", { tabId });
     if (!config) throw new Error("Connection config not found");
 
-    const limit = tableOpenPageLimit(settingsStore.editorSettings.pageSize);
+    const limit = tableOpenPageLimit();
     const refreshTableMetaInBackground = async () => {
       const metadataStartedAt = performance.now();
       console.info("[DBX][openData:metadata:start]", {

--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -23,7 +23,7 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
   const connectionStore = useConnectionStore();
   const queryStore = useQueryStore();
   const settingsStore = useSettingsStore();
-  const pageLimit = tableOpenPageLimit(settingsStore.editorSettings.pageSize);
+  const pageLimit = tableOpenPageLimit();
 
   connectionStore.activeConnectionId = target.connectionId;
   const config = connectionStore.getConfig(target.connectionId);

--- a/apps/desktop/src/lib/table/tableOpenPageLimit.ts
+++ b/apps/desktop/src/lib/table/tableOpenPageLimit.ts
@@ -2,7 +2,7 @@ import { DEFAULT_RESULT_PAGE_SIZE, normalizeResultPageSize } from "@/lib/dataGri
 
 export const DEFAULT_TABLE_OPEN_PAGE_LIMIT = DEFAULT_RESULT_PAGE_SIZE;
 
-export function tableOpenPageLimit(preferredLimit?: unknown): number {
-  // Data tabs should reopen with the rows-per-page preference the grid persists.
-  return normalizeResultPageSize(preferredLimit, DEFAULT_TABLE_OPEN_PAGE_LIMIT);
+export function tableOpenPageLimit(): number {
+  // Opening a table should not inherit the mutable SQL result-grid rows-per-page setting.
+  return normalizeResultPageSize(DEFAULT_TABLE_OPEN_PAGE_LIMIT);
 }

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2672,7 +2672,7 @@ export const useQueryStore = defineStore("query", () => {
         countSql = plan.countSql;
         useAgentResultSession = plan.useAgentResultSession;
       } else if (tab.mode === "data") {
-        pageLimit = options?.pagination?.limit ?? tableOpenPageLimit(settingsStore.editorSettings.pageSize);
+        pageLimit = options?.pagination?.limit ?? tableOpenPageLimit();
         pageOffset = options?.pagination?.offset ?? 0;
       }
 
@@ -3243,7 +3243,7 @@ export const useQueryStore = defineStore("query", () => {
       pagination:
         tab.mode === "data"
           ? {
-              limit: tab.resultPageLimit ?? tableOpenPageLimit(useSettingsStore().editorSettings.pageSize),
+              limit: tab.resultPageLimit ?? tableOpenPageLimit(),
               offset: tab.resultPageOffset ?? 0,
             }
           : undefined,

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -2396,7 +2396,7 @@ test("data tab execution preserves pagination offset metadata", async () => {
   }
 });
 
-test("data tab default pagination follows persisted rows-per-page", async () => {
+test("data tab default pagination is independent from query result page size", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());
   const connectionStore = useConnectionStore();
@@ -2429,13 +2429,59 @@ test("data tab default pagination follows persisted rows-per-page", async () => 
   });
 
   try {
-    await store.executeTabSql(tabId, 'SELECT * FROM "users" LIMIT 1000;');
+    await store.executeTabSql(tabId, 'SELECT * FROM "users" LIMIT 100;');
 
     assert.equal(preparedPagination, false);
-    assert.equal(executeBody.maxRows, 1000);
-    assert.equal(executeBody.fetchSize, 1000);
-    assert.equal(tab.resultPageLimit, 1000);
+    assert.equal(executeBody.maxRows, 100);
+    assert.equal(executeBody.fetchSize, 100);
+    assert.equal(tab.resultPageLimit, 100);
     assert.equal(tab.resultPageOffset, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("reloading an evicted data tab preserves its saved pagination", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const settingsStore = useSettingsStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  let executeBody: any;
+
+  settingsStore.updateEditorSettings({ pageSize: 1000 });
+  connectionStore.addEphemeralConnection(conn("conn-1"));
+  const tabId = store.createTab("conn-1", "db", "users", "data", "public");
+  const tab = store.tabs.find((item) => item.id === tabId);
+  assert.ok(tab);
+  tab.sql = 'SELECT * FROM "public"."users" LIMIT 50 OFFSET 50;';
+  tab.lastExecutedSql = tab.sql;
+  tab.resultPageLimit = 50;
+  tab.resultPageOffset = 50;
+  tab.resultEvicted = true;
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/execute-multi") {
+      executeBody = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify([{ columns: ["id"], rows: [[51]], affected_rows: 0, execution_time_ms: 1 }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    await store.reloadEvictedTab(tabId);
+
+    assert.equal(executeBody.maxRows, 50);
+    assert.equal(executeBody.fetchSize, 50);
+    assert.equal(tab.resultPageLimit, 50);
+    assert.equal(tab.resultPageOffset, 50);
+    assert.equal(tab.resultEvicted, undefined);
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -48,10 +48,8 @@ test("normalizes saved query result page size", () => {
   assert.equal(normalizeEditorSettings({ pageSize: 0 }).pageSize, 100);
 });
 
-test("uses saved rows-per-page for table opens", () => {
+test("uses dedicated default row limit for table opens", () => {
   assert.equal(tableOpenPageLimit(), 100);
-  assert.equal(tableOpenPageLimit(500), 500);
-  assert.equal(tableOpenPageLimit(0), 100);
 });
 
 test("defaults export batch size to 2000 rows", () => {


### PR DESCRIPTION
## 背景

Issue #2199 最初反馈：SQL 编辑器查询结果下方的行数设置，会影响点击表格时默认查询的行数。这个问题曾在 `74165cc0` 中通过 `tableOpenPageLimit()` 专用路径修复。

后续 `1ff367653` 为了让 data tab 复用已保存的行数，把 `settingsStore.editorSettings.pageSize` 又作为 `tableOpenPageLimit()` 的 preferred limit 传入了点击表格、导航打开表和 data tab fallback 路径。由于 SQL 结果区的行数设置本身就写入 `editorSettings.pageSize`，所以 0.5.52 中又出现了两个入口共用行数的问题。

## 修改

- 恢复 `tableOpenPageLimit()` 的专用默认值，不再接收 SQL 结果页的 `editorSettings.pageSize`。
- 点击侧边栏表格、通过导航目标打开表，以及 data tab fallback 执行时，都不再从 SQL 结果页行数推导默认表格查询行数。
- 保留已有 data tab 自身的 `resultPageLimit` 优先级，避免刷新/恢复加载时丢失该 tab 已保存的分页状态。
- 恢复并补充回归测试，覆盖“默认表格查询行数不受 SQL 结果页行数影响”和“已有 data tab 恢复加载时保留自身分页”。

## 验证

- `pnpm exec vitest run packages/app-tests/queryStore.test.ts packages/app-tests/settingsStore.test.ts`
- `pnpm typecheck`
- `pnpm lint`（仅有既有 warning，无错误）
- `git diff --check`

Fixes #2199