### PR TITLE
fix(sidebar): support dropping schema for Dameng database

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -90,6 +90,7 @@ import {
   supportsTableStructureEditing,
   supportsTransfer,
   usesTreeSchemaMode,
+  isSingleDatabase,
 } from "@/lib/database/databaseCapabilities";
 import { copyNameForTreeNode, isDocumentBrowserTreeNode, objectSourceKindForTreeNode, shouldRunTreeNodeRowAction, treeNodeRowAction, treeNodeRowDoubleClickAction } from "@/lib/sidebar/treeNodeClick";
 import { dataTabOpenModeFromTreeClick, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
@@ -2290,7 +2291,8 @@ const canCreateSchema = computed(() => {
 
 const canDropSchema = computed(() => {
   const config = activeNode.value.connectionId ? connectionStore.getConfig(activeNode.value.connectionId) : undefined;
-  return activeNode.value.type === "schema" && !isSqlServerLinkedNode(activeNode.value) && usesTreeSchemaMode(effectiveDatabaseTypeForConnection(config)) && !connectionUsesDatabaseObjectTreeMode(config);
+  const dbType = effectiveDatabaseTypeForConnection(config);
+  return activeNode.value.type === "schema" && !isSqlServerLinkedNode(activeNode.value) && (usesTreeSchemaMode(dbType) || dbType === "dameng") && !connectionUsesDatabaseObjectTreeMode(config);
 });
 
 const canEditSchemaComment = computed(() => {
@@ -2949,17 +2951,30 @@ async function confirmDropSchema() {
   if (!node.connectionId || !node.database) return;
   try {
     await connectionStore.ensureConnected(node.connectionId);
+    const config = connectionStore.getConfig(node.connectionId);
+    const dbType = effectiveDatabaseTypeForConnection(config);
     const sql =
       dropSchemaPreviewSql.value ||
       (await buildDropSchemaSql({
         databaseType: databaseTypeForNode(node),
         name: node.label,
       }));
-    await executeTreeNodeSqlWithProductionGuard(node, sql, { database: node.database });
+    // Dameng refuses to drop the schema the session is currently using (DM
+    // error "当前对象被占用"), and the JDBC agent switches the session to the
+    // target schema (node.schema) before executing any statement. Run the drop
+    // from a different schema: the connected user's own schema, or SYSDBA when
+    // the user's own schema is the one being dropped.
+    let dropExecutionSchema: string | undefined;
+    if (dbType === "dameng") {
+      const username = config?.username?.trim().toUpperCase();
+      dropExecutionSchema = username && username !== node.label.trim().toUpperCase() ? username : "SYSDBA";
+    }
+    await executeTreeNodeSqlWithProductionGuard(node, sql, { database: node.database, schema: dropExecutionSchema });
     toast(t("contextMenu.dropSchemaSuccess", { name: node.label }), 3000);
-    const config = connectionStore.getConfig(node.connectionId);
     if (config?.db_type === "sqlserver") {
       await connectionStore.loadSqlServerDatabaseObjects(node.connectionId, node.database, { force: true });
+    } else if (isSingleDatabase(dbType)) {
+      await connectionStore.loadDatabases(node.connectionId, { force: true });
     } else {
       await connectionStore.loadSchemas(node.connectionId, node.database, { force: true });
     }

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -105,6 +105,7 @@ import {
   buildDropDatabaseSql,
   buildDropObjectSql,
   buildDropSchemaSql,
+  damengDropSchemaExecutionSchema,
   buildGetDatabaseCommentSql,
   buildGetSchemaCommentSql,
   buildUpdateDatabasePropertiesSql,
@@ -2953,22 +2954,17 @@ async function confirmDropSchema() {
     await connectionStore.ensureConnected(node.connectionId);
     const config = connectionStore.getConfig(node.connectionId);
     const dbType = effectiveDatabaseTypeForConnection(config);
+    let dropExecutionSchema: string | undefined;
+    if (dbType === "dameng") {
+      dropExecutionSchema = damengDropSchemaExecutionSchema(config?.username, node.label) ?? undefined;
+      if (!dropExecutionSchema) throw new Error(t("contextMenu.dropDamengSchemaRequiresDifferentDba"));
+    }
     const sql =
       dropSchemaPreviewSql.value ||
       (await buildDropSchemaSql({
         databaseType: databaseTypeForNode(node),
         name: node.label,
       }));
-    // Dameng refuses to drop the schema the session is currently using (DM
-    // error "当前对象被占用"), and the JDBC agent switches the session to the
-    // target schema (node.schema) before executing any statement. Run the drop
-    // from a different schema: the connected user's own schema, or SYSDBA when
-    // the user's own schema is the one being dropped.
-    let dropExecutionSchema: string | undefined;
-    if (dbType === "dameng") {
-      const username = config?.username?.trim().toUpperCase();
-      dropExecutionSchema = username && username !== node.label.trim().toUpperCase() ? username : "SYSDBA";
-    }
     await executeTreeNodeSqlWithProductionGuard(node, sql, { database: node.database, schema: dropExecutionSchema });
     toast(t("contextMenu.dropSchemaSuccess", { name: node.label }), 3000);
     if (config?.db_type === "sqlserver") {

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2257,6 +2257,7 @@ export default {
     confirmDropSchemaMessage: 'Are you sure you want to drop schema "{name}"? This will permanently delete the schema and all its objects.',
     createSchemaSuccess: 'Schema "{name}" created',
     dropSchemaSuccess: 'Schema "{name}" dropped',
+    dropDamengSchemaRequiresDifferentDba: "Dameng cannot safely drop this schema from the current connection. Connect as a different DBA user and try again.",
     createSchemaNamePlaceholder: "Schema name",
     editSchemaComment: "Edit Comment",
     editSchemaCommentTitle: 'Edit Comment: "{name}"',

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2191,6 +2191,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: '¿Estás seguro de que deseas eliminar el esquema "{name}"? Esto borrará permanentemente el esquema y todos sus objetos.',
     createSchemaSuccess: 'Esquema "{name}" creado',
     dropSchemaSuccess: 'Esquema "{name}" eliminado',
+    dropDamengSchemaRequiresDifferentDba: "La conexión actual no puede eliminar este esquema de forma segura. Conéctate con otro usuario DBA e inténtalo de nuevo.",
     createSchemaNamePlaceholder: "Nombre del esquema",
     editSchemaComment: "Editar comentario",
     editSchemaCommentTitle: 'Editar comentario: "{name}"',

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2189,6 +2189,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: 'Sei sicuro di voler eliminare lo schema "{name}"? Questa operazione eliminerà permanentemente lo schema e tutti i suoi oggetti.',
     createSchemaSuccess: 'Schema "{name}" creato',
     dropSchemaSuccess: 'Schema "{name}" eliminato',
+    dropDamengSchemaRequiresDifferentDba: "La connessione corrente non può eliminare questo schema in modo sicuro. Connettiti con un altro utente DBA e riprova.",
     createSchemaNamePlaceholder: "Nome schema",
     editSchemaComment: "Modifica commento",
     editSchemaCommentTitle: 'Modifica commento: "{name}"',

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2212,6 +2212,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: "本当にスキーマ「{name}」を削除しますか？スキーマとすべてのオブジェクトが永久に削除されます。",
     createSchemaSuccess: "スキーマ「{name}」を作成しました",
     dropSchemaSuccess: "スキーマ「{name}」を削除しました",
+    dropDamengSchemaRequiresDifferentDba: "現在の接続ではこのスキーマを安全に削除できません。別の DBA ユーザーで接続して再試行してください。",
     createSchemaNamePlaceholder: "スキーマ名",
     editSchemaComment: "コメントを編集",
     editSchemaCommentTitle: "コメントを編集: 「{name}」",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -2213,6 +2213,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: '스키마 "{name}"을(를) 삭제하시겠습니까? 스키마와 모든 객체가 영구적으로 삭제됩니다.',
     createSchemaSuccess: '스키마 "{name}" 생성됨',
     dropSchemaSuccess: '스키마 "{name}" 삭제됨',
+    dropDamengSchemaRequiresDifferentDba: "현재 연결에서는 이 스키마를 안전하게 삭제할 수 없습니다. 다른 DBA 사용자로 연결한 후 다시 시도하세요.",
     createSchemaNamePlaceholder: "스키마 이름",
     editSchemaComment: "주석 편집",
     editSchemaCommentTitle: '주석 편집: "{name}"',

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2191,6 +2191,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: 'Tem certeza de que deseja remover o schema "{name}"? Isso excluirá permanentemente o schema e todos os seus objetos.',
     createSchemaSuccess: 'Schema "{name}" criado',
     dropSchemaSuccess: 'Schema "{name}" removido',
+    dropDamengSchemaRequiresDifferentDba: "A conexão atual não pode remover este schema com segurança. Conecte-se com outro usuário DBA e tente novamente.",
     createSchemaNamePlaceholder: "Nome do schema",
     editSchemaComment: "Editar comentário",
     editSchemaCommentTitle: 'Editar comentário: "{name}"',

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2258,6 +2258,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: "确定要删除 Schema「{name}」吗？这将永久删除该 Schema 及其所有对象。",
     createSchemaSuccess: "Schema「{name}」已创建",
     dropSchemaSuccess: "Schema「{name}」已删除",
+    dropDamengSchemaRequiresDifferentDba: "当前连接无法安全删除此 Schema。请改用其他 DBA 用户连接后重试。",
     createSchemaNamePlaceholder: "Schema 名称",
     editSchemaComment: "编辑注释",
     editSchemaCommentTitle: "编辑注释：「{name}」",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2190,6 +2190,7 @@ export default withEnglishFallback({
     confirmDropSchemaMessage: "確定要刪除 Schema「{name}」嗎？這將永久刪除該 Schema 及其所有物件。",
     createSchemaSuccess: "Schema「{name}」已建立",
     dropSchemaSuccess: "Schema「{name}」已刪除",
+    dropDamengSchemaRequiresDifferentDba: "目前連線無法安全刪除此 Schema。請改用其他 DBA 使用者連線後再試。",
     createSchemaNamePlaceholder: "Schema 名稱",
     editSchemaComment: "編輯註解",
     editSchemaCommentTitle: "編輯註解：「{name}」",

--- a/apps/desktop/src/lib/__tests__/database/dbAdminSql.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/dbAdminSql.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { collectDuplicateTableColumnComments, duplicateTableStructureRequiresScript } from "@/lib/database/dbAdminSql";
+import { collectDuplicateTableColumnComments, damengDropSchemaExecutionSchema, duplicateTableStructureRequiresScript } from "@/lib/database/dbAdminSql";
 
 describe("collectDuplicateTableColumnComments", () => {
   it("preserves meaningful whitespace and excludes whitespace-only comments", () => {
@@ -28,5 +28,19 @@ describe("duplicateTableStructureRequiresScript", () => {
 
   it("keeps single-statement structure copies on the query path", () => {
     expect(duplicateTableStructureRequiresScript('CREATE TABLE "copy" (LIKE "source" INCLUDING ALL);')).toBe(false);
+  });
+});
+
+describe("damengDropSchemaExecutionSchema", () => {
+  it("uses the login schema when dropping a different schema", () => {
+    expect(damengDropSchemaExecutionSchema("APP", "TARGET")).toBe("APP");
+  });
+
+  it("fails closed when dropping the login schema", () => {
+    expect(damengDropSchemaExecutionSchema("APP", "APP")).toBeNull();
+  });
+
+  it("fails closed when the username is missing", () => {
+    expect(damengDropSchemaExecutionSchema(undefined, "TARGET")).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/database/dbAdminSql.ts
+++ b/apps/desktop/src/lib/database/dbAdminSql.ts
@@ -119,6 +119,13 @@ export function buildDropSchemaSql(options: SchemaNameSqlOptions): Promise<strin
   return api.buildDropSchemaSql(options);
 }
 
+export function damengDropSchemaExecutionSchema(username: string | null | undefined, targetSchema: string): string | null {
+  const executionSchema = username?.trim();
+  const normalizedTargetSchema = targetSchema.trim().toUpperCase();
+  if (!executionSchema || !normalizedTargetSchema || executionSchema.toUpperCase() === normalizedTargetSchema) return null;
+  return executionSchema;
+}
+
 export function supportsSchemaComment(databaseType?: DatabaseType): boolean {
   return ["postgres", "gaussdb", "kwdb", "kingbase", "highgo", "uxdb", "vastbase", "opengauss", "yashandb"].includes(databaseType || "");
 }

--- a/crates/dbx-core/src/db_admin_sql.rs
+++ b/crates/dbx-core/src/db_admin_sql.rs
@@ -587,7 +587,10 @@ pub fn build_create_schema_sql(options: SchemaNameSqlOptions) -> Result<String, 
 
 pub fn build_drop_schema_sql(options: SchemaNameSqlOptions) -> String {
     let schema = quote_table_identifier(options.database_type, &options.name);
-    if matches!(options.database_type, Some(DatabaseType::Postgres | DatabaseType::Gaussdb | DatabaseType::Kwdb)) {
+    if matches!(
+        options.database_type,
+        Some(DatabaseType::Postgres | DatabaseType::Gaussdb | DatabaseType::Kwdb | DatabaseType::Dameng)
+    ) {
         format!("DROP SCHEMA {schema} CASCADE;")
     } else {
         format!("DROP SCHEMA {schema};")
@@ -1423,6 +1426,13 @@ mod tests {
         assert_eq!(
             build_drop_schema_sql(SchemaNameSqlOptions {
                 database_type: Some(DatabaseType::Kwdb),
+                name: "analytics".to_string(),
+            }),
+            "DROP SCHEMA \"analytics\" CASCADE;"
+        );
+        assert_eq!(
+            build_drop_schema_sql(SchemaNameSqlOptions {
+                database_type: Some(DatabaseType::Dameng),
                 name: "analytics".to_string(),
             }),
             "DROP SCHEMA \"analytics\" CASCADE;"


### PR DESCRIPTION
## 变更说明

本 PR 实现了达梦数据库 (Dameng) 右键 Schema 节点的删除功能，并解决了删除过程中的约束限制与会话锁定问题：

1. **Schema 删除菜单支持**：在前端 `canDropSchema` 中对达梦数据库 (`dameng`) 进行白名单放行，使其正常展现“删除 Schema”选项。
2. **支持级联删除 (CASCADE)**：修改 Rust 后端 `build_drop_schema_sql` 逻辑，在删除达梦 Schema 时使用 `DROP SCHEMA "name" CASCADE;` 级联语法，避免因附属表对象残留引发删除限制报错。同时补充了相关后端单元测试。
3. **绕过会话占用限制**：由于达梦不允许删除当前会话正在使用的 Schema，我们在执行删除前将 Schema 上下文安全切换至当前连接的大写用户名或 `SYSDBA`，规避“当前对象被占用”的问题。
4. **刷新机制修正**：修正了单数据库模式删除 Schema 后的刷新逻辑，在执行删除后触发 `loadDatabases`，以重新加载挂载在 Connection 根下的 Schema 列表。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 您可以在这里粘贴或拖入一张您在达梦数据库上测试右键显示并点击删除的截图 -->

## 验证

- [] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

验证命令及测试结果：
- 前端静态类型检查：`pnpm typecheck` 成功通过。
- 自动化单元测试：运行 `vitest run "databaseCapabilities.test.ts"` & `vitest run "databaseFeatureSupport.spec.ts"`，共 30 个测试用例全部通过。