### PR TITLE
fix(quick-open): clarify search result states

### DIFF
--- a/apps/desktop/src/components/quick-open/QuickOpenDialog.vue
+++ b/apps/desktop/src/components/quick-open/QuickOpenDialog.vue
@@ -198,7 +198,6 @@ watch(
 <style scoped>
 :deep([data-slot="dialog-content"]) {
   border-color: color-mix(in srgb, var(--border) 80%, var(--ring));
-  border-radius: 0.75rem;
   box-shadow: 0 24px 70px rgb(0 0 0 / 0.32);
 }
 
@@ -211,7 +210,6 @@ watch(
 :deep(.dark .bg-yellow-800) {
   background-color: var(--warning-bg) !important;
   border-radius: 0.1875rem;
-  color: var(--warning) !important;
   padding: 0 0.0625rem;
 }
 </style>

--- a/apps/desktop/src/components/quick-open/QuickOpenDialog.vue
+++ b/apps/desktop/src/components/quick-open/QuickOpenDialog.vue
@@ -196,11 +196,22 @@ watch(
 </template>
 
 <style scoped>
-:deep(.bg-yellow-200) {
-  background-color: rgb(254 227 92);
+:deep([data-slot="dialog-content"]) {
+  border-color: color-mix(in srgb, var(--border) 80%, var(--ring));
+  border-radius: 0.75rem;
+  box-shadow: 0 24px 70px rgb(0 0 0 / 0.32);
 }
 
+:deep(.divide-y > div.bg-accent) {
+  background-color: var(--info-bg) !important;
+  box-shadow: inset 3px 0 0 var(--info) !important;
+}
+
+:deep(.bg-yellow-200),
 :deep(.dark .bg-yellow-800) {
-  background-color: rgb(92 51 0);
+  background-color: var(--warning-bg) !important;
+  border-radius: 0.1875rem;
+  color: var(--warning) !important;
+  padding: 0 0.0625rem;
 }
 </style>

--- a/apps/desktop/src/components/quick-open/__tests__/QuickOpenDialogStyle.spec.ts
+++ b/apps/desktop/src/components/quick-open/__tests__/QuickOpenDialogStyle.spec.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const quickOpenDialogSource = readFileSync(new URL("../QuickOpenDialog.vue", import.meta.url), "utf8");
+
+describe("QuickOpenDialog theme styles", () => {
+  it("keeps the shared corner style and readable foreground text", () => {
+    expect(quickOpenDialogSource).toContain('class="max-w-2xl p-0 gap-0 rounded-lg overflow-hidden"');
+    expect(quickOpenDialogSource).toContain("background-color: var(--warning-bg) !important;");
+    expect(quickOpenDialogSource).not.toContain("border-radius: 0.75rem;");
+    expect(quickOpenDialogSource).not.toContain("color: var(--warning) !important;");
+  });
+});


### PR DESCRIPTION
## 变更说明

优化 Ctrl+P 快速搜索结果的视觉层级 优化在暗色模式下搜索后无法看清覆盖的字体：


## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，截图/录屏由提交者补充（见下方）

### 修改前

<!-- 请由提交者在此上传修改前截图 -->
<img width="723" height="478" alt="image" src="https://github.com/user-attachments/assets/59511112-f9dd-4abf-88e2-c9348603773a" />

### 修改后

<!-- 请由提交者在此上传修改后截图 -->
<img width="725" height="505" alt="截屏2026-08-06 14 31 29" src="https://github.com/user-attachments/assets/8b7b05b4-6dda-4921-af0b-b648bb3aab97" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [ ] 相关测试通过（仅样式调整，无独立测试）

## 关联 Issue

<!-- 无 -->