### PR TITLE
🐛 fix(desktop): 固定更新下载按钮宽度避免进度变化时抖动

### DIFF
--- a/apps/desktop/src/components/layout/UpdateDialog.spec.ts
+++ b/apps/desktop/src/components/layout/UpdateDialog.spec.ts
@@ -172,6 +172,19 @@ describe("UpdateDialog active task guard", () => {
   });
 });
 
+describe("UpdateDialog download progress", () => {
+  it("keeps the downloading button at a fixed width as progress changes", async () => {
+    const { state } = await mountDialog(0, { isDownloadingUpdate: true, downloadProgress: 9 });
+
+    expect(buttonWithText("Downloading 9%")?.classList.contains("w-52")).toBe(true);
+
+    state.downloadProgress = 100;
+    await flushDialog();
+
+    expect(buttonWithText("Downloading 100%")?.classList.contains("w-52")).toBe(true);
+  });
+});
+
 describe("UpdateDialog close protection", () => {
   it("cancels the background download when the close button is clicked", async () => {
     const { state, cancelDownload } = await mountDialog(0, { isDownloadingUpdate: true, downloadProgress: 42 });

--- a/apps/desktop/src/components/layout/UpdateDialog.vue
+++ b/apps/desktop/src/components/layout/UpdateDialog.vue
@@ -144,7 +144,7 @@ watch(
               <Loader2 class="h-4 w-4 animate-spin" />
               {{ t("updates.installing") }}
             </Button>
-            <Button v-else-if="isDownloadingUpdate" disabled>
+            <Button v-else-if="isDownloadingUpdate" class="w-52" disabled>
               <Loader2 class="h-4 w-4 animate-spin" />
               {{ t("updates.downloading", { progress: downloadProgress }) }}
             </Button>


### PR DESCRIPTION
- 为下载中按钮添加固定宽度样式
- 补充不同下载进度下按钮宽度保持一致的测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #4963