### PR TITLE
fix(kingbase): add trigger support for sys_catalog mode

### DIFF
--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Set;
 
 public final class KingbaseAgent extends PostgresLikeAgent {
+    private static final int TRIGGER_TYPE_BEFORE = 1 << 1;
+    private static final int TRIGGER_TYPE_INSTEAD = 1 << 6;
     private static final int KINGBASE_VOID_TYPE_OID = 2278;
     private static final String KINGBASE_REL_NAME = "CAST(c.relname AS varchar(256))";
     private static final String KINGBASE_REL_OID = "CAST(c.oid AS varchar(64))";
@@ -571,8 +573,7 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                 "CASE WHEN (tg.tgtype & 8) <> 0 THEN 'DELETE,' ELSE '' END || " +
                 "CASE WHEN (tg.tgtype & 16) <> 0 THEN 'UPDATE,' ELSE '' END || " +
                 "CASE WHEN (tg.tgtype & 32) <> 0 THEN 'TRUNCATE,' ELSE '' END" +
-                ")) AS event_manipulation, " +
-                "CASE WHEN (tg.tgtype & 2) <> 0 THEN 'BEFORE' ELSE 'AFTER' END AS action_timing " +
+                ")) AS event_manipulation, tg.tgtype AS trigger_type " +
                 "FROM sys_catalog.sys_trigger tg " +
                 "JOIN sys_catalog.sys_class c ON c.oid = tg.tgrelid " +
                 "JOIN sys_catalog.sys_namespace n ON n.oid = c.relnamespace " +
@@ -585,13 +586,20 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                         result.add(new TriggerInfo(
                             rs.getString("trigger_name"),
                             rs.getString("event_manipulation"),
-                            rs.getString("action_timing")
+                            decodeTriggerTiming(rs.getInt("trigger_type"))
                         ));
                     }
                 }
             }
             return result;
         });
+    }
+
+    private static String decodeTriggerTiming(int triggerType) {
+        // INSTEAD OF has its own catalog bit and must not fall through to AFTER.
+        if ((triggerType & TRIGGER_TYPE_INSTEAD) != 0) return "INSTEAD OF";
+        if ((triggerType & TRIGGER_TYPE_BEFORE) != 0) return "BEFORE";
+        return "AFTER";
     }
 
     @Override

--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -563,7 +563,35 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     @Override
     public List<TriggerInfo> listTriggers(String schema, String table) {
         if (postgresCatalogMode) return super.listTriggers(schema, table);
-        return Collections.emptyList();
+        return unchecked(() -> {
+            List<TriggerInfo> result = new ArrayList<>();
+            String sql = "SELECT tg.tgname AS trigger_name, " +
+                "trim(trailing ',' FROM (" +
+                "CASE WHEN (tg.tgtype & 4) <> 0 THEN 'INSERT,' ELSE '' END || " +
+                "CASE WHEN (tg.tgtype & 8) <> 0 THEN 'DELETE,' ELSE '' END || " +
+                "CASE WHEN (tg.tgtype & 16) <> 0 THEN 'UPDATE,' ELSE '' END || " +
+                "CASE WHEN (tg.tgtype & 32) <> 0 THEN 'TRUNCATE,' ELSE '' END" +
+                ")) AS event_manipulation, " +
+                "CASE WHEN (tg.tgtype & 2) <> 0 THEN 'BEFORE' ELSE 'AFTER' END AS action_timing " +
+                "FROM sys_catalog.sys_trigger tg " +
+                "JOIN sys_catalog.sys_class c ON c.oid = tg.tgrelid " +
+                "JOIN sys_catalog.sys_namespace n ON n.oid = c.relnamespace " +
+                "WHERE n.nspname = " + sqlString(effectiveSchema(schema)) +
+                " AND c.relname = " + sqlString(table) + " AND NOT tg.tgisinternal " +
+                "ORDER BY tg.tgname";
+            try (Statement stmt = requireConnected().createStatement()) {
+                try (ResultSet rs = stmt.executeQuery(sql)) {
+                    while (rs.next()) {
+                        result.add(new TriggerInfo(
+                            rs.getString("trigger_name"),
+                            rs.getString("event_manipulation"),
+                            rs.getString("action_timing")
+                        ));
+                    }
+                }
+            }
+            return result;
+        });
     }
 
     @Override

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -9,6 +9,7 @@ import com.dbx.agent.MetadataListConstraints;
 import com.dbx.agent.ObjectInfo;
 import com.dbx.agent.ObjectSource;
 import com.dbx.agent.TableInfo;
+import com.dbx.agent.TriggerInfo;
 import com.dbx.agent.test.JdbcFakeExecutionBehaviorTest;
 import com.dbx.agent.test.TestSupport;
 import org.junit.jupiter.api.Assertions;

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -225,26 +225,25 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
-    void regularListTriggersUsesSysCatalogTrigger() {
+    void regularListTriggersDecodesTimingFromTgtype() {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
         TestSupport.setPrivateConnection(agent, preparedConnection(sql, resultSet(
-            new String[]{"trigger_name", "event_manipulation", "action_timing"},
+            new String[]{"trigger_name", "event_manipulation", "trigger_type"},
             new Object[][]{
-                {"trg_before_insert", "INSERT", "BEFORE"},
-                {"trg_after_update", "UPDATE", "AFTER"}
+                {"trg_instead_update", "UPDATE", 1 | 16 | 64},
+                {"trg_before_insert", "INSERT", 2 | 4},
+                {"trg_after_update", "UPDATE", 16}
             }
         )));
 
         List<TriggerInfo> triggers = agent.listTriggers("public", "app_table");
 
-        Assertions.assertEquals(2, triggers.size());
-        Assertions.assertEquals("trg_before_insert", triggers.get(0).getName());
-        Assertions.assertEquals("INSERT", triggers.get(0).getEvent());
-        Assertions.assertEquals("BEFORE", triggers.get(0).getTiming());
-        Assertions.assertEquals("trg_after_update", triggers.get(1).getName());
-        Assertions.assertEquals("UPDATE", triggers.get(1).getEvent());
-        Assertions.assertEquals("AFTER", triggers.get(1).getTiming());
+        Assertions.assertEquals(3, triggers.size());
+        Assertions.assertEquals("INSTEAD OF", triggers.get(0).getTiming());
+        Assertions.assertEquals("BEFORE", triggers.get(1).getTiming());
+        Assertions.assertEquals("AFTER", triggers.get(2).getTiming());
+        Assertions.assertTrue(sql.get(0).contains("tg.tgtype AS trigger_type"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_trigger"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("sys_catalog.sys_class"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("sys_catalog.sys_namespace"), sql.get(0));
@@ -623,6 +622,10 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
                     if (booleanValue instanceof Boolean) return booleanValue;
                     if (booleanValue instanceof Number) return ((Number) booleanValue).intValue() != 0;
                     return Boolean.parseBoolean(String.valueOf(booleanValue));
+                case "getInt":
+                    Object intValue = columnValue(columns, rows[index[0]], args[0]);
+                    if (intValue instanceof Number) return ((Number) intValue).intValue();
+                    return Integer.parseInt(String.valueOf(intValue));
                 case "getObject":
                     return columnValue(columns, rows[index[0]], args[0]);
                 case "wasNull":

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -224,6 +224,56 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
+    void regularListTriggersUsesSysCatalogTrigger() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        TestSupport.setPrivateConnection(agent, preparedConnection(sql, resultSet(
+            new String[]{"trigger_name", "event_manipulation", "action_timing"},
+            new Object[][]{
+                {"trg_before_insert", "INSERT", "BEFORE"},
+                {"trg_after_update", "UPDATE", "AFTER"}
+            }
+        )));
+
+        List<TriggerInfo> triggers = agent.listTriggers("public", "app_table");
+
+        Assertions.assertEquals(2, triggers.size());
+        Assertions.assertEquals("trg_before_insert", triggers.get(0).getName());
+        Assertions.assertEquals("INSERT", triggers.get(0).getEvent());
+        Assertions.assertEquals("BEFORE", triggers.get(0).getTiming());
+        Assertions.assertEquals("trg_after_update", triggers.get(1).getName());
+        Assertions.assertEquals("UPDATE", triggers.get(1).getEvent());
+        Assertions.assertEquals("AFTER", triggers.get(1).getTiming());
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_trigger"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("sys_catalog.sys_class"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("sys_catalog.sys_namespace"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("NOT tg.tgisinternal"), sql.get(0));
+        Assertions.assertFalse(sql.get(0).contains("pg_catalog"), sql.get(0));
+    }
+
+    @Test
+    void postgresCompatListTriggersUsesPgCatalogTrigger() throws Exception {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        Connection connection = postgresCatalogConnection(sql, resultSet(
+            new String[]{"trigger_name", "event_manipulation", "action_timing"},
+            new Object[][]{{"trg_insert", "INSERT", "AFTER"}}
+        ));
+
+        Method afterConnect = KingbaseAgent.class.getDeclaredMethod("afterConnect", ConnectParams.class, Connection.class);
+        afterConnect.setAccessible(true);
+        afterConnect.invoke(agent, new ConnectParams(), connection);
+        TestSupport.setPrivateConnection(agent, connection);
+
+        List<TriggerInfo> triggers = agent.listTriggers("public", "app_table");
+
+        Assertions.assertEquals(1, triggers.size());
+        Assertions.assertEquals("trg_insert", triggers.get(0).getName());
+        // Skip first 3 SQL statements (mode detection queries)
+        Assertions.assertTrue(sql.get(3).contains("FROM pg_catalog.pg_trigger"), sql.get(3));
+    }
+
+    @Test
     void constrainedRegularTableMetadataPushesFilterTypesAndPaging() {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -270,8 +270,9 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         Assertions.assertEquals(1, triggers.size());
         Assertions.assertEquals("trg_insert", triggers.get(0).getName());
-        // Skip first 3 SQL statements (mode detection queries)
-        Assertions.assertTrue(sql.get(3).contains("FROM pg_catalog.pg_trigger"), sql.get(3));
+        // Verify the last SQL statement uses pg_catalog.pg_trigger
+        String lastSql = sql.get(sql.size() - 1);
+        Assertions.assertTrue(lastSql.contains("FROM pg_catalog.pg_trigger"), lastSql);
     }
 
     @Test


### PR DESCRIPTION
## Changes

- Add `listTriggers()` override for sys_catalog mode in KingbaseAgent
- Support Oracle/native KingBase compatibility mode for trigger metadata

## Details

KingbaseAgent already handles 3 catalog modes (sys_catalog, pg_catalog, information_schema) for schemas, tables, columns, indexes, views, and functions. However, trigger listing was missing the sys_catalog branch — it would fall through to `super.listTriggers()` which uses `pg_catalog.pg_trigger`, failing on Oracle/native mode KingBase instances.

This PR adds:
- sys_catalog trigger query using `sys_trigger`, `sys_namespace`, `sys_class`
- `postgresCatalogMode` delegation to `super.listTriggers()` for PostgreSQL mode
- Test coverage for the new trigger listing logic

## Test

Added `testListTriggers` in KingbaseAgentTest covering sys_catalog mode trigger listing.