### PR TITLE
Fix：修复 Kingbase 导出 SQL 生成 varchar(-1)

### DIFF
--- a/agents/common/src/main/java/com/dbx/agent/DdlBuilder.java
+++ b/agents/common/src/main/java/com/dbx/agent/DdlBuilder.java
@@ -218,8 +218,9 @@ public final class DdlBuilder {
     private static String columnTypeSql(ColumnInfo column) {
         String type = column.getData_type();
         String normalized = type.toLowerCase(Locale.ROOT);
-        if (isCharacterType(normalized) && column.getCharacter_maximum_length() != null) {
-            return type + "(" + column.getCharacter_maximum_length() + ")";
+        Integer characterLength = column.getCharacter_maximum_length();
+        if (isCharacterType(normalized) && characterLength != null && characterLength > 0) {
+            return type + "(" + characterLength + ")";
         }
         if (isNumericType(normalized) && column.getNumeric_precision() != null) {
             if (column.getNumeric_scale() != null) {

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -541,6 +541,23 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
+    void ddlOmitsUnknownCharacterLengthSentinel() {
+        ColumnInfo unlimited = new ColumnInfo("display_name", "varchar", true, null, false, null, null, null, null, -1);
+
+        String ddl = DdlBuilder.buildTableDdl(
+            "public",
+            "accounts",
+            Collections.singletonList(unlimited),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            true
+        );
+
+        Assertions.assertTrue(ddl.contains("`display_name` varchar"), ddl);
+        Assertions.assertFalse(ddl.contains("varchar(-1)"), ddl);
+    }
+
+    @Test
     void regularListIndexesIncludesPrimaryUniqueAndSecondaryIndexes() {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();


### PR DESCRIPTION
## 问题原因

Kingbase MySQL 兼容模式的 JDBC 元数据可能使用 `-1` 表示字符串长度未知或不受限。公共 DDL 生成器此前将所有非空长度都当作有效值，因而在导出数据库结构时生成了无效的 `varchar(-1)`。

## 改动内容

- 字符类型仅在元数据长度为正数时追加长度参数
- `-1`、`0` 等无效或哨兵长度按未指定长度处理，导出为 `varchar` / `character varying`
- 正常的 `varchar(64)`、`char(1)`、`char(10)` 等长度保持不变
- 增加 Kingbase MySQL 兼容模式回归测试

## 复现与验证

- 修复前：新增回归测试稳定失败，生成结果包含 `varchar(-1)`
- 修复后：公共 JDBC 与 Kingbase Agent 共 123 项测试通过
- Kingbase 真实实例通过 JSON-RPC 强制进入 MySQL 兼容分支，标识符为反引号，与 issue 截图路径一致
- 真实表验证结果：无限长字符串不包含 `(-1)`，`VARCHAR(64)`、`CHAR(1)`、`CHAR(10)` 均保留正确长度
- 测试表已清理

Fixes #3614
