### PR TITLE
Fix：修复新建连接弹窗标题异常焦点框

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ObjectDirective } from "vue";
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { uuid } from "@/lib/common/utils";
 import { useI18n } from "vue-i18n";
@@ -2746,11 +2747,11 @@ function backToDatabasePicker() {
   resetTestState();
 }
 
-function handleDialogOpenAutoFocus(event: Event) {
-  event.preventDefault();
-  if (!(event.currentTarget instanceof HTMLElement)) return;
-  event.currentTarget.querySelector<HTMLElement>("[data-connection-dialog-title]")?.focus({ preventScroll: true });
-}
+const vConnectionDialogAutoFocus: ObjectDirective<HTMLInputElement> = {
+  mounted(input) {
+    input.focus({ preventScroll: true });
+  },
+};
 
 function handleDialogEscape(event: KeyboardEvent) {
   if (dialogStep.value !== "config" || editingId.value) return;
@@ -4509,9 +4510,9 @@ function openExternalUrl(url: string) {
 
 <template>
   <Dialog v-model:open="open">
-    <DialogContent class="connection-dialog-content" :class="connectionDialogContentClass" :data-wide="shouldUseWideConnectionDialog ? 'true' : undefined" @interact-outside.prevent @open-auto-focus="handleDialogOpenAutoFocus" @escape-key-down="handleDialogEscape">
+    <DialogContent class="connection-dialog-content" :class="connectionDialogContentClass" :data-wide="shouldUseWideConnectionDialog ? 'true' : undefined" @interact-outside.prevent @escape-key-down="handleDialogEscape">
       <DialogHeader>
-        <DialogTitle data-connection-dialog-title tabindex="-1">{{ editingId ? t("connection.editTitle") : t("connection.title") }}</DialogTitle>
+        <DialogTitle>{{ editingId ? t("connection.editTitle") : t("connection.title") }}</DialogTitle>
       </DialogHeader>
 
       <template v-if="dialogStep === 'select'">
@@ -4546,7 +4547,7 @@ function openExternalUrl(url: string) {
               </div>
               <div class="relative w-full sm:w-64">
                 <Search class="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input v-model="dbSearchQuery" class="h-9 pl-8" :placeholder="t('connection.searchDatabasePlaceholder')" />
+                <Input v-model="dbSearchQuery" v-connection-dialog-auto-focus class="h-9 pl-8" :placeholder="t('connection.searchDatabasePlaceholder')" />
               </div>
             </div>
             <Button data-jdbc-connection-entry type="button" variant="outline" class="h-9 shrink-0 gap-2" @click="goToConnectionStep('jdbc')">
@@ -4662,7 +4663,7 @@ function openExternalUrl(url: string) {
 
                 <div class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelClass">{{ t("connection.name") }}</Label>
-                  <Input v-model="form.name" class="col-span-3" :placeholder="t('connection.namePlaceholder')" />
+                  <Input v-model="form.name" v-connection-dialog-auto-focus class="col-span-3" :placeholder="t('connection.namePlaceholder')" />
                 </div>
 
                 <div class="grid grid-cols-4 items-center gap-4">

--- a/apps/desktop/src/lib/__tests__/connection/connectionDialogAccessibility.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionDialogAccessibility.spec.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 const dialogSource = readFileSync(new URL("../../../components/connection/ConnectionDialog.vue", import.meta.url), "utf8");
 
 describe("connection dialog accessibility", () => {
-  it("moves initial focus to the dialog title instead of the dialog container", () => {
-    expect(dialogSource).toContain('<DialogTitle data-connection-dialog-title tabindex="-1">');
-    expect(dialogSource).toContain('querySelector<HTMLElement>("[data-connection-dialog-title]")?.focus({ preventScroll: true })');
+  it("moves initial focus to an input inside the dialog", () => {
+    expect(dialogSource).toContain('<Input v-model="dbSearchQuery" v-connection-dialog-auto-focus');
+    expect(dialogSource).toContain('<Input v-model="form.name" v-connection-dialog-auto-focus');
+    expect(dialogSource).toContain("const vConnectionDialogAutoFocus: ObjectDirective<HTMLInputElement>");
+    expect(dialogSource).toContain("input.focus({ preventScroll: true })");
     expect(dialogSource).not.toMatch(/<DialogContent[^>]*\stabindex="-1"/);
   });
 


### PR DESCRIPTION
## 问题

#4270 将新建连接弹窗的初始焦点从弹窗容器移到了标题，以保证焦点进入弹窗内部。但在 macOS WKWebView 中，应用重启后首次打开新建连接时，系统会在标题周围绘制蓝色原生焦点框，看起来像标题被选中。

## 修改

- 数据库类型选择页打开时，默认聚焦“搜索数据库类型”输入框
- 直接编辑已有连接时，默认聚焦“连接名称”输入框
- 使用输入框挂载指令在 FocusScope 执行默认聚焦前建立焦点，保留弹窗键盘和读屏可访问性
- 更新连接弹窗无障碍回归测试，避免后续重新聚焦标题或弹窗容器

## 验证

- macOS 使用 `DBX_DISABLE_PASSWORD=1 make dev-fast` 实际启动客户端，重启后首次打开新建连接验证通过
- `pnpm vitest run apps/desktop/src/lib/__tests__/connection/connectionDialogAccessibility.spec.ts`
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/components/connection/ConnectionDialog.vue apps/desktop/src/lib/__tests__/connection/connectionDialogAccessibility.spec.ts`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/connection/ConnectionDialog.vue apps/desktop/src/lib/__tests__/connection/connectionDialogAccessibility.spec.ts`