### PR TITLE
feat(grid): show column comments in condition suggestions

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -179,6 +179,7 @@ import { useDataGridSort } from "@/composables/useDataGridSort";
 import { useDataGridSearch, type DataGridSearchMatch } from "@/composables/useDataGridSearch";
 import { useDataGridResultLifecycle } from "@/composables/useDataGridResultLifecycle";
 import { useDataGridAutoRefresh } from "@/composables/useDataGridAutoRefresh";
+import type { DataGridConditionSuggestionInput } from "@/composables/useDataGridConditionEditor";
 import { useDataGridAsyncSurface } from "@/composables/useDataGridAsyncSurface";
 import { useDataGridFilterBuilder, type DataGridStructuredFilterRule } from "@/composables/useDataGridFilterBuilder";
 import { cloneDataGridStructuredFilterRules, loadDataGridStructuredFilterState, saveDataGridStructuredFilterState, type DataGridCachedServerColumnFilter, type DataGridStructuredFilterCacheState } from "@/lib/dataGrid/dataGridFilterBuilderPersistence";
@@ -410,6 +411,11 @@ const columnCommentMap = computed(() => {
     }
   }
   return map;
+});
+// Reuse loaded table metadata so condition suggestions never trigger an extra metadata request.
+const conditionColumnSuggestions = computed<DataGridConditionSuggestionInput[]>(() => {
+  if (!props.tableMeta?.columns) return props.result.columns;
+  return props.tableMeta.columns.map((column) => ({ value: column.name, detail: column.comment?.trim() || undefined }));
 });
 const dataGridTopbarWidth = ref(0);
 const showColumnCommentsInHeader = computed(() => settingsStore.editorSettings.showColumnCommentsInHeader);
@@ -7401,6 +7407,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   v-model:order-by-input="orderByInput"
                   v-model:filter-builder-open="filterBuilderOpen"
                   :columns="props.tableMeta?.columns.map((column) => column.name) ?? props.result.columns"
+                  :condition-columns="conditionColumnSuggestions"
                   :history-scope="conditionHistoryScope"
                   :can-use-where-search="canUseWhereSearch"
                   :compact="compactDataGridToolbar"

--- a/apps/desktop/src/components/grid/DataGridConditionEditor.vue
+++ b/apps/desktop/src/components/grid/DataGridConditionEditor.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, useId, watch, type CSSProperties } from "vue";
 import { ChevronDown, X } from "@lucide/vue";
-import { useDataGridConditionEditor, type DataGridConditionSuggestionProvider } from "@/composables/useDataGridConditionEditor";
+import { useDataGridConditionEditor, type DataGridConditionSuggestionInput, type DataGridConditionSuggestionProvider } from "@/composables/useDataGridConditionEditor";
 import { getDataGridConditionSuggestionPosition } from "@/lib/dataGrid/dataGridConditionSuggestionPosition";
 import type { DataGridConditionHistoryKind, DataGridConditionHistoryScope } from "@/lib/dataGrid/dataGridConditionHistory";
 
 const props = withDefaults(
   defineProps<{
     kind: DataGridConditionHistoryKind;
-    columns?: readonly string[];
+    columns?: readonly DataGridConditionSuggestionInput[];
     historyScope: DataGridConditionHistoryScope;
     placeholder?: string;
     ariaLabel?: string;
@@ -357,7 +357,8 @@ defineExpose({ focus, dismiss: editor.dismiss, rememberHistory: editor.rememberH
           "
           @mouseleave="hideHistoryPreview"
         >
-          <span data-condition-history-text class="min-w-0 flex-1 truncate font-mono">{{ suggestion.value }}</span>
+          <span data-condition-history-text data-condition-suggestion-value class="min-w-0 flex-1 truncate font-mono">{{ suggestion.value }}</span>
+          <span v-if="suggestion.kind === 'column' && suggestion.detail" data-condition-suggestion-detail class="ml-3 max-w-[55%] shrink-0 truncate text-muted-foreground" :title="suggestion.detail">{{ suggestion.detail }}</span>
           <button v-if="suggestion.kind === 'history'" type="button" class="ml-2 shrink-0 text-muted-foreground hover:text-foreground" @mousedown.stop.prevent="editor.deleteHistory(suggestion.value)">
             <X class="h-3 w-3" />
           </button>

--- a/apps/desktop/src/components/grid/DataGridQueryControls.vue
+++ b/apps/desktop/src/components/grid/DataGridQueryControls.vue
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import DataGridConditionEditor from "@/components/grid/DataGridConditionEditor.vue";
 import DataGridFilterBuilder from "@/components/grid/DataGridFilterBuilder.vue";
+import type { DataGridConditionSuggestionInput } from "@/composables/useDataGridConditionEditor";
 import type { DataGridStructuredFilterRule } from "@/composables/useDataGridFilterBuilder";
 import type { DataGridConditionHistoryScope } from "@/lib/dataGrid/dataGridConditionHistory";
 import type { DataGridContextFilterMode } from "@/lib/dataGrid/dataGridSql";
@@ -22,6 +23,7 @@ const props = defineProps<{
   whereInput: string;
   orderByInput: string;
   columns: readonly string[];
+  conditionColumns?: readonly DataGridConditionSuggestionInput[];
   historyScope: DataGridConditionHistoryScope;
   canUseWhereSearch: boolean;
   compact: boolean;
@@ -174,7 +176,7 @@ onUnmounted(onResizeEnd);
       <DataGridConditionEditor
         :model-value="whereInput"
         kind="where"
-        :columns="columns"
+        :columns="conditionColumns ?? columns"
         :history-scope="historyScope"
         placeholder="WHERE"
         :history-empty-text="t('grid.conditionHistoryEmpty')"
@@ -199,7 +201,7 @@ onUnmounted(onResizeEnd);
       <DataGridConditionEditor
         :model-value="orderByInput"
         kind="orderBy"
-        :columns="columns"
+        :columns="conditionColumns ?? columns"
         :history-scope="historyScope"
         placeholder="ORDER BY"
         :history-empty-text="t('grid.conditionHistoryEmpty')"

--- a/apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts
@@ -1,6 +1,6 @@
 import { effectScope, nextTick, ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useDataGridConditionEditor } from "@/composables/useDataGridConditionEditor";
+import { useDataGridConditionEditor, type DataGridConditionSuggestionInput } from "@/composables/useDataGridConditionEditor";
 import { rememberDataGridConditionHistory } from "@/lib/dataGrid/dataGridConditionHistory";
 
 const storage = new Map<string, string>();
@@ -41,10 +41,31 @@ describe("useDataGridConditionEditor", () => {
     expect(value.value).toBe("status = customer_name");
   });
 
+  it("keeps column details separate from inserted values and deduplicates by value", async () => {
+    const value = ref("");
+    const editor = useDataGridConditionEditor({
+      kind: "where",
+      value,
+      columns: [{ value: "customer_id", detail: " Customer identifier " }, { value: "customer_id", detail: "duplicate" }, { value: "customer_name", detail: "   " }, "customer_code"],
+      historyScope: {},
+    });
+
+    value.value = "cus";
+    await nextTick();
+    await vi.waitFor(() => expect(editor.suggestions.value).toHaveLength(3));
+    expect(editor.suggestions.value).toEqual([
+      { value: "customer_id", kind: "column", detail: "Customer identifier" },
+      { value: "customer_name", kind: "column" },
+      { value: "customer_code", kind: "column" },
+    ]);
+    expect(editor.accept(0)).toBe(true);
+    expect(value.value).toBe("customer_id");
+  });
+
   it("ignores stale asynchronous suggestion responses", async () => {
     vi.useFakeTimers();
     const value = ref("");
-    const resolvers = new Map<string, (values: string[]) => void>();
+    const resolvers = new Map<string, (values: DataGridConditionSuggestionInput[]) => void>();
     const editor = useDataGridConditionEditor({
       kind: "where",
       value,
@@ -62,9 +83,9 @@ describe("useDataGridConditionEditor", () => {
     vi.advanceTimersByTime(10);
     await nextTick();
 
-    resolvers.get("ord")?.(["order_id"]);
+    resolvers.get("ord")?.([{ value: "order_id", detail: "Order identifier" }]);
     await Promise.resolve();
-    expect(editor.suggestions.value.map((item) => item.value)).toEqual(["order_id"]);
+    expect(editor.suggestions.value).toEqual([{ value: "order_id", kind: "column", detail: "Order identifier" }]);
     resolvers.get("cus")?.(["customer_id"]);
     await Promise.resolve();
     expect(editor.suggestions.value.map((item) => item.value)).toEqual(["order_id"]);
@@ -115,7 +136,7 @@ describe("useDataGridConditionEditor", () => {
 
   it("maps Enter, Tab, arrows, and Escape without applying stale selections", async () => {
     const value = ref("");
-    const editor = useDataGridConditionEditor({ kind: "orderBy", value, columns: ["name"], historyScope: {} });
+    const editor = useDataGridConditionEditor({ kind: "orderBy", value, columns: [{ value: "name", detail: "Display name" }], historyScope: {} });
     value.value = "na";
     await nextTick();
     await vi.waitFor(() => expect(editor.suggestions.value).toHaveLength(1));

--- a/apps/desktop/src/composables/useDataGridConditionEditor.ts
+++ b/apps/desktop/src/composables/useDataGridConditionEditor.ts
@@ -3,9 +3,17 @@ import { forgetDataGridConditionHistory, loadDataGridConditionHistory, rememberD
 
 export type DataGridConditionSuggestionKind = "column" | "history";
 
+export type DataGridConditionSuggestionInput =
+  | string
+  | {
+      value: string;
+      detail?: string;
+    };
+
 export interface DataGridConditionSuggestion {
   value: string;
   kind: DataGridConditionSuggestionKind;
+  detail?: string;
 }
 
 export interface DataGridConditionSuggestionContext {
@@ -15,12 +23,12 @@ export interface DataGridConditionSuggestionContext {
   signal: AbortSignal;
 }
 
-export type DataGridConditionSuggestionProvider = (context: DataGridConditionSuggestionContext) => readonly string[] | Promise<readonly string[]>;
+export type DataGridConditionSuggestionProvider = (context: DataGridConditionSuggestionContext) => readonly DataGridConditionSuggestionInput[] | Promise<readonly DataGridConditionSuggestionInput[]>;
 
 export interface UseDataGridConditionEditorOptions {
   kind: DataGridConditionHistoryKind;
   value: Ref<string>;
-  columns?: MaybeRefOrGetter<readonly string[] | undefined>;
+  columns?: MaybeRefOrGetter<readonly DataGridConditionSuggestionInput[] | undefined>;
   historyScope: MaybeRefOrGetter<DataGridConditionHistoryScope>;
   suggestionProvider?: DataGridConditionSuggestionProvider;
   suggestionDebounceMs?: number;
@@ -43,6 +51,25 @@ function replaceActiveToken(kind: DataGridConditionHistoryKind, value: string, r
   const match = value.match(kind === "where" ? WHERE_TOKEN_PATTERN : ORDER_BY_TOKEN_PATTERN);
   if (!match) return value;
   return `${value.slice(0, -match[1].length)}${replacement}`;
+}
+
+function suggestionValue(suggestion: DataGridConditionSuggestionInput): string {
+  return typeof suggestion === "string" ? suggestion : suggestion.value;
+}
+
+function columnSuggestions(values: readonly DataGridConditionSuggestionInput[], limit: number): DataGridConditionSuggestion[] {
+  if (limit <= 0) return [];
+  const seen = new Set<string>();
+  const suggestions: DataGridConditionSuggestion[] = [];
+  for (const value of values) {
+    const valueText = suggestionValue(value);
+    if (seen.has(valueText)) continue;
+    seen.add(valueText);
+    const detail = typeof value === "string" ? undefined : value.detail?.trim() || undefined;
+    suggestions.push({ value: valueText, kind: "column", ...(detail ? { detail } : {}) });
+    if (suggestions.length >= limit) break;
+  }
+  return suggestions;
 }
 
 export function useDataGridConditionEditor(options: UseDataGridConditionEditorOptions) {
@@ -73,10 +100,13 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     historyOpen.value = false;
   }
 
-  function defaultSuggestions(token: string): readonly string[] {
+  function defaultSuggestions(token: string): readonly DataGridConditionSuggestionInput[] {
     const normalizedToken = token.toLowerCase();
     if (!normalizedToken) return [];
-    return (toValue(options.columns) ?? []).filter((column) => column.toLowerCase().startsWith(normalizedToken) && column.toLowerCase() !== normalizedToken);
+    return (toValue(options.columns) ?? []).filter((column) => {
+      const normalizedColumn = suggestionValue(column).toLowerCase();
+      return normalizedColumn.startsWith(normalizedToken) && normalizedColumn !== normalizedToken;
+    });
   }
 
   async function loadSuggestions(value: string, requestId: number, controller: AbortController) {
@@ -88,7 +118,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
       // A slower request must never replace suggestions for a newer editor value.
       if (controller.signal.aborted || requestId !== suggestionRequestId || options.value.value !== value || historyOpen.value) return;
       const limit = options.suggestionLimit ?? 8;
-      suggestions.value = [...new Set(values)].slice(0, limit).map((suggestion) => ({ value: suggestion, kind: "column" }));
+      suggestions.value = columnSuggestions(values, limit);
       highlightedIndex.value = suggestions.value.length > 0 ? 0 : -1;
     } catch (error) {
       if (!controller.signal.aborted && requestId === suggestionRequestId) {

--- a/packages/app-tests/dataGridConditionSuggestionDetails.test.ts
+++ b/packages/app-tests/dataGridConditionSuggestionDetails.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+import { compileScript, compileTemplate, parse } from "vue/compiler-sfc";
+
+const editorPath = "apps/desktop/src/components/grid/DataGridConditionEditor.vue";
+const controlsPath = "apps/desktop/src/components/grid/DataGridQueryControls.vue";
+const dataGridPath = "apps/desktop/src/components/grid/DataGrid.vue";
+
+function source(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function assertSfcCompiles(path: string): void {
+  const { descriptor, errors } = parse(source(path), { filename: path });
+  assert.deepEqual(errors, []);
+  assert.ok(descriptor.scriptSetup);
+  assert.ok(descriptor.template);
+  compileScript(descriptor, { id: path });
+  const result = compileTemplate({ id: path, filename: path, source: descriptor.template.content });
+  assert.deepEqual(result.errors, []);
+}
+
+test("condition suggestion components compile with structured column details", () => {
+  for (const path of [editorPath, controlsPath, dataGridPath]) assertSfcCompiles(path);
+});
+
+test("condition suggestions display comments without adding them to inserted values", () => {
+  const editor = source(editorPath);
+  const controls = source(controlsPath);
+  const dataGrid = source(dataGridPath);
+
+  assert.match(editor, /suggestion\.kind === 'column' && suggestion\.detail/);
+  assert.match(editor, /data-condition-suggestion-detail/);
+  assert.match(editor, /:title="suggestion\.detail"/);
+  assert.match(controls, /:columns="conditionColumns \?\? columns"/);
+  assert.equal((controls.match(/:columns="conditionColumns \?\? columns"/g) ?? []).length, 2);
+  assert.match(dataGrid, /:condition-columns="conditionColumnSuggestions"/);
+  assert.match(dataGrid, /detail: column\.comment\?\.trim\(\) \|\| undefined/);
+});


### PR DESCRIPTION
Closes #3671

## Problem

WHERE field suggestions only displayed column names. Tables with many similarly named columns were difficult to filter without the associated comments.

## Changes

- Extend condition suggestions with an optional display-only `detail` while preserving string inputs.
- Reuse loaded `tableMeta.columns` to attach comments without another metadata request.
- Render truncated comments beside column names in both WHERE and ORDER BY suggestions.
- Insert only the suggestion `value`; comments never become part of the condition text.
- Keep structured filters on their existing string-only column contract.
- Preserve history, keyboard navigation, asynchronous cancellation, stale-response protection, limits, and no-comment fallbacks.

## Reference

DBeaver `SQLCompletionProposal` separates `displayString`, `replacementString`, and description. This change follows the same display-versus-insertion separation for DBX condition suggestions.

## Tests

- `pnpm vitest run apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts packages/app-tests/dataGridConditionSuggestionDetails.test.ts` (8 tests)
- `pnpm typecheck`
- `pnpm lint` (passes with 10 pre-existing warnings)
- `pnpm test` (437 files, 3596 tests)
- `pnpm build`
- Formatting check for all changed files
- Re-ran the 8 targeted tests and typecheck against the final formatted commit.

## Manual verification

The local web environment requires an access password and no reusable comment-capable database container was available, so authenticated WHERE/ORDER BY interaction was not possible. Tests cover structured details, exact inserted values, duplicate fields, blank comments, asynchronous providers, history, keyboard acceptance, and both condition kinds.

## Remaining risks

The final dropdown layout and long-comment truncation were not visually exercised in an authenticated desktop session. No database request, SQL generation, or metadata loading behavior changed.