### PR TITLE
Fix: 查询结果表头显示字段可空标志

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -136,7 +136,7 @@ import { buildDataGridCellDetail, buildDataGridColumnDetail, buildDataGridRowDet
 import { applyColumnFormatter, buildColumnFormatterKey, getSupportedTimeZoneOptions, normalizeColumnFormatter, resolveColumnFormatter, type ColumnFormatterConfig, type DateTimeFormatterUnit, DateTimePatterns } from "@/lib/dataGrid/columnFormatter";
 import { temporalCellEditorConfig, type TemporalCellEditorConfig } from "@/lib/dataGrid/dataGridTemporalEditor";
 import { BOOLEAN_CELL_EDITOR_VALUES, booleanCellEditorValue, isBooleanCellValue, isBooleanColumnType, isPointInBooleanCheckbox, nextBooleanCellValue, normalizeBooleanCellValue, parseBooleanCellEditorValue } from "@/lib/dataGrid/dataGridBooleanColumn";
-import { resolveDataGridColumnsByResultIndex } from "@/lib/dataGrid/dataGridColumnMetadata";
+import { resolveDataGridColumnNullability, resolveDataGridColumnsByResultIndex } from "@/lib/dataGrid/dataGridColumnMetadata";
 import { isCancelSearchShortcut, isCopyCurrentRowShortcut, isDeleteCurrentRowShortcut, isFocusSearchShortcut, isModRShortcut, isSaveShortcut, isToggleTransposeShortcut } from "@/lib/editor/keyboardShortcuts";
 import { dataGridHeaderContentWidth, scrollbarGutterWidth } from "@/lib/dataGrid/dataGridScrollGutter";
 import { canFetchNextDataGridSegment, canGoNextDataGridPage, dataGridTotalRowCountLabelKey, dataGridTruncationHintKey, hasCompleteLocalDataGridResult, resolveDataGridPaginationTotal, type DataGridInexactTotalRowCountMode } from "@/lib/dataGrid/dataGridPagination";
@@ -534,6 +534,10 @@ function headerColumnType(column: string, actualColIdx: number): string {
     actualColIdx,
   });
   return resolved ? shortTypeName(compactHeaderColumnType(resolved)) : "";
+}
+
+function headerColumnNullability(actualColIdx: number): "nullable" | "required" | undefined {
+  return resolveDataGridColumnNullability(props.context, tableColumnForGridColumn(actualColIdx));
 }
 
 const reserveColumnTypeLine = computed(() => reserveDataGridHeaderLine(showColumnTypesInHeader.value, props.result.columns, (column, index) => headerColumnType(column, index)));
@@ -9292,6 +9296,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     :show-comment-line="reserveColumnCommentLine"
                     :tooltip-column-type="columnTypeMap.get(col.name)"
                     :tooltip-column-comment="columnCommentMap.get(col.name)"
+                    :column-nullability="headerColumnNullability(col.actualColIdx)"
                     :type-class="typeColorClass(headerColumnType(col.name, col.actualColIdx))"
                     :drag-class="columnHeaderDragClass(col.visibleColIdx)"
                     :column-style="columnHeaderStyle(col.visibleColIdx)"
@@ -9299,6 +9304,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     :column-name-label="t('grid.columnName')"
                     :column-type-label="t('grid.columnType')"
                     :column-comment-label="t('grid.columnComment')"
+                    :nullable-label="t('structureEditor.nullable')"
+                    :yes-label="t('structureEditor.yes')"
+                    :no-label="t('structureEditor.no')"
                     :column-index-label="t('grid.tableInfoIndexes')"
                     :column-primary-index-label="t('grid.columnPrimaryIndex')"
                     :column-unique-index-label="t('grid.columnUniqueIndex')"

--- a/apps/desktop/src/components/grid/DataGridColumnHeader.vue
+++ b/apps/desktop/src/components/grid/DataGridColumnHeader.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   columnComment?: string;
   tooltipColumnType?: string;
   tooltipColumnComment?: string;
+  columnNullability?: "nullable" | "required";
   showTypeLine?: boolean;
   showCommentLine?: boolean;
   typeClass?: HTMLAttributes["class"];
@@ -27,6 +28,9 @@ const props = defineProps<{
   columnNameLabel: string;
   columnTypeLabel: string;
   columnCommentLabel: string;
+  nullableLabel?: string;
+  yesLabel?: string;
+  noLabel?: string;
   columnIndexLabel: string;
   columnPrimaryIndexLabel: string;
   columnUniqueIndexLabel: string;
@@ -71,7 +75,10 @@ const emit = defineEmits<{
         <KeyRound v-if="columnIndexKind === 'primary'" class="h-3 w-3 shrink-0" :class="columnIndexColorClass(columnIndexKind)" :title="columnIndexText(columnIndexKind)" />
         <Hash v-else-if="columnIndexKind && columnIndexKind !== 'none'" class="h-3 w-3 shrink-0" :class="columnIndexColorClass(columnIndexKind)" :title="columnIndexText(columnIndexKind)" />
         <span class="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <span class="min-w-0 truncate leading-4">{{ name }}</span>
+          <span class="flex min-w-0 items-center gap-1 leading-4">
+            <span class="min-w-0 truncate">{{ name }}</span>
+            <span v-if="columnNullability === 'nullable'" data-grid-header-nullable class="shrink-0 rounded-sm border border-muted-foreground/40 px-0.5 text-[8px] font-semibold leading-3 text-muted-foreground" :title="nullableLabel" :aria-label="nullableLabel"> NULL </span>
+          </span>
           <span v-if="showTypeLine" data-grid-header-type-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3" :class="[typeClass, { invisible: !columnType }]" :title="columnType || undefined" :aria-hidden="columnType ? undefined : true">{{ columnType }}</span>
           <span v-if="showCommentLine" data-grid-header-comment-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3 text-muted-foreground" :class="{ invisible: !columnComment }" :title="columnComment || undefined" :aria-hidden="columnComment ? undefined : true">{{
             columnComment
@@ -97,6 +104,10 @@ const emit = defineEmits<{
         <template v-if="tooltipColumnComment ?? columnComment">
           <span class="text-background/70">{{ columnCommentLabel }}</span>
           <span>{{ tooltipColumnComment ?? columnComment }}</span>
+        </template>
+        <template v-if="columnNullability">
+          <span class="text-background/70">{{ nullableLabel }}</span>
+          <span>{{ columnNullability === "nullable" ? yesLabel : noLabel }}</span>
         </template>
         <template v-if="columnIndexKind && columnIndexKind !== 'none'">
           <span class="text-background/70">{{ columnIndexLabel }}</span>

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -384,6 +384,34 @@ describe("DataGridColumnHeader", () => {
     expect(findAll(mounted.root, (node) => node.props["data-grid-header-type-line"] === "")).toHaveLength(0);
     expect(findAll(mounted.root, (node) => node.props["data-grid-header-comment-line"] === "")).toHaveLength(0);
   });
+
+  it("marks nullable columns without marking required columns", () => {
+    const baseProps = {
+      name: "nickname",
+      actualColumnIndex: 1,
+      visibleColumnIndex: 1,
+      copyColumnNameLabel: "copy",
+      columnNameLabel: "name",
+      columnTypeLabel: "type",
+      columnCommentLabel: "comment",
+      nullableLabel: "nullable",
+      yesLabel: "yes",
+      noLabel: "no",
+      columnIndexLabel: "index",
+      columnPrimaryIndexLabel: "primary",
+      columnUniqueIndexLabel: "unique",
+      columnRegularIndexLabel: "regular",
+    };
+    const nullable = mountComponent(DataGridColumnHeader, { ...baseProps, columnNullability: "nullable" });
+    const required = mountComponent(DataGridColumnHeader, { ...baseProps, columnNullability: "required" });
+    const badge = findOne(nullable.root, (node) => node.props["data-grid-header-nullable"] === "");
+
+    expect(hostText(badge).trim()).toBe("NULL");
+    expect(badge.props.title).toBe("nullable");
+    expect(hostText(nullable.root)).toContain("nullableyes");
+    expect(findAll(required.root, (node) => node.props["data-grid-header-nullable"] === "")).toHaveLength(0);
+    expect(hostText(required.root)).toContain("nullableno");
+  });
 });
 
 describe("DataGridFilterBuilder", () => {

--- a/apps/desktop/src/lib/dataGrid/dataGridColumnMetadata.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridColumnMetadata.ts
@@ -1,5 +1,12 @@
 import type { ColumnInfo } from "@/types/database";
 
+export type DataGridColumnNullability = "nullable" | "required";
+
+export function resolveDataGridColumnNullability(context: "results" | "table-data" | undefined, column: Pick<ColumnInfo, "is_nullable"> | undefined): DataGridColumnNullability | undefined {
+  if (context !== "results" || !column) return undefined;
+  return column.is_nullable ? "nullable" : "required";
+}
+
 export function resolveDataGridColumnsByResultIndex(options: { resultColumns: readonly string[]; sourceColumns?: readonly (string | undefined)[]; tableColumns: readonly ColumnInfo[] }): Array<ColumnInfo | undefined> {
   const columnsByName = new Map<string, ColumnInfo>();
   for (const column of options.tableColumns) {

--- a/packages/app-tests/dataGridBooleanColumn.test.ts
+++ b/packages/app-tests/dataGridBooleanColumn.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { readFileSync } from "node:fs";
 import { test } from "vitest";
 import { BOOLEAN_CELL_EDITOR_VALUES, booleanCellEditorValue, isBooleanCellValue, isBooleanColumnType, normalizeBooleanCellValue, parseBooleanCellEditorValue } from "../../apps/desktop/src/lib/dataGrid/dataGridBooleanColumn.ts";
-import { resolveDataGridColumnsByResultIndex } from "../../apps/desktop/src/lib/dataGrid/dataGridColumnMetadata.ts";
+import { resolveDataGridColumnNullability, resolveDataGridColumnsByResultIndex } from "../../apps/desktop/src/lib/dataGrid/dataGridColumnMetadata.ts";
 import type { ColumnInfo } from "../../apps/desktop/src/types/database.ts";
 
 function column(name: string, dataType: string): ColumnInfo {
@@ -91,6 +91,17 @@ test("indexes table metadata once and resolves source-column aliases", () => {
   assert.equal(resolved[0], enabled);
   assert.equal(resolved[1], displayName);
   assert.equal(resolved[2], undefined);
+});
+
+test("shows nullability only for query results with resolved column metadata", () => {
+  const nullable = column("nickname", "varchar");
+  const required = { ...column("code", "varchar"), is_nullable: false };
+
+  assert.equal(resolveDataGridColumnNullability("results", nullable), "nullable");
+  assert.equal(resolveDataGridColumnNullability("results", required), "required");
+  assert.equal(resolveDataGridColumnNullability("results", undefined), undefined);
+  assert.equal(resolveDataGridColumnNullability("table-data", nullable), undefined);
+  assert.equal(resolveDataGridColumnNullability(undefined, nullable), undefined);
 });
 
 test("keeps the enum editor as the default boolean edit path and gates checkbox interaction behind the checkbox display mode", () => {


### PR DESCRIPTION
## 问题

查询结果已经能加载单表字段元数据，但表头没有使用 `is_nullable`，用户无法直接判断字段是否允许写入 `NULL`。

## 修改

- 可空字段在查询结果表头列名旁显示紧凑的 `NULL` 标志。
- 标志悬停说明为“可为空”，并提供对应无障碍标签。
- 表头详情同时展示“可为空：是/否”。
- 使用结果列到源字段的现有映射，因此查询别名也能显示正确标志。
- 仅在查询结果且成功解析到真实字段元数据时展示；表达式、聚合列和无法可靠映射的列不做推断。
- 不影响“查看数据”标签，避免字段元数据未加载时将占位值误判为可空。
- 增加可空、必填以及查询结果上下文边界测试。

## 兼容性

该展示基于统一的 `ColumnInfo.is_nullable` 元数据契约，不绑定单一数据库。能够为简单查询解析表来源并返回标准字段元数据的 SQL 驱动会显示；MongoDB、Redis 等非 SQL 查询以及无法解析来源的复杂结果不会显示。

## 验证

- `pnpm typecheck` 通过
- 表头组件和字段映射聚焦测试：33 个用例通过
- changed-file oxlint 与 `git diff --check` 通过
- MySQL 8.4、MariaDB 10.11：别名可空列显示 `NULL`，非空列不显示
- PostgreSQL 17.4、CockroachDB：可空列显示 `NULL`，非空列不显示
- GaussDB / openGauss 5.0.0：现有 `db4ai.snapshot` 表的可空别名列显示 `NULL`，两个非空列不显示
- KingbaseES V8：别名可空列显示 `NULL`，非空列不显示
- SQL Server：别名可空列显示 `NULL`，非空列不显示
- Oracle XE 11g：别名可空列显示 `NULL`，非空列不显示
- 达梦 DM8：选中 `DBX_TEST` 模式并显式限定 Schema 后，别名可空列显示 `NULL`，非空列不显示
- ClickHouse HTTP：`Nullable(String)` 别名列显示 `NULL`，`UInt32` / `String` 列不显示
- MySQL 同一测试表的“查看数据”标签不显示该标志
- 实测标志的 `title` 和 `aria-label` 均为“可为空”

Fixes #2359
