### PR TITLE
fix(connection): add overflow-visible to search input in database picker

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -4355,7 +4355,7 @@ function openExternalUrl(url: string) {
                   <List class="h-3.5 w-3.5" />
                 </Button>
               </div>
-              <div class="relative w-full sm:w-64">
+              <div class="relative w-full overflow-visible sm:w-64">
                 <Search class="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                 <Input v-model="dbSearchQuery" class="h-9 pl-8" :placeholder="t('connection.searchDatabasePlaceholder')" />
               </div>


### PR DESCRIPTION
## Summary

Fix search input focus ring clipping in the New Connection dialog.

## Related Issue

Fixes #4262

## Changes

After rebasing on latest `main`, most of the original clipping issues (hover border, toolbar padding) have already been fixed upstream. The remaining fix:

- **Search input wrapper** (`overflow-visible`): The focus ring (`focus-visible:ring`) on the database type search input was being clipped by the parent `overflow-hidden` container.

## Testing

- `pnpm lint` passes (0 errors)
- Visual verification: search input focus ring renders fully without clipping at the top

## Screenshots

Before: Search input shadow/focus ring clipped at top
After: Focus ring renders correctly