### PR TITLE
Fix：修复有主键表偶发显示无主键定位

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -104,7 +104,7 @@ import {
   usesTreeSchemaMode,
 } from "@/lib/database/databaseCapabilities";
 import { copyNameForTreeNode, isDocumentBrowserTreeNode, objectSourceKindForTreeNode, shouldRunTreeNodeRowAction, treeNodeRowAction, treeNodeRowDoubleClickAction } from "@/lib/sidebar/treeNodeClick";
-import { dataTabOpenModeFromTreeClick, findExistingDataTabCandidate, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
+import { canApplyDataTabMetadata, dataTabOpenModeFromTreeClick, findExistingDataTabCandidate, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
 import { isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut } from "@/lib/editor/keyboardShortcuts";
 import { formatSqlInsert } from "@/lib/export/exportFormats";
 import { joinExportedDdls } from "@/lib/export/ddlExport";
@@ -1397,17 +1397,14 @@ async function openData(node: TreeNode, request?: SidebarDataOpenRequest, openMo
   const querySchema = config ? connectionObjectTreeQuerySchema(config, node.database, tableSchema) : (tableSchema ?? "");
   const effectiveDbType = effectiveDatabaseTypeForConnection(config);
   const metadataDatabaseType = effectiveDbType || config?.db_type || "";
-  const existingDataTabCandidate = findExistingDataTabCandidate(
-    queryStore.tabs,
-    {
-      connectionId: node.connectionId,
-      database: node.database,
-      schema: tableSchema,
-      catalog: node.catalog,
-      tableName: node.label,
-    },
-    { openMode, reuseDataTab: settingsStore.editorSettings.reuseDataTab },
-  );
+  const dataTabTarget = {
+    connectionId: node.connectionId,
+    database: node.database,
+    schema: tableSchema,
+    catalog: node.catalog,
+    tableName: node.label,
+  };
+  const existingDataTabCandidate = findExistingDataTabCandidate(queryStore.tabs, dataTabTarget, { openMode, reuseDataTab: settingsStore.editorSettings.reuseDataTab });
   const existingSameTableTab = existingDataTabCandidate?.match === "same-table" ? existingDataTabCandidate.tab : undefined;
   const resetReusedDataTabState = (tab: (typeof queryStore.tabs)[number]) => {
     tab.title = node.label;
@@ -1513,11 +1510,12 @@ async function openData(node: TreeNode, request?: SidebarDataOpenRequest, openMo
 
   // Helper to check if this openData call is still active (not superseded by a newer click)
   const isActive = () => (request?.isCurrent() ?? true) && queryStore.tabs.find((t) => t.id === tabId)?.executionId === openDataId;
-  const isCurrentDataTab = () => {
-    if (!(request?.isCurrent() ?? true)) return false;
-    const current = queryStore.tabs.find((t) => t.id === tabId);
-    return current?.mode === "data" && current.connectionId === node.connectionId && current.database === node.database && current.schema === tableSchema && current.title === node.label;
-  };
+  const canApplyTableMetadata = () =>
+    canApplyDataTabMetadata(
+      queryStore.tabs.find((t) => t.id === tabId),
+      dataTabTarget,
+      request?.signal,
+    );
 
   try {
     openDataLog("info", "ensure-connected:start", { traceId, elapsed: elapsed() });
@@ -1549,7 +1547,7 @@ async function openData(node: TreeNode, request?: SidebarDataOpenRequest, openMo
           catalog: node.catalog,
           traceLogger: isDebugLoggingEnabled() ? (event) => openDataLog("debug", "metadata:trace", { sourceTraceId: traceId, ...event }) : undefined,
         });
-        if (!isCurrentDataTab()) {
+        if (!canApplyTableMetadata()) {
           openDataLog("info", "metadata:stale", {
             traceId,
             tabId,
@@ -1630,7 +1628,7 @@ async function openData(node: TreeNode, request?: SidebarDataOpenRequest, openMo
     });
     openDataLog("info", "execute:done", { traceId, tabId, elapsed: elapsed() });
     logPhase("execute-tab-sql", { tabId });
-    if (shouldRefreshTableMeta && isCurrentDataTab()) {
+    if (shouldRefreshTableMeta && canApplyTableMetadata()) {
       void refreshTableMetaInBackground();
       logPhase("metadata-started", { tabId });
     }

--- a/apps/desktop/src/lib/__tests__/sidebar/dataTabOpenPolicy.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/dataTabOpenPolicy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dataTabOpenModeFromTreeClick, findExistingDataTabCandidate } from "@/lib/sidebar/dataTabOpenPolicy";
+import { canApplyDataTabMetadata, dataTabOpenModeFromTreeClick, findExistingDataTabCandidate } from "@/lib/sidebar/dataTabOpenPolicy";
 import type { QueryTab } from "@/types/database";
 
 function click(modifiers: Partial<Pick<MouseEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">> = {}) {
@@ -64,5 +64,28 @@ describe("dataTabOpenPolicy", () => {
     expect(findExistingDataTabCandidate([sameTable], usersTarget, { openMode: "default", reuseDataTab: false })).toEqual({ tab: sameTable, match: "same-table" });
     expect(findExistingDataTabCandidate([otherTable], usersTarget, { openMode: "default", reuseDataTab: true })).toEqual({ tab: otherTable, match: "database" });
     expect(findExistingDataTabCandidate([otherTable], usersTarget, { openMode: "default", reuseDataTab: false })).toBeUndefined();
+  });
+
+  it("allows metadata to update a tab that still points to the requested table", () => {
+    const tab = dataTab("users", "users");
+    tab.tableMeta = { schema: "public", tableName: "users", columns: [], primaryKeys: [] };
+
+    expect(canApplyDataTabMetadata(tab, usersTarget, new AbortController().signal)).toBe(true);
+  });
+
+  it("rejects metadata after its request is cancelled", () => {
+    const tab = dataTab("users", "users");
+    tab.tableMeta = { schema: "public", tableName: "users", columns: [], primaryKeys: [] };
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(canApplyDataTabMetadata(tab, usersTarget, controller.signal)).toBe(false);
+  });
+
+  it("rejects stale metadata after a reusable tab switches to another table", () => {
+    const tab = dataTab("reused", "orders");
+    tab.tableMeta = { schema: "public", tableName: "orders", columns: [], primaryKeys: [] };
+
+    expect(canApplyDataTabMetadata(tab, usersTarget, new AbortController().signal)).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/__tests__/sidebar/sidebarDataOpenCoordinator.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/sidebarDataOpenCoordinator.spec.ts
@@ -138,4 +138,15 @@ describe("sidebarDataOpenCoordinator", () => {
 
     expect(signal?.aborted).toBe(true);
   });
+
+  it("marks a completed request non-current without aborting its signal", async () => {
+    let requestState: { isCurrent: () => boolean; signal: AbortSignal } | undefined;
+
+    runSidebarDataOpenImmediately({ connectionKey: "conn" }, (request) => {
+      requestState = request;
+    });
+
+    await vi.waitFor(() => expect(requestState?.isCurrent()).toBe(false));
+    expect(requestState?.signal.aborted).toBe(false);
+  });
 });

--- a/apps/desktop/src/lib/sidebar/dataTabOpenPolicy.ts
+++ b/apps/desktop/src/lib/sidebar/dataTabOpenPolicy.ts
@@ -37,6 +37,10 @@ function isSameTable(tab: DataTabLike, target: DataTabTarget): boolean {
   return isSameDatabase(tab, target) && (tab.tableMeta?.catalog || "") === (target.catalog || "") && (tab.schema || "") === (target.schema || "") && (tab.tableMeta?.tableName || tab.title) === target.tableName;
 }
 
+export function canApplyDataTabMetadata(tab: DataTabLike | undefined, target: DataTabTarget, signal?: AbortSignal): boolean {
+  return signal?.aborted !== true && tab !== undefined && isSameTable(tab, target);
+}
+
 export function findExistingDataTabCandidate<T extends DataTabLike>(tabs: T[], target: DataTabTarget, options: { openMode: DataTabOpenMode; reuseDataTab: boolean }): ExistingDataTabCandidate<T> | undefined {
   if (options.openMode === "new-tab") return undefined;
 


### PR DESCRIPTION
## 问题原因

打开表时会先以空字段、空主键元数据创建数据标签，查询完成后再异步加载完整表元数据。请求协调器在查询流程结束时会将请求标记为已完成，原逻辑随后使用 `request.isCurrent()` 判断后台元数据是否仍可回写，导致正常晚到的主键元数据被误判为过期并丢弃，页面因此可能持续显示「无主键定位」。

## 修复内容

- 将查询执行是否仍活跃与后台元数据是否可回写分开判断。
- 请求未被取消且标签仍指向同一连接、数据库、模式、目录和表时，允许完整元数据回写。
- 请求被取消或数据标签已复用到其他表时，继续拒绝旧元数据，避免竞态覆盖。
- 补充请求正常完成、取消请求和标签复用场景的回归测试。

## 测试

- `pnpm test`：407 个测试文件、3317 项测试全部通过
- `pnpm typecheck`
- 相关文件 `oxlint`
- `pnpm build`
- 本地 MySQL 实例实际打开有主键表，首次加载后主键状态正常

Fixes #3634