### PR TITLE
Fix：修复达梦 BIT 数据导出字面量错误

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -171,6 +171,9 @@ fn format_export_sql_literal_for_database(value: &Value, database_type: Option<D
         return number.to_string();
     }
     if let Some(value) = value.as_bool() {
+        if database_type == Some(DatabaseType::Dameng) {
+            return if value { "1" } else { "0" }.to_string();
+        }
         return if value { "TRUE" } else { "FALSE" }.to_string();
     }
     if let Some(arr) = value.as_array() {
@@ -1840,6 +1843,27 @@ mod tests {
         assert_eq!(
             statements,
             vec!["INSERT INTO `flags` (`enabled`, `mask`, `label`) VALUES (b'1', b'1010', '1010'), (b'0', 3, 'off');"]
+        );
+    }
+
+    #[test]
+    fn dameng_bit_columns_export_as_numeric_literals() {
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::Dameng),
+            schema: Some("DBX_TEST".to_string()),
+            table_name: Some("FLAGS".to_string()),
+            qualified_table_name: None,
+            columns: vec!["ENABLED".to_string(), "DELETED".to_string(), "OPTIONAL".to_string()],
+            column_types: vec![Some("BIT".to_string()), Some("bit".to_string()), Some("BIT".to_string())],
+            column_extras: Vec::new(),
+            rows: vec![vec![json!(true), json!(false), Value::Null]],
+            batch_size: Some(10),
+        })
+        .unwrap();
+
+        assert_eq!(
+            statements,
+            vec!["INSERT INTO \"DBX_TEST\".\"FLAGS\" (\"ENABLED\", \"DELETED\", \"OPTIONAL\") VALUES (1, 0, NULL);"]
         );
     }
 

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1038,7 +1038,7 @@ pub fn escape_value_typed(val: &serde_json::Value, db_type: &DatabaseType, colum
                     }
                 }
             }
-            DatabaseType::SqlServer => {
+            DatabaseType::SqlServer | DatabaseType::Dameng => {
                 if *b {
                     "1".to_string()
                 } else {
@@ -6104,6 +6104,25 @@ mod tests {
         );
 
         assert_eq!(sql, "INSERT INTO [dbo].[flags] ([enabled], [deleted]) VALUES\n(1, 0)");
+    }
+
+    #[test]
+    fn dameng_insert_formats_bit_booleans_as_numeric_literals() {
+        let sql = generate_insert_typed(
+            &[String::from("enabled"), String::from("deleted"), String::from("optional")],
+            &[Some(String::from("BIT")), Some(String::from("bit")), Some(String::from("BIT"))],
+            &[vec![json!(true), json!(false), serde_json::Value::Null]],
+            "flags",
+            "DBX_TEST",
+            &DatabaseType::Dameng,
+        );
+
+        assert_eq!(
+            sql,
+            "INSERT INTO \"DBX_TEST\".\"flags\" (\"enabled\", \"deleted\", \"optional\") VALUES\n(1, 0, NULL)"
+        );
+        assert!(!sql.contains("TRUE"));
+        assert!(!sql.contains("FALSE"));
     }
 
     #[test]


### PR DESCRIPTION
## 修改内容

- 达梦数据库导出布尔值时使用 `1` / `0`，避免生成不受 DM8 `BIT` 列接受的 `TRUE` / `FALSE`。
- 同步修复通用 SQL 导出构建器和桌面端数据库导出使用的 typed insert 路径。
- 增加两条回归测试，覆盖 `true`、`false` 和 `NULL`。

## 实际验证

在真实 DM8 实例中创建临时 `BIT` 表验证：

- 原导出形式 `VALUES (2, TRUE, FALSE, NULL)` 执行失败，DM8 报数据类型不匹配。
- 修复后实际生成 `VALUES (1, 1, 0, NULL)`，执行成功。
- 回读结果为 `[1, true, false, null]`，确认 `BIT` 值和 `NULL` 均正确。
- 验证结束后已删除临时表。

## 检查

- `cargo test -p dbx-core --no-default-features database_export::tests --lib`（30 项通过）
- `cargo test -p dbx-core --no-default-features transfer::tests::dameng --lib`（6 项通过）
- `pnpm check`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #3608