### PR TITLE
fix: preserve MongoDB int64 filter values

### DIFF
--- a/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
+++ b/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
@@ -857,7 +857,36 @@ public final class MongoAgent {
     }
 
     static JsonObject bsonToExtendedJson(Document doc) {
-        return JsonParser.parseString(doc.toJson(EXTENDED_JSON_SETTINGS)).getAsJsonObject();
+        JsonObject relaxed = JsonParser.parseString(doc.toJson(EXTENDED_JSON_SETTINGS)).getAsJsonObject();
+        return preserveUnsafeLongsForJsonClients(doc, relaxed).getAsJsonObject();
+    }
+
+    private static JsonElement preserveUnsafeLongsForJsonClients(Object bsonValue, JsonElement relaxedValue) {
+        if (
+            bsonValue instanceof Long longValue &&
+            (longValue < -JS_MAX_SAFE_INTEGER || longValue > JS_MAX_SAFE_INTEGER)
+        ) {
+            JsonObject wrapper = new JsonObject();
+            wrapper.addProperty("$numberLong", longValue.toString());
+            return wrapper;
+        }
+        if (bsonValue instanceof Document document && relaxedValue.isJsonObject()) {
+            JsonObject object = relaxedValue.getAsJsonObject();
+            for (Map.Entry<String, Object> entry : document.entrySet()) {
+                if (object.has(entry.getKey())) {
+                    object.add(
+                        entry.getKey(),
+                        preserveUnsafeLongsForJsonClients(entry.getValue(), object.get(entry.getKey()))
+                    );
+                }
+            }
+        } else if (bsonValue instanceof List<?> values && relaxedValue.isJsonArray()) {
+            JsonArray array = relaxedValue.getAsJsonArray();
+            for (int index = 0; index < Math.min(values.size(), array.size()); index++) {
+                array.set(index, preserveUnsafeLongsForJsonClients(values.get(index), array.get(index)));
+            }
+        }
+        return relaxedValue;
     }
 
     static Object convertValue(Object value) {

--- a/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
+++ b/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
@@ -553,6 +553,27 @@ class MongoAgentTest {
     }
 
     @Test
+    void bsonToExtendedJsonWrapsUnsafeLongsForJsonClients() {
+        Document doc = new Document("_id", 144_115_205_316_939_462L)
+            .append("nested", new Document("sequence", -144_115_205_316_939_462L))
+            .append("items", List.of(144_115_205_316_939_462L))
+            .append("safe", 42L);
+
+        JsonObject json = MongoAgent.bsonToExtendedJson(doc);
+
+        assertEquals("144115205316939462", json.getAsJsonObject("_id").get("$numberLong").getAsString());
+        assertEquals(
+            "-144115205316939462",
+            json.getAsJsonObject("nested").getAsJsonObject("sequence").get("$numberLong").getAsString()
+        );
+        assertEquals(
+            "144115205316939462",
+            json.getAsJsonArray("items").get(0).getAsJsonObject().get("$numberLong").getAsString()
+        );
+        assertEquals(42L, json.get("safe").getAsLong());
+    }
+
+    @Test
     void documentForWriteParsesMongoShellIsoDateStrings() {
         Document doc = MongoAgent.documentForWrite("{\"$set\":{\"CreateDate\":\"ISODate(\\\"2026-06-10T13:59:31.287Z\\\")\"}}");
 

--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -1655,6 +1655,7 @@ defineExpose({ focusSearch });
               rows="1"
               class="document-query-input flex-1 min-w-0 text-xs bg-transparent outline-none placeholder:text-muted-foreground/60 font-mono"
               placeholder="{}"
+              @keydown.enter.exact.prevent="applyFilter"
               @keydown.ctrl.enter.prevent="applyFilter"
               @keydown.meta.enter.prevent="applyFilter"
             />
@@ -1693,6 +1694,7 @@ defineExpose({ focusSearch });
               rows="1"
               class="document-query-input flex-1 min-w-0 text-xs bg-transparent outline-none placeholder:text-muted-foreground/60 font-mono"
               placeholder="{}"
+              @keydown.enter.exact.prevent="applyFilter"
               @keydown.ctrl.enter.prevent="applyFilter"
               @keydown.meta.enter.prevent="applyFilter"
             />

--- a/apps/desktop/src/lib/app/documentStoreProvider.ts
+++ b/apps/desktop/src/lib/app/documentStoreProvider.ts
@@ -1,4 +1,5 @@
 import type { ComposerTranslation } from "vue-i18n";
+import { normalizeJsonArgument } from "@dbx-app/mongo-shell";
 import type { DatabaseType } from "@/types/database";
 import { quoteUnquotedObjectKeys } from "@/lib/mongo/mongoShellCommand";
 import { formatMongoShellLiteral } from "@/lib/mongo/mongoDocumentValues";
@@ -531,9 +532,21 @@ function isDigit(value: string | undefined): boolean {
 export function parseDocumentFilterInput(input: string, options: DocumentFilterParseOptions = {}): Record<string, unknown> {
   const trimmed = input.trim();
   if (!trimmed) return {};
-  const safe = quoteUnquotedObjectKeys(trimmed);
+  const safe = normalizeDocumentQueryObjectInput(trimmed, options.kind);
   const parsed = parseJsonPreservingLargeIntegers(safe, options);
   return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+}
+
+type DocumentQueryInputNormalizer = (input: string) => string | null;
+
+const documentQueryInputNormalizers: Record<DocumentStoreKind, DocumentQueryInputNormalizer> = {
+  mongodb: normalizeJsonArgument,
+  elasticsearch: quoteUnquotedObjectKeys,
+};
+
+function normalizeDocumentQueryObjectInput(input: string, kind?: DocumentStoreKind): string {
+  const normalize = kind ? documentQueryInputNormalizers[kind] : quoteUnquotedObjectKeys;
+  return normalize(input) ?? input;
 }
 
 export function currentDocumentFilterJson(input: string, structured: Record<string, unknown> | null, kind?: DocumentStoreKind): string | undefined {

--- a/packages/app-tests/documentBrowser.test.ts
+++ b/packages/app-tests/documentBrowser.test.ts
@@ -61,3 +61,9 @@ test("document save uses shared identity plan and write helpers", () => {
   assert.doesNotMatch(source, /async function rekeyDocumentStoreDocument/);
   assert.doesNotMatch(source, /async function replaceDocumentStoreDocument/);
 });
+
+test("document query inputs apply on Enter and reserve Shift+Enter for newlines", () => {
+  const source = documentBrowserSource();
+  assert.equal(source.match(/@keydown\.enter\.exact\.prevent="applyFilter"/g)?.length, 2);
+  assert.doesNotMatch(source, /@keydown\.shift\.enter\.prevent="applyFilter"/);
+});

--- a/packages/app-tests/documentStoreProvider.test.ts
+++ b/packages/app-tests/documentStoreProvider.test.ts
@@ -211,6 +211,11 @@ test("uses elemMatch only for AND conditions on the same array object", () => {
 test("formats document query object input", () => {
   assert.equal(formatDocumentQueryInput('{profile:{city:"上海"},status:"active"}', "mongodb"), ["{", '  "profile": {', '    "city": "上海"', "  },", '  "status": "active"', "}"].join("\n"));
 });
+test("normalizes Mongo shell syntax in manual document filters", () => {
+  assert.equal(currentDocumentFilterJson("{id:NumberLong('144115205316939462')}", null, "mongodb"), JSON.stringify({ id: { $numberLong: "144115205316939462" } }));
+  assert.equal(currentDocumentFilterJson("{owner:ObjectId('507f1f77bcf86cd799439011'),status:'active'}", null, "mongodb"), JSON.stringify({ owner: { $oid: "507f1f77bcf86cd799439011" }, status: "active" }));
+});
+
 test("preserves MongoDB int64 document filter values", () => {
   const id = "2048938405781032962";
   const firstUnsafeInteger = "9007199254740993";


### PR DESCRIPTION
## 变更说明
在把 BSON（MongoDB 数据结构）转换成 JSON 给前端（尤其是 JavaScript 客户端）使用时，保护超过 JavaScript 安全整数范围的 Long 类型，避免精度丢失。
 
## 变更类型

- [ ] 新功能
- [X] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端
 N/A

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->
 
- [x] 相关测试通过

## 关联 Issue
 https://github.com/t8y2/dbx/issues/1325
