### PR TITLE
build(release): pin glibc 2.31 via cargo-zigbuild for Linux targets

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -297,9 +297,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfontconfig1-dev
 
+      - name: Install zig for glibc-2.31 Linux builds
+        if: runner.os == 'Linux'
+        uses: mlugg/setup-zig@v2
+
+      - name: Install cargo-zigbuild
+        if: runner.os == 'Linux'
+        run: cargo install cargo-zigbuild --locked
+
       - name: Build Rust CLI binary
         shell: bash
-        run: cargo build --release -p dbx-cli --no-default-features --target "${{ matrix.target }}"
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # 用 zig 作为链接器把 glibc 目标压到 2.31，覆盖 Deepin 23 / Debian 12 /
+            # Ubuntu 22.04 等老 glibc 系统；非 Linux 平台走原生的 cargo build。
+            ZIG_GLIBC=2.31 cargo zigbuild --release -p dbx-cli --no-default-features --target "${{ matrix.target }}"
+          else
+            cargo build --release -p dbx-cli --no-default-features --target "${{ matrix.target }}"
+          fi
 
       - name: Stage platform package
         shell: bash
@@ -472,9 +487,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfontconfig1-dev
 
+      - name: Install zig for glibc-2.31 Linux builds
+        if: runner.os == 'Linux'
+        uses: mlugg/setup-zig@v2
+
+      - name: Install cargo-zigbuild
+        if: runner.os == 'Linux'
+        run: cargo install cargo-zigbuild --locked
+
       - name: Build Rust MCP binary
         shell: bash
-        run: cargo build --release -p dbx-mcp --target "${{ matrix.target }}"
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            # 用 zig 作为链接器把 glibc 目标压到 2.31，覆盖 Deepin 23 / Debian 12 /
+            # Ubuntu 22.04 等老 glibc 系统；非 Linux 平台走原生的 cargo build。
+            ZIG_GLIBC=2.31 cargo zigbuild --release -p dbx-mcp --target "${{ matrix.target }}"
+          else
+            cargo build --release -p dbx-mcp --target "${{ matrix.target }}"
+          fi
 
       - name: Stage platform package
         shell: bash


### PR DESCRIPTION
## 背景
当前 `mcp-release.yml` 直接用宿主 glibc 链接，runner (Ubuntu 24.04, glibc 2.39) 产出的二进制在 Deepin 23 / Debian 12 / Ubuntu 22.04 (glibc 2.36) 等老系统上会报 `GLIBC_2.34 not found`，用户必须升级 libc 才能跑。

## 方案
Linux 矩阵任务改用 `cargo-zigbuild` + `ZIG_GLIBC=2.31`，由 zig 自带的 glibc 2.31 作为链接器，把 dbx-cli / dbx-mcp 的发布二进制锁到 glibc 2.31，覆盖主流较老的发行版；非 Linux 平台保持原生 `cargo build` 不变。

## 变更
- 新增 `Install zig for glibc-2.31 Linux builds` 步骤（`mlugg/setup-zig@v2`，仅 Linux runner）
- 新增 `Install cargo-zigbuild` 步骤（`cargo install cargo-zigbuild --locked`，仅 Linux runner）
- `Build Rust CLI binary` / `Build Rust MCP binary`：在 Linux 上条件分支，调用 `cargo zigbuild` 并设置 `ZIG_GLIBC=2.31`；其余平台走 `cargo build`

## 影响
- 仅影响 Linux 产物；macOS / Windows 行为不变
- zig 工具链与 `cargo-zigbuild` 通过 `mlugg/setup-zig` 与 `cargo install` 获取，构建时间会略增
- 二进制可在 glibc ≥ 2.31 的 Linux 发行版直接运行