### PR TITLE
Fix：限制表别名字段补全范围

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -230,6 +230,27 @@ describe("semantic SQL completion candidates", () => {
     expect(items.filter((item) => item.type === "column").map((item) => item.label)).toEqual(["id", "status"]);
   });
 
+  it("keeps a SELECT-list alias scoped when comma-separated sources follow the cursor", () => {
+    const columnsByTable = new Map<string, SqlCompletionColumn[]>([
+      ["tb_kpi_set_score", ["id", "score_name"].map((name) => ({ name, table: "tb_kpi_set_score" }))],
+      ["tb_kpi_set_score_detail", ["id", "fk_kpi_set_score_id", "detail_score"].map((name) => ({ name, table: "tb_kpi_set_score_detail" }))],
+      ["tb_kpi_set_score_relationship", ["priority", "exclude_users_account"].map((name) => ({ name, table: "tb_kpi_set_score_relationship" }))],
+    ]);
+
+    const { context, items } = semanticCompletion(
+      `SELECT
+  b.|
+FROM tb_kpi_set_score a,
+  tb_kpi_set_score_detail b
+WHERE a.id = b.fk_kpi_set_score_id`,
+      { columnsByTable },
+      { databaseType: "mysql", dialect: "mysql" },
+    );
+
+    expect(context.referencedTables).toEqual(expect.arrayContaining([expect.objectContaining({ name: "tb_kpi_set_score_detail", alias: "b" })]));
+    expect(items.filter((item) => item.type === "column").map((item) => item.label)).toEqual(["id", "fk_kpi_set_score_id", "detail_score"]);
+  });
+
   it("completes correlation columns for generic PostgreSQL table functions", () => {
     const { context, items } = semanticCompletion("SELECT * FROM generate_series(1, 3) g(value) WHERE g.|", {}, { databaseType: "postgres", dialect: "postgres" });
 

--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -25,6 +25,17 @@ function postgresConnection(): ConnectionConfig {
   } as ConnectionConfig;
 }
 
+function mysqlConnection(): ConnectionConfig {
+  return {
+    ...postgresConnection(),
+    id: "mysql-1",
+    name: "MySQL",
+    db_type: "mysql",
+    port: 3306,
+    username: "root",
+  } as ConnectionConfig;
+}
+
 function oracleConnection(): ConnectionConfig {
   return {
     ...postgresConnection(),
@@ -282,6 +293,39 @@ describe("connectionStore completion assistant", () => {
     expect(getColumns).toHaveBeenCalledWith("oracle-1", "ORCL", "", "ORDERS", undefined, "tab-a");
     expect(columns).toEqual([expect.objectContaining({ name: "REPORT_ID", table: "ORDERS", schema: undefined, dataType: "NUMBER" })]);
     expect(store.lookupLocalCompletionColumns("oracle-1", "ORCL", "ORDERS")).toEqual([]);
+  });
+
+  it("rejects assistant columns returned for a different MySQL parent table", async () => {
+    const completionAssistantSearch = vi.fn().mockResolvedValue({
+      candidates: [
+        { name: "status", kind: "column", schema: "app", parent_schema: "app", parent_name: "TB_KPI_SET_SCORE_DETAIL", data_type: "tinyint" },
+        { name: "priority", kind: "column", schema: "app", parent_schema: "app", parent_name: "tb_kpi_set_score_relationship", data_type: "smallint" },
+        { name: "archived_status", kind: "column", schema: "archive", parent_schema: "archive", parent_name: "tb_kpi_set_score_detail", data_type: "tinyint" },
+        { name: "legacy_flag", kind: "column", schema: "app", data_type: "tinyint" },
+      ],
+      incomplete: false,
+      fallback_used: false,
+    });
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      completionAssistantSearch,
+      getColumns: vi.fn(),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [mysqlConnection()];
+    store.connectedIds.add("mysql-1");
+
+    const columns = await store.listCompletionColumns("mysql-1", "app", "tb_kpi_set_score_detail", "app");
+
+    expect(completionAssistantSearch).toHaveBeenCalledWith(expect.objectContaining({ parent_name: "tb_kpi_set_score_detail", parent_schema: "app" }));
+    expect(columns.map((column) => [column.name, column.table])).toEqual([
+      ["status", "tb_kpi_set_score_detail"],
+      ["legacy_flag", "tb_kpi_set_score_detail"],
+    ]);
   });
 
   it("normalizes unquoted Oracle aliases while preserving quoted case before catalog lookup", async () => {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -5149,9 +5149,21 @@ export const useConnectionStore = defineStore("connection", () => {
     return 0;
   }
 
-  function completionAssistantColumns(candidates: CompletionAssistantCandidate[], table: string, schema?: string): SqlCompletionColumn[] {
+  function completionAssistantIdentifierMatches(candidate: string, requested: string, quoted?: boolean): boolean {
+    return quoted ? candidate === requested : candidate.toLowerCase() === requested.toLowerCase();
+  }
+
+  function completionAssistantColumns(candidates: CompletionAssistantCandidate[], table: string, schema?: string, context?: { tableQuoted?: boolean; schemaQuoted?: boolean }): SqlCompletionColumn[] {
+    const requestedSchema = schema?.trim();
     return candidates
-      .filter((candidate) => candidate.kind === "column")
+      .filter((candidate) => {
+        if (candidate.kind !== "column") return false;
+        const parentName = candidate.parent_name?.trim();
+        if (parentName && !completionAssistantIdentifierMatches(parentName, table, context?.tableQuoted)) return false;
+        const parentSchema = candidate.parent_schema?.trim() || candidate.schema?.trim();
+        if (requestedSchema && parentSchema && !completionAssistantIdentifierMatches(parentSchema, requestedSchema, context?.schemaQuoted)) return false;
+        return true;
+      })
       .map((candidate) => ({
         name: candidate.name,
         table: candidate.parent_name ?? table,
@@ -5216,7 +5228,7 @@ export const useConnectionStore = defineStore("connection", () => {
     return objects;
   }
 
-  async function listCompletionAssistantColumns(connectionId: string, database: string, table: string, schema?: string): Promise<SqlCompletionColumn[]> {
+  async function listCompletionAssistantColumns(connectionId: string, database: string, table: string, schema?: string, context?: { tableQuoted?: boolean; schemaQuoted?: boolean }): Promise<SqlCompletionColumn[]> {
     const response = await completionAssistantSearch({
       connection_id: connectionId,
       database,
@@ -5228,7 +5240,7 @@ export const useConnectionStore = defineStore("connection", () => {
       parent_name: table,
       match_mode: "prefix",
     });
-    const columns = completionAssistantColumns(response.candidates, table, schema);
+    const columns = completionAssistantColumns(response.candidates, table, schema, context);
     if (columns.length > 0) indexCompletionColumns(connectionId, database, table, schema, columns);
     return columns;
   }
@@ -5769,7 +5781,7 @@ export const useConnectionStore = defineStore("connection", () => {
           await ensureConnected(connectionId);
           if (!usesOracleCurrentSchema && !catalog) {
             try {
-              const assistantColumns = await listCompletionAssistantColumns(connectionId, database, completionTable, completionSchema);
+              const assistantColumns = await listCompletionAssistantColumns(connectionId, database, completionTable, completionSchema, context);
               if (assistantColumns.length > 0) {
                 completionColumnsCache.value[cacheKey] = assistantColumns.map((column) => ({
                   name: column.name,


### PR DESCRIPTION
## 问题

多表查询使用表别名触发字段补全时，completion assistant 返回的其他表字段可能被错误缓存到当前表，导致 `b.` 候选中混入无关字段。

## 修复

- 按请求的父表和 Schema 过滤字段候选，避免跨表、跨 Schema 污染
- 未加引号的标识符按数据库常见规则忽略大小写，带引号的标识符保持精确匹配
- 保留缺少父表元数据的旧 agent 候选，兼容旧版本 agent
- 增加逗号联表别名和错误父表响应的回归测试

## 验证

- MySQL 5.7 实际界面验证：`b.` 仅显示目标表字段
- MySQL 8.4 实际界面验证：`b.` 仅显示目标表字段
- 定向测试：2 个文件，60 个用例通过
- 全量测试：1263 个测试套件、5568 个测试通过
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`（仅仓库现有警告）

Fixes #4767