### PR TITLE
fix(sqlserver): 修复排序后查询结果不可编辑

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
@@ -569,6 +569,22 @@ describe("queryStore hidden primary key editing", () => {
     expect(tab.resultSortedSql).toBe("SELECT name, `id` AS `__DBX_PK_0` FROM users ORDER BY name ASC");
     await vi.waitFor(() => expect(tab.querySourceColumns).toEqual(["name", "id"]));
     expect(tab.queryAnalysis).toBeDefined();
+
+    await store.executeTabSql(tabId, "SELECT name FROM users", {
+      resultBaseSql: "SELECT name FROM users",
+      resultSortedSql: tab.resultSortedSql,
+      querySort: {
+        resultColumns: ["name"],
+        columnIndex: 0,
+        column: "name",
+        direction: "asc",
+      },
+      pagination: { offset: 100, limit: 100 },
+    });
+
+    await vi.waitFor(() => expect(tab.querySourceColumns).toEqual(["name", "id"]));
+    expect(tab.queryEditabilityReason).toBeUndefined();
+    expect(tab.result?.hidden_column_indexes).toEqual([1]);
   });
 
   it("clears result sorting when the editor SQL is executed again", async () => {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3823,7 +3823,10 @@ export const useQueryStore = defineStore("query", () => {
       if (tab.mode === "query") {
         const prepared = await prepareEditableQueryExecution(tab, sqlToExecute, conn, effectiveDbType, executionDatabase, traceId, elapsed);
         sqlToExecute = prepared.sql;
-        queryMetadataSql = prepared.metadataSql;
+        // Database sorting executes a generated wrapper around the user's query.
+        // Keep editability metadata anchored to the original query so the wrapper
+        // does not turn an otherwise editable result into a complex read-only one.
+        queryMetadataSql = options?.resultSortedSql ? queryBaseSql : prepared.metadataSql;
         hiddenPrimaryKeys = prepared.hiddenPrimaryKeys;
         if (options?.querySort) {
           const sorted = await api.buildSortedQuerySql({

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3826,7 +3826,7 @@ export const useQueryStore = defineStore("query", () => {
         // Database sorting executes a generated wrapper around the user's query.
         // Keep editability metadata anchored to the original query so the wrapper
         // does not turn an otherwise editable result into a complex read-only one.
-        queryMetadataSql = options?.resultSortedSql ? queryBaseSql : prepared.metadataSql;
+        queryMetadataSql = options?.resultSortedSql && !options?.querySort ? queryBaseSql : prepared.metadataSql;
         hiddenPrimaryKeys = prepared.hiddenPrimaryKeys;
         if (options?.querySort) {
           const sorted = await api.buildSortedQuerySql({

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -1934,12 +1934,14 @@ test("keeps joined query read-only when multiple source tables are writable cand
   }
 });
 
-test("uses dbo as SQL Server metadata schema when query omits schema", async () => {
+test("uses dbo as SQL Server metadata schema and keeps sorted query results editable", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());
   const connectionStore = useConnectionStore();
   const store = useQueryStore();
   const originalFetch = globalThis.fetch;
+  const baseSql = "select id, name from users";
+  const analyzedSql: string[] = [];
   const columnRequests: Array<{ schema: string | null; table: string | null }> = [];
 
   connectionStore.addEphemeralConnection(sqlServerConn("sqlserver-1"));
@@ -1961,7 +1963,13 @@ test("uses dbo as SQL Server metadata schema when query omits schema", async () 
     }
     if (url === "/api/query/analyze-editability") {
       const body = JSON.parse(String(init?.body ?? "{}"));
-      assert.equal(body.sql, "select id, name from users");
+      analyzedSql.push(body.sql);
+      if (body.sql !== baseSql) {
+        return new Response(JSON.stringify({ editable: false, reason: "complex-source" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
       return new Response(
         JSON.stringify({
           editable: true,
@@ -2020,14 +2028,27 @@ test("uses dbo as SQL Server metadata schema when query omits schema", async () 
 
   try {
     const tabId = store.createTab("sqlserver-1", "app", "Query 1", "query");
-    await store.executeTabSql(tabId, "select id, name from users");
+    await store.executeTabSql(tabId, baseSql);
 
     const tab = store.tabs.find((item) => item.id === tabId);
     await waitFor(() => columnRequests.length > 0 && tab?.tableMeta?.tableName === "users");
+    assert.deepEqual(analyzedSql, [baseSql]);
     assert.deepEqual(columnRequests, [{ schema: "dbo", table: "users" }]);
     assert.equal(tab?.tableMeta?.schema, "dbo");
     assert.equal(tab?.tableMeta?.columns[0]?.comment, "编号");
     assert.equal(tab?.tableMeta?.columns[1]?.comment, "姓名");
+
+    const sortedSql = "SELECT * FROM (select id, name from users) t([ID], [NAME]) ORDER BY [NAME] ASC;";
+    await store.executeTabSql(tabId, sortedSql, {
+      resultBaseSql: baseSql,
+      resultSortedSql: sortedSql,
+      preserveResultDuringExecution: true,
+    });
+
+    await waitFor(() => analyzedSql.length === 2);
+    assert.deepEqual(analyzedSql, [baseSql, baseSql]);
+    assert.equal(tab?.queryEditabilityReason, undefined);
+    assert.equal(tab?.queryAnalysis?.tableName, "users");
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();


### PR DESCRIPTION
## 变更说明

- 可编辑性元数据分析在数据库侧排序后继续使用用户的原始 SQL。
- 避免自动生成的排序包装 SQL 将原本可编辑的 SQL Server 查询结果误判为只读。
- 增加 SQL Server 查询结果排序后仍可编辑的回归测试。

**问题原因**

数据库侧排序会执行由 DBX 生成的 `SELECT * FROM (...) ORDER BY ...` 包装查询。此前可编辑性元数据分析的是这段包装 SQL，而不是用户的原始 SQL，因此会将结果误判为复杂来源并清空可编辑表映射。

**影响范围**

仅修正可编辑性元数据分析所使用的 SQL；实际执行的排序 SQL 不变。SQL Server 查询结果在排序前可编辑时，排序后仍保持可编辑。

**合并建议**

建议与 #4948 一起合并。本 PR 恢复数据库侧排序后的结果编辑能力，#4948 则确保 SQL Server 跨库编辑写回产生结果的数据库。两者一起合并，可以让恢复的编辑流程同时具备正确的跨库写入目标保护。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 涉及前端查询结果编辑逻辑，但不改变视觉样式。已使用真实 SQL Server 完成人工验证；修复前截图见 #4904，修复后截图目前尚未上传至 PR。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `pnpm check`：格式检查、Lint、类型检查和完整 Vitest 测试均通过。
- 人工验证：SQL Server 查询结果在数据库侧排序后仍可编辑。

## 关联 Issue

Fixes #4904

Related #4948