### PR TITLE
Fix: 修复新版 JRE 下 SQL Server 旧版 TLS 握手失败

### DIFF
--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -29,6 +29,10 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
         "RC4",
         "DES",
         "MD5WITHRSA",
+        // Legacy SQL Server TLS 1.0 endpoints commonly rely on static RSA cipher
+        // suites and RSA/SHA-1 handshake signatures disabled by newer JREs.
+        "TLS_RSA_*",
+        "RSA_PKCS1_SHA1 USAGE HANDSHAKESIGNATURE",
         "DH KEYSIZE < 1024",
         "RSA KEYSIZE < 1024"
     );
@@ -101,6 +105,9 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
             + ", jdbc=" + jdbcDriverVersion()
             + ", sslProtocol=TLSv1"
             + ", tlsV1Disabled=" + isDisabled(disabledAlgorithms, "TLSV1")
+            + ", tlsRsaDisabled=" + isDisabled(disabledAlgorithms, "TLS_RSA_*")
+            + ", rsaPkcs1Sha1HandshakeDisabled="
+            + isDisabled(disabledAlgorithms, "RSA_PKCS1_SHA1 USAGE HANDSHAKESIGNATURE")
             + ", 3desDisabled=" + isDisabled(disabledAlgorithms, "3DES_EDE_CBC")
             + ", rc4Disabled=" + isDisabled(disabledAlgorithms, "RC4");
     }

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -13,7 +13,10 @@ class SqlServerLegacyAgentTest {
         String key = "jdk.tls.disabledAlgorithms";
         String original = Security.getProperty(key);
         try {
-            Security.setProperty(key, "TLSv1, TLSv1.1, 3DES_EDE_CBC, EC keySize < 224");
+            Security.setProperty(
+                key,
+                "TLSv1, TLSv1.1, TLS_RSA_*, rsa_pkcs1_sha1 usage HandshakeSignature, 3DES_EDE_CBC, EC keySize < 224"
+            );
 
             new SqlServerLegacyAgent();
 
@@ -21,6 +24,8 @@ class SqlServerLegacyAgentTest {
             String diagnostics = SqlServerLegacyAgent.legacyTlsDiagnostics();
             Assertions.assertTrue(diagnostics.contains("sslProtocol=TLSv1"));
             Assertions.assertTrue(diagnostics.contains("tlsV1Disabled=false"));
+            Assertions.assertTrue(diagnostics.contains("tlsRsaDisabled=false"));
+            Assertions.assertTrue(diagnostics.contains("rsaPkcs1Sha1HandshakeDisabled=false"));
             Assertions.assertTrue(diagnostics.contains("3desDisabled=false"));
             Assertions.assertTrue(diagnostics.contains("rc4Disabled=false"));
         } finally {
@@ -101,10 +106,14 @@ class SqlServerLegacyAgentTest {
     @Test
     void relaxedDisabledAlgorithmsRemovesOnlyLegacyTlsEntries() {
         String current =
-            "SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL";
+            "SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, MD5withRSA, TLS_RSA_*, "
+                + "rsa_pkcs1_sha1 usage HandshakeSignature, ecdsa_sha1 usage HandshakeSignature, "
+                + "dsa_sha1 usage HandshakeSignature, DH keySize < 1024, EC keySize < 224, "
+                + "3DES_EDE_CBC, anon, NULL";
 
         Assertions.assertEquals(
-            "SSLv3, EC keySize < 224, anon, NULL",
+            "SSLv3, ecdsa_sha1 usage HandshakeSignature, dsa_sha1 usage HandshakeSignature, "
+                + "EC keySize < 224, anon, NULL",
             SqlServerLegacyAgent.relaxedDisabledAlgorithms(current)
         );
     }


### PR DESCRIPTION
## 问题

#3095 已将 TLS 1.0 兼容策略提前到 JDBC/JSSE 初始化前，但用户升级后仍出现 tls handshake eof / unexpected_message。新增诊断确认 TLSv1 已成功解除禁用。

Temurin 21.0.11 进一步默认禁用了 TLS_RSA_* 密码套件和 RSA/SHA-1 握手签名，而旧版 SQL Server TLS 1.0 实例通常依赖这些算法，因此双方仍可能没有可用的握手组合。

## 变更

- 仅在独立 sqlserver-legacy Agent 进程中放开 TLS_RSA_* 和 RSA/SHA-1 握手签名
- 扩展失败诊断，输出 tlsRsaDisabled 和 rsaPkcs1Sha1HandshakeDisabled 状态
- 补充策略测试，并确认 ECDSA/DSA 等无关弱算法仍保持禁用
- 不修改普通 SQL Server 及其他数据库的连接路径

## 验证

- ./gradlew :sqlserver-legacy:test :sqlserver-legacy:shadowJar --rerun-tasks
- ./gradlew test shadowJar --continue（150 个任务通过）
- python3 scripts/validate_agents.py
- python3 -m unittest discover -s scripts -p *_test.py
- python3 scripts/validate_agent_jars.py
- 使用 DBX 托管 Temurin 21.0.11 验证：TLS_RSA_* 默认可用套件为 0，应用兼容策略后恢复为 6

当前没有真实 SQL Server 2008/2008 R2 环境，最终握手结果仍需用户在 Agent 更新发布后验证。