### PR TITLE
docs: fix Homebrew tap name for dbx-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ DBX also provides a dedicated CLI package for terminal, script, and Codex workfl
 ```bash
 npm install -g @dbx-app/cli
 # or via Homebrew
-brew tap t8y2/dbx && brew install dbx-cli
+brew tap t8y2/tap && brew install dbx-cli
 dbx connections list --json
 dbx query local "select 1" --json
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -186,7 +186,7 @@ DBX 也提供独立 CLI 包，适合终端、脚本和 Codex 工作流：
 ```bash
 npm install -g @dbx-app/cli
 # 或通过 Homebrew
-brew tap t8y2/dbx && brew install dbx-cli
+brew tap t8y2/tap && brew install dbx-cli
 dbx connections list --json
 dbx query local "select 1" --json
 ```

--- a/docs/content/docs/cli.cn.mdx
+++ b/docs/content/docs/cli.cn.mdx
@@ -14,7 +14,7 @@ npm install -g @dbx-app/cli
 ### Homebrew
 
 ```bash
-brew tap t8y2/dbx
+brew tap t8y2/tap
 brew install dbx-cli
 ```
 

--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -16,7 +16,7 @@ npm install -g @dbx-app/cli
 ### Homebrew
 
 ```bash
-brew tap t8y2/dbx
+brew tap t8y2/tap
 brew install dbx-cli
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,7 +13,7 @@ npm install -g @dbx-app/cli
 ### Homebrew
 
 ```bash
-brew tap t8y2/dbx
+brew tap t8y2/tap
 brew install dbx-cli
 ```
 


### PR DESCRIPTION
The docs tell users to run `brew tap t8y2/dbx`, but that tap repository (`t8y2/homebrew-dbx`) does not exist, so the command fails with:

```
fatal: repository 'https://github.com/t8y2/homebrew-dbx/' not found
```

The actual tap lives at [t8y2/homebrew-tap](https://github.com/t8y2/homebrew-tap), so the correct command is `brew tap t8y2/tap`. Verified locally on macOS that `brew tap t8y2/tap && brew install dbx-cli` resolves and installs the formula.

Updated all five occurrences: README.md, README.zh-CN.md, packages/cli/README.md, and both CLI docs pages (en/cn).