### PR TITLE
fix(web): make logo and icon-preview assets base-path aware

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -126,7 +126,7 @@ import { currentLocale, setLocale, type Locale } from "@/i18n";
 import { SETTINGS_SEARCH_DEFINITIONS, TOOLBAR_VISIBILITY_ITEMS, createShortcutSettingsSearchDefinitions, resolveSettingsSearchEntries, searchSettings, toolbarVisibilityItemLabel, type SettingsCategory, type SettingsSearchEntry, type ToolbarVisibilityItem } from "@/lib/settings/settingsSearch";
 import { LOCALE_OPTIONS } from "@/lib/app/localeOptions";
 import { DEFAULT_WEB_DAV_AUTO_UPLOAD_INTERVAL_MINUTES, DEFAULT_WEB_DAV_REMOTE_PATH, normalizedWebDavAutoUploadInterval, writeWebDavAutoUploadFields } from "@/lib/webdav/webdavAutoUploadConfig";
-import { apiUrl } from "@/lib/common/webPath";
+import { apiUrl, webPath } from "@/lib/common/webPath";
 import { DEFAULT_DATA_GRID_FONT_FAMILY, DEFAULT_UI_FONT_FAMILY, normalizeCustomFontFamilyInput, readableFontFamily, SYSTEM_UI_FONT_FAMILY } from "@/lib/app/appFonts";
 import { buildFontFamilyOptions, displayFontFamily, isPresetFontFamily, loadSystemFontNames } from "@/lib/app/fontFamilyOptions";
 import { buildAppSupportInfoRows, formatAppSupportInfoForClipboard, type AppSupportInfoLabels } from "@/lib/app/supportInfo";
@@ -4195,7 +4195,7 @@ onUnmounted(() => {
                 <div class="settings-appearance-choice-grid">
                   <Button type="button" variant="outline" class="settings-choice-card h-auto justify-start border p-3" :class="editIconTheme === 'default' ? 'dbx-choice-selected' : ''" @click="setIconTheme('default')">
                     <div class="flex items-center gap-3 text-left w-full min-w-0">
-                      <img src="/icon-preview-default.png" alt="DBX" class="h-12 w-12 shrink-0" />
+                      <img :src="webPath('/icon-preview-default.png')" alt="DBX" class="h-12 w-12 shrink-0" />
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger as-child>
@@ -4217,7 +4217,7 @@ onUnmounted(() => {
                   </Button>
                   <Button type="button" variant="outline" class="settings-choice-card h-auto justify-start border p-3" :class="editIconTheme === 'black' ? 'dbx-choice-selected' : ''" @click="setIconTheme('black')">
                     <div class="flex items-center gap-3 text-left w-full min-w-0">
-                      <img src="/icon-preview-black.png" alt="DBX" class="h-12 w-12 shrink-0" />
+                      <img :src="webPath('/icon-preview-black.png')" alt="DBX" class="h-12 w-12 shrink-0" />
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger as-child>

--- a/apps/desktop/src/components/icons/AppLogo.vue
+++ b/apps/desktop/src/components/icons/AppLogo.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { webPath } from "@/lib/common/webPath";
 
 const settingsStore = useSettingsStore();
 const isBlackLogo = computed(() => settingsStore.desktopSettings.icon_theme === "black");
-const logoSrc = computed(() => (isBlackLogo.value ? "/logo-black.png" : "/logo.png"));
+const logoSrc = computed(() => webPath(isBlackLogo.value ? "/logo-black.png" : "/logo.png"));
 </script>
 
 <template>

--- a/apps/desktop/src/lib/__tests__/common/webPath.spec.ts
+++ b/apps/desktop/src/lib/__tests__/common/webPath.spec.ts
@@ -13,6 +13,10 @@ describe("webPath", () => {
     expect(webPath("/", "/dbx")).toBe("/dbx/");
     expect(webPath("/icons/database/mysql.svg", "/dbx")).toBe("/dbx/icons/database/mysql.svg");
     expect(webPath("/icons/ai/openai.svg", "/dbx")).toBe("/dbx/icons/ai/openai.svg");
+    expect(webPath("/logo.png", "/dbx")).toBe("/dbx/logo.png");
+    expect(webPath("/logo-black.png", "/dbx")).toBe("/dbx/logo-black.png");
+    expect(webPath("/icon-preview-default.png", "/dbx")).toBe("/dbx/icon-preview-default.png");
+    expect(webPath("/icon-preview-black.png", "/dbx")).toBe("/dbx/icon-preview-black.png");
     expect(apiUrl("/auth/check", "/dbx")).toBe("/dbx/api/auth/check");
     expect(apiUrl("/api/auth/check", "/dbx")).toBe("/dbx/api/auth/check");
     expect(apiUrl("api/auth/check", "/dbx")).toBe("/dbx/api/auth/check");


### PR DESCRIPTION
## Problem

When DBX is deployed under a reverse-proxy subpath (e.g. `DBX_PUBLIC_BASE_PATH=/dbx`), the app logo and the icon-theme preview images are requested from the site root (`/logo.png`, `/logo-black.png`, `/icon-preview-default.png`, `/icon-preview-black.png`) instead of the subpath (`/dbx/logo.png`), so those images 404.

This is the same class of issue previously fixed for database / AI provider icons in #2192.

## Fix

Use the existing base-path-aware `webPath()` helper for these asset URLs in `AppLogo.vue` and `EditorSettingsDialog.vue`, matching the pattern already used by `DatabaseIcon.vue` and `AiProviderLogo.vue`.

## Verification

- Extended and passed `webPath` unit tests.
- Frontend production build succeeds.
- With base path `/dbx`, `webPath("/logo.png")` → `/dbx/logo.png`.

Related: #5518
