### PR TITLE
Fix：修复 Kingbase 表结构兼容和字段改名刷新异常

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -478,17 +478,25 @@ func (s *server) queryCatalogColumns(
 	primary map[string]bool,
 	catalog, prefix, expression string,
 ) ([]columnInfo, error) {
+	identityExpression := "a.attidentity"
+	if s.catalogIdentityUnsupported {
+		identityExpression = "CAST(NULL AS varchar(1)) AS attidentity"
+	}
 	query := fmt.Sprintf(`SELECT a.attname, format_type(a.atttypid, a.atttypmod), NOT a.attnotnull,
 	%s(ad.adbin, ad.adrelid), col_description(a.attrelid, a.attnum),
 	CASE WHEN t.typname = 'numeric' AND a.atttypmod > 0 THEN ((a.atttypmod - 4) >> 16) & 65535 END,
 	CASE WHEN t.typname = 'numeric' AND a.atttypmod > 0 THEN (a.atttypmod - 4) & 65535 END,
 	CASE WHEN t.typname IN ('varchar','bpchar') AND a.atttypmod > 0 THEN a.atttypmod - 4 END,
-	a.attidentity
+	%s
 	FROM %s.%s_attribute a JOIN %s.%s_type t ON t.oid = a.atttypid
 	JOIN %s.%s_class c ON c.oid = a.attrelid JOIN %s.%s_namespace n ON n.oid = c.relnamespace
 	LEFT JOIN %s.%s_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
-WHERE n.nspname = %s AND c.relname = %s AND a.attnum > 0 AND NOT a.attisdropped ORDER BY a.attnum`, expression, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, quoteLiteral(schema), quoteLiteral(table))
+WHERE n.nspname = %s AND c.relname = %s AND a.attnum > 0 AND NOT a.attisdropped ORDER BY a.attnum`, expression, identityExpression, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, quoteLiteral(schema), quoteLiteral(table))
 	rows, err := s.metadataQuery(query)
+	if err != nil && !s.catalogIdentityUnsupported && isUndefinedColumn(err, "attidentity") {
+		s.catalogIdentityUnsupported = true
+		return s.queryCatalogColumns(schema, table, primary, catalog, prefix, expression)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -519,6 +527,14 @@ func isUndefinedFunction(err error, functionName string) bool {
 	normalized := strings.ToLower(err.Error())
 	undefined = undefined || strings.Contains(normalized, "does not exist") || strings.Contains(normalized, "不存在")
 	return undefined && strings.Contains(normalized, strings.ToLower(functionName))
+}
+
+func isUndefinedColumn(err error, columnName string) bool {
+	var driverError *gokb.Error
+	undefined := errors.As(err, &driverError) && string(driverError.Code) == "42703"
+	normalized := strings.ToLower(err.Error())
+	undefined = undefined || strings.Contains(normalized, "does not exist") || strings.Contains(normalized, "不存在")
+	return undefined && strings.Contains(normalized, strings.ToLower(columnName))
 }
 
 func (s *server) informationSchemaColumns(schema, table string, primary map[string]bool) ([]columnInfo, error) {

--- a/agents/drivers/kingbase-go/main.go
+++ b/agents/drivers/kingbase-go/main.go
@@ -129,17 +129,18 @@ type querySession struct {
 }
 
 type server struct {
-	db                     *sql.DB
-	openDatabase           kingbaseDBOpener
-	params                 connectParams
-	mode                   kingbaseMode
-	usePgDefaultExpression bool
-	currentSchema          string
-	schemaSet              bool
-	sessions               map[string]*querySession
-	nextSessionID          uint64
-	activeCancelMu         sync.Mutex
-	activeCancel           context.CancelFunc
+	db                         *sql.DB
+	openDatabase               kingbaseDBOpener
+	params                     connectParams
+	mode                       kingbaseMode
+	usePgDefaultExpression     bool
+	catalogIdentityUnsupported bool
+	currentSchema              string
+	schemaSet                  bool
+	sessions                   map[string]*querySession
+	nextSessionID              uint64
+	activeCancelMu             sync.Mutex
+	activeCancel               context.CancelFunc
 }
 
 type agentSession struct {
@@ -453,6 +454,7 @@ func (s *server) connect(cp connectParams) error {
 	s.params = cp
 	s.mode = detectKingbaseMode(db, cp.MySQLCompatMode)
 	s.usePgDefaultExpression = false
+	s.catalogIdentityUnsupported = false
 	return nil
 }
 
@@ -513,14 +515,15 @@ func openDBWithSSLMode(cp connectParams, sslMode string) (*sql.DB, error) {
 func (s *server) disconnect() error {
 	s.cancelActiveQuery()
 	s.closeAllQuerySessions()
+	s.usePgDefaultExpression = false
+	s.catalogIdentityUnsupported = false
+	s.currentSchema = ""
+	s.schemaSet = false
 	if s.db == nil {
 		return nil
 	}
 	err := s.db.Close()
 	s.db = nil
-	s.usePgDefaultExpression = false
-	s.currentSchema = ""
-	s.schemaSet = false
 	return err
 }
 

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -48,8 +48,9 @@ type fakeRows struct {
 }
 
 type fallbackDriverState struct {
-	mu      sync.Mutex
-	queries []string
+	mu                sync.Mutex
+	queries           []string
+	rejectAttidentity bool
 }
 
 type fallbackDriver struct{}
@@ -207,13 +208,20 @@ func (connection *fallbackConn) QueryContext(_ context.Context, query string, _ 
 			rows:    [][]driver.Value{{"id", "integer", "NO", nil, "primary key", int64(32), int64(0), nil}},
 		}, nil
 	}
+	if connection.state.rejectAttidentity && strings.Contains(query, "a.attidentity") {
+		return nil, &gokb.Error{Code: gokb.ErrorCode("42703"), Message: "column a.attidentity does not exist"}
+	}
 	if strings.Contains(query, "sys_get_expr(") {
 		return nil, &gokb.Error{Code: gokb.ErrorCode("42883"), Message: "function sys_get_expr(pg_node_tree, oid) does not exist"}
 	}
 	if strings.Contains(query, "pg_get_expr(") {
+		var identity driver.Value = "d"
+		if strings.Contains(query, "CAST(NULL AS varchar(1)) AS attidentity") {
+			identity = nil
+		}
 		return &valueRows{
 			columns: []string{"column_name", "data_type", "is_nullable", "column_default", "column_comment", "numeric_precision", "numeric_scale", "character_maximum_length", "attidentity"},
-			rows:    [][]driver.Value{{"id", "integer", false, nil, nil, int64(32), int64(0), nil, "d"}},
+			rows:    [][]driver.Value{{"id", "integer", false, nil, nil, int64(32), int64(0), nil, identity}},
 		}, nil
 	}
 	return nil, errors.New("unexpected query: " + query)
@@ -903,6 +911,51 @@ func TestColumnsFallbackToPgGetExprAndCacheChoice(t *testing.T) {
 	}
 	if sysCalls != 1 || pgCalls != 2 {
 		t.Fatalf("fallback choice was not cached: sys=%d pg=%d queries=%v", sysCalls, pgCalls, state.queries)
+	}
+}
+
+func TestColumnsFallbackWhenCatalogHasNoAttidentityAndCacheChoice(t *testing.T) {
+	registerExpressionFallbackDriver.Do(func() { sql.Register("kingbase-expression-fallback-test", fallbackDriver{}) })
+	state := &fallbackDriverState{rejectAttidentity: true}
+	expressionFallbackState.Store(state)
+	db, err := sql.Open("kingbase-expression-fallback-test", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	server := newServer()
+	server.db = db
+
+	for call := 0; call < 2; call++ {
+		columns, err := server.getColumns("public", "orders")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(columns) != 1 || columns[0].Extra != nil {
+			t.Fatalf("unexpected columns: %#v", columns)
+		}
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	var identityCalls, compatibleCalls, sysCalls, pgCalls int
+	for _, query := range state.queries {
+		if strings.Contains(query, "a.attidentity") {
+			identityCalls++
+		}
+		if strings.Contains(query, "CAST(NULL AS varchar(1)) AS attidentity") {
+			compatibleCalls++
+		}
+		if strings.Contains(query, "sys_get_expr(") {
+			sysCalls++
+		}
+		if strings.Contains(query, "pg_get_expr(") {
+			pgCalls++
+		}
+	}
+	if identityCalls != 1 || compatibleCalls != 3 || sysCalls != 2 || pgCalls != 2 {
+		t.Fatalf("fallback choices were not cached: identity=%d compatible=%d sys=%d pg=%d queries=%v", identityCalls, compatibleCalls, sysCalls, pgCalls, state.queries)
 	}
 }
 

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -205,7 +205,7 @@ import { useTheme } from "@/composables/useTheme";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import { simpleDataGridOrderByReferencesMissingColumn, type DataGridSortDirection, type DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
+import { simpleDataGridOrderByMatchesSort, simpleDataGridOrderByReferencesMissingColumn, type DataGridSortDirection, type DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
 import { DATA_GRID_COMPACT_TOPBAR_WIDTH, type DataGridReloadIntent, type DataGridToolbarActionCapability, type DataGridToolbarAutoRefreshCapability, type DataGridToolbarCopyCapability, type DataGridToolbarSaveCapability } from "@/lib/dataGrid/dataGridToolbar";
 import { getTableMetadataCapabilities } from "@/lib/table/tableMetadataCapabilities";
 import { getTableStructureCapabilities } from "@/lib/table/tableStructureCapabilities";
@@ -2588,12 +2588,12 @@ function syncOrderByInputWithSort(column: string | null, direction: "asc" | "des
 watch(
   () => [props.sortColumn, props.sortColumnIndex, props.sortDirection, props.sortMode] as const,
   ([column, columnIndex, direction, mode], previous) => {
-    const wasControlledSort = !!previous?.[0] && !!previous?.[2];
+    const previousOrderWasControlled = previous?.[3] === "database" && simpleDataGridOrderByMatchesSort(orderByInput.value, previous[0], previous[2]);
     const isControlledSort = !!column && !!direction;
     setSort(column && direction ? column : null, typeof columnIndex === "number" && direction ? columnIndex : null, direction ?? "asc", mode ?? "database");
     if (isControlledSort && sortMode.value === "database") {
       syncOrderByInputWithSort(sortCol.value, sortDir.value);
-    } else if (wasControlledSort) {
+    } else if (previousOrderWasControlled) {
       syncOrderByInputWithSort(null, null);
     }
   },

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -205,7 +205,7 @@ import { useTheme } from "@/composables/useTheme";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
-import type { DataGridSortDirection, DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
+import { simpleDataGridOrderByReferencesMissingColumn, type DataGridSortDirection, type DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
 import { DATA_GRID_COMPACT_TOPBAR_WIDTH, type DataGridReloadIntent, type DataGridToolbarActionCapability, type DataGridToolbarAutoRefreshCapability, type DataGridToolbarCopyCapability, type DataGridToolbarSaveCapability } from "@/lib/dataGrid/dataGridToolbar";
 import { getTableMetadataCapabilities } from "@/lib/table/tableMetadataCapabilities";
 import { getTableStructureCapabilities } from "@/lib/table/tableStructureCapabilities";
@@ -1629,6 +1629,23 @@ function clearOrderByInput() {
 watch(orderByInput, (value) => {
   emit("update:orderByInput", value);
 });
+
+watch(
+  () => props.initialOrderByInput ?? "",
+  (value) => {
+    if (value !== orderByInput.value) orderByInput.value = value;
+  },
+);
+
+watch(
+  () => props.tableMeta?.columns.map((column) => column.name),
+  (columns) => {
+    if (!columns?.length || !simpleDataGridOrderByReferencesMissingColumn(orderByInput.value, columns)) return;
+    clearSort();
+    orderByInput.value = "";
+  },
+  { immediate: true },
+);
 
 const isApplyingWhere = ref(false);
 const rowStatusFilter = ref<RowStatusFilter>("all");

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1166,7 +1166,7 @@ function onKeydown(event: KeyboardEvent) {
               @keydown.escape.prevent="isRenamingGroup = false"
               @click.stop
             />
-            <span v-else ref="labelRef" :class="labelWidthClass">{{ visibleLabel(node) }}</span>
+            <span v-else ref="labelRef" :class="[labelWidthClass, { 'flex-1': node.type === 'connection' }]">{{ visibleLabel(node) }}</span>
             <button
               v-if="canDragPinnedOrder()"
               type="button"

--- a/apps/desktop/src/composables/__tests__/useDataGridActions.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridActions.spec.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   tableOpenPageSize: 100,
   tabs: [] as QueryTab[],
   setTableMeta: vi.fn(),
+  clearInvalidDataTabSort: vi.fn(),
 }));
 
 vi.mock("vue-i18n", () => ({
@@ -47,6 +48,21 @@ vi.mock("@/stores/queryStore", () => ({
     setExecuting: mocks.setExecuting,
     updateSql: mocks.updateSql,
     tabs: mocks.tabs,
+    clearInvalidDataTabSort: mocks.clearInvalidDataTabSort.mockImplementation((id: string) => {
+      const tab = mocks.tabs.find((item) => item.id === id);
+      if (!tab?.tableMeta?.columns.length) return false;
+      const simpleOrderColumn = tab.orderByInput?.match(/^"([^"]+)"\s+(?:ASC|DESC)$/i)?.[1];
+      const staleSort = !!tab.resultSortColumn && !tab.tableMeta.columns.some((column) => column.name === tab.resultSortColumn);
+      const staleOrder = !!simpleOrderColumn && !tab.tableMeta.columns.some((column) => column.name === simpleOrderColumn);
+      if (!staleSort && !staleOrder) return false;
+      tab.resultSortColumn = undefined;
+      tab.resultSortColumnIndex = undefined;
+      tab.resultSortDirection = undefined;
+      tab.resultSortMode = undefined;
+      tab.resultSortedSql = undefined;
+      tab.orderByInput = undefined;
+      return true;
+    }),
     setTableMeta: mocks.setTableMeta.mockImplementation((id: string, meta: NonNullable<QueryTab["tableMeta"]>) => {
       const tab = mocks.tabs.find((item) => item.id === id);
       if (tab) {
@@ -137,6 +153,59 @@ describe("useDataGridActions", () => {
     expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ limit: 25, offset: 50 }));
     expect(mocks.executeTabSql).toHaveBeenCalledWith("tab-1", "SELECT * FROM public.users LIMIT 25 OFFSET 50", expect.objectContaining({ pagination: { limit: 25, offset: 50 } }));
     expect(mocks.executeTabSql.mock.calls[0]?.[2]).not.toHaveProperty("preserveTotalRowCountDuringExecution");
+  });
+
+  it("ignores a stale structured order when its column was renamed", async () => {
+    const tab = tableDataTab({
+      resultSortColumn: "old_name",
+      resultSortColumnIndex: 1,
+      resultSortDirection: "asc",
+      resultSortMode: "database",
+      orderByInput: '"old_name" ASC',
+      tableMeta: {
+        schema: "public",
+        tableName: "users",
+        tableType: "TABLE",
+        columns: [
+          { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+          { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+        ],
+        primaryKeys: ["id"],
+      },
+    });
+    mocks.tabs.push(tab);
+    const actions = useDataGridActions(computed(() => tab));
+
+    await actions.onReloadData(tab.sql, "", "", '"old_name" ASC', undefined, undefined, "refresh");
+
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }));
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.resultSortDirection).toBeUndefined();
+    expect(tab.orderByInput).toBeUndefined();
+  });
+
+  it("ignores a stale order emitted by a mounted grid after the stored sort was cleared", async () => {
+    const tab = tableDataTab({
+      orderByInput: undefined,
+      tableMeta: {
+        schema: "public",
+        tableName: "users",
+        tableType: "TABLE",
+        columns: [
+          { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+          { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+        ],
+        primaryKeys: ["id"],
+      },
+    });
+    mocks.tabs.push(tab);
+    const actions = useDataGridActions(computed(() => tab));
+
+    await actions.onReloadData(tab.sql, "", "", '"old_name" ASC', undefined, undefined, "refresh");
+
+    expect(mocks.clearInvalidDataTabSort).toHaveReturnedWith(false);
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }));
+    expect(tab.orderByInput).toBeUndefined();
   });
 
   it("keeps SQL result toolbar reload free of table pagination defaults", async () => {

--- a/apps/desktop/src/composables/__tests__/useDataGridActions.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridActions.spec.ts
@@ -55,12 +55,14 @@ vi.mock("@/stores/queryStore", () => ({
       const staleSort = !!tab.resultSortColumn && !tab.tableMeta.columns.some((column) => column.name === tab.resultSortColumn);
       const staleOrder = !!simpleOrderColumn && !tab.tableMeta.columns.some((column) => column.name === simpleOrderColumn);
       if (!staleSort && !staleOrder) return false;
-      tab.resultSortColumn = undefined;
-      tab.resultSortColumnIndex = undefined;
-      tab.resultSortDirection = undefined;
-      tab.resultSortMode = undefined;
-      tab.resultSortedSql = undefined;
-      tab.orderByInput = undefined;
+      if (staleSort) {
+        tab.resultSortColumn = undefined;
+        tab.resultSortColumnIndex = undefined;
+        tab.resultSortDirection = undefined;
+        tab.resultSortMode = undefined;
+        tab.resultSortedSql = undefined;
+      }
+      if (staleOrder) tab.orderByInput = undefined;
       return true;
     }),
     setTableMeta: mocks.setTableMeta.mockImplementation((id: string, meta: NonNullable<QueryTab["tableMeta"]>) => {
@@ -206,6 +208,35 @@ describe("useDataGridActions", () => {
     expect(mocks.clearInvalidDataTabSort).toHaveReturnedWith(false);
     expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }));
     expect(tab.orderByInput).toBeUndefined();
+  });
+
+  it("keeps a manual order when only residual structured sort state is stale", async () => {
+    const tab = tableDataTab({
+      resultSortColumn: "old_name",
+      resultSortColumnIndex: 1,
+      resultSortDirection: "asc",
+      resultSortMode: "database",
+      orderByInput: "LOWER(new_name) ASC",
+      tableMeta: {
+        schema: "public",
+        tableName: "users",
+        tableType: "TABLE",
+        columns: [
+          { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+          { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+        ],
+        primaryKeys: ["id"],
+      },
+    });
+    mocks.tabs.push(tab);
+    const actions = useDataGridActions(computed(() => tab));
+
+    await actions.onReloadData(tab.sql, "", "", "LOWER(new_name) ASC", undefined, undefined, "refresh");
+
+    expect(mocks.clearInvalidDataTabSort).toHaveReturnedWith(true);
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ orderBy: "LOWER(new_name) ASC" }));
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.orderByInput).toBe("LOWER(new_name) ASC");
   });
 
   it("keeps SQL result toolbar reload free of table pagination defaults", async () => {

--- a/apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts
@@ -192,4 +192,56 @@ describe("useNavigationTargets with the real query store", () => {
     expect(queryStore.createTab("connection-1", "app", "public.orders", "data", "public")).not.toBe(base);
     expect(queryStore.createTab("connection-1", "app", "public.users", "data", "public", undefined, undefined, { forceNew: true })).not.toBe(base);
   });
+
+  it("clears a renamed column sort when structure-save metadata reaches an open data tab", async () => {
+    const { navigation, queryStore } = await setupNavigation();
+    const dataTabId = queryStore.createTab("connection-1", "app", "public.users", "data", "public");
+    queryStore.setTableMeta(dataTabId, {
+      database: "app",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "old_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+    const dataTab = queryStore.tabs.find((tab) => tab.id === dataTabId)!;
+    dataTab.resultSortColumn = "old_name";
+    dataTab.resultSortColumnIndex = 1;
+    dataTab.resultSortDirection = "asc";
+    dataTab.resultSortMode = "database";
+    dataTab.orderByInput = '"old_name" ASC';
+    queryStore.createTab("connection-1", "app", "Edit users", "structure", "public", "users", undefined, { forceNew: true });
+    mocks.loadTableMetadata.mockResolvedValueOnce({
+      metadata: {
+        database: "app",
+        schema: "public",
+        tableName: "users",
+        tableType: "TABLE",
+        columns: [
+          { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+          { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+        ],
+        indexes: [],
+        primaryKeys: ["id"],
+        cachedAt: Date.now(),
+      },
+      cacheStatus: "miss",
+      ageMs: 0,
+    });
+
+    await navigation.onStructureEditorSaved(vi.fn().mockResolvedValue(undefined), vi.fn(), {
+      connectionId: "connection-1",
+      database: "app",
+      schema: "public",
+      tableName: "users",
+    });
+
+    expect(dataTab.tableMeta?.columns.map((column) => column.name)).toEqual(["id", "new_name"]);
+    expect(dataTab.tableMeta?.schema).toBe("public");
+    expect(dataTab.resultSortColumn).toBeUndefined();
+    expect(dataTab.resultSortDirection).toBeUndefined();
+    expect(dataTab.orderByInput).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/composables/useDataGridActions.ts
+++ b/apps/desktop/src/composables/useDataGridActions.ts
@@ -14,7 +14,7 @@ import { effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from 
 import { loadTableMetadata, TABLE_METADATA_CACHE_TTL_MS } from "@/lib/metadata/tableMetadataCache";
 import { applyMongoFindSort } from "@/lib/mongo/mongoShellCommand";
 import { uuid } from "@/lib/common/utils";
-import type { DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
+import { simpleDataGridOrderByReferencesMissingColumn, type DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
 import type { DataGridReloadIntent } from "@/lib/dataGrid/dataGridToolbar";
 import { queryResultBaseSql, queryResultExecutionSql } from "@/lib/tabs/tabPresentation";
 
@@ -137,6 +137,10 @@ export function useDataGridActions(activeTab: ComputedRef<QueryTab | undefined>)
     const elapsed = () => `${Math.round(performance.now() - startedAt)}ms`;
     if (tab.mode === "data" && tableMetaForDataTab(tab)) {
       tab.whereInput = whereInput ?? "";
+      const invalidStoredSortCleared = queryStore.clearInvalidDataTabSort(tab.id);
+      const realColumnNames = tab.tableMeta?.columns.map((column) => column.name) ?? [];
+      const incomingSortMissing = realColumnNames.length > 0 && simpleDataGridOrderByReferencesMissingColumn(orderBy, realColumnNames);
+      if (incomingSortMissing) tab.orderByInput = undefined;
       const pageLimit = limit ?? tab.resultPageLimit ?? tableOpenPageLimit(settingsStore.editorSettings.tableOpenPageSize);
       const pageOffset = offset ?? 0;
       console.info("[DBX][reloadData:start]", {
@@ -179,7 +183,7 @@ export function useDataGridActions(activeTab: ComputedRef<QueryTab | undefined>)
       }
       try {
         console.info("[DBX][reloadData:build-sql:start]", { traceId, elapsed: elapsed() });
-        const nextSql = await buildTableSql(tab, { whereInput, orderBy, limit: pageLimit, offset: pageOffset });
+        const nextSql = await buildTableSql(tab, { whereInput, orderBy: invalidStoredSortCleared || incomingSortMissing ? undefined : orderBy, limit: pageLimit, offset: pageOffset });
         console.info("[DBX][reloadData:build-sql:done]", { traceId, elapsed: elapsed() });
         queryStore.updateSql(tab.id, nextSql);
         console.info("[DBX][reloadData:execute:start]", { traceId, elapsed: elapsed() });

--- a/apps/desktop/src/composables/useDataGridActions.ts
+++ b/apps/desktop/src/composables/useDataGridActions.ts
@@ -137,7 +137,7 @@ export function useDataGridActions(activeTab: ComputedRef<QueryTab | undefined>)
     const elapsed = () => `${Math.round(performance.now() - startedAt)}ms`;
     if (tab.mode === "data" && tableMetaForDataTab(tab)) {
       tab.whereInput = whereInput ?? "";
-      const invalidStoredSortCleared = queryStore.clearInvalidDataTabSort(tab.id);
+      queryStore.clearInvalidDataTabSort(tab.id);
       const realColumnNames = tab.tableMeta?.columns.map((column) => column.name) ?? [];
       const incomingSortMissing = realColumnNames.length > 0 && simpleDataGridOrderByReferencesMissingColumn(orderBy, realColumnNames);
       if (incomingSortMissing) tab.orderByInput = undefined;
@@ -183,7 +183,7 @@ export function useDataGridActions(activeTab: ComputedRef<QueryTab | undefined>)
       }
       try {
         console.info("[DBX][reloadData:build-sql:start]", { traceId, elapsed: elapsed() });
-        const nextSql = await buildTableSql(tab, { whereInput, orderBy: invalidStoredSortCleared || incomingSortMissing ? undefined : orderBy, limit: pageLimit, offset: pageOffset });
+        const nextSql = await buildTableSql(tab, { whereInput, orderBy: incomingSortMissing ? undefined : orderBy, limit: pageLimit, offset: pageOffset });
         console.info("[DBX][reloadData:build-sql:done]", { traceId, elapsed: elapsed() });
         queryStore.updateSql(tab.id, nextSql);
         console.info("[DBX][reloadData:execute:start]", { traceId, elapsed: elapsed() });

--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -286,7 +286,7 @@ export function useNavigationTargets(dialogs: { showFieldLineageDialog: { value:
     // 其它 loadTableMetadata 消费者最长 30 秒拿到旧列。不带 schema/catalog
     // 维度（宁可多废，schema 形态在各消费点可能不同）
     invalidateTableMetadataCache({ connectionId: context.connectionId, database: context.database, tableName: context.tableName });
-    const matchingDataTabs = queryStore.tabs.filter((tab) => tab.mode === "data" && tab.connectionId === context.connectionId && tab.database === context.database && tab.tableMeta?.tableName === context.tableName && (tab.tableMeta.schema || "") === (context.schema || ""));
+    const matchingDataTabs = queryStore.tabs.filter((tab) => tab.mode === "data" && tab.connectionId === context.connectionId && tab.database === context.database && tab.tableMeta?.tableName === context.tableName && (tab.schema || tab.tableMeta.schema || "") === (context.schema || ""));
     // 同一 catalog 只强制加载一次，结果分发给全部匹配 tab
     const loadedByCatalog = new Map<string, { columns: ColumnInfo[]; primaryKeys: string[] }>();
     for (const tab of matchingDataTabs) {
@@ -295,8 +295,9 @@ export function useNavigationTargets(dialogs: { showFieldLineageDialog: { value:
         // 捕获不可变目标身份：await 期间 tab 可能被导航复用改指其他表，
         // 共享缓存结果落地前仍必须复核，不能解除新目标的 pending
         const capturedMeta = tab.tableMeta!;
-        const capturedTarget = { connectionId: tab.connectionId, database: tab.database, schema: capturedMeta.schema, catalog: capturedMeta.catalog, tableName: capturedMeta.tableName };
-        const metadataSchema = metadataSchemaForConnection(connection, tab.database, capturedMeta.schema);
+        const capturedSchema = tab.schema || capturedMeta.schema;
+        const capturedTarget = { connectionId: tab.connectionId, database: tab.database, schema: capturedSchema, catalog: capturedMeta.catalog, tableName: capturedMeta.tableName };
+        const metadataSchema = metadataSchemaForConnection(connection, tab.database, capturedSchema);
         // 分组含 tableType：主键计算依赖它，不同 tableType 不能共享加载结果
         const catalogKey = `${capturedMeta.catalog ?? ""}\u0000${capturedMeta.tableType ?? ""}`;
         let metadata = loadedByCatalog.get(catalogKey);
@@ -320,6 +321,7 @@ export function useNavigationTargets(dialogs: { showFieldLineageDialog: { value:
         if (!canApplyDataTabMetadata(currentTab, capturedTarget)) continue;
         queryStore.setTableMeta(tab.id, {
           ...capturedMeta,
+          schema: capturedSchema,
           columns: metadata.columns,
           primaryKeys: metadata.primaryKeys,
         });

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridSort.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridSort.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { simpleDataGridOrderByColumn, simpleDataGridOrderByReferencesMissingColumn } from "@/lib/dataGrid/dataGridSort";
+import { simpleDataGridOrderByColumn, simpleDataGridOrderByMatchesSort, simpleDataGridOrderByReferencesMissingColumn } from "@/lib/dataGrid/dataGridSort";
 
 describe("simpleDataGridOrderByColumn", () => {
   it.each([
@@ -23,11 +23,26 @@ describe("simpleDataGridOrderByReferencesMissingColumn", () => {
     expect(simpleDataGridOrderByReferencesMissingColumn('"old_name" ASC', ["id", "new_name"])).toBe(true);
   });
 
-  it("accepts an existing column case-insensitively", () => {
-    expect(simpleDataGridOrderByReferencesMissingColumn('"NEW_NAME" DESC', ["id", "new_name"])).toBe(false);
+  it("treats quoted identifier case as significant", () => {
+    expect(simpleDataGridOrderByReferencesMissingColumn('"NEW_NAME" DESC', ["id", "new_name"])).toBe(true);
+  });
+
+  it("accepts an existing unquoted column case-insensitively", () => {
+    expect(simpleDataGridOrderByReferencesMissingColumn("NEW_NAME DESC", ["id", "new_name"])).toBe(false);
   });
 
   it("does not reject a complex manual expression", () => {
     expect(simpleDataGridOrderByReferencesMissingColumn("LOWER(old_name) ASC", ["id", "new_name"])).toBe(false);
+  });
+});
+
+describe("simpleDataGridOrderByMatchesSort", () => {
+  it("recognizes the generated order owned by a structured sort", () => {
+    expect(simpleDataGridOrderByMatchesSort('"created_at" DESC', "created_at", "desc")).toBe(true);
+  });
+
+  it("does not treat a manual order as owned by a stale structured sort", () => {
+    expect(simpleDataGridOrderByMatchesSort("LOWER(name) ASC", "old_name", "asc")).toBe(false);
+    expect(simpleDataGridOrderByMatchesSort('"name" ASC', "old_name", "asc")).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridSort.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridSort.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { simpleDataGridOrderByColumn, simpleDataGridOrderByReferencesMissingColumn } from "@/lib/dataGrid/dataGridSort";
+
+describe("simpleDataGridOrderByColumn", () => {
+  it.each([
+    ['"old_name" ASC', "old_name"],
+    ["`old_name` DESC", "old_name"],
+    ["[old_name] ASC", "old_name"],
+    ["old_name DESC", "old_name"],
+    ['n."old_name" ASC', "old_name"],
+    ['"quoted""name" ASC', 'quoted"name'],
+  ])("extracts a generated single-column order from %s", (orderBy, expected) => {
+    expect(simpleDataGridOrderByColumn(orderBy)).toBe(expected);
+  });
+
+  it.each(["LOWER(name) ASC", "users.name ASC", '"name" ASC, "id" DESC', "name"])("leaves complex or incomplete orders untouched: %s", (orderBy) => {
+    expect(simpleDataGridOrderByColumn(orderBy)).toBeUndefined();
+  });
+});
+
+describe("simpleDataGridOrderByReferencesMissingColumn", () => {
+  it("detects a generated order for a renamed column", () => {
+    expect(simpleDataGridOrderByReferencesMissingColumn('"old_name" ASC', ["id", "new_name"])).toBe(true);
+  });
+
+  it("accepts an existing column case-insensitively", () => {
+    expect(simpleDataGridOrderByReferencesMissingColumn('"NEW_NAME" DESC', ["id", "new_name"])).toBe(false);
+  });
+
+  it("does not reject a complex manual expression", () => {
+    expect(simpleDataGridOrderByReferencesMissingColumn("LOWER(old_name) ASC", ["id", "new_name"])).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sidebar/dataTabOpenPolicy.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/dataTabOpenPolicy.spec.ts
@@ -73,6 +73,15 @@ describe("dataTabOpenPolicy", () => {
     expect(canApplyDataTabMetadata(tab, usersTarget, new AbortController().signal)).toBe(true);
   });
 
+  it("uses restored table metadata as the schema identity fallback", () => {
+    const tab = dataTab("users", "users");
+    tab.schema = undefined;
+    tab.tableMeta = { schema: "public", tableName: "users", columns: [], primaryKeys: [] };
+
+    expect(canApplyDataTabMetadata(tab, usersTarget, new AbortController().signal)).toBe(true);
+    expect(findExistingDataTabCandidate([tab], usersTarget, { openMode: "default", reuseDataTab: false })).toEqual({ tab, match: "same-table" });
+  });
+
   it("rejects metadata after its request is cancelled", () => {
     const tab = dataTab("users", "users");
     tab.tableMeta = { schema: "public", tableName: "users", columns: [], primaryKeys: [] };

--- a/apps/desktop/src/lib/dataGrid/dataGridSort.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridSort.ts
@@ -7,6 +7,23 @@ export interface DataGridSortState {
   direction: DataGridSortDirection;
 }
 
+export function simpleDataGridOrderByColumn(orderBy: string | undefined): string | undefined {
+  const match = orderBy?.trim().match(/^((?:n\.)?(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]]|\]\])+\]|[A-Za-z_][A-Za-z0-9_$]*))\s+(?:ASC|DESC)$/i);
+  if (!match) return undefined;
+  let identifier = match[1]!;
+  if (/^n\./i.test(identifier)) identifier = identifier.slice(2);
+  if (identifier.startsWith('"')) return identifier.slice(1, -1).replace(/""/g, '"');
+  if (identifier.startsWith("`")) return identifier.slice(1, -1).replace(/``/g, "`");
+  if (identifier.startsWith("[")) return identifier.slice(1, -1).replace(/\]\]/g, "]");
+  return identifier;
+}
+
+export function simpleDataGridOrderByReferencesMissingColumn(orderBy: string | undefined, columns: readonly string[]): boolean {
+  const orderByColumn = simpleDataGridOrderByColumn(orderBy);
+  if (!orderByColumn) return false;
+  return !columns.some((column) => column === orderByColumn || column.toLocaleLowerCase() === orderByColumn.toLocaleLowerCase());
+}
+
 export function nextDataGridSortState(current: DataGridSortState, column: string, columnIndex: number): DataGridSortState {
   if (current.column === column && current.columnIndex === columnIndex) {
     if (current.direction === "asc") {

--- a/apps/desktop/src/lib/dataGrid/dataGridSort.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridSort.ts
@@ -7,21 +7,42 @@ export interface DataGridSortState {
   direction: DataGridSortDirection;
 }
 
-export function simpleDataGridOrderByColumn(orderBy: string | undefined): string | undefined {
+interface SimpleDataGridOrderBy {
+  column: string;
+  direction: DataGridSortDirection;
+  quoted: boolean;
+}
+
+function parseSimpleDataGridOrderBy(orderBy: string | undefined): SimpleDataGridOrderBy | undefined {
   const match = orderBy?.trim().match(/^((?:n\.)?(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[(?:[^\]]|\]\])+\]|[A-Za-z_][A-Za-z0-9_$]*))\s+(?:ASC|DESC)$/i);
   if (!match) return undefined;
   let identifier = match[1]!;
   if (/^n\./i.test(identifier)) identifier = identifier.slice(2);
-  if (identifier.startsWith('"')) return identifier.slice(1, -1).replace(/""/g, '"');
-  if (identifier.startsWith("`")) return identifier.slice(1, -1).replace(/``/g, "`");
-  if (identifier.startsWith("[")) return identifier.slice(1, -1).replace(/\]\]/g, "]");
-  return identifier;
+  const direction = orderBy!.trim().toLocaleLowerCase().endsWith(" desc") ? "desc" : "asc";
+  if (identifier.startsWith('"')) return { column: identifier.slice(1, -1).replace(/""/g, '"'), direction, quoted: true };
+  if (identifier.startsWith("`")) return { column: identifier.slice(1, -1).replace(/``/g, "`"), direction, quoted: true };
+  if (identifier.startsWith("[")) return { column: identifier.slice(1, -1).replace(/\]\]/g, "]"), direction, quoted: true };
+  return { column: identifier, direction, quoted: false };
+}
+
+function simpleDataGridColumnMatches(orderBy: SimpleDataGridOrderBy, column: string): boolean {
+  return orderBy.quoted ? column === orderBy.column : column.toLocaleLowerCase() === orderBy.column.toLocaleLowerCase();
+}
+
+export function simpleDataGridOrderByColumn(orderBy: string | undefined): string | undefined {
+  return parseSimpleDataGridOrderBy(orderBy)?.column;
 }
 
 export function simpleDataGridOrderByReferencesMissingColumn(orderBy: string | undefined, columns: readonly string[]): boolean {
-  const orderByColumn = simpleDataGridOrderByColumn(orderBy);
-  if (!orderByColumn) return false;
-  return !columns.some((column) => column === orderByColumn || column.toLocaleLowerCase() === orderByColumn.toLocaleLowerCase());
+  const parsed = parseSimpleDataGridOrderBy(orderBy);
+  if (!parsed) return false;
+  return !columns.some((column) => simpleDataGridColumnMatches(parsed, column));
+}
+
+export function simpleDataGridOrderByMatchesSort(orderBy: string | undefined, column: string | null | undefined, direction: DataGridSortDirection | null | undefined): boolean {
+  if (!column || !direction) return false;
+  const parsed = parseSimpleDataGridOrderBy(orderBy);
+  return !!parsed && parsed.direction === direction && simpleDataGridColumnMatches(parsed, column);
 }
 
 export function nextDataGridSortState(current: DataGridSortState, column: string, columnIndex: number): DataGridSortState {

--- a/apps/desktop/src/lib/sidebar/dataTabOpenPolicy.ts
+++ b/apps/desktop/src/lib/sidebar/dataTabOpenPolicy.ts
@@ -34,7 +34,7 @@ function isSameDatabase(tab: DataTabLike, target: Pick<DataTabTarget, "connectio
 }
 
 function isSameTable(tab: DataTabLike, target: DataTabTarget): boolean {
-  return isSameDatabase(tab, target) && (tab.tableMeta?.catalog || "") === (target.catalog || "") && (tab.schema || "") === (target.schema || "") && (tab.tableMeta?.tableName || tab.title) === target.tableName;
+  return isSameDatabase(tab, target) && (tab.tableMeta?.catalog || "") === (target.catalog || "") && (tab.schema || tab.tableMeta?.schema || "") === (target.schema || "") && (tab.tableMeta?.tableName || tab.title) === target.tableName;
 }
 
 export function canApplyDataTabMetadata(tab: DataTabLike | undefined, target: DataTabTarget, signal?: AbortSignal): boolean {

--- a/apps/desktop/src/stores/__tests__/queryStore.tableDataRefresh.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.tableDataRefresh.spec.ts
@@ -239,6 +239,60 @@ describe("queryStore table data refresh", () => {
     expect(tab.orderByInput).toBe("LOWER(name) ASC");
   });
 
+  it("preserves a manual order when only residual structured sort state is invalid", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    const tab = store.tabs.find((candidate) => candidate.id === tabId)!;
+    tab.resultSortColumn = "old_name";
+    tab.resultSortColumnIndex = 1;
+    tab.resultSortDirection = "asc";
+    tab.resultSortMode = "database";
+    tab.orderByInput = "LOWER(new_name) ASC";
+
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.resultSortDirection).toBeUndefined();
+    expect(tab.orderByInput).toBe("LOWER(new_name) ASC");
+  });
+
+  it("clears quoted sorts after a case-only column rename", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    const tab = store.tabs.find((candidate) => candidate.id === tabId)!;
+    tab.resultSortColumn = "DisplayName";
+    tab.resultSortColumnIndex = 1;
+    tab.resultSortDirection = "asc";
+    tab.resultSortMode = "database";
+    tab.orderByInput = '"DisplayName" ASC';
+
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "displayname", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.resultSortDirection).toBeUndefined();
+    expect(tab.orderByInput).toBeUndefined();
+  });
+
   it("drops restored stale sort state before building a table refresh query", async () => {
     const { useQueryStore } = await import("@/stores/queryStore");
     const store = useQueryStore();

--- a/apps/desktop/src/stores/__tests__/queryStore.tableDataRefresh.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.tableDataRefresh.spec.ts
@@ -78,6 +78,7 @@ describe("queryStore table data refresh", () => {
       columns: [
         { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
         { name: "status", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+        { name: "created_at", data_type: "timestamp", is_nullable: false, column_default: null, is_primary_key: false, extra: null },
       ],
       primaryKeys: ["id"],
     });
@@ -112,7 +113,7 @@ describe("queryStore table data refresh", () => {
       tableName: "users",
       tableType: "TABLE",
       catalog: undefined,
-      columns: ["id", "status"],
+      columns: ["id", "status", "created_at"],
       primaryKeys: ["id"],
       includeRowId: false,
       whereInput: "status = 'ACTIVE'",
@@ -135,7 +136,10 @@ describe("queryStore table data refresh", () => {
         schema: "public",
         tableName: "users",
         tableType: "TABLE",
-        columns: [{ name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null }],
+        columns: [
+          { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+          { name: "created_at", data_type: "timestamp", is_nullable: false, column_default: null, is_primary_key: false, extra: null },
+        ],
         primaryKeys: ["id"],
       });
     }
@@ -160,6 +164,131 @@ describe("queryStore table data refresh", () => {
     expect(mocks.executeMulti).toHaveBeenCalledTimes(1);
     expect(store.tabs.find((tab) => tab.id === firstTabId)?.result?.rows).toEqual([]);
     expect(store.tabs.find((tab) => tab.id === secondTabId)?.result).toBeUndefined();
+  });
+
+  it("clears a structured sort when refreshed table metadata no longer contains its column", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "old_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+    const tab = store.tabs.find((candidate) => candidate.id === tabId)!;
+    tab.whereInput = "id > 0";
+    tab.orderByInput = '"old_name" ASC';
+    tab.resultSortColumn = "old_name";
+    tab.resultSortColumnIndex = 1;
+    tab.resultSortDirection = "asc";
+    tab.resultSortMode = "database";
+    tab.resultSortedSql = 'SELECT * FROM public.users ORDER BY "old_name" ASC';
+    tab.resultLocalSortOriginalRows = [[1, "alpha"]];
+    tab.resultLocalSortOriginalMongoDocuments = [{ id: 1, old_name: "alpha" }];
+    tab.resultLocalSortOriginalMongoCopyDocuments = [{ id: 1, old_name: "alpha" }];
+    tab.resultPageLimit = 25;
+    tab.resultPageOffset = 50;
+
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.resultSortColumnIndex).toBeUndefined();
+    expect(tab.resultSortDirection).toBeUndefined();
+    expect(tab.resultSortMode).toBeUndefined();
+    expect(tab.resultSortedSql).toBeUndefined();
+    expect(tab.resultLocalSortOriginalRows).toBeUndefined();
+    expect(tab.resultLocalSortOriginalMongoDocuments).toBeUndefined();
+    expect(tab.resultLocalSortOriginalMongoCopyDocuments).toBeUndefined();
+    expect(tab.orderByInput).toBeUndefined();
+    expect(tab.whereInput).toBe("id > 0");
+    expect(tab.resultPageLimit).toBe(25);
+    expect(tab.resultPageOffset).toBe(50);
+  });
+
+  it("preserves manual conditions when metadata changes without an invalid structured sort", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    const tab = store.tabs.find((candidate) => candidate.id === tabId)!;
+    tab.whereInput = "id > 0";
+    tab.orderByInput = "LOWER(name) ASC";
+
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [{ name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null }],
+      primaryKeys: ["id"],
+    });
+
+    expect(tab.whereInput).toBe("id > 0");
+    expect(tab.orderByInput).toBe("LOWER(name) ASC");
+  });
+
+  it("drops restored stale sort state before building a table refresh query", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+    const tab = store.tabs.find((candidate) => candidate.id === tabId)!;
+    tab.resultSortColumn = "old_name";
+    tab.resultSortColumnIndex = 1;
+    tab.resultSortDirection = "asc";
+    tab.resultSortMode = "database";
+    tab.orderByInput = '"old_name" ASC';
+
+    await expect(store.refreshDataTab(tabId)).resolves.toBe(true);
+
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }));
+    expect(tab.resultSortColumn).toBeUndefined();
+    expect(tab.resultSortDirection).toBeUndefined();
+    expect(tab.orderByInput).toBeUndefined();
+  });
+
+  it("drops a stale generated order even when the structured sort state was already cleared", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    store.setTableMeta(tabId, {
+      schema: "public",
+      tableName: "users",
+      tableType: "TABLE",
+      columns: [
+        { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "new_name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ],
+      primaryKeys: ["id"],
+    });
+    const tab = store.tabs.find((candidate) => candidate.id === tabId)!;
+    tab.orderByInput = '"old_name" ASC';
+
+    await expect(store.refreshDataTab(tabId)).resolves.toBe(true);
+
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ orderBy: undefined }));
+    expect(tab.orderByInput).toBeUndefined();
   });
 
   it("uses the table-open default when a refreshed data tab has no saved pagination", async () => {

--- a/apps/desktop/src/stores/__tests__/queryStore.tableMetaRestore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.tableMetaRestore.spec.ts
@@ -73,4 +73,30 @@ describe("data tab snapshot restore vs tableMetaPending", () => {
     // 恢复后行标识仍未知：编辑门控必须重新挂起
     expect(tab.tableMetaPending).toBe(true);
   });
+
+  it("does not replace current data-tab metadata with an older non-empty result snapshot", async () => {
+    vi.doMock("@/lib/tabs/tabResultCache", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/lib/tabs/tabResultCache")>();
+      return {
+        ...actual,
+        readTabResultSnapshot: vi.fn(async () => ({ result: sampleResult(), tableMeta: { tableName: "users", schema: "public", columns: [column("old_name")], primaryKeys: [] } }) as any),
+      };
+    });
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+
+    const tabId = store.createTab("pg-1", "app", "users", "data", "public");
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    tab.tableMeta = { tableName: "users", schema: "public", columns: [column("new_name")], primaryKeys: ["new_name"] };
+    tab.tableMetaPending = false;
+    tab.resultEvicted = true;
+    tab.resultCacheKey = "cache-key";
+
+    await store.reloadEvictedTab(tabId);
+
+    expect(tab.result).toBeDefined();
+    expect(tab.tableMeta?.columns.map((item) => item.name)).toEqual(["new_name"]);
+    expect(tab.tableMeta?.primaryKeys).toEqual(["new_name"]);
+    expect(tab.tableMetaPending).toBe(false);
+  });
 });

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2609,22 +2609,24 @@ export const useQueryStore = defineStore("query", () => {
 
   function clearInvalidDataTabSortState(tab: QueryTab, columns: NonNullable<QueryTab["tableMeta"]>["columns"]): boolean {
     if (tab.mode !== "data") return false;
-    const hasColumn = (name: string) => columns.some((column) => column.name === name || column.name.toLocaleLowerCase() === name.toLocaleLowerCase());
+    const hasColumn = (name: string) => columns.some((column) => column.name === name);
     const structuredSortMissing = !!tab.resultSortColumn && !hasColumn(tab.resultSortColumn);
     const simpleOrderMissing = simpleDataGridOrderByReferencesMissingColumn(
       tab.orderByInput,
       columns.map((column) => column.name),
     );
     if (!structuredSortMissing && !simpleOrderMissing) return false;
-    tab.resultSortColumn = undefined;
-    tab.resultSortColumnIndex = undefined;
-    tab.resultSortDirection = undefined;
-    tab.resultSortMode = undefined;
-    tab.resultSortedSql = undefined;
-    tab.resultLocalSortOriginalRows = undefined;
-    tab.resultLocalSortOriginalMongoDocuments = undefined;
-    tab.resultLocalSortOriginalMongoCopyDocuments = undefined;
-    tab.orderByInput = undefined;
+    if (structuredSortMissing) {
+      tab.resultSortColumn = undefined;
+      tab.resultSortColumnIndex = undefined;
+      tab.resultSortDirection = undefined;
+      tab.resultSortMode = undefined;
+      tab.resultSortedSql = undefined;
+      tab.resultLocalSortOriginalRows = undefined;
+      tab.resultLocalSortOriginalMongoDocuments = undefined;
+      tab.resultLocalSortOriginalMongoCopyDocuments = undefined;
+    }
+    if (simpleOrderMissing) tab.orderByInput = undefined;
     return true;
   }
 

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -44,7 +44,7 @@ import { buildTableSelectSql, quoteTableDataIdentifier } from "@/lib/table/table
 import { connectionQueryExecutionSchema, connectionUsesDatabaseObjectTreeMode, effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from "@/lib/database/jdbcDialect";
 import { frontendQueryTimeoutSecsForSql, queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
 import { queryResultNameFromPreamble, queryResultSourceLabel } from "@/lib/sql/queryResultSource";
-import { sortDataGridRowIndexes, type DataGridSortDirection } from "@/lib/dataGrid/dataGridSort";
+import { simpleDataGridOrderByReferencesMissingColumn, sortDataGridRowIndexes, type DataGridSortDirection } from "@/lib/dataGrid/dataGridSort";
 import { MAX_RESULT_PAGE_SIZE, normalizeResultPageSize } from "@/lib/dataGrid/paginationPageSize";
 import { executableStatementRanges, splitSqlStatementRanges } from "@/lib/sql/sqlStatementRanges";
 import { externalSqlFileDisplayTitles, normalizeExternalSqlPath } from "@/lib/sql/sqlFileOpen";
@@ -2206,6 +2206,7 @@ export const useQueryStore = defineStore("query", () => {
     const conn = connStore.getConfig(tab.connectionId);
     const effectiveDbType = effectiveDatabaseTypeForConnection(conn);
     const identifierQuote = connStore.connectionIdentifierQuote?.(tab.connectionId);
+    clearInvalidDataTabSortState(tab, tableMeta.columns);
     const primaryKeys = tab.tableMeta ? tab.tableMeta.primaryKeys : tableMeta.primaryKeys;
     const sortOrder = tab.resultSortColumn && tab.resultSortDirection ? `${quoteTableDataIdentifier(effectiveDbType, tab.resultSortColumn, identifierQuote)} ${tab.resultSortDirection.toUpperCase()}` : undefined;
     const orderBy = tab.orderByInput?.trim() || sortOrder;
@@ -2606,11 +2607,39 @@ export const useQueryStore = defineStore("query", () => {
     }
   }
 
+  function clearInvalidDataTabSortState(tab: QueryTab, columns: NonNullable<QueryTab["tableMeta"]>["columns"]): boolean {
+    if (tab.mode !== "data") return false;
+    const hasColumn = (name: string) => columns.some((column) => column.name === name || column.name.toLocaleLowerCase() === name.toLocaleLowerCase());
+    const structuredSortMissing = !!tab.resultSortColumn && !hasColumn(tab.resultSortColumn);
+    const simpleOrderMissing = simpleDataGridOrderByReferencesMissingColumn(
+      tab.orderByInput,
+      columns.map((column) => column.name),
+    );
+    if (!structuredSortMissing && !simpleOrderMissing) return false;
+    tab.resultSortColumn = undefined;
+    tab.resultSortColumnIndex = undefined;
+    tab.resultSortDirection = undefined;
+    tab.resultSortMode = undefined;
+    tab.resultSortedSql = undefined;
+    tab.resultLocalSortOriginalRows = undefined;
+    tab.resultLocalSortOriginalMongoDocuments = undefined;
+    tab.resultLocalSortOriginalMongoCopyDocuments = undefined;
+    tab.orderByInput = undefined;
+    return true;
+  }
+
+  function clearInvalidDataTabSort(id: string): boolean {
+    const tab = tabs.value.find((candidate) => candidate.id === id);
+    if (!tab?.tableMeta?.columns.length) return false;
+    return clearInvalidDataTabSortState(tab, tab.tableMeta.columns);
+  }
+
   function setTableMeta(id: string, meta: NonNullable<QueryTab["tableMeta"]>) {
     const tab = tabs.value.find((t) => t.id === id);
     if (tab) {
       tab.tableMeta = meta;
       tab.tableMetaUpdatedAt = Date.now();
+      if (meta.columns.length > 0) clearInvalidDataTabSortState(tab, meta.columns);
       // 只有真实元数据（columns 非空）落地才结束行标识等待；多处调用方会先写
       // columns/primaryKeys 为空的占位身份（如 useNavigationTargets），不得
       // 借此提前解除编辑门控。失败/中止路径不清除——标签页保持只读是安全
@@ -4676,11 +4705,10 @@ export const useQueryStore = defineStore("query", () => {
     tab.querySourceColumns = snapshot.querySourceColumns;
     tab.queryEditabilityReason = snapshot.queryEditabilityReason;
     tab.mongoEditTarget = snapshot.mongoEditTarget;
-    // Data tab 快照可能是延迟元数据期间落盘的空列占位身份：不得用它回滚
-    // 之后已落地的真实元数据（否则 pending 已清除而行标识又变未知，编辑
-    // 门控失效）；若恢复后确实没有真实列，重新挂起编辑门控
-    if (tab.tableMeta?.columns.length && !snapshot.tableMeta?.columns.length) {
-      // 保留当前真实元数据，忽略快照中的占位身份
+    // Data tab 的结果快照可能早于最近一次结构变更。已持有真实元数据时，
+    // 不允许旧快照回滚列名或主键；若恢复后仍没有真实列，重新挂起编辑门控。
+    if (tab.mode === "data" && tab.tableMeta?.columns.length) {
+      // 保留当前真实元数据
     } else {
       tab.tableMeta = snapshot.tableMeta;
     }
@@ -5126,6 +5154,7 @@ export const useQueryStore = defineStore("query", () => {
     updateSchema,
     updateConnection,
     setTableMeta,
+    clearInvalidDataTabSort,
     invalidateTableStructure,
     tableStructureRefreshVersion,
     setObjectSource,


### PR DESCRIPTION
## 改动说明

- 调整 Kingbase agent 的字段元数据读取，兼容缺少 `pg_attribute.attidentity` 的 Kingbase 版本，同时保留可用版本的标识列识别。
- 表结构保存后主动失效并刷新已打开数据标签的字段元数据，清理引用已改名或已删除字段的数据库排序，避免刷新继续执行旧 `ORDER BY`。
- 防止旧查询结果快照覆盖更新后的表结构元数据，并为 DataGrid 增加旧排序输入的兜底校验。
- 优化连接树状态指示灯布局，长连接名称使用省略号，状态点保持独立位置。

## 验证

- Kingbase V8R3：表结构页面可正常读取字段元数据。
- PostgreSQL 驱动连接 Kingbase V9：对 `sales.dbx_column_rename_refresh_repro` 按 `old_name` 数据库排序后，将字段改名为 `new_name`；返回数据标签刷新成功，排序输入自动清空，生成 SQL 不再引用旧字段。
- `go test ./...`（Kingbase agent）通过。
- `pnpm test`：658 个测试文件、5712 个用例通过。
- `pnpm typecheck` 通过。
- `pnpm lint` 通过，仅有仓库原有警告。