### PR TITLE
fix(structure): load missing index metadata

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
+++ b/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
 
-import { createApp, nextTick, type App } from "vue";
+import { createApp, defineComponent, h, nextTick, ref, type App } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TableInfoTab, TableStructureEditorDraft } from "@/types/database";
 
 const mocks = vi.hoisted(() => ({
   connection: {
@@ -291,6 +292,49 @@ async function mountLoadingEditor(initialTab: "columns" | "indexes" | "foreignKe
   return root;
 }
 
+async function mountLazyLoadingEditor(initialDraft?: TableStructureEditorDraft) {
+  mocks.connection.db_type = "postgres";
+  mocks.connection.name = "postgres";
+  mocks.connection.driver_label = "postgres";
+  mocks.ensureConnected.mockResolvedValue(undefined);
+  mocks.listDataTypes.mockResolvedValue([]);
+  mocks.buildTableStructureChangeSql.mockResolvedValue({ statements: [], warnings: [] });
+
+  const initialTab = ref<TableInfoTab>();
+  const initialTabRequestId = ref<number>();
+  const currentDraft = ref<TableStructureEditorDraft | undefined>(initialDraft);
+  const root = document.createElement("div");
+  document.body.append(root);
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(TableStructureEditor, {
+          connectionId: mocks.connection.id,
+          database: "test",
+          schema: "public",
+          tableName: "users",
+          initialTab: initialTab.value,
+          initialTabRequestId: initialTabRequestId.value,
+          draft: currentDraft.value,
+          "onUpdate:draft": (nextDraft: TableStructureEditorDraft | undefined) => {
+            currentDraft.value = nextDraft;
+          },
+        }),
+    }),
+  );
+  mountedApps.push(app);
+  app.mount(root);
+
+  return {
+    root,
+    currentDraft,
+    selectTab(tab: TableInfoTab) {
+      initialTab.value = tab;
+      initialTabRequestId.value = (initialTabRequestId.value ?? 0) + 1;
+    },
+  };
+}
+
 function columnCheckbox(root: HTMLElement, header: string): HTMLInputElement {
   const headerIndex = Array.from(root.querySelectorAll("thead th")).findIndex((cell) => cell.textContent?.trim() === header);
   if (headerIndex < 0) throw new Error(`Missing ${header} column`);
@@ -382,5 +426,92 @@ describe("TableStructureEditor metadata loading", () => {
     await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet).toHaveBeenCalledTimes(expectedFacets.length));
     expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(expectedFacets);
     expect(mocks.loadObjectDdl).not.toHaveBeenCalled();
+  });
+
+  it("loads indexes after the columns draft is synchronized to the parent", async () => {
+    mocks.loadObjectMetadataFacet.mockImplementation(async (_request: unknown, facet: string) => ({
+      value:
+        facet === "indexes"
+          ? [
+              {
+                name: "users_pkey",
+                columns: ["id"],
+                is_unique: true,
+                is_primary: true,
+              },
+            ]
+          : [],
+      cacheStatus: "remote",
+    }));
+    const { root, currentDraft, selectTab } = await mountLazyLoadingEditor();
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["columns", "comment"]));
+    await vi.waitFor(() => expect(currentDraft.value?.loadedMetadataFacets).toEqual(expect.arrayContaining(["columns", "comment"])));
+
+    selectTab("indexes");
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["columns", "comment", "indexes"]));
+    expect(root.querySelector('[data-index-row-index="0"]')).not.toBeNull();
+    expect(currentDraft.value?.loadedMetadataFacets).toEqual(expect.arrayContaining(["columns", "comment", "indexes"]));
+  });
+
+  it("retries index loading when the user switches tabs during the initial columns load", async () => {
+    let resolveColumns: ((value: { value: unknown[]; cacheStatus: "remote" }) => void) | undefined;
+    const columns = new Promise<{ value: unknown[]; cacheStatus: "remote" }>((resolve) => {
+      resolveColumns = resolve;
+    });
+    mocks.loadObjectMetadataFacet.mockImplementation(async (_request: unknown, facet: string) => {
+      if (facet === "columns") return columns;
+      return { value: [], cacheStatus: "remote" };
+    });
+    const { selectTab } = await mountLazyLoadingEditor();
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["columns", "comment"]));
+    selectTab("indexes");
+    await nextTick();
+    expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["columns", "comment"]);
+
+    resolveColumns?.({ value: [], cacheStatus: "remote" });
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["columns", "comment", "indexes"]));
+  });
+
+  it("loads only missing indexes without replacing a restored dirty columns draft", async () => {
+    const restoredDraft = draft() as TableStructureEditorDraft;
+    restoredDraft.dirty = true;
+    restoredDraft.columns[0]!.name = "edited_id";
+    restoredDraft.loadedMetadataFacets = ["columns", "comment"];
+    mocks.loadObjectMetadataFacet.mockResolvedValue({ value: [], cacheStatus: "remote" });
+    const { currentDraft, selectTab } = await mountLazyLoadingEditor(restoredDraft);
+
+    selectTab("indexes");
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["indexes"]));
+    expect(currentDraft.value?.columns[0]?.name).toBe("edited_id");
+  });
+
+  it("persists a lazily loaded comment even when its value does not change", async () => {
+    const restoredDraft = draft() as TableStructureEditorDraft;
+    restoredDraft.loadedMetadataFacets = ["columns", "indexes", "foreign-keys", "triggers"];
+    mocks.loadObjectMetadataFacet.mockResolvedValue({ value: "", cacheStatus: "remote" });
+    const { currentDraft, selectTab } = await mountLazyLoadingEditor(restoredDraft);
+
+    selectTab("indexes");
+
+    await vi.waitFor(() => expect(mocks.loadObjectMetadataFacet.mock.calls.map((call) => call[1])).toEqual(["comment"]));
+    expect(currentDraft.value?.loadedMetadataFacets).toEqual(expect.arrayContaining(["comment"]));
+  });
+
+  it("does not reload facets already recorded in a restored draft", async () => {
+    const restoredDraft = draft() as TableStructureEditorDraft;
+    restoredDraft.loadedMetadataFacets = ["columns", "indexes", "foreign-keys", "triggers", "comment"];
+    const { selectTab } = await mountLazyLoadingEditor(restoredDraft);
+
+    selectTab("indexes");
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(mocks.loadObjectMetadataFacet).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -27,7 +27,7 @@ import { formatSqlForDisplay, sqlFormatDialectForDbType } from "@/lib/sql/sqlFor
 import { queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import { invalidateObjectDdl, loadObjectDdl } from "@/lib/metadata/objectDdlCache";
-import { loadObjectMetadataFacet, type ObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
+import { loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
 import { invalidateTableMetadataCache } from "@/lib/metadata/tableMetadataCache";
 import { type BuildTableStructureChangeSqlOptions, type EditableStructureColumn, type EditableStructureForeignKey, type EditableStructureIndex, type EditableStructureTrigger } from "@/lib/table/tableStructureEditorSql";
 import { PRESET_FIELDS_TEMPLATE_ID, createTableColumnTemplateDrafts } from "@/lib/table/tableColumnTemplates";
@@ -35,7 +35,7 @@ import { getMysqlDataTypeHelp } from "@/lib/table/mysqlDataTypeHelp";
 import { getPostgresDataTypeHelp } from "@/lib/table/postgresDataTypeHelp";
 import { getSqliteDataTypeHelp } from "@/lib/table/sqliteDataTypeHelp";
 import { getTableMetadataCapabilities, firstStructureMetadataTab, isStructureMetadataTabSupported } from "@/lib/table/tableMetadataCapabilities";
-import { shouldLoadTableStructureTriggers, TRIGGERS_ONLY_REFRESH_SCOPE, visibleTableStructureRefreshScope, type TableStructureRefreshScope } from "@/lib/table/tableStructureMetadataLoading";
+import { hasTableStructureRefreshScope, missingTableStructureRefreshScope, shouldLoadTableStructureTriggers, TRIGGERS_ONLY_REFRESH_SCOPE, visibleTableStructureRefreshScope, type TableStructureMetadataFacet, type TableStructureRefreshScope } from "@/lib/table/tableStructureMetadataLoading";
 import { canAddTableStructureColumn, getTableStructureCapabilities, hasLocalTableColumnOrderChange, isPhysicalTableColumnOrderChange, supportsLocalTableColumnReorder } from "@/lib/table/tableStructureCapabilities";
 import { orderedColumnIndexes, uniqueDataGridColumnOrderKeys } from "@/lib/dataGrid/dataGridColumnOrder";
 import { loadTableDataGridColumnOrder, notifyTableDataGridColumnOrderChanged, removeTableDataGridColumnOrder, saveTableDataGridColumnOrder, tableDataGridColumnOrderScopeKey } from "@/lib/dataGrid/dataGridColumnLayoutStorage";
@@ -141,7 +141,7 @@ const foreignKeysLoading = ref(false);
 const triggersLoading = ref(false);
 const ddlContent = ref("");
 const ddlLoading = ref(false);
-const loadedMetadataFacets = new Set<ObjectMetadataFacet>();
+const loadedMetadataFacets = new Set<TableStructureMetadataFacet>();
 let structureEditorReady = false;
 const ddlPreRef = ref<HTMLPreElement | null>(null);
 function onDdlKeydown(e: KeyboardEvent) {
@@ -925,6 +925,7 @@ function createCurrentDraft(initialized = true): TableStructureEditorDraft {
     foreignKeys: cloneDraftValue(foreignKeys.value),
     triggers: cloneDraftValue(triggers.value),
     triggersLoaded: triggersLoaded.value,
+    loadedMetadataFacets: [...loadedMetadataFacets],
     scrollPositions: cloneDraftValue(structureScrollPositions.value),
     initialized,
   };
@@ -936,6 +937,31 @@ function syncDraftToParent() {
   syncingDraft = true;
   emit("update:draft", createCurrentDraft());
   syncingDraft = false;
+}
+
+function markMetadataScopeLoaded(scope: TableStructureRefreshScope) {
+  if (scope.columns) loadedMetadataFacets.add("columns");
+  if (scope.indexes) loadedMetadataFacets.add("indexes");
+  if (scope.foreignKeys) loadedMetadataFacets.add("foreign-keys");
+  if (scope.triggers) loadedMetadataFacets.add("triggers");
+  if (scope.tableComment) loadedMetadataFacets.add("comment");
+}
+
+function restoreLoadedMetadataFacets(draft: TableStructureEditorDraft) {
+  loadedMetadataFacets.clear();
+  if (draft.loadedMetadataFacets) {
+    for (const facet of draft.loadedMetadataFacets) loadedMetadataFacets.add(facet);
+    return;
+  }
+
+  // Older in-memory drafts have no facet state. Do not risk replacing a dirty draft.
+  if (draft.dirty) {
+    markMetadataScopeLoaded({ columns: true, indexes: true, foreignKeys: true, triggers: draft.triggersLoaded ?? true, tableComment: true });
+    return;
+  }
+
+  markMetadataScopeLoaded(visibleTableStructureRefreshScope(draft.activeTab || "columns"));
+  if (draft.triggersLoaded ?? true) loadedMetadataFacets.add("triggers");
 }
 
 function restoreDraft(draft: TableStructureEditorDraft) {
@@ -951,6 +977,7 @@ function restoreDraft(draft: TableStructureEditorDraft) {
   triggers.value = cloneDraftValue(draft.triggers || []);
   // Drafts created before lazy trigger loading always contained live trigger metadata.
   triggersLoaded.value = draft.triggersLoaded ?? true;
+  restoreLoadedMetadataFacets(draft);
   structureScrollPositions.value = cloneDraftValue(draft.scrollPositions || {});
   restoringDraft = false;
   draftHydrated = !needsColumnDraftMetadataHydration();
@@ -986,6 +1013,7 @@ async function hydrateRestoredDraftFromDatabase() {
       }
     }
     columns.value = rehydrateColumnDraftsFromMetadata(columns.value, nextColumns, databaseType.value);
+    loadedMetadataFacets.add("columns");
     markDraftHydratedAndSync();
     shouldRefreshPreview = true;
   } catch (e: any) {
@@ -1244,15 +1272,6 @@ function setSecondaryMetadataLoading(scope: TableStructureRefreshScope, value: b
   if (scope.triggers && tableMetadataCapabilities.value.triggers) triggersLoading.value = value;
 }
 
-function hasLoadedMetadataScope(scope: TableStructureRefreshScope): boolean {
-  if (scope.columns && !loadedMetadataFacets.has("columns")) return false;
-  if (scope.indexes && !loadedMetadataFacets.has("indexes")) return false;
-  if (scope.foreignKeys && !loadedMetadataFacets.has("foreign-keys")) return false;
-  if (scope.triggers && !loadedMetadataFacets.has("triggers")) return false;
-  if (scope.tableComment && !loadedMetadataFacets.has("comment")) return false;
-  return true;
-}
-
 async function fetchTableCommentValue(connectionId: string, database: string, schema: string, tableName: string, catalog?: string): Promise<string | undefined> {
   try {
     return (await api.getTableComment(connectionId, database, schema, tableName, catalog)) || "";
@@ -1383,6 +1402,8 @@ async function loadStructure(
     if (!silent) loading.value = false;
     if (!options.preserveDraft && loadedSuccessfully && requestId === structureLoadRequestId) {
       markDraftHydratedAndSync();
+    } else if (options.preserveDraft && loadedSuccessfully && requestId === structureLoadRequestId) {
+      syncDraftToParent();
     }
   }
 }
@@ -2557,8 +2578,27 @@ async function loadTriggersIfNeeded() {
   await loadStructure(true, TRIGGERS_ONLY_REFRESH_SCOPE, true, { blockSecondaryMetadata: true, preserveDraft: true });
 }
 
+async function loadVisibleTabMetadataIfNeeded() {
+  if (!structureEditorReady || loading.value) return;
+  const tab = activeTab.value;
+  if (tab === "ddl") {
+    if (!ddlLoading.value) await fetchDdl();
+    return;
+  }
+  if (tab === "triggers") {
+    await loadTriggersIfNeeded();
+    return;
+  }
+  if (isCreateMode.value) return;
+
+  const scope = missingTableStructureRefreshScope(visibleTableStructureRefreshScope(tab), loadedMetadataFacets);
+  if (!hasTableStructureRefreshScope(scope)) return;
+  await loadStructure(false, scope, true, { blockSecondaryMetadata: true, preserveDraft: true });
+  applyInitialStructureTarget();
+}
+
 watch([activeTab, loading], () => {
-  void loadTriggersIfNeeded();
+  void loadVisibleTabMetadataIfNeeded();
 });
 
 watch(
@@ -2592,24 +2632,9 @@ watch(refreshVersion, (version, previous) => {
     triggers.value = [];
     triggersLoaded.value = false;
   }
+  loadedMetadataFacets.clear();
   void loadStructure(true, visibleTableStructureRefreshScope(activeTab.value));
 });
-
-watch(
-  activeTab,
-  (tab) => {
-    if (!structureEditorReady) return;
-    if (tab === "ddl") {
-      void fetchDdl();
-    } else if (!isCreateMode.value && !props.draft?.initialized && !loading.value) {
-      const scope = visibleTableStructureRefreshScope(tab);
-      if (!hasLoadedMetadataScope(scope)) {
-        void loadStructure(false, scope, true, { blockSecondaryMetadata: true }).then(() => applyInitialStructureTarget());
-      }
-    }
-  },
-  { flush: "sync" },
-);
 
 watch([activeTab, ddlLoading], ([tab, loading]) => {
   if (tab === "ddl" && !loading) {

--- a/apps/desktop/src/lib/__tests__/table/tableStructureMetadataLoading.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableStructureMetadataLoading.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldLoadTableStructureTriggers, visibleTableStructureRefreshScope } from "@/lib/table/tableStructureMetadataLoading";
+import { hasTableStructureRefreshScope, missingTableStructureRefreshScope, shouldLoadTableStructureTriggers, visibleTableStructureRefreshScope } from "@/lib/table/tableStructureMetadataLoading";
 
 describe("table structure metadata loading", () => {
   it.each([
@@ -23,6 +23,19 @@ describe("table structure metadata loading", () => {
 
     expect(shouldLoadTableStructureTriggers({ ...base, loaded: false })).toBe(true);
     expect(shouldLoadTableStructureTriggers({ ...base, loaded: true })).toBe(false);
+  });
+
+  it("loads only the facet that is still missing after visiting the columns tab", () => {
+    const scope = missingTableStructureRefreshScope(visibleTableStructureRefreshScope("indexes"), new Set(["columns", "comment"]));
+
+    expect(scope).toEqual({ columns: false, indexes: true, foreignKeys: false, triggers: false, tableComment: false });
+    expect(hasTableStructureRefreshScope(scope)).toBe(true);
+  });
+
+  it("does not schedule a load when every requested facet is already present", () => {
+    const scope = missingTableStructureRefreshScope(visibleTableStructureRefreshScope("foreignKeys"), new Set(["columns", "foreign-keys", "comment"]));
+
+    expect(hasTableStructureRefreshScope(scope)).toBe(false);
   });
 
   it("waits for the initial structure load and skips create mode", () => {

--- a/apps/desktop/src/lib/table/tableStructureMetadataLoading.ts
+++ b/apps/desktop/src/lib/table/tableStructureMetadataLoading.ts
@@ -1,5 +1,7 @@
 import type { TableInfoTab } from "@/types/database";
 
+export type TableStructureMetadataFacet = "columns" | "indexes" | "foreign-keys" | "triggers" | "comment";
+
 export interface TableStructureRefreshScope {
   columns: boolean;
   indexes: boolean;
@@ -30,6 +32,20 @@ export const TRIGGERS_ONLY_REFRESH_SCOPE: TableStructureRefreshScope = {
   triggers: true,
   tableComment: false,
 };
+
+export function missingTableStructureRefreshScope(scope: TableStructureRefreshScope, loadedFacets: ReadonlySet<TableStructureMetadataFacet>): TableStructureRefreshScope {
+  return {
+    columns: scope.columns && !loadedFacets.has("columns"),
+    indexes: scope.indexes && !loadedFacets.has("indexes"),
+    foreignKeys: scope.foreignKeys && !loadedFacets.has("foreign-keys"),
+    triggers: scope.triggers && !loadedFacets.has("triggers"),
+    tableComment: scope.tableComment && !loadedFacets.has("comment"),
+  };
+}
+
+export function hasTableStructureRefreshScope(scope: TableStructureRefreshScope): boolean {
+  return scope.columns || scope.indexes || scope.foreignKeys || scope.triggers || scope.tableComment;
+}
 
 export function shouldLoadTableStructureTriggers(options: { activeTab: TableInfoTab; isCreateMode: boolean; supported: boolean; loaded: boolean; loading: boolean; structureLoading: boolean }): boolean {
   return options.activeTab === "triggers" && !options.isCreateMode && options.supported && !options.loaded && !options.loading && !options.structureLoading;

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -900,6 +900,7 @@ export interface TableStructureEditorDraft {
   foreignKeys: import("@/lib/table/tableStructureEditorSql").EditableStructureForeignKey[];
   triggers: import("@/lib/table/tableStructureEditorSql").EditableStructureTrigger[];
   triggersLoaded?: boolean;
+  loadedMetadataFacets?: import("@/lib/table/tableStructureMetadataLoading").TableStructureMetadataFacet[];
   scrollPositions?: Partial<Record<TableInfoTab, TableStructureEditorViewport>>;
   initialized: boolean;
 }


### PR DESCRIPTION
## 变更说明

修复编辑表结构时从“字段”切换到“索引”页不自动加载已存在索引的问题。

根因是按页签懒加载元数据后，初始字段加载同步的 `initialized` 草稿被误当作“所有元数据均已加载”，导致索引请求被跳过。现在草稿会记录已加载的 metadata facet，切换页签时仅请求缺失部分，避免覆盖未保存的字段、索引或外键修改。

同时处理了初始字段加载期间提前切换页签的竞态，并在结构失效或注释值未变化时正确同步 facet 状态。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [x] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（本次为元数据加载逻辑修复，无样式变更；由自动化回归测试验证）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过：`pnpm test`
- [x] `pnpm typecheck` 通过
- [x] `pnpm build` 通过
- [x] `pnpm lint` 通过

## 关联 Issue

Close #5159