### PR TITLE
fix(core): use is_none_or to satisfy clippy on main

### DIFF
--- a/crates/dbx-core/src/table_structure_sql/triggers.rs
+++ b/crates/dbx-core/src/table_structure_sql/triggers.rs
@@ -55,7 +55,7 @@ pub(super) fn build_trigger_sql(options: &TableStructureSqlOptions, warnings: &m
 }
 
 fn has_trigger_edit(trigger: &EditableStructureTrigger) -> bool {
-    trigger.marked_for_drop || trigger.original.as_ref().map_or(true, |original| has_trigger_change(trigger, original))
+    trigger.marked_for_drop || trigger.original.as_ref().is_none_or(|original| has_trigger_change(trigger, original))
 }
 
 fn has_trigger_change(trigger: &EditableStructureTrigger, original: &TriggerInfo) -> bool {


### PR DESCRIPTION
## Problem

`rust-fmt-clippy` currently fails on `main`, so every PR rebased onto the current tip inherits a red check:

```
error: this `map_or` can be simplified
  --> crates/dbx-core/src/table_structure_sql/triggers.rs:58:32
   |
58 |     trigger.marked_for_drop || trigger.original.as_ref().map_or(true, |original| has_trigger_change(trigger, original))
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
help: use `is_none_or` instead
```

Introduced in `cc7b2b17c` ("fix(postgresql): allow table edits with unchanged triggers"). Because `dbx-core` fails to compile under `-D warnings`, the dependent crates are never checked in that job either.

## Fix

Clippy's own suggestion — one line:

```rust
trigger.marked_for_drop || trigger.original.as_ref().is_none_or(|original| has_trigger_change(trigger, original))
```

`Option::map_or(true, f)` and `Option::is_none_or(f)` are equivalent: both yield `true` for `None` and `f(x)` for `Some(x)`. No behavior change.

## Verification

- `cargo clippy -p dbx-core --locked --all-targets --no-default-features --features "dbx-core/duckdb-sidecar,dbx-core/mq-admin,dbx-core/sqlite-sqlcipher" -- -D warnings` — clean (CI's `RUST_FAST_FEATURES` set).
- `cargo test -p dbx-core table_structure_sql` — 151 passed.
- Grepped the workspace for other `map_or(true, …)` / `map_or(false, …)` occurrences: none remain. Worth confirming explicitly, since `dbx-core` failing first meant CI never reached the dependent crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKcC15gEuQBHMidPCFFYwn