### PR TITLE
Fix: 修复 Kingbase V8R6 表结构元数据加载失败

### DIFF
--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -56,6 +56,7 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     );
     private boolean postgresCatalogMode;
     private boolean sqlServerIdentityCatalogMode;
+    private volatile boolean usePgDefaultExpressionFunction;
 
     public static final PostgresLikeAgentProfile KINGBASE_PROFILE = new PostgresLikeAgentProfile(
         "com.kingbase8.Driver",
@@ -70,6 +71,7 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     protected void afterConnect(ConnectParams params, Connection connection) {
         postgresCatalogMode = false;
         sqlServerIdentityCatalogMode = false;
+        usePgDefaultExpressionFunction = false;
         setMysqlCompatMode(params.isMysql_compat_mode());
         if (params.isMysql_compat_mode()) {
             return;
@@ -489,12 +491,30 @@ public final class KingbaseAgent extends PostgresLikeAgent {
     }
 
     private List<ColumnInfo> getRegularColumns(String schema, String table, Set<String> primaryKeys) {
+        boolean usePgFunction = usePgDefaultExpressionFunction;
+        try {
+            return queryRegularColumns(schema, table, primaryKeys, usePgFunction ? "pg_get_expr" : "sys_get_expr");
+        } catch (RuntimeException error) {
+            if (usePgFunction || !isUndefinedFunction(error, "sys_get_expr")) {
+                throw error;
+            }
+            usePgDefaultExpressionFunction = true;
+            return queryRegularColumns(schema, table, primaryKeys, "pg_get_expr");
+        }
+    }
+
+    private List<ColumnInfo> queryRegularColumns(
+        String schema,
+        String table,
+        Set<String> primaryKeys,
+        String defaultExpressionFunction
+    ) {
         return unchecked(() -> {
             List<ColumnInfo> result = new ArrayList<>();
             String sql = "SELECT a.attname AS column_name, " +
                 "format_type(a.atttypid, a.atttypmod) AS data_type, " +
                 "NOT a.attnotnull AS is_nullable, " +
-                "sys_get_expr(ad.adbin, ad.adrelid) AS column_default, " +
+                defaultExpressionFunction + "(ad.adbin, ad.adrelid) AS column_default, " +
                 "d.description AS column_comment, " +
                 "CASE WHEN t.typname = 'numeric' AND a.atttypmod > 0 " +
                 "THEN ((a.atttypmod - 4) >> 16) & 65535 ELSE NULL END AS numeric_precision, " +
@@ -986,6 +1006,23 @@ public final class KingbaseAgent extends PostgresLikeAgent {
             }
         }
         return insufficientPrivilege && mentionsSysFreespace;
+    }
+
+    private static boolean isUndefinedFunction(Throwable error, String functionName) {
+        boolean undefinedFunction = false;
+        boolean mentionsFunction = false;
+        for (Throwable current = error; current != null; current = current.getCause()) {
+            if (current instanceof SQLException && "42883".equals(((SQLException) current).getSQLState())) {
+                undefinedFunction = true;
+            }
+            String message = current.getMessage();
+            if (message != null) {
+                String normalized = message.toLowerCase(Locale.ROOT);
+                mentionsFunction |= normalized.contains(functionName.toLowerCase(Locale.ROOT));
+                undefinedFunction |= normalized.contains("does not exist") || normalized.contains("不存在");
+            }
+        }
+        return undefinedFunction && mentionsFunction;
     }
 
     private static void appendRoutineKindPredicate(StringBuilder sql, List<Object> args, MetadataListConstraints constraints) {

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -599,6 +599,21 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
+    void regularGetColumnsFallsBackToPgGetExprAndCachesTheChoice() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        TestSupport.setPrivateConnection(agent, defaultExpressionFallbackConnection(sql));
+
+        List<ColumnInfo> first = agent.getColumns("public", "orders");
+        List<ColumnInfo> second = agent.getColumns("public", "orders");
+
+        Assertions.assertEquals("nextval('orders_id_seq'::regclass)", first.get(0).getColumn_default());
+        Assertions.assertEquals("nextval('orders_id_seq'::regclass)", second.get(0).getColumn_default());
+        Assertions.assertEquals(1, sql.stream().filter(query -> query.contains("sys_get_expr(")).count(), sql.toString());
+        Assertions.assertEquals(2, sql.stream().filter(query -> query.contains("pg_get_expr(")).count(), sql.toString());
+    }
+
+    @Test
     void mysqlCompatGetColumnsRestoresBoundedCatalogCharacterTypes() {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();
@@ -890,6 +905,55 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
                             new Object[][]{
                                 {"id", "int", false, null, null, 32, 0, null},
                                 {"name", "character varying", false, null, null, null, null, 64}
+                            }
+                        );
+                    }
+                    if ("close".equals(statementMethod.getName())) return null;
+                    return defaultValue(statementMethod.getReturnType());
+                });
+            }
+            if ("isClosed".equals(method.getName())) return false;
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static Connection defaultExpressionFallbackConnection(List<String> sql) {
+        return proxy(Connection.class, (method, args) -> {
+            if ("prepareStatement".equals(method.getName())) {
+                String query = String.valueOf(args[0]);
+                sql.add(query);
+                return proxy(PreparedStatement.class, (statementMethod, statementArgs) -> {
+                    if ("executeQuery".equals(statementMethod.getName())) {
+                        return resultSet(new String[]{"column_name"}, new Object[][]{{"id"}});
+                    }
+                    if ("close".equals(statementMethod.getName())) return null;
+                    return defaultValue(statementMethod.getReturnType());
+                });
+            }
+            if ("createStatement".equals(method.getName())) {
+                return proxy(Statement.class, (statementMethod, statementArgs) -> {
+                    if ("executeQuery".equals(statementMethod.getName())) {
+                        String query = String.valueOf(statementArgs[0]);
+                        sql.add(query);
+                        if (query.contains("sys_get_expr(")) {
+                            throw new SQLException(
+                                "ERROR: function sys_get_expr(pg_node_tree, oid) does not exist",
+                                "42883"
+                            );
+                        }
+                        return resultSet(
+                            new String[]{
+                                "column_name",
+                                "data_type",
+                                "is_nullable",
+                                "column_default",
+                                "column_comment",
+                                "numeric_precision",
+                                "numeric_scale",
+                                "character_maximum_length"
+                            },
+                            new Object[][]{
+                                {"id", "integer", false, "nextval('orders_id_seq'::regclass)", null, 32, 0, null}
                             }
                         );
                     }


### PR DESCRIPTION
## 修改内容

- Kingbase 常规目录读取字段默认值时，优先保持现有 sys_get_expr 调用
- 当服务端明确返回 sys_get_expr 函数签名不存在时，自动改用 pg_get_expr 重试
- 在当前连接内缓存成功的函数选择，后续查看 DDL、编辑表结构和生成 DDL 不再重复触发失败
- 其他 SQL 异常仍按原逻辑返回，不进行宽泛降级

## 原因

KingbaseES 不同版本的 sys_attrdef.adbin 类型不一致：

- V8R3 使用 sys_node_tree，需要 sys_get_expr
- issue 中的 V8R6 PostgreSQL 模式使用 pg_node_tree，需要 pg_get_expr
- V9 对相关调用具备兼容性

原实现固定调用 sys_get_expr，因此 V8R6 会返回 function sys_get_expr(pg_node_tree, oid) does not exist。查看 DDL、编辑表结构和生成 DDL 共用字段元数据接口，所以会同时失败。

## 测试

- 真实 KingbaseES V008R006C009B0014 / aarch64 / PostgreSQL 模式：旧 Agent 稳定复现 issue 中相同 RPC 错误
- 同一 V8R6 实例：新 Agent 的 get_columns 成功返回字段、默认值、主键和注释
- 同一 V8R6 实例：get_table_ddl 成功生成完整 DDL
- Kingbase V8R3 MySQL 兼容模式、Kingbase V9 Oracle 兼容模式回归通过
- ./gradlew :kingbase:test :kingbase:shadowJar（40 tests passed）
- python3 scripts/validate_agents.py

Fixes #3932
