### PR TITLE
feat(editor): add scroll space past last line

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -3246,7 +3246,7 @@ onMounted(async () => {
   if (!editorRef.value) return;
 
   const [
-    { EditorView, keymap, rectangularSelection, hoverTooltip, showTooltip, Decoration, tooltips, gutter, GutterMarker, lineNumberMarkers, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, crosshairCursor, ViewPlugin },
+    { EditorView, keymap, rectangularSelection, hoverTooltip, showTooltip, Decoration, tooltips, gutter, GutterMarker, lineNumberMarkers, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, crosshairCursor, scrollPastEnd, ViewPlugin },
     { EditorState, EditorSelection, Compartment, Prec, RangeSet, StateEffect, StateField },
     langSql,
     { autocompletion, startCompletion, acceptCompletion, closeBrackets, closeBracketsKeymap, snippetCompletion, completionStatus, completionKeymap, insertCompletionText, nextSnippetField },
@@ -3687,6 +3687,7 @@ onMounted(async () => {
       trimmedSelectionLayer(),
       selectionMatchOccurrences(),
       dropCursor(),
+      props.readOnly ? [] : scrollPastEnd(),
       EditorView.dragMovesSelection.of((event) => !event.ctrlKey && !event.metaKey),
       EditorState.allowMultipleSelections.of(true),
       indentOnInput(),

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorScrollPastEnd.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorScrollPastEnd.spec.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+describe("QueryEditor bottom scroll space", () => {
+  it("allows editable documents to scroll past the last line without changing read-only previews", () => {
+    expect(queryEditorSource).toContain("scrollPastEnd, ViewPlugin");
+    expect(queryEditorSource).toContain("props.readOnly ? [] : scrollPastEnd()");
+  });
+});


### PR DESCRIPTION
## 变更说明

为可编辑的 SQL 查询编辑器启用 CodeMirror `scrollPastEnd` 扩展，使最后一行可以继续向上滚动，并在下方保留约一屏空间，避免继续编辑时鼠标容易点到窗口外。

只读对象源码预览保持原有滚动行为。

同时新增回归测试，确保可编辑查询启用底部留白，且只读预览不受影响。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

### macOS 验证

最后一行可以滚动到编辑器顶部，下方保留一屏空间：

<img width="1273" height="792" alt="Snipaste_2026-07-27_18-04-25" src="https://github.com/user-attachments/assets/1a63ff56-994f-4d8f-bad3-9e43a1f2e53e" />


## 验证

- [x] `make check` 通过（macOS）
- [ ] `make cargo-check-fast` 通过（未修改 Rust，不适用）
- [x] 相关测试通过
- [x] `pnpm build` 通过
- [x] macOS 开发版手工验证通过
- [x] 确认只读对象源码预览保持原有滚动行为

相关回归测试：

- `apps/desktop/src/lib/__tests__/editor/queryEditorScrollPastEnd.spec.ts`

## 关联 Issue

Close #4541