### PR TITLE
Fix: 支持 Oracle 执行错误位置高亮

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -79,7 +79,7 @@ import {
   type SqlObjectNavigationTarget,
 } from "@/lib/sql/sqlNavigation";
 import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
-import { lineColumnToOffset, parseSqlErrorLocation } from "@/lib/sql/sqlDiagnostics";
+import { lineColumnToOffset, sqlErrorDecorationRange as resolveSqlErrorDecorationRange } from "@/lib/sql/sqlDiagnostics";
 import {
   DBX_TABLE_REFERENCE_MIME,
   DBX_TABLE_REFERENCE_DROP_EVENT,
@@ -2208,14 +2208,11 @@ async function resolveSqlHoverTooltip(currentView: EditorViewType, pos: number) 
 function sqlErrorDecorationRange(currentState: import("@codemirror/state").EditorState) {
   if (!props.executionError) return [];
   if (!props.executionErrorSql || props.executionErrorSql !== currentState.doc.toString()) return [];
-  const location = parseSqlErrorLocation(props.executionError);
-  if (!location) return [];
-  const offset = lineColumnToOffset(currentState.doc.toString(), location);
-  if (offset == null) return [];
+  const range = resolveSqlErrorDecorationRange(currentState.doc.toString(), props.executionError);
+  if (!range) return [];
   return [
     {
-      from: offset,
-      to: Math.min(offset + 1, currentState.doc.length),
+      ...range,
       message: props.executionError,
     },
   ];

--- a/apps/desktop/src/lib/sql/sqlDiagnostics.ts
+++ b/apps/desktop/src/lib/sql/sqlDiagnostics.ts
@@ -3,6 +3,11 @@ export interface SqlErrorLocation {
   column: number;
 }
 
+export interface SqlErrorRange {
+  from: number;
+  to: number;
+}
+
 function toZeroBased(value: string | undefined): number | null {
   if (!value) return null;
   const parsed = Number.parseInt(value, 10);
@@ -41,4 +46,49 @@ export function lineColumnToOffset(sql: string, location: SqlErrorLocation): num
   }
 
   return Math.min(offset + location.column, offset + lines[location.line].length);
+}
+
+function oracleInvalidIdentifierRange(sql: string, message: string, position: number): SqlErrorRange | null {
+  const identifierMatch = /\bORA-00904:\s*"((?:""|[^"])*)"\s*:\s*invalid identifier\b/i.exec(message);
+  if (!identifierMatch?.[1]) return null;
+
+  const reportedIdentifier = identifierMatch[1].replace(/""/g, '"');
+  const identifierPattern = /"(?:""|[^"])*"|[\p{L}_][\p{L}\p{N}_$#]*/gu;
+  let bestRange: SqlErrorRange | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const match of sql.matchAll(identifierPattern)) {
+    const token = match[0];
+    const tokenStart = match.index;
+    const quoted = token.startsWith('"');
+    const identifier = quoted ? token.slice(1, -1).replace(/""/g, '"') : token;
+    if (quoted ? identifier !== reportedIdentifier : identifier.toUpperCase() !== reportedIdentifier.toUpperCase()) continue;
+
+    const from = tokenStart + (quoted ? 1 : 0);
+    const to = tokenStart + token.length - (quoted ? 1 : 0);
+    const distance = position < from ? from - position : position > to ? position - to : 0;
+    if (distance >= bestDistance) continue;
+    bestDistance = distance;
+    bestRange = { from, to };
+  }
+
+  return bestRange;
+}
+
+export function sqlErrorDecorationRange(sql: string, message: string): SqlErrorRange | null {
+  const location = parseSqlErrorLocation(message);
+  if (location) {
+    const offset = lineColumnToOffset(sql, location);
+    if (offset == null || offset >= sql.length) return null;
+    return { from: offset, to: offset + 1 };
+  }
+
+  // Oracle Agent reports a zero-based absolute offset. For qualified invalid
+  // identifiers it can point later in the selector, so prefer the named token.
+  const positionMatch = /\berror\s+occur(?:red)?\s+at\s+position\s*:\s*(\d+)\b/i.exec(message);
+  if (!positionMatch?.[1]) return null;
+  const position = Number.parseInt(positionMatch[1], 10);
+  if (!Number.isSafeInteger(position) || position < 0 || position >= sql.length) return null;
+
+  return oracleInvalidIdentifierRange(sql, message, position) ?? { from: position, to: position + 1 };
 }

--- a/packages/app-tests/sqlDiagnostics.test.ts
+++ b/packages/app-tests/sqlDiagnostics.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { parseSqlErrorLocation, sqlErrorDecorationRange } from "../../apps/desktop/src/lib/sql/sqlDiagnostics.ts";
+
+test("locates the Oracle invalid identifier reported by the Agent", () => {
+  const sql = "select x.* from si_price_adjust_task t;";
+  const message = 'ORA-00904: "X": invalid identifier error occur at position: 9';
+
+  assert.deepEqual(sqlErrorDecorationRange(sql, message), { from: 7, to: 8 });
+  assert.equal(sql.slice(7, 8), "x");
+});
+
+test("locates a multi-character qualified Oracle identifier instead of a later selector character", () => {
+  const sql = "SELECT bad.* FROM dual t";
+  const message = 'ORA-00904: "BAD": invalid identifier error occur at position: 11';
+
+  assert.deepEqual(sqlErrorDecorationRange(sql, message), { from: 7, to: 10 });
+});
+
+test("preserves Oracle quoted identifier casing", () => {
+  const sql = 'SELECT "X".*, "x".* FROM dual t';
+  const message = 'ORA-00904: "x": invalid identifier error occur at position: 18';
+
+  assert.deepEqual(sqlErrorDecorationRange(sql, message), { from: 15, to: 16 });
+});
+
+test("uses Oracle Agent absolute positions across lines", () => {
+  const sql = "SELECT 1,\n       missing_col\nFROM dual";
+  const message = 'ORA-00904: "MISSING_COL": invalid identifier error occur at position: 17';
+
+  assert.deepEqual(sqlErrorDecorationRange(sql, message), { from: 17, to: 28 });
+});
+
+test("accepts zero as an Oracle Agent absolute position", () => {
+  const sql = "SELEC 1 FROM dual";
+
+  assert.deepEqual(sqlErrorDecorationRange(sql, "ORA-00900: invalid SQL statement error occur at position: 0"), { from: 0, to: 1 });
+});
+
+test("rejects malformed or out-of-range Oracle Agent positions", () => {
+  assert.equal(sqlErrorDecorationRange("SELECT 1", "error occur at position: nope"), null);
+  assert.equal(sqlErrorDecorationRange("SELECT 1", "error occur at position: 99"), null);
+});
+
+test("keeps existing line-column and PostgreSQL caret parsing", () => {
+  assert.deepEqual(parseSqlErrorLocation("syntax error at line 2, column 4"), { line: 1, column: 3 });
+  assert.deepEqual(parseSqlErrorLocation('ERROR: column "bad" does not exist\nLINE 3: SELECT bad\n               ^'), { line: 2, column: 15 });
+  assert.deepEqual(sqlErrorDecorationRange("SELECT 1\nFROM bad", "syntax error at line 2, column 2"), { from: 10, to: 11 });
+});


### PR DESCRIPTION
## 问题原因

SQL 编辑器已有运行时错误波浪线能力，但只解析 `line/column` 和 PostgreSQL `LINE + ^` 格式。Oracle Agent 返回的是绝对位置，例如：

```text
ORA-00904: "X": invalid identifier error occur at position: 9
```

该格式无法被现有解析器识别，因此执行报错后没有生成 CodeMirror 错误装饰。

## 修复内容

- 支持解析 Oracle Agent 的 0 基绝对错误位置。
- 对 `ORA-00904` 结合错误中的标识符和位置定位实际 SQL token，避免 `x.*` 的位置落在后续选择符上而标错字符。
- 未加引号标识符按 Oracle 大写规则匹配，双引号标识符保持大小写敏感。
- 将“错误消息 + SQL -> 装饰范围”集中在 `sqlDiagnostics`，保留现有行列和 PostgreSQL caret 行为。

## 实际验证

使用 DBX Web 客户端连接真实 Oracle 18c 实例执行：

```sql
select x.* from dual t;
```

后端真实返回 `ORA-00904: "X": invalid identifier error occur at position: 9`，页面生成的 `.cm-sql-error` 文本为 `x`，波浪线精确覆盖无效标识符。另验证了普通语法错误的 `position: 0`、多行 SQL、不同长度标识符和带引号标识符。

测试结果：

- `pnpm vitest run packages/app-tests/sqlDiagnostics.test.ts`：7/7 通过
- `pnpm typecheck`：通过
- `pnpm check`：format、lint、typecheck 通过；全量测试高并发运行时有 8 个文件出现超时/状态抖动，随后以低并发单独重跑这 8 个文件，99/99 通过
- `git diff --check`：通过

Fixes #5391