### PR TITLE
修复对象浏览器多选表缺少批量清空入口

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -80,7 +80,7 @@ import QueryEditor from "@/components/editor/QueryEditor.vue";
 import DdlViewDialog from "./DdlViewDialog.vue";
 import { formatSqlForDisplay, sqlFormatDialectForDbType, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
 import { isCancelSearchShortcut } from "@/lib/editor/keyboardShortcuts";
-import { batchTableEmptyFeedback, runBatchTableEmpty } from "@/lib/sidebar/batchTableEmpty";
+import { batchTableEmptyFeedback, buildBatchTableEmptyPlan, runBatchTableEmpty, type BatchTableEmptyPlanItem } from "@/lib/sidebar/batchTableEmpty";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
   buildObjectBrowserRows,
@@ -205,7 +205,7 @@ const batchTruncatePreviewSql = ref("");
 const batchTruncateCascade = ref(false);
 const showBatchEmptyConfirm = ref(false);
 const batchEmptyPreviewSql = ref("");
-const batchEmptyTargets = ref<ObjectBrowserRow[]>([]);
+const batchEmptyPlan = ref<BatchTableEmptyPlanItem<ObjectBrowserRow>[]>([]);
 // Paste table dialog state
 const showPasteDialog = ref(false);
 const pasteTableMode = ref<PasteTableMode>("structure-and-data");
@@ -1460,40 +1460,36 @@ async function confirmBatchTruncateTables() {
 }
 
 async function refreshBatchEmptyPreviewSql(targets: ObjectBrowserRow[]) {
-  const statements: string[] = [];
-  for (const row of targets) {
-    const sql = await buildEmptyTableSql(tableAdminSqlOptions(row)).catch(() => "");
-    if (sql) statements.push(sql);
-  }
-  batchEmptyPreviewSql.value = statements.join("\n");
+  const plan = await buildBatchTableEmptyPlan(targets, (row) => buildEmptyTableSql(tableAdminSqlOptions(row)));
+  // Freeze the reviewed SQL with its target so confirmation cannot execute a different destructive statement.
+  batchEmptyPlan.value = plan;
+  batchEmptyPreviewSql.value = plan.map(({ sql }) => sql).join("\n");
 }
 
 function requestBatchEmptyTables() {
   const targets = [...selectedTableRows.value];
   if (targets.length === 0) return;
-  batchEmptyTargets.value = targets;
+  batchEmptyPlan.value = [];
   batchEmptyPreviewSql.value = "";
   void refreshBatchEmptyPreviewSql(targets)
     .then(() => {
-      if (!batchEmptyPreviewSql.value.trim()) throw new Error("Empty table SQL preview is unavailable");
       showBatchEmptyConfirm.value = true;
     })
     .catch((e: any) => {
-      batchEmptyTargets.value = [];
+      batchEmptyPlan.value = [];
       toast(t("contextMenu.tableOperationFailed", { message: e?.message || String(e) }), 5000);
     });
 }
 
 async function confirmBatchEmptyTables() {
-  const targets = batchEmptyTargets.value.slice();
-  if (targets.length === 0) return;
+  const plan = batchEmptyPlan.value.slice();
+  if (plan.length === 0) return;
   const asynchronousMutation = effectiveDatabaseType.value === "clickhouse";
-  const result = await runBatchTableEmpty(targets, async (row) => {
-    const sql = await buildEmptyTableSql(tableAdminSqlOptions(row));
+  const result = await runBatchTableEmpty(plan, async ({ sql }) => {
     await api.executeQuery(props.connection.id, props.database, sql);
   });
   for (const failure of result.failed) {
-    console.error(`Failed to empty table "${failure.target.name}":`, failure.error);
+    console.error(`Failed to empty table "${failure.target.target.name}":`, failure.error);
   }
   const feedback = batchTableEmptyFeedback(result, asynchronousMutation);
   if (feedback === "success") {
@@ -1505,7 +1501,7 @@ async function confirmBatchEmptyTables() {
   } else {
     toast(t("contextMenu.batchEmptyPartialFail", { success: result.succeeded.length, failed: result.failed.length }), 5000);
   }
-  batchEmptyTargets.value = [];
+  batchEmptyPlan.value = [];
   showBatchEmptyConfirm.value = false;
   if (result.succeeded.length > 0) {
     clearTableSelection();
@@ -2848,10 +2844,10 @@ function getObjectBrowserMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
 
   <DangerConfirmDialog
     v-model:open="showBatchEmptyConfirm"
-    :title="t('contextMenu.confirmBatchEmptyTitle', { count: batchEmptyTargets.length })"
-    :message="t('contextMenu.confirmBatchEmptyMessage', { count: batchEmptyTargets.length })"
+    :title="t('contextMenu.confirmBatchEmptyTitle', { count: batchEmptyPlan.length })"
+    :message="t('contextMenu.confirmBatchEmptyMessage', { count: batchEmptyPlan.length })"
     :sql="batchEmptyPreviewSql"
-    :confirm-label="t('contextMenu.batchEmpty', { count: batchEmptyTargets.length })"
+    :confirm-label="t('contextMenu.batchEmpty', { count: batchEmptyPlan.length })"
     @confirm="confirmBatchEmptyTables"
   />
 

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -80,6 +80,7 @@ import QueryEditor from "@/components/editor/QueryEditor.vue";
 import DdlViewDialog from "./DdlViewDialog.vue";
 import { formatSqlForDisplay, sqlFormatDialectForDbType, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
 import { isCancelSearchShortcut } from "@/lib/editor/keyboardShortcuts";
+import { batchTableEmptyFeedback, runBatchTableEmpty } from "@/lib/sidebar/batchTableEmpty";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
   buildObjectBrowserRows,
@@ -202,6 +203,9 @@ const batchDropPreviewSql = ref("");
 const showBatchTruncateConfirm = ref(false);
 const batchTruncatePreviewSql = ref("");
 const batchTruncateCascade = ref(false);
+const showBatchEmptyConfirm = ref(false);
+const batchEmptyPreviewSql = ref("");
+const batchEmptyTargets = ref<ObjectBrowserRow[]>([]);
 // Paste table dialog state
 const showPasteDialog = ref(false);
 const pasteTableMode = ref<PasteTableMode>("structure-and-data");
@@ -1455,6 +1459,61 @@ async function confirmBatchTruncateTables() {
   }
 }
 
+async function refreshBatchEmptyPreviewSql(targets: ObjectBrowserRow[]) {
+  const statements: string[] = [];
+  for (const row of targets) {
+    const sql = await buildEmptyTableSql(tableAdminSqlOptions(row)).catch(() => "");
+    if (sql) statements.push(sql);
+  }
+  batchEmptyPreviewSql.value = statements.join("\n");
+}
+
+function requestBatchEmptyTables() {
+  const targets = [...selectedTableRows.value];
+  if (targets.length === 0) return;
+  batchEmptyTargets.value = targets;
+  batchEmptyPreviewSql.value = "";
+  void refreshBatchEmptyPreviewSql(targets)
+    .then(() => {
+      if (!batchEmptyPreviewSql.value.trim()) throw new Error("Empty table SQL preview is unavailable");
+      showBatchEmptyConfirm.value = true;
+    })
+    .catch((e: any) => {
+      batchEmptyTargets.value = [];
+      toast(t("contextMenu.tableOperationFailed", { message: e?.message || String(e) }), 5000);
+    });
+}
+
+async function confirmBatchEmptyTables() {
+  const targets = batchEmptyTargets.value.slice();
+  if (targets.length === 0) return;
+  const asynchronousMutation = effectiveDatabaseType.value === "clickhouse";
+  const result = await runBatchTableEmpty(targets, async (row) => {
+    const sql = await buildEmptyTableSql(tableAdminSqlOptions(row));
+    await api.executeQuery(props.connection.id, props.database, sql);
+  });
+  for (const failure of result.failed) {
+    console.error(`Failed to empty table "${failure.target.name}":`, failure.error);
+  }
+  const feedback = batchTableEmptyFeedback(result, asynchronousMutation);
+  if (feedback === "success") {
+    toast(t("contextMenu.batchEmptySuccess", { count: result.succeeded.length }), 3000);
+  } else if (feedback === "submitted") {
+    toast(t("contextMenu.batchEmptySubmitted", { count: result.succeeded.length }), 3000);
+  } else if (feedback === "submitted-partial") {
+    toast(t("contextMenu.batchEmptySubmittedPartial", { success: result.succeeded.length, failed: result.failed.length }), 5000);
+  } else {
+    toast(t("contextMenu.batchEmptyPartialFail", { success: result.succeeded.length, failed: result.failed.length }), 5000);
+  }
+  batchEmptyTargets.value = [];
+  showBatchEmptyConfirm.value = false;
+  if (result.succeeded.length > 0) {
+    clearTableSelection();
+    await reload();
+    await connectionStore.refreshObjectListTreeNode(props.connection.id, props.database, selectedSchema.value);
+  }
+}
+
 async function exportStructure(row: ObjectBrowserRow) {
   try {
     const schema = row.schema || selectedSchema.value || props.database;
@@ -2075,7 +2134,16 @@ function exportDataSubmenu(item: ObjectBrowserRow): ContextMenuItem {
   };
 }
 
+function isSelectedBatchTableContext(item: ObjectBrowserRow): boolean {
+  return item.type === "TABLE" && selectedTableCount.value > 1 && selectedTableIds.value.has(item.id);
+}
+
+function selectedBatchTableCountLabel(key: "batchDrop" | "batchTruncate" | "batchEmpty"): string {
+  return t(`contextMenu.${key}`, { count: selectedTableCount.value });
+}
+
 function getTableMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
+  const useBatchActions = isSelectedBatchTableContext(item);
   return [
     { label: t("contextMenu.viewData"), action: () => openViewData(item), icon: Table2 },
     {
@@ -2103,22 +2171,22 @@ function getTableMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
     ...(supportsTruncateTable.value
       ? [
           {
-            label: t("contextMenu.truncateTable"),
-            action: () => requestTruncateTable(item),
+            label: useBatchActions ? selectedBatchTableCountLabel("batchTruncate") : t("contextMenu.truncateTable"),
+            action: useBatchActions ? requestBatchTruncateTables : () => requestTruncateTable(item),
             icon: Scissors,
             variant: "destructive" as const,
           },
         ]
       : []),
     {
-      label: t("contextMenu.emptyTable"),
-      action: () => requestEmptyTable(item),
+      label: useBatchActions ? selectedBatchTableCountLabel("batchEmpty") : t("contextMenu.emptyTable"),
+      action: useBatchActions ? requestBatchEmptyTables : () => requestEmptyTable(item),
       icon: Eraser,
       variant: "destructive" as const,
     },
     {
-      label: t("contextMenu.dropTable"),
-      action: () => requestDrop(item),
+      label: useBatchActions ? selectedBatchTableCountLabel("batchDrop") : t("contextMenu.dropTable"),
+      action: useBatchActions ? requestBatchDropTables : () => requestDrop(item),
       icon: Trash2,
       variant: "destructive" as const,
     },
@@ -2292,6 +2360,10 @@ function getObjectBrowserMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
       <Button v-if="supportsTruncateTable" variant="ghost" size="sm" class="h-7 px-2 text-xs text-destructive" @click="requestBatchTruncateTables">
         <Scissors class="mr-1.5 h-3.5 w-3.5" />
         {{ t("objects.truncateSelected") }}
+      </Button>
+      <Button variant="ghost" size="sm" class="h-7 px-2 text-xs text-destructive" @click="requestBatchEmptyTables">
+        <Eraser class="mr-1.5 h-3.5 w-3.5" />
+        {{ t("contextMenu.batchEmpty", { count: selectedTableCount }) }}
       </Button>
       <Button variant="ghost" size="sm" class="h-7 px-2 text-xs text-destructive" @click="requestBatchDropTables">
         <Trash2 class="mr-1.5 h-3.5 w-3.5" />
@@ -2773,6 +2845,15 @@ function getObjectBrowserMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
       </label>
     </template>
   </DangerConfirmDialog>
+
+  <DangerConfirmDialog
+    v-model:open="showBatchEmptyConfirm"
+    :title="t('contextMenu.confirmBatchEmptyTitle', { count: batchEmptyTargets.length })"
+    :message="t('contextMenu.confirmBatchEmptyMessage', { count: batchEmptyTargets.length })"
+    :sql="batchEmptyPreviewSql"
+    :confirm-label="t('contextMenu.batchEmpty', { count: batchEmptyTargets.length })"
+    @confirm="confirmBatchEmptyTables"
+  />
 
   <Dialog v-model:open="showRenameDialog">
     <DialogContent class="sm:max-w-[420px]">

--- a/apps/desktop/src/lib/__tests__/sidebar/batchTableEmpty.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/batchTableEmpty.spec.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { batchTableEmptyFeedback, runBatchTableEmpty } from "@/lib/sidebar/batchTableEmpty";
+import { batchTableEmptyFeedback, buildBatchTableEmptyPlan, runBatchTableEmpty } from "@/lib/sidebar/batchTableEmpty";
 
 describe("batch table empty", () => {
+  it("executes the exact SQL captured for the confirmation preview", async () => {
+    const targets = [{ name: "orders" }, { name: "customers" }];
+    let schema = "public";
+    const plan = await buildBatchTableEmptyPlan(targets, async (target) => `TRUNCATE TABLE "${schema}"."${target.name}";`);
+    schema = "archive";
+
+    const executed: string[] = [];
+    await runBatchTableEmpty(plan, async ({ sql }) => {
+      executed.push(sql);
+    });
+
+    expect(plan.map(({ sql }) => sql).join("\n")).toBe('TRUNCATE TABLE "public"."orders";\nTRUNCATE TABLE "public"."customers";');
+    expect(executed).toEqual(['TRUNCATE TABLE "public"."orders";', 'TRUNCATE TABLE "public"."customers";']);
+  });
+
+  it("rejects the entire destructive plan when any preview SQL is unavailable", async () => {
+    await expect(buildBatchTableEmptyPlan(["orders", "customers"], async (target) => (target === "customers" ? "" : `TRUNCATE TABLE ${target};`))).rejects.toThrow("Empty table SQL preview is unavailable");
+  });
+
   it("continues after a table fails and collects each result", async () => {
     const executed: string[] = [];
     const result = await runBatchTableEmpty(["orders", "locked", "customers"], async (table) => {

--- a/apps/desktop/src/lib/sidebar/batchTableEmpty.ts
+++ b/apps/desktop/src/lib/sidebar/batchTableEmpty.ts
@@ -3,7 +3,22 @@ export interface BatchTableEmptyResult<T> {
   failed: Array<{ target: T; error: unknown }>;
 }
 
+export interface BatchTableEmptyPlanItem<T> {
+  target: T;
+  sql: string;
+}
+
 export type BatchTableEmptyFeedback = "success" | "partial" | "submitted" | "submitted-partial";
+
+export async function buildBatchTableEmptyPlan<T>(targets: readonly T[], buildSql: (target: T) => Promise<string>): Promise<BatchTableEmptyPlanItem<T>[]> {
+  const plan: BatchTableEmptyPlanItem<T>[] = [];
+  for (const target of targets) {
+    const sql = await buildSql(target);
+    if (!sql.trim()) throw new Error("Empty table SQL preview is unavailable");
+    plan.push({ target, sql });
+  }
+  return plan;
+}
 
 export async function runBatchTableEmpty<T>(targets: readonly T[], execute: (target: T) => Promise<void>): Promise<BatchTableEmptyResult<T>> {
   const result: BatchTableEmptyResult<T> = { succeeded: [], failed: [] };


### PR DESCRIPTION
## 变更说明

- 在对象浏览器多选表后的顶部选择栏增加批量清空入口
- 右键点击已选中的多张表时，将截断、清空、删除切换为带数量的批量菜单，和连接树多选表后的右键菜单保持一致
- 批量清空复用连接树已有的批量执行与部分失败反馈逻辑，并在确认弹窗中展示待执行 SQL
- 批量清空成功后刷新对象列表和连接树节点，避免行数等对象信息停留在旧状态

## 验证

- `pnpm typecheck`
- `pnpm lint`（通过；仓库既有 warning 仍存在）
- `pnpm vitest run apps/desktop/src/lib/__tests__/sidebar/batchTableEmpty.spec.ts`
