### PR TITLE
fix(tree): expand trigger and type object groups

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -64,6 +64,7 @@ import type { ColumnInfo, DatabaseType, TreeNode, TreeNodeType } from "@/types/d
 import * as api from "@/lib/backend/api";
 import { resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
 import { canTreeNodePin, canTreeNodeShowExpander } from "@/lib/sidebar/sidebarTreeItemLayout";
+import { objectTypesForGroupNode } from "@/lib/table/tableTree";
 import { buildTableDeleteTemplate, buildTableInsertTemplate, buildTableSelectTemplate, buildTableUpdateTemplate } from "@/lib/table/tableSqlTemplates";
 import { driverStoreFocusForInstallError } from "@/lib/connection/agentDriverInstallHint";
 import {
@@ -493,7 +494,10 @@ async function toggle() {
     return;
   }
 
-  const databaseObjectGroup = node.type === "group-tables" || node.type === "group-views" || node.type === "group-materialized-views" || node.type === "group-procedures" || node.type === "group-functions" || node.type === "group-sequences" || node.type === "group-packages";
+  // Keep the click path aligned with every object-group definition. In
+  // particular, schema-level trigger/type groups have no tableName, so they
+  // must use the generic object loader rather than the table-trigger loader.
+  const databaseObjectGroup = !!objectTypesForGroupNode(node.type);
   if (databaseObjectGroup && connectionStore.isTreeNodeChildrenLoaded(node.id)) {
     node.isExpanded = !node.isExpanded;
     if (wasExpanded && !connectionStore.sidebarSearchQuery) connectionStore.releaseCollapsedTreeNodeChildren(node.id);

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -3978,7 +3978,7 @@ export const useConnectionStore = defineStore("connection", () => {
       await loadForeignKeys(node.connectionId, node.database, node.tableName, node.schema, node.id, node.catalog);
     } else if (node.type === "group-triggers" && node.connectionId && hasTreeNodeDatabaseContext(node) && node.tableName) {
       await loadTriggers(node.connectionId, node.database, node.tableName, node.schema, node.id, node.catalog);
-    } else if (node.type === "group-tables" || node.type === "group-views" || node.type === "group-materialized-views" || node.type === "group-procedures" || node.type === "group-functions" || node.type === "group-sequences" || node.type === "group-packages") {
+    } else if (objectTypesForGroupNode(node.type)) {
       await loadObjectGroupChildren(node, options);
     } else if (node.type === "group-partitions") {
       node.isExpanded = true;

--- a/packages/app-tests/sidebarTreeAffordances.test.ts
+++ b/packages/app-tests/sidebarTreeAffordances.test.ts
@@ -5,6 +5,7 @@ import { test } from "vitest";
 const treeItem = readFileSync("apps/desktop/src/components/sidebar/TreeItem.vue", "utf8");
 const runtimeHost = readFileSync("apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue", "utf8");
 const connectionTree = readFileSync("apps/desktop/src/components/sidebar/ConnectionTree.vue", "utf8");
+const connectionStore = readFileSync("apps/desktop/src/stores/connectionStore.ts", "utf8");
 
 test("sidebar rows retain database-specific node affordances", () => {
   for (const nodeType of ["connection", "database", "schema", "table", "column", "mongo-db", "mongo-collection", "redis-db", "nacos-namespace", "mq-tenant"]) {
@@ -23,4 +24,9 @@ test("complex tree changes retain the full rebuild fallback", () => {
   assert.match(connectionTree, /const flatNodes = computed<FlatTreeNode\[]>/);
   assert.match(connectionTree, /flattenTree\(filteredNodes\.value\)/);
   assert.match(connectionTree, /watch\(flatNodes,/);
+});
+
+test("programmable object groups use the shared metadata loader", () => {
+  assert.match(runtimeHost, /const databaseObjectGroup = !!objectTypesForGroupNode\(node\.type\)/);
+  assert.match(connectionStore, /else if \(objectTypesForGroupNode\(node\.type\)\) \{\s*await loadObjectGroupChildren\(node, options\);/);
 });


### PR DESCRIPTION
## 变更说明

- 修复 XuguDB 模式级“触发器”和“类型”对象组已展示、但无法展开的问题。
- 统一运行时与兼容树加载路径，使用共享的对象组映射，避免新增对象类型遗漏加载逻辑。
- 保留表级触发器原有的专用加载行为。

## 变更类型

- [x] Bug 修复

## 涉及前端

- [x] 本 PR 涉及前端交互修复；行为变更可通过下述测试及手动展开对象树验证。

## 验证

- [x] `corepack pnpm vitest run packages/app-tests/sidebarTreeAffordances.test.ts` 通过
- [x] 新增回归检查，覆盖运行时和兼容加载路径。

## 手动验证

连接 XuguDB 后，展开任意模式下的“触发器”或“类型”分组，均应加载并展示对应对象。