### PR TITLE
fix(query): Explicitly display the selected chart Y-axis fields

### DIFF
--- a/apps/desktop/src/components/chart/QueryChart.vue
+++ b/apps/desktop/src/components/chart/QueryChart.vue
@@ -6,7 +6,7 @@ import { CanvasRenderer } from "echarts/renderers";
 import { LineChart, BarChart, PieChart } from "echarts/charts";
 import { GridComponent, TooltipComponent, LegendComponent } from "echarts/components";
 import VChart from "vue-echarts";
-import { BarChart3, ChevronDown } from "@lucide/vue";
+import { BarChart3, CheckIcon, ChevronDown } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -163,7 +163,10 @@ const hasData = computed(() => props.result.rows.length > 0 && numericColumnInde
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent class="w-56" align="start" @close-auto-focus.prevent>
-              <DropdownMenuCheckboxItem v-for="col in numericColumnOptions" :key="col.index" :checked="yColumnIndexes.includes(col.index)" class="text-xs" @select.prevent @click="toggleYColumn(col.index)">
+              <DropdownMenuCheckboxItem v-for="col in numericColumnOptions" :key="col.index" :checked="yColumnIndexes.includes(col.index)" :class="['text-xs', yColumnIndexes.includes(col.index) ? 'bg-primary/10' : '']" @select.prevent @click="toggleYColumn(col.index)">
+                <span v-if="yColumnIndexes.includes(col.index)" class="absolute right-2 flex items-center justify-center pointer-events-none">
+                  <CheckIcon />
+                </span>
                 <span class="truncate">{{ col.label }}</span>
               </DropdownMenuCheckboxItem>
             </DropdownMenuContent>

--- a/apps/desktop/src/components/chart/QueryChart.vue
+++ b/apps/desktop/src/components/chart/QueryChart.vue
@@ -6,7 +6,7 @@ import { CanvasRenderer } from "echarts/renderers";
 import { LineChart, BarChart, PieChart } from "echarts/charts";
 import { GridComponent, TooltipComponent, LegendComponent } from "echarts/components";
 import VChart from "vue-echarts";
-import { BarChart3, CheckIcon, ChevronDown } from "@lucide/vue";
+import { BarChart3, ChevronDown } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -60,12 +60,12 @@ watch(
   { immediate: true },
 );
 
-function toggleYColumn(index: number) {
-  const idx = yColumnIndexes.value.indexOf(index);
-  if (idx >= 0) {
-    yColumnIndexes.value = yColumnIndexes.value.filter((selected) => selected !== index);
-  } else {
+function setYColumn(index: number, selected: boolean | "indeterminate") {
+  const isSelected = yColumnIndexes.value.includes(index);
+  if (selected === true && !isSelected) {
     yColumnIndexes.value = [...yColumnIndexes.value, index];
+  } else if (selected !== true && isSelected) {
+    yColumnIndexes.value = yColumnIndexes.value.filter((selected) => selected !== index);
   }
 }
 
@@ -163,10 +163,7 @@ const hasData = computed(() => props.result.rows.length > 0 && numericColumnInde
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent class="w-56" align="start" @close-auto-focus.prevent>
-              <DropdownMenuCheckboxItem v-for="col in numericColumnOptions" :key="col.index" :checked="yColumnIndexes.includes(col.index)" :class="['text-xs', yColumnIndexes.includes(col.index) ? 'bg-primary/10' : '']" @select.prevent @click="toggleYColumn(col.index)">
-                <span v-if="yColumnIndexes.includes(col.index)" class="absolute right-2 flex items-center justify-center pointer-events-none">
-                  <CheckIcon />
-                </span>
+              <DropdownMenuCheckboxItem v-for="col in numericColumnOptions" :key="col.index" :model-value="yColumnIndexes.includes(col.index)" :class="['text-xs', yColumnIndexes.includes(col.index) ? 'bg-primary/10' : '']" @select.prevent @update:model-value="setYColumn(col.index, $event)">
                 <span class="truncate">{{ col.label }}</span>
               </DropdownMenuCheckboxItem>
             </DropdownMenuContent>

--- a/apps/desktop/src/components/chart/__tests__/QueryChartSelection.spec.ts
+++ b/apps/desktop/src/components/chart/__tests__/QueryChartSelection.spec.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const queryChartSource = readFileSync(new URL("../QueryChart.vue", import.meta.url), "utf8");
+
+describe("QueryChart Y-axis selection", () => {
+  it("binds the visible checkbox state to the selected Y columns", () => {
+    expect(queryChartSource).toContain(':model-value="yColumnIndexes.includes(col.index)"');
+    expect(queryChartSource).toContain('@update:model-value="setYColumn(col.index, $event)"');
+    expect(queryChartSource).not.toContain(':checked="yColumnIndexes.includes(col.index)"');
+    expect(queryChartSource).not.toContain('@click="toggleYColumn(col.index)"');
+    expect(queryChartSource).not.toContain("CheckIcon");
+  });
+});


### PR DESCRIPTION
## 变更说明

查询结果图表展示功能中，已选择的Y轴字段增加选中的状态背景及图标。

具体问题参考 #5464 ，但并不与具体数据库相关， 纯粹是前端展示问题。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="578" height="460" alt="image" src="https://github.com/user-attachments/assets/ddd8f218-1dfb-4757-86b6-5ca261e36a42" />

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

Close #5464
