### PR TITLE
perf(grid): optimize bulk edit performance

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -2763,6 +2763,8 @@ const {
   isSaving,
   saveError,
   useTransaction,
+  beginBatch,
+  commitBatch,
   exitTransaction,
   startEdit,
   commitEdit,
@@ -5468,28 +5470,33 @@ function fillSelectionWithValue(value: string | null): boolean {
   const range = selectedRange.value;
   let applied = false;
   const allowDraftSelectionValue = selectedRangeTargetsOnlyDraftRow();
-  if (range) {
-    for (let rowIndex = range.startRow; rowIndex <= range.endRow; rowIndex++) {
+  beginBatch();
+  try {
+    if (range) {
+      for (let rowIndex = range.startRow; rowIndex <= range.endRow; rowIndex++) {
+        const item = displayItemAt(rowIndex);
+        if (!item) continue;
+        for (let visibleCol = range.startCol; visibleCol <= range.endCol; visibleCol++) {
+          applied = applyVisibleSelectedCellValue(item, visibleCol, value, allowDraftSelectionValue) || applied;
+        }
+      }
+      return applied;
+    }
+
+    if (!hasColumnSelection.value) return false;
+    const visibleColumnIndexes = selectedVisibleColumnIndexes();
+    if (!visibleColumnIndexes.length) return false;
+    for (let rowIndex = 0; rowIndex < displayRowCount.value; rowIndex++) {
       const item = displayItemAt(rowIndex);
       if (!item) continue;
-      for (let visibleCol = range.startCol; visibleCol <= range.endCol; visibleCol++) {
-        applied = applyVisibleSelectedCellValue(item, visibleCol, value, allowDraftSelectionValue) || applied;
+      for (const visibleCol of visibleColumnIndexes) {
+        applied = applyVisibleSelectedCellValue(item, visibleCol, value) || applied;
       }
     }
     return applied;
+  } finally {
+    commitBatch();
   }
-
-  if (!hasColumnSelection.value) return false;
-  const visibleColumnIndexes = selectedVisibleColumnIndexes();
-  if (!visibleColumnIndexes.length) return false;
-  for (let rowIndex = 0; rowIndex < displayRowCount.value; rowIndex++) {
-    const item = displayItemAt(rowIndex);
-    if (!item) continue;
-    for (const visibleCol of visibleColumnIndexes) {
-      applied = applyVisibleSelectedCellValue(item, visibleCol, value) || applied;
-    }
-  }
-  return applied;
 }
 
 function selectionHasEditableCells(): boolean {
@@ -5572,9 +5579,14 @@ function applyGeneratedSelectionValue(kind: CellValueGenerationKind, startValue 
   const values = generateCellValues(kind, cells.length, { startValue });
   const allowDraftSelectionValue = selectedRangeTargetsOnlyDraftRow();
   let applied = false;
-  cells.forEach((cell, index) => {
-    applied = applyVisibleSelectedCellValue(cell.item, cell.visibleCol, values[index] ?? null, allowDraftSelectionValue, { preserveEmptyString: kind === "empty" }) || applied;
-  });
+  beginBatch();
+  try {
+    cells.forEach((cell, index) => {
+      applied = applyVisibleSelectedCellValue(cell.item, cell.visibleCol, values[index] ?? null, allowDraftSelectionValue, { preserveEmptyString: kind === "empty" }) || applied;
+    });
+  } finally {
+    commitBatch();
+  }
   if (applied) toast(t("grid.generatedValuesApplied", { count: cells.length }));
   return applied;
 }
@@ -5628,12 +5640,17 @@ function cutSelection() {
   copySelectionTsv();
   const range = selectedRange.value;
   const allowDraftSelectionValue = selectedRangeTargetsOnlyDraftRow();
-  for (let rowIndex = range.startRow; rowIndex <= range.endRow; rowIndex++) {
-    const item = displayItemAt(rowIndex);
-    if (!item) continue;
-    for (let visibleCol = range.startCol; visibleCol <= range.endCol; visibleCol++) {
-      applyVisibleSelectedCellValue(item, visibleCol, null, allowDraftSelectionValue);
+  beginBatch();
+  try {
+    for (let rowIndex = range.startRow; rowIndex <= range.endRow; rowIndex++) {
+      const item = displayItemAt(rowIndex);
+      if (!item) continue;
+      for (let visibleCol = range.startCol; visibleCol <= range.endCol; visibleCol++) {
+        applyVisibleSelectedCellValue(item, visibleCol, null, allowDraftSelectionValue);
+      }
     }
+  } finally {
+    commitBatch();
   }
 }
 

--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -1,4 +1,4 @@
-import { ref, computed, nextTick, watch, getCurrentInstance, onActivated, onBeforeUnmount, onDeactivated, onMounted, toRaw, type ComputedRef, type Ref } from "vue";
+import { ref, shallowRef, computed, nextTick, watch, getCurrentInstance, onActivated, onBeforeUnmount, onDeactivated, onMounted, toRaw, type ComputedRef, type Ref } from "vue";
 import * as api from "@/lib/backend/api";
 import type { CellValue } from "@/lib/dataGrid/cellValue";
 import { coerceDataGridCellValue, dataGridCellEditorText } from "@/lib/dataGrid/dataGridCellCoercion";
@@ -206,7 +206,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
   const editingCell = ref<{ rowId: number; col: number } | null>(null);
   const editValue = ref("");
   const scrollerRef = ref<GridScrollerRef | null>(null);
-  const dirtyRows = ref<Map<number, Map<number, CellValue>>>(new Map());
+  const dirtyRows = shallowRef<Map<number, Map<number, CellValue>>>(new Map());
   const newRows = ref<CellValue[][]>([]);
   const deletedRows = ref<Set<number>>(new Set());
   const quickEntryDraftRow = ref<CellValue[]>([]);
@@ -500,10 +500,38 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
     }) as CellValue;
   }
 
+  let isBatching = false;
+  let batchUndoSnapshotPushed = false;
+  let batchColumnInfoCache: Map<number, ColumnInfo | undefined> | null = null;
+
+  function beginBatch() {
+    if (isBatching) return;
+    isBatching = true;
+    batchUndoSnapshotPushed = false;
+    batchColumnInfoCache = new Map();
+  }
+
+  function commitBatch() {
+    if (!isBatching) return;
+    isBatching = false;
+    batchColumnInfoCache = null;
+    dirtyRows.value = new Map(dirtyRows.value);
+    newRows.value = [...newRows.value];
+    touchPendingChanges();
+  }
+
   function tableColumnForGridColumn(columnIndex: number): ColumnInfo | undefined {
+    if (isBatching && batchColumnInfoCache) {
+      if (batchColumnInfoCache.has(columnIndex)) {
+        return batchColumnInfoCache.get(columnIndex);
+      }
+    }
     const columnName = sourceColumns.value?.[columnIndex] ?? result.value.columns[columnIndex];
-    if (!columnName) return undefined;
-    return tableMeta.value?.columns.find((column) => column.name.toLowerCase() === columnName.toLowerCase());
+    const info = columnName ? tableMeta.value?.columns.find((column) => column.name.toLowerCase() === columnName.toLowerCase()) : undefined;
+    if (isBatching && batchColumnInfoCache) {
+      batchColumnInfoCache.set(columnIndex, info);
+    }
+    return info;
   }
 
   function canEditColumn(columnIndex: number): boolean {
@@ -747,9 +775,18 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       const nextDraftRow = [...quickEntryDraftRow.value];
       nextDraftRow[col] = value === null ? null : coerceCellValue(value, oldVal, col, options);
       if (nextDraftRow[col] === oldVal) return;
-      pushUndoSnapshot();
+      if (isBatching) {
+        if (!batchUndoSnapshotPushed) {
+          pushUndoSnapshot();
+          batchUndoSnapshotPushed = true;
+        }
+      } else {
+        pushUndoSnapshot();
+      }
       quickEntryDraftRow.value = draftRowHasValue(nextDraftRow) ? nextDraftRow : emptyDraftRow();
-      touchPendingChanges();
+      if (!isBatching) {
+        touchPendingChanges();
+      }
       scheduleQuickEntryDraftPromotion();
       return;
     }
@@ -761,10 +798,19 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       const oldVal = row[col];
       const newVal = value === null ? null : coerceCellValue(value, oldVal, col, options);
       if (newVal === oldVal) return;
-      pushUndoSnapshot();
+      if (isBatching) {
+        if (!batchUndoSnapshotPushed) {
+          pushUndoSnapshot();
+          batchUndoSnapshotPushed = true;
+        }
+      } else {
+        pushUndoSnapshot();
+      }
       row[col] = newVal;
-      newRows.value = [...newRows.value];
-      touchPendingChanges();
+      if (!isBatching) {
+        newRows.value = [...newRows.value];
+        touchPendingChanges();
+      }
       return;
     }
 
@@ -778,19 +824,37 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
     const newVal = value === null ? null : coerceCellValue(value, oldVal, col, options);
     if (newVal === currentVal) return;
     if (newVal !== oldVal) {
-      pushUndoSnapshot();
+      if (isBatching) {
+        if (!batchUndoSnapshotPushed) {
+          pushUndoSnapshot();
+          batchUndoSnapshotPushed = true;
+        }
+      } else {
+        pushUndoSnapshot();
+      }
       if (!dirtyRows.value.has(item.sourceIndex)) dirtyRows.value.set(item.sourceIndex, new Map());
       dirtyRows.value.get(item.sourceIndex)!.set(col, newVal);
       if (useTransaction.value && !transactionActive.value) {
         enterTransaction();
       }
     } else {
-      if (hasPendingCellChange) pushUndoSnapshot();
+      if (hasPendingCellChange) {
+        if (isBatching) {
+          if (!batchUndoSnapshotPushed) {
+            pushUndoSnapshot();
+            batchUndoSnapshotPushed = true;
+          }
+        } else {
+          pushUndoSnapshot();
+        }
+      }
       rowChanges?.delete(col);
       if (rowChanges?.size === 0) dirtyRows.value.delete(item.sourceIndex);
     }
-    dirtyRows.value = new Map(dirtyRows.value);
-    touchPendingChanges();
+    if (!isBatching) {
+      dirtyRows.value = new Map(dirtyRows.value);
+      touchPendingChanges();
+    }
   }
 
   function restoreCellValue(rowId: number, col: number) {
@@ -1330,9 +1394,9 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
   }
 
   function discardChanges() {
-    dirtyRows.value.clear();
+    dirtyRows.value = new Map();
     newRows.value = [];
-    deletedRows.value.clear();
+    deletedRows.value = new Set();
     quickEntryDraftRow.value = emptyDraftRow();
     queuedAutoSaveChanges.clear();
     editingCell.value = null;
@@ -1477,6 +1541,8 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
     isSaving,
     saveError,
     useTransaction,
+    beginBatch,
+    commitBatch,
     enterTransaction,
     exitTransaction,
     startEdit,

--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -502,12 +502,14 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
 
   let isBatching = false;
   let batchUndoSnapshotPushed = false;
+  let batchMutated = false;
   let batchColumnInfoCache: Map<number, ColumnInfo | undefined> | null = null;
 
   function beginBatch() {
     if (isBatching) return;
     isBatching = true;
     batchUndoSnapshotPushed = false;
+    batchMutated = false;
     batchColumnInfoCache = new Map();
   }
 
@@ -515,9 +517,14 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
     if (!isBatching) return;
     isBatching = false;
     batchColumnInfoCache = null;
+    if (!batchMutated) return;
     dirtyRows.value = new Map(dirtyRows.value);
     newRows.value = [...newRows.value];
     touchPendingChanges();
+  }
+
+  function markBatchMutated() {
+    if (isBatching) batchMutated = true;
   }
 
   function tableColumnForGridColumn(columnIndex: number): ColumnInfo | undefined {
@@ -784,6 +791,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
         pushUndoSnapshot();
       }
       quickEntryDraftRow.value = draftRowHasValue(nextDraftRow) ? nextDraftRow : emptyDraftRow();
+      markBatchMutated();
       if (!isBatching) {
         touchPendingChanges();
       }
@@ -807,6 +815,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
         pushUndoSnapshot();
       }
       row[col] = newVal;
+      markBatchMutated();
       if (!isBatching) {
         newRows.value = [...newRows.value];
         touchPendingChanges();
@@ -834,6 +843,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       }
       if (!dirtyRows.value.has(item.sourceIndex)) dirtyRows.value.set(item.sourceIndex, new Map());
       dirtyRows.value.get(item.sourceIndex)!.set(col, newVal);
+      markBatchMutated();
       if (useTransaction.value && !transactionActive.value) {
         enterTransaction();
       }
@@ -850,6 +860,7 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       }
       rowChanges?.delete(col);
       if (rowChanges?.size === 0) dirtyRows.value.delete(item.sourceIndex);
+      if (hasPendingCellChange) markBatchMutated();
     }
     if (!isBatching) {
       dirtyRows.value = new Map(dirtyRows.value);

--- a/packages/app-tests/dataGridEditor.test.ts
+++ b/packages/app-tests/dataGridEditor.test.ts
@@ -773,6 +773,24 @@ test("a failed NULL save keeps the pending cell edit", async () => {
   assert.equal(editor.hasPendingChanges.value, true);
 });
 
+test("committing a no-op edit batch keeps the existing save error", () => {
+  setActivePinia(createPinia());
+  installBrowserTestGlobals();
+  const editor = createPeopleGridEditor();
+
+  editor.applyCellValue(0, 1, "Ada Lovelace");
+  editor.saveError.value = "Previous save failed";
+  const version = editor.pendingChangesVersion.value;
+
+  editor.beginBatch();
+  editor.applyCellValue(0, 1, "Ada Lovelace");
+  editor.commitBatch();
+
+  assert.equal(editor.saveError.value, "Previous save failed");
+  assert.equal(editor.pendingChangesVersion.value, version);
+  assert.equal(editor.dirtyRows.value.get(0)?.get(1), "Ada Lovelace");
+});
+
 test("a NOT NULL validation failure keeps the pending NULL cell edit recoverable", async () => {
   setActivePinia(createPinia());
   installBrowserTestGlobals();


### PR DESCRIPTION
## 变更说明

优化表格数据网格（DataGrid）在进行大规模数据批量修改/填充（例如修改 7000+ 单元格）时的严重性能卡顿。

核心优化项：
1. **引入批处理事务会话（Batch Update Session）**：提供 `beginBatch` / `commitBatch` 机制，在批量处理期间只在首次有实际变动时产生一次撤销快照，避免了原本每修改一个单元格均进行一次 Map 深拷贝所带来的 $O(N^2)$ 复杂度灾难。
2. **精简响应式代理**：将 `dirtyRows` 从普通的 `ref` 改写为 `shallowRef`，彻底消除了 Vue 对大型嵌套 Map 进行递归深度代理（Proxy）拦截的性能开销。
3. **缓存在线列元数据**：在 Batch 会话内缓存每列对应的 ColumnInfo，避免在循环内部重复对所有列进行 `Array.prototype.find` 字符串查找，开销由 $O(C)$ 降至 $O(1)$。
4. **延迟合并触发更新**：在批量操作阶段，不高频地给响应式属性赋值与派发，直到最后 `commitBatch()` 时一次性浅拷贝通知 Vue，将主线程的 UI 更新成本缩减至常数次。

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI/构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏 (见下方)

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已经在本地完全跑通了 `dataGridEditor.test.ts` 和 `dataGridRuntime.spec.ts` 等共计 72 个数据网格测试文件下的 498 项单元测试用例，结果 100% 通过。

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
