### PR TITLE
1 修改:数据库查询不读取代理设置,解决查询慢的问题.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ DBX_*_x64-portable.zip
 .pnpm-store/*
 .dbx-web
 _dev
+setup.sh

--- a/crates/dbx-core/src/agent_manager.rs
+++ b/crates/dbx-core/src/agent_manager.rs
@@ -843,7 +843,9 @@ impl AgentManager {
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
-        let resp = reqwest::get(url).await.map_err(|e| format!("Download failed: {e}"))?;
+        let client =
+            reqwest::Client::builder().no_proxy().build().map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+        let resp = client.get(url).send().await.map_err(|e| format!("Download failed: {e}"))?;
         if !resp.status().is_success() {
             return Err(format!("Download failed with status: {}", resp.status()));
         }

--- a/crates/dbx-core/src/agent_service.rs
+++ b/crates/dbx-core/src/agent_service.rs
@@ -333,6 +333,7 @@ pub async fn fetch_registry() -> Result<AgentRegistry, String> {
     }
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
+        .no_proxy()
         .build()
         .map_err(|err| format!("Failed to create HTTP client: {err}"))?;
     let resp = crate::race_download(&client, REGISTRY_PATH, REGISTRY_R2_PATH, "dbx-agent-manager")
@@ -736,6 +737,7 @@ async fn download_with_progress(
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(300))
+        .no_proxy()
         .build()
         .map_err(|err| format!("Failed to create HTTP client: {err}"))?;
     let mut last_err = None;

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -772,7 +772,7 @@ fn ai_endpoint_is_loopback(config: &AiConfig) -> bool {
 }
 
 pub fn build_ai_http_client(config: &AiConfig, timeout_secs: u64) -> Result<reqwest::Client, String> {
-    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(timeout_secs));
+    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(timeout_secs)).no_proxy();
     if config.proxy_enabled && !config.proxy_url.trim().is_empty() && !ai_endpoint_is_loopback(config) {
         let proxy_url = normalize_ai_proxy_url(&config.proxy_url);
         let proxy = reqwest::Proxy::all(&proxy_url).map_err(|e| format!("Invalid AI proxy URL: {e}"))?;
@@ -2620,6 +2620,172 @@ mod tests {
         };
 
         build_ai_http_client(&config, 1).unwrap();
+    }
+
+    /// Regression test for the AI HTTP client's proxy behavior. Spins up local
+    /// TCP sockets to act as the AI endpoint and a candidate HTTP proxy, then
+    /// verifies three properties required by the reviewer:
+    ///
+    /// 1. When `proxy_enabled` is off, ambient `HTTP_PROXY` environment
+    ///    variables are ignored (`.no_proxy()` on the base builder), so the
+    ///    request reaches the endpoint directly and the proxy is never
+    ///    contacted.
+    /// 2. When `proxy_enabled` is on with a non-loopback endpoint, the
+    ///    explicitly configured AI proxy takes effect (the proxy receives a
+    ///    `CONNECT` tunnel request).
+    /// 3. When `proxy_enabled` is on but the endpoint is loopback, the proxy
+    ///    is bypassed so the request connects directly.
+    #[tokio::test]
+    async fn ai_http_client_proxy_behavior() {
+        use std::net::UdpSocket;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        // The target server binds to 0.0.0.0 so it is reachable both via the
+        // loopback address (for the loopback-bypass case) and via the host's
+        // non-loopback interface IP (for the proxy-applied cases, where
+        // `ai_endpoint_is_loopback` must return false).
+        let target = TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let target_port = target.local_addr().unwrap().port();
+        let loopback_url = format!("http://127.0.0.1:{target_port}/v1/models");
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = target.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0_u8; 1024];
+                    let _ = stream.read(&mut buf).await;
+                    let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}";
+                    let _ = stream.write_all(resp).await;
+                });
+            }
+        });
+
+        // Find a non-loopback local IP so the endpoint is not treated as
+        // loopback by `ai_endpoint_is_loopback`. This uses a "connected" UDP
+        // socket to discover the routing interface without sending packets.
+        let non_loopback_ip = (|| {
+            let s = UdpSocket::bind("0.0.0.0:0").ok()?;
+            s.connect("8.8.8.8:80").ok()?;
+            let addr = s.local_addr().ok()?;
+            match addr.ip() {
+                std::net::IpAddr::V4(v4) if !v4.is_loopback() => Some(v4),
+                _ => None,
+            }
+        })();
+        // If the sandbox has no non-loopback interface, skip the cases that
+        // depend on it rather than failing the build. The loopback-bypass
+        // case still runs.
+        let external_url = non_loopback_ip.map(|ip| format!("http://{ip}:{target_port}/v1/models"));
+
+        // Candidate proxy: counts how many connections it receives. It replies
+        // to HTTP CONNECT so that an explicit AI proxy tunnel can be observed.
+        let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let connect_count = Arc::new(AtomicU32::new(0));
+        let count_for_server = connect_count.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = proxy.accept().await else {
+                    break;
+                };
+                count_for_server.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    let mut buf = vec![0_u8; 4096];
+                    let n = stream.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    if req.starts_with("CONNECT ") {
+                        // Acknowledge the tunnel. We do not forward the
+                        // tunneled traffic; observing the CONNECT is enough
+                        // for this test.
+                        let _ = stream.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n").await;
+                        // Drain until the client closes the tunnel.
+                        loop {
+                            if stream.read(&mut buf).await.unwrap_or(0) == 0 {
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        let proxy_connections = || connect_count.load(Ordering::SeqCst);
+
+        let base_config = AiConfig {
+            provider: AiProvider::OpenaiCompatible,
+            api_key: "key".to_string(),
+            auth_method: AiAuthMethod::Bearer,
+            endpoint: external_url.clone().unwrap_or_else(|| loopback_url.clone()),
+            model: "gpt-4o".to_string(),
+            api_style: AiApiStyle::Completions,
+            proxy_enabled: false,
+            proxy_url: String::new(),
+            enable_thinking: true,
+            reasoning_level: AiReasoningLevel::Default,
+            context_window: None,
+            codex_cli_path: None,
+            codex_cli_env: Default::default(),
+        };
+
+        // --- Case 1: ambient HTTP_PROXY ignored when proxy_enabled is off ---
+        // Point the environment at our candidate proxy; with `.no_proxy()` on
+        // the base builder the request must bypass it and reach the target.
+        if let Some(url) = &external_url {
+            safety_env_set("HTTP_PROXY", &format!("http://{proxy_addr}"));
+            safety_env_set("http_proxy", &format!("http://{proxy_addr}"));
+            let config = AiConfig { endpoint: url.clone(), ..base_config.clone() };
+            let client = build_ai_http_client(&config, 5).unwrap();
+            let before = proxy_connections();
+            let resp = client.get(url).send().await.unwrap();
+            assert!(resp.status().is_success());
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            assert_eq!(proxy_connections(), before, "ambient HTTP_PROXY must be ignored when proxy_enabled is off");
+            safety_env_unset("HTTP_PROXY");
+            safety_env_unset("http_proxy");
+        }
+
+        // --- Case 2: explicit AI proxy is applied for non-loopback endpoints ---
+        if let Some(url) = &external_url {
+            let config = AiConfig {
+                proxy_enabled: true,
+                proxy_url: proxy_addr.to_string(),
+                endpoint: url.clone(),
+                ..base_config.clone()
+            };
+            let client = build_ai_http_client(&config, 5).unwrap();
+            let before = proxy_connections();
+            // The mock proxy acknowledges CONNECT but does not forward
+            // tunneled traffic, so the request itself will not complete.
+            // We only need to confirm the proxy was contacted.
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), client.get(url).send()).await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            assert!(proxy_connections() > before, "explicit AI proxy must be applied for non-loopback endpoints");
+        }
+
+        // --- Case 3: loopback endpoint bypasses the explicit AI proxy ---
+        let config = AiConfig {
+            endpoint: loopback_url.clone(),
+            proxy_enabled: true,
+            proxy_url: proxy_addr.to_string(),
+            ..base_config
+        };
+        let client = build_ai_http_client(&config, 5).unwrap();
+        let before = proxy_connections();
+        let resp = client.get(&loopback_url).send().await.unwrap();
+        assert!(resp.status().is_success());
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(proxy_connections(), before, "loopback endpoint must bypass the AI proxy");
+    }
+
+    fn safety_env_set(key: &str, value: &str) {
+        std::env::set_var(key, value);
+    }
+
+    fn safety_env_unset(key: &str) {
+        std::env::remove_var(key);
     }
 
     #[test]

--- a/crates/dbx-core/src/cloud_sync.rs
+++ b/crates/dbx-core/src/cloud_sync.rs
@@ -40,6 +40,12 @@ const SECRET_KEYS: &[&str] = &[
 const SSH_TUNNEL_SECRET_PREFIX: &str = "ssh_tunnels.";
 const TRANSPORT_LAYER_SECRET_PREFIX: &str = "transport_layers.";
 
+/// Builds a reqwest client that ignores system/environment proxies so cloud
+/// sync always connects directly. Consistent with `db::http_client_builder`.
+fn no_proxy_client() -> Client {
+    Client::builder().no_proxy().build().unwrap_or_else(|_| Client::new())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebDavConfig {
@@ -352,7 +358,7 @@ pub async fn resolve_webdav_sync_secrets_passphrase(storage: &Storage) -> Result
 
 impl WebDavClient {
     pub fn new(config: WebDavConfig) -> Self {
-        Self { http: Client::new(), config }
+        Self { http: no_proxy_client(), config }
     }
 
     pub fn remote_path(&self) -> String {
@@ -446,7 +452,7 @@ impl WebDavClient {
 
 impl SnippetSyncClient {
     pub fn new(config: SnippetSyncConfig) -> Self {
-        Self { http: Client::new(), config }
+        Self { http: no_proxy_client(), config }
     }
 
     pub async fn test(&self) -> Result<(), String> {

--- a/crates/dbx-core/src/db/http_tunnel.rs
+++ b/crates/dbx-core/src/db/http_tunnel.rs
@@ -101,7 +101,7 @@ impl HttpTunnelEndpoint {
             connect_timeout: effective_connect_timeout(connect_timeout_secs),
             target_host: remote_host.to_string(),
             target_port: remote_port,
-            client: Client::new(),
+            client: Client::builder().no_proxy().build().unwrap_or_else(|_| Client::new()),
         })
     }
 }

--- a/crates/dbx-core/src/db/influxdb_driver.rs
+++ b/crates/dbx-core/src/db/influxdb_driver.rs
@@ -33,7 +33,8 @@ impl InfluxdbClient {
         url_params: Option<String>,
         timeout: Duration,
     ) -> Self {
-        let http = HttpClient::builder().connect_timeout(timeout).build().unwrap_or_else(|_| HttpClient::new());
+        let http =
+            HttpClient::builder().connect_timeout(timeout).no_proxy().build().unwrap_or_else(|_| HttpClient::new());
         Self {
             http,
             base_url: url.trim_end_matches('/').to_string(),
@@ -90,7 +91,7 @@ impl InfluxdbClient {
 }
 
 fn build_http_client(ca_cert_path: Option<&str>, timeout: Duration) -> Result<HttpClient, String> {
-    let mut builder = HttpClient::builder().connect_timeout(timeout);
+    let mut builder = HttpClient::builder().connect_timeout(timeout).no_proxy();
     if let Some(path) = ca_cert_path.map(str::trim).filter(|path| !path.is_empty()) {
         let path = expand_cert_path(path);
         let cert_bytes =

--- a/crates/dbx-core/src/nacos/http.rs
+++ b/crates/dbx-core/src/nacos/http.rs
@@ -28,7 +28,7 @@ pub struct NacosOpenApiAdmin {
 
 impl NacosOpenApiAdmin {
     pub fn new(cfg: NacosAdminConfig) -> Result<Self, String> {
-        let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS));
+        let mut builder = reqwest::Client::builder().timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS)).no_proxy();
         if cfg.tls_skip_verify {
             builder = builder.danger_accept_invalid_certs(true);
         }


### PR DESCRIPTION
## 变更说明
核心思路：给所有"意外继承系统/环境代理"的 reqwest 客户端显式加 .no_proxy()，使其直连。这与项目已有约定（db/mod.rs:47 的 http_client_builder() 已用 .no_proxy()）保持一致。

## 变更类型

- [ ] 新功能
- [ x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建


## 关联 Issue
Related #3111 
