### PR TITLE
Fix：避免完整结果重复触发无限滚动分页

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -2596,6 +2596,10 @@ function nextPage() {
 
 function infiniteScrollNextPage() {
   if (infiniteScrollLoading.value || props.loading) return;
+  if (!canGoNextPage.value) {
+    infiniteScrollAllLoaded = true;
+    return;
+  }
   const nextOffset = props.result.rows.length;
   const remainingRows = infiniteScrollMaxRows.value - nextOffset;
   if (remainingRows <= 0) return;

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -134,7 +134,7 @@ import { applyColumnFormatter, buildColumnFormatterKey, getSupportedTimeZoneOpti
 import { temporalCellEditorConfig, type TemporalCellEditorConfig } from "@/lib/dataGrid/dataGridTemporalEditor";
 import { isCancelSearchShortcut, isCopyCurrentRowShortcut, isDeleteCurrentRowShortcut, isFocusSearchShortcut, isModRShortcut, isSaveShortcut, isToggleTransposeShortcut } from "@/lib/editor/keyboardShortcuts";
 import { dataGridHeaderContentWidth, scrollbarGutterWidth } from "@/lib/dataGrid/dataGridScrollGutter";
-import { canGoNextDataGridPage, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal } from "@/lib/dataGrid/dataGridPagination";
+import { canFetchNextDataGridSegment, canGoNextDataGridPage, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal } from "@/lib/dataGrid/dataGridPagination";
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
 import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
 import { CANVAS_DATA_GRID_ROW_HEIGHT, canvasDataGridActionReservedWidth, dataGridSearchMatchKey, drawCanvasDataGrid } from "@/lib/dataGrid/canvasDataGridRenderer";
@@ -2469,6 +2469,15 @@ const canGoNextPage = computed(() => {
     allRowsLoaded: allRowsLoaded.value,
   });
 });
+const canFetchNextInfiniteScrollSegment = computed(() =>
+  canFetchNextDataGridSegment({
+    hasMore: props.result.has_more,
+    loadedRowCount: props.result.rows.length,
+    pageSize: pageSize.value,
+    totalRowCount: hasKnownPaginationTotalRowCount.value ? paginationTotalRowCount.value : undefined,
+    allRowsLoaded: allRowsLoaded.value,
+  }),
+);
 const canJumpLastPage = computed(() => canGoNextPage.value && (hasKnownPaginationTotalRowCount.value || allRowsLoaded.value || !!props.tableMeta || !!props.countSql));
 const totalRowCountBusy = computed(() => props.totalRowCountLoading === true || manualTotalRowCountLoading.value);
 const canCalculateTotalRowCount = computed(() => !!props.connectionId && (!!props.tableMeta || !!props.countSql));
@@ -2596,7 +2605,7 @@ function nextPage() {
 
 function infiniteScrollNextPage() {
   if (infiniteScrollLoading.value || props.loading) return;
-  if (!canGoNextPage.value) {
+  if (!canFetchNextInfiniteScrollSegment.value) {
     infiniteScrollAllLoaded = true;
     return;
   }

--- a/apps/desktop/src/lib/dataGrid/dataGridPagination.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridPagination.ts
@@ -21,6 +21,14 @@ export interface CompleteLocalDataGridResultOptions {
   hasMore?: boolean;
 }
 
+export interface CanFetchNextDataGridSegmentOptions {
+  hasMore?: boolean;
+  loadedRowCount: number;
+  pageSize: number;
+  totalRowCount?: number;
+  allRowsLoaded?: boolean;
+}
+
 export function resolveDataGridPaginationTotal(options: { paginationTotalRowCount?: number; serverKnownTotalRowCount?: number; totalRowCountIsExact: boolean }): number | undefined {
   if (options.paginationTotalRowCount !== undefined) return options.paginationTotalRowCount;
   return options.totalRowCountIsExact ? options.serverKnownTotalRowCount : undefined;
@@ -54,4 +62,16 @@ export function canGoNextDataGridPage(options: CanGoNextDataGridPageOptions): bo
   }
 
   return options.rowCount >= pageSize;
+}
+
+export function canFetchNextDataGridSegment(options: CanFetchNextDataGridSegmentOptions): boolean {
+  if (options.hasMore === true) return true;
+
+  const totalRowCount = options.totalRowCount;
+  if (typeof totalRowCount === "number" && Number.isFinite(totalRowCount) && totalRowCount >= 0) {
+    return options.loadedRowCount < totalRowCount;
+  }
+
+  if (options.allRowsLoaded === true) return false;
+  return options.loadedRowCount >= Math.max(1, options.pageSize);
 }

--- a/packages/app-tests/dataGridInfiniteScroll.test.ts
+++ b/packages/app-tests/dataGridInfiniteScroll.test.ts
@@ -27,6 +27,10 @@ test("near-bottom check matches the grid threshold", () => {
 
 test("infinite scroll requests only the next bounded segment", () => {
   const source = readFileSync("apps/desktop/src/components/grid/DataGrid.vue", "utf8");
+  assert.match(
+    source,
+    /function infiniteScrollNextPage\(\) \{[\s\S]*?if \(!canGoNextPage\.value\) \{[\s\S]*?infiniteScrollAllLoaded = true;[\s\S]*?return;[\s\S]*?\}/,
+  );
   assert.match(source, /const nextOffset = props\.result\.rows\.length/);
   assert.match(source, /Math\.min\(pageSize\.value, remainingRows\)/);
   assert.doesNotMatch(source, /emit\("paginate", 0, cumulativeLimit/);

--- a/packages/app-tests/dataGridInfiniteScroll.test.ts
+++ b/packages/app-tests/dataGridInfiniteScroll.test.ts
@@ -27,10 +27,7 @@ test("near-bottom check matches the grid threshold", () => {
 
 test("infinite scroll requests only the next bounded segment", () => {
   const source = readFileSync("apps/desktop/src/components/grid/DataGrid.vue", "utf8");
-  assert.match(
-    source,
-    /function infiniteScrollNextPage\(\) \{[\s\S]*?if \(!canGoNextPage\.value\) \{[\s\S]*?infiniteScrollAllLoaded = true;[\s\S]*?return;[\s\S]*?\}/,
-  );
+  assert.match(source, /function infiniteScrollNextPage\(\) \{[\s\S]*?if \(!canFetchNextInfiniteScrollSegment\.value\) \{[\s\S]*?infiniteScrollAllLoaded = true;[\s\S]*?return;[\s\S]*?\}/);
   assert.match(source, /const nextOffset = props\.result\.rows\.length/);
   assert.match(source, /Math\.min\(pageSize\.value, remainingRows\)/);
   assert.doesNotMatch(source, /emit\("paginate", 0, cumulativeLimit/);

--- a/packages/app-tests/dataGridPagination.test.ts
+++ b/packages/app-tests/dataGridPagination.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { canGoNextDataGridPage, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal } from "../../apps/desktop/src/lib/dataGrid/dataGridPagination.ts";
+import { canFetchNextDataGridSegment, canGoNextDataGridPage, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal } from "../../apps/desktop/src/lib/dataGrid/dataGridPagination.ts";
 
 test("estimated display totals do not become pagination bounds", () => {
   assert.equal(
@@ -97,6 +97,22 @@ test("backend hasMore takes precedence over a stale known total", () => {
 test("unknown total falls back to full-page heuristic", () => {
   assert.equal(canGoNextDataGridPage({ rowCount: 1, pageSize: 1 }), true);
   assert.equal(canGoNextDataGridPage({ rowCount: 0, pageSize: 1 }), false);
+});
+
+test("infinite scroll compares cumulative loaded rows with a known total", () => {
+  assert.equal(canFetchNextDataGridSegment({ loadedRowCount: 1_000, pageSize: 1_000, totalRowCount: 2_000 }), true);
+  assert.equal(canFetchNextDataGridSegment({ loadedRowCount: 2_000, pageSize: 1_000, totalRowCount: 2_000 }), false);
+});
+
+test("infinite scroll stops on a short unknown segment and probes a full unknown segment", () => {
+  assert.equal(canFetchNextDataGridSegment({ loadedRowCount: 673, pageSize: 1_000 }), false);
+  assert.equal(canFetchNextDataGridSegment({ loadedRowCount: 1_000, pageSize: 1_000 }), true);
+  assert.equal(canFetchNextDataGridSegment({ loadedRowCount: 2_000, pageSize: 1_000 }), true);
+});
+
+test("infinite scroll preserves authoritative has-more and complete-local-result signals", () => {
+  assert.equal(canFetchNextDataGridSegment({ hasMore: true, loadedRowCount: 673, pageSize: 1_000, totalRowCount: 673 }), true);
+  assert.equal(canFetchNextDataGridSegment({ loadedRowCount: 1_000, pageSize: 1_000, allRowsLoaded: true }), false);
 });
 
 // --- auto-redirect page calculation after refresh ---


### PR DESCRIPTION
## 问题

无限滚动模式下，即使首批查询结果已经完整加载，滚动到底部仍会再发起一次空分页查询，期间持续显示加载状态。

## 修复

- 无限滚动请求前复用现有的下一页判断
- 已无下一页时直接标记为全部加载，不再发起分页请求
- 增加 DataGrid 接入该边界判断的回归测试

## 验证

- 使用真实 SQL Server 查询 673 行，页大小 1000：修复前滚到底部会额外请求 offset 673；修复后不再新增请求
- 使用真实 SQL Server 查询 1200 行，页大小 1000：首次加载 1000 行，滚动后正常追加 200 行；再次滚到底部不再查询，并显示已全部加载
- pnpm check：format、lint、typecheck、test 全部通过

Fixes #4706