### PR TITLE
fix(mysql): handle nullable view collation

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -142,8 +142,10 @@ fn nonblank(value: String) -> Option<String> {
 }
 
 async fn query_first_nonblank_string(conn: &mut mysql_async::Conn, sql: &str) -> Option<String> {
-    match conn.query_first::<String, _>(sql).await {
-        Ok(Some(value)) => nonblank(value),
+    // MySQL reports nullable metadata such as TABLE_COLLATION as NULL for views.
+    // Reading it as String makes mysql_async panic during row conversion.
+    match conn.query_first::<Option<String>, _>(sql).await {
+        Ok(Some(value)) => value.and_then(nonblank),
         Ok(None) => None,
         Err(error) => {
             log::debug!("Failed to read optional MySQL database information with `{sql}`: {error}");
@@ -4949,6 +4951,14 @@ mod tests {
         assert!(sql.contains("COLUMN_TYPE"));
         assert!(!sql.contains("COLLATE"));
         assert!(!sql.contains("AS ENUM_VALUES"));
+    }
+
+    #[test]
+    fn mysql_nullable_table_collation_uses_optional_string_conversion() {
+        let collation = mysql_async::from_value_opt::<Option<String>>(mysql_async::Value::NULL)
+            .expect("Option<String> must accept NULL MySQL metadata values");
+
+        assert_eq!(collation, None);
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复打开 MySQL 视图后加载元数据时可能发生的崩溃。

MySQL 会为视图返回 `NULL` 的 `TABLE_COLLATION`。此前代码将该值直接转换为 `String`，导致 `mysql_async` 在转换空值时发生 panic。现在使用 `Option<String>` 读取可空元数据，因此视图能够正常加载。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过


## 关联 Issue

Close #4967
