### PR TITLE
fix(clickhouse): 跨库查询时查询结果字段注释丢失

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -631,11 +631,14 @@ async fn duckdb_attached_database_names(state: &AppState, connection_id: &str) -
     state.configs.read().await.get(connection_id).map(crate::db::duckdb_sql::config_attached_names).unwrap_or_default()
 }
 
+// ClickHouse 无 schema 概念：schema 参数携带 SQL 中 `库.表` 限定的目标库，
+// database 参数是 tab/连接的当前库。与 mysql_table_metadata_catalog 一致，
+// schema 非空时必须优先，否则跨库查询会在当前库下查不到元数据（字段注释丢失）
 fn clickhouse_metadata_database<'a>(database: &'a str, schema: &'a str) -> &'a str {
-    if database.is_empty() {
-        schema
-    } else {
+    if schema.trim().is_empty() {
         database
+    } else {
+        schema
     }
 }
 
@@ -3379,10 +3382,11 @@ mod tests {
     }
 
     #[test]
-    fn clickhouse_metadata_uses_schema_when_database_is_empty() {
+    fn clickhouse_metadata_prefers_schema_qualifier() {
         assert_eq!(clickhouse_metadata_database("", "testdb"), "testdb");
         assert_eq!(clickhouse_metadata_database("testdb", ""), "testdb");
-        assert_eq!(clickhouse_metadata_database("default", "testdb"), "default");
+        // 查询元数据流程：database 是 tab 当前库，schema 是 SQL 限定的真实库
+        assert_eq!(clickhouse_metadata_database("default", "testdb"), "testdb");
     }
 
     #[test]


### PR DESCRIPTION
## 问题描述

ClickHouse 数据源在 SQL 编辑器中执行跨库查询（如当前库为 `default`，执行 `SELECT * FROM dbx.user_stats`）时，查询结果表头不展示字段注释——表字段实际有注释，且左侧表数据预览能正常展示。

同样写法在 MySQL 数据源下表现正常。已在 ClickHouse 21 和 24 版本上复现，与服务端版本无关。

## 原因分析

查询结果的列元数据由后台补齐流程通过 `get_columns` 获取。前端传参约定：`database` 为编辑器 tab 当前库，`schema` 携带 SQL 中 `库.表` 限定的真实目标库。

- MySQL 分支的 `mysql_table_metadata_catalog`（schema.rs）在 schema 非空时优先取 schema，行为正确；
- ClickHouse 分支的 `clickhouse_metadata_database`（schema.rs）却优先取 database，跨库查询时会到 tab 当前库下查 `system.columns`，查不到目标表 → 返回空列 → 字段注释丢失。

## 修改内容

- `clickhouse_metadata_database` 改为与 MySQL 分支一致的「schema 非空时优先 schema，否则回退 database」。该函数被 ClickHouse 的取列、表清单、DDL、对象统计四处元数据入口共用，一处修复全部生效（桌面端 / Web / CLI）；
- 同步更新单元测试 `clickhouse_metadata_prefers_schema_qualifier` 的断言。

## 测试验证

- `cargo test -p dbx-core --no-default-features --lib`：schema 及相关模块单测全部通过；
- 端到端验证（前端 queryStore 完整流程 + dbx-web 后端 + 真实 ClickHouse 24.8 / 21.9 Docker 实例，表字段带中文注释）：
  - tab 在表所在库、SQL 不限定库名：修复前后均正常；
  - tab 在表所在库、SQL 用 `库.表` 限定：修复前后均正常；
  - tab 在其他库、SQL 用 `库.表` 限定：修复前无注释，修复后注释正常展示。

## 截图对比

修复前（上：tab 在 `dbx` 库时注释正常；下：tab 切到 `default` 库后同一 SQL 注释丢失）：

![修复前](https://raw.githubusercontent.com/Staroon/dbx/assets/clickhouse-metadata-fix/clickhouse-metadata-fix-before.png)

修复后（tab 在 `default` 库执行 `select * from dbx.user_stats`，注释正常展示）：

![修复后](https://raw.githubusercontent.com/Staroon/dbx/assets/clickhouse-metadata-fix/clickhouse-metadata-fix-after.png)

## 数据库验证环境

- ClickHouse 24.8.14.39（`make db DB=clickhouse@24.8`）
- ClickHouse 21.9.6.24（Docker）
