### PR TITLE
feat(grid): preserve column type, comment and index indicator in tran…

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -30,6 +30,7 @@ import {
   SquareDashed,
   Check,
   CopyPlus,
+  Hash,
   KeyRound,
   Link2,
   ListTree,
@@ -245,7 +246,7 @@ import { getTableStructureCapabilities } from "@/lib/table/tableStructureCapabil
 import { filterObjectBrowserTableColumns } from "@/lib/table/objectBrowserTableInfo";
 import { gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
 import { reserveDataGridHeaderLine } from "@/lib/dataGrid/dataGridHeaderLayout";
-import { buildColumnIndexMap, columnIndexMetadataRequestCurrent, columnIndexNameKey, columnIndexTableIdentity } from "@/lib/dataGrid/dataGridColumnIndexIcon";
+import { buildColumnIndexMap, columnIndexColorClass, columnIndexMetadataRequestCurrent, columnIndexNameKey, columnIndexTableIdentity, type ColumnIndexKind } from "@/lib/dataGrid/dataGridColumnIndexIcon";
 import { supportsTableStructureEditing } from "@/lib/database/databaseCapabilities";
 import { rememberDataGridConditionHistory } from "@/lib/dataGrid/dataGridConditionHistory";
 import { restoreDataGridLocalColumnFilters, serializeDataGridLocalColumnFilters } from "@/lib/dataGrid/dataGridLocalColumnFilterState";
@@ -7911,6 +7912,9 @@ const transposeRows = computed(() => {
     displayValue: (value, _column, index) => formatCellCached(value, visibleColumnIndexes.value[index]),
   });
 });
+const transposeReserveTypeLine = computed(() => showColumnTypesInHeader.value && transposeRows.value.some((row) => row.type));
+const transposeReserveCommentLine = computed(() => showColumnCommentsInHeader.value && transposeRows.value.some((row) => row.comment));
+const transposeRowHeight = computed(() => 30 + (transposeReserveTypeLine.value ? 14 : 0) + (transposeReserveCommentLine.value ? 14 : 0));
 const isTransposeMode = computed(() => showTranspose.value && transposeRows.value.length > 0);
 const transposeTotalWidth = computed(() => {
   const recordIndexes = multiRowTranspose.value ? Array.from({ length: displayRowCount.value }, (_, i) => i) : activeTransposeRecordIndexes.value;
@@ -7928,6 +7932,19 @@ function transposeFieldTitle(item: { column: string; type: string; comment?: str
   if (showColumnTypesInHeader.value && item.type) details.push(`${t("grid.columnType")}: ${item.type}`);
   if (showColumnCommentsInHeader.value && item.comment) details.push(`${t("grid.columnComment")}: ${item.comment}`);
   return details.join("\n");
+}
+
+function transposeColumnIndexKind(column: string): ColumnIndexKind | undefined {
+  if (!showIndexIndicatorsInHeader.value) return undefined;
+  const kind = columnIndexMap.value.get(columnIndexNameKey(column));
+  return kind && kind !== "none" ? kind : undefined;
+}
+
+function transposeColumnIndexText(kind: ColumnIndexKind): string {
+  if (kind === "primary") return t("grid.columnPrimaryIndex");
+  if (kind === "unique") return t("grid.columnUniqueIndex");
+  if (kind === "index") return t("grid.columnRegularIndex");
+  return "";
 }
 
 function updateTransposeViewport() {
@@ -10055,7 +10072,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   '--transpose-field-w': `${transposePinnedWidth}px`,
                 }"
                 :items="transposeRows"
-                :item-size="30"
+                :item-size="transposeRowHeight"
                 :buffer="400"
                 key-field="id"
                 @scroll="onTransposeScroll"
@@ -10093,21 +10110,35 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   <div
                     class="data-grid-transpose-row flex border-b border-border/60"
                     :style="{
-                      height: '30px',
+                      height: `${transposeRowHeight}px`,
                       width: `${transposeTotalWidth}px`,
                     }"
                   >
                     <LightTooltip :text="transposeFieldTitle(item)" side="right" :side-offset="6" :delay="250" :open-on-focus="false" surface="popover">
                       <div
                         data-native-clipboard
-                        class="sticky left-0 z-10 flex shrink-0 items-center gap-1.5 overflow-hidden border-r border-border bg-background px-3 py-0"
+                        class="sticky left-0 z-10 flex shrink-0 flex-col items-start justify-center overflow-hidden border-r border-border bg-background px-3 py-0"
                         :class="{
                           'bg-yellow-200/60 dark:bg-yellow-500/20': transposeHeaderIsSearchMatch(visibleColumnIndexes[index]),
                           'ring-2 ring-inset ring-yellow-500 bg-yellow-300/60 dark:bg-yellow-500/40': transposeHeaderIsCurrentMatch(visibleColumnIndexes[index]),
                         }"
                         :style="{ width: `${transposePinnedWidth}px` }"
                       >
-                        <span class="min-w-0 flex-1 truncate font-medium">{{ item.column }}</span>
+                        <span class="flex min-w-0 items-center gap-1 overflow-hidden">
+                          <KeyRound v-if="transposeColumnIndexKind(item.column) === 'primary'" data-grid-transpose-index-indicator class="h-3 w-3 shrink-0" :class="columnIndexColorClass('primary')" :title="transposeColumnIndexText('primary')" />
+                          <Hash v-else-if="transposeColumnIndexKind(item.column)" data-grid-transpose-index-indicator class="h-3 w-3 shrink-0" :class="columnIndexColorClass(transposeColumnIndexKind(item.column)!)" :title="transposeColumnIndexText(transposeColumnIndexKind(item.column)!)" />
+                          <span class="min-w-0 flex-1 truncate font-medium leading-4">{{ item.column }}</span>
+                        </span>
+                        <template v-if="showColumnTypesInHeader && item.type">
+                          <span data-grid-transpose-type-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3 select-none" :class="typeColorClass(item.type)" :title="item.type">
+                            {{ item.type }}
+                          </span>
+                        </template>
+                        <template v-if="showColumnCommentsInHeader && item.comment">
+                          <span data-grid-transpose-comment-line class="h-3 min-w-0 truncate text-[10px] font-normal leading-3 text-muted-foreground select-none" :title="item.comment">
+                            {{ item.comment }}
+                          </span>
+                        </template>
                       </div>
                       <template #content>
                         <div

--- a/apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts
@@ -4,12 +4,14 @@ import { describe, expect, it } from "vitest";
 const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
 
 describe("DataGrid transpose presentation", () => {
-  it("keeps field metadata in one compact row", () => {
-    expect(dataGridSource).toContain(':item-size="30"');
-    expect(dataGridSource).not.toContain("data-grid-transpose-field-info");
-    expect(dataGridSource).not.toContain("data-grid-transpose-comment-inline");
-    expect(dataGridSource).not.toContain("data-grid-transpose-comment-line");
-    expect(dataGridSource).not.toContain("data-grid-transpose-type-line");
+  it("renders field metadata and index indicator on separate lines in the pinned transpose column", () => {
+    expect(dataGridSource).toContain(':item-size="transposeRowHeight"');
+    expect(dataGridSource).toContain("data-grid-transpose-type-line");
+    expect(dataGridSource).toContain("data-grid-transpose-comment-line");
+    expect(dataGridSource).toContain("data-grid-transpose-index-indicator");
+    expect(dataGridSource).toContain("showColumnTypesInHeader && item.type");
+    expect(dataGridSource).toContain("showColumnCommentsInHeader && item.comment");
+    expect(dataGridSource).toContain("transposeColumnIndexKind(item.column)");
   });
 
   it("shows complete long metadata in a hoverable, bounded tooltip", () => {


### PR DESCRIPTION
…spose view

- Show column type and comment on separate lines in the transpose pinned field column.

- Respect showColumnTypesInHeader / showColumnCommentsInHeader settings.

- Show primary/unique/regular index indicator when showIndexIndicatorsInHeader is enabled.

- Dynamic transpose row height (30/44/58px) based on visible metadata.

- Update DataGridTransposePresentation spec.

## 变更说明

转置后可以根据配置显示列类型/注释/索引等信息

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="400" height="188" alt="图片" src="https://github.com/user-attachments/assets/093e9072-9d1c-44c8-93c2-b428e5f4786a" />

<img width="362" height="322" alt="图片" src="https://github.com/user-attachments/assets/61a996ed-c0db-49f8-9dbf-1b702c37e054" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过
* pnpm vitest run apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts apps/desktop/src/lib/__tests__/dataGrid/dataGridTranspose.spec.ts`：**13 个测试全部通过**
* `pnpm oxlint --vue-plugin apps/desktop/src/components/grid/DataGrid.vue`：**无报错**
* `pnpm typecheck`：**通过

## 关联 Issue

Related #5481 
