### PR TITLE
Fix：关闭新建连接弹窗后页面显示异常

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -3389,7 +3389,7 @@ onMounted(async () => {
   })();
 
   const [
-    { EditorView, keymap, rectangularSelection, hoverTooltip, showTooltip, closeHoverTooltips, Decoration, tooltips, gutter, GutterMarker, lineNumberMarkers, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, crosshairCursor, scrollPastEnd, ViewPlugin },
+    { EditorView, keymap, rectangularSelection, hoverTooltip, showTooltip, closeHoverTooltips, Decoration, gutter, GutterMarker, lineNumberMarkers, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, dropCursor, crosshairCursor, scrollPastEnd, ViewPlugin },
     { EditorState, EditorSelection, Compartment, Prec, RangeSet, StateEffect, StateField },
     langSql,
     { autocompletion, startCompletion, acceptCompletion, closeBrackets, closeBracketsKeymap, snippetCompletion, completionStatus, completionKeymap, insertCompletionText, nextSnippetField },
@@ -3844,7 +3844,6 @@ onMounted(async () => {
       keymap.of([...defaultKeymap, ...searchKeymap, ...historyKeymap, ...foldKeymap, ...completionKeymap]),
       sqlLanguageComp.of(buildSqlLanguageExtension()),
       sqlSemanticHighlightComp.of(buildSqlSemanticHighlightExtension()),
-      tooltips({ parent: document.body }),
       completionComp.of(buildSqlCompletionExtension()),
       sqlCompletionTheme(EditorView),
       codeMirrorTheme.of(theme),

--- a/apps/desktop/src/components/ui/dialog/DialogOverlay.vue
+++ b/apps/desktop/src/components/ui/dialog/DialogOverlay.vue
@@ -26,16 +26,8 @@ async function startWindowDrag(event: PointerEvent) {
 </script>
 
 <template>
-  <DialogOverlay data-slot="dialog-overlay" v-bind="delegatedProps" :class="cn('dbx-dialog-overlay-backdrop data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 fixed inset-0 isolate z-50', props.class)">
+  <DialogOverlay data-slot="dialog-overlay" v-bind="delegatedProps" :class="cn('data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 fixed inset-0 isolate z-50', props.class)">
     <div v-if="isDesktop" aria-hidden="true" class="fixed inset-x-0 top-0 h-10 pointer-events-auto" data-tauri-drag-region @pointerdown="startWindowDrag" />
     <slot />
   </DialogOverlay>
 </template>
-
-<style scoped>
-.dbx-dialog-overlay-backdrop[data-state="open"],
-.dbx-dialog-overlay-backdrop[data-open]:not([data-open="false"]) {
-  -webkit-backdrop-filter: blur(4px);
-  backdrop-filter: blur(4px);
-}
-</style>

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorTooltipParent.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorTooltipParent.spec.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+describe("QueryEditor tooltip container", () => {
+  it("keeps CodeMirror tooltips inside the editor instead of extending document.body", () => {
+    expect(queryEditorSource).not.toContain("tooltips({ parent: document.body })");
+  });
+});

--- a/apps/desktop/src/styles/__tests__/legacyWebviewFallback.spec.ts
+++ b/apps/desktop/src/styles/__tests__/legacyWebviewFallback.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 const globalsCss = readFileSync(new URL("../globals.css", import.meta.url), "utf8");
 const dialogContentSource = readFileSync(new URL("../../components/ui/dialog/DialogContent.vue", import.meta.url), "utf8");
 const dialogScrollContentSource = readFileSync(new URL("../../components/ui/dialog/DialogScrollContent.vue", import.meta.url), "utf8");
+const dialogOverlaySource = readFileSync(new URL("../../components/ui/dialog/DialogOverlay.vue", import.meta.url), "utf8");
 const connectionDialogSource = readFileSync(new URL("../../components/connection/ConnectionDialog.vue", import.meta.url), "utf8");
 const desktopIndexSource = readFileSync(new URL("../../../index.html", import.meta.url), "utf8");
 const connectionDialogLegacyCss = readFileSync(new URL("../../../public/connection-dialog-legacy.css", import.meta.url), "utf8");
@@ -41,6 +42,11 @@ describe("legacy WebView CSS fallbacks", () => {
     expect(dialogContentSource).toContain("max-h-[calc(var(--dbx-viewport-height)-2rem)]");
     expect(dialogScrollContentSource).toContain("max-h-[calc(var(--dbx-viewport-height)-6rem)]");
     expect(connectionDialogSource).toContain("max-height: calc(var(--dbx-viewport-height) - 2rem);");
+  });
+
+  it("avoids full-window backdrop filters that can blank WebKit after a dialog closes", () => {
+    expect(dialogOverlaySource).not.toContain("backdrop-filter");
+    expect(dialogOverlaySource).toContain("bg-black/10");
   });
 
   it("keeps legacy tab triggers connected to the configured corner style", () => {


### PR DESCRIPTION
## 问题

在 macOS 桌面端的 SQL 查询页面打开“新建连接”后关闭，会出现底部大片空白；从“新建查询”进入并关闭弹窗时，页面还可能整体变灰。

## 原因

- 通用对话框遮罩使用全窗口 `backdrop-filter`，会触发 WKWebView 合成异常。
- SQL 编辑器将 CodeMirror tooltip 容器挂载到 `document.body`，生成的全视口容器使 body 高度翻倍。弹窗搜索框获得焦点时 WebKit 会修改 `body.scrollTop`，关闭弹窗后偏移未恢复。

## 修复

- 移除对话框遮罩的全窗口模糊效果，保留半透明背景。
- 恢复 CodeMirror 默认 tooltip 容器，使补全和悬浮提示保留在编辑器内部。
- 增加回归测试，避免重新引入全窗口 backdrop filter 或 body tooltip 容器。

## 验证

- macOS 客户端实际复现并验证，连续打开/关闭新建连接弹窗 5 次，页面显示正常。
- 验证 SQL 补全弹窗仍能正常显示且不被裁剪。
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm lint`（无 error，仅仓库现有 warning）
- rebase 最新 main 后定向测试：2 个测试文件、6 个测试通过。

Fixes #4768