### PR TITLE
✨fix(redis): 优化自动刷新逻辑和显示TTL的计算

### DIFF
--- a/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
+++ b/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
@@ -10,19 +10,20 @@ describe("computeAutoRefreshTick", () => {
     expect(computeAutoRefreshTick(false, 5, true)).toEqual({ type: "idle" });
   });
 
-  it("returns decrement when countdown is above zero", () => {
+  it("returns decrement while more than one second remains", () => {
     expect(computeAutoRefreshTick(true, 10, false)).toEqual({ type: "decrement" });
-    expect(computeAutoRefreshTick(true, 1, false)).toEqual({ type: "decrement" });
     // decrement even when loading — countdown should keep ticking
     expect(computeAutoRefreshTick(true, 3, true)).toEqual({ type: "decrement" });
   });
 
-  it("returns refresh when countdown reaches zero and not loading", () => {
+  it("refreshes on the expiry tick instead of exposing a zero countdown", () => {
+    expect(computeAutoRefreshTick(true, 1, false)).toEqual({ type: "refresh" });
     expect(computeAutoRefreshTick(true, 0, false)).toEqual({ type: "refresh" });
     expect(computeAutoRefreshTick(true, -1, false)).toEqual({ type: "refresh" });
   });
 
-  it("returns idle when countdown is zero but a load is already in flight", () => {
+  it("does not start another refresh when a load is already in flight", () => {
+    expect(computeAutoRefreshTick(true, 1, true)).toEqual({ type: "decrement" });
     // This prevents concurrent load() calls
     expect(computeAutoRefreshTick(true, 0, true)).toEqual({ type: "idle" });
     expect(computeAutoRefreshTick(true, -1, true)).toEqual({ type: "idle" });
@@ -50,9 +51,8 @@ describe("computeDisplayTtl", () => {
     expect(computeDisplayTtl(false, 3, 10)).toBe(10);
   });
 
-  it("returns server TTL when countdown has not started (zero)", () => {
-    // countdownTtl starts at 0 before first tick; show server TTL
-    expect(computeDisplayTtl(true, 0, 10)).toBe(10);
+  it("does not flash back to the stale server TTL at zero", () => {
+    expect(computeDisplayTtl(true, 0, 5)).toBe(0);
   });
 
   it("returns live countdown when auto-refresh is active and counting", () => {
@@ -60,9 +60,7 @@ describe("computeDisplayTtl", () => {
     expect(computeDisplayTtl(true, 1, 10)).toBe(1);
   });
 
-  it("returns server TTL when countdown would go below zero", () => {
-    // Edge case: countdownTtl shouldn't be negative in practice,
-    // but if it is, fall back to server TTL
-    expect(computeDisplayTtl(true, -1, 10)).toBe(10);
+  it("clamps an active countdown below zero instead of showing stale data", () => {
+    expect(computeDisplayTtl(true, -1, 10)).toBe(0);
   });
 });

--- a/apps/desktop/src/lib/redis/redisAutoRefresh.ts
+++ b/apps/desktop/src/lib/redis/redisAutoRefresh.ts
@@ -18,9 +18,8 @@ export type AutoRefreshTickAction = { type: "idle" } | { type: "decrement" } | {
  */
 export function computeAutoRefreshTick(enabled: boolean, countdownTtl: number, isLoading: boolean): AutoRefreshTickAction {
   if (!enabled) return { type: "idle" };
-  if (countdownTtl > 0) return { type: "decrement" };
-  if (countdownTtl <= 0 && !isLoading) return { type: "refresh" };
-  return { type: "idle" };
+  if (isLoading) return countdownTtl > 0 ? { type: "decrement" } : { type: "idle" };
+  return countdownTtl <= 1 ? { type: "refresh" } : { type: "decrement" };
 }
 
 /**
@@ -36,12 +35,9 @@ export function shouldStopAutoRefresh(ttl: number): boolean {
 /**
  * Compute the TTL value that should be displayed in the badge.
  *
- * When auto-refresh is active and countdown is running, the live
- * countdown value is shown. Otherwise the last known server TTL is used.
+ * When auto-refresh is active, the live countdown value is shown. The
+ * last known server TTL must not reappear after the countdown reaches zero.
  */
 export function computeDisplayTtl(autoRefreshEnabled: boolean, countdownTtl: number, serverTtl: number): number {
-  if (autoRefreshEnabled && countdownTtl > 0) {
-    return countdownTtl;
-  }
-  return serverTtl;
+  return autoRefreshEnabled ? Math.max(countdownTtl, 0) : serverTtl;
 }


### PR DESCRIPTION
- 修改computeAutoRefreshTick函数，简化逻辑判断
- 更新computeDisplayTtl函数，确保倒计时为零时不显示过期的服务器TTL

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1888" height="1238" alt="FB46BD0E-B969-4925-8CE2-04CE8B10C9C5" src="https://github.com/user-attachments/assets/2c31e602-d460-4baf-b779-5d257e56589c" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #3183 