### PR TITLE
fix: derive Milvus default writes from schema

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -630,18 +630,19 @@ async function toggle() {
       const collectionRef = (node.meta as { collectionId?: string } | undefined)?.collectionId ?? node.label;
       const tab = queryStore.createTab(node.connectionId, node.database || "default", node.label, "vector");
       queryStore.updateSql(tab, collectionRef);
-      api
-        .vectorGetCollectionDetail(node.connectionId, node.database || "default", collectionRef)
-        .then((info) => {
-          if (info.dimension != null) {
+      if (connectionStore.getConfig(node.connectionId)?.db_type !== "milvus") {
+        api
+          .vectorGetCollectionDetail(node.connectionId, node.database || "default", collectionRef)
+          .then((info) => {
+            if (info.dimension == null) return;
             if (node.meta) {
               (node.meta as Record<string, unknown>).dimension = info.dimension;
             } else {
               node.meta = { dimension: info.dimension } as any;
             }
-          }
-        })
-        .catch(() => {});
+          })
+          .catch(() => {});
+      }
     } else if (node.type === "database" && node.connectionId && hasTreeNodeDatabaseContext(node)) {
       if (node.catalog && node.catalog !== "internal") {
         await connectionStore.loadDorisCatalogTables(node);

--- a/apps/desktop/src/components/vector/VectorBrowser.vue
+++ b/apps/desktop/src/components/vector/VectorBrowser.vue
@@ -42,7 +42,9 @@ let milvusDetailGeneration = 0;
 let milvusDetailLoad: Promise<void> | undefined;
 
 const milvusFields = computed(() => milvusSchema.value?.fields ?? []);
-const milvusSearchField = computed(() => milvusFields.value.find((field) => isMilvusVectorField(field) && !field.isFunctionOutput));
+const milvusSearchField = computed(
+  () => milvusFields.value.find((field) => isMilvusVectorField(field) && !field.isFunctionOutput) ?? milvusFields.value.find(isMilvusVectorField),
+);
 const collectionDimension = computed(() => milvusSearchField.value?.dimension ?? props.dimension);
 const dim = computed(() => collectionDimension.value ?? 4);
 function sampleVector(dimension = dim.value): number[] {
@@ -164,7 +166,11 @@ function defaultMilvusValue(field: MilvusFieldInfo): unknown {
 }
 
 function defaultMilvusUpsertEntity(): Record<string, unknown> {
-  return Object.fromEntries(milvusFields.value.filter((field) => !field.autoId && !field.isFunctionOutput && (isMilvusVectorField(field) || (!field.nullable && !field.hasDefaultValue))).map((field) => [field.name, defaultMilvusValue(field)]));
+  return Object.fromEntries(
+    milvusFields.value
+      .filter((field) => !field.isFunctionOutput && (!field.autoId || field.primaryKey) && (isMilvusVectorField(field) || (!field.nullable && !field.hasDefaultValue)))
+      .map((field) => [field.name, defaultMilvusValue(field)]),
+  );
 }
 
 function defaultMilvusPrimaryKeyFilter(): string {
@@ -182,9 +188,10 @@ function parseJsonValue(input: string): unknown | undefined {
 }
 
 function tryParseMilvusSearchVector(input: string): unknown {
-  const parsed = parseJsonValue(input);
-  if (Array.isArray(parsed) || (parsed && typeof parsed === "object")) return parsed;
   const field = milvusSearchField.value;
+  const parsed = parseJsonValue(input);
+  if (field?.isFunctionOutput) return typeof parsed === "string" ? parsed : input.trim() || "x";
+  if (Array.isArray(parsed) || (parsed && typeof parsed === "object")) return parsed;
   return field ? defaultMilvusValue(field) : [];
 }
 
@@ -303,10 +310,7 @@ function loadMilvusCollectionDetail(): Promise<void> {
     .then((info) => {
       if (generation !== milvusDetailGeneration) return;
       milvusSchema.value = info.milvusSchema;
-      if (!milvusSearchField.value) {
-        milvusDetailError.value = "Milvus collection schema did not return a supported vector field.";
-        return;
-      }
+      if (!milvusSearchField.value) milvusDetailError.value = "Milvus collection schema did not return a supported vector field.";
       if (requestIsDefault.value) resetRequest();
     })
     .catch((reason: unknown) => {
@@ -320,7 +324,10 @@ function loadMilvusCollectionDetail(): Promise<void> {
 async function ensureMilvusDefaultSchema() {
   if (props.databaseType !== "milvus" || operationMode.value === "browse" || !requestIsDefault.value) return;
   if (!milvusSchema.value) await loadMilvusCollectionDetail();
-  if (!milvusSearchField.value) {
+  if (!milvusSchema.value) {
+    throw new Error(milvusDetailError.value || "Unable to load the Milvus collection schema for the default request.");
+  }
+  if (operationMode.value === "search" && !milvusSearchField.value) {
     throw new Error(milvusDetailError.value || "Unable to determine the Milvus vector field for the default request.");
   }
 }

--- a/apps/desktop/src/components/vector/VectorBrowser.vue
+++ b/apps/desktop/src/components/vector/VectorBrowser.vue
@@ -42,9 +42,7 @@ let milvusDetailGeneration = 0;
 let milvusDetailLoad: Promise<void> | undefined;
 
 const milvusFields = computed(() => milvusSchema.value?.fields ?? []);
-const milvusSearchField = computed(
-  () => milvusFields.value.find((field) => isMilvusVectorField(field) && !field.isFunctionOutput) ?? milvusFields.value.find(isMilvusVectorField),
-);
+const milvusSearchField = computed(() => milvusFields.value.find((field) => isMilvusVectorField(field) && !field.isFunctionOutput) ?? milvusFields.value.find(isMilvusVectorField));
 const collectionDimension = computed(() => milvusSearchField.value?.dimension ?? props.dimension);
 const dim = computed(() => collectionDimension.value ?? 4);
 function sampleVector(dimension = dim.value): number[] {
@@ -166,11 +164,7 @@ function defaultMilvusValue(field: MilvusFieldInfo): unknown {
 }
 
 function defaultMilvusUpsertEntity(): Record<string, unknown> {
-  return Object.fromEntries(
-    milvusFields.value
-      .filter((field) => !field.isFunctionOutput && (!field.autoId || field.primaryKey) && (isMilvusVectorField(field) || (!field.nullable && !field.hasDefaultValue)))
-      .map((field) => [field.name, defaultMilvusValue(field)]),
-  );
+  return Object.fromEntries(milvusFields.value.filter((field) => !field.isFunctionOutput && (!field.autoId || field.primaryKey) && (isMilvusVectorField(field) || (!field.nullable && !field.hasDefaultValue))).map((field) => [field.name, defaultMilvusValue(field)]));
 }
 
 function defaultMilvusPrimaryKeyFilter(): string {

--- a/apps/desktop/src/components/vector/VectorBrowser.vue
+++ b/apps/desktop/src/components/vector/VectorBrowser.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch, defineAsyncComponent } from "vue";
+import { computed, ref, watch, defineAsyncComponent, onBeforeUnmount } from "vue";
 import { Play, RefreshCcw, RotateCcw, Save, Search, Trash2 } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "@/components/ui/button";
@@ -7,7 +7,7 @@ import ErrorBanner from "@/components/ui/ErrorBanner.vue";
 import QueryLoadingState from "@/components/common/QueryLoadingState.vue";
 import * as api from "@/lib/backend/api";
 import { uuid } from "@/lib/common/utils";
-import type { DatabaseType, QueryResult } from "@/types/database";
+import type { DatabaseType, MilvusCollectionSchema, MilvusFieldInfo, QueryResult } from "@/types/database";
 
 const DataGrid = defineAsyncComponent(() => import("@/components/grid/DataGrid.vue"));
 const { t } = useI18n();
@@ -31,14 +31,22 @@ const error = ref("");
 const statusMessage = ref("");
 const result = ref<QueryResult>(emptyResult());
 const operationMode = ref<VectorOperationMode>("browse");
-const requestText = ref(defaultRequestText(props.databaseType, props.database, props.collection, operationMode.value));
+const requestText = ref("");
+const requestIsDefault = ref(true);
 const searchVector = ref("");
 const searchTopK = ref(10);
 let loadingTimer: ReturnType<typeof setInterval> | undefined;
+const milvusSchema = ref<MilvusCollectionSchema>();
+const milvusDetailError = ref("");
+let milvusDetailGeneration = 0;
+let milvusDetailLoad: Promise<void> | undefined;
 
-const dim = computed(() => props.dimension || 4);
-function sampleVector(): number[] {
-  return Array.from({ length: dim.value }, (_, i) => parseFloat(((i + 1) / 10).toFixed(1)));
+const milvusFields = computed(() => milvusSchema.value?.fields ?? []);
+const milvusSearchField = computed(() => milvusFields.value.find((field) => isMilvusVectorField(field) && !field.isFunctionOutput));
+const collectionDimension = computed(() => milvusSearchField.value?.dimension ?? props.dimension);
+const dim = computed(() => collectionDimension.value ?? 4);
+function sampleVector(dimension = dim.value): number[] {
+  return Array.from({ length: Math.max(1, dimension) }, (_, i) => parseFloat(((i + 1) / 10).toFixed(1)));
 }
 const productLabel = computed(() => {
   switch (props.databaseType) {
@@ -79,20 +87,24 @@ const needsExplicitSearchVector = computed(() => operationMode.value === "search
 const executeDisabled = computed(() => loading.value || !requestText.value.trim() || needsExplicitSearchVector.value);
 
 watch(
-  () => [props.databaseType, props.database, props.collection] as const,
-  ([databaseType, database, collection]) => {
-    requestText.value = defaultRequestText(databaseType, database, collection, operationMode.value);
+  () => [props.connectionId, props.databaseType, props.database, props.collection] as const,
+  () => {
+    invalidateRequest();
+    resetRequest();
     result.value = emptyResult();
     error.value = "";
     statusMessage.value = "";
+    resetMilvusCollectionDetail();
+    if (props.databaseType === "milvus") void loadMilvusCollectionDetail();
   },
+  { immediate: true },
 );
 
 watch(
-  () => [operationMode.value, searchVector.value, searchTopK.value, props.dimension] as const,
+  () => [operationMode.value, searchVector.value, searchTopK.value, collectionDimension.value] as const,
   () => {
-    if (operationMode.value === "search") {
-      requestText.value = defaultRequestText(props.databaseType, props.database, props.collection, operationMode.value);
+    if (operationMode.value === "search" && requestIsDefault.value) {
+      resetRequest();
     }
   },
 );
@@ -112,46 +124,102 @@ function pathSegment(value: string): string {
   return encodeURIComponent(value || "collection");
 }
 
-function defaultRequestText(databaseType: DatabaseType | undefined, database: string, collection: string, mode: VectorOperationMode): string {
-  if (databaseType === "milvus") {
-    const body =
-      mode === "delete"
-        ? {
-            dbName: database || "default",
-            collectionName: collection,
-            filter: "id in [1]",
-          }
-        : mode === "upsert"
-          ? {
-              dbName: database || "default",
-              collectionName: collection,
-              data: [
-                {
-                  id: 1,
-                  vector: sampleVector(),
-                  title: "updated vector",
-                  kind: "demo",
-                },
-              ],
-            }
-          : mode === "search"
-            ? {
-                dbName: database || "default",
-                collectionName: collection,
-                data: [tryParseVector(searchVector.value)],
-                limit: searchTopK.value,
-                outputFields: ["*"],
-              }
-            : {
-                dbName: database || "default",
-                collectionName: collection,
-                filter: "",
-                limit: 100,
-                outputFields: ["*"],
-              };
-    const endpoint = mode === "delete" ? "delete" : mode === "upsert" ? "upsert" : mode === "search" ? "search" : "query";
-    return `POST /v2/vectordb/entities/${endpoint}\n${JSON.stringify(body, null, 2)}`;
+function milvusDataType(field: Pick<MilvusFieldInfo, "dataType">): string {
+  return field.dataType.toLowerCase();
+}
+
+function isMilvusVectorField(field: MilvusFieldInfo): boolean {
+  return milvusDataType(field).endsWith("vector");
+}
+
+function defaultMilvusValue(field: MilvusFieldInfo): unknown {
+  const type = milvusDataType(field);
+  if (isMilvusVectorField(field)) {
+    const dimension = field.dimension ?? dim.value;
+    if (type === "sparsefloatvector") return { "0": 0.1 };
+    if (type === "binaryvector") return Array.from({ length: Math.max(8, dimension) }, (_, index) => Number(index === 0));
+    if (type === "int8vector") return Array.from({ length: Math.max(1, dimension) }, () => 1);
+    return sampleVector(dimension);
   }
+  switch (type) {
+    case "bool":
+      return false;
+    case "int8":
+    case "int16":
+    case "int32":
+    case "int64":
+      return 1;
+    case "float":
+    case "double":
+      return 0.1;
+    case "json":
+      return {};
+    case "array":
+      return [];
+    case "geometry":
+      return "POINT (0 0)";
+    default:
+      return "x";
+  }
+}
+
+function defaultMilvusUpsertEntity(): Record<string, unknown> {
+  return Object.fromEntries(milvusFields.value.filter((field) => !field.autoId && !field.isFunctionOutput && (isMilvusVectorField(field) || (!field.nullable && !field.hasDefaultValue))).map((field) => [field.name, defaultMilvusValue(field)]));
+}
+
+function defaultMilvusPrimaryKeyFilter(): string {
+  const primaryKey = milvusFields.value.find((field) => field.primaryKey);
+  if (!primaryKey) return "id in [1]";
+  return `${primaryKey.name} in [${JSON.stringify(defaultMilvusValue(primaryKey))}]`;
+}
+
+function parseJsonValue(input: string): unknown | undefined {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
+}
+
+function tryParseMilvusSearchVector(input: string): unknown {
+  const parsed = parseJsonValue(input);
+  if (Array.isArray(parsed) || (parsed && typeof parsed === "object")) return parsed;
+  const field = milvusSearchField.value;
+  return field ? defaultMilvusValue(field) : [];
+}
+
+function milvusRequestText(database: string, collection: string, mode: VectorOperationMode, strongConsistency = false): string {
+  const base = { dbName: database || "default", collectionName: collection };
+  let endpoint: string;
+  let body: Record<string, unknown>;
+  switch (mode) {
+    case "delete":
+      endpoint = "delete";
+      body = { ...base, filter: defaultMilvusPrimaryKeyFilter() };
+      break;
+    case "upsert":
+      endpoint = "upsert";
+      body = { ...base, data: [defaultMilvusUpsertEntity()] };
+      break;
+    case "search":
+      endpoint = "search";
+      body = {
+        ...base,
+        data: [tryParseMilvusSearchVector(searchVector.value)],
+        limit: searchTopK.value,
+        outputFields: ["*"],
+        ...(milvusSearchField.value ? { annsField: milvusSearchField.value.name } : {}),
+      };
+      break;
+    default:
+      endpoint = "query";
+      body = { ...base, filter: "", limit: 100, outputFields: ["*"], ...(strongConsistency && { consistencyLevel: "Strong" }) };
+  }
+  return `POST /v2/vectordb/entities/${endpoint}\n${JSON.stringify(body, null, 2)}`;
+}
+
+function defaultRequestText(databaseType: DatabaseType | undefined, database: string, collection: string, mode: VectorOperationMode, strongConsistency = false): string {
+  if (databaseType === "milvus") return milvusRequestText(database, collection, mode, strongConsistency);
   if (databaseType === "weaviate") {
     const collectionName = collection || "Collection";
     if (mode === "delete") {
@@ -218,12 +286,48 @@ function defaultRequestText(databaseType: DatabaseType | undefined, database: st
   return `POST /collections/${collectionPath}/points/scroll\n${JSON.stringify({ limit: 100, with_payload: true, with_vector: false }, null, 2)}`;
 }
 
+function resetMilvusCollectionDetail() {
+  milvusDetailGeneration += 1;
+  milvusDetailLoad = undefined;
+  milvusSchema.value = undefined;
+  milvusDetailError.value = "";
+}
+
+function loadMilvusCollectionDetail(): Promise<void> {
+  if (props.databaseType !== "milvus" || !props.connectionId || !props.collection) return Promise.resolve();
+  if (milvusDetailLoad) return milvusDetailLoad;
+
+  const generation = ++milvusDetailGeneration;
+  const promise = api
+    .vectorGetCollectionDetail(props.connectionId, props.database || "default", props.collection)
+    .then((info) => {
+      if (generation !== milvusDetailGeneration) return;
+      milvusSchema.value = info.milvusSchema;
+      if (!milvusSearchField.value) {
+        milvusDetailError.value = "Milvus collection schema did not return a supported vector field.";
+        return;
+      }
+      if (requestIsDefault.value) resetRequest();
+    })
+    .catch((reason: unknown) => {
+      if (generation !== milvusDetailGeneration) return;
+      milvusDetailError.value = reason instanceof Error ? reason.message : String(reason);
+      milvusDetailLoad = undefined;
+    });
+  return (milvusDetailLoad = promise);
+}
+
+async function ensureMilvusDefaultSchema() {
+  if (props.databaseType !== "milvus" || operationMode.value === "browse" || !requestIsDefault.value) return;
+  if (!milvusSchema.value) await loadMilvusCollectionDetail();
+  if (!milvusSearchField.value) {
+    throw new Error(milvusDetailError.value || "Unable to determine the Milvus vector field for the default request.");
+  }
+}
+
 function parseVector(input: string): number[] | undefined {
-  try {
-    const parsed = JSON.parse(input);
-    if (Array.isArray(parsed) && parsed.length > 0) return parsed;
-  } catch {}
-  return undefined;
+  const parsed = parseJsonValue(input);
+  return Array.isArray(parsed) && parsed.length > 0 ? (parsed as number[]) : undefined;
 }
 
 function tryParseVector(input: string): number[] {
@@ -256,7 +360,7 @@ async function executeRequestText(text: string): Promise<QueryResult> {
   return firstResult(results);
 }
 
-async function refreshResult() {
+async function withLoading(run: (id: string) => Promise<void>) {
   if (loading.value) return;
   const id = uuid();
   executionId.value = id;
@@ -266,56 +370,74 @@ async function refreshResult() {
   statusMessage.value = "";
   startTimer();
   try {
-    const browseText = defaultRequestText(props.databaseType, props.database, props.collection, "browse");
-    const nextResult = await executeRequestText(browseText);
-    if (executionId.value === id) result.value = nextResult;
+    await run(id);
   } catch (e: unknown) {
     if (executionId.value === id) error.value = e instanceof Error ? e.message : String(e);
   } finally {
     if (executionId.value === id) {
       loading.value = false;
+      executionId.value = "";
       stopTimer();
     }
   }
 }
 
-async function runRequest() {
-  if (loading.value) return;
-  const id = uuid();
-  executionId.value = id;
-  loading.value = true;
-  cancelling.value = false;
-  error.value = "";
-  statusMessage.value = "";
-  startTimer();
-  try {
+function refreshResult() {
+  return withLoading(async (id) => {
+    const browseText = defaultRequestText(props.databaseType, props.database, props.collection, "browse");
+    const nextResult = await executeRequestText(browseText);
+    if (executionId.value === id) result.value = nextResult;
+  });
+}
+
+function runRequest() {
+  return withLoading(async (id) => {
+    await ensureMilvusDefaultSchema();
+    if (executionId.value !== id) return;
     const nextResult = await executeRequestText(requestText.value);
     if (executionId.value !== id) return;
     if (operationMode.value === "browse" || operationMode.value === "search") {
       result.value = nextResult;
     } else {
-      const browseText = defaultRequestText(props.databaseType, props.database, props.collection, "browse");
-      result.value = await executeRequestText(browseText);
+      const browseText = defaultRequestText(props.databaseType, props.database, props.collection, "browse", true);
+      const browseResult = await executeRequestText(browseText);
+      if (executionId.value !== id) return;
+      result.value = browseResult;
       statusMessage.value = t("vector.operationSuccess");
     }
-  } catch (e: unknown) {
-    if (executionId.value === id) error.value = e instanceof Error ? e.message : String(e);
-  } finally {
-    if (executionId.value === id) {
-      loading.value = false;
-      stopTimer();
-    }
-  }
+  });
 }
 
 async function cancelRequest() {
-  if (!executionId.value) return;
+  const id = executionId.value;
+  if (!id || cancelling.value) return;
   cancelling.value = true;
-  await api.cancelQuery(executionId.value).catch(() => false);
+  executionId.value = "";
+  try {
+    await api.cancelQuery(id).catch(() => false);
+  } finally {
+    loading.value = false;
+    cancelling.value = false;
+    stopTimer();
+  }
+}
+
+function invalidateRequest() {
+  const id = executionId.value;
+  executionId.value = "";
+  loading.value = false;
+  cancelling.value = false;
+  stopTimer();
+  if (id) void api.cancelQuery(id).catch(() => false);
 }
 
 function resetRequest() {
   requestText.value = defaultRequestText(props.databaseType, props.database, props.collection, operationMode.value);
+  requestIsDefault.value = true;
+}
+
+function markRequestAsCustom() {
+  requestIsDefault.value = false;
 }
 
 function setOperationMode(mode: VectorOperationMode) {
@@ -325,6 +447,11 @@ function setOperationMode(mode: VectorOperationMode) {
   error.value = "";
   statusMessage.value = "";
 }
+
+onBeforeUnmount(() => {
+  invalidateRequest();
+  resetMilvusCollectionDetail();
+});
 </script>
 
 <template>
@@ -334,7 +461,7 @@ function setOperationMode(mode: VectorOperationMode) {
         <div class="truncate text-sm font-semibold">{{ collectionLabel }}</div>
         <div class="truncate text-xs text-muted-foreground">
           {{ t("vector.productCollection", { product: productLabel }) }}
-          <span v-if="dimension != null" class="ml-1.5 inline-flex items-center rounded border bg-muted/50 px-1.5 py-px text-[11px] font-medium text-foreground/80">{{ dimension }}d</span>
+          <span v-if="collectionDimension != null" class="ml-1.5 inline-flex items-center rounded border bg-muted/50 px-1.5 py-px text-[11px] font-medium text-foreground/80">{{ collectionDimension }}d</span>
         </div>
       </div>
       <div class="flex shrink-0 items-center gap-1.5">
@@ -362,17 +489,27 @@ function setOperationMode(mode: VectorOperationMode) {
     <div v-if="operationMode === 'search'" class="flex shrink-0 flex-wrap items-center gap-3 border-b px-3 py-2">
       <div class="flex items-center gap-1.5 text-xs text-muted-foreground">
         <span>{{ t("vector.vectorLabel") }}</span>
-        <input v-model="searchVector" class="h-7 w-80 rounded border bg-muted/30 px-2 font-mono text-xs outline-none focus:border-primary" placeholder="[0.1, 0.2, ...]" spellcheck="false" />
+        <input v-model="searchVector" :disabled="loading" class="h-7 w-80 rounded border bg-muted/30 px-2 font-mono text-xs outline-none focus:border-primary" placeholder="[0.1, 0.2, ...]" spellcheck="false" />
       </div>
       <div class="flex items-center gap-1.5 text-xs text-muted-foreground">
         <span>topK</span>
-        <input v-model.number="searchTopK" type="number" min="1" max="1000" class="h-7 w-16 rounded border bg-muted/30 px-2 text-xs outline-none focus:border-primary" />
+        <input v-model.number="searchTopK" :disabled="loading" type="number" min="1" max="1000" class="h-7 w-16 rounded border bg-muted/30 px-2 text-xs outline-none focus:border-primary" />
       </div>
       <span v-if="needsExplicitSearchVector" class="text-xs text-amber-600 dark:text-amber-400">{{ t("vector.vectorDimensionRequired") }}</span>
     </div>
     <div class="grid min-h-0 flex-1 grid-rows-[minmax(9rem,15rem)_1fr]">
       <div class="min-h-0 border-b">
-        <textarea v-model="requestText" class="dbx-editor-font-family h-full w-full resize-none bg-background px-3 py-2 text-xs leading-5 outline-none" :aria-label="t('vector.requestEditor')" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off" />
+        <textarea
+          v-model="requestText"
+          :readonly="loading"
+          class="dbx-editor-font-family h-full w-full resize-none bg-background px-3 py-2 text-xs leading-5 outline-none"
+          :aria-label="t('vector.requestEditor')"
+          spellcheck="false"
+          autocomplete="off"
+          autocapitalize="off"
+          autocorrect="off"
+          @input="markRequestAsCustom"
+        />
       </div>
       <div class="min-h-0">
         <ErrorBanner v-if="error" :message="error" copy-mode="label" dismissible @dismiss="error = ''" />

--- a/apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts
+++ b/apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts
@@ -223,11 +223,7 @@ describe("VectorBrowser default requests", () => {
       name: "documents",
       id: "documents",
       milvusSchema: {
-        fields: [
-          field("document_id", "Int64", { primaryKey: true }),
-          field("text", "VarChar"),
-          field("sparse", "SparseFloatVector", { isFunctionOutput: true }),
-        ],
+        fields: [field("document_id", "Int64", { primaryKey: true }), field("text", "VarChar"), field("sparse", "SparseFloatVector", { isFunctionOutput: true })],
       },
     });
 

--- a/apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts
+++ b/apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts
@@ -194,6 +194,63 @@ describe("VectorBrowser default requests", () => {
     });
   });
 
+  it("keeps an auto-generated primary key in the default upsert entity", async () => {
+    backend.vectorGetCollectionDetail.mockResolvedValue({
+      name: "documents",
+      id: "documents",
+      milvusSchema: {
+        fields: [field("document_id", "Int64", { primaryKey: true, autoId: true }), field("embedding", "FloatVector", { dimension: 3 })],
+      },
+    });
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await flushUi();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+
+    expect(requestBody().data[0]).toEqual({ document_id: 1, embedding: [0.1, 0.2, 0.3] });
+  });
+
+  it("uses a BM25 function output field for full-text search", async () => {
+    backend.vectorGetCollectionDetail.mockResolvedValue({
+      name: "documents",
+      id: "documents",
+      milvusSchema: {
+        fields: [
+          field("document_id", "Int64", { primaryKey: true }),
+          field("text", "VarChar"),
+          field("sparse", "SparseFloatVector", { isFunctionOutput: true }),
+        ],
+      },
+    });
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await flushUi();
+
+    buttonWithText("vector.search").click();
+    await nextTick();
+
+    expect(requestBody()).toMatchObject({ annsField: "sparse", data: ["x"] });
+
+    const searchButtons = [...root!.querySelectorAll<HTMLButtonElement>("button")].filter((button) => button.textContent?.trim() === "vector.search");
+    searchButtons[searchButtons.length - 1].click();
+    await flushUi();
+    expect(backend.executeMulti).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps a custom request when the schema arrives", async () => {
     let resolveDetail: (value: CollectionInfo) => void;
     backend.vectorGetCollectionDetail.mockReturnValue(

--- a/apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts
+++ b/apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts
@@ -1,0 +1,413 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, ref, type App } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CollectionInfo, MilvusFieldInfo } from "@/types/database";
+
+const backend = vi.hoisted(() => ({
+  cancelQuery: vi.fn(),
+  executeMulti: vi.fn(),
+  vectorGetCollectionDetail: vi.fn(),
+}));
+
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+vi.mock("@/lib/backend/api", () => backend);
+vi.mock("@lucide/vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  const Icon = defineComponent({ setup: () => () => h("i") });
+  return { Play: Icon, RefreshCcw: Icon, RotateCcw: Icon, Save: Icon, Search: Icon, Trash2: Icon };
+});
+vi.mock("@/components/ui/button", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    Button: defineComponent({
+      inheritAttrs: false,
+      setup(_, { attrs, slots }) {
+        return () => h("button", attrs, slots.default?.());
+      },
+    }),
+  };
+});
+vi.mock("@/components/common/QueryLoadingState.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    default: defineComponent({
+      emits: ["cancel"],
+      setup(_, { emit }) {
+        return () => h("button", { onClick: () => emit("cancel") }, "cancel");
+      },
+    }),
+  };
+});
+vi.mock("@/components/ui/ErrorBanner.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return { default: defineComponent({ setup: () => () => h("div") }) };
+});
+vi.mock("@/components/grid/DataGrid.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return { __esModule: true, default: defineComponent({ setup: () => () => h("div") }) };
+});
+
+import VectorBrowser from "@/components/vector/VectorBrowser.vue";
+
+let app: App<Element> | null = null;
+let root: HTMLDivElement | null = null;
+
+async function flushUi() {
+  await Promise.resolve();
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+}
+
+function buttonWithText(text: string): HTMLButtonElement {
+  const button = [...root!.querySelectorAll<HTMLButtonElement>("button")].find((candidate) => candidate.textContent?.trim() === text);
+  if (!button) throw new Error(`Button not found: ${text}`);
+  return button;
+}
+
+function requestBody() {
+  const request = root!.querySelector<HTMLTextAreaElement>("textarea")!.value;
+  return JSON.parse(request.slice(request.indexOf("\n") + 1));
+}
+
+function field(name: string, dataType: string, overrides: Partial<MilvusFieldInfo> = {}): MilvusFieldInfo {
+  return { name, dataType, primaryKey: false, autoId: false, nullable: false, hasDefaultValue: false, isFunctionOutput: false, ...overrides };
+}
+
+beforeEach(() => {
+  backend.cancelQuery.mockReset();
+  backend.executeMulti.mockReset();
+  backend.vectorGetCollectionDetail.mockReset();
+  backend.cancelQuery.mockResolvedValue(false);
+  backend.executeMulti.mockResolvedValue([{ columns: [], column_types: [], column_sortables: [], rows: [], affected_rows: 0, execution_time_ms: 0 }]);
+  root = document.createElement("div");
+  document.body.appendChild(root);
+});
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  root?.remove();
+  root = null;
+  document.body.innerHTML = "";
+});
+
+describe("VectorBrowser default requests", () => {
+  it("keeps non-Milvus browse defaults schema-free", async () => {
+    for (const [databaseType, expected] of [
+      ["qdrant", "POST /collections/demo/points/scroll"],
+      ["weaviate", "GET /v1/objects?class=demo&limit=100"],
+      ["chromadb", "POST /api/v2/tenants/default_tenant/databases/default_database/collections/demo/get"],
+    ] as const) {
+      app = createApp(VectorBrowser, { connectionId: "vector-1", database: "default", collection: "demo", databaseType });
+      app.mount(root!);
+      await flushUi();
+      expect(root!.querySelector<HTMLTextAreaElement>("textarea")!.value).toContain(expected);
+      app.unmount();
+      app = null;
+      root!.replaceChildren();
+    }
+    expect(backend.vectorGetCollectionDetail).not.toHaveBeenCalled();
+  });
+
+  it("resolves the schema before executing a generated upsert request", async () => {
+    let resolveDetail: (value: CollectionInfo) => void;
+    backend.vectorGetCollectionDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "script_milvus_crud_demo",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await nextTick();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+    buttonWithText("vector.apply").click();
+    await nextTick();
+    expect(requestBody().data).toEqual([{}]);
+    expect(root!.querySelector<HTMLTextAreaElement>("textarea")!.readOnly).toBe(true);
+    expect(backend.executeMulti).not.toHaveBeenCalled();
+    expect(backend.vectorGetCollectionDetail).toHaveBeenCalledTimes(1);
+
+    resolveDetail!({
+      name: "script_milvus_crud_demo",
+      id: "script_milvus_crud_demo",
+      dimension: 4,
+      milvusSchema: { fields: [field("id", "Int64", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 4 })] },
+    });
+    await flushUi();
+
+    const request = root!.querySelector<HTMLTextAreaElement>("textarea")!.value;
+    expect(request).toContain('"embedding"');
+    expect(request).not.toContain('"vector"');
+    expect(backend.executeMulti.mock.calls[0][2]).toContain('"embedding"');
+  });
+
+  it("generates a default entity from required schema fields", async () => {
+    backend.vectorGetCollectionDetail.mockResolvedValue({
+      name: "documents",
+      id: "documents",
+      dimension: 3,
+      milvusSchema: {
+        fields: [
+          field("document_id", "VarChar", { primaryKey: true }),
+          field("embedding", "FloatVector", { dimension: 3 }),
+          field("keywords", "SparseFloatVector"),
+          field("rating", "Double"),
+          field("metadata", "JSON"),
+          field("tags", "Array"),
+          field("optional_note", "VarChar", { nullable: true }),
+          field("status", "VarChar", { hasDefaultValue: true }),
+          field("bm25", "SparseFloatVector", { isFunctionOutput: true }),
+        ],
+      },
+    });
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+      dimension: 9,
+    });
+    app.mount(root!);
+    await flushUi();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+
+    expect(requestBody().data[0]).toEqual({
+      document_id: "x",
+      embedding: [0.1, 0.2, 0.3],
+      keywords: { "0": 0.1 },
+      rating: 0.1,
+      metadata: {},
+      tags: [],
+    });
+  });
+
+  it("keeps a custom request when the schema arrives", async () => {
+    let resolveDetail: (value: CollectionInfo) => void;
+    backend.vectorGetCollectionDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await nextTick();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+    const editor = root!.querySelector<HTMLTextAreaElement>("textarea")!;
+    const customRequest = 'POST /v2/vectordb/entities/upsert\n{"collectionName":"documents","data":[{"id":7,"embedding":[1,2,3]}]}';
+    editor.value = customRequest;
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    resolveDetail!({
+      name: "documents",
+      id: "documents",
+      milvusSchema: { fields: [field("id", "Int64", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 3 })] },
+    });
+    await flushUi();
+
+    expect(editor.value).toBe(customRequest);
+  });
+
+  it("does not send a generated request when schema discovery fails", async () => {
+    backend.vectorGetCollectionDetail.mockRejectedValue(new Error("schema unavailable"));
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await flushUi();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+    buttonWithText("vector.apply").click();
+    await flushUi();
+
+    expect(backend.executeMulti).not.toHaveBeenCalled();
+  });
+
+  it("does not execute a generated request after cancellation during schema loading", async () => {
+    let resolveDetail: (value: CollectionInfo) => void;
+    backend.vectorGetCollectionDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await nextTick();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+    buttonWithText("vector.apply").click();
+    await nextTick();
+    buttonWithText("cancel").click();
+    await flushUi();
+
+    resolveDetail!({
+      name: "documents",
+      id: "documents",
+      milvusSchema: { fields: [field("id", "Int64", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 3 })] },
+    });
+    await flushUi();
+
+    expect(backend.executeMulti).not.toHaveBeenCalled();
+  });
+
+  it("does not execute a generated request after the browser unmounts", async () => {
+    let resolveDetail: (value: CollectionInfo) => void;
+    backend.vectorGetCollectionDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await nextTick();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+    buttonWithText("vector.apply").click();
+    await nextTick();
+    app.unmount();
+    app = null;
+
+    resolveDetail!({
+      name: "documents",
+      id: "documents",
+      milvusSchema: { fields: [field("id", "Int64", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 3 })] },
+    });
+    await flushUi();
+
+    expect(backend.executeMulti).not.toHaveBeenCalled();
+  });
+
+  it("does not execute a generated request after the collection changes", async () => {
+    let resolveDetail: (value: CollectionInfo) => void;
+    const collection = ref("documents");
+    backend.vectorGetCollectionDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    app = createApp(
+      defineComponent({
+        setup: () => () => h(VectorBrowser, { connectionId: "milvus-1", database: "default", collection: collection.value, databaseType: "milvus" }),
+      }),
+    );
+    app.mount(root!);
+    await nextTick();
+
+    buttonWithText("vector.upsert").click();
+    await nextTick();
+    buttonWithText("vector.apply").click();
+    await nextTick();
+    collection.value = "other_documents";
+    await nextTick();
+
+    resolveDetail!({
+      name: "documents",
+      id: "documents",
+      milvusSchema: { fields: [field("id", "Int64", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 3 })] },
+    });
+    await flushUi();
+
+    expect(backend.executeMulti).not.toHaveBeenCalled();
+  });
+
+  it("keeps a custom search request when the schema arrives", async () => {
+    let resolveDetail: (value: CollectionInfo) => void;
+    backend.vectorGetCollectionDetail.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await nextTick();
+
+    buttonWithText("vector.search").click();
+    await nextTick();
+    const editor = root!.querySelector<HTMLTextAreaElement>("textarea")!;
+    const customRequest = 'POST /v2/vectordb/entities/search\n{"collectionName":"documents","data":[[1,2,3]]}';
+    editor.value = customRequest;
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    resolveDetail!({
+      name: "documents",
+      id: "documents",
+      milvusSchema: { fields: [field("id", "Int64", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 3 })] },
+    });
+    await flushUi();
+
+    expect(editor.value).toBe(customRequest);
+  });
+
+  it("uses the schema primary key and vector field for delete and search defaults", async () => {
+    backend.vectorGetCollectionDetail.mockResolvedValue({
+      name: "documents",
+      id: "documents",
+      milvusSchema: { fields: [field("document_id", "VarChar", { primaryKey: true }), field("embedding", "FloatVector", { dimension: 3 })] },
+    });
+
+    app = createApp(VectorBrowser, {
+      connectionId: "milvus-1",
+      database: "default",
+      collection: "documents",
+      databaseType: "milvus",
+    });
+    app.mount(root!);
+    await flushUi();
+
+    buttonWithText("vector.delete").click();
+    await nextTick();
+    expect(requestBody().filter).toBe('document_id in ["x"]');
+
+    buttonWithText("vector.search").click();
+    await nextTick();
+    expect(requestBody()).toMatchObject({ annsField: "embedding", data: [[0.1, 0.2, 0.3]] });
+  });
+});

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -1116,6 +1116,21 @@ export interface VectorCollectionMeta {
   collectionId?: string;
 }
 
+export interface MilvusFieldInfo {
+  name: string;
+  dataType: string;
+  dimension?: number;
+  primaryKey: boolean;
+  autoId: boolean;
+  nullable: boolean;
+  hasDefaultValue: boolean;
+  isFunctionOutput: boolean;
+}
+
+export interface MilvusCollectionSchema {
+  fields: MilvusFieldInfo[];
+}
+
 /** Mongo collection node metadata (not SQL tableType). */
 export type MongoCollectionKind = "collection" | "view" | "timeseries";
 
@@ -1127,6 +1142,7 @@ export interface CollectionInfo {
   name: string;
   id: string;
   dimension?: number;
+  milvusSchema?: MilvusCollectionSchema;
   kind?: MongoCollectionKind | "bucket";
   bucketName?: string;
 }

--- a/crates/dbx-core/src/db/vector_driver.rs
+++ b/crates/dbx-core/src/db/vector_driver.rs
@@ -29,10 +29,37 @@ const QUERY_VALUE_ENCODE_SET: &AsciiSet = &PATH_SEGMENT_ENCODE_SET.add(b'&').add
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct MilvusCollectionSchema {
+    #[serde(default)]
+    pub fields: Vec<MilvusFieldInfo>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MilvusFieldInfo {
+    pub name: String,
+    pub data_type: String,
+    pub dimension: Option<u32>,
+    #[serde(default)]
+    pub primary_key: bool,
+    #[serde(default)]
+    pub auto_id: bool,
+    #[serde(default)]
+    pub nullable: bool,
+    #[serde(default)]
+    pub has_default_value: bool,
+    #[serde(default)]
+    pub is_function_output: bool,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CollectionInfo {
     pub name: String,
     pub id: String,
     pub dimension: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub milvus_schema: Option<MilvusCollectionSchema>,
     pub kind: Option<String>,
     pub bucket_name: Option<String>,
 }
@@ -218,13 +245,7 @@ async fn list_qdrant_collections(client: &VectorClient) -> Result<Vec<Collection
         .flatten()
         .filter_map(|item| {
             let name = item.get("name").and_then(Value::as_str)?;
-            Some(CollectionInfo {
-                name: name.to_string(),
-                id: name.to_string(),
-                dimension: None,
-                kind: None,
-                bucket_name: None,
-            })
+            Some(CollectionInfo { name: name.to_string(), id: name.to_string(), ..Default::default() })
         })
         .collect();
     infos.sort_by(|a, b| a.name.cmp(&b.name));
@@ -243,7 +264,7 @@ async fn list_milvus_collections(client: &VectorClient, database: &str) -> Resul
             .iter()
             .filter_map(|item| {
                 let name = collection_name_from_milvus_item(item)?;
-                Some(CollectionInfo { name: name.clone(), id: name, dimension: None, kind: None, bucket_name: None })
+                Some(CollectionInfo { name: name.clone(), id: name, ..Default::default() })
             })
             .collect(),
         _ => Vec::new(),
@@ -263,7 +284,7 @@ async fn list_weaviate_collections(client: &VectorClient) -> Result<Vec<Collecti
     let body = send_json(client.get("/v1/schema"), "Weaviate").await?;
     let mut infos: Vec<CollectionInfo> = weaviate_collection_names_from_schema(&body)
         .into_iter()
-        .map(|name| CollectionInfo { name: name.clone(), id: name, dimension: None, kind: None, bucket_name: None })
+        .map(|name| CollectionInfo { name: name.clone(), id: name, ..Default::default() })
         .collect();
     infos.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(infos)
@@ -281,13 +302,7 @@ async fn list_chroma_collections(client: &VectorClient) -> Result<Vec<Collection
             let name = item.get("name").and_then(Value::as_str)?;
             let id = item.get("id").and_then(Value::as_str)?;
             let dimension = item.get("dimension").and_then(|v| v.as_u64()).map(|d| d as u32);
-            Some(CollectionInfo {
-                name: name.to_string(),
-                id: id.to_string(),
-                dimension,
-                kind: None,
-                bucket_name: None,
-            })
+            Some(CollectionInfo { name: name.to_string(), id: id.to_string(), dimension, ..Default::default() })
         })
         .collect();
     infos.sort_by(|a, b| a.name.cmp(&b.name));
@@ -314,13 +329,7 @@ async fn get_weaviate_collection_detail(client: &VectorClient, collection: &str)
             Ok(body) => weaviate_vector_dimension_from_graphql(&body, collection),
             Err(_) => None,
         };
-    Ok(CollectionInfo {
-        name: collection.to_string(),
-        id: collection.to_string(),
-        dimension,
-        kind: None,
-        bucket_name: None,
-    })
+    Ok(CollectionInfo { name: collection.to_string(), id: collection.to_string(), dimension, ..Default::default() })
 }
 
 async fn get_qdrant_collection_detail(client: &VectorClient, collection: &str) -> Result<CollectionInfo, String> {
@@ -338,28 +347,78 @@ async fn get_qdrant_collection_detail(client: &VectorClient, collection: &str) -
         name: collection.to_string(),
         id: collection.to_string(),
         dimension: dim,
-        kind: None,
-        bucket_name: None,
+        ..Default::default()
     })
 }
 
-fn milvus_vector_dim_from_field(field: &Value) -> Option<u32> {
-    if let Some(dim) = field.pointer("/params/dim").and_then(Value::as_u64) {
-        return Some(dim as u32);
-    }
-    if let Some(params) = field.get("params").and_then(Value::as_array) {
-        for param in params {
-            if param.get("key").and_then(Value::as_str) == Some("dim") {
-                if let Some(v) = param.get("value").and_then(Value::as_str) {
-                    return v.parse().ok();
-                }
-                if let Some(v) = param.get("value").and_then(Value::as_u64) {
-                    return Some(v as u32);
-                }
-            }
-        }
-    }
-    None
+fn milvus_data_type(field: &Value) -> Option<String> {
+    field.get("dataType").and_then(Value::as_str).map(str::to_string).or_else(|| match field.get("type")? {
+        Value::String(data_type) => Some(data_type.clone()),
+        Value::Number(code) => code.as_i64().and_then(milvus_data_type_from_code).map(str::to_string),
+        _ => None,
+    })
+}
+
+fn milvus_data_type_from_code(code: i64) -> Option<&'static str> {
+    Some(match code {
+        1 => "Bool",
+        2 => "Int8",
+        3 => "Int16",
+        4 => "Int32",
+        5 => "Int64",
+        10 => "Float",
+        11 => "Double",
+        20 => "String",
+        21 => "VarChar",
+        22 => "Array",
+        23 => "JSON",
+        24 => "Geometry",
+        100 => "BinaryVector",
+        101 => "FloatVector",
+        102 => "Float16Vector",
+        103 => "BFloat16Vector",
+        104 => "SparseFloatVector",
+        105 => "Int8Vector",
+        _ => return None,
+    })
+}
+
+fn milvus_dimension(field: &Value) -> Option<u32> {
+    let value = field.pointer("/elementTypeParams/dim").or_else(|| {
+        field
+            .get("params")
+            .and_then(Value::as_array)
+            .and_then(|params| params.iter().find(|param| param.get("key").and_then(Value::as_str) == Some("dim")))
+            .and_then(|param| param.get("value"))
+    })?;
+    value.as_u64().and_then(|dimension| dimension.try_into().ok()).or_else(|| value.as_str()?.parse().ok())
+}
+
+fn milvus_flag(field: &Value, name: &str, old_name: &str) -> bool {
+    field.get(name).or_else(|| field.get(old_name)).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn is_milvus_vector_data_type(data_type: &str) -> bool {
+    data_type.ends_with("Vector")
+}
+
+fn milvus_field_info(field: &Value) -> Option<MilvusFieldInfo> {
+    let name = field.get("fieldName").or_else(|| field.get("name"))?.as_str()?.to_string();
+    let data_type = milvus_data_type(field)?;
+    Some(MilvusFieldInfo {
+        name,
+        dimension: is_milvus_vector_data_type(&data_type).then(|| milvus_dimension(field)).flatten(),
+        data_type,
+        primary_key: milvus_flag(field, "isPrimaryKey", "is_primary_key"),
+        auto_id: milvus_flag(field, "autoId", "auto_id"),
+        nullable: field.get("nullable").and_then(Value::as_bool).unwrap_or(false),
+        has_default_value: field.get("defaultValue").is_some_and(|value| !value.is_null()),
+        is_function_output: milvus_flag(field, "isFunctionOutput", "is_function_output"),
+    })
+}
+
+fn milvus_collection_schema(fields: &[Value]) -> MilvusCollectionSchema {
+    MilvusCollectionSchema { fields: fields.iter().filter_map(milvus_field_info).collect() }
 }
 
 async fn get_milvus_collection_detail(
@@ -379,24 +438,18 @@ async fn get_milvus_collection_detail(
         let msg = body.get("message").and_then(Value::as_str).unwrap_or("unknown error");
         return Err(format!("Milvus collection detail error: {msg}"));
     }
-    let fields = body.pointer("/data/fields").and_then(Value::as_array);
-    let dim = fields
-        .and_then(|f| {
-            f.iter().find(|f| {
-                let t = f.get("type");
-                t.and_then(Value::as_str) == Some("FloatVector")
-                    || t.and_then(Value::as_str) == Some("BinaryVector")
-                    || t.and_then(Value::as_i64) == Some(101)
-                    || t.and_then(Value::as_i64) == Some(102)
-            })
-        })
-        .and_then(milvus_vector_dim_from_field);
+    let milvus_schema =
+        body.pointer("/data/fields").and_then(Value::as_array).map(|fields| milvus_collection_schema(fields));
+    let dimension = milvus_schema
+        .as_ref()
+        .and_then(|schema| schema.fields.iter().find(|field| is_milvus_vector_data_type(&field.data_type)))
+        .and_then(|field| field.dimension);
     Ok(CollectionInfo {
         name: collection.to_string(),
         id: collection.to_string(),
-        dimension: dim,
-        kind: None,
-        bucket_name: None,
+        dimension,
+        milvus_schema,
+        ..Default::default()
     })
 }
 
@@ -412,7 +465,7 @@ async fn get_chroma_collection_detail(client: &VectorClient, collection: &str) -
     let name = body.get("name").and_then(Value::as_str).unwrap_or(collection);
     let id = body.get("id").and_then(Value::as_str).unwrap_or(collection);
     let dimension = body.get("dimension").and_then(|v| v.as_u64()).map(|d| d as u32);
-    Ok(CollectionInfo { name: name.to_string(), id: id.to_string(), dimension, kind: None, bucket_name: None })
+    Ok(CollectionInfo { name: name.to_string(), id: id.to_string(), dimension, ..Default::default() })
 }
 
 fn chroma_get_response_to_rows(body: &Value) -> Vec<Value> {
@@ -602,11 +655,35 @@ pub async fn execute_rest_query(client: &VectorClient, input: &str) -> Result<Qu
     let resp = request.send().await.map_err(|e| format!("{} request failed: {e}", client.kind.label()))?;
     let status = resp.status().as_u16();
     let body = resp.json::<Value>().await.unwrap_or(Value::Null);
+    rest_query_result(client.kind, status, body, start)
+}
+
+fn rest_query_result(kind: VectorDbKind, status: u16, body: Value, start: Instant) -> Result<QueryResult, String> {
     if !(200..300).contains(&status) {
         let detail = serde_json::to_string_pretty(&body).unwrap_or_else(|_| body.to_string());
-        return Err(format!("{} error ({status}): {detail}", client.kind.label()));
+        return Err(format!("{} error ({status}): {detail}", kind.label()));
+    }
+    if kind == VectorDbKind::Milvus {
+        if let Some(error) = milvus_business_error(&body) {
+            return Err(error);
+        }
     }
     Ok(json_to_query_result(status, body, start))
+}
+
+// Milvus v2 returns many request failures as HTTP 200 with a non-zero JSON code.
+fn milvus_business_error(body: &Value) -> Option<String> {
+    let code = body.get("code").and_then(Value::as_i64)?;
+    if code == 0 {
+        return None;
+    }
+    let detail = body
+        .get("message")
+        .or_else(|| body.get("msg"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| serde_json::to_string_pretty(body).unwrap_or_else(|_| body.to_string()));
+    Some(format!("Milvus error (code {code}): {detail}"))
 }
 
 fn parse_rest_query(client: &VectorClient, input: &str) -> Result<reqwest::RequestBuilder, String> {
@@ -800,11 +877,11 @@ fn format_reqwest_error(err: &reqwest::Error) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        chroma_get_response_to_rows, starts_with_http_method, values_to_query_result, vector_auth,
-        weaviate_collection_names_from_schema, weaviate_vector_dimension_from_graphql, CollectionInfo, VectorAuth,
-        VectorDbKind,
+        chroma_get_response_to_rows, milvus_collection_schema, rest_query_result, starts_with_http_method,
+        values_to_query_result, vector_auth, weaviate_collection_names_from_schema,
+        weaviate_vector_dimension_from_graphql, CollectionInfo, VectorAuth, VectorDbKind,
     };
-    use serde_json::json;
+    use serde_json::{json, Value};
     use std::time::Instant;
 
     #[test]
@@ -812,6 +889,21 @@ mod tests {
         assert!(starts_with_http_method("post /collections/foo"));
         assert!(starts_with_http_method("GET /collections"));
         assert!(!starts_with_http_method("collection_name"));
+    }
+
+    #[test]
+    fn rejects_milvus_business_errors_returned_with_http_success() {
+        assert_eq!(
+            rest_query_result(
+                VectorDbKind::Milvus,
+                200,
+                json!({ "code": 1100, "message": "field kind does not exist" }),
+                Instant::now()
+            )
+            .unwrap_err(),
+            "Milvus error (code 1100): field kind does not exist"
+        );
+        assert!(rest_query_result(VectorDbKind::Milvus, 200, json!({ "code": 0 }), Instant::now()).is_ok());
     }
 
     #[test]
@@ -845,6 +937,88 @@ mod tests {
             }
         });
         assert_eq!(weaviate_vector_dimension_from_graphql(&body, "Article"), Some(1024));
+    }
+
+    #[test]
+    fn retains_milvus_fields_needed_for_schema_driven_upsert() {
+        let fields = vec![
+            json!({ "fieldName": "doc_id", "dataType": "VarChar", "isPrimaryKey": true }),
+            json!({ "fieldName": "embedding", "dataType": "FloatVector", "elementTypeParams": { "dim": "4" } }),
+            json!({ "fieldName": "score", "dataType": "Double" }),
+            json!({ "fieldName": "optional_note", "dataType": "VarChar", "nullable": true }),
+            json!({ "fieldName": "status", "dataType": "VarChar", "defaultValue": "new" }),
+            json!({ "fieldName": "bm25", "dataType": "SparseFloatVector", "isFunctionOutput": true }),
+        ];
+
+        let schema = milvus_collection_schema(&fields);
+        assert_eq!(schema.fields.len(), 6);
+        let primary_key = schema.fields.iter().find(|field| field.name == "doc_id").unwrap();
+        assert!(primary_key.primary_key);
+        let vector = schema.fields.iter().find(|field| field.name == "embedding").unwrap();
+        assert_eq!(vector.dimension, Some(4));
+        assert_eq!(vector.data_type, "FloatVector");
+        assert!(schema.fields.iter().find(|field| field.name == "optional_note").unwrap().nullable);
+        assert!(schema.fields.iter().find(|field| field.name == "status").unwrap().has_default_value);
+        assert!(schema.fields.iter().find(|field| field.name == "bm25").unwrap().is_function_output);
+    }
+
+    #[test]
+    fn extracts_milvus_schema_from_describe_response() {
+        let body = json!({
+            "data": {
+                "fields": [
+                    { "fieldName": "id", "dataType": "Int64" },
+                    {
+                        "fieldName": "embedding",
+                        "dataType": "FloatVector",
+                        "elementTypeParams": { "dim": "4" }
+                    }
+                ]
+            }
+        });
+
+        let schema = milvus_collection_schema(
+            body.pointer("/data/fields").and_then(Value::as_array).expect("Milvus schema fields"),
+        );
+        assert_eq!(schema.fields[1].name, "embedding");
+        assert_eq!(schema.fields[1].dimension, Some(4));
+    }
+
+    #[test]
+    fn accepts_existing_milvus_describe_fields() {
+        let body = json!({
+            "data": {
+                "fields": [{
+                    "name": "embedding",
+                    "type": 101,
+                    "params": [{ "key": "dim", "value": "4" }]
+                }]
+            }
+        });
+        let schema = milvus_collection_schema(
+            body.pointer("/data/fields").and_then(Value::as_array).expect("Milvus schema fields"),
+        );
+        assert_eq!(schema.fields[0].data_type, "FloatVector");
+        assert_eq!(schema.fields[0].dimension, Some(4));
+    }
+
+    #[test]
+    fn serializes_milvus_schema_for_the_frontend() {
+        let info = CollectionInfo {
+            name: "documents".to_string(),
+            id: "documents".to_string(),
+            milvus_schema: Some(milvus_collection_schema(&[json!({
+                "fieldName": "embedding",
+                "dataType": "FloatVector",
+                "elementTypeParams": { "dim": 3 },
+                "isPrimaryKey": true
+            })])),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(info).unwrap();
+        assert_eq!(value.pointer("/milvusSchema/fields/0/dataType"), Some(&json!("FloatVector")));
+        assert_eq!(value.pointer("/milvusSchema/fields/0/dimension"), Some(&json!(3)));
+        assert_eq!(value.pointer("/milvusSchema/fields/0/primaryKey"), Some(&json!(true)));
     }
 
     #[test]
@@ -898,13 +1072,7 @@ mod tests {
             .filter_map(|item| {
                 let name = item.get("name").and_then(|v| v.as_str())?;
                 let id = item.get("id").and_then(|v| v.as_str())?;
-                Some(CollectionInfo {
-                    name: name.to_string(),
-                    id: id.to_string(),
-                    dimension: None,
-                    kind: None,
-                    bucket_name: None,
-                })
+                Some(CollectionInfo { name: name.to_string(), id: id.to_string(), ..Default::default() })
             })
             .collect();
         assert_eq!(infos.len(), 2);

--- a/crates/dbx-core/src/db/vector_driver.rs
+++ b/crates/dbx-core/src/db/vector_driver.rs
@@ -394,8 +394,8 @@ fn milvus_dimension(field: &Value) -> Option<u32> {
     value.as_u64().and_then(|dimension| dimension.try_into().ok()).or_else(|| value.as_str()?.parse().ok())
 }
 
-fn milvus_flag(field: &Value, name: &str, old_name: &str) -> bool {
-    field.get(name).or_else(|| field.get(old_name)).and_then(Value::as_bool).unwrap_or(false)
+fn milvus_flag(field: &Value, names: &[&str]) -> bool {
+    names.iter().find_map(|name| field.get(name)).and_then(Value::as_bool).unwrap_or(false)
 }
 
 fn is_milvus_vector_data_type(data_type: &str) -> bool {
@@ -409,11 +409,11 @@ fn milvus_field_info(field: &Value) -> Option<MilvusFieldInfo> {
         name,
         dimension: is_milvus_vector_data_type(&data_type).then(|| milvus_dimension(field)).flatten(),
         data_type,
-        primary_key: milvus_flag(field, "isPrimaryKey", "is_primary_key"),
-        auto_id: milvus_flag(field, "autoId", "auto_id"),
+        primary_key: milvus_flag(field, &["primaryKey", "isPrimaryKey", "is_primary_key"]),
+        auto_id: milvus_flag(field, &["autoId", "auto_id"]),
         nullable: field.get("nullable").and_then(Value::as_bool).unwrap_or(false),
         has_default_value: field.get("defaultValue").is_some_and(|value| !value.is_null()),
-        is_function_output: milvus_flag(field, "isFunctionOutput", "is_function_output"),
+        is_function_output: milvus_flag(field, &["isFunctionOutput", "is_function_output"]),
     })
 }
 
@@ -942,7 +942,7 @@ mod tests {
     #[test]
     fn retains_milvus_fields_needed_for_schema_driven_upsert() {
         let fields = vec![
-            json!({ "fieldName": "doc_id", "dataType": "VarChar", "isPrimaryKey": true }),
+            json!({ "name": "doc_id", "type": "VarChar", "primaryKey": true, "autoId": true }),
             json!({ "fieldName": "embedding", "dataType": "FloatVector", "elementTypeParams": { "dim": "4" } }),
             json!({ "fieldName": "score", "dataType": "Double" }),
             json!({ "fieldName": "optional_note", "dataType": "VarChar", "nullable": true }),
@@ -954,6 +954,7 @@ mod tests {
         assert_eq!(schema.fields.len(), 6);
         let primary_key = schema.fields.iter().find(|field| field.name == "doc_id").unwrap();
         assert!(primary_key.primary_key);
+        assert!(primary_key.auto_id);
         let vector = schema.fields.iter().find(|field| field.name == "embedding").unwrap();
         assert_eq!(vector.dimension, Some(4));
         assert_eq!(vector.data_type, "FloatVector");

--- a/crates/dbx-core/src/document_ops.rs
+++ b/crates/dbx-core/src/document_ops.rs
@@ -87,13 +87,7 @@ fn mongo_list_databases_unauthorized(error: &str) -> bool {
 }
 
 fn mongo_collection_info(name: String, kind: mongo_driver::MongoCollectionKind) -> CollectionInfo {
-    CollectionInfo {
-        name: name.clone(),
-        id: name,
-        dimension: None,
-        kind: Some(kind.as_str().to_string()),
-        bucket_name: None,
-    }
+    CollectionInfo { name: name.clone(), id: name, kind: Some(kind.as_str().to_string()), ..Default::default() }
 }
 
 fn sort_mongo_collection_specs(
@@ -125,9 +119,9 @@ fn mongo_bucket_infos(names: &[String]) -> Vec<CollectionInfo> {
         .map(|bucket_name| CollectionInfo {
             name: bucket_name.clone(),
             id: format!("bucket:{bucket_name}"),
-            dimension: None,
             kind: Some("bucket".to_string()),
             bucket_name: Some(bucket_name),
+            ..Default::default()
         })
         .collect()
 }
@@ -221,10 +215,7 @@ pub async fn list_collections_core(
         }
         PoolKind::Elasticsearch(client) => {
             let names = sort_names(elasticsearch_driver::list_indices(client).await?);
-            Ok(names
-                .into_iter()
-                .map(|n| CollectionInfo { name: n.clone(), id: n, dimension: None, kind: None, bucket_name: None })
-                .collect())
+            Ok(names.into_iter().map(|n| CollectionInfo { name: n.clone(), id: n, ..Default::default() }).collect())
         }
         PoolKind::VectorDb(client) => vector_driver::list_collections_with_db(client, database).await,
         PoolKind::Agent(client) => {


### PR DESCRIPTION
## 变更说明

### 问题原因

Milvus 的默认写入请求此前固定生成 `vector` 字段，例如：

```json
{
  "id": 1,
  "vector": [0.1, 0.2, 0.3, 0.4]
}
```

但 Milvus collection 的向量字段不是固定名称。对于 `script_milvus_crud_demo`，describe collection 返回的实际字段名是 `embedding`。因此默认请求发送到 `/v2/vectordb/entities/upsert` 后，Milvus 返回 HTTP 200 和业务错误码 `1804`：`missing vector field: embedding`。

此前后端仅依据 HTTP 状态判断 REST 请求是否成功，导致这类 HTTP 200 但 `code != 0` 的 Milvus 业务错误未被转换为前端错误。前端也只使用 collection 的维度，没有取得完整 schema，无法知道真实的向量字段、主键字段和必填标量字段。

### 修复方式

1. 后端解析 Milvus describe collection 的 `data.fields`，将字段名、数据类型、维度、主键、auto ID、可空、默认值及函数输出标记返回给前端；同时保留现有 describe 响应格式的解析。
2. 前端基于 schema 生成 Milvus 的默认请求：
   - upsert 使用实际向量字段名（如 `embedding`），并补充非空且无默认值的标量字段；跳过 auto ID 和函数输出字段。
   - delete 使用实际主键字段构造 filter。
   - search 使用实际向量字段作为 `annsField`，并按该字段维度生成示例向量。
3. 对默认 upsert、delete 和 search，在 schema 未加载时先等待 collection detail；schema 获取失败或未包含受支持向量字段时不发送生成的请求，并展示错误。
4. 后端识别 Milvus HTTP 2xx 响应中的非零 `code`，将其作为可见错误返回，而不是将错误 JSON 当作成功查询结果。
5. 为异步 schema 加载补充生命周期保护：取消请求、切换 connection/database/collection 或关闭 VectorBrowser 后，使当前执行失效；请求进行期间锁定请求正文、搜索向量和 topK，避免 schema 返回后执行用户中途改写的默认请求。
6. Milvus collection detail 只由 VectorBrowser 加载，避免 Sidebar 再发起重复请求。

### 影响

使用非 `vector` 名称、多个必填字段、非数值主键、稀疏向量或 auto ID 的 Milvus collection 都能获得与实际 schema 一致的默认请求。用户仍可手动编辑请求；手动请求不会被异步返回的 schema 覆盖。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本次仅修复默认请求内容与执行期间的输入保护，没有新增视觉样式，未附截图或录屏。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过：`pnpm vitest run apps/desktop/src/components/vector/__tests__/VectorBrowser.spec.ts`（10/10）

新增覆盖包括：schema 驱动的默认 upsert、必填字段生成、schema 加载失败、取消/卸载/切换 collection 时不执行、搜索请求不被 schema 覆盖，以及 delete/search 使用实际 schema 字段。

## 关联 Issue

无
