### PR TITLE
Fix：新建表后立即刷新侧边栏表大小

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.sidebarTableStorage.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.sidebarTableStorage.spec.ts
@@ -11,6 +11,14 @@ function installLocalStorage() {
   });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("connectionStore sidebar table storage", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -24,13 +32,9 @@ describe("connectionStore sidebar table storage", () => {
       { name: "EXISTING_TABLE", table_type: "BASE TABLE", comment: null },
       { name: "NEW_TABLE", table_type: "BASE TABLE", comment: null },
     ]);
-    const listObjectStatistics = vi
-      .fn()
-      .mockResolvedValueOnce([{ name: "EXISTING_TABLE", schema: "APP", total_bytes: 8192 }])
-      .mockResolvedValueOnce([
-        { name: "EXISTING_TABLE", schema: "APP", total_bytes: 8192 },
-        { name: "NEW_TABLE", schema: "APP", total_bytes: 16384 },
-      ]);
+    const initialStatistics = deferred<Array<{ name: string; schema: string; total_bytes: number }>>();
+    const refreshedStatistics = deferred<Array<{ name: string; schema: string; total_bytes: number }>>();
+    const listObjectStatistics = vi.fn().mockReturnValueOnce(initialStatistics.promise).mockReturnValueOnce(refreshedStatistics.promise);
     vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
     vi.doMock("@/lib/backend/api", () => ({
       checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
@@ -84,13 +88,23 @@ describe("connectionStore sidebar table storage", () => {
     store.connectedIds.add(connection.id);
     store.treeNodes = [{ id: connection.id, label: connection.name, type: "connection", connectionId: connection.id, children: [schemaNode] }];
 
-    await store.loadSidebarTableStorage({ connectionId: connection.id, database: connection.database, schema: "APP" });
-    expect(existingTable.sizeBytes).toBe(8192);
+    const initialLoad = store.loadSidebarTableStorage({ connectionId: connection.id, database: connection.database, schema: "APP" });
+    expect(listObjectStatistics).toHaveBeenCalledTimes(1);
 
     await store.refreshObjectListTreeNode(connection.id, connection.database, "APP");
-
-    const newTable = schemaNode.children?.find((node) => node.label === "NEW_TABLE");
     expect(listObjectStatistics).toHaveBeenCalledTimes(2);
+
+    const currentExistingTable = schemaNode.children?.find((node) => node.label === "EXISTING_TABLE");
+    const newTable = schemaNode.children?.find((node) => node.label === "NEW_TABLE");
+    refreshedStatistics.resolve([
+      { name: "EXISTING_TABLE", schema: "APP", total_bytes: 8192 },
+      { name: "NEW_TABLE", schema: "APP", total_bytes: 16384 },
+    ]);
+    await vi.waitFor(() => expect(newTable?.sizeBytes).toBe(16384));
+
+    initialStatistics.resolve([{ name: "EXISTING_TABLE", schema: "APP", total_bytes: 4096 }]);
+    await initialLoad;
+    expect(currentExistingTable?.sizeBytes).toBe(8192);
     expect(newTable?.sizeBytes).toBe(16384);
   });
 });

--- a/apps/desktop/src/stores/__tests__/connectionStore.sidebarTableStorage.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.sidebarTableStorage.spec.ts
@@ -1,0 +1,96 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectionConfig, TreeNode } from "@/types/database";
+
+function installLocalStorage() {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => data.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => data.set(key, value)),
+    removeItem: vi.fn((key: string) => data.delete(key)),
+  });
+}
+
+describe("connectionStore sidebar table storage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    installLocalStorage();
+    setActivePinia(createPinia());
+  });
+
+  it("reloads table sizes after refreshing an object list with a newly created table", async () => {
+    const listTables = vi.fn().mockResolvedValue([
+      { name: "EXISTING_TABLE", table_type: "BASE TABLE", comment: null },
+      { name: "NEW_TABLE", table_type: "BASE TABLE", comment: null },
+    ]);
+    const listObjectStatistics = vi
+      .fn()
+      .mockResolvedValueOnce([{ name: "EXISTING_TABLE", schema: "APP", total_bytes: 8192 }])
+      .mockResolvedValueOnce([
+        { name: "EXISTING_TABLE", schema: "APP", total_bytes: 8192 },
+        { name: "NEW_TABLE", schema: "APP", total_bytes: 16384 },
+      ]);
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined),
+      listInstalledAgents: vi.fn().mockResolvedValue([]),
+      listObjects: vi.fn().mockResolvedValue([]),
+      listObjectStatistics,
+      listTables,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const store = useConnectionStore();
+    const settingsStore = useSettingsStore();
+    settingsStore.editorSettings.sidebarObjectDisplay = "simple";
+    settingsStore.editorSettings.sidebarObjectInfoMode = "size";
+
+    const connection = {
+      id: "oracle-1",
+      name: "Oracle",
+      db_type: "oracle",
+      host: "127.0.0.1",
+      port: 1521,
+      username: "APP",
+      password: "",
+      database: "ORCL",
+    } as ConnectionConfig;
+    const existingTable: TreeNode = {
+      id: "oracle-1:ORCL:APP:EXISTING_TABLE",
+      label: "EXISTING_TABLE",
+      type: "table",
+      connectionId: connection.id,
+      database: connection.database,
+      schema: "APP",
+    };
+    const schemaNode: TreeNode = {
+      id: "oracle-1:ORCL:APP",
+      label: "APP",
+      type: "schema",
+      connectionId: connection.id,
+      database: connection.database,
+      schema: "APP",
+      isExpanded: true,
+      children: [existingTable],
+    };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [{ id: connection.id, label: connection.name, type: "connection", connectionId: connection.id, children: [schemaNode] }];
+
+    await store.loadSidebarTableStorage({ connectionId: connection.id, database: connection.database, schema: "APP" });
+    expect(existingTable.sizeBytes).toBe(8192);
+
+    await store.refreshObjectListTreeNode(connection.id, connection.database, "APP");
+
+    const newTable = schemaNode.children?.find((node) => node.label === "NEW_TABLE");
+    expect(listObjectStatistics).toHaveBeenCalledTimes(2);
+    expect(newTable?.sizeBytes).toBe(16384);
+  });
+});

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -2948,13 +2948,14 @@ export const useConnectionStore = defineStore("connection", () => {
       return;
     }
 
-    let request = sidebarTableStorageInFlight.get(requestKey);
+    let request = options?.force ? undefined : sidebarTableStorageInFlight.get(requestKey);
     if (!request) {
       request = api.listObjectStatistics(scope.connectionId, scope.database, scope.schema);
       sidebarTableStorageInFlight.set(requestKey, request);
     }
     try {
       const statistics = await request;
+      if (sidebarTableStorageInFlight.get(requestKey) !== request) return;
       sidebarTableStorageCache.set(requestKey, {
         expiresAt: Date.now() + SIDEBAR_DATABASE_STORAGE_CACHE_TTL_MS,
         value: statistics,
@@ -5264,9 +5265,10 @@ export const useConnectionStore = defineStore("connection", () => {
     const node = shouldRefreshSchemaNode ? findNode(treeNodes.value, `${connectionId}:${database}:${schema}`) : null;
     if (node) {
       await refreshTreeNode(node);
-      return;
+    } else {
+      await refreshDatabaseTreeNode(connectionId, database, catalog);
     }
-    await refreshDatabaseTreeNode(connectionId, database, catalog);
+    await loadSidebarTableStorage({ connectionId, database, schema: schema || "" }, { force: true });
   }
 
   function isSchemaAwareDatabase(connectionId: string): boolean {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -5268,7 +5268,7 @@ export const useConnectionStore = defineStore("connection", () => {
     } else {
       await refreshDatabaseTreeNode(connectionId, database, catalog);
     }
-    await loadSidebarTableStorage({ connectionId, database, schema: schema || "" }, { force: true });
+    void loadSidebarTableStorage({ connectionId, database, schema: schema || "" }, { force: true });
   }
 
   function isSchemaAwareDatabase(connectionId: string): boolean {


### PR DESCRIPTION
## 问题

启用侧边栏对象大小显示后，在已有 Schema 中新建表，表节点会立即刷新，但表大小统计仍会命中刷新前的 30 秒缓存，导致新表暂时不显示大小。该问题影响所有支持侧边栏表大小的数据库，并非 Oracle 特有。

## 修复

- 对象列表刷新成功后，强制更新对应数据库和 Schema 的表大小统计
- 强制刷新不再复用可能早于建表操作发起的旧请求
- 仅允许同一统计范围内的最新请求更新缓存和树节点，避免旧响应晚到后覆盖新结果
- 增加“预热旧缓存后新建表”的 Store 回归测试

## 测试

- `pnpm test`：722 个测试文件、6441 个测试全部通过
- `pnpm typecheck`：通过
- Oracle XE 11g 实例：创建临时表后，表列表立即可见，统计接口返回 131072 字节；测试表已清理
