### PR TITLE
修复侧边栏跨连接数据库搜索

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -163,6 +163,12 @@ function isSimpleObjectSearchParent(node: TreeNode): boolean {
 }
 
 function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>[], refreshedNodeIds?: Set<string>) {
+  if (refreshedNodeIds && node.type === "connection" && node.connectionId) {
+    if (store.connectedIds.has(node.connectionId)) {
+      tasks.push(store.loadConnectedConnectionRootForSidebarSearch(node.connectionId));
+    }
+    if (node.connectionId !== store.activeConnectionId) return;
+  }
   if (refreshedNodeIds && isSimpleObjectSearchParent(node)) {
     refreshedNodeIds.add(node.id);
     tasks.push(store.refreshTreeNode(node));

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -479,14 +479,14 @@ async function toggle() {
   const databaseObjectGroup = node.type === "group-tables" || node.type === "group-views" || node.type === "group-materialized-views" || node.type === "group-procedures" || node.type === "group-functions" || node.type === "group-sequences" || node.type === "group-packages";
   if (databaseObjectGroup && connectionStore.isTreeNodeChildrenLoaded(node.id)) {
     node.isExpanded = !node.isExpanded;
-    if (wasExpanded) connectionStore.releaseCollapsedTreeNodeChildren(node.id);
+    if (wasExpanded && !connectionStore.sidebarSearchQuery) connectionStore.releaseCollapsedTreeNodeChildren(node.id);
     emit("node-toggled", node, wasExpanded);
     return;
   }
 
   if (node.isExpanded) {
     node.isExpanded = false;
-    connectionStore.releaseCollapsedTreeNodeChildren(node.id);
+    if (!connectionStore.sidebarSearchQuery) connectionStore.releaseCollapsedTreeNodeChildren(node.id);
     emit("node-toggled", node, wasExpanded);
     return;
   }

--- a/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
@@ -58,6 +58,95 @@ describe("connectionStore metadata loading", () => {
     setActivePinia(createPinia());
   });
 
+  it("loads missing database roots only for connected sidebar search targets", async () => {
+    const checkConnectionHealth = vi.fn().mockResolvedValue(undefined);
+    const listDatabases = vi.fn().mockResolvedValue([{ name: "dajia", comment: null }]);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth,
+      listDatabases,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { filterSidebarTree } = await import("@/lib/sidebar/sidebarSearchTree");
+    const store = useConnectionStore();
+    const active = { ...mysqlConnection(), id: "mysql-active", name: "localhost" };
+    const connected = { ...mysqlConnection(), id: "mysql-connected", name: "PLM-PRO" };
+    const disconnected = { ...mysqlConnection(), id: "mysql-disconnected", name: "offline" };
+    const nodes: TreeNode[] = [
+      {
+        id: active.id,
+        label: active.name,
+        type: "connection",
+        connectionId: active.id,
+        isExpanded: true,
+        children: [{ id: `${active.id}:dajia`, label: "dajia", type: "database", connectionId: active.id, database: "dajia", isExpanded: false }],
+      },
+      { id: connected.id, label: connected.name, type: "connection", connectionId: connected.id, isExpanded: false, children: [] },
+      { id: disconnected.id, label: disconnected.name, type: "connection", connectionId: disconnected.id, isExpanded: false, children: [] },
+    ];
+    store.connections = [active, connected, disconnected];
+    store.connectedIds = new Set([active.id, connected.id]);
+    store.activeConnectionId = active.id;
+    store.treeNodes = nodes;
+
+    await Promise.all(nodes.map((node) => store.loadConnectedConnectionRootForSidebarSearch(node.connectionId!)));
+
+    expect(listDatabases).toHaveBeenCalledTimes(1);
+    expect(listDatabases).toHaveBeenCalledWith(connected.id);
+    expect(checkConnectionHealth).not.toHaveBeenCalled();
+    expect(store.activeConnectionId).toBe(active.id);
+    expect(nodes.map((node) => node.isExpanded)).toEqual([true, false, false]);
+    expect(filterSidebarTree(nodes, "dajia", new Set()).map((node) => node.id)).toEqual([active.id, connected.id]);
+  });
+
+  it("does not collapse a connection whose normal root load is already in flight", async () => {
+    let resolveDatabases!: (databases: Array<{ name: string; comment: null }>) => void;
+    let markListStarted!: () => void;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
+    const listDatabases = vi.fn(
+      () =>
+        new Promise<Array<{ name: string; comment: null }>>((resolve) => {
+          resolveDatabases = resolve;
+          markListStarted();
+        }),
+    );
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      listDatabases,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    const connection = mysqlConnection();
+    const node: TreeNode = { id: connection.id, label: connection.name, type: "connection", connectionId: connection.id, isExpanded: false, children: [] };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [node];
+
+    const normalLoad = store.loadDatabases(connection.id);
+    const searchLoad = store.loadConnectedConnectionRootForSidebarSearch(connection.id);
+    await listStarted;
+    resolveDatabases([{ name: "dajia", comment: null }]);
+    await Promise.all([normalLoad, searchLoad]);
+
+    expect(listDatabases).toHaveBeenCalledTimes(1);
+    expect(node.isExpanded).toBe(true);
+  });
+
   it("renders simple-mode table children without waiting for supplemental objects", async () => {
     const tables: TableInfo[] = [{ name: "users", table_type: "TABLE", comment: null }];
     const listTables = vi.fn().mockResolvedValue(tables);

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -205,6 +205,7 @@ export type TreeClipboard =
 
 interface LoadTreeOptions {
   force?: boolean;
+  connectedOnly?: boolean;
   expectedSidebarSearchQuery?: string;
   searchFilter?: string;
   sidebarTableSearchParentId?: string;
@@ -2227,7 +2228,11 @@ export const useConnectionStore = defineStore("connection", () => {
         if (!node) return;
         node.isLoading = true;
         try {
-          await ensureConnected(connectionId);
+          if (options?.connectedOnly) {
+            if (!connectedIds.value.has(connectionId)) return;
+          } else {
+            await ensureConnected(connectionId);
+          }
           if (useCachedChildren(node, options)) return;
 
           const config = getConfig(connectionId);
@@ -2366,6 +2371,25 @@ export const useConnectionStore = defineStore("connection", () => {
       },
       options,
     );
+  }
+
+  async function loadConnectedConnectionRootForSidebarSearch(connectionId: string) {
+    if (!connectedIds.value.has(connectionId)) return;
+    const config = getConfig(connectionId);
+    if (!config || ["redis", "etcd", "zookeeper", "mongodb", "elasticsearch", "milvus", "qdrant", "weaviate", "chromadb", "mq", "nacos"].includes(config.db_type)) return;
+    const node = findNode(treeNodes.value, connectionId);
+    if (!node || node.type !== "connection" || node.isLoading || hasConnectionMetadataChildren(node.children)) return;
+    const scope = { kind: "connection-databases" as const, connectionId, driverProfile: metadataDriverProfile(config) };
+    if (metadataLoadCoordinator.has(scope)) return;
+
+    const wasExpanded = !!node.isExpanded;
+    node.isLoading = true;
+    try {
+      await loadDatabases(connectionId, { connectedOnly: true });
+    } finally {
+      node.isExpanded = wasExpanded;
+      node.isLoading = false;
+    }
   }
 
   async function loadRedisDatabases(connectionId: string) {
@@ -5369,6 +5393,7 @@ export const useConnectionStore = defineStore("connection", () => {
     disconnect,
     closeDatabaseConnection,
     ensureConnected,
+    loadConnectedConnectionRootForSidebarSearch,
     isTreeNodeChildrenLoaded,
     releaseCollapsedTreeNodeChildren,
     setBeforeConnectHandler,


### PR DESCRIPTION
## 修改概述

- 侧边栏搜索现在会覆盖所有已连接的关系型数据库连接，即使某个连接尚未在连接树中展开。
- 未连接或未启用的连接不会因为搜索而执行 `ensureConnected()`。
- 搜索期间不会修改 `activeConnectionId`，也不会改变各连接真实的展开/折叠状态。
- 修复搜索状态下折叠节点后，整条连接从搜索结果中消失的问题。

## 修复的问题

### 1. 只能搜索到第一个或已经展开连接中的数据库

此前侧边栏搜索只会遍历已经加载到本地连接树中的元数据。一个连接即使已经建立数据库连接，只要从未在侧边栏展开，其数据库根节点就尚未加载，因此该连接下名称匹配的数据库无法参与搜索过滤。

现在开始搜索时，会为 `connectedIds` 中已连接、但缺少数据库根节点的关系型数据库连接补充加载数据库列表。这个过程具有以下边界：

- 不会主动连接未连接或未启用的连接；
- 不会切换当前活动连接；
- 不会改变节点的真实展开状态；
- 更深层对象的实时刷新仍然只作用于当前 `activeConnectionId`；
- 复用现有元数据加载协调器，避免与正常展开操作重复请求，并避免并发加载覆盖展开状态。

### 2. 搜索状态下折叠连接会导致整条连接消失

搜索结果是基于真实连接树生成的过滤视图，但此前在过滤视图中执行折叠时，仍会触发正常连接树的大子树内存回收。如果真实树中的子节点被清理，连接就会失去用于匹配搜索条件的后代节点，随后整条连接会从搜索结果中消失。

现在搜索状态下的折叠只修改搜索结果的展示状态，不再清理真实连接树中的子节点。退出搜索后的正常折叠以及大子树内存回收行为保持不变。

## 验证

- `pnpm test`：447 个测试文件、3663 个测试全部通过
- `pnpm typecheck`：通过
- `pnpm build`：通过
- 已在本地 Tauri 开发版中使用多个已连接的 MySQL 连接验证实际效果

Fixes #3615
