### PR TITLE
优化 Kingbase 表结构读取，避免重复探测缺失字段

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -539,8 +539,10 @@ func isUndefinedColumn(err error, columnName string) bool {
 }
 
 func (s *server) informationSchemaColumns(schema, table string, primary map[string]bool) ([]columnInfo, error) {
-	includeColumnType := true
-	includeUdtName := true
+	// Cache the optional information_schema capabilities for this connection so
+	// subsequent table metadata requests do not repeat known failing probes.
+	includeColumnType := !s.infoColumnTypeUnsupported
+	includeUdtName := !s.infoUdtNameUnsupported
 	for {
 		result, err := s.queryInformationSchemaColumns(schema, table, primary, includeColumnType, includeUdtName)
 		if err == nil {
@@ -549,8 +551,10 @@ func (s *server) informationSchemaColumns(schema, table string, primary map[stri
 		switch {
 		case includeColumnType && isUndefinedColumn(err, "column_type"):
 			includeColumnType = false
+			s.infoColumnTypeUnsupported = true
 		case includeUdtName && isUndefinedColumn(err, "udt_name"):
 			includeUdtName = false
+			s.infoUdtNameUnsupported = true
 		default:
 			return nil, err
 		}

--- a/agents/drivers/kingbase-go/main.go
+++ b/agents/drivers/kingbase-go/main.go
@@ -135,6 +135,8 @@ type server struct {
 	mode                       kingbaseMode
 	usePgDefaultExpression     bool
 	catalogIdentityUnsupported bool
+	infoColumnTypeUnsupported  bool
+	infoUdtNameUnsupported     bool
 	currentSchema              string
 	schemaSet                  bool
 	sessions                   map[string]*querySession
@@ -455,6 +457,8 @@ func (s *server) connect(cp connectParams) error {
 	s.mode = detectKingbaseMode(db, cp.MySQLCompatMode)
 	s.usePgDefaultExpression = false
 	s.catalogIdentityUnsupported = false
+	s.infoColumnTypeUnsupported = false
+	s.infoUdtNameUnsupported = false
 	return nil
 }
 
@@ -517,6 +521,8 @@ func (s *server) disconnect() error {
 	s.closeAllQuerySessions()
 	s.usePgDefaultExpression = false
 	s.catalogIdentityUnsupported = false
+	s.infoColumnTypeUnsupported = false
+	s.infoUdtNameUnsupported = false
 	s.currentSchema = ""
 	s.schemaSet = false
 	if s.db == nil {

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -1156,6 +1156,16 @@ func TestInformationSchemaColumnsResolveUserDefinedTypeWithoutColumnType(t *test
 	if ddl := renderTableDDL("public", "orders", columns, nil); !strings.Contains(ddl, `"created_at" datetime`) || strings.Contains(ddl, "USER-DEFINED") {
 		t.Fatalf("unexpected user-defined type DDL:\n%s", ddl)
 	}
+
+	if _, err := server.informationSchemaColumns("public", "events", map[string]bool{}); err != nil {
+		t.Fatal(err)
+	}
+	state.mu.Lock()
+	queries := append([]string(nil), state.queries...)
+	state.mu.Unlock()
+	if len(queries) != 3 || strings.Contains(queries[2], "c.column_type") {
+		t.Fatalf("missing column_type capability must be cached: %v", queries)
+	}
 }
 
 func TestInformationSchemaColumnsPreserveColumnTypeWithoutUdtName(t *testing.T) {
@@ -1174,20 +1184,23 @@ func TestInformationSchemaColumnsPreserveColumnTypeWithoutUdtName(t *testing.T) 
 	server := newServer()
 	server.db = openMetadataDB(t, state)
 
-	columns, err := server.informationSchemaColumns("public", "orders", map[string]bool{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(columns) != 1 || columns[0].FullDataType != "enum('new','done')" {
-		t.Fatalf("unexpected metadata columns: %#v", columns)
-	}
-	if ddl := renderTableDDL("public", "orders", columns, nil); !strings.Contains(ddl, `"status" enum('new','done')`) {
-		t.Fatalf("unexpected table DDL:\n%s", ddl)
+	for _, table := range []string{"orders", "events"} {
+		columns, err := server.informationSchemaColumns("public", table, map[string]bool{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(columns) != 1 || columns[0].FullDataType != "enum('new','done')" {
+			t.Fatalf("unexpected metadata columns: %#v", columns)
+		}
+		if ddl := renderTableDDL("public", table, columns, nil); !strings.Contains(ddl, `"status" enum('new','done')`) {
+			t.Fatalf("unexpected table DDL:\n%s", ddl)
+		}
 	}
 	state.mu.Lock()
-	defer state.mu.Unlock()
-	if len(state.queries) != 2 {
-		t.Fatalf("unexpected query count: got %d, want 2: %v", len(state.queries), state.queries)
+	queries := append([]string(nil), state.queries...)
+	state.mu.Unlock()
+	if len(queries) != 3 || !strings.Contains(queries[0], "c.udt_name") || strings.Contains(queries[1], "c.udt_name") || strings.Contains(queries[2], "c.udt_name") {
+		t.Fatalf("missing udt_name capability must be detected once and cached: %v", queries)
 	}
 }
 
@@ -1210,17 +1223,20 @@ func TestInformationSchemaColumnsFallbackWithoutExtendedTypeColumns(t *testing.T
 	server := newServer()
 	server.db = openMetadataDB(t, state)
 
-	columns, err := server.informationSchemaColumns("public", "orders", map[string]bool{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(columns) != 1 || columnDDLDefinition(columns[0]) != `"label" varchar(64)` {
-		t.Fatalf("unexpected fallback columns: %#v", columns)
+	for _, table := range []string{"orders", "events"} {
+		columns, err := server.informationSchemaColumns("public", table, map[string]bool{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(columns) != 1 || columnDDLDefinition(columns[0]) != `"label" varchar(64)` {
+			t.Fatalf("unexpected fallback columns: %#v", columns)
+		}
 	}
 	state.mu.Lock()
-	defer state.mu.Unlock()
-	if len(state.queries) != 3 {
-		t.Fatalf("unexpected query count: got %d, want 3: %v", len(state.queries), state.queries)
+	queries := append([]string(nil), state.queries...)
+	state.mu.Unlock()
+	if len(queries) != 4 || !strings.Contains(queries[2], "NULL AS column_type") || !strings.Contains(queries[3], "NULL AS column_type") {
+		t.Fatalf("missing extended type capabilities must be detected once and cached: %v", queries)
 	}
 }
 
@@ -1275,6 +1291,19 @@ func TestInformationSchemaColumnsRetriesOnlyForMissingTypeMetadataColumns(t *tes
 				t.Fatalf("unexpected query count: got %d, want %d: %v", len(queries), wantQueries, queries)
 			}
 		})
+	}
+}
+
+func TestDisconnectResetsInformationSchemaCapabilityCache(t *testing.T) {
+	server := newServer()
+	server.infoColumnTypeUnsupported = true
+	server.infoUdtNameUnsupported = true
+
+	if err := server.disconnect(); err != nil {
+		t.Fatal(err)
+	}
+	if server.infoColumnTypeUnsupported || server.infoUdtNameUnsupported {
+		t.Fatal("disconnect must reset cached information_schema capabilities")
 	}
 }
 


### PR DESCRIPTION
## 说明

官方已通过 [4858fed870c39379de9ed55445eb92a71f812517](https://github.com/t8y2/dbx/commit/4858fed870c39379de9ed55445eb92a71f812517) 修复 #5173 的正确性问题。本 PR 不替代官方修复，而是在其基础上提供一种“连接级能力缓存”的参考实现，供维护者评估是否值得采用。

## 背景

官方实现会在每次读取单张表的字段元数据时，重新从“同时包含 `column_type` 和 `udt_name`”的查询开始探测。对于固定缺少其中一个或两个字段的 Kingbase 实例，每张表都会先产生一次或两次预期内的缺列错误，再进入兼容查询。

单表操作的额外成本很小，但数据库导出、结构对比等批量读取多张表的场景会重复发生同样的失败查询。

## 与官方修复的不同点

### 官方实现

- `includeColumnType` 和 `includeUdtName` 是单次 `informationSchemaColumns` 调用内的局部变量。
- 每张表都会独立探测元数据能力。
- 实现无跨请求状态，逻辑更简单。

### 本 PR 的参考实现

- 将已确认缺失的 `column_type` / `udt_name` 记录在当前 Kingbase 连接对应的 `server` 中。
- 只在第一次遇到精确的缺列错误时降级；同一连接后续读取其他表时直接使用已确认可用的查询层级。
- 在 `connect` 和 `disconnect` 时清空缓存，避免跨连接沿用旧能力。
- 保留官方的四级回退顺序和非相关错误传播行为。

假设读取 N 张表：

- 缺少一个扩展字段：官方约为 `2N` 次字段查询；本实现约为 `N + 1` 次。
- 两个扩展字段都缺少：官方约为 `3N` 次字段查询；本实现约为 `N + 2` 次。

## 取舍

收益：

- 减少批量导出、结构对比和连续打开表结构时的失败查询与网络往返。
- 减少数据库侧重复的缺列错误日志。

成本：

- 引入少量连接级状态。
- 能力判断属于负缓存；如果缺列错误被误判，影响会持续到当前连接断开。
- 相比官方无状态实现，生命周期维护和测试成本略高。

因此本 PR 以草稿形式提供，主要用于对比和方案选择；若维护者更偏好最小、无状态实现，可继续保留当前官方方案。

## 变更内容

- 缓存当前连接不支持的 Kingbase 类型元数据字段。
- 连接建立和断开时重置能力缓存。
- 增加跨两张表的回归测试，验证缺列探测只发生一次。
- 增加断开连接后缓存重置测试。

## 验证

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `git diff --check`
