### PR TITLE
fix(kingbase): 兼容 kingbase8 连接 URL

### DIFF
--- a/apps/desktop/src/lib/connection/connectionPresentation.ts
+++ b/apps/desktop/src/lib/connection/connectionPresentation.ts
@@ -144,6 +144,9 @@ export function connectionUrlPlaceholder(dbType: DatabaseType): string {
     case "dameng":
       return "dm://user:password@host:port";
 
+    case "kingbase":
+      return "kingbase8://user:password@host:54321/database";
+
     case "tdengine":
       return "tdengine://user:password@host:6041/database";
 

--- a/apps/desktop/src/lib/connection/connectionUrl.ts
+++ b/apps/desktop/src/lib/connection/connectionUrl.ts
@@ -49,6 +49,8 @@ const SCHEME_PROFILES: Record<string, ConnectionProfile> = {
   chromadb: { type: "chromadb", profile: "chromadb", label: "ChromaDB", defaultPort: 8000 },
   dm: { type: "dameng", profile: "dm", label: "DM (Dameng)", defaultPort: 5236 },
   dameng: { type: "dameng", profile: "dm", label: "DM (Dameng)", defaultPort: 5236 },
+  kingbase: { type: "kingbase", profile: "kingbase", label: "KingBase", defaultPort: 54321 },
+  kingbase8: { type: "kingbase", profile: "kingbase", label: "KingBase", defaultPort: 54321 },
   gaussdb: { type: "gaussdb", profile: "gaussdb", label: "GaussDB", defaultPort: 5432 },
   kwdb: { type: "kwdb", profile: "kwdb", label: "KWDB", defaultPort: 26257 },
   gbase: { type: "gbase", profile: "gbase", label: "GBase", defaultPort: 5258 },
@@ -591,12 +593,18 @@ function applyParsedUsername(config: Omit<ConnectionConfig, "id">, parsed: Parse
   if (parsed.dbType === "h2" && config.db_type === "h2" && !h2JdbcUrlHasUserParam(parsed.connectionString)) {
     return config.username || parsed.username;
   }
+  if (parsed.dbType === "kingbase" && config.db_type === "kingbase" && !parsed.username) {
+    return config.username;
+  }
   return parsed.username;
 }
 
 function applyParsedPassword(config: Omit<ConnectionConfig, "id">, parsed: ParsedConnectionUrl): string {
   if (parsed.dbType === "h2" && config.db_type === "h2" && !h2JdbcUrlHasPasswordParam(parsed.connectionString)) {
     return config.password || parsed.password;
+  }
+  if (parsed.dbType === "kingbase" && config.db_type === "kingbase" && !parsed.password) {
+    return config.password;
   }
   return parsed.password;
 }

--- a/packages/app-tests/connectionUrl.test.ts
+++ b/packages/app-tests/connectionUrl.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import { applyParsedConnectionUrl, normalizeMongoConnectionString, parseConnectionUrl } from "../../apps/desktop/src/lib/connection/connectionUrl.ts";
+import { connectionUrlPlaceholder } from "../../apps/desktop/src/lib/connection/connectionPresentation.ts";
 import { h2FileJdbcUrlWithPath } from "../../apps/desktop/src/lib/database/h2Connection.ts";
 
 test("parses postgres connection URLs", () => {
@@ -31,6 +32,36 @@ test("parses KWDB connection URLs", () => {
     urlParams: "sslmode=require",
     ssl: true,
   });
+});
+
+test.each(["kingbase", "kingbase8", "jdbc:kingbase8"])("parses %s connection URLs as native KingBase connections", (scheme) => {
+  assert.deepEqual(parseConnectionUrl(`${scheme}://framework:secret@172.21.203.70:443/hq_official?sslmode=disable`), {
+    dbType: "kingbase",
+    driverProfile: "kingbase",
+    driverLabel: "KingBase",
+    host: "172.21.203.70",
+    port: 443,
+    username: "framework",
+    password: "secret",
+    database: "hq_official",
+    urlParams: "sslmode=disable",
+    ssl: false,
+  });
+});
+
+test("shows the vendor KingBase URL scheme in the connection form", () => {
+  assert.equal(connectionUrlPlaceholder("kingbase"), "kingbase8://user:password@host:54321/database");
+});
+
+test("applies a credential-free KingBase URL without clearing typed credentials", () => {
+  const parsed = parseConnectionUrl("kingbase8://172.21.203.70:443/hq_official");
+  const applied = applyParsedConnectionUrl({ name: "hq", db_type: "kingbase", username: "framework", password: "typed-secret" } as any, parsed);
+
+  assert.equal(applied.host, "172.21.203.70");
+  assert.equal(applied.port, 443);
+  assert.equal(applied.database, "hq_official");
+  assert.equal(applied.username, "framework");
+  assert.equal(applied.password, "typed-secret");
 });
 
 test("parses mysql URLs with encoded credentials", () => {


### PR DESCRIPTION
## 问题

KingBase 原生连接表单提供了“URL（可选）”入口，但连接 URL 解析器没有注册 KingBase scheme。用户输入厂商常用地址：

```text
kingbase8://172.21.203.70:443/hq_official
```

会在真正调用 Kingbase 驱动前失败：

```text
Unsupported connection URL scheme: kingbase8
```

解析失败后，表单仍保留默认的 `127.0.0.1:54321`，因此无法验证原生 Kingbase 驱动连接。

另外，DBX 自己生成的 `kingbase://` 地址此前也无法被同一个解析器重新读取。

## 修复

- 将 `kingbase://` 注册为原生 KingBase URL scheme
- 将厂商常用的 `kingbase8://` 注册为同一原生 KingBase profile
- 兼容带 JDBC 前缀的 `jdbc:kingbase8://`
- KingBase 连接表单显示专用的 `kingbase8://` URL 示例
- URL 未携带账号密码时，保留用户在独立输入框中填写的凭据

修复后，用户反馈地址会自动应用为：

```text
host = 172.21.203.70
port = 443
database = hq_official
```

后续仍由 DBX 原生 Kingbase Agent 使用 `jdbc:kingbase8://...` 建立连接。

## 验证

- `pnpm vitest run packages/app-tests/connectionUrl.test.ts`：48 passed
- `pnpm typecheck`：通过
- `pnpm lint`：通过（仅有仓库原有 warning）

测试覆盖 `kingbase://`、`kingbase8://`、`jdbc:kingbase8://`，并覆盖用户截图中 URL 不含凭据、账号密码单独填写的场景。