### PR TITLE
fix(structure): SQL Server 结构变更脚本按 GO 分批，避免单条失败中断整个脚本

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -21,6 +21,7 @@ import { useSettingsStore, type StructureEditorDensity } from "@/stores/settings
 import { useTheme } from "@/composables/useTheme";
 import { useToast } from "@/composables/useToast";
 import { type SqlHighlighter, createShikiSqlHighlighter } from "@/lib/sql/sqlHighlighter";
+import { joinSqlStatementsForScript } from "@/lib/sql/sqlBatchScript";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatSqlForDisplay, sqlFormatDialectForDbType } from "@/lib/sql/sqlFormatter";
 import { queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
@@ -99,10 +100,10 @@ onMounted(async () => {
 
 const highlightedSql = computed(() => {
   if (!pendingStatements.value.length) return "";
-  const sql = pendingStatements.value.join("\n");
+  const sql = previewSqlText.value;
   return sqlHighlighter.value?.(sql) ?? sql;
 });
-const previewSqlText = computed(() => pendingStatements.value.join("\n"));
+const previewSqlText = computed(() => joinSqlStatementsForScript(pendingStatements.value, databaseType.value));
 
 const props = defineProps<{
   connectionId: string;

--- a/apps/desktop/src/lib/sql/sqlBatchScript.ts
+++ b/apps/desktop/src/lib/sql/sqlBatchScript.ts
@@ -3,8 +3,8 @@ import type { DatabaseType } from "@/types/database";
 /**
  * Joins generated DDL statements into a script for display/copy. SQL Server statements
  * are separated with GO so tools that execute the copied script (SSMS, sqlcmd, DBX's
- * GO-aware runner) treat each statement as an independent batch — one failing statement
- * (e.g. a column that already exists) no longer aborts the rest of the script.
+ * GO-aware runner) treat each statement as an independent batch. GO only defines batch
+ * boundaries; whether execution continues after an error depends on the client policy.
  */
 export function joinSqlStatementsForScript(statements: readonly string[], databaseType?: DatabaseType): string {
   if (databaseType !== "sqlserver") return statements.join("\n");

--- a/apps/desktop/src/lib/sql/sqlBatchScript.ts
+++ b/apps/desktop/src/lib/sql/sqlBatchScript.ts
@@ -1,0 +1,12 @@
+import type { DatabaseType } from "@/types/database";
+
+/**
+ * Joins generated DDL statements into a script for display/copy. SQL Server statements
+ * are separated with GO so tools that execute the copied script (SSMS, sqlcmd, DBX's
+ * GO-aware runner) treat each statement as an independent batch — one failing statement
+ * (e.g. a column that already exists) no longer aborts the rest of the script.
+ */
+export function joinSqlStatementsForScript(statements: readonly string[], databaseType?: DatabaseType): string {
+  if (databaseType !== "sqlserver") return statements.join("\n");
+  return statements.map((statement) => statement.trimEnd()).join("\nGO\n");
+}

--- a/packages/app-tests/sqlBatchScript.test.ts
+++ b/packages/app-tests/sqlBatchScript.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { joinSqlStatementsForScript } from "../../apps/desktop/src/lib/sql/sqlBatchScript.ts";
+
+const statements = [
+  "ALTER TABLE [dbo].[GOODS] ADD [FYLKH] nvarchar(255);",
+  "IF EXISTS (SELECT 1 FROM sys.extended_properties WHERE name = N'MS_Description') EXEC sys.sp_dropextendedproperty @name=N'MS_Description';",
+  "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'用料款号';",
+];
+
+test("separates SQL Server statements with GO batch separators", () => {
+  const script = joinSqlStatementsForScript(statements, "sqlserver");
+  assert.equal(script, statements.join("\nGO\n"));
+});
+
+test("does not append a trailing GO after the last SQL Server statement", () => {
+  const script = joinSqlStatementsForScript(statements, "sqlserver");
+  assert.ok(!script.endsWith("GO"));
+  assert.equal(script.split("\nGO\n").length, statements.length);
+});
+
+test("keeps a single SQL Server statement without GO", () => {
+  assert.equal(joinSqlStatementsForScript([statements[0]], "sqlserver"), statements[0]);
+});
+
+test("joins statements with newlines for other database types", () => {
+  assert.equal(joinSqlStatementsForScript(statements, "mysql"), statements.join("\n"));
+  assert.equal(joinSqlStatementsForScript(statements, undefined), statements.join("\n"));
+});
+
+test("returns an empty script for an empty statement list", () => {
+  assert.equal(joinSqlStatementsForScript([], "sqlserver"), "");
+  assert.equal(joinSqlStatementsForScript([], "mysql"), "");
+});
+
+test("keeps GO on its own line when statements carry trailing whitespace", () => {
+  const script = joinSqlStatementsForScript(["SELECT 1;\n", "SELECT 2;  "], "sqlserver");
+  assert.equal(script, "SELECT 1;\nGO\nSELECT 2;");
+});


### PR DESCRIPTION
Fixes #3408

## 问题

表结构编辑器为 SQL Server 生成的变更脚本（`ALTER TABLE ADD` + 注释的 `sp_addextendedproperty` 等）在预览/复制时只用换行拼接，没有 `GO` 批分隔符。用户把脚本拷出去执行时整个脚本是一个批——任一语句失败（如第一个字段已存在数据库），整批中止，后面的字段全部加不上。

## 修复

- 新增纯函数 `apps/desktop/src/lib/sql/sqlBatchScript.ts`：`joinSqlStatementsForScript(statements, databaseType)`，仅当 `sqlserver`（含 JDBC 走 sqlserver 方言的连接）时用 `GO` 分隔语句，与 SSMS 生成脚本一致；其他数据库保持原有换行拼接。
- `TableStructureEditor.vue` 的 SQL 预览高亮、复制 SQL、历史记录改走该函数。
- **内部"应用变更"路径不变**：`executeBatch` 仍接收原始语句数组，`GO` 只出现在展示/复制文本中。dbx-core 的 SQL 切分器已支持 sqlserver 的 `GO` 批分隔（`supports_go_batch_separator`），复制的脚本粘回 DBX 编辑器执行同样正常。
- 新增 6 个单元测试（GO 分隔、无尾随 GO、单语句、其他方言、空列表、尾随空白）。

## 验证

- 真实 SQL Server 2022（Docker）+ Playwright 驱动完整 UI 链路：结构编辑器加两个带中文注释的字段——预览正确显示 GO 分隔；界面"应用变更"成功，两列及注释均落库。
- **issue 场景 A/B 对照**（第一列已存在时用 sqlcmd 执行导出脚本）：
  - 无 GO（修复前）：首条 `ALTER` 报 2705 后整批中止，第二列未创建；
  - 有 GO（修复后）：首批报错但后续批独立执行，第二列与两条注释全部生效。
- `pnpm check` 全部通过（format / lint / typecheck / test）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)