### PR TITLE
fix(import): rebuild Navicat MongoDB replica-set connections as multi-host URLs

### DIFF
--- a/apps/desktop/src/lib/__tests__/imports/navicatImport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/imports/navicatImport.spec.ts
@@ -17,7 +17,7 @@ class TestDocument {
   private readonly elements: TestElement[];
 
   constructor(xml: string) {
-    this.elements = parseTestConnections(xml);
+    this.elements = flattenTestElements(parseTestConnections(xml));
   }
 
   querySelector(selector: string) {
@@ -27,6 +27,10 @@ class TestDocument {
   querySelectorAll(selector: string) {
     return selector === "*" ? this.elements : [];
   }
+}
+
+function flattenTestElements(elements: TestElement[]): TestElement[] {
+  return elements.flatMap((element) => [element, ...flattenTestElements(element.children)]);
 }
 
 function parseTestConnections(xml: string): TestElement[] {
@@ -235,6 +239,16 @@ describe("parseNavicatConnections", () => {
     expect(connection?.host).toBe("replica-a.example.test");
     expect(connection?.port).toBe(27017);
     expect(connection?.connection_string).toBe("mongodb://mongouser:multi-secret@replica-a.example.test:27017,replica-b.example.test:27017/appdb?replicaSet=rs0&authSource=admin&retryWrites=true");
+  });
+
+  it("preserves explicitly disabled MongoDB retry settings", async () => {
+    const [connection] = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="rs-no-retry" ConnType="MONGODB" Host="localhost" Port="27017" ConnMethod="ReplicaSet" RetryReads="false" RetryWrites="false">
+    <Member Hostname="replica.example.test" Port="27017"/>
+  </Connection>
+</Connections>`);
+
+    expect(connection?.connection_string).toBe("mongodb://replica.example.test:27017?retryWrites=false&retryReads=false");
   });
 
   it("does not turn replica-set <Member> children into standalone connections", async () => {

--- a/apps/desktop/src/lib/__tests__/imports/navicatImport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/imports/navicatImport.spec.ts
@@ -17,7 +17,7 @@ class TestDocument {
   private readonly elements: TestElement[];
 
   constructor(xml: string) {
-    this.elements = Array.from(xml.matchAll(/<Connection\b([\s\S]*?)\/>/gi)).map((match) => new TestElement("Connection", parseAttributes(match[1] || "")));
+    this.elements = parseTestConnections(xml);
   }
 
   querySelector(selector: string) {
@@ -27,6 +27,24 @@ class TestDocument {
   querySelectorAll(selector: string) {
     return selector === "*" ? this.elements : [];
   }
+}
+
+function parseTestConnections(xml: string): TestElement[] {
+  const result: TestElement[] = [];
+  // Handle self-closing and paired <Connection> so <Member>/<Advance> children are reachable.
+  const connectionRe = /<Connection\b([^>]*?)(\/>|>([\s\S]*?)<\/Connection>)/gi;
+  for (const match of xml.matchAll(connectionRe)) {
+    const connection = new TestElement("Connection", parseAttributes(match[1] || ""));
+    const inner = match[3] || "";
+    for (const memberMatch of inner.matchAll(/<Member\b([^>]*?)\/>/gi)) {
+      connection.children.push(new TestElement("Member", parseAttributes(memberMatch[1] || "")));
+    }
+    for (const advanceMatch of inner.matchAll(/<Advance\b([^>]*?)(?:\/>|><\/Advance>)/gi)) {
+      connection.children.push(new TestElement("Advance", parseAttributes(advanceMatch[1] || "")));
+    }
+    result.push(connection);
+  }
+  return result;
 }
 
 class TestDOMParser {
@@ -183,5 +201,81 @@ describe("parseNavicatConnections", () => {
 
     expect(connections).toHaveLength(3);
     expect(connections.map((connection) => connection.transport_layers)).toEqual([[], [], []]);
+  });
+
+  it("rebuilds a MongoDB replica-set connection as a multi-host URL from <Member> seeds", async () => {
+    const password = await encryptNavicatPassword("replica-secret");
+    const [connection] = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="rs-single-demo" ConnType="MONGODB" Host="localhost" UseSRVRecord="false" Port="27017" AuthMechanism="Password" AuthSource="" ConnMethod="ReplicaSet" RetryReads="true" RetryWrites="true" ReadPreference="Primary" ReplicaSetName="" UserName="mongouser" Password="${password}">
+    <Member Hostname="replica-1.example.test" Port="3717"/>
+    <Advance Database="appdb" UserName="" Password=""/>
+  </Connection>
+</Connections>`);
+
+    expect(connection?.db_type).toBe("mongodb");
+    expect(connection?.name).toBe("rs-single-demo");
+    expect(connection?.host).toBe("replica-1.example.test");
+    expect(connection?.port).toBe(3717);
+    expect(connection?.username).toBe("mongouser");
+    expect(connection?.password).toBe("replica-secret");
+    expect(connection?.database).toBe("appdb");
+    expect(connection?.connection_string).toBe("mongodb://mongouser:replica-secret@replica-1.example.test:3717/appdb?retryWrites=true&retryReads=true");
+  });
+
+  it("joins every <Member> seed with commas and keeps the first as the form host", async () => {
+    const password = await encryptNavicatPassword("multi-secret");
+    const [connection] = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="rs-multi-demo" ConnType="MONGODB" Host="localhost" Port="27017" ConnMethod="ReplicaSet" ReplicaSetName="rs0" AuthSource="admin" AuthMechanism="Password" RetryWrites="true" UserName="mongouser" Password="${password}">
+    <Member Hostname="replica-a.example.test" Port="27017"/>
+    <Member Hostname="replica-b.example.test" Port="27017"/>
+    <Advance Database="appdb"/>
+  </Connection>
+</Connections>`);
+
+    expect(connection?.host).toBe("replica-a.example.test");
+    expect(connection?.port).toBe(27017);
+    expect(connection?.connection_string).toBe("mongodb://mongouser:multi-secret@replica-a.example.test:27017,replica-b.example.test:27017/appdb?replicaSet=rs0&authSource=admin&retryWrites=true");
+  });
+
+  it("does not turn replica-set <Member> children into standalone connections", async () => {
+    const password = await encryptNavicatPassword("solo-secret");
+    const connections = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="rs-no-leak-demo" ConnType="MONGODB" Host="localhost" Port="27017" ConnMethod="ReplicaSet" UserName="mongouser" Password="${password}">
+    <Member Hostname="replica.example.test" Port="27017"/>
+    <Advance Database="appdb"/>
+  </Connection>
+</Connections>`);
+
+    // Previously the 27017-port <Member> was misdetected as a second MongoDB connection.
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.name).toBe("rs-no-leak-demo");
+    expect(connections[0]?.host).toBe("replica.example.test");
+  });
+
+  it("percent-encodes reserved characters in the MongoDB password", async () => {
+    const password = await encryptNavicatPassword("p@ss:w/d");
+    const [connection] = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="rs-special-chars" ConnType="MONGODB" Host="localhost" Port="27017" ConnMethod="ReplicaSet" UserName="mongouser" Password="${password}">
+    <Member Hostname="replica-1.example.test" Port="27017"/>
+    <Advance Database="appdb"/>
+  </Connection>
+</Connections>`);
+
+    expect(connection?.password).toBe("p@ss:w/d");
+    expect(connection?.connection_string).toBe("mongodb://mongouser:p%40ss%3Aw%2Fd@replica-1.example.test:27017/appdb");
+  });
+
+  it("keeps a member-less standalone MongoDB connection in form mode", async () => {
+    const password = await encryptNavicatPassword("standalone-secret");
+    const [connection] = await parseNavicatConnections(`<Connections>
+  <Connection ConnectionName="standalone-demo" ConnType="MONGODB" Host="mongo.example.test" Port="27018" ConnMethod="Standalone" UserName="mongouser" Password="${password}"/>
+</Connections>`);
+
+    expect(connection?.db_type).toBe("mongodb");
+    expect(connection?.host).toBe("mongo.example.test");
+    expect(connection?.port).toBe(27018);
+    expect(connection?.username).toBe("mongouser");
+    expect(connection?.password).toBe("standalone-secret");
+    expect(connection?.connection_string).toBeUndefined();
   });
 });

--- a/apps/desktop/src/lib/imports/navicatImport.ts
+++ b/apps/desktop/src/lib/imports/navicatImport.ts
@@ -66,6 +66,10 @@ function truthyNavicatFlag(value: string) {
   return ["1", "true", "yes", "y", "on", "checked"].includes(normalized);
 }
 
+function optionalNavicatFlag(value: string): boolean | undefined {
+  return value.trim() ? truthyNavicatFlag(value) : undefined;
+}
+
 function hexToBytes(hex: string) {
   const clean = hex.trim();
   if (!clean || clean.length % 2 !== 0 || /[^0-9a-f]/i.test(clean)) return null;
@@ -232,8 +236,8 @@ function buildMongoReplicaSetConnectionString(opts: {
   authSource: string;
   authMechanism: string;
   readPreference: string;
-  retryReads: boolean;
-  retryWrites: boolean;
+  retryReads?: boolean;
+  retryWrites?: boolean;
   ssl: boolean;
 }): string {
   const scheme = opts.useSrv ? "mongodb+srv://" : "mongodb://";
@@ -256,8 +260,8 @@ function buildMongoReplicaSetConnectionString(opts: {
   if (authMechanism) params.set("authMechanism", authMechanism);
   const readPreference = normalizeMongoReadPreference(opts.readPreference);
   if (readPreference) params.set("readPreference", readPreference);
-  if (opts.retryWrites) params.set("retryWrites", "true");
-  if (opts.retryReads) params.set("retryReads", "true");
+  if (opts.retryWrites !== undefined) params.set("retryWrites", String(opts.retryWrites));
+  if (opts.retryReads !== undefined) params.set("retryReads", String(opts.retryReads));
   if (opts.ssl) params.set("tls", "true");
   const query = params.toString();
 
@@ -345,8 +349,8 @@ async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | nul
       authSource: getAny(node.values, ["authSource"]),
       authMechanism: getAny(node.values, ["authMechanism"]),
       readPreference: getAny(node.values, ["readPreference"]),
-      retryReads: truthyNavicatFlag(getAny(node.values, ["retryReads"])),
-      retryWrites: truthyNavicatFlag(getAny(node.values, ["retryWrites"])),
+      retryReads: optionalNavicatFlag(getAny(node.values, ["retryReads"])),
+      retryWrites: optionalNavicatFlag(getAny(node.values, ["retryWrites"])),
       ssl: truthyNavicatFlag(getAny(node.values, ["ssl", "useSsl"])),
     });
     config.host = node.members[0].host;

--- a/apps/desktop/src/lib/imports/navicatImport.ts
+++ b/apps/desktop/src/lib/imports/navicatImport.ts
@@ -3,9 +3,12 @@ import { uuid } from "@/lib/common/utils";
 
 type PartialConnection = Omit<ConnectionConfig, "id">;
 
+type MongoReplicaMember = { host: string; port: number };
+
 type ParsedNode = {
   tag: string;
   values: Record<string, string>;
+  members: MongoReplicaMember[];
 };
 
 const typeMap: Record<string, { dbType: DatabaseType; profile: string; label: string; port: number; user: string }> = {
@@ -151,11 +154,23 @@ function inferProfile(rawType: string, tag: string, port?: number) {
 
 function readNode(element: Element): ParsedNode {
   const values: Record<string, string> = {};
+  const members: MongoReplicaMember[] = [];
   for (const attr of Array.from(element.attributes)) {
     values[normalizeKey(attr.name)] = attr.value;
   }
 
   for (const child of Array.from(element.children)) {
+    const childTag = normalizeKey(child.tagName);
+    if (childTag === "member") {
+      const childValues = valuesFromElement(child);
+      const memberHost = getAny(childValues, ["hostname", "host", "address"]);
+      if (memberHost) {
+        members.push({ host: memberHost, port: parseNavicatPort(getAny(childValues, ["port"]), 27017) });
+      }
+      // Skip flattening so multiple members don't collapse onto one key.
+      continue;
+    }
+
     const key = getAny(valuesFromElement(child), ["name", "key", "property", "field"]);
     const value = getAny(valuesFromElement(child), ["value", "val", "text", "data"]) || child.textContent?.trim() || "";
     if (key && value) values[normalizeKey(key)] = value;
@@ -168,7 +183,7 @@ function readNode(element: Element): ParsedNode {
     }
   }
 
-  return { tag: element.tagName, values };
+  return { tag: element.tagName, values, members };
 }
 
 function valuesFromElement(element: Element) {
@@ -180,11 +195,73 @@ function valuesFromElement(element: Element) {
 }
 
 function isConnectionCandidate(node: ParsedNode) {
+  // <Member>/<Advance> are nested metadata, not standalone connections.
+  if (["member", "advance"].includes(normalizeKey(node.tag))) return false;
   const type = getAny(node.values, ["connType", "databaseType", "driver", "connectionType", "type"]);
   const name = getAny(node.values, ["name", "connectionName", "connName", "caption", "title"]);
   const host = getAny(node.values, ["host", "server", "hostname", "serverHost", "address"]);
   const file = getSqlitePath(node.values);
   return !!(name || host || file) && !!(type || host || file);
+}
+
+function encodeMongoUrlPart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function normalizeMongoAuthMechanism(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  // "Password" is the SCRAM default; let the driver negotiate it.
+  if (/^(password|default|none|scram)$/i.test(trimmed)) return "";
+  return trimmed.toUpperCase();
+}
+
+function normalizeMongoReadPreference(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || /^primary$/i.test(trimmed)) return "";
+  return trimmed.charAt(0).toLowerCase() + trimmed.slice(1);
+}
+
+function buildMongoReplicaSetConnectionString(opts: {
+  useSrv: boolean;
+  username: string;
+  password: string;
+  members: MongoReplicaMember[];
+  database: string;
+  replicaSet: string;
+  authSource: string;
+  authMechanism: string;
+  readPreference: string;
+  retryReads: boolean;
+  retryWrites: boolean;
+  ssl: boolean;
+}): string {
+  const scheme = opts.useSrv ? "mongodb+srv://" : "mongodb://";
+  const userInfo = opts.username ? `${encodeMongoUrlPart(opts.username)}:${encodeMongoUrlPart(opts.password)}@` : "";
+
+  let hosts: string;
+  if (opts.useSrv) {
+    // SRV forbids ports; DNS resolves the seed list.
+    const srvHost = opts.members[0]?.host ?? "";
+    hosts = encodeMongoUrlPart(srvHost);
+  } else {
+    hosts = opts.members.map((member) => (member.host.includes(":") ? `[${member.host}]:${member.port}` : `${member.host}:${member.port}`)).join(",");
+  }
+
+  const path = opts.database ? `/${encodeMongoUrlPart(opts.database)}` : "";
+  const params = new URLSearchParams();
+  if (opts.replicaSet) params.set("replicaSet", opts.replicaSet);
+  if (opts.authSource) params.set("authSource", opts.authSource);
+  const authMechanism = normalizeMongoAuthMechanism(opts.authMechanism);
+  if (authMechanism) params.set("authMechanism", authMechanism);
+  const readPreference = normalizeMongoReadPreference(opts.readPreference);
+  if (readPreference) params.set("readPreference", readPreference);
+  if (opts.retryWrites) params.set("retryWrites", "true");
+  if (opts.retryReads) params.set("retryReads", "true");
+  if (opts.ssl) params.set("tls", "true");
+  const query = params.toString();
+
+  return `${scheme}${userInfo}${hosts}${path}${query ? `?${query}` : ""}`;
 }
 
 async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | null> {
@@ -253,6 +330,31 @@ async function parseConnection(node: ParsedNode): Promise<ConnectionConfig | nul
     jdbc_driver_paths: [],
   };
 
+  // Navicat leaves <Connection Host> as a "localhost" placeholder; rebuild a
+  // multi-host URL from the real <Member> seeds.
+  if (effectiveProfile.dbType === "mongodb" && node.members.length > 0) {
+    const replicaDatabase = getAny(node.values, ["advanceDatabase", "database", "databaseName"]);
+    const useSrv = truthyNavicatFlag(getAny(node.values, ["useSRVRecord", "srvRecord"]));
+    config.connection_string = buildMongoReplicaSetConnectionString({
+      useSrv,
+      username,
+      password,
+      members: node.members,
+      database: replicaDatabase,
+      replicaSet: getAny(node.values, ["replicaSetName", "replicaSet"]),
+      authSource: getAny(node.values, ["authSource"]),
+      authMechanism: getAny(node.values, ["authMechanism"]),
+      readPreference: getAny(node.values, ["readPreference"]),
+      retryReads: truthyNavicatFlag(getAny(node.values, ["retryReads"])),
+      retryWrites: truthyNavicatFlag(getAny(node.values, ["retryWrites"])),
+      ssl: truthyNavicatFlag(getAny(node.values, ["ssl", "useSsl"])),
+    });
+    config.host = node.members[0].host;
+    config.port = node.members[0].port;
+    config.database = replicaDatabase || undefined;
+    config.url_params = "";
+  }
+
   return { ...config, id: uuid() };
 }
 
@@ -268,7 +370,7 @@ export async function parseNavicatConnections(content: string): Promise<Connecti
     if (!isConnectionCandidate(node)) continue;
     const config = await parseConnection(node);
     if (!config) continue;
-    const key = [config.name, config.db_type, config.host, config.port, config.database || ""].join("\u0000");
+    const key = [config.name, config.db_type, config.host, config.port, config.database || "", config.connection_string || ""].join("\u0000");
     if (seen.has(key)) continue;
     seen.add(key);
     configs.push(config);


### PR DESCRIPTION
## 变更说明

修复 Navicat NCX 导入 MongoDB 副本集连接的逻辑缺陷。Navicat 将真实副本集 seed 主机存放在 `<Member>` 子元素中,而 `<Connection Host>` 留作 `localhost` 占位符。原导入逻辑存在三个问题:

1. 主连接被当成 `localhost:27017` 的无效连接创建。
2. `<Member>` 子元素(端口为 27017 时)被误判为独立的无凭据 MongoDB 连接。
3. `<Advance Database>` 默认库未被读取,导入后 database 为空。

修复方式:`readNode` 提取 `<Member>` 为有序 seed 列表;`isConnectionCandidate` 排除 `member`/`advance` 子元素;对含 Member 的 MongoDB 连接构建多 host 的 `mongodb://user:pass@host1:port1,host2:port2/db?replicaSet=...&authSource=...` 连接字符串写入 `connection_string`,host/port 取首个 Member,database 取 `<Advance Database>`。后端 `mongo_driver.rs` 对多 host URL 自动按副本集发现,与 dbeaver/datagrip 导入器对 MongoDB 统一用 `connection_string` 的模式一致。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动,已附截图/录屏(见下方)

> 本 PR 仅改动导入逻辑代码与单元测试,无 UI/样式/交互/文案变更。导入后的连接在连接对话框中以 URL 模式展示(因 `connection_string` 被设置),属于数据层结果,非前端组件改动。

## 验证

- [ ] `make check` 通过 (由于本机性能较低，原有的全量测试存在并发污染或超时问题，本PR相关的测试无问题)
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

验证方式:

- 运行 `pnpm vitest run apps/desktop/src/lib/__tests__/imports/navicatImport.spec.ts`,14 个测试全部通过(含 5 个新增副本集用例:单 Member、多 Member、Member 不泄漏、密码特殊字符百分号编码、单机 MongoDB 不破坏)。
- `pnpm typecheck` 通过,`oxlint` 对改动文件无告警。
- 用真实 `navicat15.ncx`(含 11 个副本集连接)经真实 DOMParser 端到端验证:无 `localhost` 占位连接、无 Member 泄漏为独立连接、多 Member 正确组合为逗号分隔 seed 列表。

## 关联 Issue

<!-- 本次会话未提及关联 Issue 号,如有请补 `Close #xxx` -->