### PR TITLE
Fix：修复 Windows 7 Oracle Agent 启动崩溃

### DIFF
--- a/.github/workflows/agents-release.yml
+++ b/.github/workflows/agents-release.yml
@@ -179,7 +179,6 @@ jobs:
             ["linux-aarch64"]="linux/arm64"
             ["linux-x64"]="linux/amd64"
             ["windows-aarch64"]="windows/arm64"
-            ["windows-x64"]="windows/amd64"
           )
           for platform in "${!TARGETS[@]}"; do
             IFS=/ read -r goos goarch <<< "${TARGETS[$platform]}"
@@ -191,6 +190,20 @@ jobs:
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags="-s -w" -o "$output" .
           done
           ls -lh ../../../release-native
+      # Go 1.20 is the last release that supports Windows 7; keep other targets on Go 1.22.
+      - name: Set up Go for Windows 7-compatible Oracle agent
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.20.14"
+          cache-dependency-path: agents/drivers/oracle-go/go.sum
+      - name: Build Windows 7-compatible Oracle agent
+        shell: bash
+        working-directory: agents/drivers/oracle-go
+        run: |
+          output="../../../release-native/dbx-agent-oracle-windows-x64.exe"
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o "$output" .
+          go version -m "$output" | tee /tmp/oracle-windows-x64-build-info.txt
+          grep -q ': go1\.20\.14$' /tmp/oracle-windows-x64-build-info.txt
       - uses: actions/upload-artifact@v4
         with:
           name: oracle-native

--- a/agents/drivers/oracle-go/go.mod
+++ b/agents/drivers/oracle-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/t8y2/dbx/agents/drivers/oracle-go
 
-go 1.22
+go 1.20
 
 require github.com/sijms/go-ora/v2 v2.9.0
 


### PR DESCRIPTION
## 问题

Windows 7 用户安装 Oracle 驱动后，Agent 在输出启动握手前直接退出：

```text
Failed to read startup line from agent: end of stream
agent process exited with exit code: 2
```

SQL Server、SQLite、MySQL、PostgreSQL 均可正常使用。检查实际发布的 `agents-v0.2.77` 后确认，Oracle Windows x64 Agent 由 Go 1.22.12 构建；Go 1.21 起最低要求 Windows 10 / Windows Server 2016，因此该原生 Agent 无法在 Windows 7 启动。

官方说明：https://go.dev/doc/go1.21#windows

## 修改

- 将 Oracle Agent 的 Go 语言版本声明调整为 1.20。
- macOS、Linux、Windows ARM64 仍使用 Go 1.22 构建。
- 仅 Oracle `windows-x64` 使用最后支持 Windows 7 的 Go 1.20.14 构建。
- 发布流程校验 Windows x64 产物内嵌的 Go 版本，避免误用不支持 Win7 的工具链。

## 验证

- `GOTOOLCHAIN=go1.20.14 go test ./...`
- `CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build ...`
- `go version -m`：确认产物为 `go1.20.14`、`GOOS=windows`、`GOARCH=amd64`
- Go 1.20.14 本机产物可正常输出 `{"ready":true}` 启动握手
- `python3 scripts/validate_agents.py`
- Agent 脚本单测 21 项通过
- Agent 发布工作流语法检查通过

当前缺少真实 Windows 7 环境，最终 Oracle 连接仍需在 Win7 机器上验收。
