### PR TITLE
fix(safety): guard object browser batch empty

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -1534,9 +1534,13 @@ async function confirmBatchEmptyTables() {
   const plan = batchEmptyPlan.value.slice();
   if (plan.length === 0) return;
   const asynchronousMutation = effectiveDatabaseType.value === "clickhouse";
-  const result = await runBatchTableEmpty(plan, async ({ sql }) => {
-    await api.executeQuery(props.connection.id, props.database, sql);
+  const reviewSql = plan.map(({ sql }) => sql).join(";\n");
+  const result = await executeObjectBrowserSqlWithProductionGuard(reviewSql, () => {
+    return runBatchTableEmpty(plan, async ({ sql }) => {
+      await api.executeQuery(props.connection.id, props.database, sql);
+    });
   });
+  if (!result) return;
   for (const failure of result.failed) {
     console.error(`Failed to empty table "${failure.target.target.name}":`, failure.error);
   }

--- a/packages/app-tests/productionGuardEntrypoints.test.ts
+++ b/packages/app-tests/productionGuardEntrypoints.test.ts
@@ -6,6 +6,26 @@ function readSource(path: string): string {
   return readFileSync(path, "utf8");
 }
 
+function functionBody(source: string, name: string): string {
+  const signature = `function ${name}(`;
+  const asyncSignature = `async ${signature}`;
+  const signatureIndex = source.indexOf(asyncSignature) >= 0 ? source.indexOf(asyncSignature) : source.indexOf(signature);
+  assert.notEqual(signatureIndex, -1, `Could not find function ${name}`);
+  const bodyStart = source.indexOf("{", signatureIndex);
+  assert.notEqual(bodyStart, -1, `Could not find body for ${name}`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(bodyStart + 1, index);
+    }
+  }
+  throw new Error(`Could not parse body for ${name}`);
+}
+
 test("secondary write entrypoints use the shared production SQL guard", () => {
   const entrypoints = [
     {
@@ -76,4 +96,12 @@ test("secondary write entrypoints use the shared production SQL guard", () => {
     assert.ok(source.includes(entrypoint.executor), `${entrypoint.path} should still execute SQL through its original backend API`);
     assert.ok(source.includes(entrypoint.sourceKey), `${entrypoint.path} should label the confirmation source`);
   }
+});
+
+test("object browser batch empty reviews the frozen SQL plan before executing", () => {
+  const source = readSource("apps/desktop/src/components/objects/ObjectBrowser.vue");
+  const body = functionBody(source, "confirmBatchEmptyTables");
+  assert.match(body, /executeObjectBrowserSqlWithProductionGuard\(\s*reviewSql/, "batch empty must use the Object Browser production guard");
+  assert.match(body, /runBatchTableEmpty/, "batch empty should still use the batch executor after confirmation");
+  assert.ok(body.indexOf("executeObjectBrowserSqlWithProductionGuard") < body.indexOf("runBatchTableEmpty"), "production guard must be entered before the batch executor");
 });


### PR DESCRIPTION
## 变更说明

修复对象浏览器多选模式下“清空所选表”绕过生产环境二次确认的问题。

现在批量清空会复用确认弹窗中已冻结的 SQL 预览内容，在真正执行批量清空前先进入对象浏览器的生产 SQL guard。若用户取消生产确认，则不会执行清空操作。

同时补充回归测试，确保对象浏览器批量清空必须先经过生产环境 guard，再执行批量操作。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm vitest run packages/app-tests/productionGuardEntrypoints.test.ts apps/desktop/src/lib/__tests__/sidebar/batchTableEmpty.spec.ts apps/desktop/src/lib/database/__tests__/productionExecutionGuard.spec.ts apps/desktop/src/lib/database/__tests__/productionSafety.spec.ts`
- `pnpm typecheck`
- `pnpm lint`

## 关联 Issue
无