### PR TITLE
fix(transfer): 修复  数据传输 startrocks 数据库图标展示

### DIFF
--- a/apps/desktop/src/components/transfer/DataTransferDialog.vue
+++ b/apps/desktop/src/components/transfer/DataTransferDialog.vue
@@ -11,6 +11,7 @@ import SearchableSelect from "@/components/ui/searchable-select/SearchableSelect
 import ConnectionGroupBadge from "@/components/connection/ConnectionGroupBadge.vue";
 import { useConnectionStore } from "@/stores/connectionStore";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
+import { connectionIconType } from "@/lib/connection/connectionPresentation";
 import * as api from "@/lib/backend/api";
 import type { TransferMode, TransferTableNameCase } from "@/lib/backend/api";
 import type { DatabaseType } from "@/types/database";
@@ -559,7 +560,7 @@ function getConnectionName(id: string) {
                 >
                   <template #option-label="{ option, label }">
                     <div class="flex min-w-0 items-center gap-1.5">
-                      <DatabaseIcon :db-type="sqlConnections.find((c) => c.id === option)?.db_type ?? 'mysql'" class="h-3.5 w-3.5 shrink-0" />
+                      <DatabaseIcon :db-type="connectionIconType(sqlConnections.find((c) => c.id === option))" class="h-3.5 w-3.5 shrink-0" />
                       <ConnectionGroupBadge :connection-id="option" />
                       <span class="min-w-0 flex-1 truncate">{{ label }}</span>
                     </div>
@@ -638,7 +639,7 @@ function getConnectionName(id: string) {
                 >
                   <template #option-label="{ option, label }">
                     <div class="flex min-w-0 items-center gap-1.5">
-                      <DatabaseIcon :db-type="sqlConnections.find((c) => c.id === option)?.db_type ?? 'mysql'" class="h-3.5 w-3.5 shrink-0" />
+                      <DatabaseIcon :db-type="connectionIconType(sqlConnections.find((c) => c.id === option))" class="h-3.5 w-3.5 shrink-0" />
                       <ConnectionGroupBadge :connection-id="option" />
                       <span class="min-w-0 flex-1 truncate">{{ label }}</span>
                     </div>


### PR DESCRIPTION
## 变更说明

- 小更新上一个 pr 太大了，就没整到一起
- 用connectionIconType函数替换直接访问db_type属性
- 简化sqlConnections中数据库类型的处理方式
- 保证图标显示逻辑更加统一和可扩展
- 减少硬编码，提升代码可维护性
- 应用于DataTransferDialog组件的两个option-label模板中

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<img width="784" height="858" alt="image" src="https://github.com/user-attachments/assets/f291c0e5-27fd-455a-b64f-81a28e573cf0" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

Close #4672
