### PR TITLE
Fix：修复前导空格数据库无法打开

### DIFF
--- a/apps/desktop/src/lib/database/databaseTree.ts
+++ b/apps/desktop/src/lib/database/databaseTree.ts
@@ -17,8 +17,8 @@ export function sortSidebarDatabases(databases: readonly DatabaseInfo[]): Databa
 
 export function buildDatabaseTreeNodes(connectionId: string, databases: DatabaseInfo[], options: { includeDefaultWhenEmpty?: boolean } = {}): TreeNode[] {
   const nodes = sortSidebarDatabases(databases).flatMap((db) => {
-    const name = db.name.trim();
-    if (!name) return [];
+    const name = db.name;
+    if (!name.trim()) return [];
     return [
       {
         id: `${connectionId}:${name}`,
@@ -66,8 +66,8 @@ export function buildDuckDbConnectionTreeNodes(connectionId: string, databases: 
   });
 
   const attachedCatalogNodes = sortSidebarDatabases(databases).flatMap((db) => {
-    const name = db.name.trim();
-    if (!name || name === "main") return [];
+    const name = db.name;
+    if (!name.trim() || name === "main") return [];
     return [
       {
         id: `${connectionId}:${name}`,

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -2249,7 +2249,7 @@ export const useConnectionStore = defineStore("connection", () => {
               setChildren(node, children);
               await savePersistedConnectionTreeChildren(cacheKey, node.children || children);
             } else {
-              const cacheKey = schemaCacheKey(connectionId, "databases");
+              const cacheKey = schemaCacheKey(connectionId, "databases-v2");
               if (!options?.force) {
                 const cached = await loadPersistedTreeChildren(node, cacheKey);
                 if (cached.hit) {

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -3103,7 +3103,7 @@ fn base_pool_key_for(
     if is_single_connection_pool {
         connection_id.to_string()
     } else {
-        match database.map(str::trim).filter(|db| !db.is_empty()) {
+        match database.filter(|db| !db.trim().is_empty()) {
             Some(db) => format!("{connection_id}:{db}"),
             None => connection_id.to_string(),
         }
@@ -4221,6 +4221,22 @@ mod tests {
         assert_eq!(
             super::base_pool_key_for(Some(DatabaseType::MongoDb), "mongo-conn", Some("shop"), false),
             "mongo-conn:shop"
+        );
+    }
+
+    #[test]
+    fn database_scoped_pool_keys_preserve_identifier_whitespace() {
+        assert_eq!(
+            super::base_pool_key_for(Some(DatabaseType::Mysql), "mysql-conn", Some(" analytics"), false),
+            "mysql-conn: analytics"
+        );
+        assert_eq!(
+            super::base_pool_key_for(Some(DatabaseType::Mysql), "mysql-conn", Some("analytics"), false),
+            "mysql-conn:analytics"
+        );
+        assert_eq!(
+            super::base_pool_key_for(Some(DatabaseType::Postgres), "pg-conn", Some("analytics "), false),
+            "pg-conn:analytics "
         );
     }
 

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -4565,6 +4565,16 @@ UNIQUE KEY(`tenant_id`, `name``part`)
     }
 
     #[test]
+    fn mysql_setup_queries_preserve_database_identifier_whitespace() {
+        let queries = mysql_setup_queries("mysql://root:secret@localhost:3306/%20analytics%20?charset=utf8mb4", &[]);
+
+        assert_eq!(
+            queries,
+            vec!["USE ` analytics `", "SET NAMES utf8mb4", "SET SESSION group_concat_max_len = 1048576"]
+        );
+    }
+
+    #[test]
     fn mysql_setup_queries_can_select_database_without_url_path() {
         let queries = mysql_setup_queries_for_database(
             "mysql://root:secret@localhost:3306?charset=utf8mb4",

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -755,11 +755,7 @@ impl ConnectionConfig {
     }
 
     pub fn effective_database(&self) -> Option<&str> {
-        self.database
-            .as_deref()
-            .map(str::trim)
-            .filter(|database| !database.is_empty())
-            .or_else(|| self.default_database())
+        self.database.as_deref().filter(|database| !database.trim().is_empty()).or_else(|| self.default_database())
     }
 
     fn default_database(&self) -> Option<&'static str> {
@@ -1954,6 +1950,30 @@ mod tests {
             is_production: false,
             production_databases: vec![],
         }
+    }
+
+    #[test]
+    fn database_identifier_whitespace_is_preserved_and_percent_encoded() {
+        let mut config = mysql_config("root", "secret", Some(" analytics "));
+
+        assert_eq!(config.effective_database(), Some(" analytics "));
+        assert_eq!(
+            config.connection_url(),
+            "mysql://root:secret@10.1.2.3:2883/%20analytics%20?ssl-mode=disabled&charset=utf8mb4"
+        );
+
+        config.db_type = DatabaseType::Postgres;
+        assert_eq!(config.effective_database(), Some(" analytics "));
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20");
+    }
+
+    #[test]
+    fn whitespace_only_database_uses_database_type_default() {
+        let mut config = mysql_config("root", "secret", Some("   "));
+        assert_eq!(config.effective_database(), None);
+
+        config.db_type = DatabaseType::Postgres;
+        assert_eq!(config.effective_database(), Some("postgres"));
     }
 
     fn mongodb_config(username: &str, password: &str, database: Option<&str>) -> ConnectionConfig {

--- a/packages/app-tests/databaseTree.test.ts
+++ b/packages/app-tests/databaseTree.test.ts
@@ -15,3 +15,16 @@ test("数据库节点按自然名称排序", () => {
 test("sidebar name sorting uses numeric-aware ordering", () => {
   assert.deepEqual(sortSidebarNames(["db10", "db2", "db1"]), ["db1", "db2", "db10"]);
 });
+
+test("数据库节点保留名称首尾空格并忽略纯空白名称", () => {
+  const nodes = buildDatabaseTreeNodes("conn-1", [{ name: " analytics" }, { name: "analytics" }, { name: "archive " }, { name: "   " }]);
+
+  assert.deepEqual(
+    nodes.map((node) => ({ id: node.id, label: node.label, database: node.database })),
+    [
+      { id: "conn-1: analytics", label: " analytics", database: " analytics" },
+      { id: "conn-1:analytics", label: "analytics", database: "analytics" },
+      { id: "conn-1:archive ", label: "archive ", database: "archive " },
+    ],
+  );
+});


### PR DESCRIPTION
## 问题

数据库名称以空格开头时，前端数据库树和后端连接配置会对名称执行 `trim()`，导致实际连接到错误的数据库；当空格名称与非空格名称同时存在时，还可能错误复用同一个连接池。

## 修复

- 数据库树保留数据库名称的原始首尾空格，仅过滤纯空白名称
- 数据库连接 URL 对名称中的首尾空格进行正确编码
- 连接池键保留完整数据库名称，隔离近似名称数据库
- 升级数据库树缓存键，避免继续读取旧版本中已被截断的缓存
- 补充数据库树、连接配置、连接池键和 MySQL 初始化查询测试

## 验证

- `pnpm check`
- `cargo test -p dbx-core --no-default-features whitespace --lib`
- `cargo fmt --all -- --check`
- MySQL 真实实例：分别创建 `dbx_issue3485` 与 ` dbx_issue3485`，验证 `DATABASE()` 返回精确名称，标记表数据互不串库
- PostgreSQL 真实实例：分别创建 `dbx_issue3485` 与 ` dbx_issue3485`，验证 `current_database()` 返回精确名称，标记表数据互不串库
- 验证完成后已删除全部临时数据库

Closes #3485