### PR TITLE
fix: 修复 LM Studio 查询持续思考的问题

### DIFF
--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -555,6 +555,12 @@ pub fn openai_stream_reasoning(event: &serde_json::Value) -> Option<&str> {
         .filter(|text| !text.is_empty())
 }
 
+fn openai_stream_has_finish_reason(event: &serde_json::Value) -> bool {
+    event["choices"].as_array().is_some_and(|choices| {
+        choices.iter().any(|choice| choice["finish_reason"].as_str().is_some_and(|reason| !reason.is_empty()))
+    })
+}
+
 pub fn responses_stream_text(event: &serde_json::Value) -> Option<&str> {
     let event_type = event["type"].as_str().unwrap_or_default();
     if !event_type.is_empty() && event_type != "response.output_text.delta" {
@@ -1567,6 +1573,7 @@ async fn stream_openai(
 
     let mut byte_stream = res.bytes_stream();
     let mut buf = Vec::new();
+    let mut finish_reason_deadline = None;
 
     loop {
         tokio::select! {
@@ -1600,12 +1607,22 @@ async fn stream_openai(
                                 done: false,
                             });
                         }
+                        if finish_reason_deadline.is_none() && openai_stream_has_finish_reason(&event) {
+                            finish_reason_deadline =
+                                Some(tokio::time::Instant::now() + std::time::Duration::from_secs(1));
+                        }
                     }
                 }
 
                 if finished { break; }
             }
             _ = cancelled.notified() => { break; }
+            _ = async {
+                match finish_reason_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
+                }
+            } => { break; }
         }
     }
 
@@ -2130,6 +2147,7 @@ async fn stream_openai_with_tools(
     let mut byte_stream = res.bytes_stream();
     let mut buf = Vec::new();
     let mut token_usage: Option<TokenUsage> = None;
+    let mut finish_reason_deadline = None;
 
     loop {
         tokio::select! {
@@ -2192,6 +2210,10 @@ async fn stream_openai_with_tools(
                                 }
                             }
                         }
+                        if finish_reason_deadline.is_none() && openai_stream_has_finish_reason(&event) {
+                            finish_reason_deadline =
+                                Some(tokio::time::Instant::now() + std::time::Duration::from_secs(1));
+                        }
                     }
                 }
 
@@ -2200,6 +2222,12 @@ async fn stream_openai_with_tools(
             _ = cancelled.notified() => {
                 return Err(AGENT_CANCELLED_ERROR.to_string());
             }
+            _ = async {
+                match finish_reason_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
+                }
+            } => { break; }
         }
     }
 
@@ -2600,6 +2628,7 @@ pub fn load_config(path: &Path) -> Result<Option<AiConfig>, String> {
 mod tests {
     use std::cell::RefCell;
     use std::collections::{HashMap, HashSet};
+    use tokio::sync::Notify;
 
     use super::{
         apply_chat_completion_thinking_toggle, build_ai_http_client, build_responses_input_with_tools, claude_headers,
@@ -2607,10 +2636,10 @@ mod tests {
         maybe_bearer_headers, openai_response_text, openai_stream_reasoning, openai_stream_text,
         parse_model_list_response, resolve_endpoint, resolve_gemini_stream_endpoint, resolve_model_list_endpoint,
         responses_function_tool, responses_max_output_tokens, responses_stream_text, responses_text,
-        responses_token_usage, set_chat_completion_token_limit, stream_data_payload, uses_anthropic_messages_api,
-        validate_config, validate_model_list_config, AiApiStyle, AiAuthMethod, AiConfig, AiMessage, AiModelInfo,
-        AiProvider, AiReasoningLevel, StreamToolEvent, StreamingToolCallAccumulator, ToolCallRef, AUTHORIZATION,
-        CLAUDE_DEFAULT_SYSTEM, TEST_PROMPT,
+        responses_token_usage, set_chat_completion_token_limit, stream_data_payload, stream_openai_with_tools,
+        uses_anthropic_messages_api, validate_config, validate_model_list_config, AiApiStyle, AiAuthMethod,
+        AiCompletionRequest, AiConfig, AiMessage, AiModelInfo, AiProvider, AiReasoningLevel, StreamToolEvent,
+        StreamingToolCallAccumulator, ToolCallRef, AUTHORIZATION, CLAUDE_DEFAULT_SYSTEM, TEST_PROMPT,
     };
 
     /// Reproduce the "Unknown tool:" bug: some OpenAI-compatible providers
@@ -3465,6 +3494,88 @@ mod tests {
             }))
         );
         assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[tokio::test]
+    async fn openai_tool_stream_finishes_without_done_marker_after_finish_reason() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let payload =
+                concat!("data: {\"choices\":[{\"delta\":{\"content\":\"done\"},", "\"finish_reason\":\"stop\"}]}\n\n");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n{:X}\r\n{}\r\n",
+                payload.len(),
+                payload
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+            let keep_alive = ": keep-alive\n\n";
+            for _ in 0..20 {
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                let chunk = format!("{:X}\r\n{}\r\n", keep_alive.len(), keep_alive);
+                if socket.write_all(chunk.as_bytes()).await.is_err() {
+                    break;
+                }
+                if socket.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let config = AiConfig {
+            provider: AiProvider::OpenaiCompatible,
+            api_key: "lm-studio".to_string(),
+            auth_method: AiAuthMethod::Bearer,
+            endpoint: format!("http://{address}/v1"),
+            model: "local-model".to_string(),
+            models: Vec::new(),
+            api_style: AiApiStyle::Completions,
+            proxy_enabled: false,
+            proxy_url: String::new(),
+            enable_thinking: true,
+            reasoning_level: AiReasoningLevel::Default,
+            context_window: None,
+            codex_cli_path: None,
+            codex_cli_env: Default::default(),
+            claude_code_cli_path: None,
+            claude_code_cli_env: Default::default(),
+        };
+        let request = AiCompletionRequest {
+            config: config.clone(),
+            system_prompt: "Use tools when needed.".to_string(),
+            messages: vec![AiMessage {
+                role: "tool".to_string(),
+                content: "query failed".to_string(),
+                tool_call_id: Some("call-1".to_string()),
+                tool_calls: Vec::new(),
+            }],
+            task_contract: None,
+            max_tokens: Some(64),
+        };
+        let client = build_ai_http_client(&config, 10).unwrap();
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let captured = events.clone();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            stream_openai_with_tools(&client, "lm-studio-test", &request, &[], &Notify::new(), &move |event| {
+                captured.lock().unwrap().push(event);
+            }),
+        )
+        .await
+        .expect("stream should finish after the finish_reason grace period");
+
+        assert!(result.is_ok());
+        assert!(events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| matches!(event, StreamToolEvent::Chunk(chunk) if chunk.delta == "done")));
+        server.abort();
     }
 
     #[test]

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -4285,7 +4285,7 @@ mod tests {
 
         assert_eq!(
             connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://gaussdb:secret@127.0.0.1:3306/postgres"
+            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=disable"
         );
     }
 

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -2097,7 +2097,7 @@ mod tests {
 
         config.db_type = DatabaseType::Postgres;
         assert_eq!(config.effective_database(), Some(" analytics "));
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20?sslmode=disable");
     }
 
     #[test]
@@ -2789,7 +2789,7 @@ mod tests {
         config.db_type = DatabaseType::Postgres;
         config.driver_profile = Some("cockroachdb".to_string());
 
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/defaultdb");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/defaultdb?sslmode=disable");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

使用 LM Studio 等 OpenAI Compatible 服务时，AI 配置测试可以成功，但实际查询在工具调用后可能一直停留在“思考中”。

配置测试只需收到首个文本或推理片段；实际查询会执行 SQL 工具并把结果返回模型继续生成。部分兼容服务会通过 `finish_reason` 表示响应结束，但不发送 SSE `[DONE]`，也不主动关闭连接。DBX 原先只在收到 `[DONE]`、连接关闭、取消或请求超时后结束流，因此已收到完整响应时仍可能继续等待。开启 Thinking 时请求超时可达 600 秒。

## 修复

- OpenAI Compatible 普通流和工具调用流均识别非空 `finish_reason`。
- 首次收到 `finish_reason` 后保留 1 秒宽限期，用于接收 usage 尾包或标准 `[DONE]`。
- 宽限期使用固定截止时间，持续 SSE keep-alive 不会重新计时。
- 保持原有 `[DONE]`、连接关闭和取消行为不变。

## 验证

- 新增真实 TCP/HTTP/SSE 回归测试：服务返回带 `finish_reason: "stop"` 的最终文本，不发送 `[DONE]`，保持连接并持续发送 keep-alive；DBX 在约 1.03 秒内结束并保留文本。
- `cargo test -p dbx-core ai::tests --lib -- --test-threads=4`：31 passed。
- `cargo test -p dbx-core --lib -- --test-threads=4`：2173 passed，0 failed，6 ignored。
- `cargo clippy -p dbx-core --lib --locked`：通过；仅有仓库已有的 warning。
- `cargo fmt --all -- --check`、`git diff --check`：通过。

本机未安装截图中的 LM Studio 和具体模型，因此没有声称完成该模型的端到端复现；本次测试覆盖的是导致卡住的真实流式协议行为。

## CI 补充

主分支提交 `c40683431` 将 PostgreSQL 族默认连接模式调整为 `sslmode=disable`，但遗漏更新 3 个旧 URL 断言，导致所有后端 PR 的 `rust-test` 失败。本 PR 同步补齐这些测试预期，不改变连接实现；完整 `dbx-core` 测试已全部通过。