### PR TITLE
fix(opengauss): 修复序列查询兼容性

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3492,16 +3492,18 @@ fn postgres_sequences_sql() -> &'static str {
 }
 
 fn opengauss_sequences_sql() -> &'static str {
-    "SELECT sequence_name, \
-      COALESCE(data_type::text, 'bigint'), \
-      COALESCE(start_value::text, '1'), \
-      COALESCE(minimum_value::text, '1'), \
-      COALESCE(maximum_value::text, '9223372036854775807'), \
-      COALESCE(increment::text, '1'), \
-      COALESCE(cycle_option::text, 'NO') \
-     FROM information_schema.sequences \
-     WHERE sequence_schema = $1 \
-     ORDER BY sequence_name"
+    "SELECT s.sequence_name, \
+      COALESCE(s.data_type::text, 'bigint'), \
+      COALESCE(s.start_value::text, '1'), \
+      COALESCE(s.minimum_value::text, '1'), \
+      COALESCE(s.maximum_value::text, '9223372036854775807'), \
+      COALESCE(s.increment::text, '1'), \
+      COALESCE(s.cycle_option::text, 'NO') \
+     FROM information_schema.sequences s \
+     JOIN pg_namespace n ON n.nspname = s.sequence_schema \
+     JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = s.sequence_name \
+     WHERE s.sequence_schema = $1 AND c.relkind IN ('S','L','z','Z') \
+     ORDER BY s.sequence_name"
 }
 
 fn postgres_sequence_last_values_sql() -> &'static str {
@@ -3515,7 +3517,7 @@ fn opengauss_sequence_last_values_sql() -> &'static str {
     "SELECT c.relname, (pg_sequence_last_value(c.oid)).last_value::text \
      FROM pg_class c \
      JOIN pg_namespace n ON n.oid = c.relnamespace \
-     WHERE c.relkind = 'S' AND n.nspname = $1"
+     WHERE c.relkind IN ('S','L','z','Z') AND n.nspname = $1"
 }
 
 async fn list_sequences_with_sql(
@@ -4800,7 +4802,8 @@ mod tests {
         let sql = opengauss_sequences_sql();
 
         assert!(sql.contains("information_schema.sequences"));
-        assert!(sql.contains("sequence_schema = $1"));
+        assert!(sql.contains("s.sequence_schema = $1"));
+        assert!(sql.contains("c.relkind IN ('S','L','z','Z')"));
         assert!(sql.contains("sequence_name"));
         assert!(sql.contains("start_value"));
         assert!(sql.contains("minimum_value"));
@@ -4815,7 +4818,7 @@ mod tests {
         let sql = opengauss_sequence_last_values_sql();
 
         assert!(sql.contains("(pg_sequence_last_value(c.oid)).last_value::text"));
-        assert!(sql.contains("c.relkind = 'S'"));
+        assert!(sql.contains("c.relkind IN ('S','L','z','Z')"));
         assert!(sql.contains("n.nspname = $1"));
     }
 

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3476,28 +3476,57 @@ pub async fn list_functions(pool: &Pool, schema: &str) -> Result<Vec<FunctionInf
         .collect())
 }
 
-pub async fn list_sequences(pool: &Pool, schema: &str, with_last_values: bool) -> Result<Vec<SequenceInfo>, String> {
+fn postgres_sequences_sql() -> &'static str {
+    "SELECT c.relname, \
+      COALESCE(format_type(s.seqtypid, NULL), 'bigint'), \
+      COALESCE(s.seqstart::text, '1'), \
+      COALESCE(s.seqmin::text, '1'), \
+      COALESCE(s.seqmax::text, '9223372036854775807'), \
+      COALESCE(s.seqincrement::text, '1'), \
+      CASE WHEN s.seqcycle THEN 'YES' ELSE 'NO' END \
+     FROM pg_class c \
+     JOIN pg_namespace n ON n.oid = c.relnamespace \
+     LEFT JOIN pg_sequence s ON s.seqrelid = c.oid \
+     WHERE c.relkind = 'S' AND n.nspname = $1 \
+     ORDER BY c.relname"
+}
+
+fn opengauss_sequences_sql() -> &'static str {
+    "SELECT sequence_name, \
+      COALESCE(data_type::text, 'bigint'), \
+      COALESCE(start_value::text, '1'), \
+      COALESCE(minimum_value::text, '1'), \
+      COALESCE(maximum_value::text, '9223372036854775807'), \
+      COALESCE(increment::text, '1'), \
+      COALESCE(cycle_option::text, 'NO') \
+     FROM information_schema.sequences \
+     WHERE sequence_schema = $1 \
+     ORDER BY sequence_name"
+}
+
+fn postgres_sequence_last_values_sql() -> &'static str {
+    "SELECT c.relname, pg_sequence_last_value(c.oid)::text \
+     FROM pg_class c \
+     JOIN pg_namespace n ON n.oid = c.relnamespace \
+     WHERE c.relkind = 'S' AND n.nspname = $1"
+}
+
+fn opengauss_sequence_last_values_sql() -> &'static str {
+    "SELECT c.relname, (pg_sequence_last_value(c.oid)).last_value::text \
+     FROM pg_class c \
+     JOIN pg_namespace n ON n.oid = c.relnamespace \
+     WHERE c.relkind = 'S' AND n.nspname = $1"
+}
+
+async fn list_sequences_with_sql(
+    pool: &Pool,
+    schema: &str,
+    with_last_values: bool,
+    metadata_sql: &str,
+    last_values_sql: &str,
+) -> Result<Vec<SequenceInfo>, String> {
     let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
-    // Use pg_class + pg_sequence + pg_namespace instead of pg_sequences view
-    // for better compatibility and permission handling
-    let rows = postgres_query_cached(
-        &client,
-        "SELECT c.relname, \
-          COALESCE(format_type(s.seqtypid, NULL), 'bigint'), \
-          COALESCE(s.seqstart::text, '1'), \
-          COALESCE(s.seqmin::text, '1'), \
-          COALESCE(s.seqmax::text, '9223372036854775807'), \
-          COALESCE(s.seqincrement::text, '1'), \
-          CASE WHEN s.seqcycle THEN 'YES' ELSE 'NO' END \
-         FROM pg_class c \
-         JOIN pg_namespace n ON n.oid = c.relnamespace \
-         LEFT JOIN pg_sequence s ON s.seqrelid = c.oid \
-         WHERE c.relkind = 'S' AND n.nspname = $1 \
-         ORDER BY c.relname",
-        &[&schema],
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = postgres_query_cached(&client, metadata_sql, &[&schema]).await.map_err(|e| e.to_string())?;
 
     let mut sequences: Vec<SequenceInfo> = rows
         .iter()
@@ -3514,17 +3543,12 @@ pub async fn list_sequences(pool: &Pool, schema: &str, with_last_values: bool) -
         .collect();
 
     if with_last_values {
-        // Batch query: get last values for all sequences in one query
-        let sql = "SELECT c.relname, pg_sequence_last_value(c.oid) \
-                   FROM pg_class c \
-                   JOIN pg_namespace n ON n.oid = c.relnamespace \
-                   WHERE c.relkind = 'S' AND n.nspname = $1";
-        if let Ok(rows) = postgres_query_cached(&client, sql, &[&schema]).await {
+        if let Ok(rows) = postgres_query_cached(&client, last_values_sql, &[&schema]).await {
             for row in rows {
                 let name: String = pg_row_try_string(&row, 0);
-                if let Ok(val) = row.try_get::<_, i64>(1) {
+                if let Ok(Some(value)) = row.try_get::<_, Option<String>>(1) {
                     if let Some(seq) = sequences.iter_mut().find(|s| s.name == name) {
-                        seq.last_value = Some(val.to_string());
+                        seq.last_value = Some(value);
                     }
                 }
             }
@@ -3532,6 +3556,36 @@ pub async fn list_sequences(pool: &Pool, schema: &str, with_last_values: bool) -
     }
 
     Ok(sequences)
+}
+
+pub async fn list_sequences(pool: &Pool, schema: &str, with_last_values: bool) -> Result<Vec<SequenceInfo>, String> {
+    // PostgreSQL 10+ stores sequence properties in pg_sequence.
+    list_sequences_with_sql(
+        pool,
+        schema,
+        with_last_values,
+        postgres_sequences_sql(),
+        postgres_sequence_last_values_sql(),
+    )
+    .await
+}
+
+pub async fn list_opengauss_sequences(
+    pool: &Pool,
+    schema: &str,
+    with_last_values: bool,
+) -> Result<Vec<SequenceInfo>, String> {
+    // openGauss does not expose PostgreSQL 10's pg_sequence catalog. Its
+    // information_schema view contains the portable sequence properties, while
+    // pg_sequence_last_value returns a record rather than a scalar.
+    list_sequences_with_sql(
+        pool,
+        schema,
+        with_last_values,
+        opengauss_sequences_sql(),
+        opengauss_sequence_last_values_sql(),
+    )
+    .await
 }
 
 pub async fn list_rules(pool: &Pool, schema: &str) -> Result<Vec<RuleInfo>, String> {
@@ -4739,6 +4793,35 @@ mod tests {
         assert!(POSTGRES_COLUMNS_INFORMATION_SCHEMA_SQL.contains("NULL::text AS enum_values"));
         assert!(!POSTGRES_COLUMNS_INFORMATION_SCHEMA_SQL.contains("pg_attribute"));
         assert!(!POSTGRES_COLUMNS_INFORMATION_SCHEMA_SQL.contains("regclass"));
+    }
+
+    #[test]
+    fn opengauss_sequence_metadata_uses_compatible_information_schema_view() {
+        let sql = opengauss_sequences_sql();
+
+        assert!(sql.contains("information_schema.sequences"));
+        assert!(sql.contains("sequence_schema = $1"));
+        assert!(sql.contains("sequence_name"));
+        assert!(sql.contains("start_value"));
+        assert!(sql.contains("minimum_value"));
+        assert!(sql.contains("maximum_value"));
+        assert!(sql.contains("increment"));
+        assert!(sql.contains("cycle_option"));
+        assert!(!sql.contains("pg_sequence s"));
+    }
+
+    #[test]
+    fn opengauss_sequence_last_values_extract_record_field_as_text() {
+        let sql = opengauss_sequence_last_values_sql();
+
+        assert!(sql.contains("(pg_sequence_last_value(c.oid)).last_value::text"));
+        assert!(sql.contains("c.relkind = 'S'"));
+        assert!(sql.contains("n.nspname = $1"));
+    }
+
+    #[test]
+    fn postgres_sequence_last_values_are_read_as_text() {
+        assert!(postgres_sequence_last_values_sql().contains("pg_sequence_last_value(c.oid)::text"));
     }
 
     #[test]

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -3012,6 +3012,17 @@ mod tests {
     }
 
     #[test]
+    fn detects_opengauss_sequence_compatibility_profiles() {
+        assert!(super::is_opengauss_family_config(&test_connection_config(DatabaseType::OpenGauss)));
+        assert!(super::is_opengauss_family_config(&test_connection_config(DatabaseType::Gaussdb)));
+        assert!(!super::is_opengauss_family_config(&test_connection_config(DatabaseType::Postgres)));
+
+        let mut profiled_postgres = test_connection_config(DatabaseType::Postgres);
+        profiled_postgres.driver_profile = Some("opengauss".to_string());
+        assert!(super::is_opengauss_family_config(&profiled_postgres));
+    }
+
+    #[test]
     fn agent_paging_detection_avoids_double_offset_only_when_page_sized() {
         assert!(super::agent_paging_likely_applied(true, Some(500), 500));
         assert!(super::agent_paging_likely_applied(true, Some(500), 120));
@@ -5471,10 +5482,14 @@ pub async fn list_sequences_core(
 ) -> Result<Vec<db::SequenceInfo>, String> {
     retry_metadata_connection(state, connection_id, Some(database), || async {
         let pool_key = state.get_or_create_pool(connection_id, Some(database)).await?;
+        let db_config = connection_config(state, connection_id).await;
         let connections = state.connections.read().await;
         let pool = connections.get(&pool_key).ok_or("Pool not found")?;
 
         match pool {
+            PoolKind::Postgres(p) if db_config.as_ref().is_some_and(is_opengauss_family_config) => {
+                db::postgres::list_opengauss_sequences(p, schema, with_last_values).await
+            }
             PoolKind::Postgres(p) => db::postgres::list_sequences(p, schema, with_last_values).await,
             _ => Ok(vec![]),
         }
@@ -5942,6 +5957,40 @@ fn opengauss_object_source_sql(
     postgres_object_source_sql_inner(schema, name, kind, signature, true, true)
 }
 
+fn opengauss_sequence_object_source_sql(schema: &str, name: &str) -> String {
+    format!(
+        "SELECT concat_ws(E'\\n\\n', \
+           '-- auto-generated definition' || E'\\n' || \
+           'create ' || CASE WHEN lower(COALESCE(s.data_type::text, '')) = 'numeric' THEN 'large ' ELSE '' END || \
+           'sequence ' || quote_ident(c.relname) || E'\\n' || \
+           '    increment by ' || COALESCE(s.increment::text, '1') || E'\\n' || \
+           '    minvalue ' || COALESCE(s.minimum_value::text, '1') || E'\\n' || \
+           '    maxvalue ' || COALESCE(s.maximum_value::text, '9223372036854775807') || E'\\n' || \
+           '    start with ' || COALESCE(s.start_value::text, '1') || E'\\n' || \
+           CASE WHEN upper(COALESCE(s.cycle_option::text, 'NO')) = 'YES' \
+             THEN '    cycle;' ELSE '    no cycle;' END, \
+           'alter ' || CASE WHEN lower(COALESCE(s.data_type::text, '')) = 'numeric' THEN 'large ' ELSE '' END || \
+           'sequence ' || quote_ident(c.relname) || ' owner to ' || quote_ident(pg_get_userbyid(c.relowner)) || ';', \
+           CASE WHEN owned.relname IS NOT NULL AND a.attname IS NOT NULL \
+             THEN 'alter ' || CASE WHEN lower(COALESCE(s.data_type::text, '')) = 'numeric' THEN 'large ' ELSE '' END || \
+             'sequence ' || quote_ident(c.relname) || ' owned by ' || quote_ident(owned.relname) || '.' || quote_ident(a.attname) || ';' \
+           END \
+         ) \
+         FROM pg_catalog.pg_class c \
+         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+         JOIN information_schema.sequences s \
+           ON s.sequence_schema = n.nspname AND s.sequence_name = c.relname \
+         LEFT JOIN pg_catalog.pg_depend d \
+           ON d.classid = 'pg_class'::regclass AND d.objid = c.oid AND d.deptype = 'a' \
+         LEFT JOIN pg_catalog.pg_class owned ON owned.oid = d.refobjid \
+         LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid \
+         WHERE n.nspname = {} AND c.relname = {} AND c.relkind = 'S' \
+         ORDER BY c.oid LIMIT 1",
+        sql_string(schema),
+        sql_string(name)
+    )
+}
+
 fn postgres_object_source_sql_without_relispopulated(
     schema: &str,
     name: &str,
@@ -6055,6 +6104,9 @@ fn postgres_object_source_sql_inner(
             )
         }
         db::ObjectSourceKind::Sequence => {
+            if unwrap_opengauss_record {
+                return opengauss_sequence_object_source_sql(schema, name);
+            }
             format!(
                 "SELECT concat_ws(E'\\n\\n', \
                    '-- auto-generated definition' || E'\\n' || \
@@ -6832,6 +6884,20 @@ mod object_source_tests {
             postgres_function_object_source_sql_without_prokind("public", "recalc_score", true),
             "SELECT (pg_get_functiondef(p.oid)).definition FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'recalc_score' AND NOT p.proisagg AND NOT p.proiswindow ORDER BY p.oid LIMIT 1"
         );
+    }
+
+    #[test]
+    fn builds_opengauss_sequence_source_without_pg_sequence_catalog() {
+        let sql = opengauss_object_source_sql("public", "order_id_seq", &ObjectSourceKind::Sequence, None);
+
+        assert!(sql.contains("information_schema.sequences"));
+        assert!(sql.contains("s.sequence_schema = n.nspname"));
+        assert!(sql.contains("s.sequence_name = c.relname"));
+        assert!(sql.contains("increment by"));
+        assert!(sql.contains("start with"));
+        assert!(sql.contains("cycle;"));
+        assert!(sql.contains("THEN 'large '"));
+        assert!(!sql.contains("pg_catalog.pg_sequence"));
     }
 
     #[test]

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -3020,6 +3020,9 @@ mod tests {
         let mut profiled_postgres = test_connection_config(DatabaseType::Postgres);
         profiled_postgres.driver_profile = Some("opengauss".to_string());
         assert!(super::is_opengauss_family_config(&profiled_postgres));
+
+        profiled_postgres.driver_profile = Some("gaussdb".to_string());
+        assert!(super::is_opengauss_family_config(&profiled_postgres));
     }
 
     #[test]
@@ -5957,22 +5960,28 @@ fn opengauss_object_source_sql(
     postgres_object_source_sql_inner(schema, name, kind, signature, true, true)
 }
 
-fn opengauss_sequence_object_source_sql(schema: &str, name: &str) -> String {
+fn opengauss_sequence_object_source_sql(schema: &str, name: &str, include_cache: bool) -> String {
+    let cache_clause = if include_cache {
+        "'    cache ' || COALESCE((pg_sequence_last_value(c.oid)).cache_value::text, '1') || E'\\n' || "
+    } else {
+        ""
+    };
     format!(
         "SELECT concat_ws(E'\\n\\n', \
            '-- auto-generated definition' || E'\\n' || \
-           'create ' || CASE WHEN lower(COALESCE(s.data_type::text, '')) = 'numeric' THEN 'large ' ELSE '' END || \
+           'create ' || CASE WHEN c.relkind IN ('L','Z') THEN 'large ' ELSE '' END || \
            'sequence ' || quote_ident(c.relname) || E'\\n' || \
            '    increment by ' || COALESCE(s.increment::text, '1') || E'\\n' || \
            '    minvalue ' || COALESCE(s.minimum_value::text, '1') || E'\\n' || \
            '    maxvalue ' || COALESCE(s.maximum_value::text, '9223372036854775807') || E'\\n' || \
            '    start with ' || COALESCE(s.start_value::text, '1') || E'\\n' || \
+           {cache_clause} \
            CASE WHEN upper(COALESCE(s.cycle_option::text, 'NO')) = 'YES' \
              THEN '    cycle;' ELSE '    no cycle;' END, \
-           'alter ' || CASE WHEN lower(COALESCE(s.data_type::text, '')) = 'numeric' THEN 'large ' ELSE '' END || \
+           'alter ' || CASE WHEN c.relkind IN ('L','Z') THEN 'large ' ELSE '' END || \
            'sequence ' || quote_ident(c.relname) || ' owner to ' || quote_ident(pg_get_userbyid(c.relowner)) || ';', \
            CASE WHEN owned.relname IS NOT NULL AND a.attname IS NOT NULL \
-             THEN 'alter ' || CASE WHEN lower(COALESCE(s.data_type::text, '')) = 'numeric' THEN 'large ' ELSE '' END || \
+             THEN 'alter ' || CASE WHEN c.relkind IN ('L','Z') THEN 'large ' ELSE '' END || \
              'sequence ' || quote_ident(c.relname) || ' owned by ' || quote_ident(owned.relname) || '.' || quote_ident(a.attname) || ';' \
            END \
          ) \
@@ -5984,10 +5993,10 @@ fn opengauss_sequence_object_source_sql(schema: &str, name: &str) -> String {
            ON d.classid = 'pg_class'::regclass AND d.objid = c.oid AND d.deptype = 'a' \
          LEFT JOIN pg_catalog.pg_class owned ON owned.oid = d.refobjid \
          LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid \
-         WHERE n.nspname = {} AND c.relname = {} AND c.relkind = 'S' \
+         WHERE n.nspname = {schema} AND c.relname = {name} AND c.relkind IN ('S','L','z','Z') \
          ORDER BY c.oid LIMIT 1",
-        sql_string(schema),
-        sql_string(name)
+        schema = sql_string(schema),
+        name = sql_string(name)
     )
 }
 
@@ -6105,7 +6114,7 @@ fn postgres_object_source_sql_inner(
         }
         db::ObjectSourceKind::Sequence => {
             if unwrap_opengauss_record {
-                return opengauss_sequence_object_source_sql(schema, name);
+                return opengauss_sequence_object_source_sql(schema, name, true);
             }
             format!(
                 "SELECT concat_ws(E'\\n\\n', \
@@ -6745,6 +6754,17 @@ async fn postgres_object_source(
         }
         Err(primary_err)
             if unwrap_opengauss_record
+                && matches!(object_type, db::ObjectSourceKind::Sequence)
+                && opengauss_sequence_cache_metadata_error(&primary_err) =>
+        {
+            let fallback_sql = opengauss_sequence_object_source_sql(schema, name, false);
+            db::postgres::execute_query(pool, &fallback_sql)
+                .await
+                .and_then(first_string_cell)
+                .map_err(|fallback_err| format!("{primary_err}; sequence cache fallback failed: {fallback_err}"))
+        }
+        Err(primary_err)
+            if unwrap_opengauss_record
                 && matches!(object_type, db::ObjectSourceKind::Procedure | db::ObjectSourceKind::Function) =>
         {
             let mut errors = vec![primary_err];
@@ -6785,6 +6805,11 @@ fn postgres_missing_prokind_error(err: &str) -> bool {
         && (lower.contains("column p.prokind")
             || lower.contains("column \"p\".\"prokind\"")
             || lower.contains("column \"prokind\""))
+}
+
+fn opengauss_sequence_cache_metadata_error(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("pg_sequence_last_value") || lower.contains("cache_value")
 }
 
 fn postgres_missing_relispopulated_error(err: &str) -> bool {
@@ -6893,11 +6918,26 @@ mod object_source_tests {
         assert!(sql.contains("information_schema.sequences"));
         assert!(sql.contains("s.sequence_schema = n.nspname"));
         assert!(sql.contains("s.sequence_name = c.relname"));
+        assert!(sql.contains("c.relkind IN ('S','L','z','Z')"));
+        assert!(sql.contains("CASE WHEN c.relkind IN ('L','Z') THEN 'large '"));
         assert!(sql.contains("increment by"));
         assert!(sql.contains("start with"));
+        assert!(sql.contains("(pg_sequence_last_value(c.oid)).cache_value::text"));
         assert!(sql.contains("cycle;"));
-        assert!(sql.contains("THEN 'large '"));
         assert!(!sql.contains("pg_catalog.pg_sequence"));
+
+        let fallback_sql = opengauss_sequence_object_source_sql("public", "order_id_seq", false);
+        assert!(fallback_sql.contains("c.relkind IN ('S','L','z','Z')"));
+        assert!(fallback_sql.contains("CASE WHEN c.relkind IN ('L','Z') THEN 'large '"));
+        assert!(!fallback_sql.contains("pg_sequence_last_value"));
+        assert!(!fallback_sql.contains("cache_value"));
+    }
+
+    #[test]
+    fn detects_opengauss_sequence_cache_metadata_fallback_errors() {
+        assert!(opengauss_sequence_cache_metadata_error("cannot execute pg_sequence_last_value() on a standby node"));
+        assert!(opengauss_sequence_cache_metadata_error("column notation .cache_value applied to type text"));
+        assert!(!opengauss_sequence_cache_metadata_error("permission denied for sequence order_id_seq"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复 openGauss / GaussDB 展开序列时出现 `relation "pg_catalog.pg_sequence" does not exist on sgnode` 的问题。

### 根因与解决思路

openGauss 不提供 PostgreSQL 10+ 的 `pg_catalog.pg_sequence`，且 `pg_sequence_last_value` 返回记录类型。本次改动为 openGauss / GaussDB 分派兼容查询，使用 `information_schema.sequences` 读取元数据，从记录字段读取最后值并转为文本以兼容 LARGE SEQUENCE；同时修复双击序列查看定义的同类查询，并保留 PostgreSQL 原有路径。

## 变更类型

- [x] Bug 修复

## 涉及前端

本 PR 不涉及前端改动。

## 验证

- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已通过格式化、dbx-core 相关单元测试、`cargo check`、严格 `clippy` 和 `git diff --check`。

## 关联 Issue

Close #4526