### PR TITLE
Fix：修复虚谷旧版本无法编辑单元格

### DIFF
--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -51,6 +51,15 @@ WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
   AND UPPER(t.TABLE_NAME) = UPPER(?)
   AND (c.IS_HIDE IS NULL OR c.IS_HIDE = FALSE)
 ORDER BY c.COL_NO`
+const xuguLegacyListColumnsSQL = `
+SELECT c.COL_NAME, c.TYPE_NAME, c.NOT_NULL, c.DEF_VAL, c.COMMENTS, c.SCALE, c."VARYING"
+FROM ALL_COLUMNS c
+JOIN ALL_TABLES t ON t.DB_ID = c.DB_ID AND t.TABLE_ID = c.TABLE_ID
+JOIN ALL_SCHEMAS s ON s.DB_ID = t.DB_ID AND s.SCHEMA_ID = t.SCHEMA_ID
+WHERE UPPER(s.SCHEMA_NAME) = UPPER(?)
+  AND UPPER(t.TABLE_NAME) = UPPER(?)
+  AND (c.IS_HIDE IS NULL OR c.IS_HIDE = FALSE)
+ORDER BY c.COL_NO`
 const xuguListIndexesSQL = `
 SELECT i.INDEX_NAME, i.KEYS, i.IS_UNIQUE, i.IS_PRIMARY, i.INDEX_TYPE, i.FILTER
 FROM ALL_INDEXES i
@@ -1250,6 +1259,17 @@ func isXuguMetadataAccessError(err error) bool {
 		strings.Contains(message, "SYS_TRIGGERS")
 }
 
+func isXuguMissingOnNullColumnError(err error) bool {
+	message := strings.ToUpper(strings.TrimSpace(strings.TrimRight(err.Error(), "\x00")))
+	if !strings.Contains(message, "ON_NULL") {
+		return false
+	}
+	return strings.Contains(message, "E10049") ||
+		strings.Contains(message, "不存在") ||
+		strings.Contains(message, "DOES NOT EXIST") ||
+		strings.Contains(message, "UNKNOWN COLUMN")
+}
+
 func xuguDSNValue(dsn string, key string) string {
 	for _, part := range strings.Split(dsn, ";") {
 		name, value, ok := strings.Cut(part, "=")
@@ -1569,7 +1589,7 @@ func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.queryRows(xuguListColumnsSQL, []any{schema, table})
+	rows, hasDefaultOnNull, err := s.queryColumnRows(schema, table)
 	if err != nil {
 		if isXuguMetadataAccessError(err) {
 			return s.columnsFromSelect(schema, table, primaryKeys)
@@ -1584,16 +1604,12 @@ func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 		var onNull any
 		var scale *int
 		var varying any
-		if err := rows.Scan(
-			&item.Name,
-			&item.DataType,
-			&notNull,
-			&item.ColumnDefault,
-			&onNull,
-			&item.Comment,
-			&scale,
-			&varying,
-		); err != nil {
+		destinations := []any{&item.Name, &item.DataType, &notNull, &item.ColumnDefault}
+		if hasDefaultOnNull {
+			destinations = append(destinations, &onNull)
+		}
+		destinations = append(destinations, &item.Comment, &scale, &varying)
+		if err := rows.Scan(destinations...); err != nil {
 			return nil, err
 		}
 		item.DataType = normalizeXuguColumnType(item.DataType, varying)
@@ -1604,6 +1620,19 @@ func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 		result = append(result, item)
 	}
 	return emptyIfNil(result), rows.Err()
+}
+
+func (s *server) queryColumnRows(schema, table string) (*sql.Rows, bool, error) {
+	args := []any{schema, table}
+	rows, err := s.queryRows(xuguListColumnsSQL, args)
+	if err == nil {
+		return rows, true, nil
+	}
+	if !isXuguMissingOnNullColumnError(err) {
+		return nil, false, err
+	}
+	rows, err = s.queryRows(xuguLegacyListColumnsSQL, args)
+	return rows, false, err
 }
 
 func (s *server) columnsFromSelect(schema, table string, primaryKeys map[string]bool) ([]columnInfo, error) {

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -479,6 +479,59 @@ func TestColumnSQLUsesLowPrivilegeDictionary(t *testing.T) {
 	}
 }
 
+func TestLegacyColumnSQLSupportsServersWithoutOnNullMetadata(t *testing.T) {
+	sqlText := strings.ToUpper(xuguLegacyListColumnsSQL)
+
+	for _, want := range []string{"ALL_COLUMNS", "ALL_TABLES", "ALL_SCHEMAS", "COMMENTS", `"VARYING"`} {
+		if !strings.Contains(sqlText, want) {
+			t.Fatalf("legacy column listing should query %s, got: %s", want, xuguLegacyListColumnsSQL)
+		}
+	}
+	if strings.Contains(sqlText, "ON_NULL") {
+		t.Fatalf("legacy column listing should not require ON_NULL, got: %s", xuguLegacyListColumnsSQL)
+	}
+}
+
+func TestXuguMissingOnNullColumnErrorDetection(t *testing.T) {
+	if !isXuguMissingOnNullColumnError(errors.New("[E10049 L2 C57] 字段变量或函数\"C\".\"ON_NULL\"不存在\x00")) {
+		t.Fatal("expected the Xugu 12.0 missing ON_NULL error to use the legacy column query")
+	}
+	if !isXuguMissingOnNullColumnError(errors.New(`column C.ON_NULL does not exist`)) {
+		t.Fatal("expected an English missing ON_NULL error to use the legacy column query")
+	}
+	for _, err := range []error{
+		errors.New("network timeout"),
+		errors.New("column C.OTHER_COLUMN does not exist"),
+		errors.New("permission denied for C.ON_NULL"),
+	} {
+		if isXuguMissingOnNullColumnError(err) {
+			t.Fatalf("unexpected legacy column fallback for %q", err)
+		}
+	}
+}
+
+func TestGetColumnsFallsBackWhenOnNullMetadataIsUnavailable(t *testing.T) {
+	db, err := sql.Open("xugu-test-legacy-columns", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	columns, err := s.getColumns("SYSDBA", "PRODUCTS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(columns) != 1 {
+		t.Fatalf("expected one legacy column, got %#v", columns)
+	}
+	column := columns[0]
+	if column.Name != "PRODUCT_ID" || column.DataType != "INTEGER" || !column.IsPrimaryKey || column.IsNullable {
+		t.Fatalf("unexpected legacy column metadata: %#v", column)
+	}
+}
+
 func TestIndexSQLUsesLowPrivilegeDictionary(t *testing.T) {
 	sqlText := strings.ToUpper(xuguListIndexesSQL)
 
@@ -831,11 +884,59 @@ func contains(values []string, target string) bool {
 	return false
 }
 
-// -- fake drivers for timeout tests --
+// -- fake drivers for agent tests --
 
 func init() {
 	sql.Register("xugu-test-blocking", &xuguBlockingDriver{})
 	sql.Register("xugu-test-fast", &xuguFastDriver{})
+	sql.Register("xugu-test-legacy-columns", &xuguLegacyColumnsDriver{})
+}
+
+type xuguLegacyColumnsDriver struct{}
+
+func (d *xuguLegacyColumnsDriver) Open(name string) (driver.Conn, error) {
+	return &xuguLegacyColumnsConn{}, nil
+}
+
+type xuguLegacyColumnsConn struct{}
+
+func (c *xuguLegacyColumnsConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not supported")
+}
+func (c *xuguLegacyColumnsConn) Close() error              { return nil }
+func (c *xuguLegacyColumnsConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+func (c *xuguLegacyColumnsConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	upper := strings.ToUpper(query)
+	switch {
+	case strings.Contains(upper, "ALL_CONSTRAINTS"):
+		return &xuguStaticRows{columns: []string{"DEFINE"}, values: [][]driver.Value{{`PRIMARY KEY ("PRODUCT_ID")`}}}, nil
+	case strings.Contains(upper, "ON_NULL"):
+		return nil, errors.New("[E10049 L2 C57] 字段变量或函数\"C\".\"ON_NULL\"不存在\x00")
+	case strings.Contains(upper, "ALL_COLUMNS"):
+		return &xuguStaticRows{
+			columns: []string{"COL_NAME", "TYPE_NAME", "NOT_NULL", "DEF_VAL", "COMMENTS", "SCALE", "VARYING"},
+			values:  [][]driver.Value{{"PRODUCT_ID", "INTEGER", true, nil, nil, int64(-1), false}},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", query)
+	}
+}
+
+type xuguStaticRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *xuguStaticRows) Columns() []string { return r.columns }
+func (r *xuguStaticRows) Close() error      { return nil }
+func (r *xuguStaticRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
 }
 
 var xuguBlockingUnblock chan struct{}


### PR DESCRIPTION
## 问题

新版虚谷 agent 在读取列元数据时查询了 `ALL_COLUMNS.ON_NULL`。虚谷 12.0 不提供该字段，`get_columns` 会返回 `E10049 ON_NULL 不存在`，导致表字段及主键元数据无法加载，最终表现为数据表单元格不可编辑。

## 改动

- 默认保留包含 `ON_NULL` 的新版列元数据查询。
- 仅在确认 `ON_NULL` 字段不存在时，自动重试不包含该字段的兼容查询。
- 兼容查询继续返回列类型、长度、精度、注释和主键标记。
- 网络、权限及其他字段错误保持原样返回，避免掩盖真实故障。
- 增加旧版系统字典、错误识别和完整回退链路测试。

## 验证

- 在虚谷 12.0 测试库中成功读取 `PRODUCTS` 的 5 个字段，并正确识别 `PRODUCT_ID` 主键。
- 实际修改 `PRODUCT_NAME`，事务影响 1 行，查询确认成功后已恢复原值。
- `GONOSUMDB=gitee.com/XuguDB/go-xugu-driver go test ./...` 通过。
- `go vet ./...` 通过。
- Linux amd64 CI 同款交叉编译通过。
- `agents/scripts/validate_agents.py` 通过。