### PR TITLE
feat(query): 添加批量执行遇错继续设置，支持多段SQL报错后继续执行

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -263,6 +263,7 @@ const editAutoCloseBrackets = ref(settingsStore.editorSettings.autoCloseBrackets
 const editSqlSemanticDiagnosticsMode = ref<SqlSemanticDiagnosticsMode>(settingsStore.editorSettings.sqlSemanticDiagnosticsMode);
 const editSqlSemanticDiagnosticsEnabled = ref(settingsStore.editorSettings.sqlSemanticDiagnosticsEnabled);
 const editConfirmDangerousSqlExecution = ref(settingsStore.editorSettings.confirmDangerousSqlExecution);
+const editContinueOnErrorOnBatch = ref(settingsStore.editorSettings.continueOnErrorOnBatch);
 const editConfirmUnsavedSqlClose = ref(settingsStore.editorSettings.confirmUnsavedSqlClose);
 const editAppLayout = ref(settingsStore.editorSettings.appLayout);
 const editShowTrayIcon = ref(settingsStore.desktopSettings.show_tray_icon);
@@ -397,6 +398,7 @@ function currentEditorSettingsDraft(): EditorSettingsDraft {
     autoCloseBrackets: editAutoCloseBrackets.value,
     sqlSemanticDiagnosticsMode: editSqlSemanticDiagnosticsMode.value,
     confirmDangerousSqlExecution: editConfirmDangerousSqlExecution.value,
+    continueOnErrorOnBatch: editContinueOnErrorOnBatch.value,
     confirmUnsavedSqlClose: editConfirmUnsavedSqlClose.value,
     appLayout: editAppLayout.value,
     showColumnCommentsInHeader: editShowColumnCommentsInHeader.value,
@@ -672,6 +674,7 @@ function syncEditorSettingsDraftFromStore() {
   editSqlSemanticDiagnosticsMode.value = settingsStore.editorSettings.sqlSemanticDiagnosticsMode;
   editSqlSemanticDiagnosticsEnabled.value = settingsStore.editorSettings.sqlSemanticDiagnosticsEnabled;
   editConfirmDangerousSqlExecution.value = settingsStore.editorSettings.confirmDangerousSqlExecution;
+  editContinueOnErrorOnBatch.value = settingsStore.editorSettings.continueOnErrorOnBatch;
   editConfirmUnsavedSqlClose.value = settingsStore.editorSettings.confirmUnsavedSqlClose;
   editAppLayout.value = settingsStore.editorSettings.appLayout;
   editShowColumnCommentsInHeader.value = settingsStore.editorSettings.showColumnCommentsInHeader;
@@ -859,6 +862,7 @@ function resetDefaultsForTab(tab: SettingsCategory) {
     editSqlSemanticDiagnosticsMode.value = DEFAULT_EDITOR_SETTINGS.sqlSemanticDiagnosticsMode;
     editSqlSemanticDiagnosticsEnabled.value = DEFAULT_EDITOR_SETTINGS.sqlSemanticDiagnosticsEnabled;
     editConfirmDangerousSqlExecution.value = DEFAULT_EDITOR_SETTINGS.confirmDangerousSqlExecution;
+    editContinueOnErrorOnBatch.value = DEFAULT_EDITOR_SETTINGS.continueOnErrorOnBatch;
     editConfirmUnsavedSqlClose.value = DEFAULT_EDITOR_SETTINGS.confirmUnsavedSqlClose;
     editSqlVariableSyntaxOverrides.value = normalizeSqlVariableSyntaxOverrides(DEFAULT_EDITOR_SETTINGS.sqlVariableSyntaxOverrides);
   } else if (tab === "formatter") {
@@ -2793,6 +2797,16 @@ onUnmounted(cleanupPreviewEditor);
                     </p>
                   </div>
                   <Switch id="editor-confirm-dangerous-sql" v-model="editConfirmDangerousSqlExecution" class="mt-0.5" />
+                </div>
+
+                <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
+                  <div class="space-y-1">
+                    <Label for="editor-continue-on-error">{{ t("settings.continueOnErrorOnBatch") }}</Label>
+                    <p class="text-xs text-muted-foreground">
+                      {{ t("settings.continueOnErrorOnBatchDescription") }}
+                    </p>
+                  </div>
+                  <Switch id="editor-continue-on-error" v-model="editContinueOnErrorOnBatch" class="mt-0.5" />
                 </div>
 
                 <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -3426,6 +3426,8 @@ export default {
     sqlSemanticDiagnosticsEnabledDescription: "When enabled, the editor reports semantic issues such as unknown tables and columns. Disable it to reduce parsing and metadata checks for large SQL.",
     confirmDangerousSqlExecution: "Confirm before dangerous SQL",
     confirmDangerousSqlExecutionDescription: "When disabled, ALTER, DROP, DELETE, TRUNCATE, and other dangerous SQL run without the warning dialog.",
+    continueOnErrorOnBatch: "Continue on Error",
+    continueOnErrorOnBatchDescription: "When enabled, multi-statement execution continues after an error instead of stopping at the first failure.",
     confirmUnsavedSqlClose: "Confirm before closing unsaved SQL",
     confirmUnsavedSqlCloseDescription: "When disabled, SQL tabs with unsaved edits close or quit without the save confirmation dialog.",
     prefillNewQueryWithSelect: "Prefill new query with SELECT *",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -3216,6 +3216,8 @@ export default withEnglishFallback({
     sqlSemanticDiagnosticsEnabledDescription: "Al activarse, el editor informa de problemas semánticos como tablas y columnas desconocidas. Desactívalo para reducir el análisis y las comprobaciones de metadatos en SQL grandes.",
     confirmDangerousSqlExecution: "Confirmar antes de SQL peligroso",
     confirmDangerousSqlExecutionDescription: "Cuando se desactiva, ALTER, DROP, DELETE, TRUNCATE y otras sentencias peligrosas se ejecutan sin el diálogo de advertencia.",
+    continueOnErrorOnBatch: "Continuar en error",
+    continueOnErrorOnBatchDescription: "Cuando está habilitado, la ejecución de múltiples sentencias continúa después de un error en lugar de detenerse en el primer fallo.",
     confirmUnsavedSqlClose: "Confirmar antes de cerrar SQL sin guardar",
     confirmUnsavedSqlCloseDescription: "Cuando se desactiva, las pestañas SQL con ediciones sin guardar se cierran o salen sin el diálogo de confirmación de guardado.",
     prefillNewQueryWithSelect: "Rellenar nueva consulta con SELECT *",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -3214,6 +3214,8 @@ export default withEnglishFallback({
     sqlSemanticDiagnosticsEnabledDescription: "Se abilitata, l'editor segnala problemi semantici come tabelle e colonne sconosciute. Disabilitala per ridurre l'analisi e i controlli dei metadati per file SQL di grandi dimensioni.",
     confirmDangerousSqlExecution: "Conferma prima di SQL pericoloso",
     confirmDangerousSqlExecutionDescription: "Se disattivato, ALTER, DROP, DELETE, TRUNCATE e altri SQL pericolosi verranno eseguiti senza la finestra di avviso.",
+    continueOnErrorOnBatch: "Continua in caso di errore",
+    continueOnErrorOnBatchDescription: "Se abilitato, l'esecuzione di più istruzioni continua dopo un errore invece di interrompersi al primo fallimento.",
     confirmUnsavedSqlClose: "Conferma prima di chiudere SQL non salvato",
     confirmUnsavedSqlCloseDescription: "Se disattivato, le schede SQL con modifiche non salvate verranno chiuse o usciranno senza la finestra di conferma di salvataggio.",
     prefillNewQueryWithSelect: "Precompila nuova query con SELECT *",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -3204,6 +3204,8 @@ export default withEnglishFallback({
     sqlSemanticDiagnosticsEnabledDescription: "有効時、エディタは不明なテーブルや列などの意味的な問題を表示します。大きなSQLの解析とメタデータ確認の負荷を減らすには無効にします。",
     confirmDangerousSqlExecution: "危険なSQLの前に確認",
     confirmDangerousSqlExecutionDescription: "無効時、ALTER、DROP、DELETE、TRUNCATEなどの危険なSQLが警告ダイアログなしで実行されます。",
+    continueOnErrorOnBatch: "エラー時も継続",
+    continueOnErrorOnBatchDescription: "有効にすると、複数SQL文の実行時にエラーが発生しても、最初の失敗で停止せずに後続の文を実行し続けます。",
     confirmUnsavedSqlClose: "未保存のSQLを閉じる前に確認",
     confirmUnsavedSqlCloseDescription: "無効時、未保存の編集があるSQLタブは保存確認ダイアログなしで閉じるか終了します。",
     prefillNewQueryWithSelect: "新規クエリに SELECT を自動入力",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -3216,6 +3216,8 @@ export default withEnglishFallback({
     sqlSemanticDiagnosticsEnabledDescription: "Quando ativado, o editor relata problemas semânticos como tabelas e colunas desconhecidas. Desative para reduzir a análise e verificações de metadados em SQL grande.",
     confirmDangerousSqlExecution: "Confirmar antes de SQL perigoso",
     confirmDangerousSqlExecutionDescription: "Quando desativado, ALTER, DROP, DELETE, TRUNCATE e outros SQL perigosos são executados sem a caixa de diálogo de aviso.",
+    continueOnErrorOnBatch: "Continuar em erro",
+    continueOnErrorOnBatchDescription: "Quando ativado, a execução de múltiplas instruções continua após um erro em vez de parar na primeira falha.",
     confirmUnsavedSqlClose: "Confirmar antes de fechar SQL não salvo",
     confirmUnsavedSqlCloseDescription: "Quando desativado, abas SQL com edições não salvas são fechadas ou o app é encerrado sem a caixa de diálogo de confirmação de salvamento.",
     prefillNewQueryWithSelect: "Preencher nova consulta com SELECT *",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -3425,6 +3425,8 @@ export default withEnglishFallback({
     sqlSemanticDiagnosticsEnabledDescription: "开启后，编辑器会提示未知表、字段等语义问题；关闭可减少 SQL 解析和元数据检查的性能开销。",
     confirmDangerousSqlExecution: "执行危险 SQL 前弹出确认",
     confirmDangerousSqlExecutionDescription: "关闭后，ALTER、DROP、DELETE、TRUNCATE 等危险 SQL 将直接执行。",
+    continueOnErrorOnBatch: "批量执行遇错继续",
+    continueOnErrorOnBatchDescription: "开启后，多条 SQL 批量执行时遇到错误将继续执行后续语句，而非中断。",
     confirmUnsavedSqlClose: "关闭未保存 SQL 前弹出确认",
     confirmUnsavedSqlCloseDescription: "关闭后，有未保存内容的 SQL 标签页会直接关闭或退出，不再弹出保存确认。",
     prefillNewQueryWithSelect: "新建查询时预填充 SELECT 语句",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -3065,6 +3065,8 @@ export default withEnglishFallback({
     sqlSemanticDiagnosticsEnabledDescription: "開啟後，編輯器會提示未知資料表、欄位等語意問題；關閉可減少 SQL 解析和中繼資料檢查的效能負擔。",
     confirmDangerousSqlExecution: "執行危險 SQL 前彈出確認",
     confirmDangerousSqlExecutionDescription: "關閉後，ALTER、DROP、DELETE、TRUNCATE 等危險 SQL 會直接執行。",
+    continueOnErrorOnBatch: "批次執行遇錯繼續",
+    continueOnErrorOnBatchDescription: "開啟後，多條 SQL 批次執行時遇到錯誤將繼續執行後續語句，而非中斷。",
     confirmUnsavedSqlClose: "關閉未儲存 SQL 前彈出確認",
     confirmUnsavedSqlCloseDescription: "關閉後，有未儲存內容的 SQL 分頁會直接關閉或結束，不再彈出儲存確認。",
     prefillNewQueryWithSelect: "新建查詢時預填 SELECT 語句",

--- a/apps/desktop/src/lib/backend/http.ts
+++ b/apps/desktop/src/lib/backend/http.ts
@@ -706,6 +706,7 @@ export async function executeMulti(
     clientSessionId?: string;
     timeoutSecs?: number;
     useTransaction?: boolean;
+    continueOnError?: boolean;
   },
 ): Promise<QueryResult[]> {
   return post("/api/query/execute-multi", { connectionId, database, sql, schema, executionId, ...options });

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -777,6 +777,7 @@ export async function executeMulti(
     clientSessionId?: string;
     timeoutSecs?: number;
     useTransaction?: boolean;
+    continueOnError?: boolean;
   },
 ): Promise<QueryResult[]> {
   return invoke("execute_multi", { connectionId, database, sql, schema, executionId, ...options });

--- a/apps/desktop/src/lib/settings/__tests__/editorSettingsDraft.spec.ts
+++ b/apps/desktop/src/lib/settings/__tests__/editorSettingsDraft.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { EDITOR_SETTINGS_DRAFT_KEYS, editorSettingsDraftFromSettings, editorSettingsDraftChanged, editorSettingsPatchFromDraft } from "../editorSettingsDraft";
+import type { EditorSettings } from "@/stores/settingsStore";
+
+function makeSettings(overrides: Partial<EditorSettings> = {}): EditorSettings {
+  return {
+    autoCalculateTotalRows: false,
+    pageSize: 100,
+    sqlEngine: "desktop",
+    tabSize: 2,
+    keywordCase: "upper",
+    indentStyle: "standard",
+    lineWidth: 80,
+    commaPosition: "end",
+    editorFontFamily: "",
+    editorFontSize: 0,
+    editorLineHeight: 0,
+    maxRowsPerPage: 50000,
+    showHiddenFiles: false,
+    confirmDangerousSqlExecution: true,
+    continueOnErrorOnBatch: false,
+    confirmUnsavedSqlClose: true,
+    objectBrowserViewMode: "list",
+    sqlVariableSyntaxOverrides: {},
+    ...overrides,
+  };
+}
+
+describe("EDITOR_SETTINGS_DRAFT_KEYS", () => {
+  it("includes continueOnErrorOnBatch", () => {
+    expect(EDITOR_SETTINGS_DRAFT_KEYS).toContain("continueOnErrorOnBatch");
+  });
+});
+
+describe("editorSettingsDraftFromSettings", () => {
+  it("maps continueOnErrorOnBatch from settings", () => {
+    const draft = editorSettingsDraftFromSettings(makeSettings({ continueOnErrorOnBatch: true }));
+    expect(draft.continueOnErrorOnBatch).toBe(true);
+  });
+
+  it("maps continueOnErrorOnBatch=false from settings", () => {
+    const draft = editorSettingsDraftFromSettings(makeSettings({ continueOnErrorOnBatch: false }));
+    expect(draft.continueOnErrorOnBatch).toBe(false);
+  });
+});
+
+describe("editorSettingsDraftChanged", () => {
+  it("detects change in continueOnErrorOnBatch", () => {
+    const settings = makeSettings({ continueOnErrorOnBatch: false });
+    const draft = editorSettingsDraftFromSettings(settings);
+    const base = editorSettingsDraftFromSettings(settings);
+    draft.continueOnErrorOnBatch = true;
+    expect(editorSettingsDraftChanged(draft, base)).toBe(true);
+  });
+
+  it("detects no change when continueOnErrorOnBatch matches", () => {
+    const settings = makeSettings({ continueOnErrorOnBatch: false });
+    const draft = editorSettingsDraftFromSettings(settings);
+    const base = editorSettingsDraftFromSettings(settings);
+    expect(editorSettingsDraftChanged(draft, base)).toBe(false);
+  });
+});
+
+describe("editorSettingsPatchFromDraft", () => {
+  it("includes continueOnErrorOnBatch in patch when changed", () => {
+    const settings = makeSettings({ continueOnErrorOnBatch: false });
+    const draft = editorSettingsDraftFromSettings(settings);
+    const base = editorSettingsDraftFromSettings(settings);
+    draft.continueOnErrorOnBatch = true;
+    const patch = editorSettingsPatchFromDraft(draft, base);
+    expect(patch.continueOnErrorOnBatch).toBe(true);
+  });
+
+  it("omits continueOnErrorOnBatch when unchanged", () => {
+    const settings = makeSettings({ continueOnErrorOnBatch: false });
+    const draft = editorSettingsDraftFromSettings(settings);
+    const base = editorSettingsDraftFromSettings(settings);
+    const patch = editorSettingsPatchFromDraft(draft, base);
+    expect(patch.continueOnErrorOnBatch).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/lib/settings/editorSettingsDraft.ts
+++ b/apps/desktop/src/lib/settings/editorSettingsDraft.ts
@@ -51,6 +51,7 @@ export const EDITOR_SETTINGS_DRAFT_KEYS = [
   "toolbarItems",
   "snippets",
   "sqlVariableSyntaxOverrides",
+  "continueOnErrorOnBatch",
 ] as const satisfies readonly (keyof EditorSettings)[];
 
 export type EditorSettingsDraftKey = (typeof EDITOR_SETTINGS_DRAFT_KEYS)[number];

--- a/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
@@ -30,7 +30,7 @@ vi.mock("@/stores/connectionStore", () => ({
 
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { autoCalculateTotalRows: false, pageSize: 100 },
+    editorSettings: { autoCalculateTotalRows: false, pageSize: 100, continueOnErrorOnBatch: false },
   }),
 }));
 
@@ -137,5 +137,16 @@ describe("queryStore multi-statement errors", () => {
     const tab = store.tabs.find((item) => item.id === tabId)!;
     expect(tab.activeResultIndex).toBe(0);
     expect(tab.result?.columns).toEqual(["value"]);
+  });
+
+  it("passes continueOnError=false from settings to executeMulti by default", async () => {
+    mocks.executeMulti.mockResolvedValue([{ columns: ["value"], rows: [[1]], affected_rows: 0, execution_time_ms: 1 }]);
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "SELECT 1");
+
+    expect(mocks.executeMulti).toHaveBeenCalledWith("mysql-1", "app", "SELECT 1", undefined, expect.any(String), expect.objectContaining({ continueOnError: false }));
   });
 });

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -112,3 +112,18 @@ describe("normalizeDesktopSettings", () => {
     expect(normalizeDesktopSettings({ duckdb_worker_max_processes: 3.6 }).duckdb_worker_max_processes).toBe(4);
   });
 });
+
+describe("normalizeEditorSettings - continueOnErrorOnBatch", () => {
+  it("defaults continueOnErrorOnBatch to false", () => {
+    expect(normalizeEditorSettings({}).continueOnErrorOnBatch).toBe(false);
+  });
+
+  it("preserves enabled continueOnErrorOnBatch", () => {
+    expect(normalizeEditorSettings({ continueOnErrorOnBatch: true }).continueOnErrorOnBatch).toBe(true);
+  });
+
+  it("treats non-boolean values as false", () => {
+    expect(normalizeEditorSettings({ continueOnErrorOnBatch: "yes" } as any).continueOnErrorOnBatch).toBe(false);
+    expect(normalizeEditorSettings({ continueOnErrorOnBatch: 1 } as any).continueOnErrorOnBatch).toBe(false);
+  });
+});

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3000,6 +3000,7 @@ export const useQueryStore = defineStore("query", () => {
             : {}),
           ...(clientSessionId ? { clientSessionId } : {}),
           timeoutSecs: queryTimeoutSecs,
+          continueOnError: settingsStore.editorSettings.continueOnErrorOnBatch,
         };
         console.info("[DBX][executeTabSql:execute-multi:invoke]", {
           traceId,

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -432,6 +432,7 @@ export interface EditorSettings {
   objectBrowserShowCheckbox: boolean;
   objectBrowserViewMode: "list" | "grid";
   sqlVariableSyntaxOverrides: SqlVariableSyntaxOverrides;
+  continueOnErrorOnBatch: boolean;
 }
 
 export interface ToolbarItems {
@@ -569,6 +570,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   objectBrowserShowCheckbox: false,
   objectBrowserViewMode: "list",
   sqlVariableSyntaxOverrides: {},
+  continueOnErrorOnBatch: false,
 };
 
 export const STORAGE_KEY = "dbx-editor-settings";
@@ -806,6 +808,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
     objectBrowserShowCheckbox: typeof settings.objectBrowserShowCheckbox === "boolean" ? settings.objectBrowserShowCheckbox : DEFAULT_EDITOR_SETTINGS.objectBrowserShowCheckbox,
     objectBrowserViewMode: settings.objectBrowserViewMode === "grid" ? "grid" : DEFAULT_EDITOR_SETTINGS.objectBrowserViewMode,
     sqlVariableSyntaxOverrides: normalizeSqlVariableSyntaxOverrides(settings.sqlVariableSyntaxOverrides),
+    continueOnErrorOnBatch: settings.continueOnErrorOnBatch === true,
   };
 }
 
@@ -1055,6 +1058,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.objectBrowserShowCheckbox !== undefined) editorSettings.value.objectBrowserShowCheckbox = partial.objectBrowserShowCheckbox === true;
     if (partial.objectBrowserViewMode !== undefined) editorSettings.value.objectBrowserViewMode = partial.objectBrowserViewMode === "grid" ? "grid" : "list";
     if (partial.sqlVariableSyntaxOverrides !== undefined) editorSettings.value.sqlVariableSyntaxOverrides = normalizeSqlVariableSyntaxOverrides(partial.sqlVariableSyntaxOverrides);
+    if (partial.continueOnErrorOnBatch !== undefined) editorSettings.value.continueOnErrorOnBatch = partial.continueOnErrorOnBatch === true;
     saveEditorSettings(editorSettings.value);
   }
 

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -1991,9 +1991,9 @@ where
             Err(err) => {
                 let action = pool_error_action(db_type, &err);
                 results.push(ExecuteMultiResult::execution_error(error_query_result(err)));
-                // When continue_on_error is enabled, keep executing remaining statements
-                // after a failure. Otherwise (the default), stop immediately.
-                if !continue_on_error {
+                // Statement errors are safe to collect, but connection-level failures leave
+                // the protocol state unusable and must still trigger pool cleanup.
+                if !continue_on_error || action != PoolErrorAction::Keep {
                     return (results, Some(action));
                 }
             }
@@ -3262,6 +3262,48 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results[1].execution_error);
         assert_eq!(error_action, Some(PoolErrorAction::Keep));
+    }
+
+    #[tokio::test]
+    async fn mysql_batch_continues_after_statement_errors_when_enabled() {
+        let statements = vec!["first".to_string(), "fails".to_string(), "third".to_string()];
+        let mut executor = FakeMysqlBatchExecutor {
+            outcomes: std::collections::VecDeque::from([
+                Ok(empty_query_result(0)),
+                Err("Duplicate entry".to_string()),
+                Ok(empty_query_result(0)),
+            ]),
+            executed: Vec::new(),
+        };
+
+        let (results, error_action) =
+            execute_mysql_batch_statements(&mut executor, &statements, Some(DatabaseType::Mysql), None, true).await;
+
+        assert_eq!(executor.executed, statements);
+        assert_eq!(results.len(), 3);
+        assert!(results[1].execution_error);
+        assert_eq!(error_action, None);
+    }
+
+    #[tokio::test]
+    async fn mysql_batch_stops_on_connection_errors_when_continue_is_enabled() {
+        let statements = vec!["first".to_string(), "disconnects".to_string(), "must-not-run".to_string()];
+        let mut executor = FakeMysqlBatchExecutor {
+            outcomes: std::collections::VecDeque::from([
+                Ok(empty_query_result(0)),
+                Err("connection reset by peer".to_string()),
+                Ok(empty_query_result(0)),
+            ]),
+            executed: Vec::new(),
+        };
+
+        let (results, error_action) =
+            execute_mysql_batch_statements(&mut executor, &statements, Some(DatabaseType::Mysql), None, true).await;
+
+        assert_eq!(executor.executed, vec!["first", "disconnects"]);
+        assert_eq!(results.len(), 2);
+        assert!(results[1].execution_error);
+        assert_eq!(error_action, Some(PoolErrorAction::ReconnectAndRetry));
     }
 
     #[test]

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -305,6 +305,10 @@ pub struct QueryExecutionOptions {
     /// (BEGIN … COMMIT) instead of auto-commit mode. `None` and `Some(false)` behave
     /// identically — auto-commit for each statement.
     pub use_transaction: Option<bool>,
+    /// When `true`, multi-statement execution continues after an error instead of
+    /// stopping at the first failure. Currently affects MySQL-protocol batch execution;
+    /// other databases already continue on error.
+    pub continue_on_error: bool,
 }
 
 fn query_result_row_limit(max_rows: Option<usize>) -> usize {
@@ -1970,6 +1974,7 @@ async fn execute_mysql_batch_statements<E>(
     statements: &[String],
     db_type: Option<DatabaseType>,
     cancel_token: Option<CancellationToken>,
+    continue_on_error: bool,
 ) -> (Vec<ExecuteMultiResult>, Option<PoolErrorAction>)
 where
     E: MysqlBatchStatementExecutor,
@@ -1986,8 +1991,11 @@ where
             Err(err) => {
                 let action = pool_error_action(db_type, &err);
                 results.push(ExecuteMultiResult::execution_error(error_query_result(err)));
-                // Do not run dependent statements after any MySQL-protocol statement fails.
-                return (results, Some(action));
+                // When continue_on_error is enabled, keep executing remaining statements
+                // after a failure. Otherwise (the default), stop immediately.
+                if !continue_on_error {
+                    return (results, Some(action));
+                }
             }
         }
     }
@@ -2039,7 +2047,8 @@ async fn execute_multi_mysql(
         dialect,
     };
     let (results, error_action) =
-        execute_mysql_batch_statements(&mut executor, statements, db_type, cancel_token).await;
+        execute_mysql_batch_statements(&mut executor, statements, db_type, cancel_token, options.continue_on_error)
+            .await;
     drop(executor);
 
     if matches!(error_action, Some(PoolErrorAction::Discard | PoolErrorAction::ReconnectAndRetry)) {
@@ -3247,7 +3256,7 @@ mod tests {
         };
 
         let (results, error_action) =
-            execute_mysql_batch_statements(&mut executor, &statements, Some(DatabaseType::Mysql), None).await;
+            execute_mysql_batch_statements(&mut executor, &statements, Some(DatabaseType::Mysql), None, false).await;
 
         assert_eq!(executor.executed, vec!["first", "fails"]);
         assert_eq!(results.len(), 2);

--- a/crates/dbx-web/src/routes/query.rs
+++ b/crates/dbx-web/src/routes/query.rs
@@ -23,6 +23,7 @@ pub struct ExecuteQueryRequest {
     pub client_session_id: Option<String>,
     pub timeout_secs: Option<u64>,
     pub use_transaction: Option<bool>,
+    pub continue_on_error: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -372,7 +373,7 @@ pub async fn execute_multi(
             timeout_secs: req.timeout_secs,
             execution_id: Some(execution_id),
             use_transaction: req.use_transaction,
-            ..Default::default()
+            continue_on_error: req.continue_on_error.unwrap_or(false),
         },
     )
     .await

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -70,6 +70,7 @@ pub async fn execute_multi(
     client_session_id: Option<String>,
     timeout_secs: Option<u64>,
     use_transaction: Option<bool>,
+    continue_on_error: Option<bool>,
 ) -> Result<Vec<dbx_core::query::ExecuteMultiResult>, String> {
     let execution_id = execution_id.filter(|id| !id.trim().is_empty());
     let registered_query = execution_id.as_ref().map(|id| {
@@ -106,6 +107,7 @@ pub async fn execute_multi(
             timeout_secs,
             execution_id,
             use_transaction,
+            continue_on_error: continue_on_error.unwrap_or(false),
         },
     )
     .await;


### PR DESCRIPTION
## 概述

新增**"批量执行遇错继续"**设置项，允许用户在查询编辑器中执行多段 SQL 时，即使某段语句报错，也可以选择继续执行后续语句，而非立即中断。

## 背景

当前行为因数据库类型而异：
- **MySQL 协议数据库**（MySQL、MariaDB 等）：多段 SQL 执行时遇到错误会**立即中断**，不再执行后续语句
- **其他数据库**（PostgreSQL、SQLite 等）：遇到错误后**继续执行**后续语句

这种不一致体验对用户不够友好，且 MySQL 的中断行为在某些场景（如批量脚本调试）下不方便。

## 改动内容

### 后端（Rust）
- `QueryExecutionOptions` 新增 `continue_on_error: bool` 字段
- MySQL 协议批处理函数 `execute_mysql_batch_statements` 根据 `continue_on_error` 参数决定遇到错误后是否中断
- Tauri 命令 `execute_multi` 新增 `continue_on_error` 可选参数
- Web 路由 `ExecuteQueryRequest` 新增 `continue_on_error` 可选字段

### 前端（TypeScript / Vue）
- `settingsStore` 的 `EditorSettings` 新增 `continueOnErrorOnBatch` 布尔字段，**默认关闭**（保持原有中断行为）
- `queryStore` 在执行 SQL 时从设置中读取并传递 `continueOnError` 参数
- `EditorSettingsDialog` 新增开关 UI，位于"执行前确认危险 SQL"开关下方

<img width="1321" height="269" alt="16ccb6b615855298bae0f9246f74b424" src="https://github.com/user-attachments/assets/34865f5d-7f96-4284-b2ed-3b37cb8e6441" />


### 国际化
- 新增 7 种语言翻译：中文（简/繁）、英语、西班牙语、意大利语、日语、葡萄牙语（巴西）

### 测试
- `settingsStore.spec.ts`：3 个测试用例，覆盖默认值、归一化、非布尔值处理
- `editorSettingsDraft.spec.ts`：7 个测试用例，覆盖 draft keys 包含检测、值映射、变更检测、patch 生成
- `queryStore.multiStatementError.spec.ts`：1 个测试用例，验证 `continueOnError=false` 从设置正确传递到 `executeMulti`

## 修改文件清单

| 层级 | 文件 | 改动 |
|------|------|------|
| 后端 | `crates/dbx-core/src/query.rs` | `QueryExecutionOptions` 新增字段 + MySQL 批处理逻辑 |
| 后端 | `src-tauri/src/commands/query.rs` | Tauri 命令新增参数 |
| 后端 | `crates/dbx-web/src/routes/query.rs` | Web 路由新增字段 |
| 前端 | `apps/desktop/src/lib/backend/tauri.ts` | API 层新增参数 |
| 前端 | `apps/desktop/src/lib/backend/http.ts` | API 层新增参数 |
| 前端 | `apps/desktop/src/stores/settingsStore.ts` | 设置项定义 + 归一化 |
| 前端 | `apps/desktop/src/stores/queryStore.ts` | 传递参数 |
| 前端 | `apps/desktop/src/lib/settings/editorSettingsDraft.ts` | Draft keys 补充 |
| 前端 | `apps/desktop/src/components/editor/EditorSettingsDialog.vue` | UI 开关 |
| 前端 | `apps/desktop/src/i18n/locales/*.ts` (7 个) | 翻译文案 |
| 测试 | `apps/desktop/src/stores/__tests__/settingsStore.spec.ts` | 归一化测试 |
| 测试 | `apps/desktop/src/lib/settings/__tests__/editorSettingsDraft.spec.ts` | Draft 变更检测测试 |
| 测试 | `apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts` | 参数传递测试 |