### PR TITLE
Fix：修复 i18n 自动补全解析简写属性失败

### DIFF
--- a/.github/scripts/i18n-autofill.mjs
+++ b/.github/scripts/i18n-autofill.mjs
@@ -201,9 +201,7 @@ function assertSamePlaceholders(key, source, translated, locale) {
   const sourcePlaceholders = placeholders(source);
   const translatedPlaceholders = placeholders(translated);
   if (sourcePlaceholders.join("\0") !== translatedPlaceholders.join("\0")) {
-    throw new Error(
-      `${locale}:${key} placeholder mismatch: expected [${sourcePlaceholders.join(", ")}], got [${translatedPlaceholders.join(", ")}]`,
-    );
+    throw new Error(`${locale}:${key} placeholder mismatch: expected [${sourcePlaceholders.join(", ")}], got [${translatedPlaceholders.join(", ")}]`);
   }
 }
 
@@ -362,7 +360,7 @@ function flattenNode(node, path, result) {
     const nextPath = [...path, property.key];
     if (property.value.type === "object") {
       flattenNode(property.value, nextPath, result);
-    } else {
+    } else if (property.value.type === "string") {
       result.set(nextPath.join("."), property.value.value);
     }
   }
@@ -416,6 +414,12 @@ class Parser {
       const start = this.index;
       const key = this.parseKey();
       this.skipSpace();
+      if (this.peek() === "," || this.peek() === "}") {
+        const hasComma = this.peek() === ",";
+        if (hasComma) this.index += 1;
+        properties.push({ key, start, end: this.index, hasComma, value: { type: "external" } });
+        continue;
+      }
       this.expect(":");
       this.skipSpace();
       const value = this.parseValue();

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2421,7 +2421,7 @@ export default withEnglishFallback({
     changeOpenMode: "Modificar modo de apertura",
     closeRightTabs: "Cerrar pestañas a la derecha",
     compileObject: "Compilar",
-    compileObjectSuccess: "\"{name}\" compilado con éxito",
+    compileObjectSuccess: '"{name}" compilado con éxito',
   },
   visibleDatabases: {
     title: "Bases de datos visibles",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2419,7 +2419,7 @@ export default withEnglishFallback({
     changeOpenMode: "Modifica modalità apertura",
     closeRightTabs: "Chiudi le schede a destra",
     compileObject: "Compila",
-    compileObjectSuccess: "\"{name}\" compilato con successo",
+    compileObjectSuccess: '"{name}" compilato con successo',
   },
   visibleDatabases: {
     title: "Database Visibili",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2446,7 +2446,7 @@ export default withEnglishFallback({
     changeOpenMode: "開き方を変更",
     closeRightTabs: "右側のタブを閉じる",
     compileObject: "コンパイル",
-    compileObjectSuccess: "\"{name}\" のコンパイルに成功しました",
+    compileObjectSuccess: '"{name}" のコンパイルに成功しました',
   },
   visibleDatabases: {
     title: "表示するデータベース",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2421,7 +2421,7 @@ export default withEnglishFallback({
     changeOpenMode: "Alterar modo de abertura",
     closeRightTabs: "Fechar abas à direita",
     compileObject: "Compilar",
-    compileObjectSuccess: "\"{name}\" compilado com sucesso",
+    compileObjectSuccess: '"{name}" compilado com sucesso',
   },
   visibleDatabases: {
     title: "Bancos de dados visíveis",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2420,7 +2420,7 @@ export default withEnglishFallback({
     changeOpenMode: "修改開啟方式",
     closeRightTabs: "關閉右側標籤頁",
     compileObject: "編譯",
-    compileObjectSuccess: "\"{name}\" 編譯成功",
+    compileObjectSuccess: '"{name}" 編譯成功',
   },
   visibleDatabases: {
     title: "顯示資料庫",

--- a/packages/app-tests/i18nAutofillParser.test.ts
+++ b/packages/app-tests/i18nAutofillParser.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { test } from "vitest";
+
+test("i18n autofill parses locale roots with imported shorthand sections", () => {
+  const output = execFileSync(process.execPath, [".github/scripts/i18n-autofill.mjs", "--dry-run", "--base-ref", "HEAD"], {
+    encoding: "utf8",
+  });
+
+  assert.match(output, /No new zh-CN i18n keys compared with HEAD/);
+});


### PR DESCRIPTION
## 问题

当前 locale 根对象通过 `docs,` 引入外部文档翻译。i18n autofill 的可信解析器只接受 `key: value`，任何修改 locale 的 PR 都会在 `zh-CN.ts:8` 报错：

`Expected :`

该问题阻塞了 #5589 等仅做既有 locale 格式修正的 PR。

## 修改内容

- 识别对象简写属性并将其标记为外部数据
- 展开叶子翻译时跳过外部数据，保持普通对象和字符串逻辑不变
- 增加执行真实 autofill 脚本的回归测试
- 同时修正 5 个 locale 文件已有的引号格式问题

## 验证

- `node .github/scripts/i18n-autofill.mjs --dry-run --base-ref origin/main`
- `pnpm exec vitest run packages/app-tests/i18nAutofillParser.test.ts`（1/1）
- `pnpm check`（format、lint、typecheck、7295/7295 tests）

这是可信 base 脚本的自举修复：本 PR 自身的旧 `autofill` 检查仍会使用 `main` 上尚未修复的解析器，需要维护者允许本次合入；合入后后续 locale PR 将恢复正常。