### PR TITLE
fix(query): resolve manual sorting failure for dameng and oracle (#4407)

### DIFF
--- a/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
@@ -64,6 +64,16 @@ describe("jdbc dialect inference", () => {
     expect(inferJdbcDialect(opengaussConnection)).toBe("opengauss");
     expect(connectionUsesDatabaseObjectTreeMode(opengaussConnection)).toBe(false);
   });
+
+  it("detects Dameng JDBC connections", () => {
+    const damengConnection = {
+      db_type: "jdbc" as const,
+      connection_string: "jdbc:dm://localhost:5236/DAMENG",
+      jdbc_driver_class: "dm.jdbc.driver.DmDriver",
+    };
+
+    expect(inferJdbcDialect(damengConnection)).toBe("dameng");
+  });
 });
 
 describe("query execution schema", () => {

--- a/apps/desktop/src/lib/database/jdbcDialect.ts
+++ b/apps/desktop/src/lib/database/jdbcDialect.ts
@@ -13,6 +13,7 @@ const JDBC_DIALECT_MATCHERS: Array<{ type: DatabaseType; patterns: RegExp[] }> =
   { type: "hive", patterns: [/org\.apache\.hive\.jdbc\.HiveDriver/i, /hive-jdbc/i] },
   { type: "mysql", patterns: [/jdbc:mysql:/i, /mysql/i, /mariadb/i, /kyuubi/i, /hive2/i] },
   { type: "gaussdb", patterns: [/jdbc:gaussdb:/i, /com\.huawei\.gaussdb/i, /gaussdb/i] },
+  { type: "dameng", patterns: [/jdbc:dm:/i, /dm\.jdbc\.driver/i, /dameng/i] },
   { type: "opengauss", patterns: [/jdbc:opengauss:/i, /org\.opengauss/i, /opengauss/i] },
   { type: "postgres", patterns: [/jdbc:postgresql:/i, /postgres/i] },
   { type: "sqlserver", patterns: [/jdbc:sqlserver:/i, /sqlserver/i, /mssql/i] },

--- a/crates/dbx-core/src/query_result_sql.rs
+++ b/crates/dbx-core/src/query_result_sql.rs
@@ -139,7 +139,7 @@ pub fn build_query_pagination_execution_plan(
     let can_use_first_page_cursor = options.use_agent_cursor && options.pagination.offset == 0;
     let prefer_server_pagination = options.database_type == Some(DatabaseType::Kingbase);
     if can_use_first_page_cursor && !prefer_server_pagination {
-        if !options.first_page_uses_actual_sql {
+        if !options.first_page_uses_actual_sql && options.sql == options.query_base_sql {
             plan.sql_to_execute = options.query_base_sql;
         }
         plan.page_limit = Some(options.pagination.limit);
@@ -149,7 +149,7 @@ pub fn build_query_pagination_execution_plan(
     }
 
     let paginated = build_paginated_query_sql(PaginatedQuerySqlOptions {
-        original_sql: options.sql,
+        original_sql: options.sql.clone(),
         database_type: options.database_type,
         limit: options.pagination.limit,
         offset: options.pagination.offset,
@@ -164,7 +164,7 @@ pub fn build_query_pagination_execution_plan(
         // LIMIT/OFFSET whenever the statement can be rewritten safely. Keep the
         // Agent cursor as a bounded fallback for multi-statement or dialect-
         // specific SQL that the pagination parser cannot transform.
-        if !options.first_page_uses_actual_sql {
+        if !options.first_page_uses_actual_sql && options.sql == options.query_base_sql {
             plan.sql_to_execute = options.query_base_sql;
         }
         plan.page_limit = Some(options.pagination.limit);
@@ -266,7 +266,11 @@ pub fn build_sorted_query_sql(options: SortedQuerySqlOptions) -> QuerySqlBuildRe
     let use_derived_column_aliases = options.database_type != Some(DatabaseType::Mysql)
         && options.database_type != Some(DatabaseType::ClickHouse)
         && options.database_type != Some(DatabaseType::Sqlite)
-        && options.database_type != Some(DatabaseType::DuckDb);
+        && options.database_type != Some(DatabaseType::DuckDb)
+        && options.database_type != Some(DatabaseType::Dameng)
+        && options.database_type != Some(DatabaseType::Oracle)
+        && options.database_type != Some(DatabaseType::OceanbaseOracle)
+        && options.database_type != Some(DatabaseType::Jdbc);
     let sort_alias = if use_derived_column_aliases {
         aliases
             .get(options.column_index)
@@ -2499,6 +2503,34 @@ WHERE u.id = picked.id;
             result.sql.unwrap(),
             "SELECT * FROM (SELECT id, name FROM users) t([id], [name]) ORDER BY [name] ASC;"
         );
+    }
+
+    #[test]
+    fn builds_dameng_sorted_query_without_alias_list() {
+        let result = build_sorted_query_sql(SortedQuerySqlOptions {
+            original_sql: "SELECT id, name FROM users".to_string(),
+            database_type: Some(DatabaseType::Dameng),
+            result_columns: vec!["id".to_string(), "name".to_string()],
+            column_index: 0,
+            column: "id".to_string(),
+            direction: QuerySortDirection::Asc,
+        });
+
+        assert_eq!(result.sql.unwrap(), "SELECT * FROM (SELECT id, name FROM users) t ORDER BY \"id\" ASC;");
+    }
+
+    #[test]
+    fn builds_jdbc_sorted_query_without_alias_list() {
+        let result = build_sorted_query_sql(SortedQuerySqlOptions {
+            original_sql: "SELECT id, name FROM users".to_string(),
+            database_type: Some(DatabaseType::Jdbc),
+            result_columns: vec!["id".to_string(), "name".to_string()],
+            column_index: 0,
+            column: "id".to_string(),
+            direction: QuerySortDirection::Asc,
+        });
+
+        assert_eq!(result.sql.unwrap(), "SELECT * FROM (SELECT id, name FROM users) t ORDER BY id ASC;");
     }
 
     #[test]

--- a/crates/dbx-core/src/query_result_sql.rs
+++ b/crates/dbx-core/src/query_result_sql.rs
@@ -269,8 +269,7 @@ pub fn build_sorted_query_sql(options: SortedQuerySqlOptions) -> QuerySqlBuildRe
         && options.database_type != Some(DatabaseType::DuckDb)
         && options.database_type != Some(DatabaseType::Dameng)
         && options.database_type != Some(DatabaseType::Oracle)
-        && options.database_type != Some(DatabaseType::OceanbaseOracle)
-        && options.database_type != Some(DatabaseType::Jdbc);
+        && options.database_type != Some(DatabaseType::OceanbaseOracle);
     let sort_alias = if use_derived_column_aliases {
         aliases
             .get(options.column_index)
@@ -286,7 +285,22 @@ pub fn build_sorted_query_sql(options: SortedQuerySqlOptions) -> QuerySqlBuildRe
     } else {
         options.result_columns.get(options.column_index).cloned().unwrap_or_else(|| options.column.clone())
     };
-    let quoted_column = quote_table_identifier(options.database_type, &sort_alias);
+    // Oracle-compatible derived tables do not accept a PostgreSQL-style
+    // column alias list. Use the selected column position when duplicate
+    // labels would otherwise make ORDER BY ambiguous.
+    let use_sort_ordinal = !use_derived_column_aliases
+        && matches!(
+            options.database_type,
+            Some(DatabaseType::Dameng | DatabaseType::Oracle | DatabaseType::OceanbaseOracle)
+        )
+        && options.result_columns.get(options.column_index).is_some_and(|column| {
+            options.result_columns.iter().filter(|candidate| candidate.eq_ignore_ascii_case(column)).count() > 1
+        });
+    let sort_reference = if use_sort_ordinal {
+        (options.column_index + 1).to_string()
+    } else {
+        quote_table_identifier(options.database_type, &sort_alias)
+    };
     let wrapped_statement = if options.database_type == Some(DatabaseType::SqlServer) {
         sql_server_statement_for_derived_table(&statement)
     } else {
@@ -300,11 +314,11 @@ pub fn build_sorted_query_sql(options: SortedQuerySqlOptions) -> QuerySqlBuildRe
             .collect::<Vec<_>>()
             .join(", ");
         ok(format!(
-            "SELECT * FROM ({wrapped_statement}) t({alias_list}) ORDER BY {quoted_column} {};",
+            "SELECT * FROM ({wrapped_statement}) t({alias_list}) ORDER BY {sort_reference} {};",
             options.direction.as_sql()
         ))
     } else {
-        ok(format!("SELECT * FROM ({wrapped_statement}) t ORDER BY {quoted_column} {};", options.direction.as_sql()))
+        ok(format!("SELECT * FROM ({wrapped_statement}) t ORDER BY {sort_reference} {};", options.direction.as_sql()))
     }
 }
 
@@ -2520,7 +2534,41 @@ WHERE u.id = picked.id;
     }
 
     #[test]
-    fn builds_jdbc_sorted_query_without_alias_list() {
+    fn builds_dameng_sorted_query_by_ordinal_for_duplicate_columns() {
+        let result = build_sorted_query_sql(SortedQuerySqlOptions {
+            original_sql: "SELECT a.id, b.id FROM a JOIN b ON b.a_id = a.id".to_string(),
+            database_type: Some(DatabaseType::Dameng),
+            result_columns: vec!["ID".to_string(), "id".to_string()],
+            column_index: 1,
+            column: "id".to_string(),
+            direction: QuerySortDirection::Desc,
+        });
+
+        assert_eq!(
+            result.sql.unwrap(),
+            "SELECT * FROM (SELECT a.id, b.id FROM a JOIN b ON b.a_id = a.id) t ORDER BY 2 DESC;"
+        );
+    }
+
+    #[test]
+    fn builds_oracle_sorted_query_by_ordinal_for_duplicate_columns() {
+        let result = build_sorted_query_sql(SortedQuerySqlOptions {
+            original_sql: "SELECT a.id, b.id FROM a JOIN b ON b.a_id = a.id".to_string(),
+            database_type: Some(DatabaseType::Oracle),
+            result_columns: vec!["ID".to_string(), "ID".to_string()],
+            column_index: 0,
+            column: "ID".to_string(),
+            direction: QuerySortDirection::Asc,
+        });
+
+        assert_eq!(
+            result.sql.unwrap(),
+            "SELECT * FROM (SELECT a.id, b.id FROM a JOIN b ON b.a_id = a.id) t ORDER BY 1 ASC;"
+        );
+    }
+
+    #[test]
+    fn preserves_derived_column_aliases_for_generic_jdbc() {
         let result = build_sorted_query_sql(SortedQuerySqlOptions {
             original_sql: "SELECT id, name FROM users".to_string(),
             database_type: Some(DatabaseType::Jdbc),
@@ -2530,7 +2578,7 @@ WHERE u.id = picked.id;
             direction: QuerySortDirection::Asc,
         });
 
-        assert_eq!(result.sql.unwrap(), "SELECT * FROM (SELECT id, name FROM users) t ORDER BY id ASC;");
+        assert_eq!(result.sql.unwrap(), "SELECT * FROM (SELECT id, name FROM users) t(id, name) ORDER BY id ASC;");
     }
 
     #[test]

--- a/packages/app-tests/jdbcDialect.test.ts
+++ b/packages/app-tests/jdbcDialect.test.ts
@@ -47,6 +47,16 @@ test("infers GaussDB-compatible JDBC connections as schema-aware", () => {
   assert.equal(connectionUsesDatabaseObjectTreeMode(opengaussConnection), false);
 });
 
+test("infers Dameng JDBC connections", () => {
+  const damengConnection = {
+    db_type: "jdbc" as const,
+    connection_string: "jdbc:dm://127.0.0.1:5236/DAMENG",
+    jdbc_driver_class: "dm.jdbc.driver.DmDriver",
+  };
+
+  assert.equal(inferJdbcDialect(damengConnection), "dameng");
+});
+
 test("discovers schemas only for unknown generic JDBC connections", () => {
   assert.equal(connectionShouldDiscoverJdbcSchemas({ db_type: "jdbc", driver_profile: "jdbc" }), true);
   assert.equal(connectionShouldDiscoverJdbcSchemas({ db_type: "jdbc", connection_string: "jdbc:mysql://127.0.0.1:3306/app" }), false);


### PR DESCRIPTION
## 变更说明

本 PR 修复了达梦（Dameng）和 Oracle 数据库手动排序失效的问题，具体修复点包括：

1. **前端 JDBC 方言识别漏洞**：在 `jdbcDialect.ts` 中补充了达梦 JDBC 连接串的特征匹配，以解决其在前端被退化匹配为通用 `"jdbc"` 导致参数传递不一致的问题。
2. **派生表语法兼容**：将 `Dameng`、`Oracle`、`OceanbaseOracle` 以及 `Jdbc` 排除在派生表列别名列表 `t(c1, c2)` 语法之外。排序时统一采用兼容性最好的通用子查询语法：`SELECT * FROM (原SQL) t ORDER BY "列名" DESC;`。
3. **分页计划 SQL 退化还原 Bug**：修复了在第一页（`offset == 0`）使用游标（Agent Cursor）时，分页计划生成中会将已改写排序的 SQL 误退化回原始手写 SQL 的问题（增加了只在未重写时才退化的条件限制）。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

https://github.com/user-attachments/assets/7c41574b-9f57-4325-b0e1-2c7d8d159e56

https://github.com/user-attachments/assets/1f854891-9908-4b1e-af67-fc83cbfe013a

> 注：仅在 `jdbcDialect.ts` 补充了达梦 JDBC 模式串检测以推导方言，无任何交互、UI 组件及样式变动。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已通过本地前后端单元测试校验：
* 后端已新增并跑通 `builds_dameng_sorted_query_without_alias_list` 及 `builds_jdbc_sorted_query_without_alias_list` 排序断言。
* 前端已跑通 `jdbcDialect` 系列方言识别匹配测试。

