### PR TITLE
fix(linux): 修复 Nouveau 驱动下界面黑屏

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,14 +185,22 @@ enum LinuxNvidiaDriver {
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LinuxDrmRenderDevice {
+    device_file: std::path::PathBuf,
+    driver: Option<String>,
+    boot_vga: bool,
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn linux_nvidia_driver_from_state(
     proprietary_control_exists: bool,
     proprietary_proc_exists: bool,
-    nouveau_module_loaded: bool,
+    render_driver: Option<&str>,
 ) -> LinuxNvidiaDriver {
     if proprietary_control_exists || proprietary_proc_exists {
         LinuxNvidiaDriver::Proprietary
-    } else if nouveau_module_loaded {
+    } else if render_driver.is_some_and(|driver| driver.eq_ignore_ascii_case("nouveau")) {
         LinuxNvidiaDriver::Nouveau
     } else {
         LinuxNvidiaDriver::None
@@ -200,11 +208,63 @@ fn linux_nvidia_driver_from_state(
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_selected_drm_render_device<'a>(
+    explicit_device_file: Option<&std::path::Path>,
+    devices: &'a [LinuxDrmRenderDevice],
+) -> Option<&'a LinuxDrmRenderDevice> {
+    if let Some(explicit_device_file) = explicit_device_file {
+        // WebKit gives this environment override precedence over EGL/DRM discovery.
+        return devices.iter().find(|device| device.device_file.as_path() == explicit_device_file);
+    }
+    // Before WebKit initializes EGL, boot_vga is the best available default-display signal.
+    // The sorted first render node mirrors WebKit's final DRM-device fallback.
+    devices.iter().find(|device| device.boot_vga).or_else(|| devices.first())
+}
+
+#[cfg(target_os = "linux")]
+fn linux_drm_render_devices() -> Vec<LinuxDrmRenderDevice> {
+    let Ok(entries) = std::fs::read_dir("/sys/class/drm") else {
+        return Vec::new();
+    };
+    let mut devices = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let node_name = entry.file_name();
+            let node_name = node_name.to_str()?;
+            let render_index = node_name.strip_prefix("renderD")?;
+            if render_index.is_empty() || !render_index.bytes().all(|byte| byte.is_ascii_digit()) {
+                return None;
+            }
+            let device_path = entry.path().join("device");
+            let driver = std::fs::read_link(device_path.join("driver"))
+                .ok()
+                .and_then(|path| path.file_name().and_then(std::ffi::OsStr::to_str).map(str::to_ascii_lowercase));
+            let boot_vga = std::fs::read_to_string(device_path.join("boot_vga")).is_ok_and(|value| value.trim() == "1");
+            Some(LinuxDrmRenderDevice {
+                device_file: std::path::Path::new("/dev/dri").join(node_name),
+                driver,
+                boot_vga,
+            })
+        })
+        .collect::<Vec<_>>();
+    devices.sort_by(|left, right| left.device_file.cmp(&right.device_file));
+    devices
+}
+
+#[cfg(target_os = "linux")]
 fn linux_nvidia_driver() -> LinuxNvidiaDriver {
+    let devices = linux_drm_render_devices();
+    let explicit_device_file = std::env::var_os("WEBKIT_WEB_RENDER_DEVICE_FILE")
+        .filter(|path| !path.is_empty())
+        .map(std::path::PathBuf::from)
+        // Resolve stable /dev/dri/by-path links to the renderD* node used by sysfs.
+        .map(|path| std::fs::canonicalize(&path).unwrap_or(path));
+    let render_driver = linux_selected_drm_render_device(explicit_device_file.as_deref(), &devices)
+        .and_then(|device| device.driver.as_deref());
     linux_nvidia_driver_from_state(
         std::path::Path::new("/dev/nvidiactl").exists(),
         std::path::Path::new("/proc/driver/nvidia/version").exists(),
-        std::path::Path::new("/sys/module/nouveau").exists(),
+        render_driver,
     )
 }
 
@@ -530,11 +590,13 @@ pub(crate) fn apply_desktop_settings(app: &tauri::AppHandle, desktop_settings: &
 mod tests {
     use super::{
         linux_appimage_system_gtk_immodules_cache, linux_appimage_wayland_backend_override,
-        linux_nvidia_driver_from_state, linux_webkit_rendering_workarounds, native_window_decorations_override,
-        should_confirm_app_exit_request, should_hide_window_on_close, should_setup_desktop_tray,
-        should_show_main_window_after_setup, uses_application_level_icon, LinuxNvidiaDriver,
+        linux_nvidia_driver_from_state, linux_selected_drm_render_device, linux_webkit_rendering_workarounds,
+        native_window_decorations_override, should_confirm_app_exit_request, should_hide_window_on_close,
+        should_setup_desktop_tray, should_show_main_window_after_setup, uses_application_level_icon,
+        LinuxDrmRenderDevice, LinuxNvidiaDriver,
     };
     use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
 
     const TEST_GTK3_IMMODULES_CACHE: &str = "/usr/lib/test/gtk-3.0/3.0.0/immodules.cache";
 
@@ -613,12 +675,68 @@ mod tests {
     }
 
     #[test]
-    fn detects_loaded_linux_nvidia_driver() {
-        assert_eq!(linux_nvidia_driver_from_state(true, false, false), LinuxNvidiaDriver::Proprietary);
-        assert_eq!(linux_nvidia_driver_from_state(false, true, false), LinuxNvidiaDriver::Proprietary);
-        assert_eq!(linux_nvidia_driver_from_state(true, false, true), LinuxNvidiaDriver::Proprietary);
-        assert_eq!(linux_nvidia_driver_from_state(false, false, true), LinuxNvidiaDriver::Nouveau);
-        assert_eq!(linux_nvidia_driver_from_state(false, false, false), LinuxNvidiaDriver::None);
+    fn classifies_linux_nvidia_driver_from_selected_renderer() {
+        assert_eq!(linux_nvidia_driver_from_state(true, false, None), LinuxNvidiaDriver::Proprietary);
+        assert_eq!(linux_nvidia_driver_from_state(false, true, None), LinuxNvidiaDriver::Proprietary);
+        assert_eq!(linux_nvidia_driver_from_state(true, false, Some("nouveau")), LinuxNvidiaDriver::Proprietary);
+        assert_eq!(linux_nvidia_driver_from_state(false, false, Some("nouveau")), LinuxNvidiaDriver::Nouveau);
+        assert_eq!(linux_nvidia_driver_from_state(false, false, Some("i915")), LinuxNvidiaDriver::None);
+        assert_eq!(linux_nvidia_driver_from_state(false, false, Some("amdgpu")), LinuxNvidiaDriver::None);
+        assert_eq!(linux_nvidia_driver_from_state(false, false, None), LinuxNvidiaDriver::None);
+    }
+
+    fn drm_render_device(path: &str, driver: &str, boot_vga: bool) -> LinuxDrmRenderDevice {
+        LinuxDrmRenderDevice { device_file: PathBuf::from(path), driver: Some(driver.to_string()), boot_vga }
+    }
+
+    #[test]
+    fn keeps_linux_dmabuf_when_nouveau_is_loaded_but_not_the_default_renderer() {
+        let devices = [
+            drm_render_device("/dev/dri/renderD128", "i915", true),
+            drm_render_device("/dev/dri/renderD129", "nouveau", false),
+        ];
+
+        let selected = linux_selected_drm_render_device(None, &devices).unwrap();
+        assert_eq!(selected.driver.as_deref(), Some("i915"));
+        assert_eq!(linux_nvidia_driver_from_state(false, false, selected.driver.as_deref()), LinuxNvidiaDriver::None);
+    }
+
+    #[test]
+    fn honors_explicit_webkit_linux_render_device_on_hybrid_gpus() {
+        let devices = [
+            drm_render_device("/dev/dri/renderD128", "i915", true),
+            drm_render_device("/dev/dri/renderD129", "nouveau", false),
+        ];
+
+        let selected = linux_selected_drm_render_device(Some(Path::new("/dev/dri/renderD129")), &devices).unwrap();
+        assert_eq!(selected.driver.as_deref(), Some("nouveau"));
+        assert_eq!(
+            linux_nvidia_driver_from_state(false, false, selected.driver.as_deref()),
+            LinuxNvidiaDriver::Nouveau
+        );
+
+        let devices = [
+            drm_render_device("/dev/dri/renderD128", "i915", false),
+            drm_render_device("/dev/dri/renderD129", "nouveau", true),
+        ];
+        let selected = linux_selected_drm_render_device(Some(Path::new("/dev/dri/renderD128")), &devices).unwrap();
+        assert_eq!(selected.driver.as_deref(), Some("i915"));
+        assert_eq!(linux_nvidia_driver_from_state(false, false, selected.driver.as_deref()), LinuxNvidiaDriver::None);
+    }
+
+    #[test]
+    fn uses_nouveau_workaround_for_the_default_linux_renderer() {
+        let devices = [
+            drm_render_device("/dev/dri/renderD128", "amdgpu", false),
+            drm_render_device("/dev/dri/renderD129", "nouveau", true),
+        ];
+
+        let selected = linux_selected_drm_render_device(None, &devices).unwrap();
+        assert_eq!(selected.driver.as_deref(), Some("nouveau"));
+        assert_eq!(
+            linux_nvidia_driver_from_state(false, false, selected.driver.as_deref()),
+            LinuxNvidiaDriver::Nouveau
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -177,26 +177,55 @@ fn build_app_menu<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) -> tauri:
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn linux_has_nvidia_gpu() -> bool {
-    // Detect the proprietary NVIDIA driver by checking for its kernel device
-    // node / proc entry. This is more reliable than parsing lspci output and
-    // has no external deps. Nouveau (open-source) does not create these nodes
-    // and falls through to the Mesa / DMABuf path, which is the desired behavior.
-    std::path::Path::new("/dev/nvidiactl").exists() || std::path::Path::new("/proc/driver/nvidia/version").exists()
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LinuxNvidiaDriver {
+    None,
+    Nouveau,
+    Proprietary,
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn linux_webkit_rendering_workarounds(has_nvidia: bool) -> &'static [(&'static str, &'static str)] {
-    if has_nvidia {
-        // NVIDIA + Wayland: the DMABuf renderer triggers blank-window / Wayland
-        // protocol errors (EGL_EXT_image_dma_buf_import mismatch). Disable it
-        // and suppress explicit-sync to avoid a compositor crash.
-        &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1"), ("__NV_DISABLE_EXPLICIT_SYNC", "1")]
+fn linux_nvidia_driver_from_state(
+    proprietary_control_exists: bool,
+    proprietary_proc_exists: bool,
+    nouveau_module_loaded: bool,
+) -> LinuxNvidiaDriver {
+    if proprietary_control_exists || proprietary_proc_exists {
+        LinuxNvidiaDriver::Proprietary
+    } else if nouveau_module_loaded {
+        LinuxNvidiaDriver::Nouveau
     } else {
-        // AMD / Intel / other Mesa drivers support DMABuf natively.
-        // Keeping DMABUF enabled lets WebKitGTK use GPU compositing, which
-        // dramatically reduces CPU usage and eliminates UI lag on Wayland.
-        &[]
+        LinuxNvidiaDriver::None
+    }
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_nvidia_driver() -> LinuxNvidiaDriver {
+    linux_nvidia_driver_from_state(
+        std::path::Path::new("/dev/nvidiactl").exists(),
+        std::path::Path::new("/proc/driver/nvidia/version").exists(),
+        std::path::Path::new("/sys/module/nouveau").exists(),
+    )
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_webkit_rendering_workarounds(driver: LinuxNvidiaDriver) -> &'static [(&'static str, &'static str)] {
+    match driver {
+        LinuxNvidiaDriver::Proprietary => {
+            // NVIDIA's proprietary driver needs both DMABuf and explicit-sync
+            // workarounds to avoid blank windows and compositor failures.
+            &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1"), ("__NV_DISABLE_EXPLICIT_SYNC", "1")]
+        }
+        LinuxNvidiaDriver::Nouveau => {
+            // WebKitGTK's DMABuf renderer can produce a fully black WebView on
+            // Nouveau while the DOM remains interactive.
+            &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
+        }
+        LinuxNvidiaDriver::None => {
+            // AMD / Intel and other Mesa drivers keep DMABuf enabled to avoid
+            // unnecessary CPU usage and UI lag on Wayland.
+            &[]
+        }
     }
 }
 
@@ -258,8 +287,7 @@ fn linux_appimage_system_gtk_immodules_cache(
 
 #[cfg(target_os = "linux")]
 fn apply_linux_webkit_rendering_workarounds() {
-    let has_nvidia = linux_has_nvidia_gpu();
-    for (key, value) in linux_webkit_rendering_workarounds(has_nvidia) {
+    for (key, value) in linux_webkit_rendering_workarounds(linux_nvidia_driver()) {
         if std::env::var_os(key).is_none() {
             std::env::set_var(key, value);
         }
@@ -502,9 +530,9 @@ pub(crate) fn apply_desktop_settings(app: &tauri::AppHandle, desktop_settings: &
 mod tests {
     use super::{
         linux_appimage_system_gtk_immodules_cache, linux_appimage_wayland_backend_override,
-        linux_webkit_rendering_workarounds, native_window_decorations_override, should_confirm_app_exit_request,
-        should_hide_window_on_close, should_setup_desktop_tray, should_show_main_window_after_setup,
-        uses_application_level_icon,
+        linux_nvidia_driver_from_state, linux_webkit_rendering_workarounds, native_window_decorations_override,
+        should_confirm_app_exit_request, should_hide_window_on_close, should_setup_desktop_tray,
+        should_show_main_window_after_setup, uses_application_level_icon, LinuxNvidiaDriver,
     };
     use std::ffi::OsStr;
 
@@ -585,14 +613,25 @@ mod tests {
     }
 
     #[test]
-    fn applies_linux_webkit_rendering_workarounds_before_webkit_starts() {
-        // NVIDIA: DMABuf must be disabled to avoid blank window / Wayland protocol errors.
+    fn detects_loaded_linux_nvidia_driver() {
+        assert_eq!(linux_nvidia_driver_from_state(true, false, false), LinuxNvidiaDriver::Proprietary);
+        assert_eq!(linux_nvidia_driver_from_state(false, true, false), LinuxNvidiaDriver::Proprietary);
+        assert_eq!(linux_nvidia_driver_from_state(true, false, true), LinuxNvidiaDriver::Proprietary);
+        assert_eq!(linux_nvidia_driver_from_state(false, false, true), LinuxNvidiaDriver::Nouveau);
+        assert_eq!(linux_nvidia_driver_from_state(false, false, false), LinuxNvidiaDriver::None);
+    }
+
+    #[test]
+    fn applies_driver_specific_linux_webkit_rendering_workarounds() {
         assert_eq!(
-            linux_webkit_rendering_workarounds(true),
+            linux_webkit_rendering_workarounds(LinuxNvidiaDriver::Proprietary),
             &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1"), ("__NV_DISABLE_EXPLICIT_SYNC", "1")]
         );
-        // AMD / Intel / Mesa: DMABuf is supported — no workarounds needed.
-        assert_eq!(linux_webkit_rendering_workarounds(false), &[]);
+        assert_eq!(
+            linux_webkit_rendering_workarounds(LinuxNvidiaDriver::Nouveau),
+            &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
+        );
+        assert_eq!(linux_webkit_rendering_workarounds(LinuxNvidiaDriver::None), &[]);
     }
 
     #[test]


### PR DESCRIPTION
## 背景

Issue #3406 用户在 Debian 13.6、NVIDIA GeForce GT 520 + Nouveau、X11 环境中启动 DBX 后界面全黑，但 DOM 仍可交互。deb 和 AppImage 均可复现。

用户验证设置 `WEBKIT_DISABLE_DMABUF_RENDERER=1` 后可以正常显示，确认问题来自 WebKitGTK 的 DMABUF 渲染路径。

## 根因

现有 Linux 启动兼容逻辑仅通过 NVIDIA 专有驱动的设备节点判断是否关闭 DMABUF，没有覆盖 Nouveau；直接改为检查 Nouveau 内核模块又会误伤混合显卡环境，因为模块已加载不代表 WebKit 正在该设备上渲染。

## 改动

- 区分 NVIDIA 专有驱动、Nouveau 和非 NVIDIA 渲染设备
- 从 `/sys/class/drm/renderD*` 读取 render node 对应的实际驱动
- 优先尊重 `WEBKIT_WEB_RENDER_DEVICE_FILE`，并解析 `/dev/dri/by-path` 等符号链接
- 未显式配置时选择 `boot_vga` 主显示设备；无主显示标记时按 WebKit 的 DRM 回退方式选择首个 render node
- 仅当 WebKit 选中的渲染设备使用 Nouveau 时设置 `WEBKIT_DISABLE_DMABUF_RENDERER=1`
- NVIDIA 专有驱动继续保留原有 DMABUF 和 explicit-sync 兼容变量

## 安全性

- 不根据 Nouveau 模块是否加载全局关闭 DMABUF
- Intel/AMD 主显卡 + Nouveau 独显的混合环境保持硬件渲染
- 显式选择 Intel/AMD render node 时，即使默认设备为 Nouveau 也不应用兼容变量
- 显式选择 Nouveau 或 Nouveau 为默认渲染设备时才关闭 DMABUF
- `__NV_DISABLE_EXPLICIT_SYNC` 仍仅用于 NVIDIA 专有驱动
- 保留用户已显式设置环境变量时不覆盖的现有行为

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p dbx --no-default-features linux_`：8/8 通过
- `cargo test -p dbx --no-default-features`：93/93 通过
- `cargo clippy -p dbx --locked --all-targets --no-default-features`

覆盖场景包括：

- Nouveau 为默认渲染设备
- Nouveau 已加载但 Intel 为默认渲染设备
- 显式选择 Nouveau render node
- Nouveau 为默认设备但显式选择 Intel render node
- AMD/Intel 渲染设备保持 DMABUF

Fixes #3406