### PR TITLE
fix(editor): 优先展示 SQL 补全字段名

### DIFF
--- a/apps/desktop/src/lib/__tests__/editorThemes.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editorThemes.spec.ts
@@ -51,4 +51,11 @@ describe("SQL completion theme", () => {
     expect(rules[".cm-tooltip.cm-tooltip-autocomplete"]).toMatchObject({ borderRadius: "var(--dbx-radius-md)" });
     expect(rules[".cm-tooltip.cm-tooltip-autocomplete > ul > li"]).toMatchObject({ borderRadius: "var(--dbx-radius-sm)" });
   });
+
+  it("keeps completion labels ahead of long detail text", () => {
+    const rules = buildSqlCompletionThemeRules();
+
+    expect(rules[".cm-completionLabel"]).toMatchObject({ flex: "0 1 auto" });
+    expect(rules[".cm-completionDetail"]).toMatchObject({ flex: "1 1 0", minWidth: "0", textOverflow: "ellipsis" });
+  });
 });

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -995,7 +995,7 @@ export function buildSqlCompletionThemeRules(): CodeMirrorStyleSpec {
       fontSize: `clamp(11px, calc(var(${EDITOR_FONT_SIZE_CSS_VAR}, 13px) - 1px), 13px)`,
       fontWeight: "500",
       fontStyle: "normal",
-      flex: "1 1 auto",
+      flex: "1 1 0",
       marginLeft: "10px",
       minWidth: "0",
       opacity: "1",


### PR DESCRIPTION
## 问题

通过表别名触发字段补全时，补全详情使用内容宽度参与 flex 收缩。字段注释较长时，字段名和详情会同时被压缩，导致字段名提前省略。

## 修复

- 将补全详情的 flex 基准宽度调整为 `0`，优先保留字段名的自然宽度
- 详情仅使用剩余空间并继续以省略号截断，字段名自身超过弹窗宽度时仍可正常省略
- 增加主题规则回归测试，固定字段名与详情的宽度优先级

## 验证

- 在 DBX Dev PostgreSQL 16 创建带长注释字段，通过 `c.` 真实触发别名字段补全
- 修复前字段名从约 `368px` 被压缩到约 `182px`；修复后恢复完整 `368px`，长详情在剩余约 `332px` 内省略
- `pnpm check`（format、lint、typecheck、全部 Vitest）通过

Fixes #4696