### PR TITLE
Fix：避免全列查询等待元数据

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
@@ -131,6 +131,44 @@ describe("queryStore hidden primary key editing", () => {
     expect(tab.queryEditabilityReason).toBeUndefined();
   });
 
+  it("starts a qualified MySQL star query before slow column metadata finishes", async () => {
+    const columnsGate = deferred<Awaited<ReturnType<typeof getColumns>>>();
+    getColumns.mockReturnValue(columnsGate.promise);
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "sys_dept",
+        selectStar: true,
+        columns: [],
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["dept_id", "dept_name"],
+        rows: [[1, "Headquarters"]],
+        affected_rows: 0,
+        execution_time_ms: 12,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    const execution = store.executeTabSql(tabId, "SELECT sys_dept.* FROM sys_dept");
+    await vi.waitFor(() => expect(executeMulti).toHaveBeenCalled());
+    expect(executeMulti).toHaveBeenCalledWith("mysql-1", "app", "SELECT sys_dept.* FROM sys_dept", undefined, expect.any(String), expect.objectContaining({ timeoutSecs: 30 }));
+
+    columnsGate.resolve([
+      { name: "dept_id", data_type: "bigint", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+      { name: "dept_name", data_type: "varchar", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+    ]);
+    await execution;
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.tableMeta?.tableName).toBe("sys_dept"));
+  });
+
   it("loads metadata from the connection default database when the query tab database is empty", async () => {
     const { useQueryStore } = await import("@/stores/queryStore");
     const store = useQueryStore();
@@ -206,6 +244,45 @@ describe("queryStore hidden primary key editing", () => {
     const tab = store.tabs.find((item) => item.id === tabId)!;
     await vi.waitFor(() => expect(tab.querySourceColumns).toEqual(["name", "id"]));
     expect(tab.queryEditabilityReason).toBeUndefined();
+  });
+
+  it("starts a MySQL JDBC star query before slow column metadata finishes", async () => {
+    const columnsGate = deferred<Awaited<ReturnType<typeof getColumns>>>();
+    getConnectionConfig.mockReturnValue({ id: "jdbc-1", name: "JDBC MySQL", db_type: "jdbc", connection_string: "jdbc:mysql://localhost:3306/app", database: "app", query_timeout_secs: 30 });
+    getColumns.mockReturnValue(columnsGate.promise);
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "sys_dept",
+        selectStar: true,
+        columns: [],
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["dept_id", "dept_name"],
+        rows: [[1, "Headquarters"]],
+        affected_rows: 0,
+        execution_time_ms: 12,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("jdbc-1", "", "Query");
+
+    const execution = store.executeTabSql(tabId, "SELECT * FROM sys_dept");
+    await vi.waitFor(() => expect(executeMulti).toHaveBeenCalled());
+    expect(executeMulti).toHaveBeenCalledWith("jdbc-1", "", "SELECT * FROM sys_dept", undefined, expect.any(String), expect.objectContaining({ timeoutSecs: 30 }));
+
+    columnsGate.resolve([
+      { name: "dept_id", data_type: "bigint", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+      { name: "dept_name", data_type: "varchar", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+    ]);
+    await execution;
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.tableMeta?.tableName).toBe("sys_dept"));
   });
 
   it("keeps an explicitly selected database instead of falling back to the connection default", async () => {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -326,6 +326,10 @@ function editableQuerySources(analysis: EditableQueryInfo): EditableQuerySource[
       ];
 }
 
+function projectsAllColumnsForSource(analysis: EditableQueryInfo, sourceKey: string): boolean {
+  return analysis.selectStar || analysis.columns.some((column) => column.star && (!column.sourceKey || column.sourceKey === sourceKey));
+}
+
 function cloneAnalysisForSource(analysis: EditableQueryInfo, source: EditableQuerySource): EditableQueryInfo {
   return {
     ...analysis,
@@ -2716,6 +2720,9 @@ export const useQueryStore = defineStore("query", () => {
       const analysis = editability.analysis;
       const sources = editableQuerySources(analysis);
       if (sources.length !== 1 || analysis.distinct) return unchanged;
+      // Whole-source projections already include declared primary keys. Only
+      // Oracle needs preflight metadata here to add ROWID for a keyless table.
+      if (databaseType !== "oracle" && projectsAllColumnsForSource(analysis, sources[0]!.key)) return unchanged;
 
       const target = resolveEditableSourceMetadataTarget(tab, analysis, sources[0]!, conn, databaseType, executionDatabase);
       const cached = getCachedTableMetadata(target.request);
@@ -2730,8 +2737,7 @@ export const useQueryStore = defineStore("query", () => {
         });
         void fullMetadataPromise.catch((error) => queryExecutionLog("warn", "metadata:table-prefetch:failed", { traceId, error, elapsed: elapsed() }));
         const indexes = await loadTableIndexes(target.request);
-        const projectsAllColumns = target.analysis.selectStar || target.analysis.columns.some((column) => column.star && (!column.sourceKey || column.sourceKey === target.source.key));
-        if (primaryKeyIndex(indexes) && projectsAllColumns) {
+        if (primaryKeyIndex(indexes) && projectsAllColumnsForSource(target.analysis, target.source.key)) {
           return unchanged;
         }
         loaded = loadedEditableSourceFromMetadata(target, (await fullMetadataPromise).metadata);


### PR DESCRIPTION
## 变更说明

修复 #4707。

执行 `SELECT * FROM sys_dept` 等全列查询时，数据库实际执行只需十几毫秒，但 DBX 界面可能持续加载十几秒。

- 非 Oracle 查询投影来源表全部字段时，不再同步等待编辑元数据，直接执行 SQL。
- 覆盖 `*`、`table.*`、表别名以及带引号别名等全列投影形式。
- 查询完成后仍通过原有后台流程加载元数据，不影响结果集编辑能力判断。
- 保留 Oracle 的预执行元数据逻辑，以继续支持无主键表的隐藏 `ROWID`。
- 非全列查询补充隐藏主键的原有行为保持不变。

## 变更类型

- [ ] 新功能
- [X] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

N/A

## 验证

- 目标查询 Store 测试 通过
- 全部 Store 测试  通过
- SQL/JDBC 相关测试  通过
- `pnpm typecheck` 通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
https://github.com/t8y2/dbx/issues/4707