### PR TITLE
Fix：修复侧边栏树节点展开后无法收起

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -385,7 +385,7 @@ function filterLocallySearchedTables(nodes: TreeNode[]): TreeNode[] {
         : indexed
           ? buildTableTreeNodes({ nodeId: node.id, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, tables: indexed.filter((entry) => !!matchSidebarLabel(entry.name.toLowerCase(), query.toLowerCase())) })
           : children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label.toLowerCase(), query.toLowerCase()));
-    return { ...node, children: matchingChildren, isExpanded: true };
+    return { ...node, children: matchingChildren };
   });
 }
 
@@ -1181,8 +1181,8 @@ function onSearchToggle(node: TreeNode) {
   searchCollapsedIds.value = next;
 }
 
-function onNodeToggled(node: TreeNode, wasExpanded: boolean) {
-  if (isTreeSearchFiltering.value || !wasExpanded) return;
+function onNodeToggled(node: TreeNode) {
+  if (isTreeSearchFiltering.value) return;
   syncSidebarTreeNodeExpansion(store.treeNodes, node);
 }
 

--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -40,6 +40,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { codeMirrorSqlDialect } from "@/lib/database/jdbcDialect";
 import { sqlFormatDialectForDbType } from "@/lib/sql/sqlFormatter";
 import { createSidebarActionTarget, findSidebarActionTarget, matchesSidebarActionTarget, type SidebarActionTarget } from "@/lib/sidebar/sidebarActionTarget";
+import { syncSidebarTreeNodeExpansion } from "@/lib/sidebar/sidebarTreeExpansion";
 import type { SidebarDangerDialogRequest } from "@/lib/sidebar/sidebarDangerDialog";
 import { resetSidebarTreeDialogState } from "./sidebarTreeDialogState";
 import { SidebarDangerConfirmDialog, SidebarDdlViewDialog, SidebarObjectSourceDialog, SidebarProcedureExecutionDialog, SidebarVisibleDatabasesDialog, SidebarVisibleSchemasDialog } from "./sidebarAsyncDialogs";
@@ -667,10 +668,7 @@ watch(flatNodes, (nodes) => {
     }
   }
   stickyScrollTop.value = 0;
-  void nextTick(() => {
-    treeScrollerRef.value?.forceUpdate(true);
-    scheduleSidebarScrollMetricsUpdate();
-  });
+  void nextTick(scheduleSidebarScrollMetricsUpdate);
 });
 
 const sidebarTreeOverflowClass = computed(() => (settingsStore.editorSettings.sidebarAllowHorizontalScroll ? "overflow-x-auto sidebar-tree-horizontal-scroll" : "overflow-x-hidden"));
@@ -1183,6 +1181,11 @@ function onSearchToggle(node: TreeNode) {
   searchCollapsedIds.value = next;
 }
 
+function onNodeToggled(node: TreeNode, wasExpanded: boolean) {
+  if (isTreeSearchFiltering.value || !wasExpanded) return;
+  syncSidebarTreeNodeExpansion(store.treeNodes, node);
+}
+
 function openSidebarContextMenu(event: MouseEvent, node: TreeNode, openContextMenu: (event: MouseEvent, itemsOverride?: ContextMenuItem[]) => void) {
   const items = sidebarTreeRuntime.buildContextMenu(node);
   sidebarContextMenuTarget.value = createSidebarActionTarget(node);
@@ -1663,6 +1666,7 @@ defineExpose({ focusSearch, createNewGroup, collapseAllTreeNodes });
       :node="sidebarTreeRuntimeInitialNode"
       :depth="0"
       @search-toggle="onSearchToggle"
+      @node-toggled="onNodeToggled"
       @open-ddl="openSidebarDdl"
       @open-object-source="openSidebarObjectSource"
       @open-procedure="openSidebarProcedure"

--- a/apps/desktop/src/lib/sidebar/sidebarTreeExpansion.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarTreeExpansion.ts
@@ -1,0 +1,9 @@
+import type { TreeNode } from "@/types/database";
+import { findSidebarActionTarget } from "@/lib/sidebar/sidebarActionTarget";
+
+export function syncSidebarTreeNodeExpansion(nodes: readonly TreeNode[], renderedNode: TreeNode): boolean {
+  const liveNode = findSidebarActionTarget(nodes, renderedNode);
+  if (!liveNode || liveNode === renderedNode || liveNode.isExpanded === renderedNode.isExpanded) return false;
+  liveNode.isExpanded = renderedNode.isExpanded;
+  return true;
+}

--- a/packages/app-tests/sidebarTreeAffordances.test.ts
+++ b/packages/app-tests/sidebarTreeAffordances.test.ts
@@ -1,6 +1,8 @@
 import { strict as assert } from "node:assert";
 import { readFileSync } from "node:fs";
 import { test } from "vitest";
+import { syncSidebarTreeNodeExpansion } from "../../apps/desktop/src/lib/sidebar/sidebarTreeExpansion.ts";
+import type { TreeNode } from "../../apps/desktop/src/types/database.ts";
 
 const treeItem = readFileSync("apps/desktop/src/components/sidebar/TreeItem.vue", "utf8");
 const runtimeHost = readFileSync("apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue", "utf8");
@@ -24,6 +26,23 @@ test("complex tree changes retain the full rebuild fallback", () => {
   assert.match(connectionTree, /const flatNodes = computed<FlatTreeNode\[]>/);
   assert.match(connectionTree, /flattenTree\(filteredNodes\.value\)/);
   assert.match(connectionTree, /watch\(flatNodes,/);
+  assert.doesNotMatch(connectionTree, /treeScrollerRef\.value\?\.(?:forceUpdate|updateVisibleItems)/);
+  assert.match(connectionTree, /@node-toggled="onNodeToggled"/);
+});
+
+test("tree toggles synchronize filtered node clones with the live sidebar tree", () => {
+  const liveConnection: TreeNode = {
+    id: "connection-1",
+    label: "Connection 1",
+    type: "connection",
+    connectionId: "connection-1",
+    isExpanded: true,
+  };
+  const renderedClone: TreeNode = { ...liveConnection, isExpanded: false };
+
+  assert.equal(syncSidebarTreeNodeExpansion([liveConnection], renderedClone), true);
+  assert.equal(liveConnection.isExpanded, false);
+  assert.equal(syncSidebarTreeNodeExpansion([liveConnection], liveConnection), false);
 });
 
 test("tree rebuilds keep a context menu only while its target row remains visible", () => {

--- a/packages/app-tests/sidebarTreeAffordances.test.ts
+++ b/packages/app-tests/sidebarTreeAffordances.test.ts
@@ -31,18 +31,34 @@ test("complex tree changes retain the full rebuild fallback", () => {
 });
 
 test("tree toggles synchronize filtered node clones with the live sidebar tree", () => {
-  const liveConnection: TreeNode = {
+  const expandedConnection: TreeNode = {
     id: "connection-1",
     label: "Connection 1",
     type: "connection",
     connectionId: "connection-1",
     isExpanded: true,
   };
-  const renderedClone: TreeNode = { ...liveConnection, isExpanded: false };
+  const collapsedClone: TreeNode = { ...expandedConnection, isExpanded: false };
+  const collapsedConnection: TreeNode = {
+    id: "connection-2",
+    label: "Connection 2",
+    type: "connection",
+    connectionId: "connection-2",
+    isExpanded: false,
+  };
+  const expandedClone: TreeNode = { ...collapsedConnection, isExpanded: true };
 
-  assert.equal(syncSidebarTreeNodeExpansion([liveConnection], renderedClone), true);
-  assert.equal(liveConnection.isExpanded, false);
-  assert.equal(syncSidebarTreeNodeExpansion([liveConnection], liveConnection), false);
+  assert.equal(syncSidebarTreeNodeExpansion([expandedConnection], collapsedClone), true);
+  assert.equal(expandedConnection.isExpanded, false);
+  assert.equal(syncSidebarTreeNodeExpansion([collapsedConnection], expandedClone), true);
+  assert.equal(collapsedConnection.isExpanded, true);
+  assert.equal(syncSidebarTreeNodeExpansion([expandedConnection], expandedConnection), false);
+});
+
+test("local table search preserves live expansion state", () => {
+  assert.match(connectionTree, /return \{ \.\.\.node, children: matchingChildren \};/);
+  assert.doesNotMatch(connectionTree, /children: matchingChildren,\s*isExpanded:\s*true/);
+  assert.match(connectionTree, /function onNodeToggled\(node: TreeNode\) \{\s*if \(isTreeSearchFiltering\.value\) return;\s*syncSidebarTreeNodeExpansion/);
 });
 
 test("tree rebuilds keep a context menu only while its target row remains visible", () => {


### PR DESCRIPTION
## 问题

本地表搜索会为渲染结果创建树节点副本。用户收起数据库、表或字段节点时，运行时只修改了渲染副本，连接存储中的真实节点仍保持展开，导致侧边栏无法单独收起。

同时，树重建逻辑调用了不属于 `RecycleScroller` 的 `forceUpdate` 方法，进一步产生运行时异常。

## 修复

- 在非全局搜索状态下，将收起操作同步到连接存储中的真实树节点。
- 仅同步收起路径，避免覆盖异步展开加载器已经更新的状态。
- 移除无效的 `RecycleScroller.forceUpdate` 调用，使用组件自身的响应式列表更新。
- 增加节点副本与真实树节点状态同步的回归测试。

## 验证

- 实际 UI 验证点击连接整行可以展开、收起。
- 实际 UI 验证点击左侧箭头可以展开、收起。
- 控制台不再出现 `forceUpdate is not a function`。
- `pnpm check` 通过：format、lint、typecheck、test。

## 关联 Issue

- Closes #4878
- Closes #4873
- Related to #4936
- Related to #4937
- Related to #4940