### PR TITLE
Fix：执行 SQL 后保持编辑器焦点

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -622,6 +622,7 @@ function emitExecutionRequest(source: SqlExecutionOverride, openInNewResultTab =
 function requestExecute(options: RequestExecuteOptions = {}) {
   const currentView = view.value;
   if (!currentView) return false;
+  currentView.focus();
   return requestExecuteFromView(currentView, currentView.state.selection.main.head, options);
 }
 

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -229,6 +229,7 @@ async function changeCatalog(selectedCatalog: string) {
             class="h-6 w-6"
             :class="executeButtonClass"
             :disabled="activeTab.isCancelling || activeTab.isExplaining || (!activeTab.isExecuting && !executableSql.trim())"
+            @mousedown.prevent
             @click="activeTab.isExecuting ? emit('cancel') : emit('execute')"
           >
             <Loader2 v-if="activeTab.isCancelling" class="h-3.5 w-3.5 animate-spin" />

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
@@ -4,6 +4,7 @@ import { focusEditorView, type EditorViewLike } from "@/lib/editor/queryEditorFo
 
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 const contentAreaSource = readFileSync(new URL("../../../components/layout/ContentArea.vue", import.meta.url), "utf8");
+const editorToolbarSource = readFileSync(new URL("../../../components/layout/EditorToolbar.vue", import.meta.url), "utf8");
 
 function createMockView(overrides: Partial<EditorViewLike> = {}): EditorViewLike {
   return {
@@ -45,5 +46,12 @@ describe("QueryEditor auto focus wiring", () => {
 
   it("enables auto focus for query tabs", () => {
     expect(contentAreaSource).toMatch(/<QueryEditor[\s\S]*?\sauto-focus\s[\s\S]*?:model-value="activeTab\.sql"/);
+  });
+});
+
+describe("QueryEditor toolbar focus", () => {
+  it("does not move focus from the editor when clicking execute", () => {
+    expect(editorToolbarSource).toMatch(/:disabled="activeTab\.isCancelling[\s\S]*?@mousedown\.prevent[\s\S]*?@click="activeTab\.isExecuting \? emit\('cancel'\) : emit\('execute'\)"/);
+    expect(queryEditorSource).toMatch(/function requestExecute\([\s\S]*?const currentView = view\.value;[\s\S]*?currentView\.focus\(\);[\s\S]*?requestExecuteFromView\(currentView/);
   });
 });


### PR DESCRIPTION
## 修改内容

- 阻止点击 SQL 编辑器左上角执行按钮时抢占编辑器焦点
- 从工具栏触发执行时主动恢复 CodeMirror 焦点，保持光标位置和连续输入体验
- 补充执行按钮与编辑器聚焦链路的回归测试

## 测试

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts`（7/7 通过）
- `pnpm typecheck`
- 定向 `oxlint` 与 `oxfmt --check`
- 免密网页连接本地 SQLite 执行 `select 1`，查询成功后等待 1 秒，焦点仍位于 `.cm-content`