### PR TITLE
fix(editor): reuse existing data tab on Ctrl+Click table navigation

### DIFF
--- a/apps/desktop/src/composables/__tests__/useNavigationTargets.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useNavigationTargets.spec.ts
@@ -80,9 +80,13 @@ vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({ editorSettings: { reuseDataTab: true } }),
 }));
 
-vi.mock("@/lib/table/tableSelectSql", () => ({
-  buildTableSelectSql: async ({ tableName }: { tableName: string }) => `SELECT * FROM ${tableName}`,
-}));
+vi.mock("@/lib/table/tableSelectSql", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/table/tableSelectSql")>();
+  return {
+    ...actual,
+    buildTableSelectSql: async ({ tableName }: { tableName: string }) => `SELECT * FROM ${tableName}`,
+  };
+});
 
 const dialogs = {
   showFieldLineageDialog: { value: false },

--- a/apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts
@@ -131,6 +131,22 @@ describe("useNavigationTargets with the real query store", () => {
     expect(queryStore.tabs.map((tab) => tab.sql)).toEqual(['SELECT * FROM users WHERE "id" = 1', 'SELECT * FROM users WHERE "id" = 2']);
   });
 
+  it("reuses an existing same-table tab instead of opening a new one", async () => {
+    const { navigation, queryStore } = await setupNavigation();
+    const target = { connectionId: "connection-1", database: "app", schema: "public", tableName: "users" };
+
+    await navigation.openTableTarget(target);
+    expect(queryStore.tabs).toHaveLength(1);
+    const firstTabId = queryStore.tabs[0]!.id;
+    expect(queryStore.tabs[0]!.result).toBeDefined();
+
+    await navigation.openTableTarget(target);
+
+    expect(queryStore.tabs).toHaveLength(1);
+    expect(queryStore.tabs[0]!.id).toBe(firstTabId);
+    expect(queryStore.activeTabId).toBe(firstTabId);
+  });
+
   it("creates a new target tab even when the same table was restored", async () => {
     mocks.loadOpenTabsState.mockResolvedValue({
       tabs: [

--- a/apps/desktop/src/composables/useNavigationTargets.ts
+++ b/apps/desktop/src/composables/useNavigationTargets.ts
@@ -1,12 +1,13 @@
 import * as api from "@/lib/backend/api";
 import { connectionObjectTreeNodeSchema, effectiveDatabaseTypeForConnection, metadataSchemaForConnection } from "@/lib/database/jdbcDialect";
 import { invalidateTableMetadataCache, loadTableMetadata } from "@/lib/metadata/tableMetadataCache";
-import { canApplyDataTabMetadata } from "@/lib/sidebar/dataTabOpenPolicy";
+import { canApplyDataTabMetadata, findExistingDataTabCandidate } from "@/lib/sidebar/dataTabOpenPolicy";
 import { isNoSnapshotErrorResult } from "@/lib/query/queryResultError";
-import { buildTableSelectSql } from "@/lib/table/tableSelectSql";
+import { buildTableSelectSql, normalizeWhereInput } from "@/lib/table/tableSelectSql";
 import { editableRowIdentifierColumns, usesSyntheticRowIdKey } from "@/lib/table/tableEditing";
 import { tableOpenPageLimit } from "@/lib/table/tableOpenPageLimit";
 import { uuid } from "@/lib/common/utils";
+import { canActivateExistingDataTableTab } from "@/lib/tabs/dataTabActivation";
 import { beginDataTabNavigation, endDataTabNavigation, isCurrentDataTabNavigation } from "@/lib/tabs/dataTabNavigationGeneration";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
@@ -38,6 +39,26 @@ async function openTableTarget(target: NavigationTarget, options: { tableInfoTab
     await connectionStore.ensureConnected(target.connectionId);
     const tabId = queryStore.createTab(target.connectionId, target.database || "default", tabTitle, "vector");
     queryStore.updateSql(tabId, target.tableName);
+    return;
+  }
+  // 复用已打开的同一张表标签页（受 reuseDataTab 设置控制，同表匹配不受其控制）。
+  // 仅当同表 + 相同 whereInput + 标签页已成功加载过数据时复用：canActivateExistingDataTableTab
+  // 对无 result 的标签页返回 false，天然排除持久化恢复的空标签页（避免覆盖恢复的查询）。
+  const dataTabTarget = {
+    connectionId: target.connectionId,
+    database: target.database,
+    schema: tableSchema,
+    catalog: target.catalog,
+    tableName: target.tableName,
+  };
+  const existingCandidate = findExistingDataTabCandidate(queryStore.tabs, dataTabTarget, {
+    openMode: "default",
+    reuseDataTab: settingsStore.editorSettings.reuseDataTab,
+  });
+  const normalizedWhere = normalizeWhereInput(target.whereInput);
+  const existingSameTableTab = existingCandidate?.match === "same-table" && normalizeWhereInput(existingCandidate.tab.whereInput) === normalizedWhere ? existingCandidate.tab : undefined;
+  if (existingSameTableTab && canActivateExistingDataTableTab(existingSameTableTab, { activateExecuting: false })) {
+    queryStore.switchTab(existingSameTableTab.id);
     return;
   }
   const tabId = queryStore.createTab(target.connectionId, target.database, tabTitle, "data", tableSchema, undefined, undefined, { forceNew: true });


### PR DESCRIPTION
## 变更说明

修复编辑器 Ctrl+Click 表名、对象页面（ObjectBrowser）打开表时不复用已打开的同一张表标签页的问题——即使已开启"复用数据标签页"设置也会重复新建标签页。#4976

**根因**：`openTableTarget`（`useNavigationTargets.ts`）调用 `createTab(..., { forceNew: true })` 强制新建标签页，绕过了复用逻辑；而侧边栏的 `openData` 正常使用 `findExistingDataTabCandidate` 查找并复用。

**修复**：在 `createTab` 之前用 `findExistingDataTabCandidate` 查找已存在的同表标签页，满足条件时直接 `switchTab` 激活而非新建：

- 同表匹配（`same-table`，与侧边栏一致，不受 `reuseDataTab` 控制）
- 相同 `whereInput`（用 `normalizeWhereInput` 比对，不同过滤条件仍新建标签页）
- 标签页已成功加载过数据（`canActivateExistingDataTableTab`，天然排除持久化恢复的空标签页，避免覆盖恢复的查询）

复用时仅激活不重查，与侧边栏点击已打开表的行为一致。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

**手动验证步骤：**

1. 开启设置 → 编辑器 → "复用数据标签页"
2. 侧边栏打开表 A → 出现表 A 数据标签页（有数据）
3. 在 SQL 编辑器中 Ctrl+点击表 A 名 → 应激活已有标签页，不新建
4. 对象页面双击表 A → 应激活已有标签页
5. Ctrl+点击另一张表 B → 应新建标签页（不同表）
6. Ctrl+点击同表但带不同 whereInput 的查询场景 → 应新建标签页（不同过滤条件）

**单元测试：**

- `useNavigationTargets.store.spec.ts` 新增 `reuses an existing same-table tab instead of opening a new one`
- 现有测试全部继续通过：
  - `creates a new target tab even when the same table was restored`（持久化恢复的空标签页不复用）
  - `opens same-table search results with different predicates in separate tabs`（不同 whereInput 新建）
  - `keeps concurrent same-table opens independent`（并发同表不同 whereInput 独立）

## 关联 Issue

#4976