### PR TITLE
Feat: reasoning char count heartbeat for collapsed thinking panel

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -78,6 +78,7 @@ import { AI_TABLE_MENTION_CANDIDATE_LIMIT, AI_TABLE_MENTION_SCHEMA_LIMIT, filter
 import { isAiPromptImeCompositionEvent, shouldSubmitAiPromptOnKeydown } from "@/lib/ai/aiPromptKeyboard";
 import { looksLikeActionProposal, containsChinese } from "@/lib/ai/aiProposalDetect";
 import { visibleToActualIndex } from "@/lib/ai/aiMessageEdit";
+import { shouldShowReasoningCharCount, reasoningCharCountClass } from "@/lib/ai/aiReasoningPresentation";
 
 const { t } = useI18n();
 const settings = useSettingsStore();
@@ -1871,7 +1872,7 @@ async function openExternalUrl(url: string) {
                     <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': reasoningExpanded }" />
                     <Loader2 v-if="msg.isThinking" class="h-3 w-3 animate-spin" />
                     <span>{{ t("ai.reasoningProcess") }}</span>
-                    <span v-if="msg.reasoning && !reasoningExpanded" class="tabular-nums text-muted-foreground/60" :class="{ 'animate-pulse': msg.isThinking }">{{ msg.reasoning.length }} {{ t("ai.chars") }}</span>
+                    <span v-if="shouldShowReasoningCharCount(msg.reasoning, reasoningExpanded)" :class="reasoningCharCountClass(!!msg.isThinking)">{{ msg.reasoning?.length ?? 0 }} {{ t("ai.chars") }}</span>
                   </button>
                   <div
                     class="overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out"

--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -1871,6 +1871,7 @@ async function openExternalUrl(url: string) {
                     <ChevronRight class="h-3 w-3 transition-transform duration-200" :class="{ 'rotate-90': reasoningExpanded }" />
                     <Loader2 v-if="msg.isThinking" class="h-3 w-3 animate-spin" />
                     <span>{{ t("ai.reasoningProcess") }}</span>
+                    <span v-if="msg.reasoning && !reasoningExpanded" class="tabular-nums text-muted-foreground/60" :class="{ 'animate-pulse': msg.isThinking }">{{ msg.reasoning.length }} {{ t("ai.chars") }}</span>
                   </button>
                   <div
                     class="overflow-hidden transition-[max-height,opacity] duration-200 ease-in-out"

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1314,6 +1314,7 @@ export default {
     newChat: "New Chat",
     thinking: "Thinking...",
     reasoningProcess: "Thinking process",
+    chars: "chars",
     stopGenerating: "Stop generating",
     scrollToBottom: "Back to bottom",
     tableMentionEmpty: "No matching tables or SQL files",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1273,6 +1273,7 @@ export default withEnglishFallback({
     newChat: "Nuevo chat",
     thinking: "Procesando...",
     reasoningProcess: "Proceso de razonamiento",
+    chars: "car.",
     stopGenerating: "Detener generación",
     scrollToBottom: "Volver al final",
     tableMentionEmpty: "Sin tablas ni archivos SQL coincidentes",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1254,6 +1254,7 @@ export default withEnglishFallback({
     newChat: "Nuova Chat",
     thinking: "Riflessione...",
     reasoningProcess: "Processo di riflessione",
+    chars: "car.",
     stopGenerating: "Interrompi generazione",
     scrollToBottom: "Torna in fondo",
     tableMentionEmpty: "Nessuna tabella o file SQL corrispondente",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1277,6 +1277,7 @@ export default withEnglishFallback({
     newChat: "新しいチャット",
     thinking: "思考中...",
     reasoningProcess: "思考プロセス",
+    chars: "文字",
     stopGenerating: "生成を停止",
     scrollToBottom: "一番下へ戻る",
     tableMentionEmpty: "一致するテーブルまたは SQL ファイルがありません",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1275,6 +1275,7 @@ export default withEnglishFallback({
     newChat: "Nova Conversa",
     thinking: "Pensando...",
     reasoningProcess: "Processo de raciocínio",
+    chars: "car.",
     stopGenerating: "Parar geração",
     scrollToBottom: "Voltar ao fim",
     tableMentionEmpty: "Nenhuma tabela ou arquivo SQL correspondente",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1314,6 +1314,7 @@ export default withEnglishFallback({
     newChat: "新对话",
     thinking: "思考中...",
     reasoningProcess: "思考过程",
+    chars: "字",
     stopGenerating: "停止生成",
     scrollToBottom: "回到底部",
     tableMentionEmpty: "没有匹配的表或 SQL 文件",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1256,6 +1256,7 @@ export default withEnglishFallback({
     newChat: "新對話",
     thinking: "思考中……",
     reasoningProcess: "思考過程",
+    chars: "字",
     stopGenerating: "停止產生",
     scrollToBottom: "回到底部",
     tableMentionEmpty: "沒有相符的資料表或 SQL 檔案",

--- a/apps/desktop/src/lib/ai/__tests__/aiReasoningPresentation.spec.ts
+++ b/apps/desktop/src/lib/ai/__tests__/aiReasoningPresentation.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowReasoningCharCount, reasoningCharCountClass, REASONING_CHAR_COUNT_BASE_CLASS, REASONING_CHAR_COUNT_PULSE_CLASS } from "@/lib/ai/aiReasoningPresentation";
+
+describe("shouldShowReasoningCharCount", () => {
+  it("shows the counter when reasoning exists and the panel is collapsed", () => {
+    expect(shouldShowReasoningCharCount("正在分析表结构...", false)).toBe(true);
+  });
+
+  it("hides the counter when the panel is expanded", () => {
+    expect(shouldShowReasoningCharCount("正在分析表结构...", true)).toBe(false);
+  });
+
+  it("hides the counter when reasoning is empty", () => {
+    expect(shouldShowReasoningCharCount("", false)).toBe(false);
+  });
+
+  it("hides the counter when reasoning is undefined", () => {
+    expect(shouldShowReasoningCharCount(undefined, false)).toBe(false);
+  });
+});
+
+describe("reasoningCharCountClass", () => {
+  it("includes the pulse class while the model is still thinking", () => {
+    const cls = reasoningCharCountClass(true);
+    expect(cls).toContain(REASONING_CHAR_COUNT_BASE_CLASS);
+    expect(cls).toContain(REASONING_CHAR_COUNT_PULSE_CLASS);
+  });
+
+  it("uses only the base class when thinking has finished", () => {
+    expect(reasoningCharCountClass(false)).toBe(REASONING_CHAR_COUNT_BASE_CLASS);
+  });
+});

--- a/apps/desktop/src/lib/ai/aiReasoningPresentation.ts
+++ b/apps/desktop/src/lib/ai/aiReasoningPresentation.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure presentation logic for the collapsed reasoning-process char counter.
+ *
+ * Kept side-effect-free so it can be unit-tested without a DOM harness, matching
+ * the existing pattern of `aiAgentStepPresentation.ts`. The AiAssistant template
+ * consumes these helpers so its render decisions (show/hide, pulse class, text)
+ * are covered by Vitest rather than only by the rendered template.
+ */
+
+/** Base CSS classes for the collapsed reasoning char counter span. */
+export const REASONING_CHAR_COUNT_BASE_CLASS = "tabular-nums text-muted-foreground/60";
+
+/** Extra class added while the model is still producing reasoning deltas. */
+export const REASONING_CHAR_COUNT_PULSE_CLASS = "animate-pulse";
+
+/**
+ * Decide whether the collapsed reasoning char counter should render.
+ * Visible only when there is reasoning text AND the panel is collapsed,
+ * so the counter acts as a "still alive" heartbeat without forcing the
+ * user to open the panel.
+ *
+ * @param reasoning  Accumulated reasoning text (may be empty during initial thinking).
+ * @param expanded   Whether the reasoning panel is currently expanded.
+ */
+export function shouldShowReasoningCharCount(reasoning: string | undefined, expanded: boolean): boolean {
+  return !expanded && !!reasoning && reasoning.length > 0;
+}
+
+/**
+ * Return the CSS class string for the counter span.
+ * Adds a pulse animation while the model is still thinking so the number
+ * reads as actively growing rather than frozen.
+ */
+export function reasoningCharCountClass(isThinking: boolean): string {
+  return isThinking ? `${REASONING_CHAR_COUNT_BASE_CLASS} ${REASONING_CHAR_COUNT_PULSE_CLASS}` : REASONING_CHAR_COUNT_BASE_CLASS;
+}


### PR DESCRIPTION
## Reasoning char count heartbeat for collapsed thinking panel

Closes #3516

### Background

When the reasoning (thinking) process panel is collapsed by default, users cannot tell whether the AI is still working without expanding it. Issue #3516 requests showing an output char/token count next to the thinking process label so users can see at a glance that the AI is "alive."

The panel was intentionally changed from auto-expand/collapse (which caused flickering during interleaved thinking and answering) to a fixed manual toggle. This change preserves that manual toggle behavior while adding a live heartbeat indicator.

### Changes

Feature (80ecc643)

- Added a real-time char counter to the collapsed reasoning panel button in AiAssistant.vue. The count updates as reasoning deltas stream in, and pulses while the model is still thinking.
- Added ai.chars i18n key across all 7 supported locales (en, es, it, ja, pt-BR, zh-CN, zh-TW).

Tests (b718265f)

- Extracted presentation logic into a pure helper aiReasoningPresentation.ts (shouldShowReasoningCharCount, reasoningCharCountClass), following the existing aiAgentStepPresentation.ts pattern.
- Added 6 unit tests covering: collapsed+has-reasoning shows count, expanded hides count, empty/undefined reasoning hides count, thinking state adds pulse class, finished state uses base class only.
- Updated AiAssistant.vue template to consume the helper instead of inline logic.

### Files Changed

| File | Type | Description |
| :--- | :--- | :--- |
| apps/desktop/src/components/editor/AiAssistant.vue | Modified | Char counter span in collapsed reasoning button |
| apps/desktop/src/lib/ai/aiReasoningPresentation.ts | New | Pure presentation helper for show/hide + class decisions |
| apps/desktop/src/lib/ai/__tests__/aiReasoningPresentation.spec.ts | New | 6 unit tests (positive + boundary + thinking state) |
| apps/desktop/src/i18n/locales/{en,es,it,ja,pt-BR,zh-CN,zh-TW}.ts | Modified | Added ai.chars key |

### Verification

- pnpm typecheck — passed
- pnpm lint — passed (no new warnings)
- pnpm test — 408 test files / 3319 tests passed (+6 new)
- git diff --check — passed
- Secret scan — no hits
- pre-commit hooks (oxfmt) — passed

### Design Decision

Chose char count over token count because:

- output_tokens is only reported once at AgentEnd, not streamed during reasoning.
- Streaming token counts would require a backend tokenizer + SSE protocol changes, with high cost and low provider coverage (Claude/Gemini paths report None).
- msg.reasoning.length is already available on the frontend via streaming reasoning_delta, updates in real-time per animation frame, and requires zero backend changes.
- A continuously growing number is itself the strongest "alive" signal.

<img width="793" height="453" alt="image" src="https://github.com/user-attachments/assets/5734257a-144b-4916-9642-a8d23438c319" />
