### PR TITLE
test(core): 补齐 SSL mode 行为变更后遗漏的三处测试断言

### DIFF
--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -4285,7 +4285,7 @@ mod tests {
 
         assert_eq!(
             connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://gaussdb:secret@127.0.0.1:3306/postgres"
+            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=disable"
         );
     }
 

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -2097,7 +2097,7 @@ mod tests {
 
         config.db_type = DatabaseType::Postgres;
         assert_eq!(config.effective_database(), Some(" analytics "));
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20?sslmode=disable");
     }
 
     #[test]
@@ -2789,7 +2789,7 @@ mod tests {
         config.db_type = DatabaseType::Postgres;
         config.driver_profile = Some("cockroachdb".to_string());
 
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/defaultdb");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/defaultdb?sslmode=disable");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

c4068343（fix(postgres): align SSL mode behavior）将 postgres 连接 URL 构建逻辑改为：无 `sslmode` 参数时总是追加（`force_tls` 时 `sslmode=require`，否则 `sslmode=disable`）。该提交更新了大部分测试断言，但遗漏了三处，导致 main 分支 `cargo test -p dbx-core` 有 3 个测试失败：

- `connection::tests::opengauss_endpoint_url_uses_postgres_scheme_for_native_driver`
- `models::connection::tests::cockroachdb_url_defaults_to_defaultdb_database`
- `models::connection::tests::database_identifier_whitespace_is_preserved_and_percent_encoded`

由于 c4068343 之后 main 上的几次 push 只改了 website/updater/docker 等文件，CI 路径过滤跳过了 rust-test，所以 main 显示为绿色；但任何触发 rust-test 的 PR（如 #3816）都会在合并 ref 上被这 3 个失败测试连累。

## 修复

仅同步测试期望值：为三处断言的期望 URL 补上 `?sslmode=disable`（3 行改动，无生产代码变化）。

## 验证

- `cargo test -p dbx-core --lib` 三个目标测试全部通过
- `cargo fmt --check -p dbx-core` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)