### PR TITLE
fix(macos): surface failed main-window reveals instead of discarding them

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -476,11 +476,34 @@ fn apply_linux_webkit_rendering_workarounds() {
     }
 }
 
-fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.show();
-        let _ = window.unminimize();
-        let _ = window.set_focus();
+/// Brings the main window to the foreground, reporting whether it ended up visible.
+///
+/// The individual calls used to be discarded with `let _ =`, which made a failed
+/// reveal completely silent. That matters on macOS: an instance that has lost its
+/// WindowServer connection stays alive and idle but can no longer present a window
+/// or a tray icon, and the single-instance guard keeps handing later launches to it,
+/// so the app looks like it simply does not start. Logging here is what makes that
+/// state diagnosable at all.
+fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    let Some(window) = app.get_webview_window("main") else {
+        eprintln!("[WINDOW] show_main_window: no \"main\" webview window to reveal");
+        return false;
+    };
+    if let Err(err) = window.show() {
+        eprintln!("[WINDOW] show_main_window: show() failed: {err}");
+    }
+    if let Err(err) = window.unminimize() {
+        eprintln!("[WINDOW] show_main_window: unminimize() failed: {err}");
+    }
+    if let Err(err) = window.set_focus() {
+        eprintln!("[WINDOW] show_main_window: set_focus() failed: {err}");
+    }
+    match window.is_visible() {
+        Ok(visible) => visible,
+        Err(err) => {
+            eprintln!("[WINDOW] show_main_window: is_visible() failed: {err}");
+            false
+        }
     }
 }
 
@@ -736,7 +759,9 @@ fn setup_desktop_tray<R: tauri::Runtime, M: Manager<R>>(
     })
     .on_tray_icon_event(|tray, event| match event {
         TrayIconEvent::Click { button: MouseButton::Left, button_state: MouseButtonState::Up, .. }
-        | TrayIconEvent::DoubleClick { button: MouseButton::Left, .. } => show_main_window(tray.app_handle()),
+        | TrayIconEvent::DoubleClick { button: MouseButton::Left, .. } => {
+            show_main_window(tray.app_handle());
+        }
         _ => {}
     })
     .build(manager)?;
@@ -1240,7 +1265,16 @@ pub fn run() {
                 }
                 let _ = app.emit("dbx-open-db-files", db_paths);
             }
-            show_main_window(app);
+            // This runs inside the *existing* instance: a second launch has already
+            // handed over its arguments and exited. If we cannot reveal a window here
+            // the user is left with no feedback whatsoever - the app they clicked
+            // simply vanished - so make the reason recoverable from the logs.
+            if !show_main_window(app) {
+                eprintln!(
+                    "[WINDOW] single-instance handoff could not reveal the main window; {}",
+                    main_window_probe_state(app)
+                );
+            }
         }))
     } else {
         builder
@@ -2134,8 +2168,13 @@ pub fn run() {
 
             #[cfg(target_os = "macos")]
             if let RunEvent::Reopen { has_visible_windows, .. } = &event {
-                if !has_visible_windows {
-                    show_main_window(app_handle);
+                if !has_visible_windows && !show_main_window(app_handle) {
+                    // Dock / Finder reopen is the other way back into a hidden
+                    // instance, and it fails silently for the same reason.
+                    eprintln!(
+                        "[WINDOW] reopen could not reveal the main window; {}",
+                        main_window_probe_state(app_handle)
+                    );
                 }
                 let app_handle = app_handle.clone();
                 tauri::async_runtime::spawn(async move {


### PR DESCRIPTION
Refs #5262

## Problem

`show_main_window` discarded all three of its calls:

```rust
fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
    if let Some(window) = app.get_webview_window("main") {
        let _ = window.show();
        let _ = window.unminimize();
        let _ = window.set_focus();
    }
}
```

So a failed reveal produced **no output at all**, on any platform.

That silence is what makes #5262 so hard to diagnose. On macOS an instance can lose its WindowServer (CoreGraphics) connection and keep running, idle: it can no longer present a window *or* render a tray icon, but it still holds the single-instance lock. Every later launch is handed to that instance and exits `0` in ~115 ms. From the user's side the app simply does not start — no error, no window, no crash report.

In the case I hit, the stuck process had been alive 5h22m and was invisible to LaunchServices:

```console
$ lsappinfo info 60873
    pid =  !cgsConnection !signalled  Arch=!!none      # all fields NULL
```

...while `sample` showed a perfectly normal, idle Cocoa event loop at 0% CPU (`-[NSApplication run]` → `mach_msg2_trap`) — so the process was *healthy, just blind*. With `quit_on_close: false` the window had been hidden rather than quit, and all three ways back (window, tray icon, Dock reopen) fail together.

## What this PR does

Narrow scope: it makes the failure **observable**. No behaviour change on the success path.

- `show_main_window` now returns whether the window actually ended up visible, and logs each failing call (`show`, `unminimize`, `set_focus`, `is_visible`) rather than swallowing it.
- The single-instance handoff logs `main_window_probe_state` when it cannot reveal a window. That helper already existed and computed exactly the right thing — it just was not used on this path.
- The macOS `RunEvent::Reopen` path gets the same diagnostic, since it fails identically.

`eprintln!` is deliberate rather than `log::`. `append_startup_probe` routes to `startup_recovery::record`, which is the no-op implementation everywhere except Windows, and `log` is set to `LevelFilter::Off` unless the user has enabled debug logging — so neither leaves a trace in exactly the situation that needs one.

## What this PR deliberately does *not* do

It does not attempt automatic recovery, and I want to be upfront about why rather than ship something that looks like a fix.

**I could not reproduce the lost WindowServer connection on demand.** Without a reproduction I cannot verify that any liveness probe actually detects the broken state — an `NSWindow` in a process that has lost its CGS connection may well still report `isVisible == true`, in which case a probe would silently never fire. And a probe that gets it *wrong in the other direction* would tear down a healthy instance and lose the user's unsaved editor state, which is considerably worse than the bug it is trying to fix.

So the recovery step needs a liveness signal that is known-good, and this PR is the prerequisite: with these logs, the next occurrence produces the evidence needed to build that check on something real.

If you would like to go further in this PR, the options I can see are:

1. On failed reveal, have the stale instance exit so the *next* launch succeeds (one dead click instead of a permanent lockout).
2. Same, but re-spawn a detached replacement first — mirroring what `startup_recovery` already does on Windows.
3. If the tray icon fails to install, fall back to `quit_on_close: true` so a hidden unreachable process cannot happen in the first place.

Happy to implement whichever you prefer, or to drop the diagnostics into a different shape if you would rather they went through `log::`.

## Testing

```
cargo check   --no-default-features   # clean
cargo test    --no-default-features --lib   # 196 passed
cargo clippy  --no-default-features -- -D warnings   # clean
cargo fmt -- --check   # clean
```

No new tests: the changed function needs a live Tauri window to exercise, and the failure mode it reports is the one I could not reproduce. The pure helpers around it are already covered by the existing suite.

Manual verification of the underlying bug and the workaround: `SIGTERM` on the stuck process exited it in ~2s, and the relaunched instance registered correctly (`lsappinfo` → `LSDisplayName="DBX"`, RSS 115 MB vs the stuck process's 1.2 MB) and came to the front.

---

### 中文说明

`show_main_window` 用 `let _ =` 丢弃了 `show()`、`unminimize()`、`set_focus()` 的全部返回值，因此窗口显示失败时**没有任何输出**。

这正是 #5262 难以定位的原因：在 macOS 上，实例可能丢失与 WindowServer (CoreGraphics) 的连接后继续空闲运行 —— 既无法显示窗口，也无法渲染托盘图标，但仍持有 single-instance 锁。之后每次启动都会把参数转交给它并在约 115ms 内以 `0` 退出，用户看到的就是"点了没反应"，且没有报错、没有窗口、没有 crash report。

本 PR 只做一件事：**让失败可见**，成功路径行为不变。

- `show_main_window` 返回窗口最终是否可见，并记录每个失败的调用。
- single-instance 回调在无法显示窗口时输出 `main_window_probe_state`（该函数已存在，只是没用在这条路径上）。
- macOS `RunEvent::Reopen` 路径同样加上该诊断。

使用 `eprintln!` 而非 `log::` 是有意的：`append_startup_probe` 在非 Windows 平台是 no-op，而 `log` 在未开启 debug logging 时为 `LevelFilter::Off`，两者恰好在最需要日志的场景下都不会留下记录。

**本 PR 不包含自动恢复。** 我无法稳定复现 CGS 连接丢失的状态，因此无法验证任何存活检测是否真的能识别该状态（丢失 CGS 连接的 `NSWindow` 可能仍然返回 `isVisible == true`）；而误判则会导致健康实例被强制重启、丢失用户未保存的编辑内容，后果比原 bug 更严重。上面列出了三种可选的后续方案，您倾向哪种我都可以实现。
