### PR TITLE
Fix: 移除查询结果表头 NULL 徽标

### DIFF
--- a/apps/desktop/src/components/grid/DataGridColumnHeader.vue
+++ b/apps/desktop/src/components/grid/DataGridColumnHeader.vue
@@ -75,10 +75,7 @@ const emit = defineEmits<{
         <KeyRound v-if="columnIndexKind === 'primary'" class="h-3 w-3 shrink-0" :class="columnIndexColorClass(columnIndexKind)" :title="columnIndexText(columnIndexKind)" />
         <Hash v-else-if="columnIndexKind && columnIndexKind !== 'none'" class="h-3 w-3 shrink-0" :class="columnIndexColorClass(columnIndexKind)" :title="columnIndexText(columnIndexKind)" />
         <span class="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <span class="flex min-w-0 items-center gap-1 leading-4">
-            <span class="min-w-0 truncate">{{ name }}</span>
-            <span v-if="columnNullability === 'nullable'" data-grid-header-nullable class="shrink-0 rounded-sm border border-muted-foreground/40 px-0.5 text-[8px] font-semibold leading-3 text-muted-foreground" :title="nullableLabel" :aria-label="nullableLabel"> NULL </span>
-          </span>
+          <span class="min-w-0 truncate leading-4">{{ name }}</span>
           <span v-if="showTypeLine" data-grid-header-type-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3" :class="[typeClass, { invisible: !columnType }]" :title="columnType || undefined" :aria-hidden="columnType ? undefined : true">{{ columnType }}</span>
           <span v-if="showCommentLine" data-grid-header-comment-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3 text-muted-foreground" :class="{ invisible: !columnComment }" :title="columnComment || undefined" :aria-hidden="columnComment ? undefined : true">{{
             columnComment

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -387,7 +387,7 @@ describe("DataGridColumnHeader", () => {
     expect(findAll(mounted.root, (node) => node.props["data-grid-header-comment-line"] === "")).toHaveLength(0);
   });
 
-  it("marks nullable columns without marking required columns", () => {
+  it("shows column nullability in the header tooltip without an inline badge", () => {
     const baseProps = {
       name: "nickname",
       actualColumnIndex: 1,
@@ -406,12 +406,10 @@ describe("DataGridColumnHeader", () => {
     };
     const nullable = mountComponent(DataGridColumnHeader, { ...baseProps, columnNullability: "nullable" });
     const required = mountComponent(DataGridColumnHeader, { ...baseProps, columnNullability: "required" });
-    const badge = findOne(nullable.root, (node) => node.props["data-grid-header-nullable"] === "");
 
-    expect(hostText(badge).trim()).toBe("NULL");
-    expect(badge.props.title).toBe("nullable");
-    expect(hostText(nullable.root)).toContain("nullableyes");
+    expect(findAll(nullable.root, (node) => node.props["data-grid-header-nullable"] === "")).toHaveLength(0);
     expect(findAll(required.root, (node) => node.props["data-grid-header-nullable"] === "")).toHaveLength(0);
+    expect(hostText(nullable.root)).toContain("nullableyes");
     expect(hostText(required.root)).toContain("nullableno");
   });
 });


### PR DESCRIPTION
## 背景

PR #5667 在查询结果表头增加了 `NULL` 徽标，但徽标会固定占用列名区域，窄列下会导致字段名更早被截断。

## 修改内容

- 移除查询结果表头列名旁常驻的 `NULL` 徽标
- 保留表头悬浮详情中的“可为空：是/否”，字段元数据信息仍可查看
- 更新表头组件测试，覆盖无内联徽标且悬浮信息保留的行为

## 验证

- `pnpm -s test apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts`（23 项通过）
- `pnpm -s typecheck`
- `oxfmt --check`
- `oxlint --vue-plugin`

Follow-up to #5667
