### PR TITLE
Fix：修复达梦连接重复的 Schema 过滤入口

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -63,7 +63,9 @@ import { useDatabaseOptions } from "@/composables/useDatabaseOptions";
 import type { ColumnInfo, DatabaseType, TreeNode, TreeNodeType } from "@/types/database";
 import * as api from "@/lib/backend/api";
 import { resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
+import { connectionUsesVisibleSchemaFilter } from "@/lib/database/visibleDatabases";
 import { canTreeNodePin, canTreeNodeShowExpander } from "@/lib/sidebar/sidebarTreeItemLayout";
+import { sidebarConnectionVisibleFilterMenu } from "@/lib/sidebar/sidebarVisibleFilterMenu";
 import { objectTypesForGroupNode } from "@/lib/table/tableTree";
 import { loadSidebarObjectGroup } from "@/lib/sidebar/sidebarObjectGroupRouting";
 import { mysqlObjectTemplateForGroup } from "@/lib/sidebar/mysqlObjectTemplates";
@@ -3715,23 +3717,15 @@ function buildConnectionSidebarMenu(context: SidebarMenuFactoryContext): boolean
       icon: RefreshCw,
       shortcut: shortcutRefresh,
     });
-    if (canConfigureVisibleDatabases.value) {
+    const visibleFilterMenu = sidebarConnectionVisibleFilterMenu({
+      canConfigureVisibleDatabases: canConfigureVisibleDatabases.value,
+      canConfigureVisibleSchemas: canConfigureVisibleSchemas.value,
+      databaseFilterUsesSchemas: connectionUsesVisibleSchemaFilter(node.connectionId ? connectionStore.getConfig(node.connectionId) : undefined),
+    });
+    for (const entry of visibleFilterMenu) {
       items.push({
-        label: t("contextMenu.configureVisibleObjects"),
-        action: openVisibleDatabasesDialog,
-        icon: ListFilter,
-      });
-    } else if (canConfigureVisibleSchemas.value) {
-      items.push({
-        label: t("visibleSchemas.title"),
-        action: openVisibleSchemasDialog,
-        icon: ListFilter,
-      });
-    }
-    if (canConfigureVisibleSchemas.value) {
-      items.push({
-        label: t("visibleSchemas.title"),
-        action: openVisibleSchemasDialog,
+        label: t(entry.label === "schemas" ? "visibleSchemas.title" : "contextMenu.configureVisibleObjects"),
+        action: entry.target === "visible-schemas" ? openVisibleSchemasDialog : openVisibleDatabasesDialog,
         icon: ListFilter,
       });
     }

--- a/apps/desktop/src/lib/sidebar/sidebarVisibleFilterMenu.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarVisibleFilterMenu.ts
@@ -1,0 +1,18 @@
+export type SidebarVisibleFilterMenuEntry = {
+  label: "objects" | "schemas";
+  target: "visible-databases" | "visible-schemas";
+};
+
+export function sidebarConnectionVisibleFilterMenu(options: { canConfigureVisibleDatabases: boolean; canConfigureVisibleSchemas: boolean; databaseFilterUsesSchemas: boolean }): SidebarVisibleFilterMenuEntry[] {
+  if (!options.canConfigureVisibleDatabases) {
+    return options.canConfigureVisibleSchemas ? [{ label: "schemas", target: "visible-schemas" }] : [];
+  }
+
+  if (options.databaseFilterUsesSchemas) {
+    return [{ label: "schemas", target: "visible-databases" }];
+  }
+
+  const entries: SidebarVisibleFilterMenuEntry[] = [{ label: "objects", target: "visible-databases" }];
+  if (options.canConfigureVisibleSchemas) entries.push({ label: "schemas", target: "visible-schemas" });
+  return entries;
+}

--- a/packages/app-tests/sidebarVisibleFilterMenu.test.ts
+++ b/packages/app-tests/sidebarVisibleFilterMenu.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { sidebarConnectionVisibleFilterMenu } from "../../apps/desktop/src/lib/sidebar/sidebarVisibleFilterMenu.ts";
+
+test("Dameng and Oracle schema-mode filters keep the connection-level dialog with one schema label", () => {
+  assert.deepEqual(
+    sidebarConnectionVisibleFilterMenu({
+      canConfigureVisibleDatabases: true,
+      canConfigureVisibleSchemas: true,
+      databaseFilterUsesSchemas: true,
+    }),
+    [{ label: "schemas", target: "visible-databases" }],
+  );
+});
+
+test("connections with independent database and schema filters retain both entries", () => {
+  assert.deepEqual(
+    sidebarConnectionVisibleFilterMenu({
+      canConfigureVisibleDatabases: true,
+      canConfigureVisibleSchemas: true,
+      databaseFilterUsesSchemas: false,
+    }),
+    [
+      { label: "objects", target: "visible-databases" },
+      { label: "schemas", target: "visible-schemas" },
+    ],
+  );
+});
+
+test("schema-mode database dialog does not depend on a dedicated schema action", () => {
+  assert.deepEqual(
+    sidebarConnectionVisibleFilterMenu({
+      canConfigureVisibleDatabases: true,
+      canConfigureVisibleSchemas: false,
+      databaseFilterUsesSchemas: true,
+    }),
+    [{ label: "schemas", target: "visible-databases" }],
+  );
+});
+
+test("schema-only connections produce one schema menu entry", () => {
+  assert.deepEqual(
+    sidebarConnectionVisibleFilterMenu({
+      canConfigureVisibleDatabases: false,
+      canConfigureVisibleSchemas: true,
+      databaseFilterUsesSchemas: false,
+    }),
+    [{ label: "schemas", target: "visible-schemas" }],
+  );
+});


### PR DESCRIPTION
## 问题

达梦和 Oracle 的连接级可见对象过滤本身使用 Schema 模式，但右键菜单仍同时追加了独立的“Schema 过滤器”，导致两个入口功能重复，并且“可见对象过滤器”文案与实际行为不一致。

## 修改内容

- 对使用 Schema 模式的连接只保留一个“Schema 过滤器”入口
- 继续使用连接级过滤弹窗，兼容未填写默认 database 的达梦连接
- 对真正具有独立数据库过滤和 Schema 过滤能力的连接保留两个入口
- 增加菜单决策回归测试，覆盖 Schema 模式、双过滤器和仅 Schema 过滤器场景

## 验证

- 使用真实 DM8 测试库连接成功，侧边栏加载出 5 个 Schema
- 右键达梦连接仅显示一个“Schema 过滤器”，弹窗可正常打开
- 取消选择 `TEST` 并保存后，侧边栏立即隐藏该 Schema；重新打开弹窗显示已选择 `4/5`，确认持久化成功；测试后已恢复显示全部
- 聚焦测试：3 个测试文件、29 个测试全部通过
- `pnpm check`：format、lint、typecheck、test 全部通过

Fixes #4724