### PR TITLE
Fix：兼容 Kingbase V8 对象源码读取并补充扩展详情

### DIFF
--- a/agents/drivers/kingbase-go/integration_test.go
+++ b/agents/drivers/kingbase-go/integration_test.go
@@ -100,6 +100,10 @@ func TestKingbaseIntegration(t *testing.T) {
 	if err != nil || !strings.Contains(fmt.Sprint(source["source"]), function) {
 		t.Fatalf("get function source failed: source=%v err=%v", source, err)
 	}
+	viewSource, err := server.getObjectSource("public", view, "VIEW")
+	if err != nil || !strings.Contains(fmt.Sprint(viewSource["source"]), parent) {
+		t.Fatalf("get view source failed: source=%v err=%v", viewSource, err)
+	}
 
 	transactionParams := map[string]json.RawMessage{
 		"schema":     rawJSON("public"),

--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -741,17 +741,35 @@ func (s *server) getObjectSource(schema, name, objectType string) (map[string]an
 			catalog, prefix, function := "sys_catalog", "sys", "sys_get_viewdef"
 			if s.mode.postgresCatalog {
 				catalog, prefix, function = "pg_catalog", "pg", "pg_get_viewdef"
+			} else if s.usePgViewDefinition {
+				function = "pg_get_viewdef"
 			}
-			query := fmt.Sprintf("SELECT %s(c.oid) FROM %s.%s_class c JOIN %s.%s_namespace n ON n.oid=c.relnamespace WHERE n.nspname=%s AND c.relname=%s LIMIT 1", function, catalog, prefix, catalog, prefix, quoteLiteral(effective), quoteLiteral(name))
-			err = s.requireDBQueryRow(query, &source)
+			querySource := func(definitionFunction string) error {
+				query := fmt.Sprintf("SELECT %s(c.oid) FROM %s.%s_class c JOIN %s.%s_namespace n ON n.oid=c.relnamespace WHERE n.nspname=%s AND c.relname=%s LIMIT 1", definitionFunction, catalog, prefix, catalog, prefix, quoteLiteral(effective), quoteLiteral(name))
+				return s.requireDBQueryRow(query, &source)
+			}
+			err = querySource(function)
+			if err != nil && function == "sys_get_viewdef" && isUndefinedFunction(err, function) {
+				s.usePgViewDefinition = true
+				err = querySource("pg_get_viewdef")
+			}
 		}
 	} else if kind == "FUNCTION" || kind == "PROCEDURE" {
 		catalog, prefix, function := "sys_catalog", "sys", "sys_get_functiondef"
 		if s.mode.postgresCatalog {
 			catalog, prefix, function = "pg_catalog", "pg", "pg_get_functiondef"
+		} else if s.usePgFunctionDefinition {
+			function = "pg_get_functiondef"
 		}
-		query := fmt.Sprintf("SELECT %s(p.oid) FROM %s.%s_proc p JOIN %s.%s_namespace n ON n.oid=p.pronamespace WHERE n.nspname=%s AND p.proname=%s ORDER BY CASE WHEN p.prorettype=2278 THEN 0 ELSE 1 END LIMIT 1", function, catalog, prefix, catalog, prefix, quoteLiteral(effective), quoteLiteral(name))
-		err = s.requireDBQueryRow(query, &source)
+		querySource := func(definitionFunction string) error {
+			query := fmt.Sprintf("SELECT %s(p.oid) FROM %s.%s_proc p JOIN %s.%s_namespace n ON n.oid=p.pronamespace WHERE n.nspname=%s AND p.proname=%s ORDER BY CASE WHEN p.prorettype=2278 THEN 0 ELSE 1 END LIMIT 1", definitionFunction, catalog, prefix, catalog, prefix, quoteLiteral(effective), quoteLiteral(name))
+			return s.requireDBQueryRow(query, &source)
+		}
+		err = querySource(function)
+		if err != nil && function == "sys_get_functiondef" && isUndefinedFunction(err, function) {
+			s.usePgFunctionDefinition = true
+			err = querySource("pg_get_functiondef")
+		}
 	}
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err

--- a/agents/drivers/kingbase-go/main.go
+++ b/agents/drivers/kingbase-go/main.go
@@ -134,6 +134,8 @@ type server struct {
 	params                     connectParams
 	mode                       kingbaseMode
 	usePgDefaultExpression     bool
+	usePgViewDefinition        bool
+	usePgFunctionDefinition    bool
 	catalogIdentityUnsupported bool
 	infoColumnTypeUnsupported  bool
 	infoUdtNameUnsupported     bool
@@ -456,6 +458,8 @@ func (s *server) connect(cp connectParams) error {
 	s.params = cp
 	s.mode = detectKingbaseMode(db, cp.MySQLCompatMode)
 	s.usePgDefaultExpression = false
+	s.usePgViewDefinition = false
+	s.usePgFunctionDefinition = false
 	s.catalogIdentityUnsupported = false
 	s.infoColumnTypeUnsupported = false
 	s.infoUdtNameUnsupported = false
@@ -520,6 +524,8 @@ func (s *server) disconnect() error {
 	s.cancelActiveQuery()
 	s.closeAllQuerySessions()
 	s.usePgDefaultExpression = false
+	s.usePgViewDefinition = false
+	s.usePgFunctionDefinition = false
 	s.catalogIdentityUnsupported = false
 	s.infoColumnTypeUnsupported = false
 	s.infoUdtNameUnsupported = false

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -1142,6 +1142,98 @@ func TestRoutineSourceUsesKingbaseCatalogFunction(t *testing.T) {
 	}
 }
 
+func TestObjectSourceFallsBackToPgDefinitionFunctionsAndCachesChoice(t *testing.T) {
+	tests := []struct {
+		name         string
+		objectType   string
+		objectName   string
+		sysFunction  string
+		pgFunction   string
+		catalogTable string
+		source       string
+	}{
+		{
+			name:         "function",
+			objectType:   "FUNCTION",
+			objectName:   "format_name",
+			sysFunction:  "sys_get_functiondef",
+			pgFunction:   "pg_get_functiondef",
+			catalogTable: "sys_catalog.sys_proc",
+			source:       "CREATE FUNCTION public.format_name() RETURNS text AS $$ SELECT 'x'; $$",
+		},
+		{
+			name:         "view",
+			objectType:   "VIEW",
+			objectName:   "active_orders",
+			sysFunction:  "sys_get_viewdef",
+			pgFunction:   "pg_get_viewdef",
+			catalogTable: "sys_catalog.sys_class",
+			source:       "SELECT * FROM public.orders WHERE active",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := &metadataDriverState{query: func(query string) (driver.Rows, error) {
+				if !strings.Contains(query, test.catalogTable) {
+					return nil, errors.New("unexpected query: " + query)
+				}
+				if strings.Contains(query, test.sysFunction+"(") {
+					return nil, &gokb.Error{Code: gokb.ErrorCode("42883"), Message: "function " + test.sysFunction + "(oid) does not exist"}
+				}
+				if strings.Contains(query, test.pgFunction+"(") {
+					return &valueRows{columns: []string{"source"}, rows: [][]driver.Value{{test.source}}}, nil
+				}
+				return nil, errors.New("unexpected query: " + query)
+			}}
+			server := newServer()
+			server.db = openMetadataDB(t, state)
+
+			for call := 0; call < 2; call++ {
+				source, err := server.getObjectSource("public", test.objectName, test.objectType)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if source["source"] != test.source {
+					t.Fatalf("unexpected source: %#v", source)
+				}
+			}
+
+			state.mu.Lock()
+			queries := append([]string(nil), state.queries...)
+			state.mu.Unlock()
+			if len(queries) != 3 ||
+				!strings.Contains(queries[0], test.sysFunction+"(") ||
+				!strings.Contains(queries[1], test.pgFunction+"(") ||
+				!strings.Contains(queries[2], test.pgFunction+"(") {
+				t.Fatalf("definition fallback choice was not cached: %v", queries)
+			}
+		})
+	}
+}
+
+func TestObjectSourceDoesNotFallbackOnUnrelatedErrors(t *testing.T) {
+	permissionErr := errors.New("permission denied for sys_proc")
+	state := &metadataDriverState{query: func(query string) (driver.Rows, error) {
+		if strings.Contains(query, "sys_get_functiondef(") {
+			return nil, permissionErr
+		}
+		return nil, errors.New("unexpected fallback query: " + query)
+	}}
+	server := newServer()
+	server.db = openMetadataDB(t, state)
+
+	_, err := server.getObjectSource("public", "format_name", "FUNCTION")
+	if !errors.Is(err, permissionErr) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.queries) != 1 || !strings.Contains(state.queries[0], "sys_get_functiondef(") {
+		t.Fatalf("unrelated error triggered a fallback: %v", state.queries)
+	}
+}
+
 func TestColumnsFallbackToPgGetExprAndCacheChoice(t *testing.T) {
 	registerExpressionFallbackDriver.Do(func() { sql.Register("kingbase-expression-fallback-test", fallbackDriver{}) })
 	state := &fallbackDriverState{}

--- a/apps/desktop/src/components/objects/ExtensionDetailsDialog.vue
+++ b/apps/desktop/src/components/objects/ExtensionDetailsDialog.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { Package } from "@lucide/vue";
+import { useI18n } from "vue-i18n";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { ExtensionInfo, TreeNode } from "@/types/database";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  node: TreeNode;
+}>();
+
+const open = ref(false);
+const extension = computed<ExtensionInfo>(() => {
+  const meta = props.node.meta as ExtensionInfo | undefined;
+  return {
+    name: meta?.name || props.node.label,
+    version: meta?.version || "-",
+    schema: meta?.schema || props.node.schema || null,
+    comment: meta?.comment || null,
+  };
+});
+
+function show() {
+  open.value = true;
+}
+
+defineExpose({ show });
+</script>
+
+<template>
+  <Dialog v-model:open="open">
+    <DialogContent class="sm:max-w-lg">
+      <DialogHeader>
+        <DialogTitle class="flex min-w-0 items-center gap-2 pr-8">
+          <Package class="h-4 w-4 shrink-0 text-violet-500" />
+          <span class="truncate">{{ t("extension.detailsTitle") }}</span>
+        </DialogTitle>
+      </DialogHeader>
+
+      <dl class="overflow-hidden rounded-md border text-sm">
+        <div class="grid grid-cols-[7rem_minmax(0,1fr)] border-b px-3 py-2.5">
+          <dt class="text-muted-foreground">{{ t("extension.name") }}</dt>
+          <dd class="min-w-0 break-words font-medium">{{ extension.name }}</dd>
+        </div>
+        <div class="grid grid-cols-[7rem_minmax(0,1fr)] border-b px-3 py-2.5">
+          <dt class="text-muted-foreground">{{ t("connection.version") }}</dt>
+          <dd class="min-w-0 break-words">{{ extension.version }}</dd>
+        </div>
+        <div class="grid grid-cols-[7rem_minmax(0,1fr)] border-b px-3 py-2.5">
+          <dt class="text-muted-foreground">Schema</dt>
+          <dd class="min-w-0 break-words">{{ extension.schema || "-" }}</dd>
+        </div>
+        <div class="grid grid-cols-[7rem_minmax(0,1fr)] px-3 py-2.5">
+          <dt class="text-muted-foreground">{{ t("structureEditor.comment") }}</dt>
+          <dd class="min-w-0 whitespace-pre-wrap break-words">{{ extension.comment || "-" }}</dd>
+        </div>
+      </dl>
+
+      <DialogFooter>
+        <Button variant="outline" @click="open = false">{{ t("common.close") }}</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/apps/desktop/src/components/objects/__tests__/ExtensionDetailsDialog.spec.ts
+++ b/apps/desktop/src/components/objects/__tests__/ExtensionDetailsDialog.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, ref, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import type { TreeNode } from "@/types/database";
+
+vi.mock("@/components/ui/dialog", async () => {
+  const { defineComponent, h } = await import("vue");
+  const passthrough = defineComponent({
+    setup(_props, { slots }) {
+      return () => h("div", slots.default?.());
+    },
+  });
+  const dialog = defineComponent({
+    props: { open: Boolean },
+    setup(props, { slots }) {
+      return () => (props.open ? h("div", slots.default?.()) : null);
+    },
+  });
+  return { Dialog: dialog, DialogContent: passthrough, DialogFooter: passthrough, DialogHeader: passthrough, DialogTitle: passthrough };
+});
+
+vi.mock("@/components/ui/button", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    Button: defineComponent({
+      setup(_props, { slots }) {
+        return () => h("button", slots.default?.());
+      },
+    }),
+  };
+});
+
+import ExtensionDetailsDialog from "@/components/objects/ExtensionDetailsDialog.vue";
+
+const mountedApps: App[] = [];
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.innerHTML = "";
+});
+
+describe("ExtensionDetailsDialog", () => {
+  it("shows metadata already loaded for the extension tree node", async () => {
+    const node: TreeNode = {
+      id: "connection:database:public:sys_stat_statements",
+      label: "sys_stat_statements",
+      type: "extension",
+      schema: "public",
+      meta: {
+        name: "sys_stat_statements",
+        version: "1.10",
+        schema: "public",
+        comment: "track planning and execution statistics",
+      },
+    };
+    const dialog = ref<InstanceType<typeof ExtensionDetailsDialog> | null>(null);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const app = createApp(
+      defineComponent({
+        setup() {
+          return () => h(ExtensionDetailsDialog, { ref: dialog, node });
+        },
+      }),
+    );
+    mountedApps.push(app);
+    app.use(i18n);
+    app.mount(container);
+    dialog.value?.show();
+    await nextTick();
+
+    const text = document.body.textContent || "";
+    expect(text).toContain("sys_stat_statements");
+    expect(text).toContain("1.10");
+    expect(text).toContain("public");
+    expect(text).toContain("track planning and execution statistics");
+  });
+});

--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -29,6 +29,7 @@ import TreeItem from "./TreeItem.vue";
 import SidebarTreeRuntimeHost from "./SidebarTreeRuntimeHost.vue";
 import SidebarTreeItemDialogs from "./SidebarTreeItemDialogs.vue";
 import InstallExtensionDialog from "@/components/objects/InstallExtensionDialog.vue";
+import ExtensionDetailsDialog from "@/components/objects/ExtensionDetailsDialog.vue";
 import { RecycleScroller } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 import LightDropdown from "@/components/ui/LightDropdown.vue";
@@ -79,6 +80,8 @@ const sidebarDangerDialogConfirming = ref(false);
 const sidebarTreeItemDialogController = ref<Record<string, any> | null>(null);
 const sidebarInstallExtensionTarget = ref<TreeNode | null>(null);
 const sidebarInstallExtensionDialogRef = ref<InstanceType<typeof InstallExtensionDialog> | null>(null);
+const sidebarExtensionDetailsTarget = ref<TreeNode | null>(null);
+const sidebarExtensionDetailsDialogRef = ref<InstanceType<typeof ExtensionDetailsDialog> | null>(null);
 const sidebarTreeRuntimeHostRef = ref<SidebarTreeRuntimeHostInstance | null>(null);
 const sidebarTreeRuntime = createSidebarTreeRuntime();
 const sidebarTreeRuntimeInitialNode: TreeNode = { id: "__sidebar-runtime__", label: "", type: "connection-group" };
@@ -1284,6 +1287,12 @@ async function openSidebarInstallExtension(node: TreeNode) {
   sidebarInstallExtensionDialogRef.value?.show();
 }
 
+async function openSidebarExtensionDetails(node: TreeNode) {
+  sidebarExtensionDetailsTarget.value = createSidebarActionTarget(node);
+  await nextTick();
+  sidebarExtensionDetailsDialogRef.value?.show();
+}
+
 function beginSidebarAction(): number {
   sidebarActionGeneration += 1;
   sidebarDdlOpen.value = false;
@@ -1751,6 +1760,7 @@ defineExpose({ focusSearch, createNewGroup, collapseAllTreeNodes });
       @open-danger-dialog="openSidebarDangerDialog"
       @open-dialog-controller="updateSidebarTreeItemDialogController"
       @open-install-extension="openSidebarInstallExtension"
+      @open-extension-details="openSidebarExtensionDetails"
     />
     <div class="connection-tree-search sticky top-0 z-10 bg-background px-2 py-1">
       <div class="relative flex items-center gap-1">
@@ -2056,6 +2066,7 @@ defineExpose({ focusSearch, createNewGroup, collapseAllTreeNodes });
     </SidebarDangerConfirmDialog>
     <SidebarTreeItemDialogs v-if="sidebarTreeItemDialogController" :key="sidebarTreeItemDialogController.node?.id" :controller="sidebarTreeItemDialogController" @closed="sidebarTreeItemDialogController = null" />
     <InstallExtensionDialog v-if="sidebarInstallExtensionTarget" ref="sidebarInstallExtensionDialogRef" :node="sidebarInstallExtensionTarget" @close="refreshSidebarActionTarget" @changed="refreshSidebarActionTarget" />
+    <ExtensionDetailsDialog v-if="sidebarExtensionDetailsTarget" ref="sidebarExtensionDetailsDialogRef" :node="sidebarExtensionDetailsTarget" />
     <div v-if="store.treeNodes.length === 0" class="px-3 py-8 text-center text-muted-foreground text-xs">
       {{ t("sidebar.noConnections") }}
     </div>

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -341,6 +341,7 @@ const emit = defineEmits<{
   "open-danger-dialog": [request: SidebarDangerDialogRequest];
   "open-dialog-controller": [controller: Record<string, any> | null];
   "open-install-extension": [node: TreeNode];
+  "open-extension-details": [node: TreeNode];
 }>();
 
 const {
@@ -759,6 +760,8 @@ function runRowClickAction(clickDetail: number) {
     scheduleOpenData(node);
   } else if (action === "open-source") {
     openObjectSourceDialog(false);
+  } else if (action === "open-extension-details") {
+    emit("open-extension-details", node);
   } else if (isDocumentBrowserTreeNode(node.type)) {
     openMongoTreeData(node);
   } else if (action === "toggle") {
@@ -1066,6 +1069,8 @@ function onDoubleClick(event: MouseEvent) {
     activateDataTableFromDoubleClick();
   } else if (action === "open-source") {
     openObjectSourceDialog(false);
+  } else if (action === "open-extension-details") {
+    emit("open-extension-details", activeNode.value);
   } else if (action === "open-saved-sql") {
     openSavedSqlFile();
   } else if (action === "toggle" && (activeNode.value.type === "mongo-gridfs" || isDocumentBrowserTreeNode(activeNode.value.type))) {
@@ -4393,6 +4398,8 @@ function buildSpecialSidebarMenu(context: SidebarMenuFactoryContext): boolean {
 
   // 8.5 Extension
   if (node.type === "extension") {
+    items.push({ label: t("extension.viewDetails"), action: () => emit("open-extension-details", node), icon: Info });
+    items.push({ label: "", separator: true });
     items.push({ label: t("contextMenu.copyName"), action: copyName, icon: Copy, shortcut: shortcutCopyName.value });
     return true;
   }

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2566,6 +2566,8 @@ export default {
   extension: {
     manageTitle: "Manage Extensions",
     installTitle: "Install Extension",
+    detailsTitle: "Extension Details",
+    viewDetails: "View details",
     name: "Extension name",
     namePlaceholder: "e.g. pg_stat_statements",
     install: "Install",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -5933,6 +5933,8 @@ export default withEnglishFallback({
   extension: {
     installTitle: "Instalar extensión",
     manageTitle: "Administrar extensión",
+    detailsTitle: "Detalles de la extensión",
+    viewDetails: "Ver detalles",
     name: "Nombre de la extensión",
     namePlaceholder: "Por ejemplo: pg_stat_statements",
     install: "Instalar",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -5933,6 +5933,8 @@ export default withEnglishFallback({
   extension: {
     installTitle: "Installa estensione",
     manageTitle: "Gestisci estensioni",
+    detailsTitle: "Dettagli estensione",
+    viewDetails: "Visualizza dettagli",
     name: "Nome estensione",
     namePlaceholder: "Es: pg_stat_statements",
     install: "Installa",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -5988,6 +5988,8 @@ export default withEnglishFallback({
   extension: {
     installTitle: "拡張機能のインストール",
     manageTitle: "拡張機能の管理",
+    detailsTitle: "拡張機能の詳細",
+    viewDetails: "詳細を表示",
     name: "拡張機能名",
     namePlaceholder: "例: pg_stat_statements",
     install: "インストール",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -2440,6 +2440,8 @@ export default withEnglishFallback({
   extension: {
     manageTitle: "확장 관리",
     installTitle: "확장 설치",
+    detailsTitle: "확장 세부 정보",
+    viewDetails: "세부 정보 보기",
     name: "확장 이름",
     namePlaceholder: "예: pg_stat_statements",
     install: "설치",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -5935,6 +5935,8 @@ export default withEnglishFallback({
   extension: {
     installTitle: "Instalar extensão",
     manageTitle: "Gerenciar extensão",
+    detailsTitle: "Detalhes da extensão",
+    viewDetails: "Ver detalhes",
     name: "Nome da extensão",
     namePlaceholder: "Exemplo: pg_stat_statements",
     install: "Instalar",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2566,6 +2566,8 @@ export default withEnglishFallback({
   extension: {
     installTitle: "安装扩展",
     manageTitle: "管理扩展",
+    detailsTitle: "扩展详情",
+    viewDetails: "查看详情",
     name: "扩展名称",
     namePlaceholder: "例如: pg_stat_statements",
     install: "安装",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5928,6 +5928,8 @@ export default withEnglishFallback({
   extension: {
     installTitle: "安裝擴展",
     manageTitle: "管理擴展",
+    detailsTitle: "擴展詳情",
+    viewDetails: "查看詳情",
     name: "擴展名稱",
     namePlaceholder: "例如：pg_stat_statements",
     install: "安裝",

--- a/apps/desktop/src/lib/sidebar/treeNodeClick.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeClick.ts
@@ -1,8 +1,8 @@
 import type { ObjectSourceKind, TreeNode, TreeNodeType } from "@/types/database";
 import { matchesShortcut, type ShortcutLikeEvent } from "@/lib/editor/keyboardShortcuts";
 
-export type TreeNodeRowAction = "open-data" | "open-source" | "toggle" | "none";
-export type TreeNodeRowDoubleClickAction = "open-data" | "activate-data" | "open-object-browser" | "open-object-browser-and-expand" | "open-source" | "open-saved-sql" | "toggle" | "none";
+export type TreeNodeRowAction = "open-data" | "open-source" | "open-extension-details" | "toggle" | "none";
+export type TreeNodeRowDoubleClickAction = "open-data" | "activate-data" | "open-object-browser" | "open-object-browser-and-expand" | "open-source" | "open-extension-details" | "open-saved-sql" | "toggle" | "none";
 export type SidebarSelectionCopyAction = "copy-name" | "none";
 export type SidebarActivation = "single" | "double";
 
@@ -36,6 +36,7 @@ export function isDocumentBrowserTreeNode(type: TreeNodeType): boolean {
 
 export function treeNodeRowAction(type: TreeNodeType, canExpand: boolean, activation: SidebarActivation = "single"): TreeNodeRowAction {
   if (activation === "double") return "none";
+  if (type === "extension") return "open-extension-details";
   if (dataNodeTypes.has(type)) return "open-data";
   if (sourceNodeTypes.has(type)) return "open-source";
   if (toggleLeafNodeTypes.has(type)) return "toggle";
@@ -55,6 +56,7 @@ export function treeNodeRowDoubleClickAction(type: TreeNodeType, canOpenObjectBr
   // sequence. Only double-click activation needs a second-stage table action.
   if (type === "table") return activation === "double" ? "activate-data" : "none";
   if (activation === "double") {
+    if (type === "extension") return "open-extension-details";
     if (dataNodeTypes.has(type)) return "open-data";
     if (sourceNodeTypes.has(type)) return "open-source";
     if (savedSqlNodeTypes.has(type)) return "open-saved-sql";

--- a/packages/app-tests/treeNodeClick.test.ts
+++ b/packages/app-tests/treeNodeClick.test.ts
@@ -16,6 +16,12 @@ test("single click navigation mode opens source-capable rows", () => {
   assert.equal(treeNodeRowAction("sequence", false), "open-source");
 });
 
+test("extension rows open their metadata details", () => {
+  assert.equal(treeNodeRowAction("extension", false, "single"), "open-extension-details");
+  assert.equal(treeNodeRowAction("extension", false, "double"), "none");
+  assert.equal(treeNodeRowDoubleClickAction("extension", false, "double"), "open-extension-details");
+});
+
 test("double click navigation mode selects rows on single click", () => {
   assert.equal(treeNodeRowAction("table", true, "double"), "none");
   assert.equal(treeNodeRowAction("view", true, "double"), "none");


### PR DESCRIPTION
## 背景

部分 KingbaseES V8 实例保留 `sys_catalog` 元数据表，但未提供 `sys_get_functiondef/sys_get_viewdef`。在 DBX 中打开函数或视图时会报错：

```text
kb: function sys_get_functiondef(oid) does not exist
```

同时，侧边栏“扩展”节点只展示名称，已加载的版本、Schema 和说明没有可查看入口。

## 修改内容

- Kingbase Agent 在 `sys_get_functiondef/sys_get_viewdef` 明确不存在时，分别回退到 `pg_get_functiondef/pg_get_viewdef`
- 按连接缓存兼容函数选择，避免后续重复失败探测
- 仅对“函数不存在”错误回退，不吞掉权限或其他查询错误
- 扩展节点支持按侧边栏单击/双击设置打开详情
- 右键菜单增加“查看详情”，展示名称、版本、Schema 和注释
- 补充函数、视图回退缓存、错误边界及扩展详情交互测试

## 实际验证

- KingbaseES V8：`public.sys_stat_statements` 函数源码连续读取两次成功
- KingbaseES V8：同名视图源码连续读取两次成功
- KingbaseES V8：`sys_anon`、`kdb_license` 扩展详情显示正确
- Kingbase 集成测试创建临时函数和视图后读取成功，并自动清理

## 测试

- `go test ./...`
- `pnpm -s typecheck`
- `pnpm -s vitest run`：824 个测试文件、7370 项测试全部通过
- Agent 校验及脚本测试通过
- i18n 新增文案完整性检查通过