### PR TITLE
🐛 fix(grid): 修复转置模式下的选中定位与键盘导航

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6401,6 +6401,13 @@ function copyColumnDetailFieldValue(field: DataGridCellDetail) {
 
 const transposeRecordWidths = ref<number[]>([]);
 const transposeManualRecordWidthIndexes = ref(new Set<number>());
+const transposeRecordOffsets = computed(() => {
+  const offsets = [0];
+  for (let index = 0; index < displayRowCount.value; index += 1) {
+    offsets.push(offsets[index] + getTransposeRecordWidth(index));
+  }
+  return offsets;
+});
 
 function calcTransposeRecordWidth(recordIndex: number): number {
   const item = displayItemAt(recordIndex);
@@ -6451,6 +6458,7 @@ const transposeRecordWindow = computed(() =>
     viewportWidth: transposeViewportWidth.value,
     pinnedWidth: transposePinnedWidth.value,
     recordWidth: estimatedTransposeRecordWidth(),
+    recordOffsets: transposeRecordOffsets.value,
     overscan: 2,
   }),
 );
@@ -6514,6 +6522,8 @@ function scrollTransposeRecordIntoView(rowIndex: number) {
       viewportWidth: el.clientWidth,
       pinnedWidth: transposePinnedWidth.value,
       recordWidth: estimatedTransposeRecordWidth(),
+      recordOffsets: transposeRecordOffsets.value,
+      currentScrollLeft: el.scrollLeft,
     });
     updateTransposeViewport();
   });

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5882,6 +5882,18 @@ function currentSelectedCellPosition() {
 }
 
 function scrollCellIntoView(rowIndex: number, colIndex: number) {
+  if (isTransposeMode.value) {
+    nextTick(() => {
+      const scroller = transposeScrollRef.value;
+      if (scroller && !(scroller instanceof HTMLElement)) {
+        (scroller as { scrollToItem?: (index: number) => void }).scrollToItem?.(colIndex);
+      } else if (scroller instanceof HTMLElement) {
+        scroller.scrollTop = colIndex * 30;
+      }
+      scrollTransposeRecordIntoView(rowIndex);
+    });
+    return;
+  }
   nextTick(() => {
     scrollGridColumnIntoView(colIndex);
     if (useCanvasGridRows.value) {
@@ -5953,9 +5965,22 @@ function scrollGridRowIntoView(rowIndex: number) {
   });
 }
 
-function currentTransposeRequestedRowIndex(): number {
+function selectedTransposeRowIndex(): number | null {
   const position = currentSelectedCellPosition();
   if (position) return position.rowIndex;
+  const lastSelectedRowIndex = selection.lastClickedRowIndex.value;
+  if (lastSelectedRowIndex !== null) {
+    const item = displayItemAt(lastSelectedRowIndex);
+    if (item && selectedRowIds.value.has(item.id)) return lastSelectedRowIndex;
+  }
+  const selectedRowIndex = displayRowRefs.value.findIndex((row) => selectedRowIds.value.has(row.id));
+  if (selectedRowIndex >= 0) return selectedRowIndex;
+  return null;
+}
+
+function currentTransposeRequestedRowIndex(): number {
+  const selectedRowIndex = selectedTransposeRowIndex();
+  if (selectedRowIndex !== null) return selectedRowIndex;
   if (transposeRowIndex.value !== null) return transposeRowIndex.value;
   return 0;
 }
@@ -6183,13 +6208,23 @@ async function onGridKeydown(event: KeyboardEvent) {
     event.preventDefault();
     return;
   }
-  if (event.key === "ArrowLeft" && moveTransposeRecordSelection(-1)) {
-    event.preventDefault();
-    return;
-  }
-  if (event.key === "ArrowRight" && moveTransposeRecordSelection(1)) {
-    event.preventDefault();
-    return;
+  if (isTransposeMode.value) {
+    if (event.key === "ArrowUp" && moveSelectedCell(0, -1)) {
+      event.preventDefault();
+      return;
+    }
+    if (event.key === "ArrowDown" && moveSelectedCell(0, 1)) {
+      event.preventDefault();
+      return;
+    }
+    if (event.key === "ArrowLeft" && (moveSelectedCell(-1, 0) || moveTransposeRecordSelection(-1))) {
+      event.preventDefault();
+      return;
+    }
+    if (event.key === "ArrowRight" && (moveSelectedCell(1, 0) || moveTransposeRecordSelection(1))) {
+      event.preventDefault();
+      return;
+    }
   }
   if (event.key === "ArrowUp" && moveSelectedCell(-1, 0)) {
     event.preventDefault();
@@ -6586,10 +6621,12 @@ function openContextTranspose() {
     return;
   }
   if (!contextCell.value) return;
+  const selectedRowIndex = selectedTransposeRowIndex();
+  const requestedRowIndex = selectedRowIds.value.size === 1 && selectedRowIndex !== null ? selectedRowIndex : contextCell.value.rowIndex;
   const next = nextContextTransposeState({
     showTranspose: showTranspose.value,
     transposeRowIndex: transposeRowIndex.value,
-    requestedRowIndex: contextCell.value.rowIndex,
+    requestedRowIndex,
     rowIds: displayRowRefs.value.map((ref) => ref.id),
     selectedRowIds: selectedRowIds.value,
     selectedRange: selectedRange.value,

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { averageTransposeRecordWidth, calculateTransposeRecordWidth, defaultTransposeRecordWidth, minTransposeFieldWidth, shouldAutoTransposeSingleRow, transposeFieldWidth, transposeRecordWidthsForDensity, visibleTransposeRecordWindow } from "@/lib/dataGrid/dataGridTranspose";
+import {
+  averageTransposeRecordWidth,
+  calculateTransposeRecordWidth,
+  defaultTransposeRecordWidth,
+  minTransposeFieldWidth,
+  shouldAutoTransposeSingleRow,
+  transposeAnchorRowIndex,
+  transposeFieldWidth,
+  transposeRecordWidthsForDensity,
+  visibleTransposeRecordWindow,
+} from "@/lib/dataGrid/dataGridTranspose";
 
 describe("single-row automatic transpose", () => {
   it("only opens for enabled multi-column results that are not preserving a manual transpose", () => {
@@ -9,6 +19,21 @@ describe("single-row automatic transpose", () => {
     expect(shouldAutoTransposeSingleRow({ enabled: true, preserveTranspose: false, rowCount: 0, columnCount: 2 })).toBe(false);
     expect(shouldAutoTransposeSingleRow({ enabled: true, preserveTranspose: false, rowCount: 2, columnCount: 2 })).toBe(false);
     expect(shouldAutoTransposeSingleRow({ enabled: true, preserveTranspose: false, rowCount: 1, columnCount: 1 })).toBe(false);
+  });
+});
+
+describe("transpose row anchor", () => {
+  it("keeps the requested row when multiple rows or cells are selected", () => {
+    const rowIds = [1, 2, 3, 4];
+
+    expect(
+      transposeAnchorRowIndex({
+        requestedRowIndex: 3,
+        rowIds,
+        selectedRowIds: new Set([1, 4]),
+        selectedRange: { startRow: 0, endRow: 3, startCol: 0, endCol: 1 },
+      }),
+    ).toBe(3);
   });
 });
 

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
@@ -7,6 +7,7 @@ import {
   shouldAutoTransposeSingleRow,
   transposeAnchorRowIndex,
   transposeFieldWidth,
+  transposeScrollLeftForRecord,
   transposeRecordWidthsForDensity,
   visibleTransposeRecordWindow,
 } from "@/lib/dataGrid/dataGridTranspose";
@@ -101,5 +102,48 @@ describe("dataGridTranspose density widths", () => {
     expect(compactWindow.beforeWidth).not.toBe(comfortableWindow.beforeWidth);
     expect(compactWindow.afterWidth).not.toBe(comfortableWindow.afterWidth);
     expect(averageTransposeRecordWidth([], "compact")).toBe(defaultTransposeRecordWidth("compact"));
+  });
+});
+
+describe("transpose record scrolling", () => {
+  it("uses the scroll position after the sticky field for virtualization", () => {
+    expect(
+      visibleTransposeRecordWindow({
+        totalRecords: 3,
+        scrollLeft: 500,
+        viewportWidth: 300,
+        pinnedWidth: 100,
+        recordWidth: 230,
+        recordOffsets: [0, 500, 596, 692],
+        overscan: 0,
+      }),
+    ).toEqual({ start: 1, end: 3, beforeWidth: 500, afterWidth: 0 });
+  });
+
+  it("uses actual record widths and nearest scrolling", () => {
+    const recordOffsets = [0, 500, 596, 692];
+
+    expect(
+      transposeScrollLeftForRecord({
+        recordIndex: 2,
+        totalRecords: 3,
+        viewportWidth: 300,
+        pinnedWidth: 100,
+        recordWidth: 230,
+        recordOffsets,
+        currentScrollLeft: 0,
+      }),
+    ).toBe(492);
+    expect(
+      transposeScrollLeftForRecord({
+        recordIndex: 1,
+        totalRecords: 3,
+        viewportWidth: 300,
+        pinnedWidth: 100,
+        recordWidth: 230,
+        recordOffsets,
+        currentScrollLeft: 450,
+      }),
+    ).toBe(450);
   });
 });

--- a/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
@@ -50,6 +50,7 @@ export interface TransposeRecordWindowOptions {
   viewportWidth: number;
   pinnedWidth: number;
   recordWidth: number;
+  recordOffsets?: readonly number[];
   overscan?: number;
 }
 
@@ -159,6 +160,8 @@ export interface TransposeScrollLeftOptions {
   viewportWidth: number;
   pinnedWidth: number;
   recordWidth: number;
+  recordOffsets?: readonly number[];
+  currentScrollLeft?: number;
 }
 
 export interface TransposeRecordIndexesForModeOptions {
@@ -269,8 +272,25 @@ export function visibleTransposeRecordWindow(options: TransposeRecordWindowOptio
   }
 
   const overscan = options.overscan ?? 2;
-  const recordScrollLeft = Math.max(0, options.scrollLeft - options.pinnedWidth);
+  const recordScrollLeft = Math.max(0, options.scrollLeft);
   const recordViewportWidth = Math.max(0, options.viewportWidth - options.pinnedWidth);
+  if (options.recordOffsets?.length === options.totalRecords + 1) {
+    const offsets = options.recordOffsets;
+    const firstVisible = Math.max(
+      0,
+      offsets.findIndex((_offset, index) => index < options.totalRecords && offsets[index + 1] > recordScrollLeft),
+    );
+    const firstAfterViewport = offsets.findIndex((offset, index) => index > firstVisible && offset >= recordScrollLeft + recordViewportWidth);
+    const start = Math.max(0, firstVisible - overscan);
+    const end = Math.min(options.totalRecords, (firstAfterViewport < 0 ? options.totalRecords : firstAfterViewport) + overscan);
+    const totalWidth = offsets[options.totalRecords];
+    return {
+      start,
+      end,
+      beforeWidth: offsets[start],
+      afterWidth: Math.max(0, totalWidth - offsets[end]),
+    };
+  }
   const start = Math.max(0, Math.floor(recordScrollLeft / options.recordWidth) - overscan);
   const end = Math.min(options.totalRecords, Math.ceil((recordScrollLeft + recordViewportWidth) / options.recordWidth) + overscan + 1);
 
@@ -306,8 +326,15 @@ export function transposeFieldWidth(columns: string[], options: TransposeFieldWi
 
 export function transposeScrollLeftForRecord(options: TransposeScrollLeftOptions): number {
   if (options.recordWidth <= 0 || options.totalRecords <= 0) return 0;
-  const desired = Math.max(0, options.recordIndex) * options.recordWidth;
-  const totalWidth = options.pinnedWidth + options.totalRecords * options.recordWidth;
+  const recordIndex = Math.max(0, Math.min(options.totalRecords - 1, options.recordIndex));
+  const offsets = options.recordOffsets?.length === options.totalRecords + 1 ? options.recordOffsets : undefined;
+  const recordStart = offsets ? offsets[recordIndex] : recordIndex * options.recordWidth;
+  const recordEnd = offsets ? offsets[recordIndex + 1] : recordStart + options.recordWidth;
+  const recordsWidth = offsets ? offsets[options.totalRecords] : options.totalRecords * options.recordWidth;
+  const recordViewportWidth = Math.max(0, options.viewportWidth - options.pinnedWidth);
+  const currentScrollLeft = Math.max(0, options.currentScrollLeft ?? recordStart);
+  const desired = recordStart < currentScrollLeft ? recordStart : recordEnd > currentScrollLeft + recordViewportWidth ? recordEnd - recordViewportWidth : currentScrollLeft;
+  const totalWidth = options.pinnedWidth + recordsWidth;
   const maxScrollLeft = Math.max(0, totalWidth - options.viewportWidth);
-  return Math.min(desired, maxScrollLeft);
+  return Math.max(0, Math.min(desired, maxScrollLeft));
 }

--- a/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
@@ -290,18 +290,7 @@ export function transposeRecordIndexesForMode(options: TransposeRecordIndexesFor
 }
 
 export function transposeAnchorRowIndex(options: TransposeAnchorOptions): number {
-  const requestedRowId = options.rowIds[options.requestedRowIndex];
-  if (requestedRowId !== undefined && options.selectedRowIds.size > 1 && options.selectedRowIds.has(requestedRowId)) {
-    const firstSelectedIndex = options.rowIds.findIndex((rowId) => options.selectedRowIds.has(rowId));
-    if (firstSelectedIndex >= 0) return firstSelectedIndex;
-  }
-
-  const range = options.selectedRange;
-  if (range && range.startRow !== range.endRow && options.requestedRowIndex >= range.startRow && options.requestedRowIndex <= range.endRow) {
-    return range.startRow;
-  }
-
-  return options.requestedRowIndex;
+  return Math.max(0, Math.min(options.rowIds.length - 1, options.requestedRowIndex));
 }
 
 export function transposeFieldWidth(columns: string[], options: TransposeFieldWidthOptions = {}): number {

--- a/packages/app-tests/dataGridTranspose.test.ts
+++ b/packages/app-tests/dataGridTranspose.test.ts
@@ -256,10 +256,10 @@ test("calculates a horizontal record window with spacer widths", () => {
       overscan: 1,
     }),
     {
-      start: 1,
-      end: 7,
-      beforeWidth: 160,
-      afterWidth: 14880,
+      start: 3,
+      end: 9,
+      beforeWidth: 480,
+      afterWidth: 14560,
     },
   );
 });

--- a/packages/app-tests/dataGridTranspose.test.ts
+++ b/packages/app-tests/dataGridTranspose.test.ts
@@ -36,7 +36,7 @@ test("row number double click closes transpose for the same row", () => {
   });
 });
 
-test("context menu transpose closes when invoked for the current anchor row", () => {
+test("context menu transpose keeps the requested row when multiple rows are selected", () => {
   assert.deepEqual(
     nextContextTransposeState({
       showTranspose: true,
@@ -47,8 +47,8 @@ test("context menu transpose closes when invoked for the current anchor row", ()
       selectedRange: null,
     }),
     {
-      showTranspose: false,
-      transposeRowIndex: null,
+      showTranspose: true,
+      transposeRowIndex: 3,
     },
   );
 });
@@ -264,7 +264,7 @@ test("calculates a horizontal record window with spacer widths", () => {
   );
 });
 
-test("uses the first selected row as the transpose anchor when context row is inside row selection", () => {
+test("keeps the requested row as the transpose anchor when context row is inside row selection", () => {
   assert.equal(
     transposeAnchorRowIndex({
       requestedRowIndex: 3,
@@ -272,11 +272,11 @@ test("uses the first selected row as the transpose anchor when context row is in
       selectedRowIds: new Set([12, 13, 14]),
       selectedRange: null,
     }),
-    2,
+    3,
   );
 });
 
-test("uses the first selected cell range row as the transpose anchor when context row is inside range", () => {
+test("keeps the requested row as the transpose anchor when context row is inside range", () => {
   assert.equal(
     transposeAnchorRowIndex({
       requestedRowIndex: 5,
@@ -284,7 +284,7 @@ test("uses the first selected cell range row as the transpose anchor when contex
       selectedRowIds: new Set(),
       selectedRange: { startRow: 2, endRow: 5, startCol: 0, endCol: 2 },
     }),
-    2,
+    5,
   );
 });
 


### PR DESCRIPTION
- 转置视图中滚动到目标单元格及对应记录
- 支持上下左右键按转置方向移动单元格与记录选择
- 打开转置视图时优先保留单行选中记录，否则使用右键单元格所在行
- 保持多行或多单元格选择时的请求行锚点，仅对索引进行边界限制
- 补充转置行锚点测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="886" height="968" alt="89AFCD81-A71A-4909-98A2-24BFF4B369E3" src="https://github.com/user-attachments/assets/96630ba5-237d-4a67-95e9-4600b1a5cd73" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #4969