### PR TITLE
Fix：避免 GaussDB 嵌套过程体被提前分句

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -71,6 +71,15 @@ BEGIN
    SELECT 1 + 2 INTO PRE_TRD_DATE FROM DUAL;
 END;`;
 
+const gaussDbNestedProcedure = `CREATE OR REPLACE PROCEDURE public.dbx_issue_4318()
+AS
+BEGIN
+  BEGIN
+    NULL;
+  END;
+  NULL;
+END;`;
+
 const mysqlRoutineFixture = `CREATE PROCEDURE p()
 BEGIN
   SELECT 1;
@@ -208,6 +217,10 @@ describe("splitSqlStatementRanges", () => {
 
   it("keeps issue #2405 Oracle PL/SQL block together without a slash delimiter", () => {
     expect(rangeSqlTexts(splitSqlStatementRanges(oracleIssue2405PlSql, "oracle"))).toEqual([oracleIssue2405PlSql]);
+  });
+
+  it("keeps nested GaussDB procedure blocks together", () => {
+    expect(rangeSqlTexts(splitSqlStatementRanges(gaussDbNestedProcedure, "gaussdb"))).toEqual([gaussDbNestedProcedure]);
   });
 
   it("keeps SAP HANA DO blocks together", () => {
@@ -718,6 +731,11 @@ WHERE request_json LIKE '%"paperFlag":null%';`;
     for (const cursor of [indexOf(oracleIssue2405PlSql, "PRE_TRD_DATE"), indexOf(oracleIssue2405PlSql, "SELECT 1 + 2"), indexOf(oracleIssue2405PlSql, "END;")]) {
       expect(statementRangeAtCursor(oracleIssue2405PlSql, cursor, "oracle")?.sql.trim()).toBe(oracleIssue2405PlSql);
     }
+  });
+
+  it("returns the full GaussDB procedure for cursors after a nested block", () => {
+    const outerNull = indexOf(gaussDbNestedProcedure, "NULL;", 2);
+    expect(statementRangeAtCursor(gaussDbNestedProcedure, outerNull, "gaussdb")?.sql.trim()).toBe(gaussDbNestedProcedure);
   });
 
   it("returns the full SAP HANA DO block for cursors inside nested statements", () => {

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -1669,14 +1669,15 @@ function oraclePlSqlBlockIsComplete(sql: string): boolean {
     if (token.kind !== "word") continue;
 
     if (token.value === "DECLARE") {
-      stack.push("BLOCK");
+      stack.push("DECLARATION");
       continue;
     }
     if (token.value === "BEGIN") {
       if (tokens[index - 1]?.kind === "word" && tokens[index - 1]?.value === "TRANSACTION") continue;
       const previous = previousWordToken(tokens, index);
       if (previous === "END") continue;
-      if (stack[stack.length - 1] !== "BLOCK") stack.push("BLOCK");
+      if (stack[stack.length - 1] === "DECLARATION") stack[stack.length - 1] = "BLOCK";
+      else stack.push("BLOCK");
       continue;
     }
     if (token.value === "IF") {


### PR DESCRIPTION
## 问题

GaussDB 的存储过程包含嵌套 `BEGIN ... END` 块时，前端 PL/SQL 分句器会把连续的 `BEGIN` 视为同一层。内层 `END;` 因此被误判为整个过程结束，执行范围会被拆成：

1. 截止到内层 `END;` 的不完整 `CREATE PROCEDURE`
2. 外层剩余语句
3. 外层 `END`

第一段发送到 GaussDB 后会返回 issue 中相同的错误：

```text
ERROR: subprogram body is not ended correctly at end of input
```

## 修改

- 在 Oracle-like PL/SQL 块状态中区分“声明阶段”和已进入的 `BEGIN` 块。
- `DECLARE ... BEGIN` 仍作为同一层处理。
- 已处于执行块时遇到新的 `BEGIN` 会建立真正的嵌套层级，只有对应外层 `END;` 才结束整个过程。
- 增加 GaussDB 嵌套过程的分句和光标执行范围回归测试。

## 真实验证

使用 `openGauss-lite 5.0.3`（GaussDB/openGauss 兼容路径）和 DBX 真实执行接口验证：

- 完整嵌套过程可直接创建、调用和删除。
- 修复前，DBX 前端生成的第一执行范围截止于内层 `END;`，服务端复现 `subprogram body is not ended correctly`。
- 修复后，浏览器加载当前分支的实际分句模块得到 `rangeCount = 1`。
- 仅提交该第一执行范围，DBX 返回 HTTP 200，过程创建成功。
- 通过 DBX 调用和删除过程均成功，数据库残留对象数为 0。

## 自动化验证

```text
sqlStatementRanges.spec.ts: 127 passed
format: passed
lint: passed
typecheck: passed
```

本机全量 Vitest 在高负载下有无关的固定 5 秒超时和性能阈值失败；本次相关测试全部通过。GitHub `frontend` CI 已在独立 runner 上全量通过。

Fixes #4318