### PR TITLE
fix(editor): restore WHERE keyword completion after quoted prefilled

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1329,6 +1329,12 @@ async function newQuery() {
     databaseType: effectiveDatabaseTypeForConnection(conn),
   });
   const tabId = queryStore.createTab(conn.id, target.database, undefined, "query", target.schema, initialSql, target.catalog);
+  if (initialSql) {
+    const prefilledTab = queryStore.tabs.find((t) => t.id === tabId);
+    if (prefilledTab) {
+      prefilledTab.editorSelection = { anchor: initialSql.length, head: initialSql.length };
+    }
+  }
   try {
     await connectionStore.ensureConnected(target.connectionId);
     if (target.shouldRefreshDefaultDatabase) {

--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -419,4 +419,16 @@ WHERE a.id = b.fk_kpi_set_score_id`,
     expect(context.suggestTables).toBe(true);
     expect(items.filter((item) => item.type === "table").map((item) => item.label)).toEqual(["orders"]);
   });
+
+  it.each([
+    ["PostgreSQL quoted table", 'SELECT * FROM "users" wh|', "postgres", "postgres"],
+    ["PostgreSQL quoted schema.table", 'SELECT * FROM "public"."users" wh|', "postgres", "postgres"],
+    ["MySQL backtick table", "SELECT * FROM `users` wh|", "mysql", "mysql"],
+    ["SQL Server bracket table", "SELECT * FROM [users] wh|", "sqlserver", "sqlserver"],
+  ] as const)("offers WHERE keyword completion after a quoted prefilled table (%s)", (_label, markedSql, databaseType, dialect) => {
+    const { context, items } = semanticCompletion(markedSql, {}, { databaseType, dialect });
+
+    expect(context.suggestKeywords).toBe(true);
+    expect(items.filter((item) => item.type === "keyword").map((item) => item.label)).toEqual(expect.arrayContaining(["WHERE", "WHEN", "WITH"]));
+  });
 });

--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -423,8 +423,12 @@ WHERE a.id = b.fk_kpi_set_score_id`,
   it.each([
     ["PostgreSQL quoted table", 'SELECT * FROM "users" wh|', "postgres", "postgres"],
     ["PostgreSQL quoted schema.table", 'SELECT * FROM "public"."users" wh|', "postgres", "postgres"],
+    ["PostgreSQL quoted keyword table", 'SELECT * FROM "from" wh|', "postgres", "postgres"],
+    ["PostgreSQL quoted schema.keyword table", 'SELECT * FROM "public"."from" wh|', "postgres", "postgres"],
     ["MySQL backtick table", "SELECT * FROM `users` wh|", "mysql", "mysql"],
+    ["MySQL backtick keyword table", "SELECT * FROM `join` wh|", "mysql", "mysql"],
     ["SQL Server bracket table", "SELECT * FROM [users] wh|", "sqlserver", "sqlserver"],
+    ["SQL Server bracket keyword table", "SELECT * FROM [update] wh|", "sqlserver", "sqlserver"],
   ] as const)("offers WHERE keyword completion after a quoted prefilled table (%s)", (_label, markedSql, databaseType, dialect) => {
     const { context, items } = semanticCompletion(markedSql, {}, { databaseType, dialect });
 

--- a/apps/desktop/src/lib/sql/semantic/model.ts
+++ b/apps/desktop/src/lib/sql/semantic/model.ts
@@ -598,12 +598,12 @@ function trailingIdentifier(tokens: readonly SqlSemanticToken[], cursor: number,
 
 function previousWord(tokens: readonly SqlSemanticToken[], cursor: number): string {
   const before = tokens.filter((item) => item.span.end <= cursor && item.kind !== "comment");
-  return nearestPreviousIdentifierName(before);
+  return nearestPreviousSyntaxWord(before);
 }
 
 function wordBeforePosition(tokens: readonly SqlSemanticToken[], position: number): string {
   const before = tokens.filter((item) => item.span.end <= position && item.kind !== "comment");
-  return nearestPreviousIdentifierName(before);
+  return nearestPreviousSyntaxWord(before);
 }
 
 function wordBeforeTrailingIdentifier(tokens: readonly SqlSemanticToken[], cursor: number, trailing: TrailingIdentifier): string {
@@ -619,22 +619,20 @@ function wordBeforeTrailingIdentifier(tokens: readonly SqlSemanticToken[], curso
     identifiersToSkip -= 1;
     index -= 1;
   }
-  return nearestPreviousIdentifierName(before.slice(0, index + 1));
+  return nearestPreviousSyntaxWord(before.slice(0, index + 1));
 }
 
 /**
- * Scans backward from the end of `before` for the nearest identifier and returns
- * its normalized name. Plain `word` tokens use their normalized (case-folded)
- * spelling; `quoted_identifier` tokens (e.g. a prefilled `SELECT * FROM "users"`)
- * are treated as an ordinary previous word too, so a following keyword such as
- * `where` is not misclassified as a continued `FROM` table reference.
+ * Scans backward from the end of `before` for the nearest unquoted syntax word.
+ * A quoted identifier is a barrier: its object name must not participate in
+ * keyword comparisons even when it is named `from`, `join`, or `update`.
  */
-function nearestPreviousIdentifierName(tokens: readonly SqlSemanticToken[]): string {
+function nearestPreviousSyntaxWord(tokens: readonly SqlSemanticToken[]): string {
   for (let index = tokens.length - 1; index >= 0; index -= 1) {
     const item = tokens[index];
     if (!item) continue;
     if (item.kind === "word") return item.normalized;
-    if (item.kind === "quoted_identifier") return unquoteSqlSemanticIdentifier(item);
+    if (item.kind === "quoted_identifier") return "";
     if (item.text === "." || item.kind === "comment") continue;
     break;
   }

--- a/apps/desktop/src/lib/sql/semantic/model.ts
+++ b/apps/desktop/src/lib/sql/semantic/model.ts
@@ -597,13 +597,13 @@ function trailingIdentifier(tokens: readonly SqlSemanticToken[], cursor: number,
 }
 
 function previousWord(tokens: readonly SqlSemanticToken[], cursor: number): string {
-  const before = tokens.filter((item) => item.span.end <= cursor && item.kind === "word");
-  return before[before.length - 1]?.normalized ?? "";
+  const before = tokens.filter((item) => item.span.end <= cursor && item.kind !== "comment");
+  return nearestPreviousIdentifierName(before);
 }
 
 function wordBeforePosition(tokens: readonly SqlSemanticToken[], position: number): string {
-  const before = tokens.filter((item) => item.span.end <= position && item.kind === "word");
-  return before[before.length - 1]?.normalized ?? "";
+  const before = tokens.filter((item) => item.span.end <= position && item.kind !== "comment");
+  return nearestPreviousIdentifierName(before);
 }
 
 function wordBeforeTrailingIdentifier(tokens: readonly SqlSemanticToken[], cursor: number, trailing: TrailingIdentifier): string {
@@ -619,7 +619,26 @@ function wordBeforeTrailingIdentifier(tokens: readonly SqlSemanticToken[], curso
     identifiersToSkip -= 1;
     index -= 1;
   }
-  return before[index]?.kind === "word" ? before[index].normalized : "";
+  return nearestPreviousIdentifierName(before.slice(0, index + 1));
+}
+
+/**
+ * Scans backward from the end of `before` for the nearest identifier and returns
+ * its normalized name. Plain `word` tokens use their normalized (case-folded)
+ * spelling; `quoted_identifier` tokens (e.g. a prefilled `SELECT * FROM "users"`)
+ * are treated as an ordinary previous word too, so a following keyword such as
+ * `where` is not misclassified as a continued `FROM` table reference.
+ */
+function nearestPreviousIdentifierName(tokens: readonly SqlSemanticToken[]): string {
+  for (let index = tokens.length - 1; index >= 0; index -= 1) {
+    const item = tokens[index];
+    if (!item) continue;
+    if (item.kind === "word") return item.normalized;
+    if (item.kind === "quoted_identifier") return unquoteSqlSemanticIdentifier(item);
+    if (item.text === "." || item.kind === "comment") continue;
+    break;
+  }
+  return "";
 }
 
 function isTableListContinuation(tokens: readonly SqlSemanticToken[], position: number): boolean {


### PR DESCRIPTION
## 变更说明

修复开启新建查询时预填充SELECT语句后，光标位置异常和WHERE等补全失效问题
## 根本原因
问题 1（补全失效）的真正根因：预填充 SQL 通过 qualifiedTableName 给表名加引号（如 PostgreSQL 的 "users"、MySQL 的 `users`、SQL Server 的 [users]）。在 buildSqlSemanticModel 中，wordBeforePosition 只识别 word 类型的 token，跳过 quoted_identifier，导致光标在带引号表名后输入 wh 时，wordBeforeReplacement 误判为 "from"，从而：

* cursorIntent 变成 table（认为还在补表名）
* suggestKeywords: false → 不显示 WHERE/WHEN/WITH 关键字补全

问题 2（光标位置）：新建查询 createTab 时 editorSelection 为 undefined，光标默认停在文档开头 (0,0)，没有定位到预填充 SQL 末尾。

## 修复（3 个文件）
1. apps/desktop/src/lib/sql/semantic/model.ts（核心修复）：重写 previousWord、wordBeforePosition、wordBeforeTrailingIdentifier，新增 nearestPreviousIdentifierName，让它们在查找"前一个词"时把 quoted_identifier（带引号表名）当作普通词处理。修复后带引号表名后输入 wh 正确返回 WHERE/WHEN/WITH 关键字补全。

2. apps/desktop/src/App.vue：新建查询预填充后，将新 tab 的 editorSelection 定位到 SQL 末尾，解决光标位置问题。

3. apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts：添加 4 个回退测试，覆盖 PostgreSQL 双引号、MySQL 反引号、SQL Server 方括号的带引号表名关键字补全。
## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1203" height="426" alt="image" src="https://github.com/user-attachments/assets/dcbfadad-b5b5-4ff5-a610-33c5ae26f361" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->
* 修复前：带引号表名 + wh → cursorIntent: table, suggestKeywords: false, 补全项为空
* 修复后：带引号表名 + wh → cursorIntent: keyword, suggestKeywords: true, 补全项 ['WHERE','WHEN','WITH']
* 全部相关测试通过：semantic 目录 104 个 + sqlCompletion 相关 115 个，无回归
* lint 无错误
- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #3746