### PR TITLE
fix(connection): restore New Connection dialog after RabbitMQ

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -2202,7 +2202,7 @@ const dbCategoryDefinitions: Array<{
   {
     key: "mq",
     titleKey: "connection.databaseCategoryMq",
-    optionValues: ["mq", "kafka", "rocketmq"],
+    optionValues: ["mq", "kafka", "rocketmq", "rabbitmq"],
   },
   {
     key: "registry_config",

--- a/packages/app-tests/databaseCategoryOptions.test.ts
+++ b/packages/app-tests/databaseCategoryOptions.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { test } from "vitest";
 import { assertCompleteDatabaseCategories, databaseSelectionForCategory } from "../../apps/desktop/src/lib/connection/databaseCategoryOptions.ts";
 
@@ -13,4 +16,22 @@ test("database category changes keep only visible selections", () => {
   assert.equal(databaseSelectionForCategory("mysql", ["mysql", "postgres"]), "mysql");
   assert.equal(databaseSelectionForCategory("mysql", ["questdb", "tdengine"]), "questdb");
   assert.equal(databaseSelectionForCategory("mysql", []), undefined);
+});
+
+test("ConnectionDialog database categories stay exhaustive", () => {
+  const dialogPath = join(dirname(fileURLToPath(import.meta.url)), "../../apps/desktop/src/components/connection/ConnectionDialog.vue");
+  const source = readFileSync(dialogPath, "utf8");
+  const optionsMatch = source.match(/const dbOptions: DbOption\[] = \[([\s\S]*?)\];/);
+  const categoriesMatch = source.match(/const dbCategoryDefinitions: Array<\{[\s\S]*?\}> = \[([\s\S]*?)\];/);
+  assert.ok(optionsMatch, "dbOptions not found");
+  assert.ok(categoriesMatch, "dbCategoryDefinitions not found");
+
+  const optionValues = [...optionsMatch[1].matchAll(/value:\s*"([^"]+)"/g)].map((match) => match[1]);
+  const categoryBlocks = [...categoriesMatch[1].matchAll(/optionValues:\s*\[([^\]]*)\]/g)].map((match) =>
+    [...match[1].matchAll(/"([^"]+)"/g)].map((valueMatch) => valueMatch[1]),
+  );
+
+  assert.doesNotThrow(() => assertCompleteDatabaseCategories(optionValues, categoryBlocks));
+  assert.ok(optionValues.includes("rabbitmq"), "rabbitmq must remain in dbOptions");
+  assert.ok(categoryBlocks.some((values) => values.includes("rabbitmq")), "rabbitmq must remain categorized");
 });


### PR DESCRIPTION
## Summary
- RabbitMQ was added to `dbOptions` but omitted from database category definitions, so `assertCompleteDatabaseCategories` threw when `ConnectionDialog` loaded and New Connection appeared unresponsive.
- Add `rabbitmq` to the MQ category and cover the dialog lists with a regression test so future driver additions cannot silently break the picker.

## Test plan
- [ ] Click **新建连接** / New Connection and confirm the database picker opens
- [ ] Switch to the MQ category and confirm RabbitMQ is listed
- [ ] `pnpm exec vitest run packages/app-tests/databaseCategoryOptions.test.ts`