### PR TITLE
fix: 修复对象浏览器打开表时 schema 前缀重复导致的 dbo.dbo 报错

### DIFF
--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -50,6 +50,18 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
   })();
   const targetTab = queryStore.tabs.find((tab) => tab.id === tabId);
   if (targetTab) targetTab.tableInfoTab = options.tableInfoTab;
+  // Stamp the new table identity synchronously so SQL rebuilds (refresh,
+  // filters, row count) never read a stale tableMeta from a reused tab or
+  // fall back to parsing the schema-qualified tab title (issue #3613).
+  queryStore.setTableMeta(tabId, {
+    schema: target.schema,
+    catalog: target.catalog,
+    database: target.database,
+    tableName: target.tableName,
+    tableType: target.tableType ?? "TABLE",
+    columns: [],
+    primaryKeys: [],
+  });
   queryStore.setExecuting(tabId, true);
 
   try {

--- a/apps/desktop/src/lib/table/tableDataTabMeta.ts
+++ b/apps/desktop/src/lib/table/tableDataTabMeta.ts
@@ -2,6 +2,19 @@ import type { QueryTab, ColumnInfo } from "@/types/database";
 
 export type DataTabTableMeta = NonNullable<QueryTab["tableMeta"]>;
 
+// Data tabs opened from the object browser are titled "<schema>.<table>".
+// When the tab has no usable tableMeta yet, strip the schema prefix so SQL
+// rebuilt from this fallback does not qualify the table twice
+// (e.g. [dbo].[dbo.users] on SQL Server — see issue #3613).
+function titleTableName(tab: QueryTab): string {
+  const title = tab.title.trim();
+  const schema = tab.schema?.trim();
+  if (schema && title.length > schema.length + 1 && title.startsWith(`${schema}.`)) {
+    return title.slice(schema.length + 1);
+  }
+  return title;
+}
+
 function fallbackColumnInfo(name: string): ColumnInfo {
   return {
     name,
@@ -16,7 +29,7 @@ function fallbackColumnInfo(name: string): ColumnInfo {
 export function tableMetaForDataTab(tab: QueryTab | undefined): DataTabTableMeta | undefined {
   if (!tab || tab.mode !== "data") return undefined;
   if (tab.tableMeta?.columns.length) return tab.tableMeta;
-  const tableName = tab.title.trim();
+  const tableName = tab.tableMeta?.tableName.trim() || titleTableName(tab);
   if (!tableName) return undefined;
 
   // Keep filters usable when the table identity loaded but its column metadata did not.

--- a/packages/app-tests/tableDataTabMeta.test.ts
+++ b/packages/app-tests/tableDataTabMeta.test.ts
@@ -122,6 +122,35 @@ test("uses result columns when persisted table metadata has no columns", () => {
   );
 });
 
+test("prefers the tableMeta table name over a schema-qualified tab title", () => {
+  // Data tabs opened from the object browser are titled "<schema>.<table>";
+  // rebuilding SQL from the title would qualify the table twice (issue #3613).
+  const tableMeta = {
+    schema: "dbo",
+    tableName: "wcs_dispatch_task",
+    columns: [],
+    primaryKeys: [],
+  };
+
+  const meta = tableMetaForDataTab(tab({ title: "dbo.wcs_dispatch_task", schema: "dbo", tableMeta }));
+
+  assert.equal(meta?.tableName, "wcs_dispatch_task");
+  assert.equal(meta?.schema, "dbo");
+});
+
+test("strips the schema prefix from the tab title when no tableMeta exists", () => {
+  const meta = tableMetaForDataTab(tab({ title: "dbo.wcs_dispatch_task", schema: "dbo" }));
+
+  assert.equal(meta?.tableName, "wcs_dispatch_task");
+  assert.equal(meta?.schema, "dbo");
+});
+
+test("keeps a dotted tab title intact when it does not start with the schema", () => {
+  const meta = tableMetaForDataTab(tab({ title: "audit.2024_log", schema: "public" }));
+
+  assert.equal(meta?.tableName, "audit.2024_log");
+});
+
 test("does not infer table metadata for query tabs", () => {
   assert.equal(tableMetaForDataTab(tab({ mode: "query" })), undefined);
 });


### PR DESCRIPTION
## 问题

Fixes #3613

从对象浏览器（dbo 页签）打开表时，部分表报错：
`Invalid object name 'dbo.dbo.wcs_dispatch_task'`。而从左侧树打开正常，Ctrl+R 刷新后也正常。

## 根因

从对象浏览器打开的 data 页签标题是 `<schema>.<table>`（如 `dbo.wcs_dispatch_task`），而 `tableMetaForDataTab` 在列元数据尚未加载（`columns` 为空）时会**直接拿 `tab.title` 当表名**。此后任何 SQL 重建（总行数统计、刷新、筛选）都会再次做 schema 限定，拼出 `[dbo].[dbo.wcs_dispatch_task]`。

这与 issue 中的现象完全吻合：
- 左侧树打开的页签标题是裸表名 → 正常
- 元数据加载完成后 `columns` 非空 → 走正常分支，所以 Ctrl+R 后正常
- 只有「打开后元数据未就绪的窗口期/元数据加载失败」的表会触发 → 「部分表」报错

## 修复

1. `tableMetaForDataTab` 优先使用 `tableMeta.tableName`；标题兜底时剥离与 `tab.schema` 一致的前缀（`apps/desktop/src/lib/table/tableDataTabMeta.ts`）
2. `openTableTarget` 在页签建立/复用后**立即同步写入新表身份元数据**（`apps/desktop/src/composables/useNavigationTargets.ts`），消除两个隐患：
   - 复用 data 页签时旧 `tableMeta` 在异步构建窗口内指向上一张表
   - catalog 三段标题（`catalog.schema.table`）在无元数据窗口内被整串当作表名

已知取舍：若一张表的真实名字恰好是 `<schema>.<xxx>` 形式（表名本身含点且以所在 schema 开头）、且页签完全没有 tableMeta（仅极老的持久化会话），标题兜底会误剥前缀。该歧义从标题本身无法判定，而修复 2 已让所有生产打开路径都同步携带 tableMeta，实际影响面趋近于零。

## 验证

- 新增 3 个回归测试（`packages/app-tests/tableDataTabMeta.test.ts`）：
  - tableMeta 存在时优先其表名而非限定标题
  - 无 tableMeta 时正确剥离 schema 前缀
  - 点号表名不以 schema 开头时保持原样
- `pnpm check` 全绿（format / lint / typecheck / test）

改动模块：`apps/desktop`（lib 纯逻辑 + composable）、`packages/app-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
