### PR TITLE
Fix/webview2 f6 black screen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ dirs-sys = { path = "vendor/dirs-sys" }
 pageant = { path = "vendor/pageant" }
 # Wry 0.55 probes and creates WebView2 with a null browser folder. Pass the
 # bundled Fixed Runtime path explicitly so Windows 7 does not fall back to an
-# unavailable system Runtime.
+# unavailable system Runtime. The vendored copy also intercepts the WebView2
+# F6 "Focus Next Pane" accelerator to prevent a black screen on frameless
+# Overlay-titlebar windows (see vendor/wry/src/webview2/mod.rs).
 wry = { path = "vendor/wry" }
 tokio-postgres = { git = "https://github.com/t8y2/tokio-postgres-gaussdb.git", rev = "115f9fef10f0fc3669b5337955e4eb461fc349a6" }
 postgres-types = { git = "https://github.com/t8y2/tokio-postgres-gaussdb.git", rev = "115f9fef10f0fc3669b5337955e4eb461fc349a6" }

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -2320,7 +2320,7 @@ mod tests {
 
         let find = command.get_document("explain").unwrap();
         assert_eq!(find.get_str("find").unwrap(), "im_msg");
-        assert_eq!(find.get_document("filter").unwrap().get_bool("active").unwrap(), true);
+        assert!(find.get_document("filter").unwrap().get_bool("active").unwrap());
         assert_eq!(find.get_document("projection").unwrap().get_i64("email").unwrap(), 1);
         assert_eq!(find.get_document("sort").unwrap().get_i64("email").unwrap(), 1);
         assert_eq!(find.get_i64("skip").unwrap(), 2);

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -1016,7 +1016,7 @@ async fn postgres_query_one_cached(
 }
 
 enum PreparedSelectOutcome {
-    Complete(QueryResult),
+    Complete(Box<QueryResult>),
     TextFallback { column_types: Vec<String>, unsupported_type: String },
 }
 
@@ -1129,7 +1129,7 @@ async fn execute_select_prepared(
     );
 
     let (spatial_columns, spatial_values) = spatial_columns.finish_with_values(spatial_values);
-    Ok(PreparedSelectOutcome::Complete(QueryResult {
+    Ok(PreparedSelectOutcome::Complete(Box::new(QueryResult {
         columns,
         column_types,
         column_sortables: Vec::new(),
@@ -1143,7 +1143,7 @@ async fn execute_select_prepared(
         has_more: false,
         elasticsearch_raw_body: None,
         messages: Vec::new(),
-    }))
+    })))
 }
 
 fn matching_pg_text_column_types(columns: &[String], prepared: Option<Vec<String>>) -> Vec<String> {
@@ -1250,7 +1250,7 @@ async fn finish_prepared_select(
     progress_clock: Option<&StreamProgressClock>,
 ) -> Result<QueryResult, String> {
     match outcome {
-        PreparedSelectOutcome::Complete(result) => Ok(result),
+        PreparedSelectOutcome::Complete(result) => Ok(*result),
         PreparedSelectOutcome::TextFallback { column_types, unsupported_type } => {
             log::info!(
                 "[postgres][select:text_fallback] unsupported_type={} switching_to=simple_query",
@@ -1585,8 +1585,10 @@ const POSTGRES_CONNECTION_IDENTITY_SQL: &str = "SELECT pg_backend_pid(), \
 /// Notice buffers for live connections, keyed by connection identity. Entries
 /// are weak so they disappear once the pooled connection (and its driver
 /// task) is dropped.
-fn postgres_notice_buffers() -> &'static Mutex<HashMap<PostgresConnectionKey, Weak<Mutex<Vec<QueryMessage>>>>> {
-    static BUFFERS: OnceLock<Mutex<HashMap<PostgresConnectionKey, Weak<Mutex<Vec<QueryMessage>>>>>> = OnceLock::new();
+type PostgresNoticeBuffers = HashMap<PostgresConnectionKey, Weak<Mutex<Vec<QueryMessage>>>>;
+
+fn postgres_notice_buffers() -> &'static Mutex<PostgresNoticeBuffers> {
+    static BUFFERS: OnceLock<Mutex<PostgresNoticeBuffers>> = OnceLock::new();
     BUFFERS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -1599,11 +1601,10 @@ fn postgres_notice_buffers() -> &'static Mutex<HashMap<PostgresConnectionKey, We
 /// never be retried from `drain_postgres_notices`, which can run inside the
 /// read-only transaction used for EXPLAIN, where a failing query would abort
 /// the user's statement.
-fn postgres_client_keys(
-) -> &'static Mutex<HashMap<usize, (Weak<deadpool_postgres::StatementCache>, Option<PostgresConnectionKey>)>> {
-    static KEYS: OnceLock<
-        Mutex<HashMap<usize, (Weak<deadpool_postgres::StatementCache>, Option<PostgresConnectionKey>)>>,
-    > = OnceLock::new();
+type PostgresClientKeys = HashMap<usize, (Weak<deadpool_postgres::StatementCache>, Option<PostgresConnectionKey>)>;
+
+fn postgres_client_keys() -> &'static Mutex<PostgresClientKeys> {
+    static KEYS: OnceLock<Mutex<PostgresClientKeys>> = OnceLock::new();
     KEYS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -3220,12 +3220,12 @@ mod tests {
         sqlserver_dml_output_returns_rows, sqlserver_done_trace_event, sqlserver_filter_definition_error,
         sqlserver_hidden_schema_names, sqlserver_indexes_sql, sqlserver_legacy_indexes_sql, sqlserver_legacy_probe,
         sqlserver_legacy_probe_with_nonce, sqlserver_legacy_wildcard_metadata_query, sqlserver_list_objects_sql,
-        sqlserver_list_schemas_sql, sqlserver_list_tables_sql, sqlserver_probe_explicit_alias, sqlserver_query_messages,
-        sqlserver_schema_name_predicate, sqlserver_spatial_marker, sqlserver_supports_session_database_switch,
-        sqlserver_table_comment_sql, sqlserver_triggers_sql, sqlserver_visible_object_predicate,
-        strip_dbx_sqlserver_row_number_column, SqlServerDescribedColumn, SqlServerProbeOutputNameOverride,
-        SqlServerResultSet, SqlServerSpatialColumn, SqlServerTdsEvent, SQLSERVER_COMPLETION_CONTEXT_SQL,
-        SQLSERVER_RESULT_TYPE_PROBE_SQL,
+        sqlserver_list_schemas_sql, sqlserver_list_tables_sql, sqlserver_probe_explicit_alias,
+        sqlserver_query_messages, sqlserver_schema_name_predicate, sqlserver_spatial_marker,
+        sqlserver_supports_session_database_switch, sqlserver_table_comment_sql, sqlserver_triggers_sql,
+        sqlserver_visible_object_predicate, strip_dbx_sqlserver_row_number_column, SqlServerDescribedColumn,
+        SqlServerProbeOutputNameOverride, SqlServerResultSet, SqlServerSpatialColumn, SqlServerTdsEvent,
+        SQLSERVER_COMPLETION_CONTEXT_SQL, SQLSERVER_RESULT_TYPE_PROBE_SQL,
     };
     use crate::types::{
         CompletionAssistantMatchMode, CompletionAssistantObjectKind, CompletionAssistantRequest, QueryResult,

--- a/vendor/wry/src/webview2/mod.rs
+++ b/vendor/wry/src/webview2/mod.rs
@@ -22,7 +22,7 @@ use windows::{
     Globalization::*,
     Graphics::Gdi::*,
     System::{Com::*, LibraryLoader::GetModuleHandleW},
-    UI::{Input::KeyboardAndMouse::SetFocus, Shell::*, WindowsAndMessaging::*},
+    UI::{Input::KeyboardAndMouse::{SetFocus, VK_F6}, Shell::*, WindowsAndMessaging::*},
   },
 };
 
@@ -470,6 +470,32 @@ impl InnerWebView {
 
     // Webview handlers
     unsafe { Self::attach_handlers(hwnd, &webview, &mut attributes, &mut token, env)? };
+
+    // Swallow the WebView2 "Focus Next Pane" browser accelerator (F6 / Shift+F6).
+    // DBX has no F6 binding, and Chromium's focus cycling against the frameless
+    // Overlay-titlebar window can drop the compositor into a black screen
+    // (reproduced in both dev and packaged builds). Marking the key as handled
+    // stops the WebView from performing its default focus action.
+    unsafe {
+      let accelerator_key_handler = AcceleratorKeyPressedEventHandler::create(Box::new(
+        move |_, args| {
+          let Some(args) = args else { return Ok(()) };
+          let mut kind = COREWEBVIEW2_KEY_EVENT_KIND::default();
+          args.KeyEventKind(&mut kind)?;
+          if kind == COREWEBVIEW2_KEY_EVENT_KIND_KEY_DOWN
+            || kind == COREWEBVIEW2_KEY_EVENT_KIND_SYSTEM_KEY_DOWN
+          {
+            let mut virtual_key = 0u32;
+            args.VirtualKey(&mut virtual_key)?;
+            if virtual_key == VK_F6.0 as u32 {
+              args.SetHandled(true)?;
+            }
+          }
+          Ok(())
+        },
+      ));
+      controller.add_AcceleratorKeyPressed(&accelerator_key_handler, &mut token)?;
+    }
 
     // IPC handler
     unsafe { Self::attach_ipc_handler(&webview, &mut attributes, &mut token)? };


### PR DESCRIPTION
## 变更说明

修复 Windows 下按 F6 导致应用黑屏的问题。

**根因**：F6 是 WebView2 原生处理的浏览器加速键 "Focus Next Pane"（聚焦下一窗格），应用代码中没有任何 F6 绑定（已全量排查前端快捷键注册表、全局 keydown、Rust 后端均无）。由于本应用使用 `titleBarStyle: Overlay` 的无边框窗口，WebView2 在原生层执行焦点循环时会触发渲染合成问题导致黑屏，开发版和打包版均可复现。JS `preventDefault` 无法拦截——该键在原生层处理、DOM 收不到事件。

**修复**：在 vendored wry 的 WebView2 控制器上注册 `AcceleratorKeyPressed` 事件处理器，对 F6（含 Shift+F6 等组合）调用 `SetHandled(true)`，阻止 WebView 执行默认焦点动作。仅拦截 F6 单个按键，其余浏览器加速键（F12 开发者工具、F5 刷新、Ctrl+P 等）全部保留。

**改动文件**：
- `vendor/wry/src/webview2/mod.rs`：注册 AcceleratorKeyPressed 处理器 + 导入 `VK_F6`（+28 行）
- `Cargo.toml`：更新 wry vendor 补丁说明注释（+4 行）

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR **不涉及**前端改动（改动仅在 Rust 层：vendored wry 的 Windows WebView2 初始化代码，前端源码零改动）。

- [x] 本 PR 不涉及前端改动

## 验证

- [x] `make cargo-check-fast`（`cargo check --no-default-features`，全 workspace）通过
- [ ] `make check`（前端检查，本次改动不涉及前端，未运行）
- [x] `cargo test --no-default-features`：dbx-core 3865/3866 通过；唯一失败为预存的 Windows 路径分隔符问题（`resolves_manifest_agent_launch_with_driver_dir_templates` 期望 `dameng-go\config.json`，实际生成 `/` 分隔，与本次改动无关）
- [x] `cargo check --manifest-path vendor/wry/Cargo.toml -p wry`（新基线 `upstream/main` 上单独验证）通过
- [ ] 实机验证：Windows 上运行后按 F6 不再黑屏

## 关联 Issue

https://github.com/t8y2/dbx/issues/5651