### PR TITLE
统一表属性面板中编辑表结构图标为 PencilRuler

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -68,7 +68,7 @@ import {
   TableProperties,
   Database,
   Columns3,
-  Columns3Cog,
+  PencilRuler,
   Timer,
 } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
@@ -10657,7 +10657,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 </Button>
               </div>
               <Button v-if="canOpenTableStructureEditor" variant="ghost" size="sm" class="table-info-action-button h-6 px-2 text-xs" :title="t('contextMenu.editStructure')" :aria-label="t('contextMenu.editStructure')" @click="openTableStructureEditor">
-                <Columns3Cog class="w-3 h-3" />
+                <PencilRuler class="w-3 h-3" />
                 <span class="table-info-action-label">{{ t("contextMenu.editStructure") }}</span>
               </Button>
               <Button variant="ghost" size="icon" class="h-5 w-5" @click="showTableInfo = false">

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -14,7 +14,6 @@ import {
   CopyPlus,
   ChevronDown,
   ChevronRight,
-  Columns3Cog,
   Download,
   Eraser,
   Eye,
@@ -2684,7 +2683,7 @@ function getObjectBrowserMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
               </Button>
             </div>
             <Button v-if="canOpenTableStructureEditor" variant="ghost" size="sm" class="table-info-action-button h-6 px-2 text-xs" :title="t('contextMenu.editStructure')" :aria-label="t('contextMenu.editStructure')" @click="openTableStructureEditor">
-              <Columns3Cog class="w-3 h-3" />
+              <PencilRuler class="w-3 h-3" />
               <span class="table-info-action-label">{{ t("contextMenu.editStructure") }}</span>
             </Button>
             <Button variant="ghost" size="icon" class="h-5 w-5" @click="closeSidePanel">


### PR DESCRIPTION
## 变更内容

将表属性面板中"编辑表结构"按钮的图标从 `Columns3Cog` 替换为 `PencilRuler`，与对象列表右键菜单中的"编辑表结构"图标保持一致。

## 修改文件

- `DataGrid.vue` — 替换表属性抽屉中编辑表结构按钮图标，更新导入
- `ObjectBrowser.vue` — 替换侧边面板中编辑表结构按钮图标，移除无用 `Columns3Cog` 导入

## 影响范围

仅影响表属性面板（DataGrid 抽屉和 ObjectBrowser 侧边面板）中的"编辑表结构"按钮图标，不影响其他页面或功能。`Columns3Cog` 在 `ContentArea.vue` 中仍用于"列宽"设置，不受影响。