### PR TITLE
fix(sql): 修复 ClickHouse SQL 格式化拆坏 lambda 箭头

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -14,6 +14,24 @@ describe("sqlFormatter", () => {
     }
   });
 
+  it("preserves ClickHouse lambda arrows when formatting issue #3573 SQL", async () => {
+    const sql = `
+      WITH industry_code_donghua_id_RYCzfD AS (SELECT id
+      FROM cd.industry_code_donghua
+      WHERE cd.industry_code_donghua.code IN ('INB0709', 'INB0004'))
+      SELECT id,ent_short,arrayMap(x->dictGet(cd.industry_donghua_dict,'name',x),prefer_industry) as prefer_industry_name,org_type,company_id,arrayCount(\`investment.be_company_id\` -> 1, \`investment.be_company_id\`) as be_company_count
+      FROM search_donghua.investor
+      WHERE arrayExists(x -> x IN industry_code_donghua_id_RYCzfD, prefer_industry)
+      ORDER BY be_company_count DESC,id ASC
+      LIMIT 0,10
+    `;
+
+    const formatted = await formatSqlText(sql, sqlFormatDialectForDbType("clickhouse"));
+
+    expect(formatted).toContain("x -> dictGet");
+    expect(formatted).not.toContain("- >");
+  });
+
   it("falls back to the postgres formatter when the generic dialect cannot parse SQL", async () => {
     const formatted = await formatSqlText("SELECT 1::int AS id;", "generic");
 

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_SQL_FORMATTER_SETTINGS, sqlFormatterOptions, type SqlFormatterSettings } from "@/lib/sql/sqlFormatterConfig";
 
-export type SqlFormatDialect = "mysql" | "postgres" | "sqlite" | "sqlserver" | "generic";
+export type SqlFormatDialect = "mysql" | "postgres" | "sqlite" | "sqlserver" | "clickhouse" | "generic";
 
 export const MAX_SQL_FORMAT_CHARS = 1_000_000;
 
@@ -34,6 +34,8 @@ export function sqlFormatDialectForDbType(dbType: string | null | undefined): Sq
       return "sqlite";
     case "sqlserver":
       return "sqlserver";
+    case "clickhouse":
+      return "clickhouse";
     default:
       return "generic";
   }
@@ -49,6 +51,8 @@ function formatterLanguage(dialect: SqlFormatDialect) {
       return "sqlite";
     case "sqlserver":
       return "transactsql";
+    case "clickhouse":
+      return "clickhouse";
     default:
       return "sql";
   }


### PR DESCRIPTION
## 问题

Closes #3573

ClickHouse 连接中格式化前可正常执行的 SQL，格式化后执行报错。issue 中的查询含 `arrayMap(x->dictGet(...))` 等高阶函数，格式化后 lambda 箭头 `->` 被拆成 `- >`：

```
arrayMap (
  x - > dictGet (cd.industry_donghua_dict, 'name', x),
  ...
)
```

`- >` 不是合法操作符，SQL 无法执行。

## 根因

`sqlFormatDialectForDbType`（`apps/desktop/src/lib/sql/sqlFormatter.ts`）没有 ClickHouse 的映射，`dbType=clickhouse` 落到 generic `sql` 方言。sql-formatter 的 generic 语法不认识 `->` 操作符，将其按 `-` 和 `>` 两个独立操作符断开。

## 修改

仓库内的 sql-formatter 15.8.0 已原生提供 `clickhouse` 方言（支持 `->` lambda、反引号标识符、`LIMIT offset,count`）：

- `SqlFormatDialect` 联合类型新增 `"clickhouse"`；
- `sqlFormatDialectForDbType` 为 `clickhouse` 返回该方言，`formatterLanguage` 映射到 sql-formatter 的 `clickhouse` 语言；
- 解析失败回退 postgresql 的既有逻辑不变。

已用 issue 原始 SQL 验证：反引号嵌套列名 `` `investment.be_company_id` ``、`LIMIT 0,10`、WITH CTE、lambda 箭头全部正确保留。

## 测试

`sqlFormatter.spec.ts` 新增回归用例：用 issue 原始 ClickHouse SQL 断言格式化结果保留 `x -> dictGet` 且不出现 `- >`。

## 验证

- `pnpm check` 全绿（format / lint / typecheck / test）
- 定向 vitest：sqlFormatter.spec.ts 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)