### PR TITLE
Fix：修复 Kingbase 可连接数据库未显示

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -16,6 +16,11 @@ import (
 
 const metadataTimeout = 15 * time.Second
 
+const (
+	kingbaseListDatabasesSQL         = "SELECT datname FROM sys_catalog.sys_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1', 'template2') ORDER BY datname"
+	kingbaseListDatabasesPostgresSQL = "SELECT datname FROM pg_catalog.pg_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1', 'template2') ORDER BY datname"
+)
+
 // Escape '_' so only Kingbase internal SYS_/XLOG_ prefixes are hidden; names
 // such as SYSTEMS and SYSLOG may be user-created schemas in MySQL mode.
 const kingbaseMySQLCompatListSchemasSQL = `SELECT schema_name FROM information_schema.schemata WHERE UPPER(schema_name) <> 'INFORMATION_SCHEMA' AND UPPER(schema_name) NOT LIKE 'SYS\_%' ESCAPE '\' AND UPPER(schema_name) NOT LIKE 'XLOG\_%' ESCAPE '\' ORDER BY schema_name`
@@ -191,8 +196,8 @@ func (s *server) connectionInfo() (map[string]any, error) {
 
 func (s *server) listDatabases() ([]databaseInfo, error) {
 	queries := []string{
-		"SELECT datname FROM sys_catalog.sys_database WHERE NOT datistemplate AND datallowconn ORDER BY datname",
-		"SELECT datname FROM pg_catalog.pg_database WHERE NOT datistemplate AND datallowconn ORDER BY datname",
+		kingbaseListDatabasesSQL,
+		kingbaseListDatabasesPostgresSQL,
 		"SELECT current_database()",
 	}
 	for _, query := range queries {

--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -17,8 +17,8 @@ import (
 const metadataTimeout = 15 * time.Second
 
 const (
-	kingbaseListDatabasesSQL         = "SELECT datname FROM sys_catalog.sys_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1', 'template2') ORDER BY datname"
-	kingbaseListDatabasesPostgresSQL = "SELECT datname FROM pg_catalog.pg_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1', 'template2') ORDER BY datname"
+	kingbaseListDatabasesSQL         = "SELECT datname FROM sys_catalog.sys_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1') ORDER BY datname"
+	kingbaseListDatabasesPostgresSQL = "SELECT datname FROM pg_catalog.pg_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1') ORDER BY datname"
 )
 
 // Escape '_' so only Kingbase internal SYS_/XLOG_ prefixes are hidden; names

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -1006,12 +1006,45 @@ func TestMetadataNormalizationHelpers(t *testing.T) {
 	}
 }
 
+func TestListDatabasesKeepsConnectableCustomTemplates(t *testing.T) {
+	for _, query := range []string{kingbaseListDatabasesSQL, kingbaseListDatabasesPostgresSQL} {
+		lowerQuery := strings.ToLower(query)
+		if !strings.Contains(lowerQuery, "where datallowconn") {
+			t.Fatalf("database query must keep the connectable filter: %s", query)
+		}
+		if strings.Contains(lowerQuery, "not datistemplate") {
+			t.Fatalf("database query must not hide connectable custom templates: %s", query)
+		}
+		if !strings.Contains(lowerQuery, "lower(datname) not in ('template0', 'template1', 'template2')") {
+			t.Fatalf("database query must hide only the standard template databases: %s", query)
+		}
+	}
+
+	state := &metadataDriverState{query: func(query string) (driver.Rows, error) {
+		if query != kingbaseListDatabasesSQL {
+			return nil, errors.New("unexpected query: " + query)
+		}
+		return &valueRows{columns: []string{"datname"}, rows: [][]driver.Value{{"JA_SICP_GEOSMARTER"}}}, nil
+	}}
+	server := newServer()
+	server.db = openMetadataDB(t, state)
+	server.params.Database = "configured"
+
+	databases, err := server.listDatabases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(databases) != 1 || databases[0].Name != "JA_SICP_GEOSMARTER" {
+		t.Fatalf("unexpected databases: %#v", databases)
+	}
+}
+
 func TestListDatabasesFallsBackToPostgresCatalog(t *testing.T) {
 	state := &metadataDriverState{query: func(query string) (driver.Rows, error) {
 		switch {
-		case strings.Contains(query, "sys_catalog.sys_database"):
+		case query == kingbaseListDatabasesSQL:
 			return nil, errors.New("sys catalog unavailable")
-		case strings.Contains(query, "pg_catalog.pg_database"):
+		case query == kingbaseListDatabasesPostgresSQL:
 			return &valueRows{columns: []string{"datname"}, rows: [][]driver.Value{{"app"}, {"test"}}}, nil
 		default:
 			return nil, errors.New("unexpected query: " + query)

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -1015,8 +1015,11 @@ func TestListDatabasesKeepsConnectableCustomTemplates(t *testing.T) {
 		if strings.Contains(lowerQuery, "not datistemplate") {
 			t.Fatalf("database query must not hide connectable custom templates: %s", query)
 		}
-		if !strings.Contains(lowerQuery, "lower(datname) not in ('template0', 'template1', 'template2')") {
+		if !strings.Contains(lowerQuery, "lower(datname) not in ('template0', 'template1')") {
 			t.Fatalf("database query must hide only the standard template databases: %s", query)
+		}
+		if strings.Contains(lowerQuery, "'template2'") {
+			t.Fatalf("database query must keep a connectable database named template2: %s", query)
 		}
 	}
 


### PR DESCRIPTION
 Fixes： #5390 

## 问题

Kingbase 中部分业务数据库会同时标记为 `datistemplate=true` 和 `datallowconn=true`。现有数据库列表查询通过 `NOT datistemplate` 过滤模板库，导致这类实际可连接的业务数据库无法在侧边栏显示，但将其配置为默认库时仍能正常连接。

## 改动

- 数据库列表以 `datallowconn` 作为可连接性判断，不再统一排除所有带模板标记的数据库
- 仅按名称隐藏 Kingbase 标准模板库 `TEMPLATE0`、`TEMPLATE1`、`TEMPLATE2`
- PostgreSQL catalog 回退查询保持相同规则
- 补充自定义模板数据库和 catalog 回退路径的回归测试

## 验证

- `go test ./...`
- `go test -race ./...`
- Kingbase V8 实库验证：创建 `datistemplate=true`、`datallowconn=true` 的临时数据库，确认可直接连接并能通过 agent `list_databases` 返回，同时标准模板库仍保持隐藏；验证后已清理临时数据库
