### PR TITLE
Fix: 修复 TDengine 大量表加载超时

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -1915,7 +1915,7 @@ async fn list_tables_once(
         try_sqlserver!(connections, &pool_key, list_tables, schema, filter, limit, offset);
         if let Some(client) = extract_pool!(&connections, &pool_key, Agent) {
             let is_oracle = db_config.as_ref().is_some_and(|config| config.db_type == DatabaseType::Oracle);
-            let use_oracle_agent_paging = db_config.as_ref().is_some_and(is_default_oracle_agent_config);
+            let use_agent_table_paging = db_config.as_ref().is_some_and(supports_agent_table_paging);
             let filter_locally_after_oracle_comments =
                 is_oracle && filter.is_some_and(|filter| !filter.trim().is_empty());
             let timeout_duration = agent_metadata_timeout(db_config.as_ref());
@@ -1925,14 +1925,14 @@ async fn list_tables_once(
             let agent_filter = if filter_locally_after_oracle_comments { None } else { filter };
             let agent_limit = if filter_locally_after_oracle_comments {
                 None
-            } else if use_oracle_agent_paging {
+            } else if use_agent_table_paging {
                 limit
             } else {
                 None
             };
             let agent_offset = if filter_locally_after_oracle_comments {
                 None
-            } else if use_oracle_agent_paging {
+            } else if use_agent_table_paging {
                 offset
             } else {
                 None
@@ -1962,7 +1962,7 @@ async fn list_tables_once(
                     }
                     let final_offset = if filter_locally_after_oracle_comments {
                         offset
-                    } else if oracle_agent_paging_likely_applied(use_oracle_agent_paging, limit, tables.len()) {
+                    } else if agent_paging_likely_applied(use_agent_table_paging, limit, tables.len()) {
                         Some(0)
                     } else {
                         offset
@@ -2597,12 +2597,23 @@ mod tests {
     }
 
     #[test]
-    fn oracle_agent_paging_detection_avoids_double_offset_only_when_page_sized() {
-        assert!(super::oracle_agent_paging_likely_applied(true, Some(500), 500));
-        assert!(super::oracle_agent_paging_likely_applied(true, Some(500), 120));
-        assert!(!super::oracle_agent_paging_likely_applied(true, Some(500), 501));
-        assert!(!super::oracle_agent_paging_likely_applied(false, Some(500), 120));
-        assert!(!super::oracle_agent_paging_likely_applied(true, None, 120));
+    fn agent_table_paging_supports_tdengine_and_default_oracle_only() {
+        assert!(super::supports_agent_table_paging(&test_connection_config(DatabaseType::Tdengine)));
+        assert!(super::supports_agent_table_paging(&test_connection_config(DatabaseType::Oracle)));
+        assert!(!super::supports_agent_table_paging(&test_connection_config(DatabaseType::Dameng)));
+
+        let mut legacy_oracle = test_connection_config(DatabaseType::Oracle);
+        legacy_oracle.driver_profile = Some("oracle-legacy".to_string());
+        assert!(!super::supports_agent_table_paging(&legacy_oracle));
+    }
+
+    #[test]
+    fn agent_paging_detection_avoids_double_offset_only_when_page_sized() {
+        assert!(super::agent_paging_likely_applied(true, Some(500), 500));
+        assert!(super::agent_paging_likely_applied(true, Some(500), 120));
+        assert!(!super::agent_paging_likely_applied(true, Some(500), 501));
+        assert!(!super::agent_paging_likely_applied(false, Some(500), 120));
+        assert!(!super::agent_paging_likely_applied(true, None, 120));
     }
 
     #[test]
@@ -3516,7 +3527,7 @@ pub async fn list_objects_core(
             .await
             .map(|outcome| {
                 let final_offset = if outcome.paging_applied
-                    || oracle_agent_paging_likely_applied(use_oracle_agent_paging, limit, outcome.objects.len())
+                    || agent_paging_likely_applied(use_oracle_agent_paging, limit, outcome.objects.len())
                 {
                     Some(0)
                 } else {
@@ -4960,7 +4971,12 @@ fn is_default_oracle_agent_config(config: &ConnectionConfig) -> bool {
         && !matches!(config.driver_profile.as_deref(), Some("oracle-legacy" | "oracle-10g"))
 }
 
-fn oracle_agent_paging_likely_applied(enabled: bool, limit: Option<usize>, returned_len: usize) -> bool {
+fn supports_agent_table_paging(config: &ConnectionConfig) -> bool {
+    // Keep paging opt-in until each legacy agent is known to apply metadata constraints server-side.
+    matches!(config.db_type, DatabaseType::Tdengine) || is_default_oracle_agent_config(config)
+}
+
+fn agent_paging_likely_applied(enabled: bool, limit: Option<usize>, returned_len: usize) -> bool {
     enabled && limit.is_some_and(|limit| returned_len <= limit)
 }
 


### PR DESCRIPTION
## 修改内容

- 将侧边栏请求的表列表分页参数转发给 TDengine Agent，避免一次性加载并序列化全部表
- Agent 已完成分页时不再在客户端重复应用 offset
- 分页能力仅对 TDengine 和现有默认 Oracle Agent 开启，不改变其他数据库 Agent 的处理方式

## 修复原因

TDengine Agent 本身支持对 information_schema 的表元数据查询进行分页，但 Rust 中间层此前没有向 TDengine 转发 limit/offset。表数量较多时，Agent 会先加载全部表再由客户端截取，导致内存占用明显增加，并可能触发 60 秒 RPC 超时。

真实 TDengine 3.3.4.8 环境验证：

- 50 万张子表：无分页返回 500001 项，Agent 峰值约 691 MB；下推 LIMIT 101 后返回 101 项，峰值约 102 MB
- 1 万张子表连续两页：每页返回 101 项，分页衔接正确、展示数据无重复

## 测试

- cargo test -p dbx-core --no-default-features schema::tests:: --lib（43 passed）
- cargo fmt --check
- git diff --check
- 真实 TDengine 3.3.4.8 / JDBC 3.6.3 分页验证

Fixes #3904
