### PR TITLE
fix(import): allow selecting data type in create-table mapping

### DIFF
--- a/apps/desktop/src/components/import/TableImportDialog.vue
+++ b/apps/desktop/src/components/import/TableImportDialog.vue
@@ -1453,7 +1453,7 @@ watch(rawProgressPercent, (percent) => {
 
       <!-- 全局数据类型 popover：仅一个实例，替代每列的 SearchableSelect -->
       <Teleport to="body">
-        <div v-if="activeDataTypeColumn && dataTypePickerOpen" id="table-import-data-type-options" role="listbox" :style="dataTypePickerStyle" class="z-[9999] max-h-48 overflow-auto rounded-md border bg-popover p-0.5 shadow-md">
+        <div v-if="activeDataTypeColumn && dataTypePickerOpen" id="table-import-data-type-options" role="listbox" :style="dataTypePickerStyle" class="pointer-events-auto z-[9999] max-h-48 overflow-auto rounded-md border bg-popover p-0.5 shadow-md">
           <button
             v-for="(opt, index) in dataTypePickerOptions"
             :key="opt"


### PR DESCRIPTION
## 问题

关联 Issue: #4582

导入数据新建表时,映射步骤的"目标类型"下拉预置值无法选择,垂直滚动条点击和鼠标滚轮都不起作用(仅能手动录入)。

## 根因

数据类型选择弹层通过 `Teleport to="body"` 渲染,是模态对话框内容层(`DialogContent`,带 `pointer-events-auto`)的兄弟节点。reka-ui 的 `DismissableLayer` 在模态层激活时会把 `document.body` 的 `pointer-events` 置为 `none`,只有对话框内容层能接收事件。teleport 出去的弹层不在该范围内,于是继承了 `pointer-events: none`:

- 选项按钮的 `pointerdown` 不触发 → 预置值无法选择
- `overflow-auto` 容器收不到 pointer/wheel 事件 → 滚动条与滚轮失效

输入框本身在对话框内容层里,所以仍可聚焦、手动录入,与 Issue 现状一致。

该问题与数据库类型无关,所有"新建表"导入场景都会复现(Issue 上的 `db/sqlserver` 标签有误导)。

## 修复

给 teleport 出去的弹层加 `pointer-events-auto`,与仓库中 `DialogContent.vue`、`DialogOverlay.vue` 突破该遮罩的既有做法一致。一处改动同时解决"无法选择 + 无法滚动"。

## 验证

- `pnpm typecheck` 通过
- 本地手动验证:新建表映射步骤中,目标类型预置值可正常点击选择,滚动条与滚轮均恢复正常