### PR TITLE
支持通过 -- Name 注释自定义查询结果名称

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/queryResultSource.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryResultSource.spec.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { queryResultSourceLabel } from "@/lib/sql/queryResultSource";
+import { queryResultNameFromPreamble, queryResultSourceLabel } from "@/lib/sql/queryResultSource";
+
+describe("queryResultNameFromPreamble", () => {
+  it("uses the nearest non-empty Name line comment", () => {
+    expect(queryResultNameFromPreamble("-- Name: Old name\n-- unrelated\r\n  -- NAME :  Latest name  \r\n")).toBe("Latest name");
+    expect(queryResultNameFromPreamble("-- Name: kept\n-- Name:   \n")).toBe("kept");
+  });
+
+  it("ignores unrelated, malformed, and block comments", () => {
+    expect(queryResultNameFromPreamble("-- Name without colon\n/*\n-- Name: block\n*/\n-- ordinary comment\n")).toBeUndefined();
+  });
+});
 
 describe("queryResultSourceLabel", () => {
   it("uses the current database for an unqualified table", () => {

--- a/apps/desktop/src/lib/sql/queryResultSource.ts
+++ b/apps/desktop/src/lib/sql/queryResultSource.ts
@@ -7,6 +7,16 @@ export interface QueryResultSourceLabelOptions {
   databaseType?: DatabaseType;
 }
 
+export function queryResultNameFromPreamble(preamble: string): string | undefined {
+  let name: string | undefined;
+  const withoutBlockComments = preamble.replace(/\/\*[\s\S]*?\*\//g, "");
+  for (const line of withoutBlockComments.split(/\r?\n/)) {
+    const candidate = line.match(/^\s*--\s*name\s*:\s*(.*)$/i)?.[1]?.trim();
+    if (candidate) name = candidate;
+  }
+  return name;
+}
+
 function firstSourceOfKind(sources: SqlSemanticRowSource[], kind: SqlSemanticRowSource["kind"]): SqlSemanticRowSource | undefined {
   return sources.filter((source) => source.kind === kind).sort((left, right) => left.sourceSpan.start - right.sourceSpan.start)[0];
 }

--- a/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
@@ -127,6 +127,21 @@ describe("queryStore multi-statement errors", () => {
     });
   });
 
+  it("uses Name comments for their indexed query results", async () => {
+    mocks.executeMulti.mockResolvedValue([
+      { columns: ["id"], rows: [[2]], affected_rows: 0, execution_time_ms: 1, statement_index: 1 },
+      { columns: ["id"], rows: [[1]], affected_rows: 0, execution_time_ms: 1, statement_index: 0 },
+    ]);
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+    const sql = "-- Name: Users\nSELECT * FROM users;\n-- name : Orders\nSELECT * FROM orders";
+
+    await store.executeTabSql(tabId, sql);
+
+    expect(store.tabs.find((item) => item.id === tabId)?.results?.map((result) => result.sourceLabel)).toEqual(["Orders", "Users"]);
+  });
+
   it("does not promote an unmarked Error alias without type metadata as a batch failure", async () => {
     mocks.executeMulti.mockResolvedValue([
       { columns: ["value"], rows: [[1]], affected_rows: 0, execution_time_ms: 1 },

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -39,7 +39,7 @@ import { loadTableMetadata } from "@/lib/metadata/tableMetadataCache";
 import { buildTableSelectSql, quoteTableDataIdentifier } from "@/lib/table/tableSelectSql";
 import { connectionQueryExecutionSchema, effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from "@/lib/database/jdbcDialect";
 import { frontendQueryTimeoutSecsForSql, queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
-import { queryResultSourceLabel } from "@/lib/sql/queryResultSource";
+import { queryResultNameFromPreamble, queryResultSourceLabel } from "@/lib/sql/queryResultSource";
 import { sortDataGridRowIndexes, type DataGridSortDirection } from "@/lib/dataGrid/dataGridSort";
 import { normalizeResultPageSize } from "@/lib/dataGrid/paginationPageSize";
 import { executableStatementRanges, splitSqlStatementRanges } from "@/lib/sql/sqlStatementRanges";
@@ -154,6 +154,8 @@ function annotateQueryResultSources(results: QueryResult[], sql: string, databas
     const statement = statements[sourceIndex];
     if (!statement) continue;
     annotateQueryResultSource(result, statement.sql, database, databaseType, sourceOffset === undefined ? undefined : { from: sourceOffset + statement.from, to: sourceOffset + statement.to });
+    const customName = queryResultNameFromPreamble(sql.slice(statement.hitFrom, statement.from));
+    if (customName) result.sourceLabel = customName;
   }
   return results;
 }


### PR DESCRIPTION
## 变更内容

- 支持通过 `-- Name: ...` 前导行注释自定义 SQL 查询结果名称
- 未命名语句继续使用现有的表名推导结果
- 保持执行 SQL、来源语句范围和 `statement_index` 映射不变
- 增加名称解析及乱序多语句结果映射的回归测试

## 根因

前端语句切分器只在 `hitFrom` 到 `from` 的范围内保留前导注释，而结果注解使用的 `statement.sql` 从 `from` 开始，导致 `-- Name:` 注释在设置结果名称前被丢弃。

## 适用范围

名称从实际执行 SQL 的每条语句前导注释中读取。支持整段多语句执行，以及选区内包含命名注释的执行；不改变现有“执行当前语句”的解析行为。

## 验证

- 定向 Vitest：2 个文件、15 个测试通过
- `pnpm check`：格式检查、lint、类型检查和测试全部通过
- GitHub CI：全部相关检查通过

Fixes #3513