### PR TITLE
fix: 修复 SQL Server 重启后无法定位视图

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -783,6 +783,12 @@ async function ensureTreeLoadedForTarget(target: ActiveTabSidebarTarget, opts?: 
       if (force || !databaseChildrenLoaded) {
         await store.loadSqlServerDatabaseObjects(connId, target.database, loadOptions);
       }
+      if (targetSchema) {
+        const schemaNode = findSchemaNode(store.treeNodes, connId, target.database, targetSchema);
+        if (schemaNode && (force || !schemaNode.children || schemaNode.children.length === 0)) {
+          await store.loadTables(connId, target.database, targetSchema, loadOptions);
+        }
+      }
     } else if (usesSchemaTree) {
       if (force || !databaseChildrenLoaded) {
         await store.loadSchemas(connId, target.database, loadOptions);

--- a/packages/app-tests/queryCursorTableTarget.test.ts
+++ b/packages/app-tests/queryCursorTableTarget.test.ts
@@ -63,6 +63,18 @@ test("builds schema-aware cursor table candidates", () => {
   });
 });
 
+test("builds SQL Server view candidates from bracket-quoted identifiers", () => {
+  const sql = "SELECT * FROM [sales].[v_city_sales]";
+  const tab = queryTab(sql, sql.length, undefined);
+
+  assert.deepEqual(queryCursorTableCandidate(tab, "sqlserver"), {
+    connectionId: "conn-1",
+    database: "app",
+    schema: "sales",
+    tableName: "v_city_sales",
+  });
+});
+
 test("builds database-qualified candidates for multi-database non-schema engines", () => {
   const tab = queryTab("select * from analytics.events", "select * from analytics.events".length, undefined);
 


### PR DESCRIPTION
## 问题

DBX 重启后，在 SQL Server 查询编辑器中对带 Schema 的视图 SQL 点击“在侧边栏中定位”，侧边栏只会定位到 Schema，无法定位到具体视图。

## 原因

SQL Server 的冷启动定位流程只加载了数据库下的 Schema 列表，没有继续加载目标 Schema 的对象。后续查找不到视图节点，只能回退选择 Schema。

## 修改

- SQL Server 定位到带 Schema 的对象时，补充加载目标 Schema 的对象树
- 增加 SQL Server 方括号限定视图名的解析回归测试

## 验证

- 使用 SQL Server 测试库 `dbx_sqlserver_demo` 实际验证 `SELECT * FROM [sales].[v_city_sales]`
- 确认元数据接口返回 `v_city_sales`，类型为 `VIEW`
- 浏览器端禁用密码并重启页面，点击定位后成功展开 `sales -> 视图` 并选中 `v_city_sales`
- `pnpm typecheck`
- `pnpm test`（407 个测试文件、3314 条测试全部通过）