### PR TITLE
feat(sidebar): 优化双击模式下容器节点单击展开

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -869,7 +869,9 @@ function onClick(event: MouseEvent) {
   }
   selectSingleTreeNode(props.node);
   rowRef.value?.focus({ preventScroll: true });
-  if (settingsStore.editorSettings.sidebarActivation === "double") return;
+  // In double-click mode, container nodes (databases, schemas, groups) still
+  // toggle on single click; data objects are only selected and open on double
+  // click. treeNodeRowAction returns "none" for data objects in double mode.
   runRowClickAction(event.detail);
 }
 

--- a/apps/desktop/src/lib/sidebar/treeNodeClick.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeClick.ts
@@ -31,7 +31,18 @@ export function isDocumentBrowserTreeNode(type: TreeNodeType): boolean {
 }
 
 export function treeNodeRowAction(type: TreeNodeType, canExpand: boolean, activation: SidebarActivation = "single"): TreeNodeRowAction {
-  if (activation === "double") return "none";
+  if (activation === "double") {
+    // In double-click mode, container nodes (databases, schemas, groups,
+    // connections) still expand on single click so navigation doesn't require
+    // double-clicking to traverse the tree. Data objects (tables, procedures,
+    // etc.) are only selected on single click and opened on double click.
+    if (dataNodeTypes.has(type)) return "none";
+    if (sourceNodeTypes.has(type)) return "none";
+    if (savedSqlNodeTypes.has(type)) return "none";
+    if (toggleLeafNodeTypes.has(type)) return "none";
+    if (canExpand) return "toggle";
+    return "none";
+  }
   if (dataNodeTypes.has(type)) return "open-data";
   if (toggleLeafNodeTypes.has(type)) return "toggle";
   if (canExpand) return "toggle";

--- a/packages/app-tests/treeNodeClick.test.ts
+++ b/packages/app-tests/treeNodeClick.test.ts
@@ -10,8 +10,32 @@ test("table and view rows open data without toggling structure groups", () => {
 test("double click navigation mode selects rows on single click", () => {
   assert.equal(treeNodeRowAction("table", true, "double"), "none");
   assert.equal(treeNodeRowAction("view", true, "double"), "none");
+  assert.equal(treeNodeRowAction("materialized_view", true, "double"), "none");
   assert.equal(treeNodeRowAction("procedure", false, "double"), "none");
+  assert.equal(treeNodeRowAction("function", false, "double"), "none");
+  assert.equal(treeNodeRowAction("sequence", false, "double"), "none");
+  assert.equal(treeNodeRowAction("package", false, "double"), "none");
+  assert.equal(treeNodeRowAction("package-body", false, "double"), "none");
   assert.equal(treeNodeRowAction("saved-sql-file", false, "double"), "none");
+});
+
+test("double click navigation mode still toggles container nodes on single click", () => {
+  assert.equal(treeNodeRowAction("connection", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("database", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("schema", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("group-columns", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("group-tables", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("group-views", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("group-procedures", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("group-functions", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("group-sequences", true, "double"), "toggle");
+});
+
+test("double click navigation mode does not toggle leaf metadata nodes on single click", () => {
+  assert.equal(treeNodeRowAction("column", false, "double"), "none");
+  assert.equal(treeNodeRowAction("index", false, "double"), "none");
+  assert.equal(treeNodeRowAction("fkey", false, "double"), "none");
+  assert.equal(treeNodeRowAction("trigger", false, "double"), "none");
 });
 
 test("double click navigation mode opens actionable rows on double click", () => {
@@ -80,8 +104,9 @@ test("database and schema rows open object browser only on double click", () => 
   assert.equal(treeNodeRowAction("schema", true), "toggle");
   assert.equal(treeNodeRowDoubleClickAction("database", true), "open-object-browser");
   assert.equal(treeNodeRowDoubleClickAction("schema", true), "open-object-browser");
-  assert.equal(treeNodeRowAction("database", true, "double"), "none");
-  assert.equal(treeNodeRowAction("schema", true, "double"), "none");
+  // In double-click mode, container nodes still toggle on single click
+  assert.equal(treeNodeRowAction("database", true, "double"), "toggle");
+  assert.equal(treeNodeRowAction("schema", true, "double"), "toggle");
 });
 
 test("double click navigation mode opens object browser for database and schema rows", () => {


### PR DESCRIPTION
## 优化内容

优化侧边栏"双击打开"导航模式（`sidebarActivation = "double"`）的交互体验。

### 问题

在"双击打开"模式下，**所有节点**（包括连接、数据库、Schema、分组等容器节点）都需要双击才能展开/折叠，导致导航层级时操作繁琐。

### 改动

| 节点类型 | 优化前（双击模式） | 优化后（双击模式） |
|---------|------------------|------------------|
| 连接 / 数据库 / Schema / 分组 | 双击展开 | **单击展开** |
| 表 / 视图 / 物化视图 | 单击只选中，双击打开数据 | 单击只选中，双击打开数据（不变） |
| 存储过程 / 函数 / 序列 / 包 | 单击只选中，双击查看源码 | 单击只选中，双击查看源码（不变） |
| Saved SQL 文件 | 单击只选中，双击打开 | 单击只选中，双击打开（不变） |
| 浏览对象节点 | 单击只选中，双击打开 | 单击只选中，双击打开（不变） |

### 实现方式

- `treeNodeRowAction`：在 `"double"` 模式下，容器节点（`canExpand = true` 且非数据对象）返回 `"toggle"` 而非 `"none"`，数据对象仍返回 `"none"`
- `TreeItem.vue` 的 `onClick`：移除 `"double"` 模式下的提前 `return`，让容器节点单击触发 toggle

### 改动文件

- `apps/desktop/src/lib/sidebar/treeNodeClick.ts` — 核心逻辑
- `apps/desktop/src/components/sidebar/TreeItem.vue` — 移除提前 return
- `packages/app-tests/treeNodeClick.test.ts` — 新增 2 个测试 + 更新 1 个旧测试

### 测试

- typecheck 通过
- 85 个相关测试全部通过