### PR TITLE
fix(mongodb): accept trailing commas in shell arguments

### DIFF
--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -524,6 +524,69 @@ test("parseMongoAggregateCommand accepts an empty pipeline", () => {
   });
 });
 
+test("parseMongoAggregateCommand accepts Mongo Shell trailing commas", () => {
+  const command = parseMongoAggregateCommand(`db.AdressInfo.aggregate([
+    {
+      $match: {
+        IsDelete: 0,
+        DataSource: { $ne: 'XC' },
+        TypeName: 1,
+      },
+    },
+    {
+      $project: {
+        MainId: '$_id',
+        labels: ['primary', 'backup',],
+      },
+    },
+    { $out: 'IBMBiititle' },
+  ], {
+    allowDiskUse: true,
+  })`);
+
+  assert.ok(command);
+  assert.deepEqual(JSON.parse(command.pipeline), [
+    {
+      $match: {
+        IsDelete: 0,
+        DataSource: { $ne: "XC" },
+        TypeName: 1,
+      },
+    },
+    {
+      $project: {
+        MainId: "$_id",
+        labels: ["primary", "backup"],
+      },
+    },
+    { $out: "IBMBiititle" },
+  ]);
+  assert.deepEqual(JSON.parse(command.options ?? "null"), { allowDiskUse: true });
+});
+
+test("parseMongoAggregateCommand preserves trailing-comma text inside strings", () => {
+  const command = parseMongoAggregateCommand(`db.logs.aggregate([
+    {
+      $project: {
+        objectText: "literal,}",
+        arrayText: "literal,]",
+        escapedQuote: "literal\\",]",
+      },
+    },
+  ])`);
+
+  assert.ok(command);
+  assert.deepEqual(JSON.parse(command.pipeline), [
+    {
+      $project: {
+        objectText: "literal,}",
+        arrayText: "literal,]",
+        escapedQuote: 'literal",]',
+      },
+    },
+  ]);
+});
+
 test("parseMongoAggregateCommand ignores comments inside aggregate pipelines", () => {
   const command = parseMongoAggregateCommand(`
     db.cash.aggregate([

--- a/packages/app-tests/mongoShellCommand.test.ts
+++ b/packages/app-tests/mongoShellCommand.test.ts
@@ -344,6 +344,16 @@ test("parseMongoWriteCommand accepts unquoted insert and update commands", () =>
   });
 });
 
+test("parseMongoWriteCommand unwraps EJSON.deserialize values", () => {
+  assert.deepEqual(parseMongoWriteCommand('db.products.updateOne({_id: ObjectId("507f1f77bcf86cd799439011")}, {$set: {price: EJSON.deserialize({"$numberDecimal":"12.34"}), payload: EJSON.deserialize({"$binary":{"base64":"AQI=","subType":"00"}})}})'), {
+    kind: "update",
+    collection: "products",
+    filter: '{"_id": {"$oid":"507f1f77bcf86cd799439011"}}',
+    update: '{"$set": {"price": {"$numberDecimal":"12.34"}, "payload": {"$binary":{"base64":"AQI=","subType":"00"}}}}',
+    many: false,
+  });
+});
+
 test("parseMongoWriteCommand accepts legacy insert commands", () => {
   assert.deepEqual(
     parseMongoWriteCommand(`db.getCollection("accounting_reconciliations").insert({

--- a/packages/mongo-shell/src/json.ts
+++ b/packages/mongo-shell/src/json.ts
@@ -12,7 +12,7 @@ export function normalizeJsonArgument(value: string): string | null {
   // Rewrite mongo shell constructors that are not valid JSON into extended JSON
   // (mongo_driver::json_value_to_bson): ObjectId / NumberLong / ISODate / new Date.
   const withExtendedJson = replaceMongoShellConstructors(withoutComments);
-  const preprocessed = quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson));
+  const preprocessed = removeTrailingCommas(quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson)));
   try {
     JSON.parse(preprocessed);
     return preprocessed;
@@ -238,6 +238,39 @@ function mongoLineCommentEnd(source: string, start: number): number {
     if (char === "\n" || char === "\u2028" || char === "\u2029") return index + 1;
   }
   return source.length;
+}
+
+function removeTrailingCommas(source: string): string {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index] ?? "";
+    if (inString) {
+      result += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === ",") {
+      let next = index + 1;
+      while (/\s/.test(source[next] ?? "")) next += 1;
+      if (source[next] === "}" || source[next] === "]") continue;
+    }
+
+    result += char;
+  }
+
+  return result;
 }
 
 export function quoteUnquotedObjectKeys(source: string): string {

--- a/packages/mongo-shell/src/json.ts
+++ b/packages/mongo-shell/src/json.ts
@@ -9,10 +9,11 @@ export function normalizeJsonArgument(value: string): string | null {
   if (!trimmed) return "{}";
   const withoutComments = stripMongoJsonComments(trimmed).trim();
   if (!withoutComments) return "{}";
+  const withoutEjsonDeserialize = replaceMongoEjsonDeserialize(withoutComments);
   // Rewrite mongo shell constructors that are not valid JSON into extended JSON
   // (mongo_driver::json_value_to_bson): ObjectId / NumberLong / ISODate / new Date.
-  const withExtendedJson = replaceMongoShellConstructors(withoutComments);
-  const preprocessed = removeTrailingCommas(quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson)));
+  const withExtendedJson = replaceMongoShellConstructors(withoutEjsonDeserialize);
+  const preprocessed = quoteUnquotedObjectKeys(convertSingleQuotedStrings(withExtendedJson));
   try {
     JSON.parse(preprocessed);
     return preprocessed;
@@ -319,6 +320,48 @@ function shouldQuoteObjectKey(source: string, index: number): boolean {
   return source[after] === ":";
 }
 
+function replaceMongoEjsonDeserialize(source: string): string {
+  const callPattern = /^EJSON\s*\.\s*deserialize\s*\(/;
+  let result = "";
+  let index = 0;
+  while (index < source.length) {
+    const quote = source[index];
+    if (quote === '"' || quote === "'") {
+      const start = index++;
+      while (index < source.length) {
+        if (source[index] === "\\") index += 2;
+        else if (source[index] === quote) {
+          index++;
+          break;
+        } else index++;
+      }
+      result += source.slice(start, index);
+      continue;
+    }
+
+    const match = source.slice(index).match(callPattern);
+    if (!match) {
+      result += source[index++]!;
+      continue;
+    }
+    const openIndex = index + match[0].lastIndexOf("(");
+    const closeIndex = findMatchingParen(source, openIndex);
+    if (closeIndex < 0) {
+      result += source[index++]!;
+      continue;
+    }
+    const args = splitTopLevel(source.slice(openIndex + 1, closeIndex));
+    if (args.length !== 1 || !args[0]?.trim()) {
+      result += source.slice(index, closeIndex + 1);
+      index = closeIndex + 1;
+      continue;
+    }
+    result += args[0].trim();
+    index = closeIndex + 1;
+  }
+  return result;
+}
+
 function replaceMongoShellConstructors(source: string): string {
   const constructor = /^(ObjectId|NumberLong|ISODate)\s*\(\s*["']([^"']+)["']\s*\)|^(ObjectId|NumberLong)\s*\(\s*(-?\d+)\s*\)|^(?:new\s+Date)\s*\(\s*["']([^"']+)["']\s*\)/;
   let result = "";
@@ -397,5 +440,6 @@ function convertSingleQuotedStrings(source: string): string {
     }
   }
 
-  return quote === "'" ? source : result + source.slice(copiedUntil);
+  const converted = quote === "'" ? source : result + source.slice(copiedUntil);
+  return removeTrailingCommas(converted);
 }


### PR DESCRIPTION
## 变更说明

修复 Mongo Shell 风格参数中包含尾随逗号时无法解析的问题。

DBX 已支持单引号、无引号对象键、注释和 Mongo Shell 构造器，但参数仍会经过严格 JSON 解析，因此合法的对象或数组尾随逗号会导致 `aggregate` 管道被误判为非数组。

本次变更在共享 Mongo 参数规范化逻辑中移除对象和数组的尾随逗号，同时保留字符串内部的 `,}`、`,]` 和转义引号等原始内容。该修复也适用于其他复用此规范化逻辑的 Mongo Shell 命令参数。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及 UI 组件、样式、交互或文案变更。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm exec vitest run packages/app-tests/mongoShellCommand.test.ts`（69 项通过）
- `pnpm build:packages`
- `pnpm test:packages`
- `pnpm publish:dry-run`
- 使用 MongoDB 5.0.18 和 DBX Web UI 执行包含嵌套尾随逗号、`$dateAdd` 与 `$out` 的聚合管道，目标集合成功写入预期数据

## 关联 Issue

Close #4354
