### PR TITLE
fix(zookeeper): 修复慢连接超时

### DIFF
--- a/agents/drivers/zookeeper/src/main/java/com/dbx/agent/zookeeper/ZooKeeperAgent.java
+++ b/agents/drivers/zookeeper/src/main/java/com/dbx/agent/zookeeper/ZooKeeperAgent.java
@@ -32,7 +32,7 @@ public final class ZooKeeperAgent {
     private static final Gson GSON = new GsonBuilder().serializeNulls().create();
     private static final int DEFAULT_LIMIT = 100;
     private static final int DEFAULT_SESSION_TIMEOUT_MS = 30000;
-    private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 5000;
+    private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 15000;
     private static final int DEFAULT_BASE_SLEEP_TIME_MS = 250;
     private static final int DEFAULT_MAX_RETRIES = 2;
     private static final int DEFAULT_PORT = 2181;

--- a/agents/drivers/zookeeper/src/test/java/com/dbx/agent/zookeeper/ZooKeeperAgentTest.java
+++ b/agents/drivers/zookeeper/src/test/java/com/dbx/agent/zookeeper/ZooKeeperAgentTest.java
@@ -14,8 +14,16 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 final class ZooKeeperAgentTest {
     @AfterEach
@@ -134,6 +142,23 @@ final class ZooKeeperAgentTest {
                 "{\"connection\":{\"connect_string\":\"" + server.getConnectString() + "\"}}"
             ));
             Assertions.assertTrue(test.get("ok").getAsBoolean());
+        }
+    }
+
+    @Test
+    void defaultTimeoutAllowsSessionEstablishmentAfterFiveSeconds() throws Exception {
+        try (TestingServer server = new TestingServer();
+             DelayedTcpProxy proxy = new DelayedTcpProxy(server.getConnectString(), 5500)) {
+            long startedAt = System.nanoTime();
+            JsonObject connect = result(request(
+                1,
+                "connect",
+                "{\"connection\":{\"connect_string\":\"" + proxy.getConnectString() + "\"}}"
+            ));
+            long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+
+            Assertions.assertTrue(connect.get("ok").getAsBoolean());
+            Assertions.assertTrue(elapsedMs >= 5000, "expected delayed handshake, took " + elapsedMs + "ms");
         }
     }
 
@@ -674,5 +699,88 @@ final class ZooKeeperAgentTest {
         }
         Assertions.fail("expected listed row for " + key);
         return new JsonObject();
+    }
+
+    private static final class DelayedTcpProxy implements AutoCloseable {
+        private final ServerSocket listener;
+        private final InetSocketAddress target;
+        private final long delayMs;
+        private final ExecutorService executor;
+        private final Set<Socket> sockets = ConcurrentHashMap.newKeySet();
+
+        private DelayedTcpProxy(String targetConnectString, long delayMs) throws IOException {
+            this.listener = new ServerSocket(0);
+            this.target = ZooKeeperAgent.parseEndpoint(targetConnectString);
+            this.delayMs = delayMs;
+            this.executor = Executors.newCachedThreadPool(task -> {
+                Thread thread = new Thread(task, "dbx-zookeeper-delayed-proxy");
+                thread.setDaemon(true);
+                return thread;
+            });
+            executor.submit(this::acceptConnections);
+        }
+
+        private String getConnectString() {
+            return "127.0.0.1:" + listener.getLocalPort();
+        }
+
+        private void acceptConnections() {
+            while (!listener.isClosed()) {
+                try {
+                    Socket client = listener.accept();
+                    sockets.add(client);
+                    executor.submit(() -> forwardAfterDelay(client));
+                } catch (IOException error) {
+                    if (!listener.isClosed()) {
+                        throw new IllegalStateException("Delayed proxy failed to accept a connection", error);
+                    }
+                }
+            }
+        }
+
+        private void forwardAfterDelay(Socket client) {
+            try {
+                Thread.sleep(delayMs);
+                Socket server = new Socket();
+                sockets.add(server);
+                server.connect(target);
+                executor.submit(() -> copyUntilClosed(client, server));
+                copyUntilClosed(server, client);
+            } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                closeSocket(client);
+            } catch (IOException error) {
+                closeSocket(client);
+            }
+        }
+
+        private void copyUntilClosed(Socket source, Socket destination) {
+            try {
+                source.getInputStream().transferTo(destination.getOutputStream());
+            } catch (IOException ignored) {
+                // Closing either side is expected when a probe or client disconnects.
+            } finally {
+                closeSocket(source);
+                closeSocket(destination);
+            }
+        }
+
+        private void closeSocket(Socket socket) {
+            sockets.remove(socket);
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+                // Best effort cleanup for test sockets.
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            listener.close();
+            for (Socket socket : sockets) {
+                closeSocket(socket);
+            }
+            executor.shutdownNow();
+        }
     }
 }

--- a/crates/dbx-core/src/agent_connection.rs
+++ b/crates/dbx-core/src/agent_connection.rs
@@ -5,6 +5,7 @@ use crate::path_utils::expand_tilde;
 
 const OCEANBASE_ORACLE_COMPATIBLE_OJDBC_VERSION_KEY: &str = "compatibleOjdbcVersion";
 const OCEANBASE_ORACLE_COMPATIBLE_OJDBC_VERSION_PARAM: &str = "compatibleOjdbcVersion=8";
+const ZOOKEEPER_MIN_CONNECTION_TIMEOUT_MS: u64 = 15_000;
 
 pub fn agent_connect_params(config: &ConnectionConfig, host: &str, port: u16, database: &str) -> serde_json::Value {
     let agent_database = if config.db_type == DatabaseType::MongoDb {
@@ -44,7 +45,7 @@ pub fn agent_connect_params(config: &ConnectionConfig, host: &str, port: u16, da
     };
     let (agent_host, agent_port) = if is_h2_file_connection(config) { ("", 0) } else { (host, port) };
 
-    serde_json::json!({
+    let mut params = serde_json::json!({
         "host": agent_host,
         "port": agent_port,
         "port_explicit": config.sqlserver_port_explicit(),
@@ -64,7 +65,13 @@ pub fn agent_connect_params(config: &ConnectionConfig, host: &str, port: u16, da
         "informix_server": config.informix_server,
         "jdbc_driver_class": config.jdbc_driver_class.as_deref().unwrap_or(""),
         "jdbc_driver_paths": &config.jdbc_driver_paths,
-    })
+    });
+    if config.db_type == DatabaseType::ZooKeeper {
+        params["connection_timeout_ms"] = serde_json::json!(
+            (config.effective_connect_timeout_secs() * 1000).max(ZOOKEEPER_MIN_CONNECTION_TIMEOUT_MS)
+        );
+    }
+    params
 }
 
 fn oracle_uses_sysdba(config: &ConnectionConfig) -> bool {
@@ -718,11 +725,13 @@ mod tests {
     fn zookeeper_agent_params_preserve_configured_connect_string() {
         let mut cfg = config(DatabaseType::ZooKeeper, None);
         cfg.connection_string = Some("zk-1:2181,zk-2:2181/app".to_string());
+        cfg.connect_timeout_secs = 20;
 
         let params = agent_connect_params(&cfg, "127.0.0.1", 2181, "");
 
         assert_eq!(params["connection_string"], "zk-1:2181,zk-2:2181/app");
         assert_eq!(params["zookeeper_connect_string"], "zk-1:2181,zk-2:2181/app");
+        assert_eq!(params["connection_timeout_ms"], 20_000);
     }
 
     #[test]
@@ -733,6 +742,7 @@ mod tests {
 
         assert_eq!(params["connection_string"], "");
         assert_eq!(params["zookeeper_connect_string"], "zk.local:2281");
+        assert_eq!(params["connection_timeout_ms"], ZOOKEEPER_MIN_CONNECTION_TIMEOUT_MS);
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

- 将连接配置中的超时时间透传为 ZooKeeper agent 的 `connection_timeout_ms`
- ZooKeeper 保留 15 秒最低连接等待，用户配置更长超时时间时按配置生效
- 将 agent 默认连接超时从 5 秒恢复为 15 秒，避免 TCP 可达但 Session 建立较慢时误判失败
- 保留现有 TCP 可达性预探测和快速失败逻辑

## 根因

ZooKeeper agent 0.1.9 将内部连接超时从 15 秒缩短到 5 秒，但 DBX 未将连接编辑页的超时配置传递给 agent。对于 TCP 已连接、ZooKeeper Session 需要 5 秒以上才能建立的环境，agent 会先超时关闭，随后建立成功的 Session 又立即被关闭。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p dbx-core zookeeper_agent_params --lib`（2 passed）
- `./agents/gradlew -p agents :zookeeper:test --no-daemon`（通过）
- 新增延迟 TCP 代理回归测试：端口立即可达、ZooKeeper 协议转发延迟 5.5 秒
- 反向验证旧 5 秒默认值时该回归测试失败，恢复 15 秒后通过
- `git diff --check`

Fixes #3644