### PR TITLE
Fix：移除 200% 界面缩放选项

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -3479,7 +3479,7 @@ onUnmounted(cleanupPreviewEditor);
                     "
                   >
                     <SelectTrigger class="h-8 w-full">
-                      <SelectValue />
+                      <SelectValue>{{ Math.round(editUiScale * 100) }}%</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem v-for="scale in uiScaleOptions" :key="scale" :value="String(scale)" class="pl-2.5"> {{ Math.round(scale * 100) }}% </SelectItem>

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -379,7 +379,7 @@ const editToolbarItems = ref({ ...settingsStore.editorSettings.toolbarItems });
 const systemFonts = ref<string[]>([]);
 const systemFontsLoading = ref(false);
 const systemFontsLoaded = ref(false);
-const uiScaleOptions = [0.75, 0.9, 0.95, 1, 1.05, 1.1, 1.15, 1.2, 1.25, 1.5, 1.75, 2];
+const uiScaleOptions = [0.75, 0.9, 0.95, 1, 1.05, 1.1, 1.15, 1.2, 1.25, 1.5, 1.75];
 const fontSearchTriggerClass =
   "h-8 w-full max-w-none justify-between gap-1.5 rounded-[6px] border border-input bg-transparent py-2 pl-2.5 pr-2 text-sm font-normal shadow-none hover:bg-transparent focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-expanded:bg-transparent dark:bg-input/30 dark:hover:bg-input/50";
 const appearanceFontSearchTriggerClass = `${fontSearchTriggerClass} gap-0 pl-2 pr-1.5`;

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -530,6 +530,12 @@ test("normalizeEditorSettings keeps valid UI scales with two-decimal precision",
   assert.equal(normalizeEditorSettings({ uiScale: 1.125 }).uiScale, 1.13);
 });
 
+test("shows persisted UI scales that are not available as presets", () => {
+  const source = readFileSync("apps/desktop/src/components/editor/EditorSettingsDialog.vue", "utf8");
+
+  assert.match(source, /<SelectValue>\{\{ Math\.round\(editUiScale \* 100\) \}\}%<\/SelectValue>/);
+});
+
 test("defaults SQL formatter settings", () => {
   assert.deepEqual(DEFAULT_EDITOR_SETTINGS.sqlFormatter, DEFAULT_SQL_FORMATTER_SETTINGS);
   assert.deepEqual(normalizeEditorSettings({}).sqlFormatter, DEFAULT_EDITOR_SETTINGS.sqlFormatter);


### PR DESCRIPTION
## 问题

在设置中选择 `200%` 后，界面会被大幅放大。不熟悉缩放快捷键的用户可能难以重新进入设置并恢复正常比例。

## 修改

- 从界面缩放下拉选项中移除 `200%`，可选上限调整为 `175%`
- 保持默认 `100%` 和其他缩放档位不变
- 不修改底层缩放兼容范围及快捷键行为，避免影响已有保存配置

## 验证

- `pnpm check`