### PR TITLE
修复对象浏览页空闲时周期性刷新

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -2179,7 +2179,7 @@ onBeforeUnmount(() => {
 });
 
 watch(
-  () => [props.connection.id, props.database, props.schema] as const,
+  [() => props.connection.id, () => props.database, () => props.schema],
   async () => {
     selectedSchema.value = props.schema;
     userHasSelectedFilter.value = false;

--- a/apps/desktop/src/lib/__tests__/table/objectBrowserContextWatch.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/objectBrowserContextWatch.spec.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { nextTick, ref, watch } from "vue";
+import { describe, expect, it } from "vitest";
+
+const objectBrowserSource = readFileSync(new URL("../../../components/objects/ObjectBrowser.vue", import.meta.url), "utf8");
+
+describe("ObjectBrowser context watcher", () => {
+  it("watches context fields independently", () => {
+    expect(objectBrowserSource).toContain("[() => props.connection.id, () => props.database, () => props.schema]");
+    expect(objectBrowserSource).not.toContain("() => [props.connection.id, props.database, props.schema]");
+  });
+
+  it("ignores connection object replacement when the context values stay unchanged", async () => {
+    const connection = ref({ id: "connection-1" });
+    const database = ref("database-1");
+    const schema = ref<string | undefined>("public");
+    let reloads = 0;
+    const stop = watch([() => connection.value.id, () => database.value, () => schema.value], () => reloads++);
+
+    connection.value = { id: "connection-1" };
+    await nextTick();
+    expect(reloads).toBe(0);
+
+    schema.value = "audit";
+    await nextTick();
+    expect(reloads).toBe(1);
+    stop();
+  });
+});


### PR DESCRIPTION
## 问题

对象浏览页停留不操作时，会约每 30 秒短暂进入“正在加载对象…”状态并重新加载列表。

原因是对象上下文 watcher 通过单个 getter 返回新数组。连接健康检查更新连接配置对象后，即使连接 ID、数据库和 schema 都没有变化，watcher 仍会把新数组视为变化并触发 reload。

## 修改

- 将连接 ID、数据库和 schema 改为独立 watch source，按字段值判断上下文是否真正变化。
- 保留真实上下文切换时的对象重载行为。
- 增加回归测试，覆盖“仅替换连接对象但 ID 不变时不刷新”和“schema 变化时正常刷新”。

## 验证

- 修复前：在 Kingbase `dbx_kingbase_demo.core` 页面连续抓帧，捕获到列表清空并显示“正在加载对象…”的闪动帧；诊断记录显示相同上下文约每 30 秒触发一次 watcher。
- 修复后：同一页面连续抓取 100 帧、覆盖约 90 秒和至少三次连接更新周期，100 帧哈希完全一致，未再出现加载态。
- `pnpm check`：format、lint、typecheck、test 全部通过。

Fixes：
#3795 #3767 #3808 