### PR TITLE
Fix：修复表数据标签字段注释缺失

### DIFF
--- a/apps/desktop/src/composables/useSidebarDataOpenRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarDataOpenRuntime.ts
@@ -7,7 +7,7 @@ import { uuid } from "@/lib/common/utils";
 import { appendDebugLog, isDebugLoggingEnabled } from "@/lib/backend/debugLog";
 import { effectiveDatabaseTypeForConnection, connectionObjectTreeNodeSchema, connectionObjectTreeQuerySchema } from "@/lib/database/jdbcDialect";
 import { getCachedTableMetadata, loadTableMetadata, TABLE_METADATA_CACHE_TTL_MS, tableMetadataToDataTabMeta } from "@/lib/metadata/tableMetadataCache";
-import { canApplyDataTabMetadata, findExistingDataTabCandidate, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
+import { canApplyDataTabMetadata, dataTabMetadataNeedsRefresh, findExistingDataTabCandidate, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
 import type { SidebarDataOpenRequest } from "@/lib/sidebar/sidebarDataOpenCoordinator";
 import { hasTreeNodeDatabaseContext } from "@/lib/sidebar/treeNodeContext";
 import { buildTableSelectSql } from "@/lib/table/tableSelectSql";
@@ -65,6 +65,57 @@ export function useSidebarDataOpenRuntime() {
       catalog: node.catalog,
       tableName: node.label,
     };
+    const canApplyTableMetadata = (targetTabId: string) =>
+      canApplyDataTabMetadata(
+        queryStore.tabs.find((tab) => tab.id === targetTabId),
+        dataTabTarget,
+        request?.signal,
+      );
+    const refreshTableMetaInBackground = async (targetTabId: string, ensureConnected = false) => {
+      if (!config) return;
+      const metadataStartedAt = performance.now();
+      openDataLog("info", "metadata:start", {
+        traceId,
+        elapsed: elapsed(),
+      });
+      try {
+        if (ensureConnected) await connectionStore.ensureConnected(node.connectionId);
+        const loadedMetadata = await loadTableMetadata({
+          connectionId: node.connectionId,
+          database: node.database,
+          schema: querySchema,
+          tableName: node.label,
+          tableType,
+          databaseType: metadataDatabaseType,
+          driverProfile: config.driver_profile || config.db_type,
+          catalog: node.catalog,
+          traceLogger: isDebugLoggingEnabled() ? (event) => openDataLog("debug", "metadata:trace", { sourceTraceId: traceId, ...event }) : undefined,
+        });
+        if (!canApplyTableMetadata(targetTabId)) {
+          openDataLog("info", "metadata:stale", {
+            traceId,
+            tabId: targetTabId,
+            columnCount: loadedMetadata.metadata.columns.length,
+            elapsed: elapsed(),
+          });
+          return;
+        }
+        const nextTableMeta = tableMetadataToDataTabMeta(loadedMetadata.metadata, tableSchema);
+        queryStore.setTableMeta(targetTabId, nextTableMeta);
+        openDataLog("info", "metadata:done", {
+          traceId,
+          tabId: targetTabId,
+          columnCount: nextTableMeta.columns.length,
+          primaryKeyCount: nextTableMeta.primaryKeys.length,
+          cacheStatus: loadedMetadata.cacheStatus,
+          ageMs: Math.round(loadedMetadata.ageMs),
+          elapsed: elapsed(),
+          metadataMs: Math.round(performance.now() - metadataStartedAt),
+        });
+      } catch (error) {
+        openDataLog("warn", "metadata:error", { traceId, tabId: targetTabId, elapsed: elapsed(), error });
+      }
+    };
     const existingDataTabCandidate = findExistingDataTabCandidate(queryStore.tabs, dataTabTarget, { openMode, reuseDataTab: settingsStore.editorSettings.reuseDataTab });
     const existingSameTableTab = existingDataTabCandidate?.match === "same-table" ? existingDataTabCandidate.tab : undefined;
     const resetReusedDataTabState = (tab: (typeof queryStore.tabs)[number]) => {
@@ -93,6 +144,10 @@ export function useSidebarDataOpenRuntime() {
     if (existingSameTableTab && canActivateExistingDataTableTab(existingSameTableTab, { activateExecuting: false })) {
       queryStore.switchTab(existingSameTableTab.id);
       logPhase("existing-tab-activated", { table: node.label });
+      if (dataTabMetadataNeedsRefresh(existingSameTableTab, DATA_TAB_METADATA_TTL_MS)) {
+        void refreshTableMetaInBackground(existingSameTableTab.id, true);
+        logPhase("metadata-started", { tabId: existingSameTableTab.id, reason: "existing-tab-stale" });
+      }
       return;
     }
 
@@ -171,12 +226,6 @@ export function useSidebarDataOpenRuntime() {
 
     // Helper to check if this openData call is still active (not superseded by a newer click)
     const isActive = () => (request?.isCurrent() ?? true) && queryStore.tabs.find((t) => t.id === tabId)?.executionId === openDataId;
-    const canApplyTableMetadata = () =>
-      canApplyDataTabMetadata(
-        queryStore.tabs.find((t) => t.id === tabId),
-        dataTabTarget,
-        request?.signal,
-      );
 
     try {
       openDataLog("info", "ensure-connected:start", { traceId, elapsed: elapsed() });
@@ -190,49 +239,6 @@ export function useSidebarDataOpenRuntime() {
       if (!config) throw new Error("Connection config not found");
 
       const limit = tableOpenPageLimit();
-      const refreshTableMetaInBackground = async () => {
-        const metadataStartedAt = performance.now();
-        openDataLog("info", "metadata:start", {
-          traceId,
-          elapsed: elapsed(),
-        });
-        try {
-          const loadedMetadata = await loadTableMetadata({
-            connectionId: node.connectionId,
-            database: node.database,
-            schema: querySchema,
-            tableName: node.label,
-            tableType,
-            databaseType: metadataDatabaseType,
-            driverProfile: config.driver_profile || config.db_type,
-            catalog: node.catalog,
-            traceLogger: isDebugLoggingEnabled() ? (event) => openDataLog("debug", "metadata:trace", { sourceTraceId: traceId, ...event }) : undefined,
-          });
-          if (!canApplyTableMetadata()) {
-            openDataLog("info", "metadata:stale", {
-              traceId,
-              tabId,
-              columnCount: loadedMetadata.metadata.columns.length,
-              elapsed: elapsed(),
-            });
-            return;
-          }
-          const nextTableMeta = tableMetadataToDataTabMeta(loadedMetadata.metadata, tableSchema);
-          queryStore.setTableMeta(tabId, nextTableMeta);
-          openDataLog("info", "metadata:done", {
-            traceId,
-            tabId,
-            columnCount: nextTableMeta.columns.length,
-            primaryKeyCount: nextTableMeta.primaryKeys.length,
-            cacheStatus: loadedMetadata.cacheStatus,
-            ageMs: Math.round(loadedMetadata.ageMs),
-            elapsed: elapsed(),
-            metadataMs: Math.round(performance.now() - metadataStartedAt),
-          });
-        } catch (error) {
-          openDataLog("warn", "metadata:error", { traceId, tabId, elapsed: elapsed(), error });
-        }
-      };
       const shouldRefreshTableMeta = !cachedTableMeta;
       if (cachedTableMeta) {
         openDataLog("info", "metadata:cache-hit", {
@@ -289,8 +295,8 @@ export function useSidebarDataOpenRuntime() {
       });
       openDataLog("info", "execute:done", { traceId, tabId, elapsed: elapsed() });
       logPhase("execute-tab-sql", { tabId });
-      if (shouldRefreshTableMeta && canApplyTableMetadata()) {
-        void refreshTableMetaInBackground();
+      if (shouldRefreshTableMeta && canApplyTableMetadata(tabId)) {
+        void refreshTableMetaInBackground(tabId);
         logPhase("metadata-started", { tabId });
       }
     } catch (e: any) {

--- a/apps/desktop/src/lib/__tests__/sidebar/dataTabOpenPolicy.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/dataTabOpenPolicy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canApplyDataTabMetadata, dataTabOpenModeFromTreeClick, findExistingDataTabCandidate } from "@/lib/sidebar/dataTabOpenPolicy";
+import { canApplyDataTabMetadata, dataTabMetadataNeedsRefresh, dataTabOpenModeFromTreeClick, findExistingDataTabCandidate } from "@/lib/sidebar/dataTabOpenPolicy";
 import type { QueryTab } from "@/types/database";
 
 function click(modifiers: Partial<Pick<MouseEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">> = {}) {
@@ -87,5 +87,27 @@ describe("dataTabOpenPolicy", () => {
     tab.tableMeta = { schema: "public", tableName: "orders", columns: [], primaryKeys: [] };
 
     expect(canApplyDataTabMetadata(tab, usersTarget, new AbortController().signal)).toBe(false);
+  });
+
+  it("refreshes missing, restored, and expired table metadata", () => {
+    const now = 100_000;
+    const ttl = 30_000;
+    const tab = dataTab("users", "users");
+
+    expect(dataTabMetadataNeedsRefresh(tab, ttl, now)).toBe(true);
+
+    tab.tableMeta = {
+      schema: "public",
+      tableName: "users",
+      columns: [{ name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null }],
+      primaryKeys: ["id"],
+    };
+    expect(dataTabMetadataNeedsRefresh(tab, ttl, now)).toBe(true);
+
+    tab.tableMetaUpdatedAt = now - ttl + 1;
+    expect(dataTabMetadataNeedsRefresh(tab, ttl, now)).toBe(false);
+
+    tab.tableMetaUpdatedAt = now - ttl;
+    expect(dataTabMetadataNeedsRefresh(tab, ttl, now)).toBe(true);
   });
 });

--- a/apps/desktop/src/lib/sidebar/dataTabOpenPolicy.ts
+++ b/apps/desktop/src/lib/sidebar/dataTabOpenPolicy.ts
@@ -3,7 +3,7 @@ import type { QueryTab, TreeNodeType } from "@/types/database";
 
 export type DataTabOpenMode = "default" | "new-tab";
 
-type DataTabLike = Pick<QueryTab, "id" | "mode" | "connectionId" | "database" | "schema" | "title" | "tableMeta">;
+type DataTabLike = Pick<QueryTab, "id" | "mode" | "connectionId" | "database" | "schema" | "title" | "tableMeta" | "tableMetaUpdatedAt">;
 
 export interface DataTabTarget {
   connectionId: string;
@@ -39,6 +39,11 @@ function isSameTable(tab: DataTabLike, target: DataTabTarget): boolean {
 
 export function canApplyDataTabMetadata(tab: DataTabLike | undefined, target: DataTabTarget, signal?: AbortSignal): boolean {
   return signal?.aborted !== true && tab !== undefined && isSameTable(tab, target);
+}
+
+export function dataTabMetadataNeedsRefresh(tab: DataTabLike, maxAgeMs: number, now = Date.now()): boolean {
+  if (!tab.tableMeta?.columns.length || tab.tableMetaUpdatedAt === undefined) return true;
+  return now - tab.tableMetaUpdatedAt >= maxAgeMs;
 }
 
 export function findExistingDataTabCandidate<T extends DataTabLike>(tabs: T[], target: DataTabTarget, options: { openMode: DataTabOpenMode; reuseDataTab: boolean }): ExistingDataTabCandidate<T> | undefined {


### PR DESCRIPTION
## 问题

表数据标签的字段元数据加载失败、被取消或标签从旧状态恢复后，再次点击同一张表只会激活已有标签，不会重新获取字段元数据，导致表头只能显示查询结果中的字段名和类型，缺少字段注释。

## 修复

- 激活已有同表标签时，检测字段元数据缺失、恢复状态无更新时间或元数据过期的情况
- 在后台重新加载字段元数据并更新表头，不重新执行表数据查询，也不清空 WHERE、ORDER BY 等标签状态
- 元数据返回前再次校验标签仍指向原表，避免异步结果写入已关闭或复用的标签
- 增加缺失、恢复及过期元数据的策略测试

## 验证

- PostgreSQL 真实实例：创建带两条字段注释的临时表，确认表数据表头显示字段注释
- 故障注入：首次字段元数据请求返回 503，确认表数据仍正常展示但无注释；解除阻断后再次点击同表，仅重新请求字段和索引元数据，未重复执行表数据查询，表头恢复两条字段注释
- `pnpm check`：format、lint、typecheck、test 全部通过

Closes #3679