### PR TITLE
fix(grid): stabilize header height during horizontal scroll

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -439,7 +439,8 @@ function headerColumnType(column: string, actualColIdx: number): string {
 }
 
 const reserveColumnTypeLine = computed(() => reserveDataGridHeaderLine(showColumnTypesInHeader.value, props.result.columns, (column, index) => headerColumnType(column, index)));
-const reserveColumnCommentLine = computed(() => reserveDataGridHeaderLine(showColumnCommentsInHeader.value, props.tableMeta?.columns ?? [], (column) => column.comment));
+// Match the rendered header columns so comments from unprojected metadata cannot add an empty row.
+const reserveColumnCommentLine = computed(() => reserveDataGridHeaderLine(showColumnCommentsInHeader.value, props.result.columns, (column) => headerColumnComment(column)));
 
 function shortTypeName(t: string): string {
   const s = t.toLowerCase();

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -192,6 +192,7 @@ import type { DataGridSortDirection, DataGridSortMode } from "@/lib/dataGrid/dat
 import { DATA_GRID_COMPACT_TOPBAR_WIDTH, type DataGridReloadIntent, type DataGridToolbarActionCapability, type DataGridToolbarAutoRefreshCapability, type DataGridToolbarSaveCapability } from "@/lib/dataGrid/dataGridToolbar";
 import { getTableMetadataCapabilities } from "@/lib/table/tableMetadataCapabilities";
 import { getTableStructureCapabilities } from "@/lib/table/tableStructureCapabilities";
+import { reserveDataGridHeaderLine } from "@/lib/dataGrid/dataGridHeaderLayout";
 import { supportsTableStructureEditing } from "@/lib/database/databaseCapabilities";
 import { rememberDataGridConditionHistory } from "@/lib/dataGrid/dataGridConditionHistory";
 import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
@@ -436,6 +437,9 @@ function headerColumnType(column: string, actualColIdx: number): string {
   });
   return resolved ? shortTypeName(compactHeaderColumnType(resolved)) : "";
 }
+
+const reserveColumnTypeLine = computed(() => reserveDataGridHeaderLine(showColumnTypesInHeader.value, props.result.columns, (column, index) => headerColumnType(column, index)));
+const reserveColumnCommentLine = computed(() => reserveDataGridHeaderLine(showColumnCommentsInHeader.value, props.tableMeta?.columns ?? [], (column) => column.comment));
 
 function shortTypeName(t: string): string {
   const s = t.toLowerCase();
@@ -7763,6 +7767,8 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     :tooltip-disabled="columnHeaderTooltipsDisabled"
                     :column-type="headerColumnType(col.name, col.actualColIdx)"
                     :column-comment="headerColumnComment(col.name)"
+                    :show-type-line="reserveColumnTypeLine"
+                    :show-comment-line="reserveColumnCommentLine"
                     :tooltip-column-type="columnTypeMap.get(col.name)"
                     :tooltip-column-comment="columnCommentMap.get(col.name)"
                     :type-class="typeColorClass(headerColumnType(col.name, col.actualColIdx))"

--- a/apps/desktop/src/components/grid/DataGridColumnHeader.vue
+++ b/apps/desktop/src/components/grid/DataGridColumnHeader.vue
@@ -15,6 +15,8 @@ defineProps<{
   columnComment?: string;
   tooltipColumnType?: string;
   tooltipColumnComment?: string;
+  showTypeLine?: boolean;
+  showCommentLine?: boolean;
   typeClass?: HTMLAttributes["class"];
   dragClass?: HTMLAttributes["class"];
   columnStyle?: CSSProperties;
@@ -51,8 +53,10 @@ const emit = defineEmits<{
       <span class="flex min-w-0 items-center gap-1 overflow-hidden">
         <span class="flex min-w-0 flex-1 flex-col overflow-hidden">
           <span class="min-w-0 truncate leading-4">{{ name }}</span>
-          <span v-if="columnType" class="min-w-0 truncate text-[10px] font-normal leading-3" :class="typeClass" :title="columnType">{{ columnType }}</span>
-          <span v-if="columnComment" class="min-w-0 truncate text-[10px] font-normal leading-3 text-muted-foreground" :title="columnComment">{{ columnComment }}</span>
+          <span v-if="showTypeLine" data-grid-header-type-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3" :class="[typeClass, { invisible: !columnType }]" :title="columnType || undefined" :aria-hidden="columnType ? undefined : true">{{ columnType }}</span>
+          <span v-if="showCommentLine" data-grid-header-comment-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3 text-muted-foreground" :class="{ invisible: !columnComment }" :title="columnComment || undefined" :aria-hidden="columnComment ? undefined : true">{{
+            columnComment
+          }}</span>
         </span>
         <slot name="actions" />
       </span>

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -212,6 +212,67 @@ describe("DataGridColumnHeader", () => {
     dispatch(handle, "dblclick");
     expect(autoFit).toHaveBeenCalledOnce();
   });
+
+  it("keeps configured type and comment lines mounted for columns without values", () => {
+    const empty = mountComponent(DataGridColumnHeader, {
+      name: "id",
+      actualColumnIndex: 0,
+      visibleColumnIndex: 0,
+      showTypeLine: true,
+      showCommentLine: true,
+      copyColumnNameLabel: "copy",
+      columnNameLabel: "name",
+      columnTypeLabel: "type",
+      columnCommentLabel: "comment",
+    });
+    const emptyType = findOne(empty.root, (node) => node.props["data-grid-header-type-line"] === "");
+    const emptyComment = findOne(empty.root, (node) => node.props["data-grid-header-comment-line"] === "");
+
+    expect(String(emptyType.props.class)).toContain("h-3");
+    expect(String(emptyType.props.class)).toContain("invisible");
+    expect(emptyType.props.title).toBeUndefined();
+    expect(String(emptyComment.props.class)).toContain("h-3");
+    expect(String(emptyComment.props.class)).toContain("invisible");
+    expect(emptyComment.props.title).toBeUndefined();
+
+    const populated = mountComponent(DataGridColumnHeader, {
+      name: "status",
+      actualColumnIndex: 1,
+      visibleColumnIndex: 1,
+      columnType: "varchar",
+      columnComment: "Current status",
+      showTypeLine: true,
+      showCommentLine: true,
+      copyColumnNameLabel: "copy",
+      columnNameLabel: "name",
+      columnTypeLabel: "type",
+      columnCommentLabel: "comment",
+    });
+    const populatedType = findOne(populated.root, (node) => node.props["data-grid-header-type-line"] === "");
+    const populatedComment = findOne(populated.root, (node) => node.props["data-grid-header-comment-line"] === "");
+
+    expect(String(populatedType.props.class)).not.toContain("invisible");
+    expect(populatedType.props.title).toBe("varchar");
+    expect(String(populatedComment.props.class)).not.toContain("invisible");
+    expect(populatedComment.props.title).toBe("Current status");
+  });
+
+  it("omits optional header lines when both display settings are off", () => {
+    const mounted = mountComponent(DataGridColumnHeader, {
+      name: "id",
+      actualColumnIndex: 0,
+      visibleColumnIndex: 0,
+      columnType: "number",
+      columnComment: "Identifier",
+      copyColumnNameLabel: "copy",
+      columnNameLabel: "name",
+      columnTypeLabel: "type",
+      columnCommentLabel: "comment",
+    });
+
+    expect(findAll(mounted.root, (node) => node.props["data-grid-header-type-line"] === "")).toHaveLength(0);
+    expect(findAll(mounted.root, (node) => node.props["data-grid-header-comment-line"] === "")).toHaveLength(0);
+  });
 });
 
 describe("DataGridFilterBuilder", () => {

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridHeaderLayout.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridHeaderLayout.spec.ts
@@ -21,4 +21,16 @@ describe("reserveDataGridHeaderLine", () => {
     expect(reserved).toBe(true);
     expect(visited).toEqual([0, 1, 2]);
   });
+
+  it("does not reserve a comment line for a comment on an unprojected column", () => {
+    const comments = new Map([["internal_id", "Not selected"]]);
+
+    expect(reserveDataGridHeaderLine(true, ["id", "name"], (column) => comments.get(column))).toBe(false);
+  });
+
+  it("reserves a comment line when a projected column has a comment", () => {
+    const comments = new Map([["name", "Display name"]]);
+
+    expect(reserveDataGridHeaderLine(true, ["id", "name"], (column) => comments.get(column))).toBe(true);
+  });
 });

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridHeaderLayout.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridHeaderLayout.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { reserveDataGridHeaderLine } from "@/lib/dataGrid/dataGridHeaderLayout";
+
+describe("reserveDataGridHeaderLine", () => {
+  it("reserves a line only when the setting and full-column content require it", () => {
+    const values = [{ text: "" }, { text: "later column" }];
+
+    expect(reserveDataGridHeaderLine(false, values, (value) => value.text)).toBe(false);
+    expect(reserveDataGridHeaderLine(true, values, (value) => value.text)).toBe(true);
+    expect(reserveDataGridHeaderLine(true, [{ text: "" }, { text: "  " }], (value) => value.text)).toBe(false);
+    expect(reserveDataGridHeaderLine(true, [], (value: { text: string }) => value.text)).toBe(false);
+  });
+
+  it("resolves all columns rather than relying on the currently rendered window", () => {
+    const visited: number[] = [];
+    const reserved = reserveDataGridHeaderLine(true, ["", "", "comment"], (value, index) => {
+      visited.push(index);
+      return value;
+    });
+
+    expect(reserved).toBe(true);
+    expect(visited).toEqual([0, 1, 2]);
+  });
+});

--- a/apps/desktop/src/lib/dataGrid/dataGridHeaderLayout.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridHeaderLayout.ts
@@ -1,0 +1,4 @@
+/** Resolve header height from the full column set so virtual-window changes cannot resize it. */
+export function reserveDataGridHeaderLine<T>(enabled: boolean, values: readonly T[], resolveText: (value: T, index: number) => string | null | undefined): boolean {
+  return enabled && values.some((value, index) => Boolean(resolveText(value, index)?.trim()));
+}


### PR DESCRIPTION
Closes #2114

## Problem

Column headers are horizontally virtualized, while type and comment rows were rendered only when each visible column had content. Scrolling from columns without comments to columns with comments could therefore change the header row height.

## Root cause

Header height was derived from the current virtual column window instead of the complete result and table metadata.

## Changes

- Determine type and comment row visibility from the full column set.
- Keep fixed-height placeholder rows mounted for visible columns without values.
- Omit the extra row when the setting is disabled or the complete table has no corresponding metadata.
- Preserve full type and comment tooltips while avoiding empty tooltip content.
- Keep the shared DOM header unchanged for both DOM and Canvas row renderers.

## Reference

DBeaver LightGrid computes one global `headerHeight` from the maximum header height across all top-level columns (`LightGrid#computeHeaderSizes`). This change applies the same full-column invariant to DBX virtualized headers.

## Tests

- `pnpm vitest run apps/desktop/src/lib/__tests__/dataGrid/dataGridHeaderLayout.spec.ts apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts` (10 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with 10 pre-existing warnings)
- `pnpm test` (437 files, 3597 tests)
- `pnpm build`
- Formatting check for all changed frontend files
- Re-ran the 10 targeted tests and typecheck against the final formatted commit.

## Manual verification

No reusable Oracle, PostgreSQL, or MySQL container was available. The local web client requires an access password, so authenticated horizontal-scroll testing could not be performed. Equivalent component coverage verifies full-column layout decisions, fixed placeholder height, disabled settings, no-comment tables, and tooltip behavior.

## Remaining risks

Oracle 12c and authenticated DOM/Canvas horizontal scrolling were not exercised in this environment. The fix is database-independent and does not alter the Canvas renderer or metadata loading path.