### PR TITLE
✨ feat(tests): 添加 PostgreSQL 表层次结构的分页测试用例

### DIFF
--- a/apps/desktop/src/lib/__tests__/table/tableTree.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableTree.spec.ts
@@ -29,6 +29,35 @@ describe("PostgreSQL overloaded routines", () => {
   });
 });
 
+describe("PostgreSQL table hierarchy", () => {
+  it("keeps schema pagination visible at the table-group root when a page ends inside nested partitions", () => {
+    const nodes = buildTableTreeNodes({
+      ...context,
+      schema: "public",
+      tables: [
+        { name: "orders", table_type: "BASE TABLE", comment: null },
+        { name: "orders_2026", table_type: "BASE TABLE", comment: null, parent_schema: "public", parent_name: "orders" },
+        { name: "orders_2026_01", table_type: "BASE TABLE", comment: null, parent_schema: "public", parent_name: "orders_2026" },
+      ],
+    });
+    const loadMore: TreeNode = {
+      id: "load-more:1000",
+      label: "tree.loadMore",
+      type: "load-more",
+      connectionId: context.connectionId,
+      database: context.database,
+      loadMore: { parentId: "connection:db:__tables", offset: 1000, pageSize: 1000 },
+    };
+
+    const withLoadMore = appendTableTreeLoadMoreNode(nodes, loadMore, { schema: "public", name: "orders_2026" });
+
+    expect(withLoadMore.map((node) => node.label)).toEqual(["orders", "tree.loadMore"]);
+    const yearPartition = tablePartitionGroups(withLoadMore[0])[0].children?.[0];
+    expect(yearPartition?.label).toBe("orders_2026");
+    expect(tablePartitionGroups(yearPartition!)[0].children?.map((node) => node.label)).toEqual(["orders_2026_01"]);
+  });
+});
+
 describe("TDengine table hierarchy", () => {
   it("groups child tables under their supertable and keeps ordinary tables flat", () => {
     const tables: TableInfo[] = [

--- a/apps/desktop/src/lib/table/tableTree.ts
+++ b/apps/desktop/src/lib/table/tableTree.ts
@@ -353,7 +353,10 @@ function findTableTreeNode(nodes: readonly TreeNode[], parent: TableTreeLoadMore
 
 export function appendTableTreeLoadMoreNode(children: TreeNode[], loadMoreNode: TreeNode, parent?: TableTreeLoadMoreParent): TreeNode[] {
   const parentNode = parent ? findTableTreeNode(children, parent) : undefined;
-  const childGroup = parentNode ? tablePartitionGroups(parentNode)[0] : undefined;
+  // Only TDengine pages are scoped to a STABLE's child-table group. PostgreSQL
+  // paginates the whole schema, so nesting its global cursor under whichever
+  // partition happens to end the page can hide all remaining schema objects.
+  const childGroup = parentNode && isSuperTable(parentNode) ? tablePartitionGroups(parentNode)[0] : undefined;
   if (!childGroup) return [...children, loadMoreNode];
 
   childGroup.children = [...(childGroup.children ?? []), loadMoreNode];

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1045,7 +1045,7 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   function objectGroupCacheKey(node: TreeNode): string {
-    return schemaCacheKey(node.connectionId || "", node.database || "", node.schema || "", node.type, "objects-v3");
+    return schemaCacheKey(node.connectionId || "", node.database || "", node.schema || "", node.type, "objects-v4");
   }
 
   function metadataListDriverProfile(connectionId?: string): string | undefined {
@@ -2991,7 +2991,7 @@ export const useConnectionStore = defineStore("connection", () => {
           await ensureConnected(connectionId);
           if (useCachedChildren(node, options)) return;
           const searchFilter = activeTreeLoadSearchFilter(options);
-          const cacheKey = schemaCacheKey(connectionId, `doris-catalog:${catalog}`, database, "objects-simple-v3");
+          const cacheKey = schemaCacheKey(connectionId, `doris-catalog:${catalog}`, database, "objects-simple-v4");
           if (!options?.force && !searchFilter) {
             const cached = await loadPersistedTreeChildren(node, cacheKey);
             if (cached.hit) {
@@ -3064,7 +3064,7 @@ export const useConnectionStore = defineStore("connection", () => {
           await ensureConnected(connectionId);
           if (useCachedChildren(node, options)) return;
           const simpleObjectDisplay = useSettingsStore().editorSettings.sidebarObjectDisplay === "simple";
-          const cacheKey = schemaCacheKey(connectionId, database, schema || "", simpleObjectDisplay ? "objects-simple-v3" : "objects-grouped-v3");
+          const cacheKey = schemaCacheKey(connectionId, database, schema || "", simpleObjectDisplay ? "objects-simple-v4" : "objects-grouped-v4");
           const searchFilter = activeTreeLoadSearchFilter(options);
           const isSidebarTableSearch = !!options?.sidebarTableSearchParentId;
           if (!options?.force && !searchFilter) {
@@ -3322,7 +3322,7 @@ export const useConnectionStore = defineStore("connection", () => {
             if (!canApplyTreeMetadataResult(parent)) return;
             parent.objectCount = mergedChildren.length;
             setChildren(parent, nextChildren);
-            await savePersistedTreeChildren(schemaCacheKey(parentConnectionId, parentDatabase, parent.schema || "", "objects-simple-v3"), nextChildren);
+            await savePersistedTreeChildren(schemaCacheKey(parentConnectionId, parentDatabase, parent.schema || "", "objects-simple-v4"), nextChildren);
             parent.isExpanded = true;
             return;
           }


### PR DESCRIPTION
- 新增测试用例以确保在嵌套分区中分页时，表组根的模式分页可见
- 更新 `appendTableTreeLoadMoreNode` 函数以支持 PostgreSQL 的分页逻辑
- 修改缓存键以适应新的对象版本

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

可使用如下 SQL 进行验证：

<details>
<summary>点击展开/折叠代码</summary>

```
-- DBX issue #3298 PostgreSQL reproduction fixture
-- https://github.com/t8y2/dbx/issues/3298
--
-- Target: PostgreSQL 14+
-- Result:
--   * 70 top-level tables (1 partitioned root + 69 ordinary tables)
--   * 10 first-level partitioned tables
--   * 3000 second-level leaf partitions
--   * 3080 pg_class table-like relations in total
--
-- Important: run this file without wrapping it in an explicit BEGIN/COMMIT.
-- The builder procedure commits every 50 leaf partitions so a default
-- PostgreSQL installation does not retain locks for all 3000 tables at once.

SET client_min_messages = notice;
SET statement_timeout = 0;
SET lock_timeout = 0;

-- Dedicated disposable schema. This statement makes the fixture repeatable.
DROP SCHEMA IF EXISTS dbx_issue_3298 CASCADE;
CREATE SCHEMA dbx_issue_3298;

CREATE TABLE dbx_issue_3298.p_event_log (
    bucket_l1  integer NOT NULL,
    bucket_l2  integer NOT NULL,
    event_id   bigint NOT NULL,
    payload    text,
    created_at timestamp with time zone NOT NULL DEFAULT clock_timestamp()
) PARTITION BY RANGE (bucket_l1);

-- Build a two-level hierarchy:
--   p_event_log
--     -> p_event_log_l1_00 .. p_event_log_l1_09
--          -> p_event_log_l1_XX_l2_000 .. _299
--
-- COMMIT inside a procedure requires CALL to run outside an explicit
-- transaction block. psql -f and DBX autocommit mode both satisfy that rule.
CREATE OR REPLACE PROCEDURE dbx_issue_3298.build_partition_fixture()
LANGUAGE plpgsql
AS $fixture$
DECLARE
    l1 integer;
    l2 integer;
    l1_name text;
    l2_name text;
BEGIN
    FOR l1 IN 0..9 LOOP
        l1_name := format('p_event_log_l1_%s', lpad(l1::text, 2, '0'));

        EXECUTE format(
            'CREATE TABLE %I.%I PARTITION OF %I.%I '
            'FOR VALUES FROM (%s) TO (%s) PARTITION BY RANGE (bucket_l2)',
            'dbx_issue_3298', l1_name,
            'dbx_issue_3298', 'p_event_log',
            l1, l1 + 1
        );
        COMMIT;

        FOR l2 IN 0..299 LOOP
            l2_name := format(
                'p_event_log_l1_%s_l2_%s',
                lpad(l1::text, 2, '0'),
                lpad(l2::text, 3, '0')
            );

            EXECUTE format(
                'CREATE TABLE %I.%I PARTITION OF %I.%I '
                'FOR VALUES FROM (%s) TO (%s)',
                'dbx_issue_3298', l2_name,
                'dbx_issue_3298', l1_name,
                l2, l2 + 1
            );

            IF (l2 + 1) % 50 = 0 THEN
                COMMIT;
            END IF;
        END LOOP;

        RAISE NOTICE 'created first-level partition % with 300 leaf partitions', l1_name;
    END LOOP;
END;
$fixture$;

CALL dbx_issue_3298.build_partition_fixture();
DROP PROCEDURE dbx_issue_3298.build_partition_fixture();

-- Add 69 ordinary root tables after the partition hierarchy in lexical order.
-- Together with p_event_log, the DBX tree should ultimately show 70 roots.
DO $ordinary$
DECLARE
    n integer;
    table_name text;
BEGIN
    FOR n IN 1..69 LOOP
        table_name := format('z_normal_%s', lpad(n::text, 2, '0'));
        EXECUTE format(
            'CREATE TABLE %I.%I ('
            'id bigint PRIMARY KEY, '
            'note text, created_at timestamp with time zone DEFAULT clock_timestamp())',
            'dbx_issue_3298', table_name
        );
    END LOOP;
END;
$ordinary$;

-- ---------------------------------------------------------------------------
-- Verification queries
-- ---------------------------------------------------------------------------

-- Expected: total_relations=3080, partitioned_relations=11,
-- ordinary_or_leaf_relations=3069, top_level_relations=70.
SELECT
    count(*) AS total_relations,
    count(*) FILTER (WHERE c.relkind = 'p') AS partitioned_relations,
    count(*) FILTER (WHERE c.relkind = 'r') AS ordinary_or_leaf_relations,
    count(*) FILTER (WHERE i.inhrelid IS NULL) AS top_level_relations
FROM pg_catalog.pg_class AS c
JOIN pg_catalog.pg_namespace AS n
  ON n.oid = c.relnamespace
LEFT JOIN pg_catalog.pg_inherits AS i
  ON i.inhrelid = c.oid
WHERE n.nspname = 'dbx_issue_3298'
  AND c.relkind IN ('r', 'p');

-- Expected hierarchy: 3011 rows, max_level=2, leaf_relations=3000.
SELECT
    count(*) AS hierarchy_relations,
    max(level) AS max_level,
    count(*) FILTER (WHERE isleaf) AS leaf_relations
FROM pg_catalog.pg_partition_tree('dbx_issue_3298.p_event_log'::regclass);

-- Emulate the ordering used by DBX's PostgreSQL list_tables query.
-- With DBX's default sidebar page size of 1000, row 1000 is a leaf partition
-- whose immediate parent is p_event_log_l1_03. In affected builds the global
-- "Load more" node is therefore inserted inside that collapsed partition group.
WITH ordered AS (
    SELECT
        row_number() OVER (ORDER BY c.relname) AS row_no,
        c.relname AS table_name,
        pc.relname AS parent_name,
        c.relkind
    FROM pg_catalog.pg_class AS c
    JOIN pg_catalog.pg_namespace AS n
      ON n.oid = c.relnamespace
    LEFT JOIN pg_catalog.pg_inherits AS i
      ON i.inhrelid = c.oid
    LEFT JOIN pg_catalog.pg_class AS pc
      ON pc.oid = i.inhparent
    WHERE n.nspname = 'dbx_issue_3298'
      AND c.relkind IN ('r', 'p')
)
SELECT row_no, table_name, parent_name, relkind
FROM ordered
WHERE row_no BETWEEN 998 AND 1002
ORDER BY row_no;

-- Expected: ordinary_tables_after_first_page=69 and
-- relations_after_first_page=2080. These objects cannot be reached from the
-- top-level tree when the misplaced pagination node is not visible.
WITH ordered AS (
    SELECT
        row_number() OVER (ORDER BY c.relname) AS row_no,
        c.relname AS table_name
    FROM pg_catalog.pg_class AS c
    JOIN pg_catalog.pg_namespace AS n
      ON n.oid = c.relnamespace
    WHERE n.nspname = 'dbx_issue_3298'
      AND c.relkind IN ('r', 'p')
)
SELECT
    count(*) FILTER (WHERE table_name LIKE 'z_normal_%') AS ordinary_tables_after_first_page,
    count(*) AS relations_after_first_page
FROM ordered
WHERE row_no > 1000;

-- Manual DBX v0.5.55 check:
--   1. Connect to this database and refresh schema dbx_issue_3298.
--   2. Keep "Sidebar page size" at 1000.
--   3. Expand Tables (grouped mode) or the schema (simple mode).
--   4. Observe that z_normal_01 .. z_normal_69 are absent and the top-level
--      "+ Load more..." entry is absent.
--   5. The misplaced entry is buried under:
--        p_event_log -> Partitions -> p_event_log_l1_03 -> Partitions
--
-- Optional cleanup after testing:
-- DROP SCHEMA dbx_issue_3298 CASCADE;
```

</details>

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #3298 