### PR TITLE
fix: 修复 Kingbase 普通账号加载表列表权限错误

### DIFF
--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -18,6 +18,7 @@ import com.dbx.agent.TriggerInfo;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     private static final String KINGBASE_REL_NAME = "CAST(c.relname AS varchar(256))";
     private static final String KINGBASE_REL_OID = "CAST(c.oid AS varchar(64))";
     private static final String KINGBASE_REL_NAMESPACE = "CAST(c.relnamespace AS varchar(64))";
+    private static final String KINGBASE_REL_OWNER = "c.relowner";
     private static final String KINGBASE_SCHEMA_NAME = "CAST(n.nspname AS varchar(256))";
     private static final String KINGBASE_NAMESPACE_OID = "CAST(n.oid AS varchar(64))";
     private static final String KINGBASE_DESCRIPTION = "CAST(d.description AS varchar(4000))";
@@ -68,13 +70,27 @@ public final class KingbaseAgent extends PostgresLikeAgent {
         }
         postgresCatalogMode = !catalogExists(connection, "sys_catalog.sys_namespace")
             && catalogExists(connection, "pg_catalog.pg_namespace");
-        if (!postgresCatalogMode && mysqlSqlModeExists(connection)) {
+        if (!postgresCatalogMode && detectMysqlCompatMode(connection)) {
             setMysqlCompatMode(true);
         }
         // SQLServer compatibility exposes identity metadata through this catalog only.
         sqlServerIdentityCatalogMode = !postgresCatalogMode
             && !isMysqlCompatMode()
             && catalogExists(connection, "sys.identity_columns");
+    }
+
+    private static boolean detectMysqlCompatMode(Connection connection) {
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery(
+                 "SELECT setting FROM sys_catalog.sys_settings WHERE LOWER(name) = 'database_mode'"
+             )) {
+            if (rs.next()) {
+                return "mysql".equalsIgnoreCase(rs.getString(1));
+            }
+        } catch (Exception ignored) {
+            // Older Kingbase versions do not expose database_mode.
+        }
+        return mysqlSqlModeExists(connection);
     }
 
     private static boolean mysqlSqlModeExists(Connection connection) {
@@ -219,6 +235,20 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     }
 
     private List<TableInfo> queryMysqlCompatTables(String schema, MetadataListConstraints constraints) {
+        try {
+            return queryMysqlCompatInformationSchemaTables(schema, constraints);
+        } catch (RuntimeException error) {
+            if (!isSysFreespacePermissionError(error)) {
+                throw error;
+            }
+            return queryMysqlCompatCatalogTables(schema, constraints);
+        }
+    }
+
+    private List<TableInfo> queryMysqlCompatInformationSchemaTables(
+        String schema,
+        MetadataListConstraints constraints
+    ) {
         return unchecked(() -> {
             List<TableInfo> result = new ArrayList<>();
             List<Object> args = new ArrayList<>();
@@ -242,6 +272,39 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
                         result.add(new TableInfo(rs.getString(1), normalizeTableType(rs.getString(2)), rs.getString(3)));
+                    }
+                }
+            }
+            return constraints.withoutPaging().filterTables(result);
+        });
+    }
+
+    private List<TableInfo> queryMysqlCompatCatalogTables(String schema, MetadataListConstraints constraints) {
+        return unchecked(() -> {
+            List<TableInfo> result = new ArrayList<>();
+            List<Object> args = new ArrayList<>();
+            StringBuilder sql = new StringBuilder("SELECT ")
+                .append(KINGBASE_REL_NAME).append(" AS table_name, ")
+                .append("CASE WHEN CAST(c.relkind AS varchar(16)) IN ('r', 'p') THEN 'TABLE' ELSE 'VIEW' END AS table_type, ")
+                .append(KINGBASE_DESCRIPTION).append(" AS table_comment ")
+                .append("FROM sys_catalog.sys_class c ")
+                .append("JOIN sys_catalog.sys_namespace n ON ").append(KINGBASE_NAMESPACE_OID).append(" = ").append(KINGBASE_REL_NAMESPACE).append(' ')
+                .append("LEFT JOIN sys_catalog.sys_description d ON CAST(d.objoid AS varchar(64)) = ").append(KINGBASE_REL_OID).append(" AND d.objsubid = 0 ")
+                .append("WHERE ").append(KINGBASE_SCHEMA_NAME).append(" = ").append(sqlString(effectiveSchema(schema)));
+            appendMysqlCompatCatalogTypePredicate(sql, constraints);
+            appendRelationVisibilityPredicate(sql);
+            MetadataSqlSupport.appendNameFilter(sql, args, KINGBASE_REL_NAME, constraints);
+            sql.append(" ORDER BY ").append(KINGBASE_REL_NAME);
+            MetadataSqlSupport.appendLiteralLimitOffset(sql, constraints);
+            try (PreparedStatement stmt = requireConnected().prepareStatement(sql.toString())) {
+                MetadataSqlSupport.bind(stmt, args);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        result.add(new TableInfo(
+                            rs.getString("table_name"),
+                            normalizeTableType(rs.getString("table_type")),
+                            rs.getString("table_comment")
+                        ));
                     }
                 }
             }
@@ -817,7 +880,35 @@ public final class KingbaseAgent extends PostgresLikeAgent {
             .append(" AND CAST(sa2.attname AS varchar(256)) = 'log_cnt')");
     }
 
-    private static void appendMysqlCompatTableTypePredicate(StringBuilder sql, List<Object> args, MetadataListConstraints constraints) {
+    private static void appendRelationVisibilityPredicate(StringBuilder sql) {
+        sql.append(" AND (SYS_HAS_ROLE(").append(KINGBASE_REL_OWNER).append(", 'USAGE')")
+            .append(" OR HAS_TABLE_PRIVILEGE(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')")
+            .append(" OR HAS_ANY_COLUMN_PRIVILEGE(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES'))");
+    }
+
+    private static void appendMysqlCompatCatalogTypePredicate(
+        StringBuilder sql,
+        MetadataListConstraints constraints
+    ) {
+        boolean includeTables = constraints.tableTypeAllowed("TABLE");
+        boolean includeViews = constraints.tableTypeAllowed("VIEW");
+        if (includeTables && includeViews) {
+            sql.append(" AND (CAST(c.relkind AS varchar(16)) IN ('r', 'p')")
+                .append(" OR (CAST(c.relkind AS varchar(16)) = 'v' AND c.oid >= 16384))");
+        } else if (includeTables) {
+            sql.append(" AND CAST(c.relkind AS varchar(16)) IN ('r', 'p')");
+        } else if (includeViews) {
+            sql.append(" AND CAST(c.relkind AS varchar(16)) = 'v' AND c.oid >= 16384");
+        } else {
+            sql.append(" AND 1 = 0");
+        }
+    }
+
+    private static void appendMysqlCompatTableTypePredicate(
+        StringBuilder sql,
+        List<Object> args,
+        MetadataListConstraints constraints
+    ) {
         if (!constraints.hasObjectTypes()) {
             sql.append(" AND table_type IN ('BASE TABLE', 'VIEW')");
             return;
@@ -835,6 +926,23 @@ public final class KingbaseAgent extends PostgresLikeAgent {
         }
         sql.append(" AND table_type IN (").append(MetadataSqlSupport.placeholders(types.size())).append(")");
         args.addAll(types);
+    }
+
+    private static boolean isSysFreespacePermissionError(Throwable error) {
+        boolean insufficientPrivilege = false;
+        boolean mentionsSysFreespace = false;
+        for (Throwable current = error; current != null; current = current.getCause()) {
+            if (current instanceof SQLException && "42501".equals(((SQLException) current).getSQLState())) {
+                insufficientPrivilege = true;
+            }
+            String message = current.getMessage();
+            if (message != null) {
+                String normalized = message.toLowerCase(Locale.ROOT);
+                mentionsSysFreespace |= normalized.contains("sys_freespace")
+                    || normalized.contains("pg_relation_size_ex");
+            }
+        }
+        return insufficientPrivilege && mentionsSysFreespace;
     }
 
     private static void appendRoutineKindPredicate(StringBuilder sql, List<Object> args, MetadataListConstraints constraints) {

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -168,10 +168,10 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
-    void detectsMysqlCompatModeFromServerSqlMode() throws Exception {
+    void detectsMysqlCompatModeFromServerDatabaseMode() throws Exception {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
-        Connection connection = mysqlCompatConnection(sql);
+        Connection connection = compatibilityModeConnection(sql, "mysql", true);
 
         Method afterConnect = KingbaseAgent.class.getDeclaredMethod("afterConnect", ConnectParams.class, Connection.class);
         afterConnect.setAccessible(true);
@@ -180,14 +180,45 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertTrue(agent.isMysqlCompatMode());
         Assertions.assertEquals("`", agent.getIdentifierQuote());
         Assertions.assertEquals("SELECT 1 FROM sys_catalog.sys_namespace WHERE 1 = 0", sql.get(0));
-        Assertions.assertEquals("SELECT 1 FROM sys_catalog.sys_settings WHERE LOWER(name) = 'sql_mode'", sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("LOWER(name) = 'database_mode'"), sql.get(1));
+        Assertions.assertEquals(2, sql.size());
+    }
+
+    @Test
+    void legacyKingbaseFallsBackToSqlModeDetection() throws Exception {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        Connection connection = compatibilityModeConnection(sql, null, true);
+
+        Method afterConnect = KingbaseAgent.class.getDeclaredMethod("afterConnect", ConnectParams.class, Connection.class);
+        afterConnect.setAccessible(true);
+        afterConnect.invoke(agent, new ConnectParams(), connection);
+
+        Assertions.assertTrue(agent.isMysqlCompatMode());
+        Assertions.assertTrue(sql.get(1).contains("LOWER(name) = 'database_mode'"), sql.get(1));
+        Assertions.assertTrue(sql.get(2).contains("LOWER(name) = 'sql_mode'"), sql.get(2));
+    }
+
+    @Test
+    void oracleDatabaseModeIsNotMisdetectedFromSqlMode() throws Exception {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        Connection connection = compatibilityModeConnection(sql, "oracle", true);
+
+        Method afterConnect = KingbaseAgent.class.getDeclaredMethod("afterConnect", ConnectParams.class, Connection.class);
+        afterConnect.setAccessible(true);
+        afterConnect.invoke(agent, new ConnectParams(), connection);
+
+        Assertions.assertFalse(agent.isMysqlCompatMode());
+        Assertions.assertTrue(sql.get(1).contains("LOWER(name) = 'database_mode'"), sql.get(1));
+        Assertions.assertFalse(sql.stream().anyMatch(query -> query.contains("LOWER(name) = 'sql_mode'")), sql.toString());
     }
 
     @Test
     void detectsSqlServerIdentityCatalogMode() throws Exception {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
-        Connection connection = sqlServerCompatConnection(sql);
+        Connection connection = compatibilityModeConnection(sql, "sqlserver", true);
 
         Method afterConnect = KingbaseAgent.class.getDeclaredMethod("afterConnect", ConnectParams.class, Connection.class);
         afterConnect.setAccessible(true);
@@ -195,7 +226,7 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         Assertions.assertTrue(isSqlServerIdentityCatalogMode(agent));
         Assertions.assertEquals("SELECT 1 FROM sys_catalog.sys_namespace WHERE 1 = 0", sql.get(0));
-        Assertions.assertEquals("SELECT 1 FROM sys_catalog.sys_settings WHERE LOWER(name) = 'sql_mode'", sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("LOWER(name) = 'database_mode'"), sql.get(1));
         Assertions.assertEquals("SELECT 1 FROM sys.identity_columns WHERE 1 = 0", sql.get(2));
     }
 
@@ -213,9 +244,53 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         Assertions.assertEquals("test_timestamps", table.getName());
         Assertions.assertEquals("timestamp samples", table.getComment());
-        Assertions.assertTrue(sql.get(0).contains("FROM information_schema.tables"));
+        Assertions.assertTrue(sql.get(0).contains("FROM information_schema.tables"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("LEFT JOIN sys_catalog.sys_description"), sql.get(0));
         Assertions.assertFalse(sql.get(0).contains("SHOW"));
+    }
+
+    @Test
+    void mysqlCompatListTablesFallsBackFromSysFreespacePermissionError() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        agent.setMysqlCompatMode(true);
+        TestSupport.setPrivateConnection(agent, preparedConnectionWithMetadataFailure(
+            sql,
+            "permission denied for function sys_freespace",
+            "42501",
+            resultSet(
+                new String[]{"table_name", "table_type", "table_comment"},
+                new Object[][]{{"orders", "TABLE", "customer orders"}}
+            )
+        ));
+
+        TableInfo table = agent.listTables("sales").get(0);
+
+        Assertions.assertEquals("orders", table.getName());
+        Assertions.assertEquals("customer orders", table.getComment());
+        Assertions.assertEquals(2, sql.size());
+        Assertions.assertTrue(sql.get(0).contains("FROM information_schema.tables"), sql.get(0));
+        Assertions.assertTrue(sql.get(1).contains("FROM sys_catalog.sys_class"), sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("CAST(c.relkind AS varchar(16)) IN ('r', 'p')"), sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("c.oid >= 16384"), sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("HAS_TABLE_PRIVILEGE"), sql.get(1));
+        Assertions.assertFalse(sql.get(1).contains("information_schema.tables"), sql.get(1));
+    }
+
+    @Test
+    void mysqlCompatListTablesDoesNotHideUnrelatedPermissionErrors() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        agent.setMysqlCompatMode(true);
+        TestSupport.setPrivateConnection(agent, preparedConnectionWithMetadataFailure(
+            sql,
+            "permission denied for relation tables",
+            "42501",
+            resultSet(new String[]{"table_name", "table_type", "table_comment"}, new Object[][]{})
+        ));
+
+        Assertions.assertThrows(RuntimeException.class, () -> agent.listTables("sales"));
+        Assertions.assertEquals(1, sql.size());
     }
 
     @Test
@@ -236,6 +311,7 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertEquals("customer orders", tables.get(0).getComment());
         Assertions.assertTrue(sql.get(0).contains("UPPER(t.table_name) LIKE ? ESCAPE '\\\\'"), sql.get(0));
         Assertions.assertTrue(sql.get(0).contains("LEFT JOIN sys_catalog.sys_description"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("information_schema.tables"), sql.get(0));
         Assertions.assertTrue(sql.get(0).endsWith("LIMIT 20 OFFSET 40"), sql.get(0));
     }
 
@@ -674,6 +750,36 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         return preparedConnectionWithFailures(sql, List.of(failingSqlFragment), fallback);
     }
 
+    private static Connection preparedConnectionWithMetadataFailure(
+        List<String> sql,
+        String message,
+        String sqlState,
+        ResultSet fallback
+    ) {
+        return proxy(Connection.class, (method, args) -> {
+            if ("prepareStatement".equals(method.getName())) {
+                String preparedSql = String.valueOf(args[0]);
+                sql.add(preparedSql);
+                return proxy(PreparedStatement.class, (statementMethod, statementArgs) -> {
+                    if ("executeQuery".equals(statementMethod.getName())) {
+                        if (preparedSql.contains("information_schema.tables")) {
+                            throw new SQLException(message, sqlState);
+                        }
+                        return fallback;
+                    }
+                    if ("close".equals(statementMethod.getName())) {
+                        return null;
+                    }
+                    return defaultValue(statementMethod.getReturnType());
+                });
+            }
+            if ("isClosed".equals(method.getName())) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
     private static Connection preparedConnectionWithFailures(List<String> sql, List<String> failingSqlFragments, ResultSet fallback) {
         return proxy(Connection.class, (method, args) -> {
             if ("prepareStatement".equals(method.getName())) {
@@ -729,33 +835,25 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         });
     }
 
-    private static Connection mysqlCompatConnection(List<String> sql) {
+    private static Connection compatibilityModeConnection(
+        List<String> sql,
+        String databaseMode,
+        boolean sqlModeExists
+    ) {
         return proxy(Connection.class, (method, args) -> {
             if ("createStatement".equals(method.getName())) {
                 return proxy(Statement.class, (statementMethod, statementArgs) -> {
                     if ("executeQuery".equals(statementMethod.getName())) {
                         String query = String.valueOf(statementArgs[0]);
                         sql.add(query);
-                        if (query.contains("sys_settings")) {
+                        if (query.contains("LOWER(name) = 'database_mode'")) {
+                            return databaseMode == null
+                                ? resultSet(new String[]{"setting"}, new Object[][]{})
+                                : resultSet(new String[]{"setting"}, new Object[][]{{databaseMode}});
+                        }
+                        if (query.contains("LOWER(name) = 'sql_mode'") && sqlModeExists) {
                             return resultSet(new String[]{"probe"}, new Object[][]{{1}});
                         }
-                        return resultSet(new String[]{"probe"}, new Object[][]{});
-                    }
-                    return defaultValue(statementMethod.getReturnType());
-                });
-            }
-            if ("isClosed".equals(method.getName())) return false;
-            return defaultValue(method.getReturnType());
-        });
-    }
-
-    private static Connection sqlServerCompatConnection(List<String> sql) {
-        return proxy(Connection.class, (method, args) -> {
-            if ("createStatement".equals(method.getName())) {
-                return proxy(Statement.class, (statementMethod, statementArgs) -> {
-                    if ("executeQuery".equals(statementMethod.getName())) {
-                        String query = String.valueOf(statementArgs[0]);
-                        sql.add(query);
                         return resultSet(new String[]{"probe"}, new Object[][]{});
                     }
                     return defaultValue(statementMethod.getReturnType());


### PR DESCRIPTION
## 问题原因

KingbaseES V009R001C010 MySQL 兼容模式的 `information_schema.tables` 会计算 `TABLE_ROWS`、`DATA_LENGTH` 等字段，并通过 `pg_relation_size_ex` 调用受限系统函数 `sys_freespace`。普通业务账号没有该函数的执行权限时，DBX 加载表列表会触发 `42501` 权限错误。

同时，原兼容模式探测仅判断 `sql_mode` 是否存在；V9 Oracle 模式同样包含该设置，可能被误判为 MySQL 模式。

## 修复内容

- 保留原有 `information_schema.tables` 查询，避免改变 V8、C001 及高权限账号的既有对象列表
- 仅在确认 `SQLState=42501` 且错误涉及 `sys_freespace/pg_relation_size_ex` 时，回退到不计算存储空间的 `sys_catalog` 查询
- fallback 按 Kingbase 的表、用户视图规则过滤对象，并保留对象权限过滤、表/视图类型、注释、搜索和分页
- 兼容模式优先读取 `database_mode=mysql`；旧版本缺少该参数时再回退到 `sql_mode`，避免 V9 Oracle/SQLServer 模式误判

## 验证

- Kingbase Agent 36 项测试通过，包含目标权限错误 fallback、非目标错误不吞掉、V9 Oracle/MySQL 和 V8 探测回归
- `:kingbase:shadowJar` 构建通过
- Agent 清单及 JAR 校验通过
- 真实 KingbaseES V009R001C010 MySQL 实例：普通账号无 `sys_freespace` 权限时，原 Agent 稳定复现 Issue；新 Agent 可正常加载已授权表和视图，未授权表不展示，注释、类型筛选和搜索分页正常
- 同镜像 Oracle 模式正确使用双引号；V008R003C002B0320 继续使用反引号并保持原 6 个对象不变

Closes #3792