### PR TITLE
fix(grid): 修复 WHERE 清空后筛选状态残留

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -1559,11 +1559,6 @@ function onSearchKeydown(e: KeyboardEvent) {
   }
 }
 
-function clearWhereFilterInput() {
-  whereFilterInput.value = "";
-  void applyWhereFilter();
-}
-
 watch(whereFilterInput, () => {
   emit("update:whereInput", currentWhereInput() ?? "");
   persistStructuredFilterState();
@@ -7442,7 +7437,6 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   :mode-options="filterModeOptions"
                   :column-search="filterBuilderColumnSearch"
                   :apply-where="applyWhereFilter"
-                  :clear-where="clearWhereFilterInput"
                   :apply-order-by="applyOrderBySearch"
                   :clear-order-by="clearOrderByInput"
                   @update:column-search="filterBuilderColumnSearch = $event"

--- a/apps/desktop/src/components/grid/DataGridFilterBuilder.vue
+++ b/apps/desktop/src/components/grid/DataGridFilterBuilder.vue
@@ -9,16 +9,19 @@ import type { DataGridContextFilterMode } from "@/lib/dataGrid/dataGridSql";
 import type { DataGridStructuredFilterRule } from "@/composables/useDataGridFilterBuilder";
 
 const { t } = useI18n();
-const props = defineProps<{
-  rules: DataGridStructuredFilterRule[];
-  columns: string[];
-  filteredColumns: string[];
-  modeOptions: Array<{ value: DataGridContextFilterMode; labelKey: string }>;
-  columnSearch: string;
-  disabled?: boolean;
-  showHeader?: boolean;
-  showFooter?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    rules: DataGridStructuredFilterRule[];
+    columns: string[];
+    filteredColumns: string[];
+    modeOptions: Array<{ value: DataGridContextFilterMode; labelKey: string }>;
+    columnSearch: string;
+    disabled?: boolean;
+    showHeader?: boolean;
+    showFooter?: boolean;
+  }>(),
+  { showHeader: true, showFooter: true },
+);
 const emit = defineEmits<{
   add: [];
   apply: [];

--- a/apps/desktop/src/components/grid/DataGridQueryControls.vue
+++ b/apps/desktop/src/components/grid/DataGridQueryControls.vue
@@ -39,7 +39,6 @@ const props = defineProps<{
   modeOptions: Array<{ value: DataGridContextFilterMode; labelKey: string }>;
   columnSearch: string;
   applyWhere: (value?: string) => void | boolean | Promise<void | boolean>;
-  clearWhere: () => void | Promise<void>;
   applyOrderBy: (value?: string) => void | boolean | Promise<void | boolean>;
   clearOrderBy: () => void | Promise<void>;
 }>();
@@ -108,6 +107,10 @@ function updateRule(id: string, patch: Partial<DataGridStructuredFilterRule>) {
   emit("updateRule", id, patch);
 }
 
+function clearWhere() {
+  emit("clearFilters");
+}
+
 onUnmounted(onResizeEnd);
 </script>
 
@@ -162,7 +165,6 @@ onUnmounted(onResizeEnd);
             :column-search="columnSearch"
             :disabled="!canUseWhereSearch"
             :show-header="false"
-            :show-footer="false"
             @add="emit('addRule')"
             @apply="emit('applyFilters')"
             @reset="emit('resetFilters')"

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -17,7 +17,7 @@ vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
 vi.mock("@lucide/vue", async () => {
   const { createPassthroughStub } = await import("./vueHostHarness");
   const icon = createPassthroughStub("Icon", "i");
-  return { Check: icon, ChevronLeft: icon, ChevronRight: icon, ChevronsLeft: icon, ChevronsRight: icon, Loader2: icon, Upload: icon, Search: icon, X: icon, Code2: icon, Copy: icon, Eye: icon, EyeOff: icon, Info: icon, Pencil: icon, Plus: icon, Trash2: icon };
+  return { Check: icon, ChevronDown: icon, ChevronLeft: icon, ChevronRight: icon, ChevronsLeft: icon, ChevronsRight: icon, Filter: icon, Loader2: icon, Upload: icon, Search: icon, X: icon, Code2: icon, Copy: icon, Eye: icon, EyeOff: icon, Info: icon, Pencil: icon, Plus: icon, Trash2: icon };
 });
 
 vi.mock("@/components/ui/button", async () => ({ Button: (await import("./vueHostHarness")).createPassthroughStub("Button", "button") }));
@@ -65,6 +65,7 @@ import DataGridCellDetailPanel from "@/components/grid/DataGridCellDetailPanel.v
 import DataGridColumnHeader from "@/components/grid/DataGridColumnHeader.vue";
 import DataGridFilterBuilder from "@/components/grid/DataGridFilterBuilder.vue";
 import DataGridPagination from "@/components/grid/DataGridPagination.vue";
+import DataGridQueryControls from "@/components/grid/DataGridQueryControls.vue";
 import DataGridSearchBar from "@/components/grid/DataGridSearchBar.vue";
 
 function detail(patch: Partial<DataGridCellDetail> = {}): DataGridCellDetail {
@@ -284,6 +285,62 @@ describe("DataGridFilterBuilder", () => {
     expect(dispatch(searchInput, "keydown", { key: "Backspace" }).propagationStopped).toBe(true);
     expect(dispatch(searchInput, "keydown", { key: "ArrowDown" }).propagationStopped).toBe(false);
     expect(dispatch(searchInput, "keydown", { key: "Process", isComposing: true }).propagationStopped).toBe(true);
+  });
+});
+
+describe("DataGridQueryControls", () => {
+  it("keeps filter actions available in the popover", () => {
+    const clearFilters = vi.fn();
+    const applyFilters = vi.fn();
+    const resetFilters = vi.fn();
+    const mounted = mountComponent(DataGridQueryControls, {
+      whereInput: "id = 1",
+      orderByInput: "",
+      columns: ["id"],
+      conditionColumns: ["id"],
+      historyScope: {},
+      canUseWhereSearch: true,
+      compact: false,
+      leadingBorder: false,
+      filterBuilderOpen: true,
+      filterButtonActive: true,
+      filterButtonCount: 1,
+      hasLocalColumnFilters: false,
+      localFilterCount: 0,
+      localFilterSummaries: [],
+      rules: [{ id: "r1", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" }],
+      filteredColumns: ["id"],
+      modeOptions: [{ value: "equals", labelKey: "equals" }],
+      columnSearch: "",
+      applyWhere: vi.fn(),
+      applyOrderBy: vi.fn(),
+      clearOrderBy: vi.fn(),
+      onClearFilters: clearFilters,
+      onApplyFilters: applyFilters,
+      onResetFilters: resetFilters,
+    });
+
+    dispatch(
+      findOne(mounted.root, (node) => node.type === "button" && hostText(node) === "grid.clearFilter"),
+      "click",
+    );
+    dispatch(
+      findOne(mounted.root, (node) => node.type === "button" && hostText(node) === "grid.resetFilterBuilder"),
+      "click",
+    );
+    dispatch(
+      findOne(mounted.root, (node) => node.type === "button" && hostText(node) === "grid.applyFilter"),
+      "click",
+    );
+    const whereInput = findOne(mounted.root, (node) => node.type === "textarea" && node.props.placeholder === "WHERE");
+    const whereControl = whereInput.parent?.parent;
+    expect(whereControl).toBeTruthy();
+    const whereButtons = findAll(whereControl!, (node) => node.type === "button");
+    dispatch(whereButtons[whereButtons.length - 1], "click");
+
+    expect(clearFilters).toHaveBeenCalledTimes(2);
+    expect(resetFilters).toHaveBeenCalledOnce();
+    expect(applyFilters).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## 问题

WHERE 输入框的清空按钮只清除了手写条件，没有同步清理结构化筛选和表头筛选状态，导致筛选角标仍然存在。筛选面板拆分为独立组件后，底部的“清除 / 重置 / 应用”操作又因布尔属性默认值被隐藏，单条规则也无法通过删除按钮移除。

## 修改

- 将 WHERE 清空入口统一到完整筛选清理流程，同时清除手写条件、结构化规则及本地/服务端列筛选
- 为筛选构建器的标题和底部操作区设置明确默认值，恢复“清除 / 重置 / 应用”按钮
- 增加查询控件交互回归测试，覆盖 WHERE 清空和筛选面板操作

## 验证

- 本地浏览器实际验证：筛选角标和条件可正常清空
- `pnpm vitest run apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts apps/desktop/src/composables/__tests__/useDataGridFilterBuilder.spec.ts`
- `pnpm typecheck`
- 完整前端测试：3676 passed

Fixes： #3764 