### PR TITLE
fix(grid): strip thousand separators in numeric grid cells

### DIFF
--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
@@ -65,4 +65,55 @@ describe("coerceDataGridCellValue", () => {
     expect(coerceDataGridCellValue(options)).toBeNull();
     expect(coerceDataGridCellValue({ ...options, preserveEmptyString: true })).toBe("");
   });
+
+  it("strips thousands separators before numeric coercion", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "1,234.50",
+        oldValue: 1234.5,
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "float" },
+      }),
+    ).toBe(1234.5);
+
+    expect(
+      coerceDataGridCellValue({
+        value: "10,000",
+        oldValue: 10000,
+        databaseType: "mysql",
+        columnInfo: { data_type: "int" },
+      }),
+    ).toBe(10000);
+
+    expect(
+      coerceDataGridCellValue({
+        value: "-10,000.00",
+        oldValue: "-10000.00",
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "decimal(18,2)" },
+      }),
+    ).toBe("-10000.00");
+  });
+
+  it("does not strip commas when the column is not numeric", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "10,000.00",
+        oldValue: "10,000.00",
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "varchar(255)" },
+      }),
+    ).toBe("10,000.00");
+  });
+
+  it("leaves invalid thousand-grouping values untouched", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "1,23",
+        oldValue: 123,
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "decimal(18,2)" },
+      }),
+    ).toBe("1,23");
+  });
 });

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
@@ -106,6 +106,26 @@ describe("coerceDataGridCellValue", () => {
     ).toBe("10000.00");
   });
 
+  it("normalizes grouped mantissas with scientific notation", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "1,234.50e2",
+        oldValue: "0",
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "decimal(18,2)" },
+      }),
+    ).toBe("1234.50e2");
+
+    expect(
+      coerceDataGridCellValue({
+        value: "-1,234.5E-2",
+        oldValue: "0",
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "decimal(18,2)" },
+      }),
+    ).toBe("-1234.5E-2");
+  });
+
   it("preserves exact text for grouped integers beyond Number.MAX_SAFE_INTEGER", () => {
     expect(
       coerceDataGridCellValue({
@@ -126,6 +146,15 @@ describe("coerceDataGridCellValue", () => {
         columnInfo: { data_type: "int" },
       }),
     ).toBe("10,000");
+
+    expect(
+      coerceDataGridCellValue({
+        value: "1,000e3",
+        oldValue: 1000000,
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "float" },
+      }),
+    ).toBe("1,000e3");
   });
 
   it("does not strip commas when the column is not numeric", () => {

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
@@ -66,7 +66,7 @@ describe("coerceDataGridCellValue", () => {
     expect(coerceDataGridCellValue({ ...options, preserveEmptyString: true })).toBe("");
   });
 
-  it("strips thousands separators before numeric coercion", () => {
+  it("strips unambiguous thousands separators before numeric coercion", () => {
     expect(
       coerceDataGridCellValue({
         value: "1,234.50",
@@ -78,12 +78,12 @@ describe("coerceDataGridCellValue", () => {
 
     expect(
       coerceDataGridCellValue({
-        value: "10,000",
-        oldValue: 10000,
-        databaseType: "mysql",
+        value: "1,234,567",
+        oldValue: 1234567,
+        databaseType: "sqlserver",
         columnInfo: { data_type: "int" },
       }),
-    ).toBe(10000);
+    ).toBe(1234567);
 
     expect(
       coerceDataGridCellValue({
@@ -93,6 +93,39 @@ describe("coerceDataGridCellValue", () => {
         columnInfo: { data_type: "decimal(18,2)" },
       }),
     ).toBe("-10000.00");
+  });
+
+  it("preserves exact text for grouped decimals", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "10,000.00",
+        oldValue: "10000.50",
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "decimal(18,2)" },
+      }),
+    ).toBe("10000.00");
+  });
+
+  it("preserves exact text for grouped integers beyond Number.MAX_SAFE_INTEGER", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "9,007,199,254,740,993",
+        oldValue: 9007199254740992,
+        databaseType: "mysql",
+        columnInfo: { data_type: "bigint" },
+      }),
+    ).toBe("9007199254740993");
+  });
+
+  it("leaves ambiguous single-group values untouched", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "10,000",
+        oldValue: 10000,
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "int" },
+      }),
+    ).toBe("10,000");
   });
 
   it("does not strip commas when the column is not numeric", () => {

--- a/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
@@ -1,5 +1,6 @@
 import type { GridCellValue } from "@/lib/dataGrid/dataGridSql";
 import type { DatabaseType, ColumnInfo } from "@/types/database";
+import { isNumericColumnType } from "@/lib/dataGrid/dataGridColumnType";
 
 export interface CoerceDataGridCellValueOptions {
   value: string;
@@ -10,21 +11,21 @@ export interface CoerceDataGridCellValueOptions {
 }
 
 export function coerceDataGridCellValue(options: CoerceDataGridCellValueOptions): GridCellValue {
-  let { value, oldValue } = options;
+  const { value, oldValue } = options;
   if (value === "" && oldValue === null && !options.preserveEmptyString) return null;
-  // Excel-pasted values often carry thousands separators (10,000.00) that make
-  // Number() return NaN and the literal fail to convert on the server.
-  if (isNumericColumn(options.columnInfo)) {
-    value = stripThousandSeparators(value);
-  }
   const postgresArrayValue = coercePostgresArrayValue(options);
   if (postgresArrayValue !== undefined) return postgresArrayValue;
+  // Excel-pasted values often carry thousands separators (10,000.00) that make
+  // Number() return NaN and the literal fail to convert on the server. Strip
+  // only unambiguous groupings and keep the normalized text for the precision
+  // checks below, so exact values survive as text.
+  const numericText = normalizeGroupedNumberText(value, options.columnInfo);
   if (typeof oldValue === "number") {
-    const num = Number(value);
+    const num = Number(numericText);
     if (!Number.isNaN(num)) {
-      if (shouldPreserveNumericText(options, num)) {
+      if (shouldPreserveNumericText(options, num, numericText)) {
         // Keep precision-sensitive numeric edits as text; JS Number rounds 64-bit integers.
-        const text = value.trim();
+        const text = numericText.trim();
         if (text === String(oldValue)) return oldValue;
         return text;
       }
@@ -32,9 +33,9 @@ export function coerceDataGridCellValue(options: CoerceDataGridCellValueOptions)
     }
   }
   if (typeof oldValue === "boolean") {
-    return value === "true" || value === "1";
+    return numericText === "true" || numericText === "1";
   }
-  return normalizeSmartQuotedJsonInput(value);
+  return normalizeSmartQuotedJsonInput(numericText);
 }
 
 export function dataGridCellEditorText(options: { value: GridCellValue | undefined; databaseType: DatabaseType | undefined; columnInfo: Pick<ColumnInfo, "data_type"> | undefined }): string {
@@ -97,10 +98,24 @@ function isPostgresArrayColumn(columnInfo: Pick<ColumnInfo, "data_type"> | undef
   return dataType === "array" || dataType.endsWith("[]") || dataType.startsWith("_");
 }
 
-function shouldPreserveNumericText(options: CoerceDataGridCellValueOptions, parsedNumber: number): boolean {
-  const text = options.value.trim();
+function shouldPreserveNumericText(options: CoerceDataGridCellValueOptions, parsedNumber: number, text: string): boolean {
   if (!isNumericLiteralText(text)) return false;
   return shouldPreserveNumericTextForType(options.columnInfo?.data_type, text, parsedNumber);
+}
+
+function normalizeGroupedNumberText(value: string, columnInfo: Pick<ColumnInfo, "data_type"> | undefined): string {
+  if (!isNumericColumnType(columnInfo?.data_type)) return value;
+  return stripUnambiguousThousandSeparators(value);
+}
+
+function stripUnambiguousThousandSeparators(value: string): string {
+  const trimmed = value.trim();
+  if (!/^[+-]?\d{1,3}(,\d{3})+(\.\d+)?$/.test(trimmed)) return value;
+  // A lone "1,000" (one comma group, no decimal point) is ambiguous: in
+  // comma-decimal locales it reads as 1.000. Only strip when a decimal point
+  // is present (1,234.56) or there are multiple comma groups (1,234,567).
+  if (/^[+-]?\d{1,3},\d{3}$/.test(trimmed)) return value;
+  return trimmed.replace(/,/g, "");
 }
 
 function postgresArrayElementDataType(dataType: string | undefined): string {
@@ -119,18 +134,6 @@ function shouldPreserveNumericTextForType(dataType: string | undefined, text: st
 
 function normalizeDataType(dataType: string | undefined): string {
   return (dataType ?? "").trim().toLowerCase();
-}
-
-function isNumericColumn(columnInfo: Pick<ColumnInfo, "data_type"> | undefined): boolean {
-  return /^(?:bit|tinyint|smallint|mediumint|int|integer|bigint|serial|smallserial|bigserial|int2|int4|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|decimal|numeric|number|dec|fixed|float|double|real|money|smallmoney|binary_float|binary_double|bigdecimal|bignumeric|big_numeric)\b/.test(
-    normalizeDataType(columnInfo?.data_type),
-  );
-}
-
-function stripThousandSeparators(value: string): string {
-  const trimmed = value.trim();
-  if (!/^[+-]?\d{1,3}(,\d{3})+(\.\d+)?$/.test(trimmed)) return value;
-  return trimmed.replace(/,/g, "");
 }
 
 function isOracleDateColumn(databaseType: DatabaseType | undefined, columnInfo: Pick<ColumnInfo, "data_type"> | undefined): boolean {

--- a/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
@@ -110,12 +110,15 @@ function normalizeGroupedNumberText(value: string, columnInfo: Pick<ColumnInfo, 
 
 function stripUnambiguousThousandSeparators(value: string): string {
   const trimmed = value.trim();
-  if (!/^[+-]?\d{1,3}(,\d{3})+(\.\d+)?$/.test(trimmed)) return value;
+  const match = trimmed.match(/^([+-]?\d{1,3}(?:,\d{3})+(?:\.\d+)?)([eE][+-]?\d+)?$/);
+  if (!match) return value;
+  const mantissa = match[1];
+  const exponent = match[2] ?? "";
   // A lone "1,000" (one comma group, no decimal point) is ambiguous: in
   // comma-decimal locales it reads as 1.000. Only strip when a decimal point
   // is present (1,234.56) or there are multiple comma groups (1,234,567).
-  if (/^[+-]?\d{1,3},\d{3}$/.test(trimmed)) return value;
-  return trimmed.replace(/,/g, "");
+  if (/^[+-]?\d{1,3},\d{3}$/.test(mantissa)) return value;
+  return `${mantissa.replace(/,/g, "")}${exponent}`;
 }
 
 function postgresArrayElementDataType(dataType: string | undefined): string {

--- a/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
@@ -10,8 +10,13 @@ export interface CoerceDataGridCellValueOptions {
 }
 
 export function coerceDataGridCellValue(options: CoerceDataGridCellValueOptions): GridCellValue {
-  const { value, oldValue } = options;
+  let { value, oldValue } = options;
   if (value === "" && oldValue === null && !options.preserveEmptyString) return null;
+  // Excel-pasted values often carry thousands separators (10,000.00) that make
+  // Number() return NaN and the literal fail to convert on the server.
+  if (isNumericColumn(options.columnInfo)) {
+    value = stripThousandSeparators(value);
+  }
   const postgresArrayValue = coercePostgresArrayValue(options);
   if (postgresArrayValue !== undefined) return postgresArrayValue;
   if (typeof oldValue === "number") {
@@ -114,6 +119,18 @@ function shouldPreserveNumericTextForType(dataType: string | undefined, text: st
 
 function normalizeDataType(dataType: string | undefined): string {
   return (dataType ?? "").trim().toLowerCase();
+}
+
+function isNumericColumn(columnInfo: Pick<ColumnInfo, "data_type"> | undefined): boolean {
+  return /^(?:bit|tinyint|smallint|mediumint|int|integer|bigint|serial|smallserial|bigserial|int2|int4|int8|int16|int32|int64|uint|uint8|uint16|uint32|uint64|decimal|numeric|number|dec|fixed|float|double|real|money|smallmoney|binary_float|binary_double|bigdecimal|bignumeric|big_numeric)\b/.test(
+    normalizeDataType(columnInfo?.data_type),
+  );
+}
+
+function stripThousandSeparators(value: string): string {
+  const trimmed = value.trim();
+  if (!/^[+-]?\d{1,3}(,\d{3})+(\.\d+)?$/.test(trimmed)) return value;
+  return trimmed.replace(/,/g, "");
 }
 
 function isOracleDateColumn(databaseType: DatabaseType | undefined, columnInfo: Pick<ColumnInfo, "data_type"> | undefined): boolean {


### PR DESCRIPTION
Closes #5210

## Problem

Pasting a value with thousands separators (e.g. `10,000.00`) from Excel into a numeric grid cell fails to save — the value is sent to the server as the literal `10,000.00` and SQL Server rejects it:

> Token error: '从数据类型 nvarchar 转换为 numeric 时出错'

Root cause: `Number("10,000.00")` returns `NaN` in `coerceDataGridCellValue`, so the string is passed through untouched instead of being coerced to a number.

## Change

`dataGridCellCoercion.ts` — when the target column is numeric and the value is a valid thousand-grouped number, strip the separators before normal coercion. Non-numeric columns and invalid groupings (`1,23`) are untouched.

## Test

Added 4 cases to `dataGridCellCoercion.spec.ts` (separator stripping, negative values, non-numeric column preservation, invalid grouping). Watched the stripping test fail before the fix, then pass after.

- `pnpm vitest run apps/desktop/src/lib/__tests__/dataGrid/` → 236 passed (only `geometryProjection.spec.ts` fails, pre-existing missing `proj4` dependency)
- `pnpm oxlint` clean
- `pnpm typecheck` clean except pre-existing missing `proj4` module