### PR TITLE
Fix：转置切换后保持表格滚动位置

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -1927,6 +1927,8 @@ const gridStyle = computed(() => ({
 const gridHorizontalScrollLeft = ref(0);
 const gridViewportWidth = ref(0);
 let gridScrollLeftBeforeTranspose = 0;
+let gridScrollTopBeforeKeyboardTranspose: number | null = null;
+let restoreGridScrollTopAfterTranspose = false;
 const {
   renderedColumnOffsets,
   horizontalColumnWindow,
@@ -6093,13 +6095,18 @@ function toggleKeyboardTranspose(): boolean {
     selectedRowIds: selectedRowIds.value,
     selectedRange: selectedRange.value,
   });
+  if (next.showTranspose) {
+    gridScrollTopBeforeKeyboardTranspose = gridScrollerElement()?.scrollTop ?? null;
+  } else if (gridScrollTopBeforeKeyboardTranspose !== null) {
+    restoreGridScrollTopAfterTranspose = true;
+  }
   showTranspose.value = next.showTranspose;
   transposeRowIndex.value = next.transposeRowIndex;
   if (next.showTranspose) {
     closeCellDetails();
     nextTick(updateTransposeViewport);
     if (next.transposeRowIndex !== null) scrollTransposeRecordIntoView(next.transposeRowIndex);
-  } else {
+  } else if (!restoreGridScrollTopAfterTranspose) {
     scrollGridRowIntoView(requestedRowIndex);
   }
   return true;
@@ -6825,10 +6832,14 @@ watch(isTransposeMode, (active) => {
     return;
   }
 
+  const scrollTopBeforeTranspose = restoreGridScrollTopAfterTranspose ? (gridScrollTopBeforeKeyboardTranspose ?? undefined) : undefined;
+  restoreGridScrollTopAfterTranspose = false;
+  gridScrollTopBeforeKeyboardTranspose = null;
   nextTick(() => {
     restoreDataGridAfterTranspose({
       scroller: gridScrollerElement(),
       scrollLeftBeforeTranspose: gridScrollLeftBeforeTranspose,
+      scrollTopBeforeTranspose,
       attachCanvasResizeObserver,
       refreshGridScrollerMetrics,
     });

--- a/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridTranspose.ts
@@ -189,8 +189,17 @@ export function nextTransposeState(showTranspose: boolean, transposeRowIndex: nu
   return { showTranspose: true, transposeRowIndex: requestedRowIndex };
 }
 
-export function restoreDataGridAfterTranspose(options: { scroller: Pick<HTMLElement, "scrollLeft" | "scrollWidth" | "clientWidth"> | null; scrollLeftBeforeTranspose: number; attachCanvasResizeObserver: () => void; refreshGridScrollerMetrics: () => void }) {
+export function restoreDataGridAfterTranspose(options: {
+  scroller: Pick<HTMLElement, "scrollTop" | "scrollLeft" | "scrollHeight" | "scrollWidth" | "clientHeight" | "clientWidth"> | null;
+  scrollLeftBeforeTranspose: number;
+  scrollTopBeforeTranspose?: number;
+  attachCanvasResizeObserver: () => void;
+  refreshGridScrollerMetrics: () => void;
+}) {
   if (!options.scroller) return;
+  if (options.scrollTopBeforeTranspose !== undefined) {
+    options.scroller.scrollTop = Math.max(0, Math.min(Math.max(0, options.scroller.scrollHeight - options.scroller.clientHeight), options.scrollTopBeforeTranspose));
+  }
   options.scroller.scrollLeft = restoredDataGridScrollLeft(options.scrollLeftBeforeTranspose, options.scroller.scrollWidth, options.scroller.clientWidth);
   options.attachCanvasResizeObserver();
   options.refreshGridScrollerMetrics();

--- a/packages/app-tests/dataGridTransposeLifecycle.test.ts
+++ b/packages/app-tests/dataGridTransposeLifecycle.test.ts
@@ -5,12 +5,14 @@ import { useDataGridCanvasRuntime, type DataGridAnimationFrameDriver } from "../
 import { useDataGridScrollbars } from "../../apps/desktop/src/composables/useDataGridScrollbars.ts";
 import { restoreDataGridAfterTranspose, transposeRecordIndexesForMode } from "../../apps/desktop/src/lib/dataGrid/dataGridTranspose.ts";
 
-type TestScroller = HTMLElement & { clientHeight: number };
+type TestScroller = HTMLElement & { clientHeight: number; scrollHeight: number };
 
-function createScroller(scrollWidth: number, clientWidth: number, clientHeight: number): TestScroller {
+function createScroller(scrollWidth: number, clientWidth: number, clientHeight: number, scrollHeight = 1200): TestScroller {
   return {
     children: [],
+    scrollTop: 0,
     scrollLeft: 0,
+    scrollHeight,
     scrollWidth,
     clientWidth,
     clientHeight,
@@ -132,6 +134,30 @@ test("restores a wide canvas grid after single-row and multi-row transpose remou
 
   canvasRuntime.dispose();
   scrollbarsRuntime.dispose();
+});
+
+test("restores the vertical grid position after a keyboard transpose round trip", () => {
+  const viewport = createScroller(600, 600, 320, 2600);
+
+  restoreDataGridAfterTranspose({
+    scroller: viewport,
+    scrollLeftBeforeTranspose: 0,
+    scrollTopBeforeTranspose: 1300,
+    attachCanvasResizeObserver() {},
+    refreshGridScrollerMetrics() {},
+  });
+
+  assert.equal(viewport.scrollTop, 1300);
+
+  restoreDataGridAfterTranspose({
+    scroller: viewport,
+    scrollLeftBeforeTranspose: 0,
+    scrollTopBeforeTranspose: 2500,
+    attachCanvasResizeObserver() {},
+    refreshGridScrollerMetrics() {},
+  });
+
+  assert.equal(viewport.scrollTop, 2280, "restored position should stay within the remounted grid bounds");
 });
 
 test("error result recovery participates in canvas observer remounts", () => {


### PR DESCRIPTION
## 修复内容

- 键盘进入转置视图时记录普通数据网格的纵向滚动位置
- 再次通过键盘退出转置时，在网格重新挂载后恢复原始位置
- 对恢复值做滚动范围限制，并保留现有横向位置与自定义滚动条恢复逻辑
- 双击、右键和关闭按钮等其他转置退出路径继续按当前记录定位，不改变既有行为

## 验证

- 最新 `main` 修复前实测：选中第 56 行，切换前 `scrollTop=1300`，返回后变为 `1430`，选中行被顶到首行
- 修复后使用隔离 SQLite 数据库重复操作：返回后 `scrollTop=1300`，第 56 行保持在原视口位置
- `pnpm -s test -- packages/app-tests/dataGridTransposeLifecycle.test.ts packages/app-tests/dataGridTranspose.test.ts`（698 个测试文件、6138 个测试通过）
- `pnpm -s typecheck`
- `pnpm -s build`
- 定向 `oxlint` 与 `oxfmt --check`

Fixes #4562
