### PR TITLE
fix(grid): 单条数据修改不再强制开启事务

### DIFF
--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -1269,7 +1269,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       rollbackStatements: rollbackStmts,
     });
 
-    if (useTransaction.value && hasBackendSaveTarget.value) {
+    if (useTransaction.value && stmts.length > 1 && hasBackendSaveTarget.value) {
       try {
         apiResult = await api.executeInTransaction(connectionId.value!, database.value ?? "", stmts, preparedSave?.executionSchema);
       } catch (e: any) {

--- a/packages/app-tests/dataGridEditor.test.ts
+++ b/packages/app-tests/dataGridEditor.test.ts
@@ -1062,7 +1062,7 @@ test("saving manually typed JSON arrays from a Postgres array column uses array 
   assert.deepEqual(executedSql, [`UPDATE "articles" SET "tags" = '{"draft","发布"}' WHERE "id" = 1;`]);
 });
 
-test("failed table data save records a failed history entry", async () => {
+test("single-statement table data save uses auto-commit and records a failed history entry", async () => {
   setActivePinia(createPinia());
   installBrowserTestGlobals();
 
@@ -1082,7 +1082,7 @@ test("failed table data save records a failed history entry", async () => {
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     }
-    if (url === "/api/query/execute-in-transaction") {
+    if (url === "/api/query/execute-batch") {
       return new Response(permissionError, { status: 500 });
     }
     if (url === "/api/history/save") {
@@ -1148,6 +1148,89 @@ test("failed table data save records a failed history entry", async () => {
   assert.equal(historyEntry.rollback_sql, undefined);
   assert.equal(historyEntry.affected_rows, undefined);
   assert.equal(historyEntry.sql, `UPDATE "pp_questions" SET "title" = 'New title' WHERE "id" = 1;`);
+});
+
+test("multi-statement table data save remains transactional", async () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+
+  const executionEndpoints: string[] = [];
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/prepare-data-grid-save") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      const options = body.options as DataGridSaveStatementOptions;
+      return new Response(
+        JSON.stringify({
+          statements: mockPreparedSaveStatements(options),
+          rollbackStatements: [],
+          executionSchema: options.tableMeta.schema,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/execute-in-transaction" || url === "/api/query/execute-batch") {
+      executionEndpoints.push(url);
+      return new Response(JSON.stringify({ affected_rows: 2 }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/history/save") {
+      return new Response("null", { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response(`unexpected request: ${url}`, { status: 500 });
+  }) as typeof fetch;
+
+  const result = computed(() => ({
+    columns: ["id", "title"],
+    rows: [
+      [1, "Old title 1"],
+      [2, "Old title 2"],
+    ] as CellValue[][],
+  }));
+  const rowStatusFilter = ref<"all" | "changed" | "edited" | "new" | "deleted">("all");
+  const editor = useDataGridEditor({
+    result,
+    editable: computed(() => true),
+    databaseType: computed(() => "mysql"),
+    connectionId: computed(() => "conn-1"),
+    database: computed(() => "app_db"),
+    tableMeta: computed(() => ({
+      tableName: "pp_questions",
+      columns: [column("id", true), column("title")],
+      primaryKeys: ["id"],
+    })),
+    onExecuteSql: computed(() => undefined),
+    customSaveHandler: computed(() => undefined),
+    sql: computed(() => "SELECT id, title FROM pp_questions"),
+    searchText: ref(""),
+    whereFilterInput: ref(""),
+    currentWhereInput: computed(() => undefined),
+    orderByInput: ref(""),
+    rowStatusFilter,
+    pageSize: ref(50),
+    currentPage: ref(1),
+    getRowItem: (rowId) => {
+      const row = result.value.rows[rowId];
+      if (!row) return undefined;
+      return {
+        id: rowId,
+        sourceIndex: rowId,
+        data: row,
+        isNew: false,
+        isDeleted: false,
+        isDirtyCol: [false, false],
+        status: "clean",
+      };
+    },
+    emit: () => {},
+  });
+
+  editor.applyCellValue(0, 1, "New title 1");
+  editor.applyCellValue(1, 1, "New title 2");
+  await editor.saveChanges();
+
+  assert.deepEqual(executionEndpoints, ["/api/query/execute-in-transaction"]);
+  assert.equal(editor.saveError.value, "");
+  assert.equal(editor.dirtyRows.value.size, 0);
 });
 
 test("quick entry off keeps blur edits pending without saving", async () => {


### PR DESCRIPTION
## 问题

MySQL 连接指向不支持 `START TRANSACTION` 的 Mycat 端点时，即使数据网格只生成一条 `UPDATE`，保存也会先调用事务接口，导致在实际 DML 执行前返回 `ERROR HY000 (1047): Unsupported statement`。

## 修复

- 数据网格只生成一条 DML 时通过单语句批处理路径直接执行
- 生成两条及以上语句时仍使用事务接口
- 不在事务启动失败后自动重放多条 DML，避免部分提交
- 增加单语句和多语句保存路由的回归测试

单条 `UPDATE/INSERT/DELETE` 本身具有语句级原子性，因此无需额外发送 `START TRANSACTION`。

## 验证

### 自动化验证

- `pnpm exec vitest run packages/app-tests/dataGridEditor.test.ts`：40/40 通过
- `pnpm test`：407 个测试文件、3314 个测试通过
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/composables/useDataGridEditor.ts packages/app-tests/dataGridEditor.test.ts`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/composables/useDataGridEditor.ts packages/app-tests/dataGridEditor.test.ts`

### 真实 Mycat 验证

在 macOS arm64 Docker 环境启动 Mycat 官方 `1.4-release-20151019230038`，后端使用 MariaDB：

- DBX 原生 MySQL 驱动连接成功
- `SELECT VERSION()` 返回 `5.5.8-mycat-1.4-release-20151019230038`
- DBX `execute-batch` 执行单条更新成功，`affected_rows=1`
- 查询回读确认数据已更新

官方 Mycat 1.4 本身支持事务。为复现 issue 中特定部署拒绝事务的行为，在真实 Mycat 前增加临时 MySQL 协议代理，仅对 `START TRANSACTION` 返回 `1047 HY000 Unsupported statement`，其余请求原样转发：

- 旧事务路径：HTTP 500，返回与 issue 一致的 `Failed to begin transaction ... ERROR HY000 (1047): Unsupported statement`
- 修复后的单语句路径：HTTP 200，`affected_rows=1`，回读更新值成功
- 两条更新仍走事务路径；事务启动失败后两条数据均保持原值，未发生部分提交

验证结束后已删除临时 Mycat、MariaDB、协议代理、Docker 网络和测试镜像。

Fixes #3562
