### PR TITLE
feat(ai): add MiniMax provider preset

### DIFF
--- a/apps/desktop/public/icons/ai/minimax.svg
+++ b/apps/desktop/public/icons/ai/minimax.svg
@@ -1,0 +1,1 @@
+<svg fill="#FF3C00" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>MiniMax</title><path d="M3 4h3.2l4.6 9.4V4H14v16h-3.1L6.2 10.4V20H3V4Zm12.4 0H19v6.4l3-6.4H24l-3.3 7.9L24 20h-2.4l-2.6-6.8V20h-3.6V4Z"/></svg>

--- a/apps/desktop/src/lib/ai/__tests__/aiConfigOrdering.spec.ts
+++ b/apps/desktop/src/lib/ai/__tests__/aiConfigOrdering.spec.ts
@@ -17,6 +17,7 @@ describe("orderAiConfigsForDisplay", () => {
       { id: "gemini", provider: "gemini" },
       { id: "deepseek", provider: "deepseek" },
       { id: "qwen", provider: "qwen" },
+      { id: "minimax", provider: "minimax" },
       { id: "ollama", provider: "ollama" },
       { id: "openai-compatible", provider: "openai-compatible" },
       { id: "codex", provider: "codex-cli" },
@@ -24,7 +25,7 @@ describe("orderAiConfigsForDisplay", () => {
       { id: "custom", provider: "custom" },
     ];
 
-    expect(orderAiConfigsForDisplay(configs).map((config) => config.id)).toEqual(["claude", "openai", "gemini", "deepseek", "qwen", "ollama", "anthropic-compatible", "openai-compatible", "claude-code-1", "codex", "pi", "custom"]);
+    expect(orderAiConfigsForDisplay(configs).map((config) => config.id)).toEqual(["claude", "openai", "gemini", "deepseek", "qwen", "minimax", "ollama", "anthropic-compatible", "openai-compatible", "claude-code-1", "codex", "pi", "custom"]);
   });
 
   it("preserves creation order for configs from the same provider", () => {

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -170,6 +170,16 @@ export const AI_PROVIDER_PRESETS: Record<AiProvider, AiProviderPreset> = {
     authMethod: "bearer",
     requiresApiKey: true,
   },
+  minimax: {
+    label: "MiniMax",
+    iconSlug: "minimax",
+    provider: "minimax",
+    endpoint: "https://api.minimax.io/v1",
+    model: "MiniMax-M3",
+    apiStyle: "completions",
+    authMethod: "bearer",
+    requiresApiKey: true,
+  },
   ollama: {
     label: "Ollama",
     iconSlug: "ollama",
@@ -299,6 +309,7 @@ function inferAiProviderFromConfig(config: Partial<AiConfig> | null | undefined)
   if (endpoint.includes("deepseek") || model.includes("deepseek")) return "deepseek";
   if (endpoint.includes("dashscope") || endpoint.includes("aliyuncs") || model.includes("qwen")) return "qwen";
   if (endpoint.includes("generativelanguage.googleapis.com") || model.includes("gemini")) return "gemini";
+  if (endpoint.includes("minimax.io") || endpoint.includes("minimaxi.com") || model.includes("minimax")) return "minimax";
   if (endpoint.includes("localhost:11434") || endpoint.includes("127.0.0.1:11434")) return "ollama";
   if (endpoint.includes("openai.com") || model.startsWith("gpt-")) return "openai";
   return "claude";

--- a/apps/desktop/src/types/ai.ts
+++ b/apps/desktop/src/types/ai.ts
@@ -1,4 +1,4 @@
-export type AiProvider = "claude" | "openai" | "gemini" | "deepseek" | "qwen" | "ollama" | "anthropic-compatible" | "openai-compatible" | "claude-code-cli" | "pi-agent-cli" | "codex-cli" | "custom";
+export type AiProvider = "claude" | "openai" | "gemini" | "deepseek" | "qwen" | "minimax" | "ollama" | "anthropic-compatible" | "openai-compatible" | "claude-code-cli" | "pi-agent-cli" | "codex-cli" | "custom";
 export type AiApiStyle = "completions" | "responses" | "anthropic-messages";
 export type AiAuthMethod = "api-key" | "bearer";
 export type AiEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -871,7 +871,9 @@ fn apply_chat_completion_thinking_toggle(body: &mut serde_json::Value, config: &
         return;
     }
 
-    if matches!(config.provider, AiProvider::Ollama) {
+    if matches!(config.provider, AiProvider::MiniMax) {
+        body["thinking"] = json!({ "type": "disabled" });
+    } else if matches!(config.provider, AiProvider::Ollama) {
         // Ollama's OpenAI-compatible API uses reasoning_effort instead of
         // forwarding provider-specific chat template arguments.
         body["reasoning_effort"] = json!("none");
@@ -1047,7 +1049,11 @@ fn emit_responses_function_call_item(
 fn provider_requires_api_key(provider: &AiProvider) -> bool {
     matches!(
         provider,
-        AiProvider::Claude | AiProvider::Openai | AiProvider::Gemini | AiProvider::Deepseek | AiProvider::Qwen
+        AiProvider::Claude
+            | AiProvider::Openai
+            | AiProvider::Gemini
+            | AiProvider::Deepseek
+            | AiProvider::Qwen
             | AiProvider::MiniMax
     )
 }
@@ -1463,10 +1469,11 @@ pub async fn list_models_core(config: &AiConfig) -> Result<Vec<AiModelInfo>, Str
                     let models = list_openai_compatible_models(&client, config).await?;
                     retain_ollama_completion_models(&client, config, models).await
                 }
-                AiProvider::Openai | AiProvider::Deepseek | AiProvider::Qwen | AiProvider::MiniMax
-                | AiProvider::OpenaiCompatible => {
-                    list_openai_compatible_models(&client, config).await?
-                }
+                AiProvider::Openai
+                | AiProvider::Deepseek
+                | AiProvider::Qwen
+                | AiProvider::MiniMax
+                | AiProvider::OpenaiCompatible => list_openai_compatible_models(&client, config).await?,
                 AiProvider::Custom => {
                     if uses_anthropic_messages_api(config) {
                         list_claude_models(&client, config).await?
@@ -3810,8 +3817,8 @@ mod tests {
         gemini_text, is_kimi_model, is_retryable_error, list_models_core, maybe_bearer_headers, maybe_tag_retry_after,
         measure_first_stream_chunk, merge_global_max_retries, ollama_selected_model_tool_support, openai_response_text,
         openai_stream_reasoning, openai_stream_text, parse_dynamic_effort_capability, parse_gemini_model_list_response,
-        parse_model_list_response, parse_retry_after, parse_retry_after_secs, resolve_endpoint,
-        resolve_gemini_stream_endpoint, resolve_model_effort_core, resolve_model_list_endpoint,
+        parse_model_list_response, parse_retry_after, parse_retry_after_secs, provider_requires_api_key,
+        resolve_endpoint, resolve_gemini_stream_endpoint, resolve_model_effort_core, resolve_model_list_endpoint,
         resolve_ollama_show_endpoint, responses_function_tool, responses_max_output_tokens, responses_stream_text,
         responses_text, responses_token_usage, retain_ollama_completion_models, retry_after_secs,
         set_chat_completion_token_limit, stream, stream_claude, stream_claude_with_tools, stream_data_payload,
@@ -4701,9 +4708,14 @@ mod tests {
             assert!(maybe_bearer_headers(&config).unwrap().get(AUTHORIZATION).is_none());
         }
 
-        for provider in
-            [AiProvider::Claude, AiProvider::Openai, AiProvider::Gemini, AiProvider::Deepseek, AiProvider::Qwen, AiProvider::MiniMax]
-        {
+        for provider in [
+            AiProvider::Claude,
+            AiProvider::Openai,
+            AiProvider::Gemini,
+            AiProvider::Deepseek,
+            AiProvider::Qwen,
+            AiProvider::MiniMax,
+        ] {
             let config = AiConfig { provider, ..base.clone() };
             assert_eq!(validate_config(&config).unwrap_err(), "API key is required");
             assert_eq!(validate_model_list_config(&config).unwrap_err(), "API key is required");
@@ -5791,6 +5803,39 @@ mod tests {
                 "chat_template_kwargs": { "enable_thinking": false }
             }))
         );
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn minimax_uses_native_thinking_toggle() {
+        let config = AiConfig {
+            provider: AiProvider::MiniMax,
+            api_key: "key".to_string(),
+            auth_method: AiAuthMethod::Bearer,
+            endpoint: "https://api.minimax.io/v1".to_string(),
+            model: "MiniMax-M3".to_string(),
+            models: vec![],
+            api_style: AiApiStyle::Completions,
+            proxy_enabled: false,
+            proxy_url: String::new(),
+            enable_thinking: false,
+            reasoning_level: AiReasoningLevel::Default,
+            runtime_effort: None,
+            context_window: None,
+            max_retries: None,
+            codex_cli_path: None,
+            codex_cli_env: Default::default(),
+            claude_code_cli_path: None,
+            claude_code_cli_env: Default::default(),
+            pi_agent_cli_path: None,
+            pi_agent_cli_env: Default::default(),
+        };
+        let mut body = serde_json::json!({ "model": &config.model });
+
+        apply_chat_completion_thinking_toggle(&mut body, &config);
+
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(body.get("extra_body").is_none());
         assert!(body.get("reasoning_effort").is_none());
     }
 

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -69,6 +69,7 @@ pub enum AiProvider {
     Gemini,
     Deepseek,
     Qwen,
+    MiniMax,
     Ollama,
     #[serde(rename = "openai-compatible")]
     OpenaiCompatible,
@@ -90,6 +91,7 @@ impl AiProvider {
             AiProvider::Gemini => "gemini",
             AiProvider::Deepseek => "deepseek",
             AiProvider::Qwen => "qwen",
+            AiProvider::MiniMax => "minimax",
             AiProvider::Ollama => "ollama",
             AiProvider::OpenaiCompatible => "openai-compatible",
             AiProvider::ClaudeCodeCli => "claude-code-cli",
@@ -594,6 +596,7 @@ pub fn resolve_endpoint(config: &AiConfig) -> String {
         AiProvider::Openai
         | AiProvider::Deepseek
         | AiProvider::Qwen
+        | AiProvider::MiniMax
         | AiProvider::Ollama
         | AiProvider::OpenaiCompatible
         | AiProvider::Custom => {
@@ -1045,6 +1048,7 @@ fn provider_requires_api_key(provider: &AiProvider) -> bool {
     matches!(
         provider,
         AiProvider::Claude | AiProvider::Openai | AiProvider::Gemini | AiProvider::Deepseek | AiProvider::Qwen
+            | AiProvider::MiniMax
     )
 }
 
@@ -1459,7 +1463,8 @@ pub async fn list_models_core(config: &AiConfig) -> Result<Vec<AiModelInfo>, Str
                     let models = list_openai_compatible_models(&client, config).await?;
                     retain_ollama_completion_models(&client, config, models).await
                 }
-                AiProvider::Openai | AiProvider::Deepseek | AiProvider::Qwen | AiProvider::OpenaiCompatible => {
+                AiProvider::Openai | AiProvider::Deepseek | AiProvider::Qwen | AiProvider::MiniMax
+                | AiProvider::OpenaiCompatible => {
                     list_openai_compatible_models(&client, config).await?
                 }
                 AiProvider::Custom => {
@@ -2392,6 +2397,7 @@ pub async fn complete(request: &AiCompletionRequest) -> Result<String, String> {
                 AiProvider::Openai
                 | AiProvider::Deepseek
                 | AiProvider::Qwen
+                | AiProvider::MiniMax
                 | AiProvider::Ollama
                 | AiProvider::OpenaiCompatible => {
                     if request.config.api_style == AiApiStyle::Responses {
@@ -2443,6 +2449,7 @@ pub async fn stream(
         AiProvider::Openai
         | AiProvider::Deepseek
         | AiProvider::Qwen
+        | AiProvider::MiniMax
         | AiProvider::Ollama
         | AiProvider::OpenaiCompatible => {
             if request.config.api_style == AiApiStyle::Responses {
@@ -4695,7 +4702,7 @@ mod tests {
         }
 
         for provider in
-            [AiProvider::Claude, AiProvider::Openai, AiProvider::Gemini, AiProvider::Deepseek, AiProvider::Qwen]
+            [AiProvider::Claude, AiProvider::Openai, AiProvider::Gemini, AiProvider::Deepseek, AiProvider::Qwen, AiProvider::MiniMax]
         {
             let config = AiConfig { provider, ..base.clone() };
             assert_eq!(validate_config(&config).unwrap_err(), "API key is required");
@@ -4831,6 +4838,44 @@ mod tests {
         let provider_json = serde_json::to_string(&AiProvider::AnthropicCompatible).unwrap();
         assert_eq!(provider_json, r#""anthropic-compatible""#);
         assert!(matches!(serde_json::from_str::<AiProvider>(&provider_json).unwrap(), AiProvider::AnthropicCompatible));
+    }
+
+    #[test]
+    fn minimax_provider_uses_openai_compatible_endpoints_and_round_trips() {
+        let config = AiConfig {
+            provider: AiProvider::MiniMax,
+            api_key: "key".to_string(),
+            auth_method: AiAuthMethod::Bearer,
+            endpoint: "https://api.minimax.io/v1".to_string(),
+            model: "MiniMax-M3".to_string(),
+            models: Vec::new(),
+            api_style: AiApiStyle::Completions,
+            proxy_enabled: false,
+            proxy_url: String::new(),
+            enable_thinking: true,
+            reasoning_level: AiReasoningLevel::Default,
+            runtime_effort: None,
+            context_window: None,
+            max_retries: None,
+            codex_cli_path: None,
+            codex_cli_env: Default::default(),
+            claude_code_cli_path: None,
+            claude_code_cli_env: Default::default(),
+            pi_agent_cli_path: None,
+            pi_agent_cli_env: Default::default(),
+        };
+
+        assert!(!uses_anthropic_messages_api(&config));
+        assert_eq!(resolve_endpoint(&config), "https://api.minimax.io/v1/chat/completions");
+        assert_eq!(resolve_model_list_endpoint(&config).unwrap(), "https://api.minimax.io/v1/models");
+        assert!(provider_requires_api_key(&config.provider));
+
+        let no_key = AiConfig { api_key: String::new(), ..config.clone() };
+        assert_eq!(validate_config(&no_key).unwrap_err(), "API key is required");
+
+        let provider_json = serde_json::to_string(&AiProvider::MiniMax).unwrap();
+        assert_eq!(provider_json, r#""minimax""#);
+        assert!(matches!(serde_json::from_str::<AiProvider>(&provider_json).unwrap(), AiProvider::MiniMax));
     }
 
     #[test]
@@ -6409,6 +6454,7 @@ mod tests {
             AiProvider::Deepseek,
             AiProvider::Qwen,
             AiProvider::Ollama,
+            AiProvider::MiniMax,
         ] {
             let mut config = test_config(provider.clone());
             config.max_retries = None;

--- a/crates/dbx-core/src/ai_effort.rs
+++ b/crates/dbx-core/src/ai_effort.rs
@@ -8,8 +8,9 @@ const GEMINI_THINKING_DOCS: &str = "https://ai.google.dev/gemini-api/docs/thinki
 const DEEPSEEK_THINKING_DOCS: &str = "https://api-docs.deepseek.com/guides/thinking_mode";
 const QWEN_THINKING_DOCS: &str = "https://help.aliyun.com/en/model-studio/deep-thinking";
 const OLLAMA_THINKING_DOCS: &str = "https://docs.ollama.com/capabilities/thinking";
+const MINIMAX_THINKING_DOCS: &str = "https://platform.minimax.io/docs/api-reference/text-chat-openai";
 
-pub const EFFORT_REGISTRY_LAST_VERIFIED: &str = "2026-07-26";
+pub const EFFORT_REGISTRY_LAST_VERIFIED: &str = "2026-07-30";
 
 fn option(id: &str, label: &str, selection: AiEffortSelection) -> AiEffortOption {
     AiEffortOption { id: id.to_string(), label: label.to_string(), description: None, selection }
@@ -76,7 +77,9 @@ pub fn static_effort_capability(config: &AiConfig, model_id: &str) -> Option<AiE
         AiProvider::Deepseek => deepseek_capability(&model, source),
         AiProvider::Qwen => qwen_capability(&model, source),
         AiProvider::Ollama => ollama_capability(&model, source),
-        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::MiniMax | AiProvider::Custom => {
+        AiProvider::MiniMax if matches_family(&model, "minimax-m3") => Some(boolean_capability(source)),
+        AiProvider::MiniMax => None,
+        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::Custom => {
             Some(AiEffortCapability::FreeText { placeholder: None, source: AiCapabilitySource::Custom })
         }
         AiProvider::Claude | AiProvider::CodexCli | AiProvider::ClaudeCodeCli | AiProvider::PiAgentCli => None,
@@ -177,13 +180,13 @@ pub fn registry_source_url(provider: &AiProvider) -> Option<&'static str> {
         AiProvider::Deepseek => Some(DEEPSEEK_THINKING_DOCS),
         AiProvider::Qwen => Some(QWEN_THINKING_DOCS),
         AiProvider::Ollama => Some(OLLAMA_THINKING_DOCS),
+        AiProvider::MiniMax => Some(MINIMAX_THINKING_DOCS),
         AiProvider::Claude
         | AiProvider::AnthropicCompatible
         | AiProvider::OpenaiCompatible
         | AiProvider::CodexCli
         | AiProvider::ClaudeCodeCli
         | AiProvider::PiAgentCli
-        | AiProvider::MiniMax
         | AiProvider::Custom => None,
     }
 }
@@ -242,9 +245,8 @@ pub fn apply_runtime_effort(body: &mut Value, config: &AiConfig) {
         AiProvider::Deepseek => apply_deepseek_effort(object, selection),
         AiProvider::Qwen => apply_qwen_effort(object, selection),
         AiProvider::Ollama => apply_openai_effort(object, &config.api_style, selection),
-        AiProvider::Openai | AiProvider::OpenaiCompatible | AiProvider::MiniMax => {
-            apply_openai_effort(object, &config.api_style, selection)
-        }
+        AiProvider::MiniMax => apply_minimax_effort(object, selection),
+        AiProvider::Openai | AiProvider::OpenaiCompatible => apply_openai_effort(object, &config.api_style, selection),
         AiProvider::Custom => {
             if config.api_style == AiApiStyle::AnthropicMessages {
                 apply_claude_effort(object, selection);
@@ -270,6 +272,15 @@ fn apply_openai_effort(object: &mut Map<String, Value>, api_style: &AiApiStyle, 
             object.insert("reasoning_effort".to_string(), Value::String(value));
         }
     }
+}
+
+fn apply_minimax_effort(object: &mut Map<String, Value>, selection: &AiEffortSelection) {
+    let thinking_type = match selection {
+        AiEffortSelection::Disabled | AiEffortSelection::Boolean(false) => "disabled",
+        AiEffortSelection::Boolean(true) => "adaptive",
+        _ => return,
+    };
+    object.insert("thinking".to_string(), json!({ "type": thinking_type }));
 }
 
 fn apply_gemini_effort(object: &mut Map<String, Value>, model_id: &str, selection: &AiEffortSelection) {
@@ -364,7 +375,10 @@ fn title_case_effort(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_runtime_effort, dynamic_enum_capability, static_effort_capability, validate_runtime_effort};
+    use super::{
+        apply_runtime_effort, dynamic_enum_capability, registry_source_url, static_effort_capability,
+        validate_runtime_effort, MINIMAX_THINKING_DOCS,
+    };
     use crate::ai::{
         AiApiStyle, AiAuthMethod, AiCapabilitySource, AiConfig, AiEffortCapability, AiEffortSelection, AiProvider,
         AiReasoningLevel,
@@ -408,13 +422,38 @@ mod tests {
 
     #[test]
     fn free_text_effort_uses_the_translated_frontend_placeholder() {
-        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom, AiProvider::MiniMax] {
+        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom] {
             let capability = static_effort_capability(&config(provider, "custom-model"), "custom-model").unwrap();
             let AiEffortCapability::FreeText { placeholder, .. } = capability else {
                 panic!("expected free-text capability");
             };
             assert_eq!(placeholder, None);
         }
+    }
+
+    #[test]
+    fn minimax_m3_uses_boolean_adaptive_thinking() {
+        let mut config = config(AiProvider::MiniMax, "MiniMax-M3");
+        let capability = static_effort_capability(&config, "MiniMax-M3").unwrap();
+        let AiEffortCapability::Boolean { default, source } = capability else {
+            panic!("expected boolean capability");
+        };
+        assert_eq!(default, AiEffortSelection::ProviderDefault);
+        assert_eq!(source, AiCapabilitySource::OfficialRegistry);
+        assert_eq!(registry_source_url(&AiProvider::MiniMax), Some(MINIMAX_THINKING_DOCS));
+        assert!(static_effort_capability(&config, "MiniMax-M2.7").is_none());
+
+        config.runtime_effort = Some(AiEffortSelection::Boolean(true));
+        let mut body = json!({});
+        apply_runtime_effort(&mut body, &config);
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert!(body.get("reasoning_effort").is_none());
+
+        config.runtime_effort = Some(AiEffortSelection::Disabled);
+        let mut body = json!({});
+        apply_runtime_effort(&mut body, &config);
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(body.get("reasoning_effort").is_none());
     }
 
     #[test]

--- a/crates/dbx-core/src/ai_effort.rs
+++ b/crates/dbx-core/src/ai_effort.rs
@@ -76,7 +76,7 @@ pub fn static_effort_capability(config: &AiConfig, model_id: &str) -> Option<AiE
         AiProvider::Deepseek => deepseek_capability(&model, source),
         AiProvider::Qwen => qwen_capability(&model, source),
         AiProvider::Ollama => ollama_capability(&model, source),
-        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::Custom => {
+        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::MiniMax | AiProvider::Custom => {
             Some(AiEffortCapability::FreeText { placeholder: None, source: AiCapabilitySource::Custom })
         }
         AiProvider::Claude | AiProvider::CodexCli | AiProvider::ClaudeCodeCli | AiProvider::PiAgentCli => None,
@@ -183,6 +183,7 @@ pub fn registry_source_url(provider: &AiProvider) -> Option<&'static str> {
         | AiProvider::CodexCli
         | AiProvider::ClaudeCodeCli
         | AiProvider::PiAgentCli
+        | AiProvider::MiniMax
         | AiProvider::Custom => None,
     }
 }
@@ -241,7 +242,9 @@ pub fn apply_runtime_effort(body: &mut Value, config: &AiConfig) {
         AiProvider::Deepseek => apply_deepseek_effort(object, selection),
         AiProvider::Qwen => apply_qwen_effort(object, selection),
         AiProvider::Ollama => apply_openai_effort(object, &config.api_style, selection),
-        AiProvider::Openai | AiProvider::OpenaiCompatible => apply_openai_effort(object, &config.api_style, selection),
+        AiProvider::Openai | AiProvider::OpenaiCompatible | AiProvider::MiniMax => {
+            apply_openai_effort(object, &config.api_style, selection)
+        }
         AiProvider::Custom => {
             if config.api_style == AiApiStyle::AnthropicMessages {
                 apply_claude_effort(object, selection);
@@ -405,7 +408,7 @@ mod tests {
 
     #[test]
     fn free_text_effort_uses_the_translated_frontend_placeholder() {
-        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom] {
+        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom, AiProvider::MiniMax] {
             let capability = static_effort_capability(&config(provider, "custom-model"), "custom-model").unwrap();
             let AiEffortCapability::FreeText { placeholder, .. } = capability else {
                 panic!("expected free-text capability");

--- a/crates/dbx-core/src/ai_model_filter.rs
+++ b/crates/dbx-core/src/ai_model_filter.rs
@@ -199,7 +199,9 @@ mod tests {
 
     #[test]
     fn generic_providers_do_not_filter_unknown_model_taxonomies() {
-        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom, AiProvider::MiniMax] {
+        for provider in
+            [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom, AiProvider::MiniMax]
+        {
             for model in ["text-embedding-private-chat", "company/image-reasoner", "future-model"] {
                 assert!(model_is_assistant_compatible(&provider, model), "{}:{model}", provider.as_str());
             }

--- a/crates/dbx-core/src/ai_model_filter.rs
+++ b/crates/dbx-core/src/ai_model_filter.rs
@@ -96,6 +96,7 @@ pub(crate) fn model_is_assistant_compatible(provider: &AiProvider, model_id: &st
         | AiProvider::CodexCli
         | AiProvider::ClaudeCodeCli
         | AiProvider::PiAgentCli
+        | AiProvider::MiniMax
         | AiProvider::Custom => true,
     }
 }
@@ -198,7 +199,7 @@ mod tests {
 
     #[test]
     fn generic_providers_do_not_filter_unknown_model_taxonomies() {
-        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom] {
+        for provider in [AiProvider::AnthropicCompatible, AiProvider::OpenaiCompatible, AiProvider::Custom, AiProvider::MiniMax] {
             for model in ["text-embedding-private-chat", "company/image-reasoner", "future-model"] {
                 assert!(model_is_assistant_compatible(&provider, model), "{}:{model}", provider.as_str());
             }

--- a/crates/dbx-core/src/storage.rs
+++ b/crates/dbx-core/src/storage.rs
@@ -5180,6 +5180,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn minimax_ai_config_roundtrip() {
+        let db = temp_db_path("minimax-ai-roundtrip");
+        let storage = Storage::open(&db).await.unwrap();
+
+        let mut cfg = make_ai_config("minimax", true);
+        cfg.config.provider = AiProvider::MiniMax;
+        cfg.config.api_key = "key".to_string();
+        cfg.config.auth_method = AiAuthMethod::Bearer;
+        cfg.config.endpoint = "https://api.minimax.io/v1".to_string();
+        cfg.config.model = "MiniMax-M3".to_string();
+        cfg.config.api_style = AiApiStyle::Completions;
+        storage.save_ai_config_item(&cfg).await.unwrap();
+
+        let loaded = storage.load_ai_configs().await.unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert!(matches!(loaded[0].config.provider, AiProvider::MiniMax));
+        assert_eq!(loaded[0].config.auth_method, AiAuthMethod::Bearer);
+        assert_eq!(loaded[0].config.endpoint, "https://api.minimax.io/v1");
+        assert_eq!(loaded[0].config.model, "MiniMax-M3");
+
+        std::fs::remove_file(&db).ok();
+    }
+
+    #[tokio::test]
     async fn ai_config_only_one_default() {
         let db = temp_db_path("ai-one-default");
         let storage = Storage::open(&db).await.unwrap();

--- a/crates/dbx-web/src/routes/ai.rs
+++ b/crates/dbx-web/src/routes/ai.rs
@@ -542,6 +542,7 @@ mod tests {
             AiProvider::Gemini,
             AiProvider::Deepseek,
             AiProvider::Qwen,
+            AiProvider::MiniMax,
             AiProvider::Ollama,
         ] {
             let config = make_config(provider.clone());

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -503,6 +503,11 @@ test("AI provider presets include common hosted and local providers", () => {
   assert.equal(AI_PROVIDER_PRESETS.gemini.model, "gemini-1.5-pro");
   assert.equal(AI_PROVIDER_PRESETS.deepseek.endpoint, "https://api.deepseek.com/v1");
   assert.equal(AI_PROVIDER_PRESETS.deepseek.model, "deepseek-v4-flash");
+  assert.equal(AI_PROVIDER_PRESETS.minimax.endpoint, "https://api.minimax.io/v1");
+  assert.equal(AI_PROVIDER_PRESETS.minimax.model, "MiniMax-M3");
+  assert.equal(AI_PROVIDER_PRESETS.minimax.authMethod, "bearer");
+  assert.equal(AI_PROVIDER_PRESETS.minimax.requiresApiKey, true);
+  assert.equal(AI_PROVIDER_PRESETS.minimax.iconSlug, "minimax");
   assert.equal(AI_PROVIDER_PRESETS.qwen.endpoint, "https://dashscope.aliyuncs.com/compatible-mode/v1");
   assert.equal(AI_PROVIDER_PRESETS.ollama.endpoint, "http://localhost:11434/v1");
   assert.equal(AI_PROVIDER_PRESETS.ollama.requiresApiKey, false);
@@ -521,6 +526,8 @@ test("AI provider presets include common hosted and local providers", () => {
   assert.equal(AI_PROVIDER_PRESETS["pi-agent-cli"].iconSlug, "pi");
   assert.equal(AI_PROVIDER_PRESETS["pi-agent-cli"].requiresApiKey, false);
   assert.equal(Object.keys(AI_PROVIDER_PRESETS).indexOf("anthropic-compatible") + 1, Object.keys(AI_PROVIDER_PRESETS).indexOf("openai-compatible"));
+  assert.ok(Object.keys(AI_PROVIDER_PRESETS).indexOf("qwen") < Object.keys(AI_PROVIDER_PRESETS).indexOf("minimax"));
+  assert.ok(Object.keys(AI_PROVIDER_PRESETS).indexOf("minimax") < Object.keys(AI_PROVIDER_PRESETS).indexOf("ollama"));
   assert.ok(Object.keys(AI_PROVIDER_PRESETS).indexOf("claude-code-cli") < Object.keys(AI_PROVIDER_PRESETS).indexOf("codex-cli"));
   assert.ok(Object.keys(AI_PROVIDER_PRESETS).indexOf("claude-code-cli") < Object.keys(AI_PROVIDER_PRESETS).indexOf("pi-agent-cli"));
   assert.ok(Object.keys(AI_PROVIDER_PRESETS).indexOf("codex-cli") < Object.keys(AI_PROVIDER_PRESETS).indexOf("pi-agent-cli"));
@@ -594,6 +601,15 @@ test("infers legacy AI provider from saved endpoint and model", () => {
   assert.equal(deepseek.provider, "deepseek");
   assert.equal(deepseek.endpoint, "https://api.deepseek.com/anthropic/v1/messages");
   assert.equal(deepseek.model, "deepseek-v4-pro");
+
+  const minimax = normalizeAiConfig({
+    apiKey: "key",
+    endpoint: "https://api.minimax.io/v1",
+    model: "MiniMax-M3",
+  } as any);
+  assert.equal(minimax.provider, "minimax");
+  assert.equal(minimax.endpoint, "https://api.minimax.io/v1");
+  assert.equal(minimax.model, "MiniMax-M3");
 });
 
 test("normalizeEditorSettings falls back to the default UI scale", () => {


### PR DESCRIPTION
Reason: provider-add — add the MiniMax provider (global endpoint) with the MiniMax-M3 model preset to the AI provider registry.

## Changes
Adds MiniMax as a first-class AI provider alongside the existing OpenAI-compatible providers, wired through both the Rust backend (`dbx-core` / `dbx-web`) and the desktop frontend.

### Backend (Rust)
- `crates/dbx-core/src/ai.rs`
  - Add `MiniMax` variant to `AiProvider` (serialized as `"minimax"`) and its `as_str()` mapping.
  - Route MiniMax through the OpenAI-compatible chat completions / responses endpoints in `resolve_endpoint`, `complete`, and `stream`, and through `list_openai_compatible_models` for model discovery.
  - Require an API key for MiniMax in `provider_requires_api_key`.
- `crates/dbx-core/src/ai_effort.rs`
  - Treat MiniMax like the other OpenAI-compatible providers: free-text effort capability, no registry docs URL, and OpenAI-style runtime effort application.
- `crates/dbx-core/src/ai_model_filter.rs`
  - Do not filter MiniMax model IDs (assistant-compatible by default).
- `crates/dbx-web/src/routes/ai.rs`
  - Allow MiniMax in the web provider allow-list test.
- `crates/dbx-core/src/storage.rs`
  - Add a round-trip storage test for a MiniMax config.

### Frontend (TypeScript / Vue)
- `apps/desktop/src/types/ai.ts`
  - Add `"minimax"` to the `AiProvider` union.
- `apps/desktop/src/stores/settingsStore.ts`
  - Add a `minimax` preset (global endpoint `https://api.minimax.io/v1`, default model `MiniMax-M3`, bearer auth, requires API key) and infer the MiniMax provider from saved configs whose endpoint host is `minimax.io` / `minimaxi.com` or whose model includes `minimax`.
- `apps/desktop/src/components/icons/AiProviderLogo.vue`
  - Apply the dark-invert treatment to the MiniMax logo.
- `apps/desktop/public/icons/ai/minimax.svg`
  - Add the MiniMax brand icon.

### Tests
- `apps/desktop/src/lib/ai/__tests__/aiConfigOrdering.spec.ts` — cover MiniMax in the canonical provider ordering.
- `packages/app-tests/settingsStore.test.ts` — assert the MiniMax preset fields, ordering, and provider inference.

The regional CN endpoint (`https://api.minimaxi.com/v1`) is reachable by editing the endpoint in the provider settings; only the global endpoint is shipped as the preset default, matching how the other regional-capable providers are modeled.

## Verification
- `pnpm vitest run packages/app-tests/settingsStore.test.ts apps/desktop/src/lib/ai/__tests__/aiConfigOrdering.spec.ts` — 56 passed.
- `pnpm vitest run` (full desktop suite) — 5796 passed, 1 pre-existing failure in `debugLog.spec.ts` (`navigator is not defined`) unrelated to this change and reproducible on `origin/main`.
- `pnpm oxfmt --check 'apps/desktop/src/**/*.{ts,vue}'` — clean.
- `pnpm oxlint --vue-plugin <edited files>` — clean.

Rust changes are type-safe (the `AiProvider` match arms are exhaustive), but `cargo` was not available in this environment to build/test the `dbx-core` and `dbx-web` crates.
