### PR TITLE
fix: 兼容达梦低权限用户加载模式

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -26,6 +26,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Types;
@@ -73,7 +74,7 @@ public final class DamengAgent extends BaseDatabaseAgent {
         """.stripIndent().trim();
     private static final Set<String> SYSTEM_USERS = Set.of(
         "SYS", "SYSAUDITOR", "SYSSSO", "CTISYS",
-        "SYS_DBA", "_SYS_STATISTICS", "SYS_PHM"
+        "SYSDBA", "SYS_DBA", "_SYS_STATISTICS", "SYS_PHM"
     );
 
     private Connection connection;
@@ -140,7 +141,18 @@ public final class DamengAgent extends BaseDatabaseAgent {
 
     @Override
     public List<String> listSchemas() {
-        return unchecked(this::listVisibleSchemas);
+        return unchecked(() -> {
+            try {
+                return listVisibleSchemas();
+            } catch (SQLException catalogError) {
+                try {
+                    return listVisibleUsers();
+                } catch (Exception fallbackError) {
+                    catalogError.addSuppressed(fallbackError);
+                    throw catalogError;
+                }
+            }
+        });
     }
 
     private List<String> listVisibleUsers() throws Exception {

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -113,6 +113,20 @@ class DamengAgentMetadataTest {
     }
 
     @Test
+    void listSchemasFallsBackToAllUsersWithoutSysObjectsPrivilege() {
+        DamengAgent agent = new DamengAgent();
+        List<String> sqls = new ArrayList<>();
+        TestSupport.setPrivateConnection(agent, restrictedSchemaConnection(sqls));
+
+        List<String> schemas = agent.listSchemas();
+
+        Assertions.assertEquals(List.of("APP", "REPORTING"), schemas);
+        Assertions.assertEquals(2, sqls.size(), String.join("\n", sqls));
+        Assertions.assertTrue(sqls.get(0).contains("SYS.SYSOBJECTS"), sqls.get(0));
+        Assertions.assertTrue(sqls.get(1).contains("ALL_USERS"), sqls.get(1));
+    }
+
+    @Test
     void mapsMaterializedViewsFromMetadata() {
         DamengAgent agent = new DamengAgent();
         TestSupport.setPrivateConnection(agent, metadataConnection("id comment", null, true));
@@ -685,6 +699,30 @@ class DamengAgentMetadataTest {
                         Arrays.asList("SALES_VIEW", "VIEW", "regular view")
                     ));
                 }
+            }
+            if ("close".equals(name)) {
+                return null;
+            }
+            if ("isClosed".equals(name)) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static Connection restrictedSchemaConnection(List<String> sqls) {
+        return proxy(Connection.class, (method, args) -> {
+            String name = method.getName();
+            if ("prepareStatement".equals(name)) {
+                String sql = (String) args[0];
+                sqls.add(sql);
+                if (sql.contains("SYS.SYSOBJECTS")) {
+                    return failingMetadataStatement("no SYS.SYSOBJECTS privilege");
+                }
+                if (sql.contains("ALL_USERS")) {
+                    return metadataStatement(List.of(List.of("APP"), List.of("REPORTING")));
+                }
+                throw new AssertionError("Unexpected SQL: " + sql);
             }
             if ("close".equals(name)) {
                 return null;


### PR DESCRIPTION
## 问题

达梦普通用户可以正常建立连接，但没有 `SYS.SYSOBJECTS` 查询权限。DBX 在加载模式列表时固定查询该系统表，导致连接后返回 `Agent RPC error (-1): 没有[SYSOBJECTS]对象的查询权限`。

Fixes #3954

## 修复

- 优先保留 `SYS.SYSOBJECTS` 查询，确保高权限用户仍能发现尚无子对象的独立 schema
- 系统目录查询抛出 `SQLException` 时，降级到普通用户可访问的 `ALL_USERS`
- 补充 `SYSDBA` 系统账号过滤，避免降级列表暴露系统用户
- 增加低权限回退路径测试

## 真实验证

- 在本机 Dameng8 测试库创建仅授予 `RESOURCE` 的临时用户
- 修复前：连接成功，直接查询 `SYS.SYSOBJECTS` 返回 500，`/api/schema/schemas` 同样返回权限错误
- 修复后：该用户仍无 `SYS.SYSOBJECTS` 权限，但 schema API 正常返回可见用户，自有 schema 的表列表可正常展开
- `SYSDBA` 未出现在降级结果中
- 临时连接已断开，临时用户已删除并确认无残留

## 自动化验证

- `./gradlew test shadowJar --continue`：150 个 task 通过
- `python3 scripts/validate_agents.py`
- `python3 scripts/validate_agent_jars.py`