### PR TITLE
fix(sidebar): 修复删除连接弹窗状态异常 (#3766)

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeItemDialogs.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeItemDialogs.vue
@@ -163,14 +163,7 @@ watch(
       </p>
       <DialogFooter>
         <Button variant="outline" @click="showDeleteConfirm = false">{{ t("dangerDialog.cancel") }}</Button>
-        <Button
-          variant="destructive"
-          @click="
-            showDeleteConfirm = false;
-            confirmDelete();
-          "
-          >{{ connectionDeleteMenuLabel() }}</Button
-        >
+        <Button variant="destructive" @click="confirmDelete()">{{ connectionDeleteMenuLabel() }}</Button>
       </DialogFooter>
     </DialogContent>
   </Dialog>

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -401,22 +401,17 @@ function claimTreeItemDialogOwnership() {
 }
 
 function routeTreeItemDialogController() {
+  // Reuse the cached reactive controller. Cloning/spreading it unwraps nested
+  // module-level refs (e.g. showDeleteConfirm) into disconnected plain values.
   const controller = getTreeItemDialogController();
   const target = createSidebarActionTarget(activeNode.value);
   sidebarFormTarget.value = target;
-  const routedController = reactive<Record<string, any>>({ ...controller, node: target });
-  for (const [key, value] of Object.entries(controller)) {
-    if (typeof value !== "function") continue;
-    routedController[key] = (...args: unknown[]) => {
-      activateActionTarget(target);
-      return value(...args);
-    };
-  }
-  routedController.pasteTableDataCopySupported = pasteTableDataCopySupported.value;
-  routedController.canSetCreateDatabaseCharset = canSetCreateDatabaseCharset.value;
-  routedController.canEditDatabaseCharsetCollation = canEditDatabaseCharsetCollation.value;
-  routedController.canEditDatabaseComment = canEditDatabaseComment.value;
-  emit("open-dialog-controller", routedController);
+  controller.node = target;
+  controller.pasteTableDataCopySupported = pasteTableDataCopySupported.value;
+  controller.canSetCreateDatabaseCharset = canSetCreateDatabaseCharset.value;
+  controller.canEditDatabaseCharsetCollation = canEditDatabaseCharsetCollation.value;
+  controller.canEditDatabaseComment = canEditDatabaseComment.value;
+  emit("open-dialog-controller", controller);
 }
 
 const sidebarTreeContext = inject(sidebarTreeContextKey, null);
@@ -3229,16 +3224,34 @@ function databaseSpecificDialogCapabilities() {
   };
 }
 
+function bindDialogControllerActions(capabilities: Record<string, unknown>): Record<string, unknown> {
+  const bound: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(capabilities)) {
+    if (typeof value !== "function") {
+      bound[key] = value;
+      continue;
+    }
+    bound[key] = (...args: unknown[]) => {
+      const target = sidebarFormTarget.value;
+      if (target) activateActionTarget(target);
+      return (value as (...inner: unknown[]) => unknown)(...args);
+    };
+  }
+  return bound;
+}
+
 function getTreeItemDialogController(): Record<string, any> {
   if (treeItemDialogController) return treeItemDialogController;
   treeItemDialogController = reactive<Record<string, any>>({
     node: createSidebarActionTarget(activeNode.value),
     t,
     highlight,
-    ...connectionDialogCapabilities(),
-    ...objectDialogCapabilities(),
-    ...databaseDialogCapabilities(),
-    ...databaseSpecificDialogCapabilities(),
+    ...bindDialogControllerActions({
+      ...connectionDialogCapabilities(),
+      ...objectDialogCapabilities(),
+      ...databaseDialogCapabilities(),
+      ...databaseSpecificDialogCapabilities(),
+    }),
   });
   return treeItemDialogController;
 }

--- a/apps/desktop/src/composables/useSidebarConnectionMutationRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarConnectionMutationRuntime.ts
@@ -86,7 +86,9 @@ export function useSidebarConnectionMutationRuntime(options: SidebarConnectionMu
   }
 
   async function confirmDelete() {
-    const targets = connectionDeleteTargets();
+    const targets = connectionDeleteTargetSnapshot.value.slice();
+    showDeleteConfirm.value = false;
+    connectionDeleteTargetSnapshot.value = [];
     if (!targets.length) return;
     const connectionIds = targets.map((target) => target.connectionId);
     try {

--- a/packages/app-tests/sidebarDialogRouting.test.ts
+++ b/packages/app-tests/sidebarDialogRouting.test.ts
@@ -62,3 +62,27 @@ test("shared dialog state is owner-gated and confirm handlers use snapshots", ()
   assert.match(runtimeHost, /batchTruncateTargets\.value = targets\.slice\(\)/);
   assert.match(runtimeHost, /activateActionTarget\(target\)/);
 });
+
+test("dialog controller routing reuses the cached reactive instance", () => {
+  // Cloning/spreading the controller unwraps nested module refs (showDeleteConfirm)
+  // into disconnected plain values. Route must mutate and emit the same instance.
+  const routeBody = (() => {
+    const signatureIndex = runtimeHost.indexOf("function routeTreeItemDialogController(");
+    assert.notEqual(signatureIndex, -1);
+    const bodyStart = runtimeHost.indexOf("{", signatureIndex);
+    let depth = 0;
+    for (let index = bodyStart; index < runtimeHost.length; index += 1) {
+      if (runtimeHost[index] === "{") depth += 1;
+      if (runtimeHost[index] === "}" && --depth === 0) return runtimeHost.slice(bodyStart + 1, index);
+    }
+    throw new Error("Could not parse routeTreeItemDialogController");
+  })();
+  assert.match(routeBody, /getTreeItemDialogController\(\)/);
+  assert.match(routeBody, /controller\.node = target/);
+  assert.match(routeBody, /emit\("open-dialog-controller", controller\)/);
+  assert.doesNotMatch(routeBody, /\.\.\.controller/);
+  assert.doesNotMatch(routeBody, /reactive\(/);
+  assert.match(runtimeHost, /bindDialogControllerActions\(/);
+  assert.match(runtimeHost, /sidebarFormTarget\.value/);
+  assert.match(dialogHost, /@click="confirmDelete\(\)"/);
+});

--- a/packages/app-tests/sidebarMutationRuntime.test.ts
+++ b/packages/app-tests/sidebarMutationRuntime.test.ts
@@ -57,5 +57,16 @@ test("menu and dialog mutations resolve immutable accepted targets", () => {
   assert.match(runtimeHost, /activateActionTarget\(target\)/);
   assert.match(runtimeHost, /findSidebarActionTarget\(connectionStore\.treeNodes, target\) \?\? target/);
   assert.match(runtimeHost, /routedRequest\.confirm = async \(\) => \{[\s\S]*?activateActionTarget\(target\)/);
-  assert.match(runtimeHost, /routedController\[key\] = \(\.\.\.args: unknown\[\]\) => \{[\s\S]*?activateActionTarget\(target\)/);
+  assert.match(runtimeHost, /function bindDialogControllerActions\(/);
+  assert.match(runtimeHost, /const target = sidebarFormTarget\.value/);
+  assert.match(runtimeHost, /if \(target\) activateActionTarget\(target\)/);
+});
+
+test("connection delete confirm uses the dialog snapshot and clears open state", () => {
+  const body = functionBody("confirmDelete");
+  assert.match(body, /connectionDeleteTargetSnapshot\.value\.slice\(\)/);
+  assert.doesNotMatch(body, /connectionDeleteTargets\(\)/);
+  assert.match(body, /showDeleteConfirm\.value = false/);
+  assert.match(body, /connectionDeleteTargetSnapshot\.value = \[\]/);
+  assert.match(body, /removeConnections\(connectionIds\)/);
 });


### PR DESCRIPTION
## 变更说明

修复侧边栏删除连接确认弹窗状态与 UI 脱节的问题：

- 右键菜单打开时不再 clone dialog controller；复用缓存的 reactive 实例，避免 Vue spread 解包嵌套 ref（如 `showDeleteConfirm`）后与模块级状态断开
- 对话框 action 在 controller 创建时绑定到 `sidebarFormTarget`，不再每次菜单打开重新包装
- `confirmDelete` 仅使用打开弹窗时的 snapshot，并负责关闭弹窗与清空 snapshot
- 确认按钮只调用 `confirmDelete()`，避免双重清理

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [x] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

修复侧边栏删除连接确认交互；无视觉样式变更，建议本地验证：
1. 右键连接 → 删除连接 → 弹窗正常出现
2. 确认删除后连接被移除，弹窗不再反复出现
3. 取消后再次右键其他连接，不会自动弹出删除确认框

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过



## 关联 Issue

Close #3766