### PR TITLE
修复 MCP DML 结果与返回行集丢失

### DIFF
--- a/agents/drivers/duckdb/src/query.rs
+++ b/agents/drivers/duckdb/src/query.rs
@@ -46,6 +46,22 @@ mod tests {
     }
 
     #[test]
+    fn duckdb_execute_returns_dml_returning_rows() {
+        let con = duckdb::Connection::open_in_memory().expect("connect in-memory DuckDB");
+        con.execute_batch("CREATE TABLE users (id INTEGER, name VARCHAR)").expect("create table");
+
+        let inserted = duckdb_execute(&con, "INSERT INTO users VALUES (1, 'Ada') RETURNING id, name")
+            .expect("insert returning");
+        let updated = duckdb_execute(&con, "UPDATE users SET name = 'Ada Lovelace' RETURNING id, name")
+            .expect("update returning");
+        let deleted = duckdb_execute(&con, "DELETE FROM users RETURNING id, name").expect("delete returning");
+
+        assert_eq!(inserted.rows, vec![vec![serde_json::json!(1), serde_json::json!("Ada")]]);
+        assert_eq!(updated.rows, vec![vec![serde_json::json!(1), serde_json::json!("Ada Lovelace")]]);
+        assert_eq!(deleted.rows, vec![vec![serde_json::json!(1), serde_json::json!("Ada Lovelace")]]);
+    }
+
+    #[test]
     fn duckdb_execute_returns_rows_for_from_first_query() {
         let con = duckdb::Connection::open_in_memory().expect("connect in-memory DuckDB");
         con.execute_batch("CREATE TABLE users (id INTEGER, name VARCHAR)").expect("create table");

--- a/agents/drivers/duckdb/src/sql.rs
+++ b/agents/drivers/duckdb/src/sql.rs
@@ -202,6 +202,62 @@ pub fn starts_with_duckdb_result_sql_keyword(sql: &str) -> bool {
         .any(|keyword| {
             token.eq_ignore_ascii_case(keyword) || (*keyword == "DESCRIBE" && token.eq_ignore_ascii_case("DESC"))
         })
+        || matches!(token.to_ascii_uppercase().as_str(), "INSERT" | "UPDATE" | "DELETE" | "MERGE")
+            && contains_unquoted_sql_keyword(sql, "RETURNING")
+}
+
+fn contains_unquoted_sql_keyword(sql: &str, keyword: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' if !in_double => {
+                if in_single && bytes.get(index + 1) == Some(&b'\'') {
+                    index += 2;
+                    continue;
+                }
+                in_single = !in_single;
+                index += 1;
+            }
+            b'"' if !in_single => {
+                if in_double && bytes.get(index + 1) == Some(&b'"') {
+                    index += 2;
+                    continue;
+                }
+                in_double = !in_double;
+                index += 1;
+            }
+            b'-' if !in_single && !in_double && bytes.get(index + 1) == Some(&b'-') => {
+                index += 2;
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'/' if !in_single && !in_double && bytes.get(index + 1) == Some(&b'*') => {
+                index += 2;
+                while index + 1 < bytes.len() && !(bytes[index] == b'*' && bytes[index + 1] == b'/') {
+                    index += 1;
+                }
+                index = (index + 2).min(bytes.len());
+            }
+            byte if !in_single && !in_double && (byte.is_ascii_alphabetic() || byte == b'_') => {
+                let start = index;
+                index += 1;
+                while index < bytes.len() && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_') {
+                    index += 1;
+                }
+                if sql[start..index].eq_ignore_ascii_case(keyword) {
+                    return true;
+                }
+            }
+            _ => index += 1,
+        }
+    }
+
+    false
 }
 
 fn first_executable_sql_token(sql: &str) -> Option<&str> {
@@ -269,6 +325,8 @@ mod tests {
     fn detects_result_statements_after_comments() {
         assert!(starts_with_duckdb_result_sql_keyword("/* note */ WITH rows AS (SELECT 1) SELECT * FROM rows"));
         assert!(starts_with_duckdb_result_sql_keyword("DESC SELECT 1"));
+        assert!(starts_with_duckdb_result_sql_keyword("INSERT INTO items VALUES (1) RETURNING id"));
+        assert!(!starts_with_duckdb_result_sql_keyword("INSERT INTO items(note) VALUES ('RETURNING')"));
         assert!(!starts_with_duckdb_result_sql_keyword("INSERT INTO items VALUES (1)"));
     }
 }

--- a/crates/dbx-core/src/agent_tools.rs
+++ b/crates/dbx-core/src/agent_tools.rs
@@ -616,8 +616,10 @@ async fn execute_execute_query(
 
 /// Format a QueryResult as a Markdown table for LLM consumption.
 fn format_query_result_as_text(result: &QueryResult, limit: usize) -> Result<String, String> {
-    if result.rows.is_empty() {
-        return Ok("Query returned 0 rows.".to_string());
+    // A result without columns is a command result, not an empty result set.
+    // This is how drivers represent DML that does not use RETURNING.
+    if result.columns.is_empty() {
+        return Ok(format!("Query executed. {} row(s) affected.", result.affected_rows));
     }
 
     let mut lines = Vec::new();
@@ -1133,6 +1135,48 @@ for line in sys.stdin:
         let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
 
         assert!(names.contains(&"explain_query"));
+    }
+
+    fn query_result(columns: Vec<&str>, rows: Vec<Vec<serde_json::Value>>, affected_rows: u64) -> QueryResult {
+        QueryResult {
+            columns: columns.into_iter().map(str::to_string).collect(),
+            column_types: Vec::new(),
+            column_sortables: Vec::new(),
+            rows,
+            affected_rows,
+            execution_time_ms: 1,
+            truncated: false,
+            session_id: None,
+            has_more: false,
+            elasticsearch_raw_body: None,
+        }
+    }
+
+    #[test]
+    fn query_result_formatter_reports_dml_affected_rows() {
+        let result = query_result(vec![], vec![], 2);
+
+        assert_eq!(format_query_result_as_text(&result, 50).unwrap(), "Query executed. 2 row(s) affected.");
+    }
+
+    #[test]
+    fn query_result_formatter_distinguishes_zero_row_dml_from_an_empty_result_set() {
+        let dml = query_result(vec![], vec![], 0);
+        let returning = query_result(vec!["id", "name"], vec![], 0);
+
+        assert_eq!(format_query_result_as_text(&dml, 50).unwrap(), "Query executed. 0 row(s) affected.");
+        assert_eq!(format_query_result_as_text(&returning, 50).unwrap(), "| id | name |\n|---|---|\n(0 rows, 1ms)");
+    }
+
+    #[test]
+    fn query_result_formatter_renders_returning_rows() {
+        let result =
+            query_result(vec!["id", "name"], vec![vec![serde_json::json!(5), serde_json::json!("returning")]], 0);
+
+        assert_eq!(
+            format_query_result_as_text(&result, 50).unwrap(),
+            "| id | name |\n|---|---|\n| 5 | returning |\n(1 rows, 1ms)"
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/agent_tools.rs
+++ b/crates/dbx-core/src/agent_tools.rs
@@ -1142,6 +1142,8 @@ for line in sys.stdin:
             columns: columns.into_iter().map(str::to_string).collect(),
             column_types: Vec::new(),
             column_sortables: Vec::new(),
+            spatial_columns: Vec::new(),
+            spatial_values: Vec::new(),
             rows,
             affected_rows,
             execution_time_ms: 1,

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -4,6 +4,9 @@ use mysql_async::consts::ColumnType;
 use mysql_async::prelude::*;
 use percent_encoding::percent_decode_str;
 use rust_decimal::Decimal;
+use sqlparser::ast::Statement;
+use sqlparser::dialect::MySqlDialect;
+use sqlparser::parser::Parser;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -4175,12 +4178,31 @@ fn prefers_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
     is_result_set_query(sql, dialect) || requires_text_protocol_query(sql, dialect)
 }
 
-fn is_result_set_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
+pub(crate) fn is_result_set_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
     starts_with_executable_sql_keyword_for_database(
         sql,
         &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL"],
         DatabaseType::Mysql,
-    ) || dialect.supports_admin_show_results && is_admin_show_query(sql)
+    ) || mysql_statement_returns_rows(sql)
+        || dialect.supports_admin_show_results && is_admin_show_query(sql)
+}
+
+/// MariaDB 10.5+ returns a result set for INSERT/DELETE/REPLACE ... RETURNING.
+/// Route it through the existing query path; MySQL servers that do not support
+/// the syntax still return their normal SQL syntax error.
+fn mysql_statement_returns_rows(sql: &str) -> bool {
+    let Ok(statements) = Parser::parse_sql(&MySqlDialect {}, sql) else {
+        return false;
+    };
+    let [statement] = statements.as_slice() else {
+        return false;
+    };
+
+    match statement {
+        Statement::Insert(insert) => insert.returning.is_some(),
+        Statement::Delete(delete) => delete.returning.is_some(),
+        _ => false,
+    }
 }
 
 fn requires_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
@@ -4607,6 +4629,15 @@ mod tests {
     fn mysql_with_queries_are_treated_as_result_sets() {
         let sql = "WITH RECURSIVE org_tree AS (SELECT 1 AS id) SELECT id FROM org_tree";
         assert!(is_result_set_query(sql, MySqlQueryDialect::default()));
+    }
+
+    #[test]
+    fn mariadb_returning_dml_is_treated_as_a_result_set() {
+        let dialect = MySqlQueryDialect::default();
+
+        assert!(is_result_set_query("INSERT INTO users (id) VALUES (1) RETURNING id", dialect));
+        assert!(is_result_set_query("DELETE FROM users WHERE id = 1 RETURNING id", dialect));
+        assert!(!is_result_set_query("UPDATE users SET name = 'Ada'", dialect));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -8,6 +8,9 @@ use rustls::client::verify_server_cert_signed_by_trust_anchor;
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::server::ParsedCertificate;
+use sqlparser::ast::Statement;
+use sqlparser::dialect::PostgreSqlDialect;
+use sqlparser::parser::Parser;
 use std::collections::{BTreeSet, HashMap};
 use std::fs::File;
 use std::future::Future;
@@ -3219,6 +3222,29 @@ fn query_result_row_limit(max_rows: Option<usize>) -> usize {
     max_rows.unwrap_or(crate::query::MAX_ROWS).max(1)
 }
 
+/// Returns whether PostgreSQL should execute this statement through the row
+/// retrieval path. DML without `RETURNING` needs `execute` for its command
+/// tag/affected-row count, while DML with `RETURNING` produces a result set.
+pub(crate) fn postgres_statement_returns_rows(sql: &str) -> bool {
+    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "EXPLAIN", "WITH", "TABLE"]) {
+        return true;
+    }
+
+    let Ok(statements) = Parser::parse_sql(&PostgreSqlDialect {}, sql) else {
+        return false;
+    };
+    let [statement] = statements.as_slice() else {
+        return false;
+    };
+
+    match statement {
+        Statement::Insert(insert) => insert.returning.is_some(),
+        Statement::Update(update) => update.returning.is_some(),
+        Statement::Delete(delete) => delete.returning.is_some(),
+        _ => false,
+    }
+}
+
 pub async fn execute_query(pool: &Pool, sql: &str) -> Result<QueryResult, String> {
     execute_query_with_max_rows(pool, sql, None).await
 }
@@ -3231,7 +3257,7 @@ pub async fn execute_query_with_max_rows(
     let start = Instant::now();
     let row_limit = query_result_row_limit(max_rows);
 
-    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "EXPLAIN", "WITH", "TABLE"]) {
+    if postgres_statement_returns_rows(sql) {
         let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
         execute_select_query(&client, sql, start, row_limit).await
     } else {
@@ -3729,7 +3755,7 @@ async fn execute_query_with_max_rows_inner(
     let start = Instant::now();
     let row_limit = query_result_row_limit(max_rows);
 
-    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "EXPLAIN", "WITH", "TABLE"]) {
+    if postgres_statement_returns_rows(sql) {
         if prefer_text_protocol {
             execute_select_text(client, sql, start, row_limit, None).await
         } else {
@@ -4679,6 +4705,27 @@ mod tests {
     }
 
     #[test]
+    fn postgres_statement_returns_rows_for_returning_dml_only() {
+        for sql in [
+            "INSERT INTO users (id) VALUES (1) RETURNING id",
+            "UPDATE users SET name = 'Ada' RETURNING id, name",
+            "DELETE FROM users WHERE id = 1 RETURNING id",
+            "WITH removed AS (DELETE FROM users WHERE id = 1 RETURNING id) SELECT * FROM removed",
+        ] {
+            assert!(postgres_statement_returns_rows(sql), "expected result rows for: {sql}");
+        }
+
+        for sql in [
+            "INSERT INTO users (id) VALUES (1)",
+            "UPDATE users SET name = 'Ada'",
+            "DELETE FROM users WHERE id = 1",
+            "INSERT INTO users (note) VALUES ('RETURNING is text')",
+        ] {
+            assert!(!postgres_statement_returns_rows(sql), "expected command result for: {sql}");
+        }
+    }
+
+    #[test]
     fn database_list_does_not_collect_storage_usage() {
         assert!(list_databases_sql().contains("pg_database"));
         assert!(!list_databases_sql().contains("pg_database_size"));
@@ -4844,6 +4891,58 @@ mod tests {
                 Err(error) => panic!("docker postgres did not become ready: {error}"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn postgres_dml_returning_preserves_result_rows() {
+        let Some(container) = start_docker_postgres().await else {
+            return;
+        };
+        let pool = connect(&container.url(), Duration::from_secs(5)).await.expect("connect postgres");
+
+        execute_query(&pool, "CREATE TABLE dml_returning (id integer PRIMARY KEY, name text NOT NULL)")
+            .await
+            .expect("create table");
+
+        let inserted = execute_query(&pool, "INSERT INTO dml_returning VALUES (1, 'alice'), (2, 'bob')")
+            .await
+            .expect("insert rows");
+        let updated = execute_query(&pool, "UPDATE dml_returning SET name = 'bob-updated' WHERE id = 2")
+            .await
+            .expect("update rows");
+        let deleted = execute_query(&pool, "DELETE FROM dml_returning WHERE id = 1").await.expect("delete row");
+        let unmatched =
+            execute_query(&pool, "UPDATE dml_returning SET name = name WHERE id = 999").await.expect("update no rows");
+
+        assert_eq!(inserted.affected_rows, 2);
+        assert_eq!(updated.affected_rows, 1);
+        assert_eq!(deleted.affected_rows, 1);
+        assert_eq!(unmatched.affected_rows, 0);
+
+        let insert_returning = execute_query(&pool, "INSERT INTO dml_returning VALUES (3, 'carol') RETURNING id, name")
+            .await
+            .expect("insert returning");
+        let update_returning =
+            execute_query(&pool, "UPDATE dml_returning SET name = 'carol-updated' WHERE id = 3 RETURNING id, name")
+                .await
+                .expect("update returning");
+        let delete_returning = execute_query(&pool, "DELETE FROM dml_returning WHERE id = 3 RETURNING id, name")
+            .await
+            .expect("delete returning");
+        let empty_returning =
+            execute_query(&pool, "UPDATE dml_returning SET name = name WHERE id = 999 RETURNING id, name")
+                .await
+                .expect("empty returning");
+
+        for result in [&insert_returning, &update_returning, &delete_returning] {
+            assert_eq!(result.columns, vec!["id", "name"]);
+            assert_eq!(result.rows.len(), 1);
+        }
+        assert_eq!(insert_returning.rows[0], vec![serde_json::json!(3), serde_json::json!("carol")]);
+        assert_eq!(update_returning.rows[0], vec![serde_json::json!(3), serde_json::json!("carol-updated")]);
+        assert_eq!(delete_returning.rows[0], vec![serde_json::json!(3), serde_json::json!("carol-updated")]);
+        assert_eq!(empty_returning.columns, vec!["id", "name"]);
+        assert!(empty_returning.rows.is_empty());
     }
 
     async fn assert_postgres_18(pool: &Pool) {

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3241,6 +3241,7 @@ pub(crate) fn postgres_statement_returns_rows(sql: &str) -> bool {
         Statement::Insert(insert) => insert.returning.is_some(),
         Statement::Update(update) => update.returning.is_some(),
         Statement::Delete(delete) => delete.returning.is_some(),
+        Statement::Merge(merge) => merge.output.is_some(),
         _ => false,
     }
 }
@@ -4710,6 +4711,7 @@ mod tests {
             "INSERT INTO users (id) VALUES (1) RETURNING id",
             "UPDATE users SET name = 'Ada' RETURNING id, name",
             "DELETE FROM users WHERE id = 1 RETURNING id",
+            "MERGE INTO users AS target USING updates AS source ON target.id = source.id WHEN MATCHED THEN UPDATE SET name = source.name RETURNING target.id",
             "WITH removed AS (DELETE FROM users WHERE id = 1 RETURNING id) SELECT * FROM removed",
         ] {
             assert!(postgres_statement_returns_rows(sql), "expected result rows for: {sql}");
@@ -4719,6 +4721,7 @@ mod tests {
             "INSERT INTO users (id) VALUES (1)",
             "UPDATE users SET name = 'Ada'",
             "DELETE FROM users WHERE id = 1",
+            "MERGE INTO users AS target USING updates AS source ON target.id = source.id WHEN MATCHED THEN UPDATE SET name = source.name",
             "INSERT INTO users (note) VALUES ('RETURNING is text')",
         ] {
             assert!(!postgres_statement_returns_rows(sql), "expected command result for: {sql}");

--- a/crates/dbx-core/src/db/sqlite.rs
+++ b/crates/dbx-core/src/db/sqlite.rs
@@ -2,6 +2,9 @@ use percent_encoding::percent_decode_str;
 use rusqlite::functions::{Context, FunctionFlags};
 use rusqlite::types::{Value, ValueRef};
 use rusqlite::{Connection, LoadExtensionGuard, OpenFlags};
+use sqlparser::ast::Statement;
+use sqlparser::dialect::SQLiteDialect;
+use sqlparser::parser::Parser;
 use std::collections::HashSet;
 use std::io::Read;
 use std::path::Path;
@@ -579,6 +582,45 @@ mod tests {
         let result = execute_query(&pool, "SELECT name FROM memory_probe WHERE id = 1;").await.expect("select row");
 
         assert_eq!(result.rows[0][0], serde_json::json!("Ada"));
+    }
+
+    #[tokio::test]
+    async fn sqlite_dml_returning_preserves_result_rows() {
+        let pool = connect_path(":memory:").await.expect("connect in-memory SQLite");
+        execute_query(&pool, "CREATE TABLE dml_returning (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+            .await
+            .expect("create table");
+
+        let inserted = execute_query(&pool, "INSERT INTO dml_returning VALUES (1, 'alice')").await.expect("insert row");
+        let unmatched =
+            execute_query(&pool, "UPDATE dml_returning SET name = name WHERE id = 999").await.expect("update no rows");
+        assert_eq!(inserted.affected_rows, 1);
+        assert_eq!(unmatched.affected_rows, 0);
+
+        let insert_returning = execute_query(&pool, "INSERT INTO dml_returning VALUES (2, 'bob') RETURNING id, name")
+            .await
+            .expect("insert returning");
+        let update_returning =
+            execute_query(&pool, "UPDATE dml_returning SET name = 'bob-updated' WHERE id = 2 RETURNING id, name")
+                .await
+                .expect("update returning");
+        let delete_returning = execute_query(&pool, "DELETE FROM dml_returning WHERE id = 2 RETURNING id, name")
+            .await
+            .expect("delete returning");
+        let empty_returning =
+            execute_query(&pool, "UPDATE dml_returning SET name = name WHERE id = 999 RETURNING id, name")
+                .await
+                .expect("empty returning");
+
+        for result in [&insert_returning, &update_returning, &delete_returning] {
+            assert_eq!(result.columns, vec!["id", "name"]);
+            assert_eq!(result.rows.len(), 1);
+        }
+        assert_eq!(insert_returning.rows[0], vec![serde_json::json!(2), serde_json::json!("bob")]);
+        assert_eq!(update_returning.rows[0], vec![serde_json::json!(2), serde_json::json!("bob-updated")]);
+        assert_eq!(delete_returning.rows[0], vec![serde_json::json!(2), serde_json::json!("bob-updated")]);
+        assert_eq!(empty_returning.columns, vec!["id", "name"]);
+        assert!(empty_returning.rows.is_empty());
     }
 
     #[tokio::test]
@@ -2322,6 +2364,28 @@ fn query_result_row_limit(max_rows: Option<usize>) -> usize {
     max_rows.unwrap_or(crate::query::MAX_ROWS).max(1)
 }
 
+/// DML with `RETURNING` produces a result set in SQLite and must use the
+/// statement query API instead of `execute_batch`.
+fn sqlite_statement_returns_rows(sql: &str) -> bool {
+    if starts_with_executable_sql_keyword(sql, &["SELECT", "PRAGMA", "EXPLAIN", "WITH"]) {
+        return true;
+    }
+
+    let Ok(statements) = Parser::parse_sql(&SQLiteDialect {}, sql) else {
+        return false;
+    };
+    let [statement] = statements.as_slice() else {
+        return false;
+    };
+
+    match statement {
+        Statement::Insert(insert) => insert.returning.is_some(),
+        Statement::Update(update) => update.returning.is_some(),
+        Statement::Delete(delete) => delete.returning.is_some(),
+        _ => false,
+    }
+}
+
 const SQLITE_FUNCTION_ALIASES: &[(&str, &str)] = &[("if", "IIF"), ("substring", "substr")];
 
 fn normalize_sqlite_sql(sql: &str) -> String {
@@ -2426,7 +2490,7 @@ fn execute_query_blocking(pool: &SqliteHandle, sql: &str, max_rows: Option<usize
     let row_limit = query_result_row_limit(max_rows);
 
     pool.with_connection(|conn| {
-        if starts_with_executable_sql_keyword(sql, &["SELECT", "PRAGMA", "EXPLAIN", "WITH"]) {
+        if sqlite_statement_returns_rows(sql) {
             let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
             let columns = stmt.column_names().iter().map(|name| name.to_string()).collect::<Vec<_>>();
             let column_decl_types =

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -2479,7 +2479,9 @@ pub async fn execute_query_with_max_rows(
 ) -> Result<QueryResult, String> {
     let start = Instant::now();
 
-    if starts_with_executable_sql_keyword(sql, &["SELECT", "EXEC", "WITH", "TABLE"]) {
+    if starts_with_executable_sql_keyword(sql, &["SELECT", "EXEC", "WITH", "TABLE"])
+        || sqlserver_dml_output_returns_rows(sql)
+    {
         let query = match sqlserver_unsafe_type_query(client, sql).await {
             Ok(Some(query)) => query,
             Ok(None) => SqlServerUnsafeTypeQuery::plain(sql),
@@ -3154,6 +3156,32 @@ mod tests {
             "DECLARE @id INT = 1; UPDATE dbo.users SET active = 0 WHERE id = @id;"
         ));
         assert!(sqlserver_dml_output_returns_rows("DELETE FROM dbo.users OUTPUT deleted.id WHERE id = 1;"));
+    }
+
+    #[test]
+    fn sqlserver_dml_output_detection_distinguishes_client_rows_from_output_into() {
+        assert!(sqlserver_dml_output_returns_rows(
+            "INSERT INTO dbo.users(name) OUTPUT inserted.id, inserted.name VALUES (N'Ada')"
+        ));
+        assert!(sqlserver_dml_output_returns_rows("UPDATE dbo.users SET active = 1 OUTPUT inserted.id WHERE id = 1"));
+        assert!(sqlserver_dml_output_returns_rows("DELETE FROM dbo.users OUTPUT deleted.id WHERE id = 1"));
+        assert!(!sqlserver_dml_output_returns_rows(
+            "INSERT INTO dbo.audit OUTPUT inserted.id INTO dbo.audit_ids VALUES (1)"
+        ));
+        assert!(!sqlserver_dml_output_returns_rows(
+            "UPDATE dbo.users SET note = N'OUTPUT inserted.id' WHERE id = 1 -- OUTPUT deleted.id"
+        ));
+        assert!(!sqlserver_dml_output_returns_rows("SELECT N'OUTPUT inserted.id'"));
+    }
+
+    #[test]
+    fn sqlserver_dml_output_uses_the_result_set_execution_path() {
+        let source = include_str!("sqlserver.rs");
+        let execute_query = source.split("pub async fn execute_query_with_max_rows").nth(1).unwrap();
+        let execute_query = execute_query.split("pub async fn execute_batch").next().unwrap();
+
+        assert!(execute_query.contains("sqlserver_dml_output_returns_rows(sql)"));
+        assert!(execute_query.contains("client.query(query_sql.as_str(), &[])"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -3181,7 +3181,7 @@ mod tests {
         let execute_query = execute_query.split("pub async fn execute_batch").next().unwrap();
 
         assert!(execute_query.contains("sqlserver_dml_output_returns_rows(sql)"));
-        assert!(execute_query.contains("client.query(query_sql.as_str(), &[])"));
+        assert!(execute_query.contains("client.query(query.sql.as_str(), &[])"));
     }
 
     #[test]

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -22,7 +22,7 @@ use crate::database_capabilities;
 use crate::db;
 use crate::models::connection::{ConnectionConfig, DatabaseType};
 use crate::query_execution_sql::is_write_sql;
-use crate::sql::{split_sql_batches, split_sql_statements, starts_with_executable_sql_keyword};
+use crate::sql::{split_sql_batches, split_sql_statements};
 use crate::sql_dialect::{resolve_for_db, CAP_TRANSACTIONAL_DDL};
 use crate::sql_risk::{classify_sql_risk_for_database, SqlRisk};
 
@@ -3522,7 +3522,7 @@ async fn execute_manual_txn_postgres_statement(
     sql: &str,
     row_limit: usize,
 ) -> Result<db::QueryResult, String> {
-    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "EXPLAIN", "WITH", "TABLE"]) {
+    if db::postgres::postgres_statement_returns_rows(sql) {
         db::postgres::execute_select_query(conn, sql, std::time::Instant::now(), row_limit).await
     } else {
         let affected = conn.execute(sql, &[]).await.map_err(|e| format!("Query failed: {e}"))?;
@@ -3548,7 +3548,7 @@ async fn execute_manual_txn_mysql_statement(
     sql: &str,
     row_limit: usize,
 ) -> Result<db::QueryResult, String> {
-    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH"]) {
+    if db::mysql::is_result_set_query(sql, db::mysql::MySqlQueryDialect::default()) {
         let start = std::time::Instant::now();
         let mut result = conn.query_iter(sql).await.map_err(|e| format!("Query failed: {e}"))?;
         let columns: Vec<String> = result.columns_ref().iter().map(|c| c.name_str().to_string()).collect();


### PR DESCRIPTION
## 简要说明

修复 MCP/Agent 执行成功 DML 时误报“Query returned 0 rows.”的问题，并保留 PostgreSQL、SQLite、DuckDB、MariaDB 兼容路径的 DML `RETURNING` 结果集及 SQL Server DML `OUTPUT` 结果集。

---

## 背景与动机

当前结果格式化逻辑以“是否有返回行”判断查询是否有结果。普通 DML 即使成功影响了记录，通常也没有返回列或行，因此会被错误显示为“Query returned 0 rows.”，忽略实际的 `affected_rows`。

同时，部分数据库的 DML 可以返回结果集：PostgreSQL、SQLite、DuckDB 使用 `RETURNING`，MariaDB 支持部分 DML 的 `RETURNING`，SQL Server 使用 `OUTPUT`。原有按首关键字分流的执行路径会将它们误送入仅执行、不取行的分支，造成结果行丢失。

可能导致：

- MCP/Agent 无法确认 DML 是否成功及其影响行数
- `RETURNING` 或 `OUTPUT` 的返回行和列定义丢失
- 空返回结果集无法区分于普通 DML

关联 Issue：

Fixes #5093

---

## 修改内容

- MCP/Agent 共用结果格式化改为按“是否有列”而非“是否有行”区分 DML 与结果集
- 无列 DML 显示 `Query executed. N row(s) affected.`
- 有列但零行的结果集保留 Markdown 表头并显示 `0 row(s)`
- PostgreSQL 原生执行器识别 `INSERT`、`UPDATE`、`DELETE ... RETURNING`，并在普通与手动事务路径均读取结果集
- SQLite 原生执行器识别 DML `RETURNING` 并读取结果集
- MySQL 执行器识别 MariaDB 的 `INSERT`、`DELETE`、`REPLACE ... RETURNING`
- DuckDB sidecar 识别顶层 DML `RETURNING`，同时避开字符串字面量与注释中的误匹配
- SQL Server 原生执行器识别向客户端返回行的 DML `OUTPUT`，改走 `query()` 结果集路径；`OUTPUT ... INTO` 保持既有 execute 路径
- 新增单元、集成及 Web + MCP 端到端回归测试

---

## 设计与实现细节

修改前：

```text
DML SQL
  |
  +-- 按首关键字判定为“非查询”
        |
        +-- execute()
              |
              +-- RETURNING / OUTPUT 行集被丢弃
```

修改后：

```text
SQL
  |
  +-- 普通查询关键字 --------------------------> 读取结果集
  |
  +-- DML
        |
        +-- 方言语法判定含 RETURNING / OUTPUT -> 读取结果集
        |
        +-- 其他 DML --------------------------> execute() + affected_rows
```

结果格式化层以 `columns` 是否为空为边界：无列表示普通 DML，使用 `affected_rows`；有列则始终格式化结果表，即使 `rows` 为空。SQL Server 复用已有 `OUTPUT` 语义识别，仅在行会返回给客户端时切换路径，避免将 `OUTPUT ... INTO` 误判为结果集。

---

## 测试验证

测试方式：

- 单元测试：MCP/Agent 结果格式化、PostgreSQL/MariaDB/SQLite/DuckDB/SQL Server 语句识别
- 集成测试：SQLite、DuckDB，以及 Docker PostgreSQL 16 的 DML/RETURNING 执行
- 手工端到端验证：通过 DBX Web 后端和 `dbx-mcp` 调用实际 MariaDB、PostgreSQL 与 SQL Server

测试环境：

- 操作系统：macOS 26.5（arm64）
- Rust：rustc 1.95.0
- PostgreSQL：16（Docker 集成测试）；13.5（Web + MCP 实库验证）
- MariaDB：10.5.13（Web + MCP 实库验证）
- SQL Server：2019（Web + MCP 实库验证）

测试命令：

```text
cargo fmt --check
cargo test -p dbx-core agent_tools::tests --lib
cargo test -p dbx-core db::sqlite::tests::sqlite_dml_returning_preserves_result_rows --lib
cargo test -p dbx-core db::mysql::tests::mariadb_returning_dml_is_treated_as_a_result_set --lib
cargo test -p dbx-core db::postgres::tests::postgres_dml_returning_preserves_result_rows --lib
cargo test --manifest-path agents/drivers/duckdb/Cargo.toml dml_returning --lib
cargo test -p dbx-core db::sqlserver::tests --lib
```

测试结果：

- 格式化测试：34 项通过
- SQLite、MariaDB 分流、PostgreSQL Docker、DuckDB 测试均通过
- SQL Server 测试：78 项通过，1 项既有的环境依赖测试忽略
- MCP 实库验证：MariaDB、PostgreSQL 与 SQL Server 的普通 DML 显示受影响行数；`RETURNING` / `OUTPUT` 返回行；零行结果保留表头

---

## 影响范围

影响模块：

- `crates/dbx-core` 的 MCP/Agent 结果格式化和 PostgreSQL、SQLite、MySQL、SQL Server 执行路径
- DuckDB sidecar 的结果集语句识别

不受影响模块：

- Cloudflare D1：原本直接保留 API 返回的结果与 changes
- JDBC/Agent 驱动：依据 `Statement.execute()` 的实际 ResultSet 判定
- 普通 MySQL：不支持本 PR 涉及的 `RETURNING` 语法
- Redis、MongoDB、Elasticsearch 等非关系型执行路径

兼容性：

- 对外 API、ABI 和连接配置无变化
- 既有 `SELECT` 与普通 DML 的执行语义不变
- SQL Server 的 `OUTPUT ... INTO` 不向客户端返回行，继续使用既有 execute 路径

---

## 风险评估

低风险。

原因：

- 修改限定在结果集判定与格式化边界
- 仅在数据库方言明确支持 DML 返回行的情况下改走取行路径
- 普通 DML 及 SQL Server `OUTPUT ... INTO` 继续使用既有 execute 路径
- 已覆盖普通 DML、返回行、零行结果集、PostgreSQL 手动事务路径和 SQL Server `OUTPUT`

---

## 检查清单

- [x] 代码格式检查通过
- [x] 已添加必要的单元和集成回归测试
- [x] 已完成 MariaDB、PostgreSQL 与 SQL Server 的 Web + MCP 端到端验证
- [x] 无需更新用户文档：这是内部执行与结果呈现缺陷修复
- [x] 无破坏性变更