### PR TITLE
修复深层连接分组路径显示不全

### DIFF
--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -329,7 +329,7 @@ function databaseOptionIsProduction(database: string): boolean {
           trigger-class="font-medium text-foreground"
           :display-name="connectionDisplayName"
           list-class="w-96 max-w-[calc(100vw-2rem)]"
-          item-class="h-9"
+          item-class="min-h-9 h-auto py-1"
           @update:model-value="(connectionId) => emit('changeConnection', connectionId)"
         >
           <template #trigger-label="{ label }">
@@ -344,7 +344,9 @@ function databaseOptionIsProduction(database: string): boolean {
             <div class="flex min-w-0 items-center gap-2">
               <DatabaseIcon :db-type="connectionIconType(connectionById(option))" class="h-3.5 w-3.5 shrink-0" />
               <div class="flex min-w-0 flex-1 items-center gap-2">
-                <TruncatedTextTooltip :text="connectionGroupLabel(option)" class="block min-w-0 max-w-48 shrink-0 rounded-sm bg-muted/70 px-1.5 py-0.5 text-[11px] text-muted-foreground" side="left" :side-offset="8" />
+                <span class="block min-w-0 max-w-48 shrink-0 whitespace-normal break-words rounded-sm bg-muted/70 px-1.5 py-0.5 text-[11px] leading-tight text-muted-foreground">
+                  {{ connectionGroupLabel(option) }}
+                </span>
                 <TruncatedTextTooltip :text="label" class="block min-w-[7rem] flex-1 text-sm font-medium" side="left" :side-offset="8" />
               </div>
             </div>

--- a/apps/desktop/src/lib/common/__tests__/searchableSelectLayout.spec.ts
+++ b/apps/desktop/src/lib/common/__tests__/searchableSelectLayout.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 const searchableSelectSource = readFileSync(new URL("../../../components/ui/searchable-select/SearchableSelect.vue", import.meta.url), "utf8");
 const dataTransferDialogSource = readFileSync(new URL("../../../components/transfer/DataTransferDialog.vue", import.meta.url), "utf8");
+const editorToolbarSource = readFileSync(new URL("../../../components/layout/EditorToolbar.vue", import.meta.url), "utf8");
 
 describe("SearchableSelect layout", () => {
   it("keeps slotted option labels inside a shrinkable overflow boundary", () => {
@@ -17,5 +18,12 @@ describe("SearchableSelect layout", () => {
 
     expect(truncatedConnectionLabels).toHaveLength(2);
     expect(fixedConnectionIcons).toHaveLength(2);
+  });
+
+  it("wraps deep connection group paths without hiding connection names", () => {
+    expect(editorToolbarSource).toContain('item-class="min-h-9 h-auto py-1"');
+    expect(editorToolbarSource).toMatch(/<span class="[^"]*max-w-48[^"]*shrink-0[^"]*whitespace-normal[^"]*break-words[^"]*">\s*\{\{ connectionGroupLabel\(option\) \}\}\s*<\/span>/);
+    expect(editorToolbarSource).toContain('<TruncatedTextTooltip :text="label" class="block min-w-[7rem] flex-1 text-sm font-medium"');
+    expect(editorToolbarSource).not.toContain('<TruncatedTextTooltip :text="connectionGroupLabel(option)"');
   });
 });


### PR DESCRIPTION
## 问题

右上角连接选择器在展示层级较深的连接分组时，会把完整分组路径限制在单行内并截断，用户无法直接看全连接所属位置。

## 根因

连接下拉项同时使用了固定高度 `h-9`，分组路径又通过 `TruncatedTextTooltip` 强制单行截断。分组层级增加后，路径既无法换行，列表项也无法随内容增高。

## 修复

- 仅调整编辑器工具栏中的连接选择器，不修改共享 `SearchableSelect`。
- 将连接项改为最小高度 36px、内容较多时自动增高。
- 分组路径允许正常换行和长词断行，完整内容直接可见。
- 保留连接名称的最小宽度与截断提示，避免路径挤占名称区域。
- 增加布局回归检查，锁定自动行高、路径换行和连接名称空间。

## 验证

- 回归测试先行：修复前新增用例按预期失败，修复后 3/3 通过。
- `pnpm exec oxfmt --check apps/desktop/src/components/layout/EditorToolbar.vue apps/desktop/src/lib/common/__tests__/searchableSelectLayout.spec.ts`
- `pnpm typecheck`
- `pnpm lint`：0 个错误，仅有与本次修改无关的既有警告。
- `pnpm test`（Node 22.13.0）：436 个测试文件、3594 个测试全部通过。
- `pnpm build`
- 隔离 Web 环境实际验证 1280px 与 800px 视口：六层长分组路径完整显示，无裁切或重叠；普通连接项仍保持原高度。界面截图见 PR 评论。
- Claude CLI 已完成候选排序、根因挑战、补丁审核和发布前审核，均为 `GO`。

Fixes #3675
