### PR TITLE
fix(mcp): require managed runtime for desktop launch

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -89,16 +89,17 @@ pub async fn ai_agent_stream(
     allow_write_sql: Option<bool>,
 ) -> Result<String, String> {
     let request = resolve_codex_cli_request(request);
-    let cancelled = dbx_core::ai::register_stream(&session_id).await;
 
     let parsed_db_type: DatabaseType =
         serde_json::from_str(&format!("\"{}\"", db_type)).map_err(|_| format!("Unknown database type: {db_type}"))?;
 
     let cli_mcp_server_command = if matches!(request.config.provider, AiProvider::CodexCli) {
-        super::mcp::resolve_mcp_server_command().await.map(|(program, args)| CliAgentCommandSpec { program, args })
+        let (program, args) = super::mcp::resolve_mcp_server_command().await?;
+        Some(CliAgentCommandSpec { program, args })
     } else {
         None
     };
+    let cancelled = dbx_core::ai::register_stream(&session_id).await;
     let production_database = state
         .configs
         .read()

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -201,8 +201,11 @@ async fn fetch_latest_mcp_version() -> Result<String, String> {
     Ok(package.version)
 }
 
-pub(crate) async fn resolve_mcp_server_command() -> Option<(String, Vec<String>)> {
-    tauri::async_runtime::spawn_blocking(resolve_mcp_server_command_sync).await.ok().flatten()
+pub(crate) async fn resolve_mcp_server_command() -> Result<(String, Vec<String>), String> {
+    let command = tauri::async_runtime::spawn_blocking(resolve_mcp_server_command_sync)
+        .await
+        .map_err(|err| format!("Failed to resolve DBX MCP Server runtime: {err}"))?;
+    require_managed_mcp_command(command)
 }
 
 fn resolve_mcp_server_command_sync() -> Option<(String, Vec<String>)> {
@@ -223,6 +226,15 @@ fn resolve_managed_mcp_command(
         log::warn!("Ignoring unbound MCP package shim at {}", shim.display());
     }
     None
+}
+
+fn require_managed_mcp_command(command: Option<(String, Vec<String>)>) -> Result<(String, Vec<String>), String> {
+    command.ok_or_else(|| {
+        format!(
+            "DBX MCP Server is unavailable: no compatible Node.js ({}) installation containing {} was found. Install MCP Server from DBX settings and try again.",
+            MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME
+        )
+    })
 }
 
 fn resolve_node_runtime() -> Option<NodeRuntime> {
@@ -799,8 +811,9 @@ mod tests {
     use super::{bash_login_script, canonical_runtime_path, NodeRuntimeCandidate};
     use super::{
         is_mcp_compatible_node_version, mcp_command_for_runtime, normalized_reported_path, npm_cli_candidates,
-        parse_node_version, prefer_runtime, prefixed_output_path, resolve_managed_mcp_command,
-        stdout_after_shell_marker, NodeRuntime, NodeVersion, SHELL_COMMAND_MARKER,
+        parse_node_version, prefer_runtime, prefixed_output_path, require_managed_mcp_command,
+        resolve_managed_mcp_command, stdout_after_shell_marker, NodeRuntime, NodeVersion,
+        MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME, SHELL_COMMAND_MARKER,
     };
     #[cfg(not(windows))]
     use super::{shell_command_script, shell_quote};
@@ -942,6 +955,15 @@ mod tests {
             resolve_managed_mcp_command(Some(&incompatible), || Some(PathBuf::from("/path/bin/dbx-mcp-server")));
 
         assert!(command.is_none());
+    }
+
+    #[test]
+    fn desktop_launch_requires_a_managed_mcp_command() {
+        let error = require_managed_mcp_command(None).unwrap_err();
+
+        assert!(error.contains(MCP_MIN_NODE_VERSION_REQUIREMENT));
+        assert!(error.contains(MCP_PACKAGE_NAME));
+        assert!(error.contains("DBX settings"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

补全 DBX Desktop 的 MCP 受管运行时约束：

- Codex CLI 启动前必须成功解析兼容的 Node.js 与 MCP package entry 组合。
- 无法解析时直接返回包含版本要求和恢复方式的错误，不再将 `None` 传入核心层并重新触发 `dbx-mcp-server` PATH shim 默认值。
- MCP 前置检查完成后再注册 AI stream，避免前置校验失败时留下无效任务。
- 保留 `dbx-web` 对核心层默认命令的现有行为。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端 UI 改动。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo fmt --all --check`
- `cargo test -p dbx commands::mcp::tests --no-default-features`（14 passed）
- `make check`
- `make cargo-check-fast`
- `git diff --check`

## 关联 Issue

Follow-up to #3455
