### PR TITLE
fix: 修复小窗口连接弹窗无法滚动

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -4812,8 +4812,8 @@ function openExternalUrl(url: string) {
               </TabsList>
             </div>
 
-            <TabsContent value="connection" class="m-0 min-h-0 flex-1 overflow-hidden">
-              <div class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto pt-4 pr-2 pb-2">
+            <TabsContent value="connection" class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div class="connection-form-body grid min-h-0 flex-1 gap-4 overflow-y-auto pt-4 pr-2 pb-2">
                 <div v-if="!isJdbcConnection && form.db_type !== 'nacos'" class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelClass">{{ t("connection.connectionUrlOptional") }}</Label>
                   <div class="col-span-3 flex items-center gap-1">
@@ -6251,8 +6251,8 @@ function openExternalUrl(url: string) {
               </div>
             </TabsContent>
 
-            <TabsContent v-if="supportsTlsToggle" value="tls" class="m-0 min-h-0 flex-1 overflow-hidden">
-              <div class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto overflow-x-hidden pt-4 pr-2">
+            <TabsContent v-if="supportsTlsToggle" value="tls" class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div class="connection-form-body grid min-h-0 flex-1 gap-4 overflow-y-auto overflow-x-hidden pt-4 pr-2">
                 <div v-if="!supportsPostgresTlsOptions && !supportsMysqlTlsOptions" class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelSmallClass">SSL/TLS</Label>
                   <label class="col-span-3 flex items-center gap-2 cursor-pointer">
@@ -6551,8 +6551,8 @@ function openExternalUrl(url: string) {
               </div>
             </TabsContent>
 
-            <TabsContent value="advanced" class="m-0 min-h-0 flex-1 overflow-hidden">
-              <div class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto pt-4 pr-2">
+            <TabsContent value="advanced" class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div class="connection-form-body grid min-h-0 flex-1 gap-4 overflow-y-auto pt-4 pr-2">
                 <div v-if="showGaussdbIdentifierQuoteStyle" class="grid grid-cols-4 items-start gap-4">
                   <Label :class="connectionLabelSmallPaddedClass">{{ t("connection.gaussdbIdentifierQuoteStyle") }}</Label>
                   <div class="col-span-3 grid gap-1">
@@ -6654,8 +6654,8 @@ function openExternalUrl(url: string) {
               </div>
             </TabsContent>
 
-            <TabsContent v-if="canUseTransportLayers" value="transport" class="m-0 min-h-0 flex-1 overflow-hidden">
-              <div class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto overflow-x-hidden pt-4 pr-2">
+            <TabsContent v-if="canUseTransportLayers" value="transport" class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div class="connection-form-body grid min-h-0 flex-1 gap-4 overflow-y-auto overflow-x-hidden pt-4 pr-2">
                 <div class="connection-label-wide-grid grid min-w-0 grid-cols-4 items-start gap-4">
                   <Label :class="connectionLabelSmallPaddedClass">{{ t("connection.sshHops") }}</Label>
                   <div class="col-span-3 grid min-w-0 gap-3">

--- a/apps/desktop/src/lib/__tests__/connection/connectionDialogScrolling.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionDialogScrolling.spec.ts
@@ -4,14 +4,16 @@ import { describe, expect, it } from "vitest";
 const dialogSource = readFileSync(new URL("../../../components/connection/ConnectionDialog.vue", import.meta.url), "utf8");
 
 describe("connection dialog scrolling", () => {
-  it("gives the configuration step a definite viewport-constrained height", () => {
+  it("keeps every configuration tab inside a shrinkable form viewport", () => {
     expect(dialogSource).toContain("return `${widthClass} connection-dialog-content--config`;");
-    expect(dialogSource).toMatch(/\.connection-dialog-content--config\s*\{[\s\S]*?min-height:\s*0;[\s\S]*?@media \(max-height: 720px\)[\s\S]*?height:\s*calc\(var\(--dbx-viewport-height\) - 2rem\);/);
+    expect(dialogSource.match(/<TabsContent[^>]*class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">/g)).toHaveLength(4);
+    expect(dialogSource.match(/class="connection-form-body grid min-h-0 flex-1 gap-4 overflow-y-auto/g)).toHaveLength(4);
+    expect(dialogSource).toMatch(/@media \(max-height: 720px\)[\s\S]*?height:\s*calc\(var\(--dbx-viewport-height\) - 2rem\);/);
     expect(dialogSource).toMatch(/\.connection-dialog-content--config \.connection-form-body\s*\{[\s\S]*?align-content:\s*start;/);
   });
 
   it("keeps the transport form inside a shrinkable scroll viewport", () => {
-    expect(dialogSource).toContain('<TabsContent v-if="canUseTransportLayers" value="transport" class="m-0 min-h-0 flex-1 overflow-hidden">');
-    expect(dialogSource).toContain('class="connection-form-body grid h-full min-h-0 gap-4 overflow-y-auto overflow-x-hidden pt-4 pr-2"');
+    expect(dialogSource).toContain('<TabsContent v-if="canUseTransportLayers" value="transport" class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">');
+    expect(dialogSource).toContain('class="connection-form-body grid min-h-0 flex-1 gap-4 overflow-y-auto overflow-x-hidden pt-4 pr-2"');
   });
 });


### PR DESCRIPTION
## 问题

缩小 DBX 窗口高度后，Nacos 编辑连接弹窗的表单会被裁切，且无法通过滚轮访问底部配置项。实际复现中，窗口高度为 740px 时，表单外层仅有 528px 可用高度，但内部表单仍按 898px 展开，并被 `overflow-hidden` 裁切。

## 修复

- 将连接信息、TLS、高级和隧道/代理四个配置页统一改为可收缩的纵向 flex 布局
- 让表单区域通过 `flex-1` 获取真实可用高度并承担纵向滚动
- 保留原有 720px 以下固定弹窗高度规则，避免改变小窗口标签切换体验
- 补充滚动布局回归测试，覆盖全部四个配置页

## 验证

- 1000x740 窗口：Nacos 表单视口 528px、内容 898px，滚轮可滚动至底部，标题和操作按钮保持可见
- 1000x520 窗口：表单可滚动至最大 590px，底部测试/保存按钮完整可见
- 全量前端测试：657 个测试文件、5689 项测试全部通过
- `pnpm typecheck` 通过
- `pnpm build` 通过
- `pnpm lint` 通过（仅保留仓库现有警告）
- 格式检查和 `git diff --check` 通过