### PR TITLE
fix(sqlserver): 修复表格编辑反斜杠被重复保存

### DIFF
--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1801,20 +1801,52 @@ pub fn format_grid_sql_literal(
         let escaped_text = literal_text.replace('\\', "\\\\").replace('\'', "''");
         return format!("E'{escaped_text}'");
     }
+    if database_type == Some(DatabaseType::SqlServer) {
+        return format_sqlserver_unicode_literal(&literal_text);
+    }
     let escaped_text = if database_type == Some(DatabaseType::Neo4j) {
         literal_text.replace('\\', "\\\\").replace('\'', "\\'")
-    } else if database_type == Some(DatabaseType::SqlServer) || is_sqlite_literal_database(database_type) {
-        // SQL Server and SQLite-family engines do not treat backslash as a
-        // string-literal escape character, so only the quote delimiter needs escaping.
+    } else if is_sqlite_literal_database(database_type) {
+        // SQLite-family engines do not treat backslash as a string-literal
+        // escape character, so only the quote delimiter needs escaping.
         literal_text.replace('\'', "''")
     } else {
         literal_text.replace('\\', "\\\\").replace('\'', "''")
     };
     let escaped = format!("'{escaped_text}'");
-    if database_type == Some(DatabaseType::SqlServer) {
-        format!("N{escaped}")
+    escaped
+}
+
+fn format_sqlserver_unicode_literal(text: &str) -> String {
+    let mut parts = Vec::new();
+    let mut segment = String::new();
+
+    for ch in text.chars() {
+        let line_break = match ch {
+            '\r' => Some(13),
+            '\n' => Some(10),
+            _ => None,
+        };
+        if let Some(codepoint) = line_break {
+            if !segment.is_empty() {
+                parts.push(format!("N'{}'", segment.replace('\'', "''")));
+                segment.clear();
+            }
+            // Keep physical newlines out of generated SQL so a preceding
+            // backslash cannot be consumed as a line-continuation marker.
+            parts.push(format!("NCHAR({codepoint})"));
+        } else {
+            segment.push(ch);
+        }
+    }
+
+    if !segment.is_empty() {
+        parts.push(format!("N'{}'", segment.replace('\'', "''")));
+    }
+    if parts.is_empty() {
+        "N''".to_string()
     } else {
-        escaped
+        parts.join(" + ")
     }
 }
 
@@ -4801,6 +4833,18 @@ mod tests {
         assert_eq!(
             format_grid_sql_literal(&json!(r".\SQL2016's"), Some(DatabaseType::SqlServer), None),
             r"N'.\SQL2016''s'"
+        );
+    }
+
+    #[test]
+    fn sqlserver_literals_preserve_backslashes_before_line_breaks() {
+        assert_eq!(
+            format_grid_sql_literal(&json!("line1\\\nline2"), Some(DatabaseType::SqlServer), None),
+            r"N'line1\' + NCHAR(10) + N'line2'"
+        );
+        assert_eq!(
+            format_grid_sql_literal(&json!("line1\\\r\nline2"), Some(DatabaseType::SqlServer), None),
+            r"N'line1\' + NCHAR(13) + NCHAR(10) + N'line2'"
         );
     }
 

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1803,9 +1803,9 @@ pub fn format_grid_sql_literal(
     }
     let escaped_text = if database_type == Some(DatabaseType::Neo4j) {
         literal_text.replace('\\', "\\\\").replace('\'', "\\'")
-    } else if is_sqlite_literal_database(database_type) {
-        // SQLite-family engines do not treat backslash as a string-literal
-        // escape character, so only the quote delimiter needs escaping.
+    } else if database_type == Some(DatabaseType::SqlServer) || is_sqlite_literal_database(database_type) {
+        // SQL Server and SQLite-family engines do not treat backslash as a
+        // string-literal escape character, so only the quote delimiter needs escaping.
         literal_text.replace('\'', "''")
     } else {
         literal_text.replace('\\', "\\\\").replace('\'', "''")
@@ -4793,6 +4793,43 @@ mod tests {
             );
             assert_eq!(format_grid_sql_literal(&json!("it's"), Some(database_type), None), "'it''s'");
         }
+    }
+
+    #[test]
+    fn sqlserver_literals_do_not_double_escape_backslashes() {
+        assert_eq!(format_grid_sql_literal(&json!(r".\SQL2016"), Some(DatabaseType::SqlServer), None), r"N'.\SQL2016'");
+        assert_eq!(
+            format_grid_sql_literal(&json!(r".\SQL2016's"), Some(DatabaseType::SqlServer), None),
+            r"N'.\SQL2016''s'"
+        );
+    }
+
+    #[test]
+    fn prepares_sqlserver_updates_without_doubling_backslashes() {
+        let result = prepare_data_grid_save(DataGridSaveStatementOptions {
+            database_type: Some(DatabaseType::SqlServer),
+            identifier_quote: None,
+            table_meta: DataGridTableMeta {
+                catalog: None,
+                database: None,
+                schema: Some("dbo".to_string()),
+                table_name: "dbx_issue_4181".to_string(),
+                primary_keys: vec!["id".to_string()],
+                columns: Some(vec![column("id", "int", false, None), column("value", "nvarchar(100)", true, None)]),
+            },
+            columns: vec!["id".to_string(), "value".to_string()],
+            source_columns: None,
+            rows: vec![vec![json!(1), json!("initial")]],
+            dirty_rows: vec![(0, vec![(1, json!(r".\SQL2016"))])],
+            deleted_rows: vec![],
+            new_rows: vec![],
+        });
+
+        assert_eq!(result.validation_error, None);
+        assert_eq!(
+            result.statements,
+            vec![r"UPDATE [dbo].[dbx_issue_4181] SET [value] = N'.\SQL2016' WHERE [id] = 1;"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

DataGrid 保存文本时沿用了会复制反斜杠的通用 SQL 字符串转义。SQL Server 字符串字面量不把反斜杠作为转义字符，因此输入 `.\SQL2016` 时，生成的 `N'.\\SQL2016'` 会把两个反斜杠原样写入数据库。

## 修复

- SQL Server DataGrid 字符串字面量只转义单引号，不再复制反斜杠
- 保留 Unicode 字符串的 `N` 前缀
- 保持 MySQL、Neo4j、PostgreSQL 和 SQLite 系列现有转义逻辑不变
- 增加字面量与完整 DataGrid UPDATE 语句回归测试

## 真实验证

在 SQL Server 2022 Developer Edition 上创建 `nvarchar(100)` 测试列并执行 DataGrid 对应 SQL：

- 修复前：生成 `N'.\\SQL2016'`，查询结果包含两个反斜杠，`LEN=10`、`DATALENGTH=20`
- 修复后：生成 `N'.\SQL2016'`，查询结果为 `.\SQL2016`，`LEN=9`、`DATALENGTH=18`
- 测试临时表验证后已删除

## 测试

- `cargo test -p dbx-core --lib`：2479 passed，12 ignored
- `cargo clippy --workspace --locked --all-targets --no-default-features --features "dbx/mq-admin,dbx/sqlite-sqlcipher,dbx-core/mq-admin,dbx-core/sqlite-sqlcipher,dbx-web/mq-admin,dbx-web/sqlite-sqlcipher" -- -D warnings`
- `cargo test --workspace --locked --no-default-features --features "dbx/mq-admin,dbx/sqlite-sqlcipher,dbx-core/mq-admin,dbx-core/sqlite-sqlcipher,dbx-web/mq-admin,dbx-web/sqlite-sqlcipher"`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #4181