### PR TITLE
Fix：修复 MySQL 整库导出重复分号与导入拆句错误

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -783,9 +783,8 @@ pub fn build_database_sql_export(options: BuildDatabaseSqlExportOptions) -> Resu
 
     for table in options.tables {
         if let Some(ddl) = table.ddl.as_ref().map(|ddl| ddl.trim()).filter(|ddl| !ddl.is_empty()) {
-            let ddl = normalize_export_table_ddl(ddl, table.database_type);
             lines.push(format!("-- Structure for {}", table.display_name));
-            lines.push(format!("{};", ddl.trim_end_matches(';')));
+            lines.push(format_export_table_ddl(ddl, table.database_type));
             lines.push(String::new());
         }
 
@@ -842,6 +841,12 @@ fn normalize_export_table_ddl(ddl: &str, database_type: Option<DatabaseType>) ->
         std::sync::LazyLock::new(|| regex::Regex::new(r"(?i)\bROW_FORMAT\s*=\s*(COMPACT|REDUNDANT)\b").unwrap());
 
     LEGACY_MYSQL_ROW_FORMAT_RE.replace_all(ddl, "ROW_FORMAT=DYNAMIC").into_owned()
+}
+
+fn format_export_table_ddl(ddl: &str, database_type: Option<DatabaseType>) -> String {
+    let ddl = normalize_export_table_ddl(ddl, database_type);
+    let ddl = ddl.trim().trim_end_matches(';').trim_end();
+    format!("{ddl};")
 }
 
 fn postgres_sequence_qualified_name(schema: &str, sequence_name: &str) -> String {
@@ -1534,8 +1539,8 @@ pub async fn export_database_sql_core(
             };
             match ddl_result {
                 Ok(ddl) => {
-                    let ddl = normalize_export_table_ddl(&ddl, Some(db_type));
-                    writeln!(file, "{};\n", ddl).map_err(|e| format!("Failed to write file: {e}"))?;
+                    let ddl = format_export_table_ddl(&ddl, Some(db_type));
+                    writeln!(file, "{ddl}\n").map_err(|e| format!("Failed to write file: {e}"))?;
                 }
                 Err(e) => {
                     record_export_error(
@@ -1952,7 +1957,7 @@ mod tests {
     use super::concurrent_metadata_prefetch_allowed;
     use super::{
         build_database_export_object_source_sql, build_database_sql_export, build_export_insert_statements,
-        drop_table_if_exists_sql, filter_export_table_infos, format_export_sql_literal,
+        drop_table_if_exists_sql, filter_export_table_infos, format_export_sql_literal, format_export_table_ddl,
         generate_postgres_extension_ddl, generate_postgres_sequence_create_ddl, generate_postgres_sequence_owner_ddl,
         generate_postgres_sequence_setval_sql, is_postgres_extension_member_routine, normalize_export_table_ddl,
         record_export_error, BuildDatabaseSqlExportOptions, BuildExportInsertStatementsOptions, ExportedTableSql,
@@ -2626,6 +2631,17 @@ mod tests {
                 String::new(),
             ]
             .join("\n")
+        );
+    }
+
+    #[test]
+    fn table_ddl_export_has_one_statement_terminator() {
+        let ddl = "CREATE TABLE `users` (`id` int);;\n";
+
+        assert_eq!(format_export_table_ddl(ddl, Some(DatabaseType::Mysql)), "CREATE TABLE `users` (`id` int);");
+        assert_eq!(
+            format_export_table_ddl("CREATE TABLE users (id int)", Some(DatabaseType::Postgres)),
+            "CREATE TABLE users (id int);"
         );
     }
 

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -382,11 +382,11 @@ impl SqlStatementSplitter {
             }
 
             match ch {
-                '\'' if !self.in_double_quote && !self.in_backtick && self.previous != Some('\\') => {
+                '\'' if !self.in_double_quote && !self.in_backtick && !has_odd_trailing_backslashes(&self.buffer) => {
                     self.in_single_quote = !self.in_single_quote;
                     self.buffer.push(ch);
                 }
-                '"' if !self.in_single_quote && !self.in_backtick && self.previous != Some('\\') => {
+                '"' if !self.in_single_quote && !self.in_backtick && !has_odd_trailing_backslashes(&self.buffer) => {
                     self.in_double_quote = !self.in_double_quote;
                     self.buffer.push(ch);
                 }
@@ -520,6 +520,10 @@ impl SqlStatementSplitter {
         let line = self.buffer[start..].trim_start().as_bytes();
         line.len() >= 9 && line[..9].eq_ignore_ascii_case(b"delimiter")
     }
+}
+
+fn has_odd_trailing_backslashes(sql: &str) -> bool {
+    sql.as_bytes().iter().rev().take_while(|byte| **byte == b'\\').count() % 2 == 1
 }
 
 pub fn split_sql_statements(sql: &str) -> Vec<String> {
@@ -2455,6 +2459,39 @@ mod tests {
                 "-- comment ; ignored\n/* block ; ignored */\nSELECT 1",
             ]
         );
+    }
+
+    #[test]
+    fn closes_mysql_string_after_even_trailing_backslashes() {
+        let sql = r#"CREATE TABLE paths (value varchar(100) COMMENT 'Windows path\\'); DROP TABLE paths;"#;
+
+        assert_eq!(
+            split_sql_statements_for_database(sql, DatabaseType::Mysql),
+            vec![r#"CREATE TABLE paths (value varchar(100) COMMENT 'Windows path\\')"#, "DROP TABLE paths"]
+        );
+    }
+
+    #[test]
+    fn keeps_mysql_string_open_after_odd_trailing_backslashes() {
+        let sql = r#"INSERT INTO notes VALUES ('it\'s; still one value'); SELECT 1;"#;
+
+        assert_eq!(
+            split_sql_statements_for_database(sql, DatabaseType::Mysql),
+            vec![r#"INSERT INTO notes VALUES ('it\'s; still one value')"#, "SELECT 1"]
+        );
+    }
+
+    #[test]
+    fn closes_mysql_string_after_even_trailing_backslashes_across_chunks() {
+        let mut splitter =
+            SqlStatementSplitter::with_options(SqlParsingOptions::for_database_type(DatabaseType::Mysql));
+
+        assert!(splitter.push_chunk("CREATE TABLE paths (value varchar(100) COMMENT 'Windows path\\").is_empty());
+        assert_eq!(
+            splitter.push_chunk("\\'); DROP TABLE paths;"),
+            vec![r#"CREATE TABLE paths (value varchar(100) COMMENT 'Windows path\\')"#, "DROP TABLE paths"]
+        );
+        assert!(splitter.finish().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

MySQL 表 DDL 在元数据层已经带有语句终止分号，整库导出时再次无条件追加，导致导出文件出现 `;;`。

此外，SQL 文件解析器仅检查引号前一个字符是否为反斜杠。MySQL `SHOW CREATE TABLE` 遇到以反斜杠结尾的注释或默认值时会输出偶数个反斜杠，解析器会误判结束引号仍被转义，并把后续多张表的 DDL 合并为一条语句，最终报错位置类似 `; DROP TABLE ...; CREATE TABLE ...`。

## 修复

- 统一格式化导出的表 DDL，移除已有尾部分号后只追加一个终止符。
- 按连续反斜杠数量的奇偶性判断引号是否被转义。
- 覆盖偶数、奇数及跨流式读取块的反斜杠解析场景。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p dbx-core sql::tests -- --nocapture`：613 通过，0 失败，1 个既有远程测试忽略
- `cargo test -p dbx-core database_export::tests -- --nocapture`：40 通过，0 失败
- `cargo clippy -p dbx-core --all-targets -- -D warnings -A clippy::nonminimal-bool`
- MySQL 8.0.45 真实往返：通过 DBX `export_database_sql_core` 导出 413,275 字节 SQL，再通过 `execute_sql_file_path` 流式导入；100 条语句成功、0 失败，49 张表完整恢复，导出文件不再包含 `;;`

本机 Rust 1.94.1 下未豁免的 Clippy 会被 `origin/main` 现有两条 `nonminimal_bool` 警告阻断；本 PR 未修改对应代码。仓库 CI 使用 Rust 1.97.1。