### PR TITLE
Feature：支持清除 Oracle 兼容数据库的查询模式

### DIFF
--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -15,7 +15,7 @@ import { connectionIconType } from "@/lib/connection/connectionPresentation";
 import { formatDatabaseLabel, isDefaultDatabase } from "@/lib/database/defaultDatabase";
 import { connectionDisplayName } from "@/lib/tabs/tabPresentation";
 import { buildConnectionGroupPathMap } from "@/lib/sidebar/sidebarLayout";
-import { isSingleDatabase, supportsSqlInListPaste, supportsTransaction as supportsTransactionFeature } from "@/lib/database/databaseCapabilities";
+import { isSingleDatabase, supportsClearableQuerySchema, supportsSqlInListPaste, supportsTransaction as supportsTransactionFeature } from "@/lib/database/databaseCapabilities";
 import { hexToRgba } from "@/lib/common/color";
 import { productionContextForDatabase } from "@/lib/database/productionSafety";
 import type { QueryTab, ConnectionConfig } from "@/types/database";
@@ -411,6 +411,7 @@ function databaseOptionIsProduction(database: string): boolean {
           :empty-text="t('grid.noSearchResults')"
           :loading-text="t('common.loading')"
           :loading="!!activeConnection && isLoadingSchemas(activeConnection.id, schemaDatabaseKey)"
+          :clear-selected-option="supportsClearableQuerySchema(activeConnection?.db_type)"
           trigger-class="gap-1.5"
           @update:model-value="(schema) => emit('changeSchema', schema || undefined)"
           @update:open="

--- a/apps/desktop/src/components/ui/searchable-select/SearchableSelect.vue
+++ b/apps/desktop/src/components/ui/searchable-select/SearchableSelect.vue
@@ -33,12 +33,14 @@ const props = withDefaults(
     optionTooltip?: (option: string) => string | undefined;
     normalizeCustom?: (value: string) => string;
     clearable?: boolean;
+    clearSelectedOption?: boolean;
   }>(),
   {
     loading: false,
     disabled: false,
     allowCustom: false,
     clearable: false,
+    clearSelectedOption: false,
     loadingText: "Loading...",
     triggerVariant: "ghost",
     triggerIconClass: "h-3 w-3",
@@ -183,6 +185,10 @@ function selectOption(option: string) {
   open.value = false;
 }
 
+function selectOrClearOption(option: string) {
+  selectOption(props.clearSelectedOption && option === props.modelValue ? "" : option);
+}
+
 function selectCustomOption() {
   if (!canSelectCustom.value) return;
   selectOption(customOptionValue.value);
@@ -214,7 +220,7 @@ function handleKeydown(event: KeyboardEvent) {
     if (highlightIndex.value < 0 || highlightIndex.value >= optionCount()) return;
     event.preventDefault();
     if (highlightIndex.value < filteredOptions.value.length) {
-      selectOption(filteredOptions.value[highlightIndex.value]);
+      selectOrClearOption(filteredOptions.value[highlightIndex.value]);
     } else {
       selectCustomOption();
     }
@@ -255,15 +261,18 @@ function handleKeydown(event: KeyboardEvent) {
                 :title="optionTooltip(option) ? undefined : optionTitle(option)"
                 :class="
                   cn(
-                    'flex h-8 w-full min-w-0 items-center gap-2 rounded-sm px-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none',
+                    'group flex h-8 w-full min-w-0 items-center gap-2 rounded-sm px-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none',
                     props.itemClass,
                     index === highlightIndex && 'bg-accent text-accent-foreground',
                   )
                 "
                 @pointerenter="activateHelpForOption(option)"
-                @click="selectOption(option)"
+                @click="selectOrClearOption(option)"
               >
-                <Check :class="cn('h-3.5 w-3.5 shrink-0', option === modelValue ? 'opacity-100' : 'opacity-0')" />
+                <span class="relative h-3.5 w-3.5 shrink-0">
+                  <Check :class="cn('absolute inset-0 h-3.5 w-3.5', option !== modelValue ? 'opacity-0' : clearSelectedOption ? 'opacity-100 group-hover:opacity-0 group-focus-visible:opacity-0' : 'opacity-100')" />
+                  <X v-if="clearSelectedOption && option === modelValue" class="absolute inset-0 h-3.5 w-3.5 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100" />
+                </span>
                 <slot name="option-label" :option="option" :label="displayName?.(option)">
                   <span class="truncate">{{ displayName?.(option) }}</span>
                 </slot>

--- a/apps/desktop/src/lib/database/databaseCapabilitySets.ts
+++ b/apps/desktop/src/lib/database/databaseCapabilitySets.ts
@@ -39,6 +39,8 @@ export const SCHEMA_AWARE_TYPES = new Set<DatabaseType>([
 
 export const SINGLE_DATABASE_TYPES = new Set<DatabaseType>(["oracle", "dameng", "firebird", "oceanbase-oracle", "access", "questdb"]);
 
+export const CLEARABLE_QUERY_SCHEMA_TYPES = new Set<DatabaseType>(["oracle", "dameng", "oceanbase-oracle"]);
+
 export const FETCH_FIRST_TYPES = new Set<DatabaseType>(["oracle", "dameng"]);
 
 export const TREE_SCHEMA_TYPES = new Set<DatabaseType>([

--- a/apps/desktop/src/lib/database/databaseFeatureSupport.ts
+++ b/apps/desktop/src/lib/database/databaseFeatureSupport.ts
@@ -1,7 +1,7 @@
 import type { ConnectionConfig, DatabaseType, TreeNodeType } from "@/types/database";
 import { supportsDatabaseFeature } from "@/lib/database/databaseDriverManifest";
 import { canEditTableStructure } from "@/lib/table/tableStructureCapabilities";
-import { DATABASE_OBJECT_TREE_TYPES, FETCH_FIRST_TYPES, PG_LIKE_STRUCTURE_TYPES, SCHEMA_AWARE_TYPES, SINGLE_DATABASE_TYPES, TREE_SCHEMA_TYPES } from "@/lib/database/databaseCapabilitySets";
+import { CLEARABLE_QUERY_SCHEMA_TYPES, DATABASE_OBJECT_TREE_TYPES, FETCH_FIRST_TYPES, PG_LIKE_STRUCTURE_TYPES, SCHEMA_AWARE_TYPES, SINGLE_DATABASE_TYPES, TREE_SCHEMA_TYPES } from "@/lib/database/databaseCapabilitySets";
 
 export function isSchemaAware(dbType?: DatabaseType): boolean {
   return !!dbType && SCHEMA_AWARE_TYPES.has(dbType);
@@ -57,6 +57,10 @@ export function databaseObjectTreeNodeSchema(dbType: DatabaseType | undefined, d
 
 export function isSingleDatabase(dbType?: DatabaseType): boolean {
   return !!dbType && SINGLE_DATABASE_TYPES.has(dbType);
+}
+
+export function supportsClearableQuerySchema(dbType?: DatabaseType): boolean {
+  return !!dbType && CLEARABLE_QUERY_SCHEMA_TYPES.has(dbType);
 }
 
 export function usesFetchFirst(dbType?: DatabaseType): boolean {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -358,6 +358,7 @@ export const useQueryStore = defineStore("query", () => {
   const closeConfirmContext = ref<CloseConfirmContext>("tab");
   const tableStructureRefreshVersions = ref<Record<string, number>>({});
   const savedSqlEditorPositionTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const pendingTabSessionResets = new Map<string, Promise<void>>();
   let resultCacheTrimScheduled = false;
   let resultCacheTrimRunning = false;
   let resultCacheTrimRequested = false;
@@ -412,6 +413,29 @@ export const useQueryStore = defineStore("query", () => {
     const clientSessionIds = [...new Set([tabClientSessionId(tab), ...BACKGROUND_CLIENT_SESSION_SUFFIXES.map((suffix) => tabClientSessionId(tab, suffix)), tab.explainClientSessionId].filter((sessionId): sessionId is string => !!sessionId))];
     for (const clientSessionId of clientSessionIds) {
       await closeClientSessionId(tab.connectionId, executionDatabase, clientSessionId, { tabId: tab.id });
+    }
+  }
+
+  function queueTabSessionReset(tab: QueryTab) {
+    const previousReset = pendingTabSessionResets.get(tab.id);
+    const reset = (async () => {
+      if (previousReset) await previousReset;
+      await closeResultSession(tab);
+      await closeClientConnectionSession(tab);
+    })();
+    pendingTabSessionResets.set(tab.id, reset);
+    const clearPendingReset = () => {
+      if (pendingTabSessionResets.get(tab.id) === reset) pendingTabSessionResets.delete(tab.id);
+    };
+    void reset.then(clearPendingReset, clearPendingReset);
+  }
+
+  async function waitForTabSessionReset(tabId: string) {
+    while (true) {
+      const pendingReset = pendingTabSessionResets.get(tabId);
+      if (!pendingReset) return;
+      await pendingReset;
+      if (pendingTabSessionResets.get(tabId) === pendingReset) pendingTabSessionResets.delete(tabId);
     }
   }
 
@@ -1988,8 +2012,7 @@ export const useQueryStore = defineStore("query", () => {
     rollbackTabTransaction(tab);
     const clearsQuerySchema = tab.mode === "query" && tab.schema && !schema && supportsClearableQuerySchema(useConnectionStore().getConfig(tab.connectionId)?.db_type);
     if (clearsQuerySchema) {
-      void closeResultSession(tab);
-      void closeClientConnectionSession(tab);
+      queueTabSessionReset(tab);
       clearResultPayload(tab);
       tab.lastExecutedSql = undefined;
       tab.resultBaseSql = undefined;
@@ -2616,6 +2639,7 @@ export const useQueryStore = defineStore("query", () => {
     let countSql: string | undefined;
     let useAgentResultSession = false;
     try {
+      await waitForTabSessionReset(id);
       const connStore = useConnectionStore();
       let conn = connStore.getConfig(tab.connectionId);
       const parsedMongoCommands = conn?.db_type === "mongodb" ? splitMongoCommandRanges(sql) : undefined;
@@ -3219,6 +3243,8 @@ export const useQueryStore = defineStore("query", () => {
     tab.explainSql = undefined;
     tab.explainTableSql = undefined;
     tab.lastExplainedSql = sql;
+
+    await waitForTabSessionReset(id);
 
     // DM and Oracle agents expose native text plans. DM also supports autotrace.
     if (databaseType === "dameng" || databaseType === "oracle") {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -381,7 +381,7 @@ export const useQueryStore = defineStore("query", () => {
   }
   const MAX_CACHED_RESULTS = 5;
 
-  async function closeResultSession(tab: QueryTab | undefined, preserveSessionId?: string) {
+  async function closeResultSession(tab: QueryTab | undefined, preserveSessionId?: string, throwOnError = false) {
     const sessionId = tab?.resultSessionId ?? tab?.result?.session_id;
     if (!tab || !sessionId || sessionId === preserveSessionId) return;
     try {
@@ -391,28 +391,30 @@ export const useQueryStore = defineStore("query", () => {
       await api.closeQuerySession(tab.connectionId, executionDatabase, sessionId, tab.id);
     } catch (error) {
       console.warn("[DBX][query-session:close:error]", { tabId: tab.id, sessionId, error });
+      if (throwOnError) throw error;
     } finally {
       if (tab.resultSessionId === sessionId) tab.resultSessionId = undefined;
       if (tab.result?.session_id === sessionId) tab.result.session_id = undefined;
     }
   }
 
-  async function closeClientSessionId(connectionId: string, database: string, clientSessionId: string, logContext: Record<string, unknown> = {}) {
+  async function closeClientSessionId(connectionId: string, database: string, clientSessionId: string, logContext: Record<string, unknown> = {}, throwOnError = false) {
     try {
       await api.closeClientConnectionSession(connectionId, database, clientSessionId);
     } catch (error) {
       console.warn("[DBX][client-session:close:error]", { ...logContext, clientSessionId, error });
+      if (throwOnError) throw error;
     }
   }
 
-  async function closeClientConnectionSession(tab: QueryTab | undefined) {
+  async function closeClientConnectionSession(tab: QueryTab | undefined, throwOnError = false) {
     if (!tab?.connectionId) return;
     const catalog = tab.mode === "data" ? tab.tableMeta?.catalog : undefined;
     const connection = catalog ? useConnectionStore().getConfig(tab.connectionId) : undefined;
     const executionDatabase = dataTabExecutionDatabase(connection, tab.database, catalog);
     const clientSessionIds = [...new Set([tabClientSessionId(tab), ...BACKGROUND_CLIENT_SESSION_SUFFIXES.map((suffix) => tabClientSessionId(tab, suffix)), tab.explainClientSessionId].filter((sessionId): sessionId is string => !!sessionId))];
     for (const clientSessionId of clientSessionIds) {
-      await closeClientSessionId(tab.connectionId, executionDatabase, clientSessionId, { tabId: tab.id });
+      await closeClientSessionId(tab.connectionId, executionDatabase, clientSessionId, { tabId: tab.id }, throwOnError);
     }
   }
 
@@ -420,8 +422,9 @@ export const useQueryStore = defineStore("query", () => {
     const previousReset = pendingTabSessionResets.get(tab.id);
     const reset = (async () => {
       if (previousReset) await previousReset;
-      await closeResultSession(tab);
-      await closeClientConnectionSession(tab);
+      // A schema reset must fail closed: reusing the old session would retain Oracle CURRENT_SCHEMA.
+      await closeResultSession(tab, undefined, true);
+      await closeClientConnectionSession(tab, true);
     })();
     pendingTabSessionResets.set(tab.id, reset);
     const clearPendingReset = () => {
@@ -3244,7 +3247,15 @@ export const useQueryStore = defineStore("query", () => {
     tab.explainTableSql = undefined;
     tab.lastExplainedSql = sql;
 
-    await waitForTabSessionReset(id);
+    try {
+      await waitForTabSessionReset(id);
+    } catch (e: any) {
+      // Do not start an explain with a session whose schema reset did not complete.
+      tab.isExplaining = false;
+      tab.explainExecutionId = undefined;
+      tab.explainError = String(e?.message || e);
+      return { ok: false as const, reason: tab.explainError };
+    }
 
     // DM and Oracle agents expose native text plans. DM also supports autotrace.
     if (databaseType === "dameng" || databaseType === "oracle") {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -28,6 +28,7 @@ import { redisCommandResultToQueryResult } from "@/lib/redis/redisQueryResult";
 import { nextRedisCommandDb } from "@/lib/redis/redisCommandSession";
 import { isRedisMutatingCommand } from "@/lib/redis/redisCommandTable";
 import { usesAgentCursorForQuery } from "@/lib/database/databaseDriverManifest";
+import { supportsClearableQuerySchema } from "@/lib/database/databaseFeatureSupport";
 import { canUseKeylessRowPredicate, DBX_ROWID_COLUMN, editablePrimaryKeys, usesSyntheticRowIdKey } from "@/lib/table/tableEditing";
 import { TABLE_DATA_EXPORT_PAGE_SIZE } from "@/lib/table/tableDataExport";
 import { tableMetaForDataTab } from "@/lib/table/tableDataTabMeta";
@@ -1985,6 +1986,16 @@ export const useQueryStore = defineStore("query", () => {
     const tab = tabs.value.find((t) => t.id === id);
     if (!tab || tab.schema === schema) return;
     rollbackTabTransaction(tab);
+    const clearsQuerySchema = tab.mode === "query" && tab.schema && !schema && supportsClearableQuerySchema(useConnectionStore().getConfig(tab.connectionId)?.db_type);
+    if (clearsQuerySchema) {
+      void closeResultSession(tab);
+      void closeClientConnectionSession(tab);
+      clearResultPayload(tab);
+      tab.lastExecutedSql = undefined;
+      tab.resultBaseSql = undefined;
+      tab.resultSortedSql = undefined;
+      clearExplain(tab);
+    }
     tab.schema = schema;
     if (tab.mode === "objects") tab.objectBrowser = { ...tab.objectBrowser, schema, viewport: undefined };
   }

--- a/packages/app-tests/databaseCapabilities.test.ts
+++ b/packages/app-tests/databaseCapabilities.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { isSchemaAware, supportsDatabaseCreation, usesTreeSchemaMode } from "../../apps/desktop/src/lib/database/databaseCapabilities.ts";
+import { isSchemaAware, supportsClearableQuerySchema, supportsDatabaseCreation, usesTreeSchemaMode } from "../../apps/desktop/src/lib/database/databaseCapabilities.ts";
 
 test("TDengine uses database/catalog tree nodes without a schema layer", () => {
   assert.equal(isSchemaAware("tdengine"), false);
@@ -15,4 +15,14 @@ test("IoTDB keeps schema-qualified paths without showing a duplicate schema node
 test("GoldenDB and Vastbase expose database creation", () => {
   assert.equal(supportsDatabaseCreation("goldendb"), true);
   assert.equal(supportsDatabaseCreation("vastbase"), true);
+});
+
+test("only Oracle-compatible single-database schemas can be cleared from query tabs", () => {
+  assert.equal(supportsClearableQuerySchema("oracle"), true);
+  assert.equal(supportsClearableQuerySchema("dameng"), true);
+  assert.equal(supportsClearableQuerySchema("oceanbase-oracle"), true);
+  assert.equal(supportsClearableQuerySchema("mysql"), false);
+  assert.equal(supportsClearableQuerySchema("postgres"), false);
+  assert.equal(supportsClearableQuerySchema("sqlserver"), false);
+  assert.equal(supportsClearableQuerySchema("jdbc"), false);
 });

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -48,6 +48,13 @@ function oracleConn(id: string): ConnectionConfig {
   };
 }
 
+function oracleCompatibleConn(id: string, dbType: "oracle" | "dameng" | "oceanbase-oracle"): ConnectionConfig {
+  return {
+    ...oracleConn(id),
+    db_type: dbType,
+  };
+}
+
 function sqlServerConn(id: string): ConnectionConfig {
   return {
     ...conn(id),
@@ -760,7 +767,10 @@ test("sortTabResultLocally sorts current rows and restores original order", () =
     [2, "Grace"],
     [3, "Linus"],
   ]);
-  assert.deepEqual(tab.result?.mongo_documents?.map((document) => (document as { id: number }).id), [1, 2, 3]);
+  assert.deepEqual(
+    tab.result?.mongo_documents?.map((document) => (document as { id: number }).id),
+    [1, 2, 3],
+  );
   assert.equal(tab.resultSortColumn, "name");
   assert.equal(tab.resultSortColumnIndex, 1);
   assert.equal(tab.resultSortDirection, "asc");
@@ -774,7 +784,10 @@ test("sortTabResultLocally sorts current rows and restores original order", () =
     [2, "Grace"],
     [1, "Ada"],
   ]);
-  assert.deepEqual(tab.result?.mongo_documents?.map((document) => (document as { id: number }).id), [3, 2, 1]);
+  assert.deepEqual(
+    tab.result?.mongo_documents?.map((document) => (document as { id: number }).id),
+    [3, 2, 1],
+  );
 
   store.sortTabResultLocally(tabId, "name", 1, null);
 
@@ -783,7 +796,10 @@ test("sortTabResultLocally sorts current rows and restores original order", () =
     [1, "Ada"],
     [3, "Linus"],
   ]);
-  assert.deepEqual(tab.result?.mongo_documents?.map((document) => (document as { id: number }).id), [2, 1, 3]);
+  assert.deepEqual(
+    tab.result?.mongo_documents?.map((document) => (document as { id: number }).id),
+    [2, 1, 3],
+  );
   assert.equal(tab.resultSortColumn, undefined);
   assert.equal(tab.resultSortMode, undefined);
 });
@@ -920,7 +936,10 @@ test("removing the active result run clears output when remaining caches are una
   assert.equal(tab.activeResultRunId, undefined);
   assert.equal(tab.result, undefined);
   assert.equal(tab.results, undefined);
-  assert.deepEqual(tab.resultRuns?.map((run) => run.id), ["run-2"]);
+  assert.deepEqual(
+    tab.resultRuns?.map((run) => run.id),
+    ["run-2"],
+  );
 });
 
 test("removed result runs are excluded from result archives", async () => {
@@ -4128,6 +4147,78 @@ test("closing a data tab releases its tab-scoped client session", async () => {
       closedSessions.some((body) => body.clientSessionId === tabId && body.connectionId === "conn-1"),
       `expected close-client-session for tab session, got ${JSON.stringify(closedSessions)}`,
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+for (const dbType of ["oracle", "dameng", "oceanbase-oracle"] as const) {
+  test(`clearing a ${dbType} query schema releases its tab-scoped client session`, async () => {
+    const restoreStorage = installMemoryStorage();
+    setActivePinia(createPinia());
+    const connectionStore = useConnectionStore();
+    const store = useQueryStore();
+    const originalFetch = globalThis.fetch;
+    const connectionId = `${dbType}-1`;
+
+    connectionStore.addEphemeralConnection(oracleCompatibleConn(connectionId, dbType));
+    const tabId = store.createTab(connectionId, "SERVICE", "Query", "query", "REPORTING");
+    const closedSessions: any[] = [];
+
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url === "/api/query/close-client-session") {
+        closedSessions.push(JSON.parse(String(init?.body ?? "{}")));
+        return new Response(JSON.stringify(true), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected request", { status: 500 });
+    };
+
+    try {
+      store.updateSchema(tabId, undefined);
+
+      await waitFor(() => closedSessions.some((body) => body.clientSessionId === tabId));
+      assert.equal(store.tabs.find((tab) => tab.id === tabId)?.schema, undefined);
+      assert.ok(
+        closedSessions.some((body) => body.connectionId === connectionId && body.database === "SERVICE" && body.clientSessionId === tabId),
+        `expected close-client-session for cleared query schema, got ${JSON.stringify(closedSessions)}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreStorage();
+    }
+  });
+}
+
+test("clearing a non-clearable query schema does not reset its client session", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  let closeRequests = 0;
+
+  connectionStore.addEphemeralConnection(conn("pg-1"));
+  const tabId = store.createTab("pg-1", "app", "Query", "query", "public");
+
+  globalThis.fetch = async (input) => {
+    if (String(input) === "/api/query/close-client-session") closeRequests += 1;
+    return new Response(JSON.stringify(true), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    store.updateSchema(tabId, undefined);
+    await Promise.resolve();
+
+    assert.equal(store.tabs.find((tab) => tab.id === tabId)?.schema, undefined);
+    assert.equal(closeRequests, 0);
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -4194,6 +4194,66 @@ for (const dbType of ["oracle", "dameng", "oceanbase-oracle"] as const) {
   });
 }
 
+test("query execution waits for a cleared schema client session to close", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+
+  connectionStore.addEphemeralConnection(oracleConn("oracle-1"));
+  const tabId = store.createTab("oracle-1", "ORCL", "Query", "query", "REPORTING");
+  let resolveClientSessionClose: ((response: Response) => void) | undefined;
+  let executeRequests = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (url === "/api/query/close-client-session") {
+      if (!resolveClientSessionClose) {
+        return new Promise<Response>((resolve) => {
+          resolveClientSessionClose = resolve;
+        });
+      }
+      return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/query/prepare-pagination-plan") {
+      return new Response(
+        JSON.stringify({
+          sqlToExecute: "select 1",
+          pageLimit: 100,
+          pageOffset: 0,
+          useAgentResultSession: false,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/execute-multi") {
+      executeRequests += 1;
+      return new Response(JSON.stringify([{ columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  };
+
+  try {
+    store.updateSchema(tabId, undefined);
+    const execution = store.executeTabSql(tabId, "select 1", { skipEnsureConnected: true });
+
+    await waitFor(() => !!resolveClientSessionClose);
+    await Promise.resolve();
+    assert.equal(executeRequests, 0);
+
+    resolveClientSessionClose!(new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } }));
+    await execution;
+    assert.equal(executeRequests, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test("clearing a non-clearable query schema does not reset its client session", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -4254,6 +4254,55 @@ test("query execution waits for a cleared schema client session to close", async
   }
 });
 
+test("failed schema session reset blocks query and Oracle explain execution", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  let executeRequests = 0;
+  let explainRequests = 0;
+
+  connectionStore.addEphemeralConnection(oracleConn("oracle-1"));
+  const queryTabId = store.createTab("oracle-1", "ORCL", "Query", "query", "REPORTING");
+  const explainTabId = store.createTab("oracle-1", "ORCL", "Explain", "query", "REPORTING");
+
+  globalThis.fetch = async (input) => {
+    const url = String(input);
+    if (url === "/api/query/close-client-session") return new Response("reset failed", { status: 500 });
+    if (url === "/api/query/execute-multi") {
+      executeRequests += 1;
+      return new Response(JSON.stringify([]), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/query/get-explain-info") {
+      explainRequests += 1;
+      return new Response("unexpected explain request", { status: 500 });
+    }
+    return new Response("unexpected request", { status: 500 });
+  };
+
+  try {
+    store.updateSchema(queryTabId, undefined);
+    const queryExecution = store.executeTabSql(queryTabId, "select 1", { skipEnsureConnected: true });
+    await queryExecution;
+    const queryTab = store.tabs.find((tab) => tab.id === queryTabId)!;
+    assert.equal(executeRequests, 0);
+    assert.equal(queryTab.result?.execution_error, true);
+    assert.match(String(queryTab.result?.rows[0]?.[0]), /reset failed/i);
+
+    store.updateSchema(explainTabId, undefined);
+    const explainResult = await store.explainTabSql(explainTabId, "select 1", "oracle");
+    const explainTab = store.tabs.find((tab) => tab.id === explainTabId)!;
+    assert.equal(explainResult.ok, false);
+    assert.equal(explainRequests, 0);
+    assert.equal(explainTab.isExplaining, false);
+    assert.match(explainTab.explainError ?? "", /reset failed/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test("clearing a non-clearable query schema does not reset its client session", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());


### PR DESCRIPTION
## 改动内容

- 在 Oracle、达梦和 OceanBase Oracle 的查询模式列表中，悬浮当前选中项时将对勾切换为清除图标，点击或按 Enter 可恢复未显式选择模式的状态
- 清除模式时按顺序关闭结果游标和查询客户端会话，避免数据库连接继续沿用此前的会话级 schema
- 查询执行和执行计划会等待该 tab 的会话重置完成，避免清除 schema 后立即执行时复用旧会话
- 使用独立能力白名单限制适用范围，MySQL、PostgreSQL、SQL Server、通用 JDBC 及其他选择器保持原有行为
- 补充能力范围、会话释放和并发时序测试

## 验证

- `pnpm typecheck`
- `pnpm vitest run --maxWorkers=4`：387 个测试文件、3110 项测试通过
- `pnpm build`
- 达梦真实实例验证：登录默认模式为 `DBX_TEST`，切换到 `TEST` 后会话模式变为 `TEST`；关闭并重建查询会话后恢复为 `DBX_TEST`
