### PR TITLE
Fix：修复自定义 SQL 代码片段触发键失效

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -65,6 +65,7 @@ import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, loadEditorTheme, 
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 import { appendSqlCompletionSpace } from "@/lib/editor/sqlCompletionInsertion";
+import { completionLabelPresentation } from "@/lib/editor/sqlCompletionPresentation";
 import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
 import { normalizeShortcutSettings, shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
 import { trimmedSelectionLayer } from "@/lib/editor/codemirrorTrimmedSelectionLayer";
@@ -2490,12 +2491,14 @@ function shouldInsertSqlCompletionSpace(): boolean {
 }
 
 function completionOptionForItem(item: QueryCompletionItem) {
+  const filterText = "filterText" in item && typeof item.filterText === "string" ? item.filterText : undefined;
+  const labelPresentation = completionLabelPresentation(item.label, filterText);
   const record = () => {
     recordCompletionSelection(item.label, item.type);
   };
   if ((item.type === "snippet" || item.type === "function") && item.apply) {
     const completion = codeMirrorSnippetCompletion(item.apply, {
-      label: item.label,
+      ...labelPresentation,
       type: item.type,
       detail: item.detail,
       info: item.info,
@@ -2520,7 +2523,7 @@ function completionOptionForItem(item: QueryCompletionItem) {
     };
   }
   return {
-    label: item.label,
+    ...labelPresentation,
     type: item.type,
     detail: item.detail,
     info: item.info,

--- a/apps/desktop/src/lib/__tests__/editor/sqlCompletionPresentation.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/sqlCompletionPresentation.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { acceptCompletion, autocompletion, completionStatus, currentCompletions, snippetCompletion, startCompletion } from "@codemirror/autocomplete";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { describe, expect, it } from "vitest";
+import { completionLabelPresentation } from "@/lib/editor/sqlCompletionPresentation";
+
+describe("SQL completion label presentation", () => {
+  it("filters a custom snippet by trigger while preserving its display label", () => {
+    expect(completionLabelPresentation("SELECT *", "ssf")).toEqual({
+      label: "ssf SELECT *",
+      displayLabel: "SELECT *",
+      sortText: "SELECT *",
+    });
+  });
+
+  it("leaves ordinary completion labels unchanged", () => {
+    expect(completionLabelPresentation("SELECT")).toEqual({ label: "SELECT" });
+    expect(completionLabelPresentation("select *", "sel")).toEqual({ label: "select *" });
+  });
+
+  it("keeps a differently named snippet visible and applicable in CodeMirror", async () => {
+    const presentation = completionLabelPresentation("SELECT *", "ssf");
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        doc: "ssf",
+        selection: { anchor: 3 },
+        extensions: [
+          autocompletion({
+            interactionDelay: 0,
+            override: [() => ({ from: 0, options: [snippetCompletion("SELECT * FROM", { ...presentation, type: "snippet" })] })],
+          }),
+        ],
+      }),
+    });
+
+    startCompletion(view);
+    await expect.poll(() => completionStatus(view.state)).toBe("active");
+    expect(currentCompletions(view.state)[0]).toMatchObject({ label: "ssf SELECT *", displayLabel: "SELECT *" });
+    expect(acceptCompletion(view)).toBe(true);
+    expect(view.state.doc.toString()).toBe("SELECT * FROM");
+    view.destroy();
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.snippet.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.snippet.spec.ts
@@ -50,6 +50,18 @@ describe("buildSnippetItems", () => {
     expect(items[0].apply).toBe("SELECT *\nFROM my_table;");
   });
 
+  it("keeps a distinct trigger available to CodeMirror filtering", () => {
+    const items = buildSnippetItemsForTest("ssf", [{ id: "custom", label: "SELECT *", prefix: "ssf", body: "SELECT * FROM" }]);
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        label: "SELECT *",
+        filterText: "ssf",
+        type: "snippet",
+      }),
+    ]);
+  });
+
   it("uses CodeMirror placeholders for the built-in select snippet", () => {
     const items = buildSnippetItemsForTest("sel", [BUILTIN_SELECT]);
 

--- a/apps/desktop/src/lib/editor/sqlCompletionPresentation.ts
+++ b/apps/desktop/src/lib/editor/sqlCompletionPresentation.ts
@@ -1,0 +1,15 @@
+export interface CompletionLabelPresentation {
+  label: string;
+  displayLabel?: string;
+  sortText?: string;
+}
+
+export function completionLabelPresentation(label: string, filterText?: string): CompletionLabelPresentation {
+  const normalizedFilterText = filterText?.trim();
+  if (!normalizedFilterText || label.toLowerCase().startsWith(normalizedFilterText.toLowerCase())) return { label };
+  return {
+    label: `${normalizedFilterText} ${label}`,
+    displayLabel: label,
+    sortText: label,
+  };
+}

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -1190,6 +1190,7 @@ export interface SqlCompletionForeignKey {
 
 export interface SqlCompletionItem {
   label: string;
+  filterText?: string;
   type: "keyword" | "table" | "column" | "snippet" | "function" | "schema";
   detail?: string;
   info?: string;
@@ -4083,6 +4084,7 @@ function buildSnippetItems(prefix: string, snippets: SqlSnippet[], keywordCase?:
       const apply = applyBuiltinSnippetKeywordCase(snippet, applyBuiltinSnippetPlaceholders(snippet, resolvedBody), keywordCase);
       return {
         label: snippet.label,
+        filterText: snippet.prefix,
         type: "snippet" as const,
         detail: body,
         apply,


### PR DESCRIPTION
## 问题

自定义 SQL 代码片段的触发键与显示名称不一致时，例如触发键为 `ssf`、显示名称为 `SELECT *`，输入触发键后补全候选不会出现。

原因是 DBX 找到代码片段后，CodeMirror 会继续使用候选的显示名称进行过滤，导致触发键无法匹配显示名称。

## 修复

- 将代码片段触发键传递给编辑器补全层
- 使用触发键参与 CodeMirror 过滤，同时继续展示原始片段名称
- 保持内置片段原有的显示和排序行为
- 增加真实 CodeMirror 补全过滤、展示及插入回归测试

## 验证

- `pnpm check`
- 定向 CodeMirror/片段测试：53 项通过
- 完整 SQL 测试：538 项通过
- 本地 Web 预览验证：输入 `ssf` 可显示 `SELECT *`，接受后插入 `SELECT * FROM`