### PR TITLE
Feat：增加界面缩放微调档位

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -348,7 +348,7 @@ const editToolbarItems = ref({ ...settingsStore.editorSettings.toolbarItems });
 const systemFonts = ref<string[]>([]);
 const systemFontsLoading = ref(false);
 const systemFontsLoaded = ref(false);
-const uiScaleOptions = [0.75, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2];
+const uiScaleOptions = [0.75, 0.9, 0.95, 1, 1.05, 1.1, 1.15, 1.2, 1.25, 1.5, 1.75, 2];
 const fontSearchTriggerClass =
   "h-8 w-full max-w-none justify-between gap-1.5 rounded-[6px] border border-input bg-transparent py-2 pl-2.5 pr-2 text-sm font-normal shadow-none hover:bg-transparent focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-expanded:bg-transparent dark:bg-input/30 dark:hover:bg-input/50";
 const appearanceFontSearchTriggerClass = `${fontSearchTriggerClass} gap-0 pl-2 pr-1.5`;


### PR DESCRIPTION
**需求背景**

当前界面缩放在 100% 附近只有 `90% / 100% / 110% / 125%`。部分用户觉得 100% 字体偏小，但调整到下一档后又偏大，缺少适合高分屏和不同系统缩放设置的微调档位。

**改动内容**

在设置页的界面缩放下拉选项中增加：

- `95%`
- `105%`
- `115%`
- `120%`

调整后的完整顺序为：

```text
75%、90%、95%、100%、105%、110%、115%、120%、125%、150%、175%、200%
```

**兼容性说明**

- 缩放配置原本已支持两位小数保存并即时应用，无需调整存储结构或迁移旧配置。
- 默认值仍为 `100%`，不会改变现有用户界面大小。
- 原有档位全部保留，仅增加 100% 附近的细分选项。
- 本次没有新增界面文案，不涉及 i18n 调整。

**验证结果**

`pnpm check` 全部通过：

- format
- lint
- typecheck
- test