### PR TITLE
Fix: 无限滚动追加时保留行选择

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -141,7 +141,7 @@ import { isCancelSearchShortcut, isCopyCurrentRowShortcut, isDeleteCurrentRowSho
 import { dataGridHeaderContentWidth, scrollbarGutterWidth } from "@/lib/dataGrid/dataGridScrollGutter";
 import { canFetchNextDataGridSegment, canGoNextDataGridPage, dataGridTotalRowCountLabelKey, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal, type DataGridInexactTotalRowCountMode } from "@/lib/dataGrid/dataGridPagination";
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
-import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
+import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, isDataGridPrefixAppend, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
 import { CANVAS_DATA_GRID_ROW_HEIGHT, canvasDataGridActionOverlayWidth, canvasDataGridActionReservedWidth, dataGridSearchMatchKey, drawCanvasDataGrid, type CanvasDevicePixelSize } from "@/lib/dataGrid/canvasDataGridRenderer";
 import { DATA_GRID_DARK_STRIPED_ROW_BG, DATA_GRID_LIGHT_STRIPED_ROW_BG, dataGridActiveRowBackground } from "@/lib/dataGrid/dataGridPaintTheme";
 import { createRowLowerTextCache } from "@/lib/dataGrid/dataGridRowLowerText";
@@ -7112,9 +7112,10 @@ watch(isTransposeMode, (active) => {
 
 watch(
   () => props.result,
-  () => {
+  (result, previousResult) => {
     const shouldPreserveTranspose = preserveTransposeOnNextResult.value;
     preserveTransposeOnNextResult.value = false;
+    if (isDataGridPrefixAppend(previousResult, result)) return;
     if (getResetScrollAfterResult()) {
       clearResetScrollAfterResult();
       resetGridVerticalScroll();

--- a/apps/desktop/src/lib/dataGrid/dataGridInfiniteScroll.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridInfiniteScroll.ts
@@ -9,6 +9,11 @@ export interface DataGridScrollMetrics {
   clientHeight: number;
 }
 
+export interface DataGridAppendResult {
+  rows: readonly unknown[];
+  appended_from_row_count?: number;
+}
+
 export function dataGridScrollPosition(top: number, left: number): DataGridScrollPosition {
   return {
     top: Math.max(0, top),
@@ -28,6 +33,11 @@ export function shouldCheckInfiniteScrollAfterScroll(previous: DataGridScrollPos
 
 export function isDataGridNearScrollBottom(metrics: DataGridScrollMetrics, threshold = 100): boolean {
   return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight < threshold;
+}
+
+export function isDataGridPrefixAppend(previous: DataGridAppendResult | undefined, next: DataGridAppendResult): boolean {
+  if (!previous || next.appended_from_row_count !== previous.rows.length || next.rows.length < previous.rows.length) return false;
+  return previous.rows.every((row, index) => row === next.rows[index]);
 }
 
 export function isDataGridAtScrollBottom(metrics: DataGridScrollMetrics, tolerance = 1): boolean {

--- a/packages/app-tests/dataGridInfiniteScroll.test.ts
+++ b/packages/app-tests/dataGridInfiniteScroll.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { readFileSync } from "node:fs";
 import { test } from "vitest";
-import { dataGridScrollPosition, isDataGridNearScrollBottom, shouldCheckInfiniteScrollAfterScroll } from "../../apps/desktop/src/lib/dataGrid/dataGridInfiniteScroll.ts";
+import { dataGridScrollPosition, isDataGridNearScrollBottom, isDataGridPrefixAppend, shouldCheckInfiniteScrollAfterScroll } from "../../apps/desktop/src/lib/dataGrid/dataGridInfiniteScroll.ts";
 
 test("horizontal-only scroll does not check infinite scroll", () => {
   assert.equal(shouldCheckInfiniteScrollAfterScroll(dataGridScrollPosition(240, 0), dataGridScrollPosition(240, 180)), false);
@@ -23,6 +23,21 @@ test("first scroll position only establishes the infinite scroll baseline", () =
 test("near-bottom check matches the grid threshold", () => {
   assert.equal(isDataGridNearScrollBottom({ scrollTop: 801, scrollHeight: 1000, clientHeight: 100 }), true);
   assert.equal(isDataGridNearScrollBottom({ scrollTop: 800, scrollHeight: 1000, clientHeight: 100 }), false);
+});
+
+test("prefix-only append preserves the existing result identity", () => {
+  const first = [1, "Ada"];
+  const second = [2, "Linus"];
+  const previous = { rows: [first, second] };
+  assert.equal(isDataGridPrefixAppend(previous, { rows: [first, second, [3, "Grace"]], appended_from_row_count: 2 }), true);
+});
+
+test("append marker does not preserve state when an existing row was replaced", () => {
+  const first = [1, "Ada"];
+  const second = [2, "Linus"];
+  const previous = { rows: [first, second] };
+  assert.equal(isDataGridPrefixAppend(previous, { rows: [first, [...second], [3, "Grace"]], appended_from_row_count: 2 }), false);
+  assert.equal(isDataGridPrefixAppend(previous, { rows: [first, second, [3, "Grace"]] }), false);
 });
 
 test("infinite scroll requests only the next bounded segment", () => {


### PR DESCRIPTION
## 问题

无限滚动加载下一段查询结果时，结果对象更新会触发数据网格的通用重置逻辑，清空已选行和 Shift 多选锚点。

## 修复

- 仅在追加标记、旧行数量和旧行对象身份都匹配时，将结果更新识别为前缀追加
- 前缀追加时保留当前选择和交互状态
- 普通刷新、筛选、排序、分页和已有行替换仍按原逻辑重置状态

## 验证

- MySQL 8.4：300 行结果按 100 行无限滚动，100→200→300 两次追加后首行均保持选中，Shift 点击第 5 行可连续选中 1–5 行
- `pnpm typecheck`
- `pnpm exec vitest run packages/app-tests/dataGridInfiniteScroll.test.ts packages/app-tests/dataGridEditor.test.ts packages/app-tests/queryStore.test.ts`（213 个测试通过）
- `pnpm lint`

Fixes #2511