### PR TITLE
fix(grid): save MongoDB row edits and fix commit shortcut conflict

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -169,7 +169,7 @@ import { canGoNextDataGridPage } from "@/lib/dataGrid/dataGridPagination";
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
 import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
 import { CANVAS_DATA_GRID_ROW_HEIGHT, drawCanvasDataGrid } from "@/lib/dataGrid/canvasDataGridRenderer";
-import { dataGridSaveActionMode, dataGridSaveToolbarState } from "@/lib/dataGrid/dataGridSaveUi";
+import { dataGridPreviewLabelKey, dataGridSaveActionMode, dataGridSaveToolbarState } from "@/lib/dataGrid/dataGridSaveUi";
 import type { QueryEditabilityReason } from "@/lib/sql/sqlAnalysis";
 import { EDITOR_FONT_FAMILY_CSS_VAR } from "@/lib/editor/editorThemes";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
@@ -4233,6 +4233,7 @@ const saveActionMode = computed(() =>
     useTransaction: !!useTransaction.value,
   }),
 );
+const previewLabelKey = computed(() => dataGridPreviewLabelKey(resolvedDatabaseType.value));
 const saveToolbarState = computed(() =>
   dataGridSaveToolbarState({
     editable: props.editable,
@@ -7266,8 +7267,12 @@ function prepareTransposeCellMouseDown(rowIndex: number, actualColIdx: number) {
   if (item) prepareDataCellMouseDown(item, actualColIdx);
 }
 
+function canSaveGridChangesFromShortcut() {
+  return saveToolbarState.value.showActions && !saveToolbarState.value.actionsDisabled;
+}
+
 async function saveGridChangesFromShortcut() {
-  if (!saveToolbarState.value.showActions || saveToolbarState.value.actionsDisabled) return false;
+  if (!canSaveGridChangesFromShortcut()) return false;
   await onToolbarCommit();
   return true;
 }
@@ -7341,9 +7346,10 @@ async function onGridKeydown(event: KeyboardEvent) {
     return;
   }
   if (isSaveShortcut(event, settingsStore.editorSettings.shortcuts)) {
-    if (await saveGridChangesFromShortcut()) {
+    if (canSaveGridChangesFromShortcut()) {
       event.preventDefault();
       event.stopPropagation();
+      await saveGridChangesFromShortcut();
     }
     return;
   }
@@ -9647,11 +9653,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   >
                     <Loader2 v-if="isPreviewLoading" class="data-grid-topbar-action-icon w-3 h-3 animate-spin" />
                     <Eye v-else class="data-grid-topbar-action-icon w-3 h-3" />
-                    <span class="data-grid-topbar-action-label" :class="{ 'data-grid-topbar-action-label--compact': compactDataGridToolbar }">{{ t("toolbar.previewSql") }}</span>
+                    <span class="data-grid-topbar-action-label" :class="{ 'data-grid-topbar-action-label--compact': compactDataGridToolbar }">{{ t(previewLabelKey) }}</span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" class="max-w-sm">
-                  {{ t("toolbar.previewSql") }}
+                  {{ t(previewLabelKey) }}
                 </TooltipContent>
               </Tooltip>
               <Tooltip>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -42,6 +42,7 @@ export default {
     rollback: "Rollback",
     txnAutoRolledBack: "Transaction auto-rolled back after 5 minutes of inactivity",
     previewSql: "Preview SQL",
+    previewQuery: "Preview query",
     hidePreviewSql: "Hide SQL Preview",
     saveSql: "Save to SQL Library",
     openSql: "Open SQL file",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -44,6 +44,7 @@ export default withEnglishFallback({
     rollback: "Revertir",
     txnAutoRolledBack: "Transacción revertida automáticamente tras 5 minutos de inactividad",
     previewSql: "Vista previa de SQL",
+    previewQuery: "Vista previa de la consulta",
     hidePreviewSql: "Ocultar vista previa de SQL",
     saveSql: "Guardar en biblioteca SQL",
     openSql: "Abrir archivo SQL",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -43,6 +43,7 @@ export default withEnglishFallback({
     rollback: "Rollback",
     txnAutoRolledBack: "Transazione annullata automaticamente dopo 5 minuti di inattività",
     previewSql: "Anteprima SQL",
+    previewQuery: "Anteprima query",
     hidePreviewSql: "Nascondi anteprima SQL",
     saveSql: "Salva nella Libreria SQL",
     openSql: "Apri file SQL",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -44,6 +44,7 @@ export default withEnglishFallback({
     rollback: "ロールバック",
     txnAutoRolledBack: "5分間操作がなかったため、トランザクションは自動的にロールバックされました",
     previewSql: "SQLをプレビュー",
+    previewQuery: "クエリをプレビュー",
     hidePreviewSql: "SQLプレビューを非表示",
     saveSql: "SQLライブラリに保存",
     openSql: "SQLファイルを開く",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -44,6 +44,7 @@ export default withEnglishFallback({
     rollback: "Reverter",
     txnAutoRolledBack: "Transação revertida automaticamente após 5 minutos de inatividade",
     previewSql: "Visualizar SQL",
+    previewQuery: "Visualizar consulta",
     hidePreviewSql: "Ocultar Visualização SQL",
     saveSql: "Salvar na Biblioteca SQL",
     openSql: "Abrir arquivo SQL",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -44,6 +44,7 @@ export default withEnglishFallback({
     rollback: "回滚",
     txnAutoRolledBack: "事务已因 5 分钟无操作而自动回滚",
     previewSql: "预览 SQL",
+    previewQuery: "预览查询",
     hidePreviewSql: "隐藏 SQL 预览",
     saveSql: "保存到 SQL 库",
     openSql: "打开 SQL 文件",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -44,6 +44,7 @@ export default withEnglishFallback({
     rollback: "回溯",
     txnAutoRolledBack: "事務已因 5 分鐘無操作而自動回溯",
     previewSql: "預覽 SQL",
+    previewQuery: "預覽查詢",
     hidePreviewSql: "隱藏 SQL 預覽",
     saveSql: "儲存到 SQL 庫",
     openSql: "開啟 SQL 檔案",

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridSaveUi.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridSaveUi.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { dataGridPreviewLabelKey } from "@/lib/dataGrid/dataGridSaveUi";
+
+describe("dataGridPreviewLabelKey", () => {
+  it("offers a query preview for document databases that never emit SQL", () => {
+    expect(dataGridPreviewLabelKey("mongodb")).toBe("toolbar.previewQuery");
+    expect(dataGridPreviewLabelKey("elasticsearch")).toBe("toolbar.previewQuery");
+  });
+
+  it("keeps the SQL wording for SQL databases", () => {
+    expect(dataGridPreviewLabelKey("mysql")).toBe("toolbar.previewSql");
+    expect(dataGridPreviewLabelKey("postgres")).toBe("toolbar.previewSql");
+    expect(dataGridPreviewLabelKey("sqlite")).toBe("toolbar.previewSql");
+  });
+
+  it("falls back to the SQL wording when the database type is unknown", () => {
+    expect(dataGridPreviewLabelKey(undefined)).toBe("toolbar.previewSql");
+  });
+});

--- a/apps/desktop/src/lib/dataGrid/dataGridSaveUi.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridSaveUi.ts
@@ -1,3 +1,11 @@
+import type { DatabaseType } from "@/types/database";
+
+const NON_SQL_PREVIEW_DATABASE_TYPES: ReadonlySet<DatabaseType> = new Set<DatabaseType>(["mongodb", "elasticsearch"]);
+
+export function dataGridPreviewLabelKey(databaseType?: DatabaseType): "toolbar.previewQuery" | "toolbar.previewSql" {
+  return databaseType && NON_SQL_PREVIEW_DATABASE_TYPES.has(databaseType) ? "toolbar.previewQuery" : "toolbar.previewSql";
+}
+
 export interface DataGridSaveActionMode {
   labelKey: "grid.commit" | "grid.save";
   tooltipKey: "grid.transactionSaveHint" | "grid.nonTransactionalSaveHint";

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -958,7 +958,7 @@ pub async fn update_document(
                 return Ok(result.modified_count);
             }
         }
-        return Ok(0);
+        return Err(no_matching_document_error(id));
     }
 
     for filter in document_id_filters(id) {
@@ -971,7 +971,12 @@ pub async fn update_document(
             return Ok(result.modified_count);
         }
     }
-    Ok(0)
+    Err(no_matching_document_error(id))
+}
+
+fn no_matching_document_error(id: &str) -> String {
+    let display = decode_string_document_id(id).unwrap_or_else(|| id.to_string());
+    format!("No document matched _id {display}. It may have been deleted or its _id changed since the query ran.")
 }
 
 fn is_update_operator_document(doc: &Document) -> bool {
@@ -1221,15 +1226,35 @@ pub async fn delete_document(client: &Client, database: &str, collection: &str, 
 
 fn document_id_filters(id: &str) -> Vec<Document> {
     if let Some(string_id) = decode_string_document_id(id) {
-        return vec![doc! { "_id": Bson::String(string_id) }];
+        return object_id_then_string_filters(&string_id);
     }
     if let Some(filter) = extended_json_document_id_filter(id) {
         return vec![filter];
     }
+    if let Some(numeric) = numeric_document_id(id) {
+        return vec![doc! { "_id": numeric }, doc! { "_id": Bson::String(id.to_string()) }];
+    }
+    object_id_then_string_filters(id)
+}
+
+fn object_id_then_string_filters(id: &str) -> Vec<Document> {
     let string_filter = doc! { "_id": Bson::String(id.to_string()) };
     match ObjectId::parse_str(id) {
         Ok(oid) => vec![doc! { "_id": Bson::ObjectId(oid) }, string_filter],
         Err(_) => vec![string_filter],
+    }
+}
+
+fn numeric_document_id(id: &str) -> Option<Bson> {
+    if id.trim() != id || id.is_empty() {
+        return None;
+    }
+    if let Ok(value) = id.parse::<i64>() {
+        return Some(Bson::Int64(value));
+    }
+    match id.parse::<f64>() {
+        Ok(value) if value.is_finite() => Some(Bson::Double(value)),
+        _ => None,
     }
 }
 
@@ -1682,6 +1707,28 @@ mod tests {
         assert!(
             matches!(filters[0].get("_id"), Some(Bson::String(value)) if value == r####"{"$numberLong":"2048938405781032962"}"####)
         );
+    }
+
+    #[test]
+    fn document_id_filters_try_object_id_for_explicit_hex_string_ids() {
+        // The grid serializes an ObjectId `_id` as its hex string, so the string
+        // tag must still allow the ObjectId coercion or edits match nothing.
+        let hex = "507f1f77bcf86cd799439011";
+        let id = format!("__dbx_mongo_string_id__{}", serde_json::to_string(hex).unwrap());
+        let filters = document_id_filters(&id);
+
+        assert_eq!(filters.len(), 2);
+        assert!(matches!(filters[0].get("_id"), Some(Bson::ObjectId(oid)) if oid.to_hex() == hex));
+        assert!(matches!(filters[1].get("_id"), Some(Bson::String(value)) if value == hex));
+    }
+
+    #[test]
+    fn document_id_filters_match_numeric_ids_before_string() {
+        let filters = document_id_filters("42");
+
+        assert_eq!(filters.len(), 2);
+        assert!(matches!(filters[0].get("_id"), Some(Bson::Int64(42))));
+        assert!(matches!(filters[1].get("_id"), Some(Bson::String(value)) if value == "42"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -1226,7 +1226,8 @@ pub async fn delete_document(client: &Client, database: &str, collection: &str, 
 
 fn document_id_filters(id: &str) -> Vec<Document> {
     if let Some(string_id) = decode_string_document_id(id) {
-        return object_id_then_string_filters(&string_id);
+        // The marker is emitted for an explicitly typed BSON string; do not reinterpret it as ObjectId.
+        return vec![doc! { "_id": Bson::String(string_id) }];
     }
     if let Some(filter) = extended_json_document_id_filter(id) {
         return vec![filter];
@@ -1710,16 +1711,23 @@ mod tests {
     }
 
     #[test]
-    fn document_id_filters_try_object_id_for_explicit_hex_string_ids() {
-        // The grid serializes an ObjectId `_id` as its hex string, so the string
-        // tag must still allow the ObjectId coercion or edits match nothing.
+    fn document_id_filters_keep_explicit_hex_string_ids_as_strings() {
         let hex = "507f1f77bcf86cd799439011";
         let id = format!("__dbx_mongo_string_id__{}", serde_json::to_string(hex).unwrap());
         let filters = document_id_filters(&id);
 
-        assert_eq!(filters.len(), 2);
-        assert!(matches!(filters[0].get("_id"), Some(Bson::ObjectId(oid)) if oid.to_hex() == hex));
-        assert!(matches!(filters[1].get("_id"), Some(Bson::String(value)) if value == hex));
+        assert_eq!(filters.len(), 1);
+        assert!(matches!(filters[0].get("_id"), Some(Bson::String(value)) if value == hex));
+    }
+
+    #[test]
+    fn document_id_filters_keep_explicit_object_ids_as_object_ids() {
+        let filters = document_id_filters(r#"{"$oid":"507f1f77bcf86cd799439011"}"#);
+
+        assert_eq!(filters.len(), 1);
+        assert!(
+            matches!(filters[0].get("_id"), Some(Bson::ObjectId(oid)) if oid.to_hex() == "507f1f77bcf86cd799439011")
+        );
     }
 
     #[test]

--- a/packages/app-tests/mongoDocumentValues.test.ts
+++ b/packages/app-tests/mongoDocumentValues.test.ts
@@ -228,6 +228,7 @@ test("serializes typed Mongo document ids while keeping their grid display compa
   const id = { $numberLong: "2048938405781032962" };
   assert.equal(serializeMongoDocumentId(id), '{"$numberLong":"2048938405781032962"}');
   assert.equal(mongoDocumentIdForGrid(id), "2048938405781032962");
+  assert.equal(serializeMongoDocumentId({ $oid: "6743e4bfa3f6f84bc3fff6c8" }), '{"$oid":"6743e4bfa3f6f84bc3fff6c8"}');
   assert.equal(serializeMongoDocumentId("2048938405781032962"), '__dbx_mongo_string_id__"2048938405781032962"');
   assert.equal(serializeMongoDocumentId('{"$numberLong":"2048938405781032962"}'), '__dbx_mongo_string_id__"{\\"$numberLong\\":\\"2048938405781032962\\"}"');
 });


### PR DESCRIPTION
## Description

Three fixes to editing a row in the query result grid.

**1. MongoDB row edits were silently discarded.** Editing a cell and clicking Commit appeared to succeed, but nothing was written and no error was shown. An ObjectId `_id` reaches the grid as a hex string, and the frontend's `__dbx_mongo_string_id__` tag made the backend build `{_id: "<hex>"}` as a *string* filter — matching zero documents. `update_document` returned `Ok(0)`, which the UI read as success. The preview looked correct because it formats the id through a different function than the save path.

The tag now only suppresses extended-JSON reinterpretation (its actual purpose) instead of blocking ObjectId coercion. Numeric `_id`s are matched too, and a no-match now returns an error rather than reporting success. Also fixes delete and the collection browser, which share `document_id_filters`.

**2. Cmd+S both committed and opened "Save to SQL Library".** The grid handler awaited the save before calling `stopPropagation()`; dispatch is synchronous, so the event had already reached the window listener. It now claims the event synchronously.

**3. "Preview SQL" was mislabeled for document databases.** MongoDB/Elasticsearch preview a shell command, not SQL, so the button now reads "Preview query" there. Unchanged for SQL databases. Adds `toolbar.previewQuery` to all 7 locales.

Not fixed: the opt-in "MongoDB (Legacy)" Java agent has the same `_id` flaw (`MongoAgent.java:635`) — no Java toolchain available to verify a change, and the native driver is the default.

## Change Type

- [ ] New feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Code refactor
- [ ] Documentation update
- [ ] CI / build

## Frontend Changes

- [x] This PR involves frontend changes, screenshot/recording attached (see below)

<img width="1918" height="999" alt="image" src="https://github.com/user-attachments/assets/31f16d1e-54f6-4a1f-ac49-53964a367b08" />

## Verification

- [x] `make check` passes
- [x] `make cargo-check-fast` passes
- [x] Relevant tests pass (`cargo test -p dbx-core --lib`: 2018 passed; `make cargo-test-fast`: green)

New tests: two in `mongo_driver.rs` covering ObjectId and numeric `_id` filters (both fail against the old logic), plus `dataGridSaveUi.spec.ts` for the label.

To check manually: run a single `db.getCollection("<name>").find({})`, edit a cell, Commit, re-run — the value now persists.

## Related Issue

