### PR TITLE
fix(grid): 修复多行转置关闭后滚动条消失、网格显示异常

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -97,6 +97,7 @@ import {
   nextKeyboardTransposeState,
   nextTransposeState,
   nextTransposeStateForRecordCount,
+  restoreDataGridAfterTranspose,
   transposeRecordIndexesForMode,
   transposeRecordWidthsForDensity,
   transposeFieldWidth,
@@ -128,7 +129,7 @@ import { isCancelSearchShortcut, isCopyCurrentRowShortcut, isDeleteCurrentRowSho
 import { dataGridHeaderContentWidth, scrollbarGutterWidth } from "@/lib/dataGrid/dataGridScrollGutter";
 import { canGoNextDataGridPage } from "@/lib/dataGrid/dataGridPagination";
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
-import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, restoredDataGridScrollLeft, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
+import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
 import { CANVAS_DATA_GRID_ROW_HEIGHT, drawCanvasDataGrid } from "@/lib/dataGrid/canvasDataGridRenderer";
 import { dataGridPreviewLabelKey, dataGridSaveActionMode, dataGridSaveToolbarState } from "@/lib/dataGrid/dataGridSaveUi";
 import type { QueryEditabilityReason } from "@/lib/sql/sqlAnalysis";
@@ -4837,11 +4838,10 @@ function drawCanvasGrid() {
 }
 
 watch(
-  [useCanvasGridRows, hasVisibleRows],
+  [useCanvasGridRows, hasVisibleRows, isErrorResult],
   () => {
-    // When an empty table gets its first pending row, the canvas scroller is created by
-    // the v-if branch after the original mount-time observer attempt has already no-op'd.
-    // Reattach after that branch mounts so the canvas/overlay get real viewport dimensions.
+    // Empty and error surfaces replace the canvas scroller. Reattach after the
+    // normal branch remounts so the canvas/overlay get real viewport dimensions.
     nextTick(attachCanvasResizeObserver);
   },
   { immediate: true },
@@ -6303,12 +6303,12 @@ watch(isTransposeMode, (active) => {
   }
 
   nextTick(() => {
-    const scroller = gridScrollerElement();
-    if (!scroller) return;
-    // Transpose mode replaces the normal grid scroller, so restore its state and
-    // reconnect overflow observers only after Vue mounts the new element.
-    scroller.scrollLeft = restoredDataGridScrollLeft(gridScrollLeftBeforeTranspose, scroller.scrollWidth, scroller.clientWidth);
-    refreshGridScrollerMetrics();
+    restoreDataGridAfterTranspose({
+      scroller: gridScrollerElement(),
+      scrollLeftBeforeTranspose: gridScrollLeftBeforeTranspose,
+      attachCanvasResizeObserver,
+      refreshGridScrollerMetrics,
+    });
   });
 });
 

--- a/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
@@ -1,4 +1,5 @@
 import { COLUMN_WIDTH_DENSITY_PRESETS, percentileValue } from "@/lib/dataGrid/dataGridColumnWidth";
+import { restoredDataGridScrollLeft } from "@/lib/dataGrid/dataGridInfiniteScroll";
 import type { ColumnWidthDensity } from "@/stores/settingsStore";
 
 export interface DataGridTransposeState {
@@ -172,6 +173,13 @@ export function nextTransposeState(showTranspose: boolean, transposeRowIndex: nu
     return { showTranspose: false, transposeRowIndex: null };
   }
   return { showTranspose: true, transposeRowIndex: requestedRowIndex };
+}
+
+export function restoreDataGridAfterTranspose(options: { scroller: Pick<HTMLElement, "scrollLeft" | "scrollWidth" | "clientWidth"> | null; scrollLeftBeforeTranspose: number; attachCanvasResizeObserver: () => void; refreshGridScrollerMetrics: () => void }) {
+  if (!options.scroller) return;
+  options.scroller.scrollLeft = restoredDataGridScrollLeft(options.scrollLeftBeforeTranspose, options.scroller.scrollWidth, options.scroller.clientWidth);
+  options.attachCanvasResizeObserver();
+  options.refreshGridScrollerMetrics();
 }
 
 export function nextContextTransposeState(options: ContextTransposeStateOptions): DataGridTransposeState {

--- a/packages/app-tests/dataGridTransposeLifecycle.test.ts
+++ b/packages/app-tests/dataGridTransposeLifecycle.test.ts
@@ -1,0 +1,140 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+import { useDataGridCanvasRuntime, type DataGridAnimationFrameDriver } from "../../apps/desktop/src/composables/useDataGridCanvasRuntime.ts";
+import { useDataGridScrollbars } from "../../apps/desktop/src/composables/useDataGridScrollbars.ts";
+import { restoreDataGridAfterTranspose, transposeRecordIndexesForMode } from "../../apps/desktop/src/lib/dataGrid/dataGridTranspose.ts";
+
+type TestScroller = HTMLElement & { clientHeight: number };
+
+function createScroller(scrollWidth: number, clientWidth: number, clientHeight: number): TestScroller {
+  return {
+    children: [],
+    scrollLeft: 0,
+    scrollWidth,
+    clientWidth,
+    clientHeight,
+  } as unknown as TestScroller;
+}
+
+function createFrameDriver() {
+  let nextId = 0;
+  const frames = new Map<number, FrameRequestCallback>();
+  const driver: DataGridAnimationFrameDriver = {
+    request(callback) {
+      const id = nextId++;
+      frames.set(id, callback);
+      return id;
+    },
+    cancel(id) {
+      frames.delete(id);
+    },
+  };
+  return {
+    driver,
+    runAll() {
+      while (frames.size > 0) {
+        const pending = [...frames.entries()];
+        frames.clear();
+        pending.forEach(([, callback]) => callback(0));
+      }
+    },
+  };
+}
+
+function createObserverHarness() {
+  const callbacks: ResizeObserverCallback[] = [];
+  const observed: Element[] = [];
+  return {
+    observed,
+    create(callback: ResizeObserverCallback) {
+      callbacks.push(callback);
+      return {
+        disconnect() {},
+        observe(element: Element) {
+          observed.push(element);
+        },
+      } as unknown as ResizeObserver;
+    },
+    fireLatest() {
+      callbacks.at(-1)?.([], {} as ResizeObserver);
+    },
+  };
+}
+
+test("restores a wide canvas grid after single-row and multi-row transpose remounts", () => {
+  const frames = createFrameDriver();
+  const canvasObservers = createObserverHarness();
+  let viewport: TestScroller | null = createScroller(1600, 600, 320);
+  let syncedViewportHeight = 0;
+  let hasHorizontalOverflow = false;
+
+  const canvasRuntime = useDataGridCanvasRuntime({
+    draw() {},
+    syncViewport() {
+      syncedViewportHeight = viewport?.clientHeight ?? 0;
+    },
+    getViewport: () => viewport,
+    frameDriver: frames.driver,
+    createResizeObserver: canvasObservers.create,
+  });
+  const scrollbarsRuntime = useDataGridScrollbars({
+    update() {
+      hasHorizontalOverflow = !!viewport && viewport.scrollWidth - viewport.clientWidth > 1;
+    },
+    getScroller: () => viewport,
+    applyHorizontalDrag() {},
+    applyVerticalDrag() {},
+    frameDriver: frames.driver,
+  });
+
+  canvasRuntime.observeViewport();
+  scrollbarsRuntime.observeScroller();
+  frames.runAll();
+
+  for (const { mode, multiRow, expectedRecordIndexes, savedScrollLeft } of [
+    { mode: "single-row", multiRow: false, expectedRecordIndexes: [1], savedScrollLeft: 320 },
+    { mode: "multi-row", multiRow: true, expectedRecordIndexes: [0, 1, 2], savedScrollLeft: 540 },
+  ]) {
+    assert.deepEqual(
+      transposeRecordIndexesForMode({
+        multiRow,
+        activeRecordIndex: 1,
+        totalRecords: 3,
+        visibleRecordIndexes: [0, 1, 2],
+      }),
+      expectedRecordIndexes,
+    );
+    viewport!.scrollLeft = savedScrollLeft;
+    viewport = null;
+    canvasRuntime.observeViewport();
+    scrollbarsRuntime.observeScroller();
+    frames.runAll();
+    assert.equal(hasHorizontalOverflow, false, `${mode} transpose should remove the normal grid scrollbar`);
+
+    viewport = createScroller(1600, 600, 320);
+    restoreDataGridAfterTranspose({
+      scroller: viewport,
+      scrollLeftBeforeTranspose: savedScrollLeft,
+      attachCanvasResizeObserver: canvasRuntime.observeViewport,
+      refreshGridScrollerMetrics: scrollbarsRuntime.observeScroller,
+    });
+    frames.runAll();
+
+    assert.equal(viewport.scrollLeft, savedScrollLeft, `${mode} transpose should restore horizontal position`);
+    assert.equal(hasHorizontalOverflow, true, `${mode} transpose should restore the custom scrollbar`);
+    assert.equal(canvasObservers.observed.at(-1), viewport, `${mode} transpose should observe the remounted canvas scroller`);
+
+    viewport.clientHeight = 180;
+    canvasObservers.fireLatest();
+    assert.equal(syncedViewportHeight, 180, `${mode} transpose should react to a later container resize`);
+  }
+
+  canvasRuntime.dispose();
+  scrollbarsRuntime.dispose();
+});
+
+test("error result recovery participates in canvas observer remounts", () => {
+  const source = readFileSync("apps/desktop/src/components/grid/DataGrid.vue", "utf8");
+  assert.match(source, /watch\(\s*\[useCanvasGridRows, hasVisibleRows, isErrorResult\]/);
+});


### PR DESCRIPTION
Fixes #3447

## 问题

数据网格开启单行或多行转置后再关闭，普通网格的 DOM 会重新挂载。旧滚动容器上的观察器随之失效，导致自定义横向滚动条不能恢复；canvas 也不再响应后续容器尺寸变化。在宽表场景下还会丢失关闭转置前的横向位置。

## 根因

转置视图与普通网格是同级的 `v-if / v-else` 分支。切换到转置时普通网格滚动容器被卸载，关闭转置后：

1. 新滚动容器没有重新绑定 canvas 的 `ResizeObserver`；
2. 自定义滚动条指标没有立即刷新；
3. 主分支最新加入的 `scrollLeft` 恢复逻辑与观察器恢复逻辑没有合并；
4. 错误结果会同样替换网格分支，错误恢复为正常结果后也需要重新绑定观察器。

## 修复

- 重基到最新 `main`，保留并整合主分支的横向滚动位置恢复逻辑；
- 关闭转置并等待 DOM 更新后，按顺序恢复 `scrollLeft`、重新绑定 canvas 观察器、刷新滚动条指标；
- 将错误状态加入网格生命周期 watcher，确保错误界面恢复为正常结果时观察器重新挂载；
- 把恢复流程提取为可直接回归测试的纯编排函数，不引入新依赖。

## 自动化回归

新增生命周期回归，覆盖：

- 宽网格；
- 单行转置和多行转置；
- 关闭转置后自定义横向滚动条恢复；
- 关闭转置前横向位置恢复；
- 普通网格重新挂载后 canvas 重新观察容器，并响应容器尺寸变化；
- 错误结果恢复为正常网格时的 watcher 接线。

## 验证

- 相关测试：4 个测试文件、33 个测试通过；
- 非 `node-core` 测试：427 个测试文件、3539 个测试通过；
- 格式检查、lint、Vue 类型检查、diff 检查通过；
- 本地完整测试仅有 4 个 `node-core` 用例因共享 `better-sqlite3` 原生模块 ABI 与当前 Node 版本不匹配而无法加载，和本次改动无关。