### PR TITLE
fix(sqlserver): 使用前置 USE 作为补全上下文

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -44,7 +44,7 @@ import { buildSqlSemanticModel } from "@/lib/sql/semantic/model";
 import { mergeSqlSemanticReferenceAnalysis, resolveSqlSemanticNavigationTarget } from "@/lib/sql/semantic/references";
 import { buildElasticsearchCompletionItemsFromContext, getElasticsearchCompletionContext, getElasticsearchCompletionResultValidFor, shouldAutoOpenElasticsearchCompletion, type ElasticsearchCompletionItem } from "@/lib/elasticsearch/elasticsearchCompletion";
 import { buildMongoCompletionItemsFromContext, getMongoCompletionContext, getMongoCompletionResultValidFor, mongoCompletionNeedsCollections, mongoCompletionNeedsFields, shouldAutoOpenMongoCompletion, type MongoCompletionItem } from "@/lib/mongo/mongoCompletion";
-import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionScope, resolveSqlCompletionTableLookupTarget, type SqlCompletionScope } from "@/lib/sql/sqlCompletionLookupTarget";
 import { usesOracleSessionCompletionColumns as shouldUseOracleSessionCompletionColumns } from "@/lib/sql/oracleCompletionSession";
 import { extractIdentifierDetailsAt, isSqlKeyword, matchTable, mergeSqlObjectNavigationType, splitQualifiedIdentifier, sqlObjectHoverDetail, sqlObjectNavigationTarget, type SqlObjectNavigationTarget } from "@/lib/sql/sqlNavigation";
 import { buildHoverTableSql, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
@@ -1607,9 +1607,12 @@ function identifierRangeAt(sql: string, pos: number): { from: number; to: number
   return { from, to, text };
 }
 
-function completionCacheKey(table: { name: string; catalog?: string | null; database?: string | null; schema?: string | null }) {
-  const schema = table.schema ?? props.schema;
-  const database = supportsDatabaseSchemaQualifierCompletion() ? table.database : undefined;
+type CompletionMetadataScope = Pick<SqlCompletionScope, "database" | "schema">;
+
+function completionCacheKey(table: { name: string; catalog?: string | null; database?: string | null; schema?: string | null }, scope?: CompletionMetadataScope) {
+  const schema = table.schema ?? scope?.schema ?? props.schema;
+  const scopedDatabase = scope && scope.database !== props.database ? scope.database : undefined;
+  const database = supportsDatabaseSchemaQualifierCompletion() ? (table.database ?? scopedDatabase) : undefined;
   return schema ? `${database ? `${database}.` : ""}${schema}.${table.name}` : table.name;
 }
 
@@ -1692,15 +1695,16 @@ function allowsOnDemandQualifiedTableCompletion(prefix: string): boolean {
   return prefix.trim().length >= PRESTO_ON_DEMAND_TABLE_COMPLETION_MIN_PREFIX;
 }
 
-function completionMetadataTarget(table: { name: string; catalog?: string | null; database?: string | null; schema?: string | null }): { database: string; schema?: string; catalog?: string } | null {
-  if (props.database == null) return null;
+function completionMetadataTarget(table: { name: string; catalog?: string | null; database?: string | null; schema?: string | null }, scope?: CompletionMetadataScope): { database: string; schema?: string; catalog?: string } | null {
+  const currentDatabase = scope?.database ?? props.database;
+  if (currentDatabase == null) return null;
   if (supportsDatabaseSchemaQualifierCompletion() && table.database) {
     return { database: table.database, schema: table.schema ?? undefined, catalog: table.catalog ?? props.catalog };
   }
   if (supportsDatabaseQualifierCompletion() && table.schema) {
     return { database: table.schema, catalog: table.catalog ?? props.catalog };
   }
-  return { database: props.database, schema: table.schema ?? props.schema, catalog: table.catalog ?? props.catalog };
+  return { database: currentDatabase, schema: table.schema ?? scope?.schema ?? props.schema, catalog: table.catalog ?? props.catalog };
 }
 
 function isVirtualCompletionTableReference(table: { name: string; database?: string | null; schema?: string | null }): boolean {
@@ -2506,15 +2510,17 @@ function mayCompleteDatabaseSchemaQualifier(completionContext: ReturnType<typeof
   return (completionContext.qualifierParts?.filter(Boolean).length ?? completionContext.qualifier?.split(".").filter(Boolean).length ?? 0) === 1;
 }
 
-function localCompletionSchemasForDatabaseDisambiguation(completionContext: ReturnType<typeof getSqlCompletionContext>, databaseNames: string[]): string[] {
-  if (!props.connectionId || props.database == null || !mayCompleteDatabaseSchemaQualifier(completionContext)) return [];
+function localCompletionSchemasForDatabaseDisambiguation(completionContext: ReturnType<typeof getSqlCompletionContext>, databaseNames: string[], scope?: CompletionMetadataScope): string[] {
+  const currentDatabase = scope?.database ?? props.database;
+  const currentSchema = scope?.schema ?? props.schema;
+  if (!props.connectionId || currentDatabase == null || !mayCompleteDatabaseSchemaQualifier(completionContext)) return [];
   const database = resolveSqlCompletionSchemaLookupDatabase({
     supportsDatabaseSchemaQualifier: true,
     completionContext,
     knownDatabases: databaseNames,
   });
   if (!database) return [];
-  return mergeSqlCompletionQualifierNames(props.schema ? [props.schema] : [], connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.qualifier, MAX_COMPLETION_TABLES));
+  return mergeSqlCompletionQualifierNames(currentSchema ? [currentSchema] : [], connectionStore.lookupLocalCompletionSchemas(props.connectionId, currentDatabase, completionContext.qualifier, MAX_COMPLETION_TABLES));
 }
 
 function shouldInsertSqlCompletionSpace(): boolean {
@@ -2703,7 +2709,7 @@ async function provideSqlCompletions(context: CompletionContext) {
 
     const legacyCompletionContext = getSqlCompletionContext(fullDoc, position, sqlCompletionDialectOptions());
     const semanticModel = SEMANTIC_SQL_COMPLETION_ENABLED ? buildSqlSemanticModel(fullDoc, position, sqlCompletionDialectOptions()) : null;
-    const completionContext = semanticModel ? sqlCompletionContextFromSemantic(semanticModel, legacyCompletionContext) : legacyCompletionContext;
+    let completionContext = semanticModel ? sqlCompletionContextFromSemantic(semanticModel, legacyCompletionContext) : legacyCompletionContext;
 
     if (!hasDatabase) {
       const items = buildSqlCompletionItemsFromContext(completionContext, {
@@ -2721,6 +2727,16 @@ async function provideSqlCompletions(context: CompletionContext) {
       });
       return buildCompletionResult(items, position - completionContext.prefix.length, getSqlCompletionResultValidFor(fullDoc, position));
     }
+
+    const completionScope = resolveSqlCompletionScope({
+      sql: fullDoc,
+      cursor: position,
+      databaseType: props.databaseType,
+      currentDatabase: props.database!,
+      currentSchema: props.schema,
+      completionContext,
+    });
+    completionContext = completionScope.completionContext;
 
     const needsAsyncData =
       completionContext.suggestTables || completionContext.suggestRoutines || completionContext.exclusiveRoutineSuggestions || !!completionContext.qualifier || !!completionContext.insertTable || completionContext.exclusiveColumnSuggestions || completionContext.referencedTables.length > 0;
@@ -2745,14 +2761,14 @@ async function provideSqlCompletions(context: CompletionContext) {
     const tableNameCompletion = isTableNameCompletionContext(completionContext);
     const shouldResolveColumnCompletion = completionContext.suggestColumns && completionContext.referencedTables.length > 0 && (completionContext.prefix.length > 0 || typedActivation);
     const shouldResolveAsyncCompletion = tableNameCompletion || shouldResolveColumnCompletion;
-    const localResult = buildLocalSqlCompletionResult(completionContext, fullDoc, position);
+    const localResult = buildLocalSqlCompletionResult(completionContext, fullDoc, position, completionScope);
     if (localResult) {
-      scheduleCompletionMetadataRefresh(completionContext, fullDoc, position);
+      scheduleCompletionMetadataRefresh(completionContext, fullDoc, position, completionScope);
       const hasLocalColumnResult = localResult.options.some((option) => option.type === "column");
       if ((!explicit || typedActivation) && (!shouldResolveColumnCompletion || hasLocalColumnResult)) return localResult;
     }
     if ((!explicit || typedActivation) && !shouldResolveAsyncCompletion) {
-      scheduleCompletionMetadataRefresh(completionContext, fullDoc, position);
+      scheduleCompletionMetadataRefresh(completionContext, fullDoc, position, completionScope);
       return null;
     }
 
@@ -2776,7 +2792,7 @@ async function provideSqlCompletions(context: CompletionContext) {
           return;
         }
         try {
-          const result = await performAsyncCompletionWithResult(epoch, completionContext, fullDoc, position);
+          const result = await performAsyncCompletionWithResult(epoch, completionContext, fullDoc, position, completionScope);
           resolve(result ?? localResult);
         } catch {
           resolve(localResult);
@@ -2837,10 +2853,10 @@ function shouldStartSqlCompletionAfterInput(insertedText: string, removedText: s
   return isTableNameCompletionContext(completionContext) || shouldAutoOpenSqlCompletion(fullDoc, position, sqlCompletionDialectOptions());
 }
 
-function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number) {
+function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number, scope: CompletionMetadataScope) {
   if (!props.connectionId || props.database == null) return null;
   const databaseNames = localCompletionDatabaseNames(completionContext);
-  const currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames);
+  const currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames, scope);
   const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
     supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
     completionContext,
@@ -2849,8 +2865,8 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
   });
   const shouldLoadTables = !schemaLookupDatabase && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)));
   const tableLookupTarget = resolveSqlCompletionTableLookupTarget({
-    currentDatabase: props.database,
-    currentSchema: props.schema,
+    currentDatabase: scope.database,
+    currentSchema: scope.schema,
     supportsDatabaseQualifier: supportsDatabaseQualifierCompletion(),
     supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
     completionContext,
@@ -2867,28 +2883,28 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
       ? schemaLookupDatabase
         ? connectionStore.lookupLocalCompletionSchemas(props.connectionId, schemaLookupDatabase, completionContext.prefix, MAX_COMPLETION_TABLES)
         : !completionContext.qualifier
-          ? mergeSqlCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId, props.database, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames)
+          ? mergeSqlCompletionQualifierNames(connectionStore.lookupLocalCompletionSchemas(props.connectionId, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES), databaseNames)
           : []
       : [];
 
   const columnsByTable = new Map<string, SqlCompletionColumn[]>();
   if (completionContext.insertTable) {
-    const insertDatabase = (supportsDatabaseSchemaQualifierCompletion() ? completionContext.insertDatabase : undefined) ?? props.database;
-    const insertSchema = completionContext.insertSchema ?? props.schema;
+    const insertDatabase = (supportsDatabaseSchemaQualifierCompletion() ? completionContext.insertDatabase : undefined) ?? scope.database;
+    const insertSchema = completionContext.insertSchema ?? scope.schema;
     const insertColumns = usesOracleSessionCompletionColumns(insertSchema) ? [] : connectionStore.lookupLocalCompletionColumns(props.connectionId, insertDatabase, completionContext.insertTable, insertSchema, props.catalog);
     if (insertColumns.length > 0) {
-      columnsByTable.set(completionCacheKey({ name: completionContext.insertTable, database: completionContext.insertDatabase, schema: insertSchema }), insertColumns);
+      columnsByTable.set(completionCacheKey({ name: completionContext.insertTable, database: completionContext.insertDatabase, schema: insertSchema }, scope), insertColumns);
     }
   }
 
   const qualifiedColumnTarget = completionQualifiedTableTarget(completionContext);
   if (qualifiedColumnTarget) {
-    const cacheKey = completionCacheKey(qualifiedColumnTarget);
+    const cacheKey = completionCacheKey(qualifiedColumnTarget, scope);
     const cached = cachedColumnsByTable.get(cacheKey);
     if (cached) {
       columnsByTable.set(cacheKey, cached);
     } else {
-      const target = completionMetadataTarget(qualifiedColumnTarget);
+      const target = completionMetadataTarget(qualifiedColumnTarget, scope);
       const localColumns = target && !usesOracleSessionCompletionColumns(target.schema) ? connectionStore.lookupLocalCompletionColumns(props.connectionId, target.database, qualifiedColumnTarget.name, target.schema, target.catalog) : [];
       if (localColumns.length > 0) {
         columnsByTable.set(cacheKey, localColumns);
@@ -2911,13 +2927,13 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
       );
       continue;
     }
-    const cacheKey = completionCacheKey(refTable);
+    const cacheKey = completionCacheKey(refTable, scope);
     const cached = cachedColumnsByTable.get(cacheKey);
     if (cached) {
       columnsByTable.set(cacheKey, cached);
       continue;
     }
-    const target = completionMetadataTarget(refTable);
+    const target = completionMetadataTarget(refTable, scope);
     const localColumns = target && !usesOracleSessionCompletionColumns(target.schema) ? connectionStore.lookupLocalCompletionColumns(props.connectionId, target.database, refTable.name, target.schema, target.catalog, refTable) : [];
     if (localColumns.length > 0) {
       columnsByTable.set(cacheKey, localColumns);
@@ -2942,7 +2958,7 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
     snippets: settingsStore.editorSettings.snippets,
     dialect: props.dialect,
     databaseType: snippetDatabaseType.value,
-    currentSchema: props.schema,
+    currentSchema: scope.schema,
     keywordCase: settingsStore.editorSettings.sqlFormatter.keywordCase,
     autoAliasTables: settingsStore.editorSettings.autoAliasTables,
   });
@@ -2950,15 +2966,15 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
   return buildCompletionResult(items, position - completionContext.prefix.length, getSqlCompletionResultValidFor(fullDoc, position));
 }
 
-function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number) {
+function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number, scope: CompletionMetadataScope) {
   if (!props.connectionId || props.database == null) return;
   const localOnlyMetadata = usesLocalOnlyCompletionMetadata();
   const onDemandOnlyColumns = usesOnDemandOnlyCompletionColumns();
   const tableNameCompletion = isTableNameCompletionContext(completionContext);
   const connectionId = props.connectionId;
-  const database = props.database;
+  const database = scope.database;
   const databaseNames = localCompletionDatabaseNames(completionContext);
-  const currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames);
+  const currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames, scope);
   const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
     supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
     completionContext,
@@ -2967,7 +2983,7 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
   });
   const tableLookupTarget = resolveSqlCompletionTableLookupTarget({
     currentDatabase: database,
-    currentSchema: props.schema,
+    currentSchema: scope.schema,
     supportsDatabaseQualifier: supportsDatabaseQualifierCompletion(),
     supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
     completionContext,
@@ -2976,7 +2992,7 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
   if (!localOnlyMetadata && !schemaLookupDatabase && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)))) {
     const globalOracleTableSearch = props.databaseType === "oracle" && completionContext.suggestTables && !completionContext.qualifier;
     void connectionStore
-      .refreshCompletionTables(connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch, props.schema, props.catalog)
+      .refreshCompletionTables(connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch, scope.schema, props.catalog)
       .then((tables) => {
         const scopedTables = tables.map((table) => ({ ...table, database: table.database ?? tableLookupTarget.database }));
         cachedTables = mergeCompletionTables(cachedTables, scopedTables);
@@ -3009,17 +3025,17 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
   if (!onDemandOnlyColumns && completionContext.insertTable) {
     const insertTable = completionContext.insertTable;
     const insertDatabase = (supportsDatabaseSchemaQualifierCompletion() ? completionContext.insertDatabase : undefined) ?? database;
-    void refreshCompletionColumnsForEditor(connectionId, insertDatabase, insertTable, completionContext.insertSchema ?? props.schema)
+    void refreshCompletionColumnsForEditor(connectionId, insertDatabase, insertTable, completionContext.insertSchema ?? scope.schema)
       .then((columns) => {
-        const insertSchema = completionContext.insertSchema ?? props.schema;
-        cachedColumnsByTable.set(completionCacheKey({ name: insertTable, database: completionContext.insertDatabase, schema: insertSchema }), columns);
+        const insertSchema = completionContext.insertSchema ?? scope.schema;
+        cachedColumnsByTable.set(completionCacheKey({ name: insertTable, database: completionContext.insertDatabase, schema: insertSchema }, scope), columns);
       })
       .catch(() => {});
   }
   const qualifiedColumnTarget = completionQualifiedTableTarget(completionContext);
-  const qualifiedColumnCacheKey = qualifiedColumnTarget ? completionCacheKey(qualifiedColumnTarget) : undefined;
+  const qualifiedColumnCacheKey = qualifiedColumnTarget ? completionCacheKey(qualifiedColumnTarget, scope) : undefined;
   if (!onDemandOnlyColumns && qualifiedColumnTarget && qualifiedColumnCacheKey && !cachedColumnsByTable.has(qualifiedColumnCacheKey)) {
-    const target = completionMetadataTarget(qualifiedColumnTarget);
+    const target = completionMetadataTarget(qualifiedColumnTarget, scope);
     if (target) {
       void refreshCompletionColumnsForEditor(connectionId, target.database, qualifiedColumnTarget.name, target.schema, target.catalog)
         .then((columns) => {
@@ -3032,10 +3048,10 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
     for (const refTable of completionContext.referencedTables) {
       if (isVirtualCompletionTableReference(refTable)) continue;
       if (refTable.columns && refTable.columns.length > 0) continue;
-      const cacheKey = completionCacheKey(refTable);
+      const cacheKey = completionCacheKey(refTable, scope);
       if (cacheKey === qualifiedColumnCacheKey) continue;
       if (cachedColumnsByTable.has(cacheKey)) continue;
-      const target = completionMetadataTarget(refTable);
+      const target = completionMetadataTarget(refTable, scope);
       if (!target) continue;
       void refreshCompletionColumnsForEditor(connectionId, target.database, refTable.name, target.schema, target.catalog, refTable)
         .then((columns) => {
@@ -3075,9 +3091,9 @@ function withCompletionLatencyBudget<T>(remote: Promise<T>, local: T): Promise<T
   return Promise.race([remote, new Promise<T>((resolve) => setTimeout(() => resolve(local), COMPLETION_REMOTE_LATENCY_BUDGET_MS))]);
 }
 
-function listCompletionTablesWithLatencyBudget(connectionId: string, database: string, filter: string, limit: number, schema?: string, globalSearch = false, catalog = props.catalog): Promise<SqlCompletionTable[]> {
+function listCompletionTablesWithLatencyBudget(connectionId: string, database: string, filter: string, limit: number, schema?: string, globalSearch = false, catalog = props.catalog, currentSchema = props.schema): Promise<SqlCompletionTable[]> {
   const local = connectionStore.lookupLocalCompletionTables(connectionId, database, filter, limit, globalSearch ? undefined : schema, catalog).map((table) => ({ ...table, catalog: table.catalog ?? catalog, database: table.database ?? database }));
-  const remote = connectionStore.listCompletionTables(connectionId, database, filter, limit, schema, globalSearch, props.schema, catalog).then((tables) => {
+  const remote = connectionStore.listCompletionTables(connectionId, database, filter, limit, schema, globalSearch, currentSchema, catalog).then((tables) => {
     const scopedTables = tables.map((table) => ({ ...table, catalog: table.catalog ?? catalog, database: table.database ?? database }));
     cachedTables = mergeCompletionTables(cachedTables, scopedTables);
     return scopedTables;
@@ -3138,19 +3154,19 @@ function completionObjectKindsForContext(completionContext: ReturnType<typeof ge
   return ["routine"];
 }
 
-async function performAsyncCompletionWithResult(epoch: number, completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number) {
+async function performAsyncCompletionWithResult(epoch: number, completionContext: ReturnType<typeof getSqlCompletionContext>, fullDoc: string, position: number, scope: CompletionMetadataScope) {
   const localOnlyMetadata = usesLocalOnlyCompletionMetadata();
   const onDemandOnlyColumns = usesOnDemandOnlyCompletionColumns();
   // Handle INSERT column list: fetch columns for the target table
   let insertColumnsByTable = new Map<string, SqlCompletionColumn[]>();
   if (completionContext.insertTable) {
     try {
-      const insertDatabase = (supportsDatabaseSchemaQualifierCompletion() ? completionContext.insertDatabase : undefined) ?? props.database!;
-      const insertCols = await listCompletionColumnsForEditor(props.connectionId!, insertDatabase, completionContext.insertTable, completionContext.insertSchema ?? props.schema);
+      const insertDatabase = (supportsDatabaseSchemaQualifierCompletion() ? completionContext.insertDatabase : undefined) ?? scope.database;
+      const insertCols = await listCompletionColumnsForEditor(props.connectionId!, insertDatabase, completionContext.insertTable, completionContext.insertSchema ?? scope.schema);
       if (epoch !== completionEpoch) return null;
       if (insertCols.length > 0) {
-        const insertSchema = completionContext.insertSchema ?? props.schema;
-        const insertKey = completionCacheKey({ name: completionContext.insertTable, database: completionContext.insertDatabase, schema: insertSchema });
+        const insertSchema = completionContext.insertSchema ?? scope.schema;
+        const insertKey = completionCacheKey({ name: completionContext.insertTable, database: completionContext.insertDatabase, schema: insertSchema }, scope);
         insertColumnsByTable.set(insertKey, insertCols);
       }
     } catch {
@@ -3159,12 +3175,12 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   }
 
   let databaseNames = localCompletionDatabaseNames(completionContext);
-  let currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames);
+  let currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames, scope);
   const mayCompleteDatabaseSchema = mayCompleteDatabaseSchemaQualifier(completionContext);
   if (!localOnlyMetadata && supportsDatabaseNameCompletion(props.databaseType) && completionContext.suggestTables && !completionContext.insertTable && (!completionContext.qualifier || mayCompleteDatabaseSchema)) {
-    const [databasesResult, schemasResult] = await Promise.allSettled([connectionStore.listCompletionDatabases(props.connectionId!), mayCompleteDatabaseSchema ? connectionStore.listCompletionSchemas(props.connectionId!, props.database!) : Promise.resolve(currentDatabaseSchemaNames)]);
+    const [databasesResult, schemasResult] = await Promise.allSettled([connectionStore.listCompletionDatabases(props.connectionId!), mayCompleteDatabaseSchema ? connectionStore.listCompletionSchemas(props.connectionId!, scope.database) : Promise.resolve(currentDatabaseSchemaNames)]);
     databaseNames = databasesResult.status === "fulfilled" ? databasesResult.value : [];
-    if (schemasResult.status === "fulfilled") currentDatabaseSchemaNames = mergeSqlCompletionQualifierNames(props.schema ? [props.schema] : [], schemasResult.value);
+    if (schemasResult.status === "fulfilled") currentDatabaseSchemaNames = mergeSqlCompletionQualifierNames(scope.schema ? [scope.schema] : [], schemasResult.value);
     if (epoch !== completionEpoch) return null;
   }
   const schemaLookupDatabase = resolveSqlCompletionSchemaLookupDatabase({
@@ -3175,8 +3191,8 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   });
   const shouldLoadTables = !schemaLookupDatabase && (completionContext.suggestTables || (!!completionContext.qualifier && !isReferencedTableQualifier(completionContext)));
   const tableLookupTarget = resolveSqlCompletionTableLookupTarget({
-    currentDatabase: props.database!,
-    currentSchema: props.schema,
+    currentDatabase: scope.database,
+    currentSchema: scope.schema,
     supportsDatabaseQualifier: supportsDatabaseQualifierCompletion(),
     supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
     completionContext,
@@ -3188,10 +3204,10 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
     : shouldLoadTables
       ? localOnlyMetadata
         ? connectionStore.lookupLocalCompletionTables(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog)
-        : await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch)
+        : await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, tableLookupTarget.schema, globalOracleTableSearch, props.catalog, scope.schema)
       : cachedTables;
   if (localOnlyMetadata && tables.length === 0 && supportsDatabaseSchemaQualifierCompletion() && (completionContext.qualifierParts?.length ?? 0) >= 2 && allowsOnDemandQualifiedTableCompletion(completionContext.prefix)) {
-    tables = await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, PRESTO_ON_DEMAND_TABLE_COMPLETION_LIMIT, tableLookupTarget.schema);
+    tables = await listCompletionTablesWithLatencyBudget(props.connectionId!, tableLookupTarget.database, tableLookupTarget.filter, PRESTO_ON_DEMAND_TABLE_COMPLETION_LIMIT, tableLookupTarget.schema, false, props.catalog, scope.schema);
   }
   if (epoch !== completionEpoch) return null;
 
@@ -3211,7 +3227,7 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   // Fetch schemas for schema completion
   let schemaNames: string[] = [];
   if (completionContext.suggestTables && !completionContext.insertTable && (schemaLookupDatabase || !completionContext.qualifier)) {
-    const database = schemaLookupDatabase ?? props.database!;
+    const database = schemaLookupDatabase ?? scope.database;
     if (localOnlyMetadata) {
       const schemas = connectionStore.lookupLocalCompletionSchemas(props.connectionId!, database, completionContext.prefix, MAX_COMPLETION_TABLES);
       schemaNames = schemaLookupDatabase ? schemas : mergeSqlCompletionQualifierNames(schemas, databaseNames);
@@ -3229,11 +3245,11 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   // If qualifier didn't match any table names, try it as a schema name
   let qualifierIsSchema = false;
   if (completionContext.qualifier && !schemaLookupDatabase && !tableLookupTarget.qualifierDatabase && !isReferencedTableQualifier(completionContext) && tables.length === 0 && (completionContext.suggestTables || completionContext.exclusiveColumnSuggestions)) {
-    let schemaTables = connectionStore.lookupLocalCompletionTables(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier, props.catalog);
+    let schemaTables = connectionStore.lookupLocalCompletionTables(props.connectionId!, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier, props.catalog);
     if (!localOnlyMetadata) {
-      schemaTables = await listCompletionTablesWithLatencyBudget(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier);
+      schemaTables = await listCompletionTablesWithLatencyBudget(props.connectionId!, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier, false, props.catalog, scope.schema);
     } else if (schemaTables.length === 0 && allowsOnDemandQualifiedTableCompletion(completionContext.prefix)) {
-      schemaTables = await listCompletionTablesWithLatencyBudget(props.connectionId!, props.database!, completionContext.prefix, PRESTO_ON_DEMAND_TABLE_COMPLETION_LIMIT, completionContext.qualifier);
+      schemaTables = await listCompletionTablesWithLatencyBudget(props.connectionId!, scope.database, completionContext.prefix, PRESTO_ON_DEMAND_TABLE_COMPLETION_LIMIT, completionContext.qualifier, false, props.catalog, scope.schema);
     }
     if (schemaTables.length > 0) {
       tables = schemaTables;
@@ -3255,7 +3271,12 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   });
   const unresolvedRefs = refs.filter((rt) => !usesOracleSessionCompletionColumns(rt.schema) && !rt.schema && !rt.columns && !isVirtualCompletionTableReference(rt));
   if (!localOnlyMetadata && unresolvedRefs.length > 0) {
-    const lookupGroups = await Promise.all(unresolvedRefs.map((rt) => connectionStore.listCompletionTables(props.connectionId!, props.database!, rt.name, 20, props.schema, false, props.schema, props.catalog)));
+    const lookupGroups = await Promise.all(
+      unresolvedRefs.map((rt) => {
+        const target = completionMetadataTarget(rt, scope);
+        return connectionStore.listCompletionTables(props.connectionId!, target?.database ?? scope.database, rt.name, 20, target?.schema ?? scope.schema, false, scope.schema, target?.catalog ?? props.catalog);
+      }),
+    );
     if (epoch !== completionEpoch) return null;
     const lookupTables = lookupGroups.flat();
     refs = refs.map((rt) => {
@@ -3295,10 +3316,10 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
       refs.map(async (refTable) => {
         if (isVirtualCompletionTableReference(refTable)) return;
         if (refTable.columns && refTable.columns.length > 0) return;
-        const cacheKey = completionCacheKey(refTable);
+        const cacheKey = completionCacheKey(refTable, scope);
         if (cachedColumnsByTable.has(cacheKey)) return;
         try {
-          const target = completionMetadataTarget(refTable);
+          const target = completionMetadataTarget(refTable, scope);
           if (!target) return;
           const columns = await listCompletionColumnsForEditor(props.connectionId!, target.database, refTable.name, target.schema, target.catalog, refTable);
           if (epoch !== completionEpoch) return;
@@ -3339,14 +3360,14 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
         );
         continue;
       }
-      const cacheKey = completionCacheKey(refTable);
+      const cacheKey = completionCacheKey(refTable, scope);
       const cached = cachedColumnsByTable.get(cacheKey);
       if (cached) {
         columnsByTable.set(cacheKey, cached);
       }
       let cachedForeignKeys = cachedForeignKeysByTable.get(cacheKey);
       if (!cachedForeignKeys) {
-        const target = completionMetadataTarget(refTable);
+        const target = completionMetadataTarget(refTable, scope);
         cachedForeignKeys = target ? connectionStore.lookupLocalCompletionForeignKeys(props.connectionId!, target.database, refTable.name, target.schema) : [];
         if (cachedForeignKeys.length > 0) cachedForeignKeysByTable.set(cacheKey, cachedForeignKeys);
       }
@@ -3376,7 +3397,7 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
     snippets: settingsStore.editorSettings.snippets,
     dialect: props.dialect,
     databaseType: snippetDatabaseType.value,
-    currentSchema: props.schema,
+    currentSchema: scope.schema,
     keywordCase: settingsStore.editorSettings.sqlFormatter.keywordCase,
     autoAliasTables: settingsStore.editorSettings.autoAliasTables,
   });

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -52,6 +52,7 @@ import {
   resolveSqlCompletionScope,
   resolveSqlCompletionTableLookupTarget,
   resolveSqlServerUseDatabaseCompletion,
+  sqlServerUseCompletionDatabaseNames,
   sqlServerUseDatabaseBeforeCursor,
   type SqlCompletionScope,
 } from "@/lib/sql/sqlCompletionLookupTarget";
@@ -109,7 +110,7 @@ import { sqlReferenceAnalysisDialectFor } from "@/lib/sql/semantic/dialect";
 import { buildRedisSyntaxDiagnostics, shouldRunRedisDiagnostics } from "@/lib/redis/redisSyntaxDiagnostics";
 import { buildRedisCompletionItemsFromContext, getRedisCompletionContext, getRedisCompletionResultValidFor, shouldAutoOpenRedisCompletion, takesKeyArgument, type RedisCompletionItem } from "@/lib/redis/redisCompletion";
 import type { SqlCompletionColumn, SqlCompletionForeignKey, SqlCompletionItem, SqlCompletionObject, SqlCompletionReferencedTable, SqlCompletionTable } from "@/lib/sql/sqlCompletion";
-import type { CompletionAssistantObjectKind, ColumnInfo, DatabaseType, IndexInfo, SqlReferenceAnalysis, SqlTableReference, SqlTextSpan } from "@/types/database";
+import type { CompletionAssistantObjectKind, ColumnInfo, DatabaseType, IndexInfo, SqlReferenceAnalysis, SqlServerCompletionContext, SqlTableReference, SqlTextSpan } from "@/types/database";
 
 const props = defineProps<{
   modelValue: string;
@@ -429,7 +430,7 @@ function editorThemeAppearance() {
 
 // Completion cache
 let cachedTables: SqlCompletionTable[] = [];
-let cachedCompletionObjects: SqlCompletionObject[] = [];
+const cachedCompletionObjectsByScope = new Map<string, SqlCompletionObject[]>();
 // Persistent column cache keyed by "schema.table" or "table"
 const cachedColumnsByTable = new Map<string, SqlCompletionColumn[]>();
 const cachedInsertValueHintColumnsByTable = new Map<string, string[]>();
@@ -2724,13 +2725,29 @@ async function provideSqlCompletions(context: CompletionContext) {
     if (!explicit && !useDatabaseCompletion && !shouldAutoOpenSqlCompletion(fullDoc, position, sqlCompletionDialectOptions())) return null;
 
     if (useDatabaseCompletion) {
+      const currentDatabase = props.database ?? "";
+      if (!currentDatabase) return null;
+      let sqlServerContext: SqlServerCompletionContext;
       try {
-        await connectionStore.listCompletionDatabases(props.connectionId);
+        sqlServerContext = await connectionStore.getSqlServerCompletionContext(props.connectionId, currentDatabase);
       } catch {
-        // Keep locally indexed database names available when metadata refresh fails.
+        // Without a server-reported capability, do not suggest a USE target
+        // that the current SQL Server session may be unable to switch to.
+        return null;
+      }
+      if (sqlServerContext.supports_session_database_switch) {
+        try {
+          await connectionStore.listCompletionDatabases(props.connectionId);
+        } catch {
+          // Keep locally indexed database names available when metadata refresh fails.
+        }
       }
       if (epoch !== completionEpoch) return null;
-      const databaseNames = connectionStore.lookupLocalCompletionDatabases(props.connectionId, useDatabaseCompletion.prefix, MAX_COMPLETION_TABLES);
+      const databaseNames = sqlServerUseCompletionDatabaseNames({
+        databaseNames: connectionStore.lookupLocalCompletionDatabases(props.connectionId, useDatabaseCompletion.prefix, MAX_COMPLETION_TABLES),
+        currentDatabase,
+        supportsSessionDatabaseSwitch: sqlServerContext.supports_session_database_switch,
+      });
       const items = buildSqlServerUseDatabaseCompletionItems(databaseNames, useDatabaseCompletion);
       return buildCompletionResult(items, useDatabaseCompletion.from);
     }
@@ -2758,16 +2775,28 @@ async function provideSqlCompletions(context: CompletionContext) {
 
     const useDatabase = props.databaseType === "sqlserver" ? sqlServerUseDatabaseBeforeCursor(fullDoc, position) : undefined;
     let knownUseDatabases: string[] | undefined;
+    let supportsSessionDatabaseSwitch: boolean | undefined;
+    let useDatabaseDefaultSchema: string | undefined;
     if (useDatabase) {
-      knownUseDatabases = mergeSqlCompletionQualifierNames([props.database!], connectionStore.lookupLocalCompletionDatabases(props.connectionId, "", MAX_COMPLETION_TABLES));
-      if (!knownUseDatabases.some((database) => database.toLowerCase() === useDatabase.toLowerCase())) {
-        try {
-          knownUseDatabases = mergeSqlCompletionQualifierNames([props.database!], await connectionStore.listCompletionDatabases(props.connectionId));
-        } catch {
-          // An unverified USE target must not replace the selected database.
+      try {
+        const currentContext = await connectionStore.getSqlServerCompletionContext(props.connectionId, props.database!);
+        supportsSessionDatabaseSwitch = currentContext.supports_session_database_switch;
+        knownUseDatabases = [props.database!];
+        if (supportsSessionDatabaseSwitch) {
+          knownUseDatabases = mergeSqlCompletionQualifierNames(knownUseDatabases, connectionStore.lookupLocalCompletionDatabases(props.connectionId, "", MAX_COMPLETION_TABLES));
+          if (!knownUseDatabases.some((database) => database.toLowerCase() === useDatabase.toLowerCase())) {
+            knownUseDatabases = mergeSqlCompletionQualifierNames(knownUseDatabases, await connectionStore.listCompletionDatabases(props.connectionId));
+          }
         }
-        if (epoch !== completionEpoch) return null;
+        const targetDatabase = knownUseDatabases.find((database) => database.toLowerCase() === useDatabase.toLowerCase());
+        if (targetDatabase) {
+          const targetContext = targetDatabase.toLowerCase() === props.database!.toLowerCase() ? currentContext : await connectionStore.getSqlServerCompletionContext(props.connectionId, targetDatabase);
+          useDatabaseDefaultSchema = targetContext.default_schema;
+        }
+      } catch {
+        // An unverified USE target must not replace the selected database.
       }
+      if (epoch !== completionEpoch) return null;
     }
 
     const completionScope = resolveSqlCompletionScope({
@@ -2777,6 +2806,8 @@ async function provideSqlCompletions(context: CompletionContext) {
       currentDatabase: props.database!,
       currentSchema: props.schema,
       knownDatabases: knownUseDatabases,
+      supportsSessionDatabaseSwitch,
+      useDatabaseDefaultSchema,
       completionContext,
     });
     completionContext = completionScope.completionContext;
@@ -2922,7 +2953,8 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
   const tables = schemaLookupDatabase ? [] : shouldLoadTables ? connectionStore.lookupLocalCompletionTables(props.connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog) : cachedTables;
 
   const shouldLoadObjects = shouldLoadCompletionObjects(completionContext);
-  const completionObjects = shouldLoadObjects ? lookupLocalCompletionObjectsForContext(completionContext) : cachedCompletionObjects;
+  const scopedCachedCompletionObjects = completionObjectsForScope(scope);
+  const completionObjects = shouldLoadObjects ? lookupLocalCompletionObjectsForContext(completionContext, scope) : scopedCachedCompletionObjects;
 
   const schemaNames =
     completionContext.suggestTables && !completionContext.insertTable
@@ -3049,11 +3081,12 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
       .catch(() => {});
   }
   if (!localOnlyMetadata && shouldLoadCompletionObjects(completionContext)) {
-    void listCompletionObjectsForContext(completionContext)
+    void listCompletionObjectsForContext(completionContext, scope)
       .then((objects) => {
-        const merged = mergeCompletionObjects(cachedCompletionObjects, objects);
-        const changed = completionObjectsDiffer(cachedCompletionObjects, merged);
-        cachedCompletionObjects = merged;
+        const cachedObjects = completionObjectsForScope(scope);
+        const merged = mergeCompletionObjects(cachedObjects, objects);
+        const changed = completionObjectsDiffer(cachedObjects, merged);
+        cachedCompletionObjectsByScope.set(completionObjectScopeKey(scope), merged);
         if (changed) refreshActiveSqlCompletion(fullDoc, position, completionContext);
       })
       .catch(() => {});
@@ -3172,24 +3205,24 @@ function oracleRoutineCompletionTargets(completionContext: ReturnType<typeof get
   return [{ schema: parts[parts.length - 2], parentName: parts[parts.length - 1] }];
 }
 
-function lookupLocalCompletionObjectsForContext(completionContext: ReturnType<typeof getSqlCompletionContext>): SqlCompletionObject[] {
+function lookupLocalCompletionObjectsForContext(completionContext: ReturnType<typeof getSqlCompletionContext>, scope: CompletionMetadataScope): SqlCompletionObject[] {
   if (!props.connectionId || props.database == null) return [];
   if (props.databaseType === "oracle") {
-    return connectionStore.lookupLocalCompletionObjects(props.connectionId, props.database, completionContext.prefix, MAX_COMPLETION_TABLES);
+    return connectionStore.lookupLocalCompletionObjects(props.connectionId, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES);
   }
-  const target = resolveSqlCompletionRoutineLookupTarget({ currentSchema: props.schema, completionContext });
-  return connectionStore.lookupLocalCompletionObjects(props.connectionId, props.database, target.mask, MAX_COMPLETION_TABLES, target.schema);
+  const target = resolveSqlCompletionRoutineLookupTarget({ currentSchema: scope.schema, completionContext });
+  return connectionStore.lookupLocalCompletionObjects(props.connectionId, scope.database, target.mask, MAX_COMPLETION_TABLES, target.schema);
 }
 
-async function listCompletionObjectsForContext(completionContext: ReturnType<typeof getSqlCompletionContext>): Promise<SqlCompletionObject[]> {
+async function listCompletionObjectsForContext(completionContext: ReturnType<typeof getSqlCompletionContext>, scope: CompletionMetadataScope): Promise<SqlCompletionObject[]> {
   if (!props.connectionId || props.database == null) return [];
   const objectKinds = completionObjectKindsForContext(completionContext);
   if (props.databaseType !== "oracle") {
-    const target = resolveSqlCompletionRoutineLookupTarget({ currentSchema: props.schema, completionContext });
-    return connectionStore.listCompletionObjects(props.connectionId, props.database, target.mask, MAX_COMPLETION_TABLES, target.schema, undefined, false, props.schema, objectKinds);
+    const target = resolveSqlCompletionRoutineLookupTarget({ currentSchema: scope.schema, completionContext });
+    return connectionStore.listCompletionObjects(props.connectionId, scope.database, target.mask, MAX_COMPLETION_TABLES, target.schema, undefined, false, scope.schema, objectKinds);
   }
   const groups = await Promise.all(
-    oracleRoutineCompletionTargets(completionContext).map((target) => connectionStore.listCompletionObjects(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES, target.schema, target.parentName, target.globalSearch, props.schema, objectKinds)),
+    oracleRoutineCompletionTargets(completionContext).map((target) => connectionStore.listCompletionObjects(props.connectionId!, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES, target.schema, target.parentName, target.globalSearch, scope.schema, objectKinds)),
   );
   return groups.reduce((objects, group) => mergeCompletionObjects(objects, group), [] as SqlCompletionObject[]);
 }
@@ -3258,17 +3291,18 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   if (epoch !== completionEpoch) return null;
 
   const shouldLoadObjects = shouldLoadCompletionObjects(completionContext);
-  let completionObjects = shouldLoadObjects ? (localOnlyMetadata ? lookupLocalCompletionObjectsForContext(completionContext) : await listCompletionObjectsForContext(completionContext)) : cachedCompletionObjects;
+  const scopedCachedCompletionObjects = completionObjectsForScope(scope);
+  let completionObjects = shouldLoadObjects ? (localOnlyMetadata ? lookupLocalCompletionObjectsForContext(completionContext, scope) : await listCompletionObjectsForContext(completionContext, scope)) : scopedCachedCompletionObjects;
   if (epoch !== completionEpoch) return null;
 
   if (!props.catalog && props.databaseType !== "oracle" && !localOnlyMetadata && completionContext.qualifier && completionObjects.length === 0) {
-    const schemaObjects = await connectionStore.listCompletionObjects(props.connectionId!, props.database!, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier);
+    const schemaObjects = await connectionStore.listCompletionObjects(props.connectionId!, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier, undefined, false, scope.schema);
     if (schemaObjects.length > 0) {
       completionObjects = schemaObjects;
     }
     if (epoch !== completionEpoch) return null;
   }
-  cachedCompletionObjects = mergeCompletionObjects(cachedCompletionObjects, completionObjects);
+  cachedCompletionObjectsByScope.set(completionObjectScopeKey(scope), mergeCompletionObjects(scopedCachedCompletionObjects, completionObjects));
 
   // Fetch schemas for schema completion
   let schemaNames: string[] = [];
@@ -3478,6 +3512,14 @@ function mergeCompletionObjects(existing: SqlCompletionObject[], incoming: SqlCo
   return merged;
 }
 
+function completionObjectScopeKey(scope: CompletionMetadataScope): string {
+  return `${scope.database}:${scope.schema ?? ""}`.toLowerCase();
+}
+
+function completionObjectsForScope(scope: CompletionMetadataScope): SqlCompletionObject[] {
+  return cachedCompletionObjectsByScope.get(completionObjectScopeKey(scope)) ?? [];
+}
+
 function completionObjectIdentityKey(object: SqlCompletionObject): string {
   return `${object.type}:${object.schema ?? ""}:${object.name}:${object.parentName ?? ""}:${object.signature?.trim() ?? ""}`.toLowerCase();
 }
@@ -3513,7 +3555,7 @@ function refreshActiveSqlCompletion(fullDoc: string, position: number, completio
 
 function refreshCompletionCache() {
   cachedTables = [];
-  cachedCompletionObjects = [];
+  cachedCompletionObjectsByScope.clear();
   cachedColumnsByTable.clear();
   cachedInsertValueHintColumnsByTable.clear();
   loadedColumnsByTable.clear();
@@ -4307,7 +4349,7 @@ onMounted(async () => {
   registerTableReferenceDropListener();
 
   cachedTables = [];
-  cachedCompletionObjects = [];
+  cachedCompletionObjectsByScope.clear();
   scheduleSemanticDiagnostics();
 
   if (props.autoFocus) {

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -2953,7 +2953,8 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
   const tables = schemaLookupDatabase ? [] : shouldLoadTables ? connectionStore.lookupLocalCompletionTables(props.connectionId, tableLookupTarget.database, tableLookupTarget.filter, MAX_COMPLETION_TABLES, globalOracleTableSearch ? undefined : tableLookupTarget.schema, props.catalog) : cachedTables;
 
   const shouldLoadObjects = shouldLoadCompletionObjects(completionContext);
-  const scopedCachedCompletionObjects = completionObjectsForScope(scope);
+  const completionObjectScope = routineCompletionScopeForContext(completionContext, scope);
+  const scopedCachedCompletionObjects = completionObjectsForScope(completionObjectScope);
   const completionObjects = shouldLoadObjects ? lookupLocalCompletionObjectsForContext(completionContext, scope) : scopedCachedCompletionObjects;
 
   const schemaNames =
@@ -3081,12 +3082,13 @@ function scheduleCompletionMetadataRefresh(completionContext: ReturnType<typeof 
       .catch(() => {});
   }
   if (!localOnlyMetadata && shouldLoadCompletionObjects(completionContext)) {
+    const completionObjectScope = routineCompletionScopeForContext(completionContext, scope);
     void listCompletionObjectsForContext(completionContext, scope)
       .then((objects) => {
-        const cachedObjects = completionObjectsForScope(scope);
+        const cachedObjects = completionObjectsForScope(completionObjectScope);
         const merged = mergeCompletionObjects(cachedObjects, objects);
         const changed = completionObjectsDiffer(cachedObjects, merged);
-        cachedCompletionObjectsByScope.set(completionObjectScopeKey(scope), merged);
+        cachedCompletionObjectsByScope.set(completionObjectScopeKey(completionObjectScope), merged);
         if (changed) refreshActiveSqlCompletion(fullDoc, position, completionContext);
       })
       .catch(() => {});
@@ -3205,21 +3207,36 @@ function oracleRoutineCompletionTargets(completionContext: ReturnType<typeof get
   return [{ schema: parts[parts.length - 2], parentName: parts[parts.length - 1] }];
 }
 
+function routineCompletionTargetForContext(completionContext: ReturnType<typeof getSqlCompletionContext>, scope: CompletionMetadataScope) {
+  return resolveSqlCompletionRoutineLookupTarget({
+    currentDatabase: scope.database,
+    currentSchema: scope.schema,
+    supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion(),
+    completionContext,
+  });
+}
+
+function routineCompletionScopeForContext(completionContext: ReturnType<typeof getSqlCompletionContext>, scope: CompletionMetadataScope): CompletionMetadataScope {
+  if (props.databaseType === "oracle") return scope;
+  const target = routineCompletionTargetForContext(completionContext, scope);
+  return { database: target.database, schema: target.schema };
+}
+
 function lookupLocalCompletionObjectsForContext(completionContext: ReturnType<typeof getSqlCompletionContext>, scope: CompletionMetadataScope): SqlCompletionObject[] {
   if (!props.connectionId || props.database == null) return [];
   if (props.databaseType === "oracle") {
     return connectionStore.lookupLocalCompletionObjects(props.connectionId, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES);
   }
-  const target = resolveSqlCompletionRoutineLookupTarget({ currentSchema: scope.schema, completionContext });
-  return connectionStore.lookupLocalCompletionObjects(props.connectionId, scope.database, target.mask, MAX_COMPLETION_TABLES, target.schema);
+  const target = routineCompletionTargetForContext(completionContext, scope);
+  return connectionStore.lookupLocalCompletionObjects(props.connectionId, target.database, target.mask, MAX_COMPLETION_TABLES, target.schema);
 }
 
 async function listCompletionObjectsForContext(completionContext: ReturnType<typeof getSqlCompletionContext>, scope: CompletionMetadataScope): Promise<SqlCompletionObject[]> {
   if (!props.connectionId || props.database == null) return [];
   const objectKinds = completionObjectKindsForContext(completionContext);
   if (props.databaseType !== "oracle") {
-    const target = resolveSqlCompletionRoutineLookupTarget({ currentSchema: scope.schema, completionContext });
-    return connectionStore.listCompletionObjects(props.connectionId, scope.database, target.mask, MAX_COMPLETION_TABLES, target.schema, undefined, false, scope.schema, objectKinds);
+    const target = routineCompletionTargetForContext(completionContext, scope);
+    return connectionStore.listCompletionObjects(props.connectionId, target.database, target.mask, MAX_COMPLETION_TABLES, target.schema, undefined, false, scope.schema, objectKinds);
   }
   const groups = await Promise.all(
     oracleRoutineCompletionTargets(completionContext).map((target) => connectionStore.listCompletionObjects(props.connectionId!, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES, target.schema, target.parentName, target.globalSearch, scope.schema, objectKinds)),
@@ -3291,18 +3308,20 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   if (epoch !== completionEpoch) return null;
 
   const shouldLoadObjects = shouldLoadCompletionObjects(completionContext);
-  const scopedCachedCompletionObjects = completionObjectsForScope(scope);
+  const completionObjectScope = routineCompletionScopeForContext(completionContext, scope);
+  const scopedCachedCompletionObjects = completionObjectsForScope(completionObjectScope);
   let completionObjects = shouldLoadObjects ? (localOnlyMetadata ? lookupLocalCompletionObjectsForContext(completionContext, scope) : await listCompletionObjectsForContext(completionContext, scope)) : scopedCachedCompletionObjects;
   if (epoch !== completionEpoch) return null;
 
   if (!props.catalog && props.databaseType !== "oracle" && !localOnlyMetadata && completionContext.qualifier && completionObjects.length === 0) {
-    const schemaObjects = await connectionStore.listCompletionObjects(props.connectionId!, scope.database, completionContext.prefix, MAX_COMPLETION_TABLES, completionContext.qualifier, undefined, false, scope.schema);
+    const target = routineCompletionTargetForContext(completionContext, scope);
+    const schemaObjects = await connectionStore.listCompletionObjects(props.connectionId!, target.database, target.mask, MAX_COMPLETION_TABLES, target.schema, undefined, false, scope.schema);
     if (schemaObjects.length > 0) {
       completionObjects = schemaObjects;
     }
     if (epoch !== completionEpoch) return null;
   }
-  cachedCompletionObjectsByScope.set(completionObjectScopeKey(scope), mergeCompletionObjects(scopedCachedCompletionObjects, completionObjects));
+  cachedCompletionObjectsByScope.set(completionObjectScopeKey(completionObjectScope), mergeCompletionObjects(scopedCachedCompletionObjects, completionObjects));
 
   // Fetch schemas for schema completion
   let schemaNames: string[] = [];

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -44,7 +44,17 @@ import { buildSqlSemanticModel } from "@/lib/sql/semantic/model";
 import { mergeSqlSemanticReferenceAnalysis, resolveSqlSemanticNavigationTarget } from "@/lib/sql/semantic/references";
 import { buildElasticsearchCompletionItemsFromContext, getElasticsearchCompletionContext, getElasticsearchCompletionResultValidFor, shouldAutoOpenElasticsearchCompletion, type ElasticsearchCompletionItem } from "@/lib/elasticsearch/elasticsearchCompletion";
 import { buildMongoCompletionItemsFromContext, getMongoCompletionContext, getMongoCompletionResultValidFor, mongoCompletionNeedsCollections, mongoCompletionNeedsFields, shouldAutoOpenMongoCompletion, type MongoCompletionItem } from "@/lib/mongo/mongoCompletion";
-import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionScope, resolveSqlCompletionTableLookupTarget, type SqlCompletionScope } from "@/lib/sql/sqlCompletionLookupTarget";
+import {
+  buildSqlServerUseDatabaseCompletionItems,
+  mergeSqlCompletionQualifierNames,
+  resolveSqlCompletionRoutineLookupTarget,
+  resolveSqlCompletionSchemaLookupDatabase,
+  resolveSqlCompletionScope,
+  resolveSqlCompletionTableLookupTarget,
+  resolveSqlServerUseDatabaseCompletion,
+  sqlServerUseDatabaseBeforeCursor,
+  type SqlCompletionScope,
+} from "@/lib/sql/sqlCompletionLookupTarget";
 import { usesOracleSessionCompletionColumns as shouldUseOracleSessionCompletionColumns } from "@/lib/sql/oracleCompletionSession";
 import { extractIdentifierDetailsAt, isSqlKeyword, matchTable, mergeSqlObjectNavigationType, splitQualifiedIdentifier, sqlObjectHoverDetail, sqlObjectNavigationTarget, type SqlObjectNavigationTarget } from "@/lib/sql/sqlNavigation";
 import { buildHoverTableSql, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
@@ -2477,7 +2487,8 @@ function isTypedCompletionActivation(explicit: boolean) {
 }
 
 function markCompletionAccepted(item: QueryCompletionItem) {
-  suppressNextSqlCompletionAutoStartUntil = shouldChainSqlCompletionAfterAccept(item) ? 0 : Date.now() + 750;
+  const shouldContinueCompletion = shouldChainSqlCompletionAfterAccept(item) || (props.databaseType === "sqlserver" && item.type === "keyword" && item.label.toUpperCase() === "USE");
+  suppressNextSqlCompletionAutoStartUntil = shouldContinueCompletion ? 0 : Date.now() + 750;
   completionEpoch++;
 }
 
@@ -2705,7 +2716,24 @@ async function provideSqlCompletions(context: CompletionContext) {
 
   try {
     if (isSqlCompletionSuppressedContext(fullDoc, position)) return null;
-    if (!explicit && !shouldAutoOpenSqlCompletion(fullDoc, position, sqlCompletionDialectOptions())) return null;
+    const useDatabaseCompletion = resolveSqlServerUseDatabaseCompletion({
+      sql: fullDoc,
+      cursor: position,
+      databaseType: props.databaseType,
+    });
+    if (!explicit && !useDatabaseCompletion && !shouldAutoOpenSqlCompletion(fullDoc, position, sqlCompletionDialectOptions())) return null;
+
+    if (useDatabaseCompletion) {
+      try {
+        await connectionStore.listCompletionDatabases(props.connectionId);
+      } catch {
+        // Keep locally indexed database names available when metadata refresh fails.
+      }
+      if (epoch !== completionEpoch) return null;
+      const databaseNames = connectionStore.lookupLocalCompletionDatabases(props.connectionId, useDatabaseCompletion.prefix, MAX_COMPLETION_TABLES);
+      const items = buildSqlServerUseDatabaseCompletionItems(databaseNames, useDatabaseCompletion);
+      return buildCompletionResult(items, useDatabaseCompletion.from);
+    }
 
     const legacyCompletionContext = getSqlCompletionContext(fullDoc, position, sqlCompletionDialectOptions());
     const semanticModel = SEMANTIC_SQL_COMPLETION_ENABLED ? buildSqlSemanticModel(fullDoc, position, sqlCompletionDialectOptions()) : null;
@@ -2728,12 +2756,27 @@ async function provideSqlCompletions(context: CompletionContext) {
       return buildCompletionResult(items, position - completionContext.prefix.length, getSqlCompletionResultValidFor(fullDoc, position));
     }
 
+    const useDatabase = props.databaseType === "sqlserver" ? sqlServerUseDatabaseBeforeCursor(fullDoc, position) : undefined;
+    let knownUseDatabases: string[] | undefined;
+    if (useDatabase) {
+      knownUseDatabases = mergeSqlCompletionQualifierNames([props.database!], connectionStore.lookupLocalCompletionDatabases(props.connectionId, "", MAX_COMPLETION_TABLES));
+      if (!knownUseDatabases.some((database) => database.toLowerCase() === useDatabase.toLowerCase())) {
+        try {
+          knownUseDatabases = mergeSqlCompletionQualifierNames([props.database!], await connectionStore.listCompletionDatabases(props.connectionId));
+        } catch {
+          // An unverified USE target must not replace the selected database.
+        }
+        if (epoch !== completionEpoch) return null;
+      }
+    }
+
     const completionScope = resolveSqlCompletionScope({
       sql: fullDoc,
       cursor: position,
       databaseType: props.databaseType,
       currentDatabase: props.database!,
       currentSchema: props.schema,
+      knownDatabases: knownUseDatabases,
       completionContext,
     });
     completionContext = completionScope.completionContext;
@@ -2828,7 +2871,9 @@ function flushImeComposition() {
   emit("cursorChange", currentView.state.selection.main.head);
   latestSelection = readEditorSelection(currentView);
   if (editorIsActive) emitEditorSelection(latestSelection);
-  if (shouldAutoOpenSqlCompletion(currentView.state.doc.toString(), currentView.state.selection.main.head, sqlCompletionDialectOptions())) {
+  const fullDoc = currentView.state.doc.toString();
+  const position = currentView.state.selection.main.head;
+  if (resolveSqlServerUseDatabaseCompletion({ sql: fullDoc, cursor: position, databaseType: props.databaseType }) || shouldAutoOpenSqlCompletion(fullDoc, position, sqlCompletionDialectOptions())) {
     scheduleSqlCompletionStart(currentView);
   }
 }
@@ -2836,6 +2881,7 @@ function flushImeComposition() {
 function shouldStartSqlCompletionAfterInput(insertedText: string, removedText: string, currentView: EditorViewType): boolean {
   const position = currentView.state.selection.main.head;
   const fullDoc = currentView.state.doc.toString();
+  if (resolveSqlServerUseDatabaseCompletion({ sql: fullDoc, cursor: position, databaseType: props.databaseType })) return true;
   if (!insertedText && removedText) {
     const completionContext = getSqlCompletionContext(fullDoc, position, sqlCompletionDialectOptions());
     return isTableNameCompletionContext(completionContext) && shouldAutoOpenSqlCompletion(fullDoc, position, sqlCompletionDialectOptions());

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorDatabaseNameCompletion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorDatabaseNameCompletion.spec.ts
@@ -36,10 +36,11 @@ describe("QueryEditor database name completion wiring", () => {
   });
 
   it("uses the resolved database scope for routine completion and isolates the editor cache", () => {
-    expect(extractFunction("lookupLocalCompletionObjectsForContext")).toContain("scope.database");
-    expect(extractFunction("lookupLocalCompletionObjectsForContext")).toContain("currentSchema: scope.schema");
-    expect(extractFunction("listCompletionObjectsForContext")).toContain("scope.database");
-    expect(extractFunction("listCompletionObjectsForContext")).toContain("currentSchema: scope.schema");
+    expect(extractFunction("routineCompletionTargetForContext")).toContain("currentDatabase: scope.database");
+    expect(extractFunction("routineCompletionTargetForContext")).toContain("supportsDatabaseSchemaQualifier: supportsDatabaseSchemaQualifierCompletion()");
+    expect(extractFunction("lookupLocalCompletionObjectsForContext")).toContain("target.database");
+    expect(extractFunction("listCompletionObjectsForContext")).toContain("target.database");
+    expect(extractFunction("routineCompletionScopeForContext")).toContain("database: target.database");
     expect(extractFunction("completionObjectScopeKey")).toContain("scope.database");
     expect(extractFunction("completionObjectScopeKey")).toContain("scope.schema");
     expect(queryEditorSource).toContain("cachedCompletionObjectsByScope");

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorDatabaseNameCompletion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorDatabaseNameCompletion.spec.ts
@@ -34,4 +34,22 @@ describe("QueryEditor database name completion wiring", () => {
     expect(guard).toContain("supportsDatabaseNameCompletion(props.databaseType)");
     expect(guard).toContain("supportsDatabaseSchemaQualifierCompletion()");
   });
+
+  it("uses the resolved database scope for routine completion and isolates the editor cache", () => {
+    expect(extractFunction("lookupLocalCompletionObjectsForContext")).toContain("scope.database");
+    expect(extractFunction("lookupLocalCompletionObjectsForContext")).toContain("currentSchema: scope.schema");
+    expect(extractFunction("listCompletionObjectsForContext")).toContain("scope.database");
+    expect(extractFunction("listCompletionObjectsForContext")).toContain("currentSchema: scope.schema");
+    expect(extractFunction("completionObjectScopeKey")).toContain("scope.database");
+    expect(extractFunction("completionObjectScopeKey")).toContain("scope.schema");
+    expect(queryEditorSource).toContain("cachedCompletionObjectsByScope");
+  });
+
+  it("loads SQL Server capability metadata before offering or applying USE completion", () => {
+    const provider = extractFunction("provideSqlCompletions");
+
+    expect(provider).toContain("getSqlServerCompletionContext");
+    expect(provider).toContain("supports_session_database_switch");
+    expect(provider).toContain("useDatabaseDefaultSchema");
+  });
 });

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
@@ -410,16 +410,34 @@ describe("sqlCompletionLookupTarget", () => {
   ])("separates a routine schema from its name mask for %s", (sql, schema, mask) => {
     const completionContext = getSqlCompletionContext(sql, sql.length);
 
-    expect(resolveSqlCompletionRoutineLookupTarget({ currentSchema: "fallback", completionContext })).toEqual({ schema, mask });
+    expect(resolveSqlCompletionRoutineLookupTarget({ currentDatabase: "app", currentSchema: "fallback", completionContext })).toEqual({ database: "app", schema, mask });
   });
 
   it("uses the current schema for an unqualified routine mask", () => {
     const sql = "SELECT st_";
     const completionContext = getSqlCompletionContext(sql, sql.length);
 
-    expect(resolveSqlCompletionRoutineLookupTarget({ currentSchema: "public", completionContext })).toEqual({
+    expect(resolveSqlCompletionRoutineLookupTarget({ currentDatabase: "app", currentSchema: "public", completionContext })).toEqual({
+      database: "app",
       schema: "public",
       mask: "st_",
+    });
+  });
+
+  it.each(["SELECT BarDB.sales.fn_", "EXEC BarDB.sales.proc_"])("uses an explicit SQL Server database and schema for %s", (sql) => {
+    const completionContext = getSqlCompletionContext(sql, sql.length);
+
+    expect(
+      resolveSqlCompletionRoutineLookupTarget({
+        currentDatabase: "FooDB",
+        currentSchema: "app_user",
+        supportsDatabaseSchemaQualifier: true,
+        completionContext,
+      }),
+    ).toEqual({
+      database: "BarDB",
+      schema: "sales",
+      mask: sql.endsWith("fn_") ? "fn_" : "proc_",
     });
   });
 });

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { getSqlCompletionContext } from "@/lib/sql/sqlCompletion";
-import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionScope, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import {
+  buildSqlServerUseDatabaseCompletionItems,
+  mergeSqlCompletionQualifierNames,
+  resolveSqlCompletionRoutineLookupTarget,
+  resolveSqlCompletionSchemaLookupDatabase,
+  resolveSqlCompletionScope,
+  resolveSqlCompletionTableLookupTarget,
+  resolveSqlServerUseDatabaseCompletion,
+} from "@/lib/sql/sqlCompletionLookupTarget";
 
 describe("sqlCompletionLookupTarget", () => {
   it("treats qualified table completion as a database lookup for MySQL-compatible engines", () => {
@@ -184,7 +192,7 @@ describe("sqlCompletionLookupTarget", () => {
   });
 
   it("uses the preceding SQL Server USE database and dbo for unqualified table completion", () => {
-    const sql = "USE [BarDB]\n\nSELECT * FROM T";
+    const sql = "USE [bardb]\n\nSELECT * FROM T";
     const completionContext = getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" });
     const scope = resolveSqlCompletionScope({
       sql,
@@ -192,6 +200,7 @@ describe("sqlCompletionLookupTarget", () => {
       databaseType: "sqlserver",
       currentDatabase: "FooDB",
       currentSchema: "sales",
+      knownDatabases: ["FooDB", "BarDB"],
       completionContext,
     });
 
@@ -220,6 +229,7 @@ describe("sqlCompletionLookupTarget", () => {
       cursor: sql.length,
       databaseType: "sqlserver",
       currentDatabase: "SelectedDB",
+      knownDatabases: ["SelectedDB", "FooDB", "Bar]DB"],
       completionContext,
     });
 
@@ -276,6 +286,7 @@ describe("sqlCompletionLookupTarget", () => {
       cursor: sql.length,
       databaseType: "sqlserver",
       currentDatabase: "FooDB",
+      knownDatabases: ["FooDB", "BarDB", "ArchiveDB"],
       completionContext,
     });
 
@@ -288,6 +299,53 @@ describe("sqlCompletionLookupTarget", () => {
         { name: "TArchive", database: "ArchiveDB", schema: "history" },
       ],
     });
+  });
+
+  it("falls back to the selected SQL Server database when USE names an unknown database", () => {
+    const sql = "USE [MissingDB];\nSELECT * FROM T";
+    const completionContext = getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" });
+    const scope = resolveSqlCompletionScope({
+      sql,
+      cursor: sql.length,
+      databaseType: "sqlserver",
+      currentDatabase: "FooDB",
+      currentSchema: "sales",
+      knownDatabases: ["FooDB", "BarDB"],
+      completionContext,
+    });
+
+    expect(scope).toEqual({
+      database: "FooDB",
+      schema: "sales",
+      completionContext,
+    });
+  });
+
+  it.each([
+    ["USE ", { from: 4, prefix: "", quoteStyle: "none" }],
+    ["USE Bar", { from: 4, prefix: "Bar", quoteStyle: "none" }],
+    ["USE [Bar", { from: 5, prefix: "Bar", quoteStyle: "bracket" }],
+    ['USE "Bar', { from: 5, prefix: "Bar", quoteStyle: "double" }],
+    ["SELECT 1;\nUSE [Bar", { from: 15, prefix: "Bar", quoteStyle: "bracket" }],
+  ])("resolves SQL Server database completion for %s", (sql, expected) => {
+    expect(resolveSqlServerUseDatabaseCompletion({ sql, cursor: sql.length, databaseType: "sqlserver" })).toEqual(expected);
+  });
+
+  it("does not offer USE database completion outside an incomplete SQL Server USE target", () => {
+    expect(resolveSqlServerUseDatabaseCompletion({ sql: "USE", cursor: 3, databaseType: "sqlserver" })).toBeUndefined();
+    expect(resolveSqlServerUseDatabaseCompletion({ sql: "USE [BarDB]", cursor: 11, databaseType: "sqlserver" })).toBeUndefined();
+    expect(resolveSqlServerUseDatabaseCompletion({ sql: "SELECT 'USE Bar'", cursor: 15, databaseType: "sqlserver" })).toBeUndefined();
+    expect(resolveSqlServerUseDatabaseCompletion({ sql: "USE Bar", cursor: 7, databaseType: "postgres" })).toBeUndefined();
+  });
+
+  it("builds quoted SQL Server USE database completion insertions", () => {
+    const unquoted = resolveSqlServerUseDatabaseCompletion({ sql: "USE Odd", cursor: 7, databaseType: "sqlserver" })!;
+    const bracketed = resolveSqlServerUseDatabaseCompletion({ sql: "USE [Odd", cursor: 8, databaseType: "sqlserver" })!;
+    const doubleQuoted = resolveSqlServerUseDatabaseCompletion({ sql: 'USE "Odd', cursor: 8, databaseType: "sqlserver" })!;
+
+    expect(buildSqlServerUseDatabaseCompletionItems(["Odd]DB"], unquoted)[0]).toMatchObject({ label: "Odd]DB", detail: "database", apply: "[Odd]]DB]" });
+    expect(buildSqlServerUseDatabaseCompletionItems(["Odd]DB"], bracketed)[0]).toMatchObject({ label: "Odd]DB", filterText: "Odd]]DB", apply: "Odd]]DB]" });
+    expect(buildSqlServerUseDatabaseCompletionItems(['Odd"DB'], doubleQuoted)[0]).toMatchObject({ label: 'Odd"DB', filterText: 'Odd""DB', apply: 'Odd""DB"' });
   });
 
   it.each([

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
@@ -8,6 +8,7 @@ import {
   resolveSqlCompletionScope,
   resolveSqlCompletionTableLookupTarget,
   resolveSqlServerUseDatabaseCompletion,
+  sqlServerUseCompletionDatabaseNames,
 } from "@/lib/sql/sqlCompletionLookupTarget";
 
 describe("sqlCompletionLookupTarget", () => {
@@ -191,7 +192,7 @@ describe("sqlCompletionLookupTarget", () => {
     });
   });
 
-  it("uses the preceding SQL Server USE database and dbo for unqualified table completion", () => {
+  it("uses the preceding SQL Server USE database and its server-reported default schema", () => {
     const sql = "USE [bardb]\n\nSELECT * FROM T";
     const completionContext = getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" });
     const scope = resolveSqlCompletionScope({
@@ -201,11 +202,13 @@ describe("sqlCompletionLookupTarget", () => {
       currentDatabase: "FooDB",
       currentSchema: "sales",
       knownDatabases: ["FooDB", "BarDB"],
+      supportsSessionDatabaseSwitch: true,
+      useDatabaseDefaultSchema: "app_user",
       completionContext,
     });
 
     expect(scope.database).toBe("BarDB");
-    expect(scope.schema).toBe("dbo");
+    expect(scope.schema).toBe("app_user");
     expect(
       resolveSqlCompletionTableLookupTarget({
         currentDatabase: scope.database,
@@ -216,7 +219,7 @@ describe("sqlCompletionLookupTarget", () => {
       }),
     ).toEqual({
       database: "BarDB",
-      schema: "dbo",
+      schema: "app_user",
       filter: "T",
     });
   });
@@ -230,6 +233,8 @@ describe("sqlCompletionLookupTarget", () => {
       databaseType: "sqlserver",
       currentDatabase: "SelectedDB",
       knownDatabases: ["SelectedDB", "FooDB", "Bar]DB"],
+      supportsSessionDatabaseSwitch: true,
+      useDatabaseDefaultSchema: "reporting_user",
       completionContext,
     });
 
@@ -287,14 +292,16 @@ describe("sqlCompletionLookupTarget", () => {
       databaseType: "sqlserver",
       currentDatabase: "FooDB",
       knownDatabases: ["FooDB", "BarDB", "ArchiveDB"],
+      supportsSessionDatabaseSwitch: true,
+      useDatabaseDefaultSchema: "app_user",
       completionContext,
     });
 
     expect(scope.completionContext).toMatchObject({
       insertDatabase: "BarDB",
-      insertSchema: "dbo",
+      insertSchema: "app_user",
       referencedTables: [
-        { name: "TUser", database: "BarDB", schema: "dbo" },
+        { name: "TUser", database: "BarDB", schema: "app_user" },
         { name: "TOrder", database: "BarDB", schema: "sales" },
         { name: "TArchive", database: "ArchiveDB", schema: "history" },
       ],
@@ -311,11 +318,36 @@ describe("sqlCompletionLookupTarget", () => {
       currentDatabase: "FooDB",
       currentSchema: "sales",
       knownDatabases: ["FooDB", "BarDB"],
+      supportsSessionDatabaseSwitch: true,
+      useDatabaseDefaultSchema: "dbo",
       completionContext,
     });
 
     expect(scope).toEqual({
       database: "FooDB",
+      schema: "sales",
+      completionContext,
+    });
+  });
+
+  it("falls back to the selected database when the endpoint cannot switch sessions", () => {
+    const sql = "USE [BarDB];\nSELECT * FROM T";
+    const completionContext = getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" });
+
+    expect(
+      resolveSqlCompletionScope({
+        sql,
+        cursor: sql.length,
+        databaseType: "sqlserver",
+        currentDatabase: "AzureDB",
+        currentSchema: "sales",
+        knownDatabases: ["AzureDB", "BarDB"],
+        supportsSessionDatabaseSwitch: false,
+        useDatabaseDefaultSchema: "dbo",
+        completionContext,
+      }),
+    ).toEqual({
+      database: "AzureDB",
       schema: "sales",
       completionContext,
     });
@@ -346,6 +378,30 @@ describe("sqlCompletionLookupTarget", () => {
     expect(buildSqlServerUseDatabaseCompletionItems(["Odd]DB"], unquoted)[0]).toMatchObject({ label: "Odd]DB", detail: "database", apply: "[Odd]]DB]" });
     expect(buildSqlServerUseDatabaseCompletionItems(["Odd]DB"], bracketed)[0]).toMatchObject({ label: "Odd]DB", filterText: "Odd]]DB", apply: "Odd]]DB]" });
     expect(buildSqlServerUseDatabaseCompletionItems(['Odd"DB'], doubleQuoted)[0]).toMatchObject({ label: 'Odd"DB', filterText: 'Odd""DB', apply: 'Odd""DB"' });
+  });
+
+  it("limits USE database candidates to the current database when session switching is unsupported", () => {
+    expect(
+      sqlServerUseCompletionDatabaseNames({
+        databaseNames: ["master", "AzureDB", "OtherDB"],
+        currentDatabase: "azuredb",
+        supportsSessionDatabaseSwitch: false,
+      }),
+    ).toEqual(["AzureDB"]);
+    expect(
+      sqlServerUseCompletionDatabaseNames({
+        databaseNames: ["FooDB", "BarDB"],
+        currentDatabase: "FooDB",
+        supportsSessionDatabaseSwitch: true,
+      }),
+    ).toEqual(["FooDB", "BarDB"]);
+    expect(
+      sqlServerUseCompletionDatabaseNames({
+        databaseNames: [],
+        currentDatabase: "",
+        supportsSessionDatabaseSwitch: false,
+      }),
+    ).toEqual([]);
   });
 
   it.each([

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletionLookupTarget.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getSqlCompletionContext } from "@/lib/sql/sqlCompletion";
-import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
+import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionScope, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
 
 describe("sqlCompletionLookupTarget", () => {
   it("treats qualified table completion as a database lookup for MySQL-compatible engines", () => {
@@ -180,6 +180,113 @@ describe("sqlCompletionLookupTarget", () => {
       database: "app",
       schema: "public",
       filter: "ord",
+    });
+  });
+
+  it("uses the preceding SQL Server USE database and dbo for unqualified table completion", () => {
+    const sql = "USE [BarDB]\n\nSELECT * FROM T";
+    const completionContext = getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" });
+    const scope = resolveSqlCompletionScope({
+      sql,
+      cursor: sql.length,
+      databaseType: "sqlserver",
+      currentDatabase: "FooDB",
+      currentSchema: "sales",
+      completionContext,
+    });
+
+    expect(scope.database).toBe("BarDB");
+    expect(scope.schema).toBe("dbo");
+    expect(
+      resolveSqlCompletionTableLookupTarget({
+        currentDatabase: scope.database,
+        currentSchema: scope.schema,
+        supportsDatabaseQualifier: false,
+        supportsDatabaseSchemaQualifier: true,
+        completionContext: scope.completionContext,
+      }),
+    ).toEqual({
+      database: "BarDB",
+      schema: "dbo",
+      filter: "T",
+    });
+  });
+
+  it("uses the last preceding SQL Server USE and unescapes its identifier", () => {
+    const sql = "USE FooDB;\nUSE [Bar]]DB];\nSELECT * FROM T";
+    const completionContext = getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" });
+    const scope = resolveSqlCompletionScope({
+      sql,
+      cursor: sql.length,
+      databaseType: "sqlserver",
+      currentDatabase: "SelectedDB",
+      completionContext,
+    });
+
+    expect(scope.database).toBe("Bar]DB");
+  });
+
+  it("ignores commented, quoted, current, later, and non-SQL Server USE text", () => {
+    const sql = "-- USE [CommentDB]\nSELECT 'USE [StringDB]';\nSELECT * FROM T;\nUSE [LaterDB];";
+    const cursor = sql.indexOf("T;") + 1;
+    const completionContext = getSqlCompletionContext(sql, cursor, { databaseType: "sqlserver", dialect: "sqlserver" });
+
+    expect(
+      resolveSqlCompletionScope({
+        sql,
+        cursor,
+        databaseType: "sqlserver",
+        currentDatabase: "FooDB",
+        currentSchema: "dbo",
+        completionContext,
+      }).database,
+    ).toBe("FooDB");
+    const currentUseSql = "USE [BarDB]";
+    expect(
+      resolveSqlCompletionScope({
+        sql: currentUseSql,
+        cursor: currentUseSql.length,
+        databaseType: "sqlserver",
+        currentDatabase: "FooDB",
+        currentSchema: "dbo",
+        completionContext,
+      }).database,
+    ).toBe("FooDB");
+    expect(
+      resolveSqlCompletionScope({
+        sql: "USE [BarDB];\nSELECT * FROM T",
+        cursor: "USE [BarDB];\nSELECT * FROM T".length,
+        databaseType: "postgres",
+        currentDatabase: "FooDB",
+        currentSchema: "public",
+        completionContext,
+      }),
+    ).toMatchObject({ database: "FooDB", schema: "public", completionContext });
+  });
+
+  it("scopes unqualified SQL Server references without overriding explicit databases or schemas", () => {
+    const sql = "USE [BarDB];\nSELECT * FROM T";
+    const completionContext = {
+      ...getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" }),
+      insertTable: "NewRow",
+      referencedTables: [{ name: "TUser" }, { name: "TOrder", schema: "sales" }, { name: "TArchive", database: "ArchiveDB", schema: "history" }],
+    };
+    const scope = resolveSqlCompletionScope({
+      sql,
+      cursor: sql.length,
+      databaseType: "sqlserver",
+      currentDatabase: "FooDB",
+      completionContext,
+    });
+
+    expect(scope.completionContext).toMatchObject({
+      insertDatabase: "BarDB",
+      insertSchema: "dbo",
+      referencedTables: [
+        { name: "TUser", database: "BarDB", schema: "dbo" },
+        { name: "TOrder", database: "BarDB", schema: "sales" },
+        { name: "TArchive", database: "ArchiveDB", schema: "history" },
+      ],
     });
   });
 

--- a/apps/desktop/src/lib/backend/api.ts
+++ b/apps/desktop/src/lib/backend/api.ts
@@ -138,6 +138,7 @@ export const syncSavedSqlDirectory = forward("syncSavedSqlDirectory");
 // Schema
 export const listDatabases = forward("listDatabases");
 export const listDatabaseStorage = forward("listDatabaseStorage");
+export const getSqlServerCompletionContext = forward("getSqlServerCompletionContext");
 export const listDorisCatalogs = forward("listDorisCatalogs");
 export const listDorisCatalogDatabases = forward("listDorisCatalogDatabases");
 export const listSqlServerLinkedServers = forward("listSqlServerLinkedServers");

--- a/apps/desktop/src/lib/backend/http.ts
+++ b/apps/desktop/src/lib/backend/http.ts
@@ -4,6 +4,7 @@ import type {
   DatabaseConnectionInfo,
   DatabaseInfo,
   DatabaseStorageInfo,
+  SqlServerCompletionContext,
   SchemaInfo,
   LinkedServerInfo,
   CatalogInfo,
@@ -632,6 +633,10 @@ export async function listDatabaseStorage(connectionId: string, databases: strin
     connection_id: connectionId,
     databases,
   });
+}
+
+export async function getSqlServerCompletionContext(connectionId: string, database: string): Promise<SqlServerCompletionContext> {
+  return get(`/api/schema/sqlserver/completion-context?${qs({ connection_id: connectionId, database })}`);
 }
 
 export async function listDorisCatalogs(connectionId: string): Promise<CatalogInfo[]> {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -8,6 +8,7 @@ import type {
   DatabaseConnectionInfo,
   DatabaseInfo,
   DatabaseStorageInfo,
+  SqlServerCompletionContext,
   SchemaInfo,
   LinkedServerInfo,
   CatalogInfo,
@@ -867,6 +868,10 @@ export async function listDatabases(connectionId: string): Promise<DatabaseInfo[
 
 export async function listDatabaseStorage(connectionId: string, databases: string[]): Promise<DatabaseStorageInfo[]> {
   return invoke("list_database_storage", { connectionId, databases });
+}
+
+export async function getSqlServerCompletionContext(connectionId: string, database: string): Promise<SqlServerCompletionContext> {
+  return invoke("get_sqlserver_completion_context", { connectionId, database });
 }
 
 export async function listDorisCatalogs(connectionId: string): Promise<CatalogInfo[]> {

--- a/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
@@ -134,7 +134,23 @@ export function buildSqlServerUseDatabaseCompletionItems(databaseNames: readonly
   });
 }
 
-export function resolveSqlCompletionScope(options: { sql: string; cursor: number; databaseType?: DatabaseType; currentDatabase: string; currentSchema?: string; knownDatabases?: readonly string[]; completionContext: SqlCompletionContext }): SqlCompletionScope {
+export function sqlServerUseCompletionDatabaseNames(options: { databaseNames: readonly string[]; currentDatabase: string; supportsSessionDatabaseSwitch: boolean }): string[] {
+  if (options.supportsSessionDatabaseSwitch) return [...options.databaseNames];
+  const currentDatabase = options.currentDatabase.trim();
+  return currentDatabase ? [findExactName(options.databaseNames, currentDatabase) ?? currentDatabase] : [];
+}
+
+export function resolveSqlCompletionScope(options: {
+  sql: string;
+  cursor: number;
+  databaseType?: DatabaseType;
+  currentDatabase: string;
+  currentSchema?: string;
+  knownDatabases?: readonly string[];
+  supportsSessionDatabaseSwitch?: boolean;
+  useDatabaseDefaultSchema?: string;
+  completionContext: SqlCompletionContext;
+}): SqlCompletionScope {
   if (options.databaseType !== "sqlserver") {
     return {
       database: options.currentDatabase,
@@ -143,15 +159,16 @@ export function resolveSqlCompletionScope(options: { sql: string; cursor: number
     };
   }
   const parsedDatabase = sqlServerUseDatabaseBeforeCursor(options.sql, options.cursor);
-  const database = parsedDatabase && options.knownDatabases !== undefined ? findExactName(options.knownDatabases, parsedDatabase) : parsedDatabase;
-  if (!database) {
+  const database = parsedDatabase ? findExactName(options.knownDatabases, parsedDatabase) : undefined;
+  const targetsCurrentDatabase = database?.toLowerCase() === options.currentDatabase.toLowerCase();
+  const schema = options.useDatabaseDefaultSchema?.trim();
+  if (!database || !schema || (!targetsCurrentDatabase && options.supportsSessionDatabaseSwitch !== true)) {
     return {
       database: options.currentDatabase,
       schema: options.currentSchema,
       completionContext: options.completionContext,
     };
   }
-  const schema = "dbo";
   return {
     database,
     schema,

--- a/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
@@ -10,6 +10,7 @@ export interface SqlCompletionTableLookupTarget {
 }
 
 export interface SqlCompletionRoutineLookupTarget {
+  database: string;
   schema?: string;
   mask: string;
 }
@@ -259,13 +260,17 @@ export function resolveSqlCompletionTableLookupTarget(options: {
   };
 }
 
-export function resolveSqlCompletionRoutineLookupTarget(options: { currentSchema?: string; completionContext: Pick<SqlCompletionContext, "qualifier" | "qualifierParts" | "prefix"> }): SqlCompletionRoutineLookupTarget {
-  const qualifierParts = options.completionContext.qualifierParts?.filter(Boolean);
-  const schema = qualifierParts?.[qualifierParts.length - 1] ?? options.completionContext.qualifier?.trim() ?? options.currentSchema;
+export function resolveSqlCompletionRoutineLookupTarget(options: { currentDatabase: string; currentSchema?: string; supportsDatabaseSchemaQualifier?: boolean; completionContext: Pick<SqlCompletionContext, "qualifier" | "qualifierParts" | "prefix"> }): SqlCompletionRoutineLookupTarget {
+  const qualifier = options.completionContext.qualifier?.trim();
+  const qualifierParts = options.completionContext.qualifierParts?.filter(Boolean) ?? qualifier?.split(".").filter(Boolean) ?? [];
+  const hasDatabaseQualifier = options.supportsDatabaseSchemaQualifier && qualifierParts.length >= 2;
+  const database = hasDatabaseQualifier ? qualifierParts[qualifierParts.length - 2]! : options.currentDatabase;
+  const schema = qualifierParts[qualifierParts.length - 1] ?? qualifier ?? options.currentSchema;
 
   // A qualified routine uses the qualifier as metadata scope; only the final
   // identifier fragment is the function/procedure name mask.
   return {
+    database,
     schema: schema || undefined,
     mask: options.completionContext.prefix,
   };

--- a/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
@@ -1,4 +1,6 @@
 import type { SqlCompletionContext } from "@/lib/sql/sqlCompletion";
+import { executableStatementRanges } from "@/lib/sql/sqlStatementRanges";
+import type { DatabaseType } from "@/types/database";
 
 export interface SqlCompletionTableLookupTarget {
   database: string;
@@ -10,6 +12,86 @@ export interface SqlCompletionTableLookupTarget {
 export interface SqlCompletionRoutineLookupTarget {
   schema?: string;
   mask: string;
+}
+
+export interface SqlCompletionScope {
+  database: string;
+  schema?: string;
+  completionContext: SqlCompletionContext;
+}
+
+function sqlStatementWithoutLeadingComments(statement: string): string {
+  let remaining = statement.trimStart();
+  while (remaining) {
+    if (remaining.startsWith("--")) {
+      const newline = remaining.indexOf("\n");
+      remaining = newline < 0 ? "" : remaining.slice(newline + 1).trimStart();
+      continue;
+    }
+    if (remaining.startsWith("/*")) {
+      const end = remaining.indexOf("*/", 2);
+      if (end < 0) return "";
+      remaining = remaining.slice(end + 2).trimStart();
+      continue;
+    }
+    break;
+  }
+  return remaining;
+}
+
+function sqlServerUseDatabase(statement: string): string | undefined {
+  const match = /^USE\s+(?:\[((?:[^\]]|\]\])*)\]|"((?:[^"]|"")*)"|([\p{L}_@#][\p{L}\p{N}_@$#]*))\s*;?\s*$/iu.exec(sqlStatementWithoutLeadingComments(statement));
+  if (!match) return undefined;
+  if (match[1] !== undefined) return match[1].replaceAll("]]", "]");
+  if (match[2] !== undefined) return match[2].replaceAll('""', '"');
+  return match[3];
+}
+
+function sqlServerUseDatabaseBeforeCursor(sql: string, cursor: number): string | undefined {
+  const position = Math.max(0, Math.min(cursor, sql.length));
+  let database: string | undefined;
+  for (const statement of executableStatementRanges(sql, "sqlserver")) {
+    if (statement.from >= position || statement.to >= position) break;
+    database = sqlServerUseDatabase(statement.sql) ?? database;
+  }
+  return database;
+}
+
+export function resolveSqlCompletionScope(options: { sql: string; cursor: number; databaseType?: DatabaseType; currentDatabase: string; currentSchema?: string; completionContext: SqlCompletionContext }): SqlCompletionScope {
+  if (options.databaseType !== "sqlserver") {
+    return {
+      database: options.currentDatabase,
+      schema: options.currentSchema,
+      completionContext: options.completionContext,
+    };
+  }
+  const database = sqlServerUseDatabaseBeforeCursor(options.sql, options.cursor);
+  if (!database) {
+    return {
+      database: options.currentDatabase,
+      schema: options.currentSchema,
+      completionContext: options.completionContext,
+    };
+  }
+  const schema = "dbo";
+  return {
+    database,
+    schema,
+    completionContext: {
+      ...options.completionContext,
+      insertDatabase: options.completionContext.insertTable && !options.completionContext.insertDatabase ? database : options.completionContext.insertDatabase,
+      insertSchema: options.completionContext.insertTable && !options.completionContext.insertSchema ? schema : options.completionContext.insertSchema,
+      referencedTables: options.completionContext.referencedTables.map((table) =>
+        table.database
+          ? table
+          : {
+              ...table,
+              database,
+              schema: table.schema ?? schema,
+            },
+      ),
+    },
+  };
 }
 
 function findExactName(names: readonly string[] | undefined, value: string): string | undefined {

--- a/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletionLookupTarget.ts
@@ -1,5 +1,5 @@
-import type { SqlCompletionContext } from "@/lib/sql/sqlCompletion";
-import { executableStatementRanges } from "@/lib/sql/sqlStatementRanges";
+import type { SqlCompletionContext, SqlCompletionItem } from "@/lib/sql/sqlCompletion";
+import { currentExecutableStatementRange, executableStatementRanges } from "@/lib/sql/sqlStatementRanges";
 import type { DatabaseType } from "@/types/database";
 
 export interface SqlCompletionTableLookupTarget {
@@ -18,6 +18,12 @@ export interface SqlCompletionScope {
   database: string;
   schema?: string;
   completionContext: SqlCompletionContext;
+}
+
+export interface SqlServerUseDatabaseCompletion {
+  from: number;
+  prefix: string;
+  quoteStyle: "none" | "bracket" | "double";
 }
 
 function sqlStatementWithoutLeadingComments(statement: string): string {
@@ -47,7 +53,7 @@ function sqlServerUseDatabase(statement: string): string | undefined {
   return match[3];
 }
 
-function sqlServerUseDatabaseBeforeCursor(sql: string, cursor: number): string | undefined {
+export function sqlServerUseDatabaseBeforeCursor(sql: string, cursor: number): string | undefined {
   const position = Math.max(0, Math.min(cursor, sql.length));
   let database: string | undefined;
   for (const statement of executableStatementRanges(sql, "sqlserver")) {
@@ -57,7 +63,78 @@ function sqlServerUseDatabaseBeforeCursor(sql: string, cursor: number): string |
   return database;
 }
 
-export function resolveSqlCompletionScope(options: { sql: string; cursor: number; databaseType?: DatabaseType; currentDatabase: string; currentSchema?: string; completionContext: SqlCompletionContext }): SqlCompletionScope {
+function unclosedQuotedIdentifierPrefix(value: string, quoteStyle: "bracket" | "double"): string | undefined {
+  const closingQuote = quoteStyle === "bracket" ? "]" : '"';
+  let prefix = "";
+  for (let index = 1; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (character !== closingQuote) {
+      prefix += character;
+      continue;
+    }
+    if (value[index + 1] !== closingQuote) return undefined;
+    prefix += closingQuote;
+    index += 1;
+  }
+  return prefix;
+}
+
+export function resolveSqlServerUseDatabaseCompletion(options: { sql: string; cursor: number; databaseType?: DatabaseType }): SqlServerUseDatabaseCompletion | undefined {
+  if (options.databaseType !== "sqlserver") return undefined;
+  const position = Math.max(0, Math.min(options.cursor, options.sql.length));
+  const statement = currentExecutableStatementRange(options.sql, position, "sqlserver");
+  if (!statement || (statement.to > position && options.sql.slice(position, statement.to).trim())) return undefined;
+
+  const beforeCursor = options.sql.slice(statement.from, position);
+  const useMatch = /^USE(?=\s)/iu.exec(beforeCursor);
+  if (!useMatch) return undefined;
+
+  let targetOffset = useMatch[0].length;
+  while (targetOffset < beforeCursor.length && /\s/u.test(beforeCursor[targetOffset]!)) targetOffset += 1;
+
+  const target = beforeCursor.slice(targetOffset);
+  if (!target) {
+    return {
+      from: statement.from + targetOffset,
+      prefix: "",
+      quoteStyle: "none",
+    };
+  }
+  if (/^[\p{L}_@#][\p{L}\p{N}_@$#]*$/u.test(target)) {
+    return {
+      from: statement.from + targetOffset,
+      prefix: target,
+      quoteStyle: "none",
+    };
+  }
+
+  const quoteStyle = target[0] === "[" ? "bracket" : target[0] === '"' ? "double" : undefined;
+  if (!quoteStyle) return undefined;
+  const prefix = unclosedQuotedIdentifierPrefix(target, quoteStyle);
+  if (prefix === undefined) return undefined;
+  return {
+    from: statement.from + targetOffset + 1,
+    prefix,
+    quoteStyle,
+  };
+}
+
+export function buildSqlServerUseDatabaseCompletionItems(databaseNames: readonly string[], completion: SqlServerUseDatabaseCompletion): SqlCompletionItem[] {
+  return databaseNames.map((database) => {
+    const escapedDatabase = completion.quoteStyle === "double" ? database.replaceAll('"', '""') : database.replaceAll("]", "]]");
+    const apply = completion.quoteStyle === "bracket" ? `${escapedDatabase}]` : completion.quoteStyle === "double" ? `${escapedDatabase}"` : `[${escapedDatabase}]`;
+    return {
+      label: database,
+      filterText: completion.quoteStyle === "none" ? database : escapedDatabase,
+      type: "schema",
+      detail: "database",
+      apply,
+      boost: 1_500,
+    };
+  });
+}
+
+export function resolveSqlCompletionScope(options: { sql: string; cursor: number; databaseType?: DatabaseType; currentDatabase: string; currentSchema?: string; knownDatabases?: readonly string[]; completionContext: SqlCompletionContext }): SqlCompletionScope {
   if (options.databaseType !== "sqlserver") {
     return {
       database: options.currentDatabase,
@@ -65,7 +142,8 @@ export function resolveSqlCompletionScope(options: { sql: string; cursor: number
       completionContext: options.completionContext,
     };
   }
-  const database = sqlServerUseDatabaseBeforeCursor(options.sql, options.cursor);
+  const parsedDatabase = sqlServerUseDatabaseBeforeCursor(options.sql, options.cursor);
+  const database = parsedDatabase && options.knownDatabases !== undefined ? findExactName(options.knownDatabases, parsedDatabase) : parsedDatabase;
   if (!database) {
     return {
       database: options.currentDatabase,

--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -557,9 +557,9 @@ describe("connectionStore completion assistant", () => {
     ]);
   });
 
-  it("searches default SQL Server schemas without treating the username as a schema", async () => {
+  it("searches the server-reported SQL Server default schema without treating the username as a schema", async () => {
     const completionAssistantSearch = vi.fn().mockResolvedValue({
-      candidates: [{ name: "st_area", kind: "function", schema: "dbo", data_type: "float" }],
+      candidates: [{ name: "st_area", kind: "function", schema: "app_user", data_type: "float" }],
       incomplete: false,
       fallback_used: false,
     });
@@ -576,11 +576,11 @@ describe("connectionStore completion assistant", () => {
     store.connections = [sqlServerConnection()];
     store.connectedIds.add("sqlserver-1");
 
-    const objects = await store.listCompletionObjects("sqlserver-1", "app", "st_", 20);
+    const objects = await store.listCompletionObjects("sqlserver-1", "app", "st_", 20, undefined, undefined, false, "app_user");
 
     expect(completionAssistantSearch).toHaveBeenCalledWith(
       expect.objectContaining({
-        schema: null,
+        schema: "app_user",
         parent_schema: null,
         mask: "st_",
       }),
@@ -588,13 +588,67 @@ describe("connectionStore completion assistant", () => {
     expect(objects).toEqual([
       expect.objectContaining({
         name: "st_area",
-        schema: "dbo",
+        schema: "app_user",
         type: "function",
         dataType: "float",
-        applyName: "dbo.st_area",
+        applyName: "app_user.st_area",
         boost: 1000,
       }),
     ]);
+  });
+
+  it("caches SQL Server completion context independently for each database", async () => {
+    const getSqlServerCompletionContext = vi.fn(async (_connectionId: string, database: string) => ({
+      default_schema: database === "BarDB" ? "bar_user" : "foo_user",
+      supports_session_database_switch: true,
+    }));
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      getSqlServerCompletionContext,
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [sqlServerConnection()];
+    store.connectedIds.add("sqlserver-1");
+
+    const foo = await store.getSqlServerCompletionContext("sqlserver-1", "FooDB");
+    const fooCached = await store.getSqlServerCompletionContext("sqlserver-1", "FooDB");
+    const bar = await store.getSqlServerCompletionContext("sqlserver-1", "BarDB");
+
+    expect(foo).toMatchObject({ default_schema: "foo_user" });
+    expect(fooCached).toEqual(foo);
+    expect(bar).toMatchObject({ default_schema: "bar_user" });
+    expect(getSqlServerCompletionContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps SQL Server routine results isolated across databases", async () => {
+    const completionAssistantSearch = vi.fn(async (request: { database: string }) => ({
+      candidates: [{ name: request.database === "BarDB" ? "bar_proc" : "foo_proc", kind: "procedure", schema: "app_user" }],
+      incomplete: false,
+      fallback_used: false,
+    }));
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      completionAssistantSearch,
+      listCompletionObjects: vi.fn().mockResolvedValue([]),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [sqlServerConnection()];
+    store.connectedIds.add("sqlserver-1");
+
+    const foo = await store.listCompletionObjects("sqlserver-1", "FooDB", "", 20, undefined, undefined, false, "app_user");
+    const bar = await store.listCompletionObjects("sqlserver-1", "BarDB", "", 20, undefined, undefined, false, "app_user");
+
+    expect(foo.map((object) => object.name)).toEqual(["foo_proc"]);
+    expect(bar.map((object) => object.name)).toEqual(["bar_proc"]);
+    expect(completionAssistantSearch).toHaveBeenCalledTimes(2);
   });
 
   it("limits concurrent completion column metadata requests per connection database", async () => {

--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -597,6 +597,37 @@ describe("connectionStore completion assistant", () => {
     ]);
   });
 
+  it("prefers an explicit SQL Server routine schema over the current default schema", async () => {
+    const completionAssistantSearch = vi.fn().mockResolvedValue({
+      candidates: [{ name: "calculate_tax", kind: "function", schema: "sales", data_type: "decimal" }],
+      incomplete: false,
+      fallback_used: false,
+    });
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      completionAssistantSearch,
+      listCompletionObjects: vi.fn().mockResolvedValue([]),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [sqlServerConnection()];
+    store.connectedIds.add("sqlserver-1");
+
+    await store.listCompletionObjects("sqlserver-1", "BarDB", "calculate_", 20, "sales", undefined, false, "app_user");
+
+    expect(completionAssistantSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        database: "BarDB",
+        schema: "sales",
+        parent_schema: "sales",
+        mask: "calculate_",
+      }),
+    );
+  });
+
   it("caches SQL Server completion context independently for each database", async () => {
     const getSqlServerCompletionContext = vi.fn(async (_connectionId: string, database: string) => ({
       default_schema: database === "BarDB" ? "bar_user" : "foo_user",

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -10,6 +10,7 @@ import type {
   DatabaseType,
   DatabaseConnectionInfo,
   DatabaseStorageInfo,
+  SqlServerCompletionContext,
   CatalogInfo,
   ForeignKeyInfo,
   ObjectInfo,
@@ -338,6 +339,7 @@ export const useConnectionStore = defineStore("connection", () => {
   const completionColumnsCache = ref<Record<string, ColumnInfo[]>>({});
   const completionForeignKeysCache = ref<Record<string, ForeignKeyInfo[]>>({});
   const completionDatabasesCache = ref<Record<string, string[]>>({});
+  const sqlServerCompletionContextCache = ref<Record<string, SqlServerCompletionContext>>({});
   const elasticsearchCompletionIndicesCache = ref<Record<string, string[]>>({});
   const redisCompletionKeysCache = ref<Record<string, string[]>>({});
   const mongoCompletionCollectionsCache = ref<Record<string, string[]>>({});
@@ -2291,6 +2293,9 @@ export const useConnectionStore = defineStore("connection", () => {
     }
     for (const key of Object.keys(schemaListCache.value)) {
       if (key === exactCacheKey || key.startsWith(cachePrefix)) delete schemaListCache.value[key];
+    }
+    for (const key of Object.keys(sqlServerCompletionContextCache.value)) {
+      if (key === exactCacheKey || key.startsWith(cachePrefix)) delete sqlServerCompletionContextCache.value[key];
     }
     for (const key of Object.keys(elasticsearchCompletionIndicesCache.value)) {
       if (key === exactCacheKey || key.startsWith(cachePrefix)) delete elasticsearchCompletionIndicesCache.value[key];
@@ -5381,7 +5386,7 @@ export const useConnectionStore = defineStore("connection", () => {
     const databaseType = getConfig(connectionId)?.db_type;
     const oracleAssistant = databaseType === "oracle";
     const requestedSchema = currentSchema?.trim() || schema?.trim() || undefined;
-    const preferredSchema = oracleAssistant ? completionPreferredSchema(connectionId, currentSchema) : requestedSchema || (databaseType === "sqlserver" ? "dbo" : databaseType === "postgres" ? "public" : databaseType === "mysql" ? database : undefined);
+    const preferredSchema = oracleAssistant ? completionPreferredSchema(connectionId, currentSchema) : requestedSchema || (databaseType === "postgres" ? "public" : databaseType === "mysql" ? database : undefined);
     const response = await completionAssistantSearch({
       connection_id: connectionId,
       database,
@@ -5627,6 +5632,20 @@ export const useConnectionStore = defineStore("connection", () => {
       },
       { scope: completionLimiterScope(connectionId), kind: "databases" },
     );
+  }
+
+  async function getSqlServerCompletionContext(connectionId: string, database: string): Promise<SqlServerCompletionContext> {
+    const cacheKey = `${connectionId}:${database}`;
+    if (sqlServerCompletionContextCache.value[cacheKey]) {
+      return sqlServerCompletionContextCache.value[cacheKey];
+    }
+    return withCompletionInFlight(`${cacheKey}:sqlserver-completion-context`, async () => {
+      await ensureConnected(connectionId);
+      const context = await api.getSqlServerCompletionContext(connectionId, database);
+      sqlServerCompletionContextCache.value[cacheKey] = context;
+      evictOldestCacheEntries(sqlServerCompletionContextCache.value, COMPLETION_CACHE_MAX);
+      return context;
+    });
   }
 
   async function listCompletionSchemas(connectionId: string, database: string): Promise<string[]> {
@@ -6727,6 +6746,7 @@ export const useConnectionStore = defineStore("connection", () => {
     listCompletionForeignKeys,
     listCompletionSchemas,
     listCompletionDatabases,
+    getSqlServerCompletionContext,
     lookupLocalCompletionTables,
     lookupLocalCompletionObjects,
     lookupLocalCompletionColumns,

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -5385,7 +5385,7 @@ export const useConnectionStore = defineStore("connection", () => {
   ): Promise<SqlCompletionObject[]> {
     const databaseType = getConfig(connectionId)?.db_type;
     const oracleAssistant = databaseType === "oracle";
-    const requestedSchema = currentSchema?.trim() || schema?.trim() || undefined;
+    const requestedSchema = schema?.trim() || currentSchema?.trim() || undefined;
     const preferredSchema = oracleAssistant ? completionPreferredSchema(connectionId, currentSchema) : requestedSchema || (databaseType === "postgres" ? "public" : databaseType === "mysql" ? database : undefined);
     const response = await completionAssistantSearch({
       connection_id: connectionId,

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -370,6 +370,11 @@ export interface DatabaseStorageInfo {
   size_bytes: number | null;
 }
 
+export interface SqlServerCompletionContext {
+  default_schema: string;
+  supports_session_database_switch: boolean;
+}
+
 export interface SchemaInfo {
   name: string;
   comment?: string | null;

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -92,6 +92,55 @@ pub struct SqlServerColumnMetadata {
     pub generated_always_type: i32,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SqlServerCompletionContext {
+    pub default_schema: String,
+    pub supports_session_database_switch: bool,
+}
+
+const SQLSERVER_COMPLETION_CONTEXT_SQL: &str = "\
+    SELECT COALESCE(\
+        (SELECT default_schema.name \
+         FROM sys.schemas default_schema \
+         WHERE default_schema.name = SCHEMA_NAME()), \
+        N'dbo'\
+    ) AS default_schema, \
+    CONVERT(int, SERVERPROPERTY(N'EngineEdition')) AS engine_edition";
+
+fn sqlserver_supports_session_database_switch(engine_edition: i32) -> bool {
+    // Azure SQL Database and Azure Synapse endpoints require callers to open a
+    // connection directly to the target database instead of issuing USE.
+    !matches!(engine_edition, 5 | 6 | 11)
+}
+
+fn sqlserver_completion_context(
+    default_schema: Option<&str>,
+    engine_edition: Option<i32>,
+) -> Result<SqlServerCompletionContext, String> {
+    let default_schema = default_schema.map(str::trim).filter(|schema| !schema.is_empty()).unwrap_or("dbo");
+    let engine_edition = engine_edition.ok_or_else(|| "SQL Server EngineEdition is unavailable".to_string())?;
+    Ok(SqlServerCompletionContext {
+        default_schema: default_schema.to_string(),
+        supports_session_database_switch: sqlserver_supports_session_database_switch(engine_edition),
+    })
+}
+
+pub fn completion_context_sql() -> &'static str {
+    SQLSERVER_COMPLETION_CONTEXT_SQL
+}
+
+pub fn completion_context_from_query_result(result: QueryResult) -> Result<SqlServerCompletionContext, String> {
+    let row = result.rows.first().ok_or_else(|| "SQL Server completion context query returned no rows".to_string())?;
+    let default_schema = row.first().and_then(serde_json::Value::as_str);
+    let engine_edition = row.get(1).and_then(|value| {
+        value
+            .as_i64()
+            .and_then(|value| i32::try_from(value).ok())
+            .or_else(|| value.as_str()?.trim().parse::<i32>().ok())
+    });
+    sqlserver_completion_context(default_schema, engine_edition)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct SqlServerEndpoint<'a> {
     host: &'a str,
@@ -1131,6 +1180,15 @@ pub async fn list_databases(client: &mut SqlServerClient) -> Result<Vec<Database
         .map_err(|e| e.to_string())?;
     let rows = stream.into_first_result().await.map_err(|e| e.to_string())?;
     Ok(rows.iter().map(|row| DatabaseInfo { name: row.get::<&str, _>(0).unwrap_or("").to_string() }).collect())
+}
+
+pub async fn get_completion_context(client: &mut SqlServerClient) -> Result<SqlServerCompletionContext, String> {
+    let stream = client.query(SQLSERVER_COMPLETION_CONTEXT_SQL, &[]).await.map_err(|e| e.to_string())?;
+    let rows = stream.into_first_result().await.map_err(|e| e.to_string())?;
+    let row = rows.first().ok_or_else(|| "SQL Server completion context query returned no rows".to_string())?;
+    let default_schema = row.try_get::<&str, _>(0).map_err(|e| e.to_string())?;
+    let engine_edition = row.try_get::<i32, _>(1).map_err(|e| e.to_string())?;
+    sqlserver_completion_context(default_schema, engine_edition)
 }
 
 pub async fn test_connection(client: &mut SqlServerClient) -> Result<(), String> {
@@ -2483,17 +2541,18 @@ fn first_sql_tokens(sql: &str, limit: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_sqlserver_unsafe_type_query, capture_sqlserver_messages, format_sqlserver_numeric,
-        is_blocking_sqlserver_unsafe_probe_error, is_sqlserver_spatial_column, is_sqlserver_variant_column,
-        query_result_with_server_messages, requires_simple_query_batch, restore_sqlserver_legacy_probe_output_names,
-        sqlserver_batch_can_use_execute, sqlserver_bulk_token_row, sqlserver_cell_to_json, sqlserver_columns_sql,
-        sqlserver_completion_assistant_sql, sqlserver_dml_output_returns_rows, sqlserver_filter_definition_error,
-        sqlserver_hidden_schema_names, sqlserver_indexes_sql, sqlserver_legacy_indexes_sql, sqlserver_legacy_probe,
-        sqlserver_legacy_probe_with_nonce, sqlserver_list_objects_sql, sqlserver_list_schemas_sql,
-        sqlserver_list_tables_sql, sqlserver_probe_explicit_alias, sqlserver_schema_name_predicate,
+        build_sqlserver_unsafe_type_query, capture_sqlserver_messages, completion_context_from_query_result,
+        format_sqlserver_numeric, is_blocking_sqlserver_unsafe_probe_error, is_sqlserver_spatial_column,
+        is_sqlserver_variant_column, query_result_with_server_messages, requires_simple_query_batch,
+        restore_sqlserver_legacy_probe_output_names, sqlserver_batch_can_use_execute, sqlserver_bulk_token_row,
+        sqlserver_cell_to_json, sqlserver_columns_sql, sqlserver_completion_assistant_sql,
+        sqlserver_dml_output_returns_rows, sqlserver_filter_definition_error, sqlserver_hidden_schema_names,
+        sqlserver_indexes_sql, sqlserver_legacy_indexes_sql, sqlserver_legacy_probe, sqlserver_legacy_probe_with_nonce,
+        sqlserver_list_objects_sql, sqlserver_list_schemas_sql, sqlserver_list_tables_sql,
+        sqlserver_probe_explicit_alias, sqlserver_schema_name_predicate, sqlserver_supports_session_database_switch,
         sqlserver_table_comment_sql, sqlserver_triggers_sql, sqlserver_visible_object_predicate,
         strip_dbx_sqlserver_row_number_column, SqlServerDescribedColumn, SqlServerProbeOutputNameOverride,
-        SqlServerResultSet, SQLSERVER_RESULT_TYPE_PROBE_SQL,
+        SqlServerResultSet, SQLSERVER_COMPLETION_CONTEXT_SQL, SQLSERVER_RESULT_TYPE_PROBE_SQL,
     };
     use crate::types::{
         CompletionAssistantMatchMode, CompletionAssistantObjectKind, CompletionAssistantRequest, QueryResult,
@@ -2941,6 +3000,43 @@ mod tests {
         );
         assert!(sqlserver_list_tables_sql("", None, None, None).contains(&predicate));
         assert!(sqlserver_columns_sql("\t", "orders").contains(&predicate));
+    }
+
+    #[test]
+    fn sqlserver_completion_context_uses_the_database_user_default_schema() {
+        assert!(SQLSERVER_COMPLETION_CONTEXT_SQL.contains("SCHEMA_NAME()"));
+        assert!(SQLSERVER_COMPLETION_CONTEXT_SQL.contains("sys.schemas"));
+        assert!(SQLSERVER_COMPLETION_CONTEXT_SQL.contains("N'dbo'"));
+        assert!(SQLSERVER_COMPLETION_CONTEXT_SQL.contains("EngineEdition"));
+    }
+
+    #[test]
+    fn sqlserver_completion_context_disables_use_for_azure_database_endpoints() {
+        assert!(!sqlserver_supports_session_database_switch(5));
+        assert!(!sqlserver_supports_session_database_switch(6));
+        assert!(!sqlserver_supports_session_database_switch(11));
+        assert!(sqlserver_supports_session_database_switch(3));
+        assert!(sqlserver_supports_session_database_switch(8));
+    }
+
+    #[test]
+    fn sqlserver_completion_context_parses_agent_query_results() {
+        let context = completion_context_from_query_result(QueryResult {
+            columns: vec!["default_schema".to_string(), "engine_edition".to_string()],
+            column_types: vec![],
+            column_sortables: vec![],
+            rows: vec![vec![serde_json::json!("app_user"), serde_json::json!("8")]],
+            affected_rows: 0,
+            execution_time_ms: 0,
+            truncated: false,
+            session_id: None,
+            has_more: false,
+            elasticsearch_raw_body: None,
+        })
+        .unwrap();
+
+        assert_eq!(context.default_schema, "app_user");
+        assert!(context.supports_session_database_switch);
     }
 
     #[test]

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -108,9 +108,10 @@ const SQLSERVER_COMPLETION_CONTEXT_SQL: &str = "\
     CONVERT(int, SERVERPROPERTY(N'EngineEdition')) AS engine_edition";
 
 fn sqlserver_supports_session_database_switch(engine_edition: i32) -> bool {
-    // Azure SQL Database and Azure Synapse endpoints require callers to open a
-    // connection directly to the target database instead of issuing USE.
-    !matches!(engine_edition, 5 | 6 | 11)
+    // Only known boxed SQL Server, Managed Instance, and SQL Edge editions are
+    // allowed to switch databases. Cloud single-database endpoints and future
+    // editions default to opening a connection directly to the target database.
+    matches!(engine_edition, 1 | 2 | 3 | 4 | 8 | 9)
 }
 
 fn sqlserver_completion_context(
@@ -3015,8 +3016,11 @@ mod tests {
         assert!(!sqlserver_supports_session_database_switch(5));
         assert!(!sqlserver_supports_session_database_switch(6));
         assert!(!sqlserver_supports_session_database_switch(11));
+        assert!(!sqlserver_supports_session_database_switch(12));
+        assert!(!sqlserver_supports_session_database_switch(99));
         assert!(sqlserver_supports_session_database_switch(3));
         assert!(sqlserver_supports_session_database_switch(8));
+        assert!(sqlserver_supports_session_database_switch(9));
     }
 
     #[test]

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -235,6 +235,55 @@ pub async fn list_sqlserver_linked_servers_core(
     Ok(vec![])
 }
 
+pub async fn get_sqlserver_completion_context_core(
+    state: &AppState,
+    connection_id: &str,
+    database: &str,
+) -> Result<db::sqlserver::SqlServerCompletionContext, String> {
+    retry_metadata_connection(state, connection_id, Some(database), || async {
+        let pool_key = state.get_or_create_pool(connection_id, Some(database)).await?;
+        let db_config = connection_config(state, connection_id).await;
+        let connections = state.connections.read().await;
+        if let Some(PoolKind::ExternalDriver { config, session, .. }) = connections.get(&pool_key) {
+            let config = config.clone();
+            let session = session.clone();
+            drop(connections);
+            let result: db::QueryResult = session
+                .invoke_with_timeout(
+                    "executeQuery",
+                    serde_json::json!({
+                        "connection": config.as_ref(),
+                        "database": database,
+                        "sql": db::sqlserver::completion_context_sql(),
+                        "maxRows": 1
+                    }),
+                    agent_metadata_timeout(Some(config.as_ref())),
+                )
+                .await?;
+            return db::sqlserver::completion_context_from_query_result(result);
+        }
+        try_sqlserver!(connections, &pool_key, get_completion_context);
+        if let Some(client) = extract_pool!(&connections, &pool_key, Agent) {
+            drop(connections);
+            let mut client = client.lock().await;
+            let result = client
+                .execute_query_with_timeout::<db::QueryResult>(
+                    agent_execute_query_params(
+                        db::sqlserver::completion_context_sql(),
+                        if database.is_empty() { None } else { Some(database) },
+                        None,
+                        QueryExecutionOptions { max_rows: Some(1), ..Default::default() },
+                    ),
+                    agent_metadata_timeout(db_config.as_ref()),
+                )
+                .await?;
+            return db::sqlserver::completion_context_from_query_result(result);
+        }
+        Err("SQL Server completion context requires a SQL Server connection".to_string())
+    })
+    .await
+}
+
 pub async fn list_sqlserver_linked_server_catalogs_core(
     state: &AppState,
     connection_id: &str,

--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -344,6 +344,7 @@ async fn main() {
         // Schema
         .route("/schema/databases", get(routes::schema::list_databases))
         .route("/schema/database-storage", post(routes::schema::list_database_storage))
+        .route("/schema/sqlserver/completion-context", get(routes::schema::get_sqlserver_completion_context))
         .route("/schema/doris/catalogs", get(routes::schema::list_doris_catalogs))
         .route("/schema/doris/catalog-databases", get(routes::schema::list_doris_catalog_databases))
         .route("/schema/sqlserver/linked-servers", get(routes::schema::list_sqlserver_linked_servers))

--- a/crates/dbx-web/src/routes/schema.rs
+++ b/crates/dbx-web/src/routes/schema.rs
@@ -52,6 +52,17 @@ pub async fn list_database_storage(
     Ok(Json(result))
 }
 
+pub async fn get_sqlserver_completion_context(
+    State(state): State<Arc<WebState>>,
+    Query(q): Query<SchemaQuery>,
+) -> Result<Json<dbx_core::db::sqlserver::SqlServerCompletionContext>, AppError> {
+    let database = q.database.as_deref().unwrap_or("");
+    let result = dbx_core::schema::get_sqlserver_completion_context_core(&state.app, &q.connection_id, database)
+        .await
+        .map_err(AppError::from)?;
+    Ok(Json(result))
+}
+
 /// Resolve a non-internal catalog for dispatch to the Doris multi-catalog path.
 async fn external_doris_catalog(state: &Arc<WebState>, connection_id: &str, catalog: Option<&str>) -> Option<String> {
     dbx_core::schema::resolve_external_doris_catalog(&state.app, connection_id, catalog).await

--- a/src-tauri/src/commands/schema.rs
+++ b/src-tauri/src/commands/schema.rs
@@ -29,6 +29,15 @@ pub async fn list_database_storage(
 }
 
 #[tauri::command]
+pub async fn get_sqlserver_completion_context(
+    state: State<'_, Arc<AppState>>,
+    connection_id: String,
+    database: String,
+) -> Result<db::sqlserver::SqlServerCompletionContext, String> {
+    dbx_core::schema::get_sqlserver_completion_context_core(&state, &connection_id, &database).await
+}
+
+#[tauri::command]
 pub async fn list_doris_catalogs(
     state: State<'_, Arc<AppState>>,
     connection_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1633,6 +1633,7 @@ pub fn run() {
             commands::plugins::uninstall_jdbc_plugin,
             commands::schema::list_databases,
             commands::schema::list_database_storage,
+            commands::schema::get_sqlserver_completion_context,
             commands::schema::list_doris_catalogs,
             commands::schema::list_doris_catalog_databases,
             commands::schema::list_sqlserver_linked_servers,


### PR DESCRIPTION
## 变更说明

- SQL Server 编辑器会读取光标所在语句之前最近一条可解析的 `USE database`，并以该数据库作为未限定对象的补全范围。
- 在当前 `USE `、`USE Bar`、`USE [Bar` 等输入位置直接联想连接中可用的数据库；接受候选时按 T-SQL 标识符规则补全括号与转义。
- 前置 `USE` 的数据库名会与连接中的已知数据库做不区分大小写的精确校验：命中时使用真实名称并默认补全 `dbo`；数据库不存在或无法确认时，回退到右上角当前选择的 Database/Schema。
- 显式 Database/Schema 限定仍保持最高优先级。
- 表、视图、列、外键与 INSERT 补全缓存按实际 Database/Schema 隔离，避免跨库元数据泄漏。
- 注释、字符串、光标当前语句及光标之后的 `USE` 不会改变后续语句的补全范围；没有前置 `USE` 时继续使用右上角选择值。

## 根因

原实现只在后续 SQL 补全时解析前置 `USE`，但 `USE` 本身不是表名补全上下文，因此不会触发数据库候选加载；同时解析出的数据库名未经存在性校验，导致无效的 `USE [MissingDB]` 也会覆盖右上角选择的数据库。

## 范围说明

本次仅启用 SQL Server。Trino/Presto 的三段式名称使用 Catalog/Schema/Table，且不采用 T-SQL `USE [database]` 语义；若一起修改，需要单独定义 Catalog 切换及无效 Catalog 的回退规则，因此不在本 PR 中扩大范围。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及编辑器补全改动
- [x] 已使用 SQL Server 实际连接手动验证

验证场景：

- 输入 `USE ` 能展示数据库候选，并可按前缀过滤。
- 有效的 `USE [BarDB]` 使后续未限定对象从 `BarDB.dbo` 补全。
- 无效的 `USE [MissingDB]` 使后续补全回退到右上角选择的 Database/Schema。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] `pnpm check` 通过（format、lint、typecheck、全量 Vitest）
- [x] `sqlCompletionLookupTarget.spec.ts`：29 项通过
- [x] SQL Server 实际连接手动验证通过

## 关联 Issue

Fixes #1570
