### PR TITLE
fix(schema-diff): 避免失效视图 definer 导致结构比对失败

### DIFF
--- a/apps/desktop/src/components/diff/SchemaDiffDialog.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDialog.vue
@@ -18,7 +18,7 @@ import SchemaDiffOptionsPanel from "@/components/diff/SchemaDiffOptionsPanel.vue
 
 import { getSchemaDiffOptionsForDbType } from "@/lib/schema/schemaDiffOptions";
 import { buildDeployTxResult } from "@/lib/schema/deployTxResult";
-import { createConcurrencyLimiter, mapWithConcurrency, schemaDiffMetadataConcurrency, shouldFetchSchemaDiffDdl } from "@/lib/schema/schemaDiffMetadataLoad";
+import { createConcurrencyLimiter, mapWithConcurrency, schemaDiffMetadataConcurrency, schemaDiffMetadataLoadPlan } from "@/lib/schema/schemaDiffMetadataLoad";
 import { normalizeSchemaDiffCompareOptions } from "@/types/schemaDiff";
 import type { SchemaDiffCompareOptions, SchemaDiffConfig, FieldMappingEntry } from "@/types/schemaDiff";
 import type { ObjectSourceKind, TableInfo } from "@/types/database";
@@ -43,7 +43,7 @@ import {
   type PermissionDiff,
   type DependencyGraph,
 } from "@/lib/schema/schemaDiff";
-import { compileSchemaDiffTableFilter, filterSchemaDiffTables } from "@/lib/schema/schemaDiffTableFilter";
+import { compileSchemaDiffTableFilter, filterSchemaDiffTables, isSchemaDiffView } from "@/lib/schema/schemaDiffTableFilter";
 import { Splitpanes, Pane } from "splitpanes";
 import "splitpanes/dist/splitpanes.css";
 
@@ -350,23 +350,19 @@ interface SchemaDetailLoadContext {
   options: SchemaDiffCompareOptions;
 }
 
-function shouldLoadIndexes(options: SchemaDiffCompareOptions): boolean {
-  return options.indexes || options.primaryKeys || options.uniqueKeys;
-}
-
 async function loadSchemaDetails(tables: TableInfo[], context: SchemaDetailLoadContext): Promise<TableSchemaDetail[]> {
   const concurrency = schemaDiffMetadataConcurrency(context.dbType, tables.length);
   const runMetadataQuery = createConcurrencyLimiter(concurrency);
 
   return mapWithConcurrency(tables, concurrency, async (table) => {
     const objectType = isViewOrMaterializedView(table.table_type);
-    const shouldFetchDdl = shouldFetchSchemaDiffDdl(Boolean(objectType), context.options);
-    const ddlPromise = shouldFetchDdl ? runMetadataQuery(() => api.getTableDdl(context.connectionId, context.database, context.schema, table.name, objectType)) : Promise.resolve("");
+    const loadPlan = schemaDiffMetadataLoadPlan(isSchemaDiffView(table), context.options);
+    const ddlPromise = loadPlan.ddl ? runMetadataQuery(() => api.getTableDdl(context.connectionId, context.database, context.schema, table.name, objectType)) : Promise.resolve("");
     const [columns, indexes, foreignKeys, triggers, ddl] = await Promise.all([
-      runMetadataQuery(() => api.getColumns(context.connectionId, context.database, context.schema, table.name)),
-      shouldLoadIndexes(context.options) ? runMetadataQuery(() => api.listIndexes(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
-      context.options.foreignKeys ? runMetadataQuery(() => api.listForeignKeys(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
-      context.options.triggers ? runMetadataQuery(() => api.listTriggers(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
+      loadPlan.columns ? runMetadataQuery(() => api.getColumns(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
+      loadPlan.indexes ? runMetadataQuery(() => api.listIndexes(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
+      loadPlan.foreignKeys ? runMetadataQuery(() => api.listForeignKeys(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
+      loadPlan.triggers ? runMetadataQuery(() => api.listTriggers(context.connectionId, context.database, context.schema, table.name)) : Promise.resolve([]),
       ddlPromise,
     ]);
 
@@ -399,7 +395,7 @@ async function handleCompare() {
     await store.ensureConnected(targetConnectionId.value);
 
     const [srcTables, tgtTables] = await Promise.all([api.listTables(sourceConnectionId.value, sourceDatabase.value, sourceSchema.value), api.listTables(targetConnectionId.value, targetDatabase.value, targetSchema.value)]);
-    const { sourceTables, targetTables } = filterSchemaDiffTables(srcTables, tgtTables, tableFilter);
+    const { sourceTables, targetTables } = filterSchemaDiffTables(srcTables, tgtTables, tableFilter, opts);
 
     const sourceDetails = await loadSchemaDetails(sourceTables, {
       connectionId: sourceConnectionId.value,

--- a/apps/desktop/src/lib/README.md
+++ b/apps/desktop/src/lib/README.md
@@ -14,3 +14,14 @@
 - `diagram`, `document`, `export`, `imports`: feature-specific utilities that are shared by more than one component.
 
 Tests under `src/lib/__tests__` mirror the same domain folders. When moving a module, update both runtime imports and colocated tests so stale root-level aliases do not return.
+
+## Schema Diff Metadata Guardrails
+
+Schema comparison must filter disabled object types before loading metadata. Tables load columns and the relational metadata enabled by the compare options; views load DDL only.
+
+Do not call column, index, foreign-key, or trigger metadata APIs for views. MySQL 5.7 can validate a `SQL SECURITY DEFINER` view during column discovery and return error 1143 when its definer account no longer exists, even though `SHOW CREATE VIEW` still succeeds. Keep view detection centralized in `schema/schemaDiffTableFilter.ts` and preserve the DDL-only plan in `schema/schemaDiffMetadataLoad.ts`.
+
+Regression coverage belongs in:
+
+- `src/lib/__tests__/schema/schemaDiffTableFilter.spec.ts`
+- `src/lib/__tests__/schema/schemaDiffMetadataLoad.spec.ts`

--- a/apps/desktop/src/lib/__tests__/schema/schemaDiffMetadataLoad.spec.ts
+++ b/apps/desktop/src/lib/__tests__/schema/schemaDiffMetadataLoad.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createConcurrencyLimiter, mapWithConcurrency, schemaDiffMetadataConcurrency, shouldFetchSchemaDiffDdl } from "@/lib/schema/schemaDiffMetadataLoad";
+import { createConcurrencyLimiter, mapWithConcurrency, schemaDiffMetadataConcurrency, schemaDiffMetadataLoadPlan, shouldFetchSchemaDiffDdl } from "@/lib/schema/schemaDiffMetadataLoad";
 
 function wait(ms: number) {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -22,6 +22,66 @@ describe("schemaDiffMetadataLoad", () => {
     expect(shouldFetchSchemaDiffDdl(true, { tables: false, views: true })).toBe(true);
     expect(shouldFetchSchemaDiffDdl(false, { tables: false, views: true })).toBe(false);
     expect(shouldFetchSchemaDiffDdl(false, { tables: true, views: false })).toBe(true);
+  });
+
+  it("uses DDL-only metadata for views so invalid definers cannot break column discovery", () => {
+    expect(
+      schemaDiffMetadataLoadPlan(true, {
+        tables: true,
+        views: true,
+        indexes: true,
+        primaryKeys: true,
+        uniqueKeys: true,
+        foreignKeys: true,
+        triggers: true,
+      }),
+    ).toEqual({
+      columns: false,
+      indexes: false,
+      foreignKeys: false,
+      triggers: false,
+      ddl: true,
+    });
+  });
+
+  it("does not load any metadata for disabled views", () => {
+    expect(
+      schemaDiffMetadataLoadPlan(true, {
+        tables: true,
+        views: false,
+        indexes: true,
+        primaryKeys: true,
+        uniqueKeys: true,
+        foreignKeys: true,
+        triggers: true,
+      }),
+    ).toEqual({
+      columns: false,
+      indexes: false,
+      foreignKeys: false,
+      triggers: false,
+      ddl: false,
+    });
+  });
+
+  it("preserves enabled relational metadata for tables", () => {
+    expect(
+      schemaDiffMetadataLoadPlan(false, {
+        tables: true,
+        views: false,
+        indexes: false,
+        primaryKeys: true,
+        uniqueKeys: false,
+        foreignKeys: true,
+        triggers: false,
+      }),
+    ).toEqual({
+      columns: true,
+      indexes: true,
+      foreignKeys: true,
+      triggers: false,
+      ddl: true,
+    });
   });
 
   it("maps items with limited concurrency and preserves output order", async () => {

--- a/apps/desktop/src/lib/__tests__/schema/schemaDiffTableFilter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/schema/schemaDiffTableFilter.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { compileSchemaDiffTableFilter, filterSchemaDiffTables, isSchemaDiffView } from "@/lib/schema/schemaDiffTableFilter";
+import { DEFAULT_MYSQL_OPTIONS } from "@/types/schemaDiff";
+import type { TableInfo } from "@/types/database";
+
+const tables: TableInfo[] = [
+  { name: "users", table_type: "BASE TABLE" },
+  { name: "active_users", table_type: "VIEW" },
+  { name: "monthly_users", table_type: "MATERIALIZED VIEW" },
+];
+
+describe("schemaDiffTableFilter", () => {
+  it("recognizes regular and materialized views", () => {
+    expect(isSchemaDiffView(tables[0])).toBe(false);
+    expect(isSchemaDiffView(tables[1])).toBe(true);
+    expect(isSchemaDiffView(tables[2])).toBe(true);
+  });
+
+  it("completely excludes views when view comparison is disabled", () => {
+    const options = { ...DEFAULT_MYSQL_OPTIONS, tables: true, views: false };
+    const result = filterSchemaDiffTables(tables, tables, compileSchemaDiffTableFilter(options), options);
+
+    expect(result.sourceTables.map((table) => table.name)).toEqual(["users"]);
+    expect(result.targetTables.map((table) => table.name)).toEqual(["users"]);
+  });
+
+  it("completely excludes tables when table comparison is disabled", () => {
+    const options = { ...DEFAULT_MYSQL_OPTIONS, tables: false, views: true };
+    const result = filterSchemaDiffTables(tables, tables, compileSchemaDiffTableFilter(options), options);
+
+    expect(result.sourceTables.map((table) => table.name)).toEqual(["active_users", "monthly_users"]);
+    expect(result.targetTables.map((table) => table.name)).toEqual(["active_users", "monthly_users"]);
+  });
+
+  it("applies name filters after object type options", () => {
+    const options = {
+      ...DEFAULT_MYSQL_OPTIONS,
+      tables: true,
+      views: true,
+      tableIncludePattern: "users$",
+      tableExcludePattern: "^active_",
+    };
+    const result = filterSchemaDiffTables(tables, tables, compileSchemaDiffTableFilter(options), options);
+
+    expect(result.sourceTables.map((table) => table.name)).toEqual(["users", "monthly_users"]);
+  });
+});

--- a/apps/desktop/src/lib/schema/schemaDiffMetadataLoad.ts
+++ b/apps/desktop/src/lib/schema/schemaDiffMetadataLoad.ts
@@ -24,6 +24,34 @@ export function shouldFetchSchemaDiffDdl(isView: boolean, options: Pick<SchemaDi
   return isView ? options.views : options.tables;
 }
 
+export interface SchemaDiffMetadataLoadPlan {
+  columns: boolean;
+  indexes: boolean;
+  foreignKeys: boolean;
+  triggers: boolean;
+  ddl: boolean;
+}
+
+export function schemaDiffMetadataLoadPlan(isView: boolean, options: Pick<SchemaDiffCompareOptions, "tables" | "views" | "indexes" | "primaryKeys" | "uniqueKeys" | "foreignKeys" | "triggers">): SchemaDiffMetadataLoadPlan {
+  if (isView) {
+    return {
+      columns: false,
+      indexes: false,
+      foreignKeys: false,
+      triggers: false,
+      ddl: shouldFetchSchemaDiffDdl(true, options),
+    };
+  }
+
+  return {
+    columns: options.tables,
+    indexes: options.tables && (options.indexes || options.primaryKeys || options.uniqueKeys),
+    foreignKeys: options.tables && options.foreignKeys,
+    triggers: options.tables && options.triggers,
+    ddl: shouldFetchSchemaDiffDdl(false, options),
+  };
+}
+
 export async function mapWithConcurrency<T, R>(items: readonly T[], limit: number, worker: (item: T, index: number) => Promise<R>): Promise<R[]> {
   const workerCount = Math.min(normalizeConcurrencyLimit(limit), items.length);
   if (workerCount === 0) return [];

--- a/apps/desktop/src/lib/schema/schemaDiffTableFilter.ts
+++ b/apps/desktop/src/lib/schema/schemaDiffTableFilter.ts
@@ -41,9 +41,19 @@ export function matchesSchemaDiffTableFilter(tableName: string, filter: Compiled
   return includeMatches && !excludeMatches;
 }
 
-export function filterSchemaDiffTables(sourceTables: TableInfo[], targetTables: TableInfo[], filter: CompiledSchemaDiffTableFilter): FilteredSchemaDiffTables {
+export function isSchemaDiffView(table: Pick<TableInfo, "table_type">): boolean {
+  return table.table_type.toUpperCase().replace(/\s+/g, "_").includes("VIEW");
+}
+
+function isSchemaDiffObjectEnabled(table: TableInfo, options: Pick<SchemaDiffCompareOptions, "tables" | "views">): boolean {
+  return isSchemaDiffView(table) ? options.views : options.tables;
+}
+
+export function filterSchemaDiffTables(sourceTables: TableInfo[], targetTables: TableInfo[], filter: CompiledSchemaDiffTableFilter, options: Pick<SchemaDiffCompareOptions, "tables" | "views">): FilteredSchemaDiffTables {
+  const includeTable = (table: TableInfo) => isSchemaDiffObjectEnabled(table, options) && matchesSchemaDiffTableFilter(table.name, filter);
+
   return {
-    sourceTables: sourceTables.filter((table) => matchesSchemaDiffTableFilter(table.name, filter)),
-    targetTables: targetTables.filter((table) => matchesSchemaDiffTableFilter(table.name, filter)),
+    sourceTables: sourceTables.filter(includeTable),
+    targetTables: targetTables.filter(includeTable),
   };
 }

--- a/apps/desktop/src/lib/schema/schemaDiffTableFilter.ts
+++ b/apps/desktop/src/lib/schema/schemaDiffTableFilter.ts
@@ -49,7 +49,7 @@ function isSchemaDiffObjectEnabled(table: TableInfo, options: Pick<SchemaDiffCom
   return isSchemaDiffView(table) ? options.views : options.tables;
 }
 
-export function filterSchemaDiffTables(sourceTables: TableInfo[], targetTables: TableInfo[], filter: CompiledSchemaDiffTableFilter, options: Pick<SchemaDiffCompareOptions, "tables" | "views">): FilteredSchemaDiffTables {
+export function filterSchemaDiffTables(sourceTables: TableInfo[], targetTables: TableInfo[], filter: CompiledSchemaDiffTableFilter, options: Pick<SchemaDiffCompareOptions, "tables" | "views"> = { tables: true, views: true }): FilteredSchemaDiffTables {
   const includeTable = (table: TableInfo) => isSchemaDiffObjectEnabled(table, options) && matchesSchemaDiffTableFilter(table.name, filter);
 
   return {


### PR DESCRIPTION
## 变更说明

修复 MySQL 5.7 结构比对在视图 `DEFINER` 账号失效时被 `ERROR 1143` 中断的问题。

### 问题现象

在两个 MySQL 5.7 `agent` schema 之间执行结构比对时，DBX 0.5.69 报错：

```text
ERROR 1143 (42000): SELECT command denied to user ''@'%'
for column 'chat_id' in table 'custom_record'
```

错误截图：

![结构比对错误：ERROR 1143，视图字段权限校验失败](https://raw.githubusercontent.com/DASungta/dbx/8b188c80023d479c2b651610ccff8b922ba4b324/error-1143.png)

### 定位和根因

报错中虽然出现了基础表 `custom_record`，但实际失败对象是引用该字段的视图 `agent.chat_record`：

- 视图使用 `SQL SECURITY DEFINER`。
- 视图的 `DEFINER` 对应账号已经不存在。
- `SHOW CREATE VIEW` 仍可正常返回 DDL。
- DBX 调用 `getColumns` 获取视图字段时，MySQL 5.7 会校验 definer 权限，因此在 `custom_record.chat_id` 上返回 1143。

原结构比对流程在 `listTables` 返回表和视图后，会对两类对象统一加载字段、索引、外键和触发器。任意一个失效 definer 视图的字段探测失败，都会中断整个 schema 比对。

### 修复方式

1. 在元数据加载前按 `tables` / `views` 选项过滤对象类型，使这两个选项真正控制加载范围。
2. 普通表继续按选项加载字段、索引、外键、触发器和 DDL。
3. 视图改为只加载 DDL，不再调用字段、索引、外键或触发器元数据接口。
4. 普通表的元数据错误仍正常向上抛出，不做静默吞错。

当前 schema diff 核心对新增/删除视图使用 DDL，视图字段信息不参与差异计算，因此 DDL-only 不会降低现有的视图比对能力，同时可以避开 MySQL 5.7 对失效 definer 的字段权限校验。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附错误截图（见上方）

本次没有视觉样式变化，截图用于展示修复前的实际错误。

## 验证

- [x] Schema Diff 相关测试：5 个测试文件、23 项测试全部通过
- [x] 兼容性契约测试：`packages/app-tests/schemaDiffTableFilter.test.ts`
- [x] 完整前端检查：`pnpm check`（format、lint、typecheck、test）
- [x] `pnpm build`
- [x] MySQL 5.7 真实环境回归：相同源端和目标端可以进入结构差异结果页，不再出现 1143
- [x] 回归过程只执行元数据读取和差异计算，未执行生成的 DDL

新增回归测试覆盖：

- 视图识别（含物化视图）
- `tables` / `views` 对象类型过滤
- 视图 DDL-only 元数据计划
- 普通表元数据加载选项保持不变
- 元数据并发加载错误继续向上抛出

## 关联 Issue

无公开 Issue，问题来自真实 MySQL 5.7 环境复现。
