### PR TITLE
Fix：修复(日语)普通表格总行数错误显示为至少

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -308,8 +308,10 @@ interface DataGridProps {
 }
 
 const props = withDefaults(defineProps<DataGridProps>(), {
-  // Vue casts absent Boolean props to false unless the default is explicitly
-  // undefined; omitted row-action limits must keep normal table-data editing.
+  // Vue casts absent Boolean props to false unless a default is explicit.
+  // Regular grids have exact totals; document stores opt into lower-bound totals.
+  totalRowCountIsExact: true,
+  // Omitted row-action limits must keep normal table-data editing.
   allowInsertRows: undefined,
   allowDeleteRows: undefined,
 });

--- a/apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import DataGrid from "../DataGrid.vue";
+
+type VuePropDefinition = { default?: unknown };
+type VueComponentWithProps = { props?: Record<string, VuePropDefinition> };
+
+describe("DataGrid total row count exactness", () => {
+  it("treats totals as exact unless a caller explicitly marks them as a lower bound", () => {
+    const component = DataGrid as unknown as VueComponentWithProps;
+    expect(component.props?.totalRowCountIsExact?.default).toBe(true);
+  });
+});


### PR DESCRIPTION
## 问题

#4274 为 Elasticsearch 下限总数增加了“至少 N 条”状态，但 `totalRowCountIsExact` 是可选 Boolean prop。Vue 会将未传入的 Boolean prop 自动转换为 `false`，导致普通查询结果和表数据页面也被误判为下限总数。

日语界面因此把原本的 `全 N 件` 错误显示成 `少なくとも N 件`，其他语言也会出现对应的“至少”文案。

## 修改

- 在共享 DataGrid 中显式将 `totalRowCountIsExact` 默认设为 `true`
- 所有未声明精确度的数据库类型和结果表格继续按精确总数展示
- Elasticsearch 文档浏览器明确传入 `false` 时，仍保留“至少 N 条”的下限语义
- 增加组件级回归测试，检查 Vue 编译后的 prop 默认值

## 验证

- `pnpm exec vitest run apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts`
- `pnpm check`
  - format
  - lint
  - typecheck
  - test