### PR TITLE
fix(settings): keep MCP client tabs scrollable without overlap

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -5395,15 +5395,15 @@ onUnmounted(cleanupPreviewEditor);
               <div class="space-y-2">
                 <Label>{{ t("settings.mcpConfig") }}</Label>
                 <Tabs v-model="mcpConfigTab" class="space-y-3">
-                  <TabsList class="h-8 w-full max-w-full justify-start gap-1 overflow-x-auto overflow-y-hidden">
-                    <TabsTrigger value="claude" class="h-8 flex-none shrink-0 px-2.5">Claude Code</TabsTrigger>
-                    <TabsTrigger value="cursor" class="h-8 flex-none shrink-0 px-2.5">Cursor</TabsTrigger>
-                    <TabsTrigger value="trae" class="h-8 flex-none shrink-0 px-2.5">TRAE</TabsTrigger>
-                    <TabsTrigger value="vscode" class="h-8 flex-none shrink-0 px-2.5">VS Code</TabsTrigger>
-                    <TabsTrigger value="windsurf" class="h-8 flex-none shrink-0 px-2.5">Windsurf</TabsTrigger>
-                    <TabsTrigger value="codex" class="h-8 flex-none shrink-0 px-2.5">Codex</TabsTrigger>
-                    <TabsTrigger value="opencode" class="h-8 flex-none shrink-0 px-2.5">OpenCode</TabsTrigger>
-                    <TabsTrigger value="cherry-studio" class="h-8 flex-none shrink-0 px-2.5">Cherry Studio</TabsTrigger>
+                  <TabsList class="h-auto min-h-8 w-full min-w-0 max-w-full justify-start gap-1 overflow-x-auto overflow-y-hidden overscroll-x-contain group-data-horizontal/tabs:h-auto">
+                    <TabsTrigger value="claude" class="h-7 flex-none shrink-0 px-2.5">Claude Code</TabsTrigger>
+                    <TabsTrigger value="cursor" class="h-7 flex-none shrink-0 px-2.5">Cursor</TabsTrigger>
+                    <TabsTrigger value="trae" class="h-7 flex-none shrink-0 px-2.5">TRAE</TabsTrigger>
+                    <TabsTrigger value="vscode" class="h-7 flex-none shrink-0 px-2.5">VS Code</TabsTrigger>
+                    <TabsTrigger value="windsurf" class="h-7 flex-none shrink-0 px-2.5">Windsurf</TabsTrigger>
+                    <TabsTrigger value="codex" class="h-7 flex-none shrink-0 px-2.5">Codex</TabsTrigger>
+                    <TabsTrigger value="opencode" class="h-7 flex-none shrink-0 px-2.5">OpenCode</TabsTrigger>
+                    <TabsTrigger value="cherry-studio" class="h-7 flex-none shrink-0 px-2.5">Cherry Studio</TabsTrigger>
                   </TabsList>
 
                   <TabsContent value="claude" class="m-0">

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -5395,7 +5395,7 @@ onUnmounted(cleanupPreviewEditor);
               <div class="space-y-2">
                 <Label>{{ t("settings.mcpConfig") }}</Label>
                 <Tabs v-model="mcpConfigTab" class="space-y-3">
-                  <TabsList class="flex h-auto w-full min-w-0 flex-wrap items-center justify-start gap-1 overflow-visible group-data-horizontal/tabs:h-auto">
+                  <TabsList class="h-8 w-full max-w-full justify-start gap-1 overflow-x-auto overflow-y-hidden">
                     <TabsTrigger value="claude" class="h-8 flex-none shrink-0 px-2.5">Claude Code</TabsTrigger>
                     <TabsTrigger value="cursor" class="h-8 flex-none shrink-0 px-2.5">Cursor</TabsTrigger>
                     <TabsTrigger value="trae" class="h-8 flex-none shrink-0 px-2.5">TRAE</TabsTrigger>

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -5395,15 +5395,15 @@ onUnmounted(cleanupPreviewEditor);
               <div class="space-y-2">
                 <Label>{{ t("settings.mcpConfig") }}</Label>
                 <Tabs v-model="mcpConfigTab" class="space-y-3">
-                  <TabsList class="grid h-auto w-full grid-cols-2 gap-1 overflow-visible group-data-horizontal/tabs:h-auto sm:grid-cols-4 xl:grid-cols-8">
-                    <TabsTrigger value="claude" class="h-8 min-w-0 px-2">Claude Code</TabsTrigger>
-                    <TabsTrigger value="cursor" class="h-8 min-w-0 px-2">Cursor</TabsTrigger>
-                    <TabsTrigger value="trae" class="h-8 min-w-0 px-2">TRAE</TabsTrigger>
-                    <TabsTrigger value="vscode" class="h-8 min-w-0 px-2">VS Code</TabsTrigger>
-                    <TabsTrigger value="windsurf" class="h-8 min-w-0 px-2">Windsurf</TabsTrigger>
-                    <TabsTrigger value="codex" class="h-8 min-w-0 px-2">Codex</TabsTrigger>
-                    <TabsTrigger value="opencode" class="h-8 min-w-0 px-2">OpenCode</TabsTrigger>
-                    <TabsTrigger value="cherry-studio" class="h-8 min-w-0 px-2">Cherry Studio</TabsTrigger>
+                  <TabsList class="flex h-auto w-full min-w-0 flex-wrap items-center justify-start gap-1 overflow-visible group-data-horizontal/tabs:h-auto">
+                    <TabsTrigger value="claude" class="h-8 flex-none shrink-0 px-2.5">Claude Code</TabsTrigger>
+                    <TabsTrigger value="cursor" class="h-8 flex-none shrink-0 px-2.5">Cursor</TabsTrigger>
+                    <TabsTrigger value="trae" class="h-8 flex-none shrink-0 px-2.5">TRAE</TabsTrigger>
+                    <TabsTrigger value="vscode" class="h-8 flex-none shrink-0 px-2.5">VS Code</TabsTrigger>
+                    <TabsTrigger value="windsurf" class="h-8 flex-none shrink-0 px-2.5">Windsurf</TabsTrigger>
+                    <TabsTrigger value="codex" class="h-8 flex-none shrink-0 px-2.5">Codex</TabsTrigger>
+                    <TabsTrigger value="opencode" class="h-8 flex-none shrink-0 px-2.5">OpenCode</TabsTrigger>
+                    <TabsTrigger value="cherry-studio" class="h-8 flex-none shrink-0 px-2.5">Cherry Studio</TabsTrigger>
                   </TabsList>
 
                   <TabsContent value="claude" class="m-0">

--- a/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
@@ -110,14 +110,16 @@ describe("MCP policy settings state", () => {
     expect(settingsDialogSource).toContain("onMcpExecutionModeKeydown($event, 'safe_write')");
   });
 
-  it("keeps MCP client config tabs wrapping without squeezed labels", () => {
+  it("keeps MCP client config tabs on a single scrollable row", () => {
     const tabsStart = settingsDialogSource.indexOf('<Tabs v-model="mcpConfigTab"');
     const tabsEnd = settingsDialogSource.indexOf("</TabsList>", tabsStart);
     const tabsSource = settingsDialogSource.slice(tabsStart, tabsEnd);
 
     expect(tabsStart).toBeGreaterThan(-1);
     expect(tabsEnd).toBeGreaterThan(tabsStart);
-    expect(tabsSource).toContain("flex-wrap");
+    expect(tabsSource).toContain("overflow-x-auto");
+    expect(tabsSource).toContain("max-w-full");
+    expect(tabsSource).not.toContain("flex-wrap");
     expect(tabsSource).not.toContain("grid-cols-");
     expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(8);
     expect(tabsSource).not.toContain("min-w-0 px-");

--- a/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
@@ -109,6 +109,19 @@ describe("MCP policy settings state", () => {
     expect(settingsDialogSource).toContain(":aria-checked=\"mcpExecutionMode === 'safe_write'\"");
     expect(settingsDialogSource).toContain("onMcpExecutionModeKeydown($event, 'safe_write')");
   });
+
+  it("keeps MCP client config tabs wrapping without squeezed labels", () => {
+    const tabsStart = settingsDialogSource.indexOf('<Tabs v-model="mcpConfigTab"');
+    const tabsEnd = settingsDialogSource.indexOf("</TabsList>", tabsStart);
+    const tabsSource = settingsDialogSource.slice(tabsStart, tabsEnd);
+
+    expect(tabsStart).toBeGreaterThan(-1);
+    expect(tabsEnd).toBeGreaterThan(tabsStart);
+    expect(tabsSource).toContain("flex-wrap");
+    expect(tabsSource).not.toContain("grid-cols-");
+    expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(8);
+    expect(tabsSource).not.toContain("min-w-0 px-");
+  });
 });
 
 describe("MCP connection search", () => {

--- a/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
@@ -118,7 +118,9 @@ describe("MCP policy settings state", () => {
     expect(tabsStart).toBeGreaterThan(-1);
     expect(tabsEnd).toBeGreaterThan(tabsStart);
     expect(tabsSource).toContain("overflow-x-auto");
+    expect(tabsSource).toContain("min-w-0");
     expect(tabsSource).toContain("max-w-full");
+    expect(tabsSource).toContain("overscroll-x-contain");
     expect(tabsSource).not.toContain("flex-wrap");
     expect(tabsSource).not.toContain("grid-cols-");
     expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(8);


### PR DESCRIPTION
## 变更说明

设置 → MCP →「MCP 配置」客户端 tabs 在窗口变窄时文字重叠。

**根因**
- `TabsList` 被改成 `grid` + `TabsTrigger min-w-0`
- 默认 `whitespace-nowrap` 下格子被压扁，文字溢出叠在一起

**修复**
- 恢复单行胶囊条 + `overflow-x-auto` 横向滚动
- 标签 `flex-none shrink-0`，不被压缩
- 补 `min-w-0` / `max-w-full` / `overscroll-x-contain`，适配设置内容区 `overflow-x-hidden` 父级
- 高度改为 `h-auto min-h-8` + trigger `h-7`，避免 `h-8` 列表高度与 padding/滚动条盒模型冲突
- 回归测试锁定 scroll 布局，禁止回到 grid/wrap

## 变更类型

- [x] Bug 修复

## 涉及前端

- [x] 本 PR 涉及前端改动

## 验证

- [x] `pnpm exec vitest run apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts` → 17/17 passed
- [x] 回归测试 red/green：改回 grid 后失败，恢复后通过
- [x] `twMerge` 类名合并：`min-w-0` + `overflow-x-auto` 生效，`flex-none` 覆盖默认 `flex-1`
- [x] Edge headless 几何复现：
  - old grid：`overlaps=6`
  - fix scroll：`overlaps=0`，`scrollWorks=true`，`minWidth=0px`
- [x] `pnpm build` 通过（此前前端构建成功）
- [ ] 未在完整 Tauri 打包 exe 内手工点一遍（本机验证为 headless 布局复现 + unit）

手动验证：
1. 打开设置 → MCP
2. 缩窄窗口
3. 客户端标签单行完整显示，可横向滚动，不再重叠

## 关联 Issue

无
