### PR TITLE
fix: disconnect failed mysql export streams

### DIFF
--- a/crates/dbx-core/src/query_result_export.rs
+++ b/crates/dbx-core/src/query_result_export.rs
@@ -35,6 +35,18 @@ const STREAMING_PAGINATION_UNSUPPORTED_ERROR: &str = "当前查询暂不支持�
 const AGENT_SESSION_MISSING_ERROR: &str = "查询结果流式导出需要驱动返回结果集会话，但当前驱动未返回 session_id。";
 const STREAM_PROGRESS_TIME_INTERVAL: Duration = Duration::from_secs(1);
 
+async fn disconnect_with_timeout<C, F, Fut>(
+    connection: C,
+    cleanup_timeout: Duration,
+    disconnect: F,
+) -> Result<Result<(), String>, tokio::time::error::Elapsed>
+where
+    F: FnOnce(C) -> Fut,
+    Fut: std::future::Future<Output = Result<(), String>>,
+{
+    tokio::time::timeout(cleanup_timeout, disconnect(connection)).await
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryResultExportRequest {
@@ -941,6 +953,25 @@ async fn try_export_mysql_query_result_stream(
     watcher_done.cancel();
 
     if let Err(error) = stream_result {
+        // A timed-out, cancelled, or failed MySQL result stream may leave an
+        // incomplete protocol packet on the connection. Explicitly disconnect
+        // it so mysql_async cannot recycle the poisoned connection into the pool.
+        match disconnect_with_timeout(conn, operation_budget.cleanup_timeout, |conn| async move {
+            conn.disconnect().await.map_err(|error| error.to_string())
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(disconnect_error)) => {
+                log::warn!(
+                    "Failed to disconnect MySQL export connection {mysql_connection_id} after stream error: {disconnect_error}"
+                );
+            }
+            Err(_) => {
+                log::warn!("Timed out disconnecting MySQL export connection {mysql_connection_id} after stream error");
+            }
+        }
+
         if error == QUERY_CANCELED
             || export_cancelled.load(Ordering::SeqCst)
             || cancel_token.as_ref().is_some_and(|token| token.is_cancelled())
@@ -1410,5 +1441,28 @@ mod tests {
     fn keyset_candidate_rejects_filters_and_projection_changes() {
         assert!(safe_keyset_candidate("SELECT * FROM users WHERE active = true").is_none());
         assert!(safe_keyset_candidate("SELECT id, name FROM users").is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_mysql_stream_disconnects_connection_without_database_or_xlsx() {
+        let disconnected = Arc::new(AtomicBool::new(false));
+        let disconnected_for_call = disconnected.clone();
+        let result = disconnect_with_timeout((), Duration::from_secs(1), move |_| async move {
+            disconnected_for_call.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+        assert!(matches!(result, Ok(Ok(()))));
+        assert!(disconnected.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn failed_mysql_stream_disconnect_is_bounded_by_cleanup_timeout() {
+        let result = disconnect_with_timeout((), Duration::from_millis(1), |_| async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(())
+        })
+        .await;
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## 变更说明

修复 MySQL 查询结果流式导出首次超时/取消/异常后，异常连接可能被回收到连接池，导致后续导出复用该连接时报错的问题，例如：

`Input/output error: bytes remaining on stream`

本次改动在 MySQL 流式导出读取阶段失败时，主动对当前连接执行带超时保护的 `disconnect()`，避免协议状态不完整的连接被放回连接池。连接池后续会重新创建健康连接。

同时补充了不依赖真实数据库、不依赖真实 Excel 导出的单元测试，验证失败后会触发断开逻辑，以及断开连接过程受 `cleanup_timeout` 限制。

后续优化方向：Excel 导出这类长耗时流式导出可以考虑单独建立专用连接，导出完成后直接销毁连接，并对该导出连接设置不超时或独立超时策略，从而与正常业务连接池隔离，避免长时间导出影响常规查询连接复用。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

无前端改动。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行定向测试：

`cargo test --offline -p dbx-core --no-default-features failed_mysql_stream_disconnect --lib`

覆盖测试：

- `failed_mysql_stream_disconnects_connection_without_database_or_xlsx`
- `failed_mysql_stream_disconnect_is_bounded_by_cleanup_timeout`

## 关联 Issue

Closes #2889 