### PR TITLE
fix(desktop): preserve SQL file tabs on cold start

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1126,9 +1126,15 @@ function pasteClipboardAsSqlInCondition() {
   void contentAreaRef.value?.pasteClipboardAsSqlInCondition?.();
 }
 
+// Cold-start file arguments can arrive while persisted tabs are still being
+// restored. Keep external SQL tabs behind the same desktop initialization so
+// initOpenTabs cannot replace a tab that was just opened from the OS.
+let desktopInitializationPromise: Promise<void> | null = null;
+
 async function openSqlFilePath(path: string) {
   if (!isTauriRuntime()) return;
   try {
+    await desktopInitializationPromise;
     const content = await api.readExternalSqlFile(path);
     const connectionId = connectionStore.activeConnectionId || activeTab.value?.connectionId || connectionStore.connections[0]?.id || "";
     const connection = connectionId ? connectionStore.getConfig(connectionId) : undefined;
@@ -2129,7 +2135,7 @@ onMounted(async () => {
       .catch(() => {});
     return;
   }
-  void initApp();
+  desktopInitializationPromise = initApp();
   setupFileDrop().catch(() => {});
   setTimeout(() => {
     runUpdateNotificationChecks();

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -34,6 +34,7 @@ import { useVisibilityChange } from "@/composables/useVisibilityChange";
 import { useWebDavAutoUpload } from "@/composables/useWebDavAutoUpload";
 import { useScheduledDatabaseBackups } from "@/composables/useScheduledDatabaseBackups";
 import { shouldDrawDesktopWindowFrame } from "@/composables/useWindowControls";
+import { createOpenTabsRestorationBarrier, initializeDesktopOpenTabs, type OpenTabsRestorationBarrier } from "@/lib/app/openTabsStartup";
 import { useSaveSqlFolderSelection } from "@/composables/useSaveSqlFolderSelection";
 import "@/i18n";
 import { translateBackendError } from "@/i18n/backend-errors";
@@ -1127,14 +1128,14 @@ function pasteClipboardAsSqlInCondition() {
 }
 
 // Cold-start file arguments can arrive while persisted tabs are still being
-// restored. Keep external SQL tabs behind the same desktop initialization so
-// initOpenTabs cannot replace a tab that was just opened from the OS.
-let desktopInitializationPromise: Promise<void> | null = null;
+// restored. Keep external SQL tabs behind that phase only, so unrelated
+// initialization cannot permanently block files opened from the OS.
+let desktopOpenTabsRestorationBarrier: OpenTabsRestorationBarrier | null = null;
 
 async function openSqlFilePath(path: string) {
   if (!isTauriRuntime()) return;
   try {
-    await desktopInitializationPromise;
+    await desktopOpenTabsRestorationBarrier?.settled;
     const content = await api.readExternalSqlFile(path);
     const connectionId = connectionStore.activeConnectionId || activeTab.value?.connectionId || connectionStore.connections[0]?.id || "";
     const connection = connectionId ? connectionStore.getConfig(connectionId) : undefined;
@@ -1997,14 +1998,27 @@ function onLoginSuccess() {
 async function initApp() {
   const t0 = performance.now();
   console.log("[STARTUP] initApp begin");
-  await settingsStore.initAiConfigs();
-  try {
+  const restoreOpenTabs = async () => {
     await settingsStore.initEditorSettings();
     console.log(`[STARTUP]   settingsStore.initEditorSettings: ${(performance.now() - t0).toFixed(0)}ms`);
     await connectionStore.initFromDisk();
     console.log(`[STARTUP]   connectionStore.initFromDisk: ${(performance.now() - t0).toFixed(0)}ms`);
     await queryStore.initOpenTabs({ validConnectionIds: connectionStore.connections.map((connection) => connection.id) });
     console.log(`[STARTUP]   queryStore.initOpenTabs: ${(performance.now() - t0).toFixed(0)}ms`);
+  };
+
+  if (!desktopOpenTabsRestorationBarrier) await settingsStore.initAiConfigs();
+  try {
+    if (desktopOpenTabsRestorationBarrier) {
+      await initializeDesktopOpenTabs({
+        barrier: desktopOpenTabsRestorationBarrier,
+        initializeOptionalState: () => settingsStore.initAiConfigs(),
+        restoreOpenTabs,
+        onOptionalStateError: (error) => console.error("[STARTUP] settingsStore.initAiConfigs failed", error),
+      });
+    } else {
+      await restoreOpenTabs();
+    }
     await settingsStore.initDesktopSettings().catch(() => {});
 
     void promptTemplateStore.init();
@@ -2135,7 +2149,8 @@ onMounted(async () => {
       .catch(() => {});
     return;
   }
-  desktopInitializationPromise = initApp();
+  desktopOpenTabsRestorationBarrier = createOpenTabsRestorationBarrier();
+  void initApp();
   setupFileDrop().catch(() => {});
   setTimeout(() => {
     runUpdateNotificationChecks();

--- a/apps/desktop/src/lib/app/openTabsStartup.ts
+++ b/apps/desktop/src/lib/app/openTabsStartup.ts
@@ -1,0 +1,41 @@
+export interface OpenTabsRestorationBarrier {
+  readonly settled: Promise<void>;
+  settle: () => void;
+}
+
+export function createOpenTabsRestorationBarrier(): OpenTabsRestorationBarrier {
+  let resolveBarrier: () => void;
+  let isSettled = false;
+  const settled = new Promise<void>((resolve) => {
+    resolveBarrier = resolve;
+  });
+
+  return {
+    settled,
+    settle: () => {
+      if (isSettled) return;
+      isSettled = true;
+      resolveBarrier();
+    },
+  };
+}
+
+interface InitializeDesktopOpenTabsOptions {
+  barrier: OpenTabsRestorationBarrier;
+  initializeOptionalState: () => Promise<void>;
+  restoreOpenTabs: () => Promise<void>;
+  onOptionalStateError: (error: unknown) => void;
+}
+
+export async function initializeDesktopOpenTabs({ barrier, initializeOptionalState, restoreOpenTabs, onOptionalStateError }: InitializeDesktopOpenTabsOptions): Promise<void> {
+  try {
+    try {
+      await initializeOptionalState();
+    } catch (error) {
+      onOptionalStateError(error);
+    }
+    await restoreOpenTabs();
+  } finally {
+    barrier.settle();
+  }
+}

--- a/packages/app-tests/externalSqlFileStartup.test.ts
+++ b/packages/app-tests/externalSqlFileStartup.test.ts
@@ -1,8 +1,58 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "vitest";
+import { createOpenTabsRestorationBarrier, initializeDesktopOpenTabs } from "../../apps/desktop/src/lib/app/openTabsStartup.ts";
 
 const appSource = readFileSync("apps/desktop/src/App.vue", "utf8");
+
+test("desktop SQL file opening survives unrelated initialization failure and follows restored tabs", async () => {
+  const events: string[] = [];
+  const barrier = createOpenTabsRestorationBarrier();
+  const fileOpen = (async () => {
+    await barrier.settled;
+    events.push("read-file");
+    events.push("open-tab");
+  })();
+
+  await initializeDesktopOpenTabs({
+    barrier,
+    initializeOptionalState: async () => {
+      events.push("initialize-ai-configs");
+      throw new Error("AI config storage unavailable");
+    },
+    restoreOpenTabs: async () => {
+      events.push("initialize-editor-settings");
+      events.push("initialize-connections");
+      events.push("restore-tabs");
+    },
+    onOptionalStateError: () => events.push("ignore-ai-config-error"),
+  });
+  await fileOpen;
+
+  assert.deepEqual(events, ["initialize-ai-configs", "ignore-ai-config-error", "initialize-editor-settings", "initialize-connections", "restore-tabs", "read-file", "open-tab"]);
+});
+
+test("desktop SQL file opening is released when persisted tab restoration rejects", async () => {
+  const events: string[] = [];
+  const barrier = createOpenTabsRestorationBarrier();
+  const fileOpen = barrier.settled.then(() => events.push("open-file"));
+
+  await assert.rejects(
+    initializeDesktopOpenTabs({
+      barrier,
+      initializeOptionalState: async () => {},
+      restoreOpenTabs: async () => {
+        events.push("restore-tabs");
+        throw new Error("corrupt persisted tabs");
+      },
+      onOptionalStateError: () => {},
+    }),
+    /corrupt persisted tabs/,
+  );
+  await fileOpen;
+
+  assert.deepEqual(events, ["restore-tabs", "open-file"]);
+});
 
 test("cold-start SQL files wait for restored tabs before opening", () => {
   const openPathStart = appSource.indexOf("async function openSqlFilePath");
@@ -10,7 +60,7 @@ test("cold-start SQL files wait for restored tabs before opening", () => {
   assert.ok(openPathStart >= 0 && openPathEnd > openPathStart);
 
   const openPathSource = appSource.slice(openPathStart, openPathEnd);
-  const initializationWait = openPathSource.indexOf("await desktopInitializationPromise");
+  const initializationWait = openPathSource.indexOf("await desktopOpenTabsRestorationBarrier?.settled");
   const fileRead = openPathSource.indexOf("api.readExternalSqlFile(path)");
   const tabOpen = openPathSource.indexOf("queryStore.openExternalSqlFile");
   assert.ok(initializationWait >= 0);
@@ -22,8 +72,14 @@ test("cold-start SQL files wait for restored tabs before opening", () => {
   assert.ok(mountedStart >= 0 && mountedEnd > mountedStart);
 
   const mountedSource = appSource.slice(mountedStart, mountedEnd);
-  const initializationStart = mountedSource.indexOf("desktopInitializationPromise = initApp()");
+  const barrierCreation = mountedSource.indexOf("desktopOpenTabsRestorationBarrier = createOpenTabsRestorationBarrier()");
+  const initializationStart = mountedSource.indexOf("void initApp()", barrierCreation);
+  const listenerSetup = mountedSource.indexOf("setupTauriListeners()", initializationStart);
   const pendingFileOpen = mountedSource.indexOf("openPendingSqlFiles()");
+  assert.ok(barrierCreation >= 0);
   assert.ok(initializationStart >= 0);
+  assert.ok(barrierCreation < initializationStart);
+  assert.ok(initializationStart < listenerSetup);
+  assert.ok(listenerSetup < pendingFileOpen);
   assert.ok(initializationStart < pendingFileOpen);
 });

--- a/packages/app-tests/externalSqlFileStartup.test.ts
+++ b/packages/app-tests/externalSqlFileStartup.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "vitest";
+
+const appSource = readFileSync("apps/desktop/src/App.vue", "utf8");
+
+test("cold-start SQL files wait for restored tabs before opening", () => {
+  const openPathStart = appSource.indexOf("async function openSqlFilePath");
+  const openPathEnd = appSource.indexOf("async function openPendingSqlFiles", openPathStart);
+  assert.ok(openPathStart >= 0 && openPathEnd > openPathStart);
+
+  const openPathSource = appSource.slice(openPathStart, openPathEnd);
+  const initializationWait = openPathSource.indexOf("await desktopInitializationPromise");
+  const fileRead = openPathSource.indexOf("api.readExternalSqlFile(path)");
+  const tabOpen = openPathSource.indexOf("queryStore.openExternalSqlFile");
+  assert.ok(initializationWait >= 0);
+  assert.ok(initializationWait < fileRead);
+  assert.ok(fileRead < tabOpen);
+
+  const mountedStart = appSource.indexOf("onMounted(async () =>");
+  const mountedEnd = appSource.indexOf("onUnmounted(", mountedStart);
+  assert.ok(mountedStart >= 0 && mountedEnd > mountedStart);
+
+  const mountedSource = appSource.slice(mountedStart, mountedEnd);
+  const initializationStart = mountedSource.indexOf("desktopInitializationPromise = initApp()");
+  const pendingFileOpen = mountedSource.indexOf("openPendingSqlFiles()");
+  assert.ok(initializationStart >= 0);
+  assert.ok(initializationStart < pendingFileOpen);
+});


### PR DESCRIPTION
## 变更说明

修复桌面端在完全未启动时，通过系统打开 SQL 文件后，文件页签短暂出现又被恢复中的默认页签覆盖的问题。

- 复用桌面端的初始化 Promise，确保外部 SQL 文件在持久化页签恢复完成后再打开。
- 保持应用已运行时打开 SQL 文件的现有行为不变。
- 新增回归测试，约束初始化、读取文件和创建外部 SQL 页签的执行顺序。

## 根因

桌面端挂载时并发触发 `initApp()` 和 `openPendingSqlFiles()`。冷启动文件参数处理较快时，外部 SQL 页签会先被创建；随后 `queryStore.initOpenTabs()` 恢复持久化页签并整体替换当前页签列表，导致刚打开的 SQL 文件消失。

## 范围

本 PR 仅调整桌面端外部 SQL 文件的冷启动顺序，不修改系统文件关联、单实例转发、数据库文件、连接链接或其他启动流程。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动

本次不涉及视觉样式，仅修复冷启动时 SQL 页签被覆盖的问题。

## 验证

- [x] `pnpm check` 通过（format、lint、typecheck、test）
- [x] 新增冷启动 SQL 文件页签顺序回归测试
- [x] 使用 Dev DBX 携带外部 SQL 文件参数冷启动，确认文件页签及内容保留并成为活动页签
- [ ] 手动验证截图已保存，Draft 阶段待附到 PR

## 关联 Issue

Closes #4737
