### PR TITLE
✨ feat(redis): 优化键详情自动刷新与 TTL 轮询

### DIFF
--- a/apps/desktop/src/components/redis/RedisValueViewer.expiry.spec.ts
+++ b/apps/desktop/src/components/redis/RedisValueViewer.expiry.spec.ts
@@ -7,6 +7,7 @@ import { calendarDateTimeToUnixSeconds, parseLocalDateTime } from "@/components/
 
 const mocks = vi.hoisted(() => ({
   redisGetValue: vi.fn(),
+  redisGetTtl: vi.fn(),
   redisSetTtl: vi.fn(),
   redisSetExpireAt: vi.fn(),
   toast: vi.fn(),
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/backend/api", () => ({
   redisGetValue: mocks.redisGetValue,
+  redisGetTtl: mocks.redisGetTtl,
   redisSetTtl: mocks.redisSetTtl,
   redisSetExpireAt: mocks.redisSetExpireAt,
 }));
@@ -39,6 +41,9 @@ afterEach(() => {
     unmount();
     host.remove();
   }
+  localStorage.removeItem("dbx-redis-auto-refresh-enabled-v2");
+  localStorage.removeItem("dbx-redis-auto-refresh-interval-seconds-v2");
+  vi.useRealTimers();
 });
 
 beforeEach(() => {
@@ -153,6 +158,112 @@ async function setStringDraft(value: string) {
 }
 
 describe("RedisValueViewer expiry saving", () => {
+  it("defaults to manual refresh without TTL polling", async () => {
+    vi.useFakeTimers();
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+
+    mountViewer(vi.fn());
+    await settle();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(mocks.redisGetTtl).not.toHaveBeenCalled();
+    expect(document.querySelector<HTMLButtonElement>("[aria-label='grid.refresh']")?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("polls only the TTL at the configured interval", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "5");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    mocks.redisGetTtl.mockResolvedValueOnce(45);
+
+    mountViewer(vi.fn());
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(mocks.redisGetTtl).toHaveBeenCalledWith("connection", 0, "key");
+    expect(mocks.redisGetValue).toHaveBeenCalledOnce();
+    expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("00:00:45");
+  });
+
+  it("shows auto-refresh as stopped after a TTL polling error", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    mocks.redisGetTtl.mockRejectedValueOnce(new Error("network unavailable"));
+
+    mountViewer(vi.fn());
+    await settle();
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+
+    expect(document.querySelector<HTMLButtonElement>("[aria-label='grid.refresh']")?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("stops auto-refresh and shows no expiry after an external PERSIST", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    mocks.redisGetTtl.mockResolvedValueOnce(-1);
+
+    mountViewer(vi.fn());
+    await settle();
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(mocks.redisGetTtl).toHaveBeenCalledOnce();
+    expect(document.querySelector<HTMLButtonElement>("[aria-label='grid.refresh']")?.getAttribute("aria-pressed")).toBe("false");
+    expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("redis.noExpiry");
+  });
+
+  it("pauses TTL polling while a value draft is unsaved", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    const deleted = vi.fn();
+
+    mountViewer(deleted);
+    await settle();
+    await setStringDraft("draft");
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(mocks.redisGetTtl).not.toHaveBeenCalled();
+    expect(deleted).not.toHaveBeenCalled();
+    expect(document.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("draft");
+  });
+
+  it("ignores a missing-key response when a draft is created during TTL polling", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    const ttlRequest = deferred<number>();
+    mocks.redisGetTtl.mockReturnValueOnce(ttlRequest.promise);
+    const deleted = vi.fn();
+
+    mountViewer(deleted);
+    await settle();
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+    expect(mocks.redisGetTtl).toHaveBeenCalledOnce();
+
+    await setStringDraft("draft");
+    ttlRequest.resolve(-2);
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(mocks.redisGetTtl).toHaveBeenCalledOnce();
+    expect(deleted).not.toHaveBeenCalled();
+    expect(document.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe("draft");
+  });
+
   it("removes a key that disappears while a TTL save fails", async () => {
     mocks.redisGetValue.mockResolvedValueOnce(stringValue()).mockResolvedValueOnce(missingValue());
     mocks.redisSetTtl.mockRejectedValueOnce(new Error("Redis key no longer exists; EXPIRE was not applied"));

--- a/apps/desktop/src/components/redis/RedisValueViewer.expiry.spec.ts
+++ b/apps/desktop/src/components/redis/RedisValueViewer.expiry.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { createApp, defineComponent, h, nextTick } from "vue";
+import { createApp, defineComponent, h, KeepAlive, nextTick, ref } from "vue";
 import { createI18n } from "vue-i18n";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { calendarDateTimeToUnixSeconds, parseLocalDateTime } from "@/components/ui/date-time-picker/dateTimePicker";
@@ -36,6 +36,30 @@ import RedisValueViewer from "./RedisValueViewer.vue";
 
 const mountedApps: Array<{ unmount: () => void; host: HTMLElement }> = [];
 
+function createLocalStorage(): Storage {
+  const entries = new Map<string, string>();
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key) {
+      return entries.get(key) ?? null;
+    },
+    key(index) {
+      return [...entries.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      entries.delete(key);
+    },
+    setItem(key, value) {
+      entries.set(key, String(value));
+    },
+  };
+}
+
 afterEach(() => {
   for (const { unmount, host } of mountedApps.splice(0)) {
     unmount();
@@ -43,11 +67,13 @@ afterEach(() => {
   }
   localStorage.removeItem("dbx-redis-auto-refresh-enabled-v2");
   localStorage.removeItem("dbx-redis-auto-refresh-interval-seconds-v2");
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubGlobal("localStorage", createLocalStorage());
 });
 
 async function settle() {
@@ -86,7 +112,7 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function mountViewer(onDeleted: (keyRaw: string) => void) {
+function mountViewer(onDeleted: (keyRaw: string) => void, onLoaded = vi.fn()) {
   const host = document.createElement("div");
   document.body.append(host);
   const app = createApp(
@@ -99,6 +125,7 @@ function mountViewer(onDeleted: (keyRaw: string) => void) {
             keyDisplay: "key",
             keyRaw: "key",
             onDeleted,
+            onLoaded,
           });
       },
     }),
@@ -106,6 +133,42 @@ function mountViewer(onDeleted: (keyRaw: string) => void) {
   app.use(createI18n({ legacy: false, locale: "en", messages: { en: {} }, missingWarn: false, fallbackWarn: false }));
   app.mount(host);
   mountedApps.push({ unmount: () => app.unmount(), host });
+}
+
+function mountKeepAliveViewer(onDeleted = vi.fn()) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const active = ref(true);
+  const inactiveView = defineComponent({ setup: () => () => h("div") });
+  const app = createApp(
+    defineComponent({
+      setup() {
+        return () =>
+          h(KeepAlive, null, {
+            default: () =>
+              active.value
+                ? h(RedisValueViewer, {
+                    key: "viewer",
+                    connectionId: "connection",
+                    db: 0,
+                    keyDisplay: "key",
+                    keyRaw: "key",
+                    onDeleted,
+                  })
+                : h(inactiveView, { key: "inactive" }),
+          });
+      },
+    }),
+  );
+  app.use(createI18n({ legacy: false, locale: "en", messages: { en: {} }, missingWarn: false, fallbackWarn: false }));
+  app.mount(host);
+  mountedApps.push({ unmount: () => app.unmount(), host });
+  return {
+    async setActive(value: boolean) {
+      active.value = value;
+      await settle();
+    },
+  };
 }
 
 async function saveTtlFromEditor() {
@@ -176,15 +239,33 @@ describe("RedisValueViewer expiry saving", () => {
     localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "5");
     mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
     mocks.redisGetTtl.mockResolvedValueOnce(45);
+    const loaded = vi.fn();
 
-    mountViewer(vi.fn());
+    mountViewer(vi.fn(), loaded);
     await settle();
     await vi.advanceTimersByTimeAsync(5000);
     await settle();
 
     expect(mocks.redisGetTtl).toHaveBeenCalledWith("connection", 0, "key");
     expect(mocks.redisGetValue).toHaveBeenCalledOnce();
+    expect(loaded).toHaveBeenCalledOnce();
     expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("00:00:45");
+  });
+
+  it("keeps polling when the loaded TTL starts at zero", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 0));
+    mocks.redisGetTtl.mockResolvedValueOnce(30);
+
+    mountViewer(vi.fn());
+    await settle();
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+
+    expect(mocks.redisGetTtl).toHaveBeenCalledOnce();
+    expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("00:00:30");
   });
 
   it("shows auto-refresh as stopped after a TTL polling error", async () => {
@@ -202,22 +283,71 @@ describe("RedisValueViewer expiry saving", () => {
     expect(document.querySelector<HTMLButtonElement>("[aria-label='grid.refresh']")?.getAttribute("aria-pressed")).toBe("false");
   });
 
-  it("stops auto-refresh and shows no expiry after an external PERSIST", async () => {
+  it("keeps polling after an external PERSIST and picks up a later TTL", async () => {
     vi.useFakeTimers();
     localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
     localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
     mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
-    mocks.redisGetTtl.mockResolvedValueOnce(-1);
+    mocks.redisGetTtl.mockResolvedValueOnce(-1).mockResolvedValueOnce(30);
 
     mountViewer(vi.fn());
     await settle();
     await vi.advanceTimersByTimeAsync(1000);
     await settle();
+    expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("redis.noExpiry");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+
+    expect(mocks.redisGetTtl).toHaveBeenCalledTimes(2);
+    expect(document.querySelector<HTMLButtonElement>("[data-redis-value-refresh]")?.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("00:00:30");
+  });
+
+  it("pauses polling while the document is hidden and resumes when visible", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    mocks.redisGetTtl.mockResolvedValue(45);
+    let visibilityState: DocumentVisibilityState = "visible";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
+
+    mountViewer(vi.fn());
+    await settle();
+    visibilityState = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
     await vi.advanceTimersByTimeAsync(5000);
 
+    expect(mocks.redisGetTtl).not.toHaveBeenCalled();
+
+    visibilityState = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+
     expect(mocks.redisGetTtl).toHaveBeenCalledOnce();
-    expect(document.querySelector<HTMLButtonElement>("[aria-label='grid.refresh']")?.getAttribute("aria-pressed")).toBe("false");
-    expect(document.querySelector<HTMLElement>("[data-slot='badge'][aria-label='redis.expiry']")?.textContent).toContain("redis.noExpiry");
+  });
+
+  it("pauses polling while deactivated and resumes from the saved setting", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("dbx-redis-auto-refresh-enabled-v2", "true");
+    localStorage.setItem("dbx-redis-auto-refresh-interval-seconds-v2", "1");
+    mocks.redisGetValue.mockResolvedValueOnce(stringValue("dmFsdWU=", 60));
+    mocks.redisGetTtl.mockResolvedValue(45);
+
+    const viewer = mountKeepAliveViewer();
+    await settle();
+    await viewer.setActive(false);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(mocks.redisGetTtl).not.toHaveBeenCalled();
+
+    await viewer.setActive(true);
+    await vi.advanceTimersByTimeAsync(1000);
+    await settle();
+
+    expect(mocks.redisGetTtl).toHaveBeenCalledOnce();
   });
 
   it("pauses TTL polling while a value draft is unsaved", async () => {

--- a/apps/desktop/src/components/redis/RedisValueViewer.streamMonitoring.spec.ts
+++ b/apps/desktop/src/components/redis/RedisValueViewer.streamMonitoring.spec.ts
@@ -159,6 +159,15 @@ function openGroups(host: HTMLElement) {
   host.querySelector<HTMLButtonElement>("[data-redis-stream-groups-tab]")!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
 }
 
+async function refreshValue(host: HTMLElement) {
+  host.querySelector<HTMLButtonElement>("[data-redis-value-refresh]")!.click();
+  await settle();
+  const refreshItem = document.querySelector<HTMLElement>("[data-slot='dropdown-menu-content'] [data-slot='dropdown-menu-item']");
+  expect(refreshItem).not.toBeNull();
+  refreshItem!.click();
+  await settle();
+}
+
 describe("RedisValueViewer stream monitoring", () => {
   it("loads more Stream entries from the returned cursor", async () => {
     mocks.redisGetValue.mockResolvedValue(streamValue([streamEntry("1714470000000-0")], "1714470000000-0"));
@@ -347,8 +356,7 @@ describe("RedisValueViewer stream monitoring", () => {
     host.querySelector<HTMLButtonElement>("[data-redis-stream-consumer-row]")!.click();
     await settle();
 
-    host.querySelector<HTMLButtonElement>("[data-redis-value-refresh]")!.click();
-    await settle();
+    await refreshValue(host);
 
     expect(mocks.redisGetValue).toHaveBeenCalledTimes(2);
     expect(mocks.redisGetStreamGroups).toHaveBeenCalledTimes(2);
@@ -372,8 +380,7 @@ describe("RedisValueViewer stream monitoring", () => {
     host.querySelector<HTMLButtonElement>("[data-redis-stream-consumer-row]")!.click();
     await settle();
 
-    host.querySelector<HTMLButtonElement>("[data-redis-value-refresh]")!.click();
-    await settle();
+    await refreshValue(host);
 
     expect(mocks.redisGetStreamConsumers).toHaveBeenCalledTimes(2);
     expect(host.querySelector("[data-redis-stream-consumer-crumb]")).toBeNull();
@@ -399,8 +406,7 @@ describe("RedisValueViewer stream monitoring", () => {
     host.querySelector<HTMLElement>("[data-redis-stream-group-row]")!.click();
     await settle();
 
-    host.querySelector<HTMLButtonElement>("[data-redis-value-refresh]")!.click();
-    await settle();
+    await refreshValue(host);
 
     expect(mocks.redisGetStreamGroups).toHaveBeenCalledTimes(2);
     expect(host.querySelector("[data-redis-stream-group-detail]")).toBeNull();

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, shallowRef, nextTick, onBeforeUnmount, onMounted, watch } from "vue";
+import { computed, ref, shallowRef, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, watch } from "vue";
 import type { CalendarDateTime } from "@internationalized/date";
 import { useI18n } from "vue-i18n";
 import { onClickOutside } from "@vueuse/core";
@@ -25,7 +25,7 @@ import { useEditorFontFamilyStyle } from "@/composables/useEditorFontFamilyStyle
 import { createShikiJsonHighlighter, type JsonHighlighter } from "@/lib/common/shikiJsonHighlighter";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatTtl } from "@/lib/common/ttlFormat";
-import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, normalizeRedisAutoRefreshInterval, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
+import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, normalizeRedisAutoRefreshInterval } from "@/lib/redis/redisAutoRefresh";
 import {
   canRenderRedisValueFormat,
   canEditRedisMemberDetail,
@@ -174,6 +174,11 @@ const refreshingTtl = ref(false);
 let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
 let ttlRefreshRequestId = 0;
+let redisValueViewerIsActive = true;
+
+function canRunAutoRefresh(): boolean {
+  return redisValueViewerIsActive && document.visibilityState !== "hidden";
+}
 
 function disableAutoRefresh() {
   autoRefreshEnabled.value = false;
@@ -193,13 +198,7 @@ function selectAutoRefreshInterval(interval: number) {
 
 function startAutoRefresh() {
   stopAutoRefresh();
-  if (!autoRefreshEnabled.value || !data.value) return;
-  if (shouldStopAutoRefresh(data.value.ttl)) {
-    // A non-expiring or missing key has no TTL to poll. Keep the persisted
-    // preference, but make the visible state match the stopped timers.
-    autoRefreshEnabled.value = false;
-    return;
-  }
+  if (!autoRefreshEnabled.value || !data.value || !canRunAutoRefresh()) return;
 
   countdownTtl.value = data.value.ttl;
   countdownTimer = setInterval(() => {
@@ -213,7 +212,7 @@ function startAutoRefresh() {
 }
 
 async function refreshTtl() {
-  if (refreshingTtl.value || loading.value || editingTtl.value || savingTtl.value || hasUnsavedRedisDraft.value || !autoRefreshEnabled.value || !data.value) return;
+  if (refreshingTtl.value || loading.value || editingTtl.value || savingTtl.value || hasUnsavedRedisDraft.value || !autoRefreshEnabled.value || !data.value || !canRunAutoRefresh()) return;
 
   const requestId = ++ttlRefreshRequestId;
   refreshingTtl.value = true;
@@ -221,7 +220,7 @@ async function refreshTtl() {
     const ttl = await api.redisGetTtl(props.connectionId, props.db, props.keyRaw);
     // A draft may be created while the request is in flight. Never apply even
     // a missing-key response after the user has started editing.
-    if (requestId !== ttlRefreshRequestId || hasUnsavedRedisDraft.value || !autoRefreshEnabled.value || !data.value) return;
+    if (requestId !== ttlRefreshRequestId || hasUnsavedRedisDraft.value || !autoRefreshEnabled.value || !data.value || !canRunAutoRefresh()) return;
 
     if (ttl === -2) {
       data.value = null;
@@ -236,15 +235,6 @@ async function refreshTtl() {
 
     const refreshedValue = { ...data.value, ttl };
     data.value = refreshedValue;
-    emit("loaded", refreshedValue);
-    if (shouldStopAutoRefresh(ttl)) {
-      stopAutoRefresh();
-      // An external PERSIST makes this key non-expiring. As with a polling
-      // error, do not overwrite the user's saved preference, but do not show
-      // auto-refresh as active after its timers have stopped.
-      autoRefreshEnabled.value = false;
-      return;
-    }
     countdownTtl.value = ttl;
   } catch {
     // A failed background read must not retry in a tight loop. Manual refresh
@@ -272,6 +262,14 @@ function stopAutoRefresh() {
     clearInterval(countdownTimer);
     countdownTimer = null;
   }
+}
+
+function handleDocumentVisibilityChange() {
+  if (document.visibilityState === "hidden") {
+    stopAutoRefresh();
+    return;
+  }
+  startAutoRefresh();
 }
 
 const hashSortBy = ref<"field" | "value" | null>(null);
@@ -1103,7 +1101,7 @@ async function load(options: { selectDefaultMember?: boolean; preserveDraft?: bo
   } finally {
     if (requestId === loadRequestId) {
       loading.value = false;
-      if (autoRefreshEnabled.value && data.value && data.value.ttl > 0) {
+      if (autoRefreshEnabled.value && data.value) {
         startAutoRefresh();
       }
     }
@@ -1944,6 +1942,7 @@ watch(showMemberDetail, (open) => {
 
 onMounted(() => {
   window.addEventListener("pointerdown", handleValueViewerPointerDown, true);
+  document.addEventListener("visibilitychange", handleDocumentVisibilityChange);
   void load();
   void createShikiJsonHighlighter({
     appearance: () => redisJsonAppearance.value,
@@ -1955,8 +1954,18 @@ onMounted(() => {
       redisJsonHighlighter.value = undefined;
     });
 });
+onActivated(() => {
+  redisValueViewerIsActive = true;
+  startAutoRefresh();
+});
+onDeactivated(() => {
+  redisValueViewerIsActive = false;
+  stopAutoRefresh();
+});
 onBeforeUnmount(() => {
   window.removeEventListener("pointerdown", handleValueViewerPointerDown, true);
+  document.removeEventListener("visibilitychange", handleDocumentVisibilityChange);
+  redisValueViewerIsActive = false;
   stopAutoRefresh();
   stopResizeHashColumns();
   stopResizeZsetColumns();

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -4,7 +4,7 @@ import type { CalendarDateTime } from "@internationalized/date";
 import { useI18n } from "vue-i18n";
 import { onClickOutside } from "@vueuse/core";
 import { DynamicScroller, DynamicScrollerItem, RecycleScroller } from "vue-virtual-scroller";
-import { Copy, ClipboardCopy, Eye, Trash2, Save, RefreshCw, Plus, Loader2, Pencil, WrapText, ArrowUp, ArrowDown, ArrowUpDown, Search, Clock } from "@lucide/vue";
+import { Check, Copy, ClipboardCopy, Eye, Trash2, Save, RefreshCw, Plus, Loader2, Pencil, WrapText, ArrowUp, ArrowDown, ArrowUpDown, Search } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DateTimePicker from "@/components/ui/date-time-picker/DateTimePicker.vue";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import DangerConfirmDialog from "@/components/editor/DangerConfirmDialog.vue";
 import JsonTree from "@/components/common/JsonTree.vue";
 import RedisJsonEditor from "@/components/redis/RedisJsonEditor.vue";
@@ -24,7 +25,7 @@ import { useEditorFontFamilyStyle } from "@/composables/useEditorFontFamilyStyle
 import { createShikiJsonHighlighter, type JsonHighlighter } from "@/lib/common/shikiJsonHighlighter";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatTtl } from "@/lib/common/ttlFormat";
-import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
+import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, normalizeRedisAutoRefreshInterval, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
 import {
   canRenderRedisValueFormat,
   canEditRedisMemberDetail,
@@ -74,6 +75,11 @@ const emit = defineEmits<{ deleted: [keyRaw: string]; loaded: [value: RedisValue
 
 const REDIS_JSON_WRAP_STORAGE_KEY = "dbx-redis-json-word-wrap";
 const REDIS_VALUE_FORMAT_STORAGE_KEY = "dbx-redis-value-format";
+// Versioned after moving the setting into the refresh menu so the previous
+// always-on default does not carry into the new manual-refresh default.
+const REDIS_AUTO_REFRESH_ENABLED_STORAGE_KEY = "dbx-redis-auto-refresh-enabled-v2";
+const REDIS_AUTO_REFRESH_INTERVAL_STORAGE_KEY = "dbx-redis-auto-refresh-interval-seconds-v2";
+const REDIS_AUTO_REFRESH_INTERVAL_OPTIONS = [1, 3, 5, 10] as const;
 const REDIS_COLLECTION_ROW_HEIGHT = 32;
 const REDIS_STREAM_MIN_ROW_HEIGHT = 96;
 
@@ -158,57 +164,113 @@ const memberValueView = ref<RedisValueFormat>(readPreferredRedisValueFormat());
 const redisJsonWordWrap = ref(readRedisJsonWordWrap());
 const redisJsonHighlighter = ref<JsonHighlighter>();
 
-// Auto-refresh
-const autoRefreshEnabled = ref(true);
+// Auto-refresh keeps the displayed TTL moving locally and periodically asks
+// Redis for the authoritative value. The two timers stay separate so a short
+// polling interval never causes a full key-value reload.
+const autoRefreshEnabled = ref(readRedisAutoRefreshEnabled());
+const autoRefreshIntervalSeconds = ref(readRedisAutoRefreshInterval());
 const countdownTtl = ref(0);
+const refreshingTtl = ref(false);
 let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+let countdownTimer: ReturnType<typeof setInterval> | null = null;
+let ttlRefreshRequestId = 0;
 
-function toggleAutoRefresh() {
-  autoRefreshEnabled.value = !autoRefreshEnabled.value;
-  if (autoRefreshEnabled.value) {
-    startAutoRefresh();
-  } else {
-    stopAutoRefresh();
+function disableAutoRefresh() {
+  autoRefreshEnabled.value = false;
+  persistRedisAutoRefreshEnabled(false);
+  stopAutoRefresh();
+}
+
+function selectAutoRefreshInterval(interval: number) {
+  autoRefreshIntervalSeconds.value = interval;
+  persistRedisAutoRefreshInterval(interval);
+  if (!autoRefreshEnabled.value) {
+    autoRefreshEnabled.value = true;
+    persistRedisAutoRefreshEnabled(true);
   }
+  startAutoRefresh();
 }
 
 function startAutoRefresh() {
   stopAutoRefresh();
-  if (data.value && data.value.ttl > 0) {
-    countdownTtl.value = data.value.ttl;
+  if (!autoRefreshEnabled.value || !data.value) return;
+  if (shouldStopAutoRefresh(data.value.ttl)) {
+    // A non-expiring or missing key has no TTL to poll. Keep the persisted
+    // preference, but make the visible state match the stopped timers.
+    autoRefreshEnabled.value = false;
+    return;
   }
-  autoRefreshTimer = setInterval(() => {
-    const action = computeAutoRefreshTick(autoRefreshEnabled.value, countdownTtl.value, loading.value);
+
+  countdownTtl.value = data.value.ttl;
+  countdownTimer = setInterval(() => {
+    const action = computeAutoRefreshTick(autoRefreshEnabled.value, countdownTtl.value);
     if (action.type === "decrement") {
       countdownTtl.value--;
-      return;
-    }
-    if (action.type === "refresh") {
-      // Do not let a background refresh overwrite a Redis value draft.
-      if (hasUnsavedRedisDraft.value) return;
-      load({ preserveDraft: true })
-        .then((applied) => {
-          if (!applied || !autoRefreshEnabled.value) return;
-          if (!data.value || shouldStopAutoRefresh(data.value.ttl)) {
-            stopAutoRefresh();
-            autoRefreshEnabled.value = false;
-          }
-        })
-        .catch(() => {
-          // Network / connection error — stop auto-refresh to avoid tight retry loop
-          if (autoRefreshEnabled.value) {
-            stopAutoRefresh();
-            autoRefreshEnabled.value = false;
-          }
-        });
     }
   }, 1000);
+
+  autoRefreshTimer = setInterval(() => void refreshTtl(), autoRefreshIntervalSeconds.value * 1000);
+}
+
+async function refreshTtl() {
+  if (refreshingTtl.value || loading.value || editingTtl.value || savingTtl.value || hasUnsavedRedisDraft.value || !autoRefreshEnabled.value || !data.value) return;
+
+  const requestId = ++ttlRefreshRequestId;
+  refreshingTtl.value = true;
+  try {
+    const ttl = await api.redisGetTtl(props.connectionId, props.db, props.keyRaw);
+    // A draft may be created while the request is in flight. Never apply even
+    // a missing-key response after the user has started editing.
+    if (requestId !== ttlRefreshRequestId || hasUnsavedRedisDraft.value || !autoRefreshEnabled.value || !data.value) return;
+
+    if (ttl === -2) {
+      data.value = null;
+      collectionItems.value = [];
+      scanCursor.value = undefined;
+      resetStreamEntries();
+      resetStreamMonitoring();
+      stopAutoRefresh();
+      emit("deleted", props.keyRaw);
+      return;
+    }
+
+    const refreshedValue = { ...data.value, ttl };
+    data.value = refreshedValue;
+    emit("loaded", refreshedValue);
+    if (shouldStopAutoRefresh(ttl)) {
+      stopAutoRefresh();
+      // An external PERSIST makes this key non-expiring. As with a polling
+      // error, do not overwrite the user's saved preference, but do not show
+      // auto-refresh as active after its timers have stopped.
+      autoRefreshEnabled.value = false;
+      return;
+    }
+    countdownTtl.value = ttl;
+  } catch {
+    // A failed background read must not retry in a tight loop. Manual refresh
+    // remains available and starts a fresh polling lifecycle on success.
+    if (requestId === ttlRefreshRequestId) {
+      stopAutoRefresh();
+      // The user did not turn the preference off, so do not persist this
+      // transient failure. The visible state must still match the stopped
+      // timers and let one click restart polling.
+      autoRefreshEnabled.value = false;
+    }
+  } finally {
+    if (requestId === ttlRefreshRequestId) refreshingTtl.value = false;
+  }
 }
 
 function stopAutoRefresh() {
+  ttlRefreshRequestId++;
+  refreshingTtl.value = false;
   if (autoRefreshTimer !== null) {
     clearInterval(autoRefreshTimer);
     autoRefreshTimer = null;
+  }
+  if (countdownTimer !== null) {
+    clearInterval(countdownTimer);
+    countdownTimer = null;
   }
 }
 
@@ -773,6 +835,39 @@ function readRedisJsonWordWrap(): boolean {
     return localStorage.getItem(REDIS_JSON_WRAP_STORAGE_KEY) !== "false";
   } catch {
     return true;
+  }
+}
+
+function readRedisAutoRefreshEnabled(): boolean {
+  try {
+    return localStorage.getItem(REDIS_AUTO_REFRESH_ENABLED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function persistRedisAutoRefreshEnabled(enabled: boolean) {
+  try {
+    localStorage.setItem(REDIS_AUTO_REFRESH_ENABLED_STORAGE_KEY, enabled ? "true" : "false");
+  } catch {
+    // Keep the preference for this component if storage is unavailable.
+  }
+}
+
+function readRedisAutoRefreshInterval(): number {
+  try {
+    const stored = localStorage.getItem(REDIS_AUTO_REFRESH_INTERVAL_STORAGE_KEY);
+    return stored === null ? DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS : normalizeRedisAutoRefreshInterval(stored);
+  } catch {
+    return DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS;
+  }
+}
+
+function persistRedisAutoRefreshInterval(interval: number) {
+  try {
+    localStorage.setItem(REDIS_AUTO_REFRESH_INTERVAL_STORAGE_KEY, String(interval));
+  } catch {
+    // Keep the current interval if storage is unavailable.
   }
 }
 
@@ -1897,7 +1992,39 @@ defineExpose({ focusSearch });
       <div class="shrink-0 border-b bg-background">
         <div class="flex h-9 items-center gap-2 px-4">
           <span class="dbx-editor-font-family min-w-0 flex-1 truncate text-sm font-semibold">{{ formatValue(data.key_display) }}</span>
-          <Button data-redis-value-refresh variant="ghost" size="icon" class="h-7 w-7 shrink-0 animate-none" :disabled="hasUnsavedRedisDraft" @click="refreshValueAndStreamGroups"><RefreshCw class="h-3.5 w-3.5 animate-none" /></Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger as-child>
+              <Button
+                data-redis-value-refresh
+                variant="ghost"
+                size="icon"
+                class="h-7 w-7 shrink-0 animate-none"
+                :class="autoRefreshEnabled ? 'bg-primary/10 text-primary hover:bg-primary/15' : ''"
+                :title="autoRefreshEnabled ? `${t('redis.autoRefresh')}: ${autoRefreshIntervalSeconds}s` : t('grid.refresh')"
+                :aria-label="autoRefreshEnabled ? `${t('redis.autoRefresh')}: ${autoRefreshIntervalSeconds}s` : t('grid.refresh')"
+                :aria-pressed="autoRefreshEnabled"
+                ><RefreshCw class="h-3.5 w-3.5 animate-none"
+              /></Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" class="w-40">
+              <DropdownMenuItem class="gap-2" :disabled="hasUnsavedRedisDraft" @select="refreshValueAndStreamGroups">
+                <RefreshCw class="h-3.5 w-3.5" />
+                {{ t("grid.refresh") }}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>{{ t("redis.autoRefresh") }}</DropdownMenuLabel>
+              <DropdownMenuItem class="gap-2" @select="disableAutoRefresh">
+                <Check v-if="!autoRefreshEnabled" class="h-3.5 w-3.5" />
+                <span v-else class="h-3.5 w-3.5" />
+                {{ t("serverDashboard.off") }}
+              </DropdownMenuItem>
+              <DropdownMenuItem v-for="interval in REDIS_AUTO_REFRESH_INTERVAL_OPTIONS" :key="interval" class="gap-2" @select="selectAutoRefreshInterval(interval)">
+                <Check v-if="autoRefreshEnabled && autoRefreshIntervalSeconds === interval" class="h-3.5 w-3.5" />
+                <span v-else class="h-3.5 w-3.5" />
+                {{ interval }}s
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0" :title="t('grid.copyValue')" :aria-label="t('grid.copyValue')" @click="copyValue"><Copy class="h-3.5 w-3.5" /></Button>
           <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0" :title="t('redis.copyInsertStatement')" :aria-label="t('redis.copyInsertStatement')" @click="copyInsertStatement"><ClipboardCopy class="h-3.5 w-3.5" /></Button>
           <Button variant="ghost" size="icon" class="h-7 w-7 shrink-0 text-destructive" @click="requestDeleteKey"><Trash2 class="h-3.5 w-3.5" /></Button>
@@ -1929,9 +2056,6 @@ defineExpose({ focusSearch });
             <DateTimePicker v-else-if="ttlExpiryMode === 'at'" v-model="ttlExpireAt" compact :locale="locale" :disabled="savingTtl" />
             <Button variant="ghost" size="icon" class="h-6 w-6 shrink-0" :disabled="savingTtl" :title="t('grid.save')" :aria-label="t('grid.save')" @click="saveTtl"><Save class="h-3 w-3" /></Button>
           </div>
-          <Button variant="ghost" size="icon" class="h-6 w-6 shrink-0" :class="{ 'text-primary bg-accent': autoRefreshEnabled }" :title="t('redis.autoRefresh')" @click="toggleAutoRefresh">
-            <Clock class="h-3.5 w-3.5" />
-          </Button>
         </div>
       </div>
 

--- a/apps/desktop/src/lib/__tests__/redis/RedisValueViewer.redisJson.spec.ts
+++ b/apps/desktop/src/lib/__tests__/redis/RedisValueViewer.redisJson.spec.ts
@@ -234,7 +234,7 @@ describe("native RedisJSON editor", () => {
   });
 
   it("keeps retained drafts out of background refresh and exposes word wrap for every JSON editor", () => {
-    const autoRefresh = findFunction("startAutoRefresh");
+    const refreshTtl = findFunction("refreshTtl");
     const hashSearch = findFunction("onHashSearch");
     const viewMember = findFunction("viewMember");
     const setMemberValueFormat = findFunction("setMemberValueFormat");
@@ -243,10 +243,9 @@ describe("native RedisJSON editor", () => {
     const labels = templateElements(parsedViewer.descriptor.template!.ast as unknown as TemplateElement);
     const stringTextarea = findTemplateElement((element) => element.tag === "textarea" && directiveExpression(element, "model") === "editValue");
     const memberTextarea = findTemplateElement((element) => element.tag === "textarea" && directiveExpression(element, "model") === "memberEditValue");
-    const refreshButton = findTemplateElement((element) => element.tag === "Button" && directiveExpression(element, "on", "click") === "refreshValueAndStreamGroups");
+    const refreshItem = findTemplateElement((element) => element.tag === "DropdownMenuItem" && directiveExpression(element, "on", "select") === "refreshValueAndStreamGroups");
 
-    expect(autoRefresh.getText()).toContain("if (hasUnsavedRedisDraft.value) return;");
-    expect(autoRefresh.getText()).toContain("load({ preserveDraft: true })");
+    expect(refreshTtl.getText().match(/hasUnsavedRedisDraft\.value/g)).toHaveLength(2);
     expect(hashSearch.getText()).toContain("if (!hasRetainedMemberDraft.value) clearSelectedMember();");
     expect(viewMember.getText()).toContain("hasRetainedMemberDraft.value");
     // Clean JSON → other format must clear memberDraftFormat so rawText is not compared to the pretty baseline.
@@ -259,6 +258,6 @@ describe("native RedisJSON editor", () => {
     expect(labels.some((element) => element.tag === "label" && directiveExpression(element, "if") === "isTextRedisFormat(memberValueView)")).toBe(true);
     expect(directiveExpression(stringTextarea, "bind", "readonly")).toBe("!canEditCurrentStringFormat || savingString");
     expect(directiveExpression(memberTextarea, "bind", "readonly")).toBe("savingMember");
-    expect(directiveExpression(refreshButton, "bind", "disabled")).toBe("hasUnsavedRedisDraft");
+    expect(directiveExpression(refreshItem, "bind", "disabled")).toBe("hasUnsavedRedisDraft");
   });
 });

--- a/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
+++ b/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, normalizeRedisAutoRefreshInterval, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
+import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, normalizeRedisAutoRefreshInterval } from "@/lib/redis/redisAutoRefresh";
 
 describe("computeAutoRefreshTick", () => {
   it("returns idle when auto-refresh is disabled", () => {
@@ -26,22 +26,6 @@ describe("normalizeRedisAutoRefreshInterval", () => {
     expect(normalizeRedisAutoRefreshInterval(0)).toBe(1);
     expect(normalizeRedisAutoRefreshInterval(1.9)).toBe(1);
     expect(normalizeRedisAutoRefreshInterval(9_999)).toBe(3600);
-  });
-});
-
-describe("shouldStopAutoRefresh", () => {
-  it("returns true when TTL is zero (key expired)", () => {
-    expect(shouldStopAutoRefresh(0)).toBe(true);
-  });
-
-  it("returns true when TTL is negative (no expiry or key deleted)", () => {
-    expect(shouldStopAutoRefresh(-1)).toBe(true);
-    expect(shouldStopAutoRefresh(-2)).toBe(true);
-  });
-
-  it("returns false when TTL is positive (key still alive)", () => {
-    expect(shouldStopAutoRefresh(1)).toBe(false);
-    expect(shouldStopAutoRefresh(3600)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
+++ b/apps/desktop/src/lib/__tests__/redis/redisAutoRefresh.spec.ts
@@ -1,32 +1,31 @@
 import { describe, expect, it } from "vitest";
 
-import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
+import { computeAutoRefreshTick, computeDisplayTtl, computeTtlForExpiryEdit, DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, normalizeRedisAutoRefreshInterval, shouldStopAutoRefresh } from "@/lib/redis/redisAutoRefresh";
 
 describe("computeAutoRefreshTick", () => {
   it("returns idle when auto-refresh is disabled", () => {
-    expect(computeAutoRefreshTick(false, 10, false)).toEqual({ type: "idle" });
-    // countdown value and loading flag don't matter when disabled
-    expect(computeAutoRefreshTick(false, 0, false)).toEqual({ type: "idle" });
-    expect(computeAutoRefreshTick(false, 5, true)).toEqual({ type: "idle" });
+    expect(computeAutoRefreshTick(false, 10)).toEqual({ type: "idle" });
+    expect(computeAutoRefreshTick(false, 0)).toEqual({ type: "idle" });
+    expect(computeAutoRefreshTick(false, 5)).toEqual({ type: "idle" });
   });
 
-  it("returns decrement while more than one second remains", () => {
-    expect(computeAutoRefreshTick(true, 10, false)).toEqual({ type: "decrement" });
-    // decrement even when loading — countdown should keep ticking
-    expect(computeAutoRefreshTick(true, 3, true)).toEqual({ type: "decrement" });
+  it("returns decrement while a positive TTL remains", () => {
+    expect(computeAutoRefreshTick(true, 10)).toEqual({ type: "decrement" });
+    expect(computeAutoRefreshTick(true, 1)).toEqual({ type: "decrement" });
   });
 
-  it("refreshes on the expiry tick instead of exposing a zero countdown", () => {
-    expect(computeAutoRefreshTick(true, 1, false)).toEqual({ type: "refresh" });
-    expect(computeAutoRefreshTick(true, 0, false)).toEqual({ type: "refresh" });
-    expect(computeAutoRefreshTick(true, -1, false)).toEqual({ type: "refresh" });
+  it("stops decrementing after the TTL has reached zero", () => {
+    expect(computeAutoRefreshTick(true, 0)).toEqual({ type: "idle" });
+    expect(computeAutoRefreshTick(true, -1)).toEqual({ type: "idle" });
   });
+});
 
-  it("does not start another refresh when a load is already in flight", () => {
-    expect(computeAutoRefreshTick(true, 1, true)).toEqual({ type: "decrement" });
-    // This prevents concurrent load() calls
-    expect(computeAutoRefreshTick(true, 0, true)).toEqual({ type: "idle" });
-    expect(computeAutoRefreshTick(true, -1, true)).toEqual({ type: "idle" });
+describe("normalizeRedisAutoRefreshInterval", () => {
+  it("uses the default for invalid values and clamps arbitrary input to safe seconds", () => {
+    expect(normalizeRedisAutoRefreshInterval("invalid")).toBe(DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS);
+    expect(normalizeRedisAutoRefreshInterval(0)).toBe(1);
+    expect(normalizeRedisAutoRefreshInterval(1.9)).toBe(1);
+    expect(normalizeRedisAutoRefreshInterval(9_999)).toBe(3600);
   });
 });
 

--- a/apps/desktop/src/lib/backend/api.ts
+++ b/apps/desktop/src/lib/backend/api.ts
@@ -392,6 +392,7 @@ export const redisScanKeys = forward("redisScanKeys");
 export const redisScanKeysBatch = forward("redisScanKeysBatch");
 export const redisScanValues = forward("redisScanValues");
 export const redisGetValue = forward("redisGetValue");
+export const redisGetTtl = forward("redisGetTtl");
 export const redisGetStreamEntries = forward("redisGetStreamEntries");
 export const redisGetStreamGroups = forward("redisGetStreamGroups");
 export const redisGetStreamConsumers = forward("redisGetStreamConsumers");

--- a/apps/desktop/src/lib/backend/http.ts
+++ b/apps/desktop/src/lib/backend/http.ts
@@ -2254,6 +2254,10 @@ export async function redisGetValue(connectionId: string, db: number, keyRaw: st
   return post("/api/redis/get-value", { connectionId, db, keyRaw });
 }
 
+export async function redisGetTtl(connectionId: string, db: number, keyRaw: string): Promise<number> {
+  return post("/api/redis/get-ttl", { connectionId, db, keyRaw });
+}
+
 export async function redisGetStreamEntries(connectionId: string, db: number, keyRaw: string, cursor?: string): Promise<RedisStreamPage> {
   return post("/api/redis/get-stream-entries", { connectionId, db, keyRaw, cursor });
 }

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -2090,6 +2090,10 @@ export async function redisGetValue(connectionId: string, db: number, keyRaw: st
   return invoke("redis_get_value", { connectionId, db, keyRaw });
 }
 
+export async function redisGetTtl(connectionId: string, db: number, keyRaw: string): Promise<number> {
+  return invoke("redis_get_ttl", { connectionId, db, keyRaw });
+}
+
 export async function redisGetStreamEntries(connectionId: string, db: number, keyRaw: string, cursor?: string): Promise<RedisStreamPage> {
   return invoke("redis_get_stream_entries", { connectionId, db, keyRaw, cursor });
 }

--- a/apps/desktop/src/lib/redis/redisAutoRefresh.ts
+++ b/apps/desktop/src/lib/redis/redisAutoRefresh.ts
@@ -31,16 +31,6 @@ export function computeAutoRefreshTick(enabled: boolean, countdownTtl: number): 
 }
 
 /**
- * Determine whether auto-refresh should be automatically disabled
- * after a server load completes (e.g. key expired or deleted).
- *
- * @param ttl  The TTL value returned by the server (seconds, -1 = no expiry).
- */
-export function shouldStopAutoRefresh(ttl: number): boolean {
-  return ttl <= 0;
-}
-
-/**
  * Compute the TTL value that should be displayed in the badge.
  *
  * When auto-refresh is active, the live countdown value is shown. The

--- a/apps/desktop/src/lib/redis/redisAutoRefresh.ts
+++ b/apps/desktop/src/lib/redis/redisAutoRefresh.ts
@@ -5,21 +5,29 @@
  * state-machine logic without mounting a Vue component.
  */
 
-/** Action computed after evaluating one auto-refresh tick. */
-export type AutoRefreshTickAction = { type: "idle" } | { type: "decrement" } | { type: "refresh" };
+export const MIN_REDIS_AUTO_REFRESH_INTERVAL_SECONDS = 1;
+export const MAX_REDIS_AUTO_REFRESH_INTERVAL_SECONDS = 3600;
+export const DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS = 5;
+
+/** Action computed after evaluating one visible TTL countdown tick. */
+export type AutoRefreshTickAction = { type: "idle" } | { type: "decrement" };
+
+/** Keep a user-entered polling frequency within a safe, whole-second range. */
+export function normalizeRedisAutoRefreshInterval(value: unknown): number {
+  const seconds = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(seconds)) return DEFAULT_REDIS_AUTO_REFRESH_INTERVAL_SECONDS;
+  return Math.min(MAX_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, Math.max(MIN_REDIS_AUTO_REFRESH_INTERVAL_SECONDS, Math.floor(seconds)));
+}
 
 /**
- * Evaluate one tick of the auto-refresh interval.
+ * Evaluate one one-second visible TTL countdown tick.
  *
  * @param enabled  Whether auto-refresh is currently toggled on.
  * @param countdownTtl  Current countdown value in seconds.
- * @param isLoading  Whether a data load is already in flight.
  * @returns The action the caller should take this tick.
  */
-export function computeAutoRefreshTick(enabled: boolean, countdownTtl: number, isLoading: boolean): AutoRefreshTickAction {
-  if (!enabled) return { type: "idle" };
-  if (isLoading) return countdownTtl > 0 ? { type: "decrement" } : { type: "idle" };
-  return countdownTtl <= 1 ? { type: "refresh" } : { type: "decrement" };
+export function computeAutoRefreshTick(enabled: boolean, countdownTtl: number): AutoRefreshTickAction {
+  return enabled && countdownTtl > 0 ? { type: "decrement" } : { type: "idle" };
 }
 
 /**

--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -2358,6 +2358,18 @@ where
     })
 }
 
+/// Read only a key's TTL without loading its value or collection members.
+///
+/// Redis returns `-2` for a missing key and `-1` for a key without an expiry;
+/// callers preserve those sentinel values so the UI can update its detail view
+/// without an additional round trip.
+pub async fn get_ttl<C>(con: &mut C, key: &[u8]) -> Result<i64, String>
+where
+    C: ConnectionLike + Send + Sync + Unpin,
+{
+    redis::cmd("TTL").arg(key).query_async(con).await.map_err(|e| e.to_string())
+}
+
 fn redis_value_matches_query(value: &RedisValue, query: &str) -> bool {
     let query = query.trim();
     if query.is_empty() {

--- a/crates/dbx-core/src/redis_ops.rs
+++ b/crates/dbx-core/src/redis_ops.rs
@@ -137,6 +137,37 @@ pub async fn redis_get_value_in_db_core(
     }
 }
 
+/// Fetch only the TTL for a selected key. This avoids repeatedly loading a
+/// potentially large Redis value when the desktop detail view is polling.
+pub async fn redis_get_ttl_in_db_core(
+    state: &AppState,
+    connection_id: &str,
+    db: u32,
+    key_raw: &str,
+) -> Result<i64, String> {
+    ensure_redis_pool(state, connection_id).await?;
+    let connections = state.connections.read().await;
+    let pool = connections.get(connection_id).ok_or("Connection not found")?;
+    match pool {
+        PoolKind::Redis(redis) => {
+            let key = redis_driver::redis_key_raw_to_bytes(key_raw)?;
+            match redis {
+                RedisConnection::Direct(con) => {
+                    let mut con = con.lock().await;
+                    redis_driver::select_db(&mut *con, db).await?;
+                    redis_driver::get_ttl(&mut *con, &key).await
+                }
+                RedisConnection::Cluster(cluster) => {
+                    redis_driver::ensure_cluster_db(db)?;
+                    let mut con = redis_driver::cluster_key_connection(cluster, &key).await?;
+                    redis_driver::get_ttl(&mut con, &key).await
+                }
+            }
+        }
+        _ => Err("Not a Redis connection".to_string()),
+    }
+}
+
 pub async fn redis_stream_entries_in_db_core(
     state: &AppState,
     connection_id: &str,

--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -493,6 +493,7 @@ async fn main() {
         .route("/redis/scan-keys-batch", post(routes::redis::scan_keys_batch))
         .route("/redis/scan-values", post(routes::redis::scan_values))
         .route("/redis/get-value", post(routes::redis::get_value))
+        .route("/redis/get-ttl", post(routes::redis::get_ttl))
         .route("/redis/get-stream-entries", post(routes::redis::get_stream_entries))
         .route("/redis/get-stream-groups", post(routes::redis::get_stream_groups))
         .route("/redis/get-stream-consumers", post(routes::redis::get_stream_consumers))

--- a/crates/dbx-web/src/routes/redis.rs
+++ b/crates/dbx-web/src/routes/redis.rs
@@ -331,6 +331,16 @@ pub async fn get_value(
     Ok(Json(serde_json::to_value(result).map_err(|e| AppError::from(e.to_string()))?))
 }
 
+pub async fn get_ttl(
+    State(state): State<Arc<WebState>>,
+    Json(req): Json<RedisKeyRequest>,
+) -> Result<Json<i64>, AppError> {
+    let ttl = dbx_core::redis_ops::redis_get_ttl_in_db_core(&state.app, &req.connection_id, req.db, &req.key_raw)
+        .await
+        .map_err(AppError::from)?;
+    Ok(Json(ttl))
+}
+
 pub async fn get_stream_entries(
     State(state): State<Arc<WebState>>,
     Json(req): Json<RedisStreamEntriesRequest>,

--- a/src-tauri/src/commands/redis_cmd.rs
+++ b/src-tauri/src/commands/redis_cmd.rs
@@ -88,6 +88,16 @@ pub async fn redis_get_value(
 }
 
 #[tauri::command]
+pub async fn redis_get_ttl(
+    state: State<'_, Arc<AppState>>,
+    connection_id: String,
+    db: u32,
+    key_raw: String,
+) -> Result<i64, String> {
+    dbx_core::redis_ops::redis_get_ttl_in_db_core(&state, &connection_id, db, &key_raw).await
+}
+
+#[tauri::command]
 pub async fn redis_get_stream_entries(
     state: State<'_, Arc<AppState>>,
     connection_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1765,6 +1765,7 @@ pub fn run() {
             commands::redis_cmd::redis_scan_keys_batch,
             commands::redis_cmd::redis_scan_values,
             commands::redis_cmd::redis_get_value,
+            commands::redis_cmd::redis_get_ttl,
             commands::redis_cmd::redis_get_stream_entries,
             commands::redis_cmd::redis_get_stream_groups,
             commands::redis_cmd::redis_get_stream_consumers,


### PR DESCRIPTION
- 默认关闭自动刷新，支持在刷新菜单中选择关闭或 1/3/5/10 秒轮询间隔，并持久化配置
- 自动刷新改为仅查询 TTL，避免重复加载大型键值及 Stream 数据
- 新增 Redis TTL 查询接口，覆盖桌面 Tauri 与 Web 后端
- 在草稿未保存、键被持久化或请求失败时安全停止轮询，避免覆盖用户编辑
- 将手动刷新入口迁移至下拉菜单，并补充相关测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="736" height="316" alt="image" src="https://github.com/user-attachments/assets/60b28ecc-b408-4e9d-928d-a458f9e0f34b" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #4924