### PR TITLE
fix(tabs): 恢复关闭右侧标签页

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -195,8 +195,12 @@ function hasTabsToRight(tab: QueryTab) {
 }
 
 function closeTabsToRightFromTab(tab: QueryTab) {
-  queryStore.closeRightTabs(tab.id);
-  if (!tab.pinned) closeSpecialRegularSurfaces();
+  const shouldActivateTarget = !tab.pinned && (!!props.settingsPageActive || !!props.driverStoreActive);
+  queryStore.closeRightTabs(tab.id, () => {
+    if (tab.pinned) return;
+    closeSpecialRegularSurfaces();
+    if (shouldActivateTarget) activateTab(tab.id);
+  });
 }
 
 function hasSpecialRegularSurfaceToRight(surface: SpecialRegularSurface) {
@@ -204,7 +208,10 @@ function hasSpecialRegularSurfaceToRight(surface: SpecialRegularSurface) {
 }
 
 function closeSpecialRegularSurfacesToRight(surface: SpecialRegularSurface) {
-  if (surface === "settings" && props.driverStoreOpen) emit("close-driver-store");
+  if (surface !== "settings" || !props.driverStoreOpen) return;
+  const shouldActivateSettings = !!props.driverStoreActive;
+  emit("close-driver-store");
+  if (shouldActivateSettings) emit("activate-settings-page");
 }
 
 function closeAllRegularSurfaces() {

--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -184,6 +184,29 @@ function closeOtherRegularTabsFromTab(tab: QueryTab) {
   closeSpecialRegularSurfaces();
 }
 
+function tabsToRightInGroup(tab: QueryTab) {
+  const groupedTabs = tab.pinned ? fixedTabs.value : regularTabs.value;
+  const targetIndex = groupedTabs.findIndex((item) => item.id === tab.id);
+  return targetIndex < 0 ? [] : groupedTabs.slice(targetIndex + 1);
+}
+
+function hasTabsToRight(tab: QueryTab) {
+  return tabsToRightInGroup(tab).length > 0 || (!tab.pinned && (!!props.settingsPageOpen || !!props.driverStoreOpen));
+}
+
+function closeTabsToRightFromTab(tab: QueryTab) {
+  queryStore.closeRightTabs(tab.id);
+  if (!tab.pinned) closeSpecialRegularSurfaces();
+}
+
+function hasSpecialRegularSurfaceToRight(surface: SpecialRegularSurface) {
+  return surface === "settings" && !!props.driverStoreOpen;
+}
+
+function closeSpecialRegularSurfacesToRight(surface: SpecialRegularSurface) {
+  if (surface === "settings" && props.driverStoreOpen) emit("close-driver-store");
+}
+
 function closeAllRegularSurfaces() {
   queryStore.closeRegularTabs();
   closeSpecialRegularSurfaces();
@@ -233,6 +256,12 @@ function getSpecialRegularTabMenuItems(surface: SpecialRegularSurface): ContextM
       disabled: closeOtherDisabled,
       icon: X,
       shortcut: settingsStore.editorSettings.shortcuts.closeOtherTabs,
+    },
+    {
+      label: t("contextMenu.closeRightTabs"),
+      action: () => closeSpecialRegularSurfacesToRight(surface),
+      disabled: !hasSpecialRegularSurfaceToRight(surface),
+      icon: X,
     },
     {
       label: closeAllLabel,
@@ -296,6 +325,12 @@ function getTabMenuItems(tab: QueryTab): ContextMenuItem[] {
       disabled: closeOtherDisabled,
       icon: X,
       shortcut: settingsStore.editorSettings.shortcuts.closeOtherTabs,
+    },
+    {
+      label: t("contextMenu.closeRightTabs"),
+      action: () => closeTabsToRightFromTab(tab),
+      disabled: !hasTabsToRight(tab),
+      icon: X,
     },
     {
       label: closeAllLabel,

--- a/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
@@ -53,4 +53,14 @@ describe("AppTabBar right-side close action", () => {
       expect(position).toBeLessThan(closeAllPositions[index]);
     });
   });
+
+  it("waits for query tab confirmation before closing special surfaces", () => {
+    expect(tabBarSource).toMatch(/queryStore\.closeRightTabs\(tab\.id, \(\) => \{[\s\S]*closeSpecialRegularSurfaces\(\);/);
+    expect(tabBarSource).toContain("if (shouldActivateTarget) activateTab(tab.id)");
+  });
+
+  it("reactivates settings after closing an active driver store to its right", () => {
+    expect(tabBarSource).toContain("const shouldActivateSettings = !!props.driverStoreActive");
+    expect(tabBarSource).toMatch(/emit\("close-driver-store"\);\s*if \(shouldActivateSettings\) emit\("activate-settings-page"\);/);
+  });
 });

--- a/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
@@ -35,3 +35,22 @@ describe("AppTabBar objects presentation", () => {
     expect(tabBarSource.match(/tabMenuIcon\(tab\).*tabIconClass\(tab\)/g)).toHaveLength(2);
   });
 });
+
+describe("AppTabBar right-side close action", () => {
+  it("places the action after close-other and disables it when the target has no tabs to its right", () => {
+    expect(tabBarSource).toContain('label: t("contextMenu.closeRightTabs")');
+    expect(tabBarSource).toContain("action: () => closeTabsToRightFromTab(tab)");
+    expect(tabBarSource).toContain("disabled: !hasTabsToRight(tab)");
+
+    const closeOtherPositions = [...tabBarSource.matchAll(/label: closeOtherLabel,/g)].map((match) => match.index);
+    const closeRightPositions = [...tabBarSource.matchAll(/label: t\("contextMenu\.closeRightTabs"\),/g)].map((match) => match.index);
+    const closeAllPositions = [...tabBarSource.matchAll(/label: closeAllLabel,/g)].map((match) => match.index);
+    expect(closeOtherPositions).toHaveLength(2);
+    expect(closeRightPositions).toHaveLength(2);
+    expect(closeAllPositions).toHaveLength(2);
+    closeRightPositions.forEach((position, index) => {
+      expect(position).toBeGreaterThan(closeOtherPositions[index]);
+      expect(position).toBeLessThan(closeAllPositions[index]);
+    });
+  });
+});

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2101,6 +2101,7 @@ export default {
     fullTabTitle: "Show Full Tab Titles",
     closeTab: "Close Tab",
     closeFixedTab: "Close Fixed Tab",
+    closeRightTabs: "Close Tabs to the Right",
     closeOtherTabs: "Close Other Tabs",
     closeOtherRegularTabs: "Close Other Regular Tabs",
     closeOtherFixedTabs: "Close Other Fixed Tabs",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2283,6 +2283,7 @@ export default withEnglishFallback({
     createFunction: "Nueva función",
     createTrigger: "Nuevo disparador",
     changeOpenMode: "Modificar modo de apertura",
+    closeRightTabs: "Cerrar pestañas a la derecha",
   },
   visibleDatabases: {
     title: "Bases de datos visibles",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2281,6 +2281,7 @@ export default withEnglishFallback({
     createFunction: "Nuova funzione",
     createTrigger: "Nuovo trigger",
     changeOpenMode: "Modifica modalità apertura",
+    closeRightTabs: "Chiudi le schede a destra",
   },
   visibleDatabases: {
     title: "Database Visibili",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2308,6 +2308,7 @@ export default withEnglishFallback({
     createFunction: "新規関数",
     createTrigger: "新規トリガー",
     changeOpenMode: "開き方を変更",
+    closeRightTabs: "右側のタブを閉じる",
   },
   visibleDatabases: {
     title: "表示するデータベース",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2283,6 +2283,7 @@ export default withEnglishFallback({
     createFunction: "Nova função",
     createTrigger: "Novo gatilho",
     changeOpenMode: "Alterar modo de abertura",
+    closeRightTabs: "Fechar abas à direita",
   },
   visibleDatabases: {
     title: "Bancos de dados visíveis",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2102,6 +2102,7 @@ export default withEnglishFallback({
     fullTabTitle: "完整标签标题",
     closeTab: "关闭标签页",
     closeFixedTab: "关闭固定标签页",
+    closeRightTabs: "关闭右侧标签页",
     closeOtherTabs: "关闭其他标签页",
     closeOtherRegularTabs: "关闭其他普通标签页",
     closeOtherFixedTabs: "关闭其他固定标签页",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2282,6 +2282,7 @@ export default withEnglishFallback({
     createFunction: "新增函數",
     createTrigger: "新增觸發器",
     changeOpenMode: "修改開啟方式",
+    closeRightTabs: "關閉右側標籤頁",
   },
   visibleDatabases: {
     title: "顯示資料庫",

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2054,6 +2054,19 @@ export const useQueryStore = defineStore("query", () => {
     );
   }
 
+  function closeRightTabs(id: string) {
+    const target = tabs.value.find((tab) => tab.id === id);
+    if (!target) return;
+
+    const groupedTabs = tabs.value.filter((tab) => Boolean(tab.pinned) === Boolean(target.pinned));
+    const targetIndex = groupedTabs.findIndex((tab) => tab.id === id);
+    const ids = groupedTabs.slice(targetIndex + 1).map((tab) => tab.id);
+    if (ids.length === 0) return;
+
+    const finalActiveTabId = activeTabId.value && !ids.includes(activeTabId.value) ? activeTabId.value : id;
+    beginBatchClose(ids, finalActiveTabId);
+  }
+
   function finalActiveTabAfterClosing(ids: string[]) {
     const closingIds = new Set(ids);
     const activeTab = activeTabId.value ? tabs.value.find((tab) => tab.id === activeTabId.value) : undefined;
@@ -5275,6 +5288,7 @@ export const useQueryStore = defineStore("query", () => {
     discardTabChanges,
     requestAppCloseConfirmation,
     closeOtherTabs,
+    closeRightTabs,
     closeOtherRegularTabs,
     closeRegularTabs,
     closeOtherFixedTabs,

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -649,6 +649,7 @@ export const useQueryStore = defineStore("query", () => {
   const pendingCloseTabId = ref<string | null>(null);
   const pendingBatchCloseTabIds = ref<string[] | null>(null);
   const pendingBatchCloseFinalActiveTabId = ref<string | null | undefined>(undefined);
+  let pendingBatchCloseComplete: (() => void) | null = null;
   const isConfirmingAppClose = ref(false);
   const closeConfirmContext = ref<CloseConfirmContext>("tab");
   const tableStructureRefreshVersions = ref<Record<string, number>>({});
@@ -1876,11 +1877,14 @@ export const useQueryStore = defineStore("query", () => {
 
   function finishPendingBatchClose() {
     const finalActiveTabId = pendingBatchCloseFinalActiveTabId.value;
+    const onComplete = pendingBatchCloseComplete;
     pendingBatchCloseTabIds.value = null;
     pendingBatchCloseFinalActiveTabId.value = undefined;
+    pendingBatchCloseComplete = null;
     if (finalActiveTabId !== undefined) {
       activeTabId.value = finalActiveTabId && tabs.value.some((tab) => tab.id === finalActiveTabId) ? finalActiveTabId : null;
     }
+    return onComplete;
   }
 
   function continuePendingBatchClose() {
@@ -1890,7 +1894,7 @@ export const useQueryStore = defineStore("query", () => {
     const remainingIds = pendingIds.filter((id) => tabs.value.some((tab) => tab.id === id));
     pendingBatchCloseTabIds.value = remainingIds;
     if (remainingIds.length === 0) {
-      finishPendingBatchClose();
+      finishPendingBatchClose()?.();
       return;
     }
 
@@ -1901,15 +1905,20 @@ export const useQueryStore = defineStore("query", () => {
       return;
     }
 
-    finishPendingBatchClose();
+    const onComplete = finishPendingBatchClose();
     for (const id of remainingIds) closeTab(id, { force: true });
+    onComplete?.();
   }
 
-  function beginBatchClose(ids: string[], finalActiveTabId?: string | null) {
+  function beginBatchClose(ids: string[], finalActiveTabId?: string | null, onComplete?: () => void) {
     const uniqueIds = [...new Set(ids)].filter((id) => tabs.value.some((tab) => tab.id === id));
-    if (uniqueIds.length === 0) return;
+    if (uniqueIds.length === 0) {
+      onComplete?.();
+      return;
+    }
     pendingBatchCloseTabIds.value = uniqueIds;
     pendingBatchCloseFinalActiveTabId.value = finalActiveTabId;
+    pendingBatchCloseComplete = onComplete ?? null;
     continuePendingBatchClose();
   }
 
@@ -1971,12 +1980,14 @@ export const useQueryStore = defineStore("query", () => {
     const pendingId = pendingCloseTabId.value;
     const batchIds = pendingBatchCloseTabIds.value?.filter((id) => tabs.value.some((tab) => tab.id === id)) ?? null;
     const finalActiveTabId = pendingBatchCloseFinalActiveTabId.value;
+    const onBatchComplete = pendingBatchCloseComplete;
     const confirmingAppClose = isConfirmingAppClose.value;
 
     pendingCloseTabId.value = null;
     showCloseConfirm.value = false;
     pendingBatchCloseTabIds.value = null;
     pendingBatchCloseFinalActiveTabId.value = undefined;
+    pendingBatchCloseComplete = null;
     isConfirmingAppClose.value = false;
     closeConfirmContext.value = "tab";
 
@@ -1988,6 +1999,7 @@ export const useQueryStore = defineStore("query", () => {
     if (finalActiveTabId !== undefined) {
       activeTabId.value = finalActiveTabId && tabs.value.some((tab) => tab.id === finalActiveTabId) ? finalActiveTabId : null;
     }
+    if (batchIds) onBatchComplete?.();
   }
 
   function cancelClosePendingTab() {
@@ -1995,6 +2007,7 @@ export const useQueryStore = defineStore("query", () => {
     showCloseConfirm.value = false;
     pendingBatchCloseTabIds.value = null;
     pendingBatchCloseFinalActiveTabId.value = undefined;
+    pendingBatchCloseComplete = null;
     isConfirmingAppClose.value = false;
     closeConfirmContext.value = "tab";
   }
@@ -2027,12 +2040,14 @@ export const useQueryStore = defineStore("query", () => {
     const pendingId = pendingCloseTabId.value;
     const batchIds = pendingBatchCloseTabIds.value?.filter((id) => tabs.value.some((tab) => tab.id === id)) ?? null;
     const finalActiveTabId = pendingBatchCloseFinalActiveTabId.value;
+    const onBatchComplete = pendingBatchCloseComplete;
     const confirmingAppClose = isConfirmingAppClose.value;
 
     pendingCloseTabId.value = null;
     showCloseConfirm.value = false;
     pendingBatchCloseTabIds.value = null;
     pendingBatchCloseFinalActiveTabId.value = undefined;
+    pendingBatchCloseComplete = null;
     isConfirmingAppClose.value = false;
     closeConfirmContext.value = "tab";
 
@@ -2043,6 +2058,7 @@ export const useQueryStore = defineStore("query", () => {
     if (finalActiveTabId !== undefined) {
       activeTabId.value = finalActiveTabId && tabs.value.some((tab) => tab.id === finalActiveTabId) ? finalActiveTabId : null;
     }
+    if (batchIds) onBatchComplete?.();
     return "tabs" as const;
   }
 
@@ -2054,17 +2070,20 @@ export const useQueryStore = defineStore("query", () => {
     );
   }
 
-  function closeRightTabs(id: string) {
+  function closeRightTabs(id: string, onComplete?: () => void) {
     const target = tabs.value.find((tab) => tab.id === id);
     if (!target) return;
 
     const groupedTabs = tabs.value.filter((tab) => Boolean(tab.pinned) === Boolean(target.pinned));
     const targetIndex = groupedTabs.findIndex((tab) => tab.id === id);
     const ids = groupedTabs.slice(targetIndex + 1).map((tab) => tab.id);
-    if (ids.length === 0) return;
+    if (ids.length === 0) {
+      onComplete?.();
+      return;
+    }
 
     const finalActiveTabId = activeTabId.value && !ids.includes(activeTabId.value) ? activeTabId.value : id;
-    beginBatchClose(ids, finalActiveTabId);
+    beginBatchClose(ids, finalActiveTabId, onComplete);
   }
 
   function finalActiveTabAfterClosing(ids: string[]) {

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -768,13 +768,17 @@ test("close right tabs only closes tabs to the right in the same group", () => {
     false,
   );
 
-  store.closeRightTabs(targetId);
+  let completions = 0;
+  store.closeRightTabs(targetId, () => {
+    completions += 1;
+  });
 
   assert.deepEqual(
     store.tabs.map((tab) => tab.id),
     [fixedId, targetId],
   );
   assert.equal(store.activeTabId, targetId);
+  assert.equal(completions, 1);
 });
 
 test("close right fixed tabs keeps regular tabs and a retained active tab", () => {
@@ -821,6 +825,38 @@ test("close right tabs pauses before closing an unsaved query", () => {
     [targetId],
   );
   assert.equal(store.activeTabId, targetId);
+});
+
+test("close right tabs only runs completion after the pending batch succeeds", () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+  const targetId = store.createTab("conn-1", "db", "target");
+  const dirtyId = store.createTab("conn-1", "db", "dirty");
+  store.updateSql(dirtyId, "select 1;");
+  let completions = 0;
+
+  store.closeRightTabs(targetId, () => {
+    completions += 1;
+  });
+  assert.equal(completions, 0);
+
+  store.cancelClosePendingTab();
+  assert.equal(completions, 0);
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [targetId, dirtyId],
+  );
+
+  store.closeRightTabs(targetId, () => {
+    completions += 1;
+  });
+  store.forceClosePendingTab();
+
+  assert.equal(completions, 1);
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [targetId],
+  );
 });
 
 test("close other tabs pauses on restored unsaved query tabs", async () => {

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -746,6 +746,83 @@ test("close other fixed tabs does not close regular tabs", () => {
   );
 });
 
+test("close right tabs only closes tabs to the right in the same group", () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+  const fixedId = store.createTab("conn-1", "db", "fixed");
+  const targetId = store.createTab("conn-1", "db", "target");
+  const rightA = store.createTab("conn-1", "db", "right a");
+  const rightB = store.createTab("conn-1", "db", "right b");
+  store.togglePinnedTab(fixedId);
+  store.activeTabId = rightB;
+
+  store.closeRightTabs(targetId);
+
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [fixedId, targetId],
+  );
+  assert.equal(store.activeTabId, targetId);
+  assert.equal(
+    store.tabs.some((tab) => tab.id === rightA || tab.id === rightB),
+    false,
+  );
+
+  store.closeRightTabs(targetId);
+
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [fixedId, targetId],
+  );
+  assert.equal(store.activeTabId, targetId);
+});
+
+test("close right fixed tabs keeps regular tabs and a retained active tab", () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+  const targetId = store.createTab("conn-1", "db", "fixed target");
+  const rightFixedId = store.createTab("conn-1", "db", "fixed right");
+  const regularId = store.createTab("conn-1", "db", "regular");
+  store.togglePinnedTab(targetId);
+  store.togglePinnedTab(rightFixedId);
+  store.activeTabId = regularId;
+
+  store.closeRightTabs(targetId);
+
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [targetId, regularId],
+  );
+  assert.equal(store.activeTabId, regularId);
+});
+
+test("close right tabs pauses before closing an unsaved query", () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+  const targetId = store.createTab("conn-1", "db", "target");
+  const dirtyId = store.createTab("conn-1", "db", "dirty");
+  store.updateSql(dirtyId, "select 1;");
+
+  store.closeRightTabs(targetId);
+
+  assert.equal(store.showCloseConfirm, true);
+  assert.equal(store.pendingCloseTabId, dirtyId);
+  assert.equal(store.closeConfirmContext, "batch");
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [targetId, dirtyId],
+  );
+
+  store.forceClosePendingTab();
+
+  assert.equal(store.showCloseConfirm, false);
+  assert.deepEqual(
+    store.tabs.map((tab) => tab.id),
+    [targetId],
+  );
+  assert.equal(store.activeTabId, targetId);
+});
+
 test("close other tabs pauses on restored unsaved query tabs", async () => {
   const restoreStorage = installMemoryStorage();
   try {


### PR DESCRIPTION
## 关联 Issue

Closes #5309

## 问题背景

#169 曾提出顶部标签页批量关闭能力，#142 也曾实现“关闭右侧标签页”。但当前 `main` 中已经没有对应的菜单入口和 Store 行为，右键菜单只保留关闭当前、关闭其他和关闭全部，导致该功能回归。

## 变更内容

- 在顶部标签页右键菜单中恢复“关闭右侧标签页”，并放在“关闭其他标签页”下方。
- 以被右键标签为基准，仅关闭同一固定/普通分组内位于其右侧的标签。
- 右侧没有可关闭标签时禁用菜单项。
- 复用现有批量关闭管线，保留未保存内容确认、执行取消和资源清理行为。
- 保持设置页、驱动商店等普通页签现有的右侧关闭语义。
- 补充中英文文案及菜单顺序、分组边界、激活标签和未保存确认测试。

## 影响范围

改动仅涉及顶部标签页菜单、查询标签 Store、文案和对应测试，不涉及数据库执行逻辑。

本 PR 不包含：

- “关闭左侧标签页”
- 移除“关闭全部标签页”
- 菜单行高、悬停或选中背景色调整

## 验证

- [x] `pnpm exec vitest run packages/app-tests/queryStore.test.ts apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts`（158 项通过）
- [x] `pnpm typecheck`
- [x] 本地手工验证菜单顺序、关闭范围和末尾标签禁用状态

