### PR TITLE
feat(xugu): enable schema diagrams

### DIFF
--- a/crates/dbx-core/assets/database-drivers.manifest.json
+++ b/crates/dbx-core/assets/database-drivers.manifest.json
@@ -1717,7 +1717,7 @@
         "objectBrowser": true,
         "objectSource": false,
         "schemaSearch": true,
-        "diagram": false,
+        "diagram": true,
         "tableDataEdit": false,
         "tableStructureEdit": true,
         "tableImport": false,


### PR DESCRIPTION
## Summary

Enable DBX's existing Schema/ER diagram feature for XuguDB connections.

The diagram UI already loads tables, columns, foreign keys, and indexes through the Xugu agent. XuguDB was the only configuration entry with `diagram: false`, so the context-menu entry was hidden even though the metadata path was available.

This change flips only the XuguDB product capability flag to `true`. No shared diagram code, agent SQL, or other database driver capabilities are changed.

## Validation

- `pnpm typecheck`
- `pnpm test -- apps/desktop/src/components/diagram` (full Vitest suite: 814 files / 7,291 tests passed)
- `pnpm build`
- `go test ./...` in `agents/drivers/xugu`
- Read-only validation against a private multi-schema XuguDB test instance:
  - Hundreds of tables, tens of thousands of columns, more than a thousand indexes, and dozens of foreign keys were discovered.
  - A representative schema containing 180 tables exercised 540 table/column/foreign-key/index metadata queries with zero errors in about 2.5 seconds.

No database objects were created, modified, or deleted during validation.
