### PR TITLE
Fix：兼容 MySQL 代理拒绝会话变量设置

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -730,7 +730,9 @@ async fn verify_pool_connection_with_setup_fallback(
             let Some(fallback_mode) = mysql_group_concat_setup_fallback_mode(setup_mode, &err) else {
                 return Err(err);
             };
-            log::info!("MySQL server rejected group_concat_max_len setup syntax; retrying with {fallback_mode:?} mode");
+            log::info!(
+                "MySQL server rejected optional group_concat_max_len setup; retrying with {fallback_mode:?} mode"
+            );
             let fallback_pool = create_pool(
                 url,
                 ca_cert_path,
@@ -758,7 +760,14 @@ fn mysql_group_concat_setup_fallback_mode(setup_mode: MySqlSetupMode, error: &st
     let sphinxql_setup_query_rejected = lower.contains("sphinxql")
         && lower.contains("only 0 and 1 could be used as boolean values")
         && lower.contains(&format!("near '{MYSQL_GROUP_CONCAT_MAX_LEN}'"));
-    if (lower.contains("group_concat_max_len") && setup_query_rejected) || sphinxql_setup_query_rejected {
+    // Some MySQL gateways omit the variable name and report session-variable
+    // changes as a forbidden global-variable operation.
+    let gateway_session_variable_rejected =
+        lower.contains("error 10192 (hy000)") && lower.contains("set global variables is forbidden");
+    if (lower.contains("group_concat_max_len") && setup_query_rejected)
+        || sphinxql_setup_query_rejected
+        || gateway_session_variable_rejected
+    {
         return Some(MySqlSetupMode::Compatible);
     }
 
@@ -4859,6 +4868,27 @@ mod tests {
             mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error),
             Some(MySqlSetupMode::Compatible)
         );
+    }
+
+    #[test]
+    fn mysql_gateway_forbidden_global_variables_error_retries_without_session_variable() {
+        let error = "MySQL connection failed: Server error: `ERROR 10192 (HY000): SET GLOBAL VARIABLES is forbidden'";
+
+        assert_eq!(
+            mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error),
+            Some(MySqlSetupMode::Compatible)
+        );
+    }
+
+    #[test]
+    fn mysql_gateway_setup_retry_requires_exact_error_code_and_message() {
+        for error in [
+            "Server error: ERROR 10192 (HY000): operation is forbidden",
+            "Server error: ERROR 1227 (42000): SET GLOBAL VARIABLES is forbidden",
+            "Server error: ERROR 101920 (HY000): SET GLOBAL VARIABLES is forbidden",
+        ] {
+            assert_eq!(mysql_group_concat_setup_fallback_mode(MySqlSetupMode::Standard, error), None);
+        }
     }
 
     #[test]

--- a/crates/dbx-core/src/db/questdb.rs
+++ b/crates/dbx-core/src/db/questdb.rs
@@ -210,6 +210,15 @@ async fn questdb_normal_view_ddl(pool: &Pool, view: &str) -> Result<String, Stri
     first_string_cell(db::postgres::execute_query(pool, &sql).await?)
 }
 
+fn first_string_cell(result: QueryResult) -> Result<String, String> {
+    result
+        .rows
+        .first()
+        .and_then(|row| row.iter().find_map(|value| value.as_str().map(str::to_string)))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "Object source not found".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,13 +229,4 @@ mod tests {
         assert_eq!(questdb_tables_sql_mat_view_version(), "SELECT table_name, matView FROM tables()");
         assert_eq!(questdb_tables_sql_basic(), "SELECT table_name FROM tables()");
     }
-}
-
-fn first_string_cell(result: QueryResult) -> Result<String, String> {
-    result
-        .rows
-        .first()
-        .and_then(|row| row.iter().find_map(|value| value.as_str().map(str::to_string)))
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| "Object source not found".to_string())
 }


### PR DESCRIPTION
## 问题

DBX 0.5.66 连接 MySQL 时会设置当前连接的 `SESSION group_concat_max_len`，用于避免元数据中的 `GROUP_CONCAT` 结果被默认长度截断。

部分 MySQL 代理不会返回变量名，而是将该会话变量设置笼统地拒绝为：

```text
ERROR 10192 (HY000): SET GLOBAL VARIABLES is forbidden
```

受影响的普通账号已确认，直接执行相同的 `SET SESSION group_concat_max_len` 也会返回该错误。现有兼容逻辑无法识别这条通用错误，因此不会跳过可选设置并重试连接。

## 修改

- 严格匹配 `ERROR 10192 (HY000)` 和 `SET GLOBAL VARIABLES is forbidden` 的组合
- 命中后使用兼容模式重连，不再设置可选的 `group_concat_max_len`
- 保留其他初始化语句和真实权限错误，不扩大降级范围
- 调整重试日志，使其同时适用于语法不兼容和代理权限限制
- 增加错误码、错误文案及近似错误的正反例测试

## 验证

- `cargo test -p dbx-core --locked db::mysql::tests --lib`：125 通过，1 个既有远程 MariaDB 测试忽略
- `cargo clippy -p dbx-core --locked --lib --no-default-features --features mq-admin,sqlite-sqlcipher -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

## 基线状态

当前 `origin/main` 的 CI 在 QuestDB 改动中已有 Rust 测试和全目标 Clippy 失败，与本 PR 的 MySQL 改动无关：[main CI](https://github.com/t8y2/dbx/actions/runs/30082731424)。