### PR TITLE
chore: bump MSRV to 1.88.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you are not sure what to pick, choose an issue with clear reproduction steps,
 
 - Node.js >= 22.13.0
 - pnpm 10.27.0
-- Rust >= 1.77
+- Rust >= 1.88
 - Make
 
 Linux desktop builds also need WebKit/GTK packages. See [README.md](README.md#getting-started) for the exact commands.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -16,7 +16,7 @@
 
 - Node.js >= 22.13.0
 - pnpm 10.27.0
-- Rust >= 1.77
+- Rust >= 1.88
 - Make
 
 Linux 桌面端还需要 WebKit/GTK 相关依赖，具体命令见 [README.zh-CN.md](README.zh-CN.md#快速开始)。

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ When building the frontend yourself with an absolute asset base, set
 
 - [Node.js](https://nodejs.org/) >= 18
 - [pnpm](https://pnpm.io/)
-- [Rust](https://www.rust-lang.org/tools/install) >= 1.77
+- [Rust](https://www.rust-lang.org/tools/install) >= 1.88
 
 #### System Dependencies
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -283,7 +283,7 @@ environment:
 
 - [Node.js](https://nodejs.org/) >= 18
 - [pnpm](https://pnpm.io/)
-- [Rust](https://www.rust-lang.org/tools/install) >= 1.77
+- [Rust](https://www.rust-lang.org/tools/install) >= 1.88
 
 #### 系统依赖
 

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -1631,13 +1631,11 @@ pub async fn list_tables_filtered(
     Ok(tables)
 }
 
-// `Option::is_none_or` requires Rust 1.82, while DBX still supports Rust 1.77.2.
-#[allow(clippy::unnecessary_map_or)]
 fn should_fallback_empty_list_tables(filter: Option<&str>) -> bool {
     // MySQL proxies such as MyCat can return an empty information_schema.TABLES
     // even when SHOW TABLES exposes objects. Avoid the fallback for active
     // searches so normal MySQL "no match" queries do not rescan large schemas.
-    filter.map_or(true, |filter| filter.trim().is_empty())
+    filter.is_none_or(|filter| filter.trim().is_empty())
 }
 
 fn filter_list_tables_fallback(

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
 
-        # Rust toolchain — lock to the minimum required version (1.77)
+        # Rust toolchain — lock to the minimum required version (1.88)
         # while allowing newer stable releases to satisfy all crate deps.
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["skyler"]
 license = "Apache-2.0"
 repository = ""
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.88.0"
 
 [lib]
 name = "dbx_lib"

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -78,7 +78,7 @@ impl NodeRuntime {
         let package_is_compatible = package
             .as_ref()
             .and_then(|package| package.minimum_node_version)
-            .map_or(true, |minimum| parse_node_version(&node_version).is_some_and(|version| version >= minimum));
+            .is_none_or(|minimum| parse_node_version(&node_version).is_some_and(|version| version >= minimum));
         let mcp_version = package.as_ref().and_then(|package| package.version.clone());
         // Resolve the package-declared launcher so npm layout changes do not break the built-in AI assistant.
         let mcp_script_path = package.filter(|_| package_is_compatible).map(|package| package.script_path);

--- a/src-tauri/src/commands/mcp_bridge.rs
+++ b/src-tauri/src/commands/mcp_bridge.rs
@@ -703,7 +703,7 @@ fn mongo_filter_is_effectively_unbounded(filter_json: &str) -> bool {
     serde_json::from_str::<serde_json::Value>(filter_json)
         .ok()
         .as_ref()
-        .map_or(true, |value| mongo_filter_contains_opaque_logic(value) || mongo_filter_value_is_unbounded(value))
+        .is_none_or(|value| mongo_filter_contains_opaque_logic(value) || mongo_filter_value_is_unbounded(value))
 }
 
 fn mongo_filter_contains_opaque_logic(value: &serde_json::Value) -> bool {
@@ -877,10 +877,10 @@ fn mongo_filter_value_is_unbounded(value: &serde_json::Value) -> bool {
         "$comment" => true,
         "$and" => value
             .as_array()
-            .map_or(true, |clauses| clauses.is_empty() || clauses.iter().all(mongo_filter_value_is_unbounded)),
+            .is_none_or(|clauses| clauses.is_empty() || clauses.iter().all(mongo_filter_value_is_unbounded)),
         "$or" => value
             .as_array()
-            .map_or(true, |clauses| clauses.is_empty() || clauses.iter().any(mongo_filter_value_is_unbounded)),
+            .is_none_or(|clauses| clauses.is_empty() || clauses.iter().any(mongo_filter_value_is_unbounded)),
         "$nor" => true,
         _ if mongo_field_predicate_is_empty_nin(value) => true,
         "_id" if mongo_field_predicate_is_exists_true(value) => true,


### PR DESCRIPTION

## 变更说明

The declared rust-version 1.77.2 was stale: dependencies such as darling, image, mongodb, time, serde_with, plist and hickory-resolver now require Rust 1.88. Verified empirically — the workspace builds on 1.88.0, and cargo rejects 1.87.0 listing those deps.

Update rust-version in src-tauri, the README/CONTRIBUTING/flake docs, and drop the now-obsolete 1.77.2 workaround in mysql.rs (use Option::is_none_or instead of map_or).

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [ ] CI / 构建

## 涉及前端

None

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

None

## 验证


- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

None