### PR TITLE
Fix：兼容 MongoDB insert 写入语法

### DIFF
--- a/apps/desktop/src/lib/mongo/mongoShellCommand.ts
+++ b/apps/desktop/src/lib/mongo/mongoShellCommand.ts
@@ -421,6 +421,16 @@ export function parseMongoWriteCommand(input: string): MongoWriteCommand | null 
     return Array.isArray(JSON.parse(docs)) ? { kind: "insert", collection: insertMany.collection, docsJson: docs } : null;
   }
 
+  const insert = parseCollectionMethodTarget(source, "insert");
+  if (insert) {
+    const args = parseMethodArgs(source, insert.methodCallIndex);
+    if (!args || args.length !== 1 || !args[0]?.trim()) return null;
+    const docs = normalizeJsonArgument(args[0]);
+    if (!docs) return null;
+    const value = JSON.parse(docs);
+    return value !== null && typeof value === "object" ? { kind: "insert", collection: insert.collection, docsJson: docs } : null;
+  }
+
   for (const method of ["updateOne", "updateMany"] as const) {
     const target = parseCollectionMethodTarget(source, method);
     if (!target) continue;

--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -288,6 +288,33 @@ test("parseMongoWriteCommand accepts unquoted insert and update commands", () =>
   });
 });
 
+test("parseMongoWriteCommand accepts legacy insert commands", () => {
+  assert.deepEqual(
+    parseMongoWriteCommand(`db.getCollection("accounting_reconciliations").insert({
+      "accountId": 999,
+      "status": "done"
+    });`),
+    {
+      kind: "insert",
+      collection: "accounting_reconciliations",
+      docsJson: '{\n      "accountId": 999,\n      "status": "done"\n    }',
+    },
+  );
+  assert.deepEqual(parseMongoWriteCommand("db.products.insert([{name: 'first'}, {name: 'second'}])"), {
+    kind: "insert",
+    collection: "products",
+    docsJson: '[{"name": "first"}, {"name": "second"}]',
+  });
+  assert.deepEqual(parseMongoWriteCommand("db.products.insertMany([{name: 'first'}, {name: 'second'}])"), {
+    kind: "insert",
+    collection: "products",
+    docsJson: '[{"name": "first"}, {"name": "second"}]',
+  });
+  assert.equal(parseMongoWriteCommand("db.products.insert({name: 'demo'}, {writeConcern: {w: 1}})"), null);
+  assert.equal(parseMongoWriteCommand("db.products.insert()"), null);
+  assert.equal(parseMongoWriteCommand("db.products.insert('demo')"), null);
+});
+
 test("parseMongoWriteCommand accepts updateMany arrayFilters options", () => {
   assert.deepEqual(
     parseMongoWriteCommand(`db.issue_3231.updateMany(

--- a/packages/node-core/src/database.ts
+++ b/packages/node-core/src/database.ts
@@ -1613,6 +1613,16 @@ export function parseMongoWriteCommand(input: string): MongoWriteCommand | null 
     return Array.isArray(JSON.parse(docs)) ? { kind: "insert", collection: insertMany.collection, docsJson: docs } : null;
   }
 
+  const insert = parseCollectionMethodTarget(source, "insert");
+  if (insert) {
+    const args = parseMethodArgs(source, insert.methodCallIndex);
+    if (!args || args.length !== 1 || !args[0]?.trim()) return null;
+    const docs = normalizeJsonArgument(args[0]);
+    if (!docs) return null;
+    const value = JSON.parse(docs);
+    return value !== null && typeof value === "object" ? { kind: "insert", collection: insert.collection, docsJson: docs } : null;
+  }
+
   for (const method of ["updateOne", "updateMany"] as const) {
     const target = parseCollectionMethodTarget(source, method);
     if (!target) continue;

--- a/packages/node-core/tests/mongo-query.test.ts
+++ b/packages/node-core/tests/mongo-query.test.ts
@@ -295,6 +295,26 @@ test("parseMongoWriteCommand accepts supported write commands", () => {
   });
 });
 
+test("parseMongoWriteCommand accepts legacy insert commands", () => {
+  assert.deepEqual(parseMongoWriteCommand('db.getCollection("accounting_reconciliations").insert({"accountId":999,"status":"done"});'), {
+    kind: "insert",
+    collection: "accounting_reconciliations",
+    docsJson: '{"accountId":999,"status":"done"}',
+  });
+  assert.deepEqual(parseMongoWriteCommand('db.projects.insert([{"name":"first"},{"name":"second"}])'), {
+    kind: "insert",
+    collection: "projects",
+    docsJson: '[{"name":"first"},{"name":"second"}]',
+  });
+  assert.deepEqual(parseMongoWriteCommand('db.projects.insertMany([{"name":"first"},{"name":"second"}])'), {
+    kind: "insert",
+    collection: "projects",
+    docsJson: '[{"name":"first"},{"name":"second"}]',
+  });
+  assert.equal(parseMongoWriteCommand('db.projects.insert({"name":"demo"},{"writeConcern":{"w":1}})'), null);
+  assert.equal(parseMongoWriteCommand("db.projects.insert()"), null);
+});
+
 test("parseMongoWriteCommand rejects invalid dropIndex and dropIndexes commands", () => {
   assert.equal(parseMongoWriteCommand("db.projects.dropIndex()"), null);
   assert.equal(parseMongoWriteCommand('db.projects.dropIndex("*")'), null);


### PR DESCRIPTION
## 变更说明

- MongoDB Shell 写命令解析新增对旧式 `db.collection.insert(...)` 与 `db.getCollection(...).insert(...)` 语法的支持
- 单文档和文档数组复用现有批量写入执行路径
- 同步桌面端与 node-core 的解析行为
- 对空参数、非对象参数及额外 options 参数保持明确拒绝，避免静默忽略写入选项

## 验证

- `pnpm exec vitest run packages/app-tests/mongoShellCommand.test.ts`
- `pnpm exec vitest run packages/node-core/tests/mongo-query.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test`（465 个测试文件，3793 项测试通过）
- `pnpm --filter @dbx-app/node-core build`
- 真实 MongoDB 7.0：通过 DBX 执行链路验证单文档写入 1 条、数组写入 2 条，并查询确认结果；测试集合已清理

Fixes #3811