### PR TITLE
✨ feat(query): 支持单独关闭查询结果并释放结果会话

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -2119,7 +2119,7 @@ function handleNativeSelectAll(e: KeyboardEvent) {
   if (shouldBlockAppNativeSelectAll(e)) e.preventDefault();
 }
 
-function handleKeydown(e: KeyboardEvent) {
+async function handleKeydown(e: KeyboardEvent) {
   if (e.defaultPrevented) return;
 
   const shortcuts = settingsStore.editorSettings.shortcuts;
@@ -2197,6 +2197,7 @@ function handleKeydown(e: KeyboardEvent) {
     } else if (showDriverStore.value) {
       closeDriverStorePage();
     } else if (queryStore.activeTabId) {
+      if (await queryStore.clearQueryResults(queryStore.activeTabId)) return;
       queryStore.closeTab(queryStore.activeTabId);
     }
     return;

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -419,6 +419,7 @@ const resultAutoSave = computed(() => props.activeTab.resultAutoSave === true);
 const activeResultRunItem = computed(() => resultRuns.value.find((run) => run.active));
 const showResultRunTabs = computed(() => resultRuns.value.length > 0 && resultRunDisplayMode.value === "tabs");
 const showResultRunSelector = computed(() => resultRuns.value.length > 0 && resultRunDisplayMode.value === "list");
+const canCloseQueryResult = computed(() => props.activeTab.mode === "query" && !props.activeTab.isExecuting && !props.activeTab.activeResultRunId && (!!props.activeTab.result || !!props.activeTab.results?.length || props.activeTab.resultEvicted === true));
 watch(
   () => `${resultRunDisplayMode.value}:${resultRuns.value.map((run) => run.id).join(",")}:${props.activeTab.activeResultRunId ?? ""}`,
   () => {
@@ -853,6 +854,11 @@ async function removeResultRun(runId: string) {
   activeRunTab?.scrollIntoView({ block: "nearest", inline: "nearest" });
 }
 
+async function closeCurrentQueryResult() {
+  if (!(await queryStore.closeQueryResult(props.activeTab.id))) return;
+  emit("update:activeOutputView", "result");
+}
+
 async function selectResultRun(runId: string) {
   if (!(await queryStore.setActiveResultRun(props.activeTab.id, runId))) {
     toast(t("tabs.missingResultRun"), 4000);
@@ -1055,6 +1061,9 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
                 @click="toggleResultAutoSave"
               >
                 <Pin class="h-3.5 w-3.5" :class="{ 'fill-current': resultAutoSave }" />
+              </Button>
+              <Button v-if="canCloseQueryResult" variant="ghost" size="icon" class="h-6 w-7 shrink-0 text-muted-foreground hover:bg-accent hover:text-foreground" :title="t('tabs.closeResult')" :aria-label="t('tabs.closeResult')" @click="closeCurrentQueryResult">
+                <X class="h-3.5 w-3.5" />
               </Button>
               <template v-if="resultRuns.length > 0 || visibleResultItems.length > 0">
                 <span class="mx-1 h-4 w-px shrink-0 bg-border" />

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1271,6 +1271,7 @@ export default {
     resultRuns: "Result runs",
     resultSets: "Result sets",
     removeRun: "Remove run {n}",
+    closeResult: "Close result",
     autoKeepResults: "Auto-keep query results",
     autoKeepResultsEnabled: "Auto-keep results enabled",
     autoKeepResultsDisabled: "Auto-keep results disabled",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1248,6 +1248,7 @@ export default withEnglishFallback({
     resultRuns: "Ejecuciones de resultado",
     resultSets: "Conjuntos de resultados",
     removeRun: "Eliminar ejecución {n}",
+    closeResult: "Cerrar resultado",
     autoKeepResults: "Conservar resultados automáticamente",
     autoKeepResultsEnabled: "Conservación automática activada",
     autoKeepResultsDisabled: "Conservación automática desactivada",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1246,6 +1246,7 @@ export default withEnglishFallback({
     resultRuns: "Esecuzioni risultati",
     resultSets: "Set di risultati",
     removeRun: "Rimuovi esecuzione {n}",
+    closeResult: "Chiudi risultato",
     autoKeepResults: "Mantieni automaticamente i risultati",
     autoKeepResultsEnabled: "Mantieni risultati abilitato",
     autoKeepResultsDisabled: "Mantieni risultati disabilitato",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1265,6 +1265,7 @@ export default withEnglishFallback({
     resultRuns: "実行履歴",
     resultSets: "結果セット",
     removeRun: "実行 {n} を削除",
+    closeResult: "結果を閉じる",
     autoKeepResults: "クエリ結果を自動保持",
     autoKeepResultsEnabled: "結果の自動保持をオンにしました",
     autoKeepResultsDisabled: "結果の自動保持をオフにしました",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -1160,6 +1160,7 @@ export default withEnglishFallback({
     resultRuns: "결과 실행",
     resultSets: "결과 집합",
     removeRun: "실행 {n} 제거",
+    closeResult: "결과 닫기",
     autoKeepResults: "쿼리 결과 자동 보관",
     autoKeepResultsEnabled: "결과 자동 보관 활성화됨",
     autoKeepResultsDisabled: "결과 자동 보관 비활성화됨",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1248,6 +1248,7 @@ export default withEnglishFallback({
     resultRuns: "Execuções de resultado",
     resultSets: "Conjuntos de resultados",
     removeRun: "Remover execução {n}",
+    closeResult: "Fechar resultado",
     autoKeepResults: "Manter resultados automaticamente",
     autoKeepResultsEnabled: "Manutenção automática de resultados ativada",
     autoKeepResultsDisabled: "Manutenção automática de resultados desativada",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1196,6 +1196,7 @@ export default withEnglishFallback({
     resultRuns: "执行结果",
     resultSets: "语句结果",
     removeRun: "删除执行 {n}",
+    closeResult: "关闭结果",
     autoKeepResults: "自动保留查询结果",
     autoKeepResultsEnabled: "已开启自动保留结果",
     autoKeepResultsDisabled: "已关闭自动保留结果",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1247,6 +1247,7 @@ export default withEnglishFallback({
     resultRuns: "執行結果",
     resultSets: "語句結果",
     removeRun: "移除執行 {n}",
+    closeResult: "關閉結果",
     autoKeepResults: "自動保留查詢結果",
     autoKeepResultsEnabled: "自動保留結果已啟用",
     autoKeepResultsDisabled: "自動保留結果已停用",

--- a/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts
@@ -810,4 +810,74 @@ describe("queryStore multi-statement errors", () => {
     expect(tab.activeResultRunId).toBe(tab.resultRuns?.[0]?.id);
     expect(tab.result?.rows).toEqual([[1]]);
   });
+
+  it("does not clear a newer result while closing the previous result session", async () => {
+    const pendingClose = deferred<void>();
+    mocks.closeQuerySession.mockReturnValue(pendingClose.promise);
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    tab.result = { columns: ["value"], rows: [[1]], affected_rows: 0, execution_time_ms: 1, session_id: "result-session-1" };
+    tab.resultSessionId = "result-session-1";
+    tab.resultClientSessionId = "result-client-1";
+
+    const closing = store.closeQueryResult(tabId);
+    expect(tab.result).toBeUndefined();
+
+    tab.result = { columns: ["value"], rows: [[2]], affected_rows: 0, execution_time_ms: 1, session_id: "result-session-2" };
+    tab.resultSessionId = "result-session-2";
+    tab.resultClientSessionId = "result-client-2";
+    pendingClose.resolve();
+
+    await expect(closing).resolves.toBe(true);
+    expect(tab.result?.rows).toEqual([[2]]);
+    expect(tab.resultSessionId).toBe("result-session-2");
+    expect(tab.resultClientSessionId).toBe("result-client-2");
+  });
+
+  it("clears every retained result run while preserving the query tab", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    tab.sql = "select draft";
+    tab.result = { columns: ["value"], rows: [[1]], affected_rows: 0, execution_time_ms: 1, session_id: "result-session-1" };
+    tab.resultSessionId = "result-session-1";
+    tab.resultClientSessionId = "result-client-1";
+    tab.resultAutoSave = true;
+    tab.resultRuns = [
+      {
+        id: "run-1",
+        title: "Run 1",
+        sequence: 1,
+        sql: "select 1",
+        createdAt: 1,
+        result: tab.result,
+        resultSessionId: "result-session-1",
+        resultClientSessionId: "result-client-1",
+      },
+      {
+        id: "run-2",
+        title: "Run 2",
+        sequence: 2,
+        sql: "select 2",
+        createdAt: 2,
+        result: { columns: ["value"], rows: [[2]], affected_rows: 0, execution_time_ms: 1, session_id: "result-session-2" },
+        resultSessionId: "result-session-2",
+        resultClientSessionId: "result-client-2",
+      },
+    ];
+    tab.activeResultRunId = "run-1";
+
+    await expect(store.clearQueryResults(tabId)).resolves.toBe(true);
+
+    expect(mocks.closeQuerySession).toHaveBeenCalledTimes(2);
+    expect(tab.sql).toBe("select draft");
+    expect(tab.resultAutoSave).toBe(true);
+    expect(tab.result).toBeUndefined();
+    expect(tab.results).toBeUndefined();
+    expect(tab.resultRuns).toBeUndefined();
+    expect(tab.activeResultRunId).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -1095,6 +1095,45 @@ export const useQueryStore = defineStore("query", () => {
     return true;
   }
 
+  async function closeQueryResult(id: string) {
+    const tab = tabs.value.find((item) => item.id === id);
+    if (!tab || tab.mode !== "query" || tab.isExecuting) return false;
+
+    if (tab.activeResultRunId) return removeResultRun(id, tab.activeResultRunId);
+    if (!tab.result && !tab.results?.length && !tab.resultEvicted) return false;
+
+    const closeSession = closeResultSession(tab);
+    clearResultPayload(tab);
+    await closeSession;
+    return true;
+  }
+
+  async function clearQueryResults(id: string) {
+    const tab = tabs.value.find((item) => item.id === id);
+    if (!tab || tab.mode !== "query" || tab.isExecuting) return false;
+
+    const resultRuns = tab.resultRuns ?? [];
+    if (!tab.result && !tab.results?.length && !tab.resultEvicted && resultRuns.length === 0) return false;
+
+    const closedSessionIds = new Set<string>();
+    const currentSessionId = tab.resultSessionId ?? tab.result?.session_id;
+    if (currentSessionId) closedSessionIds.add(currentSessionId);
+    const closeOperations = [closeResultSession(tab)];
+
+    for (const run of resultRuns) {
+      if (run.resultCacheKey) void deleteTabResultSnapshot(run.resultCacheKey);
+      if (!run.resultSessionId || closedSessionIds.has(run.resultSessionId)) continue;
+      closedSessionIds.add(run.resultSessionId);
+      closeOperations.push(closeResultRunSession(tab, run));
+    }
+
+    tab.resultRuns = undefined;
+    tab.activeResultRunId = undefined;
+    clearResultPayload(tab);
+    await Promise.all(closeOperations);
+    return true;
+  }
+
   function nextResultRunSequence(tab: QueryTab): number {
     return (tab.resultRuns?.reduce((max, run) => Math.max(max, run.sequence), 0) ?? 0) + 1;
   }
@@ -5697,6 +5736,8 @@ export const useQueryStore = defineStore("query", () => {
     toggleResultAutoSave,
     setActiveResultRun,
     removeResultRun,
+    closeQueryResult,
+    clearQueryResults,
     setActiveResultIndex,
     executeCurrentTab,
     executeCurrentSql,

--- a/packages/app-tests/queryResultToolbar.test.ts
+++ b/packages/app-tests/queryResultToolbar.test.ts
@@ -4,6 +4,7 @@ import { test } from "vitest";
 import { compileScript, compileTemplate, parse } from "vue/compiler-sfc";
 
 const contentAreaPath = "apps/desktop/src/components/layout/ContentArea.vue";
+const appPath = "apps/desktop/src/App.vue";
 const dataGridPath = "apps/desktop/src/components/grid/DataGrid.vue";
 const viewSwitcherPath = "apps/desktop/src/components/layout/QueryResultViewSwitcher.vue";
 const toolbarActionsPath = "apps/desktop/src/components/layout/QueryResultToolbarActions.vue";
@@ -55,6 +56,10 @@ test("ContentArea exposes retained result runs as switchable tabs or a compact l
   assert.match(contentArea, /data-result-run-tab/);
   assert.match(contentArea, /@keydown="onResultRunTabKeydown\(\$event, runIndex\)"/);
   assert.match(contentArea, /@click\.stop\.prevent="removeResultRun\(run\.id\)"/);
+  assert.match(contentArea, /const canCloseQueryResult = computed\([\s\S]*!props\.activeTab\.activeResultRunId/);
+  assert.match(contentArea, /v-if="canCloseQueryResult"[\s\S]*@click="closeCurrentQueryResult"/);
+  assert.match(contentArea, /queryStore\.closeQueryResult\(props\.activeTab\.id\)/);
+  assert.match(contentArea, /t\('tabs\.closeResult'\)/);
   assert.match(contentArea, /<DropdownMenuContent align="start" class="w-48">[\s\S]*v-for="run in resultRuns"/);
   assert.match(contentArea, /setResultRunDisplayMode\('list'\)/);
   assert.match(contentArea, /setResultRunDisplayMode\('tabs'\)/);
@@ -66,6 +71,16 @@ test("ContentArea exposes retained result runs as switchable tabs or a compact l
   assert.doesNotMatch(contentArea, /queryResultAutoRefresh|QUERY_RESULT_AUTO_REFRESH|nextResultToolbarLayout/);
   assert.equal((contentArea.match(/<QueryResultViewSwitcher\b/g) ?? []).length, 2);
   assert.equal((contentArea.match(/<QueryResultToolbarActions\b/g) ?? []).length, 2);
+});
+
+test("the close-tab shortcut clears query results before closing the tab", () => {
+  const app = source(appPath);
+  const closeShortcutStart = app.indexOf("if (isCloseTabShortcut(e, shortcuts))");
+  const closeShortcutEnd = app.indexOf("if (isSaveShortcut", closeShortcutStart);
+  const closeShortcut = app.slice(closeShortcutStart, closeShortcutEnd);
+
+  assert.ok(closeShortcutStart >= 0);
+  assert.ok(closeShortcut.indexOf("await queryStore.clearQueryResults(queryStore.activeTabId)") < closeShortcut.indexOf("queryStore.closeTab(queryStore.activeTabId)"));
 });
 
 test("ContentArea keeps MySQL standard explain results available in the shared toolbar", () => {

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -1304,6 +1304,27 @@ test("removing the active result run selects an adjacent run", async () => {
   assert.deepEqual(tab.result?.columns, ["one"]);
 });
 
+test("closing an ordinary query result preserves the query tab", async () => {
+  setActivePinia(createPinia());
+  const store = useQueryStore();
+  const tabId = store.createTab("conn-1", "db");
+  const tab = store.tabs.find((item) => item.id === tabId);
+  assert.ok(tab);
+
+  tab.sql = "select draft";
+  tab.result = { columns: ["one"], rows: [[1]], affected_rows: 0, execution_time_ms: 1 };
+  tab.lastExecutedSql = "select 1";
+
+  assert.equal(await store.closeQueryResult(tabId), true);
+
+  assert.equal(tab.sql, "select draft");
+  assert.equal(tab.connectionId, "conn-1");
+  assert.equal(tab.database, "db");
+  assert.equal(tab.result, undefined);
+  assert.equal(tab.results, undefined);
+  assert.equal(tab.activeResultRunId, undefined);
+});
+
 test("removing the active result run clears output when remaining caches are unavailable", async () => {
   setActivePinia(createPinia());
   const store = useQueryStore();


### PR DESCRIPTION
## 变更说明

- 在查询结果工具栏增加“关闭结果”操作，关闭结果后保留查询标签、SQL 编辑内容和连接上下文。
- `Cmd/Ctrl+W` 在查询标签存在结果时先清空该标签的全部结果及保留执行记录；结果已清空后，继续使用原有的标签关闭和未保存 SQL 确认流程。
- 清理关联结果会话和缓存快照，并覆盖异步会话关闭期间新结果不被误清的场景。
- 补充多语言文案及相关回归测试。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="2220" height="1736" alt="49C004A1-6720-4805-A6F5-211F5ACF0EB4" src="https://github.com/user-attachments/assets/cf6a0d10-c6f4-453e-a867-fa7a95bc59fa" />


TODO: 补充修复后的桌面端截图或录屏。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已通过：

- `env CI=true pnpm test -- apps/desktop/src/stores/__tests__/queryStore.multiStatementError.spec.ts packages/app-tests/queryStore.test.ts packages/app-tests/queryResultToolbar.test.ts`
- `pnpm typecheck`
- `git diff --check`

## 关联 Issue

Close #5799