### PR TITLE
fix: 恢复 Kingbase system 模式显示

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -187,7 +187,7 @@ func (s *server) listSchemas(visible []string) ([]string, error) {
 	if s.mode.postgresCatalog {
 		query = "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname NOT LIKE 'pg_temp_%' AND nspname NOT LIKE 'pg_toast_temp_%' ORDER BY nspname"
 	} else if s.mode.mysqlCompat {
-		query = "SELECT schema_name FROM information_schema.schemata WHERE UPPER(schema_name) <> 'INFORMATION_SCHEMA' AND UPPER(schema_name) NOT LIKE 'SYS%' AND UPPER(schema_name) NOT LIKE 'XLOG%' ORDER BY schema_name"
+		query = "SELECT schema_name FROM information_schema.schemata WHERE UPPER(schema_name) <> 'INFORMATION_SCHEMA' AND (UPPER(schema_name) = 'SYSTEM' OR UPPER(schema_name) NOT LIKE 'SYS%') AND UPPER(schema_name) NOT LIKE 'XLOG%' ORDER BY schema_name"
 	}
 	rows, err := s.metadataQuery(query)
 	if err != nil {

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -23,6 +23,7 @@ var expressionFallbackState atomic.Pointer[fallbackDriverState]
 type fakeDriverState struct {
 	queryArgs int
 	queryCtx  context.Context
+	query     string
 	rowCount  int
 }
 
@@ -60,10 +61,11 @@ func (fakeConn) Close() error { return nil }
 
 func (fakeConn) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
 
-func (fakeConn) QueryContext(ctx context.Context, _ string, args []driver.NamedValue) (driver.Rows, error) {
+func (fakeConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	state := testDriverState.Load()
 	state.queryArgs = len(args)
 	state.queryCtx = ctx
+	state.query = query
 	return &fakeRows{count: state.rowCount}, nil
 }
 
@@ -205,6 +207,20 @@ func TestMetadataNormalizationHelpers(t *testing.T) {
 	}
 	if boundedVarcharLength("text") != nil {
 		t.Fatal("unbounded type returned a length")
+	}
+}
+
+func TestMySQLCompatSchemasKeepSystemAndFilterOtherSysSchemas(t *testing.T) {
+	db, state := openFakeDB(t, 1)
+	server := newServer()
+	server.db = db
+	server.mode.mysqlCompat = true
+
+	if _, err := server.listSchemas(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(state.query, "UPPER(schema_name) = 'SYSTEM'") || !strings.Contains(state.query, "UPPER(schema_name) NOT LIKE 'SYS%'") {
+		t.Fatalf("unexpected schema query: %s", state.query)
 	}
 }
 

--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -167,7 +167,7 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                 ? "SELECT schema_name " +
                     "FROM information_schema.schemata " +
                     "WHERE UPPER(schema_name) <> 'INFORMATION_SCHEMA' " +
-                    "AND UPPER(schema_name) NOT LIKE 'SYS%' " +
+                    "AND (UPPER(schema_name) = 'SYSTEM' OR UPPER(schema_name) NOT LIKE 'SYS%') " +
                     "AND UPPER(schema_name) NOT LIKE 'XLOG%' " +
                     "ORDER BY schema_name"
                 : "SELECT nspname AS schema_name " +

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -146,6 +146,21 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
     }
 
     @Test
+    void mysqlCompatListSchemasKeepsSystemAndFiltersOtherSysSchemas() {
+        List<String> sql = new ArrayList<>();
+        KingbaseAgent agent = new KingbaseAgent();
+        agent.setMysqlCompatMode(true);
+        TestSupport.setPrivateConnection(agent, preparedConnection(sql, resultSet(
+            new String[]{"schema_name"},
+            new Object[][]{{"public"}, {"system"}}
+        )));
+
+        Assertions.assertEquals(Arrays.asList("public", "system"), agent.listSchemas());
+        Assertions.assertTrue(sql.get(0).contains("UPPER(schema_name) = 'SYSTEM'"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("UPPER(schema_name) NOT LIKE 'SYS%'"), sql.get(0));
+    }
+
+    @Test
     void postgresCompatModeUsesPostgresCatalogForMetadata() throws Exception {
         List<String> sql = new ArrayList<>();
         KingbaseAgent agent = new KingbaseAgent();

--- a/agents/metadata-constraint-coverage.tsv
+++ b/agents/metadata-constraint-coverage.tsv
@@ -12,6 +12,7 @@ h2	native-pushdown	java-sql	Uses INFORMATION_SCHEMA with type, filter, stable or
 hive	intentional-fallback	java-sql	Uses Hive metadata paths where stable server-side fuzzy paging is not portable, common constraints filter locally.
 informix	native-pushdown	java-sql	Uses systables/sysprocedures with type, filter, stable order, and SKIP/FIRST.
 kingbase	native-pushdown	java-sql	Uses sys_catalog/information_schema with type, filter, stable order, and LIMIT/OFFSET for both compatibility modes.
+kingbase-go	intentional-fallback	native-go	Loads Kingbase catalog metadata with stable ordering, then applies portable type, fuzzy-filter, and paging constraints in Go.
 kylin	intentional-fallback	java-jdbc-metadata	Uses JDBC metadata from Kylin driver; no portable server-side paging API, common constraints filter locally.
 neo4j	intentional-fallback	java-graph-metadata	Uses JDBC metadata with Cypher fallback; label discovery cannot guarantee relational-style filtered paging, common constraints filter locally.
 oceanbase-oracle	native-pushdown	java-sql	Uses Oracle-compatible metadata SQL with type, filter, stable order, and ROWNUM paging.


### PR DESCRIPTION
## 问题

Kingbase MySQL 兼容模式使用 `SYS%` 前缀过滤系统模式，导致精确名称为 `system` 的模式也被误过滤，展开数据库后无法显示。

## 修复

- Java 与原生 Go 两条 Kingbase Agent 路径均为精确名称 `SYSTEM` 增加例外
- 继续过滤 `SYS_CATALOG`、`SYS_TEMP_*` 等其他 Kingbase 内部模式
- 两条 Agent 路径均增加回归测试
- 为主干新增的 `kingbase-go` 补充元数据约束覆盖矩阵登记

## 验证

- `./gradlew test shadowJar --continue`：150 个 task 通过
- `go test ./...`（`agents/drivers/kingbase-go`）
- `python3 scripts/validate_agents.py`
- `python3 scripts/validate_agent_jars.py`
- 真实 Kingbase MySQL 兼容实例临时创建 `system` 模式后，`/api/schema/schemas` 正确返回 `system`
- 同一验证中 `SYS_CATALOG`、`SYS_TEMP_*` 等内部模式仍未暴露
- 临时 `system` 模式已删除并确认无残留