### PR TITLE
fix(clickhouse): handle system.settings pagination

### DIFF
--- a/crates/dbx-core/src/query_result_sql.rs
+++ b/crates/dbx-core/src/query_result_sql.rs
@@ -8,7 +8,7 @@ use crate::sql_dialect::{
     firebird_rows_clause, pagination_strategy, quote_table_identifier, PaginationContext, TablePaginationStrategy,
 };
 use sqlparser::ast::{Expr, GroupByExpr, SelectItem, SetExpr, Statement};
-use sqlparser::dialect::{GenericDialect, MsSqlDialect};
+use sqlparser::dialect::{ClickHouseDialect, GenericDialect, MsSqlDialect};
 use sqlparser::parser::Parser;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1015,10 +1015,7 @@ fn add_outer_standard_limit(
 
 fn add_clickhouse_limit(statement: &str, limit_sql: &str) -> String {
     let limit_sql = limit_sql.trim();
-    let settings_index = top_level_sql_tokens(statement)
-        .iter()
-        .find(|token| token.text == "SETTINGS" && !is_qualified_identifier_part(statement, token))
-        .map(|token| token.start);
+    let settings_index = clickhouse_settings_clause_index(statement);
 
     if let Some(index) = settings_index {
         let statement_before_settings = statement[..index].trim_end();
@@ -1027,6 +1024,25 @@ fn add_clickhouse_limit(statement: &str, limit_sql: &str) -> String {
     }
 
     append_sql_suffix(statement, &format!("{limit_sql};"))
+}
+
+fn clickhouse_settings_clause_index(statement: &str) -> Option<usize> {
+    let parsed_settings = Parser::parse_sql(&ClickHouseDialect {}, statement).ok().and_then(|statements| {
+        let [Statement::Query(query)] = statements.as_slice() else {
+            return None;
+        };
+        Some(query.settings.is_some())
+    });
+    if parsed_settings == Some(false) {
+        return None;
+    }
+
+    // Keep the lexical fallback for valid ClickHouse syntax that sqlparser does not yet support.
+    top_level_sql_tokens(statement)
+        .iter()
+        .rev()
+        .find(|token| token.text == "SETTINGS" && !is_qualified_identifier_part(statement, token))
+        .map(|token| token.start)
 }
 
 fn is_qualified_identifier_part(sql: &str, token: &SqlToken) -> bool {
@@ -1837,6 +1853,35 @@ WHERE u.id = picked.id;
 
         assert!(result.ok);
         assert_eq!(result.sql.unwrap(), "SELECT * FROM system.settings LIMIT 100;");
+    }
+
+    #[test]
+    fn clickhouse_settings_identifier_is_not_treated_as_settings_clause() {
+        let result = build_paginated_query_sql(PaginatedQuerySqlOptions {
+            original_sql: "SELECT settings FROM (SELECT 1 AS settings)".to_string(),
+            database_type: Some(DatabaseType::ClickHouse),
+            limit: 100,
+            offset: 0,
+        });
+
+        assert!(result.ok);
+        assert_eq!(result.sql.unwrap(), "SELECT settings FROM (SELECT 1 AS settings) LIMIT 100;");
+    }
+
+    #[test]
+    fn clickhouse_settings_identifier_keeps_trailing_settings_clause() {
+        let result = build_paginated_query_sql(PaginatedQuerySqlOptions {
+            original_sql: "SELECT settings FROM (SELECT 1 AS settings) SETTINGS max_threads = 1".to_string(),
+            database_type: Some(DatabaseType::ClickHouse),
+            limit: 100,
+            offset: 0,
+        });
+
+        assert!(result.ok);
+        assert_eq!(
+            result.sql.unwrap(),
+            "SELECT settings FROM (SELECT 1 AS settings) LIMIT 100 SETTINGS max_threads = 1;"
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/query_result_sql.rs
+++ b/crates/dbx-core/src/query_result_sql.rs
@@ -1015,8 +1015,10 @@ fn add_outer_standard_limit(
 
 fn add_clickhouse_limit(statement: &str, limit_sql: &str) -> String {
     let limit_sql = limit_sql.trim();
-    let settings_index =
-        top_level_sql_tokens(statement).iter().find(|token| token.text == "SETTINGS").map(|token| token.start);
+    let settings_index = top_level_sql_tokens(statement)
+        .iter()
+        .find(|token| token.text == "SETTINGS" && !is_qualified_identifier_part(statement, token))
+        .map(|token| token.start);
 
     if let Some(index) = settings_index {
         let statement_before_settings = statement[..index].trim_end();
@@ -1025,6 +1027,12 @@ fn add_clickhouse_limit(statement: &str, limit_sql: &str) -> String {
     }
 
     append_sql_suffix(statement, &format!("{limit_sql};"))
+}
+
+fn is_qualified_identifier_part(sql: &str, token: &SqlToken) -> bool {
+    let token_end = token.start + token.text.len();
+    sql[..token.start].chars().rev().find(|ch| !ch.is_whitespace()) == Some('.')
+        || sql[token_end..].chars().find(|ch| !ch.is_whitespace()) == Some('.')
 }
 
 fn derived_table_sql(prefix: &str, statement: &str, suffix: &str) -> String {
@@ -1816,6 +1824,19 @@ WHERE u.id = picked.id;
             result.sql.unwrap(),
             "SELECT * FROM system.clusters LIMIT 50 OFFSET 100 SETTINGS max_execution_time = 0;"
         );
+    }
+
+    #[test]
+    fn clickhouse_settings_table_is_not_treated_as_settings_clause() {
+        let result = build_paginated_query_sql(PaginatedQuerySqlOptions {
+            original_sql: "SELECT * FROM system.settings".to_string(),
+            database_type: Some(DatabaseType::ClickHouse),
+            limit: 100,
+            offset: 0,
+        });
+
+        assert!(result.ok);
+        assert_eq!(result.sql.unwrap(), "SELECT * FROM system.settings LIMIT 100;");
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复 ClickHouse 中直接执行 `SELECT * FROM system.settings` 时，分页 SQL 生成错误的问题。

原有逻辑将限定表名中的 `settings` 误判为 ClickHouse `SETTINGS` 子句，生成了类似下面的错误 SQL：

```sql
SELECT * FROM system. LIMIT 100 settings;
```

本次修改在识别 `SETTINGS` 子句时排除点号限定标识符，使 SQL 正确生成为：

```sql
SELECT * FROM system.settings LIMIT 100;
```

同时保留真实 `SETTINGS` 子句的处理逻辑，分页子句仍会插入到 `SETTINGS max_execution_time = 0` 之前。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 不涉及前端改动。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo test -p dbx-core --no-default-features query_result_sql::tests --lib`（92 项通过）
- `cargo check -p dbx-core --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## 关联 Issue

Close #4315
