### PR TITLE
Fix：提升未保存弹框按钮对比度

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -1011,9 +1011,9 @@ function onOverflowItemKeydown(event: KeyboardEvent, tabId: string, kind: "regul
       </div>
       <DialogFooter class="min-w-0 sm:flex-wrap">
         <Button variant="outline" @click="handleCancelClose">{{ t("common.cancel") }}</Button>
-        <Button v-if="showCloseConfirmBulkActions" variant="secondary" @click="handleDiscardAllAndClose">{{ t("editor.discardAllChanges") }}</Button>
+        <Button v-if="showCloseConfirmBulkActions" variant="secondary" class="border-border" @click="handleDiscardAllAndClose">{{ t("editor.discardAllChanges") }}</Button>
         <Button v-if="showCloseConfirmBulkActions" @click="handleSaveAllAndClose">{{ t("editor.saveAllChanges") }}</Button>
-        <Button variant="secondary" @click="handleDiscardAndClose">{{ t("editor.discardChanges") }}</Button>
+        <Button variant="secondary" class="border-border" @click="handleDiscardAndClose">{{ t("editor.discardChanges") }}</Button>
         <Button @click="handleSaveAndClose">{{ t("savedSql.save") }}</Button>
       </DialogFooter>
     </DialogContent>

--- a/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
@@ -11,9 +11,9 @@ describe("AppTabBar close confirmation layout", () => {
 
   it("keeps all single and bulk close actions while allowing the footer to wrap", () => {
     expect(tabBarSource).toMatch(/<DialogFooter class="[^"]*\bmin-w-0\b[^"]*\bsm:flex-wrap\b">/);
-    expect(tabBarSource).toContain('v-if="showCloseConfirmBulkActions" variant="secondary" @click="handleDiscardAllAndClose"');
+    expect(tabBarSource).toContain('v-if="showCloseConfirmBulkActions" variant="secondary" class="border-border" @click="handleDiscardAllAndClose"');
     expect(tabBarSource).toContain('v-if="showCloseConfirmBulkActions" @click="handleSaveAllAndClose"');
-    expect(tabBarSource).toContain('@click="handleDiscardAndClose"');
+    expect(tabBarSource).toContain('variant="secondary" class="border-border" @click="handleDiscardAndClose"');
     expect(tabBarSource).toContain('@click="handleSaveAndClose"');
     expect(tabBarSource).toContain('@click="handleCancelClose"');
   });


### PR DESCRIPTION
## 改动说明

- 为未保存更改弹框中的“不保存”和“全部不保存”按钮增加主题边框
- 保留原有次级操作填充色与按钮层级，并使用各主题自身的边框色，统一改善浅色和深色主题下的辨识度
- 更新弹框操作布局测试，防止次级操作的可见边界回退

## 验证

- `pnpm -s vitest run apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts`
- `pnpm -s typecheck`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/layout/AppTabBar.vue apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts`
- IDEA 浅色主题下实际打开未保存更改弹框验证