### PR TITLE
Feat：为连接配置增加备注字段

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -445,6 +445,23 @@ function sshLayersForConfig(config: LegacyConnectionConfig): SshTunnelConfig[] {
 }
 
 const form = ref(defaultForm());
+const noteTextareaRef = ref<HTMLTextAreaElement | null>(null);
+
+function resizeNoteTextarea() {
+  const textarea = noteTextareaRef.value;
+  if (!textarea) return;
+
+  const style = window.getComputedStyle(textarea);
+  const lineHeight = Number.parseFloat(style.lineHeight) || 20;
+  const paddingHeight = (Number.parseFloat(style.paddingTop) || 0) + (Number.parseFloat(style.paddingBottom) || 0);
+  const borderHeight = (Number.parseFloat(style.borderTopWidth) || 0) + (Number.parseFloat(style.borderBottomWidth) || 0);
+  const maxContentHeight = lineHeight * 3 + paddingHeight;
+
+  textarea.style.height = "auto";
+  textarea.style.height = `${Math.min(textarea.scrollHeight, maxContentHeight) + borderHeight}px`;
+  textarea.style.overflowY = textarea.scrollHeight > maxContentHeight ? "auto" : "hidden";
+}
+
 const showJdbcDependencyDriverManagerAction = computed(() => form.value.db_type === "jdbc" && isJdbcMissingRuntimeDependencyError(connectionErrorDetail.value));
 
 function externalConfigRecord(value: unknown): Record<string, unknown> {
@@ -518,6 +535,9 @@ const dbPickerView = ref<DbPickerView>(loadConnectionPickerView());
 const dbSearchQuery = ref("");
 const selectedDbCategory = ref<DbCategoryKey>("sql");
 const configTab = ref<ConfigTab>("connection");
+watch([() => form.value.note, configTab, dialogStep, open], () => {
+  void nextTick(resizeNoteTextarea);
+});
 const MQ_KAFKA_SECURITY_PROTOCOL_AUTO = "__auto";
 const mqAdminUrl = ref("http://127.0.0.1:8080");
 const mqSystemKind = ref<MqSystemKind>("pulsar");
@@ -4747,7 +4767,7 @@ function openExternalUrl(url: string) {
             </div>
 
             <TabsContent value="connection" class="m-0 min-h-0 flex-1 overflow-hidden">
-              <div class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto pt-4 pr-2">
+              <div class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto pt-4 pr-2 pb-2">
                 <div v-if="!isJdbcConnection && form.db_type !== 'nacos'" class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelClass">{{ t("connection.connectionUrlOptional") }}</Label>
                   <div class="col-span-3 flex items-center gap-1">
@@ -4766,11 +4786,6 @@ function openExternalUrl(url: string) {
                 <div class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelClass">{{ t("connection.name") }}</Label>
                   <Input v-model="form.name" v-connection-dialog-auto-focus class="col-span-3" :placeholder="t('connection.namePlaceholder')" />
-                </div>
-
-                <div class="grid grid-cols-4 items-center gap-4">
-                  <Label :class="connectionLabelClass">{{ t("connection.note") }}</Label>
-                  <Input v-model="form.note" class="col-span-3" :placeholder="t('connection.notePlaceholder')" />
                 </div>
 
                 <div class="grid grid-cols-4 items-center gap-4">
@@ -6155,6 +6170,18 @@ function openExternalUrl(url: string) {
                       </dl>
                     </PopoverContent>
                   </Popover>
+                </div>
+
+                <div class="grid grid-cols-4 items-start gap-4">
+                  <Label :class="connectionLabelTopClass">{{ t("connection.note") }}</Label>
+                  <textarea
+                    ref="noteTextareaRef"
+                    v-model="form.note"
+                    rows="1"
+                    class="col-span-3 min-h-8 w-full min-w-0 resize-none overflow-y-hidden rounded-md border border-input bg-transparent px-2.5 py-1 text-base leading-5 transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30 md:text-sm"
+                    :placeholder="t('connection.notePlaceholder')"
+                    @input="resizeNoteTextarea"
+                  />
                 </div>
               </div>
             </TabsContent>

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -213,6 +213,7 @@ function initialConfigTab(): ConfigTab {
 
 const defaultForm = (): ConnectionForm => ({
   name: "",
+  note: "",
   db_type: "mysql",
   driver_profile: "mysql",
   driver_label: "MySQL",
@@ -1922,6 +1923,7 @@ watch(
       const profileConfig = driverProfiles[profile];
       form.value = {
         name: config.name,
+        note: config.note || "",
         db_type: oceanbasePatch?.db_type || profileConfig?.type || config.db_type,
         driver_profile: oceanbasePatch?.driver_profile || profile,
         driver_label: config.driver_label || oceanbasePatch?.driver_label || driverProfiles[profile]?.label || config.db_type,
@@ -3035,6 +3037,7 @@ function generateConnectionName(): string {
 function connectionConfigForSubmit(id: string, generatedName = ""): ConnectionConfig {
   const config = { ...formValueForSubmit(), id } as LegacyConnectionConfig;
   config.database_info = undefined;
+  config.note = config.note?.trim() || undefined;
   if (selectedType.value === "oceanbase" && (config.driver_profile === "oceanbase" || config.driver_profile === "oceanbase-oracle")) {
     Object.assign(config, oceanbaseModeConnectionPatch(oceanbaseSubMode.value));
   }
@@ -4763,6 +4766,11 @@ function openExternalUrl(url: string) {
                 <div class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelClass">{{ t("connection.name") }}</Label>
                   <Input v-model="form.name" v-connection-dialog-auto-focus class="col-span-3" :placeholder="t('connection.namePlaceholder')" />
+                </div>
+
+                <div class="grid grid-cols-4 items-center gap-4">
+                  <Label :class="connectionLabelClass">{{ t("connection.note") }}</Label>
+                  <Input v-model="form.note" class="col-span-3" :placeholder="t('connection.notePlaceholder')" />
                 </div>
 
                 <div class="grid grid-cols-4 items-center gap-4">

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -175,6 +175,8 @@ export default {
     title: "New Connection",
     name: "Name",
     namePlaceholder: "Connection name, auto-generated if empty",
+    note: "Notes",
+    notePlaceholder: "Do not store passwords in plaintext in notes",
     type: "Type",
     host: "Host",
     filePath: "File Path",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -177,6 +177,8 @@ export default withEnglishFallback({
     title: "Nueva conexión",
     name: "Nombre",
     namePlaceholder: "Nombre de conexión, se genera automáticamente si está vacío",
+    note: "Notas",
+    notePlaceholder: "No guardes contraseñas en texto plano en las notas",
     type: "Tipo",
     host: "Host",
     filePath: "Ruta del archivo",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -176,6 +176,8 @@ export default withEnglishFallback({
     title: "Nuova Connessione",
     name: "Nome",
     namePlaceholder: "Nome connessione, generato automaticamente se vuoto",
+    note: "Note",
+    notePlaceholder: "Non salvare password in chiaro nelle note",
     type: "Tipo",
     host: "Host",
     filePath: "Percorso File",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -176,6 +176,8 @@ export default withEnglishFallback({
     title: "新しい接続",
     name: "名前",
     namePlaceholder: "接続名（空の場合は自動生成）",
+    note: "メモ",
+    notePlaceholder: "メモにパスワードを平文で保存しないでください",
     type: "タイプ",
     host: "ホスト",
     filePath: "ファイルパス",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -177,6 +177,8 @@ export default withEnglishFallback({
     title: "Nova Conexão",
     name: "Nome",
     namePlaceholder: "Nome da conexão, gerado automaticamente se vazio",
+    note: "Observações",
+    notePlaceholder: "Não salve senhas em texto simples nas observações",
     type: "Tipo",
     host: "Host",
     filePath: "Caminho do Arquivo",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -177,6 +177,8 @@ export default withEnglishFallback({
     title: "新建连接",
     name: "名称",
     namePlaceholder: "连接名称，留空则自动生成",
+    note: "备注",
+    notePlaceholder: "请勿在备注中明文保存密码",
     type: "类型",
     host: "主机",
     filePath: "文件路径",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -177,6 +177,8 @@ export default withEnglishFallback({
     title: "建立連線",
     name: "名稱",
     namePlaceholder: "連線名稱，留空則自動產生",
+    note: "備註",
+    notePlaceholder: "請勿在備註中以明文儲存密碼",
     type: "類型",
     host: "主機",
     filePath: "檔案路徑",

--- a/apps/desktop/src/lib/connection/__tests__/connectionDatabaseInfo.spec.ts
+++ b/apps/desktop/src/lib/connection/__tests__/connectionDatabaseInfo.spec.ts
@@ -65,6 +65,7 @@ describe("connectionDatabaseInfo", () => {
     expect(connectionConfigFingerprint({ ...original, transport_layers: [{ ...original.transport_layers![0], host: "other-jump" }] })).not.toBe(connectionConfigFingerprint(original));
     expect(connectionConfigFingerprint(original, "")).not.toBe(connectionConfigFingerprint(original, original.name));
     expect(connectionConfigFingerprint({ ...original, database_info: { productName: "MySQL", productVersion: "8.4.0" } })).toBe(connectionConfigFingerprint(original));
+    expect(connectionConfigFingerprint({ ...original, note: "Production reporting" })).toBe(connectionConfigFingerprint(original));
   });
 
   it("formats only database metadata for rows and copied text", () => {

--- a/apps/desktop/src/lib/connection/connectionDatabaseInfo.ts
+++ b/apps/desktop/src/lib/connection/connectionDatabaseInfo.ts
@@ -86,7 +86,7 @@ function fnv1a(value: string, seed: number): number {
 }
 
 export function connectionConfigFingerprint(config: ConnectionConfig, sourceName = config.name): string {
-  const { database_info: _databaseInfo, ...submittedConfig } = config;
+  const { database_info: _databaseInfo, note: _note, ...submittedConfig } = config;
   const serialized = JSON.stringify(stableValue({ config: submittedConfig, sourceName }));
   const first = fnv1a(serialized, 0x811c9dc5).toString(16).padStart(8, "0");
   const second = fnv1a(serialized, 0x9e3779b9).toString(16).padStart(8, "0");

--- a/apps/desktop/src/stores/__tests__/connectionStore.databaseInfo.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.databaseInfo.spec.ts
@@ -101,6 +101,31 @@ describe("connectionStore database info", () => {
     expect(store.connectedIds.has(config.id)).toBe(true);
   });
 
+  it("keeps a live connection when only its note changes", async () => {
+    const config = mysqlConnection();
+    const saveConnections = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      connectDb: vi.fn().mockResolvedValue(config.id),
+      connectionDatabaseInfo: vi.fn().mockRejectedValue(new Error("metadata unavailable")),
+      saveConnections,
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+      connectionIdentifierQuote: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    await store.addConnection(config);
+    await store.connect(config);
+
+    await store.updateConnection({ ...config, note: "Production reporting" });
+
+    expect(saveConnections).toHaveBeenLastCalledWith([expect.objectContaining({ id: config.id, note: "Production reporting" })]);
+    expect(store.getConfig(config.id)?.note).toBe("Production reporting");
+    expect(store.connectedIds.has(config.id)).toBe(true);
+  });
+
   it("does not delay connection success while optional metadata is loading", async () => {
     const config = mysqlConnection();
     let resolveDatabaseInfo!: (value: { productName: string; productVersion: string }) => void;

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -2119,11 +2119,13 @@ export const useConnectionStore = defineStore("connection", () => {
     config = normalizeConnection(config);
     const idx = connections.value.findIndex((c) => c.id === config.id);
     if (idx < 0) return;
+    const runtimeConfigChanged = connectionConfigFingerprint(connections.value[idx]) !== connectionConfigFingerprint(config);
     const nextConnections = [...connections.value];
     nextConnections[idx] = config;
     await persistConnections(nextConnections);
     connections.value = nextConnections;
     rebuildTreeNodes();
+    if (!runtimeConfigChanged) return;
     connectedIds.value.delete(config.id);
     clearConnectionIdentifierQuote(config.id);
     clearConnectionHealthCheck(config.id);

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -116,6 +116,7 @@ export interface CompletionAssistantResponse {
 export interface ConnectionConfig {
   id: string;
   name: string;
+  note?: string;
   db_type: DatabaseType;
   driver_profile?: string;
   driver_label?: string;

--- a/crates/dbx-core/src/agent_connection.rs
+++ b/crates/dbx-core/src/agent_connection.rs
@@ -598,6 +598,7 @@ mod tests {
         ConnectionConfig {
             id: "conn".to_string(),
             name: "Connection".to_string(),
+            note: String::new(),
             db_type,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/cloud_sync.rs
+++ b/crates/dbx-core/src/cloud_sync.rs
@@ -1117,6 +1117,7 @@ mod tests {
         ConnectionConfig {
             id: id.to_string(),
             name: "Postgres".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Postgres,
             driver_profile: None,
             driver_label: None,
@@ -1171,6 +1172,7 @@ mod tests {
         ConnectionConfig {
             id: id.to_string(),
             name: "Nacos".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Nacos,
             driver_profile: None,
             driver_label: None,
@@ -1262,6 +1264,7 @@ mod tests {
         let mut config = ConnectionConfig {
             id: "id".to_string(),
             name: "name".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Postgres,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -3854,6 +3854,7 @@ mod tests {
         ConnectionConfig {
             id: "conn".to_string(),
             name: "MySQL".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Mysql,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/connection_secrets.rs
+++ b/crates/dbx-core/src/connection_secrets.rs
@@ -737,6 +737,7 @@ mod tests {
         ConnectionConfig {
             id: id.to_string(),
             name: format!("{id} connection"),
+            note: String::new(),
             db_type: DatabaseType::Postgres,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -4175,6 +4175,7 @@ mod tests {
         ConnectionConfig {
             id: "redis".to_string(),
             name: "Redis".to_string(),
+            note: String::new(),
             db_type: crate::models::connection::DatabaseType::Redis,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -72,6 +72,8 @@ pub fn database_info_from_protocol_value(value: &Value) -> Option<DatabaseConnec
 pub struct ConnectionConfig {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub note: String,
     pub db_type: DatabaseType,
     #[serde(default)]
     pub driver_profile: Option<String>,
@@ -536,6 +538,8 @@ pub enum DatabaseType {
 struct ConnectionConfigData {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub note: String,
     pub db_type: DatabaseType,
     #[serde(default)]
     pub driver_profile: Option<String>,
@@ -631,6 +635,7 @@ impl From<ConnectionConfigData> for ConnectionConfig {
         Self {
             id: data.id,
             name: data.name,
+            note: data.note,
             db_type: data.db_type,
             driver_profile: data.driver_profile,
             driver_label: data.driver_label,
@@ -2175,6 +2180,7 @@ mod tests {
         ConnectionConfig {
             id: "id".to_string(),
             name: "name".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Mysql,
             driver_profile: None,
             driver_label: None,
@@ -2241,6 +2247,20 @@ mod tests {
         .unwrap();
         assert!(serde_json::to_value(&legacy).unwrap().get("mcp_access").is_none());
         assert!(!legacy.read_only);
+    }
+
+    #[test]
+    fn connection_note_is_optional_and_round_trips_when_present() {
+        let config = mysql_config("root", "secret", Some("app"));
+        let value = serde_json::to_value(&config).unwrap();
+        assert!(value.get("note").is_none());
+        assert!(serde_json::from_value::<ConnectionConfig>(value).unwrap().note.is_empty());
+
+        let mut config = config;
+        config.note = "Production reporting".to_string();
+        let value = serde_json::to_value(&config).unwrap();
+        assert_eq!(value["note"], "Production reporting");
+        assert_eq!(serde_json::from_value::<ConnectionConfig>(value).unwrap().note, config.note);
     }
 
     #[test]

--- a/crates/dbx-core/src/mq/config.rs
+++ b/crates/dbx-core/src/mq/config.rs
@@ -104,6 +104,7 @@ mod tests {
         let mut cfg = ConnectionConfig {
             id: "c1".to_string(),
             name: "mq".to_string(),
+            note: String::new(),
             db_type: crate::models::connection::DatabaseType::MessageQueue,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/mq/service.rs
+++ b/crates/dbx-core/src/mq/service.rs
@@ -857,6 +857,7 @@ mod tests {
         ConnectionConfig {
             id: "readonly-mq".to_string(),
             name: "Read only MQ".to_string(),
+            note: String::new(),
             db_type: DatabaseType::MessageQueue,
             driver_profile: Some("pulsar".to_string()),
             driver_label: Some("Apache Pulsar".to_string()),

--- a/crates/dbx-core/src/nacos/config.rs
+++ b/crates/dbx-core/src/nacos/config.rs
@@ -286,6 +286,7 @@ mod tests {
         ConnectionConfig {
             id: "nacos-1".to_string(),
             name: "Nacos".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Nacos,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/nacos/service.rs
+++ b/crates/dbx-core/src/nacos/service.rs
@@ -218,6 +218,7 @@ mod tests {
         let mut cfg = crate::models::connection::ConnectionConfig {
             id: "nacos-1".to_string(),
             name: "Nacos".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Nacos,
             driver_profile: None,
             driver_label: None,
@@ -287,6 +288,7 @@ mod tests {
         let cfg = crate::models::connection::ConnectionConfig {
             id: "nacos-rollback".to_string(),
             name: "Nacos".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Nacos,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/production_safety.rs
+++ b/crates/dbx-core/src/production_safety.rs
@@ -640,6 +640,7 @@ mod tests {
         ConnectionConfig {
             id: "conn".to_string(),
             name: "test".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Mysql,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -3579,6 +3579,7 @@ mod tests {
         ConnectionConfig {
             id: "conn-1".to_string(),
             name: "Connection".to_string(),
+            note: String::new(),
             db_type,
             driver_profile: None,
             driver_label: None,
@@ -4660,6 +4661,7 @@ mod tests {
         let config = ConnectionConfig {
             id: "jdbc-1".to_string(),
             name: "JDBC".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Jdbc,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2886,6 +2886,7 @@ mod tests {
         ConnectionConfig {
             id: "test".to_string(),
             name: "test".to_string(),
+            note: String::new(),
             db_type,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/storage.rs
+++ b/crates/dbx-core/src/storage.rs
@@ -3720,6 +3720,7 @@ mod tests {
         ConnectionConfig {
             id: id.to_string(),
             name: "Pulsar".to_string(),
+            note: String::new(),
             db_type: DatabaseType::MessageQueue,
             driver_profile: Some("pulsar".to_string()),
             driver_label: Some("Apache Pulsar".to_string()),
@@ -3781,6 +3782,7 @@ mod tests {
         ConnectionConfig {
             id: id.to_string(),
             name: "Nacos".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Nacos,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -4921,6 +4921,7 @@ mod tests {
         crate::models::connection::ConnectionConfig {
             id: id.to_string(),
             name: id.to_string(),
+            note: String::new(),
             db_type: DatabaseType::DuckDb,
             driver_profile: None,
             driver_label: None,

--- a/crates/dbx-core/tests/database_export_prefetch.rs
+++ b/crates/dbx-core/tests/database_export_prefetch.rs
@@ -87,6 +87,7 @@ fn postgres_test_config(id: &str, port: u16) -> ConnectionConfig {
     ConnectionConfig {
         id: id.to_string(),
         name: id.to_string(),
+        note: String::new(),
         db_type: DatabaseType::Postgres,
         driver_profile: None,
         driver_label: None,

--- a/crates/dbx-core/tests/live_postgres_query_result_export.rs
+++ b/crates/dbx-core/tests/live_postgres_query_result_export.rs
@@ -20,6 +20,7 @@ fn live_postgres_config(
     ConnectionConfig {
         id: id.to_string(),
         name: id.to_string(),
+        note: String::new(),
         db_type: DatabaseType::Postgres,
         driver_profile: None,
         driver_label: None,

--- a/crates/dbx-core/tests/live_postgres_transfer.rs
+++ b/crates/dbx-core/tests/live_postgres_transfer.rs
@@ -12,6 +12,7 @@ fn postgres_test_config(id: &str, database: &str) -> ConnectionConfig {
     ConnectionConfig {
         id: id.to_string(),
         name: id.to_string(),
+        note: String::new(),
         db_type: DatabaseType::Postgres,
         driver_profile: None,
         driver_label: None,

--- a/crates/dbx-core/tests/live_sqlserver_completion.rs
+++ b/crates/dbx-core/tests/live_sqlserver_completion.rs
@@ -15,6 +15,7 @@ fn live_sqlserver_config(id: &str, database: &str) -> dbx_core::models::connecti
     dbx_core::models::connection::ConnectionConfig {
         id: id.to_string(),
         name: id.to_string(),
+        note: String::new(),
         db_type: DatabaseType::SqlServer,
         driver_profile: None,
         driver_label: None,

--- a/crates/dbx-core/tests/live_sqlserver_query_result_export.rs
+++ b/crates/dbx-core/tests/live_sqlserver_query_result_export.rs
@@ -10,6 +10,7 @@ fn live_sqlserver_config(id: &str, database: &str) -> dbx_core::models::connecti
     dbx_core::models::connection::ConnectionConfig {
         id: id.to_string(),
         name: id.to_string(),
+        note: String::new(),
         db_type: DatabaseType::SqlServer,
         driver_profile: None,
         driver_label: None,

--- a/crates/dbx-web/src/routes/connection.rs
+++ b/crates/dbx-web/src/routes/connection.rs
@@ -417,6 +417,7 @@ mod tests {
         ConnectionConfig {
             id: id.to_string(),
             name: "SQLite".to_string(),
+            note: String::new(),
             db_type: DatabaseType::Sqlite,
             driver_profile: None,
             driver_label: None,

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -176,6 +176,7 @@ mod tests {
         ConnectionConfig {
             id: "mongo".to_string(),
             name: "MongoDB".to_string(),
+            note: String::new(),
             db_type: DatabaseType::MongoDb,
             driver_profile: Some("mongodb".to_string()),
             driver_label: Some("MongoDB".to_string()),


### PR DESCRIPTION
Close：#2460 

## 变更内容

- 在共享连接配置中增加备注字段，覆盖数据库、JDBC、消息队列、Nacos 等全部连接类型
- 将备注放在“连接信息”页面最底部，根据内容自动增高，最多显示 3 行，超出后在输入框内部滚动
- 备注输入框的高度、内边距、边框和聚焦效果与普通输入框保持一致，并为底部焦点环保留完整显示空间
- 新建和编辑连接时均可填写、保存和回显备注，保存前自动去除首尾空白
- 输入框提示“请勿在备注中明文保存密码”，并补齐 7 种语言翻译
- 空备注不写入配置，旧配置缺少备注字段时默认按空值读取；连接导出、导入和 WebDAV 备份会随连接配置保留备注
- 将备注视为描述性元数据，避免仅修改备注时清除已保存的数据库信息或断开当前连接

## 验证

- 实际 UI 验证 MySQL 备注位于连接信息末尾，新建、保存、重新编辑回显正常
- 实际 UI 验证 JDBC 独立入口显示备注字段与安全提示
- 实际 UI 验证输入框随 1、2、3 行内容自动增高，第 4 行保持最大高度并启用内部滚动，删除内容后可自动缩回
- 实际 UI 验证备注输入框与普通输入框的单行高度、内边距、边框和聚焦效果一致，底部焦点环完整显示
- `pnpm typecheck`
- `pnpm test apps/desktop/src/stores/__tests__/connectionStore.databaseInfo.spec.ts apps/desktop/src/lib/__tests__/connection/connectionDialogScrolling.spec.ts apps/desktop/src/lib/__tests__/connection/connectionDialogRadius.spec.ts apps/desktop/src/lib/__tests__/connection/connectionDialogAccessibility.spec.ts`（4 个测试文件、10 个用例通过）
- `pnpm exec vitest run`（此前完整验证 596 个测试文件、4903 个用例通过）
- `pnpm lint`（通过，保留 3 条与本改动无关的既有 warning）
- `cargo fmt --all --check`
- `cargo test -p dbx-core --locked --no-default-features --features mq-admin,sqlite-sqlcipher connection_note_is_optional_and_round_trips_when_present`
- `cargo clippy --workspace --locked --all-targets --no-default-features --features dbx/mq-admin,dbx/sqlite-sqlcipher,dbx-core/mq-admin,dbx-core/sqlite-sqlcipher,dbx-web/mq-admin,dbx-web/sqlite-sqlcipher -- -D warnings`
