### PR TITLE
fix(ui): refine dark toolbar controls

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -7613,7 +7613,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
             <div class="data-grid-topbar flex items-stretch relative" :class="{ 'data-grid-topbar--compact': compactDataGridToolbar }">
               <div v-if="useTransaction && editable && hasDataGridSaveTarget" class="flex items-center px-2 py-0.5 border-r shrink-0">
                 <Select :model-value="rowStatusFilter" @update:model-value="(value: any) => setRowStatusFilter(String(value))">
-                  <SelectTrigger class="h-5 max-w-28 border-0 bg-transparent px-0 py-0 text-xs font-medium text-foreground/70 shadow-none focus-visible:ring-0 data-[state=open]:text-foreground [&_svg]:size-3">
+                  <SelectTrigger class="h-5 max-w-28 border-0 bg-transparent px-0 py-0 text-xs font-medium text-foreground/70 shadow-none focus-visible:ring-0 data-[state=open]:text-foreground dark:bg-transparent dark:hover:bg-transparent [&_svg]:size-3">
                     <SelectValue :placeholder="t('grid.filterRows')" />
                   </SelectTrigger>
                   <SelectContent position="popper">

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -218,11 +218,11 @@ function databaseOptionIsProduction(database: string): boolean {
             variant="ghost"
             size="icon"
             class="h-6 w-6"
-            :class="isTransactionActive || autoCommit === false ? 'text-orange-600 bg-orange-100 dark:text-orange-300 dark:bg-orange-900/30' : 'text-muted-foreground/50'"
+            :class="isTransactionActive || autoCommit === false ? 'bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-300' : 'text-orange-600/70 hover:bg-orange-500/10 hover:text-orange-700 dark:text-orange-300/70 dark:hover:text-orange-200'"
             :disabled="activeTab.isExecuting || activeTab.isExplaining"
             @click="emit('update:autoCommit', autoCommit === false)"
           >
-            <span class="font-bold" style="font-size: 9px">Tx</span>
+            <span class="text-xs font-bold leading-none">Tx</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent>{{ transactionTooltip }}</TooltipContent>
@@ -267,8 +267,8 @@ function databaseOptionIsProduction(database: string): boolean {
           <Button
             variant="ghost"
             size="icon"
-            class="h-6 w-6 font-mono text-[11px] leading-none"
-            :class="keywordCaseIsLower ? 'bg-amber-500/10 text-amber-700 hover:bg-amber-500/20 hover:text-amber-800 dark:text-amber-300 dark:hover:text-amber-200' : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
+            class="h-6 w-6 font-mono text-sm font-semibold leading-none"
+            :class="keywordCaseIsLower ? 'bg-amber-500/10 text-amber-700 hover:bg-amber-500/20 hover:text-amber-800 dark:text-amber-300 dark:hover:text-amber-200' : 'text-amber-600/70 hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-300/70 dark:hover:text-amber-200'"
             :aria-label="keywordCaseToggleTooltip"
             @click="emit('toggleSqlKeywordCase')"
           >


### PR DESCRIPTION
## 背景

暗色模式下，表数据工具栏的“全部行”无边框下拉仍继承公共 `SelectTrigger` 的暗色背景，只有触发器自身区域着色，视觉上像背景没有覆盖完整。SQL 编辑器工具栏的 `Tx` 和关键字大小写 `A/a` 文本图标也偏小，默认态缺少与激活态一致的功能色。

## 修改

- 为表数据行状态下拉显式覆盖暗色常态和悬停背景，使其统一使用工具栏底色
- `Tx` 字号调整为 12px，默认使用橙色，并保留手动事务激活背景
- `A/a` 字号调整为 14px并增加字重，默认使用琥珀色，并保留切换后的激活背景
- 按钮尺寸仍为 `24x24`，不改变工具栏布局和间距
- 不修改公共 `SelectTrigger`，避免影响其他有边框、有背景的下拉控件

## 验证

- 本地免密 Web 预览验证，MySQL 保存连接真实连接成功
- `oxfmt --check` 通过
- `oxlint --vue-plugin` 通过
- `vue-tsc --noEmit` 通过
- `vitest run`：546 个测试文件、4504 条用例通过
- `git diff --check` 通过