### PR TITLE
修复 SQL Server CTE 更新始终返回 0 行的问题

### DIFF
--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -1835,12 +1835,25 @@ fn sqlserver_batch_can_use_execute(sql: &str) -> bool {
 
 fn sqlserver_batch_may_return_result_set(sql: &str) -> bool {
     let tokens = top_level_sqlserver_tokens(sql);
-    tokens.iter().any(|token| matches!(token.text.as_str(), "SELECT" | "EXEC" | "EXECUTE" | "WITH" | "TABLE"))
+    let starts_with_cte_dml = tokens.first().is_some_and(|token| token.text == "WITH")
+        && tokens.iter().any(|token| matches!(token.text.as_str(), "INSERT" | "UPDATE" | "DELETE" | "MERGE"))
+        && crate::sql::split_sql_statements(sql).len() == 1;
+    tokens.iter().any(|token| {
+        matches!(token.text.as_str(), "SELECT" | "EXEC" | "EXECUTE" | "TABLE")
+            || (token.text == "WITH" && !starts_with_cte_dml)
+    })
 }
 
 fn sqlserver_dml_output_returns_rows(sql: &str) -> bool {
-    starts_with_executable_sql_keyword(sql, &["INSERT", "UPDATE", "DELETE", "MERGE"])
-        && first_sql_tokens(sql, 64).iter().any(|token| token.eq_ignore_ascii_case("OUTPUT"))
+    if starts_with_executable_sql_keyword(sql, &["INSERT", "UPDATE", "DELETE", "MERGE"]) {
+        return first_sql_tokens(sql, 64).iter().any(|token| token.eq_ignore_ascii_case("OUTPUT"));
+    }
+
+    let tokens = top_level_sqlserver_tokens(sql);
+    tokens.first().is_some_and(|token| token.text == "WITH")
+        && tokens
+            .iter()
+            .any(|token| token.text == "OUTPUT" && (token.start == 0 || sql.as_bytes()[token.start - 1] != b'@'))
 }
 
 fn contains_transaction_control(sql: &str) -> bool {
@@ -2062,6 +2075,51 @@ mod tests {
         assert!(sqlserver_batch_can_use_execute("DELETE FROM dbo.users WHERE id = 1;"));
         assert!(sqlserver_batch_can_use_execute(
             "MERGE dbo.t AS t USING dbo.s AS s ON t.id = s.id WHEN MATCHED THEN UPDATE SET name = s.name;"
+        ));
+    }
+
+    #[test]
+    fn sqlserver_cte_dml_batches_use_execute_for_affected_rows() {
+        assert!(sqlserver_batch_can_use_execute(
+            ";WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0 FROM dbo.users JOIN cte ON cte.id = users.id;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "WITH a AS (SELECT 1 AS id), b AS (SELECT id FROM a) DELETE dbo.users FROM dbo.users JOIN b ON b.id = users.id;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "WITH source AS (SELECT 1 AS id) MERGE dbo.users AS target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET active = 0;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users WITH (ROWLOCK) SET note = 'SELECT OUTPUT' /* WITH SELECT OUTPUT */;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = @output WHERE id = 1;"
+        ));
+
+        assert!(!sqlserver_batch_can_use_execute("WITH cte AS (SELECT 1 AS id) SELECT * FROM cte;"));
+        assert!(!sqlserver_batch_can_use_execute("WITH cte AS (SELECT 1 AS id) (SELECT id FROM cte);"));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) (SELECT id FROM cte) UNION (SELECT 2);"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) (SELECT id FROM cte); UPDATE dbo.users SET active = 0;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute("WITH XMLNAMESPACES ('urn:demo' AS ns) SELECT 1 AS id;"));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0 OUTPUT inserted.id;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0 OUTPUT inserted.id INTO dbo.audit_ids;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0; SELECT 1;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) INSERT INTO dbo.users(id) SELECT id FROM cte;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute("RESTORE HEADERONLY FROM DISK = 'backup.bak' WITH FILE = 1;"));
+        assert!(sqlserver_batch_can_use_execute(
+            "DECLARE @output INT = 1; UPDATE dbo.users SET active = @output WHERE id = 1;"
         ));
     }
 

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -1845,15 +1845,25 @@ fn sqlserver_batch_may_return_result_set(sql: &str) -> bool {
 }
 
 fn sqlserver_dml_output_returns_rows(sql: &str) -> bool {
-    if starts_with_executable_sql_keyword(sql, &["INSERT", "UPDATE", "DELETE", "MERGE"]) {
-        return first_sql_tokens(sql, 64).iter().any(|token| token.eq_ignore_ascii_case("OUTPUT"));
-    }
+    crate::sql::split_sql_statements(sql).iter().any(|statement| {
+        let tokens = top_level_sqlserver_tokens(statement);
+        let contains_dml = starts_with_executable_sql_keyword(statement, &["INSERT", "UPDATE", "DELETE", "MERGE"])
+            || (tokens.first().is_some_and(|token| token.text == "WITH")
+                && tokens.iter().any(|token| matches!(token.text.as_str(), "INSERT" | "UPDATE" | "DELETE" | "MERGE")));
+        if !contains_dml {
+            return false;
+        }
 
-    let tokens = top_level_sqlserver_tokens(sql);
-    tokens.first().is_some_and(|token| token.text == "WITH")
-        && tokens
-            .iter()
-            .any(|token| token.text == "OUTPUT" && (token.start == 0 || sql.as_bytes()[token.start - 1] != b'@'))
+        tokens.iter().enumerate().any(|(output_index, token)| {
+            if token.text != "OUTPUT" || (token.start > 0 && statement.as_bytes()[token.start - 1] == b'@') {
+                return false;
+            }
+
+            // SQL Server may combine OUTPUT ... INTO with a second OUTPUT clause.
+            // Only an OUTPUT whose rows are not routed before the next clause reaches the client.
+            !tokens[output_index + 1..].iter().take_while(|next| next.text != "OUTPUT").any(|next| next.text == "INTO")
+        })
+    })
 }
 
 fn contains_transaction_control(sql: &str) -> bool {
@@ -2109,10 +2119,28 @@ mod tests {
             "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0 OUTPUT inserted.id;"
         ));
         assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) DELETE dbo.users OUTPUT deleted.id FROM dbo.users JOIN cte ON cte.id = users.id;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH source AS (SELECT 1 AS id) MERGE dbo.users AS target USING source ON target.id = source.id WHEN MATCHED THEN DELETE OUTPUT deleted.id;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
             "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0 OUTPUT inserted.id INTO dbo.audit_ids;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) DELETE dbo.users OUTPUT deleted.id INTO dbo.audit_ids FROM dbo.users JOIN cte ON cte.id = users.id;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "WITH source AS (SELECT 1 AS id) MERGE dbo.users AS target USING source ON target.id = source.id WHEN MATCHED THEN DELETE OUTPUT deleted.id INTO dbo.audit_ids;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH source AS (SELECT 1 AS id) MERGE dbo.users AS target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET active = 0 OUTPUT inserted.id INTO dbo.audit_ids OUTPUT inserted.id;"
         ));
         assert!(!sqlserver_batch_can_use_execute(
             "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0; SELECT 1;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "WITH cte AS (SELECT 1 AS id) UPDATE dbo.users SET active = 0 OUTPUT inserted.id INTO dbo.audit_ids; SELECT 1;"
         ));
         assert!(!sqlserver_batch_can_use_execute(
             "WITH cte AS (SELECT 1 AS id) INSERT INTO dbo.users(id) SELECT id FROM cte;"
@@ -2151,6 +2179,18 @@ mod tests {
         ));
         assert!(!sqlserver_batch_can_use_execute("WITH cte AS (SELECT 1 AS id) SELECT * FROM cte;"));
         assert!(!sqlserver_batch_can_use_execute("UPDATE dbo.users SET active = 0 OUTPUT inserted.id WHERE id = 1;"));
+        assert!(sqlserver_batch_can_use_execute(
+            "UPDATE dbo.users SET active = 0 OUTPUT inserted.id INTO dbo.audit_ids WHERE id = 1;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "DELETE FROM dbo.users OUTPUT deleted.id INTO @audit_ids WHERE id = 1;"
+        ));
+        assert!(sqlserver_batch_can_use_execute(
+            "MERGE dbo.users AS target USING dbo.source AS source ON target.id = source.id WHEN MATCHED THEN DELETE OUTPUT deleted.id INTO dbo.audit_ids;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "UPDATE dbo.users SET active = 0 OUTPUT inserted.id INTO dbo.audit_ids OUTPUT inserted.id WHERE id = 1;"
+        ));
         assert!(sqlserver_batch_can_use_execute(
             "DECLARE @id INT = 1; UPDATE dbo.users SET active = 0 WHERE id = @id;"
         ));


### PR DESCRIPTION
## 问题

SQL Server 中以 `;WITH` 开头的 CTE 更新语句会始终显示受影响行数为 0，即使数据库实际已经完成更新。

## 根因

SQL Server 批次分类器把所有顶层 `WITH` 都视为可能返回结果集，导致 CTE 外层的 `UPDATE`、`DELETE` 和 `MERGE` 无法进入 `client.execute` 路径。Tiberius 的 `QueryStream` 不公开 DONE token 中的行数，因此原有回退路径只能返回 0。

## 修复

- 仅将单语句、以 CTE 开头且包含顶层 DML 的批次送入可统计 `rows_affected` 的执行路径。
- 保留 CTE `SELECT`、括号化查询、混合批次和 `OUTPUT` 子句的结果集路径。
- 区分 `OUTPUT` 子句与 `@output` 变量，避免扩大现有行为。
- 增加前导分号、多 CTE、表提示、括号化查询、尾随查询、`OUTPUT`、`RESTORE ... WITH` 和混合批次回归测试。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --locked --all-targets`
- `cargo test --workspace --locked`
- Claude CLI 使用 `claude-fable-5[1m]`、`xhigh` 完成分诊、根因质疑、补丁审核和最终审核，最终结论为 `GO`

所有离线测试通过；需要真实数据库的 `live_*` 测试按仓库配置保持忽略。Clippy 仅报告仓库已有警告，本次修改未新增警告。

## 限制

当前环境没有可用的真实 SQL Server，因此本次通过纯分类逻辑测试和 Tiberius 0.12.3 源码确认执行路径。CTE `INSERT ... SELECT` 继续沿用现有保守结果集路径，不在本 Issue 的更新语句修复范围内。

Closes #3676