### PR TITLE
fix(query): 多结果集按语句判断可编辑性

### DIFF
--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -161,6 +161,10 @@ function annotateQueryResultSource(result: QueryResult, sourceStatement: string,
   return result;
 }
 
+function displayedQueryMetadataSql(tab: QueryTab, fallbackSql: string): string {
+  return tab.results?.length ? (tab.result?.sourceStatement ?? fallbackSql) : fallbackSql;
+}
+
 async function withFrontendQueryTimeout<T>(promise: Promise<T>, timeoutSecs: number, message: string): Promise<T> {
   if (timeoutSecs === 0) return promise;
 
@@ -3158,7 +3162,9 @@ export const useQueryStore = defineStore("query", () => {
           backendMs: current.result?.execution_time_ms,
           elapsed: elapsed(),
         });
-        if (current.mode === "query" && current.result) analyzeQueryMetadataInBackground(id, queryMetadataSql, current.result, traceId, elapsed, hiddenPrimaryKeys);
+        if (current.mode === "query" && current.result) {
+          analyzeQueryMetadataInBackground(id, displayedQueryMetadataSql(current, queryMetadataSql), current.result, traceId, elapsed, hiddenPrimaryKeys);
+        }
       } else {
         console.warn("[DBX][executeTabSql:stale-result]", {
           traceId,
@@ -3510,6 +3516,11 @@ export const useQueryStore = defineStore("query", () => {
     tab.queryEditabilityReason = undefined;
     tab.mongoEditTarget = undefined;
     syncActiveResultRunFromDisplayed(tab);
+    const sourceStatement = tab.result?.sourceStatement;
+    if (tab.mode === "query" && sourceStatement && splitMongoCommandRanges(sourceStatement).length === 0) {
+      const metadataStartedAt = performance.now();
+      analyzeQueryMetadataInBackground(id, sourceStatement, tab.result, uuid().slice(0, 8), () => `${Math.round(performance.now() - metadataStartedAt)}ms`);
+    }
   }
 
   function notifyConnectionMayBeLost() {

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -3,6 +3,7 @@ import { test } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { isReactive } from "vue";
 import { decodeQueryResultArchive } from "../../apps/desktop/src/lib/query/queryResultArchive.ts";
+import { analyzeEditableQueryEditability } from "../../apps/desktop/src/lib/sql/sqlAnalysis.ts";
 import { resultSqlForGrid } from "../../apps/desktop/src/lib/tabs/tabPresentation.ts";
 import { useConnectionStore } from "../../apps/desktop/src/stores/connectionStore.ts";
 import { useQueryStore } from "../../apps/desktop/src/stores/queryStore.ts";
@@ -4559,6 +4560,148 @@ test("multi statement execution shows the first result set by default", async ()
       tab?.results?.every((result) => !isReactive(result.rows)),
       true,
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("multi statement results analyze editability from each active source statement", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const analyzedSql: string[] = [];
+
+  connectionStore.addEphemeralConnection(conn("multi-result-editability"));
+  const tabId = store.createTab("multi-result-editability", "db", "Query");
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/query/execute-multi") {
+      return new Response(
+        JSON.stringify([
+          { columns: ["id", "name"], rows: [[1, "Ada"]], affected_rows: 0, execution_time_ms: 1 },
+          { columns: ["id", "total"], rows: [[10, 42]], affected_rows: 0, execution_time_ms: 1 },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/analyze-editability") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      analyzedSql.push(body.sql);
+      return new Response(JSON.stringify(analyzeEditableQueryEditability(body.sql)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.startsWith("/api/schema/columns?")) {
+      const table = new URL(url, "http://localhost").searchParams.get("table");
+      const columns =
+        table === "users"
+          ? [
+              { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+              { name: "name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+            ]
+          : [
+              { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+              { name: "total", data_type: "numeric", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+            ];
+      return new Response(JSON.stringify(columns), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    await store.executeTabSql(tabId, "select * from users; select * from orders");
+
+    const tab = store.tabs.find((item) => item.id === tabId);
+    await waitFor(() => tab?.tableMeta?.tableName === "users" && !!tab.queryAnalysis);
+    assert.deepEqual(analyzedSql, ["select * from users"]);
+    assert.equal(tab?.queryEditabilityReason, undefined);
+    assert.equal(tab?.queryAnalysis?.tableName, "users");
+
+    store.setActiveResultIndex(tabId, 1);
+    await waitFor(() => tab?.tableMeta?.tableName === "orders" && !!tab.queryAnalysis);
+    assert.deepEqual(analyzedSql, ["select * from users", "select * from orders"]);
+    assert.equal(tab?.queryEditabilityReason, undefined);
+    assert.equal(tab?.queryAnalysis?.tableName, "orders");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("multi statement result switching keeps unsupported statements read-only", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const analyzedSql: string[] = [];
+
+  connectionStore.addEphemeralConnection(conn("multi-result-readonly"));
+  const tabId = store.createTab("multi-result-readonly", "db", "Query");
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === "/api/query/execute-multi") {
+      return new Response(
+        JSON.stringify([
+          { columns: ["id", "name"], rows: [[1, "Ada"]], affected_rows: 0, execution_time_ms: 1 },
+          { columns: ["id", "total"], rows: [[10, 42]], affected_rows: 0, execution_time_ms: 1 },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/analyze-editability") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      analyzedSql.push(body.sql);
+      return new Response(JSON.stringify(analyzeEditableQueryEditability(body.sql)), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.startsWith("/api/schema/columns?")) {
+      return new Response(
+        JSON.stringify([
+          { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+          { name: "name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const sql = "select * from users; select id, count(*) as total from orders group by id";
+    await store.executeTabSql(tabId, sql);
+
+    const tab = store.tabs.find((item) => item.id === tabId);
+    await waitFor(() => tab?.tableMeta?.tableName === "users" && !!tab.queryAnalysis);
+    assert.equal(tab?.queryEditabilityReason, undefined);
+
+    store.setActiveResultIndex(tabId, 1);
+    await waitFor(() => tab?.queryEditabilityReason === "aggregation");
+    assert.deepEqual(analyzedSql, ["select * from users", "select id, count(*) as total from orders group by id"]);
+    assert.equal(tab?.queryAnalysis, undefined);
+    assert.equal(tab?.tableMeta, undefined);
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();


### PR DESCRIPTION
## 问题

多条 SQL 一次执行时，DBX 已经为每个结果集记录了对应的 `sourceStatement`，但可编辑性分析仍使用整段 SQL。解析器遇到语句间分号后会返回 `complex-source`，导致本可回写的查询结果全部显示为只读；切换结果页签时也没有针对新结果重新分析。

## 修复

- 多结果集首次展示时，使用当前结果的 `sourceStatement` 分析可编辑性
- 切换结果页签后，根据新结果的来源语句重新加载编辑元数据
- 单结果查询继续使用原有 metadata SQL，保留隐藏主键补全行为
- MongoDB 结果继续走自身的文档编辑目标逻辑，不进入关系型 SQL 分析
- 增加多条可编辑 SELECT 和“可编辑 SELECT + 只读聚合查询”的回归测试

## 验证

- `pnpm vitest run packages/app-tests/queryStore.test.ts packages/app-tests/tabPresentation.test.ts`：121 passed
- `pnpm typecheck`：通过
- `pnpm lint`：通过（仅仓库已有 warnings）
- `oxfmt --check`、`git diff --check`：通过

### 实际 MySQL 验证

在真实 MySQL 测试库的 `t_0001` 表执行：

```sql
SELECT * FROM t_0001 LIMIT 10;
SELECT * FROM t_0001 LIMIT 10;
```

验证结果：

- 返回两个独立结果页签
- 第一个结果可编辑，“新增行”可用，没有安全回写目标只读提示
- 切换第二个结果后仍可编辑，“新增行”可用，同样没有只读提示
- 验证过程只执行 SELECT，未提交任何数据修改

Fixes #3503