### PR TITLE
[codex] enable StarRocks user and privilege management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 .claude/
 .codex/
+.zcode/
 .superpowers/
 .trellis/
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules/
 .claude/
 .codex/
-.zcode/
 .superpowers/
 .trellis/
 .worktrees/

--- a/apps/desktop/src/components/admin/DatabaseUserAdmin.vue
+++ b/apps/desktop/src/components/admin/DatabaseUserAdmin.vue
@@ -15,6 +15,7 @@ import type { ConnectionConfig } from "@/types/database";
 import * as api from "@/lib/backend/api";
 import { executeWithProductionSqlGuard } from "@/lib/database/productionExecutionGuard";
 import { grantsFromQueryResult, getDatabaseUserAdminProvider, supportsDatabaseUserAdmin, type DatabaseUserIdentity, type PrivilegeScope } from "@/lib/database/databaseUserAdmin";
+import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 
 const props = defineProps<{
   connection: ConnectionConfig;
@@ -54,8 +55,9 @@ const grantOption = ref(false);
 const selectedPrivileges = ref<string[]>(["SELECT"]);
 const createCanLogin = ref(true);
 
-const supported = computed(() => supportsDatabaseUserAdmin(props.connection.db_type));
-const provider = computed(() => getDatabaseUserAdminProvider(props.connection.db_type));
+const effectiveType = computed(() => effectiveDatabaseTypeForConnection(props.connection));
+const supported = computed(() => supportsDatabaseUserAdmin(effectiveType.value));
+const provider = computed(() => getDatabaseUserAdminProvider(effectiveType.value));
 const isPostgres = computed(() => provider.value?.dialect === "postgres");
 const selectedUser = computed(() => users.value.find((user) => userKey(user) === selectedUserKey.value));
 const filteredUsers = computed(() => {
@@ -135,7 +137,7 @@ async function loadGrants() {
     const result = await api.executeQuery(props.connection.id, "", userProvider.showGrantsSql(user), undefined, undefined, {
       maxRows: 1000,
     });
-    grants.value = grantsFromQueryResult(result);
+    grants.value = (userProvider.parseGrants ?? grantsFromQueryResult)(result);
   } catch (error: any) {
     grantError.value = error?.message || String(error);
     grants.value = [];

--- a/apps/desktop/src/components/admin/DatabaseUserAdmin.vue
+++ b/apps/desktop/src/components/admin/DatabaseUserAdmin.vue
@@ -14,8 +14,7 @@ import { useSqlHighlighter } from "@/composables/useSqlHighlighter";
 import type { ConnectionConfig } from "@/types/database";
 import * as api from "@/lib/backend/api";
 import { executeWithProductionSqlGuard } from "@/lib/database/productionExecutionGuard";
-import { grantsFromQueryResult, getDatabaseUserAdminProvider, supportsDatabaseUserAdmin, type DatabaseUserIdentity, type PrivilegeScope } from "@/lib/database/databaseUserAdmin";
-import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
+import { grantsFromQueryResult, resolveDatabaseUserAdminProviderForConnection, type DatabaseUserIdentity, type PrivilegeScope } from "@/lib/database/databaseUserAdmin";
 
 const props = defineProps<{
   connection: ConnectionConfig;
@@ -55,10 +54,16 @@ const grantOption = ref(false);
 const selectedPrivileges = ref<string[]>(["SELECT"]);
 const createCanLogin = ref(true);
 
-const effectiveType = computed(() => effectiveDatabaseTypeForConnection(props.connection));
-const supported = computed(() => supportsDatabaseUserAdmin(effectiveType.value));
-const provider = computed(() => getDatabaseUserAdminProvider(effectiveType.value));
+const provider = computed(() => resolveDatabaseUserAdminProviderForConnection(props.connection));
+const supported = computed(() => provider.value !== null);
 const isPostgres = computed(() => provider.value?.dialect === "postgres");
+const canCreateUser = computed(() => !!provider.value?.createUserSql);
+const canAlterPassword = computed(() => !!provider.value?.alterPasswordSql);
+const canAlterLogin = computed(() => !!provider.value?.alterLoginSql);
+const canDropUser = computed(() => !!provider.value?.dropUserSql);
+const canGrantPrivileges = computed(() => !!provider.value?.grantPrivilegesSql);
+const canRevokePrivileges = computed(() => !!provider.value?.revokePrivilegesSql);
+const canEditPrivileges = computed(() => canGrantPrivileges.value || canRevokePrivileges.value);
 const selectedUser = computed(() => users.value.find((user) => userKey(user) === selectedUserKey.value));
 const filteredUsers = computed(() => {
   const query = search.value.trim().toLowerCase();
@@ -66,7 +71,7 @@ const filteredUsers = computed(() => {
   return users.value.filter((user) => userLabel(user).toLowerCase().includes(query));
 });
 const selectedPrivilegeSet = computed(() => new Set(selectedPrivileges.value));
-const availablePrivileges = computed(() => provider.value?.privilegesForScope(privilegeScope.value) ?? []);
+const availablePrivileges = computed(() => provider.value?.privilegesForScope?.(privilegeScope.value) ?? []);
 const hasPrivilegePicker = computed(() => privilegeScope.value !== "role");
 const loginDisableLabel = computed(() => (isPostgres.value ? t("userAdmin.disableLogin") : t("userAdmin.lock")));
 const loginEnableLabel = computed(() => (isPostgres.value ? t("userAdmin.enableLogin") : t("userAdmin.unlock")));
@@ -190,10 +195,11 @@ async function applyPendingSql() {
 
 function previewCreateUser() {
   const userProvider = provider.value;
-  if (!userProvider) return;
+  const createUserSql = userProvider?.createUserSql;
+  if (!createUserSql) return;
   if (!createUser.value.trim() || !createPassword.value) return;
   previewSql(
-    userProvider.createUserSql({
+    createUserSql({
       user: createUser.value.trim(),
       host: createHost.value.trim() || "%",
       password: createPassword.value,
@@ -211,8 +217,9 @@ function previewCreateUser() {
 function previewPasswordChange() {
   const user = selectedUser.value;
   const userProvider = provider.value;
-  if (!user || !userProvider || !newPassword.value) return;
-  previewSql(userProvider.alterPasswordSql(user, newPassword.value), {
+  const alterPasswordSql = userProvider?.alterPasswordSql;
+  if (!user || !alterPasswordSql || !newPassword.value) return;
+  previewSql(alterPasswordSql(user, newPassword.value), {
     danger: true,
     afterApply: async () => {
       passwordDialogOpen.value = false;
@@ -224,23 +231,26 @@ function previewPasswordChange() {
 function previewDropUser() {
   const user = selectedUser.value;
   const userProvider = provider.value;
-  if (!user || !userProvider) return;
-  previewSql(userProvider.dropUserSql(user), { danger: true });
+  const dropUserSql = userProvider?.dropUserSql;
+  if (!user || !dropUserSql) return;
+  previewSql(dropUserSql(user), { danger: true });
 }
 
 function previewLoginChange(enabled: boolean) {
   const user = selectedUser.value;
   const userProvider = provider.value;
-  if (!user || !userProvider) return;
-  previewSql(userProvider.alterLoginSql(user, enabled), { danger: true });
+  const alterLoginSql = userProvider?.alterLoginSql;
+  if (!user || !alterLoginSql) return;
+  previewSql(alterLoginSql(user, enabled), { danger: true });
 }
 
 function previewGrant() {
   const user = selectedUser.value;
   const userProvider = provider.value;
-  if (!user || !userProvider || (privilegeScope.value === "role" && !privilegeRole.value.trim())) return;
+  const grantPrivilegesSql = userProvider?.grantPrivilegesSql;
+  if (!user || !grantPrivilegesSql || (privilegeScope.value === "role" && !privilegeRole.value.trim())) return;
   previewSql(
-    userProvider.grantPrivilegesSql({
+    grantPrivilegesSql({
       user,
       privileges: selectedPrivileges.value,
       database: privilegeDatabase.value,
@@ -255,9 +265,10 @@ function previewGrant() {
 function previewRevoke() {
   const user = selectedUser.value;
   const userProvider = provider.value;
-  if (!user || !userProvider || (privilegeScope.value === "role" && !privilegeRole.value.trim())) return;
+  const revokePrivilegesSql = userProvider?.revokePrivilegesSql;
+  if (!user || !revokePrivilegesSql || (privilegeScope.value === "role" && !privilegeRole.value.trim())) return;
   previewSql(
-    userProvider.revokePrivilegesSql({
+    revokePrivilegesSql({
       user,
       privileges: selectedPrivileges.value,
       database: privilegeDatabase.value,
@@ -272,7 +283,7 @@ function previewRevoke() {
 function resetPrivilegeDefaults(scope: PrivilegeScope) {
   const userProvider = provider.value;
   if (!userProvider) return;
-  selectedPrivileges.value = userProvider.defaultPrivilegesForScope(scope);
+  selectedPrivileges.value = userProvider.defaultPrivilegesForScope?.(scope) ?? [];
   if (userProvider.dialect === "postgres") {
     if (scope === "database") privilegeDatabase.value = props.connection.database || "postgres";
     if (scope === "schema" || scope === "table") privilegeDatabase.value = "public";
@@ -298,7 +309,7 @@ watch(
 );
 
 watch(
-  () => provider.value?.dialect,
+  () => provider.value,
   () => {
     privilegeScope.value = provider.value?.defaultScope ?? "mysql";
     resetPrivilegeDefaults(privilegeScope.value);
@@ -328,7 +339,7 @@ onMounted(loadUsers);
           <RefreshCcw v-else class="h-3.5 w-3.5" />
           {{ t("grid.refresh") }}
         </Button>
-        <Button size="sm" class="h-7 gap-1.5 px-2 text-xs" :disabled="!supported" @click="createDialogOpen = true">
+        <Button v-if="canCreateUser" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="createDialogOpen = true">
           <Plus class="h-3.5 w-3.5" />
           {{ t("userAdmin.newUser") }}
         </Button>
@@ -387,27 +398,27 @@ onMounted(loadUsers);
             </Badge>
           </div>
           <div class="ml-auto flex items-center gap-1.5">
-            <Button variant="outline" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="passwordDialogOpen = true">
+            <Button v-if="canAlterPassword" variant="outline" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="passwordDialogOpen = true">
               <KeyRound class="h-3.5 w-3.5" />
               {{ t("userAdmin.changePassword") }}
             </Button>
-            <Button variant="outline" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="previewLoginChange(false)">
+            <Button v-if="canAlterLogin" variant="outline" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="previewLoginChange(false)">
               <Lock class="h-3.5 w-3.5" />
               {{ loginDisableLabel }}
             </Button>
-            <Button variant="outline" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="previewLoginChange(true)">
+            <Button v-if="canAlterLogin" variant="outline" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="previewLoginChange(true)">
               <Unlock class="h-3.5 w-3.5" />
               {{ loginEnableLabel }}
             </Button>
-            <Button variant="destructive" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="previewDropUser">
+            <Button v-if="canDropUser" variant="destructive" size="sm" class="h-7 gap-1.5 px-2 text-xs" @click="previewDropUser">
               <Trash2 class="h-3.5 w-3.5" />
               {{ t("userAdmin.dropUser") }}
             </Button>
           </div>
         </div>
 
-        <div v-if="selectedUser" class="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_320px]">
-          <section class="flex min-h-0 flex-col border-r">
+        <div v-if="selectedUser" class="grid min-h-0 flex-1" :class="canEditPrivileges ? 'grid-cols-[minmax(0,1fr)_320px]' : 'grid-cols-1'">
+          <section class="flex min-h-0 flex-col" :class="{ 'border-r': canEditPrivileges }">
             <div class="flex h-9 shrink-0 items-center gap-2 border-b bg-muted/20 px-3 text-xs font-medium">
               <ShieldCheck class="h-3.5 w-3.5" />
               {{ t("userAdmin.grants") }}
@@ -422,7 +433,7 @@ onMounted(loadUsers);
             </div>
           </section>
 
-          <aside class="flex min-h-0 flex-col bg-muted/10">
+          <aside v-if="canEditPrivileges" class="flex min-h-0 flex-col bg-muted/10">
             <div class="border-b p-3">
               <div class="text-xs font-semibold">{{ t("userAdmin.privilegeEditor") }}</div>
               <div class="mt-1 text-[11px] leading-4 text-muted-foreground">{{ t("userAdmin.privilegeHint") }}</div>
@@ -480,10 +491,10 @@ onMounted(loadUsers);
               </label>
             </div>
             <div class="flex shrink-0 items-center justify-end gap-2 border-t p-3">
-              <Button variant="outline" size="sm" class="h-7 px-2 text-xs" @click="previewRevoke">
+              <Button v-if="canRevokePrivileges" variant="outline" size="sm" class="h-7 px-2 text-xs" @click="previewRevoke">
                 {{ t("userAdmin.revoke") }}
               </Button>
-              <Button size="sm" class="h-7 px-2 text-xs" @click="previewGrant">
+              <Button v-if="canGrantPrivileges" size="sm" class="h-7 px-2 text-xs" @click="previewGrant">
                 {{ t("userAdmin.grant") }}
               </Button>
             </div>

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -144,7 +144,7 @@ import { sidebarDisplayTableName } from "@/lib/sidebar/sidebarTableNameDisplay";
 import { shouldMeasureSidebarLabelOverflow } from "@/lib/sidebar/sidebarLabelTooltip";
 import { selectedTreeNodesInVisibleOrder as orderSelectedTreeNodes, treeSelectionRangeIdsByIndex, treeSelectionRangeIds } from "@/lib/sidebar/sidebarTreeSelection";
 import { connectionPasteTargetGroupId, selectedConnectionClipboardTargets, selectedConnectionDeleteTargets, selectedConnectionDuplicateTargets, selectedConnectionEditTarget } from "@/lib/sidebar/sidebarConnectionSelection";
-import { supportsDatabaseUserAdmin } from "@/lib/database/databaseUserAdmin";
+import { connectionSupportsDatabaseUserAdmin } from "@/lib/database/databaseUserAdmin";
 import { connectionSupportsProcessList } from "@/lib/database/processListDrivers";
 import { connectionSupportsServerDashboard } from "@/lib/database/mysqlServerStatus";
 import { canCloseSidebarDatabaseConnection, isSidebarDatabaseOpened } from "@/lib/sidebar/sidebarDatabaseOpenState";
@@ -5075,7 +5075,7 @@ function treeItemMenuItems(): ContextMenuItem[] {
     }
     const sqlHistoryMenu = savedSqlHistorySubmenu();
     if (sqlHistoryMenu) items.push(sqlHistoryMenu);
-    if (supportsDatabaseUserAdmin(currentDatabaseType())) {
+    if (node.connectionId && connectionSupportsDatabaseUserAdmin(connectionStore.getConfig(node.connectionId))) {
       items.push({ label: t("contextMenu.userAdmin"), action: openUserAdmin, icon: UsersRound });
     }
     if (node.connectionId && connectionSupportsProcessList(connectionStore.getConfig(node.connectionId))) {

--- a/apps/desktop/src/lib/database/databaseUserAdmin.ts
+++ b/apps/desktop/src/lib/database/databaseUserAdmin.ts
@@ -1,5 +1,6 @@
-import type { DatabaseType, QueryResult } from "@/types/database";
+import type { ConnectionConfig, DatabaseType, QueryResult } from "@/types/database";
 import { supportsDatabaseFeature } from "@/lib/database/databaseDriverManifest";
+import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 
 export type UserAdminDialect = "mysql" | "postgres";
 export type PrivilegeScope = "mysql" | "database" | "schema" | "table" | "role";
@@ -33,42 +34,25 @@ export interface DatabaseUserAdminProvider {
   parseUsers(result: QueryResult): DatabaseUserIdentity[];
   parseFallbackUsers?: (result: QueryResult) => DatabaseUserIdentity[];
   showGrantsSql(user: DatabaseUserIdentity): string;
-  createUserSql(input: CreatePrincipalInput): string;
-  alterPasswordSql(user: DatabaseUserIdentity, password: string): string;
-  alterLoginSql(user: DatabaseUserIdentity, enabled: boolean): string;
-  dropUserSql(user: DatabaseUserIdentity): string;
-  grantPrivilegesSql(input: PrivilegeChangeInput): string;
-  revokePrivilegesSql(input: PrivilegeChangeInput): string;
   parseGrants?(result: QueryResult): string[];
+  createUserSql?(input: CreatePrincipalInput): string;
+  alterPasswordSql?(user: DatabaseUserIdentity, password: string): string;
+  alterLoginSql?(user: DatabaseUserIdentity, enabled: boolean): string;
+  dropUserSql?(user: DatabaseUserIdentity): string;
+  grantPrivilegesSql?(input: PrivilegeChangeInput): string;
+  revokePrivilegesSql?(input: PrivilegeChangeInput): string;
   label(user: DatabaseUserIdentity): string;
   detail(user: DatabaseUserIdentity): string | undefined;
-  privilegesForScope(scope: PrivilegeScope): readonly string[];
-  defaultPrivilegesForScope(scope: PrivilegeScope): string[];
+  privilegesForScope?(scope: PrivilegeScope): readonly string[];
+  defaultPrivilegesForScope?(scope: PrivilegeScope): string[];
 }
 
-export const MYSQL_USER_ADMIN_TYPES = new Set<DatabaseType>(["mysql", "goldendb"]);
-export const KINGBASE_USER_ADMIN_TYPES = new Set<DatabaseType>(["kingbase"]);
-export const POSTGRES_USER_ADMIN_TYPES = new Set<DatabaseType>(["postgres", "gaussdb", "highgo", "kwdb", "opengauss", "questdb", "vastbase"]);
-export const STARROCKS_USER_ADMIN_TYPES = new Set<DatabaseType>(["starrocks"]);
-
 export const MYSQL_COMMON_PRIVILEGES = ["SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "INDEX", "REFERENCES", "EXECUTE", "SHOW VIEW", "TRIGGER", "EVENT", "CREATE TEMPORARY TABLES"] as const;
+export const STARROCKS_TABLE_PRIVILEGES = ["SELECT", "INSERT", "UPDATE", "DELETE", "ALTER", "DROP", "EXPORT", "ALL"] as const;
 
 export const POSTGRES_DATABASE_PRIVILEGES = ["CONNECT", "CREATE", "TEMPORARY"] as const;
 export const POSTGRES_SCHEMA_PRIVILEGES = ["USAGE", "CREATE"] as const;
 export const POSTGRES_TABLE_PRIVILEGES = ["SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"] as const;
-
-export function supportsDatabaseUserAdmin(dbType: DatabaseType | undefined): boolean {
-  return !!dbType && supportsDatabaseFeature(dbType, "userAdmin") && !!getDatabaseUserAdminProvider(dbType);
-}
-
-export function getDatabaseUserAdminProvider(dbType: DatabaseType | undefined): DatabaseUserAdminProvider | null {
-  if (!dbType) return null;
-  if (MYSQL_USER_ADMIN_TYPES.has(dbType)) return mysqlUserAdminProvider;
-  if (KINGBASE_USER_ADMIN_TYPES.has(dbType)) return kingbaseUserAdminProvider;
-  if (POSTGRES_USER_ADMIN_TYPES.has(dbType)) return postgresUserAdminProvider;
-  if (STARROCKS_USER_ADMIN_TYPES.has(dbType)) return starrocksUserAdminProvider;
-  return null;
-}
 
 export function quoteSqlString(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
@@ -162,6 +146,27 @@ export function mysqlGrantPrivilegesSql(input: PrivilegeChangeInput): string {
 export function mysqlRevokePrivilegesSql(input: PrivilegeChangeInput): string {
   const privileges = normalizePrivileges(input.privileges).join(", ");
   return `REVOKE ${privileges} ON ${mysqlPrivilegeTargetSql(input.database, input.table)} FROM ${mysqlUserAccount(input.user)};`;
+}
+
+export function starrocksPrivilegeTargetSql(database: string, table = "*"): string {
+  const db = database.trim();
+  const tbl = table.trim();
+  if (!tbl || tbl === "*") {
+    return !db || db === "*" ? "ALL TABLES IN ALL DATABASES" : `ALL TABLES IN DATABASE ${quoteMySqlIdentifier(db)}`;
+  }
+  const tableName = quoteMySqlIdentifier(tbl);
+  return !db || db === "*" ? `TABLE ${tableName}` : `TABLE ${quoteMySqlIdentifier(db)}.${tableName}`;
+}
+
+export function starrocksGrantPrivilegesSql(input: PrivilegeChangeInput): string {
+  const privileges = normalizePrivileges(input.privileges).join(", ");
+  const grantOption = input.grantOption ? " WITH GRANT OPTION" : "";
+  return `GRANT ${privileges} ON ${starrocksPrivilegeTargetSql(input.database, input.table)} TO USER ${mysqlUserAccount(input.user)}${grantOption};`;
+}
+
+export function starrocksRevokePrivilegesSql(input: PrivilegeChangeInput): string {
+  const privileges = normalizePrivileges(input.privileges).join(", ");
+  return `REVOKE ${privileges} ON ${starrocksPrivilegeTargetSql(input.database, input.table)} FROM USER ${mysqlUserAccount(input.user)};`;
 }
 
 export function normalizePrivileges(privileges: string[], fallback = "SELECT"): string[] {
@@ -491,19 +496,49 @@ export const kingbaseUserAdminProvider: DatabaseUserAdminProvider = {
 
 export const starrocksUserAdminProvider: DatabaseUserAdminProvider = {
   dialect: "mysql",
-  defaultScope: "mysql",
+  defaultScope: "table",
   listUsersSql: starrocksListUsersSql,
   parseUsers: starrocksUsersResult,
   showGrantsSql: mysqlShowGrantsSql,
   parseGrants: starrocksGrantsResult,
   createUserSql: mysqlCreateUserSql,
   alterPasswordSql: mysqlAlterUserPasswordSql,
-  alterLoginSql: (user, enabled) => mysqlAlterUserAccountLockSql(user, !enabled),
   dropUserSql: mysqlDropUserSql,
-  grantPrivilegesSql: mysqlGrantPrivilegesSql,
-  revokePrivilegesSql: mysqlRevokePrivilegesSql,
+  grantPrivilegesSql: starrocksGrantPrivilegesSql,
+  revokePrivilegesSql: starrocksRevokePrivilegesSql,
   label: mysqlUserLabel,
   detail: (user) => user.plugin,
-  privilegesForScope: () => MYSQL_COMMON_PRIVILEGES,
+  privilegesForScope: () => STARROCKS_TABLE_PRIVILEGES,
   defaultPrivilegesForScope: () => ["SELECT"],
 };
+
+const DATABASE_USER_ADMIN_PROVIDER_BY_TYPE = new Map<DatabaseType, DatabaseUserAdminProvider>([
+  ["mysql", mysqlUserAdminProvider],
+  ["goldendb", mysqlUserAdminProvider],
+  ["kingbase", kingbaseUserAdminProvider],
+  ["postgres", postgresUserAdminProvider],
+  ["gaussdb", postgresUserAdminProvider],
+  ["highgo", postgresUserAdminProvider],
+  ["kwdb", postgresUserAdminProvider],
+  ["opengauss", postgresUserAdminProvider],
+  ["questdb", postgresUserAdminProvider],
+  ["vastbase", postgresUserAdminProvider],
+  ["starrocks", starrocksUserAdminProvider],
+]);
+
+export function getDatabaseUserAdminProvider(dbType: DatabaseType | undefined): DatabaseUserAdminProvider | null {
+  return dbType ? (DATABASE_USER_ADMIN_PROVIDER_BY_TYPE.get(dbType) ?? null) : null;
+}
+
+export function supportsDatabaseUserAdmin(dbType: DatabaseType | undefined): boolean {
+  return !!dbType && supportsDatabaseFeature(dbType, "userAdmin") && DATABASE_USER_ADMIN_PROVIDER_BY_TYPE.has(dbType);
+}
+
+export function resolveDatabaseUserAdminProviderForConnection(connection: ConnectionConfig | undefined): DatabaseUserAdminProvider | null {
+  const dbType = effectiveDatabaseTypeForConnection(connection);
+  return supportsDatabaseUserAdmin(dbType) ? getDatabaseUserAdminProvider(dbType) : null;
+}
+
+export function connectionSupportsDatabaseUserAdmin(connection: ConnectionConfig | undefined): boolean {
+  return resolveDatabaseUserAdminProviderForConnection(connection) !== null;
+}

--- a/apps/desktop/src/lib/database/databaseUserAdmin.ts
+++ b/apps/desktop/src/lib/database/databaseUserAdmin.ts
@@ -39,6 +39,7 @@ export interface DatabaseUserAdminProvider {
   dropUserSql(user: DatabaseUserIdentity): string;
   grantPrivilegesSql(input: PrivilegeChangeInput): string;
   revokePrivilegesSql(input: PrivilegeChangeInput): string;
+  parseGrants?(result: QueryResult): string[];
   label(user: DatabaseUserIdentity): string;
   detail(user: DatabaseUserIdentity): string | undefined;
   privilegesForScope(scope: PrivilegeScope): readonly string[];
@@ -48,6 +49,7 @@ export interface DatabaseUserAdminProvider {
 export const MYSQL_USER_ADMIN_TYPES = new Set<DatabaseType>(["mysql", "goldendb"]);
 export const KINGBASE_USER_ADMIN_TYPES = new Set<DatabaseType>(["kingbase"]);
 export const POSTGRES_USER_ADMIN_TYPES = new Set<DatabaseType>(["postgres", "gaussdb", "highgo", "kwdb", "opengauss", "questdb", "vastbase"]);
+export const STARROCKS_USER_ADMIN_TYPES = new Set<DatabaseType>(["starrocks"]);
 
 export const MYSQL_COMMON_PRIVILEGES = ["SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "INDEX", "REFERENCES", "EXECUTE", "SHOW VIEW", "TRIGGER", "EVENT", "CREATE TEMPORARY TABLES"] as const;
 
@@ -64,6 +66,7 @@ export function getDatabaseUserAdminProvider(dbType: DatabaseType | undefined): 
   if (MYSQL_USER_ADMIN_TYPES.has(dbType)) return mysqlUserAdminProvider;
   if (KINGBASE_USER_ADMIN_TYPES.has(dbType)) return kingbaseUserAdminProvider;
   if (POSTGRES_USER_ADMIN_TYPES.has(dbType)) return postgresUserAdminProvider;
+  if (STARROCKS_USER_ADMIN_TYPES.has(dbType)) return starrocksUserAdminProvider;
   return null;
 }
 
@@ -101,6 +104,25 @@ export function mysqlListUsersSql(): string {
 
 export function mysqlListUsersFallbackSql(): string {
   return "SELECT DISTINCT GRANTEE AS grantee FROM information_schema.USER_PRIVILEGES ORDER BY GRANTEE;";
+}
+
+export function starrocksListUsersSql(): string {
+  return "SHOW USERS;";
+}
+
+export function starrocksUsersResult(result: QueryResult): DatabaseUserIdentity[] {
+  const userIndex = columnIndex(result, "user", "User");
+  if (userIndex < 0) return [];
+  return result.rows.flatMap((row) => {
+    const parsed = parseMySqlGrantee(String(row[userIndex] ?? ""));
+    return parsed ? [parsed] : [];
+  });
+}
+
+export function starrocksGrantsResult(result: QueryResult): string[] {
+  const grantsIndex = columnIndex(result, "grants", "Grants");
+  if (grantsIndex < 0) return result.rows.map((row) => String(row[0] ?? "")).filter(Boolean);
+  return result.rows.map((row) => String(row[grantsIndex] ?? "")).filter(Boolean);
 }
 
 export function mysqlShowGrantsSql(user: DatabaseUserIdentity): string {
@@ -465,4 +487,23 @@ export const kingbaseUserAdminProvider: DatabaseUserAdminProvider = {
   ...postgresUserAdminProvider,
   listUsersSql: kingbaseListRolesSql,
   showGrantsSql: kingbaseShowGrantsSql,
+};
+
+export const starrocksUserAdminProvider: DatabaseUserAdminProvider = {
+  dialect: "mysql",
+  defaultScope: "mysql",
+  listUsersSql: starrocksListUsersSql,
+  parseUsers: starrocksUsersResult,
+  showGrantsSql: mysqlShowGrantsSql,
+  parseGrants: starrocksGrantsResult,
+  createUserSql: mysqlCreateUserSql,
+  alterPasswordSql: mysqlAlterUserPasswordSql,
+  alterLoginSql: (user, enabled) => mysqlAlterUserAccountLockSql(user, !enabled),
+  dropUserSql: mysqlDropUserSql,
+  grantPrivilegesSql: mysqlGrantPrivilegesSql,
+  revokePrivilegesSql: mysqlRevokePrivilegesSql,
+  label: mysqlUserLabel,
+  detail: (user) => user.plugin,
+  privilegesForScope: () => MYSQL_COMMON_PRIVILEGES,
+  defaultPrivilegesForScope: () => ["SELECT"],
 };

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -56,7 +56,7 @@ import { hasTreeNodeDatabaseContext, normalizeCataloglessDatabaseNodes, treeNode
 import { decodeSchemaTreeCache, encodeSchemaTreeCache } from "@/lib/metadata/schemaTreeCache";
 import { sortSidebarTreeChildrenForParent } from "@/lib/sidebar/sidebarNodeOrdering";
 import { prunePinnedTreeNodeIdsForConnection } from "@/lib/app/pinnedTreeNodeIds";
-import { supportsDatabaseUserAdmin } from "@/lib/database/databaseUserAdmin";
+import { connectionSupportsDatabaseUserAdmin } from "@/lib/database/databaseUserAdmin";
 import { getTableMetadataCapabilities } from "@/lib/table/tableMetadataCapabilities";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { encodeSqlServerLinkedSchema, parseSqlServerLinkedSchema } from "@/lib/database/sqlServerLinkedServers";
@@ -994,7 +994,7 @@ export const useConnectionStore = defineStore("connection", () => {
 
   function buildUserAdminNode(connectionId: string, existingConnectionNode?: TreeNode): TreeNode | undefined {
     const config = getConfig(connectionId);
-    if (!supportsDatabaseUserAdmin(effectiveDatabaseTypeForConnection(config))) return undefined;
+    if (!connectionSupportsDatabaseUserAdmin(config)) return undefined;
     const existing = existingConnectionNode?.children?.find((child) => child.type === "user-admin");
     return {
       id: `${connectionId}:__user_admin`,

--- a/crates/dbx-core/assets/database-drivers.manifest.json
+++ b/crates/dbx-core/assets/database-drivers.manifest.json
@@ -525,7 +525,7 @@
         "databaseCreate": true,
         "fieldLineage": false,
         "sqlExplain": false,
-        "userAdmin": false,
+        "userAdmin": true,
         "driverManagement": false
       }
     },

--- a/crates/dbx-core/tests/database_capabilities.rs
+++ b/crates/dbx-core/tests/database_capabilities.rs
@@ -327,10 +327,7 @@ fn driver_manifest_declares_expected_product_capabilities() {
     assert!(!zookeeper.capabilities.metadata_browse);
 
     let starrocks = find_driver(DatabaseType::StarRocks);
-    assert_eq!(starrocks.support_level, "operate");
     assert!(starrocks.capabilities.user_admin);
-    assert!(starrocks.capabilities.table_data_edit);
-    assert!(starrocks.capabilities.table_structure_edit);
 }
 
 #[test]

--- a/crates/dbx-core/tests/database_capabilities.rs
+++ b/crates/dbx-core/tests/database_capabilities.rs
@@ -325,6 +325,12 @@ fn driver_manifest_declares_expected_product_capabilities() {
     assert!(zookeeper.capabilities.query_execution);
     assert!(zookeeper.capabilities.driver_management);
     assert!(!zookeeper.capabilities.metadata_browse);
+
+    let starrocks = find_driver(DatabaseType::StarRocks);
+    assert_eq!(starrocks.support_level, "operate");
+    assert!(starrocks.capabilities.user_admin);
+    assert!(starrocks.capabilities.table_data_edit);
+    assert!(starrocks.capabilities.table_structure_edit);
 }
 
 #[test]

--- a/packages/app-tests/databaseUserAdmin.test.ts
+++ b/packages/app-tests/databaseUserAdmin.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import {
   grantsFromQueryResult,
+  getDatabaseUserAdminProvider,
   mysqlAlterUserAccountLockSql,
   mysqlAlterUserPasswordSql,
   mysqlCreateUserSql,
@@ -25,6 +26,9 @@ import {
   quoteMySqlIdentifier,
   quoteMySqlString,
   quotePostgresIdentifier,
+  starrocksGrantsResult,
+  starrocksListUsersSql,
+  starrocksUsersResult,
   usersFromMySqlGranteeResult,
   usersFromMySqlUserResult,
   usersFromPostgresRolesResult,
@@ -174,4 +178,76 @@ test("builds PostgreSQL role metadata SQL without directly requiring rolbypassrl
   assert.match(grantsSql, /AS rolbypassrls/);
   assert.match(grantsSql, /n\.nspname NOT LIKE 'pg~_%' ESCAPE '~'/);
   assert.ok(!grantsSql.includes("ESCAPE '\\'"));
+});
+
+test("builds StarRocks user listing SQL", () => {
+  assert.equal(starrocksListUsersSql(), "SHOW USERS;");
+});
+
+test("parses StarRocks SHOW USERS result", () => {
+  assert.deepEqual(
+    starrocksUsersResult(
+      result(
+        ["User"],
+        [
+          ["'root'@'%'"],
+          ["'grader_reader'@'%'"],
+          ["'o''brien'@'localhost'"],
+          ["malformed"],
+        ],
+      ),
+    ),
+    [
+      { user: "root", host: "%" },
+      { user: "grader_reader", host: "%" },
+      { user: "o'brien", host: "localhost" },
+    ],
+  );
+});
+
+test("parses StarRocks SHOW GRANTS three-column result", () => {
+  assert.deepEqual(
+    starrocksGrantsResult(
+      result(
+        ["UserIdentity", "Catalog", "Grants"],
+        [
+          ["'root'@'%'", null, "GRANT 'root' TO 'root'@'%'"],
+          ["'grader_reader'@'%'", "default_catalog", "GRANT SELECT ON ALL TABLES IN DATABASE grader_events TO USER 'grader_reader'@'%'"],
+          ["'reader'@'%'", "paimon", null],
+        ],
+      ),
+    ),
+    [
+      "GRANT 'root' TO 'root'@'%'",
+      "GRANT SELECT ON ALL TABLES IN DATABASE grader_events TO USER 'grader_reader'@'%'",
+    ],
+  );
+});
+
+test("StarRocks grants parser falls back to first column when Grants column is absent", () => {
+  assert.deepEqual(
+    starrocksGrantsResult(result(["Grants for app@%"], [["GRANT SELECT ON `app`.* TO 'app'@'%'"]])),
+    ["GRANT SELECT ON `app`.* TO 'app'@'%'"],
+  );
+});
+
+test("routes StarRocks to the StarRocks user admin provider", () => {
+  const provider = getDatabaseUserAdminProvider("starrocks");
+  assert.ok(provider, "expected a provider for starrocks");
+  assert.equal(provider?.dialect, "mysql");
+  assert.equal(provider?.listUsersSql(), "SHOW USERS;");
+  assert.equal(provider?.showGrantsSql({ user: "root", host: "%" }), "SHOW GRANTS FOR 'root'@'%';");
+  assert.equal(
+    provider?.createUserSql({ user: "app", host: "%", password: "secret" }),
+    "CREATE USER 'app'@'%' IDENTIFIED BY 'secret';",
+  );
+  assert.equal(provider?.dropUserSql({ user: "app", host: "%" }), "DROP USER 'app'@'%';");
+  assert.equal(
+    provider?.grantPrivilegesSql({
+      user: { user: "reporter", host: "%" },
+      privileges: ["SELECT"],
+      database: "analytics",
+    }),
+    "GRANT SELECT ON `analytics`.* TO 'reporter'@'%';",
+  );
 });

--- a/packages/app-tests/databaseUserAdmin.test.ts
+++ b/packages/app-tests/databaseUserAdmin.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import {
+  connectionSupportsDatabaseUserAdmin,
   grantsFromQueryResult,
   getDatabaseUserAdminProvider,
   mysqlAlterUserAccountLockSql,
@@ -26,14 +27,18 @@ import {
   quoteMySqlIdentifier,
   quoteMySqlString,
   quotePostgresIdentifier,
+  resolveDatabaseUserAdminProviderForConnection,
+  starrocksGrantPrivilegesSql,
   starrocksGrantsResult,
   starrocksListUsersSql,
+  starrocksPrivilegeTargetSql,
+  starrocksRevokePrivilegesSql,
   starrocksUsersResult,
   usersFromMySqlGranteeResult,
   usersFromMySqlUserResult,
   usersFromPostgresRolesResult,
 } from "../../apps/desktop/src/lib/database/databaseUserAdmin.ts";
-import type { QueryResult } from "../../apps/desktop/src/types/database.ts";
+import type { ConnectionConfig, QueryResult } from "../../apps/desktop/src/types/database.ts";
 
 function result(columns: string[], rows: QueryResult["rows"]): QueryResult {
   return {
@@ -184,25 +189,28 @@ test("builds StarRocks user listing SQL", () => {
   assert.equal(starrocksListUsersSql(), "SHOW USERS;");
 });
 
+test("builds StarRocks table privilege SQL", () => {
+  const input = {
+    user: { user: "reporter", host: "%" },
+    privileges: ["select", "EXPORT"],
+    database: "analytics",
+    table: "daily`rollup",
+    grantOption: true,
+  };
+
+  assert.equal(starrocksPrivilegeTargetSql("*"), "ALL TABLES IN ALL DATABASES");
+  assert.equal(starrocksPrivilegeTargetSql("analytics"), "ALL TABLES IN DATABASE `analytics`");
+  assert.equal(starrocksPrivilegeTargetSql("analytics", "daily`rollup"), "TABLE `analytics`.`daily``rollup`");
+  assert.equal(starrocksGrantPrivilegesSql(input), "GRANT SELECT, EXPORT ON TABLE `analytics`.`daily``rollup` TO USER 'reporter'@'%' WITH GRANT OPTION;");
+  assert.equal(starrocksRevokePrivilegesSql(input), "REVOKE SELECT, EXPORT ON TABLE `analytics`.`daily``rollup` FROM USER 'reporter'@'%';");
+});
+
 test("parses StarRocks SHOW USERS result", () => {
-  assert.deepEqual(
-    starrocksUsersResult(
-      result(
-        ["User"],
-        [
-          ["'root'@'%'"],
-          ["'grader_reader'@'%'"],
-          ["'o''brien'@'localhost'"],
-          ["malformed"],
-        ],
-      ),
-    ),
-    [
-      { user: "root", host: "%" },
-      { user: "grader_reader", host: "%" },
-      { user: "o'brien", host: "localhost" },
-    ],
-  );
+  assert.deepEqual(starrocksUsersResult(result(["User"], [["'root'@'%'"], ["'grader_reader'@'%'"], ["'o''brien'@'localhost'"], ["malformed"]])), [
+    { user: "root", host: "%" },
+    { user: "grader_reader", host: "%" },
+    { user: "o'brien", host: "localhost" },
+  ]);
 });
 
 test("parses StarRocks SHOW GRANTS three-column result", () => {
@@ -217,18 +225,12 @@ test("parses StarRocks SHOW GRANTS three-column result", () => {
         ],
       ),
     ),
-    [
-      "GRANT 'root' TO 'root'@'%'",
-      "GRANT SELECT ON ALL TABLES IN DATABASE grader_events TO USER 'grader_reader'@'%'",
-    ],
+    ["GRANT 'root' TO 'root'@'%'", "GRANT SELECT ON ALL TABLES IN DATABASE grader_events TO USER 'grader_reader'@'%'"],
   );
 });
 
 test("StarRocks grants parser falls back to first column when Grants column is absent", () => {
-  assert.deepEqual(
-    starrocksGrantsResult(result(["Grants for app@%"], [["GRANT SELECT ON `app`.* TO 'app'@'%'"]])),
-    ["GRANT SELECT ON `app`.* TO 'app'@'%'"],
-  );
+  assert.deepEqual(starrocksGrantsResult(result(["Grants for app@%"], [["GRANT SELECT ON `app`.* TO 'app'@'%'"]])), ["GRANT SELECT ON `app`.* TO 'app'@'%'"]);
 });
 
 test("routes StarRocks to the StarRocks user admin provider", () => {
@@ -237,17 +239,35 @@ test("routes StarRocks to the StarRocks user admin provider", () => {
   assert.equal(provider?.dialect, "mysql");
   assert.equal(provider?.listUsersSql(), "SHOW USERS;");
   assert.equal(provider?.showGrantsSql({ user: "root", host: "%" }), "SHOW GRANTS FOR 'root'@'%';");
+  assert.equal(provider?.createUserSql?.({ user: "app", host: "%", password: "secret" }), "CREATE USER 'app'@'%' IDENTIFIED BY 'secret';");
+  assert.equal(provider?.dropUserSql?.({ user: "app", host: "%" }), "DROP USER 'app'@'%';");
   assert.equal(
-    provider?.createUserSql({ user: "app", host: "%", password: "secret" }),
-    "CREATE USER 'app'@'%' IDENTIFIED BY 'secret';",
-  );
-  assert.equal(provider?.dropUserSql({ user: "app", host: "%" }), "DROP USER 'app'@'%';");
-  assert.equal(
-    provider?.grantPrivilegesSql({
+    provider?.grantPrivilegesSql?.({
       user: { user: "reporter", host: "%" },
       privileges: ["SELECT"],
       database: "analytics",
     }),
-    "GRANT SELECT ON `analytics`.* TO 'reporter'@'%';",
+    "GRANT SELECT ON ALL TABLES IN DATABASE `analytics` TO USER 'reporter'@'%';",
   );
+  assert.equal(provider?.alterLoginSql, undefined);
+  assert.deepEqual(provider?.privilegesForScope?.("table"), ["SELECT", "INSERT", "UPDATE", "DELETE", "ALTER", "DROP", "EXPORT", "ALL"]);
+});
+
+test("resolves user admin support from the effective connection type", () => {
+  const mysqlProtocolStarRocks = {
+    id: "starrocks-1",
+    db_type: "mysql",
+    driver_profile: "starrocks",
+  } as ConnectionConfig;
+  const jdbcStarRocks = {
+    id: "starrocks-jdbc-1",
+    db_type: "jdbc",
+    connection_string: "jdbc:mysql://localhost:9030/analytics",
+    driver_profile: "starrocks",
+  } as ConnectionConfig;
+
+  assert.equal(resolveDatabaseUserAdminProviderForConnection(mysqlProtocolStarRocks), getDatabaseUserAdminProvider("starrocks"));
+  assert.equal(resolveDatabaseUserAdminProviderForConnection(jdbcStarRocks), getDatabaseUserAdminProvider("starrocks"));
+  assert.equal(connectionSupportsDatabaseUserAdmin(mysqlProtocolStarRocks), true);
+  assert.equal(connectionSupportsDatabaseUserAdmin({ id: "sqlite-1", db_type: "sqlite" } as ConnectionConfig), false);
 });


### PR DESCRIPTION
## 背景

StarRocks 已具备用户和权限管理能力，但 DBX 没有在连接树中展示“用户与权限”入口。使用 MySQL 协议或通用 JDBC、并通过 `driver_profile` 识别为 StarRocks 的连接也会受到影响。

根因是入口判断只依赖连接表面的数据库类型，而用户管理实现又默认所有 provider 都支持完整的 MySQL 账户操作。直接复用 MySQL SQL 还会生成 StarRocks 不支持或语义不正确的账户锁定、权限名称和授权目标语法。

## 改动

- 在驱动能力清单中开启 StarRocks 的 `userAdmin` 能力。
- 统一按连接的 effective database type 解析用户管理 provider，覆盖原生 StarRocks、MySQL 协议 `driver_profile=starrocks` 和通用 JDBC profile。
- 使用 `SHOW USERS` 和 `SHOW GRANTS` 获取用户与现有授权，并兼容 StarRocks 三列的 `SHOW GRANTS` 结果。
- 为 StarRocks 生成其原生的表权限目标语法：`ALL TABLES IN ALL DATABASES`、`ALL TABLES IN DATABASE ...` 和 `TABLE db.table`。
- 权限列表只暴露 StarRocks 表对象支持的权限；不再复用 MySQL 的 `ACCOUNT LOCK/UNLOCK`。
- 将 provider 的变更操作声明为可选能力，界面按能力显示创建、改密、锁定、删除、授权和撤权操作，便于后续接入能力不完全相同的数据库。
- 使用统一的 provider 映射和 connection-level 支持判断，避免侧边栏、树节点和管理页分别维护数据库类型分支。

## 本次未做：把已有授权解析并回填右侧编辑器

左侧“授权”区域目前仍是服务端返回 SQL 的只读展示；右侧是独立的授权/撤权 SQL 构造器。因此，即使左侧已有 `GRANT ... ON ...`，右侧的数据库和表也不会从该语句自动回填，StarRocks 当前仍会看到构造器的 `*` 默认值。PostgreSQL 中显示当前数据库，是现有 PG 专用默认值逻辑，并非从左侧授权记录解析得到。

这次没有顺带实现自动回填，因为它不是简单拆分一个字符串：StarRocks 的授权对象包含系统、catalog、数据库、表、视图、物化视图、函数、资源、资源组、存储卷和角色等多种范围，不同版本的授权语法也有差异。完整实现需要引入结构化授权模型、各数据库/版本的 GRANT 解析器、左侧授权选择交互、元数据选择与跨 provider 的往返测试，改动范围和回归风险明显大于本次“恢复 StarRocks 用户管理入口并保证生成 SQL 正确”的目标。

后续如需完善，建议单独将“provider 声明可用授权范围”和“结构化解析已有授权”作为一项跨数据库能力建设，避免继续在组件中增加数据库专用分支。

## 验证

- `pnpm test -- --run`：388 个测试文件、3119 个测试通过。
- `pnpm typecheck`：通过。
- `pnpm lint`：通过，仅有仓库已有警告。
- `cargo test -p dbx-core --test database_capabilities`：9 个测试通过。
- `git diff --check main`：通过。

说明：当前实现使用的 `SHOW USERS` 对应 StarRocks 3.0+ 的权限模型。
