### PR TITLE
fix(mcp): 修复 Linux 下 MCP 服务启动崩溃与找不到数据库的问题

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -363,9 +363,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfontconfig1-dev
 
+      - name: Setup Python for cargo-zigbuild
+        if: runner.os == 'Linux'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install zig and cargo-zigbuild
+        if: runner.os == 'Linux'
+        run: pip install ziglang==0.14.0 cargo-zigbuild==0.23.0
+
       - name: Build Rust CLI binary
         shell: bash
-        run: cargo build --release -p dbx-cli --no-default-features --target "${{ matrix.target }}"
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release -p dbx-cli --no-default-features --target "${{ matrix.target }}.2.31"
+          else
+            cargo build --release -p dbx-cli --no-default-features --target "${{ matrix.target }}"
+          fi
 
       - name: Stage platform package
         shell: bash
@@ -538,9 +553,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libfontconfig1-dev
 
+      - name: Setup Python for cargo-zigbuild
+        if: runner.os == 'Linux'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install zig and cargo-zigbuild
+        if: runner.os == 'Linux'
+        run: pip install ziglang==0.14.0 cargo-zigbuild==0.23.0
+
       - name: Build Rust MCP binary
         shell: bash
-        run: cargo build --release -p dbx-mcp --target "${{ matrix.target }}"
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cargo zigbuild --release -p dbx-mcp --target "${{ matrix.target }}.2.31"
+          else
+            cargo build --release -p dbx-mcp --target "${{ matrix.target }}"
+          fi
 
       - name: Stage platform package
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,6 +1763,7 @@ version = "0.4.48"
 dependencies = [
  "async-trait",
  "dbx-core",
+ "dirs",
  "reqwest 0.12.28",
  "rmcp",
  "schemars 1.2.1",

--- a/crates/dbx-mcp/Cargo.toml
+++ b/crates/dbx-mcp/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 async-trait = "0.1"
 dbx-core = { path = "../dbx-core", default-features = false }
+dirs = "6"
 rmcp = { version = "2.2.0", features = ["client", "transport-io"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 schemars = "1"

--- a/crates/dbx-mcp/src/paths.rs
+++ b/crates/dbx-mcp/src/paths.rs
@@ -2,27 +2,16 @@ use std::path::PathBuf;
 
 pub const STORAGE_DB_FILE_NAME: &str = "dbx.db";
 
+/// Mirrors `dirs::data_dir()` (same call the Tauri desktop app makes) so MCP/CLI and the desktop
+/// app resolve the same `dbx.db`, including under `XDG_DATA_HOME` on Linux.
 pub fn app_data_dir() -> Result<PathBuf, String> {
     if let Some(path) = std::env::var_os("DBX_DATA_DIR").filter(|value| !value.is_empty()) {
         return Ok(PathBuf::from(path));
     }
 
-    let home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .map(PathBuf::from)
-        .ok_or_else(|| "Unable to resolve the user home directory. Set DBX_DATA_DIR explicitly.".to_string())?;
-
-    #[cfg(target_os = "macos")]
-    return Ok(home.join("Library/Application Support/com.dbx.app"));
-
-    #[cfg(target_os = "windows")]
-    return Ok(std::env::var_os("APPDATA")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join("AppData/Roaming"))
-        .join("com.dbx.app"));
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    return Ok(home.join(".local/share/com.dbx.app"));
+    let base = dirs::data_dir()
+        .ok_or_else(|| "Unable to resolve the user data directory. Set DBX_DATA_DIR explicitly.".to_string())?;
+    Ok(base.join("com.dbx.app"))
 }
 
 pub fn storage_db_path() -> Result<PathBuf, String> {


### PR DESCRIPTION
## 变更说明

修复 Linux 环境下 DBX MCP 服务的两个问题：

1. **MCP 二进制启动崩溃**：发布的 linux-x64/arm64 二进制在 ubuntu-24.04 上构建，绑定了 GLIBC_2.38（gcc 14 的 `__isoc23_*` 符号）和 GLIBC_2.39（Rust std 的 pidfd 弱符号），在 glibc 2.38 的系统（如 Deepin 25）上无法加载，MCP 启动即崩溃，客户端报 `-32000`。
   - 改用 `cargo zigbuild` 构建 Linux 目标，目标 glibc 锁定 2.31（ziglang 0.14.0 / cargo-zigbuild 0.23.0），将 glibc 下限降至 2.30，兼容 Ubuntu 20.04+/Debian 11+。
   - macOS / Windows 仍走原有 `cargo build`，不受影响。

2. **MCP 找不到桌面端创建的数据库**：`dbx_mcp::paths::app_data_dir()` 硬编码 `~/.local/share/com.dbx.app`，从不读取 `XDG_DATA_HOME`；而 Tauri 桌面端通过 `dirs::data_dir()` 解析（遵循 `XDG_DATA_HOME`）。Linux 用户设置非默认 `XDG_DATA_HOME` 时两者错位，MCP 打开的是空库而非桌面端建好的库。
   - 改用 `dirs::data_dir()`（与 Tauri `app_data_dir()` 同源）解析基目录，确保 MCP/CLI 与桌面端在各平台解析到同一个 `dbx.db`。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [x] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

无前端改动。

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

验证详情：
- `cargo check -p dbx-mcp --no-default-features` 通过
- `cargo test -p dbx-mcp --no-default-features paths` 通过（`explicit_data_dir_wins` 无回归）
- glibc 修复：本地用 cargo-zigbuild（glibc 2.31）构建后，二进制最高 glibc 要求从 `GLIBC_2.39` 降至 `GLIBC_2.30`；在 Deepin 25（glibc 2.38）上启动正常，无 `GLIBC_2.39 not found`
- 数据目录修复：独立 crate 实测 `dirs::data_dir()` 在无 `XDG_DATA_HOME` 时解析到 `~/.local/share/com.dbx.app`（与改前一致），设置 `XDG_DATA_HOME=/opt/custom-xdg` 时跟随到 `/opt/custom-xdg/com.dbx.app`（与桌面端一致）

## 关联 Issue

Closes #4473 