### PR TITLE
Fix：修复批量设置空字符串后保存快捷键失效

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6464,7 +6464,10 @@ function applyGeneratedSelectionValue(kind: CellValueGenerationKind, startValue 
   } finally {
     commitBatch();
   }
-  if (applied) toast(t("grid.generatedValuesApplied", { count: cells.length }));
+  if (applied) {
+    toast(t("grid.generatedValuesApplied", { count: cells.length }));
+    void nextTick(() => window.requestAnimationFrame(() => gridRef.value?.focus({ preventScroll: true })));
+  }
   return applied;
 }
 

--- a/packages/app-tests/dataGridContextMenu.test.ts
+++ b/packages/app-tests/dataGridContextMenu.test.ts
@@ -23,6 +23,12 @@ test("set NULL applies a real null value only to editable selections", () => {
   assert.doesNotMatch(handler, /fillSelectionWithValue\(["'](?:NULL)?["']\)/);
 });
 
+test("generated selection values restore grid focus for keyboard shortcuts", () => {
+  const applyHandler = dataGridSource.match(/function applyGeneratedSelectionValue\([^]*?\n\}/)?.[0] ?? "";
+
+  assert.match(applyHandler, /if \(applied\)[^]*nextTick\(\(\) => window\.requestAnimationFrame\(\(\) => gridRef\.value\?\.focus\(\{ preventScroll: true \}\)\)\)/);
+});
+
 test("column-header context menus defer copy statement generation", () => {
   const handler = dataGridSource.match(/function onHeaderContext\([^]*?\n\}/)?.[0] ?? "";
 


### PR DESCRIPTION
## 问题

批量选择多行单元格并通过右键菜单生成空字符串后，右键菜单关闭时焦点没有回到数据表格，导致紧接着按保存快捷键时表格收不到按键事件。

## 修改

- 批量生成值成功后，在菜单完成卸载的下一帧恢复数据表格焦点
- 增加回归测试，确保生成值流程保留键盘快捷键焦点

## 验证

- 在 MySQL 测试表中选中同一列的 3 行，右键选择“生成值 -> 空字符串”
- 不再点击其他单元格，直接按 `Cmd+S`，3 条修改成功提交
- 测试后已恢复测试表原始数据
- `pnpm -s vitest run packages/app-tests/dataGridContextMenu.test.ts apps/desktop/src/components/ui/__tests__/CustomContextMenu.spec.ts`
- `pnpm -s typecheck`
- `pnpm -s exec oxfmt --check apps/desktop/src/components/grid/DataGrid.vue packages/app-tests/dataGridContextMenu.test.ts`
- `pnpm -s exec oxlint --vue-plugin apps/desktop/src/components/grid/DataGrid.vue packages/app-tests/dataGridContextMenu.test.ts`

Refs #5701
