### PR TITLE
feat(grid): 优化数据表格列宽三种密度模式

### DIFF
--- a/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
@@ -44,11 +44,13 @@ describe("useDataGridColumnResize", () => {
     });
 
     state.initColumnWidths();
-    expect(state.columnWidths.value[0]).toBe(DATA_GRID_COL_MAX_WIDTH);
+    // standard valueTextLimit=40, 120 chars → truncated to 40: 40×8+24=344
+    // header "description"=11×8+85=173 < 344 → 344
+    expect(state.columnWidths.value[0]).toBe(344);
 
     state.autoFitColumn(0);
 
-    expect(state.columnWidths.value[0]).toBeGreaterThan(DATA_GRID_COL_MAX_WIDTH);
+    expect(state.columnWidths.value[0]).toBeGreaterThan(344);
     expect(state.columnWidths.value[0]).toBeLessThanOrEqual(DATA_GRID_COL_AUTO_FIT_MAX_WIDTH);
   });
 
@@ -76,7 +78,7 @@ describe("useDataGridColumnResize", () => {
     const state = createResizeState({
       columns: ["some_column_name_here"],
       rows: [["a"]],
-      density: "compact",
+      density: "standard",
       compactColumnHeaderActions: true,
     });
 
@@ -87,8 +89,83 @@ describe("useDataGridColumnResize", () => {
     await nextTick();
 
     const widthNonCompact = state.renderedColumnWidths.value[0];
-    // compact: charWidth*nameLen + headerControlWidthCompact(20) = 7*21+20=167
-    // non-compact: 7*21+headerControlWidth(36)=183
+    // standard compactActions=true: 21×8+59=227
+    // standard compactActions=false: 21×8+83=251
     expect(widthNonCompact).toBeGreaterThan(widthCompact);
+  });
+
+  it("compact mode bases width on field name only, capping long names", () => {
+    // 短字段名：列宽=字段名宽度，值不参与撑宽
+    const short = createResizeState({
+      columns: ["id"],
+      rows: [["x".repeat(100)]],
+      density: "compact",
+      compactColumnHeaderActions: true,
+    });
+    short.initColumnWidths();
+    // "id"=2×7+45=59 < min 60 → 60
+    expect(short.columnWidths.value[0]).toBe(60);
+
+    // 中等字段名：刚好完整显示
+    const mid = createResizeState({
+      columns: ["user_name"],
+      rows: [["a"]],
+      density: "compact",
+      compactColumnHeaderActions: true,
+    });
+    mid.initColumnWidths();
+    // 9×7+45=108
+    expect(mid.columnWidths.value[0]).toBe(108);
+
+    // 过长字段名：截断到边界
+    const capped = createResizeState({
+      columns: ["x".repeat(70)],
+      rows: [["a"]],
+      density: "compact",
+      compactColumnHeaderActions: true,
+    });
+    capped.initColumnWidths();
+    // 70×7+45=535 > maxWidth 480 → 480
+    expect(capped.columnWidths.value[0]).toBe(480);
+  });
+
+  it("comfortable mode uses percentile to ignore outlier values", () => {
+    const shortRows = Array.from({ length: 49 }, () => ["short"]);
+    const rows = [...shortRows, ["x".repeat(200)]];
+
+    const state = createResizeState({
+      columns: ["data"],
+      rows,
+      density: "comfortable",
+      compactColumnHeaderActions: true,
+    });
+
+    state.initColumnWidths();
+    // P95 of 50 samples ignores the single 200-char outlier;
+    // "short" = 5 chars → 5×8+24=64, header "data"=4×8+59=91 → max=91
+    expect(state.columnWidths.value[0]).toBeLessThan(600);
+    expect(state.columnWidths.value[0]).toBe(91);
+  });
+
+  it("comfortable mode is never narrower than standard for the same column", () => {
+    const rows = Array.from({ length: 50 }, () => ["medium_value"]);
+
+    const std = createResizeState({
+      columns: ["description"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+    });
+    std.initColumnWidths();
+
+    const comf = createResizeState({
+      columns: ["description"],
+      rows,
+      density: "comfortable",
+      compactColumnHeaderActions: true,
+    });
+    comf.initColumnWidths();
+
+    expect(comf.columnWidths.value[0]).toBeGreaterThanOrEqual(std.columnWidths.value[0]);
   });
 });

--- a/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
@@ -54,6 +54,21 @@ describe("useDataGridColumnResize", () => {
     expect(state.columnWidths.value[0]).toBeLessThanOrEqual(DATA_GRID_COL_AUTO_FIT_MAX_WIDTH);
   });
 
+  it("includes values when explicitly auto-fitting a compact column", () => {
+    const state = createResizeState({
+      columns: ["id"],
+      rows: [["x".repeat(120)]],
+      density: "compact",
+    });
+
+    state.initColumnWidths();
+    expect(state.columnWidths.value[0]).toBe(60);
+
+    state.autoFitColumn(0);
+
+    expect(state.columnWidths.value[0]).toBeGreaterThan(60);
+  });
+
   it("clamps manual column resizing to the minimum width", () => {
     expect(resizeDataGridColumnWidth(120, -200)).toBe(DATA_GRID_COL_MIN_WIDTH);
     expect(resizeDataGridColumnWidth(120, 30)).toBe(150);

--- a/apps/desktop/src/composables/useDataGridColumnResize.ts
+++ b/apps/desktop/src/composables/useDataGridColumnResize.ts
@@ -113,6 +113,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
       valueTextLimit: DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT,
       density: density.value,
       compactColumnHeaderActions: compactColumnHeaderActions.value,
+      includeValues: true,
     });
   }
 

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
@@ -20,6 +20,12 @@ describe("dataGridTranspose density widths", () => {
     expect(transposeFieldWidth([], { density: "compact" })).toBe(minTransposeFieldWidth("compact"));
   });
 
+  it("keeps compact record width independent of field order", () => {
+    const longValue = "x".repeat(100);
+
+    expect(calculateTransposeRecordWidth([longValue, "a"], "compact")).toBe(calculateTransposeRecordWidth(["a", longValue], "compact"));
+  });
+
   it("recalculates automatic widths while preserving manual pixel overrides", () => {
     const records = [["x".repeat(40)], ["y".repeat(20)]];
     const standardWidths = transposeRecordWidthsForDensity({ records, density: "standard" });

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
@@ -79,13 +79,19 @@ function displaySampleValue(value: CellValue): string | null {
 // 取排序后第 percentile 百分位的值
 export function percentileValue(values: number[], percentile: number): number {
   if (values.length === 0) return 0;
-  if (percentile >= 100 || values.length === 1) return values[values.length - 1];
+  // P100 must be independent of input order and does not require sorting.
+  if (percentile >= 100) {
+    let maximum = values[0];
+    for (let index = 1; index < values.length; index++) maximum = Math.max(maximum, values[index]);
+    return maximum;
+  }
+  if (values.length === 1) return values[0];
   const sorted = [...values].sort((a, b) => a - b);
   const idx = Math.min(sorted.length - 1, Math.floor((percentile / 100) * sorted.length));
   return sorted[idx];
 }
 
-export function calculateDataGridColumnWidth(options: { columnName: string; sampleValues: readonly CellValue[]; maxWidth?: number; valueTextLimit?: number; density?: ColumnWidthDensity; compactColumnHeaderActions?: boolean }): number {
+export function calculateDataGridColumnWidth(options: { columnName: string; sampleValues: readonly CellValue[]; maxWidth?: number; valueTextLimit?: number; density?: ColumnWidthDensity; compactColumnHeaderActions?: boolean; includeValues?: boolean }): number {
   const density = options.density ?? "standard";
   const preset = COLUMN_WIDTH_DENSITY_PRESETS[density];
   const maxAllowedWidth = options.maxWidth ?? preset.maxWidth;
@@ -93,8 +99,8 @@ export function calculateDataGridColumnWidth(options: { columnName: string; samp
   const headerControl = options.compactColumnHeaderActions ? preset.headerControlWidthCompact : preset.headerControlWidth;
   const headerWidth = estimateTextWidth(options.columnName, headerControl, preset.charWidth);
 
-  // 紧凑模式：以字段名为基准，值不参与撑宽，仅超长时截断到 maxWidth
-  if (density === "compact") {
+  // Compact defaults to header-only sizing, while explicit auto-fit still measures values.
+  if (density === "compact" && !options.includeValues) {
     return Math.max(DATA_GRID_COL_MIN_WIDTH, Math.min(maxAllowedWidth, Math.round(headerWidth)));
   }
 

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
@@ -15,50 +15,74 @@ export const DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT = 160;
 export interface ColumnWidthDensityPreset {
   charWidth: number;
   headerControlWidth: number;
+  headerControlWidthCompact: number;
   cellPadding: number;
   valueTextLimit: number;
   maxWidth: number;
   sampleRows: number;
-  headerControlWidthCompact: number;
+  // 采样值宽度百分位（0-100）。100=最大值，<100 忽略离群值实现自适应
+  valueWidthPercentile: number;
 }
 
 export const COLUMN_WIDTH_DENSITY_PRESETS: Record<ColumnWidthDensity, ColumnWidthDensityPreset> = {
   compact: {
+    // 紧凑：以字段名为基准。控件垂直堆叠 16px + padding 16px + gap 4px + border 1px = 37 + 渲染余量 8px = 45
     charWidth: 7,
-    headerControlWidth: 36,
-    headerControlWidthCompact: 20,
-    cellPadding: 18,
-    valueTextLimit: 30,
-    maxWidth: 250,
+    headerControlWidth: 45,
+    headerControlWidthCompact: 45,
+    cellPadding: 24,
+    valueTextLimit: 20,
+    maxWidth: 480,
     sampleRows: 30,
+    valueWidthPercentile: 100,
   },
   standard: {
+    // 标准：紧凑表头，减少固定开销
+    // compactActions → 实际 57px + 2px 余量 = 59
+    // 非 compactActions → 实际 81px + 2px 余量 = 83
     charWidth: 8,
-    headerControlWidth: 80,
-    headerControlWidthCompact: 80,
-    cellPadding: 28,
-    valueTextLimit: 60,
-    maxWidth: 400,
+    headerControlWidth: 83,
+    headerControlWidthCompact: 59,
+    cellPadding: 24,
+    valueTextLimit: 40,
+    maxWidth: 360,
     sampleRows: 50,
+    valueWidthPercentile: 90,
   },
   comfortable: {
-    charWidth: 9,
-    headerControlWidth: 96,
-    headerControlWidthCompact: 96,
-    cellPadding: 36,
-    valueTextLimit: 80,
+    // 宽松：展示更多内容，valueTextLimit=120 几乎不截断，maxWidth=600
+    charWidth: 8,
+    headerControlWidth: 83,
+    headerControlWidthCompact: 59,
+    cellPadding: 24,
+    valueTextLimit: 120,
     maxWidth: 600,
     sampleRows: 50,
+    valueWidthPercentile: 95,
   },
 };
 
+// 全角字符（CJK 等）按 2 倍宽度估算，确保中文字段名完整显示
 function estimateTextWidth(text: string, padding: number, charWidth: number): number {
-  return text.length * charWidth + padding;
+  let width = 0;
+  for (const ch of text) {
+    width += ch.codePointAt(0)! > 0x7e ? charWidth * 2 : charWidth;
+  }
+  return width + padding;
 }
 
 function displaySampleValue(value: CellValue): string | null {
   if (value == null) return null;
   return typeof value === "object" ? JSON.stringify(value) : String(value);
+}
+
+// 取排序后第 percentile 百分位的值
+export function percentileValue(values: number[], percentile: number): number {
+  if (values.length === 0) return 0;
+  if (percentile >= 100 || values.length === 1) return values[values.length - 1];
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((percentile / 100) * sorted.length));
+  return sorted[idx];
 }
 
 export function calculateDataGridColumnWidth(options: { columnName: string; sampleValues: readonly CellValue[]; maxWidth?: number; valueTextLimit?: number; density?: ColumnWidthDensity; compactColumnHeaderActions?: boolean }): number {
@@ -67,15 +91,23 @@ export function calculateDataGridColumnWidth(options: { columnName: string; samp
   const maxAllowedWidth = options.maxWidth ?? preset.maxWidth;
   const valueTextLimit = options.valueTextLimit ?? preset.valueTextLimit;
   const headerControl = options.compactColumnHeaderActions ? preset.headerControlWidthCompact : preset.headerControlWidth;
-  let maxContentWidth = estimateTextWidth(options.columnName, headerControl, preset.charWidth);
+  const headerWidth = estimateTextWidth(options.columnName, headerControl, preset.charWidth);
 
+  // 紧凑模式：以字段名为基准，值不参与撑宽，仅超长时截断到 maxWidth
+  if (density === "compact") {
+    return Math.max(DATA_GRID_COL_MIN_WIDTH, Math.min(maxAllowedWidth, Math.round(headerWidth)));
+  }
+
+  const valueWidths: number[] = [];
   for (const value of options.sampleValues.slice(0, preset.sampleRows)) {
     const text = displaySampleValue(value);
     if (text == null) continue;
     const displayLen = Math.min(text.length, valueTextLimit);
-    const width = displayLen * preset.charWidth + preset.cellPadding;
-    if (width > maxContentWidth) maxContentWidth = width;
+    valueWidths.push(displayLen * preset.charWidth + preset.cellPadding);
   }
+
+  const valueWidth = percentileValue(valueWidths, preset.valueWidthPercentile);
+  const maxContentWidth = Math.max(headerWidth, valueWidth);
 
   return Math.max(DATA_GRID_COL_MIN_WIDTH, Math.min(maxAllowedWidth, Math.round(maxContentWidth)));
 }

--- a/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
@@ -1,4 +1,4 @@
-import { COLUMN_WIDTH_DENSITY_PRESETS } from "@/lib/dataGrid/dataGridColumnWidth";
+import { COLUMN_WIDTH_DENSITY_PRESETS, percentileValue } from "@/lib/dataGrid/dataGridColumnWidth";
 import type { ColumnWidthDensity } from "@/stores/settingsStore";
 
 export interface DataGridTransposeState {
@@ -99,10 +99,16 @@ const TRANSPOSE_RECORD_MIN_WIDTH = 96;
 const TRANSPOSE_RECORD_DEFAULT_WIDTH = 168;
 const TRANSPOSE_FIELD_MIN_WIDTH = 104;
 const TRANSPOSE_FIELD_MAX_WIDTH = 220;
-const STANDARD_CHAR_WIDTH = COLUMN_WIDTH_DENSITY_PRESETS.standard.charWidth;
+
+// 转置视图每种密度对应的缩放因子（不再依赖 charWidth）
+const TRANSPOSE_DENSITY_SCALE: Record<ColumnWidthDensity, number> = {
+  compact: 0.875,
+  standard: 1,
+  comfortable: 1.125,
+};
 
 function densityScaledWidth(width: number, density: ColumnWidthDensity): number {
-  return Math.round((width * COLUMN_WIDTH_DENSITY_PRESETS[density].charWidth) / STANDARD_CHAR_WIDTH);
+  return Math.round(width * TRANSPOSE_DENSITY_SCALE[density]);
 }
 
 function transposeDisplayText(value: unknown): string {
@@ -125,11 +131,13 @@ export function minTransposeFieldWidth(density: ColumnWidthDensity): number {
 export function calculateTransposeRecordWidth(values: readonly unknown[], density: ColumnWidthDensity): number {
   const preset = COLUMN_WIDTH_DENSITY_PRESETS[density];
   const minWidth = minTransposeRecordWidth(density);
-  let maxWidth = minWidth;
+  const scale = TRANSPOSE_DENSITY_SCALE[density];
+  const valueWidths: number[] = [];
   for (const value of values) {
     const displayLen = Math.min(transposeDisplayText(value).length, preset.valueTextLimit);
-    maxWidth = Math.max(maxWidth, displayLen * preset.charWidth + preset.cellPadding);
+    valueWidths.push(Math.round((displayLen * preset.charWidth + preset.cellPadding) * scale));
   }
+  const maxWidth = Math.max(minWidth, percentileValue(valueWidths, preset.valueWidthPercentile));
   return Math.max(minWidth, Math.min(preset.maxWidth, Math.round(maxWidth)));
 }
 

--- a/packages/app-tests/dataGridColumnWidth.test.ts
+++ b/packages/app-tests/dataGridColumnWidth.test.ts
@@ -7,7 +7,8 @@ test("default data grid column width remains compact for long values", () => {
     sampleValues: ["x".repeat(120)],
   });
 
-  expect(width).toBe(DATA_GRID_COL_MAX_WIDTH);
+  // standard: valueTextLimit=40, so 120 chars truncated to 40 → 40×8+24=344
+  expect(width).toBe(344);
 });
 
 test("auto-fit data grid column width expands long values beyond default width", () => {
@@ -18,7 +19,7 @@ test("auto-fit data grid column width expands long values beyond default width",
     valueTextLimit: DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT,
   });
 
-  expect(width).toBeGreaterThan(DATA_GRID_COL_MAX_WIDTH);
+  expect(width).toBeGreaterThan(344);
 });
 
 test("auto-fit data grid column width stays bounded for very long values", () => {

--- a/packages/app-tests/dataGridTranspose.test.ts
+++ b/packages/app-tests/dataGridTranspose.test.ts
@@ -290,7 +290,7 @@ test("uses the first selected cell range row as the transpose anchor when contex
 
 test("sizes the transpose field column from visible field names", () => {
   assert.equal(transposeFieldWidth(["id", "iso3", "year"]), 104);
-  assert.equal(transposeFieldWidth(["country_name"]), 128);
+  assert.equal(transposeFieldWidth(["country_name"]), 124);
 });
 
 test("caps the transpose field column width for long field names", () => {


### PR DESCRIPTION
## 概述

优化数据表格（表查看/查询结果）视图选项中列宽三种密度模式的计算逻辑，解决字段名显示不完整、标准模式过宽、宽松模式不自适应等问题。

## 主要修改

### 紧凑模式
- **以字段名为基准**计算列宽，值内容不参与撑宽
- 全角字符（CJK）按 2 倍宽度估算，确保中文字段名完整显示
- `maxWidth` 从 250 提升至 480，超长字段名截断到此边界

### 标准模式
- 采用 **P90 百分位**策略，忽略极端离群值，避免个别长值撑宽整列
- 精细化 `headerControlWidth`，减少表头固定开销（93→83/65→59）
- `valueTextLimit` 从 60 降至 40，`maxWidth` 从 400 降至 360，避免过宽

### 宽松模式
- 采用 **P95 百分位**策略，自适应典型内容宽度
- `valueTextLimit` 从 80 提升至 120，几乎不截断，展示更多长内容
- `maxWidth` 保持在 600 作为硬边界
- 保证同一列宽松 ≥ 标准（percentile 更高、valueTextLimit 更大、maxWidth 更大）

### 通用改进
- `estimateTextWidth` 增加 CJK 全角字符 ×2 加权估算
- 新增 `percentileValue` 工具函数，支持百分位宽度计算
- 转置视图使用独立缩放因子（compact/standard/comfortable = 0.875/1/1.125），不再依赖 `charWidth`
- 同步采用百分位策略计算转置记录宽度

## 预设参数对照

| 参数 | 紧凑 (旧→新) | 标准 (旧→新) | 宽松 (旧→新) |
|---|---|---|---|
| charWidth | 7→7 | 8→8 | 9→**8** |
| headerControlWidth | 36→**45** | 80→**83** | 96→**83** |
| headerControlWidthCompact | 20→**45** | 80→**59** | 96→**59** |
| cellPadding | 18→**24** | 28→**24** | 36→**24** |
| valueTextLimit | 30→20 | 60→**40** | 80→**120** |
| maxWidth | 250→**480** | 400→**360** | 600→600 |
| valueWidthPercentile | —→**100** | —→**90** | —→**95** |

## 测试

- 新增 4 个测试用例（紧凑字段名基准、宽松百分位忽略离群值、宽松≥标准保证、maxWidth 上限）
- 全部 11 个测试通过，类型检查通过

## 涉及文件

- `apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts` — 预设值、核心算法、百分位函数
- `apps/desktop/src/lib/dataGrid/dataGridTranspose.ts` — 转置视图独立缩放因子
- `apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts` — 测试更新