### PR TITLE
Fix：兼容 Cnch/ClickHouse MySQL 协议连接初始化

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -644,7 +644,9 @@ fn mysql_group_concat_setup_fallback_mode(setup_mode: MySqlSetupMode, error: &st
     }
 
     let lower = error.to_ascii_lowercase();
-    if lower.contains("group_concat_max_len") && (lower.contains("1193") || lower.contains("unknown system variable")) {
+    let setup_query_rejected =
+        lower.contains("1193") || lower.contains("unknown system variable") || lower.contains("syntax error");
+    if lower.contains("group_concat_max_len") && setup_query_rejected {
         return Some(MySqlSetupMode::Compatible);
     }
 
@@ -4480,6 +4482,16 @@ UNIQUE KEY(`tenant_id`, `name``part`)
     #[test]
     fn mysql_group_concat_setup_error_retries_without_session_variable() {
         let error = "MySQL connection failed: Server error: `ERROR HY000 (1193): Unknown system variable,stmt:SET @@group_concat_max_len = 1048576'";
+
+        assert_eq!(
+            mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error),
+            Some(MySqlSetupMode::Compatible)
+        );
+    }
+
+    #[test]
+    fn mysql_cnch_group_concat_syntax_error_retries_without_session_variable() {
+        let error = "MySQL connection failed: Server error: `ERROR HY000 (1105): unknown error: Error 62 (HY000): Code: 62, e.displayText() = DB::Exception: host = cnch-server-2: Syntax error: failed at position 13 ('group_concat_max_len'): group_concat_max_len = 1048576. Expected one of: Dot, token, Equals SQLSTATE: 42000 (version 21.8.7.1)'";
 
         assert_eq!(
             mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error),


### PR DESCRIPTION
**问题现象**

用户升级最新版后，通过 MySQL 连接类型访问 Cnch/ClickHouse MySQL 协议接口时无法连接，服务端返回：

```text
ERROR HY000 (1105): ... Code: 62 ... Syntax error: failed at position 13 (group_concat_max_len): group_concat_max_len = 1048576
```

升级前同一连接配置可以正常使用。

**原因分析**

DBX 为避免 MySQL 元数据查询中的 `GROUP_CONCAT` 被默认长度 1024 截断，会在建立连接时执行：

```sql
SET SESSION group_concat_max_len = 1048576
```

#3409 为兼容会错误解析 `@@group_concat_max_len` 的部分 MySQL 代理，将初始化语句调整为 `SET SESSION`。标准 MySQL 支持该语法，但 Cnch/ClickHouse 21.8 的 MySQL 协议接口不支持，并返回 `1105 + Code 62 + Syntax error`。

现有连接兜底只识别 MySQL 原生的 `1193` 或 `Unknown system variable`，因此没有切换到 Compatible 模式，最终导致整个连接失败。

**修复内容**

- 当错误同时明确包含 `group_concat_max_len` 和 `Syntax error` 时，判定为可选初始化语句不受支持。
- 自动使用 Compatible 模式重建连接池，不再执行该变量设置。
- 不对所有 `1105` 错误进行宽泛回退；无关的代理错误仍按原错误返回，避免掩盖真实连接问题。
- 标准 MySQL 继续设置 `group_concat_max_len`，不影响现有元数据完整性。
- 增加 Cnch/ClickHouse `1105 / Code 62` 原始错误结构的回归测试。

**验证结果**

- `cargo test -p dbx-core --no-default-features group_concat --lib`：5 项通过。
- `cargo check -p dbx-core --no-default-features`：通过。
- `cargo fmt --check`：通过。
- `git diff --check`：通过。