### PR TITLE
fix(xugu): return result sets for SHOW statements

### DIFF
--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	_ "gitee.com/XuguDB/go-xugu-driver"
 )
@@ -3953,18 +3955,28 @@ func stripLeadingSQLComments(sqlText string) string {
 }
 
 func isQuerySQL(sqlText string) bool {
-	fields := strings.Fields(strings.ToLower(stripLeadingSQLComments(sqlText)))
-	if len(fields) == 0 {
+	sqlText = stripLeadingSQLComments(sqlText)
+	for _, keyword := range []string{"select", "with", "show"} {
+		if hasLeadingSQLKeyword(sqlText, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLeadingSQLKeyword(sqlText, keyword string) bool {
+	if len(sqlText) < len(keyword) || !strings.EqualFold(sqlText[:len(keyword)], keyword) {
 		return false
 	}
-	switch fields[0] {
-	case "select", "with", "show":
-		// Xugu's SHOW statements return result sets (for example SHOW DB_INFO),
-		// so they must use QueryContext rather than ExecContext.
+	if len(sqlText) == len(keyword) {
 		return true
-	default:
-		return false
 	}
+	next, _ := utf8.DecodeRuneInString(sqlText[len(keyword):])
+	return !isSQLIdentifierContinuation(next)
+}
+
+func isSQLIdentifierContinuation(value rune) bool {
+	return value == '_' || value == '$' || value == '#' || unicode.IsLetter(value) || unicode.IsDigit(value) || unicode.IsMark(value)
 }
 
 func quoteIdentifier(value string) string {

--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -3953,8 +3953,18 @@ func stripLeadingSQLComments(sqlText string) string {
 }
 
 func isQuerySQL(sqlText string) bool {
-	lower := strings.ToLower(strings.TrimSpace(sqlText))
-	return strings.HasPrefix(lower, "select") || strings.HasPrefix(lower, "with")
+	fields := strings.Fields(strings.ToLower(stripLeadingSQLComments(sqlText)))
+	if len(fields) == 0 {
+		return false
+	}
+	switch fields[0] {
+	case "select", "with", "show":
+		// Xugu's SHOW statements return result sets (for example SHOW DB_INFO),
+		// so they must use QueryContext rather than ExecContext.
+		return true
+	default:
+		return false
+	}
 }
 
 func quoteIdentifier(value string) string {

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -1511,17 +1511,67 @@ func TestXuguShowStatementsUseResultSetQueryPath(t *testing.T) {
 	}
 }
 
-func TestIsQuerySQLRecognizesXuguShowStatements(t *testing.T) {
+func TestXuguQueryKeywordBoundariesUseResultSetPath(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		sqlText     string
+		wantQuery   string
+		wantColumns []string
+		wantValue   any
+	}{
+		{name: "parenthesized select", sqlText: "SELECT(1);", wantQuery: "SELECT(1)", wantColumns: []string{"VALUE"}, wantValue: int64(1)},
+		{name: "select hint", sqlText: "SELECT/*+ index */1;", wantQuery: "SELECT/*+ index */1", wantColumns: []string{"VALUE"}, wantValue: int64(1)},
+		{name: "show comment", sqlText: "SHOW/* metadata */ DB_INFO;", wantQuery: "SHOW/* metadata */ DB_INFO", wantColumns: []string{"DB_NAME", "DB_ID", "DB_OWNER", "DB_CHARSET", "DB_TIMEZ"}, wantValue: "SYSTEM"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resetXuguShowResultDriver()
+			db, err := sql.Open("xugu-test-show-result", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			s := newServer()
+			s.db = db
+			result, err := s.executeQuery(queryOptions{SQL: test.sqlText})
+			if err != nil {
+				t.Fatalf("executeQuery(%q): %v", test.sqlText, err)
+			}
+			if !equalStrings(result.Columns, test.wantColumns) {
+				t.Fatalf("columns = %v, want %v", result.Columns, test.wantColumns)
+			}
+			if len(result.Rows) != 1 || len(result.Rows[0]) == 0 || result.Rows[0][0] != test.wantValue {
+				t.Fatalf("rows = %#v, want first value %#v", result.Rows, test.wantValue)
+			}
+
+			queries, execs := recordedXuguShowStatements()
+			if !equalStrings(queries, []string{test.wantQuery}) {
+				t.Fatalf("queries = %v, want %v", queries, []string{test.wantQuery})
+			}
+			if len(execs) != 0 {
+				t.Fatalf("query statements must not use ExecContext, got %v", execs)
+			}
+		})
+	}
+}
+
+func TestIsQuerySQLRecognizesQueryKeywordBoundaries(t *testing.T) {
 	for _, test := range []struct {
 		sqlText string
 		want    bool
 	}{
 		{sqlText: "SELECT 1", want: true},
+		{sqlText: "SELECT(1)", want: true},
+		{sqlText: "SELECT/*+ index */1", want: true},
 		{sqlText: "WITH value AS (SELECT 1) SELECT * FROM value", want: true},
 		{sqlText: "SHOW DB_INFO", want: true},
 		{sqlText: "  show current_schema", want: true},
 		{sqlText: "/* Xugu metadata */ SHOW CHARSETS", want: true},
+		{sqlText: "SHOW/* metadata */ DB_INFO", want: true},
+		{sqlText: "-- leading comment\nSELECT(1)", want: true},
+		{sqlText: "SELECTIVE settings", want: false},
 		{sqlText: "SHOWCASE settings", want: false},
+		{sqlText: "SHOW_CURRENT_SCHEMA", want: false},
 		{sqlText: "CREATE TABLE items (id INTEGER)", want: false},
 	} {
 		t.Run(test.sqlText, func(t *testing.T) {
@@ -1602,13 +1652,17 @@ func (c *xuguShowResultConn) QueryContext(_ context.Context, query string, _ []d
 	xuguShowResultState.queries = append(xuguShowResultState.queries, query)
 	xuguShowResultState.Unlock()
 
-	if query != "SHOW DB_INFO" {
-		return nil, fmt.Errorf("unexpected SHOW query: %s", query)
+	switch query {
+	case "SELECT(1)", "SELECT/*+ index */1":
+		return &xuguStaticRows{columns: []string{"VALUE"}, values: [][]driver.Value{{int64(1)}}}, nil
+	case "SHOW DB_INFO", "SHOW/* metadata */ DB_INFO":
+		return &xuguStaticRows{
+			columns: []string{"DB_NAME", "DB_ID", "DB_OWNER", "DB_CHARSET", "DB_TIMEZ"},
+			values:  [][]driver.Value{{"SYSTEM", int64(1), "SYS", "UTF8.UTF8_GENERAL_CI", "GMT+08:00"}},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", query)
 	}
-	return &xuguStaticRows{
-		columns: []string{"DB_NAME", "DB_ID", "DB_OWNER", "DB_CHARSET", "DB_TIMEZ"},
-		values:  [][]driver.Value{{"SYSTEM", int64(1), "SYS", "UTF8.UTF8_GENERAL_CI", "GMT+08:00"}},
-	}, nil
 }
 func (c *xuguShowResultConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
 	xuguShowResultState.Lock()

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -1472,6 +1472,66 @@ func TestExecuteQueryPreservesXuguTypeBodyTerminator(t *testing.T) {
 	}
 }
 
+func TestXuguShowStatementsUseResultSetQueryPath(t *testing.T) {
+	resetXuguShowResultDriver()
+	db, err := sql.Open("xugu-test-show-result", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+
+	result, err := s.executeQuery(queryOptions{SQL: "SHOW DB_INFO;"})
+	if err != nil {
+		t.Fatalf("executeQuery(SHOW DB_INFO): %v", err)
+	}
+	if got, want := result.Columns, []string{"DB_NAME", "DB_ID", "DB_OWNER", "DB_CHARSET", "DB_TIMEZ"}; !equalStrings(got, want) {
+		t.Fatalf("SHOW DB_INFO columns = %v, want %v", got, want)
+	}
+	if len(result.Rows) != 1 || result.Rows[0][0] != "SYSTEM" {
+		t.Fatalf("SHOW DB_INFO rows = %#v, want database row", result.Rows)
+	}
+
+	page, err := s.executeQueryPage(queryOptions{SQL: "SHOW DB_INFO"}, 10)
+	if err != nil {
+		t.Fatalf("executeQueryPage(SHOW DB_INFO): %v", err)
+	}
+	if len(page.Rows) != 1 || page.Rows[0][0] != "SYSTEM" {
+		t.Fatalf("SHOW DB_INFO page rows = %#v, want database row", page.Rows)
+	}
+
+	queries, execs := recordedXuguShowStatements()
+	if got, want := queries, []string{"SHOW DB_INFO", "SHOW DB_INFO"}; !equalStrings(got, want) {
+		t.Fatalf("SHOW statements queried = %v, want %v", got, want)
+	}
+	if len(execs) != 0 {
+		t.Fatalf("SHOW statements must not use ExecContext, got %v", execs)
+	}
+}
+
+func TestIsQuerySQLRecognizesXuguShowStatements(t *testing.T) {
+	for _, test := range []struct {
+		sqlText string
+		want    bool
+	}{
+		{sqlText: "SELECT 1", want: true},
+		{sqlText: "WITH value AS (SELECT 1) SELECT * FROM value", want: true},
+		{sqlText: "SHOW DB_INFO", want: true},
+		{sqlText: "  show current_schema", want: true},
+		{sqlText: "/* Xugu metadata */ SHOW CHARSETS", want: true},
+		{sqlText: "SHOWCASE settings", want: false},
+		{sqlText: "CREATE TABLE items (id INTEGER)", want: false},
+	} {
+		t.Run(test.sqlText, func(t *testing.T) {
+			if got := isQuerySQL(test.sqlText); got != test.want {
+				t.Fatalf("isQuerySQL(%q) = %t, want %t", test.sqlText, got, test.want)
+			}
+		})
+	}
+}
+
 func contains(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {
@@ -1479,6 +1539,18 @@ func contains(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
 }
 
 // -- fake drivers for agent tests --
@@ -1490,6 +1562,59 @@ func init() {
 	sql.Register("xugu-test-legacy-columns", &xuguLegacyColumnsDriver{})
 	sql.Register("xugu-test-table-objects", &xuguTableObjectsDriver{})
 	sql.Register("xugu-test-table-ddl", &xuguTableDDLDriver{})
+	sql.Register("xugu-test-show-result", &xuguShowResultDriver{})
+}
+
+type xuguShowResultDriver struct{}
+
+var xuguShowResultState struct {
+	sync.Mutex
+	queries []string
+	execs   []string
+}
+
+func resetXuguShowResultDriver() {
+	xuguShowResultState.Lock()
+	xuguShowResultState.queries = nil
+	xuguShowResultState.execs = nil
+	xuguShowResultState.Unlock()
+}
+
+func recordedXuguShowStatements() (queries []string, execs []string) {
+	xuguShowResultState.Lock()
+	defer xuguShowResultState.Unlock()
+	return append([]string(nil), xuguShowResultState.queries...), append([]string(nil), xuguShowResultState.execs...)
+}
+
+func (d *xuguShowResultDriver) Open(name string) (driver.Conn, error) {
+	return &xuguShowResultConn{}, nil
+}
+
+type xuguShowResultConn struct{}
+
+func (c *xuguShowResultConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not supported")
+}
+func (c *xuguShowResultConn) Close() error              { return nil }
+func (c *xuguShowResultConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+func (c *xuguShowResultConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	xuguShowResultState.Lock()
+	xuguShowResultState.queries = append(xuguShowResultState.queries, query)
+	xuguShowResultState.Unlock()
+
+	if query != "SHOW DB_INFO" {
+		return nil, fmt.Errorf("unexpected SHOW query: %s", query)
+	}
+	return &xuguStaticRows{
+		columns: []string{"DB_NAME", "DB_ID", "DB_OWNER", "DB_CHARSET", "DB_TIMEZ"},
+		values:  [][]driver.Value{{"SYSTEM", int64(1), "SYS", "UTF8.UTF8_GENERAL_CI", "GMT+08:00"}},
+	}, nil
+}
+func (c *xuguShowResultConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	xuguShowResultState.Lock()
+	xuguShowResultState.execs = append(xuguShowResultState.execs, query)
+	xuguShowResultState.Unlock()
+	return nil, fmt.Errorf("SHOW statement was incorrectly sent to ExecContext: %s", query)
 }
 
 type xuguTableDDLDriver struct{}


### PR DESCRIPTION
## Summary
- Classify Xugu `SHOW` commands as row-producing SQL and route them through `QueryContext`.
- Keep `SELECT` and `WITH` on the same query path, but match complete leading SQL keywords rather than raw prefixes.
- Add regression coverage for standard and paginated execution of `SHOW DB_INFO`.

## Problem
XuguDB returns a result set for statements such as `SHOW DB_INFO`. The Xugu Agent previously recognized only `SELECT` and `WITH` as queries, so it sent `SHOW` through `ExecContext`. DBX therefore reported success but had no columns or rows to render.

## Implementation
The change is intentionally limited to `agents/drivers/xugu`:
- `isQuerySQL` now recognizes the `SHOW` keyword after whitespace or leading SQL comments.
- The behavioral regression driver returns a `DB_INFO` row only from `QueryContext` and fails if `ExecContext` is used.
- The test exercises both `execute_query` and the paginated `execute_query_page` path, asserts all five `SHOW DB_INFO` columns and the returned row, and verifies that no execution-path call occurred.

No frontend or Rust changes are required: the desktop already renders the `columns` and `rows` returned by the Agent; the defect was solely the native Xugu Agent's dispatch choice.

## Validation
- [x] `GONOSUMDB=gitee.com/XuguDB/go-xugu-driver go test ./...` in `agents/drivers/xugu`
- [x] `GONOSUMDB=gitee.com/XuguDB/go-xugu-driver CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /tmp/dbx-agent-xugu-linux-x64 .`
- [x] `go vet .`
- [x] `git diff --check`
- [x] Manual Agent RPC validation against a local XuguDB instance with DBX's pinned `go-xugu-driver v1.0.12`:
  - `SHOW DB_INFO` returned `DB_NAME`, `DB_ID`, `DB_OWNER`, `DB_CHARSET`, and `DB_TIMEZ` plus one row.
  - `SHOW CHARSETS` returned a paginated result set.
  - `SHOW CURRENT_SCHEMA` returned its single row.

## Compatibility evidence
A separate 73-statement comparison of xgconsole and `go-xugu-driver v1.0.13` found 66 commands succeeding in both clients. This confirms that ordinary Xugu `SHOW` commands provide real driver result sets. MySQL-style `SHOW DATABASES`, `SHOW TABLES`, and `SHOW VARIABLES` remain unsupported by the Xugu driver and are intentionally not emulated by this PR.

## Scope
- [x] Bug fix
- [ ] Frontend change
- [ ] Documentation change
- [ ] CI / build change