### PR TITLE
fix(grid): 修复切换页签后方向键无法导航单元格的问题

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5386,9 +5386,9 @@ watch(
 
 function pauseCanvasGridWork() {
   dataGridIsActive = false;
+  stopLoadingElapsedTimer();
   gridFocusActivationToken += 1;
   gridRef.value?.setAttribute("data-grid-active", "false");
-  stopLoadingElapsedTimer();
   if (gridSurfaceBusy.value) finishDataGridNativeSelectionBlock(dataGridNativeSelectionBlockOwner);
   canvasRuntime.pause();
   gridScrollbarsRuntime.pause();
@@ -5402,8 +5402,8 @@ function pauseCanvasGridWork() {
 
 function resumeCanvasGridWork() {
   dataGridIsActive = true;
-  gridRef.value?.setAttribute("data-grid-active", "true");
   startLoadingElapsedTimer();
+  gridRef.value?.setAttribute("data-grid-active", "true");
   if (gridSurfaceBusy.value) beginDataGridNativeSelectionBlock(dataGridNativeSelectionBlockOwner);
   canvasRuntime.resume();
   gridScrollbarsRuntime.resume();

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5386,6 +5386,8 @@ watch(
 
 function pauseCanvasGridWork() {
   dataGridIsActive = false;
+  gridFocusActivationToken += 1;
+  gridRef.value?.setAttribute("data-grid-active", "false");
   stopLoadingElapsedTimer();
   if (gridSurfaceBusy.value) finishDataGridNativeSelectionBlock(dataGridNativeSelectionBlockOwner);
   canvasRuntime.pause();
@@ -5400,6 +5402,7 @@ function pauseCanvasGridWork() {
 
 function resumeCanvasGridWork() {
   dataGridIsActive = true;
+  gridRef.value?.setAttribute("data-grid-active", "true");
   startLoadingElapsedTimer();
   if (gridSurfaceBusy.value) beginDataGridNativeSelectionBlock(dataGridNativeSelectionBlockOwner);
   canvasRuntime.resume();
@@ -5421,6 +5424,7 @@ function clearInternalClipboardCopy() {
 // grid never gets it back on its own, which breaks arrow-key cell navigation
 // after returning to the tab.
 let lastFocusedWithinGrid: HTMLElement | null = null;
+let gridFocusActivationToken = 0;
 
 function onGridFocusIn(event: FocusEvent) {
   if (event.target instanceof HTMLElement) lastFocusedWithinGrid = event.target;
@@ -5428,7 +5432,9 @@ function onGridFocusIn(event: FocusEvent) {
 
 function restoreGridFocusAfterActivation() {
   if (!lastFocusedWithinGrid) return;
+  const activationToken = ++gridFocusActivationToken;
   nextTick(() => {
+    if (!dataGridIsActive || activationToken !== gridFocusActivationToken) return;
     if (editingCell.value) return; // the cell editor restores its own input focus
     const target = resolveGridFocusRestoreTarget(gridRef.value, lastFocusedWithinGrid, document.activeElement);
     target?.focus({ preventScroll: true });
@@ -8420,7 +8426,18 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 </script>
 
 <template>
-  <div ref="gridRef" data-grid-root class="h-full flex flex-col overflow-hidden outline-none" :class="{ 'data-grid--editing-cell': !!editingCell, 'data-grid--dark': isDark }" :style="gridStyle" tabindex="0" @keydown="onGridKeydown" @paste="onGridPaste" @focusin="onGridFocusIn">
+  <div
+    ref="gridRef"
+    data-grid-root
+    data-grid-active="true"
+    class="h-full flex flex-col overflow-hidden outline-none"
+    :class="{ 'data-grid--editing-cell': !!editingCell, 'data-grid--dark': isDark }"
+    :style="gridStyle"
+    tabindex="0"
+    @keydown="onGridKeydown"
+    @paste="onGridPaste"
+    @focusin="onGridFocusIn"
+  >
     <CustomContextMenu :items="gridContextMenuItems" v-slot="{ onContextMenu }">
       <div v-if="hasData || canShowWhereSearch" class="flex-1 flex flex-col overflow-hidden" @contextmenu="onContextMenu">
         <!-- Search bar -->

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -214,6 +214,7 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { simpleDataGridOrderByMatchesSort, simpleDataGridOrderByReferencesMissingColumn, type DataGridSortDirection, type DataGridSortMode } from "@/lib/dataGrid/dataGridSort";
+import { resolveGridFocusRestoreTarget } from "@/lib/dataGrid/dataGridFocusRestore";
 import { buildOrderedGridRows, type GridInsertRowPosition, type GridNewRowPlacement } from "@/lib/dataGrid/gridNewRowPlacement";
 import { DATA_GRID_CONDITION_TOOLBAR_MIN_WIDTH, isDataGridToolbarCompact, type DataGridReloadIntent, type DataGridToolbarActionCapability, type DataGridToolbarAddRowCapability, type DataGridToolbarAutoRefreshCapability, type DataGridToolbarSaveCapability } from "@/lib/dataGrid/dataGridToolbar";
 import { getTableMetadataCapabilities } from "@/lib/table/tableMetadataCapabilities";
@@ -5415,6 +5416,27 @@ function clearInternalClipboardCopy() {
   clearDataGridClipboardCopy();
 }
 
+// Remember the last element that held focus inside the grid. Switching to
+// another tab moves focus onto the tab strip (or body) and the kept-alive
+// grid never gets it back on its own, which breaks arrow-key cell navigation
+// after returning to the tab.
+let lastFocusedWithinGrid: HTMLElement | null = null;
+
+function onGridFocusIn(event: FocusEvent) {
+  if (event.target instanceof HTMLElement) lastFocusedWithinGrid = event.target;
+}
+
+function restoreGridFocusAfterActivation() {
+  if (!lastFocusedWithinGrid) return;
+  nextTick(() => {
+    if (editingCell.value) return; // the cell editor restores its own input focus
+    const target = resolveGridFocusRestoreTarget(gridRef.value, lastFocusedWithinGrid, document.activeElement);
+    target?.focus({ preventScroll: true });
+  });
+}
+
+onActivated(restoreGridFocusAfterActivation);
+
 onMounted(resumeCanvasGridWork);
 onActivated(resumeCanvasGridWork);
 onMounted(() => {
@@ -8398,7 +8420,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 </script>
 
 <template>
-  <div ref="gridRef" data-grid-root class="h-full flex flex-col overflow-hidden outline-none" :class="{ 'data-grid--editing-cell': !!editingCell, 'data-grid--dark': isDark }" :style="gridStyle" tabindex="0" @keydown="onGridKeydown" @paste="onGridPaste">
+  <div ref="gridRef" data-grid-root class="h-full flex flex-col overflow-hidden outline-none" :class="{ 'data-grid--editing-cell': !!editingCell, 'data-grid--dark': isDark }" :style="gridStyle" tabindex="0" @keydown="onGridKeydown" @paste="onGridPaste" @focusin="onGridFocusIn">
     <CustomContextMenu :items="gridContextMenuItems" v-slot="{ onContextMenu }">
       <div v-if="hasData || canShowWhereSearch" class="flex-1 flex flex-col overflow-hidden" @contextmenu="onContextMenu">
         <!-- Search bar -->

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridFocusRestore.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridFocusRestore.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveGridFocusRestoreTarget } from "@/lib/dataGrid/dataGridFocusRestore";
+
+function element(overrides: { connected?: boolean; children?: HTMLElement[] } = {}) {
+  const children = overrides.children ?? [];
+  return {
+    isConnected: overrides.connected ?? true,
+    contains: (other: Element | null) => !!other && (children as Element[]).includes(other),
+  } as unknown as HTMLElement;
+}
+
+describe("resolveGridFocusRestoreTarget", () => {
+  it("returns null when the grid never held focus", () => {
+    const root = element();
+    expect(resolveGridFocusRestoreTarget(root, null, null)).toBeNull();
+  });
+
+  it("returns null when focus is already inside the grid", () => {
+    const input = element();
+    const root = element({ children: [input] });
+    expect(resolveGridFocusRestoreTarget(root, input, input)).toBeNull();
+  });
+
+  it("restores the last focused inner element when focus was left on the tab strip", () => {
+    const searchInput = element();
+    const root = element({ children: [searchInput] });
+    const tabButton = element();
+    expect(resolveGridFocusRestoreTarget(root, searchInput, tabButton)).toBe(searchInput);
+  });
+
+  it("falls back to the grid root when the last focused element was removed", () => {
+    const staleEditor = element({ connected: false });
+    const root = element();
+    const tabButton = element();
+    expect(resolveGridFocusRestoreTarget(root, staleEditor, tabButton)).toBe(root);
+  });
+
+  it("falls back to the grid root when the last focused element is no longer inside the grid", () => {
+    const movedElsewhere = element();
+    const root = element();
+    expect(resolveGridFocusRestoreTarget(root, movedElsewhere, null)).toBe(root);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridFocusRestore.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridFocusRestore.spec.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { resolveGridFocusRestoreTarget } from "@/lib/dataGrid/dataGridFocusRestore";
 
-function element(overrides: { connected?: boolean; children?: HTMLElement[] } = {}) {
+function element(overrides: { connected?: boolean; children?: HTMLElement[]; closest?: Record<string, HTMLElement | null>; ownerDocument?: { body: HTMLElement; documentElement: HTMLElement }; activeGrid?: boolean } = {}) {
   const children = overrides.children ?? [];
-  return {
+  const target = {
     isConnected: overrides.connected ?? true,
     contains: (other: Element | null) => !!other && (children as Element[]).includes(other),
+    closest: (selector: string) => overrides.closest?.[selector] ?? null,
+    ownerDocument: overrides.ownerDocument,
+    dataset: overrides.activeGrid === undefined ? {} : { gridActive: String(overrides.activeGrid) },
   } as unknown as HTMLElement;
+  return target;
 }
 
 describe("resolveGridFocusRestoreTarget", () => {
@@ -24,20 +28,41 @@ describe("resolveGridFocusRestoreTarget", () => {
   it("restores the last focused inner element when focus was left on the tab strip", () => {
     const searchInput = element();
     const root = element({ children: [searchInput] });
-    const tabButton = element();
+    const tabButton = element({ closest: { ".app-tab-bar, [role='tab'], [role='tablist']": element() } });
     expect(resolveGridFocusRestoreTarget(root, searchInput, tabButton)).toBe(searchInput);
   });
 
   it("falls back to the grid root when the last focused element was removed", () => {
     const staleEditor = element({ connected: false });
     const root = element();
-    const tabButton = element();
+    const tabButton = element({ closest: { ".app-tab-bar, [role='tab'], [role='tablist']": element() } });
     expect(resolveGridFocusRestoreTarget(root, staleEditor, tabButton)).toBe(root);
   });
 
-  it("falls back to the grid root when the last focused element is no longer inside the grid", () => {
+  it("falls back to the grid root from body when the last focused element moved", () => {
     const movedElsewhere = element();
-    const root = element();
-    expect(resolveGridFocusRestoreTarget(root, movedElsewhere, null)).toBe(root);
+    const body = element();
+    const documentElement = element();
+    const root = element({ ownerDocument: { body, documentElement } });
+    expect(resolveGridFocusRestoreTarget(root, movedElsewhere, body)).toBe(root);
+  });
+
+  it("does not steal focus from an external dialog or editor", () => {
+    const searchInput = element();
+    const root = element({ children: [searchInput] });
+    const dialogInput = element();
+    expect(resolveGridFocusRestoreTarget(root, searchInput, dialogInput)).toBeNull();
+  });
+
+  it("restores from an inactive grid but not from another active grid", () => {
+    const searchInput = element();
+    const root = element({ children: [searchInput] });
+    const inactiveGrid = element({ activeGrid: false });
+    const inactiveGridInput = element({ closest: { "[data-grid-root]": inactiveGrid } });
+    expect(resolveGridFocusRestoreTarget(root, searchInput, inactiveGridInput)).toBe(searchInput);
+
+    const activeGrid = element({ activeGrid: true });
+    const activeGridInput = element({ closest: { "[data-grid-root]": activeGrid } });
+    expect(resolveGridFocusRestoreTarget(root, searchInput, activeGridInput)).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/dataGrid/dataGridFocusRestore.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridFocusRestore.ts
@@ -2,12 +2,10 @@
  * Decide where focus should go when a kept-alive data grid becomes active
  * again after a tab switch.
  *
- * Switching away from a tab moves focus to the tab strip (or body), so the
- * grid root loses keyboard focus and arrow-key cell navigation stops working
- * when the user comes back. To match Navicat / DataGrip behavior, focus
- * returns to the element that last held it inside the grid (toolbar buttons,
- * search inputs, ...), falling back to the grid root when that element is
- * gone (e.g. a re-rendered cell editor).
+ * Switching away from a tab moves focus to the tab strip, body, or an element
+ * inside the grid that is being deactivated. Focus is restored only from one
+ * of those states so activation never steals focus from a dialog, editor,
+ * input, menu, or another active grid.
  *
  * Returns null when no focus restore should happen: the grid never held
  * focus, or focus is already inside the grid (e.g. the cell editor restored
@@ -16,8 +14,21 @@
 export function resolveGridFocusRestoreTarget(root: HTMLElement | null | undefined, lastFocusedWithinGrid: HTMLElement | null | undefined, activeElement: Element | null): HTMLElement | null {
   if (!root || !lastFocusedWithinGrid) return null;
   if (root.contains(activeElement)) return null;
+  if (!gridFocusCanTransferFrom(root, activeElement)) return null;
   if (lastFocusedWithinGrid.isConnected && root.contains(lastFocusedWithinGrid)) {
     return lastFocusedWithinGrid;
   }
   return root;
+}
+
+function gridFocusCanTransferFrom(root: HTMLElement, activeElement: Element | null): boolean {
+  if (!activeElement || !activeElement.isConnected) return true;
+  const ownerDocument = root.ownerDocument;
+  if (activeElement === ownerDocument?.body || activeElement === ownerDocument?.documentElement) return true;
+
+  const closest = (activeElement as HTMLElement).closest?.bind(activeElement as HTMLElement);
+  if (!closest) return false;
+  const activeGrid = closest("[data-grid-root]") as HTMLElement | null;
+  if (activeGrid && activeGrid !== root) return activeGrid.dataset.gridActive !== "true";
+  return !!closest(".app-tab-bar, [role='tab'], [role='tablist']");
 }

--- a/apps/desktop/src/lib/dataGrid/dataGridFocusRestore.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridFocusRestore.ts
@@ -1,0 +1,23 @@
+/**
+ * Decide where focus should go when a kept-alive data grid becomes active
+ * again after a tab switch.
+ *
+ * Switching away from a tab moves focus to the tab strip (or body), so the
+ * grid root loses keyboard focus and arrow-key cell navigation stops working
+ * when the user comes back. To match Navicat / DataGrip behavior, focus
+ * returns to the element that last held it inside the grid (toolbar buttons,
+ * search inputs, ...), falling back to the grid root when that element is
+ * gone (e.g. a re-rendered cell editor).
+ *
+ * Returns null when no focus restore should happen: the grid never held
+ * focus, or focus is already inside the grid (e.g. the cell editor restored
+ * its own input focus first).
+ */
+export function resolveGridFocusRestoreTarget(root: HTMLElement | null | undefined, lastFocusedWithinGrid: HTMLElement | null | undefined, activeElement: Element | null): HTMLElement | null {
+  if (!root || !lastFocusedWithinGrid) return null;
+  if (root.contains(activeElement)) return null;
+  if (lastFocusedWithinGrid.isConnected && root.contains(lastFocusedWithinGrid)) {
+    return lastFocusedWithinGrid;
+  }
+  return root;
+}


### PR DESCRIPTION
## 变更说明

修复多个数据表页签之间切换后，上下左右方向键无法继续导航单元格的问题。

**根因**：网格的方向键导航依赖根元素（`tabindex=0` 的 grid root）持有键盘焦点。点击页签条切换页签后，焦点停留在页签按钮上（所以左右键变成了在页签间移动）；`KeepAlive` 重新激活 `ContentArea` 时，`DataGrid` 的 `onActivated` 只恢复了滚动位置与渲染状态，从未恢复焦点，导致切回后方向键全部失效。

**改动**：
- `DataGrid` 根元素新增 `focusin` 监听，持续记录网格内最后持有焦点的元素（单元格点击后现有逻辑本就会 focus 根元素，记录自然产生）；
- 新增 `onActivated` 恢复逻辑：页签重新激活时，若焦点不在网格内且当前没有进行中的单元格编辑（编辑态由 `useDataGridEditor` 自行恢复输入框焦点），将焦点恢复到该元素；元素已失效（如重建过的编辑器）则回退到网格根元素，均使用 `preventScroll` 避免视口跳动；
- 恢复决策抽为纯函数 `resolveGridFocusRestoreTarget`（`apps/desktop/src/lib/dataGrid/dataGridFocusRestore.ts`）并附单元测试。

**行为说明**：
- 数据表页签：点击过单元格 → 切走 → 切回，方向键立即恢复单元格导航，与 Navicat / DataGrip 交互一致；
- 查询页签行为不变：`QueryEditor` 原有的 rAF 焦点恢复仍最后生效，不会与网格争抢焦点；
- 从未与网格交互过的页签不会被主动抢占焦点。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 为交互行为修复，无视觉/样式变化。已按 issue 复现步骤在 Windows + MySQL 环境人工验证通过（修复经报告者环境复现确认）。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过（format / lint / typecheck 全部通过；test 中 `windowsInstallerTemplate.spec.ts` 的 1 个失败在未改动的 main 上同样失败，为与 NSIS 安装模板相关的既有问题，与本 PR 无关）
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过（新增 `dataGridFocusRestore.spec.ts` 5 个用例；`vitest run` 全量 6687 个用例通过，唯一失败为上述既有问题）

手动验证步骤：
1. 打开多个数据表页签（MySQL）；
2. 点击某个数据单元格；
3. 切换到其他页签，再切回；
4. 直接按上下左右键，单元格选择可正常移动。

## 关联 Issue

Close #5265