### PR TITLE
Style：降低生产环境水印视觉干扰

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -800,7 +800,7 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
         <Pane class="min-h-0" :size="editorPaneSize" :min-size="resultsPaneOpen ? 15 : 100">
           <div class="h-full flex flex-col relative">
             <div v-if="activeProductionContext.active" class="production-watermark pointer-events-none absolute inset-0 z-10 grid select-none" aria-hidden="true">
-              <span v-for="index in 4" :key="index" class="production-watermark__label whitespace-nowrap font-mono text-6xl font-extrabold text-red-700/[0.24] dark:text-red-200/[0.2]">{{ productionWatermarkText }}</span>
+              <span v-for="index in 4" :key="index" class="production-watermark__label whitespace-nowrap font-mono text-6xl font-extrabold text-red-700/[0.12] dark:text-red-200/[0.1]">{{ productionWatermarkText }}</span>
             </div>
             <QueryEditor
               ref="queryEditorRef"


### PR DESCRIPTION
## 变更说明

- 将日间模式生产环境水印不透明度由 `24%` 降至 `12%`
- 将夜间模式生产环境水印不透明度由 `20%` 降至 `10%`
- 保留顶部生产环境警示条和左侧红色边线，继续提供明确的环境提示
- 不修改生产环境判断、交互和水印布局

## 验证

- [x] 在 macOS 客户端实际预览生产环境水印
- [x] `pnpm check`（format、lint、typecheck、test）