### PR TITLE
Fix：优化 JSON 单元格详情双击交互

### DIFF
--- a/apps/desktop/src/components/grid/DataGridCellDetailPanel.vue
+++ b/apps/desktop/src/components/grid/DataGridCellDetailPanel.vue
@@ -55,6 +55,18 @@ void geometryCanvas;
 void detailsEditorContainer;
 void sideJsonPreviewContainer;
 
+function startJsonEditFromBlankArea(event: MouseEvent) {
+  const target = event.target as { closest?: (selector: string) => Element | null } | null;
+  const line = target?.closest?.(".cm-line");
+  if (line) {
+    const range = line.ownerDocument.createRange();
+    range.selectNodeContents(line);
+    const textHit = Array.from(range.getClientRects()).some((rect) => event.clientX >= rect.left && event.clientX <= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom);
+    if (textHit) return;
+  }
+  emit("startEdit");
+}
+
 defineExpose({ openSearch });
 </script>
 
@@ -159,9 +171,10 @@ defineExpose({ openSearch });
           v-else-if="detail.formattedJson"
           ref="sideJsonPreviewContainer"
           data-cell-detail-editor-root
+          data-cell-detail-json-preview
           class="overflow-hidden rounded border bg-muted/20 p-2"
           :class="[{ 'cursor-text': detail.isEditable }, valueFillsHeight ? 'min-h-0 flex-1' : 'h-72 max-h-[42vh]']"
-          @dblclick.capture="emit('startEdit')"
+          @dblclick.capture="startJsonEditFromBlankArea"
         />
         <pre
           v-else

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -916,7 +916,7 @@ describe("cell detail surfaces", () => {
     expect(updateOpen).toHaveBeenCalledWith(false);
   });
 
-  it("forwards panel edit/copy/cancel actions and exposes search", () => {
+  it("forwards panel actions and only starts JSON editing from preview whitespace", async () => {
     const startEdit = vi.fn();
     const copyValue = vi.fn();
     const cancel = vi.fn();
@@ -959,6 +959,26 @@ describe("cell detail surfaces", () => {
     expect(cancel).toHaveBeenCalledOnce();
     mounted.exposed.value.openSearch();
     expect(mocks.panelOpenSearch).toHaveBeenCalledOnce();
+
+    await mounted.setProps({ detail: detail() });
+    const jsonPreview = findOne(mounted.root, (node) => node.props["data-cell-detail-json-preview"] === "");
+    const doubleClickCapture = jsonPreview.props.onDblclickCapture;
+    const textLine = {
+      ownerDocument: {
+        createRange: () => ({
+          selectNodeContents: vi.fn(),
+          getClientRects: () => [{ left: 10, right: 110, top: 20, bottom: 40 }],
+        }),
+      },
+    };
+    const lineTarget = { closest: (selector: string) => (selector === ".cm-line" ? textLine : null) };
+
+    doubleClickCapture({ target: lineTarget, clientX: 60, clientY: 30 });
+    expect(startEdit).toHaveBeenCalledTimes(2);
+
+    doubleClickCapture({ target: lineTarget, clientX: 160, clientY: 30 });
+    doubleClickCapture({ target: { closest: () => null }, clientX: 60, clientY: 80 });
+    expect(startEdit).toHaveBeenCalledTimes(4);
   });
 });
 


### PR DESCRIPTION
## 问题

JSON 单元格详情的只读预览在捕获到任意双击时都会直接进入编辑，导致用户无法通过双击选中 JSON 文本。

## 修改

- 按 JSON 文本实际渲染范围判断双击位置
- 双击文本时保留只读预览和 CodeMirror 原生选词
- 双击同一行右侧或内容下方空白时进入编辑
- 普通非 JSON 单元格的双击编辑行为保持不变
- 增加组件回归测试，覆盖文本、行内空白和下方空白

## 验证

- PostgreSQL 17.4 可编辑 JSONB 表：双击文本可选中 `hello`，且保持查看态
- 双击同一文本行右侧空白可进入编辑态
- 测试后已删除临时表
- `pnpm exec vitest run apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts`（23 项通过）
- `pnpm -s typecheck`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/grid/DataGridCellDetailPanel.vue apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts`

Refs #5701