### PR TITLE
fix(agent): 修复离线整包未导入 JRE

### DIFF
--- a/crates/dbx-core/src/agent_service.rs
+++ b/crates/dbx-core/src/agent_service.rs
@@ -1239,6 +1239,7 @@ pub fn import_offline_zip(
     let registry = read_registry_from_zip(&mut archive)?;
 
     let platform = AgentManager::current_platform();
+    std::fs::create_dir_all(am.base_dir()).map_err(|e| format!("Failed to create agent directory: {e}"))?;
     let mut local_state = am.load_state();
     let mut result =
         OfflineImportResult { jre_installed: Vec::new(), drivers_installed: Vec::new(), drivers_skipped: Vec::new() };
@@ -1375,7 +1376,7 @@ fn read_registry_from_zip(archive: &mut zip::ZipArchive<std::fs::File>) -> Resul
 
 fn extract_jre_key_from_filename(name: &str) -> Option<String> {
     let filename = name.rsplit('/').next()?;
-    let rest = filename.strip_prefix("jre-")?;
+    let rest = filename.strip_prefix("dbx-jre-").or_else(|| filename.strip_prefix("jre-"))?;
     let key = rest.split('-').next()?;
     if key.is_empty() {
         return None;
@@ -1441,6 +1442,12 @@ mod agent_download_url_tests {
             r2_path_with_cache_buster("agents/drivers/dbx-agent-h2.jar?mirror=r2", "0.5.33"),
             "agents/drivers/dbx-agent-h2.jar?mirror=r2&v=0.5.33"
         );
+    }
+
+    #[test]
+    fn offline_jre_filename_parser_accepts_release_and_legacy_names() {
+        assert_eq!(extract_jre_key_from_filename("jre/dbx-jre-21-macos-aarch64.tar.gz").as_deref(), Some("21"));
+        assert_eq!(extract_jre_key_from_filename("jre/jre-21-macos-aarch64.tar.gz").as_deref(), Some("21"));
     }
 }
 

--- a/crates/dbx-core/tests/agent_service.rs
+++ b/crates/dbx-core/tests/agent_service.rs
@@ -492,6 +492,26 @@ fn offline_zip_import_emits_progress_and_updates_state() {
 }
 
 #[test]
+fn offline_zip_import_installs_release_named_jre() {
+    let manager = test_manager("offline-release-jre");
+    let zip_path = test_path("offline-release-jre-zip").join("agents.zip");
+    std::fs::create_dir_all(zip_path.parent().unwrap()).unwrap();
+    write_offline_driver_zip_with_jre(&zip_path, "h2", "0.2.0", "21.0.12");
+    let events = std::sync::Mutex::new(Vec::new());
+
+    let result = import_agents_from_zip(&manager, &zip_path, |event| {
+        events.lock().unwrap().push(event);
+    })
+    .unwrap();
+
+    assert_eq!(result.jre_installed, vec![DEFAULT_JRE_KEY]);
+    assert_eq!(result.drivers_installed, vec!["h2"]);
+    assert!(manager.is_jre_installed(DEFAULT_JRE_KEY));
+    assert_eq!(manager.load_state().jre_versions.get(DEFAULT_JRE_KEY).map(String::as_str), Some("21.0.12"));
+    assert!(events.lock().unwrap().iter().any(|event| event.step == "jre-extract"));
+}
+
+#[test]
 fn offline_zip_import_rejects_corrupt_jar() {
     let manager = test_manager("offline-corrupt-driver");
     let zip_path = test_path("offline-corrupt-driver-zip").join("agents.zip");
@@ -507,6 +527,64 @@ fn offline_zip_import_rejects_corrupt_jar() {
 
 fn write_offline_driver_zip(path: &std::path::Path, db_type: &str, version: &str) {
     write_offline_driver_zip_with_jar(path, db_type, version, test_agent_jar_bytes());
+}
+
+fn write_offline_driver_zip_with_jre(path: &std::path::Path, db_type: &str, version: &str, jre_version: &str) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let jar = test_agent_jar_bytes();
+    let jre_archive = test_jre_archive_bytes();
+    let registry = serde_json::json!({
+        "jres": {
+            DEFAULT_JRE_KEY: {
+                "version": jre_version,
+                "platforms": {}
+            }
+        },
+        "drivers": {
+            db_type: {
+                "version": version,
+                "label": db_type,
+                "min_app_version": "0.1.0",
+                "jre": DEFAULT_JRE_KEY,
+                "jar": { "url": format!("https://example.com/dbx-agent-{db_type}.jar"), "size": jar.len() }
+            }
+        }
+    });
+
+    zip.start_file("agent-registry.json", options).unwrap();
+    std::io::Write::write_all(&mut zip, registry.to_string().as_bytes()).unwrap();
+    zip.start_file(format!("jre/dbx-jre-{DEFAULT_JRE_KEY}-{}.tar.gz", AgentManager::current_platform()), options)
+        .unwrap();
+    std::io::Write::write_all(&mut zip, &jre_archive).unwrap();
+    zip.start_file(format!("drivers/dbx-agent-{db_type}.jar"), options).unwrap();
+    std::io::Write::write_all(&mut zip, &jar).unwrap();
+    zip.finish().unwrap();
+}
+
+fn test_jre_archive_bytes() -> Vec<u8> {
+    let root = test_path("jre-archive");
+    let runtime_root = root.join("dbx-jre");
+    let bin_dir = runtime_root.join("bin");
+    let archive = root.join("jre.tar.gz");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    std::fs::write(bin_dir.join("java"), b"java").unwrap();
+    std::fs::write(bin_dir.join("java.exe"), b"java").unwrap();
+
+    let status = std::process::Command::new("tar")
+        .arg("czf")
+        .arg(&archive)
+        .arg("-C")
+        .arg(&root)
+        .arg("dbx-jre")
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let bytes = std::fs::read(&archive).unwrap();
+    std::fs::remove_dir_all(root).ok();
+    bytes
 }
 
 fn write_offline_driver_zip_with_jar(path: &std::path::Path, db_type: &str, version: &str, jar: Vec<u8>) {


### PR DESCRIPTION
## 背景

有内网用户导入平台对应的 Agent 离线整包后，驱动管理中只有数据库驱动，连接 OceanBase Oracle 模式时仍提示 JRE 21 未安装。该问题会影响所有依赖 Java Agent 的离线安装场景，并非 OceanBase 特有。

## 原因

离线整包构建脚本将 JRE 保存为 jre/dbx-jre-21-{platform}.tar.gz，但导入器只解析以 jre- 开头的文件名。由于扫描使用 filter_map，名称解析失败后 JRE 会被静默跳过，数据库驱动仍继续安装，因此界面会表现为导入成功但缺少 JRE。

完整导入测试还发现，全新安装时 Agent 根目录可能尚未创建；JRE 恢复识别后，需要先创建该目录才能写入临时归档。

## 修改

- 识别正式发布包使用的 dbx-jre- 文件名
- 保留对旧版 jre- 文件名的兼容
- 离线导入前确保 Agent/JRE 根目录存在
- 增加真实离线 ZIP 回归测试，验证 JRE 解压、版本状态、驱动安装和进度事件

## 验证

- cargo test -p dbx-core --test agent_service --no-default-features（22 项通过）
- cargo test -p dbx-core --lib --no-default-features agent_download_url_tests（3 项通过）
- cargo fmt --all -- --check
- git diff --check