### PR TITLE
fix(dameng): 保真导出字符串中的 NUL 字符

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -293,11 +293,30 @@ fn quote_export_sql_string(text: &str) -> String {
 }
 
 fn quote_export_sql_string_for_database(text: &str, database_type: Option<DatabaseType>) -> String {
-    if is_mysql_compatible_export_literal_target(database_type) {
-        quote_mysql_compatible_export_sql_string(text)
-    } else {
-        quote_export_sql_string(text)
+    match database_type {
+        Some(DatabaseType::Dameng) => quote_dameng_export_sql_string(text),
+        database_type if is_mysql_compatible_export_literal_target(database_type) => {
+            quote_mysql_compatible_export_sql_string(text)
+        }
+        _ => quote_export_sql_string(text),
     }
+}
+
+fn quote_dameng_export_sql_string(text: &str) -> String {
+    if !text.contains('\0') {
+        return quote_export_sql_string(text);
+    }
+
+    let mut parts = Vec::new();
+    for (index, segment) in text.split('\0').enumerate() {
+        if index > 0 {
+            parts.push("CHR(0)".to_string());
+        }
+        if !segment.is_empty() {
+            parts.push(quote_export_sql_string(segment));
+        }
+    }
+    parts.join(" || ")
 }
 
 fn quote_mysql_compatible_export_sql_string(text: &str) -> String {
@@ -2437,6 +2456,47 @@ mod tests {
             statements,
             vec!["INSERT INTO \"DBX_TEST\".\"FLAGS\" (\"ENABLED\", \"DELETED\", \"OPTIONAL\") VALUES (1, 0, NULL);"]
         );
+    }
+
+    #[test]
+    fn dameng_strings_export_nul_as_chr_expression() {
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::Dameng),
+            schema: Some("DBX_TEST".to_string()),
+            table_name: Some("NUL_VALUES".to_string()),
+            qualified_table_name: None,
+            columns: vec![
+                "PLAIN".to_string(),
+                "TRAILING".to_string(),
+                "LEADING".to_string(),
+                "MIDDLE".to_string(),
+                "CONSECUTIVE".to_string(),
+                "ONLY_NUL".to_string(),
+            ],
+            column_types: vec![Some("VARCHAR".to_string()); 6],
+            column_extras: Vec::new(),
+            rows: vec![vec![
+                json!("plain"),
+                json!("eHall\0"),
+                json!("\0leading"),
+                json!("left\0right"),
+                json!("left\0\0right"),
+                json!("\0"),
+            ]],
+            batch_size: Some(10),
+        })
+        .unwrap();
+
+        assert_eq!(
+            statements,
+            vec![concat!(
+                "INSERT INTO \"DBX_TEST\".\"NUL_VALUES\" ",
+                "(\"PLAIN\", \"TRAILING\", \"LEADING\", \"MIDDLE\", \"CONSECUTIVE\", \"ONLY_NUL\") ",
+                "VALUES ('plain', 'eHall' || CHR(0), CHR(0) || 'leading', 'left' || CHR(0) || 'right', ",
+                "'left' || CHR(0) || CHR(0) || 'right', CHR(0));"
+            )]
+        );
+        assert!(!statements[0].contains('\0'));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

达梦 JDBC Agent 返回的字符串可能包含 NUL（`U+0000`）。DBX 原先直接把该字符写入导出的 SQL 文件，编辑器会显示为 `<0x00>`，文件中也确实存在原始 `0x00` 字节。

## 修复

- 达梦导出遇到 NUL 时，按原位置生成 `CHR(0)` 拼接表达式，例如 `eHall\0` 导出为 `'eHall' || CHR(0)`。
- 不删除 NUL，保证备份数据可还原。
- 覆盖开头、结尾、中间、连续 NUL 和仅含 NUL 的字符串。
- 不影响不含 NUL 的达梦字符串以及其他数据库导出逻辑。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p dbx-core database_export::tests`
  - 41 个导出模块测试通过
- `cargo clippy -p dbx-core --all-targets -- -D warnings -A clippy::nonminimal-bool`
- 真实 DM8（`192.168.58.103:15236`）验证：将修复后生成的表达式实际插入数据库，再读取长度、尾字符编码及完整值比较
  - 普通、开头、结尾、中间、连续及纯 NUL 六类数据均可写入
  - `ASCII(SUBSTR(...)) = 0`
  - `LENGTH` 与预期一致
  - 原值比较结果为真
  - 验证用临时表已清理
