### PR TITLE
fix：完善复制 INSERT 的字段与方言兼容性

### DIFF
--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDataGridExport, type UseDataGridExportOptions } from "@/composables/useDataGridExport";
 import { buildDataGridCopyInsertStatement, buildDataGridCopyUpdateStatements } from "@/lib/dataGrid/dataGridSql";
 import { copyToClipboard } from "@/lib/common/clipboard";
+import type { DatabaseType } from "@/types/database";
 import type { DataGridTableMeta } from "@/lib/dataGrid/dataGridSql";
 
 const toast = vi.fn();
@@ -83,14 +84,14 @@ function createMongoExportState(options: { columns: string[]; item: ReturnType<t
   return useDataGridExport(state);
 }
 
-function createExportState(tableMeta: DataGridTableMeta, columns = tableMeta.columns?.map((column) => column.name) ?? ["id", "name"]) {
+function createExportState(tableMeta: DataGridTableMeta, columns = tableMeta.columns?.map((column) => column.name) ?? ["id", "name"], databaseType: DatabaseType = "mysql") {
   const item = row(columns.map((column, index) => (column === "id" ? 1 : `value-${index}`)));
   const options: UseDataGridExportOptions = {
     columns: computed(() => columns),
     displayItems: computed(() => [item]),
     sql: computed(() => undefined),
     tableMeta: computed(() => tableMeta),
-    databaseType: computed(() => "mysql"),
+    databaseType: computed(() => databaseType),
     connectionId: computed(() => "connection-1"),
     database: computed(() => "dbx"),
     context: computed(() => "table-data"),
@@ -124,10 +125,10 @@ describe("useDataGridExport prepared row statements", () => {
     vi.clearAllMocks();
   });
 
-  it("reuses an in-flight INSERT prefetch when the copy action runs", async () => {
+  it.each<DatabaseType>(["mysql", "postgres", "sqlserver", "oracle", "clickhouse", "tdengine"])("reuses an in-flight %s INSERT prefetch when the first copy action runs", async (databaseType) => {
     const pending = deferred<string | undefined>();
     vi.mocked(buildDataGridCopyInsertStatement).mockReturnValueOnce(pending.promise);
-    const state = createExportState(editableTable);
+    const state = createExportState(editableTable, undefined, databaseType);
 
     const prefetch = state.prefetchRowAsInsertStatement(false);
     const copy = state.copyRowAsInsert();
@@ -152,17 +153,31 @@ describe("useDataGridExport prepared row statements", () => {
     expect(copyToClipboard).toHaveBeenCalledWith("UPDATE users SET name = 'Alice' WHERE id = 1;");
   });
 
-  it.each(["GENERATED ALWAYS AS (1)", "IDENTITY(1, 1)"])("disables copy-as-insert when every result column is non-insertable (%s)", (extra) => {
+  it("disables copy-as-insert when every result column is a non-identity generated column", () => {
     const state = createExportState(
       {
         tableName: "generated_values",
         primaryKeys: [],
-        columns: [{ name: "computed_value", data_type: "int", is_nullable: true, extra }],
+        columns: [{ name: "computed_value", data_type: "int", is_nullable: true, extra: "GENERATED ALWAYS AS (1)" }],
       },
       ["computed_value"],
     );
 
     expect(state.canCopyRowAsInsert.value).toBe(false);
+  });
+
+  it.each(["auto_increment", "AUTOINCREMENT", "IDENTITY(1, 1)"])("keeps copy-as-insert available for explicit generated key values (%s)", (extra) => {
+    const state = createExportState(
+      {
+        tableName: "generated_values",
+        primaryKeys: ["id"],
+        columns: [{ name: "id", data_type: "bigint", is_nullable: false, is_primary_key: true, extra }],
+      },
+      ["id"],
+    );
+
+    expect(state.canCopyRowAsInsert.value).toBe(true);
+    expect(state.canCopyRowAsInsertWithoutPrimaryKeys.value).toBe(false);
   });
 
   it("reports a shared builder failure when the user invokes copy", async () => {

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -1408,7 +1408,7 @@ function isCopyInsertOmittedColumn(databaseType: DatabaseType | undefined, colum
   const normalizedType = columnInfo?.data_type.trim().replace(/^"|"$/g, "").toLowerCase();
   if (databaseType === "postgres" && (normalizedType === "tsvector" || normalizedType?.endsWith(".tsvector"))) return true;
   const extra = columnInfo?.extra?.toLowerCase() ?? "";
-  return /\b(auto_increment|autoincrement|identity)\b/.test(extra) || (extra.includes("generated always as") && !extra.includes("identity"));
+  return extra.includes("generated always as") && !extra.includes("identity");
 }
 
 function findColumnIndex(columns: Array<string | undefined>, target: string): number {

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -2562,8 +2562,36 @@ mod tests {
 
     #[test]
     fn oracle_copy_insert_statement_uses_one_statement_per_row() {
+        for database_type in [DatabaseType::Oracle, DatabaseType::OceanbaseOracle] {
+            let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
+                database_type: Some(database_type),
+                table_meta: Some(DataGridTableMeta {
+                    catalog: None,
+                    database: None,
+                    schema: Some("APP".to_string()),
+                    table_name: "USERS".to_string(),
+                    primary_keys: vec!["ID".to_string()],
+                    columns: None,
+                }),
+                columns: vec!["ID".to_string(), "NAME".to_string()],
+                column_types: None,
+                source_columns: None,
+                rows: vec![vec![json!(1), json!("Ada")], vec![json!(2), json!("Linus")]],
+                exclude_primary_keys: false,
+                insert_mode: DataGridCopyInsertMode::Merged,
+            });
+
+            assert_eq!(
+                statement.as_deref(),
+                Some("INSERT INTO \"APP\".\"USERS\" (\"ID\", \"NAME\") VALUES (1, 'Ada');\nINSERT INTO \"APP\".\"USERS\" (\"ID\", \"NAME\") VALUES (2, 'Linus');")
+            );
+        }
+    }
+
+    #[test]
+    fn iris_copy_insert_statement_uses_one_statement_per_row() {
         let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
-            database_type: Some(DatabaseType::Oracle),
+            database_type: Some(DatabaseType::Iris),
             table_meta: Some(DataGridTableMeta {
                 catalog: None,
                 database: None,
@@ -2584,6 +2612,59 @@ mod tests {
             statement.as_deref(),
             Some("INSERT INTO \"APP\".\"USERS\" (\"ID\", \"NAME\") VALUES (1, 'Ada');\nINSERT INTO \"APP\".\"USERS\" (\"ID\", \"NAME\") VALUES (2, 'Linus');")
         );
+    }
+
+    #[test]
+    fn sqlserver_copy_insert_uses_bracketed_identifiers_and_typed_literals() {
+        let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
+            database_type: Some(DatabaseType::SqlServer),
+            table_meta: Some(DataGridTableMeta {
+                catalog: None,
+                database: None,
+                schema: Some("dbo".to_string()),
+                table_name: "user data".to_string(),
+                primary_keys: vec!["id".to_string()],
+                columns: Some(vec![
+                    column("id", "bigint", false, Some("IDENTITY(1,1)")),
+                    column("display name", "nvarchar(100)", false, None),
+                    column("enabled", "bit", false, None),
+                ]),
+            }),
+            columns: vec!["id".to_string(), "display name".to_string(), "enabled".to_string()],
+            column_types: None,
+            source_columns: None,
+            rows: vec![vec![json!(1), json!("Ada's account"), json!(true)]],
+            exclude_primary_keys: false,
+            insert_mode: DataGridCopyInsertMode::Merged,
+        });
+
+        assert_eq!(
+            statement.as_deref(),
+            Some("INSERT INTO [dbo].[user data] ([id], [display name], [enabled]) VALUES (1, N'Ada''s account', 1);")
+        );
+    }
+
+    #[test]
+    fn clickhouse_copy_insert_formats_array_values() {
+        let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
+            database_type: Some(DatabaseType::ClickHouse),
+            table_meta: Some(DataGridTableMeta {
+                catalog: None,
+                database: None,
+                schema: Some("default".to_string()),
+                table_name: "events".to_string(),
+                primary_keys: vec!["id".to_string()],
+                columns: Some(vec![column("id", "UInt64", false, None), column("tags", "Array(String)", false, None)]),
+            }),
+            columns: vec!["id".to_string(), "tags".to_string()],
+            column_types: None,
+            source_columns: None,
+            rows: vec![vec![json!(1), json!(["alpha", "beta"])]],
+            exclude_primary_keys: false,
+            insert_mode: DataGridCopyInsertMode::Merged,
+        });
+
+        assert_eq!(statement.as_deref(), Some("INSERT INTO `events` (`id`, `tags`) VALUES (1, ['alpha','beta']);"));
     }
 
     #[test]

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1742,6 +1742,30 @@ mod tests {
     }
 
     #[test]
+    fn iris_export_inserts_use_one_statement_per_row() {
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::Iris),
+            schema: Some("APP".to_string()),
+            table_name: Some("USERS".to_string()),
+            qualified_table_name: None,
+            columns: vec!["ID".to_string(), "NAME".to_string()],
+            column_types: Vec::new(),
+            column_extras: Vec::new(),
+            rows: vec![vec![json!(1), json!("Ada")], vec![json!(2), json!("Linus")]],
+            batch_size: Some(100),
+        })
+        .unwrap();
+
+        assert_eq!(
+            statements,
+            vec![
+                "INSERT INTO \"APP\".\"USERS\" (\"ID\", \"NAME\") VALUES (1, 'Ada');",
+                "INSERT INTO \"APP\".\"USERS\" (\"ID\", \"NAME\") VALUES (2, 'Linus');",
+            ]
+        );
+    }
+
+    #[test]
     fn oracle_export_omits_synthetic_rowid_from_insert_columns() {
         let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
             database_type: Some(DatabaseType::Oracle),

--- a/crates/dbx-core/src/sql_dialect/capabilities.rs
+++ b/crates/dbx-core/src/sql_dialect/capabilities.rs
@@ -69,10 +69,9 @@ pub fn uses_oracle_row_id(database_type: Option<DatabaseType>) -> bool {
     matches!(database_type, Some(DatabaseType::Oracle | DatabaseType::OceanbaseOracle))
 }
 
-/// Oracle 系方言不支持 `INSERT ... VALUES (...), (...)` 多行语法，
-/// 复制为 INSERT 与导出 INSERT 都需按行生成单条语句。
+/// These dialects do not support `INSERT ... VALUES (...), (...)` multi-row syntax.
 pub fn uses_single_row_insert_statements(database_type: DatabaseType) -> bool {
-    matches!(database_type, DatabaseType::Oracle | DatabaseType::OceanbaseOracle)
+    matches!(database_type, DatabaseType::Oracle | DatabaseType::OceanbaseOracle | DatabaseType::Iris)
 }
 
 pub fn pagination_strategy(database_type: Option<DatabaseType>, context: PaginationContext) -> TablePaginationStrategy {


### PR DESCRIPTION
## 背景

这是 #3161 的后续兼容性检查。首次右键按需生成逻辑本身与数据库无关，但复查字段资格和 SQL 方言后发现两处边界需要补齐。

## 变更说明

- 菜单资格判断与 Rust 生成器保持一致：自增列和 Identity 列允许复制其显式值，仅省略非 Identity 计算列。
- IRIS 不再生成不支持的多行 `VALUES (...), (...)`，复制 INSERT 和 SQL 导出均改为逐行语句。
- 扩充首次点击测试，覆盖 MySQL、PostgreSQL、SQL Server、Oracle、ClickHouse、TDengine。
- 扩充方言和字段测试，覆盖 Oracle/OceanBase Oracle 逐行语句、SQL Server 标识符/Unicode/bit/Identity、ClickHouse 数组、PostgreSQL tsvector、MySQL blob、IRIS 复制与导出；MongoDB BSON 类型测试继续通过。

## 验证

- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts`（15 passed）
- `pnpm exec vitest run packages/app-tests/useDataGridExport.test.ts`（25 passed）
- `cargo test -p dbx-core copy_insert`（9 passed）
- `cargo test -p dbx-core iris_export_inserts_use_one_statement_per_row`（1 passed）
- `cargo fmt --all -- --check`
- `git diff --check`