### PR TITLE
fix: 修复现代布局右侧面板圆角显示

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -2339,7 +2339,7 @@ onUnmounted(() => {
 
           <div v-if="showAiPanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: aiPanelWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startAiPanelResize" />
-            <div class="h-full min-h-0 overflow-hidden">
+            <div class="h-full min-h-0 overflow-hidden rounded-[inherit]">
               <AiAssistant
                 v-if="aiPanelReady"
                 ref="aiAssistantRef"
@@ -2359,19 +2359,21 @@ onUnmounted(() => {
 
           <div v-if="showHistory" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: historyWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startHistoryResize" />
-            <QueryHistory :current-connection-id="activeTab?.connectionId" :current-database="activeTab?.database" @restore="restoreHistorySql" @analyze-ai="analyzeHistoryWithAi" @close="closeRightSidebarPanel('history')" />
+            <div class="h-full min-h-0 overflow-hidden rounded-[inherit]">
+              <QueryHistory :current-connection-id="activeTab?.connectionId" :current-database="activeTab?.database" @restore="restoreHistorySql" @analyze-ai="analyzeHistoryWithAi" @close="closeRightSidebarPanel('history')" />
+            </div>
           </div>
 
           <div v-if="showSqlLibraryPanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: sqlLibraryWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startSqlLibraryResize" />
-            <div class="h-full min-h-0 overflow-hidden">
+            <div class="h-full min-h-0 overflow-hidden rounded-[inherit]">
               <SqlLibraryPanel @close="closeRightSidebarPanel('sqlLibrary')" />
             </div>
           </div>
 
           <div v-if="showSqlFilePanel" :class="isClassicLayout ? 'h-full shrink-0 relative z-30 isolate bg-background' : 'h-full shrink-0 relative z-30 isolate rounded-md border border-border/80 bg-background'" :style="{ width: sqlFilePanelWidth + 'px' }">
             <div class="panel-resize-handle panel-resize-handle--left" @mousedown="startSqlFilePanelResize" />
-            <div class="h-full min-h-0 overflow-hidden">
+            <div class="h-full min-h-0 overflow-hidden rounded-[inherit]">
               <SqlFilePanel @close="closeRightSidebarPanel('sqlFile')" />
             </div>
           </div>


### PR DESCRIPTION
## 问题

在“大圆角 + 现代分隔”设置下，SQL 库等右侧面板的内部内容仍按矩形绘制，覆盖了外层容器的圆角，导致界面看起来是直角。

## 修改

- 让 AI、历史、SQL 库和 SQL 文件面板的内容层继承外层圆角并裁剪内部背景
- 保持面板宽度拖拽手柄位于裁剪层之外，避免缩小可操作区域
- 经典紧凑布局继承 0px 圆角，保持原有显示

## 验证

- 实际验证大圆角、小圆角及经典紧凑布局
- 实际打开 AI、历史、SQL 库和 SQL 文件面板检查边角显示
- 验证面板宽度拖拽热区未被裁剪
- `pnpm -s typecheck`
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/app/rightSidebarPanels.spec.ts`（4 项通过）
- `pnpm exec oxlint --vue-plugin apps/desktop/src/App.vue`
- `pnpm -s build`