### PR TITLE
Fix：粘贴 IN 条件时遵循 SQL 关键字大小写

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1127,7 +1127,7 @@ async function pasteClipboardAsSqlInCondition(): Promise<boolean> {
     }
   }
 
-  const result = buildSqlInConditionFromPasteSource(source);
+  const result = buildSqlInConditionFromPasteSource(source, settingsStore.editorSettings.sqlFormatter.keywordCase);
   if (!result.ok) {
     const key = result.reason === "too-large" ? "editor.exPasteTooLarge" : result.reason === "too-many-values" ? "editor.exPasteTooManyValues" : result.reason === "not-list" ? "editor.exPasteNotList" : "editor.exPasteNoValues";
     toast(t(key, { limit: result.limit ?? 0 }), 5000);

--- a/apps/desktop/src/lib/__tests__/sql/sqlInListPaste.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlInListPaste.spec.ts
@@ -10,6 +10,19 @@ describe("sqlInListPaste", () => {
     });
   });
 
+  it("uses the configured SQL keyword case", () => {
+    expect(buildSqlInConditionFromPasteSource("A\nB", "lower")).toEqual({
+      ok: true,
+      sql: "in ('A', 'B')",
+      valueCount: 2,
+    });
+    expect(buildSqlInConditionFromPasteSource("A\nB", "upper")).toEqual({
+      ok: true,
+      sql: "IN ('A', 'B')",
+      valueCount: 2,
+    });
+  });
+
   it("splits comma, tab, and newline separated clipboard content", () => {
     expect(buildSqlInConditionFromPasteSource("A\tB\nC,D")).toEqual({
       ok: true,

--- a/apps/desktop/src/lib/sql/sqlInListPaste.ts
+++ b/apps/desktop/src/lib/sql/sqlInListPaste.ts
@@ -27,7 +27,7 @@ interface ParsedPasteValues {
 
 const SIMPLE_SLASH_LIST_VALUE_RE = /^[A-Za-z0-9_.:-]+$/;
 
-export function buildSqlInConditionFromPasteSource(source: string): SqlInListPasteResult {
+export function buildSqlInConditionFromPasteSource(source: string, keywordCase: "preserve" | "upper" | "lower" = "upper"): SqlInListPasteResult {
   if (source.length > SQL_IN_LIST_PASTE_MAX_SOURCE_LENGTH) {
     return { ok: false, reason: "too-large", limit: SQL_IN_LIST_PASTE_MAX_SOURCE_LENGTH };
   }
@@ -41,9 +41,10 @@ export function buildSqlInConditionFromPasteSource(source: string): SqlInListPas
   }
 
   const literals = values.map(formatSqlLiteral);
+  const inKeyword = keywordCase === "lower" ? "in" : "IN";
   return {
     ok: true,
-    sql: `IN (${literals.join(", ")})`,
+    sql: `${inKeyword} (${literals.join(", ")})`,
     valueCount: values.length,
   };
 }


### PR DESCRIPTION
## 问题

启用“小写 SQL 关键字”后，粘贴为 IN 条件仍固定生成大写 `IN (...)`，与编辑器配置不一致。

## 修复

- 将当前 SQL 关键字大小写配置传入 ExPaste
- 小写模式生成 `in (...)`，大写模式保持 `IN (...)`
- 增加大小写两种模式的回归测试

## 验证

- 在最新 `main` 复现：小写模式仍生成 `IN ('A', 'B')`
- 使用独立 SQLite 连接在本地 Web UI 验证：修复后生成 `in ('A', 'B')`
- `pnpm vitest run apps/desktop/src/lib/__tests__/sql/sqlInListPaste.spec.ts packages/app-tests/settingsStore.test.ts`
- `pnpm typecheck`
- `pnpm build`
- 针对修改文件运行 oxlint

Fixes #5009