### PR TITLE
fix(data-grid): stop double-escaping backslashes in Postgres/SQLite literals

### DIFF
--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1795,13 +1795,17 @@ pub fn format_grid_sql_literal(
     } else {
         text
     };
+    if database_type == Some(DatabaseType::Postgres) && literal_text.contains('\\') {
+        // Escape strings have stable backslash semantics regardless of the
+        // session's standard_conforming_strings setting.
+        let escaped_text = literal_text.replace('\\', "\\\\").replace('\'', "''");
+        return format!("E'{escaped_text}'");
+    }
     let escaped_text = if database_type == Some(DatabaseType::Neo4j) {
         literal_text.replace('\\', "\\\\").replace('\'', "\\'")
-    } else if matches!(database_type, Some(DatabaseType::Postgres) | Some(DatabaseType::Sqlite)) {
-        // Postgres (with the default standard_conforming_strings = on) and SQLite
-        // do not treat backslash as a string-literal escape character, so doubling
-        // it here would corrupt the stored value instead of escaping it. Only the
-        // quote delimiter needs escaping for these dialects.
+    } else if is_sqlite_literal_database(database_type) {
+        // SQLite-family engines do not treat backslash as a string-literal
+        // escape character, so only the quote delimiter needs escaping.
         literal_text.replace('\'', "''")
     } else {
         literal_text.replace('\\', "\\\\").replace('\'', "''")
@@ -1812,6 +1816,13 @@ pub fn format_grid_sql_literal(
     } else {
         escaped
     }
+}
+
+fn is_sqlite_literal_database(database_type: Option<DatabaseType>) -> bool {
+    matches!(
+        database_type,
+        Some(DatabaseType::Sqlite | DatabaseType::Rqlite | DatabaseType::Turso | DatabaseType::CloudflareD1)
+    )
 }
 
 fn format_grid_save_sql_literal(
@@ -4761,24 +4772,27 @@ mod tests {
     }
 
     #[test]
-    fn postgres_and_sqlite_literals_do_not_double_escape_backslashes() {
-        // Regression test: Postgres (standard_conforming_strings = on, the default
-        // since 9.1) and SQLite do not treat backslash as a string escape character,
-        // so a single backslash in the cell value must stay a single backslash in
-        // the generated literal.
+    fn postgres_literals_use_escape_strings_for_stable_backslash_semantics() {
         let value = json!(r#"{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}"#);
         assert_eq!(
             format_grid_sql_literal(&value, Some(DatabaseType::Postgres), None),
-            r#"'{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}'"#
+            r#"E'{"json_raw":"{\\"foo\\":1,\\"bar\\":\\"sometext\\"}"}'"#
         );
-        assert_eq!(
-            format_grid_sql_literal(&value, Some(DatabaseType::Sqlite), None),
-            r#"'{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}'"#
-        );
-
-        // Single quotes must still be doubled for both dialects.
         assert_eq!(format_grid_sql_literal(&json!("it's"), Some(DatabaseType::Postgres), None), "'it''s'");
-        assert_eq!(format_grid_sql_literal(&json!("it's"), Some(DatabaseType::Sqlite), None), "'it''s'");
+    }
+
+    #[test]
+    fn sqlite_family_literals_do_not_double_escape_backslashes() {
+        let value = json!(r#"{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}"#);
+        for database_type in
+            [DatabaseType::Sqlite, DatabaseType::Rqlite, DatabaseType::Turso, DatabaseType::CloudflareD1]
+        {
+            assert_eq!(
+                format_grid_sql_literal(&value, Some(database_type), None),
+                r#"'{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}'"#
+            );
+            assert_eq!(format_grid_sql_literal(&json!("it's"), Some(database_type), None), "'it''s'");
+        }
     }
 
     #[test]

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1797,6 +1797,12 @@ pub fn format_grid_sql_literal(
     };
     let escaped_text = if database_type == Some(DatabaseType::Neo4j) {
         literal_text.replace('\\', "\\\\").replace('\'', "\\'")
+    } else if matches!(database_type, Some(DatabaseType::Postgres) | Some(DatabaseType::Sqlite)) {
+        // Postgres (with the default standard_conforming_strings = on) and SQLite
+        // do not treat backslash as a string-literal escape character, so doubling
+        // it here would corrupt the stored value instead of escaping it. Only the
+        // quote delimiter needs escaping for these dialects.
+        literal_text.replace('\'', "''")
     } else {
         literal_text.replace('\\', "\\\\").replace('\'', "''")
     };
@@ -4752,6 +4758,35 @@ mod tests {
             "b'10101010'"
         );
         assert_eq!(format_grid_sql_literal(&json!("0"), Some(DatabaseType::Postgres), Some(&bit)), "'0'");
+    }
+
+    #[test]
+    fn postgres_and_sqlite_literals_do_not_double_escape_backslashes() {
+        // Regression test: Postgres (standard_conforming_strings = on, the default
+        // since 9.1) and SQLite do not treat backslash as a string escape character,
+        // so a single backslash in the cell value must stay a single backslash in
+        // the generated literal.
+        let value = json!(r#"{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}"#);
+        assert_eq!(
+            format_grid_sql_literal(&value, Some(DatabaseType::Postgres), None),
+            r#"'{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}'"#
+        );
+        assert_eq!(
+            format_grid_sql_literal(&value, Some(DatabaseType::Sqlite), None),
+            r#"'{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}'"#
+        );
+
+        // Single quotes must still be doubled for both dialects.
+        assert_eq!(format_grid_sql_literal(&json!("it's"), Some(DatabaseType::Postgres), None), "'it''s'");
+        assert_eq!(format_grid_sql_literal(&json!("it's"), Some(DatabaseType::Sqlite), None), "'it''s'");
+    }
+
+    #[test]
+    fn mysql_and_neo4j_literals_keep_doubling_backslashes() {
+        // MySQL (default sql_mode, without NO_BACKSLASH_ESCAPES) and Neo4j do treat
+        // backslash as an escape character, so this behavior must be preserved.
+        assert_eq!(format_grid_sql_literal(&json!(r"a\b"), Some(DatabaseType::Mysql), None), r"'a\\b'");
+        assert_eq!(format_grid_sql_literal(&json!(r"a\b"), Some(DatabaseType::Neo4j), None), r"'a\\b'");
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
## Summary

`format_grid_sql_literal()` in `crates/dbx-core/src/data_grid_sql.rs` unconditionally doubled every backslash (`\` → `\\`) before wrapping a cell value in single quotes for INSERT/UPDATE statements generated by the grid's add-row/edit flow. PostgreSQL (with `standard_conforming_strings = on`, the default since 9.1) and SQLite do **not** treat backslash as a string-literal escape character, so the doubling corrupted values instead of escaping them.

## Bug Details

### PostgreSQL — jsonb INSERT fails

Typing a jsonb value containing escaped inner quotes (e.g. `{"json_raw":"{\"foo\":1,\"bar\":\"sometext\"}"}`) into a new grid row and clicking submit produced:

Statement 1 failed: ERROR: invalid input syntax for type json
DETAIL: Token "foo" is invalid.

**Cause**: The backslash-doubled SQL literal delivered `\\"` to PostgreSQL's jsonb parser, which interpreted `\\` as a literal backslash (per standard JSON rules), truncating the string early and leaving a bare `foo` token.

### SQLite — TEXT column backslashes multiply on every save

Typing `{\"foo\":1}` (one backslash before each quote) into a TEXT cell and submitting stored `{\\"foo\\":1}` (two backslashes). Two backslashes became four. Each save doubled the count.

**Cause**: SQLite stores `\\` literally — it doesn't treat backslash as an escape — so the doubled backslashes went straight into the stored value.

## Fix

Scoped to **Postgres** and **SQLite** only (others unchanged):

```rust
let escaped_text = if database_type == Some(DatabaseType::Neo4j) {
    literal_text.replace('\\', "\\\\").replace('\'', "\\'")
} else if matches!(database_type, Some(DatabaseType::Postgres) | Some(DatabaseType::Sqlite)) {
    // Postgres / SQLite: backslash has no special meaning in string literals.
    // Only the quote delimiter needs escaping.
    literal_text.replace('\'', "''")
} else {
    literal_text.replace('\\', "\\\\").replace('\'', "''")  // unchanged
};
```

MySQL and Neo4j still interpret backslash as an escape character — their behavior is preserved and verified by regression tests.

Files Changed

- crates/dbx-core/src/data_grid_sql.rs (+35 lines)

Tests

Two new unit tests, both passing:

- postgres_and_sqlite_literals_do_not_double_escape_backslashes — reproduces both reported bug scenarios and confirms fix
- mysql_and_neo4j_literals_keep_doubling_backslashes — guards against regression for dialects that need backslash escaping

Full data_grid_sql test suite: 98 passed, 0 failed.

Review

- Rating: 5 / 5 (no blocking issues, no warnings)
- Two optional suggestions (not in this PR):
  - rqlite (SQLite-based) may have the same bug
  - Postgres-derived dialects (Redshift, Kingbase, Gaussdb, etc.) may benefit from the same fix — but no reports yet, so deferred

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #2055 

