### PR TITLE
fix: prevent IF...BEGIN...END blocks from being split in SQL Server scripts

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -335,6 +335,44 @@ describe("splitSqlStatementRanges", () => {
     expect(rangeSqlTexts(splitSqlStatementRanges(sql, "sqlserver"))).toEqual(["SELECT 'GO'\n-- GO\nSELECT 2", "SELECT 3"]);
   });
 
+  it("keeps SQL Server IF...BEGIN...END block together as a single statement", () => {
+    const sql = `IF OBJECT_ID ('CATEGORIA') IS NOT NULL
+BEGIN
+DROP TABLE CATEGORIA
+END
+CREATE TABLE CATEGORIA
+(
+  COD_CATE CHAR(3) NOT NULL PRIMARY KEY,
+  NOMBRE VARCHAR(25) NOT NULL
+)`;
+    const ranges = splitSqlStatementRanges(sql, "sqlserver");
+    expect(rangeSqlTexts(ranges)).toEqual([sql]);
+  });
+
+  it("keeps SQL Server IF...BEGIN...END block together in executable ranges", () => {
+    const sql = `IF OBJECT_ID ('CATEGORIA') IS NOT NULL
+BEGIN
+DROP TABLE CATEGORIA
+END
+CREATE TABLE CATEGORIA
+(
+  COD_CATE CHAR(3) NOT NULL PRIMARY KEY,
+  NOMBRE VARCHAR(25) NOT NULL
+)`;
+    expect(rangeSqlTexts(executableStatementRanges(sql, "sqlserver"))).toEqual([sql]);
+  });
+
+  it("keeps SQL Server IF...BEGIN...END block together at cursor position", () => {
+    const sql = `IF OBJECT_ID ('CATEGORIA') IS NOT NULL
+BEGIN
+DROP TABLE CATEGORIA
+END`;
+    const cursorPos = sql.indexOf("BEGIN") + 2;
+    const range = statementRangeAtCursor(sql, cursorPos, "sqlserver");
+    expect(range).not.toBeNull();
+    expect(range!.sql.trim()).toBe(sql.trim());
+  });
+
   it("keeps Oracle PL/SQL blocks together and treats slash lines as delimiters", () => {
     const ranges = splitSqlStatementRanges(oraclePlSqlFixture, "oracle");
     expect(rangeSqlTexts(ranges)).toEqual([oraclePlSqlFixture.slice(0, oraclePlSqlFixture.indexOf("\n/")), "SELECT 1"]);

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -651,6 +651,7 @@ function splitStatementRangeAtSoftStarts(sql: string, statement: RawStatement, d
   if (isSapHanaScriptBlockStatement(statement.sql, databaseType)) return [statement];
   // Routine bodies contain top-level-looking SET/INSERT/SELECT lines that are not independent statements.
   if (isMysqlRoutineBlockDatabase(databaseType) && startsWithMysqlRoutineBlock(statement.sql, parameterOptions)) return [statement];
+  if (supportsSqlServerGoCommands(databaseType) && startsWithSqlServerTsqlBlock(statement.sql)) return [statement];
 
   const lineStarts = topLevelSoftStatementLineStarts(sql, statement, databaseType, parameterOptions);
   if (lineStarts.length <= 1) return [statement];
@@ -1935,6 +1936,12 @@ function supportsSqlServerGoCommands(databaseType?: DatabaseType): boolean {
 function isSqlServerGoLine(sql: string, pos: number): boolean {
   const lineEnd = findLineEnd(sql, pos);
   return /^go(?:\s+\d+)?$/i.test(sql.slice(pos, lineEnd).trim());
+}
+
+function startsWithSqlServerTsqlBlock(sql: string): boolean {
+  const match = /^[A-Za-z_][\w$]*/.exec(sql.trimStart());
+  if (!match || match[0].toUpperCase() !== "IF") return false;
+  return /\bBEGIN\b/i.test(sql);
 }
 
 function startsDelimiterCommand(sql: string, pos: number): boolean {

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -674,6 +674,9 @@ fn split_statement_range_at_blank_lines(
     if options.profile.supports_hana_do_blocks && starts_with_hana_do_block(&statement.text) {
         return vec![statement.clone()];
     }
+    if starts_with_tsql_if_block(&statement.text) {
+        return vec![statement.clone()];
+    }
 
     let mut ranges = Vec::new();
     let mut scanner = SqlScanner::with_profile(options.profile);
@@ -2046,6 +2049,14 @@ fn oracle_plsql_block_is_complete(sql: &str) -> bool {
 
 fn starts_with_hana_do_block(sql: &str) -> bool {
     HanaDoBlock::parse(sql).starts_block()
+}
+
+fn starts_with_tsql_if_block(sql: &str) -> bool {
+    let tokens = first_sql_tokens(sql, 4);
+    if tokens.first().is_some_and(|t| t.eq_ignore_ascii_case("IF")) && sql.to_uppercase().contains("BEGIN") {
+        return true;
+    }
+    false
 }
 
 fn hana_do_block_is_complete(sql: &str) -> bool {
@@ -3871,6 +3882,25 @@ END";
         assert_eq!(
             super::find_statement_at_cursor_for_database(sql, cursor, DatabaseType::SqlServer),
             "ALTER PROC dbo.usp_demo\nAS\nBEGIN\n  UPDATE dbo.users SET name = name;\nEND"
+        );
+    }
+
+    #[test]
+    fn sqlserver_keeps_tsql_if_begin_end_block_together() {
+        let sql = "\
+IF OBJECT_ID ('CATEGORIA') IS NOT NULL
+BEGIN
+DROP TABLE CATEGORIA
+END
+CREATE TABLE CATEGORIA
+(
+  COD_CATE CHAR(3) NOT NULL PRIMARY KEY,
+  NOMBRE VARCHAR(25) NOT NULL
+)";
+        let cursor = sql[..sql.find("BEGIN").unwrap()].encode_utf16().count();
+        assert_eq!(
+            super::find_statement_at_cursor_for_database(sql, cursor, DatabaseType::SqlServer),
+            sql
         );
     }
 


### PR DESCRIPTION
## Problem

SQL Server scripts containing `IF...BEGIN...END` blocks are incorrectly split into individual statements by the SQL splitter. This causes `Incorrect syntax near 'NULL'` errors when executing scripts that use conditional blocks.

**Example that fails:**
```sql
IF OBJECT_ID ('CATEGORIA') IS NOT NULL
BEGIN
DROP TABLE CATEGORIA
END
CREATE TABLE CATEGORIA (...)
```

The splitter treats `BEGIN`, `DROP`, `END` etc. as separate statements because they appear at the start of a line after a newline.

## Solution

Added detection of T-SQL `IF` blocks in both:

- **Rust backend** (`crates/dbx-core/src/sql.rs`): `starts_with_tsql_if_block()` function detects `IF` keyword at start of statement text and guards in `split_statement_range_at_blank_lines`
- **TypeScript frontend** (`apps/desktop/src/lib/sql/sqlStatementRanges.ts`): `startsWithSqlServerTsqlBlock()` function with regex detection, guard in `splitStatementRangeAtSoftStarts`

The guard returns the entire statement as-is (no splitting) when the statement starts with an `IF` block.

## Tests

- Rust: `sqlserver_keeps_tsql_if_begin_end_block_together`
- TypeScript: 3 tests covering `splitSqlStatementRanges`, `executableStatementRanges`, and `statementRangeAtCursor`

All 147 TS tests and Rust unit tests pass.