### PR TITLE
fix(codex): relax model discovery timeouts for Windows

### DIFF
--- a/crates/dbx-core/src/ai_codex_cli.rs
+++ b/crates/dbx-core/src/ai_codex_cli.rs
@@ -25,8 +25,11 @@ const DEFAULT_CODEX_MODELS: &[&str] = &["default", "gpt-5.5", "gpt-5.4-mini"];
 const CODEX_MODEL_SUCCESS_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 const CODEX_MODEL_COMPATIBILITY_CACHE_TTL: Duration = Duration::from_secs(30);
 const CODEX_MODEL_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(10);
-const CODEX_MODEL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(3);
-const CODEX_MODEL_COMPATIBILITY_TIMEOUT: Duration = Duration::from_secs(2);
+// Codex app-server and npm-installed CLI can take several seconds to cold-start,
+// especially on Windows. Keep discovery bounded while allowing capability metadata
+// to be returned before falling back to the static catalog.
+const CODEX_MODEL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(15);
+const CODEX_MODEL_COMPATIBILITY_TIMEOUT: Duration = Duration::from_secs(10);
 #[cfg(not(windows))]
 const CODEX_PATH_MARKER: &str = "__DBX_CODEX_PATH__";
 
@@ -1514,8 +1517,8 @@ mod tests {
 
     #[test]
     fn model_cache_uses_bounded_success_fallback_and_negative_ttls() {
-        assert_eq!(CODEX_MODEL_DISCOVERY_TIMEOUT, Duration::from_secs(3));
-        assert_eq!(CODEX_MODEL_COMPATIBILITY_TIMEOUT, Duration::from_secs(2));
+        assert_eq!(CODEX_MODEL_DISCOVERY_TIMEOUT, Duration::from_secs(15));
+        assert_eq!(CODEX_MODEL_COMPATIBILITY_TIMEOUT, Duration::from_secs(10));
         assert_eq!(CODEX_MODEL_SUCCESS_CACHE_TTL, Duration::from_secs(5 * 60));
         assert_eq!(CODEX_MODEL_COMPATIBILITY_CACHE_TTL, Duration::from_secs(30));
         assert_eq!(CODEX_MODEL_NEGATIVE_CACHE_TTL, Duration::from_secs(10));


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
Fixes #5597

  ## Problem

  On Windows with an npm-installed Codex CLI, model discovery can exceed DBX's previous 3-second app-server timeout and 2-second compatibility timeout.

  When both discovery paths time out, DBX falls back to the static legacy model list and cannot obtain reasoning-effort capabilities for newer models.

  ## Root cause

  Codex model discovery first queries `app-server model/list`, then falls back to `codex debug models`.

  Cold startup can take several seconds on Windows, causing both discovery paths to time out before model and capability metadata is returned.

  ## Fix

  - Increase the app-server discovery timeout from 3 seconds to 15 seconds.
  - Increase the compatibility discovery timeout from 2 seconds to 10 seconds.
  - Update the timeout assertions in the model-cache test.

  The existing success, compatibility-fallback, and negative-fallback cache TTLs remain unchanged.

  ## Compatibility

  No configuration or API changes.

  The static fallback model list is preserved when both Codex discovery paths fail.

  ## Validation

  - `git diff --check` — passed
  - `cargo fmt --all -- --check` — passed

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #5597