### PR TITLE
Fix：修复 Kingbase V8R6 MySQL 模式连接失败

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -21,9 +21,9 @@ const (
 	kingbaseListDatabasesPostgresSQL = "SELECT datname FROM pg_catalog.pg_database WHERE datallowconn AND LOWER(datname) NOT IN ('template0', 'template1') ORDER BY datname"
 )
 
-// Escape '_' so only Kingbase internal SYS_/XLOG_ prefixes are hidden; names
-// such as SYSTEMS and SYSLOG may be user-created schemas in MySQL mode.
-const kingbaseMySQLCompatListSchemasSQL = `SELECT schema_name FROM information_schema.schemata WHERE UPPER(schema_name) <> 'INFORMATION_SCHEMA' AND UPPER(schema_name) NOT LIKE 'SYS\_%' ESCAPE '\' AND UPPER(schema_name) NOT LIKE 'XLOG\_%' ESCAPE '\' ORDER BY schema_name`
+// Escape '_' so only Kingbase internal SYS_/XLOG_ prefixes are hidden; use a
+// non-backslash escape because MySQL mode treats backslash as a string escape.
+const kingbaseMySQLCompatListSchemasSQL = `SELECT schema_name FROM information_schema.schemata WHERE UPPER(schema_name) <> 'INFORMATION_SCHEMA' AND UPPER(schema_name) NOT LIKE 'SYS#_%' ESCAPE '#' AND UPPER(schema_name) NOT LIKE 'XLOG#_%' ESCAPE '#' ORDER BY schema_name`
 
 var kingbaseDataTypes = []string{
 	"bigint", "bigserial", "bit", "bit varying", "boolean", "bytea", "char", "character",

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -962,7 +962,7 @@ func TestKingbaseCatalogFunctionsFollowMetadataMode(t *testing.T) {
 func TestMySQLCompatSchemaQueryKeepsUserSchemasWithSystemLikeNames(t *testing.T) {
 	query := kingbaseMySQLCompatListSchemasSQL
 	for _, prefix := range []string{"SYS", "XLOG"} {
-		expected := "NOT LIKE '" + prefix + `\_%' ESCAPE '\'`
+		expected := "NOT LIKE '" + prefix + `#_%' ESCAPE '#'`
 		if !strings.Contains(query, expected) {
 			t.Fatalf("schema query must only hide the internal %s_ prefix: %s", prefix, query)
 		}


### PR DESCRIPTION
## 问题

KingbaseES V8R6 MySQL 兼容模式下，DBX 完成网络连接和认证后，在加载 Schema 列表时失败：

```text
Agent RPC error (-1): kb: syntax error at or near "XLOG"
```

实际环境为 `KingbaseES V008R006C008M020B0025`，并确认 `database_mode=mysql`。

当前 Agent 使用反斜杠作为 `LIKE ... ESCAPE` 的转义字符：

```sql
NOT LIKE 'SYS\_%' ESCAPE '\'
```

MySQL 兼容模式会把反斜杠按字符串转义处理，导致字符串未正确结束。用户在同一实例、同一账号下执行该 SQL，可稳定复现 `42601: Unterminated string literal`；不带过滤的查询正常。

## 修改

- 将 Schema 前缀过滤的转义字符由反斜杠改为 `#`。
- 继续只过滤 Kingbase 内部的 `SYS_`、`XLOG_` 前缀，不影响 `SYSTEMS`、`SYSLOG` 等可能由用户创建的 Schema。
- 更新回归测试，固定 MySQL 兼容模式下可解析的 SQL。

修正后的语法已在用户的 V8R6 MySQL 兼容实例上实际执行成功：

```sql
NOT LIKE 'SYS#_%' ESCAPE '#'
```

## 验证

- `go test ./...`：Kingbase Go Agent 全部通过
- `python3 scripts/validate_agents.py`：通过
- Agent 脚本单测 21 项通过
- Windows x64 交叉编译成功
- 检查 Windows 产物，确认包含修正后的 `ESCAPE '#'` 查询
