### PR TITLE
Fix：设置页面切换分类时重置滚动位置

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -1329,6 +1329,7 @@ function setSidebarActivation(value: "single" | "double") {
 }
 
 const activeSettingsTab = ref("appearance");
+const settingsContentScrollRef = ref<HTMLElement | null>(null);
 const isWeb = !isTauriRuntime();
 const appSupportInfo = ref<AppSupportInfo | null>(null);
 const appSupportInfoLoading = ref(false);
@@ -1372,6 +1373,12 @@ function settingsCategoryButton(value: SettingsCategory): string {
     "settings-category-button w-auto shrink-0 whitespace-nowrap rounded-md px-3 py-2 text-left text-sm transition-colors lg:w-full",
     value === activeSettingsTab.value ? "settings-category-button--active bg-primary text-primary-foreground shadow-sm" : "text-muted-foreground hover:bg-muted hover:text-foreground",
   ].join(" ");
+}
+
+async function resetSettingsContentScroll() {
+  await nextTick();
+  const scroller = settingsContentScrollRef.value;
+  if (scroller) scroller.scrollTop = 0;
 }
 
 function openExternalUrl(url: string) {
@@ -2016,6 +2023,7 @@ watch(snippetProvider, (provider) => {
 });
 
 watch(activeSettingsTab, async (tab) => {
+  void resetSettingsContentScroll();
   if (tab === "mcp" && !mcpStatus.value && !mcpStatusLoading.value) void refreshMcpStatus();
   if (tab === "ai" && aiIsCliProvider.value) void ensureCliMcpStatus();
   if (tab === "ai") {
@@ -3121,7 +3129,7 @@ onUnmounted(cleanupPreviewEditor);
         </nav>
 
         <div class="min-w-0 flex-1 overflow-hidden px-1 flex flex-col">
-          <div class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1 pr-2">
+          <div ref="settingsContentScrollRef" class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-1 pr-2">
             <section v-if="activeSettingsTab === 'editor'" class="flex flex-col gap-5 py-2">
               <div class="grid gap-4 md:grid-cols-[1fr_auto]">
                 <!-- Font Family -->

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -607,6 +607,16 @@ test("shows persisted UI scales that are not available as presets", () => {
   assert.match(source, /<SelectValue>\{\{ Math\.round\(editUiScale \* 100\) \}\}%<\/SelectValue>/);
 });
 
+test("settings page resets content scroll when switching categories", () => {
+  const source = readFileSync("apps/desktop/src/components/editor/EditorSettingsDialog.vue", "utf8");
+
+  assert.match(source, /const settingsContentScrollRef = ref<HTMLElement \| null>\(null\)/);
+  assert.match(source, /function resetSettingsContentScroll\(\)/);
+  assert.match(source, /if \(scroller\) scroller\.scrollTop = 0/);
+  assert.match(source, /watch\(activeSettingsTab, async \(tab\) => \{\s+void resetSettingsContentScroll\(\);/);
+  assert.match(source, /ref="settingsContentScrollRef" class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden/);
+});
+
 test("defaults SQL formatter settings", () => {
   assert.deepEqual(DEFAULT_EDITOR_SETTINGS.sqlFormatter, DEFAULT_SQL_FORMATTER_SETTINGS);
   assert.deepEqual(normalizeEditorSettings({}).sqlFormatter, DEFAULT_EDITOR_SETTINGS.sqlFormatter);


### PR DESCRIPTION
## 背景
设置页面右侧内容区域在不同分类之间复用同一个滚动容器。用户在某个设置分类中向下滚动后，切换到下一个分类时会继承原来的滚动位置，导致新分类打开后初始内容不在顶部。

## 改动
- 为设置内容滚动容器增加引用，在切换设置分类时重置 `scrollTop`。
- 补充静态回归测试，避免后续移除滚动重置逻辑。

## 验证
- `pnpm vitest run packages/app-tests/settingsStore.test.ts --pool=forks`
- `pnpm typecheck`