### PR TITLE
Fix：支持使用完整表名补全字段

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -205,6 +205,19 @@ describe("semantic SQL completion candidates", () => {
   });
 
   it.each([
+    ["table name", "SELECT orders.| FROM orders"],
+    ["schema-qualified table name", "SELECT public.orders.| FROM public.orders"],
+  ] as const)("completes PostgreSQL columns through a %s qualifier", (_label, markedSql) => {
+    const columnsByTable = new Map<string, SqlCompletionColumn[]>([["orders", ["id", "customer_name", "total_amount"].map((name) => ({ name, table: "orders", schema: "public" }))]]);
+
+    const { context, items } = semanticCompletion(markedSql, { columnsByTable }, { databaseType: "postgres", dialect: "postgres" });
+
+    expect(context.contextKind).toBe("alias_column");
+    expect(context.exclusiveColumnSuggestions).toBe(true);
+    expect(items.filter((item) => item.type === "column").map((item) => item.label)).toEqual(["id", "customer_name", "total_amount"]);
+  });
+
+  it.each([
     ["PostgreSQL", "postgres", "postgres"],
     ["SQL Server", "sqlserver", "sqlserver"],
   ] as const)("uses row-source aliases for %s self-join column collisions", (_label, databaseType, dialect) => {

--- a/apps/desktop/src/lib/__tests__/sql/semantic/model.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/model.spec.ts
@@ -80,6 +80,17 @@ describe("sqlSemanticModel baseline fixtures", () => {
     expect(model.cursorIntent).toEqual(expect.objectContaining({ kind: "alias_column", qualifierParts: ["b"] }));
   });
 
+  it.each([
+    ["table name", "SELECT orders.| FROM orders", ["orders"]],
+    ["schema-qualified table name", "SELECT public.orders.| FROM public.orders", ["public", "orders"]],
+  ] as const)("resolves columns through a PostgreSQL %s qualifier before FROM", (_label, markedSql, qualifierParts) => {
+    const { sql, cursor } = sqlFixtureCursor(markedSql);
+    const model = buildSqlSemanticModel(sql, cursor, { databaseType: "postgres", dialect: "postgres" });
+
+    expect(model.rowSources).toEqual(expect.arrayContaining([expect.objectContaining({ name: "orders", alias: undefined })]));
+    expect(model.cursorIntent).toEqual(expect.objectContaining({ kind: "alias_column", qualifierParts, targetSourceId: model.rowSources[0]?.id }));
+  });
+
   it("keeps nested EXISTS sources and outer correlated sources visible", () => {
     const { sql, cursor } = sqlFixtureCursor("SELECT * FROM aa.tb t WHERE EXISTS (SELECT 1 FROM aa.tb1 t1, aa.tb2 t2 WHERE t1.|)");
     const model = buildSqlSemanticModel(sql, cursor, { databaseType: "mysql", dialect: "mysql" });

--- a/apps/desktop/src/lib/sql/semantic/model.ts
+++ b/apps/desktop/src/lib/sql/semantic/model.ts
@@ -713,7 +713,7 @@ function buildCursorIntent(tokens: readonly SqlSemanticToken[], cursor: number, 
       TABLE_INTRODUCERS.has(previous) ||
       TABLE_INTRODUCERS.has(wordBeforeReplacement) ||
       TABLE_INTRODUCERS.has(wordBeforeTrailing) ||
-      (!!targetSource && !targetSource.alias && trailing.replacementRange.start <= targetSource.sourceSpan.end + 1 && TABLE_INTRODUCERS.has(wordBeforePosition(tokens, targetSource.sourceSpan.start))))
+      (!!targetSource && !targetSource.alias && trailing.replacementRange.start >= targetSource.sourceSpan.start && trailing.replacementRange.start <= targetSource.sourceSpan.end + 1 && TABLE_INTRODUCERS.has(wordBeforePosition(tokens, targetSource.sourceSpan.start))))
   ) {
     const role = dialect.qualifierRole(trailing.qualifierParts, "table");
     return { kind: role === "catalog" ? "catalog" : "table", prefix: trailing.prefix, replacementRange: trailing.replacementRange, qualifierParts: trailing.qualifierParts, expectedObjectKinds: ["table", "view"], confidence: "medium" };


### PR DESCRIPTION
## 问题

SQL 编辑器在 `SELECT orders.` 中使用完整表名限定字段时，会把该位置误判为 `FROM` 后的表名补全，因此不加载 `orders` 的字段；使用别名 `o.` 时则正常。

## 修复

- 只有补全位置确实位于 `FROM` 表名范围内时，才按表名继续补全处理
- 位于 SELECT 列表中的完整表名和 `schema.table` 限定符改为字段补全上下文
- 增加完整表名及 Schema 限定表名的语义解析和候选回归测试
- 保持 `FROM reporting.` 这类 Schema 表补全行为不变

## 验证

- PostgreSQL 16 实际编辑器验证：`codex_4813_orders.` 正确显示 4 个目标表字段
- PostgreSQL 16 实际编辑器验证：`public.codex_4813_orders.` 正确显示相同字段
- 定向测试：2 个文件、90 个用例通过
- 全量测试：1267 个测试套件、5582 个测试通过
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`（仅仓库现有警告）

Fixes #4813