### PR TITLE
fix(clickhouse): 只读账号无法查询（max_result_rows READONLY）

### DIFF
--- a/crates/dbx-core/src/db/clickhouse_driver.rs
+++ b/crates/dbx-core/src/db/clickhouse_driver.rs
@@ -1,6 +1,7 @@
 use futures::StreamExt;
 use reqwest::{Certificate, Client as HttpClient};
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::fs;
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -119,11 +120,6 @@ struct ChColumn {
     _type: String,
 }
 
-enum QueryResultLimit {
-    Unlimited,
-    Limited(usize),
-}
-
 enum QueryResultFormat {
     JsonCompact,
     JsonCompactEachRowWithNamesAndTypes,
@@ -146,28 +142,19 @@ pub enum ClickHouseQueryStreamItem {
     Row(Vec<serde_json::Value>),
 }
 
-fn build_query_url(
-    base_url: &str,
-    database: Option<&str>,
-    limit: QueryResultLimit,
-    extra_params: Option<&str>,
-) -> String {
-    build_query_url_with_format(base_url, database, limit, QueryResultFormat::JsonCompact, extra_params)
+fn build_query_url(base_url: &str, database: Option<&str>, extra_params: Option<&str>) -> String {
+    build_query_url_with_format(base_url, database, QueryResultFormat::JsonCompact, extra_params)
 }
 
 fn build_query_url_with_format(
     base_url: &str,
     database: Option<&str>,
-    limit: QueryResultLimit,
     format: QueryResultFormat,
     extra_params: Option<&str>,
 ) -> String {
     let mut url = format!("{}/?default_format={}", base_url, format.as_str());
     if let Some(db) = database {
         url.push_str(&format!("&database={db}"));
-    }
-    if let QueryResultLimit::Limited(max_rows) = limit {
-        url.push_str(&format!("&max_result_rows={max_rows}&result_overflow_mode=break"));
     }
     // 用户自定义 URL 参数放在最后追加，允许其覆盖前面的默认设置（ClickHouse 取同名参数的最后一个值）
     if let Some(params) = normalize_extra_params(extra_params) {
@@ -274,16 +261,7 @@ fn build_request(client: &ChClient, req: reqwest::RequestBuilder) -> reqwest::Re
 }
 
 async fn ch_query(client: &ChClient, sql: &str, database: Option<&str>) -> Result<ChJsonResult, String> {
-    ch_query_with_limit(client, sql, database, QueryResultLimit::Unlimited).await
-}
-
-async fn ch_query_with_limit(
-    client: &ChClient,
-    sql: &str,
-    database: Option<&str>,
-    limit: QueryResultLimit,
-) -> Result<ChJsonResult, String> {
-    let url = build_query_url(&client.base_url, database, limit, client.extra_params.as_deref());
+    let url = build_query_url(&client.base_url, database, client.extra_params.as_deref());
     log::info!("[clickhouse] query url={url} user={:?} has_pass={}", client.username, client.password.is_some());
     let req = build_request(client, client.http.post(&url).body(sql.to_string()));
     let resp = req.send().await.map_err(|e| format!("ClickHouse request failed: {e}"))?;
@@ -305,11 +283,9 @@ pub async fn stream_query_with_max_rows(
     mut on_item: impl FnMut(ClickHouseQueryStreamItem) -> Result<(), String>,
 ) -> Result<(), String> {
     let max_rows = max_rows.map(|max_rows| max_rows.max(1));
-    let limit = max_rows.map(QueryResultLimit::Limited).unwrap_or(QueryResultLimit::Unlimited);
     let url = build_query_url_with_format(
         &client.base_url,
         Some(database),
-        limit,
         QueryResultFormat::JsonCompactEachRowWithNamesAndTypes,
         client.extra_params.as_deref(),
     );
@@ -637,15 +613,22 @@ pub async fn execute_query_with_max_rows(
     let row_limit = query_result_row_limit(max_rows);
 
     if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH"]) {
-        let result = ch_query_with_limit(client, sql, Some(database), QueryResultLimit::Limited(row_limit + 1)).await?;
+        // 只读账号无法修改 `max_result_rows` / `result_overflow_mode` 等 setting
+        // （会报 READONLY: Cannot modify ... in readonly mode），因此不再通过 URL query
+        // 参数施加服务端行数限制。
+        // 对于支持 `LIMIT` 子句的语句（SELECT / WITH），改写 SQL 注入 `LIMIT` 限制返回行数，
+        // 多取一行作为「是否还有更多数据」的探针，再由 `limited_query_result` 截断；
+        // SHOW/DESCRIBE/EXPLAIN 等元数据查询结果集很小，不追加 LIMIT，直接依赖客户端截断。
+        let can_append_limit = starts_with_executable_sql_keyword(sql, &["SELECT", "WITH"]);
+        let limited_sql = if can_append_limit {
+           Cow::Owned(format!("{sql} LIMIT {}", row_limit + 1))
+        } else {
+           Cow::Borrowed(sql)
+        };
+        let result = ch_query(client, &limited_sql, Some(database)).await?;
         Ok(limited_query_result(result, start.elapsed().as_millis(), Some(row_limit)))
     } else {
-        let url = build_query_url(
-            &client.base_url,
-            Some(database),
-            QueryResultLimit::Unlimited,
-            client.extra_params.as_deref(),
-        );
+        let url = build_query_url(&client.base_url, Some(database), client.extra_params.as_deref());
         let req = build_request(client, client.http.post(&url).body(sql.to_string()));
         let resp = req.send().await.map_err(|e| format!("ClickHouse request failed: {e}"))?;
         if !resp.status().is_success() {
@@ -672,46 +655,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn query_url_for_result_sets_adds_row_limit_break_settings() {
-        let url = build_query_url(
-            "http://localhost:8123",
-            Some("analytics"),
-            QueryResultLimit::Limited(crate::query::MAX_ROWS + 1),
-            None,
-        );
-
-        assert_eq!(
-            url,
-            "http://localhost:8123/?default_format=JSONCompact&database=analytics&max_result_rows=10001&result_overflow_mode=break"
-        );
+    fn query_url_does_not_send_server_side_row_limit_settings() {
+        // 只读账号无法修改 max_result_rows / result_overflow_mode（见 #5178），
+        // 因此 URL 不应再包含这些 setting 参数；行数限制改由 SQL LIMIT / 客户端截断完成。
+        let url = build_query_url("http://localhost:8123", Some("analytics"), None);
+        assert_eq!(url, "http://localhost:8123/?default_format=JSONCompact&database=analytics");
+        assert!(!url.contains("max_result_rows"));
+        assert!(!url.contains("result_overflow_mode"));
     }
 
     #[test]
     fn query_url_appends_custom_url_params() {
         // 用户在「URL 参数」填 dialect_type=ANSI，应追加到 query string 末尾
-        let url = build_query_url(
-            "http://localhost:8123",
-            Some("analytics"),
-            QueryResultLimit::Unlimited,
-            Some("dialect_type=ANSI"),
-        );
-
+        let url = build_query_url("http://localhost:8123", Some("analytics"), Some("dialect_type=ANSI"));
         assert_eq!(url, "http://localhost:8123/?default_format=JSONCompact&database=analytics&dialect_type=ANSI");
     }
 
     #[test]
     fn query_url_normalizes_leading_symbols_and_ignores_blank_params() {
         // 允许用户带上开头的 ? 或 &，也允许多个参数
-        let url = build_query_url(
-            "http://localhost:8123",
-            None,
-            QueryResultLimit::Unlimited,
-            Some("?dialect_type=ANSI&max_threads=8"),
-        );
+        let url = build_query_url("http://localhost:8123", None, Some("?dialect_type=ANSI&max_threads=8"));
         assert_eq!(url, "http://localhost:8123/?default_format=JSONCompact&dialect_type=ANSI&max_threads=8");
 
         // 空白参数不产生多余的 &
-        let url = build_query_url("http://localhost:8123", None, QueryResultLimit::Unlimited, Some("   "));
+        let url = build_query_url("http://localhost:8123", None, Some("   "));
         assert_eq!(url, "http://localhost:8123/?default_format=JSONCompact");
     }
 
@@ -720,14 +687,13 @@ mod tests {
         let url = build_query_url_with_format(
             "http://localhost:8123",
             Some("analytics"),
-            QueryResultLimit::Limited(500),
             QueryResultFormat::JsonCompactEachRowWithNamesAndTypes,
             None,
         );
 
         assert_eq!(
             url,
-            "http://localhost:8123/?default_format=JSONCompactEachRowWithNamesAndTypes&database=analytics&max_result_rows=500&result_overflow_mode=break"
+            "http://localhost:8123/?default_format=JSONCompactEachRowWithNamesAndTypes&database=analytics"
         );
     }
 

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-07-31T19:11:03.244Z",
-  "stars": 12837,
+  "generatedAt": "2026-08-01T18:56:56.227Z",
+  "stars": 12911,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2699,
+      "commits": 2730,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-07-30T18:31:46.370Z",
-  "stars": 12586,
+  "generatedAt": "2026-07-31T19:11:03.244Z",
+  "stars": 12837,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2666,
+      "commits": 2699,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 414,
-      "mergedPullRequests": 414,
+      "commits": 423,
+      "mergedPullRequests": 423,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-07-30T18:05:37Z"
+      "latestContributionAt": "2026-07-31T11:33:44Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 112,
-      "mergedPullRequests": 111,
+      "commits": 116,
+      "mergedPullRequests": 115,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-07-30T17:06:03Z"
+      "latestContributionAt": "2026-07-31T15:11:48Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 70,
-      "mergedPullRequests": 58,
+      "commits": 72,
+      "mergedPullRequests": 60,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-07-30T10:41:56Z"
+      "latestContributionAt": "2026-07-31T13:17:58Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 41,
-      "mergedPullRequests": 41,
+      "commits": 43,
+      "mergedPullRequests": 43,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-07-30T08:49:15Z"
+      "latestContributionAt": "2026-07-31T10:26:43Z"
     },
     {
       "login": "Illuminated2020",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 35,
-      "mergedPullRequests": 33,
+      "commits": 36,
+      "mergedPullRequests": 34,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-07-29T14:53:34Z"
+      "latestContributionAt": "2026-07-31T17:17:50Z"
     },
     {
       "login": "lexmin0412",
@@ -112,6 +112,15 @@
       "latestContributionAt": "2026-07-10T10:15:25Z"
     },
     {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 25,
+      "mergedPullRequests": 25,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-07-31T08:27:06Z"
+    },
+    {
       "login": "rarnu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/209014?v=4",
       "profileUrl": "https://github.com/rarnu",
@@ -128,15 +137,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-26T03:29:22Z",
       "latestContributionAt": "2026-07-16T17:17:49Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 22,
-      "mergedPullRequests": 22,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-07-29T10:43:32Z"
     },
     {
       "login": "ptma",
@@ -184,6 +184,15 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-07-31T17:39:19Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -191,15 +200,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-17T03:22:35Z",
       "latestContributionAt": "2026-07-20T08:54:52Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 12,
-      "mergedPullRequests": 12,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-07-30T10:18:43Z"
     },
     {
       "login": "haipengno1",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-07-31T14:31:51Z"
+    },
+    {
       "login": "chenhbb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
       "profileUrl": "https://github.com/chenhbb",
@@ -256,13 +265,13 @@
       "latestContributionAt": "2026-07-30T13:10:20Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-07-30T10:40:12Z"
+      "login": "guoyongchang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
+      "profileUrl": "https://github.com/guoyongchang",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-30T02:45:51Z",
+      "latestContributionAt": "2026-07-31T13:22:32Z"
     },
     {
       "login": "czs208112",
@@ -272,6 +281,15 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-18T17:32:18Z",
       "latestContributionAt": "2026-07-29T16:27:55Z"
+    },
+    {
+      "login": "tianyifeng-druid",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
+      "profileUrl": "https://github.com/tianyifeng-druid",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-06-21T01:57:56Z",
+      "latestContributionAt": "2026-07-31T08:23:56Z"
     },
     {
       "login": "xKrah",
@@ -310,15 +328,6 @@
       "latestContributionAt": "2026-07-01T11:05:45Z"
     },
     {
-      "login": "tianyifeng-druid",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
-      "profileUrl": "https://github.com/tianyifeng-druid",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-06-21T01:57:56Z",
-      "latestContributionAt": "2026-07-29T14:37:05Z"
-    },
-    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -344,15 +353,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-01T08:26:41Z",
       "latestContributionAt": "2026-06-30T17:35:07Z"
-    },
-    {
-      "login": "guoyongchang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
-      "profileUrl": "https://github.com/guoyongchang",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-30T02:45:51Z",
-      "latestContributionAt": "2026-07-30T15:03:49Z"
     },
     {
       "login": "wang-zhengxin",
@@ -391,6 +391,15 @@
       "latestContributionAt": "2026-06-26T09:45:45Z"
     },
     {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-07-31T16:19:04Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -407,6 +416,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-21T12:32:56Z",
       "latestContributionAt": "2026-07-27T08:11:54Z"
+    },
+    {
+      "login": "Staroon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26004564?v=4",
+      "profileUrl": "https://github.com/Staroon",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-22T04:43:40Z",
+      "latestContributionAt": "2026-07-31T05:54:26Z"
     },
     {
       "login": "wbean",
@@ -481,15 +499,6 @@
       "latestContributionAt": "2026-06-25T04:51:02Z"
     },
     {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-07-28T17:05:24Z"
-    },
-    {
       "login": "James-Leong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
       "profileUrl": "https://github.com/James-Leong",
@@ -524,15 +533,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-05T10:39:05Z",
       "latestContributionAt": "2026-07-29T12:48:40Z"
-    },
-    {
-      "login": "Staroon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/26004564?v=4",
-      "profileUrl": "https://github.com/Staroon",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-22T04:43:40Z",
-      "latestContributionAt": "2026-07-25T00:47:51Z"
     },
     {
       "login": "vergil-lai",
@@ -607,6 +607,15 @@
       "latestContributionAt": "2026-06-20T16:04:52Z"
     },
     {
+      "login": "cwatanab",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10162172?v=4",
+      "profileUrl": "https://github.com/cwatanab",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-06-15T09:19:19Z",
+      "latestContributionAt": "2026-07-31T08:24:13Z"
+    },
+    {
       "login": "Doracoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9206272?v=4",
       "profileUrl": "https://github.com/Doracoin",
@@ -616,6 +625,15 @@
       "latestContributionAt": "2026-06-11T09:29:40Z"
     },
     {
+      "login": "encyc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62669951?v=4",
+      "profileUrl": "https://github.com/encyc",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-29T06:54:05Z",
+      "latestContributionAt": "2026-07-31T06:38:50Z"
+    },
+    {
       "login": "funnytime75",
       "avatarUrl": "https://avatars.githubusercontent.com/u/162818986?v=4",
       "profileUrl": "https://github.com/funnytime75",
@@ -623,6 +641,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T08:35:12Z",
       "latestContributionAt": "2026-06-30T01:14:44Z"
+    },
+    {
+      "login": "gadfly3173",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28685179?v=4",
+      "profileUrl": "https://github.com/gadfly3173",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-28T10:07:29Z",
+      "latestContributionAt": "2026-07-31T03:36:43Z"
     },
     {
       "login": "greathaoqi",
@@ -787,6 +814,15 @@
       "latestContributionAt": "2026-07-29T10:42:44Z"
     },
     {
+      "login": "yanguibao1997",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39548181?v=4",
+      "profileUrl": "https://github.com/yanguibao1997",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-29T06:58:27Z",
+      "latestContributionAt": "2026-07-31T08:27:37Z"
+    },
+    {
       "login": "Mukesh-234234",
       "avatarUrl": "https://avatars.githubusercontent.com/u/281438489?v=4",
       "profileUrl": "https://github.com/Mukesh-234234",
@@ -803,6 +839,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-28T08:46:06Z",
       "latestContributionAt": "2026-05-28T09:59:00Z"
+    },
+    {
+      "login": "Aealen",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/55618346?v=4",
+      "profileUrl": "https://github.com/Aealen",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-31T04:41:31Z",
+      "latestContributionAt": "2026-07-31T08:24:30Z"
     },
     {
       "login": "andremacola",
@@ -904,15 +949,6 @@
       "latestContributionAt": "2026-07-17T10:51:34Z"
     },
     {
-      "login": "cwatanab",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10162172?v=4",
-      "profileUrl": "https://github.com/cwatanab",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-06-15T09:19:19Z",
-      "latestContributionAt": "2026-06-15T09:27:06Z"
-    },
-    {
       "login": "d0zingcat",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8235790?v=4",
       "profileUrl": "https://github.com/d0zingcat",
@@ -920,6 +956,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-02T07:45:55Z",
       "latestContributionAt": "2026-07-02T08:37:21Z"
+    },
+    {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-07-31T06:55:23Z"
     },
     {
       "login": "digyear",
@@ -949,13 +994,13 @@
       "latestContributionAt": "2026-07-08T10:53:49Z"
     },
     {
-      "login": "encyc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62669951?v=4",
-      "profileUrl": "https://github.com/encyc",
+      "login": "ekesaiting",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36790768?v=4",
+      "profileUrl": "https://github.com/ekesaiting",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-29T06:54:05Z",
-      "latestContributionAt": "2026-07-29T11:21:57Z"
+      "firstContributionAt": "2026-07-31T16:18:14Z",
+      "latestContributionAt": "2026-07-31T18:19:11Z"
     },
     {
       "login": "eninem123",
@@ -967,6 +1012,15 @@
       "latestContributionAt": "2026-07-09T08:39:06Z"
     },
     {
+      "login": "EuanTop",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/194128472?v=4",
+      "profileUrl": "https://github.com/EuanTop",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-31T06:57:15Z",
+      "latestContributionAt": "2026-07-31T08:22:42Z"
+    },
+    {
       "login": "faithererer",
       "avatarUrl": "https://avatars.githubusercontent.com/u/104252444?v=4",
       "profileUrl": "https://github.com/faithererer",
@@ -974,15 +1028,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-05T11:00:04Z",
       "latestContributionAt": "2026-07-05T11:38:51Z"
-    },
-    {
-      "login": "gadfly3173",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28685179?v=4",
-      "profileUrl": "https://github.com/gadfly3173",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-28T10:07:29Z",
-      "latestContributionAt": "2026-07-28T13:36:56Z"
     },
     {
       "login": "gdzhu8023",
@@ -1255,6 +1300,15 @@
       "latestContributionAt": "2026-06-07T18:07:00Z"
     },
     {
+      "login": "rihkddd",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
+      "profileUrl": "https://github.com/rihkddd",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-30T13:25:21Z",
+      "latestContributionAt": "2026-07-30T19:09:19Z"
+    },
+    {
       "login": "shenmo7192",
       "avatarUrl": "https://avatars.githubusercontent.com/u/47873776?v=4",
       "profileUrl": "https://github.com/shenmo7192",
@@ -1363,6 +1417,15 @@
       "latestContributionAt": "2026-06-17T14:06:33Z"
     },
     {
+      "login": "xEdenx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7685451?v=4",
+      "profileUrl": "https://github.com/xEdenx",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-31T07:13:20Z",
+      "latestContributionAt": "2026-07-31T08:49:40Z"
+    },
+    {
       "login": "xiaoliangL",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29444559?v=4",
       "profileUrl": "https://github.com/xiaoliangL",
@@ -1379,15 +1442,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-27T13:49:30Z",
       "latestContributionAt": "2026-07-28T19:18:06Z"
-    },
-    {
-      "login": "yanguibao1997",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39548181?v=4",
-      "profileUrl": "https://github.com/yanguibao1997",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-29T06:58:27Z",
-      "latestContributionAt": "2026-07-29T13:27:37Z"
     },
     {
       "login": "YangYuS8",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-01T18:56:56.227Z",
-  "stars": 12911,
+  "generatedAt": "2026-08-02T18:58:08.401Z",
+  "stars": 12970,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2730,
+      "commits": 2751,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 423,
-      "mergedPullRequests": 423,
+      "commits": 433,
+      "mergedPullRequests": 433,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-07-31T11:33:44Z"
+      "latestContributionAt": "2026-08-02T11:09:23Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 116,
-      "mergedPullRequests": 115,
+      "commits": 120,
+      "mergedPullRequests": 119,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-07-31T15:11:48Z"
+      "latestContributionAt": "2026-08-02T08:34:14Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 72,
-      "mergedPullRequests": 60,
+      "commits": 76,
+      "mergedPullRequests": 64,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-07-31T13:17:58Z"
+      "latestContributionAt": "2026-08-02T14:46:13Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 43,
-      "mergedPullRequests": 43,
+      "commits": 44,
+      "mergedPullRequests": 44,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-07-31T10:26:43Z"
+      "latestContributionAt": "2026-08-02T14:45:33Z"
     },
     {
       "login": "Illuminated2020",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 36,
-      "mergedPullRequests": 34,
+      "commits": 37,
+      "mergedPullRequests": 35,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-07-31T17:17:50Z"
+      "latestContributionAt": "2026-08-02T08:37:46Z"
     },
     {
       "login": "lexmin0412",
@@ -187,10 +187,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 13,
-      "mergedPullRequests": 13,
+      "commits": 14,
+      "mergedPullRequests": 14,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-07-31T17:39:19Z"
+      "latestContributionAt": "2026-08-02T01:02:01Z"
     },
     {
       "login": "SpencerZhang",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
+      "login": "chenhbb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
+      "profileUrl": "https://github.com/chenhbb",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-06-20T07:06:56Z",
+      "latestContributionAt": "2026-08-02T01:04:30Z"
+    },
+    {
       "login": "amwps290",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
       "profileUrl": "https://github.com/amwps290",
@@ -245,15 +254,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-07-21T05:32:24Z",
       "latestContributionAt": "2026-07-31T14:31:51Z"
-    },
-    {
-      "login": "chenhbb",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
-      "profileUrl": "https://github.com/chenhbb",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-06-20T07:06:56Z",
-      "latestContributionAt": "2026-06-29T18:45:22Z"
     },
     {
       "login": "dienaso",
@@ -355,6 +355,15 @@
       "latestContributionAt": "2026-06-30T17:35:07Z"
     },
     {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-02T08:34:50Z"
+    },
+    {
       "login": "wang-zhengxin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
       "profileUrl": "https://github.com/wang-zhengxin",
@@ -382,6 +391,15 @@
       "latestContributionAt": "2026-06-29T03:16:38Z"
     },
     {
+      "login": "CSXFanMeng",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
+      "profileUrl": "https://github.com/CSXFanMeng",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-02T10:52:18Z",
+      "latestContributionAt": "2026-08-02T11:35:45Z"
+    },
+    {
       "login": "Dreamescaper",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17177729?v=4",
       "profileUrl": "https://github.com/Dreamescaper",
@@ -389,15 +407,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-09T07:54:46Z",
       "latestContributionAt": "2026-06-26T09:45:45Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-07-31T16:19:04Z"
     },
     {
       "login": "jeeinn",
@@ -479,15 +488,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-24T07:06:09Z",
       "latestContributionAt": "2026-07-30T10:19:40Z"
-    },
-    {
-      "login": "CSXFanMeng",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
-      "profileUrl": "https://github.com/CSXFanMeng",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-02T10:52:18Z",
-      "latestContributionAt": "2026-07-19T02:32:34Z"
     },
     {
       "login": "echocde",
@@ -713,6 +713,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-13T12:34:22Z",
       "latestContributionAt": "2026-06-17T18:01:01Z"
+    },
+    {
+      "login": "lizujie",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18705063?v=4",
+      "profileUrl": "https://github.com/lizujie",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-29T04:57:31Z",
+      "latestContributionAt": "2026-08-02T08:35:04Z"
     },
     {
       "login": "onlyc0302",
@@ -1190,15 +1199,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-17T14:08:31Z",
       "latestContributionAt": "2026-06-17T14:12:59Z"
-    },
-    {
-      "login": "lizujie",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18705063?v=4",
-      "profileUrl": "https://github.com/lizujie",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-29T04:57:31Z",
-      "latestContributionAt": "2026-07-29T16:58:41Z"
     },
     {
       "login": "LSvKing",


### PR DESCRIPTION
## 关联 Issue

Closes #5178

## 问题

ClickHouse 只读账号（`readonly=1/2`）执行任何带行数限制的查询都会失败：

```
ClickHouse error: Code: 164. DB::Exception: Cannot modify 'max_result_rows' setting in readonly mode. (READONLY)
```

根因在 `clickhouse_driver.rs` 的 `build_query_url_with_format`：当设置了行数限制（`QueryResultLimit::Limited`）时，会在 URL query string 上追加两个 ClickHouse **setting**：

```
&max_result_rows={max_rows}&result_overflow_mode=break
```

而 `max_result_rows` / `result_overflow_mode` 在 ClickHouse 中属于「只读模式下不可修改」的 setting，只读账号一旦收到这两个参数就会报 Code 164，导致普通查询、数据传输、流式导出三条路径**全部不可用**。

影响入口：
- `execute_query_with_max_rows`（普通查询 / 数据传输，clickhouse_driver.rs）
- `stream_query_with_max_rows`（流式导出，经 `query_result_export.rs` 调用）

## 思路（方案 A）

核心观察：**这两条路径本来就已经有客户端侧的行数限制，服务端那两个参数其实是冗余的。**

- 流式路径（`stream_query_with_max_rows`）：本就用 `rows_seen` 在客户端计数，到达 `max_rows` 时通过哨兵错误 `CLICKHOUSE_STREAM_ROW_LIMIT_REACHED` 主动断流，从不依赖服务端截断。
- 结果集路径（`execute_query_with_max_rows`）：本就用「取 `row_limit + 1` 行探针 + `limited_query_result` 客户端截断」判断 `truncated`。

因此方案 A 直接移除服务端那两个 setting，并保留各路径已有的客户端限制逻辑：

1. `build_query_url` / `build_query_url_with_format` 去掉 `limit` 参数，URL 不再追加 `max_result_rows` / `result_overflow_mode`。顺带删除因此变成 dead code 的 `QueryResultLimit` 枚举与 `ch_query_with_limit`（合并回 `ch_query`）。
2. 流式路径：删掉 `limit` 计算，其余客户端计数逻辑不变。
3. 结果集路径：为避免「无服务端限制 → 超大结果集全量进内存」的回归，把行数限制改写到 SQL 上——对支持 `LIMIT` 子句的 `SELECT` / `WITH` 追加 `LIMIT row_limit + 1`（`LIMIT` 是查询子句，不是 setting，只读账号完全可用），多取的那一行继续作为「是否还有更多数据」的探针；`SHOW` / `DESCRIBE` / `EXPLAIN` 这类元数据查询本身结果集很小且不接受 `LIMIT`，保持原样，直接交给 `limited_query_result` 客户端截断。

## 验证

- `cargo test -p dbx-core --lib -- clickhouse_driver` → 12 passed。
- 更新了 URL 构造相关单测：原断言「URL 含 `max_result_rows` / `result_overflow_mode`」改为断言「URL **不**含」这两个参数。

## 兼容性

- 普通账号：行为不变（结果集行数依然被限制，只是限制从「服务端 setting」改为「SQL LIMIT + 客户端截断」）。
- 只读账号：从「完全无法查询」恢复为正常可用。