### PR TITLE
perf(export): CSV/TSV 批量格式化直写缓冲，消除逐格分配

### DIFF
--- a/crates/dbx-core/src/csv_export.rs
+++ b/crates/dbx-core/src/csv_export.rs
@@ -27,8 +27,71 @@ pub struct TableCsvExportOptions {
     pub timeout_secs: Option<u64>,
 }
 
+/// CSV 转义直写目标 buffer：包引号 + 内部 `"` 翻倍。值不含 `"` 时整段拷贝，
+/// 不做 replace 分配（逐批流式导出对每个单元格调用，是导出热路径）。
+pub(crate) fn push_csv_escaped(out: &mut String, value: &str) {
+    out.push('"');
+    let mut rest = value;
+    while let Some(pos) = rest.find('"') {
+        out.push_str(&rest[..=pos]);
+        out.push('"');
+        rest = &rest[pos + 1..];
+    }
+    out.push_str(rest);
+    out.push('"');
+}
+
+fn push_csv_value(out: &mut String, value: &Value) {
+    match value {
+        Value::Null => {}
+        Value::String(v) => push_csv_escaped(out, v),
+        // 布尔/数字的文本形式不含引号，跳过转义扫描
+        Value::Bool(v) => {
+            out.push('"');
+            out.push_str(if *v { "true" } else { "false" });
+            out.push('"');
+        }
+        Value::Number(v) => {
+            out.push('"');
+            out.push_str(&v.to_string());
+            out.push('"');
+        }
+        other => push_csv_escaped(out, &other.to_string()),
+    }
+}
+
+/// TSV 转义直写：仅含特殊字符时包引号（语义与原 escape_tsv 一致）。
+fn push_tsv_escaped(out: &mut String, value: &str) {
+    if value.contains('\t') || value.contains('\n') || value.contains('\r') || value.contains('"') {
+        push_csv_escaped(out, value);
+    } else {
+        out.push_str(value);
+    }
+}
+
+fn push_tsv_value(out: &mut String, value: &Value) {
+    match value {
+        Value::Null => {}
+        Value::String(v) => push_tsv_escaped(out, v),
+        Value::Bool(v) => out.push_str(if *v { "true" } else { "false" }),
+        Value::Number(v) => out.push_str(&v.to_string()),
+        other => push_tsv_escaped(out, &other.to_string()),
+    }
+}
+
+/// 预分配粗估：按全部行的实际单元格数求和（不假设等宽），饱和运算防溢出，
+/// 并设上限——估算只是性能提示，绝不能因病态输入放大成巨额分配
+const ROWS_CAPACITY_ESTIMATE_MAX: usize = 16 * 1024 * 1024;
+
+pub(crate) fn estimated_rows_capacity(rows: &[Vec<Value>]) -> usize {
+    let cells: usize = rows.iter().map(Vec::len).fold(0usize, usize::saturating_add);
+    cells.saturating_mul(12).min(ROWS_CAPACITY_ESTIMATE_MAX)
+}
+
 pub(crate) fn escape_csv(value: &str) -> String {
-    format!("\"{}\"", value.replace('"', "\"\""))
+    let mut out = String::with_capacity(value.len() + 2);
+    push_csv_escaped(&mut out, value);
+    out
 }
 
 pub(crate) fn value_to_csv_text(value: &Value) -> String {
@@ -42,48 +105,81 @@ pub(crate) fn value_to_csv_text(value: &Value) -> String {
 }
 
 fn format_csv_value(value: &Value) -> String {
-    match value {
-        Value::Null => String::new(),
-        other => escape_csv(&value_to_csv_text(other)),
-    }
+    let mut out = String::new();
+    push_csv_value(&mut out, value);
+    out
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn escape_tsv(value: &str) -> String {
-    if value.contains('\t') || value.contains('\n') || value.contains('\r') || value.contains('"') {
-        format!("\"{}\"", value.replace('"', "\"\""))
-    } else {
-        value.to_string()
-    }
+    let mut out = String::with_capacity(value.len());
+    push_tsv_escaped(&mut out, value);
+    out
 }
 
 pub(crate) fn format_tsv_rows(rows: &[Vec<Value>]) -> String {
-    rows.iter()
-        .map(|row| row.iter().map(|cell| escape_tsv(&value_to_csv_text(cell))).collect::<Vec<_>>().join("\t"))
-        .collect::<Vec<_>>()
-        .join("\n")
+    let mut out = String::with_capacity(estimated_rows_capacity(rows));
+    for (row_index, row) in rows.iter().enumerate() {
+        if row_index > 0 {
+            out.push('\n');
+        }
+        for (cell_index, cell) in row.iter().enumerate() {
+            if cell_index > 0 {
+                out.push('\t');
+            }
+            push_tsv_value(&mut out, cell);
+        }
+    }
+    out
 }
 
 pub(crate) fn format_tsv(columns: &[String], rows: &[Vec<Value>]) -> String {
-    let header = columns.iter().map(|col| escape_tsv(col)).collect::<Vec<_>>().join("\t");
-    let body = format_tsv_rows(rows);
-    format!("{header}\n{body}")
+    let mut out = String::with_capacity(
+        estimated_rows_capacity(rows).saturating_add(columns.len().saturating_mul(12)).min(ROWS_CAPACITY_ESTIMATE_MAX),
+    );
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            out.push('\t');
+        }
+        push_tsv_escaped(&mut out, column);
+    }
+    out.push('\n');
+    out.push_str(&format_tsv_rows(rows));
+    out
 }
 
 /// Format query-result rows as CSV text without a header row. Database NULLs
 /// use the same empty-cell representation as table-data exports. Used by the
 /// streaming query-result export for batches after the first.
 pub fn format_query_result_csv_rows(rows: &[Vec<Value>]) -> String {
-    rows.iter().map(|row| row.iter().map(format_csv_value).collect::<Vec<_>>().join(",")).collect::<Vec<_>>().join("\n")
+    let mut out = String::with_capacity(estimated_rows_capacity(rows));
+    for (row_index, row) in rows.iter().enumerate() {
+        if row_index > 0 {
+            out.push('\n');
+        }
+        for (cell_index, cell) in row.iter().enumerate() {
+            if cell_index > 0 {
+                out.push(',');
+            }
+            push_csv_value(&mut out, cell);
+        }
+    }
+    out
 }
 
 fn format_csv_with_value_formatter(columns: &[String], rows: &[Vec<Value>]) -> String {
-    let header = columns.iter().map(|col| escape_csv(col)).collect::<Vec<_>>().join(",");
-    let body = rows
-        .iter()
-        .map(|row| row.iter().map(format_csv_value).collect::<Vec<_>>().join(","))
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!("{header}\n{body}")
+    let mut out = String::with_capacity(
+        estimated_rows_capacity(rows).saturating_add(columns.len().saturating_mul(12)).min(ROWS_CAPACITY_ESTIMATE_MAX),
+    );
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        push_csv_escaped(&mut out, column);
+    }
+    out.push('\n');
+    out.push_str(&format_query_result_csv_rows(rows));
+    out
 }
 
 pub fn format_csv(columns: &[String], rows: &[Vec<Value>]) -> String {
@@ -234,6 +330,37 @@ mod tests {
             &[vec![json!(1), Value::Null], vec![json!(2), json!("line1\n\"line2\"")]],
         );
         assert_eq!(out, "id\tnote\n1\t\n2\t\"line1\n\"\"line2\"\"\"");
+    }
+
+    #[test]
+    fn capacity_estimate_sums_actual_cells_across_ragged_rows() {
+        // 不等宽行按实际单元格数求和，不得按首行宽度放大
+        let wide_first = vec![vec![serde_json::Value::Null; 1000], vec![], vec![serde_json::Value::Null]];
+        assert_eq!(super::estimated_rows_capacity(&wide_first), 1001 * 12);
+        assert!(super::estimated_rows_capacity(&[]) == 0);
+    }
+
+    #[test]
+    fn escape_tsv_matches_reference_semantics() {
+        // TSV 仅在含 \t/\n/\r/引号时包引号；逗号不触发
+        for input in ["", "plain", "with,comma", "tab\there", "line\nbreak", "cr\rhere", "quo\"te", "\t\"mix\""] {
+            let expected =
+                if input.contains('\t') || input.contains('\n') || input.contains('\r') || input.contains('"') {
+                    format!("\"{}\"", input.replace('"', "\"\""))
+                } else {
+                    input.to_string()
+                };
+            assert_eq!(super::escape_tsv(input), expected, "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn push_csv_escaped_matches_replace_reference() {
+        // 直写实现必须与原 replace 版本逐字节等价（含引号在首/尾/连续的边界）
+        for input in ["", "plain", "\"", "\"\"", "a\"b", "\"start", "end\"", "mid\"\"dle", "逗,号\n换行"] {
+            let expected = format!("\"{}\"", input.replace('"', "\"\""));
+            assert_eq!(super::escape_csv(input), expected, "input: {input:?}");
+        }
     }
 
     use serde_json::Value;

--- a/crates/dbx-core/src/csv_export.rs
+++ b/crates/dbx-core/src/csv_export.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
@@ -29,8 +30,7 @@ pub struct TableCsvExportOptions {
 
 /// CSV 转义直写目标 buffer：包引号 + 内部 `"` 翻倍。值不含 `"` 时整段拷贝，
 /// 不做 replace 分配（逐批流式导出对每个单元格调用，是导出热路径）。
-pub(crate) fn push_csv_escaped(out: &mut String, value: &str) {
-    out.push('"');
+fn push_csv_escaped_content(out: &mut String, value: &str) {
     let mut rest = value;
     while let Some(pos) = rest.find('"') {
         out.push_str(&rest[..=pos]);
@@ -38,26 +38,45 @@ pub(crate) fn push_csv_escaped(out: &mut String, value: &str) {
         rest = &rest[pos + 1..];
     }
     out.push_str(rest);
+}
+
+pub(crate) fn push_csv_escaped(out: &mut String, value: &str) {
+    out.push('"');
+    push_csv_escaped_content(out, value);
+    out.push('"');
+}
+
+struct CsvEscapedWriter<'a>(&'a mut String);
+
+impl fmt::Write for CsvEscapedWriter<'_> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        push_csv_escaped_content(self.0, value);
+        Ok(())
+    }
+}
+
+/// 将表导出 CSV 值直接写入已有 buffer；包括 NULL 在内的值均保留分页导出的带引号旧语义。
+pub(crate) fn push_csv_text_value(out: &mut String, value: &Value) {
+    out.push('"');
+    match value {
+        Value::Null => {}
+        Value::String(value) => push_csv_escaped_content(out, value),
+        Value::Bool(value) => out.push_str(if *value { "true" } else { "false" }),
+        Value::Number(value) => {
+            fmt::write(out, format_args!("{value}")).expect("writing a number into a String cannot fail")
+        }
+        // 数组和对象可能包含引号，通过转义 writer 格式化，避免分配中间 JSON 字符串
+        other => fmt::write(&mut CsvEscapedWriter(out), format_args!("{other}"))
+            .expect("writing JSON into a String cannot fail"),
+    }
     out.push('"');
 }
 
 fn push_csv_value(out: &mut String, value: &Value) {
-    match value {
-        Value::Null => {}
-        Value::String(v) => push_csv_escaped(out, v),
-        // 布尔/数字的文本形式不含引号，跳过转义扫描
-        Value::Bool(v) => {
-            out.push('"');
-            out.push_str(if *v { "true" } else { "false" });
-            out.push('"');
-        }
-        Value::Number(v) => {
-            out.push('"');
-            out.push_str(&v.to_string());
-            out.push('"');
-        }
-        other => push_csv_escaped(out, &other.to_string()),
+    if value.is_null() {
+        return;
     }
+    push_csv_text_value(out, value);
 }
 
 /// TSV 转义直写：仅含特殊字符时包引号（语义与原 escape_tsv 一致）。
@@ -74,7 +93,9 @@ fn push_tsv_value(out: &mut String, value: &Value) {
         Value::Null => {}
         Value::String(v) => push_tsv_escaped(out, v),
         Value::Bool(v) => out.push_str(if *v { "true" } else { "false" }),
-        Value::Number(v) => out.push_str(&v.to_string()),
+        Value::Number(value) => {
+            fmt::write(out, format_args!("{value}")).expect("writing a number into a String cannot fail")
+        }
         other => push_tsv_escaped(out, &other.to_string()),
     }
 }
@@ -94,16 +115,6 @@ pub(crate) fn escape_csv(value: &str) -> String {
     out
 }
 
-pub(crate) fn value_to_csv_text(value: &Value) -> String {
-    match value {
-        Value::Null => String::new(),
-        Value::Bool(v) => v.to_string(),
-        Value::Number(v) => v.to_string(),
-        Value::String(v) => v.clone(),
-        other => other.to_string(),
-    }
-}
-
 fn format_csv_value(value: &Value) -> String {
     let mut out = String::new();
     push_csv_value(&mut out, value);
@@ -117,8 +128,7 @@ pub(crate) fn escape_tsv(value: &str) -> String {
     out
 }
 
-pub(crate) fn format_tsv_rows(rows: &[Vec<Value>]) -> String {
-    let mut out = String::with_capacity(estimated_rows_capacity(rows));
+fn push_tsv_rows(out: &mut String, rows: &[Vec<Value>]) {
     for (row_index, row) in rows.iter().enumerate() {
         if row_index > 0 {
             out.push('\n');
@@ -127,9 +137,14 @@ pub(crate) fn format_tsv_rows(rows: &[Vec<Value>]) -> String {
             if cell_index > 0 {
                 out.push('\t');
             }
-            push_tsv_value(&mut out, cell);
+            push_tsv_value(out, cell);
         }
     }
+}
+
+pub(crate) fn format_tsv_rows(rows: &[Vec<Value>]) -> String {
+    let mut out = String::with_capacity(estimated_rows_capacity(rows));
+    push_tsv_rows(&mut out, rows);
     out
 }
 
@@ -144,15 +159,14 @@ pub(crate) fn format_tsv(columns: &[String], rows: &[Vec<Value>]) -> String {
         push_tsv_escaped(&mut out, column);
     }
     out.push('\n');
-    out.push_str(&format_tsv_rows(rows));
+    push_tsv_rows(&mut out, rows);
     out
 }
 
 /// Format query-result rows as CSV text without a header row. Database NULLs
 /// use the same empty-cell representation as table-data exports. Used by the
 /// streaming query-result export for batches after the first.
-pub fn format_query_result_csv_rows(rows: &[Vec<Value>]) -> String {
-    let mut out = String::with_capacity(estimated_rows_capacity(rows));
+fn push_query_result_csv_rows(out: &mut String, rows: &[Vec<Value>]) {
     for (row_index, row) in rows.iter().enumerate() {
         if row_index > 0 {
             out.push('\n');
@@ -161,9 +175,14 @@ pub fn format_query_result_csv_rows(rows: &[Vec<Value>]) -> String {
             if cell_index > 0 {
                 out.push(',');
             }
-            push_csv_value(&mut out, cell);
+            push_csv_value(out, cell);
         }
     }
+}
+
+pub fn format_query_result_csv_rows(rows: &[Vec<Value>]) -> String {
+    let mut out = String::with_capacity(estimated_rows_capacity(rows));
+    push_query_result_csv_rows(&mut out, rows);
     out
 }
 
@@ -178,7 +197,7 @@ fn format_csv_with_value_formatter(columns: &[String], rows: &[Vec<Value>]) -> S
         push_csv_escaped(&mut out, column);
     }
     out.push('\n');
-    out.push_str(&format_query_result_csv_rows(rows));
+    push_query_result_csv_rows(&mut out, rows);
     out
 }
 
@@ -360,6 +379,23 @@ mod tests {
         for input in ["", "plain", "\"", "\"\"", "a\"b", "\"start", "end\"", "mid\"\"dle", "逗,号\n换行"] {
             let expected = format!("\"{}\"", input.replace('"', "\"\""));
             assert_eq!(super::escape_csv(input), expected, "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn push_csv_text_value_preserves_paginated_export_semantics() {
+        let cases = [
+            (serde_json::Value::Null, "\"\""),
+            (serde_json::json!(true), "\"true\""),
+            (serde_json::json!(42.5), "\"42.5\""),
+            (serde_json::json!("a\"b"), "\"a\"\"b\""),
+            (serde_json::json!({"key": "value"}), "\"{\"\"key\"\":\"\"value\"\"}\""),
+        ];
+
+        for (value, expected) in cases {
+            let mut out = String::from("prefix,");
+            super::push_csv_text_value(&mut out, &value);
+            assert_eq!(out, format!("prefix,{expected}"));
         }
     }
 

--- a/crates/dbx-core/src/table_export.rs
+++ b/crates/dbx-core/src/table_export.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::connection::MysqlMode;
 use crate::connection::{config_for_pool_key, task_client_session_id, AppState, PoolKind};
-use crate::csv_export::{format_csv, format_tsv, format_tsv_rows, value_to_csv_text};
+use crate::csv_export::{format_csv, format_tsv, format_tsv_rows, push_csv_text_value};
 pub use crate::database_export::ExportStatus;
 use crate::database_export::{
     build_export_insert_statements, is_export_cancelled, is_internal_export_column, BuildExportInsertStatementsOptions,
@@ -86,7 +86,7 @@ fn format_csv_rows(rows: &[Vec<Value>]) -> String {
             if cell_index > 0 {
                 out.push(',');
             }
-            crate::csv_export::push_csv_escaped(&mut out, &value_to_csv_text(cell));
+            push_csv_text_value(&mut out, cell);
         }
     }
     out

--- a/crates/dbx-core/src/table_export.rs
+++ b/crates/dbx-core/src/table_export.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::connection::MysqlMode;
 use crate::connection::{config_for_pool_key, task_client_session_id, AppState, PoolKind};
-use crate::csv_export::{escape_csv, format_csv, format_tsv, format_tsv_rows, value_to_csv_text};
+use crate::csv_export::{format_csv, format_tsv, format_tsv_rows, value_to_csv_text};
 pub use crate::database_export::ExportStatus;
 use crate::database_export::{
     build_export_insert_statements, is_export_cancelled, is_internal_export_column, BuildExportInsertStatementsOptions,
@@ -75,10 +75,21 @@ pub struct TableExportProgress {
 /// Format rows as CSV text without a header row.
 /// Used for streaming subsequent pagination batches.
 fn format_csv_rows(rows: &[Vec<Value>]) -> String {
-    rows.iter()
-        .map(|row| row.iter().map(|cell| escape_csv(&value_to_csv_text(cell))).collect::<Vec<_>>().join(","))
-        .collect::<Vec<_>>()
-        .join("\n")
+    // 注意：该无表头批次路径的 Null 输出为 ""（带引号空串），与查询结果导出
+    // 及首批 format_csv 的裸空单元格语义不同，直写化必须保留该差异
+    let mut out = String::with_capacity(crate::csv_export::estimated_rows_capacity(rows));
+    for (row_index, row) in rows.iter().enumerate() {
+        if row_index > 0 {
+            out.push('\n');
+        }
+        for (cell_index, cell) in row.iter().enumerate() {
+            if cell_index > 0 {
+                out.push(',');
+            }
+            crate::csv_export::push_csv_escaped(&mut out, &value_to_csv_text(cell));
+        }
+    }
+    out
 }
 
 fn export_column_types(request: &TableExportRequest) -> Vec<String> {


### PR DESCRIPTION
## 问题

内存态 CSV/TSV 批量格式化（`query_result_export` 的流式导出与 `table_export` 每批调用）逐单元格分配：`escape_csv` 无条件 `replace`（即使无引号也新建 String）再套一层 `format!`（又一次分配）；每行 collect 一个临时 `Vec<String>` 再 join，每批再 collect + join。大导出时分配次数远超实际需要。

## 改动

`crates/dbx-core/src/csv_export.rs` + `table_export.rs`：

- 新增直写原语 `push_csv_escaped` / `push_csv_value` / `push_tsv_escaped` / `push_tsv_value`：向复用 String 追加，无引号值整段拷贝（`find('"')` 循环，零 replace 分配）；Null 空单元格、Bool/Number 文本跳过转义扫描
- 四个批量入口重写为单个预分配 String 直写，消灭全部中间 Vec 与 join
- 容量粗估按**全部行实际单元格数求和**（不假设等宽——首行宽度假设在稀疏行下会放大成百 MB 级预分配）、全程饱和运算、16 MiB 硬上限
- `table_export::format_csv_rows`（逐行流式与分页批次两个调用点）同步直写化，**保留该路径 Null 输出 \"\"（带引号空串）的既有语义**（与查询结果导出的裸空单元格不同，已注释说明）
- 公开辅助函数签名与输出逐字节不变，外部调用者零改动

## 验证

- 新增 3 组回归测试：CSV 转义与原 replace 实现逐字节等价（9 个边界输入）、TSV 条件包引号语义（含逗号不触发断言）、不等宽行容量按实际单元格求和
- csv 23 + table_export 21 个测试全过（既有测试对输出逐字节敏感）
- `cargo check --workspace --locked` 无警告；全量 `cargo test -p dbx-core` 2172 通过（3 失败为上游存量 URL 测试，干净 main 复现）
- 已经过两轮独立代码审查，终版 PASS；第一轮发现的容量估算稀疏行放大/溢出与 table_export 遗漏路径两个 Critical 均已修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)