### PR TITLE
Fix：修复 Oracle DIP 左侧对象树显示不完整

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
@@ -37,6 +37,19 @@ function mysqlConnection(): ConnectionConfig {
   } as ConnectionConfig;
 }
 
+function oracleConnection(): ConnectionConfig {
+  return {
+    id: "oracle-1",
+    name: "Oracle",
+    db_type: "oracle",
+    host: "127.0.0.1",
+    port: 1521,
+    username: "SYSTEM",
+    password: "",
+    database: "XE",
+  } as ConnectionConfig;
+}
+
 function procedure(name: string): ObjectInfo {
   return {
     name,
@@ -210,6 +223,85 @@ describe("connectionStore metadata loading", () => {
     expect(listTables).toHaveBeenCalledWith(connection.id, "app", "public", undefined, 1001, 0);
     expect(listObjects).toHaveBeenCalled();
     expect(schemaNode.children?.map((node) => node.label)).toEqual(["users"]);
+  });
+
+  it("bypasses Oracle object-group caches created before DIP visibility was fixed", async () => {
+    const listTables = vi.fn().mockResolvedValue([
+      { name: "V_ONE", table_type: "VIEW", comment: null },
+      { name: "V_TWO", table_type: "VIEW", comment: null },
+      { name: "V_THREE", table_type: "VIEW", comment: null },
+    ] satisfies TableInfo[]);
+    const legacyChildren: TreeNode[] = [
+      { id: "oracle-1:XE:DIP:__views:DIP:V_ONE", label: "V_ONE", type: "view", connectionId: "oracle-1", database: "XE", schema: "DIP", isExpanded: false },
+      { id: "oracle-1:XE:DIP:__views:DIP:V_TWO", label: "V_TWO", type: "view", connectionId: "oracle-1", database: "XE", schema: "DIP", isExpanded: false },
+    ];
+    const loadSchemaCache = vi.fn(async (key: string) =>
+      key.endsWith(":objects-v5")
+        ? {
+            version: 2,
+            cachedAt: new Date().toISOString(),
+            children: legacyChildren,
+          }
+        : null,
+    );
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined),
+      listTables,
+      loadSchemaCache,
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const store = useConnectionStore();
+    useSettingsStore().desktopSettings.sidebar_table_page_size = 200;
+    const connection = oracleConnection();
+    const viewGroup: TreeNode = {
+      id: "oracle-1:XE:DIP:__views",
+      label: "tree.views",
+      type: "group-views",
+      connectionId: connection.id,
+      database: "XE",
+      schema: "DIP",
+      isExpanded: false,
+      children: [],
+    };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [
+      {
+        id: connection.id,
+        label: connection.name,
+        type: "connection",
+        connectionId: connection.id,
+        isExpanded: true,
+        children: [
+          {
+            id: "oracle-1:XE:DIP",
+            label: "DIP",
+            type: "schema",
+            connectionId: connection.id,
+            database: "XE",
+            schema: "DIP",
+            isExpanded: true,
+            children: [viewGroup],
+          },
+        ],
+      },
+    ];
+
+    const storedViewGroup = store.treeNodes[0].children?.[0].children?.[0];
+    expect(storedViewGroup?.type).toBe("group-views");
+    await store.loadObjectGroupChildren(storedViewGroup!);
+
+    expect(loadSchemaCache).toHaveBeenCalledWith("oracle-1:XE:DIP:group-views:objects-v6");
+    expect(listTables).toHaveBeenCalledWith(connection.id, "XE", "DIP", undefined, 201, 0, ["VIEW"]);
+    expect(storedViewGroup?.children?.map((node) => node.label)).toEqual(["V_ONE", "V_THREE", "V_TWO"]);
   });
 
   it("clears a stale connection error after a schema metadata retry succeeds", async () => {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1111,7 +1111,9 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   function objectGroupCacheKey(node: TreeNode): string {
-    return schemaCacheKey(node.connectionId || "", node.database || "", node.schema || "", node.type, "objects-v5");
+    const config = node.connectionId ? getConfig(node.connectionId) : undefined;
+    const cacheVersion = config?.db_type === "oracle" ? "objects-v6" : "objects-v5";
+    return schemaCacheKey(node.connectionId || "", node.database || "", node.schema || "", node.type, cacheVersion);
   }
 
   function metadataListDriverProfile(connectionId?: string): string | undefined {


### PR DESCRIPTION
## 问题

关联已合并 PR #4075。该 PR 恢复了 Oracle `DIP` 用户的显示，并升级了 Schema 列表缓存键，但 `DIP` 下表、视图等对象分组仍会读取旧的 `objects-v5` 持久缓存。

因此左侧树可能继续显示旧缓存中的少量对象，而右侧对象浏览器实时请求后能显示完整列表。

## 改动

- Oracle 对象分组使用新的 `objects-v6` 缓存版本，升级后自动重新加载表、视图等对象。
- 其他数据库继续使用原有 `objects-v5`，避免无关缓存失效。
- 增加回归测试：旧缓存只有 2 个视图、实时接口返回 3 个时，左侧树必须绕过旧缓存并完整显示 3 个。

## 验证

- Oracle 11g 临时创建 `DIP` Schema 和 12 个视图，左树使用的 `list_tables` 与右侧使用的 `list_objects` 均完整返回 12 个；测试数据已清理。
- format、lint、typecheck 通过。
- 相关 Store 测试 56 项通过。
- 全量前端测试通过：500 个测试文件、4095 项测试。