### PR TITLE
fix(structure): show Postgres index types in structure editor

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -70,6 +70,7 @@ import {
   rehydrateColumnDraftsFromMetadata,
   resolveInsertColumnIndex,
   restoreDamengLengthUnitsAfterSave,
+  sameStructureIndexType,
   splitDataType,
   toColumnNames,
 } from "@/lib/table/tableStructureEditorState";
@@ -212,7 +213,7 @@ function indexChanged(index: EditableStructureIndex): boolean {
     !sameList(index.columns, original.columns) ||
     index.isUnique !== original.is_unique ||
     !sameText(index.filter, original.filter) ||
-    !sameText(index.indexType, original.index_type) ||
+    !sameStructureIndexType(index.indexType, original.index_type) ||
     !sameList(index.includedColumns, original.included_columns) ||
     !sameText(index.comment, original.comment)
   );

--- a/apps/desktop/src/lib/table/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorState.ts
@@ -758,6 +758,16 @@ export function rehydrateColumnDraftsFromMetadata(draftColumns: EditableStructur
   return [...nextColumns, ...missingMetadataDrafts];
 }
 
+/** Canonicalize index method for structure editor options (e.g. Postgres `btree` → `BTREE`). */
+export function normalizeStructureIndexType(indexType: string | null | undefined): string {
+  return (indexType ?? "").trim().toUpperCase();
+}
+
+/** Case-insensitive index-type equality (draft is uppercased; API may still return lowercase amname). */
+export function sameStructureIndexType(left: string | null | undefined, right: string | null | undefined): boolean {
+  return normalizeStructureIndexType(left) === normalizeStructureIndexType(right);
+}
+
 export function createIndexDrafts(indexes: IndexInfo[]): EditableStructureIndex[] {
   return indexes.map((index) => ({
     id: `existing:${index.name}`,
@@ -767,7 +777,8 @@ export function createIndexDrafts(indexes: IndexInfo[]): EditableStructureIndex[
     isUnique: index.is_unique,
     isPrimary: index.is_primary,
     filter: index.filter ?? "",
-    indexType: index.index_type ?? "",
+    // Match Select options (BTREE/GIN/…); Postgres pg_am.amname is lowercase.
+    indexType: normalizeStructureIndexType(index.index_type),
     includedColumns: index.included_columns ? [...index.included_columns] : [],
     comment: index.comment ?? "",
     original: index,

--- a/packages/app-tests/tableStructureEditorState.test.ts
+++ b/packages/app-tests/tableStructureEditorState.test.ts
@@ -19,9 +19,11 @@ import {
   isSqlServerIdentityCompatibleDataType,
   mysqlEnumDataType,
   normalizeDataTypeParams,
+  normalizeStructureIndexType,
   parseExtraToColumnExtra,
   rehydrateColumnDraftsFromMetadata,
   resolveInsertColumnIndex,
+  sameStructureIndexType,
   toColumnNames,
 } from "../../apps/desktop/src/lib/table/tableStructureEditorState.ts";
 import { firstStructureMetadataTab, isStructureMetadataTabSupported } from "../../apps/desktop/src/lib/table/tableMetadataCapabilities.ts";
@@ -400,6 +402,48 @@ test("creates editable index drafts and splits pasted column lists", () => {
     ],
   );
   assert.equal(toColumnNames(["id", "name"]), "id, name");
+});
+
+test("normalizes Postgres lowercase index types when creating structure drafts", () => {
+  const postgresIndexes: IndexInfo[] = [
+    {
+      name: "system_big_screen_asset_pkey",
+      columns: ["id"],
+      is_unique: true,
+      is_primary: true,
+      index_type: "btree",
+    },
+    {
+      name: "SYSTEM_BIG_SCREEN_ASSET_TAGS_JSON_IDX",
+      columns: ["tags_json"],
+      is_unique: false,
+      is_primary: false,
+      index_type: "gin",
+    },
+    {
+      name: "idx_hash",
+      columns: ["name"],
+      is_unique: false,
+      is_primary: false,
+      index_type: "hash",
+    },
+  ];
+
+  const drafts = createIndexDrafts(postgresIndexes);
+  assert.deepEqual(
+    drafts.map((draft) => ({ name: draft.name, indexType: draft.indexType })),
+    [
+      { name: "system_big_screen_asset_pkey", indexType: "BTREE" },
+      { name: "SYSTEM_BIG_SCREEN_ASSET_TAGS_JSON_IDX", indexType: "GIN" },
+      { name: "idx_hash", indexType: "HASH" },
+    ],
+  );
+
+  // Uppercased drafts must not look like a type change vs Postgres amname.
+  assert.equal(sameStructureIndexType(drafts[0]!.indexType, postgresIndexes[0]!.index_type), true);
+  assert.equal(sameStructureIndexType("BTREE", "btree"), true);
+  assert.equal(sameStructureIndexType("GIN", "hash"), false);
+  assert.equal(normalizeStructureIndexType("  gist "), "GIST");
 });
 
 test("generates conventional index names from table and columns", () => {


### PR DESCRIPTION
## 变更说明

修复 PostgreSQL 表结构编辑器中索引「类型」列不显示的问题。

- Postgres `pg_am.amname` 返回小写方法名（如 `btree` / `gin`），结构编辑器 Select 选项为大写（`BTREE` / `GIN`），精确匹配失败导致下拉为空。
- 在 `createIndexDrafts` 边界将 `index_type` 规范化为大写，对齐 UI 选项。
- `indexChanged` 对索引类型做大小写不敏感比较，避免 draft 大写与 API 原始小写被误判为已修改。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）


## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过（`packages/app-tests/tableStructureEditorState.test.ts`，含 Postgres 小写 index type 规范化用例）

## 关联 Issue

Closes #4606