### PR TITLE
Fix：格式化 Nacos 配置历史时间显示

### DIFF
--- a/apps/desktop/src/components/nacos/NacosConfigHistoryDialog.vue
+++ b/apps/desktop/src/components/nacos/NacosConfigHistoryDialog.vue
@@ -5,6 +5,7 @@ import { useI18n } from "vue-i18n";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { formatNacosHistoryTime } from "@/lib/nacos/nacosAdmin";
 import type { NacosConfigHistoryItem, NacosConfigItem } from "@/types/nacos";
 
 const open = defineModel<boolean>("open", { default: false });
@@ -69,6 +70,10 @@ function display(value?: string | null) {
   return trimmed || "-";
 }
 
+function displayHistoryTime(value?: string | null) {
+  return formatNacosHistoryTime(value);
+}
+
 function operationLabel(value?: string) {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return "-";
@@ -128,7 +133,7 @@ function loadPage(pageNo: number) {
             <tr v-for="item in items" :key="`${item.historyId}:${item.nid ?? ''}`" class="border-b">
               <td class="max-w-72 truncate px-4 py-2 font-medium" :title="item.dataId">{{ item.dataId }}</td>
               <td class="max-w-44 truncate px-4 py-2 text-xs text-muted-foreground" :title="item.group">{{ item.group || "DEFAULT_GROUP" }}</td>
-              <td class="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">{{ display(item.lastModifiedTime) }}</td>
+              <td class="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground" :title="display(item.lastModifiedTime)">{{ displayHistoryTime(item.lastModifiedTime) }}</td>
               <td class="max-w-40 truncate px-4 py-2 text-xs text-muted-foreground" :title="item.appName || ''">{{ display(item.appName) }}</td>
               <td class="px-4 py-2">
                 <Badge variant="outline">{{ operationLabel(item.operation) }}</Badge>
@@ -189,7 +194,7 @@ function loadPage(pageNo: number) {
           <div class="min-w-0 truncate font-mono" :title="viewingItem.namespace || 'public'">namespace={{ viewingItem.namespace || "public" }}</div>
           <div class="min-w-0 truncate font-mono" :title="viewingItem.dataId">dataId={{ viewingItem.dataId }}</div>
           <div class="min-w-0 truncate font-mono" :title="viewingItem.group || 'DEFAULT_GROUP'">group={{ viewingItem.group || "DEFAULT_GROUP" }}</div>
-          <div class="min-w-0 truncate" :title="display(viewingItem.lastModifiedTime)">{{ t("nacos.updatedAt") }}={{ display(viewingItem.lastModifiedTime) }}</div>
+          <div class="min-w-0 truncate" :title="display(viewingItem.lastModifiedTime)">{{ t("nacos.updatedAt") }}={{ displayHistoryTime(viewingItem.lastModifiedTime) }}</div>
         </div>
       </DialogHeader>
       <div class="min-h-0 flex-1 overflow-auto bg-muted/20 p-4">

--- a/apps/desktop/src/lib/__tests__/nacos/nacosAdmin.spec.ts
+++ b/apps/desktop/src/lib/__tests__/nacos/nacosAdmin.spec.ts
@@ -100,10 +100,19 @@ describe("nacosAdmin helpers", () => {
   });
 
   it("formats Nacos history timestamps for display", () => {
+    const epochDate = new Date(1_710_000_000_000);
+    const epochDatePart = [epochDate.getFullYear(), epochDate.getMonth() + 1, epochDate.getDate()].map((part) => String(part).padStart(2, "0")).join("-");
+    const epochTimePart = [epochDate.getHours(), epochDate.getMinutes(), epochDate.getSeconds()].map((part) => String(part).padStart(2, "0")).join(":");
+    const epochDisplay = `${epochDatePart} ${epochTimePart}`;
+
     expect(formatNacosHistoryTime("2026-07-27T18:16:36.000+08:00")).toBe("2026-07-27 18:16:36");
     expect(formatNacosHistoryTime("2026-07-27T18:16:36Z")).toBe("2026-07-27 18:16:36");
     expect(formatNacosHistoryTime("2026-07-27 18:16:36")).toBe("2026-07-27 18:16:36");
+    expect(formatNacosHistoryTime("1710000000000")).toBe(epochDisplay);
+    expect(formatNacosHistoryTime("1710000000")).toBe(epochDisplay);
+    expect(formatNacosHistoryTime("0")).toBe("-");
     expect(formatNacosHistoryTime("")).toBe("-");
+    expect(formatNacosHistoryTime(null)).toBe("-");
     expect(formatNacosHistoryTime("not-a-time")).toBe("not-a-time");
   });
 

--- a/apps/desktop/src/lib/__tests__/nacos/nacosAdmin.spec.ts
+++ b/apps/desktop/src/lib/__tests__/nacos/nacosAdmin.spec.ts
@@ -13,6 +13,7 @@ import {
   createNacosConfigDeleteSnapshot,
   createNacosConfigSaveSnapshot,
   createNacosLatestRequestGuard,
+  formatNacosHistoryTime,
   isNacosRawMutation,
   isNacosErrorCode,
   isNacosConfigSaveSnapshotCurrent,
@@ -96,6 +97,14 @@ describe("nacosAdmin helpers", () => {
     expect(isNacosErrorCode(new Error("NACOS_ERROR[stalePreview]: preview again"), "stalePreview")).toBe(true);
     expect(isNacosErrorCode("NACOS_ERROR[authFailed]: forbidden", "stalePreview")).toBe(false);
     expect(isNacosErrorCode(new Error("stalePreview"), "stalePreview")).toBe(false);
+  });
+
+  it("formats Nacos history timestamps for display", () => {
+    expect(formatNacosHistoryTime("2026-07-27T18:16:36.000+08:00")).toBe("2026-07-27 18:16:36");
+    expect(formatNacosHistoryTime("2026-07-27T18:16:36Z")).toBe("2026-07-27 18:16:36");
+    expect(formatNacosHistoryTime("2026-07-27 18:16:36")).toBe("2026-07-27 18:16:36");
+    expect(formatNacosHistoryTime("")).toBe("-");
+    expect(formatNacosHistoryTime("not-a-time")).toBe("not-a-time");
   });
 
   it("redirects r-nacos console settings to the compatible OpenAPI endpoint", () => {

--- a/apps/desktop/src/lib/nacos/nacosAdmin.ts
+++ b/apps/desktop/src/lib/nacos/nacosAdmin.ts
@@ -672,6 +672,14 @@ export function buildNacosConfigDeleteConfirm(item: NacosConfigItem, fallbackNam
   return formatNacosConfigIdentity(item, fallbackNamespace);
 }
 
+export function formatNacosHistoryTime(value?: string | null): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return "-";
+  const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/);
+  if (!match) return trimmed;
+  return `${match[1]} ${match[2]}`;
+}
+
 export function buildNacosConfigHistoryRollbackConfirm(item: NacosConfigHistoryItem, fallbackNamespace = ""): string {
   return [`namespace=${item.namespace || fallbackNamespace || "public"}`, `dataId=${item.dataId}`, `group=${item.group || "DEFAULT_GROUP"}`, item.lastModifiedTime ? `historyTime=${item.lastModifiedTime}` : "", item.operator ? `operator=${item.operator}` : ""].filter(Boolean).join("\n");
 }

--- a/apps/desktop/src/lib/nacos/nacosAdmin.ts
+++ b/apps/desktop/src/lib/nacos/nacosAdmin.ts
@@ -675,6 +675,16 @@ export function buildNacosConfigDeleteConfirm(item: NacosConfigItem, fallbackNam
 export function formatNacosHistoryTime(value?: string | null): string {
   const trimmed = value?.trim();
   if (!trimmed) return "-";
+  if (/^0+$/.test(trimmed)) return "-";
+  if (/^\d{10}(?:\d{3})?$/.test(trimmed)) {
+    const timestamp = Number(trimmed);
+    const date = new Date(trimmed.length === 10 ? timestamp * 1_000 : timestamp);
+    if (!Number.isNaN(date.getTime())) {
+      const datePart = [date.getFullYear(), date.getMonth() + 1, date.getDate()].map((part) => String(part).padStart(2, "0")).join("-");
+      const timePart = [date.getHours(), date.getMinutes(), date.getSeconds()].map((part) => String(part).padStart(2, "0")).join(":");
+      return `${datePart} ${timePart}`;
+    }
+  }
   const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/);
   if (!match) return trimmed;
   return `${match[1]} ${match[2]}`;


### PR DESCRIPTION
## 变更说明
- 将 Nacos 配置历史列表和详情中的更新时间显示为 `YYYY-MM-DD HH:mm:ss`
- 保留 hover title 中的原始时间字符串，便于需要时查看完整返回值
- 补充 Nacos 时间格式化 helper 测试，覆盖 ISO 时间、已格式化时间、空值和异常文本

## 验证
- `./node_modules/.bin/oxfmt --check 'apps/desktop/src/**/*.{ts,vue}'`\n- `./node_modules/.bin/oxlint --vue-plugin apps/desktop/src`\n- `./node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json`\n- `pnpm test apps/desktop/src/lib/__tests__/nacos/nacosAdmin.spec.ts`\n- `git diff --check`