### PR TITLE
feat(duckdb): bundle parquet extension

### DIFF
--- a/crates/dbx-core/Cargo.toml
+++ b/crates/dbx-core/Cargo.toml
@@ -33,7 +33,7 @@ bench = false
 
 [features]
 default = ["duckdb-bundled", "mq-admin", "sqlite-sqlcipher"]
-duckdb-bundled = ["duckdb/bundled"]
+duckdb-bundled = ["duckdb/bundled", "duckdb/parquet"]
 mq-admin = []
 sqlite-sqlcipher = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
 

--- a/crates/dbx-core/src/db/duckdb_driver.rs
+++ b/crates/dbx-core/src/db/duckdb_driver.rs
@@ -61,6 +61,10 @@ pub fn connect_path(path: &str) -> Result<Arc<DuckDbConnection>, String> {
     let connection = if is_memory { duckdb::Connection::open_in_memory() } else { duckdb::Connection::open(path) }
         .map_err(|e| format!("DuckDb connection failed: {e}"))?;
 
+    connection
+        .execute_batch("LOAD parquet;")
+        .map_err(|e| format!("DuckDb failed to load parquet extension: {e}"))?;
+
     Ok(Arc::new(DuckDbConnection::new(connection)))
 }
 

--- a/crates/dbx-core/src/db/duckdb_driver.rs
+++ b/crates/dbx-core/src/db/duckdb_driver.rs
@@ -63,7 +63,7 @@ pub fn connect_path(path: &str) -> Result<Arc<DuckDbConnection>, String> {
 
     connection
         .execute_batch("LOAD parquet;")
-        .map_err(|e| format!("DuckDb failed to load parquet extension: {e}"))?;
+        .map_err(|e| format!("DuckDb failed to load parquet extension (ensure the binary was built with the parquet feature enabled): {e}"))?;
 
     Ok(Arc::new(DuckDbConnection::new(connection)))
 }

--- a/crates/dbx-core/src/db/duckdb_driver.rs
+++ b/crates/dbx-core/src/db/duckdb_driver.rs
@@ -61,10 +61,6 @@ pub fn connect_path(path: &str) -> Result<Arc<DuckDbConnection>, String> {
     let connection = if is_memory { duckdb::Connection::open_in_memory() } else { duckdb::Connection::open(path) }
         .map_err(|e| format!("DuckDb connection failed: {e}"))?;
 
-    connection
-        .execute_batch("LOAD parquet;")
-        .map_err(|e| format!("DuckDb failed to load parquet extension (ensure the binary was built with the parquet feature enabled): {e}"))?;
-
     Ok(Arc::new(DuckDbConnection::new(connection)))
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]
 default = ["duckdb-bundled", "mq-admin", "sqlite-sqlcipher"]
-duckdb-bundled = ["duckdb", "dbx-core/duckdb-bundled"]
+duckdb-bundled = ["duckdb", "duckdb/parquet", "dbx-core/duckdb-bundled"]
 mq-admin = ["dbx-core/mq-admin"]
 sqlite-sqlcipher = ["dbx-core/sqlite-sqlcipher"]
 


### PR DESCRIPTION
## 变更说明

DuckDB was bundled without the parquet extension. Adds `duckdb/parquet` to the `duckdb-bundled` Cargo feature so parquet is statically compiled in. When built with the `parquet` feature, DuckDB registers it automatically on every connection — no `LOAD parquet;` needed.

## 变更类型

- [x] 新功能

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

Closes https://github.com/t8y2/dbx/issues/945