### PR TITLE
fix(ai): keep saved models selectable and persist manual models

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -57,6 +57,7 @@ import { useToast } from "@/composables/useToast";
 import { useNavigationTargets } from "@/composables/useNavigationTargets";
 import { buildAiContext, resolveAiDatabaseTarget, resolveAiNamespaceSelection, resolveDefaultAiSchema, runAgentStream, isVectorDbType, isValidActionForMode, defaultActionForMode, type AiAction, type AiAssistantMode, type AiSqlFileContext, type CustomPromptContext } from "@/lib/ai/ai";
 import { isAiConfigModelCandidate } from "@/lib/ai/aiConfigCandidates";
+import { addConfiguredAiModel, aiModelOptions } from "@/lib/ai/aiConfigList";
 import { orderAiConfigsForDisplay } from "@/lib/ai/aiConfigOrdering";
 import { effortSelectionEquals, runtimeEffortFromPreference } from "@/lib/ai/aiEffortPreference";
 import { useAiModelCatalog } from "@/composables/useAiModelCatalog";
@@ -345,7 +346,9 @@ const activeFullConfig = computed(() => {
 });
 
 function getModelsForConfig(configId: string) {
-  return modelCatalogs.get(configId)?.models ?? [];
+  const config = settings.aiConfigs.find((item) => item.id === configId);
+  if (!config) return [];
+  return aiModelOptions(config, modelCatalogs.get(configId)?.models ?? []);
 }
 
 function configMatchesModelQuery(config: AiConfigItem, query: string): boolean {
@@ -420,12 +423,21 @@ function startManualModel(configId: string) {
   nextTick(() => document.querySelector<HTMLInputElement>("[data-manual-model-input]")?.focus());
 }
 
-function applyManualModel(configId: string) {
+async function applyManualModel(configId: string) {
   const modelId = manualModelId.value.trim();
   if (!modelId) return;
-  handleModelSelect(configId, modelId);
-  manualModelConfigId.value = "";
-  manualModelId.value = "";
+  const config = settings.aiConfigs.find((item) => item.id === configId);
+  if (!config) return;
+  try {
+    if (config.model.trim() !== modelId) {
+      await settings.updateAiConfigItem(configId, { models: addConfiguredAiModel(config.models, modelId) });
+    }
+    handleModelSelect(configId, modelId);
+    manualModelConfigId.value = "";
+    manualModelId.value = "";
+  } catch (error) {
+    toast(translateBackendError(t, error));
+  }
 }
 
 const activeEffortEntry = computed(() => {

--- a/apps/desktop/src/lib/ai/__tests__/aiConfigList.spec.ts
+++ b/apps/desktop/src/lib/ai/__tests__/aiConfigList.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { generateId } from "@/lib/ai/aiConfigList";
+import { addConfiguredAiModel, aiModelOptions, generateId } from "@/lib/ai/aiConfigList";
 
 describe("generateId", () => {
   afterEach(() => {
@@ -20,5 +20,45 @@ describe("generateId", () => {
     vi.spyOn(Math, "random").mockReturnValue(0);
 
     expect(generateId()).toBe("00000000-0000-4000-8000-000000000000");
+  });
+});
+
+describe("AI model options", () => {
+  it("keeps saved models selectable when provider model discovery fails", () => {
+    const options = aiModelOptions(
+      {
+        model: "ark-code-latest",
+        models: [{ name: "doubao-seed-2.0-code", label: "Doubao Code" }],
+      },
+      [],
+    );
+
+    expect(options).toEqual([
+      { id: "ark-code-latest", displayName: undefined, supportedEffortLevels: undefined, effortCapability: undefined },
+      { id: "doubao-seed-2.0-code", displayName: "Doubao Code", supportedEffortLevels: undefined, effortCapability: undefined },
+    ]);
+  });
+
+  it("persists a manual model only once", () => {
+    expect(addConfiguredAiModel([{ name: "ark-code-latest" }], "  doubao-seed-2.0-code  ")).toEqual([{ name: "ark-code-latest" }, { name: "doubao-seed-2.0-code" }]);
+    expect(addConfiguredAiModel([{ name: "ark-code-latest" }], "ark-code-latest")).toEqual([{ name: "ark-code-latest" }]);
+  });
+
+  it("merges saved metadata with discovered capabilities", () => {
+    const options = aiModelOptions(
+      {
+        model: "",
+        models: [{ name: "gpt-4o", label: "GPT-4o", supportedEffortLevels: ["high"] }],
+      },
+      [{ id: "gpt-4o", displayName: "Discovered GPT-4o", effortCapability: { kind: "unsupported" } }],
+    );
+
+    expect(options).toEqual([{ id: "gpt-4o", displayName: "GPT-4o", supportedEffortLevels: ["high"], effortCapability: { kind: "unsupported" } }]);
+  });
+
+  it("handles an empty configured model and blank manual ids", () => {
+    expect(aiModelOptions({ model: "", models: [{ name: "a-model" }] }, [])).toEqual([{ id: "a-model", displayName: undefined, supportedEffortLevels: undefined, effortCapability: undefined }]);
+    expect(addConfiguredAiModel(undefined, "new-model")).toEqual([{ name: "new-model" }]);
+    expect(addConfiguredAiModel([{ name: "existing" }], "   ")).toEqual([{ name: "existing" }]);
   });
 });

--- a/apps/desktop/src/lib/ai/aiConfigList.ts
+++ b/apps/desktop/src/lib/ai/aiConfigList.ts
@@ -1,4 +1,5 @@
-import type { AiConfig, AiConfigItem } from "@/types/ai";
+import type { AiConfig, AiConfigItem, AiConfiguredModel } from "@/types/ai";
+import type { AiModelInfo } from "@/lib/backend/tauri";
 import { uuid } from "@/lib/common/utils";
 
 export type { AiConfigItem };
@@ -18,6 +19,46 @@ export function aiConfigToItem(config: AiConfig, id: string, name: string): AiCo
     id,
     name,
   };
+}
+
+/**
+ * Combines models saved by the user with models returned by a provider's
+ * discovery endpoint. Some OpenAI-compatible providers intentionally do not
+ * expose `/models`, so their saved models must remain selectable on their own.
+ */
+export function aiModelOptions(config: Pick<AiConfig, "model" | "models">, discovered: AiModelInfo[]): AiModelInfo[] {
+  const saved: AiModelInfo[] = [
+    config.model.trim() ? { id: config.model.trim() } : null,
+    ...(config.models ?? []).map((model) => ({
+      id: model.name.trim(),
+      displayName: model.label?.trim() || undefined,
+      supportedEffortLevels: model.supportedEffortLevels,
+    })),
+  ].filter((model): model is AiModelInfo => Boolean(model?.id));
+
+  const options = new Map<string, AiModelInfo>();
+  for (const model of [...saved, ...discovered]) {
+    const id = model.id.trim();
+    if (!id) continue;
+    const existing = options.get(id);
+    options.set(id, {
+      ...model,
+      id,
+      displayName: existing?.displayName ?? model.displayName,
+      supportedEffortLevels: existing?.supportedEffortLevels ?? model.supportedEffortLevels,
+      effortCapability: model.effortCapability ?? existing?.effortCapability,
+    });
+  }
+  return [...options.values()];
+}
+
+/** Add a manually entered model once while retaining its optional display metadata. */
+export function addConfiguredAiModel(models: AiConfiguredModel[] | undefined, modelId: string): AiConfiguredModel[] {
+  const id = modelId.trim();
+  if (!id) return models ?? [];
+  const existing = models ?? [];
+  if (existing.some((model) => model.name.trim() === id)) return existing;
+  return [...existing, { name: id }];
 }
 
 export type ConfigNameValidationResult = "empty" | "duplicate" | "valid";


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
## Summary

The AI model list in the assistant dialog consistently failed for providers whose model-discovery endpoint (`/models`) returns empty or errors, and manually entered ("manual") models were never persisted — they were only set as the active selection in memory, so they vanished on restart.

This PR makes the model list resilient to discovery failure by always merging saved models with discovered ones, and persists manual models through the existing config storage pipeline so they survive restarts.

## Root Cause

1. **Empty model list on discovery failure** — `getModelsForConfig` returned only `modelCatalogs.get(configId)?.models ?? []`, i.e. models discovered from the provider's `/models` endpoint. When discovery failed or returned an empty list, the dialog showed a "Failed to load models" state with no usable entries, even if the user had already saved models for that config.

2. **Manual models never saved** — `applyManualModel` only called `handleModelSelect` (which sets the active model in memory). Nothing wrote the model back to `config.models`, so it was not stored in `ai_configs.models` and disappeared after restart.

## Changes

### `apps/desktop/src/lib/ai/aiConfigList.ts`

- **`aiModelOptions(config, discovered)`** — new pure helper that combines the user's saved models (`config.model` + `config.models`) with the provider-discovered models, deduplicated by trimmed model id:
  - `displayName` / `supportedEffortLevels` prefer the saved entry (user labels win)
  - `effortCapability` prefers the discovered entry
  - So saved models remain selectable even when discovery fails or is empty.
- **`addConfiguredAiModel(models, modelId)`** — new pure helper that appends a trimmed model id to `config.models`, skipping empty ids and duplicates.

### `apps/desktop/src/components/editor/AiAssistant.vue`

- `getModelsForConfig` now resolves the config from `settings.aiConfigs` and returns `aovered)` instead of the raw catalog.
- `applyManualModel` is now async and:
  1. persists the manual model via `settings.updateAiConfigItem(configId, { models: add — verified to persist through the Rust backend into the `ai_configs.models` column,
  2. skips the redundant write when the entered id equals the config's default `model`,
  3. only then selects the model and clears the form,
  4. surfaces save failures through `toast(translateBackendError(...))`, consistent wit

### `apps/desktop/src/lib/ai/__tests__/aiConfigList.spec.ts`

Added 4 tests covering:

- saved models remain selectable when discovery returns nothing
- manual model persisted only once (trim + dedupe)
- merge precedence between saved metadata and discovered capability
- empty configured model / blank manual id edge cases

## Testing

- `vitest run` — **701 test files / 6,203 tests, all passing**
- `typecheck` (vue-tsc) — passing
- `oxlint` + `oxfmt` — clean

## Follow-up (not blocking)

- `applyManualModel` integration logic in `AiAssistant.vue` has no component-level testinto the unit-tested helpers. A component test harness for the assistant dialog could beadded later.

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="375" height="409" alt="image" src="https://github.com/user-attachments/assets/df9fe186-98f0-45e8-ab7d-d82592d2ee55" />

<img width="644" height="735" alt="image" src="https://github.com/user-attachments/assets/80bdcbe0-09d2-42ae-9ee9-8f86b8cbdeff" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #4859 
