### PR TITLE
fix: 对象浏览器表名排序与侧边栏保持一致

### DIFF
--- a/apps/desktop/src/lib/table/objectBrowserRows.ts
+++ b/apps/desktop/src/lib/table/objectBrowserRows.ts
@@ -1,5 +1,5 @@
 import type { ObjectInfo } from "@/types/database";
-import { createDatabaseObjectNameComparator, normalizeDatabaseObjectName } from "@/lib/table/tableTree";
+import { compareDatabaseObjectNames, normalizeDatabaseObjectName } from "@/lib/table/tableTree";
 import { parseSlashDelimitedRegexQuery } from "@/lib/common/searchPattern";
 
 export type ObjectBrowserRow = {
@@ -122,11 +122,12 @@ export function filterObjectBrowserRows(rows: ObjectBrowserRow[], query: string)
 
 export function sortObjectBrowserRows(rows: ObjectBrowserRow[], key: ObjectBrowserSortKey, direction: ObjectBrowserSortDirection): ObjectBrowserRow[] {
   const multiplier = direction === "asc" ? 1 : -1;
-  const compareNames = createDatabaseObjectNameComparator(rows.map((row) => row.displayName));
+  // Sort by natural visible name, matching the sidebar tree ordering
+  // (see fix "keep tables sorted by visible name" and issue #3604).
   return [...rows].sort((left, right) => {
-    const compared = key === "name" ? compareNames(left.displayName, right.displayName) : compareObjectBrowserValue(left[key], right[key], key, direction);
+    const compared = key === "name" ? compareDatabaseObjectNames(left.displayName, right.displayName) : compareObjectBrowserValue(left[key], right[key], key, direction);
     if (compared !== 0) return compared * multiplier;
-    return compareNames(left.displayName, right.displayName);
+    return compareDatabaseObjectNames(left.displayName, right.displayName);
   });
 }
 

--- a/apps/desktop/src/lib/table/tableTree.ts
+++ b/apps/desktop/src/lib/table/tableTree.ts
@@ -211,6 +211,12 @@ export function sortDatabaseObjectsByName<T>(items: readonly T[], getName: (item
   return [...items].sort((left, right) => databaseObjectNameCollator.compare(getName(left), getName(right)));
 }
 
+// Shared with the object browser so both sides of the UI list objects in the
+// same natural visible-name order as the sidebar tree (issue #3604).
+export function compareDatabaseObjectNames(left: string, right: string): number {
+  return databaseObjectNameCollator.compare(left, right);
+}
+
 export function mergeTableInfosIntoObjects(objects: readonly ObjectInfo[], tables: readonly TableInfo[], schema?: string): ObjectInfo[] {
   const merged = [...objects];
   const seen = new Set(

--- a/packages/app-tests/objectBrowserRows.test.ts
+++ b/packages/app-tests/objectBrowserRows.test.ts
@@ -193,7 +193,7 @@ test("object browser formats statistics for compact table cells", () => {
   assert.equal(formatObjectBrowserBytes(null), "");
 });
 
-test("object browser name sort keeps base-prefixed tables before prefixed variants", () => {
+test("object browser name sort keeps natural name order like the sidebar tree", () => {
   const rows = buildObjectBrowserRows({
     objects: [
       { name: "chat_staff", object_type: "TABLE", schema: "public" },
@@ -208,7 +208,27 @@ test("object browser name sort keeps base-prefixed tables before prefixed varian
 
   assert.deepEqual(
     sortObjectBrowserRows(rows, "name", "asc").map((row) => row.name),
-    ["staff", "staff_his", "chat_staff", "chat_staff_his"],
+    ["chat_staff", "chat_staff_his", "staff", "staff_his"],
+  );
+});
+
+test("object browser name sort does not relocate prefixed business tables by suffix", () => {
+  // Mirrors the sidebar regression test from "keep tables sorted by visible
+  // name" — both sides must list tables identically (issue #3604).
+  const rows = buildObjectBrowserRows({
+    objects: [
+      { name: "YonSuite_CurrentStock", object_type: "TABLE", schema: "dbo" },
+      { name: "CurrentStock", object_type: "TABLE", schema: "dbo" },
+      { name: "YonSuite_LocationStock", object_type: "TABLE", schema: "dbo" },
+    ],
+    database: "app",
+    fallbackSchema: "dbo",
+    needsSchema: true,
+  });
+
+  assert.deepEqual(
+    sortObjectBrowserRows(rows, "name", "asc").map((row) => row.name),
+    ["CurrentStock", "YonSuite_CurrentStock", "YonSuite_LocationStock"],
   );
 });
 


### PR DESCRIPTION
## 问题

Fixes #3604

左侧连接树展开的表名列表与右侧对象浏览器的表名排序不一致。

## 根因

上游 0aab07e9（`fix(sidebar): keep tables sorted by visible name`）已将**侧边栏**改回自然名称排序（`Intl.Collator` numeric + base），并添加了 `YonSuite_CurrentStock` 不得因后缀被挪到 `CurrentStock` 旁边的回归测试；但**对象浏览器**的 `sortObjectBrowserRows` 仍在使用旧的前缀优先比较器 `createDatabaseObjectNameComparator`，两侧排序规则从此分叉。

## 修复

从 `tableTree.ts` 导出侧边栏同款的自然名称比较器 `compareDatabaseObjectNames`（复用同一个模块级 `Intl.Collator` 实例，保证永不漂移），`sortObjectBrowserRows` 改用它，两侧排序完全一致。

## 验证

- 更新既有排序断言为自然顺序，并新增镜像上游侧边栏回归测试的用例（`CurrentStock` / `YonSuite_CurrentStock` / `YonSuite_LocationStock` 不被前缀规则重排）
- `pnpm check` 全绿（format / lint / typecheck / test）

改动模块：`apps/desktop/src/lib/table`、`packages/app-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
