### PR TITLE
fix(core): keep JSON array/object as a single JSON literal when copying as INSERT

### DIFF
--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1724,6 +1724,20 @@ fn format_grid_copy_insert_sql_literal(
             }
         }
     }
+    // JSON columns may expose a JSON array/object value (e.g. `[1,2,3]` or `{}`)
+    // instead of its string form. Keep it as a single JSON literal rather than
+    // letting format_grid_sql_literal serialize it as a PostgreSQL-style array
+    // (`{...}`). Serialize the value back to compact JSON text, format that as a
+    // string literal, then cast it for MySQL so it inserts as JSON.
+    if column_info.is_some_and(|column| {
+        let dt = column.data_type.trim();
+        dt.eq_ignore_ascii_case("json") || dt.eq_ignore_ascii_case("jsonb")
+    }) && (value.is_array() || value.is_object())
+    {
+        let json_text = value.to_string();
+        let string_literal = format_grid_sql_literal(&Value::String(json_text), database_type, column_info);
+        return mysql_json_predicate_literal(string_literal, database_type, column_info);
+    }
     format_grid_sql_literal(value, database_type, column_info)
 }
 
@@ -2988,6 +3002,57 @@ mod tests {
             statement.as_deref(),
             Some("INSERT INTO table_name (\"id\", \"active\", \"profile\") VALUES (7, TRUE, '{\"name\":\"Ada\",\"roles\":[\"admin\"]}');")
         );
+    }
+
+    #[test]
+    fn copy_insert_keeps_mysql_json_array_as_single_json_literal() {
+        let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
+            database_type: Some(DatabaseType::Mysql),
+            table_meta: None,
+            columns: vec!["data".to_string()],
+            column_types: Some(vec![Some("json".to_string())]),
+            source_columns: None,
+            rows: vec![vec![json!([1, 2, 3])]],
+            exclude_primary_keys: false,
+            include_computed_columns: false,
+            insert_mode: DataGridCopyInsertMode::Merged,
+        });
+
+        assert_eq!(statement.as_deref(), Some("INSERT INTO table_name (`data`) VALUES (CAST('[1,2,3]' AS JSON));"));
+    }
+
+    #[test]
+    fn copy_insert_keeps_mysql_json_empty_array_as_single_json_literal() {
+        let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
+            database_type: Some(DatabaseType::Mysql),
+            table_meta: None,
+            columns: vec!["data".to_string()],
+            column_types: Some(vec![Some("json".to_string())]),
+            source_columns: None,
+            rows: vec![vec![json!([])]],
+            exclude_primary_keys: false,
+            include_computed_columns: false,
+            insert_mode: DataGridCopyInsertMode::Merged,
+        });
+
+        assert_eq!(statement.as_deref(), Some("INSERT INTO table_name (`data`) VALUES (CAST('[]' AS JSON));"));
+    }
+
+    #[test]
+    fn copy_insert_keeps_mysql_json_object_as_single_json_literal() {
+        let statement = build_data_grid_copy_insert_statement(DataGridCopyInsertStatementOptions {
+            database_type: Some(DatabaseType::Mysql),
+            table_meta: None,
+            columns: vec!["data".to_string()],
+            column_types: Some(vec![Some("json".to_string())]),
+            source_columns: None,
+            rows: vec![vec![json!({"a": 1})]],
+            exclude_primary_keys: false,
+            include_computed_columns: false,
+            insert_mode: DataGridCopyInsertMode::Merged,
+        });
+
+        assert_eq!(statement.as_deref(), Some("INSERT INTO table_name (`data`) VALUES (CAST('{\"a\":1}' AS JSON));"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

复制为 INSERT 语句时,MySQL 等数据库的 `json` 列若以数组/对象形式(`Value::Array` / `Value::Object`)传入后端,会被 `format_grid_sql_literal` 误当作 PostgreSQL 数组,序列化后空数组 `[]` 变成 `{}`(issue #4944)。

在 `format_grid_copy_insert_sql_literal` 中新增分支:当列类型为 `json`/`jsonb` 且值为数组或对象时,先 `value.to_string()` 还原为紧凑 JSON 文本,再按字符串字面量格式化,并用既有的 `mysql_json_predicate_literal` 包成 `CAST(... AS JSON)`,从而保留为单个 JSON 字面量。

- 不影响已以字符串形式传入的 json 值(如 Elasticsearch 用例);
- 不动共享的 `format_grid_sql_literal` 主函数,ClickHouse / Databend 的数组行为保持不变。

## 变更类型

- [x] Bug 修复

## 涉及前端

- [ ] 本 PR 不涉及前端改动

## 验证

- [x] `cargo test -p dbx-core copy_insert` 通过:
  - 新增 `copy_insert_keeps_mysql_json_array_as_single_json_literal`:`[1,2,3]` → `CAST('[1,2,3]' AS JSON)`
  - 新增 `copy_insert_keeps_mysql_json_empty_array_as_single_json_literal`:`[]` → `CAST('[]' AS JSON)`(修复前为 `{}`)
  - 新增 `copy_insert_keeps_mysql_json_object_as_single_json_literal`:`{"a":1}` → `CAST('{"a":1}' AS JSON)`
  - 原有 `copy_insert_keeps_json_cells_as_single_json_literals`(Elasticsearch)仍通过

## 关联 Issue

Close #4944
