### PR TITLE
fix(postgres): 未设置 sslmode 时默认改回 prefer

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -5620,7 +5620,7 @@ function openExternalUrl(url: string) {
                                     ? 'catalog=paimon_catalog'
                                     : form.db_type === 'cassandra'
                                       ? 'localdatacenter=dc1'
-                                      : 'sslmode=disable'
+                                      : 'sslmode=prefer'
                       "
                     />
                   </div>

--- a/apps/desktop/src/lib/connection/__tests__/postgresTlsMode.spec.ts
+++ b/apps/desktop/src/lib/connection/__tests__/postgresTlsMode.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { postgresTlsModeForForm } from "@/lib/connection/postgresTlsMode";
 
 describe("postgresTlsModeForForm", () => {
-  it("uses disable when legacy connections have no explicit mode", () => {
-    expect(postgresTlsModeForForm(undefined, false)).toBe("disable");
+  it("uses prefer when legacy connections have no explicit mode", () => {
+    expect(postgresTlsModeForForm(undefined, false)).toBe("prefer");
   });
 
   it("keeps the legacy TLS toggle mapped to require", () => {
@@ -12,6 +12,7 @@ describe("postgresTlsModeForForm", () => {
 
   it("honors explicit modes and aliases", () => {
     expect(postgresTlsModeForForm("disable", false)).toBe("disable");
+    expect(postgresTlsModeForForm("prefer", false)).toBe("prefer");
     expect(postgresTlsModeForForm("verify_identity", false)).toBe("verify-full");
   });
 });

--- a/apps/desktop/src/lib/connection/postgresTlsMode.ts
+++ b/apps/desktop/src/lib/connection/postgresTlsMode.ts
@@ -12,7 +12,8 @@ export function postgresTlsModeForForm(value: string | undefined, ssl: boolean |
     case "verify-identity":
       return "verify-full";
     default:
-      // DBX and DBeaver expose TLS as opt-in; an absent mode must remain plaintext.
-      return ssl ? "require" : "disable";
+      // Align with libpq/JDBC: absent mode prefers TLS and can fall back to plaintext.
+      // Legacy ssl=true still maps to require.
+      return ssl ? "require" : "prefer";
   }
 }

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -3638,10 +3638,10 @@ fn native_postgres_url_config(config: &ConnectionConfig) -> Option<ConnectionCon
                         if config.ssl {
                             "sslmode=require".to_string()
                         } else {
-                            "sslmode=disable".to_string()
+                            "sslmode=prefer".to_string()
                         }
                     } else {
-                        let sslmode = if config.ssl { "sslmode=require" } else { "sslmode=disable" };
+                        let sslmode = if config.ssl { "sslmode=require" } else { "sslmode=prefer" };
                         format!("{sslmode}&{params}")
                     });
                 }
@@ -4589,11 +4589,11 @@ mod tests {
 
         assert_eq!(
             connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=disable"
+            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=prefer"
         );
         assert_eq!(
             redacted_connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://127.0.0.1:3306/postgres?sslmode=disable"
+            "postgres://127.0.0.1:3306/postgres?sslmode=prefer"
         );
     }
 
@@ -4607,11 +4607,11 @@ mod tests {
 
         assert_eq!(
             connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://root:secret@127.0.0.1:26257/defaultdb?sslmode=disable"
+            "postgres://root:secret@127.0.0.1:26257/defaultdb?sslmode=prefer"
         );
         assert_eq!(
             redacted_connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://127.0.0.1:26257/defaultdb?sslmode=disable"
+            "postgres://127.0.0.1:26257/defaultdb?sslmode=prefer"
         );
     }
 
@@ -4639,7 +4639,7 @@ mod tests {
 
         assert_eq!(
             connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=disable"
+            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=prefer"
         );
     }
 
@@ -4681,7 +4681,7 @@ mod tests {
 
         assert_eq!(
             connection_url_for_endpoint(&config, &config.host, config.port),
-            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=disable&application_name=dbx"
+            "postgres://gaussdb:secret@127.0.0.1:3306/postgres?sslmode=prefer&application_name=dbx"
         );
     }
 

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -1700,8 +1700,9 @@ fn normalize_postgres_url_params(value: &str, force_tls: bool) -> String {
 
     if connection_options.is_empty() {
         if !parts.iter().any(|part| url_param_key_is(part, "sslmode")) {
-            // TLS is opt-in in the connection form; avoid tokio-postgres' implicit prefer mode.
-            parts.insert(0, if force_tls { "sslmode=require" } else { "sslmode=disable" }.to_string());
+            // Match libpq/JDBC: absent mode prefers TLS and falls back to plaintext.
+            // Explicit ssl toggle still forces require; users can opt into disable.
+            parts.insert(0, if force_tls { "sslmode=require" } else { "sslmode=prefer" }.to_string());
         }
         return parts.join("&");
     }
@@ -1729,7 +1730,7 @@ fn normalize_postgres_url_params(value: &str, force_tls: bool) -> String {
     }
 
     if !parts.iter().any(|part| url_param_key_is(part, "sslmode")) {
-        parts.insert(0, if force_tls { "sslmode=require" } else { "sslmode=disable" }.to_string());
+        parts.insert(0, if force_tls { "sslmode=require" } else { "sslmode=prefer" }.to_string());
     }
 
     parts.join("&")
@@ -2120,7 +2121,7 @@ mod tests {
 
         config.db_type = DatabaseType::Postgres;
         assert_eq!(config.effective_database(), Some(" analytics "));
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20?sslmode=disable");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/%20analytics%20?sslmode=prefer");
     }
 
     #[test]
@@ -2681,11 +2682,11 @@ mod tests {
     }
 
     #[test]
-    fn postgres_url_disables_tls_by_default() {
+    fn postgres_url_prefers_tls_by_default() {
         let mut config = mysql_config("postgres", "secret", Some("test"));
         config.db_type = DatabaseType::Postgres;
 
-        assert_eq!(config.connection_url(), "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=disable");
+        assert_eq!(config.connection_url(), "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=prefer");
     }
 
     #[test]
@@ -2719,7 +2720,7 @@ mod tests {
 
         assert_eq!(
             config.connection_url(),
-            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=disable&options=%2Dc%20search%5Fpath%3Dpublic"
+            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=prefer&options=%2Dc%20search%5Fpath%3Dpublic"
         );
         let pg_config = tokio_postgres::Config::from_str(&config.connection_url()).unwrap();
         assert_eq!(pg_config.get_options(), Some("-c search_path=public"));
@@ -2733,7 +2734,7 @@ mod tests {
 
         assert_eq!(
             config.connection_url(),
-            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=disable&options=%2Dc%20search%5Fpath%3Dapp"
+            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=prefer&options=%2Dc%20search%5Fpath%3Dapp"
         );
         let pg_config = tokio_postgres::Config::from_str(&config.connection_url()).unwrap();
         assert_eq!(pg_config.get_options(), Some("-c search_path=app"));
@@ -2767,7 +2768,7 @@ mod tests {
 
         assert_eq!(
             config.connection_url(),
-            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=disable&options=%2Dc%20statement%5Ftimeout%3D5000%20%2Dc%20TimeZone%3DUTC"
+            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=prefer&options=%2Dc%20statement%5Ftimeout%3D5000%20%2Dc%20TimeZone%3DUTC"
         );
     }
 
@@ -2779,7 +2780,7 @@ mod tests {
 
         assert_eq!(
             config.connection_url(),
-            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=disable&options=-c%20TimeZone%3DUTC"
+            "postgres://postgres:secret@10.1.2.3:2883/test?sslmode=prefer&options=-c%20TimeZone%3DUTC"
         );
     }
 
@@ -2788,7 +2789,7 @@ mod tests {
         let mut config = mysql_config("root", "secret", None);
         config.db_type = DatabaseType::Postgres;
 
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/postgres?sslmode=disable");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/postgres?sslmode=prefer");
     }
 
     #[test]
@@ -2796,7 +2797,7 @@ mod tests {
         let mut config = mysql_config("root", "secret", Some(""));
         config.db_type = DatabaseType::Postgres;
 
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/postgres?sslmode=disable");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/postgres?sslmode=prefer");
     }
 
     #[test]
@@ -2804,7 +2805,7 @@ mod tests {
         let mut config = mysql_config("awsuser", "secret", Some(""));
         config.db_type = DatabaseType::Redshift;
 
-        assert_eq!(config.connection_url(), "postgres://awsuser:secret@10.1.2.3:2883/dev?sslmode=disable");
+        assert_eq!(config.connection_url(), "postgres://awsuser:secret@10.1.2.3:2883/dev?sslmode=prefer");
     }
 
     #[test]
@@ -2813,7 +2814,7 @@ mod tests {
         config.db_type = DatabaseType::Postgres;
         config.driver_profile = Some("cockroachdb".to_string());
 
-        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/defaultdb?sslmode=disable");
+        assert_eq!(config.connection_url(), "postgres://root:secret@10.1.2.3:2883/defaultdb?sslmode=prefer");
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

v0.5.60 起（`c4068343`）将 PostgreSQL 未显式设置 `sslmode` 时的默认从隐式 `prefer` 改为强制 `disable`，导致：
- `pg_hba.conf` 仅允许 SSL（`hostssl`）的服务器报 `no encryption`（见 #3928）
- 经 jumpserver 等代理的 PG 协议库可能超时（见 #4255）
- 存量连接大多未保存 `sslmode`，升级后批量中招

本次将缺省改回与 libpq/JDBC 一致的 `prefer`（先尝试 TLS，不支持再退明文）：
- Postgres / Redshift URL 构建默认 `sslmode=prefer`
- GaussDB / KWDB 转原生驱动时默认同步为 `prefer`
- 连接表单缺省 TLS 模式显示「优先使用」
- 显式 `require` / `disable` / 用户手写 URL 参数行为不变

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

连接对话框：
- TLS 模式缺省由「禁用」改为「优先使用」
- URL 参数占位符示例由 `sslmode=disable` 改为 `sslmode=prefer`（仅提示，不强制写入）

本地可验证：
1. 新建 Postgres 连接不填 sslmode、不手开 SSL，连 `hostssl` 强制加密库应可成功
2. 纯明文 Postgres 仍可连接（prefer 自动退回）
3. 显式选择「禁用 / 必须使用」行为与改前一致
4. URL 参数手写 `sslmode=require` 等仍生效，并与 TLS 模式下拉同步

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关功能本地验证通过

补充覆盖：
- `cargo test -p dbx-core --lib prefers_tls_by_default` / `endpoint_url_uses_postgres` / `models::connection::tests::postgres_` 相关用例通过
- `pnpm vitest run apps/desktop/src/lib/connection/__tests__/postgresTlsMode.spec.ts`（3 tests passed）

## 关联 Issue

Closes #4273
Closes #3928