### PR TITLE
fix(sidebar): 修复侧边栏批量复制粘贴表后列表只多显示了一张表，手动刷新后才能显示所有复制的表。

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -2800,7 +2800,7 @@ async function confirmPasteTable() {
   showPasteDialog.value = false;
   let successCount = 0;
   let failCount = 0;
-  const refreshedConnections = new Set<string>();
+  const refreshTargets = new Map<string, { connectionId: string; database: string; schema?: string }>();
   for (const entry of entries) {
     const targetName = entry.targetName.trim();
     try {
@@ -2832,13 +2832,22 @@ async function confirmPasteTable() {
       }
       successCount++;
       const refreshKey = `${entry.connectionId}:${entry.database}:${entry.schema || ""}`;
-      if (!refreshedConnections.has(refreshKey)) {
-        refreshedConnections.add(refreshKey);
-        await connectionStore.refreshObjectListTreeNode(entry.connectionId, entry.database, entry.schema);
-      }
+      refreshTargets.set(refreshKey, {
+        connectionId: entry.connectionId,
+        database: entry.database,
+        schema: entry.schema,
+      });
     } catch (e: any) {
       failCount++;
       console.error(`Failed to paste table "${entry.sourceName}" -> "${targetName}":`, e);
+    }
+  }
+  for (const refreshTarget of refreshTargets.values()) {
+    try {
+      await connectionStore.refreshObjectListTreeNode(refreshTarget.connectionId, refreshTarget.database, refreshTarget.schema);
+    } catch (e: any) {
+      failCount++;
+      console.error(`Failed to refresh pasted tables for "${refreshTarget.database}"${refreshTarget.schema ? ` schema "${refreshTarget.schema}"` : ""}:`, e);
     }
   }
   if (failCount === 0) {

--- a/packages/app-tests/sidebarContextMenuHost.test.ts
+++ b/packages/app-tests/sidebarContextMenuHost.test.ts
@@ -71,3 +71,16 @@ test("table copy menu uses the shared single and multi-selection clipboard path"
   assert.match(copySelectedNamesBody, /updateTreeClipboardForNodes\(nodes\)/);
   assert.match(copySelectedNamesBody, /copyToClipboard\(nodes\.map\(copyNameForTreeNode\)\.join\("\\n"\)\)/);
 });
+
+test("batch table paste refreshes each object list after all tables are processed", () => {
+  const runtimeHost = readFileSync("apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue", "utf8");
+  const confirmPasteTableBody = functionBody(runtimeHost, "confirmPasteTable");
+  const pasteLoopIndex = confirmPasteTableBody.indexOf("for (const entry of entries)");
+  const refreshLoopIndex = confirmPasteTableBody.indexOf("for (const refreshTarget of refreshTargets.values())");
+
+  assert.notEqual(pasteLoopIndex, -1);
+  assert.notEqual(refreshLoopIndex, -1);
+  assert.ok(refreshLoopIndex > pasteLoopIndex, "object-list refresh must run after the table paste loop");
+  assert.doesNotMatch(confirmPasteTableBody.slice(pasteLoopIndex, refreshLoopIndex), /refreshObjectListTreeNode/);
+  assert.match(confirmPasteTableBody.slice(refreshLoopIndex), /refreshObjectListTreeNode\(refreshTarget\.connectionId, refreshTarget\.database, refreshTarget\.schema\)/);
+});


### PR DESCRIPTION
## 变更说明

修复侧边栏选择多张表后复制粘贴，侧边栏列表只多了一张表，刷新后才能展示所有复制的表的bug。


## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

复制3个表后粘贴：
<img width="644" height="366" alt="image" src="https://github.com/user-attachments/assets/782cd07d-d7fc-401b-8a4f-99353576ea49" />

只多了一个
<img width="285" height="390" alt="image" src="https://github.com/user-attachments/assets/ebc0febf-357f-444d-b7a1-00e1d69841a3" />

刷新后多的3个都显示了
<img width="265" height="379" alt="image" src="https://github.com/user-attachments/assets/2205f8b3-9703-446b-adaa-ab88246ccd56" />

修复后问题已解决。

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
