### PR TITLE
Fix: 修复 Kingbase MySQL 模式字符串长度识别

### DIFF
--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class KingbaseAgent extends PostgresLikeAgent {
     private static final int TRIGGER_TYPE_BEFORE = 1 << 1;
@@ -48,6 +50,10 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     private static final String KINGBASE_VIEW_SCHEMA = "CAST(v.schemaname AS varchar(256))";
     private static final String KINGBASE_MATVIEW_NAME = "CAST(mv.matviewname AS varchar(256))";
     private static final String KINGBASE_MATVIEW_SCHEMA = "CAST(mv.schemaname AS varchar(256))";
+    private static final Pattern BOUNDED_VARCHAR_TYPE = Pattern.compile(
+        "^(?:varchar|character\\s+varying)\\s*\\(\\s*(\\d+)\\s*\\)$",
+        Pattern.CASE_INSENSITIVE
+    );
     private boolean postgresCatalogMode;
     private boolean sqlServerIdentityCatalogMode;
 
@@ -572,6 +578,7 @@ public final class KingbaseAgent extends PostgresLikeAgent {
             List<ColumnInfo> result = new ArrayList<>();
             String sql = "SELECT ic.column_name, ic.data_type, ic.is_nullable, ic.column_default, " +
                 "ic.numeric_precision, ic.numeric_scale, ic.character_maximum_length, " +
+                "format_type(a.atttypid, a.atttypmod) AS catalog_data_type, " +
                 "d.description AS column_comment " +
                 "FROM information_schema.columns ic " +
                 // information_schema preserves MySQL-compatible type metadata but does not expose comments.
@@ -587,9 +594,19 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                 try (ResultSet rs = stmt.executeQuery(sql)) {
                     while (rs.next()) {
                         String columnName = rs.getString("column_name");
+                        String dataType = rs.getString("data_type");
+                        Integer characterLength = intObject(rs, "character_maximum_length");
+                        String catalogDataType = rs.getString("catalog_data_type");
+                        Integer catalogCharacterLength = boundedCharacterLength(catalogDataType);
+                        if ("varchar".equalsIgnoreCase(dataType)
+                            && (characterLength == null || characterLength <= 0)
+                            && catalogCharacterLength != null) {
+                            dataType = catalogDataType;
+                            characterLength = catalogCharacterLength;
+                        }
                         result.add(new ColumnInfo(
                             columnName,
-                            rs.getString("data_type"),
+                            dataType,
                             "YES".equalsIgnoreCase(coalesce(rs.getString("is_nullable"))),
                             rs.getString("column_default"),
                             primaryKeys.contains(columnName),
@@ -597,13 +614,25 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                             rs.getString("column_comment"),
                             intObject(rs, "numeric_precision"),
                             intObject(rs, "numeric_scale"),
-                            intObject(rs, "character_maximum_length")
+                            characterLength
                         ));
                     }
                 }
             }
             return result;
         });
+    }
+
+    private static Integer boundedCharacterLength(String dataType) {
+        if (dataType == null) return null;
+        Matcher match = BOUNDED_VARCHAR_TYPE.matcher(dataType.trim());
+        if (!match.matches()) return null;
+        try {
+            int length = Integer.parseInt(match.group(1));
+            return length > 0 ? length : null;
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
     }
 
     @Override

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -556,7 +556,7 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
-    void mysqlCompatGetColumnsKeepsInformationSchemaPath() {
+    void mysqlCompatGetColumnsRestoresBoundedCatalogCharacterTypes() {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
         agent.setMysqlCompatMode(true);
@@ -574,9 +574,14 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
                     "numeric_precision",
                     "numeric_scale",
                     "character_maximum_length",
+                    "catalog_data_type",
                     "column_comment"
                 },
-                new Object[][]{{"id", "int", "NO", null, 32, 0, null, "identifier"}}
+                new Object[][]{
+                    {"id", "int", "NO", null, 32, 0, null, "integer", "identifier"},
+                    {"name", "varchar", "YES", null, null, null, -1, "character varying(64)", null},
+                    {"notes", "varchar", "YES", null, null, null, -1, "varchar", null}
+                }
             )
         ));
 
@@ -584,9 +589,26 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
 
         Assertions.assertEquals("int", columns.get(0).getData_type());
         Assertions.assertEquals("identifier", columns.get(0).getComment());
+        Assertions.assertEquals("character varying(64)", columns.get(1).getData_type());
+        Assertions.assertEquals(Integer.valueOf(64), columns.get(1).getCharacter_maximum_length());
+        Assertions.assertEquals("varchar", columns.get(2).getData_type());
+        Assertions.assertEquals(Integer.valueOf(-1), columns.get(2).getCharacter_maximum_length());
         Assertions.assertTrue(sql.get(1).contains("FROM information_schema.columns"), sql.get(1));
+        Assertions.assertTrue(sql.get(1).contains("format_type(a.atttypid, a.atttypmod) AS catalog_data_type"), sql.get(1));
         Assertions.assertTrue(sql.get(1).contains("LEFT JOIN sys_catalog.sys_description"), sql.get(1));
         Assertions.assertNull(columns.get(0).getExtra());
+
+        String ddl = DdlBuilder.buildTableDdl(
+            "PUBLIC",
+            "orders",
+            columns,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            true
+        );
+        Assertions.assertTrue(ddl.contains("`name` character varying(64)"), ddl);
+        Assertions.assertTrue(ddl.contains("`notes` varchar"), ddl);
+        Assertions.assertFalse(ddl.contains("varchar(-1)"), ddl);
     }
 
     @Test


### PR DESCRIPTION
## 变更说明

修复 KingbaseES MySQL 兼容模式下有界字符串字段被识别为 `varchar/-1` 的问题。

Kingbase 的 `information_schema.columns` 在该模式下会把 `character varying(n)` 统一返回为 `varchar`，并将 `character_maximum_length` 返回为 `-1`。本次在原有查询中补充 `format_type(a.atttypid, a.atttypmod)`，仅当字段为 `varchar` 且长度缺失/无效时，从系统目录恢复有界的 `varchar(n)` 或 `character varying(n)` 及其长度。无界 `varchar` 保持原行为。

这会同时修复表结构编辑器中的类型/长度显示，以及导出 DDL 丢失长度的问题。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

不涉及前端改动。

## 真实数据库验证

使用 KingbaseES V009R001C010、`database_mode=mysql` 创建：

```sql
CREATE TABLE issue3888.character_types (
  id character varying(50) NOT NULL,
  conference_no character varying(50),
  scf_type character varying(4),
  unlimited_text character varying
);
```

修复前 Agent 返回：

```text
id              -> varchar, length -1
conference_no   -> varchar, length -1
scf_type        -> varchar, length -1
unlimited_text  -> varchar, length -1
```

修复后重新打包 Agent 并通过 JSON-RPC 实际连接验证：

```text
id              -> character varying(50), length 50
conference_no   -> character varying(50), length 50
scf_type        -> character varying(4), length 4
unlimited_text  -> varchar, length -1
```

生成 DDL：

```sql
CREATE TABLE `issue3888`.`character_types` (
  `id` character varying(50) NOT NULL,
  `conference_no` character varying(50),
  `scf_type` character varying(4),
  `unlimited_text` varchar
);
```

## 验证

- [x] `pnpm check` 通过（format、lint、typecheck、test）
- [x] `pnpm build` 通过
- [x] `:common:test :kingbase:test` 通过
- [x] KingbaseES MySQL 兼容模式真实实例验证通过
- [x] 有界与无界 `varchar` 回归测试通过

## 关联 Issue

Fixes #3888
