### PR TITLE
Fix：修复 MySQL BINARY/VARBINARY 无法正确 Hex 查看

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4891,7 +4891,7 @@ function formatCell(value: CellValue, columnIndex?: number): string {
   const arrayDisplay = formatter ? undefined : dataGridCellDisplayText({ value, databaseType: props.databaseType, columnInfo: displayColumnInfo });
   if (arrayDisplay !== undefined) return arrayDisplay;
   const binaryDisplay = formatter ? null : binaryCellDisplayText(value, columnInfo?.data_type ?? (columnName ? columnTypeMap.value.get(columnName) : undefined));
-  if (binaryDisplay) return binaryDisplay;
+  if (binaryDisplay !== null) return binaryDisplay;
   const s = applyColumnFormatter(value, formatter);
   return limitDataGridCellDisplay(s, resolvedDatabaseType.value === "sqlserver" ? SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH : undefined);
 }

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4885,12 +4885,11 @@ function primitiveCellFormatKey(value: CellValue, columnIndex?: number): string 
 
 function formatCell(value: CellValue, columnIndex?: number): string {
   const formatter = columnIndex === undefined ? undefined : resolvedColumnFormatters.value[columnIndex];
-  const columnName = columnIndex === undefined ? undefined : props.result.columns[columnIndex];
   const columnInfo = columnIndex === undefined ? undefined : tableColumnForGridColumn(columnIndex);
   const displayColumnInfo = columnInfo ?? (columnIndex === undefined ? undefined : resultColumnInfoForGridColumn(columnIndex));
   const arrayDisplay = formatter ? undefined : dataGridCellDisplayText({ value, databaseType: props.databaseType, columnInfo: displayColumnInfo });
   if (arrayDisplay !== undefined) return arrayDisplay;
-  const binaryDisplay = formatter ? null : binaryCellDisplayText(value, columnInfo?.data_type ?? (columnName ? columnTypeMap.value.get(columnName) : undefined));
+  const binaryDisplay = formatter ? null : binaryCellDisplayText(value, columnIndex === undefined ? undefined : allColumnTypes.value[columnIndex]);
   if (binaryDisplay !== null) return binaryDisplay;
   const s = applyColumnFormatter(value, formatter);
   return limitDataGridCellDisplay(s, resolvedDatabaseType.value === "sqlserver" ? SQLSERVER_DATA_GRID_CELL_DISPLAY_MAX_LENGTH : undefined);

--- a/apps/desktop/src/lib/dataGrid/binaryCellDownload.ts
+++ b/apps/desktop/src/lib/dataGrid/binaryCellDownload.ts
@@ -111,6 +111,8 @@ const HEX_VALUE_RE = /^(?:0[xX]|\\x)([0-9a-fA-F\s]+)$/;
 const BARE_HEX_RE = /^[0-9a-fA-F\s]+$/;
 const HEX_ESCAPE_RE = /^(?:\\x[0-9a-fA-F]{2}|\s)+$/;
 const BINARY_TYPE_RE = /^(?:blob|tinyblob|mediumblob|longblob|bytea|bytes|binary|varbinary|image|raw|long\s+raw)(?:\b|\()/i;
+const FIXED_BINARY_TYPE_RE = /^binary(?:\b|\()/i;
+const BINARY_STRING_TYPE_RE = /^(?:binary|varbinary)(?:\b|\()/i;
 const MYSQL_FILE_IMPORT_TYPE_RE = /^(?:blob|tinyblob|mediumblob|longblob|binary|varbinary)(?:\b|\()/i;
 
 function copyBytesForBlob(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
@@ -192,7 +194,33 @@ export function canDownloadBinaryCellValue(value: unknown, columnType?: string):
 export function binaryCellDisplayText(value: unknown, columnType?: string): string | null {
   const bytes = parseBinaryCellBytes(value, columnType);
   if (!bytes || !isBinaryCellColumnType(columnType)) return null;
+  if (BINARY_STRING_TYPE_RE.test((columnType ?? "").trim())) {
+    const previewBytes = FIXED_BINARY_TYPE_RE.test((columnType ?? "").trim()) ? trimTrailingNullBytes(bytes) : bytes;
+    const text = printableUtf8Text(previewBytes);
+    if (text !== null) return text;
+  }
   return `${binaryCellDisplayLabel(columnType)} [${formatBinaryCellByteSize(bytes.length)}]`;
+}
+
+function trimTrailingNullBytes(bytes: Uint8Array): Uint8Array {
+  let end = bytes.length;
+  while (end > 0 && bytes[end - 1] === 0) end--;
+  return bytes.subarray(0, end);
+}
+
+function printableUtf8Text(bytes: Uint8Array): string | null {
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+  for (const char of text) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    const allowedWhitespace = codePoint === 9 || codePoint === 10 || codePoint === 13;
+    if (!allowedWhitespace && (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159))) return null;
+  }
+  return text;
 }
 
 function binaryCellDisplayLabel(columnType?: string): string {

--- a/apps/desktop/src/lib/dataGrid/binaryCellDownload.ts
+++ b/apps/desktop/src/lib/dataGrid/binaryCellDownload.ts
@@ -107,7 +107,7 @@ export function retainBinaryCellDownloadMenuForHover(openCell: BinaryCellPositio
   return openCell?.rowIndex === hoveredCell.rowIndex && openCell.col === hoveredCell.col ? openCell : null;
 }
 
-const HEX_VALUE_RE = /^(?:0[xX]|\\x)([0-9a-fA-F\s]+)$/;
+const HEX_VALUE_RE = /^(?:0[xX]|\\x)([0-9a-fA-F\s]*)$/;
 const BARE_HEX_RE = /^[0-9a-fA-F\s]+$/;
 const HEX_ESCAPE_RE = /^(?:\\x[0-9a-fA-F]{2}|\s)+$/;
 const BINARY_TYPE_RE = /^(?:blob|tinyblob|mediumblob|longblob|bytea|bytes|binary|varbinary|image|raw|long\s+raw)(?:\b|\()/i;
@@ -129,7 +129,8 @@ export function parseBinaryCellHexValue(value: CellValue): Uint8Array | null {
 
 function bytesFromHex(value: string): Uint8Array | null {
   const hex = value.replace(/\s+/g, "");
-  if (!hex || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) return null;
+  if (hex.length === 0) return new Uint8Array();
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) return null;
 
   const bytes = new Uint8Array(hex.length / 2);
   for (let i = 0; i < bytes.length; i++) {

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -283,21 +283,6 @@ fn is_mysql_binary_string_column(column: &mysql_async::Column) -> bool {
         )
 }
 
-fn mysql_printable_binary_preview(bytes: &[u8]) -> Option<String> {
-    let trimmed = bytes.strip_suffix(&[0]).map_or(bytes, |mut value| {
-        while let Some(rest) = value.strip_suffix(&[0]) {
-            value = rest;
-        }
-        value
-    });
-    if trimmed.is_empty() {
-        return Some(String::new());
-    }
-
-    let text = std::str::from_utf8(trimmed).ok()?;
-    text.chars().all(|ch| !ch.is_control() || matches!(ch, '\t' | '\n' | '\r')).then(|| text.to_string())
-}
-
 fn mysql_blob_preview(bytes: &[u8], label: &str) -> serde_json::Value {
     if label == "BLOB" {
         return super::binary_value_to_json(bytes);
@@ -326,9 +311,7 @@ fn mysql_bytes_to_json(bytes: Vec<u8>, column: &mysql_async::Column) -> serde_js
         return mysql_blob_preview(&bytes, "BLOB");
     }
     if is_mysql_binary_string_column(column) {
-        return mysql_printable_binary_preview(&bytes)
-            .map(serde_json::Value::String)
-            .unwrap_or_else(|| super::binary_value_to_json(&bytes));
+        return super::binary_value_to_json(&bytes);
     }
     serde_json::Value::String(bytes_to_string_lossy(bytes))
 }
@@ -6390,16 +6373,23 @@ mod tests {
     }
 
     #[test]
-    fn mysql_binary_preview_renders_binary_and_varbinary_like_navicat_text_preview() {
+    fn mysql_binary_values_preserve_all_bytes_as_hex() {
         let binary_column = mysql_test_column(ColumnType::MYSQL_TYPE_STRING, 63, ColumnFlags::BINARY_FLAG, 8);
         let varbinary_column = mysql_test_column(ColumnType::MYSQL_TYPE_VAR_STRING, 63, ColumnFlags::BINARY_FLAG, 8);
 
-        assert_eq!(mysql_bytes_to_json(b"150010\0\0".to_vec(), &binary_column), serde_json::json!("150010"));
-        assert_eq!(mysql_bytes_to_json(b"150010".to_vec(), &varbinary_column), serde_json::json!("150010"));
+        assert_eq!(
+            mysql_bytes_to_json(b"150010\0\0".to_vec(), &binary_column),
+            serde_json::json!("0x3135303031300000")
+        );
+        assert_eq!(mysql_bytes_to_json(b"150010".to_vec(), &varbinary_column), serde_json::json!("0x313530303130"));
+        assert_eq!(
+            mysql_bytes_to_json(b"SN-A0001".to_vec(), &varbinary_column),
+            serde_json::json!("0x534e2d4130303031")
+        );
     }
 
     #[test]
-    fn mysql_binary_preview_falls_back_to_hex_for_unprintable_bytes() {
+    fn mysql_binary_values_preserve_unprintable_bytes_as_hex() {
         let binary_column = mysql_test_column(ColumnType::MYSQL_TYPE_STRING, 63, ColumnFlags::BINARY_FLAG, 8);
         let varbinary_column = mysql_test_column(ColumnType::MYSQL_TYPE_VAR_STRING, 63, ColumnFlags::BINARY_FLAG, 8);
 

--- a/packages/app-tests/binaryCellDownload.test.ts
+++ b/packages/app-tests/binaryCellDownload.test.ts
@@ -19,6 +19,7 @@ import {
 test("parseBinaryCellHexValue accepts 0x and \\x prefixed hex values", () => {
   assert.deepEqual(Array.from(parseBinaryCellHexValue("0X48656c6c6f") ?? []), [72, 101, 108, 108, 111]);
   assert.deepEqual(Array.from(parseBinaryCellHexValue("\\x00 ff") ?? []), [0, 255]);
+  assert.deepEqual(Array.from(parseBinaryCellHexValue("0x") ?? []), []);
 });
 
 test("parseBinaryCellHexValue rejects non-hex and odd-length payloads", () => {
@@ -75,6 +76,7 @@ test("binaryCellDisplayText previews printable binary strings without changing t
   assert.equal(binaryCellDisplayText("0x89504e47", "BLOB"), "BLOB [4 bytes]");
   assert.equal(binaryCellDisplayText(`0x${"00".repeat(2048)}`, "VARBINARY(2048)"), "VARBINARY [2.0 KB]");
   assert.equal(binaryCellDisplayText("0x89504e47"), null);
+  assert.equal(binaryCellDisplayText("0x", "VARBINARY(0)"), "");
 });
 
 test("binaryCellDownloadPayload builds raw and decoded payloads", () => {
@@ -90,6 +92,16 @@ test("binaryCellDownloadPayload builds raw and decoded payloads", () => {
 
   const paddedBinary = binaryCellDownloadPayload("0x3135303031300000", "binary", "BINARY(8)");
   assert.deepEqual(Array.from(paddedBinary.data as Uint8Array), [49, 53, 48, 48, 49, 48, 0, 0]);
+
+  const emptyBinary = binaryCellDownloadPayload("0x", "binary", "VARBINARY(0)");
+  assert.deepEqual(Array.from(emptyBinary.data as Uint8Array), []);
+});
+
+test("DataGrid binary preview prefers ResultSet column types when table metadata is unavailable", () => {
+  const source = readFileSync("apps/desktop/src/components/grid/DataGrid.vue", "utf8");
+  const formatter = source.match(/function formatCell\([^]*?\n\}/)?.[0] ?? "";
+
+  assert.match(formatter, /binaryCellDisplayText\(value, columnIndex === undefined \? undefined : allColumnTypes\.value\[columnIndex\]\)/);
 });
 
 test("binaryCellDownloadPayload decodes GBK text bytes", () => {

--- a/packages/app-tests/binaryCellDownload.test.ts
+++ b/packages/app-tests/binaryCellDownload.test.ts
@@ -29,6 +29,8 @@ test("parseBinaryCellHexValue rejects non-hex and odd-length payloads", () => {
 
 test("parseBinaryCellBytes accepts common driver binary shapes", () => {
   assert.deepEqual(Array.from(parseBinaryCellBytes("89504e47", "BLOB") ?? []), [137, 80, 78, 71]);
+  assert.deepEqual(Array.from(parseBinaryCellBytes("0x534e2d4130303031", "VARBINARY(8)") ?? []), [83, 78, 45, 65, 48, 48, 48, 49]);
+  assert.deepEqual(Array.from(parseBinaryCellBytes("0x3135303031300000", "BINARY(8)") ?? []), [49, 53, 48, 48, 49, 48, 0, 0]);
   assert.deepEqual(Array.from(parseBinaryCellBytes("\\x89\\x50\\x4e\\x47") ?? []), [137, 80, 78, 71]);
   assert.deepEqual(Array.from(parseBinaryCellBytes([0, 1, 171, 255]) ?? []), [0, 1, 171, 255]);
   assert.deepEqual(Array.from(parseBinaryCellBytes({ type: "Buffer", data: [222, 173, 190, 239] }) ?? []), [222, 173, 190, 239]);
@@ -63,7 +65,13 @@ test("canDownloadBinaryCellValue allows displayed binary hex strings", () => {
   assert.equal(canDownloadBinaryCellValue("89504e47"), false);
 });
 
-test("binaryCellDisplayText summarizes binary values for grid display", () => {
+test("binaryCellDisplayText previews printable binary strings without changing their raw bytes", () => {
+  assert.equal(binaryCellDisplayText("0x534e2d4130303031", "VARBINARY(8)"), "SN-A0001");
+  assert.equal(binaryCellDisplayText("0x3135303031300000", "BINARY(8)"), "150010");
+  assert.equal(binaryCellDisplayText("0x0000", "BINARY(2)"), "");
+  assert.equal(binaryCellDisplayText("0x68690a", "VARBINARY(3)"), "hi\n");
+  assert.equal(binaryCellDisplayText("0x680069", "VARBINARY(3)"), "VARBINARY [3 bytes]");
+  assert.equal(binaryCellDisplayText("0xdeadbeef", "VARBINARY(4)"), "VARBINARY [4 bytes]");
   assert.equal(binaryCellDisplayText("0x89504e47", "BLOB"), "BLOB [4 bytes]");
   assert.equal(binaryCellDisplayText(`0x${"00".repeat(2048)}`, "VARBINARY(2048)"), "VARBINARY [2.0 KB]");
   assert.equal(binaryCellDisplayText("0x89504e47"), null);
@@ -79,6 +87,9 @@ test("binaryCellDownloadPayload builds raw and decoded payloads", () => {
   assert.equal(text.mimeType, "text/plain;charset=utf-8");
   assert.equal(text.extension, "txt");
   assert.equal(text.data, "Hi");
+
+  const paddedBinary = binaryCellDownloadPayload("0x3135303031300000", "binary", "BINARY(8)");
+  assert.deepEqual(Array.from(paddedBinary.data as Uint8Array), [49, 53, 48, 48, 49, 48, 0, 0]);
 });
 
 test("binaryCellDownloadPayload decodes GBK text bytes", () => {


### PR DESCRIPTION
## 问题

MySQL 原生驱动会把可打印的 `BINARY/VARBINARY` 字节转换为普通文本，导致前端无法恢复原始字节：

- 普通文本无法在 Hex 查看器中显示
- 只包含十六进制字符的文本可能被误当作 Hex
- 固定长度 `BINARY(n)` 的尾部补零会丢失

## 修改

- MySQL 后端对 `BINARY/VARBINARY` 始终返回带 `0x` 前缀的完整字节
- 表格展示层对可打印 UTF-8 内容保留可读预览
- 固定长度 `BINARY(n)` 仅在展示时去除尾部补零，Hex、下载和编辑仍使用完整原值
- 不可打印内容显示字节数摘要
- 保持 BLOB 等其他二进制类型的现有展示行为

## 实际验证

使用 DBX 原生 MySQL 驱动连接 MySQL 8.4，执行包含可打印值、固定长度补零值和不可打印值的查询，后端实际返回：

```text
column_types=["varbinary", "varbinary", "varbinary"]
rows=[[
  "0x534e2d4130303031",
  "0x3135303031300000",
  "0xdeadbeef"
]]
```

确认 Hex 解析与二进制下载均保留完整字节，包括 `BINARY(8)` 的两个尾部 `00`。

- `cargo test -p dbx-core mysql_binary --lib`：5 项通过
- `pnpm check`：format、lint、typecheck、全量 Vitest 均通过
- `git diff --check`：通过

Related to #5873