### PR TITLE
feat: support Oracle trigger editing in table structure editor

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -2062,7 +2062,7 @@ function canDropIndex(index: EditableStructureIndex): boolean {
 }
 
 const canEditForeignKeys = computed(() => structureCapabilities.value.foreignKey);
-const canEditMysqlTriggers = computed(() => structureDialect.value === "mysql");
+const canEditTriggers = computed(() => structureDialect.value === "mysql" || structureDialect.value === "oracle");
 
 function generatedForeignKeyName(column = ""): string {
   const table = structureIndexTableName() || "table";
@@ -2110,7 +2110,7 @@ function canEditForeignKeyDraft(foreignKey: EditableStructureForeignKey): boolea
 }
 
 function addTrigger() {
-  if (!canEditMysqlTriggers.value || triggersLoading.value) return;
+  if (!canEditTriggers.value || triggersLoading.value) return;
   activeTab.value = "triggers";
   triggers.value.push({
     id: `new:${uuid()}`,
@@ -2132,7 +2132,7 @@ function toggleDropTrigger(trigger: EditableStructureTrigger) {
 }
 
 function canEditTriggerDraft(trigger: EditableStructureTrigger): boolean {
-  return !triggersLoading.value && canEditMysqlTriggers.value && !trigger.markedForDrop;
+  return !triggersLoading.value && canEditTriggers.value && !trigger.markedForDrop;
 }
 
 function primarySqlOperation(sql: string): string {
@@ -2265,7 +2265,7 @@ function addItemForActiveTab(): boolean {
     addForeignKey();
     return true;
   }
-  if (activeTab.value === "triggers" && canEditMysqlTriggers.value) {
+  if (activeTab.value === "triggers" && canEditTriggers.value) {
     addTrigger();
     return true;
   }
@@ -2609,7 +2609,7 @@ watch([activeTab, ddlLoading], ([tab, loading]) => {
                 <Plus :class="structureIconClass" />
                 {{ t("structureEditor.addForeignKey") }}
               </Button>
-              <Button v-if="activeTab === 'triggers'" size="sm" :class="structureToolbarButtonClass" :disabled="!canEditMysqlTriggers || triggersLoading" @click="addTrigger">
+              <Button v-if="activeTab === 'triggers'" size="sm" :class="structureToolbarButtonClass" :disabled="!canEditTriggers || triggersLoading" @click="addTrigger">
                 <Plus :class="structureIconClass" />
                 {{ t("structureEditor.addTrigger") }}
               </Button>

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -2703,6 +2703,69 @@ fn builds_mysql_trigger_changes() {
 }
 
 #[test]
+fn builds_oracle_trigger_changes() {
+    let mut existing = trigger("orders_bu", "BEFORE", "UPDATE", "BEGIN\n  :NEW.updated_at := SYSTIMESTAMP;\nEND");
+    existing.original = Some(TriggerInfo {
+        name: "orders_bu".to_string(),
+        event: "UPDATE".to_string(),
+        timing: "BEFORE".to_string(),
+        statement: Some("BEGIN\n  :NEW.updated_at := CURRENT_TIMESTAMP;\nEND".to_string()),
+    });
+
+    let result = build_table_structure_change_sql(TableStructureSqlOptions {
+        database_type: Some(DatabaseType::Oracle),
+        schema: Some("APP".to_string()),
+        table_name: "orders".to_string(),
+        columns: Vec::new(),
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        triggers: vec![existing],
+        table_comment: None,
+        original_table_comment: None,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(
+        result.statements,
+        vec![
+            "CREATE OR REPLACE TRIGGER \"APP\".\"orders_bu\" BEFORE UPDATE ON \"APP\".\"orders\" FOR EACH ROW\nBEGIN\n  :NEW.updated_at := SYSTIMESTAMP;\nEND;",
+        ]
+    );
+}
+
+#[test]
+fn drops_oracle_trigger_when_renamed() {
+    let mut existing = trigger("orders_audit_bu", "BEFORE", "UPDATE", "BEGIN\n  NULL;\nEND");
+    existing.original = Some(TriggerInfo {
+        name: "orders_bu".to_string(),
+        event: "UPDATE".to_string(),
+        timing: "BEFORE".to_string(),
+        statement: Some("BEGIN\n  NULL;\nEND".to_string()),
+    });
+
+    let result = build_table_structure_change_sql(TableStructureSqlOptions {
+        database_type: Some(DatabaseType::Oracle),
+        schema: Some("APP".to_string()),
+        table_name: "orders".to_string(),
+        columns: Vec::new(),
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        triggers: vec![existing],
+        table_comment: None,
+        original_table_comment: None,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(
+        result.statements,
+        vec![
+            "DROP TRIGGER \"APP\".\"orders_bu\";",
+            "CREATE OR REPLACE TRIGGER \"APP\".\"orders_audit_bu\" BEFORE UPDATE ON \"APP\".\"orders\" FOR EACH ROW\nBEGIN\n  NULL;\nEND;",
+        ]
+    );
+}
+
+#[test]
 fn mysql_varchar_default_is_quoted() {
     let mut col = column("name");
     col.data_type = "varchar(255)".to_string();

--- a/crates/dbx-core/src/table_structure_sql/triggers.rs
+++ b/crates/dbx-core/src/table_structure_sql/triggers.rs
@@ -7,19 +7,20 @@ pub(super) fn build_trigger_sql(options: &TableStructureSqlOptions, warnings: &m
         return Vec::new();
     }
 
+    let dialect = super::dialect::capabilities_for(options.database_type).dialect;
     let database_label = database_label(options.database_type);
-    if super::dialect::capabilities_for(options.database_type).dialect != StructureDialect::Mysql {
+    if !matches!(dialect, StructureDialect::Mysql | StructureDialect::Oracle) {
         warnings.push(format!("Editing triggers is not supported for {database_label} from this editor."));
         return Vec::new();
     }
 
-    let table = qualified_table(StructureDialect::Mysql, options.schema.as_deref(), &options.table_name);
+    let table = qualified_table(dialect, options.schema.as_deref(), &options.table_name);
     let mut statements = Vec::new();
 
     for trigger in &options.triggers {
         if trigger.marked_for_drop {
             if let Some(original) = &trigger.original {
-                statements.push(drop_trigger_sql(options.schema.as_deref(), &original.name));
+                statements.push(drop_trigger_sql(dialect, options.schema.as_deref(), &original.name));
             }
             continue;
         }
@@ -28,10 +29,12 @@ pub(super) fn build_trigger_sql(options: &TableStructureSqlOptions, warnings: &m
             if !has_trigger_change(trigger, original) {
                 continue;
             }
-            statements.push(drop_trigger_sql(options.schema.as_deref(), &original.name));
+            if dialect != StructureDialect::Oracle || clean(&trigger.name) != clean(&original.name) {
+                statements.push(drop_trigger_sql(dialect, options.schema.as_deref(), &original.name));
+            }
         }
 
-        if let Some(sql) = create_trigger_sql(&table, trigger, warnings) {
+        if let Some(sql) = create_trigger_sql(dialect, options.schema.as_deref(), &table, trigger, warnings) {
             statements.push(sql);
         }
     }
@@ -46,20 +49,22 @@ fn has_trigger_change(trigger: &EditableStructureTrigger, original: &TriggerInfo
         || normalize_statement(&trigger.statement) != normalize_statement(original.statement.as_deref().unwrap_or(""))
 }
 
-fn drop_trigger_sql(schema: Option<&str>, name: &str) -> String {
+fn drop_trigger_sql(dialect: StructureDialect, schema: Option<&str>, name: &str) -> String {
     let qualified_name = if schema.is_some_and(|schema| !schema.trim().is_empty()) {
-        format!(
-            "{}.{}",
-            quote_ident(StructureDialect::Mysql, schema.unwrap()),
-            quote_ident(StructureDialect::Mysql, name)
-        )
+        format!("{}.{}", quote_ident(dialect, schema.unwrap()), quote_ident(dialect, name))
     } else {
-        quote_ident(StructureDialect::Mysql, name)
+        quote_ident(dialect, name)
     };
     format!("DROP TRIGGER {qualified_name};")
 }
 
-fn create_trigger_sql(table: &str, trigger: &EditableStructureTrigger, warnings: &mut Vec<String>) -> Option<String> {
+fn create_trigger_sql(
+    dialect: StructureDialect,
+    schema: Option<&str>,
+    table: &str,
+    trigger: &EditableStructureTrigger,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
     let name = clean(&trigger.name);
     let timing = normalize_keyword(&trigger.timing);
     let event = normalize_keyword(&trigger.event);
@@ -78,9 +83,18 @@ fn create_trigger_sql(table: &str, trigger: &EditableStructureTrigger, warnings:
         return None;
     }
 
+    let create_keyword =
+        if dialect == StructureDialect::Oracle { "CREATE OR REPLACE TRIGGER" } else { "CREATE TRIGGER" };
+    let trigger_name = if dialect == StructureDialect::Oracle && schema.is_some_and(|schema| !schema.trim().is_empty())
+    {
+        format!("{}.{}", quote_ident(dialect, schema.unwrap()), quote_ident(dialect, &name))
+    } else {
+        quote_ident(dialect, &name)
+    };
+
     Some(format!(
-        "CREATE TRIGGER {} {timing} {event} ON {table} FOR EACH ROW\n{};",
-        quote_ident(StructureDialect::Mysql, &name),
+        "{create_keyword} {} {timing} {event} ON {table} FOR EACH ROW\n{};",
+        trigger_name,
         statement.trim_end_matches(';').trim_end()
     ))
 }


### PR DESCRIPTION
## 变更说明

  前端允许 Oracle 进入触发器编辑：apps/desktop/src/components/structure/TableStructureEditor.vue:2065
  后端支持 Oracle trigger DDL：crates/dbx-core/src/table_structure_sql/triggers.rs:12
      - MySQL 行为保持不变：DROP TRIGGER + CREATE TRIGGER
      - Oracle 使用 CREATE OR REPLACE TRIGGER
      - Oracle 改名时先 DROP TRIGGER "schema"."old_name"
      - Oracle 创建时也限定 schema：CREATE OR REPLACE TRIGGER "schema"."trigger_name" ... ON "schema"."table"

  - 补了两个 Oracle 测试：crates/dbx-core/src/table_structure_sql/tests.rs:2706

## 变更类型

- [ x ] 新功能

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
