### PR TITLE
feat(grid): show connection name in data header

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1217,10 +1217,13 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
     <template v-else-if="activeTab.mode === 'data'">
       <div class="flex-1 min-h-0 flex flex-col">
         <div class="h-9 shrink-0 border-b bg-background/80 px-3 flex items-center gap-2 text-xs">
-          <span class="inline-flex items-center rounded border border-border bg-muted/50 px-2 py-0.5 font-medium truncate">
+          <span v-if="activeConnection?.name?.trim()" data-data-header-connection class="inline-flex max-w-48 min-w-0 items-center truncate rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground" :title="activeConnection.name">
+            {{ activeConnection.name }}
+          </span>
+          <span class="inline-flex max-w-48 min-w-0 items-center truncate rounded border border-border bg-muted/50 px-2 py-0.5 font-medium">
             {{ activeTab.tableMeta?.tableName || activeTab.title }}
           </span>
-          <span class="inline-flex items-center rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground truncate">
+          <span class="inline-flex max-w-56 min-w-0 items-center truncate rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground">
             <template v-if="activeTab.tableMeta?.schema">{{ activeTab.tableMeta.schema }}@</template>{{ databaseDisplayNameForTab(activeTab.connectionId, activeTab.database, t) }}
           </span>
           <span v-if="activeTab.mode === 'data' && activeTab.tableMeta" class="inline-flex shrink-0 items-center rounded border border-border bg-muted/30 px-2 py-0.5 font-medium text-muted-foreground tabular-nums"> {{ activeTab.tableMeta.columns.length }} {{ t("tree.columns") }} </span>

--- a/packages/app-tests/dataTabHeaderConnection.test.ts
+++ b/packages/app-tests/dataTabHeaderConnection.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+import { compileTemplate, parse } from "vue/compiler-sfc";
+
+const contentAreaPath = "apps/desktop/src/components/layout/ContentArea.vue";
+
+function dataModeTemplate(): string {
+  const source = readFileSync(contentAreaPath, "utf8");
+  const { descriptor, errors } = parse(source, { filename: contentAreaPath });
+  assert.deepEqual(errors, []);
+  assert.ok(descriptor.template);
+  const result = compileTemplate({ id: contentAreaPath, filename: contentAreaPath, source: descriptor.template.content });
+  assert.deepEqual(result.errors, []);
+
+  const start = descriptor.template.content.indexOf("activeTab.mode === 'data'");
+  const end = descriptor.template.content.indexOf("activeTab.mode === 'redis'", start);
+  assert.ok(start >= 0 && end > start, "ContentArea should keep a bounded data-mode template");
+  return descriptor.template.content.slice(start, end);
+}
+
+test("data tab header shows the active connection before the table context", () => {
+  const template = dataModeTemplate();
+  const connectionIndex = template.indexOf("data-data-header-connection");
+  const tableIndex = template.indexOf("activeTab.tableMeta?.tableName");
+
+  assert.ok(connectionIndex >= 0 && connectionIndex < tableIndex);
+  assert.match(template, /v-if="activeConnection\?\.name\?\.trim\(\)"/);
+  assert.match(template, /:title="activeConnection\.name"/);
+  assert.match(template, /data-data-header-connection class="[^"]*max-w-48[^"]*truncate/);
+});


### PR DESCRIPTION
Closes #3577

## Problem

Data tabs only showed the table and database context. When two connections contain the same database, schema, and table names, the active environment was ambiguous.

## Changes

- Show the active connection name before the table context in data-mode headers.
- Hide the badge when the connection or its name is unavailable.
- Truncate long context badges while preserving the full connection name in a tooltip and keeping toolbar actions available.
- Add a template regression test for data-mode scoping, ordering, and tooltip behavior.

## Reference

DBeaver includes the data source container name in SQL editor context tooltips (`SQLEditor#getTitleToolTip`) to make the active connection explicit.

## Tests

- `pnpm vitest run packages/app-tests/dataTabHeaderConnection.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with 10 pre-existing warnings)
- `pnpm test` (437 files, 3594 tests)
- `pnpm build`
- `pnpm exec oxfmt --check apps/desktop/src/components/layout/ContentArea.vue packages/app-tests/dataTabHeaderConnection.test.ts`

## Manual verification

The local web client started without console errors. Authenticated data-tab verification was not possible because the development environment requires an access password.

## Remaining risks

The long-name and narrow-pane behavior is covered by explicit truncation contracts and compilation tests but was not visually exercised in an authenticated desktop session.