### PR TITLE
Fix: 修复 ZooKeeper 空数据节点查询报错

### DIFF
--- a/agents/drivers/zookeeper/src/main/java/com/dbx/agent/zookeeper/ZooKeeperAgent.java
+++ b/agents/drivers/zookeeper/src/main/java/com/dbx/agent/zookeeper/ZooKeeperAgent.java
@@ -385,14 +385,15 @@ public final class ZooKeeperAgent {
     }
 
     private static Map<String, Object> valueObject(byte[] bytes) {
+        byte[] normalized = bytes == null ? new byte[0] : bytes;
         Map<String, Object> value = new LinkedHashMap<>();
-        String utf8 = strictUtf8(bytes);
+        String utf8 = strictUtf8(normalized);
         if (utf8 != null) {
             value.put("encoding", "utf8");
             value.put("data", utf8);
         } else {
             value.put("encoding", "base64");
-            value.put("data", Base64.getEncoder().encodeToString(bytes));
+            value.put("data", Base64.getEncoder().encodeToString(normalized));
         }
         return value;
     }

--- a/agents/drivers/zookeeper/src/test/java/com/dbx/agent/zookeeper/ZooKeeperAgentTest.java
+++ b/agents/drivers/zookeeper/src/test/java/com/dbx/agent/zookeeper/ZooKeeperAgentTest.java
@@ -5,12 +5,18 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 final class ZooKeeperAgentTest {
     @AfterEach
@@ -318,6 +324,33 @@ final class ZooKeeperAgentTest {
             JsonObject value = result(request(3, "kv_get", "{\"key\":\"/bin\"}")).getAsJsonObject("value");
             Assertions.assertEquals("base64", value.get("encoding").getAsString());
             Assertions.assertEquals("/wAB", value.get("data").getAsString());
+        }
+    }
+
+    @Test
+    void kvGetTreatsNullZnodeDataAsEmptyUtf8Value() throws Exception {
+        try (TestingServer server = new TestingServer()) {
+            CountDownLatch connected = new CountDownLatch(1);
+            ZooKeeper rawClient = new ZooKeeper(server.getConnectString(), 10000, event -> {
+                if (event.getState() == Watcher.Event.KeeperState.SyncConnected) {
+                    connected.countDown();
+                }
+            });
+            try {
+                Assertions.assertTrue(connected.await(10, TimeUnit.SECONDS));
+                rawClient.create("/null-data", null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } finally {
+                rawClient.close();
+            }
+
+            connect(server);
+            JsonObject get = result(request(3, "kv_get", "{\"key\":\"/null-data\"}"));
+
+            JsonObject value = get.getAsJsonObject("value");
+            Assertions.assertEquals("utf8", value.get("encoding").getAsString());
+            Assertions.assertEquals("", value.get("data").getAsString());
+            Assertions.assertEquals(0, get.getAsJsonObject("metadata").get("dataLength").getAsInt());
+            Assertions.assertEquals(0, get.getAsJsonObject("metadata").get("valueSize").getAsInt());
         }
     }
 


### PR DESCRIPTION
## 问题原因

ZooKeeper 允许 znode 的 data 为 `null`。查询这类节点时，agent 直接将 null 字节数组传给 `ByteBuffer.wrap()`，因此触发数组长度空指针异常，右侧节点信息无法显示。

## 修改内容

- 将 ZooKeeper 的 null data 统一按零字节值处理
- 返回 UTF-8 空字符串，同时保持 `dataLength` 和 `valueSize` 为 0
- 增加真实 null-data znode 的回归测试，覆盖节点值和 metadata

## 验证

- `:zookeeper:test :zookeeper:shadowJar` 通过
- 在 ZooKeeper 3.9.5 测试实例创建 null-data 节点，修复前稳定复现 RPC 错误
- 使用修复后的 agent 查询成功，返回空字符串和完整 metadata
- 测试节点已清理

Fixes #3302