### PR TITLE
fix(settings): resolve TDZ crash in EditorSettingsDialog that silenced delete-group dialog

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -1801,6 +1801,12 @@ async function scrollToInitialSettingsSection() {
   }
 }
 
+// AI Config List Mode — declared before the immediate watcher to avoid TDZ crash
+const aiConfigListMode = ref<"list" | "edit">("list");
+const aiEditConfigName = ref("");
+const aiEditConfigId = ref<string | null>(null);
+const displayedAiConfigs = computed(() => orderAiConfigsForDisplay(settingsStore.aiConfigs));
+
 watch(
   () => settingsVisible.value,
   async (open) => {
@@ -1934,11 +1940,6 @@ async function changePassword() {
 }
 
 // ---------- AI Settings ----------
-// AI Config List Mode
-const aiConfigListMode = ref<"list" | "edit">("list");
-const aiEditConfigName = ref("");
-const aiEditConfigId = ref<string | null>(null);
-const displayedAiConfigs = computed(() => orderAiConfigsForDisplay(settingsStore.aiConfigs));
 
 // AI Config Delete Confirmation
 const aiDeleteConfirmOpen = ref(false);


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

Fix a Temporal Dead Zone (TDZ) crash in `EditorSettingsDialog` that silently suppressed UI interactions — most notably, the **delete connection group confirmation dialog** never appeared after clicking "Delete Group".

## Root Cause

`EditorSettingsDialog.vue` contains two `watch({ immediate: true })` calls on `settingsVisible`. The second one (around line 1804) referenced `aiConfigListMode` and `aiEditConfigId` inside its handler, but both were declared as `const` **after** the `watch()` call (around line 1938/1940).

With `immediate: true`, Vue executes the handler **synchronously** during `watch()` setup. When the settings page is already open at mount time (`settingsVisible === true`), the handler runs before those `const` declarations are reached, triggering a `ReferenceError: Cannot access '...' before initialization`.

ReferenceError: Cannot access 'B_' before initialization
  at v.immediate (EditorSettingsDialog-BESkNMRk.js:20:13542)
  at setup (EditorSettingsDialog-BESkNMRk.js:20:13513)

The component crashed on mount, making the entire settings dialog non-functional and — because the delete-group confirmation dialog is rendered inside the same component tree — the "Delete Group" action silently failed with no user feedback.

## Fix

Move `aiConfigListMode`, `aiEditConfigName`, `aiEditConfigId`, and `displayedAiConfigs` from their original position (under the `// AI Settings` section header) to **before** the `watch` block, so they are fully initialized when the immediate handler executes.

No behavioral change — the declarations are pure `ref`/`computed` initializations with deterministic defaults.

## Verification

- All other identifiers referenced in the immediate handler were confirmed safe: function declarations (`syncAiEditState`, `ensureCliMcpStatus`, etc.) are hoisted; remaining `const` refs (`activeSettingsTab`, `passwordMessage`, etc.) were already declared before line 1804.
- `aiIsCliProvider` (declared after the watch) is guarded by `activeSettingsTab.value === "ai"`, which short-circuits before it is accessed on initialization.
- TypeScript: `vue-tsc --noEmit` passes with zero errors.
- Tests: 3735/3735 pass (Vitest).

## Changes

- `apps/desktop/src/components/editor/EditorSettingsDialog.vue` — move4 declarations (3 `ref` + 1 `computed`) ~130 lines earlier; add inline comment explaining the constraint.

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #3754 
