### PR TITLE
Fix：修复 GBase 8a 表 DDL 丢失原生定义细节

### DIFF
--- a/agents/drivers/gbase8a/src/main/java/com/dbx/agent/gbase8a/Gbase8aAgent.java
+++ b/agents/drivers/gbase8a/src/main/java/com/dbx/agent/gbase8a/Gbase8aAgent.java
@@ -171,36 +171,48 @@ public final class Gbase8aAgent extends ConfiguredJdbcAgent {
     }
 
     @Override
+    public String getTableDdl(String schema, String table) {
+        try {
+            String ddl = showCreateDefinition("TABLE", schema, table);
+            if (!ddl.isEmpty()) {
+                return ddl;
+            }
+        } catch (RuntimeException ignored) {
+            // Keep metadata-based DDL available for servers that restrict SHOW CREATE TABLE.
+        }
+        return super.getTableDdl(schema, table);
+    }
+
+    @Override
     public ObjectSource getObjectSource(String schema, String name, String objectType) {
+        String normalizedType = objectType.toUpperCase(Locale.ROOT);
+        if (!List.of("VIEW", "PROCEDURE", "FUNCTION").contains(normalizedType)) {
+            throw new IllegalArgumentException("Unsupported object type: " + objectType);
+        }
+        return new ObjectSource(name, normalizedType, schema, showCreateDefinition(normalizedType, schema, name));
+    }
+
+    private String showCreateDefinition(String objectType, String schema, String name) {
         return unchecked(() -> {
-            String normalizedType = objectType.toUpperCase(Locale.ROOT);
-            String sql = switch (normalizedType) {
-                case "VIEW" -> "SHOW CREATE VIEW ";
-                case "PROCEDURE" -> "SHOW CREATE PROCEDURE ";
-                case "FUNCTION" -> "SHOW CREATE FUNCTION ";
-                default -> throw new IllegalArgumentException("Unsupported object type: " + objectType);
-            };
             String qualifiedName = hasSchema(schema)
                 ? JdbcIdentifiers.INSTANCE.backtick(schema) + "." + JdbcIdentifiers.INSTANCE.backtick(name)
                 : JdbcIdentifiers.INSTANCE.backtick(name);
-
-            String source = "";
             try (Statement stmt = requireConnection().createStatement();
-                 ResultSet rs = stmt.executeQuery(sql + qualifiedName)) {
-                if (rs.next()) {
-                    // SHOW CREATE result layouts vary by GBase driver version, so locate the definition column by label.
-                    ResultSetMetaData metadata = rs.getMetaData();
-                    for (int index = 1; index <= metadata.getColumnCount(); index++) {
-                        String label = metadata.getColumnLabel(index);
-                        if (label != null && label.toUpperCase(Locale.ROOT).startsWith("CREATE ")) {
-                            String value = rs.getString(index);
-                            source = value == null ? "" : value;
-                            break;
-                        }
+                 ResultSet rs = stmt.executeQuery("SHOW CREATE " + objectType + " " + qualifiedName)) {
+                if (!rs.next()) {
+                    return "";
+                }
+                // SHOW CREATE result layouts vary by GBase driver version, so locate the definition column by label.
+                ResultSetMetaData metadata = rs.getMetaData();
+                for (int index = 1; index <= metadata.getColumnCount(); index++) {
+                    String label = metadata.getColumnLabel(index);
+                    if (label != null && label.toUpperCase(Locale.ROOT).startsWith("CREATE ")) {
+                        String value = rs.getString(index);
+                        return value == null ? "" : value;
                     }
                 }
+                return "";
             }
-            return new ObjectSource(name, normalizedType, schema, source);
         });
     }
 

--- a/agents/drivers/gbase8a/src/test/java/com/dbx/agent/gbase8a/Gbase8aAgentTest.java
+++ b/agents/drivers/gbase8a/src/test/java/com/dbx/agent/gbase8a/Gbase8aAgentTest.java
@@ -99,6 +99,25 @@ class Gbase8aAgentTest {
     }
 
     @Test
+    void getTableDdlUsesShowCreateToPreserveNativeColumnClauses() {
+        List<String> sql = new ArrayList<>();
+        String nativeDdl = "CREATE TABLE \"orders`archive\" (\n" +
+            "  \"UPDATE_TIME\" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'updated at'\n" +
+            ") ENGINE=EXPRESS DEFAULT CHARSET=utf8";
+        Gbase8aAgent agent = new Gbase8aAgent();
+        TestSupport.setPrivateConnection(agent, statementConnection(sql, resultSet(
+            new String[]{"Table", "Create Table"},
+            new Object[][]{{"orders`archive", nativeDdl}}
+        )));
+
+        String ddl = agent.getTableDdl("app`prod", "orders`archive");
+
+        Assertions.assertEquals(nativeDdl, ddl);
+        Assertions.assertTrue(ddl.contains("ON UPDATE CURRENT_TIMESTAMP"), ddl);
+        Assertions.assertEquals("SHOW CREATE TABLE `app``prod`.`orders``archive`", sql.get(0));
+    }
+
+    @Test
     void getObjectSourceUsesShowCreateForRoutines() {
         List<String> sql = new ArrayList<>();
         Gbase8aAgent agent = new Gbase8aAgent();


### PR DESCRIPTION
## 问题

GBase 8a 的表 DDL 此前由 JDBC 字段元数据重新拼装。驱动返回的字段默认值不包含 `ON UPDATE CURRENT_TIMESTAMP`，因此右键查看 DDL 时会丢失该子句，同时也可能遗漏引擎、字符集、表空间等 GBase 专有定义。

## 修改

- GBase 8a 表 DDL 优先直接使用 `SHOW CREATE TABLE` 的原生结果
- 按结果列标签定位 `Create Table`，兼容不同 JDBC 驱动的结果布局
- 原生查询不可用或结果为空时，保留现有元数据拼装作为兼容回退
- 复用现有 `SHOW CREATE` 提取逻辑，并增加字段更新子句与标识符转义测试

## 真实库验证

在 GBase 8a 8.6.2.43-R7-free.110605 上创建包含以下字段定义的临时表：

```sql
UPDATE_TIME timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
```

修复前 agent 返回的 DDL 缺少 `ON UPDATE CURRENT_TIMESTAMP`；修复后返回结果与数据库原生 `SHOW CREATE TABLE` 一致，并完整保留字段注释、`ENGINE=EXPRESS`、字符集和表空间。另验证了已有表 `orders_10k` 的 DDL 及视图 `v_city_sales` 的源码读取。临时表已清理。

## 自动化测试

- GBase 8a 定向测试与 shadow jar 重新构建通过
- `./gradlew test shadowJar --continue`：150 个任务通过
- agent 校验脚本、脚本单测及 jar 校验通过
- Oracle、Xugu 原生 agent 测试与构建通过

Fixes #3654