### PR TITLE
fix: 定时驱动更新检查遵循下载源设置

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick, defineAsyncComponent } from "vue";
 import { useI18n } from "vue-i18n";
-import { invoke } from "@tauri-apps/api/core";
 import { ChevronsRight } from "@lucide/vue";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import AppToolbar from "@/components/layout/AppToolbar.vue";
@@ -86,7 +85,7 @@ import { buildAppendedEditorSql } from "@/lib/ai/aiSqlAppend";
 import { assessProductionSql } from "@/lib/database/productionSafety";
 import { executeWithProductionSqlGuard } from "@/lib/database/productionExecutionGuard";
 import { buildHistoryAiAnalysisPrompt } from "@/lib/history/historyAiAnalysis";
-import { countAvailableAgentDriverUpdates, type AgentDriverUpdateBadgeState } from "@/lib/connection/agentDriverUpdateBadge";
+import { countAvailableAgentDriverUpdates } from "@/lib/connection/agentDriverUpdateBadge";
 import type { DriverStoreFocus } from "@/lib/connection/agentDriverInstallHint";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import { apiUrl, webPath } from "@/lib/common/webPath";
@@ -245,7 +244,7 @@ function updateAgentDriverUpdateCount(count: number) {
 async function refreshAgentDriverUpdateCount() {
   if (!isDesktop || !settingsStore.editorSettings.updateNotificationsEnabled) return;
   try {
-    const drivers = await invoke<AgentDriverUpdateBadgeState[]>("list_installed_agents");
+    const drivers = await api.listInstalledAgents();
     if (!settingsStore.editorSettings.updateNotificationsEnabled) return;
     updateAgentDriverUpdateCount(countAvailableAgentDriverUpdates(drivers));
   } catch {

--- a/crates/dbx-core/src/lib.rs
+++ b/crates/dbx-core/src/lib.rs
@@ -106,7 +106,6 @@ impl DownloadSource {
         match self {
             Self::Official => Ok(download_candidate_urls(github_url, r2_path)),
             Self::Cnb => Ok(mirror_download_candidate_urls(
-                github_url,
                 r2_path,
                 rewrite_github_release_url(github_url, CNB_RELEASE_DOWNLOAD_PREFIX)?,
             )),
@@ -114,14 +113,9 @@ impl DownloadSource {
     }
 }
 
-fn mirror_download_candidate_urls(github_url: &str, r2_path: &str, mirror_url: String) -> Vec<String> {
+fn mirror_download_candidate_urls(r2_path: &str, mirror_url: String) -> Vec<String> {
     let r2_url = format!("{R2_CDN_BASE}{r2_path}");
-    // Mutable mirror aliases can lag even when versioned release assets are healthy.
-    if github_url.ends_with("/agents-latest/agent-registry.json") {
-        vec![r2_url, mirror_url]
-    } else {
-        vec![mirror_url, r2_url]
-    }
+    vec![mirror_url, r2_url]
 }
 
 fn rewrite_github_release_url(url: &str, target_prefix: &str) -> Result<String, String> {
@@ -202,13 +196,13 @@ mod tests {
     }
 
     #[test]
-    fn mirror_download_candidates_prefer_stable_registry_metadata() {
+    fn mirror_download_candidates_prefer_selected_source() {
         let github_url = "https://github.com/t8y2/dbx/releases/download/agents-latest/agent-registry.json";
         assert_eq!(
             DownloadSource::Cnb.download_candidate_urls(github_url, "agents/agent-registry.json").unwrap(),
             vec![
-                "https://dl.dbxio.com/agents/agent-registry.json",
                 "https://cnb.cool/dbxio.com/dbx/-/releases/download/agents-latest/agent-registry.json",
+                "https://dl.dbxio.com/agents/agent-registry.json",
             ]
         );
     }

--- a/crates/dbx-mcp/src/transport.rs
+++ b/crates/dbx-mcp/src/transport.rs
@@ -32,31 +32,29 @@ where
         self.inner.send(item)
     }
 
-    fn receive(&mut self) -> impl Future<Output = Option<RxJsonRpcMessage<RoleServer>>> + Send {
-        async move {
-            loop {
-                let message = self.inner.receive().await?;
-                let discovery_request_id = match &message {
-                    ClientJsonRpcMessage::Request(request)
-                        if matches!(
-                            &request.request,
-                            ClientRequest::CustomRequest(custom) if custom.method == "server/discover"
-                        ) =>
-                    {
-                        Some(request.id.clone())
-                    }
-                    _ => None,
-                };
-
-                let Some(request_id) = discovery_request_id else {
-                    return Some(message);
-                };
-
-                // Reject discovery without closing so new clients can fall back to the legacy initialize flow.
-                let error = ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None);
-                if self.inner.send(ServerJsonRpcMessage::error(error, Some(request_id))).await.is_err() {
-                    return None;
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        loop {
+            let message = self.inner.receive().await?;
+            let discovery_request_id = match &message {
+                ClientJsonRpcMessage::Request(request)
+                    if matches!(
+                        &request.request,
+                        ClientRequest::CustomRequest(custom) if custom.method == "server/discover"
+                    ) =>
+                {
+                    Some(request.id.clone())
                 }
+                _ => None,
+            };
+
+            let Some(request_id) = discovery_request_id else {
+                return Some(message);
+            };
+
+            // Reject discovery without closing so new clients can fall back to the legacy initialize flow.
+            let error = ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None);
+            if self.inner.send(ServerJsonRpcMessage::error(error, Some(request_id))).await.is_err() {
+                return None;
             }
         }
     }

--- a/packages/app-tests/driverDownloadSource.test.ts
+++ b/packages/app-tests/driverDownloadSource.test.ts
@@ -8,6 +8,7 @@ function source(relativePath: string): string {
 }
 
 test("shares the configured download source with agent driver management", () => {
+  const app = source("apps/desktop/src/App.vue");
   const driverStore = source("apps/desktop/src/components/config/DriverStoreDialog.vue");
   const backendApi = source("apps/desktop/src/lib/backend/api.ts");
 
@@ -20,4 +21,6 @@ test("shares the configured download source with agent driver management", () =>
   assert.match(backendApi, /backend\.installAgent\(dbType, useSettingsStore\(\)\.editorSettings\.updateDownloadSource(?:, operationId)?\)/);
   assert.match(backendApi, /backend\.upgradeAllAgents\(useSettingsStore\(\)\.editorSettings\.updateDownloadSource(?:, operationId)?\)/);
   assert.match(backendApi, /backend\.reinstallJre\(jreKey, useSettingsStore\(\)\.editorSettings\.updateDownloadSource(?:, operationId)?\)/);
+  assert.match(app, /const drivers = await api\.listInstalledAgents\(\)/);
+  assert.doesNotMatch(app, /invoke<[^>]+>\("list_installed_agents"\)/);
 });


### PR DESCRIPTION
## 问题

每小时更新检查会同时检查应用版本和驱动更新。应用版本检查已能读取下载源，但驱动更新角标仍直接调用 Tauri 命令，没有传递用户选择的下载源，因此会默认访问官方源。

此外，CNB 的驱动注册表候选顺序此前仍将 `dl.dbxio.com` 放在首位，即使选择 CNB 也会先请求该域名。

## 修改

- 定时驱动更新检查改走统一后端 API，自动携带设置中的下载源
- CNB 模式优先读取 CNB 驱动注册表，CNB 请求失败时再回退官方源
- 保持官方源及其他下载行为不变
- 补充回归测试，防止定时检查再次绕过下载源

## CI 兼容

首轮 CI 暴露了主分支在 Rust 1.97 下新增的 `manual_async_fn` 告警。按 Clippy 建议将 `dbx-mcp` 对应实现改为等价 `async fn`，不改变传输行为。

## 验证

- 实际请求 CNB 与官方驱动注册表，文件大小均为 31109 字节，SHA-256 均为 `30bf5fb280d106b866d7cdd4483ccdd8df2924bdca2e15410dd048d1385f5dfa`
- 前端相关测试：11 passed
- `pnpm -s typecheck`
- `pnpm -s lint`（仅仓库已有警告）
- `cargo test -p dbx-core --lib`：3902 passed，21 ignored
- `cargo test -p dbx-mcp --lib`：25 passed
- `cargo clippy -p dbx-core --lib -- -D warnings`
- `cargo clippy -p dbx-mcp --lib -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #5229