### PR TITLE
fix(ai): pass system proxy and valid reasoning effort to Codex CLI

### DIFF
--- a/crates/dbx-core/src/ai_cli_agent.rs
+++ b/crates/dbx-core/src/ai_cli_agent.rs
@@ -203,7 +203,7 @@ fn parse_codex_jsonl_line(line: &str) -> ParsedCliAgentEvent {
         "item.started" => parse_codex_item_started(&value),
         "item.completed" => parse_codex_item_completed(&value),
         "turn.completed" => parse_codex_turn_completed(&value),
-        "turn.failed" | "error" => {
+        "turn.failed" => {
             let message = codex_error_message(&value);
             ParsedCliAgentEvent {
                 error: Some(message.clone()),
@@ -211,8 +211,24 @@ fn parse_codex_jsonl_line(line: &str) -> ParsedCliAgentEvent {
                 ..Default::default()
             }
         }
+        "error" => {
+            let message = codex_error_message(&value);
+            if is_codex_retry_error(&message) {
+                ParsedCliAgentEvent::default()
+            } else {
+                ParsedCliAgentEvent {
+                    error: Some(message.clone()),
+                    events: vec![AgentEvent::Error { message }],
+                    ..Default::default()
+                }
+            }
+        }
         _ => ParsedCliAgentEvent::default(),
     }
+}
+
+fn is_codex_retry_error(message: &str) -> bool {
+    message.trim_start().to_ascii_lowercase().starts_with("reconnecting...")
 }
 
 fn parse_codex_item_started(value: &Value) -> ParsedCliAgentEvent {
@@ -539,5 +555,27 @@ mod tests {
         let pid = std::fs::read_to_string(&pid_file).expect("child pid should be captured");
         assert!(!process_is_alive(pid.trim()));
         let _ = std::fs::remove_file(pid_file);
+    }
+
+    #[tokio::test]
+    async fn jsonl_retry_error_allows_child_to_complete() {
+        let spec = CliAgentProcessSpec {
+            command: CliAgentCommandSpec {
+                program: "sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "printf '%s\n' '{\"type\":\"error\",\"message\":\"Reconnecting... 2/5 (request timed out)\"}' '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"recovered\"}}' '{\"type\":\"turn.completed\"}'".to_string(),
+                ],
+            },
+            env: Vec::new(),
+            stdin: None,
+            dialect: CliAgentJsonlDialect::CodexExec,
+            classify_spawn_error,
+            classify_run_error,
+        };
+
+        let result = run_cli_jsonl_agent(spec, &Notify::new(), |_| {}).await.unwrap();
+
+        assert_eq!(result, "recovered");
     }
 }


### PR DESCRIPTION
## Summary

- map DBX's `minimal` reasoning setting to Codex CLI's supported `low` effort
- automatically pass the operating system proxy to Codex CLI when no explicit proxy environment is configured
- preserve explicit `codexCliEnv` proxy values, including lowercase environment keys
- revert the earlier retry-event workaround because it did not address the reproduced failure

## Root cause

Two independent configuration mismatches affected GUI-launched Codex CLI requests:

1. DBX passed `model_reasoning_effort="minimal"`, while the selected Codex model rejects that value and accepts `low`, `medium`, `high`, and related supported levels.
2. A Codex child launched from the macOS GUI did not receive the shell's proxy environment. Requests only worked after manually entering proxy variables in DBX.

## Implementation

- `AiReasoningLevel::Minimal` now serializes as `low` for Codex CLI.
- Codex process setup uses DBX's existing platform system-proxy resolver and fills `HTTP_PROXY` and `HTTPS_PROXY` only when equivalent keys are absent.
- User-provided proxy environment values take precedence, matched case-insensitively.
- The same process environment path is shared by model listing, connection testing, and agent execution.

## Verification

### Rust checks

- `cargo fmt --all -- --check && git diff --check && CARGO_TARGET_DIR=/tmp/dbx-cargo-target cargo test -p dbx-core --lib` — exit 0; 2000 declared: 1994 passed, 0 failed, 6 ignored, 0 filtered. The six ignored cases require external live databases.
- `CARGO_TARGET_DIR=/tmp/dbx-cargo-target cargo clippy -p dbx-core --locked --all-targets` — exit 0; existing warnings remain (73 library, 80 test-target warnings).

### Tauri development UI flow

- Isolated configuration: provider `codex-cli`, model `gpt-5.6-luna`, reasoning `minimal`, empty `codexCliEnv`.
- Launched the parent process with `HTTP_PROXY`, `HTTPS_PROXY`, lowercase variants, and `ALL_PROXY` explicitly removed.
- Sent `只回复 E2E_PROXY_REASONING_OK` through the AI panel at `http://localhost:1420`.
- Received exactly `E2E_PROXY_REASONING_OK` from `Codex CLI / gpt-5.6-luna`.

### Packaged macOS debug app flow

- `pnpm tauri build --debug --bundles app --config /tmp/dbx-e2e-3457/tauri.e2e.conf.json -- --no-default-features` — exit 0.
- Launched `DBX E2E 3457.app` with the same isolated configuration and all parent proxy variables removed.
- Sent `只回复 PACKAGED_PROXY_REASONING_OK` through the packaged `tauri://localhost` UI.
- Received exactly `PACKAGED_PROXY_REASONING_OK` from `Codex CLI / gpt-5.6-luna`.

The UI verification covers the reproduced macOS development and packaged-debug flows. It does not claim signed/notarized release validation or a Windows UI run.
