### PR TITLE
fix(grid): 修复插入多行对话框无法修改行数问题

### DIFF
--- a/apps/desktop/src/components/grid/DataGridInsertRowsDialog.vue
+++ b/apps/desktop/src/components/grid/DataGridInsertRowsDialog.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{ insert: [count: number, position: GridInsertRowPositi
 
 const canUsePosition = computed(() => props.canPlaceAtSelection !== false);
 
-const rowCount = ref("1");
+const rowCount = ref<string | number>("1");
 const position = ref<GridInsertRowPosition>("below");
 
 watch(
@@ -36,8 +36,8 @@ watch(canUsePosition, (canUse) => {
   if (!canUse) position.value = "end";
 });
 
-function parseIntegerOrNull(raw: string): number | null {
-  const trimmed = raw.trim();
+function parseIntegerOrNull(raw: string | number): number | null {
+  const trimmed = String(raw).trim();
   if (!/^\d+$/.test(trimmed)) return null;
   const value = Number(trimmed);
   return Number.isInteger(value) && value >= 1 ? value : null;
@@ -50,7 +50,7 @@ const parsedCount = computed<number | null>(() => {
 });
 
 const inputInvalid = computed(() => {
-  const raw = rowCount.value.trim();
+  const raw = String(rowCount.value).trim();
   if (raw === "") return false;
   return parseIntegerOrNull(raw) === null;
 });

--- a/apps/desktop/src/components/grid/__tests__/DataGridInsertRowsDialog.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridInsertRowsDialog.spec.ts
@@ -33,20 +33,6 @@ vi.mock("@/components/ui/button", async () => {
   };
 });
 
-vi.mock("@/components/ui/input", async () => {
-  const { defineComponent, h } = await import("vue");
-  return {
-    Input: defineComponent({
-      inheritAttrs: false,
-      props: { modelValue: String },
-      emits: ["update:modelValue"],
-      setup(props, { attrs, emit }) {
-        return () => h("input", { ...attrs, value: props.modelValue, onInput: (event: Event) => emit("update:modelValue", (event.target as HTMLInputElement).value) });
-      },
-    }),
-  };
-});
-
 import DataGridInsertRowsDialog from "../DataGridInsertRowsDialog.vue";
 
 const mountedApps: Array<{ app: App; host: HTMLElement }> = [];
@@ -79,5 +65,28 @@ describe("DataGridInsertRowsDialog", () => {
     [...host.querySelectorAll("button")].find((button) => button.textContent === "Insert")!.click();
     await nextTick();
     expect(onInsert).toHaveBeenCalledWith(1, "end");
+  });
+
+  it("accepts a numeric value emitted by the number input", async () => {
+    const onInsert = vi.fn();
+    const host = document.createElement("div");
+    document.body.append(host);
+    const app = createApp(DataGridInsertRowsDialog, {
+      open: true,
+      canPlaceAtSelection: true,
+      onInsert,
+    });
+    app.use(i18n);
+    app.mount(host);
+    mountedApps.push({ app, host });
+
+    const input = host.querySelector("#insert-rows-count") as HTMLInputElement;
+    input.value = "3";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    [...host.querySelectorAll("button")].find((button) => button.textContent === "Insert")!.click();
+    await nextTick();
+    expect(onInsert).toHaveBeenCalledWith(3, "below");
   });
 });


### PR DESCRIPTION
## 变更说明

修复“插入多行”对话框处理 `type="number"` 的 `v-model` 数值时调用 `.trim()` 抛出异常的问题。

- 接受 `string | number` 作为行数
- 添加真实数值输入的回归测试

## 变更类型

- [x] Bug 修复

## 涉及前端

- [x] 本 PR 涉及前端改动

## 验证

- [x] 相关测试通过：`DataGridInsertRowsDialog.spec.ts`
- [x] 桌面端 SQLite 手动验证：可输入数量并插入对应草稿行

## 关联 Issue

Fixes #5359
Fixes #5298