### PR TITLE
Fix：重新执行 SQL 时清除排序状态并优化排序菜单

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -35,6 +35,7 @@ import {
   PanelRight,
   TableProperties,
   Database,
+  Eraser,
   Columns3,
   PencilRuler,
   WandSparkles,
@@ -492,7 +493,7 @@ function sortMenuItems(column: string, columnIndex: number) {
       currentPageDescending: t("grid.sortCurrentPageDescending"),
       clear: t("grid.clearSort"),
     },
-    icons: { database: Database, ascending: ArrowUp, descending: ArrowDown, clear: ArrowUpDown },
+    icons: { database: Database, ascending: ArrowUp, descending: ArrowDown, clear: Eraser },
   });
 }
 
@@ -7364,7 +7365,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
         localDescending: t("grid.sortCurrentPageDescending"),
         clearSort: t("grid.clearSort"),
       },
-      icons: { copy: Copy, columnDetails: TableProperties, database: Database, ascending: ArrowUp, descending: ArrowDown, clearSort: ArrowUpDown },
+      icons: { copy: Copy, columnDetails: TableProperties, database: Database, ascending: ArrowUp, descending: ArrowDown, clearSort: Eraser },
       actions: { copyName: copyHeaderColumn, copyNames: copyColumnNames, details: openContextColumnDetailDialog, copyAlterSql: copyAlterColumnSql, sort: applyContextSort },
       filterSubmenu: filterSubmenu(),
     }),
@@ -7847,9 +7848,10 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           :items="sortMenuItems(col.name, col.actualColIdx)"
                           :open="headerSortMenuOpenColumn === col.actualColIdx"
                           :selected-value="selectedSortMenuValue(col.name, col.actualColIdx)"
+                          check-position="none"
                           align="end"
                           content-class="w-max min-w-28 p-0.5"
-                          item-class="gap-1 px-1.5 py-0.5 text-xs"
+                          item-class="gap-1 rounded-none px-1.5 py-0.5 text-xs"
                           item-icon-class="h-3 w-3"
                           :match-trigger-width="false"
                           @update:open="(value: boolean) => (headerSortMenuOpenColumn = value ? col.actualColIdx : null)"
@@ -7858,8 +7860,8 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           <template #trigger="{ open, toggle }">
                             <button
                               type="button"
-                              class="flex h-4 w-4 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-foreground"
-                              :class="columnIsSorted(col.name, col.actualColIdx) ? 'text-primary opacity-100' : 'opacity-80'"
+                              class="flex h-4 w-4 shrink-0 items-center justify-center rounded"
+                              :class="columnIsSorted(col.name, col.actualColIdx) ? 'bg-primary text-primary-foreground opacity-100 shadow-sm hover:bg-primary/90' : 'text-muted-foreground opacity-80 hover:bg-accent hover:text-foreground'"
                               :title="t('grid.sort')"
                               :aria-expanded="open"
                               @mousedown.stop

--- a/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
@@ -332,6 +332,27 @@ describe("queryStore hidden primary key editing", () => {
     expect(tab.queryAnalysis).toBeDefined();
   });
 
+  it("clears result sorting when the editor SQL is executed again", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    tab.resultSortColumn = "name";
+    tab.resultSortColumnIndex = 0;
+    tab.resultSortDirection = "desc";
+    tab.resultSortMode = "database";
+    tab.resultSortedSql = "SELECT name FROM users ORDER BY name DESC";
+
+    await store.executeCurrentSql("SELECT name FROM users");
+
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.resultSortColumnIndex).toBeUndefined();
+    expect(tab.resultSortDirection).toBeUndefined();
+    expect(tab.resultSortMode).toBeUndefined();
+    expect(tab.resultSortedSql).toBeUndefined();
+    expect(executeMulti).toHaveBeenLastCalledWith("mysql-1", "app", "SELECT name, `id` AS `__DBX_PK_0` FROM users", undefined, expect.any(String), expect.objectContaining({ timeoutSecs: 30 }));
+  });
+
   it("preserves the original query behavior when the primary key is already returned", async () => {
     analyzeEditableQueryEditability.mockResolvedValue({
       editable: true,

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2357,6 +2357,14 @@ export const useQueryStore = defineStore("query", () => {
 
   async function executeCurrentSql(sql: string, options?: { skipRedisSafetyCheck?: boolean; sourceOffset?: number }) {
     if (!activeTabId.value) return;
+    const tab = tabs.value.find((item) => item.id === activeTabId.value);
+    if (tab?.mode === "query") {
+      tab.resultSortColumn = undefined;
+      tab.resultSortColumnIndex = undefined;
+      tab.resultSortDirection = undefined;
+      tab.resultSortMode = undefined;
+      tab.resultSortedSql = undefined;
+    }
     await executeTabSql(activeTabId.value, sql, { resultBaseSql: sql, resultSortedSql: undefined, ...options });
   }
 


### PR DESCRIPTION
修复 SQL 编辑器结果重新查询后仍保留旧排序状态的问题，并优化列头排序交互。

**改动内容**

- SQL 编辑器重新执行查询时清除结果排序字段、方向、模式及排序 SQL，确保新结果与列头状态一致
- 排序菜单移除勾选占位，选中项使用直角背景高亮
- 已排序列头使用主题强调色常驻高亮，并保留悬浮反馈
- “清除排序”改用橡皮擦图标
- 增加重新执行 SQL 后清除排序状态的回归测试

**验证**

- `pnpm -s typecheck`
- `pnpm exec oxlint apps/desktop/src/components/grid/DataGrid.vue apps/desktop/src/stores/queryStore.ts apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts`
- 专项测试：2 个测试文件、19 项测试通过
- 真实 MySQL UI：数据库降序后再次执行原 SQL，结果恢复原始顺序，列头排序状态同步清除
- 洁白、深色主题下检查排序强调色；排序菜单无勾选占位且选中背景无圆角

**基线说明**

完整前端测试在最新 `main` 上仍有一项既有失败：`packages/app-tests/dataGridContextMenu.test.ts` 要求 `onHeaderContext` 调用 `prefetchCopyStatements()`，但最新主线实现本身已无该调用；本 PR 未修改该函数或断言。另一个连接侧栏搜索超时项单独复跑已通过。