### PR TITLE
feat(metadata): 表对象元数据持久化缓存与按标签懒加载

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1510,6 +1510,7 @@ async function onOpenObjectSource(table: SqlObjectNavigationTarget, initialEditi
 function onQueryEditorObjectSourceSaved() {
   const target = queryEditorObjectSourceTarget.value;
   if (!target) return;
+  connectionStore.invalidateMetadataCache(target.connectionId, target.database, target.schema, target.name);
   connectionStore.invalidateCompletionCache(target.connectionId, target.database);
   contentAreaRef.value?.refreshQueryEditorCompletionCache();
 }

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -46,8 +46,8 @@ import { buildElasticsearchCompletionItemsFromContext, getElasticsearchCompletio
 import { buildMongoCompletionItemsFromContext, getMongoCompletionContext, getMongoCompletionResultValidFor, mongoCompletionNeedsCollections, mongoCompletionNeedsFields, shouldAutoOpenMongoCompletion, type MongoCompletionItem } from "@/lib/mongo/mongoCompletion";
 import { mergeSqlCompletionQualifierNames, resolveSqlCompletionRoutineLookupTarget, resolveSqlCompletionSchemaLookupDatabase, resolveSqlCompletionTableLookupTarget } from "@/lib/sql/sqlCompletionLookupTarget";
 import { usesOracleSessionCompletionColumns as shouldUseOracleSessionCompletionColumns } from "@/lib/sql/oracleCompletionSession";
-import { extractIdentifierDetailsAt, isSqlKeyword, matchTable, mergeSqlObjectNavigationType, splitQualifiedIdentifier, sqlObjectHoverDetail, sqlObjectNavigationTarget, type SqlObjectNavigationTarget } from "@/lib/sql/sqlNavigation";
-import { buildHoverTableSql, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
+import { extractIdentifierDetailsAt, isSqlKeyword, matchTable, mergeSqlObjectNavigationType, splitQualifiedIdentifier, sqlObjectHoverDetail, sqlObjectNavigationSourceKind, sqlObjectNavigationTarget, type SqlObjectNavigationTarget } from "@/lib/sql/sqlNavigation";
+import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
 import { lineColumnToOffset, parseSqlErrorLocation } from "@/lib/sql/sqlDiagnostics";
 import {
   DBX_TABLE_REFERENCE_MIME,
@@ -80,7 +80,8 @@ import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
 import { isSchemaAware, isSingleDatabase, supportsDatabaseNameCompletion, supportsDatabaseSchemaQualifier, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
 import { metadataSchemaForConnection, sqlSnippetDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 import { usesLocalOnlyEditorCompletionMetadata, usesOnDemandOnlyEditorColumnMetadata } from "@/lib/metadata/completionMetadataPolicy";
-import { loadTableMetadata, type TableMetadataLoadResult } from "@/lib/metadata/tableMetadataCache";
+import { loadObjectDdl } from "@/lib/metadata/objectDdlCache";
+import { loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
 import { queryContextObjectActions, queryContextObjectRoute, queryTableCandidateAtSqlPosition, resolveQueryContextCandidateDatabase, resolveQueryContextObjectTarget, type QueryContextObjectAction } from "@/lib/sql/queryCursorTableTarget";
 import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
@@ -426,8 +427,7 @@ const cachedInsertValueHintColumnsByTable = new Map<string, string[]>();
 const cachedForeignKeysByTable = new Map<string, SqlCompletionForeignKey[]>();
 const loadedColumnsByTable = new Set<string>();
 
-// Hover tooltip uses the shared table metadata cache (loadTableMetadata)
-// which provides TTL, invalidation, and in-flight deduplication.
+// Hover tooltip shares the persisted object cache with the DDL and structure views.
 let hoverSqlHighlighter: SqlHighlighter | null = null;
 
 function sqlCompletionDialectOptions() {
@@ -1922,15 +1922,22 @@ async function resolveSqlHoverTooltip(currentView: EditorViewType, pos: number) 
       const hoverDatabase = hoverScope.database;
       const hoverSchema = hoverScope.schema ?? table.schema ?? "";
       const hoverQualifiedName = [hoverScope.catalog, hoverDatabase, hoverSchema, table.name].filter(Boolean).join(".");
+      const objectMetadataRequest = {
+        connectionId: props.connectionId,
+        database: hoverDatabase,
+        schema: hoverSchema,
+        tableName: table.name,
+        catalog: hoverScope.catalog,
+        objectType: sqlObjectNavigationSourceKind(table),
+      };
       let sqlContent: string | undefined;
       let metadataLoadFailed = false;
 
-      // Primary path: the backend's raw getTableDdl (SHOW CREATE TABLE, pg_ddl,
-      // build_sqlserver_ddl, ...) is authoritative. Parse it into structured
-      // fields and rebuild with vertical field alignment (name, type, extra,
-      // default, nullable, comment), stripping charset/COLLATE noise.
+      // The persisted display DDL is canonical across the full-page and hover
+      // views. Hover only removes PostgreSQL's appended access-control tail.
       try {
-        const rawDdl = await api.getTableDdl(props.connectionId, hoverDatabase, hoverSchema, table.name, undefined, hoverScope.catalog);
+        const { ddl } = await loadObjectDdl(objectMetadataRequest);
+        const rawDdl = ddlForHoverPreview(ddl);
         if (rawDdl && rawDdl.trim()) {
           sqlContent = reformatHoverDdl(rawDdl, quoteQualifiedName(hoverQualifiedName));
         }
@@ -1945,24 +1952,20 @@ async function resolveSqlHoverTooltip(currentView: EditorViewType, pos: number) 
         let fullIndexes: IndexInfo[] = [];
         let tableComment: string | undefined;
         try {
-          const result: TableMetadataLoadResult = await loadTableMetadata({
-            connectionId: props.connectionId,
-            database: hoverDatabase,
-            schema: hoverSchema,
-            tableName: table.name,
-            databaseType: props.databaseType ?? "",
-            catalog: hoverScope.catalog,
-          });
-          fullColumns = result.metadata.columns;
-          fullIndexes = result.metadata.indexes;
+          const [columnsResult, indexesResult] = await Promise.all([
+            loadObjectMetadataFacet(objectMetadataRequest, "columns", () => api.getColumns(props.connectionId!, hoverDatabase, hoverSchema, table.name, hoverScope.catalog)),
+            loadObjectMetadataFacet(objectMetadataRequest, "indexes", () => api.listIndexes(props.connectionId!, hoverDatabase, hoverSchema, table.name, hoverScope.catalog).catch(() => [])),
+          ]);
+          fullColumns = columnsResult.value;
+          fullIndexes = indexesResult.value;
         } catch (error) {
           metadataLoadFailed = true;
           console.warn(`[DBX] Failed to load table metadata for ${hoverDatabase}.${hoverSchema}.${table.name}:`, error);
         }
         if (!metadataLoadFailed) {
           try {
-            const commentResult = await api.getTableComment(props.connectionId, hoverDatabase, hoverSchema, table.name, hoverScope.catalog);
-            if (commentResult) tableComment = commentResult;
+            const commentResult = await loadObjectMetadataFacet(objectMetadataRequest, "comment", () => api.getTableComment(props.connectionId!, hoverDatabase, hoverSchema, table.name, hoverScope.catalog));
+            if (commentResult.value) tableComment = commentResult.value;
           } catch (error) {
             console.warn(`[DBX] Failed to load table comment for ${hoverDatabase}.${hoverSchema}.${table.name}:`, error);
           }

--- a/apps/desktop/src/components/objects/DdlViewDialog.vue
+++ b/apps/desktop/src/components/objects/DdlViewDialog.vue
@@ -9,7 +9,7 @@ import { loadEditorTheme, editorFontTheme } from "@/lib/editor/editorThemes";
 import { createDbxCodeMirrorSqlDialect } from "@/lib/editor/codemirrorSqlDialect";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatSqlForDisplay, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
-import * as api from "@/lib/backend/api";
+import { loadObjectDdl } from "@/lib/metadata/objectDdlCache";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import EditorSearchPanel from "@/components/editor/EditorSearchPanel.vue";
@@ -51,23 +51,38 @@ const ddlEditorContainer = ref<HTMLDivElement>();
 const ddlSearchPanelRef = ref<InstanceType<typeof EditorSearchPanel>>();
 const ddlEditorView = shallowRef<EditorView | null>(null);
 
-/** Fetches the table DDL when the dialog opens. */
+async function loadDdl(force = false) {
+  ddlError.value = "";
+  ddlLoading.value = true;
+  if (force) destroyDdlEditor();
+  try {
+    const schema = props.schema || props.database;
+    const { ddl } = await loadObjectDdl(
+      {
+        connectionId: props.connectionId,
+        database: props.database,
+        schema,
+        tableName: props.tableName,
+        objectType: props.objectType,
+        catalog: props.catalog,
+      },
+      { force },
+    );
+    ddlContent.value = await formatSqlForDisplay(ddl, props.formatDialect ?? props.dialect, settingsStore.editorSettings.sqlFormatter);
+  } catch (e: any) {
+    ddlError.value = e?.message || String(e);
+  } finally {
+    ddlLoading.value = false;
+  }
+}
+
+/** Loads the persisted table DDL when the dialog opens. */
 watch(
   () => props.open,
   async (open) => {
     if (!open) return;
     ddlContent.value = "";
-    ddlError.value = "";
-    ddlLoading.value = true;
-    try {
-      const schema = props.schema || props.database;
-      const ddl = await api.getTableDisplayDdl(props.connectionId, props.database, schema, props.tableName, props.objectType, props.catalog);
-      ddlContent.value = await formatSqlForDisplay(ddl, props.formatDialect ?? props.dialect, settingsStore.editorSettings.sqlFormatter);
-    } catch (e: any) {
-      ddlError.value = e?.message || String(e);
-    } finally {
-      ddlLoading.value = false;
-    }
+    await loadDdl();
   },
   { immediate: true },
 );
@@ -171,21 +186,8 @@ onUnmounted(() => {
 });
 
 function retry() {
-  ddlError.value = "";
-  ddlLoading.value = true;
   ddlContent.value = "";
-  const schema = props.schema || props.database;
-  api
-    .getTableDisplayDdl(props.connectionId, props.database, schema, props.tableName, props.objectType)
-    .then(async (ddl) => {
-      ddlContent.value = await formatSqlForDisplay(ddl, props.formatDialect ?? props.dialect, settingsStore.editorSettings.sqlFormatter);
-    })
-    .catch((e: any) => {
-      ddlError.value = e?.message || String(e);
-    })
-    .finally(() => {
-      ddlLoading.value = false;
-    });
+  void loadDdl(true);
 }
 
 function onClose() {
@@ -218,6 +220,10 @@ function onClose() {
       </div>
       <DialogFooter>
         <Button variant="outline" @click="onClose">{{ t("common.close") }}</Button>
+        <Button variant="outline" :disabled="ddlLoading" :title="t('structureEditor.refresh')" @click="loadDdl(true)">
+          <RefreshCw class="h-4 w-4" />
+          {{ t("structureEditor.refresh") }}
+        </Button>
         <Button variant="outline" :disabled="!ddlContent" @click="copyDdlContent">
           <Clipboard class="h-4 w-4" />
           {{ t("grid.copyDdl") }}

--- a/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
+++ b/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
@@ -14,6 +14,10 @@ const mocks = vi.hoisted(() => ({
   listDataTypes: vi.fn(),
   buildTableStructureChangeSql: vi.fn(),
   updateEditorSettings: vi.fn(),
+  loadObjectDdl: vi.fn(),
+  invalidateObjectDdl: vi.fn(),
+  loadObjectMetadataFacet: vi.fn(),
+  invalidateTableMetadataCache: vi.fn(),
 }));
 
 vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
@@ -184,6 +188,12 @@ vi.mock("@/stores/settingsStore", () => ({
 vi.mock("@/composables/useTheme", () => ({ useTheme: () => ({ isDark: { value: false } }) }));
 vi.mock("@/composables/useToast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
 vi.mock("@/lib/sql/sqlHighlighter", () => ({ createShikiSqlHighlighter: vi.fn(async () => (sql: string) => sql) }));
+vi.mock("@/lib/metadata/objectDdlCache", () => ({
+  loadObjectDdl: mocks.loadObjectDdl,
+  invalidateObjectDdl: mocks.invalidateObjectDdl,
+}));
+vi.mock("@/lib/metadata/objectMetadataCache", () => ({ loadObjectMetadataFacet: mocks.loadObjectMetadataFacet }));
+vi.mock("@/lib/metadata/tableMetadataCache", () => ({ invalidateTableMetadataCache: mocks.invalidateTableMetadataCache }));
 vi.mock("@/lib/backend/api", () => ({
   listDataTypes: mocks.listDataTypes,
   buildTableStructureChangeSql: mocks.buildTableStructureChangeSql,
@@ -254,6 +264,33 @@ async function mountEditor(databaseType: "dameng" | "oracle", isPrimaryKey = fal
   return root;
 }
 
+async function mountLoadingEditor(initialTab: "columns" | "indexes" | "foreignKeys" | "triggers" | "ddl") {
+  mocks.connection.db_type = "postgres";
+  mocks.connection.name = "postgres";
+  mocks.connection.driver_label = "postgres";
+  mocks.ensureConnected.mockResolvedValue(undefined);
+  mocks.listDataTypes.mockResolvedValue([]);
+  mocks.buildTableStructureChangeSql.mockResolvedValue({ statements: [], warnings: [] });
+  mocks.loadObjectDdl.mockResolvedValue({ ddl: "CREATE TABLE users (id bigint)", cacheStatus: "remote" });
+  mocks.loadObjectMetadataFacet.mockImplementation(async (_request, facet: string) => ({ value: facet === "comment" ? "" : [], cacheStatus: "remote" }));
+
+  const root = document.createElement("div");
+  document.body.append(root);
+  const app = createApp(TableStructureEditor, {
+    connectionId: mocks.connection.id,
+    database: "test",
+    schema: "public",
+    tableName: "users",
+    initialTab,
+  });
+  mountedApps.push(app);
+  app.mount(root);
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+  return root;
+}
+
 function columnCheckbox(root: HTMLElement, header: string): HTMLInputElement {
   const headerIndex = Array.from(root.querySelectorAll("thead th")).findIndex((cell) => cell.textContent?.trim() === header);
   if (headerIndex < 0) throw new Error(`Missing ${header} column`);
@@ -266,6 +303,9 @@ function columnCheckbox(root: HTMLElement, header: string): HTMLInputElement {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.loadObjectDdl.mockResolvedValue({ ddl: "CREATE TABLE users (id bigint)", cacheStatus: "remote" });
+  mocks.invalidateObjectDdl.mockResolvedValue(undefined);
+  mocks.loadObjectMetadataFacet.mockResolvedValue({ value: [], cacheStatus: "remote" });
 });
 
 afterEach(() => {
@@ -320,5 +360,27 @@ describe("TableStructureEditor primary key editing", () => {
         columns: [expect.objectContaining({ isPrimaryKey: false })],
       }),
     );
+  });
+});
+
+describe("TableStructureEditor metadata loading", () => {
+  it("opens the initial DDL tab without starting structure metadata loads", async () => {
+    await mountLoadingEditor("ddl");
+
+    await vi.waitFor(() => expect(mocks.loadObjectDdl).toHaveBeenCalledTimes(1));
+    expect(mocks.loadObjectMetadataFacet).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["columns", ["columns", "comment"]],
+    ["indexes", ["columns", "indexes", "comment"]],
+    ["foreignKeys", ["columns", "foreign-keys", "comment"]],
+    ["triggers", ["triggers", "comment"]],
+  ] as const)("loads only the required facets for the initial %s tab", async (initialTab, expectedFacets) => {
+    await mountLoadingEditor(initialTab);
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet).toHaveBeenCalledTimes(expectedFacets.length));
+    expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(expectedFacets);
+    expect(mocks.loadObjectDdl).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -27,7 +27,7 @@ import { formatSqlForDisplay, sqlFormatDialectForDbType } from "@/lib/sql/sqlFor
 import { queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import { invalidateObjectDdl, loadObjectDdl } from "@/lib/metadata/objectDdlCache";
-import { loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
+import { loadObjectMetadataFacet, type ObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
 import { invalidateTableMetadataCache } from "@/lib/metadata/tableMetadataCache";
 import { type BuildTableStructureChangeSqlOptions, type EditableStructureColumn, type EditableStructureForeignKey, type EditableStructureIndex, type EditableStructureTrigger } from "@/lib/table/tableStructureEditorSql";
 import { PRESET_FIELDS_TEMPLATE_ID, createTableColumnTemplateDrafts } from "@/lib/table/tableColumnTemplates";
@@ -141,7 +141,8 @@ const foreignKeysLoading = ref(false);
 const triggersLoading = ref(false);
 const ddlContent = ref("");
 const ddlLoading = ref(false);
-const structureMetadataLoaded = ref(false);
+const loadedMetadataFacets = new Set<ObjectMetadataFacet>();
+let structureEditorReady = false;
 const ddlPreRef = ref<HTMLPreElement | null>(null);
 function onDdlKeydown(e: KeyboardEvent) {
   if ((e.ctrlKey || e.metaKey) && e.key === "a") {
@@ -1204,7 +1205,7 @@ function resetState() {
   selectedColumnId.value = null;
   ddlContent.value = "";
   ddlFetched.value = false;
-  structureMetadataLoaded.value = false;
+  loadedMetadataFacets.clear();
   newTableName.value = "";
   tableComment.value = "";
   originalTableComment.value = "";
@@ -1228,7 +1229,7 @@ async function reloadStructureFromDatabase() {
   const metadataMatch = { connectionId: props.connectionId, database: props.database, schema: metadataSchema.value, tableName: props.tableName };
   invalidateTableMetadataCache(metadataMatch);
   await invalidateObjectDdl(ddlRequest());
-  structureMetadataLoaded.value = false;
+  loadedMetadataFacets.clear();
   if (refreshDdl) {
     ddlFetched.value = false;
     await fetchDdl(true);
@@ -1241,6 +1242,15 @@ function setSecondaryMetadataLoading(scope: TableStructureRefreshScope, value: b
   if (scope.indexes && tableMetadataCapabilities.value.indexes) indexesLoading.value = value;
   if (scope.foreignKeys && tableMetadataCapabilities.value.foreignKeys) foreignKeysLoading.value = value;
   if (scope.triggers && tableMetadataCapabilities.value.triggers) triggersLoading.value = value;
+}
+
+function hasLoadedMetadataScope(scope: TableStructureRefreshScope): boolean {
+  if (scope.columns && !loadedMetadataFacets.has("columns")) return false;
+  if (scope.indexes && !loadedMetadataFacets.has("indexes")) return false;
+  if (scope.foreignKeys && !loadedMetadataFacets.has("foreign-keys")) return false;
+  if (scope.triggers && !loadedMetadataFacets.has("triggers")) return false;
+  if (scope.tableComment && !loadedMetadataFacets.has("comment")) return false;
+  return true;
 }
 
 async function fetchTableCommentValue(connectionId: string, database: string, schema: string, tableName: string, catalog?: string): Promise<string | undefined> {
@@ -1320,6 +1330,7 @@ async function loadStructure(
       const nextColumnDrafts = createColumnDrafts(nextColumns, databaseType.value);
       const hydratedColumnDrafts = databaseType.value === "dameng" && options.damengLengthUnitsAfterSave ? restoreDamengLengthUnitsAfterSave(nextColumnDrafts, options.damengLengthUnitsAfterSave) : nextColumnDrafts;
       columns.value = applyStoredLocalColumnOrder(hydratedColumnDrafts);
+      loadedMetadataFacets.add("columns");
       if (!options.preserveDraft) selectedColumnId.value = null;
     }
 
@@ -1327,15 +1338,23 @@ async function loadStructure(
     if (nextTableComment !== undefined) {
       originalTableComment.value = nextTableComment;
       tableComment.value = nextTableComment;
+      loadedMetadataFacets.add("comment");
     }
     const applySecondaryMetadata = async () => {
       const [nextIndexes, nextForeignKeys, nextTriggers] = await Promise.all([indexesPromise, foreignKeysPromise, triggersPromise]);
       if (requestId !== structureLoadRequestId) return;
-      if (nextIndexes) indexes.value = createIndexDrafts(nextIndexes);
-      if (nextForeignKeys) foreignKeys.value = createForeignKeyDrafts(nextForeignKeys);
+      if (nextIndexes) {
+        indexes.value = createIndexDrafts(nextIndexes);
+        loadedMetadataFacets.add("indexes");
+      }
+      if (nextForeignKeys) {
+        foreignKeys.value = createForeignKeyDrafts(nextForeignKeys);
+        loadedMetadataFacets.add("foreign-keys");
+      }
       if (nextTriggers) {
         triggers.value = createTriggerDrafts(nextTriggers);
         triggersLoaded.value = true;
+        loadedMetadataFacets.add("triggers");
       }
     };
 
@@ -1351,7 +1370,6 @@ async function loadStructure(
       await secondaryMetadataPromise;
     }
     loadedSuccessfully = true;
-    structureMetadataLoaded.value = true;
   } catch (e: any) {
     if (showErrors) {
       errorMessage.value = e?.message || String(e);
@@ -2301,6 +2319,7 @@ async function applyChanges() {
     if (!isCreateMode.value && props.tableName) {
       invalidateTableMetadataCache({ connectionId: props.connectionId, database: props.database, schema: metadataSchema.value, tableName: props.tableName });
       await invalidateObjectDdl(ddlRequest());
+      loadedMetadataFacets.clear();
     }
     toast(t("structureEditor.saved"), 2500);
     pendingStatements.value = [];
@@ -2398,10 +2417,15 @@ onMounted(() => {
     // A restored draft owns its saved tab unless navigation explicitly requested another one.
     applyInitialStructureTab(false);
     applyInitialStructureTarget();
+  }
+  structureEditorReady = true;
+  if (props.draft?.initialized) {
     void hydrateRestoredDraftFromDatabase().then(() => applyInitialStructureTarget());
   } else if (isCreateMode.value) {
     markDraftHydratedAndSync();
-  } else if (activeTab.value !== "ddl") {
+  } else if (activeTab.value === "ddl") {
+    void fetchDdl();
+  } else {
     void loadStructure(false, visibleTableStructureRefreshScope(activeTab.value), true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
   }
 });
@@ -2574,13 +2598,17 @@ watch(refreshVersion, (version, previous) => {
 watch(
   activeTab,
   (tab) => {
+    if (!structureEditorReady) return;
     if (tab === "ddl") {
       void fetchDdl();
-    } else if (!isCreateMode.value && !props.draft?.initialized && !structureMetadataLoaded.value && !loading.value) {
-      void loadStructure(false, visibleTableStructureRefreshScope(tab), true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
+    } else if (!isCreateMode.value && !props.draft?.initialized && !loading.value) {
+      const scope = visibleTableStructureRefreshScope(tab);
+      if (!hasLoadedMetadataScope(scope)) {
+        void loadStructure(false, scope, true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
+      }
     }
   },
-  { immediate: true },
+  { flush: "sync" },
 );
 
 watch([activeTab, ddlLoading], ([tab, loading]) => {

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -26,6 +26,9 @@ import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatSqlForDisplay, sqlFormatDialectForDbType } from "@/lib/sql/sqlFormatter";
 import { queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
+import { invalidateObjectDdl, loadObjectDdl } from "@/lib/metadata/objectDdlCache";
+import { loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
+import { invalidateTableMetadataCache } from "@/lib/metadata/tableMetadataCache";
 import { type BuildTableStructureChangeSqlOptions, type EditableStructureColumn, type EditableStructureForeignKey, type EditableStructureIndex, type EditableStructureTrigger } from "@/lib/table/tableStructureEditorSql";
 import { PRESET_FIELDS_TEMPLATE_ID, createTableColumnTemplateDrafts } from "@/lib/table/tableColumnTemplates";
 import { getMysqlDataTypeHelp } from "@/lib/table/mysqlDataTypeHelp";
@@ -138,6 +141,7 @@ const foreignKeysLoading = ref(false);
 const triggersLoading = ref(false);
 const ddlContent = ref("");
 const ddlLoading = ref(false);
+const structureMetadataLoaded = ref(false);
 const ddlPreRef = ref<HTMLPreElement | null>(null);
 function onDdlKeydown(e: KeyboardEvent) {
   if ((e.ctrlKey || e.metaKey) && e.key === "a") {
@@ -153,11 +157,21 @@ function onDdlKeydown(e: KeyboardEvent) {
 }
 const ddlFetched = ref(false);
 
-async function fetchDdl() {
-  if (!props.connectionId || !props.database || !props.tableName || ddlFetched.value || !tableMetadataCapabilities.value.ddl) return;
+function ddlRequest() {
+  return {
+    connectionId: props.connectionId,
+    database: props.database,
+    schema: metadataSchema.value,
+    tableName: props.tableName,
+    catalog: props.catalog,
+  };
+}
+
+async function fetchDdl(force = false) {
+  if (!props.connectionId || !props.database || !props.tableName || (!force && ddlFetched.value) || !tableMetadataCapabilities.value.ddl) return;
   ddlLoading.value = true;
   try {
-    const ddl = await api.getTableDisplayDdl(props.connectionId, props.database, metadataSchema.value, props.tableName, undefined, props.catalog);
+    const { ddl } = await loadObjectDdl(ddlRequest(), { force });
     ddlContent.value = await formatSqlForDisplay(ddl, sqlFormatDialectForDbType(databaseType.value), settingsStore.editorSettings.sqlFormatter);
     ddlFetched.value = true;
   } catch (e: any) {
@@ -959,10 +973,10 @@ async function hydrateRestoredDraftFromDatabase() {
   let shouldRefreshPreview = false;
   try {
     await store.ensureConnected(connectionId);
-    let nextColumns = await api.getColumns(connectionId, database, schema, tableName, catalog);
+    let { value: nextColumns } = await loadObjectMetadataFacet({ connectionId, database, schema, tableName, catalog }, "columns", () => api.getColumns(connectionId, database, schema, tableName, catalog));
     if (databaseType.value === "manticoresearch" && tableMetadataCapabilities.value.ddl) {
       try {
-        const ddl = await api.getTableDisplayDdl(connectionId, database, schema, tableName, undefined, catalog);
+        const { ddl } = await loadObjectDdl({ connectionId, database, schema, tableName, catalog });
         ddlContent.value = await formatSqlForDisplay(ddl, sqlFormatDialectForDbType(databaseType.value), settingsStore.editorSettings.sqlFormatter);
         ddlFetched.value = true;
         nextColumns = applyManticoreDdlColumnExtras(nextColumns, ddl);
@@ -1190,6 +1204,7 @@ function resetState() {
   selectedColumnId.value = null;
   ddlContent.value = "";
   ddlFetched.value = false;
+  structureMetadataLoaded.value = false;
   newTableName.value = "";
   tableComment.value = "";
   originalTableComment.value = "";
@@ -1209,7 +1224,17 @@ async function reloadStructureFromDatabase() {
     triggers.value = [];
     triggersLoaded.value = false;
   }
-  await loadStructure(false, visibleTableStructureRefreshScope(activeTab.value), true, { blockSecondaryMetadata: true });
+  const refreshDdl = activeTab.value === "ddl";
+  const metadataMatch = { connectionId: props.connectionId, database: props.database, schema: metadataSchema.value, tableName: props.tableName };
+  invalidateTableMetadataCache(metadataMatch);
+  await invalidateObjectDdl(ddlRequest());
+  structureMetadataLoaded.value = false;
+  if (refreshDdl) {
+    ddlFetched.value = false;
+    await fetchDdl(true);
+  } else {
+    await loadStructure(false, visibleTableStructureRefreshScope(activeTab.value), true, { blockSecondaryMetadata: true, forceDdl: true, forceMetadata: true });
+  }
 }
 
 function setSecondaryMetadataLoading(scope: TableStructureRefreshScope, value: boolean) {
@@ -1232,7 +1257,16 @@ async function fetchTableCommentValue(connectionId: string, database: string, sc
   }
 }
 
-async function loadStructure(silent = false, scope: TableStructureRefreshScope = visibleTableStructureRefreshScope(activeTab.value), showErrors = true, options: { blockSecondaryMetadata?: boolean; preserveDraft?: boolean; damengLengthUnitsAfterSave?: ReadonlyMap<string, string> } = {}) {
+function loadCachedTableComment(request: ReturnType<typeof ddlRequest>, force = false): Promise<{ value: string | undefined; cacheStatus: "disk" | "remote" }> {
+  return loadObjectMetadataFacet(request, "comment", () => fetchTableCommentValue(request.connectionId, request.database, request.schema, request.tableName, request.catalog), { force });
+}
+
+async function loadStructure(
+  silent = false,
+  scope: TableStructureRefreshScope = visibleTableStructureRefreshScope(activeTab.value),
+  showErrors = true,
+  options: { blockSecondaryMetadata?: boolean; preserveDraft?: boolean; damengLengthUnitsAfterSave?: ReadonlyMap<string, string>; forceDdl?: boolean; forceMetadata?: boolean } = {},
+) {
   const connectionId = props.connectionId;
   const database = props.database;
   const catalog = props.catalog;
@@ -1248,17 +1282,31 @@ async function loadStructure(silent = false, scope: TableStructureRefreshScope =
   try {
     await store.ensureConnected(connectionId);
 
-    const columnsPromise = scope.columns ? api.getColumns(connectionId, database, schema, tableName, catalog) : Promise.resolve(undefined);
-    const indexesPromise = scope.indexes ? (tableMetadataCapabilities.value.indexes ? api.listIndexes(connectionId, database, schema, tableName, catalog).catch(() => []) : Promise.resolve([])) : Promise.resolve(undefined);
-    const foreignKeysPromise = scope.foreignKeys ? (tableMetadataCapabilities.value.foreignKeys ? api.listForeignKeys(connectionId, database, schema, tableName, catalog).catch(() => []) : Promise.resolve([])) : Promise.resolve(undefined);
-    const triggersPromise = scope.triggers ? (tableMetadataCapabilities.value.triggers ? api.listTriggers(connectionId, database, schema, tableName, catalog).catch(() => []) : Promise.resolve([])) : Promise.resolve(undefined);
-    const tableCommentPromise = scope.tableComment && structureCapabilities.value.comment ? fetchTableCommentValue(connectionId, database, schema, tableName, catalog) : Promise.resolve(undefined);
+    const metadataRequest = ddlRequest();
+    const forceMetadata = options.forceMetadata === true;
+    const columnsPromise = scope.columns ? loadObjectMetadataFacet(metadataRequest, "columns", () => api.getColumns(connectionId, database, schema, tableName, catalog), { force: forceMetadata }).then((result) => result.value) : Promise.resolve(undefined);
+    const indexesPromise = scope.indexes
+      ? tableMetadataCapabilities.value.indexes
+        ? loadObjectMetadataFacet(metadataRequest, "indexes", () => api.listIndexes(connectionId, database, schema, tableName, catalog).catch(() => []), { force: forceMetadata }).then((result) => result.value)
+        : Promise.resolve([])
+      : Promise.resolve(undefined);
+    const foreignKeysPromise = scope.foreignKeys
+      ? tableMetadataCapabilities.value.foreignKeys
+        ? loadObjectMetadataFacet(metadataRequest, "foreign-keys", () => api.listForeignKeys(connectionId, database, schema, tableName, catalog).catch(() => []), { force: forceMetadata }).then((result) => result.value)
+        : Promise.resolve([])
+      : Promise.resolve(undefined);
+    const triggersPromise = scope.triggers
+      ? tableMetadataCapabilities.value.triggers
+        ? loadObjectMetadataFacet(metadataRequest, "triggers", () => api.listTriggers(connectionId, database, schema, tableName, catalog).catch(() => []), { force: forceMetadata }).then((result) => result.value)
+        : Promise.resolve([])
+      : Promise.resolve(undefined);
+    const tableCommentPromise = scope.tableComment && structureCapabilities.value.comment ? loadCachedTableComment(metadataRequest, forceMetadata).then((result) => result.value) : Promise.resolve(undefined);
 
     let nextColumns = await columnsPromise;
     if (nextColumns) {
       if (databaseType.value === "manticoresearch" && tableMetadataCapabilities.value.ddl) {
         try {
-          const ddl = await api.getTableDisplayDdl(connectionId, database, schema, tableName, undefined, catalog);
+          const { ddl } = await loadObjectDdl({ connectionId, database, schema, tableName, catalog }, { force: options.forceDdl });
           ddlContent.value = await formatSqlForDisplay(ddl, sqlFormatDialectForDbType(databaseType.value), settingsStore.editorSettings.sqlFormatter);
           ddlFetched.value = true;
           nextColumns = applyManticoreDdlColumnExtras(nextColumns, ddl);
@@ -1303,6 +1351,7 @@ async function loadStructure(silent = false, scope: TableStructureRefreshScope =
       await secondaryMetadataPromise;
     }
     loadedSuccessfully = true;
+    structureMetadataLoaded.value = true;
   } catch (e: any) {
     if (showErrors) {
       errorMessage.value = e?.message || String(e);
@@ -1327,7 +1376,7 @@ async function refreshStructureAfterSave(scope: TableStructureRefreshScope, dame
     console.warn("[DBX][structure-editor:post-save-refresh-failed]", e);
   } finally {
     postSaveRefreshing.value = false;
-    if (activeTab.value === "ddl") void fetchDdl();
+    if (activeTab.value === "ddl") void fetchDdl(true);
   }
 }
 
@@ -2249,6 +2298,10 @@ async function applyChanges() {
       ? await api.applySqliteTableStructureChange(props.connectionId, props.database, structureChangeOptions(), sqliteSchemaRevision.value!)
       : await api.executeBatch(props.connectionId, props.database, pendingStatements.value, props.schema, queryTimeoutSecsForConnection(connection));
     await recordStructureHistory(sql, startedAt, true, result);
+    if (!isCreateMode.value && props.tableName) {
+      invalidateTableMetadataCache({ connectionId: props.connectionId, database: props.database, schema: metadataSchema.value, tableName: props.tableName });
+      await invalidateObjectDdl(ddlRequest());
+    }
     toast(t("structureEditor.saved"), 2500);
     pendingStatements.value = [];
     warnings.value = [];
@@ -2348,7 +2401,7 @@ onMounted(() => {
     void hydrateRestoredDraftFromDatabase().then(() => applyInitialStructureTarget());
   } else if (isCreateMode.value) {
     markDraftHydratedAndSync();
-  } else {
+  } else if (activeTab.value !== "ddl") {
     void loadStructure(false, visibleTableStructureRefreshScope(activeTab.value), true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
   }
 });
@@ -2523,6 +2576,8 @@ watch(
   (tab) => {
     if (tab === "ddl") {
       void fetchDdl();
+    } else if (!isCreateMode.value && !structureMetadataLoaded.value && !loading.value) {
+      void loadStructure(false, visibleTableStructureRefreshScope(tab), true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
     }
   },
   { immediate: true },
@@ -2543,7 +2598,7 @@ watch([activeTab, ddlLoading], ([tab, loading]) => {
       <Database :class="[structureIconClass, 'text-muted-foreground']" />
       <span class="min-w-0 flex-1 truncate font-medium">{{ targetLabel || t("editor.noDatabase") }}</span>
       <Badge variant="outline">{{ connection?.driver_label || databaseType }}</Badge>
-      <Button v-if="!isCreateMode" variant="ghost" size="sm" :class="structureToolbarButtonClass" :disabled="loading || saving" @click="reloadStructureFromDatabase">
+      <Button v-if="!isCreateMode" variant="ghost" size="sm" :class="structureToolbarButtonClass" :disabled="loading || saving || ddlLoading" @click="reloadStructureFromDatabase">
         <RefreshCw :class="structureIconClass" />
         {{ t("structureEditor.refresh") }}
       </Button>

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -2576,7 +2576,7 @@ watch(
   (tab) => {
     if (tab === "ddl") {
       void fetchDdl();
-    } else if (!isCreateMode.value && !structureMetadataLoaded.value && !loading.value) {
+    } else if (!isCreateMode.value && !props.draft?.initialized && !structureMetadataLoaded.value && !loading.value) {
       void loadStructure(false, visibleTableStructureRefreshScope(tab), true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
     }
   },

--- a/apps/desktop/src/lib/__tests__/table/contentAreaObjectBrowserCatalog.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/contentAreaObjectBrowserCatalog.spec.ts
@@ -25,8 +25,8 @@ describe("ContentArea external catalog wiring", () => {
     expect(openingTag(connectionTreeSource, "SidebarDdlViewDialog")).toContain(':catalog="sidebarDdlTarget.catalog"');
   });
 
-  it("forwards the DDL dialog catalog to the metadata API", () => {
-    expect(ddlViewDialogSource).toMatch(/api\.getTableDisplayDdl\([\s\S]*?props\.objectType, props\.catalog\)/);
+  it("forwards the DDL dialog catalog to the persistent DDL loader", () => {
+    expect(ddlViewDialogSource).toMatch(/loadObjectDdl\([\s\S]*?objectType: props\.objectType,[\s\S]*?catalog: props\.catalog/);
   });
 });
 

--- a/apps/desktop/src/lib/__tests__/table/tableStructureMetadataLoading.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableStructureMetadataLoading.spec.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import { shouldLoadTableStructureTriggers, visibleTableStructureRefreshScope } from "@/lib/table/tableStructureMetadataLoading";
 
 describe("table structure metadata loading", () => {
-  it("does not request triggers while opening the default columns tab", () => {
-    expect(visibleTableStructureRefreshScope("columns").triggers).toBe(false);
-  });
-
-  it("requests triggers when the structure editor opens on the trigger tab", () => {
-    expect(visibleTableStructureRefreshScope("triggers").triggers).toBe(true);
+  it.each([
+    ["columns", { columns: true, indexes: false, foreignKeys: false, triggers: false, tableComment: true }],
+    ["indexes", { columns: true, indexes: true, foreignKeys: false, triggers: false, tableComment: true }],
+    ["foreignKeys", { columns: true, indexes: false, foreignKeys: true, triggers: false, tableComment: true }],
+    ["triggers", { columns: false, indexes: false, foreignKeys: false, triggers: true, tableComment: true }],
+    ["ddl", { columns: false, indexes: false, foreignKeys: false, triggers: false, tableComment: false }],
+  ] as const)("requests only the metadata required by the %s tab", (tab, expected) => {
+    expect(visibleTableStructureRefreshScope(tab)).toEqual(expected);
   });
 
   it("loads trigger metadata once when the trigger tab becomes visible", () => {

--- a/apps/desktop/src/lib/editor/__tests__/hoverTableSql.spec.ts
+++ b/apps/desktop/src/lib/editor/__tests__/hoverTableSql.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildHoverTableSql, hoverTableMatchesScope, reformatHoverDdl, sanitizeHoverDdl, scopeHoverTables } from "@/lib/editor/hoverTableSql";
+import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, reformatHoverDdl, sanitizeHoverDdl, scopeHoverTables } from "@/lib/editor/hoverTableSql";
 import type { ColumnInfo, IndexInfo } from "@/types/database";
 
 type ColumnOverride = Partial<ColumnInfo> & { name: string; data_type: string };
@@ -207,6 +207,27 @@ describe("buildHoverTableSql", () => {
 });
 
 describe("reformatHoverDdl", () => {
+  it("removes the PostgreSQL access-control tail from canonical display DDL", () => {
+    const displayDdl = `CREATE TABLE "public"."users" (
+  "id" bigint NOT NULL
+);
+
+ALTER TABLE "public"."users" OWNER TO "app_owner";
+
+SET ROLE "app_owner";
+GRANT SELECT ON TABLE "public"."users" TO "reporter";
+RESET ROLE;`;
+
+    expect(ddlForHoverPreview(displayDdl)).toBe(`CREATE TABLE "public"."users" (
+  "id" bigint NOT NULL
+);`);
+  });
+
+  it("keeps non-PostgreSQL and structural companion statements unchanged", () => {
+    const ddl = "CREATE TABLE t (id int);\nCREATE INDEX ix_t_id ON t (id);";
+    expect(ddlForHoverPreview(ddl)).toBe(ddl);
+  });
+
   it("preserves sanitized raw MySQL DDL when table options are present", () => {
     const raw = `CREATE TABLE \`users\` (
   \`id\` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',

--- a/apps/desktop/src/lib/editor/hoverTableSql.ts
+++ b/apps/desktop/src/lib/editor/hoverTableSql.ts
@@ -107,6 +107,16 @@ export function sanitizeHoverDdl(ddl: string): string {
 }
 
 /**
+ * The persisted display DDL is the canonical object definition. Native
+ * PostgreSQL appends owner and grant statements after the structural DDL;
+ * quick-look hover keeps the structure and omits that access-control tail.
+ */
+export function ddlForHoverPreview(ddl: string): string {
+  const accessTail = /\n\s*ALTER\s+TABLE\s+[^\n;]+\s+OWNER\s+TO\s+[^\n;]+;/i.exec(ddl);
+  return accessTail ? ddl.slice(0, accessTail.index).trimEnd() : ddl;
+}
+
+/**
  * Display fields of a single column line, prior to vertical alignment.
  */
 interface ColumnFieldParts {

--- a/apps/desktop/src/lib/metadata/__tests__/objectDdlCache.spec.ts
+++ b/apps/desktop/src/lib/metadata/__tests__/objectDdlCache.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getTableDisplayDdl: vi.fn(),
+  saveSchemaCache: vi.fn(),
+  loadSchemaCache: vi.fn(),
+  deleteSchemaCachePrefix: vi.fn(),
+}));
+
+vi.mock("@/lib/backend/api", () => mocks);
+
+import { invalidateObjectDdl, invalidateObjectDdlCache, loadObjectDdl, objectDdlCacheKey } from "@/lib/metadata/objectDdlCache";
+
+const request = { connectionId: "c1", database: "app", schema: "public", tableName: "users" } as const;
+
+describe("objectDdlCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadSchemaCache.mockResolvedValue(null);
+    mocks.saveSchemaCache.mockResolvedValue(undefined);
+    mocks.deleteSchemaCachePrefix.mockResolvedValue(undefined);
+  });
+
+  it("returns persisted DDL without querying the database", async () => {
+    mocks.loadSchemaCache.mockResolvedValue({ version: 1, cachedAt: new Date().toISOString(), ddl: "CREATE TABLE users (id int)" });
+
+    await expect(loadObjectDdl(request)).resolves.toEqual({ ddl: "CREATE TABLE users (id int)", cacheStatus: "disk" });
+    expect(mocks.getTableDisplayDdl).not.toHaveBeenCalled();
+  });
+
+  it("persists a remote cache miss", async () => {
+    mocks.getTableDisplayDdl.mockResolvedValue("CREATE TABLE users (id bigint)");
+
+    await expect(loadObjectDdl(request)).resolves.toEqual({ ddl: "CREATE TABLE users (id bigint)", cacheStatus: "remote" });
+    expect(mocks.saveSchemaCache).toHaveBeenCalledWith(objectDdlCacheKey(request), expect.objectContaining({ version: 1, ddl: "CREATE TABLE users (id bigint)" }));
+  });
+
+  it("deduplicates concurrent remote loads", async () => {
+    let release: (ddl: string) => void = () => {};
+    mocks.getTableDisplayDdl.mockReturnValue(
+      new Promise<string>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const first = loadObjectDdl(request);
+    const second = loadObjectDdl(request);
+    await vi.waitFor(() => expect(mocks.getTableDisplayDdl).toHaveBeenCalledTimes(1));
+
+    release("CREATE TABLE users (id int)");
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
+
+  it("force refresh bypasses disk and overwrites it", async () => {
+    mocks.loadSchemaCache.mockResolvedValue({ version: 1, cachedAt: new Date().toISOString(), ddl: "old ddl" });
+    mocks.getTableDisplayDdl.mockResolvedValue("new ddl");
+
+    await expect(loadObjectDdl(request, { force: true })).resolves.toEqual({ ddl: "new ddl", cacheStatus: "remote" });
+    expect(mocks.loadSchemaCache).not.toHaveBeenCalled();
+    expect(mocks.saveSchemaCache).toHaveBeenCalledWith(objectDdlCacheKey(request), expect.objectContaining({ ddl: "new ddl" }));
+  });
+
+  it("deletes the exact persisted entry", async () => {
+    await invalidateObjectDdl(request);
+    expect(mocks.deleteSchemaCachePrefix).toHaveBeenCalledWith(objectDdlCacheKey(request));
+  });
+
+  it("does not persist an in-flight result across invalidation", async () => {
+    let release: (ddl: string) => void = () => {};
+    mocks.getTableDisplayDdl.mockReturnValue(
+      new Promise<string>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const load = loadObjectDdl(request);
+    await vi.waitFor(() => expect(mocks.getTableDisplayDdl).toHaveBeenCalledTimes(1));
+
+    await invalidateObjectDdlCache({ connectionId: request.connectionId, database: request.database, schema: request.schema });
+    release("stale ddl");
+    await expect(load).resolves.toEqual({ ddl: "stale ddl", cacheStatus: "remote" });
+    expect(mocks.saveSchemaCache).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/metadata/__tests__/objectDdlCache.spec.ts
+++ b/apps/desktop/src/lib/metadata/__tests__/objectDdlCache.spec.ts
@@ -5,20 +5,28 @@ const mocks = vi.hoisted(() => ({
   saveSchemaCache: vi.fn(),
   loadSchemaCache: vi.fn(),
   deleteSchemaCachePrefix: vi.fn(),
+  persisted: new Map<string, unknown>(),
 }));
 
 vi.mock("@/lib/backend/api", () => mocks);
 
 import { invalidateObjectDdl, invalidateObjectDdlCache, loadObjectDdl, objectDdlCacheKey } from "@/lib/metadata/objectDdlCache";
 
-const request = { connectionId: "c1", database: "app", schema: "public", tableName: "users" } as const;
+const request = { connectionId: "c1", database: "app", schema: "public", tableName: "users", catalog: "analytics" } as const;
 
 describe("objectDdlCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.loadSchemaCache.mockResolvedValue(null);
-    mocks.saveSchemaCache.mockResolvedValue(undefined);
-    mocks.deleteSchemaCachePrefix.mockResolvedValue(undefined);
+    mocks.persisted.clear();
+    mocks.loadSchemaCache.mockImplementation(async (cacheKey: string) => mocks.persisted.get(cacheKey) ?? null);
+    mocks.saveSchemaCache.mockImplementation(async (cacheKey: string, payload: unknown) => {
+      mocks.persisted.set(cacheKey, payload);
+    });
+    mocks.deleteSchemaCachePrefix.mockImplementation(async (prefix: string) => {
+      for (const cacheKey of mocks.persisted.keys()) {
+        if (cacheKey === prefix || cacheKey.startsWith(prefix)) mocks.persisted.delete(cacheKey);
+      }
+    });
   });
 
   it("returns persisted DDL without querying the database", async () => {
@@ -63,6 +71,15 @@ describe("objectDdlCache", () => {
   it("deletes the exact persisted entry", async () => {
     await invalidateObjectDdl(request);
     expect(mocks.deleteSchemaCachePrefix).toHaveBeenCalledWith(objectDdlCacheKey(request));
+  });
+
+  it("reloads from the database after table-level persisted cache invalidation", async () => {
+    mocks.getTableDisplayDdl.mockResolvedValueOnce("old ddl").mockResolvedValueOnce("new ddl");
+
+    await expect(loadObjectDdl(request)).resolves.toEqual({ ddl: "old ddl", cacheStatus: "remote" });
+    await invalidateObjectDdlCache({ connectionId: request.connectionId, database: request.database, schema: request.schema, tableName: request.tableName });
+    await expect(loadObjectDdl(request)).resolves.toEqual({ ddl: "new ddl", cacheStatus: "remote" });
+    expect(mocks.getTableDisplayDdl).toHaveBeenCalledTimes(2);
   });
 
   it("does not persist an in-flight result across invalidation", async () => {

--- a/apps/desktop/src/lib/metadata/__tests__/objectMetadataCache.spec.ts
+++ b/apps/desktop/src/lib/metadata/__tests__/objectMetadataCache.spec.ts
@@ -4,20 +4,28 @@ const mocks = vi.hoisted(() => ({
   saveSchemaCache: vi.fn(),
   loadSchemaCache: vi.fn(),
   deleteSchemaCachePrefix: vi.fn(),
+  persisted: new Map<string, unknown>(),
 }));
 
 vi.mock("@/lib/backend/api", () => mocks);
 
 import { invalidateObjectMetadataCache, loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
 
-const request = { connectionId: "c1", database: "app", schema: "public", tableName: "users" } as const;
+const request = { connectionId: "c1", database: "app", schema: "public", tableName: "users", catalog: "analytics" } as const;
 
 describe("objectMetadataCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.loadSchemaCache.mockResolvedValue(null);
-    mocks.saveSchemaCache.mockResolvedValue(undefined);
-    mocks.deleteSchemaCachePrefix.mockResolvedValue(undefined);
+    mocks.persisted.clear();
+    mocks.loadSchemaCache.mockImplementation(async (cacheKey: string) => mocks.persisted.get(cacheKey) ?? null);
+    mocks.saveSchemaCache.mockImplementation(async (cacheKey: string, payload: unknown) => {
+      mocks.persisted.set(cacheKey, payload);
+    });
+    mocks.deleteSchemaCachePrefix.mockImplementation(async (prefix: string) => {
+      for (const cacheKey of mocks.persisted.keys()) {
+        if (cacheKey === prefix || cacheKey.startsWith(prefix)) mocks.persisted.delete(cacheKey);
+      }
+    });
   });
 
   it("reads a facet from disk without invoking the loader", async () => {
@@ -35,11 +43,21 @@ describe("objectMetadataCache", () => {
     await expect(loadObjectMetadataFacet(request, "indexes", loader, { force: true })).resolves.toEqual({ value: ["new"], cacheStatus: "remote" });
     expect(loader).toHaveBeenCalledTimes(1);
     expect(mocks.loadSchemaCache).not.toHaveBeenCalled();
-    expect(mocks.saveSchemaCache).toHaveBeenCalledWith(expect.stringContaining("object-meta:v1:c1:app:public::users:indexes:"), expect.objectContaining({ value: ["new"] }));
+    expect(mocks.saveSchemaCache).toHaveBeenCalledWith(expect.stringContaining("object-meta:v1:c1:app:public:users:analytics:indexes:"), expect.objectContaining({ value: ["new"] }));
   });
 
   it("invalidates only the requested object's facets", async () => {
     await invalidateObjectMetadataCache(request);
     expect(mocks.deleteSchemaCachePrefix).toHaveBeenCalledWith("object-meta:v1:c1:app:public:users:");
+  });
+
+  it("reloads a persisted facet after table-level invalidation", async () => {
+    const initialLoader = vi.fn().mockResolvedValue(["old"]);
+    const refreshedLoader = vi.fn().mockResolvedValue(["new"]);
+
+    await expect(loadObjectMetadataFacet(request, "indexes", initialLoader)).resolves.toEqual({ value: ["old"], cacheStatus: "remote" });
+    await invalidateObjectMetadataCache({ connectionId: request.connectionId, database: request.database, schema: request.schema, tableName: request.tableName });
+    await expect(loadObjectMetadataFacet(request, "indexes", refreshedLoader)).resolves.toEqual({ value: ["new"], cacheStatus: "remote" });
+    expect(refreshedLoader).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/lib/metadata/__tests__/objectMetadataCache.spec.ts
+++ b/apps/desktop/src/lib/metadata/__tests__/objectMetadataCache.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  saveSchemaCache: vi.fn(),
+  loadSchemaCache: vi.fn(),
+  deleteSchemaCachePrefix: vi.fn(),
+}));
+
+vi.mock("@/lib/backend/api", () => mocks);
+
+import { invalidateObjectMetadataCache, loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
+
+const request = { connectionId: "c1", database: "app", schema: "public", tableName: "users" } as const;
+
+describe("objectMetadataCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadSchemaCache.mockResolvedValue(null);
+    mocks.saveSchemaCache.mockResolvedValue(undefined);
+    mocks.deleteSchemaCachePrefix.mockResolvedValue(undefined);
+  });
+
+  it("reads a facet from disk without invoking the loader", async () => {
+    mocks.loadSchemaCache.mockResolvedValue({ version: 1, cachedAt: new Date().toISOString(), value: [{ name: "id" }] });
+    const loader = vi.fn().mockResolvedValue([{ name: "remote" }]);
+
+    await expect(loadObjectMetadataFacet(request, "columns", loader)).resolves.toEqual({ value: [{ name: "id" }], cacheStatus: "disk" });
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("persists a remote facet and force bypasses disk", async () => {
+    mocks.loadSchemaCache.mockResolvedValue({ version: 1, cachedAt: new Date().toISOString(), value: ["old"] });
+    const loader = vi.fn().mockResolvedValue(["new"]);
+
+    await expect(loadObjectMetadataFacet(request, "indexes", loader, { force: true })).resolves.toEqual({ value: ["new"], cacheStatus: "remote" });
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(mocks.loadSchemaCache).not.toHaveBeenCalled();
+    expect(mocks.saveSchemaCache).toHaveBeenCalledWith(expect.stringContaining("object-meta:v1:c1:app:public::users:indexes:"), expect.objectContaining({ value: ["new"] }));
+  });
+
+  it("invalidates only the requested object's facets", async () => {
+    await invalidateObjectMetadataCache(request);
+    expect(mocks.deleteSchemaCachePrefix).toHaveBeenCalledWith("object-meta:v1:c1:app:public:users:");
+  });
+});

--- a/apps/desktop/src/lib/metadata/objectDdlCache.ts
+++ b/apps/desktop/src/lib/metadata/objectDdlCache.ts
@@ -64,7 +64,7 @@ function cacheSegment(value: string | undefined): string {
 }
 
 export function objectDdlCacheKey(request: ObjectDdlRequest): string {
-  return `${[OBJECT_DDL_CACHE_PREFIX, cacheSegment(request.connectionId), cacheSegment(request.database), cacheSegment(request.schema), cacheSegment(request.catalog), cacheSegment(request.objectType ?? "TABLE"), cacheSegment(request.tableName)].join(":")}:`;
+  return `${[OBJECT_DDL_CACHE_PREFIX, cacheSegment(request.connectionId), cacheSegment(request.database), cacheSegment(request.schema), cacheSegment(request.tableName), cacheSegment(request.catalog), cacheSegment(request.objectType ?? "TABLE")].join(":")}:`;
 }
 
 function invalidationPrefix(match: MetadataCacheInvalidation): string {
@@ -75,6 +75,8 @@ function invalidationPrefix(match: MetadataCacheInvalidation): string {
   parts.push(cacheSegment(match.database ?? undefined));
   if (!match.schema) return `${parts.join(":")}:`;
   parts.push(cacheSegment(match.schema ?? undefined));
+  if (!match.tableName) return `${parts.join(":")}:`;
+  parts.push(cacheSegment(match.tableName));
   return `${parts.join(":")}:`;
 }
 

--- a/apps/desktop/src/lib/metadata/objectDdlCache.ts
+++ b/apps/desktop/src/lib/metadata/objectDdlCache.ts
@@ -35,6 +35,30 @@ export interface ObjectDdlLoadResult {
 const remoteLoads = new Map<string, InFlightDdlLoad>();
 const pendingInvalidations = new Map<string, Promise<void>>();
 
+async function loadSchemaCacheSafe<T>(cacheKey: string): Promise<T | null> {
+  try {
+    return await api.loadSchemaCache<T>(cacheKey);
+  } catch {
+    return null;
+  }
+}
+
+async function saveSchemaCacheSafe(cacheKey: string, payload: unknown): Promise<void> {
+  try {
+    await api.saveSchemaCache(cacheKey, payload);
+  } catch {
+    // Cache persistence is best effort and must not block DDL rendering.
+  }
+}
+
+async function deleteSchemaCachePrefixSafe(prefix: string): Promise<void> {
+  try {
+    await api.deleteSchemaCachePrefix(prefix);
+  } catch {
+    // Cache invalidation is best effort when running with a reduced backend.
+  }
+}
+
 function cacheSegment(value: string | undefined): string {
   return encodeURIComponent(value ?? "");
 }
@@ -80,7 +104,7 @@ async function loadRemoteDdl(request: ObjectDdlRequest, cacheKey: string, force:
     .then(async (ddl) => {
       if (!entry.invalidated && ddl.length <= MAX_PERSISTED_DDL_CHARS) {
         const envelope: ObjectDdlCacheEnvelope = { version: 1, cachedAt: new Date().toISOString(), ddl };
-        await api.saveSchemaCache(cacheKey, envelope).catch(() => undefined);
+        await saveSchemaCacheSafe(cacheKey, envelope);
       }
       return ddl;
     })
@@ -96,7 +120,7 @@ export async function loadObjectDdl(request: ObjectDdlRequest, options?: { force
   await waitForPendingInvalidations(cacheKey);
 
   if (!options?.force) {
-    const cached = decodeCachedDdl(await api.loadSchemaCache<unknown>(cacheKey).catch(() => null));
+    const cached = decodeCachedDdl(await loadSchemaCacheSafe<unknown>(cacheKey));
     if (cached !== null) return { ddl: cached, cacheStatus: "disk" };
   }
 
@@ -113,12 +137,9 @@ export async function invalidateObjectDdlCache(match: MetadataCacheInvalidation)
 
   const existing = pendingInvalidations.get(prefix);
   if (existing) return existing;
-  const deletion = api
-    .deleteSchemaCachePrefix(prefix)
-    .catch(() => undefined)
-    .finally(() => {
-      if (pendingInvalidations.get(prefix) === deletion) pendingInvalidations.delete(prefix);
-    });
+  const deletion = deleteSchemaCachePrefixSafe(prefix).finally(() => {
+    if (pendingInvalidations.get(prefix) === deletion) pendingInvalidations.delete(prefix);
+  });
   pendingInvalidations.set(prefix, deletion);
   await Promise.all([deletion, invalidateObjectMetadataCache(match)]);
 }
@@ -131,7 +152,7 @@ export async function invalidateObjectDdl(request: ObjectDdlRequest): Promise<vo
     remoteLoads.delete(cacheKey);
   }
   await Promise.all([
-    api.deleteSchemaCachePrefix(cacheKey).catch(() => undefined),
+    deleteSchemaCachePrefixSafe(cacheKey),
     invalidateObjectMetadataCache({
       connectionId: request.connectionId,
       database: request.database,

--- a/apps/desktop/src/lib/metadata/objectDdlCache.ts
+++ b/apps/desktop/src/lib/metadata/objectDdlCache.ts
@@ -1,0 +1,142 @@
+import * as api from "@/lib/backend/api";
+import type { ObjectSourceKind } from "@/types/database";
+import type { MetadataCacheInvalidation } from "./metadataResultCache";
+import { invalidateObjectMetadataCache } from "./objectMetadataCache";
+
+const OBJECT_DDL_CACHE_PREFIX = "object-ddl:v1";
+const MAX_PERSISTED_DDL_CHARS = 5 * 1024 * 1024;
+
+interface ObjectDdlCacheEnvelope {
+  version: 1;
+  cachedAt: string;
+  ddl: string;
+}
+
+interface InFlightDdlLoad {
+  force: boolean;
+  invalidated: boolean;
+  promise: Promise<string>;
+}
+
+export interface ObjectDdlRequest {
+  connectionId: string;
+  database: string;
+  schema: string;
+  tableName: string;
+  objectType?: ObjectSourceKind;
+  catalog?: string;
+}
+
+export interface ObjectDdlLoadResult {
+  ddl: string;
+  cacheStatus: "disk" | "remote";
+}
+
+const remoteLoads = new Map<string, InFlightDdlLoad>();
+const pendingInvalidations = new Map<string, Promise<void>>();
+
+function cacheSegment(value: string | undefined): string {
+  return encodeURIComponent(value ?? "");
+}
+
+export function objectDdlCacheKey(request: ObjectDdlRequest): string {
+  return `${[OBJECT_DDL_CACHE_PREFIX, cacheSegment(request.connectionId), cacheSegment(request.database), cacheSegment(request.schema), cacheSegment(request.catalog), cacheSegment(request.objectType ?? "TABLE"), cacheSegment(request.tableName)].join(":")}:`;
+}
+
+function invalidationPrefix(match: MetadataCacheInvalidation): string {
+  const parts = [OBJECT_DDL_CACHE_PREFIX];
+  if (!match.connectionId) return `${OBJECT_DDL_CACHE_PREFIX}:`;
+  parts.push(cacheSegment(match.connectionId ?? undefined));
+  if (!match.database) return `${parts.join(":")}:`;
+  parts.push(cacheSegment(match.database ?? undefined));
+  if (!match.schema) return `${parts.join(":")}:`;
+  parts.push(cacheSegment(match.schema ?? undefined));
+  return `${parts.join(":")}:`;
+}
+
+function decodeCachedDdl(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const envelope = payload as Partial<ObjectDdlCacheEnvelope>;
+  if (envelope.version !== 1 || typeof envelope.cachedAt !== "string" || !Number.isFinite(Date.parse(envelope.cachedAt)) || typeof envelope.ddl !== "string") return null;
+  return envelope.ddl;
+}
+
+async function waitForPendingInvalidations(cacheKey: string): Promise<void> {
+  const pending = [...pendingInvalidations.entries()].filter(([prefix]) => cacheKey.startsWith(prefix)).map(([, promise]) => promise);
+  if (pending.length) await Promise.all(pending);
+}
+
+async function loadRemoteDdl(request: ObjectDdlRequest, cacheKey: string, force: boolean): Promise<string> {
+  const existing = remoteLoads.get(cacheKey);
+  if (existing && (!force || existing.force)) return existing.promise;
+  if (existing) {
+    existing.invalidated = true;
+    remoteLoads.delete(cacheKey);
+  }
+
+  const entry: InFlightDdlLoad = { force, invalidated: false, promise: Promise.resolve("") };
+  entry.promise = api
+    .getTableDisplayDdl(request.connectionId, request.database, request.schema, request.tableName, request.objectType, request.catalog)
+    .then(async (ddl) => {
+      if (!entry.invalidated && ddl.length <= MAX_PERSISTED_DDL_CHARS) {
+        const envelope: ObjectDdlCacheEnvelope = { version: 1, cachedAt: new Date().toISOString(), ddl };
+        await api.saveSchemaCache(cacheKey, envelope).catch(() => undefined);
+      }
+      return ddl;
+    })
+    .finally(() => {
+      if (remoteLoads.get(cacheKey) === entry) remoteLoads.delete(cacheKey);
+    });
+  remoteLoads.set(cacheKey, entry);
+  return entry.promise;
+}
+
+export async function loadObjectDdl(request: ObjectDdlRequest, options?: { force?: boolean }): Promise<ObjectDdlLoadResult> {
+  const cacheKey = objectDdlCacheKey(request);
+  await waitForPendingInvalidations(cacheKey);
+
+  if (!options?.force) {
+    const cached = decodeCachedDdl(await api.loadSchemaCache<unknown>(cacheKey).catch(() => null));
+    if (cached !== null) return { ddl: cached, cacheStatus: "disk" };
+  }
+
+  return { ddl: await loadRemoteDdl(request, cacheKey, options?.force === true), cacheStatus: "remote" };
+}
+
+export async function invalidateObjectDdlCache(match: MetadataCacheInvalidation): Promise<void> {
+  const prefix = invalidationPrefix(match);
+  for (const [cacheKey, entry] of remoteLoads) {
+    if (!cacheKey.startsWith(prefix)) continue;
+    entry.invalidated = true;
+    remoteLoads.delete(cacheKey);
+  }
+
+  const existing = pendingInvalidations.get(prefix);
+  if (existing) return existing;
+  const deletion = api
+    .deleteSchemaCachePrefix(prefix)
+    .catch(() => undefined)
+    .finally(() => {
+      if (pendingInvalidations.get(prefix) === deletion) pendingInvalidations.delete(prefix);
+    });
+  pendingInvalidations.set(prefix, deletion);
+  await Promise.all([deletion, invalidateObjectMetadataCache(match)]);
+}
+
+export async function invalidateObjectDdl(request: ObjectDdlRequest): Promise<void> {
+  const cacheKey = objectDdlCacheKey(request);
+  const entry = remoteLoads.get(cacheKey);
+  if (entry) {
+    entry.invalidated = true;
+    remoteLoads.delete(cacheKey);
+  }
+  await Promise.all([
+    api.deleteSchemaCachePrefix(cacheKey).catch(() => undefined),
+    invalidateObjectMetadataCache({
+      connectionId: request.connectionId,
+      database: request.database,
+      schema: request.schema,
+      tableName: request.tableName,
+    }),
+  ]);
+}

--- a/apps/desktop/src/lib/metadata/objectMetadataCache.ts
+++ b/apps/desktop/src/lib/metadata/objectMetadataCache.ts
@@ -20,6 +20,30 @@ interface InFlightLoad<T> {
 const inFlightLoads = new Map<string, InFlightLoad<unknown>>();
 const pendingInvalidations = new Map<string, Promise<void>>();
 
+async function loadSchemaCacheSafe<T>(cacheKey: string): Promise<T | null> {
+  try {
+    return await api.loadSchemaCache<T>(cacheKey);
+  } catch {
+    return null;
+  }
+}
+
+async function saveSchemaCacheSafe(cacheKey: string, payload: unknown): Promise<void> {
+  try {
+    await api.saveSchemaCache(cacheKey, payload);
+  } catch {
+    // Cache persistence is best effort and must not block metadata rendering.
+  }
+}
+
+async function deleteSchemaCachePrefixSafe(prefix: string): Promise<void> {
+  try {
+    await api.deleteSchemaCachePrefix(prefix);
+  } catch {
+    // Cache invalidation is best effort when running with a reduced backend.
+  }
+}
+
 export type ObjectMetadataFacet = "columns" | "indexes" | "foreign-keys" | "triggers" | "comment";
 
 function cacheSegment(value: string | undefined): string {
@@ -60,7 +84,7 @@ export async function loadObjectMetadataFacet<T>(request: ObjectDdlRequest, face
   await waitForPendingInvalidations(cacheKey);
 
   if (!options?.force) {
-    const cached = decodeEnvelope<T>(await api.loadSchemaCache<unknown>(cacheKey).catch(() => null));
+    const cached = decodeEnvelope<T>(await loadSchemaCacheSafe<unknown>(cacheKey));
     if (cached !== null) return { value: cached, cacheStatus: "disk" };
   }
 
@@ -77,7 +101,7 @@ export async function loadObjectMetadataFacet<T>(request: ObjectDdlRequest, face
       const serialized = JSON.stringify(value);
       if (!entry.invalidated && serialized.length <= MAX_PERSISTED_METADATA_CHARS) {
         const envelope: ObjectMetadataCacheEnvelope<T> = { version: 1, cachedAt: new Date().toISOString(), value };
-        await api.saveSchemaCache(cacheKey, envelope).catch(() => undefined);
+        await saveSchemaCacheSafe(cacheKey, envelope);
       }
       return value;
     })
@@ -98,12 +122,9 @@ export async function invalidateObjectMetadataCache(match: MetadataCacheInvalida
 
   const existing = pendingInvalidations.get(prefix);
   if (existing) return existing;
-  const deletion = api
-    .deleteSchemaCachePrefix(prefix)
-    .catch(() => undefined)
-    .finally(() => {
-      if (pendingInvalidations.get(prefix) === deletion) pendingInvalidations.delete(prefix);
-    });
+  const deletion = deleteSchemaCachePrefixSafe(prefix).finally(() => {
+    if (pendingInvalidations.get(prefix) === deletion) pendingInvalidations.delete(prefix);
+  });
   pendingInvalidations.set(prefix, deletion);
   return deletion;
 }

--- a/apps/desktop/src/lib/metadata/objectMetadataCache.ts
+++ b/apps/desktop/src/lib/metadata/objectMetadataCache.ts
@@ -51,7 +51,7 @@ function cacheSegment(value: string | undefined): string {
 }
 
 function facetKey(request: ObjectDdlRequest, facet: ObjectMetadataFacet): string {
-  return `${[OBJECT_METADATA_CACHE_PREFIX, cacheSegment(request.connectionId), cacheSegment(request.database), cacheSegment(request.schema), cacheSegment(request.catalog), cacheSegment(request.tableName), facet].join(":")}:`;
+  return `${[OBJECT_METADATA_CACHE_PREFIX, cacheSegment(request.connectionId), cacheSegment(request.database), cacheSegment(request.schema), cacheSegment(request.tableName), cacheSegment(request.catalog), facet].join(":")}:`;
 }
 
 function invalidationPrefix(match: MetadataCacheInvalidation): string {

--- a/apps/desktop/src/lib/metadata/objectMetadataCache.ts
+++ b/apps/desktop/src/lib/metadata/objectMetadataCache.ts
@@ -1,0 +1,109 @@
+import * as api from "@/lib/backend/api";
+import type { MetadataCacheInvalidation } from "./metadataResultCache";
+import type { ObjectDdlRequest } from "./objectDdlCache";
+
+const OBJECT_METADATA_CACHE_PREFIX = "object-meta:v1";
+const MAX_PERSISTED_METADATA_CHARS = 5 * 1024 * 1024;
+
+interface ObjectMetadataCacheEnvelope<T> {
+  version: 1;
+  cachedAt: string;
+  value: T;
+}
+
+interface InFlightLoad<T> {
+  force: boolean;
+  invalidated: boolean;
+  promise: Promise<T>;
+}
+
+const inFlightLoads = new Map<string, InFlightLoad<unknown>>();
+const pendingInvalidations = new Map<string, Promise<void>>();
+
+export type ObjectMetadataFacet = "columns" | "indexes" | "foreign-keys" | "triggers" | "comment";
+
+function cacheSegment(value: string | undefined): string {
+  return encodeURIComponent(value ?? "");
+}
+
+function facetKey(request: ObjectDdlRequest, facet: ObjectMetadataFacet): string {
+  return `${[OBJECT_METADATA_CACHE_PREFIX, cacheSegment(request.connectionId), cacheSegment(request.database), cacheSegment(request.schema), cacheSegment(request.catalog), cacheSegment(request.tableName), facet].join(":")}:`;
+}
+
+function invalidationPrefix(match: MetadataCacheInvalidation): string {
+  const parts = [OBJECT_METADATA_CACHE_PREFIX];
+  if (!match.connectionId) return `${OBJECT_METADATA_CACHE_PREFIX}:`;
+  parts.push(cacheSegment(match.connectionId));
+  if (!match.database) return `${parts.join(":")}:`;
+  parts.push(cacheSegment(match.database));
+  if (!match.schema) return `${parts.join(":")}:`;
+  parts.push(cacheSegment(match.schema));
+  if (!match.tableName) return `${parts.join(":")}:`;
+  parts.push(cacheSegment(match.tableName));
+  return `${parts.join(":")}:`;
+}
+
+function decodeEnvelope<T>(payload: unknown): T | null {
+  if (!payload || typeof payload !== "object") return null;
+  const envelope = payload as Partial<ObjectMetadataCacheEnvelope<T>>;
+  if (envelope.version !== 1 || typeof envelope.cachedAt !== "string" || !Number.isFinite(Date.parse(envelope.cachedAt)) || !("value" in envelope)) return null;
+  return envelope.value === undefined ? null : envelope.value;
+}
+
+async function waitForPendingInvalidations(cacheKey: string): Promise<void> {
+  const pending = [...pendingInvalidations.entries()].filter(([prefix]) => cacheKey.startsWith(prefix)).map(([, promise]) => promise);
+  if (pending.length) await Promise.all(pending);
+}
+
+export async function loadObjectMetadataFacet<T>(request: ObjectDdlRequest, facet: ObjectMetadataFacet, loader: () => Promise<T>, options?: { force?: boolean }): Promise<{ value: T; cacheStatus: "disk" | "remote" }> {
+  const cacheKey = facetKey(request, facet);
+  await waitForPendingInvalidations(cacheKey);
+
+  if (!options?.force) {
+    const cached = decodeEnvelope<T>(await api.loadSchemaCache<unknown>(cacheKey).catch(() => null));
+    if (cached !== null) return { value: cached, cacheStatus: "disk" };
+  }
+
+  const existing = inFlightLoads.get(cacheKey);
+  if (existing && (!options?.force || existing.force)) return { value: (await existing.promise) as T, cacheStatus: "remote" };
+  if (existing) {
+    existing.invalidated = true;
+    inFlightLoads.delete(cacheKey);
+  }
+
+  const entry: InFlightLoad<T> = { force: options?.force === true, invalidated: false, promise: Promise.resolve(undefined as T) };
+  entry.promise = loader()
+    .then(async (value) => {
+      const serialized = JSON.stringify(value);
+      if (!entry.invalidated && serialized.length <= MAX_PERSISTED_METADATA_CHARS) {
+        const envelope: ObjectMetadataCacheEnvelope<T> = { version: 1, cachedAt: new Date().toISOString(), value };
+        await api.saveSchemaCache(cacheKey, envelope).catch(() => undefined);
+      }
+      return value;
+    })
+    .finally(() => {
+      if (inFlightLoads.get(cacheKey) === entry) inFlightLoads.delete(cacheKey);
+    });
+  inFlightLoads.set(cacheKey, entry as InFlightLoad<unknown>);
+  return { value: await entry.promise, cacheStatus: "remote" };
+}
+
+export async function invalidateObjectMetadataCache(match: MetadataCacheInvalidation): Promise<void> {
+  const prefix = invalidationPrefix(match);
+  for (const [cacheKey, entry] of inFlightLoads) {
+    if (!cacheKey.startsWith(prefix)) continue;
+    entry.invalidated = true;
+    inFlightLoads.delete(cacheKey);
+  }
+
+  const existing = pendingInvalidations.get(prefix);
+  if (existing) return existing;
+  const deletion = api
+    .deleteSchemaCachePrefix(prefix)
+    .catch(() => undefined)
+    .finally(() => {
+      if (pendingInvalidations.get(prefix) === deletion) pendingInvalidations.delete(prefix);
+    });
+  pendingInvalidations.set(prefix, deletion);
+  return deletion;
+}

--- a/apps/desktop/src/lib/table/tableStructureMetadataLoading.ts
+++ b/apps/desktop/src/lib/table/tableStructureMetadataLoading.ts
@@ -9,15 +9,18 @@ export interface TableStructureRefreshScope {
 }
 
 export function visibleTableStructureRefreshScope(activeTab: TableInfoTab): TableStructureRefreshScope {
-  return {
-    columns: true,
-    indexes: true,
-    foreignKeys: true,
-    // Trigger definitions can contain large source bodies, so defer them until
-    // the trigger editor is actually visible.
-    triggers: activeTab === "triggers",
-    tableComment: true,
-  };
+  switch (activeTab) {
+    case "columns":
+      return { columns: true, indexes: false, foreignKeys: false, triggers: false, tableComment: true };
+    case "indexes":
+      return { columns: true, indexes: true, foreignKeys: false, triggers: false, tableComment: true };
+    case "foreignKeys":
+      return { columns: true, indexes: false, foreignKeys: true, triggers: false, tableComment: true };
+    case "triggers":
+      return { columns: false, indexes: false, foreignKeys: false, triggers: true, tableComment: true };
+    case "ddl":
+      return { columns: false, indexes: false, foreignKeys: false, triggers: false, tableComment: false };
+  }
 }
 
 export const TRIGGERS_ONLY_REFRESH_SCOPE: TableStructureRefreshScope = {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -111,6 +111,7 @@ import { createMetadataLoadTrace, logMetadataLoadTrace, MetadataLoadCoordinator,
 import type { MetadataScopeInput } from "@/lib/metadata/metadataLoadScope";
 import { MetadataResultCache, type MetadataCacheInvalidation } from "@/lib/metadata/metadataResultCache";
 import { invalidateTableMetadataCache } from "@/lib/metadata/tableMetadataCache";
+import { invalidateObjectDdlCache } from "@/lib/metadata/objectDdlCache";
 import { invalidateObjectBrowserRowsCache } from "@/lib/table/objectBrowserRowsCache";
 import { MetadataTaskLimiter } from "@/lib/metadata/metadataTaskLimiter";
 import { TreeNodeLoadRegistry, type TreeNodeLoadHandle } from "@/lib/metadata/treeNodeLoadHandle";
@@ -1505,16 +1506,20 @@ export const useConnectionStore = defineStore("connection", () => {
   function invalidateMetadataCachesForNode(node: TreeNode) {
     if (!node.connectionId) return;
     const tableName = node.tableName || (node.type === "table" || node.type === "view" || node.type === "materialized_view" || node.type === "mongo-collection" ? node.label : undefined);
-    invalidateMetadataCaches({
+    const match = {
       connectionId: node.connectionId,
       database: node.database || undefined,
       schema: node.schema || undefined,
       tableName,
-    });
+    };
+    invalidateMetadataCaches(match);
+    void invalidateObjectDdlCache(match);
   }
 
   function invalidateMetadataCache(connectionId: string, database?: string, schema?: string, tableName?: string) {
-    invalidateMetadataCaches({ connectionId, database, schema, tableName });
+    const match = { connectionId, database, schema, tableName };
+    invalidateMetadataCaches(match);
+    void invalidateObjectDdlCache(match);
   }
 
   function buildLoadMoreNode(parent: TreeNode, offset: number, pageSize: number): TreeNode {
@@ -2355,6 +2360,7 @@ export const useConnectionStore = defineStore("connection", () => {
     if (treeSelectionAnchorId.value && removedIds.has(treeSelectionAnchorId.value)) treeSelectionAnchorId.value = null;
     for (const id of removedIds) {
       invalidateCompletionCache(id);
+      void invalidateObjectDdlCache({ connectionId: id });
       clearLoadedChildrenCache(id);
       void deleteTabResultSnapshotsForOwner(id);
     }
@@ -2379,6 +2385,7 @@ export const useConnectionStore = defineStore("connection", () => {
     clearConnectionIdentifierQuote(config.id);
     clearConnectionHealthCheck(config.id);
     invalidateCompletionCache(config.id);
+    void invalidateObjectDdlCache({ connectionId: config.id });
     clearLoadedChildrenCache(config.id);
     const node = findConnectionNode(config.id);
     if (node?.isExpanded) {
@@ -5156,7 +5163,9 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   async function refreshObjectListTreeNode(connectionId: string, database: string, schema?: string, catalog?: string) {
-    invalidateMetadataCaches({ connectionId, database, schema });
+    const match = { connectionId, database, schema };
+    invalidateMetadataCaches(match);
+    void invalidateObjectDdlCache(match);
     const shouldRefreshSchemaNode = !!schema && !catalog;
     const node = shouldRefreshSchemaNode ? findNode(treeNodes.value, `${connectionId}:${database}:${schema}`) : null;
     if (node) {


### PR DESCRIPTION
引入 objectDdlCache 和 objectMetadataCache 模块实现持久化缓存
在连接存储中集成新的缓存失效逻辑，统一管理元数据缓存
重构 DDL 视图对话框使用新的缓存加载机制替代直接 API 调用
为结构编辑器添加强制刷新按钮并改进加载状态控制
更新测试用例验证新的缓存和失效行为
优化表结构编辑器中的元数据加载流程和并发控制

## 变更说明

本 PR 优化 SQL 查询编辑器中通过 Ctrl + 左键 打开表 DDL 和表结构编辑器的加载体验。

DDL、列、索引、外键、触发器和表注释现在按表对象分别持久化到本地 SQLite 的 schema_cache 中。表树继续使用原有的树节点缓存格式和 key，不与对象详情缓存混用；两者通过对象级失效逻辑保持一致。

打开 DDL 标签时只读取 DDL 缓存，不再同时远程加载整套表结构元数据。切换到列、索引、外键或触发器标签时，再按需加载对应 facet。关闭标签后重新打开时，优先读取磁盘缓存，不依赖常驻内存状态。

用户点击结构编辑器刷新按钮时，会统一失效当前表的 DDL、列、索引、外键、触发器、表注释及相关内存缓存，并仅强制刷新当前标签；其他标签在切换时再加载最新数据。DBX 保存表结构后也会执行同样的对象级失效，避免不同标签显示不同版本的元数据。

缓存加载支持并发请求合并，失效期间已经启动的旧请求不会重新写回磁盘缓存。单条过大的 DDL 或元数据结果不会持久化，避免缓存异常膨胀。

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [x] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] pnpm typecheck 通过
- [x] 对象缓存测试通过：9/9
- [x] 元数据相关测试通过：37/37
- [x] 触及文件 oxlint 通过
- [x] git diff --check 通过
- [x] pnpm build 通过，Vite 成功转换 4800 个模块

手动验证重点：

首次打开表 DDL，确认产生本地 schema_cache 记录。
关闭 DDL 标签后再次打开，确认直接显示缓存内容且不重新请求 DDL。
点击刷新按钮，确认当前标签重新远程查询并覆盖磁盘缓存。
切换列、索引、外键和触发器标签，确认各自按需读取缓存或发起首次查询。
修改并保存表结构，确认相关对象缓存全部失效。

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
