### PR TITLE
fix(zookeeper): 新建查询打开键浏览器

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1131,6 +1131,28 @@ async function newQuery() {
   const conn = connectionStore.getConfig(target.connectionId);
   if (!conn) return;
   connectionStore.activeConnectionId = target.connectionId;
+  const connectionTarget = quickConnectionOpenTarget(conn);
+  if (connectionTarget.kind !== "query") {
+    try {
+      await connectionStore.ensureConnected(target.connectionId);
+      if (connectionTarget.kind === "mq-admin") {
+        queryStore.openMqAdmin(target.connectionId);
+      } else if (connectionTarget.kind === "nacos-admin") {
+        await connectionStore.loadNacosNamespaces(target.connectionId);
+        queryStore.openNacosAdmin(target.connectionId);
+      } else {
+        queryStore.createTab(target.connectionId, "", `${conn.name}:keys`, connectionTarget.kind);
+      }
+    } catch (e: any) {
+      toast(
+        t("connection.connectFailed", {
+          message: translateBackendError(t, e?.message || String(e)),
+        }),
+        5000,
+      );
+    }
+    return;
+  }
   // Prefill the editor with `SELECT * FROM <focused table>` when enabled and a
   // table context (active data/structure tab or selected table node) is available.
   // Built before createTab so the tab opens with the content directly (no flash).
@@ -1173,6 +1195,20 @@ async function openConnectionQuery(connectionId: string) {
     try {
       await connectionStore.ensureConnected(connectionId);
       await connectionStore.loadNacosNamespaces(connectionId);
+    } catch (e: any) {
+      toast(
+        t("connection.connectFailed", {
+          message: translateBackendError(t, e?.message || String(e)),
+        }),
+        5000,
+      );
+    }
+    return;
+  }
+  if (initialTarget.kind === "etcd" || initialTarget.kind === "zookeeper") {
+    try {
+      await connectionStore.ensureConnected(connectionId);
+      queryStore.createTab(connectionId, "", `${connection.name}:keys`, initialTarget.kind);
     } catch (e: any) {
       toast(
         t("connection.connectFailed", {

--- a/apps/desktop/src/lib/__tests__/connection/connectionOpenTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionOpenTarget.spec.ts
@@ -28,6 +28,14 @@ describe("quickConnectionOpenTarget", () => {
     expect(quickConnectionOpenTarget(connection("nacos"))).toEqual({ kind: "nacos-admin" });
   });
 
+  it("opens Etcd connections in the key browser", () => {
+    expect(quickConnectionOpenTarget(connection("etcd"))).toEqual({ kind: "etcd" });
+  });
+
+  it("opens ZooKeeper connections in the key browser", () => {
+    expect(quickConnectionOpenTarget(connection("zookeeper"))).toEqual({ kind: "zookeeper" });
+  });
+
   it("opens regular connections in a query tab", () => {
     expect(quickConnectionOpenTarget({ ...connection("postgresql"), database: "app" })).toEqual({
       kind: "query",

--- a/apps/desktop/src/lib/connection/connectionOpenTarget.ts
+++ b/apps/desktop/src/lib/connection/connectionOpenTarget.ts
@@ -1,7 +1,7 @@
 import type { ConnectionConfig } from "@/types/database";
 import { resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
 
-export type QuickConnectionOpenTarget = { kind: "mq-admin" } | { kind: "nacos-admin" } | { kind: "query"; database: string };
+export type QuickConnectionOpenTarget = { kind: "mq-admin" } | { kind: "nacos-admin" } | { kind: "etcd" } | { kind: "zookeeper" } | { kind: "query"; database: string };
 
 export function quickConnectionOpenTarget(connection: Pick<ConnectionConfig, "db_type" | "database">, databaseOptions: string[] = []): QuickConnectionOpenTarget {
   if (connection.db_type === "mq") {
@@ -9,6 +9,12 @@ export function quickConnectionOpenTarget(connection: Pick<ConnectionConfig, "db
   }
   if (connection.db_type === "nacos") {
     return { kind: "nacos-admin" };
+  }
+  if (connection.db_type === "etcd") {
+    return { kind: "etcd" };
+  }
+  if (connection.db_type === "zookeeper") {
+    return { kind: "zookeeper" };
   }
   return { kind: "query", database: resolveDefaultDatabase(connection, databaseOptions) };
 }


### PR DESCRIPTION
## 变更说明

- 全局“新建查询”选中 ZooKeeper 连接时直接打开 ZooKeeper Keys 浏览器
- Etcd 连接同样打开 Keys 浏览器
- MQ/Nacos 连接分别进入对应管理页
- 快速打开 ZooKeeper/Etcd 连接时使用相同分流规则
- 避免非 SQL agent 落入通用 SQL 初始化并调用 `list_databases`

## 根因

全局 `newQuery()` 无条件创建 SQL 查询页，并在缺少数据库上下文时调用通用 `list_databases`。ZooKeeper agent 只提供 KV 能力，不支持该 SQL 元数据方法，因此连接已经成功后仍会显示：

`Agent RPC error (-1): Unknown method: list_databases`

本 PR 扩展现有 `quickConnectionOpenTarget()`，在创建 SQL 页和加载数据库列表之前分流到对应的专用页面。

## 验证

- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/connectionOpenTarget.spec.ts packages/app-tests/newQueryContext.test.ts`（9 passed）
- `git diff --check`

Related #3644
Follow-up to #3657