### PR TITLE
feat(grid): support Home, End, PageUp, PageDown and Shift range selec…

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -197,7 +197,8 @@ import { useDataGridColumnLayout, useDataGridColumnLayoutState } from "@/composa
 import { dataGridCanvasDevicePixelSize, useDataGridCanvasRuntime, type DataGridCanvasRuntime } from "@/composables/useDataGridCanvasRuntime";
 import { useDataGridScrollbars, type DataGridScrollbarsRuntime } from "@/composables/useDataGridScrollbars";
 import { useDataGridSelection } from "@/composables/useDataGridSelection";
-import { moveDataGridCell } from "@/lib/dataGrid/dataGridNavigation";
+import { dataGridNavigationOrigin, dataGridRowScrollTop, moveDataGridCell, navigateDataGridCell, type DataGridNavigationDirection, type DataGridScrollAlignment } from "@/lib/dataGrid/dataGridNavigation";
+import type { CellPosition } from "@/lib/dataGrid/gridSelection";
 import { createDataGridRuntimeScope } from "@/lib/dataGrid/dataGridRuntime";
 import { useDataGridEditor } from "@/composables/useDataGridEditor";
 import { useDataGridSort } from "@/composables/useDataGridSort";
@@ -3791,6 +3792,7 @@ const {
   selectColumn,
   selectAllCells,
   extendCellSelectionTo,
+  selectionFocus,
   finishCellSelection,
   extendCellSelection,
   cellIsSelected,
@@ -6218,7 +6220,9 @@ function currentSelectedCellPosition() {
   return { rowIndex: range.startRow, colIndex: range.startCol };
 }
 
-function scrollCellIntoView(rowIndex: number, colIndex: number) {
+const DOM_DATA_GRID_ROW_HEIGHT = 26;
+
+function scrollCellIntoView(rowIndex: number, colIndex: number, block: DataGridScrollAlignment = "nearest") {
   if (isTransposeMode.value) {
     nextTick(() => {
       const scroller = transposeScrollRef.value;
@@ -6232,15 +6236,17 @@ function scrollCellIntoView(rowIndex: number, colIndex: number) {
     return;
   }
   nextTick(() => {
-    scrollGridColumnIntoView(colIndex);
     if (useCanvasGridRows.value) {
-      scrollCanvasRowIntoView(rowIndex, "nearest");
+      scrollGridColumnIntoView(colIndex);
+      scrollCanvasRowIntoView(rowIndex, block);
       return;
     }
-    nextTick(() => {
+    scrollGridColumnIntoView(colIndex);
+    scrollDomRowIntoView(rowIndex, block);
+    requestAnimationFrame(() => {
       const rowEl = gridRef.value?.querySelector<HTMLElement>(`[data-row-index="${rowIndex}"]`);
       const cellEl = rowEl?.querySelector<HTMLElement>(`[data-visible-col-index="${colIndex}"]`);
-      (cellEl ?? rowEl)?.scrollIntoView({ block: "nearest", inline: "nearest" });
+      (cellEl ?? rowEl)?.scrollIntoView({ block, inline: "nearest" });
     });
   });
 }
@@ -6267,18 +6273,40 @@ function scrollGridColumnIntoView(visibleColIdx: number) {
   if (useCanvasGridRows.value) syncCanvasViewport();
 }
 
-function scrollCanvasRowIntoView(rowIndex: number, block: "nearest" | "start") {
+function scrollCanvasRowIntoView(rowIndex: number, block: DataGridScrollAlignment) {
   const target = Math.max(0, Math.min(displayRowCount.value - 1, rowIndex));
   const scroller = canvasScrollerElement();
   if (!scroller) return;
   const rowTop = target * CANVAS_DATA_GRID_ROW_HEIGHT;
   const rowBottom = rowTop + CANVAS_DATA_GRID_ROW_HEIGHT;
-  if (block === "start" || rowTop < scroller.scrollTop) {
+  if (block === "end") {
+    // Align the target row to the bottom of the viewport, even when it is already visible.
+    scroller.scrollTop = Math.max(0, rowBottom - scroller.clientHeight);
+  } else if (block === "start" || rowTop < scroller.scrollTop) {
     scroller.scrollTop = rowTop;
   } else if (rowBottom > scroller.scrollTop + scroller.clientHeight) {
     scroller.scrollTop = Math.max(0, rowBottom - scroller.clientHeight);
   }
   syncCanvasViewport();
+}
+
+function scrollDomRowIntoView(rowIndex: number, block: DataGridScrollAlignment) {
+  const target = Math.max(0, Math.min(displayRowCount.value - 1, rowIndex));
+  const scroller = gridScrollerElement();
+  if (!scroller) return;
+  const nextScrollTop = dataGridRowScrollTop({
+    rowIndex: target,
+    rowHeight: DOM_DATA_GRID_ROW_HEIGHT,
+    viewportHeight: scroller.clientHeight,
+    currentScrollTop: scroller.scrollTop,
+    alignment: block,
+  });
+  const virtualScroller = scrollerRef.value;
+  if (virtualScroller && !(virtualScroller instanceof HTMLElement)) {
+    virtualScroller.scrollToPosition?.(nextScrollTop);
+  } else {
+    scroller.scrollTop = nextScrollTop;
+  }
 }
 
 function scrollGridRowIntoView(rowIndex: number) {
@@ -6288,13 +6316,7 @@ function scrollGridRowIntoView(rowIndex: number) {
       scrollCanvasRowIntoView(target, "start");
       return;
     }
-    const scroller = scrollerRef.value;
-    if (scroller && !(scroller instanceof HTMLElement)) {
-      scroller.scrollToItem?.(target);
-      scroller.scrollToPosition?.(target * 26);
-    } else if (scroller instanceof HTMLElement) {
-      scroller.scrollTop = target * 26;
-    }
+    scrollDomRowIntoView(target, "start");
     requestAnimationFrame(() => {
       const rowEl = gridRef.value?.querySelector<HTMLElement>(`[data-row-index="${target}"]`);
       rowEl?.scrollIntoView({ block: "nearest", inline: "nearest" });
@@ -6350,20 +6372,57 @@ function toggleKeyboardTranspose(): boolean {
   return true;
 }
 
-function moveSelectedCell(rowDelta: number, colDelta: number): boolean {
-  const position = currentSelectedCellPosition();
+// Shared path that selects or extends to nextPosition and scrolls it into view.
+// Used by both moveSelectedCell (relative steps) and navigateSelectedCell (absolute/page jumps).
+function applyCellNavigation(nextPosition: CellPosition, extend = false, block: DataGridScrollAlignment = "nearest"): boolean {
+  invalidateSyntheticContextSelection();
+  if (extend) extendCellSelectionTo(nextPosition.rowIndex, nextPosition.colIndex);
+  else selectSingleCell(nextPosition.rowIndex, nextPosition.colIndex);
+  clearRowSelection();
+  if (showTranspose.value) transposeRowIndex.value = nextPosition.rowIndex;
+  scrollCellIntoView(nextPosition.rowIndex, nextPosition.colIndex, block);
+  return true;
+}
+
+function moveSelectedCell(rowDelta: number, colDelta: number, extend = false): boolean {
+  const position = dataGridNavigationOrigin(currentSelectedCellPosition(), selectionFocus.value, extend);
   if (!position || editingCell.value || displayRowCount.value === 0 || visibleColumnIndexes.value.length === 0) return false;
   const nextPosition = moveDataGridCell(position, rowDelta, colDelta, {
     rowCount: displayRowCount.value,
     visibleColumnCount: visibleColumnIndexes.value.length,
   });
   if (!nextPosition) return false;
-  invalidateSyntheticContextSelection();
-  selectSingleCell(nextPosition.rowIndex, nextPosition.colIndex);
-  clearRowSelection();
-  if (showTranspose.value) transposeRowIndex.value = nextPosition.rowIndex;
-  scrollCellIntoView(nextPosition.rowIndex, nextPosition.colIndex);
-  return true;
+  return applyCellNavigation(nextPosition, extend);
+}
+
+// Rows moved by a single PageUp/PageDown, i.e. one viewport worth of rows.
+// Canvas mode computes this from its fixed row height; the DOM virtual scroller reuses the same
+// approximate row height (26px) that scrollGridRowIntoView relies on.
+function gridPageRowCount(): number {
+  const canvasMode = useCanvasGridRows.value;
+  const scroller = canvasMode ? canvasScrollerElement() : gridScrollerElement();
+  if (!scroller) return 1;
+  const rowHeight = canvasMode ? CANVAS_DATA_GRID_ROW_HEIGHT : DOM_DATA_GRID_ROW_HEIGHT;
+  if (rowHeight <= 0) return 1;
+  return Math.max(1, Math.floor(scroller.clientHeight / rowHeight));
+}
+
+// Direction-based absolute movement for Home/End/PageUp/PageDown, including their Ctrl combinations.
+// Transpose mode is handled by a dedicated branch in onGridKeydown, so this always assumes the normal grid.
+// When extend is true (Shift combinations) the anchor stays put and only the focus moves, growing the range.
+function navigateSelectedCell(direction: DataGridNavigationDirection, extend = false): boolean {
+  // While extending, move from the focus end of the range; fall back to the range start for a single selection.
+  const position = dataGridNavigationOrigin(currentSelectedCellPosition(), selectionFocus.value, extend);
+  if (!position || editingCell.value || displayRowCount.value === 0 || visibleColumnIndexes.value.length === 0) return false;
+  const nextPosition = navigateDataGridCell(position, direction, {
+    rowCount: displayRowCount.value,
+    visibleColumnCount: visibleColumnIndexes.value.length,
+    pageRowCount: gridPageRowCount(),
+  });
+  if (!nextPosition) return false;
+  // docHome/docEnd must reach the very start/end of the grid even if the target row is already visible, so "nearest" is not used.
+  const block: DataGridScrollAlignment = direction === "docHome" ? "start" : direction === "docEnd" ? "end" : "nearest";
+  return applyCellNavigation(nextPosition, extend, block);
 }
 
 function editSelectedCell(): boolean {
@@ -6564,36 +6623,54 @@ async function onGridKeydown(event: KeyboardEvent) {
     return;
   }
   if (isTransposeMode.value) {
-    if (event.key === "ArrowUp" && moveSelectedCell(0, -1)) {
+    if (event.key === "ArrowUp" && moveSelectedCell(0, -1, event.shiftKey)) {
       event.preventDefault();
       return;
     }
-    if (event.key === "ArrowDown" && moveSelectedCell(0, 1)) {
+    if (event.key === "ArrowDown" && moveSelectedCell(0, 1, event.shiftKey)) {
       event.preventDefault();
       return;
     }
-    if (event.key === "ArrowLeft" && (moveSelectedCell(-1, 0) || moveTransposeRecordSelection(-1))) {
+    if (event.key === "ArrowLeft" && (moveSelectedCell(-1, 0, event.shiftKey) || moveTransposeRecordSelection(-1))) {
       event.preventDefault();
       return;
     }
-    if (event.key === "ArrowRight" && (moveSelectedCell(1, 0) || moveTransposeRecordSelection(1))) {
+    if (event.key === "ArrowRight" && (moveSelectedCell(1, 0, event.shiftKey) || moveTransposeRecordSelection(1))) {
       event.preventDefault();
       return;
     }
   }
-  if (event.key === "ArrowUp" && moveSelectedCell(-1, 0)) {
+  if (event.key === "ArrowUp" && moveSelectedCell(-1, 0, event.shiftKey)) {
     event.preventDefault();
     return;
   }
-  if (event.key === "ArrowDown" && moveSelectedCell(1, 0)) {
+  if (event.key === "ArrowDown" && moveSelectedCell(1, 0, event.shiftKey)) {
     event.preventDefault();
     return;
   }
-  if (event.key === "ArrowLeft" && moveSelectedCell(0, -1)) {
+  if (event.key === "ArrowLeft" && moveSelectedCell(0, -1, event.shiftKey)) {
     event.preventDefault();
     return;
   }
-  if (event.key === "ArrowRight" && moveSelectedCell(0, 1)) {
+  if (event.key === "ArrowRight" && moveSelectedCell(0, 1, event.shiftKey)) {
+    event.preventDefault();
+    return;
+  }
+  // Home / End / Ctrl+Home / Ctrl+End: transpose mode is served by the dedicated branch above,
+  // so these only apply to the normal grid.
+  if (!isTransposeMode.value && (event.key === "Home" || event.key === "End")) {
+    const docJump = event.metaKey || event.ctrlKey;
+    const direction: DataGridNavigationDirection = event.key === "Home" ? (docJump ? "docHome" : "home") : docJump ? "docEnd" : "end";
+    if (navigateSelectedCell(direction, event.shiftKey)) {
+      event.preventDefault();
+      return;
+    }
+  }
+  if (!isTransposeMode.value && event.key === "PageUp" && navigateSelectedCell("pageUp", event.shiftKey)) {
+    event.preventDefault();
+    return;
+  }
+  if (!isTransposeMode.value && event.key === "PageDown" && navigateSelectedCell("pageDown", event.shiftKey)) {
     event.preventDefault();
     return;
   }
@@ -9427,7 +9504,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 class="data-grid-scroller dbx-data-grid-font-family flex-1 overflow-x-auto overscroll-none"
                 :class="{ 'is-scrolling': isScrolling, 'has-horizontal-scrollbar': hasGridHorizontalOverflow }"
                 :items="displayItems"
-                :item-size="26"
+                :item-size="DOM_DATA_GRID_ROW_HEIGHT"
                 :buffer="600"
                 :skip-hover="true"
                 key-field="id"

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -197,7 +197,7 @@ import { useDataGridColumnLayout, useDataGridColumnLayoutState } from "@/composa
 import { dataGridCanvasDevicePixelSize, useDataGridCanvasRuntime, type DataGridCanvasRuntime } from "@/composables/useDataGridCanvasRuntime";
 import { useDataGridScrollbars, type DataGridScrollbarsRuntime } from "@/composables/useDataGridScrollbars";
 import { useDataGridSelection } from "@/composables/useDataGridSelection";
-import { dataGridNavigationOrigin, dataGridRowScrollTop, moveDataGridCell, navigateDataGridCell, type DataGridNavigationDirection, type DataGridScrollAlignment } from "@/lib/dataGrid/dataGridNavigation";
+import { dataGridNavigationOrigin, dataGridPageScrollTop, dataGridRowScrollTop, moveDataGridCell, navigateDataGridCell, type DataGridNavigationDirection, type DataGridScrollAlignment } from "@/lib/dataGrid/dataGridNavigation";
 import type { CellPosition } from "@/lib/dataGrid/gridSelection";
 import { createDataGridRuntimeScope } from "@/lib/dataGrid/dataGridRuntime";
 import { useDataGridEditor } from "@/composables/useDataGridEditor";
@@ -6222,7 +6222,7 @@ function currentSelectedCellPosition() {
 
 const DOM_DATA_GRID_ROW_HEIGHT = 26;
 
-function scrollCellIntoView(rowIndex: number, colIndex: number, block: DataGridScrollAlignment = "nearest") {
+function scrollCellIntoView(rowIndex: number, colIndex: number, block: DataGridScrollAlignment = "nearest", previousPageRowIndex?: number) {
   if (isTransposeMode.value) {
     nextTick(() => {
       const scroller = transposeScrollRef.value;
@@ -6238,15 +6238,15 @@ function scrollCellIntoView(rowIndex: number, colIndex: number, block: DataGridS
   nextTick(() => {
     if (useCanvasGridRows.value) {
       scrollGridColumnIntoView(colIndex);
-      scrollCanvasRowIntoView(rowIndex, block);
+      scrollCanvasRowIntoView(rowIndex, block, previousPageRowIndex);
       return;
     }
     scrollGridColumnIntoView(colIndex);
-    scrollDomRowIntoView(rowIndex, block);
+    scrollDomRowIntoView(rowIndex, block, previousPageRowIndex);
     requestAnimationFrame(() => {
       const rowEl = gridRef.value?.querySelector<HTMLElement>(`[data-row-index="${rowIndex}"]`);
       const cellEl = rowEl?.querySelector<HTMLElement>(`[data-visible-col-index="${colIndex}"]`);
-      (cellEl ?? rowEl)?.scrollIntoView({ block, inline: "nearest" });
+      (cellEl ?? rowEl)?.scrollIntoView({ block: previousPageRowIndex === undefined ? block : "nearest", inline: "nearest" });
     });
   });
 }
@@ -6273,34 +6273,49 @@ function scrollGridColumnIntoView(visibleColIdx: number) {
   if (useCanvasGridRows.value) syncCanvasViewport();
 }
 
-function scrollCanvasRowIntoView(rowIndex: number, block: DataGridScrollAlignment) {
+function scrollCanvasRowIntoView(rowIndex: number, block: DataGridScrollAlignment, previousPageRowIndex?: number) {
   const target = Math.max(0, Math.min(displayRowCount.value - 1, rowIndex));
   const scroller = canvasScrollerElement();
   if (!scroller) return;
-  const rowTop = target * CANVAS_DATA_GRID_ROW_HEIGHT;
-  const rowBottom = rowTop + CANVAS_DATA_GRID_ROW_HEIGHT;
-  if (block === "end") {
-    // Align the target row to the bottom of the viewport, even when it is already visible.
-    scroller.scrollTop = Math.max(0, rowBottom - scroller.clientHeight);
-  } else if (block === "start" || rowTop < scroller.scrollTop) {
-    scroller.scrollTop = rowTop;
-  } else if (rowBottom > scroller.scrollTop + scroller.clientHeight) {
-    scroller.scrollTop = Math.max(0, rowBottom - scroller.clientHeight);
-  }
+  scroller.scrollTop =
+    previousPageRowIndex === undefined
+      ? dataGridRowScrollTop({
+          rowIndex: target,
+          rowHeight: CANVAS_DATA_GRID_ROW_HEIGHT,
+          viewportHeight: scroller.clientHeight,
+          currentScrollTop: scroller.scrollTop,
+          alignment: block,
+        })
+      : dataGridPageScrollTop({
+          previousRowIndex: previousPageRowIndex,
+          rowIndex: target,
+          rowHeight: CANVAS_DATA_GRID_ROW_HEIGHT,
+          currentScrollTop: scroller.scrollTop,
+          maximumScrollTop: scroller.scrollHeight - scroller.clientHeight,
+        });
   syncCanvasViewport();
 }
 
-function scrollDomRowIntoView(rowIndex: number, block: DataGridScrollAlignment) {
+function scrollDomRowIntoView(rowIndex: number, block: DataGridScrollAlignment, previousPageRowIndex?: number) {
   const target = Math.max(0, Math.min(displayRowCount.value - 1, rowIndex));
   const scroller = gridScrollerElement();
   if (!scroller) return;
-  const nextScrollTop = dataGridRowScrollTop({
-    rowIndex: target,
-    rowHeight: DOM_DATA_GRID_ROW_HEIGHT,
-    viewportHeight: scroller.clientHeight,
-    currentScrollTop: scroller.scrollTop,
-    alignment: block,
-  });
+  const nextScrollTop =
+    previousPageRowIndex === undefined
+      ? dataGridRowScrollTop({
+          rowIndex: target,
+          rowHeight: DOM_DATA_GRID_ROW_HEIGHT,
+          viewportHeight: scroller.clientHeight,
+          currentScrollTop: scroller.scrollTop,
+          alignment: block,
+        })
+      : dataGridPageScrollTop({
+          previousRowIndex: previousPageRowIndex,
+          rowIndex: target,
+          rowHeight: DOM_DATA_GRID_ROW_HEIGHT,
+          currentScrollTop: scroller.scrollTop,
+          maximumScrollTop: scroller.scrollHeight - scroller.clientHeight,
+        });
   const virtualScroller = scrollerRef.value;
   if (virtualScroller && !(virtualScroller instanceof HTMLElement)) {
     virtualScroller.scrollToPosition?.(nextScrollTop);
@@ -6374,13 +6389,13 @@ function toggleKeyboardTranspose(): boolean {
 
 // Shared path that selects or extends to nextPosition and scrolls it into view.
 // Used by both moveSelectedCell (relative steps) and navigateSelectedCell (absolute/page jumps).
-function applyCellNavigation(nextPosition: CellPosition, extend = false, block: DataGridScrollAlignment = "nearest"): boolean {
+function applyCellNavigation(nextPosition: CellPosition, extend = false, block: DataGridScrollAlignment = "nearest", previousPageRowIndex?: number): boolean {
   invalidateSyntheticContextSelection();
   if (extend) extendCellSelectionTo(nextPosition.rowIndex, nextPosition.colIndex);
   else selectSingleCell(nextPosition.rowIndex, nextPosition.colIndex);
   clearRowSelection();
   if (showTranspose.value) transposeRowIndex.value = nextPosition.rowIndex;
-  scrollCellIntoView(nextPosition.rowIndex, nextPosition.colIndex, block);
+  scrollCellIntoView(nextPosition.rowIndex, nextPosition.colIndex, block, previousPageRowIndex);
   return true;
 }
 
@@ -6422,7 +6437,8 @@ function navigateSelectedCell(direction: DataGridNavigationDirection, extend = f
   if (!nextPosition) return false;
   // docHome/docEnd must reach the very start/end of the grid even if the target row is already visible, so "nearest" is not used.
   const block: DataGridScrollAlignment = direction === "docHome" ? "start" : direction === "docEnd" ? "end" : "nearest";
-  return applyCellNavigation(nextPosition, extend, block);
+  const previousPageRowIndex = direction === "pageUp" || direction === "pageDown" ? position.rowIndex : undefined;
+  return applyCellNavigation(nextPosition, extend, block, previousPageRowIndex);
 }
 
 function editSelectedCell(): boolean {

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridNavigation.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridNavigation.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { moveDataGridCell, navigateDataGridCell } from "@/lib/dataGrid/dataGridNavigation";
+import { dataGridNavigationOrigin, dataGridRowScrollTop, moveDataGridCell, navigateDataGridCell } from "@/lib/dataGrid/dataGridNavigation";
 
 const bounds = { rowCount: 3, visibleColumnCount: 4 };
 
@@ -10,6 +10,15 @@ describe("dataGridNavigation", () => {
     expect(moveDataGridCell({ rowIndex: 1, colIndex: 2 }, -1, 1, bounds)).toEqual({ rowIndex: 0, colIndex: 3 });
   });
 
+  it("continues Shift navigation from the selection focus", () => {
+    const rangeStart = { rowIndex: 1, colIndex: 1 };
+    const selectionFocus = { rowIndex: 3, colIndex: 2 };
+
+    expect(dataGridNavigationOrigin(rangeStart, selectionFocus, true)).toEqual(selectionFocus);
+    expect(dataGridNavigationOrigin(rangeStart, selectionFocus, false)).toEqual(rangeStart);
+    expect(dataGridNavigationOrigin(rangeStart, null, true)).toEqual(rangeStart);
+  });
+
   it("supports home and end navigation without changing the row", () => {
     expect(navigateDataGridCell({ rowIndex: 2, colIndex: 2 }, "home", bounds)).toEqual({ rowIndex: 2, colIndex: 0 });
     expect(navigateDataGridCell({ rowIndex: 2, colIndex: 0 }, "end", bounds)).toEqual({ rowIndex: 2, colIndex: 3 });
@@ -17,5 +26,38 @@ describe("dataGridNavigation", () => {
 
   it("returns no target for an empty grid", () => {
     expect(navigateDataGridCell({ rowIndex: 0, colIndex: 0 }, "down", { rowCount: 0, visibleColumnCount: 4 })).toBeNull();
+  });
+
+  it("supports page up and page down by the configured page row count", () => {
+    const pageBounds = { rowCount: 10, visibleColumnCount: 4, pageRowCount: 5 };
+    expect(navigateDataGridCell({ rowIndex: 7, colIndex: 2 }, "pageUp", pageBounds)).toEqual({ rowIndex: 2, colIndex: 2 });
+    expect(navigateDataGridCell({ rowIndex: 2, colIndex: 2 }, "pageDown", pageBounds)).toEqual({ rowIndex: 7, colIndex: 2 });
+  });
+
+  it("clamps page navigation at the grid boundaries", () => {
+    const pageBounds = { rowCount: 10, visibleColumnCount: 4, pageRowCount: 5 };
+    expect(navigateDataGridCell({ rowIndex: 1, colIndex: 2 }, "pageUp", pageBounds)).toEqual({ rowIndex: 0, colIndex: 2 });
+    expect(navigateDataGridCell({ rowIndex: 8, colIndex: 2 }, "pageDown", pageBounds)).toEqual({ rowIndex: 9, colIndex: 2 });
+  });
+
+  it("falls back to a single row when pageRowCount is omitted", () => {
+    expect(navigateDataGridCell({ rowIndex: 1, colIndex: 2 }, "pageUp", bounds)).toEqual({ rowIndex: 0, colIndex: 2 });
+    expect(navigateDataGridCell({ rowIndex: 1, colIndex: 2 }, "pageDown", bounds)).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+
+  it("jumps to the first and last cell with docHome and docEnd", () => {
+    expect(navigateDataGridCell({ rowIndex: 2, colIndex: 3 }, "docHome", bounds)).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(navigateDataGridCell({ rowIndex: 0, colIndex: 0 }, "docEnd", bounds)).toEqual({ rowIndex: 2, colIndex: 3 });
+  });
+
+  it("aligns document jumps to the first and last grid rows", () => {
+    expect(dataGridRowScrollTop({ rowIndex: 0, rowHeight: 26, viewportHeight: 260, currentScrollTop: 1200, alignment: "start" })).toBe(0);
+    expect(dataGridRowScrollTop({ rowIndex: 99, rowHeight: 26, viewportHeight: 260, currentScrollTop: 0, alignment: "end" })).toBe(2340);
+  });
+
+  it("keeps a visible row in place and minimally reveals a row outside the viewport", () => {
+    expect(dataGridRowScrollTop({ rowIndex: 12, rowHeight: 26, viewportHeight: 260, currentScrollTop: 260, alignment: "nearest" })).toBe(260);
+    expect(dataGridRowScrollTop({ rowIndex: 9, rowHeight: 26, viewportHeight: 260, currentScrollTop: 260, alignment: "nearest" })).toBe(234);
+    expect(dataGridRowScrollTop({ rowIndex: 20, rowHeight: 26, viewportHeight: 260, currentScrollTop: 260, alignment: "nearest" })).toBe(286);
   });
 });

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridNavigation.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridNavigation.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { dataGridNavigationOrigin, dataGridRowScrollTop, moveDataGridCell, navigateDataGridCell } from "@/lib/dataGrid/dataGridNavigation";
+import { CANVAS_DATA_GRID_ROW_HEIGHT } from "@/lib/dataGrid/canvasDataGridRenderer";
+import { dataGridNavigationOrigin, dataGridPageScrollTop, dataGridRowScrollTop, moveDataGridCell, navigateDataGridCell } from "@/lib/dataGrid/dataGridNavigation";
 
 const bounds = { rowCount: 3, visibleColumnCount: 4 };
 
@@ -34,6 +35,16 @@ describe("dataGridNavigation", () => {
     expect(navigateDataGridCell({ rowIndex: 2, colIndex: 2 }, "pageDown", pageBounds)).toEqual({ rowIndex: 7, colIndex: 2 });
   });
 
+  it("continues Shift+Page navigation from the range focus", () => {
+    const pageBounds = { rowCount: 30, visibleColumnCount: 4, pageRowCount: 10 };
+    const anchor = { rowIndex: 5, colIndex: 2 };
+    const firstFocus = navigateDataGridCell(dataGridNavigationOrigin(anchor, null, true)!, "pageDown", pageBounds);
+    const secondFocus = navigateDataGridCell(dataGridNavigationOrigin(anchor, firstFocus, true)!, "pageDown", pageBounds);
+
+    expect(firstFocus).toEqual({ rowIndex: 15, colIndex: 2 });
+    expect(secondFocus).toEqual({ rowIndex: 25, colIndex: 2 });
+  });
+
   it("clamps page navigation at the grid boundaries", () => {
     const pageBounds = { rowCount: 10, visibleColumnCount: 4, pageRowCount: 5 };
     expect(navigateDataGridCell({ rowIndex: 1, colIndex: 2 }, "pageUp", pageBounds)).toEqual({ rowIndex: 0, colIndex: 2 });
@@ -59,5 +70,23 @@ describe("dataGridNavigation", () => {
     expect(dataGridRowScrollTop({ rowIndex: 12, rowHeight: 26, viewportHeight: 260, currentScrollTop: 260, alignment: "nearest" })).toBe(260);
     expect(dataGridRowScrollTop({ rowIndex: 9, rowHeight: 26, viewportHeight: 260, currentScrollTop: 260, alignment: "nearest" })).toBe(234);
     expect(dataGridRowScrollTop({ rowIndex: 20, rowHeight: 26, viewportHeight: 260, currentScrollTop: 260, alignment: "nearest" })).toBe(286);
+  });
+
+  describe.each([
+    ["DOM", 26],
+    ["Canvas", CANVAS_DATA_GRID_ROW_HEIGHT],
+  ])("%s PageUp/PageDown scrolling", (_renderMode, rowHeight) => {
+    const maximumScrollTop = 100 * rowHeight - 260;
+
+    it("keeps the focused row at the same viewport-relative position", () => {
+      expect(dataGridPageScrollTop({ previousRowIndex: 5, rowIndex: 15, rowHeight, currentScrollTop: 0, maximumScrollTop })).toBe(260);
+      expect(dataGridPageScrollTop({ previousRowIndex: 15, rowIndex: 5, rowHeight, currentScrollTop: 260, maximumScrollTop })).toBe(0);
+      expect(dataGridPageScrollTop({ previousRowIndex: 10, rowIndex: 20, rowHeight, currentScrollTop: 117, maximumScrollTop })).toBe(377);
+    });
+
+    it("clamps scrolling at the upper and lower boundaries", () => {
+      expect(dataGridPageScrollTop({ previousRowIndex: 2, rowIndex: 0, rowHeight, currentScrollTop: 0, maximumScrollTop })).toBe(0);
+      expect(dataGridPageScrollTop({ previousRowIndex: 97, rowIndex: 99, rowHeight, currentScrollTop: maximumScrollTop, maximumScrollTop })).toBe(maximumScrollTop);
+    });
   });
 });

--- a/apps/desktop/src/lib/dataGrid/dataGridNavigation.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridNavigation.ts
@@ -1,14 +1,40 @@
 import type { CellPosition } from "@/lib/dataGrid/gridSelection";
 
-export type DataGridNavigationDirection = "up" | "down" | "left" | "right" | "home" | "end";
+export type DataGridNavigationDirection = "up" | "down" | "left" | "right" | "home" | "end" | "pageUp" | "pageDown" | "docHome" | "docEnd";
 
 export interface DataGridNavigationBounds {
   rowCount: number;
   visibleColumnCount: number;
+  /** Rows moved by a single PageUp / PageDown. Defaults to 1 when omitted. */
+  pageRowCount?: number;
+}
+
+export type DataGridScrollAlignment = "nearest" | "start" | "end";
+
+export interface DataGridRowScrollOptions {
+  rowIndex: number;
+  rowHeight: number;
+  viewportHeight: number;
+  currentScrollTop: number;
+  alignment: DataGridScrollAlignment;
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value));
+}
+
+export function dataGridNavigationOrigin(position: CellPosition | null, selectionFocus: CellPosition | null, extend: boolean): CellPosition | null {
+  return extend ? (selectionFocus ?? position) : position;
+}
+
+export function dataGridRowScrollTop(options: DataGridRowScrollOptions): number {
+  const rowTop = options.rowIndex * options.rowHeight;
+  const rowBottom = rowTop + options.rowHeight;
+  if (options.alignment === "start" || rowTop < options.currentScrollTop) return Math.max(0, rowTop);
+  if (options.alignment === "end" || rowBottom > options.currentScrollTop + options.viewportHeight) {
+    return Math.max(0, rowBottom - options.viewportHeight);
+  }
+  return options.currentScrollTop;
 }
 
 export function moveDataGridCell(position: CellPosition, rowDelta: number, columnDelta: number, bounds: DataGridNavigationBounds): CellPosition | null {
@@ -21,6 +47,10 @@ export function moveDataGridCell(position: CellPosition, rowDelta: number, colum
 
 export function navigateDataGridCell(position: CellPosition, direction: DataGridNavigationDirection, bounds: DataGridNavigationBounds): CellPosition | null {
   if (bounds.rowCount <= 0 || bounds.visibleColumnCount <= 0) return null;
+  const lastRowIndex = bounds.rowCount - 1;
+  const lastColIndex = bounds.visibleColumnCount - 1;
+  // PageUp/PageDown step follows the viewport row count, with a one-row floor.
+  const pageRowCount = Math.max(1, Math.floor(bounds.pageRowCount ?? 1));
   switch (direction) {
     case "up":
       return moveDataGridCell(position, -1, 0, bounds);
@@ -31,8 +61,20 @@ export function navigateDataGridCell(position: CellPosition, direction: DataGrid
     case "right":
       return moveDataGridCell(position, 0, 1, bounds);
     case "home":
+      // First visible column of the current row
       return { rowIndex: position.rowIndex, colIndex: 0 };
     case "end":
-      return { rowIndex: position.rowIndex, colIndex: bounds.visibleColumnCount - 1 };
+      // Last visible column of the current row
+      return { rowIndex: position.rowIndex, colIndex: lastColIndex };
+    case "pageUp":
+      return { rowIndex: clamp(position.rowIndex - pageRowCount, 0, lastRowIndex), colIndex: position.colIndex };
+    case "pageDown":
+      return { rowIndex: clamp(position.rowIndex + pageRowCount, 0, lastRowIndex), colIndex: position.colIndex };
+    case "docHome":
+      // First cell of the whole grid (Ctrl/Cmd + Home)
+      return { rowIndex: 0, colIndex: 0 };
+    case "docEnd":
+      // Last cell of the whole grid (Ctrl/Cmd + End)
+      return { rowIndex: lastRowIndex, colIndex: lastColIndex };
   }
 }

--- a/apps/desktop/src/lib/dataGrid/dataGridNavigation.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridNavigation.ts
@@ -19,6 +19,14 @@ export interface DataGridRowScrollOptions {
   alignment: DataGridScrollAlignment;
 }
 
+export interface DataGridPageScrollOptions {
+  previousRowIndex: number;
+  rowIndex: number;
+  rowHeight: number;
+  currentScrollTop: number;
+  maximumScrollTop: number;
+}
+
 function clamp(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value));
 }
@@ -35,6 +43,11 @@ export function dataGridRowScrollTop(options: DataGridRowScrollOptions): number 
     return Math.max(0, rowBottom - options.viewportHeight);
   }
   return options.currentScrollTop;
+}
+
+export function dataGridPageScrollTop(options: DataGridPageScrollOptions): number {
+  const rowOffset = (options.rowIndex - options.previousRowIndex) * options.rowHeight;
+  return clamp(options.currentScrollTop + rowOffset, 0, Math.max(0, options.maximumScrollTop));
 }
 
 export function moveDataGridCell(position: CellPosition, rowDelta: number, columnDelta: number, bounds: DataGridNavigationBounds): CellPosition | null {


### PR DESCRIPTION
## 变更说明

  结果表格此前只处理方向键的单元格移动，`Home`、`End`、`PageUp`、`PageDown`
  按下后没有任何反应，且方向键无法配合 `Shift` 扩展选区。
  本 PR 为数据表格补齐标准的键盘单元格导航与区域选择：

  | 按键 | 行为 |
  | --- | --- |
  | `Home` / `End` | 跳到当前行的首列 / 末列 |
  | `Ctrl`(`Cmd`)+`Home` / `End` | 跳到表格的第一个 / 最后一个单元格 |
  | `PageUp` / `PageDown` | 按一屏的行数上下移动 |
  | `Shift` + 方向键 | 以锚点为基准扩展单元格选区 |
  | `Shift` + 上述任意导航键 | 同样扩展选区（含 `Shift`+`Ctrl`+`Home`/`End`
  一路选到首/末单元格） |

  翻页步长按滚动容器的可视高度计算，因此 Canvas 与 DOM 两种渲染模式下都正好移动一屏。
  `Ctrl`+`Home`/`End` 使用 top/bottom 对齐而非 `nearest`——`nearest`
  在目标行恰好已可见时会跳过滚动，导致横向滚动跟随、纵向不动。

  实现要点：

  - `dataGridNavigation.ts`：为 `DataGridNavigationDirection` 增加 `pageUp` / `pageDown`
  / `docHome` / `docEnd`；抽出纯函数 `dataGridRowScrollTop()`（滚动对齐）与
  `dataGridNavigationOrigin()`（扩展选区时以 focus 端为移动起点），便于单测覆盖。
  - `DataGrid.vue`：新增 `navigateSelectedCell()` 与既有 `moveSelectedCell()`
  并列，两者共用 `applyCellNavigation()` 处理选中与滚动，并统一接受 `extend`
  参数；`Shift` 复用鼠标拖拽选区所走的
  `extendCellSelectionTo()`，因此选区结果与鼠标操作一致（复制等后续操作行为不变）。
  - 转置（transpose）模式沿用原有的方向键分支，未改变其既有行为。

  按键判断使用标准 `event.key`，并同等对待 `metaKey` /
  `ctrlKey`（与该文件中既有快捷键一致），因此 macOS 下 `Cmd`+`Home`/`End` 及
  `fn`+方向键输入同样生效。

  ## 变更类型

  - [x] 新功能
  - [ ] Bug 修复
  - [ ] 性能优化
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] CI / 构建

  ## 涉及前端

  - [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

https://github.com/user-attachments/assets/4c4a0d58-7e64-43bf-afb3-e993ed2ecb4f


  <!-- 截图区域 -->

## 验证

  - [ ] `make check` 通过
  - [ ] `make cargo-check-fast` 通过
  - [x] 相关测试通过

  `pnpm test`：与本 PR 相关的表格测试 52 个文件 / 338
  条用例全部通过（新增翻页导航、文档跳转、滚动对齐与扩展选区起点的用例）。
  `pnpm typecheck`、`pnpm lint`、`oxfmt --check` 均无新增问题。

  `pnpm check` 目前有 1
  条失败：`apps/desktop/src/lib/__tests__/windowsInstallerTemplate.spec.ts`（WebView2
  安装模板校验）。
  该用例在未包含本 PR 的 `main` 上同样失败，属于既有问题，与本次改动无关。

  本 PR 仅涉及前端，未改动 Rust 代码，故未运行 `cargo-check-fast`。
  另在 Windows 上以 `pnpm tauri dev` 连接 MySQL 手动验证：单键、`Ctrl` 组合、`Shift`
  方向键与 `Shift` 导航键选区，Canvas 与 DOM 两种渲染模式下均正常。

  ## 关联 Issue

  <!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->