### PR TITLE
fix(ui): 修正加密导出密码框的 Tab 顺序

### DIFF
--- a/apps/desktop/src/components/config/ConfigPassphraseDialog.vue
+++ b/apps/desktop/src/components/config/ConfigPassphraseDialog.vue
@@ -76,12 +76,12 @@ const displayError = computed(() => error.value || props.externalError || "");
 
         <div class="grid gap-2">
           <Label>{{ t("configExport.passphrase") }}</Label>
-          <PasswordInput v-model="passphrase" :placeholder="t('configExport.passphrasePlaceholder')" @keydown.enter="mode === 'import' ? confirm() : undefined" />
+          <PasswordInput v-model="passphrase" :placeholder="t('configExport.passphrasePlaceholder')" :toggle-tab-index="-1" @keydown.enter="mode === 'import' ? confirm() : undefined" />
         </div>
 
         <div v-if="mode === 'export'" class="grid gap-2">
           <Label>{{ t("configExport.passphraseConfirm") }}</Label>
-          <PasswordInput v-model="passphraseConfirm" :placeholder="t('configExport.passphraseConfirmPlaceholder')" @keydown.enter="confirm" />
+          <PasswordInput v-model="passphraseConfirm" :placeholder="t('configExport.passphraseConfirmPlaceholder')" :toggle-tab-index="-1" @keydown.enter="confirm" />
         </div>
 
         <p v-if="displayError" class="text-sm text-destructive">{{ displayError }}</p>

--- a/apps/desktop/src/components/ui/PasswordInput.vue
+++ b/apps/desktop/src/components/ui/PasswordInput.vue
@@ -13,6 +13,7 @@ const props = withDefaults(
     class?: string;
     inputClass?: string;
     showToggle?: boolean;
+    toggleTabIndex?: number;
     showLabel?: string;
     hideLabel?: string;
   }>(),
@@ -29,7 +30,16 @@ const toggleLabel = computed(() => (visible.value ? props.hideLabel || t("common
 <template>
   <div :class="props.class" class="relative">
     <Input v-model="model" :type="visible ? 'text' : 'password'" :placeholder="placeholder" :disabled="disabled" :class="[props.inputClass, props.showToggle ? 'pr-8' : undefined]" v-bind="$attrs" />
-    <button v-if="props.showToggle" type="button" :disabled="disabled" class="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-50" :aria-label="toggleLabel" :title="toggleLabel" @click="visible = !visible">
+    <button
+      v-if="props.showToggle"
+      type="button"
+      :disabled="disabled"
+      :tabindex="toggleTabIndex"
+      class="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+      :aria-label="toggleLabel"
+      :title="toggleLabel"
+      @click="visible = !visible"
+    >
       <Eye v-if="!visible" class="size-3.5" />
       <EyeOff v-else class="size-3.5" />
     </button>

--- a/apps/desktop/src/lib/__tests__/ui/passwordInput.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ui/passwordInput.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { createApp, nextTick, ref } from "vue";
+import { createI18n } from "vue-i18n";
+import { afterEach, describe, expect, it } from "vitest";
+import PasswordInput from "@/components/ui/PasswordInput.vue";
+
+const mountedApps: Array<ReturnType<typeof createApp>> = [];
+
+async function mountPasswordInput(toggleTabIndex?: number) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const app = createApp({
+    components: { PasswordInput },
+    setup() {
+      return { toggleTabIndex, value: ref("") };
+    },
+    template: '<PasswordInput v-model="value" :toggle-tab-index="toggleTabIndex" />',
+  });
+  app.use(
+    createI18n({
+      legacy: false,
+      locale: "en",
+      messages: { en: { common: { hidePassword: "Hide password", showPassword: "Show password" } } },
+    }),
+  );
+  app.mount(host);
+  mountedApps.push(app);
+  await nextTick();
+  return host.querySelector("button") as HTMLButtonElement;
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.replaceChildren();
+});
+
+describe("PasswordInput", () => {
+  it("keeps the visibility toggle in the default tab order", async () => {
+    expect((await mountPasswordInput()).tabIndex).toBe(0);
+  });
+
+  it("allows forms to remove the visibility toggle from the tab order", async () => {
+    expect((await mountPasswordInput(-1)).tabIndex).toBe(-1);
+  });
+});


### PR DESCRIPTION
## 问题

加密导出对话框中的显示密码按钮默认参与 Tab 顺序，导致用户在输入密码短语后按 Tab 时，焦点先落到显示密码按钮，而不是下一个输入框。

## 修改

- 为 `PasswordInput` 增加可选的显示按钮 `tabIndex` 配置
- 加密导出/解密导入对话框将显示密码按钮移出 Tab 顺序
- 保留显示密码按钮的鼠标点击能力
- 其他页面的 `PasswordInput` 继续使用原有默认 Tab 行为
- 增加组件测试，覆盖默认行为和 `tabIndex=-1` 配置

## 验证

- 实际浏览器验证：第一个密码框按 Tab 后直接聚焦确认密码框，再按 Tab 聚焦导出按钮
- 实际浏览器验证：显示/隐藏密码按钮仍可通过鼠标正常切换
- `pnpm vitest run apps/desktop/src/lib/__tests__/ui/passwordInput.spec.ts`
- `pnpm check`