### PR TITLE
feat(export): 导出完成后支持打开所在文件夹

### DIFF
--- a/apps/desktop/src/components/export/ExportProgressDialog.vue
+++ b/apps/desktop/src/components/export/ExportProgressDialog.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle2, XCircle, AlertCircle, X } from "@lucide/vue";
+import { Loader2, CheckCircle2, XCircle, AlertCircle, FolderOpen, X } from "@lucide/vue";
+import { useToast } from "@/composables/useToast";
+import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
+import * as api from "@/lib/backend/api";
 
 const { t } = useI18n();
+const { toast } = useToast();
 const open = defineModel<boolean>("open", { default: false });
+const isRevealing = ref(false);
 
 const props = defineProps<{
   title: string;
@@ -16,6 +21,7 @@ const props = defineProps<{
   totalRows: number | null;
   status: string;
   errorMessage: string | null;
+  filePath?: string | null;
   disableCancel?: boolean;
 }>();
 
@@ -26,6 +32,7 @@ const emit = defineEmits<{
 
 const isActive = computed(() => props.status === "Running" || props.status === "Writing");
 const isFinished = computed(() => props.status === "Done" || props.status === "Error" || props.status === "Cancelled");
+const canRevealFile = computed(() => props.status === "Done" && !!props.filePath && isTauriRuntime());
 const progressPercent = computed(() => {
   if (!props.totalRows || props.totalRows <= 0) return 0;
   return Math.min(100, Math.round((props.rowsExported / props.totalRows) * 100));
@@ -39,6 +46,19 @@ const rowsText = computed(() => {
   }
   return t("exportProgress.rowsExported", { count: props.rowsExported.toLocaleString() });
 });
+
+async function revealExportFile() {
+  if (!props.filePath || isRevealing.value) return;
+  isRevealing.value = true;
+  try {
+    await api.revealPathInFileManager(props.filePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    toast(t("exportProgress.openFolderFailed", { message }), 5000);
+  } finally {
+    isRevealing.value = false;
+  }
+}
 </script>
 
 <template>
@@ -108,6 +128,11 @@ const rowsText = computed(() => {
           </Button>
         </template>
         <template v-else-if="isFinished">
+          <Button v-if="canRevealFile" size="sm" :disabled="isRevealing" @click="revealExportFile">
+            <Loader2 v-if="isRevealing" class="mr-1 h-3.5 w-3.5 animate-spin" />
+            <FolderOpen v-else class="mr-1 h-3.5 w-3.5" />
+            {{ t("exportProgress.openFolder") }}
+          </Button>
           <Button variant="outline" size="sm" @click="emit('update:open', false)">
             {{ t("exportProgress.close") }}
           </Button>

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6524,6 +6524,7 @@ const exportProgressState = ref({
   totalRows: null as number | null,
   status: "",
   errorMessage: null as string | null,
+  filePath: null as string | null,
 });
 const exportCancelHandler = ref<(() => Promise<void>) | null>(null);
 

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -103,6 +103,7 @@ export interface UseDataGridExportOptions {
     totalRows: number | null;
     status: string;
     errorMessage: string | null;
+    filePath: string | null;
   }>;
   exportCancelHandler?: Ref<(() => Promise<void>) | null>;
 }
@@ -688,6 +689,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             totalRows: null,
             status: "Running",
             errorMessage: null,
+            filePath: null,
           };
           exportProgressDialog.value = true;
         }
@@ -733,6 +735,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
         if (needsFullExport && exportProgressState) {
           exportProgressState.value = {
             ...exportProgressState.value,
+            filePath: outputPath,
             status: "Done",
             rowsExported: result.rows.length,
             totalRows: result.rows.length,
@@ -920,6 +923,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             totalRows: null,
             status: "Running",
             errorMessage: null,
+            filePath: outputPath,
           };
           exportProgressDialog.value = true;
         }
@@ -1073,6 +1077,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
         totalRows: null,
         status: "Running",
         errorMessage: null,
+        filePath: outputPath,
       };
     }
     if (exportProgressDialog) exportProgressDialog.value = true;
@@ -1160,6 +1165,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
         totalRows: request.totalRows ?? null,
         status: "Running",
         errorMessage: null,
+        filePath: outputPath,
       };
     }
     if (exportProgressDialog) exportProgressDialog.value = true;

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1051,6 +1051,8 @@ export default {
     rowsExported: "{count} rows exported",
     rowsShort: "rows",
     cancel: "Cancel",
+    openFolder: "Open containing folder",
+    openFolderFailed: "Failed to open folder: {message}",
     close: "Close",
     tooltip: "Background Tasks",
     failedTooltip: "{count} background task failed | {count} background tasks failed",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -995,6 +995,8 @@ export default withEnglishFallback({
     rowsExported: "{count} filas exportadas",
     rowsShort: "filas",
     cancel: "Cancelar",
+    openFolder: "Abrir carpeta contenedora",
+    openFolderFailed: "No se pudo abrir la carpeta: {message}",
     close: "Cerrar",
     tooltip: "Progreso de exportación",
     popoverTitle: "Exportaciones",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -993,6 +993,8 @@ export default withEnglishFallback({
     rowsExported: "{count} righe esportate",
     rowsShort: "righe",
     cancel: "Annulla",
+    openFolder: "Apri cartella contenente",
+    openFolderFailed: "Impossibile aprire la cartella: {message}",
     close: "Chiudi",
     tooltip: "Stato Esportazione",
     failedTooltip: "{count} attività in background non riuscita | {count} attività in background non riuscite",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -994,6 +994,8 @@ export default withEnglishFallback({
     rowsExported: "{count}行をエクスポートしました",
     rowsShort: "行",
     cancel: "キャンセル",
+    openFolder: "保存先フォルダーを開く",
+    openFolderFailed: "フォルダーを開けませんでした：{message}",
     close: "閉じる",
     tooltip: "エクスポートの進行状況",
     popoverTitle: "エクスポート",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -995,6 +995,8 @@ export default withEnglishFallback({
     rowsExported: "{count} linhas exportadas",
     rowsShort: "linhas",
     cancel: "Cancelar",
+    openFolder: "Abrir pasta do arquivo",
+    openFolderFailed: "Falha ao abrir a pasta: {message}",
     close: "Fechar",
     tooltip: "Progresso da Exportação",
     failedTooltip: "{count} tarefa em segundo plano falhou | {count} tarefas em segundo plano falharam",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1052,6 +1052,8 @@ export default withEnglishFallback({
     rowsExported: "已导出 {count} 行",
     rowsShort: "行",
     cancel: "取消",
+    openFolder: "打开所在文件夹",
+    openFolderFailed: "打开文件夹失败：{message}",
     close: "关闭",
     tooltip: "后台任务",
     failedTooltip: "{count} 个后台任务失败",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -994,6 +994,8 @@ export default withEnglishFallback({
     rowsExported: "已匯出 {count} 列",
     rowsShort: "列",
     cancel: "取消",
+    openFolder: "開啟所在資料夾",
+    openFolderFailed: "開啟資料夾失敗：{message}",
     close: "關閉",
     tooltip: "背景工作",
     failedTooltip: "{count} 個背景工作失敗 | {count} 個背景工作失敗",

--- a/packages/app-tests/useDataGridExport.test.ts
+++ b/packages/app-tests/useDataGridExport.test.ts
@@ -65,6 +65,7 @@ function buildExportHarness(
     totalRows: null as number | null,
     status: "",
     errorMessage: null as string | null,
+    filePath: null as string | null,
   });
   const exportCancelHandler = ref<(() => Promise<void>) | null>(null);
   const fullExportResult = vi.fn(async () => {
@@ -150,6 +151,7 @@ function buildTableDataExportHarness() {
     totalRows: null as number | null,
     status: "",
     errorMessage: null as string | null,
+    filePath: null as string | null,
   });
   const exportCancelHandler = ref<(() => Promise<void>) | null>(null);
 
@@ -626,6 +628,7 @@ test("full query result CSV export streams through the backend without loading a
   assert.equal(apiMock.exportQueryResultCsv.mock.calls.length, 0);
   assert.equal(exportProgressDialog.value, true);
   assert.equal(exportProgressState.value.status, "Done");
+  assert.equal(exportProgressState.value.filePath, apiMock.startQueryResultExport.mock.calls[0][0].filePath);
 });
 
 test("full query result CSV export defaults to the saved SQL title", async () => {
@@ -662,11 +665,12 @@ test("table data export keeps the table name as the default file base", async ()
   const restoreStorage = installMemoryStorage();
   try {
     vi.setSystemTime(new Date(2026, 5, 2, 15, 4, 5));
-    const { composable } = buildTableDataExportHarness();
+    const { composable, exportProgressState } = buildTableDataExportHarness();
 
     await composable.exportCsv();
 
     assert.equal(apiMock.startTableExport.mock.calls[0][0].filePath, "users_260602150405.csv");
+    assert.equal(exportProgressState.value.filePath, "users_260602150405.csv");
   } finally {
     vi.useRealTimers();
     restoreStorage();


### PR DESCRIPTION
## 背景

数据导出完成后，进度弹窗目前只有“关闭”按钮。用户需要自行找到刚才选择的保存路径，操作不够直接。

## 改动

- 在导出进度状态中记录最终输出文件路径
- 导出成功后，在弹窗页脚增加“打开所在文件夹”按钮
- 点击按钮后调用现有系统文件管理器能力：macOS 使用 Finder、Windows 使用 Explorer、Linux 使用 `xdg-open`
- 仅在桌面运行时、导出成功且路径有效时显示按钮；浏览器版受沙箱限制不展示该入口
- 打开失败时显示本地化错误提示
- 补全英文、简繁中文、日语、西班牙语、意大利语和葡萄牙语文案
- 覆盖查询结果流式导出、完整 CSV/XLSX 导出和表数据后台导出

## 验证

- `pnpm check`
- `pnpm exec vitest run packages/app-tests/useDataGridExport.test.ts`：25/25 通过
- `cargo test -p dbx --no-default-features commands::fs_open::tests`：8/8 通过

## 界面示意

![导出完成后打开所在文件夹](https://github.com/user-attachments/assets/2b45141e-5e37-4b3d-86cb-862090c91276)