### PR TITLE
fix(mysql): preserve fractional dashboard rates

### DIFF
--- a/apps/desktop/src/components/admin/MySqlDashboard.vue
+++ b/apps/desktop/src/components/admin/MySqlDashboard.vue
@@ -9,7 +9,7 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import MetricCard from "@/components/common/MetricCard.vue";
 import MetricLineChart from "@/components/chart/MetricLineChart.vue";
 import * as api from "@/lib/backend/api";
-import { computeQps, computeRate, formatBytes, formatBytesPerSec, formatNumber, formatUptime, GLOBAL_STATUS_SQL, GLOBAL_VARIABLES_SQL, innodbBufferHitRatio, MAX_SAMPLES, parseStatusResult, statusEntries, statusNumber, type StatusSample } from "@/lib/database/mysqlServerStatus";
+import { computeQps, computeRate, formatBytes, formatBytesPerSec, formatNumber, formatRate, formatUptime, GLOBAL_STATUS_SQL, GLOBAL_VARIABLES_SQL, innodbBufferHitRatio, MAX_SAMPLES, parseStatusResult, statusEntries, statusNumber, type StatusSample } from "@/lib/database/mysqlServerStatus";
 
 const props = defineProps<{
   connectionId: string;
@@ -195,7 +195,7 @@ onUnmounted(stopAutoRefresh);
 
     <div class="flex min-h-0 flex-1 flex-col gap-3 p-3">
       <div class="grid shrink-0 grid-cols-2 gap-3 sm:grid-cols-4">
-        <MetricCard :label="t('serverDashboard.qps')" :value="formatNumber(qps)" :icon="Gauge" />
+        <MetricCard :label="t('serverDashboard.qps')" :value="formatRate(qps)" :icon="Gauge" />
         <MetricCard :label="t('serverDashboard.connections')" :value="`${formatNumber(threadsConnected)}${maxConnections ? ' / ' + formatNumber(maxConnections) : ''}`" :icon="Users" />
         <MetricCard :label="t('serverDashboard.running')" :value="formatNumber(threadsRunning)" :icon="Activity" />
         <MetricCard :label="t('serverDashboard.trafficIn')" :value="formatBytesPerSec(rate('Bytes_received'))" :icon="ArrowDownUp" />
@@ -206,10 +206,10 @@ onUnmounted(stopAutoRefresh);
       </div>
 
       <div class="grid shrink-0 grid-cols-1 gap-3 xl:grid-cols-2">
-        <MetricLineChart :title="t('serverDashboard.qpsChart')" :labels="chartLabels" :series="qpsSeries" :value-formatter="formatNumber" />
-        <MetricLineChart :title="t('serverDashboard.sessionsChart')" :labels="chartLabels" :series="sessionsSeries" :value-formatter="formatNumber" />
+        <MetricLineChart :title="t('serverDashboard.qpsChart')" :labels="chartLabels" :series="qpsSeries" :value-formatter="formatRate" />
+        <MetricLineChart :title="t('serverDashboard.sessionsChart')" :labels="chartLabels" :series="sessionsSeries" :value-formatter="formatRate" />
         <MetricLineChart :title="t('serverDashboard.trafficChart')" :labels="chartLabels" :series="trafficSeries" :value-formatter="formatBytes" />
-        <MetricLineChart :title="t('serverDashboard.commandChart')" :labels="chartLabels" :series="commandSeries" :value-formatter="formatNumber" />
+        <MetricLineChart :title="t('serverDashboard.commandChart')" :labels="chartLabels" :series="commandSeries" :value-formatter="formatRate" />
       </div>
 
       <div class="flex flex-col rounded-lg border bg-card" :class="showStatusTable ? 'min-h-0 flex-1' : 'shrink-0'">

--- a/apps/desktop/src/lib/__tests__/database/mysqlServerStatus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/mysqlServerStatus.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { QueryResult } from "@/types/database";
-import { computeQps, computeRate, connectionSupportsServerDashboard, formatBytes, formatBytesPerSec, formatUptime, innodbBufferHitRatio, parseStatusResult, statusNumber, supportsServerDashboard, type StatusSample } from "@/lib/database/mysqlServerStatus";
+import { computeQps, computeRate, connectionSupportsServerDashboard, formatBytes, formatBytesPerSec, formatNumber, formatRate, formatUptime, innodbBufferHitRatio, parseStatusResult, statusNumber, supportsServerDashboard, type StatusSample } from "@/lib/database/mysqlServerStatus";
 
 function statusResult(rows: [string, string][]): QueryResult {
   return { columns: ["Variable_name", "Value"], rows, affected_rows: 0, execution_time_ms: 0 };
@@ -42,6 +42,14 @@ describe("computeRate", () => {
     expect(computeRate(prev, curr, "Bytes_sent")).toBe(2000); // 4000 bytes / 2s
   });
 
+  it("preserves a fractional connection rate over a longer sample interval", () => {
+    const prev = sample(0, { Connections: "100" });
+    const curr = sample(5000, { Connections: "101" });
+    const rate = computeRate(prev, curr, "Connections");
+    expect(rate).toBe(0.2);
+    expect(formatRate(rate)).toBe("0.2");
+  });
+
   it("returns 0 on counter reset (decrease)", () => {
     const prev = sample(1000, { Queries: "9000" });
     const curr = sample(2000, { Queries: "10" });
@@ -75,6 +83,24 @@ describe("innodbBufferHitRatio", () => {
 });
 
 describe("formatters", () => {
+  it("formats rates with up to three fractional digits", () => {
+    expect(formatRate(0)).toBe("0");
+    expect(formatRate(0.2)).toBe("0.2");
+    expect(formatRate(0.125)).toBe("0.125");
+    expect(formatRate(1 / 3)).toBe("0.333");
+    expect(formatRate(1)).toBe("1");
+    expect(formatRate(1000)).toBe("1,000");
+    expect(formatRate(1234.5678)).toBe("1,234.568");
+    expect(formatRate(Number.NaN)).toBe("0");
+    expect(formatRate(Number.POSITIVE_INFINITY)).toBe("0");
+    expect(formatRate(Number.NEGATIVE_INFINITY)).toBe("0");
+  });
+
+  it("keeps integer metric formatting unchanged", () => {
+    expect(formatNumber(0.2)).toBe("0");
+    expect(formatNumber(1234.6)).toBe("1,235");
+  });
+
   it("formats bytes and bytes/sec", () => {
     expect(formatBytes(0)).toBe("0 B");
     expect(formatBytes(1024)).toBe("1.0 KB");

--- a/apps/desktop/src/lib/database/mysqlServerStatus.ts
+++ b/apps/desktop/src/lib/database/mysqlServerStatus.ts
@@ -110,6 +110,13 @@ export function formatNumber(value: number): string {
   return Math.round(value).toLocaleString("en-US");
 }
 
+const RATE_NUMBER_FORMATTER = new Intl.NumberFormat("en-US", { maximumFractionDigits: 3 });
+
+/** Cumulative-counter rates can be below 1/s, so preserve their fractional value. */
+export function formatRate(value: number): string {
+  return Number.isFinite(value) ? RATE_NUMBER_FORMATTER.format(value) : "0";
+}
+
 const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"];
 
 export function formatBytes(value: number): string {


### PR DESCRIPTION
## 变更说明

Preserve fractional values for MySQL dashboard per-second metrics instead of rounding them to integers.

The rate calculation already returned the correct decimal value, but the QPS card and the QPS, new-session, and command-rate charts passed those values through `formatNumber`, which uses `Math.round`. For example, one new connection during a five-second interval was calculated as `0.2/s` but displayed as `0`.

This change adds a reusable rate formatter with up to three fractional digits and applies it to all per-second count metrics. Integer counters and byte-rate formatting remain unchanged.

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

This PR changes frontend metric formatting. Manual UI validation was completed with MySQL 8.0.46 and a five-second refresh interval. A post-fix screenshot was captured locally, but GitHub CLI cannot upload it as a PR attachment.

Observed results:

- The new-session chart displayed distinct fractional Y-axis labels from `0` through `0.25` and peaks around `0.2/s`.
- The QPS card displayed a fractional value such as `2.799`.
- The command-rate chart preserved fractional labels and data points.
- Integer cards remained integer-formatted.
- Traffic cards and charts retained byte units.

## 验证

- [x] `CI=true pnpm check` passed with Node 24.16.0
- [ ] `make cargo-check-fast` passed (not run; frontend-only change)
- [x] `CI=true pnpm exec vitest run apps/desktop/src/lib/__tests__/database/mysqlServerStatus.spec.ts`
- [x] `git diff --check`
- [x] Manual desktop validation against MySQL Community Server 8.0.46
- [x] Five-second sampling with one additional connection produced a fractional session rate instead of zero
- [x] Regression checks for integer metrics and byte-rate charts

## 关联 Issue

Fixes #3360