### PR TITLE
Fix：鼠标切换单元格时同步更新详情

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6190,7 +6190,7 @@ function onTransposeCellContext(rowIndex: number, actualColIdx: number, event: M
   contextCell.value = item ? { rowId: item.id, rowIndex, col: actualColIdx } : null;
 }
 
-watch([selectedRange, showCellDetail, isEditingDetail], () => {
+watch([selectedRange, showCellDetail, isEditingDetail, isSelectingCells], () => {
   if (isSelectingCells.value) return;
   const selectedCell = currentSelectedCellPosition();
   const target = linkedCellDetailTarget({

--- a/apps/desktop/src/components/grid/__tests__/DataGridCellDetailSelection.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridCellDetailSelection.spec.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
+
+describe("DataGrid cell detail selection", () => {
+  it("resynchronizes the open detail after a mouse selection gesture finishes", () => {
+    expect(dataGridSource).toContain("watch([selectedRange, showCellDetail, isEditingDetail, isSelectingCells]");
+    expect(dataGridSource).toContain("if (isSelectingCells.value) return;");
+  });
+});


### PR DESCRIPTION
修复内容：

- 鼠标按下和拖选期间继续暂停详情同步，避免拖动过程中反复刷新
- 鼠标松开结束选择后，根据最终选中单元格更新已展开的详情
- 保留方向键切换和详情编辑状态下的现有行为
- 增加回归测试，确保拖选结束状态参与详情同步

验证：

- `pnpm -s vitest run apps/desktop/src/components/grid/__tests__/DataGridCellDetailSelection.spec.ts apps/desktop/src/composables/__tests__/useDataGridSelection.spec.ts`
- `pnpm -s typecheck`
- `pnpm -s lint`（通过，仅有现有警告）
- `make dev-fast` 构建并启动成功

Fixes #5869