### PR TITLE
fix(dameng): 修复库内表搜索转义错误

### DIFF
--- a/agents/common/src/main/java/com/dbx/agent/MetadataListConstraints.java
+++ b/agents/common/src/main/java/com/dbx/agent/MetadataListConstraints.java
@@ -61,6 +61,10 @@ public final class MetadataListConstraints {
     }
 
     public String fuzzyLikePattern() {
+        return fuzzyLikePattern('\\');
+    }
+
+    public String fuzzyLikePattern(char escapeCharacter) {
         if (filter.isEmpty()) {
             return "%%";
         }
@@ -68,8 +72,8 @@ public final class MetadataListConstraints {
         builder.append('%');
         for (int i = 0; i < filter.length(); i++) {
             char ch = filter.charAt(i);
-            if (ch == '\\' || ch == '%' || ch == '_') {
-                builder.append('\\');
+            if (ch == escapeCharacter || ch == '%' || ch == '_') {
+                builder.append(escapeCharacter);
             }
             builder.append(ch);
             builder.append('%');

--- a/agents/common/src/test/java/com/dbx/agent/MetadataListConstraintsTest.java
+++ b/agents/common/src/test/java/com/dbx/agent/MetadataListConstraintsTest.java
@@ -1,0 +1,21 @@
+package com.dbx.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MetadataListConstraintsTest {
+    @Test
+    void fuzzyLikePatternKeepsBackslashAsDefaultEscapeCharacter() {
+        MetadataListConstraints constraints = new MetadataListConstraints("a_%~\\", null, null, null);
+
+        assertEquals("%a%\\_%\\%%~%\\\\%", constraints.fuzzyLikePattern());
+    }
+
+    @Test
+    void fuzzyLikePatternSupportsDatabaseSpecificEscapeCharacter() {
+        MetadataListConstraints constraints = new MetadataListConstraints("a_%~\\", null, null, null);
+
+        assertEquals("%a%~_%~%%~~%\\%", constraints.fuzzyLikePattern('~'));
+    }
+}

--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -408,8 +408,8 @@ public final class DamengAgent extends BaseDatabaseAgent {
         if (!constraints.hasFilter()) {
             return;
         }
-        sql.append(" AND UPPER(").append(column).append(") LIKE ? ESCAPE '\\\\'");
-        args.add(constraints.fuzzyLikePattern().toUpperCase(Locale.ROOT));
+        sql.append(" AND UPPER(").append(column).append(") LIKE ? ESCAPE '~'");
+        args.add(constraints.fuzzyLikePattern('~').toUpperCase(Locale.ROOT));
     }
 
     private static void appendLimitOffset(StringBuilder sql, List<Object> args, MetadataListConstraints constraints) {

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
@@ -140,7 +140,7 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         assertTrue(query.sql().contains("o.OBJECT_TYPE = 'MATERIALIZED VIEW'"));
         assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
         assertTrue(query.sql().contains("IN (?, ?)"));
-        assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '\\\\'"));
+        assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '~'"));
         assertTrue(query.sql().endsWith("LIMIT ? OFFSET ?"));
         assertEquals(List.of("APP", "TABLE", "VIEW", "%O%R%D%", 50, 100), query.args());
     }
@@ -186,7 +186,7 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         assertFalse(query.sql().contains("USER_MVIEWS"));
         assertFalse(query.sql().contains("DBMS_METADATA.GET_DDL"));
         assertTrue(query.sql().contains("mv.MVIEW_NAME IS NOT NULL"));
-        assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '\\\\'"));
+        assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '~'"));
         assertTrue(query.sql().endsWith("LIMIT ? OFFSET ?"));
         assertEquals(List.of("REPORTING", "VIEW", "MATERIALIZED_VIEW", "%S%A%L%E%S%", 20, 40), query.args());
     }
@@ -218,6 +218,17 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         assertTrue(query.sql().contains("WHEN 'PROCEDURE' THEN 3"));
         assertTrue(query.sql().endsWith("LIMIT ?"));
         assertEquals(List.of("APP", "PROCEDURE", "FUNCTION", "%S%Y%N%C%", 20), query.args());
+    }
+
+    @Test
+    void constrainedTableQueryEscapesDamengLikeWildcardsWithSingleCharacter() {
+        DamengAgent.MetadataQuery query = DamengAgent.buildConstrainedTablesQuery(
+            "APP",
+            new MetadataListConstraints("a_%~\\", 20, null, List.of("TABLE"))
+        );
+
+        assertTrue(query.sql().contains("UPPER(o.OBJECT_NAME) LIKE ? ESCAPE '~'"));
+        assertEquals(List.of("APP", "TABLE", "%A%~_%~%%~~%\\%", 20), query.args());
     }
 
     @Test


### PR DESCRIPTION
## 问题

达梦元数据筛选生成了 `LIKE ? ESCAPE '\\'`。达梦将 SQL 中的反斜杠字面量识别为两个字符，搜索表名时会报 `DMException: 无效的转义字符长度`。

## 修改

- 达梦表/对象筛选改用单字符 `~` 作为 LIKE 转义符
- LIKE pattern 同步按 `~` 转义 `%`、`_` 和转义符自身
- 保持其他数据库默认使用反斜杠的现有行为
- 补充默认 pattern 与达梦特殊字符搜索的回归测试

## 验证

- 在 DBX Dev 达梦 DM8 上通过 DBX 查询链路复现原错误
- 使用新 agent 搜索 `PLAN`，正常返回 `##PLAN_TABLE`
- 创建 `DBX_I3971_A_B` 和 `DBX_I3971_AXB`，搜索 `a_b` 仅返回带字面下划线的前者
- 临时测试表已清理并确认无残留
- `python3 -m unittest discover -s scripts -p '*_test.py'`
- `python3 scripts/validate_agents.py`
- Oracle/Xugu 原生 agent 测试及 Linux 构建
- `./gradlew test shadowJar --continue`
- `python3 scripts/validate_agent_jars.py`

Closes #3971