### PR TITLE
Fix：修复 Kingbase MySQL 兼容模式只显示当前数据库

### DIFF
--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -100,10 +100,6 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     public List<DatabaseInfo> listDatabases() {
         if (postgresCatalogMode) return super.listDatabases();
         return unchecked(() -> {
-            if (isMysqlCompatMode()) {
-                List<DatabaseInfo> result = queryDatabases("SELECT current_database() AS database_name");
-                if (!result.isEmpty()) return result;
-            }
             for (String sql : List.of(
                 "SELECT datname AS database_name FROM sys_catalog.sys_database WHERE datistemplate = false ORDER BY datname",
                 "SELECT datname AS database_name FROM pg_database WHERE datistemplate = false ORDER BY datname"
@@ -113,6 +109,14 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                     if (!result.isEmpty()) return result;
                 } catch (Exception ignored) {
                     // Kingbase catalog names differ across compatibility modes and versions.
+                }
+            }
+            if (isMysqlCompatMode()) {
+                try {
+                    List<DatabaseInfo> result = queryDatabases("SELECT current_database() AS database_name");
+                    if (!result.isEmpty()) return result;
+                } catch (Exception ignored) {
+                    // Keep the configured database as the final fallback if current_database() is unavailable.
                 }
             }
             return Collections.singletonList(new DatabaseInfo(getConfiguredDatabase()));

--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -101,8 +101,8 @@ public final class KingbaseAgent extends PostgresLikeAgent {
         if (postgresCatalogMode) return super.listDatabases();
         return unchecked(() -> {
             for (String sql : List.of(
-                "SELECT datname AS database_name FROM sys_catalog.sys_database WHERE datistemplate = false ORDER BY datname",
-                "SELECT datname AS database_name FROM pg_database WHERE datistemplate = false ORDER BY datname"
+                "SELECT datname AS database_name FROM sys_catalog.sys_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname",
+                "SELECT datname AS database_name FROM pg_database WHERE datistemplate = false AND datallowconn = true ORDER BY datname"
             )) {
                 try {
                     List<DatabaseInfo> result = queryDatabases(sql);

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -74,6 +74,7 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertEquals("app", databases.get(0).getName());
         Assertions.assertEquals("analytics", databases.get(1).getName());
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_database"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("datallowconn = true"), sql.get(0));
     }
 
     @Test
@@ -89,7 +90,9 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         Assertions.assertEquals("TEST", agent.listDatabases().get(0).getName());
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_database"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("datallowconn = true"), sql.get(0));
         Assertions.assertTrue(sql.get(1).contains("FROM pg_database"), sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("datallowconn = true"), sql.get(1));
         Assertions.assertEquals("SELECT current_database() AS database_name", sql.get(2));
     }
 
@@ -107,6 +110,7 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertEquals("app", databases.get(0).getName());
         Assertions.assertEquals("analytics", databases.get(1).getName());
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_database"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("datallowconn = true"), sql.get(0));
     }
 
     @Test
@@ -124,6 +128,7 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertEquals("test", databases.get(0).getName());
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_database"), sql.get(0));
         Assertions.assertTrue(sql.get(1).contains("FROM pg_database"), sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("datallowconn = true"), sql.get(1));
     }
 
     @Test

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -59,17 +59,38 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
-    void mysqlCompatListDatabasesUsesCurrentDatabase() {
+    void mysqlCompatListDatabasesUsesKingbaseCatalog() {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
         agent.setMysqlCompatMode(true);
         TestSupport.setPrivateConnection(agent, preparedConnection(sql, resultSet(
             new String[]{"database_name"},
-            new Object[][]{{"TEST"}}
+            new Object[][]{{"app"}, {"analytics"}}
         )));
 
+        List<DatabaseInfo> databases = agent.listDatabases();
+
+        Assertions.assertEquals(2, databases.size());
+        Assertions.assertEquals("app", databases.get(0).getName());
+        Assertions.assertEquals("analytics", databases.get(1).getName());
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_database"), sql.get(0));
+    }
+
+    @Test
+    void mysqlCompatListDatabasesFallsBackToCurrentDatabase() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        agent.setMysqlCompatMode(true);
+        TestSupport.setPrivateConnection(agent, preparedConnectionWithFailures(
+            sql,
+            List.of("sys_catalog.sys_database", "FROM pg_database"),
+            resultSet(new String[]{"database_name"}, new Object[][]{{"TEST"}})
+        ));
+
         Assertions.assertEquals("TEST", agent.listDatabases().get(0).getName());
-        Assertions.assertEquals("SELECT current_database() AS database_name", sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_database"), sql.get(0));
+        Assertions.assertTrue(sql.get(1).contains("FROM pg_database"), sql.get(1));
+        Assertions.assertEquals("SELECT current_database() AS database_name", sql.get(2));
     }
 
     @Test
@@ -602,14 +623,20 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     private static Connection preparedConnectionWithFailure(List<String> sql, String failingSqlFragment, ResultSet fallback) {
+        return preparedConnectionWithFailures(sql, List.of(failingSqlFragment), fallback);
+    }
+
+    private static Connection preparedConnectionWithFailures(List<String> sql, List<String> failingSqlFragments, ResultSet fallback) {
         return proxy(Connection.class, (method, args) -> {
             if ("prepareStatement".equals(method.getName())) {
                 String preparedSql = String.valueOf(args[0]);
                 sql.add(preparedSql);
                 return proxy(PreparedStatement.class, (statementMethod, statementArgs) -> {
                     if ("executeQuery".equals(statementMethod.getName())) {
-                        if (preparedSql.contains(failingSqlFragment)) {
-                            throw new SQLException("relation does not exist: " + failingSqlFragment);
+                        for (String failingSqlFragment : failingSqlFragments) {
+                            if (preparedSql.contains(failingSqlFragment)) {
+                                throw new SQLException("relation does not exist: " + failingSqlFragment);
+                            }
                         }
                         return fallback;
                     }


### PR DESCRIPTION
## 问题原因

Kingbase Agent 在 #3257 之后能够自动识别 MySQL 兼容模式，但该模式下的数据库枚举会优先执行 `SELECT current_database()` 并立即返回。因此即使 `sys_catalog.sys_database` 中存在多个可连接数据库，侧边栏也只能收到当前数据库。

## 修复方案

- 非 PostgreSQL 目录模式统一优先查询 `sys_catalog.sys_database`，获取完整的非模板数据库列表
- 保留 `pg_database` 作为不同 Kingbase 版本和兼容模式的目录回退
- 仅当两个数据库目录均不可用时，MySQL 兼容模式才回退到 `current_database()`
- 如果连 `current_database()` 也不可用，继续保留配置数据库作为最终兜底
- 增加 MySQL 兼容模式多数据库返回及旧版本回退路径测试

普通 Kingbase 和 PostgreSQL 兼容目录模式的原有分支不变；不暴露数据库目录的旧版 MySQL 兼容实例仍保持只显示当前数据库的兼容行为。

## 测试

- `./gradlew :kingbase:test`
- `./gradlew test shadowJar --continue`：150 个 Gradle 任务通过
- Agent 脚本测试、配置校验及 JAR 校验通过
- Oracle/Xugu 原生 Agent Go 测试与 Linux amd64 构建通过

真实 Kingbase MySQL 兼容实例验证：

- 修复前 Kingbase Agent `0.1.32` 仅返回 `dbx_kingbase_demo`
- 本分支 Agent 返回 `dbx_kingbase_demo`、`dbx_kingbase_demo2`、`SAMPLES`、`SECURITY`、`TEST`
- `dbx_kingbase_demo2` 可独立连接，`current_database()` 返回该库，并成功读取 `PUBLIC`、`sales` Schema