### PR TITLE
Fix：修复 GaussDB 存储过程吞并后续 SQL

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -92,6 +92,37 @@ END$function$;
 
 DROP FUNCTION IF EXISTS dbx_issue_4572_tmp_missing;`;
 
+const gaussDbIssue4573Script = `CREATE OR REPLACE PROCEDURE createIndex (
+  dbName IN VARCHAR(32),
+  tableName IN VARCHAR(64),
+  indexInfo IN VARCHAR(64),
+  indexColumns IN VARCHAR(128)
+) AS
+DECLARE STMT TEXT;
+
+DECLARE flag int;
+
+BEGIN
+SELECT
+  count(*) INTO flag
+FROM
+  PG_CATALOG.PG_INDEXES
+WHERE
+  schemaname = dbName
+  AND TABLENAME = tableName
+  AND INDEXNAME = indexInfo;
+
+IF flag = 0 THEN STMT := 'CREATE INDEX ' || indexInfo || ' ON ' || dbName || '.' || tableName || '(' || indexColumns || ')';
+
+EXECUTE STMT;
+
+END IF;
+
+END;
+
+SELECT 1 AS after_procedure;
+SELECT 2 AS final_statement;`;
+
 const xuguProgrammableObjectFixtures = [
   `CREATE OR REPLACE PROCEDURE dbx_xugu_procedure AS
   v_value INTEGER;
@@ -311,6 +342,10 @@ describe("splitSqlStatementRanges", () => {
       gaussDbDollarQuotedFunctionScript.slice(gaussDbDollarQuotedFunctionScript.indexOf("CREATE"), gaussDbDollarQuotedFunctionScript.lastIndexOf(";\n\nDROP")),
       "DROP FUNCTION IF EXISTS dbx_issue_4572_tmp_missing",
     ]);
+  });
+
+  it("separates the issue #4573 GaussDB procedure from following statements", () => {
+    expect(rangeSqlTexts(splitSqlStatementRanges(gaussDbIssue4573Script, "gaussdb"))).toEqual([gaussDbIssue4573Script.slice(0, gaussDbIssue4573Script.indexOf("\n\nSELECT 1")), "SELECT 1 AS after_procedure", "SELECT 2 AS final_statement"]);
   });
 
   it("keeps Xugu programmable object DDL together and retains its terminator", () => {
@@ -874,6 +909,11 @@ WHERE request_json LIKE '%"paperFlag":null%';`;
   it("returns the full GaussDB procedure for cursors after a nested block", () => {
     const outerNull = indexOf(gaussDbNestedProcedure, "NULL;", 2);
     expect(statementRangeAtCursor(gaussDbNestedProcedure, outerNull, "gaussdb")?.sql.trim()).toBe(gaussDbNestedProcedure);
+  });
+
+  it("returns only the issue #4573 GaussDB procedure for a gutter cursor", () => {
+    const expected = gaussDbIssue4573Script.slice(0, gaussDbIssue4573Script.indexOf("\n\nSELECT 1"));
+    expect(statementRangeAtCursor(gaussDbIssue4573Script, indexOf(gaussDbIssue4573Script, "count(*)"), "gaussdb")?.sql.trim()).toBe(expected);
   });
 
   it("returns the full SAP HANA DO block for cursors inside nested statements", () => {

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -1705,7 +1705,7 @@ function oraclePlSqlBlockIsComplete(sql: string): boolean {
     if (token.kind !== "word") continue;
 
     if (token.value === "DECLARE") {
-      stack.push("DECLARATION");
+      if (stack[stack.length - 1] !== "DECLARATION") stack.push("DECLARATION");
       continue;
     }
     if (token.value === "BEGIN") {

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -3222,6 +3222,48 @@ DROP FUNCTION IF EXISTS dbx_issue_4572_tmp_missing;";
     }
 
     #[test]
+    fn gaussdb_split_separates_issue_4573_procedure_from_following_statements() {
+        let sql = "\
+CREATE OR REPLACE PROCEDURE createIndex (
+  dbName IN VARCHAR(32),
+  tableName IN VARCHAR(64),
+  indexInfo IN VARCHAR(64),
+  indexColumns IN VARCHAR(128)
+) AS
+DECLARE STMT TEXT;
+
+DECLARE flag int;
+
+BEGIN
+SELECT
+  count(*) INTO flag
+FROM
+  PG_CATALOG.PG_INDEXES
+WHERE
+  schemaname = dbName
+  AND TABLENAME = tableName
+  AND INDEXNAME = indexInfo;
+
+IF flag = 0 THEN STMT := 'CREATE INDEX ' || indexInfo || ' ON ' || dbName || '.' || tableName || '(' || indexColumns || ')';
+
+EXECUTE STMT;
+
+END IF;
+
+END;
+
+SELECT 1 AS after_procedure;
+SELECT 2 AS final_statement;";
+
+        let statements = split_sql_statements_for_database(sql, DatabaseType::Gaussdb);
+        assert_eq!(statements.len(), 3);
+        assert!(statements[0].starts_with("CREATE OR REPLACE PROCEDURE createIndex"));
+        assert!(statements[0].ends_with("END;"));
+        assert_eq!(statements[1], "SELECT 1 AS after_procedure");
+        assert_eq!(statements[2], "SELECT 2 AS final_statement");
+    }
+
+    #[test]
     fn oracle_like_split_keeps_issue_2405_anonymous_plsql_block_together() {
         let sql = "\
 DECLARE


### PR DESCRIPTION
## 问题

GaussDB 存储过程在外层 `BEGIN` 前使用多个 `DECLARE` 时，前端 PL/SQL 范围解析器会为每个 `DECLARE` 叠加一层声明作用域。最终 `END;` 后仍残留作用域，导致编辑器把后续全部 SQL 识别成同一条语句，点击左侧运行按钮时一并执行。

## 修改

- 将外层 `BEGIN` 前连续的 `DECLARE` 识别为同一声明区
- 保留块内 `DECLARE ... BEGIN ... END` 的嵌套层级行为
- 补充编辑器分句、光标运行范围和后端分句回归测试

## 验证

- openGauss 5.0.3 实测原始双 `DECLARE` 过程成功创建，后续两条 `SELECT` 分别独立返回 `1`、`2`，临时过程已清理
- `pnpm check`：格式、lint、类型检查及前端全量测试通过（5055 passed）
- `cargo fmt --all -- --check`
- CI 同款 workspace Clippy 通过
- CI 同款 workspace Rust 全量测试通过（`dbx-core`: 2847 passed, 17 ignored；其余 workspace 目标通过）

Fixes #4573