### PR TITLE
区分对象页签与表数据页签

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -449,7 +449,8 @@ function tabColorStyle(tab: QueryTab) {
 
 function tabIconClass(tab: QueryTab) {
   if (tab.mode === "mq") return "";
-  if (tab.mode === "data" || tab.mode === "mongo" || tab.mode === "vector" || tab.mode === "redis" || tab.mode === "hbase" || tab.mode === "objects" || tab.mode === "structure") return "text-emerald-600 dark:text-emerald-400";
+  if (tab.mode === "objects") return "text-amber-500 dark:text-amber-400";
+  if (tab.mode === "data" || tab.mode === "mongo" || tab.mode === "vector" || tab.mode === "redis" || tab.mode === "hbase" || tab.mode === "structure") return "text-emerald-600 dark:text-emerald-400";
   return "text-blue-600 dark:text-blue-400";
 }
 

--- a/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
@@ -23,6 +23,15 @@ describe("AppTabBar HBase presentation", () => {
   it("uses the table icon in regular, pinned, and overflow tab surfaces", () => {
     expect(tabBarSource).toContain('if (tab.mode === "data" || tab.mode === "mongo" || tab.mode === "redis" || tab.mode === "hbase") return Table2;');
     expect(tabBarSource.match(/tab\.mode === 'hbase'/g)).toHaveLength(2);
-    expect(tabBarSource).toContain('tab.mode === "hbase" || tab.mode === "objects"');
+    expect(tabBarSource).toContain('tab.mode === "hbase" || tab.mode === "structure"');
+  });
+});
+
+describe("AppTabBar objects presentation", () => {
+  it("uses an amber icon color on regular, pinned, and overflow tab surfaces", () => {
+    expect(tabBarSource).toContain('if (tab.mode === "objects") return "text-amber-500 dark:text-amber-400";');
+    expect(tabBarSource).toContain('if (tab.mode === "objects") return TableProperties;');
+    expect(tabBarSource.match(/:class="tabIconClass\(tab\)"/g)).toHaveLength(2);
+    expect(tabBarSource.match(/tabMenuIcon\(tab\).*tabIconClass\(tab\)/g)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## 变更内容

- 将数据库对象页签的图标颜色调整为琥珀色，表数据页签继续使用绿色
- 通过统一的图标样式逻辑，同时覆盖普通页签、固定页签和页签溢出菜单
- 增加回归测试，验证三种展示位置的图标样式

## 变更原因

对象列表页签和表数据页签目前都使用绿色系的表格图标。打开多个页签时，两者不容易快速区分。

## 截图

修改前，对象页签和表数据页签均为绿色系图标：

![修改前的对象页签和表数据页签](https://raw.githubusercontent.com/DASungta/dbx/issue-assets-4939/issue-assets/4939/object-vs-table-tabs.png)

修改后，对象页签图标显示为琥珀色，表数据页签图标保持绿色：

![修改后的对象页签和表数据页签](https://raw.githubusercontent.com/DASungta/dbx/issue-assets-4939/issue-assets/4939/object-tab-amber-after.png)

## 验证

- `pnpm exec vitest run apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts --reporter=verbose`：1 个测试文件、4 个测试全部通过
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/layout/AppTabBar.vue apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts`：通过
- GitHub Actions `frontend`：通过
- 已在 Tauri 桌面端手动验证

关联 #4939 的问题一。
