### PR TITLE
Fix：修复 Kingbase 表结构字段长度不回显

### DIFF
--- a/apps/desktop/src/lib/__tests__/table/tableStructureEditorState.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableStructureEditorState.spec.ts
@@ -24,6 +24,56 @@ import {
 } from "@/lib/table/tableStructureEditorState";
 
 describe("tableStructureEditorState", () => {
+  it("hydrates Kingbase type parameters returned separately from the data type", () => {
+    const columns = createColumnDrafts(
+      [
+        {
+          name: "display_name",
+          data_type: "varchar",
+          is_nullable: true,
+          column_default: null,
+          is_primary_key: false,
+          extra: null,
+          character_maximum_length: 255,
+        },
+        {
+          name: "amount",
+          data_type: "numeric",
+          is_nullable: false,
+          column_default: null,
+          is_primary_key: false,
+          extra: null,
+          numeric_precision: 12,
+          numeric_scale: 2,
+        },
+        {
+          name: "attempts",
+          data_type: "integer",
+          is_nullable: false,
+          column_default: null,
+          is_primary_key: false,
+          extra: null,
+          numeric_precision: 32,
+          numeric_scale: 0,
+        },
+        {
+          name: "code",
+          data_type: "character varying(64)",
+          is_nullable: true,
+          column_default: null,
+          is_primary_key: false,
+          extra: null,
+          character_maximum_length: 64,
+        },
+      ],
+      "kingbase",
+    );
+
+    expect(columns.map((column) => column.dataType)).toEqual(["varchar(255)", "numeric(12,2)", "integer", "character varying(64)"]);
+    expect(columns.map((column) => column.original?.data_type)).toEqual(["varchar(255)", "numeric(12,2)", "integer", "character varying(64)"]);
+    expect(dataTypeLengthInputValue("kingbase", columns[0]?.dataType ?? "")).toBe("255");
+  });
+
   it("parses Kingbase SQLServer compatibility identity metadata", () => {
     expect(parseExtraToColumnExtra("identity(10, 2)", "kingbase")).toEqual({
       autoIncrement: true,

--- a/apps/desktop/src/lib/table/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorState.ts
@@ -638,11 +638,30 @@ function columnDefaultForEditor(column: ColumnInfo, databaseType?: DatabaseType)
   return defaultValue;
 }
 
+const CHARACTER_LENGTH_METADATA_TYPES = new Set(["binary", "char", "character", "character varying", "nchar", "nvarchar", "nvarchar2", "varbinary", "varchar", "varchar2"]);
+const NUMERIC_PRECISION_METADATA_TYPES = new Set(["decimal", "number", "numeric"]);
+
+function columnDataTypeForEditor(column: ColumnInfo, databaseType?: DatabaseType): string {
+  const parsed = splitDataType(column.data_type);
+  if (parsed.params) return column.data_type;
+
+  const baseType = parsed.baseType.trim().replace(/\s+/g, " ");
+  const normalized = baseType.toLowerCase();
+  if (CHARACTER_LENGTH_METADATA_TYPES.has(normalized) && Number.isInteger(column.character_maximum_length) && Number(column.character_maximum_length) > 0) {
+    return combineDataTypeForDatabase(databaseType, baseType, String(column.character_maximum_length));
+  }
+  if (NUMERIC_PRECISION_METADATA_TYPES.has(normalized) && Number.isInteger(column.numeric_precision) && Number(column.numeric_precision) > 0) {
+    const scale = Number.isInteger(column.numeric_scale) && Number(column.numeric_scale) >= 0 ? `,${column.numeric_scale}` : "";
+    return combineDataTypeForDatabase(databaseType, baseType, `${column.numeric_precision}${scale}`);
+  }
+  return column.data_type;
+}
+
 export function createColumnDrafts(columns: ColumnInfo[], databaseType?: DatabaseType): EditableStructureColumn[] {
   return columns.map((column, index) => {
     const defaultValue = columnDefaultForEditor(column, databaseType);
     const enumValues = isMysqlEnumDataType(databaseType, column.data_type) ? [...(column.enum_values ?? [])] : undefined;
-    const dataType = enumValues?.length ? mysqlEnumDataType(enumValues) : column.data_type;
+    const dataType = enumValues?.length ? mysqlEnumDataType(enumValues) : columnDataTypeForEditor(column, databaseType);
     return {
       id: `existing:${column.name}`,
       name: column.name,


### PR DESCRIPTION
## 问题

Kingbase MySQL 兼容模式会将字段基础类型与长度、精度分别返回。表结构编辑器此前只读取 `data_type`，导致 `varchar(255)` 的长度在字段列表中不回显。

## 修改

- 在类型字符串不含参数时，从字段元数据补全字符长度和数值精度/小数位
- 保留已有参数的类型、自定义类型及整数类型，避免重复或错误拼接
- 同步编辑器原始类型基线，避免加载后被误判为字段类型变更
- 增加 Kingbase 兼容模式元数据回显的回归测试

## 测试

- `pnpm test`（429 个测试文件，3484 个用例通过）
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Fixes #3668