### PR TITLE
Fix：修复长关键词前缀补全遗漏

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -35,6 +35,34 @@ function semanticCompletion(markedSql: string, input: Partial<SqlCompletionProvi
 }
 
 describe("semantic SQL completion candidates", () => {
+  it.each([
+    ["MySQL ORDER BY", "SELECT * FROM t LIMIT 100 or|", "mysql", "mysql", "ORDER BY"],
+    ["PostgreSQL ON CONFLICT", "INSERT INTO t VALUES (1) on|", "postgres", "postgres", "ON CONFLICT"],
+    ["Oracle EXECUTE IMMEDIATE", "exec|", "oracle", undefined, "EXECUTE IMMEDIATE"],
+  ] as const)("keeps the longer %s keyword available before the current token is committed", (_label, sql, databaseType, dialect, expectedKeyword) => {
+    const { context, items } = semanticCompletion(sql, {}, { databaseType, dialect });
+
+    expect(context.suggestKeywords).toBe(false);
+    expect(items).toEqual(expect.arrayContaining([expect.objectContaining({ label: expectedKeyword, type: "keyword" })]));
+  });
+
+  it("does not offer keyword continuations for qualified column prefixes", () => {
+    const columnsByTable = new Map<string, SqlCompletionColumn[]>([["t", [{ name: "order_number", table: "t" }]]]);
+    const { context, items } = semanticCompletion("SELECT * FROM t WHERE t.or|", { columnsByTable }, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.qualifier).toBe("t");
+    expect(items.some((item) => item.label === "ORDER BY")).toBe(false);
+  });
+
+  it("stops offering ORDER BY as a prefix continuation after OR is committed with whitespace", () => {
+    const columnsByTable = new Map<string, SqlCompletionColumn[]>([["t", [{ name: "id", table: "t" }]]]);
+    const { context, items } = semanticCompletion("SELECT * FROM t WHERE id = 1 OR |", { columnsByTable }, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prefix).toBe("");
+    expect(items.some((item) => item.label === "ORDER BY")).toBe(false);
+    expect(items.some((item) => item.label === "id" && item.type === "column")).toBe(true);
+  });
+
   it("keeps matching functions available in column expressions", () => {
     const columnsByTable = new Map<string, SqlCompletionColumn[]>([
       [

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -1393,6 +1393,8 @@ class SqlCompletionProvider {
     if (context.suggestKeywords && !context.exclusiveRoutineSuggestions && !pendingJoinKeyword) {
       this.items.push(...buildJoinModifierKeywordItems(context.prefix, this.input.keywordCase));
       this.items.push(...buildKeywordItems(context.prefix, context, this.databaseType, this.input.keywordCase));
+    } else if (shouldOfferKeywordPrefixContinuations(context, pendingJoinKeyword)) {
+      this.items.push(...buildKeywordPrefixContinuationItems(context.prefix, context, this.databaseType, this.input.keywordCase));
     }
 
     if (!context.exclusiveTableSuggestions && context.suggestColumns) {
@@ -4145,6 +4147,18 @@ function buildKeywordItems(prefix: string, context: SqlCompletionContext, databa
         boost: base + freqBoost,
       };
     });
+}
+
+function shouldOfferKeywordPrefixContinuations(context: SqlCompletionContext, pendingJoinKeyword: boolean): boolean {
+  return !!context.prefix && !pendingJoinKeyword && !context.qualifier && !context.exclusiveTableSuggestions && !context.exclusiveColumnSuggestions;
+}
+
+function buildKeywordPrefixContinuationItems(prefix: string, context: SqlCompletionContext, databaseType?: DatabaseType, keywordCase?: SqlKeywordCase): SqlCompletionItem[] {
+  const normalizedPrefix = prefix.toLowerCase();
+  return buildKeywordItems(prefix, context, databaseType, keywordCase).filter((item) => {
+    const normalizedLabel = item.label.toLowerCase();
+    return normalizedLabel.length > normalizedPrefix.length && normalizedLabel.startsWith(normalizedPrefix);
+  });
 }
 
 function matchesPrefix(candidate: string, prefix: string): boolean {


### PR DESCRIPTION
## 问题

当已输入内容既是完整短关键字、又是更长关键字的前缀时，语义补全会提前切换上下文。例如输入 `or` 后会按 `OR` 后续字段处理，导致 `ORDER BY` 消失，必须继续输入 `ord` 才能看到。

## 改动

- 在语义范围已切换时，保留严格以当前输入开头且长度更长的关键字候选
- 覆盖 MySQL `OR → ORDER BY`、PostgreSQL `ON → ON CONFLICT`、Oracle `EXEC/EXECUTE → EXECUTE IMMEDIATE` 等同类场景
- 仅对未限定的普通前缀生效，表名补全、`别名.字段` 和其他排他补全范围保持不变
- 输入空格确认短关键字后停止提供长前缀候选，继续进入原有字段补全流程

## 验证

- SQL 模块 26 个测试文件、449 条测试通过
- 语义补全及上下文定向测试 60 条通过
- `pnpm typecheck`
- `pnpm lint`
- 在真实 CodeMirror 编辑器中验证输入 `or` 时 `ORDER BY` 可直接出现