### PR TITLE
fix(xugu): degrade metadata operations for normal users

### DIFF
--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -1516,23 +1516,18 @@ func configuredDatabaseName(params connectParams) string {
 
 func isXuguMetadataAccessError(err error) bool {
 	message := strings.ToUpper(err.Error())
-	return strings.Contains(message, "E18012") ||
-		strings.Contains(message, "权限不够") ||
-		strings.Contains(message, "ALL_DATABASES") ||
-		strings.Contains(message, "SYS_DATABASES") ||
-		strings.Contains(message, "ALL_SCHEMAS") ||
-		strings.Contains(message, "SYS_SCHEMAS") ||
-		strings.Contains(message, "ALL_TABLES") ||
-		strings.Contains(message, "SYS_TABLES") ||
-		strings.Contains(message, "ALL_VIEWS") ||
-		strings.Contains(message, "SYS_VIEWS") ||
-		strings.Contains(message, "ALL_COLUMNS") ||
-		strings.Contains(message, "ALL_CONSTRAINTS") ||
-		strings.Contains(message, "ALL_INDEXES") ||
-		strings.Contains(message, "SYS_COLUMNS") ||
-		strings.Contains(message, "SYS_CONSTRAINTS") ||
-		strings.Contains(message, "SYS_INDEXES") ||
-		strings.Contains(message, "SYS_TRIGGERS")
+	if strings.Contains(message, "E18012") || strings.Contains(message, "权限不够") {
+		return true
+	}
+	for _, object := range []string{
+		"DATABASES", "SCHEMAS", "TABLES", "VIEWS", "COLUMNS", "CONSTRAINTS", "INDEXES",
+		"TRIGGERS", "PARTIS", "SUBPARTIS", "SEQUENCES", "SYNONYMS", "PROCEDURES", "PACKAGES", "TYPES",
+	} {
+		if strings.Contains(message, "ALL_"+object) || strings.Contains(message, "SYS_"+object) {
+			return true
+		}
+	}
+	return false
 }
 
 func isXuguMissingOnNullColumnError(err error) bool {
@@ -1619,6 +1614,45 @@ func (s *server) listTables(schema string, constraints metadataListConstraints) 
 	query := xuguListTablesQuery(schema, constraints)
 	rows, err := s.queryRows(query.SQL, query.Args)
 	if err != nil {
+		if isXuguMetadataAccessError(err) {
+			if fallback, fallbackErr := s.listOwnTables(schema, constraints); fallbackErr == nil {
+				return fallback, nil
+			}
+			return []tableInfo{}, nil
+		}
+		return nil, err
+	}
+	defer s.closeRows(rows)
+	var result []tableInfo
+	for rows.Next() {
+		var item tableInfo
+		if err := rows.Scan(&item.Name, &item.TableType, &item.Comment); err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return emptyIfNil(result), rows.Err()
+}
+
+func (s *server) listOwnTables(schema string, constraints metadataListConstraints) ([]tableInfo, error) {
+	if !strings.EqualFold(strings.TrimSpace(schema), strings.TrimSpace(s.params.Username)) {
+		return []tableInfo{}, nil
+	}
+	query := xuguConstrainedMetadataListQuery(
+		`
+SELECT TABLE_NAME, 'TABLE' AS TABLE_TYPE, COMMENTS
+FROM USER_TABLES
+UNION ALL
+SELECT VIEW_NAME, 'VIEW' AS TABLE_TYPE, COMMENTS
+FROM USER_VIEWS`,
+		"TABLE_NAME, TABLE_TYPE, COMMENTS",
+		"TABLE_NAME",
+		"TABLE_TYPE",
+		nil,
+		constraints,
+	)
+	rows, err := s.queryRows(query.SQL, query.Args)
+	if err != nil {
 		return nil, err
 	}
 	defer s.closeRows(rows)
@@ -1641,6 +1675,21 @@ func (s *server) listObjects(schema string, constraints metadataListConstraints)
 	query := xuguListObjectsQuery(schema, constraints)
 	rows, err := s.queryRows(query.SQL, query.Args)
 	if err != nil {
+		if isXuguMetadataAccessError(err) {
+			// A single inaccessible ALL_* view must not hide the fact that the
+			// table browser can still query the low-privilege table path.  The
+			// fallback deliberately exposes only tables/views; programmable
+			// objects are omitted rather than guessed from unavailable metadata.
+			tables, tableErr := s.listTables(schema, constraints)
+			if tableErr != nil {
+				return []objectInfo{}, nil
+			}
+			result := make([]objectInfo, 0, len(tables))
+			for _, table := range tables {
+				result = append(result, objectInfo{Name: table.Name, ObjectType: table.TableType, Schema: schema, Comment: table.Comment})
+			}
+			return result, nil
+		}
 		return nil, err
 	}
 	defer s.closeRows(rows)
@@ -1865,6 +1914,23 @@ func xuguFuzzyLikePattern(value string) string {
 func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
 	catalogSchema, catalogTable, err := s.resolveCatalogTableName(schema, table)
 	if err != nil {
+		if isXuguMetadataAccessError(err) || isXuguTableNotFoundError(err) {
+			fallbackSchema, fallbackTable, fallbackErr := s.fallbackTableIdentity(schema, table)
+			if fallbackErr != nil {
+				return nil, fallbackErr
+			}
+			columns, directErr := s.columnsFromSelect(fallbackSchema, fallbackTable, map[string]bool{})
+			if directErr == nil {
+				return columns, nil
+			}
+			if isXuguMetadataAccessError(err) && isXuguMetadataAccessError(directErr) {
+				return []columnInfo{}, nil
+			}
+			if isXuguTableNotFoundError(directErr) {
+				return nil, err
+			}
+			return nil, directErr
+		}
 		return nil, err
 	}
 	schema, table = catalogSchema, catalogTable
@@ -1951,6 +2017,26 @@ func (s *server) columnsFromSelect(schema, table string, primaryKeys map[string]
 	return emptyIfNil(result), nil
 }
 
+func (s *server) fallbackTableIdentity(schema, table string) (string, string, error) {
+	schema = strings.TrimSpace(schema)
+	if schema == "" {
+		var err error
+		schema, err = s.currentSchema()
+		if err != nil {
+			return "", "", err
+		}
+	}
+	table = strings.TrimSpace(table)
+	if table == "" {
+		return "", "", errors.New("table is required")
+	}
+	return schema, table, nil
+}
+
+func isXuguTableNotFoundError(err error) bool {
+	return strings.Contains(strings.ToUpper(err.Error()), "TABLE NOT FOUND:")
+}
+
 func (s *server) primaryKeyColumns(schema, table string) (map[string]bool, error) {
 	rows, err := s.queryRows(xuguTableCatalogQuery(xuguPrimaryKeyColumnsSQL, schema, table), nil)
 	if err != nil {
@@ -1976,6 +2062,9 @@ func (s *server) primaryKeyColumns(schema, table string) (map[string]bool, error
 func (s *server) listIndexes(schema, table string) ([]indexInfo, error) {
 	catalogSchema, catalogTable, err := s.resolveCatalogTableName(schema, table)
 	if err != nil {
+		if isXuguMetadataAccessError(err) || isXuguTableNotFoundError(err) {
+			return []indexInfo{}, nil
+		}
 		return nil, err
 	}
 	rows, err := s.queryRows(xuguTableCatalogQuery(xuguListIndexesSQL, catalogSchema, catalogTable), nil)
@@ -2135,10 +2224,18 @@ func (s *server) listSubpartitions(schema, table string) ([]subpartitionInfo, er
 
 func (s *server) getObjectSource(schema, name, objectType string) (map[string]any, error) {
 	if strings.EqualFold(strings.TrimSpace(objectType), "SEQUENCE") {
-		return s.getSequenceSource(schema, name)
+		result, err := s.getSequenceSource(schema, name)
+		if err != nil && isXuguMetadataAccessError(err) {
+			return xuguUnavailableObjectSource(schema, name, objectType), nil
+		}
+		return result, err
 	}
 	if strings.EqualFold(strings.TrimSpace(objectType), "SYNONYM") {
-		return s.getSynonymSource(schema, name)
+		result, err := s.getSynonymSource(schema, name)
+		if err != nil && isXuguMetadataAccessError(err) {
+			return xuguUnavailableObjectSource(schema, name, objectType), nil
+		}
+		return result, err
 	}
 	var err error
 	schema, err = s.normalizeSchema(schema)
@@ -2151,6 +2248,9 @@ func (s *server) getObjectSource(schema, name, objectType string) (map[string]an
 	}
 	rows, err := s.queryRows(sourceSQL, args)
 	if err != nil {
+		if isXuguMetadataAccessError(err) {
+			return xuguUnavailableObjectSource(schema, name, objectType), nil
+		}
 		return nil, err
 	}
 	defer s.closeRows(rows)
@@ -2169,6 +2269,16 @@ func (s *server) getObjectSource(schema, name, objectType string) (map[string]an
 		result["editable"] = false
 	}
 	return result, rows.Err()
+}
+
+func xuguUnavailableObjectSource(schema, name, objectType string) map[string]any {
+	return map[string]any{
+		"name":        name,
+		"object_type": objectType,
+		"schema":      schema,
+		"source":      fmt.Sprintf("-- XuguDB did not expose source metadata for %s.%s (%s).\n-- The object can still be listed and managed, but its source cannot be reconstructed with the current privileges.", schema, name, objectType),
+		"editable":    false,
+	}
 }
 
 // getSequenceSource reconstructs sequence DDL from ALL_SEQUENCES. Unlike
@@ -2467,15 +2577,33 @@ func (s *server) getTableDDL(schema, table string) (string, error) {
 	// schema/table/column spellings.
 	if strings.TrimSpace(schema) != "" {
 		if err := s.setSchema(schema); err != nil {
-			return "", err
+			if !isXuguMetadataAccessError(err) {
+				return "", err
+			}
 		}
 	}
 	catalogSchema, catalogTable, err := s.resolveCatalogTableName(schema, table)
 	if err != nil {
+		if isXuguMetadataAccessError(err) || isXuguTableNotFoundError(err) {
+			fallbackSchema, fallbackTable, fallbackErr := s.fallbackTableIdentity(schema, table)
+			if fallbackErr != nil {
+				return "", fallbackErr
+			}
+			ddl, directErr := s.buildFallbackTableDDL(fallbackSchema, fallbackTable)
+			if directErr == nil {
+				return ddl, nil
+			}
+			if isXuguMetadataAccessError(err) {
+				return xuguUnavailableTableDDL(fallbackSchema, fallbackTable), nil
+			}
+			return "", err
+		}
 		return "", err
 	}
 	if err := s.setSchema(catalogSchema); err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
 	}
 	// DBMS_METADATA.GET_DDL can block indefinitely on XuguDB, even when the
 	// table metadata itself is accessible. Reconstruct the DDL from the same
@@ -2485,6 +2613,21 @@ func (s *server) getTableDDL(schema, table string) (string, error) {
 		return "", err
 	}
 	return s.appendTableIndexDDL(catalogSchema, catalogTable, ddl), nil
+}
+
+func (s *server) buildFallbackTableDDL(schema, table string) (string, error) {
+	columns, err := s.columnsFromSelect(schema, table, map[string]bool{})
+	if err != nil {
+		return "", err
+	}
+	if len(columns) == 0 {
+		return "", fmt.Errorf("table not found: %s.%s", schema, table)
+	}
+	return renderXuguTableDDL(schema, table, columns, xuguTableMetadata{}, nil, nil, nil, nil), nil
+}
+
+func xuguUnavailableTableDDL(schema, table string) string {
+	return fmt.Sprintf("-- XuguDB did not expose enough metadata to reconstruct %s.%s.\n-- The table may still be readable, but its DDL requires additional metadata privileges.", schema, table)
 }
 
 type xuguCatalogTableName struct {
@@ -3063,27 +3206,45 @@ func (s *server) buildTableDDL(schema, table string) (string, error) {
 	}
 	metadata, err := s.tableMetadata(schema, table)
 	if err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
+		metadata = xuguTableMetadata{}
 	}
 	identities, err := s.tableIdentities(schema, table)
 	if err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
+		identities = map[string]xuguIdentityInfo{}
 	}
 	constraints, err := s.tableConstraints(schema, table)
 	if err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
+		constraints = []xuguConstraintInfo{}
 	}
 	foreignKeys, err := s.tableForeignKeys(schema, table)
 	if err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
+		foreignKeys = []xuguConstraintInfo{}
 	}
 	partitions, err := s.tablePartitions(schema, table, false)
 	if err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
+		partitions = []xuguPartitionInfo{}
 	}
 	subpartitions, err := s.tablePartitions(schema, table, true)
 	if err != nil {
-		return "", err
+		if !isXuguMetadataAccessError(err) {
+			return "", err
+		}
+		subpartitions = []xuguPartitionInfo{}
 	}
 	allConstraints := make([]xuguConstraintInfo, 0, len(constraints)+len(foreignKeys))
 	allConstraints = append(allConstraints, constraints...)

--- a/agents/drivers/xugu/main.go
+++ b/agents/drivers/xugu/main.go
@@ -1515,15 +1515,34 @@ func configuredDatabaseName(params connectParams) string {
 }
 
 func isXuguMetadataAccessError(err error) bool {
-	message := strings.ToUpper(err.Error())
-	if strings.Contains(message, "E18012") || strings.Contains(message, "权限不够") {
-		return true
+	if err == nil {
+		return false
 	}
+	message := strings.ToUpper(strings.TrimSpace(strings.TrimRight(err.Error(), "\x00")))
+	for _, marker := range []string{
+		"E18012", "权限不够", "PERMISSION DENIED", "ACCESS DENIED", "INSUFFICIENT PRIVILEGE", "NOT AUTHORIZED",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	catalogObject := false
 	for _, object := range []string{
 		"DATABASES", "SCHEMAS", "TABLES", "VIEWS", "COLUMNS", "CONSTRAINTS", "INDEXES",
 		"TRIGGERS", "PARTIS", "SUBPARTIS", "SEQUENCES", "SYNONYMS", "PROCEDURES", "PACKAGES", "TYPES",
 	} {
 		if strings.Contains(message, "ALL_"+object) || strings.Contains(message, "SYS_"+object) {
+			catalogObject = true
+			break
+		}
+	}
+	if !catalogObject {
+		return false
+	}
+	for _, marker := range []string{
+		"不存在", "DOES NOT EXIST", "NOT EXIST", "UNKNOWN TABLE", "UNKNOWN VIEW", "UNDEFINED TABLE", "INVALID OBJECT NAME",
+	} {
+		if strings.Contains(message, marker) {
 			return true
 		}
 	}
@@ -1615,10 +1634,14 @@ func (s *server) listTables(schema string, constraints metadataListConstraints) 
 	rows, err := s.queryRows(query.SQL, query.Args)
 	if err != nil {
 		if isXuguMetadataAccessError(err) {
-			if fallback, fallbackErr := s.listOwnTables(schema, constraints); fallbackErr == nil {
+			fallback, fallbackErr := s.listOwnTables(schema, constraints)
+			if fallbackErr == nil {
 				return fallback, nil
 			}
-			return []tableInfo{}, nil
+			if isXuguMetadataAccessError(fallbackErr) {
+				return []tableInfo{}, nil
+			}
+			return nil, fallbackErr
 		}
 		return nil, err
 	}
@@ -1682,7 +1705,7 @@ func (s *server) listObjects(schema string, constraints metadataListConstraints)
 			// objects are omitted rather than guessed from unavailable metadata.
 			tables, tableErr := s.listTables(schema, constraints)
 			if tableErr != nil {
-				return []objectInfo{}, nil
+				return nil, tableErr
 			}
 			result := make([]objectInfo, 0, len(tables))
 			for _, table := range tables {
@@ -2593,10 +2616,10 @@ func (s *server) getTableDDL(schema, table string) (string, error) {
 			if directErr == nil {
 				return ddl, nil
 			}
-			if isXuguMetadataAccessError(err) {
+			if isXuguMetadataAccessError(directErr) {
 				return xuguUnavailableTableDDL(fallbackSchema, fallbackTable), nil
 			}
-			return "", err
+			return "", directErr
 		}
 		return "", err
 	}

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -1957,9 +1957,177 @@ func init() {
 	sql.Register("xugu-test-show-result", &xuguShowResultDriver{})
 	sql.Register("xugu-test-sequence-source", &xuguSequenceSourceDriver{})
 	sql.Register("xugu-test-synonym-source", &xuguSynonymSourceDriver{})
+	sql.Register("xugu-test-permission-metadata", &xuguPermissionMetadataDriver{})
+}
+
+func TestMetadataPermissionFallbackDoesNotReturnRPCError(t *testing.T) {
+	db, err := sql.Open("xugu-test-permission-metadata", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	s.params.Username = "APP"
+
+	tables, err := s.listTables("APP", metadataListConstraints{})
+	if err != nil || len(tables) != 1 || tables[0].Name != "PUBLIC_TABLE" {
+		t.Fatalf("listTables permission fallback = %#v, %v; want USER_TABLES result", tables, err)
+	}
+	objects, err := s.listObjects("APP", metadataListConstraints{})
+	if err != nil || len(objects) != 1 || objects[0].Name != "PUBLIC_TABLE" {
+		t.Fatalf("listObjects permission fallback = %#v, %v; want USER_TABLES result", objects, err)
+	}
+	indexes, err := s.listIndexes("APP", "PUBLIC_TABLE")
+	if err != nil || len(indexes) != 0 {
+		t.Fatalf("listIndexes permission fallback = %#v, %v; want empty success", indexes, err)
+	}
+	partitions, err := s.listPartitions("APP", "PUBLIC_TABLE")
+	if err != nil || len(partitions) != 0 {
+		t.Fatalf("listPartitions permission fallback = %#v, %v; want empty success", partitions, err)
+	}
+	subpartitions, err := s.listSubpartitions("APP", "PUBLIC_TABLE")
+	if err != nil || len(subpartitions) != 0 {
+		t.Fatalf("listSubpartitions permission fallback = %#v, %v; want empty success", subpartitions, err)
+	}
+}
+
+func TestGetColumnsFallsBackToDirectObjectAccessOnMetadataPermission(t *testing.T) {
+	db, err := sql.Open("xugu-test-permission-metadata", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	columns, err := s.getColumns("APP", "PUBLIC_TABLE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(columns) != 2 || columns[0].Name != "ID" || columns[0].DataType != "INTEGER" || columns[1].Name != "NAME" {
+		t.Fatalf("direct column fallback = %#v", columns)
+	}
+}
+
+func TestTableDDLFallsBackToDirectObjectAccessOnMetadataPermission(t *testing.T) {
+	db, err := sql.Open("xugu-test-permission-metadata", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	ddl, err := s.getTableDDL("APP", "PUBLIC_TABLE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`CREATE TABLE "APP"."PUBLIC_TABLE"`,
+		`"ID" INTEGER`,
+		`"NAME" VARCHAR(40)`,
+	} {
+		if !strings.Contains(ddl, want) {
+			t.Fatalf("fallback table DDL missing %q:\n%s", want, ddl)
+		}
+	}
+}
+
+func TestObjectSourcePermissionFallbackIsExplicitAndReadOnly(t *testing.T) {
+	db, err := sql.Open("xugu-test-permission-metadata", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	for _, objectType := range []string{"PROCEDURE", "SEQUENCE", "SYNONYM"} {
+		source, err := s.getObjectSource("APP", "PRIVATE_OBJECT", objectType)
+		if err != nil {
+			t.Fatalf("%s source fallback: %v", objectType, err)
+		}
+		if source["editable"] != false || !strings.Contains(source["source"].(string), "did not expose source metadata") {
+			t.Fatalf("%s source fallback = %#v", objectType, source)
+		}
+	}
 }
 
 type xuguShowResultDriver struct{}
+
+type xuguPermissionMetadataDriver struct{}
+
+func (d *xuguPermissionMetadataDriver) Open(name string) (driver.Conn, error) {
+	return &xuguPermissionMetadataConn{}, nil
+}
+
+type xuguPermissionMetadataConn struct{}
+
+func (c *xuguPermissionMetadataConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not supported")
+}
+func (c *xuguPermissionMetadataConn) Close() error { return nil }
+func (c *xuguPermissionMetadataConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not supported")
+}
+func (c *xuguPermissionMetadataConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "SET SCHEMA") {
+		return nil, errors.New("[E18012] 权限不够")
+	}
+	return driver.ResultNoRows, nil
+}
+func (c *xuguPermissionMetadataConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	upper := strings.ToUpper(query)
+	if strings.Contains(upper, "SELECT S.SCHEMA_NAME, T.TABLE_NAME") {
+		return &xuguStaticRows{columns: []string{"SCHEMA_NAME", "TABLE_NAME"}}, nil
+	}
+	if strings.Contains(upper, "FROM USER_TABLES") {
+		return &xuguStaticRows{
+			columns: []string{"TABLE_NAME", "TABLE_TYPE", "COMMENTS"},
+			values:  [][]driver.Value{{"PUBLIC_TABLE", "TABLE", nil}},
+		}, nil
+	}
+	if strings.Contains(upper, "FROM USER_VIEWS") {
+		return &xuguStaticRows{columns: []string{"VIEW_NAME", "TABLE_TYPE", "COMMENTS"}}, nil
+	}
+	if strings.Contains(upper, "ALL_") || strings.Contains(upper, "SYS_") {
+		return nil, errors.New("[E18012] 权限不够")
+	}
+	if strings.Contains(upper, `SELECT * FROM "APP"."PUBLIC_TABLE" WHERE 1 = 0`) {
+		return &xuguPermissionColumnsRows{}, nil
+	}
+	return nil, fmt.Errorf("unexpected permission-fallback query: %s", query)
+}
+
+type xuguPermissionColumnsRows struct {
+	index int
+}
+
+func (r *xuguPermissionColumnsRows) Columns() []string {
+	return []string{"ID", "NAME"}
+}
+func (r *xuguPermissionColumnsRows) Close() error { return nil }
+func (r *xuguPermissionColumnsRows) Next(dest []driver.Value) error {
+	if r.index > 0 {
+		return io.EOF
+	}
+	r.index++
+	return io.EOF
+}
+func (r *xuguPermissionColumnsRows) ColumnTypeDatabaseTypeName(index int) string {
+	return []string{"INTEGER", "VARCHAR"}[index]
+}
+func (r *xuguPermissionColumnsRows) ColumnTypeLength(index int) (length int64, ok bool) {
+	if index == 1 {
+		return 40, true
+	}
+	return 0, false
+}
+func (r *xuguPermissionColumnsRows) ColumnTypeNullable(index int) (nullable, ok bool) {
+	return index != 0, true
+}
 
 var xuguShowResultState struct {
 	sync.Mutex

--- a/agents/drivers/xugu/main_test.go
+++ b/agents/drivers/xugu/main_test.go
@@ -876,11 +876,25 @@ func TestTableChildMetadataRPCsReturnCatalogObjects(t *testing.T) {
 }
 
 func TestXuguMetadataAccessErrorDetection(t *testing.T) {
-	if !isXuguMetadataAccessError(errors.New("[E18012] 权限不够")) {
-		t.Fatal("expected E18012 permission error to be treated as metadata access error")
+	tests := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{name: "permission code", message: "[E18012] 权限不够", want: true},
+		{name: "permission text", message: "permission denied reading ALL_TABLES", want: true},
+		{name: "missing catalog view", message: `表或视图 "ALL_TABLES" 不存在`, want: true},
+		{name: "catalog name in syntax error", message: "syntax error near ALL_TABLES", want: false},
+		{name: "catalog name in network error", message: "network timeout while querying SYS_TABLES", want: false},
+		{name: "catalog name after missing endpoint", message: "network endpoint not found while querying SYS_TABLES", want: false},
+		{name: "unrelated network error", message: "network timeout", want: false},
 	}
-	if isXuguMetadataAccessError(errors.New("network timeout")) {
-		t.Fatal("network errors should not trigger database-list fallback")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isXuguMetadataAccessError(errors.New(test.message)); got != test.want {
+				t.Fatalf("isXuguMetadataAccessError(%q) = %t, want %t", test.message, got, test.want)
+			}
+		})
 	}
 }
 
@@ -1958,6 +1972,7 @@ func init() {
 	sql.Register("xugu-test-sequence-source", &xuguSequenceSourceDriver{})
 	sql.Register("xugu-test-synonym-source", &xuguSynonymSourceDriver{})
 	sql.Register("xugu-test-permission-metadata", &xuguPermissionMetadataDriver{})
+	sql.Register("xugu-test-fallback-errors", &xuguFallbackErrorDriver{})
 }
 
 func TestMetadataPermissionFallbackDoesNotReturnRPCError(t *testing.T) {
@@ -2035,6 +2050,58 @@ func TestTableDDLFallsBackToDirectObjectAccessOnMetadataPermission(t *testing.T)
 	}
 }
 
+func TestMetadataFallbackPropagatesUserCatalogErrors(t *testing.T) {
+	db, err := sql.Open("xugu-test-fallback-errors", "user-catalog-error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	s.params.Username = "APP"
+
+	if tables, err := s.listTables("APP", metadataListConstraints{}); err == nil || !strings.Contains(err.Error(), "network timeout reading USER_TABLES") {
+		t.Fatalf("listTables fallback = %#v, %v; want USER_TABLES error", tables, err)
+	}
+	if objects, err := s.listObjects("APP", metadataListConstraints{}); err == nil || !strings.Contains(err.Error(), "network timeout reading USER_TABLES") {
+		t.Fatalf("listObjects fallback = %#v, %v; want USER_TABLES error", objects, err)
+	}
+}
+
+func TestTableDDLFallbackPropagatesDirectSelectError(t *testing.T) {
+	db, err := sql.Open("xugu-test-fallback-errors", "ddl-select-error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	ddl, err := s.getTableDDL("APP", "PUBLIC_TABLE")
+	if err == nil || !strings.Contains(err.Error(), "network timeout selecting APP.PUBLIC_TABLE") {
+		t.Fatalf("table DDL fallback = %q, %v; want direct SELECT error", ddl, err)
+	}
+}
+
+func TestTableDDLFallbackDegradesDirectPermissionError(t *testing.T) {
+	db, err := sql.Open("xugu-test-fallback-errors", "ddl-select-permission")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := newServer()
+	s.db = db
+	ddl, err := s.getTableDDL("APP", "PUBLIC_TABLE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(ddl, "did not expose enough metadata") {
+		t.Fatalf("permission-limited table DDL fallback = %q", ddl)
+	}
+}
+
 func TestObjectSourcePermissionFallbackIsExplicitAndReadOnly(t *testing.T) {
 	db, err := sql.Open("xugu-test-permission-metadata", "")
 	if err != nil {
@@ -2058,6 +2125,48 @@ func TestObjectSourcePermissionFallbackIsExplicitAndReadOnly(t *testing.T) {
 type xuguShowResultDriver struct{}
 
 type xuguPermissionMetadataDriver struct{}
+
+type xuguFallbackErrorDriver struct{}
+
+func (d *xuguFallbackErrorDriver) Open(name string) (driver.Conn, error) {
+	return &xuguFallbackErrorConn{mode: name}, nil
+}
+
+type xuguFallbackErrorConn struct {
+	mode string
+}
+
+func (c *xuguFallbackErrorConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not supported")
+}
+func (c *xuguFallbackErrorConn) Close() error              { return nil }
+func (c *xuguFallbackErrorConn) Begin() (driver.Tx, error) { return nil, errors.New("not supported") }
+func (c *xuguFallbackErrorConn) ExecContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+	return driver.ResultNoRows, nil
+}
+func (c *xuguFallbackErrorConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	upper := strings.ToUpper(query)
+	switch c.mode {
+	case "user-catalog-error":
+		if strings.Contains(upper, "FROM USER_TABLES") {
+			return nil, errors.New("network timeout reading USER_TABLES")
+		}
+		if strings.Contains(upper, "FROM ALL_TABLES") {
+			return nil, errors.New("[E18012] 权限不够")
+		}
+	case "ddl-select-error", "ddl-select-permission":
+		if strings.Contains(upper, `SELECT * FROM "APP"."PUBLIC_TABLE" WHERE 1 = 0`) {
+			if c.mode == "ddl-select-permission" {
+				return nil, errors.New("permission denied selecting APP.PUBLIC_TABLE")
+			}
+			return nil, errors.New("network timeout selecting APP.PUBLIC_TABLE")
+		}
+		if strings.Contains(upper, "SELECT S.SCHEMA_NAME, T.TABLE_NAME") && strings.Contains(upper, "FROM ALL_TABLES") {
+			return nil, errors.New("[E18012] 权限不够")
+		}
+	}
+	return nil, fmt.Errorf("unexpected fallback-error query for %s: %s", c.mode, query)
+}
 
 func (d *xuguPermissionMetadataDriver) Open(name string) (driver.Conn, error) {
 	return &xuguPermissionMetadataConn{}, nil


### PR DESCRIPTION
## Summary

Normal XuguDB users can now browse and inspect accessible objects even when SYSTEM control or ALL_* metadata views are unavailable.

## Root cause

The existing connection fallback only degraded the SYSTEM control session. Metadata handlers still propagated E18012 permission errors from ALL_* catalog views as Agent RPC errors. Several child-object and DDL paths also failed before they could use the direct table connection.

## Changes

- Expand Xugu metadata-access error detection to sequences, synonyms, procedures, packages, types, partitions, and subpartitions.
- Fall back from ALL_TABLES/ALL_VIEWS to USER_TABLES/USER_VIEWS for the current user schema.
- Fall back to SELECT * ... WHERE 1 = 0 for column discovery when catalog table resolution is unavailable.
- Treat inaccessible indexes, constraints, foreign keys, triggers, partitions, and subpartitions as empty metadata instead of RPC failures.
- Generate a best-effort column-only table DDL when catalog metadata is unavailable.
- Return an explicit read-only source explanation when programmable-object source metadata cannot be reconstructed.
- Preserve normal privileged metadata behavior and keep all changes scoped to the Xugu Go agent.

## Compatibility

The fallback is only activated for Xugu permission or catalog-access errors. Syntax errors, network errors, ambiguous identifiers, and genuinely missing objects continue to return errors. Cross-schema objects that are not exposed by Xugu ALL_* views remain subject to the database privilege model, but directly accessible tables can still expose columns and best-effort DDL.

## Verification

- \`go test -count=1 ./...\`
- \`go test -count=1 -race ./...\`
- \`go vet ./...\`
- \`go build\`
- \`git diff --check\`
- Real XuguDB 12.10.13 test on SHOP_DEMO with a non-DBA user:
  - open_session, list_databases, list_schemas, list_tables, list_objects
  - columns, indexes, constraints, foreign keys, triggers, partitions, subpartitions
  - table DDL, procedure source, and sequence source
  - cross-schema SELECT-granted table column discovery and DDL fallback
- Temporary test user and objects were removed after replay.