### PR TITLE
fix(sqlserver): 修复中文表名别名后的字段联想

### DIFF
--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -2511,9 +2511,10 @@ function extractReferencedTables(sql: string, databaseType?: DatabaseType): SqlC
   ]);
 
   // STRAIGHT_JOIN is a standalone MySQL table introducer, not a modifier followed by JOIN.
-  const identifier = '(?:"[^"]+"|`[^`]+`|\\[[^\\]]+\\]|[A-Za-z_][\\w$@#]*)';
+  const unquotedIdentifier = databaseType === "sqlserver" ? "[_\\p{ID_Start}][$@#_\\u200c\\u200d\\p{ID_Continue}]*" : "[A-Za-z_][\\w$@#]*";
+  const identifier = `(?:"[^"]+"|\`[^\`]+\`|\\[[^\\]]+\\]|${unquotedIdentifier})`;
   const qualifiedSeparator = databaseType === "sqlserver" ? `\\.(?:${identifier}|\\.${identifier})` : `\\.${identifier}`;
-  const pattern = new RegExp(`\\b(?:from|join|straight_join|update|apply)\\s+(${identifier}(?:${qualifiedSeparator}){0,3})(?:\\s+(?:as\\s+)?([A-Za-z_][\\w$]*))?`, "gi");
+  const pattern = new RegExp(`\\b(?:from|join|straight_join|update|apply)\\s+(${identifier}(?:${qualifiedSeparator}){0,3})(?:\\s+(?:as\\s+)?([A-Za-z_][\\w$]*))?`, databaseType === "sqlserver" ? "giu" : "gi");
   const referenced: SqlCompletionReferencedTable[] = [];
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(sql)) !== null) {

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import {
   buildSqlCompletionItems,
+  buildSqlCompletionItemsFromContext,
   getSqlFunctionSignatureHelp,
   getSqlCompletionResultValidFor,
   isSqlCommentContext,
@@ -494,6 +495,40 @@ test("suggests SQL Server tables for unquoted Chinese prefixes", () => {
     ["客户订单"],
   );
   assert.equal(shouldAutoOpenSqlCompletion(sql, sql.length), true);
+});
+
+test("suggests SQL Server columns for an aliased unquoted Chinese table", () => {
+  const sql = "SELECT * FROM 大客户报废物资 AS tb2 WHERE ";
+  const options = { databaseType: "sqlserver" as const, dialect: "sqlserver" as const };
+  const legacy = getSqlCompletionContext(sql, sql.length, options);
+  const semantic = buildSqlSemanticModel(sql, sql.length, options);
+  const context = sqlCompletionContextFromSemantic(semantic, legacy);
+  const items = buildSqlCompletionItemsFromContext(context, {
+    ...options,
+    tables: [{ name: "大客户报废物资", schema: "dbo", type: "table" }],
+    columnsByTable: new Map([
+      [
+        "dbo.大客户报废物资",
+        [
+          { name: "物资编号", table: "大客户报废物资", schema: "dbo" },
+          { name: "客户名称", table: "大客户报废物资", schema: "dbo" },
+        ],
+      ],
+    ]),
+  });
+
+  assert.equal(context.referencedTables.length, 1);
+  assert.equal(context.referencedTables[0]?.name, "大客户报废物资");
+  assert.equal(context.referencedTables[0]?.alias, "tb2");
+  assert.equal(context.suggestColumns, true);
+  assert.equal(shouldAutoOpenSqlCompletion(sql, sql.length, options), true);
+  assert.deepEqual(
+    items
+      .filter((item) => item.type === "column")
+      .map((item) => item.label)
+      .sort(),
+    ["客户名称", "物资编号"],
+  );
 });
 
 test("preserves Unicode prefixes through the semantic completion context", () => {


### PR DESCRIPTION
## 变更说明

- SQL Server 解析未加引号的表引用时支持 Unicode 标识符。
- 正确识别 `FROM 大客户报废物资 AS tb2`，使 `WHERE` 和 `tb2.` 后能够提示对应字段。
- 保持其他数据库现有的标识符解析逻辑不变。
- 增加覆盖语义上下文合并、表引用识别、字段候选和自动弹出行为的回归测试。

## 问题原因

#4505 已修复输入中文表名前缀时的表名提示，但完整 SQL 的表引用提取仍使用 ASCII-only 正则。中文表名带别名后无法写入 `referencedTables`，因此字段提示没有目标表可解析。

## 影响范围

本次仅放宽 SQL Server 未加引号表名的解析规则，不改变 MySQL、PostgreSQL 等其他数据库的补全行为。

## 验证

- `pnpm vitest run packages/app-tests/sqlCompletion.test.ts apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts apps/desktop/src/lib/__tests__/sql/semantic/model.spec.ts`（362 项通过）
- `pnpm typecheck`
- 目标文件 Oxlint 检查通过
- 手动连接 SQL Server 验证中文表名在 `WHERE` 和别名点号后的字段提示

Closes #5268