### PR TITLE
Fix：修复 SQL 当前语句执行范围判断

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -3226,8 +3226,7 @@ function buildPreviewCurrentStatementFrameExtension(viewModule: Pick<typeof impo
 }
 
 function previewCurrentStatementFrameTo(view: import("@codemirror/view").EditorView, range: SqlTextRange): number {
-  const nextChar = range.to < view.state.doc.length ? view.state.doc.sliceString(range.to, range.to + 1) : "";
-  return currentStatementFrameRangeTo(nextChar, range);
+  return currentStatementFrameRangeTo(view.state.doc, range);
 }
 
 watch(

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -11,7 +11,7 @@ import SqlExecutionTargetPicker from "./SqlExecutionTargetPicker.vue";
 import DelimitedListDialog from "./DelimitedListDialog.vue";
 import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomContextMenu.vue";
 import { copyToClipboard, readTextFromClipboard } from "@/lib/common/clipboard";
-import { resolveExecutableSql, type SqlExecutionSnapshot, type SqlExecutionOverride, type SqlExecutionCandidate } from "@/lib/sql/sqlExecutionTarget";
+import { executionCandidateForMode, resolveExecutableSql, type SqlExecutionSnapshot, type SqlExecutionOverride, type SqlExecutionCandidate } from "@/lib/sql/sqlExecutionTarget";
 import { buildExecutionCandidates, hasMultipleExecutionTargets, supportsExecutionTargetPicker, type SqlTextRange } from "@/lib/sql/sqlStatementRanges";
 import { executableStatementRangeAtCursor, executableStatementRangeCacheForDoc, executableStatementRangeStartingAt as executableStatementRangeStartingAtLine, type ExecutableStatementRangeCache } from "@/lib/sql/executableStatementRangeCache";
 import { currentStatementFrameRangeTo, shouldRebuildCurrentStatementFrame, visualSqlColumnsWithInlineHints } from "@/lib/sql/currentStatementFrame";
@@ -644,12 +644,12 @@ function requestExecuteFromView(currentView: EditorViewType, cursorPos: number, 
   const doc = currentView.state.doc.toString();
   const parameterOptions = sqlStatementParameterOptions();
   const candidates = buildExecutionCandidates(doc, cursorPos, props.databaseType, parameterOptions);
-  if (candidates.length === 0) return false;
+  if (candidates.length === 0) return true;
   // The execution shortcut keeps executing the configured target (cursor/all) directly:
   // it stays keyboard-driven and never pops the picker, which is reserved for click entry points.
   if (options.bypassPicker || !settingsStore.editorSettings.showExecutionTargetPicker || !hasMultipleExecutionTargets(doc, props.databaseType, parameterOptions)) {
-    const preferredKind = settingsStore.editorSettings.executeMode === "current" ? "cursor" : "all";
-    const candidate = candidates.find((item) => item.kind === preferredKind) ?? candidates[0];
+    const candidate = executionCandidateForMode(candidates, settingsStore.editorSettings.executeMode);
+    if (!candidate) return true;
     emitExecutionRequest(sqlExecutionSnapshotForRange(currentView, candidate), options.openInNewResultTab);
     return true;
   }
@@ -4011,8 +4011,7 @@ onMounted(async () => {
   );
 
   function currentStatementFrameTo(view: import("@codemirror/view").EditorView, range: SqlTextRange): number {
-    const nextChar = range.to < view.state.doc.length ? view.state.doc.sliceString(range.to, range.to + 1) : "";
-    return currentStatementFrameRangeTo(nextChar, range);
+    return currentStatementFrameRangeTo(view.state.doc, range);
   }
 
   const activeLineHighlighter = ViewPlugin.fromClass(

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
@@ -21,10 +21,20 @@ describe("QueryEditor execution routing", () => {
 
   it("keeps selection priority and the configured current/all target choice", () => {
     const selectionBranch = queryEditorSource.indexOf("if (!options.ignoreSelection && !selection.empty)");
-    const executeModeBranch = queryEditorSource.indexOf('settingsStore.editorSettings.executeMode === "current" ? "cursor" : "all"');
+    const executeModeBranch = queryEditorSource.indexOf("executionCandidateForMode(candidates, settingsStore.editorSettings.executeMode)");
 
     expect(selectionBranch).toBeGreaterThan(-1);
     expect(executeModeBranch).toBeGreaterThan(selectionBranch);
+  });
+
+  it("does not fall back to all SQL when current mode has no statement at the cursor", () => {
+    expect(queryEditorSource).toContain("const candidate = executionCandidateForMode(candidates, settingsStore.editorSettings.executeMode)");
+    expect(queryEditorSource).toContain("if (!candidate) return true");
+    expect(queryEditorSource).not.toContain("?? candidates[0]");
+  });
+
+  it("consumes the execution shortcut when the editor has no executable target", () => {
+    expect(queryEditorSource).toContain("if (candidates.length === 0) return true");
   });
 
   it("preserves the source range when executing a current/all candidate without a manual selection", () => {

--- a/apps/desktop/src/lib/__tests__/sql/currentStatementFrame.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/currentStatementFrame.spec.ts
@@ -2,15 +2,42 @@ import { describe, expect, it } from "vitest";
 import { currentStatementFrameRangeTo, estimateInlineHintVisualColumns, isWideSqlChar, shouldRebuildCurrentStatementFrame, visualSqlColumns, visualSqlColumnsWithInlineHints } from "@/lib/sql/currentStatementFrame";
 import type { SqlTextRange } from "@/lib/sql/sqlStatementRanges";
 
+function frameDocument(sql: string) {
+  return {
+    length: sql.length,
+    sliceString: (from: number, to: number) => sql.slice(from, to),
+  };
+}
+
 describe("currentStatementFrameRangeTo", () => {
   it("includes a directly adjacent trailing semicolon in frame width calculations", () => {
+    const sql = "SELECT 1;";
     const range: SqlTextRange = { from: 0, to: "SELECT 1".length, sql: "SELECT 1" };
-    expect(currentStatementFrameRangeTo(";", range)).toBe(range.to + 1);
+    expect(currentStatementFrameRangeTo(frameDocument(sql), range)).toBe(sql.length);
   });
 
-  it("does not extend the frame when the next character is not a semicolon", () => {
+  it("includes a trailing semicolon on its own line", () => {
+    const sql = "SELECT 1\n;\n\nSELECT 2;";
     const range: SqlTextRange = { from: 0, to: "SELECT 1".length, sql: "SELECT 1" };
-    expect(currentStatementFrameRangeTo("\n", range)).toBe(range.to);
+    expect(currentStatementFrameRangeTo(frameDocument(sql), range)).toBe(sql.indexOf(";") + 1);
+  });
+
+  it("does not extend the frame across a comment before a later semicolon", () => {
+    const sql = "SELECT 1\n-- comment\n;";
+    const range: SqlTextRange = { from: 0, to: "SELECT 1".length, sql: "SELECT 1" };
+    expect(currentStatementFrameRangeTo(frameDocument(sql), range)).toBe(range.to);
+  });
+
+  it("does not extend the frame across a blank line before a later semicolon", () => {
+    const sql = "SELECT 1\n\n;";
+    const range: SqlTextRange = { from: 0, to: "SELECT 1".length, sql: "SELECT 1" };
+    expect(currentStatementFrameRangeTo(frameDocument(sql), range)).toBe(range.to);
+  });
+
+  it("does not extend the frame when the next non-whitespace character is not a semicolon", () => {
+    const sql = "SELECT 1\n\nSELECT 2";
+    const range: SqlTextRange = { from: 0, to: "SELECT 1".length, sql: "SELECT 1" };
+    expect(currentStatementFrameRangeTo(frameDocument(sql), range)).toBe(range.to);
   });
 });
 

--- a/apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
@@ -93,6 +93,24 @@ describe("executableStatementRangeCacheForDoc", () => {
     expect(executableStatementRangeAtCursor(cache, semicolonGapCursor)?.sql).toBe("SELECT 1");
   });
 
+  it("keeps a standalone next-line semicolon attached to the current statement", () => {
+    const sql = "SELECT *\nFROM users\n;\n\nSELECT * FROM audit;";
+    const doc = Text.of(sql.split("\n"));
+    const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");
+    const delimiterCursor = sql.indexOf(";");
+
+    expect(executableStatementRangeAtCursor(cache, delimiterCursor)?.sql).toBe("SELECT *\nFROM users");
+    expect(executableStatementRangeAtCursor(cache, delimiterCursor + 1)?.sql).toBe("SELECT *\nFROM users");
+  });
+
+  it("does not attach a semicolon after a blank line to the previous statement", () => {
+    const sql = "SELECT 1\n\n;";
+    const doc = Text.of(sql.split("\n"));
+    const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");
+
+    expect(executableStatementRangeAtCursor(cache, sql.indexOf(";"))).toBeNull();
+  });
+
   it("returns null for blank and pure comment cursor lines", () => {
     const doc = Text.of(["SELECT 1;", "-- comment", "/* block comment */", "", "SELECT 2;"]);
     const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");

--- a/apps/desktop/src/lib/__tests__/sql/sqlExecutionTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlExecutionTarget.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveExecutableSql } from "@/lib/sql/sqlExecutionTarget";
+import { executionCandidateForMode, resolveExecutableSql, type SqlExecutionCandidate } from "@/lib/sql/sqlExecutionTarget";
+
+function candidate(kind: SqlExecutionCandidate["kind"], supportedKinds: SqlExecutionCandidate["supportedKinds"]): SqlExecutionCandidate {
+  return { kind, supportedKinds, label: kind, sql: "SELECT 1", from: 0, to: 8 };
+}
 
 describe("resolveExecutableSql", () => {
   it("uses selected SQL before cursor-mode resolution", () => {
@@ -8,5 +12,29 @@ describe("resolveExecutableSql", () => {
     const cursorAfterFirstSemicolon = sql.indexOf(";") + 1;
 
     expect(resolveExecutableSql(sql, selectedSql, { mode: "current", cursorPos: cursorAfterFirstSemicolon })).toBe("select 2;");
+  });
+});
+
+describe("executionCandidateForMode", () => {
+  it("does not fall back to all SQL when current mode has no cursor statement", () => {
+    const all = candidate("all", ["all"]);
+
+    expect(executionCandidateForMode([all], "current")).toBeNull();
+    expect(executionCandidateForMode([all], "all")).toBe(all);
+  });
+
+  it("uses the deduplicated candidate when one statement is both current and all", () => {
+    const currentAndAll = candidate("all", ["cursor", "all"]);
+
+    expect(executionCandidateForMode([currentAndAll], "current")).toBe(currentAndAll);
+    expect(executionCandidateForMode([currentAndAll], "all")).toBe(currentAndAll);
+  });
+
+  it("selects the exact target when current and all candidates are distinct", () => {
+    const current = candidate("cursor", ["cursor"]);
+    const all = candidate("all", ["all"]);
+
+    expect(executionCandidateForMode([current, all], "current")).toBe(current);
+    expect(executionCandidateForMode([current, all], "all")).toBe(all);
   });
 });

--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { executionCandidateForMode } from "@/lib/sql/sqlExecutionTarget";
 import { buildExecutionCandidates, currentExecutableStatementRange, executableStatementRanges, fullSqlRange, hasMultipleExecutionTargets, splitSqlStatementRanges, statementRangeAtCursor, supportsExecutionTargetPicker } from "@/lib/sql/sqlStatementRanges";
 
 function indexOf(sql: string, needle: string, occurrence = 1): number {
@@ -529,6 +530,22 @@ GET /_cat/indices`;
     const gapPos = sql.indexOf(";") + 1;
     const range = statementRangeAtCursor(sql, gapPos);
     expect(range?.sql.trim()).toBe("SELECT *\nFROM system_dept");
+  });
+
+  it("keeps a standalone next-line semicolon cursor on the current multi-line statement", () => {
+    const sql = "SELECT *\nFROM system_dept\n;\n\nSELECT * FROM sys;";
+    const delimiterPos = sql.indexOf(";");
+
+    expect(statementRangeAtCursor(sql, delimiterPos)?.sql.trim()).toBe("SELECT *\nFROM system_dept");
+    expect(statementRangeAtCursor(sql, delimiterPos + 1)?.sql.trim()).toBe("SELECT *\nFROM system_dept");
+  });
+
+  it("assigns a standalone trailing semicolon to the final soft statement", () => {
+    const sql = "SELECT * FROM `t_0001`\nSELECT * FROM `t_0001` LIMIT 1\n;";
+    const delimiterPos = sql.lastIndexOf(";");
+
+    expect(statementRangeAtCursor(sql, delimiterPos, "mysql")?.sql).toBe("SELECT * FROM `t_0001` LIMIT 1");
+    expect(statementRangeAtCursor(sql, delimiterPos + 1, "mysql")?.sql).toBe("SELECT * FROM `t_0001` LIMIT 1");
   });
 
   it("returns the next same-line statement when the cursor is inside it", () => {
@@ -1113,6 +1130,20 @@ describe("buildExecutionCandidates", () => {
     expect(candidateLabels(candidates)).toEqual(["currentStatement", "allStatements"]);
   });
 
+  it("keeps a MySQL FORCE INDEX query current when its semicolon is on the next line", () => {
+    const firstStatement = `SELECT count(*)
+FROM cus_loan_status_copy1 t2
+LEFT JOIN case_allocation_details_copy1 t4 FORCE INDEX(idx_debt_case_number)
+  ON t2.caseno = t4.debt_case_number
+WHERE t2.product_name = '12345'
+;`;
+    const sql = `${firstStatement}\n\nSELECT count(*) FROM cus_loan_status_copy1;`;
+    const candidates = buildExecutionCandidates(sql, indexOf(sql, "12345"), "mysql");
+
+    expect(candidateKinds(candidates)).toEqual(["cursor", "all"]);
+    expect(executionCandidateForMode(candidates, "current")?.sql.trim()).toBe(firstStatement.replace(/\n;$/, ""));
+  });
+
   it("uses the current statement when the cursor is immediately after its semicolon before a blank line", () => {
     const sql = "select 1;\n\nselect 2;";
     const cursorAfterFirstSemicolon = sql.indexOf(";") + 1;
@@ -1126,6 +1157,13 @@ describe("buildExecutionCandidates", () => {
     expect(candidateSummaries(candidates)).toEqual(["cursor:SELECT 2", "all:SELECT 1\nSELECT 2"]);
   });
 
+  it("uses the final soft statement when the cursor is on a standalone trailing semicolon", () => {
+    const sql = "SELECT * FROM `t_0001`\nSELECT * FROM `t_0001` LIMIT 1\n;";
+    const candidates = buildExecutionCandidates(sql, sql.lastIndexOf(";"), "mysql");
+
+    expect(candidateSummaries(candidates)).toEqual(["cursor:SELECT * FROM `t_0001` LIMIT 1", "all:SELECT * FROM `t_0001`\nSELECT * FROM `t_0001` LIMIT 1\n;"]);
+  });
+
   it("dedupes when the cursor statement equals the full document", () => {
     const sql = "SELECT 1;";
     const candidates = buildExecutionCandidates(sql, indexOf(sql, "1"));
@@ -1137,6 +1175,16 @@ describe("buildExecutionCandidates", () => {
     const sql = "SELECT 1;\n\nSELECT 2;";
     const candidates = buildExecutionCandidates(sql, sql.indexOf("\n") + 1);
     expect(candidateKinds(candidates)).toEqual(["all"]);
+    expect(candidates[0].supportedKinds).toEqual(["all"]);
+    expect(executionCandidateForMode(candidates, "current")).toBeNull();
+    expect(executionCandidateForMode(candidates, "all")).toBe(candidates[0]);
+  });
+
+  it("marks a deduplicated single-statement candidate as both current and all", () => {
+    const sql = "SELECT 1;";
+    const candidates = buildExecutionCandidates(sql, indexOf(sql, "1"));
+
+    expect(candidates[0].supportedKinds).toEqual(["cursor", "all"]);
   });
 
   it("returns no candidates for an empty document", () => {

--- a/apps/desktop/src/lib/sql/currentStatementFrame.ts
+++ b/apps/desktop/src/lib/sql/currentStatementFrame.ts
@@ -1,7 +1,9 @@
 import type { SqlTextRange } from "@/lib/sql/sqlStatementRanges";
+import { trailingStatementDelimiterPosition, type StatementDelimiterDocument } from "@/lib/sql/statementDelimiter";
 
-export function currentStatementFrameRangeTo(nextChar: string, range: SqlTextRange): number {
-  return nextChar === ";" ? range.to + 1 : range.to;
+export function currentStatementFrameRangeTo(doc: StatementDelimiterDocument, range: SqlTextRange): number {
+  const delimiterPos = trailingStatementDelimiterPosition(doc, range.to);
+  return delimiterPos === null ? range.to : delimiterPos + 1;
 }
 
 export function shouldRebuildCurrentStatementFrame(update: { docChanged: boolean; selectionSet: boolean; configurationChanged: boolean }): boolean {

--- a/apps/desktop/src/lib/sql/executableStatementRangeCache.ts
+++ b/apps/desktop/src/lib/sql/executableStatementRangeCache.ts
@@ -2,6 +2,7 @@ import type { Text } from "@codemirror/state";
 import type { DatabaseType } from "@/types/database";
 import { readSqlBracedParameterAt, type SqlParameterOptions } from "@/lib/sql/sqlParameters";
 import { executableStatementRanges, type SqlTextRange } from "@/lib/sql/sqlStatementRanges";
+import { cursorBelongsToTrailingStatementDelimiter } from "@/lib/sql/statementDelimiter";
 
 export interface ExecutableStatementRangeCache {
   doc: Text;
@@ -61,7 +62,7 @@ export function executableStatementRangeAtCursor(cache: ExecutableStatementRange
     }
 
     const next = cache.ranges[index + 1];
-    if (pos > range.to && (!next || pos < next.from) && range.to >= line.from && range.to <= line.to && cursorRemainsOnRangeLine(cache.doc, range.to, pos)) {
+    if (pos > range.to && (!next || pos < next.from) && cursorBelongsToTrailingStatementDelimiter(cache.doc, range.to, pos)) {
       return range;
     }
   }
@@ -79,15 +80,4 @@ function isCursorOnLeadingBlockComment(lineText: string, lineOffset: number): bo
   if (!afterComment.trim()) return true;
 
   return lineOffset <= commentEnd + 2;
-}
-
-function cursorRemainsOnRangeLine(doc: Text, rangeTo: number, cursorPos: number): boolean {
-  const between = doc.sliceString(rangeTo, cursorPos);
-  if (between.includes("\n")) return false;
-  const delimiterIndex = between.lastIndexOf(";");
-  if (delimiterIndex === -1) return between.trim() === "";
-
-  const beforeDelimiter = between.slice(0, delimiterIndex);
-  const afterDelimiter = between.slice(delimiterIndex + 1);
-  return beforeDelimiter.trim() === "" && afterDelimiter.trim() === "";
 }

--- a/apps/desktop/src/lib/sql/sqlExecutionTarget.ts
+++ b/apps/desktop/src/lib/sql/sqlExecutionTarget.ts
@@ -23,6 +23,7 @@ export type SqlExecutionTargetKind = "cursor" | "all";
  */
 export interface SqlExecutionCandidate {
   kind: SqlExecutionTargetKind;
+  supportedKinds: SqlExecutionTargetKind[];
   label: string;
   sql: string;
   from: number;
@@ -38,6 +39,11 @@ export interface SqlExecutionChoiceRequest {
 
 export function isSqlExecutionSnapshot(value: SqlExecutionOverride | undefined): value is SqlExecutionSnapshot {
   return typeof value === "object" && value !== null && typeof value.fullSql === "string" && typeof value.selectedSql === "string" && typeof value.cursorPos === "number" && typeof value.selectionFrom === "number" && typeof value.selectionTo === "number";
+}
+
+export function executionCandidateForMode(candidates: SqlExecutionCandidate[], mode: ExecuteMode): SqlExecutionCandidate | null {
+  const targetKind: SqlExecutionTargetKind = mode === "current" ? "cursor" : "all";
+  return candidates.find((candidate) => candidate.supportedKinds.includes(targetKind)) ?? null;
 }
 
 export function resolveExecutableSql(fullSql: string, selectedSql: string, options?: { mode?: ExecuteMode; cursorPos?: number }): string {

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -1,4 +1,5 @@
 import type { SqlExecutionCandidate } from "@/lib/sql/sqlExecutionTarget";
+import { cursorBelongsToTrailingStatementDelimiter } from "@/lib/sql/statementDelimiter";
 import { splitMongoCommandRanges } from "@/lib/mongo/mongoShellCommand";
 import { readSqlBracedParameterAt, type SqlParameterOptions } from "@/lib/sql/sqlParameters";
 import { isElasticsearchCompatibleDatabaseType, type DatabaseType } from "@/types/database";
@@ -576,8 +577,8 @@ export function statementRangeAtCursor(sql: string, cursorPos: number, databaseT
     const next = statements[index + 1];
     // A caret after a statement's semicolon still belongs to that statement
     // until the next statement's text begins.
-    if (pos > statement.to && (!next || pos < next.from) && isCursorInSameLineDelimiterGap(sql, statement.to, pos)) {
-      return rangeForCursorInSoftRanges(sql, softRanges, pos) ?? rangeFor(statement, sql);
+    if (pos > statement.to && (!next || pos < next.from) && isCursorInTrailingDelimiterGap(sql, statement.to, pos)) {
+      return rangeForCursorInSoftRanges(sql, softRanges, pos) ?? rangeFor(softRanges[softRanges.length - 1] ?? statement, sql);
     }
 
     // Cursor in indentation or inter-statement whitespace immediately before
@@ -585,9 +586,9 @@ export function statementRangeAtCursor(sql: string, cursorPos: number, databaseT
     // execution range remains tight around the SQL text itself.
     if (pos >= statement.hitFrom && pos < statement.from && (sql.slice(pos, statement.from).trim() === "" || (isElasticsearchCompatibleDatabaseType(databaseType) && isElasticsearchRequestPreamble(sql.slice(statement.hitFrom, statement.from))))) {
       const previous = statements[index - 1];
-      if (previous && isCursorInSameLineDelimiterGap(sql, previous.to, pos)) {
+      if (previous && isCursorInTrailingDelimiterGap(sql, previous.to, pos)) {
         const previousSoftRanges = splitStatementRangeAtSoftStarts(sql, previous, databaseType, parameterOptions);
-        return rangeForCursorInSoftRanges(sql, previousSoftRanges, pos) ?? rangeFor(previous, sql);
+        return rangeForCursorInSoftRanges(sql, previousSoftRanges, pos) ?? rangeFor(previousSoftRanges[previousSoftRanges.length - 1] ?? previous, sql);
       }
       return rangeForCursorInSoftRanges(sql, softRanges, pos) ?? rangeFor(statement, sql);
     }
@@ -614,7 +615,7 @@ export function mongoCommandRangeAtCursor(sql: string, cursorPos: number): SqlTe
     if (pos >= command.from && pos <= command.to) return range;
 
     const next = commands[index + 1];
-    if (pos > command.to && (!next || pos < next.from) && isCursorInSameLineDelimiterGap(sql, command.to, pos)) return range;
+    if (pos > command.to && (!next || pos < next.from) && isCursorInTrailingDelimiterGap(sql, command.to, pos)) return range;
 
     if (pos < command.from && sql.slice(pos, command.from).trim() === "" && isCursorOnStatementLine(sql, pos, command)) return range;
   }
@@ -622,13 +623,8 @@ export function mongoCommandRangeAtCursor(sql: string, cursorPos: number): SqlTe
   return null;
 }
 
-function isCursorInSameLineDelimiterGap(sql: string, previousStatementEnd: number, cursorPos: number): boolean {
-  if (cursorPos <= previousStatementEnd) return false;
-  const between = sql.slice(previousStatementEnd, cursorPos);
-  const delimiterIndex = between.lastIndexOf(";");
-  if (delimiterIndex === -1) return false;
-  const afterDelimiter = between.slice(delimiterIndex + 1);
-  return !afterDelimiter.includes("\n") && between.slice(0, delimiterIndex).trim() === "" && afterDelimiter.trim() === "";
+function isCursorInTrailingDelimiterGap(sql: string, previousStatementEnd: number, cursorPos: number): boolean {
+  return cursorBelongsToTrailingStatementDelimiter(sql, previousStatementEnd, cursorPos);
 }
 
 function rangeForCursorInSoftRanges(sql: string, ranges: RawStatement[], pos: number): SqlTextRange | null {
@@ -2043,16 +2039,17 @@ export function buildExecutionCandidates(sql: string, cursorPos: number, databas
 
   const sameContent = normalizeSql(cursorStatement.sql) === normalizeSql(full.sql);
   if (sameContent) {
-    return [candidateFromRange(full, "all", databaseType)];
+    return [candidateFromRange(full, "all", databaseType, ["cursor", "all"])];
   }
 
   return [candidateFromRange(cursorStatement, "cursor", databaseType), candidateFromRange(full, "all", databaseType)];
 }
 
-function candidateFromRange(range: SqlTextRange, kind: SqlExecutionCandidate["kind"], databaseType?: DatabaseType): SqlExecutionCandidate {
+function candidateFromRange(range: SqlTextRange, kind: SqlExecutionCandidate["kind"], databaseType?: DatabaseType, supportedKinds: SqlExecutionCandidate["supportedKinds"] = [kind]): SqlExecutionCandidate {
   const isRedis = databaseType === "redis";
   return {
     kind,
+    supportedKinds,
     label: kind === "cursor" ? (isRedis ? "currentCommand" : "currentStatement") : isRedis ? "allCommands" : "allStatements",
     sql: range.sql,
     from: range.from,

--- a/apps/desktop/src/lib/sql/statementDelimiter.ts
+++ b/apps/desktop/src/lib/sql/statementDelimiter.ts
@@ -1,0 +1,32 @@
+export interface StatementDelimiterDocument {
+  readonly length: number;
+  sliceString(from: number, to: number): string;
+}
+
+type StatementDelimiterSource = string | StatementDelimiterDocument;
+
+export function trailingStatementDelimiterPosition(source: StatementDelimiterSource, rangeTo: number): number | null {
+  let delimiterPos = rangeTo;
+  let lineBreakCount = 0;
+  while (delimiterPos < source.length) {
+    const char = sliceSource(source, delimiterPos, delimiterPos + 1);
+    if (!/\s/u.test(char)) break;
+    if (char === "\n" && ++lineBreakCount > 1) return null;
+    delimiterPos += 1;
+  }
+  return sliceSource(source, delimiterPos, delimiterPos + 1) === ";" ? delimiterPos : null;
+}
+
+export function cursorBelongsToTrailingStatementDelimiter(source: StatementDelimiterSource, rangeTo: number, cursorPos: number): boolean {
+  if (cursorPos < rangeTo) return false;
+  const delimiterPos = trailingStatementDelimiterPosition(source, rangeTo);
+  if (delimiterPos === null) return false;
+  if (cursorPos <= delimiterPos + 1) return true;
+
+  const afterDelimiter = sliceSource(source, delimiterPos + 1, cursorPos);
+  return !afterDelimiter.includes("\n") && afterDelimiter.trim() === "";
+}
+
+function sliceSource(source: StatementDelimiterSource, from: number, to: number): string {
+  return typeof source === "string" ? source.slice(from, to) : source.sliceString(from, to);
+}

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -1613,12 +1613,19 @@ fn classify_query_error(db_type: Option<DatabaseType>, error: QueryExecutionErro
         QueryExecutionError::Legacy(message) if is_dbx_query_timeout_error(&message.to_ascii_lowercase()) => {
             QueryExecutionError::Timeout(message)
         }
-        QueryExecutionError::Legacy(message)
-            if db_type == Some(DatabaseType::Postgres) && message.trim_start().starts_with("ERROR:") =>
-        {
+        QueryExecutionError::Legacy(message) if is_native_sql_server_error(db_type, &message) => {
             QueryExecutionError::Sql(message)
         }
         other => other,
+    }
+}
+
+fn is_native_sql_server_error(db_type: Option<DatabaseType>, message: &str) -> bool {
+    let message = message.trim_start();
+    match db_type {
+        Some(DatabaseType::Postgres) => message.starts_with("ERROR:"),
+        Some(DatabaseType::Mysql) => message.starts_with("Server error: `ERROR "),
+        _ => false,
     }
 }
 
@@ -5039,6 +5046,31 @@ for line in sys.stdin:
             backend_error.detail(),
             Some(
                 "ERROR: relation \"dbx_table_that_does_not_exist\" does not exist SQL text omitted from user-facing error; enable debug SQL diagnostics for a redacted statement."
+            )
+        );
+    }
+
+    #[test]
+    fn mysql_server_error_preserves_sql_catalog_identity_and_detail() {
+        let error = classify_query_error(
+            Some(DatabaseType::Mysql),
+            QueryExecutionError::Legacy(
+                "Server error: `ERROR 1064 (42000): You have an error in your SQL syntax`".to_string(),
+            ),
+        )
+        .with_omitted_sql_context("SELECT 111 AS first_value FROM DUAL");
+        let backend_error = error.into_backend_error();
+
+        assert_eq!(backend_error.code(), "DBX-JDBC-4001");
+        assert_eq!(backend_error.message_key(), "backendErrors.jdbc.sqlFailed");
+        assert_eq!(
+            backend_error.message_params().get("stage"),
+            Some(&crate::backend_error::BackendMessageParam::String("execute".to_string()))
+        );
+        assert_eq!(
+            backend_error.detail(),
+            Some(
+                "Server error: `ERROR 1064 (42000): You have an error in your SQL syntax` SQL text omitted from user-facing error; enable debug SQL diagnostics for a redacted statement."
             )
         );
     }

--- a/crates/dbx-mcp/src/transport.rs
+++ b/crates/dbx-mcp/src/transport.rs
@@ -32,31 +32,29 @@ where
         self.inner.send(item)
     }
 
-    fn receive(&mut self) -> impl Future<Output = Option<RxJsonRpcMessage<RoleServer>>> + Send {
-        async move {
-            loop {
-                let message = self.inner.receive().await?;
-                let discovery_request_id = match &message {
-                    ClientJsonRpcMessage::Request(request)
-                        if matches!(
-                            &request.request,
-                            ClientRequest::CustomRequest(custom) if custom.method == "server/discover"
-                        ) =>
-                    {
-                        Some(request.id.clone())
-                    }
-                    _ => None,
-                };
-
-                let Some(request_id) = discovery_request_id else {
-                    return Some(message);
-                };
-
-                // Reject discovery without closing so new clients can fall back to the legacy initialize flow.
-                let error = ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None);
-                if self.inner.send(ServerJsonRpcMessage::error(error, Some(request_id))).await.is_err() {
-                    return None;
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        loop {
+            let message = self.inner.receive().await?;
+            let discovery_request_id = match &message {
+                ClientJsonRpcMessage::Request(request)
+                    if matches!(
+                        &request.request,
+                        ClientRequest::CustomRequest(custom) if custom.method == "server/discover"
+                    ) =>
+                {
+                    Some(request.id.clone())
                 }
+                _ => None,
+            };
+
+            let Some(request_id) = discovery_request_id else {
+                return Some(message);
+            };
+
+            // Reject discovery without closing so new clients can fall back to the legacy initialize flow.
+            let error = ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None);
+            if self.inner.send(ServerJsonRpcMessage::error(error, Some(request_id))).await.is_err() {
+                return None;
             }
         }
     }


### PR DESCRIPTION
## 修改内容

- “执行光标所在语句”模式下，光标位于空白行时不再回退执行整个编辑器内容
- 支持将紧邻下一行的独立分号纳入当前语句外框，并让分号字符及其后位置归属前一条语句
- 连续顶层 SQL 缺少分号时，将末尾独立分号归属最后一个软分段，避免把多条 SQL 拼接执行
- 保持空白行、注释和后续语句的范围隔离
- 将 MySQL 原生服务端 SQL 错误归类为 SQL 执行错误，提供更准确的错误摘要

## 验证

- `pnpm exec vitest run ...`：6 个测试文件、363 项测试通过
- `pnpm -s typecheck` 通过
- `pnpm -s lint` 通过（仅仓库已有 warning）
- `cargo fmt --all -- --check` 通过
- `cargo test -p dbx-core mysql_server_error_preserves_sql_catalog_identity_and_detail` 通过
- MySQL 8.4 实际验证：在第三行独立分号处执行两条无分号分隔的顶层 `SELECT`，仅执行最后一个软分段并返回预期结果
