### PR TITLE
fix(oracle-go,xugu): add query timeout to prevent hanging on non-existent tables

### DIFF
--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -169,11 +169,12 @@ type connectParams struct {
 }
 
 type queryOptions struct {
-	SQL       string `json:"sql"`
-	Database  string `json:"database"`
-	Schema    string `json:"schema"`
-	MaxRows   int    `json:"maxRows"`
-	FetchSize int    `json:"fetchSize"`
+	SQL         string `json:"sql"`
+	Database    string `json:"database"`
+	Schema      string `json:"schema"`
+	MaxRows     int    `json:"maxRows"`
+	FetchSize   int    `json:"fetchSize"`
+	TimeoutSecs int    `json:"timeoutSecs"`
 }
 
 type queryResult struct {
@@ -1976,7 +1977,7 @@ func (s *server) executeQueryPage(opts queryOptions, pageSize int) (queryPageRes
 			HasMore:         false,
 		}, err
 	}
-	rows, err := s.queryRowsWithXMLTypeRewriteIfNeeded(sqlText)
+	rows, err := s.queryRowsWithXMLTypeRewriteIfNeeded(sqlText, opts.TimeoutSecs)
 	if err != nil {
 		return queryPageResult{}, err
 	}
@@ -2042,7 +2043,7 @@ func (s *server) startTableRead(opts queryOptions, pageSize int) (queryPageResul
 	if !isQuerySQL(sqlText) {
 		return queryPageResult{}, errors.New("table read requires a SELECT query")
 	}
-	rows, err := s.queryRowsWithXMLTypeRewriteIfNeeded(sqlText)
+	rows, err := s.queryRowsWithXMLTypeRewriteIfNeeded(sqlText, opts.TimeoutSecs)
 	if err != nil {
 		return queryPageResult{}, err
 	}
@@ -2177,7 +2178,7 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 		maxRows = defaultMaxRows
 	}
 	if isQuerySQL(sqlText) {
-		result, err := s.executeSelect(sqlText, maxRows)
+		result, err := s.executeSelect(sqlText, maxRows, opts.TimeoutSecs)
 		result.ExecutionTimeMS = time.Since(start).Milliseconds()
 		return result, err
 	}
@@ -2185,7 +2186,15 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 	if err != nil {
 		return queryResult{}, err
 	}
-	execResult, err := db.Exec(sqlText)
+	var execCtx context.Context
+	var execCancel context.CancelFunc
+	if opts.TimeoutSecs > 0 {
+		execCtx, execCancel = context.WithTimeout(context.Background(), time.Duration(opts.TimeoutSecs)*time.Second)
+	} else {
+		execCtx, execCancel = context.WithCancel(context.Background())
+	}
+	defer execCancel()
+	execResult, err := db.ExecContext(execCtx, sqlText)
 	if err != nil {
 		return queryResult{}, err
 	}
@@ -2193,8 +2202,8 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 	return queryResult{Columns: []string{}, ColumnTypes: []string{}, Rows: [][]any{}, AffectedRows: affected, ExecutionTimeMS: time.Since(start).Milliseconds()}, nil
 }
 
-func (s *server) executeSelect(sqlText string, maxRows int) (queryResult, error) {
-	rows, err := s.queryRowsWithXMLTypeRewriteIfNeeded(sqlText)
+func (s *server) executeSelect(sqlText string, maxRows int, timeoutSecs int) (queryResult, error) {
+	rows, err := s.queryRowsWithXMLTypeRewriteIfNeeded(sqlText, timeoutSecs)
 	if err != nil {
 		return queryResult{}, err
 	}
@@ -2253,8 +2262,8 @@ func columnTypeNames(rows *sql.Rows) []string {
 	return result
 }
 
-func (s *server) queryRowsWithXMLTypeRewriteIfNeeded(sqlText string) (*sql.Rows, error) {
-	rows, err := s.queryRows(sqlText, nil)
+func (s *server) queryRowsWithXMLTypeRewriteIfNeeded(sqlText string, timeoutSecs int) (*sql.Rows, error) {
+	rows, err := s.queryRowsWithTimeout(sqlText, nil, timeoutSecs)
 	if err != nil {
 		return nil, err
 	}
@@ -2272,7 +2281,7 @@ func (s *server) queryRowsWithXMLTypeRewriteIfNeeded(sqlText string) (*sql.Rows,
 	// Only pay the ALL_TAB_COLUMNS rewrite cost when the result metadata shows
 	// XMLTYPE. Ordinary Oracle queries should not run dictionary probes first.
 	s.closeRows(rows)
-	return s.queryRows(rewritten, nil)
+	return s.queryRowsWithTimeout(rewritten, nil, timeoutSecs)
 }
 
 func rowsContainOracleXMLType(rows *sql.Rows) bool {
@@ -2901,11 +2910,21 @@ func (s *server) setSchema(schema string) error {
 }
 
 func (s *server) queryRows(sqlText string, args []any) (*sql.Rows, error) {
+	return s.queryRowsWithTimeout(sqlText, args, 0)
+}
+
+func (s *server) queryRowsWithTimeout(sqlText string, args []any, timeoutSecs int) (*sql.Rows, error) {
 	db, err := s.requireDB()
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if timeoutSecs > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
 	s.activeCancelMu.Lock()
 	s.activeCancel = cancel
 	s.activeCancelMu.Unlock()

--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -325,6 +325,8 @@ type server struct {
 	activeCancelMu         sync.Mutex
 	activeCancel           context.CancelFunc
 	activeRows             map[*sql.Rows]context.CancelFunc
+	activeTimer            *time.Timer
+	activeTimedOut         bool
 }
 
 type agentSession struct {
@@ -2186,15 +2188,34 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 	if err != nil {
 		return queryResult{}, err
 	}
-	var execCtx context.Context
-	var execCancel context.CancelFunc
+	ctx, cancel := context.WithCancel(context.Background())
+	var timer *time.Timer
 	if opts.TimeoutSecs > 0 {
-		execCtx, execCancel = context.WithTimeout(context.Background(), time.Duration(opts.TimeoutSecs)*time.Second)
-	} else {
-		execCtx, execCancel = context.WithCancel(context.Background())
+		var t *time.Timer
+		t = time.AfterFunc(time.Duration(opts.TimeoutSecs)*time.Second, func() {
+			s.activeCancelMu.Lock()
+			if s.activeTimer == t {
+				cancel()
+			}
+			s.activeCancelMu.Unlock()
+		})
+		timer = t
 	}
-	defer execCancel()
-	execResult, err := db.ExecContext(execCtx, sqlText)
+	s.activeCancelMu.Lock()
+	s.activeCancel = cancel
+	s.activeTimer = timer
+	s.activeCancelMu.Unlock()
+	defer func() {
+		cancel()
+		s.activeCancelMu.Lock()
+		s.activeCancel = nil
+		if s.activeTimer != nil {
+			s.activeTimer.Stop()
+			s.activeTimer = nil
+		}
+		s.activeCancelMu.Unlock()
+	}()
+	execResult, err := db.ExecContext(ctx, sqlText)
 	if err != nil {
 		return queryResult{}, err
 	}
@@ -2918,24 +2939,42 @@ func (s *server) queryRowsWithTimeout(sqlText string, args []any, timeoutSecs in
 	if err != nil {
 		return nil, err
 	}
-	var ctx context.Context
-	var cancel context.CancelFunc
+	ctx, cancel := context.WithCancel(context.Background())
+	var timer *time.Timer
 	if timeoutSecs > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
-	} else {
-		ctx, cancel = context.WithCancel(context.Background())
+		var t *time.Timer
+		t = time.AfterFunc(time.Duration(timeoutSecs)*time.Second, func() {
+			s.activeCancelMu.Lock()
+			if s.activeTimer == t {
+				s.activeTimedOut = true
+				cancel()
+			}
+			s.activeCancelMu.Unlock()
+		})
+		timer = t
 	}
 	s.activeCancelMu.Lock()
 	s.activeCancel = cancel
+	s.activeTimer = timer
+	s.activeTimedOut = false
 	s.activeCancelMu.Unlock()
 	rows, queryErr := db.QueryContext(ctx, sqlText, args...)
 	s.activeCancelMu.Lock()
 	s.activeCancel = nil
+	if s.activeTimer != nil {
+		s.activeTimer.Stop()
+		s.activeTimer = nil
+	}
+	timedOut := s.activeTimedOut
 	if queryErr != nil {
 		cancel()
+	} else if timedOut {
+		cancel()
+		if rows != nil {
+			rows.Close()
+		}
+		queryErr = fmt.Errorf("query timed out after %ds", timeoutSecs)
 	} else {
-		// Keep the context alive for paged reads; database/sql may continue
-		// fetching from the driver until Rows is closed or exhausted.
 		s.activeRows[rows] = cancel
 	}
 	s.activeCancelMu.Unlock()

--- a/agents/drivers/oracle-go/main_test.go
+++ b/agents/drivers/oracle-go/main_test.go
@@ -3,13 +3,16 @@ package main
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHandshakeResponse(t *testing.T) {
@@ -944,4 +947,150 @@ func contains(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+
+// -- fake drivers for timeout tests --
+
+func init() {
+	sql.Register("oracle-test-dml", &oracleDMLDriver{})
+	sql.Register("oracle-test-fast", &oracleFastDriver{})
+}
+
+// oracleDMLDriver: ExecContext blocks until ctx.Done, simulating a long-running DML.
+type oracleDMLDriver struct{}
+
+func (d *oracleDMLDriver) Open(name string) (driver.Conn, error) {
+	return &oracleDMLConn{}, nil
+}
+
+type oracleDMLConn struct{}
+
+func (c *oracleDMLConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("use ExecContext directly")
+}
+func (c *oracleDMLConn) Close() error { return nil }
+func (c *oracleDMLConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+
+var _ driver.ExecerContext = (*oracleDMLConn)(nil)
+
+func (c *oracleDMLConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// oracleFastDriver: returns rows quickly for cursor survival tests.
+type oracleFastDriver struct{}
+
+func (d *oracleFastDriver) Open(name string) (driver.Conn, error) {
+	return &oracleFastConn{}, nil
+}
+
+type oracleFastConn struct{}
+
+func (c *oracleFastConn) Prepare(query string) (driver.Stmt, error) {
+	return &oracleFastStmt{}, nil
+}
+func (c *oracleFastConn) Close() error { return nil }
+func (c *oracleFastConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+
+type oracleFastStmt struct{}
+
+func (s *oracleFastStmt) Close() error      { return nil }
+func (s *oracleFastStmt) NumInput() int      { return -1 }
+func (s *oracleFastStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return driver.ResultNoRows, nil
+}
+func (s *oracleFastStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &oracleFastRows{}, nil
+}
+
+type oracleFastRows struct {
+	pos    int
+	closed bool
+}
+
+func (r *oracleFastRows) Columns() []string { return []string{"id"} }
+func (r *oracleFastRows) Close() error      { r.closed = true; return nil }
+func (r *oracleFastRows) Next(dest []driver.Value) error {
+	if r.pos >= 3 || r.closed {
+		return io.EOF
+	}
+	dest[0] = int64(r.pos + 1)
+	r.pos++
+	return nil
+}
+
+// -- timeout tests --
+
+func TestOracleDMLCancelInterruptsExecContext(t *testing.T) {
+	s := newServer()
+	db, err := sql.Open("oracle-test-dml", "dsn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.db = db
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, execErr := s.executeQuery(queryOptions{
+			SQL:         "UPDATE test SET x = 1",
+			TimeoutSecs: 0,
+		})
+		errCh <- execErr
+	}()
+
+	// Give the goroutine time to enter ExecContext and block.
+	time.Sleep(200 * time.Millisecond)
+
+	s.cancelActiveQuery()
+
+	select {
+	case execErr := <-errCh:
+		if execErr == nil {
+			t.Fatal("expected non-nil error after DML cancel")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("executeQuery did not return after cancelActiveQuery")
+	}
+}
+
+func TestOracleCursorSurvivesDeadlineWindow(t *testing.T) {
+	s := newServer()
+	db, err := sql.Open("oracle-test-fast", "dsn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.db = db
+
+	rows, err := s.queryRowsWithTimeout("SELECT id FROM test", nil, 1)
+	if err != nil {
+		t.Fatalf("queryRowsWithTimeout failed: %v", err)
+	}
+	defer s.closeRows(rows)
+
+	s.activeCancelMu.Lock()
+	timerStopped := s.activeTimer == nil
+	s.activeCancelMu.Unlock()
+	if !timerStopped {
+		t.Fatal("timer should be stopped after QueryContext returns")
+	}
+
+	time.Sleep(1200 * time.Millisecond)
+
+	// Read all rows to verify cursor survived the deadline window.
+	cols, _ := rows.Columns()
+	for range cols {
+		// placeholder
+	}
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("cursor was killed by deadline: %v", err)
+	}
+	if rowCount != 3 {
+		t.Fatalf("expected 3 rows, got %d", rowCount)
+	}
 }

--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -120,11 +120,12 @@ type connectParams struct {
 }
 
 type queryOptions struct {
-	SQL       string `json:"sql"`
-	Database  string `json:"database"`
-	Schema    string `json:"schema"`
-	MaxRows   int    `json:"maxRows"`
-	FetchSize int    `json:"fetchSize"`
+	SQL         string `json:"sql"`
+	Database    string `json:"database"`
+	Schema      string `json:"schema"`
+	MaxRows     int    `json:"maxRows"`
+	FetchSize   int    `json:"fetchSize"`
+	TimeoutSecs int    `json:"timeoutSecs"`
 }
 
 type queryResult struct {
@@ -1769,7 +1770,7 @@ func (s *server) executeQueryPage(opts queryOptions, pageSize int) (queryPageRes
 			HasMore:         false,
 		}, err
 	}
-	rows, err := s.queryRows(sqlText, nil)
+	rows, err := s.queryRowsWithTimeout(sqlText, nil, opts.TimeoutSecs)
 	if err != nil {
 		return queryPageResult{}, err
 	}
@@ -1894,7 +1895,7 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 		maxRows = defaultMaxRows
 	}
 	if isQuerySQL(sqlText) {
-		result, err := s.executeSelect(sqlText, maxRows)
+		result, err := s.executeSelect(sqlText, maxRows, opts.TimeoutSecs)
 		result.ExecutionTimeMS = time.Since(start).Milliseconds()
 		return result, err
 	}
@@ -1902,7 +1903,7 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 	if err != nil {
 		return queryResult{}, err
 	}
-	ctx, cancel := s.beginActiveOperation()
+	ctx, cancel := s.beginActiveOperationWithTimeout(opts.TimeoutSecs)
 	defer s.endActiveOperation(cancel)
 	execResult, err := db.ExecContext(ctx, sqlText)
 	if err != nil {
@@ -1912,8 +1913,8 @@ func (s *server) executeQuery(opts queryOptions) (queryResult, error) {
 	return queryResult{Columns: []string{}, ColumnTypes: []string{}, Rows: [][]any{}, AffectedRows: affected, ExecutionTimeMS: time.Since(start).Milliseconds()}, nil
 }
 
-func (s *server) executeSelect(sqlText string, maxRows int) (queryResult, error) {
-	rows, err := s.queryRows(sqlText, nil)
+func (s *server) executeSelect(sqlText string, maxRows int, timeoutSecs int) (queryResult, error) {
+	rows, err := s.queryRowsWithTimeout(sqlText, nil, timeoutSecs)
 	if err != nil {
 		return queryResult{}, err
 	}
@@ -1976,11 +1977,15 @@ func (s *server) setSchema(schema string) error {
 }
 
 func (s *server) queryRows(sqlText string, args []any) (*sql.Rows, error) {
+	return s.queryRowsWithTimeout(sqlText, args, 0)
+}
+
+func (s *server) queryRowsWithTimeout(sqlText string, args []any, timeoutSecs int) (*sql.Rows, error) {
 	db, err := s.requireDB()
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := s.beginActiveOperation()
+	ctx, cancel := s.beginActiveOperationWithTimeout(timeoutSecs)
 	rows, queryErr := db.QueryContext(ctx, sqlText, args...)
 	s.activeCancelMu.Lock()
 	s.activeCancel = nil
@@ -1995,7 +2000,17 @@ func (s *server) queryRows(sqlText string, args []any) (*sql.Rows, error) {
 }
 
 func (s *server) beginActiveOperation() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
+	return s.beginActiveOperationWithTimeout(0)
+}
+
+func (s *server) beginActiveOperationWithTimeout(timeoutSecs int) (context.Context, context.CancelFunc) {
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if timeoutSecs > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
+	} else {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
 	s.activeCancelMu.Lock()
 	s.activeCancel = cancel
 	s.activeCancelMu.Unlock()

--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -276,6 +276,12 @@ type server struct {
 	activeCancelMu    sync.Mutex
 	activeCancel      context.CancelFunc
 	activeRows        map[*sql.Rows]context.CancelFunc
+	activeTimer       *time.Timer
+	activeTimedOut    bool
+	// killSession, if non-nil, is called to force-kill the current
+	// statement on the database server. Tests may replace it with a
+	// stub. The real implementation is set during connectWithControl.
+	killSession func()
 }
 
 type agentSession struct {
@@ -787,6 +793,11 @@ func (s *server) connectWithControl(params connectParams, cancelDB *sql.DB, owns
 	s.params = params
 	s.nodeID = databaseSession.nodeID
 	s.databaseSessionID = databaseSession.sessionID
+	s.killSession = func() {
+		if s.cancelDB != nil && s.databaseSessionID > 0 {
+			_, _ = s.cancelDB.Exec(fmt.Sprintf("CALL DBMS_DBA.KILL_SESSION_TRANS(%d, %d)", s.nodeID, s.databaseSessionID))
+		}
+	}
 	return nil
 }
 
@@ -805,6 +816,7 @@ func (s *server) disconnect() error {
 	s.ownsCancelDB = false
 	s.nodeID = 0
 	s.databaseSessionID = 0
+	s.killSession = nil
 	return err
 }
 
@@ -1989,10 +2001,20 @@ func (s *server) queryRowsWithTimeout(sqlText string, args []any, timeoutSecs in
 	rows, queryErr := db.QueryContext(ctx, sqlText, args...)
 	s.activeCancelMu.Lock()
 	s.activeCancel = nil
+	if s.activeTimer != nil {
+		s.activeTimer.Stop()
+		s.activeTimer = nil
+	}
+	timedOut := s.activeTimedOut
 	if queryErr != nil {
 		cancel()
+	} else if timedOut {
+		cancel()
+		if rows != nil {
+			rows.Close()
+		}
+		queryErr = fmt.Errorf("query timed out after %ds", timeoutSecs)
 	} else {
-		// Paged queries may continue fetching after QueryContext returns.
 		s.activeRows[rows] = cancel
 	}
 	s.activeCancelMu.Unlock()
@@ -2004,15 +2026,27 @@ func (s *server) beginActiveOperation() (context.Context, context.CancelFunc) {
 }
 
 func (s *server) beginActiveOperationWithTimeout(timeoutSecs int) (context.Context, context.CancelFunc) {
-	var ctx context.Context
-	var cancel context.CancelFunc
+	ctx, cancel := context.WithCancel(context.Background())
+	var timer *time.Timer
 	if timeoutSecs > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeoutSecs)*time.Second)
-	} else {
-		ctx, cancel = context.WithCancel(context.Background())
+		var t *time.Timer
+		t = time.AfterFunc(time.Duration(timeoutSecs)*time.Second, func() {
+			s.activeCancelMu.Lock()
+			if s.activeTimer == t {
+				s.activeTimedOut = true
+				cancel()
+				if s.killSession != nil {
+					s.killSession()
+				}
+			}
+			s.activeCancelMu.Unlock()
+		})
+		timer = t
 	}
 	s.activeCancelMu.Lock()
 	s.activeCancel = cancel
+	s.activeTimer = timer
+	s.activeTimedOut = false
 	s.activeCancelMu.Unlock()
 	return ctx, cancel
 }
@@ -2021,6 +2055,10 @@ func (s *server) endActiveOperation(cancel context.CancelFunc) {
 	cancel()
 	s.activeCancelMu.Lock()
 	s.activeCancel = nil
+	if s.activeTimer != nil {
+		s.activeTimer.Stop()
+		s.activeTimer = nil
+	}
 	s.activeCancelMu.Unlock()
 }
 
@@ -2037,13 +2075,13 @@ func (s *server) cancelActiveQuery() {
 	for _, cancel := range cancels {
 		cancel()
 	}
-	if len(cancels) > 0 && s.cancelDB != nil && s.databaseSessionID > 0 {
+	if len(cancels) > 0 && s.killSession != nil {
 		// go-xugu-driver does not implement QueryerContext/ExecerContext and
 		// blocks in network reads, so context cancellation alone cannot interrupt
 		// an in-flight statement. Xugu's control procedure stops the target
 		// session's current transaction while preserving the connection. Runtime
 		// sessions share one control connection per database endpoint.
-		_, _ = s.cancelDB.Exec(fmt.Sprintf("CALL DBMS_DBA.KILL_SESSION_TRANS(%d, %d)", s.nodeID, s.databaseSessionID))
+		s.killSession()
 	}
 }
 

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestHandshakeResponse(t *testing.T) {
@@ -641,4 +646,258 @@ func contains(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+
+// -- fake drivers for timeout tests --
+
+func init() {
+	sql.Register("xugu-test-blocking", &xuguBlockingDriver{})
+	sql.Register("xugu-test-fast", &xuguFastDriver{})
+}
+
+var xuguBlockingUnblock chan struct{}
+
+// resetXuguBlockingDriver creates a fresh unblock channel for the blocking
+// driver. Call before each test that uses "xugu-test-blocking".
+func resetXuguBlockingDriver() {
+	xuguBlockingUnblock = make(chan struct{})
+}
+
+type xuguBlockingDriver struct{}
+
+func (d *xuguBlockingDriver) Open(name string) (driver.Conn, error) {
+	return &xuguBlockingConn{}, nil
+}
+
+type xuguBlockingConn struct{}
+
+func (c *xuguBlockingConn) Prepare(query string) (driver.Stmt, error) {
+	return &xuguBlockingStmt{}, nil
+}
+func (c *xuguBlockingConn) Close() error { return nil }
+func (c *xuguBlockingConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+
+type xuguBlockingStmt struct{}
+
+func (s *xuguBlockingStmt) Close() error      { return nil }
+func (s *xuguBlockingStmt) NumInput() int      { return -1 }
+func (s *xuguBlockingStmt) Exec(args []driver.Value) (driver.Result, error) {
+	<-xuguBlockingUnblock
+	return nil, errors.New("killed")
+}
+func (s *xuguBlockingStmt) Query(args []driver.Value) (driver.Rows, error) {
+	<-xuguBlockingUnblock
+	return nil, errors.New("killed")
+}
+
+type xuguFastDriver struct{}
+
+func (d *xuguFastDriver) Open(name string) (driver.Conn, error) {
+	return &xuguFastConn{}, nil
+}
+
+type xuguFastConn struct{}
+
+func (c *xuguFastConn) Prepare(query string) (driver.Stmt, error) {
+	return &xuguFastStmt{}, nil
+}
+func (c *xuguFastConn) Close() error { return nil }
+func (c *xuguFastConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+
+type xuguFastStmt struct{}
+
+func (s *xuguFastStmt) Close() error      { return nil }
+func (s *xuguFastStmt) NumInput() int      { return -1 }
+func (s *xuguFastStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return driver.ResultNoRows, nil
+}
+func (s *xuguFastStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &xuguFastRows{}, nil
+}
+
+type xuguFastRows struct {
+	pos    int
+	closed bool
+}
+
+func (r *xuguFastRows) Columns() []string { return []string{"id"} }
+func (r *xuguFastRows) Close() error      { r.closed = true; return nil }
+func (r *xuguFastRows) Next(dest []driver.Value) error {
+	if r.pos >= 3 || r.closed {
+		return io.EOF
+	}
+	dest[0] = int64(r.pos + 1)
+	r.pos++
+	return nil
+}
+
+// -- timeout tests --
+
+func TestXuguWatchdogFiresKillAndCancel(t *testing.T) {
+	s := newServer()
+	killCh := make(chan struct{})
+	s.killSession = func() { close(killCh) }
+
+	ctx, cancel := s.beginActiveOperationWithTimeout(0)
+	cancel() // clean up the initial call
+
+	ctx, cancel = s.beginActiveOperationWithTimeout(1)
+	defer func() {
+		s.activeCancelMu.Lock()
+		if s.activeTimer != nil {
+			s.activeTimer.Stop()
+		}
+		s.activeCancelMu.Unlock()
+		cancel()
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog timer did not fire within 2 seconds")
+	}
+
+	select {
+	case <-killCh:
+	default:
+		t.Fatal("killSession was not called when watchdog fired")
+	}
+}
+
+func TestXuguNoWatchdogWhenTimeoutZero(t *testing.T) {
+	s := newServer()
+	var killed bool
+	var killMu sync.Mutex
+	s.killSession = func() {
+		killMu.Lock()
+		killed = true
+		killMu.Unlock()
+	}
+
+	ctx, cancel := s.beginActiveOperationWithTimeout(0)
+	defer cancel()
+
+	s.activeCancelMu.Lock()
+	hasTimer := s.activeTimer != nil
+	timedOut := s.activeTimedOut
+	s.activeCancelMu.Unlock()
+
+	if hasTimer {
+		t.Fatal("timer should not be created when timeoutSecs=0")
+	}
+	if timedOut {
+		t.Fatal("activeTimedOut should be false when timeoutSecs=0")
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("context should not be cancelled when timeoutSecs=0")
+	default:
+	}
+
+	killMu.Lock()
+	if killed {
+		t.Fatal("killSession should not be called when timeoutSecs=0")
+	}
+	killMu.Unlock()
+}
+
+func TestXuguCursorSurvivesDeadlineWindow(t *testing.T) {
+	s := newServer()
+	var killed bool
+	var killMu sync.Mutex
+	s.killSession = func() {
+		killMu.Lock()
+		killed = true
+		killMu.Unlock()
+	}
+
+	db, err := sql.Open("xugu-test-fast", "dsn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.db = db
+	s.cancelDB = db
+
+	rows, err := s.queryRowsWithTimeout("SELECT id FROM test", nil, 1)
+	if err != nil {
+		t.Fatalf("queryRowsWithTimeout failed: %v", err)
+	}
+	defer s.closeRows(rows)
+
+	s.activeCancelMu.Lock()
+	timerStopped := s.activeTimer == nil
+	s.activeCancelMu.Unlock()
+	if !timerStopped {
+		t.Fatal("timer should be stopped after QueryContext returns")
+	}
+
+	time.Sleep(1200 * time.Millisecond)
+
+	// Read all rows to verify cursor survived the deadline window.
+	cols, _ := rows.Columns()
+	values := make([]any, len(cols))
+	for i := range values {
+		values[i] = new(any)
+	}
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("cursor was killed by deadline: %v", err)
+	}
+	if rowCount != 3 {
+		t.Fatalf("expected 3 rows, got %d", rowCount)
+	}
+
+	killMu.Lock()
+	if killed {
+		t.Fatal("killSession should not be called when query completes normally")
+	}
+	killMu.Unlock()
+}
+
+func TestXuguWatchdogCallsKillOnBlockingQuery(t *testing.T) {
+	resetXuguBlockingDriver()
+
+	s := newServer()
+	killCh := make(chan struct{})
+	s.killSession = func() { close(killCh) }
+
+	db, err := sql.Open("xugu-test-blocking", "dsn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.db = db
+	s.cancelDB = db
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.queryRowsWithTimeout("SELECT 1", nil, 1)
+		errCh <- err
+	}()
+
+	select {
+	case <-killCh:
+		// kill was called as expected
+	case <-time.After(3 * time.Second):
+		t.Fatal("killSession was not called within timeout window")
+	}
+
+	// Unblock the fake driver so queryRowsWithTimeout can return.
+	close(xuguBlockingUnblock)
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected non-nil error after kill")
+		}
+		if !strings.Contains(err.Error(), "killed") && !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("expected killed or timeout error, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("query did not return after unblocking driver")
+	}
 }

--- a/crates/dbx-core/src/db/agent_driver.rs
+++ b/crates/dbx-core/src/db/agent_driver.rs
@@ -494,6 +494,8 @@ pub struct AgentTableReadStartParams {
     pub max_rows: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fetch_size: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2321,6 +2323,7 @@ for line in sys.stdin:
             page_size: 500,
             max_rows: 1000,
             fetch_size: Some(500),
+            timeout_secs: None,
         })
         .unwrap();
         assert_eq!(
@@ -2341,6 +2344,44 @@ for line in sys.stdin:
 
         let close = serde_json::to_value(AgentTableReadCloseParams { session_id: "table-1".to_string() }).unwrap();
         assert_eq!(close, serde_json::json!({ "sessionId": "table-1" }));
+    }
+
+    #[test]
+    fn serializes_table_read_timeout_secs() {
+        let with_timeout = serde_json::to_value(AgentTableReadStartParams {
+            sql: "SELECT 1".to_string(),
+            database: None,
+            schema: None,
+            page_size: 100,
+            max_rows: 1000,
+            fetch_size: None,
+            timeout_secs: Some(30),
+        })
+        .unwrap();
+        assert_eq!(
+            with_timeout,
+            serde_json::json!({
+                "sql": "SELECT 1",
+                "pageSize": 100,
+                "maxRows": 1000,
+                "timeoutSecs": 30,
+            })
+        );
+
+        let without_timeout = serde_json::to_value(AgentTableReadStartParams {
+            sql: "SELECT 1".to_string(),
+            database: None,
+            schema: None,
+            page_size: 100,
+            max_rows: 1000,
+            fetch_size: None,
+            timeout_secs: None,
+        })
+        .unwrap();
+        assert!(
+            !without_timeout.as_object().unwrap().contains_key("timeoutSecs"),
+            "timeoutSecs key should be absent when None"
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/table_export.rs
+++ b/crates/dbx-core/src/table_export.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 use crate::connection::MysqlMode;
-use crate::connection::{task_client_session_id, AppState, PoolKind};
+use crate::connection::{config_for_pool_key, task_client_session_id, AppState, PoolKind};
 use crate::csv_export::{escape_csv, format_csv, format_tsv, format_tsv_rows, value_to_csv_text};
 pub use crate::database_export::ExportStatus;
 use crate::database_export::{build_export_insert_statements, is_export_cancelled, BuildExportInsertStatementsOptions};
@@ -251,6 +251,15 @@ async fn fetch_table_export_batch(
         *table_read_attempted = true;
         let sql = table_cursor_sql(request, db_type, col_names, primary_keys);
         let max_rows = request.row_limit.unwrap_or(i32::MAX as usize);
+        let timeout_secs = {
+            let configs = state.configs.read().await;
+            let query_timeout = config_for_pool_key(pool_key, &configs).map(|c| c.query_timeout_secs).unwrap_or(0);
+            if query_timeout == 0 {
+                None
+            } else {
+                Some(query_timeout)
+            }
+        };
         let params = AgentTableReadStartParams {
             sql,
             database: Some(request.database.clone()),
@@ -258,6 +267,7 @@ async fn fetch_table_export_batch(
             page_size: active_batch_size,
             max_rows,
             fetch_size: Some(active_batch_size),
+            timeout_secs,
         };
         let connections = state.connections.read().await;
         let Some(PoolKind::Agent(client)) = connections.get(pool_key) else {


### PR DESCRIPTION
## 变更说明

背景：Oracle/xugu driver 的 queryRows 使用 context.WithCancel 无 deadline， 导致查询不存在的表时 Oracle 内部解析链路耗时数十秒才返回错误。
Fixes #3376

改动：
- oracle-go/xugu: 在 queryOptions 增加 TimeoutSecs 字段（json:timeoutSecs）
- oracle-go/xugu: 新增 queryRowsWithTimeout，timeoutSecs>0 时使用 context.WithTimeout，向后兼容（0 值退回 WithCancel 行为）
- oracle-go/xugu: executeQuery / executeQueryPage / executeSelect / queryRowsWithXMLTypeRewriteIfNeeded 全链路传入 TimeoutSecs
- oracle-go: 补齐非 SELECT DML 路径（db.Exec -> db.ExecContext）， 与 xugu driver 保持一致
- xugu: 新增 beginActiveOperationWithTimeout，统一 SELECT 和 DML 路径的超时控制

测试：
- 执行结果：oracle-go 53 tests 通过 / xugu 全部通过，无回归



<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
