### PR TITLE
Fix/linux disable dmabuf on virtio gpu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -474,9 +474,8 @@ fn linux_appimage_system_gtk_immodules_cache(
 #[cfg(target_os = "linux")]
 fn apply_linux_webkit_rendering_workarounds() {
     let render_devices = linux_drm_render_devices();
-    let has_hardware_render_device = render_devices
-        .iter()
-        .any(|device| !linux_drm_driver_is_software_only(device.driver.as_deref()));
+    let has_hardware_render_device =
+        render_devices.iter().any(|device| !linux_drm_driver_is_software_only(device.driver.as_deref()));
     for (key, value) in linux_webkit_rendering_workarounds(linux_nvidia_driver(), has_hardware_render_device) {
         if std::env::var_os(key).is_none() {
             std::env::set_var(key, value);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -344,6 +344,30 @@ fn linux_drm_render_devices() -> Vec<LinuxDrmRenderDevice> {
     linux_drm_render_devices_from_paths(std::path::Path::new("/sys/class/drm"), std::path::Path::new("/dev/dri"))
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+const LINUX_SOFTWARE_ONLY_DRM_DRIVERS: &[&str] = &[
+    "virtio-pci", // QEMU/KVM virtio-gpu: 2D dumb-buffer only, GL falls back to llvmpipe
+    "virtio_gpu", // virtio-gpu on virtio-mmio/platform buses
+    "qxl",        // QEMU/SPICE 2D display adapter
+    "bochs",      // QEMU/BOCHS VGA (2D only)
+    "cirrus",     // legacy Cirrus VGA (2D only)
+    "vmwgfx",     // VMware SVGA
+    "vboxvideo",  // VirtualBox graphics
+    "xen",        // Xen virtual GPU
+    "udl",        // DisplayLink 2D framebuffer
+    "mgag200",    // Matrox server BMC
+    "ast",        // ASPEED server BMC
+    "hibmc",      // Huawei HiBMC server BMC
+];
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn linux_drm_driver_is_software_only(driver: Option<&str>) -> bool {
+    // 2D-only/virtual drivers leave GL rendering to llvmpipe, where WebKitGTK's
+    // DMABuf compositing drives the gallivm LLVM JIT that can fail to
+    // materialize compositing shaders (blank window on GPU-less VMs).
+    driver.is_none_or(|driver| LINUX_SOFTWARE_ONLY_DRM_DRIVERS.contains(&driver))
+}
+
 #[cfg(target_os = "linux")]
 fn linux_nvidia_driver() -> LinuxNvidiaDriver {
     let devices = linux_drm_render_devices();
@@ -364,7 +388,7 @@ fn linux_nvidia_driver() -> LinuxNvidiaDriver {
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn linux_webkit_rendering_workarounds(
     driver: LinuxNvidiaDriver,
-    has_render_device: bool,
+    has_hardware_render_device: bool,
 ) -> &'static [(&'static str, &'static str)] {
     match driver {
         LinuxNvidiaDriver::Proprietary => {
@@ -377,12 +401,12 @@ fn linux_webkit_rendering_workarounds(
             // Nouveau while the DOM remains interactive.
             &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
         }
-        LinuxNvidiaDriver::None if !has_render_device => {
-            // No DRM render node means Mesa can only render through llvmpipe.
-            // WebKitGTK's DMABuf compositing then drives llvmpipe's gallivm
-            // LLVM JIT, which can fail to materialize the compositing shaders
-            // (blank/white window on GPU-less VMs and servers), so disable the
-            // DMABuf renderer there as well.
+        LinuxNvidiaDriver::None if !has_hardware_render_device => {
+            // No hardware render device means Mesa can only render through
+            // llvmpipe. WebKitGTK's DMABuf compositing then drives llvmpipe's
+            // gallivm LLVM JIT, which can fail to materialize the compositing
+            // shaders (blank/white window on GPU-less VMs and servers), so
+            // disable the DMABuf renderer there as well.
             &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
         }
         LinuxNvidiaDriver::None => {
@@ -449,8 +473,11 @@ fn linux_appimage_system_gtk_immodules_cache(
 
 #[cfg(target_os = "linux")]
 fn apply_linux_webkit_rendering_workarounds() {
-    let has_render_device = !linux_drm_render_devices().is_empty();
-    for (key, value) in linux_webkit_rendering_workarounds(linux_nvidia_driver(), has_render_device) {
+    let render_devices = linux_drm_render_devices();
+    let has_hardware_render_device = render_devices
+        .iter()
+        .any(|device| !linux_drm_driver_is_software_only(device.driver.as_deref()));
+    for (key, value) in linux_webkit_rendering_workarounds(linux_nvidia_driver(), has_hardware_render_device) {
         if std::env::var_os(key).is_none() {
             std::env::set_var(key, value);
         }
@@ -850,12 +877,13 @@ pub(crate) fn apply_desktop_settings(app: &tauri::AppHandle, desktop_settings: &
 mod tests {
     use super::{
         app_menu_copy_support_info_label, app_menu_quit_label, linux_appimage_system_gtk_immodules_cache,
-        linux_appimage_wayland_backend_override, linux_drm_render_devices_from_paths, linux_nvidia_driver_from_state,
-        linux_selected_drm_render_device, linux_webkit_rendering_workarounds, native_window_decorations_override,
-        should_confirm_app_exit_request, should_enable_single_instance, should_fallback_to_native_quit,
-        should_hide_window_on_close, should_setup_desktop_tray, should_show_main_window_after_setup,
-        should_show_main_window_before_setup_tasks, startup_data_dir_mode, tray_menu_labels_for_locale,
-        uses_application_level_icon, LinuxDrmRenderDevice, LinuxNvidiaDriver,
+        linux_appimage_wayland_backend_override, linux_drm_driver_is_software_only,
+        linux_drm_render_devices_from_paths, linux_nvidia_driver_from_state, linux_selected_drm_render_device,
+        linux_webkit_rendering_workarounds, native_window_decorations_override, should_confirm_app_exit_request,
+        should_enable_single_instance, should_fallback_to_native_quit, should_hide_window_on_close,
+        should_setup_desktop_tray, should_show_main_window_after_setup, should_show_main_window_before_setup_tasks,
+        startup_data_dir_mode, tray_menu_labels_for_locale, uses_application_level_icon, LinuxDrmRenderDevice,
+        LinuxNvidiaDriver,
     };
     use crate::data_dir::DataDirMode;
     use std::ffi::OsStr;
@@ -1101,12 +1129,25 @@ mod tests {
             &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
         );
         assert_eq!(linux_webkit_rendering_workarounds(LinuxNvidiaDriver::None, true), &[]);
-        // Without any DRM render node (GPU-less VM / server) Mesa falls back to
-        // llvmpipe, whose DMABuf compositing path can crash the WebKit process.
+        // Without any hardware render device (GPU-less VM / server) Mesa falls
+        // back to llvmpipe, whose DMABuf compositing path can crash the WebKit
+        // process.
         assert_eq!(
             linux_webkit_rendering_workarounds(LinuxNvidiaDriver::None, false),
             &[("WEBKIT_DISABLE_DMABUF_RENDERER", "1")]
         );
+    }
+
+    #[test]
+    fn treats_virtual_and_2d_drm_drivers_as_software_rendering() {
+        assert!(linux_drm_driver_is_software_only(Some("virtio-pci")));
+        assert!(linux_drm_driver_is_software_only(Some("virtio_gpu")));
+        assert!(linux_drm_driver_is_software_only(Some("qxl")));
+        assert!(linux_drm_driver_is_software_only(Some("bochs")));
+        assert!(linux_drm_driver_is_software_only(None));
+        assert!(!linux_drm_driver_is_software_only(Some("amdgpu")));
+        assert!(!linux_drm_driver_is_software_only(Some("i915")));
+        assert!(!linux_drm_driver_is_software_only(Some("nouveau")));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复 Linux 无 GPU 虚拟机（QEMU/KVM virtio-gpu 等虚拟显卡）上 DBX 启动白屏的问题。

**背景**：此前的修复（#92991bcc7）以"是否存在可打开的 DRM render 节点"作为是否禁用 WebKitGTK DMABuf 渲染器的依据。但 virtio-gpu 等虚拟显卡的 `renderD128` 节点存在且可打开（支持 dumb buffer），**却没有 3D 加速能力**——Mesa 的 GL 渲染实际回退到 llvmpipe。此时 WebKitGTK 的 DMABuf 合成路径会驱动 llvmpipe 的 gallivm LLVM JIT 编译合成 shader，在 aarch64 上触发 `JIT session error: Missing definitions ... fs_variant_whole/fs_variant_partial` 崩溃，导致 WebKitWebProcess 挂掉、窗口白屏。

**变更**：
- 新增 `LINUX_SOFTWARE_ONLY_DRM_DRIVERS` 黑名单，覆盖常见无 3D 加速的虚拟/2D 驱动：`virtio-pci`（QEMU/KVM virtio-gpu 在 PCI 总线上的实际驱动名）、`virtio_gpu`、`qxl`、`bochs`、`cirrus`、`vmwgfx`、`vboxvideo`、`xen`、`udl`、`mgag200`、`ast`、`hibmc`。
- 将 `linux_webkit_rendering_workarounds` 的参数从 `has_render_device` 升级为 `has_hardware_render_device`：只要**所有可用 render 节点都属于软件渲染驱动**（或没有节点），就判定为无硬件渲染设备，自动设置 `WEBKIT_DISABLE_DMABUF_RENDERER=1`。
- 保留原有 NVIDIA（专有/nouveau）分支行为不变，AMD/Intel 等真实硬件驱动不受影响（不额外禁用 DMABuf，避免 Wayland 下的性能回退）。

## 变更类型

- [x] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 仅改动 Rust 侧（`src-tauri/src/lib.rs`），不涉及前端。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `cargo test` 通过（195 passed, 0 failed，含新增测试 `treats_virtual_and_2d_drm_drivers_as_software_rendering`）
- [x] `cargo fmt --check` 通过
- [x] `cargo clippy --workspace -D warnings` 通过
- [x] **已自行编译打包 aarch64 rpm，并在 openEuler 24.03 LTS aarch64 无 GPU 虚拟机（virtio-gpu）上部署实测**：启动后窗口正常显示、无白屏，此前复现的 `JIT session error` 消失；不带该修复的 0.5.75 包在同一机器上必现白屏，对照验证有效。

补充说明：本次改动在 `apply_linux_webkit_rendering_workarounds()` 中额外读取一次 `/sys/class/drm` 并逐个 `open` render 节点、读取驱动名，均在进程启动早期完成，开销可忽略。

## 关联 Issue

无（社区无对应 issue，问题由实机复现与排查定位）。
