### PR TITLE
修复 Manticore Search 连接初始化失败

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -696,10 +696,12 @@ enum MySqlSetupMode {
     Compatible,
 }
 
+const MYSQL_GROUP_CONCAT_MAX_LEN: u64 = 1_048_576;
+
 impl MySqlSetupMode {
-    fn group_concat_max_len_query(self) -> Option<&'static str> {
+    fn group_concat_max_len_query(self) -> Option<String> {
         match self {
-            Self::Standard => Some("SET SESSION group_concat_max_len = 1048576"),
+            Self::Standard => Some(format!("SET SESSION group_concat_max_len = {MYSQL_GROUP_CONCAT_MAX_LEN}")),
             Self::Compatible => None,
         }
     }
@@ -745,7 +747,10 @@ fn mysql_group_concat_setup_fallback_mode(setup_mode: MySqlSetupMode, error: &st
     let lower = error.to_ascii_lowercase();
     let setup_query_rejected =
         lower.contains("1193") || lower.contains("unknown system variable") || lower.contains("syntax error");
-    if lower.contains("group_concat_max_len") && setup_query_rejected {
+    let sphinxql_setup_query_rejected = lower.contains("sphinxql")
+        && lower.contains("only 0 and 1 could be used as boolean values")
+        && lower.contains(&format!("near '{MYSQL_GROUP_CONCAT_MAX_LEN}'"));
+    if (lower.contains("group_concat_max_len") && setup_query_rejected) || sphinxql_setup_query_rejected {
         return Some(MySqlSetupMode::Compatible);
     }
 
@@ -944,7 +949,7 @@ fn mysql_setup_queries_for_database_with_mode(
     // GROUP_CONCAT results. Skip it for MySQL protocol-compatible databases
     // such as old StarRocks versions that reject unknown MySQL variables.
     if let Some(query) = setup_mode.group_concat_max_len_query() {
-        queries.push(query.to_string());
+        queries.push(query);
     }
     // StarRocks/Doris expose external storage (Paimon, Hive, ...) through a
     // catalog. `SET catalog` must run *before* `USE <database>` (the database
@@ -4650,6 +4655,26 @@ UNIQUE KEY(`tenant_id`, `name``part`)
             mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error),
             Some(MySqlSetupMode::Compatible)
         );
+    }
+
+    #[test]
+    fn mysql_sphinxql_group_concat_boolean_error_retries_without_session_variable() {
+        let error = "MySQL connection failed: Server error: `ERROR 42000 (1064): sphinxql: only 0 and 1 could be used as boolean values near '1048576'`";
+
+        assert_eq!(
+            mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error),
+            Some(MySqlSetupMode::Compatible)
+        );
+    }
+
+    #[test]
+    fn mysql_sphinxql_boolean_error_retry_stays_scoped_to_group_concat_setup() {
+        for error in [
+            "Server error: sphinxql: only 0 and 1 could be used as boolean values near '42'",
+            "Server error: only 0 and 1 could be used as boolean values near '1048576'",
+        ] {
+            assert_eq!(mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error), None);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 变更内容

- 识别 SphinxQL/Manticore 对 `group_concat_max_len` 初始化语句返回的布尔值错误
- 命中该精确错误后复用现有 `Compatible` 连接回退，跳过不支持的 MySQL 会话变量
- 让初始化值由单一常量同时驱动 SQL 和错误识别，避免后续修改产生漂移
- 增加 issue 原始错误和两个近似错误的正负向回归测试

## 根因

标准 MySQL 连接初始化会执行：

```sql
SET SESSION group_concat_max_len = 1048576
```

现有兼容回退只识别包含 `group_concat_max_len`、未知变量或语法错误信息的响应。SphinxQL 返回的错误仅包含“只允许 0 或 1”以及出错值 `1048576`，没有返回变量名，因此分类器未命中，连接直接失败。

本次修复仅在错误同时包含 `sphinxql`、完整布尔值错误短语和当前初始化值时触发回退，不会把其他连接错误吞掉。专用 Manticore Search 连接类型原本已经使用兼容模式，本修复补齐以标准 MySQL 路径连接兼容服务时的兜底。

## 验证

- 新增正向测试在修复前稳定失败：实际为 `None`，期望为 `Some(Compatible)`
- `cargo test -p dbx-core mysql_sphinxql --lib`：2 项通过
- `cargo test -p dbx-core group_concat --lib`：7 项通过
- `cargo fmt --all -- --check`
- `make cargo-check-fast`
- `make cargo-test-fast`：完整非 live Rust 测试通过
- `git diff --check`
- Claude CLI 使用 `claude-fable-5[1m]`、`xhigh` 完成分诊、根因挑战、补丁审查和最终审查，结论均为 `GO`

本地没有可用的 Manticore Search 实例，因此未进行真实连接联调；回归测试使用 issue 报告中的完整错误文本验证回退分类。

Fixes #3667