### PR TITLE
Fix：避免标签轻微移动误触拖拽

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -47,7 +47,7 @@ const queryStore = useQueryStore();
 const settingsStore = useSettingsStore();
 const { toast } = useToast();
 const tabDrag = useTabDrag((draggedId, targetId, position) => {
-  queryStore.reorderTab(draggedId, targetId, position);
+  return queryStore.reorderTab(draggedId, targetId, position);
 });
 const editingTabId = ref<string | null>(null);
 const editingTitle = ref("");
@@ -538,7 +538,7 @@ function tabMenuIcon(tab: QueryTab) {
 }
 
 function handleTabClick(tab: QueryTab) {
-  if (tabDrag.state.wasDragged) return;
+  if (tabDrag.state.suppressClick) return;
   activateTab(tab.id);
 }
 

--- a/apps/desktop/src/composables/__tests__/useTabDrag.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useTabDrag.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TAB_DRAG_HORIZONTAL_THRESHOLD, useTabDrag } from "@/composables/useTabDrag";
+
+function createDragHarness(onDrop = vi.fn(() => true)) {
+  const drag = useTabDrag(onDrop);
+  const source = document.createElement("div");
+  source.innerHTML = '<span class="truncate">Source</span>';
+  source.addEventListener("mousedown", (event) => drag.startDrag(event, "source"));
+  document.body.appendChild(source);
+  return { drag, source, onDrop };
+}
+
+function beginDrag(source: HTMLElement, x = 100, y = 20) {
+  source.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, clientX: x, clientY: y }));
+}
+
+function movePointer(x: number, y = 20) {
+  document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: x, clientY: y }));
+}
+
+function releasePointer() {
+  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
+function enterDropTarget(drag: ReturnType<typeof useTabDrag>, tabId = "target", x = 10) {
+  const target = document.createElement("div");
+  target.getBoundingClientRect = () => ({ x: 0, y: 0, left: 0, top: 0, right: 100, bottom: 28, width: 100, height: 28, toJSON: () => ({}) });
+  target.addEventListener("mousemove", (event) => drag.updateTarget(event, tabId));
+  document.body.appendChild(target);
+  target.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: x, clientY: 20 }));
+}
+
+afterEach(() => {
+  releasePointer();
+  document.body.innerHTML = "";
+  document.body.style.cursor = "";
+  document.body.style.userSelect = "";
+});
+
+describe("useTabDrag", () => {
+  it("ignores sub-threshold horizontal movement and vertical pointer jitter", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source);
+
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD - 1, 120);
+
+    expect(drag.state.active).toBe(false);
+    expect(drag.state.suppressClick).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress the click when a drag gesture has no valid drop target", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD);
+    expect(drag.state.active).toBe(true);
+
+    releasePointer();
+
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(drag.state.suppressClick).toBe(false);
+  });
+
+  it("does not suppress the click when the drop callback reports no reorder", () => {
+    const onDrop = vi.fn(() => false);
+    const { drag, source } = createDragHarness(onDrop);
+    beginDrag(source);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD);
+    enterDropTarget(drag);
+
+    releasePointer();
+
+    expect(onDrop).toHaveBeenCalledWith("source", "target", "before");
+    expect(drag.state.suppressClick).toBe(false);
+  });
+
+  it("suppresses the click only after a completed reorder", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD);
+    enterDropTarget(drag, "target", 90);
+
+    releasePointer();
+
+    expect(onDrop).toHaveBeenCalledWith("source", "target", "after");
+    expect(drag.state.suppressClick).toBe(true);
+
+    beginDrag(source);
+    expect(drag.state.suppressClick).toBe(false);
+  });
+});

--- a/apps/desktop/src/composables/useTabDrag.ts
+++ b/apps/desktop/src/composables/useTabDrag.ts
@@ -7,19 +7,19 @@ interface TabDragState {
   draggedId: string | null;
   targetId: string | null;
   dropPosition: TabDropPosition | null;
-  wasDragged: boolean;
+  suppressClick: boolean;
   startX: number;
   startY: number;
 }
 
-const DRAG_THRESHOLD = 5;
+export const TAB_DRAG_HORIZONTAL_THRESHOLD = 12;
 
 const state = reactive<TabDragState>({
   active: false,
   draggedId: null,
   targetId: null,
   dropPosition: null,
-  wasDragged: false,
+  suppressClick: false,
   startX: 0,
   startY: 0,
 });
@@ -30,7 +30,7 @@ let pending: {
   y: number;
   sourceEl: HTMLElement | null;
 } | null = null;
-let onDropCallback: ((draggedId: string, targetId: string, position: TabDropPosition) => void) | null = null;
+let onDropCallback: ((draggedId: string, targetId: string, position: TabDropPosition) => boolean) | null = null;
 let ghostEl: HTMLElement | null = null;
 
 function createGhost(sourceEl: HTMLElement, x: number, y: number) {
@@ -79,10 +79,8 @@ function onMouseMove(event: MouseEvent) {
 
   if (pending && !state.active) {
     const dx = event.clientX - pending.x;
-    const dy = event.clientY - pending.y;
-    if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) return;
+    if (Math.abs(dx) < TAB_DRAG_HORIZONTAL_THRESHOLD) return;
     state.active = true;
-    state.wasDragged = true;
     state.draggedId = pending.id;
     state.startX = pending.x;
     state.startY = pending.y;
@@ -100,8 +98,9 @@ function onMouseMove(event: MouseEvent) {
 }
 
 function onMouseUp() {
+  state.suppressClick = false;
   if (state.active && state.draggedId && state.targetId && state.dropPosition && onDropCallback) {
-    onDropCallback(state.draggedId, state.targetId, state.dropPosition);
+    state.suppressClick = onDropCallback(state.draggedId, state.targetId, state.dropPosition);
   }
   reset();
 }
@@ -128,7 +127,7 @@ function ensureListeners() {
   listenersAttached = true;
 }
 
-export function useTabDrag(onDrop: (draggedId: string, targetId: string, position: TabDropPosition) => void) {
+export function useTabDrag(onDrop: (draggedId: string, targetId: string, position: TabDropPosition) => boolean) {
   ensureListeners();
   onDropCallback = onDrop;
 
@@ -136,7 +135,7 @@ export function useTabDrag(onDrop: (draggedId: string, targetId: string, positio
     if (event.button !== 0) return;
     const target = event.target as HTMLElement;
     if (target.closest("button, input, [data-tab-title-input]")) return;
-    state.wasDragged = false;
+    state.suppressClick = false;
     const el = (event.currentTarget as HTMLElement) || null;
     pending = { id: tabId, x: event.clientX, y: event.clientY, sourceEl: el };
   }

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2702,11 +2702,16 @@ export const useQueryStore = defineStore("query", () => {
   function reorderTab(id: string, targetId: string, position: "before" | "after") {
     const fromIdx = tabs.value.findIndex((t) => t.id === id);
     const toIdx = tabs.value.findIndex((t) => t.id === targetId);
-    if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return;
-    const [tab] = tabs.value.splice(fromIdx, 1);
-    const newToIdx = tabs.value.findIndex((t) => t.id === targetId);
-    tabs.value.splice(newToIdx + (position === "after" ? 1 : 0), 0, tab);
-    tabs.value = orderPinnedFirst(tabs.value, (item) => !!item.pinned);
+    if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return false;
+
+    const reordered = [...tabs.value];
+    const [tab] = reordered.splice(fromIdx, 1);
+    const newToIdx = reordered.findIndex((t) => t.id === targetId);
+    reordered.splice(newToIdx + (position === "after" ? 1 : 0), 0, tab);
+    const nextTabs = orderPinnedFirst(reordered, (item) => !!item.pinned);
+    if (nextTabs.every((item, index) => item.id === tabs.value[index]?.id)) return false;
+    tabs.value = nextTabs;
+    return true;
   }
 
   function persistSavedSqlExecutionTarget(tab: QueryTab, options: UpdateExecutionTargetOptions) {

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -7302,9 +7302,26 @@ test("reorderTab with after position places tab correctly", () => {
   const tabC = store.createTab("conn-1", "db", "C", "query");
 
   // Drag A after C
-  store.reorderTab(tabA, tabC, "after");
+  assert.equal(store.reorderTab(tabA, tabC, "after"), true);
   assert.deepEqual(
     store.tabs.map((t) => t.id),
     [tabB, tabC, tabA],
   );
+});
+
+test("reorderTab reports adjacent no-op drops without replacing tab order", () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+
+  const tabA = store.createTab("conn-1", "db", "A", "query");
+  const tabB = store.createTab("conn-1", "db", "B", "query");
+  const tabC = store.createTab("conn-1", "db", "C", "query");
+  const originalTabs = [...store.tabs];
+
+  assert.equal(store.reorderTab(tabA, tabB, "before"), false);
+  assert.deepEqual(store.tabs, originalTabs);
+  assert.equal(store.reorderTab(tabB, tabA, "after"), false);
+  assert.deepEqual(store.tabs, originalTabs);
+  assert.equal(store.reorderTab(tabC, "missing", "before"), false);
+  assert.deepEqual(store.tabs, originalTabs);
 });


### PR DESCRIPTION
## 问题

标签拖拽原先使用 5px 的横纵向位移阈值，轻微移动就会进入拖拽状态。即使最终没有有效重排，也会吞掉点击事件，导致标签既未移动也未打开。

## 修复

- 将拖拽触发条件调整为横向移动达到 12px，忽略垂直方向的指针抖动
- 仅在标签顺序实际发生变化时抑制本次点击
- 无有效目标或相邻位置无变化时继续执行标签点击
- 为拖拽阈值、无效拖放和有效重排补充测试

## 测试

- `pnpm -s vitest run apps/desktop/src/composables/__tests__/useTabDrag.spec.ts packages/app-tests/queryStore.test.ts`（160 项通过）
- `pnpm -s typecheck`
- 完整前端测试 7504 项通过；首次 Rust 编译导致文档导出钩子超时，编译完成后单独复跑通过
- `make dev-fast` 客户端实际验证通过

Fixes #5671
