### PR TITLE
Fix：增强数据列表交叉行对比度

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4328,9 +4328,7 @@ function dataGridRowStyle(item: RowItem): CSSProperties {
           ? "rgb(51, 51, 55)"
           : "rgb(243, 243, 243)"
         : item.displayIndex % 2 === 1
-          ? dark
-            ? DATA_GRID_DARK_STRIPED_ROW_BG
-            : DATA_GRID_LIGHT_STRIPED_ROW_BG
+          ? `var(--data-grid-row-muted-bg, ${dark ? DATA_GRID_DARK_STRIPED_ROW_BG : DATA_GRID_LIGHT_STRIPED_ROW_BG})`
           : dark
             ? "rgb(19, 20, 22)"
             : "rgb(255, 255, 255)";
@@ -9060,7 +9058,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 @reference "../../styles/globals.css";
 
 [data-grid-root] {
-  --data-grid-row-muted-bg: rgb(243, 243, 243);
+  --data-grid-row-muted-bg: rgb(240, 240, 240);
   --data-grid-row-new-bg: rgb(243, 243, 243);
   --data-grid-row-deleted-bg: rgb(255, 244, 244);
   --data-grid-cell-active-bg: rgb(232, 232, 232);

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -133,6 +133,7 @@ import { canGoNextDataGridPage, hasCompleteLocalDataGridResult } from "@/lib/dat
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
 import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
 import { CANVAS_DATA_GRID_ROW_HEIGHT, dataGridSearchMatchKey, drawCanvasDataGrid } from "@/lib/dataGrid/canvasDataGridRenderer";
+import { DATA_GRID_DARK_STRIPED_ROW_BG, DATA_GRID_LIGHT_STRIPED_ROW_BG } from "@/lib/dataGrid/dataGridPaintTheme";
 import { createRowLowerTextCache } from "@/lib/dataGrid/dataGridRowLowerText";
 import { dataGridPreviewLabelKey, dataGridSaveActionMode, dataGridSaveToolbarState } from "@/lib/dataGrid/dataGridSaveUi";
 import type { QueryEditabilityReason } from "@/lib/sql/sqlAnalysis";
@@ -4328,8 +4329,8 @@ function dataGridRowStyle(item: RowItem): CSSProperties {
           : "rgb(243, 243, 243)"
         : item.displayIndex % 2 === 1
           ? dark
-            ? "rgb(32, 32, 34)"
-            : "rgb(248, 248, 248)"
+            ? DATA_GRID_DARK_STRIPED_ROW_BG
+            : DATA_GRID_LIGHT_STRIPED_ROW_BG
           : dark
             ? "rgb(19, 20, 22)"
             : "rgb(255, 255, 255)";
@@ -9059,7 +9060,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 @reference "../../styles/globals.css";
 
 [data-grid-root] {
-  --data-grid-row-muted-bg: rgb(248, 248, 248);
+  --data-grid-row-muted-bg: rgb(243, 243, 243);
   --data-grid-row-new-bg: rgb(243, 243, 243);
   --data-grid-row-deleted-bg: rgb(255, 244, 244);
   --data-grid-cell-active-bg: rgb(232, 232, 232);
@@ -9085,7 +9086,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 
 [data-grid-root].data-grid--dark,
 :global(.dark) [data-grid-root] {
-  --data-grid-row-muted-bg: rgb(32, 32, 34);
+  --data-grid-row-muted-bg: rgb(40, 40, 43);
   --data-grid-row-new-bg: rgb(51, 51, 55);
   --data-grid-row-deleted-bg: rgb(55, 31, 32);
   --data-grid-cell-active-bg: rgb(64, 64, 64);
@@ -9111,7 +9112,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 
 @supports (background: color-mix(in oklab, white 50%, transparent)) {
   [data-grid-root] {
-    --data-grid-row-muted-bg: color-mix(in oklab, var(--muted) 30%, transparent);
+    --data-grid-row-muted-bg: color-mix(in oklab, var(--muted) 99%, var(--foreground));
     --data-grid-row-new-bg: color-mix(in oklab, var(--primary) 5%, transparent);
     --data-grid-row-deleted-bg: color-mix(in oklab, var(--destructive) 5%, transparent);
     --data-grid-cell-active-bg: color-mix(in oklab, var(--primary) 15%, transparent);

--- a/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
@@ -35,6 +35,8 @@ export const DATA_GRID_DARK_SEARCH_COLORS = {
   current: "rgb(116, 87, 0)",
   currentBorder: "rgb(239, 177, 0)",
 } as const;
+export const DATA_GRID_LIGHT_STRIPED_ROW_BG = "rgb(243, 243, 243)";
+export const DATA_GRID_DARK_STRIPED_ROW_BG = "rgb(40, 40, 43)";
 export const DATA_GRID_DARK_ROW_NUMBER_BG = "rgb(35, 37, 42)";
 const DATA_GRID_DARK_ROW_NUMBER_NEW_BG = "rgb(33, 45, 40)";
 const DATA_GRID_DARK_ROW_NUMBER_EDITED_BG = "rgb(48, 41, 28)";
@@ -239,7 +241,7 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
   const destructive = cssVarColor(getVar, "--destructive", isDark ? "rgb(243, 98, 95)" : "rgb(231, 0, 11)");
   const accent = cssVarColor(getVar, "--accent", isDark ? "rgb(46, 47, 51)" : "rgb(245, 245, 245)");
   const activeSurface = isDark ? "rgb(64, 64, 64)" : "rgb(232, 232, 232)";
-  const rowMuted = isDark ? "rgb(32, 32, 34)" : "rgb(248, 248, 248)";
+  const rowMuted = isDark ? DATA_GRID_DARK_STRIPED_ROW_BG : DATA_GRID_LIGHT_STRIPED_ROW_BG;
   const rowNew = isDark ? "rgb(51, 51, 55)" : "rgb(243, 243, 243)";
   const rowDeleted = isDark ? "rgb(55, 31, 32)" : "rgb(255, 244, 244)";
   const cellActive = activeSurface;

--- a/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
@@ -35,7 +35,7 @@ export const DATA_GRID_DARK_SEARCH_COLORS = {
   current: "rgb(116, 87, 0)",
   currentBorder: "rgb(239, 177, 0)",
 } as const;
-export const DATA_GRID_LIGHT_STRIPED_ROW_BG = "rgb(243, 243, 243)";
+export const DATA_GRID_LIGHT_STRIPED_ROW_BG = "rgb(240, 240, 240)";
 export const DATA_GRID_DARK_STRIPED_ROW_BG = "rgb(40, 40, 43)";
 export const DATA_GRID_DARK_ROW_NUMBER_BG = "rgb(35, 37, 42)";
 const DATA_GRID_DARK_ROW_NUMBER_NEW_BG = "rgb(33, 45, 40)";

--- a/packages/app-tests/canvasDataGridRenderer.test.ts
+++ b/packages/app-tests/canvasDataGridRenderer.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import { fitCanvasText } from "../../apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts";
+import { DATA_GRID_DARK_STRIPED_ROW_BG, DATA_GRID_LIGHT_STRIPED_ROW_BG, resolveDataGridPaintTheme } from "../../apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts";
 
 function measureContext(charWidth = 1): CanvasRenderingContext2D {
   return {
@@ -20,4 +21,11 @@ test("fitCanvasText truncates only when text exceeds the available cell width", 
   const ctx = measureContext();
 
   assert.equal(fitCanvasText(ctx, "1234567890", 8), "12345...");
+});
+
+test("data grid paint themes use the increased striped row contrast", () => {
+  const getVar = () => "";
+
+  assert.equal(resolveDataGridPaintTheme({ getVar, isDark: false }).rowMuted, DATA_GRID_LIGHT_STRIPED_ROW_BG);
+  assert.equal(resolveDataGridPaintTheme({ getVar, isDark: true }).rowMuted, DATA_GRID_DARK_STRIPED_ROW_BG);
 });

--- a/packages/app-tests/canvasDataGridRenderer.test.ts
+++ b/packages/app-tests/canvasDataGridRenderer.test.ts
@@ -26,6 +26,14 @@ test("fitCanvasText truncates only when text exceeds the available cell width", 
 test("data grid paint themes use the increased striped row contrast", () => {
   const getVar = () => "";
 
-  assert.equal(resolveDataGridPaintTheme({ getVar, isDark: false }).rowMuted, DATA_GRID_LIGHT_STRIPED_ROW_BG);
+  const lightTheme = resolveDataGridPaintTheme({ getVar, isDark: false });
+  assert.equal(lightTheme.rowMuted, DATA_GRID_LIGHT_STRIPED_ROW_BG);
+  assert.notEqual(lightTheme.rowMuted, lightTheme.rowNew);
   assert.equal(resolveDataGridPaintTheme({ getVar, isDark: true }).rowMuted, DATA_GRID_DARK_STRIPED_ROW_BG);
+});
+
+test("data grid paint theme uses the resolved striped row token", () => {
+  const getVar = (name: string) => (name === "--data-grid-row-muted-bg" ? "rgb(235, 239, 244)" : "");
+
+  assert.equal(resolveDataGridPaintTheme({ getVar, isDark: false }).rowMuted, "rgb(235, 239, 244)");
 });


### PR DESCRIPTION
## 问题

查询结果交叉行背景与普通行过于接近，特别是在浅色主题和 Canvas 渲染模式下，连续查看大量数据时不易区分行边界。

## 修改内容

- 浅色交叉行由 `rgb(248, 248, 248)` 调整为约 `rgb(243, 243, 243)`
- 深色交叉行由 `rgb(32, 32, 34)` 调整为 `rgb(40, 40, 43)`
- 主题混色改为不透明背景，避免 Canvas 合成后交叉色再次变淡
- DOM 与 Canvas 渲染复用同一组颜色常量，保持两种渲染模式一致
- 保持悬浮、选中、编辑、新增和删除状态的现有视觉层级

## 验证

- 使用免密网页环境执行真实 MySQL 查询并检查 8 行查询结果
- `pnpm typecheck`
- `pnpm test`：506 个测试文件、4225 个用例通过
- `pnpm build`
- 目标文件 Oxlint、Oxfmt、`git diff --check` 通过

Fixes #4180
