### PR TITLE
✨feat(driverStore): 驱动下载支持跟随选择的下载源下载

### DIFF
--- a/apps/desktop/src/components/config/DriverStoreDialog.vue
+++ b/apps/desktop/src/components/config/DriverStoreDialog.vue
@@ -239,6 +239,7 @@ const usageSummary = computed(() => {
   ];
 });
 const canClearDownloadCache = computed(() => !clearingDownloadCache.value && installing.value === null && !upgradingAll.value && reinstallingJre.value === null && downloadCacheBytes.value > 0);
+const downloadSourceBusy = computed(() => refreshing.value || installing.value !== null || upgradingAll.value || queuedDriverInstalls.value.length > 0 || reinstallingJre.value !== null);
 const jreUsageByKey = computed(() => {
   const map = new Map<string, number>();
   for (const item of driverStoreUsage.value?.jres || []) {
@@ -328,6 +329,13 @@ async function forceRefresh() {
   } finally {
     refreshing.value = false;
   }
+}
+
+function setUpdateDownloadSource(value: unknown) {
+  if (value !== "official" && value !== "cnb" && value !== "atomgit") return;
+  if (value === settingsStore.editorSettings.updateDownloadSource) return;
+  settingsStore.updateEditorSettings({ updateDownloadSource: value });
+  void forceRefresh().catch(() => undefined);
 }
 
 async function loadJavaRuntimeConfig() {
@@ -1143,7 +1151,20 @@ watch(driverStoreTab, (tab) => {
                 {{ t("driverStore.storageTab") }}
               </TabsTrigger>
             </TabsList>
-            <div v-if="driverStoreTab !== 'storage'" class="flex items-center gap-2">
+            <div v-if="driverStoreTab !== 'storage'" class="flex flex-wrap items-center gap-2">
+              <div v-if="driverStoreTab === 'agent' && !isWeb" class="flex items-center gap-1.5">
+                <span class="text-xs text-muted-foreground">{{ t("settings.updateDownloadSource") }}</span>
+                <Select :model-value="settingsStore.editorSettings.updateDownloadSource" :disabled="downloadSourceBusy" @update:model-value="setUpdateDownloadSource">
+                  <SelectTrigger class="h-7 w-[160px] rounded-[6px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="official">{{ t("settings.updateDownloadSourceOfficial") }}</SelectItem>
+                    <SelectItem value="cnb">{{ t("settings.updateDownloadSourceCnb") }}</SelectItem>
+                    <SelectItem value="atomgit">{{ t("settings.updateDownloadSourceAtomgit") }}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
               <Button variant="ghost" size="sm" class="h-7 rounded-[6px] text-xs gap-1 text-muted-foreground" :disabled="importingZip" @click="importOfflineZip">
                 <FileUp class="h-3.5 w-3.5" />
                 {{ importingZip ? t("driverStore.importing") : t("driverStore.importOfflinePackage") }}

--- a/packages/app-tests/driverDownloadSource.test.ts
+++ b/packages/app-tests/driverDownloadSource.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "vitest";
+
+function source(relativePath: string): string {
+  return readFileSync(path.resolve(relativePath), "utf8");
+}
+
+test("shares the configured download source with agent driver management", () => {
+  const driverStore = source("apps/desktop/src/components/config/DriverStoreDialog.vue");
+  const backendApi = source("apps/desktop/src/lib/backend/api.ts");
+
+  assert.match(driverStore, /driverStoreTab === 'agent' && !isWeb/);
+  assert.match(driverStore, /:model-value="settingsStore\.editorSettings\.updateDownloadSource"/);
+  assert.match(driverStore, /settingsStore\.updateEditorSettings\(\{ updateDownloadSource: value \}\)/);
+  assert.match(driverStore, /void forceRefresh\(\)\.catch\(\(\) => undefined\)/);
+
+  assert.match(backendApi, /backend\.listInstalledAgents\(useSettingsStore\(\)\.editorSettings\.updateDownloadSource\)/);
+  assert.match(backendApi, /backend\.installAgent\(dbType, useSettingsStore\(\)\.editorSettings\.updateDownloadSource\)/);
+  assert.match(backendApi, /backend\.upgradeAllAgents\(useSettingsStore\(\)\.editorSettings\.updateDownloadSource\)/);
+  assert.match(backendApi, /backend\.reinstallJre\(jreKey, useSettingsStore\(\)\.editorSettings\.updateDownloadSource\)/);
+});


### PR DESCRIPTION
- 新增下载源选择器，支持官方、cnb 和 atomgit 选项
- 更新设置存储以反映所选下载源
- 添加计算属性以处理下载源的忙碌状态

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="1287" height="564" alt="image" src="https://github.com/user-attachments/assets/854ca319-c3b7-410a-bd18-bbe70026e8b0" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

切换下载源之后，在终端监听：

```
while true; do
  find "$HOME/.dbx/agents" -type f -name '*.download.source' -exec grep -H '' {} \;
  sleep 0.2
done
```

点击下载，可以看到下载的源地址。

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
close #3705