### PR TITLE
fix(connection): keep db picker top border on hover

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -4391,7 +4391,7 @@ function openExternalUrl(url: string) {
                     v-for="opt in category.options"
                     :key="opt.value"
                     type="button"
-                    class="connection-db-picker-option group flex min-h-24 flex-col items-center justify-center gap-2 rounded-xl border bg-background/70 p-3 text-center transition hover:-translate-y-0.5 hover:border-primary/40 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    class="connection-db-picker-option group flex min-h-24 flex-col items-center justify-center gap-2 rounded-xl border bg-background/70 p-3 text-center transition hover:border-primary/40 hover:bg-muted/40 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     :class="selectedType === opt.value ? 'connection-db-picker-option--selected shadow-sm' : 'border-border'"
                     :aria-pressed="selectedType === opt.value"
                     @click="onDbTypeChange(opt.value)"

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -4343,8 +4343,8 @@ function openExternalUrl(url: string) {
       </DialogHeader>
 
       <template v-if="dialogStep === 'select'">
-        <div class="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-h-0 flex-1 flex-col gap-4">
+          <div class="flex flex-col gap-3 p-0.5 sm:flex-row sm:items-center sm:justify-between">
             <div class="flex items-center gap-2">
               <div class="flex shrink-0 rounded-lg border bg-muted/40 p-0.5">
                 <Button type="button" size="icon-sm" :variant="dbPickerView === 'icon' ? 'secondary' : 'ghost'" :title="t('connection.iconView')" :aria-label="t('connection.iconView')" @click="dbPickerView = 'icon'">
@@ -4380,7 +4380,7 @@ function openExternalUrl(url: string) {
               </button>
             </nav>
 
-            <div class="min-w-0 flex-1 space-y-5 overflow-y-auto pr-2">
+            <div class="min-w-0 flex-1 space-y-5 overflow-y-auto p-0.5 pr-2">
               <div v-if="isDbSearchActive" class="text-sm font-medium">{{ t("connection.searchResults") }}</div>
 
               <section v-for="category in visibleDbCategories" :key="category.key" class="space-y-2">


### PR DESCRIPTION
## Summary
- Database type cards used `hover:-translate-y-0.5`, which overflow clipped the top border in the connection dialog picker.
- The database search input focus ring was also clipped by a parent `overflow-hidden`.
- Replace the card lift with `hover:shadow-sm`, drop the unnecessary outer overflow clip, and leave padding so focus rings stay visible.

## Test plan
- [ ] Open New Connection and hover a database card in the icon picker
- [ ] Confirm the full border (including top edge) remains visible
- [ ] Focus the database search input and confirm the full border/focus ring is visible on all sides
- [ ] Confirm selected and unselected cards still show hover feedback