### PR TITLE
修复当前语句执行丢失优化器提示

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -771,6 +771,14 @@ describe("buildExecutionCandidates", () => {
     expect(candidateKinds(candidates)).toEqual(["cursor", "all"]);
   });
 
+  it("preserves leading optimizer hints in current statement candidates", () => {
+    const hintedSql = "/*+ SET(polar_csi.enable_query on) SET(polar_csi.cost_threshold 0)*/\nselect count(1) from xxx";
+    const sql = `select 1;\n${hintedSql};`;
+    const candidates = buildExecutionCandidates(sql, indexOf(sql, "count"), "postgres");
+
+    expect(candidates[0].sql).toBe(hintedSql);
+  });
+
   it("uses the cursor statement for the first candidate when there is no selection", () => {
     const sql = "SELECT *\nFROM users\nWHERE active = 1";
     const candidates = buildExecutionCandidates(sql, indexOf(sql, "users"));

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -282,6 +282,7 @@ export function splitSqlStatementRanges(sql: string, databaseType?: DatabaseType
   let statementStart = -1;
   let statementEnd = -1;
   let statementHitStart = 0;
+  let pendingHintStart = -1;
   let customDelimiter: string | null = null;
   let state: QuoteState = "none";
   let dollarTag = "";
@@ -290,13 +291,17 @@ export function splitSqlStatementRanges(sql: string, databaseType?: DatabaseType
   const isWhitespace = (ch: string) => ch === " " || ch === "\t" || ch === "\r" || ch === "\n";
 
   const markContent = (pos: number) => {
-    if (statementStart === -1) statementStart = pos;
+    if (statementStart === -1) {
+      statementStart = pendingHintStart === -1 ? pos : pendingHintStart;
+      pendingHintStart = -1;
+    }
     statementEnd = pos + 1;
   };
 
   const flush = (to = statementEnd) => {
     if (statementStart === -1) {
       statementEnd = -1;
+      pendingHintStart = -1;
       return;
     }
     const trimmedTo = trimRangeEnd(sql, statementStart, to);
@@ -305,6 +310,7 @@ export function splitSqlStatementRanges(sql: string, databaseType?: DatabaseType
     }
     statementStart = -1;
     statementEnd = -1;
+    pendingHintStart = -1;
   };
 
   while (i < len) {
@@ -418,6 +424,7 @@ export function splitSqlStatementRanges(sql: string, databaseType?: DatabaseType
     }
     // Block comments consume until the closing */.
     if (ch === "/" && next === "*") {
+      if (statementStart === -1 && pendingHintStart === -1 && sql[i + 2] === "+") pendingHintStart = i;
       const close = sql.indexOf("*/", i + 2);
       i = close === -1 ? len : close + 2;
       continue;


### PR DESCRIPTION
## 变更内容

- 当前语句、强制当前语句和行号执行时保留语句前的 `/*+ ... */` 优化器提示
- 保持普通前导注释和仅含提示注释文本的现有非执行语义
- 增加 PolarDB for PostgreSQL 语法的回归测试

## 根因

前端 `splitSqlStatementRanges` 在提取当前语句范围时，会把语句正文之前的块注释全部跳过。完整文档执行和 Rust 后端仍保留原始 SQL，但当前语句相关路径直接使用前端范围中的 SQL，导致具有执行语义的 `/*+ SET(...) */` 提示未发送到数据库。

本次修复只在真正遇到语句正文后采用待定的 `/*+` 起点，并在每个语句边界清理状态，因此不会把普通注释或仅含提示的文本变成可执行语句。

## 验证

- 新增回归测试在修复前稳定失败，修复后定向测试 117 项全部通过
- `npx --yes node@22.13.0 scripts/run-check.mjs`
- `npx --yes --package=node@22.13.0 -- pnpm test:packages`
- `npx --yes --package=node@22.13.0 -- pnpm publish:dry-run`
- `git diff --check`

本地没有可用的 PolarDB for PostgreSQL 实例，因此未进行真实数据库联调；SQL 范围保留行为已由纯逻辑回归测试和全量前端检查覆盖。

Fixes #3569