### PR TITLE
fix(grid): show field metadata in transpose view

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -50,6 +50,7 @@ import { Input } from "@/components/ui/input";
 import QueryLoadingState from "@/components/common/QueryLoadingState.vue";
 import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomContextMenu.vue";
 import LightDropdownMenu from "@/components/ui/LightDropdownMenu.vue";
+import LightTooltip from "@/components/ui/LightTooltip.vue";
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -163,7 +164,7 @@ import {
 } from "@/lib/dataGrid/dataGridColumnFilter";
 import { normalizeResultPageSize, resultPageSizeMenuOptions } from "@/lib/dataGrid/paginationPageSize";
 import { allNullColumnIndexes } from "@/lib/dataGrid/dataGridColumnVisibility";
-import { buildDataGridColumnLookupItems, filterDataGridColumnLookupItems } from "@/lib/dataGrid/dataGridColumnLookup";
+import { buildDataGridColumnLookupItems, dataGridColumnCommentFor, filterDataGridColumnLookupItems } from "@/lib/dataGrid/dataGridColumnLookup";
 import { uniqueDataGridColumnOrderKeys } from "@/lib/dataGrid/dataGridColumnOrder";
 import { dataGridColumnLayoutScopeKey, TABLE_DATA_GRID_COLUMN_ORDER_CHANGED_EVENT, tableDataGridColumnOrderScopeKey } from "@/lib/dataGrid/dataGridColumnLayoutStorage";
 import { summarizeSelection } from "@/lib/dataGrid/gridSelection";
@@ -1810,6 +1811,7 @@ const allColumnTypes = computed(() =>
   ),
 );
 const visibleColumnTypes = computed(() => visibleColumnIndexes.value.map((index) => allColumnTypes.value[index]));
+const visibleColumnComments = computed(() => visibleColumnIndexes.value.map((index) => dataGridColumnCommentFor(columnCommentMap.value, props.result.columns[index] ?? "", props.sourceColumns?.[index])));
 const visibleColumnCount = computed(() => visibleColumnIndexes.value.length);
 
 const numericColumnRightAlign = computed(() => (settingsStore.editorSettings.numericColumnRightAlign ?? true) && !showTranspose.value);
@@ -6577,7 +6579,8 @@ const transposeRows = computed(() => {
     records: displayRowRefs.value.map((_, index) => displayItemAt(index)?.data ?? []),
     recordIndexes: activeTransposeRecordIndexes.value,
     valueIndexes: visibleColumnIndexes.value,
-    typeByColumn: columnTypeMap.value,
+    types: visibleColumnTypes.value.map((type) => (type ? shortTypeName(compactHeaderColumnType(type)) : "")),
+    comments: visibleColumnComments.value,
     displayValue: (value, _column, index) => formatCellCached(value, visibleColumnIndexes.value[index]),
   });
 });
@@ -6591,6 +6594,13 @@ function transposeScrollElement(): HTMLElement | undefined {
   const raw = transposeScrollRef.value;
   if (!raw) return undefined;
   return raw instanceof HTMLElement ? raw : raw.$el;
+}
+
+function transposeFieldTitle(item: { column: string; type: string; comment?: string }): string {
+  const details = [item.column];
+  if (showColumnTypesInHeader.value && item.type) details.push(`${t("grid.columnType")}: ${item.type}`);
+  if (showColumnCommentsInHeader.value && item.comment) details.push(`${t("grid.columnComment")}: ${item.comment}`);
+  return details.join("\n");
 }
 
 function updateTransposeViewport() {
@@ -8373,18 +8383,36 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 </template>
                 <template #default="{ item, index }">
                   <div class="data-grid-transpose-row flex border-b border-border/60" :style="{ height: '30px', width: `${transposeTotalWidth}px` }">
-                    <div
-                      data-native-clipboard
-                      class="sticky left-0 z-10 flex shrink-0 items-center border-r border-border bg-background px-3 py-0 font-medium truncate"
-                      :class="{
-                        'bg-yellow-200/60 dark:bg-yellow-500/20': transposeHeaderIsSearchMatch(visibleColumnIndexes[index]),
-                        'ring-2 ring-inset ring-yellow-500 bg-yellow-300/60 dark:bg-yellow-500/40': transposeHeaderIsCurrentMatch(visibleColumnIndexes[index]),
-                      }"
-                      :style="{ width: `${transposePinnedWidth}px` }"
-                      :title="item.column"
-                    >
-                      {{ item.column }}
-                    </div>
+                    <LightTooltip :text="transposeFieldTitle(item)" side="right" :side-offset="6" :delay="250" :open-on-focus="false" surface="popover">
+                      <div
+                        data-native-clipboard
+                        class="sticky left-0 z-10 flex shrink-0 items-center gap-1.5 overflow-hidden border-r border-border bg-background px-3 py-0"
+                        :class="{
+                          'bg-yellow-200/60 dark:bg-yellow-500/20': transposeHeaderIsSearchMatch(visibleColumnIndexes[index]),
+                          'ring-2 ring-inset ring-yellow-500 bg-yellow-300/60 dark:bg-yellow-500/40': transposeHeaderIsCurrentMatch(visibleColumnIndexes[index]),
+                        }"
+                        :style="{ width: `${transposePinnedWidth}px` }"
+                      >
+                        <span class="min-w-0 flex-1 truncate font-medium">{{ item.column }}</span>
+                      </div>
+                      <template #content>
+                        <div
+                          data-grid-transpose-field-tooltip
+                          class="grid max-h-[min(20rem,calc(100vh-1rem))] w-[min(24rem,calc(100vw-1rem))] grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 overflow-auto rounded-md border border-border bg-popover px-3 py-2 text-left text-popover-foreground shadow-md"
+                        >
+                          <span class="text-muted-foreground">{{ t("grid.columnName") }}</span>
+                          <span class="min-w-0 break-all font-mono select-text">{{ item.column }}</span>
+                          <template v-if="showColumnTypesInHeader && item.type">
+                            <span class="text-muted-foreground">{{ t("grid.columnType") }}</span>
+                            <span class="min-w-0 break-all font-mono select-text" :class="typeColorClass(item.type)">{{ item.type }}</span>
+                          </template>
+                          <template v-if="showColumnCommentsInHeader && item.comment">
+                            <span class="text-muted-foreground">{{ t("grid.columnComment") }}</span>
+                            <span class="min-w-0 whitespace-pre-wrap break-words select-text">{{ item.comment }}</span>
+                          </template>
+                        </div>
+                      </template>
+                    </LightTooltip>
                     <div class="shrink-0" :style="{ width: `${transposeBeforeSpacerWidth}px` }" />
                     <div
                       v-for="cell in item.values"

--- a/apps/desktop/src/components/grid/__tests__/DataGridClipboardRegion.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridClipboardRegion.spec.ts
@@ -9,6 +9,6 @@ describe("DataGrid native clipboard regions", () => {
   });
 
   it("keeps transposed field-name text selection out of grid copy shortcuts", () => {
-    expect(dataGridSource).toMatch(/<div\b(?=[^>]*\bdata-native-clipboard)(?=[^>]*:title="item\.column")[^>]*>/);
+    expect(dataGridSource).toMatch(/<div\b(?=[^>]*\bdata-native-clipboard)(?=[^>]*class="sticky left-0)[^>]*>/);
   });
 });

--- a/apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
+
+describe("DataGrid transpose presentation", () => {
+  it("keeps field metadata in one compact row", () => {
+    expect(dataGridSource).toContain(':item-size="30"');
+    expect(dataGridSource).not.toContain("data-grid-transpose-field-info");
+    expect(dataGridSource).not.toContain("data-grid-transpose-comment-inline");
+    expect(dataGridSource).not.toContain("data-grid-transpose-comment-line");
+    expect(dataGridSource).not.toContain("data-grid-transpose-type-line");
+  });
+
+  it("shows complete long metadata in a hoverable, bounded tooltip", () => {
+    expect(dataGridSource).toContain("data-grid-transpose-field-tooltip");
+    expect(dataGridSource).toContain(':text="transposeFieldTitle(item)"');
+    expect(dataGridSource).toContain('side="right"');
+    expect(dataGridSource).toContain("max-h-[min(20rem,calc(100vh-1rem))]");
+    expect(dataGridSource).toContain("w-[min(24rem,calc(100vw-1rem))]");
+    expect(dataGridSource).toContain("overflow-auto rounded-md");
+    expect(dataGridSource).toContain("whitespace-pre-wrap break-words select-text");
+    expect(dataGridSource).not.toContain("data-grid-transpose-field-popover");
+  });
+});

--- a/apps/desktop/src/components/ui/LightTooltip.vue
+++ b/apps/desktop/src/components/ui/LightTooltip.vue
@@ -198,8 +198,17 @@ function onPointerDown(e: PointerEvent) {
   close();
 }
 
+function onScroll(e: Event) {
+  const target = e.target;
+  if (target instanceof Node && tooltipRef.value?.contains(target)) {
+    clearCloseTimer();
+    return;
+  }
+  close();
+}
+
 function addGlobalListeners() {
-  window.addEventListener("scroll", close, true);
+  window.addEventListener("scroll", onScroll, true);
   window.addEventListener("resize", close);
   window.addEventListener("blur", close);
   document.addEventListener("visibilitychange", close);
@@ -209,7 +218,7 @@ function addGlobalListeners() {
 }
 
 function removeGlobalListeners() {
-  window.removeEventListener("scroll", close, true);
+  window.removeEventListener("scroll", onScroll, true);
   window.removeEventListener("resize", close);
   window.removeEventListener("blur", close);
   document.removeEventListener("visibilitychange", close);

--- a/apps/desktop/src/components/ui/__tests__/LightTooltip.spec.ts
+++ b/apps/desktop/src/components/ui/__tests__/LightTooltip.spec.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LightTooltip from "@/components/ui/LightTooltip.vue";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("LightTooltip scrolling", () => {
+  it("stays open for content scrolling and closes for outside scrolling", async () => {
+    vi.useFakeTimers();
+    const root = defineComponent({
+      setup() {
+        return () =>
+          h(
+            LightTooltip,
+            { text: "Field details", delay: 0 },
+            {
+              default: () => h("span", { id: "tooltip-trigger" }, "Field"),
+              content: () => h("div", { id: "tooltip-content" }, "Long comment"),
+            },
+          );
+      },
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const app = createApp(root);
+    app.mount(container);
+
+    const trigger = container.querySelector<HTMLElement>("#tooltip-trigger");
+    expect(trigger).toBeTruthy();
+    vi.spyOn(trigger!, "matches").mockImplementation((selector) => selector === ":hover");
+    trigger?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    await vi.runAllTimersAsync();
+    await nextTick();
+
+    const content = document.querySelector("#tooltip-content");
+    expect(content).toBeTruthy();
+    content?.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    expect(document.querySelector("#tooltip-content")).toBeTruthy();
+
+    document.dispatchEvent(new Event("scroll"));
+    await nextTick();
+    expect(document.querySelector("#tooltip-content")).toBeNull();
+
+    app.unmount();
+  });
+});

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   averageTransposeRecordWidth,
+  buildVisibleTransposeRows,
   calculateTransposeRecordWidth,
   defaultTransposeRecordWidth,
   minTransposeFieldWidth,
@@ -145,5 +146,24 @@ describe("transpose record scrolling", () => {
         currentScrollLeft: 450,
       }),
     ).toBe(450);
+  });
+});
+
+describe("dataGridTranspose field metadata", () => {
+  it("keeps type and comment metadata aligned with visible columns", () => {
+    const rows = buildVisibleTransposeRows({
+      columns: ["display_name", "status"],
+      records: [["Ada", 1]],
+      recordIndexes: [0],
+      valueIndexes: [0, 1],
+      types: ["varchar", "int"],
+      comments: ["User name", "Current status"],
+      displayValue: String,
+    });
+
+    expect(rows.map(({ column, type, comment }) => ({ column, type, comment }))).toEqual([
+      { column: "display_name", type: "varchar", comment: "User name" },
+      { column: "status", type: "int", comment: "Current status" },
+    ]);
   });
 });

--- a/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
@@ -11,6 +11,8 @@ export interface BuildTransposeRowsOptions<T> {
   columns: string[];
   records: T[][];
   typeByColumn?: Map<string, string>;
+  types?: readonly (string | undefined)[];
+  comments?: readonly (string | undefined)[];
   displayValue: (value: T, column: string, columnIndex: number, recordIndex: number) => string;
 }
 
@@ -29,6 +31,7 @@ export interface DataGridTransposeRow<T> {
   id: string;
   column: string;
   type: string;
+  comment?: string;
   values: Array<DataGridTransposeCell<T>>;
 }
 
@@ -36,6 +39,7 @@ export interface DataGridVisibleTransposeRow<T> {
   id: string;
   column: string;
   type: string;
+  comment?: string;
   values: Array<DataGridVisibleTransposeCell<T>>;
 }
 
@@ -228,7 +232,8 @@ export function buildTransposeRows<T>(options: BuildTransposeRowsOptions<T>): Ar
     return {
       id: `${columnIndex}:${column}`,
       column,
-      type: options.typeByColumn?.get(column) || "",
+      type: options.types?.[columnIndex] || options.typeByColumn?.get(column) || "",
+      ...(options.comments ? { comment: options.comments[columnIndex] || "" } : {}),
       values: options.records.map((record, recordIndex) => {
         const value = record[columnIndex] as T;
         return {
@@ -246,7 +251,8 @@ export function buildVisibleTransposeRows<T>(options: BuildVisibleTransposeRowsO
     return {
       id: `${columnIndex}:${column}`,
       column,
-      type: options.typeByColumn?.get(column) || "",
+      type: options.types?.[columnIndex] || options.typeByColumn?.get(column) || "",
+      ...(options.comments ? { comment: options.comments[columnIndex] || "" } : {}),
       values: options.recordIndexes.flatMap((recordIndex) => {
         const record = options.records[recordIndex];
         if (!record) return [];


### PR DESCRIPTION
## 变更说明

修复转置视图无法查看列注释的问题，并保持转置表的紧凑字段/值结构：

- 字段行维持固定单行高度，不新增类型列、注释列、元数据行或信息图标
- 鼠标悬停字段名单元格时展示完整字段名、类型和注释，无需点击
- 超长内容可换行、选择和滚动，并自动避让视口边缘；浮层内滚动不会意外关闭
- 按可见列索引传递元数据，兼容隐藏列、来源列名、别名和大小写差异


## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（截图待补充，不包含在本次提交中）
<img width="841" height="311" alt="image" src="https://github.com/user-attachments/assets/841ace1c-4087-4735-aab2-7abfafb532a2" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

新增转置字段元数据对齐、紧凑无图标布局、悬停展示和超长内容滚动行为的回归测试。

## 关联 Issue

Close #4994