### PR TITLE
fix(postgresql): 避免枚举字段查询回退到文本协议

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -476,6 +476,7 @@ fn pg_type_requires_text_protocol(pg_type: &Type, col_type: PgColType) -> bool {
     }
 
     match pg_type.kind() {
+        Kind::Enum(_) => false,
         Kind::Array(element_type) => element_type.oid() >= POSTGRES_FIRST_NORMAL_OBJECT_ID,
         Kind::Simple => pg_scalar_type_requires_text_protocol(pg_type.oid(), col_type),
         _ => pg_type.oid() >= POSTGRES_FIRST_NORMAL_OBJECT_ID,
@@ -4802,6 +4803,21 @@ mod tests {
             Type::new("_record".to_string(), Type::RECORD_ARRAY.oid(), Kind::Simple, "pg_catalog".to_string());
         assert!(pg_type_requires_text_protocol(&dynamic_record, PgColType::Other));
         assert!(pg_type_requires_text_protocol(&dynamic_record_array, PgColType::GenericArray));
+    }
+
+    #[test]
+    fn postgres_enum_keeps_binary_protocol() {
+        let enum_type = Type::new(
+            "withdraw_btc_status".to_string(),
+            98_765,
+            Kind::Enum(vec!["pending".to_string(), "completed".to_string()]),
+            "risk".to_string(),
+        );
+        let enum_array =
+            Type::new("_withdraw_btc_status".to_string(), 98_766, Kind::Array(enum_type.clone()), "risk".to_string());
+
+        assert!(!pg_type_requires_text_protocol(&enum_type, PgColType::Other));
+        assert!(pg_type_requires_text_protocol(&enum_array, PgColType::GenericArray));
     }
 
     #[test]


### PR DESCRIPTION
PR 标题：fix(postgresql): 避免标量枚举查询回退到文本协议

## 修改概述

修复 PostgreSQL 查询结果包含自定义标量枚举时的性能回退问题。

此前，只要查询结果中包含 PostgreSQL 自定义枚举字段，DBX 就会把整条查询从预处理二进制协议切换到 `simple_query_raw` 文本协议。

对于字段较多、返回数据量较大的查询，文本协议会带来额外的传输和解析开销。在高延迟网络环境下，这个问题更加明显，最终可能超过 DBX 默认的查询超时时间。

## 问题表现

PostgreSQL 连接和测试连接均可以正常完成，但查询包含自定义枚举字段的数据表时，可能出现执行阶段超时：

> 数据库操作超时（阶段：execute），查询执行超过默认超时时间。

例如存在以下完全中性的测试类型和数据表：

```sql
CREATE TYPE sample_state AS ENUM (
  'state_a',
  'state_b'
);

CREATE TABLE sample_records (
  id bigint PRIMARY KEY,
  state sample_state NOT NULL,
  data jsonb,
  created_at timestamptz NOT NULL
);
```

不包含枚举字段的查询可以正常使用预处理二进制协议：

```sql
SELECT id
FROM sample_records
LIMIT 2000;
```

加入枚举字段后，旧逻辑会将整条查询切换到文本协议：

```sql
SELECT id, state
FROM sample_records
LIMIT 2000;
```

字段较多、返回数据量较大的查询受到的影响更加明显：

```sql
SELECT *
FROM sample_records
LIMIT 2000;
```

这个问题容易被误认为是数据库连接异常，但实际上连接仍然正常，额外耗时主要发生在查询结果传输和解析阶段。

## 根本原因

DBX 会检查查询结果中每一列的 PostgreSQL 类型，以判断是否需要切换到文本协议。

之前的判断逻辑将大部分 OID 大于或等于 `16384` 的用户自定义类型都视为二进制协议无法处理的类型。

PostgreSQL 自定义枚举同样使用用户自定义 OID。因此，只要查询结果中存在一个枚举字段，整条查询就会切换到：

```rust
simple_query_raw
```

这意味着不仅枚举字段，查询结果中的整数、时间、JSON、数字和文本等其他字段，也会一起通过文本协议传输和解析。

当查询返回大量宽表数据时，这些额外开销可能导致查询超过默认超时时间。

## 修复方案

将 PostgreSQL 标量枚举识别为二进制查询路径可以处理的类型：

```rust
Kind::Enum(_) => false,
```

DBX 已经实现了 `PgAnyString` 解码器，可以读取 PostgreSQL 自定义类型的原始字节，并将其作为 UTF-8 字符串解析。

PostgreSQL 标量枚举的二进制内容可以通过现有的 `PgAnyString` 解码为枚举标签，因此不需要将整条查询切换到文本协议。

修复后：

- 标量枚举字段继续使用预处理二进制查询路径。
- PostgreSQL 内置字段继续使用各自的原生二进制解码器。
- 枚举值仍然以字符串形式返回。
- Composite 和 Record 等类型继续使用原有文本回退。
- 自定义类型数组及枚举数组保持原有行为和返回格式。

## 修复前后对比

修复前：

```text
SELECT id, state FROM sample_records
        │
        └── state 是用户自定义枚举
                │
                └── 整条查询切换到 simple_query_raw
                        │
                        └── 大数据量查询可能超过默认超时时间
```

修复后：

```text
SELECT id, state FROM sample_records
        │
        ├── id 使用原生二进制解码
        └── state 使用 PgAnyString 解码
                │
                └── 整条查询继续使用预处理二进制协议
```

## 修改范围

本次修改有意保持最小范围，没有删除现有的自定义类型文本回退机制。

以下类型仍然保留原有文本回退行为：

- Composite 类型
- Record 类型
- Domain 等仍需要服务端文本输出的类型
- 自定义类型数组
- 枚举数组

枚举数组暂时不切换到二进制路径，以避免改变其当前的序列化格式和对外返回结构。

## 测试

新增回归测试，验证：

- PostgreSQL 标量枚举不会触发文本协议。
- PostgreSQL 枚举数组仍然保持现有文本回退行为。

执行的检查：

```text
cargo fmt --check
cargo test -p dbx-core postgres_ --lib
```

测试结果：

```text
262 passed
0 failed
7 ignored
```

被忽略的测试均为需要连接真实 PostgreSQL 数据库的 Live 测试。

## 用户影响

修复后，包含 PostgreSQL 标量枚举字段的数据表，不会再因为单个枚举字段而将整个结果集切换到性能较低的文本协议。

以下场景的改善会比较明显：

- 字段数量较多的数据表
- 一次返回大量数据的查询
- 包含多个标量枚举字段的数据表
- 同时包含 JSON、时间和数字等宽字段的数据表
- 高延迟网络环境下的 PostgreSQL 查询