### PR TITLE
fix(editor): keep execution shortcut from popping target picker

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -467,6 +467,7 @@ function handleTab(view: EditorViewType): boolean {
 
 interface RequestExecuteOptions {
   ignoreSelection?: boolean;
+  bypassPicker?: boolean;
 }
 
 function requestExecute(options: RequestExecuteOptions = {}) {
@@ -486,11 +487,13 @@ function requestExecuteFromView(currentView: EditorViewType, cursorPos: number, 
     emit("execute", sqlExecutionSnapshotFromView(currentView));
     return true;
   }
-  // No selection → show the execution target picker.
+  // No selection → resolve the execution target, optionally via the picker.
   const doc = currentView.state.doc.toString();
   const candidates = buildExecutionCandidates(doc, cursorPos, props.databaseType);
   if (candidates.length === 0) return false;
-  if (!settingsStore.editorSettings.showExecutionTargetPicker || !hasMultipleExecutionTargets(doc, props.databaseType)) {
+  // The execution shortcut keeps executing the configured target (cursor/all) directly:
+  // it stays keyboard-driven and never pops the picker, which is reserved for click entry points.
+  if (options.bypassPicker || !settingsStore.editorSettings.showExecutionTargetPicker || !hasMultipleExecutionTargets(doc, props.databaseType)) {
     const preferredKind = settingsStore.editorSettings.executeMode === "current" ? "cursor" : "all";
     const candidate = candidates.find((item) => item.kind === preferredKind) ?? candidates[0];
     emit("execute", candidate.sql);
@@ -1161,8 +1164,9 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
   const shortcuts = normalizeShortcutSettings(settingsStore.editorSettings.shortcuts);
   const Prec = codeMirrorPrec;
   const binding = (shortcut: string, run: (view: EditorViewType) => boolean) => (shortcut ? [{ key: shortcutToCodeMirrorKey(shortcut), preventDefault: true, run }] : []);
-  // Keep the shortcut on the shared path so selection, picker, and execute-mode behavior stay aligned with other execution entry points.
-  const executeBindings = props.hideExecutionControls ? [] : binding(shortcuts.executeSql, () => requestExecute());
+  // Keep the shortcut on the shared execution-mode path (selection priority + configured cursor/all target),
+  // but bypass the picker so the keyboard shortcut always executes directly instead of popping a dialog.
+  const executeBindings = props.hideExecutionControls ? [] : binding(shortcuts.executeSql, () => requestExecute({ bypassPicker: true }));
   return [
     Prec?.high(
       codeMirrorKeymap.of([

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from "vitest";
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 
 describe("QueryEditor execution routing", () => {
-  it("routes the execution shortcut through the shared execution-mode contract", () => {
-    expect(queryEditorSource).toContain("binding(shortcuts.executeSql, () => requestExecute())");
+  it("routes the execution shortcut through the shared execution-mode contract while bypassing the picker", () => {
+    expect(queryEditorSource).toContain("binding(shortcuts.executeSql, () => requestExecute({ bypassPicker: true }))");
     expect(queryEditorSource).not.toContain("forceCurrent");
   });
 
@@ -15,5 +15,10 @@ describe("QueryEditor execution routing", () => {
 
     expect(selectionBranch).toBeGreaterThan(-1);
     expect(executeModeBranch).toBeGreaterThan(selectionBranch);
+  });
+
+  it("lets the shortcut skip the picker without affecting other execution entry points", () => {
+    // The picker guard must also honor the shortcut's bypass flag, otherwise Ctrl+Enter would keep popping the dialog.
+    expect(queryEditorSource).toContain("if (options.bypassPicker || !settingsStore.editorSettings.showExecutionTargetPicker");
   });
 });


### PR DESCRIPTION
## 背景 / Background

Fixes #4043

用户反馈 Ctrl+Enter（执行光标处语句）失效，改为弹出执行目标选择弹框。

Ctrl+Enter used to always execute the statement at the cursor, but it now pops the execution-target picker dialog instead.

## 根因 / Root cause

回归由提交 `990be3c` (`fix(editor): respect configured SQL execution mode`) 引入：该提交移除了快捷键专用的 `forceCurrent` 分支，把快捷键改为走共享路径 `requestExecute()`。结果是当用户开启了 `showExecutionTargetPicker` 且编辑器里有多条语句时，Ctrl+Enter 会弹出 picker，而不是直接执行光标处语句。

Commit `990be3c` removed the shortcut-only `forceCurrent` branch and routed the shortcut through the shared `requestExecute()` path, so with the picker setting enabled + multiple statements, the shortcut now shows the picker instead of executing directly.

## 改动 / Changes

- `RequestExecuteOptions` 新增 `bypassPicker` 选项；快捷键传入该选项，无选区时直接按 `executeMode`（cursor/all）执行，跳过 picker。
- 保留提交 990be3c 的本意：快捷键仍尊重当前/全部配置，且手动选区仍优先执行。
- picker 仍保留给点击类入口（执行按钮 / 右键菜单）。
- 更新 `queryEditorExecution.spec.ts` 的快捷键契约断言，并新增守护 picker bypass 分支的用例。

## 测试 / Testing

- `vitest run apps/desktop/src/lib/__tests__/editor` → 12 files / 56 tests passed
- `vue-tsc --noEmit` 无类型报错