### PR TITLE
Fix：修复 MySQL 截断分区语句识别

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -451,6 +451,20 @@ COMMENT = '测试';`;
     expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
   });
 
+  it("keeps MySQL truncate partition clauses when comments separate ALTER TABLE", () => {
+    const sql = "ALTER /* online ddl */ TABLE t\nTRUNCATE PARTITION p0;";
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "TRUNCATE"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
+  it("keeps MySQL truncate partition clauses when comments precede PARTITION", () => {
+    const sql = "ALTER TABLE t\nTRUNCATE /* keep */ PARTITION p0;";
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "TRUNCATE"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
   it("keeps standalone truncate table statements separate from preceding alter statements", () => {
     const sql = "ALTER TABLE events ADD COLUMN source varchar(100)\nTRUNCATE TABLE events;";
 

--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -443,6 +443,21 @@ COMMENT = '测试';`;
     expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
   });
 
+  it("keeps MySQL ALTER TABLE truncate partition clauses with the statement", () => {
+    const sql = "ALTER TABLE ems.r_r_curve_e_hour\nTRUNCATE PARTITION p202602, p202603, p202604, p202605, p202606;";
+
+    expect(statementRangeAtCursor(sql, indexOf(sql, "ALTER"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(statementRangeAtCursor(sql, indexOf(sql, "TRUNCATE"), "mysql")?.sql.trim()).toBe(sql.slice(0, -1));
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual([sql.slice(0, -1)]);
+  });
+
+  it("keeps standalone truncate table statements separate from preceding alter statements", () => {
+    const sql = "ALTER TABLE events ADD COLUMN source varchar(100)\nTRUNCATE TABLE events;";
+
+    expect(rangeSqlTexts(executableStatementRanges(sql, "mysql"))).toEqual(["ALTER TABLE events ADD COLUMN source varchar(100)", "TRUNCATE TABLE events"]);
+    expect(rangeSqlTexts(executableStatementRanges(sql, "postgres"))).toEqual(["ALTER TABLE events ADD COLUMN source varchar(100)", "TRUNCATE TABLE events"]);
+  });
+
   it("keeps issue #4045 ClickHouse ALTER TABLE UPDATE mutation together", () => {
     const sql = `ALTER TABLE m2_db.history_data5
 UPDATE value = 14.06

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -935,7 +935,7 @@ function isClickHouseAlterTableUpdateContinuation(sql: string, statementFrom: nu
 
 function isMysqlAlterTableTruncatePartitionContinuation(sql: string, statementFrom: number, lineStartFrom: number, keyword: string, databaseType?: DatabaseType): boolean {
   if (databaseType !== "mysql" || keyword !== "TRUNCATE") return false;
-  if (!/^ALTER\s+TABLE\b/i.test(sql.slice(statementFrom, lineStartFrom))) return false;
+  if (!startsWithSqlWords(sql, statementFrom, ["ALTER", "TABLE"])) return false;
   return nextSqlWord(sql, lineStartFrom + keyword.length) === "PARTITION";
 }
 
@@ -1107,9 +1107,49 @@ function nextNonWhitespaceChar(sql: string, pos: number): string | null {
 }
 
 function nextSqlWord(sql: string, pos: number): string | null {
+  return nextSqlWordToken(sql, pos)?.word ?? null;
+}
+
+function startsWithSqlWords(sql: string, pos: number, expectedWords: readonly string[]): boolean {
   let i = pos;
-  while (i < sql.length && isSqlWhitespace(sql[i])) i += 1;
-  return /^[A-Za-z_][\w$]*/.exec(sql.slice(i))?.[0]?.toUpperCase() ?? null;
+  for (const expectedWord of expectedWords) {
+    const token = nextSqlWordToken(sql, i);
+    if (token?.word !== expectedWord) return false;
+    i = token.end;
+  }
+  return true;
+}
+
+function nextSqlWordToken(sql: string, pos: number): { word: string; end: number } | null {
+  let i = pos;
+  // SQL comments may legally appear anywhere whitespace can separate keywords.
+  while (i < sql.length) {
+    if (isSqlWhitespace(sql[i])) {
+      i += 1;
+      continue;
+    }
+    if (sql[i] === "-" && sql[i + 1] === "-") {
+      i += 2;
+      while (i < sql.length && sql[i] !== "\n" && sql[i] !== "\r") i += 1;
+      continue;
+    }
+    if (sql[i] === "#") {
+      i += 1;
+      while (i < sql.length && sql[i] !== "\n" && sql[i] !== "\r") i += 1;
+      continue;
+    }
+    if (sql[i] === "/" && sql[i + 1] === "*") {
+      const commentEnd = sql.indexOf("*/", i + 2);
+      if (commentEnd < 0) return null;
+      i = commentEnd + 2;
+      continue;
+    }
+    break;
+  }
+
+  const match = /^[A-Za-z_][\w$]*/.exec(sql.slice(i));
+  if (!match) return null;
+  return { word: match[0].toUpperCase(), end: i + match[0].length };
 }
 
 function isExplainLikeKeyword(keyword: string | null): boolean {

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -689,6 +689,10 @@ function splitStatementRangeAtSoftStarts(sql: string, statement: RawStatement, d
       continue;
     }
 
+    if (currentBodyKeyword === "ALTER" && isMysqlAlterTableTruncatePartitionContinuation(sql, boundaries[boundaries.length - 1].from, lineStart.from, lineStart.keyword, databaseType)) {
+      continue;
+    }
+
     if (currentBodyKeyword === "ALTER" && ALTER_BODY_KEYWORDS.has(lineStart.keyword)) {
       continue;
     }
@@ -927,6 +931,12 @@ function isMysqlCreateTableOptionContinuation(sql: string, statementFrom: number
 function isClickHouseAlterTableUpdateContinuation(sql: string, statementFrom: number, lineStartFrom: number, keyword: string, databaseType?: DatabaseType): boolean {
   if (databaseType !== "clickhouse" || keyword !== "UPDATE") return false;
   return CLICKHOUSE_ALTER_TABLE_HEADER.test(sql.slice(statementFrom, lineStartFrom));
+}
+
+function isMysqlAlterTableTruncatePartitionContinuation(sql: string, statementFrom: number, lineStartFrom: number, keyword: string, databaseType?: DatabaseType): boolean {
+  if (databaseType !== "mysql" || keyword !== "TRUNCATE") return false;
+  if (!/^ALTER\s+TABLE\b/i.test(sql.slice(statementFrom, lineStartFrom))) return false;
+  return nextSqlWord(sql, lineStartFrom + keyword.length) === "PARTITION";
 }
 
 function startsWithMysqlCreateTable(sql: string, statementFrom: number): boolean {


### PR DESCRIPTION
## 变更内容

- 将 MySQL `ALTER TABLE ... TRUNCATE PARTITION ...` 识别为同一条可执行语句，避免换行后被拆成两个执行目标
- 保持独立 `TRUNCATE TABLE` 及其他数据库方言的原有语句边界行为
- 补充原始场景与边界回归测试

## 测试

- `pnpm test apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts`
- `pnpm test`（505 个测试文件、4217 项测试全部通过）
- `pnpm exec oxfmt --check apps/desktop/src/lib/sql/sqlStatementRanges.ts apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts`
- `pnpm check` 中 format、lint、typecheck 通过
- MySQL 9.6.0 真实分区表验证：换行执行 `ALTER TABLE ... TRUNCATE PARTITION p2026` 后，目标分区为 0 行，其他分区数据保留