### PR TITLE
Fix Linux system theme sync

### DIFF
--- a/apps/desktop/src/composables/__tests__/useTheme.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useTheme.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mediaQueryChangeListener: ((event: MediaQueryListEvent) => void) | undefined;
+let mediaQueryMatches = false;
+const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+  callback(0);
+  return 0;
+});
+const setTheme = vi.fn(async () => {});
+
+function installBrowserStubs() {
+  const mediaQuery = {
+    get matches() {
+      return mediaQueryMatches;
+    },
+    addEventListener: vi.fn((event: string, listener: (event: MediaQueryListEvent) => void) => {
+      if (event === "change") mediaQueryChangeListener = listener;
+    }),
+    removeEventListener: vi.fn(),
+  };
+  vi.stubGlobal("navigator", { userAgent: "Mozilla/5.0 (X11; Linux x86_64)" });
+  vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
+  Object.defineProperty(window, "matchMedia", { configurable: true, value: vi.fn(() => mediaQuery) });
+}
+
+async function loadTheme() {
+  localStorage.setItem("dbx-theme", "system");
+  const { useTheme } = await import("@/composables/useTheme");
+  return useTheme();
+}
+
+describe("useTheme on Linux", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.documentElement.style.colorScheme = "";
+    mediaQueryChangeListener = undefined;
+    mediaQueryMatches = false;
+    installBrowserStubs();
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => true }));
+    vi.doMock("@tauri-apps/api/window", () => ({ getCurrentWindow: () => ({ setTheme }) }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/lib/backend/tauriRuntime");
+    vi.doUnmock("@tauri-apps/api/window");
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the Linux system preference after a fresh startup without overwriting GTK", async () => {
+    mediaQueryMatches = true;
+    const theme = await loadTheme();
+
+    theme.applyTheme();
+
+    expect(theme.isDark.value).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(setTheme).not.toHaveBeenCalled();
+  });
+
+  it("continues to apply system preference changes without writing the native theme", async () => {
+    const theme = await loadTheme();
+    theme.applyTheme();
+
+    mediaQueryChangeListener?.({ matches: true } as MediaQueryListEvent);
+
+    expect(theme.isDark.value).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(setTheme).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/composables/useTheme.ts
+++ b/apps/desktop/src/composables/useTheme.ts
@@ -18,6 +18,10 @@ import {
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 
+function isLinuxTauriRuntime() {
+  return isTauriRuntime() && typeof navigator !== "undefined" && /linux/i.test(navigator.userAgent);
+}
+
 const savedThemeMode = safeLocalStorageGet(APP_THEME_STORAGE_KEY);
 const themeMode = ref<AppThemeMode>(normalizeAppThemeMode(savedThemeMode));
 const savedThemePalette = safeLocalStorageGet(APP_THEME_PALETTE_STORAGE_KEY);
@@ -67,8 +71,10 @@ function applyTheme() {
   // force reflow so the class toggle takes effect before re-enabling transitions
   doc.offsetHeight; // eslint-disable-line @typescript-eslint/no-unused-expressions
   requestAnimationFrame(() => doc.classList.remove("disable-transitions"));
+  // Tao owns the Linux GTK preference. Calling setTheme(null) here forces it
+  // to light, so DBX must leave the native setting untouched on Linux.
+  if (!isTauriRuntime() || isLinuxTauriRuntime()) return;
 
-  if (!isTauriRuntime()) return;
   if (cachedTauriWindow) {
     cachedTauriWindow
       .getCurrentWindow()


### PR DESCRIPTION
## 变更说明

修复 Linux 的“跟随系统”主题在启动时覆盖系统偏好的问题。

应用启动时会调用 `applyTheme()`。在 Linux 上，原有代码随后调用 Tauri 的 `setTheme(null)`；当前 Tao 会将该值映射为 GTK 的非深色偏好，导致已由桌面 Portal 读取到的深色主题被覆盖为浅色。现在 Linux Tauri 环境不再写入原生主题，保留 Tao/GTK/WebKit 提供的系统偏好；Windows 和 macOS 的既有行为保持不变。

默认主题仍为浅色，只有已选择“跟随系统”的用户会使用系统主题。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 只修复主题偏好读取与同步行为，不调整任何组件样式、布局或文案；按需求未附截图/录屏。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

测试环境：Fedora Linux 44 (KDE Plasma Desktop Edition)，KDE Plasma 6.7.0，Wayland。通过 session D-Bus 读取 `org.freedesktop.portal.Settings.Read(org.freedesktop.appearance, color-scheme)`，返回 `<<uint32 1>>`（Prefer Dark）。

## 关联 Issue

Close #4094
