### PR TITLE
feat(editor): prefill new query with SELECT * FROM focused table

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -38,7 +38,7 @@ import * as api from "@/lib/backend/api";
 import { connectionRedactedNameLabel } from "@/lib/connection/connectionPresentation";
 import { quickConnectionOpenTarget } from "@/lib/connection/connectionOpenTarget";
 import { resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
-import { findTreeNodeById, resolveNewQueryTarget } from "@/lib/sql/newQueryContext";
+import { findTreeNodeById, resolveNewQueryTarget, resolveNewQueryInitialSql } from "@/lib/sql/newQueryContext";
 import { buildExecutableObjectSourceStatements, executeObjectSourceSave } from "@/lib/table/objectSourceEditor";
 import { resolveExecutableSql, resolveExecutableSqlWithBackend, type SqlExecutionSnapshot } from "@/lib/sql/sqlExecutionTarget";
 import { uuid } from "@/lib/common/utils";
@@ -1085,7 +1085,18 @@ async function newQuery() {
   const conn = connectionStore.getConfig(target.connectionId);
   if (!conn) return;
   connectionStore.activeConnectionId = target.connectionId;
-  const tabId = queryStore.createTab(conn.id, target.database, undefined, "query", target.schema);
+  // Prefill the editor with `SELECT * FROM <focused table>` when enabled and a
+  // table context (active data/structure tab or selected table node) is available.
+  // Built before createTab so the tab opens with the content directly (no flash).
+  const initialSql = resolveNewQueryInitialSql({
+    activeTab: activeTab.value,
+    selectedTreeNode: findTreeNodeById(connectionStore.treeNodes, connectionStore.selectedTreeNodeId),
+    preferredSource: newQueryContextSource.value,
+    prefillEnabled: settingsStore.editorSettings.prefillNewQueryWithSelect,
+    targetConnectionId: target.connectionId,
+    databaseType: effectiveDatabaseTypeForConnection(conn),
+  });
+  const tabId = queryStore.createTab(conn.id, target.database, undefined, "query", target.schema, initialSql);
   try {
     await connectionStore.ensureConnected(target.connectionId);
     if (target.shouldRefreshDefaultDatabase) {

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1094,6 +1094,7 @@ async function newQuery() {
     preferredSource: newQueryContextSource.value,
     prefillEnabled: settingsStore.editorSettings.prefillNewQueryWithSelect,
     targetConnectionId: target.connectionId,
+    targetDatabase: target.database,
     databaseType: effectiveDatabaseTypeForConnection(conn),
   });
   const tabId = queryStore.createTab(conn.id, target.database, undefined, "query", target.schema, initialSql);

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -330,6 +330,7 @@ const editAutoSelectActiveSidebarNode = ref(settingsStore.editorSettings.autoSel
 const editOpenTabsRestoreMode = ref<OpenTabsRestoreMode>(settingsStore.editorSettings.openTabsRestoreMode);
 const editDisconnectTabHandlingMode = ref<DisconnectTabHandlingMode>(settingsStore.editorSettings.disconnectTabHandlingMode);
 const editReuseDataTab = ref(settingsStore.editorSettings.reuseDataTab);
+const editPrefillNewQueryWithSelect = ref(settingsStore.editorSettings.prefillNewQueryWithSelect);
 const editUpdateNotificationsEnabled = ref(settingsStore.editorSettings.updateNotificationsEnabled);
 const editSidebarHiddenTablePrefixes = ref(settingsStore.editorSettings.sidebarHiddenTablePrefixes.join("\n"));
 const editSidebarHideTableComments = ref(settingsStore.editorSettings.sidebarHideTableComments);
@@ -415,6 +416,7 @@ function currentEditorSettingsDraft(): EditorSettingsDraft {
     openTabsRestoreMode: editOpenTabsRestoreMode.value,
     disconnectTabHandlingMode: editDisconnectTabHandlingMode.value,
     reuseDataTab: editReuseDataTab.value,
+    prefillNewQueryWithSelect: editPrefillNewQueryWithSelect.value,
     updateNotificationsEnabled: editUpdateNotificationsEnabled.value,
     sidebarHideTableComments: editSidebarHideTableComments.value,
     sidebarAllowHorizontalScroll: editSidebarAllowHorizontalScroll.value,
@@ -690,6 +692,7 @@ function syncEditorSettingsDraftFromStore() {
   editOpenTabsRestoreMode.value = settingsStore.editorSettings.openTabsRestoreMode;
   editDisconnectTabHandlingMode.value = settingsStore.editorSettings.disconnectTabHandlingMode;
   editReuseDataTab.value = settingsStore.editorSettings.reuseDataTab;
+  editPrefillNewQueryWithSelect.value = settingsStore.editorSettings.prefillNewQueryWithSelect;
   editUpdateNotificationsEnabled.value = settingsStore.editorSettings.updateNotificationsEnabled;
   editSidebarHiddenTablePrefixes.value = settingsStore.editorSettings.sidebarHiddenTablePrefixes.join("\n");
   editSidebarHideTableComments.value = settingsStore.editorSettings.sidebarHideTableComments;
@@ -882,6 +885,7 @@ function resetDefaultsForTab(tab: SettingsCategory) {
     editOpenTabsRestoreMode.value = DEFAULT_EDITOR_SETTINGS.openTabsRestoreMode;
     editDisconnectTabHandlingMode.value = DEFAULT_EDITOR_SETTINGS.disconnectTabHandlingMode;
     editReuseDataTab.value = DEFAULT_EDITOR_SETTINGS.reuseDataTab;
+    editPrefillNewQueryWithSelect.value = DEFAULT_EDITOR_SETTINGS.prefillNewQueryWithSelect;
     editUpdateNotificationsEnabled.value = DEFAULT_EDITOR_SETTINGS.updateNotificationsEnabled;
     editSidebarHideTableComments.value = DEFAULT_EDITOR_SETTINGS.sidebarHideTableComments;
     editSidebarAllowHorizontalScroll.value = DEFAULT_EDITOR_SETTINGS.sidebarAllowHorizontalScroll;
@@ -960,6 +964,7 @@ function resetAllDefaults() {
   editOpenTabsRestoreMode.value = DEFAULT_EDITOR_SETTINGS.openTabsRestoreMode;
   editDisconnectTabHandlingMode.value = DEFAULT_EDITOR_SETTINGS.disconnectTabHandlingMode;
   editReuseDataTab.value = DEFAULT_EDITOR_SETTINGS.reuseDataTab;
+  editPrefillNewQueryWithSelect.value = DEFAULT_EDITOR_SETTINGS.prefillNewQueryWithSelect;
   editUpdateNotificationsEnabled.value = DEFAULT_EDITOR_SETTINGS.updateNotificationsEnabled;
   editSidebarHideTableComments.value = DEFAULT_EDITOR_SETTINGS.sidebarHideTableComments;
   editSidebarAllowHorizontalScroll.value = DEFAULT_EDITOR_SETTINGS.sidebarAllowHorizontalScroll;
@@ -2798,6 +2803,14 @@ onUnmounted(cleanupPreviewEditor);
                     </p>
                   </div>
                   <Switch id="editor-confirm-unsaved-sql-close" v-model="editConfirmUnsavedSqlClose" class="mt-0.5" />
+                </div>
+
+                <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
+                  <div class="space-y-1">
+                    <Label for="editor-prefill-new-query">{{ t("settings.prefillNewQueryWithSelect") }}</Label>
+                    <p class="text-xs text-muted-foreground">{{ t("settings.prefillNewQueryWithSelectDescription") }}</p>
+                  </div>
+                  <Switch id="editor-prefill-new-query" v-model="editPrefillNewQueryWithSelect" class="mt-0.5" />
                 </div>
               </div>
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -3351,6 +3351,8 @@ export default {
     confirmDangerousSqlExecutionDescription: "When disabled, ALTER, DROP, DELETE, TRUNCATE, and other dangerous SQL run without the warning dialog.",
     confirmUnsavedSqlClose: "Confirm before closing unsaved SQL",
     confirmUnsavedSqlCloseDescription: "When disabled, SQL tabs with unsaved edits close or quit without the save confirmation dialog.",
+    prefillNewQueryWithSelect: "Prefill new query with SELECT *",
+    prefillNewQueryWithSelectDescription: "When creating a new query, prefill the editor with SELECT * FROM <table> based on the active table tab or the table selected in the sidebar.",
     sqlVariableSyntax: "SQL variable & placeholder substitution",
     sqlVariableSyntaxDescription: "Choose which variable and placeholder syntaxes DBX substitutes before running SQL, per database type. All are enabled by default.",
     sqlVariableSyntax_positional: "Positional placeholder",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -3187,6 +3187,8 @@ export default withEnglishFallback({
     confirmDangerousSqlExecutionDescription: "Cuando se desactiva, ALTER, DROP, DELETE, TRUNCATE y otras sentencias peligrosas se ejecutan sin el diálogo de advertencia.",
     confirmUnsavedSqlClose: "Confirmar antes de cerrar SQL sin guardar",
     confirmUnsavedSqlCloseDescription: "Cuando se desactiva, las pestañas SQL con ediciones sin guardar se cierran o salen sin el diálogo de confirmación de guardado.",
+    prefillNewQueryWithSelect: "Rellenar nueva consulta con SELECT *",
+    prefillNewQueryWithSelectDescription: "Al crear una nueva consulta, rellena el editor con SELECT * FROM <tabla> según la pestaña de tabla activa o la tabla seleccionada en la barra lateral.",
     sqlVariableSyntax: "Sustitución de variables y marcadores SQL",
     sqlVariableSyntaxDescription: "Elige qué sintaxis de variables y marcadores sustituye DBX antes de ejecutar SQL, por tipo de base de datos. Todas están habilitadas de forma predeterminada.",
     sqlVariableSyntax_positional: "Marcador posicional",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -3185,6 +3185,8 @@ export default withEnglishFallback({
     confirmDangerousSqlExecutionDescription: "Se disattivato, ALTER, DROP, DELETE, TRUNCATE e altri SQL pericolosi verranno eseguiti senza la finestra di avviso.",
     confirmUnsavedSqlClose: "Conferma prima di chiudere SQL non salvato",
     confirmUnsavedSqlCloseDescription: "Se disattivato, le schede SQL con modifiche non salvate verranno chiuse o usciranno senza la finestra di conferma di salvataggio.",
+    prefillNewQueryWithSelect: "Precompila nuova query con SELECT *",
+    prefillNewQueryWithSelectDescription: "Alla creazione di una nuova query, precompila l'editor con SELECT * FROM <tabella> in base alla scheda tabella attiva o alla tabella selezionata nella barra laterale.",
     sqlVariableSyntax: "Sostituzione di variabili e segnaposto SQL",
     sqlVariableSyntaxDescription: "Scegli quali sintassi di variabili e segnaposto DBX sostituisce prima di eseguire SQL, per tipo di database. Tutte abilitate per impostazione predefinita.",
     sqlVariableSyntax_positional: "Segnaposto posizionale",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -3175,6 +3175,8 @@ export default withEnglishFallback({
     confirmDangerousSqlExecutionDescription: "無効時、ALTER、DROP、DELETE、TRUNCATEなどの危険なSQLが警告ダイアログなしで実行されます。",
     confirmUnsavedSqlClose: "未保存のSQLを閉じる前に確認",
     confirmUnsavedSqlCloseDescription: "無効時、未保存の編集があるSQLタブは保存確認ダイアログなしで閉じるか終了します。",
+    prefillNewQueryWithSelect: "新規クエリに SELECT を自動入力",
+    prefillNewQueryWithSelectDescription: "新規クエリ作成時、アクティブなテーブルタブまたはサイドバーで選択したテーブルに基づき、エディタに SELECT * FROM <テーブル名> を自動入力します。",
     sqlVariableSyntax: "SQL 変数・プレースホルダー置換",
     sqlVariableSyntaxDescription: "SQL 実行前に置換する変数・プレースホルダー構文をデータベース種別ごとに選択します。既定ではすべて有効です。",
     sqlVariableSyntax_positional: "位置プレースホルダー",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -3187,6 +3187,8 @@ export default withEnglishFallback({
     confirmDangerousSqlExecutionDescription: "Quando desativado, ALTER, DROP, DELETE, TRUNCATE e outros SQL perigosos são executados sem a caixa de diálogo de aviso.",
     confirmUnsavedSqlClose: "Confirmar antes de fechar SQL não salvo",
     confirmUnsavedSqlCloseDescription: "Quando desativado, abas SQL com edições não salvas são fechadas ou o app é encerrado sem a caixa de diálogo de confirmação de salvamento.",
+    prefillNewQueryWithSelect: "Preencher nova consulta com SELECT *",
+    prefillNewQueryWithSelectDescription: "Ao criar uma nova consulta, preenche o editor com SELECT * FROM <tabela> com base na aba de tabela ativa ou na tabela selecionada na barra lateral.",
     sqlVariableSyntax: "Substituição de variáveis e espaços reservados SQL",
     sqlVariableSyntaxDescription: "Escolha quais sintaxes de variáveis e espaços reservados o DBX substitui antes de executar SQL, por tipo de banco de dados. Todas ativadas por padrão.",
     sqlVariableSyntax_positional: "Espaço reservado posicional",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -3350,6 +3350,8 @@ export default withEnglishFallback({
     confirmDangerousSqlExecutionDescription: "关闭后，ALTER、DROP、DELETE、TRUNCATE 等危险 SQL 将直接执行。",
     confirmUnsavedSqlClose: "关闭未保存 SQL 前弹出确认",
     confirmUnsavedSqlCloseDescription: "关闭后，有未保存内容的 SQL 标签页会直接关闭或退出，不再弹出保存确认。",
+    prefillNewQueryWithSelect: "新建查询时预填充 SELECT 语句",
+    prefillNewQueryWithSelectDescription: "新建查询时，根据当前激活的数据表标签页或侧边栏选中的表，自动在编辑器中填充 SELECT * FROM <表名>。",
     sqlVariableSyntax: "SQL 变量与占位符替换",
     sqlVariableSyntaxDescription: "按数据库类型选择执行 SQL 前替换哪些变量与占位符语法，默认全部开启。",
     sqlVariableSyntax_positional: "位置占位符",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -3036,6 +3036,8 @@ export default withEnglishFallback({
     confirmDangerousSqlExecutionDescription: "關閉後，ALTER、DROP、DELETE、TRUNCATE 等危險 SQL 會直接執行。",
     confirmUnsavedSqlClose: "關閉未儲存 SQL 前彈出確認",
     confirmUnsavedSqlCloseDescription: "關閉後，有未儲存內容的 SQL 分頁會直接關閉或結束，不再彈出儲存確認。",
+    prefillNewQueryWithSelect: "新建查詢時預填 SELECT 語句",
+    prefillNewQueryWithSelectDescription: "新建查詢時，根據目前啟用的資料表分頁或側邊欄選取的資料表，自動在編輯器中填入 SELECT * FROM <資料表名稱>。",
     sqlVariableSyntax: "SQL 變數與佔位符替換",
     sqlVariableSyntaxDescription: "依資料庫類型選擇執行 SQL 前替換哪些變數與佔位符語法，預設全部開啟。",
     sqlVariableSyntax_positional: "位置佔位符",

--- a/apps/desktop/src/lib/__tests__/app/openTabsPersistence.spec.ts
+++ b/apps/desktop/src/lib/__tests__/app/openTabsPersistence.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { serializeOpenTabs, restoreOpenTabsPayload } from "@/lib/app/openTabsPersistence";
+import type { QueryTab } from "@/types/database";
+
+function queryTab(overrides: Partial<QueryTab>): QueryTab {
+  return {
+    id: "t1",
+    title: "query_1",
+    connectionId: "c1",
+    database: "db",
+    mode: "query",
+    sql: "",
+    isExecuting: false,
+    ...overrides,
+  } as QueryTab;
+}
+
+function roundTrip(tabs: QueryTab[]) {
+  const saved = serializeOpenTabs(tabs);
+  return restoreOpenTabsPayload({ tabs: saved, activeTabId: tabs[0]?.id ?? null }).tabs;
+}
+
+describe("openTabsPersistence originalSql round-trip", () => {
+  it("restores a clean prefilled query tab as clean (sql === originalSql)", () => {
+    const sql = 'SELECT * FROM "public"."users"';
+    const [restored] = roundTrip([queryTab({ sql, originalSql: sql })]);
+    expect(restored.sql).toBe(sql);
+    expect(restored.originalSql).toBe(sql);
+    expect(restored.sql === restored.originalSql).toBe(true);
+  });
+
+  it("restores a user-edited scratch query tab as dirty (originalSql stays empty)", () => {
+    const [restored] = roundTrip([queryTab({ sql: "SELECT 1", originalSql: "" })]);
+    expect(restored.sql).toBe("SELECT 1");
+    expect(restored.originalSql).toBe("");
+    expect(restored.sql === restored.originalSql).toBe(false);
+  });
+
+  it("restores an empty new query tab as clean", () => {
+    const [restored] = roundTrip([queryTab({ sql: "", originalSql: "" })]);
+    expect(restored.sql).toBe("");
+    expect(restored.originalSql).toBe("");
+  });
+
+  it("falls back to empty originalSql for old saved state without the field (backward compat)", () => {
+    const [restored] = restoreOpenTabsPayload({
+      tabs: [{ id: "t1", title: "query_1", connectionId: "c1", database: "db", mode: "query", sql: "SELECT 1" }],
+      activeTabId: "t1",
+    }).tabs;
+    expect(restored.sql).toBe("SELECT 1");
+    expect(restored.originalSql).toBe("");
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { buildSelectAllSql, isNewQueryPrefillSupported, resolveNewQueryInitialSql, resolveNewQueryTable, type ResolveNewQueryTableInput } from "@/lib/sql/newQueryContext";
+import type { QueryTab, TreeNode } from "@/types/database";
+
+function dataTab(overrides: Partial<Pick<QueryTab, "mode" | "connectionId" | "schema" | "tableMeta" | "structureTableName" | "title">> = {}): ResolveNewQueryTableInput["activeTab"] {
+  return {
+    mode: "data",
+    connectionId: "conn-1",
+    schema: "public",
+    title: "users",
+    tableMeta: { schema: "public", tableName: "users", columns: [], primaryKeys: [] },
+    ...overrides,
+  };
+}
+
+function tableNode(overrides: Partial<Pick<TreeNode, "type" | "connectionId" | "schema" | "catalog" | "tableName" | "label">> = {}): ResolveNewQueryTableInput["selectedTreeNode"] {
+  return { type: "table", connectionId: "conn-1", schema: "public", tableName: "orders", label: "orders", ...overrides };
+}
+
+describe("resolveNewQueryTable", () => {
+  it("resolves the table from an active data tab", () => {
+    const table = resolveNewQueryTable({ activeTab: dataTab(), preferredSource: "tab" });
+    expect(table).toEqual({ connectionId: "conn-1", schema: "public", catalog: undefined, tableName: "users" });
+  });
+
+  it("returns null when a data tab has no loaded tableMeta (still loading or errored)", () => {
+    // A data tab's title is schema/catalog-qualified (e.g. "public.events"), so it must
+    // not be used as a bare table name - require the loaded tableMeta instead.
+    const table = resolveNewQueryTable({
+      activeTab: { mode: "data", connectionId: "conn-1", schema: "public", title: "public.events" },
+      preferredSource: "tab",
+    });
+    expect(table).toBeNull();
+  });
+
+  it("resolves the table from an active structure tab", () => {
+    const table = resolveNewQueryTable({
+      activeTab: { mode: "structure", connectionId: "conn-1", schema: "public", structureTableName: "users" },
+      preferredSource: "tab",
+    });
+    expect(table).toEqual({ connectionId: "conn-1", schema: "public", catalog: undefined, tableName: "users" });
+  });
+
+  it("returns null for a query tab with no table context", () => {
+    const table = resolveNewQueryTable({
+      activeTab: { mode: "query", connectionId: "conn-1", schema: "public", title: "query_1" },
+      preferredSource: "tab",
+    });
+    expect(table).toBeNull();
+  });
+
+  it("resolves the table from a selected sidebar table/view/materialized_view node", () => {
+    expect(resolveNewQueryTable({ selectedTreeNode: tableNode(), preferredSource: "sidebar" })?.tableName).toBe("orders");
+    expect(resolveNewQueryTable({ selectedTreeNode: tableNode({ type: "view" }), preferredSource: "sidebar" })?.tableName).toBe("orders");
+    expect(resolveNewQueryTable({ selectedTreeNode: tableNode({ type: "materialized_view" }), preferredSource: "sidebar" })?.tableName).toBe("orders");
+  });
+
+  it("uses the node label when tableName is absent", () => {
+    const table = resolveNewQueryTable({
+      selectedTreeNode: { type: "table", connectionId: "conn-1", schema: "public", label: "by_label" },
+      preferredSource: "sidebar",
+    });
+    expect(table?.tableName).toBe("by_label");
+  });
+
+  it("ignores sidebar nodes that are not tables", () => {
+    const table = resolveNewQueryTable({
+      selectedTreeNode: { type: "schema", connectionId: "conn-1", label: "public" },
+      preferredSource: "sidebar",
+    });
+    expect(table).toBeNull();
+  });
+
+  it("prefers the active tab when preferredSource is 'tab'", () => {
+    const table = resolveNewQueryTable({ activeTab: dataTab(), selectedTreeNode: tableNode(), preferredSource: "tab" });
+    expect(table?.tableName).toBe("users");
+  });
+
+  it("prefers the sidebar node when preferredSource is 'sidebar'", () => {
+    const table = resolveNewQueryTable({ activeTab: dataTab(), selectedTreeNode: tableNode(), preferredSource: "sidebar" });
+    expect(table?.tableName).toBe("orders");
+  });
+
+  it("falls back to the secondary context when the primary has no table", () => {
+    const table = resolveNewQueryTable({
+      activeTab: { mode: "query", connectionId: "conn-1", title: "query_1" },
+      selectedTreeNode: tableNode(),
+      preferredSource: "tab",
+    });
+    expect(table?.tableName).toBe("orders");
+  });
+
+  it("returns null when no context is available", () => {
+    expect(resolveNewQueryTable({})).toBeNull();
+    expect(resolveNewQueryTable({ activeTab: null, selectedTreeNode: null })).toBeNull();
+  });
+});
+
+describe("buildSelectAllSql", () => {
+  it("quotes a MySQL table with backticks", () => {
+    expect(buildSelectAllSql("mysql", { tableName: "users" })).toBe("SELECT * FROM `users`");
+  });
+
+  it("ignores the schema for non-schema-aware databases like MySQL", () => {
+    expect(buildSelectAllSql("mysql", { schema: "mydb", tableName: "users" })).toBe("SELECT * FROM `users`");
+  });
+
+  it("qualifies and quotes a PostgreSQL table with its schema", () => {
+    expect(buildSelectAllSql("postgres", { schema: "public", tableName: "users" })).toBe('SELECT * FROM "public"."users"');
+  });
+
+  it("bracket-quotes a SQL Server table", () => {
+    expect(buildSelectAllSql("sqlserver", { schema: "dbo", tableName: "users" })).toBe("SELECT * FROM [dbo].[users]");
+    expect(buildSelectAllSql("sqlserver", { tableName: "users" })).toBe("SELECT * FROM [users]");
+  });
+
+  it("escapes embedded quote characters", () => {
+    expect(buildSelectAllSql("mysql", { tableName: "a`b" })).toBe("SELECT * FROM `a``b`");
+    expect(buildSelectAllSql("postgres", { tableName: 'a"b' })).toBe('SELECT * FROM "a""b"');
+  });
+});
+
+describe("isNewQueryPrefillSupported", () => {
+  it("disables the prefill for Neo4j (Cypher, not SQL)", () => {
+    expect(isNewQueryPrefillSupported("neo4j")).toBe(false);
+  });
+
+  it("enables the prefill for standard SQL databases", () => {
+    expect(isNewQueryPrefillSupported("mysql")).toBe(true);
+    expect(isNewQueryPrefillSupported("postgres")).toBe(true);
+    expect(isNewQueryPrefillSupported("sqlserver")).toBe(true);
+    expect(isNewQueryPrefillSupported("sqlite")).toBe(true);
+    expect(isNewQueryPrefillSupported("clickhouse")).toBe(true);
+  });
+
+  it("enables the prefill when the database type is unknown", () => {
+    expect(isNewQueryPrefillSupported(undefined)).toBe(true);
+  });
+});
+
+describe("resolveNewQueryInitialSql", () => {
+  it("prefills SQL from the active table when enabled", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        activeTab: dataTab(),
+        prefillEnabled: true,
+        targetConnectionId: "conn-1",
+        databaseType: "postgres",
+      }),
+    ).toBe('SELECT * FROM "public"."users"');
+  });
+
+  it("leaves new queries empty when the setting is disabled", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        activeTab: dataTab(),
+        prefillEnabled: false,
+        targetConnectionId: "conn-1",
+        databaseType: "postgres",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not prefill a table from another connection", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        activeTab: dataTab({ connectionId: "conn-2" }),
+        prefillEnabled: true,
+        targetConnectionId: "conn-1",
+        databaseType: "postgres",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("leaves new queries empty without a table context", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        prefillEnabled: true,
+        targetConnectionId: "conn-1",
+        databaseType: "postgres",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not prefill for unsupported database types (e.g. Neo4j)", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        activeTab: dataTab(),
+        prefillEnabled: true,
+        targetConnectionId: "conn-1",
+        databaseType: "neo4j",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { buildSelectAllSql, isNewQueryPrefillSupported, resolveNewQueryInitialSql, resolveNewQueryTable, type ResolveNewQueryTableInput } from "@/lib/sql/newQueryContext";
 import type { QueryTab, TreeNode } from "@/types/database";
 
-function dataTab(overrides: Partial<Pick<QueryTab, "mode" | "connectionId" | "schema" | "tableMeta" | "structureTableName" | "title">> = {}): ResolveNewQueryTableInput["activeTab"] {
+function dataTab(overrides: Partial<Pick<QueryTab, "mode" | "connectionId" | "database" | "schema" | "tableMeta" | "structureTableName" | "title">> = {}): ResolveNewQueryTableInput["activeTab"] {
   return {
     mode: "data",
     connectionId: "conn-1",
+    database: "app_db",
     schema: "public",
     title: "users",
     tableMeta: { schema: "public", tableName: "users", columns: [], primaryKeys: [] },
@@ -13,21 +14,21 @@ function dataTab(overrides: Partial<Pick<QueryTab, "mode" | "connectionId" | "sc
   };
 }
 
-function tableNode(overrides: Partial<Pick<TreeNode, "type" | "connectionId" | "schema" | "catalog" | "tableName" | "label">> = {}): ResolveNewQueryTableInput["selectedTreeNode"] {
-  return { type: "table", connectionId: "conn-1", schema: "public", tableName: "orders", label: "orders", ...overrides };
+function tableNode(overrides: Partial<Pick<TreeNode, "type" | "connectionId" | "database" | "schema" | "catalog" | "tableName" | "label">> = {}): ResolveNewQueryTableInput["selectedTreeNode"] {
+  return { type: "table", connectionId: "conn-1", database: "app_db", schema: "public", tableName: "orders", label: "orders", ...overrides };
 }
 
 describe("resolveNewQueryTable", () => {
   it("resolves the table from an active data tab", () => {
     const table = resolveNewQueryTable({ activeTab: dataTab(), preferredSource: "tab" });
-    expect(table).toEqual({ connectionId: "conn-1", schema: "public", catalog: undefined, tableName: "users" });
+    expect(table).toEqual({ connectionId: "conn-1", database: "app_db", schema: "public", catalog: undefined, tableName: "users" });
   });
 
   it("returns null when a data tab has no loaded tableMeta (still loading or errored)", () => {
     // A data tab's title is schema/catalog-qualified (e.g. "public.events"), so it must
     // not be used as a bare table name - require the loaded tableMeta instead.
     const table = resolveNewQueryTable({
-      activeTab: { mode: "data", connectionId: "conn-1", schema: "public", title: "public.events" },
+      activeTab: { mode: "data", connectionId: "conn-1", database: "app_db", schema: "public", title: "public.events" },
       preferredSource: "tab",
     });
     expect(table).toBeNull();
@@ -35,15 +36,15 @@ describe("resolveNewQueryTable", () => {
 
   it("resolves the table from an active structure tab", () => {
     const table = resolveNewQueryTable({
-      activeTab: { mode: "structure", connectionId: "conn-1", schema: "public", structureTableName: "users" },
+      activeTab: { mode: "structure", connectionId: "conn-1", database: "app_db", schema: "public", structureTableName: "users" },
       preferredSource: "tab",
     });
-    expect(table).toEqual({ connectionId: "conn-1", schema: "public", catalog: undefined, tableName: "users" });
+    expect(table).toEqual({ connectionId: "conn-1", database: "app_db", schema: "public", catalog: undefined, tableName: "users" });
   });
 
   it("returns null for a query tab with no table context", () => {
     const table = resolveNewQueryTable({
-      activeTab: { mode: "query", connectionId: "conn-1", schema: "public", title: "query_1" },
+      activeTab: { mode: "query", connectionId: "conn-1", database: "app_db", schema: "public", title: "query_1" },
       preferredSource: "tab",
     });
     expect(table).toBeNull();
@@ -57,7 +58,7 @@ describe("resolveNewQueryTable", () => {
 
   it("uses the node label when tableName is absent", () => {
     const table = resolveNewQueryTable({
-      selectedTreeNode: { type: "table", connectionId: "conn-1", schema: "public", label: "by_label" },
+      selectedTreeNode: { type: "table", connectionId: "conn-1", database: "app_db", schema: "public", label: "by_label" },
       preferredSource: "sidebar",
     });
     expect(table?.tableName).toBe("by_label");
@@ -83,7 +84,7 @@ describe("resolveNewQueryTable", () => {
 
   it("falls back to the secondary context when the primary has no table", () => {
     const table = resolveNewQueryTable({
-      activeTab: { mode: "query", connectionId: "conn-1", title: "query_1" },
+      activeTab: { mode: "query", connectionId: "conn-1", database: "app_db", title: "query_1" },
       selectedTreeNode: tableNode(),
       preferredSource: "tab",
     });
@@ -145,6 +146,7 @@ describe("resolveNewQueryInitialSql", () => {
         activeTab: dataTab(),
         prefillEnabled: true,
         targetConnectionId: "conn-1",
+        targetDatabase: "app_db",
         databaseType: "postgres",
       }),
     ).toBe('SELECT * FROM "public"."users"');
@@ -156,6 +158,7 @@ describe("resolveNewQueryInitialSql", () => {
         activeTab: dataTab(),
         prefillEnabled: false,
         targetConnectionId: "conn-1",
+        targetDatabase: "app_db",
         databaseType: "postgres",
       }),
     ).toBeUndefined();
@@ -167,7 +170,22 @@ describe("resolveNewQueryInitialSql", () => {
         activeTab: dataTab({ connectionId: "conn-2" }),
         prefillEnabled: true,
         targetConnectionId: "conn-1",
+        targetDatabase: "app_db",
         databaseType: "postgres",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not prefill a table from another database on the same connection", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        activeTab: { mode: "query", connectionId: "conn-1", database: "db_a", title: "query_1" },
+        selectedTreeNode: tableNode({ database: "db_b" }),
+        preferredSource: "tab",
+        prefillEnabled: true,
+        targetConnectionId: "conn-1",
+        targetDatabase: "db_a",
+        databaseType: "mysql",
       }),
     ).toBeUndefined();
   });
@@ -177,6 +195,7 @@ describe("resolveNewQueryInitialSql", () => {
       resolveNewQueryInitialSql({
         prefillEnabled: true,
         targetConnectionId: "conn-1",
+        targetDatabase: "app_db",
         databaseType: "postgres",
       }),
     ).toBeUndefined();
@@ -188,6 +207,7 @@ describe("resolveNewQueryInitialSql", () => {
         activeTab: dataTab(),
         prefillEnabled: true,
         targetConnectionId: "conn-1",
+        targetDatabase: "app_db",
         databaseType: "neo4j",
       }),
     ).toBeUndefined();

--- a/apps/desktop/src/lib/app/openTabsPersistence.ts
+++ b/apps/desktop/src/lib/app/openTabsPersistence.ts
@@ -22,6 +22,7 @@ export interface SavedOpenTab {
   database: string;
   schema?: string;
   sql: string;
+  originalSql?: string;
   savedSqlId?: string;
   externalSqlPath?: string;
   lastExecutedSql?: string;
@@ -69,6 +70,10 @@ function restoredOriginalSql(tab: SavedOpenTab, mode: QueryTab["mode"], sql: str
   if (mode !== "query") return undefined;
   if (tab.externalSqlPath) return sql;
   if (tab.savedSqlId) return sql ? "" : undefined;
+  // Prefer the persisted originalSql so a clean prefilled query tab (sql === originalSql)
+  // restores clean instead of being marked dirty. Older saved state without this field
+  // falls through to "" (preserving prior behavior for user-edited scratch tabs).
+  if (tab.originalSql !== undefined) return tab.originalSql;
   return "";
 }
 
@@ -81,6 +86,10 @@ export function serializeOpenTabs(tabs: QueryTab[]): SavedOpenTab[] {
     database: tab.database,
     schema: tab.schema,
     sql: shouldPersistTabSql(tab) ? tab.sql : "",
+    // Only round-trip originalSql for plain query tabs (no savedSqlId / externalSqlPath):
+    // saved-SQL and external-file tabs re-derive it on restore, and persisting it here
+    // would duplicate their (potentially large) SQL text in the open-tabs state.
+    ...(tab.originalSql !== undefined && !tab.savedSqlId && !tab.externalSqlPath ? { originalSql: tab.originalSql } : {}),
     savedSqlId: tab.savedSqlId,
     externalSqlPath: tab.externalSqlPath,
     ...(tab.lastExecutedSql !== undefined ? { lastExecutedSql: tab.lastExecutedSql } : {}),

--- a/apps/desktop/src/lib/settings/editorSettingsDraft.ts
+++ b/apps/desktop/src/lib/settings/editorSettingsDraft.ts
@@ -38,6 +38,7 @@ export const EDITOR_SETTINGS_DRAFT_KEYS = [
   "openTabsRestoreMode",
   "disconnectTabHandlingMode",
   "reuseDataTab",
+  "prefillNewQueryWithSelect",
   "updateNotificationsEnabled",
   "sidebarHideTableComments",
   "sidebarAllowHorizontalScroll",

--- a/apps/desktop/src/lib/sql/newQueryContext.ts
+++ b/apps/desktop/src/lib/sql/newQueryContext.ts
@@ -63,20 +63,22 @@ function targetFromContext(context: Pick<QueryTab | TreeNode, "connectionId" | "
 
 export interface NewQueryTable {
   connectionId: string;
+  database: string;
   schema?: string;
   catalog?: string;
   tableName: string;
 }
 
 export interface ResolveNewQueryTableInput {
-  activeTab?: Pick<QueryTab, "mode" | "connectionId" | "schema" | "tableMeta" | "structureTableName" | "title"> | null;
-  selectedTreeNode?: Pick<TreeNode, "type" | "connectionId" | "schema" | "catalog" | "tableName" | "label"> | null;
+  activeTab?: Pick<QueryTab, "mode" | "connectionId" | "database" | "schema" | "tableMeta" | "structureTableName" | "title"> | null;
+  selectedTreeNode?: Pick<TreeNode, "type" | "connectionId" | "database" | "schema" | "catalog" | "tableName" | "label"> | null;
   preferredSource?: NewQueryContextSource;
 }
 
 export interface ResolveNewQueryInitialSqlInput extends ResolveNewQueryTableInput {
   prefillEnabled: boolean;
   targetConnectionId: string;
+  targetDatabase: string;
   databaseType?: DatabaseType;
 }
 
@@ -97,12 +99,12 @@ function tableFromTab(tab: ResolveNewQueryTableInput["activeTab"]): NewQueryTabl
     const meta = tab.tableMeta;
     const tableName = meta?.tableName?.trim();
     if (!tableName) return null;
-    return { connectionId: tab.connectionId, schema: meta?.schema ?? tab.schema, catalog: meta?.catalog, tableName };
+    return { connectionId: tab.connectionId, database: tab.database, schema: meta?.schema ?? tab.schema, catalog: meta?.catalog, tableName };
   }
   if (tab.mode === "structure") {
     const tableName = (tab.structureTableName || "").trim();
     if (!tableName) return null;
-    return { connectionId: tab.connectionId, schema: tab.schema, tableName };
+    return { connectionId: tab.connectionId, database: tab.database, schema: tab.schema, tableName };
   }
   return null;
 }
@@ -112,7 +114,7 @@ function tableFromNode(node: ResolveNewQueryTableInput["selectedTreeNode"]): New
   if (node.type !== "table" && node.type !== "view" && node.type !== "materialized_view") return null;
   const tableName = (node.tableName || node.label || "").trim();
   if (!tableName) return null;
-  return { connectionId: node.connectionId, schema: node.schema, catalog: node.catalog, tableName };
+  return { connectionId: node.connectionId, database: node.database || "", schema: node.schema, catalog: node.catalog, tableName };
 }
 
 /**
@@ -140,14 +142,14 @@ export function buildSelectAllSql(databaseType: DatabaseType | undefined, table:
 
 /**
  * Resolves the optional initial SQL for a new query tab. A table from another
- * connection is intentionally ignored because it cannot safely run on the
- * target connection selected for the new tab.
+ * connection or database is intentionally ignored because it cannot safely run
+ * in the execution context selected for the new tab.
  */
 export function resolveNewQueryInitialSql(input: ResolveNewQueryInitialSqlInput): string | undefined {
   if (!input.prefillEnabled || !isNewQueryPrefillSupported(input.databaseType)) return undefined;
 
   const table = resolveNewQueryTable(input);
-  if (!table || table.connectionId !== input.targetConnectionId) return undefined;
+  if (!table || table.connectionId !== input.targetConnectionId || table.database !== input.targetDatabase) return undefined;
 
   return buildSelectAllSql(input.databaseType, table);
 }

--- a/apps/desktop/src/lib/sql/newQueryContext.ts
+++ b/apps/desktop/src/lib/sql/newQueryContext.ts
@@ -1,5 +1,6 @@
 import { resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
-import type { ConnectionConfig, QueryTab, TreeNode } from "@/types/database";
+import { qualifiedTableName } from "@/lib/table/tableSelectSql";
+import type { ConnectionConfig, DatabaseType, QueryTab, TreeNode } from "@/types/database";
 
 export interface NewQueryTarget {
   connectionId: string;
@@ -58,4 +59,95 @@ function targetFromContext(context: Pick<QueryTab | TreeNode, "connectionId" | "
     schema: "schema" in context ? (context as { schema?: string }).schema : undefined,
     shouldRefreshDefaultDatabase: !context.database,
   };
+}
+
+export interface NewQueryTable {
+  connectionId: string;
+  schema?: string;
+  catalog?: string;
+  tableName: string;
+}
+
+export interface ResolveNewQueryTableInput {
+  activeTab?: Pick<QueryTab, "mode" | "connectionId" | "schema" | "tableMeta" | "structureTableName" | "title"> | null;
+  selectedTreeNode?: Pick<TreeNode, "type" | "connectionId" | "schema" | "catalog" | "tableName" | "label"> | null;
+  preferredSource?: NewQueryContextSource;
+}
+
+export interface ResolveNewQueryInitialSqlInput extends ResolveNewQueryTableInput {
+  prefillEnabled: boolean;
+  targetConnectionId: string;
+  databaseType?: DatabaseType;
+}
+
+// Database types whose "table" view does not use standard SQL `SELECT * FROM <table>`
+// (e.g. Neo4j uses Cypher). The new-query prefill is skipped for these.
+const NEW_QUERY_PREFILL_DISABLED_TYPES: ReadonlySet<DatabaseType | undefined> = new Set<DatabaseType | undefined>(["neo4j"]);
+
+export function isNewQueryPrefillSupported(databaseType: DatabaseType | undefined): boolean {
+  return !NEW_QUERY_PREFILL_DISABLED_TYPES.has(databaseType);
+}
+
+function tableFromTab(tab: ResolveNewQueryTableInput["activeTab"]): NewQueryTable | null {
+  if (!tab?.connectionId) return null;
+  if (tab.mode === "data") {
+    // Require the loaded tableMeta: a data tab's title is schema/catalog-qualified
+    // (e.g. "public.users"), so using it as a bare table name while tableMeta is
+    // still loading or errored would yield an invalid double-qualified reference.
+    const meta = tab.tableMeta;
+    const tableName = meta?.tableName?.trim();
+    if (!tableName) return null;
+    return { connectionId: tab.connectionId, schema: meta?.schema ?? tab.schema, catalog: meta?.catalog, tableName };
+  }
+  if (tab.mode === "structure") {
+    const tableName = (tab.structureTableName || "").trim();
+    if (!tableName) return null;
+    return { connectionId: tab.connectionId, schema: tab.schema, tableName };
+  }
+  return null;
+}
+
+function tableFromNode(node: ResolveNewQueryTableInput["selectedTreeNode"]): NewQueryTable | null {
+  if (!node?.connectionId) return null;
+  if (node.type !== "table" && node.type !== "view" && node.type !== "materialized_view") return null;
+  const tableName = (node.tableName || node.label || "").trim();
+  if (!tableName) return null;
+  return { connectionId: node.connectionId, schema: node.schema, catalog: node.catalog, tableName };
+}
+
+/**
+ * Resolves the "focused table" for a new query, mirroring the primary/secondary
+ * selection of {@link resolveNewQueryTarget}: when `preferredSource` is `"sidebar"`
+ * the selected tree node wins, otherwise the active tab wins; the other is the
+ * fallback. Returns null when no table context is available.
+ */
+export function resolveNewQueryTable(input: ResolveNewQueryTableInput): NewQueryTable | null {
+  const tabFirst = input.preferredSource !== "sidebar";
+  const primary = tabFirst ? tableFromTab(input.activeTab) : tableFromNode(input.selectedTreeNode);
+  if (primary) return primary;
+  return tabFirst ? tableFromNode(input.selectedTreeNode) : tableFromTab(input.activeTab);
+}
+
+/**
+ * Builds a `SELECT * FROM <table>` statement for the new-query prefill, reusing
+ * the same per-dialect identifier quoting and schema/catalog qualification used
+ * by the table-data view.
+ */
+export function buildSelectAllSql(databaseType: DatabaseType | undefined, table: Pick<NewQueryTable, "schema" | "catalog" | "tableName">): string {
+  const ref = qualifiedTableName({ databaseType, schema: table.schema, catalog: table.catalog, tableName: table.tableName });
+  return `SELECT * FROM ${ref}`;
+}
+
+/**
+ * Resolves the optional initial SQL for a new query tab. A table from another
+ * connection is intentionally ignored because it cannot safely run on the
+ * target connection selected for the new tab.
+ */
+export function resolveNewQueryInitialSql(input: ResolveNewQueryInitialSqlInput): string | undefined {
+  if (!input.prefillEnabled || !isNewQueryPrefillSupported(input.databaseType)) return undefined;
+
+  const table = resolveNewQueryTable(input);
+  if (!table || table.connectionId !== input.targetConnectionId) return undefined;
+
+  return buildSelectAllSql(input.databaseType, table);
 }

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -851,7 +851,7 @@ export const useQueryStore = defineStore("query", () => {
     return tabs.value.find((tab) => tab.connectionId === connectionId && tab.database === database && tab.title === title && tab.mode === mode && (tab.schema || "") === (schema || ""));
   }
 
-  function createTab(connectionId: string, database: string, title?: string, mode: QueryTab["mode"] = "query", schema?: string) {
+  function createTab(connectionId: string, database: string, title?: string, mode: QueryTab["mode"] = "query", schema?: string, initialSql?: string) {
     if (title) {
       const existing = findTabByIdentity(connectionId, database, title, mode, schema);
       if (existing) {
@@ -868,13 +868,13 @@ export const useQueryStore = defineStore("query", () => {
       connectionId,
       database,
       schema,
-      sql: "",
+      sql: initialSql ?? "",
       isExecuting: false,
       isCancelling: false,
       isExplaining: false,
       mode,
     };
-    if (mode === "query") tab.originalSql = "";
+    if (mode === "query") tab.originalSql = initialSql ?? "";
     tabs.value.push(tab);
     activeTabId.value = id;
     return id;

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -413,6 +413,7 @@ export interface EditorSettings {
   openTabsRestoreMode: OpenTabsRestoreMode;
   disconnectTabHandlingMode: DisconnectTabHandlingMode;
   reuseDataTab: boolean;
+  prefillNewQueryWithSelect: boolean;
   updateNotificationsEnabled: boolean;
   sidebarHiddenTablePrefixes: string[];
   sidebarHideTableComments: boolean;
@@ -548,6 +549,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   openTabsRestoreMode: "all",
   disconnectTabHandlingMode: "close-tabs",
   reuseDataTab: false,
+  prefillNewQueryWithSelect: true,
   updateNotificationsEnabled: true,
   sidebarHiddenTablePrefixes: [],
   sidebarHideTableComments: false,
@@ -783,6 +785,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
     openTabsRestoreMode: normalizeOpenTabsRestoreMode((settings as Partial<EditorSettings>).openTabsRestoreMode, (settings as Partial<EditorSettings> & { restoreOpenTabsOnLaunch?: boolean }).restoreOpenTabsOnLaunch),
     disconnectTabHandlingMode: normalizeDisconnectTabHandlingMode((settings as Partial<EditorSettings>).disconnectTabHandlingMode, (settings as Partial<EditorSettings> & { closeQueryTabsOnDisconnect?: boolean }).closeQueryTabsOnDisconnect),
     reuseDataTab: settings.reuseDataTab ?? DEFAULT_EDITOR_SETTINGS.reuseDataTab,
+    prefillNewQueryWithSelect: typeof settings.prefillNewQueryWithSelect === "boolean" ? settings.prefillNewQueryWithSelect : DEFAULT_EDITOR_SETTINGS.prefillNewQueryWithSelect,
     updateNotificationsEnabled: settings.updateNotificationsEnabled ?? DEFAULT_EDITOR_SETTINGS.updateNotificationsEnabled,
     sidebarHiddenTablePrefixes: normalizeSidebarHiddenTablePrefixes(settings.sidebarHiddenTablePrefixes),
     sidebarHideTableComments: settings.sidebarHideTableComments ?? DEFAULT_EDITOR_SETTINGS.sidebarHideTableComments,
@@ -1030,6 +1033,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.openTabsRestoreMode !== undefined) editorSettings.value.openTabsRestoreMode = normalizeOpenTabsRestoreMode(partial.openTabsRestoreMode);
     if (partial.disconnectTabHandlingMode !== undefined) editorSettings.value.disconnectTabHandlingMode = normalizeDisconnectTabHandlingMode(partial.disconnectTabHandlingMode);
     if (partial.reuseDataTab !== undefined) editorSettings.value.reuseDataTab = partial.reuseDataTab;
+    if (partial.prefillNewQueryWithSelect !== undefined) editorSettings.value.prefillNewQueryWithSelect = partial.prefillNewQueryWithSelect;
     if (partial.updateNotificationsEnabled !== undefined) editorSettings.value.updateNotificationsEnabled = partial.updateNotificationsEnabled;
     if (partial.sidebarHiddenTablePrefixes !== undefined) editorSettings.value.sidebarHiddenTablePrefixes = normalizeSidebarHiddenTablePrefixes(partial.sidebarHiddenTablePrefixes);
     if (partial.sidebarHideTableComments !== undefined) editorSettings.value.sidebarHideTableComments = partial.sidebarHideTableComments;


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## Summary

Opening a table and clicking the top toolbar **New Query** button now prefills the SQL editor with `SELECT * FROM <schema>.<table>` based on the focused table (Navicat-style), instead of starting from a blank editor.

## Behavior

- Resolves the focused table from the **active data/structure tab**, falling back to the table selected in the **sidebar** (`table` / `view` / `materialized_view`).
- Per-dialect identifier quoting is reused from the table-data view: MySQL backticks, Postgres double-quotes, SQL Server brackets — schema/catalog qualified.
- A table belonging to a different connection than the new tab's target is ignored (it can't safely run there).
- Skipped for **Neo4j** (Cypher, not SQL) and when no table context is available — the editor stays blank (original behavior).
- The prefilled tab opens **clean** (not marked unsaved) and remains clean across app restart.

## Setting

Gated by a new editor setting **"Prefill new query with SELECT *"** — **default ON**, toggleable under **Settings → Editor**. When off, new queries open blank as before.

## Implementation

- `resolveNewQueryInitialSql()` in `newQueryContext.ts` owns the full decision path — setting × db-type guard × table resolution × cross-connection check × SQL build — as a single pure, unit-testable function called from `App.vue::newQuery()`.
- `queryStore.createTab()` gains an optional `initialSql` parameter that sets both `sql` and `originalSql`, giving the prefilled tab clean (non-dirty) semantics.
- `openTabsPersistence` round-trips `originalSql` for plain query tabrnal-file tabs) so a clean prefilled tab restores clean after restart.
- `prefillNewQueryWithSelect` added to `EditorSettings` (default `true`) plus the settings draft, a Switch in `EditorSettingsDialog`, and all 7 locales.

## Testing

- `newQueryContext.spec.ts`: 5 new tests for `resolveNewQueryInitialSql` (enabled, disabled, cross-connection, no-context, Neo4j guard) on top of existing table-resolution / SQL-build / guard coverage.
- `openTabsPersistence.spec.ts`: 4 round-trip tests — clean prefilled tab restores clean, edited scratch tab restores dirty, empty query restores clean, and backward-compat with older saved state lacking `originalSql`.
- Full suite **2859 passed** (362 files); `vue-tsc` exit 0; `oxlint`

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1561" height="924" alt="374dd1de-be91-42c7-af18-bc36af57498b" src="https://github.com/user-attachments/assets/dabe3600-bf1e-42ea-bcae-6679e3b6f988" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #3187 
