### PR TITLE
Fix：新增字段时不再误报字段排序提示

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
+++ b/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   invalidateObjectDdl: vi.fn(),
   loadObjectMetadataFacet: vi.fn(),
   invalidateTableMetadataCache: vi.fn(),
+  toast: vi.fn(),
 }));
 
 vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
@@ -186,7 +187,7 @@ vi.mock("@/stores/settingsStore", () => ({
   }),
 }));
 vi.mock("@/composables/useTheme", () => ({ useTheme: () => ({ isDark: { value: false } }) }));
-vi.mock("@/composables/useToast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/composables/useToast", () => ({ useToast: () => ({ toast: mocks.toast }) }));
 vi.mock("@/lib/sql/sqlHighlighter", () => ({ createShikiSqlHighlighter: vi.fn(async () => (sql: string) => sql) }));
 vi.mock("@/lib/metadata/objectDdlCache", () => ({
   loadObjectDdl: mocks.loadObjectDdl,
@@ -239,7 +240,7 @@ function draft(isPrimaryKey = false) {
   };
 }
 
-async function mountEditor(databaseType: "dameng" | "oracle", isPrimaryKey = false) {
+async function mountEditor(databaseType: "sqlserver" | "postgres" | "sqlite" | "oracle" | "dameng" | "duckdb" | "informix", isPrimaryKey = false) {
   mocks.connection.db_type = databaseType;
   mocks.connection.name = databaseType;
   mocks.connection.driver_label = databaseType;
@@ -360,6 +361,19 @@ describe("TableStructureEditor primary key editing", () => {
         columns: [expect.objectContaining({ isPrimaryKey: false })],
       }),
     );
+  });
+});
+
+describe("TableStructureEditor local column order notice", () => {
+  it.each(["sqlserver", "postgres", "sqlite", "oracle", "dameng", "duckdb", "informix"] as const)("does not show the reorder notice when adding a %s column", async (databaseType) => {
+    const root = await mountEditor(databaseType);
+    const addColumnButton = Array.from(root.querySelectorAll("button")).find((button) => button.textContent?.includes("structureEditor.addColumn"));
+    if (!addColumnButton) throw new Error("Missing add column button");
+
+    addColumnButton.click();
+    await nextTick();
+
+    expect(mocks.toast).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -1437,7 +1437,7 @@ async function addColumn() {
   const insertAt = resolveInsertColumnIndex(columns.value, selectedColumnId.value);
   columns.value.splice(insertAt, 0, column);
   selectedColumnId.value = column.id;
-  if (usesLocalTableColumnOrder.value) persistLocalColumnOrder();
+  if (usesLocalTableColumnOrder.value) persistLocalColumnOrder(false);
   await focusColumnNameInput(column.id);
 }
 
@@ -1455,7 +1455,7 @@ function applyColumnTemplate(templateId: string) {
   const insertAt = resolveInsertColumnIndex(columns.value, selectedColumnId.value);
   columns.value.splice(insertAt, 0, ...templateColumns);
   selectedColumnId.value = templateColumns[templateColumns.length - 1]?.id ?? selectedColumnId.value;
-  if (usesLocalTableColumnOrder.value) persistLocalColumnOrder();
+  if (usesLocalTableColumnOrder.value) persistLocalColumnOrder(false);
 }
 
 function removeNewColumn(column: EditableStructureColumn) {


### PR DESCRIPTION
## 问题

对不支持数据库物理字段重排、仅在本地保存字段顺序的数据库，编辑已有表并新增字段时，会错误提示“字段顺序仅保存在本地”，但用户并未执行字段拖动排序。

受影响的数据库类型包括 SQL Server、PostgreSQL、SQLite、Oracle、达梦、DuckDB 和 Informix。

## 修复

- 新增字段及套用字段模板时静默同步本地字段顺序
- 仅在实际拖动字段排序时保留提示
- 对全部 7 类本地字段排序数据库增加参数化回归测试

## 验证

- `pnpm exec vitest run apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts --reporter=verbose`（16 项通过，包含 7 类数据库）
- `pnpm typecheck`
- `pnpm exec oxlint apps/desktop/src/components/structure/TableStructureEditor.vue apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts`
- 本地免密预览连接 PostgreSQL 17.4，编辑已有表结构并新增字段：字段草稿正常出现，未显示字段排序提示