### PR TITLE
feat(connection): add copy connection name

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -11,7 +11,7 @@ import { filterSidebarSearchRootsByConnectionState, filterSidebarTree, filterSid
 import { isCancelSearchShortcut, isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut } from "@/lib/editor/keyboardShortcuts";
 import { copyNameForTreeNode, objectSourceKindForTreeNode } from "@/lib/sidebar/treeNodeClick";
 import { copyToClipboard } from "@/lib/common/clipboard";
-import { connectionPasteTargetGroupId, selectedConnectionClipboardNodes, selectedConnectionEditTarget } from "@/lib/sidebar/sidebarConnectionSelection";
+import { connectionPasteTargetGroupId, copySelectedConnectionsToClipboards, selectedConnectionEditTarget } from "@/lib/sidebar/sidebarConnectionSelection";
 import { isEditableSidebarTypeSearchTarget, sidebarTypeSearchNextQuery } from "@/lib/sidebar/sidebarTypeSearch";
 import { usesTreeSchemaMode } from "@/lib/database/databaseFeatureSupport";
 import { connectionUsesDatabaseObjectTreeMode, effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
@@ -1304,11 +1304,10 @@ function requestSelectedConnectionEdit(): boolean {
 function copySelectedSidebarNames(): boolean {
   const nodes = selectedSidebarNodesInVisibleOrder();
   if (nodes.length === 0) return false;
-  const connectionNodes = selectedConnectionClipboardNodes(nodes);
-  if (connectionNodes.length > 0) {
-    const copiedCount = store.copyConnectionsToTreeClipboard(connectionNodes.map((node) => node.connectionId));
-    if (copiedCount > 0) toast(t("connection.copied"), 2000);
-    return copiedCount > 0;
+  const copiedCount = copySelectedConnectionsToClipboards(nodes, (connectionIds) => store.copyConnectionsToTreeClipboard(connectionIds), copyToClipboard);
+  if (copiedCount > 0) {
+    toast(t("connection.copied"), 2000);
+    return true;
   }
   const tableNodes = nodes.filter((node) => node.type === "table" && !!node.connectionId && !!node.database);
   store.treeClipboard =

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -1285,7 +1285,14 @@ async function copySelectedNames() {
   const connectionTargets = selectedConnectionClipboardTargets(activeNode.value, nodes);
   if (connectionTargets.length > 0) {
     const copiedCount = connectionStore.copyConnectionsToTreeClipboard(connectionTargets.map((node) => node.connectionId));
-    if (copiedCount > 0) toast(t("connection.copied"), 2000);
+    if (copiedCount > 0) {
+      try {
+        await copyToClipboard(connectionTargets.map(copyNameForTreeNode).join("\n"));
+      } catch {
+        /* system clipboard copy is best-effort */
+      }
+      toast(t("connection.copied"), 2000);
+    }
     return;
   }
   updateTreeClipboardForNodes(nodes);
@@ -3504,6 +3511,9 @@ function buildConnectionSidebarMenu(context: SidebarMenuFactoryContext): boolean
     } else {
       items.push({ label: t("contextMenu.closeConnection"), action: disconnectConnection, icon: Unplug });
     }
+    items.push({ label: "", separator: true });
+    items.push({ label: t("contextMenu.copyName"), action: copyName, icon: Copy, shortcut: shortcutCopyName.value });
+    items.push({ label: "", separator: true });
     items.push({ label: t("contextMenu.newQuery"), action: newQuery, icon: TerminalSquare });
     if (currentDatabaseType() === "redis") {
       items.push({ label: t("contextMenu.instanceInfo"), action: openRedisInstanceInfo, icon: Info });

--- a/apps/desktop/src/lib/__tests__/sidebar/sidebarConnectionSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/sidebarConnectionSelection.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { selectedConnectionDeleteTargets, selectedConnectionDuplicateTargets } from "@/lib/sidebar/sidebarConnectionSelection";
+import { describe, expect, it, vi } from "vitest";
+import { copySelectedConnectionsToClipboards, selectedConnectionDeleteTargets, selectedConnectionDuplicateTargets } from "@/lib/sidebar/sidebarConnectionSelection";
 import type { TreeNode } from "@/types/database";
 
 function node(id: string, type: TreeNode["type"] = "connection"): TreeNode {
@@ -31,5 +31,23 @@ describe("sidebar connection selection", () => {
     const selected = [current, node("conn-2")];
 
     expect(selectedConnectionDuplicateTargets(current, selected)).toEqual(selectedConnectionDeleteTargets(current, selected));
+  });
+
+  it("copies selected connection names to the system clipboard for the sidebar copy shortcut", () => {
+    const copyConnectionsToTreeClipboard = vi.fn(() => 2);
+    const copyToSystemClipboard = vi.fn(() => Promise.resolve());
+
+    expect(copySelectedConnectionsToClipboards([node("conn-1"), node("conn-2")], copyConnectionsToTreeClipboard, copyToSystemClipboard)).toBe(2);
+    expect(copyConnectionsToTreeClipboard).toHaveBeenCalledWith(["conn-1", "conn-2"]);
+    expect(copyToSystemClipboard).toHaveBeenCalledWith("conn-1\nconn-2");
+  });
+
+  it("keeps the tree clipboard copy when system clipboard access is denied", async () => {
+    const copyConnectionsToTreeClipboard = vi.fn(() => 1);
+    const copyToSystemClipboard = vi.fn(() => Promise.reject(new Error("denied")));
+
+    expect(copySelectedConnectionsToClipboards([node("conn-1")], copyConnectionsToTreeClipboard, copyToSystemClipboard)).toBe(1);
+    await Promise.resolve();
+    expect(copyConnectionsToTreeClipboard).toHaveBeenCalledWith(["conn-1"]);
   });
 });

--- a/apps/desktop/src/lib/sidebar/sidebarConnectionSelection.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarConnectionSelection.ts
@@ -1,4 +1,5 @@
 import type { TreeNode } from "@/types/database";
+import { copyNameForTreeNode } from "@/lib/sidebar/treeNodeClick";
 
 type ConnectionTreeNode = TreeNode & { connectionId: string };
 
@@ -37,6 +38,22 @@ export function selectedConnectionEditTarget(currentNode: TreeNode, selectedNode
 export function selectedConnectionClipboardNodes(selectedNodes: TreeNode[]): ConnectionTreeNode[] {
   if (selectedNodes.length === 0 || !selectedNodes.every(isConnectionNode)) return [];
   return selectedNodes;
+}
+
+export function copySelectedConnectionsToClipboards(
+  selectedNodes: TreeNode[],
+  copyConnectionsToTreeClipboard: (connectionIds: string[]) => number,
+  copyToSystemClipboard: (text: string) => Promise<void>,
+): number {
+  const connectionNodes = selectedConnectionClipboardNodes(selectedNodes);
+  if (connectionNodes.length === 0) return 0;
+
+  const copiedCount = copyConnectionsToTreeClipboard(connectionNodes.map((node) => node.connectionId));
+  if (copiedCount > 0) {
+    // Connection duplication uses the tree clipboard, so keep it available even if OS clipboard access is denied.
+    void copyToSystemClipboard(connectionNodes.map(copyNameForTreeNode).join("\n")).catch(() => {});
+  }
+  return copiedCount;
 }
 
 export function connectionPasteTargetGroupId(node: TreeNode | null | undefined, groupIdForConnection: (connectionId: string) => string | null): string | null {

--- a/apps/desktop/src/lib/sidebar/sidebarConnectionSelection.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarConnectionSelection.ts
@@ -40,11 +40,7 @@ export function selectedConnectionClipboardNodes(selectedNodes: TreeNode[]): Con
   return selectedNodes;
 }
 
-export function copySelectedConnectionsToClipboards(
-  selectedNodes: TreeNode[],
-  copyConnectionsToTreeClipboard: (connectionIds: string[]) => number,
-  copyToSystemClipboard: (text: string) => Promise<void>,
-): number {
+export function copySelectedConnectionsToClipboards(selectedNodes: TreeNode[], copyConnectionsToTreeClipboard: (connectionIds: string[]) => number, copyToSystemClipboard: (text: string) => Promise<void>): number {
   const connectionNodes = selectedConnectionClipboardNodes(selectedNodes);
   if (connectionNodes.length === 0) return 0;
 


### PR DESCRIPTION
Add "Copy Name" to the connection context menu and copy the connection name to the system clipboard when pressing Cmd/Ctrl+C on a selected connection node.

Closes #4122

## 变更说明

在连接节点的右键菜单中新增「Copy Name」菜单项，并支持选中连接后按 Cmd/Ctrl+C 将连接名称复制到系统剪贴板。

具体改动：
1. **右键菜单**：在 [buildConnectionSidebarMenu](src/components/sidebar/SidebarTreeRuntimeHost.vue:3502:0-3655:1) 中，Open/Close Connection 之后、New Query 之前，添加「Copy Name」菜单项（带快捷键提示），与连接分组、数据库、表等其他节点类型保持一致。
2. **键盘快捷键**：修改 [copySelectedNames](src/components/sidebar/SidebarTreeRuntimeHost.vue:1281:0-1304:1) 函数，对连接节点在设置内部剪贴板（用于 DBX 内部粘贴/复制连接）的同时，也将连接名称文本写入系统剪贴板，方便用户粘贴到其他应用（如 MCP 客户端）。系统剪贴板复制为 best-effort，失败不影响内部操作。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="574" height="624" alt="image" src="https://github.com/user-attachments/assets/81af85d9-7e23-48e6-bcda-8de06d95bae7" />

## 验证

- [x] `vue-tsc --noEmit` 类型检查通过
- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

> 注：本次仅修改前端 Vue 组件，未涉及 Rust 后端改动，`cargo-check-fast` 不受影响。

## 关联 Issue

Close #4122
