### PR TITLE
Fix：修复 SQL 库导入 GBK 脚本乱码

### DIFF
--- a/apps/desktop/src/components/layout/SqlLibraryPanel.vue
+++ b/apps/desktop/src/components/layout/SqlLibraryPanel.vue
@@ -235,7 +235,6 @@ async function importDirectoryIntoLibrary(targetFolder?: SavedSqlFolder) {
 
   try {
     const { open } = await import("@tauri-apps/plugin-dialog");
-    const { readTextFile } = await import("@tauri-apps/plugin-fs");
     const selected = await open({
       directory: true,
       multiple: false,
@@ -253,7 +252,7 @@ async function importDirectoryIntoLibrary(targetFolder?: SavedSqlFolder) {
     const takenNames = new Set((targetFolder ? savedSqlStore.filesInFolder(targetFolder.id) : savedSqlStore.filesWithoutFolder()).filter((file) => !orphanedIds.value.has(file.id)).map((file) => file.name));
 
     for (const path of sqlPaths) {
-      const content = await readTextFile(path);
+      const content = await api.readExternalSqlFile(path);
       const displayName = uniqueImportedName(relativeImportName(selected, path), takenNames);
       await savedSqlStore.saveFile({
         connectionId,

--- a/packages/app-tests/sqlLibraryImportEncoding.test.ts
+++ b/packages/app-tests/sqlLibraryImportEncoding.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+
+const source = readFileSync("apps/desktop/src/components/layout/SqlLibraryPanel.vue", "utf8");
+
+test("SQL library imports use the charset-aware external SQL reader", () => {
+  const start = source.indexOf("async function importDirectoryIntoLibrary");
+  const end = source.indexOf("async function chooseSyncDirectory", start);
+  const handler = start >= 0 && end > start ? source.slice(start, end) : "";
+
+  assert.match(handler, /await api\.readExternalSqlFile\(path\)/);
+  assert.doesNotMatch(handler, /readTextFile/);
+});


### PR DESCRIPTION
修复将非 UTF-8 SQL 文件导入 SQL 库后中文乱码的问题。

**问题原因**

SQL 编辑器直接打开本地文件时会调用 `readExternalSqlFile`，支持 UTF-8、带 BOM 的 UTF-16 和 GBK；SQL 库导入文件夹时却直接使用 Tauri `readTextFile`，固定按 UTF-8 读取，因此同一个 GBK 文件直接打开正常、导入 SQL 库后乱码。

**修改内容**

- SQL 库导入复用 `readExternalSqlFile`，与编辑器直接打开文件保持相同的编码识别逻辑
- 增加回归测试，防止导入流程再次绕过字符集感知的读取入口

**验证**

- 使用用户提供的 GBK SQL 文件确认原始内容可正确解码为“抄送邮件邮箱地址”
- `pnpm -s typecheck`
- `pnpm exec oxlint apps/desktop/src/components/layout/SqlLibraryPanel.vue packages/app-tests/sqlLibraryImportEncoding.test.ts`
- 完整前端测试：493 个测试文件、4044 项测试全部通过