### PR TITLE
fix(sql): 修复 ${} 与 #{} 占位符导致 SQL 格式化失败

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -14,6 +14,18 @@ describe("sqlFormatter", () => {
     }
   });
 
+  it("preserves DBX brace placeholders in generic and MySQL SQL", async () => {
+    const sql = "SELECT ${x} AS shell_value, #{x} AS mybatis_value, '${date}' AS quoted_value";
+
+    for (const dialect of ["generic", "mysql"] as const) {
+      const formatted = await formatSqlText(sql, dialect);
+
+      expect(formatted).toContain("${x}");
+      expect(formatted).toContain("#{x}");
+      expect(formatted).toContain("'${date}'");
+    }
+  });
+
   it("falls back to the postgres formatter when the generic dialect cannot parse SQL", async () => {
     const formatted = await formatSqlText("SELECT 1::int AS id;", "generic");
 

--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatterConfig.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatterConfig.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SQL_FORMATTER_SETTINGS, parseSqlFormatterConfig, serializeSqlFormatterConfig } from "@/lib/sql/sqlFormatterConfig";
+import { DEFAULT_SQL_FORMATTER_SETTINGS, parseSqlFormatterConfig, serializeSqlFormatterConfig, sqlFormatterOptions } from "@/lib/sql/sqlFormatterConfig";
 
 describe("sqlFormatterConfig shortcut storage", () => {
   it("does not serialize JSON editor shortcut settings", () => {
@@ -22,5 +22,21 @@ describe("sqlFormatterConfig shortcut storage", () => {
     );
 
     expect(result.ok).toBe(true);
+  });
+
+  it("merges DBX custom parameter types with user paramTypes", () => {
+    const options = sqlFormatterOptions({
+      paramTypes: {
+        positional: false,
+        named: ["@"],
+        custom: [{ regex: String.raw`\{\{[^}]+\}\}` }],
+      },
+    });
+
+    expect(options.paramTypes).toEqual({
+      positional: false,
+      named: ["@"],
+      custom: [{ regex: String.raw`\{\{[^}]+\}\}` }, { regex: String.raw`\$\{[^}]+\}` }, { regex: String.raw`#\{[^}]+\}` }],
+    });
   });
 });

--- a/apps/desktop/src/lib/sql/sqlFormatterConfig.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatterConfig.ts
@@ -22,6 +22,11 @@ export interface SqlFormatterCustomParameter {
   regex: string;
 }
 
+// DBX substitutes `${name}`/`#{name}` placeholders client-side (see sqlVariableSyntax.ts),
+// but no sql-formatter dialect tokenizes them, so raw SQL containing them would fail to
+// format with a parse error. Always registering them as custom params keeps formatting working.
+const DBX_CUSTOM_PARAM_TYPES: SqlFormatterCustomParameter[] = [{ regex: String.raw`\$\{[^}]+\}` }, { regex: String.raw`#\{[^}]+\}` }];
+
 export interface SqlFormatterParamTypes {
   positional?: boolean;
   numbered?: ("?" | ":" | "$")[];
@@ -239,6 +244,7 @@ export function syncSqlFormatterConfigDraft(text: string, syncSettings: (setting
 
 export function sqlFormatterOptions(settings: unknown) {
   const normalized = sqlFormatterOptionSettings(settings);
+  const paramTypes = normalized.paramTypes ?? {};
   return {
     keywordCase: normalized.keywordCase,
     dataTypeCase: normalized.dataTypeCase,
@@ -252,6 +258,9 @@ export function sqlFormatterOptions(settings: unknown) {
     linesBetweenQueries: normalized.linesBetweenQueries,
     denseOperators: normalized.denseOperators,
     newlineBeforeSemicolon: normalized.newlineBeforeSemicolon,
-    ...(normalized.paramTypes !== null ? { paramTypes: normalized.paramTypes } : {}),
+    paramTypes: {
+      ...paramTypes,
+      custom: [...(paramTypes.custom ?? []), ...DBX_CUSTOM_PARAM_TYPES],
+    },
   };
 }

--- a/packages/app-tests/sqlFormatterConfig.test.ts
+++ b/packages/app-tests/sqlFormatterConfig.test.ts
@@ -249,6 +249,9 @@ test("maps DBX formatter settings to sql-formatter options", () => {
       linesBetweenQueries: 1,
       denseOperators: false,
       newlineBeforeSemicolon: true,
+      paramTypes: {
+        custom: [{ regex: String.raw`\$\{[^}]+\}` }, { regex: String.raw`#\{[^}]+\}` }],
+      },
     },
   );
 
@@ -270,7 +273,10 @@ test("maps DBX formatter settings to sql-formatter options", () => {
       linesBetweenQueries: 1,
       denseOperators: false,
       newlineBeforeSemicolon: false,
-      paramTypes: { positional: true },
+      paramTypes: {
+        positional: true,
+        custom: [{ regex: String.raw`\$\{[^}]+\}` }, { regex: String.raw`#\{[^}]+\}` }],
+      },
     },
   );
 });


### PR DESCRIPTION
## 问题

Closes #3571

SQL 编辑器中含 `${date}` 或 `#{name}` 占位符的语句无法格式化，直接报 Parse error（`Unexpected "${date}"`）。`?`、`:name`、`@name` 三种占位符可正常格式化。

## 根因

DBX 支持 5 种客户端占位符语法（`?` / `:name` / `${name}` / `#{name}` / `@name`，见 `apps/desktop/src/lib/sql/sqlVariableSyntax.ts`，替换发生在发送 SQL 之前），但 sql-formatter 没有任何方言能把 `${name}`、`#{name}` 识别为 token，含这两种占位符的原始 SQL 一进格式化器就抛解析错误。

## 修改

`sqlFormatterOptions`（`apps/desktop/src/lib/sql/sqlFormatterConfig.ts`）现在始终把这两种语法注册为 sql-formatter 的 custom paramTypes（`\$\{[^}]+\}`、`#\{[^}]+\}`）：

- 用户在格式化设置里自己配置的 `paramTypes` 完整保留：`custom` 数组做拼接，`positional`/`numbered`/`named`/`quoted` 原样透传；
- 带引号的 `'${date}'` 本就是字符串字面量，行为不变；
- `sqlFormatterOptions` 仅被 `formatSqlText` 消费，注入不影响配置文件序列化（`serializeSqlFormatterConfig` 走 `sqlFormatterOptionSettings`）。

已做 6 方言（sql/mysql/postgresql/transactsql/sqlite/clickhouse）× 5 占位符共 30 组 before/after 对照：零回归，`${x}`、`#{x}` 在全部方言下由报错转为正常。

## 测试

- `sqlFormatter.spec.ts`：断言 `${x}`、`#{x}` 在 generic 与 mysql 方言下格式化不抛错且原样保留，带引号 `'${date}'` 不受影响；
- `sqlFormatterConfig.spec.ts`：断言用户已配置 paramTypes 时 custom 正则被合并而非覆盖；
- `packages/app-tests/sqlFormatterConfig.test.ts`：同步 options 映射契约预期。

## 验证

- `pnpm check` 全绿（format / lint / typecheck / test）
- 定向 vitest：3 个被改测试文件 19 用例全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)