### PR TITLE
Fix：修复PostgreSQL分区表挤占侧边栏分页

### DIFF
--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1073,7 +1073,7 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   function objectGroupCacheKey(node: TreeNode): string {
-    return schemaCacheKey(node.connectionId || "", node.database || "", node.schema || "", node.type, "objects-v4");
+    return schemaCacheKey(node.connectionId || "", node.database || "", node.schema || "", node.type, "objects-v5");
   }
 
   function metadataListDriverProfile(connectionId?: string): string | undefined {
@@ -3125,7 +3125,7 @@ export const useConnectionStore = defineStore("connection", () => {
           await ensureConnected(connectionId);
           if (useCachedChildren(node, options)) return;
           const simpleObjectDisplay = useSettingsStore().editorSettings.sidebarObjectDisplay === "simple";
-          const cacheKey = schemaCacheKey(connectionId, database, schema || "", simpleObjectDisplay ? "objects-simple-v4" : "objects-grouped-v4");
+          const cacheKey = schemaCacheKey(connectionId, database, schema || "", simpleObjectDisplay ? "objects-simple-v5" : "objects-grouped-v5");
           const searchFilter = activeTreeLoadSearchFilter(options);
           const isSidebarTableSearch = !!options?.sidebarTableSearchParentId;
           if (!options?.force && !searchFilter) {
@@ -3383,7 +3383,7 @@ export const useConnectionStore = defineStore("connection", () => {
             if (!canApplyTreeMetadataResult(parent)) return;
             parent.objectCount = mergedChildren.length;
             setChildren(parent, nextChildren);
-            await savePersistedTreeChildren(schemaCacheKey(parentConnectionId, parentDatabase, parent.schema || "", "objects-simple-v4"), nextChildren);
+            await savePersistedTreeChildren(schemaCacheKey(parentConnectionId, parentDatabase, parent.schema || "", "objects-simple-v5"), nextChildren);
             parent.isExpanded = true;
             return;
           }

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -1696,6 +1696,8 @@ fn postgres_table_comment_sql() -> &'static str {
 fn postgres_tables_sql() -> &'static str {
     // PostgreSQL and Redshift can infer different wire types for LIMIT/OFFSET
     // placeholders. Keep them explicit so the shared i64 parameters serialize reliably.
+    // Root relations must precede partition descendants so a large partition
+    // hierarchy cannot push unrelated schema tables into later sidebar pages.
     "SELECT c.relname AS table_name, \
          CASE c.relkind WHEN 'r' THEN 'BASE TABLE' WHEN 'v' THEN 'VIEW' \
            WHEN 'm' THEN 'MATERIALIZED_VIEW' WHEN 'f' THEN 'FOREIGN TABLE' \
@@ -1710,7 +1712,7 @@ fn postgres_tables_sql() -> &'static str {
          LEFT JOIN pg_catalog.pg_namespace pn ON pn.oid = pc.relnamespace \
          WHERE n.nspname = $1 AND c.relkind IN ('r','v','m','f','p') \
            AND ($2 = '%%' OR c.relname ILIKE $2 ESCAPE '~' OR ($3 <> '' AND c.relname ILIKE $3 ESCAPE '~')) \
-         ORDER BY c.relname \
+         ORDER BY CASE WHEN pc.relkind = 'p' THEN 1 ELSE 0 END, c.relname \
          LIMIT CAST($4 AS BIGINT) OFFSET CAST($5 AS BIGINT)"
 }
 
@@ -4197,6 +4199,7 @@ mod tests {
         assert!(sql.contains("ILIKE $2 ESCAPE '~'"));
         assert!(sql.contains("$3 <> ''"));
         assert!(sql.contains("ILIKE $3 ESCAPE '~'"));
+        assert!(sql.contains("ORDER BY CASE WHEN pc.relkind = 'p' THEN 1 ELSE 0 END, c.relname"));
         assert!(sql.contains("LIMIT CAST($4 AS BIGINT) OFFSET CAST($5 AS BIGINT)"));
     }
 


### PR DESCRIPTION
## 问题

PostgreSQL 表元数据分页时，顶层表和分区子表原本统一按名称排序。分区数量较多时，大量最终会折叠到父表下的分区子表会占满分页，导致后续普通表未出现在首屏，表数量显示不完整，并且需要反复点击“加载更多”。

## 修改

- PostgreSQL 表列表优先返回顶层对象，再分页返回分区子表，避免分区层级挤占普通表的首屏位置
- 保留现有分区分页机制，不改为全量加载
- 升级侧边栏对象树缓存版本，避免升级后继续使用旧分页结果

## 验证

在 PostgreSQL 16.11 中构造 70 个顶层表和 2989 个分区子表，分页大小为 1000：

- 修复前：4 页新增顶层表数量依次为 32、0、0、38
- 修复后：首屏即可包含全部 70 个顶层表
- 简单视图和分组视图均通过 DBX API 验证
- `pnpm check`
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --locked --all-targets`

Fixes #3625