### PR TITLE
fix(desktop): respect table tab reuse policy on editor table click

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1646,7 +1646,7 @@ async function onClickTable(table: SqlObjectNavigationTarget) {
     return;
   }
   try {
-    await openTableTarget(target, { tableInfoTab: "ddl" });
+    await openObjectBrowserTableTarget(target);
   } catch (e: any) {
     toast(t("connection.connectFailed", { message: translateBackendError(t, e) }), 5000);
   }
@@ -1656,7 +1656,7 @@ async function onViewTableData(table: SqlObjectNavigationTarget) {
   const target = tableTargetFromActiveTab(table);
   if (!target) return;
   try {
-    await openTableTarget(target);
+    await openObjectBrowserTableTarget(target);
   } catch (e: any) {
     toast(t("connection.connectFailed", { message: translateBackendError(t, e) }), 5000);
   }

--- a/apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts
@@ -217,6 +217,20 @@ describe("useNavigationTargets with the real query store", () => {
     expect(queryStore.activeTabId).toBe(sidebarTabId);
   });
 
+  it("reuses existing table tab when navigating via object browser target in same-table mode", async () => {
+    mocks.settingsStore.editorSettings.dataTabReuseMode = "same-table";
+    const { navigation, queryStore } = await setupNavigation();
+    const target = { connectionId: "connection-1", database: "app", schema: "public", tableName: "users", tableType: "TABLE" };
+
+    await navigation.openObjectBrowserTableTarget(target);
+    const firstTabId = queryStore.activeTabId;
+
+    await navigation.openObjectBrowserTableTarget(target);
+
+    expect(queryStore.tabs).toHaveLength(1);
+    expect(queryStore.activeTabId).toBe(firstTabId);
+  });
+
   it("reuses a restored legacy MySQL tab when the same table is opened from the sidebar", async () => {
     mocks.connectionStore.getConfig.mockImplementation((connectionId: string) => ({ id: connectionId, db_type: "mysql" }));
     mocks.loadOpenTabsState.mockResolvedValue({


### PR DESCRIPTION
## 变更说明

修复在 SQL 编辑器中点击表名跳转时误调用 `openTableTarget`（强制开新标签页）的问题，改为调用 `openObjectBrowserTableTarget`，使其正确遵循用户在设置中配置的 `dataTabReuseMode`（如仅复用同一张表）标签页复用策略，并补充了单元测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] 单元测试 `pnpm test apps/desktop/src/composables/__tests__/useNavigationTargets.store.spec.ts` 通过
- [x] TypeScript 类型检查 `pnpm typecheck` 通过
- [x] 手动验证：设置中开启“仅复用同一张表”后，在编辑器内多次点击同一表名正确跳转并复用已打开的 Tab

## 关联 Issue
https://github.com/t8y2/dbx/issues/5777
