### PR TITLE
feat(editor): 自动聚焦新建查询的SQL编辑器

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -58,6 +58,7 @@ import { normalizeShortcutSettings, shortcutToCodeMirrorKey } from "@/lib/editor
 import { trimmedSelectionLayer } from "@/lib/editor/codemirrorTrimmedSelectionLayer";
 import { selectionMatchOccurrences } from "@/lib/editor/codemirrorSelectionMatches";
 import { createInsertValueHintsExtension, requestInsertValueHintsRefresh } from "@/lib/editor/codemirrorInsertValueHints";
+import { focusEditorView } from "@/lib/editor/queryEditorFocus";
 import { createDbxCodeMirrorSqlDialect } from "@/lib/editor/codemirrorSqlDialect";
 import { startsQueryEditorRectangularSelection } from "@/lib/editor/queryEditorPointerSelection";
 import { isSchemaAware, isSingleDatabase, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
@@ -3117,6 +3118,13 @@ onMounted(async () => {
   cachedCompletionObjects = [];
   scheduleSemanticDiagnostics();
 
+  // Auto-focus the editor after mount so the user can start typing immediately
+  nextTick(() => {
+    requestAnimationFrame(() => {
+      focusEditorView(view.value);
+    });
+  });
+
   // Ensure theme is applied with the latest settings after mount
   void nextTick(async () => {
     if (!view.value || !codeMirrorTheme) return;
@@ -3368,8 +3376,7 @@ function restoreEditorSelection() {
 
 function restoreEditorFocus() {
   const focusEditorAcrossFrames = () => {
-    if (!view.value || view.value.hasFocus) return;
-    view.value.focus();
+    focusEditorView(view.value);
   };
   focusEditorAcrossFrames();
   nextTick(() => {

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -83,6 +83,7 @@ const props = defineProps<{
   executionError?: string;
   executionErrorSql?: string;
   readOnly?: boolean;
+  autoFocus?: boolean;
   forceWordWrap?: boolean;
   hideExecutionControls?: boolean;
   initialViewport?: { scrollTop: number; scrollLeft: number };
@@ -3118,12 +3119,14 @@ onMounted(async () => {
   cachedCompletionObjects = [];
   scheduleSemanticDiagnostics();
 
-  // Auto-focus the editor after mount so the user can start typing immediately
-  nextTick(() => {
-    requestAnimationFrame(() => {
-      focusEditorView(view.value);
+  if (props.autoFocus) {
+    // Query tabs opt in; shared editor instances must preserve the surrounding UI focus.
+    nextTick(() => {
+      requestAnimationFrame(() => {
+        focusEditorView(view.value);
+      });
     });
-  });
+  }
 
   // Ensure theme is applied with the latest settings after mount
   void nextTick(async () => {

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -766,6 +766,7 @@ defineExpose({ focusSearch, refreshData, handleModRTarget, requestQueryEditorExe
             <QueryEditor
               ref="queryEditorRef"
               class="relative z-0 flex-1"
+              auto-focus
               :model-value="activeTab.sql"
               :connection-id="activeTab.connectionId"
               :database="activeTab.database"

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { focusEditorView, type EditorViewLike } from "@/lib/editor/queryEditorFocus";
+
+function createMockView(overrides: Partial<EditorViewLike> = {}): EditorViewLike {
+  return {
+    hasFocus: false,
+    focus: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("focusEditorView", () => {
+  it("focuses the editor when view exists and does not have focus", () => {
+    const view = createMockView({ hasFocus: false });
+    const result = focusEditorView(view);
+    expect(result).toBe(true);
+    expect(view.focus).toHaveBeenCalledOnce();
+  });
+
+  it("skips focus when the editor already has focus", () => {
+    const view = createMockView({ hasFocus: true });
+    const result = focusEditorView(view);
+    expect(result).toBe(false);
+    expect(view.focus).not.toHaveBeenCalled();
+  });
+
+  it("returns false when view is null", () => {
+    expect(focusEditorView(null)).toBe(false);
+  });
+
+  it("returns false when view is undefined", () => {
+    expect(focusEditorView(undefined)).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
@@ -1,5 +1,9 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { focusEditorView, type EditorViewLike } from "@/lib/editor/queryEditorFocus";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+const contentAreaSource = readFileSync(new URL("../../../components/layout/ContentArea.vue", import.meta.url), "utf8");
 
 function createMockView(overrides: Partial<EditorViewLike> = {}): EditorViewLike {
   return {
@@ -30,5 +34,16 @@ describe("focusEditorView", () => {
 
   it("returns false when view is undefined", () => {
     expect(focusEditorView(undefined)).toBe(false);
+  });
+});
+
+describe("QueryEditor auto focus wiring", () => {
+  it("keeps auto focus opt-in for shared editor instances", () => {
+    expect(queryEditorSource).toContain("autoFocus?: boolean;");
+    expect(queryEditorSource).toMatch(/if \(props\.autoFocus\) \{[\s\S]*focusEditorView\(view\.value\);/);
+  });
+
+  it("enables auto focus for query tabs", () => {
+    expect(contentAreaSource).toMatch(/<QueryEditor[\s\S]*?\sauto-focus\s[\s\S]*?:model-value="activeTab\.sql"/);
   });
 });

--- a/apps/desktop/src/lib/editor/queryEditorFocus.ts
+++ b/apps/desktop/src/lib/editor/queryEditorFocus.ts
@@ -1,0 +1,21 @@
+/**
+ * Focus logic for the query editor CodeMirror view.
+ *
+ * Extracted from QueryEditor.vue so the guard condition can be unit-tested
+ * without mounting the full Vue component.
+ */
+
+export interface EditorViewLike {
+  hasFocus: boolean;
+  focus(): void;
+}
+
+/**
+ * Focus the editor if it exists and does not already have focus.
+ * Returns `true` when `view.focus()` was actually called, `false` otherwise.
+ */
+export function focusEditorView(view: EditorViewLike | null | undefined): boolean {
+  if (!view || view.hasFocus) return false;
+  view.focus();
+  return true;
+}


### PR DESCRIPTION
## 问题

点击顶端菜单栏「新建查询」后，系统显示空白页签可以录入 SQL 语句，但默认光标并不在 SQL 编辑区域，每次都要手动点击编辑区域才能开始输入。

## 原因分析

- 新建查询时，`queryStore.createTab()` 创建新标签页
- `ContentArea` 因 `:key` 变化而重新挂载 → `QueryEditor` 的 `onMounted` 创建 CodeMirror `EditorView`
- **但 `onMounted` 中没有调用 `focus()`**
- `restoreEditorFocus()` 仅在 `onActivated`（KeepAlive 缓存恢复）时调用，新建标签页走的是 `onMounted` 流程，不触发 `onActivated`

## 修改内容

1. **提取 `focusEditorView()` 工具函数**（`lib/editor/queryEditorFocus.ts`）
   - 将焦点逻辑抽象为独立可测试的函数
   - 接受 `EditorViewLike` 接口，解耦 CodeMirror 依赖

2. **在 `QueryEditor.vue` 的 `onMounted` 中添加自动聚焦**
   - 通过 `nextTick` + `requestAnimationFrame` 延迟调用，确保 DOM 渲染完成

3. **复用 `focusEditorView()` 替换 `restoreEditorFocus()` 中的内联逻辑**
   - 统一焦点管理代码，避免重复

4. **新增单元测试**（`queryEditorFocus.spec.ts`，4 个用例全部通过）
   - 编辑器无焦点时调用 `focus()`
   - 编辑器已有焦点时跳过
   - `view` 为 `null` / `undefined` 时安全返回


## 文件变更

| 文件 | 变更 |
|------|------|
| `apps/desktop/src/lib/editor/queryEditorFocus.ts` | 新增 - 焦点工具函数 |
| `apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts` | 新增 - 单元测试 |
| `apps/desktop/src/components/editor/QueryEditor.vue` | 修改 - onMounted 自动聚焦 + 复用 focusEditorView |