### PR TITLE
fix(grid): 修正复制行与刷新后的右键菜单状态

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5532,6 +5532,7 @@ const {
   copyText,
   copyCell,
   copyRow,
+  copyRowCount,
   canCopyRow,
   copyAll,
   copyWithExtractor,
@@ -7112,6 +7113,7 @@ watch(
     }
     clearCellSelection();
     clearRowSelection();
+    invalidateSyntheticContextSelection();
     closeCellDetails();
     closeDetailDialogs();
     if (shouldPreserveTranspose) {
@@ -8298,7 +8300,7 @@ function copySubmenu(): ContextMenuItem {
     items.push({ label: t("grid.copyCell"), action: copyCell });
   }
   items.push({
-    label: isMultiRow.value ? t("grid.copyRows", { count: multiRowCount.value }) : t("grid.copyRow"),
+    label: copyRowCount.value > 1 ? t("grid.copyRows", { count: copyRowCount.value }) : t("grid.copyRow"),
     action: copyRow,
     disabled: () => !canCopyRow.value,
   });

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5532,6 +5532,7 @@ const {
   copyText,
   copyCell,
   copyRow,
+  canCopyRow,
   copyAll,
   copyWithExtractor,
   previewWithExtractor,
@@ -8296,7 +8297,11 @@ function copySubmenu(): ContextMenuItem {
   if (contextColumn.value) {
     items.push({ label: t("grid.copyCell"), action: copyCell });
   }
-  items.push({ label: isMultiRow.value ? t("grid.copyRows", { count: multiRowCount.value }) : t("grid.copyRow"), action: copyRow });
+  items.push({
+    label: isMultiRow.value ? t("grid.copyRows", { count: multiRowCount.value }) : t("grid.copyRow"),
+    action: copyRow,
+    disabled: () => !canCopyRow.value,
+  });
   items.push({ label: "", separator: true });
   items.push(...buildExtractorContextItems());
   items.push({ label: "", separator: true });

--- a/apps/desktop/src/components/ui/CustomContextMenu.vue
+++ b/apps/desktop/src/components/ui/CustomContextMenu.vue
@@ -86,7 +86,8 @@ function onScroll(e: Event) {
 }
 
 function onKeydown(e: KeyboardEvent) {
-  if (e.key === "Escape") close();
+  if (["Alt", "Control", "Meta", "Shift"].includes(e.key)) return;
+  close();
 }
 
 function onResize() {
@@ -97,12 +98,12 @@ watch(show, (val) => {
   contextMenuRegistration?.setOpen(val);
   if (val) {
     document.addEventListener("pointerdown", onPointerDownOutside, true);
-    document.addEventListener("keydown", onKeydown);
+    document.addEventListener("keydown", onKeydown, true);
     document.addEventListener("scroll", onScroll, true);
     window.addEventListener("resize", onResize);
   } else {
     document.removeEventListener("pointerdown", onPointerDownOutside, true);
-    document.removeEventListener("keydown", onKeydown);
+    document.removeEventListener("keydown", onKeydown, true);
     document.removeEventListener("scroll", onScroll, true);
     window.removeEventListener("resize", onResize);
   }

--- a/apps/desktop/src/components/ui/CustomContextMenu.vue
+++ b/apps/desktop/src/components/ui/CustomContextMenu.vue
@@ -264,7 +264,7 @@ onBeforeUnmount(() => {
   contextMenuRegistration?.dispose();
   contextMenuRegistration = null;
   document.removeEventListener("pointerdown", onPointerDownOutside, true);
-  document.removeEventListener("keydown", onKeydown);
+  document.removeEventListener("keydown", onKeydown, true);
   document.removeEventListener("scroll", onScroll, true);
   window.removeEventListener("resize", onResize);
 });

--- a/apps/desktop/src/components/ui/__tests__/CustomContextMenu.spec.ts
+++ b/apps/desktop/src/components/ui/__tests__/CustomContextMenu.spec.ts
@@ -97,6 +97,41 @@ describe("CustomContextMenu lifecycle", () => {
     app.unmount();
   });
 
+  it("closes the menu when an application shortcut is pressed", async () => {
+    const root = defineComponent({
+      setup() {
+        return () =>
+          h(
+            CustomContextMenu,
+            { items: [{ label: "Refresh row" }] },
+            {
+              default: ({ onContextMenu }: { onContextMenu: (event: MouseEvent) => void }) => h("div", { id: "context-target", onContextmenu: onContextMenu, onKeydown: (event: KeyboardEvent) => event.stopPropagation() }, "Target"),
+            },
+          );
+      },
+    });
+    const container = document.createElement("div");
+    mountedContainers.push(container);
+    document.body.append(container);
+    const app = createApp(root);
+    app.mount(container);
+
+    const target = container.querySelector("#context-target");
+    target?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+    await nextTick();
+    expect(document.body.textContent).toContain("Refresh row");
+
+    target?.dispatchEvent(new KeyboardEvent("keydown", { key: "Meta", metaKey: true, bubbles: true }));
+    await nextTick();
+    expect(document.body.textContent).toContain("Refresh row");
+
+    target?.dispatchEvent(new KeyboardEvent("keydown", { key: "r", metaKey: true, bubbles: true }));
+    await nextTick();
+    expect(document.body.textContent).not.toContain("Refresh row");
+
+    app.unmount();
+  });
+
   it("renders checked state after the menu label", async () => {
     const root = defineComponent({
       setup() {

--- a/apps/desktop/src/components/ui/__tests__/CustomContextMenu.spec.ts
+++ b/apps/desktop/src/components/ui/__tests__/CustomContextMenu.spec.ts
@@ -20,6 +20,38 @@ afterEach(() => {
 });
 
 describe("CustomContextMenu lifecycle", () => {
+  it("removes the capture keydown listener when unmounted while open", async () => {
+    const documentAdd = vi.spyOn(document, "addEventListener");
+    const documentRemove = vi.spyOn(document, "removeEventListener");
+    const root = defineComponent({
+      setup() {
+        return () =>
+          h(
+            CustomContextMenu,
+            { items: [{ label: "Inspect" }] },
+            {
+              default: ({ onContextMenu }: { onContextMenu: (event: MouseEvent) => void }) => h("div", { id: "context-target", onContextmenu: onContextMenu }, "Target"),
+            },
+          );
+      },
+    });
+    const container = document.createElement("div");
+    mountedContainers.push(container);
+    document.body.append(container);
+    const app = createApp(root);
+    app.mount(container);
+
+    container.querySelector("#context-target")?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+    await nextTick();
+    const keydownListener = callsFor(documentAdd, "keydown").at(-1)?.[1];
+    expect(keydownListener).toBeTruthy();
+
+    app.unmount();
+    await nextTick();
+
+    expect(documentRemove.mock.calls).toContainEqual(["keydown", keydownListener, true]);
+  });
+
   it("uses one shared listener set across repeated bulk mount cycles", async () => {
     const documentAdd = vi.spyOn(document, "addEventListener");
     const documentRemove = vi.spyOn(document, "removeEventListener");

--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -111,9 +111,10 @@ function createExportState(
   hasColumnSelection = false,
   visibleColumnIndexes?: number[],
   isSyntheticContext = false,
+  contextRowId?: number | null,
 ) {
   const rows = (rowDataList ?? [rowData ?? columns.map((column, index) => (column === "id" ? 1 : `value-${index}`))]).map((data, index) => ({ ...row(data), id: index + 1 }));
-  const item = rows[0]!;
+  const resolvedContextRowId = contextRowId === undefined ? (rows[0]?.id ?? null) : contextRowId;
   const selectedRowIds = ref(new Set(selectedRowIdValues));
   const options: UseDataGridExportOptions = {
     columns: computed(() => columns),
@@ -136,7 +137,7 @@ function createExportState(
     selectedCells: computed(() => selectedCellMatrix ?? selectedCellsOverride ?? { columns: [], rows: [] }),
     selectedCellMatrix: computed(() => selectedCellMatrix ?? null),
     selectedRange: computed(() => null),
-    contextCell: ref({ rowId: item.id, rowIndex: 0, col: isSyntheticContext ? 0 : -1 }),
+    contextCell: ref(resolvedContextRowId === null ? null : { rowId: resolvedContextRowId, rowIndex: 0, col: isSyntheticContext ? 0 : -1 }),
     contextSelectionIsSynthetic: ref(isSyntheticContext),
     getRowItem: (rowId) => rows.find((candidate) => candidate.id === rowId),
     selectedRowIds,
@@ -158,6 +159,24 @@ describe("useDataGridExport prepared row statements", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearDataGridClipboardCopy();
+  });
+
+  it("disables row copy when the result has no rows", () => {
+    const state = createExportState(editableTable, ["id", "name"], undefined, undefined, undefined, [], [], DEFAULT_DATA_GRID_EXTRACTOR_OPTIONS, false, undefined, false, null);
+
+    expect(state.canCopyRow.value).toBe(false);
+  });
+
+  it("disables row copy when rows exist but none is selected or targeted", () => {
+    const state = createExportState(editableTable, ["id", "name"], undefined, [1, "Ada"], undefined, undefined, [], DEFAULT_DATA_GRID_EXTRACTOR_OPTIONS, false, undefined, false, null);
+
+    expect(state.canCopyRow.value).toBe(false);
+  });
+
+  it("enables row copy for a valid context row without a prior selection", () => {
+    const state = createExportState(editableTable, ["id", "name"], undefined, [1, "Ada"], undefined, undefined, [], DEFAULT_DATA_GRID_EXTRACTOR_OPTIONS, false, undefined, false, 1);
+
+    expect(state.canCopyRow.value).toBe(true);
   });
 
   it("builds SQL UPDATE from only selected writable columns while retaining a hidden primary key", async () => {

--- a/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.spec.ts
@@ -179,6 +179,24 @@ describe("useDataGridExport prepared row statements", () => {
     expect(state.canCopyRow.value).toBe(true);
   });
 
+  it("counts only visible non-draft rows selected for copying", () => {
+    const first = { ...row([1, "Ada"]), sourceIndex: 0 };
+    const draft = { ...row([2, "Draft"]), id: 2, sourceIndex: 1, isDraft: true };
+    const state = createMongoExportState({
+      columns: ["id", "name"],
+      item: first,
+      items: [first, draft],
+      mongoDocuments: [
+        { id: 1, name: "Ada" },
+        { id: 2, name: "Draft" },
+      ],
+      selectedRowIds: new Set([1, 2, 999]),
+    });
+
+    expect(state.copyRowCount.value).toBe(1);
+    expect(state.canCopyRow.value).toBe(true);
+  });
+
   it("builds SQL UPDATE from only selected writable columns while retaining a hidden primary key", async () => {
     const item = row([7, "Ada", true]);
     const matrix: CellSelectionMatrix = {

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -363,6 +363,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     return item && !item.isDraft ? [item] : [];
   }
 
+  const canCopyRow = computed(() => targetedRows().length > 0);
+
   function selectionInsertData(): CopyInsertData | null {
     const matrix = selectedCellMatrix.value;
     if (!matrix) return null;
@@ -1308,6 +1310,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     copyText,
     copyCell,
     copyRow,
+    canCopyRow,
     copyAll,
     copyWithExtractor,
     previewWithExtractor,

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -363,7 +363,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     return item && !item.isDraft ? [item] : [];
   }
 
-  const canCopyRow = computed(() => targetedRows().length > 0);
+  const copyRowCount = computed(() => targetedRows().length);
+  const canCopyRow = computed(() => copyRowCount.value > 0);
 
   function selectionInsertData(): CopyInsertData | null {
     const matrix = selectedCellMatrix.value;
@@ -1310,6 +1311,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     copyText,
     copyCell,
     copyRow,
+    copyRowCount,
     canCopyRow,
     copyAll,
     copyWithExtractor,

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridContextMenuState.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridContextMenuState.spec.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dataGridSource = readFileSync(new URL("../../../components/grid/DataGrid.vue", import.meta.url), "utf8");
+
+describe("DataGrid context menu state", () => {
+  it("clears the context target whenever the result is replaced", () => {
+    expect(dataGridSource).toMatch(/watch\(\s*\(\) => props\.result,[\s\S]*?clearRowSelection\(\);\s*invalidateSyntheticContextSelection\(\);[\s\S]*?exitTransaction\(\);/);
+  });
+
+  it("uses the actual copyable row count in the copy menu", () => {
+    expect(dataGridSource).toContain('label: copyRowCount.value > 1 ? t("grid.copyRows", { count: copyRowCount.value }) : t("grid.copyRow")');
+  });
+});


### PR DESCRIPTION
## 问题

- 查询报错、空结果或未指向任何有效行时，右键菜单中的「复制行 (JSON)」仍可点击，但实际不会复制内容。
- 数据表右键菜单打开后使用 `Cmd+R` / `Ctrl+R` 刷新，刷新会执行，但菜单不会关闭。

## 修复

- 复用数据导出逻辑已有的目标行解析结果，暴露响应式 `canCopyRow`，仅在选中行、多行范围或右键有效行存在时启用「复制行 (JSON)」。
- 菜单项动态读取最新目标状态，避免右键目标在同一事件周期更新时使用旧状态。
- 通用右键菜单在捕获阶段监听实际按键并关闭；单独按下 `Cmd`、`Ctrl`、`Shift`、`Alt` 不关闭。这样即使 DataGrid 的刷新快捷键调用 `stopPropagation()`，菜单也能在刷新前关闭。

## 验证

- 使用真实 MySQL 8.4 测试连接执行不存在表的 SQL，进入查询错误页并打开右键菜单。
- 在 DataGrid 上按 `Cmd+R`，确认刷新执行，右键菜单元素数量从 `1` 变为 `0`。
- 定向测试：3 个测试文件、41 个测试全部通过。
- `pnpm check`：format、lint、typecheck 通过；全量测试 6746/6748 通过。剩余 2 条失败来自未修改的 `packages/app-tests/treeNodeClick.test.ts`，为 Windows `Ctrl+C` 大小写断言的主线既有问题。