### PR TITLE
fix(desktop): preserve Linux system theme

### DIFF
--- a/apps/desktop/src/composables/__tests__/useTheme.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useTheme.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mediaQueryChangeListener: ((event: MediaQueryListEvent) => void) | undefined;
+let mediaQueryMatches = false;
+const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+  callback(0);
+  return 0;
+});
+const setTheme = vi.fn(async () => {});
+
+function installBrowserStubs() {
+  const mediaQuery = {
+    get matches() {
+      return mediaQueryMatches;
+    },
+    addEventListener: vi.fn((event: string, listener: (event: MediaQueryListEvent) => void) => {
+      if (event === "change") mediaQueryChangeListener = listener;
+    }),
+    removeEventListener: vi.fn(),
+  };
+  vi.stubGlobal("navigator", { userAgent: "Mozilla/5.0 (X11; Linux x86_64)" });
+  vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
+  Object.defineProperty(window, "matchMedia", { configurable: true, value: vi.fn(() => mediaQuery) });
+}
+
+async function loadTheme() {
+  localStorage.setItem("dbx-theme", "system");
+  const { useTheme } = await import("@/composables/useTheme");
+  return useTheme();
+}
+
+describe("useTheme on Linux", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    document.documentElement.className = "";
+    document.documentElement.style.colorScheme = "";
+    mediaQueryChangeListener = undefined;
+    mediaQueryMatches = false;
+    installBrowserStubs();
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => true }));
+    vi.doMock("@tauri-apps/api/window", () => ({ getCurrentWindow: () => ({ setTheme }) }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("@/lib/backend/tauriRuntime");
+    vi.doUnmock("@tauri-apps/api/window");
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the Linux system preference after a fresh startup without overwriting GTK", async () => {
+    mediaQueryMatches = true;
+    const theme = await loadTheme();
+
+    theme.applyTheme();
+
+    expect(theme.isDark.value).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(setTheme).not.toHaveBeenCalled();
+  });
+
+  it("continues to apply system preference changes without writing the native theme", async () => {
+    const theme = await loadTheme();
+    theme.applyTheme();
+
+    mediaQueryChangeListener?.({ matches: true } as MediaQueryListEvent);
+
+    expect(theme.isDark.value).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(setTheme).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/composables/__tests__/useTheme.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useTheme.spec.ts
@@ -9,6 +9,22 @@ const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
 });
 const setTheme = vi.fn(async () => {});
 
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  const storage = {
+    get length() {
+      return store.size;
+    },
+    clear: vi.fn(() => store.clear()),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => [...store.keys()][index] ?? null),
+    removeItem: vi.fn((key: string) => store.delete(key)),
+    setItem: vi.fn((key: string, value: string) => store.set(key, String(value))),
+  } as Storage;
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+}
+
 function installBrowserStubs() {
   const mediaQuery = {
     get matches() {
@@ -24,10 +40,15 @@ function installBrowserStubs() {
   Object.defineProperty(window, "matchMedia", { configurable: true, value: vi.fn(() => mediaQuery) });
 }
 
-async function loadTheme() {
-  localStorage.setItem("dbx-theme", "system");
+async function loadTheme(mode: "light" | "dark" | "system" = "system") {
+  window.localStorage.setItem("dbx-theme", mode);
   const { useTheme } = await import("@/composables/useTheme");
   return useTheme();
+}
+
+async function flushDynamicImport() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("useTheme on Linux", () => {
@@ -35,7 +56,8 @@ describe("useTheme on Linux", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
-    localStorage.clear();
+    installLocalStorageStub();
+    window.localStorage.clear();
     document.documentElement.className = "";
     document.documentElement.style.colorScheme = "";
     mediaQueryChangeListener = undefined;
@@ -71,5 +93,18 @@ describe("useTheme on Linux", () => {
     expect(theme.isDark.value).toBe(true);
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     expect(setTheme).not.toHaveBeenCalled();
+  });
+
+  it("still writes explicit dark and light choices to the native Linux window theme", async () => {
+    const theme = await loadTheme("dark");
+    expect(theme.themeMode.value).toBe("dark");
+
+    theme.applyTheme();
+    await flushDynamicImport();
+    expect(setTheme).toHaveBeenLastCalledWith("dark");
+
+    theme.setThemeMode("light");
+    await flushDynamicImport();
+    expect(setTheme).toHaveBeenLastCalledWith("light");
   });
 });

--- a/apps/desktop/src/composables/useTheme.ts
+++ b/apps/desktop/src/composables/useTheme.ts
@@ -71,21 +71,24 @@ function applyTheme() {
   // force reflow so the class toggle takes effect before re-enabling transitions
   doc.offsetHeight; // eslint-disable-line @typescript-eslint/no-unused-expressions
   requestAnimationFrame(() => doc.classList.remove("disable-transitions"));
-  // Tao owns the Linux GTK preference. Calling setTheme(null) here forces it
-  // to light, so DBX must leave the native setting untouched on Linux.
-  if (!isTauriRuntime() || isLinuxTauriRuntime()) return;
+  if (!isTauriRuntime()) return;
+
+  const tauriTheme = getTauriThemeForMode(themeMode.value);
+  // Tauri owns the Linux GTK preference. Calling setTheme(null) here forces it
+  // to light, so only skip the native system-theme write and keep explicit modes.
+  if (isLinuxTauriRuntime() && tauriTheme == null) return;
 
   if (cachedTauriWindow) {
     cachedTauriWindow
       .getCurrentWindow()
-      .setTheme(getTauriThemeForMode(themeMode.value))
+      .setTheme(tauriTheme)
       .catch(() => {});
   } else {
     import("@tauri-apps/api/window").then((mod) => {
       cachedTauriWindow = mod;
       mod
         .getCurrentWindow()
-        .setTheme(getTauriThemeForMode(themeMode.value))
+        .setTheme(tauriTheme)
         .catch(() => {});
     });
   }

--- a/apps/desktop/src/composables/useTheme.ts
+++ b/apps/desktop/src/composables/useTheme.ts
@@ -18,6 +18,10 @@ import {
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 
+function isLinuxTauriRuntime() {
+  return isTauriRuntime() && typeof navigator !== "undefined" && /linux/i.test(navigator.userAgent);
+}
+
 const savedThemeMode = safeLocalStorageGet(APP_THEME_STORAGE_KEY);
 const themeMode = ref<AppThemeMode>(normalizeAppThemeMode(savedThemeMode));
 const savedThemePalette = safeLocalStorageGet(APP_THEME_PALETTE_STORAGE_KEY);
@@ -67,8 +71,10 @@ function applyTheme() {
   // force reflow so the class toggle takes effect before re-enabling transitions
   doc.offsetHeight; // eslint-disable-line @typescript-eslint/no-unused-expressions
   requestAnimationFrame(() => doc.classList.remove("disable-transitions"));
+  // Tao owns the Linux GTK preference. Calling setTheme(null) here forces it
+  // to light, so DBX must leave the native setting untouched on Linux.
+  if (!isTauriRuntime() || isLinuxTauriRuntime()) return;
 
-  if (!isTauriRuntime()) return;
   if (cachedTauriWindow) {
     cachedTauriWindow
       .getCurrentWindow()


### PR DESCRIPTION
## 变更说明

- 防止 Linux 的“跟随系统”模式在应用启动时调用 `setTheme(null)`；该调用会覆盖 GTK 的深色偏好，使 DBX 重启后仍显示为浅色。
- 保留现有的 `matchMedia("(prefers-color-scheme: dark)")` 系统主题同步，不改变 Windows 或 macOS 的原生主题行为。
- 新增 Linux 回归测试，覆盖冷启动读取系统深色偏好，以及系统偏好变化时不写入原生主题。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 只修复主题偏好同步逻辑，不修改组件样式、布局、交互或文案，因此不需要截图或录屏。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过：Linux 主题回归测试包含在 `make check` 中

Linux 环境核验：Fedora Linux 44 (KDE Plasma Desktop Edition)，KDE Plasma 6.7.0，Wayland

## 关联 Issue

Closes #4094
