### PR TITLE
Fix：修复 WHERE/ORDER BY 展开输入框内容重叠

### DIFF
--- a/apps/desktop/src/components/grid/DataGridConditionEditor.vue
+++ b/apps/desktop/src/components/grid/DataGridConditionEditor.vue
@@ -44,7 +44,7 @@ const overlayRef = ref<HTMLTextAreaElement>();
 const controlRef = ref<HTMLDivElement>();
 const dropdownRef = ref<HTMLDivElement>();
 const expanded = ref(false);
-const expandedRect = ref({ left: 0, top: 0, width: 0 });
+const expandedRect = ref({ left: 0, top: 0, width: 0, controlsTop: 0, inputTop: 0, prefix: 0, suffix: 28 });
 const expandedHeight = ref(56);
 const suggestionPosition = ref({ left: 0, top: 0, width: 180 });
 const historyPreview = ref<{ value: string; left: number; top: number; maxWidth: number; arrowTop: number; side: "left" | "right" } | null>(null);
@@ -71,6 +71,10 @@ const suggestionStyle = computed<CSSProperties>(() => ({
   width: `${suggestionPosition.value.width}px`,
 }));
 const overlayStyle = computed<CSSProperties>(() => ({
+  "--data-grid-condition-controls-top": `${expandedRect.value.controlsTop}px`,
+  "--data-grid-condition-input-top": `${expandedRect.value.inputTop}px`,
+  "--data-grid-condition-prefix-indent": `${expandedRect.value.prefix}px`,
+  "--data-grid-condition-suffix-width": `${expandedRect.value.suffix}px`,
   left: `${expandedRect.value.left}px`,
   top: `${expandedRect.value.top}px`,
   width: `${expandedRect.value.width}px`,
@@ -109,6 +113,23 @@ function measureExpandedHeight(input: HTMLTextAreaElement) {
   return Math.min(Math.max(56, lineHeight * 2.5, contentHeight), Math.min(260, availableHeight));
 }
 
+function measureExpandedRect(input: HTMLTextAreaElement) {
+  const inputRect = input.getBoundingClientRect();
+  const control = controlRef.value;
+  const controlRect = control?.getBoundingClientRect() ?? inputRect;
+  const controlsRect = control?.firstElementChild?.getBoundingClientRect() ?? controlRect;
+  const horizontalInset = 8;
+  return {
+    left: controlRect.left - horizontalInset,
+    top: controlRect.top,
+    width: controlRect.width + horizontalInset * 2,
+    controlsTop: Math.max(0, controlsRect.top - controlRect.top),
+    inputTop: Math.max(0, inputRect.top - controlRect.top),
+    prefix: Math.max(0, inputRect.left - controlRect.left),
+    suffix: Math.max(28, controlRect.right - inputRect.right),
+  };
+}
+
 function updateSuggestionPosition() {
   void nextTick(() => {
     const target = activeEditor.value;
@@ -128,7 +149,7 @@ function resizeEditor(forceExpand = false) {
     const focused = document.activeElement === input || document.activeElement === overlayRef.value;
     const nextExpanded = focused && shouldExpand(input) && (forceExpand || expanded.value);
     if (nextExpanded) {
-      expandedRect.value = input.getBoundingClientRect();
+      expandedRect.value = measureExpandedRect(input);
       expandedHeight.value = measureExpandedHeight(input);
     }
     expanded.value = nextExpanded;

--- a/apps/desktop/src/components/grid/DataGridQueryControls.vue
+++ b/apps/desktop/src/components/grid/DataGridQueryControls.vue
@@ -118,7 +118,7 @@ onUnmounted(onResizeEnd);
         <PopoverTrigger as-child>
           <button
             type="button"
-            class="relative flex h-5 w-5 shrink-0 items-center justify-center rounded border text-[11px] font-medium transition-colors"
+            class="relative flex h-5 w-5 -translate-x-1 shrink-0 items-center justify-center rounded border text-[11px] font-medium transition-colors"
             :class="filterButtonActive ? 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/15' : 'border-border/70 text-muted-foreground hover:bg-accent hover:text-foreground'"
             :disabled="!canUseWhereSearch"
             @click="emit('ensureRule')"


### PR DESCRIPTION
## 变更说明

- 修复长条件展开后，`WHERE` / `ORDER BY` 标签与首行文字重叠的问题
- 根据完整控件的实际尺寸动态计算展开层位置、首行缩进及右侧按钮留白
- 扩展悬浮输入框左右边界，并调整筛选按钮间距，避免控件边缘互相遮挡
- 保持调整 WHERE/ORDER BY 宽度及清除按钮显隐时的布局同步

## 验证

- [x] 在 macOS 客户端实际验证 WHERE 长条件自动展开及多行输入
- [x] 验证历史、清除和筛选按钮布局
- [x] `pnpm check`（format、lint、typecheck、test）