### PR TITLE
feat(editor): add toggle fold shortcut (Ctrl+.) for SQL editor code f…

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -791,6 +791,7 @@ const formatterEditorShortcutIds: ShortcutActionId[] = [
   "selectAll",
   "uppercaseSelection",
   "lowercaseSelection",
+  "toggleFold",
 ];
 const formatterEditorShortcutDefinitions = computed(() => formatterEditorShortcutIds.map((id) => SHORTCUT_DEFINITIONS.find((definition) => definition.id === id)).filter((definition): definition is (typeof SHORTCUT_DEFINITIONS)[number] => !!definition));
 const filteredShortcutDefinitions = computed(() => {

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -356,6 +356,7 @@ let codeMirrorRedo: typeof import("@codemirror/commands").redo | null = null;
 let codeMirrorSelectAll: typeof import("@codemirror/commands").selectAll | null = null;
 let codeMirrorInsertNewlineKeepIndent: typeof import("@codemirror/commands").insertNewlineKeepIndent | null = null;
 let codeMirrorToggleLineComment: typeof import("@codemirror/commands").toggleLineComment | null = null;
+let codeMirrorToggleFold: typeof import("@codemirror/language").toggleFold | null = null;
 let pendingCompletionTabTimer: ReturnType<typeof setTimeout> | null = null;
 let setSqlDiagnosticsEffect: import("@codemirror/state").StateEffectType<SqlSemanticDiagnostic[]> | null = null;
 let setPreviewRangeEffect:
@@ -1395,6 +1396,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
         ...binding(shortcuts.uppercaseSelection, () => convertSelectedSqlCase("upper")),
         ...binding(shortcuts.lowercaseSelection, () => convertSelectedSqlCase("lower")),
         ...binding(shortcuts.toggleLineComment, (view) => codeMirrorToggleLineComment?.(view) ?? false),
+        ...binding(shortcuts.toggleFold, (view) => codeMirrorToggleFold?.(view) ?? false),
         ...binding(shortcuts.exPasteSqlInCondition, () => {
           if (!supportsSqlInListPaste(props.databaseType)) return false;
           void pasteClipboardAsSqlInCondition();
@@ -3392,7 +3394,7 @@ onMounted(async () => {
     langSql,
     { autocompletion, startCompletion, acceptCompletion, closeBrackets, closeBracketsKeymap, snippetCompletion, completionStatus, completionKeymap, insertCompletionText, nextSnippetField },
     { copyLineDown, copyLineUp, deleteLine, indentLess, indentMore, insertNewlineKeepIndent, moveLineDown, moveLineUp, redo, selectAll, undo, toggleLineComment, history, defaultKeymap, historyKeymap },
-    { bracketMatching, foldGutter, indentOnInput, indentUnit, syntaxHighlighting, defaultHighlightStyle, foldKeymap, ensureSyntaxTree },
+    { bracketMatching, foldGutter, indentOnInput, indentUnit, syntaxHighlighting, defaultHighlightStyle, foldKeymap, toggleFold, ensureSyntaxTree },
     { searchKeymap },
   ] = await Promise.all([import("@codemirror/view"), import("@codemirror/state"), import("@codemirror/lang-sql"), import("@codemirror/autocomplete"), import("@codemirror/commands"), import("@codemirror/language"), import("@codemirror/search")]);
   editorViewModule = {
@@ -3439,6 +3441,7 @@ onMounted(async () => {
   codeMirrorSelectAll = selectAll;
   codeMirrorInsertNewlineKeepIndent = insertNewlineKeepIndent;
   codeMirrorToggleLineComment = toggleLineComment;
+  codeMirrorToggleFold = toggleFold;
   codeMirrorIndentUnit = indentUnit;
   window.addEventListener("keyup", clearTableNavigationHoverOnModifierRelease);
   window.addEventListener("blur", clearTableNavigationHover);

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -4634,6 +4634,7 @@ export default {
     shortcutEditSidebarConnection: "Edit sidebar connection",
     shortcutOpenDataInNewTab: "Open data in new tab (mouse click)",
     shortcutSendSelectionToAi: "Send selection to AI",
+    shortcutToggleFold: "Toggle fold",
     shortcutScopeGlobal: "Global",
     shortcutScopeEditor: "SQL editor",
     shortcutScopeGrid: "Data grid",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -4389,6 +4389,7 @@ export default withEnglishFallback({
     shortcutEditSidebarConnection: "Editar conexión de la barra lateral",
     shortcutOpenDataInNewTab: "Abrir datos en una pestaña nueva (clic del ratón)",
     shortcutSendSelectionToAi: "Enviar selección a IA",
+    shortcutToggleFold: "Contraer/expandir código",
     shortcutScopeGlobal: "Global",
     shortcutScopeEditor: "Editor SQL",
     shortcutScopeGrid: "Cuadrícula de datos",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -4387,6 +4387,7 @@ export default withEnglishFallback({
     shortcutEditSidebarConnection: "Modifica connessione barra laterale",
     shortcutOpenDataInNewTab: "Apri dati in una nuova scheda (clic del mouse)",
     shortcutSendSelectionToAi: "Invia selezione ad AI",
+    shortcutToggleFold: "Comprimi/espandi codice",
     shortcutScopeGlobal: "Globale",
     shortcutScopeEditor: "Editor SQL",
     shortcutScopeGrid: "Griglia dati",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -4371,6 +4371,7 @@ export default withEnglishFallback({
     shortcutEditSidebarConnection: "サイドバー接続を編集",
     shortcutOpenDataInNewTab: "新しいデータタブで開く（マウスクリック）",
     shortcutSendSelectionToAi: "選択範囲をAIに送信",
+    shortcutToggleFold: "折りたたみの切り替え",
     shortcutScopeGlobal: "グローバル",
     shortcutScopeEditor: "SQLエディタ",
     shortcutScopeGrid: "データグリッド",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -4389,6 +4389,7 @@ export default withEnglishFallback({
     shortcutEditSidebarConnection: "Editar conexão da barra lateral",
     shortcutOpenDataInNewTab: "Abrir dados em nova aba (clique do mouse)",
     shortcutSendSelectionToAi: "Enviar seleção para IA",
+    shortcutToggleFold: "Recolher/expandir código",
     shortcutScopeGlobal: "Global",
     shortcutScopeEditor: "Editor SQL",
     shortcutScopeGrid: "Grade de dados",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -4636,6 +4636,7 @@ export default withEnglishFallback({
     shortcutEditSidebarConnection: "编辑侧边栏连接",
     shortcutOpenDataInNewTab: "在新数据标签页中打开（鼠标点击）",
     shortcutSendSelectionToAi: "发送选中代码到 AI",
+    shortcutToggleFold: "切换折叠",
     shortcutScopeGlobal: "全局",
     shortcutScopeEditor: "SQL 编辑器",
     shortcutScopeGrid: "数据表格",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -4044,6 +4044,7 @@ export default withEnglishFallback({
     shortcutEditSidebarConnection: "編輯側邊欄連線",
     shortcutOpenDataInNewTab: "在新資料分頁中開啟（滑鼠點擊）",
     shortcutSendSelectionToAi: "傳送選取程式碼至 AI",
+    shortcutToggleFold: "切換折疊",
     shortcutScopeGlobal: "全域",
     shortcutScopeEditor: "SQL 編輯器",
     shortcutScopeGrid: "資料表格",

--- a/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
@@ -19,6 +19,7 @@ describe("shortcutRegistry editor actions", () => {
     "uppercaseSelection",
     "lowercaseSelection",
     "exPasteSqlInCondition",
+    "toggleFold",
   ];
   const sidebarShortcutActionIds: ShortcutActionId[] = ["copySidebarSelection", "pasteSidebarSelection", "editSidebarConnection"];
 
@@ -100,6 +101,7 @@ describe("shortcutRegistry editor actions", () => {
     expect(shortcuts.uppercaseSelection).toBe("Shift+Alt+U");
     expect(shortcuts.lowercaseSelection).toBe("Shift+Alt+L");
     expect(shortcuts.exPasteSqlInCondition).toBe("");
+    expect(shortcuts.toggleFold).toBe("Mod+.");
   });
 
   it("detects conflicts between formatter editor shortcuts and other editor shortcuts", () => {

--- a/apps/desktop/src/lib/editor/shortcutRegistry.ts
+++ b/apps/desktop/src/lib/editor/shortcutRegistry.ts
@@ -21,6 +21,7 @@ export type ShortcutActionId =
   | "uppercaseSelection"
   | "lowercaseSelection"
   | "exPasteSqlInCondition"
+  | "toggleFold"
   | "copyCurrentRow"
   | "deleteCurrentRow"
   | "newQuery"
@@ -201,6 +202,12 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     labelKey: "settings.shortcutExPasteSqlInCondition",
     scope: "editor",
     defaultShortcut: "",
+  },
+  {
+    id: "toggleFold",
+    labelKey: "settings.shortcutToggleFold",
+    scope: "editor",
+    defaultShortcut: "Mod+.",
   },
   {
     id: "copyCurrentRow",


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
add toggle fold shortcut (Ctrl+.) for SQL editor code folding

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1311" height="960" alt="image" src="https://github.com/user-attachments/assets/36656b28-7027-43a8-b785-cb8f1cfd3d6f" />
<img width="1305" height="960" alt="image" src="https://github.com/user-attachments/assets/8fbceb2a-961a-43fc-9d0b-640b20354f25" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

 Test Files  637 passed (637)
      Tests  5518 passed (5518)
   Start at  17:11:48
   Duration  104.21s (transform 22.92s, setup 0ms, import 103.44s, tests 56.47s, environment 28.25s)

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
