### PR TITLE
Enhance(export): 优化 SQL 导出性能并统一导出进度交互

### DIFF
--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -272,25 +272,27 @@ async function startExport() {
     preparing: true,
   };
 
-  const request: api.DatabaseExportRequest = {
-    exportId: exportId.value,
-    connectionId: connectionId.value,
-    database: database.value,
-    schema: schema.value,
-    filePath,
-    selectedTables: buildSelectedTablesPayload(tables.value, selectedTables.value),
-    includeStructure: includeStructure.value,
-    includeData: includeData.value,
-    includeObjects: includeObjects.value,
-    includeCreateDatabase: includeCreateDatabase.value,
-    dropTableIfExists: dropTableIfExists.value,
-    omitAutoIncrement: omitAutoIncrement.value,
-    batchSize: 1000,
-  };
-
   addDatabaseExportTask(exportId.value, database.value || "database", filePath);
 
   try {
+    const connectionType = store.getConfig(connectionId.value)?.db_type;
+    const snapshotSessionId = includeData.value && (connectionType === "mysql" || connectionType === "postgres") ? (await api.beginDatabaseBackupSnapshot(connectionId.value, database.value)).sessionId : undefined;
+    const request: api.DatabaseExportRequest = {
+      exportId: exportId.value,
+      connectionId: connectionId.value,
+      database: database.value,
+      schema: schema.value,
+      filePath,
+      selectedTables: buildSelectedTablesPayload(tables.value, selectedTables.value),
+      includeStructure: includeStructure.value,
+      includeData: includeData.value,
+      includeObjects: includeObjects.value,
+      includeCreateDatabase: includeCreateDatabase.value,
+      dropTableIfExists: dropTableIfExists.value,
+      omitAutoIncrement: omitAutoIncrement.value,
+      snapshotSessionId,
+      batchSize: 1000,
+    };
     await api.exportDatabaseSql(request, (progress) => {
       exportProgress.value = { ...progress };
       updateDatabaseExportTask(progress.exportId, progress);
@@ -352,6 +354,7 @@ async function startAllDatabasesExport() {
   batchRowsExported.value = 0;
 
   const dbs = [...selectedDatabases.value];
+  const connectionType = store.getConfig(connectionId.value)?.db_type;
   const batchId = generateDatabaseExportId();
   exportId.value = batchId;
   exportProgress.value = {
@@ -402,6 +405,7 @@ async function startAllDatabasesExport() {
         includeCreateDatabase: includeCreateDatabase.value,
         dropTableIfExists: dropTableIfExists.value,
         omitAutoIncrement: omitAutoIncrement.value,
+        snapshotSessionId: includeData.value && (connectionType === "mysql" || connectionType === "postgres") ? (await api.beginDatabaseBackupSnapshot(connectionId.value, item.database)).sessionId : undefined,
         batchSize: 1000,
       };
       let currentDatabaseRowsExported = 0;

--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -12,7 +12,7 @@ import * as api from "@/lib/backend/api";
 import type { ExportProgress } from "@/lib/backend/api";
 import { isSchemaAware } from "@/lib/database/databaseFeatureSupport";
 import { databaseOptionsForConnection } from "@/composables/useDatabaseOptions";
-import { buildAllDatabaseExportPlan, generateDatabaseExportId, runDatabaseExportUntilTerminal, type AllDatabaseExportPlanItem } from "@/lib/export/databaseExport";
+import { buildAllDatabaseExportPlan, generateDatabaseExportId, runDatabaseExportUntilTerminal, runWithDatabaseBackupSnapshot, type AllDatabaseExportPlanItem } from "@/lib/export/databaseExport";
 import { buildSelectedTablesPayload } from "@/lib/export/databaseExportSelection";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { useToast } from "@/composables/useToast";
@@ -300,41 +300,50 @@ async function startExport() {
 
   try {
     const connectionType = store.getConfig(connectionId.value)?.db_type;
-    const snapshotSessionId = includeData.value && (connectionType === "mysql" || connectionType === "postgres") ? (await api.beginDatabaseBackupSnapshot(connectionId.value, database.value)).sessionId : undefined;
-    const request: api.DatabaseExportRequest = {
-      exportId: exportId.value,
-      connectionId: connectionId.value,
-      database: database.value,
-      schema: schema.value,
-      filePath,
-      selectedTables: buildSelectedTablesPayload(tables.value, selectedTables.value),
-      includeStructure: includeStructure.value,
-      includeData: includeData.value,
-      includeObjects: includeObjects.value,
-      includeCreateDatabase: includeCreateDatabase.value,
-      dropTableIfExists: dropTableIfExists.value,
-      omitAutoIncrement: omitAutoIncrement.value,
-      snapshotSessionId,
-      batchSize: 1000,
-    };
-    await api.exportDatabaseSql(request, (progress) => {
-      exportProgress.value = { ...progress };
-      updateDatabaseExportTask(progress.exportId, progress);
-      if (progress.status === "Done") {
-        finishExportTiming();
-        exportDone.value = true;
-        isExporting.value = false;
-        toast(t("databaseExport.exportSuccess"), 3000);
-      } else if (progress.status === "Error") {
-        finishExportTiming();
-        exportError.value = progress.error;
-        isExporting.value = false;
-      } else if (progress.status === "Cancelled") {
-        finishExportTiming();
-        exportCancelled.value = true;
-        isExporting.value = false;
-      }
-    });
+    await runWithDatabaseBackupSnapshot(
+      {
+        connectionId: connectionId.value,
+        database: database.value,
+        enabled: includeData.value && (connectionType === "mysql" || connectionType === "postgres"),
+      },
+      async (snapshotSessionId) => {
+        const request: api.DatabaseExportRequest = {
+          exportId: exportId.value,
+          connectionId: connectionId.value,
+          database: database.value,
+          schema: schema.value,
+          filePath,
+          selectedTables: buildSelectedTablesPayload(tables.value, selectedTables.value),
+          includeStructure: includeStructure.value,
+          includeData: includeData.value,
+          includeObjects: includeObjects.value,
+          includeCreateDatabase: includeCreateDatabase.value,
+          dropTableIfExists: dropTableIfExists.value,
+          omitAutoIncrement: omitAutoIncrement.value,
+          snapshotSessionId,
+          batchSize: 1000,
+        };
+        await api.exportDatabaseSql(request, (progress) => {
+          exportProgress.value = { ...progress };
+          updateDatabaseExportTask(progress.exportId, progress);
+          if (progress.status === "Done") {
+            finishExportTiming();
+            exportDone.value = true;
+            isExporting.value = false;
+            toast(t("databaseExport.exportSuccess"), 3000);
+          } else if (progress.status === "Error") {
+            finishExportTiming();
+            exportError.value = progress.error;
+            isExporting.value = false;
+          } else if (progress.status === "Cancelled") {
+            finishExportTiming();
+            exportCancelled.value = true;
+            isExporting.value = false;
+          }
+        });
+      },
+      () => !exportError.value && !exportCancelled.value,
+    );
   } catch (e: any) {
     exportError.value = e?.message || String(e);
     const lastProgress = exportProgress.value as api.ExportProgress | null;
@@ -423,51 +432,62 @@ async function startAllDatabasesExport() {
       const currentExportId = `${batchId}-${index + 1}`;
       activeDatabaseExportId.value = currentExportId;
       const filePath = isTauriRuntime() ? joinExportPath(directoryPath, `${sanitizeFileName(item.fileStem)}.sql`) : `__web_export_${currentExportId}.sql`;
-      const request: api.DatabaseExportRequest = {
-        exportId: currentExportId,
-        connectionId: connectionId.value,
-        database: item.database,
-        schema: item.schema,
-        filePath,
-        includeStructure: includeStructure.value,
-        includeData: includeData.value,
-        includeObjects: includeObjects.value,
-        includeCreateDatabase: includeCreateDatabase.value,
-        dropTableIfExists: dropTableIfExists.value,
-        omitAutoIncrement: omitAutoIncrement.value,
-        snapshotSessionId: includeData.value && (connectionType === "mysql" || connectionType === "postgres") ? (await api.beginDatabaseBackupSnapshot(connectionId.value, item.database)).sessionId : undefined,
-        batchSize: 1000,
-      };
       let currentDatabaseRowsExported = 0;
 
-      await runDatabaseExportUntilTerminal(request, (progress) => {
-        const nextRowsExported = Math.max(0, progress.rowsExported);
-        batchRowsExported.value += Math.max(0, nextRowsExported - currentDatabaseRowsExported);
-        currentDatabaseRowsExported = nextRowsExported;
-        exportProgress.value = {
-          ...progress,
-          exportId: batchId,
-          currentObject: `${item.displayName}: ${progress.currentObject || item.displayName}`,
-          rowsExported: batchRowsExported.value,
-        };
-        updateDatabaseExportTask(batchId, {
-          ...progress,
-          exportId: batchId,
-          currentObject: item.displayName,
-          objectIndex: index,
-          totalObjects: exportPlan.length,
-          rowsExported: batchRowsExported.value,
-        });
-        if (progress.status === "Error") {
-          finishExportTiming();
-          exportError.value = progress.error;
-          isExporting.value = false;
-        } else if (progress.status === "Cancelled") {
-          finishExportTiming();
-          exportCancelled.value = true;
-          isExporting.value = false;
-        }
-      });
+      await runWithDatabaseBackupSnapshot(
+        {
+          connectionId: connectionId.value,
+          database: item.database,
+          enabled: includeData.value && (connectionType === "mysql" || connectionType === "postgres"),
+        },
+        (snapshotSessionId) =>
+          runDatabaseExportUntilTerminal(
+            {
+              exportId: currentExportId,
+              connectionId: connectionId.value,
+              database: item.database,
+              schema: item.schema,
+              filePath,
+              includeStructure: includeStructure.value,
+              includeData: includeData.value,
+              includeObjects: includeObjects.value,
+              includeCreateDatabase: includeCreateDatabase.value,
+              dropTableIfExists: dropTableIfExists.value,
+              omitAutoIncrement: omitAutoIncrement.value,
+              snapshotSessionId,
+              batchSize: 1000,
+            },
+            (progress) => {
+              const nextRowsExported = Math.max(0, progress.rowsExported);
+              batchRowsExported.value += Math.max(0, nextRowsExported - currentDatabaseRowsExported);
+              currentDatabaseRowsExported = nextRowsExported;
+              exportProgress.value = {
+                ...progress,
+                exportId: batchId,
+                currentObject: `${item.displayName}: ${progress.currentObject || item.displayName}`,
+                rowsExported: batchRowsExported.value,
+              };
+              updateDatabaseExportTask(batchId, {
+                ...progress,
+                exportId: batchId,
+                currentObject: item.displayName,
+                objectIndex: index,
+                totalObjects: exportPlan.length,
+                rowsExported: batchRowsExported.value,
+              });
+              if (progress.status === "Error") {
+                finishExportTiming();
+                exportError.value = progress.error;
+                isExporting.value = false;
+              } else if (progress.status === "Cancelled") {
+                finishExportTiming();
+                exportCancelled.value = true;
+                isExporting.value = false;
+              }
+            },
+          ),
+        (terminal) => terminal.status === "Done",
+      );
 
       if (exportError.value || exportCancelled.value) break;
       activeDatabaseExportId.value = "";

--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Dialog, DialogHeader, DialogTitle, DialogFooter, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -18,7 +18,7 @@ import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { useToast } from "@/composables/useToast";
 import { Input } from "@/components/ui/input";
 import { Download, Square, CheckSquare, Search, X, Loader2 } from "@lucide/vue";
-import { useExportTracker } from "@/composables/useExportTracker";
+import { formatDataTransferDuration, useExportTracker } from "@/composables/useExportTracker";
 
 const { t } = useI18n();
 const { toast } = useToast();
@@ -73,6 +73,9 @@ const exportId = ref("");
 const exportDone = ref(false);
 const exportError = ref<string | null>(null);
 const exportCancelled = ref(false);
+const exportStartedAt = ref<number | null>(null);
+const exportFinishedAt = ref<number | null>(null);
+const currentTime = ref(Date.now());
 const pendingPrefillTable = ref("");
 const pendingPrefillTables = ref<string[]>([]);
 const exportAllDatabases = ref(false);
@@ -80,6 +83,25 @@ const batchDatabaseIndex = ref(0);
 const batchDatabaseTotal = ref(0);
 const batchRowsExported = ref(0);
 const activeDatabaseExportId = ref("");
+
+let elapsedTimer: ReturnType<typeof setInterval> | undefined;
+onMounted(() => {
+  elapsedTimer = setInterval(() => {
+    currentTime.value = Date.now();
+  }, 1000);
+});
+onBeforeUnmount(() => {
+  if (elapsedTimer) clearInterval(elapsedTimer);
+});
+
+function finishExportTiming() {
+  exportFinishedAt.value ??= Date.now();
+}
+
+const exportElapsedText = computed(() => {
+  if (exportStartedAt.value === null) return "";
+  return formatDataTransferDuration((exportFinishedAt.value ?? currentTime.value) - exportStartedAt.value);
+});
 
 const sqlConnections = computed(() => store.connections.filter((c) => !["redis", "mongodb", "elasticsearch", "easysearch", "qdrant", "milvus", "weaviate", "chromadb", "etcd", "zookeeper", "mq", "nacos"].includes(c.db_type)));
 
@@ -257,6 +279,8 @@ async function startExport() {
   // Switch to the progress view only after the save dialog closes, and seed a
   // preparing state so the dialog is never a blank panel while metadata loads.
   isExporting.value = true;
+  exportStartedAt.value = Date.now();
+  exportFinishedAt.value = null;
   exportDone.value = false;
   exportError.value = null;
   exportCancelled.value = false;
@@ -297,13 +321,16 @@ async function startExport() {
       exportProgress.value = { ...progress };
       updateDatabaseExportTask(progress.exportId, progress);
       if (progress.status === "Done") {
+        finishExportTiming();
         exportDone.value = true;
         isExporting.value = false;
         toast(t("databaseExport.exportSuccess"), 3000);
       } else if (progress.status === "Error") {
+        finishExportTiming();
         exportError.value = progress.error;
         isExporting.value = false;
       } else if (progress.status === "Cancelled") {
+        finishExportTiming();
         exportCancelled.value = true;
         isExporting.value = false;
       }
@@ -322,6 +349,7 @@ async function startExport() {
       error: exportError.value,
     };
     updateDatabaseExportTask(exportId.value, fallbackProgress);
+    finishExportTiming();
     isExporting.value = false;
   }
 }
@@ -347,6 +375,8 @@ async function startAllDatabasesExport() {
   }
 
   isExporting.value = true;
+  exportStartedAt.value = Date.now();
+  exportFinishedAt.value = null;
   exportDone.value = false;
   exportError.value = null;
   exportCancelled.value = false;
@@ -429,9 +459,11 @@ async function startAllDatabasesExport() {
           rowsExported: batchRowsExported.value,
         });
         if (progress.status === "Error") {
+          finishExportTiming();
           exportError.value = progress.error;
           isExporting.value = false;
         } else if (progress.status === "Cancelled") {
+          finishExportTiming();
           exportCancelled.value = true;
           isExporting.value = false;
         }
@@ -443,6 +475,7 @@ async function startAllDatabasesExport() {
 
     if (!exportError.value && !exportCancelled.value) {
       exportDone.value = true;
+      finishExportTiming();
       isExporting.value = false;
       const finalProgress: api.ExportProgress = {
         exportId: batchId,
@@ -470,6 +503,7 @@ async function startAllDatabasesExport() {
       status: "Error",
       error: exportError.value,
     });
+    finishExportTiming();
     isExporting.value = false;
   }
 }
@@ -478,6 +512,7 @@ async function cancelExport() {
   if (exportId.value) {
     if (exportAllDatabases.value) {
       exportCancelled.value = true;
+      finishExportTiming();
       isExporting.value = false;
       if (activeDatabaseExportId.value) {
         await api.cancelDatabaseExport(activeDatabaseExportId.value);
@@ -513,6 +548,8 @@ function resetState() {
   exportDone.value = false;
   exportError.value = null;
   exportCancelled.value = false;
+  exportStartedAt.value = null;
+  exportFinishedAt.value = null;
   exportId.value = "";
   batchDatabaseIndex.value = 0;
   batchDatabaseTotal.value = 0;
@@ -805,6 +842,9 @@ watch(
 
             <div v-if="exportProgress && !isPreparingExport" class="text-xs text-muted-foreground">
               {{ exportAllDatabases ? t("databaseExport.allRowsExported", { count: exportProgress.rowsExported.toLocaleString() }) : t("databaseExport.rowsExported", { current: exportProgress.objectIndex, total: exportProgress.totalObjects, count: exportProgress.rowsExported.toLocaleString() }) }}
+            </div>
+            <div v-if="exportElapsedText" class="text-xs text-muted-foreground tabular-nums">
+              {{ t("exportProgress.elapsed", { duration: exportElapsedText }) }}
             </div>
           </div>
 

--- a/apps/desktop/src/components/export/ExportProgressDialog.vue
+++ b/apps/desktop/src/components/export/ExportProgressDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -8,11 +8,22 @@ import { useToast } from "@/composables/useToast";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import * as api from "@/lib/backend/api";
 import { translateBackendError } from "@/i18n/backend-errors";
+import { formatDataTransferDuration } from "@/composables/useExportTracker";
 
 const { t } = useI18n();
 const { toast } = useToast();
 const open = defineModel<boolean>("open", { default: false });
 const isRevealing = ref(false);
+const currentTime = ref(Date.now());
+let elapsedTimer: ReturnType<typeof setInterval> | undefined;
+onMounted(() => {
+  elapsedTimer = setInterval(() => {
+    currentTime.value = Date.now();
+  }, 1000);
+});
+onBeforeUnmount(() => {
+  if (elapsedTimer) clearInterval(elapsedTimer);
+});
 
 const props = defineProps<{
   title: string;
@@ -23,6 +34,8 @@ const props = defineProps<{
   status: string;
   errorMessage: string | null;
   filePath?: string | null;
+  startedAt?: number;
+  finishedAt?: number;
   disableCancel?: boolean;
   canMinimize?: boolean;
 }>();
@@ -49,6 +62,10 @@ const rowsText = computed(() => {
     });
   }
   return t("exportProgress.rowsExported", { count: props.rowsExported.toLocaleString() });
+});
+const elapsedText = computed(() => {
+  if (props.startedAt === undefined) return "";
+  return formatDataTransferDuration((props.finishedAt ?? currentTime.value) - props.startedAt);
 });
 
 async function revealExportFile() {
@@ -120,6 +137,7 @@ async function revealExportFile() {
         <!-- Row count -->
         <div class="text-xs text-muted-foreground tabular-nums">
           {{ rowsText }}
+          <span v-if="elapsedText" class="ml-2">{{ t("exportProgress.elapsed", { duration: elapsedText }) }}</span>
         </div>
       </div>
 

--- a/apps/desktop/src/components/export/ExportProgressPopover.vue
+++ b/apps/desktop/src/components/export/ExportProgressPopover.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
@@ -12,7 +12,18 @@ const { tasks, activeCount, hasActive, clearFinished, cancelTask, removeTask } =
 const open = ref(false);
 const showAll = ref(false);
 const expandedFailureTaskIds = ref<string[]>([]);
+const currentTime = ref(Date.now());
 const MAX_VISIBLE = 5;
+
+let elapsedTimer: ReturnType<typeof setInterval> | undefined;
+onMounted(() => {
+  elapsedTimer = setInterval(() => {
+    currentTime.value = Date.now();
+  }, 1000);
+});
+onBeforeUnmount(() => {
+  if (elapsedTimer) clearInterval(elapsedTimer);
+});
 
 const reversedTasks = computed(() => {
   return [...tasks.value].reverse();
@@ -94,6 +105,12 @@ const rowsText = (task: ExportTask) => {
   }
   if (task.totalRows) return `${task.rowsExported.toLocaleString()} / ${task.totalRows.toLocaleString()}`;
   return `${task.rowsExported.toLocaleString()} ${t("exportProgress.rowsShort")}`;
+};
+
+const elapsedText = (task: ExportTask) => {
+  if (task.startedAt === undefined) return "";
+  const finishedAt = task.finishedAt ?? currentTime.value;
+  return t("exportProgress.elapsed", { duration: formatDataTransferDuration(finishedAt - task.startedAt) });
 };
 
 const statusIcon = (task: ExportTask) => {
@@ -192,6 +209,7 @@ function failureDetailCount(task: ExportTask) {
 
             <div class="min-w-0 text-muted-foreground">
               <span class="break-words tabular-nums">{{ rowsText(task) }}</span>
+              <span v-if="task.kind !== 'data-transfer' && task.startedAt !== undefined" class="ml-1 tabular-nums">{{ elapsedText(task) }}</span>
               <span v-if="task.status === 'Error' && task.errorMessage" class="mt-1 block whitespace-normal break-words text-destructive" :title="translateBackendError(t, task.errorMessage)">
                 {{ translateBackendError(t, task.errorMessage) }}
               </span>

--- a/apps/desktop/src/components/export/__tests__/ExportProgressPopover.spec.ts
+++ b/apps/desktop/src/components/export/__tests__/ExportProgressPopover.spec.ts
@@ -66,8 +66,8 @@ async function mountPopover() {
   await nextTick();
 }
 
-describe("ExportProgressPopover data transfer duration", () => {
-  it("shows frozen transfer elapsed time without adding it to other task kinds", async () => {
+describe("ExportProgressPopover task duration", () => {
+  it("shows frozen transfer elapsed time and live duration for table tasks", async () => {
     const tracker = useExportTracker();
     now = 1_000;
     const transfer = tracker.addDataTransferTask("transfer", "users", 1);
@@ -89,7 +89,7 @@ describe("ExportProgressPopover data transfer duration", () => {
     await mountPopover();
 
     expect(document.body.textContent).toContain("Elapsed: 1m 5s");
-    expect(document.body.textContent?.match(/Elapsed:/g)).toHaveLength(1);
+    expect(document.body.textContent?.match(/Elapsed:/g)).toHaveLength(2);
   });
 
   it("expands complete per-table transfer failure details", async () => {

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5519,6 +5519,8 @@ const exportProgressState = ref({
   status: "",
   errorMessage: null as string | null,
   filePath: null as string | null,
+  startedAt: undefined as number | undefined,
+  finishedAt: undefined as number | undefined,
 });
 const exportCancelHandler = ref<(() => Promise<void>) | null>(null);
 const exportCanMinimize = ref(false);

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -1884,6 +1884,7 @@ async function exportTableData(row: ObjectBrowserRow, format: "csv" | "xlsx" | "
       columns,
       columnComments: format === "xlsx" ? columnComments : undefined,
       batchSize: settingsStore.editorSettings.exportBatchSize,
+      skipCount: format === "sql",
       rowLimit,
     };
 

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -83,7 +83,6 @@ import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { generateDatabaseExportId } from "@/lib/export/databaseExport";
 import { copyToClipboard, eventTargetAllowsAppClipboardShortcut } from "@/lib/common/clipboard";
 import { defaultPasteTableMode, pasteTableModeCopiesData, supportsWholeRowTableDataCopy, tableClipboardMatchesTarget, tableClipboardMenuState, tableClipboardSourceContext, tableDataCopyColumnOptions, type PasteTableMode, type TableClipboardContext } from "@/lib/table/tableClipboard";
-import { formatSqlInsert } from "@/lib/export/exportFormats";
 import { buildSingleDdlExportFileContent } from "@/lib/export/ddlExport";
 import { fetchTableDataForExport } from "@/lib/table/tableDataExport";
 import { useConnectionStore } from "@/stores/connectionStore";
@@ -259,7 +258,7 @@ let stopColumnResize: (() => void) | null = null;
 let preserveObjectFilterScrollOnce = false;
 
 // Export via background tracker
-const { addTask: addExportTask } = useExportTracker();
+const { addTask: addExportTask, updateTableExportTask } = useExportTracker();
 
 const needsSchema = computed(() => isSchemaAware(props.connection.db_type) && !connectionUsesDatabaseObjectTreeMode(props.connection));
 const canDropTargetCascade = computed(() => dropTarget.value?.type === "TABLE" && supportsDropTableCascade(effectiveDatabaseType.value));
@@ -1749,11 +1748,10 @@ function tableDdlObjectType(type: ObjectBrowserRow["type"]): ObjectSourceKind | 
   return undefined;
 }
 
-async function exportDataLegacy(row: ObjectBrowserRow, format: "json" | "sql") {
+async function exportDataLegacy(row: ObjectBrowserRow, format: "json") {
   try {
     const schema = row.schema || selectedSchema.value;
-    const tableColumns = format === "sql" ? await api.getColumns(props.connection.id, props.database, schema || props.database, row.name, props.catalog) : undefined;
-    const queryColumns = props.connection.db_type === "neo4j" ? (tableColumns ?? (await api.getColumns(props.connection.id, props.database, schema || props.database, row.name, props.catalog))).map((column) => column.name) : undefined;
+    const queryColumns = props.connection.db_type === "neo4j" ? (await api.getColumns(props.connection.id, props.database, schema || props.database, row.name, props.catalog)).map((column) => column.name) : undefined;
     const result = await fetchTableDataForExport({
       databaseType: effectiveDatabaseType.value,
       identifierQuote: connectionStore.connectionIdentifierQuote?.(props.connection.id),
@@ -1776,35 +1774,15 @@ async function exportDataLegacy(row: ObjectBrowserRow, format: "json" | "sql") {
       }
       await api.exportQueryResultJson(outputPath, result.columns, result.rows);
       toast(t("grid.exported"));
-      return;
     }
-
-    const content = await formatSqlInsert({
-      databaseType: effectiveDatabaseType.value,
-      schema,
-      tableName: row.name,
-      columns: result.columns,
-      columnTypes: tableColumns ? columnTypesForResultColumns(result.columns, tableColumns) : undefined,
-      rows: result.rows,
-    });
-    await saveFileContent(content, `${row.name}.sql`, "SQL", "sql");
-    toast(t("grid.exported"));
   } catch (e: any) {
     toast(t("grid.exportFailed", { message: e?.message || String(e) }), 5000);
   }
 }
 
-function columnTypesForResultColumns(columns: string[], tableColumns: Array<{ name: string; data_type: string }>): Array<string | undefined> {
-  const typesByName = new Map(tableColumns.map((column) => [column.name.toLocaleLowerCase(), column.data_type]));
-  return columns.map((column) => typesByName.get(column.toLocaleLowerCase()));
-}
-
 async function exportData(row: ObjectBrowserRow, format: "csv" | "json" | "sql") {
-  if (format === "csv") {
-    await exportTableData(row, "csv");
-    return;
-  }
-  await exportDataLegacy(row, format);
+  if (format === "json") await exportDataLegacy(row, format);
+  else await exportTableData(row, format);
 }
 
 function showObjectBrowserXlsxHeaderDialog(hasComments: boolean): Promise<boolean | null> {
@@ -1850,7 +1828,7 @@ async function exportDataXlsx(row: ObjectBrowserRow) {
   await exportTableData(row, "xlsx", columnInfos, useCommentHeader);
 }
 
-async function exportTableData(row: ObjectBrowserRow, format: "csv" | "xlsx", columnInfos?: ColumnInfo[], useCommentHeader = false) {
+async function exportTableData(row: ObjectBrowserRow, format: "csv" | "xlsx" | "sql", columnInfos?: ColumnInfo[], useCommentHeader = false) {
   const schema = row.schema || selectedSchema.value;
 
   // Save dialog first
@@ -1860,7 +1838,7 @@ async function exportTableData(row: ObjectBrowserRow, format: "csv" | "xlsx", co
   if (isTauriRuntime()) {
     try {
       const { save } = await import("@tauri-apps/plugin-dialog");
-      const filter = format === "csv" ? { name: "CSV", extensions: ["csv"] } : { name: "Excel", extensions: ["xlsx"] };
+      const filter = format === "csv" ? { name: "CSV", extensions: ["csv"] } : format === "xlsx" ? { name: "Excel", extensions: ["xlsx"] } : { name: "SQL", extensions: ["sql"] };
       const path = await save({
         defaultPath: defaultName,
         filters: [filter],
@@ -1910,10 +1888,7 @@ async function exportTableData(row: ObjectBrowserRow, format: "csv" | "xlsx", co
     };
 
     const terminalProgress = await api.startTableExport(request, (progress) => {
-      currentTask.rowsExported = progress.rowsExported;
-      currentTask.totalRows = progress.totalRows;
-      currentTask.status = progress.status;
-      currentTask.errorMessage = progress.errorMessage || null;
+      updateTableExportTask(currentTask.exportId, progress);
     });
     if (terminalProgress.status === "Done") {
       toast(t("grid.exported"));

--- a/apps/desktop/src/composables/__tests__/useDataGridExport.sqlProgress.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridExport.sqlProgress.spec.ts
@@ -1,0 +1,142 @@
+import { computed, ref } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDataGridExport, type UseDataGridExportOptions } from "@/composables/useDataGridExport";
+import { useExportTracker } from "@/composables/useExportTracker";
+import * as api from "@/lib/backend/api";
+
+vi.mock("@/lib/backend/tauriRuntime", () => ({
+  isTauriRuntime: () => true,
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: vi.fn().mockResolvedValue("C:/exports/query-result.sql"),
+}));
+
+vi.mock("@/lib/backend/api", () => ({
+  startQueryResultExport: vi.fn(),
+  cancelQueryResultExport: vi.fn(),
+}));
+
+vi.mock("@/composables/useToast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/composables/useDataGridExtractor", () => ({
+  useDataGridExtractor: () => ({
+    copyWithExtractor: vi.fn(),
+    previewWithExtractor: vi.fn(),
+    canCopyWithExtractor: vi.fn(),
+  }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings: {
+      exportBatchSize: 1000,
+      globalDateTimeExportFormat: "",
+      numericColumnRightAlign: true,
+    },
+  }),
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/i18n", () => ({
+  default: { install() {} },
+}));
+
+function createOptions(overrides: Partial<UseDataGridExportOptions> = {}): UseDataGridExportOptions {
+  const base: UseDataGridExportOptions = {
+    columns: computed(() => ["id", "name"]),
+    displayItems: computed(() => []),
+    sql: computed(() => "SELECT id, name FROM users"),
+    tableMeta: computed(() => ({
+      tableName: "users",
+      primaryKeys: [],
+      columns: [
+        { name: "id", data_type: "int" },
+        { name: "name", data_type: "text" },
+      ],
+    })),
+    databaseType: computed(() => "postgres"),
+    connectionId: computed(() => "connection-1"),
+    database: computed(() => "dbx"),
+    context: computed(() => "results"),
+    sourceColumns: computed(() => ["id", "name"]),
+    columnTypes: computed(() => ["int4", "text"]),
+    allColumnTypes: computed(() => ["int4", "text"]),
+    whereInput: computed(() => undefined),
+    orderBy: computed(() => undefined),
+    exportBatchSize: computed(() => 1000),
+    hasCellSelection: computed(() => false),
+    selectedCells: computed(() => ({ columns: [], rows: [] })),
+    selectedCellMatrix: computed(() => null),
+    selectedRange: computed(() => null),
+    contextCell: ref(null),
+    contextSelectionIsSynthetic: ref(false),
+    getRowItem: () => undefined,
+    selectedRowIds: ref(new Set<number>()),
+    hasRowSelection: computed(() => false),
+    hasCompleteLocalResult: computed(() => false),
+    queryResultExportRequest: vi.fn(async (request) => ({
+      ...request,
+      connectionId: "connection-1",
+      database: "dbx",
+      databaseType: "postgres",
+      queryBaseSql: "SELECT id, name FROM users",
+      sql: "SELECT id, name FROM users",
+      executionId: "execution-1",
+    })),
+  };
+  return { ...base, ...overrides };
+}
+
+describe("query result SQL export progress", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const tracker = useExportTracker();
+    for (const task of tracker.tasks.value) tracker.removeTask(task.exportId);
+    vi.mocked(api.startQueryResultExport).mockImplementation(async (_request, onProgress) => {
+      onProgress({ exportId: "sql-export", tableName: "Query Result", rowsExported: 1, totalRows: 1, status: "Done", errorMessage: null });
+      return { exportId: "sql-export", tableName: "Query Result", rowsExported: 1, totalRows: 1, status: "Done", errorMessage: null };
+    });
+  });
+
+  afterEach(() => {
+    const tracker = useExportTracker();
+    for (const task of tracker.tasks.value) tracker.removeTask(task.exportId);
+  });
+
+  it("uses the same progress dialog and task lifecycle as CSV/XLSX", async () => {
+    const progressDialog = ref(false);
+    const progressState = ref({
+      title: "",
+      tableName: "",
+      format: "",
+      rowsExported: 0,
+      totalRows: null as number | null,
+      status: "",
+      errorMessage: null as string | null,
+      filePath: null as string | null,
+      startedAt: undefined as number | undefined,
+      finishedAt: undefined as number | undefined,
+    });
+    const cancelHandler = ref<(() => Promise<void>) | null>(null);
+    const canMinimize = ref(false);
+    const state = useDataGridExport(createOptions({ exportProgressDialog: progressDialog, exportProgressState: progressState, exportCancelHandler: cancelHandler, exportCanMinimize: canMinimize }));
+
+    await state.exportSql();
+
+    expect(progressDialog.value).toBe(true);
+    expect(canMinimize.value).toBe(false);
+    expect(progressState.value.format).toBe("sql");
+    expect(progressState.value.status).toBe("Done");
+    expect(progressState.value.rowsExported).toBe(1);
+    expect(progressState.value.startedAt).toEqual(expect.any(Number));
+    expect(progressState.value.finishedAt).toEqual(expect.any(Number));
+    expect(cancelHandler.value).toBeNull();
+    expect(api.startQueryResultExport).toHaveBeenCalledWith(expect.objectContaining({ format: "sql", exportTableName: "users", exportColumnTypes: ["int4", "text"] }), expect.any(Function));
+  });
+});

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -130,6 +130,8 @@ export interface UseDataGridExportOptions {
     status: string;
     errorMessage: string | null;
     filePath: string | null;
+    startedAt?: number;
+    finishedAt?: number;
   }>;
   exportCancelHandler?: Ref<(() => Promise<void>) | null>;
   exportCanMinimize?: Ref<boolean>;
@@ -147,7 +149,6 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   const { toast } = useToast();
   const tracker = useExportTracker();
   const exportGuard: ActionActivationGuard = {};
-  const { addTask, updateTableExportTask, registerTaskCancelHandler, unregisterTaskCancelHandler, removeTask } = useExportTracker();
 
   const {
     columns,
@@ -618,6 +619,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             status: "Running",
             errorMessage: null,
             filePath: null,
+            startedAt: Date.now(),
+            finishedAt: undefined,
           };
           exportProgressDialog.value = true;
         }
@@ -667,6 +670,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             status: "Done",
             rowsExported: result.rows.length,
             totalRows: result.rows.length,
+            finishedAt: Date.now(),
           };
         }
         toast(t("grid.exported"));
@@ -855,6 +859,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             status: "Running",
             errorMessage: null,
             filePath: outputPath,
+            startedAt: Date.now(),
+            finishedAt: undefined,
           };
           exportProgressDialog.value = true;
         }
@@ -889,6 +895,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             status: "Done",
             rowsExported: result.rows.length,
             totalRows: result.rows.length,
+            finishedAt: Date.now(),
           };
         }
         toast(t("grid.exported"));
@@ -1025,6 +1032,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
         status: "Running",
         errorMessage: null,
         filePath: outputPath,
+        startedAt: Date.now(),
+        finishedAt: undefined,
       };
     }
     if (exportProgressDialog) exportProgressDialog.value = true;
@@ -1071,6 +1080,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
               totalRows: progress.totalRows,
               status: progress.status,
               errorMessage: progress.errorMessage || null,
+              finishedAt: progress.status === "Done" || progress.status === "Error" || progress.status === "Cancelled" ? Date.now() : exportProgressState.value.finishedAt,
             };
           }
           tracker.updateTableExportTask(exportId, progress);
@@ -1087,7 +1097,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     return true;
   }
 
-  async function exportQueryResultViaBackend(format: "csv" | "xlsx" | "txt", rowIds?: number[], includeSqlSheet = false, useCommentHeader = false): Promise<boolean> {
+  async function exportQueryResultViaBackend(format: "csv" | "xlsx" | "txt" | "sql", rowIds?: number[], includeSqlSheet = false, useCommentHeader = false): Promise<boolean> {
     if (rowIds !== undefined || context.value !== "results" || !queryResultExportRequest) {
       return false;
     }
@@ -1111,7 +1121,14 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
     }
 
     const exportId = uuid();
-    const baseRequest = await queryResultExportRequest({ exportId, filePath: outputPath, format, includeSqlSheet });
+    const baseRequest = await queryResultExportRequest({
+      exportId,
+      filePath: outputPath,
+      format,
+      includeSqlSheet,
+      exportTableName: format === "sql" ? tableMeta.value?.tableName : undefined,
+      exportColumnTypes: format === "sql" ? allColumnTypes.value?.map((type) => type ?? null) : undefined,
+    });
     const columnComments = useCommentHeader ? buildColumnComments(columns.value) : undefined;
     const request = baseRequest ? { ...baseRequest, dateTimeFormat: useSettingsStore().editorSettings.globalDateTimeExportFormat || undefined, numericColumnRightAlign: useSettingsStore().editorSettings.numericColumnRightAlign ?? true, columnComments } : undefined;
     if (!request) throw new Error("Unable to build query result export request");
@@ -1126,6 +1143,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
         status: "Running",
         errorMessage: null,
         filePath: outputPath,
+        startedAt: Date.now(),
+        finishedAt: undefined,
       };
     }
     if (exportProgressDialog) exportProgressDialog.value = true;
@@ -1147,6 +1166,7 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
             totalRows: adjustedTotal,
             status: progress.status,
             errorMessage: progress.errorMessage || null,
+            finishedAt: progress.status === "Done" || progress.status === "Error" || progress.status === "Cancelled" ? Date.now() : exportProgressState.value.finishedAt,
           };
         }
         tracker.updateTableExportTask(exportId, progress);
@@ -1154,6 +1174,25 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
       if (terminalProgress.status === "Done") {
         toast(t("grid.exported"));
       }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (exportProgressState) {
+        exportProgressState.value = {
+          ...exportProgressState.value,
+          status: "Error",
+          errorMessage,
+          finishedAt: Date.now(),
+        };
+      }
+      tracker.updateTableExportTask(exportId, {
+        exportId,
+        tableName: "Query Result",
+        rowsExported: exportProgressState?.value.rowsExported ?? 0,
+        totalRows: exportProgressState?.value.totalRows ?? null,
+        status: "Error",
+        errorMessage,
+      });
+      throw error;
     } finally {
       if (exportCancelHandler) exportCancelHandler.value = null;
       tracker.unregisterTaskCancelHandler(exportId);
@@ -1163,71 +1202,8 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   }
 
   async function exportQueryResultSqlViaBackend(rowIds?: number[]): Promise<boolean> {
-    // Guard: only for query-result context without complete local result, desktop only
-    if (rowIds !== undefined || context.value !== "results" || !queryResultExportRequest) return false;
-    if (databaseType.value === "mongodb") return false;
-    if (hasCompleteLocalResult?.value) return false;
-    if (!isTauriRuntime()) return false; // Web → local export fallback
-
-    // 1. Save dialog FIRST (immediate user feedback)
-    let outputPath = exportFileName("query-result", "sql");
-    const { save } = await import("@tauri-apps/plugin-dialog");
-    const path = await save({
-      defaultPath: outputPath,
-      filters: [{ name: "SQL", extensions: ["sql"] }],
-    });
-    if (!path) return true;
-    outputPath = path as string;
-
-    // 2. Register background task FIRST so its exportId drives the request.
-    //    addTask generates its own ID — capture it so progress callbacks match.
-    const task = addTask(tableMeta.value?.tableName || "Query Result", "sql", outputPath);
-    const taskExportId = task.exportId;
-
-    let request: api.QueryResultExportRequest;
-    try {
-      const built = await queryResultExportRequest({
-        exportId: taskExportId,
-        filePath: outputPath,
-        format: "sql",
-        exportTableName: tableMeta.value?.tableName,
-        exportColumnTypes: allColumnTypes.value?.map((t) => t ?? null) as Array<string | null | undefined> | undefined,
-      });
-      if (!built) {
-        // builder declined — clean up the task we just registered
-        removeTask(taskExportId);
-        return false;
-      }
-      request = built;
-    } catch {
-      removeTask(taskExportId);
-      return false;
-    }
-
-    registerTaskCancelHandler(taskExportId, () => api.cancelQueryResultExport(taskExportId, request.executionId));
-
-    try {
-      await api.startQueryResultExport(request, (progress) => {
-        updateTableExportTask(taskExportId, progress);
-        if (progress.status === "Done") {
-          toast(t("grid.exported"));
-        }
-      });
-    } catch (e) {
-      // 4. Startup rejection → mark task Error (fixes stuck-Running bug)
-      updateTableExportTask(taskExportId, {
-        exportId: taskExportId,
-        tableName: tableMeta.value?.tableName || "Query Result",
-        rowsExported: 0,
-        totalRows: null,
-        status: "Error" as const,
-        errorMessage: (e as Error)?.message || String(e),
-      });
-      throw e;
-    } finally {
-      unregisterTaskCancelHandler(taskExportId);
-    }
-    return true;
+    if (!isTauriRuntime()) return false;
+    return exportQueryResultViaBackend("sql", rowIds);
   }
 
   async function exportSql(rowIds?: number[]) {

--- a/apps/desktop/src/composables/useExportTracker.ts
+++ b/apps/desktop/src/composables/useExportTracker.ts
@@ -175,6 +175,10 @@ function finishDataTransferTask(task: ExportTask) {
   task.finishedAt ??= Date.now();
 }
 
+function finishExportTask(task: ExportTask) {
+  task.finishedAt ??= Date.now();
+}
+
 export function formatDataTransferDuration(elapsedMs: number): string {
   const safeElapsedMs = Math.max(0, Number.isFinite(elapsedMs) ? Math.round(elapsedMs) : 0);
   if (safeElapsedMs < 1000) return `${safeElapsedMs} ms`;
@@ -244,6 +248,7 @@ export function useExportTracker() {
       totalRows: null,
       status: "Running",
       errorMessage: null,
+      startedAt: Date.now(),
     });
     taskMap.set(id, task);
     return task;
@@ -262,6 +267,7 @@ export function useExportTracker() {
       errorMessage: null,
       objectIndex: 0,
       totalObjects: 0,
+      startedAt: Date.now(),
     });
     taskMap.set(exportId, task);
     return task;
@@ -380,6 +386,7 @@ export function useExportTracker() {
     task.totalRows = progress.totalRows;
     task.status = normalizeExportStatus(progress.status);
     task.errorMessage = progress.errorMessage || null;
+    if (task.status === "Done" || task.status === "Error" || task.status === "Cancelled") finishExportTask(task);
   }
 
   function updateDatabaseExportTask(exportId: string, progress: api.ExportProgress & { overallPercent?: number }) {
@@ -398,6 +405,7 @@ export function useExportTracker() {
     if (progress.overallPercent !== undefined) {
       task.overallPercent = Math.max(0, Math.min(100, Math.round(progress.overallPercent)));
     }
+    if (task.status === "Done" || task.status === "Error" || task.status === "Cancelled") finishExportTask(task);
   }
 
   function updateSqlFileTask(executionId: string, progress: api.SqlFileProgress) {

--- a/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
@@ -10,7 +10,6 @@ import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 import { joinExportedDdls } from "@/lib/export/ddlExport";
-import { formatSqlInsert } from "@/lib/export/exportFormats";
 import { translateBackendError } from "@/i18n/backend-errors";
 import { sidebarStructureExportTargets } from "@/lib/sidebar/sidebarExportRuntime";
 import { fetchTableDataForExport } from "@/lib/table/tableDataExport";
@@ -28,7 +27,7 @@ interface SidebarTreeExportRuntimeOptions {
 export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOptions) {
   const { t } = useI18n();
   const { toast } = useToast();
-  const { addTask: addExportTask } = useExportTracker();
+  const { addTask: addExportTask, updateTableExportTask } = useExportTracker();
   const { activeNode, connectionStore, settingsStore } = options;
 
   async function saveFileContent(content: string, defaultFileName: string, filterName: string, filterExt: string) {
@@ -195,12 +194,7 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
     }
   }
 
-  function columnTypesForResultColumns(columns: string[], tableColumns: ColumnInfo[]): Array<string | undefined> {
-    const typesByName = new Map(tableColumns.map((column) => [column.name.toLocaleLowerCase(), column.data_type]));
-    return columns.map((column) => typesByName.get(column.toLocaleLowerCase()));
-  }
-
-  async function exportDataLegacy(format: "json" | "sql") {
+  async function exportDataLegacy(format: "json") {
     const node = activeNode.value;
     if (!node.connectionId || !node.database) return;
     const connectionId = node.connectionId;
@@ -210,8 +204,7 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
 
     try {
       await connectionStore.ensureConnected(connectionId);
-      const tableColumns = format === "sql" ? await api.getColumns(connectionId, database, node.schema || database, node.label) : undefined;
-      const queryColumns = config.db_type === "neo4j" ? (tableColumns ?? (await api.getColumns(connectionId, database, node.schema || database, node.label))).map((column) => column.name) : undefined;
+      const queryColumns = config.db_type === "neo4j" ? (await api.getColumns(connectionId, database, node.schema || database, node.label)).map((column) => column.name) : undefined;
       const effectiveDbType = effectiveDatabaseTypeForConnection(config);
       const result = await fetchTableDataForExport({
         databaseType: effectiveDbType,
@@ -233,25 +226,13 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
         }
         await api.exportQueryResultJson(outputPath, result.columns, result.rows);
         toast(t("grid.exported"));
-        return;
       }
-
-      const content = await formatSqlInsert({
-        databaseType: effectiveDbType,
-        schema: node.schema,
-        tableName: node.label,
-        columns: result.columns,
-        columnTypes: tableColumns ? columnTypesForResultColumns(result.columns, tableColumns) : undefined,
-        rows: result.rows,
-      });
-      await saveFileContent(content, `${node.label}.sql`, "SQL", "sql");
-      toast(t("grid.exported"));
     } catch (error: any) {
       toast(t("grid.exportFailed", { message: translateBackendError(t, error) }), 5000);
     }
   }
 
-  async function exportTableData(format: "csv" | "xlsx") {
+  async function exportTableData(format: "csv" | "xlsx" | "sql") {
     const node = activeNode.value;
     if (!node.connectionId || !node.database) return;
     const connectionId = node.connectionId;
@@ -261,20 +242,20 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
 
     let task: ExportTask | null = null;
     try {
-      await connectionStore.ensureConnected(connectionId);
-
       // Choose the destination before registering a background task so cancellation creates no orphan tracker entry.
       let outputPath = `${node.label}.${format}`;
       if (isTauriRuntime()) {
         const { save } = await import("@tauri-apps/plugin-dialog");
+        const filterName = format === "csv" ? "CSV" : format === "xlsx" ? "Excel" : "SQL";
         const path = await save({
           defaultPath: outputPath,
-          filters: [{ name: format === "csv" ? "CSV" : "Excel", extensions: [format] }],
+          filters: [{ name: filterName, extensions: [format] }],
         });
         if (!path) return;
         outputPath = path as string;
       }
 
+      await connectionStore.ensureConnected(connectionId);
       task = addExportTask(node.label, format, outputPath);
       const currentTask = task;
       const queryColumns = config.db_type === "neo4j" ? (await api.getColumns(connectionId, database, node.schema || database, node.label)).map((column) => column.name) : undefined;
@@ -294,10 +275,7 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
       };
 
       await api.startTableExport(request, (progress) => {
-        currentTask.rowsExported = progress.rowsExported;
-        currentTask.totalRows = progress.totalRows;
-        currentTask.status = progress.status;
-        currentTask.errorMessage = progress.errorMessage || null;
+        updateTableExportTask(currentTask.exportId, progress);
         if (progress.status === "Done") toast(t("grid.exported"));
         else if (progress.status === "Error") toast(t("grid.exportFailed", { message: translateBackendError(t, progress.errorMessage || "") }), 5000);
       });
@@ -311,8 +289,8 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
   }
 
   async function exportData(format: "csv" | "json" | "sql") {
-    if (format === "csv") await exportTableData("csv");
-    else await exportDataLegacy(format);
+    if (format === "json") await exportDataLegacy(format);
+    else await exportTableData(format);
   }
 
   async function exportDataXlsx() {

--- a/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
@@ -271,6 +271,7 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
         format,
         columns: queryColumns,
         batchSize: settingsStore.editorSettings.exportBatchSize,
+        skipCount: format === "sql",
         rowLimit,
       };
 

--- a/apps/desktop/src/lib/export/databaseExport.ts
+++ b/apps/desktop/src/lib/export/databaseExport.ts
@@ -66,6 +66,12 @@ export interface AllDatabaseExportPlanItem {
   displayName: string;
 }
 
+export interface DatabaseBackupSnapshotOptions {
+  connectionId: string;
+  database: string;
+  enabled: boolean;
+}
+
 export function buildInsertStatements(options: BuildExportInsertStatementsOptions): Promise<string[]> {
   return api.buildExportInsertStatements(options);
 }
@@ -98,6 +104,23 @@ export async function runDatabaseExportUntilTerminal(request: api.DatabaseExport
       })
       .catch(reject);
   });
+}
+
+export async function runWithDatabaseBackupSnapshot<T>(options: DatabaseBackupSnapshotOptions, operation: (snapshotSessionId: string | undefined) => Promise<T>, shouldPropagateCleanupError: (result: T) => boolean = () => true): Promise<T> {
+  if (!options.enabled) return operation(undefined);
+
+  const snapshot = await api.beginDatabaseBackupSnapshot(options.connectionId, options.database);
+  let result: T | undefined;
+  let operationCompleted = false;
+  try {
+    result = await operation(snapshot.sessionId);
+    operationCompleted = true;
+    return result;
+  } finally {
+    await api.rollbackManualTransaction(snapshot.sessionId).catch((error) => {
+      if (operationCompleted && shouldPropagateCleanupError(result as T)) throw error;
+    });
+  }
 }
 
 export function buildAllDatabaseExportPlan(options: AllDatabaseExportPlanInput): AllDatabaseExportPlanItem[] {

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::sync::RwLock;
 
 use crate::connection::task_client_session_id;
@@ -12,8 +12,7 @@ use crate::sql_dialect::{qualified_table_name, quote_table_identifier, uses_sing
 use crate::transfer::{
     format_ch_array_sql_literal, format_pg_array_sql_literal, is_identity_column_extra,
     is_mysql_generated_column_extra, keyset_pagination_sql_with_identifier_quote, quote_identifier,
-    quote_postgres_string_literal, selected_columns_include_identity_extras, wrap_dameng_identity_insert_sql,
-    wrap_dameng_identity_insert_sql_for_table,
+    quote_postgres_string_literal, wrap_dameng_identity_insert_sql_for_table,
 };
 use crate::types::ObjectSourceKind;
 
@@ -1369,7 +1368,7 @@ fn database_export_metadata_prefetch_concurrency(db_type: DatabaseType) -> usize
     }
 }
 
-fn record_export_error(file: &mut std::fs::File, fail_on_error: bool, message: String) -> Result<(), String> {
+fn record_export_error<W: Write>(file: &mut W, fail_on_error: bool, message: String) -> Result<(), String> {
     if fail_on_error {
         Err(message)
     } else {
@@ -1383,8 +1382,8 @@ fn database_export_select_sql(columns: &[String], table: &str, schema: &str, db_
     format!("SELECT {columns} FROM {table}")
 }
 
-fn write_database_export_rows(
-    file: &mut std::fs::File,
+fn write_database_export_rows<W: Write>(
+    file: &mut W,
     rows: &[Vec<Value>],
     columns: &[String],
     column_types: &[Option<String>],
@@ -1434,28 +1433,21 @@ fn write_database_export_rows(
             filtered_rows.as_slice(),
         )
     };
-    let mut insert_sql = crate::transfer::generate_insert_typed(
-        insert_columns,
-        insert_column_types,
-        insert_rows,
-        table,
-        schema,
-        db_type,
-        None,
-    );
-    if *db_type == DatabaseType::Dameng
-        && selected_columns_include_identity_extras(insert_columns, insert_column_extras)
-    {
-        insert_sql = wrap_dameng_identity_insert_sql(&insert_sql, table, schema);
+    let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+        database_type: Some(*db_type),
+        schema: (!schema.is_empty()).then(|| schema.to_string()),
+        table_name: Some(table.to_string()),
+        qualified_table_name: None,
+        columns: insert_columns.to_vec(),
+        column_types: insert_column_types.to_vec(),
+        column_extras: insert_column_extras.to_vec(),
+        rows: insert_rows.to_vec(),
+        batch_size: Some(DATABASE_EXPORT_INSERT_BATCH_SIZE),
+    })?;
+    for statement in statements {
+        writeln!(file, "{statement}\n").map_err(|error| format!("Failed to write file: {error}"))?;
     }
-    if insert_sql.is_empty() {
-        return Ok(());
-    }
-    if insert_sql.trim_end().ends_with(';') {
-        writeln!(file, "{}\n", insert_sql).map_err(|error| format!("Failed to write file: {error}"))
-    } else {
-        writeln!(file, "{};\n", insert_sql).map_err(|error| format!("Failed to write file: {error}"))
-    }
+    Ok(())
 }
 
 fn emit_database_export_running(
@@ -1517,7 +1509,8 @@ pub async fn export_database_sql_core(
     )
     .await?;
     // 4. Create file
-    let mut file = std::fs::File::create(&request.file_path).map_err(|e| format!("Failed to write file: {e}"))?;
+    let file = std::fs::File::create(&request.file_path).map_err(|e| format!("Failed to write file: {e}"))?;
+    let mut file = BufWriter::new(file);
 
     let create_database_preamble = if request.include_create_database && matches!(db_type, DatabaseType::Mysql) {
         Some(mysql_database_export_preamble_for_request(state, request).await)
@@ -2293,6 +2286,8 @@ pub async fn export_database_sql_core(
     if matches!(db_type, DatabaseType::Mysql) {
         writeln!(file, "SET FOREIGN_KEY_CHECKS = 1;").map_err(|e| format!("Failed to write file: {e}"))?;
     }
+
+    file.flush().map_err(|e| format!("Failed to finalize export file: {e}"))?;
 
     // Emit Done progress
     on_progress(ExportProgress {
@@ -3310,7 +3305,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(path).unwrap(),
-            "INSERT INTO `orders` (`id`, `quantity`, `created_at`) VALUES\n(7, 2, '2026-07-30 08:00:00');\n\n"
+            "INSERT INTO `orders` (`id`, `quantity`, `created_at`) VALUES (7, 2, '2026-07-30 08:00:00');\n\n"
         );
     }
 

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1433,11 +1433,15 @@ fn write_database_export_rows<W: Write>(
             filtered_rows.as_slice(),
         )
     };
+    // Database exports use the same table qualification as the SELECT/DDL
+    // path and the legacy typed INSERT writer. In particular, MySQL uses the
+    // selected database rather than a schema-qualified table name.
+    let qualified_table_name = crate::transfer::qualified_table(table, schema, db_type, None);
     let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
         database_type: Some(*db_type),
         schema: (!schema.is_empty()).then(|| schema.to_string()),
         table_name: Some(table.to_string()),
-        qualified_table_name: None,
+        qualified_table_name: Some(qualified_table_name),
         columns: insert_columns.to_vec(),
         column_types: insert_column_types.to_vec(),
         column_extras: insert_column_extras.to_vec(),

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -231,6 +231,7 @@ pub enum ExportStatus {
 pub const DATABASE_EXPORT_ROW_LIMIT: usize = 10_000;
 pub const DATABASE_EXPORT_PAGE_SIZE: usize = 500;
 pub const DATABASE_EXPORT_INSERT_BATCH_SIZE: usize = 100;
+pub const DATABASE_EXPORT_TARGET_STATEMENT_BYTES: usize = 512 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PostgresExportSequence {
@@ -859,7 +860,12 @@ pub fn build_export_insert_statements(options: BuildExportInsertStatementsOption
     let batch_size = if options.database_type.is_some_and(uses_single_row_insert_statements) {
         1
     } else {
-        options.batch_size.unwrap_or(DATABASE_EXPORT_INSERT_BATCH_SIZE).max(1)
+        let requested = options.batch_size.unwrap_or(DATABASE_EXPORT_INSERT_BATCH_SIZE).max(1);
+        if options.database_type == Some(DatabaseType::SqlServer) {
+            requested.min(1000)
+        } else {
+            requested
+        }
     };
     let columns = insert_columns
         .iter()
@@ -872,35 +878,67 @@ pub fn build_export_insert_statements(options: BuildExportInsertStatementsOption
             is_identity_column_extra(options.column_extras.get(*index).and_then(|value| value.as_deref()))
         });
 
-    for rows in options.rows.chunks(batch_size) {
-        let values = rows
-            .iter()
-            .map(|row| {
-                let values = insert_columns
-                    .iter()
-                    .map(|(index, _)| {
-                        let value = row.get(*index).unwrap_or(&Value::Null);
-                        format_export_sql_literal_typed(
-                            value,
-                            options.database_type,
-                            options.column_types.get(*index).and_then(|value| value.as_deref()),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("({values})")
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        let insert_sql = format!("INSERT INTO {table} ({columns}) VALUES {values};");
+    let statement_prefix = format!("INSERT INTO {table} ({columns}) VALUES ");
+    let statement_overhead_bytes = export_sql_statement_bytes(options.database_type, &statement_prefix) + 1;
+    let target_statement_bytes = DATABASE_EXPORT_TARGET_STATEMENT_BYTES;
+    let separator_bytes = export_sql_statement_bytes(options.database_type, ", ");
+    let mut current_values = Vec::with_capacity(batch_size);
+    let mut current_values_bytes = 0usize;
+
+    let flush_values = |statements: &mut Vec<String>, values: &mut Vec<String>, values_bytes: &mut usize| {
+        if values.is_empty() {
+            return;
+        }
+        let insert_sql = format!("{statement_prefix}{};", values.join(", "));
         if needs_dameng_identity_insert {
             statements.push(wrap_dameng_identity_insert_sql_for_table(&insert_sql, &table));
         } else {
             statements.push(insert_sql);
         }
+        values.clear();
+        *values_bytes = 0;
+    };
+
+    for row in options.rows {
+        let row_values = insert_columns
+            .iter()
+            .map(|(index, _)| {
+                let value = row.get(*index).unwrap_or(&Value::Null);
+                format_export_sql_literal_typed(
+                    value,
+                    options.database_type,
+                    options.column_types.get(*index).and_then(|value| value.as_deref()),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let rendered_row = format!("({row_values})");
+        let rendered_row_bytes = export_sql_statement_bytes(options.database_type, &rendered_row);
+        let candidate_bytes = statement_overhead_bytes
+            + current_values_bytes
+            + if current_values.is_empty() { 0 } else { separator_bytes }
+            + rendered_row_bytes;
+
+        if !current_values.is_empty()
+            && (current_values.len() >= batch_size || candidate_bytes > target_statement_bytes)
+        {
+            flush_values(&mut statements, &mut current_values, &mut current_values_bytes);
+        }
+        current_values_bytes += if current_values.is_empty() { 0 } else { separator_bytes };
+        current_values_bytes += rendered_row_bytes;
+        current_values.push(rendered_row);
     }
+    flush_values(&mut statements, &mut current_values, &mut current_values_bytes);
 
     Ok(statements)
+}
+
+fn export_sql_statement_bytes(database_type: Option<DatabaseType>, text: &str) -> usize {
+    if database_type == Some(DatabaseType::SqlServer) {
+        text.encode_utf16().count() * 2
+    } else {
+        text.len()
+    }
 }
 
 pub(crate) fn is_internal_export_column(database_type: Option<DatabaseType>, column: &str) -> bool {
@@ -2668,6 +2706,46 @@ mod tests {
             statements,
             vec!["INSERT INTO `notes` (`body`) VALUES ('line1\\nline2\\tcol\\rend\\\\slash\\0\\ZO''Hara');"]
         );
+    }
+
+    #[test]
+    fn export_insert_batches_split_on_statement_bytes() {
+        let long_value = "x".repeat(300_000);
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::Mysql),
+            schema: None,
+            table_name: Some("payloads".to_string()),
+            qualified_table_name: None,
+            columns: vec!["payload".to_string()],
+            column_types: vec![Some("longtext".to_string())],
+            column_extras: Vec::new(),
+            rows: vec![vec![json!(long_value.clone())], vec![json!(long_value)]],
+            batch_size: Some(100),
+        })
+        .unwrap();
+
+        assert_eq!(statements.len(), 2);
+        assert!(statements.iter().all(|statement| statement.matches("INSERT INTO").count() == 1));
+    }
+
+    #[test]
+    fn sqlserver_export_caps_multi_row_insert_at_1000_rows() {
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::SqlServer),
+            schema: Some("dbo".to_string()),
+            table_name: Some("items".to_string()),
+            qualified_table_name: None,
+            columns: vec!["id".to_string()],
+            column_types: vec![Some("int".to_string())],
+            column_extras: Vec::new(),
+            rows: (0..1001).map(|id| vec![json!(id)]).collect(),
+            batch_size: Some(2000),
+        })
+        .unwrap();
+
+        assert_eq!(statements.len(), 2);
+        assert_eq!(statements[0].matches("), (").count(), 999);
+        assert_eq!(statements[1].matches("), (").count(), 0);
     }
 
     #[test]

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -11,8 +11,8 @@ use crate::object_source_sql::build_export_object_source_sql;
 use crate::sql_dialect::{qualified_table_name, quote_table_identifier, uses_single_row_insert_statements};
 use crate::transfer::{
     format_ch_array_sql_literal, format_pg_array_sql_literal, is_identity_column_extra,
-    is_mysql_generated_column_extra, quote_identifier, quote_postgres_string_literal,
-    selected_columns_include_identity_extras, wrap_dameng_identity_insert_sql,
+    is_mysql_generated_column_extra, keyset_pagination_sql_with_identifier_quote, quote_identifier,
+    quote_postgres_string_literal, selected_columns_include_identity_extras, wrap_dameng_identity_insert_sql,
     wrap_dameng_identity_insert_sql_for_table,
 };
 use crate::types::ObjectSourceKind;
@@ -2000,24 +2000,21 @@ pub async fn export_database_sql_core(
                     )
                     .await?;
                 } else {
-                    let count_query = crate::transfer::count_sql(table_name, &request.schema, &db_type, None);
-                    let total_rows = match crate::transfer::execute_read_on_pool(state, &pool_key, &count_query).await {
-                        Ok(result) => {
-                            let count = result.rows.first().and_then(|row| row.first()).and_then(|value| match value {
-                                serde_json::Value::Number(number) => number.as_u64(),
-                                serde_json::Value::String(text) => text.parse::<u64>().ok(),
-                                _ => None,
-                            });
-                            if request.fail_on_error && count.is_none() {
-                                return Err(format!("Failed to read row count for table {table_name}"));
-                            }
-                            count
-                        }
-                        Err(error) if request.fail_on_error => {
-                            return Err(format!("Failed to read row count for table {table_name}: {error}"));
-                        }
-                        Err(_) => None,
-                    };
+                    // Exact COUNT(*) is deliberately skipped for manual database exports. It adds a full
+                    // table scan before the real read and does not improve correctness. Progress reports
+                    // exported rows while total_rows remains indeterminate.
+                    let total_rows = None;
+                    let primary_keys = columns
+                        .iter()
+                        .filter(|column| column.is_primary_key)
+                        .map(|column| column.name.clone())
+                        .collect::<Vec<_>>();
+                    let primary_key_indices = primary_keys
+                        .iter()
+                        .filter_map(|primary_key| col_names.iter().position(|column| column == primary_key))
+                        .collect::<Vec<_>>();
+                    let use_keyset = !primary_keys.is_empty() && primary_key_indices.len() == primary_keys.len();
+                    let mut last_primary_key_values = Vec::new();
                     let mut offset = 0_u64;
 
                     loop {
@@ -2036,14 +2033,27 @@ pub async fn export_database_sql_core(
                             return Ok(());
                         }
 
-                        let sql = crate::transfer::pagination_sql(
-                            &col_names,
-                            table_name,
-                            &request.schema,
-                            &db_type,
-                            offset,
-                            batch_size,
-                        );
+                        let sql = if use_keyset {
+                            keyset_pagination_sql_with_identifier_quote(
+                                &col_names,
+                                table_name,
+                                &request.schema,
+                                &db_type,
+                                &primary_keys,
+                                &last_primary_key_values,
+                                batch_size,
+                                None,
+                            )
+                        } else {
+                            crate::transfer::pagination_sql(
+                                &col_names,
+                                table_name,
+                                &request.schema,
+                                &db_type,
+                                offset,
+                                batch_size,
+                            )
+                        };
                         let result = match crate::transfer::execute_read_on_pool(state, &pool_key, &sql).await {
                             Ok(result) => result,
                             Err(error) => {
@@ -2070,7 +2080,14 @@ pub async fn export_database_sql_core(
                             &db_type,
                         )?;
                         total_rows_exported += row_count as u64;
-                        offset += row_count as u64;
+                        if use_keyset {
+                            if let Some(last_row) = result.rows.last() {
+                                last_primary_key_values =
+                                    primary_key_indices.iter().map(|&index| last_row[index].clone()).collect();
+                            }
+                        } else {
+                            offset += row_count as u64;
+                        }
                         on_progress(ExportProgress {
                             export_id: request.export_id.clone(),
                             current_object: table_name.clone(),

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1292,7 +1292,8 @@ pub(crate) fn is_mysql_generated_column_extra(extra: Option<&str>) -> bool {
     })
 }
 
-pub(crate) fn selected_columns_include_identity_extras(columns: &[String], column_extras: &[Option<String>]) -> bool {
+#[cfg(test)]
+fn selected_columns_include_identity_extras(columns: &[String], column_extras: &[Option<String>]) -> bool {
     columns
         .iter()
         .enumerate()
@@ -1344,7 +1345,8 @@ fn dameng_identity_insert_statement(table: &str, schema: &str, enabled: bool) ->
     format!("SET IDENTITY_INSERT {full_table} {}", if enabled { "ON" } else { "OFF" })
 }
 
-pub(crate) fn wrap_dameng_identity_insert_sql(insert_sql: &str, table: &str, schema: &str) -> String {
+#[cfg(test)]
+fn wrap_dameng_identity_insert_sql(insert_sql: &str, table: &str, schema: &str) -> String {
     let full_table = qualified_table(table, schema, &DatabaseType::Dameng, None);
     wrap_dameng_identity_insert_sql_for_table(insert_sql, &full_table)
 }

--- a/packages/app-tests/databaseExportSnapshot.test.ts
+++ b/packages/app-tests/databaseExportSnapshot.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { beforeEach, test, vi } from "vitest";
+
+const { beginDatabaseBackupSnapshot, rollbackManualTransaction } = vi.hoisted(() => ({
+  beginDatabaseBackupSnapshot: vi.fn(),
+  rollbackManualTransaction: vi.fn(),
+}));
+
+vi.mock("@/lib/backend/api", () => ({
+  beginDatabaseBackupSnapshot,
+  rollbackManualTransaction,
+}));
+
+import { runWithDatabaseBackupSnapshot } from "../../apps/desktop/src/lib/export/databaseExport.ts";
+
+beforeEach(() => {
+  beginDatabaseBackupSnapshot.mockReset();
+  rollbackManualTransaction.mockReset();
+  beginDatabaseBackupSnapshot.mockResolvedValue({ sessionId: "snapshot-1" });
+  rollbackManualTransaction.mockResolvedValue({});
+});
+
+test("database export snapshot is released after success", async () => {
+  const operation = vi.fn(async (sessionId: string | undefined) => `done:${sessionId}`);
+
+  const result = await runWithDatabaseBackupSnapshot({ connectionId: "conn-1", database: "app", enabled: true }, operation);
+
+  assert.equal(result, "done:snapshot-1");
+  assert.deepEqual(operation.mock.calls, [["snapshot-1"]]);
+  assert.deepEqual(rollbackManualTransaction.mock.calls, [["snapshot-1"]]);
+});
+
+test("database export snapshot is released without masking an export error", async () => {
+  const exportError = new Error("export failed");
+  const cleanupError = new Error("cleanup failed");
+  rollbackManualTransaction.mockRejectedValue(cleanupError);
+
+  await assert.rejects(
+    runWithDatabaseBackupSnapshot({ connectionId: "conn-1", database: "app", enabled: true }, async () => {
+      throw exportError;
+    }),
+    exportError,
+  );
+
+  assert.deepEqual(rollbackManualTransaction.mock.calls, [["snapshot-1"]]);
+});
+
+test("database export snapshot is released after cancellation", async () => {
+  const cleanupError = new Error("cleanup failed");
+  rollbackManualTransaction.mockRejectedValue(cleanupError);
+
+  const result = await runWithDatabaseBackupSnapshot(
+    { connectionId: "conn-1", database: "app", enabled: true },
+    async () => ({ status: "Cancelled" as const }),
+    (terminal) => terminal.status === "Done",
+  );
+
+  assert.equal(result.status, "Cancelled");
+  assert.deepEqual(rollbackManualTransaction.mock.calls, [["snapshot-1"]]);
+});
+
+test("database export snapshot cleanup failure is reported after success", async () => {
+  const cleanupError = new Error("cleanup failed");
+  rollbackManualTransaction.mockRejectedValue(cleanupError);
+
+  await assert.rejects(
+    runWithDatabaseBackupSnapshot({ connectionId: "conn-1", database: "app", enabled: true }, async () => "done"),
+    cleanupError,
+  );
+});


### PR DESCRIPTION
## 变更说明

 优化 SQL 导出性能并统一导出进度交互

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端
添加耗时统计

<img width="714" height="204" alt="image" src="https://github.com/user-attachments/assets/27c26d6c-783e-4957-8cb7-4e0cc98487b4" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

 
<!--StartFragment--><p>在 PostgreSQL 16.14、50 万行测试表上：</p><div><div><div>
格式 | 耗时 | 输出大小
-- | -- | --
CSV | 16.891s | 76.75 MiB
SQL | 20.821s | 133.49 MiB
XLSX | 43.361s | 38.63 MiB

 
## 关联 Issue
https://github.com/t8y2/dbx/issues/5310
 