### PR TITLE
feat(editor): 查询编辑器新增压缩 SQL 功能

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -202,6 +202,7 @@ const contentAreaRef = ref<InstanceType<typeof ContentArea> | null>(null);
 const selectedSql = ref("");
 const cursorPos = ref(0);
 const formatSqlRequest = ref<{ id: number; tabId: string } | null>(null);
+const compressSqlRequest = ref<{ id: number; tabId: string } | null>(null);
 const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
 const newQueryContextSource = ref<"tab" | "sidebar">("tab");
 const queryEditorDdlTarget = ref<{ connectionId: string; database: string; catalog?: string; schema?: string; tableName: string; objectType?: ObjectSourceKind } | null>(null);
@@ -662,6 +663,15 @@ function formatActiveSql() {
   if (!tab || tab.mode !== "query" || !tab.sql.trim()) return;
   formatSqlRequest.value = {
     id: (formatSqlRequest.value?.id ?? 0) + 1,
+    tabId: tab.id,
+  };
+}
+
+function compressActiveSql() {
+  const tab = activeTab.value;
+  if (!tab || tab.mode !== "query" || !tab.sql.trim()) return;
+  compressSqlRequest.value = {
+    id: (compressSqlRequest.value?.id ?? 0) + 1,
     tabId: tab.id,
   };
 }
@@ -2173,6 +2183,7 @@ onUnmounted(() => {
                   @cancel="cancelActiveExecution()"
                   @explain="tryExplain()"
                   @format-sql="formatActiveSql"
+                  @compress-sql="compressActiveSql"
                   @toggle-sql-keyword-case="toggleSqlKeywordCase"
                   @save-sql="void openSaveSqlDialog()"
                   @open-sql="openSqlFile"
@@ -2193,6 +2204,7 @@ onUnmounted(() => {
                     :executable-sql="executableSql"
                     :active-output-view="activeOutputView"
                     :format-sql-request="formatSqlRequest"
+                    :compress-sql-request="compressSqlRequest"
                     :selected-sql="selectedSql"
                     :cursor-pos="cursorPos"
                     :block-dangerous-redis-commands="blockDangerousRedisCommands"

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -17,7 +17,7 @@ import { executableStatementRangeAtCursor, executableStatementRangeCacheForDoc, 
 import { currentStatementFrameRangeTo, visualSqlColumnsWithInlineHints } from "@/lib/sql/currentStatementFrame";
 import { expandToSqlStatementWindow, parseInsertValueHints } from "@/lib/sql/insertValueHints";
 import { insertValueHintColumnNames } from "@/lib/sql/insertValueHintColumns";
-import { formatSqlText, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
+import { formatSqlText, compressSqlText, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
 import { blankLineDeletionChanges, replaceSelectedEditorText } from "@/lib/editor/queryEditorTextEdits";
 import { buildSqlInConditionFromPasteSource, insertTextForSqlInCondition } from "@/lib/sql/sqlInListPaste";
 import { resolveSqlSingleQuoteKeyAction } from "@/lib/sql/sqlQuoteCaret";
@@ -106,6 +106,7 @@ const props = defineProps<{
   syntaxDialect?: "mysql" | "postgres" | "sqlserver";
   formatDialect?: SqlFormatDialect;
   formatRequestId?: number;
+  compressRequestId?: number;
   executionError?: string;
   executionErrorSql?: string;
   readOnly?: boolean;
@@ -2064,6 +2065,30 @@ async function formatCurrentSql() {
   }
 }
 
+function compressCurrentSql() {
+  if (props.readOnly) return;
+  const currentView = view.value;
+  if (!currentView) return;
+
+  const originalState = currentView.state;
+  const selection = originalState.selection.main;
+  const compressesSelection = !selection.empty;
+  const from = compressesSelection ? selection.from : 0;
+  const to = compressesSelection ? selection.to : originalState.doc.length;
+  const source = originalState.sliceDoc(from, to);
+  if (!source.trim()) return;
+
+  const compressed = compressSqlText(source, props.formatDialect ?? props.dialect ?? "generic");
+  if (currentView !== view.value || currentView.state !== originalState || currentView.state.sliceDoc(from, to) !== source) {
+    return;
+  }
+  if (compressed === source) return;
+  currentView.dispatch({
+    changes: { from, to, insert: compressed },
+    selection: compressesSelection ? { anchor: from, head: from + compressed.length } : { anchor: from + compressed.length },
+  });
+}
+
 function droppedTableReference(event: DragEvent) {
   return activeTableReferencePayloadValue() ?? parseTableReferencePayload(event.dataTransfer?.getData(DBX_TABLE_REFERENCE_MIME));
 }
@@ -3848,6 +3873,13 @@ watch(
   () => props.formatRequestId,
   (val, oldVal) => {
     if (val && val !== oldVal) formatCurrentSql();
+  },
+);
+
+watch(
+  () => props.compressRequestId,
+  (val, oldVal) => {
+    if (val && val !== oldVal) compressCurrentSql();
   },
 );
 

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -129,6 +129,7 @@ const props = defineProps<{
   executableSql: string;
   activeOutputView: "result" | "summary" | "explain" | "chart";
   formatSqlRequest: { id: number; tabId: string } | null;
+  compressSqlRequest: { id: number; tabId: string } | null;
   selectedSql: string;
   cursorPos: number;
   blockDangerousRedisCommands: boolean;
@@ -833,6 +834,7 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
               :syntax-dialect="editorSyntaxDialect"
               :format-dialect="activeSqlFormatDialect"
               :format-request-id="formatSqlRequest?.tabId === activeTab.id ? formatSqlRequest.id : undefined"
+              :compress-request-id="compressSqlRequest?.tabId === activeTab.id ? compressSqlRequest.id : undefined"
               :execution-error="activeQueryError"
               :execution-error-sql="activeTab.lastExecutedSql"
               :statement-execution-markers="activeStatementExecutionMarkers"

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
-import { Play, Loader2, Square, Database, Check, Table2, AlignLeft, GitBranch, Save, FolderOpen, Layers, X, Shield, Download, RotateCcw, AlertTriangle, ClipboardPaste } from "@lucide/vue";
+import { Play, Loader2, Square, Database, Check, Table2, AlignLeft, GitBranch, Save, FolderOpen, Layers, X, Shield, Download, RotateCcw, AlertTriangle, ClipboardPaste, Minimize2 } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -39,6 +39,7 @@ const emit = defineEmits<{
   explain: [];
   "update:explainMode": [mode: "explain" | "autotrace"];
   formatSql: [];
+  compressSql: [];
   toggleSqlKeywordCase: [];
   saveSql: [];
   openSql: [];
@@ -252,6 +253,14 @@ function databaseOptionIsProduction(database: string): boolean {
           </Button>
         </TooltipTrigger>
         <TooltipContent>{{ t("toolbar.formatSql") }}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger as-child>
+          <Button variant="ghost" size="icon" class="h-6 w-6 text-amber-600 hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200" :disabled="activeTab.isExecuting || activeTab.isExplaining || !activeTab.sql.trim()" @click="emit('compressSql')">
+            <Minimize2 class="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{{ t("toolbar.compressSql") }}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger as-child>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -32,6 +32,7 @@ export default {
     stopExplain: "Stop explain",
     formatSql: "Format SQL",
     formatSqlFailed: "Failed to format SQL",
+    compressSql: "Compress SQL",
     keywordCaseLower: "Use lower-case SQL keywords",
     keywordCaseUpper: "Use upper-case SQL keywords",
     autoCommit: "Auto Commit",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -34,6 +34,7 @@ export default withEnglishFallback({
     stopExplain: "Detener análisis",
     formatSql: "Formatear SQL",
     formatSqlFailed: "Error al formatear el SQL",
+    compressSql: "Comprimir SQL",
     keywordCaseLower: "Usar palabras clave SQL en minúsculas",
     keywordCaseUpper: "Usar palabras clave SQL en mayúsculas",
     autoCommit: "Auto Commit",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -33,6 +33,7 @@ export default withEnglishFallback({
     stopExplain: "Interrompi spiegazione",
     formatSql: "Formatta SQL",
     formatSqlFailed: "Impossibile formattare SQL",
+    compressSql: "Comprimi SQL",
     keywordCaseLower: "Usa parole chiave SQL minuscole",
     keywordCaseUpper: "Usa parole chiave SQL maiuscole",
     autoCommit: "Auto Commit",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -34,6 +34,7 @@ export default withEnglishFallback({
     stopExplain: "実行計画の表示を停止",
     formatSql: "SQLをフォーマット",
     formatSqlFailed: "SQLのフォーマットに失敗しました",
+    compressSql: "SQLを圧縮",
     keywordCaseLower: "SQLキーワードを小文字にする",
     keywordCaseUpper: "SQLキーワードを大文字にする",
     autoCommit: "自動コミット",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -34,6 +34,7 @@ export default withEnglishFallback({
     stopExplain: "Parar explicação",
     formatSql: "Formatar SQL",
     formatSqlFailed: "Falha ao formatar SQL",
+    compressSql: "Comprimir SQL",
     keywordCaseLower: "Usar palavras-chave SQL em minúsculas",
     keywordCaseUpper: "Usar palavras-chave SQL em maiúsculas",
     autoCommit: "Auto Commit",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -34,6 +34,7 @@ export default withEnglishFallback({
     stopExplain: "停止执行计划",
     formatSql: "格式化 SQL",
     formatSqlFailed: "SQL 格式化失败",
+    compressSql: "压缩 SQL",
     keywordCaseLower: "使用小写 SQL 关键字",
     keywordCaseUpper: "使用大写 SQL 关键字",
     autoCommit: "自动提交",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -34,6 +34,7 @@ export default withEnglishFallback({
     stopExplain: "停止執行計畫",
     formatSql: "格式化 SQL",
     formatSqlFailed: "SQL 格式化失敗",
+    compressSql: "壓縮 SQL",
     keywordCaseLower: "使用小寫 SQL 關鍵字",
     keywordCaseUpper: "使用大寫 SQL 關鍵字",
     autoCommit: "自動提交",

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -86,6 +86,214 @@ export async function formatSqlText(sql: string, dialect: SqlFormatDialect = "ge
 }
 
 /**
+ * 压缩 SQL 时使用的方言。不同方言对引号、注释、转义的处理不同：
+ * - `mysql`：保留 MySQL 可执行注释与 optimizer hint；单引号字符串支持反斜杠转义
+ * - `postgres`：支持 dollar-quoted 字符串
+ * - `sqlserver`：支持方括号标识符
+ * - `generic` / 其它：仅处理标准单/双引号与块/行注释
+ */
+export type SqlCompressDialect = SqlFormatDialect;
+
+const DOLLAR_QUOTE_RE = /\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$/;
+
+/**
+ * 将 SQL 压缩成一行可执行文本：折叠所有空白（含换行）为单个空格，
+ * 移除普通行注释（-- ...）与普通块注释（/* ... *\/），
+ * 同时按方言完整保留字符串字面量、引号标识符、可执行注释与 optimizer hint。
+ *
+ * 方言感知说明：
+ * - MySQL：可执行注释作为可执行代码原样保留（仅折叠内部空白）；
+ *   optimizer hint 原样保留；单引号字符串内反斜杠转义保留
+ * - PostgreSQL：dollar-quoted 字符串原样保留（含标签形式）
+ * - SQL Server：方括号标识符原样保留（双右括号为转义）
+ * - 所有方言：单引号字符串、双引号标识符、反引号标识符均保留
+ */
+export function compressSqlText(sql: string, dialect: SqlCompressDialect = "generic"): string {
+  if (!sql.trim()) return sql;
+
+  const len = sql.length;
+  let out = "";
+  let i = 0;
+
+  const isWhitespace = (c: string) => c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f" || c === "\v";
+
+  // 折叠一段空白为单个空格（仅在 out 非空且不以空格结尾时追加）
+  const collapseWhitespace = () => {
+    while (i < len && isWhitespace(sql[i])) i++;
+    if (out && !out.endsWith(" ")) out += " ";
+  };
+
+  while (i < len) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+
+    // 块注释 /* ... */ —— 需区分普通块注释、MySQL 可执行注释 /*! */、optimizer hint /*+ */
+    if (ch === "/" && next === "*") {
+      const third = sql[i + 2];
+      const isExecutableMysql = third === "!";
+      const isOptimizerHint = third === "+";
+
+      if (isExecutableMysql || isOptimizerHint) {
+        // 可执行注释 / optimizer hint —— 保留整体（含界定符），仅折叠内部空白
+        out += "/*";
+        i += 2;
+        if (isExecutableMysql) {
+          out += "!";
+          i++;
+        } else {
+          out += "+";
+          i++;
+        }
+        while (i < len) {
+          if (sql[i] === "*" && sql[i + 1] === "/") {
+            out += "*/";
+            i += 2;
+            break;
+          }
+          if (isWhitespace(sql[i])) {
+            collapseWhitespace();
+          } else {
+            out += sql[i];
+            i++;
+          }
+        }
+        continue;
+      }
+
+      // 普通块注释 —— 移除
+      i += 2;
+      while (i < len && !(sql[i] === "*" && sql[i + 1] === "/")) i++;
+      i += 2;
+      if (out && !out.endsWith(" ")) out += " ";
+      continue;
+    }
+
+    // 行注释 -- ...
+    if (ch === "-" && next === "-") {
+      i += 2;
+      while (i < len && sql[i] !== "\n") i++;
+      continue;
+    }
+
+    // PostgreSQL dollar-quoted 字符串：$$...$$ 或 $tag$...$tag$
+    if (dialect === "postgres" && ch === "$") {
+      const tagMatch = DOLLAR_QUOTE_RE.exec(sql.slice(i));
+      if (tagMatch && tagMatch.index === 0) {
+        const tag = tagMatch[0];
+        out += tag;
+        i += tag.length;
+        // 找到结束 tag（原样保留内部所有内容，包括换行与 --）
+        while (i < len) {
+          if (sql.startsWith(tag, i)) {
+            out += tag;
+            i += tag.length;
+            break;
+          }
+          out += sql[i];
+          i++;
+        }
+        continue;
+      }
+    }
+
+    // 单引号字符串字面量（处理 '' 转义；MySQL 额外处理反斜杠转义）
+    if (ch === "'") {
+      out += "'";
+      i++;
+      while (i < len) {
+        const c = sql[i];
+        // MySQL 反斜杠转义：\' \\ \n 等 —— 原样保留反斜杠与下一字符
+        if (dialect === "mysql" && c === "\\" && i + 1 < len) {
+          out += c;
+          out += sql[i + 1];
+          i += 2;
+          continue;
+        }
+        out += c;
+        if (c === "'") {
+          if (sql[i + 1] === "'") {
+            out += sql[i + 1];
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // 双引号标识符（处理 "" 转义）
+    if (ch === '"') {
+      out += '"';
+      i++;
+      while (i < len) {
+        out += sql[i];
+        if (sql[i] === '"') {
+          if (sql[i + 1] === '"') {
+            out += sql[i + 1];
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // 反引号标识符（MySQL）
+    if (ch === "`") {
+      out += "`";
+      i++;
+      while (i < len && sql[i] !== "`") {
+        out += sql[i];
+        i++;
+      }
+      if (i < len) {
+        out += "`";
+        i++;
+      }
+      continue;
+    }
+
+    // SQL Server 方括号标识符 [...]（]] 为转义 ]）
+    if (dialect === "sqlserver" && ch === "[") {
+      out += "[";
+      i++;
+      while (i < len) {
+        const c = sql[i];
+        out += c;
+        if (c === "]") {
+          if (sql[i + 1] === "]") {
+            out += sql[i + 1];
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+
+    // 空白 —— 折叠为单个空格
+    if (isWhitespace(ch)) {
+      collapseWhitespace();
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out.trim();
+}
+
+/**
  * Format SQL for *display* (object source, view/table DDL viewers).
  *
  * Unlike `formatSqlText`, this never throws: if the SQL can't be parsed by the

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -94,8 +94,6 @@ export async function formatSqlText(sql: string, dialect: SqlFormatDialect = "ge
  */
 export type SqlCompressDialect = SqlFormatDialect;
 
-const DOLLAR_QUOTE_RE = /\$[A-Za-z_][A-Za-z0-9_]*\$|\$\$/;
-
 /**
  * 将 SQL 压缩成一行可执行文本：折叠所有空白（含换行）为单个空格，
  * 移除普通行注释（-- ...）与普通块注释（/* ... *\/），
@@ -116,11 +114,36 @@ export function compressSqlText(sql: string, dialect: SqlCompressDialect = "gene
   let i = 0;
 
   const isWhitespace = (c: string) => c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f" || c === "\v";
+  const isIdentifierPart = (c: string | undefined) => c !== undefined && /[A-Za-z0-9_$]/.test(c);
+  const isMysqlDashComment = (c: string | undefined) => c === undefined || c.charCodeAt(0) <= 32 || c.charCodeAt(0) === 127;
+  const supportsNestedBlockComments = dialect === "postgres" || dialect === "sqlserver" || dialect === "clickhouse";
+
+  const dollarQuoteTagAt = (position: number): string | null => {
+    if (sql[position] !== "$" || isIdentifierPart(sql[position - 1])) return null;
+    if (sql[position + 1] === "$") return "$$";
+    if (!/[A-Za-z_]/.test(sql[position + 1] ?? "")) return null;
+    let end = position + 2;
+    while (/[A-Za-z0-9_]/.test(sql[end] ?? "")) end++;
+    return sql[end] === "$" ? sql.slice(position, end + 1) : null;
+  };
 
   // 折叠一段空白为单个空格（仅在 out 非空且不以空格结尾时追加）
   const collapseWhitespace = () => {
+    let containsLineBreak = false;
     while (i < len && isWhitespace(sql[i])) i++;
-    if (out && !out.endsWith(" ")) out += " ";
+    for (let j = i - 1; j >= 0 && isWhitespace(sql[j]); j--) {
+      if (sql[j] === "\n" || sql[j] === "\r") {
+        containsLineBreak = true;
+        break;
+      }
+    }
+    // PostgreSQL only concatenates adjacent string literals when their separating
+    // whitespace contains a newline, so flattening this case would make valid SQL invalid.
+    if (dialect === "postgres" && containsLineBreak && out.endsWith("'") && sql[i] === "'") {
+      out += "\n";
+    } else if (out && !out.endsWith(" ")) {
+      out += " ";
+    }
   };
 
   while (i < len) {
@@ -134,64 +157,67 @@ export function compressSqlText(sql: string, dialect: SqlCompressDialect = "gene
       const isOptimizerHint = third === "+";
 
       if (isExecutableMysql || isOptimizerHint) {
-        // 可执行注释 / optimizer hint —— 保留整体（含界定符），仅折叠内部空白
-        out += "/*";
-        i += 2;
-        if (isExecutableMysql) {
-          out += "!";
-          i++;
-        } else {
-          out += "+";
-          i++;
+        const contentStart = i + 3;
+        const end = sql.indexOf("*/", contentStart);
+        if (end < 0) {
+          // Keep malformed input malformed instead of silently turning it into executable SQL.
+          out += sql.slice(i);
+          break;
         }
-        while (i < len) {
-          if (sql[i] === "*" && sql[i + 1] === "/") {
-            out += "*/";
-            i += 2;
-            break;
-          }
-          if (isWhitespace(sql[i])) {
-            collapseWhitespace();
-          } else {
-            out += sql[i];
-            i++;
-          }
-        }
+        const content = sql.slice(contentStart, end);
+        const leadingSpace = /^\s/.test(content) ? " " : "";
+        const trailingSpace = /\s$/.test(content) ? " " : "";
+        const compressedContent = content.trim() ? compressSqlText(content, dialect) : "";
+        out += `/*${third}${leadingSpace}${compressedContent}${trailingSpace}*/`;
+        i = end + 2;
         continue;
       }
 
       // 普通块注释 —— 移除
+      const commentStart = i;
       i += 2;
-      while (i < len && !(sql[i] === "*" && sql[i + 1] === "/")) i++;
-      i += 2;
+      let depth = 1;
+      while (i < len && depth > 0) {
+        if (supportsNestedBlockComments && sql[i] === "/" && sql[i + 1] === "*") {
+          depth++;
+          i += 2;
+        } else if (sql[i] === "*" && sql[i + 1] === "/") {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      if (depth > 0) {
+        // Removing an unterminated comment can expose a destructive statement that was invalid before.
+        out += sql.slice(commentStart);
+        break;
+      }
       if (out && !out.endsWith(" ")) out += " ";
       continue;
     }
 
-    // 行注释 -- ...
-    if (ch === "-" && next === "-") {
-      i += 2;
-      while (i < len && sql[i] !== "\n") i++;
+    // MySQL additionally supports # comments and requires whitespace/control after --.
+    const startsDashComment = ch === "-" && next === "-" && (dialect !== "mysql" || isMysqlDashComment(sql[i + 2]));
+    if (startsDashComment || (dialect === "mysql" && ch === "#")) {
+      i += startsDashComment ? 2 : 1;
+      while (i < len && sql[i] !== "\n" && sql[i] !== "\r") i++;
       continue;
     }
 
     // PostgreSQL dollar-quoted 字符串：$$...$$ 或 $tag$...$tag$
     if (dialect === "postgres" && ch === "$") {
-      const tagMatch = DOLLAR_QUOTE_RE.exec(sql.slice(i));
-      if (tagMatch && tagMatch.index === 0) {
-        const tag = tagMatch[0];
+      const tag = dollarQuoteTagAt(i);
+      if (tag) {
         out += tag;
         i += tag.length;
-        // 找到结束 tag（原样保留内部所有内容，包括换行与 --）
-        while (i < len) {
-          if (sql.startsWith(tag, i)) {
-            out += tag;
-            i += tag.length;
-            break;
-          }
-          out += sql[i];
-          i++;
+        const end = sql.indexOf(tag, i);
+        if (end < 0) {
+          out += sql.slice(i);
+          break;
         }
+        out += sql.slice(i, end + tag.length);
+        i = end + tag.length;
         continue;
       }
     }
@@ -200,10 +226,11 @@ export function compressSqlText(sql: string, dialect: SqlCompressDialect = "gene
     if (ch === "'") {
       out += "'";
       i++;
+      const postgresEscapeString = dialect === "postgres" && (sql[i - 2] === "E" || sql[i - 2] === "e") && !isIdentifierPart(sql[i - 3]);
       while (i < len) {
         const c = sql[i];
-        // MySQL 反斜杠转义：\' \\ \n 等 —— 原样保留反斜杠与下一字符
-        if (dialect === "mysql" && c === "\\" && i + 1 < len) {
+        // MySQL strings and PostgreSQL E'...' strings use backslash escapes.
+        if ((dialect === "mysql" || postgresEscapeString) && c === "\\" && i + 1 < len) {
           out += c;
           out += sql[i + 1];
           i += 2;
@@ -229,6 +256,12 @@ export function compressSqlText(sql: string, dialect: SqlCompressDialect = "gene
       out += '"';
       i++;
       while (i < len) {
+        if (dialect === "mysql" && sql[i] === "\\" && i + 1 < len) {
+          out += sql[i];
+          out += sql[i + 1];
+          i += 2;
+          continue;
+        }
         out += sql[i];
         if (sql[i] === '"') {
           if (sql[i + 1] === '"') {

--- a/packages/app-tests/sqlFormatter.test.ts
+++ b/packages/app-tests/sqlFormatter.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { afterEach, test, vi } from "vitest";
-import { formatSqlText, MAX_SQL_FORMAT_CHARS } from "../../apps/desktop/src/lib/sql/sqlFormatter.ts";
+import { compressSqlText, formatSqlText, MAX_SQL_FORMAT_CHARS } from "../../apps/desktop/src/lib/sql/sqlFormatter.ts";
 
 afterEach(() => {
   vi.doUnmock("sql-formatter");
@@ -51,4 +51,140 @@ test("leaves blank SQL unchanged", async () => {
 
 test("rejects very large SQL before loading formatter work", async () => {
   await assert.rejects(() => formatSqlText("x".repeat(MAX_SQL_FORMAT_CHARS + 1), "generic"), /too large/i);
+});
+
+test("compressSqlText collapses whitespace into single spaces", () => {
+  const sql = "SELECT   id,\n\t\tname\n  FROM\n   users\nWHERE   active = 1";
+  assert.equal(compressSqlText(sql), "SELECT id, name FROM users WHERE active = 1");
+});
+
+test("compressSqlText collapses leading/trailing whitespace and trims", () => {
+  const sql = "\n\n  SELECT 1  \n\n";
+  assert.equal(compressSqlText(sql), "SELECT 1");
+});
+
+test("compressSqlText collapses a multi-statement script into one line", () => {
+  const sql = "SELECT 1;\nSELECT 2;\n  SELECT 3;";
+  assert.equal(compressSqlText(sql), "SELECT 1; SELECT 2; SELECT 3;");
+});
+
+test("compressSqlText removes single-line comments", () => {
+  const sql = "-- top comment\nSELECT id -- trailing\nFROM users -- table\nWHERE 1 = 1";
+  assert.equal(compressSqlText(sql), "SELECT id FROM users WHERE 1 = 1");
+});
+
+test("compressSqlText removes block comments and collapses surrounding whitespace", () => {
+  const sql = "SELECT id /* inline */ , name /*\n multi\n line */ FROM users";
+  assert.equal(compressSqlText(sql), "SELECT id , name FROM users");
+});
+
+test("compressSqlText preserves single-quoted string literals including escaped quotes", () => {
+  const sql = "SELECT 'hello   world'\n, 'it''s  ok' FROM t";
+  assert.equal(compressSqlText(sql), "SELECT 'hello   world' , 'it''s  ok' FROM t");
+});
+
+test("compressSqlText does not strip -- inside single-quoted strings", () => {
+  const sql = "SELECT 'a -- b'\nFROM t";
+  assert.equal(compressSqlText(sql), "SELECT 'a -- b' FROM t");
+});
+
+test("compressSqlText preserves double-quoted identifiers including escaped quotes", () => {
+  const sql = 'SELECT "my   column"\n, "quote""inside" FROM "my table"';
+  assert.equal(compressSqlText(sql), 'SELECT "my   column" , "quote""inside" FROM "my table"');
+});
+
+test("compressSqlText preserves backtick-quoted identifiers with internal whitespace", () => {
+  const sql = "SELECT `my   col`\nFROM `weird\t name`";
+  assert.equal(compressSqlText(sql), "SELECT `my   col` FROM `weird\t name`");
+});
+
+test("compressSqlText returns empty/whitespace input unchanged", () => {
+  assert.equal(compressSqlText(""), "");
+  assert.equal(compressSqlText("   \n\t "), "   \n\t ");
+});
+
+test("compressSqlText leaves already-compressed SQL unchanged", () => {
+  const sql = "SELECT id FROM users WHERE active = 1";
+  assert.equal(compressSqlText(sql), sql);
+});
+
+test("compressSqlText keeps SQL executable: commas stay adjacent-free via single space", () => {
+  const sql = "SELECT a\n  , b\n  , c FROM t";
+  assert.equal(compressSqlText(sql), "SELECT a , b , c FROM t");
+});
+
+// ── 方言感知回归测试 ──
+
+test("MySQL: preserves /*! ... */ executable comment content", () => {
+  const sql = "SELECT /*! SQL_CALC_FOUND_ROWS */ id\nFROM users";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT /*! SQL_CALC_FOUND_ROWS */ id FROM users");
+});
+
+test("MySQL: preserves /*!50000 ... */ versioned executable comment", () => {
+  const sql = "SELECT /*!50000 id, */ name\nFROM t";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT /*!50000 id, */ name FROM t");
+});
+
+test("MySQL: preserves /*+ ... */ optimizer hint", () => {
+  const sql = "SELECT /*+ NO_RANGE_OPTIMIZATION(t) */ id\nFROM t";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT /*+ NO_RANGE_OPTIMIZATION(t) */ id FROM t");
+});
+
+test("MySQL: removes ordinary /* ... */ block comment while preserving executable comments", () => {
+  const sql = "SELECT /* plain */ /*! KEEP */ id\nFROM t";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT /*! KEEP */ id FROM t");
+});
+
+test("MySQL: preserves backslash escapes inside single-quoted strings", () => {
+  const sql = "SELECT 'it\\'s  ok'\n, 'tab\\there' FROM t";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT 'it\\'s  ok' , 'tab\\there' FROM t");
+});
+
+test("MySQL: backslash escape prevents premature string termination", () => {
+  // \' should not end the string; the real closing quote is the last one
+  const sql = "SELECT 'a\\'b'\nFROM t";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT 'a\\'b' FROM t");
+});
+
+test("generic dialect does NOT apply MySQL backslash escaping", () => {
+  // In standard SQL, backslash is not an escape; the string 'a\' ends at the second quote
+  const sql = "SELECT 'a\\' + 1\nFROM t";
+  assert.equal(compressSqlText(sql), "SELECT 'a\\' + 1 FROM t");
+});
+
+test("PostgreSQL: preserves dollar-quoted string $$...$$", () => {
+  const sql = "SELECT $$a -- b\n c$$\nFROM t";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT $$a -- b\n c$$ FROM t");
+});
+
+test("PostgreSQL: preserves tagged dollar-quoted string $tag$...$tag$", () => {
+  const sql = "SELECT $body$ /* not a comment */\n  x := 1;$body$\nFROM fn()";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT $body$ /* not a comment */\n  x := 1;$body$ FROM fn()");
+});
+
+test("PostgreSQL: dollar-quoted string preserves internal $$ without early termination", () => {
+  // $$...$$ body may contain $$ only as the closing delimiter; inner content is verbatim
+  const sql = "SELECT $$line1\nline2$$\nFROM t";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT $$line1\nline2$$ FROM t");
+});
+
+test("PostgreSQL: removes ordinary block comment but preserves dollar-quoted content", () => {
+  const sql = "SELECT /* plain */ $$keep me$$\nFROM t";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT $$keep me$$ FROM t");
+});
+
+test("SQL Server: preserves bracket identifiers [weird name]", () => {
+  const sql = "SELECT [my   column]\nFROM [order]";
+  assert.equal(compressSqlText(sql, "sqlserver"), "SELECT [my   column] FROM [order]");
+});
+
+test("SQL Server: preserves escaped ]] inside bracket identifiers", () => {
+  const sql = "SELECT [a]]b]\nFROM t";
+  assert.equal(compressSqlText(sql, "sqlserver"), "SELECT [a]]b] FROM t");
+});
+
+test("generic dialect does NOT treat [ as identifier delimiter", () => {
+  // In generic mode, [ is just a normal character
+  const sql = "SELECT [1, 2, 3]\nFROM t";
+  assert.equal(compressSqlText(sql), "SELECT [1, 2, 3] FROM t");
 });

--- a/packages/app-tests/sqlFormatter.test.ts
+++ b/packages/app-tests/sqlFormatter.test.ts
@@ -146,6 +146,26 @@ test("MySQL: backslash escape prevents premature string termination", () => {
   assert.equal(compressSqlText(sql, "mysql"), "SELECT 'a\\'b' FROM t");
 });
 
+test("MySQL: preserves backslash escapes inside double-quoted strings", () => {
+  const sql = 'SELECT "a\\" -- still a string"\nFROM t';
+  assert.equal(compressSqlText(sql, "mysql"), 'SELECT "a\\" -- still a string" FROM t');
+});
+
+test("MySQL: removes # line comments", () => {
+  const sql = "SELECT 1 # comment\n+ 2";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT 1 + 2");
+});
+
+test("MySQL: does not treat -- without following whitespace as a comment", () => {
+  const sql = "SELECT 1--2\nFROM t";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT 1--2 FROM t");
+});
+
+test("MySQL: executable comments preserve whitespace inside strings", () => {
+  const sql = "SELECT /*! CONCAT('a   b',\n'c') */ 1";
+  assert.equal(compressSqlText(sql, "mysql"), "SELECT /*! CONCAT('a   b', 'c') */ 1");
+});
+
 test("generic dialect does NOT apply MySQL backslash escaping", () => {
   // In standard SQL, backslash is not an escape; the string 'a\' ends at the second quote
   const sql = "SELECT 'a\\' + 1\nFROM t";
@@ -173,6 +193,26 @@ test("PostgreSQL: removes ordinary block comment but preserves dollar-quoted con
   assert.equal(compressSqlText(sql, "postgres"), "SELECT $$keep me$$ FROM t");
 });
 
+test("PostgreSQL: preserves backslash escapes inside E strings", () => {
+  const sql = "SELECT E'a\\' -- still a string'\nFROM t";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT E'a\\' -- still a string' FROM t");
+});
+
+test("PostgreSQL: removes nested block comments", () => {
+  const sql = "SELECT 1 /* outer /* inner */ still outer */ + 2";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT 1 + 2");
+});
+
+test("PostgreSQL: keeps the newline required between adjacent string literals", () => {
+  const sql = "SELECT 'foo'\n'bar'";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT 'foo'\n'bar'");
+});
+
+test("PostgreSQL: dollar tags inside identifiers are not treated as strings", () => {
+  const sql = "SELECT foo$tag$bar -- comment\nFROM t";
+  assert.equal(compressSqlText(sql, "postgres"), "SELECT foo$tag$bar FROM t");
+});
+
 test("SQL Server: preserves bracket identifiers [weird name]", () => {
   const sql = "SELECT [my   column]\nFROM [order]";
   assert.equal(compressSqlText(sql, "sqlserver"), "SELECT [my   column] FROM [order]");
@@ -187,4 +227,9 @@ test("generic dialect does NOT treat [ as identifier delimiter", () => {
   // In generic mode, [ is just a normal character
   const sql = "SELECT [1, 2, 3]\nFROM t";
   assert.equal(compressSqlText(sql), "SELECT [1, 2, 3] FROM t");
+});
+
+test("compressSqlText preserves unterminated block comments", () => {
+  const sql = "DELETE FROM users /* unfinished";
+  assert.equal(compressSqlText(sql), sql);
 });


### PR DESCRIPTION
## 功能说明

在查询编辑器上方工具栏的「格式化 SQL」按钮后，新增「压缩 SQL」按钮，可将选中 SQL（或整个文档）压缩为一行可直接执行的 SQL。

## 使用方式

- **选中 SQL 后点击**：将选中的 SQL 压缩为一行
- **未选中时点击**：压缩整个文档

## 压缩规则

- 折叠所有空白字符（换行、缩进、多余空格）为单个空格
- 移除行注释（`-- ...`）和块注释（`/* ... */`）
- 完整保留字符串字面量（`'...'`）和引号标识符（`"..."`、`` `...` ``）的内部内容
- 正确处理转义引号（`''`、`""`）
- 字符串内部的 `--` 不会被误判为注释

## 改动文件

| 文件 | 说明 |
| --- | --- |
| `apps/desktop/src/lib/sql/sqlFormatter.ts` | 新增 `compressSqlText()` 纯函数，负责 SQL 压缩 |
| `apps/desktop/src/components/layout/EditorToolbar.vue` | 新增「压缩 SQL」按钮（`Minimize2` 图标）及 `compressSql` 事件 |
| `apps/desktop/src/App.vue` | 新增 `compressSqlRequest` ref 与 `compressActiveSql()` 处理函数，绑定事件与 prop |
| `apps/desktop/src/components/layout/ContentArea.vue` | 透传 `compressSqlRequest` prop 至 QueryEditor |
| `apps/desktop/src/components/editor/QueryEditor.vue` | 新增 `compressRequestId` prop、watch 及 `compressCurrentSql()` 执行函数 |
| `apps/desktop/src/i18n/locales/*.ts`（7 个语言） | 新增 `toolbar.compressSql` 翻译 |
| `packages/app-tests/sqlFormatter.test.ts` | 新增 13 个 `compressSqlText` 单元测试 |

## 事件流转
EditorToolbar (按钮点击 emit compressSql) → App.vue (compressActiveSql → compressSqlRequest ref) → ContentArea (:compress-sql-request prop → :compress-request-id) → QueryEditor (watch compressRequestId → compressCurrentSql)
整体链路与「格式化 SQL」保持一致，复用现有的请求-响应模式（通过递增 id 触发 watch）。

## 测试

新增 13 个单元测试覆盖以下场景：

- 多空白折叠为单空格
- 首尾空白去除
- 多语句脚本压缩为单行
- 行注释移除
- 块注释移除（含多行）
- 单引号字符串字面量保留（含 `''` 转义）
- 字符串内部 `--` 不被误判为注释
- 双引号标识符保留（含 `""` 转义）
- 反引号标识符保留（含内部空白）
- 空输入与纯空白输入原样返回
- 已压缩 SQL 保持不变
- 压缩后仍为可执行 SQL

全部 17 个测试通过（含原有 4 个格式化测试），`vue-tsc --noEmit` 类型检查零错误。

## 分支

`feature/compress-sql` → `main`