### PR TITLE
fix(editor): 修复标识符处无法追加多光标

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -86,7 +86,7 @@ import { createInsertValueHintsExtension, requestInsertValueHintsRefresh } from 
 import { focusEditorView } from "@/lib/editor/queryEditorFocus";
 import { createDbxCodeMirrorSqlDialect, type CodeMirrorSqlDialectName } from "@/lib/editor/codemirrorSqlDialect";
 import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorSqlSemanticHighlight";
-import { startsQueryEditorRectangularSelection } from "@/lib/editor/queryEditorPointerSelection";
+import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
 import { isSchemaAware, isSingleDatabase, supportsDatabaseNameCompletion, supportsDatabaseSchemaQualifier, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
@@ -844,7 +844,7 @@ function tableNavigationIdentifierAt(currentView: EditorViewType, event: MouseEv
 }
 
 function updateTableNavigationHover(currentView: EditorViewType, event: MouseEvent) {
-  if (!event.metaKey && !event.ctrlKey) {
+  if (!usesQueryEditorObjectNavigationModifier(event)) {
     clearTableNavigationHover();
     return false;
   }
@@ -854,7 +854,7 @@ function updateTableNavigationHover(currentView: EditorViewType, event: MouseEve
 }
 
 function clearTableNavigationHoverOnModifierRelease(event: KeyboardEvent) {
-  if (!event.metaKey && !event.ctrlKey) clearTableNavigationHover();
+  if (!usesQueryEditorObjectNavigationModifier(event)) clearTableNavigationHover();
 }
 
 function isEditorScrollbarPointerEvent(currentView: EditorViewType, event: MouseEvent) {
@@ -4185,14 +4185,15 @@ onMounted(async () => {
           if (currentView && startEditorSelectionDrag(currentView, event)) {
             return true;
           }
-          // Click without modifier -> close column panel
-          if (!event.metaKey && !event.ctrlKey) {
-            if (event.button === 0) {
+          // Alt belongs to CodeMirror's rectangular and multi-cursor gestures,
+          // even when Cmd/Ctrl is held at the same time.
+          if (!usesQueryEditorObjectNavigationModifier(event)) {
+            // Click without modifier -> close column panel
+            if (!event.metaKey && !event.ctrlKey && event.button === 0) {
               emit("closeColumnPanel");
             }
             return false;
           }
-          // Only handle Ctrl/Cmd + left click
           if (event.button !== 0) return false;
 
           if (!currentView || !props.connectionId || props.database == null) {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorPointerSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorPointerSelection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { startsQueryEditorRectangularSelection } from "@/lib/editor/queryEditorPointerSelection";
+import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 
 describe("query editor pointer selection", () => {
   it("starts rectangular selection for Alt+left drag", () => {
@@ -12,5 +12,19 @@ describe("query editor pointer selection", () => {
 
   it("leaves ordinary left clicks to the normal cursor handler", () => {
     expect(startsQueryEditorRectangularSelection({ altKey: false, button: 0 })).toBe(false);
+  });
+
+  it("uses Cmd or Ctrl without Alt for object navigation", () => {
+    expect(usesQueryEditorObjectNavigationModifier({ altKey: false, ctrlKey: false, metaKey: true })).toBe(true);
+    expect(usesQueryEditorObjectNavigationModifier({ altKey: false, ctrlKey: true, metaKey: false })).toBe(true);
+  });
+
+  it("leaves Alt+Cmd and Alt+Ctrl to multi-cursor selection", () => {
+    expect(usesQueryEditorObjectNavigationModifier({ altKey: true, ctrlKey: false, metaKey: true })).toBe(false);
+    expect(usesQueryEditorObjectNavigationModifier({ altKey: true, ctrlKey: true, metaKey: false })).toBe(false);
+  });
+
+  it("does not treat an unmodified pointer event as object navigation", () => {
+    expect(usesQueryEditorObjectNavigationModifier({ altKey: false, ctrlKey: false, metaKey: false })).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/editor/queryEditorPointerSelection.ts
+++ b/apps/desktop/src/lib/editor/queryEditorPointerSelection.ts
@@ -3,6 +3,16 @@ export interface QueryEditorPointerEvent {
   button: number;
 }
 
+export interface QueryEditorObjectNavigationModifierEvent {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
 export function startsQueryEditorRectangularSelection(event: QueryEditorPointerEvent): boolean {
   return event.altKey || event.button === 1;
+}
+
+export function usesQueryEditorObjectNavigationModifier(event: QueryEditorObjectNavigationModifierEvent): boolean {
+  return !event.altKey && (event.metaKey || event.ctrlKey);
 }


### PR DESCRIPTION
## 修复内容

- 将 SQL 对象跳转手势限定为未按 Alt 的 Cmd/Ctrl + 点击
- Alt 与 Cmd/Ctrl 同时按下时交还给 CodeMirror 多光标选择逻辑
- 同步修正对象跳转悬停判定，避免标识符显示错误的跳转手型
- 补充 Cmd、Ctrl、Alt+Cmd、Alt+Ctrl 的回归测试

## 实际验证

- 最新 `main` 复现：同一 SQL 中，Alt+Cmd 点击关键字后有 2 个光标；点击 `scroll_test` 后只剩 1 个光标
- 修复分支复测：Alt+Cmd 点击 `scroll_test` 后保留原光标并新增光标，共 2 个光标
- 隔离 SQLite 连接的表 DDL 悬浮仍能正常识别 `scroll_test`
- `pnpm -s typecheck`
- `pnpm -s test`：698 个测试文件、6140 个测试通过
- `pnpm -s build`
- 定向 `oxlint` 与 `oxfmt --check`

Fixes #4095