### PR TITLE
Fix：修复大段 SQL 粘贴内容被截断

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onBeforeUnmount, onActivated, onDeactivated, watch, sha
 import { CaseLower, CaseUpper, Code2, FileCode, Pencil, PencilRuler, Play, Copy, List, Search, Sparkles, Table2, TextSelect, Trash2 } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import type { CompletionContext } from "@codemirror/autocomplete";
+import { Transaction } from "@codemirror/state";
 import type { EditorView as EditorViewType } from "@codemirror/view";
 import { search as cmSearch } from "@codemirror/search";
 import EditorSearchPanel from "./EditorSearchPanel.vue";
@@ -68,7 +69,7 @@ import { focusEditorView } from "@/lib/editor/queryEditorFocus";
 import { createDbxCodeMirrorSqlDialect } from "@/lib/editor/codemirrorSqlDialect";
 import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorSqlSemanticHighlight";
 import { startsQueryEditorRectangularSelection } from "@/lib/editor/queryEditorPointerSelection";
-import { normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
+import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
 import { isSchemaAware, isSingleDatabase, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
 import { metadataSchemaForConnection } from "@/lib/database/jdbcDialect";
@@ -1014,11 +1015,14 @@ function recoverLargeTauriPaste(event: ClipboardEvent, currentView: EditorViewTy
   const insertedText = normalizeQueryEditorPasteText(eventText);
   const insertedFrom = selection.from;
   const insertedTo = insertedFrom + insertedText.length;
+  const pasteStartedAt = Date.now();
   currentView.dispatch({
     changes: { from: selection.from, to: selection.to, insert: insertedText },
     selection: { anchor: insertedTo },
     scrollIntoView: true,
-    userEvent: "input.paste",
+    // CodeMirror only joins input.type history events; keep one timestamp so delayed recovery is one undo step.
+    annotations: Transaction.time.of(pasteStartedAt),
+    userEvent: LARGE_PASTE_HISTORY_USER_EVENT,
   });
 
   void readTextFromClipboard()
@@ -1032,7 +1036,8 @@ function recoverLargeTauriPaste(event: ClipboardEvent, currentView: EditorViewTy
         changes: { from: insertedTo, insert: suffix },
         ...(selectionRemainedAtPasteEnd ? { selection: { anchor: insertedTo + suffix.length } } : {}),
         scrollIntoView: selectionRemainedAtPasteEnd,
-        userEvent: "input.paste",
+        annotations: Transaction.time.of(pasteStartedAt),
+        userEvent: LARGE_PASTE_HISTORY_USER_EVENT,
       });
     })
     .catch(() => {});

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -68,12 +68,14 @@ import { focusEditorView } from "@/lib/editor/queryEditorFocus";
 import { createDbxCodeMirrorSqlDialect } from "@/lib/editor/codemirrorSqlDialect";
 import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorSqlSemanticHighlight";
 import { startsQueryEditorRectangularSelection } from "@/lib/editor/queryEditorPointerSelection";
+import { normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
 import { isSchemaAware, isSingleDatabase, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
 import { metadataSchemaForConnection } from "@/lib/database/jdbcDialect";
 import { usesLocalOnlyEditorCompletionMetadata, usesOnDemandOnlyEditorColumnMetadata } from "@/lib/metadata/completionMetadataPolicy";
 import { queryContextObjectActions, queryContextObjectRoute, queryTableCandidateAtSqlPosition, resolveQueryContextCandidateDatabase, resolveQueryContextObjectTarget, type QueryContextObjectAction } from "@/lib/sql/queryCursorTableTarget";
 import * as api from "@/lib/backend/api";
+import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import {
   areSqlSemanticDiagnosticsEqual,
   buildSqlParserErrorDiagnostic,
@@ -1000,6 +1002,40 @@ async function pasteClipboardAsSqlInCondition(): Promise<boolean> {
   });
   currentView.focus();
   toast(t("editor.exPastePasted", { count: result.valueCount }), 2000);
+  return true;
+}
+
+function recoverLargeTauriPaste(event: ClipboardEvent, currentView: EditorViewType): boolean {
+  const eventText = event.clipboardData?.getData("text/plain") ?? "";
+  if (props.readOnly || currentView.state.selection.ranges.length !== 1 || !shouldRecoverLargeTauriPaste(eventText, isTauriRuntime())) return false;
+
+  event.preventDefault();
+  const selection = currentView.state.selection.main;
+  const insertedText = normalizeQueryEditorPasteText(eventText);
+  const insertedFrom = selection.from;
+  const insertedTo = insertedFrom + insertedText.length;
+  currentView.dispatch({
+    changes: { from: selection.from, to: selection.to, insert: insertedText },
+    selection: { anchor: insertedTo },
+    scrollIntoView: true,
+    userEvent: "input.paste",
+  });
+
+  void readTextFromClipboard()
+    .then((nativeText) => {
+      const suffix = recoverableNativePasteSuffix(eventText, nativeText);
+      if (!suffix || props.readOnly || view.value !== currentView) return;
+      if (currentView.state.doc.sliceString(insertedFrom, insertedTo) !== insertedText) return;
+      const currentSelection = currentView.state.selection.main;
+      const selectionRemainedAtPasteEnd = currentSelection.empty && currentSelection.head === insertedTo;
+      currentView.dispatch({
+        changes: { from: insertedTo, insert: suffix },
+        ...(selectionRemainedAtPasteEnd ? { selection: { anchor: insertedTo + suffix.length } } : {}),
+        scrollIntoView: selectionRemainedAtPasteEnd,
+        userEvent: "input.paste",
+      });
+    })
+    .catch(() => {});
   return true;
 }
 
@@ -3567,6 +3603,9 @@ onMounted(async () => {
         }),
       ),
       EditorView.domEventHandlers({
+        paste(event, currentView) {
+          return recoverLargeTauriPaste(event, currentView);
+        },
         dragover(event) {
           if (props.readOnly || !hasDroppedTableReference(event)) return false;
           event.preventDefault();

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorLargePaste.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorLargePaste.spec.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
+import { history, undo, undoDepth } from "@codemirror/commands";
+import { EditorState, Transaction } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
-import { LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
+import { LARGE_PASTE_HISTORY_USER_EVENT, LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 
@@ -22,6 +24,40 @@ describe("QueryEditor large paste recovery", () => {
     expect(shouldRecoverLargeTauriPaste("x".repeat(LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD), false)).toBe(false);
     expect(recoverableNativePasteSuffix("SELECT 1", "SELECT 1")).toBeNull();
     expect(recoverableNativePasteSuffix("SELECT 1", "SELECT 2 with more text")).toBeNull();
+  });
+
+  it("preserves Unicode separators that CodeMirror does not treat as line breaks", () => {
+    expect(normalizeQueryEditorPasteText("SELECT '\u2028\u2029'\r\n")).toBe("SELECT '\u2028\u2029'\n");
+  });
+
+  it("groups the WebView prefix and native suffix into one undo step", () => {
+    const pasteStartedAt = Date.now();
+    let state = EditorState.create({ doc: "SELECT ", selection: { anchor: 7 }, extensions: [history()] });
+    state = state.update({
+      changes: { from: 7, insert: "prefix" },
+      selection: { anchor: 13 },
+      annotations: Transaction.time.of(pasteStartedAt),
+      userEvent: LARGE_PASTE_HISTORY_USER_EVENT,
+    }).state;
+    state = state.update({
+      changes: { from: 13, insert: "suffix" },
+      selection: { anchor: 19 },
+      annotations: Transaction.time.of(pasteStartedAt),
+      userEvent: LARGE_PASTE_HISTORY_USER_EVENT,
+    }).state;
+    const view = {
+      get state() {
+        return state;
+      },
+      dispatch(transaction: Transaction) {
+        state = transaction.state;
+      },
+    } as unknown as Parameters<typeof undo>[0];
+
+    expect(undoDepth(state)).toBe(1);
+    expect(undo(view)).toBe(true);
+    expect(state.doc.toString()).toBe("SELECT ");
+    expect(state.selection.main.from).toBe(7);
   });
 
   it("wires the recovery into the editor paste event", () => {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorLargePaste.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorLargePaste.spec.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+describe("QueryEditor large paste recovery", () => {
+  it("recovers the suffix of a SQL paste truncated at the WebView boundary", () => {
+    const sql = Array.from({ length: 10_925 }, (_, index) => `('Z${String(index).padStart(13, "0")}'),`).join("\r\n");
+    const eventText = sql.slice(0, 128 * 1024);
+
+    expect(shouldRecoverLargeTauriPaste(eventText, true)).toBe(true);
+    const suffix = recoverableNativePasteSuffix(eventText, sql);
+    expect(suffix).not.toBeNull();
+    const recovered = normalizeQueryEditorPasteText(eventText) + suffix;
+    expect(recovered).toBe(normalizeQueryEditorPasteText(sql));
+    expect(recovered.split("\n")).toHaveLength(10_925);
+  });
+
+  it("does not alter small, web, unchanged, or unrelated clipboard text", () => {
+    expect(shouldRecoverLargeTauriPaste("x".repeat(LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD - 1), true)).toBe(false);
+    expect(shouldRecoverLargeTauriPaste("x".repeat(LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD), false)).toBe(false);
+    expect(recoverableNativePasteSuffix("SELECT 1", "SELECT 1")).toBeNull();
+    expect(recoverableNativePasteSuffix("SELECT 1", "SELECT 2 with more text")).toBeNull();
+  });
+
+  it("wires the recovery into the editor paste event", () => {
+    expect(queryEditorSource).toMatch(/paste\(event, currentView\)[\s\S]*?recoverLargeTauriPaste\(event, currentView\)/);
+  });
+});

--- a/apps/desktop/src/lib/editor/queryEditorLargePaste.ts
+++ b/apps/desktop/src/lib/editor/queryEditorLargePaste.ts
@@ -1,7 +1,8 @@
 export const LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD = 120 * 1024;
+export const LARGE_PASTE_HISTORY_USER_EVENT = "input.type.paste";
 
 export function normalizeQueryEditorPasteText(text: string): string {
-  return text.replace(/\r\n?|\u2028|\u2029/g, "\n");
+  return text.replace(/\r\n?/g, "\n");
 }
 
 export function shouldRecoverLargeTauriPaste(eventText: string, tauriRuntime: boolean): boolean {

--- a/apps/desktop/src/lib/editor/queryEditorLargePaste.ts
+++ b/apps/desktop/src/lib/editor/queryEditorLargePaste.ts
@@ -1,0 +1,18 @@
+export const LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD = 120 * 1024;
+
+export function normalizeQueryEditorPasteText(text: string): string {
+  return text.replace(/\r\n?|\u2028|\u2029/g, "\n");
+}
+
+export function shouldRecoverLargeTauriPaste(eventText: string, tauriRuntime: boolean): boolean {
+  if (!tauriRuntime || !eventText) return false;
+  if (eventText.length >= LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD) return true;
+  return new TextEncoder().encode(eventText).byteLength >= LARGE_PASTE_NATIVE_RECOVERY_THRESHOLD;
+}
+
+export function recoverableNativePasteSuffix(eventText: string, nativeText: string): string | null {
+  const normalizedEventText = normalizeQueryEditorPasteText(eventText);
+  const normalizedNativeText = normalizeQueryEditorPasteText(nativeText);
+  if (normalizedNativeText.length <= normalizedEventText.length || !normalizedNativeText.startsWith(normalizedEventText)) return null;
+  return normalizedNativeText.slice(normalizedEventText.length);
+}


### PR DESCRIPTION
## 问题

Windows 桌面端粘贴大段 SQL 时，WebView 的 `ClipboardEvent` 可能只提供约 128 KiB 文本，导致一万多行 SQL 在六千多行处被截断。编辑器自身不存在对应的行数或字符数限制。

## 改动

- 仅在 Tauri 桌面端的大文本、单选区粘贴场景启用原生剪贴板恢复。
- 先插入 WebView 提供的内容，再读取系统剪贴板；确认原生文本更长且前缀完全一致后，只补入缺失后缀。
- 网页端、普通小文本、多选区及剪贴板内容不一致的场景保持原有行为。
- 补充换行归一化和截断恢复回归测试。

## 验证

- 模拟 128 KiB WebView 截断后，可恢复完整 10,925 行 SQL。
- Tauri 客户端实际粘贴并回读 10,925 行、283,688 字节，首尾内容完整。
- `pnpm check` 通过（format、lint、typecheck、全量前端测试）。