### PR TITLE
Feature：支持清除 GaussDB 查询模式

### DIFF
--- a/apps/desktop/src/lib/database/databaseCapabilitySets.ts
+++ b/apps/desktop/src/lib/database/databaseCapabilitySets.ts
@@ -39,7 +39,7 @@ export const SCHEMA_AWARE_TYPES = new Set<DatabaseType>([
 
 export const SINGLE_DATABASE_TYPES = new Set<DatabaseType>(["oracle", "dameng", "firebird", "oceanbase-oracle", "access", "questdb"]);
 
-export const CLEARABLE_QUERY_SCHEMA_TYPES = new Set<DatabaseType>(["oracle", "dameng", "oceanbase-oracle"]);
+export const CLEARABLE_QUERY_SCHEMA_TYPES = new Set<DatabaseType>(["oracle", "dameng", "gaussdb", "oceanbase-oracle"]);
 
 export const FETCH_FIRST_TYPES = new Set<DatabaseType>(["oracle", "dameng"]);
 

--- a/packages/app-tests/databaseCapabilities.test.ts
+++ b/packages/app-tests/databaseCapabilities.test.ts
@@ -33,12 +33,14 @@ test("visible schema menu capability preserves adjacent database families", () =
   assert.equal(canConfigureVisibleSchemasForTreeNode("mysql", "database", "app"), false);
 });
 
-test("only Oracle-compatible single-database schemas can be cleared from query tabs", () => {
+test("only explicitly supported query schemas can be cleared from query tabs", () => {
   assert.equal(supportsClearableQuerySchema("oracle"), true);
   assert.equal(supportsClearableQuerySchema("dameng"), true);
+  assert.equal(supportsClearableQuerySchema("gaussdb"), true);
   assert.equal(supportsClearableQuerySchema("oceanbase-oracle"), true);
   assert.equal(supportsClearableQuerySchema("mysql"), false);
   assert.equal(supportsClearableQuerySchema("postgres"), false);
+  assert.equal(supportsClearableQuerySchema("opengauss"), false);
   assert.equal(supportsClearableQuerySchema("sqlserver"), false);
   assert.equal(supportsClearableQuerySchema("jdbc"), false);
 });

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -49,9 +49,9 @@ function oracleConn(id: string): ConnectionConfig {
   };
 }
 
-function oracleCompatibleConn(id: string, dbType: "oracle" | "dameng" | "oceanbase-oracle"): ConnectionConfig {
+function clearableQuerySchemaConn(id: string, dbType: "oracle" | "dameng" | "gaussdb" | "oceanbase-oracle"): ConnectionConfig {
   return {
-    ...oracleConn(id),
+    ...conn(id),
     db_type: dbType,
   };
 }
@@ -4238,7 +4238,7 @@ test("closing a data tab releases its tab-scoped client session", async () => {
   }
 });
 
-for (const dbType of ["oracle", "dameng", "oceanbase-oracle"] as const) {
+for (const dbType of ["oracle", "dameng", "gaussdb", "oceanbase-oracle"] as const) {
   test(`clearing a ${dbType} query schema releases its tab-scoped client session`, async () => {
     const restoreStorage = installMemoryStorage();
     setActivePinia(createPinia());
@@ -4247,7 +4247,7 @@ for (const dbType of ["oracle", "dameng", "oceanbase-oracle"] as const) {
     const originalFetch = globalThis.fetch;
     const connectionId = `${dbType}-1`;
 
-    connectionStore.addEphemeralConnection(oracleCompatibleConn(connectionId, dbType));
+    connectionStore.addEphemeralConnection(clearableQuerySchemaConn(connectionId, dbType));
     const tabId = store.createTab(connectionId, "SERVICE", "Query", "query", "REPORTING");
     const closedSessions: any[] = [];
 


### PR DESCRIPTION
## 改动内容

- 补充 PR #3459 未覆盖的 GaussDB：查询编辑器的模式列表支持再次点击当前选中项以清除选择
- 清除 GaussDB 模式时复用现有的 tab 会话重置机制，等待旧会话关闭后再执行下一条查询，恢复账号默认 `search_path`
- 保持 PostgreSQL、openGauss、MySQL、SQL Server、通用 JDBC 等其他数据库的原有交互不变
- 扩展数据库能力和查询会话释放回归测试

## 可行性说明

GaussDB 使用 PostgreSQL 兼容的 schema / `search_path` 机制。DBX 在指定 schema 查询时设置对应 `search_path`，清除后关闭 tab 级会话并以未指定 schema 的状态执行，可以可靠恢复连接账号的默认搜索路径，无需新增数据库 DDL 或修改服务端配置。

## 验证

- GaussDB 真实实例：默认 `current_schema=gaussdb`、`search_path="$user",public`
- 选择 `public` 后：`current_schema=public`
- 清除选择并关闭 tab 会话后：恢复 `current_schema=gaussdb`、`search_path="$user",public`
- `pnpm vitest run packages/app-tests/databaseCapabilities.test.ts packages/app-tests/queryStore.test.ts --maxWorkers=4`：114 项通过
- `pnpm vitest run --maxWorkers=4`：407 个测试文件、3314 项测试通过
- `pnpm typecheck`
- `pnpm build`
