### PR TITLE
Fix: 优化 Oracle 不存在表查询耗时

### DIFF
--- a/apps/desktop/src/lib/metadata/tableMetadataCache.ts
+++ b/apps/desktop/src/lib/metadata/tableMetadataCache.ts
@@ -139,7 +139,7 @@ export async function loadTableMetadata(request: TableMetadataRequest): Promise<
       scope,
       async () => {
         const columns = await api.getColumns(request.connectionId, request.database, request.schema ?? "", request.tableName, request.catalog);
-        const indexes = await api.listIndexes(request.connectionId, request.database, request.schema ?? "", request.tableName, request.catalog).catch((): IndexInfo[] => []);
+        const indexes = columns.length > 0 ? await api.listIndexes(request.connectionId, request.database, request.schema ?? "", request.tableName, request.catalog).catch((): IndexInfo[] => []) : [];
         const primaryKeys = editableRowIdentifierColumns(request.databaseType as DatabaseType, columns, indexes, request.tableType);
         return {
           schema: request.schema || undefined,

--- a/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
@@ -173,6 +173,40 @@ describe("queryStore hidden primary key editing", () => {
     expect(tab.queryEditabilityReason).toBeUndefined();
   });
 
+  it("does not check Oracle ROWID eligibility when query metadata returns no columns", async () => {
+    getConnectionConfig.mockReturnValue({ id: "oracle-1", name: "Oracle", db_type: "oracle", database: "ORCL", query_timeout_secs: 30 });
+    getColumns.mockResolvedValue([]);
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "aa",
+        selectStar: true,
+        columns: [],
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["Error"],
+        rows: [["ORA-00942: table or view does not exist"]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+        execution_error: true,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("oracle-1", "ORCL", "Query");
+
+    await store.executeTabSql(tabId, "SELECT * FROM aa");
+
+    expect(getColumns).toHaveBeenCalledWith("oracle-1", "ORCL", "", "AA", undefined);
+    expect(listIndexes).not.toHaveBeenCalled();
+    expect(listObjects).not.toHaveBeenCalled();
+    expect(executeMulti).toHaveBeenCalledWith("oracle-1", "ORCL", "SELECT * FROM aa", undefined, expect.any(String), expect.objectContaining({ timeoutSecs: 30 }));
+  });
+
   it("keeps a keyless Oracle query editable when its WHERE clause reads another table", async () => {
     getConnectionConfig.mockReturnValue({ id: "oracle-1", name: "Oracle", db_type: "oracle", database: "ORCL", query_timeout_secs: 30 });
     getColumns.mockResolvedValue([

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2449,6 +2449,7 @@ export const useQueryStore = defineStore("query", () => {
       if (sources.length !== 1 || analysis.distinct) return unchanged;
 
       const loaded = await loadEditableQuerySource(tab, analysis, sources[0]!, conn, databaseType, traceId, elapsed);
+      if (loaded.tableMeta.columns.length === 0) return unchanged;
       if (loaded.tableMeta.tableType?.toUpperCase().includes("VIEW")) return unchanged;
       const metadataAnalysis = expandStarProjectionColumnsForSource(bindColumnsForSource(databaseType, loaded.analysis, loaded.source, loaded.tableMeta.columns), loaded.source, loaded.tableMeta.columns);
       const declaredPrimaryKeys = loaded.tableMeta.columns.filter((column) => column.is_primary_key).map((column) => column.name);


### PR DESCRIPTION
## 背景

Fix: #3907

Oracle 查询不存在的表时，前端会先尝试为结果编辑能力加载表元数据。对于不存在的表，列元数据为空，但之前仍会继续探测索引和 Oracle ROWID 可编辑性，可能在大 schema 下拖慢真正的 SQL 错误返回。

## 改动

- 表列元数据为空时跳过索引加载。
- 查询编辑增强遇到空列元数据时直接回退原 SQL 执行，避免继续做 Oracle ROWID 可用性探测。
- 补充 Oracle 缺表场景回归测试，确保不会继续调用 `listIndexes` / `listObjects`。

## 验证

- 真实 UI 预览：Oracle 11g 可展开到 `DBX_TEST` / `HR`。
- 真实 UI 执行 `SELECT * FROM aa`，约 1.16s 返回 `ORA-00942: table or view does not exist`。
- 真实 UI 执行 `SELECT 1 FROM DUAL`，返回 1 行，页面显示 66ms。
- `pnpm exec vitest run apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts`
- `pnpm exec vitest run apps/desktop/src/lib/metadata/__tests__/tableMetadataCache.invalidation.spec.ts`
- `git diff --check`

说明：`pnpm typecheck` 在当前临时 worktree 中仍因依赖解析不到 `@dbx-app/mongo-shell` 失败，报错集中在 `apps/desktop/src/lib/mongo/mongoShellCommand.ts`，不属于本次改动范围。