### PR TITLE
fix(sqlserver): 执行 USE 后同步数据库选择器

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
@@ -351,6 +351,31 @@ describe("queryStore multi-statement errors", () => {
     ]);
   });
 
+  it("syncs the executing SQL Server tab after a successful standalone USE", async () => {
+    mocks.getConnectionConfig.mockReturnValue({
+      id: "sqlserver-1",
+      name: "SQL Server",
+      db_type: "sqlserver",
+      database: "FooDB",
+      query_timeout_secs: 30,
+    });
+    mocks.executeMulti.mockResolvedValueOnce([{ columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 }]).mockResolvedValueOnce([{ columns: ["Error"], rows: [["Database does not exist"]], affected_rows: 0, execution_time_ms: 1 }]);
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabA = store.createTab("sqlserver-1", "FooDB", "Tab A", "query", "dbo");
+    const tabB = store.createTab("sqlserver-1", "FooDB", "Tab B", "query", "dbo");
+
+    await store.executeTabSql(tabA, "/* switch */ USE [BarDB];");
+
+    expect(store.tabs.find((tab) => tab.id === tabA)).toMatchObject({ database: "BarDB", schema: undefined });
+    expect(store.tabs.find((tab) => tab.id === tabB)).toMatchObject({ database: "FooDB", schema: "dbo" });
+    expect(mocks.closeClientConnectionSession).toHaveBeenCalledWith("sqlserver-1", "FooDB", tabA);
+
+    await store.executeTabSql(tabA, "USE [MissingDB];");
+
+    expect(store.tabs.find((tab) => tab.id === tabA)?.database).toBe("BarDB");
+  });
+
   it("invalidates Oracle completion metadata when clearing a tab schema resets its session", async () => {
     mocks.getConnectionConfig.mockReturnValue({
       id: "oracle-1",

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -361,6 +361,20 @@ function isSapHanaSetSchemaStatement(statement: string | undefined): boolean {
   return /^SET\s+SCHEMA\s+(?:"(?:[^"]|"")*"|[A-Za-z_][\w$#]*)\s*;?\s*$/i.test(sqlStatementWithoutLeadingComments(statement));
 }
 
+function sqlServerUseDatabaseFromStatement(statement: string | undefined): string | undefined {
+  const match = /^USE\s+(?:\[((?:[^\]]|\]\])*)\]|"((?:[^"]|"")*)"|([A-Za-z_][\w@$#]*))\s*;?\s*$/i.exec(sqlStatementWithoutLeadingComments(statement));
+  if (!match) return undefined;
+  if (match[1] !== undefined) return match[1].replaceAll("]]", "]");
+  if (match[2] !== undefined) return match[2].replaceAll('""', '"');
+  return match[3];
+}
+
+function isSqlServerBatchErrorResult(result: QueryResult): boolean {
+  // SQL Server batch errors can arrive without execution_error metadata.
+  // A standalone USE statement cannot legitimately return an Error column.
+  return result.execution_error === true || (result.columns.length === 1 && result.columns[0] === "Error" && result.rows.length > 0);
+}
+
 function sapHanaCurrentSchemaFromResult(result: QueryResult): string | undefined {
   const schema = result.rows[0]?.[0];
   return typeof schema === "string" && schema.trim() ? schema.trim() : undefined;
@@ -3943,6 +3957,7 @@ export const useQueryStore = defineStore("query", () => {
       reconcileBatchSqlResults(tab, executionId, results);
       const successfulOracleSchemaChanges = effectiveDbType === "oracle" ? results.filter((result) => result.execution_error !== true && isOracleCurrentSchemaStatement(result.sourceStatement)).length : 0;
       const successfulSapHanaSchemaChanges = effectiveDbType === "saphana" ? results.filter((result) => result.execution_error !== true && isSapHanaSetSchemaStatement(result.sourceStatement)).length : 0;
+      const sqlServerUseDatabase = effectiveDbType === "sqlserver" && !results.some(isSqlServerBatchErrorResult) ? sqlServerUseDatabaseFromStatement(sql) : undefined;
       if (hiddenPrimaryKeys.length > 0 && results.length === 1) {
         const hiddenIndexes = hiddenResultColumnIndexes(results[0]!.columns, hiddenPrimaryKeys);
         if (hiddenIndexes.length > 0) results[0]!.hidden_column_indexes = hiddenIndexes;
@@ -3978,6 +3993,12 @@ export const useQueryStore = defineStore("query", () => {
         if (resolvedSapHanaSchema) {
           current.schema = resolvedSapHanaSchema;
           current.completionContextVersion = (current.completionContextVersion ?? 0) + successfulSapHanaSchemaChanges;
+        }
+        if (sqlServerUseDatabase && current.database !== sqlServerUseDatabase) {
+          rollbackTabTransaction(current);
+          void closeClientConnectionSession(current);
+          current.database = sqlServerUseDatabase;
+          current.schema = undefined;
         }
         const activeGroupIndex = current.activeResultIndex;
         const activeGroupResults = current.results;


### PR DESCRIPTION
## 变更说明

- 仅在 SQL Server 成功执行独立的 `USE database` 语句后，同步当前查询标签页的数据库选择器。
- 切换数据库时清空旧 Schema，并关闭旧数据库对应的 tab 会话，避免会话池残留；当前执行结果仍正常保留。
- 兼容方括号、双引号和普通标识符，且不会在 `USE` 执行失败或其他数据库类型下切换。
- 新增 store 单元测试，覆盖成功切换、失败不切换、仅更新当前标签页及旧会话清理。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

> 当前为 Draft，待补充 SQL Server 实库操作截图/录屏后转为 Ready for review。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过
- [x] `pnpm check` 通过（format、lint、typecheck、全量 Vitest）
- [x] `pnpm exec vitest run apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts`

## 关联 Issue

Fixes #4979