### PR TITLE
fix(mq): preserve message browsing state

### DIFF
--- a/apps/desktop/src/components/mq/SendMessagePanel.vue
+++ b/apps/desktop/src/components/mq/SendMessagePanel.vue
@@ -42,8 +42,8 @@ const peekAdvancedExpanded = ref(false);
 const peekLoading = ref(false);
 const peekError = ref<string>();
 const peekMessages = ref<PeekedMessage[]>([]);
-const peekPartition = ref("");
-const peekOffset = ref("");
+const peekPartition = ref<string | number>("");
+const peekOffset = ref<string | number>("");
 const peekCount = ref(20);
 
 let successTimer: ReturnType<typeof setTimeout> | undefined;
@@ -196,11 +196,6 @@ async function sendMessage() {
       if (sendNamespace) req.namespace = sendNamespace;
     }
     success.value = await mqSendMessage(props.connectionId, req);
-    if (canBrowseMessages.value) {
-      peekPartition.value = String(success.value.partition);
-      peekOffset.value = String(success.value.offset);
-      void loadMessages();
-    }
     messageValue.value = "";
     messageKey.value = "";
     clearSuccessLater();
@@ -223,8 +218,8 @@ async function loadMessages() {
     const count = Math.max(1, Math.min(100, Number(peekCount.value) || 20));
     peekCount.value = count;
     const options: { partition?: number; offset?: number } = {};
-    const partitionText = peekPartition.value.trim();
-    const offsetText = peekOffset.value.trim();
+    const partitionText = String(peekPartition.value).trim();
+    const offsetText = String(peekOffset.value).trim();
     if (partitionText !== "") {
       const partition = parseNonNegativeSafeInteger(partitionText);
       if (partition == null) {

--- a/apps/desktop/src/components/mq/__tests__/SendMessagePanel.spec.ts
+++ b/apps/desktop/src/components/mq/__tests__/SendMessagePanel.spec.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, nextTick, type App } from "vue";
+
+const backend = vi.hoisted(() => ({
+  mqListTopics: vi.fn(),
+  mqPeekMessages: vi.fn(),
+  mqSendMessage: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/backend/api", () => ({
+  mqListTopics: backend.mqListTopics,
+  mqPeekMessages: backend.mqPeekMessages,
+  mqSendMessage: backend.mqSendMessage,
+}));
+
+import SendMessagePanel from "@/components/mq/SendMessagePanel.vue";
+
+const TOPIC = {
+  name: "persistent://public/default/events",
+  shortName: "events",
+  partitioned: false,
+  persistent: true,
+};
+
+type BrowseableSystem = "kafka" | "rabbitmq";
+
+let app: App<Element> | null = null;
+let root: HTMLDivElement | null = null;
+
+async function flushUi() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await nextTick();
+}
+
+function buttonByText(container: ParentNode, text: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll<HTMLButtonElement>("button")].find((item) => item.textContent?.includes(text));
+  if (!button) throw new Error(`Button not found: ${text}`);
+  return button;
+}
+
+async function setInputValue(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+}
+
+function expectedTopic(system: BrowseableSystem) {
+  return {
+    tenant: system === "rabbitmq" ? "_rabbitmq" : "_kafka",
+    namespace: "default",
+    topic: TOPIC.shortName,
+    persistent: true,
+    partitioned: false,
+  };
+}
+
+async function mountPanel(system: BrowseableSystem) {
+  root = document.createElement("div");
+  document.body.appendChild(root);
+  app = createApp(SendMessagePanel, {
+    connectionId: "mq-1",
+    tenant: system === "rabbitmq" ? "_rabbitmq" : "_kafka",
+    namespace: "default",
+    topic: TOPIC,
+    mqSystemKind: system,
+    isFlatMqCluster: true,
+    supportsPeekMessages: true,
+  });
+  app.config.globalProperties.$t = (key: string) => key;
+  app.mount(root);
+  await flushUi();
+  return root;
+}
+
+async function sendMessage(container: ParentNode, value: string) {
+  const textarea = container.querySelector<HTMLTextAreaElement>(".code-textarea");
+  if (!textarea) throw new Error("Message textarea not found");
+  await setInputValue(textarea, value);
+  buttonByText(container, "mqMessages.sendMessage").click();
+  await flushUi();
+}
+
+async function loadMessages(container: ParentNode) {
+  const button = buttonByText(container, "mqMessages.loadMessages");
+  if (button.disabled) throw new Error("Load messages button is disabled");
+  button.click();
+  await flushUi();
+}
+
+beforeEach(() => {
+  backend.mqListTopics.mockReset();
+  backend.mqPeekMessages.mockReset();
+  backend.mqSendMessage.mockReset();
+  backend.mqListTopics.mockResolvedValue([TOPIC]);
+  backend.mqPeekMessages.mockResolvedValue([
+    {
+      position: 1,
+      messageId: "0",
+      payloadBase64: "",
+      payloadText: "existing message",
+      properties: { partition: "0" },
+      headers: {},
+    },
+  ]);
+  backend.mqSendMessage.mockResolvedValue({ topic: TOPIC.shortName, partition: 2, offset: 17 });
+});
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  root?.remove();
+  root = null;
+});
+
+describe("SendMessagePanel post-send browsing", () => {
+  for (const system of ["kafka", "rabbitmq"] as const) {
+    it(`keeps ${system} results unchanged after sending`, async () => {
+      const panel = await mountPanel(system);
+
+      await loadMessages(panel);
+      expect(backend.mqPeekMessages).toHaveBeenCalledWith("mq-1", expectedTopic(system), "__dbx_kafka_viewer__", 20, {});
+      expect(panel.textContent).toContain("existing message");
+
+      await sendMessage(panel, "new message");
+
+      expect(backend.mqPeekMessages).toHaveBeenCalledTimes(1);
+      expect(panel.textContent).toContain("existing message");
+    });
+  }
+
+  it("preserves Kafka advanced filters until the user explicitly loads messages", async () => {
+    const panel = await mountPanel("kafka");
+
+    buttonByText(panel, "mqMessages.advancedFilter").click();
+    await flushUi();
+    const partitionInput = panel.querySelector<HTMLInputElement>('input[placeholder="mqMessages.partitionPlaceholderAll"]');
+    const offsetInput = panel.querySelector<HTMLInputElement>('input[placeholder="mqMessages.offsetPlaceholderEarliest"]');
+    if (!partitionInput || !offsetInput) throw new Error("Advanced filter inputs not found");
+    await setInputValue(partitionInput, "2");
+    await setInputValue(offsetInput, "17");
+
+    await sendMessage(panel, "new message");
+
+    expect(partitionInput.value).toBe("2");
+    expect(offsetInput.value).toBe("17");
+    expect(backend.mqPeekMessages).not.toHaveBeenCalled();
+
+    await loadMessages(panel);
+    expect(backend.mqPeekMessages).toHaveBeenCalledWith("mq-1", expectedTopic("kafka"), "__dbx_kafka_viewer__", 20, { partition: 2, offset: 17 });
+  });
+});


### PR DESCRIPTION
## 变更说明

修复 Kafka 和 RabbitMQ 发送消息后隐式改写消息浏览状态的问题。

- 发送成功后不再自动加载消息，也不再覆盖用户填写的分区和 Offset。
- 保留当前列表和高级筛选，消息加载仅在用户主动点击时执行。
- 修复数字类型的高级筛选调用 `.trim()` 导致的运行时错误。

## 根因与修复

- 旧逻辑将发送回执中的 `partition` 和 `offset` 写入折叠的高级筛选，并自动加载消息；用户表面上未设置筛选，后续手动加载却仍携带这两个值。
- Kafka 将显式 Offset 视为精确读取起点。刚发送消息位于尾部时，按该分区和 Offset 查询只能读到新消息；后端语义正确，问题在前端错误持久化了发送回执。
- 本 PR 移除发送后的隐式加载和筛选改写。发送成功仅显示分区与 Offset、清空表单并保留当前浏览状态；用户主动加载时，空筛选走默认范围，显式筛选继续精确生效。
- 分区和 Offset 输入框为 `type="number"`，Vue 会产生数字值；旧逻辑直接调用 `.trim()` 会报错。本 PR 在解析前统一转换为字符串，并新增回归测试。

复现录屏：

https://github.com/user-attachments/assets/95d9e715-dc06-49a2-b5d0-ccb489d913f0

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）



## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过：`apps/desktop/src/components/mq/__tests__/SendMessagePanel.spec.ts`

## 关联 Issue

Close #4565 #4596
