### PR TITLE
fix(editor): 固定 SQL 语句执行栏宽度

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -401,9 +401,9 @@ let tableReferenceDropListenerRegistered = false;
 let imeCompositionActive = false;
 let pendingImeModelEmit = false;
 
-function runStatementGutterExtension(markers = props.statementExecutionMarkers ?? []): import("@codemirror/state").Extension {
+function runStatementGutterExtension(): import("@codemirror/state").Extension {
   const showRunButtons = !props.hideExecutionControls && settingsStore.editorSettings.showStatementRunButtons;
-  return shouldShowStatementGutter(showRunButtons, markers.length) ? (buildRunStatementGutterExtension?.() ?? []) : [];
+  return shouldShowStatementGutter(showRunButtons) ? (buildRunStatementGutterExtension?.() ?? []) : [];
 }
 
 type SelectionCaseMode = "upper" | "lower";
@@ -4285,15 +4285,6 @@ watch(
 );
 
 watch(
-  () => props.statementExecutionMarkers?.length ?? 0,
-  () => {
-    if (!view.value || !runGutterComp) return;
-    // Remove the compartment entirely when controls and markers are absent so the editor keeps no empty gutter width.
-    view.value.dispatch({ effects: runGutterComp.reconfigure(runStatementGutterExtension()) });
-  },
-);
-
-watch(
   () => props.connectionId,
   () => {
     refreshCompletionCache();
@@ -4694,7 +4685,7 @@ defineExpose({
 }
 
 :deep(.cm-run-statement-gutter) {
-  min-width: 34px;
+  min-width: 28px;
 }
 
 :deep(.cm-run-statement-gutter .cm-gutterElement) {
@@ -4702,8 +4693,8 @@ defineExpose({
   box-sizing: border-box;
   display: flex;
   justify-content: center;
-  min-width: 34px;
-  padding: 0 5px;
+  min-width: 28px;
+  padding: 0 2px;
 }
 
 :deep(.cm-statement-execution-marker) {

--- a/apps/desktop/src/lib/__tests__/codemirrorStatementGutter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/codemirrorStatementGutter.spec.ts
@@ -4,10 +4,9 @@ import { describe, expect, it } from "vitest";
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 
 describe("CodeMirror statement gutter marker", () => {
-  it("omits the gutter when run buttons and status markers are absent", () => {
-    expect(shouldShowStatementGutter(false, 0)).toBe(false);
-    expect(shouldShowStatementGutter(true, 0)).toBe(true);
-    expect(shouldShowStatementGutter(false, 1)).toBe(true);
+  it("keeps gutter visibility controlled by the run-button preference", () => {
+    expect(shouldShowStatementGutter(false)).toBe(false);
+    expect(shouldShowStatementGutter(true)).toBe(true);
   });
 
   it("keeps execution status inside the run button column", () => {

--- a/apps/desktop/src/lib/editor/codemirrorStatementGutter.ts
+++ b/apps/desktop/src/lib/editor/codemirrorStatementGutter.ts
@@ -8,8 +8,8 @@ export interface StatementGutterMarkerDomOptions {
   statusLabel?: string;
 }
 
-export function shouldShowStatementGutter(showRunButtons: boolean, markerCount: number): boolean {
-  return showRunButtons || markerCount > 0;
+export function shouldShowStatementGutter(showRunButtons: boolean): boolean {
+  return showRunButtons;
 }
 
 function createStatusIconDom(status: StatementExecutionMarkerStatus, includeCircle: boolean) {

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -762,19 +762,19 @@ export function buildEditorFontThemeRules(opts?: { fixedHeight?: boolean; scroll
     },
     ".cm-lineNumbers .cm-gutterElement": {
       cursor: "pointer",
-      paddingRight: "16px",
+      paddingRight: "8px",
       userSelect: "none",
     },
     ".cm-run-statement-gutter": {
-      minWidth: "34px",
+      minWidth: "28px",
     },
     ".cm-run-statement-gutter .cm-gutterElement": {
       alignItems: "center",
       boxSizing: "border-box",
       display: "flex",
       justifyContent: "center",
-      minWidth: "34px",
-      padding: "0 5px",
+      minWidth: "28px",
+      padding: "0 2px",
     },
     ".cm-run-statement-marker": {
       alignItems: "center",


### PR DESCRIPTION


https://github.com/user-attachments/assets/f69a3ffc-b901-437d-8b98-5ad2aae384bb

## 变更说明

修复 SQL 查询编辑器在语句执行前后左侧 gutter 宽度变化的问题。

### 原因

此前执行状态标记会参与 gutter 的显示判断：即使用户关闭了“显示语句执行按钮”，执行状态出现时仍会重新挂载执行栏，导致行号区域动态扩宽、SQL 内容横向跳动。

### 解决思路

- 让“显示语句执行按钮”配置独立决定执行 gutter 是否存在。
- 移除根据执行状态标记数量动态重配 gutter 的逻辑。
- 开启配置时将执行 gutter 固定为 28px，状态变化不再影响宽度。
- 将行号右侧留白由 16px 调整为 8px，压缩左侧区域占用。
- 关闭配置时不展示左侧执行按钮及执行状态；查询结果与错误信息仍正常显示在结果区域。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）



## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

验证内容：

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/codemirrorStatementGutter.spec.ts apps/desktop/src/lib/__tests__/editorThemes.spec.ts`
- `pnpm typecheck`
- 定向 `oxlint`
- `oxfmt --check`

## 关联 Issue

Close #5052
