### PR TITLE
fix(docs): 修复 changelog 桌面端"加载更多版本"失效问题

### DIFF
--- a/docs/components/landing/ChangelogList.tsx
+++ b/docs/components/landing/ChangelogList.tsx
@@ -1,10 +1,26 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useSyncExternalStore } from "react";
 import type { ChangelogRelease } from "@/lib/changelog";
 import { ChevronDown, Tag } from "lucide-react";
 
 const PAGE_SIZE = 5;
+
+const DESKTOP_MEDIA = "(min-width: 761px)";
+
+function subscribeToDesktop(onChange: () => void) {
+  const mql = window.matchMedia(DESKTOP_MEDIA);
+  mql.addEventListener("change", onChange);
+  return () => mql.removeEventListener("change", onChange);
+}
+
+function getDesktopSnapshot() {
+  return window.matchMedia(DESKTOP_MEDIA).matches;
+}
+
+function getDesktopServerSnapshot() {
+  return false;
+}
 
 const sectionLabels: Record<string, Record<string, string>> = {
   added: { en: "New Features", cn: "新功能" },
@@ -22,11 +38,11 @@ function formatDate(dateStr: string, lang: string) {
   return d.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
 }
 
-function ReleaseCard({ release, lang, featured }: { release: ChangelogRelease; lang: string; featured: boolean }) {
+function ReleaseCard({ release, lang, featured, expanded }: { release: ChangelogRelease; lang: string; featured: boolean; expanded: boolean }) {
   const t = lang === "cn" ? { publishedOn: "发布于", download: "下载", seeGitHub: "查看 GitHub Release 获取详情" } : { publishedOn: "Published on", download: "Download", seeGitHub: "See GitHub Release for details" };
 
   return (
-    <details className="changelog-release border-t border-[rgba(155,176,205,0.18)]" open={featured || undefined}>
+    <details className="changelog-release border-t border-[rgba(155,176,205,0.18)]" open={featured || expanded || undefined}>
       <summary className="changelog-release-summary min-h-[72px] cursor-pointer list-none items-center justify-between gap-4 py-4 text-[#e2e8f0]">
         <span className="min-w-0">
           <strong className="block truncate text-[17px] font-[720]">Release {release.tag}</strong>
@@ -84,10 +100,13 @@ function ReleaseCard({ release, lang, featured }: { release: ChangelogRelease; l
 export function ChangelogList({ releases, lang }: { releases: ChangelogRelease[]; lang: string }) {
   const [count, setCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const isDesktop = useSyncExternalStore(subscribeToDesktop, getDesktopSnapshot, getDesktopServerSnapshot);
+  const visible = releases.slice(0, count);
+  const hasMore = count < releases.length;
 
   useEffect(() => {
     const node = sentinelRef.current;
-    if (!node) return;
+    if (!node || !hasMore) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -100,15 +119,12 @@ export function ChangelogList({ releases, lang }: { releases: ChangelogRelease[]
 
     observer.observe(node);
     return () => observer.disconnect();
-  }, [releases.length]);
-
-  const visible = releases.slice(0, count);
-  const hasMore = count < releases.length;
+  }, [count, hasMore, releases.length]);
 
   return (
     <>
       {visible.map((release, index) => (
-        <ReleaseCard key={release.tag} release={release} lang={lang} featured={index === 0} />
+        <ReleaseCard key={release.tag} release={release} lang={lang} featured={index === 0} expanded={isDesktop} />
       ))}
       {hasMore && (
         <div ref={sentinelRef} className="flex justify-center py-12 text-[#64748b] text-sm">


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
### 问题

`/cn/changelog`（以及 `/en/changelog`）在桌面端视口下，"加载更多版本" 功能无法正常使用：

- 只有列表第一项被设置为 `open`，桌面端 CSS 又将 `<summary>` 设为 `display: none`，
- 而浏览器对未展开 `<details>` 的非 summary 子内容一律不渲染（CSS 无法覆盖），
- 导致第 2 个及以后的版本全部折叠成 1px 高的不可见占位；
- 滚动触发的"加载更多"只是加入更多 1px 占位，视觉上毫无变化；
- 且滚动到页底后 IntersectionObserver 不再触发，加载停在某个批量不再继续。

### 修复

修改 `docs/components/landing/ChangelogList.tsx`：

1. **桌面端全部展开**：使用 `useSyncExternalStore` + `matchMedia("(min-width: 761px)")` 感知视口宽度，
   桌面端所有版本卡片保持 `open` 完整展示，移动端仍为手风琴折叠（仅首条展开）。
2. **无限滚动稳定化**：IntersectionObserver 改为以 `count` 为依赖重新挂钩并加 `hasMore` 守卫，
   修复滚动到页底后加载中断的问题，保证能逐批加载完全部版本。

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
原来
<img width="1920" height="923" alt="旧" src="https://github.com/user-attachments/assets/78d05c9a-cbf7-4d08-b2de-52c3b5a7c571" />

现在
<img width="1919" height="987" alt="新" src="https://github.com/user-attachments/assets/faffc75d-6238-4a00-8ee4-a1beed9d29d1" />



## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->
在本地 `next dev` 下实测：

| 视口 | 加载前 | 滚动加载后 |
| --- | --- | --- |
| 1440px（桌面） | 5 条，全部展开可见 | 100 条，全部展开可见 |
| 390px（移动） | 5 条，手风琴 | 100 条，手风琴样式保持不变 |

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
无