### PR TITLE
Fix：兼容 macOS 12 连接选择器网格布局

### DIFF
--- a/apps/desktop/public/connection-dialog-legacy.css
+++ b/apps/desktop/public/connection-dialog-legacy.css
@@ -1,8 +1,10 @@
 /* Keep these classic media queries outside the Vite/Tailwind transform pipeline.
- * Older WebKit ignores the range syntax emitted by the production CSS build. */
+ * Older WebKit ignores the range syntax emitted by the production CSS build and
+ * needs definite inline sizes for flex items that contain fractional grids. */
 @media (min-width: 640px) {
   [data-slot="dialog-content"].connection-dialog-content--picker {
     width: calc(100vw - 2rem) !important;
+    min-width: 38rem !important;
     height: 720px !important;
     max-width: 880px !important;
   }
@@ -47,6 +49,7 @@
   }
 
   .connection-db-picker-results {
+    width: 0 !important;
     min-width: 0 !important;
     flex: 1 1 0% !important;
   }
@@ -56,7 +59,12 @@
   }
 
   .connection-db-picker-grid {
+    width: 100% !important;
     grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+  }
+
+  .connection-db-picker-option {
+    min-width: 0 !important;
   }
 }
 

--- a/apps/desktop/src/styles/__tests__/legacyWebviewFallback.spec.ts
+++ b/apps/desktop/src/styles/__tests__/legacyWebviewFallback.spec.ts
@@ -53,6 +53,9 @@ describe("legacy WebView CSS fallbacks", () => {
     expect(desktopIndexSource).toContain('href="/connection-dialog-legacy.css"');
     expect(connectionDialogLegacyCss).toContain("@media (min-width: 640px)");
     expect(connectionDialogLegacyCss).toContain("@media (min-width: 1024px)");
+    expect(connectionDialogLegacyCss).toContain("min-width: 38rem !important;");
+    expect(connectionDialogLegacyCss).toContain("width: 0 !important;");
+    expect(connectionDialogLegacyCss).toContain(".connection-db-picker-option");
     expect(connectionDialogLegacyCss).not.toContain("width >=");
     expect(connectionDialogSource).not.toContain("@media (min-width: 640px)");
   });


### PR DESCRIPTION
## 变更说明

- 作为 #4467 的补充，修复更低版本 WebKit 中连接选择器结果区域和数据库卡片可能被压缩成窄竖条的问题
- 在未经 Vite/Tailwind 转换的 legacy CSS 中为桌面弹窗、flex 结果区和分数网格补充稳定的宽度约束
- 保持窄窗口下原有的两列布局，不影响新版 WebView 的响应式表现
- 增加回归断言，防止关键兼容样式被移除

## 验证

- `pnpm vitest run apps/desktop/src/styles/__tests__/legacyWebviewFallback.spec.ts`（4 项通过）
- `pnpm typecheck`
- `pnpm build`
- 确认生产产物中的 `connection-dialog-legacy.css` 与源码逐字一致
- 在 1200px、640px、600px 视口检查连接选择器，无卡片挤压或横向溢出

当前没有 macOS 12 / Safari 15 实机环境，仍需受影响用户进行最终实机确认。