### PR TITLE
Fix：修复 SAP HANA 别名字段无法补全

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -37,6 +37,18 @@ function oracleConnection(): ConnectionConfig {
   } as ConnectionConfig;
 }
 
+function sapHanaConnection(): ConnectionConfig {
+  return {
+    ...postgresConnection(),
+    id: "hana-1",
+    name: "SAP HANA",
+    db_type: "saphana",
+    port: 30015,
+    username: "SYSTEM",
+    database: "",
+  } as ConnectionConfig;
+}
+
 function sqlServerConnection(): ConnectionConfig {
   return {
     ...postgresConnection(),
@@ -294,6 +306,45 @@ describe("connectionStore completion assistant", () => {
 
     expect(getColumns.mock.calls.map((call) => call[3])).toEqual(["ORDERS_ALIAS", "orders_alias", "Orders_Alias"]);
     expect(completionAssistantSearch).not.toHaveBeenCalled();
+  });
+
+  it("normalizes unquoted SAP HANA table and schema names before column lookup", async () => {
+    const completionAssistantSearch = vi.fn(async (request: { parent_name?: string | null; parent_schema?: string | null }) => ({
+      candidates: [
+        {
+          name: request.parent_name === "ACDOCA" ? "BELNR" : "MixedColumn",
+          kind: "column",
+          schema: request.parent_schema,
+          parent_schema: request.parent_schema,
+          parent_name: request.parent_name,
+          data_type: "NVARCHAR",
+        },
+      ],
+      incomplete: false,
+      fallback_used: false,
+    }));
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      completionAssistantSearch,
+      getColumns: vi.fn(),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [sapHanaConnection()];
+    store.connectedIds.add("hana-1");
+
+    const unquoted = await store.listCompletionColumns("hana-1", "", "acdoca", "saphanadb", { tableQuoted: false, schemaQuoted: false });
+    const quoted = await store.listCompletionColumns("hana-1", "", "MixedTable", "MixedSchema", { tableQuoted: true, schemaQuoted: true });
+
+    expect(completionAssistantSearch.mock.calls.map(([request]) => ({ schema: request.schema, parent_schema: request.parent_schema, parent_name: request.parent_name }))).toEqual([
+      { schema: "SAPHANADB", parent_schema: "SAPHANADB", parent_name: "ACDOCA" },
+      { schema: "MixedSchema", parent_schema: "MixedSchema", parent_name: "MixedTable" },
+    ]);
+    expect(unquoted).toEqual([expect.objectContaining({ name: "BELNR", table: "ACDOCA", schema: "SAPHANADB" })]);
+    expect(quoted).toEqual([expect.objectContaining({ name: "MixedColumn", table: "MixedTable", schema: "MixedSchema" })]);
   });
 
   it("keeps quoted and unquoted Oracle objects separate in the local column index", async () => {

--- a/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
@@ -174,6 +174,35 @@ describe("queryStore multi-statement errors", () => {
     expect(mocks.executeMulti.mock.calls.map((call) => call[5]?.clientSessionId)).toEqual([tabA, tabA, tabA]);
   });
 
+  it("updates only the executing SAP HANA tab after successful SET SCHEMA statements", async () => {
+    mocks.getConnectionConfig.mockReturnValue({
+      id: "hana-1",
+      name: "SAP HANA",
+      db_type: "saphana",
+      database: "",
+      query_timeout_secs: 30,
+    });
+    mocks.executeMulti
+      .mockResolvedValueOnce([{ columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 }])
+      .mockResolvedValueOnce([{ columns: ["Error"], rows: [["schema missing"]], affected_rows: 0, execution_time_ms: 1, execution_error: true }])
+      .mockResolvedValueOnce([{ columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 }]);
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabA = store.createTab("hana-1", "", "Tab A");
+    const tabB = store.createTab("hana-1", "", "Tab B");
+
+    await store.executeTabSql(tabA, "SET SCHEMA saphanadb");
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "SAPHANADB", completionContextVersion: 1 });
+    expect(store.tabs.find((tab) => tab.id === tabB)?.schema).toBeUndefined();
+
+    await store.executeTabSql(tabA, 'SET SCHEMA "MissingSchema"');
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "SAPHANADB", completionContextVersion: 1 });
+
+    await store.executeTabSql(tabA, '/* switch */ SET SCHEMA "MixedSchema"');
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "MixedSchema", completionContextVersion: 2 });
+    expect(mocks.executeMulti.mock.calls.map((call) => call[5]?.clientSessionId)).toEqual([tabA, tabA, tabA]);
+  });
+
   it("invalidates Oracle completion metadata when clearing a tab schema resets its session", async () => {
     mocks.getConnectionConfig.mockReturnValue({
       id: "oracle-1",

--- a/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   closeQuerySession: vi.fn(),
   ensureConnected: vi.fn(),
   executeMulti: vi.fn(),
+  executeQuery: vi.fn(),
   getConnectionConfig: vi.fn(),
   prepareQueryPaginationExecutionPlan: vi.fn(),
   saveOpenTabsState: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock("@/lib/backend/api", () => ({
   closeClientConnectionSession: mocks.closeClientConnectionSession,
   closeQuerySession: mocks.closeQuerySession,
   executeMulti: mocks.executeMulti,
+  executeQuery: mocks.executeQuery,
   prepareQueryPaginationExecutionPlan: mocks.prepareQueryPaginationExecutionPlan,
   saveOpenTabsState: mocks.saveOpenTabsState,
 }));
@@ -174,7 +176,7 @@ describe("queryStore multi-statement errors", () => {
     expect(mocks.executeMulti.mock.calls.map((call) => call[5]?.clientSessionId)).toEqual([tabA, tabA, tabA]);
   });
 
-  it("updates only the executing SAP HANA tab after successful SET SCHEMA statements", async () => {
+  it("resolves the actual SAP HANA schema from the executing Agent session", async () => {
     mocks.getConnectionConfig.mockReturnValue({
       id: "hana-1",
       name: "SAP HANA",
@@ -186,21 +188,26 @@ describe("queryStore multi-statement errors", () => {
       .mockResolvedValueOnce([{ columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 }])
       .mockResolvedValueOnce([{ columns: ["Error"], rows: [["schema missing"]], affected_rows: 0, execution_time_ms: 1, execution_error: true }])
       .mockResolvedValueOnce([{ columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 }]);
+    mocks.executeQuery.mockResolvedValueOnce({ columns: ["CURRENT_SCHEMA"], rows: [["APP_SCHEMA"]], affected_rows: 0, execution_time_ms: 1 }).mockResolvedValueOnce({ columns: ["CURRENT_SCHEMA"], rows: [["MixedTargetSchema"]], affected_rows: 0, execution_time_ms: 1 });
     const { useQueryStore } = await import("@/stores/queryStore");
     const store = useQueryStore();
     const tabA = store.createTab("hana-1", "", "Tab A");
     const tabB = store.createTab("hana-1", "", "Tab B");
 
-    await store.executeTabSql(tabA, "SET SCHEMA saphanadb");
-    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "SAPHANADB", completionContextVersion: 1 });
+    await store.executeTabSql(tabA, "SET SCHEMA app_schema_synonym");
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "APP_SCHEMA", completionContextVersion: 1 });
     expect(store.tabs.find((tab) => tab.id === tabB)?.schema).toBeUndefined();
 
     await store.executeTabSql(tabA, 'SET SCHEMA "MissingSchema"');
-    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "SAPHANADB", completionContextVersion: 1 });
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "APP_SCHEMA", completionContextVersion: 1 });
 
     await store.executeTabSql(tabA, '/* switch */ SET SCHEMA "MixedSchema"');
-    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "MixedSchema", completionContextVersion: 2 });
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ schema: "MixedTargetSchema", completionContextVersion: 2 });
     expect(mocks.executeMulti.mock.calls.map((call) => call[5]?.clientSessionId)).toEqual([tabA, tabA, tabA]);
+    expect(mocks.executeQuery.mock.calls.map((call) => ({ sql: call[2], schema: call[3], clientSessionId: call[5]?.clientSessionId }))).toEqual([
+      { sql: "SELECT CURRENT_SCHEMA FROM DUMMY", schema: undefined, clientSessionId: tabA },
+      { sql: "SELECT CURRENT_SCHEMA FROM DUMMY", schema: undefined, clientSessionId: tabA },
+    ]);
   });
 
   it("invalidates Oracle completion metadata when clearing a tab schema resets its session", async () => {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -5748,9 +5748,10 @@ export const useConnectionStore = defineStore("connection", () => {
   async function listCompletionColumns(connectionId: string, database: string, table: string, schema?: string, context?: { clientSessionId?: string; version?: number; tableQuoted?: boolean; schemaQuoted?: boolean }, catalog?: string): Promise<SqlCompletionColumn[]> {
     const config = getConfig(connectionId);
     const oracleIdentifier = config?.db_type === "oracle";
-    const completionTable = oracleIdentifier && context?.tableQuoted === false ? table.toUpperCase() : table;
+    const uppercaseUnquotedIdentifier = oracleIdentifier || config?.db_type === "saphana";
+    const completionTable = uppercaseUnquotedIdentifier && context?.tableQuoted === false ? table.toUpperCase() : table;
     const rawCompletionSchema = schema?.trim() || undefined;
-    const completionSchema = oracleIdentifier && rawCompletionSchema && context?.schemaQuoted === false ? rawCompletionSchema.toUpperCase() : rawCompletionSchema;
+    const completionSchema = uppercaseUnquotedIdentifier && rawCompletionSchema && context?.schemaQuoted === false ? rawCompletionSchema.toUpperCase() : rawCompletionSchema;
     const usesOracleCurrentSchema = config?.db_type === "oracle" && !completionSchema;
     if (isSchemaAwareDatabase(connectionId) && !connectionUsesDatabaseObjectTreeMode(config) && !completionSchema && !usesOracleCurrentSchema) {
       return [];

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -229,11 +229,13 @@ function isOracleCurrentSchemaStatement(statement: string | undefined): boolean 
   return /^ALTER\s+SESSION\s+SET\s+CURRENT_SCHEMA\s*=/i.test(sqlStatementWithoutLeadingComments(statement));
 }
 
-function sapHanaSchemaFromStatement(statement: string | undefined): string | undefined {
-  const match = /^SET\s+SCHEMA\s+(?:"((?:[^"]|"")*)"|([A-Za-z_][\w$#]*))\s*;?\s*$/i.exec(sqlStatementWithoutLeadingComments(statement));
-  if (!match) return undefined;
-  if (match[1] != null) return match[1].replace(/""/g, '"');
-  return match[2]?.toUpperCase();
+function isSapHanaSetSchemaStatement(statement: string | undefined): boolean {
+  return /^SET\s+SCHEMA\s+(?:"(?:[^"]|"")*"|[A-Za-z_][\w$#]*)\s*;?\s*$/i.test(sqlStatementWithoutLeadingComments(statement));
+}
+
+function sapHanaCurrentSchemaFromResult(result: QueryResult): string | undefined {
+  const schema = result.rows[0]?.[0];
+  return typeof schema === "string" && schema.trim() ? schema.trim() : undefined;
 }
 
 function annotateQueryResultSource(result: QueryResult, sourceStatement: string, database?: string, databaseType?: DatabaseType, sourceRange?: { from: number; to: number }): QueryResult {
@@ -3700,13 +3702,7 @@ export const useQueryStore = defineStore("query", () => {
       }
       const results = annotateQueryResultSources(markQueryResultsRowsRaw(await withFrontendQueryTimeout(executionPromise, frontendTimeoutSecs, t("editor.queryTimeoutError", { seconds: frontendTimeoutSecs }))), queryBaseSql, sourceLabelDatabase, effectiveDbType, options?.sourceOffset);
       const successfulOracleSchemaChanges = effectiveDbType === "oracle" ? results.filter((result) => result.execution_error !== true && isOracleCurrentSchemaStatement(result.sourceStatement)).length : 0;
-      const successfulSapHanaSchemas =
-        effectiveDbType === "saphana"
-          ? results
-              .filter((result) => result.execution_error !== true)
-              .map((result) => sapHanaSchemaFromStatement(result.sourceStatement))
-              .filter((schema): schema is string => !!schema)
-          : [];
+      const successfulSapHanaSchemaChanges = effectiveDbType === "saphana" ? results.filter((result) => result.execution_error !== true && isSapHanaSetSchemaStatement(result.sourceStatement)).length : 0;
       if (hiddenPrimaryKeys.length > 0 && results.length === 1) {
         const hiddenIndexes = hiddenResultColumnIndexes(results[0]!.columns, hiddenPrimaryKeys);
         if (hiddenIndexes.length > 0) results[0]!.hidden_column_indexes = hiddenIndexes;
@@ -3721,15 +3717,27 @@ export const useQueryStore = defineStore("query", () => {
         columnCounts: results.map((result) => result.columns.length),
         elapsed: elapsed(),
       });
+      let resolvedSapHanaSchema: string | undefined;
+      if (successfulSapHanaSchemaChanges > 0 && tabs.value.find((item) => item.id === id)?.executionId === executionId) {
+        try {
+          const schemaResult = await api.executeQuery(tab.connectionId, executionDatabase, "SELECT CURRENT_SCHEMA FROM DUMMY", undefined, executionId, {
+            clientSessionId: tabClientSessionId(tab),
+            timeoutSecs: queryTimeoutSecs,
+          });
+          resolvedSapHanaSchema = sapHanaCurrentSchemaFromResult(schemaResult);
+        } catch (error) {
+          console.warn("[DBX] Failed to resolve SAP HANA CURRENT_SCHEMA", error);
+        }
+      }
       const current = tabs.value.find((t) => t.id === id);
       if (current?.executionId === executionId) {
         if (openInNewResultTab && current.isCancelling && restorePendingResultRun(current, executionId)) return false;
         if (successfulOracleSchemaChanges > 0) {
           current.completionContextVersion = (current.completionContextVersion ?? 0) + successfulOracleSchemaChanges;
         }
-        if (successfulSapHanaSchemas.length > 0) {
-          current.schema = successfulSapHanaSchemas[successfulSapHanaSchemas.length - 1];
-          current.completionContextVersion = (current.completionContextVersion ?? 0) + successfulSapHanaSchemas.length;
+        if (resolvedSapHanaSchema) {
+          current.schema = resolvedSapHanaSchema;
+          current.completionContextVersion = (current.completionContextVersion ?? 0) + successfulSapHanaSchemaChanges;
         }
         const activeGroupIndex = current.activeResultIndex;
         const activeGroupResults = current.results;

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -206,7 +206,7 @@ function annotateQueryResultSources(results: QueryResult[], sql: string, databas
   return results;
 }
 
-function isOracleCurrentSchemaStatement(statement: string | undefined): boolean {
+function sqlStatementWithoutLeadingComments(statement: string | undefined): string {
   let remaining = statement?.trimStart() ?? "";
   while (remaining) {
     if (remaining.startsWith("--")) {
@@ -216,13 +216,24 @@ function isOracleCurrentSchemaStatement(statement: string | undefined): boolean 
     }
     if (remaining.startsWith("/*")) {
       const end = remaining.indexOf("*/", 2);
-      if (end < 0) return false;
+      if (end < 0) return "";
       remaining = remaining.slice(end + 2).trimStart();
       continue;
     }
     break;
   }
-  return /^ALTER\s+SESSION\s+SET\s+CURRENT_SCHEMA\s*=/i.test(remaining);
+  return remaining;
+}
+
+function isOracleCurrentSchemaStatement(statement: string | undefined): boolean {
+  return /^ALTER\s+SESSION\s+SET\s+CURRENT_SCHEMA\s*=/i.test(sqlStatementWithoutLeadingComments(statement));
+}
+
+function sapHanaSchemaFromStatement(statement: string | undefined): string | undefined {
+  const match = /^SET\s+SCHEMA\s+(?:"((?:[^"]|"")*)"|([A-Za-z_][\w$#]*))\s*;?\s*$/i.exec(sqlStatementWithoutLeadingComments(statement));
+  if (!match) return undefined;
+  if (match[1] != null) return match[1].replace(/""/g, '"');
+  return match[2]?.toUpperCase();
 }
 
 function annotateQueryResultSource(result: QueryResult, sourceStatement: string, database?: string, databaseType?: DatabaseType, sourceRange?: { from: number; to: number }): QueryResult {
@@ -3689,6 +3700,13 @@ export const useQueryStore = defineStore("query", () => {
       }
       const results = annotateQueryResultSources(markQueryResultsRowsRaw(await withFrontendQueryTimeout(executionPromise, frontendTimeoutSecs, t("editor.queryTimeoutError", { seconds: frontendTimeoutSecs }))), queryBaseSql, sourceLabelDatabase, effectiveDbType, options?.sourceOffset);
       const successfulOracleSchemaChanges = effectiveDbType === "oracle" ? results.filter((result) => result.execution_error !== true && isOracleCurrentSchemaStatement(result.sourceStatement)).length : 0;
+      const successfulSapHanaSchemas =
+        effectiveDbType === "saphana"
+          ? results
+              .filter((result) => result.execution_error !== true)
+              .map((result) => sapHanaSchemaFromStatement(result.sourceStatement))
+              .filter((schema): schema is string => !!schema)
+          : [];
       if (hiddenPrimaryKeys.length > 0 && results.length === 1) {
         const hiddenIndexes = hiddenResultColumnIndexes(results[0]!.columns, hiddenPrimaryKeys);
         if (hiddenIndexes.length > 0) results[0]!.hidden_column_indexes = hiddenIndexes;
@@ -3708,6 +3726,10 @@ export const useQueryStore = defineStore("query", () => {
         if (openInNewResultTab && current.isCancelling && restorePendingResultRun(current, executionId)) return false;
         if (successfulOracleSchemaChanges > 0) {
           current.completionContextVersion = (current.completionContextVersion ?? 0) + successfulOracleSchemaChanges;
+        }
+        if (successfulSapHanaSchemas.length > 0) {
+          current.schema = successfulSapHanaSchemas[successfulSapHanaSchemas.length - 1];
+          current.completionContextVersion = (current.completionContextVersion ?? 0) + successfulSapHanaSchemas.length;
         }
         const activeGroupIndex = current.activeResultIndex;
         const activeGroupResults = current.results;


### PR DESCRIPTION
## 问题

SAP HANA 查询中先执行 SET SCHEMA saphanadb，再输入类似以下 SQL 时，ac. 后没有字段补全：

```sql
SELECT * FROM acdoca AS ac
WHERE ac.
```

代码排查确认有三个原因：

- DBX 仅跟踪 Oracle 的会话 schema 变更，HANA 成功执行 SET SCHEMA 后没有同步查询标签的 schema，字段补全会因缺少 schema 直接返回空结果。
- HANA 未使用双引号的标识符应按大写查询 JDBC 元数据，但此前仅对 Oracle 做了大写归一化，acdoca 无法正确查询到 ACDOCA 的字段。
- SET SCHEMA 可以接收 schema synonym，SQL 中输入的名称不一定等于执行后的实际 CURRENT_SCHEMA。

## 修复

- HANA SET SCHEMA 成功后，通过同一查询标签的 Agent session 执行 SELECT CURRENT_SCHEMA FROM DUMMY，使用数据库返回的实际 schema 更新当前标签。
- 读取 CURRENT_SCHEMA 时不传旧 schema 执行上下文，避免探测前将会话切回旧 schema。
- 执行失败的 SET SCHEMA、CURRENT_SCHEMA 探测失败或已过期的标签执行均不更新 schema，也不影响其他查询标签。
- HANA 未引用的 schema 和表名按大写查询元数据，双引号标识符保持原始大小写。

## 验证

本次没有可用的真实 SAP HANA 测试环境，未进行真实数据库验证。验证范围为代码层面定位、模拟同一 Agent session 的元数据响应和自动化测试：

- 针对性测试：3 个测试文件、51 项测试全部通过。
- 覆盖成功/失败的 SET SCHEMA、标签隔离、schema synonym 返回实际目标 schema、同一 clientSessionId、探测时不传旧 schema、未引用标识符大写归一化和双引号大小写保留。
- pnpm check：format、lint、typecheck、test 全部通过。