### PR TITLE
Fix：修复 SQL Server 长 VARCHAR 查询结果显示不完整

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -106,7 +106,7 @@ import {
   visibleTransposeRecordWindow,
 } from "@/lib/dataGrid/dataGridTranspose";
 import { canApplyGridSelectionValue, canDeleteGridRowItem, canEditGridCellDetail, matchesRowStatusFilter, shouldShowQuickEntryDraftRow, type RowStatus, type RowStatusFilter } from "@/lib/dataGrid/gridRowStatus";
-import { displayCellValue, firstLineCellDisplayValue, type CellValue } from "@/lib/dataGrid/cellValue";
+import { displayCellValue, firstLineCellDisplayValue, limitDataGridCellDisplay, SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH, type CellValue } from "@/lib/dataGrid/cellValue";
 import { getApplicablePreviewActions } from "@/lib/dataGrid/resultPreviewRegistry";
 import "@/lib/dataGrid/geometryMapPreview";
 import {
@@ -4141,7 +4141,6 @@ async function applyWhereFilter() {
   }
 }
 
-const CELL_DISPLAY_MAX_LENGTH = 256;
 const CELL_FORMAT_CACHE_LIMIT = 20_000;
 const CELL_FORMAT_CACHE_PRUNE_COUNT = 5_000;
 
@@ -4190,7 +4189,7 @@ function formatCell(value: CellValue, columnIndex?: number): string {
   const binaryDisplay = formatter ? null : binaryCellDisplayText(value, columnInfo?.data_type ?? (columnName ? columnTypeMap.value.get(columnName) : undefined));
   if (binaryDisplay) return binaryDisplay;
   const s = applyColumnFormatter(value, formatter);
-  return s.length > CELL_DISPLAY_MAX_LENGTH ? s.slice(0, CELL_DISPLAY_MAX_LENGTH) : s;
+  return limitDataGridCellDisplay(s, resolvedDatabaseType.value === "sqlserver" ? SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH : undefined);
 }
 
 function formatCellCached(value: CellValue, columnIndex?: number): string {

--- a/apps/desktop/src/lib/dataGrid/cellValue.ts
+++ b/apps/desktop/src/lib/dataGrid/cellValue.ts
@@ -1,5 +1,8 @@
 export type CellValue = string | number | boolean | null;
 
+export const DATA_GRID_CELL_DISPLAY_MAX_LENGTH = 256;
+export const SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH = 8_000;
+
 export function displayCellValue(value: CellValue): string {
   if (value === null) return "NULL";
   if (typeof value === "boolean") return value ? "true" : "false";
@@ -10,4 +13,9 @@ export function displayCellValue(value: CellValue): string {
 export function firstLineCellDisplayValue(value: string): string {
   const lineBreakIndex = value.search(/\r\n|\r|\n/);
   return lineBreakIndex === -1 ? value : value.slice(0, lineBreakIndex);
+}
+
+export function limitDataGridCellDisplay(value: string, maxLength = DATA_GRID_CELL_DISPLAY_MAX_LENGTH): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...`;
 }

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
-use tiberius::{AuthMethod, Client, ColumnData, Config, FromSql, QueryItem, QueryStream, SqlBrowser};
+use tiberius::{AuthMethod, Client, ColumnData, ColumnType, Config, FromSql, QueryItem, QueryStream, SqlBrowser};
 use tokio::net::TcpStream;
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 use tokio_util::sync::CancellationToken;
@@ -194,11 +194,14 @@ fn columns_from_metadata(metadata: &tiberius::ResultMetadata) -> Vec<String> {
     metadata.columns().iter().map(|c| c.name().to_string()).collect()
 }
 
-/// Map a tiberius column to a user-facing type name for the result-grid header.
-/// Uses the TDS column-type debug name lowercased; good enough for display, with
-/// no risk of mismatching the enum variants across tiberius versions.
 fn sqlserver_column_type_name(column: &tiberius::Column) -> String {
-    format!("{:?}", column.column_type()).to_lowercase()
+    match column.column_type() {
+        ColumnType::BigVarChar => "varchar".to_string(),
+        ColumnType::BigChar => "char".to_string(),
+        ColumnType::BigVarBin => "varbinary".to_string(),
+        ColumnType::BigBinary => "binary".to_string(),
+        column_type => format!("{column_type:?}").to_lowercase(),
+    }
 }
 
 fn column_types_from_metadata(metadata: &tiberius::ResultMetadata) -> Vec<String> {
@@ -2096,7 +2099,7 @@ mod tests {
     };
     use chrono::NaiveDate;
     use std::{borrow::Cow, time::Instant};
-    use tiberius::{ColumnData, IntoSql};
+    use tiberius::{Column, ColumnData, ColumnType, IntoSql};
 
     #[tokio::test]
     async fn sqlserver_ignores_non_info_tiberius_events() {
@@ -2164,6 +2167,19 @@ mod tests {
             sqlserver_cell_to_json(&cell),
             serde_json::Value::String("<ShowPlanXML><RelOp NodeId=\"0\" /></ShowPlanXML>".to_string())
         );
+    }
+
+    #[test]
+    fn sqlserver_uses_sql_type_names_for_tds_big_types() {
+        for (column_type, expected) in [
+            (ColumnType::BigVarChar, "varchar"),
+            (ColumnType::BigChar, "char"),
+            (ColumnType::BigVarBin, "varbinary"),
+            (ColumnType::BigBinary, "binary"),
+        ] {
+            let column = Column::new("value".to_string(), column_type);
+            assert_eq!(super::sqlserver_column_type_name(&column), expected);
+        }
     }
 
     #[test]

--- a/crates/dbx-core/tests/live_sqlserver_long_varchar.rs
+++ b/crates/dbx-core/tests/live_sqlserver_long_varchar.rs
@@ -1,0 +1,39 @@
+use dbx_core::db::sqlserver;
+use std::time::Duration;
+
+#[tokio::test]
+#[ignore = "requires DBX_LIVE_SQLSERVER_HOST/PORT/USER/PASSWORD pointing at SQL Server"]
+async fn live_sqlserver_long_varchar_results_are_complete_and_use_sql_type_names() {
+    let host = std::env::var("DBX_LIVE_SQLSERVER_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = std::env::var("DBX_LIVE_SQLSERVER_PORT").ok().and_then(|value| value.parse().ok()).unwrap_or(1433);
+    let user = std::env::var("DBX_LIVE_SQLSERVER_USER").unwrap_or_else(|_| "sa".to_string());
+    let password = std::env::var("DBX_LIVE_SQLSERVER_PASSWORD").expect("DBX_LIVE_SQLSERVER_PASSWORD");
+    let database = std::env::var("DBX_LIVE_SQLSERVER_DATABASE").unwrap_or_else(|_| "tempdb".to_string());
+    let mut client = sqlserver::connect_with_port_explicit(
+        &host,
+        port,
+        true,
+        &user,
+        &password,
+        Some(&database),
+        Duration::from_secs(15),
+    )
+    .await
+    .expect("connect to SQL Server");
+
+    let result = sqlserver::execute_query(
+        &mut client,
+        "SELECT CAST(REPLICATE('A', 250) + REPLICATE('B', 250) AS VARCHAR(500)) AS long_value \
+         UNION ALL \
+         SELECT CAST(REPLICATE('C', 500) AS VARCHAR(500))",
+    )
+    .await
+    .expect("query VARCHAR(500) values");
+
+    assert_eq!(result.columns, vec!["long_value"]);
+    assert_eq!(result.column_types, vec!["varchar"]);
+    assert_eq!(result.rows.len(), 2);
+    assert_eq!(result.rows[0][0].as_str().map(str::len), Some(500));
+    assert_eq!(result.rows[0][0], serde_json::json!(format!("{}{}", "A".repeat(250), "B".repeat(250))));
+    assert_eq!(result.rows[1][0], serde_json::json!("C".repeat(500)));
+}

--- a/packages/app-tests/cellValue.test.ts
+++ b/packages/app-tests/cellValue.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { displayCellValue } from "../../apps/desktop/src/lib/dataGrid/cellValue.ts";
+import { DATA_GRID_CELL_DISPLAY_MAX_LENGTH, displayCellValue, limitDataGridCellDisplay, SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH } from "../../apps/desktop/src/lib/dataGrid/cellValue.ts";
 
 test("displayCellValue returns NULL for null", () => {
   assert.equal(displayCellValue(null), "NULL");
@@ -25,6 +25,21 @@ test("displayCellValue returns String for strings", () => {
 test("displayCellValue does not truncate long strings", () => {
   const long = "a".repeat(1000);
   assert.equal(displayCellValue(long), long);
+});
+
+test("limitDataGridCellDisplay preserves bounded SQL Server varchar values", () => {
+  const value = "a".repeat(500);
+  assert.equal(limitDataGridCellDisplay(value, SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH), value);
+});
+
+test("limitDataGridCellDisplay marks oversized LOB previews as truncated", () => {
+  const value = "a".repeat(DATA_GRID_CELL_DISPLAY_MAX_LENGTH + 1);
+  assert.equal(limitDataGridCellDisplay(value), `${"a".repeat(DATA_GRID_CELL_DISPLAY_MAX_LENGTH)}...`);
+});
+
+test("limitDataGridCellDisplay preserves the default grid rendering limit", () => {
+  const value = "a".repeat(500);
+  assert.equal(limitDataGridCellDisplay(value), `${"a".repeat(DATA_GRID_CELL_DISPLAY_MAX_LENGTH)}...`);
 });
 
 test("displayCellValue serializes JSON strings containing complex nested objects", () => {


### PR DESCRIPTION
## 修改内容

- 将 SQL Server 查询结果网格的文本显示上限扩展到 8000 字符，完整覆盖普通 `VARCHAR(n)`，其他数据库继续保留原有 256 字符性能保护
- 超过网格显示上限的 LOB 使用省略号明确标识，单元格原值、复制和详情数据不受影响
- 将 Tiberius 的 `BigVarChar`、`BigChar`、`BigVarBin`、`BigBinary` 内部类型名映射为 SQL Server 标准类型名
- 增加长 `VARCHAR` 前端回归测试、类型映射单元测试和真实 SQL Server 集成测试

## 原因

DBX 此前为了避免超大文本影响网格滚动性能，将所有单元格显示内容静默截断为 256 字符，因此 `VARCHAR(500)` 会显示不完整。同时 SQL Server 驱动直接展示 Tiberius 的 TDS 枚举名，导致 `VARCHAR` 显示为 `bigvarchar`。

## 测试

- `pnpm check`
- `cargo test -p dbx-core --no-default-features --features sqlite-sqlcipher --lib`（2117 passed，9 ignored）
- 真实 SQL Server 2022：`VARCHAR(500)` 拼接及 `UNION ALL` 两行均返回完整 500 字符，结果类型为 `varchar`

Fixes #3858