### PR TITLE
fix(sidebar): 修复首次展开数据库节点后自动收起

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -1184,9 +1184,9 @@ function onSearchToggle(node: TreeNode) {
   searchCollapsedIds.value = next;
 }
 
-function onNodeToggled(node: TreeNode) {
+function onNodeToggled(node: TreeNode, wasExpanded: boolean) {
   if (isTreeSearchFiltering.value) return;
-  syncSidebarTreeNodeExpansion(store.treeNodes, node);
+  syncSidebarTreeNodeExpansion(store.treeNodes, node, !wasExpanded);
 }
 
 function openSidebarContextMenu(event: MouseEvent, node: TreeNode, openContextMenu: (event: MouseEvent, itemsOverride?: ContextMenuItem[]) => void) {

--- a/apps/desktop/src/lib/sidebar/sidebarTreeExpansion.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarTreeExpansion.ts
@@ -1,9 +1,9 @@
 import type { TreeNode } from "@/types/database";
 import { findSidebarActionTarget } from "@/lib/sidebar/sidebarActionTarget";
 
-export function syncSidebarTreeNodeExpansion(nodes: readonly TreeNode[], renderedNode: TreeNode): boolean {
+export function syncSidebarTreeNodeExpansion(nodes: readonly TreeNode[], renderedNode: TreeNode, expanded: boolean): boolean {
   const liveNode = findSidebarActionTarget(nodes, renderedNode);
-  if (!liveNode || liveNode === renderedNode || liveNode.isExpanded === renderedNode.isExpanded) return false;
-  liveNode.isExpanded = renderedNode.isExpanded;
+  if (!liveNode || liveNode === renderedNode || liveNode.isExpanded === expanded) return false;
+  liveNode.isExpanded = expanded;
   return true;
 }

--- a/packages/app-tests/sidebarTreeAffordances.test.ts
+++ b/packages/app-tests/sidebarTreeAffordances.test.ts
@@ -48,17 +48,35 @@ test("tree toggles synchronize filtered node clones with the live sidebar tree",
   };
   const expandedClone: TreeNode = { ...collapsedConnection, isExpanded: true };
 
-  assert.equal(syncSidebarTreeNodeExpansion([expandedConnection], collapsedClone), true);
+  assert.equal(syncSidebarTreeNodeExpansion([expandedConnection], collapsedClone, false), true);
   assert.equal(expandedConnection.isExpanded, false);
-  assert.equal(syncSidebarTreeNodeExpansion([collapsedConnection], expandedClone), true);
+  assert.equal(syncSidebarTreeNodeExpansion([collapsedConnection], expandedClone, true), true);
   assert.equal(collapsedConnection.isExpanded, true);
-  assert.equal(syncSidebarTreeNodeExpansion([expandedConnection], expandedConnection), false);
+  assert.equal(syncSidebarTreeNodeExpansion([expandedConnection], expandedConnection, true), false);
+});
+
+test("async tree expansion does not restore a stale rendered clone state", () => {
+  const liveDatabase: TreeNode = {
+    id: "connection-1:database-1",
+    label: "Database 1",
+    type: "database",
+    connectionId: "connection-1",
+    database: "database-1",
+    isExpanded: false,
+    children: [],
+  };
+  const staleRenderedClone: TreeNode = { ...liveDatabase, children: [] };
+
+  liveDatabase.isExpanded = true;
+
+  assert.equal(syncSidebarTreeNodeExpansion([liveDatabase], staleRenderedClone, true), false);
+  assert.equal(liveDatabase.isExpanded, true);
 });
 
 test("local table search preserves live expansion state", () => {
   assert.match(connectionTree, /return \{ \.\.\.node, children: matchingChildren \};/);
   assert.doesNotMatch(connectionTree, /children: matchingChildren,\s*isExpanded:\s*true/);
-  assert.match(connectionTree, /function onNodeToggled\(node: TreeNode\) \{\s*if \(isTreeSearchFiltering\.value\) return;\s*syncSidebarTreeNodeExpansion/);
+  assert.match(connectionTree, /function onNodeToggled\(node: TreeNode, wasExpanded: boolean\) \{\s*if \(isTreeSearchFiltering\.value\) return;\s*syncSidebarTreeNodeExpansion\(store\.treeNodes, node, !wasExpanded\)/);
 });
 
 test("tree rebuilds keep a context menu only while its target row remains visible", () => {


### PR DESCRIPTION
## 问题

#4882 合并后，连接可以展开，但首次加载的数据库节点可能在异步加载完成后又被收起，因此用户看到“连接能展开、库不能展开”。

回归原因是树节点有两份状态：数据加载器更新真实节点为 `isExpanded = true`，而筛选/渲染树中的克隆仍可能保留旧的 `false`。`node-toggled` 回调随后从这个过期克隆读取状态并同步回真实节点，导致刚展开的数据库再次被收起。缓存节点不一定触发该路径，所以表现并非每次一致。

## 修复

- `node-toggled` 使用事件提供的 `wasExpanded` 计算用户本次操作的明确目标状态。
- 展开状态同步函数接收目标状态，不再读取可能过期的渲染克隆。
- 增加异步展开后遇到旧克隆状态的回归测试，并更新展开/收起双向同步测试。

## 验证

- `pnpm vitest run packages/app-tests/sidebarTreeAffordances.test.ts packages/app-tests/sidebarLargeTree.test.ts`
  - 2 个测试文件、8 个测试全部通过。
- `pnpm typecheck`
  - 通过。
- Vite 网页真实连接验证：
  - 密码关闭的开发后端 + 当前分支 Vite 前端。
  - 展开公共 PostgreSQL 16 连接后正常显示 `dbx_test`、`postgres`。
  - 首次展开未缓存的 `dbx_test` 后保持展开，正常显示 `public`、扩展等子节点。
  - 收起后再次展开仍正常。
  - 页面控制台无 error/warn。
- 提交者已在同一 Vite 预览中手动验证通过。

关联：#4882
