### PR TITLE
Fix：修复 MongoDB 复制 SQL UPDATE 报错

### DIFF
--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -691,4 +691,44 @@ describe("useDataGridExport prepared row statements", () => {
     );
     expect(extractDataGridSelection).not.toHaveBeenCalled();
   });
+
+  it("uses the Mongo update formatter for SQL Updates", async () => {
+    const item = { ...row(['ObjectId("507f1f77bcf86cd799439011")', "Alice"]), sourceIndex: 0 };
+    const state = createMongoExportState({
+      columns: ["_id", "name"],
+      item,
+      mongoDocuments: [{ _id: { $oid: "507f1f77bcf86cd799439011" }, name: "Alice" }],
+      selectedCellMatrix: {
+        rowIndexes: [0],
+        columnIndexes: [0, 1],
+        columns: ["_id", "name"],
+        rows: [[item.data[0], item.data[1]]],
+      },
+    });
+
+    expect(state.canCopyWithExtractor("sql-updates")).toBe(true);
+    await expect(state.copyWithExtractor("sql-updates")).resolves.toBe(true);
+
+    const copied = vi.mocked(copyToClipboard).mock.calls[0]?.[0] ?? "";
+    expect(copied).toContain('db.getCollection("documents")');
+    expect(copied).toContain(".updateOne(");
+    expect(copied).toContain('"_id": ObjectId("507f1f77bcf86cd799439011")');
+    expect(copied).toContain('"name": "Alice"');
+    expect(extractDataGridSelection).not.toHaveBeenCalled();
+  });
+
+  it("does not expose Mongo SQL Updates without an explicit update target", async () => {
+    const item = { ...row(["507f1f77bcf86cd799439011", "Alice"]), sourceIndex: 0 };
+    const state = createMongoExportState({
+      columns: ["_id", "name"],
+      item,
+      mongoDocuments: [{ _id: { $oid: "507f1f77bcf86cd799439011" }, name: "Alice" }],
+      mongoUpdateTarget: false,
+    });
+
+    expect(state.canCopyWithExtractor("sql-updates")).toBe(false);
+    await expect(state.copyWithExtractor("sql-updates")).resolves.toBe(false);
+    expect(extractDataGridSelection).not.toHaveBeenCalled();
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -717,6 +717,74 @@ describe("useDataGridExport prepared row statements", () => {
     expect(extractDataGridSelection).not.toHaveBeenCalled();
   });
 
+  it("updates only explicitly selected Mongo fields while keeping _id as the filter", async () => {
+    const item = { ...row(['ObjectId("507f1f77bcf86cd799439011")', "Alice", "active"]), sourceIndex: 0 };
+    const state = createMongoExportState({
+      columns: ["_id", "name", "status"],
+      item,
+      mongoDocuments: [{ _id: { $oid: "507f1f77bcf86cd799439011" }, name: "Alice", status: "active" }],
+      selectedCellMatrix: {
+        rowIndexes: [0],
+        columnIndexes: [1],
+        columns: ["name"],
+        rows: [[item.data[1]]],
+      },
+    });
+
+    expect(state.canCopyWithExtractor("sql-updates")).toBe(true);
+    await expect(state.copyWithExtractor("sql-updates")).resolves.toBe(true);
+
+    const copied = vi.mocked(copyToClipboard).mock.calls[0]?.[0] ?? "";
+    expect(copied).toContain('"_id": ObjectId("507f1f77bcf86cd799439011")');
+    expect(copied).toContain('"name": "Alice"');
+    expect(copied).not.toContain('"status"');
+  });
+
+  it("does not expose Mongo SQL Updates for an _id-only selection", async () => {
+    const item = { ...row(['ObjectId("507f1f77bcf86cd799439011")', "Alice"]), sourceIndex: 0 };
+    const state = createMongoExportState({
+      columns: ["_id", "name"],
+      item,
+      mongoDocuments: [{ _id: { $oid: "507f1f77bcf86cd799439011" }, name: "Alice" }],
+      selectedCellMatrix: {
+        rowIndexes: [0],
+        columnIndexes: [0],
+        columns: ["_id"],
+        rows: [[item.data[0]]],
+      },
+    });
+
+    expect(state.canCopyWithExtractor("sql-updates")).toBe(false);
+    await expect(state.copyWithExtractor("sql-updates")).resolves.toBe(false);
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("filters new and deleted Mongo rows from SQL Updates", async () => {
+    const current = { ...row(['ObjectId("507f1f77bcf86cd799439011")', "Alice"]), id: 1, sourceIndex: 0 };
+    const added = { ...row(['ObjectId("507f1f77bcf86cd799439012")', "New"]), id: 2, sourceIndex: 1, isNew: true };
+    const deleted = { ...row(['ObjectId("507f1f77bcf86cd799439013")', "Deleted"]), id: 3, sourceIndex: 2, isDeleted: true };
+    const state = createMongoExportState({
+      columns: ["_id", "name"],
+      item: current,
+      items: [current, added, deleted],
+      mongoDocuments: [
+        { _id: { $oid: "507f1f77bcf86cd799439011" }, name: "Alice" },
+        { _id: { $oid: "507f1f77bcf86cd799439012" }, name: "New" },
+        { _id: { $oid: "507f1f77bcf86cd799439013" }, name: "Deleted" },
+      ],
+      selectedRowIds: new Set([1, 2, 3]),
+    });
+
+    expect(state.canCopyWithExtractor("sql-updates")).toBe(true);
+    await expect(state.copyWithExtractor("sql-updates")).resolves.toBe(true);
+
+    const copied = vi.mocked(copyToClipboard).mock.calls[0]?.[0] ?? "";
+    expect(copied.match(/\.updateOne\(/g)).toHaveLength(1);
+    expect(copied).toContain('"name": "Alice"');
+    expect(copied).not.toContain('"name": "New"');
+    expect(copied).not.toContain('"name": "Deleted"');
+  });
+
   it("does not expose Mongo SQL Updates without an explicit update target", async () => {
     const item = { ...row(["507f1f77bcf86cd799439011", "Alice"]), sourceIndex: 0 };
     const state = createMongoExportState({

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -5,7 +5,7 @@ import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { saveTextFile, sanitizeExportBaseName, compactLocalTimestamp } from "@/lib/export/saveTextFile";
 import * as api from "@/lib/backend/api";
 import { type CellSelectionMatrix, type CellSelectionRange, type SelectionData } from "@/lib/dataGrid/gridSelection";
-import type { DataGridExtractorOptions } from "@/lib/dataGrid/dataGridCopyExtractor";
+import type { DataGridExtractRequest, DataGridExtractorOptions } from "@/lib/dataGrid/dataGridCopyExtractor";
 import { useToast } from "@/composables/useToast";
 import { useExportTracker } from "@/composables/useExportTracker";
 import { displayCellValue, type CellValue } from "@/lib/dataGrid/cellValue";
@@ -493,14 +493,28 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     return buildCopyInsertStatement(rowLimit === undefined ? data : { ...data, rows: data.rows.slice(0, rowLimit) }, extractorOptions.sql.excludePrimaryKeysFromInsert, extractorOptions.sql.insertMode);
   }
 
-  async function buildMongoExtractorUpdate(_extractorOptions: DataGridExtractorOptions, rowLimit?: number): Promise<string | undefined> {
+  function mongoUpdateColumnIndexes(request: DataGridExtractRequest): number[] {
+    const selectedColumns = new Set(
+      request.selectedColumnIndexes
+        .map((index) => request.columns[index]?.sourceName ?? request.columns[index]?.displayName)
+        .filter((column): column is string => !!column)
+        .map(normalizeColumnName),
+    );
+    return effectiveColumns(sourceColumns.value, columns.value)
+      .map((column, index) => (column && selectedColumns.has(normalizeColumnName(column)) ? index : -1))
+      .filter((index) => index >= 0);
+  }
+
+  async function buildMongoExtractorUpdate(request: DataGridExtractRequest, rowLimit?: number): Promise<string | undefined> {
     const target = options.mongoUpdateTarget?.value;
     const documents = options.mongoDocuments?.value;
     if (!target || !documents) return undefined;
     const rows = updateEligibleRows();
     if (rows.length === 0) return undefined;
     const limitedRows = rowLimit === undefined ? rows : rows.slice(0, rowLimit);
-    const copyColumns = effectiveColumns(sourceColumns.value, columns.value).map((column) => column ?? "");
+    const allCopyColumns = effectiveColumns(sourceColumns.value, columns.value).map((column) => column ?? "");
+    const selectedColumnIndexes = mongoUpdateColumnIndexes(request);
+    const copyColumns = selectedColumnIndexes.map((index) => allCopyColumns[index]);
     await yieldToMainThread();
     const statements: string[] = [];
     for (const item of limitedRows) {
@@ -509,7 +523,13 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
       if (!originalDocument || typeof originalDocument !== "object" || Array.isArray(originalDocument)) continue;
       const source = originalDocument as Record<string, unknown>;
       if (!Object.prototype.hasOwnProperty.call(source, target.idColumn)) continue;
-      const update = buildMongoCopyUpdateDocument(item.data as MongoInputValue[], copyColumns, item.isDirtyCol, originalDocument, target.idColumn);
+      const update = buildMongoCopyUpdateDocument(
+        selectedColumnIndexes.map((index) => item.data[index]) as MongoInputValue[],
+        copyColumns,
+        selectedColumnIndexes.map((index) => item.isDirtyCol[index] ?? false),
+        originalDocument,
+        target.idColumn,
+      );
       if (!update) continue;
       const statement = `db.getCollection(${JSON.stringify(target.collection)}).updateOne({${JSON.stringify(target.idColumn)}:${formatMongoShellLiteral(source[target.idColumn])}},${formatMongoShellLiteral(update)});`;
       statements.push(formatMongoCopyStatement(statement) ?? statement);
@@ -517,15 +537,14 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     return statements.length > 0 ? statements.join("\n") : undefined;
   }
 
-  function canBuildMongoExtractorUpdate(): boolean {
+  function canBuildMongoExtractorUpdate(request: DataGridExtractRequest): boolean {
     const target = options.mongoUpdateTarget?.value;
     const documents = options.mongoDocuments?.value;
     const rows = updateEligibleRows();
     if (!target || !documents || rows.length === 0) return false;
 
-    const copyColumns = effectiveColumns(sourceColumns.value, columns.value).map((column) => column ?? "");
     const normalizedIdColumn = normalizeColumnName(target.idColumn);
-    if (!copyColumns.some((column) => normalizeColumnName(column) === normalizedIdColumn)) return false;
+    const copyColumns = mongoUpdateColumnIndexes(request).map((index) => effectiveColumns(sourceColumns.value, columns.value)[index] ?? "");
     if (!copyColumns.some((column) => column && normalizeColumnName(column) !== normalizedIdColumn)) return false;
 
     return rows.every((item) => {

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -469,6 +469,10 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     return targetedRows().filter((item) => !item.isDraft);
   }
 
+  function updateEligibleRows(): RowItem[] {
+    return targetedRows().filter((item) => !item.isNew && !item.isDraft && !item.isDeleted);
+  }
+
   function insertableCopyColumnCount(excludePrimaryKeys: boolean, copyColumns = effectiveColumns(sourceColumns.value, columns.value), extractorOptions?: DataGridExtractorOptions): number {
     const primaryKeySet = new Set((tableMeta.value?.primaryKeys ?? []).map(normalizeColumnName));
     return copyColumns.filter((column): column is string => !!column && !isCopyInsertOmittedColumn(databaseType.value, column, tableMeta.value, extractorOptions) && (!excludePrimaryKeys || !primaryKeySet.has(normalizeColumnName(column)))).length;
@@ -493,7 +497,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     const target = options.mongoUpdateTarget?.value;
     const documents = options.mongoDocuments?.value;
     if (!target || !documents) return undefined;
-    const rows = insertEligibleRows();
+    const rows = updateEligibleRows();
     if (rows.length === 0) return undefined;
     const limitedRows = rowLimit === undefined ? rows : rows.slice(0, rowLimit);
     const copyColumns = effectiveColumns(sourceColumns.value, columns.value).map((column) => column ?? "");
@@ -511,6 +515,24 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
       statements.push(formatMongoCopyStatement(statement) ?? statement);
     }
     return statements.length > 0 ? statements.join("\n") : undefined;
+  }
+
+  function canBuildMongoExtractorUpdate(): boolean {
+    const target = options.mongoUpdateTarget?.value;
+    const documents = options.mongoDocuments?.value;
+    const rows = updateEligibleRows();
+    if (!target || !documents || rows.length === 0) return false;
+
+    const copyColumns = effectiveColumns(sourceColumns.value, columns.value).map((column) => column ?? "");
+    const normalizedIdColumn = normalizeColumnName(target.idColumn);
+    if (!copyColumns.some((column) => normalizeColumnName(column) === normalizedIdColumn)) return false;
+    if (!copyColumns.some((column) => column && normalizeColumnName(column) !== normalizedIdColumn)) return false;
+
+    return rows.every((item) => {
+      if (item.sourceIndex === undefined) return false;
+      const document = documents[item.sourceIndex];
+      return !!document && typeof document === "object" && !Array.isArray(document) && Object.prototype.hasOwnProperty.call(document, target.idColumn);
+    });
   }
 
   const { copyWithExtractor, previewWithExtractor, canCopyWithExtractor } = useDataGridExtractor({
@@ -537,6 +559,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     },
     buildMongoInsert: buildMongoExtractorInsert,
     buildMongoUpdate: buildMongoExtractorUpdate,
+    canBuildMongoUpdate: canBuildMongoExtractorUpdate,
     contextCell,
     contextSelectionIsSynthetic,
   });

--- a/apps/desktop/src/composables/useDataGridExtractor.ts
+++ b/apps/desktop/src/composables/useDataGridExtractor.ts
@@ -47,8 +47,8 @@ interface UseDataGridExtractorOptions {
   copyText: (text: string, gridCopy?: { rows: readonly (readonly unknown[])[]; header?: readonly unknown[] }) => Promise<boolean>;
   canCopySqlInsert: (request: DataGridExtractRequest) => boolean;
   buildMongoInsert: (extractorOptions: DataGridExtractorOptions, rowLimit?: number) => Promise<string | undefined>;
-  buildMongoUpdate?: (extractorOptions: DataGridExtractorOptions, rowLimit?: number) => Promise<string | undefined>;
-  canBuildMongoUpdate?: () => boolean;
+  buildMongoUpdate?: (request: DataGridExtractRequest, rowLimit?: number) => Promise<string | undefined>;
+  canBuildMongoUpdate?: (request: DataGridExtractRequest) => boolean;
 }
 
 export function useDataGridExtractor(options: UseDataGridExtractorOptions) {
@@ -184,7 +184,10 @@ export function useDataGridExtractor(options: UseDataGridExtractorOptions) {
     }
     if (extractor === "sql-updates") {
       // Mongo has a dedicated updateOne path that doesn't need SQL primary keys.
-      if (options.databaseType.value === "mongodb") return options.canBuildMongoUpdate?.() ?? false;
+      if (options.databaseType.value === "mongodb") {
+        const request = buildRequest(extractor, extractorOptions);
+        return request !== null && (options.canBuildMongoUpdate?.(request) ?? false);
+      }
       return canBuildSqlUpdateRequest();
     }
     return selectionData() !== null;
@@ -192,9 +195,8 @@ export function useDataGridExtractor(options: UseDataGridExtractorOptions) {
 
   async function resolveMongoExtractorResult(extractor: DataGridCopyExtractorId, request: DataGridExtractRequest, rowLimit?: number) {
     if (options.databaseType.value !== "mongodb") return undefined;
-    const builder = extractor === "sql-inserts" ? options.buildMongoInsert : extractor === "sql-updates" ? options.buildMongoUpdate : undefined;
-    if (!builder) return undefined;
-    const text = (await builder(request.options, rowLimit)) ?? "";
+    if (extractor !== "sql-inserts" && extractor !== "sql-updates") return undefined;
+    const text = extractor === "sql-inserts" ? ((await options.buildMongoInsert(request.options, rowLimit)) ?? "") : ((await options.buildMongoUpdate?.(request, rowLimit)) ?? "");
     return { text, mimeType: "application/javascript", fileExtension: "js", rowCount: rowLimit ?? request.rows.length, columnCount: request.selectedColumnIndexes.length, warnings: undefined, omittedColumns: undefined };
   }
 

--- a/apps/desktop/src/composables/useDataGridExtractor.ts
+++ b/apps/desktop/src/composables/useDataGridExtractor.ts
@@ -48,6 +48,7 @@ interface UseDataGridExtractorOptions {
   canCopySqlInsert: (request: DataGridExtractRequest) => boolean;
   buildMongoInsert: (extractorOptions: DataGridExtractorOptions, rowLimit?: number) => Promise<string | undefined>;
   buildMongoUpdate?: (extractorOptions: DataGridExtractorOptions, rowLimit?: number) => Promise<string | undefined>;
+  canBuildMongoUpdate?: () => boolean;
 }
 
 export function useDataGridExtractor(options: UseDataGridExtractorOptions) {
@@ -183,18 +184,17 @@ export function useDataGridExtractor(options: UseDataGridExtractorOptions) {
     }
     if (extractor === "sql-updates") {
       // Mongo has a dedicated updateOne path that doesn't need SQL primary keys.
-      if (options.databaseType.value === "mongodb") return !!options.buildMongoUpdate;
+      if (options.databaseType.value === "mongodb") return options.canBuildMongoUpdate?.() ?? false;
       return canBuildSqlUpdateRequest();
     }
     return selectionData() !== null;
   }
 
   async function resolveMongoExtractorResult(extractor: DataGridCopyExtractorId, request: DataGridExtractRequest, rowLimit?: number) {
-    if (options.databaseType.value !== "mongodb") return null;
+    if (options.databaseType.value !== "mongodb") return undefined;
     const builder = extractor === "sql-inserts" ? options.buildMongoInsert : extractor === "sql-updates" ? options.buildMongoUpdate : undefined;
-    if (!builder) return null;
+    if (!builder) return undefined;
     const text = (await builder(request.options, rowLimit)) ?? "";
-    if (!text) return null;
     return { text, mimeType: "application/javascript", fileExtension: "js", rowCount: rowLimit ?? request.rows.length, columnCount: request.selectedColumnIndexes.length, warnings: undefined, omittedColumns: undefined };
   }
 


### PR DESCRIPTION
## 问题

MongoDB 数据表格右键选择“复制 -> SQL UPDATE 语句”时，部分场景会错误回退到关系型 SQL 提取器，最终提示 `Copy failed: [object Object]`。

## 修复

- 恢复 MongoDB UPDATE 复制的可用性校验，仅在存在明确集合目标、原始 BSON 文档、`_id` 和可更新字段时启用
- 排除新增行、草稿行和已删除行，避免生成无效的 `updateOne`
- MongoDB 专用构建器返回空结果时不再回退到关系型 SQL 提取器
- 补充 MongoDB `updateOne` 成功生成及缺少更新目标时禁用的回归测试

## 验证

- `corepack pnpm check`：format、lint、typecheck、test 全部通过
- `corepack pnpm vitest run apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts`：25 个测试全部通过
- 使用 DBX 客户端现有 MongoDB 8.2 测试连接，在 `dbx_test.users` 表格中实际执行“复制 -> SQL UPDATE 语句”，成功复制完整 `db.getCollection("users").updateOne(...)`，未出现错误提示

Fixes #5095