### PR TITLE
fix(mongodb): 修复长整型筛选与 _id 更新失败

### DIFF
--- a/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
+++ b/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
@@ -633,6 +633,10 @@ public final class MongoAgent {
     }
 
     static Object parseId(String id) {
+        String stringId = decodeStringDocumentId(id);
+        if (stringId != null) {
+            return stringId;
+        }
         String trimmed = id.trim();
         if (isNumberLongIdWrapper(trimmed)) {
             try {
@@ -645,6 +649,19 @@ public final class MongoAgent {
             return new ObjectId(id);
         } catch (Exception e) {
             return id;
+        }
+    }
+
+    private static String decodeStringDocumentId(String id) {
+        String prefix = "__dbx_mongo_string_id__";
+        if (!id.startsWith(prefix)) {
+            return null;
+        }
+        try {
+            JsonElement value = JsonParser.parseString(id.substring(prefix.length()));
+            return value.isJsonPrimitive() && value.getAsJsonPrimitive().isString() ? value.getAsString() : null;
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
+++ b/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
@@ -632,7 +632,15 @@ public final class MongoAgent {
         return Collections.singletonMap("inserted_id", insertedId);
     }
 
-    private static Object parseId(String id) {
+    static Object parseId(String id) {
+        String trimmed = id.trim();
+        if (trimmed.startsWith("{")) {
+            try {
+                return Document.parse("{\"_id\":" + trimmed + "}").get("_id");
+            } catch (Exception e) {
+                // Fall through to the legacy ObjectId/string handling below.
+            }
+        }
         try {
             return new ObjectId(id);
         } catch (Exception e) {
@@ -765,9 +773,16 @@ public final class MongoAgent {
     private static Map<String, Object> bsonToJson(Document doc) {
         Map<String, Object> result = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : doc.entrySet()) {
-            result.put(entry.getKey(), convertValue(entry.getValue()));
+            result.put(entry.getKey(), convertDocumentFieldValue(entry.getKey(), entry.getValue()));
         }
         return result;
+    }
+
+    static Object convertDocumentFieldValue(String key, Object value) {
+        if ("_id".equals(key) && value instanceof Long longValue) {
+            return Collections.singletonMap("$numberLong", longValue.toString());
+        }
+        return convertValue(value);
     }
 
     static JsonObject bsonToExtendedJson(Document doc) {

--- a/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
+++ b/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
@@ -634,7 +634,7 @@ public final class MongoAgent {
 
     static Object parseId(String id) {
         String trimmed = id.trim();
-        if (trimmed.startsWith("{")) {
+        if (isNumberLongIdWrapper(trimmed)) {
             try {
                 return Document.parse("{\"_id\":" + trimmed + "}").get("_id");
             } catch (Exception e) {
@@ -645,6 +645,23 @@ public final class MongoAgent {
             return new ObjectId(id);
         } catch (Exception e) {
             return id;
+        }
+    }
+
+    private static boolean isNumberLongIdWrapper(String value) {
+        try {
+            JsonElement parsed = JsonParser.parseString(value);
+            if (!parsed.isJsonObject()) {
+                return false;
+            }
+            JsonObject wrapper = parsed.getAsJsonObject();
+            JsonElement numberLong = wrapper.get("$numberLong");
+            return wrapper.size() == 1
+                && numberLong != null
+                && numberLong.isJsonPrimitive()
+                && numberLong.getAsJsonPrimitive().isString();
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
+++ b/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
@@ -83,6 +83,14 @@ class MongoAgentTest {
     // ─── existing tests ───
 
     @Test
+    void parsesExplicitStringDocumentIdsWithoutTreatingThemAsExtendedJson() {
+        assertEquals(
+            "{\"$numberLong\":\"2048938405781032962\"}",
+            MongoAgent.parseId("__dbx_mongo_string_id__\"{\\\"$numberLong\\\":\\\"2048938405781032962\\\"}\"")
+        );
+    }
+
+    @Test
     void exposesProtocolHandshakeOverJsonRpc() {
         String response = MongoAgent.handleRequest(
             "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"handshake\","

--- a/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
+++ b/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Date;
 import org.bson.Document;
 import org.bson.types.ObjectId;
@@ -157,6 +158,16 @@ class MongoAgentTest {
         assertNotNull(filter);
         assertEquals(2_048_938_405_781_032_962L, filter.get("processInfoId"));
         assertEquals(9_007_199_254_740_993L, filter.get("snowflake"));
+    }
+
+    @Test
+    void preservesLongDocumentIdTypeForGridUpdates() {
+        Object id = MongoAgent.convertDocumentFieldValue("_id", 2_048_938_405_781_032_962L);
+        Object value = MongoAgent.convertDocumentFieldValue("snowflake", 2_048_938_405_781_032_962L);
+
+        assertEquals(Collections.singletonMap("$numberLong", "2048938405781032962"), id);
+        assertEquals("2048938405781032962", value);
+        assertEquals(2_048_938_405_781_032_962L, MongoAgent.parseId("{\"$numberLong\":\"2048938405781032962\"}"));
     }
 
     @Test

--- a/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
+++ b/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
@@ -171,6 +171,17 @@ class MongoAgentTest {
     }
 
     @Test
+    void preservesJsonLookingStringDocumentIds() {
+        assertEquals("{}", MongoAgent.parseId("{}"));
+        assertEquals("{\"tenant\":1}", MongoAgent.parseId("{\"tenant\":1}"));
+        assertEquals(
+            "{\"$numberLong\":\"2048938405781032962\",\"tenant\":1}",
+            MongoAgent.parseId("{\"$numberLong\":\"2048938405781032962\",\"tenant\":1}")
+        );
+        assertEquals("{\"$numberLong\":\"invalid\"}", MongoAgent.parseId("{\"$numberLong\":\"invalid\"}"));
+    }
+
+    @Test
     void serverVersionMethodIsRecognizedOverJsonRpc() {
         String response = MongoAgent.handleRequest(
             "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"server_version\","

--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -28,7 +28,7 @@ import {
   type DocumentFilterMode,
   type DocumentFilterRule,
 } from "@/lib/app/documentStoreProvider";
-import { buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, parseMongoDocumentInputValue, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
+import { buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, mongoDocumentIdForGrid, parseMongoDocumentInputValue, serializeMongoDocumentId, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
 import { normalizeResultPageSize } from "@/lib/dataGrid/paginationPageSize";
 import { useSettingsStore } from "@/stores/settingsStore";
 import JsonEditNode from "./JsonEditNode.vue";
@@ -131,8 +131,9 @@ const deleteDetails = computed(() => {
   if (!pending) return "";
   if (pending.kind === "document") {
     const id = documents.value[pending.index]?._id ?? "";
-    if (props.databaseType === "elasticsearch") return `Elasticsearch index: ${props.collection}\nDocument _id: ${String(id)}`;
-    return t("dangerDialog.mongoDocumentDetails", { collection: props.collection, id: String(id) });
+    const displayId = mongoDocumentIdForGrid(id);
+    if (props.databaseType === "elasticsearch") return `Elasticsearch index: ${props.collection}\nDocument _id: ${String(displayId)}`;
+    return t("dangerDialog.mongoDocumentDetails", { collection: props.collection, id: String(displayId) });
   }
   return t("dangerDialog.mongoFieldDetails", { field: pending.name || t("mongo.field") });
 });
@@ -162,6 +163,7 @@ const gridResult = computed<QueryResult>(() => {
     columns.map((col) => {
       const val = doc[col];
       if (val === undefined || val === null) return null;
+      if (col === "_id") return mongoDocumentIdForGrid(val);
       if (typeof val === "object") return JSON.stringify(val);
       if (typeof val === "string" || typeof val === "number" || typeof val === "boolean") return val;
       return String(val);
@@ -254,6 +256,19 @@ function clearDocumentFilters(clearLocalFilter?: (columnIndex?: number) => void)
 
 function documentIdFromGridValue(value: MongoInputValue | undefined): string | null {
   if (value === null || value === undefined) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (trimmed.startsWith('"')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        return typeof parsed === "string" && parsed.trim() ? parsed : trimmed;
+      } catch {
+        return trimmed;
+      }
+    }
+    return trimmed;
+  }
   const parsed = parseMongoDocumentInputValue(value);
   if (parsed === null || parsed === undefined) return null;
   const id = typeof parsed === "object" ? JSON.stringify(parsed) : String(parsed);
@@ -307,15 +322,18 @@ async function gridSave(changes: DocumentGridChanges) {
 
     const updateDoc = buildMongoUpdateDocument(dirtyCols, cols, documents.value[rowIdx]);
     if (Object.keys(updateDoc).length === 0) continue;
-    await api.documentUpdateDocument(props.connectionId, props.database, props.collection, String(id), JSON.stringify(updateDoc));
+    const documentId = documents.value[rowIdx]?._id ?? id;
+    await api.documentUpdateDocument(props.connectionId, props.database, props.collection, serializeMongoDocumentId(documentId), JSON.stringify(updateDoc));
   }
 
   for (const rowIdx of changes.deletedRows) {
     const row = changes.rows[rowIdx];
     const id = row?.[idColIdx];
     if (id == null) continue;
-    const routing = isEs ? documentRoutingFromDocument(documents.value[rowIdx]) : undefined;
-    await api.documentDeleteDocument(props.connectionId, props.database, props.collection, String(id), routing);
+    const document = documents.value[rowIdx];
+    const routing = isEs ? documentRoutingFromDocument(document) : undefined;
+    const documentId = isEs ? id : (document?._id ?? id);
+    await api.documentDeleteDocument(props.connectionId, props.database, props.collection, isEs ? String(documentId) : serializeMongoDocumentId(documentId), routing);
   }
 
   for (const newRow of changes.newRows) {
@@ -335,17 +353,10 @@ async function gridSave(changes: DocumentGridChanges) {
   await load();
 }
 
-function formatMongoValue(val: unknown): string {
-  if (val === null || val === undefined) return "null";
-  if (typeof val === "number" || typeof val === "boolean") return String(val);
-  if (typeof val === "string") return JSON.stringify(val);
-  return JSON.stringify(val);
-}
-
 function mongoIdPreview(val: unknown): string {
   if (val === null || val === undefined) return "null";
   if (typeof val === "string" && /^[a-fA-F0-9]{24}$/.test(val)) return `ObjectId("${val}")`;
-  return formatMongoValue(val);
+  return formatMongoShellLiteral(val);
 }
 
 function elasticsearchPathIdPreview(id: string): string {
@@ -383,7 +394,7 @@ async function previewDocumentChanges(changes: DocumentGridChanges): Promise<str
       stmts.push(`POST /${coll}/_update/${elasticsearchPathIdPreview(String(id))}${elasticsearchRoutingPreview(routing)}\n${JSON.stringify({ doc: updateDoc.$set ?? updateDoc }, null, 2)}`);
     } else {
       const updateDoc = buildMongoUpdateDocument(dirtyCols, columns, documents.value[rowIdx]);
-      stmts.push(`db.${coll}.updateOne({_id: ${mongoIdPreview(id)}}, ${formatMongoShellLiteral(updateDoc)})`);
+      stmts.push(`db.${coll}.updateOne({_id: ${mongoIdPreview(documents.value[rowIdx]?._id ?? id)}}, ${formatMongoShellLiteral(updateDoc)})`);
     }
   }
 
@@ -395,7 +406,7 @@ async function previewDocumentChanges(changes: DocumentGridChanges): Promise<str
       const routing = documentRoutingFromGridRow(row, columns);
       stmts.push(`DELETE /${coll}/_doc/${elasticsearchPathIdPreview(String(id))}${elasticsearchRoutingPreview(routing)}`);
     } else {
-      stmts.push(`db.${coll}.deleteOne({_id: ${mongoIdPreview(id)}})`);
+      stmts.push(`db.${coll}.deleteOne({_id: ${mongoIdPreview(documents.value[rowIdx]?._id ?? id)}})`);
     }
   }
 
@@ -692,7 +703,7 @@ async function saveDoc() {
         error.value = "No _id field";
         return;
       }
-      await api.documentUpdateDocument(props.connectionId, props.database, props.collection, String(id), JSON.stringify(doc), documentRoutingFromDocument(current));
+      await api.documentUpdateDocument(props.connectionId, props.database, props.collection, serializeMongoDocumentId(id), JSON.stringify(doc), documentRoutingFromDocument(current));
     }
     isEditing.value = false;
     isNew.value = false;
@@ -712,7 +723,7 @@ async function applyDeleteDoc(idx: number) {
   if (!id) return;
   error.value = "";
   try {
-    await api.documentDeleteDocument(props.connectionId, props.database, props.collection, String(id), documentRoutingFromDocument(doc));
+    await api.documentDeleteDocument(props.connectionId, props.database, props.collection, serializeMongoDocumentId(id), documentRoutingFromDocument(doc));
     if (selectedIdx.value === idx) {
       selectedIdx.value = null;
       editJson.value = "";

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -74,7 +74,7 @@ import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 import { chartableColumnIndexes } from "@/lib/dataGrid/chartData";
 import { elasticsearchJsonResponseForResult } from "@/lib/elasticsearch/elasticsearchJsonResponse";
 import * as api from "@/lib/backend/api";
-import { applyMongoGridChangesToDocument, buildMongoUpdateDocument, formatMongoShellLiteral, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
+import { applyMongoGridChangesToDocument, buildMongoUpdateDocument, formatMongoShellLiteral, serializeMongoDocumentId, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
 import type { SqlExecutionOverride } from "@/lib/sql/sqlExecutionTarget";
 import type { DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
 import { DATA_GRID_COMPACT_TOPBAR_WIDTH, type DataGridReloadIntent } from "@/lib/dataGrid/dataGridToolbar";
@@ -377,6 +377,11 @@ function mongoIdPreview(val: unknown): string {
 function mongoCollectionExpression(collection: string): string {
   return `db.getCollection(${JSON.stringify(collection)})`;
 }
+function mongoQueryResultDocumentId(rowIdx: number, fallback: unknown): unknown {
+  const document = props.activeTab.result?.mongo_documents?.[rowIdx];
+  if (!document || typeof document !== "object" || Array.isArray(document)) return fallback;
+  return (document as Record<string, unknown>)._id ?? fallback;
+}
 const mongoQueryResultSaveHandler = computed<CustomSaveHandler | undefined>(() => {
   const tab = props.activeTab;
   const target = tab.mongoEditTarget;
@@ -395,7 +400,7 @@ const mongoQueryResultSaveHandler = computed<CustomSaveHandler | undefined>(() =
       if (id === null || id === undefined || String(id).trim() === "") continue;
       const updateDoc = buildMongoUpdateDocument(dirtyCols, changes.columns, tab.result?.mongo_documents?.[rowIdx]);
       if (Object.keys(updateDoc).length === 0) continue;
-      await api.mongoUpdateDocument(tab.connectionId, tab.database, target.collection, String(id), JSON.stringify(updateDoc));
+      await api.mongoUpdateDocument(tab.connectionId, tab.database, target.collection, serializeMongoDocumentId(mongoQueryResultDocumentId(rowIdx, id)), JSON.stringify(updateDoc));
     }
   };
 
@@ -409,7 +414,7 @@ const mongoQueryResultSaveHandler = computed<CustomSaveHandler | undefined>(() =
       if (id === null || id === undefined || String(id).trim() === "") continue;
       const updateDoc = buildMongoUpdateDocument(dirtyCols, changes.columns, tab.result?.mongo_documents?.[rowIdx]);
       if (Object.keys(updateDoc).length === 0) continue;
-      stmts.push(`${mongoCollectionExpression(target.collection)}.updateOne({_id: ${mongoIdPreview(id)}}, ${formatMongoShellLiteral(updateDoc)})`);
+      stmts.push(`${mongoCollectionExpression(target.collection)}.updateOne({_id: ${mongoIdPreview(mongoQueryResultDocumentId(rowIdx, id))}}, ${formatMongoShellLiteral(updateDoc)})`);
     }
     return stmts;
   };

--- a/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
+++ b/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
@@ -168,6 +168,7 @@ export function formatMongoShellLiteral(value: unknown): string {
 }
 
 export function serializeMongoDocumentId(value: unknown): string {
+  if (typeof value === "string") return `__dbx_mongo_string_id__${JSON.stringify(value)}`;
   if (isMongoExtendedJsonId(value)) return JSON.stringify(value);
   return String(value);
 }

--- a/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
+++ b/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
@@ -3,6 +3,10 @@ export type MongoInputValue = string | number | boolean | null;
 const MONGO_SHELL_DATE_PATTERN = /^(?:ISODate|new Date)\(\s*(["'])(.+)\1\s*\)$/;
 const LEGACY_MONGO_DATE_DISPLAY_PATTERN = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d{1,3}))?$/;
 const MONGO_OBJECT_ID_PATTERN = /^[a-fA-F0-9]{24}$/;
+const MONGO_INTEGER_PATTERN = /^-?\d+$/;
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_BSON_INT64 = -9223372036854775808n;
+const MAX_BSON_INT64 = 9223372036854775807n;
 
 export function mongoShellDateToExtendedJson(value: unknown): unknown {
   if (typeof value !== "string") return value;
@@ -24,7 +28,14 @@ export function parseMongoDocumentInputValue(raw: MongoInputValue): unknown {
   const legacyDate = legacyMongoDateDisplayToExtendedJson(trimmed);
   if (legacyDate) return legacyDate;
 
-  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if (MONGO_INTEGER_PATTERN.test(trimmed)) {
+    const integer = BigInt(trimmed);
+    if (integer > MAX_SAFE_BIGINT || integer < -MAX_SAFE_BIGINT) {
+      return integer >= MIN_BSON_INT64 && integer <= MAX_BSON_INT64 ? { $numberLong: trimmed } : trimmed;
+    }
+    return Number(trimmed);
+  }
+  if (/^-?\d+\.\d+$/.test(trimmed)) return Number(trimmed);
   if (trimmed.startsWith("{") || trimmed.startsWith("[") || trimmed.startsWith('"')) {
     return mongoShellDateToExtendedJson(JSON.parse(trimmed));
   }
@@ -154,4 +165,26 @@ export function formatMongoShellLiteral(value: unknown): string {
     return `{${keys.map((key) => `${JSON.stringify(key)}:${formatMongoShellLiteral(object[key])}`).join(",")}}`;
   }
   return JSON.stringify(String(value));
+}
+
+export function serializeMongoDocumentId(value: unknown): string {
+  if (isMongoExtendedJsonId(value)) return JSON.stringify(value);
+  return String(value);
+}
+
+export function mongoDocumentIdForGrid(value: unknown): MongoInputValue {
+  if (isMongoNumberLong(value)) return value.$numberLong;
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  return JSON.stringify(value);
+}
+
+function isMongoExtendedJsonId(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const object = value as Record<string, unknown>;
+  const keys = Object.keys(object);
+  return keys.length === 1 && (typeof object.$numberLong === "string" || typeof object.$oid === "string");
+}
+
+function isMongoNumberLong(value: unknown): value is { $numberLong: string } {
+  return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 1 && typeof (value as Record<string, unknown>).$numberLong === "string";
 }

--- a/apps/desktop/src/lib/mongo/mongoShellCommand.ts
+++ b/apps/desktop/src/lib/mongo/mongoShellCommand.ts
@@ -644,11 +644,7 @@ function normalizeJsonArgument(value: string): string | null {
   // filter such as { createdAt: { $gte: ISODate("...") } } fails JSON.parse,
   // the command is left unrecognized and falls through to the SQL executor,
   // which rejects it with "Use MongoDB-specific commands".
-  const withExtendedJson = trimmed
-    .replace(/ObjectId\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$oid":"$1"}')
-    .replace(/NumberLong\s*\(\s*["'](-?\d+)["']\s*\)/g, '{"$numberLong":"$1"}')
-    .replace(/NumberLong\s*\(\s*(-?\d+)\s*\)/g, '{"$numberLong":"$1"}')
-    .replace(/(?:ISODate|new\s+Date)\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$date":"$1"}');
+  const withExtendedJson = replaceMongoShellConstructors(trimmed);
   const preprocessed = quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson));
   try {
     JSON.parse(preprocessed);
@@ -656,6 +652,41 @@ function normalizeJsonArgument(value: string): string | null {
   } catch {
     return null;
   }
+}
+
+function replaceMongoShellConstructors(source: string): string {
+  const constructor = /^(ObjectId|NumberLong|ISODate)\s*\(\s*["']([^"']+)["']\s*\)|^(ObjectId|NumberLong)\s*\(\s*(-?\d+)\s*\)|^(?:new\s+Date)\s*\(\s*["']([^"']+)["']\s*\)/;
+  let result = "";
+  let index = 0;
+  while (index < source.length) {
+    const quote = source[index];
+    if (quote === '"' || quote === "'") {
+      const start = index++;
+      while (index < source.length) {
+        if (source[index] === "\\") index += 2;
+        else if (source[index] === quote) {
+          index++;
+          break;
+        } else index++;
+      }
+      result += source.slice(start, index);
+      continue;
+    }
+    const match = source.slice(index).match(constructor);
+    if (!match) {
+      result += source[index++];
+      continue;
+    }
+    if (match[1]) {
+      result += match[1] === "ObjectId" ? `{"$oid":"${match[2]}"}` : match[1] === "NumberLong" ? `{"$numberLong":"${match[2]}"}` : `{"$date":"${match[2]}"}`;
+    } else if (match[3]) {
+      result += match[3] === "NumberLong" ? `{"$numberLong":"${match[4]}"}` : `{"$oid":"${match[4]}"}`;
+    } else {
+      result += `{"$date":"${match[5]}"}`;
+    }
+    index += match[0].length;
+  }
+  return result;
 }
 
 function parseMethodArgs(source: string, methodCallIndex: number): string[] | null {

--- a/apps/desktop/src/lib/mongo/mongoShellCommand.ts
+++ b/apps/desktop/src/lib/mongo/mongoShellCommand.ts
@@ -1,4 +1,5 @@
 import type { QueryResult } from "@/types/database";
+import { mongoDocumentIdForGrid } from "@/lib/mongo/mongoDocumentValues";
 
 export interface MongoFindCommand {
   collection: string;
@@ -638,11 +639,16 @@ function normalizeJsonArgument(value: string): string | null {
   if (!trimmed) return "{}";
   // Rewrite mongo shell constructors that are not valid JSON into the extended
   // JSON the backend understands (mongo_driver::json_value_to_bson): ObjectId(x)
-  // -> {"$oid":x} and ISODate(x)/new Date(x) -> {"$date":x}. Without this a
+  // -> {"$oid":x}, NumberLong(x) -> {"$numberLong":x}, and
+  // ISODate(x)/new Date(x) -> {"$date":x}. Without this a
   // filter such as { createdAt: { $gte: ISODate("...") } } fails JSON.parse,
   // the command is left unrecognized and falls through to the SQL executor,
   // which rejects it with "Use MongoDB-specific commands".
-  const withExtendedJson = trimmed.replace(/ObjectId\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$oid":"$1"}').replace(/(?:ISODate|new\s+Date)\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$date":"$1"}');
+  const withExtendedJson = trimmed
+    .replace(/ObjectId\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$oid":"$1"}')
+    .replace(/NumberLong\s*\(\s*["'](-?\d+)["']\s*\)/g, '{"$numberLong":"$1"}')
+    .replace(/NumberLong\s*\(\s*(-?\d+)\s*\)/g, '{"$numberLong":"$1"}')
+    .replace(/(?:ISODate|new\s+Date)\s*\(\s*["']([^"']+)["']\s*\)/g, '{"$date":"$1"}');
   const preprocessed = quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson));
   try {
     JSON.parse(preprocessed);
@@ -1171,5 +1177,5 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function toCellValue(value: unknown): string | number | boolean | null {
   if (value === undefined || value === null) return null;
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
-  return JSON.stringify(value);
+  return mongoDocumentIdForGrid(value);
 }

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -991,11 +991,27 @@ pub async fn delete_document(client: &Client, database: &str, collection: &str, 
 }
 
 fn document_id_filters(id: &str) -> Vec<Document> {
+    if let Some(filter) = extended_json_document_id_filter(id) {
+        return vec![filter];
+    }
     let string_filter = doc! { "_id": Bson::String(id.to_string()) };
     match ObjectId::parse_str(id) {
         Ok(oid) => vec![doc! { "_id": Bson::ObjectId(oid) }, string_filter],
         Err(_) => vec![string_filter],
     }
+}
+
+fn extended_json_document_id_filter(id: &str) -> Option<Document> {
+    let trimmed = id.trim();
+    if !trimmed.starts_with('{') {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+    let bson = json_value_to_bson(&value);
+    if matches!(bson, Bson::Document(_)) {
+        return None;
+    }
+    Some(doc! { "_id": bson })
 }
 
 pub async fn delete_documents(
@@ -1034,12 +1050,21 @@ fn bson_to_json(bson: &Bson) -> serde_json::Value {
         Bson::Document(doc) => {
             let mut map = serde_json::Map::new();
             for (k, v) in doc {
-                map.insert(k.clone(), bson_to_json(v));
+                map.insert(k.clone(), bson_document_field_to_json(k, v));
             }
             serde_json::Value::Object(map)
         }
         _ => serde_json::Value::String(format!("{bson}")),
     }
+}
+
+fn bson_document_field_to_json(key: &str, bson: &Bson) -> serde_json::Value {
+    if key == "_id" {
+        if let Bson::Int64(value) = bson {
+            return serde_json::json!({ "$numberLong": value.to_string() });
+        }
+    }
+    bson_to_json(bson)
 }
 
 /// Convert a `serde_json::Value` (JSON object) to a BSON `Document`,
@@ -1142,6 +1167,9 @@ fn json_value_to_bson(value: &serde_json::Value) -> Bson {
                         return Bson::ObjectId(oid);
                     }
                 }
+                if let Some(value) = parse_extended_json_int64(obj) {
+                    return Bson::Int64(value);
+                }
                 if let Some(date) = parse_extended_json_date(obj) {
                     return Bson::DateTime(date);
                 }
@@ -1207,6 +1235,14 @@ fn parse_extended_json_date(obj: &serde_json::Map<String, serde_json::Value>) ->
     }
 }
 
+fn parse_extended_json_int64(obj: &serde_json::Map<String, serde_json::Value>) -> Option<i64> {
+    match obj.get("$numberLong")? {
+        serde_json::Value::String(value) => value.parse().ok(),
+        serde_json::Value::Number(value) => value.as_i64(),
+        _ => None,
+    }
+}
+
 fn json_filter_value_to_bson(value: &serde_json::Value, field_name: Option<&str>) -> Bson {
     if field_name == Some("_id") {
         if let Some(id) = value.as_str() {
@@ -1224,6 +1260,9 @@ fn json_filter_value_to_bson(value: &serde_json::Value, field_name: Option<&str>
                     if let Ok(oid) = ObjectId::parse_str(hex) {
                         return Bson::ObjectId(oid);
                     }
+                }
+                if let Some(value) = parse_extended_json_int64(obj) {
+                    return Bson::Int64(value);
                 }
                 // Extended JSON dates must be decoded in filters too, otherwise
                 // {"$date": ...} reaches the server as a raw document: a bare
@@ -1390,6 +1429,22 @@ mod tests {
     }
 
     #[test]
+    fn document_id_filters_preserve_extended_json_int64_ids() {
+        let filters = document_id_filters(r#"{"$numberLong":"2048938405781032962"}"#);
+
+        assert_eq!(filters.len(), 1);
+        assert!(matches!(filters[0].get("_id"), Some(Bson::Int64(2_048_938_405_781_032_962))));
+    }
+
+    #[test]
+    fn json_filter_to_document_preserves_extended_json_int64_values() {
+        let filter = serde_json::json!({ "snowflake": { "$numberLong": "2048938405781032962" } });
+        let document = json_filter_to_document(&filter).unwrap();
+
+        assert!(matches!(document.get("snowflake"), Some(Bson::Int64(2_048_938_405_781_032_962))));
+    }
+
+    #[test]
     fn json_filter_to_document_matches_object_id_and_string_for_id_hex() {
         let id = "507f1f77bcf86cd799439011";
         let filter = serde_json::json!({ "_id": id });
@@ -1466,6 +1521,17 @@ mod tests {
         let value = bson_to_json(&Bson::Int64(2_326_645_729_978_441_729));
 
         assert_eq!(value, serde_json::json!("2326645729978441729"));
+    }
+
+    #[test]
+    fn bson_to_json_preserves_int64_id_type_for_updates() {
+        let value = bson_to_json(&Bson::Document(doc! {
+            "_id": Bson::Int64(2_048_938_405_781_032_962),
+            "snowflake": Bson::Int64(2_048_938_405_781_032_962),
+        }));
+
+        assert_eq!(value["_id"], serde_json::json!({ "$numberLong": "2048938405781032962" }));
+        assert_eq!(value["snowflake"], serde_json::json!("2048938405781032962"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -991,6 +991,9 @@ pub async fn delete_document(client: &Client, database: &str, collection: &str, 
 }
 
 fn document_id_filters(id: &str) -> Vec<Document> {
+    if let Some(string_id) = decode_string_document_id(id) {
+        return vec![doc! { "_id": Bson::String(string_id) }];
+    }
     if let Some(filter) = extended_json_document_id_filter(id) {
         return vec![filter];
     }
@@ -999,6 +1002,10 @@ fn document_id_filters(id: &str) -> Vec<Document> {
         Ok(oid) => vec![doc! { "_id": Bson::ObjectId(oid) }, string_filter],
         Err(_) => vec![string_filter],
     }
+}
+
+fn decode_string_document_id(id: &str) -> Option<String> {
+    id.strip_prefix("__dbx_mongo_string_id__").and_then(|payload| serde_json::from_str::<String>(payload).ok())
 }
 
 fn extended_json_document_id_filter(id: &str) -> Option<Document> {
@@ -1412,7 +1419,7 @@ mod tests {
     #[test]
     fn document_id_filters_try_object_id_then_string_for_hex_ids() {
         let id = "507f1f77bcf86cd799439011";
-        let filters = document_id_filters(id);
+        let filters = document_id_filters(&id);
 
         assert_eq!(filters.len(), 2);
         assert!(matches!(filters[0].get("_id"), Some(Bson::ObjectId(_))));
@@ -1422,7 +1429,7 @@ mod tests {
     #[test]
     fn document_id_filters_use_string_only_for_non_hex_ids() {
         let id = "customer-42";
-        let filters = document_id_filters(id);
+        let filters = document_id_filters(&id);
 
         assert_eq!(filters.len(), 1);
         assert!(matches!(filters[0].get("_id"), Some(Bson::String(value)) if value == id));
@@ -1434,6 +1441,18 @@ mod tests {
 
         assert_eq!(filters.len(), 1);
         assert!(matches!(filters[0].get("_id"), Some(Bson::Int64(2_048_938_405_781_032_962))));
+    }
+
+    #[test]
+    fn document_id_filters_decode_explicit_string_ids_before_extended_json() {
+        let original = r#"{"$numberLong":"2048938405781032962"}"#;
+        let id = format!("__dbx_mongo_string_id__{}", serde_json::to_string(original).unwrap());
+        let filters = document_id_filters(&id);
+
+        assert_eq!(filters.len(), 1);
+        assert!(
+            matches!(filters[0].get("_id"), Some(Bson::String(value)) if value == r####"{"$numberLong":"2048938405781032962"}"####)
+        );
     }
 
     #[test]

--- a/packages/app-tests/mongoDocumentValues.test.ts
+++ b/packages/app-tests/mongoDocumentValues.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { applyMongoGridChangesToDocument, buildMongoCopyDocumentFromOriginal, buildMongoCopyInsertDocument, buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, parseMongoDocumentInputValue } from "../../apps/desktop/src/lib/mongo/mongoDocumentValues.ts";
+import { applyMongoGridChangesToDocument, buildMongoCopyDocumentFromOriginal, buildMongoCopyInsertDocument, buildMongoInsertDocument, buildMongoUpdateDocument, formatMongoShellLiteral, mongoDocumentIdForGrid, parseMongoDocumentInputValue, serializeMongoDocumentId } from "../../apps/desktop/src/lib/mongo/mongoDocumentValues.ts";
 
 test("parses Mongo shell ISODate literals as extended JSON dates", () => {
   assert.deepEqual(parseMongoDocumentInputValue('ISODate("2026-06-10T13:59:31.287Z")'), {
@@ -16,6 +16,12 @@ test("parses legacy Mongo date display values as UTC dates", () => {
     $date: "2025-08-14T02:25:43.718Z",
   });
   assert.equal(parseMongoDocumentInputValue('"2025-08-14 02:25:43.718"'), "2025-08-14 02:25:43.718");
+});
+
+test("preserves unsafe Mongo int64 input values without JavaScript rounding", () => {
+  assert.deepEqual(parseMongoDocumentInputValue("2048938405781032962"), { $numberLong: "2048938405781032962" });
+  assert.equal(parseMongoDocumentInputValue("9007199254740991"), 9007199254740991);
+  assert.equal(parseMongoDocumentInputValue("9223372036854775808"), "9223372036854775808");
 });
 
 test("builds Mongo grid updates with set and unset operators", () => {
@@ -216,6 +222,13 @@ test("formats extended JSON dates as Mongo shell ISODate literals", () => {
 
 test("formats extended JSON object ids as Mongo shell ObjectId literals", () => {
   assert.equal(formatMongoShellLiteral({ $oid: "6743e4bfa3f6f84bc3fff6c8" }), 'ObjectId("6743e4bfa3f6f84bc3fff6c8")');
+});
+
+test("serializes typed Mongo document ids while keeping their grid display compact", () => {
+  const id = { $numberLong: "2048938405781032962" };
+  assert.equal(serializeMongoDocumentId(id), '{"$numberLong":"2048938405781032962"}');
+  assert.equal(mongoDocumentIdForGrid(id), "2048938405781032962");
+  assert.equal(serializeMongoDocumentId("2048938405781032962"), "2048938405781032962");
 });
 
 test("formats extended JSON int64 values as Mongo shell NumberLong literals", () => {

--- a/packages/app-tests/mongoDocumentValues.test.ts
+++ b/packages/app-tests/mongoDocumentValues.test.ts
@@ -228,7 +228,8 @@ test("serializes typed Mongo document ids while keeping their grid display compa
   const id = { $numberLong: "2048938405781032962" };
   assert.equal(serializeMongoDocumentId(id), '{"$numberLong":"2048938405781032962"}');
   assert.equal(mongoDocumentIdForGrid(id), "2048938405781032962");
-  assert.equal(serializeMongoDocumentId("2048938405781032962"), "2048938405781032962");
+  assert.equal(serializeMongoDocumentId("2048938405781032962"), '__dbx_mongo_string_id__"2048938405781032962"');
+  assert.equal(serializeMongoDocumentId('{"$numberLong":"2048938405781032962"}'), '__dbx_mongo_string_id__"{\\"$numberLong\\":\\"2048938405781032962\\"}"');
 });
 
 test("formats extended JSON int64 values as Mongo shell NumberLong literals", () => {

--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -65,6 +65,17 @@ test("parseMongoFindCommand accepts Compass-style unquoted keys and ObjectId", (
   assert.deepEqual(JSON.parse(command.filter), { _id: { $oid: "6a045a92d2971e44243771a1" } });
 });
 
+test("parseMongoFindCommand does not rewrite NumberLong text inside strings", () => {
+  const command = parseMongoFindCommand('db.orders.find({label: "NumberLong(123)"})');
+  assert.deepEqual(command, {
+    collection: "orders",
+    filter: '{"label": "NumberLong(123)"}',
+    skip: 0,
+    limit: 100,
+    sort: undefined,
+  });
+});
+
 test("parseMongoFindCommand rewrites ISODate into extended JSON $date", () => {
   const command = parseMongoFindCommand(`db.trainingdocuments.find({
     createdAt: { $gte: ISODate("2025-02-25T04:57:39.965Z") }

--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -82,6 +82,16 @@ test("parseMongoFindCommand rewrites new Date and single-quoted ISODate", () => 
   });
 });
 
+test("parseMongoFindCommand rewrites NumberLong into extended JSON", () => {
+  const quoted = parseMongoFindCommand('db.orders.find({_id: NumberLong("2048938405781032962")})');
+  const unquoted = parseMongoFindCommand("db.orders.find({snowflake: NumberLong(9007199254740993)})");
+
+  assert.ok(quoted);
+  assert.deepEqual(JSON.parse(quoted.filter), { _id: { $numberLong: "2048938405781032962" } });
+  assert.ok(unquoted);
+  assert.deepEqual(JSON.parse(unquoted.filter), { snowflake: { $numberLong: "9007199254740993" } });
+});
+
 test("parseMongoFindCommand accepts single-quoted string values and unquoted sort keys", () => {
   const command = parseMongoFindCommand("db.products.find({category: 'Electronics'}).sort({price: -1}).limit(2)");
   assert.ok(command);
@@ -513,6 +523,14 @@ test("mongoDocumentsToQueryResult turns mongo documents into grid rows", () => {
   assert.equal(result.affected_rows, 12);
   assert.equal(result.execution_time_ms, 5);
   assert.equal(result.truncated, true);
+});
+
+test("mongoDocumentsToQueryResult displays typed int64 ids without losing raw type metadata", () => {
+  const id = { $numberLong: "2048938405781032962" };
+  const result = mongoDocumentsToQueryResult([{ _id: id, name: "snowflake" }], 1, 1);
+
+  assert.deepEqual(result.rows, [["2048938405781032962", "snowflake"]]);
+  assert.deepEqual(result.mongo_documents, [{ _id: id, name: "snowflake" }]);
 });
 
 test("buildMongoUpdateDocument ignores _id and preserves typed values", () => {


### PR DESCRIPTION
## 背景

Issue #2527 在已发布修复后追加反馈：0.5.55 中，MongoDB 雪花 ID 仍存在三个相关问题：

1. 表列表结构化筛选生成的 `NumberLong(...)` 查询无法执行；
2. 筛选输入框手动输入 `NumberLong(...)` 同样无法执行；
3. BSON `Int64` 类型的 `_id` 在查询结果中编辑保存时，被当作字符串条件，导致更新匹配不到文档。

## 原因

此前的修复会使用 Extended JSON `$numberLong` 保存长整型筛选精度，并在查询预览中显示为 `NumberLong(...)`，但链路仍有缺口：

- Mongo Shell 命令解析器只转换了 `ObjectId` 和日期构造器，没有识别 `NumberLong`，预览语句重新执行时会解析失败；
- 原生 Rust MongoDB 驱动未将筛选中的 `$numberLong` 解码为 BSON `Int64`；
- 查询结果为避免 JavaScript 精度丢失，会把超长 `Int64` 显示为字符串，同时丢失 `_id` 的原始 BSON 类型，保存时最终生成了字符串匹配条件。

## 修改

- Mongo Shell 命令解析器支持带引号和不带引号的 `NumberLong(...)`，统一转换为 `$numberLong`；
- 原生 Rust 驱动在查询、写入和筛选路径中正确解析 Extended JSON `Int64`；
- 查询返回时为 BSON `Int64` 类型的 `_id` 保留类型元数据，表格仍显示纯数字；
- 表列表和 SQL 查询结果保存/预览时使用原始类型化 `_id`，生成 `NumberLong("...")` 条件并精确更新；
- Legacy MongoDB Agent 同步保留 Long `_id` 类型并按 Extended JSON ID 更新；
- 编辑其他超出 JavaScript 安全整数范围的 Int64 值时，不再经过 `Number` 舍入。

实现保留了字符串 `_id` 的原有语义：即使数据库中同时存在数字文本相同的 String `_id` 和 Int64 `_id`，更新 Int64 文档也不会误改字符串文档。

## 验证

- `pnpm check`：format、lint、typecheck、全量 2774 项测试通过；
- `cargo test -p dbx-core db::mongo_driver::tests --lib`：45 项通过；
- `cargo fmt --all -- --check`：通过；
- `./gradlew :mongodb:test :mongodb:shadowJar`：通过；
- MongoDB 8.0.26 真实环境验证：
  - 原生 Rust 驱动使用 `$numberLong` 筛选命中 1 条；
  - Int64 `_id` 更新返回 1，回读值正确；
  - 同数字文本的 String `_id` 文档未被修改；
  - Legacy Java Agent 筛选命中 1 条，更新返回 `modified_count: 1`，回读值正确。

Refs #2527（修复该 Issue 的最新评论追加反馈）