### PR TITLE
fix(desktop): 修复 Windows 窗口顶边框与左右底不一致

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -45,7 +45,7 @@ import { sqlObjectNavigationSourceKind, sqlObjectNavigationTableType, type SqlOb
 import { buildExecutableObjectSourceStatements, executeObjectSourceSave } from "@/lib/table/objectSourceEditor";
 import { resolveExecutableSql, resolveExecutableSqlWithBackend, type SqlExecutionSnapshot } from "@/lib/sql/sqlExecutionTarget";
 import { uuid } from "@/lib/common/utils";
-import { isMacOS } from "@/lib/backend/platform";
+import { isMacOS, isWindows } from "@/lib/backend/platform";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { openQueryResultArchiveFile } from "@/lib/query/queryResultArchiveFile";
 import { sqlFileTitleFromPath } from "@/lib/sql/sqlFileOpen";
@@ -152,7 +152,7 @@ const {
 const { setupFileDrop } = useFileDrop();
 
 const isDesktop = isTauriRuntime();
-const drawDesktopWindowFrame = shouldDrawDesktopWindowFrame(isMacOS(), isDesktop);
+const drawDesktopWindowFrame = shouldDrawDesktopWindowFrame(isMacOS(), isDesktop, isWindows());
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 let updateCheckTimer: ReturnType<typeof setInterval> | undefined;
 const needsAuth = ref(!isDesktop);

--- a/apps/desktop/src/composables/__tests__/useWindowControls.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useWindowControls.spec.ts
@@ -14,10 +14,11 @@ describe("window controls", () => {
     expect(shouldShowWindowControls(false, false)).toBe(false);
   });
 
-  it("draws an app frame only for self-decorated desktop windows", () => {
-    expect(shouldDrawDesktopWindowFrame(false, true)).toBe(true);
-    expect(shouldDrawDesktopWindowFrame(true, true)).toBe(false);
-    expect(shouldDrawDesktopWindowFrame(false, false)).toBe(false);
+  it("draws an app frame only for self-decorated non-Windows desktop windows", () => {
+    expect(shouldDrawDesktopWindowFrame(false, true, false)).toBe(true);
+    expect(shouldDrawDesktopWindowFrame(false, true, true)).toBe(false);
+    expect(shouldDrawDesktopWindowFrame(true, true, false)).toBe(false);
+    expect(shouldDrawDesktopWindowFrame(false, false, false)).toBe(false);
   });
 
   it("reserves traffic light inset only for non-fullscreen macOS desktop windows", () => {

--- a/apps/desktop/src/composables/useWindowControls.ts
+++ b/apps/desktop/src/composables/useWindowControls.ts
@@ -35,8 +35,10 @@ export function shouldShowWindowControls(isMac: boolean, isDesktop = true): bool
   return isDesktop && !isMac;
 }
 
-export function shouldDrawDesktopWindowFrame(isMac: boolean, isDesktop = true): boolean {
-  return isDesktop && !isMac;
+export function shouldDrawDesktopWindowFrame(isMac: boolean, isDesktop = true, isWindows = false): boolean {
+  // Windows frameless+shadow windows already get a DWM 1px border on all sides.
+  // An extra CSS top hairline stacks on that edge and no longer matches left/right/bottom.
+  return isDesktop && !isMac && !isWindows;
 }
 
 export function useWindowControls() {


### PR DESCRIPTION
## 变更说明

Windows 无边框 + shadow 窗口的左右底边框由 DWM 绘制；此前为补顶边又叠了一层 CSS `::before` 顶线（`dbx-desktop-window-frame`），截图像素可见顶边实际是双层（系统 `#B8` + CSS `#A3`），观感与左右底不一致。

本次在 Windows 上关闭该 CSS 顶线，顶边与左右底共用同一条系统边框：
- macOS 本就不画 CSS 窗框，行为不变
- Linux 仍保留 CSS 补线（无 DWM）

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<img width="461" height="162" alt="image" src="https://github.com/user-attachments/assets/7752907c-3c45-4c32-b80c-58063f0ffd42" />

本地可验证：
1. Windows 桌面端启动后，顶边与左右底边框颜色/粗细一致
2. 最大化/还原后顶边仍与侧边一致
3. macOS / Linux 行为无回归（Mac 无 CSS 窗框；Linux 仍画顶线）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关功能本地验证通过

补充覆盖：`pnpm vitest run apps/desktop/src/composables/__tests__/useWindowControls.spec.ts`（7 tests passed）

## 关联 Issue

Closes #4059