### PR TITLE
fix(xugu): avoid privileged metadata DDL lookups

### DIFF
--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -1715,20 +1715,10 @@ func (s *server) getTableDDL(schema, table string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var ddl string
-	rows, err := s.queryRows("SELECT TO_CHAR(DBMS_METADATA.GET_DDL('TABLE', ?, ?)) FROM DUAL", []any{strings.ToUpper(table), schema})
-	if err == nil {
-		defer s.closeRows(rows)
-		if rows.Next() {
-			if scanErr := rows.Scan(&ddl); scanErr == nil && strings.TrimSpace(ddl) != "" {
-				if err := rows.Err(); err != nil {
-					return "", err
-				}
-				return s.appendTableIndexDDL(schema, table, ddl), nil
-			}
-		}
-	}
-	ddl, err = s.buildTableDDL(schema, table)
+	// DBMS_METADATA.GET_DDL can block indefinitely on XuguDB, even when the
+	// table metadata itself is accessible. Reconstruct the DDL from the same
+	// ALL_* catalog views used by the object browser instead.
+	ddl, err := s.buildTableDDL(schema, table)
 	if err != nil {
 		return "", err
 	}
@@ -2159,32 +2149,32 @@ func objectSourceQuery(schema, name, objectType string) (string, []any, error) {
 	case "VIEW":
 		return `
 SELECT TO_CHAR(v.DEFINE)
-FROM SYS_VIEWS v
-JOIN SYS_SCHEMAS s ON s.DB_ID = v.DB_ID AND s.SCHEMA_ID = v.SCHEMA_ID
+FROM ALL_VIEWS v
+JOIN ALL_SCHEMAS s ON s.DB_ID = v.DB_ID AND s.SCHEMA_ID = v.SCHEMA_ID
 WHERE UPPER(s.SCHEMA_NAME) = UPPER(?) AND UPPER(v.VIEW_NAME) = UPPER(?)`, []any{schema, name}, nil
 	case "TRIGGER":
 		return `
 SELECT TO_CHAR(t.DEFINE)
-FROM SYS_TRIGGERS t
-JOIN SYS_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+FROM ALL_TRIGGERS t
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
 WHERE UPPER(s.SCHEMA_NAME) = UPPER(?) AND UPPER(t.TRIG_NAME) = UPPER(?)`, []any{schema, name}, nil
 	case "PROCEDURE", "FUNCTION":
 		return `
 SELECT TO_CHAR(p.DEFINE)
-FROM SYS_PROCEDURES p
-JOIN SYS_SCHEMAS s ON s.DB_ID = p.DB_ID AND s.SCHEMA_ID = p.SCHEMA_ID
+FROM ALL_PROCEDURES p
+JOIN ALL_SCHEMAS s ON s.DB_ID = p.DB_ID AND s.SCHEMA_ID = p.SCHEMA_ID
 WHERE UPPER(s.SCHEMA_NAME) = UPPER(?) AND UPPER(p.PROC_NAME) = UPPER(?)`, []any{schema, name}, nil
 	case "PACKAGE":
 		return `
 SELECT COALESCE(TO_CHAR(k.SPEC), '')
-FROM SYS_PACKAGES k
-JOIN SYS_SCHEMAS s ON s.DB_ID = k.DB_ID AND s.SCHEMA_ID = k.SCHEMA_ID
+FROM ALL_PACKAGES k
+JOIN ALL_SCHEMAS s ON s.DB_ID = k.DB_ID AND s.SCHEMA_ID = k.SCHEMA_ID
 WHERE UPPER(s.SCHEMA_NAME) = UPPER(?) AND UPPER(k.PACK_NAME) = UPPER(?)`, []any{schema, name}, nil
 	case "PACKAGE BODY", "PACKAGE_BODY":
 		return `
 SELECT COALESCE(TO_CHAR(k.BODY), '')
-FROM SYS_PACKAGES k
-JOIN SYS_SCHEMAS s ON s.DB_ID = k.DB_ID AND s.SCHEMA_ID = k.SCHEMA_ID
+FROM ALL_PACKAGES k
+JOIN ALL_SCHEMAS s ON s.DB_ID = k.DB_ID AND s.SCHEMA_ID = k.SCHEMA_ID
 WHERE UPPER(s.SCHEMA_NAME) = UPPER(?) AND UPPER(k.PACK_NAME) = UPPER(?)`, []any{schema, name}, nil
 	case "TYPE":
 		return `
@@ -2258,10 +2248,6 @@ func (s *server) buildTableDDL(schema, table string) (string, error) {
 }
 
 func (s *server) appendTableIndexDDL(schema, table, ddl string) string {
-	indexDDL, err := s.tableIndexDDL(schema, table)
-	if err == nil && strings.TrimSpace(indexDDL) != "" {
-		return appendDDLStatement(ddl, indexDDL)
-	}
 	indexes, err := s.listIndexes(schema, table)
 	if err != nil || len(indexes) == 0 {
 		return ddl
@@ -2302,27 +2288,6 @@ func (s *server) appendTableIndexDDL(schema, table, ddl string) string {
 		return ddl
 	}
 	return appendDDLStatement(ddl, builder.String())
-}
-
-func (s *server) tableIndexDDL(schema, table string) (string, error) {
-	rows, err := s.queryRows(
-		"SELECT TO_CHAR(DBMS_METADATA.GET_DDL('INDEX', ?, ?)) FROM DUAL",
-		[]any{strings.ToUpper(strings.TrimSpace(table)), schema},
-	)
-	if err != nil {
-		return "", err
-	}
-	defer s.closeRows(rows)
-	var ddl string
-	if rows.Next() {
-		if err := rows.Scan(&ddl); err != nil {
-			return "", err
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return "", err
-	}
-	return ddl, nil
 }
 
 func (s *server) tableComment(schema, table string) (string, error) {

--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -43,7 +43,7 @@ WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
   AND UPPER(t.TABLE_NAME) = UPPER(?)
   AND c.CONS_TYPE = 'P'`
 const xuguListColumnsSQL = `
-SELECT c.COL_NAME, c.TYPE_NAME, c.NOT_NULL, c.DEF_VAL, c.COMMENTS, c.SCALE, c."VARYING"
+SELECT c.COL_NAME, c.TYPE_NAME, c.NOT_NULL, c.DEF_VAL, c.ON_NULL, c.COMMENTS, c.SCALE, c."VARYING"
 FROM ALL_COLUMNS c
 JOIN ALL_TABLES t ON t.DB_ID = c.DB_ID AND t.TABLE_ID = c.TABLE_ID
 JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
@@ -268,6 +268,7 @@ type columnInfo struct {
 	DataType               string  `json:"data_type"`
 	IsNullable             bool    `json:"is_nullable"`
 	ColumnDefault          *string `json:"column_default"`
+	DefaultOnNull          int     `json:"default_on_null,omitempty"`
 	IsPrimaryKey           bool    `json:"is_primary_key"`
 	Extra                  *string `json:"extra"`
 	Comment                *string `json:"comment"`
@@ -1580,6 +1581,7 @@ func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 	for rows.Next() {
 		var item columnInfo
 		var notNull any
+		var onNull any
 		var scale *int
 		var varying any
 		if err := rows.Scan(
@@ -1587,6 +1589,7 @@ func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 			&item.DataType,
 			&notNull,
 			&item.ColumnDefault,
+			&onNull,
 			&item.Comment,
 			&scale,
 			&varying,
@@ -1595,6 +1598,7 @@ func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 		}
 		item.DataType = normalizeXuguColumnType(item.DataType, varying)
 		item.IsNullable = !truthy(notNull)
+		item.DefaultOnNull = xuguInt(onNull)
 		item.IsPrimaryKey = primaryKeys[strings.ToUpper(item.Name)]
 		item.NumericPrecision, item.NumericScale, item.CharacterMaximumLength = decodeXuguScale(item.DataType, scale)
 		result = append(result, item)
@@ -2447,6 +2451,14 @@ func renderXuguTableDDL(schema, table string, columns []columnInfo, metadata xug
 		}
 		if column.ColumnDefault != nil && strings.TrimSpace(*column.ColumnDefault) != "" {
 			item.WriteString(" DEFAULT ")
+			switch column.DefaultOnNull {
+			case 1:
+				// ON_NULL=1 means that an explicit NULL is replaced during insert.
+				// The explicit spelling also covers the legacy DEFAULT ON NULL form.
+				item.WriteString("ON NULL FOR INSERT ONLY ")
+			case 2:
+				item.WriteString("ON NULL FOR INSERT AND UPDATE ")
+			}
 			item.WriteString(strings.TrimSpace(*column.ColumnDefault))
 		}
 		if !column.IsNullable {
@@ -2574,8 +2586,17 @@ func renderXuguPartitionDDL(metadata xuguTableMetadata, partitions, subpartition
 					builder.WriteString(interval)
 				}
 			}
-			if metadata.PartitionType == 3 && len(partitions) == 0 && metadata.PartitionCount > 0 {
-				builder.WriteString(fmt.Sprintf(" PARTITIONS %d", metadata.PartitionCount))
+			if metadata.PartitionType == 3 {
+				// HASH partitions have no RANGE/LIST-style values. ALL_PARTIS can
+				// contain physical hash-partition rows, but only their count belongs
+				// in CREATE TABLE syntax.
+				count := metadata.PartitionCount
+				if count <= 0 {
+					count = len(partitions)
+				}
+				if count > 0 {
+					builder.WriteString(fmt.Sprintf(" PARTITIONS %d", count))
+				}
 			} else if len(partitions) > 0 {
 				builder.WriteString(" PARTITIONS (\n")
 				for i, partition := range partitions {
@@ -2607,8 +2628,14 @@ func renderXuguPartitionDDL(metadata xuguTableMetadata, partitions, subpartition
 			builder.WriteString(" (")
 			builder.WriteString(key)
 			builder.WriteByte(')')
-			if metadata.SubpartitionType == 3 && len(subpartitions) == 0 && metadata.SubpartitionCount > 0 {
-				builder.WriteString(fmt.Sprintf(" SUBPARTITIONS %d", metadata.SubpartitionCount))
+			if metadata.SubpartitionType == 3 {
+				count := metadata.SubpartitionCount
+				if count <= 0 {
+					count = len(subpartitions)
+				}
+				if count > 0 {
+					builder.WriteString(fmt.Sprintf(" SUBPARTITIONS %d", count))
+				}
 			} else if len(subpartitions) > 0 {
 				builder.WriteString(" SUBPARTITIONS (\n")
 				for i, partition := range subpartitions {
@@ -2660,10 +2687,14 @@ func xuguReferentialAction(value string) string {
 
 func xuguMatchClause(value string) string {
 	switch strings.ToUpper(strings.TrimSpace(value)) {
-	case "F":
+	case "A":
 		return "MATCH FULL"
 	case "P":
 		return "MATCH PARTIAL"
+	case "U":
+		// SIMPLE is Xugu's default and it is represented by omitting the
+		// clause; unlike FULL/PARTIAL, `MATCH SIMPLE` is not valid Xugu SQL.
+		return ""
 	default:
 		return ""
 	}

--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -59,6 +59,53 @@ JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
 WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
   AND UPPER(t.TABLE_NAME) = UPPER(?)
 ORDER BY i.INDEX_NAME`
+const xuguTableMetadataSQL = `
+SELECT t.TEMP_TYPE, t.ON_COMMIT_DEL, t.PCTFREE, t.COPY_NUM,
+       t.PARTI_TYPE, t.PARTI_NUM, t.PARTI_KEY,
+       t.AUTO_PARTI_TYPE, t.AUTO_PARTI_SPAN,
+       t.SUBPARTI_TYPE, t.SUBPARTI_NUM, t.SUBPARTI_KEY, t.COMMENTS
+FROM ALL_TABLES t
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
+  AND UPPER(t.TABLE_NAME) = UPPER(?)`
+const xuguTableIdentitySQL = `
+SELECT c.COL_NAME, q.MIN_VAL, q.STEP_VAL
+FROM ALL_COLUMNS c
+JOIN ALL_TABLES t ON t.DB_ID = c.DB_ID AND t.TABLE_ID = c.TABLE_ID
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+JOIN ALL_SEQUENCES q ON q.DB_ID = c.DB_ID AND q.SEQ_ID = c.SERIAL_ID
+WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
+  AND UPPER(t.TABLE_NAME) = UPPER(?)
+  AND c.IS_SERIAL = TRUE`
+const xuguTableConstraintsSQL = `
+SELECT c.CONS_NAME, c.CONS_TYPE, c.DEFINE,
+       rs.SCHEMA_NAME, rt.TABLE_NAME,
+       c.MATCH_TYPE, c.UPDATE_ACTION, c.DELETE_ACTION,
+       c.DEFERRABLE, c.INITDEFERRED, c.ENABLE
+FROM ALL_CONSTRAINTS c
+JOIN ALL_TABLES t ON t.DB_ID = c.DB_ID AND t.TABLE_ID = c.TABLE_ID
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+LEFT JOIN ALL_TABLES rt ON rt.DB_ID = c.DB_ID AND rt.TABLE_ID = c.REF_TABLE_ID
+LEFT JOIN ALL_SCHEMAS rs ON rs.DB_ID = rt.DB_ID AND rs.SCHEMA_ID = rt.SCHEMA_ID
+WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
+  AND UPPER(t.TABLE_NAME) = UPPER(?)
+ORDER BY c.CONS_NAME`
+const xuguTablePartitionsSQL = `
+SELECT p.PARTI_NAME, p.PARTI_VAL
+FROM ALL_PARTIS p
+JOIN ALL_TABLES t ON t.DB_ID = p.DB_ID AND t.TABLE_ID = p.TABLE_ID
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
+  AND UPPER(t.TABLE_NAME) = UPPER(?)
+ORDER BY p.PARTI_NO`
+const xuguTableSubpartitionsSQL = `
+SELECT p.SUBPARTI_NAME, p.SUBPARTI_VAL
+FROM ALL_SUBPARTIS p
+JOIN ALL_TABLES t ON t.DB_ID = p.DB_ID AND t.TABLE_ID = p.TABLE_ID
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
+  AND UPPER(t.TABLE_NAME) = UPPER(?)
+ORDER BY p.SUBPARTI_NO`
 
 var xuguDataTypes = []string{
 	"BOOLEAN",
@@ -257,6 +304,50 @@ type foreignKeyInfo struct {
 	Column    string `json:"column"`
 	RefTable  string `json:"ref_table"`
 	RefColumn string `json:"ref_column"`
+}
+
+// xuguTableMetadata mirrors the ALL_TABLES properties that affect a CREATE
+// TABLE statement. Keeping this separate from tableInfo lets the object tree
+// stay lightweight while the DDL exporter stays faithful to the catalog.
+type xuguTableMetadata struct {
+	TempType          int
+	OnCommitDelete    bool
+	PctFree           int
+	CopyNum           int
+	PartitionType     int
+	PartitionCount    int
+	PartitionKey      string
+	AutoPartitionType int
+	AutoPartitionSpan int
+	SubpartitionType  int
+	SubpartitionCount int
+	SubpartitionKey   string
+	Comment           string
+}
+
+type xuguIdentityInfo struct {
+	Column string
+	Start  int64
+	Step   int64
+}
+
+type xuguConstraintInfo struct {
+	Name              string
+	Type              string
+	Definition        string
+	ReferenceSchema   string
+	ReferenceTable    string
+	MatchType         string
+	UpdateAction      string
+	DeleteAction      string
+	Deferrable        bool
+	InitiallyDeferred bool
+	Enabled           bool
+}
+
+type xuguPartitionInfo struct {
+	Name  string
+	Value string
 }
 
 type triggerInfo struct {
@@ -2202,49 +2293,401 @@ func (s *server) buildTableDDL(schema, table string) (string, error) {
 	if len(columns) == 0 {
 		return "", fmt.Errorf("table not found: %s.%s", schema, table)
 	}
+	metadata, err := s.tableMetadata(schema, table)
+	if err != nil {
+		return "", err
+	}
+	identities, err := s.tableIdentities(schema, table)
+	if err != nil {
+		return "", err
+	}
+	constraints, err := s.tableConstraints(schema, table)
+	if err != nil {
+		return "", err
+	}
+	partitions, err := s.tablePartitions(schema, table, false)
+	if err != nil {
+		return "", err
+	}
+	subpartitions, err := s.tablePartitions(schema, table, true)
+	if err != nil {
+		return "", err
+	}
+	return renderXuguTableDDL(schema, table, columns, metadata, identities, constraints, partitions, subpartitions), nil
+}
+
+func (s *server) tableMetadata(schema, table string) (xuguTableMetadata, error) {
+	rows, err := s.queryRows(xuguTableMetadataSQL, []any{schema, table})
+	if err != nil {
+		return xuguTableMetadata{}, err
+	}
+	defer s.closeRows(rows)
+	var item xuguTableMetadata
+	if !rows.Next() {
+		return item, rows.Err()
+	}
+	var tempType, onCommitDelete, pctFree, copyNum, partitionType, partitionCount, partitionKey any
+	var autoType, autoSpan, subpartitionType, subpartitionCount, subpartitionKey, comment any
+	if err := rows.Scan(&tempType, &onCommitDelete, &pctFree, &copyNum, &partitionType, &partitionCount, &partitionKey,
+		&autoType, &autoSpan, &subpartitionType, &subpartitionCount, &subpartitionKey, &comment); err != nil {
+		return item, err
+	}
+	item.TempType = xuguInt(tempType)
+	item.OnCommitDelete = truthy(onCommitDelete)
+	item.PctFree = xuguInt(pctFree)
+	item.CopyNum = xuguInt(copyNum)
+	item.PartitionType = xuguInt(partitionType)
+	item.PartitionCount = xuguInt(partitionCount)
+	item.PartitionKey = xuguString(partitionKey)
+	item.AutoPartitionType = xuguInt(autoType)
+	item.AutoPartitionSpan = xuguInt(autoSpan)
+	item.SubpartitionType = xuguInt(subpartitionType)
+	item.SubpartitionCount = xuguInt(subpartitionCount)
+	item.SubpartitionKey = xuguString(subpartitionKey)
+	item.Comment = xuguString(comment)
+	return item, rows.Err()
+}
+
+func (s *server) tableIdentities(schema, table string) (map[string]xuguIdentityInfo, error) {
+	rows, err := s.queryRows(xuguTableIdentitySQL, []any{schema, table})
+	if err != nil {
+		return nil, err
+	}
+	defer s.closeRows(rows)
+	result := map[string]xuguIdentityInfo{}
+	for rows.Next() {
+		var column, start, step any
+		if err := rows.Scan(&column, &start, &step); err != nil {
+			return nil, err
+		}
+		item := xuguIdentityInfo{Column: xuguString(column), Start: int64(xuguInt(start)), Step: int64(xuguInt(step))}
+		result[strings.ToUpper(item.Column)] = item
+	}
+	return result, rows.Err()
+}
+
+func (s *server) tableConstraints(schema, table string) ([]xuguConstraintInfo, error) {
+	rows, err := s.queryRows(xuguTableConstraintsSQL, []any{schema, table})
+	if err != nil {
+		return nil, err
+	}
+	defer s.closeRows(rows)
+	var result []xuguConstraintInfo
+	for rows.Next() {
+		var item xuguConstraintInfo
+		var name, constraintType, definition, referenceSchema, referenceTable any
+		var matchType, updateAction, deleteAction, deferrable, initiallyDeferred, enabled any
+		if err := rows.Scan(&name, &constraintType, &definition, &referenceSchema, &referenceTable,
+			&matchType, &updateAction, &deleteAction, &deferrable, &initiallyDeferred, &enabled); err != nil {
+			return nil, err
+		}
+		item.Name = xuguString(name)
+		item.Type = xuguString(constraintType)
+		item.Definition = xuguString(definition)
+		item.ReferenceSchema = xuguString(referenceSchema)
+		item.ReferenceTable = xuguString(referenceTable)
+		item.MatchType = xuguString(matchType)
+		item.UpdateAction = xuguString(updateAction)
+		item.DeleteAction = xuguString(deleteAction)
+		item.Deferrable = truthy(deferrable)
+		item.InitiallyDeferred = truthy(initiallyDeferred)
+		item.Enabled = truthy(enabled)
+		result = append(result, item)
+	}
+	return emptyIfNil(result), rows.Err()
+}
+
+func (s *server) tablePartitions(schema, table string, subpartition bool) ([]xuguPartitionInfo, error) {
+	query := xuguTablePartitionsSQL
+	if subpartition {
+		query = xuguTableSubpartitionsSQL
+	}
+	rows, err := s.queryRows(query, []any{schema, table})
+	if err != nil {
+		return nil, err
+	}
+	defer s.closeRows(rows)
+	var result []xuguPartitionInfo
+	for rows.Next() {
+		var name, value any
+		if err := rows.Scan(&name, &value); err != nil {
+			return nil, err
+		}
+		result = append(result, xuguPartitionInfo{Name: xuguString(name), Value: xuguString(value)})
+	}
+	return emptyIfNil(result), rows.Err()
+}
+
+// renderXuguTableDDL is deliberately independent from database access.  The
+// exporter can consequently be regression-tested against the catalog data
+// returned by Xugu without requiring a privileged DBMS_METADATA call.
+func renderXuguTableDDL(schema, table string, columns []columnInfo, metadata xuguTableMetadata, identities map[string]xuguIdentityInfo, constraints []xuguConstraintInfo, partitions, subpartitions []xuguPartitionInfo) string {
 	var builder strings.Builder
-	builder.WriteString("CREATE TABLE ")
+	switch metadata.TempType {
+	case 2:
+		builder.WriteString("CREATE GLOBAL TEMP TABLE ")
+	case 1:
+		builder.WriteString("CREATE TEMP TABLE ")
+	default:
+		builder.WriteString("CREATE TABLE ")
+	}
 	builder.WriteString(quoteIdentifier(schema))
 	builder.WriteByte('.')
 	builder.WriteString(quoteIdentifier(table))
 	builder.WriteString(" (\n")
-	for i, column := range columns {
-		if i > 0 {
-			builder.WriteString(",\n")
+	items := make([]string, 0, len(columns)+len(constraints))
+	for _, column := range columns {
+		var item strings.Builder
+		item.WriteString("  ")
+		item.WriteString(quoteIdentifier(column.Name))
+		item.WriteByte(' ')
+		item.WriteString(columnTypeDDL(column))
+		if identity, ok := identities[strings.ToUpper(column.Name)]; ok {
+			item.WriteString(fmt.Sprintf(" IDENTITY(%d,%d)", identity.Start, identity.Step))
 		}
-		builder.WriteString("  ")
-		builder.WriteString(quoteIdentifier(column.Name))
-		builder.WriteByte(' ')
-		builder.WriteString(columnTypeDDL(column))
 		if column.ColumnDefault != nil && strings.TrimSpace(*column.ColumnDefault) != "" {
-			builder.WriteString(" DEFAULT ")
-			builder.WriteString(strings.TrimSpace(*column.ColumnDefault))
+			item.WriteString(" DEFAULT ")
+			item.WriteString(strings.TrimSpace(*column.ColumnDefault))
 		}
 		if !column.IsNullable {
-			builder.WriteString(" NOT NULL")
+			item.WriteString(" NOT NULL")
 		}
 		if column.Comment != nil && strings.TrimSpace(*column.Comment) != "" {
-			builder.WriteString(" COMMENT ")
-			builder.WriteString(quoteStringLiteral(strings.TrimSpace(*column.Comment)))
+			item.WriteString(" COMMENT ")
+			item.WriteString(quoteStringLiteral(strings.TrimSpace(*column.Comment)))
+		}
+		items = append(items, item.String())
+	}
+	for _, constraint := range constraints {
+		if item := renderXuguConstraintDDL(constraint); item != "" {
+			items = append(items, "  "+item)
 		}
 	}
-	primary := make([]string, 0)
-	for _, column := range columns {
-		if column.IsPrimaryKey {
-			primary = append(primary, quoteIdentifier(column.Name))
-		}
-	}
-	if len(primary) > 0 {
-		builder.WriteString(",\n  PRIMARY KEY (")
-		builder.WriteString(strings.Join(primary, ", "))
-		builder.WriteByte(')')
-	}
+	builder.WriteString(strings.Join(items, ",\n"))
 	builder.WriteString("\n)")
-	if comment, err := s.tableComment(schema, table); err == nil && strings.TrimSpace(comment) != "" {
-		builder.WriteString("\nCOMMENT ")
-		builder.WriteString(quoteStringLiteral(strings.TrimSpace(comment)))
+	if metadata.TempType != 0 {
+		if metadata.OnCommitDelete {
+			builder.WriteString(" ON COMMIT DELETE ROWS")
+		} else {
+			builder.WriteString(" ON COMMIT PRESERVE ROWS")
+		}
 	}
-	return builder.String(), nil
+	builder.WriteString(renderXuguPartitionDDL(metadata, partitions, subpartitions))
+	// Xugu's CREATE TABLE grammar places storage attributes after the
+	// partition/subpartition clause (not between the table body and PARTITION).
+	if metadata.PctFree > 0 {
+		builder.WriteString(fmt.Sprintf(" PCTFREE %d", metadata.PctFree))
+	}
+	if metadata.CopyNum > 0 {
+		builder.WriteString(fmt.Sprintf(" COPY NUMBER %d", metadata.CopyNum))
+	}
+	if strings.TrimSpace(metadata.Comment) != "" {
+		builder.WriteString("\nCOMMENT ")
+		builder.WriteString(quoteStringLiteral(strings.TrimSpace(metadata.Comment)))
+	}
+	for _, constraint := range constraints {
+		if !constraint.Enabled && strings.TrimSpace(constraint.Name) != "" {
+			builder.WriteString(";\n\nALTER TABLE ")
+			builder.WriteString(quoteIdentifier(schema))
+			builder.WriteByte('.')
+			builder.WriteString(quoteIdentifier(table))
+			builder.WriteString(" DISABLE CONSTRAINT ")
+			builder.WriteString(quoteIdentifier(constraint.Name))
+		}
+	}
+	return builder.String()
+}
+
+func renderXuguConstraintDDL(constraint xuguConstraintInfo) string {
+	name := strings.TrimSpace(constraint.Name)
+	definition := strings.TrimSpace(constraint.Definition)
+	if name == "" || definition == "" {
+		return ""
+	}
+	prefix := "CONSTRAINT " + quoteIdentifier(name) + " "
+	switch strings.ToUpper(strings.TrimSpace(constraint.Type)) {
+	case "P":
+		return prefix + "PRIMARY KEY (" + definition + ")"
+	case "U":
+		return prefix + "UNIQUE (" + definition + ")"
+	case "C":
+		return prefix + "CHECK (" + definition + ")"
+	case "F":
+		localColumns, referencedColumns := parseForeignKeyColumns(definition)
+		if len(localColumns) == 0 || len(referencedColumns) == 0 || strings.TrimSpace(constraint.ReferenceTable) == "" {
+			return ""
+		}
+		var builder strings.Builder
+		builder.WriteString(prefix)
+		builder.WriteString("FOREIGN KEY (")
+		builder.WriteString(quotedIdentifiers(localColumns))
+		builder.WriteString(") REFERENCES ")
+		if strings.TrimSpace(constraint.ReferenceSchema) != "" {
+			builder.WriteString(quoteIdentifier(constraint.ReferenceSchema))
+			builder.WriteByte('.')
+		}
+		builder.WriteString(quoteIdentifier(constraint.ReferenceTable))
+		builder.WriteString(" (")
+		builder.WriteString(quotedIdentifiers(referencedColumns))
+		builder.WriteByte(')')
+		if match := xuguMatchClause(constraint.MatchType); match != "" {
+			builder.WriteByte(' ')
+			builder.WriteString(match)
+		}
+		if action := xuguReferentialAction(constraint.UpdateAction); action != "" {
+			builder.WriteString(" ON UPDATE ")
+			builder.WriteString(action)
+		}
+		if action := xuguReferentialAction(constraint.DeleteAction); action != "" {
+			builder.WriteString(" ON DELETE ")
+			builder.WriteString(action)
+		}
+		if constraint.Deferrable {
+			builder.WriteString(" DEFERRABLE")
+			if constraint.InitiallyDeferred {
+				builder.WriteString(" INITIALLY DEFERRED")
+			} else {
+				builder.WriteString(" INITIALLY IMMEDIATE")
+			}
+		} else {
+			builder.WriteString(" NOT DEFERRABLE")
+		}
+		return builder.String()
+	default:
+		return ""
+	}
+}
+
+func renderXuguPartitionDDL(metadata xuguTableMetadata, partitions, subpartitions []xuguPartitionInfo) string {
+	var builder strings.Builder
+	if key := strings.TrimSpace(metadata.PartitionKey); key != "" && metadata.PartitionType != 0 {
+		typeName := xuguPartitionType(metadata.PartitionType)
+		if typeName != "" {
+			builder.WriteString(" PARTITION BY ")
+			builder.WriteString(typeName)
+			builder.WriteString(" (")
+			builder.WriteString(key)
+			builder.WriteByte(')')
+			if metadata.AutoPartitionType != 0 && metadata.AutoPartitionSpan > 0 {
+				if interval := xuguAutoPartitionInterval(metadata.AutoPartitionType, metadata.AutoPartitionSpan); interval != "" {
+					builder.WriteString(" INTERVAL ")
+					builder.WriteString(interval)
+				}
+			}
+			if metadata.PartitionType == 3 && len(partitions) == 0 && metadata.PartitionCount > 0 {
+				builder.WriteString(fmt.Sprintf(" PARTITIONS %d", metadata.PartitionCount))
+			} else if len(partitions) > 0 {
+				builder.WriteString(" PARTITIONS (\n")
+				for i, partition := range partitions {
+					if i > 0 {
+						builder.WriteString(",\n")
+					}
+					builder.WriteString("  ")
+					builder.WriteString(quoteIdentifier(partition.Name))
+					builder.WriteByte(' ')
+					if metadata.PartitionType == 1 {
+						builder.WriteString("VALUES LESS THAN (")
+					} else if metadata.PartitionType == 2 && strings.EqualFold(strings.TrimSpace(partition.Value), "OTHERVALUES") {
+						builder.WriteString("VALUES (")
+					} else {
+						builder.WriteString("VALUES (")
+					}
+					builder.WriteString(strings.TrimSpace(partition.Value))
+					builder.WriteByte(')')
+				}
+				builder.WriteString("\n)")
+			}
+		}
+	}
+	if key := strings.TrimSpace(metadata.SubpartitionKey); key != "" && metadata.SubpartitionType != 0 {
+		typeName := xuguPartitionType(metadata.SubpartitionType)
+		if typeName != "" {
+			builder.WriteString(" SUBPARTITION BY ")
+			builder.WriteString(typeName)
+			builder.WriteString(" (")
+			builder.WriteString(key)
+			builder.WriteByte(')')
+			if metadata.SubpartitionType == 3 && len(subpartitions) == 0 && metadata.SubpartitionCount > 0 {
+				builder.WriteString(fmt.Sprintf(" SUBPARTITIONS %d", metadata.SubpartitionCount))
+			} else if len(subpartitions) > 0 {
+				builder.WriteString(" SUBPARTITIONS (\n")
+				for i, partition := range subpartitions {
+					if i > 0 {
+						builder.WriteString(",\n")
+					}
+					builder.WriteString("  ")
+					builder.WriteString(quoteIdentifier(partition.Name))
+					builder.WriteByte(' ')
+					if metadata.SubpartitionType == 1 {
+						builder.WriteString("VALUES LESS THAN (")
+					} else {
+						builder.WriteString("VALUES (")
+					}
+					builder.WriteString(strings.TrimSpace(partition.Value))
+					builder.WriteByte(')')
+				}
+				builder.WriteString("\n)")
+			}
+		}
+	}
+	return builder.String()
+}
+
+func quotedIdentifiers(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, quoteIdentifier(value))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func xuguReferentialAction(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "n":
+		return "NO ACTION"
+	case "r":
+		return "RESTRICT"
+	case "c":
+		return "CASCADE"
+	case "u":
+		return "SET NULL"
+	case "d":
+		return "SET DEFAULT"
+	default:
+		return ""
+	}
+}
+
+func xuguMatchClause(value string) string {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "F":
+		return "MATCH FULL"
+	case "P":
+		return "MATCH PARTIAL"
+	default:
+		return ""
+	}
+}
+
+func xuguPartitionType(value int) string {
+	switch value {
+	case 1:
+		return "RANGE"
+	case 2:
+		return "LIST"
+	case 3:
+		return "HASH"
+	default:
+		return ""
+	}
+}
+
+func xuguAutoPartitionInterval(kind, span int) string {
+	unit := map[int]string{1: "YEAR", 2: "MONTH", 3: "DAY", 4: "HOUR"}[kind]
+	if unit == "" || span <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d %s", span, unit)
 }
 
 func (s *server) appendTableIndexDDL(schema, table, ddl string) string {
@@ -2426,6 +2869,32 @@ func truthy(value any) bool {
 		return upper == "T" || upper == "TRUE" || upper == "1" || upper == "Y" || upper == "YES"
 	default:
 		return false
+	}
+}
+
+func xuguString(value any) string {
+	value = normalizeValue(value)
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func xuguInt(value any) int {
+	value = normalizeValue(value)
+	switch v := value.(type) {
+	case int64:
+		return int(v)
+	case int:
+		return v
+	case float64:
+		return int(v)
+	case string:
+		parsed, _ := strconv.Atoi(strings.TrimSpace(v))
+		return parsed
+	default:
+		parsed, _ := strconv.Atoi(strings.TrimSpace(fmt.Sprint(v)))
+		return parsed
 	}
 }
 

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -642,6 +642,84 @@ func TestParseForeignKeyColumns(t *testing.T) {
 	}
 }
 
+func TestRenderXuguTableDDLPreservesProgrammableTableMetadata(t *testing.T) {
+	amountDefault := "0"
+	description := "child table"
+	ddl := renderXuguTableDDL(
+		"APP", "CHILD",
+		[]columnInfo{
+			{Name: "ID", DataType: "INTEGER", IsNullable: false},
+			{Name: "PARENT_ID", DataType: "INTEGER", IsNullable: false},
+			{Name: "AMOUNT", DataType: "NUMERIC", IsNullable: true, ColumnDefault: &amountDefault},
+		},
+		xuguTableMetadata{
+			PctFree:        15,
+			CopyNum:        3,
+			PartitionType:  1,
+			PartitionKey:   `"ID"`,
+			PartitionCount: 2,
+			Comment:        description,
+		},
+		map[string]xuguIdentityInfo{"ID": {Column: "ID", Start: 10, Step: 5}},
+		[]xuguConstraintInfo{
+			{Name: "PK_CHILD", Type: "P", Definition: `"ID"`, Enabled: true},
+			{Name: "CK_CHILD_AMOUNT", Type: "C", Definition: `("AMOUNT") >= (0)`, Enabled: true},
+			{
+				Name: "FK_CHILD_PARENT", Type: "F", Definition: `("PARENT_ID")("ID")`,
+				ReferenceSchema: "APP", ReferenceTable: "PARENT", UpdateAction: "n", DeleteAction: "c", Enabled: true,
+			},
+		},
+		[]xuguPartitionInfo{{Name: "P_10", Value: "10"}, {Name: "P_MAX", Value: "MAXVALUES"}}, nil,
+	)
+
+	for _, want := range []string{
+		`"ID" INTEGER IDENTITY(10,5) NOT NULL`,
+		`CONSTRAINT "PK_CHILD" PRIMARY KEY ("ID")`,
+		`CONSTRAINT "CK_CHILD_AMOUNT" CHECK (("AMOUNT") >= (0))`,
+		`CONSTRAINT "FK_CHILD_PARENT" FOREIGN KEY ("PARENT_ID") REFERENCES "APP"."PARENT" ("ID") ON UPDATE NO ACTION ON DELETE CASCADE NOT DEFERRABLE`,
+		"PCTFREE 15 COPY NUMBER 3",
+		`PARTITION BY RANGE ("ID") PARTITIONS (`,
+		`"P_10" VALUES LESS THAN (10)`,
+		`"P_MAX" VALUES LESS THAN (MAXVALUES)`,
+		"COMMENT 'child table'",
+	} {
+		if !strings.Contains(ddl, want) {
+			t.Fatalf("generated DDL is missing %q:\n%s", want, ddl)
+		}
+	}
+}
+
+func TestRenderXuguTableDDLTemporaryTableCommitMode(t *testing.T) {
+	ddl := renderXuguTableDDL("APP", "TMP", []columnInfo{{Name: "ID", DataType: "INTEGER", IsNullable: true}},
+		xuguTableMetadata{TempType: 1, OnCommitDelete: true}, nil, nil, nil, nil)
+	if !strings.HasPrefix(ddl, `CREATE TEMP TABLE "APP"."TMP"`) || !strings.Contains(ddl, "ON COMMIT DELETE ROWS") {
+		t.Fatalf("unexpected temporary table DDL: %s", ddl)
+	}
+	globalDDL := renderXuguTableDDL("APP", "GTMP", []columnInfo{{Name: "ID", DataType: "INTEGER", IsNullable: true}},
+		xuguTableMetadata{TempType: 2, OnCommitDelete: false}, nil, nil, nil, nil)
+	if !strings.HasPrefix(globalDDL, `CREATE GLOBAL TEMP TABLE "APP"."GTMP"`) || !strings.Contains(globalDDL, "ON COMMIT PRESERVE ROWS") {
+		t.Fatalf("unexpected global temporary table DDL: %s", globalDDL)
+	}
+}
+
+func TestRenderXuguTableDDLSubpartitionDefinitions(t *testing.T) {
+	ddl := renderXuguTableDDL("APP", "SUBPART", []columnInfo{{Name: "ID", DataType: "INTEGER", IsNullable: true}},
+		xuguTableMetadata{PartitionType: 2, PartitionKey: `"REGION"`, SubpartitionType: 1, SubpartitionKey: `"ID"`}, nil, nil,
+		[]xuguPartitionInfo{{Name: "P_EAST", Value: "'east'"}},
+		[]xuguPartitionInfo{{Name: "SP_10", Value: "10"}, {Name: "SP_MAX", Value: "MAXVALUES"}})
+	for _, want := range []string{
+		`PARTITION BY LIST ("REGION")`,
+		`"P_EAST" VALUES ('east')`,
+		`SUBPARTITION BY RANGE ("ID") SUBPARTITIONS (`,
+		`"SP_10" VALUES LESS THAN (10)`,
+		`"SP_MAX" VALUES LESS THAN (MAXVALUES)`,
+	} {
+		if !strings.Contains(ddl, want) {
+			t.Fatalf("generated DDL is missing %q:\n%s", want, ddl)
+		}
+	}
+}
+
 func TestDecodeXuguScale(t *testing.T) {
 	numericScale := 32*65536 + 6
 	precision, scale, length := decodeXuguScale("NUMERIC", &numericScale)

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -590,6 +590,19 @@ func TestXuguObjectSourceQuerySupportsSharedObjectKinds(t *testing.T) {
 	if !strings.Contains(typeBodyQuery, "ALL_TYPES") || !strings.Contains(typeBodyQuery, "TO_CHAR(u.BODY)") || !strings.Contains(typeBodyQuery, "u.BODY IS NOT NULL") {
 		t.Fatalf("type body query must return catalog BODY content: %s", typeBodyQuery)
 	}
+
+	for _, objectType := range []string{"VIEW", "TRIGGER", "PROCEDURE", "FUNCTION", "PACKAGE", "PACKAGE_BODY"} {
+		query, _, err := objectSourceQuery("APP", "demo", objectType)
+		if err != nil {
+			t.Fatalf("%s source query: %v", objectType, err)
+		}
+		if !strings.Contains(query, "FROM ALL_") || !strings.Contains(query, "JOIN ALL_SCHEMAS") {
+			t.Fatalf("%s must use access-scoped ALL_* metadata: %s", objectType, query)
+		}
+		if strings.Contains(query, "SYS_") {
+			t.Fatalf("%s must not require SYS_* metadata access: %s", objectType, query)
+		}
+	}
 }
 
 func TestMetadataListConstraintsFromParams(t *testing.T) {

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -720,6 +720,47 @@ func TestRenderXuguTableDDLSubpartitionDefinitions(t *testing.T) {
 	}
 }
 
+func TestRenderXuguTableDDLPreservesHashPartitionCount(t *testing.T) {
+	ddl := renderXuguTableDDL("APP", "HASH_PART", []columnInfo{{Name: "ID", DataType: "INTEGER", IsNullable: true}},
+		xuguTableMetadata{PartitionType: 3, PartitionKey: `"ID"`, PartitionCount: 4}, nil, nil,
+		[]xuguPartitionInfo{{Name: "SYS_P1", Value: "1"}, {Name: "SYS_P2", Value: "2"}}, nil)
+	if !strings.Contains(ddl, `PARTITION BY HASH ("ID") PARTITIONS 4`) {
+		t.Fatalf("hash partition count was not preserved: %s", ddl)
+	}
+	if strings.Contains(ddl, "VALUES") {
+		t.Fatalf("hash partition DDL must not render RANGE/LIST values: %s", ddl)
+	}
+}
+
+func TestRenderXuguTableDDLPreservesMatchAndDefaultOnNull(t *testing.T) {
+	insertOnlyDefault := "'insert'"
+	insertUpdateDefault := "'update'"
+	ddl := renderXuguTableDDL("APP", "CHILD",
+		[]columnInfo{
+			{Name: "A", DataType: "INTEGER", IsNullable: false},
+			{Name: "B", DataType: "INTEGER", IsNullable: false},
+			{Name: "INSERT_ONLY", DataType: "VARCHAR", IsNullable: false, ColumnDefault: &insertOnlyDefault, DefaultOnNull: 1},
+			{Name: "INSERT_UPDATE", DataType: "VARCHAR", IsNullable: false, ColumnDefault: &insertUpdateDefault, DefaultOnNull: 2},
+		},
+		xuguTableMetadata{}, nil,
+		[]xuguConstraintInfo{{
+			Name: "FK_CHILD_PARENT", Type: "F", Definition: `("A","B")("A","B")`,
+			ReferenceSchema: "APP", ReferenceTable: "PARENT", MatchType: "A", Enabled: true,
+		}}, nil, nil)
+	for _, want := range []string{
+		`DEFAULT ON NULL FOR INSERT ONLY 'insert'`,
+		`DEFAULT ON NULL FOR INSERT AND UPDATE 'update'`,
+		`FOREIGN KEY ("A", "B") REFERENCES "APP"."PARENT" ("A", "B") MATCH FULL`,
+	} {
+		if !strings.Contains(ddl, want) {
+			t.Fatalf("generated DDL is missing %q:\n%s", want, ddl)
+		}
+	}
+	if got := xuguMatchClause("U"); got != "" {
+		t.Fatalf("MATCH_TYPE U = %q, want omitted default MATCH SIMPLE", got)
+	}
+}
+
 func TestDecodeXuguScale(t *testing.T) {
 	numericScale := 32*65536 + 6
 	precision, scale, length := decodeXuguScale("NUMERIC", &numericScale)


### PR DESCRIPTION
## Summary

- Read Xugu view, trigger, procedure, function, and package source through access-scoped `ALL_*` catalogs instead of privileged `SYS_*` catalogs.
- Reconstruct Xugu table DDL from columns, primary keys, and indexes rather than calling `DBMS_METADATA.GET_DDL`, which can block indefinitely.

## Validation

- `go test ./...` in `agents/drivers/xugu`
- Manual local XuguDB regression: trigger source returned successfully; `QRTZ_BLOB_TRIGGERS` table DDL returned immediately.

## Scope

Xugu Agent only; no frontend changes or bundled Agent binary.