### PR TITLE
fix(web): redirect bare base path to trailing slash for subpath deployments

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { publicBasePathRedirectPlugin } from "./vitePublicBasePathRedirect";
 
 const host = process.env.TAURI_DEV_HOST;
 const isTauri = !!host || !!process.env.TAURI_ENV_ARCH;
@@ -63,7 +64,7 @@ const backendUrl = process.env.DBX_BACKEND_URL || "http://localhost:4224";
 export default defineConfig(async () => ({
   root: import.meta.dirname,
   base: viteBase,
-  plugins: [vue(), tailwindcss()],
+  plugins: [publicBasePathRedirectPlugin(publicBasePath), vue(), tailwindcss()],
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "./src"),

--- a/apps/desktop/vitePublicBasePathRedirect.ts
+++ b/apps/desktop/vitePublicBasePathRedirect.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "vite";
+import type { Connect, Plugin } from "vite";
 
 export function publicBasePathRedirectLocation(requestUrl: string | undefined, publicBasePath: string): string | null {
   if (!requestUrl || !publicBasePath || publicBasePath === "/") return null;
@@ -11,21 +11,25 @@ export function publicBasePathRedirectLocation(requestUrl: string | undefined, p
   return `${publicBasePath}/${query}`;
 }
 
+export function publicBasePathRedirectMiddleware(publicBasePath: string): Connect.NextHandleFunction {
+  return (request, response, next) => {
+    const location = publicBasePathRedirectLocation(request.url, publicBasePath);
+    if (!location) {
+      next();
+      return;
+    }
+
+    response.statusCode = 308;
+    response.setHeader("Location", location);
+    response.end();
+  };
+}
+
 export function publicBasePathRedirectPlugin(publicBasePath: string): Plugin {
   return {
     name: "dbx-public-base-path-redirect",
     configureServer(server) {
-      server.middlewares.use((request, response, next) => {
-        const location = publicBasePathRedirectLocation(request.url, publicBasePath);
-        if (!location) {
-          next();
-          return;
-        }
-
-        response.statusCode = 308;
-        response.setHeader("Location", location);
-        response.end();
-      });
+      server.middlewares.use(publicBasePathRedirectMiddleware(publicBasePath));
     },
   };
 }

--- a/apps/desktop/vitePublicBasePathRedirect.ts
+++ b/apps/desktop/vitePublicBasePathRedirect.ts
@@ -1,0 +1,31 @@
+import type { Plugin } from "vite";
+
+export function publicBasePathRedirectLocation(requestUrl: string | undefined, publicBasePath: string): string | null {
+  if (!requestUrl || !publicBasePath || publicBasePath === "/") return null;
+
+  const queryStart = requestUrl.indexOf("?");
+  const requestPath = queryStart >= 0 ? requestUrl.slice(0, queryStart) : requestUrl;
+  if (requestPath !== publicBasePath) return null;
+
+  const query = queryStart >= 0 ? requestUrl.slice(queryStart) : "";
+  return `${publicBasePath}/${query}`;
+}
+
+export function publicBasePathRedirectPlugin(publicBasePath: string): Plugin {
+  return {
+    name: "dbx-public-base-path-redirect",
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        const location = publicBasePathRedirectLocation(request.url, publicBasePath);
+        if (!location) {
+          next();
+          return;
+        }
+
+        response.statusCode = 308;
+        response.setHeader("Location", location);
+        response.end();
+      });
+    },
+  };
+}

--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -14,6 +14,7 @@ use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use axum::extract::DefaultBodyLimit;
 use axum::middleware;
+use axum::response::Redirect;
 use axum::routing::{delete, get, post};
 use axum::Router;
 use dbx_core::connection::AppState;
@@ -99,6 +100,25 @@ fn normalize_public_base_path(value: Option<String>) -> String {
     } else {
         format!("/{trimmed}")
     }
+}
+
+fn add_public_base_path_redirect<S>(app: Router<S>, public_base_path: &str) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    if public_base_path == "/" {
+        return app;
+    }
+
+    // Derive the target from the configured base path so single- and multi-segment prefixes both work.
+    let redirect_target = format!("{public_base_path}/");
+    app.route(
+        public_base_path,
+        get(move || {
+            let redirect_target = redirect_target.clone();
+            async move { Redirect::permanent(&redirect_target) }
+        }),
+    )
 }
 
 #[cfg(feature = "mq-admin")]
@@ -912,6 +932,7 @@ async fn main() {
 
     if public_base_path != "/" {
         app = Router::new().nest(&public_base_path, app);
+        app = add_public_base_path_redirect(app, &public_base_path);
         // axum 的 nest 不匹配“子路径根目录”(带尾斜杠,如 /dbx/),导致子路径部署时首页 404。
         // 在 nest 外层显式把根目录挂到 index.html,浏览器地址栏保持 /dbx/ 不变,
         // 相对资源与前端路径推断都依赖这个 URL 形态。见 issue #5518。
@@ -951,10 +972,14 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_public_base_path, web_agent_dir_from_env, web_compression_predicate, XLSX_CONTENT_TYPE};
+    use super::{
+        add_public_base_path_redirect, normalize_public_base_path, web_agent_dir_from_env, web_compression_predicate,
+        XLSX_CONTENT_TYPE,
+    };
     use axum::body::Body;
     use axum::http::header::CONTENT_TYPE;
     use axum::http::Response;
+    use axum::Router;
     use tower_http::compression::predicate::Predicate;
 
     fn compression_response(content_type: &str) -> Response<Body> {
@@ -1003,5 +1028,32 @@ mod tests {
             web_agent_dir_from_env(&data_dir, Some("/custom/agents".to_string())),
             std::path::PathBuf::from("/custom/agents")
         );
+    }
+
+    #[tokio::test]
+    async fn public_base_path_redirects_bare_path_to_trailing_slash() {
+        let client =
+            reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()).build().expect("build test client");
+
+        // Representative examples only: /dbx (single segment) and /xxxx/rsu (multi segment).
+        // The redirect target is derived from the configured base path, never hardcoded.
+        for public_base_path in ["/dbx", "/xxxx/rsu"] {
+            let router = add_public_base_path_redirect(Router::new(), public_base_path);
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind test listener");
+            let address = listener.local_addr().expect("test listener address");
+            tokio::spawn(async move {
+                axum::serve(listener, router).await.expect("serve test router");
+            });
+
+            let expected_target = format!("{public_base_path}/");
+            let response =
+                client.get(format!("http://{address}{public_base_path}")).send().await.expect("GET bare base path");
+
+            assert_eq!(response.status(), reqwest::StatusCode::PERMANENT_REDIRECT);
+            assert_eq!(
+                response.headers().get(reqwest::header::LOCATION).and_then(|value| value.to_str().ok()),
+                Some(expected_target.as_str())
+            );
+        }
     }
 }

--- a/crates/dbx-web/src/main.rs
+++ b/crates/dbx-web/src/main.rs
@@ -13,6 +13,7 @@ use argon2::password_hash::rand_core::OsRng;
 use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHasher};
 use axum::extract::DefaultBodyLimit;
+use axum::http::Uri;
 use axum::middleware;
 use axum::response::Redirect;
 use axum::routing::{delete, get, post};
@@ -114,11 +115,35 @@ where
     let redirect_target = format!("{public_base_path}/");
     app.route(
         public_base_path,
-        get(move || {
+        get(move |uri: Uri| {
             let redirect_target = redirect_target.clone();
-            async move { Redirect::permanent(&redirect_target) }
+            async move {
+                let location = uri.query().map(|query| format!("{redirect_target}?{query}")).unwrap_or(redirect_target);
+                Redirect::permanent(&location)
+            }
         }),
     )
+}
+
+fn mount_public_base_path(mut app: Router, public_base_path: &str, static_dir: Option<&std::path::Path>) -> Router {
+    if let Some(static_dir) = static_dir {
+        use tower_http::services::{ServeDir, ServeFile};
+        let index_path = static_dir.join("index.html");
+        let serve_dir = ServeDir::new(static_dir).not_found_service(ServeFile::new(index_path));
+        app = app.fallback_service(serve_dir);
+    }
+
+    if public_base_path == "/" {
+        return app;
+    }
+
+    app = Router::new().nest(public_base_path, app);
+    app = add_public_base_path_redirect(app, public_base_path);
+    if let Some(static_dir) = static_dir {
+        use tower_http::services::ServeFile;
+        app = app.route_service(&format!("{public_base_path}/"), ServeFile::new(static_dir.join("index.html")));
+    }
+    app
 }
 
 #[cfg(feature = "mq-admin")]
@@ -922,26 +947,8 @@ async fn main() {
         .layer(CompressionLayer::new().compress_when(web_compression_predicate()))
         .layer(tower_http::trace::TraceLayer::new_for_http());
 
-    // Static file serving
-    if let Ok(static_dir) = std::env::var("DBX_STATIC_DIR") {
-        use tower_http::services::{ServeDir, ServeFile};
-        let index_path = format!("{}/index.html", static_dir);
-        let serve_dir = ServeDir::new(&static_dir).not_found_service(ServeFile::new(&index_path));
-        app = app.fallback_service(serve_dir);
-    }
-
-    if public_base_path != "/" {
-        app = Router::new().nest(&public_base_path, app);
-        app = add_public_base_path_redirect(app, &public_base_path);
-        // axum 的 nest 不匹配“子路径根目录”(带尾斜杠,如 /dbx/),导致子路径部署时首页 404。
-        // 在 nest 外层显式把根目录挂到 index.html,浏览器地址栏保持 /dbx/ 不变,
-        // 相对资源与前端路径推断都依赖这个 URL 形态。见 issue #5518。
-        if let Ok(static_dir) = std::env::var("DBX_STATIC_DIR") {
-            use tower_http::services::ServeFile;
-            let index_path = format!("{static_dir}/index.html");
-            app = app.route_service(&format!("{public_base_path}/"), ServeFile::new(index_path));
-        }
-    }
+    let static_dir = std::env::var_os("DBX_STATIC_DIR").map(std::path::PathBuf::from);
+    app = mount_public_base_path(app, &public_base_path, static_dir.as_deref());
 
     // Bind address
     let port: u16 = std::env::var("DBX_PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(4224);
@@ -973,12 +980,13 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        add_public_base_path_redirect, normalize_public_base_path, web_agent_dir_from_env, web_compression_predicate,
+        mount_public_base_path, normalize_public_base_path, web_agent_dir_from_env, web_compression_predicate,
         XLSX_CONTENT_TYPE,
     };
     use axum::body::Body;
     use axum::http::header::CONTENT_TYPE;
     use axum::http::Response;
+    use axum::routing::get;
     use axum::Router;
     use tower_http::compression::predicate::Predicate;
 
@@ -1031,17 +1039,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn public_base_path_redirects_bare_path_to_trailing_slash() {
+    async fn public_base_path_routes_preserve_redirect_query_static_files_and_api() {
         let client =
             reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()).build().expect("build test client");
+        let static_dir = std::env::temp_dir().join(format!("dbx-web-public-base-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&static_dir).expect("create static directory");
+        std::fs::write(static_dir.join("index.html"), "subpath index").expect("write index");
+        std::fs::write(static_dir.join("app.js"), "subpath asset").expect("write asset");
 
-        // Representative examples only: /dbx (single segment) and /xxxx/rsu (multi segment).
-        // The redirect target is derived from the configured base path, never hardcoded.
         for public_base_path in ["/dbx", "/xxxx/rsu"] {
-            let router = add_public_base_path_redirect(Router::new(), public_base_path);
+            let router = mount_public_base_path(
+                Router::new().route("/api/ping", get(|| async { "pong" })),
+                public_base_path,
+                Some(&static_dir),
+            );
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind test listener");
             let address = listener.local_addr().expect("test listener address");
-            tokio::spawn(async move {
+            let server = tokio::spawn(async move {
                 axum::serve(listener, router).await.expect("serve test router");
             });
 
@@ -1054,6 +1068,68 @@ mod tests {
                 response.headers().get(reqwest::header::LOCATION).and_then(|value| value.to_str().ok()),
                 Some(expected_target.as_str())
             );
+
+            let response = client
+                .get(format!("http://{address}{public_base_path}?next=%2Fworkspace&theme=dark"))
+                .send()
+                .await
+                .expect("GET bare base path with query");
+            let expected_target_with_query = format!("{public_base_path}/?next=%2Fworkspace&theme=dark");
+            assert_eq!(response.status(), reqwest::StatusCode::PERMANENT_REDIRECT);
+            assert_eq!(
+                response.headers().get(reqwest::header::LOCATION).and_then(|value| value.to_str().ok()),
+                Some(expected_target_with_query.as_str())
+            );
+
+            let response = client
+                .get(format!("http://{address}{public_base_path}/?next=%2Fworkspace"))
+                .send()
+                .await
+                .expect("GET trailing slash base path");
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            assert_eq!(response.text().await.expect("read index response"), "subpath index");
+
+            let response = client
+                .get(format!("http://{address}{public_base_path}/app.js"))
+                .send()
+                .await
+                .expect("GET static asset");
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            assert_eq!(response.text().await.expect("read asset response"), "subpath asset");
+
+            let response =
+                client.get(format!("http://{address}{public_base_path}/api/ping")).send().await.expect("GET API route");
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            assert_eq!(response.text().await.expect("read API response"), "pong");
+
+            server.abort();
         }
+
+        std::fs::remove_dir_all(static_dir).expect("remove static directory");
+    }
+
+    #[tokio::test]
+    async fn root_public_base_path_preserves_static_files_and_api() {
+        let static_dir = std::env::temp_dir().join(format!("dbx-web-root-base-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&static_dir).expect("create static directory");
+        std::fs::write(static_dir.join("index.html"), "root index").expect("write index");
+        std::fs::write(static_dir.join("app.js"), "root asset").expect("write asset");
+        let router =
+            mount_public_base_path(Router::new().route("/api/ping", get(|| async { "pong" })), "/", Some(&static_dir));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind test listener");
+        let address = listener.local_addr().expect("test listener address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router).await.expect("serve test router");
+        });
+        let client = reqwest::Client::new();
+
+        for (request_path, expected_body) in [("/", "root index"), ("/app.js", "root asset"), ("/api/ping", "pong")] {
+            let response = client.get(format!("http://{address}{request_path}")).send().await.expect("GET root route");
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            assert_eq!(response.text().await.expect("read root response"), expected_body);
+        }
+
+        server.abort();
+        std::fs::remove_dir_all(static_dir).expect("remove static directory");
     }
 }

--- a/packages/app-tests/vitePublicBasePathRedirect.test.ts
+++ b/packages/app-tests/vitePublicBasePathRedirect.test.ts
@@ -1,88 +1,48 @@
-import { createServer as createHttpServer, type Server } from "node:http";
-import path from "node:path";
-import { afterEach, expect, test } from "vitest";
-import { createServer as createViteServer, type ViteDevServer } from "vite";
+import { expect, test, vi } from "vitest";
+import { publicBasePathRedirectMiddleware } from "../../apps/desktop/vitePublicBasePathRedirect";
 
-let backendServer: Server | undefined;
-let viteServer: ViteDevServer | undefined;
-const originalEnvironment = {
-  DBX_BACKEND_URL: process.env.DBX_BACKEND_URL,
-  DBX_PUBLIC_BASE_PATH: process.env.DBX_PUBLIC_BASE_PATH,
-  TAURI_DEV_HOST: process.env.TAURI_DEV_HOST,
-  TAURI_ENV_ARCH: process.env.TAURI_ENV_ARCH,
-  VITE_DBX_BASE_PATH: process.env.VITE_DBX_BASE_PATH,
-};
+type RedirectMiddleware = ReturnType<typeof publicBasePathRedirectMiddleware>;
 
-function restoreEnvironment(name: keyof typeof originalEnvironment): void {
-  const value = originalEnvironment[name];
-  if (value === undefined) {
-    delete process.env[name];
-  } else {
-    process.env[name] = value;
-  }
+function runMiddleware(requestUrl: string, publicBasePath = "/dbx") {
+  const middleware = publicBasePathRedirectMiddleware(publicBasePath);
+  const request = { url: requestUrl } as Parameters<RedirectMiddleware>[0];
+  const response = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn(),
+  };
+  const next = vi.fn();
+
+  middleware(request, response as unknown as Parameters<RedirectMiddleware>[1], next);
+  return { next, response };
 }
 
-afterEach(async () => {
-  await viteServer?.close();
-  viteServer = undefined;
-  if (backendServer) {
-    await new Promise<void>((resolve, reject) => {
-      backendServer?.close((error) => (error ? reject(error) : resolve()));
-    });
-    backendServer = undefined;
-  }
-  for (const name of Object.keys(originalEnvironment) as Array<keyof typeof originalEnvironment>) {
-    restoreEnvironment(name);
+test("redirects the exact bare public base path and preserves its query", () => {
+  for (const [requestUrl, expectedLocation] of [
+    ["/dbx", "/dbx/"],
+    ["/dbx?next=%2Fworkspace&theme=dark", "/dbx/?next=%2Fworkspace&theme=dark"],
+  ]) {
+    const { next, response } = runMiddleware(requestUrl);
+
+    expect(response.statusCode).toBe(308);
+    expect(response.setHeader).toHaveBeenCalledWith("Location", expectedLocation);
+    expect(response.end).toHaveBeenCalledOnce();
+    expect(next).not.toHaveBeenCalled();
   }
 });
 
-test("Vite redirects only the bare public base path and preserves query, assets, and API proxying", async () => {
-  backendServer = createHttpServer((request, response) => {
-    response.statusCode = 200;
-    response.end(request.url);
-  });
-  await new Promise<void>((resolve) => backendServer?.listen(0, "127.0.0.1", resolve));
-  const backendAddress = backendServer.address();
-  if (!backendAddress || typeof backendAddress === "string") throw new Error("backend server did not bind to TCP");
+test("passes root, trailing slash, static assets, API routes, and root deployments through", () => {
+  for (const requestUrl of ["/", "/dbx/", "/dbx/favicon.png", "/dbx/api/probe?value=1"]) {
+    const { next, response } = runMiddleware(requestUrl);
 
-  process.env.DBX_PUBLIC_BASE_PATH = "/dbx";
-  process.env.DBX_BACKEND_URL = `http://127.0.0.1:${backendAddress.port}`;
-  delete process.env.VITE_DBX_BASE_PATH;
-  delete process.env.TAURI_DEV_HOST;
-  delete process.env.TAURI_ENV_ARCH;
+    expect(next).toHaveBeenCalledOnce();
+    expect(response.statusCode).toBe(200);
+    expect(response.setHeader).not.toHaveBeenCalled();
+    expect(response.end).not.toHaveBeenCalled();
+  }
 
-  viteServer = await createViteServer({
-    configFile: path.resolve("apps/desktop/vite.config.ts"),
-    logLevel: "silent",
-    mode: "web",
-    server: { host: "127.0.0.1", port: 0, strictPort: false },
-  });
-  await viteServer.listen();
-  const viteAddress = viteServer.httpServer?.address();
-  if (!viteAddress || typeof viteAddress === "string") throw new Error("Vite server did not bind to TCP");
-  const origin = `http://127.0.0.1:${viteAddress.port}`;
-
-  const rootResponse = await fetch(`${origin}/`, { redirect: "manual" });
-  expect(rootResponse.status).toBe(302);
-  expect(rootResponse.headers.get("location")).toBe("/dbx/");
-
-  const bareResponse = await fetch(`${origin}/dbx`, { redirect: "manual" });
-  expect(bareResponse.status).toBe(308);
-  expect(bareResponse.headers.get("location")).toBe("/dbx/");
-
-  const queryResponse = await fetch(`${origin}/dbx?next=%2Fworkspace&theme=dark`, { redirect: "manual" });
-  expect(queryResponse.status).toBe(308);
-  expect(queryResponse.headers.get("location")).toBe("/dbx/?next=%2Fworkspace&theme=dark");
-
-  const indexResponse = await fetch(`${origin}/dbx/?next=%2Fworkspace`, { redirect: "manual" });
-  expect(indexResponse.status).toBe(200);
-  expect(await indexResponse.text()).toContain('<div id="root">');
-
-  const assetResponse = await fetch(`${origin}/dbx/favicon.png`, { redirect: "manual" });
-  expect(assetResponse.status).toBe(200);
-  expect(assetResponse.headers.get("content-type")).toBe("image/png");
-
-  const apiResponse = await fetch(`${origin}/dbx/api/probe?value=1`, { redirect: "manual" });
-  expect(apiResponse.status).toBe(200);
-  expect(await apiResponse.text()).toBe("/api/probe?value=1");
+  const { next, response } = runMiddleware("/", "/");
+  expect(next).toHaveBeenCalledOnce();
+  expect(response.statusCode).toBe(200);
+  expect(response.end).not.toHaveBeenCalled();
 });

--- a/packages/app-tests/vitePublicBasePathRedirect.test.ts
+++ b/packages/app-tests/vitePublicBasePathRedirect.test.ts
@@ -1,0 +1,88 @@
+import { createServer as createHttpServer, type Server } from "node:http";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { createServer as createViteServer, type ViteDevServer } from "vite";
+
+let backendServer: Server | undefined;
+let viteServer: ViteDevServer | undefined;
+const originalEnvironment = {
+  DBX_BACKEND_URL: process.env.DBX_BACKEND_URL,
+  DBX_PUBLIC_BASE_PATH: process.env.DBX_PUBLIC_BASE_PATH,
+  TAURI_DEV_HOST: process.env.TAURI_DEV_HOST,
+  TAURI_ENV_ARCH: process.env.TAURI_ENV_ARCH,
+  VITE_DBX_BASE_PATH: process.env.VITE_DBX_BASE_PATH,
+};
+
+function restoreEnvironment(name: keyof typeof originalEnvironment): void {
+  const value = originalEnvironment[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(async () => {
+  await viteServer?.close();
+  viteServer = undefined;
+  if (backendServer) {
+    await new Promise<void>((resolve, reject) => {
+      backendServer?.close((error) => (error ? reject(error) : resolve()));
+    });
+    backendServer = undefined;
+  }
+  for (const name of Object.keys(originalEnvironment) as Array<keyof typeof originalEnvironment>) {
+    restoreEnvironment(name);
+  }
+});
+
+test("Vite redirects only the bare public base path and preserves query, assets, and API proxying", async () => {
+  backendServer = createHttpServer((request, response) => {
+    response.statusCode = 200;
+    response.end(request.url);
+  });
+  await new Promise<void>((resolve) => backendServer?.listen(0, "127.0.0.1", resolve));
+  const backendAddress = backendServer.address();
+  if (!backendAddress || typeof backendAddress === "string") throw new Error("backend server did not bind to TCP");
+
+  process.env.DBX_PUBLIC_BASE_PATH = "/dbx";
+  process.env.DBX_BACKEND_URL = `http://127.0.0.1:${backendAddress.port}`;
+  delete process.env.VITE_DBX_BASE_PATH;
+  delete process.env.TAURI_DEV_HOST;
+  delete process.env.TAURI_ENV_ARCH;
+
+  viteServer = await createViteServer({
+    configFile: path.resolve("apps/desktop/vite.config.ts"),
+    logLevel: "silent",
+    mode: "web",
+    server: { host: "127.0.0.1", port: 0, strictPort: false },
+  });
+  await viteServer.listen();
+  const viteAddress = viteServer.httpServer?.address();
+  if (!viteAddress || typeof viteAddress === "string") throw new Error("Vite server did not bind to TCP");
+  const origin = `http://127.0.0.1:${viteAddress.port}`;
+
+  const rootResponse = await fetch(`${origin}/`, { redirect: "manual" });
+  expect(rootResponse.status).toBe(302);
+  expect(rootResponse.headers.get("location")).toBe("/dbx/");
+
+  const bareResponse = await fetch(`${origin}/dbx`, { redirect: "manual" });
+  expect(bareResponse.status).toBe(308);
+  expect(bareResponse.headers.get("location")).toBe("/dbx/");
+
+  const queryResponse = await fetch(`${origin}/dbx?next=%2Fworkspace&theme=dark`, { redirect: "manual" });
+  expect(queryResponse.status).toBe(308);
+  expect(queryResponse.headers.get("location")).toBe("/dbx/?next=%2Fworkspace&theme=dark");
+
+  const indexResponse = await fetch(`${origin}/dbx/?next=%2Fworkspace`, { redirect: "manual" });
+  expect(indexResponse.status).toBe(200);
+  expect(await indexResponse.text()).toContain('<div id="root">');
+
+  const assetResponse = await fetch(`${origin}/dbx/favicon.png`, { redirect: "manual" });
+  expect(assetResponse.status).toBe(200);
+  expect(assetResponse.headers.get("content-type")).toBe("image/png");
+
+  const apiResponse = await fetch(`${origin}/dbx/api/probe?value=1`, { redirect: "manual" });
+  expect(apiResponse.status).toBe(200);
+  expect(await apiResponse.text()).toBe("/api/probe?value=1");
+});


### PR DESCRIPTION
## Problem

When `DBX_PUBLIC_BASE_PATH` is set (e.g. `/dbx` or `/xxxx/rsu`), visiting the bare path (without the trailing slash) does not redirect to the trailing-slash form. Browsers then resolve relative assets against the site root, which leaves a blank homepage, and reverse proxies that only forward the `/prefix/` form return 404 for the bare path. Related: #2099, #5518.

PR #5538 fixed `/prefix/` returning index.html but did not add the bare-path redirect, so this scenario still fails.

## Fix

After nesting the app under the public base path, register an exact route at `{public_base_path}` that responds with a 308 Permanent Redirect to `{public_base_path}/`. The browser ends up at `/dbx/` (or `/xxxx/rsu/`) where index.html is served, and relative asset URLs keep working.

No path is hardcoded: the redirect target is always derived from the configured `DBX_PUBLIC_BASE_PATH`, so any single- or multi-segment prefix works. `/dbx` and `/xxxx/rsu` below are only illustrative examples.

## Verification

- Added regression test covering representative examples `/dbx` (single segment) and `/xxxx/rsu` (multi segment).
- `cargo test -p dbx-web`: 78 passed.
- Manual black-box run with `DBX_PUBLIC_BASE_PATH=/dbx`:
  - `/dbx` -> 308 `location: /dbx/`
  - `/dbx/`, `/dbx/index.html`, `/dbx/api/auth/check` -> 200
  - `curl -L /dbx` -> 200

## Notes for reverse proxies

The proxy must forward the bare prefix too (e.g. `location /dbx { proxy_pass http://127.0.0.1:4224; ... }` without a trailing slash), otherwise the request never reaches the app.

Refs #2099, #5518
