### PR TITLE
feat(structure): add copy button to DDL tab

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -2140,6 +2140,16 @@ async function copyPreviewSql() {
   }
 }
 
+async function copyDdlContent() {
+  if (!ddlContent.value.trim()) return;
+  try {
+    await copyToClipboard(ddlContent.value);
+    toast(t("contextMenu.ddlCopied"), 2000);
+  } catch (e: any) {
+    toast(t("grid.copyFailed", { message: e?.message || String(e) }), 5000);
+  }
+}
+
 function toggleSqlPreviewCollapsed() {
   sqlPreviewCollapsed.value = !sqlPreviewCollapsed.value;
   safeLocalStorageSet(STRUCTURE_SQL_PREVIEW_COLLAPSED_STORAGE_KEY, String(sqlPreviewCollapsed.value));
@@ -3115,12 +3125,18 @@ watch([activeTab, ddlLoading], ([tab, loading]) => {
             </div>
           </TabsContent>
 
-          <TabsContent ref="ddlScrollerRef" v-if="tableMetadataCapabilities.ddl" value="ddl" class="m-0 min-h-0 flex-1 overflow-auto p-[var(--structure-cell-px)]" @scroll.passive="onStructureContentScroll('ddl', $event)">
+          <TabsContent ref="ddlScrollerRef" v-if="tableMetadataCapabilities.ddl" value="ddl" class="relative m-0 min-h-0 flex-1 overflow-auto p-[var(--structure-cell-px)]" @scroll.passive="onStructureContentScroll('ddl', $event)">
             <div v-if="ddlLoading" class="flex items-center justify-center gap-2 py-10 text-muted-foreground">
               <Loader2 class="h-4 w-4 animate-spin" />
               {{ t("common.loading") }}
             </div>
-            <pre v-else ref="ddlPreRef" tabindex="0" class="m-0 min-h-0 flex-1 whitespace-pre p-3 font-mono text-xs leading-5 select-text outline-none" v-html="ddlContent ? (sqlHighlighter?.(ddlContent) ?? ddlContent) : t('structureEditor.emptyReadonly')" @keydown="onDdlKeydown"></pre>
+            <template v-else>
+              <Button v-if="ddlContent" variant="outline" size="sm" class="absolute right-3 top-3 z-10 h-7 gap-1 px-2" :title="t('grid.copyDdl')" @click="copyDdlContent">
+                <Copy class="h-3.5 w-3.5" />
+                {{ t("grid.copyDdl") }}
+              </Button>
+              <pre ref="ddlPreRef" tabindex="0" class="m-0 min-h-0 flex-1 whitespace-pre p-3 font-mono text-xs leading-5 select-text outline-none" v-html="ddlContent ? (sqlHighlighter?.(ddlContent) ?? ddlContent) : t('structureEditor.emptyReadonly')" @keydown="onDdlKeydown"></pre>
+            </template>
           </TabsContent>
         </Tabs>
       </div>


### PR DESCRIPTION
## Description
Add a Copy DDL floating button to the structure editor's DDL tab so the
generated CREATE statement can be copied to the clipboard in one
click instead of relying on manual text selection.



## Type of Change

- [X] New Feature
- [ ] Bug Fix
- [ ] Performance Optimization
- [ ] Code Refactoring
- [ ] Documentation Update
- [ ] CI / Build


## Frontend Changes

- [x] This PR involves frontend changes, and screenshots/screen recordings are attached below
<img width="806" height="320" alt="SCR-20260713-saxy" src="https://github.com/user-attachments/assets/3bba7b5f-d50a-4149-a10b-8d8f551a7d65" />



## Verification

- [X] `make check` passed
- [X] `make cargo-check-fast` passed
- [X] `pnpm typecheck` passed

## Related Issues
#3343