### PR TITLE
Fix: SQL 默认执行光标所在语句

### DIFF
--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { normalizeDesktopSettings, normalizeEditorSettings } from "@/stores/settingsStore";
+import { EXECUTE_MODE_CURRENT_DEFAULT_VERSION, normalizeDesktopSettings, normalizeEditorSettings } from "@/stores/settingsStore";
 import { createPinia, setActivePinia } from "pinia";
 import type { AiConfigItem } from "@/types/ai";
 
 describe("normalizeEditorSettings", () => {
+  it("defaults SQL execution to the current statement and migrates legacy execute-all settings", () => {
+    expect(normalizeEditorSettings({}).executeMode).toBe("current");
+    expect(normalizeEditorSettings({ executeMode: "all" }).executeMode).toBe("current");
+    expect(normalizeEditorSettings({ executeMode: "all", executeModeDefaultVersion: EXECUTE_MODE_CURRENT_DEFAULT_VERSION }).executeMode).toBe("all");
+  });
+
   it("enables automatic table aliases by default", () => {
     expect(normalizeEditorSettings({}).autoAliasTables).toBe(true);
   });

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -361,6 +361,7 @@ export interface EditorSettings {
   customThemes: CustomTheme[];
   activeCustomThemeId: string;
   executeMode: "all" | "current";
+  executeModeDefaultVersion: number;
   showExecutionTargetPicker: boolean;
   showStatementRunButtons: boolean;
   showCurrentStatementFrame: boolean;
@@ -496,6 +497,8 @@ export const FONT_FAMILIES: { value: string; label: string }[] = [
   { value: "monospace", label: "System Monospace" },
 ];
 
+export const EXECUTE_MODE_CURRENT_DEFAULT_VERSION = 1;
+
 export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   fontFamily: "'Fira Code', 'Cascadia Code', 'Cascadia Mono', 'JetBrains Mono', monospace",
   fontSize: 13,
@@ -505,7 +508,8 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   customThemeColors: { ...DEFAULT_CUSTOM_THEME_COLORS },
   customThemes: [...DEFAULT_CUSTOM_THEMES],
   activeCustomThemeId: "default",
-  executeMode: "all",
+  executeMode: "current",
+  executeModeDefaultVersion: EXECUTE_MODE_CURRENT_DEFAULT_VERSION,
   showExecutionTargetPicker: false,
   showStatementRunButtons: true,
   showCurrentStatementFrame: true,
@@ -722,6 +726,9 @@ function normalizeToolbarItems(items: Partial<ToolbarItems> | undefined): Toolba
 
 export function normalizeEditorSettings(settings: Partial<EditorSettings>, existing?: EditorSettings): EditorSettings {
   const sqlSemanticDiagnosticsMode = normalizeSqlSemanticDiagnosticsMode(settings.sqlSemanticDiagnosticsMode, settings.sqlSemanticDiagnosticsEnabled);
+  const savedExecuteModeDefaultVersion = settings.executeModeDefaultVersion;
+  const executeModeDefaultVersion = typeof savedExecuteModeDefaultVersion === "number" && savedExecuteModeDefaultVersion >= EXECUTE_MODE_CURRENT_DEFAULT_VERSION ? savedExecuteModeDefaultVersion : EXECUTE_MODE_CURRENT_DEFAULT_VERSION;
+  const hasCurrentExecuteModeDefault = executeModeDefaultVersion === savedExecuteModeDefaultVersion;
   return {
     fontFamily: normalizeFontFamily(settings.fontFamily, DEFAULT_EDITOR_SETTINGS.fontFamily),
     fontSize: settings.fontSize ?? DEFAULT_EDITOR_SETTINGS.fontSize,
@@ -755,7 +762,8 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
         : [];
     })(),
     activeCustomThemeId: settings.activeCustomThemeId ?? "default",
-    executeMode: settings.executeMode ?? DEFAULT_EDITOR_SETTINGS.executeMode,
+    executeMode: hasCurrentExecuteModeDefault && (settings.executeMode === "all" || settings.executeMode === "current") ? settings.executeMode : DEFAULT_EDITOR_SETTINGS.executeMode,
+    executeModeDefaultVersion,
     showExecutionTargetPicker: settings.showExecutionTargetPicker ?? DEFAULT_EDITOR_SETTINGS.showExecutionTargetPicker,
     showStatementRunButtons: typeof settings.showStatementRunButtons === "boolean" ? settings.showStatementRunButtons : DEFAULT_EDITOR_SETTINGS.showStatementRunButtons,
     showCurrentStatementFrame: typeof settings.showCurrentStatementFrame === "boolean" ? settings.showCurrentStatementFrame : DEFAULT_EDITOR_SETTINGS.showCurrentStatementFrame,
@@ -891,10 +899,13 @@ export const useSettingsStore = defineStore("settings", () => {
     if (isEditorSettingsLoaded.value) return;
     const saved = await api.loadEditorSettings().catch(() => null);
     if (saved && typeof saved === "object" && !Array.isArray(saved)) {
-      const normalized = normalizeEditorSettings(saved as Partial<EditorSettings>);
+      const savedSettings = saved as Partial<EditorSettings>;
+      const normalized = normalizeEditorSettings(savedSettings);
       editorSettings.value = normalized;
-      if ((saved as { updateDownloadSource?: unknown }).updateDownloadSource === "atomgit") {
-        // Persist the channel migration so the removed source cannot reappear in older settings data.
+      const needsExecuteModeDefaultMigration = typeof savedSettings.executeModeDefaultVersion !== "number" || savedSettings.executeModeDefaultVersion < EXECUTE_MODE_CURRENT_DEFAULT_VERSION;
+      const savedUpdateDownloadSource = (saved as { updateDownloadSource?: unknown }).updateDownloadSource;
+      if (savedUpdateDownloadSource === "atomgit" || needsExecuteModeDefaultMigration) {
+        // Persist one-time migrations so removed or unsafe defaults cannot reappear.
         await api.saveEditorSettings(normalized).catch(() => {});
       }
       isEditorSettingsLoaded.value = true;

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -1,4 +1,4 @@
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { createPinia, setActivePinia } from "pinia";
@@ -6,7 +6,7 @@ import { DEFAULT_SQL_FORMATTER_SETTINGS } from "../../apps/desktop/src/lib/sql/s
 import { DEFAULT_TABLE_COLUMN_TEMPLATE_FIELDS } from "../../apps/desktop/src/lib/table/tableColumnTemplates.ts";
 import { DEFAULT_UI_FONT_FAMILY, SYSTEM_UI_FONT_FAMILY } from "../../apps/desktop/src/lib/app/appFonts.ts";
 import { tableOpenPageLimit } from "../../apps/desktop/src/lib/table/tableOpenPageLimit.ts";
-import { AI_PROVIDER_PRESETS, DEFAULT_EDITOR_SETTINGS, normalizeAiConfig, normalizeEditorSettings, useSettingsStore } from "../../apps/desktop/src/stores/settingsStore.ts";
+import { AI_PROVIDER_PRESETS, DEFAULT_EDITOR_SETTINGS, EXECUTE_MODE_CURRENT_DEFAULT_VERSION, normalizeAiConfig, normalizeEditorSettings, useSettingsStore } from "../../apps/desktop/src/stores/settingsStore.ts";
 
 const OLD_FONT_SIZE_KEY = "dbx-query-editor-font-size";
 
@@ -57,6 +57,32 @@ test("normalizes the dedicated default row limit for table opens", () => {
   assert.equal(tableOpenPageLimit(), 100);
   assert.equal(tableOpenPageLimit(1000), 1000);
   assert.equal(tableOpenPageLimit(0), 100);
+});
+
+test("migrates legacy execute-all settings to current once and preserves later explicit choices", async () => {
+  await withMockLocalStorage({ "dbx-app-state:editor_settings": JSON.stringify({ executeMode: "all" }) }, async () => {
+    setActivePinia(createPinia());
+    const migratedStore = useSettingsStore();
+    await migratedStore.initEditorSettings();
+
+    assert.equal(migratedStore.editorSettings.executeMode, "current");
+    let saved = JSON.parse(localStorage.getItem("dbx-app-state:editor_settings") || "{}");
+    assert.equal(saved.executeMode, "current");
+    assert.equal(saved.executeModeDefaultVersion, EXECUTE_MODE_CURRENT_DEFAULT_VERSION);
+
+    migratedStore.updateEditorSettings({ executeMode: "all" });
+    assert.equal(migratedStore.editorSettings.executeMode, "all");
+    await vi.waitFor(() => {
+      saved = JSON.parse(localStorage.getItem("dbx-app-state:editor_settings") || "{}");
+      assert.equal(saved.executeMode, "all");
+    });
+    assert.equal(saved.executeModeDefaultVersion, EXECUTE_MODE_CURRENT_DEFAULT_VERSION);
+
+    setActivePinia(createPinia());
+    const reloadedStore = useSettingsStore();
+    await reloadedStore.initEditorSettings();
+    assert.equal(reloadedStore.editorSettings.executeMode, "all");
+  });
 });
 
 test("shows the table-open page size control in the Data settings tab", () => {


### PR DESCRIPTION
## 背景

SQL 执行快捷键开始遵循执行模式设置后，历史默认值 `all` 会让未主动配置过的用户执行编辑器中的全部 SQL，可能意外扩大执行范围。

## 改动说明

- 将 SQL 编辑器默认执行模式从 `all` 调整为 `current`
- 增加一次性设置迁移，现有用户升级后统一切换为执行光标所在语句
- 持久化迁移版本，避免后续启动重复覆盖用户选择
- 用户迁移后仍可手动改回执行全部，并在重启后保持该设置

## 验证

- `pnpm exec vitest run apps/desktop/src/stores/__tests__/settingsStore.spec.ts packages/app-tests/settingsStore.test.ts apps/desktop/src/lib/settings/__tests__/editorSettingsDraft.spec.ts apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts`（110 项通过）
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`