### PR TITLE
Feature：优化条件输入补全回车行为

### DIFF
--- a/apps/desktop/src/components/grid/__tests__/DataGridConditionEditor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridConditionEditor.spec.ts
@@ -123,6 +123,26 @@ describe("DataGridConditionEditor quote completion", () => {
     expect(input.selectionEnd).toBe(20);
   });
 
+  it("starts without an active suggestion and selects the first item on ArrowDown", async () => {
+    const { value, input } = mountEditor("orderBy", "", { columns: ["name", "namespace"] });
+    input.focus();
+    input.value = "na";
+    input.setSelectionRange(2, 2);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    await vi.waitFor(() => expect(document.querySelectorAll('[role="option"]')).toHaveLength(2));
+    expect(document.querySelector('[role="option"][aria-selected="true"]')).toBeNull();
+    expect(value.value).toBe("na");
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
+    await nextTick();
+    expect(document.querySelector('[role="option"][aria-selected="true"]')?.textContent).toContain("name");
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    await nextTick();
+    expect(value.value).toBe("name");
+  });
+
   it("keeps expanded input first-line indent and wraps long tokens", () => {
     const source = readFileSync(resolve(process.cwd(), "apps/desktop/src/components/grid/DataGridConditionEditor.vue"), "utf8");
     const expandedInputCss = source.match(/\.data-grid-topbar-condition-input--expanded\s*\{(?<body>[\s\S]*?)\n\}/)?.groups?.body;

--- a/apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts
@@ -386,12 +386,26 @@ describe("useDataGridConditionEditor", () => {
     await nextTick();
     await vi.waitFor(() => expect(editor.suggestions.value).toHaveLength(1));
 
+    const initialEnter = keyboardEvent("Enter");
+    expect(editor.handleKeydown(initialEnter)).toBe("apply");
+    expect(initialEnter.preventDefault).toHaveBeenCalledOnce();
+    expect(value.value).toBe("na");
+
     const down = keyboardEvent("ArrowDown");
     expect(editor.handleKeydown(down)).toBe("navigate");
     expect(down.preventDefault).toHaveBeenCalledOnce();
-    const tab = keyboardEvent("Tab");
-    expect(editor.handleKeydown(tab)).toBe("accept");
+    const navigatedEnter = keyboardEvent("Enter");
+    expect(editor.handleKeydown(navigatedEnter)).toBe("accept");
     expect(value.value).toBe("name");
+
+    const tabValue = ref("");
+    const tabEditor = useDataGridConditionEditor({ kind: "orderBy", value: tabValue, columns: ["name"], historyScope: {} });
+    tabValue.value = "na";
+    await nextTick();
+    await vi.waitFor(() => expect(tabEditor.suggestions.value).toHaveLength(1));
+    const tab = keyboardEvent("Tab");
+    expect(tabEditor.handleKeydown(tab)).toBe("accept");
+    expect(tabValue.value).toBe("name");
 
     const enter = keyboardEvent("Enter");
     expect(editor.handleKeydown(enter)).toBe("apply");

--- a/apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts
@@ -34,6 +34,8 @@ describe("useDataGridConditionEditor", () => {
     await nextTick();
     await vi.waitFor(() => expect(editor.suggestions.value.map((item) => item.value)).toEqual(["customer_id", "customer_name"]));
     expect(editor.navigate(1)).toBe(true);
+    expect(editor.highlightedIndex.value).toBe(0);
+    expect(editor.navigate(1)).toBe(true);
     expect(editor.highlightedIndex.value).toBe(1);
     expect(editor.navigate(1)).toBe(true);
     expect(editor.highlightedIndex.value).toBe(1);
@@ -381,10 +383,11 @@ describe("useDataGridConditionEditor", () => {
 
   it("maps Enter, Tab, arrows, and Escape without applying stale selections", async () => {
     const value = ref("");
-    const editor = useDataGridConditionEditor({ kind: "orderBy", value, columns: ["name"], historyScope: {} });
+    const editor = useDataGridConditionEditor({ kind: "orderBy", value, columns: ["name", "namespace"], historyScope: {} });
     value.value = "na";
     await nextTick();
-    await vi.waitFor(() => expect(editor.suggestions.value).toHaveLength(1));
+    await vi.waitFor(() => expect(editor.suggestions.value).toHaveLength(2));
+    expect(editor.highlightedIndex.value).toBe(-1);
 
     const initialEnter = keyboardEvent("Enter");
     expect(editor.handleKeydown(initialEnter)).toBe("apply");
@@ -394,6 +397,7 @@ describe("useDataGridConditionEditor", () => {
     const down = keyboardEvent("ArrowDown");
     expect(editor.handleKeydown(down)).toBe("navigate");
     expect(down.preventDefault).toHaveBeenCalledOnce();
+    expect(editor.highlightedIndex.value).toBe(0);
     const navigatedEnter = keyboardEvent("Enter");
     expect(editor.handleKeydown(navigatedEnter)).toBe("accept");
     expect(value.value).toBe("name");

--- a/apps/desktop/src/composables/useDataGridConditionEditor.ts
+++ b/apps/desktop/src/composables/useDataGridConditionEditor.ts
@@ -205,6 +205,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
   let suggestionRequestId = 0;
   let suggestionAbortController: AbortController | undefined;
   let suppressNextValueSuggestion = false;
+  let keyboardSelectedSuggestion = false;
 
   const dropdownOpen = computed(() => suggestions.value.length > 0 || historyOpen.value);
 
@@ -221,6 +222,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     cancelSuggestionRequest();
     suggestions.value = [];
     highlightedIndex.value = -1;
+    keyboardSelectedSuggestion = false;
     historyOpen.value = false;
     replacementRange.value = undefined;
   }
@@ -265,10 +267,12 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
       suggestions.value = values ? [...new Set(values)].slice(0, limit).map((suggestion) => ({ value: suggestion, kind: "column" })) : defaultSuggestions(target).slice(0, limit);
       replacementRange.value = { from: target.from, to: target.to };
       highlightedIndex.value = suggestions.value.length > 0 ? 0 : -1;
+      keyboardSelectedSuggestion = false;
     } catch (error) {
       if (!controller.signal.aborted && requestId === suggestionRequestId) {
         suggestions.value = [];
         highlightedIndex.value = -1;
+        keyboardSelectedSuggestion = false;
         console.warn("[DBX][condition-editor] Failed to load suggestions", error);
       }
     } finally {
@@ -280,6 +284,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     cancelSuggestionRequest();
     suggestions.value = [];
     highlightedIndex.value = -1;
+    keyboardSelectedSuggestion = false;
     historyOpen.value = false;
     if (!value.trim()) return;
 
@@ -304,6 +309,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     replacementRange.value = undefined;
     suggestions.value = loadDataGridConditionHistory(options.kind, toValue(options.historyScope), options.value.value).map((value) => ({ value, kind: "history" }));
     highlightedIndex.value = -1;
+    keyboardSelectedSuggestion = false;
   }
 
   function deleteHistory(value: string) {
@@ -311,6 +317,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     const query = options.value.value.trim().toLowerCase();
     suggestions.value = history.filter((item) => !query || item.toLowerCase().includes(query)).map((item) => ({ value: item, kind: "history" }));
     highlightedIndex.value = suggestions.value.length > 0 ? Math.min(Math.max(highlightedIndex.value, 0), suggestions.value.length - 1) : -1;
+    keyboardSelectedSuggestion = false;
     historyOpen.value = true;
   }
 
@@ -325,6 +332,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     } else {
       highlightedIndex.value = Math.min(Math.max(highlightedIndex.value + delta, 0), suggestions.value.length - 1);
     }
+    keyboardSelectedSuggestion = true;
     return true;
   }
 
@@ -370,7 +378,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     }
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      if (suggestions.value.length > 0 && highlightedIndex.value >= 0) {
+      if (keyboardSelectedSuggestion && suggestions.value.length > 0 && highlightedIndex.value >= 0) {
         if (accept()) return "accept";
       }
       return "apply";

--- a/apps/desktop/src/composables/useDataGridConditionEditor.ts
+++ b/apps/desktop/src/composables/useDataGridConditionEditor.ts
@@ -205,7 +205,6 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
   let suggestionRequestId = 0;
   let suggestionAbortController: AbortController | undefined;
   let suppressNextValueSuggestion = false;
-  let keyboardSelectedSuggestion = false;
 
   const dropdownOpen = computed(() => suggestions.value.length > 0 || historyOpen.value);
 
@@ -222,7 +221,6 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     cancelSuggestionRequest();
     suggestions.value = [];
     highlightedIndex.value = -1;
-    keyboardSelectedSuggestion = false;
     historyOpen.value = false;
     replacementRange.value = undefined;
   }
@@ -266,13 +264,11 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
       const limit = options.suggestionLimit ?? 8;
       suggestions.value = values ? [...new Set(values)].slice(0, limit).map((suggestion) => ({ value: suggestion, kind: "column" })) : defaultSuggestions(target).slice(0, limit);
       replacementRange.value = { from: target.from, to: target.to };
-      highlightedIndex.value = suggestions.value.length > 0 ? 0 : -1;
-      keyboardSelectedSuggestion = false;
+      highlightedIndex.value = -1;
     } catch (error) {
       if (!controller.signal.aborted && requestId === suggestionRequestId) {
         suggestions.value = [];
         highlightedIndex.value = -1;
-        keyboardSelectedSuggestion = false;
         console.warn("[DBX][condition-editor] Failed to load suggestions", error);
       }
     } finally {
@@ -284,7 +280,6 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     cancelSuggestionRequest();
     suggestions.value = [];
     highlightedIndex.value = -1;
-    keyboardSelectedSuggestion = false;
     historyOpen.value = false;
     if (!value.trim()) return;
 
@@ -309,15 +304,13 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     replacementRange.value = undefined;
     suggestions.value = loadDataGridConditionHistory(options.kind, toValue(options.historyScope), options.value.value).map((value) => ({ value, kind: "history" }));
     highlightedIndex.value = -1;
-    keyboardSelectedSuggestion = false;
   }
 
   function deleteHistory(value: string) {
     const history = forgetDataGridConditionHistory(options.kind, toValue(options.historyScope), value);
     const query = options.value.value.trim().toLowerCase();
     suggestions.value = history.filter((item) => !query || item.toLowerCase().includes(query)).map((item) => ({ value: item, kind: "history" }));
-    highlightedIndex.value = suggestions.value.length > 0 ? Math.min(Math.max(highlightedIndex.value, 0), suggestions.value.length - 1) : -1;
-    keyboardSelectedSuggestion = false;
+    highlightedIndex.value = suggestions.value.length > 0 && highlightedIndex.value >= 0 ? Math.min(highlightedIndex.value, suggestions.value.length - 1) : -1;
     historyOpen.value = true;
   }
 
@@ -332,11 +325,10 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     } else {
       highlightedIndex.value = Math.min(Math.max(highlightedIndex.value + delta, 0), suggestions.value.length - 1);
     }
-    keyboardSelectedSuggestion = true;
     return true;
   }
 
-  function accept(index = highlightedIndex.value) {
+  function accept(index = highlightedIndex.value >= 0 ? highlightedIndex.value : 0) {
     const suggestion = suggestions.value[index];
     if (!suggestion) return false;
     let caret: number;
@@ -378,7 +370,7 @@ export function useDataGridConditionEditor(options: UseDataGridConditionEditorOp
     }
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      if (keyboardSelectedSuggestion && suggestions.value.length > 0 && highlightedIndex.value >= 0) {
+      if (suggestions.value.length > 0 && highlightedIndex.value >= 0) {
         if (accept()) return "accept";
       }
       return "apply";


### PR DESCRIPTION
## 改动说明

- 调整表数据页 WHERE/ORDER BY 条件输入框的补全键盘行为
- 补全自动弹出时，直接按 Enter 会应用条件，不再默认插入补全项
- 用户通过 ArrowUp/ArrowDown 主动选择补全项后，Enter 才接受当前补全
- Tab 和鼠标点击仍然保留接受补全的行为

## 验证

- pnpm vitest run apps/desktop/src/composables/__tests__/useDataGridConditionEditor.spec.ts --pool=forks
- pnpm typecheck
- git diff --check origin/main...HEAD
