### PR TITLE
fix(grid): 修复 UI 缩小倍率下 Canvas 表格文字模糊

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -142,7 +142,7 @@ import { dataGridHeaderContentWidth, scrollbarGutterWidth } from "@/lib/dataGrid
 import { canFetchNextDataGridSegment, canGoNextDataGridPage, dataGridTotalRowCountLabelKey, dataGridTruncationHintKey, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal, type DataGridInexactTotalRowCountMode } from "@/lib/dataGrid/dataGridPagination";
 import { dataGridCountQueryOptions } from "@/lib/dataGrid/dataGridQueryOptions";
 import { dataGridBottomScrollTop, dataGridScrollPosition, isDataGridAtScrollBottom, isDataGridNearScrollBottom, isDataGridPrefixAppend, shouldCheckInfiniteScrollAfterScroll, type DataGridScrollPosition } from "@/lib/dataGrid/dataGridInfiniteScroll";
-import { CANVAS_DATA_GRID_ROW_HEIGHT, canvasDataGridActionOverlayWidth, canvasDataGridActionReservedWidth, dataGridSearchMatchKey, drawCanvasDataGrid, type CanvasDevicePixelSize } from "@/lib/dataGrid/canvasDataGridRenderer";
+import { CANVAS_DATA_GRID_ROW_HEIGHT, MAX_CANVAS_DATA_GRID_PIXEL_RATIO, canvasDataGridActionOverlayWidth, canvasDataGridActionReservedWidth, dataGridSearchMatchKey, drawCanvasDataGrid, type CanvasDevicePixelSize } from "@/lib/dataGrid/canvasDataGridRenderer";
 import { DATA_GRID_DARK_STRIPED_ROW_BG, DATA_GRID_LIGHT_STRIPED_ROW_BG, dataGridActiveRowBackground } from "@/lib/dataGrid/dataGridPaintTheme";
 import { createRowLowerTextCache } from "@/lib/dataGrid/dataGridRowLowerText";
 import { dataGridPreviewLabelKey, dataGridSaveActionMode, dataGridSaveToolbarState } from "@/lib/dataGrid/dataGridSaveUi";
@@ -4755,7 +4755,7 @@ const canvasScrollTop = ref(0);
 const canvasHoverCell = ref<{ rowIndex: number; visibleColIdx: number } | null>(null);
 const canvasDevicePixelRatio = ref(typeof window === "undefined" ? 1 : window.devicePixelRatio || 1);
 const canvasMeasuredDevicePixelSize = ref<CanvasDevicePixelSize | null>(null);
-const canvasBackingPixelRatio = computed(() => Math.min(4, Math.max(1, canvasDevicePixelRatio.value * settingsStore.editorSettings.uiScale)));
+const canvasBackingPixelRatio = computed(() => Math.min(MAX_CANVAS_DATA_GRID_PIXEL_RATIO, Math.max(1, canvasDevicePixelRatio.value * settingsStore.editorSettings.uiScale)));
 const useCanvasGridRows = computed(() => dataGridRenderMode.value === "canvas");
 const canvasContentHeight = computed(() => Math.max(1, displayRowCount.value * CANVAS_DATA_GRID_ROW_HEIGHT));
 // Clamp the sticky canvas/overlay to the content width. A viewport-wide sticky surface inflates the

--- a/apps/desktop/src/lib/__tests__/dataGrid/canvasDataGridRendererFrozen.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/canvasDataGridRendererFrozen.spec.ts
@@ -97,6 +97,17 @@ describe("drawCanvasDataGrid with frozen columns", () => {
     });
   });
 
+  it.each([1, 1.125, 1.1875, 1.2345])("keeps the exact observed density when the nominal ratio is %s", (pixelRatio) => {
+    expect(
+      resolveCanvasBackingStoreMetrics({
+        width: 800,
+        height: 400,
+        pixelRatio,
+        devicePixelSize: { cssWidth: 800, cssHeight: 400, pixelWidth: 1000, pixelHeight: 500 },
+      }),
+    ).toEqual({ pixelWidth: 1000, pixelHeight: 500, scaleX: 1.25, scaleY: 1.25, measured: true });
+  });
+
   it("ignores a stale observed size after the CSS viewport changes", () => {
     expect(
       resolveCanvasBackingStoreMetrics({
@@ -108,15 +119,19 @@ describe("drawCanvasDataGrid with frozen columns", () => {
     ).toEqual({ pixelWidth: 1125, pixelHeight: 500, scaleX: 1.25, scaleY: 1.25, measured: false });
   });
 
-  it("caps the observed backing store at the configured pixel ratio", () => {
+  it("caps the observed backing store only at the absolute safety limit", () => {
     expect(
       resolveCanvasBackingStoreMetrics({
         width: 801,
         height: 399,
-        pixelRatio: 4,
+        pixelRatio: 1.125,
         devicePixelSize: { cssWidth: 801, cssHeight: 399, pixelWidth: 4005, pixelHeight: 1995 },
       }),
     ).toEqual({ pixelWidth: 3204, pixelHeight: 1596, scaleX: 4, scaleY: 4, measured: true });
+  });
+
+  it("caps a fallback ratio at the absolute safety limit", () => {
+    expect(resolveCanvasBackingStoreMetrics({ width: 801, height: 399, pixelRatio: 5 })).toEqual({ pixelWidth: 3204, pixelHeight: 1596, scaleX: 4, scaleY: 4, measured: false });
   });
 
   it("draws without errors when frozenColumnCount is 0", () => {

--- a/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
+++ b/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
@@ -3,6 +3,7 @@ import type { RowStatus } from "@/lib/dataGrid/gridRowStatus";
 import { DATA_GRID_DARK_SEARCH_COLORS, resolveDataGridPaintTheme, type DataGridPaintTheme } from "@/lib/dataGrid/dataGridPaintTheme";
 
 export const CANVAS_DATA_GRID_ROW_HEIGHT = 26;
+export const MAX_CANVAS_DATA_GRID_PIXEL_RATIO = 4;
 
 export interface CanvasDevicePixelSize {
   cssWidth: number;
@@ -111,13 +112,15 @@ export interface CanvasBackingStoreMetrics {
 export function resolveCanvasBackingStoreMetrics(options: { width: number; height: number; pixelRatio: number; devicePixelSize?: CanvasDevicePixelSize | null }): CanvasBackingStoreMetrics {
   const width = Math.max(1, options.width);
   const height = Math.max(1, options.height);
-  const fallbackRatio = Math.max(1, options.pixelRatio);
+  const fallbackRatio = Math.min(MAX_CANVAS_DATA_GRID_PIXEL_RATIO, Math.max(1, options.pixelRatio));
   const measured = options.devicePixelSize;
   const measurementMatches = !!measured && Math.abs(measured.cssWidth - width) <= 0.5 && Math.abs(measured.cssHeight - height) <= 0.5 && measured.pixelWidth > 0 && measured.pixelHeight > 0;
   const fallbackPixelWidth = Math.max(1, Math.ceil(width * fallbackRatio));
   const fallbackPixelHeight = Math.max(1, Math.ceil(height * fallbackRatio));
-  const pixelWidth = measurementMatches ? Math.min(measured.pixelWidth, fallbackPixelWidth) : fallbackPixelWidth;
-  const pixelHeight = measurementMatches ? Math.min(measured.pixelHeight, fallbackPixelHeight) : fallbackPixelHeight;
+  const maxPixelWidth = Math.max(1, Math.ceil(width * MAX_CANVAS_DATA_GRID_PIXEL_RATIO));
+  const maxPixelHeight = Math.max(1, Math.ceil(height * MAX_CANVAS_DATA_GRID_PIXEL_RATIO));
+  const pixelWidth = measurementMatches ? Math.min(measured.pixelWidth, maxPixelWidth) : fallbackPixelWidth;
+  const pixelHeight = measurementMatches ? Math.min(measured.pixelHeight, maxPixelHeight) : fallbackPixelHeight;
   return {
     pixelWidth,
     pixelHeight,


### PR DESCRIPTION
## 变更说明

这是 #5312 的后续修复。

#5312 的原始修改使用 `devicePixelContentBoxSize` 设置 Canvas 的精确物理像素尺寸。该版本已经在多个缩小和放大倍率下人工验证，文字均保持清晰。

在合并前追加的 `785c540` 中，为保留 Canvas 4× 像素密度上限，实测尺寸被改为：

```ts
Math.min(measuredPixelSize, fallbackPixelSize)
```

这里将名义 fallback 尺寸同时作为了实测尺寸的上限。UI 缩放小于 100% 时，fallback 会小于浏览器报告的精确物理像素尺寸，导致 backing store 被缩小，Canvas 显示时再次发生重采样，因此 0.75、0.9、0.95 等缩小倍率下文字重新变得模糊。

放大倍率下 fallback 大于实测尺寸，不会截断实测值，所以不受影响。

本 PR 调整为：

- 有效的浏览器实测尺寸始终优先；
- 实测尺寸只受独立的绝对 4× 安全上限限制；
- 测量不可用或过期时继续使用 fallback；
- 4× 上限改为共享常量；
- 补充任意小数倍率和绝对上限测试。

该实现不依赖固定倍率列表，也支持以后增加其他倍率或改为滑块连续缩放。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 只调整 Canvas backing store 的尺寸计算，不改变表格布局、字体、主题或交互。

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

模糊效果参考（来自 #3857）：

<img width="1585" height="733" alt="Canvas table text before the fix" src="https://github.com/user-attachments/assets/234df23d-7e5e-411d-baa8-a8fa40e44bf1" />

## 验证

- [x] Canvas 相关测试通过：2 个测试文件、23 个用例
- [x] `pnpm typecheck` 通过
- [x] Windows release 构建成功
- [x] 人工验证 75%、90%、95%、100% 及放大倍率，Canvas 表格文字均保持清晰

## 关联 Issue

Follow-up to #5312

Fixes #3857