### PR TITLE
fix(ssh): 修复 Docker/Web 端首次创建 SSH 隧道不弹出信任主机确认框

### DIFF
--- a/apps/desktop/src/components/ssh/SshHostKeyPromptDialog.vue
+++ b/apps/desktop/src/components/ssh/SshHostKeyPromptDialog.vue
@@ -42,6 +42,7 @@ const secretCode = ref("");
 const resolving = ref(false);
 const unlisteners: Array<() => void> = [];
 let webEventSource: EventSource | null = null;
+let pendingTimer: ReturnType<typeof setInterval> | null = null;
 let mounted = true;
 
 function enqueuePrompt(request: SshPromptRequest) {
@@ -125,12 +126,43 @@ async function setupTauriPromptBridge() {
   }
 }
 
+// Fallback delivery alongside the SSE stream. On first connect the dialog's
+// EventSource may not be open yet when the backend fires a host-key prompt, so
+// the SSE `Prompt` event is lost and (without this) the connection hangs until
+// its timeout. Polling the pending endpoint recovers any lost prompt so the
+// dialog still appears. `enqueuePrompt` dedupes by id, so repeated polls are
+// harmless.
+async function fetchPendingPrompts() {
+  try {
+    const res = await fetch(apiUrl("/api/ssh/prompts/pending"), { credentials: "include" });
+    if (!res.ok) return;
+    const pending = (await res.json()) as SshPromptRequest[];
+    pending.forEach((req) => enqueuePrompt(req));
+  } catch {
+    // Transient failure — the next poll retries.
+  }
+}
+
 function setupWebPromptBridge() {
   webEventSource = new EventSource(apiUrl("/api/ssh/prompts"));
   webEventSource.onmessage = (event) => handleWebEvent(event.data);
-  webEventSource.onerror = () => {
-    // EventSource automatically retries. Do not close it while the app is mounted.
+  webEventSource.onopen = () => {
+    // The SSE stream is live; its replay already carries any prompt that fired
+    // before the stream opened, so stop polling to avoid needless requests.
+    if (pendingTimer) {
+      clearInterval(pendingTimer);
+      pendingTimer = null;
+    }
   };
+  webEventSource.onerror = () => {
+    // EventSource reconnects automatically. While disconnected, fall back to
+    // polling so a prompt fired during the outage is not lost.
+    if (!pendingTimer) pendingTimer = setInterval(fetchPendingPrompts, 2000);
+  };
+  // First-connect fallback: the stream may not be open yet when the backend
+  // fires a host-key prompt, so poll until it is.
+  void fetchPendingPrompts();
+  if (!pendingTimer) pendingTimer = setInterval(fetchPendingPrompts, 2000);
 }
 
 onMounted(() => {
@@ -143,6 +175,10 @@ onBeforeUnmount(() => {
   unlisteners.forEach((u) => u());
   webEventSource?.close();
   webEventSource = null;
+  if (pendingTimer) {
+    clearInterval(pendingTimer);
+    pendingTimer = null;
+  }
   if (isTauriRuntime()) void import("@tauri-apps/api/core").then(({ invoke }) => invoke("ssh_prompt_not_ready")).catch(() => undefined);
 });
 

--- a/apps/desktop/src/components/ssh/__tests__/SshHostKeyPromptDialog.spec.ts
+++ b/apps/desktop/src/components/ssh/__tests__/SshHostKeyPromptDialog.spec.ts
@@ -54,6 +54,7 @@ class MockEventSource {
 
   readonly url: string;
   onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onopen: (() => void) | null = null;
   onerror: (() => void) | null = null;
   closed = false;
 
@@ -64,6 +65,14 @@ class MockEventSource {
 
   emit(data: unknown) {
     this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+
+  open() {
+    this.onopen?.();
+  }
+
+  error() {
+    this.onerror?.();
   }
 
   close() {
@@ -77,6 +86,7 @@ beforeEach(() => {
   resolveSshPromptMock.mockReset().mockResolvedValue(undefined);
   MockEventSource.instances = [];
   vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => [] } as Response));
   i18n.global.locale.value = "en";
 });
 
@@ -159,5 +169,52 @@ describe("SshHostKeyPromptDialog web bridge", () => {
     eventSource?.emit({ type: "sync", pendingIds: [] });
     await nextTick();
     expect(document.body.textContent).not.toContain("stale.example.test:22");
+  });
+
+  it("recovers a pending host-key prompt via the polling fallback when the SSE event is missed", async () => {
+    // Simulate a prompt that fired before the EventSource was open: the backend
+    // has it pending, but the SSE `Prompt` event never reached the dialog. The
+    // polling fallback must surface it so the user can still confirm.
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        {
+          id: "prompt-3",
+          kind: "HostKeyVerify",
+          host: "first.example.test",
+          port: 22,
+          key_type: "ssh-ed25519",
+          fingerprint: "SHA256:first",
+        },
+      ],
+    } as Response);
+
+    await mountDialog();
+    await nextTick();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain("first.example.test:22");
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/ssh/prompts/pending", { credentials: "include" });
+  });
+
+  it("stops polling once the SSE stream opens and resumes it after an error", async () => {
+    const setSpy = vi.spyOn(globalThis, "setInterval");
+    const clearSpy = vi.spyOn(globalThis, "clearInterval");
+
+    await mountDialog();
+    const eventSource = MockEventSource.instances[0];
+
+    // Polling is armed on mount (first-connect fallback).
+    expect(setSpy).toHaveBeenCalled();
+
+    // Opening the stream stops the poller (SSE replay now covers lost prompts).
+    eventSource?.open();
+    expect(clearSpy).toHaveBeenCalled();
+
+    // A disconnect re-arms polling so prompts are not lost during the outage.
+    eventSource?.error();
+    expect(setSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -312,6 +312,7 @@ async fn main() {
         .route("/system/fonts", get(routes::jdbc::list_system_fonts))
         .route("/ssh/config-hosts", get(routes::ssh_config::list_ssh_config_hosts))
         .route("/ssh/prompts", get(routes::ssh_prompt::stream_ssh_prompts))
+        .route("/ssh/prompts/pending", get(routes::ssh_prompt::list_pending_ssh_prompts))
         .route("/ssh/prompts/resolve", post(routes::ssh_prompt::resolve_ssh_prompt))
         // Tunnel profiles
         .route("/tunnel-profiles/list", get(routes::tunnel_profiles::load_tunnel_profiles))

--- a/crates/dbx-web/src/routes/ssh_prompt.rs
+++ b/crates/dbx-web/src/routes/ssh_prompt.rs
@@ -1,7 +1,7 @@
 use axum::extract::State;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::Json;
-use dbx_core::db::ssh_prompt::SshPromptAnswer;
+use dbx_core::db::ssh_prompt::{SshPromptAnswer, SshPromptRequest};
 use futures::Stream;
 use serde::Deserialize;
 use std::convert::Infallible;
@@ -52,6 +52,13 @@ pub async fn resolve_ssh_prompt(
 
     state.ssh_prompts.resolve(&request.id, answer).map_err(AppError::bad_request)?;
     Ok(Json(()))
+}
+
+/// Returns all currently-pending host-key prompts. The frontend polls this as a
+/// fallback to the SSE stream so a prompt that fired before the EventSource was
+/// open is still recovered (see the SSH host-key first-connect regression).
+pub async fn list_pending_ssh_prompts(State(state): State<Arc<WebState>>) -> Json<Vec<SshPromptRequest>> {
+    Json(state.ssh_prompts.pending_requests())
 }
 
 fn ssh_prompt_event(event: SshPromptEvent) -> Event {

--- a/crates/dbx-web/src/ssh_prompt.rs
+++ b/crates/dbx-web/src/ssh_prompt.rs
@@ -47,6 +47,14 @@ impl SshPromptHub {
         (replay, receiver)
     }
 
+    /// Snapshot of all currently-pending prompt requests. The frontend uses this
+    /// as a fallback alongside the SSE stream: an SSE `Prompt` event that was
+    /// lost (e.g. the EventSource was not yet open when the prompt fired) is
+    /// recovered by polling this endpoint. Duplicates are deduped by the caller.
+    pub fn pending_requests(&self) -> Vec<SshPromptRequest> {
+        self.pending.lock().unwrap().iter().map(|prompt| prompt.request.clone()).collect()
+    }
+
     pub fn resolve(&self, id: &str, answer: SshPromptAnswer) -> Result<(), String> {
         let pending = {
             let mut pending = self.pending.lock().unwrap();
@@ -158,5 +166,25 @@ mod tests {
 
         hub.resolve("prompt-2", SshPromptAnswer::Reject).unwrap();
         assert!(matches!(receiver.await.unwrap(), SshPromptAnswer::Reject));
+    }
+
+    #[tokio::test]
+    async fn pending_requests_snapshots_unresolved_prompts_and_drops_resolved() {
+        let hub = SshPromptHub::new();
+        let (responder_a, _ra) = tokio::sync::oneshot::channel();
+        let (responder_b, _rb) = tokio::sync::oneshot::channel();
+        hub.register(SshPromptEnvelope { request: request("prompt-a"), responder: responder_a });
+        hub.register(SshPromptEnvelope { request: request("prompt-b"), responder: responder_b });
+
+        let pending = hub.pending_requests();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].id, "prompt-a");
+        assert_eq!(pending[1].id, "prompt-b");
+
+        // A resolved prompt is removed from the pending snapshot.
+        hub.resolve("prompt-a", SshPromptAnswer::Reject).unwrap();
+        let pending = hub.pending_requests();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, "prompt-b");
     }
 }


### PR DESCRIPTION
## Problem

Docker/Web 版在**首次**创建 SSH 隧道时不弹出信任主机确认框，隧道测试报 `SSH connection timed out (100s)`（5s 时）而失败。刷新页面后弹窗才出现，之后连接正常。关联 issue #5181、#4852。

## Root cause

v0.5.67 引入 host-key 验证（MITM 加固）：首次连接时 `known_hosts` 为空，host key 为 unknown，后端触发前端确认弹窗（`prompt_for_host_key`）。但该弹窗依赖 SSE 推送，首次连接时 `SshHostKeyPromptDialog` 的 EventSource 尚未就绪，后端广播的 prompt 事件丢失 → 前端不弹窗 → 后端 `prompt_for_host_key` 悬挂等待 → 外层 `connect_timeout` 先触发 → 报超时。刷新后 SSE 就绪，replay 返回 pending 的 prompt，故能弹窗。

v0.5.66 直接信任任意 host key（无验证），故无此问题。

## Fix

在 SSH 提示的 SSE 推送之外增加**主动拉取兜底**，保证首次连接也能收到 prompt：

- **后端** `crates/dbx-web/src/ssh_prompt.rs`：`SshPromptHub` 新增 `pending_requests()` 快照；新增 `GET /api/ssh/prompts/pending`（`routes/ssh_prompt.rs` + `main.rs` 路由），返回所有未决 host-key prompt，受现有认证保护。
- **前端** `apps/desktop/src/components/ssh/SshHostKeyPromptDialog.vue`：web 模式下轮询该端点——SSE 未建立时兜底拉取，SSE `onopen` 后停止（其 replay 已覆盖丢失 prompt），`onerror` 断开时恢复；`enqueuePrompt` 按 id 去重。仅影响 web 端，Tauri 桌面端走独立桥接不受影响。

## Compatibility

- 默认行为：首次连接现在能正常弹出确认框，接受后记录 host key，后续连接不再弹窗。
- 新增只读接口，不改变现有 `/ssh/prompts` SSE 与 `/ssh/prompts/resolve` 语义。
- 桌面端（Tauri）行为不变。

## Validation

- `cargo build -p dbx-web` — passed
- `cargo test -p dbx-web ssh_prompt` — 3 passed
- `vitest run SshHostKeyPromptDialog.spec.ts` — 4 passed
- `cargo fmt --all -- --check` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
