### PR TITLE
Fix：恢复 AI 默认模型配置

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -5410,6 +5410,12 @@ onUnmounted(cleanupPreviewEditor);
                   </div>
                 </div>
 
+                <!-- Default Model -->
+                <div v-if="!aiIsCliProvider" class="grid grid-cols-3 items-center gap-3">
+                  <Label class="text-right text-xs">{{ t("ai.defaultModel") }}</Label>
+                  <Input v-model="aiEditModel" autocomplete="off" class="col-span-2 h-8 text-xs" :placeholder="t('ai.manualModelPlaceholder')" />
+                </div>
+
                 <!-- Context Window -->
                 <div v-if="!aiIsCliProvider" class="grid grid-cols-3 items-start gap-3">
                   <Label class="text-right text-xs">{{ t("ai.contextWindow") }}</Label>

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -548,6 +548,15 @@ test("AI provider presets include common hosted and local providers", () => {
   assert.ok(Object.keys(AI_PROVIDER_PRESETS).indexOf("codex-cli") < Object.keys(AI_PROVIDER_PRESETS).indexOf("pi-agent-cli"));
 });
 
+test("API AI provider settings expose and persist a default model ID", () => {
+  const source = readFileSync("apps/desktop/src/components/editor/EditorSettingsDialog.vue", "utf8");
+  const modelControl = source.indexOf('<Input v-model="aiEditModel"');
+
+  assert.ok(modelControl >= 0);
+  assert.match(source.slice(modelControl - 300, modelControl + 300), /v-if="!aiIsCliProvider"[\s\S]*t\("ai\.defaultModel"\)[\s\S]*t\('ai\.manualModelPlaceholder'\)/);
+  assert.match(source, /model:\s*aiEditModel\.value/);
+});
+
 test("normalizes legacy AI config and fills provider defaults", () => {
   const legacy = normalizeAiConfig({
     provider: "openai",


### PR DESCRIPTION
## 问题

API 型 AI 提供商的配置状态仍保留 `model` 字段，但设置表单没有模型输入控件。对于不开放 `/models` 接口的本地或私有 OpenAI 兼容服务，测试连接会在模型发现阶段直接失败，用户也无法按错误提示手动填写模型 ID。

## 修复

- 在 API 型 AI 配置表单增加“默认模型”输入框
- 复用现有 `aiEditModel` 状态，将模型 ID 传入测试连接并随配置保存
- CLI 提供商保持原有配置界面
- 增加设置表单回归测试，覆盖模型控件和持久化通路

## 验证

- 本地 OpenAI 兼容服务禁用 `/models`：最新 main 测试失败并提示 `model listing disabled`
- 修复版填写 `private-model` 后测试连接成功，保存并重新编辑后模型 ID 仍保留
- `pnpm exec vitest run packages/app-tests/settingsStore.test.ts`：57 项通过
- `pnpm -s test -- packages/app-tests/settingsStore.test.ts`：698 个测试文件、6138 项测试通过
- `pnpm -s typecheck`
- `pnpm -s lint`（通过，仅有仓库已有 warning）
- `pnpm -s build`

Fixes #5140