### PR TITLE
✨feat(mysql): 添加对字符集和排序规则的支持

### DIFF
--- a/crates/dbx-core/src/table_structure_sql/create_table.rs
+++ b/crates/dbx-core/src/table_structure_sql/create_table.rs
@@ -1,5 +1,6 @@
 use super::column_format::{
     column_data_type, column_extra_clause, has_dameng_identity, is_dameng_identity_compatible_type,
+    is_mysql_character_data_type,
 };
 use super::comments::{build_sqlserver_column_comment_sql, build_sqlserver_table_comment_sql};
 use super::dialect::{capabilities_for, database_label, StructureDialect};
@@ -48,6 +49,14 @@ pub fn build_create_table_sql(mut options: TableStructureSqlOptions) -> TableStr
     for column in &active_columns {
         let data_type = column_data_type(dialect, column);
         let mut parts = vec![quote_ident(dialect, &column.name), data_type];
+        if dialect == StructureDialect::Mysql && is_mysql_character_data_type(&column.data_type) {
+            if !column.character_set.trim().is_empty() {
+                parts.push(format!("CHARACTER SET {}", quote_ident(dialect, &column.character_set)));
+            }
+            if !column.collation.trim().is_empty() {
+                parts.push(format!("COLLATE {}", quote_ident(dialect, &column.collation)));
+            }
+        }
         if !column.is_nullable
             && !column.is_primary_key
             && !matches!(dialect, StructureDialect::ClickHouse | StructureDialect::ManticoreSearch)

--- a/crates/dbx-core/src/table_structure_sql/create_table.rs
+++ b/crates/dbx-core/src/table_structure_sql/create_table.rs
@@ -10,6 +10,7 @@ use super::triggers::build_trigger_sql;
 use super::types::{TableStructureSqlOptions, TableStructureSqlResult};
 use super::util::{clean, format_default_for_sql, normalize_default, qualified_table, quote_ident, quote_string};
 use super::validation::{validate_columns, validate_dameng_identity};
+use crate::models::connection::DatabaseType;
 
 pub fn build_create_table_sql(mut options: TableStructureSqlOptions) -> TableStructureSqlResult {
     options.table_name = clean(&options.table_name);
@@ -49,7 +50,7 @@ pub fn build_create_table_sql(mut options: TableStructureSqlOptions) -> TableStr
     for column in &active_columns {
         let data_type = column_data_type(dialect, column);
         let mut parts = vec![quote_ident(dialect, &column.name), data_type];
-        if dialect == StructureDialect::Mysql && is_mysql_character_data_type(&column.data_type) {
+        if options.database_type == Some(DatabaseType::Mysql) && is_mysql_character_data_type(&column.data_type) {
             if !column.character_set.trim().is_empty() {
                 parts.push(format!("CHARACTER SET {}", quote_ident(dialect, &column.character_set)));
             }

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -2786,6 +2786,32 @@ fn mysql_create_table_keeps_column_charset_collation_and_comment() {
 }
 
 #[test]
+fn mysql_compatible_databases_do_not_emit_mysql_column_charset_clauses() {
+    for database_type in [DatabaseType::StarRocks, DatabaseType::Databend, DatabaseType::Gbase] {
+        let mut name = column("name");
+        name.data_type = "varchar(255)".to_string();
+        name.character_set = "utf8mb4".to_string();
+        name.collation = "utf8mb4_bin".to_string();
+
+        let result = build_create_table_sql(TableStructureSqlOptions {
+            database_type: Some(database_type),
+            schema: None,
+            table_name: "users".to_string(),
+            columns: vec![name],
+            indexes: Vec::new(),
+            foreign_keys: Vec::new(),
+            triggers: Vec::new(),
+            table_comment: None,
+            original_table_comment: None,
+        });
+
+        assert_eq!(result.warnings, Vec::<String>::new());
+        assert!(!result.statements[0].contains("CHARACTER SET"));
+        assert!(!result.statements[0].contains("COLLATE"));
+    }
+}
+
+#[test]
 fn mysql_create_table_with_on_update_current_timestamp() {
     let mut col = column("updated_at");
     col.data_type = "timestamp".to_string();

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -2757,6 +2757,35 @@ fn mysql_create_table_with_auto_increment() {
 }
 
 #[test]
+fn mysql_create_table_keeps_column_charset_collation_and_comment() {
+    let mut name = column("name");
+    name.data_type = "varchar(255)".to_string();
+    name.character_set = "gbk".to_string();
+    name.collation = "gbk_bin".to_string();
+    name.comment = "测试".to_string();
+
+    let result = build_create_table_sql(TableStructureSqlOptions {
+        database_type: Some(DatabaseType::Mysql),
+        schema: None,
+        table_name: "users".to_string(),
+        columns: vec![name],
+        indexes: Vec::new(),
+        foreign_keys: Vec::new(),
+        triggers: Vec::new(),
+        table_comment: Some("User accounts".to_string()),
+        original_table_comment: None,
+    });
+
+    assert_eq!(result.warnings, Vec::<String>::new());
+    assert_eq!(
+        result.statements,
+        vec![
+            "CREATE TABLE `users` (\n  `name` varchar(255) CHARACTER SET `gbk` COLLATE `gbk_bin` COMMENT '测试'\n) COMMENT = 'User accounts';"
+        ]
+    );
+}
+
+#[test]
 fn mysql_create_table_with_on_update_current_timestamp() {
     let mut col = column("updated_at");
     col.data_type = "timestamp".to_string();


### PR DESCRIPTION
- 在创建表时，支持指定列的字符集和排序规则
- 添加相应的单元测试以验证功能

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

同样的建表表单。

原来：

<img width="1482" height="500" alt="image" src="https://github.com/user-attachments/assets/a2d0b601-950e-4d2b-a649-382cf59d3d3c" />

现在：

<img width="1532" height="490" alt="image" src="https://github.com/user-attachments/assets/1118d767-8fe8-4f76-83ae-33b04d5dbff3" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #4710