### PR TITLE
fix(sqlserver): suggest database names in query completion

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -44,7 +44,7 @@ import { buildSqlSemanticModel } from "@/lib/sql/semantic/model";
 import { mergeSqlSemanticReferenceAnalysis, resolveSqlSemanticNavigationTarget } from "@/lib/sql/semantic/references";
 import { buildElasticsearchCompletionItemsFromContext, getElasticsearchCompletionContext, getElasticsearchCompletionResultValidFor, shouldAutoOpenElasticsearchCompletion, type ElasticsearchCompletionItem } from "@/lib/elasticsearch/elasticsearchCompletion";
 import { buildMongoCompletionItemsFromContext, getMongoCompletionContext, getMongoCompletionResultValidFor, mongoCompletionNeedsCollections, mongoCompletionNeedsFields, shouldAutoOpenMongoCompletion, type MongoCompletionItem } from "@/lib/mongo/mongoCompletion";
-import { resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
 import { usesOracleSessionCompletionColumns as shouldUseOracleSessionCompletionColumns } from "@/lib/sql/oracleCompletionSession";
 import { extractIdentifierDetailsAt, isSqlKeyword, matchTable, mergeSqlObjectNavigationType, splitQualifiedIdentifier, sqlObjectHoverDetail, sqlObjectNavigationTarget, type SqlObjectNavigationTarget } from "@/lib/sql/sqlNavigation";
 import { buildHoverTableSql, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
@@ -2496,18 +2496,6 @@ function buildCompletionResult(items: QueryCompletionItem[], from: number, valid
   };
 }
 
-function mergeCompletionQualifierNames(primary: string[], secondary: string[]): string[] {
-  const seen = new Set<string>();
-  const merged: string[] = [];
-  for (const name of [...primary, ...secondary]) {
-    const key = name.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    merged.push(name);
-  }
-  return merged;
-}
-
 function localCompletionDatabaseNames(completionContext: ReturnType<typeof getSqlCompletionContext>): string[] {
   if (!supportsDatabaseNameCompletion(props.databaseType) || !completionContext.suggestTables || completionContext.insertTable || !props.connectionId) return [];
   return connectionStore.lookupLocalCompletionDatabases(props.connectionId, completionContext.qualifier || completionContext.prefix, MAX_COMPLETION_TABLES);
@@ -2526,7 +2514,7 @@ function localCompletionSchemasForDatabaseDisambiguation(completionContext: Retu
     knownDatabases: databaseNames,
   });
   if (!database) return [];
-  return mergeCompletionQualifierNames(props.schema ? [props.schema] : [], connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.qualifier, MAX_COMPLETION_TABLES));
+  return mergeSqlCompletionQualifierNames(props.schema ? [props.schema] : [], connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.qualifier, MAX_COMPLETION_TABLES));
 }
 
 function shouldInsertSqlCompletionSpace(): boolean {
@@ -2879,7 +2867,7 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
       ? schemaLookupDatabase
         ? connectionStore.lookupLocalCompletionSchemas(props.connectionId, schemaLookupDatabase, completionContext.prefix, MAX_COMPLETION_TABLES)
         : !completionContext.qualifier
-          ? mergeCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames)
+          ? mergeSqlCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames)
           : []
       : [];
 
@@ -3176,7 +3164,7 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   if (!localOnlyMetadata && supportsDatabaseNameCompletion(props.databaseType) && completionContext.suggestTables && !completionContext.insertTable && (!completionContext.qualifier || mayCompleteDatabaseSchema)) {
     const [databasesResult, schemasResult] = await Promise.allSettled([connectionStore.listCompletionDatabases(props.connectionId!), mayCompleteDatabaseSchema ? connectionStore.listCompletionSchemas(props.connectionId!, props.database!) : Promise.resolve(currentDatabaseSchemaNames)]);
     databaseNames = databasesResult.status === "fulfilled" ? databasesResult.value : [];
-    if (schemasResult.status === "fulfilled") currentDatabaseSchemaNames = mergeCompletionQualifierNames(props.schema ? [props.schema] : [], schemasResult.value);
+    if (schemasResult.status === "fulfilled") currentDatabaseSchemaNames = mergeSqlCompletionQualifierNames(props.schema ? [props.schema] : [], schemasResult.value);
     if (epoch !== completionEpoch) return null;
   }
   const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
@@ -3226,11 +3214,11 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
     const database = schemaLookupDatabase ?? props.database!;
     if (localOnlyMetadata) {
       const schemas = connectionStore.lookupLocalCompletionSchemas(props.connectionId!, database, completionContext.prefix, MAX_COMPLETION_TABLES);
-      schemaNames = schemaLookupDatabase ? schemas : mergeCompletionQualifierNames(schemas, databaseNames);
+      schemaNames = schemaLookupDatabase ? schemas : mergeSqlCompletionQualifierNames(schemas, databaseNames);
     } else {
       try {
         const schemas = await connectionStore.listCompletionSchemas(props.connectionId!, database);
-        schemaNames = schemaLookupDatabase ? schemas : mergeCompletionQualifierNames(schemas, databaseNames);
+        schemaNames = schemaLookupDatabase ? schemas : mergeSqlCompletionQualifierNames(schemas, databaseNames);
         if (epoch !== completionEpoch) return null;
       } catch {
         schemaNames = schemaLookupDatabase ? [] : databaseNames;

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -44,7 +44,7 @@ import { buildSqlSemanticModel } from "@/lib/sql/semantic/model";
 import { mergeSqlSemanticReferenceAnalysis, resolveSqlSemanticNavigationTarget } from "@/lib/sql/semantic/references";
 import { buildElasticsearchCompletionItemsFromContext, getElasticsearchCompletionContext, getElasticsearchCompletionResultValidFor, shouldAutoOpenElasticsearchCompletion, type ElasticsearchCompletionItem } from "@/lib/elasticsearch/elasticsearchCompletion";
 import { buildMongoCompletionItemsFromContext, getMongoCompletionContext, getMongoCompletionResultValidFor, mongoCompletionNeedsCollections, mongoCompletionNeedsFields, shouldAutoOpenMongoCompletion, type MongoCompletionItem } from "@/lib/mongo/mongoCompletion";
-import { resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import { resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
 import { usesOracleSessionCompletionColumns as shouldUseOracleSessionCompletionColumns } from "@/lib/sql/oracleCompletionSession";
 import { extractIdentifierDetailsAt, isSqlKeyword, matchTable, mergeSqlObjectNavigationType, splitQualifiedIdentifier, sqlObjectHoverDetail, sqlObjectNavigationTarget, type SqlObjectNavigationTarget } from "@/lib/sql/sqlNavigation";
 import { buildHoverTableSql, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
@@ -77,7 +77,7 @@ import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorS
 import { startsQueryEditorRectangularSelection } from "@/lib/editor/queryEditorPointerSelection";
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
-import { isSchemaAware, isSingleDatabase, supportsDatabaseSchemaQualifier, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
+import { isSchemaAware, isSingleDatabase, supportsDatabaseNameCompletion, supportsDatabaseSchemaQualifier, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
 import { metadataSchemaForConnection, sqlSnippetDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 import { usesLocalOnlyEditorCompletionMetadata, usesOnDemandOnlyEditorColumnMetadata } from "@/lib/metadata/completionMetadataPolicy";
 import { loadTableMetadata, type TableMetadataLoadResult } from "@/lib/metadata/tableMetadataCache";
@@ -2509,8 +2509,24 @@ function mergeCompletionQualifierNames(primary: string[], secondary: string[]): 
 }
 
 function localCompletionDatabaseNames(completionContext: ReturnType<typeof getSqlCompletionContext>): string[] {
-  if (!supportsDatabaseQualifierCompletion() || !completionContext.suggestTables || completionContext.insertTable || !props.connectionId) return [];
+  if (!supportsDatabaseNameCompletion(props.databaseType) || !completionContext.suggestTables || completionContext.insertTable || !props.connectionId) return [];
   return connectionStore.lookupLocalCompletionDatabases(props.connectionId, completionContext.qualifier || completionContext.prefix, MAX_COMPLETION_TABLES);
+}
+
+function mayCompleteDatabaseSchemaQualifier(completionContext: ReturnType<typeof getSqlCompletionContext>): boolean {
+  if (!supportsDatabaseNameCompletion(props.databaseType) || !supportsDatabaseSchemaQualifierCompletion() || !completionContext.suggestTables || completionContext.insertTable) return false;
+  return (completionContext.qualifierParts?.filter(Boolean).length ?? completionContext.qualifier?.split(".").filter(Boolean).length ?? 0) === 1;
+}
+
+function localCompletionSchemasForDatabaseDisambiguation(completionContext: ReturnType<typeof getSqlCompletionContext>, databaseNames: string[]): string[] {
+  if (!props.connectionId || props.database == null || !mayCompleteDatabaseSchemaQualifier(completionContext)) return [];
+  const database = resolveSqlCompletionSchemaLookupDatabase({
+    supportsDatabaseSchemaQualifier: true,
+    completionContext,
+    knownDatabases: databaseNames,
+  });
+  if (!database) return [];
+  return mergeCompletionQualifierNames(props.schema ? [props.schema] : [], connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.qualifier, MAX_COMPLETION_TABLES));
 }
 
 function shouldInsertSqlCompletionSpace(): boolean {
@@ -2836,7 +2852,14 @@ function shouldStartSqlCompletionAfterInput(insertedText: string, removedText: s
 function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number) {
   if (!props.connectionId || props.database == null) return null;
   const databaseNames = localCompletionDatabaseNames(completionContext);
-  const shouldLoadTables = completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext));
+  const currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames);
+  const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
+    supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
+    completionContext,
+    knownDatabases: databaseNames,
+    knownSchemas: currentDatabaseSchemaNames,
+  });
+  const shouldLoadTables = !schemaLookupDatabase && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)));
   const tableLookupTarget = resolveSqlCompletionTableLookupTarget({
     currentDatabase: props.database,
     currentSchema: props.schema,
@@ -2846,13 +2869,19 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
     knownDatabases: databaseNames,
   });
   const globalOracleTableSearch = props.databaseType === "oracle" && completionContext.suggestTables && !completionContext.qualifier;
-  const tables = shouldLoadTables ? connectionStore.lookupLocalCompletionTables(props.connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog) : cachedTables;
+  const tables = schemaLookupDatabase ? [] : shouldLoadTables ? connectionStore.lookupLocalCompletionTables(props.connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog) : cachedTables;
 
   const shouldLoadObjects = shouldLoadCompletionObjects(completionContext);
   const completionObjects = shouldLoadObjects ? lookupLocalCompletionObjectsForContext(completionContext) : cachedCompletionObjects;
 
   const schemaNames =
-    completionContext.suggestTables && !completionContext.qualifier && !completionContext.insertTable ? mergeCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames) : [];
+    completionContext.suggestTables && !completionContext.insertTable
+      ? schemaLookupDatabase
+        ? connectionStore.lookupLocalCompletionSchemas(props.connectionId, schemaLookupDatabase, completionContext.prefix, MAX_COMPLETION_TABLES)
+        : !completionContext.qualifier
+          ? mergeCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames)
+          : []
+      : [];
 
   const columnsByTable = new Map<string, SqlCompletionColumn[]>();
   if (completionContext.insertTable) {
@@ -2940,15 +2969,23 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
   const tableNameCompletion = isTableNameCompletionContext(completionContext);
   const connectionId = props.connectionId;
   const database = props.database;
+  const databaseNames = localCompletionDatabaseNames(completionContext);
+  const currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames);
+  const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
+    supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
+    completionContext,
+    knownDatabases: databaseNames,
+    knownSchemas: currentDatabaseSchemaNames,
+  });
   const tableLookupTarget = resolveSqlCompletionTableLookupTarget({
     currentDatabase: database,
     currentSchema: props.schema,
     supportsDatabaseQualifier: supportsDatabaseQualifierCompletion(),
     supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
     completionContext,
-    knownDatabases: localCompletionDatabaseNames(completionContext),
+    knownDatabases: databaseNames,
   });
-  if (!localOnlyMetadata && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)))) {
+  if (!localOnlyMetadata && !schemaLookupDatabase && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)))) {
     const globalOracleTableSearch = props.databaseType === "oracle" && completionContext.suggestTables && !completionContext.qualifier;
     void connectionStore
       .refreshCompletionTables(connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch, props.schema, props.catalog)
@@ -2971,10 +3008,14 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
       })
       .catch(() => {});
   }
-  if (!localOnlyMetadata && completionContext.suggestTables && !completionContext.qualifier && !completionContext.insertTable) {
-    void connectionStore.refreshCompletionSchemas(connectionId, database).catch(() => {});
-    if (supportsDatabaseQualifierCompletion()) {
-      void connectionStore.refreshCompletionDatabases(connectionId).catch(() => {});
+  if (!localOnlyMetadata && completionContext.suggestTables && !completionContext.insertTable) {
+    if (schemaLookupDatabase) {
+      void connectionStore.refreshCompletionSchemas(connectionId, schemaLookupDatabase).catch(() => {});
+    } else if (!completionContext.qualifier) {
+      void connectionStore.refreshCompletionSchemas(connectionId, database).catch(() => {});
+      if (supportsDatabaseNameCompletion(props.databaseType)) {
+        void connectionStore.refreshCompletionDatabases(connectionId).catch(() => {});
+      }
     }
   }
   if (!onDemandOnlyColumns && completionContext.insertTable) {
@@ -3129,16 +3170,22 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
     }
   }
 
-  const shouldLoadTables = completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext));
   let databaseNames = localCompletionDatabaseNames(completionContext);
-  if (!localOnlyMetadata && supportsDatabaseQualifierCompletion() && completionContext.suggestTables && !completionContext.insertTable && !completionContext.qualifier) {
-    try {
-      databaseNames = await connectionStore.listCompletionDatabases(props.connectionId!);
-      if (epoch !== completionEpoch) return null;
-    } catch {
-      databaseNames = [];
-    }
+  let currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames);
+  const mayCompleteDatabaseSchema = mayCompleteDatabaseSchemaQualifier(completionContext);
+  if (!localOnlyMetadata && supportsDatabaseNameCompletion(props.databaseType) && completionContext.suggestTables && !completionContext.insertTable && (!completionContext.qualifier || mayCompleteDatabaseSchema)) {
+    const [databasesResult, schemasResult] = await Promise.allSettled([connectionStore.listCompletionDatabases(props.connectionId!), mayCompleteDatabaseSchema ? connectionStore.listCompletionSchemas(props.connectionId!, props.database!) : Promise.resolve(currentDatabaseSchemaNames)]);
+    databaseNames = databasesResult.status === "fulfilled" ? databasesResult.value : [];
+    if (schemasResult.status === "fulfilled") currentDatabaseSchemaNames = mergeCompletionQualifierNames(props.schema ? [props.schema] : [], schemasResult.value);
+    if (epoch !== completionEpoch) return null;
   }
+  const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
+    supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
+    completionContext,
+    knownDatabases: databaseNames,
+    knownSchemas: currentDatabaseSchemaNames,
+  });
+  const shouldLoadTables = !schemaLookupDatabase && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)));
   const tableLookupTarget = resolveSqlCompletionTableLookupTarget({
     currentDatabase: props.database!,
     currentSchema: props.schema,
@@ -3148,11 +3195,13 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
     knownDatabases: databaseNames,
   });
   const globalOracleTableSearch = props.databaseType === "oracle" && completionContext.suggestTables && !completionContext.qualifier;
-  let tables = shouldLoadTables
-    ? localOnlyMetadata
-      ? connectionStore.lookupLocalCompletionTables(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog)
-      : await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch)
-    : cachedTables;
+  let tables = schemaLookupDatabase
+    ? []
+    : shouldLoadTables
+      ? localOnlyMetadata
+        ? connectionStore.lookupLocalCompletionTables(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog)
+        : await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch)
+      : cachedTables;
   if (localOnlyMetadata && tables.length === 0 && supportsDatabaseSchemaQualifierCompletion() && (completionContext.qualifierParts?.length ?? 0) >= 2 && allowsOnDemandQualifiedTableCompletion(completionContext.prefix)) {
     tables = await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, PRESTO_ON_DEMAND_TABLE_COMPLETION_LIMIT, tableLookupTarget.schema);
   }
@@ -3173,23 +3222,25 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
 
   // Fetch schemas for schema completion
   let schemaNames: string[] = [];
-  if (completionContext.suggestTables && !completionContext.qualifier && !completionContext.insertTable) {
+  if (completionContext.suggestTables && !completionContext.insertTable && (schemaLookupDatabase || !completionContext.qualifier)) {
+    const database = schemaLookupDatabase ?? props.database!;
     if (localOnlyMetadata) {
-      schemaNames = mergeCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames);
+      const schemas = connectionStore.lookupLocalCompletionSchemas(props.connectionId!, database, completionContext.prefix, MAX_COMPLETION_TABLES);
+      schemaNames = schemaLookupDatabase ? schemas : mergeCompletionQualifierNames(schemas, databaseNames);
     } else {
       try {
-        const schemas = await connectionStore.listCompletionSchemas(props.connectionId!, props.database!);
-        schemaNames = mergeCompletionQualifierNames(schemas, databaseNames);
+        const schemas = await connectionStore.listCompletionSchemas(props.connectionId!, database);
+        schemaNames = schemaLookupDatabase ? schemas : mergeCompletionQualifierNames(schemas, databaseNames);
         if (epoch !== completionEpoch) return null;
       } catch {
-        schemaNames = databaseNames;
+        schemaNames = schemaLookupDatabase ? [] : databaseNames;
       }
     }
   }
 
   // If qualifier didn't match any table names, try it as a schema name
   let qualifierIsSchema = false;
-  if (completionContext.qualifier && !tableLookupTarget.qualifierDatabase && !isReferencedTableQualifier(completionContext) && tables.length === 0 && (completionContext.suggestTables || completionContext.exclusiveColumnSuggestions)) {
+  if (completionContext.qualifier && !schemaLookupDatabase && !tableLookupTarget.qualifierDatabase && !isReferencedTableQualifier(completionContext) && tables.length === 0 && (completionContext.suggestTables || completionContext.exclusiveColumnSuggestions)) {
     let schemaTables = connectionStore.lookupLocalCompletionTables(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier, props.catalog);
     if (!localOnlyMetadata) {
       schemaTables = await listCompletionTablesWithLatencyBudget(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier);

--- a/apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { connectionNamespaceCreationTarget, databaseNodeNamespaceCreationTarget } from "@/lib/database/databaseNamespaceCreation";
 import { editableDatabasePropertyGroups, editableSchemaPropertyGroups } from "@/lib/database/databasePropertyEditing";
 import { buildGetDatabaseCommentSql } from "@/lib/database/dbAdminSql";
-import { isSchemaAware, supportsDatabaseSchemaQualifier, supportsSqlInListPaste, supportsTransaction } from "@/lib/database/databaseFeatureSupport";
+import { isSchemaAware, supportsDatabaseNameCompletion, supportsDatabaseSchemaQualifier, supportsSqlInListPaste, supportsTransaction } from "@/lib/database/databaseFeatureSupport";
 
 describe("schema awareness", () => {
   it("keeps SQLite database aliases separate from schema-capable databases", () => {
@@ -17,6 +17,14 @@ describe("database and schema qualifiers", () => {
 
   it.each(["mysql", "postgres", "oracle", "snowflake"] as const)("does not widen unverified three-part completion for %s", (databaseType) => {
     expect(supportsDatabaseSchemaQualifier(databaseType)).toBe(false);
+  });
+
+  it.each(["mysql", "sqlite", "sqlserver"] as const)("suggests database names for %s", (databaseType) => {
+    expect(supportsDatabaseNameCompletion(databaseType)).toBe(true);
+  });
+
+  it.each(["postgres", "oracle", "snowflake", "trino", "prestosql"] as const)("does not add database name completion for %s", (databaseType) => {
+    expect(supportsDatabaseNameCompletion(databaseType)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorDatabaseNameCompletion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorDatabaseNameCompletion.spec.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+function extractFunction(name: string): string {
+  const start = queryEditorSource.indexOf(`function ${name}(`);
+  if (start < 0) throw new Error(`Missing QueryEditor function: ${name}`);
+  const bodyStart = queryEditorSource.indexOf("{", start);
+  let depth = 0;
+  for (let index = bodyStart; index < queryEditorSource.length; index++) {
+    const character = queryEditorSource[index];
+    if (character === "{") depth++;
+    if (character === "}" && --depth === 0) return queryEditorSource.slice(start, index + 1);
+  }
+  throw new Error(`Unterminated QueryEditor function: ${name}`);
+}
+
+describe("QueryEditor database name completion wiring", () => {
+  it("uses the shared capability for local lookup, background refresh, and async loading", () => {
+    expect(extractFunction("localCompletionDatabaseNames")).toContain("supportsDatabaseNameCompletion(props.databaseType)");
+    expect(extractFunction("scheduleCompletionMetadataRefresh")).toMatch(/supportsDatabaseNameCompletion\(props\.databaseType\)[\s\S]*?refreshCompletionDatabases\(connectionId\)/);
+    expect(extractFunction("performAsyncCompletionWithResult")).toMatch(/supportsDatabaseNameCompletion\(props\.databaseType\)[\s\S]*?listCompletionDatabases\(props\.connectionId!\)/);
+  });
+
+  it("does not reuse cached tables while completing schemas inside a database", () => {
+    expect(extractFunction("buildLocalSqlCompletionResult")).toMatch(/const tables = schemaLookupDatabase\s*\?\s*\[\]/);
+    expect(extractFunction("performAsyncCompletionWithResult")).toMatch(/let tables = schemaLookupDatabase\s*\?\s*\[\]/);
+  });
+
+  it("limits database and schema disambiguation to engines with both capabilities", () => {
+    const guard = extractFunction("mayCompleteDatabaseSchemaQualifier");
+
+    expect(guard).toContain("supportsDatabaseNameCompletion(props.databaseType)");
+    expect(guard).toContain("supportsDatabaseSchemaQualifierCompletion()");
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getSqlCompletionContext } from "@/lib/sql/sqlCompletion";
-import { resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
 
 describe("sqlCompletionLookupTarget", () => {
   it("treats qualified table completion as a database lookup for MySQL-compatible engines", () => {
@@ -100,7 +100,7 @@ describe("sqlCompletionLookupTarget", () => {
   });
 
   it("routes a SQL Server database qualifier to schema completion", () => {
-    const completionContext = getSqlCompletionContext("select * from reporting.d", "select * from reporting.d".length);
+    const completionContext = getSqlCompletionContext("select * from Reporting.d", "select * from Reporting.d".length);
 
     expect(
       resolveSqlCompletionSchemaLookupDatabase({
@@ -109,6 +109,31 @@ describe("sqlCompletionLookupTarget", () => {
         completionContext,
       }),
     ).toBe("Reporting");
+  });
+
+  it("does not case-fold database qualifiers while choosing a schema scope", () => {
+    const completionContext = getSqlCompletionContext("select * from reporting.d", "select * from reporting.d".length);
+
+    expect(
+      resolveSqlCompletionSchemaLookupDatabase({
+        supportsDatabaseSchemaQualifier: true,
+        knownDatabases: ["Reporting"],
+        completionContext,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not let a case-distinct schema hide an exact database qualifier", () => {
+    const completionContext = getSqlCompletionContext("select * from reporting.d", "select * from reporting.d".length);
+
+    expect(
+      resolveSqlCompletionSchemaLookupDatabase({
+        supportsDatabaseSchemaQualifier: true,
+        knownDatabases: ["reporting"],
+        knownSchemas: ["Reporting"],
+        completionContext,
+      }),
+    ).toBe("reporting");
   });
 
   it("does not mistake a current-database schema for a database", () => {
@@ -134,6 +159,10 @@ describe("sqlCompletionLookupTarget", () => {
         completionContext,
       }),
     ).toBeUndefined();
+  });
+
+  it("keeps case-distinct database and schema completion names", () => {
+    expect(mergeSqlCompletionQualifierNames(["Reporting", "dbo"], ["reporting", "dbo"])).toEqual(["Reporting", "dbo", "reporting"]);
   });
 
   it("uses the current schema for unqualified table completion", () => {

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getSqlCompletionContext } from "@/lib/sql/sqlCompletion";
-import { resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import { resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
 
 describe("sqlCompletionLookupTarget", () => {
   it("treats qualified table completion as a database lookup for MySQL-compatible engines", () => {
@@ -97,6 +97,43 @@ describe("sqlCompletionLookupTarget", () => {
     });
 
     expect(target).toEqual({ database: "app", schema: "sales", filter: "ord" });
+  });
+
+  it("routes a SQL Server database qualifier to schema completion", () => {
+    const completionContext = getSqlCompletionContext("select * from reporting.d", "select * from reporting.d".length);
+
+    expect(
+      resolveSqlCompletionSchemaLookupDatabase({
+        supportsDatabaseSchemaQualifier: true,
+        knownDatabases: ["Default_DB", "Reporting"],
+        completionContext,
+      }),
+    ).toBe("Reporting");
+  });
+
+  it("does not mistake a current-database schema for a database", () => {
+    const completionContext = getSqlCompletionContext("select * from dbo.", "select * from dbo.".length);
+
+    expect(
+      resolveSqlCompletionSchemaLookupDatabase({
+        supportsDatabaseSchemaQualifier: true,
+        knownDatabases: ["Default_DB", "Reporting"],
+        completionContext,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("prefers a current-database schema when a database has the same name", () => {
+    const completionContext = getSqlCompletionContext("select * from dbo.", "select * from dbo.".length);
+
+    expect(
+      resolveSqlCompletionSchemaLookupDatabase({
+        supportsDatabaseSchemaQualifier: true,
+        knownDatabases: ["dbo", "Reporting"],
+        knownSchemas: ["dbo", "sales"],
+        completionContext,
+      }),
+    ).toBeUndefined();
   });
 
   it("uses the current schema for unqualified table completion", () => {

--- a/apps/desktop/src/lib/database/databaseFeatureSupport.ts
+++ b/apps/desktop/src/lib/database/databaseFeatureSupport.ts
@@ -11,6 +11,10 @@ export function supportsDatabaseSchemaQualifier(dbType?: DatabaseType): boolean 
   return !!dbType && DATABASE_SCHEMA_QUALIFIED_TYPES.has(dbType);
 }
 
+export function supportsDatabaseNameCompletion(dbType?: DatabaseType): boolean {
+  return !!dbType && ((!isSchemaAware(dbType) && !isSingleDatabase(dbType)) || dbType === "sqlserver");
+}
+
 /**
  * Doris-family engines that support multi-catalog federation (`SHOW CATALOGS`):
  * Doris (incl. SelectDB) and StarRocks. Manticore Search shares the MySQL code

--- a/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
@@ -16,6 +16,21 @@ function findExactName(names: readonly string[] | undefined, value: string): str
   return names?.find((name) => name.toLowerCase() === value.toLowerCase());
 }
 
+export function resolveSqlCompletionSchemaLookupDatabase(options: {
+  supportsDatabaseSchemaQualifier?: boolean;
+  completionContext: Pick<SqlCompletionContext, "qualifier" | "qualifierParts" | "suggestTables" | "insertTable">;
+  knownDatabases?: readonly string[];
+  knownSchemas?: readonly string[];
+}): string | undefined {
+  const { completionContext } = options;
+  if (!options.supportsDatabaseSchemaQualifier || !completionContext.suggestTables || completionContext.insertTable) return undefined;
+  const qualifier = completionContext.qualifier?.trim();
+  const qualifierParts = completionContext.qualifierParts?.filter(Boolean) ?? qualifier?.split(".").filter(Boolean) ?? [];
+  if (qualifierParts.length !== 1) return undefined;
+  if (findExactName(options.knownSchemas, qualifierParts[0]!)) return undefined;
+  return findExactName(options.knownDatabases, qualifierParts[0]!);
+}
+
 export function resolveSqlCompletionTableLookupTarget(options: {
   currentDatabase: string;
   currentSchema?: string;

--- a/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
@@ -16,6 +16,14 @@ function findExactName(names: readonly string[] | undefined, value: string): str
   return names?.find((name) => name.toLowerCase() === value.toLowerCase());
 }
 
+function findCaseSensitiveName(names: readonly string[] | undefined, value: string): string | undefined {
+  return names?.find((name) => name === value);
+}
+
+export function mergeSqlCompletionQualifierNames(primary: readonly string[], secondary: readonly string[]): string[] {
+  return [...new Set([...primary, ...secondary])];
+}
+
 export function resolveSqlCompletionSchemaLookupDatabase(options: {
   supportsDatabaseSchemaQualifier?: boolean;
   completionContext: Pick<SqlCompletionContext, "qualifier" | "qualifierParts" | "suggestTables" | "insertTable">;
@@ -27,8 +35,8 @@ export function resolveSqlCompletionSchemaLookupDatabase(options: {
   const qualifier = completionContext.qualifier?.trim();
   const qualifierParts = completionContext.qualifierParts?.filter(Boolean) ?? qualifier?.split(".").filter(Boolean) ?? [];
   if (qualifierParts.length !== 1) return undefined;
-  if (findExactName(options.knownSchemas, qualifierParts[0]!)) return undefined;
-  return findExactName(options.knownDatabases, qualifierParts[0]!);
+  if (findCaseSensitiveName(options.knownSchemas, qualifierParts[0]!)) return undefined;
+  return findCaseSensitiveName(options.knownDatabases, qualifierParts[0]!);
 }
 
 export function resolveSqlCompletionTableLookupTarget(options: {

--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -725,6 +725,32 @@ describe("connectionStore completion assistant", () => {
     expect(listDatabases).toHaveBeenCalledTimes(52);
   });
 
+  it("invalidates cached completion databases for a connection", async () => {
+    const listDatabases = vi
+      .fn()
+      .mockResolvedValueOnce([{ name: "Archive" }])
+      .mockResolvedValueOnce([{ name: "Reporting" }]);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      listDatabases,
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [sqlServerConnection()];
+    store.connectedIds.add("sqlserver-1");
+
+    expect(await store.listCompletionDatabases("sqlserver-1")).toEqual(["Archive"]);
+    expect(await store.listCompletionDatabases("sqlserver-1")).toEqual(["Archive"]);
+
+    store.invalidateCompletionCache("sqlserver-1");
+
+    expect(await store.listCompletionDatabases("sqlserver-1")).toEqual(["Reporting"]);
+    expect(listDatabases).toHaveBeenCalledTimes(2);
+  });
+
   it("evicts old completion schema entries", async () => {
     const listSchemas = vi.fn(async (_connectionId: string, database: string) => [`schema_${database}`]);
 

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -2272,6 +2272,7 @@ export const useConnectionStore = defineStore("connection", () => {
 
   function invalidateCompletionCache(connectionId: string, database?: string) {
     invalidateMetadataCaches({ connectionId, database });
+    if (database == null) delete completionDatabasesCache.value[connectionId];
     const cachePrefix = database == null ? `${connectionId}:` : `${connectionId}:${database}:`;
     const exactCacheKey = database == null ? null : `${connectionId}:${database}`;
     for (const key of Object.keys(completionTablesCache.value)) {

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -2371,6 +2371,41 @@ test("schema items include apply value with trailing dot", () => {
   assert.equal(shouldChainSqlCompletionAfterAccept({ type: "table", apply: "users" }), false);
 });
 
+test.each([
+  ["Foo", "FooDB"],
+  ["Bar", "BarDB"],
+])("suggests SQL Server database name %s as a chained qualifier", (prefix, database) => {
+  const sql = `select * from ${prefix}`;
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [],
+    columnsByTable: new Map(),
+    schemas: ["FooDB", "BarDB"],
+    databaseType: "sqlserver",
+    dialect: "sqlserver",
+  });
+  const databaseItem = items.find((item) => item.type === "schema" && item.label === database);
+
+  assert.ok(databaseItem);
+  assert.equal(databaseItem.apply, `${database}.`);
+  assert.equal(shouldChainSqlCompletionAfterAccept(databaseItem), true);
+});
+
+test("suggests SQL Server schemas after a database qualifier", () => {
+  const sql = "select * from BarDB.d";
+  const items = buildSqlCompletionItems(sql, sql.length, {
+    tables: [],
+    columnsByTable: new Map(),
+    schemas: ["dbo", "data"],
+    databaseType: "sqlserver",
+    dialect: "sqlserver",
+  });
+  const schemaItem = items.find((item) => item.type === "schema" && item.label === "dbo");
+
+  assert.ok(schemaItem);
+  assert.equal(schemaItem.apply, "dbo.");
+  assert.equal(shouldChainSqlCompletionAfterAccept(schemaItem), true);
+});
+
 // --- Quoted identifier fix ---
 
 test("handles quoted identifiers with dots in splitQualifiedName", () => {


### PR DESCRIPTION
## 变更说明

修复 SQL Server 查询编辑器已经能够解析 `database.schema.table`，但不会主动提示 Database 名称的问题。

- 为 SQL Server 启用 Database 名称补全，输入 `Foo` / `Bar` 时可提示 `FooDB` / `BarDB`。
- 选中 Database 后，继续加载并提示该 Database 下的 Schema；输入 `database.schema.` 后沿用已有逻辑提示表和视图。
- Database 与当前 Database 中的 Schema 同名时优先按 Schema 解释，避免例如名为 `dbo` 的 Database 抢占 `dbo` Schema。
- 在补全 Database 下的 Schema 时不复用上一范围的缓存表，避免跨范围候选泄漏。
- 保持现有跨库表、别名字段和 INSERT 字段补全路径不变。

### 为什么本次不同时修改 Trino / Presto

SQL Server、Trino 和 Presto 都支持三段式对象名，但首段语义和元数据策略并不相同：

- SQL Server 的首段是 Database。现有三段式查询路由和 Database 元数据接口已经具备，本 Issue 的缺口是查询编辑器没有加载并展示 Database 候选。
- Trino / Presto 的首段是 Catalog，并且查询编辑器当前对它们使用本地缓存与按需加载策略。直接打开 Database 名称补全会把 Catalog 语义绑定到 Database 候选接口，同时扩大缓存、刷新和请求行为。

因此本 PR 仅为 `sqlserver` 增加该能力，Trino / Presto 现有的显式 `catalog.schema.table` 路由保持不变。若后续需要 Catalog 名称提示，应作为独立改动，基于 Catalog 元数据能力和真实 Trino / Presto 环境补充测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动

本次不涉及视觉样式，仅调整 SQL 自动补全候选与链式加载。已在真实 SQL Server 环境手动验证；Draft 阶段待补充截图或录屏。

## 验证

- [x] `make check` 通过（format、lint、typecheck、test）
- [ ] `make cargo-check-fast`（未修改 Rust）
- [x] 相关测试通过
- [x] 手动验证 SQL Server 的 Database → Schema → Table 链式补全

覆盖的回归场景包括：

- Database 前缀补全及接受候选后的 `.` 链式补全。
- Database 后的 Schema 补全。
- Database 与 Schema 同名时优先 Schema。
- 补全 Database 下 Schema 时不泄漏旧的缓存表候选。
- Trino / Presto 不启用本次新增的 Database 名称补全能力。

## 关联 Issue

Closes #4848
