### PR TITLE
upgrade jackson-databind from 2.17.2 to 2.22.1

### DIFF
--- a/plugins/jdbc/build.gradle
+++ b/plugins/jdbc/build.gradle
@@ -20,7 +20,7 @@ def mavenResolverVersion = '2.0.18'
 def mavenCoreVersion = '4.0.0-rc-5'
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
     implementation('org.slf4j:slf4j-api') {
         version {
             strictly '1.7.36'


### PR DESCRIPTION
## 变更说明
因当前版本fastxml存在较多安全漏洞，升级版本值2.22.1版本