### PR TITLE
Fix：修复 GBase 8a 离线驱动被误判未安装

### DIFF
--- a/apps/desktop/src/lib/connection/agentDriverInstallHint.ts
+++ b/apps/desktop/src/lib/connection/agentDriverInstallHint.ts
@@ -11,6 +11,7 @@ export function agentDriverInstallKey(dbType: DatabaseType | undefined, driverPr
   if (dbType === "oracle") return "oracle";
   if (dbType === "mongodb") return "mongodb";
   if (dbType === "dameng") return "dameng";
+  if (dbType === "gbase") return driverProfile === "gbase8s" ? "gbase8s" : "gbase8a";
   if (dbType === "mq") return driverProfile === "kafka" ? "kafka" : undefined;
   return driverProfile && driverProfile !== dbType ? driverProfile : dbType;
 }

--- a/packages/app-tests/agentDriverInstallHint.test.ts
+++ b/packages/app-tests/agentDriverInstallHint.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { appendAgentDriverUpdateHint, hasAgentDriverUpdate, showAgentDriverInstallHint } from "../../apps/desktop/src/lib/connection/agentDriverInstallHint.ts";
+import { agentDriverInstallKey, appendAgentDriverUpdateHint, hasAgentDriverUpdate, showAgentDriverInstallHint } from "../../apps/desktop/src/lib/connection/agentDriverInstallHint.ts";
 
 test("hides the agent driver install hint when the selected driver is installed", () => {
   assert.equal(showAgentDriverInstallHint("informix", [{ db_type: "informix", installed: true }]), false);
@@ -29,7 +29,25 @@ test("uses the unified Oracle driver for legacy Oracle profiles", () => {
   assert.equal(showAgentDriverInstallHint("oracle", [{ db_type: "oracle", installed: false }], "oracle"), true);
 });
 
-test("uses selected non-Oracle agent driver profiles for install hints", () => {
+test("uses the GBase 8a agent for generic, missing, and explicit 8a profiles", () => {
+  const drivers = [
+    { db_type: "gbase8a", installed: true },
+    { db_type: "gbase8s", installed: false },
+  ];
+
+  assert.equal(showAgentDriverInstallHint("gbase", drivers), false);
+  assert.equal(showAgentDriverInstallHint("gbase", drivers, "gbase"), false);
+  assert.equal(showAgentDriverInstallHint("gbase", drivers, "gbase8a"), false);
+});
+
+test("maps GBase profiles to their matching agent driver keys", () => {
+  assert.equal(agentDriverInstallKey("gbase"), "gbase8a");
+  assert.equal(agentDriverInstallKey("gbase", "gbase"), "gbase8a");
+  assert.equal(agentDriverInstallKey("gbase", "gbase8a"), "gbase8a");
+  assert.equal(agentDriverInstallKey("gbase", "gbase8s"), "gbase8s");
+});
+
+test("uses the selected GBase 8s agent for install hints", () => {
   assert.equal(
     showAgentDriverInstallHint(
       "gbase",


### PR DESCRIPTION
Related to #1007

## 问题

新建 GBase 连接时，界面默认选择 GBase 8a，但内部保留通用 profile gbase。

后端运行层会将该 profile 回退到 gbase8a，因此“选择显示数据库”可以正常连接；前端测试连接和保存前的驱动检查却按 gbase 查找 Agent。线上 registry 只有 gbase8a 和 gbase8s，导致已经通过离线包安装的 GBase 8a 驱动仍被误判为未安装，并尝试在线下载。

## 修复

- 将 GBase 通用、缺省及显式 gbase8a profile 统一映射到 gbase8a Agent
- 保持显式 gbase8s profile 映射到 gbase8s
- 不修改已有连接配置格式，不迁移用户数据，也不改动 Agent 后端和数据库连接逻辑
- 补充 GBase 8a/8s 驱动键、安装提示的回归测试

issue 同时包含华为 MRS-CK 需求，因此这里只关联 #1007，不自动关闭 issue。

## 验证

- pnpm vitest run packages/app-tests/agentDriverInstallHint.test.ts
- pnpm check
- pnpm build
- 使用已安装的 GBase 8a Agent 0.1.26 连接真实 GBase 8a 8.6.2.43-R7 实例，test_connection 返回 ok
- 实例 orders_10k 表 10000 行验证通过；测试后已关闭 Agent，并将测试容器恢复为原来的停止状态