### PR TITLE
fix(jdbc): avoid privileged Kingbase metadata query

### DIFF
--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -817,8 +817,12 @@ public final class KingbaseAgent extends PostgresLikeAgent {
             .append("FROM sys_catalog.sys_class c ")
             .append("JOIN sys_catalog.sys_namespace n ON ").append(KINGBASE_NAMESPACE_OID).append(" = ").append(KINGBASE_REL_NAMESPACE).append(' ')
             .append("LEFT JOIN sys_catalog.sys_description d ON CAST(d.objoid AS varchar(64)) = ").append(KINGBASE_REL_OID).append(" AND d.objsubid = 0 ")
-            .append("WHERE ").append(KINGBASE_SCHEMA_NAME).append(" = ").append(sqlString(schema));
-        appendRegularTablePredicate(sql);
+            .append("WHERE ").append(KINGBASE_SCHEMA_NAME).append(" = ").append(sqlString(schema))
+            .append(" AND (EXISTS (SELECT 1 FROM sys_catalog.sys_tables t ")
+            .append("WHERE CAST(t.schemaname AS varchar(256)) = ").append(KINGBASE_SCHEMA_NAME)
+            .append(" AND CAST(t.tablename AS varchar(256)) = ").append(KINGBASE_REL_NAME).append(')')
+            .append(" OR EXISTS (SELECT 1 FROM sys_catalog.sys_foreign_table ft ")
+            .append("WHERE CAST(ft.ftrelid AS varchar(64)) = ").append(KINGBASE_REL_OID).append("))");
         MetadataSqlSupport.appendNameFilter(sql, args, KINGBASE_REL_NAME, constraints);
         return sql.toString();
     }
@@ -865,19 +869,6 @@ public final class KingbaseAgent extends PostgresLikeAgent {
             .append("WHERE ").append(KINGBASE_MATVIEW_SCHEMA).append(" = ").append(sqlString(schema));
         MetadataSqlSupport.appendNameFilter(sql, args, KINGBASE_MATVIEW_NAME, constraints);
         return sql.toString();
-    }
-
-    private static void appendRegularTablePredicate(StringBuilder sql) {
-        sql.append(" AND NOT EXISTS (SELECT 1 FROM sys_catalog.sys_rewrite r ")
-            .append("WHERE CAST(r.ev_class AS varchar(64)) = ").append(KINGBASE_REL_OID)
-            .append(" AND CAST(r.rulename AS varchar(256)) = '_RETURN')")
-            .append(" AND NOT EXISTS (SELECT 1 FROM sys_catalog.sys_index ix ")
-            .append("WHERE CAST(ix.indexrelid AS varchar(64)) = ").append(KINGBASE_REL_OID).append(')')
-            .append(" AND NOT EXISTS (SELECT 1 FROM sys_catalog.sys_attribute sa1 ")
-            .append("JOIN sys_catalog.sys_attribute sa2 ON CAST(sa2.attrelid AS varchar(64)) = CAST(sa1.attrelid AS varchar(64)) ")
-            .append("WHERE CAST(sa1.attrelid AS varchar(64)) = ").append(KINGBASE_REL_OID)
-            .append(" AND CAST(sa1.attname AS varchar(256)) = 'last_value'")
-            .append(" AND CAST(sa2.attname AS varchar(256)) = 'log_cnt')");
     }
 
     private static void appendRelationVisibilityPredicate(StringBuilder sql) {

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -168,6 +168,30 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
+    void postgresCompatModePreservesMaterializedViews() throws Exception {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        Connection connection = postgresCatalogConnection(sql, resultSet(
+            new String[]{"table_name", "table_type", "table_comment"},
+            new Object[][]{{"orders", "TABLE", null}, {"order_summary", "MATERIALIZED VIEW", "cached orders"}}
+        ));
+
+        Method afterConnect = KingbaseAgent.class.getDeclaredMethod("afterConnect", ConnectParams.class, Connection.class);
+        afterConnect.setAccessible(true);
+        afterConnect.invoke(agent, new ConnectParams(), connection);
+        TestSupport.setPrivateConnection(agent, connection);
+
+        List<TableInfo> tables = agent.listTables("public");
+
+        Assertions.assertEquals(2, tables.size());
+        Assertions.assertEquals("MATERIALIZED VIEW", tables.get(1).getTable_type());
+        Assertions.assertEquals("SELECT 1 FROM sys_catalog.sys_namespace WHERE 1 = 0", sql.get(0));
+        Assertions.assertEquals("SELECT 1 FROM pg_catalog.pg_namespace WHERE 1 = 0", sql.get(1));
+        Assertions.assertTrue(sql.get(2).contains("FROM pg_catalog.pg_class c"), sql.get(2));
+        Assertions.assertTrue(sql.get(2).contains("c.relkind IN ('r','p','v','m','f')"), sql.get(2));
+    }
+
+    @Test
     void detectsMysqlCompatModeFromServerDatabaseMode() throws Exception {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
@@ -331,12 +355,30 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertEquals("TABLE", tables.get(0).getTable_type());
         Assertions.assertEquals("app_view", tables.get(1).getName());
         Assertions.assertEquals("VIEW", tables.get(1).getTable_type());
-        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_class"), sql.get(0));
-        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_rewrite"), sql.get(0));
-        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_index"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_class c"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_tables t"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_foreign_table ft"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_views"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_matviews"), sql.get(0));
         Assertions.assertFalse(sql.get(0).contains("relkind"), sql.get(0));
+    }
+
+    @Test
+    void regularTableDiscoveryExcludesCompositeTypesWithPositiveTableCatalog() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        TestSupport.setPrivateConnection(agent, compositeAwareTableConnection(sql));
+
+        List<TableInfo> tables = agent.listTables("public", new MetadataListConstraints(null, null, null, List.of("TABLE")));
+
+        Assertions.assertEquals(1, tables.size());
+        Assertions.assertEquals("orders", tables.get(0).getName());
+        Assertions.assertFalse(tables.stream().anyMatch(table -> "address_type".equals(table.getName())));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_tables t"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_foreign_table ft"), sql.get(0));
+        Assertions.assertFalse(sql.get(0).contains("information_schema.tables"), sql.get(0));
+        Assertions.assertFalse(sql.get(0).contains("sys_rewrite"), sql.get(0));
+        Assertions.assertFalse(sql.get(0).contains("sys_index"), sql.get(0));
     }
 
     @Test
@@ -431,7 +473,8 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         agent.listTables("public", new MetadataListConstraints("ord", 30, 60, List.of("TABLE", "VIEW")));
 
-        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_class"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_class c"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_tables t"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("FROM sys_catalog.sys_views"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("UNION ALL"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("UPPER(CAST(c.relname AS varchar(256))) LIKE ? ESCAPE '\\\\'"), sql.get(0));
@@ -738,6 +781,33 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
             }
             if ("createStatement".equals(method.getName())) {
                 return plainStatement;
+            }
+            if ("isClosed".equals(method.getName())) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static Connection compositeAwareTableConnection(List<String> sql) {
+        return proxy(Connection.class, (method, args) -> {
+            if ("prepareStatement".equals(method.getName())) {
+                String preparedSql = String.valueOf(args[0]);
+                sql.add(preparedSql);
+                boolean positivelySelectsTables = preparedSql.contains("FROM sys_catalog.sys_tables t")
+                    && preparedSql.contains("FROM sys_catalog.sys_foreign_table ft");
+                Object[][] rows = positivelySelectsTables
+                    ? new Object[][]{{"orders", "TABLE", null}}
+                    : new Object[][]{{"orders", "TABLE", null}, {"address_type", "TABLE", null}};
+                return proxy(PreparedStatement.class, (statementMethod, statementArgs) -> {
+                    if ("executeQuery".equals(statementMethod.getName())) {
+                        return resultSet(new String[]{"table_name", "table_type", "table_comment"}, rows);
+                    }
+                    if ("setString".equals(statementMethod.getName()) || "close".equals(statementMethod.getName())) {
+                        return null;
+                    }
+                    return defaultValue(statementMethod.getReturnType());
+                });
             }
             if ("isClosed".equals(method.getName())) {
                 return false;

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -1900,11 +1900,15 @@ public final class DbxJdbcPlugin {
     private static JsonNode kingbaseListTables(Connection conn, String schema, boolean objectNodes) throws SQLException {
         ArrayNode result = MAPPER.createArrayNode();
         String effectiveSchema = kingbaseEffectiveSchema(conn, schema);
-        boolean compatibilityMode = kingbaseUsesInformationSchemaTables(conn);
-        String sql = compatibilityMode ? kingbaseCompatibilityTablesSql() : kingbaseCastSafeTablesSql();
+        KingbaseTableCatalogMode catalogMode = kingbaseTableCatalogMode(conn);
+        String sql = switch (catalogMode) {
+            case SYS_CATALOG -> kingbaseCastSafeTablesSql();
+            case POSTGRES_CATALOG -> kingbasePostgresTablesSql();
+            case INFORMATION_SCHEMA -> kingbaseCompatibilityTablesSql();
+        };
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, effectiveSchema);
-            if (!compatibilityMode) {
+            if (catalogMode == KingbaseTableCatalogMode.SYS_CATALOG) {
                 ps.setString(2, effectiveSchema);
                 ps.setString(3, effectiveSchema);
             }
@@ -1928,12 +1932,38 @@ public final class DbxJdbcPlugin {
         return result;
     }
 
-    private static boolean kingbaseUsesInformationSchemaTables(Connection conn) {
+    private enum KingbaseTableCatalogMode {
+        SYS_CATALOG,
+        POSTGRES_CATALOG,
+        INFORMATION_SCHEMA
+    }
+
+    private static KingbaseTableCatalogMode kingbaseTableCatalogMode(Connection conn) {
         if (!kingbaseCatalogExists(conn, "sys_catalog.sys_namespace")) {
-            return true;
+            return kingbaseCatalogExists(conn, "pg_catalog.pg_namespace")
+                ? KingbaseTableCatalogMode.POSTGRES_CATALOG
+                : KingbaseTableCatalogMode.INFORMATION_SCHEMA;
+        }
+        return kingbaseMysqlCompatibilityMode(conn)
+            ? KingbaseTableCatalogMode.INFORMATION_SCHEMA
+            : KingbaseTableCatalogMode.SYS_CATALOG;
+    }
+
+    private static boolean kingbaseMysqlCompatibilityMode(Connection conn) {
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery(
+                 "SELECT setting FROM sys_catalog.sys_settings WHERE LOWER(name) = 'database_mode'"
+             )) {
+            if (rs.next()) {
+                return "mysql".equalsIgnoreCase(rs.getString(1));
+            }
+        } catch (Exception ignored) {
+            // Older Kingbase versions do not expose database_mode.
         }
         try (Statement statement = conn.createStatement();
-             ResultSet rs = statement.executeQuery("SELECT 1 FROM sys_settings WHERE LOWER(name) = 'sql_mode'")) {
+             ResultSet rs = statement.executeQuery(
+                 "SELECT 1 FROM sys_catalog.sys_settings WHERE LOWER(name) = 'sql_mode'"
+             )) {
             return rs.next();
         } catch (Exception ignored) {
             return false;
@@ -1965,6 +1995,24 @@ public final class DbxJdbcPlugin {
             """;
     }
 
+    private static String kingbasePostgresTablesSql() {
+        return """
+            SELECT CAST(c.relname AS varchar(256)) AS table_name,
+                CASE c.relkind
+                    WHEN 'v' THEN 'VIEW'
+                    WHEN 'm' THEN 'MATERIALIZED_VIEW'
+                    WHEN 'f' THEN 'FOREIGN TABLE'
+                    ELSE 'TABLE'
+                END AS table_type,
+                CAST(obj_description(c.oid) AS varchar(4000)) AS remarks
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = ?
+                AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+            ORDER BY c.relname
+            """;
+    }
+
     private static String kingbaseCastSafeTablesSql() {
         return """
             SELECT table_name, table_type, remarks
@@ -1978,23 +2026,16 @@ public final class DbxJdbcPlugin {
                 LEFT JOIN sys_catalog.sys_description d
                     ON CAST(d.objoid AS varchar(64)) = CAST(c.oid AS varchar(64)) AND d.objsubid = 0
                 WHERE CAST(n.nspname AS varchar(256)) = ?
-                    AND NOT EXISTS (
-                        SELECT 1 FROM sys_catalog.sys_rewrite r
-                        WHERE CAST(r.ev_class AS varchar(64)) = CAST(c.oid AS varchar(64))
-                            AND CAST(r.rulename AS varchar(256)) = '_RETURN'
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1 FROM sys_catalog.sys_index ix
-                        WHERE CAST(ix.indexrelid AS varchar(64)) = CAST(c.oid AS varchar(64))
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM sys_catalog.sys_attribute sa1
-                        JOIN sys_catalog.sys_attribute sa2
-                            ON CAST(sa2.attrelid AS varchar(64)) = CAST(sa1.attrelid AS varchar(64))
-                        WHERE CAST(sa1.attrelid AS varchar(64)) = CAST(c.oid AS varchar(64))
-                            AND CAST(sa1.attname AS varchar(256)) = 'last_value'
-                            AND CAST(sa2.attname AS varchar(256)) = 'log_cnt'
+                    AND (
+                        EXISTS (
+                            SELECT 1 FROM sys_catalog.sys_tables t
+                            WHERE CAST(t.schemaname AS varchar(256)) = CAST(n.nspname AS varchar(256))
+                                AND CAST(t.tablename AS varchar(256)) = CAST(c.relname AS varchar(256))
+                        )
+                        OR EXISTS (
+                            SELECT 1 FROM sys_catalog.sys_foreign_table ft
+                            WHERE CAST(ft.ftrelid AS varchar(64)) = CAST(c.oid AS varchar(64))
+                        )
                     )
                 UNION ALL
                 SELECT CAST(v.viewname AS varchar(256)) AS table_name,

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -1319,6 +1319,17 @@ public final class DbxJdbcPlugin {
         if (usePrestoInformationSchemaTables(connection)) {
             return prestoListTables(conn, database, schema, filter, limit, offset, objectTypes);
         }
+        if (isKingbaseUrl(optionalText(connection, "connection_string"))) {
+            return filterMetadataNodes(
+                (ArrayNode) kingbaseListTables(conn, schema, false),
+                filter,
+                limit,
+                offset,
+                objectTypes,
+                "table_type",
+                true
+            );
+        }
         DatabaseMetaData meta = conn.getMetaData();
         String[] types = constrainedJdbcTableTypes(jdbcTableTypes(meta), objectTypes);
         if (types.length == 0) {
@@ -1358,16 +1369,22 @@ public final class DbxJdbcPlugin {
         if (usePrestoInformationSchemaTables(connection)) {
             return prestoListObjects(conn, database, schema, filter, limit, offset, objectTypes);
         }
+        boolean kingbase = isKingbaseUrl(optionalText(connection, "connection_string"));
+        if (kingbase) {
+            result.addAll((ArrayNode) kingbaseListTables(conn, schema, true));
+        }
         DatabaseMetaData meta = conn.getMetaData();
         JdbcDriverQuirks quirks = driverQuirks(connection);
         String catalog = metadataCatalog(database, quirks);
         String schemaPattern = resolveSchemaPattern(meta, database, schema, quirks);
 
-        String[] tableTypes = constrainedJdbcTableTypes(jdbcTableTypes(meta), objectTypes);
-        if (tableTypes.length > 0) {
-            appendTableObjects(result, meta, catalog, schemaPattern, schema, tableTypes);
-            if (result.isEmpty() && catalog != null) {
-                appendTableObjects(result, meta, null, schemaPattern, schema, tableTypes);
+        if (!kingbase) {
+            String[] tableTypes = constrainedJdbcTableTypes(jdbcTableTypes(meta), objectTypes);
+            if (tableTypes.length > 0) {
+                appendTableObjects(result, meta, catalog, schemaPattern, schema, tableTypes);
+                if (result.isEmpty() && catalog != null) {
+                    appendTableObjects(result, meta, null, schemaPattern, schema, tableTypes);
+                }
             }
         }
 
@@ -1878,6 +1895,42 @@ public final class DbxJdbcPlugin {
             case "VIEW" -> "VIEW";
             default -> tableType;
         };
+    }
+
+    private static JsonNode kingbaseListTables(Connection conn, String schema, boolean objectNodes) throws SQLException {
+        ArrayNode result = MAPPER.createArrayNode();
+        String effectiveSchema = emptyToNull(schema) == null ? "PUBLIC" : schema;
+        String sql = "SELECT c.relname AS table_name, " +
+            "CASE c.relkind " +
+            "WHEN 'r' THEN 'TABLE' " +
+            "WHEN 'p' THEN 'TABLE' " +
+            "WHEN 'v' THEN 'VIEW' " +
+            "WHEN 'm' THEN 'MATERIALIZED VIEW' " +
+            "WHEN 'f' THEN 'FOREIGN TABLE' " +
+            "END AS table_type, d.description AS remarks " +
+            "FROM sys_catalog.sys_class c " +
+            "JOIN sys_catalog.sys_namespace n ON n.oid = c.relnamespace " +
+            "LEFT JOIN sys_catalog.sys_description d ON d.objoid = c.oid AND d.objsubid = 0 " +
+            "WHERE n.nspname = ? AND c.relkind IN ('r', 'p', 'v', 'm', 'f') " +
+            "ORDER BY c.relname";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, effectiveSchema);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ObjectNode item = MAPPER.createObjectNode();
+                    item.put("name", rs.getString("table_name"));
+                    if (objectNodes) {
+                        item.put("object_type", rs.getString("table_type"));
+                        item.put("schema", effectiveSchema);
+                    } else {
+                        item.put("table_type", rs.getString("table_type"));
+                    }
+                    putNullable(item, "comment", rs.getString("remarks"));
+                    result.add(item);
+                }
+            }
+        }
+        return result;
     }
 
     private static JsonNode kingbaseGetColumns(Connection conn, String schema, String table) throws SQLException {

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -1899,26 +1899,30 @@ public final class DbxJdbcPlugin {
 
     private static JsonNode kingbaseListTables(Connection conn, String schema, boolean objectNodes) throws SQLException {
         ArrayNode result = MAPPER.createArrayNode();
-        String effectiveSchema = emptyToNull(schema) == null ? "PUBLIC" : schema;
-        String sql = "SELECT c.relname AS table_name, " +
-            "CASE c.relkind " +
-            "WHEN 'r' THEN 'TABLE' " +
-            "WHEN 'p' THEN 'TABLE' " +
-            "WHEN 'v' THEN 'VIEW' " +
-            "WHEN 'm' THEN 'MATERIALIZED VIEW' " +
-            "WHEN 'f' THEN 'FOREIGN TABLE' " +
-            "END AS table_type, d.description AS remarks " +
-            "FROM sys_catalog.sys_class c " +
-            "JOIN sys_catalog.sys_namespace n ON n.oid = c.relnamespace " +
-            "LEFT JOIN sys_catalog.sys_description d ON d.objoid = c.oid AND d.objsubid = 0 " +
-            "WHERE n.nspname = ? AND c.relkind IN ('r', 'p', 'v', 'm', 'f') " +
-            "ORDER BY c.relname";
+        String effectiveSchema = kingbaseEffectiveSchema(conn, schema);
+        String sql = """
+            SELECT c.relname AS table_name,
+                CASE c.relkind
+                    WHEN 'r' THEN 'TABLE'
+                    WHEN 'p' THEN 'TABLE'
+                    WHEN 'v' THEN 'VIEW'
+                    WHEN 'm' THEN 'MATERIALIZED VIEW'
+                    WHEN 'f' THEN 'FOREIGN TABLE'
+                END AS table_type,
+                d.description AS remarks
+            FROM sys_catalog.sys_class c
+            JOIN sys_catalog.sys_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN sys_catalog.sys_description d ON d.objoid = c.oid AND d.objsubid = 0
+            WHERE n.nspname = ? AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+            ORDER BY c.relname
+            """;
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, effectiveSchema);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
+                    String tableName = rs.getString("table_name");
                     ObjectNode item = MAPPER.createObjectNode();
-                    item.put("name", rs.getString("table_name"));
+                    item.put("name", tableName);
                     if (objectNodes) {
                         item.put("object_type", rs.getString("table_type"));
                         item.put("schema", effectiveSchema);
@@ -1933,9 +1937,21 @@ public final class DbxJdbcPlugin {
         return result;
     }
 
+    private static String kingbaseEffectiveSchema(Connection conn, String schema) {
+        String effectiveSchema = emptyToNull(schema);
+        if (effectiveSchema != null) {
+            return effectiveSchema;
+        }
+        try {
+            effectiveSchema = emptyToNull(conn.getSchema());
+        } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
+        }
+        return effectiveSchema == null ? "PUBLIC" : effectiveSchema;
+    }
+
     private static JsonNode kingbaseGetColumns(Connection conn, String schema, String table) throws SQLException {
         ArrayNode result = MAPPER.createArrayNode();
-        String effectiveSchema = emptyToNull(schema) == null ? "PUBLIC" : schema;
+        String effectiveSchema = kingbaseEffectiveSchema(conn, schema);
         Set<String> primaryKeys = kingbasePrimaryKeys(conn, effectiveSchema, table);
         String sql = "SELECT a.attname AS column_name, " +
             "format_type(a.atttypid, a.atttypmod) AS data_type, " +

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -1900,34 +1900,25 @@ public final class DbxJdbcPlugin {
     private static JsonNode kingbaseListTables(Connection conn, String schema, boolean objectNodes) throws SQLException {
         ArrayNode result = MAPPER.createArrayNode();
         String effectiveSchema = kingbaseEffectiveSchema(conn, schema);
-        String sql = """
-            SELECT c.relname AS table_name,
-                CASE c.relkind
-                    WHEN 'r' THEN 'TABLE'
-                    WHEN 'p' THEN 'TABLE'
-                    WHEN 'v' THEN 'VIEW'
-                    WHEN 'm' THEN 'MATERIALIZED VIEW'
-                    WHEN 'f' THEN 'FOREIGN TABLE'
-                END AS table_type,
-                d.description AS remarks
-            FROM sys_catalog.sys_class c
-            JOIN sys_catalog.sys_namespace n ON n.oid = c.relnamespace
-            LEFT JOIN sys_catalog.sys_description d ON d.objoid = c.oid AND d.objsubid = 0
-            WHERE n.nspname = ? AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
-            ORDER BY c.relname
-            """;
+        boolean compatibilityMode = kingbaseUsesInformationSchemaTables(conn);
+        String sql = compatibilityMode ? kingbaseCompatibilityTablesSql() : kingbaseCastSafeTablesSql();
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, effectiveSchema);
+            if (!compatibilityMode) {
+                ps.setString(2, effectiveSchema);
+                ps.setString(3, effectiveSchema);
+            }
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
+                    String tableType = normalizeInformationSchemaTableType(rs.getString("table_type"));
                     ObjectNode item = MAPPER.createObjectNode();
                     item.put("name", tableName);
                     if (objectNodes) {
-                        item.put("object_type", rs.getString("table_type"));
+                        item.put("object_type", tableType);
                         item.put("schema", effectiveSchema);
                     } else {
-                        item.put("table_type", rs.getString("table_type"));
+                        item.put("table_type", tableType);
                     }
                     putNullable(item, "comment", rs.getString("remarks"));
                     result.add(item);
@@ -1935,6 +1926,105 @@ public final class DbxJdbcPlugin {
             }
         }
         return result;
+    }
+
+    private static boolean kingbaseUsesInformationSchemaTables(Connection conn) {
+        if (!kingbaseCatalogExists(conn, "sys_catalog.sys_namespace")) {
+            return true;
+        }
+        try (Statement statement = conn.createStatement();
+             ResultSet rs = statement.executeQuery("SELECT 1 FROM sys_settings WHERE LOWER(name) = 'sql_mode'")) {
+            return rs.next();
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private static boolean kingbaseCatalogExists(Connection conn, String catalog) {
+        try (Statement statement = conn.createStatement();
+             ResultSet ignored = statement.executeQuery("SELECT 1 FROM " + catalog + " WHERE 1 = 0")) {
+            return true;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private static String kingbaseCompatibilityTablesSql() {
+        return """
+            SELECT CAST(table_name AS varchar(256)) AS table_name,
+                CASE UPPER(CAST(table_type AS varchar(64)))
+                    WHEN 'VIEW' THEN 'VIEW'
+                    WHEN 'MATERIALIZED VIEW' THEN 'MATERIALIZED_VIEW'
+                    ELSE 'TABLE'
+                END AS table_type,
+                NULL AS remarks
+            FROM information_schema.tables
+            WHERE CAST(table_schema AS varchar(256)) = ?
+                AND UPPER(CAST(table_type AS varchar(64))) IN ('BASE TABLE', 'TABLE', 'VIEW', 'MATERIALIZED VIEW')
+            ORDER BY CAST(table_name AS varchar(256))
+            """;
+    }
+
+    private static String kingbaseCastSafeTablesSql() {
+        return """
+            SELECT table_name, table_type, remarks
+            FROM (
+                SELECT CAST(c.relname AS varchar(256)) AS table_name,
+                    'TABLE' AS table_type,
+                    CAST(d.description AS varchar(4000)) AS remarks
+                FROM sys_catalog.sys_class c
+                JOIN sys_catalog.sys_namespace n
+                    ON CAST(n.oid AS varchar(64)) = CAST(c.relnamespace AS varchar(64))
+                LEFT JOIN sys_catalog.sys_description d
+                    ON CAST(d.objoid AS varchar(64)) = CAST(c.oid AS varchar(64)) AND d.objsubid = 0
+                WHERE CAST(n.nspname AS varchar(256)) = ?
+                    AND NOT EXISTS (
+                        SELECT 1 FROM sys_catalog.sys_rewrite r
+                        WHERE CAST(r.ev_class AS varchar(64)) = CAST(c.oid AS varchar(64))
+                            AND CAST(r.rulename AS varchar(256)) = '_RETURN'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM sys_catalog.sys_index ix
+                        WHERE CAST(ix.indexrelid AS varchar(64)) = CAST(c.oid AS varchar(64))
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM sys_catalog.sys_attribute sa1
+                        JOIN sys_catalog.sys_attribute sa2
+                            ON CAST(sa2.attrelid AS varchar(64)) = CAST(sa1.attrelid AS varchar(64))
+                        WHERE CAST(sa1.attrelid AS varchar(64)) = CAST(c.oid AS varchar(64))
+                            AND CAST(sa1.attname AS varchar(256)) = 'last_value'
+                            AND CAST(sa2.attname AS varchar(256)) = 'log_cnt'
+                    )
+                UNION ALL
+                SELECT CAST(v.viewname AS varchar(256)) AS table_name,
+                    'VIEW' AS table_type,
+                    CAST(d.description AS varchar(4000)) AS remarks
+                FROM sys_catalog.sys_views v
+                JOIN sys_catalog.sys_namespace n
+                    ON CAST(n.nspname AS varchar(256)) = CAST(v.schemaname AS varchar(256))
+                JOIN sys_catalog.sys_class c
+                    ON CAST(c.relnamespace AS varchar(64)) = CAST(n.oid AS varchar(64))
+                    AND CAST(c.relname AS varchar(256)) = CAST(v.viewname AS varchar(256))
+                LEFT JOIN sys_catalog.sys_description d
+                    ON CAST(d.objoid AS varchar(64)) = CAST(c.oid AS varchar(64)) AND d.objsubid = 0
+                WHERE CAST(v.schemaname AS varchar(256)) = ?
+                UNION ALL
+                SELECT CAST(mv.matviewname AS varchar(256)) AS table_name,
+                    'MATERIALIZED_VIEW' AS table_type,
+                    CAST(d.description AS varchar(4000)) AS remarks
+                FROM sys_catalog.sys_matviews mv
+                JOIN sys_catalog.sys_namespace n
+                    ON CAST(n.nspname AS varchar(256)) = CAST(mv.schemaname AS varchar(256))
+                JOIN sys_catalog.sys_class c
+                    ON CAST(c.relnamespace AS varchar(64)) = CAST(n.oid AS varchar(64))
+                    AND CAST(c.relname AS varchar(256)) = CAST(mv.matviewname AS varchar(256))
+                LEFT JOIN sys_catalog.sys_description d
+                    ON CAST(d.objoid AS varchar(64)) = CAST(c.oid AS varchar(64)) AND d.objsubid = 0
+                WHERE CAST(mv.schemaname AS varchar(256)) = ?
+            ) metadata_tables
+            ORDER BY table_name
+            """;
     }
 
     private static String kingbaseEffectiveSchema(Connection conn, String schema) {

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -1081,7 +1081,9 @@ final class DbxJdbcPluginTest {
         assertEquals("Order records", result.path(0).path("comment").asText());
         assertEquals("VIEW", result.path(1).path("table_type").asText());
         String discoverySql = sql.get(2);
-        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_class"));
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_class c"));
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_tables t"));
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_foreign_table ft"));
         assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_views"));
         assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_matviews"));
         assertEquals(true, discoverySql.contains("CAST(c.relname AS varchar(256))"));
@@ -1104,10 +1106,51 @@ final class DbxJdbcPluginTest {
 
         assertEquals("TABLE", result.path(0).path("table_type").asText());
         assertEquals("VIEW", result.path(1).path("table_type").asText());
+        assertEquals(true, sql.get(1).contains("LOWER(name) = 'database_mode'"));
         String discoverySql = sql.get(2);
         assertEquals(true, discoverySql.contains("FROM information_schema.tables"));
         assertEquals(false, discoverySql.contains("relkind"));
         assertEquals(false, discoverySql.contains("sys_freespace"));
+    }
+
+    @Test
+    void kingbasePostgresCatalogModePreservesMaterializedViews() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("kingbaseListTables", Connection.class, String.class, boolean.class);
+        method.setAccessible(true);
+        List<String> sql = new ArrayList<>();
+        ResultSet tables = rowsResultSet(
+            new String[] { "table_name", "table_type", "remarks" },
+            new Object[][] { { "orders", "TABLE", null }, { "order_summary", "MATERIALIZED_VIEW", "Cached orders" } }
+        );
+
+        JsonNode result = (JsonNode) method.invoke(null, kingbasePostgresTableConnection(sql, tables), "APP", false);
+
+        assertEquals("TABLE", result.path(0).path("table_type").asText());
+        assertEquals("MATERIALIZED_VIEW", result.path(1).path("table_type").asText());
+        assertEquals("SELECT 1 FROM sys_catalog.sys_namespace WHERE 1 = 0", sql.get(0));
+        assertEquals("SELECT 1 FROM pg_catalog.pg_namespace WHERE 1 = 0", sql.get(1));
+        String discoverySql = sql.get(2);
+        assertEquals(true, discoverySql.contains("FROM pg_catalog.pg_class c"));
+        assertEquals(true, discoverySql.contains("JOIN pg_catalog.pg_namespace n"));
+        assertEquals(true, discoverySql.contains("c.relkind IN ('r', 'p', 'v', 'm', 'f')"));
+    }
+
+    @Test
+    void kingbaseRegularTableDiscoveryExcludesCompositeTypesWithPositiveTableCatalog() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("kingbaseListTables", Connection.class, String.class, boolean.class);
+        method.setAccessible(true);
+        List<String> sql = new ArrayList<>();
+
+        JsonNode result = (JsonNode) method.invoke(null, kingbaseCompositeCatalogConnection(sql), "APP", false);
+
+        assertEquals(1, result.size());
+        assertEquals("orders", result.path(0).path("name").asText());
+        String discoverySql = sql.get(2);
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_tables t"));
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_foreign_table ft"));
+        assertEquals(false, discoverySql.contains("information_schema.tables"));
+        assertEquals(false, discoverySql.contains("sys_rewrite"));
+        assertEquals(false, discoverySql.contains("sys_index"));
     }
 
     @Test
@@ -1531,6 +1574,46 @@ final class DbxJdbcPluginTest {
         );
     }
 
+    private static Connection kingbaseCompositeCatalogConnection(List<String> sql) {
+        return (Connection) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Connection.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "createStatement" -> kingbaseCatalogProbeStatement(sql, false);
+                case "prepareStatement" -> {
+                    String preparedSql = String.valueOf(args[0]);
+                    sql.add(preparedSql);
+                    boolean positivelySelectsTables = preparedSql.contains("FROM sys_catalog.sys_tables t")
+                        && preparedSql.contains("FROM sys_catalog.sys_foreign_table ft");
+                    Object[][] rows = positivelySelectsTables
+                        ? new Object[][] { { "orders", "TABLE", null } }
+                        : new Object[][] { { "orders", "TABLE", null }, { "address_type", "TABLE", null } };
+                    yield preparedStatement(rowsResultSet(new String[] { "table_name", "table_type", "remarks" }, rows));
+                }
+                case "isClosed" -> false;
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static Connection kingbasePostgresTableConnection(List<String> sql, ResultSet rs) {
+        return (Connection) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Connection.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "createStatement" -> kingbasePostgresCatalogProbeStatement(sql);
+                case "prepareStatement" -> {
+                    sql.add(String.valueOf(args[0]));
+                    yield preparedStatement(rs);
+                }
+                case "isClosed" -> false;
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
     private static Statement kingbaseCatalogProbeStatement(List<String> sql, boolean compatibilityMode) {
         return (Statement) Proxy.newProxyInstance(
             DbxJdbcPluginTest.class.getClassLoader(),
@@ -1542,11 +1625,36 @@ final class DbxJdbcPluginTest {
                     if (query.contains("sys_catalog.sys_namespace")) {
                         yield rowsResultSet(new String[] { "exists" }, new Object[0][]);
                     }
-                    if (query.contains("sys_settings")) {
+                    if (query.contains("LOWER(name) = 'database_mode'")) {
                         yield rowsResultSet(
-                            new String[] { "exists" },
-                            compatibilityMode ? new Object[][] { { 1 } } : new Object[0][]
+                            new String[] { "setting" },
+                            new Object[][] { { compatibilityMode ? "mysql" : "oracle" } }
                         );
+                    }
+                    if (query.contains("LOWER(name) = 'sql_mode'")) {
+                        yield rowsResultSet(new String[] { "exists" }, new Object[0][]);
+                    }
+                    throw new SQLException("Unexpected Kingbase catalog probe: " + query);
+                }
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static Statement kingbasePostgresCatalogProbeStatement(List<String> sql) {
+        return (Statement) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Statement.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "executeQuery" -> {
+                    String query = String.valueOf(args[0]);
+                    sql.add(query);
+                    if (query.contains("sys_catalog.sys_namespace")) {
+                        throw new SQLException("relation does not exist: sys_catalog.sys_namespace");
+                    }
+                    if (query.contains("pg_catalog.pg_namespace")) {
+                        yield rowsResultSet(new String[] { "exists" }, new Object[0][]);
                     }
                     throw new SQLException("Unexpected Kingbase catalog probe: " + query);
                 }

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -1062,7 +1062,7 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
-    void kingbaseListTablesAvoidsPrivilegedSpaceFunctions() throws Exception {
+    void kingbaseListTablesReusesCastSafeAgentDiscovery() throws Exception {
         Method method = DbxJdbcPlugin.class.getDeclaredMethod("kingbaseListTables", Connection.class, String.class, boolean.class);
         method.setAccessible(true);
         List<String> sql = new ArrayList<>();
@@ -1074,15 +1074,40 @@ final class DbxJdbcPluginTest {
             }
         );
 
-        JsonNode result = (JsonNode) method.invoke(null, preparedQueryConnection(sql, tables), "APP", false);
+        JsonNode result = (JsonNode) method.invoke(null, kingbaseTableConnection(sql, tables, false), "APP", false);
 
         assertEquals("orders", result.path(0).path("name").asText());
         assertEquals("TABLE", result.path(0).path("table_type").asText());
         assertEquals("Order records", result.path(0).path("comment").asText());
         assertEquals("VIEW", result.path(1).path("table_type").asText());
-        assertEquals(true, sql.get(0).contains("FROM sys_catalog.sys_class"));
-        assertEquals(false, sql.get(0).contains("sys_freespace"));
-        assertEquals(false, sql.get(0).contains("pg_relation_size_ex"));
+        String discoverySql = sql.get(2);
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_class"));
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_views"));
+        assertEquals(true, discoverySql.contains("FROM sys_catalog.sys_matviews"));
+        assertEquals(true, discoverySql.contains("CAST(c.relname AS varchar(256))"));
+        assertEquals(false, discoverySql.contains("relkind"));
+        assertEquals(false, discoverySql.contains("sys_freespace"));
+        assertEquals(false, discoverySql.contains("pg_relation_size_ex"));
+    }
+
+    @Test
+    void kingbaseCompatibilityListTablesAvoidsRelkind() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("kingbaseListTables", Connection.class, String.class, boolean.class);
+        method.setAccessible(true);
+        List<String> sql = new ArrayList<>();
+        ResultSet tables = rowsResultSet(
+            new String[] { "table_name", "table_type", "remarks" },
+            new Object[][] { { "orders", "BASE TABLE", null }, { "order_summary", "VIEW", null } }
+        );
+
+        JsonNode result = (JsonNode) method.invoke(null, kingbaseTableConnection(sql, tables, true), "APP", false);
+
+        assertEquals("TABLE", result.path(0).path("table_type").asText());
+        assertEquals("VIEW", result.path(1).path("table_type").asText());
+        String discoverySql = sql.get(2);
+        assertEquals(true, discoverySql.contains("FROM information_schema.tables"));
+        assertEquals(false, discoverySql.contains("relkind"));
+        assertEquals(false, discoverySql.contains("sys_freespace"));
     }
 
     @Test
@@ -1489,16 +1514,42 @@ final class DbxJdbcPluginTest {
         );
     }
 
-    private static Connection preparedQueryConnection(List<String> sql, ResultSet rs) {
+    private static Connection kingbaseTableConnection(List<String> sql, ResultSet rs, boolean compatibilityMode) {
         return (Connection) Proxy.newProxyInstance(
             DbxJdbcPluginTest.class.getClassLoader(),
             new Class<?>[] { Connection.class },
             (proxy, method, args) -> switch (method.getName()) {
+                case "createStatement" -> kingbaseCatalogProbeStatement(sql, compatibilityMode);
                 case "prepareStatement" -> {
                     sql.add(String.valueOf(args[0]));
                     yield preparedStatement(rs);
                 }
                 case "isClosed" -> false;
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static Statement kingbaseCatalogProbeStatement(List<String> sql, boolean compatibilityMode) {
+        return (Statement) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Statement.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "executeQuery" -> {
+                    String query = String.valueOf(args[0]);
+                    sql.add(query);
+                    if (query.contains("sys_catalog.sys_namespace")) {
+                        yield rowsResultSet(new String[] { "exists" }, new Object[0][]);
+                    }
+                    if (query.contains("sys_settings")) {
+                        yield rowsResultSet(
+                            new String[] { "exists" },
+                            compatibilityMode ? new Object[][] { { 1 } } : new Object[0][]
+                        );
+                    }
+                    throw new SQLException("Unexpected Kingbase catalog probe: " + query);
+                }
                 case "close" -> null;
                 default -> defaultValue(method.getReturnType());
             }

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -1062,6 +1062,30 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void kingbaseListTablesAvoidsPrivilegedSpaceFunctions() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("kingbaseListTables", Connection.class, String.class, boolean.class);
+        method.setAccessible(true);
+        List<String> sql = new ArrayList<>();
+        ResultSet tables = rowsResultSet(
+            new String[] { "table_name", "table_type", "remarks" },
+            new Object[][] {
+                { "orders", "TABLE", "Order records" },
+                { "order_summary", "VIEW", null }
+            }
+        );
+
+        JsonNode result = (JsonNode) method.invoke(null, preparedQueryConnection(sql, tables), "APP", false);
+
+        assertEquals("orders", result.path(0).path("name").asText());
+        assertEquals("TABLE", result.path(0).path("table_type").asText());
+        assertEquals("Order records", result.path(0).path("comment").asText());
+        assertEquals("VIEW", result.path(1).path("table_type").asText());
+        assertEquals(true, sql.get(0).contains("FROM sys_catalog.sys_class"));
+        assertEquals(false, sql.get(0).contains("sys_freespace"));
+        assertEquals(false, sql.get(0).contains("pg_relation_size_ex"));
+    }
+
+    @Test
     void columnIsNullablePrefersIsNullableStringWhenNullableCodeIsWrong() throws Exception {
         Method method = DbxJdbcPlugin.class.getDeclaredMethod("columnIsNullable", ResultSet.class);
         method.setAccessible(true);
@@ -1440,6 +1464,22 @@ final class DbxJdbcPluginTest {
             (proxy, method, args) -> switch (method.getName()) {
                 case "createStatement" -> {
                     yield statement(sql, index[0]++ == 0 ? primaryKeys : columns);
+                }
+                case "isClosed" -> false;
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static Connection preparedQueryConnection(List<String> sql, ResultSet rs) {
+        return (Connection) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Connection.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "prepareStatement" -> {
+                    sql.add(String.valueOf(args[0]));
+                    yield preparedStatement(rs);
                 }
                 case "isClosed" -> false;
                 case "close" -> null;

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -1086,6 +1086,23 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void kingbaseEffectiveSchemaPreservesConnectionSchemaCase() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("kingbaseEffectiveSchema", Connection.class, String.class);
+        method.setAccessible(true);
+        Connection connection = (Connection) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Connection.class },
+            (proxy, invokedMethod, args) -> switch (invokedMethod.getName()) {
+                case "getSchema" -> "CaseSensitiveSchema";
+                default -> defaultValue(invokedMethod.getReturnType());
+            }
+        );
+
+        assertEquals("CaseSensitiveSchema", method.invoke(null, connection, null));
+        assertEquals("ExplicitSchema", method.invoke(null, connection, "ExplicitSchema"));
+    }
+
+    @Test
     void columnIsNullablePrefersIsNullableStringWhenNullableCodeIsWrong() throws Exception {
         Method method = DbxJdbcPlugin.class.getDeclaredMethod("columnIsNullable", ResultSet.class);
         method.setAccessible(true);


### PR DESCRIPTION
## Summary

- load Kingbase tables and views directly from its system catalogs
- avoid `DatabaseMetaData.getTables()`, which invokes privileged space-statistics functions in the Kingbase JDBC driver
- preserve the existing JDBC metadata path for other database vendors
- add regression coverage for low-privilege Kingbase metadata loading

## Root cause

The Kingbase JDBC driver's table metadata query calls `information_schema.pg_relation_size_ex()`, which in turn invokes `sys_freespace()`. Accounts without permission to execute that function can connect successfully but cannot open the database in DBX.

The fix follows the same approach used by database clients with dedicated Kingbase metadata support: query object names, types, and comments from the system catalogs without requesting relation-size statistics.

## Impact

Kingbase users no longer need elevated `sys_freespace` permissions to browse database objects. Other JDBC connections are unaffected.

## Validation

- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home mvn -q test` in `plugins/jdbc` (57 tests passed)
- `git diff --check`

Closes #3590
