### PR TITLE
fix(grid): grow default column widths for large page values

### DIFF
--- a/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
@@ -1,19 +1,29 @@
 // @vitest-environment happy-dom
 
-import { computed, nextTick, ref } from "vue";
+import { computed, isRef, nextTick, ref } from "vue";
 import { beforeEach, describe, expect, it } from "vitest";
-import { DATA_GRID_COL_AUTO_FIT_MAX_WIDTH, DATA_GRID_COL_MIN_WIDTH } from "@/lib/dataGrid/dataGridColumnWidth";
+import { DATA_GRID_COL_AUTO_FIT_MAX_WIDTH, DATA_GRID_COL_MIN_WIDTH, sampleDataGridColumnValues } from "@/lib/dataGrid/dataGridColumnWidth";
 import { clearDataGridColumnWidthStates, createDataGridColumnMeasurementSignature, createDataGridColumnStructureSignature, DATA_GRID_COLUMN_WIDTH_STATE_LIMIT, dataGridColumnWidthStateCount, loadDataGridColumnWidthState, saveDataGridColumnWidthState } from "@/lib/dataGrid/dataGridColumnWidthState";
-import { DATA_GRID_ROW_NUM_WIDTH, dataGridRowNumberColumnWidth, resizeDataGridColumnWidth, resolveDataGridMaxRowNumber, useDataGridColumnResize } from "@/composables/useDataGridColumnResize";
+import { DATA_GRID_ROW_NUM_WIDTH, dataGridRowNumberColumnWidth, resizeDataGridColumnWidth, useDataGridColumnResize } from "@/composables/useDataGridColumnResize";
 
-function createResizeState(options: { columns: string[]; rows: Array<Array<string | number | boolean | null>>; columnIndexes?: number[]; columnTypes?: string[]; cacheKey?: string; density?: "compact" | "standard" | "comfortable"; compactColumnHeaderActions?: boolean; headerTextWidth?: number }) {
+function createResizeState(options: {
+  columns: string[];
+  rows: Array<Array<string | number | boolean | null>> | ReturnType<typeof ref<Array<Array<string | number | boolean | null>>>>;
+  columnIndexes?: number[];
+  columnTypes?: string[];
+  cacheKey?: string;
+  density?: "compact" | "standard" | "comfortable";
+  compactColumnHeaderActions?: boolean;
+  headerTextWidth?: number;
+}) {
   const compact = ref(options.compactColumnHeaderActions ?? true);
   const headerTextWidth = ref(options.headerTextWidth);
   const headerMeasurementKey = ref(0);
   const density = ref(options.density ?? "standard");
+  const rows = isRef(options.rows) ? options.rows : ref(options.rows);
   const state = useDataGridColumnResize({
     columns: computed(() => options.columns),
-    sourceRows: computed(() => options.rows),
+    sourceRows: computed(() => rows.value),
     columnIndexes: computed(() => options.columnIndexes ?? options.columns.map((_, index) => index)),
     density,
     compactColumnHeaderActions: computed(() => compact.value),
@@ -24,6 +34,7 @@ function createResizeState(options: { columns: string[]; rows: Array<Array<strin
   });
   return {
     ...state,
+    rows,
     setCompact(v: boolean) {
       compact.value = v;
     },
@@ -65,13 +76,13 @@ describe("useDataGridColumnResize", () => {
     });
 
     state.initColumnWidths();
-    // standard valueTextLimit=40, 120 chars → truncated to 40: 40×8+24=344
-    // header "description"=11×8+85=173 < 344 → 344
-    expect(state.columnWidths.value[0]).toBe(344);
+    // standard valueTextLimit=40, 120 chars → truncated to 40: 40×8+24+12=356
+    // header "description"=11×8+59=147 < 356 → 356
+    expect(state.columnWidths.value[0]).toBe(356);
 
     state.autoFitColumn(0);
 
-    expect(state.columnWidths.value[0]).toBeGreaterThan(344);
+    expect(state.columnWidths.value[0]).toBeGreaterThan(356);
     expect(state.columnWidths.value[0]).toBeLessThanOrEqual(DATA_GRID_COL_AUTO_FIT_MAX_WIDTH);
   });
 
@@ -274,9 +285,43 @@ describe("useDataGridColumnResize", () => {
 
     state.initColumnWidths();
     // P95 of 50 samples ignores the single 200-char outlier;
-    // "short" = 5 chars → 5×8+24=64, header "data"=4×8+59=91 → max=91
+    // "short" = 5 chars → 5×8+24+12=76, header "data"=4×8+59=91 → max=91
     expect(state.columnWidths.value[0]).toBeLessThan(600);
     expect(state.columnWidths.value[0]).toBe(91);
+  });
+
+  it("sizes short numeric columns from large sample values", () => {
+    const state = createResizeState({
+      columns: ["id"],
+      rows: Array.from({ length: 20 }, (_, index) => [1_217_001 + index]),
+      density: "standard",
+      compactColumnHeaderActions: true,
+    });
+
+    state.initColumnWidths();
+
+    // "1217001" → 7×8+24+12=92, wider than header-only "id" (~75)
+    expect(state.columnWidths.value[0]).toBeGreaterThanOrEqual(92);
+  });
+
+  it("grows cached narrow columns when later pages introduce larger values", async () => {
+    const rows = ref<Array<Array<string | number | boolean | null>>>([[1], [2], [3]]);
+    const state = createResizeState({
+      columns: ["id"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+      cacheKey: "result-grow",
+    });
+
+    state.initColumnWidths();
+    const narrowWidth = state.columnWidths.value[0];
+
+    rows.value = Array.from({ length: 20 }, (_, index) => [1_217_001 + index]);
+    await nextTick();
+
+    expect(state.columnWidths.value[0]).toBeGreaterThan(narrowWidth);
+    expect(state.columnWidths.value[0]).toBeGreaterThanOrEqual(92);
   });
 
   it("comfortable mode is never narrower than standard for the same column", () => {
@@ -299,6 +344,13 @@ describe("useDataGridColumnResize", () => {
     comf.initColumnWidths();
 
     expect(comf.columnWidths.value[0]).toBeGreaterThanOrEqual(std.columnWidths.value[0]);
+  });
+});
+
+describe("sampleDataGridColumnValues", () => {
+  it("includes both the head and tail of a long row window", () => {
+    const rows = Array.from({ length: 100 }, (_, index) => [index + 1, `row-${index + 1}`]);
+    expect(sampleDataGridColumnValues(rows, 0, 10)).toEqual([1, 2, 3, 4, 5, 96, 97, 98, 99, 100]);
   });
 });
 

--- a/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
@@ -133,6 +133,15 @@ describe("useDataGridColumnResize", () => {
     first.onResizeStart(1, new MouseEvent("mousedown", { clientX: 100, cancelable: true }));
     document.dispatchEvent(new MouseEvent("mouseup", { clientX: 160 }));
     expect(first.columnWidths.value[1]).toBe(originalWidth + 60);
+    const persisted = loadDataGridColumnWidthState(
+      {
+        cacheKey: "result-a",
+        structureSignature: createDataGridColumnStructureSignature(["id", "name"]),
+        measurementSignature: createDataGridColumnMeasurementSignature("standard", true, 0),
+      },
+      [0, 1],
+    );
+    expect(persisted?.userSizedColumnIndexes).toEqual(new Set([1]));
 
     const remounted = createResizeState({
       columns: ["id", "name"],
@@ -188,15 +197,15 @@ describe("useDataGridColumnResize", () => {
     const structureSignature = createDataGridColumnStructureSignature(["id"]);
     const measurementSignature = createDataGridColumnMeasurementSignature("standard", true, 14);
     for (let index = 0; index < DATA_GRID_COLUMN_WIDTH_STATE_LIMIT; index++) {
-      saveDataGridColumnWidthState({ cacheKey: `result-${index}`, structureSignature, measurementSignature }, [0], [100 + index]);
+      saveDataGridColumnWidthState({ cacheKey: `result-${index}`, structureSignature, measurementSignature }, [0], [100 + index], new Set());
     }
-    expect(loadDataGridColumnWidthState({ cacheKey: "result-0", structureSignature, measurementSignature }, [0])).toEqual([100]);
-    saveDataGridColumnWidthState({ cacheKey: `result-${DATA_GRID_COLUMN_WIDTH_STATE_LIMIT}`, structureSignature, measurementSignature }, [0], [100 + DATA_GRID_COLUMN_WIDTH_STATE_LIMIT]);
+    expect(loadDataGridColumnWidthState({ cacheKey: "result-0", structureSignature, measurementSignature }, [0])?.widths).toEqual([100]);
+    saveDataGridColumnWidthState({ cacheKey: `result-${DATA_GRID_COLUMN_WIDTH_STATE_LIMIT}`, structureSignature, measurementSignature }, [0], [100 + DATA_GRID_COLUMN_WIDTH_STATE_LIMIT], new Set());
 
     expect(dataGridColumnWidthStateCount()).toBe(DATA_GRID_COLUMN_WIDTH_STATE_LIMIT);
     expect(loadDataGridColumnWidthState({ cacheKey: "result-1", structureSignature, measurementSignature }, [0])).toBeUndefined();
-    expect(loadDataGridColumnWidthState({ cacheKey: "result-0", structureSignature, measurementSignature }, [0])).toEqual([100]);
-    expect(loadDataGridColumnWidthState({ cacheKey: `result-${DATA_GRID_COLUMN_WIDTH_STATE_LIMIT}`, structureSignature, measurementSignature }, [0])).toEqual([100 + DATA_GRID_COLUMN_WIDTH_STATE_LIMIT]);
+    expect(loadDataGridColumnWidthState({ cacheKey: "result-0", structureSignature, measurementSignature }, [0])?.widths).toEqual([100]);
+    expect(loadDataGridColumnWidthState({ cacheKey: `result-${DATA_GRID_COLUMN_WIDTH_STATE_LIMIT}`, structureSignature, measurementSignature }, [0])?.widths).toEqual([100 + DATA_GRID_COLUMN_WIDTH_STATE_LIMIT]);
   });
 
   it("recalculates column widths when compactColumnHeaderActions changes", async () => {
@@ -322,6 +331,93 @@ describe("useDataGridColumnResize", () => {
 
     expect(state.columnWidths.value[0]).toBeGreaterThan(narrowWidth);
     expect(state.columnWidths.value[0]).toBeGreaterThanOrEqual(92);
+
+    const remounted = createResizeState({
+      columns: ["id"],
+      rows: Array.from({ length: 20 }, () => ["x".repeat(40)]),
+      density: "standard",
+      compactColumnHeaderActions: true,
+      cacheKey: "result-grow",
+    });
+    remounted.initColumnWidths();
+    expect(remounted.columnWidths.value[0]).toBe(356);
+  });
+
+  it("grows when the width percentile changes without changing the maximum value length", async () => {
+    const rows = ref<Array<Array<string | number | boolean | null>>>([...Array.from({ length: 49 }, () => ["x"]), ["x".repeat(40)]]);
+    const state = createResizeState({
+      columns: ["id"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+    });
+
+    state.initColumnWidths();
+    expect(state.columnWidths.value[0]).toBe(75);
+
+    rows.value = [["x"], ...Array.from({ length: 49 }, () => ["x".repeat(40)])];
+    await nextTick();
+
+    expect(state.columnWidths.value[0]).toBe(356);
+  });
+
+  it("preserves a manually narrowed width across page changes and remounts", async () => {
+    const rows = ref<Array<Array<string | number | boolean | null>>>(Array.from({ length: 20 }, (_, index) => [1_217_001 + index]));
+    const state = createResizeState({
+      columns: ["id"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+      cacheKey: "manual-narrow",
+    });
+
+    state.initColumnWidths();
+    state.onResizeStart(0, new MouseEvent("mousedown", { clientX: 100, cancelable: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { clientX: 0 }));
+    expect(state.columnWidths.value[0]).toBe(DATA_GRID_COL_MIN_WIDTH);
+
+    rows.value = Array.from({ length: 20 }, () => ["x".repeat(40)]);
+    await nextTick();
+    expect(state.columnWidths.value[0]).toBe(DATA_GRID_COL_MIN_WIDTH);
+
+    const remounted = createResizeState({
+      columns: ["id"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+      cacheKey: "manual-narrow",
+    });
+    remounted.initColumnWidths();
+    expect(remounted.columnWidths.value[0]).toBe(DATA_GRID_COL_MIN_WIDTH);
+  });
+
+  it("preserves an explicit auto-fit width across page changes and remounts", async () => {
+    const rows = ref<Array<Array<string | number | boolean | null>>>([[1], [2], [3]]);
+    const state = createResizeState({
+      columns: ["id"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+      cacheKey: "manual-auto-fit",
+    });
+
+    state.initColumnWidths();
+    state.autoFitColumn(0);
+    const fittedWidth = state.columnWidths.value[0];
+
+    rows.value = Array.from({ length: 20 }, () => ["x".repeat(40)]);
+    await nextTick();
+    expect(state.columnWidths.value[0]).toBe(fittedWidth);
+
+    const remounted = createResizeState({
+      columns: ["id"],
+      rows,
+      density: "standard",
+      compactColumnHeaderActions: true,
+      cacheKey: "manual-auto-fit",
+    });
+    remounted.initColumnWidths();
+    expect(remounted.columnWidths.value[0]).toBe(fittedWidth);
   });
 
   it("comfortable mode is never narrower than standard for the same column", () => {

--- a/apps/desktop/src/composables/useDataGridColumnResize.ts
+++ b/apps/desktop/src/composables/useDataGridColumnResize.ts
@@ -1,5 +1,5 @@
 import { ref, computed, watch, type ComputedRef, type Ref } from "vue";
-import { calculateDataGridColumnWidth, DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT, DATA_GRID_COL_AUTO_FIT_MAX_WIDTH, DATA_GRID_COL_MIN_WIDTH, COLUMN_WIDTH_DENSITY_PRESETS } from "@/lib/dataGrid/dataGridColumnWidth";
+import { calculateDataGridColumnWidth, DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT, DATA_GRID_COL_AUTO_FIT_MAX_WIDTH, DATA_GRID_COL_MIN_WIDTH, COLUMN_WIDTH_DENSITY_PRESETS, sampleDataGridColumnValues } from "@/lib/dataGrid/dataGridColumnWidth";
 import { createDataGridColumnMeasurementSignature, loadDataGridColumnWidthState, removeDataGridColumnWidthState, saveDataGridColumnWidthState } from "@/lib/dataGrid/dataGridColumnWidthState";
 import type { ColumnWidthDensity } from "@/stores/settingsStore";
 
@@ -64,14 +64,54 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
 
   function sampleColumnValues(visibleColIdx: number): CellValue[] {
     const actualColIdx = columnIndexes.value[visibleColIdx];
-    const rows = sourceRows.value;
+    if (actualColIdx === undefined) return [];
     const preset = COLUMN_WIDTH_DENSITY_PRESETS[density.value];
-    const end = Math.min(rows.length, preset.sampleRows);
-    const values: CellValue[] = [];
-    for (let i = 0; i < end; i++) {
-      values.push(rows[i][actualColIdx] ?? null);
+    return sampleDataGridColumnValues(sourceRows.value, actualColIdx, preset.sampleRows);
+  }
+
+  function neededColumnWidth(colIdx: number): number {
+    const colName = columns.value[colIdx];
+    if (!colName) return DATA_GRID_COL_MIN_WIDTH;
+    return calculateDataGridColumnWidth({
+      columnName: colName,
+      sampleValues: sampleColumnValues(colIdx),
+      density: density.value,
+      compactColumnHeaderActions: compactColumnHeaderActions.value,
+      headerTextWidth: measureHeaderText?.(colName),
+    });
+  }
+
+  /** Grow-only: late pages with larger keys must not stay stuck at a short-header / early-page width. */
+  function growColumnWidthsToFitSamples() {
+    if (columnWidths.value.length !== columns.value.length || columns.value.length === 0) return;
+    let grew = false;
+    const next = columnWidths.value.slice();
+    for (let colIdx = 0; colIdx < columns.value.length; colIdx++) {
+      const needed = neededColumnWidth(colIdx);
+      if (needed > (next[colIdx] ?? 0)) {
+        next[colIdx] = needed;
+        grew = true;
+      }
     }
-    return values;
+    if (!grew) return;
+    columnWidths.value = next;
+    persistColumnWidths();
+  }
+
+  function sampleFitSignature(): string {
+    const preset = COLUMN_WIDTH_DENSITY_PRESETS[density.value];
+    return columnIndexes.value
+      .map((actualColIdx) => {
+        const values = sampleDataGridColumnValues(sourceRows.value, actualColIdx, preset.sampleRows);
+        let maxLen = 0;
+        for (const value of values) {
+          if (value == null) continue;
+          const text = typeof value === "object" ? JSON.stringify(value) : String(value);
+          maxLen = Math.max(maxLen, Math.min(text.length, preset.valueTextLimit));
+        }
+        return `${actualColIdx}:${maxLen}`;
+      })
+      .join("|");
   }
 
   function initColumnWidths(force = false) {
@@ -100,6 +140,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
       });
     }
     previousColumnIndexes = nextColumnIndexes;
+    growColumnWidthsToFitSamples();
   }
 
   function onResizeStart(colIdx: number, event: MouseEvent) {
@@ -195,10 +236,12 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
     removeDataGridColumnWidthState(options.cacheKey?.value);
     initColumnWidths(true);
   });
+  watch(sampleFitSignature, () => growColumnWidthsToFitSamples());
 
   return {
     columnWidths,
     initColumnWidths,
+    growColumnWidthsToFitSamples,
     onResizeStart,
     autoFitColumn,
     renderedColumnWidths,

--- a/apps/desktop/src/composables/useDataGridColumnResize.ts
+++ b/apps/desktop/src/composables/useDataGridColumnResize.ts
@@ -49,6 +49,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
   const columnWidths = ref<number[]>([]);
   let isResizing = false;
   let previousColumnIndexes: number[] = [];
+  let userSizedColumnIndexes = new Set<number>();
 
   function columnWidthStateIdentity() {
     return {
@@ -59,7 +60,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
   }
 
   function persistColumnWidths() {
-    saveDataGridColumnWidthState(columnWidthStateIdentity(), previousColumnIndexes, columnWidths.value);
+    saveDataGridColumnWidthState(columnWidthStateIdentity(), previousColumnIndexes, columnWidths.value, userSizedColumnIndexes);
   }
 
   function sampleColumnValues(visibleColIdx: number): CellValue[] {
@@ -81,13 +82,18 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
     });
   }
 
+  const neededColumnWidths = computed(() => columns.value.map((_, colIdx) => neededColumnWidth(colIdx)));
+  const neededColumnWidthSignature = computed(() => neededColumnWidths.value.join("|"));
+
   /** Grow-only: late pages with larger keys must not stay stuck at a short-header / early-page width. */
-  function growColumnWidthsToFitSamples() {
+  function growColumnWidthsToFitSamples(neededWidths = neededColumnWidths.value) {
     if (columnWidths.value.length !== columns.value.length || columns.value.length === 0) return;
     let grew = false;
     const next = columnWidths.value.slice();
     for (let colIdx = 0; colIdx < columns.value.length; colIdx++) {
-      const needed = neededColumnWidth(colIdx);
+      const actualColIdx = columnIndexes.value[colIdx];
+      if (actualColIdx === undefined || userSizedColumnIndexes.has(actualColIdx)) continue;
+      const needed = neededWidths[colIdx] ?? DATA_GRID_COL_MIN_WIDTH;
       if (needed > (next[colIdx] ?? 0)) {
         next[colIdx] = needed;
         grew = true;
@@ -98,49 +104,35 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
     persistColumnWidths();
   }
 
-  function sampleFitSignature(): string {
-    const preset = COLUMN_WIDTH_DENSITY_PRESETS[density.value];
-    return columnIndexes.value
-      .map((actualColIdx) => {
-        const values = sampleDataGridColumnValues(sourceRows.value, actualColIdx, preset.sampleRows);
-        let maxLen = 0;
-        for (const value of values) {
-          if (value == null) continue;
-          const text = typeof value === "object" ? JSON.stringify(value) : String(value);
-          maxLen = Math.max(maxLen, Math.min(text.length, preset.valueTextLimit));
-        }
-        return `${actualColIdx}:${maxLen}`;
-      })
-      .join("|");
+  function markColumnUserSized(visibleColIdx: number) {
+    const actualColIdx = columnIndexes.value[visibleColIdx];
+    if (actualColIdx !== undefined) userSizedColumnIndexes.add(actualColIdx);
   }
 
   function initColumnWidths(force = false) {
+    if (force) userSizedColumnIndexes.clear();
     const previousWidthsByColumnIndex = new Map<number, number>();
     previousColumnIndexes.forEach((columnIndex, visibleIndex) => {
       const width = columnWidths.value[visibleIndex];
       if (width !== undefined) previousWidthsByColumnIndex.set(columnIndex, width);
     });
     const nextColumnIndexes = [...columnIndexes.value];
-    const cachedWidths = !force && previousColumnIndexes.length === 0 ? loadDataGridColumnWidthState(columnWidthStateIdentity(), nextColumnIndexes) : undefined;
+    const cachedState = !force && previousColumnIndexes.length === 0 ? loadDataGridColumnWidthState(columnWidthStateIdentity(), nextColumnIndexes) : undefined;
+    if (cachedState) userSizedColumnIndexes = new Set(cachedState.userSizedColumnIndexes);
+    const currentNeededWidths = neededColumnWidths.value;
     if (force || columnWidths.value.length !== columns.value.length || previousColumnIndexes.join("\0") !== nextColumnIndexes.join("\0")) {
-      columnWidths.value = columns.value.map((colName, colIdx) => {
+      columnWidths.value = columns.value.map((_, colIdx) => {
         if (!force) {
           const existingWidth = previousWidthsByColumnIndex.get(nextColumnIndexes[colIdx]);
           if (existingWidth !== undefined) return existingWidth;
-          const cachedWidth = cachedWidths?.[colIdx];
+          const cachedWidth = cachedState?.widths[colIdx];
           if (cachedWidth !== undefined) return cachedWidth;
         }
-        return calculateDataGridColumnWidth({
-          columnName: colName,
-          sampleValues: sampleColumnValues(colIdx),
-          density: density.value,
-          compactColumnHeaderActions: compactColumnHeaderActions.value,
-          headerTextWidth: measureHeaderText?.(colName),
-        });
+        return currentNeededWidths[colIdx] ?? DATA_GRID_COL_MIN_WIDTH;
       });
     }
     previousColumnIndexes = nextColumnIndexes;
-    growColumnWidthsToFitSamples();
+    growColumnWidthsToFitSamples(currentNeededWidths);
   }
 
   function onResizeStart(colIdx: number, event: MouseEvent) {
@@ -177,6 +169,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
       cancelPendingFrame();
       pendingClientX = e.clientX;
       applyPendingWidth();
+      markColumnUserSized(colIdx);
       persistColumnWidths();
       requestAnimationFrame(() => {
         isResizing = false;
@@ -199,6 +192,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
       includeValues: true,
       headerTextWidth: measureHeaderText?.(colName),
     });
+    markColumnUserSized(colIdx);
     persistColumnWidths();
   }
 
@@ -229,6 +223,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
   watch([() => options.cacheKey?.value, options.columnStructureSignature], () => {
     columnWidths.value = [];
     previousColumnIndexes = [];
+    userSizedColumnIndexes.clear();
     initColumnWidths();
   });
   watch([density, compactColumnHeaderActions, () => options.headerMeasurementKey?.value], () => {
@@ -236,7 +231,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
     removeDataGridColumnWidthState(options.cacheKey?.value);
     initColumnWidths(true);
   });
-  watch(sampleFitSignature, () => growColumnWidthsToFitSamples());
+  watch(neededColumnWidthSignature, () => growColumnWidthsToFitSamples(neededColumnWidths.value));
 
   return {
     columnWidths,

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
@@ -12,6 +12,8 @@ export const DATA_GRID_CELL_PADDING = 28;
 export const DATA_GRID_SAMPLE_ROWS = 50;
 export const DATA_GRID_VALUE_TEXT_LIMIT = 60;
 export const DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT = 160;
+/** Extra px so tabular digits at default table font (13px) are not ellipsized by a tight charWidth estimate. */
+export const DATA_GRID_VALUE_WIDTH_SLACK = 12;
 
 export interface ColumnWidthDensityPreset {
   charWidth: number;
@@ -112,11 +114,29 @@ export function calculateDataGridColumnWidth(options: { columnName: string; samp
     const text = displaySampleValue(value);
     if (text == null) continue;
     const displayLen = Math.min(text.length, valueTextLimit);
-    valueWidths.push(displayLen * preset.charWidth + preset.cellPadding);
+    valueWidths.push(displayLen * preset.charWidth + preset.cellPadding + DATA_GRID_VALUE_WIDTH_SLACK);
   }
 
   const valueWidth = percentileValue(valueWidths, preset.valueWidthPercentile);
   const maxContentWidth = Math.max(headerWidth, Math.min(maxAllowedWidth, valueWidth));
 
   return Math.max(DATA_GRID_COL_MIN_WIDTH, Math.round(maxContentWidth));
+}
+
+/** Sample from the start and end of the row window so late pages / infinite-scroll tails affect default width. */
+export function sampleDataGridColumnValues(rows: readonly CellValue[][], columnIndex: number, sampleRows: number): CellValue[] {
+  const limit = Math.max(1, sampleRows);
+  if (rows.length <= limit) {
+    return rows.map((row) => row[columnIndex] ?? null);
+  }
+  const headCount = Math.ceil(limit / 2);
+  const tailCount = limit - headCount;
+  const values: CellValue[] = [];
+  for (let index = 0; index < headCount; index++) {
+    values.push(rows[index]?.[columnIndex] ?? null);
+  }
+  for (let index = rows.length - tailCount; index < rows.length; index++) {
+    values.push(rows[index]?.[columnIndex] ?? null);
+  }
+  return values;
 }

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnWidthState.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnWidthState.ts
@@ -6,12 +6,18 @@ interface DataGridColumnWidthState {
   structureSignature: string;
   measurementSignature: string;
   widthsByColumnIndex: Map<number, number>;
+  userSizedColumnIndexes: Set<number>;
 }
 
 interface DataGridColumnWidthStateIdentity {
   cacheKey?: string;
   structureSignature: string;
   measurementSignature: string;
+}
+
+export interface DataGridColumnWidthStateSnapshot {
+  widths: Array<number | undefined>;
+  userSizedColumnIndexes: Set<number>;
 }
 
 const columnWidthStates = new Map<string, DataGridColumnWidthState>();
@@ -29,7 +35,7 @@ export function createDataGridColumnMeasurementSignature(density: ColumnWidthDen
   return JSON.stringify([density, compactColumnHeaderActions, headerMeasurementKey ?? null]);
 }
 
-export function loadDataGridColumnWidthState(identity: DataGridColumnWidthStateIdentity, columnIndexes: readonly number[]): Array<number | undefined> | undefined {
+export function loadDataGridColumnWidthState(identity: DataGridColumnWidthStateIdentity, columnIndexes: readonly number[]): DataGridColumnWidthStateSnapshot | undefined {
   const cacheKey = identity.cacheKey?.trim();
   if (!cacheKey) return undefined;
   const state = columnWidthStates.get(cacheKey);
@@ -39,22 +45,29 @@ export function loadDataGridColumnWidthState(identity: DataGridColumnWidthStateI
     return undefined;
   }
   touchColumnWidthState(cacheKey, state);
-  return columnIndexes.map((columnIndex) => state.widthsByColumnIndex.get(columnIndex));
+  return {
+    widths: columnIndexes.map((columnIndex) => state.widthsByColumnIndex.get(columnIndex)),
+    userSizedColumnIndexes: new Set(state.userSizedColumnIndexes),
+  };
 }
 
-export function saveDataGridColumnWidthState(identity: DataGridColumnWidthStateIdentity, columnIndexes: readonly number[], widths: readonly number[]) {
+export function saveDataGridColumnWidthState(identity: DataGridColumnWidthStateIdentity, columnIndexes: readonly number[], widths: readonly number[], userSizedColumnIndexes: ReadonlySet<number>) {
   const cacheKey = identity.cacheKey?.trim();
   if (!cacheKey || columnIndexes.length !== widths.length) return;
   const existing = columnWidthStates.get(cacheKey);
   const widthsByColumnIndex = existing?.structureSignature === identity.structureSignature && existing.measurementSignature === identity.measurementSignature ? new Map(existing.widthsByColumnIndex) : new Map<number, number>();
+  const nextUserSizedColumnIndexes = existing?.structureSignature === identity.structureSignature && existing.measurementSignature === identity.measurementSignature ? new Set(existing.userSizedColumnIndexes) : new Set<number>();
   columnIndexes.forEach((columnIndex, visibleIndex) => {
     const width = widths[visibleIndex];
     if (Number.isFinite(width)) widthsByColumnIndex.set(columnIndex, width);
+    if (userSizedColumnIndexes.has(columnIndex)) nextUserSizedColumnIndexes.add(columnIndex);
+    else nextUserSizedColumnIndexes.delete(columnIndex);
   });
   touchColumnWidthState(cacheKey, {
     structureSignature: identity.structureSignature,
     measurementSignature: identity.measurementSignature,
     widthsByColumnIndex,
+    userSizedColumnIndexes: nextUserSizedColumnIndexes,
   });
   // Query result keys are session-scoped, so bound the in-memory cache instead of relying on store cleanup paths.
   while (columnWidthStates.size > DATA_GRID_COLUMN_WIDTH_STATE_LIMIT) {

--- a/packages/app-tests/dataGridColumnWidth.test.ts
+++ b/packages/app-tests/dataGridColumnWidth.test.ts
@@ -7,8 +7,8 @@ test("default data grid column width remains compact for long values", () => {
     sampleValues: ["x".repeat(120)],
   });
 
-  // standard: valueTextLimit=40, so 120 chars truncated to 40 → 40×8+24=344
-  expect(width).toBe(344);
+  // standard: valueTextLimit=40, so 120 chars truncated to 40 → 40×8+24+12=356
+  expect(width).toBe(356);
 });
 
 test("auto-fit data grid column width expands long values beyond default width", () => {
@@ -19,7 +19,7 @@ test("auto-fit data grid column width expands long values beyond default width",
     valueTextLimit: DATA_GRID_AUTO_FIT_VALUE_TEXT_LIMIT,
   });
 
-  expect(width).toBeGreaterThan(344);
+  expect(width).toBeGreaterThan(356);
 });
 
 test("auto-fit data grid column width stays bounded for very long values", () => {


### PR DESCRIPTION
## Summary
- Short headers like `id` kept a narrow default width from early/small samples, so late-page integers rendered as leading ellipses (`...17001`).
- Sample both the head and tail of the current row window, grow cached widths only when larger values appear, and add a small measurement slack for tabular digits.

<img width="255" height="921" alt="fb5c422f-2fc4-4b2b-82d7-b53b70ed847c" src="https://github.com/user-attachments/assets/cd013648-ccb9-47bd-abc7-91178e120c91" />

<img width="293" height="1200" alt="2f941847-b74b-48a3-9da3-6e29aeab6d61" src="https://github.com/user-attachments/assets/d38113a8-db4d-4240-8658-3f807dc78e2f" />

## Test plan
- [x] `npx vitest run apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts packages/app-tests/dataGridColumnWidth.test.ts`
- [ ] Open a large table, jump to a late page with 7-digit `id` values, confirm the first data column shows full numbers by default
- [ ] Navigate from page 1 (small ids) to a late page and confirm the column grows instead of staying ellipsized
- [ ] Manually widen a column, confirm grow-only does not shrink it on later pages
