### PR TITLE
fix(results): keep output toolbar height stable

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -7366,7 +7366,8 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
     <CustomContextMenu :items="gridContextMenuItems" v-slot="{ onContextMenu }">
       <div v-if="hasData || canShowWhereSearch" class="flex-1 flex flex-col overflow-hidden" @contextmenu="onContextMenu">
         <!-- Search bar -->
-        <div ref="dataGridTopbarRef" v-if="showDataGridTopbar" class="data-grid-topbar-shell shrink-0 flex min-w-0 border-b bg-muted/20">
+        <!-- Result and standalone output views must share a fixed toolbar height to prevent layout shifts. -->
+        <div ref="dataGridTopbarRef" v-if="showDataGridTopbar" class="data-grid-topbar-shell flex h-7 min-w-0 shrink-0 border-b bg-muted/20">
           <div v-if="hasResultToolbarLeadingSlot" class="flex shrink-0 items-center border-r">
             <slot name="result-toolbar-leading" :compact="compactDataGridToolbar" />
           </div>

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1054,7 +1054,8 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
               </div>
             </div>
 
-            <div v-if="hasQueryOutput && showStandaloneResultToolbar" ref="standaloneResultToolbarRef" class="flex min-h-7 shrink-0 items-center border-b bg-muted/20">
+            <!-- Keep this fixed height in sync with the embedded DataGrid toolbar when switching result views. -->
+            <div v-if="hasQueryOutput && showStandaloneResultToolbar" ref="standaloneResultToolbarRef" class="flex h-7 shrink-0 items-center border-b bg-muted/20">
               <QueryResultViewSwitcher
                 :active-view="activeOutputView"
                 :can-show-result="canShowResultOutput"

--- a/packages/app-tests/queryResultToolbar.test.ts
+++ b/packages/app-tests/queryResultToolbar.test.ts
@@ -81,6 +81,18 @@ test("standalone result views use the same compact toolbar breakpoint", () => {
   assert.match(dataGrid, /dataGridTopbarWidth\.value < DATA_GRID_COMPACT_TOPBAR_WIDTH/);
 });
 
+test("embedded and standalone result toolbars share the same fixed height", () => {
+  const contentArea = source(contentAreaPath);
+  const dataGrid = source(dataGridPath);
+  const standaloneClasses = contentArea.match(/ref="standaloneResultToolbarRef" class="([^"]+)"/)?.[1].split(/\s+/) ?? [];
+  const embeddedClasses = dataGrid.match(/ref="dataGridTopbarRef"[^>]+class="([^"]+)"/)?.[1].split(/\s+/) ?? [];
+
+  assert.ok(standaloneClasses.includes("h-7"));
+  assert.ok(embeddedClasses.includes("h-7"));
+  assert.ok(!standaloneClasses.includes("min-h-7"));
+  assert.ok(!embeddedClasses.includes("min-h-7"));
+});
+
 test("DataGrid marks toolbar refresh separately from current-result reloads", () => {
   const dataGrid = source(dataGridPath);
 
@@ -91,8 +103,5 @@ test("DataGrid marks toolbar refresh separately from current-result reloads", ()
 test("Elasticsearch JSON refresh preserves multi-result query groups", () => {
   const contentArea = source(contentAreaPath);
 
-  assert.match(
-    contentArea,
-    /if \(activeElasticsearchJsonResponse\.value\) \{[\s\S]*?emit\("reload", activeResultSql\.value, undefined, undefined, undefined, undefined, undefined, "refresh"\);/,
-  );
+  assert.match(contentArea, /if \(activeElasticsearchJsonResponse\.value\) \{[\s\S]*?emit\("reload", activeResultSql\.value, undefined, undefined, undefined, undefined, undefined, "refresh"\);/);
 });


### PR DESCRIPTION
Closes #3361

## Problem

The tabular result view used the embedded DataGrid toolbar while summary, chart, and explain views used a standalone toolbar. Their height contracts differed, causing the result pane to move vertically when switching views.

## Changes

- Set both toolbar containers to the same fixed `h-7` height (28px).
- Preserve the existing compact breakpoint, filters, result switcher, and action slots.
- Keep Explain in the existing shared toolbar actions instead of moving controls in this focused fix.
- Add a regression test that compares exact class tokens on both containers.

## Reference

DBeaver ResultSetViewer keeps presentations within one shared status bar and toolbar management surface. This change follows the same stable-container behavior across DBX result presentations.

## Tests

- `pnpm vitest run packages/app-tests/queryResultToolbar.test.ts` (9 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with 10 pre-existing warnings)
- `pnpm test` (436 files, 3594 tests)
- `pnpm build`
- Formatting check for all changed files

## Manual verification

The local web client requires an access password, so authenticated switching between table, summary, chart, and explain views was not possible. The SFC compilation and exact class-token regression verify that both mounted toolbar paths use the same 28px height.

## Remaining risks

The toolbar bounding rectangles were not measured in an authenticated desktop session. The change does not alter toolbar content, responsive breakpoints, or result-view routing.