### PR TITLE
feat(editor): auto-detect and losslessly format JSON/XML in the query editor

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -18,6 +18,7 @@ import { currentStatementFrameRangeTo, visualSqlColumnsWithInlineHints } from "@
 import { expandToSqlStatementWindow, parseInsertValueHints } from "@/lib/sql/insertValueHints";
 import { insertValueHintColumnNames } from "@/lib/sql/insertValueHintColumns";
 import { formatSqlText, compressSqlText, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
+import { detectAndFormatStructured } from "@/lib/sql/autoFormat";
 import { enabledSqlParameterSyntaxes, resolveSqlVariableSyntaxToggles } from "@/lib/sql/sqlVariableSyntax";
 import { blankLineDeletionChanges, replaceSelectedEditorText } from "@/lib/editor/queryEditorTextEdits";
 import { createSqlSignatureTooltipDom } from "@/lib/editor/sqlSignatureTooltip";
@@ -2346,7 +2347,25 @@ async function formatCurrentSql() {
   if (!source.trim()) return;
 
   try {
-    const formatted = props.databaseType === "mongodb" ? formatMongoShellText(source, settingsStore.editorSettings.sqlFormatter) : await formatSqlText(source, props.formatDialect ?? props.dialect ?? "generic", settingsStore.editorSettings.sqlFormatter);
+    let formatted: string;
+    if (props.databaseType === "mongodb") {
+      formatted = formatMongoShellText(source, settingsStore.editorSettings.sqlFormatter);
+    } else {
+      const structured = detectAndFormatStructured(source, {
+        indentSize: settingsStore.editorSettings.sqlFormatter.tabWidth,
+        useTabs: settingsStore.editorSettings.sqlFormatter.useTabs,
+      });
+      if (structured.kind === "json" || structured.kind === "xml") {
+        formatted = structured.formatted;
+      } else if (structured.kind === "unsupported") {
+        // Keep invalid structured text untouched — the SQL formatter would
+        // silently corrupt XML-looking content.
+        toast(t("toolbar.formatAutoDetectFailed"), 3000);
+        return;
+      } else {
+        formatted = await formatSqlText(source, props.formatDialect ?? props.dialect ?? "generic", settingsStore.editorSettings.sqlFormatter);
+      }
+    }
     if (view.value !== currentView || currentView.state !== originalState || currentView.state.sliceDoc(from, to) !== source) {
       return;
     }

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -33,6 +33,7 @@ export default {
     stopExplain: "Stop explain",
     formatSql: "Format SQL",
     formatSqlFailed: "Failed to format SQL",
+    formatAutoDetectFailed: "Cannot recognize or format the selected content",
     compressSql: "Compress SQL",
     keywordCaseLower: "Use lower-case SQL keywords",
     keywordCaseUpper: "Use upper-case SQL keywords",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -35,6 +35,7 @@ export default withEnglishFallback({
     stopExplain: "Detener análisis",
     formatSql: "Formatear SQL",
     formatSqlFailed: "Error al formatear el SQL",
+    formatAutoDetectFailed: "No se pudo reconocer ni formatear el contenido seleccionado",
     compressSql: "Comprimir SQL",
     keywordCaseLower: "Usar palabras clave SQL en minúsculas",
     keywordCaseUpper: "Usar palabras clave SQL en mayúsculas",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -34,6 +34,7 @@ export default withEnglishFallback({
     stopExplain: "Interrompi spiegazione",
     formatSql: "Formatta SQL",
     formatSqlFailed: "Impossibile formattare SQL",
+    formatAutoDetectFailed: "Impossibile riconoscere o formattare il contenuto selezionato",
     compressSql: "Comprimi SQL",
     keywordCaseLower: "Usa parole chiave SQL minuscole",
     keywordCaseUpper: "Usa parole chiave SQL maiuscole",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -35,6 +35,7 @@ export default withEnglishFallback({
     stopExplain: "実行計画の表示を停止",
     formatSql: "SQLをフォーマット",
     formatSqlFailed: "SQLのフォーマットに失敗しました",
+    formatAutoDetectFailed: "選択内容を認識またはフォーマットできません",
     compressSql: "SQLを圧縮",
     keywordCaseLower: "SQLキーワードを小文字にする",
     keywordCaseUpper: "SQLキーワードを大文字にする",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -35,6 +35,7 @@ export default withEnglishFallback({
     stopExplain: "실행 계획 중지",
     formatSql: "SQL 정렬",
     formatSqlFailed: "SQL 정렬에 실패했습니다",
+    formatAutoDetectFailed: "선택한 내용을 인식하거나 포맷할 수 없습니다",
     compressSql: "SQL 압축",
     keywordCaseLower: "SQL 키워드 소문자 사용",
     keywordCaseUpper: "SQL 키워드 대문자 사용",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -35,6 +35,7 @@ export default withEnglishFallback({
     stopExplain: "Parar explicação",
     formatSql: "Formatar SQL",
     formatSqlFailed: "Falha ao formatar SQL",
+    formatAutoDetectFailed: "Não foi possível reconhecer ou formatar o conteúdo selecionado",
     compressSql: "Comprimir SQL",
     keywordCaseLower: "Usar palavras-chave SQL em minúsculas",
     keywordCaseUpper: "Usar palavras-chave SQL em maiúsculas",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -35,6 +35,7 @@ export default withEnglishFallback({
     stopExplain: "停止执行计划",
     formatSql: "格式化 SQL",
     formatSqlFailed: "SQL 格式化失败",
+    formatAutoDetectFailed: "无法识别或格式化所选内容",
     compressSql: "压缩 SQL",
     keywordCaseLower: "使用小写 SQL 关键字",
     keywordCaseUpper: "使用大写 SQL 关键字",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -35,6 +35,7 @@ export default withEnglishFallback({
     stopExplain: "停止執行計畫",
     formatSql: "格式化 SQL",
     formatSqlFailed: "SQL 格式化失敗",
+    formatAutoDetectFailed: "無法識別或格式化所選內容",
     compressSql: "壓縮 SQL",
     keywordCaseLower: "使用小寫 SQL 關鍵字",
     keywordCaseUpper: "使用大寫 SQL 關鍵字",

--- a/apps/desktop/src/lib/__tests__/sql/autoFormat.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/autoFormat.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { detectAndFormatStructured, firstNonWhitespaceChar } from "@/lib/sql/autoFormat";
+
+describe("autoFormat", () => {
+  describe("firstNonWhitespaceChar", () => {
+    it("skips leading whitespace and returns the first significant character", () => {
+      expect(firstNonWhitespaceChar(`  \t\n{"a":1}`)).toBe("{");
+      expect(firstNonWhitespaceChar("SELECT")).toBe("S");
+      expect(firstNonWhitespaceChar("   \n\t")).toBeNull();
+    });
+  });
+
+  describe("detectAndFormatStructured", () => {
+    it("formats a JSON object losslessly with the requested indentation", () => {
+      expect(detectAndFormatStructured(`{"a":1,"b":[1,2]}`, { indentSize: 2 })).toEqual({
+        kind: "json",
+        formatted: `{\n  "a": 1,\n  "b": [\n    1,\n    2\n  ]\n}`,
+      });
+    });
+
+    it("formats a JSON array", () => {
+      const result = detectAndFormatStructured(`[1,2]`, { indentSize: 2 });
+      expect(result.kind).toBe("json");
+      if (result.kind === "json") {
+        expect(result.formatted).toContain("\n");
+      }
+    });
+
+    it("preserves big numeric literals that JSON.parse would round", () => {
+      const result = detectAndFormatStructured(`{"big":9007199254740993,"id":1}`, { indentSize: 2 });
+      expect(result.kind).toBe("json");
+      if (result.kind === "json") {
+        expect(result.formatted).toContain("9007199254740993");
+      }
+    });
+
+    it("routes invalid JSON-looking text to the SQL formatter", () => {
+      expect(detectAndFormatStructured(`{a:1}`, { indentSize: 2 })).toEqual({ kind: "sql" });
+      expect(detectAndFormatStructured(`{`, { indentSize: 2 })).toEqual({ kind: "sql" });
+    });
+
+    it("does not mistake a SQL Server bracket-quoted identifier for JSON", () => {
+      expect(detectAndFormatStructured(`[dbo].[orders]`, { indentSize: 2 })).toEqual({ kind: "sql" });
+    });
+
+    it("does not mistake a selected SQL comparison fragment for XML", () => {
+      expect(detectAndFormatStructured(`< 10`, { indentSize: 2 })).toEqual({ kind: "sql" });
+    });
+
+    it("formats XML with nested elements", () => {
+      expect(detectAndFormatStructured(`<root><item id="1">value</item><empty/></root>`, { indentSize: 2 })).toEqual({
+        kind: "xml",
+        formatted: `<root>\n  <item id="1">value</item>\n  <empty/>\n</root>`,
+      });
+    });
+
+    it("preserves XML mixed content and supports tab indentation", () => {
+      expect(detectAndFormatStructured(`<root>Hello <strong>world</strong>!</root>`, { indentSize: 2, useTabs: true })).toEqual({
+        kind: "xml",
+        formatted: `<root>Hello <strong>world</strong>!</root>`,
+      });
+    });
+
+    it("rejects invalid XML without handing it to the SQL formatter", () => {
+      expect(detectAndFormatStructured(`<root><item></root>`, { indentSize: 2 })).toEqual({ kind: "unsupported", detectedType: "xml" });
+    });
+
+    it("routes SQL (and SQL containing an embedded JSON literal) to the SQL formatter", () => {
+      expect(detectAndFormatStructured("SELECT * FROM t", { indentSize: 2 })).toEqual({ kind: "sql" });
+      expect(detectAndFormatStructured(`SELECT '{"a":1}'::jsonb FROM t`, { indentSize: 2 })).toEqual({ kind: "sql" });
+    });
+
+    it("does not treat a leading JSON string literal as JSON (identifier risk)", () => {
+      expect(detectAndFormatStructured(`"column"`, { indentSize: 2 })).toEqual({ kind: "sql" });
+    });
+
+    it("routes whitespace-only input to the SQL formatter (no-op upstream)", () => {
+      expect(detectAndFormatStructured("   \n\t", { indentSize: 2 })).toEqual({ kind: "sql" });
+    });
+  });
+});

--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -73,6 +73,7 @@ describe("sqlFormatter", () => {
 
   it("still formats selected SQL comparison fragments", async () => {
     await expect(formatSqlText(`< 10`, "postgres")).resolves.toBe(`< 10`);
+    await expect(formatSqlText(`< 10 AND score > 2`, "postgres")).resolves.toBe(`< 10\nAND score > 2`);
   });
 
   it("keeps display formatting lossless for XML/JSON-looking input", async () => {

--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatSqlForDisplay, formatSqlText, MAX_SQL_FORMAT_CHARS, sqlFormatDialectForDbType } from "@/lib/sql/sqlFormatter";
+import { formatSqlForDisplay, formatSqlText, MAX_SQL_FORMAT_CHARS, sqlFormatDialectForDbType, UnsupportedStructuredInputError } from "@/lib/sql/sqlFormatter";
 
 describe("sqlFormatter", () => {
   it("maps PostgreSQL-compatible database types to the postgres formatter dialect", () => {
@@ -55,5 +55,38 @@ describe("sqlFormatter", () => {
 
     await expect(formatSqlText(oversizedSql, "postgres")).rejects.toThrow("SQL is too large to format safely.");
     await expect(formatSqlForDisplay(oversizedSql, "postgres")).resolves.toBe(oversizedSql);
+  });
+
+  it("refuses to format XML-looking input instead of corrupting it (regression: silent rewrite)", async () => {
+    const xml = `<root><item id="1">value</item></root>`;
+
+    // The SQL formatter previously accepted this and rewrote it into corrupted
+    // output (`< root > < item id = "1" > ...`). It must now be refused so no
+    // caller can ever write sql-formatter output back over the user's text.
+    await expect(formatSqlText(xml, "generic")).rejects.toBeInstanceOf(UnsupportedStructuredInputError);
+    await expect(formatSqlText(xml, "postgres")).rejects.toBeInstanceOf(UnsupportedStructuredInputError);
+  });
+
+  it("still formats selected SQL Server bracket-quoted identifiers", async () => {
+    await expect(formatSqlText(`[dbo].[orders]`, "sqlserver")).resolves.toBe(`[dbo].[orders]`);
+  });
+
+  it("still formats selected SQL comparison fragments", async () => {
+    await expect(formatSqlText(`< 10`, "postgres")).resolves.toBe(`< 10`);
+  });
+
+  it("keeps display formatting lossless for XML/JSON-looking input", async () => {
+    const xml = `<root><item id="1">value</item></root>`;
+    const json = `{"a":1}`;
+
+    await expect(formatSqlForDisplay(xml, "generic")).resolves.toBe(xml);
+    await expect(formatSqlForDisplay(json, "generic")).resolves.toBe(json);
+  });
+
+  it("still formats genuine SQL that starts with a non-structured token", async () => {
+    const formatted = await formatSqlText(`SELECT '{"a":1}'::jsonb AS j FROM t`, "postgres");
+
+    expect(formatted).toContain("SELECT");
+    expect(formatted).toContain("::jsonb");
   });
 });

--- a/apps/desktop/src/lib/common/__tests__/xmlFormat.spec.ts
+++ b/apps/desktop/src/lib/common/__tests__/xmlFormat.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatXmlSource } from "../xmlFormat";
+
+describe("formatXmlSource", () => {
+  it("formats element-only XML while preserving attributes", () => {
+    expect(formatXmlSource(`<root attr="a > b"><child/><child>value</child></root>`)).toBe(`<root attr="a > b">\n  <child/>\n  <child>value</child>\n</root>`);
+  });
+
+  it("preserves XML declarations, DOCTYPE subsets, comments, and CDATA", () => {
+    const source = `<?xml version="1.0"?><!DOCTYPE root [<!ENTITY name "DBX">]><root><!-- note --><value><![CDATA[a < b]]></value></root>`;
+    expect(formatXmlSource(source)).toBe(`<?xml version="1.0"?>\n<!DOCTYPE root [<!ENTITY name "DBX">]>\n<root>\n  <!-- note -->\n  <value><![CDATA[a < b]]></value>\n</root>`);
+  });
+
+  it("does not alter mixed content", () => {
+    const source = `<p>Hello <em>there</em>, welcome.</p>`;
+    expect(formatXmlSource(source)).toBe(source);
+  });
+
+  it("does not alter whitespace-only text nodes", () => {
+    const source = `<p> <em/> </p>`;
+    expect(formatXmlSource(source)).toBe(source);
+  });
+
+  it("rejects malformed XML", () => {
+    expect(() => formatXmlSource(`<root><child></root>`)).toThrow(/closing tag/i);
+    expect(() => formatXmlSource(`<root>`)).toThrow(/Unclosed/i);
+  });
+});

--- a/apps/desktop/src/lib/common/xmlFormat.ts
+++ b/apps/desktop/src/lib/common/xmlFormat.ts
@@ -1,0 +1,154 @@
+type XmlNode = XmlElementNode | XmlRawNode | XmlTextNode;
+
+interface XmlElementNode {
+  type: "element";
+  name: string;
+  open: string;
+  close?: string;
+  children: XmlNode[];
+}
+
+interface XmlRawNode {
+  type: "raw";
+  raw: string;
+  preservesText?: boolean;
+}
+
+interface XmlTextNode {
+  type: "text";
+  text: string;
+}
+
+/**
+ * Formats XML without using a DOM serializer. Attributes, comments, CDATA,
+ * processing instructions, and DOCTYPE declarations remain byte-for-byte;
+ * only structural whitespace is regenerated. Any element with direct text keeps
+ * its source, including whitespace-only text nodes, so formatting cannot alter
+ * text-node semantics.
+ */
+export function formatXmlSource(source: string, indent = "  "): string {
+  const nodes = parseXmlDocument(source);
+  return nodes
+    .filter((node) => node.type !== "text" || node.text.trim())
+    .map((node) => formatNode(node, 0, indent))
+    .join("\n");
+}
+
+function parseXmlDocument(source: string): XmlNode[] {
+  const roots: XmlNode[] = [];
+  const stack: XmlElementNode[] = [];
+  let index = 0;
+  const add = (node: XmlNode) => {
+    const parent = stack[stack.length - 1];
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+  };
+
+  while (index < source.length) {
+    if (source[index] !== "<") {
+      const end = source.indexOf("<", index);
+      add({ type: "text", text: source.slice(index, end < 0 ? source.length : end) });
+      index = end < 0 ? source.length : end;
+      continue;
+    }
+    if (source.startsWith("<!--", index)) {
+      const end = source.indexOf("-->", index + 4);
+      if (end < 0) throw new SyntaxError("Unterminated XML comment");
+      add({ type: "raw", raw: source.slice(index, end + 3) });
+      index = end + 3;
+      continue;
+    }
+    if (source.startsWith("<![CDATA[", index)) {
+      const end = source.indexOf("]]>", index + 9);
+      if (end < 0) throw new SyntaxError("Unterminated CDATA section");
+      add({ type: "raw", raw: source.slice(index, end + 3), preservesText: true });
+      index = end + 3;
+      continue;
+    }
+    if (source.startsWith("<?", index)) {
+      const end = source.indexOf("?>", index + 2);
+      if (end < 0) throw new SyntaxError("Unterminated XML processing instruction");
+      add({ type: "raw", raw: source.slice(index, end + 2) });
+      index = end + 2;
+      continue;
+    }
+    if (/^<!DOCTYPE\b/i.test(source.slice(index))) {
+      const end = findMarkupEnd(source, index + 9);
+      add({ type: "raw", raw: source.slice(index, end + 1) });
+      index = end + 1;
+      continue;
+    }
+    if (source.startsWith("</", index)) {
+      const end = findMarkupEnd(source, index + 2);
+      const raw = source.slice(index, end + 1);
+      const match = raw.match(/^<\/\s*([A-Za-z_:][\w:.-]*)\s*>$/);
+      if (!match) throw new SyntaxError("Invalid XML closing tag");
+      const element = stack.pop();
+      if (!element || element.name !== match[1]) throw new SyntaxError(`Unexpected XML closing tag: ${match[1]}`);
+      element.close = raw;
+      index = end + 1;
+      continue;
+    }
+    if (source.startsWith("<!", index)) {
+      const end = findMarkupEnd(source, index + 2);
+      add({ type: "raw", raw: source.slice(index, end + 1) });
+      index = end + 1;
+      continue;
+    }
+
+    const end = findMarkupEnd(source, index + 1);
+    const raw = source.slice(index, end + 1);
+    const match = raw.match(/^<\s*([A-Za-z_:][\w:.-]*)(?=[\s/>])/);
+    if (!match) throw new SyntaxError("Invalid XML opening tag");
+    const element: XmlElementNode = { type: "element", name: match[1], open: raw, children: [] };
+    add(element);
+    if (!/\/\s*>$/.test(raw)) stack.push(element);
+    index = end + 1;
+  }
+
+  if (stack.length) throw new SyntaxError(`Unclosed XML element: ${stack[stack.length - 1]?.name}`);
+  const elements = roots.filter((node): node is XmlElementNode => node.type === "element");
+  if (elements.length !== 1 || roots.some((node) => node.type === "text" && node.text.trim())) throw new SyntaxError("XML input must contain exactly one root element");
+  return roots;
+}
+
+function findMarkupEnd(source: string, start: number): number {
+  let quote: string | null = null;
+  let subsetDepth = 0;
+  for (let index = start; index < source.length; index++) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) quote = null;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === "[") {
+      subsetDepth++;
+    } else if (character === "]") {
+      subsetDepth--;
+    } else if (character === ">" && subsetDepth === 0) {
+      return index;
+    }
+  }
+  throw new SyntaxError("Unterminated XML tag or declaration");
+}
+
+function formatNode(node: XmlNode, depth: number, indent: string): string {
+  if (node.type === "text") return node.text;
+  if (node.type === "raw") return node.raw;
+  if (!node.close) return node.open;
+  if (hasMeaningfulDirectText(node)) return originalNode(node);
+  const children = node.children.filter((child) => child.type !== "text" || child.text.trim());
+  if (!children.length) return `${node.open}${node.close}`;
+  const childIndent = indent.repeat(depth + 1);
+  return `${node.open}\n${children.map((child) => `${childIndent}${formatNode(child, depth + 1, indent)}`).join("\n")}\n${indent.repeat(depth)}${node.close}`;
+}
+
+function hasMeaningfulDirectText(element: XmlElementNode): boolean {
+  return element.children.some((child) => child.type === "text" || (child.type === "raw" && child.preservesText));
+}
+
+function originalNode(node: XmlNode): string {
+  if (node.type === "text") return node.text;
+  if (node.type === "raw") return node.raw;
+  return `${node.open}${node.children.map(originalNode).join("")}${node.close ?? ""}`;
+}

--- a/apps/desktop/src/lib/sql/autoFormat.ts
+++ b/apps/desktop/src/lib/sql/autoFormat.ts
@@ -45,8 +45,7 @@ export function detectAndFormatStructured(text: string, options: { indentSize: n
       return { kind: "sql" };
     }
   }
-  const trimmed = text.trimStart();
-  if (looksLikeXml(trimmed)) {
+  if (looksLikeXml(text)) {
     try {
       return { kind: "xml", formatted: formatXmlSource(text, options.useTabs ? "\t" : " ".repeat(options.indentSize)) };
     } catch {
@@ -56,6 +55,7 @@ export function detectAndFormatStructured(text: string, options: { indentSize: n
   return { kind: "sql" };
 }
 
-function looksLikeXml(text: string): boolean {
-  return text.startsWith("<?") || text.startsWith("<!--") || /^<!DOCTYPE\b/i.test(text) || /^<\/?[A-Za-z_:]/.test(text);
+export function looksLikeXml(text: string): boolean {
+  const trimmed = text.trimStart();
+  return trimmed.startsWith("<?") || trimmed.startsWith("<!--") || /^<!DOCTYPE\b/i.test(trimmed) || /^<\/?[A-Za-z_:]/.test(trimmed);
 }

--- a/apps/desktop/src/lib/sql/autoFormat.ts
+++ b/apps/desktop/src/lib/sql/autoFormat.ts
@@ -1,0 +1,61 @@
+import { formatJsonSource } from "@/lib/common/safeJsonFormat";
+import { formatXmlSource } from "@/lib/common/xmlFormat";
+
+/** Structured (non-SQL) content types the auto-format can recognise. */
+export type AutoDetectedStructuredType = "json" | "xml";
+
+/**
+ * Result of {@link detectAndFormatStructured}.
+ *
+ * - `{ kind: "sql" }` — not a JSON/XML document; hand off to the SQL formatter.
+ * - `{ kind: "json" | "xml", formatted }` — a valid structured document.
+ * - `{ kind: "unsupported", detectedType }` — structured-looking invalid text.
+ *   The caller must keep the original text unchanged and must never pass it to
+ *   the SQL formatter.
+ */
+export type StructuredFormatResult = { kind: "sql" } | { kind: "json" | "xml"; formatted: string } | { kind: "unsupported"; detectedType: AutoDetectedStructuredType };
+
+/** First non-whitespace character of `text`, or null when it is all whitespace. */
+export function firstNonWhitespaceChar(text: string): string | null {
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c !== " " && c !== "\t" && c !== "\n" && c !== "\r" && c !== "\f" && c !== "\v") return c;
+  }
+  return null;
+}
+
+/**
+ * Detects whether an editor selection is a JSON/XML document and formats it.
+ *
+ * A valid JSON document must start with `{` or `[`, but an editor selection can
+ * also be a SQL fragment such as a SQL Server bracket-quoted identifier. Only a
+ * successful JSON source parse is therefore classified as JSON; all other text
+ * continues through the existing SQL path.
+ *
+ * Safety contract: valid JSON/XML is formatted before reaching the SQL formatter.
+ * Invalid XML is returned as unsupported because sql-formatter silently rewrites
+ * XML-looking input into corrupted output.
+ */
+export function detectAndFormatStructured(text: string, options: { indentSize: number; useTabs?: boolean }): StructuredFormatResult {
+  const first = firstNonWhitespaceChar(text);
+  if (first === "{" || first === "[") {
+    try {
+      return { kind: "json", formatted: formatJsonSource(text, options.indentSize) };
+    } catch {
+      return { kind: "sql" };
+    }
+  }
+  const trimmed = text.trimStart();
+  if (looksLikeXml(trimmed)) {
+    try {
+      return { kind: "xml", formatted: formatXmlSource(text, options.useTabs ? "\t" : " ".repeat(options.indentSize)) };
+    } catch {
+      return { kind: "unsupported", detectedType: "xml" };
+    }
+  }
+  return { kind: "sql" };
+}
+
+function looksLikeXml(text: string): boolean {
+  return text.startsWith("<?") || text.startsWith("<!--") || /^<!DOCTYPE\b/i.test(text) || /^<\/?[A-Za-z_:]/.test(text);
+}

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SQL_FORMATTER_SETTINGS, sqlFormatterOptions, type SqlFormatterSettings } from "@/lib/sql/sqlFormatterConfig";
-import { firstNonWhitespaceChar } from "@/lib/sql/autoFormat";
+import { looksLikeXml } from "@/lib/sql/autoFormat";
 
 export type SqlFormatDialect = "mysql" | "postgres" | "sqlite" | "sqlserver" | "clickhouse" | "generic";
 
@@ -81,10 +81,7 @@ export async function formatSqlText(sql: string, dialect: SqlFormatDialect = "ge
     throw new Error("SQL is too large to format safely.");
   }
 
-  // XML guard: a document starts with `<` and has a tag terminator. Do not apply
-  // it to a selected SQL comparison fragment such as `< 10`.
-  const first = firstNonWhitespaceChar(sql);
-  if (first === "<" && sql.slice(sql.search(/\S/)).includes(">")) {
+  if (looksLikeXml(sql)) {
     throw new UnsupportedStructuredInputError("xml");
   }
 

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -1,8 +1,24 @@
 import { DEFAULT_SQL_FORMATTER_SETTINGS, sqlFormatterOptions, type SqlFormatterSettings } from "@/lib/sql/sqlFormatterConfig";
+import { firstNonWhitespaceChar } from "@/lib/sql/autoFormat";
 
 export type SqlFormatDialect = "mysql" | "postgres" | "sqlite" | "sqlserver" | "clickhouse" | "generic";
 
 export const MAX_SQL_FORMAT_CHARS = 1_000_000;
+
+/**
+ * Thrown by {@link formatSqlText} when the input is XML-looking and must never
+ * be run through the SQL formatter. sql-formatter silently rewrites well-formed
+ * XML into corrupted output, so this guard keeps any caller (including future
+ * ones) from corrupting structured text. Callers that can format XML should
+ * route before calling (see {@link detectAndFormatStructured}); this is
+ * defense-in-depth.
+ */
+export class UnsupportedStructuredInputError extends Error {
+  constructor(readonly detectedType: "xml") {
+    super(`Cannot format ${detectedType} content as SQL.`);
+    this.name = "UnsupportedStructuredInputError";
+  }
+}
 
 /**
  * Maps a connection's database type to the SQL-formatter dialect to use.
@@ -63,6 +79,13 @@ export async function formatSqlText(sql: string, dialect: SqlFormatDialect = "ge
   if (!sql.trim()) return sql;
   if (sql.length > MAX_SQL_FORMAT_CHARS) {
     throw new Error("SQL is too large to format safely.");
+  }
+
+  // XML guard: a document starts with `<` and has a tag terminator. Do not apply
+  // it to a selected SQL comparison fragment such as `< 10`.
+  const first = firstNonWhitespaceChar(sql);
+  if (first === "<" && sql.slice(sql.search(/\S/)).includes(">")) {
+    throw new UnsupportedStructuredInputError("xml");
   }
 
   const { format } = await import("sql-formatter");


### PR DESCRIPTION
Closes #4962

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
## Description

Closes #4962.

The "Format" action in the query editor (toolbar button, `Shift+Ctrl/Cmd+F` shortcut, and menu) now **auto-detects the content type** of the selected text — or of the whole document when nothing is selected — and routes it to the right formatter instead of blindly treating it as SQL:

- **JSON** (`{`/`[` first character + strict parse) → lossless formatting via the existing `formatJsonSource` scanner, which preserves large numeric literals, duplicate keys, key order, and escape sequences.
- **XML** (declaration / comment / DOCTYPE / element start) → single-root validated and formatted by a new whitespace-only `formatXmlSource` (no DOM serializer): attributes, comments, CDATA, processing instructions, and DOCTYPE internal subsets (entities) are kept byte-for-byte; only structural whitespace is regenerated. Mixed content is left untouched.
- **Anything else** → existing SQL formatting, unchanged (including SQL Server bracket-quoted identifiers like `[dbo].[orders]` and comparison fragments like `< 10`, which are no longer misclassified as structured content).

### Safety fix (bug)

`sql-formatter` **silently corrupts well-formed XML** — it rewrites `<root><item id="1">value</item></root>` into `< root > < item id = "1" > ...` without raising an error, so the editor previously overwrote the user's text with garbage. As part of this change:

- XML-looking input never reaches the SQL formatter from the editor.
- `formatSqlText` now throws `UnsupportedStructuredInputError` for XML-looking input, so **no caller** (including display/DDL surfaces) can ever write corrupted output back over the user's text.
- JSON input no longer surfaces the misleading "SQL formatting failed" toast.

### Error handling

When the selection looks like JSON/XML but cannot be parsed (invalid JSON falls through to the SQL path as before; malformed XML), the text is left **byte-for-byte unchanged** and a format-agnostic message is shown instead of the SQL-specific failure toast.

### Scope

- MongoDB connections keep their existing `formatMongoShellText` path.
- Selection-first behavior (format selection, else whole document) is unchanged.
- XML formatting fidelity contract: whitespace-only reflow, byte-lossless for all non-whitespace content.

## Files changed

- `apps/desktop/src/lib/sql/autoFormat.ts` — new: content-type detection + routing
- `apps/desktop/src/lib/common/xmlFormat.ts` — new: lossless whitespace-only XML formatter
- `apps/desktop/src/lib/sql/sqlFormatter.ts` — XML input guard in `formatSqlText`
- `apps/desktop/src/components/editor/QueryEditor.vue` — `formatCurrentSql` routing
- `apps/desktop/src/i18n/locales/*.ts` — new `toolbar.formatAutoDetectFailed` key (8 locales)
- Tests: `autoFormat.spec.ts`, `xmlFormat.spec.ts`, `sqlFormatter.spec.ts`

## Validation

- `pnpm exec vitest run` (full suite): **697 files / 6154 tests passed** (one flaky timing-sensitive failure on a first run, clean on re-runs)
- Targeted tests (`autoFormat`, `xmlFormat`, `sqlFormatter`): **28/28 passed**
- `pnpm typecheck` (vue-tsc): passed
- `pnpm lint` (oxlint): passed
- `pnpm exec oxfmt --check`: passed
- Secret/credential scan on added lines: no hits

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
## Related issue

- Closes #4962
