### PR TITLE
Fix：修复 Kingbase SQL Server 模式索引加载失败

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -488,13 +488,7 @@ func (s *server) listIndexes(schema, table string) ([]indexInfo, error) {
 	if s.mode.postgresCatalog {
 		catalog, prefix = "pg_catalog", "pg"
 	}
-	query := fmt.Sprintf(`SELECT i.relname, am.amname, ix.indisunique, ix.indisprimary, a.attname, pos.n
-FROM %s.%s_index ix JOIN %s.%s_class t ON t.oid = ix.indrelid
-JOIN %s.%s_class i ON i.oid = ix.indexrelid JOIN %s.%s_namespace n ON n.oid = t.relnamespace
-JOIN %s.%s_am am ON am.oid = i.relam
-JOIN generate_series(1,64) pos(n) ON pos.n <= array_length(string_to_array(ix.indkey::text,' '),1)
-JOIN %s.%s_attribute a ON a.attrelid = t.oid AND a.attnum = (string_to_array(ix.indkey::text,' '))[pos.n]::int2
-WHERE n.nspname = %s AND t.relname = %s ORDER BY i.relname, pos.n`, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, quoteLiteral(effective), quoteLiteral(table))
+	query := kingbaseListIndexesQuery(catalog, prefix, effective, table)
 	rows, err := s.metadataQuery(query)
 	if err != nil {
 		return nil, err
@@ -522,6 +516,16 @@ WHERE n.nspname = %s AND t.relname = %s ORDER BY i.relname, pos.n`, catalog, pre
 		result = append(result, *byName[name])
 	}
 	return result, rows.Err()
+}
+
+func kingbaseListIndexesQuery(catalog, prefix, schema, table string) string {
+	return fmt.Sprintf(`SELECT i.relname, am.amname, ix.indisunique, ix.indisprimary, a.attname, pos.n
+FROM %s.%s_index ix JOIN %s.%s_class t ON t.oid = ix.indrelid
+JOIN %s.%s_class i ON i.oid = ix.indexrelid JOIN %s.%s_namespace n ON n.oid = t.relnamespace
+JOIN %s.%s_am am ON am.oid = i.relam
+JOIN unnest(ix.indkey) WITH ORDINALITY AS pos(attnum,n) ON true
+JOIN %s.%s_attribute a ON a.attrelid = t.oid AND a.attnum = pos.attnum
+WHERE n.nspname = %s AND t.relname = %s ORDER BY i.relname, pos.n`, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, quoteLiteral(schema), quoteLiteral(table))
 }
 
 func (s *server) listForeignKeys(schema, table string) ([]foreignKeyInfo, error) {

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -192,6 +192,16 @@ func TestBuildDSNConvertsDBXJDBCURL(t *testing.T) {
 	}
 }
 
+func TestKingbaseListIndexesQuerySupportsSQLServerMode(t *testing.T) {
+	query := kingbaseListIndexesQuery("sys_catalog", "sys", "public", "orders")
+	if !strings.Contains(query, "unnest(ix.indkey) WITH ORDINALITY") {
+		t.Fatalf("index query should preserve index column order without array subscripts: %s", query)
+	}
+	if strings.Contains(query, "[pos.n]") {
+		t.Fatalf("index query should not use dynamic array subscripts in SQL Server mode: %s", query)
+	}
+}
+
 func TestMetadataNormalizationHelpers(t *testing.T) {
 	if normalizeTableType("BASE TABLE") != "TABLE" {
 		t.Fatal("BASE TABLE was not normalized")

--- a/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
+++ b/agents/drivers/kingbase/src/main/java/com/dbx/agent/kingbase/KingbaseAgent.java
@@ -668,8 +668,8 @@ public final class KingbaseAgent extends PostgresLikeAgent {
                 "JOIN SYS_CATALOG.SYS_CLASS i ON i.oid = ix.indexrelid " +
                 "JOIN SYS_CATALOG.SYS_NAMESPACE n ON n.oid = t.relnamespace " +
                 "JOIN SYS_CATALOG.SYS_AM am ON am.oid = i.relam " +
-                "JOIN generate_series(1, 64) AS pos(n) ON pos.n <= array_length(string_to_array(ix.indkey::text, ' '), 1) " +
-                "JOIN SYS_CATALOG.SYS_ATTRIBUTE a ON a.attrelid = t.oid AND a.attnum = (string_to_array(ix.indkey::text, ' '))[pos.n]::int2 " +
+                "JOIN unnest(ix.indkey) WITH ORDINALITY AS pos(attnum, n) ON true " +
+                "JOIN SYS_CATALOG.SYS_ATTRIBUTE a ON a.attrelid = t.oid AND a.attnum = pos.attnum " +
                 "WHERE n.nspname = " + sqlString(effectiveSchema(schema)) +
                 " AND t.relname = " + sqlString(table) + " " +
                 "ORDER BY i.relname, pos.n";

--- a/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
+++ b/agents/drivers/kingbase/src/test/java/com/dbx/agent/kingbase/KingbaseAgentTest.java
@@ -786,6 +786,8 @@ class KingbaseAgentTest extends JdbcFakeExecutionBehaviorTest {
         Assertions.assertFalse(indexes.get(1).getIs_primary());
         Assertions.assertEquals(Arrays.asList("name", "created"), indexes.get(2).getColumns());
         Assertions.assertTrue(sql.get(0).contains("FROM SYS_CATALOG.SYS_INDEX"), sql.get(0));
+        Assertions.assertTrue(sql.get(0).contains("unnest(ix.indkey) WITH ORDINALITY"), sql.get(0));
+        Assertions.assertFalse(sql.get(0).contains("[pos.n]"), sql.get(0));
         Assertions.assertFalse(sql.get(0).contains("information_schema.table_constraints"), sql.get(0));
     }
 


### PR DESCRIPTION
## 问题

KingbaseES SQL Server 兼容模式会把索引查询中的动态数组下标 `[pos.n]` 解析为错误语法，导致打开表结构的索引页时报错。最新 main 新增的 Go Agent 与旧 Java Agent 使用了同一种查询，因此问题仍可复现。

## 修复

- 使用 `unnest(ix.indkey) WITH ORDINALITY` 展开索引字段并保留字段顺序
- 同步修正 Go Agent 与 Java 兼容 Agent
- 增加针对 SQL Server 兼容模式语法的回归断言

## 验证

- KingbaseES V009R001C010，`database_mode=sqlserver`：修复前真实复现 `syntax error at or near "[pos.n]"`
- 修复后通过真实 Agent RPC 返回主键、唯一索引和普通联合索引，联合索引字段顺序正确
- 同一目录查询已在 Kingbase V8R3、V9 Oracle 模式和 V9 SQL Server 模式验证
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Closes #3963