### PR TITLE
修复隧道维护中 SSH config 别名无法选择

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -20,6 +20,7 @@ import type { NacosAdminConfig, NacosAuthConfig } from "@/types/nacos";
 import { CONNECTION_ATTEMPT_CANCELLED_MESSAGE, useConnectionStore } from "@/stores/connectionStore";
 import { useTunnelProfileStore } from "@/stores/tunnelProfileStore";
 import { detachTunnelProfileLayer, tunnelProfileReferenceLayer, tunnelProfileSummary } from "@/lib/connection/tunnelProfiles";
+import { applySshConfigHostAliasPrefill as prefillSshConfigHostAlias } from "@/lib/connection/sshConfigHosts";
 import { REDIS_SCAN_PAGE_SIZE_DEFAULT, REDIS_SCAN_PAGE_SIZE_MIN, REDIS_SCAN_PAGE_SIZE_MAX, REDIS_SCAN_PAGE_SIZE_OPTIONS } from "@/lib/redis/redisKeyPattern";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useToast } from "@/composables/useToast";
@@ -3480,24 +3481,8 @@ watch([() => editingId.value, () => open.value], () => {
 
 const sshConfigHostAliases = computed(() => sshConfigHosts.value.map((entry) => entry.alias));
 
-/**
- * Prefills user/port/key_path from a matching ~/.ssh/config alias, without
- * overwriting values the user already changed away from the form defaults.
- * This is a UX preview only — the authoritative resolution happens in the
- * Rust backend at connect time (see resolve_ssh_tunnel_config), so imported
- * configs that never touched this UI still resolve correctly.
- */
 function applySshConfigHostAliasPrefill(target: SshTunnelConfig) {
-  const entry = sshConfigHosts.value.find((candidate) => candidate.alias === target.host);
-  if (!entry) return;
-  if (target.user === DEFAULT_SSH_USER && entry.user) target.user = entry.user;
-  if (target.port === 22 && entry.port) target.port = entry.port;
-  if (!target.key_path && entry.identity_file) {
-    target.key_path = entry.identity_file;
-    if ((!target.auth_method || target.auth_method === "password") && !target.password?.trim()) {
-      target.auth_method = "key";
-    }
-  }
+  prefillSshConfigHostAlias(target, sshConfigHosts.value);
 }
 
 async function browseSshKeyPath(target?: SshTunnelConfig | null) {

--- a/apps/desktop/src/components/connection/TunnelProfileManager.vue
+++ b/apps/desktop/src/components/connection/TunnelProfileManager.vue
@@ -10,7 +10,9 @@ import { Loader2, Plus, Trash2 } from "@lucide/vue";
 import { useToast } from "@/composables/useToast";
 import { useTunnelProfileStore } from "@/stores/tunnelProfileStore";
 import { createTunnelProfile, createTunnelProfileTestGuard, tunnelProfileSummary, type TunnelProfileType } from "@/lib/connection/tunnelProfiles";
-import type { TunnelProfile } from "@/types/database";
+import { applySshConfigHostAliasPrefill as prefillSshConfigHostAlias } from "@/lib/connection/sshConfigHosts";
+import * as api from "@/lib/backend/api";
+import type { SshConfigHostEntry, TunnelProfile } from "@/types/database";
 import { translateBackendError } from "@/i18n/backend-errors";
 
 const { t } = useI18n();
@@ -24,6 +26,7 @@ const hasInitializedDraft = ref(false);
 const isTesting = ref(false);
 const testResult = ref<{ ok: boolean; message: string } | null>(null);
 const testGuard = createTunnelProfileTestGuard();
+const sshConfigHosts = ref<SshConfigHostEntry[]>([]);
 
 function cloneProfiles(profiles: TunnelProfile[]): TunnelProfile[] {
   return JSON.parse(JSON.stringify(profiles)) as TunnelProfile[];
@@ -56,6 +59,23 @@ const selected = computed(() => draft.value.find((profile) => profile.id === sel
 const selectedSsh = computed(() => (selected.value?.type === "ssh" ? selected.value : null));
 const selectedProxy = computed(() => (selected.value?.type === "proxy" ? selected.value : null));
 const selectedHttp = computed(() => (selected.value?.type === "http_tunnel" ? selected.value : null));
+const sshConfigHostAliases = computed(() => sshConfigHosts.value.map((entry) => entry.alias));
+
+async function loadSshConfigHosts() {
+  try {
+    sshConfigHosts.value = await api.listSshConfigHosts();
+  } catch {
+    sshConfigHosts.value = [];
+  }
+}
+
+function updateSelectedSshHost(value: string | number) {
+  if (!selectedSsh.value) return;
+  selectedSsh.value.host = String(value);
+  prefillSshConfigHostAlias(selectedSsh.value, sshConfigHosts.value);
+}
+
+void loadSshConfigHosts();
 
 function invalidateProfileTest() {
   testGuard.invalidate();
@@ -190,7 +210,10 @@ async function testSelected() {
       <template v-if="selectedSsh">
         <div class="grid grid-cols-4 items-center gap-4">
           <Label class="text-xs">{{ t("connection.sshHost") }}</Label>
-          <Input v-model="selectedSsh.host" class="col-span-2" :placeholder="t('connection.sshHostPlaceholder')" />
+          <Input :model-value="selectedSsh.host" class="col-span-2" list="tunnel-profile-ssh-config-host-aliases" :placeholder="t('connection.sshHostPlaceholder')" @update:model-value="updateSelectedSshHost" />
+          <datalist id="tunnel-profile-ssh-config-host-aliases">
+            <option v-for="alias in sshConfigHostAliases" :key="alias" :value="alias" />
+          </datalist>
           <Input v-model.number="selectedSsh.port" type="number" min="1" max="65535" class="col-span-1" />
         </div>
         <div class="grid grid-cols-4 items-center gap-4">

--- a/apps/desktop/src/lib/connection/sshConfigHosts.ts
+++ b/apps/desktop/src/lib/connection/sshConfigHosts.ts
@@ -1,0 +1,23 @@
+import type { SshConfigHostEntry, SshTunnelConfig } from "@/types/database";
+
+const DEFAULT_SSH_USER = "root";
+const DEFAULT_SSH_PORT = 22;
+
+/**
+ * Prefills an SSH form from a matching ~/.ssh/config alias without
+ * overwriting values the user already changed away from the form defaults.
+ * The Rust backend remains responsible for authoritative alias resolution at
+ * connect time; this helper only keeps the form preview consistent.
+ */
+export function applySshConfigHostAliasPrefill(target: SshTunnelConfig, hosts: readonly SshConfigHostEntry[]): void {
+  const entry = hosts.find((candidate) => candidate.alias === target.host);
+  if (!entry) return;
+  if (target.user === DEFAULT_SSH_USER && entry.user) target.user = entry.user;
+  if (target.port === DEFAULT_SSH_PORT && entry.port) target.port = entry.port;
+  if (!target.key_path && entry.identity_file) {
+    target.key_path = entry.identity_file;
+    if ((!target.auth_method || target.auth_method === "password") && !target.password?.trim()) {
+      target.auth_method = "key";
+    }
+  }
+}

--- a/packages/app-tests/sshConfigHosts.test.ts
+++ b/packages/app-tests/sshConfigHosts.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+import { applySshConfigHostAliasPrefill } from "../../apps/desktop/src/lib/connection/sshConfigHosts.ts";
+import type { SshTunnelConfig } from "../../apps/desktop/src/types/database.ts";
+
+function sshConfig(overrides: Partial<SshTunnelConfig> = {}): SshTunnelConfig {
+  return {
+    id: "ssh-1",
+    host: "production",
+    port: 22,
+    user: "root",
+    password: "",
+    key_path: "",
+    key_passphrase: "",
+    connect_timeout_secs: 5,
+    expose_lan: false,
+    auth_method: "password",
+    ...overrides,
+  };
+}
+
+const hosts = [
+  {
+    alias: "production",
+    host_name: "10.0.0.5",
+    port: 2222,
+    user: "deploy",
+    identity_file: "~/.ssh/production_ed25519",
+  },
+];
+
+test("prefills default SSH fields from a selected config alias", () => {
+  const target = sshConfig();
+
+  applySshConfigHostAliasPrefill(target, hosts);
+
+  assert.equal(target.host, "production");
+  assert.equal(target.port, 2222);
+  assert.equal(target.user, "deploy");
+  assert.equal(target.key_path, "~/.ssh/production_ed25519");
+  assert.equal(target.auth_method, "key");
+});
+
+test("does not overwrite explicit SSH form values", () => {
+  const target = sshConfig({ port: 2200, user: "admin", password: "secret", key_path: "~/.ssh/custom" });
+
+  applySshConfigHostAliasPrefill(target, hosts);
+
+  assert.equal(target.port, 2200);
+  assert.equal(target.user, "admin");
+  assert.equal(target.key_path, "~/.ssh/custom");
+  assert.equal(target.auth_method, "password");
+});
+
+test("leaves the form unchanged when no config alias matches", () => {
+  const target = sshConfig({ host: "unknown" });
+  const before = structuredClone(target);
+
+  applySshConfigHostAliasPrefill(target, hosts);
+
+  assert.deepEqual(target, before);
+});
+
+test("loads and exposes SSH config aliases in tunnel profile maintenance", () => {
+  const component = readFileSync(path.resolve("apps/desktop/src/components/connection/TunnelProfileManager.vue"), "utf8");
+
+  assert.match(component, /api\.listSshConfigHosts\(\)/);
+  assert.match(component, /list="tunnel-profile-ssh-config-host-aliases"/);
+  assert.match(component, /<datalist id="tunnel-profile-ssh-config-host-aliases">/);
+  assert.match(component, /@update:model-value="updateSelectedSshHost"/);
+});


### PR DESCRIPTION
## 问题

隧道维护页面的 SSH 主机输入框只显示了 `~/.ssh/config` 提示文案，但没有加载或绑定 Host 别名候选，因此点击后不会出现下拉选择。

## 修改

- 在隧道维护页面加载并展示 `~/.ssh/config` Host 别名
- 选择或输入完整别名后，自动预填用户、端口和密钥路径
- 将连接弹窗已有的预填规则提取为共享逻辑，保证两处行为一致
- 增加候选列表接入和预填规则测试

## 验证

- `pnpm exec vitest run packages/app-tests/sshConfigHosts.test.ts`（4 项通过）
- `pnpm typecheck`
- 改动文件通过 `oxlint` 和 `git diff --check`
- 使用隔离的临时 `~/.ssh/config` 完成真实 UI 验证：候选别名可加载，选择后端口、用户、密钥路径和登录方式均正确更新，页面无错误日志