### PR TITLE
Fix：补充 MySQL 内置函数自动补全

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
@@ -14,6 +14,64 @@ describe("sqlCompletion keyword snippets", () => {
   });
 });
 
+describe("sqlCompletion database functions", () => {
+  it("suggests MySQL Unix timestamp functions with function snippets", () => {
+    const fromUnixSql = "SELECT from_unix";
+    const fromUnixItems = buildSqlCompletionItems(fromUnixSql, fromUnixSql.length, {
+      databaseType: "mysql",
+      tables: [],
+      columnsByTable: new Map(),
+    });
+    const fromUnixTime = fromUnixItems.find((item) => item.label === "FROM_UNIXTIME");
+
+    expect(fromUnixItems[0]).toBe(fromUnixTime);
+    expect(fromUnixTime).toEqual(
+      expect.objectContaining({
+        type: "function",
+        apply: "FROM_UNIXTIME(${unix_timestamp})",
+      }),
+    );
+
+    const unixTimestampSql = "SELECT unix_time";
+    const unixTimestampItems = buildSqlCompletionItems(unixTimestampSql, unixTimestampSql.length, {
+      databaseType: "mysql",
+      tables: [],
+      columnsByTable: new Map(),
+    });
+
+    expect(unixTimestampItems[0]).toEqual(
+      expect.objectContaining({
+        label: "UNIX_TIMESTAMP",
+        type: "function",
+        apply: "UNIX_TIMESTAMP()",
+      }),
+    );
+  });
+
+  it("ranks MySQL function prefixes ahead of ordinary keyword prefixes", () => {
+    const sql = "SELECT uni";
+    const items = buildSqlCompletionItems(sql, sql.length, {
+      databaseType: "mysql",
+      tables: [],
+      columnsByTable: new Map(),
+    });
+
+    expect(items.some((item) => item.type === "keyword")).toBe(true);
+    expect(items[0]).toEqual(expect.objectContaining({ label: "UNIX_TIMESTAMP", type: "function" }));
+  });
+
+  it("does not expose MySQL-only functions to other databases", () => {
+    const sql = "SELECT from_unix";
+    const items = buildSqlCompletionItems(sql, sql.length, {
+      databaseType: "postgres",
+      tables: [],
+      columnsByTable: new Map(),
+    });
+
+    expect(items.some((item) => item.label === "FROM_UNIXTIME")).toBe(false);
+  });
+});
+
 describe("sqlCompletion quoted schema qualifiers", () => {
   it("parses quoted PostgreSQL schema names before a dot", () => {
     const sql = 'SELECT *\nFROM "order-management".';

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -883,6 +883,8 @@ const POSTGRES_FUNCTION_SIGNATURES = new Map<string, string[]>([
 
 const MYSQL_FUNCTION_SIGNATURES = new Map<string, string[]>([
   ["DATE_FORMAT", ["date", "format"]],
+  ["FROM_UNIXTIME", ["unix_timestamp"]],
+  ["UNIX_TIMESTAMP", []],
   ["JSON_EXTRACT", ["json", "path"]],
   ["JSON_UNQUOTE", ["json"]],
   ["GROUP_CONCAT", ["expression"]],


### PR DESCRIPTION
## 问题原因

SQL 编辑器已经支持函数补全，但 MySQL 专属函数签名集合缺少 `FROM_UNIXTIME` 和 `UNIX_TIMESTAMP`，因此输入 `from_unix`、`unix_time` 时无法生成函数候选。

## 修复内容

- 补充 `FROM_UNIXTIME(unix_timestamp)` 和 `UNIX_TIMESTAMP()` 的 MySQL 函数签名
- 沿用现有函数补全类型和参数占位，不将函数作为普通关键字处理
- 保持现有排序规则：函数前缀候选高于普通关键字候选，不改变字段、表等元数据的既有优先级
- 限定为 MySQL 专属候选，避免影响 PostgreSQL 等其他数据库

## 验证

- MySQL 下可补全两个函数，并生成正确的函数调用文本
- `uni` 前缀下 `UNIX_TIMESTAMP` 排在普通 SQL 关键字候选之前
- PostgreSQL 下不会出现 `FROM_UNIXTIME`
- 相关 Vitest 48 项通过
- `pnpm typecheck` 通过
- oxlint、oxfmt、`git diff --check` 通过

Closes #3284
