### PR TITLE
Fix：允许清除已删除字段的索引引用

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -55,6 +55,7 @@ import {
   dataTypeLengthInputValue,
   dataTypeLengthUnitValue,
   defaultNewColumnDataType,
+  filterStructureIndexColumnOptions,
   generateIndexName,
   generateUniqueIndexName,
   getColumnEditorControls,
@@ -2108,11 +2109,10 @@ const availableColumnNames = computed(() =>
 );
 
 const colSearch = ref("");
-const filteredColumnNames = computed(() => {
-  const q = colSearch.value.toLowerCase().trim();
-  if (!q) return availableColumnNames.value;
-  return availableColumnNames.value.filter((c) => c.toLowerCase().includes(q));
-});
+
+function filteredIndexColumnNames(selectedColumns: readonly string[]): string[] {
+  return filterStructureIndexColumnOptions(availableColumnNames.value, selectedColumns, colSearch.value);
+}
 
 function toggleIndexColumn(index: EditableStructureIndex, col: string) {
   const previousColumns = [...index.columns];
@@ -3163,7 +3163,7 @@ watch([activeTab, ddlLoading], ([tab, loading]) => {
                         <div class="px-[var(--structure-cell-px)] pb-1 pt-0.5">
                           <Input v-model="colSearch" :class="structureControlClass" :placeholder="t('grid.search')" @click.stop />
                         </div>
-                        <DropdownMenuCheckboxItem v-for="col in filteredColumnNames" :key="col" :checked="index.columns.includes(col)" :class="index.columns.includes(col) ? 'bg-primary/10' : ''" @select.prevent @click="toggleIndexColumn(index, col)">
+                        <DropdownMenuCheckboxItem v-for="col in filteredIndexColumnNames(index.columns)" :key="col" :checked="index.columns.includes(col)" :class="index.columns.includes(col) ? 'bg-primary/10' : ''" @select.prevent @click="toggleIndexColumn(index, col)">
                           {{ col }}
                         </DropdownMenuCheckboxItem>
                       </DropdownMenuContent>
@@ -3199,7 +3199,7 @@ watch([activeTab, ddlLoading], ([tab, loading]) => {
                         <div class="px-[var(--structure-cell-px)] pb-1 pt-0.5">
                           <Input v-model="colSearch" :class="structureControlClass" :placeholder="t('grid.search')" @click.stop />
                         </div>
-                        <DropdownMenuCheckboxItem v-for="col in filteredColumnNames" :key="col" :checked="index.includedColumns.includes(col)" :class="index.includedColumns.includes(col) ? 'bg-primary/10' : ''" @select.prevent @click="toggleIncludedColumn(index, col)">
+                        <DropdownMenuCheckboxItem v-for="col in filteredIndexColumnNames(index.includedColumns)" :key="col" :checked="index.includedColumns.includes(col)" :class="index.includedColumns.includes(col) ? 'bg-primary/10' : ''" @select.prevent @click="toggleIncludedColumn(index, col)">
                           {{ col }}
                         </DropdownMenuCheckboxItem>
                       </DropdownMenuContent>

--- a/apps/desktop/src/lib/table/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorState.ts
@@ -777,6 +777,15 @@ export function sameStructureIndexType(left: string | null | undefined, right: s
   return normalizeStructureIndexType(left) === normalizeStructureIndexType(right);
 }
 
+/** Keep selected fields removable even after they are no longer available on the table. */
+export function filterStructureIndexColumnOptions(availableColumns: readonly string[], selectedColumns: readonly string[], search = ""): string[] {
+  const availableSet = new Set(availableColumns);
+  const unavailableSelected = selectedColumns.filter((column) => column.trim() && !availableSet.has(column));
+  const options = [...new Set([...unavailableSelected, ...availableColumns])];
+  const query = search.trim().toLowerCase();
+  return query ? options.filter((column) => column.toLowerCase().includes(query)) : options;
+}
+
 export function createIndexDrafts(indexes: IndexInfo[]): EditableStructureIndex[] {
   return indexes.map((index) => ({
     id: `existing:${index.name}`,

--- a/packages/app-tests/tableStructureEditorState.test.ts
+++ b/packages/app-tests/tableStructureEditorState.test.ts
@@ -9,6 +9,7 @@ import {
   createColumnDrafts,
   createIndexDrafts,
   dataTypeLengthInputValue,
+  filterStructureIndexColumnOptions,
   generateIndexName,
   generateUniqueIndexName,
   getColumnEditorControls,
@@ -402,6 +403,12 @@ test("creates editable index drafts and splits pasted column lists", () => {
     ],
   );
   assert.equal(toColumnNames(["id", "name"]), "id, name");
+});
+
+test("keeps unavailable selected index fields removable", () => {
+  assert.deepEqual(filterStructureIndexColumnOptions(["id", "customer_id", "name"], ["platform_code"]), ["platform_code", "id", "customer_id", "name"]);
+  assert.deepEqual(filterStructureIndexColumnOptions(["id", "customer_id", "name"], ["customer_id", "platform_code"]), ["platform_code", "id", "customer_id", "name"]);
+  assert.deepEqual(filterStructureIndexColumnOptions(["id", "customer_id", "name"], ["platform_code"], "PLAT"), ["platform_code"]);
 });
 
 test("normalizes Postgres lowercase index types when creating structure drafts", () => {


### PR DESCRIPTION
## 改动说明

- 修复字段被删除后，索引字段下拉无法取消失效引用的问题
- 将已选但已不在当前表结构中的字段保留在候选列表顶部，支持直接取消或替换
- 同步覆盖普通索引字段和包含列，并保持主键索引不可编辑行为

## 验证

- 使用 MySQL 8.4 测试表验证删除索引字段后可取消旧字段并选择替代字段
- `pnpm -s check`