### PR TITLE
Fix：修复跨数据库表跳转使用当前数据库的问题

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -114,7 +114,7 @@ import { metadataSchemaForConnection, sqlSnippetDatabaseTypeForConnection } from
 import { usesLocalOnlyEditorCompletionMetadata, usesOnDemandOnlyEditorColumnMetadata } from "@/lib/metadata/completionMetadataPolicy";
 import { loadObjectDdl } from "@/lib/metadata/objectDdlCache";
 import { loadObjectMetadataFacet } from "@/lib/metadata/objectMetadataCache";
-import { queryContextObjectActions, queryContextObjectRoute, queryTableCandidateAtSqlPosition, resolveQueryContextCandidateDatabase, resolveQueryContextObjectTarget, type QueryContextObjectAction } from "@/lib/sql/queryCursorTableTarget";
+import { queryContextObjectActions, queryContextObjectRoute, queryTableCandidateAtSqlPosition, queryTableNavigationTargetAtSqlPosition, resolveQueryContextCandidateDatabase, resolveQueryContextObjectTarget, type QueryContextObjectAction } from "@/lib/sql/queryCursorTableTarget";
 import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { isMacOS } from "@/lib/backend/platform";
@@ -4512,6 +4512,18 @@ onMounted(async () => {
               const objectSchemaHint = identity.parts.length >= 3 ? identity.schema : identity.parts.length === 1 ? props.schema : undefined;
               const isRoutineCall = identity.role === "routine_call";
               const isRelationColumnList = identity.role === "relation_column_list";
+              const relationNavigationTarget = (target: SqlObjectNavigationTarget) =>
+                queryTableNavigationTargetAtSqlPosition(
+                  {
+                    connectionId: props.connectionId!,
+                    database: props.database!,
+                    schema: props.schema,
+                    databaseType: props.databaseType,
+                    sql: doc,
+                    position: pos,
+                  },
+                  target,
+                );
 
               // 1. Local table cache (sync). Relation column lists always prefer tables over routines.
               if (cachedTables.length === 0) {
@@ -4520,7 +4532,7 @@ onMounted(async () => {
 
               let matchedTable = matchTable(identifier, cachedTables);
               if (matchedTable) {
-                emit("clickTable", sqlObjectNavigationTarget(matchedTable));
+                emit("clickTable", relationNavigationTarget(matchedTable));
                 return;
               }
 
@@ -4581,7 +4593,7 @@ onMounted(async () => {
                 cachedTables = await connectionStore.listCompletionTables(props.connectionId!, props.database!, tableLookupFilter, MAX_COMPLETION_TABLES, props.schema, false, props.schema, props.catalog);
                 matchedTable = matchTable(identifier, cachedTables);
                 if (matchedTable) {
-                  emit("clickTable", sqlObjectNavigationTarget(matchedTable));
+                  emit("clickTable", relationNavigationTarget(matchedTable));
                   return;
                 }
               } else if (!usesLocalOnlyCompletionMetadata() && isRoutineCall) {
@@ -4590,7 +4602,7 @@ onMounted(async () => {
                 cachedTables = await connectionStore.listCompletionTables(props.connectionId!, props.database!, tableLookupFilter, 20, props.schema, false, props.schema, props.catalog);
                 matchedTable = matchTable(identifier, cachedTables);
                 if (matchedTable) {
-                  emit("clickTable", sqlObjectNavigationTarget(matchedTable));
+                  emit("clickTable", relationNavigationTarget(matchedTable));
                   return;
                 }
               }
@@ -4629,7 +4641,7 @@ onMounted(async () => {
 
               const matchedRef = matchTable(identifier, referencedTables);
               if (matchedRef) {
-                emit("clickTable", sqlObjectNavigationTarget(matchedRef));
+                emit("clickTable", relationNavigationTarget(matchedRef));
                 return;
               }
               const colName = identifierParts[identifierParts.length - 1] ?? identifier;

--- a/apps/desktop/src/lib/sql/queryCursorTableTarget.ts
+++ b/apps/desktop/src/lib/sql/queryCursorTableTarget.ts
@@ -78,6 +78,20 @@ export function queryTableCandidateAtSqlPosition(input: QueryTableCandidateAtPos
   return { connectionId: input.connectionId, database, schema, tableName };
 }
 
+export function queryTableNavigationTargetAtSqlPosition(input: QueryTableCandidateAtPositionInput, target: SqlObjectNavigationTarget): SqlObjectNavigationTarget {
+  const parts = extractQualifiedIdentifierPartsAt(input.sql, input.position);
+  if (parts.length < 2) return sqlObjectNavigationTarget(target);
+
+  const candidate = queryTableCandidateAtSqlPosition(input);
+  if (!candidate) return sqlObjectNavigationTarget(target);
+
+  return sqlObjectNavigationTarget({
+    ...target,
+    database: candidate.database,
+    schema: candidate.schema,
+  });
+}
+
 export function resolveQueryContextCandidateDatabase(candidate: QueryCursorTableCandidate, databases: readonly string[]): QueryCursorTableCandidate {
   const database = databases.find((name) => sameIdentifier(name, candidate.database));
   return database && database !== candidate.database ? { ...candidate, database } : candidate;

--- a/packages/app-tests/queryCursorTableTarget.test.ts
+++ b/packages/app-tests/queryCursorTableTarget.test.ts
@@ -8,6 +8,7 @@ import {
   queryContextTargetFromCandidate,
   queryCursorTableCandidate,
   queryTableCandidateAtSqlPosition,
+  queryTableNavigationTargetAtSqlPosition,
   resolveQueryContextCandidateDatabase,
   resolveQueryContextObjectTarget,
 } from "../../apps/desktop/src/lib/sql/queryCursorTableTarget.ts";
@@ -85,6 +86,70 @@ test("builds database-qualified candidates for multi-database non-schema engines
     schema: undefined,
     tableName: "events",
   });
+});
+
+test("maps qualified relation navigation to database or schema by dialect", () => {
+  const mysqlSql = "select * from promotion.p_settlement_account";
+  assert.deepEqual(
+    queryTableNavigationTargetAtSqlPosition(
+      {
+        connectionId: "conn-1",
+        database: "nova",
+        databaseType: "mysql",
+        sql: mysqlSql,
+        position: mysqlSql.indexOf("p_settlement_account"),
+      },
+      { name: "p_settlement_account", schema: "promotion", type: "table" },
+    ),
+    {
+      name: "p_settlement_account",
+      database: "promotion",
+      type: "table",
+    },
+  );
+
+  const postgresSql = "select * from reporting.orders";
+  assert.deepEqual(
+    queryTableNavigationTargetAtSqlPosition(
+      {
+        connectionId: "conn-1",
+        database: "app",
+        schema: "public",
+        databaseType: "postgres",
+        sql: postgresSql,
+        position: postgresSql.indexOf("orders"),
+      },
+      { name: "orders", schema: "reporting", type: "view" },
+    ),
+    {
+      name: "orders",
+      database: "app",
+      schema: "reporting",
+      type: "view",
+    },
+  );
+});
+
+test("keeps metadata scope for unqualified relation navigation", () => {
+  const sql = "select * from orders";
+  assert.deepEqual(
+    queryTableNavigationTargetAtSqlPosition(
+      {
+        connectionId: "conn-1",
+        database: "app",
+        schema: "public",
+        databaseType: "postgres",
+        sql,
+        position: sql.indexOf("orders"),
+      },
+      { name: "Orders", schema: "archive", type: "table" },
+    ),
+    {
+      name: "Orders",
+      schema: "archive",
+      type: "table",
+    },
+  );
 });
 
 test("builds three-part candidates at an explicit context-menu position", () => {


### PR DESCRIPTION
## 问题

SQL 编辑器中通过 Command/Ctrl + 点击跳转 MySQL 跨数据库表时，限定名中的数据库可能被当作 schema 处理，导致目标表继续使用当前选中的数据库并打开错误对象。

## 修复

- 在触发表导航前，按数据库方言重新解析光标处的限定表名
- MySQL 等多数据库方言将 `database.table` 正确映射到目标数据库
- PostgreSQL 等 schema 方言继续保留 `schema.table` 行为
- 未限定表名继续使用元数据中的对象范围，避免影响现有跳转逻辑
- 补充限定表名及未限定表名的回归测试

## 验证

- 使用现有 MySQL 实例，以 `demo_cafe_core` 为当前库执行 `SELECT * FROM demo_2000_tables.t_0001`，成功返回 100 行
- Command + 点击 `demo_2000_tables.t_0001` 后，打开 `t_0001@demo_2000_tables`，详情查询成功且未沿用当前库
- `pnpm -s exec vitest run apps/desktop/src/lib/__tests__/editor/queryEditor*.spec.ts apps/desktop/src/lib/__tests__/sql/sqlNavigation.spec.ts packages/app-tests/queryCursorTableTarget.test.ts`（134 项通过）
- `pnpm -s typecheck`
- `pnpm -s exec oxfmt --check ...`
- `pnpm -s exec oxlint --vue-plugin ...`
