### PR TITLE
Fix: PostgreSQL 新增字段支持选择数组类型

### DIFF
--- a/apps/desktop/src/lib/table/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorState.ts
@@ -5,6 +5,12 @@ export function hasExistingColumnTypeChange(columns: readonly EditableStructureC
   return columns.some((column) => !!column.original && !column.markedForDrop && column.dataType !== column.original.data_type);
 }
 
+const POSTGRES_SERIAL_PSEUDO_TYPES = new Set(["smallserial", "serial", "bigserial"]);
+
+function withPostgresArrayTypes(types: readonly string[]): string[] {
+  return [...types, ...types.filter((type) => !POSTGRES_SERIAL_PSEUDO_TYPES.has(type)).map((type) => `${type}[]`)];
+}
+
 export const DATA_TYPE_OPTIONS: Record<string, string[]> = {
   mysql: [
     "tinyint",
@@ -58,7 +64,7 @@ export const DATA_TYPE_OPTIONS: Record<string, string[]> = {
     "multipolygon",
     "geometrycollection",
   ],
-  postgres: [
+  postgres: withPostgresArrayTypes([
     "smallint",
     "int2",
     "integer",
@@ -122,7 +128,7 @@ export const DATA_TYPE_OPTIONS: Record<string, string[]> = {
     "tstzrange",
     "daterange",
     "oid",
-  ],
+  ]),
   sqlite: ["integer", "real", "text", "blob", "numeric"],
   rqlite: ["integer", "real", "text", "blob", "numeric"],
   turso: ["integer", "real", "text", "blob", "numeric"],
@@ -1161,7 +1167,7 @@ export function isDataTypeLengthDisabled(_dbType: DatabaseType | undefined, base
   } else if (_dbType === "manticoresearch") {
     return key !== "bit" && key !== "float_vector";
   } else if (_dbType === "postgres" || _dbType === "gaussdb" || _dbType === "kwdb" || _dbType === "opengauss" || _dbType === "highgo" || _dbType === "uxdb" || _dbType === "vastbase" || _dbType === "kingbase") {
-    return POSTGRES_TYPE_LENGTH_DISABLES.includes(key);
+    return key.endsWith("[]") || POSTGRES_TYPE_LENGTH_DISABLES.includes(key);
   } else if (isOracleLikeStructureType(_dbType)) {
     // Dameng/Oracle integer aliases have fixed precision; MySQL-style display widths generate invalid DDL.
     return ORACLE_LIKE_TYPE_LENGTH_DISABLES.includes(key);

--- a/packages/app-tests/tableStructureEditorState.test.ts
+++ b/packages/app-tests/tableStructureEditorState.test.ts
@@ -14,6 +14,7 @@ import {
   generateUniqueIndexName,
   getColumnEditorControls,
   getDataTypeOptions,
+  isDataTypeLengthDisabled,
   isProtectedManticoreIdColumn,
   isDamengIdentityCompatibleDataType,
   isMysqlEnumDataType,
@@ -483,6 +484,21 @@ test("returns data type options for compatible table structure editors", () => {
   assert.deepEqual(getDataTypeOptions("doris"), getDataTypeOptions("mysql"));
   assert.equal(getDataTypeOptions("dameng").includes("varchar2"), true);
   assert.equal(getDataTypeOptions("sqlserver").includes("nvarchar"), true);
+});
+
+test("returns PostgreSQL array type options without serial pseudo-types", () => {
+  const options = getDataTypeOptions("postgres");
+  assert.equal(options.includes("integer[]"), true);
+  assert.equal(options.includes("character varying[]"), true);
+  assert.equal(options.includes("jsonb[]"), true);
+  assert.equal(options.includes("serial[]"), false);
+  assert.equal(options.includes("smallserial[]"), false);
+  assert.equal(options.includes("bigserial[]"), false);
+});
+
+test("does not append length parameters after PostgreSQL array brackets", () => {
+  assert.equal(isDataTypeLengthDisabled("postgres", "varchar[]"), true);
+  assert.equal(combineDataTypeForDatabase("postgres", "varchar[]", "20"), "varchar[]");
 });
 
 test("returns Xugu data type options", () => {


### PR DESCRIPTION
## 问题

PostgreSQL 表结构编辑器的新字段类型列表只包含标量类型，现有数组列虽然能显示为 `character varying[]`，但新增字段时没有数组类型可选。

## 修改

- 基于已有 PostgreSQL 类型列表补充对应的 `[]` 数组类型。
- 排除 PostgreSQL 的 `smallserial`、`serial`、`bigserial` 伪类型，避免生成不支持的数组类型。
- 数组类型禁用长度参数，避免生成 `varchar[](20)` 这类无效 SQL。
- 增加数组选项和 SQL 组合回归测试。

## 验证

- `pnpm -s typecheck` 通过
- 完整前端测试：823 个测试文件、7370 个用例通过
- changed-file oxlint 与 `git diff --check` 通过
- PostgreSQL 17.4 实库客户端验证：在表结构编辑器选择 `character varying[]`，SQL 预览为 `ADD COLUMN "tags" character varying[]`，保存成功
- 回查 `information_schema.columns` 返回 `data_type=ARRAY`、`udt_name=_varchar`

Fixes #1630