### PR TITLE
Fix: 修复 Kafka Kerberos 连接缺少 JRE 模块

### DIFF
--- a/.github/workflows/agents-release.yml
+++ b/.github/workflows/agents-release.yml
@@ -174,7 +174,7 @@ jobs:
         include:
           - jre-key: "21"
             java-version: "21"
-            modules: "java.base,java.sql,java.sql.rowset,java.naming,java.management,java.desktop,java.security.jgss,java.security.sasl,jdk.charsets,java.scripting,java.compiler"
+            modules: "java.base,java.sql,java.sql.rowset,java.naming,java.management,java.desktop,java.security.jgss,java.security.sasl,jdk.security.auth,jdk.security.jgss,jdk.charsets,java.scripting,java.compiler"
     steps:
       - uses: actions/setup-java@v4
         with:
@@ -385,7 +385,7 @@ jobs:
           {
             "jres": {
               "21": {
-                "version": "21.0.12",
+                "version": "21.0.12+kerberos.1",
                 "platforms": {
           ${JRE21_PLATFORMS}
                 }

--- a/agents/scripts/validate_agents.py
+++ b/agents/scripts/validate_agents.py
@@ -236,6 +236,14 @@ def validate_release_runtime_keys(root: Path) -> list[str]:
             f"registry must publish Java {DEFAULT_AGENT_JRE_KEY} under JRE key {DEFAULT_AGENT_JRE_KEY}",
         ),
         (
+            r"jdk\.security\.auth",
+            "release workflow JRE must include jdk.security.auth for Kafka Kerberos LoginModule support",
+        ),
+        (
+            r"jdk\.security\.jgss",
+            "release workflow JRE must include jdk.security.jgss for Kafka GSSAPI SASL support",
+        ),
+        (
             r"legacy-placeholder\.jar",
             "native-only registry entries must publish a legacy jar placeholder for older DBX clients",
         ),

--- a/agents/scripts/validate_agents_test.py
+++ b/agents/scripts/validate_agents_test.py
@@ -318,6 +318,7 @@ class ValidateAgentsTest(unittest.TestCase):
                         include:
                           - jre-key: "21"
                             java-version: "21"
+                            modules: "java.base,jdk.security.auth,jdk.security.jgss"
                     detect_jre_key() {
                       case "$name" in
                         *) echo "21" ;;
@@ -372,6 +373,8 @@ class ValidateAgentsTest(unittest.TestCase):
                     "release workflow must build the default JRE with key 21",
                     "agents must use JRE key 21",
                     "registry must publish Java 21 under JRE key 21",
+                    "release workflow JRE must include jdk.security.auth for Kafka Kerberos LoginModule support",
+                    "release workflow JRE must include jdk.security.jgss for Kafka GSSAPI SASL support",
                     "native-only registry entries must publish a legacy jar placeholder for older DBX clients",
                     "release workflow must not build Java 21 under JRE key 17",
                     "agents must not use JRE key 17",

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -3375,6 +3375,24 @@ async function browseHiveKerberosFile(target: "krb5" | "jaas") {
   }
 }
 
+async function browseKafkaKerberosFile(target: "keytab" | "krb5") {
+  if (isTauriRuntime()) {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const selected = await open({
+      title: target === "keytab" ? t("connection.kafkaKerberosKeytabBrowse") : t("connection.kafkaKerberosKrb5ConfBrowse"),
+      multiple: false,
+      filters: [{ name: "Kerberos", extensions: target === "keytab" ? ["keytab", "kt", "*"] : ["conf", "ini", "*"] }],
+    });
+    if (selected && typeof selected === "string") {
+      if (target === "keytab") {
+        mqKafkaKerberosKeytabPath.value = selected;
+      } else {
+        mqKafkaKrb5ConfPath.value = selected;
+      }
+    }
+  }
+}
+
 async function browseDbFilePath() {
   if (isTauriRuntime()) {
     const { open } = await import("@tauri-apps/plugin-dialog");
@@ -4027,7 +4045,17 @@ function openExternalUrl(url: string) {
                     </div>
                     <div class="grid grid-cols-4 items-center gap-4">
                       <Label :class="connectionLabelClass">{{ t("connection.kafkaKerberosKeytab") }}</Label>
-                      <Input v-model="mqKafkaKerberosKeytabPath" class="col-span-3" :placeholder="t('connection.kafkaKerberosKeytabPlaceholder')" />
+                      <div class="col-span-3 flex items-center gap-1">
+                        <Input v-model="mqKafkaKerberosKeytabPath" class="flex-1" :placeholder="t('connection.kafkaKerberosKeytabPlaceholder')" />
+                        <Tooltip v-if="isDesktop">
+                          <TooltipTrigger as-child>
+                            <Button variant="outline" size="icon" class="h-9 w-9 shrink-0" @click="browseKafkaKerberosFile('keytab')">
+                              <FolderOpen class="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>{{ t("connection.kafkaKerberosKeytabBrowse") }}</TooltipContent>
+                        </Tooltip>
+                      </div>
                     </div>
                     <div class="grid grid-cols-4 items-center gap-4">
                       <Label :class="connectionLabelClass">{{ t("connection.kafkaKerberosServiceName") }}</Label>
@@ -4035,7 +4063,17 @@ function openExternalUrl(url: string) {
                     </div>
                     <div class="grid grid-cols-4 items-center gap-4">
                       <Label :class="connectionLabelClass">{{ t("connection.kafkaKerberosKrb5Conf") }}</Label>
-                      <Input v-model="mqKafkaKrb5ConfPath" class="col-span-3" :placeholder="t('connection.kafkaKerberosKrb5ConfPlaceholder')" />
+                      <div class="col-span-3 flex items-center gap-1">
+                        <Input v-model="mqKafkaKrb5ConfPath" class="flex-1" :placeholder="t('connection.kafkaKerberosKrb5ConfPlaceholder')" />
+                        <Tooltip v-if="isDesktop">
+                          <TooltipTrigger as-child>
+                            <Button variant="outline" size="icon" class="h-9 w-9 shrink-0" @click="browseKafkaKerberosFile('krb5')">
+                              <FolderOpen class="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>{{ t("connection.kafkaKerberosKrb5ConfBrowse") }}</TooltipContent>
+                        </Tooltip>
+                      </div>
                     </div>
                     <div class="grid grid-cols-4 items-start gap-4">
                       <div></div>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -307,6 +307,8 @@ export default {
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "Kafka Kerberos principal is required",
     kafkaKerberosKeytabRequired: "Kafka Kerberos keytab path is required",
+    kafkaKerberosKeytabBrowse: "Choose Keytab",
+    kafkaKerberosKrb5ConfBrowse: "Choose krb5.conf",
     kafkaKerberosKeytabPlaceholder: "Path on DBX Agent machine, e.g. /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "Optional path on DBX Agent machine, e.g. /etc/krb5.conf",
     kafkaKerberosPathHint: "The keytab and krb5.conf paths are read by DBX Agent and must exist on the machine running DBX Agent; files are not uploaded from this browser.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -431,6 +431,8 @@ export default withEnglishFallback({
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "Kafka Kerberos principal no puede estar vacío",
     kafkaKerberosKeytabRequired: "La ruta del keytab de Kafka Kerberos no puede estar vacía",
+    kafkaKerberosKeytabBrowse: "Elegir Keytab",
+    kafkaKerberosKrb5ConfBrowse: "Elegir krb5.conf",
     kafkaKerberosKeytabPlaceholder: "Ruta en la máquina donde se ejecuta DBX Agent, por ejemplo /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "Opcional, ruta en la máquina donde se ejecuta DBX Agent, por ejemplo /etc/krb5.conf",
     kafkaKerberosPathHint: "Las rutas de keytab y krb5.conf son leídas por DBX Agent y deben existir en la máquina donde se ejecuta DBX Agent; no se subirán archivos desde el navegador actual.",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -429,6 +429,8 @@ export default withEnglishFallback({
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "Kafka Kerberos principal non può essere vuoto",
     kafkaKerberosKeytabRequired: "Il percorso del keytab Kafka Kerberos non può essere vuoto",
+    kafkaKerberosKeytabBrowse: "Scegli Keytab",
+    kafkaKerberosKrb5ConfBrowse: "Scegli krb5.conf",
     kafkaKerberosKeytabPlaceholder: "Percorso sulla macchina DBX Agent, ad esempio /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "Opzionale, percorso sulla macchina DBX Agent, ad esempio /etc/krb5.conf",
     kafkaKerberosPathHint: "I percorsi di keytab e krb5.conf vengono letti da DBX Agent e devono esistere sulla macchina in cui è in esecuzione DBX Agent; non vengono caricati file dal browser corrente.",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -429,6 +429,8 @@ export default withEnglishFallback({
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "Kafka Kerberos プリンシパルは必須です",
     kafkaKerberosKeytabRequired: "Kafka Kerberos keytab のパスは必須です",
+    kafkaKerberosKeytabBrowse: "Keytab を選択",
+    kafkaKerberosKrb5ConfBrowse: "krb5.conf を選択",
     kafkaKerberosKeytabPlaceholder: "DBX Agent が動作するマシンのパス。例: /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "オプション。DBX Agent が動作するマシンのパス。例: /etc/krb5.conf",
     kafkaKerberosPathHint: "keytab と krb5.conf のパスは DBX Agent が読み取るため、DBX Agent が動作するマシン上に存在する必要があります。ブラウザからファイルをアップロードすることはありません。",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -430,6 +430,8 @@ export default withEnglishFallback({
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "O principal do Kafka Kerberos não pode estar vazio",
     kafkaKerberosKeytabRequired: "O caminho do keytab do Kafka Kerberos não pode estar vazio",
+    kafkaKerberosKeytabBrowse: "Escolher Keytab",
+    kafkaKerberosKrb5ConfBrowse: "Escolher krb5.conf",
     kafkaKerberosKeytabPlaceholder: "Caminho na máquina do DBX Agent, por exemplo /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "Opcional, caminho na máquina do DBX Agent, por exemplo /etc/krb5.conf",
     kafkaKerberosPathHint: "Os caminhos do keytab e do krb5.conf são lidos pelo DBX Agent e devem existir na máquina onde o DBX Agent é executado; os arquivos não são enviados do navegador atual.",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -309,6 +309,8 @@ export default withEnglishFallback({
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "Kafka Kerberos principal 不能为空",
     kafkaKerberosKeytabRequired: "Kafka Kerberos keytab 路径不能为空",
+    kafkaKerberosKeytabBrowse: "选择 Keytab",
+    kafkaKerberosKrb5ConfBrowse: "选择 krb5.conf",
     kafkaKerberosKeytabPlaceholder: "DBX Agent 所在机器路径，例如 /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "可选，DBX Agent 所在机器路径，例如 /etc/krb5.conf",
     kafkaKerberosPathHint: "keytab 和 krb5.conf 路径由 DBX Agent 读取，必须存在于运行 DBX Agent 的机器上；不会从当前浏览器上传文件。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -429,6 +429,8 @@ export default withEnglishFallback({
     kafkaKerberosKrb5Conf: "krb5.conf",
     kafkaKerberosPrincipalRequired: "Kafka Kerberos principal 不能為空",
     kafkaKerberosKeytabRequired: "Kafka Kerberos keytab 路徑不能為空",
+    kafkaKerberosKeytabBrowse: "選擇 Keytab",
+    kafkaKerberosKrb5ConfBrowse: "選擇 krb5.conf",
     kafkaKerberosKeytabPlaceholder: "DBX Agent 所在機器路徑，例如 /etc/security/keytabs/user.keytab",
     kafkaKerberosKrb5ConfPlaceholder: "可選，DBX Agent 所在機器路徑，例如 /etc/krb5.conf",
     kafkaKerberosPathHint: "keytab 和 krb5.conf 路徑由 DBX Agent 讀取，必須存在於執行 DBX Agent 的機器上；不會從當前瀏覽器上傳檔案。",


### PR DESCRIPTION
## 背景

用户在 #3124 里反馈：连接启用了 Kerberos 认证的 Kafka 集群时，测试连接报错 `No LoginModule found for com.sun.security.auth.module.Krb5LoginModule`。

Issue 截图中用户填写的是 Windows 桌面端的 `D:\...` 本地路径。这个配置本身是合理的：Kafka Kerberos 的 `keytab` 和 `krb5.conf` 路径应理解为 **DBX Agent 所在机器上的路径**。

- 桌面端 DBX：Agent 运行在当前用户电脑上，所以 Windows 本地路径是有效的。
- Web/远程 Agent 部署：Agent 运行在服务器或远程机器上，所以必须填写那台 Agent 机器能访问到的路径。

这次报错不是用户 principal/keytab 路径写法导致的，而是 DBX 发布流程裁剪 managed JRE 时缺少 Kerberos/GSSAPI 相关 JDK 模块。

## 修改

- 在 agent release 的 JRE 21 `jlink` 模块列表中加入：
  - `jdk.security.auth`：提供 `com.sun.security.auth.module.Krb5LoginModule`
  - `jdk.security.jgss`：提供 Kafka GSSAPI SASL 客户端所需实现
- 将 registry 中 JRE 21 版本标记更新为 `21.0.12+kerberos.1`，确保已经安装旧裁剪 JRE 的用户能触发 JRE 更新。
- 在 agent 校验脚本中加入这两个模块的必需检查，避免后续 release 配置回退。
- 桌面端 Kafka Kerberos 配置里为 `keytab` 和 `krb5.conf` 增加文件选择按钮，方便用户选择本机文件路径。
- Web/远程 Agent 场景仍保留手动输入路径，因为浏览器选择到的是用户本机文件，不一定是 Agent 机器上的文件。

## 验证

- `python3 -m unittest validate_agents_test`
- `./gradlew :kafka:test`
- `python3 scripts/validate_agents.py`
- `pnpm typecheck`
- 使用临时 MIT KDC + Kafka SASL/GSSAPI 环境做真实连接验证：
  - KDC realm: `DBX.TEST`
  - Kafka service principal: `kafka/kafka-kerberos@DBX.TEST`
  - Client principal: `dbx-client@DBX.TEST`
  - 在 JDK 21 runner 中用本 PR 的模块列表 `jlink` 出临时 DBX JRE
  - 使用该裁剪 JRE 启动 `dbx-agent-kafka.jar`，通过 JSON-RPC 调用 `test_connection`
  - 返回 `ok=true`，`clusterId=DBXKerberosKafka000000000001`
  - agent stderr 中确认 `Successfully logged in.`

Fixes #3124