### PR TITLE
fix(informix): hide empty owner nodes

### DIFF
--- a/agents/drivers/informix/src/main/java/com/dbx/agent/informix/InformixAgent.java
+++ b/agents/drivers/informix/src/main/java/com/dbx/agent/informix/InformixAgent.java
@@ -24,10 +24,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.TreeSet;
 
 public final class InformixAgent extends AbstractJdbcAgent {
     private String loginOwner = "";
@@ -187,27 +187,23 @@ public final class InformixAgent extends AbstractJdbcAgent {
                     }
                 }
             }
-            return mergeSchemaOwners(catalogOwners, loginOwner);
+            return normalizeSchemaOwners(catalogOwners);
         });
     }
 
     static String schemaCatalogSql() {
-        // Informix JDBC catalogs are databases; schemas are the object owners in the current database.
-        return "SELECT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL "
-                + "UNION SELECT owner FROM sysprocedures WHERE owner IS NOT NULL ORDER BY owner";
+        // The sidebar's schema nodes are table namespaces. Do not add routine-only
+        // owners or the login owner here: they produce empty table nodes.
+        return "SELECT DISTINCT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL ORDER BY owner";
     }
 
-    static List<String> mergeSchemaOwners(List<String> catalogOwners, String loginOwner) {
-        Set<String> owners = new TreeSet<>();
+    static List<String> normalizeSchemaOwners(List<String> catalogOwners) {
+        Set<String> owners = new LinkedHashSet<>();
         for (String owner : catalogOwners) {
             String normalized = normalizeOwner(owner);
             if (!normalized.isEmpty()) {
                 owners.add(normalized);
             }
-        }
-        String normalizedLoginOwner = normalizeOwner(loginOwner);
-        if (!normalizedLoginOwner.isEmpty()) {
-            owners.add(normalizedLoginOwner);
         }
         return new ArrayList<>(owners);
     }

--- a/agents/drivers/informix/src/main/java/com/dbx/agent/informix/InformixAgent.java
+++ b/agents/drivers/informix/src/main/java/com/dbx/agent/informix/InformixAgent.java
@@ -192,9 +192,10 @@ public final class InformixAgent extends AbstractJdbcAgent {
     }
 
     static String schemaCatalogSql() {
-        // The sidebar's schema nodes are table namespaces. Do not add routine-only
-        // owners or the login owner here: they produce empty table nodes.
-        return "SELECT DISTINCT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL ORDER BY owner";
+        // Informix schemas are object owners. Include routine-only owners because
+        // the same sidebar node also exposes procedures and functions.
+        return "SELECT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL "
+                + "UNION SELECT owner FROM sysprocedures WHERE owner IS NOT NULL ORDER BY owner";
     }
 
     static List<String> normalizeSchemaOwners(List<String> catalogOwners) {

--- a/agents/drivers/informix/src/test/java/com/dbx/agent/informix/InformixAgentTest.java
+++ b/agents/drivers/informix/src/test/java/com/dbx/agent/informix/InformixAgentTest.java
@@ -173,7 +173,7 @@ class InformixAgentTest {
     }
 
     @Test
-    void listsSchemasFromUserTableOwnersOnly() {
+    void listsSchemasFromTableAndRoutineOwnersWithoutLoginFallback() {
         InformixAgent agent = new InformixAgent();
         java.sql.Connection connection = JdbcMetadataSqlFake.connection();
         TestSupport.setPrivateConnection(agent, connection);
@@ -184,14 +184,16 @@ class InformixAgentTest {
         Assertions.assertEquals(List.of(), agent.listSchemas());
 
         Assertions.assertEquals(
-            List.of("SELECT DISTINCT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL ORDER BY owner"),
+            List.of("SELECT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL "
+                    + "UNION SELECT owner FROM sysprocedures WHERE owner IS NOT NULL ORDER BY owner"),
             JdbcMetadataSqlFake.statements
         );
         Assertions.assertEquals(
             List.of("table_owner", "routine_owner"),
             InformixAgent.normalizeSchemaOwners(List.of("table_owner", "routine_owner", "routine_owner", " "))
         );
-        Assertions.assertFalse(InformixAgent.schemaCatalogSql().contains("sysprocedures"));
+        Assertions.assertTrue(InformixAgent.schemaCatalogSql().contains("sysprocedures"));
+        Assertions.assertFalse(InformixAgent.normalizeSchemaOwners(List.of("routine_owner", " ")).contains("current_owner"));
         Assertions.assertNotEquals(InformixAgent.databaseCatalogSql(), InformixAgent.schemaCatalogSql());
     }
 

--- a/agents/drivers/informix/src/test/java/com/dbx/agent/informix/InformixAgentTest.java
+++ b/agents/drivers/informix/src/test/java/com/dbx/agent/informix/InformixAgentTest.java
@@ -173,7 +173,7 @@ class InformixAgentTest {
     }
 
     @Test
-    void listsSchemasFromTableRoutineAndCurrentLoginOwners() {
+    void listsSchemasFromUserTableOwnersOnly() {
         InformixAgent agent = new InformixAgent();
         java.sql.Connection connection = JdbcMetadataSqlFake.connection();
         TestSupport.setPrivateConnection(agent, connection);
@@ -181,20 +181,17 @@ class InformixAgentTest {
         params.setUsername("current_owner");
         agent.afterConnect(params, connection);
 
-        Assertions.assertEquals(List.of("current_owner"), agent.listSchemas());
+        Assertions.assertEquals(List.of(), agent.listSchemas());
 
         Assertions.assertEquals(
-            List.of("SELECT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL "
-                    + "UNION SELECT owner FROM sysprocedures WHERE owner IS NOT NULL ORDER BY owner"),
+            List.of("SELECT DISTINCT owner FROM systables WHERE tabid >= 100 AND owner IS NOT NULL ORDER BY owner"),
             JdbcMetadataSqlFake.statements
         );
         Assertions.assertEquals(
-            List.of("current_owner", "routine_owner", "table_owner"),
-            InformixAgent.mergeSchemaOwners(
-                List.of("table_owner", "routine_owner", "routine_owner", " "),
-                "current_owner"
-            )
+            List.of("table_owner", "routine_owner"),
+            InformixAgent.normalizeSchemaOwners(List.of("table_owner", "routine_owner", "routine_owner", " "))
         );
+        Assertions.assertFalse(InformixAgent.schemaCatalogSql().contains("sysprocedures"));
         Assertions.assertNotEquals(InformixAgent.databaseCatalogSql(), InformixAgent.schemaCatalogSql());
     }
 


### PR DESCRIPTION
## 变更说明

修复 Informix schema 树出现空 owner 节点的问题。

- schema 列表仅从 `systables` 中实际拥有用户表/视图的 owner 生成（`tabid >= 100`）
- 不再将仅拥有存储过程的 owner 或当前登录用户额外加入 schema 树
- 避免出现点击后没有任何表的空节点
- 保留已有的 owner 精确过滤逻辑，确保同名表仍按 owner 区分

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 不涉及前端改动

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] Informix Gradle 测试通过（本机缺少 JDK 21，未能执行）
- [x] 手工执行以下 SQL，结果与 DBeaver schema 列表一致：

  ```sql
  SELECT DISTINCT owner
  FROM systables
  WHERE tabid >= 100 AND owner IS NOT NULL
  ORDER BY owner;