### PR TITLE
fix(grid): 修复数据窗格无法保存字符串 null(输入字符串NULL、null、Null等都会将单元格置为NULL)

### DIFF
--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
@@ -34,6 +34,26 @@ describe("dataGridCellDisplayText", () => {
 });
 
 describe("coerceDataGridCellValue", () => {
+  it.each(["null", "NULL", "Null", "nUlL"])("preserves literal %s input as text", (value) => {
+    expect(
+      coerceDataGridCellValue({
+        value,
+        oldValue: null,
+        databaseType: "mysql",
+        columnInfo: { data_type: "varchar(255)" },
+      }),
+    ).toBe(value);
+
+    expect(
+      coerceDataGridCellValue({
+        value,
+        oldValue: "previous",
+        databaseType: "postgres",
+        columnInfo: { data_type: "text" },
+      }),
+    ).toBe(value);
+  });
+
   it("preserves an explicitly generated empty string for a null cell", () => {
     const options = {
       value: "",

--- a/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
@@ -11,7 +11,6 @@ export interface CoerceDataGridCellValueOptions {
 
 export function coerceDataGridCellValue(options: CoerceDataGridCellValueOptions): GridCellValue {
   const { value, oldValue } = options;
-  if (value.toUpperCase() === "NULL") return null;
   if (value === "" && oldValue === null && !options.preserveEmptyString) return null;
   const postgresArrayValue = coercePostgresArrayValue(options);
   if (postgresArrayValue !== undefined) return postgresArrayValue;

--- a/packages/app-tests/dataGridEditor.test.ts
+++ b/packages/app-tests/dataGridEditor.test.ts
@@ -618,6 +618,23 @@ test("undo and redo restore pending cell edits before save", () => {
   assert.deepEqual(editor.rowDataWithChanges(result.value.rows[0], 0), [1, "Ada Lovelace"]);
 });
 
+test("typing NULL preserves the literal string value", async () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+
+  const result = computed(() => ({
+    columns: ["id", "name"],
+    rows: [[1, "Ada"] as CellValue[]],
+  }));
+  const editor = createPeopleGridEditor(result);
+
+  editor.applyCellValue(0, 1, "NULL");
+
+  assert.equal(editor.dirtyRows.value.get(0)?.get(1), "NULL");
+  assert.deepEqual(editor.rowDataWithChanges(result.value.rows[0], 0), [1, "NULL"]);
+  assert.deepEqual(await editor.previewChanges(), [`UPDATE "people" SET "name" = 'NULL' WHERE "id" = 1;`]);
+});
+
 test("setting a cell to NULL records pending SQL and supports undo and redo", async () => {
   setActivePinia(createPinia());
   installBrowserTestGlobals();


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
### 修复数据窗格无法保存字符串 null的bug

移除数据窗格将大小写不敏感的文本 NULL 自动转换为数据库空值的隐式规则。用户输入 null、NULL、Null 等内容时，一律按普通字符串保存；数据库 NULL 继续通过现有的显式操作设置。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
- 修复前：

 输入null
<img width="525" height="150" alt="image" src="https://github.com/user-attachments/assets/ef8fbe05-7b42-4360-b36e-822602b86e5e" />

光标移动其他单元格，刚才输入的单元格变为NULL，并且无法提交
<img width="465" height="140" alt="image" src="https://github.com/user-attachments/assets/fc07d9ca-1775-46ce-a775-5d5686318ea6" />

- 修复后：

 输入null
<img width="376" height="99" alt="image" src="https://github.com/user-attachments/assets/83edac5c-b29a-4900-a7a4-d96d9695b953" />

提交修改后
<img width="450" height="129" alt="image" src="https://github.com/user-attachments/assets/a34651ec-dd62-4b0c-896f-336014e3bd69" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
