### PR TITLE
fix(mongodb): 修复集合列表复制 JSON 和 INSERT 上下文丢失

### DIFF
--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -168,7 +168,7 @@ const gridResult = computed<QueryResult>(() => {
     }),
   );
 
-  return { columns, rows, affected_rows: 0, execution_time_ms: 0, truncated: false };
+  return { columns, rows, mongo_documents: docs, affected_rows: 0, execution_time_ms: 0, truncated: false };
 });
 const documentFilterFieldOptions = computed(() => gridResult.value.columns);
 const documentStructuredFilterCount = computed(() => (appliedDocumentFilter.value ? 1 : 0));

--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -421,6 +421,7 @@ const customSaveHandler = computed<CustomSaveHandler>(() => ({
   preview: previewDocumentChanges,
   supportsInsert: true,
   readonlyColumns: documentStoreProvider.value.kind === "elasticsearch" ? ["_routing"] : undefined,
+  targetLabel: props.collection,
 }));
 
 function stopDocumentLoadingTimer() {
@@ -943,6 +944,7 @@ function resetTableSearchSplitWidth() {
       class="flex-1 min-h-0"
       :result="gridResult"
       context="results"
+      :database-type="props.databaseType"
       editable
       :custom-save-handler="customSaveHandler"
       :loading="loading"

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6504,6 +6504,7 @@ const {
   database: computed(() => props.executionDatabase ?? props.database),
   context: computed(() => props.context),
   sourceColumns: visibleSourceColumns,
+  mongoDocuments: computed(() => props.result.mongo_documents),
   columnTypes: visibleColumnTypes,
   whereInput: computed(() => currentWhereInput()),
   orderBy: computed(() => currentOrderBy()),

--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -55,6 +55,34 @@ function row(data: unknown[]) {
   };
 }
 
+function createMongoExportState(options: { columns: string[]; item: ReturnType<typeof row> & { sourceIndex: number }; mongoDocuments: unknown[] }) {
+  const state: UseDataGridExportOptions = {
+    columns: computed(() => options.columns),
+    displayItems: computed(() => [options.item]),
+    sql: computed(() => undefined),
+    tableMeta: computed(() => undefined),
+    copyInsertTargetLabel: computed(() => "documents"),
+    databaseType: computed(() => "mongodb"),
+    connectionId: computed(() => "connection-1"),
+    database: computed(() => "dbx"),
+    context: computed(() => "results"),
+    sourceColumns: computed(() => options.columns),
+    mongoDocuments: computed(() => options.mongoDocuments),
+    columnTypes: computed(() => undefined),
+    whereInput: computed(() => undefined),
+    orderBy: computed(() => undefined),
+    exportBatchSize: computed(() => 1000),
+    hasCellSelection: computed(() => false),
+    selectedCells: computed(() => ({ columns: [], rows: [] })),
+    selectedRange: computed(() => null),
+    contextCell: ref({ rowId: options.item.id, rowIndex: 0, col: -1 }),
+    getRowItem: (rowId) => (rowId === options.item.id ? options.item : undefined),
+    selectedRowIds: ref(new Set<number>()),
+    hasRowSelection: computed(() => false),
+  };
+  return useDataGridExport(state);
+}
+
 function createExportState(tableMeta: DataGridTableMeta, columns = tableMeta.columns?.map((column) => column.name) ?? ["id", "name"]) {
   const item = row(columns.map((column, index) => (column === "id" ? 1 : `value-${index}`)));
   const options: UseDataGridExportOptions = {
@@ -165,5 +193,43 @@ describe("useDataGridExport prepared row statements", () => {
     await Promise.all([prefetch, copy]);
     expect(toast).toHaveBeenCalledWith("grid.copyFailed: update builder unavailable", 5000);
     expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("copies Mongo JSON from the original document using the sorted source index and visible columns", async () => {
+    const item = { ...row(["true", '{"role":"admin"}']), sourceIndex: 1 };
+    const state = createMongoExportState({
+      columns: ["booleanText", "profile"],
+      item,
+      mongoDocuments: [
+        { booleanText: "wrong row", profile: { role: "viewer" } },
+        { booleanText: "true", profile: { role: "admin" }, hidden: "not selected" },
+      ],
+    });
+
+    await state.copyRow();
+
+    expect(copyToClipboard).toHaveBeenCalledWith(JSON.stringify({ booleanText: "true", profile: { role: "admin" } }, null, 2));
+  });
+
+  it("preserves original Mongo string types in INSERT and applies explicit edits", async () => {
+    const item = { ...row(["123", "true", '{"kind":"literal"}', "2024-01-01 00:00:00", '{"role":"maintainer"}']), sourceIndex: 0 };
+    item.isDirtyCol = [false, false, false, false, true];
+    const state = createMongoExportState({
+      columns: ["numericText", "booleanText", "jsonText", "dateText", "profile"],
+      item,
+      mongoDocuments: [
+        {
+          numericText: "123",
+          booleanText: "true",
+          jsonText: '{"kind":"literal"}',
+          dateText: "2024-01-01 00:00:00",
+          profile: { role: "admin" },
+        },
+      ],
+    });
+
+    await state.copyRowAsInsert();
+
+    expect(copyToClipboard).toHaveBeenCalledWith('db.getCollection("documents").insert({"numericText":"123","booleanText":"true","jsonText":"{\\"kind\\":\\"literal\\"}","dateText":"2024-01-01 00:00:00","profile":{"role":"maintainer"}});');
   });
 });

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -12,7 +12,7 @@ import { formatSqlInsert } from "@/lib/export/exportFormats";
 import { uuid } from "@/lib/common/utils";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { expandNestedJsonStringsForCopy } from "@/lib/common/jsonCopyValue";
-import { buildMongoCopyInsertDocument, formatMongoShellLiteral, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
+import { buildMongoCopyDocumentFromOriginal, buildMongoCopyInsertDocument, formatMongoShellLiteral, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
 import type { DatabaseType, QueryResult } from "@/types/database";
 import type { QueryResultExportRequest } from "@/lib/backend/api";
 import { DBX_ROWID_COLUMN } from "@/lib/table/tableEditing";
@@ -40,6 +40,7 @@ export interface UseDataGridExportOptions {
   database: ComputedRef<string | undefined>;
   context: ComputedRef<"results" | "table-data" | undefined>;
   sourceColumns: ComputedRef<Array<string | undefined> | undefined>;
+  mongoDocuments?: ComputedRef<unknown[] | undefined>;
   columnTypes: ComputedRef<Array<string | undefined> | undefined>;
   whereInput: ComputedRef<string | undefined>;
   orderBy: ComputedRef<string | undefined>;
@@ -233,7 +234,9 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   }
 
   function insertCopyKey(excludePrimaryKeys: boolean, insertMode: DataGridCopyInsertMode): string {
-    const rows = copyStatementRowsKey(insertEligibleRows());
+    const eligibleRows = insertEligibleRows();
+    const rows = copyStatementRowsKey(eligibleRows);
+    const originalMongoDocuments = eligibleRows.map((item) => (item.sourceIndex === undefined ? undefined : options.mongoDocuments?.value?.[item.sourceIndex]));
     return JSON.stringify({
       databaseType: databaseType.value ?? null,
       schema: tableMeta.value?.schema ?? null,
@@ -245,12 +248,13 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
       excludePrimaryKeys,
       insertMode,
       rows,
+      originalMongoDocuments,
     });
   }
 
-  function copyStatementRowsKey(rows: RowItem[]): Array<{ id: number; data: CellValue[] }> {
+  function copyStatementRowsKey(rows: RowItem[]): Array<{ id: number; sourceIndex?: number; data: CellValue[]; isDirtyCol: boolean[] }> {
     // Prepared copy SQL depends on current cell values; edited rows keep the same id while their data changes.
-    return rows.map((item) => ({ id: item.id, data: item.data }));
+    return rows.map((item) => ({ id: item.id, sourceIndex: item.sourceIndex, data: item.data, isDirtyCol: item.isDirtyCol }));
   }
 
   function insertCopyCache(excludePrimaryKeys: boolean, insertMode: DataGridCopyInsertMode): CopyStatementCache {
@@ -309,7 +313,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
               collection: copyInsertTargetLabel?.value || tableMeta.value?.tableName || "collection",
               columns: columns.value,
               sourceColumns: sourceColumns.value,
-              rows: rows.map((item) => item.data),
+              rows,
+              mongoDocuments: options.mongoDocuments?.value,
               excludePrimaryKeys,
               insertMode,
             })
@@ -516,6 +521,11 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   }
 
   function rowToJsonObject(item: RowItem): Record<string, unknown> {
+    if (options.databaseType.value === "mongodb" && item.sourceIndex !== undefined) {
+      const original = options.mongoDocuments?.value?.[item.sourceIndex];
+      const document = buildMongoCopyDocumentFromOriginal(original, item.data as MongoInputValue[], columns.value, item.isDirtyCol);
+      if (document) return document;
+    }
     const obj: Record<string, unknown> = {};
     columns.value.forEach((col, i) => {
       obj[col] = item.data[i];
@@ -526,7 +536,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   async function copyRowsAsJson(items: RowItem[]) {
     if (items.length === 0) return;
     const value = items.length === 1 ? rowToJsonObject(items[0]) : items.map(rowToJsonObject);
-    const copyValue = options.databaseType.value === "mongodb" ? expandNestedJsonStringsForCopy(value) : value;
+    const hasOriginalMongoDocuments = options.databaseType.value === "mongodb" && items.every((item) => item.sourceIndex !== undefined && options.mongoDocuments?.value?.[item.sourceIndex] !== undefined);
+    const copyValue = options.databaseType.value === "mongodb" && !hasOriginalMongoDocuments ? expandNestedJsonStringsForCopy(value) : value;
     await copyText(JSON.stringify(copyValue, null, 2));
   }
 
@@ -1241,12 +1252,17 @@ function replaceControlCharacters(value: string, replacement: string): string {
     .join("");
 }
 
-function buildMongoCopyInsertStatement(options: { collection: string; columns: string[]; sourceColumns?: Array<string | undefined>; rows: CellValue[][]; excludePrimaryKeys?: boolean; insertMode?: DataGridCopyInsertMode }): string | undefined {
+function buildMongoCopyInsertStatement(options: { collection: string; columns: string[]; sourceColumns?: Array<string | undefined>; rows: RowItem[]; mongoDocuments?: unknown[]; excludePrimaryKeys?: boolean; insertMode?: DataGridCopyInsertMode }): string | undefined {
   const saveColumns = effectiveColumns(options.sourceColumns, options.columns);
   const columnIndexes = saveColumns.map((column, index) => ({ column, index })).filter((item): item is { column: string; index: number } => !!item.column);
   if (columnIndexes.length === 0 || options.rows.length === 0) return undefined;
   const documentColumns = columnIndexes.map((item) => item.column);
-  const documents = options.rows.map((row) => buildMongoCopyInsertDocument(columnIndexes.map((item) => row[item.index]) as MongoInputValue[], documentColumns, { excludePrimaryKeys: options.excludePrimaryKeys }));
+  const documents = options.rows.map((item) => {
+    const row = columnIndexes.map(({ index }) => item.data[index]) as MongoInputValue[];
+    const dirtyColumns = columnIndexes.map(({ index }) => item.isDirtyCol[index] ?? false);
+    const original = item.sourceIndex === undefined ? undefined : options.mongoDocuments?.[item.sourceIndex];
+    return buildMongoCopyDocumentFromOriginal(original, row, documentColumns, dirtyColumns, { excludePrimaryKeys: options.excludePrimaryKeys }) ?? buildMongoCopyInsertDocument(row, documentColumns, { excludePrimaryKeys: options.excludePrimaryKeys });
+  });
   const collection = `db.getCollection(${JSON.stringify(options.collection)})`;
   if (documents.length === 1) return `${collection}.insert(${formatMongoShellLiteral(documents[0])});`;
   if (options.insertMode === "row-by-row") {

--- a/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
+++ b/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
@@ -100,6 +100,26 @@ export function buildMongoCopyInsertDocument(row: MongoInputValue[], columns: st
   return doc;
 }
 
+export function buildMongoCopyDocumentFromOriginal(original: unknown, row: MongoInputValue[], columns: string[], dirtyColumns: boolean[], options: { excludePrimaryKeys?: boolean } = {}): Record<string, unknown> | null {
+  if (!original || typeof original !== "object" || Array.isArray(original)) return null;
+
+  const source = original as Record<string, unknown>;
+  const document: Record<string, unknown> = {};
+  for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+    const column = columns[columnIndex];
+    if (!column || (options.excludePrimaryKeys && column === "_id")) continue;
+
+    // Display strings are ambiguous, so only explicitly edited cells may replace original BSON values.
+    if (dirtyColumns[columnIndex]) {
+      const value = row[columnIndex];
+      if (value !== null) document[column] = parseMongoDocumentInputValue(value);
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(source, column)) document[column] = source[column];
+  }
+  return document;
+}
+
 export function formatMongoShellLiteral(value: unknown): string {
   if (value === null || value === undefined) return "null";
   if (typeof value === "number" || typeof value === "boolean") return String(value);

--- a/packages/app-tests/documentBrowser.test.ts
+++ b/packages/app-tests/documentBrowser.test.ts
@@ -5,15 +5,25 @@ import { test } from "vitest";
 
 function searchBarSlotSource(): string {
   const source = readFileSync(path.resolve("apps/desktop/src/components/document/DocumentBrowser.vue"), "utf8");
-  const start = source.indexOf('<template #search-bar');
+  const start = source.indexOf("<template #search-bar");
   const end = source.indexOf("\n    </DataGrid>", start);
   assert.notEqual(start, -1, "expected DocumentBrowser search-bar slot");
   assert.notEqual(end, -1, "expected DocumentBrowser DataGrid closing tag");
   return source.slice(start, end);
 }
 
+function documentBrowserSource(): string {
+  return readFileSync(path.resolve("apps/desktop/src/components/document/DocumentBrowser.vue"), "utf8");
+}
+
 test("mongo document result search bar does not render a duplicate refresh button", () => {
   const slot = searchBarSlotSource();
   assert.equal(slot.includes('{{ t("grid.refresh") }}'), false);
   assert.equal(slot.includes("RefreshCcw"), false);
+});
+
+test("mongo document table passes copy context to the data grid", () => {
+  const source = documentBrowserSource();
+  assert.match(source, /<DataGrid[\s\S]*?:database-type="props\.databaseType"[\s\S]*?<\/DataGrid>/);
+  assert.match(source, /const customSaveHandler = computed<CustomSaveHandler>\(\(\) => \(\{[\s\S]*?targetLabel: props\.collection,[\s\S]*?\}\)\);/);
 });

--- a/packages/app-tests/mongoDocumentValues.test.ts
+++ b/packages/app-tests/mongoDocumentValues.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { applyMongoGridChangesToDocument, buildMongoCopyInsertDocument, buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, parseMongoDocumentInputValue } from "../../apps/desktop/src/lib/mongo/mongoDocumentValues.ts";
+import { applyMongoGridChangesToDocument, buildMongoCopyDocumentFromOriginal, buildMongoCopyInsertDocument, buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, parseMongoDocumentInputValue } from "../../apps/desktop/src/lib/mongo/mongoDocumentValues.ts";
 
 test("parses Mongo shell ISODate literals as extended JSON dates", () => {
   assert.deepEqual(parseMongoDocumentInputValue('ISODate("2026-06-10T13:59:31.287Z")'), {
@@ -86,6 +86,39 @@ test("builds Mongo copy inserts without primary keys when requested", () => {
   assert.deepEqual(buildMongoCopyInsertDocument(["6743e4bfa3f6f84bc3fff6c8", "done"], ["_id", "status"], { excludePrimaryKeys: true }), {
     status: "done",
   });
+});
+
+test("projects original Mongo values without guessing types", () => {
+  const original = {
+    _id: { $oid: "6743e4bfa3f6f84bc3fff6c8" },
+    numericText: "123",
+    booleanText: "true",
+    jsonText: '{"kind":"literal"}',
+    dateText: "2024-01-01 00:00:00",
+    profile: { role: "admin" },
+    hidden: "not selected",
+  };
+
+  assert.deepEqual(
+    buildMongoCopyDocumentFromOriginal(original, ["ignored", "ignored", "ignored", "ignored", "ignored"], ["numericText", "booleanText", "jsonText", "dateText", "profile"], [false, false, false, false, false]),
+    {
+      numericText: "123",
+      booleanText: "true",
+      jsonText: '{"kind":"literal"}',
+      dateText: "2024-01-01 00:00:00",
+      profile: { role: "admin" },
+    },
+  );
+});
+
+test("applies only explicit Mongo grid edits to copied original documents", () => {
+  assert.deepEqual(
+    buildMongoCopyDocumentFromOriginal({ _id: "1", count: "123", profile: { role: "admin" } }, ["1", "456", '{"role":"maintainer"}'], ["_id", "count", "profile"], [false, true, false], { excludePrimaryKeys: true }),
+    {
+      count: 456,
+      profile: { role: "admin" },
+    },
+  );
 });
 
 test("formats extended JSON dates as Mongo shell ISODate literals", () => {


### PR DESCRIPTION
## 问题

修复 #2215 中 MongoDB 集合浏览器表格视图与查询结果复制行为不一致的问题：

- 集合列表复制 JSON 时，嵌套文档仍被复制为转义字符串
- 集合列表复制 INSERT 时，错误生成通用的 `INSERT INTO table_name ...`
- 查询结果页面则能正确保留嵌套对象并生成 `db.getCollection(...).insert(...)`

## 原因

此前的修复已经在 `useDataGridExport` 中支持 MongoDB 嵌套 JSON 展开和 Mongo Shell INSERT，但 `DocumentBrowser` 创建 `DataGrid` 时没有传入数据库类型，现有 `customSaveHandler` 也没有提供目标集合名。

因此真实的集合浏览入口无法进入 MongoDB 复制分支。已有单测直接构造了 `databaseType: mongodb`，只验证了序列化函数，没有覆盖组件之间的参数传递，所以 0.5.55 中仍然可以复现。

## 修复

- 将 `DocumentBrowser` 的 `databaseType` 传给 `DataGrid`
- 通过 `CustomSaveHandler.targetLabel` 将当前集合名传给复制逻辑
- 增加回归测试，确保集合浏览器持续传递 MongoDB 类型和目标集合

## 验证

- `pnpm vitest run packages/app-tests/documentBrowser.test.ts packages/app-tests/jsonCopyValue.test.ts packages/app-tests/useDataGridExport.test.ts`：24 passed
- `pnpm typecheck`：通过
- `pnpm lint`：通过（仅有仓库原有 warning）

修复后，集合列表与查询结果会共用相同的 MongoDB JSON/INSERT 复制逻辑。