### PR TITLE
Fix：修复 GBase 8s 连接资源耗尽及表数据访问异常

### DIFF
--- a/agents/common/src/main/java/com/dbx/agent/AbstractJdbcAgent.java
+++ b/agents/common/src/main/java/com/dbx/agent/AbstractJdbcAgent.java
@@ -270,6 +270,10 @@ public abstract class AbstractJdbcAgent extends BaseDatabaseAgent {
         poolRegistry = registry;
     }
 
+    public boolean supportsConnectionPooling() {
+        return true;
+    }
+
     final synchronized boolean usesConnectionPool() {
         return poolRegistry != null;
     }
@@ -531,7 +535,7 @@ public abstract class AbstractJdbcAgent extends BaseDatabaseAgent {
         return this::resultValue;
     }
 
-    private Connection openInitializedConnection(ConnectParams params) throws Exception {
+    protected final Connection openInitializedConnection(ConnectParams params) throws Exception {
         Connection opened = openConnection(params);
         try {
             afterPhysicalConnect(params, opened);

--- a/agents/common/src/main/java/com/dbx/agent/MultiSessionJsonRpcServer.java
+++ b/agents/common/src/main/java/com/dbx/agent/MultiSessionJsonRpcServer.java
@@ -181,7 +181,9 @@ public final class MultiSessionJsonRpcServer implements AutoCloseable {
             session = new Session(sessionHandlerFactory.get());
         } else {
             DatabaseAgent agent = agentFactory.get();
-            if (poolRegistry.isEnabled() && agent instanceof AbstractJdbcAgent jdbcAgent) {
+            if (poolRegistry.isEnabled()
+                && agent instanceof AbstractJdbcAgent jdbcAgent
+                && jdbcAgent.supportsConnectionPooling()) {
                 jdbcAgent.attachConnectionPoolRegistry(poolRegistry);
                 ensureMaintenanceStarted();
             }

--- a/agents/drivers/gbase8s/src/main/java/com/dbx/agent/gbase8s/Gbase8sAgent.java
+++ b/agents/drivers/gbase8s/src/main/java/com/dbx/agent/gbase8s/Gbase8sAgent.java
@@ -46,9 +46,15 @@ public final class Gbase8sAgent extends ConfiguredJdbcAgent {
     private String tableCacheSchema = "";
     private long tableCacheTimeMillis;
     private List<TableInfo> tableCache = Collections.emptyList();
+    private ConnectParams databaseListParams;
 
     public Gbase8sAgent() {
         super(GBASE8S_PROFILE);
+    }
+
+    @Override
+    public boolean supportsConnectionPooling() {
+        return false;
     }
 
     public static String buildUrl(ConnectParams params) {
@@ -78,6 +84,38 @@ public final class Gbase8sAgent extends ConfiguredJdbcAgent {
         return defaultGbaseServer(params.getHost());
     }
 
+    static String buildUrlForDatabase(ConnectParams params, String database) {
+        return buildUrl(paramsForDatabase(params, database));
+    }
+
+    private static ConnectParams paramsForDatabase(ConnectParams params, String database) {
+        String connectionString = trim(params.getConnection_string());
+        if (!connectionString.isEmpty()) {
+            int schemeEnd = connectionString.indexOf("://");
+            int databaseStart = schemeEnd < 0 ? -1 : connectionString.indexOf('/', schemeEnd + 3);
+            if (databaseStart >= 0) {
+                int paramsStart = connectionString.indexOf(':', databaseStart + 1);
+                String suffix = paramsStart >= 0 ? connectionString.substring(paramsStart) : "";
+                connectionString = connectionString.substring(0, databaseStart + 1) + database + suffix;
+            }
+        }
+
+        ConnectParams databaseParams = new ConnectParams(
+            params.getHost(),
+            params.getPort(),
+            database,
+            params.getUsername(),
+            params.getPassword(),
+            params.getUrl_params(),
+            connectionString,
+            params.isMysql_compat_mode(),
+            params.getJdbc_driver_class(),
+            params.getJdbc_driver_paths()
+        );
+        databaseParams.setGbase_server(getGbaseServer(params));
+        return databaseParams;
+    }
+
     @Override
     protected String buildJdbcUrl(ConnectParams params) {
         return buildUrl(params);
@@ -86,11 +124,13 @@ public final class Gbase8sAgent extends ConfiguredJdbcAgent {
     @Override
     protected void afterConnect(ConnectParams params, Connection connection) {
         super.afterConnect(params, connection);
+        databaseListParams = paramsForDatabase(params, "sysmaster");
         clearMetadataCache();
     }
 
     @Override
     protected void afterDisconnect() {
+        databaseListParams = null;
         clearMetadataCache();
     }
 
@@ -109,13 +149,7 @@ public final class Gbase8sAgent extends ConfiguredJdbcAgent {
         if (cached != null) {
             return cached;
         }
-        List<String> names = queryDatabaseNamesInCatalog("sysmaster", "SELECT name FROM sysdatabases ORDER BY name");
-        if (names.isEmpty()) {
-            names = queryDatabaseNames("SELECT name FROM sysmaster:sysdatabases ORDER BY name");
-        }
-        if (names.isEmpty()) {
-            names = queryDatabaseNames("SELECT name FROM sysdatabases ORDER BY name");
-        }
+        List<String> names = queryDatabaseNamesFromSysmaster();
         if (names.isEmpty()) {
             return super.listDatabases();
         }
@@ -135,8 +169,14 @@ public final class Gbase8sAgent extends ConfiguredJdbcAgent {
             if (cached != null) {
                 return cached;
             }
+            Connection connection = requireConnection();
+            if (!connection.getMetaData().supportsSchemasInDataManipulation()) {
+                List<String> schemas = Collections.emptyList();
+                cacheSchemas(catalog, schemas);
+                return schemas;
+            }
             Set<String> schemas = new LinkedHashSet<>();
-            try (PreparedStatement stmt = requireConnection().prepareStatement(
+            try (PreparedStatement stmt = connection.prepareStatement(
                 "SELECT DISTINCT owner FROM systables WHERE tabid >= 100 AND tabtype IN ('T', 'V') ORDER BY owner"
             ); ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
@@ -419,33 +459,13 @@ public final class Gbase8sAgent extends ConfiguredJdbcAgent {
         return value.toLowerCase(Locale.ROOT).contains(needle.toLowerCase(Locale.ROOT));
     }
 
-    private List<String> queryDatabaseNames(String sql) {
-        try {
-            return queryDatabaseNames(requireConnection(), sql);
-        } catch (Exception ignored) {
+    private List<String> queryDatabaseNamesFromSysmaster() {
+        ConnectParams params = databaseListParams;
+        if (params == null) {
             return Collections.emptyList();
         }
-    }
-
-    private List<String> queryDatabaseNamesInCatalog(String catalog, String sql) {
-        try {
-            Connection connection = requireConnection();
-            String previousCatalog = "";
-            try {
-                previousCatalog = trim(connection.getCatalog());
-            } catch (Exception ignored) {
-            }
-            connection.setCatalog(catalog);
-            try {
-                return queryDatabaseNames(connection, sql);
-            } finally {
-                if (!previousCatalog.isEmpty()) {
-                    try {
-                        connection.setCatalog(previousCatalog);
-                    } catch (Exception ignored) {
-                    }
-                }
-            }
+        try (Connection connection = openInitializedConnection(params)) {
+            return queryDatabaseNames(connection, "SELECT name FROM sysdatabases ORDER BY name");
         } catch (Exception ignored) {
             return Collections.emptyList();
         }

--- a/agents/drivers/gbase8s/src/test/java/com/dbx/agent/gbase8s/Gbase8sAgentTest.java
+++ b/agents/drivers/gbase8s/src/test/java/com/dbx/agent/gbase8s/Gbase8sAgentTest.java
@@ -14,6 +14,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ class Gbase8sAgentTest {
         Assertions.assertEquals("jdbc:gbasedbt-sqli://{host}:{port}/{database}:GBASEDBTSERVER=gbase8s", agent.getProfile().getUrlTemplate());
         Assertions.assertEquals(9088, agent.getProfile().getDefaultPort());
         Assertions.assertTrue(agent.getProfile().getSkipExecutionContext());
+        Assertions.assertFalse(agent.supportsConnectionPooling());
     }
 
     @Test
@@ -112,6 +114,71 @@ class Gbase8sAgentTest {
         );
 
         Assertions.assertEquals("jdbc:gbasedbt-sqli://db.example.com:20013/app:GBASEDBTSERVER=gbase01", url);
+    }
+
+    @Test
+    void buildsSysmasterUrlWithoutChangingTheConfiguredDatabase() {
+        ConnectParams params = new ConnectParams(
+            "db.example.com",
+            20013,
+            "appdb",
+            "user",
+            "password",
+            "CLIENT_LOCALE=zh_cn.utf8",
+            "",
+            false
+        );
+        params.setGbase_server("gbase01");
+
+        Assertions.assertEquals(
+            "jdbc:gbasedbt-sqli://db.example.com:20013/sysmaster:GBASEDBTSERVER=gbase01;CLIENT_LOCALE=zh_cn.utf8",
+            Gbase8sAgent.buildUrlForDatabase(params, "sysmaster")
+        );
+    }
+
+    @Test
+    void replacesDatabaseInCustomConnectionStringForDatabaseListing() {
+        ConnectParams params = new ConnectParams(
+            "",
+            0,
+            "",
+            "user",
+            "password",
+            "",
+            "jdbc:gbasedbt-sqli://db.example.com:20013/appdb:GBASEDBTSERVER=gbase01;CLIENT_LOCALE=zh_cn.utf8",
+            false
+        );
+
+        Assertions.assertEquals(
+            "jdbc:gbasedbt-sqli://db.example.com:20013/sysmaster:GBASEDBTSERVER=gbase01;CLIENT_LOCALE=zh_cn.utf8",
+            Gbase8sAgent.buildUrlForDatabase(params, "sysmaster")
+        );
+    }
+
+    @Test
+    void omitsOwnerSchemasWhenTheDatabaseCannotUseThemInDml() {
+        List<String> sql = new ArrayList<>();
+        Gbase8sAgent agent = new Gbase8sAgent();
+        TestSupport.setPrivateConnection(
+            agent,
+            schemaConnection(false, sql, resultSet(new String[]{"owner"}, new Object[][]{{"gbasedbt"}}))
+        );
+
+        Assertions.assertTrue(agent.listSchemas().isEmpty());
+        Assertions.assertTrue(sql.isEmpty());
+    }
+
+    @Test
+    void listsOwnerSchemasWhenTheDatabaseSupportsThemInDml() {
+        List<String> sql = new ArrayList<>();
+        Gbase8sAgent agent = new Gbase8sAgent();
+        TestSupport.setPrivateConnection(
+            agent,
+            schemaConnection(true, sql, resultSet(new String[]{"owner"}, new Object[][]{{"gbasedbt"}}))
+        );
+
+        Assertions.assertEquals(List.of("gbasedbt"), agent.listSchemas());
+        Assertions.assertEquals(1, sql.size());
     }
 
     @Test
@@ -355,6 +422,37 @@ class Gbase8sAgentTest {
         return proxy(Connection.class, (method, args) -> {
             if ("getCatalog".equals(method.getName())) {
                 return "appdb";
+            }
+            if ("prepareStatement".equals(method.getName())) {
+                sql.add(String.valueOf(args[0]));
+                return statement;
+            }
+            if ("isClosed".equals(method.getName())) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static Connection schemaConnection(boolean supportsSchemasInDml, List<String> sql, ResultSet resultSet) {
+        DatabaseMetaData metadata = proxy(DatabaseMetaData.class, (method, args) -> {
+            if ("supportsSchemasInDataManipulation".equals(method.getName())) {
+                return supportsSchemasInDml;
+            }
+            return defaultValue(method.getReturnType());
+        });
+        PreparedStatement statement = proxy(PreparedStatement.class, (method, args) -> {
+            if ("executeQuery".equals(method.getName())) {
+                return resultSet;
+            }
+            return defaultValue(method.getReturnType());
+        });
+        return proxy(Connection.class, (method, args) -> {
+            if ("getCatalog".equals(method.getName())) {
+                return "appdb";
+            }
+            if ("getMetaData".equals(method.getName())) {
+                return metadata;
             }
             if ("prepareStatement".equals(method.getName())) {
                 sql.add(String.valueOf(args[0]));

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -51,6 +51,7 @@ import { JDBCX_DEFAULT_URL, JDBCX_DRIVER_PROFILE, JDBCX_JDBC_DRIVER_CLASS, ensur
 import { SQLITE_DATABASE_FILE_EXTENSIONS } from "@/lib/database/databaseFileDetection";
 import { connectionAttemptOriginalErrorMessage, connectionAttemptTimeoutMessage, connectionAttemptTimeoutMs } from "@/lib/connection/connectionAttemptTimeout";
 import { appendConnectionErrorHints, isJdbcMissingRuntimeDependencyError } from "@/lib/connection/connectionErrorHints";
+import { preventDialogDocumentSelectAll } from "@/lib/connection/dialogTextSelection";
 import { postgresTlsModeForForm } from "@/lib/connection/postgresTlsMode";
 import { buildMqKafkaConnectionExtra, mqKafkaConnectionTarget, resolveMqKafkaConnectionSource, type MqKafkaConnectionSource } from "@/lib/connection/mqKafkaConnection";
 import { assertCompleteDatabaseCategories, databaseSelectionForCategory } from "@/lib/connection/databaseCategoryOptions";
@@ -4735,7 +4736,7 @@ function openExternalUrl(url: string) {
 
 <template>
   <Dialog v-model:open="open">
-    <DialogContent class="connection-dialog-content" :class="connectionDialogContentClass" :data-wide="shouldUseWideConnectionDialog ? 'true' : undefined" @interact-outside.prevent @escape-key-down="handleDialogEscape">
+    <DialogContent class="connection-dialog-content" :class="connectionDialogContentClass" :data-wide="shouldUseWideConnectionDialog ? 'true' : undefined" @interact-outside.prevent @escape-key-down="handleDialogEscape" @keydown="preventDialogDocumentSelectAll">
       <DialogHeader>
         <DialogTitle>{{ editingId ? t("connection.editTitle") : t("connection.title") }}</DialogTitle>
       </DialogHeader>
@@ -6000,7 +6001,10 @@ function openExternalUrl(url: string) {
 
                   <div v-if="form.driver_profile === 'gbase8s'" class="grid grid-cols-4 items-center gap-4">
                     <Label :class="connectionLabelSmallClass">{{ t("connection.gbaseServer") }}</Label>
-                    <Input v-model="form.gbase_server" class="col-span-3" placeholder="gbase01" />
+                    <div class="col-span-3 space-y-1">
+                      <Input v-model="form.gbase_server" placeholder="gbase01" />
+                      <p class="text-xs text-muted-foreground">{{ t("connection.gbaseServerHint") }}</p>
+                    </div>
                   </div>
 
                   <div v-if="form.db_type === 'informix'" class="grid grid-cols-4 items-center gap-4">
@@ -7126,7 +7130,7 @@ function openExternalUrl(url: string) {
   </Dialog>
 
   <Dialog v-model:open="showVisibleDatabasesDialog">
-    <DialogContent class="sm:max-w-[460px]">
+    <DialogContent class="sm:max-w-[520px]" @keydown="preventDialogDocumentSelectAll">
       <DialogHeader>
         <DialogTitle>{{ t(visibleObjectTitleKey) }}</DialogTitle>
         <p class="text-sm text-muted-foreground">
@@ -7174,9 +7178,7 @@ function openExternalUrl(url: string) {
           <Loader2 class="h-4 w-4 animate-spin" />
           {{ t("common.loading") }}
         </div>
-        <div v-else-if="visibleDatabaseError" class="p-3 text-sm text-destructive">
-          {{ t(visibleObjectLoadFailedKey, { message: visibleDatabaseError }) }}
-        </div>
+        <textarea v-else-if="visibleDatabaseError" class="h-full w-full resize-none overflow-auto border-0 bg-transparent p-3 text-sm leading-5 text-destructive outline-none" :value="t(visibleObjectLoadFailedKey, { message: visibleDatabaseError })" readonly />
         <div v-else-if="!filteredVisibleDatabaseNames.length" class="p-3 text-sm text-muted-foreground">
           {{ t("grid.noSearchResults") }}
         </div>

--- a/apps/desktop/src/components/connection/ConnectionErrorIndicator.vue
+++ b/apps/desktop/src/components/connection/ConnectionErrorIndicator.vue
@@ -24,6 +24,10 @@ const errorMessage = computed(() => (props.connectionId ? connectionStore.connec
 function clearError() {
   if (props.connectionId) connectionStore.clearConnectionError(props.connectionId);
 }
+
+function selectErrorText(event: FocusEvent) {
+  if (event.target instanceof HTMLTextAreaElement) event.target.select();
+}
 </script>
 
 <template>
@@ -40,15 +44,13 @@ function clearError() {
         <AlertTriangle class="h-3.5 w-3.5" />
       </button>
     </PopoverTrigger>
-    <PopoverContent side="top" class="w-72 gap-2 p-2 text-xs" @click.stop>
+    <PopoverContent side="top" class="w-96 max-w-[calc(100vw-2rem)] gap-2 p-2 text-xs" @click.stop>
       <div class="flex items-start gap-2">
         <div class="min-w-0 flex-1">
           <div class="font-medium text-foreground">
             {{ t("connection.lastError") }}
           </div>
-          <div class="mt-1 max-h-36 overflow-auto whitespace-pre-wrap break-words text-muted-foreground">
-            {{ errorMessage }}
-          </div>
+          <textarea class="mt-1 max-h-40 min-h-20 w-full resize-none overflow-auto rounded border bg-muted/30 p-2 font-mono text-[11px] leading-4 text-muted-foreground outline-none" :value="errorMessage" readonly @focus="selectErrorText" />
         </div>
         <button type="button" class="shrink-0 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground" @click="clearError">{{ t("connection.clearError") }}</button>
       </div>

--- a/apps/desktop/src/i18n/__tests__/backendErrors.spec.ts
+++ b/apps/desktop/src/i18n/__tests__/backendErrors.spec.ts
@@ -99,6 +99,11 @@ const CASES: { name: string; message: string; key: string; params?: Record<strin
     params: { labels: "Prod MySQL, Stage PG" },
   },
   {
+    name: "GBase 8s server name mismatch",
+    message: "Agent RPC error (-1): java.sql.SQLException: GBASEDBTSERVER 与 DBSERVERNAME 或 DBSERVERALIASES 不匹配。",
+    key: "connection.gbaseServerMismatch",
+  },
+  {
     name: "Kafka topic unload unsupported",
     message: "Kafka does not support unloading topics",
     key: "mqClients.unloadTopicUnsupportedKafka",

--- a/apps/desktop/src/i18n/backend-errors.ts
+++ b/apps/desktop/src/i18n/backend-errors.ts
@@ -41,6 +41,7 @@ const patterns: [RegExp, string][] = [
   [/^Custom Java runtime path is empty\. Please choose a Java executable\.$/, "connection.customJavaPathEmpty"],
   [/^Agent requires Java 21, but DBX started it with an older Java runtime\. Use DBX managed JRE 21 or select a Java 21 executable in Driver Manager\./, "connection.agentJavaTooOld"],
   [/^JDBC plugin is not installed\. Install the optional JDBC plugin to use this connection\.$/, "connection.jdbcPluginNotInstalled"],
+  [/GBASEDBTSERVER[\s\S]*DBSERVERNAME[\s\S]*DBSERVERALIASES/, "connection.gbaseServerMismatch"],
   [/^ai\.configNameExists:(.+)$/, "ai.configNameExists"],
 
   // Tunnel / proxy test messages

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -263,6 +263,8 @@ export default {
     hiveJvmOptions: "JVM Options",
     hiveJvmOptionsPlaceholder: "-Dsun.security.krb5.debug=true",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "Must match the server DBSERVERNAME or DBSERVERALIASES.",
+    gbaseServerMismatch: "GBase 8s connection failed because GBASEDBTSERVER does not match the server DBSERVERNAME or DBSERVERALIASES. Fill GBASEDBTSERVER with the actual server name.",
     informixServer: "INFORMIXSERVER",
     sslEnable: "Enable encrypted connection",
     caCertPath: "CA Certificate",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -248,6 +248,8 @@ export default withEnglishFallback({
     d1TokenHint: "El token necesita al menos el permiso D1 Read; las escrituras, el DDL y las importaciones también requieren D1 Write.",
     d1FieldsRequired: "Se requieren el ID de cuenta de Cloudflare, el ID de la base de datos D1 y el token de API.",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "Debe coincidir con el DBSERVERNAME del servidor o con DBSERVERALIASES.",
+    gbaseServerMismatch: "Falló la conexión de GBase 8s: GBASEDBTSERVER no coincide con el DBSERVERNAME del servidor ni con sus DBSERVERALIASES. Introduce el nombre real del servidor.",
     informixServer: "INFORMIXSERVER",
     sslEnable: "Habilitar conexión cifrada",
     caCertPath: "Certificado CA",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -247,6 +247,8 @@ export default withEnglishFallback({
     d1TokenHint: "Il token richiede almeno l'autorizzazione D1 Read; per scritture, DDL e importazioni è necessaria anche D1 Write.",
     d1FieldsRequired: "Sono obbligatori l'ID account Cloudflare, l'ID database D1 e il token API.",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "Deve corrispondere al DBSERVERNAME del server o a DBSERVERALIASES.",
+    gbaseServerMismatch: "Connessione GBase 8s non riuscita: GBASEDBTSERVER non corrisponde al DBSERVERNAME del server o a uno dei DBSERVERALIASES. Inserisci il nome server effettivo.",
     informixServer: "INFORMIXSERVER",
     sslEnable: "Abilita connessione crittografata",
     caCertPath: "Certificato CA",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -247,6 +247,8 @@ export default withEnglishFallback({
     d1TokenHint: "トークンには少なくともD1 Read権限が必要です。書き込み、DDL、インポートにはD1 Write権限も必要です。",
     d1FieldsRequired: "CloudflareアカウントID、D1データベースID、APIトークンは必須です。",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "サーバー側の DBSERVERNAME または DBSERVERALIASES と一致させる必要があります。",
+    gbaseServerMismatch: "GBase 8s の接続に失敗しました。GBASEDBTSERVER がサーバー側の DBSERVERNAME または DBSERVERALIASES と一致していません。接続設定に実際のサーバー名を入力してください。",
     informixServer: "INFORMIXSERVER",
     sslEnable: "暗号化接続を有効にする",
     caCertPath: "CA証明書",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -259,6 +259,8 @@ export default withEnglishFallback({
     hiveJvmOptions: "JVM 옵션",
     hiveJvmOptionsPlaceholder: "-Dsun.security.krb5.debug=true",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "서버의 DBSERVERNAME 또는 DBSERVERALIASES와 일치해야 합니다.",
+    gbaseServerMismatch: "GBase 8s 연결 실패: GBASEDBTSERVER가 서버의 DBSERVERNAME 또는 DBSERVERALIASES와 일치하지 않습니다. 연결 설정에 실제 서버 이름을 입력하세요.",
     informixServer: "INFORMIXSERVER",
     sslEnable: "암호화된 연결 사용",
     caCertPath: "CA 인증서",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -248,6 +248,8 @@ export default withEnglishFallback({
     d1TokenHint: "O token precisa de pelo menos a permissão D1 Read; gravações, DDL e importações também exigem D1 Write.",
     d1FieldsRequired: "O ID da conta Cloudflare, o ID do banco de dados D1 e o token da API são obrigatórios.",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "Deve corresponder ao DBSERVERNAME do servidor ou a DBSERVERALIASES.",
+    gbaseServerMismatch: "Falha na conexão de GBase 8s: GBASEDBTSERVER não corresponde ao DBSERVERNAME do servidor nem a um dos DBSERVERALIASES. Informe o nome real do servidor.",
     informixServer: "INFORMIXSERVER",
     sslEnable: "Habilitar conexão criptografada",
     caCertPath: "Certificado CA",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -265,6 +265,8 @@ export default withEnglishFallback({
     hiveJvmOptions: "JVM 参数",
     hiveJvmOptionsPlaceholder: "-Dsun.security.krb5.debug=true",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "必须与服务端 DBSERVERNAME 或 DBSERVERALIASES 一致。",
+    gbaseServerMismatch: "GBase 8s 连接失败：GBASEDBTSERVER 与服务端 DBSERVERNAME 或 DBSERVERALIASES 不匹配。请在连接配置中填写实际服务名。",
     informixServer: "INFORMIXSERVER",
     sslEnable: "启用加密连接",
     caCertPath: "CA 证书",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -248,6 +248,8 @@ export default withEnglishFallback({
     d1TokenHint: "Token 至少需要 D1 Read 權限；執行寫入、DDL 或匯入時還需要 D1 Write 權限。",
     d1FieldsRequired: "必須填寫 Cloudflare Account ID、D1 Database ID 和 API Token。",
     gbaseServer: "GBASEDBTSERVER",
+    gbaseServerHint: "必須與服務端 DBSERVERNAME 或 DBSERVERALIASES 一致。",
+    gbaseServerMismatch: "GBase 8s 連線失敗：GBASEDBTSERVER 與服務端 DBSERVERNAME 或 DBSERVERALIASES 不匹配。請在連線設定中填寫實際服務名。",
     informixServer: "INFORMIXSERVER",
     sslEnable: "啟用加密連線",
     caCertPath: "CA 憑證",

--- a/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
@@ -5,6 +5,7 @@ import {
   connectionObjectTreeNodeSchema,
   connectionObjectTreeQuerySchema,
   connectionQueryExecutionSchema,
+  connectionShouldDiscoverJdbcSchemas,
   connectionShouldLoadIdentifierQuote,
   connectionUsesDatabaseObjectTreeMode,
   effectiveDatabaseTypeForConnection,
@@ -87,6 +88,8 @@ describe("jdbc dialect inference", () => {
     expect(connectionShouldLoadIdentifierQuote({ db_type: "jdbc", jdbc_driver_class: "org.postgresql.Driver" })).toBe(true);
     expect(connectionShouldLoadIdentifierQuote({ db_type: "kingbase" })).toBe(true);
     expect(connectionShouldLoadIdentifierQuote({ db_type: "gaussdb" })).toBe(true);
+    expect(connectionShouldLoadIdentifierQuote({ db_type: "gbase", driver_profile: "gbase8s" })).toBe(true);
+    expect(connectionShouldLoadIdentifierQuote({ db_type: "gbase", driver_profile: "gbase8a" })).toBe(false);
     expect(
       connectionShouldLoadIdentifierQuote({
         db_type: "jdbc",
@@ -94,6 +97,11 @@ describe("jdbc dialect inference", () => {
         external_config: { gaussdbIdentifierQuoteStyle: "backtick" },
       }),
     ).toBe(false);
+  });
+
+  it("falls back to a flat table tree when GBase 8s reports no schemas", () => {
+    expect(connectionShouldDiscoverJdbcSchemas({ db_type: "gbase", driver_profile: "gbase8s" })).toBe(true);
+    expect(connectionShouldDiscoverJdbcSchemas({ db_type: "gbase", driver_profile: "gbase8a" })).toBe(false);
   });
 
   it("recognizes GaussDB reached through PostgreSQL-compatible JDBC drivers", () => {

--- a/apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts
@@ -34,6 +34,17 @@ describe("qualifiedTableName — SQLite attached databases", () => {
   });
 });
 
+describe("qualifiedTableName — GBase 8s", () => {
+  it("keeps the owner unquoted when the driver reports no identifier quote support", () => {
+    expect(qualifiedTableName({ databaseType: "informix", identifierQuote: "", schema: "gbasedbt", tableName: "connection_smoke" })).toBe("gbasedbt.connection_smoke");
+    expect(quoteTableDataIdentifier("informix", "connection_smoke", "")).toBe("connection_smoke");
+  });
+
+  it("keeps native Informix qualification when no driver capability was loaded", () => {
+    expect(qualifiedTableName({ databaseType: "informix", schema: "gbasedbt", tableName: "connection_smoke" })).toBe("gbasedbt.connection_smoke");
+  });
+});
+
 describe("quoteTableIdentifier", () => {
   it("backtick-quotes mysql identifiers", () => {
     expect(quoteTableIdentifier("mysql", "orders")).toBe("`orders`");

--- a/apps/desktop/src/lib/connection/__tests__/dialogTextSelection.spec.ts
+++ b/apps/desktop/src/lib/connection/__tests__/dialogTextSelection.spec.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from "vitest";
+import { preventDialogDocumentSelectAll } from "../dialogTextSelection";
+
+function keyboardEvent(target: EventTarget, options: { key?: string; metaKey?: boolean; ctrlKey?: boolean; altKey?: boolean } = {}) {
+  return {
+    key: options.key ?? "a",
+    metaKey: options.metaKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+    altKey: options.altKey ?? false,
+    target,
+    preventDefault: vi.fn(),
+  } as unknown as KeyboardEvent;
+}
+
+describe("preventDialogDocumentSelectAll", () => {
+  it("prevents page selection from non-text dialog surfaces", () => {
+    const event = keyboardEvent(document.createElement("div"), { metaKey: true });
+
+    expect(preventDialogDocumentSelectAll(event)).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it.each([document.createElement("input"), document.createElement("textarea")])("keeps native select-all for text controls", (target) => {
+    const event = keyboardEvent(target, { ctrlKey: true });
+
+    expect(preventDialogDocumentSelectAll(event)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("keeps native select-all for nested textbox content", () => {
+    const textbox = document.createElement("div");
+    textbox.setAttribute("role", "textbox");
+    const child = document.createElement("span");
+    textbox.appendChild(child);
+    const event = keyboardEvent(child, { metaKey: true });
+
+    expect(preventDialogDocumentSelectAll(event)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept ordinary typing", () => {
+    const event = keyboardEvent(document.createElement("div"));
+
+    expect(preventDialogDocumentSelectAll(event)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/connection/dialogTextSelection.ts
+++ b/apps/desktop/src/lib/connection/dialogTextSelection.ts
@@ -1,0 +1,11 @@
+function isDialogTextInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || (target instanceof HTMLElement && target.isContentEditable) || !!target.closest("[contenteditable='true'], [role='textbox']");
+}
+
+export function preventDialogDocumentSelectAll(event: KeyboardEvent): boolean {
+  const isSelectAll = event.key.toLowerCase() === "a" && (event.metaKey || event.ctrlKey) && !event.altKey;
+  if (!isSelectAll || isDialogTextInputTarget(event.target)) return false;
+  event.preventDefault();
+  return true;
+}

--- a/apps/desktop/src/lib/database/jdbcDialect.ts
+++ b/apps/desktop/src/lib/database/jdbcDialect.ts
@@ -69,6 +69,7 @@ export function effectiveDatabaseTypeForConnection(connection?: JdbcDialectConne
 
 export function connectionShouldLoadIdentifierQuote(connection: JdbcDialectConnection | undefined): boolean {
   if (!connection) return false;
+  if (connection.db_type === "gbase" && isGbase8sProfile(connection.driver_profile)) return true;
   if (connection.db_type === "kingbase") return true;
   if (gaussdbIdentifierQuoteStyle(connection) !== "auto") return false;
   if (connection.db_type === "gaussdb") return true;
@@ -142,6 +143,9 @@ export function connectionUsesDatabaseObjectTreeMode(connection?: JdbcDialectCon
 }
 
 export function connectionShouldDiscoverJdbcSchemas(connection?: JdbcDialectConnection): boolean {
+  // GBase 8s exposes owner schemas only when the current database can use them
+  // in DML; non-ANSI databases fall back to the flat table tree.
+  if (connection?.db_type === "gbase" && isGbase8sProfile(connection.driver_profile)) return true;
   return connection?.db_type === "jdbc" && !inferJdbcDialect(connection);
 }
 

--- a/apps/desktop/src/lib/table/tableSelectSql.ts
+++ b/apps/desktop/src/lib/table/tableSelectSql.ts
@@ -39,7 +39,7 @@ export function quoteTableIdentifier(databaseType: DatabaseType | undefined, nam
 
 export function quoteTableDataIdentifier(databaseType: DatabaseType | undefined, name: string, identifierQuote?: string): string {
   if ((databaseType === "gaussdb" || databaseType === "opengauss" || databaseType === "postgres") && identifierQuote != null) return quoteGaussDbJdbcIdentifier(name, identifierQuote);
-  if (databaseType === "kingbase" && identifierQuote != null) {
+  if ((databaseType === "kingbase" || databaseType === "informix") && identifierQuote != null) {
     if (!identifierQuote) return name;
     return `${identifierQuote}${name.replaceAll(identifierQuote, identifierQuote + identifierQuote)}${identifierQuote}`;
   }
@@ -80,6 +80,11 @@ export function qualifiedTableName(options: Pick<BuildTableSelectSqlOptions, "da
       return `${quoteTableDataIdentifier(databaseType, trimmedSchema, identifierQuote)}.${quotedTable}`;
     }
     return quotedTable;
+  }
+  if (databaseType === "informix" && identifierQuote != null) {
+    const quotedTable = quoteTableDataIdentifier(databaseType, tableName, identifierQuote);
+    const trimmedSchema = schema?.trim();
+    return trimmedSchema ? `${quoteTableDataIdentifier(databaseType, trimmedSchema, identifierQuote)}.${quotedTable}` : quotedTable;
   }
   if ((isSchemaAware(databaseType) || databaseType === "sqlite") && !usesDatabaseObjectTreeMode(databaseType) && schema) {
     if (databaseType === "sqlserver") {

--- a/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
@@ -88,6 +88,17 @@ function informixConnection(): ConnectionConfig {
   } as ConnectionConfig;
 }
 
+function gbase8sConnection(): ConnectionConfig {
+  return {
+    ...informixConnection(),
+    id: "gbase8s-1",
+    name: "GBase 8s",
+    db_type: "gbase",
+    driver_profile: "gbase8s",
+    database: "dbx_test",
+  } as ConnectionConfig;
+}
+
 function procedure(name: string): ObjectInfo {
   return {
     name,
@@ -268,6 +279,40 @@ describe("connectionStore metadata loading", () => {
     expect(listSchemaInfos).toHaveBeenCalledWith(connection.id, "testdb");
     expect(listTables).toHaveBeenCalled();
     expect(databaseNode.children?.map((node) => [node.type, node.label, node.schema])).toEqual([["table", "t", undefined]]);
+  });
+
+  it("keeps the flat object tree for GBase 8s databases that cannot qualify schemas in DML", async () => {
+    const listSchemaInfos = vi.fn().mockResolvedValue([]);
+    const listTables = vi.fn().mockResolvedValue([{ name: "connection_smoke", table_type: "TABLE", comment: null }]);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined),
+      listObjects: vi.fn().mockResolvedValue([]),
+      listSchemaInfos,
+      listTables,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const store = useConnectionStore();
+    useSettingsStore().editorSettings.sidebarObjectDisplay = "simple";
+    const connection = gbase8sConnection();
+    const databaseNode: TreeNode = { id: `${connection.id}:dbx_test`, label: "dbx_test", type: "database", connectionId: connection.id, database: "dbx_test", isExpanded: false, children: [] };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [{ id: connection.id, label: connection.name, type: "connection", connectionId: connection.id, isExpanded: true, children: [databaseNode] }];
+
+    await store.loadTreeNodeChildren(databaseNode, { force: true });
+
+    expect(listSchemaInfos).toHaveBeenCalledWith(connection.id, "dbx_test");
+    expect(listTables).toHaveBeenCalled();
+    expect(databaseNode.children?.map((node) => [node.type, node.label, node.schema])).toEqual([["table", "connection_smoke", undefined]]);
   });
 
   it("renders simple-mode table children without waiting for supplemental objects", async () => {

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -4832,6 +4832,40 @@ mod tests {
     }
 
     #[test]
+    fn gbase8s_save_keeps_unquoted_owner_when_driver_reports_no_identifier_quote() {
+        let result = prepare_data_grid_save(DataGridSaveStatementOptions {
+            database_type: Some(DatabaseType::Informix),
+            identifier_quote: Some(String::new()),
+            table_meta: DataGridTableMeta {
+                catalog: None,
+                database: Some("dbx_test".to_string()),
+                schema: Some("gbasedbt".to_string()),
+                table_name: "connection_smoke".to_string(),
+                primary_keys: vec!["id".to_string()],
+                columns: Some(vec![column("id", "integer", false, None), column("product", "varchar", false, None)]),
+            },
+            columns: vec!["id".to_string(), "product".to_string()],
+            source_columns: None,
+            rows: vec![vec![json!(1), json!("GBase 8s")]],
+            dirty_rows: vec![(0, vec![(1, json!("GBase 8s updated"))])],
+            deleted_rows: vec![],
+            new_rows: vec![],
+        });
+
+        assert_eq!(result.validation_error, None);
+        assert_eq!(
+            result.statements,
+            vec!["UPDATE gbasedbt.connection_smoke SET product = 'GBase 8s updated' WHERE id = 1;"]
+        );
+        assert_eq!(
+            result.rollback_statements,
+            vec![
+                "UPDATE gbasedbt.connection_smoke SET product = 'GBase 8s' WHERE id = 1 AND product = 'GBase 8s updated';"
+            ]
+        );
+    }
+
+    #[test]
     fn gaussdb_jdbc_save_selectively_quotes_identifiers() {
         let result = prepare_data_grid_save(DataGridSaveStatementOptions {
             database_type: Some(DatabaseType::Gaussdb),

--- a/crates/dbx-core/src/sql_dialect/table_select.rs
+++ b/crates/dbx-core/src/sql_dialect/table_select.rs
@@ -203,6 +203,7 @@ pub(crate) fn uses_connection_identifier_quote(
     identifier_quote: Option<&str>,
 ) -> bool {
     database_type == Some(DatabaseType::Kingbase)
+        || (database_type == Some(DatabaseType::Informix) && identifier_quote.is_some())
         || (matches!(database_type, Some(DatabaseType::Gaussdb | DatabaseType::OpenGauss | DatabaseType::Postgres))
             && identifier_quote.is_some())
 }

--- a/crates/dbx-core/src/sql_dialect/tests.rs
+++ b/crates/dbx-core/src/sql_dialect/tests.rs
@@ -372,6 +372,17 @@ fn builds_table_data_where_and_schema_queries() {
     );
     assert_eq!(
         build_table_data_select_sql(TableDataSelectSqlOptions {
+            database_type: Some(DatabaseType::Informix),
+            identifier_quote: Some(String::new()),
+            schema: Some("gbasedbt".to_string()),
+            table_name: "connection_smoke".to_string(),
+            limit: Some(100),
+            ..Default::default()
+        }),
+        "SELECT FIRST 100 * FROM gbasedbt.connection_smoke"
+    );
+    assert_eq!(
+        build_table_data_select_sql(TableDataSelectSqlOptions {
             database_type: Some(DatabaseType::Gaussdb),
             identifier_quote: Some("\"".to_string()),
             schema: Some("schema_01".to_string()),


### PR DESCRIPTION
## 改动说明

- 为 Agent 增加连接池能力开关，GBase 8s 使用独立连接，避免共享 JDBC 连接状态异常导致资源上限错误。
- 数据库列表改用独立的 `sysmaster` 短连接查询，避免切换 catalog 污染业务会话。
- 根据驱动标识符能力生成 GBase 8s 表数据 SQL，查询、计数和单元格保存不再错误添加 owner 前缀。
- 改进 `GBASEDBTSERVER` 配置说明和名称不匹配错误提示，长错误信息支持换行、滚动和局部全选。
- 补充相关 Agent、SQL 生成、错误映射及文本选择回归测试，并补全 i18n。

## 验证

- 使用开发客户端真实连接 GBase 8s，完成数据库/Schema 展开并打开 `connection_smoke`，成功返回数据及主键元数据。
- 前端全量测试：754 个测试文件、6663 项测试通过。
- dbx-core 全量测试：3903 项通过、21 项忽略。
- `pnpm -s typecheck`、`cargo fmt --check` 通过。
- GBase 8s Agent 测试及 `shadowJar` 构建通过。