### PR TITLE
Fix：清晰展示关系图两端基数

### DIFF
--- a/apps/desktop/src/components/diagram/SchemaDiagramDialog.vue
+++ b/apps/desktop/src/components/diagram/SchemaDiagramDialog.vue
@@ -14,7 +14,7 @@ import { DIAGRAM_SQL_TYPES, isSchemaAware as isSchemaAwareDatabase } from "@/lib
 import { databaseOptionsForConnection } from "@/composables/useDatabaseOptions";
 import { buildDiagramJoinSql, buildDiagramRelationships, filterDiagramTables, layoutDiagramTables, normalizeCustomDiagramRelationship, type CustomDiagramRelationship, type DiagramPosition, type DiagramRelationship, type DiagramTable } from "@/lib/diagram/erDiagram";
 import { buildEngineeringDiagram } from "@/lib/diagram/engineeringDiagram";
-import { buildEngineeringDiagramSvg, buildTableDiagramSvg, diagramSvgFileName } from "@/lib/export/diagramSvgExport";
+import { buildEngineeringDiagramSvg, buildTableDiagramSvg, diagramSvgFileName, type TableDiagramRelationshipLayout } from "@/lib/export/diagramSvgExport";
 import { clampDiagramZoom, zoomFromGestureScale, zoomFromWheelDelta } from "@/lib/diagram/diagramZoom";
 import { Copy, Download, KeyRound, Link2, Loader2, Maximize2, Network, Plus, RefreshCw, Search, Table2, Trash2, X, ZoomIn, ZoomOut } from "@lucide/vue";
 import { useToast } from "@/composables/useToast";
@@ -88,7 +88,7 @@ const relationshipDraft = ref({
   sourceColumn: "",
   targetTable: "",
   targetColumn: "",
-  cardinality: "one-to-many" as "one-to-one" | "one-to-many" | "many-to-one",
+  cardinality: "one-to-many" as "one-to-one" | "one-to-many" | "many-to-one" | "many-to-many",
 });
 
 const sqlConnections = computed(() => store.connections.filter((connection) => DIAGRAM_SQL_TYPES.has(connection.db_type)));
@@ -253,6 +253,7 @@ function defaultRelationshipName(relationship: Omit<CustomDiagramRelationship, "
 function relationshipCardinality(): Pick<CustomDiagramRelationship, "sourceCardinality" | "targetCardinality"> {
   if (relationshipDraft.value.cardinality === "one-to-one") return { sourceCardinality: "1", targetCardinality: "1" };
   if (relationshipDraft.value.cardinality === "many-to-one") return { sourceCardinality: "N", targetCardinality: "1" };
+  if (relationshipDraft.value.cardinality === "many-to-many") return { sourceCardinality: "N", targetCardinality: "N" };
   return { sourceCardinality: "1", targetCardinality: "N" };
 }
 
@@ -423,10 +424,16 @@ function candidateRouteXs(source: TableRect, target: TableRect): number[] {
   });
 }
 
-function relationshipPath(relationship: DiagramRelationship): string {
+function relationshipLayout(relationship: DiagramRelationship): TableDiagramRelationshipLayout {
   const source = getTableRect(relationship.sourceTable);
   const target = getTableRect(relationship.targetTable);
-  if (!source || !target) return "";
+  if (!source || !target) {
+    return {
+      path: "",
+      sourceCardinality: { x: 0, y: 0 },
+      targetCardinality: { x: 0, y: 0 },
+    };
+  }
 
   const y1 = columnAnchorY(relationship.sourceTable, relationship.sourceColumn);
   const y2 = columnAnchorY(relationship.targetTable, relationship.targetColumn);
@@ -444,8 +451,22 @@ function relationshipPath(relationship: DiagramRelationship): string {
 
   const x1 = routeSideX(source, routeX, 2);
   const x2 = routeSideX(target, routeX, 2);
-  return `M ${x1} ${y1} L ${routeX} ${y1} L ${routeX} ${y2} L ${x2} ${y2}`;
+  const cardinalityOffset = 14;
+  const cardinalityLift = 10;
+  return {
+    path: `M ${x1} ${y1} L ${routeX} ${y1} L ${routeX} ${y2} L ${x2} ${y2}`,
+    sourceCardinality: {
+      x: x1 + (routeX < source.x ? -cardinalityOffset : cardinalityOffset),
+      y: y1 - cardinalityLift,
+    },
+    targetCardinality: {
+      x: x2 + (routeX < target.x ? -cardinalityOffset : cardinalityOffset),
+      y: y2 - cardinalityLift,
+    },
+  };
 }
+
+const tableRelationshipLayouts = computed<Record<string, TableDiagramRelationshipLayout>>(() => Object.fromEntries(visibleRelationships.value.map((relationship) => [relationship.id, relationshipLayout(relationship)])));
 
 function engineeringEntityCenter(tableName: string): DiagramPosition {
   const entity = engineeringDiagram.value.entities.find((item) => item.name === tableName);
@@ -655,10 +676,6 @@ function resetZoomAndLayout() {
   resetLayout();
 }
 
-function tableRelationshipPaths(): Record<string, string> {
-  return Object.fromEntries(visibleRelationships.value.map((relationship) => [relationship.id, relationshipPath(relationship)]));
-}
-
 function currentDiagramSvg(): string {
   if (diagramMode.value === "engineering") {
     return buildEngineeringDiagramSvg(engineeringDiagram.value);
@@ -668,7 +685,7 @@ function currentDiagramSvg(): string {
     tables: visibleTables.value,
     relationships: visibleRelationships.value,
     positions: positions.value,
-    relationshipPaths: tableRelationshipPaths(),
+    relationshipLayouts: tableRelationshipLayouts.value,
     canvas: canvasSize.value,
     cardWidth: CARD_WIDTH,
     cardHeaderHeight: CARD_HEADER_HEIGHT,
@@ -941,6 +958,7 @@ onUnmounted(stopDrag);
                 <SelectContent>
                   <SelectItem value="one-to-many">{{ t("diagram.cardinalityOneToMany") }}</SelectItem>
                   <SelectItem value="many-to-one">{{ t("diagram.cardinalityManyToOne") }}</SelectItem>
+                  <SelectItem value="many-to-many">{{ t("diagram.cardinalityManyToMany") }}</SelectItem>
                   <SelectItem value="one-to-one">{{ t("diagram.cardinalityOneToOne") }}</SelectItem>
                 </SelectContent>
               </Select>
@@ -1026,9 +1044,39 @@ onUnmounted(stopDrag);
                         <path d="M 0 0 L 8 4 L 0 8 z" class="fill-primary/70" />
                       </marker>
                     </defs>
-                    <path v-for="relationship in visibleRelationships" :key="relationship.id" :d="relationshipPath(relationship)" class="fill-none stroke-primary/55" stroke-width="1.6" marker-end="url(#diagram-arrow)">
-                      <title>{{ relationshipTitle(relationship) }}</title>
-                    </path>
+                    <template v-for="relationship in visibleRelationships" :key="relationship.id">
+                      <path :d="tableRelationshipLayouts[relationship.id]?.path" class="fill-none stroke-primary/55" stroke-width="1.6" marker-end="url(#diagram-arrow)">
+                        <title>{{ relationshipTitle(relationship) }}</title>
+                      </path>
+                      <text
+                        :data-relationship-id="relationship.id"
+                        data-cardinality-end="source"
+                        :x="tableRelationshipLayouts[relationship.id]?.sourceCardinality.x"
+                        :y="tableRelationshipLayouts[relationship.id]?.sourceCardinality.y"
+                        text-anchor="middle"
+                        dominant-baseline="middle"
+                        paint-order="stroke"
+                        stroke-width="4"
+                        stroke-linejoin="round"
+                        class="fill-foreground stroke-background text-[12px] font-semibold"
+                      >
+                        {{ relationship.sourceCardinality }}
+                      </text>
+                      <text
+                        :data-relationship-id="relationship.id"
+                        data-cardinality-end="target"
+                        :x="tableRelationshipLayouts[relationship.id]?.targetCardinality.x"
+                        :y="tableRelationshipLayouts[relationship.id]?.targetCardinality.y"
+                        text-anchor="middle"
+                        dominant-baseline="middle"
+                        paint-order="stroke"
+                        stroke-width="4"
+                        stroke-linejoin="round"
+                        class="fill-foreground stroke-background text-[12px] font-semibold"
+                      >
+                        {{ relationship.targetCardinality }}
+                      </text>
+                    </template>
                   </svg>
 
                   <div

--- a/apps/desktop/src/components/diagram/SchemaDiagramDialog.vue
+++ b/apps/desktop/src/components/diagram/SchemaDiagramDialog.vue
@@ -430,6 +430,7 @@ function relationshipLayout(relationship: DiagramRelationship): TableDiagramRela
   if (!source || !target) {
     return {
       path: "",
+      routePoints: [],
       sourceCardinality: { x: 0, y: 0 },
       targetCardinality: { x: 0, y: 0 },
     };
@@ -455,6 +456,12 @@ function relationshipLayout(relationship: DiagramRelationship): TableDiagramRela
   const cardinalityLift = 10;
   return {
     path: `M ${x1} ${y1} L ${routeX} ${y1} L ${routeX} ${y2} L ${x2} ${y2}`,
+    routePoints: [
+      { x: x1, y: y1 },
+      { x: routeX, y: y1 },
+      { x: routeX, y: y2 },
+      { x: x2, y: y2 },
+    ],
     sourceCardinality: {
       x: x1 + (routeX < source.x ? -cardinalityOffset : cardinalityOffset),
       y: y1 - cardinalityLift,
@@ -562,8 +569,12 @@ async function setSchema(value: string) {
 
 async function loadTableDiagramData(tableName: string, querySchema: string): Promise<DiagramTable> {
   try {
-    const [columns, foreignKeys] = await Promise.all([api.getColumns(connectionId.value, database.value, querySchema, tableName), api.listForeignKeys(connectionId.value, database.value, querySchema, tableName).catch(() => [])]);
-    return { name: tableName, columns, foreignKeys };
+    const [columns, foreignKeys, indexes] = await Promise.all([
+      api.getColumns(connectionId.value, database.value, querySchema, tableName),
+      api.listForeignKeys(connectionId.value, database.value, querySchema, tableName).catch(() => []),
+      api.listIndexes(connectionId.value, database.value, querySchema, tableName).catch(() => []),
+    ]);
+    return { name: tableName, columns, foreignKeys, indexes };
   } catch (e) {
     failedTableCount.value += 1;
     console.warn(`[diagram] failed to load table metadata: ${tableName}`, e);

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2829,6 +2829,7 @@ export default {
     cardinality: "Cardinality",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "Add relationship",
     removeRelationship: "Remove relationship",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2689,6 +2689,7 @@ export default withEnglishFallback({
     cardinality: "Cardinalidad",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "Agregar relación",
     removeRelationship: "Eliminar relación",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2678,6 +2678,7 @@ export default withEnglishFallback({
     cardinality: "Cardinalita",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "Aggiungi relazione",
     removeRelationship: "Rimuovi relazione",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2744,6 +2744,7 @@ export default withEnglishFallback({
     cardinality: "カーディナリティ",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "関係を追加",
     removeRelationship: "関係を削除",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -2785,6 +2785,7 @@ export default withEnglishFallback({
     cardinality: "카디널리티",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "관계 추가",
     removeRelationship: "관계 제거",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2680,6 +2680,7 @@ export default withEnglishFallback({
     cardinality: "Cardinalidade",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "Adicionar relacionamento",
     removeRelationship: "Remover relacionamento",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2829,6 +2829,7 @@ export default withEnglishFallback({
     cardinality: "基数",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "添加关系",
     removeRelationship: "删除关系",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2557,6 +2557,7 @@ export default withEnglishFallback({
     cardinality: "基數",
     cardinalityOneToMany: "1:N",
     cardinalityManyToOne: "N:1",
+    cardinalityManyToMany: "N:N",
     cardinalityOneToOne: "1:1",
     addRelationship: "新增關係",
     removeRelationship: "移除關係",

--- a/apps/desktop/src/lib/diagram/erDiagram.ts
+++ b/apps/desktop/src/lib/diagram/erDiagram.ts
@@ -1,9 +1,10 @@
-import type { ColumnInfo, ForeignKeyInfo } from "@/types/database";
+import type { ColumnInfo, ForeignKeyInfo, IndexInfo } from "@/types/database";
 
 export interface DiagramTable {
   name: string;
   columns: ColumnInfo[];
   foreignKeys: ForeignKeyInfo[];
+  indexes?: IndexInfo[];
 }
 
 export interface DiagramRelationship {
@@ -56,6 +57,24 @@ function columnExists(table: DiagramTable | undefined, columnName: string): bool
   return !!table?.columns.some((column) => column.name === columnName);
 }
 
+function sameColumnSet(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightColumns = new Set(right);
+  return left.every((column) => rightColumns.has(column));
+}
+
+function foreignKeySourceColumns(table: DiagramTable, foreignKey: ForeignKeyInfo): string[] {
+  if (!foreignKey.name) return [foreignKey.column];
+  return table.foreignKeys.filter((candidate) => candidate.name === foreignKey.name && candidate.ref_table === foreignKey.ref_table).map((candidate) => candidate.column);
+}
+
+function foreignKeySourceCardinality(table: DiagramTable, foreignKey: ForeignKeyInfo): "1" | "N" {
+  const sourceColumns = foreignKeySourceColumns(table, foreignKey);
+  const primaryKeyColumns = table.columns.filter((column) => column.is_primary_key).map((column) => column.name);
+  if (sameColumnSet(sourceColumns, primaryKeyColumns)) return "1";
+  return table.indexes?.some((index) => (index.is_unique || index.is_primary) && sameColumnSet(sourceColumns, index.columns)) ? "1" : "N";
+}
+
 function customRelationshipId(relationship: Omit<CustomDiagramRelationship, "id">): string {
   return ["custom", relationship.sourceTable, relationship.sourceColumn, relationship.targetTable, relationship.targetColumn, relationship.sourceCardinality, relationship.targetCardinality].join(":");
 }
@@ -82,7 +101,7 @@ export function buildDiagramRelationships(tables: DiagramTable[], customRelation
         sourceColumn: fk.column,
         targetTable: fk.ref_table,
         targetColumn: fk.ref_column,
-        sourceCardinality: "N" as const,
+        sourceCardinality: foreignKeySourceCardinality(table, fk),
         targetCardinality: "1" as const,
       })),
   );

--- a/apps/desktop/src/lib/diagram/erDiagram.ts
+++ b/apps/desktop/src/lib/diagram/erDiagram.ts
@@ -57,10 +57,10 @@ function columnExists(table: DiagramTable | undefined, columnName: string): bool
   return !!table?.columns.some((column) => column.name === columnName);
 }
 
-function sameColumnSet(left: string[], right: string[]): boolean {
-  if (left.length !== right.length) return false;
-  const rightColumns = new Set(right);
-  return left.every((column) => rightColumns.has(column));
+function sourceColumnsContainUniqueKey(sourceColumns: string[], keyColumns: string[]): boolean {
+  if (keyColumns.length === 0) return false;
+  const sourceColumnSet = new Set(sourceColumns);
+  return keyColumns.every((column) => sourceColumnSet.has(column));
 }
 
 function foreignKeySourceColumns(table: DiagramTable, foreignKey: ForeignKeyInfo): string[] {
@@ -71,8 +71,8 @@ function foreignKeySourceColumns(table: DiagramTable, foreignKey: ForeignKeyInfo
 function foreignKeySourceCardinality(table: DiagramTable, foreignKey: ForeignKeyInfo): "1" | "N" {
   const sourceColumns = foreignKeySourceColumns(table, foreignKey);
   const primaryKeyColumns = table.columns.filter((column) => column.is_primary_key).map((column) => column.name);
-  if (sameColumnSet(sourceColumns, primaryKeyColumns)) return "1";
-  return table.indexes?.some((index) => (index.is_unique || index.is_primary) && sameColumnSet(sourceColumns, index.columns)) ? "1" : "N";
+  if (sourceColumnsContainUniqueKey(sourceColumns, primaryKeyColumns)) return "1";
+  return table.indexes?.some((index) => (index.is_unique || index.is_primary) && !index.filter?.trim() && sourceColumnsContainUniqueKey(sourceColumns, index.columns)) ? "1" : "N";
 }
 
 function customRelationshipId(relationship: Omit<CustomDiagramRelationship, "id">): string {

--- a/apps/desktop/src/lib/export/diagramSvgExport.ts
+++ b/apps/desktop/src/lib/export/diagramSvgExport.ts
@@ -10,6 +10,7 @@ interface DiagramCanvas {
 
 export interface TableDiagramRelationshipLayout {
   path: string;
+  routePoints: DiagramPosition[];
   sourceCardinality: DiagramPosition;
   targetCardinality: DiagramPosition;
 }
@@ -36,8 +37,18 @@ function svgNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/\.?0+$/, "");
 }
 
-function svgHeader(canvas: DiagramCanvas): string {
-  return [`<svg xmlns="http://www.w3.org/2000/svg" width="${svgNumber(canvas.width)}" height="${svgNumber(canvas.height)}" viewBox="0 0 ${svgNumber(canvas.width)} ${svgNumber(canvas.height)}">`, '<rect width="100%" height="100%" fill="#fafafa"/>'].join("");
+interface SvgViewport {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function svgHeader(canvas: DiagramCanvas, viewport: SvgViewport = { x: 0, y: 0, width: canvas.width, height: canvas.height }): string {
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${svgNumber(viewport.width)}" height="${svgNumber(viewport.height)}" viewBox="${svgNumber(viewport.x)} ${svgNumber(viewport.y)} ${svgNumber(viewport.width)} ${svgNumber(viewport.height)}">`,
+    `<rect x="${svgNumber(viewport.x)}" y="${svgNumber(viewport.y)}" width="${svgNumber(viewport.width)}" height="${svgNumber(viewport.height)}" fill="#fafafa"/>`,
+  ].join("");
 }
 
 function svgText(
@@ -84,8 +95,28 @@ function isForeignKeyColumn(table: DiagramTable, columnName: string): boolean {
   return table.foreignKeys.some((fk) => fk.column === columnName);
 }
 
+function tableDiagramViewport(options: TableDiagramSvgOptions): SvgViewport {
+  const relationshipPadding = 20;
+  let minX = 0;
+  let minY = 0;
+  let maxX = options.canvas.width;
+  let maxY = options.canvas.height;
+
+  for (const layout of Object.values(options.relationshipLayouts)) {
+    const points = [...layout.routePoints, layout.sourceCardinality, layout.targetCardinality];
+    for (const point of points) {
+      minX = Math.min(minX, point.x - relationshipPadding);
+      minY = Math.min(minY, point.y - relationshipPadding);
+      maxX = Math.max(maxX, point.x + relationshipPadding);
+      maxY = Math.max(maxY, point.y + relationshipPadding);
+    }
+  }
+
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
 export function buildTableDiagramSvg(options: TableDiagramSvgOptions): string {
-  const parts = [svgHeader(options.canvas), tableDiagramDefs()];
+  const parts = [svgHeader(options.canvas, tableDiagramViewport(options)), tableDiagramDefs()];
 
   for (const relationship of options.relationships) {
     const layout = options.relationshipLayouts[relationship.id];

--- a/apps/desktop/src/lib/export/diagramSvgExport.ts
+++ b/apps/desktop/src/lib/export/diagramSvgExport.ts
@@ -8,11 +8,17 @@ interface DiagramCanvas {
   height: number;
 }
 
+export interface TableDiagramRelationshipLayout {
+  path: string;
+  sourceCardinality: DiagramPosition;
+  targetCardinality: DiagramPosition;
+}
+
 export interface TableDiagramSvgOptions {
   tables: DiagramTable[];
   relationships: DiagramRelationship[];
   positions: Record<string, DiagramPosition>;
-  relationshipPaths: Record<string, string>;
+  relationshipLayouts: Record<string, TableDiagramRelationshipLayout>;
   canvas: DiagramCanvas;
   cardWidth: number;
   cardHeaderHeight: number;
@@ -45,12 +51,22 @@ function svgText(
     anchor?: "start" | "middle" | "end";
     family?: string;
     decoration?: string;
+    stroke?: string;
+    strokeWidth?: number;
+    paintOrder?: string;
+    attributes?: Record<string, string>;
   } = {},
 ): string {
   const attrs = [`x="${svgNumber(x)}"`, `y="${svgNumber(y)}"`, `fill="${options.fill ?? "#18181b"}"`, `font-size="${options.size ?? 12}"`, `font-family="${options.family ?? "Arial, Helvetica, sans-serif"}"`, 'dominant-baseline="middle"'];
   if (options.weight) attrs.push(`font-weight="${options.weight}"`);
   if (options.anchor) attrs.push(`text-anchor="${options.anchor}"`);
   if (options.decoration) attrs.push(`text-decoration="${options.decoration}"`);
+  if (options.stroke) attrs.push(`stroke="${options.stroke}"`);
+  if (options.strokeWidth) attrs.push(`stroke-width="${svgNumber(options.strokeWidth)}"`);
+  if (options.paintOrder) attrs.push(`paint-order="${options.paintOrder}"`);
+  for (const [name, value] of Object.entries(options.attributes ?? {})) {
+    attrs.push(`${name}="${escapeXml(value)}"`);
+  }
   return `<text ${attrs.join(" ")}>${escapeXml(label)}</text>`;
 }
 
@@ -69,14 +85,41 @@ function isForeignKeyColumn(table: DiagramTable, columnName: string): boolean {
 }
 
 export function buildTableDiagramSvg(options: TableDiagramSvgOptions): string {
-  const parts = [svgHeader(options.canvas), tableDiagramDefs(), '<g fill="none" stroke="#2563eb" stroke-opacity="0.58" stroke-width="1.6">'];
+  const parts = [svgHeader(options.canvas), tableDiagramDefs()];
 
   for (const relationship of options.relationships) {
-    const path = options.relationshipPaths[relationship.id];
-    if (!path) continue;
-    parts.push(`<path d="${escapeXml(path)}" marker-end="url(#dbx-diagram-arrow)">` + `<title>${escapeXml(`${relationship.sourceTable}.${relationship.sourceColumn} -> ${relationship.targetTable}.${relationship.targetColumn}`)}</title>` + "</path>");
+    const layout = options.relationshipLayouts[relationship.id];
+    if (!layout?.path) continue;
+    parts.push(`<g data-relationship-id="${escapeXml(relationship.id)}">`);
+    parts.push(
+      `<path d="${escapeXml(layout.path)}" fill="none" stroke="#2563eb" stroke-opacity="0.58" stroke-width="1.6" marker-end="url(#dbx-diagram-arrow)">` +
+        `<title>${escapeXml(`${relationship.sourceTable}.${relationship.sourceColumn} (${relationship.sourceCardinality}:${relationship.targetCardinality}) -> ${relationship.targetTable}.${relationship.targetColumn}`)}</title>` +
+        "</path>",
+    );
+    parts.push(
+      svgText(relationship.sourceCardinality, layout.sourceCardinality.x, layout.sourceCardinality.y, {
+        size: 12,
+        weight: "600",
+        anchor: "middle",
+        stroke: "#fafafa",
+        strokeWidth: 4,
+        paintOrder: "stroke",
+        attributes: { "data-cardinality-end": "source" },
+      }),
+    );
+    parts.push(
+      svgText(relationship.targetCardinality, layout.targetCardinality.x, layout.targetCardinality.y, {
+        size: 12,
+        weight: "600",
+        anchor: "middle",
+        stroke: "#fafafa",
+        strokeWidth: 4,
+        paintOrder: "stroke",
+        attributes: { "data-cardinality-end": "target" },
+      }),
+    );
+    parts.push("</g>");
   }
-  parts.push("</g>");
 
   for (const table of options.tables) {
     const position = options.positions[table.name] ?? { x: 0, y: 0 };

--- a/packages/app-tests/diagramSvgExport.test.ts
+++ b/packages/app-tests/diagramSvgExport.test.ts
@@ -123,6 +123,26 @@ test("infers one-to-one foreign keys from primary and unique source columns", ()
     },
   ];
   assert.equal(buildDiagramRelationships(uniqueIndexTables)[0].sourceCardinality, "1");
+
+  const sourceColumnsContainingUniqueKey: DiagramTable[] = [
+    tables[0],
+    {
+      ...tables[1],
+      columns: [...tables[1].columns, { name: "tenant_id", data_type: "bigint", is_nullable: false, column_default: null, is_primary_key: false, extra: null }],
+      foreignKeys: [...tables[1].foreignKeys, { name: "orders_user_id_fk", column: "tenant_id", ref_table: "users", ref_column: "tenant_id" }],
+      indexes: [{ name: "orders_user_id_unique", columns: ["user_id"], is_unique: true, is_primary: false }],
+    },
+  ];
+  assert.equal(buildDiagramRelationships(sourceColumnsContainingUniqueKey)[0].sourceCardinality, "1");
+
+  const partialUniqueIndexTables: DiagramTable[] = [
+    tables[0],
+    {
+      ...tables[1],
+      indexes: [{ name: "orders_user_id_active_unique", columns: ["user_id"], is_unique: true, is_primary: false, filter: "deleted_at IS NULL" }],
+    },
+  ];
+  assert.equal(buildDiagramRelationships(partialUniqueIndexTables)[0].sourceCardinality, "N");
 });
 
 test("expands the exported viewBox for a relationship routed left of the canvas", () => {

--- a/packages/app-tests/diagramSvgExport.test.ts
+++ b/packages/app-tests/diagramSvgExport.test.ts
@@ -35,6 +35,10 @@ test("exports the table diagram as standalone SVG", () => {
     relationshipLayouts: {
       [relationships[0].id]: {
         path: "M 360 96 L 310 96",
+        routePoints: [
+          { x: 360, y: 96 },
+          { x: 310, y: 96 },
+        ],
         sourceCardinality: { x: 346, y: 86 },
         targetCardinality: { x: 324, y: 86 },
       },
@@ -81,6 +85,10 @@ test("exports many-to-many cardinalities at both relationship endpoints", () => 
     relationshipLayouts: {
       [customRelationship.id]: {
         path: "M 310 96 L 360 96",
+        routePoints: [
+          { x: 310, y: 96 },
+          { x: 360, y: 96 },
+        ],
         sourceCardinality: { x: 324, y: 86 },
         targetCardinality: { x: 346, y: 86 },
       },
@@ -95,6 +103,60 @@ test("exports many-to-many cardinalities at both relationship endpoints", () => 
   assert.match(svg, /data-cardinality-end="source"[^>]*>N<\/text>/);
   assert.match(svg, /data-cardinality-end="target"[^>]*>N<\/text>/);
   assert.match(svg, /users\.id \(N:N\) -&gt; orders\.id/);
+});
+
+test("infers one-to-one foreign keys from primary and unique source columns", () => {
+  const primaryKeyTables: DiagramTable[] = [
+    tables[0],
+    {
+      ...tables[1],
+      columns: tables[1].columns.map((column) => ({ ...column, is_primary_key: column.name === "user_id" })),
+    },
+  ];
+  assert.equal(buildDiagramRelationships(primaryKeyTables)[0].sourceCardinality, "1");
+
+  const uniqueIndexTables: DiagramTable[] = [
+    tables[0],
+    {
+      ...tables[1],
+      indexes: [{ name: "orders_user_id_unique", columns: ["user_id"], is_unique: true, is_primary: false }],
+    },
+  ];
+  assert.equal(buildDiagramRelationships(uniqueIndexTables)[0].sourceCardinality, "1");
+});
+
+test("expands the exported viewBox for a relationship routed left of the canvas", () => {
+  const relationships = buildDiagramRelationships(tables);
+  const svg = buildTableDiagramSvg({
+    tables,
+    relationships,
+    positions: {
+      users: { x: 16, y: 40 },
+      orders: { x: 336, y: 40 },
+    },
+    relationshipLayouts: {
+      [relationships[0].id]: {
+        path: "M 14 96 L -20 96 L -20 120 L 14 120",
+        routePoints: [
+          { x: 14, y: 96 },
+          { x: -20, y: 96 },
+          { x: -20, y: 120 },
+          { x: 14, y: 120 },
+        ],
+        sourceCardinality: { x: 0, y: 86 },
+        targetCardinality: { x: 0, y: 110 },
+      },
+    },
+    canvas: { width: 720, height: 320 },
+    cardWidth: 270,
+    cardHeaderHeight: 44,
+    columnRowHeight: 24,
+    maxVisibleColumns: 9,
+  });
+
+  assert.match(svg, /viewBox="-40 0 760 320"/);
+  assert.match(svg, /<rect x="-40" y="0" width="760" height="320" fill="#fafafa"/);
+  assert.match(svg, /<path d="M 14 96 L -20 96 L -20 120 L 14 120"/);
 });
 
 test("exports the engineering ER diagram with Chen-style shapes and cardinalities", () => {

--- a/packages/app-tests/diagramSvgExport.test.ts
+++ b/packages/app-tests/diagramSvgExport.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import { buildEngineeringDiagram } from "../../apps/desktop/src/lib/diagram/engineeringDiagram.ts";
 import { buildEngineeringDiagramSvg, buildTableDiagramSvg, diagramSvgFileName } from "../../apps/desktop/src/lib/export/diagramSvgExport.ts";
-import { buildDiagramRelationships, type DiagramTable } from "../../apps/desktop/src/lib/diagram/erDiagram.ts";
+import { buildDiagramRelationships, normalizeCustomDiagramRelationship, type DiagramTable } from "../../apps/desktop/src/lib/diagram/erDiagram.ts";
 
 const tables: DiagramTable[] = [
   {
@@ -32,8 +32,12 @@ test("exports the table diagram as standalone SVG", () => {
       users: { x: 40, y: 40 },
       orders: { x: 360, y: 40 },
     },
-    relationshipPaths: {
-      [relationships[0].id]: "M 360 96 L 310 96",
+    relationshipLayouts: {
+      [relationships[0].id]: {
+        path: "M 360 96 L 310 96",
+        sourceCardinality: { x: 346, y: 86 },
+        targetCardinality: { x: 324, y: 86 },
+      },
     },
     canvas: { width: 720, height: 320 },
     cardWidth: 270,
@@ -45,10 +49,52 @@ test("exports the table diagram as standalone SVG", () => {
 
   assert.match(svg, /^<svg /);
   assert.match(svg, /<path d="M 360 96 L 310 96"/);
+  assert.match(svg, /data-cardinality-end="source"[^>]*>N<\/text>/);
+  assert.match(svg, /data-cardinality-end="target"[^>]*>1<\/text>/);
+  assert.match(svg, /orders\.user_id \(N:1\) -&gt; users\.id/);
   assert.match(svg, />users</);
   assert.match(svg, />orders</);
   assert.match(svg, />name &amp; note</);
   assert.doesNotMatch(svg, /<foreignObject/);
+});
+
+test("exports many-to-many cardinalities at both relationship endpoints", () => {
+  const customRelationship = {
+    ...normalizeCustomDiagramRelationship({
+      name: "users_orders",
+      sourceTable: "users",
+      sourceColumn: "id",
+      targetTable: "orders",
+      targetColumn: "id",
+      sourceCardinality: "N",
+      targetCardinality: "N",
+    }),
+    kind: "custom" as const,
+  };
+  const svg = buildTableDiagramSvg({
+    tables,
+    relationships: [customRelationship],
+    positions: {
+      users: { x: 40, y: 40 },
+      orders: { x: 360, y: 40 },
+    },
+    relationshipLayouts: {
+      [customRelationship.id]: {
+        path: "M 310 96 L 360 96",
+        sourceCardinality: { x: 324, y: 86 },
+        targetCardinality: { x: 346, y: 86 },
+      },
+    },
+    canvas: { width: 720, height: 320 },
+    cardWidth: 270,
+    cardHeaderHeight: 44,
+    columnRowHeight: 24,
+    maxVisibleColumns: 9,
+  });
+
+  assert.match(svg, /data-cardinality-end="source"[^>]*>N<\/text>/);
+  assert.match(svg, /data-cardinality-end="target"[^>]*>N<\/text>/);
+  assert.match(svg, /users\.id \(N:N\) -&gt; orders\.id/);
 });
 
 test("exports the engineering ER diagram with Chen-style shapes and cardinalities", () => {


### PR DESCRIPTION
## 问题

表结构图对所有关系都只渲染同一个终点箭头，没有使用关系对象已有的源端/目标端基数，因此 `1:N`、`N:1` 和 `N:N` 在图中无法区分；导出的 SVG 也存在相同问题。

## 修复

- 让关系路由同时计算路径和两端基数标签位置
- 在表结构图的源端、目标端直接显示 `1` / `N`
- 导出 SVG 使用同一份布局信息并保留基数与关系标题
- 补充建模关系中的 `N:N` 选项及多语言键
- 增加 `N:1`、`N:N` SVG 导出测试

## 验证

- 在最新 `main` 的 SQLite 测试库中创建 `1:N`、`N:1` 两条关系，确认修复前两条路径均只有相同箭头且 SVG 无基数文本
- 修复后实际创建 `1:N`、`N:1`、`N:N` 三条关系，页面生成 6 个可见端点标签，滚动后仍与对应表端点对齐
- 通过页面实际导出 SVG，并用 XML 解析确认包含 3 个关系组、6 个端点标签，值分别为 `1:N`、`N:1`、`N:N`
- `pnpm exec vitest run --reporter=dot`：698 个测试文件、6138 项测试通过
- `pnpm -s typecheck`
- `pnpm -s lint`
- `pnpm -s build`

Fixes #4983