### PR TITLE
fix: allow MySQL SHOW TRIGGERS in agent

### DIFF
--- a/apps/desktop/src/lib/sidebar/treeNodeClick.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeClick.ts
@@ -66,8 +66,8 @@ export function treeNodeRowDoubleClickAction(type: TreeNodeType, canOpenObjectBr
   return "none";
 }
 
-export function sidebarSelectionCopyAction(event: ShortcutLikeEvent): SidebarSelectionCopyAction {
-  return matchesShortcut(event, "Mod+C") ? "copy-name" : "none";
+export function sidebarSelectionCopyAction(event: ShortcutLikeEvent, platform?: string): SidebarSelectionCopyAction {
+  return matchesShortcut(event, "Mod+C", platform) ? "copy-name" : "none";
 }
 
 export function copyNameForTreeNode(node: TreeNode): string {

--- a/crates/dbx-core/src/agent_tools.rs
+++ b/crates/dbx-core/src/agent_tools.rs
@@ -1034,12 +1034,12 @@ for line in sys.stdin:
     }
 
     #[cfg(unix)]
-    fn dameng_test_connection() -> ConnectionConfig {
+    fn agent_test_connection(id: &str, name: &str, db_type: DatabaseType, database: &str) -> ConnectionConfig {
         ConnectionConfig {
-            id: "dameng-1".to_string(),
-            name: "Dameng".to_string(),
+            id: id.to_string(),
+            name: name.to_string(),
             note: String::new(),
-            db_type: DatabaseType::Dameng,
+            db_type,
             driver_profile: None,
             driver_label: None,
             url_params: None,
@@ -1048,7 +1048,7 @@ for line in sys.stdin:
             port: 5236,
             username: "APP_USER".to_string(),
             password: String::new(),
-            database: Some("APPDB".to_string()),
+            database: Some(database.to_string()),
             visible_databases: None,
             visible_schemas: None,
             show_system_schemas: false,
@@ -1226,7 +1226,7 @@ for line in sys.stdin:
         let (client, _script) = spawn_recording_agent(&record_path).await;
         let storage = Storage::open(&temp_dir.path().join("storage.db")).await.unwrap();
         let state = Arc::new(AppState::new(storage));
-        let connection = dameng_test_connection();
+        let connection = agent_test_connection("dameng-1", "Dameng", DatabaseType::Dameng, "APPDB");
         state.configs.write().await.insert(connection.id.clone(), connection);
         state.connections.write().await.insert("dameng-1:APPDB".to_string(), PoolKind::agent(client));
 
@@ -1280,6 +1280,46 @@ for line in sys.stdin:
             assert_eq!(request["params"]["database"], "APPDB");
             assert_eq!(request["params"]["schema"], "REPORTING");
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mysql_agent_allows_show_triggers_without_write_confirmation() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let record_path = temp_dir.path().join("agent-requests.jsonl");
+        let (client, _script) = spawn_recording_agent(&record_path).await;
+        let storage = Storage::open(&temp_dir.path().join("storage.db")).await.unwrap();
+        let state = Arc::new(AppState::new(storage));
+        let connection = agent_test_connection("mysql-1", "MySQL", DatabaseType::Mysql, "rs_main");
+        state.configs.write().await.insert(connection.id.clone(), connection);
+        state.connections.write().await.insert("mysql-1:rs_main".to_string(), PoolKind::agent(client));
+
+        let sql = "SHOW TRIGGERS FROM `rs_main` LIKE 'trg_order_items_after_%';";
+        let call = ToolCall {
+            id: "show-triggers".to_string(),
+            name: "execute_query".to_string(),
+            arguments: json!({ "sql": sql }),
+            provider_payload: None,
+        };
+        let result = execute_tool(
+            &call,
+            &state,
+            "mysql-1",
+            "rs_main",
+            None,
+            &DatabaseType::Mysql,
+            AgentSqlPermissions::default(),
+        )
+        .await;
+
+        assert!(!result.is_error, "{}", result.content);
+        let request = std::fs::read_to_string(&record_path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .find(|request| request["method"] == "execute_query")
+            .unwrap();
+        assert_eq!(request["params"]["sql"], sql);
     }
 
     #[test]

--- a/crates/dbx-core/src/sql_risk.rs
+++ b/crates/dbx-core/src/sql_risk.rs
@@ -95,6 +95,14 @@ fn classify_statement(stmt: &Statement, detect_select_into: bool) -> SqlRisk {
         | Statement::ShowStatus { .. }
         | Statement::ShowProcessList { .. } => SqlRisk::ReadOnly,
 
+        // sqlparser has no dedicated MySQL `SHOW TRIGGERS` node and uses its
+        // loose `ShowVariable` fallback, with TRIGGERS as the first identifier.
+        Statement::ShowVariable { variable }
+            if variable.first().is_some_and(|identifier| identifier.value.eq_ignore_ascii_case("triggers")) =>
+        {
+            SqlRisk::ReadOnly
+        }
+
         // Write operations
         Statement::Insert { .. } | Statement::Update { .. } | Statement::Delete { .. } | Statement::Merge { .. } => {
             SqlRisk::Write
@@ -797,8 +805,15 @@ fn classify_sql_risk_with_database(
     let parser_dialect = resolve_dialect(normalized_dialect);
     let detect_select_into = database_type.is_none();
     let has_locking_clause = sql_contains_top_level_locking_clause(sql, parser_dialect.as_ref());
-    let has_dialect_specific_write = database_type
-        .is_some_and(|database_type| crate::query_execution_sql::has_dialect_specific_write(sql, database_type));
+    let has_dialect_specific_write = match database_type {
+        Some(database_type) => crate::query_execution_sql::has_dialect_specific_write(sql, database_type),
+        // Preserve MySQL executable-comment and file-output detection even
+        // when callers provide a dialect string instead of a database type.
+        None if normalized_dialect == "mysql" => {
+            crate::query_execution_sql::has_dialect_specific_write(sql, DatabaseType::Mysql)
+        }
+        None => false,
+    };
 
     match Parser::parse_sql(parser_dialect.as_ref(), sql) {
         Ok(stmts) if !stmts.is_empty() => {
@@ -872,6 +887,40 @@ mod tests {
         assert_eq!(classify_sql_risk("SHOW TABLES", "mysql").unwrap(), SqlRisk::ReadOnly);
         assert_eq!(classify_sql_risk("DESCRIBE users", "mysql").unwrap(), SqlRisk::ReadOnly);
         assert_eq!(classify_sql_risk("EXPLAIN SELECT * FROM users", "postgres").unwrap(), SqlRisk::ReadOnly);
+    }
+
+    #[test]
+    fn classify_mysql_show_triggers_as_read_only() {
+        for sql in [
+            "SHOW TRIGGERS;",
+            "SHOW TRIGGERS FROM `rs_main` LIKE 'trg_order_items_after_%';",
+            "show triggers in `rs_main` where `Event` = 'INSERT';",
+        ] {
+            assert_eq!(classify_sql_risk(sql, "mysql").unwrap(), SqlRisk::ReadOnly, "expected read-only: {sql}");
+            assert_eq!(
+                classify_sql_risk_for_database(sql, DatabaseType::Mysql).unwrap(),
+                SqlRisk::ReadOnly,
+                "expected read-only: {sql}"
+            );
+            assert!(!is_dangerous_sql_for_database(sql, DatabaseType::Mysql), "expected safe SQL: {sql}");
+        }
+    }
+
+    #[test]
+    fn mysql_show_triggers_preserves_write_detection() {
+        for (sql, expected_risk) in [
+            ("SHOW TRIGGERS; DELETE FROM order_items", SqlRisk::Write),
+            ("SHOW TRIGGERS; DROP TABLE order_items", SqlRisk::Ddl),
+            ("SHOW TRIGGERS; /*!50000 DELETE FROM order_items */", SqlRisk::Write),
+        ] {
+            assert_eq!(classify_sql_risk(sql, "mysql").unwrap(), expected_risk, "expected write detection: {sql}");
+            assert_eq!(
+                classify_sql_risk_for_database(sql, DatabaseType::Mysql).unwrap(),
+                expected_risk,
+                "expected write detection: {sql}"
+            );
+            assert!(is_dangerous_sql_for_database(sql, DatabaseType::Mysql), "expected dangerous SQL: {sql}");
+        }
     }
 
     #[test]

--- a/packages/app-tests/treeNodeClick.test.ts
+++ b/packages/app-tests/treeNodeClick.test.ts
@@ -119,13 +119,13 @@ test("double click does not open object browser for non-browsable rows", () => {
 });
 
 test("double click navigation mode copies the selected sidebar row name", () => {
-  assert.equal(sidebarSelectionCopyAction({ key: "c", metaKey: true }), "copy-name");
-  assert.equal(sidebarSelectionCopyAction({ key: "C", ctrlKey: true }), "copy-name");
+  assert.equal(sidebarSelectionCopyAction({ key: "c", metaKey: true }, "MacIntel"), "copy-name");
+  assert.equal(sidebarSelectionCopyAction({ key: "C", ctrlKey: true }, "Win32"), "copy-name");
 });
 
 test("single click navigation mode copies the selected sidebar row name", () => {
-  assert.equal(sidebarSelectionCopyAction({ key: "c", metaKey: true }), "copy-name");
-  assert.equal(sidebarSelectionCopyAction({ key: "C", ctrlKey: true }), "copy-name");
+  assert.equal(sidebarSelectionCopyAction({ key: "c", metaKey: true }, "MacIntel"), "copy-name");
+  assert.equal(sidebarSelectionCopyAction({ key: "C", ctrlKey: true }, "Win32"), "copy-name");
 });
 
 test("copying table child group rows uses the parent table name", () => {


### PR DESCRIPTION
## 变更说明

- 将 MySQL `SHOW TRIGGERS` 识别为只读元数据查询，避免 Agent 错误要求写操作确认。
- 保留多语句、MySQL 可执行注释和文件输出语法的写操作检测。
- 增加 Agent 回归测试，并让快捷键测试显式验证 macOS Command 与 Windows Ctrl 语义；运行时默认行为不变。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 的前端改动仅用于让跨平台快捷键测试可重复执行，不改变用户可见交互。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过：`cargo test -p dbx-core --lib`

## 关联 Issue

无
