### PR TITLE
Fix：修复新建表 SQL 预览闪屏

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
+++ b/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
@@ -362,6 +362,36 @@ describe("TableStructureEditor primary key editing", () => {
       }),
     );
   });
+
+  it("keeps the current SQL preview visible while a newer preview is loading", async () => {
+    const root = await mountEditor("dameng", true);
+    const primaryKey = columnCheckbox(root, "structureEditor.primaryKey");
+    const nullable = columnCheckbox(root, "structureEditor.nullable");
+    const firstSql = "ALTER TABLE users DROP CONSTRAINT users_pkey;";
+
+    mocks.buildTableStructureChangeSql.mockResolvedValueOnce({ statements: [firstSql], warnings: [] });
+    primaryKey.checked = false;
+    primaryKey.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => expect(root.textContent).toContain(firstSql));
+
+    let resolveLatestPreview!: (value: { statements: string[]; warnings: string[] }) => void;
+    mocks.buildTableStructureChangeSql.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLatestPreview = resolve;
+        }),
+    );
+    nullable.checked = true;
+    nullable.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => expect(mocks.buildTableStructureChangeSql).toHaveBeenCalledTimes(2));
+    expect(root.textContent).toContain(firstSql);
+    expect(root.textContent).not.toContain("structureEditor.noChanges");
+
+    resolveLatestPreview({ statements: ["ALTER TABLE users ALTER COLUMN id DROP NOT NULL;"], warnings: [] });
+    await vi.waitFor(() => expect(root.textContent).toContain("ALTER TABLE users ALTER COLUMN id DROP NOT NULL;"));
+  });
 });
 
 describe("TableStructureEditor local column order notice", () => {

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -1119,10 +1119,10 @@ function scheduleSqlPreviewRefresh() {
   }
   sqlPreviewRequestId++;
   deferredSqlPreviewRefresh = false;
-  pendingStatements.value = [];
-  warnings.value = [];
-  sqliteSchemaRevision.value = undefined;
   if (!hasPendingStructureChanges()) {
+    pendingStatements.value = [];
+    warnings.value = [];
+    sqliteSchemaRevision.value = undefined;
     sqlPreviewLoading.value = false;
     return;
   }


### PR DESCRIPTION
## 变更内容

- SQL 预览刷新期间保留当前 SQL 和警告内容，避免编辑表名、字段等内容时预览区短暂清空
- 仅在表结构确实没有待处理变更时清空预览状态
- 增加延迟返回场景的组件回归测试，确保新预览加载期间旧 SQL 保持可见

## 验证

- PostgreSQL 新建表页面实际验证：连续编辑表名时，SQL 预览不再切换为“暂无变更”
- 组件及关联超时用例：46 passed
- 格式检查、lint、TypeScript 类型检查通过

Fixes #5882