### PR TITLE
pref(objects): retain active tab on the objects right panel

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -931,8 +931,8 @@ async function openTableInfo(row: ObjectBrowserRow, initialTab?: TableInfoTab) {
   tableForeignKeys.value = [];
   tableTriggers.value = [];
   tableInfoSearchQuery.value = "";
-  // Determine initial tab: explicit request > first available > ddl
-  const firstTab = initialTab ?? tableInfoTabs.value[0]?.id ?? "ddl";
+  // Determine initial tab: explicit request > previously activated
+  const firstTab = initialTab ?? tableInfoTab.value;
   await selectTableInfoTab(firstTab);
 }
 


### PR DESCRIPTION
## 变更说明

对象浏览器中，在切换不同的表时，右侧面板无论之前选择的是哪个页签， 都会切换回 DDL。
本次优化内容为在多个表格间切换时， 优先保留已选择的页签。

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 仅涉及前端交互，不涉及界面改动

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

无
