### PR TITLE
fix: 修复表格单元格编辑后横向滚动位置跳动

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5793,6 +5793,9 @@ function prepareDataCellMouseDown(item: RowItem, actualColIdx: number) {
     pendingQuickEntryDraftCellFocus.value = { rowId: item.id, col: actualColIdx };
   } else {
     pendingQuickEntryDraftCellFocus.value = null;
+    if (editing && (editing.rowId !== item.id || editing.col !== actualColIdx)) {
+      void commitEditFromCellBlur();
+    }
   }
 }
 

--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -2,6 +2,7 @@ import { ref, computed, nextTick, watch, getCurrentInstance, onActivated, onBefo
 import * as api from "@/lib/backend/api";
 import type { CellValue } from "@/lib/dataGrid/cellValue";
 import { coerceDataGridCellValue, dataGridCellEditorText } from "@/lib/dataGrid/dataGridCellCoercion";
+import { focusDataGridEditorWithoutScrolling, preserveDataGridScrollPosition } from "@/lib/dataGrid/dataGridEditorFocus";
 import { normalizeDataGridSaveError } from "@/lib/dataGrid/dataGridSql";
 import { rowStatusFilterAfterAddingRow, type RowStatusFilter } from "@/lib/dataGrid/gridRowStatus";
 import { supportsDataGridTransaction } from "@/lib/table/tableEditing";
@@ -271,9 +272,10 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
   function focusEditInput(select = true) {
     const focusInput = () => {
       if (typeof document === "undefined") return;
-      const root = getScrollerElement()?.closest("[data-grid-root]");
+      const scroller = getScrollerElement();
+      const root = scroller?.closest("[data-grid-root]");
       const input = (root ?? document).querySelector(".cell-edit-input") as HTMLInputElement | HTMLTextAreaElement | null;
-      input?.focus();
+      if (input) focusDataGridEditorWithoutScrolling(input, scroller);
       if (select && input) {
         if (input instanceof HTMLTextAreaElement && input.dataset.expandedCellEditor === "true") {
           input.setSelectionRange?.(0, 0);
@@ -399,14 +401,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
   }
 
   function preserveScrollPosition() {
-    const el = getScrollerElement();
-    if (!el) return () => {};
-    const top = el.scrollTop;
-    const left = el.scrollLeft;
-    return () => {
-      el.scrollTop = top;
-      el.scrollLeft = left;
-    };
+    return preserveDataGridScrollPosition(getScrollerElement());
   }
 
   function readScrollPosition(): PendingChangesSnapshot["scroll"] | undefined {
@@ -457,6 +452,10 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
     restoreScroll();
     nextTick(() => {
       restoreScroll();
+      if (typeof requestAnimationFrame !== "function") {
+        isCancelling = false;
+        return;
+      }
       let attempts = 0;
       const restoreNextFrame = () => {
         restoreScroll();
@@ -731,7 +730,10 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       suppressNextBlurCommit = false;
       return;
     }
-    await commitEditAndMaybeAutoSave(options);
+    const restoreScroll = preserveScrollPosition();
+    const pendingCommit = commitEditAndMaybeAutoSave(options);
+    restoreScrollAcrossFrames(restoreScroll);
+    await pendingCommit;
   }
 
   function applyCellValue(rowId: number, col: number, value: string | null, options: ApplyCellValueOptions = {}) {

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridEditorFocus.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { focusDataGridEditorWithoutScrolling, preserveDataGridScrollPosition } from "@/lib/dataGrid/dataGridEditorFocus";
+
+describe("preserveDataGridScrollPosition", () => {
+  it("restores the viewport after an editor is removed", () => {
+    const scroller = { scrollLeft: 720, scrollTop: 180 };
+    const restoreScroll = preserveDataGridScrollPosition(scroller);
+
+    scroller.scrollLeft = 0;
+    scroller.scrollTop = 0;
+    restoreScroll();
+
+    expect(scroller).toEqual({ scrollLeft: 720, scrollTop: 180 });
+  });
+});
+
+describe("focusDataGridEditorWithoutScrolling", () => {
+  it("prevents focus from moving the data grid viewport", () => {
+    const scroller = { scrollLeft: 720, scrollTop: 180 };
+    const input = {
+      focus: vi.fn((options?: FocusOptions) => {
+        expect(options).toEqual({ preventScroll: true });
+        // Some WebViews still move a virtualized ancestor while mounting the editor.
+        scroller.scrollLeft = 0;
+        scroller.scrollTop = 0;
+      }),
+    };
+
+    focusDataGridEditorWithoutScrolling(input, scroller);
+
+    expect(input.focus).toHaveBeenCalledOnce();
+    expect(scroller).toEqual({ scrollLeft: 720, scrollTop: 180 });
+  });
+});

--- a/apps/desktop/src/lib/dataGrid/dataGridEditorFocus.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridEditorFocus.ts
@@ -1,0 +1,19 @@
+type DataGridEditorInput = Pick<HTMLElement, "focus">;
+type DataGridEditorScroller = Pick<HTMLElement, "scrollLeft" | "scrollTop">;
+
+export function preserveDataGridScrollPosition(scroller?: DataGridEditorScroller | null) {
+  if (!scroller) return () => {};
+  const scrollLeft = scroller.scrollLeft;
+  const scrollTop = scroller.scrollTop;
+  return () => {
+    if (scroller.scrollLeft !== scrollLeft) scroller.scrollLeft = scrollLeft;
+    if (scroller.scrollTop !== scrollTop) scroller.scrollTop = scrollTop;
+  };
+}
+
+export function focusDataGridEditorWithoutScrolling(input: DataGridEditorInput, scroller?: DataGridEditorScroller | null) {
+  const restoreScroll = preserveDataGridScrollPosition(scroller);
+
+  input.focus({ preventScroll: true });
+  restoreScroll();
+}


### PR DESCRIPTION
## 问题

在表数据页面使用 Cmd/Ctrl+F 搜索出多个结果后，将横向滚动条移动到右侧，双击单元格进入编辑，再点击其他单元格时，表格可能跳回首列。DOM 与 Canvas 表格模式都可能受影响，与具体数据库类型无关。

## 原因

- 编辑器挂载时直接调用 `focus()`，WebView 可能滚动虚拟化表格的外层容器。
- 点击其他单元格时，旧编辑器先失焦并卸载；原选择逻辑因为仍处于编辑状态而提前返回，卸载过程也没有恢复横向滚动位置。

## 修改

- 聚焦单元格编辑器时使用 `preventScroll`，并恢复聚焦前的滚动位置。
- 失焦提交期间跨渲染帧保持表格的 `scrollLeft`/`scrollTop`。
- 点击其他单元格时先提交当前编辑，再继续执行新单元格选择。
- 保留快速录入草稿行切换字段的既有逻辑。
- 增加编辑器聚焦和滚动恢复单元测试。

## 验证

- 达梦 `ORDERS_10K` 表按上述操作路径实际验证，不再跳回首列。
- `pnpm check`
  - format 通过
  - lint 通过
  - typecheck 通过
  - 510 个测试文件、4253 条测试通过
