### PR TITLE
Fix：修复 MySQL # 注释后的查询结果丢失

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use crate::models::connection::{ConnectionConfig, DatabaseConnectionInfo, DatabaseType};
-use crate::sql::starts_with_executable_sql_keyword;
+use crate::sql::{starts_with_executable_sql_keyword, starts_with_executable_sql_keyword_for_database};
 use crate::types::{
     ColumnInfo, CompletionAssistantCandidate, CompletionAssistantCandidateKind, CompletionAssistantMatchMode,
     CompletionAssistantObjectKind, CompletionAssistantRequest, CompletionAssistantResponse, DatabaseInfo,
@@ -3198,8 +3198,11 @@ fn prefers_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
 }
 
 fn is_result_set_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
-    starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL"])
-        || dialect.supports_admin_show_results && is_admin_show_query(sql)
+    starts_with_executable_sql_keyword_for_database(
+        sql,
+        &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL"],
+        DatabaseType::Mysql,
+    ) || dialect.supports_admin_show_results && is_admin_show_query(sql)
 }
 
 fn requires_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
@@ -3207,12 +3210,11 @@ fn requires_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
         return true;
     }
 
-    if !starts_with_executable_sql_keyword(sql, &["SHOW"]) {
+    if !starts_with_executable_sql_keyword_for_database(sql, &["SHOW"], DatabaseType::Mysql) {
         return false;
     }
 
-    let tokens =
-        sql.trim().trim_end_matches(';').split_whitespace().map(|token| token.to_ascii_lowercase()).collect::<Vec<_>>();
+    let tokens = leading_sql_word_tokens(sql, 3);
     if tokens.len() >= 2 && tokens[0] == "show" && tokens[1] == "grants" {
         return true;
     }
@@ -3985,6 +3987,16 @@ mod tests {
     fn mysql_with_queries_are_treated_as_result_sets() {
         let sql = "WITH RECURSIVE org_tree AS (SELECT 1 AS id) SELECT id FROM org_tree";
         assert!(is_result_set_query(sql, MySqlQueryDialect::default()));
+    }
+
+    #[test]
+    fn mysql_hash_comments_before_queries_preserve_result_sets_per_issue_3830() {
+        let dialect = MySqlQueryDialect::default();
+
+        assert!(is_result_set_query("# 注释\nSELECT NOW()", dialect));
+        assert!(prefers_text_protocol_query("# 注释\nSELECT NOW()", dialect));
+        assert!(requires_text_protocol_query("# inspect sessions\nSHOW PROCESSLIST", dialect));
+        assert!(!is_result_set_query("# update row\nUPDATE users SET name = 'Ada' WHERE id = 1", dialect));
     }
 
     #[test]


### PR DESCRIPTION
## 问题原因

MySQL 批量 SQL 已正确分成两条，但结果集分类只按通用 SQL 注释规则查找首个关键字，无法跳过 MySQL 的 `#` 行注释。第一条 `SELECT NOW()` 因此被当作非查询语句执行，返回行被丢弃。

## 变更说明

- MySQL 结果集分类改用方言感知的首关键字识别
- 管理类 `SHOW` 命令复用可跳过 MySQL 注释的 token 解析
- 保持 `UPDATE`、`SET` 等非结果语句的原有行为
- 增加 `#` 注释后的 `SELECT`、`SHOW` 及非查询语句边界测试

## 验证

- 真实 MySQL 9.6：修复前首个结果为空；修复后 `# 注释 + SELECT NOW() + 第二条 SELECT` 正确返回两个结果及对应行
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --all-targets`
- `cargo test --workspace --locked`
- 同步最新 `origin/main` 后重新通过定向测试和真实 MySQL 验证

Fixes #3830