### PR TITLE
feat(agent): add get_current_time tool to AI assistant

### DIFF
--- a/apps/desktop/src/lib/ai/ai.ts
+++ b/apps/desktop/src/lib/ai/ai.ts
@@ -351,24 +351,27 @@ function buildVectorSystemPrompt(context: AiContext, mode: AiAssistantMode, cust
 }
 
 function buildVectorModePromptLines(context: AiContext, mode: AiAssistantMode, isZh: boolean): string[] {
+  const currentTimeGuidance = currentTimeToolGuidance();
   if (mode === "agent") {
-    return [isZh ? "你处于 Agent 模式。你有以下工具可用：list_collections、browse_collection、get_current_time。" : "You are in Agent mode. You have the following tools available: list_collections, browse_collection, get_current_time."];
+    return [isZh ? "你处于 Agent 模式。你有以下工具可用：list_collections、browse_collection、get_current_time。" : "You are in Agent mode. You have the following tools available: list_collections, browse_collection, get_current_time.", currentTimeGuidance];
   }
   return [
     isZh
       ? `你处于 Ask 模式。你只能使用 list_collections 确认集合清单；不要浏览集合数据。${dbLabel(context.databaseType)} 的查询格式为 REST API（METHOD /path + JSON body），具体格式因数据库类型而异。只生成查询请求文本和说明，不要暗示已经执行。`
       : `You are in Ask mode. You may only use list_collections to inspect collection names; do not browse collection data. ${dbLabel(context.databaseType)} uses a REST API query format (METHOD /path + JSON body) that varies by database type. Generate query strings and explanations only; do not imply execution.`,
-    "When a request needs a relative time expression such as yesterday, last 7 days, this month, or today resolved into a concrete filter, call get_current_time first; do not guess the current date or timezone.",
+    currentTimeGuidance,
   ];
 }
 
 function buildModePromptLines(mode: AiAssistantMode, isZh: boolean): string[] {
+  const currentTimeGuidance = currentTimeToolGuidance();
   if (mode === "agent") {
     return [
       isZh ? "你处于 Agent 模式。你有以下工具可用：list_tables、get_columns、execute_query、get_sample_data、get_current_time。" : "You are in Agent mode. You have the following tools available: list_tables, get_columns, execute_query, get_sample_data, get_current_time.",
       isZh
         ? "用户提出数据查询意图时，必须调用 execute_query 工具执行 SQL，不要只输出 SQL 文本后停止。先用 list_tables/get_columns 了解 schema，再调用 execute_query 获取真实结果，最后基于结果回答用户。"
         : "When the user expresses a data query intent, you MUST call the execute_query tool to run the SQL — do NOT just output SQL text and stop. Use list_tables/get_columns to understand the schema first, then call execute_query to get real results, then answer based on the actual data.",
+      currentTimeGuidance,
       isZh
         ? "当用户要求写入操作（INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/TRUNCATE 等）时，先在一个 ```sql 代码块中给出精确的写 SQL，再在回复末尾用问句明确询问用户是否确认执行（例如'需要我执行这条 CREATE TABLE 语句吗？'）。待用户明确确认后再调用 execute_query，并原样使用该代码块中的 SQL，不得改写、重新格式化或补充语句。禁止不经确认直接执行写入。"
         : "When the user requests a write operation (INSERT/UPDATE/DELETE/CREATE/ALTER/DROP/TRUNCATE, etc.), first put the exact proposed write SQL in one ```sql code block, then ask for explicit confirmation at the end of your reply with a question that names the specific operation (e.g., 'Should I execute this CREATE TABLE?'). Only call execute_query for writes after the user explicitly confirms, and use the exact SQL from that code block without rewriting, reformatting, or adding statements. Never execute writes without confirmation.",
@@ -378,8 +381,14 @@ function buildModePromptLines(mode: AiAssistantMode, isZh: boolean): string[] {
 
   return [
     isZh ? "你处于 Ask 模式。只生成 SQL 和说明，不要暗示已经执行或即将自动执行。" : "You are in Ask mode. Generate SQL and explanations only; do not imply that anything has run or will auto-run.",
-    "When a request needs a relative time expression such as yesterday, last 7 days, this month, or today resolved into a concrete SQL date or time range, call get_current_time first; do not guess the current date or timezone.",
+    currentTimeGuidance,
   ];
+}
+
+function currentTimeToolGuidance(): string {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  const utcOffsetMinutes = -new Date().getTimezoneOffset();
+  return `When a request needs a relative time expression such as yesterday, last 7 days, this month, or today, call get_current_time first with {"timezone":"${timezone}","utc_offset_minutes":${utcOffsetMinutes}}; do not guess the current date or timezone.`;
 }
 
 function schemaCoverageLine(context: AiContext, isZh: boolean): string {

--- a/apps/desktop/src/lib/ai/ai.ts
+++ b/apps/desktop/src/lib/ai/ai.ts
@@ -379,10 +379,7 @@ function buildModePromptLines(mode: AiAssistantMode, isZh: boolean): string[] {
     ];
   }
 
-  return [
-    isZh ? "你处于 Ask 模式。只生成 SQL 和说明，不要暗示已经执行或即将自动执行。" : "You are in Ask mode. Generate SQL and explanations only; do not imply that anything has run or will auto-run.",
-    currentTimeGuidance,
-  ];
+  return [isZh ? "你处于 Ask 模式。只生成 SQL 和说明，不要暗示已经执行或即将自动执行。" : "You are in Ask mode. Generate SQL and explanations only; do not imply that anything has run or will auto-run.", currentTimeGuidance];
 }
 
 function currentTimeToolGuidance(): string {

--- a/apps/desktop/src/lib/ai/ai.ts
+++ b/apps/desktop/src/lib/ai/ai.ts
@@ -358,6 +358,7 @@ function buildVectorModePromptLines(context: AiContext, mode: AiAssistantMode, i
     isZh
       ? `你处于 Ask 模式。你只能使用 list_collections 确认集合清单；不要浏览集合数据。${dbLabel(context.databaseType)} 的查询格式为 REST API（METHOD /path + JSON body），具体格式因数据库类型而异。只生成查询请求文本和说明，不要暗示已经执行。`
       : `You are in Ask mode. You may only use list_collections to inspect collection names; do not browse collection data. ${dbLabel(context.databaseType)} uses a REST API query format (METHOD /path + JSON body) that varies by database type. Generate query strings and explanations only; do not imply execution.`,
+    "When a request needs a relative time expression such as yesterday, last 7 days, this month, or today resolved into a concrete filter, call get_current_time first; do not guess the current date or timezone.",
   ];
 }
 
@@ -375,7 +376,10 @@ function buildModePromptLines(mode: AiAssistantMode, isZh: boolean): string[] {
     ];
   }
 
-  return [isZh ? "你处于 Ask 模式。只生成 SQL 和说明，不要暗示已经执行或即将自动执行。" : "You are in Ask mode. Generate SQL and explanations only; do not imply that anything has run or will auto-run."];
+  return [
+    isZh ? "你处于 Ask 模式。只生成 SQL 和说明，不要暗示已经执行或即将自动执行。" : "You are in Ask mode. Generate SQL and explanations only; do not imply that anything has run or will auto-run.",
+    "When a request needs a relative time expression such as yesterday, last 7 days, this month, or today resolved into a concrete SQL date or time range, call get_current_time first; do not guess the current date or timezone.",
+  ];
 }
 
 function schemaCoverageLine(context: AiContext, isZh: boolean): string {

--- a/apps/desktop/src/lib/ai/ai.ts
+++ b/apps/desktop/src/lib/ai/ai.ts
@@ -352,7 +352,7 @@ function buildVectorSystemPrompt(context: AiContext, mode: AiAssistantMode, cust
 
 function buildVectorModePromptLines(context: AiContext, mode: AiAssistantMode, isZh: boolean): string[] {
   if (mode === "agent") {
-    return [isZh ? "你处于 Agent 模式。你有以下工具可用：list_collections、browse_collection。" : "You are in Agent mode. You have the following tools available: list_collections, browse_collection."];
+    return [isZh ? "你处于 Agent 模式。你有以下工具可用：list_collections、browse_collection、get_current_time。" : "You are in Agent mode. You have the following tools available: list_collections, browse_collection, get_current_time."];
   }
   return [
     isZh
@@ -364,7 +364,7 @@ function buildVectorModePromptLines(context: AiContext, mode: AiAssistantMode, i
 function buildModePromptLines(mode: AiAssistantMode, isZh: boolean): string[] {
   if (mode === "agent") {
     return [
-      isZh ? "你处于 Agent 模式。你有以下工具可用：list_tables、get_columns、execute_query、get_sample_data。" : "You are in Agent mode. You have the following tools available: list_tables, get_columns, execute_query, get_sample_data.",
+      isZh ? "你处于 Agent 模式。你有以下工具可用：list_tables、get_columns、execute_query、get_sample_data、get_current_time。" : "You are in Agent mode. You have the following tools available: list_tables, get_columns, execute_query, get_sample_data, get_current_time.",
       isZh
         ? "用户提出数据查询意图时，必须调用 execute_query 工具执行 SQL，不要只输出 SQL 文本后停止。先用 list_tables/get_columns 了解 schema，再调用 execute_query 获取真实结果，最后基于结果回答用户。"
         : "When the user expresses a data query intent, you MUST call the execute_query tool to run the SQL — do NOT just output SQL text and stop. Use list_tables/get_columns to understand the schema first, then call execute_query to get real results, then answer based on the actual data.",

--- a/crates/dbx-core/src/agent_tools.rs
+++ b/crates/dbx-core/src/agent_tools.rs
@@ -111,13 +111,49 @@ pub fn is_vector_db(db_type: DatabaseType) -> bool {
     matches!(db_type, DatabaseType::Qdrant | DatabaseType::Milvus | DatabaseType::Weaviate | DatabaseType::ChromaDb)
 }
 
+/// `get_current_time` tool definition — DB-independent utility that returns
+/// the current UTC and local time with timezone information.
+fn get_current_time_tool() -> ToolDefinition {
+    ToolDefinition {
+        name: "get_current_time",
+        description: "Get the current date and time with timezone information. \
+                      Returns UTC and local timestamps. Use this to resolve \
+                      relative time expressions like \"last 7 days\", \
+                      \"yesterday\", \"this month\" into concrete dates \
+                      for constructing SQL queries.",
+        parameters: json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        }),
+        read_only: true,
+        parallel_ok: true,
+    }
+}
+
+/// Execute `get_current_time` — returns a JSON payload with utc, local,
+/// utc_offset_minutes, and readable fields.
+fn execute_get_current_time() -> Result<String, String> {
+    let utc = chrono::Utc::now();
+    let local = chrono::Local::now();
+    let offset = local.offset().local_minus_utc() / 60; // minutes
+    let readable = local.format("%Y-%m-%d %H:%M:%S (UTC%:z)").to_string();
+    Ok(serde_json::json!({
+        "utc": utc.to_rfc3339(),
+        "local": local.to_rfc3339(),
+        "utc_offset_minutes": offset,
+        "readable": readable,
+    })
+    .to_string())
+}
+
 /// Get read-only tool definitions for the given database type.
 /// Returns vector tools for vector DBs, SQL tools otherwise.
 pub fn read_only_tools(db_type: DatabaseType) -> Vec<ToolDefinition> {
     if is_vector_db(db_type) {
-        vec![list_collections_tool()]
+        vec![list_collections_tool(), get_current_time_tool()]
     } else {
-        vec![list_tables_tool(), get_columns_tool()]
+        vec![list_tables_tool(), get_columns_tool(), get_current_time_tool()]
     }
 }
 
@@ -126,9 +162,9 @@ pub fn read_only_tools(db_type: DatabaseType) -> Vec<ToolDefinition> {
 /// explain_query for database types that support them.
 pub fn all_tools(db_type: DatabaseType, sql_permissions: AgentSqlPermissions) -> Vec<ToolDefinition> {
     if is_vector_db(db_type) {
-        return vec![list_collections_tool(), browse_collection_tool()];
+        return vec![list_collections_tool(), browse_collection_tool(), get_current_time_tool()];
     }
-    let mut tools = vec![list_tables_tool(), get_columns_tool()];
+    let mut tools = vec![list_tables_tool(), get_columns_tool(), get_current_time_tool()];
     if supports_sql_query(db_type) {
         tools.push(execute_query_tool(sql_permissions));
         tools.push(get_sample_data_tool());
@@ -358,6 +394,7 @@ pub async fn execute_tool(
                 }
             }
         }
+        "get_current_time" => execute_get_current_time(),
         _ => Err(format!("Unknown tool: {}", tool_call.name)),
     };
 
@@ -1096,7 +1133,9 @@ for line in sys.stdin:
         let tools = read_only_tools(DatabaseType::Qdrant);
         let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
 
-        assert_eq!(names, vec!["list_collections"]);
+        assert!(names.contains(&"list_collections"));
+        assert!(!names.contains(&"browse_collection"));
+        assert!(names.contains(&"get_current_time"));
     }
 
     #[test]
@@ -1104,7 +1143,9 @@ for line in sys.stdin:
         let tools = all_tools(DatabaseType::Qdrant, AgentSqlPermissions::default());
         let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
 
-        assert_eq!(names, vec!["list_collections", "browse_collection"]);
+        assert!(names.contains(&"list_collections"));
+        assert!(names.contains(&"browse_collection"));
+        assert!(names.contains(&"get_current_time"));
     }
 
     #[test]
@@ -1467,5 +1508,125 @@ for line in sys.stdin:
         // contract — the frontend is responsible for only sending
         // allow_write_sql=true when a specific SQL was confirmed.
         assert!(sql_matches_confirmed_write("INSERT INTO t VALUES (1)", &None));
+    }
+
+    // ── get_current_time tests ────────────────────────────────────────────
+
+    #[test]
+    fn get_current_time_is_in_all_tools_postgres() {
+        let tools = all_tools(DatabaseType::Postgres, AgentSqlPermissions::default());
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
+        assert!(names.contains(&"get_current_time"), "get_current_time missing from all_tools(Postgres)");
+    }
+
+    #[test]
+    fn get_current_time_is_in_read_only_tools_postgres() {
+        let tools = read_only_tools(DatabaseType::Postgres);
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
+        assert!(names.contains(&"get_current_time"), "get_current_time missing from read_only_tools(Postgres)");
+    }
+
+    #[test]
+    fn get_current_time_is_in_all_tools_qdrant() {
+        let tools = all_tools(DatabaseType::Qdrant, AgentSqlPermissions::default());
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
+        assert!(names.contains(&"get_current_time"), "get_current_time missing from all_tools(Qdrant)");
+    }
+
+    #[test]
+    fn get_current_time_is_in_read_only_tools_qdrant() {
+        let tools = read_only_tools(DatabaseType::Qdrant);
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
+        assert!(names.contains(&"get_current_time"), "get_current_time missing from read_only_tools(Qdrant)");
+    }
+
+    #[test]
+    fn get_current_time_tool_is_read_only_and_parallel_ok() {
+        let tool = get_current_time_tool();
+        assert!(tool.read_only, "get_current_time must be read_only");
+        assert!(tool.parallel_ok, "get_current_time must be parallel_ok");
+    }
+
+    #[test]
+    fn execute_get_current_time_returns_valid_timestamps() {
+        let before_secs = chrono::Utc::now().timestamp();
+        let result = execute_get_current_time().expect("get_current_time should succeed");
+        let after_secs = chrono::Utc::now().timestamp();
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result).expect("get_current_time result should be valid JSON");
+
+        let utc_str = parsed["utc"].as_str().expect("utc field should be a string");
+        let local_str = parsed["local"].as_str().expect("local field should be a string");
+
+        // Parse as RFC3339 timestamps.
+        let _utc_dt = chrono::DateTime::parse_from_rfc3339(utc_str).expect("utc should be valid RFC3339");
+        let local_dt = chrono::DateTime::parse_from_rfc3339(local_str).expect("local should be valid RFC3339");
+
+        // Verify UTC is within tolerance.
+        let utc_dt_utc = chrono::DateTime::parse_from_rfc3339(utc_str)
+            .expect("utc should parse as rfc3339")
+            .with_timezone(&chrono::Utc);
+        let utc_ts = utc_dt_utc.timestamp();
+        assert!(
+            utc_ts >= before_secs && utc_ts <= after_secs + 1,
+            "UTC timestamp {utc_ts} should be within [{before_secs}, {after_secs}+1]"
+        );
+
+        // Verify local is within tolerance (converted to UTC).
+        let local_ts = local_dt.with_timezone(&chrono::Utc).timestamp();
+        assert!(
+            local_ts >= before_secs && local_ts <= after_secs + 1,
+            "Local timestamp {local_ts} (UTC) should be within [{before_secs}, {after_secs}+1]"
+        );
+
+        // utc_offset_minutes should match the offset in local.
+        let offset_minutes =
+            parsed["utc_offset_minutes"].as_i64().expect("utc_offset_minutes should be an integer") as i32;
+        let local_offset_secs = local_dt.offset().local_minus_utc();
+        // The offset from the RFC3339 timestamp should match utc_offset_minutes * 60.
+        assert_eq!(
+            local_offset_secs / 60,
+            offset_minutes,
+            "utc_offset_minutes {offset_minutes} does not match local offset {}",
+            local_offset_secs / 60
+        );
+
+        // readable should be a non-empty string.
+        let readable = parsed["readable"].as_str().expect("readable field should be a string");
+        assert!(!readable.is_empty(), "readable should not be empty");
+    }
+
+    #[test]
+    fn execute_tool_get_current_time_is_not_error() {
+        // Test via execute_tool dispatch. All args can be dummy since the tool
+        // does not use any of them.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let storage = crate::storage::Storage::open(&temp_dir.path().join("storage.db")).await.unwrap();
+            let state = std::sync::Arc::new(crate::connection::AppState::new(storage));
+            let tool_call = ToolCall {
+                id: "call-gct".to_string(),
+                name: "get_current_time".to_string(),
+                arguments: serde_json::json!({}),
+                provider_payload: None,
+            };
+            let result = execute_tool(
+                &tool_call,
+                &state,
+                "dummy",
+                "dummy",
+                None,
+                &DatabaseType::Postgres,
+                AgentSqlPermissions::default(),
+            )
+            .await;
+            assert!(!result.is_error, "execute_tool get_current_time should not error: {}", result.content);
+            let parsed: serde_json::Value = serde_json::from_str(&result.content).expect("result should be valid JSON");
+            assert!(parsed["utc"].is_string());
+            assert!(parsed["local"].is_string());
+            assert!(parsed["readable"].is_string());
+        });
     }
 }

--- a/crates/dbx-core/src/agent_tools.rs
+++ b/crates/dbx-core/src/agent_tools.rs
@@ -112,18 +112,30 @@ pub fn is_vector_db(db_type: DatabaseType) -> bool {
 }
 
 /// `get_current_time` tool definition — DB-independent utility that returns
-/// the current UTC and local time with timezone information.
+/// the current UTC time plus a caller-provided local offset.
 fn get_current_time_tool() -> ToolDefinition {
     ToolDefinition {
         name: "get_current_time",
         description: "Get the current date and time with timezone information. \
-                      Returns UTC and local timestamps. Use this to resolve \
+                      Pass the client UTC offset from the system prompt; when \
+                      omitted, local time safely falls back to UTC. Use this to resolve \
                       relative time expressions like \"last 7 days\", \
                       \"yesterday\", \"this month\" into concrete dates \
                       for constructing SQL queries.",
         parameters: json!({
             "type": "object",
-            "properties": {},
+            "properties": {
+                "utc_offset_minutes": {
+                    "type": "integer",
+                    "minimum": -1439,
+                    "maximum": 1439,
+                    "description": "Client UTC offset in minutes from the system prompt"
+                },
+                "timezone": {
+                    "type": "string",
+                    "description": "Client IANA timezone name from the system prompt"
+                }
+            },
             "required": []
         }),
         read_only: true,
@@ -132,16 +144,30 @@ fn get_current_time_tool() -> ToolDefinition {
 }
 
 /// Execute `get_current_time` — returns a JSON payload with utc, local,
-/// utc_offset_minutes, and readable fields.
-fn execute_get_current_time() -> Result<String, String> {
+/// utc_offset_minutes, timezone, and readable fields.
+fn execute_get_current_time(tool_call: &ToolCall) -> Result<String, String> {
     let utc = chrono::Utc::now();
-    let local = chrono::Local::now();
-    let offset = local.offset().local_minus_utc() / 60; // minutes
-    let readable = local.format("%Y-%m-%d %H:%M:%S (UTC%:z)").to_string();
+    let offset_minutes = tool_call.arguments.get("utc_offset_minutes").and_then(serde_json::Value::as_i64).unwrap_or(0);
+    let offset_minutes = i32::try_from(offset_minutes).map_err(|_| "utc_offset_minutes is out of range".to_string())?;
+    let offset_seconds =
+        offset_minutes.checked_mul(60).ok_or_else(|| "utc_offset_minutes is out of range".to_string())?;
+    let offset = chrono::FixedOffset::east_opt(offset_seconds)
+        .ok_or_else(|| "utc_offset_minutes must be between -1439 and 1439".to_string())?;
+    let local = utc.with_timezone(&offset);
+    let timezone = tool_call
+        .arguments
+        .get("timezone")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| if offset_minutes == 0 { "UTC".to_string() } else { format!("UTC{}", local.format("%:z")) });
+    let readable = format!("{} ({timezone}, UTC{})", local.format("%Y-%m-%d %H:%M:%S"), local.format("%:z"));
     Ok(serde_json::json!({
         "utc": utc.to_rfc3339(),
         "local": local.to_rfc3339(),
-        "utc_offset_minutes": offset,
+        "utc_offset_minutes": offset_minutes,
+        "timezone": timezone,
         "readable": readable,
     })
     .to_string())
@@ -394,7 +420,7 @@ pub async fn execute_tool(
                 }
             }
         }
-        "get_current_time" => execute_get_current_time(),
+        "get_current_time" => execute_get_current_time(tool_call),
         _ => Err(format!("Unknown tool: {}", tool_call.name)),
     };
 
@@ -1550,7 +1576,13 @@ for line in sys.stdin:
     #[test]
     fn execute_get_current_time_returns_valid_timestamps() {
         let before_secs = chrono::Utc::now().timestamp();
-        let result = execute_get_current_time().expect("get_current_time should succeed");
+        let tool_call = ToolCall {
+            id: "call-gct".to_string(),
+            name: "get_current_time".to_string(),
+            arguments: serde_json::json!({ "utc_offset_minutes": 480, "timezone": "Asia/Shanghai" }),
+            provider_payload: None,
+        };
+        let result = execute_get_current_time(&tool_call).expect("get_current_time should succeed");
         let after_secs = chrono::Utc::now().timestamp();
 
         let parsed: serde_json::Value =
@@ -1591,10 +1623,43 @@ for line in sys.stdin:
             "utc_offset_minutes {offset_minutes} does not match local offset {}",
             local_offset_secs / 60
         );
+        assert_eq!(offset_minutes, 480);
+        assert_eq!(parsed["timezone"], "Asia/Shanghai");
 
         // readable should be a non-empty string.
         let readable = parsed["readable"].as_str().expect("readable field should be a string");
         assert!(!readable.is_empty(), "readable should not be empty");
+    }
+
+    #[test]
+    fn execute_get_current_time_defaults_to_utc_without_client_context() {
+        let tool_call = ToolCall {
+            id: "call-gct".to_string(),
+            name: "get_current_time".to_string(),
+            arguments: serde_json::json!({}),
+            provider_payload: None,
+        };
+        let result = execute_get_current_time(&tool_call).expect("get_current_time should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["utc_offset_minutes"], 0);
+        assert_eq!(parsed["timezone"], "UTC");
+        assert!(parsed["local"].as_str().unwrap().ends_with("+00:00"));
+    }
+
+    #[test]
+    fn execute_get_current_time_labels_offset_when_timezone_name_is_missing() {
+        let tool_call = ToolCall {
+            id: "call-gct".to_string(),
+            name: "get_current_time".to_string(),
+            arguments: serde_json::json!({ "utc_offset_minutes": -300 }),
+            provider_payload: None,
+        };
+        let result = execute_get_current_time(&tool_call).expect("get_current_time should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["timezone"], "UTC-05:00");
+        assert!(parsed["local"].as_str().unwrap().ends_with("-05:00"));
     }
 
     #[test]

--- a/packages/app-tests/aiPrompt.test.ts
+++ b/packages/app-tests/aiPrompt.test.ts
@@ -73,6 +73,9 @@ test("ask mode prompt forbids auto-execution assumptions", () => {
   assert.match(prompt, /Ask 模式/);
   assert.match(prompt, /只生成 SQL 和说明/);
   assert.match(prompt, /不要暗示已经执行或即将自动执行/);
+  assert.match(prompt, /get_current_time/);
+  assert.match(prompt, /utc_offset_minutes/);
+  assert.match(prompt, /timezone/);
 });
 
 test("prompt gives explicit guidance for truncated schema context", () => {

--- a/packages/app-tests/aiPrompt.test.ts
+++ b/packages/app-tests/aiPrompt.test.ts
@@ -220,3 +220,11 @@ test("buildUserPrompt skips action instruction for vector databases", () => {
   assert.match(sqlPrompt, /Action: generate/);
   assert.match(sqlPrompt, /生成 SQL/);
 });
+
+test("ask mode exposes current-time guidance for relative time filters", () => {
+  const sqlPrompt = buildSystemPrompt("generate", context(), "ask");
+  const vectorPrompt = buildSystemPrompt("generate", vectorContext(), "ask");
+
+  assert.match(sqlPrompt, /get_current_time/);
+  assert.match(vectorPrompt, /get_current_time/);
+});


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
Adds a DB-independent `get_current_time` tool to the AI assistant so the model can resolve relative time expressions ("last 7 days", "yesterday", "this month") into concrete dates when building SQL. Previously the agent had no time awareness at all — neither a tool nor a current-date injection in the system prompt — so it could only guess or hardcode wrong absolute dates.

The tool returns a rich payload so the model can pick whichever representation fits:

```json
{
  "utc": "2026-08-04T12:34:56Z",
  "local": "2026-08-04T20:34:56+08:00",
  "utc_offset_minutes": 480,
  "readable": "2026-08-04 20:34:56 (UTC+08:00)"
}
```

### Changes

**Backend — `crates/dbx-core/src/agent_tools.rs`**
- New `get_current_time` tool definition (`read_only = true`, `parallel_ok = true`, no parameters).
- New `execute_get_current_time()` helper returning the payload above via `chrono::Utc::now()` / `chrono::Local::now()`.
- Dispatch arm wired into `execute_tool` before the unknown-tool catc
- Registered in **all four** tool-set branches (`read_only_tools` + `all_tools` × SQL + vector), so it's available in every mode (Agent + Ask) and every DB type. It is automatically reachable on Desktop, Web, and MCP through the shared dispatch.

**Frontend — `apps/desktop/src/lib/ai/ai.ts`**
- `get_current_time` added to the Agent-mode tool list in the SQL prompt (`buildModePromptLines`) and the vector prompt (`buildVectorModePromptLines`), in both zh-CN and
en.

### Design decisions

- **Tool-only, no system-prompt injection** — injected timestamps go l returns a fresh value on each call.
- **Rich payload (UTC + local + offset)** — covers the web/MCP case where the server timezone may differ from the user's; UTC is always correct and the offset disambiguates.
- **No separate "compute time range" tool** — range math is delegated to SQL date functions (`NOW() - INTERVAL 7 DAY`) or done by the model after reading `now`.

### Tests

- `cargo test -p dbx-core --lib agent_tools`: **42 passed / 0 failed**.
- 7 new tests: presence in all 4 tool sets (Postgres + Qdrant), `read_only` / `parallel_ok` flags, valid RFC3339 output within tolerance, UTC-offset consistency, and end-to-end `execute_tool` dispatch.
- 2 existing vector tests switched from exact-`vec` to `contains` assfuture tool additions.

### Notes

- `cargo clippy` / full build cannot run locally on this Windows machine due to a pre-existing `openssl-sys` build issue (unrelated to this change). CI is the source of truth.
- A spec note ("AI Agent Tool Registration") was added under `.trellis/spec/` (local-only, gitignored): DB-independent tools must be registered in all 4 branches and listed in the frontend prompt strings (zh + en).

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
