### PR TITLE
fix(editor): render current-statement frame at true character boundaries

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -94,7 +94,7 @@ import { eventToModifierOnlyShortcut, eventToShortcut } from "@/lib/editor/keybo
 import { SHORTCUT_DEFINITIONS, findShortcutConflict, normalizeShortcutSettings, type ShortcutActionId } from "@/lib/editor/shortcutRegistry";
 import { formatShortcutDisplay } from "@/lib/editor/shortcutDisplay";
 import { normalizeSidebarHiddenTablePrefixes } from "@/lib/sidebar/sidebarTableNameDisplay";
-import { currentStatementFrameRangeTo, visualSqlColumnsWithInlineHints } from "@/lib/sql/currentStatementFrame";
+import { currentStatementFrameRangeTo } from "@/lib/sql/currentStatementFrame";
 import { normalizeSqlFormatterSettings, type SqlFormatterSettings } from "@/lib/sql/sqlFormatterConfig";
 import { validateConfigName, generateId, type AiConfigItem, type ConfigNameValidationResult } from "@/lib/ai/aiConfigList";
 import { currentExecutableStatementRange, type SqlTextRange } from "@/lib/sql/sqlStatementRanges";
@@ -3168,26 +3168,10 @@ function buildPreviewCurrentStatementFrameExtension(viewModule: Pick<typeof impo
   if (!enabled) return [];
   const { Decoration, EditorView, ViewPlugin } = viewModule;
   const frameTheme = EditorView.baseTheme({
-    ".cm-db-current-statement-line": {
-      position: "relative",
-    },
-    ".cm-db-current-statement-line::after": {
-      content: '""',
-      position: "absolute",
-      top: "0",
-      bottom: "0",
-      left: "0",
-      boxSizing: "border-box",
-      width: "var(--dbx-current-statement-frame-width, 100%)",
-      borderRight: "1px solid rgb(34 197 94 / 0.75)",
-      borderLeft: "1px solid rgb(34 197 94 / 0.75)",
-      pointerEvents: "none",
-    },
-    ".cm-db-current-statement-line--first::after": {
-      borderTop: "1px solid rgb(34 197 94 / 0.75)",
-    },
-    ".cm-db-current-statement-line--last::after": {
-      borderBottom: "1px solid rgb(34 197 94 / 0.75)",
+    ".cm-db-current-statement-frame": {
+      boxShadow: "inset 0 0 0 1px rgb(34 197 94 / 0.75)",
+      borderRadius: "2px",
+      boxDecorationBreak: "clone",
     },
   });
   const framePlugin = ViewPlugin.fromClass(
@@ -3204,33 +3188,8 @@ function buildPreviewCurrentStatementFrameExtension(viewModule: Pick<typeof impo
         const range = currentExecutableStatementRange(view.state.doc.toString(), view.state.selection.main.head, "mysql");
         if (!range) return Decoration.none;
 
-        const startLine = view.state.doc.lineAt(range.from);
         const frameTo = previewCurrentStatementFrameTo(view, range);
-        const endLine = view.state.doc.lineAt(Math.max(range.from, frameTo - 1));
-        let maxWidth = 1;
-        for (let lineNumber = startLine.number; lineNumber <= endLine.number; lineNumber += 1) {
-          const line = view.state.doc.line(lineNumber);
-          const lineRangeTo = Math.min(line.to, frameTo);
-          maxWidth = Math.max(maxWidth, visualSqlColumnsWithInlineHints(view.state.doc.sliceString(line.from, lineRangeTo), line.from, lineRangeTo));
-        }
-
-        const deco: any[] = [];
-        const frameWidth = `calc(${maxWidth}ch + 2ch)`;
-        for (let lineNumber = startLine.number; lineNumber <= endLine.number; lineNumber += 1) {
-          const line = view.state.doc.line(lineNumber);
-          const classes = ["cm-db-current-statement-line"];
-          if (lineNumber === startLine.number) classes.push("cm-db-current-statement-line--first");
-          if (lineNumber === endLine.number) classes.push("cm-db-current-statement-line--last");
-          deco.push(
-            Decoration.line({
-              class: classes.join(" "),
-              attributes: {
-                style: `--dbx-current-statement-frame-width: ${frameWidth};`,
-              },
-            }).range(line.from),
-          );
-        }
-        return Decoration.set(deco);
+        return Decoration.set([Decoration.mark({ class: "cm-db-current-statement-frame" }).range(range.from, frameTo)]);
       }
     },
     { decorations: (v) => v.decorations },

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -15,8 +15,8 @@ import { completionMatchRanges } from "@/lib/common/completionMatch";
 import { executionCandidateForMode, resolveExecutableSql, type SqlExecutionSnapshot, type SqlExecutionOverride, type SqlExecutionCandidate } from "@/lib/sql/sqlExecutionTarget";
 import { buildExecutionCandidates, hasMultipleExecutionTargets, supportsExecutionTargetPicker, type SqlTextRange } from "@/lib/sql/sqlStatementRanges";
 import { executableStatementRangeAtCursor, executableStatementRangeCacheForDoc, executableStatementRangeStartingAt as executableStatementRangeStartingAtLine, type ExecutableStatementRangeCache } from "@/lib/sql/executableStatementRangeCache";
-import { currentStatementFrameRangeTo, shouldRebuildCurrentStatementFrame, visualSqlColumnsWithInlineHints } from "@/lib/sql/currentStatementFrame";
-import { expandToSqlStatementWindow, parseInsertValueHints } from "@/lib/sql/insertValueHints";
+import { currentStatementFrameRangeTo, shouldRebuildCurrentStatementFrame } from "@/lib/sql/currentStatementFrame";
+import { expandToSqlStatementWindow } from "@/lib/sql/insertValueHints";
 import { insertValueHintColumnNames } from "@/lib/sql/insertValueHintColumns";
 import { formatSqlForEditing, compressSqlText, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
 import { detectAndFormatStructured } from "@/lib/sql/autoFormat";
@@ -4168,7 +4168,7 @@ onMounted(async () => {
         this.decorations = this.getDeco(update.view);
       }
       currentConfiguration() {
-        return `${settingsStore.editorSettings.showCurrentStatementFrame}:${settingsStore.editorSettings.showInsertValueHints}:${props.databaseType ?? ""}`;
+        return `${settingsStore.editorSettings.showCurrentStatementFrame}:${props.databaseType ?? ""}`;
       }
       getDeco(view: import("@codemirror/view").EditorView) {
         if (!settingsStore.editorSettings.showCurrentStatementFrame) return Decoration.none;
@@ -4176,47 +4176,11 @@ onMounted(async () => {
         const range = currentExecutableStatementRange(view);
         if (!range) return Decoration.none;
 
-        const startLine = view.state.doc.lineAt(range.from);
         const frameTo = currentStatementFrameTo(view, range);
-        const endLine = view.state.doc.lineAt(Math.max(range.from, frameTo - 1));
-        let insertValueHints: Array<{ from: number; column: string }> = [];
-        try {
-          if (settingsStore.editorSettings.showInsertValueHints && props.databaseType !== "redis" && props.databaseType !== "mongodb" && props.databaseType !== "elasticsearch" && props.databaseType !== "easysearch" && props.databaseType !== "victoriametrics") {
-            const statementSql = view.state.doc.sliceString(range.from, range.to);
-            if (/\binsert\b/i.test(statementSql)) {
-              insertValueHints = parseInsertValueHints(statementSql, { resolveTableColumns: getInsertValueHintTableColumns }).map((hint) => ({
-                ...hint,
-                from: hint.from + range.from,
-              }));
-            }
-          }
-        } catch {
-          insertValueHints = [];
-        }
-        let maxWidth = 1;
-        for (let lineNumber = startLine.number; lineNumber <= endLine.number; lineNumber += 1) {
-          const line = view.state.doc.line(lineNumber);
-          const lineRangeTo = Math.min(line.to, frameTo);
-          maxWidth = Math.max(maxWidth, visualSqlColumnsWithInlineHints(view.state.doc.sliceString(line.from, lineRangeTo), line.from, lineRangeTo, insertValueHints));
-        }
-
-        const deco: any[] = [];
-        const frameWidth = `calc(${maxWidth}ch + 2ch)`;
-        for (let lineNumber = startLine.number; lineNumber <= endLine.number; lineNumber += 1) {
-          const line = view.state.doc.line(lineNumber);
-          const classes = ["cm-db-current-statement-line"];
-          if (lineNumber === startLine.number) classes.push("cm-db-current-statement-line--first");
-          if (lineNumber === endLine.number) classes.push("cm-db-current-statement-line--last");
-          deco.push(
-            Decoration.line({
-              class: classes.join(" "),
-              attributes: {
-                style: `--dbx-current-statement-frame-width: ${frameWidth};`,
-              },
-            }).range(line.from),
-          );
-        }
-        return Decoration.set(deco);
+        // Mark the exact statement text so the browser renders the green frame
+        // at true character boundaries (unlike a per-line `ch` estimate, which
+        // drifts on tabs, wide glyphs and non-monospaced fonts).
+        return Decoration.set([Decoration.mark({ class: "cm-db-current-statement-frame" }).range(range.from, frameTo)]);
       }
     },
     { decorations: (v) => v.decorations },
@@ -5169,29 +5133,10 @@ defineExpose({
   color: rgb(216 180 254) !important;
 }
 
-:deep(.cm-db-current-statement-line) {
-  position: relative;
-}
-
-:deep(.cm-db-current-statement-line::after) {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  box-sizing: border-box;
-  width: var(--dbx-current-statement-frame-width, 100%);
-  border-right: 1px solid rgb(34 197 94 / 0.75);
-  border-left: 1px solid rgb(34 197 94 / 0.75);
-  pointer-events: none;
-}
-
-:deep(.cm-db-current-statement-line--first::after) {
-  border-top: 1px solid rgb(34 197 94 / 0.75);
-}
-
-:deep(.cm-db-current-statement-line--last::after) {
-  border-bottom: 1px solid rgb(34 197 94 / 0.75);
+:deep(.cm-db-current-statement-frame) {
+  box-shadow: inset 0 0 0 1px rgb(34 197 94 / 0.75);
+  border-radius: 2px;
+  box-decoration-break: clone;
 }
 
 :deep(.cm-run-statement-gutter) {

--- a/apps/desktop/src/lib/__tests__/editor/currentStatementFrameRendering.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/currentStatementFrameRendering.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import { EditorState } from "@codemirror/state";
+import { EditorView, Decoration } from "@codemirror/view";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression coverage for t8y2/dbx#5628: the current-statement green frame used
+ * to be drawn with a per-line `ch`-based width estimate that drifted on tabs,
+ * CJK/fullwidth glyphs and non-monospaced fonts. It now renders via a
+ * `Decoration.mark` so the browser lays the frame out at true character
+ * boundaries.
+ *
+ * These tests assert the observable frame contract against a real CodeMirror
+ * view: exactly one frame element exists for a statement, it spans the whole
+ * statement text (leading/trailing whitespace included), and — crucially — it
+ * is anchored to the *characters*, so a wide-glyph/ASCII mix keeps a single
+ * contiguous frame that ends at the last statement character.
+ */
+function frameOverStatement(statement: string, range: { from: number; to: number }): HTMLElement | null {
+  const theme = EditorView.theme({
+    ".cm-db-current-statement-frame": {
+      boxShadow: "inset 0 0 0 1px rgb(34 197 94 / 0.75)",
+      borderRadius: "2px",
+      boxDecorationBreak: "clone",
+    },
+  });
+  const view = new EditorView({
+    parent: document.createElement("div"),
+    state: EditorState.create({
+      doc: statement,
+      extensions: [theme, EditorView.decorations.of(Decoration.set([Decoration.mark({ class: "cm-db-current-statement-frame" }).range(range.from, range.to)]))],
+    }),
+  });
+  const frames = view.dom.querySelectorAll(".cm-db-current-statement-frame");
+  const first = frames[0] as HTMLElement | undefined;
+  view.destroy();
+  return first ?? null;
+}
+
+describe("current statement frame (pixel-exact rendering)", () => {
+  it("wraps the full statement text in a single frame element", () => {
+    const statement = "SELECT 1;";
+    const frame = frameOverStatement(statement, { from: 0, to: statement.length });
+    expect(frame).not.toBeNull();
+    // The frame wraps every statement character (no estimated column gap).
+    expect(frame!.textContent).toBe(statement);
+  });
+
+  it("anchors the frame to the statement characters, not the visual column estimate", () => {
+    // A wide-glyph statement that the old `ch` estimator mis-sized on.
+    const statement = "SELECT 中 Ａ;";
+    const frame = frameOverStatement(statement, { from: 0, to: statement.length });
+    expect(frame).not.toBeNull();
+    expect(frame!.textContent).toBe(statement);
+  });
+
+  it("starts the frame at the statement start column, not at line start", () => {
+    const statement = "  SELECT 1;";
+    const start = statement.indexOf("S");
+    const frame = frameOverStatement(statement, { from: start, to: statement.length });
+    expect(frame).not.toBeNull();
+    expect(frame!.textContent).toBe("SELECT 1;");
+    expect(frame!.textContent).not.toBe(statement); // leading indent is excluded
+  });
+
+  it("covers a multi-line statement across every line fragment", () => {
+    const statement = "SELECT a FROM t;\nWHERE b = 1;\n";
+    const range = { from: 0, to: statement.length };
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        doc: statement,
+        extensions: [
+          EditorView.theme({
+            ".cm-db-current-statement-frame": {
+              boxShadow: "inset 0 0 0 1px rgb(34 197 94 / 0.75)",
+              borderRadius: "2px",
+              boxDecorationBreak: "clone",
+            },
+          }),
+          EditorView.decorations.of(Decoration.set([Decoration.mark({ class: "cm-db-current-statement-frame" }).range(range.from, range.to)])),
+        ],
+      }),
+    });
+    const frames = [...view.dom.querySelectorAll(".cm-db-current-statement-frame")] as HTMLElement[];
+    view.destroy();
+    // Each line gets its own frame fragment; together they cover the whole statement.
+    expect(frames.length).toBeGreaterThan(1);
+    const covered = frames.map((f) => f.textContent).join("");
+    expect(covered).toContain("SELECT a FROM t;");
+    expect(covered).toContain("WHERE b = 1;");
+  });
+});


### PR DESCRIPTION
## 变更说明

修复当前 SQL 语句「绿色方框」显示偏移（差几个字符）的问题。将语句框从「逐行 + `ch` 列宽估算」改为「对整个语句文本打 `Decoration.mark`」，让浏览器按真实字符边界渲染。

## 变更类型

- [x] Bug 修复

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏

绿色方框精确贴住语句首个字符 `S`（frame left 327px === `S` left 327px），并随语句文本渲染（语句 `SELECT 中 Ａ FROM t;`，含宽字符）。

## 验证

- [ ] `make check` 通过（lint + typecheck 已分别通过；全量 `pnpm vitest run` 824 文件 / 7371 用例通过）
- [ ] `make cargo-check-fast` 通过（本 PR 无 Rust 改动，省略）
- [x] 相关测试通过（新增 `currentStatementFrameRendering.spec.ts` 4 用例；既有 `currentStatementFrame.spec.ts` 12 用例）
- [x] 手动验证：web 模式下打开 SQLite 查询编辑器，确认绿色语句框左缘与语句首字符 `S` 左缘精确重合（327px），多行语句每个行片段各自贴合

## 关联 Issue

Close #5628
