### PR TITLE
feat(grid): add show by comment option for copy column names (#4223)

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -9381,7 +9381,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
     <DataGridBulkEditDialog v-if="bulkEditDialogMounted" v-model:open="bulkEditDialogOpen" v-model:value="bulkEditValue" :selected-cell-count="selectedCellCount" @apply="applyBulkEditValue" />
 
     <DataGridExtractorDialog v-model:open="extractorConfigOpen" :extractor="selectedCopyExtractor" :options="settingsStore.editorSettings.dataGridExtractorOptions" :items="extractorMenuItems" :preview="previewWithExtractor" @save="saveExtractorConfiguration" />
-    <DataGridCopyColumnNamesDialog v-if="copyColumnNamesDialogMounted" v-model:open="copyColumnNamesDialogOpen" :column-names="copyColumnNamesDialogColumns" :database-type="resolvedDatabaseType" @copy="copyText" />
+    <DataGridCopyColumnNamesDialog v-if="copyColumnNamesDialogMounted" v-model:open="copyColumnNamesDialogOpen" :column-names="copyColumnNamesDialogColumns" :database-type="resolvedDatabaseType" :column-comments="columnCommentMap" @copy="copyText" />
 
     <Dialog v-model:open="generateIncrementDialogOpen">
       <DialogContent class="sm:max-w-[380px]">

--- a/apps/desktop/src/components/grid/DataGridCopyColumnNamesDialog.vue
+++ b/apps/desktop/src/components/grid/DataGridCopyColumnNamesDialog.vue
@@ -11,22 +11,25 @@ import type { DatabaseType } from "@/types/database";
 
 const { t } = useI18n();
 const open = defineModel<boolean>("open", { default: false });
-const props = defineProps<{ columnNames: string[]; databaseType?: DatabaseType }>();
+const props = defineProps<{ columnNames: string[]; databaseType?: DatabaseType; columnComments?: Map<string, string> }>();
 const emit = defineEmits<{ copy: [text: string] }>();
 
 const separator = ref<ColumnNameCopySeparator>(loadColumnNameCopySeparator());
 const quote = ref(false);
+const showByComment = ref(false);
 
 // 每次打开时重新读取上次分隔符选择；转义选项每次默认关闭
 watch(open, (value) => {
   if (!value) return;
   separator.value = loadColumnNameCopySeparator();
   quote.value = false;
+  showByComment.value = false;
 });
 
 const showQuoteOption = computed(() => supportsColumnNameQuoting(props.databaseType));
+const showCommentOption = computed(() => !!(props.columnComments && props.columnComments.size > 0));
 
-const previewText = computed(() => formatColumnNamesForCopy(props.columnNames, { separator: separator.value, quote: quote.value, databaseType: props.databaseType }));
+const previewText = computed(() => formatColumnNamesForCopy(props.columnNames, { separator: separator.value, quote: quote.value, databaseType: props.databaseType, showByComment: showByComment.value, commentByColumn: props.columnComments }));
 
 function onSeparatorChange(value: unknown) {
   if (isColumnNameCopySeparator(value)) separator.value = value;
@@ -60,6 +63,10 @@ function confirmCopy() {
         <div v-if="showQuoteOption" class="flex items-center justify-between gap-3">
           <Label class="shrink-0 text-sm" for="copy-column-names-quote">{{ t("grid.copyColumnNamesQuote") }}</Label>
           <Switch id="copy-column-names-quote" v-model="quote" />
+        </div>
+        <div v-if="showCommentOption" class="flex items-center justify-between gap-3">
+          <Label class="shrink-0 text-sm" for="copy-column-names-comment">{{ t("grid.copyColumnNamesShowComment") }}</Label>
+          <Switch id="copy-column-names-comment" v-model="showByComment" />
         </div>
         <div class="space-y-1.5">
           <Label class="text-sm">{{ t("grid.copyColumnNamesPreview") }}</Label>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1090,6 +1090,7 @@ export default {
     copyColumnNamesTitle: "Copy Column Names ({count})",
     copyColumnNamesSeparator: "Column Separator",
     copyColumnNamesQuote: "Quote Column Names",
+    copyColumnNamesShowComment: "Show by Comment",
     copyColumnNamesPreview: "Preview",
     copyAll: "Copy All (TSV)",
     selectionSum: "SUM: {value}",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1091,6 +1091,7 @@ export default withEnglishFallback({
     copyColumnNamesTitle: "复制列名（{count} 列）",
     copyColumnNamesSeparator: "列分隔符",
     copyColumnNamesQuote: "转义列名",
+    copyColumnNamesShowComment: "按注释显示",
     copyColumnNamesPreview: "预览",
     copyAll: "复制全部 (TSV)",
     selectionSum: "SUM: {value}",

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnNameCopy.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnNameCopy.ts
@@ -37,9 +37,10 @@ export function columnNamesForCopy(allColumnNames: readonly string[], visibleCol
   return [...(scope === "all" ? allColumnNames : visibleColumnNames)];
 }
 
-export function formatColumnNamesForCopy(names: readonly string[], options: { separator: ColumnNameCopySeparator; quote?: boolean; databaseType?: DatabaseType }): string {
+export function formatColumnNamesForCopy(names: readonly string[], options: { separator: ColumnNameCopySeparator; quote?: boolean; databaseType?: DatabaseType; showByComment?: boolean; commentByColumn?: Map<string, string> }): string {
   const quote = !!options.quote && supportsColumnNameQuoting(options.databaseType);
-  const parts = quote ? names.map((name) => quoteTableIdentifier(options.databaseType, name)) : [...names];
+  const displayNames = options.showByComment && options.commentByColumn ? names.map((name) => options.commentByColumn!.get(name) || name) : [...names];
+  const parts = quote ? displayNames.map((name) => quoteTableIdentifier(options.databaseType, name)) : displayNames;
   return parts.join(COLUMN_NAME_COPY_SEPARATOR_VALUES[options.separator]);
 }
 


### PR DESCRIPTION
## 变更说明

在"复制全部列名"对话框中新增"按注释显示"开关，位于"转义列名"下方。开启后，复制列名时字段名会被替换为对应的数据库注释文本，无注释则回退显示原始列名。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过
  - `dataGridColumnNameCopy.spec.ts` - 8 tests passed
  - `DataGridSurfaces.spec.ts` > `DataGridCopyColumnNamesDialog` - 2 tests passed

## 关联 Issue

Refs #4223
