### PR TITLE
Fix: 保留 SQL Server 旧版兼容模式的升级设置

### DIFF
--- a/apps/desktop/src/lib/__tests__/connection/sqlServerLegacyCompatibility.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/sqlServerLegacyCompatibility.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { isSqlServerNativeEncryptionDisabled, requiresSqlServerLegacyCompatibilityComponent, setSqlServerLegacyCompatibilityConfig, setSqlServerNativeEncryptionDisabled, sqlServerUsesLegacyCompatibility } from "@/lib/connection/sqlServerLegacyCompatibility";
+import {
+  isSqlServerNativeEncryptionDisabled,
+  migrateSqlServerLegacyCompatibilityConfig,
+  requiresSqlServerLegacyCompatibilityComponent,
+  setSqlServerLegacyCompatibilityConfig,
+  setSqlServerNativeEncryptionDisabled,
+  sqlServerUsesLegacyCompatibility,
+} from "@/lib/connection/sqlServerLegacyCompatibility";
 import type { ConnectionConfig } from "@/types/database";
 
 function connectionConfig(urlParams?: string): ConnectionConfig {
@@ -37,11 +44,14 @@ describe("SQL Server legacy compatibility", () => {
     expect(setSqlServerNativeEncryptionDisabled("applicationName=dbx;sqlserverEncryption=disabled", false)).toBe("applicationName=dbx");
   });
 
-  it("keeps historical disabled-encryption connections on the native driver", () => {
+  it("migrates historical disabled-encryption connections to the legacy driver profile", () => {
     const config = connectionConfig("sqlserverEncryption=disabled");
+    migrateSqlServerLegacyCompatibilityConfig(config);
 
-    expect(sqlServerUsesLegacyCompatibility(config)).toBe(false);
-    expect(requiresSqlServerLegacyCompatibilityComponent(config)).toBe(false);
+    expect(sqlServerUsesLegacyCompatibility(config)).toBe(true);
+    expect(requiresSqlServerLegacyCompatibilityComponent(config)).toBe(true);
+    expect(config.driver_label).toBe("SQL Server legacy compatibility component");
+    expect(config.url_params).toBe("");
     expect(
       requiresSqlServerLegacyCompatibilityComponent({
         ...config,
@@ -49,6 +59,24 @@ describe("SQL Server legacy compatibility", () => {
         db_type: "mysql",
       }),
     ).toBe(false);
+  });
+
+  it("preserves unrelated params while migrating the historical compatibility flag", () => {
+    const config = connectionConfig("applicationName=dbx;sqlserverEncryption=off;encrypt=false");
+
+    migrateSqlServerLegacyCompatibilityConfig(config);
+
+    expect(config.driver_profile).toBe("sqlserver-legacy");
+    expect(config.url_params).toBe("applicationName=dbx&encrypt=false");
+  });
+
+  it("keeps generic JDBC encrypt=false on the native driver", () => {
+    const config = connectionConfig("applicationName=dbx;encrypt=false");
+
+    migrateSqlServerLegacyCompatibilityConfig(config);
+
+    expect(config.driver_profile).toBe("sqlserver");
+    expect(config.url_params).toBe("applicationName=dbx;encrypt=false");
   });
 
   it("treats a persisted legacy driver profile as compatibility mode", () => {

--- a/apps/desktop/src/lib/__tests__/connection/sqlServerLegacyCompatibility.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/sqlServerLegacyCompatibility.spec.ts
@@ -70,6 +70,15 @@ describe("SQL Server legacy compatibility", () => {
     expect(config.url_params).toBe("applicationName=dbx&encrypt=false");
   });
 
+  it("preserves special characters in unrelated params during migration", () => {
+    const config = connectionConfig("applicationName={DBX Client};password=50%;sqlserverEncryption=disabled;encrypt=false");
+
+    migrateSqlServerLegacyCompatibilityConfig(config);
+
+    expect(config.driver_profile).toBe("sqlserver-legacy");
+    expect(config.url_params).toBe("applicationName={DBX Client}&password=50%&encrypt=false");
+  });
+
   it("keeps generic JDBC encrypt=false on the native driver", () => {
     const config = connectionConfig("applicationName=dbx;encrypt=false");
 

--- a/apps/desktop/src/lib/__tests__/connection/sqlServerLegacyCompatibility.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/sqlServerLegacyCompatibility.spec.ts
@@ -67,16 +67,24 @@ describe("SQL Server legacy compatibility", () => {
     migrateSqlServerLegacyCompatibilityConfig(config);
 
     expect(config.driver_profile).toBe("sqlserver-legacy");
-    expect(config.url_params).toBe("applicationName=dbx&encrypt=false");
+    expect(config.url_params).toBe("applicationName=dbx;encrypt=false");
   });
 
-  it("preserves special characters in unrelated params during migration", () => {
-    const config = connectionConfig("applicationName={DBX Client};password=50%;sqlserverEncryption=disabled;encrypt=false");
+  it("preserves semicolons and special characters inside braced values during migration", () => {
+    const config = connectionConfig("applicationName={DBX; Client};password=50%;sqlserverEncryption=disabled;encrypt=false");
 
     migrateSqlServerLegacyCompatibilityConfig(config);
 
     expect(config.driver_profile).toBe("sqlserver-legacy");
-    expect(config.url_params).toBe("applicationName={DBX Client}&password=50%&encrypt=false");
+    expect(config.url_params).toBe("applicationName={DBX; Client};password=50%;encrypt=false");
+  });
+
+  it("keeps escaped closing braces from exposing separators inside braced values", () => {
+    const config = connectionConfig("applicationName={DBX}}; Client};sqlserverEncryption=disabled;encrypt=false");
+
+    migrateSqlServerLegacyCompatibilityConfig(config);
+
+    expect(config.url_params).toBe("applicationName={DBX}}; Client};encrypt=false");
   });
 
   it("keeps generic JDBC encrypt=false on the native driver", () => {

--- a/apps/desktop/src/lib/connection/sqlServerLegacyCompatibility.ts
+++ b/apps/desktop/src/lib/connection/sqlServerLegacyCompatibility.ts
@@ -31,32 +31,60 @@ export function setSqlServerNativeEncryptionDisabled(params: string | undefined,
   return parsed.toString();
 }
 
-function isSqlServerLegacyCompatibilitySetting(params: string | undefined): boolean {
-  return (params || "")
+interface SqlServerJdbcParamPart {
+  separator: "" | "&" | ";";
+  value: string;
+}
+
+function splitSqlServerJdbcParams(params: string | undefined): SqlServerJdbcParamPart[] {
+  const source = (params || "").trim().replace(/^\?/, "");
+  const parts: SqlServerJdbcParamPart[] = [];
+  let separator: SqlServerJdbcParamPart["separator"] = "";
+  let start = 0;
+  let inBraces = false;
+
+  // SQL Server JDBC values use braces to contain separators and `}}` to escape a closing brace.
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (inBraces) {
+      if (char === "}" && source[index + 1] === "}") {
+        index += 1;
+      } else if (char === "}") {
+        inBraces = false;
+      }
+    } else if (char === "{") {
+      inBraces = true;
+    } else if (char === "&" || char === ";") {
+      parts.push({ separator, value: source.slice(start, index) });
+      separator = char;
+      start = index + 1;
+    }
+  }
+
+  parts.push({ separator, value: source.slice(start) });
+  return parts;
+}
+
+function isSqlServerLegacyCompatibilityPart(part: string): boolean {
+  const separatorIndex = part.indexOf("=");
+  if (separatorIndex < 0) return false;
+  const key = part.slice(0, separatorIndex).trim().toLowerCase();
+  const value = part
+    .slice(separatorIndex + 1)
     .trim()
-    .replace(/^\?/, "")
-    .split(/[&;]/)
-    .some((part) => {
-      const separatorIndex = part.indexOf("=");
-      if (separatorIndex < 0) return false;
-      const key = part.slice(0, separatorIndex).trim().toLowerCase();
-      const value = part
-        .slice(separatorIndex + 1)
-        .trim()
-        .toLowerCase();
-      return key === "sqlserverencryption" && SQLSERVER_ENCRYPTION_DISABLED_VALUES.has(value);
-    });
+    .toLowerCase();
+  return key === "sqlserverencryption" && SQLSERVER_ENCRYPTION_DISABLED_VALUES.has(value);
+}
+
+function isSqlServerLegacyCompatibilitySetting(params: string | undefined): boolean {
+  return splitSqlServerJdbcParams(params).some((part) => isSqlServerLegacyCompatibilityPart(part.value));
 }
 
 function removeSqlServerLegacyCompatibilitySetting(params: string | undefined): string {
-  // Preserve raw JDBC values because the legacy agent does not URL-decode properties.
-  return (params || "")
-    .trim()
-    .replace(/^\?/, "")
-    .split(/[&;]/)
-    .map((part) => part.trim())
-    .filter((part) => part && !isSqlServerLegacyCompatibilitySetting(part))
-    .join("&");
+  return splitSqlServerJdbcParams(params)
+    .filter((part) => part.value.trim() && !isSqlServerLegacyCompatibilityPart(part.value))
+    .map((part, index) => `${index === 0 ? "" : part.separator}${part.value}`)
+    .join("");
 }
 
 export function sqlServerUsesLegacyCompatibility(config: Pick<ConnectionConfig, "db_type" | "driver_profile">): boolean {

--- a/apps/desktop/src/lib/connection/sqlServerLegacyCompatibility.ts
+++ b/apps/desktop/src/lib/connection/sqlServerLegacyCompatibility.ts
@@ -32,22 +32,31 @@ export function setSqlServerNativeEncryptionDisabled(params: string | undefined,
 }
 
 function isSqlServerLegacyCompatibilitySetting(params: string | undefined): boolean {
-  const normalized = (params || "").trim().replace(/^\?/, "").replace(/;/g, "&");
-  if (!normalized) return false;
-  const parsed = new URLSearchParams(normalized);
-  for (const [key, value] of parsed.entries()) {
-    if (key.trim().toLowerCase() === "sqlserverencryption" && SQLSERVER_ENCRYPTION_DISABLED_VALUES.has(value.trim().toLowerCase())) return true;
-  }
-  return false;
+  return (params || "")
+    .trim()
+    .replace(/^\?/, "")
+    .split(/[&;]/)
+    .some((part) => {
+      const separatorIndex = part.indexOf("=");
+      if (separatorIndex < 0) return false;
+      const key = part.slice(0, separatorIndex).trim().toLowerCase();
+      const value = part
+        .slice(separatorIndex + 1)
+        .trim()
+        .toLowerCase();
+      return key === "sqlserverencryption" && SQLSERVER_ENCRYPTION_DISABLED_VALUES.has(value);
+    });
 }
 
 function removeSqlServerLegacyCompatibilitySetting(params: string | undefined): string {
-  const normalized = (params || "").trim().replace(/^\?/, "").replace(/;/g, "&");
-  const parsed = new URLSearchParams(normalized);
-  for (const key of Array.from(parsed.keys())) {
-    if (key.trim().toLowerCase() === "sqlserverencryption") parsed.delete(key);
-  }
-  return parsed.toString();
+  // Preserve raw JDBC values because the legacy agent does not URL-decode properties.
+  return (params || "")
+    .trim()
+    .replace(/^\?/, "")
+    .split(/[&;]/)
+    .map((part) => part.trim())
+    .filter((part) => part && !isSqlServerLegacyCompatibilitySetting(part))
+    .join("&");
 }
 
 export function sqlServerUsesLegacyCompatibility(config: Pick<ConnectionConfig, "db_type" | "driver_profile">): boolean {

--- a/apps/desktop/src/lib/connection/sqlServerLegacyCompatibility.ts
+++ b/apps/desktop/src/lib/connection/sqlServerLegacyCompatibility.ts
@@ -31,6 +31,25 @@ export function setSqlServerNativeEncryptionDisabled(params: string | undefined,
   return parsed.toString();
 }
 
+function isSqlServerLegacyCompatibilitySetting(params: string | undefined): boolean {
+  const normalized = (params || "").trim().replace(/^\?/, "").replace(/;/g, "&");
+  if (!normalized) return false;
+  const parsed = new URLSearchParams(normalized);
+  for (const [key, value] of parsed.entries()) {
+    if (key.trim().toLowerCase() === "sqlserverencryption" && SQLSERVER_ENCRYPTION_DISABLED_VALUES.has(value.trim().toLowerCase())) return true;
+  }
+  return false;
+}
+
+function removeSqlServerLegacyCompatibilitySetting(params: string | undefined): string {
+  const normalized = (params || "").trim().replace(/^\?/, "").replace(/;/g, "&");
+  const parsed = new URLSearchParams(normalized);
+  for (const key of Array.from(parsed.keys())) {
+    if (key.trim().toLowerCase() === "sqlserverencryption") parsed.delete(key);
+  }
+  return parsed.toString();
+}
+
 export function sqlServerUsesLegacyCompatibility(config: Pick<ConnectionConfig, "db_type" | "driver_profile">): boolean {
   return config.db_type === "sqlserver" && config.driver_profile === SQLSERVER_LEGACY_COMPATIBILITY_DRIVER_KEY;
 }
@@ -38,6 +57,12 @@ export function sqlServerUsesLegacyCompatibility(config: Pick<ConnectionConfig, 
 export function setSqlServerLegacyCompatibilityConfig(config: Pick<ConnectionConfig, "driver_label" | "driver_profile">, enabled: boolean): void {
   config.driver_profile = enabled ? SQLSERVER_LEGACY_COMPATIBILITY_DRIVER_KEY : SQLSERVER_NATIVE_DRIVER_PROFILE;
   config.driver_label = enabled ? SQLSERVER_LEGACY_COMPATIBILITY_DRIVER_LABEL : SQLSERVER_NATIVE_DRIVER_LABEL;
+}
+
+export function migrateSqlServerLegacyCompatibilityConfig(config: Pick<ConnectionConfig, "db_type" | "driver_label" | "driver_profile" | "url_params">): void {
+  if (config.db_type !== "sqlserver" || !isSqlServerLegacyCompatibilitySetting(config.url_params)) return;
+  setSqlServerLegacyCompatibilityConfig(config, true);
+  config.url_params = removeSqlServerLegacyCompatibilitySetting(config.url_params);
 }
 
 export function requiresSqlServerLegacyCompatibilityComponent(config: ConnectionConfig): boolean {

--- a/apps/desktop/src/stores/__tests__/connectionStore.sqlserverLegacy.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.sqlserverLegacy.spec.ts
@@ -41,11 +41,11 @@ describe("connectionStore SQL Server legacy compatibility", () => {
     setActivePinia(createPinia());
   });
 
-  it("does not preinstall the legacy component for historical disabled-encryption configs", async () => {
+  it("migrates historical disabled-encryption configs and installs the legacy component", async () => {
     const connectDb = vi.fn().mockResolvedValue("sqlserver-1");
     const installAgent = vi.fn().mockResolvedValue(undefined);
 
-    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => true }));
     vi.doMock("@/lib/backend/api", () => ({
       connectDb,
       installAgent,
@@ -56,8 +56,16 @@ describe("connectionStore SQL Server legacy compatibility", () => {
     const store = useConnectionStore();
     await store.connect(sqlServerNativeConnectionWithDisabledEncryption());
 
-    expect(installAgent).not.toHaveBeenCalled();
+    expect(installAgent).toHaveBeenCalledWith("sqlserver-legacy");
     expect(connectDb).toHaveBeenCalledTimes(1);
+    expect(connectDb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        driver_profile: "sqlserver-legacy",
+        driver_label: "SQL Server legacy compatibility component",
+        url_params: "",
+      }),
+      expect.any(Number),
+    );
   });
 
   it("reconnects persisted legacy profiles without reinstalling an installed component", async () => {
@@ -66,6 +74,7 @@ describe("connectionStore SQL Server legacy compatibility", () => {
     const config = sqlServerNativeConnectionWithDisabledEncryption();
     config.driver_profile = "sqlserver-legacy";
     config.driver_label = "SQL Server legacy compatibility component";
+    config.url_params = "";
 
     vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => true }));
     vi.doMock("@/lib/backend/api", () => ({
@@ -87,6 +96,7 @@ describe("connectionStore SQL Server legacy compatibility", () => {
     const connectDb = vi.fn().mockRejectedValue(new Error("TLS negotiation failed\nSQL Server error 18456: Login failed"));
     const installAgent = vi.fn().mockResolvedValue(undefined);
     const config = sqlServerNativeConnectionWithDisabledEncryption();
+    config.url_params = "";
 
     vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => true }));
     vi.doMock("@/lib/backend/api", () => ({

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -54,7 +54,7 @@ import { collapseExpandedTreeNodes } from "@/lib/sidebar/sidebarTreeCollapse";
 import { findDatabaseTreeNode } from "@/lib/sidebar/treeRefreshTarget";
 import { shouldMarkDisconnected } from "@/lib/connection/connectionHealth";
 import { connectionAttemptOriginalErrorMessage, connectionAttemptTimeoutMessage, connectionAttemptTimeoutMs } from "@/lib/connection/connectionAttemptTimeout";
-import { requiresSqlServerLegacyCompatibilityComponent, SQLSERVER_LEGACY_COMPATIBILITY_DRIVER_KEY } from "@/lib/connection/sqlServerLegacyCompatibility";
+import { migrateSqlServerLegacyCompatibilityConfig, requiresSqlServerLegacyCompatibilityComponent, SQLSERVER_LEGACY_COMPATIBILITY_DRIVER_KEY } from "@/lib/connection/sqlServerLegacyCompatibility";
 import { deleteTabResultSnapshotsForOwner } from "@/lib/tabs/tabResultCache";
 import { connectionUsesVisibleSchemaFilter, filterDatabaseNamesForConnection, filterSchemaNamesForConnection, filterVisibleDatabaseNames, normalizeVisibleDatabaseSelection } from "@/lib/database/visibleDatabases";
 import {
@@ -910,6 +910,8 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   function normalizeConnection(config: ConnectionConfig): ConnectionConfig {
+    config = { ...config };
+    migrateSqlServerLegacyCompatibilityConfig(config);
     const labelMap: Record<string, string> = {
       mysql: "MySQL",
       postgres: "PostgreSQL",

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -3965,12 +3965,13 @@ mod tests {
     }
 
     #[test]
-    fn sqlserver_legacy_url_param_does_not_force_agent_driver() {
+    fn sqlserver_legacy_url_param_requires_canonicalization_before_agent_driver_selection() {
         let mut config = mysql_config(Some("master"));
         config.db_type = DatabaseType::SqlServer;
-        config.url_params = Some("applicationName=dbx;encrypt=false".to_string());
+        config.url_params = Some("applicationName=dbx;sqlserverEncryption=disabled".to_string());
 
         assert!(!sqlserver_uses_legacy_driver(&config));
+        assert!(sqlserver_uses_legacy_driver(&config.canonicalized()));
     }
 
     #[test]

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -1391,29 +1391,66 @@ fn redis_url_params_enable_insecure(params: Option<&str>) -> bool {
     })
 }
 
+fn sqlserver_url_param_parts(params: Option<&str>) -> Vec<(Option<char>, &str)> {
+    let source = params.unwrap_or("").trim().trim_start_matches('?');
+    let mut parts = Vec::new();
+    let mut separator = None;
+    let mut start = 0;
+    let mut in_braces = false;
+    let mut chars = source.char_indices().peekable();
+
+    // SQL Server JDBC values use braces to contain separators and `}}` to escape a closing brace.
+    while let Some((index, char)) = chars.next() {
+        if in_braces {
+            if char == '}' && chars.peek().is_some_and(|(_, next)| *next == '}') {
+                chars.next();
+            } else if char == '}' {
+                in_braces = false;
+            }
+        } else if char == '{' {
+            in_braces = true;
+        } else if matches!(char, '&' | ';') {
+            parts.push((separator, &source[start..index]));
+            separator = Some(char);
+            start = index + char.len_utf8();
+        }
+    }
+
+    parts.push((separator, &source[start..]));
+    parts
+}
+
+fn sqlserver_legacy_compatibility_part(part: &str) -> bool {
+    let Some((key, value)) = part.split_once('=') else {
+        return false;
+    };
+    let disabled =
+        matches!(value.trim().to_ascii_lowercase().as_str(), "disabled" | "disable" | "false" | "0" | "off" | "no");
+    key.trim().eq_ignore_ascii_case("sqlserverEncryption") && disabled
+}
+
 fn sqlserver_legacy_compatibility_param(params: Option<&str>) -> bool {
-    params.unwrap_or("").trim().trim_start_matches('?').split(['&', ';']).any(|part| {
-        let Some((key, value)) = part.split_once('=') else {
-            return false;
-        };
-        let disabled =
-            matches!(value.trim().to_ascii_lowercase().as_str(), "disabled" | "disable" | "false" | "0" | "off" | "no");
-        key.trim().eq_ignore_ascii_case("sqlserverEncryption") && disabled
-    })
+    sqlserver_url_param_parts(params).into_iter().any(|(_, part)| sqlserver_legacy_compatibility_part(part))
 }
 
 fn without_sqlserver_legacy_compatibility_param(params: Option<&str>) -> Option<String> {
-    let retained = params
-        .unwrap_or("")
-        .trim()
-        .trim_start_matches('?')
-        .split(['&', ';'])
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
-        .filter(|part| !sqlserver_legacy_compatibility_param(Some(part)))
-        .collect::<Vec<_>>()
-        .join("&");
-    (!retained.is_empty()).then_some(retained)
+    let retained = sqlserver_url_param_parts(params)
+        .into_iter()
+        .filter(|(_, part)| !part.trim().is_empty())
+        .filter(|(_, part)| !sqlserver_legacy_compatibility_part(part))
+        .collect::<Vec<_>>();
+    if retained.is_empty() {
+        return None;
+    }
+
+    let mut output = String::new();
+    for (index, (separator, part)) in retained.into_iter().enumerate() {
+        if index > 0 {
+            output.extend(separator);
+        }
+        output.push_str(part);
+    }
+    Some(output)
 }
 
 fn url_params_contains_flag(params: Option<&str>, key: &str, expected: &str) -> bool {
@@ -2035,8 +2072,9 @@ fn bracket_ipv6(host: &str) -> String {
 mod tests {
     use super::{
         database_info_from_protocol_value, default_query_timeout_secs, default_redis_key_separator,
-        default_ssh_connect_timeout_secs, ConnectionConfig, ConnectionTestResult, DatabaseConnectionInfo, DatabaseType,
-        IdentifierCase, ProxyTunnelConfig, ProxyType, TransportLayerConfig,
+        default_ssh_connect_timeout_secs, sqlserver_legacy_compatibility_param,
+        without_sqlserver_legacy_compatibility_param, ConnectionConfig, ConnectionTestResult, DatabaseConnectionInfo,
+        DatabaseType, IdentifierCase, ProxyTunnelConfig, ProxyType, TransportLayerConfig,
     };
     use std::str::FromStr;
 
@@ -2529,13 +2567,26 @@ mod tests {
         config.db_type = DatabaseType::SqlServer;
         config.driver_profile = Some("sqlserver".to_string());
         config.driver_label = Some("SQL Server".to_string());
-        config.url_params = Some("applicationName=dbx;sqlserverEncryption=disabled".to_string());
+        config.url_params =
+            Some("applicationName={DBX; Client};password=50%;sqlserverEncryption=disabled;encrypt=false".to_string());
 
         let canonical = config.canonicalized();
 
         assert_eq!(canonical.driver_profile.as_deref(), Some("sqlserver-legacy"));
         assert_eq!(canonical.driver_label.as_deref(), Some("SQL Server legacy compatibility component"));
-        assert_eq!(canonical.url_params.as_deref(), Some("applicationName=dbx"));
+        assert_eq!(canonical.url_params.as_deref(), Some("applicationName={DBX; Client};password=50%;encrypt=false"));
+        assert_eq!(without_sqlserver_legacy_compatibility_param(Some("sqlserverEncryption=disabled")), None);
+    }
+
+    #[test]
+    fn sqlserver_legacy_migration_respects_escaped_braces() {
+        let params = "applicationName={DBX}}; Client};sqlserverEncryption=disabled;encrypt=false";
+
+        assert!(sqlserver_legacy_compatibility_param(Some(params)));
+        assert_eq!(
+            without_sqlserver_legacy_compatibility_param(Some(params)).as_deref(),
+            Some("applicationName={DBX}}; Client};encrypt=false")
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -892,6 +892,13 @@ impl ConnectionConfig {
 
     pub fn canonicalized(&self) -> Self {
         let mut config = self.clone();
+        if config.db_type == DatabaseType::SqlServer
+            && sqlserver_legacy_compatibility_param(config.url_params.as_deref())
+        {
+            config.driver_profile = Some("sqlserver-legacy".to_string());
+            config.driver_label = Some("SQL Server legacy compatibility component".to_string());
+            config.url_params = without_sqlserver_legacy_compatibility_param(config.url_params.as_deref());
+        }
         if config.db_type == DatabaseType::Mysql
             && config.driver_profile.as_deref().is_some_and(|profile| profile.eq_ignore_ascii_case("tdengine"))
         {
@@ -1382,6 +1389,31 @@ fn redis_url_params_enable_insecure(params: Option<&str>) -> bool {
         matches!(key.to_ascii_lowercase().as_str(), "insecure" | "tls_insecure" | "accept_invalid_certs")
             && matches!(value.trim().to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "insecure")
     })
+}
+
+fn sqlserver_legacy_compatibility_param(params: Option<&str>) -> bool {
+    params.unwrap_or("").trim().trim_start_matches('?').split(['&', ';']).any(|part| {
+        let Some((key, value)) = part.split_once('=') else {
+            return false;
+        };
+        let disabled =
+            matches!(value.trim().to_ascii_lowercase().as_str(), "disabled" | "disable" | "false" | "0" | "off" | "no");
+        key.trim().eq_ignore_ascii_case("sqlserverEncryption") && disabled
+    })
+}
+
+fn without_sqlserver_legacy_compatibility_param(params: Option<&str>) -> Option<String> {
+    let retained = params
+        .unwrap_or("")
+        .trim()
+        .trim_start_matches('?')
+        .split(['&', ';'])
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .filter(|part| !sqlserver_legacy_compatibility_param(Some(part)))
+        .collect::<Vec<_>>()
+        .join("&");
+    (!retained.is_empty()).then_some(retained)
 }
 
 fn url_params_contains_flag(params: Option<&str>, key: &str, expected: &str) -> bool {
@@ -2489,6 +2521,36 @@ mod tests {
         assert_eq!(canonical.driver_profile.as_deref(), Some("tdengine"));
         assert_eq!(canonical.driver_label.as_deref(), Some("TDengine"));
         assert!(!canonical.needs_bare_mysql());
+    }
+
+    #[test]
+    fn historical_sqlserver_legacy_setting_is_canonicalized_to_driver_profile() {
+        let mut config = mysql_config("sa", "secret", Some("master"));
+        config.db_type = DatabaseType::SqlServer;
+        config.driver_profile = Some("sqlserver".to_string());
+        config.driver_label = Some("SQL Server".to_string());
+        config.url_params = Some("applicationName=dbx;sqlserverEncryption=disabled".to_string());
+
+        let canonical = config.canonicalized();
+
+        assert_eq!(canonical.driver_profile.as_deref(), Some("sqlserver-legacy"));
+        assert_eq!(canonical.driver_label.as_deref(), Some("SQL Server legacy compatibility component"));
+        assert_eq!(canonical.url_params.as_deref(), Some("applicationName=dbx"));
+    }
+
+    #[test]
+    fn sqlserver_auto_profile_without_historical_setting_stays_native() {
+        let mut config = mysql_config("sa", "secret", Some("master"));
+        config.db_type = DatabaseType::SqlServer;
+        config.driver_profile = Some("sqlserver".to_string());
+        config.driver_label = Some("SQL Server".to_string());
+        config.url_params = Some("applicationName=dbx&encrypt=false".to_string());
+
+        let canonical = config.canonicalized();
+
+        assert_eq!(canonical.driver_profile.as_deref(), Some("sqlserver"));
+        assert_eq!(canonical.driver_label.as_deref(), Some("SQL Server"));
+        assert_eq!(canonical.url_params.as_deref(), Some("applicationName=dbx&encrypt=false"));
     }
 
     #[test]


### PR DESCRIPTION
## 修改内容

- 旧版本 SQL Server 连接包含 `sqlserverEncryption=disabled` 时，升级后迁移为显式 `sqlserver-legacy` 驱动配置
- 在核心配置规范化和前端连接规范化中同时处理迁移，保证已保存连接、自动重连和编辑连接时表现一致
- 迁移后移除已被驱动 profile 取代的旧标记，并保留其他 URL 参数
- 普通 JDBC 参数 `encrypt=false` 继续使用自动/原生模式，不会被误迁移
- 自动模式不增加 legacy fallback，旧版兼容驱动仍由用户显式选择

## 问题原因

#4201 将 SQL Server 旧版兼容模式从 URL 参数开关调整为显式驱动 profile，但旧版本复选框保存的 `sqlserverEncryption=disabled` 没有迁移为 `driver_profile=sqlserver-legacy`。

因此，原本已经勾选旧版兼容模式的连接在升级后会显示为“自动”，并改用原生驱动。对于依赖旧 TLS 协议的 SQL Server 2008 实例，这会在连接阶段报 `tls handshake eof`；用户手动重新选择旧版兼容后即可连接。

本次修复只迁移 DBX 旧复选框写入的专用标记。通用 JDBC `encrypt=false` 可能只是要求原生驱动使用登录阶段加密，因此不会触发驱动切换。

## 升级效果

- 旧版本已勾选“旧版兼容”：升级后继续显示并使用旧版兼容模式
- 旧版本未勾选：升级后保持自动模式
- 手动配置 `encrypt=false`：继续使用自动/原生模式

## 验证

- SQL Server/Rust 聚焦测试：165 passed，1 ignored
- 前端迁移与连接测试：10 passed
- `dbx-core` 完整测试：2630 passed，17 ignored
- `pnpm typecheck`
- `cargo clippy -p dbx-core --lib -- -D warnings`
- Oxlint、oxfmt、rustfmt 检查通过

Related: #4201
