### PR TITLE
Fix: 完善 INSERT 全字段补全

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -417,7 +417,17 @@ WHERE a.id = b.fk_kpi_set_score_id`,
     const { context, items } = semanticCompletion("INSERT INTO users (|", { columnsByTable });
 
     expect(context.insertTable).toBe("users");
-    expect(items.find((item) => item.type === "snippet" && item.label === "users.*")?.apply).toBe("id, name, email");
+    const allColumns = items.find((item) => item.type === "snippet" && item.label === "users.*");
+    expect(allColumns?.apply).toBe("id, name, email) VALUES (${1:value}, ${2:value}, ${3:value})");
+    expect(allColumns?.detail).toBe("3 columns: id, name, email) VALUES (value, value, value)");
+  });
+
+  it("uses the configured keyword case for INSERT all-column snippets", () => {
+    const columnsByTable = new Map<string, SqlCompletionColumn[]>([["users", ["id", "name"].map((name) => ({ name, table: "users" }))]]);
+
+    const { items } = semanticCompletion("insert into users (|", { columnsByTable, keywordCase: "lower" });
+
+    expect(items.find((item) => item.type === "snippet" && item.label === "users.*")?.apply).toBe("id, name) values (${1:value}, ${2:value})");
   });
 
   it("keeps partial INSERT INTO targets in table completion context", () => {

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -1412,7 +1412,7 @@ class SqlCompletionProvider {
     if (!context.exclusiveTableSuggestions && context.suggestColumns) {
       this.items.push(...buildColumnItems(context, this.input.columnsByTable, this.dialect));
       this.items.push(...buildSelectAllColumnItems(context, this.input.columnsByTable, this.t, this.dialect));
-      this.items.push(...buildInsertAllColumnItems(context, this.input.columnsByTable, this.t, this.dialect));
+      this.items.push(...buildInsertAllColumnItems(context, this.input.columnsByTable, this.t, this.dialect, this.input.keywordCase));
     }
 
     const emptyTableNameCompletion = !context.prefix && (context.suggestTables || context.exclusiveTableSuggestions);
@@ -3252,7 +3252,7 @@ function buildSelectAllColumnItems(context: SqlCompletionContext, columnsByTable
   return items;
 }
 
-function buildInsertAllColumnItems(context: SqlCompletionContext, columnsByTable: Map<string, SqlCompletionColumn[]>, t?: SqlCompletionTranslations, dialect?: "mysql" | "postgres" | "sqlserver"): SqlCompletionItem[] {
+function buildInsertAllColumnItems(context: SqlCompletionContext, columnsByTable: Map<string, SqlCompletionColumn[]>, t?: SqlCompletionTranslations, dialect?: "mysql" | "postgres" | "sqlserver", keywordCase?: SqlKeywordCase): SqlCompletionItem[] {
   if (!context.insertTable) return [];
   const columns = uniqueColumnsByName(columnsForInsertTarget(context, columnsByTable));
   if (columns.length === 0) return [];
@@ -3260,13 +3260,17 @@ function buildInsertAllColumnItems(context: SqlCompletionContext, columnsByTable
   const label = `${context.insertTable}.*`;
   if (!selectAllColumnItemMatchesPrefix(label, { name: context.insertTable, schema: context.insertSchema }, columns, context.prefix)) return [];
 
-  const expansion = columns.map((column) => quoteSqlIdentifier(column.name, dialect)).join(", ");
+  const columnList = columns.map((column) => quoteSqlIdentifier(column.name, dialect)).join(", ");
+  const valuesKeyword = applySqlKeywordCase("VALUES", keywordCase);
+  const valueList = columns.map((_, index) => `\${${index + 1}:value}`).join(", ");
+  const expansion = `${columnList}) ${valuesKeyword} (${valueList})`;
+  const preview = `${columnList}) ${valuesKeyword} (${columns.map(() => "value").join(", ")})`;
   const countText = (t?.starExpansionColumns ?? "{count} columns").replace("{count}", String(columns.length));
   return [
     {
       label,
       type: "snippet" as const,
-      detail: `${countText}: ${expansion.length > 60 ? expansion.slice(0, 57) + "..." : expansion}`,
+      detail: `${countText}: ${preview.length > 60 ? preview.slice(0, 57) + "..." : preview}`,
       apply: expansion,
       boost: 2450 + selectAllColumnItemPrefixBoost(label, { name: context.insertTable, schema: context.insertSchema }, columns, context.prefix),
     },

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -2291,7 +2291,7 @@ test("suggests INSERT columns for a SQL Server three-part target", () => {
     dialect: "sqlserver",
   });
 
-  assert.equal(items.find((item) => item.type === "snippet" && item.label === "orders.*")?.apply, "target_marker");
+  assert.equal(items.find((item) => item.type === "snippet" && item.label === "orders.*")?.apply, "target_marker) VALUES (${1:value})");
 });
 
 test("detects MySQL backtick-qualified INSERT INTO column list context", () => {
@@ -2339,7 +2339,7 @@ test("suggests all target columns for INSERT INTO column list", () => {
 
   const allColumns = items.find((item) => item.type === "snippet" && item.label === "users.*");
   assert.ok(allColumns);
-  assert.equal(allColumns.apply, "id, name, email");
+  assert.equal(allColumns.apply, "id, name, email) VALUES (${1:value}, ${2:value}, ${3:value})");
 });
 
 test("keeps INSERT INTO all-column expansion available after a column prefix", () => {
@@ -2350,7 +2350,7 @@ test("keeps INSERT INTO all-column expansion available after a column prefix", (
 
   const allColumns = items.find((item) => item.type === "snippet" && item.label === "users.*");
   assert.ok(allColumns);
-  assert.equal(allColumns.apply, "id, name, email");
+  assert.equal(allColumns.apply, "id, name, email) VALUES (${1:value}, ${2:value}, ${3:value})");
 });
 
 test("quotes PostgreSQL identifiers in INSERT INTO all-column expansion", () => {
@@ -2364,7 +2364,7 @@ test("quotes PostgreSQL identifiers in INSERT INTO all-column expansion", () => 
 
   const allColumns = items.find((item) => item.type === "snippet" && item.label === "OrderLines.*");
   assert.ok(allColumns);
-  assert.equal(allColumns.apply, 'article, "OrderId", "User", "has""quote"');
+  assert.equal(allColumns.apply, 'article, "OrderId", "User", "has""quote") VALUES (${1:value}, ${2:value}, ${3:value}, ${4:value})');
 });
 
 test("suggests all target columns for schema-qualified INSERT INTO column lists", () => {
@@ -2386,7 +2386,7 @@ test("suggests all target columns for schema-qualified INSERT INTO column lists"
 
   const allColumns = items.find((item) => item.type === "snippet" && item.label === "Users.*");
   assert.ok(allColumns);
-  assert.equal(allColumns.apply, "Id, DisplayName");
+  assert.equal(allColumns.apply, "Id, DisplayName) VALUES (${1:value}, ${2:value})");
 });
 
 test("scopes INSERT INTO all-column expansion to the database-qualified MySQL target", () => {
@@ -2400,7 +2400,7 @@ test("scopes INSERT INTO all-column expansion to the database-qualified MySQL ta
 
   const allColumns = items.find((item) => item.type === "snippet" && item.label === "orders.*");
   assert.ok(allColumns);
-  assert.equal(allColumns.apply, "id, number, status");
+  assert.equal(allColumns.apply, "id, number, status) VALUES (${1:value}, ${2:value}, ${3:value})");
 });
 
 test("suggests all target columns for MySQL backtick-qualified INSERT INTO", () => {
@@ -2414,7 +2414,7 @@ test("suggests all target columns for MySQL backtick-qualified INSERT INTO", () 
 
   const allColumns = items.find((item) => item.type === "snippet" && item.label === "orders.*");
   assert.ok(allColumns);
-  assert.equal(allColumns.apply, "id, number, status");
+  assert.equal(allColumns.apply, "id, number, status) VALUES (${1:value}, ${2:value}, ${3:value})");
 });
 
 // --- Column data type in detail ---


### PR DESCRIPTION
## 修改内容

- 在 `INSERT INTO ... (` 上选择 `表名.*` 时，补全完整列清单、右括号和 `VALUES` 值列表
- 为每个值生成独立的可编辑占位符，保留继续编写 `RETURNING`、`ON CONFLICT` 等子句的空间
- `VALUES` 遵循编辑器 SQL 关键字大小写设置，列名继续使用现有方言引号规则
- 补全列表仅展示普通 `value` 预览，不暴露内部 snippet 占位符语法
- SELECT 的全字段展开行为保持不变

## 复现与验证

- PostgreSQL 16：最新主分支选择 `codex_issue_2595_0808.*` 后仅得到 `id, display_name, created_at`，缺少右括号和 `VALUES`
- PostgreSQL 14.23：修复后选择全字段补全，实际执行 INSERT 并通过 `RETURNING` 返回 1 行
- PostgreSQL 16：修复后选择全字段补全，实际执行 INSERT 并通过 `RETURNING` 返回 1 行
- 数据库备注输入项在当前主分支无法复现抖动：逐字符输入时弹窗尺寸和位置连续 13 次测量均未变化，测试未保存
- 实测产生的临时数据和测试表已清理
- `pnpm -s typecheck`
- `pnpm -s build`
- `pnpm -s test --run`（837 个测试文件，7,514 项通过）
- `oxfmt --check`、`oxlint --vue-plugin`

Fixes #2595
