### PR TITLE
Fix：修复短字段列头显示不完整

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -501,6 +501,10 @@ const dataGridViewportWidth = ref(0);
 const showColumnCommentsInHeader = computed(() => settingsStore.editorSettings.showColumnCommentsInHeader);
 const showColumnTypesInHeader = computed(() => settingsStore.editorSettings.showColumnTypesInHeader);
 const showIndexIndicatorsInHeader = computed(() => settingsStore.editorSettings.showIndexIndicatorsInHeader !== false);
+const indexes = ref<IndexInfo[]>([]);
+const indexesLoaded = ref(false);
+const indexesLoading = ref(false);
+const indexesError = ref("");
 const primaryKeyColumnNames = computed(() => {
   const names = new Set(props.tableMeta?.primaryKeys ?? []);
   for (const column of props.tableMeta?.columns ?? []) {
@@ -1830,6 +1834,13 @@ const filteredGoToColumns = computed(() => {
   return filterDataGridColumnLookupItems(goToColumnItems.value, goToColumnSearch.value);
 });
 const visibleColumns = computed(() => visibleColumnIndexes.value.map((index) => props.result.columns[index]));
+const visibleColumnIndexIndicators = computed(() =>
+  visibleColumns.value.map((column) => {
+    if (!showIndexIndicatorsInHeader.value) return false;
+    const kind = columnIndexMap.value.get(columnIndexNameKey(column));
+    return !!kind && kind !== "none";
+  }),
+);
 const visibleSourceColumns = computed(() => {
   if (!props.sourceColumns || props.sourceColumns.length !== props.result.columns.length) return undefined;
   return visibleColumnIndexes.value.map((index) => props.sourceColumns?.[index]);
@@ -1951,6 +1962,7 @@ const { initColumnWidths, onResizeStart, autoFitColumn, renderedColumnWidths, to
   columnIndexes: visibleColumnIndexes,
   density: columnWidthDensity,
   compactColumnHeaderActions,
+  columnIndexIndicators: visibleColumnIndexIndicators,
   cacheKey: columnWidthCacheKey,
   columnStructureSignature,
   measureHeaderText: measureColumnHeaderText,
@@ -7789,10 +7801,6 @@ let detailResizeStartY = 0;
 let detailResizeStartHeight = 0;
 let mongoJsonPreviewResizeStartX = 0;
 let mongoJsonPreviewResizeStartWidth = 0;
-const indexes = ref<IndexInfo[]>([]);
-const indexesLoaded = ref(false);
-const indexesLoading = ref(false);
-const indexesError = ref("");
 const currentIndexTableIdentity = computed(() =>
   columnIndexTableIdentity({
     connectionId: props.connectionId,

--- a/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts
@@ -14,6 +14,7 @@ function createResizeState(options: {
   cacheKey?: string;
   density?: "compact" | "standard" | "comfortable";
   compactColumnHeaderActions?: boolean;
+  indexIndicatorColumnIndexes?: number[] | ReturnType<typeof ref<number[]>>;
   headerTextWidth?: number;
 }) {
   const compact = ref(options.compactColumnHeaderActions ?? true);
@@ -21,12 +22,14 @@ function createResizeState(options: {
   const headerMeasurementKey = ref(0);
   const density = ref(options.density ?? "standard");
   const rows = isRef(options.rows) ? options.rows : ref(options.rows);
+  const indexIndicatorColumnIndexes = isRef(options.indexIndicatorColumnIndexes) ? options.indexIndicatorColumnIndexes : ref(options.indexIndicatorColumnIndexes ?? []);
   const state = useDataGridColumnResize({
     columns: computed(() => options.columns),
     sourceRows: computed(() => rows.value),
     columnIndexes: computed(() => options.columnIndexes ?? options.columns.map((_, index) => index)),
     density,
     compactColumnHeaderActions: computed(() => compact.value),
+    columnIndexIndicators: computed(() => options.columns.map((_, index) => indexIndicatorColumnIndexes.value.includes(index))),
     cacheKey: computed(() => options.cacheKey),
     columnStructureSignature: computed(() => createDataGridColumnStructureSignature(options.columns, options.columnTypes)),
     measureHeaderText: () => headerTextWidth.value,
@@ -44,6 +47,9 @@ function createResizeState(options: {
     setHeaderTextWidth(width: number) {
       headerTextWidth.value = width;
       headerMeasurementKey.value += 1;
+    },
+    setIndexIndicatorColumnIndexes(indexes: number[]) {
+      indexIndicatorColumnIndexes.value = indexes;
     },
   };
 }
@@ -279,6 +285,22 @@ describe("useDataGridColumnResize", () => {
     longName.initColumnWidths();
     // 100×7+45=745，表头自动宽度限制为 500
     expect(longName.columnWidths.value[0]).toBe(500);
+  });
+
+  it("grows a short column when its index indicator metadata arrives", async () => {
+    const state = createResizeState({
+      columns: ["id"],
+      rows: [[1]],
+      density: "compact",
+      compactColumnHeaderActions: true,
+    });
+    state.initColumnWidths();
+    expect(state.columnWidths.value[0]).toBe(60);
+
+    state.setIndexIndicatorColumnIndexes([0]);
+    await nextTick();
+
+    expect(state.columnWidths.value[0]).toBe(75);
   });
 
   it("comfortable mode uses percentile to ignore outlier values", () => {

--- a/apps/desktop/src/composables/useDataGridColumnResize.ts
+++ b/apps/desktop/src/composables/useDataGridColumnResize.ts
@@ -36,6 +36,7 @@ export interface UseDataGridColumnResizeOptions {
   columnIndexes: ComputedRef<number[]>;
   density: Ref<ColumnWidthDensity>;
   compactColumnHeaderActions: ComputedRef<boolean>;
+  columnIndexIndicators?: ComputedRef<readonly boolean[]>;
   cacheKey?: ComputedRef<string | undefined>;
   columnStructureSignature: ComputedRef<string>;
   measureHeaderText?: (text: string) => number | undefined;
@@ -79,6 +80,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
       density: density.value,
       compactColumnHeaderActions: compactColumnHeaderActions.value,
       headerTextWidth: measureHeaderText?.(colName),
+      hasIndexIndicator: options.columnIndexIndicators?.value[colIdx] ?? false,
     });
   }
 
@@ -191,6 +193,7 @@ export function useDataGridColumnResize(options: UseDataGridColumnResizeOptions)
       compactColumnHeaderActions: compactColumnHeaderActions.value,
       includeValues: true,
       headerTextWidth: measureHeaderText?.(colName),
+      hasIndexIndicator: options.columnIndexIndicators?.value[colIdx] ?? false,
     });
     markColumnUserSized(colIdx);
     persistColumnWidths();

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnWidth.ts
@@ -8,6 +8,8 @@ export const DATA_GRID_COL_AUTO_FIT_MAX_WIDTH = 1200;
 export const DATA_GRID_HEADER_MAX_WIDTH = 500;
 export const DATA_GRID_CHAR_WIDTH = 8;
 export const DATA_GRID_HEADER_CONTROL_WIDTH = 80;
+/** 12px index icon plus the 4px flex gap before the column name. */
+export const DATA_GRID_HEADER_INDEX_INDICATOR_WIDTH = 16;
 export const DATA_GRID_CELL_PADDING = 28;
 export const DATA_GRID_SAMPLE_ROWS = 50;
 export const DATA_GRID_VALUE_TEXT_LIMIT = 60;
@@ -94,7 +96,17 @@ export function percentileValue(values: number[], percentile: number): number {
   return sorted[idx];
 }
 
-export function calculateDataGridColumnWidth(options: { columnName: string; sampleValues: readonly CellValue[]; maxWidth?: number; valueTextLimit?: number; density?: ColumnWidthDensity; compactColumnHeaderActions?: boolean; includeValues?: boolean; headerTextWidth?: number }): number {
+export function calculateDataGridColumnWidth(options: {
+  columnName: string;
+  sampleValues: readonly CellValue[];
+  maxWidth?: number;
+  valueTextLimit?: number;
+  density?: ColumnWidthDensity;
+  compactColumnHeaderActions?: boolean;
+  includeValues?: boolean;
+  headerTextWidth?: number;
+  hasIndexIndicator?: boolean;
+}): number {
   const density = options.density ?? "standard";
   const preset = COLUMN_WIDTH_DENSITY_PRESETS[density];
   const maxAllowedWidth = options.maxWidth ?? preset.maxWidth;
@@ -102,7 +114,8 @@ export function calculateDataGridColumnWidth(options: { columnName: string; samp
   const headerControl = options.compactColumnHeaderActions ? preset.headerControlWidthCompact : preset.headerControlWidth;
   const headerTextWidth = options.headerTextWidth ?? estimateTextWidth(options.columnName, 0, preset.charWidth);
   // Protect the grid from pathological identifiers while keeping normal names density-independent.
-  const headerWidth = Math.min(DATA_GRID_HEADER_MAX_WIDTH, headerTextWidth + headerControl);
+  const indexIndicatorWidth = options.hasIndexIndicator ? DATA_GRID_HEADER_INDEX_INDICATOR_WIDTH : 0;
+  const headerWidth = Math.min(DATA_GRID_HEADER_MAX_WIDTH, headerTextWidth + headerControl + indexIndicatorWidth);
 
   // Density limits cell content, never the column name and its header controls.
   if (density === "compact" && !options.includeValues) {


### PR DESCRIPTION
Fix：#5611 

## 问题

带主键或索引标识的短字段列在自动计算宽度时，只预留了右侧排序和字段操作控件的空间，没有计算左侧索引图标及间距，导致 `id` 等短字段名被截断显示。

## 修复

- 自动列宽计算按实际索引标识额外预留图标和间距
- 索引元数据异步加载完成后，自动扩宽尚未手动调整的列
- 不增加全局最小列宽，不影响未显示索引标识的普通列
- 补充短字段在索引元数据到达后自动扩宽的回归测试

## 测试

- `pnpm exec vitest run apps/desktop/src/composables/__tests__/useDataGridColumnResize.spec.ts`（25 项通过）
- `pnpm typecheck`
- `pnpm exec oxlint --vue-plugin ...`
- 免密网页实际打开表数据验证，`id` 列名完整显示且无截断