### PR TITLE
fix(grid): 修复 Windows 分数缩放下 Canvas 表格文字模糊

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -142,7 +142,7 @@ import { dataGridHeaderContentWidth, scrollbarGutterWidth } from "@/lib/dataGrid
 import { canFetchNextDataGridSegment, canGoNextDataGridPage, dataGridTotalRowCountLabelKey, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal, type DataGridInexactTotalRowCountMode } from "@/lib/dataGrid/dataGridPagination";
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
 import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
-import { CANVAS_DATA_GRID_ROW_HEIGHT, canvasDataGridActionOverlayWidth, canvasDataGridActionReservedWidth, dataGridSearchMatchKey, drawCanvasDataGrid } from "@/lib/dataGrid/canvasDataGridRenderer";
+import { CANVAS_DATA_GRID_ROW_HEIGHT, canvasDataGridActionOverlayWidth, canvasDataGridActionReservedWidth, dataGridSearchMatchKey, drawCanvasDataGrid, type CanvasDevicePixelSize } from "@/lib/dataGrid/canvasDataGridRenderer";
 import { DATA_GRID_DARK_STRIPED_ROW_BG, DATA_GRID_LIGHT_STRIPED_ROW_BG, dataGridActiveRowBackground } from "@/lib/dataGrid/dataGridPaintTheme";
 import { createRowLowerTextCache } from "@/lib/dataGrid/dataGridRowLowerText";
 import { dataGridPreviewLabelKey, dataGridSaveActionMode, dataGridSaveToolbarState } from "@/lib/dataGrid/dataGridSaveUi";
@@ -194,7 +194,7 @@ import { columnNamesForCopy } from "@/lib/dataGrid/dataGridColumnNameCopy";
 import { DATA_GRID_ROW_NUM_WIDTH, dataGridRowNumberColumnWidth, resolveDataGridMaxRowNumber, useDataGridColumnResize } from "@/composables/useDataGridColumnResize";
 import { createDataGridColumnStructureSignature } from "@/lib/dataGrid/dataGridColumnWidthState";
 import { useDataGridColumnLayout, useDataGridColumnLayoutState } from "@/composables/useDataGridColumnLayout";
-import { useDataGridCanvasRuntime, type DataGridCanvasRuntime } from "@/composables/useDataGridCanvasRuntime";
+import { dataGridCanvasDevicePixelSize, useDataGridCanvasRuntime, type DataGridCanvasRuntime } from "@/composables/useDataGridCanvasRuntime";
 import { useDataGridScrollbars, type DataGridScrollbarsRuntime } from "@/composables/useDataGridScrollbars";
 import { useDataGridSelection } from "@/composables/useDataGridSelection";
 import { moveDataGridCell } from "@/lib/dataGrid/dataGridNavigation";
@@ -4731,6 +4731,7 @@ const canvasViewportHeight = ref(0);
 const canvasScrollTop = ref(0);
 const canvasHoverCell = ref<{ rowIndex: number; visibleColIdx: number } | null>(null);
 const canvasDevicePixelRatio = ref(typeof window === "undefined" ? 1 : window.devicePixelRatio || 1);
+const canvasMeasuredDevicePixelSize = ref<CanvasDevicePixelSize | null>(null);
 const canvasBackingPixelRatio = computed(() => Math.min(4, Math.max(1, canvasDevicePixelRatio.value * settingsStore.editorSettings.uiScale)));
 const useCanvasGridRows = computed(() => dataGridRenderMode.value === "canvas");
 const canvasContentHeight = computed(() => Math.max(1, displayRowCount.value * CANVAS_DATA_GRID_ROW_HEIGHT));
@@ -4820,10 +4821,13 @@ function dataGridRowFromClientPoint(_clientX: number, clientY: number): number |
   return Number.isInteger(rowIndex) ? rowIndex : null;
 }
 
-function syncCanvasViewport() {
+function syncCanvasViewport(entries?: readonly ResizeObserverEntry[]) {
   if (!dataGridIsActive) return;
   const scroller = canvasScrollerElement();
   if (!scroller) return;
+  const canvas = canvasRef.value;
+  const canvasEntry = canvas ? entries?.find((entry) => entry.target === canvas) : undefined;
+  if (canvasEntry) canvasMeasuredDevicePixelSize.value = dataGridCanvasDevicePixelSize(canvasEntry);
   canvasViewportWidth.value = scroller.clientWidth;
   canvasViewportHeight.value = scroller.clientHeight;
   canvasScrollTop.value = scroller.scrollTop;
@@ -4884,6 +4888,7 @@ canvasRuntime = useDataGridCanvasRuntime({
   draw: drawCanvasGrid,
   syncViewport: syncCanvasViewport,
   getViewport: canvasScrollerElement,
+  getSurface: () => canvasRef.value ?? null,
   refreshPixelRatio: () => {
     const next = currentCanvasDevicePixelRatio();
     if (Math.abs(next - canvasDevicePixelRatio.value) > 0.001) {
@@ -5313,6 +5318,7 @@ function drawCanvasGrid() {
     width: Math.max(1, canvasSurfaceWidth.value || scroller.clientWidth),
     height: Math.max(1, canvasViewportHeight.value || scroller.clientHeight),
     pixelRatio: canvasBackingPixelRatio.value,
+    devicePixelSize: canvasMeasuredDevicePixelSize.value,
     isDark: isDark.value,
     styleKey: canvasRenderStyleKey.value,
     rowCount: displayRowCount.value,

--- a/apps/desktop/src/composables/__tests__/useDataGridCanvasRuntime.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridCanvasRuntime.spec.ts
@@ -1,6 +1,6 @@
 import { effectScope } from "vue";
 import { describe, expect, it, vi } from "vitest";
-import { useDataGridCanvasRuntime, type DataGridAnimationFrameDriver } from "@/composables/useDataGridCanvasRuntime";
+import { dataGridCanvasDevicePixelSize, useDataGridCanvasRuntime, type DataGridAnimationFrameDriver } from "@/composables/useDataGridCanvasRuntime";
 import { useDataGridScrollbars } from "@/composables/useDataGridScrollbars";
 
 function createFrameDriver() {
@@ -26,6 +26,34 @@ function createObserver() {
 }
 
 describe("data grid visual runtimes", () => {
+  it("reads the exact device-pixel content box reported for a canvas", () => {
+    const size = dataGridCanvasDevicePixelSize({
+      contentRect: { width: 801, height: 399 },
+      devicePixelContentBoxSize: [{ inlineSize: 1001, blockSize: 499 }],
+    } as unknown as ResizeObserverEntry);
+
+    expect(size).toEqual({ cssWidth: 801, cssHeight: 399, pixelWidth: 1001, pixelHeight: 499 });
+  });
+
+  it("observes the canvas device-pixel box together with its viewport", () => {
+    const resize = createObserver();
+    const viewport = { children: [] } as unknown as Element;
+    const surface = { children: [] } as unknown as Element;
+    const runtime = useDataGridCanvasRuntime({
+      draw: vi.fn(),
+      syncViewport: vi.fn(),
+      getViewport: () => viewport,
+      getSurface: () => surface,
+      createResizeObserver: () => resize.observer,
+    });
+
+    runtime.observeViewport();
+
+    expect(resize.observe).toHaveBeenNthCalledWith(1, viewport);
+    expect(resize.observe).toHaveBeenNthCalledWith(2, surface, { box: "device-pixel-content-box" });
+    runtime.dispose();
+  });
+
   it("coalesces canvas frames and cancels all resources on dispose", () => {
     const frames = createFrameDriver();
     const resize = createObserver();

--- a/apps/desktop/src/composables/useDataGridCanvasRuntime.ts
+++ b/apps/desktop/src/composables/useDataGridCanvasRuntime.ts
@@ -1,4 +1,5 @@
 import { getCurrentScope, onScopeDispose } from "vue";
+import type { CanvasDevicePixelSize } from "@/lib/dataGrid/canvasDataGridRenderer";
 
 export interface DataGridAnimationFrameDriver {
   request(callback: FrameRequestCallback): number;
@@ -7,8 +8,9 @@ export interface DataGridAnimationFrameDriver {
 
 export interface DataGridCanvasRuntimeOptions {
   draw(): void;
-  syncViewport(): void;
+  syncViewport(entries?: readonly ResizeObserverEntry[]): void;
   getViewport(): Element | null;
+  getSurface?: () => Element | null;
   refreshPixelRatio?: () => void;
   frameDriver?: DataGridAnimationFrameDriver;
   createResizeObserver?: (callback: ResizeObserverCallback) => ResizeObserver | null;
@@ -25,6 +27,18 @@ export interface DataGridCanvasRuntime {
   pause(): void;
   resume(): void;
   dispose(): void;
+}
+
+export function dataGridCanvasDevicePixelSize(entry: ResizeObserverEntry): CanvasDevicePixelSize | null {
+  const boxes = entry.devicePixelContentBoxSize;
+  const box = Array.isArray(boxes) ? boxes[0] : (boxes as unknown as ResizeObserverSize | undefined);
+  if (!box || !Number.isFinite(box.inlineSize) || !Number.isFinite(box.blockSize) || box.inlineSize <= 0 || box.blockSize <= 0) return null;
+  return {
+    cssWidth: entry.contentRect.width,
+    cssHeight: entry.contentRect.height,
+    pixelWidth: Math.round(box.inlineSize),
+    pixelHeight: Math.round(box.blockSize),
+  };
 }
 
 function defaultFrameDriver(): DataGridAnimationFrameDriver {
@@ -88,10 +102,18 @@ export function useDataGridCanvasRuntime(options: DataGridCanvasRuntimeOptions):
       options.syncViewport();
       const viewport = options.getViewport();
       if (!viewport) return;
-      resizeObserver = createResizeObserver(() => {
-        if (active && !disposed) options.syncViewport();
+      resizeObserver = createResizeObserver((entries) => {
+        if (active && !disposed) options.syncViewport(entries);
       });
       resizeObserver?.observe(viewport);
+      const surface = options.getSurface?.();
+      if (resizeObserver && surface && surface !== viewport) {
+        try {
+          resizeObserver.observe(surface, { box: "device-pixel-content-box" });
+        } catch {
+          resizeObserver.observe(surface);
+        }
+      }
     },
     pause() {
       active = false;

--- a/apps/desktop/src/lib/__tests__/dataGrid/canvasDataGridRendererFrozen.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/canvasDataGridRendererFrozen.spec.ts
@@ -108,6 +108,17 @@ describe("drawCanvasDataGrid with frozen columns", () => {
     ).toEqual({ pixelWidth: 1125, pixelHeight: 500, scaleX: 1.25, scaleY: 1.25, measured: false });
   });
 
+  it("caps the observed backing store at the configured pixel ratio", () => {
+    expect(
+      resolveCanvasBackingStoreMetrics({
+        width: 801,
+        height: 399,
+        pixelRatio: 4,
+        devicePixelSize: { cssWidth: 801, cssHeight: 399, pixelWidth: 4005, pixelHeight: 1995 },
+      }),
+    ).toEqual({ pixelWidth: 3204, pixelHeight: 1596, scaleX: 4, scaleY: 4, measured: true });
+  });
+
   it("draws without errors when frozenColumnCount is 0", () => {
     const canvas = createMockCanvas();
     const options = createBaseOptions({ canvas, frozenColumnCount: 0 });

--- a/apps/desktop/src/lib/__tests__/dataGrid/canvasDataGridRendererFrozen.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/canvasDataGridRendererFrozen.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { CANVAS_DATA_GRID_ROW_HEIGHT, drawCanvasDataGrid, type DrawCanvasDataGridOptions } from "@/lib/dataGrid/canvasDataGridRenderer";
+import { drawCanvasDataGrid, resolveCanvasBackingStoreMetrics, type DrawCanvasDataGridOptions } from "@/lib/dataGrid/canvasDataGridRenderer";
 
 function createMockCanvas(width = 800, height = 400) {
   const canvas = document.createElement("canvas");
@@ -78,6 +78,34 @@ describe("drawCanvasDataGrid with frozen columns", () => {
       lineHeight: "normal",
       getPropertyValue: () => "",
     } as CSSStyleDeclaration);
+  });
+
+  it("uses the exact observed device-pixel size instead of a nominal DPR", () => {
+    expect(
+      resolveCanvasBackingStoreMetrics({
+        width: 801,
+        height: 399,
+        pixelRatio: 1.25,
+        devicePixelSize: { cssWidth: 801, cssHeight: 399, pixelWidth: 1001, pixelHeight: 499 },
+      }),
+    ).toEqual({
+      pixelWidth: 1001,
+      pixelHeight: 499,
+      scaleX: 1001 / 801,
+      scaleY: 499 / 399,
+      measured: true,
+    });
+  });
+
+  it("ignores a stale observed size after the CSS viewport changes", () => {
+    expect(
+      resolveCanvasBackingStoreMetrics({
+        width: 900,
+        height: 400,
+        pixelRatio: 1.25,
+        devicePixelSize: { cssWidth: 801, cssHeight: 399, pixelWidth: 1001, pixelHeight: 499 },
+      }),
+    ).toEqual({ pixelWidth: 1125, pixelHeight: 500, scaleX: 1.25, scaleY: 1.25, measured: false });
   });
 
   it("draws without errors when frozenColumnCount is 0", () => {

--- a/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
+++ b/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
@@ -116,8 +116,10 @@ export function resolveCanvasBackingStoreMetrics(options: { width: number; heigh
   const fallbackRatio = Math.max(1, options.pixelRatio);
   const measured = options.devicePixelSize;
   const measurementMatches = !!measured && Math.abs(measured.cssWidth - width) <= 0.5 && Math.abs(measured.cssHeight - height) <= 0.5 && measured.pixelWidth > 0 && measured.pixelHeight > 0;
-  const pixelWidth = measurementMatches ? measured.pixelWidth : Math.max(1, Math.ceil(width * fallbackRatio));
-  const pixelHeight = measurementMatches ? measured.pixelHeight : Math.max(1, Math.ceil(height * fallbackRatio));
+  const fallbackPixelWidth = Math.max(1, Math.ceil(width * fallbackRatio));
+  const fallbackPixelHeight = Math.max(1, Math.ceil(height * fallbackRatio));
+  const pixelWidth = measurementMatches ? Math.min(measured.pixelWidth, fallbackPixelWidth) : fallbackPixelWidth;
+  const pixelHeight = measurementMatches ? Math.min(measured.pixelHeight, fallbackPixelHeight) : fallbackPixelHeight;
   return {
     pixelWidth,
     pixelHeight,

--- a/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
+++ b/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
@@ -5,6 +5,13 @@ import { BOOLEAN_CHECKBOX_SIZE, isBooleanCheckboxValue, normalizeBooleanCellValu
 
 export const CANVAS_DATA_GRID_ROW_HEIGHT = 26;
 
+export interface CanvasDevicePixelSize {
+  cssWidth: number;
+  cssHeight: number;
+  pixelWidth: number;
+  pixelHeight: number;
+}
+
 export interface CanvasDataGridRow {
   id: number;
   displayIndex: number;
@@ -49,6 +56,7 @@ export interface DrawCanvasDataGridOptions {
   width: number;
   height: number;
   pixelRatio?: number;
+  devicePixelSize?: CanvasDevicePixelSize | null;
   isDark: boolean;
   styleKey?: string;
   rowCount: number;
@@ -92,6 +100,31 @@ interface CanvasRenderState {
   searchFill: string;
   currentSearchFill: string;
   currentSearchBorder: string;
+}
+
+export interface CanvasBackingStoreMetrics {
+  pixelWidth: number;
+  pixelHeight: number;
+  scaleX: number;
+  scaleY: number;
+  measured: boolean;
+}
+
+export function resolveCanvasBackingStoreMetrics(options: { width: number; height: number; pixelRatio: number; devicePixelSize?: CanvasDevicePixelSize | null }): CanvasBackingStoreMetrics {
+  const width = Math.max(1, options.width);
+  const height = Math.max(1, options.height);
+  const fallbackRatio = Math.max(1, options.pixelRatio);
+  const measured = options.devicePixelSize;
+  const measurementMatches = !!measured && Math.abs(measured.cssWidth - width) <= 0.5 && Math.abs(measured.cssHeight - height) <= 0.5 && measured.pixelWidth > 0 && measured.pixelHeight > 0;
+  const pixelWidth = measurementMatches ? measured.pixelWidth : Math.max(1, Math.ceil(width * fallbackRatio));
+  const pixelHeight = measurementMatches ? measured.pixelHeight : Math.max(1, Math.ceil(height * fallbackRatio));
+  return {
+    pixelWidth,
+    pixelHeight,
+    scaleX: pixelWidth / width,
+    scaleY: pixelHeight / height,
+    measured: measurementMatches,
+  };
 }
 
 export function resolveCanvasDataGridRowFill(theme: Pick<DataGridPaintTheme, "cellActive" | "cellSelected">, rowBase: string, options: { isActive: boolean; isDeleted: boolean; isSelected: boolean }): string {
@@ -193,11 +226,11 @@ function alignCanvasPixel(value: number, dpr: number): number {
   return Math.round(value * dpr) / dpr;
 }
 
-function drawBooleanCheckbox(ctx: CanvasRenderingContext2D, options: { drawX: number; y: number; colWidth: number; dpr: number; theme: DataGridPaintTheme; checked: boolean }): void {
-  const { drawX, y, colWidth, dpr, theme, checked } = options;
+function drawBooleanCheckbox(ctx: CanvasRenderingContext2D, options: { drawX: number; y: number; colWidth: number; scaleX: number; scaleY: number; theme: DataGridPaintTheme; checked: boolean }): void {
+  const { drawX, y, colWidth, scaleX, scaleY, theme, checked } = options;
   const size = BOOLEAN_CHECKBOX_SIZE;
-  const boxX = alignCanvasPixel(drawX + (colWidth - size) / 2, dpr);
-  const boxY = alignCanvasPixel(y + (CANVAS_DATA_GRID_ROW_HEIGHT - size) / 2, dpr);
+  const boxX = alignCanvasPixel(drawX + (colWidth - size) / 2, scaleX);
+  const boxY = alignCanvasPixel(y + (CANVAS_DATA_GRID_ROW_HEIGHT - size) / 2, scaleY);
   ctx.lineWidth = 1;
   if (checked) {
     ctx.fillStyle = theme.primary;
@@ -302,9 +335,13 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
     rightAlignedActionCell,
     columnIsBoolean,
   } = options;
-  const dpr = Math.max(1, options.pixelRatio ?? window.devicePixelRatio ?? 1);
-  const pixelWidth = Math.max(1, Math.ceil(width * dpr));
-  const pixelHeight = Math.max(1, Math.ceil(height * dpr));
+  const fallbackRatio = Math.max(1, options.pixelRatio ?? window.devicePixelRatio ?? 1);
+  const { pixelWidth, pixelHeight, scaleX, scaleY } = resolveCanvasBackingStoreMetrics({
+    width,
+    height,
+    pixelRatio: fallbackRatio,
+    devicePixelSize: options.devicePixelSize,
+  });
   if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
     canvas.width = pixelWidth;
     canvas.height = pixelHeight;
@@ -316,7 +353,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
 
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
   ctx.imageSmoothingEnabled = false;
   ctx.clearRect(0, 0, width, height);
 
@@ -343,9 +380,9 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
   const firstCol = firstVisibleColumn(offsets, Math.max(0, contentStart - maxPreviewRightShift));
   const columnOffset = offsets[firstCol] ?? 0;
   const paintSearchMatches = !isScrolling && searchMatchKeys.size > 0;
-  const rowNumberBorderX = crispCanvasLine(rowNumberWidth - 1, dpr);
-  const rowNumberTextX = alignCanvasPixel(Math.max(0, rowNumberWidth - 1) / 2, dpr);
-  const rowTextOffsetY = alignCanvasPixel(CANVAS_DATA_GRID_ROW_HEIGHT / 2, dpr);
+  const rowNumberBorderX = crispCanvasLine(rowNumberWidth - 1, scaleX);
+  const rowNumberTextX = alignCanvasPixel(Math.max(0, rowNumberWidth - 1) / 2, scaleX);
+  const rowTextOffsetY = alignCanvasPixel(CANVAS_DATA_GRID_ROW_HEIGHT / 2, scaleY);
 
   for (let rowIndex = firstRow; rowIndex <= lastRow; rowIndex++) {
     const item = rowAt(rowIndex);
@@ -360,7 +397,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
       isDeleted: item.isDeleted,
       isSelected: rowSelectionVisual,
     });
-    const rowBorderY = crispCanvasLine(y + CANVAS_DATA_GRID_ROW_HEIGHT - 1, dpr);
+    const rowBorderY = crispCanvasLine(y + CANVAS_DATA_GRID_ROW_HEIGHT - 1, scaleY);
     ctx.globalAlpha = item.isDeleted ? 0.7 : 1;
     ctx.fillStyle = rowFill;
     ctx.fillRect(0, y, width, CANVAS_DATA_GRID_ROW_HEIGHT);
@@ -390,7 +427,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
     ctx.fillStyle = rowNumberText;
     ctx.font = item.status === "new" || item.status === "edited" || item.status === "draft" ? semiboldFont : normalFont;
     ctx.textAlign = "center";
-    const textY = alignCanvasPixel(y + rowTextOffsetY, dpr);
+    const textY = alignCanvasPixel(y + rowTextOffsetY, scaleY);
     ctx.save();
     ctx.beginPath();
     ctx.rect(0, y, rowNumberWidth, CANVAS_DATA_GRID_ROW_HEIGHT);
@@ -472,24 +509,24 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
       ctx.font = value === null ? italicFont : tabularFont;
       setCanvasNumericVariant(ctx, value === null ? "normal" : "tabular-nums");
       const reservedWidth = rightAlignedActionCell?.rowIndex === item.displayIndex && rightAlignedActionCell.visibleColIdx === visibleColIdx ? rightAlignedActionCell.reservedWidth : 0;
-      const { textAnchorX, maxWidth: cellMaxWidth } = resolveCanvasCellTextLayout({ drawX, colWidth, dpr, isRightAlign, reservedWidth });
+      const { textAnchorX, maxWidth: cellMaxWidth } = resolveCanvasCellTextLayout({ drawX, colWidth, dpr: scaleX, isRightAlign, reservedWidth });
       if (isBooleanCell && value !== null && !isEditingThisCell) {
-        drawBooleanCheckbox(ctx, { drawX, y, colWidth, dpr, theme, checked: normalizeBooleanCellValue(value) === true });
+        drawBooleanCheckbox(ctx, { drawX, y, colWidth, scaleX, scaleY, theme, checked: normalizeBooleanCellValue(value) === true });
         if (item.isDeleted) {
-          const boxX = alignCanvasPixel(drawX + (colWidth - BOOLEAN_CHECKBOX_SIZE) / 2, dpr);
-          const strikeY = alignCanvasPixel(y + CANVAS_DATA_GRID_ROW_HEIGHT / 2, dpr);
+          const boxX = alignCanvasPixel(drawX + (colWidth - BOOLEAN_CHECKBOX_SIZE) / 2, scaleX);
+          const strikeY = alignCanvasPixel(y + CANVAS_DATA_GRID_ROW_HEIGHT / 2, scaleY);
           ctx.strokeStyle = theme.foreground;
           ctx.lineWidth = 1;
           ctx.beginPath();
           ctx.moveTo(boxX - 1, strikeY);
-          ctx.lineTo(alignCanvasPixel(boxX + BOOLEAN_CHECKBOX_SIZE + 1, dpr), strikeY);
+          ctx.lineTo(alignCanvasPixel(boxX + BOOLEAN_CHECKBOX_SIZE + 1, scaleX), strikeY);
           ctx.stroke();
         }
       } else {
         const rawDisplayText = item.isDraft && value === null ? (draftCellPlaceholder ?? "") : formatCell(value, actualColIdx);
         const displayText = isEditingThisCell ? "" : firstLineCellDisplayValue(rawDisplayText);
         const text = isEditingThisCell ? displayText : fitCanvasText(ctx, displayText, cellMaxWidth, isBooleanNullCell ? "left" : isRightAlign ? "right" : "left");
-        const anchorX = isBooleanNullCell ? alignCanvasPixel(drawX + colWidth / 2, dpr) : textAnchorX;
+        const anchorX = isBooleanNullCell ? alignCanvasPixel(drawX + colWidth / 2, scaleX) : textAnchorX;
         ctx.fillText(text, anchorX, textY);
         if (item.isDeleted && text) {
           const textWidth = ctx.measureText(text).width;
@@ -497,7 +534,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
           ctx.strokeStyle = theme.foreground;
           ctx.beginPath();
           ctx.moveTo(lineStartX, textY);
-          ctx.lineTo(alignCanvasPixel(lineStartX + textWidth, dpr), textY);
+          ctx.lineTo(alignCanvasPixel(lineStartX + textWidth, scaleX), textY);
           ctx.stroke();
         }
       }
@@ -507,7 +544,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
 
       ctx.strokeStyle = theme.border;
       ctx.beginPath();
-      const columnBorderX = crispCanvasLine(drawX + colWidth - 1, dpr);
+      const columnBorderX = crispCanvasLine(drawX + colWidth - 1, scaleX);
       ctx.moveTo(columnBorderX, y);
       ctx.lineTo(columnBorderX, y + CANVAS_DATA_GRID_ROW_HEIGHT);
       ctx.stroke();


### PR DESCRIPTION
## 变更说明

修复 Windows 125% 等分数显示缩放下，Canvas 数据表文字因 backing store 与 WebView2 实际物理像素尺寸不一致而被重采样、显示模糊的问题。

**根因**：Canvas 原先使用 CSS 尺寸乘以名义 DPR 计算 backing store，并统一以该 DPR 绘制。在分数缩放下，推算并取整后的尺寸不一定等于 Chromium 分配给 Canvas 的真实物理像素框，最终显示时会发生额外缩放，文字清晰度明显下降。

**改动**：
- 使用 ResizeObserver 的 device-pixel-content-box 观察 Canvas，读取 Chromium 报告的精确物理像素尺寸；
- 按真实 pixelWidth / pixelHeight 设置 backing store，并分别使用 X/Y 实际比例绘制和对齐像素；
- 测量不可用或 CSS 视口已经变化时，回退到原有 DPR 计算，兼容不支持该能力的环境；
- 补充物理像素 ResizeObserver、精确 backing store 尺寸及过期测量回退测试。

**行为说明**：
- Windows 分数显示缩放下，Canvas 表格不再因 backing store mismatch 被整体重采样；
- DOM 表格及其他 UI 的渲染路径不变；
- 整数缩放和不支持 device-pixel-content-box 的环境继续使用原有逻辑。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 只调整 Canvas 内部 backing store 与绘制缩放，不改变表格布局、主题或交互。修复后已使用本地 Windows 打包版本，在系统缩放 125%、WebView2 DPR 1.25、DBX UI 缩放 100%、Canvas 表格模式下人工验证，表格文字恢复清晰。

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

修复前截图（来自 #3857）：

<img width="1585" height="733" alt="Canvas table text before the fix" src="https://github.com/user-attachments/assets/234df23d-7e5e-411d-baa8-a8fa40e44bf1" />

## 验证

- [x] `pnpm check` 通过（format / lint / typecheck / test 全部通过；756 个测试文件、6705 个用例通过）
- [ ] `make cargo-check-fast` 通过（本 PR 未修改 Rust 代码，未执行）
- [x] 相关测试通过（2 个 Canvas 相关测试文件、17 个用例通过）
- [x] Windows 本地打包完成（生成 dbx.exe、NSIS 和 MSI；无发布私钥，因此本地产物未签名）

手动验证步骤：
1. Windows 显示缩放设置为 125%；
2. DBX UI 缩放设置为 100%，数据表格渲染模式选择 Canvas；
3. 打开数据表并观察中文、英文和数字文本；
4. 修复后文字边缘清晰，不再出现 backing store mismatch 导致的整体模糊。

## 关联 Issue

Fixes #3857