### PR TITLE
feat(sql): add search and create folder in save SQL to library dialog (#3785)

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -32,6 +32,7 @@ import { useVisibilityChange } from "@/composables/useVisibilityChange";
 import { useWebDavAutoUpload } from "@/composables/useWebDavAutoUpload";
 import { useScheduledDatabaseBackups } from "@/composables/useScheduledDatabaseBackups";
 import { shouldDrawDesktopWindowFrame } from "@/composables/useWindowControls";
+import { useSaveSqlFolderSelection } from "@/composables/useSaveSqlFolderSelection";
 import "@/i18n";
 import { translateBackendError } from "@/i18n/backend-errors";
 import * as api from "@/lib/backend/api";
@@ -167,13 +168,13 @@ const queryEditorDdlTarget = ref<{ connectionId: string; database: string; catal
 const queryEditorObjectSourceTarget = ref<{ connectionId: string; database: string; schema?: string; name: string; objectType: ObjectSourceKind; initialEditing: boolean } | null>(null);
 const showSaveSqlDialog = ref(false);
 const saveSqlName = ref("");
-const saveSqlFolderId = ref("");
+const ROOT_SAVED_SQL_FOLDER = "__root__";
+const { selection: saveSqlFolderId, pending: saveSqlFolderCreationPending, reset: resetSaveSqlFolderSelection, invalidate: invalidateSaveSqlFolderSelection, select: selectSaveSqlFolder } = useSaveSqlFolderSelection(ROOT_SAVED_SQL_FOLDER);
 const pendingSaveAndCloseTabId = ref<string | null>(null);
 const pendingPrevActiveTabId = ref<string | null>(null);
 const pendingSaveShouldCloseTab = ref(true);
 const pendingAppCloseAction = ref<AppCloseAction | null>(null);
 const pendingCloseActionChoice = ref(false);
-const ROOT_SAVED_SQL_FOLDER = "__root__";
 
 const activeTab = computed(() => queryStore.tabs.find((t) => t.id === queryStore.activeTabId));
 
@@ -635,6 +636,7 @@ function closePendingSavedTab() {
 }
 
 function cancelPendingSaveAndClose() {
+  invalidateSaveSqlFolderSelection();
   showSaveSqlDialog.value = false;
   pendingSaveAndCloseTabId.value = null;
   pendingPrevActiveTabId.value = null;
@@ -823,7 +825,7 @@ async function handleSaveTab(tabId: string) {
   const prevActive = queryStore.activeTabId;
   queryStore.activeTabId = tabId;
   saveSqlName.value = defaultSavedSqlName(tab.title);
-  saveSqlFolderId.value = ROOT_SAVED_SQL_FOLDER;
+  resetSaveSqlFolderSelection(ROOT_SAVED_SQL_FOLDER);
   pendingSaveAndCloseTabId.value = tabId;
   pendingPrevActiveTabId.value = prevActive;
   showSaveSqlDialog.value = true;
@@ -855,7 +857,7 @@ async function openSaveSqlDialog() {
   }
 
   saveSqlName.value = defaultSavedSqlName(tab.title);
-  saveSqlFolderId.value = ROOT_SAVED_SQL_FOLDER;
+  resetSaveSqlFolderSelection(ROOT_SAVED_SQL_FOLDER);
   showSaveSqlDialog.value = true;
 }
 
@@ -912,27 +914,22 @@ function saveSqlFolderNormalizeCustom(value: string) {
 }
 
 async function handleSaveSqlFolderSelect(value: string) {
-  if (value === ROOT_SAVED_SQL_FOLDER) {
-    saveSqlFolderId.value = value;
-    return;
-  }
-  const isExisting = saveSqlFolders.value.some((f) => f.id === value);
+  const isExisting = value === ROOT_SAVED_SQL_FOLDER || saveSqlFolders.value.some((f) => f.id === value);
   if (isExisting) {
-    saveSqlFolderId.value = value;
+    await selectSaveSqlFolder(value);
     return;
   }
   const tab = activeTab.value;
   if (!tab) return;
-  try {
-    const folder = await savedSqlStore.createFolder(tab.connectionId, value);
-    saveSqlFolderId.value = folder.id;
-  } catch (e: any) {
-    saveSqlFolderId.value = ROOT_SAVED_SQL_FOLDER;
-    toast(t("savedSql.createFolderFailed", { message: e?.message || String(e) }), 5000);
-  }
+  await selectSaveSqlFolder(
+    value,
+    async () => (await savedSqlStore.createFolder(tab.connectionId, value)).id,
+    (error: any) => toast(t("savedSql.createFolderFailed", { message: error?.message || String(error) }), 5000),
+  );
 }
 
 async function confirmSaveSqlToLibrary() {
+  if (saveSqlFolderCreationPending.value) return;
   const tab = activeTab.value;
   const name = saveSqlName.value.trim();
   if (!tab || !tab.sql.trim() || !name) return;
@@ -963,6 +960,7 @@ async function saveActiveSqlAsLocalFile() {
     const path = await api.saveExternalSqlFile(defaultSavedSqlName(tab.title), tab.sql);
     if (!path) return;
     queryStore.linkExternalSqlPath(tab.id, path, sqlFileTitleFromPath(path));
+    invalidateSaveSqlFolderSelection();
     showSaveSqlDialog.value = false;
     closePendingSavedTab();
     toast(t("savedSql.saved"), 2000);
@@ -2288,7 +2286,10 @@ onUnmounted(() => {
         @update:open="
           (open: boolean) => {
             showSaveSqlDialog = open;
-            if (!open && pendingSaveAndCloseTabId) cancelPendingSaveAndClose();
+            if (!open) {
+              invalidateSaveSqlFolderSelection();
+              if (pendingSaveAndCloseTabId) cancelPendingSaveAndClose();
+            }
           }
         "
       >
@@ -2311,6 +2312,7 @@ onUnmounted(() => {
                 :placeholder="t('savedSql.folderPlaceholder')"
                 :search-placeholder="t('savedSql.searchPlaceholder')"
                 :empty-text="t('common.noResults')"
+                :disabled="saveSqlFolderCreationPending"
                 allow-custom
                 trigger-variant="outline"
                 trigger-class="h-8 w-full max-w-none text-sm"
@@ -2326,7 +2328,7 @@ onUnmounted(() => {
           <DialogFooter>
             <Button v-if="isDesktop" variant="secondary" @click="saveActiveSqlAsLocalFile">{{ t("savedSql.saveToFile") }}</Button>
             <Button variant="outline" @click="cancelPendingSaveAndClose()">{{ t("dangerDialog.cancel") }}</Button>
-            <Button :disabled="!saveSqlName.trim()" @click="confirmSaveSqlToLibrary">{{ t("savedSql.save") }}</Button>
+            <Button :disabled="saveSqlFolderCreationPending || !saveSqlName.trim()" @click="confirmSaveSqlToLibrary">{{ t("savedSql.save") }}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -91,7 +91,7 @@ import { detectDatabaseFileType } from "@/lib/database/databaseFileDetection";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SearchableSelect } from "@/components/ui/searchable-select";
 import type { HistoryEntry } from "@/lib/backend/tauri";
 import type { AiAction } from "@/lib/ai/ai";
 
@@ -895,6 +895,40 @@ async function saveActiveObjectSource(tab: QueryTab): Promise<boolean> {
   } catch (e: any) {
     toast(t("objects.sourceSaveFailed", { message: e?.message || String(e) }), 5000);
     return false;
+  }
+}
+
+function saveSqlFolderDisplayName(id: string) {
+  if (id === ROOT_SAVED_SQL_FOLDER) return t("savedSql.rootFolder");
+  const folder = saveSqlFolders.value.find((f) => f.id === id);
+  return folder?.displayName ?? id;
+}
+
+function saveSqlFolderNormalizeCustom(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  const folder = saveSqlFolders.value.find((f) => f.displayName === trimmed);
+  return folder ? folder.id : trimmed;
+}
+
+async function handleSaveSqlFolderSelect(value: string) {
+  if (value === ROOT_SAVED_SQL_FOLDER) {
+    saveSqlFolderId.value = value;
+    return;
+  }
+  const isExisting = saveSqlFolders.value.some((f) => f.id === value);
+  if (isExisting) {
+    saveSqlFolderId.value = value;
+    return;
+  }
+  const tab = activeTab.value;
+  if (!tab) return;
+  try {
+    const folder = await savedSqlStore.createFolder(tab.connectionId, value);
+    saveSqlFolderId.value = folder.id;
+  } catch (e: any) {
+    saveSqlFolderId.value = ROOT_SAVED_SQL_FOLDER;
+    toast(t("savedSql.createFolderFailed", { message: e?.message || String(e) }), 5000);
   }
 }
 
@@ -2269,17 +2303,24 @@ onUnmounted(() => {
             </div>
             <div class="space-y-1.5">
               <label class="text-xs font-medium text-muted-foreground">{{ t("savedSql.folder") }}</label>
-              <Select v-model="saveSqlFolderId">
-                <SelectTrigger class="h-8 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  <SelectItem :value="ROOT_SAVED_SQL_FOLDER">{{ t("savedSql.rootFolder") }}</SelectItem>
-                  <SelectItem v-for="folder in saveSqlFolders" :key="folder.id" :value="folder.id">
-                    {{ folder.displayName }}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+              <SearchableSelect
+                :model-value="saveSqlFolderId"
+                :options="[ROOT_SAVED_SQL_FOLDER, ...saveSqlFolders.map((f) => f.id)]"
+                :display-name="saveSqlFolderDisplayName"
+                :normalize-custom="saveSqlFolderNormalizeCustom"
+                :placeholder="t('savedSql.folderPlaceholder')"
+                :search-placeholder="t('savedSql.searchPlaceholder')"
+                :empty-text="t('common.noResults')"
+                allow-custom
+                trigger-variant="outline"
+                trigger-class="h-8 w-full max-w-none text-sm"
+                content-class="w-[var(--reka-popover-trigger-width)]"
+                @update:model-value="handleSaveSqlFolderSelect"
+              >
+                <template #custom-option-label="{ value }">
+                  <span class="truncate">{{ t("savedSql.createFolderOption", { name: value }) }}</span>
+                </template>
+              </SearchableSelect>
             </div>
           </div>
           <DialogFooter>

--- a/apps/desktop/src/composables/__tests__/useSaveSqlFolderSelection.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSaveSqlFolderSelection.spec.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { useSaveSqlFolderSelection } from "@/composables/useSaveSqlFolderSelection";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const appSource = readFileSync(new URL("../../App.vue", import.meta.url), "utf8");
+
+describe("save SQL folder selection", () => {
+  it("keeps save and reselection blocked until folder creation completes", async () => {
+    const creation = deferred<string>();
+    const folder = useSaveSqlFolderSelection("existing-folder");
+
+    const pendingSelection = folder.select("new-folder", () => creation.promise);
+    await folder.select("other-folder");
+
+    expect(folder.pending.value).toBe(true);
+    expect(folder.selection.value).toBe("existing-folder");
+    expect(appSource).toContain("if (saveSqlFolderCreationPending.value) return;");
+    expect(appSource).toContain(':disabled="saveSqlFolderCreationPending"');
+    expect(appSource).toContain(':disabled="saveSqlFolderCreationPending || !saveSqlName.trim()"');
+
+    creation.resolve("created-folder");
+    await pendingSelection;
+
+    expect(folder.pending.value).toBe(false);
+    expect(folder.selection.value).toBe("created-folder");
+  });
+
+  it("preserves the previous valid selection when folder creation fails", async () => {
+    const onError = vi.fn();
+    const folder = useSaveSqlFolderSelection("existing-folder");
+
+    await folder.select("new-folder", () => Promise.reject(new Error("create failed")), onError);
+
+    expect(folder.pending.value).toBe(false);
+    expect(folder.selection.value).toBe("existing-folder");
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("ignores stale folder creation after the dialog selection session resets", async () => {
+    const creation = deferred<string>();
+    const folder = useSaveSqlFolderSelection("first-folder");
+    const pendingSelection = folder.select("new-folder", () => creation.promise);
+
+    folder.reset("later-folder");
+    creation.resolve("stale-created-folder");
+    await pendingSelection;
+
+    expect(folder.pending.value).toBe(false);
+    expect(folder.selection.value).toBe("later-folder");
+  });
+});

--- a/apps/desktop/src/composables/useSaveSqlFolderSelection.ts
+++ b/apps/desktop/src/composables/useSaveSqlFolderSelection.ts
@@ -1,0 +1,50 @@
+import { readonly, ref } from "vue";
+
+export function useSaveSqlFolderSelection(initialSelection: string) {
+  const selection = ref(initialSelection);
+  const pending = ref(false);
+  let generation = 0;
+
+  function reset(value: string) {
+    generation++;
+    pending.value = false;
+    selection.value = value;
+  }
+
+  function invalidate() {
+    generation++;
+    pending.value = false;
+  }
+
+  async function select(value: string, create?: () => Promise<string>, onError?: (error: unknown) => void) {
+    if (pending.value) return;
+    if (!create) {
+      selection.value = value;
+      return;
+    }
+
+    const previousSelection = selection.value;
+    const requestGeneration = generation;
+    pending.value = true;
+    try {
+      const createdSelection = await create();
+      // A closed or reopened dialog owns a newer selection session.
+      if (requestGeneration !== generation) return;
+      selection.value = createdSelection;
+    } catch (error) {
+      if (requestGeneration !== generation) return;
+      selection.value = previousSelection;
+      onError?.(error);
+    } finally {
+      if (requestGeneration === generation) pending.value = false;
+    }
+  }
+
+  return {
+    selection,
+    pending: readonly(pending),
+    reset,
+    invalidate,
+    select,
+  };
+}

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -120,6 +120,10 @@ export default {
     renameFile: "Rename SQL",
     deleteFile: "Delete SQL",
     deleteFileConfirm: "Delete “{name}”?",
+    createFolderOption: "Create folder “{name}”",
+    folderPlaceholder: "Select a folder",
+    searchPlaceholder: "Search folders...",
+    createFolderFailed: "Failed to create folder: {message}",
   },
   sqlLibrary: {
     title: "SQL Library",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -122,6 +122,10 @@ export default withEnglishFallback({
     renameFile: "Renombrar SQL",
     deleteFile: "Eliminar SQL",
     deleteFileConfirm: "¿Eliminar “{name}”?",
+    createFolderOption: "Crear carpeta “{name}”",
+    folderPlaceholder: "Seleccionar carpeta",
+    searchPlaceholder: "Buscar carpetas...",
+    createFolderFailed: "Error al crear carpeta: {message}",
   },
   sqlLibrary: {
     title: "Biblioteca SQL",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -121,6 +121,10 @@ export default withEnglishFallback({
     renameFile: "Rinomina SQL",
     deleteFile: "Elimina SQL",
     deleteFileConfirm: "Eliminare “{name}”?",
+    createFolderOption: "Crea cartella “{name}”",
+    folderPlaceholder: "Seleziona cartella",
+    searchPlaceholder: "Cerca cartelle...",
+    createFolderFailed: "Impossibile creare la cartella: {message}",
   },
   sqlLibrary: {
     title: "Libreria SQL",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -122,6 +122,10 @@ export default withEnglishFallback({
     renameFile: "SQLの名前を変更",
     deleteFile: "SQLを削除",
     deleteFileConfirm: "「{name}」を削除しますか？",
+    createFolderOption: "フォルダ「{name}」を作成",
+    folderPlaceholder: "フォルダを選択",
+    searchPlaceholder: "フォルダを検索...",
+    createFolderFailed: "フォルダの作成に失敗しました: {message}",
   },
   sqlLibrary: {
     title: "SQLライブラリ",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -122,6 +122,10 @@ export default withEnglishFallback({
     renameFile: "Renomear SQL",
     deleteFile: "Excluir SQL",
     deleteFileConfirm: "Excluir “{name}”?",
+    createFolderOption: "Criar pasta “{name}”",
+    folderPlaceholder: "Selecionar pasta",
+    searchPlaceholder: "Pesquisar pastas...",
+    createFolderFailed: "Falha ao criar pasta: {message}",
   },
   sqlLibrary: {
     title: "Biblioteca SQL",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -122,6 +122,10 @@ export default withEnglishFallback({
     renameFile: "重命名 SQL",
     deleteFile: "删除 SQL",
     deleteFileConfirm: "确定删除“{name}”吗？",
+    createFolderOption: "创建文件夹“{name}”",
+    folderPlaceholder: "选择文件夹",
+    searchPlaceholder: "搜索文件夹...",
+    createFolderFailed: "创建文件夹失败：{message}",
   },
   sqlLibrary: {
     title: "SQL 库",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -122,6 +122,10 @@ export default withEnglishFallback({
     renameFile: "重新命名 SQL",
     deleteFile: "刪除 SQL",
     deleteFileConfirm: "確定刪除「{name}」嗎？",
+    createFolderOption: "建立資料夾「{name}」",
+    folderPlaceholder: "選擇資料夾",
+    searchPlaceholder: "搜尋資料夾...",
+    createFolderFailed: "建立資料夾失敗：{message}",
   },
   sqlLibrary: {
     title: "SQL 庫",


### PR DESCRIPTION
## 变更说明

在「保存 SQL 到库」对话框中，将文件夹选择器从基础的 Select 下拉框替换为 SearchableSelect 组件，支持：
- 搜索现有文件夹
- 在下拉框中直接输入新文件夹名称并创建
- 创建文件夹失败时显示错误提示

## 变更类型

- [x] 新功能

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/6ac6825c-34ea-4991-b8eb-7204840ba06c" />

## 验证

- [x] `vue-tsc --noEmit` 类型检查通过
- [x] `oxfmt` 代码格式化通过
- [x] 手动验证：打开保存 SQL 对话框，测试搜索、新建文件夹、错误处理

## 关联 Issue

Closes #3785