### PR TITLE
fix(editor): 修复 macOS 客户端拖动滚动条后点击 SQL 编辑器产生异常选区的问题

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -84,6 +84,7 @@ import { loadTableMetadata, type TableMetadataLoadResult } from "@/lib/metadata/
 import { queryContextObjectActions, queryContextObjectRoute, queryTableCandidateAtSqlPosition, resolveQueryContextCandidateDatabase, resolveQueryContextObjectTarget, type QueryContextObjectAction } from "@/lib/sql/queryCursorTableTarget";
 import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
+import { isMacOS } from "@/lib/backend/platform";
 import {
   areSqlSemanticDiagnosticsEqual,
   buildSqlParserErrorDiagnostic,
@@ -863,6 +864,9 @@ function registerEditorScrollbarPointerGuard(currentView: EditorViewType) {
     if (!isEditorScrollbarPointerEvent(currentView, event)) return;
     clearTableNavigationHover();
     event.stopPropagation();
+    if (isTauriRuntime() && isMacOS() && !currentView.contentDOM.contains(event.target as Node | null)) {
+      event.preventDefault();
+    }
   };
   currentView.scrollDOM.addEventListener("mousedown", onPointerDown, true);
   editorScrollbarPointerCleanup = () => {


### PR DESCRIPTION
## 问题现象

macOS 桌面客户端中，SQL 编辑器光标停在某处，用鼠标拖动右侧滚动条翻页后，再点击编辑器任意位置，不是将光标移动到点击处，而是出现一段「原光标位置附近 → 点击位置附近」的异常选区。

仅 macOS 桌面端（WKWebView）受影响；Web 端（Chrome / Safari 实测）与触控板双指滚动均无法复现。

## 修改内容

在既有的滚动条指针守卫（`registerEditorScrollbarPointerGuard`）中，对泄漏的滚动条 `mousedown` 补充 `preventDefault()`，阻止编辑器失焦，从源头切断问题链条。附加两个限定条件：

- 仅在 `isTauriRuntime() && isMacOS()` 时生效；
- 仅当 `event.target` 不在 `contentDOM` 内时生效：泄漏事件的 target 是 `cm-scroller` 本身，而悬浮滚动条判定区（右缘 18px）内的真实文本点击 target 在正文内，需保留其原生落光标行为，避免形成点击死区。

## 验证

- macOS 桌面客户端实测：光标定位 → 拖动滚动条 → 点击正文，异常选区不再出现；滚动条拖动、横向滚动、正常文本选择、长行行尾贴近右缘的点击落标均正常；
- 平台影响核查：Web 端（`isTauriRuntime()` 为 false）与 Windows/Linux 客户端（`isMacOS()` 为 false）代码路径与修改前完全一致；
- `pnpm typecheck`、`pnpm lint`、`pnpm test`（675 个文件 / 5875 个用例）全部通过。
