### PR TITLE
fix(settings): 日期时间格式可从列表恢复默认值

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -351,6 +351,14 @@ const editExportBatchSize = ref(settingsStore.editorSettings.exportBatchSize);
 const editGlobalDateTimeDisplayFormat = ref(settingsStore.editorSettings.globalDateTimeDisplayFormat);
 const editGlobalDateTimeExportFormat = ref(settingsStore.editorSettings.globalDateTimeExportFormat);
 const editGlobalDateTimeImportFormat = ref(settingsStore.editorSettings.globalDateTimeImportFormat);
+/** Empty first option restores default (raw/auto); avoids using tab-wide "reset defaults". */
+const globalDateTimeFormatOptions = ["", ...DateTimePatterns];
+function globalDateTimeRawFormatLabel(option: string): string {
+  return option || t("settings.dateTimeFormatRaw");
+}
+function globalDateTimeAutoFormatLabel(option: string): string {
+  return option || t("settings.dateTimeFormatAuto");
+}
 const editExportRowLimitEnabled = ref(settingsStore.editorSettings.exportRowLimitEnabled);
 const editExportRowLimit = ref(settingsStore.editorSettings.exportRowLimit);
 const editQueryExportKeysetOptimizationEnabled = ref(settingsStore.editorSettings.queryExportKeysetOptimizationEnabled);
@@ -3869,7 +3877,8 @@ onUnmounted(cleanupPreviewEditor);
                   </div>
                   <SearchableSelect
                     v-model="editGlobalDateTimeDisplayFormat"
-                    :options="DateTimePatterns"
+                    :options="globalDateTimeFormatOptions"
+                    :display-name="globalDateTimeRawFormatLabel"
                     :placeholder="t('settings.dateTimeFormatRaw')"
                     :search-placeholder="t('settings.dateTimeFormatSearchPlaceholder')"
                     :empty-text="t('settings.dateTimeFormatEmpty')"
@@ -3885,7 +3894,8 @@ onUnmounted(cleanupPreviewEditor);
                   </div>
                   <SearchableSelect
                     v-model="editGlobalDateTimeExportFormat"
-                    :options="DateTimePatterns"
+                    :options="globalDateTimeFormatOptions"
+                    :display-name="globalDateTimeRawFormatLabel"
                     :placeholder="t('settings.dateTimeFormatRaw')"
                     :search-placeholder="t('settings.dateTimeFormatSearchPlaceholder')"
                     :empty-text="t('settings.dateTimeFormatEmpty')"
@@ -3901,7 +3911,8 @@ onUnmounted(cleanupPreviewEditor);
                   </div>
                   <SearchableSelect
                     v-model="editGlobalDateTimeImportFormat"
-                    :options="DateTimePatterns"
+                    :options="globalDateTimeFormatOptions"
+                    :display-name="globalDateTimeAutoFormatLabel"
                     :placeholder="t('settings.dateTimeFormatAuto')"
                     :search-placeholder="t('settings.dateTimeFormatSearchPlaceholder')"
                     :empty-text="t('settings.dateTimeFormatEmpty')"


### PR DESCRIPTION
## 变更说明

全局日期时间格式（显示 / 导出 / 导入）选中具体 pattern 后，下拉列表里没有「默认」项，只能依赖页脚「恢复默认」整页重置。

在选项列表首项增加空值选项，文案分别为「保持数据库原始值」与「自动识别」，可单独恢复每一项默认值。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）


**修复后**：列表首项为「保持数据库原始值」/「自动识别」，可选中后应用。
<img width="526" height="516" alt="截屏2026-07-17 15 10 28" src="https://github.com/user-attachments/assets/85ced0a6-afb2-4677-b42f-0c8916e83aa9" />


## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过（`make check` 内 typecheck + test）

手动步骤：

1. 设置 → 数据 → 日期与时间
2. 为全局显示/导出/导入格式任选一个 pattern 并应用
3. 再次打开下拉，首项选「保持数据库原始值」或「自动识别」
4. 应用后该字段回到默认（空值 / placeholder 行为）

## 关联 Issue

Close #3743