### PR TITLE
fix(sidebar): preserve table details after type filtering

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -7,7 +7,7 @@ import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useToast } from "@/composables/useToast";
 import type { ObjectSourceKind, TableInfo, TableNameFilter, TreeNode, TreeNodeType } from "@/types/database";
-import { filterSidebarSearchRootsByConnectionState, filterSidebarTree, filterSidebarTreeToConnectedConnections, resolveSidebarFilterGuards } from "@/lib/sidebar/sidebarSearchTree";
+import { filterSidebarSearchRootsByConnectionState, filterSidebarTree, filterSidebarTreeToConnectedConnections, resolveSidebarFilterGuards, reuseLiveSidebarTreeNodes } from "@/lib/sidebar/sidebarSearchTree";
 import { matchSidebarLabel } from "@/lib/sidebar/sidebarSearch";
 import { buildTableTreeNodes } from "@/lib/table/tableTree";
 import { isCancelSearchShortcut, isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut } from "@/lib/editor/keyboardShortcuts";
@@ -382,7 +382,10 @@ function filterLocallySearchedTables(nodes: TreeNode[]): TreeNode[] {
       indexed === null
         ? children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label.toLowerCase(), query.toLowerCase()))
         : indexed
-          ? buildTableTreeNodes({ nodeId: node.id, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, tables: indexed.filter((entry) => !!matchSidebarLabel(entry.name.toLowerCase(), query.toLowerCase())) })
+          ? reuseLiveSidebarTreeNodes(
+              buildTableTreeNodes({ nodeId: node.id, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, tables: indexed.filter((entry) => !!matchSidebarLabel(entry.name.toLowerCase(), query.toLowerCase())) }),
+              children,
+            )
           : children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label.toLowerCase(), query.toLowerCase()));
     return { ...node, children: matchingChildren, isExpanded: true };
   });

--- a/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
@@ -49,10 +49,13 @@ function filterSidebarTreeWithMatcher(nodes: TreeNode[], matchLabel: SidebarLabe
     // Type-only filtering keeps matching rows and their ancestor path, but not
     // unrelated descendants that would make the selected type appear ignored.
     const preservesSubtree = !!matchLabel && !!selfMatch && preserveMatchedSubtreeTypes.has(node.type);
+    // A type-matched table keeps its loaded detail groups after the text query
+    // is cleared instead of being rebuilt with an empty filtered child list.
+    const preservesTypeMatchedTable = !matchLabel && !!selfMatch && node.type === "table";
     const filteredChildren = preservesSubtree ? node.children : node.children ? filterSidebarTreeWithMatcher(node.children, matchLabel, collapsedIds, searchableNodeTypes) : undefined;
 
     if (selfMatch || (filteredChildren && filteredChildren.length > 0)) {
-      if (!node.children) {
+      if (!node.children || preservesTypeMatchedTable) {
         filteredNodes.push({ node, score: selfMatch?.score ?? 0 });
       } else {
         const children = filteredChildren ?? [];

--- a/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
@@ -28,6 +28,11 @@ export function filterSidebarTree(nodes: TreeNode[], query: string, collapsedIds
   return filterSidebarTreeWithMatcher(nodes, matchLabel, collapsedIds, searchableNodeTypes);
 }
 
+export function reuseLiveSidebarTreeNodes(indexedNodes: TreeNode[], liveNodes: readonly TreeNode[]): TreeNode[] {
+  const liveNodesById = new Map(liveNodes.map((node) => [node.id, node]));
+  return indexedNodes.map((node) => liveNodesById.get(node.id) ?? node);
+}
+
 function filterSidebarTreeWithMatcher(nodes: TreeNode[], matchLabel: SidebarLabelMatcher | undefined, collapsedIds: ReadonlySet<string>, searchableNodeTypes?: ReadonlySet<TreeNodeType>): TreeNode[] {
   const filteredNodes: { node: TreeNode; score: number }[] = [];
 

--- a/packages/app-tests/sidebarSearchTree.test.ts
+++ b/packages/app-tests/sidebarSearchTree.test.ts
@@ -350,6 +350,35 @@ test("filters the sidebar by node type without a text query", () => {
   );
 });
 
+test("preserves an expanded type-filtered table after the text query is cleared", () => {
+  const table: TreeNode = {
+    id: "conn:db:orders",
+    label: "orders",
+    type: "table",
+    connectionId: "conn",
+    database: "inventory",
+    isExpanded: true,
+    children: [
+      {
+        id: "conn:db:orders:__columns",
+        label: "tree.columns",
+        type: "group-columns",
+        connectionId: "conn",
+        database: "inventory",
+        tableName: "orders",
+        isExpanded: false,
+        children: [],
+      },
+    ],
+  };
+
+  const [filteredTable] = filterSidebarTree([table], "", new Set(), new Set(["table"]));
+
+  assert.equal(filteredTable, table);
+  assert.equal(filteredTable?.isExpanded, true);
+  assert.equal(filteredTable?.children?.[0]?.type, "group-columns");
+});
+
 test("combines text search with the selected node types", () => {
   const filtered = filterSidebarTree(scopedSearchNodes(), "order", new Set(), new Set(["schema"]));
 

--- a/packages/app-tests/sidebarSearchTree.test.ts
+++ b/packages/app-tests/sidebarSearchTree.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { filterSidebarSearchRootsByConnectionState, filterSidebarTree } from "../../apps/desktop/src/lib/sidebar/sidebarSearchTree.ts";
+import { filterSidebarSearchRootsByConnectionState, filterSidebarTree, reuseLiveSidebarTreeNodes } from "../../apps/desktop/src/lib/sidebar/sidebarSearchTree.ts";
 import type { TreeNode } from "../../apps/desktop/src/types/database.ts";
 
 test("preserves loaded table children when the table itself matches search", () => {
@@ -377,6 +377,47 @@ test("preserves an expanded type-filtered table after the text query is cleared"
   assert.equal(filteredTable, table);
   assert.equal(filteredTable?.isExpanded, true);
   assert.equal(filteredTable?.children?.[0]?.type, "group-columns");
+});
+
+test("indexed table search reuses loaded live node state before type filtering", () => {
+  const liveTable: TreeNode = {
+    id: "conn:db:orders",
+    label: "orders",
+    type: "table",
+    connectionId: "conn",
+    database: "inventory",
+    isExpanded: true,
+    isLoading: true,
+    children: [
+      {
+        id: "conn:db:orders:__columns",
+        label: "tree.columns",
+        type: "group-columns",
+        connectionId: "conn",
+        database: "inventory",
+        tableName: "orders",
+        children: [],
+      },
+    ],
+  };
+  const indexedTable: TreeNode = { ...liveTable, isExpanded: false, isLoading: false, children: [] };
+  const indexedOnly: TreeNode = {
+    id: "conn:db:archive",
+    label: "archive",
+    type: "table",
+    connectionId: "conn",
+    database: "inventory",
+    children: [],
+  };
+
+  const merged = reuseLiveSidebarTreeNodes([indexedTable, indexedOnly], [liveTable]);
+  const filtered = filterSidebarTree(merged, "", new Set(), new Set(["table"]));
+
+  assert.equal(filtered[0], liveTable);
+  assert.equal(filtered[0]?.children?.[0]?.type, "group-columns");
+  assert.equal(filtered[0]?.isExpanded, true);
+  assert.equal(filtered[0]?.isLoading, true);
+  assert.equal(filtered[1], indexedOnly);
 });
 
 test("combines text search with the selected node types", () => {


### PR DESCRIPTION
## 变更说明

修复侧边栏按“表”类型筛选后，清空文本关键词会导致表节点无法展开查看详情的问题。

- 类型筛选直接命中 `table` 时，保留该节点已有的展开状态和详情子树。
- 清空关键词后，不再把表节点重新构造成 `children: []` 的展示副本。
- 保持数据库、Schema 等类型筛选的现有行为，不带回无关后代。

## 根因

有文本关键词时，命中的表会保留已加载的详情子树；文本清空但“表”类型筛选仍生效时，`filterSidebarTree` 会继续按节点类型递归过滤表的详情分组，最终生成一个空子节点副本。即使表详情已经加载，筛选结果仍无法展示 Columns、Indexes 等节点。

## 范围

本 PR 仅修复 #4841 报告的 `table` 展开问题，不同时修改 View、MongoDB Collection、筛选结果拖拽或后续折叠行为。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动

本次不涉及视觉样式，仅修正侧边栏筛选后的展开行为。Draft 阶段待补充截图或录屏。

## 验证

- [x] `pnpm check` 通过（format、lint、typecheck、test）
- [x] 前端全量测试通过：657 个测试文件、5691 个用例
- [x] 新增回归测试，覆盖“表类型筛选仍生效、文本关键词已清空、已展开表保留详情子树”的场景
- [x] 使用 SQL 数据库连接手动验证，清空关键词后点击表节点可显示 Columns、Indexes 等详情

## 关联 Issue

Closes #4841
