### PR TITLE
fix: 保留 SQL Server 批处理结果集

### DIFF
--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -2497,8 +2497,7 @@ pub async fn execute_query_with_max_rows(
         strip_dbx_sqlserver_row_number_column(&mut result, sql);
         Ok(result)
     } else if !sqlserver_batch_can_use_execute(sql) {
-        let mut results = execute_simple_batch_with_max_rows(client, sql, max_rows).await?;
-        Ok(results.remove(0))
+        execute_simple_batch_first_result_with_max_rows(client, sql, max_rows).await
     } else {
         let (result, messages) = capture_sqlserver_messages(sqlserver_driver_result(client.execute(sql, &[]))).await;
         let result = result?;
@@ -2624,6 +2623,22 @@ pub async fn execute_simple_batch_with_max_rows(
     Ok(results)
 }
 
+async fn execute_simple_batch_first_result_with_max_rows(
+    client: &mut SqlServerClient,
+    sql: &str,
+    max_rows: Option<usize>,
+) -> Result<QueryResult, String> {
+    let start = Instant::now();
+    let (result, messages) = capture_sqlserver_messages(async {
+        let stream = sqlserver_driver_result(client.simple_query(sql)).await?;
+        sqlserver_driver_result(collect_first_result_limited(stream, start, max_rows, &[])).await
+    })
+    .await;
+    let mut result = query_result_with_server_messages(result?, messages);
+    strip_dbx_sqlserver_row_number_column(&mut result, sql);
+    Ok(result)
+}
+
 fn strip_dbx_sqlserver_row_number_column(result: &mut QueryResult, sql: &str) {
     if !is_dbx_sqlserver_row_number_page_sql(sql) {
         return;
@@ -2664,13 +2679,18 @@ fn sqlserver_batch_can_use_execute(sql: &str) -> bool {
 }
 
 fn sqlserver_batch_may_return_result_set(sql: &str) -> bool {
-    let tokens = top_level_sqlserver_tokens(sql);
-    let starts_with_cte_dml = tokens.first().is_some_and(|token| token.text == "WITH")
-        && tokens.iter().any(|token| matches!(token.text.as_str(), "INSERT" | "UPDATE" | "DELETE" | "MERGE"))
-        && crate::sql::split_sql_statements(sql).len() == 1;
-    tokens.iter().any(|token| {
-        matches!(token.text.as_str(), "SELECT" | "EXEC" | "EXECUTE" | "TABLE")
-            || (token.text == "WITH" && !starts_with_cte_dml)
+    crate::sql::split_sql_statements(sql).iter().any(|statement| {
+        let tokens = top_level_sqlserver_tokens(statement);
+        let starts_with_dml = starts_with_executable_sql_keyword(statement, &["INSERT", "UPDATE", "DELETE", "MERGE"]);
+        if starts_with_dml {
+            return false;
+        }
+        let starts_with_cte_dml = tokens.first().is_some_and(|token| token.text == "WITH")
+            && tokens.iter().any(|token| matches!(token.text.as_str(), "INSERT" | "UPDATE" | "DELETE" | "MERGE"));
+        tokens.iter().any(|token| {
+            matches!(token.text.as_str(), "SELECT" | "EXEC" | "EXECUTE" | "TABLE")
+                || (token.text == "WITH" && !starts_with_cte_dml)
+        })
     })
 }
 
@@ -3032,6 +3052,12 @@ mod tests {
     fn sqlserver_cud_batches_use_execute_for_affected_rows() {
         assert!(sqlserver_batch_can_use_execute("UPDATE dbo.users SET active = 0 WHERE id = 1;"));
         assert!(sqlserver_batch_can_use_execute("INSERT INTO dbo.users(id) VALUES (1);"));
+        assert!(sqlserver_batch_can_use_execute(
+            "INSERT INTO dbo.user_archive(id, name) SELECT id, name FROM dbo.users WHERE active = 0;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
+            "INSERT INTO dbo.user_archive(id) SELECT id FROM dbo.users; SELECT COUNT(*) FROM dbo.user_archive;"
+        ));
         assert!(sqlserver_batch_can_use_execute("DELETE FROM dbo.users WHERE id = 1;"));
         assert!(sqlserver_batch_can_use_execute(
             "MERGE dbo.t AS t USING dbo.s AS s ON t.id = s.id WHEN MATCHED THEN UPDATE SET name = s.name;"
@@ -3183,7 +3209,13 @@ mod tests {
         let execute_query = execute_query.split("pub async fn execute_batch").next().unwrap();
 
         assert!(execute_query.contains("!sqlserver_batch_can_use_execute(sql)"));
-        assert!(execute_query.contains("execute_simple_batch_with_max_rows(client, sql, max_rows)"));
+        assert!(execute_query.contains("execute_simple_batch_first_result_with_max_rows(client, sql, max_rows)"));
+        assert!(!execute_query.contains("execute_simple_batch_with_max_rows(client, sql, max_rows)"));
+
+        let first_result = source.split("async fn execute_simple_batch_first_result_with_max_rows").nth(1).unwrap();
+        let first_result = first_result.split("fn strip_dbx_sqlserver_row_number_column").next().unwrap();
+        assert!(first_result.contains("collect_first_result_limited(stream, start, max_rows, &[])"));
+        assert!(!first_result.contains("collect_result_sets_limited"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -2496,30 +2496,9 @@ pub async fn execute_query_with_max_rows(
         let mut result = query_result_with_server_messages(result?, messages);
         strip_dbx_sqlserver_row_number_column(&mut result, sql);
         Ok(result)
-    } else if requires_simple_query_batch(sql) || contains_transaction_control(sql) {
-        let (result, messages) = capture_sqlserver_messages(async {
-            let stream = sqlserver_driver_result(client.simple_query(sql)).await?;
-            sqlserver_driver_result(collect_result_sets_limited(stream, start, max_rows)).await
-        })
-        .await;
-        let _ = result?;
-        Ok(query_result_with_server_messages(
-            QueryResult {
-                columns: vec![],
-                column_types: Vec::new(),
-                column_sortables: vec![],
-                spatial_columns: vec![],
-                spatial_values: vec![],
-                rows: vec![],
-                affected_rows: 0,
-                execution_time_ms: start.elapsed().as_millis(),
-                truncated: false,
-                session_id: None,
-                has_more: false,
-                elasticsearch_raw_body: None,
-            },
-            messages,
-        ))
+    } else if !sqlserver_batch_can_use_execute(sql) {
+        let mut results = execute_simple_batch_with_max_rows(client, sql, max_rows).await?;
+        Ok(results.remove(0))
     } else {
         let (result, messages) = capture_sqlserver_messages(sqlserver_driver_result(client.execute(sql, &[]))).await;
         let result = result?;
@@ -3146,6 +3125,9 @@ mod tests {
         assert!(!sqlserver_batch_can_use_execute("EXEC dbo.list_users;"));
         assert!(!sqlserver_batch_can_use_execute("DECLARE @id INT = 1; EXEC dbo.list_users @id;"));
         assert!(!sqlserver_batch_can_use_execute(
+            "SET NOCOUNT OFF; DECLARE @rows TABLE (id INT); INSERT INTO @rows VALUES (1), (2); SELECT id FROM @rows;"
+        ));
+        assert!(!sqlserver_batch_can_use_execute(
             "DECLARE @id INT = 1; CREATE TABLE #t(id INT); INSERT INTO #t VALUES (@id); SELECT id FROM #t;"
         ));
         assert!(!sqlserver_batch_can_use_execute("WITH cte AS (SELECT 1 AS id) SELECT * FROM cte;"));
@@ -3192,6 +3174,16 @@ mod tests {
 
         assert!(execute_query.contains("sqlserver_dml_output_returns_rows(sql)"));
         assert!(execute_query.contains("client.query(query.sql.as_str(), &[])"));
+    }
+
+    #[test]
+    fn sqlserver_single_result_entrypoint_keeps_result_returning_batches() {
+        let source = include_str!("sqlserver.rs");
+        let execute_query = source.split("pub async fn execute_query_with_max_rows").nth(1).unwrap();
+        let execute_query = execute_query.split("pub async fn execute_batch").next().unwrap();
+
+        assert!(execute_query.contains("!sqlserver_batch_can_use_execute(sql)"));
+        assert!(execute_query.contains("execute_simple_batch_with_max_rows(client, sql, max_rows)"));
     }
 
     #[test]

--- a/crates/dbx-core/tests/sqlserver_batch_results.rs
+++ b/crates/dbx-core/tests/sqlserver_batch_results.rs
@@ -1,24 +1,20 @@
 use dbx_core::db::sqlserver;
 use std::time::Duration;
 
-#[tokio::test]
-#[ignore = "requires DBX_TEST_SQLSERVER_HOST and DBX_TEST_SQLSERVER_PASSWORD"]
-async fn sqlserver_query_keeps_result_set_after_batch_setup_statements() {
+async fn connect_sqlserver() -> sqlserver::SqlServerClient {
     let host = std::env::var("DBX_TEST_SQLSERVER_HOST").expect("DBX_TEST_SQLSERVER_HOST");
     let port = std::env::var("DBX_TEST_SQLSERVER_PORT").ok().and_then(|value| value.parse().ok()).unwrap_or(1433);
     let user = std::env::var("DBX_TEST_SQLSERVER_USER").unwrap_or_else(|_| "sa".to_string());
     let password = std::env::var("DBX_TEST_SQLSERVER_PASSWORD").expect("DBX_TEST_SQLSERVER_PASSWORD");
-    let mut client = sqlserver::connect_with_port_explicit(
-        &host,
-        port,
-        true,
-        &user,
-        &password,
-        Some("master"),
-        Duration::from_secs(15),
-    )
-    .await
-    .expect("connect to SQL Server");
+    sqlserver::connect_with_port_explicit(&host, port, true, &user, &password, Some("master"), Duration::from_secs(15))
+        .await
+        .expect("connect to SQL Server")
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_TEST_SQLSERVER_HOST and DBX_TEST_SQLSERVER_PASSWORD"]
+async fn sqlserver_query_keeps_result_set_after_batch_setup_statements() {
+    let mut client = connect_sqlserver().await;
 
     let sql = "SET NOCOUNT OFF; \
                DECLARE @rows TABLE (id INT, label NVARCHAR(20)); \
@@ -39,4 +35,39 @@ async fn sqlserver_query_keeps_result_set_after_batch_setup_statements() {
         .expect("execute limited result-returning batch");
     assert_eq!(limited.rows.len(), 1);
     assert!(limited.truncated);
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_TEST_SQLSERVER_HOST and DBX_TEST_SQLSERVER_PASSWORD"]
+async fn sqlserver_insert_select_reports_affected_rows() {
+    let mut client = connect_sqlserver().await;
+    let sql = "DECLARE @target TABLE (id INT); \
+               INSERT INTO @target(id) SELECT id FROM (VALUES (1), (2), (3)) AS source(id);";
+
+    let result = sqlserver::execute_query(&mut client, sql).await.expect("execute INSERT SELECT batch");
+
+    assert_eq!(result.affected_rows, 3);
+    assert!(result.columns.is_empty());
+    assert!(result.rows.is_empty());
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_TEST_SQLSERVER_HOST and DBX_TEST_SQLSERVER_PASSWORD"]
+async fn sqlserver_single_result_query_drains_later_results() {
+    let mut client = connect_sqlserver().await;
+    let sql = "SELECT CAST(1 AS INT) AS retained; \
+               SELECT TOP (10000) object_id AS discarded FROM sys.all_objects ORDER BY object_id;";
+
+    let result =
+        sqlserver::execute_query_with_max_rows(&mut client, sql, Some(1)).await.expect("execute multi-result query");
+
+    assert_eq!(result.columns, vec!["retained"]);
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0][0].as_i64(), Some(1));
+    assert!(!result.truncated);
+
+    let follow_up = sqlserver::execute_query(&mut client, "SELECT CAST(2 AS INT) AS value")
+        .await
+        .expect("execute query after draining later results");
+    assert_eq!(follow_up.rows[0][0].as_i64(), Some(2));
 }

--- a/crates/dbx-core/tests/sqlserver_batch_results.rs
+++ b/crates/dbx-core/tests/sqlserver_batch_results.rs
@@ -1,0 +1,42 @@
+use dbx_core::db::sqlserver;
+use std::time::Duration;
+
+#[tokio::test]
+#[ignore = "requires DBX_TEST_SQLSERVER_HOST and DBX_TEST_SQLSERVER_PASSWORD"]
+async fn sqlserver_query_keeps_result_set_after_batch_setup_statements() {
+    let host = std::env::var("DBX_TEST_SQLSERVER_HOST").expect("DBX_TEST_SQLSERVER_HOST");
+    let port = std::env::var("DBX_TEST_SQLSERVER_PORT").ok().and_then(|value| value.parse().ok()).unwrap_or(1433);
+    let user = std::env::var("DBX_TEST_SQLSERVER_USER").unwrap_or_else(|_| "sa".to_string());
+    let password = std::env::var("DBX_TEST_SQLSERVER_PASSWORD").expect("DBX_TEST_SQLSERVER_PASSWORD");
+    let mut client = sqlserver::connect_with_port_explicit(
+        &host,
+        port,
+        true,
+        &user,
+        &password,
+        Some("master"),
+        Duration::from_secs(15),
+    )
+    .await
+    .expect("connect to SQL Server");
+
+    let sql = "SET NOCOUNT OFF; \
+               DECLARE @rows TABLE (id INT, label NVARCHAR(20)); \
+               INSERT INTO @rows VALUES (1, N'first'), (2, N'second'); \
+               SELECT id, label FROM @rows ORDER BY id;";
+    let result = sqlserver::execute_query_with_max_rows(&mut client, sql, Some(100))
+        .await
+        .expect("execute result-returning batch");
+
+    assert_eq!(result.columns, vec!["id", "label"]);
+    assert_eq!(result.rows.len(), 2);
+    assert_eq!(result.rows[0][0].as_i64(), Some(1));
+    assert_eq!(result.rows[1][1].as_str(), Some("second"));
+    assert!(!result.truncated);
+
+    let limited = sqlserver::execute_query_with_max_rows(&mut client, sql, Some(1))
+        .await
+        .expect("execute limited result-returning batch");
+    assert_eq!(limited.rows.len(), 1);
+    assert!(limited.truncated);
+}


### PR DESCRIPTION
## 问题

SQL Server 批处理以 `SET`、`DECLARE` 等准备语句开头、后续再执行 `SELECT` 时，单查询入口没有复用已有的批处理结果集判定，而是走 `Client::execute`。该路径只汇总 affected rows，不读取 TDS 结果集，因此批处理执行成功后只显示执行信息。

## 修复

- 单查询入口统一使用 `sqlserver_batch_can_use_execute` 判断是否可走纯执行路径。
- 可能返回结果集的批处理复用现有 `execute_simple_batch_with_max_rows`，返回首个结果集。
- 纯 DML 继续使用原路径统计 affected rows；分页上限、截断状态和 SQL Server 消息处理保持现有行为。
- 增加分流单测和真实 SQL Server 集成测试。

## 验证

- 最新 `main` + 真实 SQL Server：`SET NOCOUNT OFF; DECLARE ...; INSERT ...; SELECT ...` 经 `/api/query/execute` 返回空列、空行和 `affected_rows: 4`，稳定复现。
- 修复分支同一真实库、同一 API 请求：返回 `batch_value` 列以及 `1`、`2` 两行。
- 真实库集成测试同时验证 `maxRows=1` 时只返回一行且 `truncated=true`。
- SQL Server 模块单测：90 passed，4 ignored。
- `cargo fmt --check --all`、`cargo clippy -p dbx-core --lib --tests -- -D warnings`、`git diff --check` 通过。

Fixes #4371