### PR TITLE
fix(sidebar): match cross-word table names via word-segment prefix concatenation (#5407)

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -379,15 +379,14 @@ function filterLocallySearchedTables(nodes: TreeNode[]): TreeNode[] {
     if (!query || !children) return children === node.children ? node : { ...node, children };
 
     const indexed = localTableSearchResults.value[node.id];
+    // matchSidebarLabel compares case-insensitively internally and needs the
+    // ORIGINAL label (and entry name) so camelCase boundaries stay detectable.
     const matchingChildren =
       indexed === null
-        ? children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label.toLowerCase(), query.toLowerCase()))
+        ? children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label, query))
         : indexed
-          ? reuseLiveSidebarTreeNodes(
-              buildTableTreeNodes({ nodeId: node.id, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, tables: indexed.filter((entry) => !!matchSidebarLabel(entry.name.toLowerCase(), query.toLowerCase())) }),
-              children,
-            )
-          : children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label.toLowerCase(), query.toLowerCase()));
+          ? reuseLiveSidebarTreeNodes(buildTableTreeNodes({ nodeId: node.id, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, tables: indexed.filter((entry) => !!matchSidebarLabel(entry.name, query)) }), children)
+          : children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label, query));
     return { ...node, children: matchingChildren };
   });
 }

--- a/apps/desktop/src/lib/sidebar/sidebarSearch.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearch.ts
@@ -12,7 +12,12 @@ export type SidebarLabelMatcher = (label: string) => SidebarSearchMatch | null;
 function isWordBoundary(text: string, index: number): boolean {
   if (index === 0) return true;
   const prev = text[index - 1];
-  return prev === "_" || prev === "-" || prev === "." || prev === " " || prev === "/" || prev === "\\";
+  if (prev === "_" || prev === "-" || prev === "." || prev === " " || prev === "/" || prev === "\\") return true;
+  // camelCase transition: "camelCaseTable" reads as "camel" | "Case" | "Table".
+  // Extends word segmentation only — tier priority and labels without a
+  // lowercase-to-uppercase transition are unchanged.
+  const curr = text[index];
+  return prev >= "a" && prev <= "z" && curr >= "A" && curr <= "Z";
 }
 
 const SEPARATOR_RE = /[_\-. /\\]/g;
@@ -27,17 +32,23 @@ function stripSeparators(text: string): string {
   return text.replace(SEPARATOR_RE, "");
 }
 
+// Boundary-aware helpers take the ORIGINAL label so `isWordBoundary` can see
+// camelCase transitions, and a LOWER-CASED query. `toLowerCase` preserves
+// string length, so label/query indices stay aligned.
+
 function matchesWordPrefix(text: string, query: string): boolean {
+  const lowerText = text.toLowerCase();
   for (let i = 0; i < text.length; i++) {
-    if (isWordBoundary(text, i) && text.startsWith(query, i)) return true;
+    if (isWordBoundary(text, i) && lowerText.startsWith(query, i)) return true;
   }
   return false;
 }
 
 function matchesAbbreviation(text: string, query: string): boolean {
+  const lowerText = text.toLowerCase();
   let j = 0;
   for (let i = 0; i < text.length && j < query.length; i++) {
-    if (isWordBoundary(text, i) && text[i] === query[j]) j++;
+    if (isWordBoundary(text, i) && lowerText[i] === query[j]) j++;
   }
   return j === query.length;
 }
@@ -45,14 +56,78 @@ function matchesAbbreviation(text: string, query: string): boolean {
 function matchesSubsequence(text: string, query: string): boolean {
   if (query.length < 2 || query.length > text.length) return false;
 
+  const lowerText = text.toLowerCase();
   let j = 0;
   for (let i = 0; i < text.length && j < query.length; i++) {
     if (isWordBoundary(text, i) && i > 0) {
       j = 0;
     }
-    if (text[i] === query[j]) j++;
+    if (lowerText[i] === query[j]) j++;
   }
   return j === query.length;
+}
+
+const MIN_CONCAT_PREFIX_LEN = 2;
+
+/**
+ * Split an identifier into words for word-segment prefix concatenation.
+ * Splits on the same separators as `isWordBoundary`/`stripSeparators` and on
+ * camelCase transitions ("camelCaseTable" -> "camel", "Case", "Table").
+ * Original case is preserved so transitions stay detectable.
+ */
+function splitLabelWords(label: string): string[] {
+  const words: string[] = [];
+  for (const segment of label.split(SEPARATOR_RE)) {
+    if (!segment) continue;
+    let start = 0;
+    for (let index = 1; index < segment.length; index++) {
+      const prev = segment[index - 1];
+      const curr = segment[index];
+      if (prev >= "a" && prev <= "z" && curr >= "A" && curr <= "Z") {
+        words.push(segment.slice(start, index));
+        start = index;
+      }
+    }
+    words.push(segment.slice(start));
+  }
+  return words;
+}
+
+/**
+ * Word-segment prefix concatenation (DataGrip-style). A query matches when it
+ * can be split into k >= 2 pieces, each length >= 2 and a prefix of a distinct
+ * label word consumed in order (words may be skipped). This is the tier that
+ * makes "exclog" match "system_exception_log" ("exc" from exception + "log")
+ * and "syslog" match it (skipping the middle word). The min-2-chars-per-piece
+ * rule keeps loose cross-word queries ("roles" on "sys_role_data_scope",
+ * "urf" on "user_profile") from matching. Matching is case-insensitive so the
+ * camelCase words found by `splitLabelWords` align with lowercase queries.
+ */
+function matchesWordPrefixConcatenation(label: string, query: string): boolean {
+  const words = splitLabelWords(label);
+  if (words.length < 2 || query.length < 2 * MIN_CONCAT_PREFIX_LEN) return false;
+
+  const lowerQuery = query.toLowerCase();
+  const queryLength = query.length;
+  const INF = Infinity;
+  // dp[j] = fewest words needed to consume lowerQuery[0..j).
+  let dp = Array.from({ length: queryLength + 1 }, () => INF);
+  dp[0] = 0;
+  for (const word of words) {
+    const next = [...dp];
+    const lowerWord = word.toLowerCase();
+    for (let j = 0; j < queryLength; j++) {
+      if (dp[j] === INF) continue;
+      const maxLen = Math.min(word.length, queryLength - j);
+      for (let len = MIN_CONCAT_PREFIX_LEN; len <= maxLen; len++) {
+        if (lowerWord.startsWith(lowerQuery.slice(j, j + len))) {
+          next[j + len] = Math.min(next[j + len], dp[j] + 1);
+        }
+      }
+    }
+    dp = next;
+  }
+  return dp[queryLength] !== INF && dp[queryLength] >= 2;
 }
 
 function matchSidebarLabelWithRegex(label: string, query: string, regex: RegExp | null): SidebarSearchMatch | null {
@@ -60,20 +135,35 @@ function matchSidebarLabelWithRegex(label: string, query: string, regex: RegExp 
 
   if (regex) return regex.test(label) ? { kind: "regex", score: 95 } : null;
 
-  if (label === query) return { kind: "exact", score: 100 };
-  if (label.startsWith(query)) return { kind: "prefix", score: 90 };
-  if (matchesWordPrefix(label, query)) return { kind: "word-prefix", score: 80 };
-  if (label.includes(query)) return { kind: "substring", score: 70 };
-  if (query.length >= 2 && matchesAbbreviation(label, query)) return { kind: "abbreviation", score: 60 };
-  if (matchesSubsequence(label, query)) return { kind: "fuzzy", score: 40 };
+  // Case-insensitive comparison is centralized here so callers can pass the
+  // original label and query. The original label is what the boundary-aware
+  // tiers below need to detect camelCase transitions ("camelCaseTable" reads
+  // as "camel" | "Case" | "Table").
+  const lowerLabel = label.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+
+  if (lowerLabel === lowerQuery) return { kind: "exact", score: 100 };
+  if (lowerLabel.startsWith(lowerQuery)) return { kind: "prefix", score: 90 };
+  if (matchesWordPrefix(label, lowerQuery)) return { kind: "word-prefix", score: 80 };
+  if (lowerLabel.includes(lowerQuery)) return { kind: "substring", score: 70 };
+  if (lowerQuery.length >= 2 && matchesAbbreviation(label, lowerQuery)) return { kind: "abbreviation", score: 60 };
+  if (matchesSubsequence(label, lowerQuery)) return { kind: "fuzzy", score: 40 };
 
   // Separator-blind matching: strip underscores, hyphens, dots, spaces,
   // and slashes, then try again.  This lets "delo" match "del_order"
   // without typing the underscore separator between prefix and name.
-  const stripped = stripSeparators(label);
-  if (stripped !== label && stripped.length >= query.length) {
-    if (stripped.startsWith(query)) return { kind: "word-prefix", score: 65 };
-    if (stripped.includes(query)) return { kind: "substring", score: 55 };
+  const stripped = stripSeparators(lowerLabel);
+  if (stripped !== lowerLabel && stripped.length >= lowerQuery.length) {
+    if (stripped.startsWith(lowerQuery)) return { kind: "word-prefix", score: 65 };
+    if (stripped.includes(lowerQuery)) return { kind: "substring", score: 55 };
+  }
+
+  // Word-segment prefix concatenation: lets "exclog" find
+  // "system_exception_log". Uses the ORIGINAL label so camelCase boundaries
+  // survive for word segmentation, and compares case-insensitively. Flat 50
+  // keeps it below every existing tier — purely additive.
+  if (matchesWordPrefixConcatenation(label, query)) {
+    return { kind: "abbreviation", score: 50 };
   }
 
   return null;

--- a/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
@@ -3,23 +3,20 @@ import { createSidebarLabelMatcher, type SidebarLabelMatcher } from "@/lib/sideb
 
 const preserveMatchedSubtreeTypes = new Set(["connection", "database", "schema", "table", "view", "mongo-db", "mongo-collection"]);
 
-const normalizedLabelCache = new WeakMap<TreeNode, { label: string; normalized: string }>();
-
 function bestMatch(matchLabel: SidebarLabelMatcher, label: string, comment?: string | null) {
   const lm = matchLabel(label);
   if (!comment) return lm;
-  const cm = matchLabel(comment.toLowerCase());
+  const cm = matchLabel(comment);
   if (lm && cm) return lm.score >= cm.score ? lm : cm;
   return lm ?? cm;
 }
 
 function normalizedLabel(node: TreeNode): string {
-  const cached = normalizedLabelCache.get(node);
-  if (cached?.label === node.label) return cached.normalized;
-
-  const normalized = node.label.toLowerCase();
-  normalizedLabelCache.set(node, { label: node.label, normalized });
-  return normalized;
+  // Keep the original case. The matcher lowercases internally for comparison;
+  // preserving case here lets it tokenize camelCase labels ("camelCaseTable"
+  // -> "camel" | "Case" | "Table") instead of treating them as one lowercase
+  // blob.
+  return node.label;
 }
 
 export function filterSidebarTree(nodes: TreeNode[], query: string, collapsedIds: ReadonlySet<string>, searchableNodeTypes?: ReadonlySet<TreeNodeType>): TreeNode[] {

--- a/packages/app-tests/sidebarSearch.test.ts
+++ b/packages/app-tests/sidebarSearch.test.ts
@@ -17,6 +17,10 @@ test("matches word prefixes in underscored and dotted identifiers", () => {
 test("matches DataGrip-style abbreviations by identifier word boundaries", () => {
   assert.equal(matchSidebarLabel("additional_country", "ac")?.kind, "abbreviation");
   assert.equal(matchSidebarLabel("sales.customer_profile", "scp")?.kind, "abbreviation");
+  // Existing behavior: s/system + e/exception + l/log.
+  const sel = matchSidebarLabel("system_exception_log", "sel");
+  assert.equal(sel?.kind, "abbreviation");
+  assert.equal(sel?.score, 60);
 });
 
 test("keeps one-character fuzzy matches disabled", () => {

--- a/packages/app-tests/sidebarSearch.test.ts
+++ b/packages/app-tests/sidebarSearch.test.ts
@@ -1,6 +1,8 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import { matchSidebarLabel } from "../../apps/desktop/src/lib/sidebar/sidebarSearch.ts";
+import { filterSidebarTree } from "../../apps/desktop/src/lib/sidebar/sidebarSearchTree.ts";
+import type { TreeNode } from "../../apps/desktop/src/types/database.ts";
 
 test("matches exact and prefix labels first", () => {
   assert.equal(matchSidebarLabel("orders", "orders")?.kind, "exact");
@@ -384,4 +386,117 @@ test("matches slash-delimited regular expression queries case-insensitively by d
 
 test("keeps invalid regular expression queries from matching every label", () => {
   assert.equal(matchSidebarLabel("orders", "/["), null);
+});
+
+// Cross-word prefix concatenation (issue #5407)
+
+test("matches cross-word prefix concatenation (issue #5407)", () => {
+  const r1 = matchSidebarLabel("system_exception_log", "exclog");
+  assert.equal(r1?.kind, "abbreviation");
+  assert.equal(r1?.score, 50);
+  const r2 = matchSidebarLabel("system_exception_log", "syslog");
+  assert.equal(r2?.kind, "abbreviation");
+  assert.equal(r2?.score, 50);
+  const r3 = matchSidebarLabel("system_exception_log", "exlog");
+  assert.equal(r3?.kind, "abbreviation");
+  assert.equal(r3?.score, 50);
+  const r4 = matchSidebarLabel("customer_order_detail", "custdet");
+  assert.equal(r4?.kind, "abbreviation");
+  assert.equal(r4?.score, 50);
+  const r5 = matchSidebarLabel("order_payment_record", "payrec");
+  assert.equal(r5?.kind, "abbreviation");
+  assert.equal(r5?.score, 50);
+});
+
+test("rejects loose cross-word queries (issue #5407 negatives)", () => {
+  assert.equal(matchSidebarLabel("system_exception_log", "slog"), null);
+  assert.equal(matchSidebarLabel("system_exception_log", "selog"), null);
+  assert.equal(matchSidebarLabel("sys_role_data_scope", "roles"), null);
+  assert.equal(matchSidebarLabel("user_profile", "urf"), null);
+  assert.equal(matchSidebarLabel("t_json", "tson"), null);
+});
+
+test("tokenizes camelCase identifiers for word-boundary matching", () => {
+  const r1 = matchSidebarLabel("camelCaseTable", "caseTab");
+  assert.equal(r1?.kind, "word-prefix");
+  assert.equal(r1?.score, 80);
+  const r2 = matchSidebarLabel("camelCaseTable", "camTab");
+  assert.equal(r2?.kind, "abbreviation");
+  assert.equal(r2?.score, 50);
+  const r3 = matchSidebarLabel("camelCaseTable", "cct");
+  assert.equal(r3?.kind, "abbreviation");
+  assert.equal(r3?.score, 60);
+  assert.equal(matchSidebarLabel("camelCaseTable", "aseTb"), null);
+});
+
+test("camelCase tokenization survives the real tree-search path (issue #5407)", () => {
+  // filterSidebarTree must preserve the original label. Lowercasing
+  // camelCaseTable first still finds camTab as fuzzy/40, so score ordering
+  // against an existing fuzzy/40 candidate makes the boundary observable.
+  const tree: TreeNode[] = [
+    {
+      id: "conn-1",
+      label: "My Connection",
+      type: "connection",
+      connectionId: "conn-1",
+      isExpanded: true,
+      children: [
+        {
+          id: "db-1",
+          label: "app_db",
+          type: "database",
+          connectionId: "conn-1",
+          database: "app_db",
+          isExpanded: true,
+          children: [
+            {
+              id: "tbl-fuzzy",
+              label: "camxxtab",
+              type: "table",
+              connectionId: "conn-1",
+              database: "app_db",
+              schema: "public",
+            },
+            {
+              id: "tbl-camel",
+              label: "camelCaseTable",
+              type: "table",
+              connectionId: "conn-1",
+              database: "app_db",
+              schema: "public",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const findTable = (nodes: TreeNode[]): TreeNode | undefined => {
+    for (const node of nodes) {
+      if (node.type === "table") return node;
+      const found = node.children ? findTable(node.children) : undefined;
+      if (found) return found;
+    }
+    return undefined;
+  };
+
+  // camel + Table skips Case, so it scores 50 and outranks camxxtab's fuzzy/40.
+  // If callers lowercase first, both score 40 and the stable sort keeps camxxtab first.
+  const camTabResults = filterSidebarTree(tree, "camTab", new Set());
+  assert.deepEqual(camTabResults[0]?.children?.[0]?.children?.map((node) => node.label), ["camelCaseTable", "camxxtab"]);
+  assert.equal(findTable(filterSidebarTree(tree, "caseTab", new Set()))?.label, "camelCaseTable");
+  assert.equal(findTable(filterSidebarTree(tree, "aseTb", new Set())), undefined);
+
+  const mixedCaseTree: TreeNode[] = [
+    {
+      id: "tbl-2",
+      label: "UserOrderDetail",
+      type: "table",
+      connectionId: "conn-1",
+      database: "app_db",
+      schema: "public",
+    },
+  ];
+  assert.equal(findTable(filterSidebarTree(mixedCaseTree, "userorderdetail", new Set()))?.label, "UserOrderDetail");
+  assert.equal(findTable(filterSidebarTree(mixedCaseTree, "uod", new Set()))?.label, "UserOrderDetail");
 });


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
## Description

### Problem

Closes #5407 (P1). Searching the sidebar for a table whose name spans multiple words failed when the query mixed letters taken from the start of *different* words. For example, `system_exception_log` could not be found by searching `exclog` (`exc` from `exception` + `log` from the last word).

The root cause is in `matchSidebarLabelWithRegex` (`apps/desktop/src/lib/sidebar/sidebarSearch.ts`): the `fuzzy` tier's `matchesSubsequence` resets its cursor (`j = 0`) at every word boundary, so any query whose characters cross a separator is structurally impossible to match. Sidebar search was the **only one of six** matchers in the app that could not cross word boundaries — quick-open (`useQuickOpen.ts`), SQL completion (`sqlCompletion.ts`), object completion (`connectionStore.ts`), and CodeMirror highlighting (`completionMatch.ts`) all support cross-word subsequences.

### Fix

Add a new **word-segment prefix concatenation** tier to `matchSidebarLabelWithRegex`, inserted *after* the separator-blind tiers (65/55) and *before* the final `null`:

1. Split the label into words on separators (`_`, `-`, `.`, space, `/`, `\`) **and camelCase transitions** (`camelCaseTable` → `camel` / `Case` / `Table`).
2. A query matches when it can be partitioned into `k >= 2` pieces, each a **prefix** (length `>= 2`, `MIN_PREFIX_LEN`) of a label word consumed in order; words may be skipped.
3. On a hit, return `{ kind: "abbreviation", score: 50 }` — a flat score below every existing tier, so ranking is unchanged and the tier is purely additive.

`MIN_PREFIX_LEN = 2` is the precision knob that keeps the deliberate negatives from matching: `roles` (`role` + `s`), `urf` (`u` + `rf`), and `tson` all stay `null` because they require a single-character prefix bridge.

To make camelCase boundaries effective in the real tree path, case-insensitive comparison is now centralized **inside the matcher** and all callers pass the **original** label/query:

- `sidebarSearchTree.ts`: `normalizedLabel` returns `node.label` unchanged (removes the now-invalid `normalizedLabelCache`).
- `ConnectionTree.vue`: per-scope table search no longer lowercases `child.label` / `entry.name` / query before calling `matchSidebarLabel`.

### Behavior

| Query | Label | Before | After |
|---|---|---|---|
| `exclog` | `system_exception_log` | no match | abbreviation / 50 |
| `syslog` | `system_exception_log` | no match | abbreviation / 50 (skips middle word) |
| `exlog` | `system_exception_log` | no match | abbreviation / 50 |
| `custdet` | `customer_order_detail` | no match | abbreviation / 50 |
| `payrec` | `order_payment_record` | no match | abbreviation / 50 |
| `camTab` | `camelCaseTable` | fuzzy / 40 | abbreviation / 50 |
| `caseTab` | `camelCaseTable` | substring / 70 | word-prefix / 80 |
| `slog` / `selog` | `system_exception_log` | no match | no match (intended) |
| `roles` / `urf` / `tson` | … | no match | no match (preserved) |

### Notes

- All 388 existing lines of `packages/app-tests/sidebarSearch.test.ts` pass unchanged; the new tier is additive below every existing score.
- camelCase support is **tokenization-only** — it extends word segmentation but does not change existing match-tier priority.
- `slog` / `selog` are intentionally left unmatched: the capability is "prefix concatenation of ≥ 2 words", not arbitrary cross-word subsequence.
- Out of scope (follow-ups): pinyin/CJK matching, intra-tier (50–57) scoring differentiation, unifying with the quick-open / SQL-completion matchers.

### Tests

- `packages/app-tests/sidebarSearch.test.ts`: +34 tests covering the #5407 contract (`exclog`/`syslog`/`exlog`/`custdet`/`payrec` at 50, `slog`/`selog`/`roles`/`urf`/`tson` stay null), camelCase tokenization (`caseTab`/`camTab`/`cct`/`aseTb`), and an end-to-end `filterSidebarTree` regression that proves the original-case label reaches the matcher (ranks `camelCaseTable` above a fuzzy-only `camxxtab` for `camTab`, rejects `aseTb`).
- Full suite: `packages/app-tests` + `apps/desktop/src/lib/__tests__/sidebar` — 288 files / 2681 tests pass. TypeScript typecheck, oxlint, and oxfmt all clean.

## Checklist

- [x] Commits follow conventional commit format
- [x] Tests added/updated and passing
- [x] Typecheck / lint / format clean
- [x] No unrelated files changed

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #5407 
