### PR TITLE
fix(筛选): 修复字段名过长时字段下拉框与条件下拉框重叠

### DIFF
--- a/apps/desktop/src/components/grid/DataGridFilterBuilder.vue
+++ b/apps/desktop/src/components/grid/DataGridFilterBuilder.vue
@@ -63,9 +63,9 @@ function handleColumnSearchKeydown(event: KeyboardEvent) {
         <div v-if="index > 0" class="flex justify-center">
           <Button variant="ghost" size="sm" class="h-6 px-2 text-[11px]" @click="emit('updateRule', rule.id, { conjunction: rule.conjunction === 'AND' ? 'OR' : 'AND' })">{{ rule.conjunction }}</Button>
         </div>
-        <div class="grid items-center gap-2" :class="usesExpandedLayout(rule.mode) ? 'grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_auto]' : 'grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1.2fr)_auto]'">
+        <div class="grid items-center gap-2" :class="usesExpandedLayout(rule.mode) ? 'grid-cols-[minmax(0,1.2fr)_minmax(80px,1fr)_auto]' : 'grid-cols-[minmax(0,1.2fr)_minmax(80px,1fr)_minmax(0,1.2fr)_auto]'">
           <Select :model-value="rule.columnName" :disabled="rule.disabled" @update:model-value="(value: any) => updateRuleColumn(rule.id, value)">
-            <SelectTrigger class="h-8 min-w-0 text-xs"><SelectValue :placeholder="t('grid.filterBuilderColumn')" /></SelectTrigger>
+            <SelectTrigger class="h-8 w-full min-w-0 overflow-hidden text-xs [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate" style="white-space: normal"><SelectValue :placeholder="t('grid.filterBuilderColumn')" /></SelectTrigger>
             <SelectContent position="popper" class="max-h-72" :hide-scroll-buttons="true">
               <SelectItem v-for="column in props.filteredColumns" :key="column" :value="column">{{ column }}</SelectItem>
               <div v-if="!props.filteredColumns.length" class="px-2 py-2 text-xs text-muted-foreground">{{ t("grid.filterBuilderNoMatchingColumns") }}</div>
@@ -84,7 +84,7 @@ function handleColumnSearchKeydown(event: KeyboardEvent) {
             </SelectContent>
           </Select>
           <Select :model-value="rule.mode" :disabled="rule.disabled" @update:model-value="(value: any) => emit('updateRule', rule.id, { mode: value as DataGridContextFilterMode })">
-            <SelectTrigger class="h-8 min-w-0 text-xs"><SelectValue /></SelectTrigger>
+            <SelectTrigger class="h-8 w-full min-w-0 overflow-hidden text-xs [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate" style="white-space: normal"><SelectValue /></SelectTrigger>
             <SelectContent
               ><SelectItem v-for="option in props.modeOptions" :key="option.value" :value="option.value">{{ t(option.labelKey) }}</SelectItem></SelectContent
             >


### PR DESCRIPTION
## 问题

查看表数据的快速筛选界面中，当字段名过长时，字段下拉框会膨胀超出 grid 列宽，与相邻的条件下拉框重叠。
#3935 

## 原因

1. `SelectTrigger` 基础组件使用 `w-fit`，宽度随内容膨胀，不遵循 grid 列宽
2. 条件列使用 `minmax(0,1fr)` 无最小宽度，容易被挤压为 0
3. `SelectTrigger` 的 `whitespace-nowrap` 阻止文本截断

## 修改

修改 `DataGridFilterBuilder.vue`：

1. **条件列最小宽度**：`minmax(0,1fr)` → `minmax(80px,1fr)`，防止条件下拉框被挤压
2. **字段 SelectTrigger**：添加 `w-full overflow-hidden [&_[data-slot=select-value]]:min-w-0 [&_[data-slot=select-value]]:truncate` 及 `style="white-space: normal"`，覆盖基础组件的 `w-fit` 和 `whitespace-nowrap`，实现长文本省略截断
3. **条件 SelectTrigger**：同样添加截断样式，保持一致性

## 截图

| 修改前 | 修改后 |
|--------|-------|
| 长字段名导致下拉框重叠 | 长字段名省略截断显示，不再重叠 |
|<img width="519" height="228" alt="image" src="https://github.com/user-attachments/assets/4289a0da-7d72-43b8-962c-41a2cb0cdda2" />|<img width="404" height="183" alt="image" src="https://github.com/user-attachments/assets/5794f8b2-3096-4a17-a37e-6dc94fffa88c" />|