### PR TITLE
修复 MQTT 控制台国际化问题

### DIFF
--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -3518,7 +3518,7 @@ export const useConnectionStore = defineStore("connection", () => {
       // exposes a single navigation entry and must not keep a second topic tree.
       const consoleNode: TreeNode = {
         id: `${connectionId}:mqtt-topic:__console__`,
-        label: "MQTT 控制台",
+        label: i18n.global.t("connection.mqttConsoleTitle"),
         type: "mqtt-topic" as const,
         connectionId,
         children: [],


### PR DESCRIPTION
## 修复内容\n\nissue #5858 反馈英文界面下，连接侧边栏中的 MQTT 控制台标题仍显示中文。本 PR 将该节点标题改为使用 connection.mqttConsoleTitle i18n key，随当前语言切换。\n\nMQTT 订阅面板本身的国际化修复已包含在目标 main 基线中，本提交补齐侧边栏入口。\n\n## 验证\n\n- pnpm exec vitest run apps/desktop/src/lib/__tests__/mq/mqListPanels.spec.ts（4/4 通过）\n- pnpm typecheck（通过）\n\nFixes #5858