### PR TITLE
fix(tree): label Xugu table child groups

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -64,6 +64,7 @@ import { focusSidebarRenameInput } from "@/lib/sidebar/sidebarRenameFocus";
 import { useDragSort } from "@/composables/useDragSort";
 import { sidebarTreeRuntimeKey } from "@/lib/sidebar/sidebarTreeRuntime";
 import { treeNodePinKey } from "@/lib/app/pinnedItems";
+import { isTreeGroupNodeType } from "@/lib/sidebar/treeNodeGroup";
 
 const { t } = useI18n();
 
@@ -226,6 +227,11 @@ function getIconInfo(node: TreeNode): { icon: any; colorClass: string } | null {
       return { icon: Link, colorClass: "text-blue-400" };
     case "group-triggers":
       return { icon: Zap, colorClass: "text-orange-400" };
+    case "group-constraints":
+      return { icon: Key, colorClass: "text-amber-500" };
+    case "group-table-partitions":
+    case "group-table-subpartitions":
+      return { icon: node.isExpanded ? FolderOpen : FolderClosed, colorClass: "text-green-400" };
     case "object-browser":
       return { icon: TableProperties, colorClass: "text-primary" };
     case "user-admin":
@@ -306,25 +312,8 @@ function getIconInfo(node: TreeNode): { icon: any; colorClass: string } | null {
   }
 }
 
-const groupTypes: Set<TreeNodeType> = new Set([
-  "group-columns",
-  "group-indexes",
-  "group-fkeys",
-  "group-triggers",
-  "group-tables",
-  "group-views",
-  "group-materialized-views",
-  "group-procedures",
-  "group-functions",
-  "group-sequences",
-  "group-packages",
-  "group-types",
-  "group-partitions",
-  "group-extensions",
-]);
-
 function isGroupLabel(node: TreeNode): boolean {
-  return groupTypes.has(node.type);
+  return isTreeGroupNodeType(node.type);
 }
 
 function displayLabel(node: TreeNode): string {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -44,7 +44,7 @@ import ProductionContextBadge from "@/components/common/ProductionContextBadge.v
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import LightTooltip from "@/components/ui/LightTooltip.vue";
-import type { ColumnInfo, ConnectionConfig, DatabaseType, TreeNode, TreeNodeType } from "@/types/database";
+import type { ColumnInfo, ConnectionConfig, DatabaseType, TreeNode } from "@/types/database";
 import { alignedCommentLeadingWidth, canTreeNodePin, canTreeNodeShowExpander, sidebarTreeNodeComment, trailingCommentAvailableWidth, trailingCommentGapPx, treeItemPaddingLeft, treeLabelWidthClass, usesFullWidthTreeLabel } from "@/lib/sidebar/sidebarTreeItemLayout";
 import { clearActiveTableReferencePayload, createTableReferencePayload, createTableReferenceDropEvent, setActiveTableReferencePayload, type QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
 import { formatSidebarObjectStorage } from "@/lib/sidebar/sidebarDatabaseStorage";

--- a/apps/desktop/src/lib/__tests__/sidebar/treeNodeGroup.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/treeNodeGroup.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isTreeGroupNodeType } from "@/lib/sidebar/treeNodeGroup";
+
+describe("isTreeGroupNodeType", () => {
+  it("recognizes Xugu table child groups as translated tree groups", () => {
+    expect(isTreeGroupNodeType("group-constraints")).toBe(true);
+    expect(isTreeGroupNodeType("group-table-partitions")).toBe(true);
+    expect(isTreeGroupNodeType("group-table-subpartitions")).toBe(true);
+  });
+
+  it("does not classify Xugu child objects as groups", () => {
+    expect(isTreeGroupNodeType("constraint")).toBe(false);
+    expect(isTreeGroupNodeType("partition")).toBe(false);
+    expect(isTreeGroupNodeType("subpartition")).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/sidebar/treeNodeGroup.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeGroup.ts
@@ -1,0 +1,25 @@
+import type { TreeNodeType } from "@/types/database";
+
+const treeGroupNodeTypes = new Set<TreeNodeType>([
+  "group-columns",
+  "group-indexes",
+  "group-fkeys",
+  "group-triggers",
+  "group-constraints",
+  "group-table-partitions",
+  "group-table-subpartitions",
+  "group-tables",
+  "group-views",
+  "group-materialized-views",
+  "group-procedures",
+  "group-functions",
+  "group-sequences",
+  "group-packages",
+  "group-types",
+  "group-partitions",
+  "group-extensions",
+]);
+
+export function isTreeGroupNodeType(type: TreeNodeType): boolean {
+  return treeGroupNodeTypes.has(type);
+}


### PR DESCRIPTION
## Summary

Fix the sidebar presentation for Xugu table child metadata groups introduced by the table-child metadata feature.

## Problem

The `group-constraints`, `group-table-partitions`, and `group-table-subpartitions` nodes were already created and routed to their metadata loaders, but `TreeItem.vue` did not classify them as group nodes. The sidebar therefore rendered raw i18n keys such as `tree.constraints` and used the default database icon.

## Changes

- Register the three Xugu child node types as tree groups so their existing localized labels are resolved.
- Render the constraint group with the key icon and partition groups with the folder icon.
- Move the group-type classification into a small shared helper and add regression coverage for the new groups and their leaf counterparts.

## Scope

- Frontend presentation only.
- No Xugu agent, metadata SQL, protocol, or DDL changes.
- The affected node types are emitted only for Xugu table child metadata, so other database trees retain their existing behavior.

## Validation

- Added `treeNodeGroup.spec.ts` regression coverage.
- `git diff --check` passed.
- Local `pnpm` test/typecheck/build commands were not run because this isolated worktree has no installed frontend dependencies; CI will run them in the repository dependency environment.

## Change Type

- [x] Bug fix

## Frontend

- [x] This PR changes frontend tree presentation.
- [ ] Screenshot/recording attached. Not available from this isolated worktree because the frontend dependencies are not installed.