### PR TITLE
fix(sidebar): cancel in-flight metadata load when collapsing a node

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -506,7 +506,12 @@ function isGroupLabel(node: TreeNode): boolean {
 async function toggle() {
   const node = activeNode.value;
   if (node.isLoading) {
-    if (!node.isExpanded) {
+    if (node.isExpanded) {
+      node.isExpanded = false;
+      if (!connectionStore.sidebarSearchQuery) connectionStore.releaseCollapsedTreeNodeChildren(node.id);
+      connectionStore.cancelTreeNodeLoad(node.id);
+      emit("node-toggled", node, true);
+    } else {
       node.isExpanded = true;
       emit("node-toggled", node, false);
     }

--- a/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
@@ -1847,6 +1847,78 @@ describe("connectionStore metadata loading", () => {
     expect(store.isTreeNodeChildrenLoaded(test1Id)).toBe(false);
   });
 
+  it("does not re-expand a node collapsed while its load is still in flight", async () => {
+    let resolveTables!: (tables: TableInfo[]) => void;
+    const listTables = vi.fn(
+      () =>
+        new Promise<TableInfo[]>((resolve) => {
+          resolveTables = resolve;
+        }),
+    );
+    const listObjects = vi.fn().mockResolvedValue([]);
+    const checkConnectionHealth = vi.fn().mockResolvedValue(undefined);
+    const connectDb = vi.fn().mockResolvedValue("mysql-1");
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth,
+      connectDb,
+      deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined),
+      listInstalledAgents: vi.fn().mockResolvedValue([]),
+      listTables,
+      listObjects,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const store = useConnectionStore();
+    useSettingsStore().editorSettings.sidebarObjectDisplay = "simple";
+
+    const connection = mysqlConnection();
+    const test1Id = `${connection.id}:test1`;
+    const dbNode: TreeNode = {
+      id: test1Id,
+      label: "test1",
+      type: "database",
+      connectionId: connection.id,
+      database: "test1",
+      isExpanded: false,
+      children: [],
+    };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [
+      {
+        id: connection.id,
+        label: connection.name,
+        type: "connection",
+        connectionId: connection.id,
+        isExpanded: true,
+        children: [dbNode],
+      },
+    ];
+
+    const loadPromise = store.loadTables(connection.id, "test1");
+    await vi.waitFor(() => expect(listTables).toHaveBeenCalledTimes(1));
+    expect(dbNode.isLoading).toBe(true);
+    expect(dbNode.isExpanded).toBe(false);
+
+    // Simulate the user collapsing the node while the metadata load is still in flight.
+    dbNode.isExpanded = false;
+    store.cancelTreeNodeLoad(dbNode.id);
+
+    resolveTables([{ name: "users", table_type: "TABLE", comment: null }]);
+    await loadPromise;
+
+    // The in-flight load must not re-expand the node, and the spinner must be cleared.
+    expect(dbNode.isLoading).toBe(false);
+    expect(dbNode.isExpanded).toBe(false);
+  });
+
   it("does not apply load-more results after the parent generation is invalidated", async () => {
     const firstPage = Array.from({ length: 201 }, (_, index) => ({
       name: `t_${String(index + 1).padStart(4, "0")}`,

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -6590,6 +6590,15 @@ export const useConnectionStore = defineStore("connection", () => {
     clearConnectionError(normalized.id);
   }
 
+  function cancelTreeNodeLoad(nodeId: string): void {
+    // Supersede any in-flight loader for this node so a collapse issued while
+    // the load is still running (or a loader that never resolves) cannot
+    // re-expand the node via its trailing `targetNode.isExpanded = true`.
+    treeNodeLoads.invalidatePrefix(nodeId);
+    const node = findNode(treeNodes.value, nodeId);
+    if (node) node.isLoading = false;
+  }
+
   return {
     connections,
     activeConnectionId,
@@ -6662,6 +6671,7 @@ export const useConnectionStore = defineStore("connection", () => {
     isTreeNodeChildrenLoaded,
     canUseLoadedTreeNodeToggle,
     releaseCollapsedTreeNodeChildren,
+    cancelTreeNodeLoad,
     setBeforeConnectHandler,
     initFromDisk,
     loadDatabases,


### PR DESCRIPTION
## What

Follow-up enhancement to the sidebar collapse behaviour. The core "can't collapse" bug was fixed on `main` by zipg in `24d7dc48a` (Fixes #4930) via clone/live-node reference reconciliation. This PR closes a related gap that fix does **not** cover:

**A node whose metadata load is still in flight could not stay collapsed.** Once the pending loader finished, its trailing `targetNode.isExpanded = true` re-expanded the node the user had just collapsed.

## Changes

- `connectionStore`: add `cancelTreeNodeLoad(nodeId)` — invalidates any in-flight load for the node (`treeNodeLoads.invalidatePrefix`) and clears its `isLoading` flag.
- `SidebarTreeRuntimeHost.toggle()`: allow collapsing (toggling) a node while it is still loading; on collapse, release collapsed children and cancel the pending load so it cannot re-expand the node.

## Why the original PR was reworked

The original PR also reimplemented the core collapse fix in `ConnectionTree.vue` (`filterLocallySearchedTables` reference stability). After it was opened, `24d7dc48a` landed on `main` with a different, cleaner approach, so that part was dropped to avoid duplicating the already-merged fix. This PR keeps only the cancel-on-collapse enhancement.

## Verification

- `pnpm typecheck` — pass
- `pnpm lint` — 0 errors
- `connectionStore.metadataLoading.spec.ts` — 33/33 (collapse-during-load cases)
- Rebased onto current `main`; no longer conflicts with `24d7dc48a`.
