### PR TITLE
Fix：修复达梦物化视图分页元数据分类

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -32,9 +32,7 @@ import java.sql.Types;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -56,6 +54,13 @@ public final class DamengAgent extends BaseDatabaseAgent {
             WHERE materialized_view.TYPE$ = 'SCHOBJ'
               AND materialized_view.SUBTYPE$ = 'VIEW'
               AND (materialized_view.INFO1 & 0x200) > 0
+        ) mv ON mv.OWNER = o.OWNER AND mv.MVIEW_NAME = o.OBJECT_NAME
+        """.stripIndent().trim();
+    private static final String DAMENG_ACCESSIBLE_MATERIALIZED_VIEW_JOIN_SQL = """
+        LEFT JOIN (
+            SELECT DISTINCT OWNER, NAME AS MVIEW_NAME
+            FROM ALL_DEPENDENCIES
+            WHERE TYPE IN ('MATERIALIZED VIEW', 'MATERIALIZED_VIEW')
         ) mv ON mv.OWNER = o.OWNER AND mv.MVIEW_NAME = o.OBJECT_NAME
         """.stripIndent().trim();
     private static final String DAMENG_USER_MATERIALIZED_VIEW_JOIN_SQL = """
@@ -176,37 +181,17 @@ public final class DamengAgent extends BaseDatabaseAgent {
 
     @Override
     public List<TableInfo> listTables(String schema) {
-        // Keep this call on the legacy object-type overload; the common agent
-        // also exposes a constraints overload for paged metadata listing.
-        return listTables(schema, (List<String>) null);
+        return queryConstrainedTables(schema, MetadataListConstraints.NONE);
     }
 
     @Override
     public List<TableInfo> listTables(String schema, List<String> objectTypes) {
-        return unchecked(() -> {
-            Map<String, TableInfo> tablesByName = new LinkedHashMap<>();
-            if (objectTypesInclude(objectTypes, "TABLE")) {
-                loadTableOrView(schema, "TABLE", tablesByName);
-            }
-            if (objectTypesInclude(objectTypes, "VIEW")) {
-                loadTableOrView(schema, "VIEW", tablesByName);
-            }
-            if (objectTypesInclude(objectTypes, "MATERIALIZED_VIEW")) {
-                loadMaterializedViews(schema, tablesByName);
-            }
-            List<TableInfo> result = new ArrayList<>(tablesByName.values());
-            result.sort(Comparator.comparing(TableInfo::getName));
-            return result;
-        });
+        return queryConstrainedTables(schema, new MetadataListConstraints(null, null, null, objectTypes));
     }
 
     @Override
     public List<TableInfo> listTables(String schema, MetadataListConstraints constraints) {
-        MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
-        if (isUnconstrained(normalized)) {
-            return listTables(schema);
-        }
-        return queryConstrainedTables(schema, normalized);
+        return queryConstrainedTables(schema, MetadataListConstraints.orNone(constraints));
     }
 
     private List<TableInfo> queryConstrainedTables(String schema, MetadataListConstraints constraints) {
@@ -216,6 +201,16 @@ public final class DamengAgent extends BaseDatabaseAgent {
         try {
             return executeConstrainedTables(buildConstrainedTablesQuery(schema, constraints), constraints);
         } catch (RuntimeException e) {
+            if (needsMaterializedViewClassification(constraints)) {
+                try {
+                    return executeConstrainedTables(
+                        buildAccessibleConstrainedTablesQuery(schema, constraints),
+                        constraints
+                    );
+                } catch (RuntimeException ignored) {
+                    // Fall through to owner-local and raw catalog fallbacks.
+                }
+            }
             if (needsMaterializedViewClassification(constraints) && schemaMatchesConnectedUser(schema)) {
                 try {
                     return executeConstrainedTables(
@@ -223,19 +218,10 @@ public final class DamengAgent extends BaseDatabaseAgent {
                         constraints
                     );
                 } catch (RuntimeException ignored) {
-                    // Fall through to the legacy metadata path below.
+                    // Fall through to the raw catalog path below.
                 }
             }
-            if (needsMaterializedViewClassification(constraints)) {
-                try {
-                    return executePrivilegeSafeConstrainedTables(schema, constraints);
-                } catch (RuntimeException ignored) {
-                    // Fall through to the legacy metadata path below.
-                }
-            }
-            // Restricted Dameng catalog views vary by version; fall back to the
-            // legacy metadata path so browsing still works when pushdown fails.
-            return constraints.filterTables(listTables(schema));
+            return executeRawConstrainedTables(schema, constraints);
         }
     }
 
@@ -254,27 +240,26 @@ public final class DamengAgent extends BaseDatabaseAgent {
         });
     }
 
-    private List<TableInfo> executePrivilegeSafeConstrainedTables(
-        String schema,
-        MetadataListConstraints constraints
-    ) {
+    private List<TableInfo> executeRawConstrainedTables(String schema, MetadataListConstraints constraints) {
         List<TableInfo> candidates = executeConstrainedTables(
-            buildPrivilegeSafeConstrainedTablesQuery(schema, constraints),
+            buildRawConstrainedTablesQuery(schema, constraints),
             MetadataListConstraints.NONE
         );
-        List<TableInfo> classified = new ArrayList<>();
-        for (TableInfo candidate : candidates) {
-            String objectType = classifyAccessibleViewType(schema, candidate.getName(), candidate.getTable_type());
-            classified.add(new TableInfo(candidate.getName(), objectType, candidate.getComment()));
-        }
-        return constraints.filterTables(classified);
+        return constraints.filterTables(candidates);
     }
 
     static MetadataQuery buildConstrainedTablesQuery(String schema, MetadataListConstraints constraints) {
         return buildConstrainedTablesQuery(schema, constraints, DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL);
     }
 
-    static MetadataQuery buildPrivilegeSafeConstrainedTablesQuery(
+    static MetadataQuery buildAccessibleConstrainedTablesQuery(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
+        return buildConstrainedTablesQuery(schema, constraints, DAMENG_ACCESSIBLE_MATERIALIZED_VIEW_JOIN_SQL);
+    }
+
+    static MetadataQuery buildRawConstrainedTablesQuery(
         String schema,
         MetadataListConstraints constraints
     ) {
@@ -325,153 +310,11 @@ public final class DamengAgent extends BaseDatabaseAgent {
         return new MetadataQuery(sql.toString(), args);
     }
 
-    private void loadTableOrView(String schema, String tableType, Map<String, TableInfo> tablesByName) {
-        if (!loadTableOrViewFromAllObjects(schema, tableType, tablesByName)) {
-            loadTableOrViewFromComments(schema, tableType, tablesByName);
-        }
-        if ("VIEW".equals(tableType)) {
-            removeMaterializedViewsFromRegularViews(schema, tablesByName);
-        }
-    }
-
-    private boolean loadTableOrViewFromAllObjects(String schema, String tableType, Map<String, TableInfo> tablesByName) {
-        String sql = ("""
-            SELECT o.OBJECT_NAME AS TABLE_NAME, c.COMMENTS
-            FROM ALL_OBJECTS o
-            LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
-            WHERE o.OWNER = ? AND o.OBJECT_TYPE = '%s' AND ( (o.OBJECT_TYPE = 'TABLE' AND o.OBJECT_NAME NOT LIKE 'MTAB$_%%') OR o.OBJECT_TYPE = 'VIEW')
-            ORDER BY o.OBJECT_NAME
-            """).formatted(tableType).stripIndent().trim();
-        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
-            stmt.setString(1, schema);
-            try (ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    addTableInfo(tablesByName, rs.getString(1), tableType, rs.getString(2));
-                }
-            }
-            return true;
-        } catch (Exception ignored) {
-            return false;
-        }
-    }
-
-    private void loadTableOrViewFromComments(String schema, String tableType, Map<String, TableInfo> tablesByName) {
-        String tableNameFilter = "TABLE".equals(tableType) ? " AND TABLE_NAME NOT LIKE 'MTAB$_%'" : "";
-        String sql = ("""
-            SELECT TABLE_NAME, COMMENTS
-            FROM ALL_TAB_COMMENTS
-            WHERE OWNER = ? AND TABLE_TYPE = '%s'%s
-            ORDER BY TABLE_NAME
-            """).formatted(tableType, tableNameFilter).stripIndent().trim();
-        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
-            stmt.setString(1, schema);
-            try (ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    addTableInfo(tablesByName, rs.getString(1), tableType, rs.getString(2));
-                }
-            }
-        } catch (Exception ignored) {
-            // Keep metadata browsing usable even when optional catalog views are restricted.
-        }
-    }
-
-    private void loadMaterializedViews(String schema, Map<String, TableInfo> tablesByName) {
-        loadMaterializedViewsFromAllObjects(schema, tablesByName);
-    }
-
-    private void loadMaterializedViewsFromAllObjects(String schema, Map<String, TableInfo> tablesByName) {
-        String sql = """
-            SELECT m.MVIEW_NAME AS TABLE_NAME, c.COMMENTS
-			FROM USER_MVIEWS m LEFT JOIN ALL_OBJECTS o ON m.SCHID = o.OBJECT_ID
-			LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = m.MVIEW_NAME
-			WHERE o.OWNER = ?
-			ORDER BY TABLE_NAME
-            """.stripIndent().trim();
-        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
-            stmt.setString(1, schema);
-            try (ResultSet rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    addTableInfo(tablesByName, rs.getString(1), "MATERIALIZED_VIEW", rs.getString(2));
-                }
-            }
-        } catch (Exception ignored) {
-            // Older or restricted Dameng catalogs may not expose this object type.
-        }
-    }
-
-    private void loadMaterializedViewsFromUserMviews(String schema, Map<String, TableInfo> tablesByName) {
-        if (!schemaMatchesConnectedUser(schema)) {
-            return;
-        }
-        loadUserMviews("SELECT MVIEW_NAME FROM USER_MVIEWS", tablesByName);
-    }
-
-    private boolean loadUserMviews(String sql, Map<String, TableInfo> tablesByName) {
-        try (PreparedStatement stmt = requireConnected().prepareStatement(sql);
-             ResultSet rs = stmt.executeQuery()) {
-            while (rs.next()) {
-                addTableInfo(tablesByName, rs.getString(1), "MATERIALIZED_VIEW", null);
-            }
-            return true;
-        } catch (Exception ignored) {
-            return false;
-        }
-    }
-
-    private void removeMaterializedViewsFromRegularViews(String schema, Map<String, TableInfo> tablesByName) {
-        /*if (!schemaMatchesConnectedUser(schema)) {
-            return;
-        }*/
-        for (String name : listUserMviewNames()) {
-            tablesByName.remove(name);
-        }
-    }
-
-    private Set<String> listUserMviewNames() {
-        Set<String> names = new java.util.HashSet<>();
-        String sql = "SELECT MVIEW_NAME FROM USER_MVIEWS";
-        try (PreparedStatement stmt = requireConnected().prepareStatement(sql);
-             ResultSet rs = stmt.executeQuery()) {
-            while (rs.next()) {
-                String key = metadataNameKey(rs.getString(1));
-                if (!key.isEmpty()) {
-                    names.add(key);
-                }
-            }
-        } catch (Exception ignored) {
-            // Some Dameng versions or users do not expose USER_MVIEWS.
-        }
-        return names;
-    }
-
     private boolean schemaMatchesConnectedUser(String schema) {
         return connectedUsername != null
             && schema != null
             && !connectedUsername.isBlank()
             && schema.equalsIgnoreCase(connectedUsername);
-    }
-
-    private static void addTableInfo(Map<String, TableInfo> tablesByName, String name, String tableType, String comment) {
-        String key = metadataNameKey(name);
-        if (!key.isEmpty()) {
-            tablesByName.put(key, new TableInfo(name, tableType, comment));
-        }
-    }
-
-    private static boolean objectTypesInclude(List<String> objectTypes, String expectedType) {
-        if (objectTypes == null || objectTypes.isEmpty()) {
-            return true;
-        }
-        for (String objectType : objectTypes) {
-            if (expectedType.equals(normalizeObjectType(objectType))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isUnconstrained(MetadataListConstraints constraints) {
-        return !constraints.hasFilter() && !constraints.hasLimit() && !constraints.hasOffset() && !constraints.hasObjectTypes();
     }
 
     private static boolean includesSupportedObjectTypes(MetadataListConstraints constraints) {
@@ -633,41 +476,14 @@ public final class DamengAgent extends BaseDatabaseAgent {
         return upper;
     }
 
-    private static String metadataNameKey(String value) {
-        return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
-    }
-
     @Override
     public List<ObjectInfo> listObjects(String schema) {
-        return unchecked(() -> {
-            List<ObjectInfo> result = new ArrayList<>();
-            for (TableInfo table : listTables(schema)) {
-                result.add(new ObjectInfo(table.getName(), table.getTable_type(), schema, table.getComment()));
-            }
-            String sql = """
-                SELECT OBJECT_NAME, OBJECT_TYPE FROM ALL_OBJECTS
-                WHERE OWNER = ? AND OBJECT_TYPE IN ('PROCEDURE', 'FUNCTION')
-                ORDER BY CASE OBJECT_TYPE WHEN 'PROCEDURE' THEN 0 ELSE 1 END, OBJECT_NAME
-                """.stripIndent().trim();
-            try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
-                stmt.setString(1, schema);
-                try (ResultSet rs = stmt.executeQuery()) {
-                    while (rs.next()) {
-                        result.add(new ObjectInfo(rs.getString(1), rs.getString(2), schema, null));
-                    }
-                }
-            }
-            return result;
-        });
+        return queryConstrainedObjects(schema, MetadataListConstraints.NONE);
     }
 
     @Override
     public List<ObjectInfo> listObjects(String schema, MetadataListConstraints constraints) {
-        MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
-        if (isUnconstrained(normalized)) {
-            return listObjects(schema);
-        }
-        return queryConstrainedObjects(schema, normalized);
+        return queryConstrainedObjects(schema, MetadataListConstraints.orNone(constraints));
     }
 
     private List<ObjectInfo> queryConstrainedObjects(String schema, MetadataListConstraints constraints) {
@@ -677,6 +493,17 @@ public final class DamengAgent extends BaseDatabaseAgent {
         try {
             return executeConstrainedObjects(schema, buildConstrainedObjectsQuery(schema, constraints), constraints);
         } catch (RuntimeException e) {
+            if (needsMaterializedViewClassification(constraints)) {
+                try {
+                    return executeConstrainedObjects(
+                        schema,
+                        buildAccessibleConstrainedObjectsQuery(schema, constraints),
+                        constraints
+                    );
+                } catch (RuntimeException ignored) {
+                    // Fall through to owner-local and raw catalog fallbacks.
+                }
+            }
             if (needsMaterializedViewClassification(constraints) && schemaMatchesConnectedUser(schema)) {
                 try {
                     return executeConstrainedObjects(
@@ -685,19 +512,10 @@ public final class DamengAgent extends BaseDatabaseAgent {
                         constraints
                     );
                 } catch (RuntimeException ignored) {
-                    // Fall through to the legacy metadata path below.
+                    // Fall through to the raw catalog path below.
                 }
             }
-            if (needsMaterializedViewClassification(constraints)) {
-                try {
-                    return executePrivilegeSafeConstrainedObjects(schema, constraints);
-                } catch (RuntimeException ignored) {
-                    // Fall through to the legacy metadata path below.
-                }
-            }
-            // Keep restricted/older Dameng catalogs usable even if SQL pushdown
-            // is unavailable for a specific connection.
-            return constraints.filterObjects(listObjects(schema));
+            return executeRawConstrainedObjects(schema, constraints);
         }
     }
 
@@ -725,31 +543,27 @@ public final class DamengAgent extends BaseDatabaseAgent {
         });
     }
 
-    private List<ObjectInfo> executePrivilegeSafeConstrainedObjects(
-        String schema,
-        MetadataListConstraints constraints
-    ) {
+    private List<ObjectInfo> executeRawConstrainedObjects(String schema, MetadataListConstraints constraints) {
         List<ObjectInfo> candidates = executeConstrainedObjects(
             schema,
-            buildPrivilegeSafeConstrainedObjectsQuery(schema, constraints),
+            buildRawConstrainedObjectsQuery(schema, constraints),
             MetadataListConstraints.NONE
         );
-        List<ObjectInfo> classified = new ArrayList<>();
-        for (ObjectInfo candidate : candidates) {
-            String objectType = classifyAccessibleViewType(schema, candidate.getName(), candidate.getObject_type());
-            classified.add(new ObjectInfo(candidate.getName(), objectType, schema, candidate.getComment()));
-        }
-        classified.sort(Comparator
-            .comparingInt((ObjectInfo object) -> damengObjectTypeOrder(object.getObject_type()))
-            .thenComparing(ObjectInfo::getName));
-        return constraints.filterObjects(classified);
+        return constraints.filterObjects(candidates);
     }
 
     static MetadataQuery buildConstrainedObjectsQuery(String schema, MetadataListConstraints constraints) {
         return buildConstrainedObjectsQuery(schema, constraints, DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL);
     }
 
-    static MetadataQuery buildPrivilegeSafeConstrainedObjectsQuery(
+    static MetadataQuery buildAccessibleConstrainedObjectsQuery(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
+        return buildConstrainedObjectsQuery(schema, constraints, DAMENG_ACCESSIBLE_MATERIALIZED_VIEW_JOIN_SQL);
+    }
+
+    static MetadataQuery buildRawConstrainedObjectsQuery(
         String schema,
         MetadataListConstraints constraints
     ) {
@@ -804,37 +618,6 @@ public final class DamengAgent extends BaseDatabaseAgent {
             .append(" ELSE 9 END, o.OBJECT_NAME");
         appendLimitOffset(sql, args, normalized);
         return new MetadataQuery(sql.toString(), args);
-    }
-
-    private String classifyAccessibleViewType(String schema, String name, String objectType) {
-        String normalized = normalizeObjectType(objectType);
-        if (!"VIEW".equals(normalized)) {
-            return normalized;
-        }
-        String sql = "SELECT 1 FROM DUAL WHERE DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW', ?, ?) IS NOT NULL";
-        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
-            stmt.setString(1, name);
-            stmt.setString(2, schema);
-            try (ResultSet rs = stmt.executeQuery()) {
-                return rs.next() ? "MATERIALIZED_VIEW" : "VIEW";
-            }
-        } catch (Exception ignored) {
-            // GET_DDL with MATERIALIZED_VIEW fails for an ordinary view. It is
-            // also available to users that only have object-level SELECT grants,
-            // unlike SYS.SYSOBJECTS on restricted DM8 installations.
-            return "VIEW";
-        }
-    }
-
-    private static int damengObjectTypeOrder(String objectType) {
-        return switch (normalizeObjectType(objectType)) {
-            case "TABLE" -> 0;
-            case "VIEW" -> 1;
-            case "MATERIALIZED_VIEW" -> 2;
-            case "PROCEDURE" -> 3;
-            case "FUNCTION" -> 4;
-            default -> 9;
-        };
     }
 
     @Override

--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -215,12 +216,19 @@ public final class DamengAgent extends BaseDatabaseAgent {
         try {
             return executeConstrainedTables(buildConstrainedTablesQuery(schema, constraints), constraints);
         } catch (RuntimeException e) {
-            if (needsMaterializedViewClassification(constraints)) {
+            if (needsMaterializedViewClassification(constraints) && schemaMatchesConnectedUser(schema)) {
                 try {
                     return executeConstrainedTables(
                         buildConstrainedTablesQuery(schema, constraints, DAMENG_USER_MATERIALIZED_VIEW_JOIN_SQL),
                         constraints
                     );
+                } catch (RuntimeException ignored) {
+                    // Fall through to the legacy metadata path below.
+                }
+            }
+            if (needsMaterializedViewClassification(constraints)) {
+                try {
+                    return executePrivilegeSafeConstrainedTables(schema, constraints);
                 } catch (RuntimeException ignored) {
                     // Fall through to the legacy metadata path below.
                 }
@@ -246,8 +254,47 @@ public final class DamengAgent extends BaseDatabaseAgent {
         });
     }
 
+    private List<TableInfo> executePrivilegeSafeConstrainedTables(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
+        List<TableInfo> candidates = executeConstrainedTables(
+            buildPrivilegeSafeConstrainedTablesQuery(schema, constraints),
+            MetadataListConstraints.NONE
+        );
+        List<TableInfo> classified = new ArrayList<>();
+        for (TableInfo candidate : candidates) {
+            String objectType = classifyAccessibleViewType(schema, candidate.getName(), candidate.getTable_type());
+            classified.add(new TableInfo(candidate.getName(), objectType, candidate.getComment()));
+        }
+        return constraints.filterTables(classified);
+    }
+
     static MetadataQuery buildConstrainedTablesQuery(String schema, MetadataListConstraints constraints) {
         return buildConstrainedTablesQuery(schema, constraints, DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL);
+    }
+
+    static MetadataQuery buildPrivilegeSafeConstrainedTablesQuery(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
+        MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
+        List<String> objectTypes = rawDamengTableObjectTypes(normalized);
+        List<Object> args = new ArrayList<>();
+        StringBuilder sql = new StringBuilder("""
+            SELECT o.OBJECT_NAME AS TABLE_NAME,
+                   o.OBJECT_TYPE AS TABLE_TYPE,
+                   c.COMMENTS
+            FROM ALL_OBJECTS o
+            LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
+            WHERE o.OWNER = ?
+            """.stripIndent().trim());
+        args.add(schema);
+        appendRawObjectTypePredicate(sql, args, objectTypes);
+        sql.append(" AND (o.OBJECT_TYPE <> 'TABLE' OR o.OBJECT_NAME NOT LIKE 'MTAB$_%')");
+        appendNameFilter(sql, args, "o.OBJECT_NAME", normalized);
+        sql.append(" ORDER BY o.OBJECT_NAME");
+        return new MetadataQuery(sql.toString(), args);
     }
 
     private static MetadataQuery buildConstrainedTablesQuery(
@@ -475,6 +522,44 @@ public final class DamengAgent extends BaseDatabaseAgent {
         return result;
     }
 
+    private static List<String> rawDamengTableObjectTypes(MetadataListConstraints constraints) {
+        LinkedHashSet<String> result = new LinkedHashSet<>();
+        if (constraints.tableTypeAllowed("TABLE")) {
+            result.add("TABLE");
+        }
+        if (constraints.tableTypeAllowed("VIEW") || constraints.tableTypeAllowed("MATERIALIZED_VIEW")) {
+            // DM8 may expose a materialized view as VIEW in ALL_OBJECTS. Keep
+            // the direct catalog type too for versions that report it accurately.
+            result.add("VIEW");
+            result.add("MATERIALIZED VIEW");
+        }
+        return new ArrayList<>(result);
+    }
+
+    private static List<String> rawDamengObjectTypes(MetadataListConstraints constraints) {
+        List<String> result = rawDamengTableObjectTypes(constraints);
+        if (constraints.objectTypeAllowed("PROCEDURE")) {
+            result.add("PROCEDURE");
+        }
+        if (constraints.objectTypeAllowed("FUNCTION")) {
+            result.add("FUNCTION");
+        }
+        return result;
+    }
+
+    private static void appendRawObjectTypePredicate(
+        StringBuilder sql,
+        List<Object> args,
+        List<String> objectTypes
+    ) {
+        if (objectTypes.isEmpty()) {
+            sql.append(" AND 1 = 0");
+            return;
+        }
+        sql.append(" AND o.OBJECT_TYPE IN (").append(placeholders(objectTypes.size())).append(")");
+        args.addAll(objectTypes);
+    }
+
     private static boolean needsMaterializedViewClassification(MetadataListConstraints constraints) {
         return constraints.tableTypeAllowed("VIEW") || constraints.tableTypeAllowed("MATERIALIZED_VIEW");
     }
@@ -592,13 +677,20 @@ public final class DamengAgent extends BaseDatabaseAgent {
         try {
             return executeConstrainedObjects(schema, buildConstrainedObjectsQuery(schema, constraints), constraints);
         } catch (RuntimeException e) {
-            if (needsMaterializedViewClassification(constraints)) {
+            if (needsMaterializedViewClassification(constraints) && schemaMatchesConnectedUser(schema)) {
                 try {
                     return executeConstrainedObjects(
                         schema,
                         buildConstrainedObjectsQuery(schema, constraints, DAMENG_USER_MATERIALIZED_VIEW_JOIN_SQL),
                         constraints
                     );
+                } catch (RuntimeException ignored) {
+                    // Fall through to the legacy metadata path below.
+                }
+            }
+            if (needsMaterializedViewClassification(constraints)) {
+                try {
+                    return executePrivilegeSafeConstrainedObjects(schema, constraints);
                 } catch (RuntimeException ignored) {
                     // Fall through to the legacy metadata path below.
                 }
@@ -633,8 +725,51 @@ public final class DamengAgent extends BaseDatabaseAgent {
         });
     }
 
+    private List<ObjectInfo> executePrivilegeSafeConstrainedObjects(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
+        List<ObjectInfo> candidates = executeConstrainedObjects(
+            schema,
+            buildPrivilegeSafeConstrainedObjectsQuery(schema, constraints),
+            MetadataListConstraints.NONE
+        );
+        List<ObjectInfo> classified = new ArrayList<>();
+        for (ObjectInfo candidate : candidates) {
+            String objectType = classifyAccessibleViewType(schema, candidate.getName(), candidate.getObject_type());
+            classified.add(new ObjectInfo(candidate.getName(), objectType, schema, candidate.getComment()));
+        }
+        classified.sort(Comparator
+            .comparingInt((ObjectInfo object) -> damengObjectTypeOrder(object.getObject_type()))
+            .thenComparing(ObjectInfo::getName));
+        return constraints.filterObjects(classified);
+    }
+
     static MetadataQuery buildConstrainedObjectsQuery(String schema, MetadataListConstraints constraints) {
         return buildConstrainedObjectsQuery(schema, constraints, DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL);
+    }
+
+    static MetadataQuery buildPrivilegeSafeConstrainedObjectsQuery(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
+        MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
+        List<String> objectTypes = rawDamengObjectTypes(normalized);
+        List<Object> args = new ArrayList<>();
+        StringBuilder sql = new StringBuilder("""
+            SELECT o.OBJECT_NAME,
+                   o.OBJECT_TYPE,
+                   c.COMMENTS
+            FROM ALL_OBJECTS o
+            LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
+            WHERE o.OWNER = ?
+            """.stripIndent().trim());
+        args.add(schema);
+        appendRawObjectTypePredicate(sql, args, objectTypes);
+        sql.append(" AND (o.OBJECT_TYPE <> 'TABLE' OR o.OBJECT_NAME NOT LIKE 'MTAB$_%')");
+        appendNameFilter(sql, args, "o.OBJECT_NAME", normalized);
+        sql.append(" ORDER BY o.OBJECT_NAME");
+        return new MetadataQuery(sql.toString(), args);
     }
 
     private static MetadataQuery buildConstrainedObjectsQuery(
@@ -669,6 +804,37 @@ public final class DamengAgent extends BaseDatabaseAgent {
             .append(" ELSE 9 END, o.OBJECT_NAME");
         appendLimitOffset(sql, args, normalized);
         return new MetadataQuery(sql.toString(), args);
+    }
+
+    private String classifyAccessibleViewType(String schema, String name, String objectType) {
+        String normalized = normalizeObjectType(objectType);
+        if (!"VIEW".equals(normalized)) {
+            return normalized;
+        }
+        String sql = "SELECT 1 FROM DUAL WHERE DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW', ?, ?) IS NOT NULL";
+        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
+            stmt.setString(1, name);
+            stmt.setString(2, schema);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next() ? "MATERIALIZED_VIEW" : "VIEW";
+            }
+        } catch (Exception ignored) {
+            // GET_DDL with MATERIALIZED_VIEW fails for an ordinary view. It is
+            // also available to users that only have object-level SELECT grants,
+            // unlike SYS.SYSOBJECTS on restricted DM8 installations.
+            return "VIEW";
+        }
+    }
+
+    private static int damengObjectTypeOrder(String objectType) {
+        return switch (normalizeObjectType(objectType)) {
+            case "TABLE" -> 0;
+            case "VIEW" -> 1;
+            case "MATERIALIZED_VIEW" -> 2;
+            case "PROCEDURE" -> 3;
+            case "FUNCTION" -> 4;
+            default -> 9;
+        };
     }
 
     @Override

--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -42,6 +42,17 @@ import java.util.Set;
 
 public final class DamengAgent extends BaseDatabaseAgent {
     private static final String AGENT_VERSION = "9999.06.04.1-fix-default";
+    private static final String DAMENG_CLASSIFIED_OBJECT_TYPE_SQL =
+        "CASE WHEN o.OBJECT_TYPE = 'MATERIALIZED VIEW' OR (o.OBJECT_TYPE = 'VIEW' AND mv.MVIEW_NAME IS NOT NULL) "
+            + "THEN 'MATERIALIZED_VIEW' ELSE o.OBJECT_TYPE END";
+    private static final String DAMENG_MATERIALIZED_VIEW_JOIN_SQL = """
+        LEFT JOIN (
+            SELECT DISTINCT schema_object.OWNER, m.MVIEW_NAME
+            FROM USER_MVIEWS m
+            JOIN ALL_OBJECTS schema_object
+              ON schema_object.OBJECT_ID = m.SCHID AND schema_object.OBJECT_TYPE = 'SCH'
+        ) mv ON mv.OWNER = o.OWNER AND mv.MVIEW_NAME = o.OBJECT_NAME
+        """.stripIndent().trim();
     private static final Set<String> SYSTEM_USERS = Set.of(
         "SYS", "SYSAUDITOR", "SYSSSO", "CTISYS",
         "SYS_DBA", "_SYS_STATISTICS", "SYS_PHM"
@@ -213,14 +224,15 @@ public final class DamengAgent extends BaseDatabaseAgent {
     static MetadataQuery buildConstrainedTablesQuery(String schema, MetadataListConstraints constraints) {
         MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
         List<Object> args = new ArrayList<>();
-        StringBuilder sql = new StringBuilder("""
+        StringBuilder sql = new StringBuilder(("""
             SELECT o.OBJECT_NAME AS TABLE_NAME,
-                   CASE WHEN o.OBJECT_TYPE = 'MATERIALIZED VIEW' THEN 'MATERIALIZED_VIEW' ELSE o.OBJECT_TYPE END AS TABLE_TYPE,
+                   %s AS TABLE_TYPE,
                    c.COMMENTS
             FROM ALL_OBJECTS o
             LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
+            %s
             WHERE o.OWNER = ?
-            """.stripIndent().trim());
+            """).formatted(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL, DAMENG_MATERIALIZED_VIEW_JOIN_SQL).stripIndent().trim());
         args.add(schema);
         appendDamengObjectTypePredicate(sql, args, normalized, true);
         sql.append(" AND (o.OBJECT_TYPE <> 'TABLE' OR o.OBJECT_NAME NOT LIKE 'MTAB$_%')");
@@ -396,7 +408,8 @@ public final class DamengAgent extends BaseDatabaseAgent {
             sql.append(" AND 1 = 0");
             return;
         }
-        sql.append(" AND o.OBJECT_TYPE IN (").append(placeholders(objectTypes.size())).append(")");
+        sql.append(" AND ").append(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL)
+            .append(" IN (").append(placeholders(objectTypes.size())).append(")");
         args.addAll(objectTypes);
     }
 
@@ -409,7 +422,7 @@ public final class DamengAgent extends BaseDatabaseAgent {
             result.add("VIEW");
         }
         if (constraints.tableTypeAllowed("MATERIALIZED_VIEW")) {
-            result.add("MATERIALIZED VIEW");
+            result.add("MATERIALIZED_VIEW");
         }
         return result;
     }
@@ -564,22 +577,23 @@ public final class DamengAgent extends BaseDatabaseAgent {
     static MetadataQuery buildConstrainedObjectsQuery(String schema, MetadataListConstraints constraints) {
         MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
         List<Object> args = new ArrayList<>();
-        StringBuilder sql = new StringBuilder("""
+        StringBuilder sql = new StringBuilder(("""
             SELECT o.OBJECT_NAME,
-                   CASE WHEN o.OBJECT_TYPE = 'MATERIALIZED VIEW' THEN 'MATERIALIZED_VIEW' ELSE o.OBJECT_TYPE END AS OBJECT_TYPE,
+                   %s AS OBJECT_TYPE,
                    c.COMMENTS
             FROM ALL_OBJECTS o
             LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
+            %s
             WHERE o.OWNER = ?
-            """.stripIndent().trim());
+            """).formatted(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL, DAMENG_MATERIALIZED_VIEW_JOIN_SQL).stripIndent().trim());
         args.add(schema);
         appendDamengObjectTypePredicate(sql, args, normalized, false);
         sql.append(" AND (o.OBJECT_TYPE <> 'TABLE' OR o.OBJECT_NAME NOT LIKE 'MTAB$_%')");
         appendNameFilter(sql, args, "o.OBJECT_NAME", normalized);
-        sql.append(" ORDER BY CASE o.OBJECT_TYPE")
+        sql.append(" ORDER BY CASE ").append(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL)
             .append(" WHEN 'TABLE' THEN 0")
             .append(" WHEN 'VIEW' THEN 1")
-            .append(" WHEN 'MATERIALIZED VIEW' THEN 2")
+            .append(" WHEN 'MATERIALIZED_VIEW' THEN 2")
             .append(" WHEN 'PROCEDURE' THEN 3")
             .append(" WHEN 'FUNCTION' THEN 4")
             .append(" ELSE 9 END, o.OBJECT_NAME");

--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -45,7 +45,19 @@ public final class DamengAgent extends BaseDatabaseAgent {
     private static final String DAMENG_CLASSIFIED_OBJECT_TYPE_SQL =
         "CASE WHEN o.OBJECT_TYPE = 'MATERIALIZED VIEW' OR (o.OBJECT_TYPE = 'VIEW' AND mv.MVIEW_NAME IS NOT NULL) "
             + "THEN 'MATERIALIZED_VIEW' ELSE o.OBJECT_TYPE END";
-    private static final String DAMENG_MATERIALIZED_VIEW_JOIN_SQL = """
+    // DM8 does not expose ALL_MVIEWS; SYSOBJECTS provides the owning schema through SCHID.
+    private static final String DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL = """
+        LEFT JOIN (
+            SELECT schema_object.NAME AS OWNER, materialized_view.NAME AS MVIEW_NAME
+            FROM SYS.SYSOBJECTS materialized_view
+            JOIN SYS.SYSOBJECTS schema_object
+              ON schema_object.ID = materialized_view.SCHID AND schema_object.TYPE$ = 'SCH'
+            WHERE materialized_view.TYPE$ = 'SCHOBJ'
+              AND materialized_view.SUBTYPE$ = 'VIEW'
+              AND (materialized_view.INFO1 & 0x200) > 0
+        ) mv ON mv.OWNER = o.OWNER AND mv.MVIEW_NAME = o.OBJECT_NAME
+        """.stripIndent().trim();
+    private static final String DAMENG_USER_MATERIALIZED_VIEW_JOIN_SQL = """
         LEFT JOIN (
             SELECT DISTINCT schema_object.OWNER, m.MVIEW_NAME
             FROM USER_MVIEWS m
@@ -201,28 +213,52 @@ public final class DamengAgent extends BaseDatabaseAgent {
             return List.of();
         }
         try {
-            return unchecked(() -> {
-                MetadataQuery query = buildConstrainedTablesQuery(schema, constraints);
-                List<TableInfo> result = new ArrayList<>();
-                try (PreparedStatement stmt = requireConnected().prepareStatement(query.sql())) {
-                    bind(stmt, query.args());
-                    try (ResultSet rs = stmt.executeQuery()) {
-                        while (rs.next()) {
-                            result.add(new TableInfo(rs.getString("TABLE_NAME"), normalizeObjectType(rs.getString("TABLE_TYPE")), rs.getString("COMMENTS")));
-                        }
-                    }
-                }
-                return constraints.withoutPaging().filterTables(result);
-            });
+            return executeConstrainedTables(buildConstrainedTablesQuery(schema, constraints), constraints);
         } catch (RuntimeException e) {
+            if (needsMaterializedViewClassification(constraints)) {
+                try {
+                    return executeConstrainedTables(
+                        buildConstrainedTablesQuery(schema, constraints, DAMENG_USER_MATERIALIZED_VIEW_JOIN_SQL),
+                        constraints
+                    );
+                } catch (RuntimeException ignored) {
+                    // Fall through to the legacy metadata path below.
+                }
+            }
             // Restricted Dameng catalog views vary by version; fall back to the
             // legacy metadata path so browsing still works when pushdown fails.
             return constraints.filterTables(listTables(schema));
         }
     }
 
+    private List<TableInfo> executeConstrainedTables(MetadataQuery query, MetadataListConstraints constraints) {
+        return unchecked(() -> {
+            List<TableInfo> result = new ArrayList<>();
+            try (PreparedStatement stmt = requireConnected().prepareStatement(query.sql())) {
+                bind(stmt, query.args());
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        result.add(new TableInfo(rs.getString("TABLE_NAME"), normalizeObjectType(rs.getString("TABLE_TYPE")), rs.getString("COMMENTS")));
+                    }
+                }
+            }
+            return constraints.withoutPaging().filterTables(result);
+        });
+    }
+
     static MetadataQuery buildConstrainedTablesQuery(String schema, MetadataListConstraints constraints) {
+        return buildConstrainedTablesQuery(schema, constraints, DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL);
+    }
+
+    private static MetadataQuery buildConstrainedTablesQuery(
+        String schema,
+        MetadataListConstraints constraints,
+        String materializedViewJoinSql
+    ) {
         MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
+        boolean classifyMaterializedViews = needsMaterializedViewClassification(normalized);
+        String objectTypeSql = classifyMaterializedViews ? DAMENG_CLASSIFIED_OBJECT_TYPE_SQL : "o.OBJECT_TYPE";
+        String classificationJoinSql = classifyMaterializedViews ? materializedViewJoinSql : "";
         List<Object> args = new ArrayList<>();
         StringBuilder sql = new StringBuilder(("""
             SELECT o.OBJECT_NAME AS TABLE_NAME,
@@ -232,9 +268,9 @@ public final class DamengAgent extends BaseDatabaseAgent {
             LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
             %s
             WHERE o.OWNER = ?
-            """).formatted(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL, DAMENG_MATERIALIZED_VIEW_JOIN_SQL).stripIndent().trim());
+            """).formatted(objectTypeSql, classificationJoinSql).stripIndent().trim());
         args.add(schema);
-        appendDamengObjectTypePredicate(sql, args, normalized, true);
+        appendDamengObjectTypePredicate(sql, args, normalized, true, objectTypeSql);
         sql.append(" AND (o.OBJECT_TYPE <> 'TABLE' OR o.OBJECT_NAME NOT LIKE 'MTAB$_%')");
         appendNameFilter(sql, args, "o.OBJECT_NAME", normalized);
         sql.append(" ORDER BY o.OBJECT_NAME");
@@ -401,14 +437,15 @@ public final class DamengAgent extends BaseDatabaseAgent {
         StringBuilder sql,
         List<Object> args,
         MetadataListConstraints constraints,
-        boolean tableOnly
+        boolean tableOnly,
+        String objectTypeSql
     ) {
         List<String> objectTypes = tableOnly ? damengTableObjectTypes(constraints) : damengObjectTypes(constraints);
         if (objectTypes.isEmpty()) {
             sql.append(" AND 1 = 0");
             return;
         }
-        sql.append(" AND ").append(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL)
+        sql.append(" AND ").append(objectTypeSql)
             .append(" IN (").append(placeholders(objectTypes.size())).append(")");
         args.addAll(objectTypes);
     }
@@ -436,6 +473,10 @@ public final class DamengAgent extends BaseDatabaseAgent {
             result.add("FUNCTION");
         }
         return result;
+    }
+
+    private static boolean needsMaterializedViewClassification(MetadataListConstraints constraints) {
+        return constraints.tableTypeAllowed("VIEW") || constraints.tableTypeAllowed("MATERIALIZED_VIEW");
     }
 
     private static void appendNameFilter(StringBuilder sql, List<Object> args, String column, MetadataListConstraints constraints) {
@@ -549,33 +590,62 @@ public final class DamengAgent extends BaseDatabaseAgent {
             return List.of();
         }
         try {
-            return unchecked(() -> {
-                MetadataQuery query = buildConstrainedObjectsQuery(schema, constraints);
-                List<ObjectInfo> result = new ArrayList<>();
-                try (PreparedStatement stmt = requireConnected().prepareStatement(query.sql())) {
-                    bind(stmt, query.args());
-                    try (ResultSet rs = stmt.executeQuery()) {
-                        while (rs.next()) {
-                            result.add(new ObjectInfo(
-                                rs.getString("OBJECT_NAME"),
-                                normalizeObjectType(rs.getString("OBJECT_TYPE")),
-                                schema,
-                                rs.getString("COMMENTS")
-                            ));
-                        }
-                    }
-                }
-                return constraints.withoutPaging().filterObjects(result);
-            });
+            return executeConstrainedObjects(schema, buildConstrainedObjectsQuery(schema, constraints), constraints);
         } catch (RuntimeException e) {
+            if (needsMaterializedViewClassification(constraints)) {
+                try {
+                    return executeConstrainedObjects(
+                        schema,
+                        buildConstrainedObjectsQuery(schema, constraints, DAMENG_USER_MATERIALIZED_VIEW_JOIN_SQL),
+                        constraints
+                    );
+                } catch (RuntimeException ignored) {
+                    // Fall through to the legacy metadata path below.
+                }
+            }
             // Keep restricted/older Dameng catalogs usable even if SQL pushdown
             // is unavailable for a specific connection.
             return constraints.filterObjects(listObjects(schema));
         }
     }
 
+    private List<ObjectInfo> executeConstrainedObjects(
+        String schema,
+        MetadataQuery query,
+        MetadataListConstraints constraints
+    ) {
+        return unchecked(() -> {
+            List<ObjectInfo> result = new ArrayList<>();
+            try (PreparedStatement stmt = requireConnected().prepareStatement(query.sql())) {
+                bind(stmt, query.args());
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        result.add(new ObjectInfo(
+                            rs.getString("OBJECT_NAME"),
+                            normalizeObjectType(rs.getString("OBJECT_TYPE")),
+                            schema,
+                            rs.getString("COMMENTS")
+                        ));
+                    }
+                }
+            }
+            return constraints.withoutPaging().filterObjects(result);
+        });
+    }
+
     static MetadataQuery buildConstrainedObjectsQuery(String schema, MetadataListConstraints constraints) {
+        return buildConstrainedObjectsQuery(schema, constraints, DAMENG_SYSTEM_MATERIALIZED_VIEW_JOIN_SQL);
+    }
+
+    private static MetadataQuery buildConstrainedObjectsQuery(
+        String schema,
+        MetadataListConstraints constraints,
+        String materializedViewJoinSql
+    ) {
         MetadataListConstraints normalized = MetadataListConstraints.orNone(constraints);
+        boolean classifyMaterializedViews = needsMaterializedViewClassification(normalized);
+        String objectTypeSql = classifyMaterializedViews ? DAMENG_CLASSIFIED_OBJECT_TYPE_SQL : "o.OBJECT_TYPE";
+        String classificationJoinSql = classifyMaterializedViews ? materializedViewJoinSql : "";
         List<Object> args = new ArrayList<>();
         StringBuilder sql = new StringBuilder(("""
             SELECT o.OBJECT_NAME,
@@ -585,12 +655,12 @@ public final class DamengAgent extends BaseDatabaseAgent {
             LEFT JOIN ALL_TAB_COMMENTS c ON c.OWNER = o.OWNER AND c.TABLE_NAME = o.OBJECT_NAME
             %s
             WHERE o.OWNER = ?
-            """).formatted(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL, DAMENG_MATERIALIZED_VIEW_JOIN_SQL).stripIndent().trim());
+            """).formatted(objectTypeSql, classificationJoinSql).stripIndent().trim());
         args.add(schema);
-        appendDamengObjectTypePredicate(sql, args, normalized, false);
+        appendDamengObjectTypePredicate(sql, args, normalized, false, objectTypeSql);
         sql.append(" AND (o.OBJECT_TYPE <> 'TABLE' OR o.OBJECT_NAME NOT LIKE 'MTAB$_%')");
         appendNameFilter(sql, args, "o.OBJECT_NAME", normalized);
-        sql.append(" ORDER BY CASE ").append(DAMENG_CLASSIFIED_OBJECT_TYPE_SQL)
+        sql.append(" ORDER BY CASE ").append(objectTypeSql)
             .append(" WHEN 'TABLE' THEN 0")
             .append(" WHEN 'VIEW' THEN 1")
             .append(" WHEN 'MATERIALIZED_VIEW' THEN 2")

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -68,7 +68,7 @@ class DamengAgentMetadataTest {
         String allTablesSql = String.join("\n", JdbcMetadataSqlFake.statements);
         Assertions.assertTrue(tablesSql.contains("COMMENTS"), tablesSql);
         Assertions.assertTrue(allTablesSql.contains("ALL_OBJECTS"), allTablesSql);
-        Assertions.assertTrue(allTablesSql.contains("USER_MVIEWS"), allTablesSql);
+        Assertions.assertTrue(allTablesSql.contains("SYS.SYSOBJECTS materialized_view"), allTablesSql);
         Assertions.assertFalse(allTablesSql.contains("ALL_MVIEWS"), allTablesSql);
         Assertions.assertFalse(tablesSql.contains("ALL_TABLES"), tablesSql);
         Assertions.assertFalse(tablesSql.contains("ALL_VIEWS"), tablesSql);
@@ -158,24 +158,41 @@ class DamengAgentMetadataTest {
             List.of("VIEW", "MATERIALIZED_VIEW")
         );
 
-        List<TableInfo> tables = agent.listTables("REPORTING", constraints);
-        List<ObjectInfo> objects = agent.listObjects("REPORTING", constraints);
+        List<TableInfo> normalTables = agent.listTables("REPORTING");
+        List<ObjectInfo> normalObjects = agent.listObjects("REPORTING");
+        List<TableInfo> pagedTables = agent.listTables("REPORTING", constraints);
+        List<ObjectInfo> pagedObjects = agent.listObjects("REPORTING", constraints);
 
+        assertCrossOwnerTableTypes(normalTables);
+        assertCrossOwnerObjectTypes(normalObjects);
+        assertCrossOwnerTableTypes(pagedTables);
+        assertCrossOwnerObjectTypes(pagedObjects);
+        Assertions.assertTrue(sqls.stream().anyMatch(sql -> sql.contains("SYS.SYSOBJECTS materialized_view")));
+        List<String> accessibleQueries = sqls.stream()
+            .filter(sql -> sql.contains("FROM ALL_DEPENDENCIES"))
+            .toList();
+        Assertions.assertEquals(4, accessibleQueries.size(), String.join("\n", sqls));
+        Assertions.assertEquals(2, accessibleQueries.stream().filter(sql -> sql.contains("LIMIT ?")).count());
+        Assertions.assertTrue(sqls.stream().noneMatch(sql -> sql.contains("DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW'")), String.join("\n", sqls));
+        Assertions.assertTrue(sqls.stream().noneMatch(sql -> sql.contains("USER_MVIEWS")), String.join("\n", sqls));
+    }
+
+    private static void assertCrossOwnerTableTypes(List<TableInfo> tables) {
         Assertions.assertEquals("VIEW", tables.stream()
             .filter(table -> "SALES_VIEW".equals(table.getName()))
             .findFirst().orElseThrow().getTable_type());
         Assertions.assertEquals("MATERIALIZED_VIEW", tables.stream()
             .filter(table -> "SALES_MV".equals(table.getName()))
             .findFirst().orElseThrow().getTable_type());
+    }
+
+    private static void assertCrossOwnerObjectTypes(List<ObjectInfo> objects) {
         Assertions.assertEquals("VIEW", objects.stream()
             .filter(object -> "SALES_VIEW".equals(object.getName()))
             .findFirst().orElseThrow().getObject_type());
         Assertions.assertEquals("MATERIALIZED_VIEW", objects.stream()
             .filter(object -> "SALES_MV".equals(object.getName()))
             .findFirst().orElseThrow().getObject_type());
-        Assertions.assertTrue(sqls.stream().anyMatch(sql -> sql.contains("SYS.SYSOBJECTS materialized_view")));
-        Assertions.assertTrue(sqls.stream().anyMatch(sql -> sql.contains("DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW'")));
-        Assertions.assertTrue(sqls.stream().noneMatch(sql -> sql.contains("USER_MVIEWS")), String.join("\n", sqls));
     }
 
     @Test
@@ -492,6 +509,15 @@ class DamengAgentMetadataTest {
                 if (sql.contains("SYSCOLUMNCOMMENTS")) {
                     return metadataStatement(List.of());
                 }
+                if (sql.contains("FROM ALL_OBJECTS o")
+                    && (sql.contains("AS TABLE_TYPE") || sql.contains("AS OBJECT_TYPE"))) {
+                    List<List<Object>> rows = new ArrayList<>();
+                    rows.add(Arrays.asList("USERS", "TABLE", "用户示例表"));
+                    if (includeMaterializedView) {
+                        rows.add(Arrays.asList("USER_SUMMARY_MV", "MATERIALIZED_VIEW", "mv comment"));
+                    }
+                    return metadataStatement(rows);
+                }
                 if (sql.contains("ALL_OBJECTS") && sql.contains("OBJECT_TYPE = 'TABLE'")) {
                     return metadataStatement(List.of(List.of("USERS", "用户示例表")));
                 }
@@ -629,7 +655,13 @@ class DamengAgentMetadataTest {
                     return failingMetadataStatement("no SYS.SYSOBJECTS privilege");
                 }
                 if (sql.contains("DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW'")) {
-                    return materializedViewProbeStatement("SALES_MV");
+                    throw new AssertionError("Metadata listing must not probe materialized views one object at a time: " + sql);
+                }
+                if (sql.contains("FROM ALL_DEPENDENCIES")) {
+                    return metadataStatement(List.of(
+                        Arrays.asList("SALES_MV", "MATERIALIZED_VIEW", "materialized view"),
+                        Arrays.asList("SALES_VIEW", "VIEW", "regular view")
+                    ));
                 }
                 if (sql.contains("FROM ALL_OBJECTS o")) {
                     return metadataStatement(List.of(
@@ -654,31 +686,6 @@ class DamengAgentMetadataTest {
                 throw new SQLException(message);
             }
             if ("close".equals(method.getName())) {
-                return null;
-            }
-            return defaultValue(method.getReturnType());
-        });
-    }
-
-    private static PreparedStatement materializedViewProbeStatement(String materializedViewName) {
-        List<String> params = new ArrayList<>();
-        return proxy(PreparedStatement.class, (method, args) -> {
-            String name = method.getName();
-            if ("setString".equals(name)) {
-                int index = ((Integer) args[0]) - 1;
-                while (params.size() <= index) {
-                    params.add("");
-                }
-                params.set(index, String.valueOf(args[1]));
-                return null;
-            }
-            if ("executeQuery".equals(name)) {
-                if (!params.isEmpty() && materializedViewName.equals(params.get(0))) {
-                    return metadataResultSet(List.of(List.of(1)));
-                }
-                throw new SQLException("not a materialized view");
-            }
-            if ("close".equals(name)) {
                 return null;
             }
             return defaultValue(method.getReturnType());

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -1,6 +1,7 @@
 package com.dbx.agent.dameng;
 
 import com.dbx.agent.ColumnInfo;
+import com.dbx.agent.MetadataListConstraints;
 import com.dbx.agent.ObjectInfo;
 import com.dbx.agent.ObjectSource;
 import com.dbx.agent.TableInfo;
@@ -17,6 +18,7 @@ import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -141,6 +143,39 @@ class DamengAgentMetadataTest {
         Assertions.assertTrue(views.stream().noneMatch(table -> "MATERIALIZED_VIEW".equals(table.getTable_type())));
         Assertions.assertTrue(views.stream().noneMatch(table -> "USER_SUMMARY_MV".equals(table.getName())));
         Assertions.assertEquals(List.of("USER_SUMMARY_MV"), materializedViews.stream().map(TableInfo::getName).toList());
+    }
+
+    @Test
+    void classifiesGrantedCrossOwnerViewsWithoutSystemCatalogAccess() {
+        DamengAgent agent = new DamengAgent();
+        List<String> sqls = new ArrayList<>();
+        TestSupport.setPrivateConnection(agent, restrictedCrossOwnerMetadataConnection(sqls));
+        setConnectedUsername(agent, "LIMITED_READER");
+        MetadataListConstraints constraints = new MetadataListConstraints(
+            null,
+            20,
+            null,
+            List.of("VIEW", "MATERIALIZED_VIEW")
+        );
+
+        List<TableInfo> tables = agent.listTables("REPORTING", constraints);
+        List<ObjectInfo> objects = agent.listObjects("REPORTING", constraints);
+
+        Assertions.assertEquals("VIEW", tables.stream()
+            .filter(table -> "SALES_VIEW".equals(table.getName()))
+            .findFirst().orElseThrow().getTable_type());
+        Assertions.assertEquals("MATERIALIZED_VIEW", tables.stream()
+            .filter(table -> "SALES_MV".equals(table.getName()))
+            .findFirst().orElseThrow().getTable_type());
+        Assertions.assertEquals("VIEW", objects.stream()
+            .filter(object -> "SALES_VIEW".equals(object.getName()))
+            .findFirst().orElseThrow().getObject_type());
+        Assertions.assertEquals("MATERIALIZED_VIEW", objects.stream()
+            .filter(object -> "SALES_MV".equals(object.getName()))
+            .findFirst().orElseThrow().getObject_type());
+        Assertions.assertTrue(sqls.stream().anyMatch(sql -> sql.contains("SYS.SYSOBJECTS materialized_view")));
+        Assertions.assertTrue(sqls.stream().anyMatch(sql -> sql.contains("DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW'")));
+        Assertions.assertTrue(sqls.stream().noneMatch(sql -> sql.contains("USER_MVIEWS")), String.join("\n", sqls));
     }
 
     @Test
@@ -584,6 +619,72 @@ class DamengAgentMetadataTest {
         });
     }
 
+    private static Connection restrictedCrossOwnerMetadataConnection(List<String> sqls) {
+        return proxy(Connection.class, (method, args) -> {
+            String name = method.getName();
+            if ("prepareStatement".equals(name)) {
+                String sql = (String) args[0];
+                sqls.add(sql);
+                if (sql.contains("SYS.SYSOBJECTS materialized_view")) {
+                    return failingMetadataStatement("no SYS.SYSOBJECTS privilege");
+                }
+                if (sql.contains("DBMS_METADATA.GET_DDL('MATERIALIZED_VIEW'")) {
+                    return materializedViewProbeStatement("SALES_MV");
+                }
+                if (sql.contains("FROM ALL_OBJECTS o")) {
+                    return metadataStatement(List.of(
+                        Arrays.asList("SALES_MV", "VIEW", "materialized view"),
+                        Arrays.asList("SALES_VIEW", "VIEW", "regular view")
+                    ));
+                }
+            }
+            if ("close".equals(name)) {
+                return null;
+            }
+            if ("isClosed".equals(name)) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static PreparedStatement failingMetadataStatement(String message) {
+        return proxy(PreparedStatement.class, (method, args) -> {
+            if ("executeQuery".equals(method.getName())) {
+                throw new SQLException(message);
+            }
+            if ("close".equals(method.getName())) {
+                return null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static PreparedStatement materializedViewProbeStatement(String materializedViewName) {
+        List<String> params = new ArrayList<>();
+        return proxy(PreparedStatement.class, (method, args) -> {
+            String name = method.getName();
+            if ("setString".equals(name)) {
+                int index = ((Integer) args[0]) - 1;
+                while (params.size() <= index) {
+                    params.add("");
+                }
+                params.set(index, String.valueOf(args[1]));
+                return null;
+            }
+            if ("executeQuery".equals(name)) {
+                if (!params.isEmpty() && materializedViewName.equals(params.get(0))) {
+                    return metadataResultSet(List.of(List.of(1)));
+                }
+                throw new SQLException("not a materialized view");
+            }
+            if ("close".equals(name)) {
+                return null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
     private static PreparedStatement metadataStatement(List<List<Object>> rows) {
         return metadataStatement(rows, null);
     }
@@ -628,6 +729,8 @@ class DamengAgentMetadataTest {
                     return value == null ? null : value.toString();
                 }
                 return switch (((String) args[0]).toUpperCase()) {
+                    case "TABLE_NAME", "OBJECT_NAME" -> string(rows, index[0], 0);
+                    case "TABLE_TYPE", "OBJECT_TYPE" -> string(rows, index[0], 1);
                     case "COLUMN_NAME" -> string(rows, index[0], 0);
                     case "DATA_TYPE" -> string(rows, index[0], 1);
                     case "NULLABLE" -> string(rows, index[0], 2);

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
@@ -116,6 +116,23 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
+    void privilegeSafeTableQueryFetchesRawViewsWithoutSystemCatalogOrPaging() {
+        DamengAgent.MetadataQuery query = DamengAgent.buildPrivilegeSafeConstrainedTablesQuery(
+            "REPORTING",
+            new MetadataListConstraints("sales", 20, 40, List.of("VIEW", "MATERIALIZED_VIEW"))
+        );
+
+        assertTrue(query.sql().contains("FROM ALL_OBJECTS o"));
+        assertFalse(query.sql().contains("SYS.SYSOBJECTS"));
+        assertFalse(query.sql().contains("USER_MVIEWS"));
+        assertTrue(query.sql().contains("o.OBJECT_TYPE IN (?, ?)"));
+        assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '\\\\'"));
+        assertFalse(query.sql().contains("LIMIT"));
+        assertFalse(query.sql().contains("OFFSET"));
+        assertEquals(List.of("REPORTING", "VIEW", "MATERIALIZED VIEW", "%S%A%L%E%S%"), query.args());
+    }
+
+    @Test
     void constrainedObjectQueryClassifiesMaterializedViewsBeforeFiltering() {
         DamengAgent.MetadataQuery query = DamengAgent.buildConstrainedObjectsQuery(
             "APP",

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
@@ -78,7 +78,10 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         );
 
         assertTrue(query.sql().contains("FROM ALL_OBJECTS o"));
-        assertTrue(query.sql().contains("o.OBJECT_TYPE IN (?, ?)"));
+        assertTrue(query.sql().contains("FROM USER_MVIEWS m"));
+        assertTrue(query.sql().contains("o.OBJECT_TYPE = 'MATERIALIZED VIEW'"));
+        assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
+        assertTrue(query.sql().contains("IN (?, ?)"));
         assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '\\\\'"));
         assertTrue(query.sql().endsWith("LIMIT ? OFFSET ?"));
         assertEquals(List.of("APP", "TABLE", "VIEW", "%O%R%D%", 50, 100), query.args());
@@ -92,7 +95,21 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         );
 
         assertTrue(query.sql().contains("MATERIALIZED_VIEW"));
-        assertEquals(List.of("APP", "MATERIALIZED VIEW", 20), query.args());
+        assertTrue(query.sql().contains("schema_object.OBJECT_ID = m.SCHID"));
+        assertEquals(List.of("APP", "MATERIALIZED_VIEW", 20), query.args());
+    }
+
+    @Test
+    void constrainedObjectQueryClassifiesMaterializedViewsBeforeFiltering() {
+        DamengAgent.MetadataQuery query = DamengAgent.buildConstrainedObjectsQuery(
+            "APP",
+            new MetadataListConstraints(null, 20, null, List.of("VIEW", "MATERIALIZED_VIEW"))
+        );
+
+        assertTrue(query.sql().contains("FROM USER_MVIEWS m"));
+        assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
+        assertTrue(query.sql().contains("WHEN 'MATERIALIZED_VIEW' THEN 2"));
+        assertEquals(List.of("APP", "VIEW", "MATERIALIZED_VIEW", 20), query.args());
     }
 
     @Test
@@ -102,7 +119,8 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
             new MetadataListConstraints("sync", 20, null, List.of("PROCEDURE", "FUNCTION"))
         );
 
-        assertTrue(query.sql().contains("o.OBJECT_TYPE IN (?, ?)"));
+        assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
+        assertTrue(query.sql().contains("IN (?, ?)"));
         assertTrue(query.sql().contains("WHEN 'PROCEDURE' THEN 3"));
         assertTrue(query.sql().endsWith("LIMIT ?"));
         assertEquals(List.of("APP", "PROCEDURE", "FUNCTION", "%S%Y%N%C%", 20), query.args());

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
@@ -116,20 +116,22 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
-    void privilegeSafeTableQueryFetchesRawViewsWithoutSystemCatalogOrPaging() {
-        DamengAgent.MetadataQuery query = DamengAgent.buildPrivilegeSafeConstrainedTablesQuery(
+    void accessibleTableQueryBulkClassifiesViewsAndPreservesPaging() {
+        DamengAgent.MetadataQuery query = DamengAgent.buildAccessibleConstrainedTablesQuery(
             "REPORTING",
             new MetadataListConstraints("sales", 20, 40, List.of("VIEW", "MATERIALIZED_VIEW"))
         );
 
         assertTrue(query.sql().contains("FROM ALL_OBJECTS o"));
+        assertTrue(query.sql().contains("FROM ALL_DEPENDENCIES"));
+        assertTrue(query.sql().contains("TYPE IN ('MATERIALIZED VIEW', 'MATERIALIZED_VIEW')"));
         assertFalse(query.sql().contains("SYS.SYSOBJECTS"));
         assertFalse(query.sql().contains("USER_MVIEWS"));
-        assertTrue(query.sql().contains("o.OBJECT_TYPE IN (?, ?)"));
+        assertFalse(query.sql().contains("DBMS_METADATA.GET_DDL"));
+        assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
         assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '\\\\'"));
-        assertFalse(query.sql().contains("LIMIT"));
-        assertFalse(query.sql().contains("OFFSET"));
-        assertEquals(List.of("REPORTING", "VIEW", "MATERIALIZED VIEW", "%S%A%L%E%S%"), query.args());
+        assertTrue(query.sql().endsWith("LIMIT ? OFFSET ?"));
+        assertEquals(List.of("REPORTING", "VIEW", "MATERIALIZED_VIEW", "%S%A%L%E%S%", 20, 40), query.args());
     }
 
     @Test
@@ -159,5 +161,22 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         assertTrue(query.sql().contains("WHEN 'PROCEDURE' THEN 3"));
         assertTrue(query.sql().endsWith("LIMIT ?"));
         assertEquals(List.of("APP", "PROCEDURE", "FUNCTION", "%S%Y%N%C%", 20), query.args());
+    }
+
+    @Test
+    void accessibleObjectQueryBulkClassifiesViewsAndPreservesPaging() {
+        DamengAgent.MetadataQuery query = DamengAgent.buildAccessibleConstrainedObjectsQuery(
+            "REPORTING",
+            new MetadataListConstraints("sales", 10, 30, List.of("VIEW", "MATERIALIZED_VIEW"))
+        );
+
+        assertTrue(query.sql().contains("FROM ALL_DEPENDENCIES"));
+        assertTrue(query.sql().contains("TYPE IN ('MATERIALIZED VIEW', 'MATERIALIZED_VIEW')"));
+        assertFalse(query.sql().contains("SYS.SYSOBJECTS"));
+        assertFalse(query.sql().contains("USER_MVIEWS"));
+        assertFalse(query.sql().contains("DBMS_METADATA.GET_DDL"));
+        assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
+        assertTrue(query.sql().endsWith("LIMIT ? OFFSET ?"));
+        assertEquals(List.of("REPORTING", "VIEW", "MATERIALIZED_VIEW", "%S%A%L%E%S%", 10, 30), query.args());
     }
 }

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
@@ -78,7 +78,8 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         );
 
         assertTrue(query.sql().contains("FROM ALL_OBJECTS o"));
-        assertTrue(query.sql().contains("FROM USER_MVIEWS m"));
+        assertTrue(query.sql().contains("FROM SYS.SYSOBJECTS materialized_view"));
+        assertTrue(query.sql().contains("schema_object.NAME AS OWNER"));
         assertTrue(query.sql().contains("o.OBJECT_TYPE = 'MATERIALIZED VIEW'"));
         assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
         assertTrue(query.sql().contains("IN (?, ?)"));
@@ -88,15 +89,30 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
-    void constrainedTableQueryMapsMaterializedViewTypeToDamengCatalogName() {
+    void constrainedTableQueryClassifiesMaterializedViewsForAnotherOwner() {
         DamengAgent.MetadataQuery query = DamengAgent.buildConstrainedTablesQuery(
-            "APP",
+            "REPORTING",
             new MetadataListConstraints(null, 20, null, List.of("MATERIALIZED_VIEW"))
         );
 
         assertTrue(query.sql().contains("MATERIALIZED_VIEW"));
-        assertTrue(query.sql().contains("schema_object.OBJECT_ID = m.SCHID"));
-        assertEquals(List.of("APP", "MATERIALIZED_VIEW", 20), query.args());
+        assertTrue(query.sql().contains("schema_object.ID = materialized_view.SCHID"));
+        assertTrue(query.sql().contains("mv.OWNER = o.OWNER"));
+        assertEquals(List.of("REPORTING", "MATERIALIZED_VIEW", 20), query.args());
+    }
+
+    @Test
+    void constrainedTableOnlyQuerySkipsMaterializedViewCatalog() {
+        DamengAgent.MetadataQuery query = DamengAgent.buildConstrainedTablesQuery(
+            "APP",
+            new MetadataListConstraints(null, 20, null, List.of("TABLE"))
+        );
+
+        assertFalse(query.sql().contains("SYS.SYSOBJECTS materialized_view"));
+        assertFalse(query.sql().contains("USER_MVIEWS"));
+        assertFalse(query.sql().contains("mv.MVIEW_NAME"));
+        assertTrue(query.sql().contains("o.OBJECT_TYPE IN (?)"));
+        assertEquals(List.of("APP", "TABLE", 20), query.args());
     }
 
     @Test
@@ -106,7 +122,7 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
             new MetadataListConstraints(null, 20, null, List.of("VIEW", "MATERIALIZED_VIEW"))
         );
 
-        assertTrue(query.sql().contains("FROM USER_MVIEWS m"));
+        assertTrue(query.sql().contains("FROM SYS.SYSOBJECTS materialized_view"));
         assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
         assertTrue(query.sql().contains("WHEN 'MATERIALIZED_VIEW' THEN 2"));
         assertEquals(List.of("APP", "VIEW", "MATERIALIZED_VIEW", 20), query.args());
@@ -119,8 +135,10 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
             new MetadataListConstraints("sync", 20, null, List.of("PROCEDURE", "FUNCTION"))
         );
 
-        assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
-        assertTrue(query.sql().contains("IN (?, ?)"));
+        assertFalse(query.sql().contains("SYS.SYSOBJECTS materialized_view"));
+        assertFalse(query.sql().contains("USER_MVIEWS"));
+        assertFalse(query.sql().contains("mv.MVIEW_NAME"));
+        assertTrue(query.sql().contains("o.OBJECT_TYPE IN (?, ?)"));
         assertTrue(query.sql().contains("WHEN 'PROCEDURE' THEN 3"));
         assertTrue(query.sql().endsWith("LIMIT ?"));
         assertEquals(List.of("APP", "PROCEDURE", "FUNCTION", "%S%Y%N%C%", 20), query.args());


### PR DESCRIPTION
## 问题

达梦物化视图会记录在 USER_MVIEWS 中，但当前测试版本的 ALL_OBJECTS 和 ALL_TAB_COMMENTS 仍将其标记为 VIEW。

原有非分页元数据路径会通过 USER_MVIEWS 将物化视图与普通视图区分开；v0.5.56 包含的分页元数据优化改为直接按 ALL_OBJECTS.OBJECT_TYPE 过滤，绕过了达梦专用分类逻辑，导致物化视图进入普通视图分组。后续查看源码时会按 VIEW 调用 DBMS_METADATA.GET_DDL，从而报对象不存在。

## 修复

- 通过 USER_MVIEWS.SCHID 和 schema 对象识别物化视图
- listTables 和 listObjects 均先重分类，再进行类型过滤、排序和分页
- 兼容目录直接返回 MATERIALIZED VIEW 的达梦版本
- 不修改 Agent 版本号

## 验证

- 使用真实 DM8 创建 DBX_TEST.ISSUE_3418_MV 复现
- 普通视图列表仅返回 V_CITY_SALES
- 物化视图列表仅返回 ISSUE_3418_MV，类型为 MATERIALIZED_VIEW
- 对象列表能同时返回正确分类的 VIEW 和 MATERIALIZED_VIEW
- get_object_source 能成功返回完整 CREATE MATERIALIZED VIEW DDL
- ./gradlew :dameng:check：33 项测试通过

Fixes #3418