### PR TITLE
fix(mongodb): 修复集合列表复制 INSERT 的日期类型与格式

### DIFF
--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -55,6 +55,7 @@ type JsonRecord = Record<string, unknown>;
 type ViewMode = "document" | "table";
 
 const documents = ref<JsonRecord[]>([]);
+const copyDocuments = ref<JsonRecord[]>([]);
 const lastGridColumns = ref<string[]>([]);
 const total = ref(0);
 const loading = ref(false);
@@ -172,7 +173,7 @@ const gridResult = computed<QueryResult>(() => {
     }),
   );
 
-  return { columns, rows, mongo_documents: docs, affected_rows: 0, execution_time_ms: 0, truncated: false };
+  return { columns, rows, mongo_documents: docs, mongo_copy_documents: copyDocuments.value, affected_rows: 0, execution_time_ms: 0, truncated: false };
 });
 const documentFilterFieldOptions = computed(() => gridResult.value.columns);
 const documentStructuredFilterCount = computed(() => (appliedDocumentFilter.value ? 1 : 0));
@@ -487,7 +488,9 @@ async function load() {
             }
           })
         : result.documents.map(asRecord);
+    const nextCopyDocuments = result.extended_documents?.length === nextDocuments.length ? result.extended_documents.map(asRecord) : nextDocuments;
     documents.value = nextDocuments;
+    copyDocuments.value = nextCopyDocuments;
     if (nextDocuments.length > 0) {
       const keySet = new Set<string>();
       keySet.add("_id");

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6649,7 +6649,7 @@ const {
   database: computed(() => props.executionDatabase ?? props.database),
   context: computed(() => props.context),
   sourceColumns: visibleSourceColumns,
-  mongoDocuments: computed(() => props.result.mongo_documents),
+  mongoDocuments: computed(() => props.result.mongo_copy_documents ?? props.result.mongo_documents),
   columnTypes: visibleColumnTypes,
   whereInput: computed(() => currentWhereInput()),
   orderBy: computed(() => currentOrderBy()),

--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -212,10 +212,10 @@ describe("useDataGridExport prepared row statements", () => {
   });
 
   it("preserves original Mongo string types in INSERT and applies explicit edits", async () => {
-    const item = { ...row(["123", "true", '{"kind":"literal"}', "2024-01-01 00:00:00", '{"role":"maintainer"}']), sourceIndex: 0 };
-    item.isDirtyCol = [false, false, false, false, true];
+    const item = { ...row(["123", "true", '{"kind":"literal"}', "2024-01-01 00:00:00", '{"role":"maintainer"}', 'ISODate("2025-05-06T08:35:32Z")']), sourceIndex: 0 };
+    item.isDirtyCol = [false, false, false, false, true, false];
     const state = createMongoExportState({
-      columns: ["numericText", "booleanText", "jsonText", "dateText", "profile"],
+      columns: ["numericText", "booleanText", "jsonText", "dateText", "profile", "lastUpdatedDate"],
       item,
       mongoDocuments: [
         {
@@ -224,12 +224,22 @@ describe("useDataGridExport prepared row statements", () => {
           jsonText: '{"kind":"literal"}',
           dateText: "2024-01-01 00:00:00",
           profile: { role: "admin" },
+          lastUpdatedDate: { $date: "2025-05-06T08:35:32Z" },
         },
       ],
     });
 
     await state.copyRowAsInsert();
 
-    expect(copyToClipboard).toHaveBeenCalledWith('db.getCollection("documents").insert({"numericText":"123","booleanText":"true","jsonText":"{\\"kind\\":\\"literal\\"}","dateText":"2024-01-01 00:00:00","profile":{"role":"maintainer"}});');
+    expect(copyToClipboard).toHaveBeenCalledWith(`db.getCollection("documents").insert({
+  "numericText": "123",
+  "booleanText": "true",
+  "jsonText": "{\\"kind\\":\\"literal\\"}",
+  "dateText": "2024-01-01 00:00:00",
+  "profile": {
+    "role": "maintainer"
+  },
+  "lastUpdatedDate": ISODate("2025-05-06T08:35:32Z")
+});`);
   });
 });

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -13,6 +13,7 @@ import { uuid } from "@/lib/common/utils";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { expandNestedJsonStringsForCopy } from "@/lib/common/jsonCopyValue";
 import { buildMongoCopyDocumentFromOriginal, buildMongoCopyInsertDocument, formatMongoShellLiteral, type MongoInputValue } from "@/lib/mongo/mongoDocumentValues";
+import { formatMongoShellText } from "@/lib/mongo/mongoFormatter";
 import type { DatabaseType, QueryResult } from "@/types/database";
 import type { QueryResultExportRequest } from "@/lib/backend/api";
 import { usesSyntheticRowIdKey } from "@/lib/table/tableEditing";
@@ -351,15 +352,17 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     const promise = Promise.resolve().then(async () => {
       const statement =
         databaseType.value === "mongodb"
-          ? buildMongoCopyInsertStatement({
-              collection: copyInsertTargetLabel?.value || tableMeta.value?.tableName || "collection",
-              columns: columns.value,
-              sourceColumns: sourceColumns.value,
-              rows,
-              mongoDocuments: options.mongoDocuments?.value,
-              excludePrimaryKeys,
-              insertMode,
-            })
+          ? formatMongoCopyInsertStatement(
+              buildMongoCopyInsertStatement({
+                collection: copyInsertTargetLabel?.value || tableMeta.value?.tableName || "collection",
+                columns: columns.value,
+                sourceColumns: sourceColumns.value,
+                rows,
+                mongoDocuments: options.mongoDocuments?.value,
+                excludePrimaryKeys,
+                insertMode,
+              }),
+            )
           : await buildDataGridCopyInsertStatement({
               databaseType: databaseType.value,
               tableMeta: tableMeta.value,
@@ -1367,6 +1370,15 @@ function buildMongoCopyInsertStatement(options: { collection: string; columns: s
     return documents.map((document) => `${collection}.insert(${formatMongoShellLiteral(document)});`).join("\n");
   }
   return `${collection}.insertMany(${formatMongoShellLiteral(documents)});`;
+}
+
+function formatMongoCopyInsertStatement(statement: string | undefined): string | undefined {
+  if (!statement) return undefined;
+  try {
+    return formatMongoShellText(statement);
+  } catch {
+    return statement;
+  }
 }
 
 function compactLocalTimestamp(date = new Date()): string {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -1730,6 +1730,7 @@ export async function zookeeperDelete(connectionId: string, key: string): Promis
 export interface MongoDocumentResult {
   documents: any[];
   raw_documents?: string[];
+  extended_documents?: any[];
   total: number;
 }
 

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -490,6 +490,8 @@ export interface QueryResult {
    * preview. This is populated only for MongoDB document query results.
    */
   mongo_documents?: unknown[];
+  /** Type-preserving Extended JSON documents used when copying MongoDB values. */
+  mongo_copy_documents?: unknown[];
   affected_rows: number;
   execution_time_ms: number;
   truncated?: boolean;

--- a/crates/dbx-core/src/db/elasticsearch_driver.rs
+++ b/crates/dbx-core/src/db/elasticsearch_driver.rs
@@ -438,7 +438,12 @@ fn search_response_to_document_result(result: SearchResponse) -> Result<MongoDoc
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Elasticsearch document serialization failed: {e}"))?;
 
-    Ok(MongoDocumentResult { documents, raw_documents: Some(raw_documents), total: result.hits.total.value() })
+    Ok(MongoDocumentResult {
+        documents,
+        raw_documents: Some(raw_documents),
+        extended_documents: None,
+        total: result.hits.total.value(),
+    })
 }
 
 fn build_find_documents_body(

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -17,6 +17,8 @@ pub struct MongoDocumentResult {
     pub documents: Vec<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_documents: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extended_documents: Option<Vec<serde_json::Value>>,
     pub total: u64,
 }
 
@@ -586,12 +588,14 @@ pub async fn find_documents(
     let mut cursor = find.await.map_err(|e| e.to_string())?;
 
     let mut documents = Vec::new();
+    let mut extended_documents = Vec::new();
     while cursor.advance().await.map_err(|e| e.to_string())? {
         let doc = cursor.deserialize_current().map_err(|e| e.to_string())?;
-        documents.push(bson_to_json(&Bson::Document(doc)));
+        documents.push(bson_to_json(&Bson::Document(doc.clone())));
+        extended_documents.push(Bson::Document(doc).into_relaxed_extjson());
     }
 
-    Ok(MongoDocumentResult { documents, raw_documents: None, total })
+    Ok(MongoDocumentResult { documents, raw_documents: None, extended_documents: Some(extended_documents), total })
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -727,7 +731,7 @@ pub async fn find_documents_extended_json(
         documents.push(Bson::Document(doc).into_relaxed_extjson());
     }
 
-    Ok(MongoDocumentResult { documents, raw_documents: None, total })
+    Ok(MongoDocumentResult { extended_documents: Some(documents.clone()), documents, raw_documents: None, total })
 }
 
 pub async fn aggregate_documents(
@@ -749,15 +753,18 @@ pub async fn aggregate_documents(
     let max_rows = max_rows.unwrap_or(100);
     let fetch_limit = max_rows.saturating_add(1);
     let mut documents = Vec::new();
+    let mut extended_documents = Vec::new();
     while documents.len() < fetch_limit && cursor.advance().await.map_err(|e| e.to_string())? {
         let doc = cursor.deserialize_current().map_err(|e| e.to_string())?;
-        documents.push(bson_to_json(&Bson::Document(doc)));
+        documents.push(bson_to_json(&Bson::Document(doc.clone())));
+        extended_documents.push(Bson::Document(doc).into_relaxed_extjson());
     }
     let total = documents.len() as u64;
     if documents.len() > max_rows {
         documents.truncate(max_rows);
+        extended_documents.truncate(max_rows);
     }
-    Ok(MongoDocumentResult { documents, raw_documents: None, total })
+    Ok(MongoDocumentResult { documents, raw_documents: None, extended_documents: Some(extended_documents), total })
 }
 
 pub async fn create_index(
@@ -1114,11 +1121,17 @@ fn find_and_modify_array_filters(
 fn single_document_result(document: Option<Document>) -> MongoDocumentResult {
     match document {
         Some(document) => MongoDocumentResult {
-            documents: vec![bson_to_json(&Bson::Document(document))],
+            documents: vec![bson_to_json(&Bson::Document(document.clone()))],
             raw_documents: None,
+            extended_documents: Some(vec![Bson::Document(document).into_relaxed_extjson()]),
             total: 1,
         },
-        None => MongoDocumentResult { documents: Vec::new(), raw_documents: None, total: 0 },
+        None => MongoDocumentResult {
+            documents: Vec::new(),
+            raw_documents: None,
+            extended_documents: Some(Vec::new()),
+            total: 0,
+        },
     }
 }
 
@@ -1768,6 +1781,20 @@ mod tests {
         let value = bson_to_json(&Bson::DateTime(date));
 
         assert_eq!(value, serde_json::json!("ISODate(\"2026-06-10T13:59:31.287Z\")"));
+    }
+
+    #[test]
+    fn mongo_document_result_keeps_extended_json_types_for_copying() {
+        let date = DateTime::parse_rfc3339_str("2025-05-06T08:35:32Z").unwrap();
+        let result = single_document_result(Some(doc! {
+            "lastUpdatedDate": date,
+            "dateText": "ISODate(\"2025-05-06T08:35:32Z\")",
+        }));
+
+        assert_eq!(result.documents[0]["lastUpdatedDate"], serde_json::json!("ISODate(\"2025-05-06T08:35:32Z\")"));
+        let extended = result.extended_documents.expect("extended documents");
+        assert_eq!(extended[0]["lastUpdatedDate"], serde_json::json!({ "$date": "2025-05-06T08:35:32Z" }));
+        assert_eq!(extended[0]["dateText"], serde_json::json!("ISODate(\"2025-05-06T08:35:32Z\")"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/vector_driver.rs
+++ b/crates/dbx-core/src/db/vector_driver.rs
@@ -523,6 +523,7 @@ pub async fn find_documents(
         return Ok(crate::db::mongo_driver::MongoDocumentResult {
             documents,
             raw_documents: None,
+            extended_documents: None,
             total: result.affected_rows,
         });
     }
@@ -566,7 +567,12 @@ pub async fn find_documents(
             Value::Object(map)
         })
         .collect();
-    Ok(crate::db::mongo_driver::MongoDocumentResult { documents, raw_documents: None, total: result.affected_rows })
+    Ok(crate::db::mongo_driver::MongoDocumentResult {
+        documents,
+        raw_documents: None,
+        extended_documents: None,
+        total: result.affected_rows,
+    })
 }
 
 pub async fn execute_rest_query(client: &VectorClient, input: &str) -> Result<QueryResult, String> {

--- a/crates/dbx-core/tests/live_mongodb_find_one.rs
+++ b/crates/dbx-core/tests/live_mongodb_find_one.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use dbx_core::db::mongo_driver;
+use mongodb::bson::{doc, Bson, DateTime};
 
 #[tokio::test]
 #[ignore = "requires DBX_LIVE_MONGODB_URL pointing at a writable MongoDB database"]
@@ -32,5 +33,36 @@ async fn find_one_returns_only_the_sorted_document() {
 
     assert_eq!(result.total, 1);
     assert_eq!(result.documents, vec![serde_json::json!({ "name": "new" })]);
+    mongo_driver::drop_collection(&client, database, &collection).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_LIVE_MONGODB_URL pointing at a writable MongoDB database"]
+async fn find_documents_returns_type_preserving_copy_documents() {
+    let url = std::env::var("DBX_LIVE_MONGODB_URL").expect("DBX_LIVE_MONGODB_URL");
+    let client = mongo_driver::connect(&url, Duration::from_secs(10), Duration::from_secs(60)).await.unwrap();
+    let database = "dbx_live_find_one";
+    let collection = format!("copy_types_{}", std::process::id());
+
+    client
+        .database(database)
+        .collection(&collection)
+        .insert_one(doc! {
+            "lastUpdatedDate": DateTime::parse_rfc3339_str("2025-05-06T08:35:32Z").unwrap(),
+            "dateText": Bson::String("ISODate(\"2025-05-06T08:35:32Z\")".to_string()),
+        })
+        .await
+        .unwrap();
+
+    let result =
+        mongo_driver::find_documents(&client, database, &collection, 0, 10, Some("{}"), Some(r#"{"_id":0}"#), None)
+            .await
+            .unwrap();
+
+    assert_eq!(result.documents[0]["lastUpdatedDate"], serde_json::json!("ISODate(\"2025-05-06T08:35:32Z\")"));
+    let extended = result.extended_documents.expect("extended documents");
+    assert_eq!(extended[0]["lastUpdatedDate"], serde_json::json!({ "$date": "2025-05-06T08:35:32Z" }));
+    assert_eq!(extended[0]["dateText"], serde_json::json!("ISODate(\"2025-05-06T08:35:32Z\")"));
+
     mongo_driver::drop_collection(&client, database, &collection).await.unwrap();
 }

--- a/packages/app-tests/documentBrowser.test.ts
+++ b/packages/app-tests/documentBrowser.test.ts
@@ -26,4 +26,6 @@ test("mongo document table passes copy context to the data grid", () => {
   const source = documentBrowserSource();
   assert.match(source, /<DataGrid[\s\S]*?:database-type="props\.databaseType"[\s\S]*?<\/DataGrid>/);
   assert.match(source, /const customSaveHandler = computed<CustomSaveHandler>\(\(\) => \(\{[\s\S]*?targetLabel: props\.collection,[\s\S]*?\}\)\);/);
+  assert.match(source, /mongo_copy_documents: copyDocuments\.value/);
+  assert.match(source, /result\.extended_documents\?\.length === nextDocuments\.length/);
 });

--- a/packages/app-tests/useDataGridExport.test.ts
+++ b/packages/app-tests/useDataGridExport.test.ts
@@ -312,6 +312,7 @@ test("copy MongoDB row as INSERT uses Mongo shell insert syntax", async () => {
   const jsonString = '{"endingBalance":{"beginningBalance":"0","endingBalance":"100","endingDate":"2024-11-25"},"Line":[]}';
   const row = {
     id: 1,
+    sourceIndex: 0,
     data: ["6743e4bfa3f6f84bc3fff6c8", "577", "done", jsonString, 'ISODate("2024-11-25T02:45:36.184Z")'],
     isNew: false,
     isDeleted: false,
@@ -329,6 +330,15 @@ test("copy MongoDB row as INSERT uses Mongo shell insert syntax", async () => {
     database: computed(() => "db"),
     context: computed(() => "results"),
     sourceColumns: computed(() => undefined),
+    mongoDocuments: computed(() => [
+      {
+        _id: { $oid: "6743e4bfa3f6f84bc3fff6c8" },
+        accountId: 577,
+        status: "done",
+        data: { endingBalance: { beginningBalance: "0", endingBalance: "100", endingDate: "2024-11-25" }, Line: [] },
+        lastUpdatedDate: { $date: "2024-11-25T02:45:36.184Z" },
+      },
+    ]),
     columnTypes: computed(() => undefined),
     whereInput: computed(() => undefined),
     orderBy: computed(() => undefined),
@@ -348,7 +358,20 @@ test("copy MongoDB row as INSERT uses Mongo shell insert syntax", async () => {
   assert.equal(apiMock.buildDataGridCopyInsertStatement.mock.calls.length, 0);
   assert.equal(
     clipboardMock.copyToClipboard.mock.calls[0][0],
-    'db.getCollection("accounting_reconciliations").insert({"_id":ObjectId("6743e4bfa3f6f84bc3fff6c8"),"accountId":577,"status":"done","data":{"endingBalance":{"beginningBalance":"0","endingBalance":"100","endingDate":"2024-11-25"},"Line":[]},"lastUpdatedDate":ISODate("2024-11-25T02:45:36.184Z")});',
+    `db.getCollection("accounting_reconciliations").insert({
+  "_id": ObjectId("6743e4bfa3f6f84bc3fff6c8"),
+  "accountId": 577,
+  "status": "done",
+  "data": {
+    "endingBalance": {
+      "beginningBalance": "0",
+      "endingBalance": "100",
+      "endingDate": "2024-11-25"
+    },
+    "Line": []
+  },
+  "lastUpdatedDate": ISODate("2024-11-25T02:45:36.184Z")
+});`,
   );
 });
 
@@ -388,7 +411,18 @@ test("copy MongoDB rows as INSERT excludes _id for insert without primary keys",
   await composable.copyRowAsInsertWithoutPrimaryKeys();
 
   assert.equal(apiMock.buildDataGridCopyInsertStatement.mock.calls.length, 0);
-  assert.equal(clipboardMock.copyToClipboard.mock.calls[0][0], 'db.getCollection("accounting_reconciliations").insertMany([{"status":"done"},{"status":"draft"}]);');
+  assert.equal(
+    clipboardMock.copyToClipboard.mock.calls[0][0],
+    `db.getCollection("accounting_reconciliations")
+  .insertMany([
+    {
+      "status": "done"
+    },
+    {
+      "status": "draft"
+    }
+  ]);`,
+  );
 });
 
 test("copy row as INSERT refreshes prepared SQL after row data changes", async () => {


### PR DESCRIPTION
## 问题

继续修复 #2215 在 PR #3270 发布后的反馈：

1. 集合列表复制的 MongoDB INSERT 仍是单行内容，没有格式化
2. BSON DateTime 被复制成普通字符串：

```javascript
"lastUpdatedDate": "ISODate(\"2025-05-06T08:35:32Z\")"
```

预期应保留 Mongo Shell 日期类型：

```javascript
"lastUpdatedDate": ISODate("2025-05-06T08:35:32Z")
```

## 原因

PR #3270 为避免把数字字符串、JSON 字符串等值误判成 BSON 类型，复制时改为优先使用后端返回的原始文档。

但原生 MongoDB 后端此前为了表格显示，会把 BSON DateTime 扁平化成普通的 `ISODate("...")` 字符串。前端拿到这个值后无法再区分：

- 真正的 BSON DateTime
- 内容恰好为 `ISODate("...")` 的普通 BSON String

因此只能安全地按字符串加引号。

## 修复

- 原生 MongoDB 查询结果在保留原有显示文档的同时，额外返回一份类型完整的 Extended JSON 文档
- 集合浏览器仅在复制 JSON/INSERT 时使用这份类型信息，原有表格和文档显示不变
- 旧 Agent 或不提供类型文档的后端继续走原有兼容回退
- MongoDB INSERT 复制结果复用现有 Mongo Shell formatter，单条和批量 INSERT 都输出为多行格式
- 增加回归测试，确保真正的 DateTime 输出为 `ISODate(...)`，而外观相同的普通字符串仍保留引号

## 实际验证

在 MongoDB 7.0.15 实例中写入真实 BSON 文档，文档同时包含：

- `lastUpdatedDate`: BSON DateTime
- `dateText`: 内容为 `ISODate("2025-05-06T08:35:32Z")` 的 BSON String

使用当前分支的 DBX 原生 MongoDB 驱动读取后验证：

- DateTime 的复制上下文保留为 `{ "$date": ... }`
- 普通字符串仍保持字符串，不会误判成日期
- 实际集成测试 `2 passed`

测试结果：

- `pnpm vitest run apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts packages/app-tests/useDataGridExport.test.ts packages/app-tests/mongoDocumentValues.test.ts packages/app-tests/mongoFormatter.test.ts packages/app-tests/documentBrowser.test.ts`：59 passed
- `pnpm typecheck`：通过
- `pnpm lint`：通过（仅仓库已有 warning）
- `cargo test -p dbx-core --no-default-features mongo_document_result_keeps_extended_json_types_for_copying --lib`：通过
- `DBX_LIVE_MONGODB_URL=... cargo test -p dbx-core --no-default-features --test live_mongodb_find_one -- --ignored --nocapture`：2 passed