### PR TITLE
✨ feat(nacos): 支持配置分组客户端模糊筛选并优化筛选交互

### DIFF
--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -2210,9 +2210,24 @@ onBeforeUnmount(() => {
       <Pane :size="nacosSplitSize" min-size="24">
         <div class="flex h-full min-h-0 flex-col">
           <div class="grid shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto] gap-2 border-b p-2">
-            <Input v-model="configDataId" class="h-8 min-w-0" placeholder="dataId" @keyup.enter="loadConfigsWithRetry(1)" />
-            <Input v-model="configGroup" class="h-8 min-w-0" :placeholder="t('nacos.allGroups')" @keyup.enter="loadConfigsWithRetry(1)" />
-            <Input v-model="configAppName" class="h-8 min-w-0" :placeholder="t('nacos.application')" @keyup.enter="loadConfigsWithRetry(1)" />
+            <div class="relative min-w-0">
+              <Input v-model="configDataId" class="h-8 min-w-0 pr-8" placeholder="dataId" @keyup.enter="loadConfigsWithRetry(1)" />
+              <button v-if="configDataId" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="configDataId = ''">
+                <X class="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <div class="relative min-w-0">
+              <Input v-model="configGroup" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.allGroups')" @keyup.enter="loadConfigsWithRetry(1)" />
+              <button v-if="configGroup" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="configGroup = ''">
+                <X class="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <div class="relative min-w-0">
+              <Input v-model="configAppName" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.application')" @keyup.enter="loadConfigsWithRetry(1)" />
+              <button v-if="configAppName" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="configAppName = ''">
+                <X class="h-3.5 w-3.5" />
+              </button>
+            </div>
             <Button size="sm" variant="outline" class="h-8 w-9 px-0" :title="t('nacos.load')" :disabled="configLoading" @click="loadConfigsWithRetry(1)">
               <Loader2 v-if="configLoading" class="h-3.5 w-3.5 animate-spin" />
               <RefreshCw v-else class="h-3.5 w-3.5" />
@@ -2471,8 +2486,18 @@ onBeforeUnmount(() => {
       <Pane :size="nacosSplitSize" min-size="24">
         <div class="flex h-full min-h-0 flex-col">
           <div class="grid shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] gap-2 border-b p-2">
-            <Input v-model="serviceName" class="h-8 min-w-0" :placeholder="t('nacos.service')" @keyup.enter="loadServicesWithRetry(1)" />
-            <Input v-model="serviceGroup" class="h-8 min-w-0" :placeholder="t('nacos.allGroups')" @keyup.enter="loadServicesWithRetry(1)" />
+            <div class="relative min-w-0">
+              <Input v-model="serviceName" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.service')" @keyup.enter="loadServicesWithRetry(1)" />
+              <button v-if="serviceName" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="serviceName = ''">
+                <X class="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <div class="relative min-w-0">
+              <Input v-model="serviceGroup" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.allGroups')" @keyup.enter="loadServicesWithRetry(1)" />
+              <button v-if="serviceGroup" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="serviceGroup = ''">
+                <X class="h-3.5 w-3.5" />
+              </button>
+            </div>
             <Button size="sm" variant="outline" class="h-8 gap-1.5" :disabled="readOnly || !createServiceCapability.supported" :title="readOnly || !createServiceCapability.supported ? capabilityReason(createServiceCapability) : undefined" @click="openCreateService">
               <Plus class="h-3.5 w-3.5" />
               {{ t("nacos.service") }}
@@ -2642,7 +2667,7 @@ onBeforeUnmount(() => {
                     <div class="flex flex-wrap items-center gap-2">
                       <span class="font-mono text-sm font-medium">{{ instance.ip }}:{{ instance.port }}</span>
                       <Badge variant="outline">{{ instance.clusterName || "DEFAULT" }}</Badge>
-                      <Badge :variant="instance.healthy === false ? 'outline' : 'secondary'" :class="instance.healthy === false ? 'border-destructive/50 text-destructive' : ''">{{ instance.healthy === false ? t("nacos.unhealthy") : t("nacos.healthy") }}</Badge>
+                      <Badge variant="outline" :class="instance.healthy === false ? 'border-destructive/50 text-destructive' : 'border-emerald-500/50 text-emerald-700 dark:text-emerald-300'">{{ instance.healthy === false ? t("nacos.unhealthy") : t("nacos.healthy") }}</Badge>
                       <Badge :variant="instance.enabled === false ? 'outline' : 'secondary'" :class="instance.enabled === false ? 'border-muted-foreground/50 text-muted-foreground' : ''">{{ instance.enabled === false ? t("nacos.offline") : t("nacos.enabled") }}</Badge>
                       <Badge v-if="instance.ephemeral != null" variant="outline">{{ instance.ephemeral ? t("nacos.ephemeral") : t("nacos.persistent") }}</Badge>
                     </div>

--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -389,6 +389,7 @@ function buildConfigSelector(scope: NacosConfigSelectionScope): NacosConfigSelec
         ? {
             namespace: namespace.value || undefined,
             group: configGroup.value.trim() || undefined,
+            groupContains: true,
             dataId: configDataId.value.trim() || undefined,
             appName: configAppName.value.trim() || undefined,
           }
@@ -664,6 +665,7 @@ async function loadConfigs(page = configPageNo.value) {
     const result = await api.nacosListConfigs(props.connectionId, {
       namespace: namespace.value || undefined,
       group: configGroup.value.trim() || undefined,
+      groupContains: true,
       dataId: configDataId.value.trim() || undefined,
       appName: configAppName.value.trim() || undefined,
       pageNo: configPageNo.value,
@@ -684,6 +686,13 @@ async function loadConfigsWithRetry(page = configPageNo.value) {
     if (!isConnectionNotFoundError(configError.value) || attempt >= CONNECTION_NOT_FOUND_RETRY_DELAYS_MS.length) return;
     await delay(CONNECTION_NOT_FOUND_RETRY_DELAYS_MS[attempt]);
   }
+}
+
+function clearConfigFilter(filter: "dataId" | "group" | "appName") {
+  if (filter === "dataId") configDataId.value = "";
+  else if (filter === "group") configGroup.value = "";
+  else configAppName.value = "";
+  void loadConfigsWithRetry(1);
 }
 
 function closePendingConfigMutationConfirmations() {
@@ -1552,6 +1561,12 @@ async function loadServicesWithRetry(page = servicePageNo.value) {
   }
 }
 
+function clearServiceFilter(filter: "name" | "group") {
+  if (filter === "name") serviceName.value = "";
+  else serviceGroup.value = "";
+  void loadServicesWithRetry(1);
+}
+
 async function selectService(service: NacosServiceInfo) {
   serviceMutationSequence += 1;
   instanceUpdateSequence += 1;
@@ -2212,19 +2227,40 @@ onBeforeUnmount(() => {
           <div class="grid shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto] gap-2 border-b p-2">
             <div class="relative min-w-0">
               <Input v-model="configDataId" class="h-8 min-w-0 pr-8" placeholder="dataId" @keyup.enter="loadConfigsWithRetry(1)" />
-              <button v-if="configDataId" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="configDataId = ''">
+              <button
+                v-if="configDataId"
+                type="button"
+                class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                :title="t('nacos.clear')"
+                :aria-label="t('nacos.clear')"
+                @click="clearConfigFilter('dataId')"
+              >
                 <X class="h-3.5 w-3.5" />
               </button>
             </div>
             <div class="relative min-w-0">
               <Input v-model="configGroup" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.allGroups')" @keyup.enter="loadConfigsWithRetry(1)" />
-              <button v-if="configGroup" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="configGroup = ''">
+              <button
+                v-if="configGroup"
+                type="button"
+                class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                :title="t('nacos.clear')"
+                :aria-label="t('nacos.clear')"
+                @click="clearConfigFilter('group')"
+              >
                 <X class="h-3.5 w-3.5" />
               </button>
             </div>
             <div class="relative min-w-0">
               <Input v-model="configAppName" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.application')" @keyup.enter="loadConfigsWithRetry(1)" />
-              <button v-if="configAppName" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="configAppName = ''">
+              <button
+                v-if="configAppName"
+                type="button"
+                class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                :title="t('nacos.clear')"
+                :aria-label="t('nacos.clear')"
+                @click="clearConfigFilter('appName')"
+              >
                 <X class="h-3.5 w-3.5" />
               </button>
             </div>
@@ -2488,13 +2524,27 @@ onBeforeUnmount(() => {
           <div class="grid shrink-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto] gap-2 border-b p-2">
             <div class="relative min-w-0">
               <Input v-model="serviceName" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.service')" @keyup.enter="loadServicesWithRetry(1)" />
-              <button v-if="serviceName" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="serviceName = ''">
+              <button
+                v-if="serviceName"
+                type="button"
+                class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                :title="t('nacos.clear')"
+                :aria-label="t('nacos.clear')"
+                @click="clearServiceFilter('name')"
+              >
                 <X class="h-3.5 w-3.5" />
               </button>
             </div>
             <div class="relative min-w-0">
               <Input v-model="serviceGroup" class="h-8 min-w-0 pr-8" :placeholder="t('nacos.allGroups')" @keyup.enter="loadServicesWithRetry(1)" />
-              <button v-if="serviceGroup" type="button" class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :title="t('nacos.clear')" :aria-label="t('nacos.clear')" @click="serviceGroup = ''">
+              <button
+                v-if="serviceGroup"
+                type="button"
+                class="absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                :title="t('nacos.clear')"
+                :aria-label="t('nacos.clear')"
+                @click="clearServiceFilter('group')"
+              >
                 <X class="h-3.5 w-3.5" />
               </button>
             </div>

--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -178,6 +178,7 @@ const importSourceName = ref("");
 const configEditorTheme = new Compartment();
 const configEditorFontTheme = new Compartment();
 const configEditorLanguage = new Compartment();
+const configListRequestGuard = createNacosLatestRequestGuard();
 const configDetailRequestGuard = createNacosLatestRequestGuard();
 let configEditorGeneration = 0;
 let configEditorSessionId = 0;
@@ -657,33 +658,58 @@ async function loadInfo() {
   }
 }
 
-async function loadConfigs(page = configPageNo.value) {
+async function loadConfigs(page = configPageNo.value): Promise<boolean> {
+  const requestId = configListRequestGuard.begin();
+  const connectionId = props.connectionId;
+  const requestNamespace = namespace.value;
+  const requestGroup = configGroup.value.trim();
+  const requestDataId = configDataId.value.trim();
+  const requestAppName = configAppName.value.trim();
+  const requestPageSize = configPageSize.value;
+  const isCurrentRequest = () =>
+    configListRequestGuard.isCurrent(requestId) &&
+    connectionId === props.connectionId &&
+    requestNamespace === namespace.value &&
+    requestGroup === configGroup.value.trim() &&
+    requestDataId === configDataId.value.trim() &&
+    requestAppName === configAppName.value.trim() &&
+    requestPageSize === configPageSize.value;
   configLoading.value = true;
   configError.value = "";
   configPageNo.value = page;
   try {
-    const result = await api.nacosListConfigs(props.connectionId, {
-      namespace: namespace.value || undefined,
-      group: configGroup.value.trim() || undefined,
+    const result = await api.nacosListConfigs(connectionId, {
+      namespace: requestNamespace || undefined,
+      group: requestGroup || undefined,
       groupContains: true,
-      dataId: configDataId.value.trim() || undefined,
-      appName: configAppName.value.trim() || undefined,
-      pageNo: configPageNo.value,
-      pageSize: configPageSize.value,
+      dataId: requestDataId || undefined,
+      appName: requestAppName || undefined,
+      pageNo: page,
+      pageSize: requestPageSize,
     });
+    if (!isCurrentRequest()) return false;
     configs.value = applyKnownConfigFormats(result.items.map(normalizeConfigItemFormat));
     configTotal.value = result.totalCount;
+    return true;
   } catch (error) {
-    await handleRNacosConsoleError(error, () => loadConfigs(page), "config");
+    if (!isCurrentRequest()) return false;
+    await handleRNacosConsoleError(
+      error,
+      async () => {
+        await loadConfigs(page);
+      },
+      "config",
+    );
+    return true;
   } finally {
-    configLoading.value = false;
+    if (configListRequestGuard.isCurrent(requestId)) configLoading.value = false;
   }
 }
 
 async function loadConfigsWithRetry(page = configPageNo.value) {
   for (let attempt = 0; ; attempt += 1) {
-    await loadConfigs(page);
-    if (!isConnectionNotFoundError(configError.value) || attempt >= CONNECTION_NOT_FOUND_RETRY_DELAYS_MS.length) return;
+    const current = await loadConfigs(page);
+    if (!current || !isConnectionNotFoundError(configError.value) || attempt >= CONNECTION_NOT_FOUND_RETRY_DELAYS_MS.length) return;
     await delay(CONNECTION_NOT_FOUND_RETRY_DELAYS_MS[attempt]);
   }
 }
@@ -2107,6 +2133,7 @@ watch(
   () => [props.connectionId, props.namespace] as const,
   async () => {
     closePendingConfigMutationConfirmations();
+    configListRequestGuard.invalidate();
     configDetailRequestGuard.invalidate();
     configEditorSessionId += 1;
     latestConfigSaveRequestId += 1;
@@ -2156,6 +2183,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  configListRequestGuard.invalidate();
   configDetailRequestGuard.invalidate();
   servicesRequestGuard.invalidate();
   serviceDetailRequestGuard.invalidate();

--- a/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
+++ b/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
@@ -84,6 +84,18 @@ describe("NacosAdminConsole config workbench layout", () => {
     expect(source).not.toContain('v-if="serviceCluster"\n                  size="sm"');
   });
 
+  it("adds icon-only clear controls to populated configuration and service filters", () => {
+    for (const filter of ["configDataId", "configGroup", "configAppName", "serviceName", "serviceGroup"]) {
+      expect(source).toContain(`v-if="${filter}"`);
+      expect(source).toContain(`@click="${filter} = ''"`);
+    }
+    expect(source.match(/:aria-label="t\('nacos\.clear'\)"/g)?.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("uses green outlined styling for healthy instances and red styling for unhealthy instances", () => {
+    expect(source).toContain("instance.healthy === false ? 'border-destructive/50 text-destructive' : 'border-emerald-500/50 text-emerald-700 dark:text-emerald-300'");
+  });
+
   it("separates the service header, filtering controls, and management actions", () => {
     expect(source).toContain('<header class="shrink-0 border-b bg-background">');
     expect(source).toContain('class="flex flex-wrap items-center gap-x-4 gap-y-2 border-t bg-muted/30 px-4 py-2"');

--- a/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
+++ b/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
@@ -46,6 +46,16 @@ describe("NacosAdminConsole config workbench layout", () => {
     expect(source).toContain("await Promise.all([loadServiceDetail(), loadInstances()]);");
   });
 
+  it("keeps configuration list responses scoped to the latest filters", () => {
+    expect(source).toContain("const configListRequestGuard = createNacosLatestRequestGuard();");
+    expect(source).toContain("const requestId = configListRequestGuard.begin();");
+    expect(source).toContain("if (!isCurrentRequest()) return false;");
+    expect(source).toContain("if (configListRequestGuard.isCurrent(requestId)) configLoading.value = false;");
+    expect(source).toContain("const current = await loadConfigs(page);");
+    expect(source).toContain("if (!current || !isConnectionNotFoundError(configError.value)");
+    expect(source.match(/configListRequestGuard\.invalidate\(\);/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("keeps instance weight edits as drafts until the explicit save action", () => {
     expect(source).toContain("instanceWeightDrafts.value[instanceIdentity(instance)] = String(value);");
     expect(source).toContain('@click="requestInstanceWeightUpdate(instance)"');

--- a/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
+++ b/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
@@ -85,10 +85,19 @@ describe("NacosAdminConsole config workbench layout", () => {
   });
 
   it("adds icon-only clear controls to populated configuration and service filters", () => {
-    for (const filter of ["configDataId", "configGroup", "configAppName", "serviceName", "serviceGroup"]) {
+    for (const [filter, clear] of [
+      ["configDataId", "clearConfigFilter('dataId')"],
+      ["configGroup", "clearConfigFilter('group')"],
+      ["configAppName", "clearConfigFilter('appName')"],
+      ["serviceName", "clearServiceFilter('name')"],
+      ["serviceGroup", "clearServiceFilter('group')"],
+    ]) {
       expect(source).toContain(`v-if="${filter}"`);
-      expect(source).toContain(`@click="${filter} = ''"`);
+      expect(source).toContain(`@click="${clear}"`);
     }
+    expect(source).toContain("void loadConfigsWithRetry(1);");
+    expect(source).toContain("void loadServicesWithRetry(1);");
+    expect(source.match(/groupContains: true/g)?.length).toBeGreaterThanOrEqual(2);
     expect(source.match(/:aria-label="t\('nacos\.clear'\)"/g)?.length).toBeGreaterThanOrEqual(5);
   });
 

--- a/apps/desktop/src/types/nacos.ts
+++ b/apps/desktop/src/types/nacos.ts
@@ -95,6 +95,7 @@ export interface NacosAdminConfig {
 export interface NacosConfigQuery {
   namespace?: string;
   group?: string;
+  groupContains?: boolean;
   dataId?: string;
   appName?: string;
   search?: string;

--- a/crates/dbx-core/src/nacos/batch.rs
+++ b/crates/dbx-core/src/nacos/batch.rs
@@ -196,6 +196,7 @@ async fn resolve_selector(
             let mut query = selector.query.clone().unwrap_or(crate::nacos::types::NacosConfigQuery {
                 namespace: None,
                 group: None,
+                group_contains: false,
                 data_id: None,
                 app_name: None,
                 search: None,
@@ -397,6 +398,7 @@ async fn existing_config(
         .list_configs(crate::nacos::types::NacosConfigQuery {
             namespace: Some(namespace.clone()),
             group: Some(config.group.clone()),
+            group_contains: false,
             data_id: Some(config.data_id.clone()),
             app_name: None,
             search: None,

--- a/crates/dbx-core/src/nacos/http.rs
+++ b/crates/dbx-core/src/nacos/http.rs
@@ -1411,13 +1411,31 @@ impl NacosAdmin for NacosOpenApiAdmin {
             .filter(|value| !value.is_empty());
         let search = data_id_filter.clone().unwrap_or_default();
         let group_filter = query.group.map(|value| value.trim().to_string()).filter(|value| !value.is_empty());
+        let group_contains = query.group_contains;
         let group = group_filter.clone().unwrap_or_default();
         let app_name_filter = query.app_name.map(|value| value.trim().to_string()).filter(|value| !value.is_empty());
         let app_name = app_name_filter.clone().unwrap_or_default();
+
+        // Nacos v2, v3, and r-nacos do not agree on whether a group filter is
+        // exact or fuzzy. Scan without that server-side constraint so the UI
+        // always provides the same case-insensitive contains semantics.
+        if group_contains && group_filter.is_some() {
+            return self
+                .list_configs_by_client_filters(
+                    namespace,
+                    data_id_filter,
+                    group_filter,
+                    app_name_filter,
+                    page_no,
+                    page_size,
+                )
+                .await;
+        }
+
         let value = self.get_config_list_value(&namespace, &search, &group, &app_name, page_no, page_size).await?;
         let parsed =
             self.enrich_missing_config_formats(parse_config_list(value, namespace.clone(), page_no, page_size)).await;
-        if (data_id_filter.is_some() || group_filter.is_some()) && parsed.items.is_empty() {
+        if data_id_filter.is_some() && parsed.items.is_empty() {
             let fallback = self
                 .list_configs_by_client_filters(
                     namespace,
@@ -2132,6 +2150,7 @@ impl NacosAdmin for NacosOpenApiAdmin {
         let configs_future = self.list_configs(NacosConfigQuery {
             namespace: Some(namespace.clone()),
             group: None,
+            group_contains: false,
             data_id: None,
             app_name: None,
             search: None,
@@ -3268,25 +3287,23 @@ mod tests {
         server.await.unwrap();
     }
 
-    #[tokio::test]
-    async fn group_filter_falls_back_to_client_side_contains_match() {
+    async fn assert_group_filter_uses_client_side_contains_match(
+        implementation: Option<NacosImplementation>,
+        version_mode: Option<NacosVersionMode>,
+        expected_path: &str,
+        group_param: &str,
+    ) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
+        let expected_path = expected_path.to_string();
+        let group_param = group_param.to_string();
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             let target = read_request_target(&mut socket).await;
             let url = reqwest::Url::parse(&format!("http://localhost{target}")).unwrap();
             let params = url.query_pairs().collect::<HashMap<_, _>>();
-            assert_eq!(url.path(), "/nacos/v1/cs/configs");
-            assert_eq!(params.get("group").map(|value| value.as_ref()), Some("sensitive"));
-            write_json_response(&mut socket, r#"{"totalCount":0,"pageItems":[]}"#).await;
-
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let target = read_request_target(&mut socket).await;
-            let url = reqwest::Url::parse(&format!("http://localhost{target}")).unwrap();
-            let params = url.query_pairs().collect::<HashMap<_, _>>();
-            assert_eq!(url.path(), "/nacos/v1/cs/configs");
-            assert_eq!(params.get("group").map(|value| value.as_ref()), Some(""));
+            assert_eq!(url.path(), expected_path);
+            assert_eq!(params.get(group_param.as_str()).map(|value| value.as_ref()), Some(""));
             write_json_response(
                 &mut socket,
                 r#"{"totalCount":2,"pageItems":[{"dataId":"service.yaml","group":"SENSITIVE_GROUP","tenant":"ops","type":"yaml"},{"dataId":"other.yaml","group":"DEFAULT_GROUP","tenant":"ops","type":"yaml"}]}"#,
@@ -3295,14 +3312,84 @@ mod tests {
         });
         let mut config = test_admin_config(format!("http://{address}"));
         config.context_path = "/nacos".to_string();
-        config.version_mode = Some(NacosVersionMode::V2);
+        config.implementation = implementation;
+        config.version_mode = version_mode;
         let admin = NacosOpenApiAdmin::new(config).unwrap();
 
         let list = admin
             .list_configs(NacosConfigQuery {
                 namespace: Some("ops".to_string()),
                 group: Some("sensitive".to_string()),
+                group_contains: true,
                 data_id: None,
+                app_name: None,
+                search: None,
+                page_no: Some(1),
+                page_size: Some(20),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(list.total_count, 1);
+        assert_eq!(list.items.len(), 1);
+        assert_eq!(list.items[0].group, "SENSITIVE_GROUP");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn group_filter_uses_consistent_client_side_contains_matching() {
+        assert_group_filter_uses_client_side_contains_match(
+            None,
+            Some(NacosVersionMode::V2),
+            "/nacos/v1/cs/configs",
+            "group",
+        )
+        .await;
+        assert_group_filter_uses_client_side_contains_match(
+            None,
+            Some(NacosVersionMode::V3),
+            "/nacos/v3/admin/cs/config/list",
+            "groupName",
+        )
+        .await;
+        assert_group_filter_uses_client_side_contains_match(
+            Some(NacosImplementation::RNacos),
+            None,
+            "/nacos/v1/cs/configs",
+            "group",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn exact_group_filter_keeps_server_side_matching() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let target = read_request_target(&mut socket).await;
+            let url = reqwest::Url::parse(&format!("http://localhost{target}")).unwrap();
+            let params = url.query_pairs().collect::<HashMap<_, _>>();
+            assert_eq!(url.path(), "/nacos/v3/admin/cs/config/list");
+            assert_eq!(params.get("groupName").map(|value| value.as_ref()), Some("SENSITIVE_GROUP"));
+            assert_eq!(params.get("dataId").map(|value| value.as_ref()), Some("service.yaml"));
+            write_json_response(
+                &mut socket,
+                r#"{"code":0,"data":{"totalCount":1,"pageItems":[{"dataId":"service.yaml","groupName":"SENSITIVE_GROUP","namespaceId":"ops","type":"yaml"}]}}"#,
+            )
+            .await;
+        });
+        let mut config = test_admin_config(format!("http://{address}"));
+        config.context_path = "/nacos".to_string();
+        config.version_mode = Some(NacosVersionMode::V3);
+        let admin = NacosOpenApiAdmin::new(config).unwrap();
+
+        let list = admin
+            .list_configs(NacosConfigQuery {
+                namespace: Some("ops".to_string()),
+                group: Some("SENSITIVE_GROUP".to_string()),
+                group_contains: false,
+                data_id: Some("service.yaml".to_string()),
                 app_name: None,
                 search: None,
                 page_no: Some(1),
@@ -4347,6 +4434,7 @@ mod tests {
             .list_configs(NacosConfigQuery {
                 namespace: Some("ops".to_string()),
                 group: None,
+                group_contains: false,
                 data_id: None,
                 app_name: None,
                 search: None,
@@ -4397,6 +4485,7 @@ mod tests {
             .list_configs(NacosConfigQuery {
                 namespace: Some("ops".to_string()),
                 group: None,
+                group_contains: false,
                 data_id: None,
                 app_name: None,
                 search: None,

--- a/crates/dbx-core/src/nacos/http.rs
+++ b/crates/dbx-core/src/nacos/http.rs
@@ -925,19 +925,20 @@ impl NacosOpenApiAdmin {
         .await
     }
 
-    async fn list_configs_by_client_filter(
+    async fn list_configs_by_client_filters(
         &self,
         namespace: String,
-        group: Option<String>,
         data_id_filter: Option<String>,
+        group_filter: Option<String>,
         app_name_filter: Option<String>,
         page_no: u32,
         page_size: u32,
     ) -> Result<NacosConfigList, String> {
-        let Some(filter) = data_id_filter.map(|value| value.to_lowercase()).filter(|value| !value.is_empty()) else {
+        let data_id_filter = data_id_filter.map(|value| value.to_lowercase()).filter(|value| !value.is_empty());
+        let group_filter = group_filter.map(|value| value.to_lowercase()).filter(|value| !value.is_empty());
+        if data_id_filter.is_none() && group_filter.is_none() {
             return Ok(NacosConfigList { page_no, page_size, total_count: 0, items: Vec::new() });
-        };
-        let group = group.unwrap_or_default();
+        }
         let app_name = app_name_filter.unwrap_or_default();
         let scan_page_size = page_size.max(self.cfg.page_size).clamp(100, 500);
         let mut matched = Vec::new();
@@ -945,15 +946,18 @@ impl NacosOpenApiAdmin {
         let mut current_page = 1;
 
         loop {
-            let value =
-                self.get_config_list_value(&namespace, "", &group, &app_name, current_page, scan_page_size).await?;
+            let value = self.get_config_list_value(&namespace, "", "", &app_name, current_page, scan_page_size).await?;
             let list = parse_config_list(value, namespace.clone(), current_page, scan_page_size);
             let total_count = list.total_count;
             let empty = list.items.is_empty();
             let before = seen.len();
             for item in list.items {
                 let identity = (item.namespace.clone(), item.group.clone(), item.data_id.clone());
-                if seen.insert(identity) && item.data_id.to_lowercase().contains(&filter) {
+                let data_id_matches =
+                    data_id_filter.as_ref().is_none_or(|filter| item.data_id.to_lowercase().contains(filter));
+                let group_matches =
+                    group_filter.as_ref().is_none_or(|filter| item.group.to_lowercase().contains(filter));
+                if seen.insert(identity) && data_id_matches && group_matches {
                     matched.push(item);
                 }
             }
@@ -1406,19 +1410,19 @@ impl NacosAdmin for NacosOpenApiAdmin {
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
         let search = data_id_filter.clone().unwrap_or_default();
-        let group_filter = query.group.clone();
+        let group_filter = query.group.map(|value| value.trim().to_string()).filter(|value| !value.is_empty());
         let group = group_filter.clone().unwrap_or_default();
         let app_name_filter = query.app_name.map(|value| value.trim().to_string()).filter(|value| !value.is_empty());
         let app_name = app_name_filter.clone().unwrap_or_default();
         let value = self.get_config_list_value(&namespace, &search, &group, &app_name, page_no, page_size).await?;
         let parsed =
             self.enrich_missing_config_formats(parse_config_list(value, namespace.clone(), page_no, page_size)).await;
-        if data_id_filter.is_some() && parsed.items.is_empty() {
+        if (data_id_filter.is_some() || group_filter.is_some()) && parsed.items.is_empty() {
             let fallback = self
-                .list_configs_by_client_filter(
+                .list_configs_by_client_filters(
                     namespace,
-                    group_filter,
                     data_id_filter,
+                    group_filter,
                     app_name_filter,
                     page_no,
                     page_size,
@@ -3261,6 +3265,55 @@ mod tests {
         let admin = NacosOpenApiAdmin::new(config).unwrap();
 
         admin.get_config_list_value("", "", "", "", 1, 20).await.unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn group_filter_falls_back_to_client_side_contains_match() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let target = read_request_target(&mut socket).await;
+            let url = reqwest::Url::parse(&format!("http://localhost{target}")).unwrap();
+            let params = url.query_pairs().collect::<HashMap<_, _>>();
+            assert_eq!(url.path(), "/nacos/v1/cs/configs");
+            assert_eq!(params.get("group").map(|value| value.as_ref()), Some("sensitive"));
+            write_json_response(&mut socket, r#"{"totalCount":0,"pageItems":[]}"#).await;
+
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let target = read_request_target(&mut socket).await;
+            let url = reqwest::Url::parse(&format!("http://localhost{target}")).unwrap();
+            let params = url.query_pairs().collect::<HashMap<_, _>>();
+            assert_eq!(url.path(), "/nacos/v1/cs/configs");
+            assert_eq!(params.get("group").map(|value| value.as_ref()), Some(""));
+            write_json_response(
+                &mut socket,
+                r#"{"totalCount":2,"pageItems":[{"dataId":"service.yaml","group":"SENSITIVE_GROUP","tenant":"ops","type":"yaml"},{"dataId":"other.yaml","group":"DEFAULT_GROUP","tenant":"ops","type":"yaml"}]}"#,
+            )
+            .await;
+        });
+        let mut config = test_admin_config(format!("http://{address}"));
+        config.context_path = "/nacos".to_string();
+        config.version_mode = Some(NacosVersionMode::V2);
+        let admin = NacosOpenApiAdmin::new(config).unwrap();
+
+        let list = admin
+            .list_configs(NacosConfigQuery {
+                namespace: Some("ops".to_string()),
+                group: Some("sensitive".to_string()),
+                data_id: None,
+                app_name: None,
+                search: None,
+                page_no: Some(1),
+                page_size: Some(20),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(list.total_count, 1);
+        assert_eq!(list.items.len(), 1);
+        assert_eq!(list.items[0].group, "SENSITIVE_GROUP");
         server.await.unwrap();
     }
 

--- a/crates/dbx-core/src/nacos/search.rs
+++ b/crates/dbx-core/src/nacos/search.rs
@@ -319,6 +319,7 @@ where
             .list_configs(NacosConfigQuery {
                 namespace: Some(namespace.to_string()),
                 group: request.group.clone(),
+                group_contains: false,
                 data_id: None,
                 app_name: None,
                 search: None,

--- a/crates/dbx-core/src/nacos/types.rs
+++ b/crates/dbx-core/src/nacos/types.rs
@@ -184,6 +184,10 @@ pub struct NacosConfigQuery {
     pub namespace: Option<String>,
     #[serde(default)]
     pub group: Option<String>,
+    /// Applies case-insensitive contains matching to `group` after listing.
+    /// Defaults to exact server-side filtering for internal callers.
+    #[serde(default)]
+    pub group_contains: bool,
     #[serde(default)]
     pub data_id: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
- 当服务端分组筛选无结果时，回退到客户端进行大小写无关的分组包含匹配
- 为配置和服务筛选输入框增加一键清空按钮及无障碍标签
- 调整健康实例标签为绿色描边样式，保留异常实例红色提示
- 补充分组筛选回退与界面样式测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="439" height="240" alt="image" src="https://github.com/user-attachments/assets/efa97269-f02a-44fa-a05d-ccd7cfc6d3ff" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #5492