### PR TITLE
docs: bump minimum Rust version to 1.88

### DIFF
--- a/docs/content/docs/contributing.cn.mdx
+++ b/docs/content/docs/contributing.cn.mdx
@@ -41,7 +41,7 @@ DBX 桌面版基于 Tauri、Vue 和 Rust。仓库当前要求：
 | --- | --- |
 | Node.js | 22.13.0 或更高版本 |
 | pnpm | 10.27.0 |
-| Rust | 1.77 或更高版本 |
+| Rust | 1.88 或更高版本 |
 | Git | 当前稳定版本 |
 | Make | macOS 和 Linux 推荐使用 |
 

--- a/docs/content/docs/contributing.mdx
+++ b/docs/content/docs/contributing.mdx
@@ -41,7 +41,7 @@ DBX Desktop uses Tauri, Vue, and Rust. The repository currently requires:
 | --- | --- |
 | Node.js | 22.13.0 or newer |
 | pnpm | 10.27.0 |
-| Rust | 1.77 or newer |
+| Rust | 1.88 or newer |
 | Git | Current stable version |
 | Make | Recommended on macOS and Linux |
 

--- a/docs/content/docs/getting-started.cn.mdx
+++ b/docs/content/docs/getting-started.cn.mdx
@@ -218,7 +218,7 @@ description: 安装 DBX、创建第一个连接，并了解桌面版、Docker �
 - [Node.js](https://nodejs.org/) >= 22.13.0
 - [pnpm](https://pnpm.io/) 10.27.0
 - Make
-- [Rust](https://www.rust-lang.org/tools/install) >= 1.77
+- [Rust](https://www.rust-lang.org/tools/install) >= 1.88
 
 ### 系统依赖
 

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -212,7 +212,7 @@ Use source mode when contributing or debugging DBX locally.
 - [Node.js](https://nodejs.org/) >= 22.13.0
 - [pnpm](https://pnpm.io/) 10.27.0
 - Make
-- [Rust](https://www.rust-lang.org/tools/install) >= 1.77
+- [Rust](https://www.rust-lang.org/tools/install) >= 1.88
 
 ### System Dependencies
 


### PR DESCRIPTION
Aligns the four prerequisite tables with the source of truth in \`src-tauri/Cargo.toml\` (\`rust-version = \"1.88.0\"\`). The previous \`1.77\` value predates the rust-version bump in the workspace manifest and would mislead new contributors attempting local builds with an older toolchain.

## What changed

Four single-line version bumps, no other content touched:

- \`docs/content/docs/getting-started.mdx\` line 215: \`Rust >= 1.77\` → \`Rust >= 1.88\`
- \`docs/content/docs/getting-started.cn.mdx\` line 221: same
- \`docs/content/docs/contributing.mdx\` line 44: \`1.77 or newer\` → \`1.88 or newer\`
- \`docs/content/docs/contributing.cn.mdx\` line 44: same

4 files changed, 4 insertions(+), 4 deletions(-).

## Why

\`src-tauri/Cargo.toml\` declares \`rust-version = \"1.88.0\"\`. Anyone following the docs and installing Rust 1.77 will hit a toolchain version error on first \`cargo check\`. A new contributor reading these pages is the worst time to discover the mismatch.

## Testing done

- \`git diff --stat\`: \`4 4\` — exactly four single-line changes
- \`docs/node_modules/.bin/fumadocs-mdx\`: \`[MDX] generated files in 11ms\` — all four .mdx files parse cleanly
- Spot-checked each diff to confirm only the version digit changed, no surrounding text shifted