### PR TITLE
feat(grid): add set NULL context menu action

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -7045,6 +7045,11 @@ function selectionHasEditableCells(): boolean {
   return false;
 }
 
+function setSelectionNull() {
+  if (!props.editable || !selectionHasEditableCells()) return;
+  fillSelectionWithValue(null);
+}
+
 function openBulkEditDialog() {
   if (!props.editable || !selectionHasEditableCells()) return;
   bulkEditValue.value = "";
@@ -8975,10 +8980,19 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
   }
 
   if (props.editable && hasCellSelection.value) {
+    const hasEditableSelection = selectionHasEditableCells();
+    if (!contextHeaderColumn.value) {
+      items.push({
+        label: t("grid.setNull"),
+        action: setSelectionNull,
+        disabled: !hasEditableSelection,
+        icon: X,
+      });
+    }
     items.push({
       label: t("grid.bulkEditSelection"),
       action: openBulkEditDialog,
-      disabled: !selectionHasEditableCells(),
+      disabled: !hasEditableSelection,
       icon: Pencil,
     });
   }

--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -299,6 +299,8 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
   }
 
   function touchPendingChanges() {
+    // Save errors describe the previous pending snapshot; edits, undo/redo, and rollback make them stale.
+    saveError.value = "";
     pendingChangesVersion.value++;
   }
 

--- a/packages/app-tests/dataGridContextMenu.test.ts
+++ b/packages/app-tests/dataGridContextMenu.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+import { compileScript, parse } from "vue/compiler-sfc";
+
+const dataGridPath = "apps/desktop/src/components/grid/DataGrid.vue";
+const dataGridSource = readFileSync(dataGridPath, "utf8");
+
+test("DataGrid context menu script compiles", () => {
+  const { descriptor, errors } = parse(dataGridSource, { filename: dataGridPath });
+
+  assert.deepEqual(errors, []);
+  assert.ok(descriptor.scriptSetup);
+  compileScript(descriptor, { id: "data-grid-context-menu-test" });
+});
+
+test("set NULL applies a real null value only to editable selections", () => {
+  const handler = dataGridSource.match(/function setSelectionNull\(\) \{[^]*?\n\}/)?.[0] ?? "";
+
+  assert.match(handler, /if \(!props\.editable \|\| !selectionHasEditableCells\(\)\) return;/);
+  assert.match(handler, /fillSelectionWithValue\(null\);/);
+  assert.doesNotMatch(handler, /fillSelectionWithValue\(["'](?:NULL)?["']\)/);
+});
+
+test("editable cell selections expose set NULL before bulk edit", () => {
+  const menuBlock = dataGridSource.match(/if \(props\.editable && hasCellSelection\.value\) \{[^]*?\n  \}/)?.[0] ?? "";
+
+  assert.match(menuBlock, /const hasEditableSelection = selectionHasEditableCells\(\);/);
+  assert.match(menuBlock, /if \(!contextHeaderColumn\.value\) \{/);
+  assert.match(menuBlock, /label: t\("grid\.setNull"\),\s+action: setSelectionNull,\s+disabled: !hasEditableSelection,\s+icon: X,/);
+  assert.match(menuBlock, /label: t\("grid\.bulkEditSelection"\),\s+action: openBulkEditDialog,\s+disabled: !hasEditableSelection,/);
+  assert.ok(menuBlock.indexOf('t("grid.setNull")') < menuBlock.indexOf('t("grid.bulkEditSelection")'));
+});

--- a/packages/app-tests/dataGridEditor.test.ts
+++ b/packages/app-tests/dataGridEditor.test.ts
@@ -618,6 +618,109 @@ test("undo and redo restore pending cell edits before save", () => {
   assert.deepEqual(editor.rowDataWithChanges(result.value.rows[0], 0), [1, "Ada Lovelace"]);
 });
 
+test("setting a cell to NULL records pending SQL and supports undo and redo", async () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+
+  const result = computed(() => ({
+    columns: ["id", "name"],
+    rows: [[1, "Ada"] as CellValue[]],
+  }));
+  const editor = createPeopleGridEditor(result);
+
+  editor.applyCellValue(0, 1, null);
+
+  assert.equal(editor.dirtyRows.value.get(0)?.get(1), null);
+  assert.equal(editor.hasPendingChanges.value, true);
+  assert.deepEqual(editor.rowDataWithChanges(result.value.rows[0], 0), [1, null]);
+
+  const statements = await editor.previewChanges();
+  assert.deepEqual(statements, ['UPDATE "people" SET "name" = NULL WHERE "id" = 1;']);
+  assert.doesNotMatch(statements.join("\n"), /["']NULL["']/);
+
+  editor.undoPendingChange();
+  assert.equal(editor.dirtyRows.value.size, 0);
+  assert.deepEqual(editor.rowDataWithChanges(result.value.rows[0], 0), [1, "Ada"]);
+
+  editor.redoPendingChange();
+  assert.equal(editor.dirtyRows.value.get(0)?.get(1), null);
+  assert.deepEqual(editor.rowDataWithChanges(result.value.rows[0], 0), [1, null]);
+});
+
+test("setting an existing NULL cell to NULL is a no-op", async () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+
+  const result = computed(() => ({
+    columns: ["id", "name"],
+    rows: [[1, null] as CellValue[]],
+  }));
+  const editor = createPeopleGridEditor(result);
+
+  editor.applyCellValue(0, 1, null);
+
+  assert.equal(editor.dirtyRows.value.size, 0);
+  assert.equal(editor.hasPendingChanges.value, false);
+  assert.equal(editor.canUndoPendingChange.value, false);
+  assert.deepEqual(await editor.previewChanges(), []);
+});
+
+test("a failed NULL save keeps the pending cell edit", async () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+  const editor = createQuickEntryEditor({
+    quickEntryEnabled: false,
+    save: async () => {
+      throw new Error("NULL write rejected");
+    },
+  });
+
+  editor.applyCellValue(0, 1, null);
+  await editor.saveChanges();
+
+  assert.equal(editor.saveError.value, "NULL write rejected");
+  assert.equal(editor.dirtyRows.value.get(0)?.get(1), null);
+  assert.equal(editor.hasPendingChanges.value, true);
+});
+
+test("a NOT NULL validation failure keeps the pending NULL cell edit recoverable", async () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+  globalThis.fetch = (async (input) => {
+    if (String(input) !== "/api/query/prepare-data-grid-save") return new Response("unexpected request", { status: 500 });
+    return new Response(
+      JSON.stringify({
+        validationError: 'Column "name" does not allow NULL.',
+        statements: [],
+        rollbackStatements: [],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }) as typeof fetch;
+  const editor = createPeopleGridEditor();
+
+  editor.applyCellValue(0, 1, null);
+  await editor.saveChanges();
+
+  assert.equal(editor.saveError.value, 'Column "name" does not allow NULL.');
+  assert.equal(editor.dirtyRows.value.get(0)?.get(1), null);
+  assert.equal(editor.hasPendingChanges.value, true);
+  assert.equal(editor.canUndoPendingChange.value, true);
+
+  editor.undoPendingChange();
+  assert.equal(editor.dirtyRows.value.size, 0);
+  assert.equal(editor.saveError.value, "");
+
+  editor.redoPendingChange();
+  await editor.saveChanges();
+  assert.equal(editor.saveError.value, 'Column "name" does not allow NULL.');
+
+  editor.discardChanges();
+  assert.equal(editor.dirtyRows.value.size, 0);
+  assert.equal(editor.hasPendingChanges.value, false);
+  assert.equal(editor.saveError.value, "");
+});
+
 test("restoring a pending cell edit records undo and redo history", () => {
   setActivePinia(createPinia());
   installBrowserTestGlobals();


### PR DESCRIPTION
## Change summary

Add a **Set NULL** action to editable DataGrid cell-selection context menus.

- Reuse the existing pending-edit workflow and write a real JavaScript `null` without saving immediately.
- Preserve the current right-click selection behavior and skip cells protected by the existing editability guards.
- Hide the action from header and read-only menus, and disable it when the selection has no editable cells.
- Reuse the existing `grid.setNull` translations and `X` icon.
- Clear stale save/validation errors after the pending snapshot changes through editing, undo/redo, discard, or rollback.
- Keep the existing bulk-edit action and behavior unchanged.

## Change type

- [x] Feature
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Frontend impact

- [x] This PR changes frontend UI and interactions.

### Manual UI validation

Validated in the local Tauri desktop app against an isolated MySQL 8.3.0 instance:

- A single nullable cell enters the pending state as `NULL`; SQL preview uses unquoted `NULL`; save and refresh persist a database NULL.
- A multi-row cell selection sets only editable targets to NULL and preserves the selection when right-clicking inside it.
- Right-clicking outside the prior selection collapses the operation to the clicked cell.
- An already-NULL cell does not add a pending change.
- A NOT NULL write is rejected before execution, leaves the database unchanged, and remains recoverable.
- Undo, redo, save, discard/rollback, read-only results, header menus, and the existing bulk-edit action were verified.
- The stale validation banner found during manual testing now clears after rollback and was re-verified in the desktop app.

The desktop flow was manually verified before submission. A binary screenshot could not be attached through the CLI submission path.

## Verification

- [x] `pnpm exec vitest run packages/app-tests/dataGridContextMenu.test.ts packages/app-tests/dataGridEditor.test.ts packages/app-tests/dataGridSelection.test.ts` — 49 tests passed
- [x] `pnpm check` — format, lint, typecheck, and full test suite passed
- [x] `cargo test -p dbx-core --no-default-features data_grid_sql` — 69 tests passed
- [x] `make cargo-check-fast` passed
- [x] `git diff --check` passed
- [x] Manual Tauri + MySQL 8.3.0 validation passed

Existing unrelated Rust warnings remain for the unused `AttachedDatabaseConfig` import, the unused `duckdb_paths_match` function, and `proc-macro-error2` future incompatibility.

## Related issue

Close #3488
