### PR TITLE
fix(web): serve index.html at base path root for subpath deployments

### DIFF
--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -799,6 +799,14 @@ async fn main() {
 
     if public_base_path != "/" {
         app = Router::new().nest(&public_base_path, app);
+        // axum 的 nest 不匹配“子路径根目录”(带尾斜杠,如 /dbx/),导致子路径部署时首页 404。
+        // 在 nest 外层显式把根目录挂到 index.html,浏览器地址栏保持 /dbx/ 不变,
+        // 相对资源与前端路径推断都依赖这个 URL 形态。见 issue #5518。
+        if let Ok(static_dir) = std::env::var("DBX_STATIC_DIR") {
+            use tower_http::services::ServeFile;
+            let index_path = format!("{static_dir}/index.html");
+            app = app.route_service(&format!("{public_base_path}/"), ServeFile::new(index_path));
+        }
     }
 
     // Bind address


### PR DESCRIPTION
## Problem

When `DBX_PUBLIC_BASE_PATH` is set (e.g. `/dbx`), the homepage at the base path root returns **404** even though the service starts normally. `/dbx/index.html`, `/dbx/assets/*` and all `/dbx/api/*` routes work.

This breaks reverse-proxy subpath deployments: the browser loads `/dbx/` (or is redirected there), gets a 404, and the app cannot be used. Related: #5518, #2099.

## Root cause

The web server mounts the whole app with `Router::new().nest(&public_base_path, app)`. axum's `nest()` matches `/dbx` and `/dbx/{path}` but **not** the trailing-slash root `/dbx/`, so the root request never reaches the `ServeDir` fallback and returns 404.

## Fix

After nesting, explicitly register a route at `{public_base_path}/` that serves `index.html` directly:

```rust
if public_base_path != "/" {
    app = Router::new().nest(&public_base_path, app);
    if let Ok(static_dir) = std::env::var("DBX_STATIC_DIR") {
        use tower_http::services::ServeFile;
        let index_path = format!("{static_dir}/index.html");
        app = app.route_service(&format!("{public_base_path}/"), ServeFile::new(index_path));
    }
}
```

The browser URL stays at `/dbx/`, so relative asset URLs and the frontend's runtime base-path inference keep working.

## Verification

Reproduced with a minimal axum 0.8.9 / tower-http 0.6.11 app using the same router structure:

| path | before | after |
| --- | --- | --- |
| `/dbx` | 200 | 200 |
| `/dbx/` | 404 | 200 |
| `/dbx/index.html` | 200 | 200 |
| `/dbx/api/...` | 200 | 200 |
| `/` (no base path) | 200 | 200 |

Closes #5518
