### PR TITLE
fix(completion): 修复 Oracle schema 限定后表名无法补全

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -159,6 +159,32 @@ describe("connectionStore completion assistant", () => {
     expect(tables).toEqual([{ name: "TEST_USERS", schema: "SYSDBA", type: "table" }]);
   });
 
+  it("scopes Oracle table completion to a qualified schema case-insensitively", async () => {
+    const completionAssistantSearch = vi.fn(async (request: { schema?: string | null }) => ({
+      candidates: request.schema?.toLowerCase() === "scott" ? [{ name: "EMP", kind: "table", schema: "SCOTT", data_type: "TABLE" }] : [],
+      incomplete: false,
+      fallback_used: false,
+    }));
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      completionAssistantSearch,
+      listTables: vi.fn().mockResolvedValue([]),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [oracleConnection()];
+    store.connectedIds.add("oracle-1");
+
+    const tables = await store.listCompletionTables("oracle-1", "ORCL", "", 20, "scott", false, "APP");
+
+    expect(completionAssistantSearch).toHaveBeenCalledWith(expect.objectContaining({ schema: "scott", parent_schema: "scott", global_search: false, mask: "" }));
+    expect(tables).toEqual([expect.objectContaining({ name: "EMP", schema: "SCOTT", applyName: "EMP", boost: 2400 })]);
+    expect(store.lookupLocalCompletionTables("oracle-1", "ORCL", "", 20, "scott")).toEqual(tables);
+  });
+
   it("maps global Oracle tables with safe qualification and schema priority", async () => {
     const completionAssistantSearch = vi.fn().mockResolvedValue({
       candidates: [

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -4008,7 +4008,7 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   function completionScopeKey(connectionId: string, database: string, schema?: string): string {
-    return `${connectionId}:${database}:${schema ?? ""}`;
+    return `${connectionId}:${database}:${schema?.toLowerCase() ?? ""}`;
   }
 
   function completionColumnsKey(connectionId: string, database: string, table: string, schema?: string): string {
@@ -4135,7 +4135,7 @@ export const useConnectionStore = defineStore("connection", () => {
 
   async function listCompletionAssistantTables(connectionId: string, database: string, filter: string, limit?: number, schema?: string, globalSearch = false, currentSchema?: string): Promise<SqlCompletionTable[]> {
     const oracleAssistant = getConfig(connectionId)?.db_type === "oracle";
-    const preferredSchema = oracleAssistant ? completionPreferredSchema(connectionId, currentSchema) : schema?.trim() || undefined;
+    const preferredSchema = oracleAssistant ? completionPreferredSchema(connectionId, globalSearch ? currentSchema : (schema ?? currentSchema)) : schema?.trim() || undefined;
     const objectKinds: CompletionAssistantObjectKind[] = ["table", "view"];
     const response = await completionAssistantSearch({
       connection_id: connectionId,


### PR DESCRIPTION
## 问题

Closes #3478

Oracle 连接的 SQL 编辑器中输入 `SELECT * FROM SCOTT.`（schema 名加点）后，不会弹出该 schema 下的表名/视图补全列表。多 Schema 环境下影响很大。

## 根因

限定符 `SCOTT` 在前端解析、lookup target 推导两层都传递正确，断点在 store 层，且有两处：

1. **限定符被丢弃**（`apps/desktop/src/stores/connectionStore.ts` 的 `listCompletionAssistantTables`）：Oracle 分支在 scoped 补全时忽略传入的 schema 参数（用户敲的限定符），固定用当前 schema/用户名作为请求的 `schema` 字段，限定符只落在 `parent_schema` 里。失败测试实际捕获到请求发送的是 `schema: "APP"` 而不是 `scott`，远端因此永远查不到目标 schema 的表。
2. **缓存 key 大小写敏感**（`completionScopeKey`）：修复第一处后，结果以 `SCOTT`（Oracle 实际 owner）写入本地补全索引，用户输入小写 `scott.` 查询时返回空数组。

## 修改

生产代码仅 2 行：

- scoped Oracle 请求改用用户输入的 schema（`globalSearch ? currentSchema : (schema ?? currentSchema)`），无限定符的 global search 行为不变；
- `completionScopeKey` 的 schema 部分统一小写（表名部分本已 `toLowerCase()`，保持同一约定）。

MySQL 系 `database.table` 补全分支未改动。

## 测试

`connectionStore.completion.spec.ts` 新增回归用例：小写 `scott` 限定符 → 断言请求参数（`schema: "scott"`、`parent_schema: "scott"`、`global_search: false`）、大写 `SCOTT` owner 的候选正确映射（`applyName` 不重复带 schema 前缀）、本地缓存以小写限定符可命中。

## 验证

- 定向 vitest：completion 相关 3 个 spec 文件 45/45 通过（含既有 MySQL database qualifier 与 Oracle global search 用例，无回归）
- `pnpm check` 全绿（format / lint / typecheck / test）

🤖 Generated with [Claude Code](https://claude.com/claude-code)