### PR TITLE
fix: GaussDB M模式类型显示支持

### DIFF
--- a/agents/common/src/main/java/com/dbx/agent/ConfiguredJdbcAgent.java
+++ b/agents/common/src/main/java/com/dbx/agent/ConfiguredJdbcAgent.java
@@ -115,7 +115,7 @@ public abstract class ConfiguredJdbcAgent extends AbstractJdbcAgent {
 
     @Override
     public List<IndexInfo> listIndexes(String schema, String table) {
-        return StandardJdbcMetadata.INSTANCE.listIndexes(requireConnection(), schema, table);
+        return StandardJdbcMetadata.INSTANCE.listIndexes(requireConnection(), configuredDatabase, schema, table);
     }
 
     @Override

--- a/agents/common/src/main/java/com/dbx/agent/ConfiguredJdbcAgent.java
+++ b/agents/common/src/main/java/com/dbx/agent/ConfiguredJdbcAgent.java
@@ -115,7 +115,7 @@ public abstract class ConfiguredJdbcAgent extends AbstractJdbcAgent {
 
     @Override
     public List<IndexInfo> listIndexes(String schema, String table) {
-        return StandardJdbcMetadata.INSTANCE.listIndexes(requireConnection(), configuredDatabase, schema, table);
+        return StandardJdbcMetadata.INSTANCE.listIndexes(requireConnection(), profile, configuredDatabase, schema, table);
     }
 
     @Override

--- a/agents/common/src/main/java/com/dbx/agent/StandardJdbcMetadata.java
+++ b/agents/common/src/main/java/com/dbx/agent/StandardJdbcMetadata.java
@@ -207,10 +207,16 @@ public final class StandardJdbcMetadata {
         });
     }
 
-    public List<IndexInfo> listIndexes(Connection conn, String configuredDatabase, String schema, String table) {
+    public List<IndexInfo> listIndexes(
+        Connection conn,
+        JdbcAgentProfile profile,
+        String configuredDatabase,
+        String schema,
+        String table
+    ) {
         return unchecked(() -> {
             List<IndexInfo> result = listIndexesInternal(conn, null, schema, table);
-            if (result.isEmpty() && hasConfiguredDatabase(configuredDatabase)) {
+            if (result.isEmpty() && profile.getCatalogFallbackEnabled() && hasConfiguredDatabase(configuredDatabase)) {
                 result = listIndexesInternal(conn, configuredDatabase, schema, table);
             }
             return result;

--- a/agents/common/src/main/java/com/dbx/agent/StandardJdbcMetadata.java
+++ b/agents/common/src/main/java/com/dbx/agent/StandardJdbcMetadata.java
@@ -207,12 +207,22 @@ public final class StandardJdbcMetadata {
         });
     }
 
-    public List<IndexInfo> listIndexes(Connection conn, String schema, String table) {
+    public List<IndexInfo> listIndexes(Connection conn, String configuredDatabase, String schema, String table) {
+        return unchecked(() -> {
+            List<IndexInfo> result = listIndexesInternal(conn, null, schema, table);
+            if (result.isEmpty() && hasConfiguredDatabase(configuredDatabase)) {
+                result = listIndexesInternal(conn, configuredDatabase, schema, table);
+            }
+            return result;
+        });
+    }
+
+    private List<IndexInfo> listIndexesInternal(Connection conn, String catalog, String schema, String table) {
         return unchecked(() -> {
             DatabaseMetaData meta = conn.getMetaData();
             Map<String, List<IndexColumn>> indexes = new LinkedHashMap<>();
             Map<String, Boolean> unique = new LinkedHashMap<>();
-            try (ResultSet rs = meta.getIndexInfo(null, blankToNull(schema), table, false, false)) {
+            try (ResultSet rs = meta.getIndexInfo(blankToNull(catalog), blankToNull(schema), table, false, false)) {
                 while (rs.next()) {
                     String name = rs.getString("INDEX_NAME");
                     String column = rs.getString("COLUMN_NAME");

--- a/agents/common/src/test/java/com/dbx/agent/StandardJdbcMetadataTest.java
+++ b/agents/common/src/test/java/com/dbx/agent/StandardJdbcMetadataTest.java
@@ -419,11 +419,60 @@ class StandardJdbcMetadataTest {
             rows()
         );
 
-        List<IndexInfo> indexes = StandardJdbcMetadata.INSTANCE.listIndexes(conn, null, "APP", "ORDERS");
+        List<IndexInfo> indexes = StandardJdbcMetadata.INSTANCE.listIndexes(conn, profile, null, "APP", "ORDERS");
 
         assertEquals(1, indexes.size());
         assertEquals(Arrays.asList("A", "B"), indexes.get(0).getColumns());
         assertFalse(indexes.get(0).getIs_unique());
+    }
+
+    @Test
+    void listIndexesUsesConfiguredCatalogOnlyWhenProfileAllowsFallback() {
+        Connection enabledConn = catalogIndexFallbackConnection(
+            "TENANTDB",
+            rows(),
+            rows(row("INDEX_NAME", "IDX_ORDERS", "COLUMN_NAME", "ID", "ORDINAL_POSITION", (short) 1, "NON_UNIQUE", false))
+        );
+
+        List<IndexInfo> enabledIndexes = StandardJdbcMetadata.INSTANCE.listIndexes(
+            enabledConn,
+            profile,
+            "TENANTDB",
+            "APP",
+            "ORDERS"
+        );
+
+        assertEquals(1, enabledIndexes.size());
+
+        JdbcAgentProfile fallbackDisabledProfile = new JdbcAgentProfile(
+            "example.Driver",
+            "jdbc:example://{host}:{port}/{database}",
+            0,
+            false,
+            Collections.emptySet(),
+            Collections.singletonList("TABLE"),
+            "\"",
+            "SET SCHEMA",
+            false,
+            false,
+            false,
+            false
+        );
+        Connection disabledConn = catalogIndexFallbackConnection(
+            "TENANTDB",
+            rows(),
+            rows(row("INDEX_NAME", "IDX_ORDERS", "COLUMN_NAME", "ID", "ORDINAL_POSITION", (short) 1, "NON_UNIQUE", false))
+        );
+
+        List<IndexInfo> disabledIndexes = StandardJdbcMetadata.INSTANCE.listIndexes(
+            disabledConn,
+            fallbackDisabledProfile,
+            "TENANTDB",
+            "APP",
+            "ORDERS"
+        );
+
+        assertTrue(disabledIndexes.isEmpty());
     }
 
     @Test
@@ -661,6 +710,31 @@ class StandardJdbcMetadataTest {
                 }
                 if ("getCatalog".equals(method.getName())) {
                     return null;
+                }
+                return defaultValue(method.getReturnType());
+            }
+        });
+    }
+
+    private static Connection catalogIndexFallbackConnection(
+        String fallbackCatalog,
+        ResultSet defaultIndexes,
+        ResultSet fallbackIndexes
+    ) {
+        DatabaseMetaData meta = proxy(DatabaseMetaData.class, new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                if ("getIndexInfo".equals(method.getName())) {
+                    return fallbackCatalog.equals(args[0]) ? fallbackIndexes : defaultIndexes;
+                }
+                return defaultValue(method.getReturnType());
+            }
+        });
+        return proxy(Connection.class, new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                if ("getMetaData".equals(method.getName())) {
+                    return meta;
                 }
                 return defaultValue(method.getReturnType());
             }

--- a/agents/common/src/test/java/com/dbx/agent/StandardJdbcMetadataTest.java
+++ b/agents/common/src/test/java/com/dbx/agent/StandardJdbcMetadataTest.java
@@ -419,7 +419,7 @@ class StandardJdbcMetadataTest {
             rows()
         );
 
-        List<IndexInfo> indexes = StandardJdbcMetadata.INSTANCE.listIndexes(conn, "APP", "ORDERS");
+        List<IndexInfo> indexes = StandardJdbcMetadata.INSTANCE.listIndexes(conn, null, "APP", "ORDERS");
 
         assertEquals(1, indexes.size());
         assertEquals(Arrays.asList("A", "B"), indexes.get(0).getColumns());

--- a/agents/drivers/tdengine/tests/live.rs
+++ b/agents/drivers/tdengine/tests/live.rs
@@ -89,7 +89,7 @@ fn tdengine_websocket_live_compatibility() {
                 format!("CREATE DATABASE IF NOT EXISTS {database}"),
                 format!("CREATE STABLE IF NOT EXISTS {database}.meters (ts TIMESTAMP, current FLOAT, voltage INT, active BOOL, note NCHAR(32)) TAGS (location NCHAR(64), group_id INT)"),
                 format!("CREATE TABLE IF NOT EXISTS {database}.d1001 USING {database}.meters TAGS ('California.SanFrancisco', 2)"),
-                format!("INSERT INTO {database}.d1001 VALUES ('2026-08-04 10:00:00.001', 10.1, 220, true, 'first') ('2026-08-04 10:00:00.002', 10.2, 221, false, 'second') ('2026-08-04 10:00:00.003', 10.3, 222, true, 'third')")
+                format!("INSERT INTO {database}.d1001 VALUES (1785808800001, 10.1, 220, true, 'first') (1785808800002, 10.2, 221, false, 'second') (1785808800003, 10.3, 222, true, 'third')")
             ]
         }),
     );

--- a/agents/metadata-constraint-coverage.tsv
+++ b/agents/metadata-constraint-coverage.tsv
@@ -10,6 +10,7 @@ gbase8s	native-pushdown	java-sql	Uses systables with type, filter, stable order,
 goldendb	native-pushdown	java-sql	Uses information_schema with type, filter, stable order, and LIMIT/OFFSET.
 h2	native-pushdown	java-sql	Uses INFORMATION_SCHEMA with type, filter, stable order, and LIMIT/OFFSET.
 hive	intentional-fallback	java-sql	Uses Hive metadata paths where stable server-side fuzzy paging is not portable, common constraints filter locally.
+hive-go	shared-fallback	native-go	Uses HiveServer2 metadata APIs, then applies stable filtering and paging in the native agent with a SHOW TABLES fallback.
 informix	native-pushdown	java-sql	Uses systables/sysprocedures with type, filter, stable order, and SKIP/FIRST.
 iotdb	shared-fallback	native-go	Uses SHOW DEVICES or SHOW TABLES DETAILS for Tree/Table metadata, then applies stable filtering and paging in the native agent.
 kingbase-go	shared-fallback	native-go	Uses sys_catalog/information_schema for compatibility-aware metadata, then applies stable filtering and paging in the native agent.

--- a/apps/desktop/src/components/editor/ColumnInfoPanel.vue
+++ b/apps/desktop/src/components/editor/ColumnInfoPanel.vue
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/composables/useToast";
 import { copyToClipboard } from "@/lib/common/clipboard";
+import { gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
+import type { DatabaseType } from "@/types/database";
 
 export interface ColumnInfo {
   name: string;
@@ -17,10 +19,12 @@ export interface ColumnInfo {
   extra?: string | null;
 }
 
-defineProps<{
+const props = defineProps<{
   columns: ColumnInfo[];
   loading: boolean;
   error?: string;
+  databaseType?: DatabaseType;
+  isGaussdbM?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -29,6 +33,14 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const { toast } = useToast();
+
+function displayDataType(dataType: string | undefined): string {
+  if (!dataType) return "—";
+  if (props.databaseType === "gaussdb" && props.isGaussdbM) {
+    return gaussdbMTypeDisplayName(dataType);
+  }
+  return dataType;
+}
 
 async function copyText(text: string) {
   try {
@@ -81,8 +93,8 @@ async function copyText(text: string) {
           <div class="rounded-md border border-border divide-y divide-border text-xs">
             <div class="flex items-center justify-between px-2 py-1">
               <span class="text-muted-foreground">{{ t("grid.columnType") }}</span>
-              <span class="font-medium max-w-[180px] truncate" :title="col.dataType">
-                {{ col.dataType || "—" }}
+              <span class="font-medium max-w-[180px] truncate" :title="displayDataType(col.dataType)">
+                {{ displayDataType(col.dataType) }}
               </span>
             </div>
             <div class="flex items-center justify-between px-2 py-1">

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -241,6 +241,7 @@ import {
 import { getTableMetadataCapabilities } from "@/lib/table/tableMetadataCapabilities";
 import { getTableStructureCapabilities } from "@/lib/table/tableStructureCapabilities";
 import { filterObjectBrowserTableColumns } from "@/lib/table/objectBrowserTableInfo";
+import { gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
 import { reserveDataGridHeaderLine } from "@/lib/dataGrid/dataGridHeaderLayout";
 import { buildColumnIndexMap, columnIndexMetadataRequestCurrent, columnIndexNameKey, columnIndexTableIdentity } from "@/lib/dataGrid/dataGridColumnIndexIcon";
 import { supportsTableStructureEditing } from "@/lib/database/databaseCapabilities";
@@ -357,7 +358,11 @@ interface DataGridProps {
   onExecuteSql?: (sql: string) => Promise<void>;
   fullExportResult?: (onProgress?: (info: { rowsExported: number; totalRows: number | null }) => void) => Promise<QueryResult | undefined>;
   queryResultExportRequest?: (options: { exportId: string; filePath: string; format: "csv" | "xlsx" | "txt" | "sql"; includeSqlSheet?: boolean; exportTableName?: string; exportColumnTypes?: Array<string | null | undefined> }) => Promise<api.QueryResultExportRequest | undefined>;
-  allExportResults?: Array<{ sheetName: string; result: QueryResult; sql?: string }>;
+  allExportResults?: Array<{
+    sheetName: string;
+    result: QueryResult;
+    sql?: string;
+  }>;
   exportFileBaseName?: string;
   customSaveHandler?: import("@/composables/useDataGridEditor").CustomSaveHandler;
   mongoUpdateTarget?: MongoCopyUpdateTarget;
@@ -403,7 +408,10 @@ const emit = defineEmits<{
   "local-column-filters-change": [value: Record<string, string[]>];
 }>();
 
-const autoRefresh = useDataGridAutoRefresh({ canRefresh: computed(() => !isSaving.value && !props.loading), refresh: onToolbarRefresh });
+const autoRefresh = useDataGridAutoRefresh({
+  canRefresh: computed(() => !isSaving.value && !props.loading),
+  refresh: onToolbarRefresh,
+});
 const autoRefreshIntervalSeconds = autoRefresh.intervalSeconds;
 const autoRefreshEnabled = autoRefresh.enabled;
 const autoRefreshLabel = computed(() => (autoRefreshEnabled.value ? t("tabs.autoRefreshEvery", { seconds: autoRefreshIntervalSeconds.value }) : t("tabs.autoRefresh")));
@@ -422,7 +430,10 @@ if (isDebugLoggingEnabled()) {
 const transposeRowIndex = ref<number | null>(null);
 const showTranspose = ref(false);
 const preserveTransposeOnNextResult = ref(false);
-let preservedSelectionOnNextResult: { selection: PersistedDataGridSelection; sourceResult: QueryResult } | null = null;
+let preservedSelectionOnNextResult: {
+  selection: PersistedDataGridSelection;
+  sourceResult: QueryResult;
+} | null = null;
 
 watch(
   () => props.result,
@@ -462,7 +473,15 @@ watch(
 watch(
   () => props.result,
   (result) => {
-    if (!shouldAutoTransposeSingleRow({ enabled: !!props.autoTransposeSingleRow, preserveTranspose: preserveTransposeOnNextResult.value, rowCount: result.rows.length, columnCount: result.columns.length })) return;
+    if (
+      !shouldAutoTransposeSingleRow({
+        enabled: !!props.autoTransposeSingleRow,
+        preserveTranspose: preserveTransposeOnNextResult.value,
+        rowCount: result.rows.length,
+        columnCount: result.columns.length,
+      })
+    )
+      return;
     nextTick(() => {
       if (props.result !== result || !props.autoTransposeSingleRow || result.rows.length !== 1 || result.columns.length <= 1) return;
       applyTransposeState({ showTranspose: true, transposeRowIndex: 0 }, "start");
@@ -568,7 +587,24 @@ function shortTypeName(t: string): string {
   if (s === "integer") return "int";
   if (s === "smallint") return "int2";
   if (s === "real") return "float4";
+  // GaussDB M mode uses MySQL-style type names
+  if (resolvedDatabaseType.value === "gaussdb") {
+    const conn = resolvedConnectionConfig.value;
+    if (conn?.driver_profile?.toLowerCase() === "gaussdb-m") {
+      return gaussdbMTypeDisplayName(t);
+    }
+  }
   return t;
+}
+
+function gaussdbMColumnType(dataType: string): string {
+  if (resolvedDatabaseType.value === "gaussdb") {
+    const conn = resolvedConnectionConfig.value;
+    if (conn?.driver_profile?.toLowerCase() === "gaussdb-m") {
+      return gaussdbMTypeDisplayName(dataType);
+    }
+  }
+  return dataType;
 }
 
 function headerColumnSortable(actualColIdx: number): boolean {
@@ -581,7 +617,12 @@ function columnIsSorted(column: string, columnIndex: number): boolean {
 }
 
 function currentColumnSortState(): DataGridColumnSortState {
-  return { column: sortCol.value, columnIndex: sortColIndex.value, direction: sortDir.value, mode: sortMode.value };
+  return {
+    column: sortCol.value,
+    columnIndex: sortColIndex.value,
+    direction: sortDir.value,
+    mode: sortMode.value,
+  };
 }
 
 function sortMenuItems(column: string, columnIndex: number) {
@@ -596,7 +637,12 @@ function sortMenuItems(column: string, columnIndex: number) {
       currentPageDescending: t("grid.sortCurrentPageDescending"),
       clear: t("grid.clearSort"),
     },
-    icons: { database: Database, ascending: ArrowUp, descending: ArrowDown, clear: Eraser },
+    icons: {
+      database: Database,
+      ascending: ArrowUp,
+      descending: ArrowDown,
+      clear: Eraser,
+    },
   });
 }
 
@@ -623,7 +669,11 @@ function typeColorClass(t: string): string {
   if (["geometry", "geography", "sdo_geometry"].includes(base)) return "text-emerald-500";
   return "text-muted-foreground";
 }
-const contextCell = ref<{ rowId: number; rowIndex: number; col: number } | null>(null);
+const contextCell = ref<{
+  rowId: number;
+  rowIndex: number;
+  col: number;
+} | null>(null);
 // True when onCellContext created a synthetic single-cell selection (the cell
 // was not previously selected). Lets buildRequest distinguish a genuine 1×1
 // selection (user Ctrl+click) from a synthetic one (right-click on unselected).
@@ -672,7 +722,10 @@ const cellDetailDialogMounted = useDataGridAsyncSurface(cellDetailDialogOpen);
 const detailDialogsMounted = useDataGridAsyncSurface(computed(() => rowDetailDialogOpen.value || columnDetailDialogOpen.value));
 const imagePreviewMounted = useDataGridAsyncSurface(imagePreviewOpen);
 const previewDialogOpen = ref(false);
-const previewDialogConfig = shallowRef<{ component: any; props: Record<string, any> } | null>(null);
+const previewDialogConfig = shallowRef<{
+  component: any;
+  props: Record<string, any>;
+} | null>(null);
 const transposeScrollRef = ref<HTMLElement | { $el?: HTMLElement }>();
 const transposeScrollLeft = ref(0);
 const transposeViewportWidth = ref(0);
@@ -742,9 +795,15 @@ const allFilterModeOptions: Array<{ value: FilterMode; labelKey: string }> = [
   { value: "like", labelKey: "grid.filterBuilderContains" },
   { value: "not-like", labelKey: "grid.filterBuilderNotContains" },
   { value: "greater-than", labelKey: "grid.filterBuilderGreaterThan" },
-  { value: "greater-than-or-equal", labelKey: "grid.filterBuilderGreaterThanOrEqual" },
+  {
+    value: "greater-than-or-equal",
+    labelKey: "grid.filterBuilderGreaterThanOrEqual",
+  },
   { value: "less-than", labelKey: "grid.filterBuilderLessThan" },
-  { value: "less-than-or-equal", labelKey: "grid.filterBuilderLessThanOrEqual" },
+  {
+    value: "less-than-or-equal",
+    labelKey: "grid.filterBuilderLessThanOrEqual",
+  },
   { value: "in", labelKey: "grid.filterBuilderIn" },
   { value: "not-in", labelKey: "grid.filterBuilderNotIn" },
   { value: "between", labelKey: "grid.filterBuilderBetween" },
@@ -832,7 +891,10 @@ const localFilterSummaries = computed(() =>
       .map(([columnIndexText, selected]) => {
         const columnIndex = Number(columnIndexText);
         const labelByKey = new Map(buildLocalFilterOptions(columnIndex).map((option) => [option.key, option.label]));
-        return { columnIndex, values: [...selected].map((key) => labelByKey.get(key) ?? key) };
+        return {
+          columnIndex,
+          values: [...selected].map((key) => labelByKey.get(key) ?? key),
+        };
       }),
     ...Object.entries(serverColumnFilters.value).map(([columnIndexText, filter]) => ({
       columnIndex: Number(columnIndexText),
@@ -875,7 +937,12 @@ function buildLocalFilterOptions(columnIndex: number): LocalFilterOption[] {
     if (current) {
       current.count = (current.count ?? 0) + 1;
     } else {
-      byKey.set(key, { key, label: localFilterLabel(value, columnIndex), count: 1, value });
+      byKey.set(key, {
+        key,
+        label: localFilterLabel(value, columnIndex),
+        count: 1,
+        value,
+      });
     }
   };
 
@@ -889,7 +956,10 @@ function buildLocalFilterOptions(columnIndex: number): LocalFilterOption[] {
   return [...byKey.values()].sort((a, b) => {
     if (a.value === null && b.value !== null) return -1;
     if (a.value !== null && b.value === null) return 1;
-    return a.label.localeCompare(b.label, undefined, { numeric: true, sensitivity: "base" });
+    return a.label.localeCompare(b.label, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
   });
 }
 
@@ -1070,7 +1140,11 @@ function openCompactLocalFilter(colIdx: number, mode: LocalFilterMode = "local")
 
 function compactColumnActionMenuItems(columnName: string) {
   return createDataGridCompactColumnActionItems({
-    labels: { formatter: t("grid.columnFormatter"), localFilter: t("grid.localFilter"), serverFilter: t("grid.databaseValueFilter") },
+    labels: {
+      formatter: t("grid.columnFormatter"),
+      localFilter: t("grid.localFilter"),
+      serverFilter: t("grid.databaseValueFilter"),
+    },
     icons: { formatter: Code2, filter: Filter, database: Database },
     formatterAvailable: !!formatterKeyForColumn(columnName),
     serverFilterAvailable: canUseServerColumnFilter.value,
@@ -1150,13 +1224,26 @@ function currentFormatterDraft(): ColumnFormatterConfig {
     };
   }
   if (formatterKind.value === "custom-template") {
-    return { kind: "custom-template", template: formatterCustomTemplate.value.trim() || "${value}" };
+    return {
+      kind: "custom-template",
+      template: formatterCustomTemplate.value.trim() || "${value}",
+    };
   }
-  return { kind: "datetime", unit: formatterDateUnit.value, pattern: formatterDatetimePattern.value, timezone: formatterDateTimezone.value };
+  return {
+    kind: "datetime",
+    unit: formatterDateUnit.value,
+    pattern: formatterDatetimePattern.value,
+    timezone: formatterDateTimezone.value,
+  };
 }
 
 function loadFormatterDraft(formatter: ColumnFormatterConfig | undefined) {
-  const draft = formatter ?? { kind: "datetime", unit: "auto" as const, pattern: "YYYY-MM-DD HH:mm:ss" as const, timezone: dayjs.tz.guess() };
+  const draft = formatter ?? {
+    kind: "datetime",
+    unit: "auto" as const,
+    pattern: "YYYY-MM-DD HH:mm:ss" as const,
+    timezone: dayjs.tz.guess(),
+  };
   formatterKind.value = draft.kind === "custom-ref" ? "custom-template" : draft.kind;
   if (draft.kind === "datetime") {
     formatterDateUnit.value = draft.unit;
@@ -2375,7 +2462,11 @@ let infiniteScrollPositions = new WeakMap<HTMLElement, DataGridScrollPosition>()
 
 function updateDomGridVisibleItemsDuringScroll(scroller: HTMLElement) {
   if (useCanvasGridRows.value || scroller !== gridScrollerElement()) return;
-  (scrollerRef.value as { updateVisibleItems?: (itemsChanged: boolean, checkPositionDiff?: boolean) => void } | null)?.updateVisibleItems?.(false, true);
+  (
+    scrollerRef.value as {
+      updateVisibleItems?: (itemsChanged: boolean, checkPositionDiff?: boolean) => void;
+    } | null
+  )?.updateVisibleItems?.(false, true);
 }
 
 function markGridScrolling() {
@@ -2876,7 +2967,12 @@ async function lastPage() {
       // Keep the busy overlay until the parent query loading flag can take over.
       await nextTick();
     } catch (e: any) {
-      toast(t("grid.calculateTotalRowsFailed", { message: e?.message || String(e) }), 5000);
+      toast(
+        t("grid.calculateTotalRowsFailed", {
+          message: e?.message || String(e),
+        }),
+        5000,
+      );
     } finally {
       manualTotalRowCountLoading.value = false;
     }
@@ -2918,7 +3014,10 @@ async function buildCurrentCountTarget(): Promise<{ sql: string; schema?: string
       tableName: props.tableMeta.tableName,
       whereInput: currentWhereInput(),
     });
-    return { sql, schema: props.context === "table-data" ? undefined : (props.tableMeta.schema ?? props.schema) };
+    return {
+      sql,
+      schema: props.context === "table-data" ? undefined : (props.tableMeta.schema ?? props.schema),
+    };
   }
   return undefined;
 }
@@ -3074,7 +3173,10 @@ const {
   isPreviewLoading,
   previewChanges,
 } = editor;
-const pendingQuickEntryDraftCellFocus = ref<{ rowId: number; col: number } | null>(null);
+const pendingQuickEntryDraftCellFocus = ref<{
+  rowId: number;
+  col: number;
+} | null>(null);
 const batchAppendPasteRowId = ref<number | null>(null);
 
 const showSqlPreview = ref(false);
@@ -3207,7 +3309,15 @@ function startCellEdit(rowId: number, columnIndex: number, expanded: boolean) {
 function startDomCellEdit(rowId: number, columnIndex: number, displayText: string, event: MouseEvent) {
   const item = getRowItem(rowId);
   const editText = item ? cellEditorTextForValue(item.data[columnIndex], columnIndex) : displayText;
-  startCellEdit(rowId, columnIndex, cellEditContentNeedsExpandedEditor({ displayText, editText, target: event.currentTarget }));
+  startCellEdit(
+    rowId,
+    columnIndex,
+    cellEditContentNeedsExpandedEditor({
+      displayText,
+      editText,
+      target: event.currentTarget,
+    }),
+  );
 }
 
 function showReadonlyCellDetailsOnDblClick(item: RowItem, rowIndex: number, visibleColIdx: number, actualColIdx: number): boolean {
@@ -3511,9 +3621,24 @@ const addRowToolbarCapability = computed<DataGridToolbarAddRowCapability>(() => 
   visible: canInsertRows.value,
   items: [
     { value: "insert-multiple", label: t("grid.insertMultipleRows") },
-    { value: "position-above", label: t("grid.insertPositionAbove"), separatorBefore: true, selected: insertPosition.value === "above", disabled: !canPlaceInsertAtSelection.value },
-    { value: "position-below", label: t("grid.insertPositionBelow"), selected: insertPosition.value === "below", disabled: !canPlaceInsertAtSelection.value },
-    { value: "position-end", label: t("grid.insertPositionEnd"), selected: insertPosition.value === "end" },
+    {
+      value: "position-above",
+      label: t("grid.insertPositionAbove"),
+      separatorBefore: true,
+      selected: insertPosition.value === "above",
+      disabled: !canPlaceInsertAtSelection.value,
+    },
+    {
+      value: "position-below",
+      label: t("grid.insertPositionBelow"),
+      selected: insertPosition.value === "below",
+      disabled: !canPlaceInsertAtSelection.value,
+    },
+    {
+      value: "position-end",
+      label: t("grid.insertPositionEnd"),
+      selected: insertPosition.value === "end",
+    },
   ],
   onTrigger: addRow,
   onSelect: handleAddRowMenuSelect,
@@ -3546,7 +3671,9 @@ const previewToolbarCapability = computed<DataGridToolbarActionCapability>(() =>
 }));
 const saveToolbarCapability = computed<DataGridToolbarSaveCapability>(() => ({
   label: t(saveActionMode.value.labelKey, { count: pendingChangeCount.value }),
-  tooltip: t(saveActionMode.value.tooltipKey, { count: pendingChangeCount.value }),
+  tooltip: t(saveActionMode.value.tooltipKey, {
+    count: pendingChangeCount.value,
+  }),
   visible: saveToolbarState.value.showActions,
   disabled: saveToolbarState.value.actionsDisabled,
   loading: isSaving.value,
@@ -3598,7 +3725,14 @@ const displayRowRefs = computed<DisplayRowRef[]>(() => {
       const status: RowStatus = isDeleted ? "deleted" : dirty?.size ? "edited" : "clean";
       const isActiveEditingRow = quickEntryEnabled.value && editingCell.value?.rowId === sourceIndex;
       if (matchesRowStatusFilter(status, rowStatusFilter.value) || isActiveEditingRow) {
-        refs.push({ id: sourceIndex, displayIndex: refs.length, sourceIndex, isNew: false, isDeleted, status });
+        refs.push({
+          id: sourceIndex,
+          displayIndex: refs.length,
+          sourceIndex,
+          isNew: false,
+          isDeleted,
+          status,
+        });
       }
     } else {
       const newIndex = entry.newIndex;
@@ -4192,7 +4326,10 @@ function cellDetailFor(rowIndex: number, columnIndex: number): DataGridCellDetai
     resultColumnTypes: props.result.column_types,
     commentByColumn: columnCommentMap.value,
     displayValue: (value, index) => formatCellCached(value, index),
-    isEditable: canEditGridCellDetail({ canEditCell: canEditCellItem(item, columnIndex), isDraft: !!item.isDraft }),
+    isEditable: canEditGridCellDetail({
+      canEditCell: canEditCellItem(item, columnIndex),
+      isDraft: !!item.isDraft,
+    }),
   });
 }
 
@@ -4260,7 +4397,11 @@ const rowDetail = computed(() => {
     resultColumnTypes: props.result.column_types,
     commentByColumn: columnCommentMap.value,
     displayValue: (value, index) => formatCellCached(value, index),
-    isEditableColumn: (columnIndex) => canEditGridCellDetail({ canEditCell: canEditCellItem(item, columnIndex), isDraft: !!item.isDraft }),
+    isEditableColumn: (columnIndex) =>
+      canEditGridCellDetail({
+        canEditCell: canEditCellItem(item, columnIndex),
+        isDraft: !!item.isDraft,
+      }),
   });
 });
 
@@ -4274,7 +4415,10 @@ const columnDetail = computed(() => {
         rowIndex: item.displayIndex,
         rowId: item.id,
         row: item.data,
-        isEditable: canEditGridCellDetail({ canEditCell: canEditCellItem(item, columnIndex), isDraft: !!item.isDraft }),
+        isEditable: canEditGridCellDetail({
+          canEditCell: canEditCellItem(item, columnIndex),
+          isDraft: !!item.isDraft,
+        }),
       })),
     columns: props.result.columns,
     columnIndex,
@@ -4363,7 +4507,10 @@ function syncPendingDataEditorDraft(pending: boolean) {
   if (tab?.mode === "data") tab.hasPendingDataEditorDraft = pending || undefined;
 }
 
-watch(hasPendingDataEditorDraft, syncPendingDataEditorDraft, { immediate: true, flush: "sync" });
+watch(hasPendingDataEditorDraft, syncPendingDataEditorDraft, {
+  immediate: true,
+  flush: "sync",
+});
 
 const activeValueEditorActions = computed(() => {
   const detail = activeCellDetail.value;
@@ -4568,11 +4715,15 @@ function warnFormattedJsonEditIfNeeded(detail: DataGridCellDetail, force = false
 }
 
 function toggleCellDetailJsonFormatted() {
-  settingsStore.updateEditorSettings({ cellDetailJsonFormatted: !cellDetailJsonFormatted.value });
+  settingsStore.updateEditorSettings({
+    cellDetailJsonFormatted: !cellDetailJsonFormatted.value,
+  });
 }
 
 function toggleCellDetailMetadataCollapsed() {
-  settingsStore.updateEditorSettings({ cellDetailMetadataCollapsed: !cellDetailMetadataCollapsed.value });
+  settingsStore.updateEditorSettings({
+    cellDetailMetadataCollapsed: !cellDetailMetadataCollapsed.value,
+  });
 }
 
 function startDetailEdit() {
@@ -4888,7 +5039,13 @@ function formatCell(value: CellValue, columnIndex?: number): string {
   const columnName = columnIndex === undefined ? undefined : props.result.columns[columnIndex];
   const columnInfo = columnIndex === undefined ? undefined : tableColumnForGridColumn(columnIndex);
   const displayColumnInfo = columnInfo ?? (columnIndex === undefined ? undefined : resultColumnInfoForGridColumn(columnIndex));
-  const arrayDisplay = formatter ? undefined : dataGridCellDisplayText({ value, databaseType: props.databaseType, columnInfo: displayColumnInfo });
+  const arrayDisplay = formatter
+    ? undefined
+    : dataGridCellDisplayText({
+        value,
+        databaseType: props.databaseType,
+        columnInfo: displayColumnInfo,
+      });
   if (arrayDisplay !== undefined) return arrayDisplay;
   const binaryDisplay = formatter ? null : binaryCellDisplayText(value, columnInfo?.data_type ?? (columnName ? columnTypeMap.value.get(columnName) : undefined));
   if (binaryDisplay) return binaryDisplay;
@@ -5340,7 +5497,13 @@ function onCanvasMouseMove(event: MouseEvent) {
   }
   const hit = canvasHitTest(event);
   const hitItem = hit ? displayItemAt(hit.rowIndex) : undefined;
-  const next = hit && hitItem ? { rowIndex: hitItem.displayIndex, visibleColIdx: hit.rowNumber ? -1 : hit.visibleColIdx } : null;
+  const next =
+    hit && hitItem
+      ? {
+          rowIndex: hitItem.displayIndex,
+          visibleColIdx: hit.rowNumber ? -1 : hit.visibleColIdx,
+        }
+      : null;
   const actualColIdx = next ? visibleColumnIndexes.value[next.visibleColIdx] : undefined;
   if (canvasRef.value) {
     const overBooleanInteractive =
@@ -5375,7 +5538,10 @@ function onCanvasMouseLeave(event?: MouseEvent) {
 function keepCanvasDetailHover() {
   const cell = canvasDetailButtonCell.value;
   if (!cell) return;
-  canvasHoverCell.value = { rowIndex: cell.rowIndex, visibleColIdx: cell.visibleColIdx };
+  canvasHoverCell.value = {
+    rowIndex: cell.rowIndex,
+    visibleColIdx: cell.visibleColIdx,
+  };
   hoveredDetailCell.value = { rowIndex: cell.rowIndex, col: cell.actualColIdx };
   scheduleCanvasDraw();
 }
@@ -5394,7 +5560,15 @@ function booleanCheckboxHitFromCanvasEvent(item: RowItem, hit: { rowIndex: numbe
   const canvasRect = canvas?.getBoundingClientRect();
   const cellRect = canvasCellViewportRect(hit.rowIndex, hit.visibleColIdx);
   if (!canvasRect || !cellRect) return false;
-  return isPointInBooleanCheckbox({ x: event.clientX - canvasRect.left, y: event.clientY - canvasRect.top }, { left: cellRect.left, top: cellRect.top, width: cellRect.width, height: cellRect.height });
+  return isPointInBooleanCheckbox(
+    { x: event.clientX - canvasRect.left, y: event.clientY - canvasRect.top },
+    {
+      left: cellRect.left,
+      top: cellRect.top,
+      width: cellRect.width,
+      height: cellRect.height,
+    },
+  );
 }
 
 function booleanNullTextHitFromCanvasEvent(item: RowItem, hit: { rowIndex: number; visibleColIdx: number }, actualColIdx: number, event: MouseEvent): boolean {
@@ -5536,7 +5710,13 @@ const canvasEditingCell = computed(() => {
   if (rowIndex < 0 || visibleColIdx < 0) return null;
   const rect = canvasCellViewportRect(rowIndex, visibleColIdx);
   if (!rect) return null;
-  return { rowId: editing.rowId, rowIndex, visibleColIdx, actualColIdx: editing.col, rect };
+  return {
+    rowId: editing.rowId,
+    rowIndex,
+    visibleColIdx,
+    actualColIdx: editing.col,
+    rect,
+  };
 });
 
 function canvasEffectiveViewportWidth(): number {
@@ -5588,7 +5768,14 @@ const canvasDetailButtonCell = computed(() => {
   const foreignKey = canvasCellForeignKey(target.rowIndex, target.col);
   const minWidth = canvasDataGridActionOverlayWidth(canQuickDownload, !!foreignKey) + 2;
   if (rect.top < 0 || rect.top > viewportHeight - 1 || visibleRight - visibleLeft < minWidth) return null;
-  return { rowIndex: target.rowIndex, visibleColIdx, actualColIdx: target.col, rect, canQuickDownload, foreignKey };
+  return {
+    rowIndex: target.rowIndex,
+    visibleColIdx,
+    actualColIdx: target.col,
+    rect,
+    canQuickDownload,
+    foreignKey,
+  };
 });
 
 const canvasDetailButtonStyle = computed(() => {
@@ -5665,7 +5852,9 @@ watch(
   },
   { immediate: true },
 );
-watch(showDataGridTopbar, () => nextTick(observeDataGridTopbarWidth), { immediate: true });
+watch(showDataGridTopbar, () => nextTick(observeDataGridTopbarWidth), {
+  immediate: true,
+});
 watch(columnAligns, () => scheduleCanvasDraw());
 watch(booleanDisplayMode, () => scheduleCanvasDraw());
 watch(
@@ -5946,7 +6135,9 @@ function openExtractorConfiguration() {
 function setDefaultCopyPreference(value: string) {
   const item = copyPreferenceMenuItems.value.find((candidate) => candidate.value === value);
   if (!item || item.disabled) return;
-  settingsStore.updateEditorSettings({ dataGridCopyExtractor: item.value as DataGridCopyPreference });
+  settingsStore.updateEditorSettings({
+    dataGridCopyExtractor: item.value as DataGridCopyPreference,
+  });
 }
 
 function sqlInsertExtractorOptions(excludePrimaryKeysFromInsert: boolean) {
@@ -5958,7 +6149,10 @@ function sqlInsertExtractorOptions(excludePrimaryKeysFromInsert: boolean) {
 }
 
 function saveExtractorConfiguration(value: { preference: DataGridCopyPreference; options: typeof settingsStore.editorSettings.dataGridExtractorOptions }) {
-  settingsStore.updateEditorSettings({ dataGridCopyExtractor: value.preference, dataGridExtractorOptions: value.options });
+  settingsStore.updateEditorSettings({
+    dataGridCopyExtractor: value.preference,
+    dataGridExtractorOptions: value.options,
+  });
 }
 
 const pageSizeMenuItems = computed(() =>
@@ -5971,14 +6165,45 @@ const pageSizeMenuItems = computed(() =>
 const exportMenuItems = computed(() => {
   const hasFullResultExport = !!props.fullExportResult;
   const canIncludeSql = props.context === "results" && !!(props.exportSql || props.sql)?.trim();
-  const allResultItems = (props.allExportResults?.length ?? 0) > 1 ? [{ value: "all-results-xlsx", label: t("grid.exportAllResultsXlsx"), separatorBefore: true }, ...(canIncludeSql ? [{ value: "all-results-xlsx-with-sql", label: t("grid.exportAllResultsXlsxWithSql") }] : [])] : [];
+  const allResultItems =
+    (props.allExportResults?.length ?? 0) > 1
+      ? [
+          {
+            value: "all-results-xlsx",
+            label: t("grid.exportAllResultsXlsx"),
+            separatorBefore: true,
+          },
+          ...(canIncludeSql
+            ? [
+                {
+                  value: "all-results-xlsx-with-sql",
+                  label: t("grid.exportAllResultsXlsxWithSql"),
+                },
+              ]
+            : []),
+        ]
+      : [];
   const selectedItems = isMultiRow.value
     ? [
-        { value: "selected-csv", label: t("grid.exportSelectedRowsCsv"), separatorBefore: true },
+        {
+          value: "selected-csv",
+          label: t("grid.exportSelectedRowsCsv"),
+          separatorBefore: true,
+        },
         { value: "selected-xlsx", label: t("grid.exportSelectedRowsXlsx") },
-        ...(canIncludeSql ? [{ value: "selected-xlsx-with-sql", label: t("grid.exportSelectedRowsXlsxWithSql") }] : []),
+        ...(canIncludeSql
+          ? [
+              {
+                value: "selected-xlsx-with-sql",
+                label: t("grid.exportSelectedRowsXlsxWithSql"),
+              },
+            ]
+          : []),
         { value: "selected-json", label: t("grid.exportSelectedRowsJson") },
-        { value: "selected-markdown", label: t("grid.exportSelectedRowsMarkdown") },
+        {
+          value: "selected-markdown",
+          label: t("grid.exportSelectedRowsMarkdown"),
+        },
         { value: "selected-sql", label: t("grid.exportSelectedRowsSql") },
         { value: "selected-txt", label: t("grid.exportSelectedRowsTxt") },
       ]
@@ -6001,14 +6226,32 @@ const exportMenuItems = computed(() => {
   return [
     { value: "page-csv", label: t("grid.exportCurrentPageCsv") },
     { value: "page-xlsx", label: t("grid.exportCurrentPageXlsx") },
-    ...(canIncludeSql ? [{ value: "page-xlsx-with-sql", label: t("grid.exportCurrentPageXlsxWithSql") }] : []),
+    ...(canIncludeSql
+      ? [
+          {
+            value: "page-xlsx-with-sql",
+            label: t("grid.exportCurrentPageXlsxWithSql"),
+          },
+        ]
+      : []),
     { value: "page-json", label: t("grid.exportCurrentPageJson") },
     { value: "page-markdown", label: t("grid.exportCurrentPageMarkdown") },
     { value: "page-sql", label: t("grid.exportCurrentPageSql") },
     { value: "page-txt", label: t("grid.exportCurrentPageTxt") },
-    { value: "csv", label: t("grid.exportCurrentResultCsv"), separatorBefore: true },
+    {
+      value: "csv",
+      label: t("grid.exportCurrentResultCsv"),
+      separatorBefore: true,
+    },
     { value: "xlsx", label: t("grid.exportCurrentResultXlsx") },
-    ...(canIncludeSql ? [{ value: "xlsx-with-sql", label: t("grid.exportCurrentResultXlsxWithSql") }] : []),
+    ...(canIncludeSql
+      ? [
+          {
+            value: "xlsx-with-sql",
+            label: t("grid.exportCurrentResultXlsxWithSql"),
+          },
+        ]
+      : []),
     { value: "json", label: t("grid.exportCurrentResultJson") },
     { value: "markdown", label: t("grid.exportCurrentResultMarkdown") },
     { value: "sql", label: t("grid.exportCurrentResultSql") },
@@ -6196,7 +6439,12 @@ watch([selectedRange, showCellDetail, isEditingDetail], () => {
   const target = linkedCellDetailTarget({
     isOpen: showCellDetail.value,
     isEditing: isEditingDetail.value && activeCellDetailTab.value !== "valueEditor",
-    selectedCell: selectedCell ? { rowIndex: selectedCell.rowIndex, visibleColIndex: selectedCell.colIndex } : null,
+    selectedCell: selectedCell
+      ? {
+          rowIndex: selectedCell.rowIndex,
+          visibleColIndex: selectedCell.colIndex,
+        }
+      : null,
     actualColumnIndex,
   });
   if (!target) return;
@@ -6466,7 +6714,9 @@ function applyGeneratedDetailValue(kind: CellValueGenerationKind, startValue = 1
   const detail = activeCellDetail.value;
   if (!detail?.isEditable) return false;
   const value = generateCellValues(kind, 1, { startValue })[0] ?? null;
-  applyCellValue(detail.rowId, detail.colIndex, value, { preserveEmptyString: kind === "empty" });
+  applyCellValue(detail.rowId, detail.colIndex, value, {
+    preserveEmptyString: kind === "empty",
+  });
   detailEditValue.value = cellDetailEditorText(value);
   syncEditorFromDetailEdit();
   isEditingDetail.value = activeCellDetailTab.value === "valueEditor";
@@ -6496,13 +6746,41 @@ function applyGenerateIncrementValue() {
 
 function generateSelectionMenuItems(disabled: boolean): ContextMenuItem[] {
   return [
-    { label: t("grid.generateEmptyString"), action: () => applyGeneratedSelectionValue("empty"), disabled },
-    { label: t("grid.generateNull"), action: () => applyGeneratedSelectionValue("null"), disabled },
-    { label: t("grid.generateCurrentDatetime"), action: () => applyGeneratedSelectionValue("datetime"), disabled },
-    { label: t("grid.generateCurrentDate"), action: () => applyGeneratedSelectionValue("date"), disabled },
-    { label: t("grid.generateUuid"), action: () => applyGeneratedSelectionValue("uuid"), disabled },
-    { label: t("grid.generateSnowflakeId"), action: () => applyGeneratedSelectionValue("snowflake"), disabled },
-    { label: t("grid.generateIncrementId"), action: () => openGenerateIncrementDialog("selection"), disabled },
+    {
+      label: t("grid.generateEmptyString"),
+      action: () => applyGeneratedSelectionValue("empty"),
+      disabled,
+    },
+    {
+      label: t("grid.generateNull"),
+      action: () => applyGeneratedSelectionValue("null"),
+      disabled,
+    },
+    {
+      label: t("grid.generateCurrentDatetime"),
+      action: () => applyGeneratedSelectionValue("datetime"),
+      disabled,
+    },
+    {
+      label: t("grid.generateCurrentDate"),
+      action: () => applyGeneratedSelectionValue("date"),
+      disabled,
+    },
+    {
+      label: t("grid.generateUuid"),
+      action: () => applyGeneratedSelectionValue("uuid"),
+      disabled,
+    },
+    {
+      label: t("grid.generateSnowflakeId"),
+      action: () => applyGeneratedSelectionValue("snowflake"),
+      disabled,
+    },
+    {
+      label: t("grid.generateIncrementId"),
+      action: () => openGenerateIncrementDialog("selection"),
+      disabled,
+    },
   ];
 }
 
@@ -6557,7 +6835,10 @@ function scrollCellIntoView(rowIndex: number, colIndex: number, block: DataGridS
     requestAnimationFrame(() => {
       const rowEl = gridRef.value?.querySelector<HTMLElement>(`[data-row-index="${rowIndex}"]`);
       const cellEl = rowEl?.querySelector<HTMLElement>(`[data-visible-col-index="${colIndex}"]`);
-      (cellEl ?? rowEl)?.scrollIntoView({ block: previousPageRowIndex === undefined ? block : "nearest", inline: "nearest" });
+      (cellEl ?? rowEl)?.scrollIntoView({
+        block: previousPageRowIndex === undefined ? block : "nearest",
+        inline: "nearest",
+      });
     });
   });
 }
@@ -6837,7 +7118,10 @@ function prepareDataCellMouseDown(item: RowItem, actualColIdx: number) {
   batchAppendPasteRowId.value = null;
   const editing = editingCell.value;
   if (editing?.rowId === quickEntryDraftRowId && item.isDraft && item.id === quickEntryDraftRowId && editing.col !== actualColIdx) {
-    pendingQuickEntryDraftCellFocus.value = { rowId: item.id, col: actualColIdx };
+    pendingQuickEntryDraftCellFocus.value = {
+      rowId: item.id,
+      col: actualColIdx,
+    };
   } else {
     pendingQuickEntryDraftCellFocus.value = null;
     if (editing && (editing.rowId !== item.id || editing.col !== actualColIdx)) {
@@ -7252,7 +7536,13 @@ watch(columnWidthDensity, () => {
   nextTick(updateTransposeViewport);
 });
 const transposePinnedWidthOverride = ref<number | null>(null);
-const transposePinnedWidth = computed(() => transposePinnedWidthOverride.value ?? transposeFieldWidth(visibleColumns.value, { density: columnWidthDensity.value }));
+const transposePinnedWidth = computed(
+  () =>
+    transposePinnedWidthOverride.value ??
+    transposeFieldWidth(visibleColumns.value, {
+      density: columnWidthDensity.value,
+    }),
+);
 const transposeEndSpacerWidth = computed(() => {
   if (!multiRowTranspose.value || displayRowCount.value <= 0) return 0;
   return transposeEndAlignmentSpacerWidth({
@@ -7775,14 +8065,20 @@ function resizeCellEditTextareaElement(textarea: HTMLTextAreaElement | null) {
   }
 }
 
-function cellEditTextMetrics(textarea: HTMLTextAreaElement): { lineHeight: number; verticalChrome: number } {
+function cellEditTextMetrics(textarea: HTMLTextAreaElement): {
+  lineHeight: number;
+  verticalChrome: number;
+} {
   const computedStyle = window.getComputedStyle(textarea);
   const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 18;
   const paddingTop = Number.parseFloat(computedStyle.paddingTop) || 0;
   const paddingBottom = Number.parseFloat(computedStyle.paddingBottom) || 0;
   const borderTop = Number.parseFloat(computedStyle.borderTopWidth) || 0;
   const borderBottom = Number.parseFloat(computedStyle.borderBottomWidth) || 0;
-  return { lineHeight, verticalChrome: paddingTop + paddingBottom + borderTop + borderBottom };
+  return {
+    lineHeight,
+    verticalChrome: paddingTop + paddingBottom + borderTop + borderBottom,
+  };
 }
 
 function cellEditNaturalHeight(textarea: HTMLTextAreaElement, metrics = cellEditTextMetrics(textarea)): number {
@@ -7879,7 +8175,12 @@ function onRowContext(rowId: number, rowIndex: number) {
 
 const sqlOneLiner = computed(() => props.sql?.replace(/\s+/g, " ").trim() || "");
 
-type TableInfoTabItem = { id: TableInfoTab; label: string; icon: Component; count?: number };
+type TableInfoTabItem = {
+  id: TableInfoTab;
+  label: string;
+  icon: Component;
+  count?: number;
+};
 
 const TABLE_INFO_DRAWER_MIN_WIDTH = 240;
 const CELL_DETAIL_PANEL_MIN_HEIGHT = 180;
@@ -8115,7 +8416,12 @@ const tableInfoTabs = computed(() => {
     });
   }
   if (canShowTableIndexes.value) {
-    tabs.push({ id: "indexes", label: t("grid.tableInfoIndexes"), icon: KeyRound, count: indexes.value.length });
+    tabs.push({
+      id: "indexes",
+      label: t("grid.tableInfoIndexes"),
+      icon: KeyRound,
+      count: indexes.value.length,
+    });
   }
   if (tableMetadataCapabilities.value.foreignKeys) {
     tabs.push({
@@ -8126,7 +8432,12 @@ const tableInfoTabs = computed(() => {
     });
   }
   if (tableMetadataCapabilities.value.triggers) {
-    tabs.push({ id: "triggers", label: t("grid.tableInfoTriggers"), icon: RotateCcw, count: triggers.value.length });
+    tabs.push({
+      id: "triggers",
+      label: t("grid.tableInfoTriggers"),
+      icon: RotateCcw,
+      count: triggers.value.length,
+    });
   }
   return tabs;
 });
@@ -8193,14 +8504,38 @@ async function fetchIndexes() {
   indexesError.value = "";
   try {
     const nextIndexes = await api.listIndexes(connectionId, database, schema, tableName, catalog);
-    if (!columnIndexMetadataRequestCurrent({ requestGeneration, currentGeneration: indexesRequestGeneration, requestIdentity, currentIdentity: currentIndexTableIdentity.value })) return;
+    if (
+      !columnIndexMetadataRequestCurrent({
+        requestGeneration,
+        currentGeneration: indexesRequestGeneration,
+        requestIdentity,
+        currentIdentity: currentIndexTableIdentity.value,
+      })
+    )
+      return;
     indexes.value = nextIndexes;
     indexesLoaded.value = true;
   } catch (e: any) {
-    if (!columnIndexMetadataRequestCurrent({ requestGeneration, currentGeneration: indexesRequestGeneration, requestIdentity, currentIdentity: currentIndexTableIdentity.value })) return;
+    if (
+      !columnIndexMetadataRequestCurrent({
+        requestGeneration,
+        currentGeneration: indexesRequestGeneration,
+        requestIdentity,
+        currentIdentity: currentIndexTableIdentity.value,
+      })
+    )
+      return;
     indexesError.value = String(e?.message || e);
   } finally {
-    if (columnIndexMetadataRequestCurrent({ requestGeneration, currentGeneration: indexesRequestGeneration, requestIdentity, currentIdentity: currentIndexTableIdentity.value })) indexesLoading.value = false;
+    if (
+      columnIndexMetadataRequestCurrent({
+        requestGeneration,
+        currentGeneration: indexesRequestGeneration,
+        requestIdentity,
+        currentIdentity: currentIndexTableIdentity.value,
+      })
+    )
+      indexesLoading.value = false;
   }
 }
 
@@ -8216,9 +8551,18 @@ async function refreshMongoIndexMetadataAfterMutation() {
   const collection = props.tableMeta?.tableName;
   if (!connectionId || !database || !collection) return;
   try {
-    await refreshLoadedMongoIndexes(connectionStore, { connectionId, database, collection });
+    await refreshLoadedMongoIndexes(connectionStore, {
+      connectionId,
+      database,
+      collection,
+    });
   } catch (e: any) {
-    toast(t("contextMenu.mongoIndexRefreshFailed", { message: String(e?.message || e) }), 5000);
+    toast(
+      t("contextMenu.mongoIndexRefreshFailed", {
+        message: String(e?.message || e),
+      }),
+      5000,
+    );
   }
 }
 
@@ -8235,14 +8579,38 @@ async function fetchForeignKeys() {
   foreignKeysError.value = "";
   try {
     const nextForeignKeys = await api.listForeignKeys(connectionId, database, schema, tableName, catalog);
-    if (!foreignKeyMetadataRequestCurrent({ requestGeneration, currentGeneration: foreignKeysRequestGeneration, requestIdentity, currentIdentity: currentForeignKeyTableIdentity.value })) return;
+    if (
+      !foreignKeyMetadataRequestCurrent({
+        requestGeneration,
+        currentGeneration: foreignKeysRequestGeneration,
+        requestIdentity,
+        currentIdentity: currentForeignKeyTableIdentity.value,
+      })
+    )
+      return;
     foreignKeys.value = nextForeignKeys;
     foreignKeysLoaded.value = true;
   } catch (e: any) {
-    if (!foreignKeyMetadataRequestCurrent({ requestGeneration, currentGeneration: foreignKeysRequestGeneration, requestIdentity, currentIdentity: currentForeignKeyTableIdentity.value })) return;
+    if (
+      !foreignKeyMetadataRequestCurrent({
+        requestGeneration,
+        currentGeneration: foreignKeysRequestGeneration,
+        requestIdentity,
+        currentIdentity: currentForeignKeyTableIdentity.value,
+      })
+    )
+      return;
     foreignKeysError.value = String(e?.message || e);
   } finally {
-    if (foreignKeyMetadataRequestCurrent({ requestGeneration, currentGeneration: foreignKeysRequestGeneration, requestIdentity, currentIdentity: currentForeignKeyTableIdentity.value })) foreignKeysLoading.value = false;
+    if (
+      foreignKeyMetadataRequestCurrent({
+        requestGeneration,
+        currentGeneration: foreignKeysRequestGeneration,
+        requestIdentity,
+        currentIdentity: currentForeignKeyTableIdentity.value,
+      })
+    )
+      foreignKeysLoading.value = false;
   }
 }
 
@@ -8441,7 +8809,9 @@ function onDdlResizeMove(event: MouseEvent) {
 
 function onDdlResizeEnd() {
   if (isResizingDdl.value) {
-    settingsStore.updateEditorSettings({ tableInfoDrawerWidth: ddlWidth.value });
+    settingsStore.updateEditorSettings({
+      tableInfoDrawerWidth: ddlWidth.value,
+    });
   }
   isResizingDdl.value = false;
   document.body.classList.remove("select-none", "cursor-col-resize");
@@ -8468,7 +8838,9 @@ function onDetailResizeMove(event: MouseEvent) {
 
 function onDetailResizeEnd() {
   if (isResizingDetail.value) {
-    settingsStore.updateEditorSettings({ cellDetailDrawerWidth: detailPanelHeight.value });
+    settingsStore.updateEditorSettings({
+      cellDetailDrawerWidth: detailPanelHeight.value,
+    });
   }
   isResizingDetail.value = false;
   document.body.classList.remove("select-none", "cursor-row-resize", "cursor-col-resize");
@@ -8596,7 +8968,11 @@ const dropMongoIndexConfirmMessage = computed(() =>
     : "",
 );
 const dropMongoIndexPreview = computed(() => (pendingDropMongoIndex.value ? mongoDropIndexPreview(props.database || "", props.tableMeta?.tableName || "", pendingDropMongoIndex.value.name) : ""));
-const dropAllMongoIndexesConfirmMessage = computed(() => t("contextMenu.confirmDropMongoAllIndexesMessage", { name: props.tableMeta?.tableName || "" }));
+const dropAllMongoIndexesConfirmMessage = computed(() =>
+  t("contextMenu.confirmDropMongoAllIndexesMessage", {
+    name: props.tableMeta?.tableName || "",
+  }),
+);
 const dropAllMongoIndexesConfirmDetails = computed(() => t("contextMenu.confirmDropMongoAllIndexesDetails"));
 const dropAllMongoIndexesPreview = computed(() => mongoDropAllIndexesPreview(props.database || "", props.tableMeta?.tableName || ""));
 
@@ -8634,14 +9010,26 @@ async function confirmDropMongoIndex() {
     onSuccess: (result) => {
       const failed = mongoDropIndexFailureCount(result);
       if (failed > 0) {
-        toast(t("contextMenu.dropIndexesPartialFailure", { success: result.dropped_names.length, failed }), 5000);
+        toast(
+          t("contextMenu.dropIndexesPartialFailure", {
+            success: result.dropped_names.length,
+            failed,
+          }),
+          5000,
+        );
       } else {
         toast(t("contextMenu.dropTableChildObjectSuccess", { name: index.name }), 3000);
       }
       showDropMongoIndexConfirm.value = false;
       pendingDropMongoIndex.value = null;
     },
-    onError: (e: any) => toast(t("contextMenu.tableOperationFailed", { message: e?.message || String(e) }), 5000),
+    onError: (e: any) =>
+      toast(
+        t("contextMenu.tableOperationFailed", {
+          message: e?.message || String(e),
+        }),
+        5000,
+      ),
   });
 }
 
@@ -8667,13 +9055,31 @@ async function confirmDropAllMongoIndexes() {
     onSuccess: (result) => {
       const failed = mongoDropIndexFailureCount(result);
       if (failed > 0) {
-        toast(t("contextMenu.dropIndexesPartialFailure", { success: result.dropped_names.length, failed }), 5000);
+        toast(
+          t("contextMenu.dropIndexesPartialFailure", {
+            success: result.dropped_names.length,
+            failed,
+          }),
+          5000,
+        );
       } else {
-        toast(t("contextMenu.dropAllIndexesSuccess", { count: result.dropped_names.length, name: tableName }), 3000);
+        toast(
+          t("contextMenu.dropAllIndexesSuccess", {
+            count: result.dropped_names.length,
+            name: tableName,
+          }),
+          3000,
+        );
       }
       showDropAllMongoIndexesConfirm.value = false;
     },
-    onError: (e: any) => toast(t("contextMenu.tableOperationFailed", { message: e?.message || String(e) }), 5000),
+    onError: (e: any) =>
+      toast(
+        t("contextMenu.tableOperationFailed", {
+          message: e?.message || String(e),
+        }),
+        5000,
+      ),
   });
 }
 
@@ -8862,7 +9268,10 @@ function copySubmenu(): ContextMenuItem {
   items.push(...buildExtractorContextItems());
   items.push({ label: "", separator: true });
   items.push({ label: t("grid.copyAll"), action: copyAll });
-  items.push({ label: t("grid.copyColumnNames"), action: openCopyAllColumnNamesDialog });
+  items.push({
+    label: t("grid.copyColumnNames"),
+    action: openCopyAllColumnNamesDialog,
+  });
   return { label: t("grid.copy"), icon: Copy, children: items };
 }
 
@@ -8876,16 +9285,35 @@ function exportSubmenu(): ContextMenuItem {
     { label: t("grid.exportTxt"), action: exportTxt },
   ];
   if (props.context === "results" && !!(props.exportSql || props.sql)?.trim()) {
-    items.splice(2, 0, { label: t("grid.exportXlsxWithSql"), action: exportXlsxWithSql });
+    items.splice(2, 0, {
+      label: t("grid.exportXlsxWithSql"),
+      action: exportXlsxWithSql,
+    });
   }
   if (isMultiRow.value) {
     items.push(
       { label: "", separator: true },
       { label: t("grid.exportSelectedRowsCsv"), action: exportSelectedRowsCsv },
-      { label: t("grid.exportSelectedRowsXlsx"), action: exportSelectedRowsXlsx },
-      ...(props.context === "results" && !!(props.exportSql || props.sql)?.trim() ? [{ label: t("grid.exportSelectedRowsXlsxWithSql"), action: exportSelectedRowsXlsxWithSql }] : []),
-      { label: t("grid.exportSelectedRowsJson"), action: exportSelectedRowsJson },
-      { label: t("grid.exportSelectedRowsMarkdown"), action: exportSelectedRowsMarkdown },
+      {
+        label: t("grid.exportSelectedRowsXlsx"),
+        action: exportSelectedRowsXlsx,
+      },
+      ...(props.context === "results" && !!(props.exportSql || props.sql)?.trim()
+        ? [
+            {
+              label: t("grid.exportSelectedRowsXlsxWithSql"),
+              action: exportSelectedRowsXlsxWithSql,
+            },
+          ]
+        : []),
+      {
+        label: t("grid.exportSelectedRowsJson"),
+        action: exportSelectedRowsJson,
+      },
+      {
+        label: t("grid.exportSelectedRowsMarkdown"),
+        action: exportSelectedRowsMarkdown,
+      },
       { label: t("grid.exportSelectedRowsSql"), action: exportSelectedRowsSql },
       { label: t("grid.exportSelectedRowsTxt"), action: exportSelectedRowsTxt },
     );
@@ -8927,7 +9355,12 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
       contextVisibleColIdx: contextHeaderVisibleColIdx.value ?? undefined,
       hasColumnSelection: hasColumnSelection.value,
       labels: {
-        copyName: selectedColumnNamesForCopy.value.length > 1 ? t("grid.copyColumnNamesSelected", { count: selectedColumnNamesForCopy.value.length }) : t("grid.copyColumnName"),
+        copyName:
+          selectedColumnNamesForCopy.value.length > 1
+            ? t("grid.copyColumnNamesSelected", {
+                count: selectedColumnNamesForCopy.value.length,
+              })
+            : t("grid.copyColumnName"),
         copyNames: t("grid.copyColumnNames"),
         details: t("grid.openColumnDetailsDialog"),
         copyAlterSql: t("grid.copyAlterColumnSql"),
@@ -8940,7 +9373,14 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
         freezeSelectedColumns: t("grid.freezeSelectedColumns"),
         unfreezeColumns: t("grid.unfreezeColumns"),
       },
-      icons: { copy: Copy, columnDetails: TableProperties, database: Database, ascending: ArrowUp, descending: ArrowDown, clearSort: Eraser },
+      icons: {
+        copy: Copy,
+        columnDetails: TableProperties,
+        database: Database,
+        ascending: ArrowUp,
+        descending: ArrowDown,
+        clearSort: Eraser,
+      },
       actions: {
         copyName: copyHeaderColumnOrSelected,
         copyNames: openCopyAllColumnNamesDialog,
@@ -8981,13 +9421,31 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
         bulkEdit: t("grid.bulkEditSelection"),
         transpose: t("grid.transpose"),
       },
-      icons: { cellDetails: Maximize2, columnDetails: TableProperties, rowDetails: ListTree, setNull: X, bulkEdit: Pencil, transpose: Rows3 },
-      actions: { cellDetails: openContextCellDetailDialog, columnDetails: openContextColumnDetailDialog, rowDetails: openContextRowDetailDialog, setNull: setSelectionNull, bulkEdit: openBulkEditDialog, transpose: openContextTranspose },
+      icons: {
+        cellDetails: Maximize2,
+        columnDetails: TableProperties,
+        rowDetails: ListTree,
+        setNull: X,
+        bulkEdit: Pencil,
+        transpose: Rows3,
+      },
+      actions: {
+        cellDetails: openContextCellDetailDialog,
+        columnDetails: openContextColumnDetailDialog,
+        rowDetails: openContextRowDetailDialog,
+        setNull: setSelectionNull,
+        bulkEdit: openBulkEditDialog,
+        transpose: openContextTranspose,
+      },
       importItem: binaryImportItem(contextCellDetail.value),
       downloadItem: binaryDownloadSubmenu(contextCellDetail.value),
       foreignKeyItem: contextForeignKeyMenuItem(),
       copySubmenu: copySubmenu(),
-      clearSelectionItem: { label: t("grid.clearSelection"), action: clearCellSelection, icon: SquareDashed },
+      clearSelectionItem: {
+        label: t("grid.clearSelection"),
+        action: clearCellSelection,
+        icon: SquareDashed,
+      },
       generateSubmenu: {
         label: t("grid.generateValue"),
         icon: WandSparkles,
@@ -9021,7 +9479,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
     data-grid-root
     data-grid-active="true"
     class="h-full flex flex-col overflow-hidden outline-none"
-    :class="{ 'data-grid--editing-cell': !!editingCell, 'data-grid--dark': isDark, 'data-grid--has-save-error': !!saveError }"
+    :class="{
+      'data-grid--editing-cell': !!editingCell,
+      'data-grid--dark': isDark,
+      'data-grid--has-save-error': !!saveError,
+    }"
     :style="gridStyle"
     tabindex="0"
     @keydown="onGridKeydown"
@@ -9147,7 +9609,13 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     @click="toggleMongoJsonPreview"
                   >
                     <Code2 class="data-grid-topbar-action-icon w-3 h-3" />
-                    <span class="data-grid-topbar-action-label" :class="{ 'data-grid-topbar-action-label--compact': compactDataGridToolbar }">{{ t("grid.mongoJsonPreview") }}</span>
+                    <span
+                      class="data-grid-topbar-action-label"
+                      :class="{
+                        'data-grid-topbar-action-label--compact': compactDataGridToolbar,
+                      }"
+                      >{{ t("grid.mongoJsonPreview") }}</span
+                    >
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">{{ t("grid.mongoJsonPreview") }}</TooltipContent>
@@ -9161,7 +9629,13 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     <PopoverTrigger as-child>
                       <Button variant="ghost" size="sm" :class="['data-grid-topbar-action-button h-5 shrink-0 text-xs px-1.5', compactDataGridToolbar ? 'data-grid-topbar-action-button--compact' : '', goToColumnOpen ? 'text-primary bg-primary/10' : '']">
                         <Columns3 class="data-grid-topbar-action-icon w-3 h-3" />
-                        <span class="data-grid-topbar-action-label" :class="{ 'data-grid-topbar-action-label--compact': compactDataGridToolbar }">{{ t("grid.goToColumn") }}</span>
+                        <span
+                          class="data-grid-topbar-action-label"
+                          :class="{
+                            'data-grid-topbar-action-label--compact': compactDataGridToolbar,
+                          }"
+                          >{{ t("grid.goToColumn") }}</span
+                        >
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent align="end" class="w-56 p-2" @keydown="onGoToColumnKeydown">
@@ -9178,7 +9652,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           <span class="shrink-0 font-mono text-[10px] text-muted-foreground">#{{ column.index + 1 }}</span>
                           <span v-if="column.comment" class="col-span-2 min-w-0 truncate text-[11px] leading-4 text-muted-foreground" :title="column.comment">{{ column.comment }}</span>
                         </button>
-                        <div v-if="!filteredGoToColumns.length" class="px-2 py-3 text-center text-xs text-muted-foreground">{{ t("grid.noColumnsFound") }}</div>
+                        <div v-if="!filteredGoToColumns.length" class="px-2 py-3 text-center text-xs text-muted-foreground">
+                          {{ t("grid.noColumnsFound") }}
+                        </div>
                       </div>
                     </PopoverContent>
                   </Popover>
@@ -9269,7 +9745,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                         'transpose-record-header-active text-primary': transposeRecordUsesActiveHighlight(recordIndex) && !transposeRecordUsesFramedHeader(recordIndex),
                         'data-grid-header-cell': !transposeRecordUsesActiveHighlight(recordIndex) && !transposeRecordUsesFramedHeader(recordIndex),
                       }"
-                      :style="{ width: `${getTransposeRecordWidth(recordIndex)}px` }"
+                      :style="{
+                        width: `${getTransposeRecordWidth(recordIndex)}px`,
+                      }"
                       @click="selectTransposeRecord(recordIndex, $event)"
                       @contextmenu="selectTransposeRecord(recordIndex, $event)"
                     >
@@ -9280,7 +9758,13 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                   </div>
                 </template>
                 <template #default="{ item, index }">
-                  <div class="data-grid-transpose-row flex border-b border-border/60" :style="{ height: '30px', width: `${transposeTotalWidth}px` }">
+                  <div
+                    class="data-grid-transpose-row flex border-b border-border/60"
+                    :style="{
+                      height: '30px',
+                      width: `${transposeTotalWidth}px`,
+                    }"
+                  >
                     <LightTooltip :text="transposeFieldTitle(item)" side="right" :side-offset="6" :delay="250" :open-on-focus="false" surface="popover">
                       <div
                         data-native-clipboard
@@ -9332,7 +9816,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                         'hover:bg-gray-200 dark:hover:bg-gray-800':
                           !isScrolling && canEditCellItem(displayItems[cell.recordIndex], cell.valueIndex) && !transposeRecordUsesSelectionVisual(cell.recordIndex) && !transposeRecordUsesActiveHighlight(cell.recordIndex) && !transposeCellIsSelected(cell.recordIndex, cell.valueIndex),
                       }"
-                      :style="{ width: `${getTransposeRecordWidth(cell.recordIndex)}px` }"
+                      :style="{
+                        width: `${getTransposeRecordWidth(cell.recordIndex)}px`,
+                      }"
                       :title="cell.display"
                       @mousedown="prepareTransposeCellMouseDown(cell.recordIndex, cell.valueIndex)"
                       @click="selectTransposeCell(cell.recordIndex, cell.valueIndex, $event)"
@@ -9447,7 +9933,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 <div class="data-grid-header-row flex w-(--header-total-w) font-semibold text-foreground">
                   <div
                     class="data-grid-header-cell shrink-0 px-2 py-1.5 border-r w-(--row-num-w) border-border text-center text-muted-foreground select-none cursor-default hover:bg-gray-200 dark:hover:bg-gray-800 sticky left-0 z-20"
-                    :class="{ 'data-grid-header-cell--selected': isSelectingAll }"
+                    :class="{
+                      'data-grid-header-cell--selected': isSelectingAll,
+                    }"
                     @click="selectAllCells"
                   >
                     #
@@ -9496,7 +9984,12 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     @copy-name="copyText(col.name)"
                   >
                     <template #actions>
-                      <span class="flex shrink-0 items-center gap-1" :class="{ 'flex-col !gap-0': columnWidthDensity === 'compact' }">
+                      <span
+                        class="flex shrink-0 items-center gap-1"
+                        :class="{
+                          'flex-col !gap-0': columnWidthDensity === 'compact',
+                        }"
+                      >
                         <LightDropdownMenu
                           v-if="headerColumnSortable(col.actualColIdx)"
                           :items="sortMenuItems(col.name, col.actualColIdx)"
@@ -9571,7 +10064,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           <PopoverContent align="start" side="bottom" class="w-[450px] max-w-[calc(100vw-2rem)] gap-0 overflow-hidden rounded-md border bg-popover p-0 text-popover-foreground shadow-xl" @click.stop @keydown.stop>
                             <div class="border-b bg-muted/40 px-3 py-2">
                               <div class="text-sm font-semibold">
-                                {{ t("grid.columnFormatterFor", { column: col.name }) }}
+                                {{
+                                  t("grid.columnFormatterFor", {
+                                    column: col.name,
+                                  })
+                                }}
                               </div>
                               <div class="mt-0.5 text-[11px] text-muted-foreground">
                                 {{ t("grid.columnFormatterHint") }}
@@ -9767,7 +10264,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                               <span class="min-w-0 truncate">
                                 <template v-if="serverFilterLoading">{{ t("grid.loadingValues") }}</template>
                                 <template v-else-if="serverFilterError">{{ serverFilterError }}</template>
-                                <template v-else>{{ t("grid.serverValuesLimited", { count: SERVER_COLUMN_FILTER_LIMIT }) }}</template>
+                                <template v-else>{{
+                                  t("grid.serverValuesLimited", {
+                                    count: SERVER_COLUMN_FILTER_LIMIT,
+                                  })
+                                }}</template>
                               </span>
                             </div>
                             <div class="max-h-72 overflow-auto py-0.5">
@@ -9775,7 +10276,12 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                                 <span class="flex h-4 w-4 items-center justify-center rounded border" :class="localFilterDraft?.values.has(option.key) ? 'border-blue-600 bg-blue-600 text-white' : 'border-border bg-background text-foreground/70'">
                                   <Check v-if="localFilterDraft?.values.has(option.key)" class="h-3 w-3 stroke-[3]" />
                                 </span>
-                                <span class="truncate font-mono" :class="{ 'italic text-muted-foreground': option.value === null }">
+                                <span
+                                  class="truncate font-mono"
+                                  :class="{
+                                    'italic text-muted-foreground': option.value === null,
+                                  }"
+                                >
                                   {{ option.label }}
                                 </span>
                                 <span class="text-right tabular-nums text-muted-foreground text-xs">{{ option.count ?? "" }}</span>
@@ -9790,7 +10296,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                               <button v-if="canApplyTypedLocalFilterValue" type="button" class="grid w-full grid-cols-[1.75rem_minmax(0,1fr)] items-center px-2 py-1 text-left text-xs text-primary hover:bg-accent" @click="applyTypedLocalFilterValue">
                                 <Search class="h-3.5 w-3.5" />
                                 <span class="truncate font-mono">
-                                  {{ t("grid.filterTypedValue", { value: localFilterTypedValue }) }}
+                                  {{
+                                    t("grid.filterTypedValue", {
+                                      value: localFilterTypedValue,
+                                    })
+                                  }}
                                 </span>
                               </button>
                               <div v-if="localFilterOptions.length === 0 && !canApplyTypedLocalFilterValue && !serverFilterLoading" class="px-2 py-6 text-center text-xs text-muted-foreground">
@@ -9837,7 +10347,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-2 px-6 text-center text-muted-foreground">
                   <component :is="hasActiveFilter ? SearchX : Inbox" class="h-8 w-8 text-muted-foreground/50" aria-hidden="true" />
                   <div class="space-y-1">
-                    <div class="text-sm font-medium text-foreground">{{ emptyTitle }}</div>
+                    <div class="text-sm font-medium text-foreground">
+                      {{ emptyTitle }}
+                    </div>
                     <div class="text-xs">{{ emptyDescription }}</div>
                   </div>
                 </div>
@@ -9847,15 +10359,27 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 v-else-if="useCanvasGridRows"
                 ref="scrollerRef"
                 class="data-grid-scroller canvas-grid-scroller flex-1 overflow-auto overscroll-none relative"
-                :class="{ 'is-scrolling': isScrolling, 'has-horizontal-scrollbar': hasGridHorizontalOverflow }"
+                :class="{
+                  'is-scrolling': isScrolling,
+                  'has-horizontal-scrollbar': hasGridHorizontalOverflow,
+                }"
                 @scroll="onCanvasScroll"
                 @wheel="onCanvasWheel"
               >
-                <div class="relative" :style="{ width: `${totalWidth}px`, height: `${canvasContentHeight}px` }">
+                <div
+                  class="relative"
+                  :style="{
+                    width: `${totalWidth}px`,
+                    height: `${canvasContentHeight}px`,
+                  }"
+                >
                   <canvas
                     ref="canvasRef"
                     class="canvas-grid-surface dbx-data-grid-font-family sticky left-0 top-0 z-0 block font-normal"
-                    :style="{ width: `${canvasSurfaceWidth}px`, height: `${canvasViewportHeight}px` }"
+                    :style="{
+                      width: `${canvasSurfaceWidth}px`,
+                      height: `${canvasViewportHeight}px`,
+                    }"
                     @mousemove="onCanvasMouseMove"
                     @mouseleave="onCanvasMouseLeave"
                     @mousedown="onCanvasMouseDown"
@@ -9942,7 +10466,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                       <button
                         v-if="canvasDetailButtonCell.foreignKey"
                         class="flex h-5 w-5 items-center justify-center rounded bg-background/90 text-muted-foreground shadow-sm ring-1 ring-border hover:text-foreground"
-                        :title="t('grid.foreignKeyNavigate', { table: canvasDetailButtonCell.foreignKey.ref_table })"
+                        :title="
+                          t('grid.foreignKeyNavigate', {
+                            table: canvasDetailButtonCell.foreignKey.ref_table,
+                          })
+                        "
                         @mousedown.stop
                         @click.stop="navigateToForeignKeyCell(canvasDetailButtonCell.rowIndex, canvasDetailButtonCell.actualColIdx)"
                       >
@@ -9971,7 +10499,10 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 <RecycleScroller
                   ref="scrollerRef"
                   class="data-grid-scroller dbx-data-grid-font-family h-full overflow-x-auto overscroll-none"
-                  :class="{ 'is-scrolling': isScrolling, 'has-horizontal-scrollbar': hasGridHorizontalOverflow }"
+                  :class="{
+                    'is-scrolling': isScrolling,
+                    'has-horizontal-scrollbar': hasGridHorizontalOverflow,
+                  }"
                   :items="displayItems"
                   :item-size="DOM_DATA_GRID_ROW_HEIGHT"
                   :buffer="600"
@@ -9996,14 +10527,25 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     >
                       <div
                         class="data-grid-row-number w-(--row-num-w) shrink-0 px-2 py-1 border-r text-center select-none cursor-default sticky left-0 z-10"
-                        :class="[rowNumberStatusClass(item), { 'data-grid-row-number--selected': isRowSelected(item.id), 'data-grid-row-number--in-selection': rowNumberShowsSelectionTint(item) }]"
+                        :class="[
+                          rowNumberStatusClass(item),
+                          {
+                            'data-grid-row-number--selected': isRowSelected(item.id),
+                            'data-grid-row-number--in-selection': rowNumberShowsSelectionTint(item),
+                          },
+                        ]"
                         @mousedown="onRowNumberMouseDown(item, $event)"
                         @dblclick.stop="toggleTranspose(item.displayIndex)"
                         @contextmenu="onRowContext(item.id, item.displayIndex)"
                       >
                         {{ rowNumberText(item) }}
                       </div>
-                      <div class="shrink-0" :style="{ width: `${horizontalColumnWindowBeforeWidth}px` }" />
+                      <div
+                        class="shrink-0"
+                        :style="{
+                          width: `${horizontalColumnWindowBeforeWidth}px`,
+                        }"
+                      />
                       <div
                         v-for="col in renderedGridColumns"
                         :key="col.actualColIdx"
@@ -10153,7 +10695,12 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           </div>
                         </template>
                       </div>
-                      <div class="shrink-0" :style="{ width: `${horizontalColumnWindow.afterWidth}px` }" />
+                      <div
+                        class="shrink-0"
+                        :style="{
+                          width: `${horizontalColumnWindow.afterWidth}px`,
+                        }"
+                      />
                     </div>
                   </template>
                 </RecycleScroller>
@@ -10259,10 +10806,18 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                 <thead class="sticky top-0 bg-muted text-muted-foreground">
                   <tr class="border-b">
                     <th class="text-left text-nowrap font-medium px-3 py-2 w-8">#</th>
-                    <th class="text-left text-nowrap font-medium px-3 py-2">{{ t("grid.columnName") }}</th>
-                    <th class="text-left text-nowrap font-medium px-3 py-2">{{ t("grid.columnType") }}</th>
-                    <th class="text-left text-nowrap font-medium px-3 py-2">{{ t("grid.tableInfoNullable") }}</th>
-                    <th class="text-left text-nowrap font-medium px-3 py-2">{{ t("structureEditor.defaultValue") }}</th>
+                    <th class="text-left text-nowrap font-medium px-3 py-2">
+                      {{ t("grid.columnName") }}
+                    </th>
+                    <th class="text-left text-nowrap font-medium px-3 py-2">
+                      {{ t("grid.columnType") }}
+                    </th>
+                    <th class="text-left text-nowrap font-medium px-3 py-2">
+                      {{ t("grid.tableInfoNullable") }}
+                    </th>
+                    <th class="text-left text-nowrap font-medium px-3 py-2">
+                      {{ t("structureEditor.defaultValue") }}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -10277,7 +10832,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     @keydown.enter.prevent="scrollToTableInfoColumn(column.name)"
                     @keydown.space.prevent="scrollToTableInfoColumn(column.name)"
                   >
-                    <td class="px-3 py-2 text-muted-foreground w-8">{{ index + 1 }}</td>
+                    <td class="px-3 py-2 text-muted-foreground w-8">
+                      {{ index + 1 }}
+                    </td>
                     <td class="cursor-text select-text px-3 py-2 font-medium">
                       <span class="inline-flex items-center gap-1.5">
                         <KeyRound v-if="column.is_primary_key" class="h-3 w-3 text-amber-500" />
@@ -10287,9 +10844,20 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                         {{ column.comment }}
                       </div>
                     </td>
-                    <td class="px-3 py-2 font-mono text-[11px] text-muted-foreground">{{ column.data_type }}</td>
-                    <td class="px-3 py-2">{{ column.is_nullable ? "YES" : "NO" }}</td>
-                    <td data-table-info-column-default class="max-w-56 px-3 py-2 font-mono text-[11px]" :class="{ 'text-muted-foreground/70': column.column_default == null }" :title="column.column_default ?? undefined">
+                    <td class="px-3 py-2 font-mono text-[11px] text-muted-foreground">
+                      {{ gaussdbMColumnType(column.data_type) }}
+                    </td>
+                    <td class="px-3 py-2">
+                      {{ column.is_nullable ? "YES" : "NO" }}
+                    </td>
+                    <td
+                      data-table-info-column-default
+                      class="max-w-56 px-3 py-2 font-mono text-[11px]"
+                      :class="{
+                        'text-muted-foreground/70': column.column_default == null,
+                      }"
+                      :title="column.column_default ?? undefined"
+                    >
                       <span class="block max-w-56 truncate">{{ tableColumnDefaultDisplayValue(column.column_default) }}</span>
                     </td>
                   </tr>
@@ -10301,7 +10869,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
               <div v-if="indexesLoading" class="h-full flex items-center justify-center">
                 <Loader2 class="w-4 h-4 animate-spin text-muted-foreground" />
               </div>
-              <div v-else-if="indexesError" class="p-3 text-xs text-destructive">{{ indexesError }}</div>
+              <div v-else-if="indexesError" class="p-3 text-xs text-destructive">
+                {{ indexesError }}
+              </div>
               <div v-else-if="searchQuery && filteredIndexes.length === 0" class="p-6 text-center text-xs text-muted-foreground">
                 {{ t("grid.tableInfoNoResults") }}
               </div>
@@ -10335,7 +10905,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
               <div v-if="foreignKeysLoading" class="h-full flex items-center justify-center">
                 <Loader2 class="w-4 h-4 animate-spin text-muted-foreground" />
               </div>
-              <div v-else-if="foreignKeysError" class="p-3 text-xs text-destructive">{{ foreignKeysError }}</div>
+              <div v-else-if="foreignKeysError" class="p-3 text-xs text-destructive">
+                {{ foreignKeysError }}
+              </div>
               <div v-else-if="searchQuery && filteredForeignKeys.length === 0" class="p-6 text-center text-xs text-muted-foreground">
                 {{ t("grid.tableInfoNoResults") }}
               </div>
@@ -10354,7 +10926,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
               <div v-if="triggersLoading" class="h-full flex items-center justify-center">
                 <Loader2 class="w-4 h-4 animate-spin text-muted-foreground" />
               </div>
-              <div v-else-if="triggersError" class="p-3 text-xs text-destructive">{{ triggersError }}</div>
+              <div v-else-if="triggersError" class="p-3 text-xs text-destructive">
+                {{ triggersError }}
+              </div>
               <div v-else-if="searchQuery && filteredTriggers.length === 0" class="p-6 text-center text-xs text-muted-foreground">
                 {{ t("grid.tableInfoNoResults") }}
               </div>
@@ -10470,7 +11044,13 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
               <TabsContent v-if="activeCellDetailTabs.includes('hexViewer')" value="hexViewer" class="m-0 min-h-0 flex-1 flex flex-col p-3 text-xs">
                 <div class="mb-2 min-w-0 shrink-0">
                   <div class="font-medium">{{ t("grid.hexViewer") }}</div>
-                  <div class="text-[11px] text-muted-foreground">{{ t("grid.hexViewerByteCount", { count: activeBinaryHexByteCount }) }}</div>
+                  <div class="text-[11px] text-muted-foreground">
+                    {{
+                      t("grid.hexViewerByteCount", {
+                        count: activeBinaryHexByteCount,
+                      })
+                    }}
+                  </div>
                 </div>
                 <div class="min-h-0 flex-1 overflow-auto rounded border bg-muted/20 font-mono text-[11px]">
                   <div class="sticky top-0 grid grid-cols-[5.5rem_minmax(24rem,1fr)_8rem] gap-3 border-b bg-muted px-2 py-1 font-semibold text-muted-foreground">
@@ -10479,7 +11059,9 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     <div>{{ t("grid.hexViewerAscii") }}</div>
                   </div>
                   <div v-for="row in activeBinaryHexRows" :key="row.offset" class="grid grid-cols-[5.5rem_minmax(24rem,1fr)_8rem] gap-3 border-b border-border/50 px-2 py-1 last:border-b-0">
-                    <div class="select-all text-muted-foreground">{{ row.offset }}</div>
+                    <div class="select-all text-muted-foreground">
+                      {{ row.offset }}
+                    </div>
                     <div class="select-all whitespace-pre">{{ row.hex }}</div>
                     <div class="select-all whitespace-pre">{{ row.ascii }}</div>
                   </div>
@@ -10562,7 +11144,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
     <div v-if="!isErrorResult" class="grid grid-cols-[max-content_minmax(0,1fr)_max-content] items-center gap-2 px-3 py-1 border-t text-xs text-muted-foreground bg-muted/30 shrink-0">
       <div class="flex min-w-0 items-center gap-2 overflow-hidden">
         <span v-if="hasData" class="shrink-0">
-          {{ t(showTruncationWarning ? "grid.loadedRows" : "grid.totalRows", { count: result.rows.length }) }}
+          {{
+            t(showTruncationWarning ? "grid.loadedRows" : "grid.totalRows", {
+              count: result.rows.length,
+            })
+          }}
           <span v-if="typeof displayedTotalRowCount === 'number' && displayedTotalRowCount >= 0" class="text-muted-foreground/70">{{ t(totalRowCountLabelKey, { count: displayedTotalRowCount }) }}</span>
           <span v-if="totalRowCountBusy" class="text-muted-foreground/70">
             {{ t("grid.totalRowCountLoading") }}
@@ -10664,7 +11250,11 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
         </DialogHeader>
         <div class="space-y-2">
           <p class="text-sm text-muted-foreground">
-            {{ t("grid.generateSequenceDescription", { count: generateIncrementTarget === "detail" ? 1 : editableSelectionCells().length }) }}
+            {{
+              t("grid.generateSequenceDescription", {
+                count: generateIncrementTarget === "detail" ? 1 : editableSelectionCells().length,
+              })
+            }}
           </p>
           <Input v-model="generateIncrementStartValue" inputmode="numeric" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false" placeholder="1" @keydown.enter.prevent="applyGenerateIncrementValue" />
         </div>
@@ -10682,7 +11272,13 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
 
     <DangerConfirmDialog
       v-model:open="showDeleteRowConfirm"
-      :message="pendingDeleteRowIds.length > 1 ? t('dangerDialog.deleteRowsMessage', { count: pendingDeleteRowIds.length }) : t('dangerDialog.deleteRowMessage')"
+      :message="
+        pendingDeleteRowIds.length > 1
+          ? t('dangerDialog.deleteRowsMessage', {
+              count: pendingDeleteRowIds.length,
+            })
+          : t('dangerDialog.deleteRowMessage')
+      "
       :details="deleteRowDetails"
       :confirm-label="pendingDeleteRowIds.length > 1 ? t('grid.deleteRows', { count: pendingDeleteRowIds.length }) : t('grid.deleteRow')"
       @confirm="confirmDeleteRow"

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1040,7 +1040,15 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
               @click-column="onHandleClickColumn"
               @close-column-panel="onHandleCloseColumnPanel"
             />
-            <ColumnInfoPanel v-if="showColumnInfo" :columns="columnInfoColumns" :loading="columnInfoLoading" :error="columnInfoError" @close="closeColumnInfo" />
+            <ColumnInfoPanel
+              v-if="showColumnInfo"
+              :columns="columnInfoColumns"
+              :loading="columnInfoLoading"
+              :error="columnInfoError"
+              :database-type="activeEffectiveDatabaseType"
+              :is-gaussdb-m="activeEffectiveDatabaseType === 'gaussdb' && activeResultConnection?.driver_profile?.toLowerCase() === 'gaussdb-m'"
+              @close="closeColumnInfo"
+            />
             <Button v-if="hasQueryOutput && !resultsPaneOpen" variant="secondary" size="sm" class="absolute bottom-3 right-3 z-20 h-7 gap-1.5 rounded-full border bg-background/95 px-3 text-xs shadow-lg hover:bg-accent" @click="resultsPaneOpen = true">
               <ChevronUp class="h-3.5 w-3.5" />
               {{ t("editor.showResultsPane") }}

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -125,6 +125,7 @@ import { filterObjectBrowserTableColumns } from "@/lib/table/objectBrowserTableI
 import { createSidePanelRequestGuard } from "@/lib/table/sidePanelRequestGuard";
 import { runBatchTableTruncate } from "@/lib/table/batchTableTruncate";
 import { tableColumnDefaultDisplayValue } from "@/lib/table/tableColumnDefaultPresentation";
+import { gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
 import { cacheObjectBrowserRows, createObjectBrowserRowsCacheWriteToken, getCachedObjectBrowserRows, type ObjectBrowserRowsCacheScope, type ObjectBrowserRowsCacheWriteToken } from "@/lib/table/objectBrowserRowsCache";
 import { createObjectBrowserRowsLoadGuard, type ObjectBrowserRowsLoadHandle } from "@/lib/table/objectBrowserRowsLoadGuard";
 
@@ -202,8 +203,16 @@ const sidePanelGuard = createSidePanelRequestGuard();
 const sidePanelRef = ref<InstanceType<typeof CustomTypeInfoPanel> | null>(null);
 const tableMetadataCapabilities = computed<TableMetadataCapabilities>(() => getTableMetadataCapabilities(effectiveDatabaseType.value));
 const effectiveDatabaseType = computed(() => effectiveDatabaseTypeForConnection(props.connection) ?? props.connection.db_type);
+const isGaussdbM = computed(() => effectiveDatabaseType.value === "gaussdb" && props.connection.driver_profile?.toLowerCase() === "gaussdb-m");
 const isVictoriaMetrics = computed(() => effectiveDatabaseType.value === "victoriametrics");
 const objectRowsLabel = computed(() => t(isVictoriaMetrics.value ? "objects.series" : "objects.rows"));
+
+function gaussdbMColumnType(dataType: string): string {
+  if (isGaussdbM.value) {
+    return gaussdbMTypeDisplayName(dataType);
+  }
+  return dataType;
+}
 const tableStructureDatabaseType = computed(() => tableStructureDatabaseTypeForConnection(props.connection) ?? props.connection.db_type);
 const sourceEditableText = ref("");
 const sourceDraft = ref("");
@@ -3200,7 +3209,7 @@ function getObjectBrowserMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
                       {{ column.comment }}
                     </div>
                   </td>
-                  <td class="px-3 py-2 font-mono text-[11px] text-muted-foreground">{{ column.data_type }}</td>
+                  <td class="px-3 py-2 font-mono text-[11px] text-muted-foreground">{{ gaussdbMColumnType(column.data_type) }}</td>
                   <td class="px-3 py-2">{{ column.is_nullable ? "YES" : "NO" }}</td>
                   <td data-table-info-column-default class="max-w-56 px-3 py-2 font-mono text-[11px]" :class="{ 'text-muted-foreground/70': column.column_default == null }" :title="column.column_default ?? undefined">
                     <span class="block max-w-56 truncate">{{ tableColumnDefaultDisplayValue(column.column_default) }}</span>

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -32,7 +32,7 @@ import { invalidateTableMetadataCache } from "@/lib/metadata/tableMetadataCache"
 import { type BuildTableStructureChangeSqlOptions, type EditableStructureColumn, type EditableStructureForeignKey, type EditableStructureIndex, type EditableStructureTrigger } from "@/lib/table/tableStructureEditorSql";
 import { PRESET_FIELDS_TEMPLATE_ID, createTableColumnTemplateDrafts } from "@/lib/table/tableColumnTemplates";
 import { getMysqlDataTypeHelp } from "@/lib/table/mysqlDataTypeHelp";
-import { getPostgresDataTypeHelp } from "@/lib/table/postgresDataTypeHelp";
+import { getPostgresDataTypeHelp, gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
 import { getSqliteDataTypeHelp } from "@/lib/table/sqliteDataTypeHelp";
 import { getTableMetadataCapabilities, firstStructureMetadataTab, isStructureMetadataTabSupported } from "@/lib/table/tableMetadataCapabilities";
 import { hasTableStructureRefreshWork, unloadedTableStructureRefreshScope, visibleTableStructureRefreshScope, type TableStructureRefreshScope } from "@/lib/table/tableStructureMetadataLoading";
@@ -1077,6 +1077,16 @@ function dataTypeTooltip(option: string): string | undefined {
   if (databaseType.value === "postgres") return postgresDataTypeTooltip(option);
   if (databaseType.value === "sqlite") return sqliteDataTypeTooltip(option);
   return undefined;
+}
+
+function gaussdbMDataTypeDisplayName(option: string): string {
+  if (databaseType.value === "gaussdb") {
+    const conn = connection.value;
+    if (conn?.driver_profile?.toLowerCase() === "gaussdb-m") {
+      return gaussdbMTypeDisplayName(option);
+    }
+  }
+  return option;
 }
 
 async function loadDynamicDataTypeOptions() {
@@ -2801,10 +2811,11 @@ watch([activeTab, ddlLoading], ([tab, loading]) => {
                       :loading-text="t('common.loading')"
                       :allow-custom="true"
                       :option-tooltip="dataTypeTooltip"
+                      :display-name="gaussdbMDataTypeDisplayName"
                       :trigger-class="[structureMonoControlClass, 'w-full']"
                       @update:model-value="(v: string) => updateColumnDataType(column, v)"
                     />
-                    <Input v-else :model-value="splitDataType(column.dataType).baseType" :class="[structureMonoControlClass, 'w-full']" disabled />
+                    <Input v-else :model-value="gaussdbMDataTypeDisplayName(splitDataType(column.dataType).baseType)" :class="[structureMonoControlClass, 'w-full']" disabled />
                   </td>
                   <td v-if="columnEditorControls.length" :class="structureCellClass">
                     <Popover v-if="isMysqlEnumDataType(databaseType, column.dataType)">

--- a/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
@@ -9,6 +9,7 @@ import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
+import { gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
 import { joinExportedDdls } from "@/lib/export/ddlExport";
 import { translateBackendError } from "@/i18n/backend-errors";
 import { sidebarStructureExportTargets } from "@/lib/sidebar/sidebarExportRuntime";
@@ -108,7 +109,10 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
   }
 
   function columnDocCells(target: TreeNode, column: ColumnInfo, includeTable: boolean): unknown[] {
-    const cells = [column.name, column.data_type, column.is_primary_key ? t("contextMenu.structureDocYes") : t("contextMenu.structureDocNo"), column.is_nullable ? t("contextMenu.structureDocYes") : t("contextMenu.structureDocNo"), column.column_default, column.comment];
+    const config = connectionStore.getConfig(target.connectionId);
+    const isGaussdbM = effectiveDatabaseTypeForConnection(config) === "gaussdb" && config?.driver_profile?.toLowerCase() === "gaussdb-m";
+    const dataType = isGaussdbM ? gaussdbMTypeDisplayName(column.data_type) : column.data_type;
+    const cells = [column.name, dataType, column.is_primary_key ? t("contextMenu.structureDocYes") : t("contextMenu.structureDocNo"), column.is_nullable ? t("contextMenu.structureDocYes") : t("contextMenu.structureDocNo"), column.column_default, column.comment];
     return includeTable ? [structureTargetName(target), ...cells] : cells;
   }
 

--- a/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
@@ -108,10 +108,11 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
     return includeTable ? [t("contextMenu.structureDocTable"), ...headers] : headers;
   }
 
-  function columnDocCells(target: TreeNode, column: ColumnInfo, includeTable: boolean): unknown[] {
+  function columnDocCells(target: TreeNode & { connectionId: string }, column: ColumnInfo, includeTable: boolean): unknown[] {
     const config = connectionStore.getConfig(target.connectionId);
     const isGaussdbM = effectiveDatabaseTypeForConnection(config) === "gaussdb" && config?.driver_profile?.toLowerCase() === "gaussdb-m";
-    const dataType = isGaussdbM ? gaussdbMTypeDisplayName(column.data_type) : column.data_type;
+    const sourceDataType = column.data_type;
+    const dataType = isGaussdbM && sourceDataType ? gaussdbMTypeDisplayName(sourceDataType) : sourceDataType;
     const cells = [column.name, dataType, column.is_primary_key ? t("contextMenu.structureDocYes") : t("contextMenu.structureDocNo"), column.is_nullable ? t("contextMenu.structureDocYes") : t("contextMenu.structureDocNo"), column.column_default, column.comment];
     return includeTable ? [structureTargetName(target), ...cells] : cells;
   }

--- a/apps/desktop/src/lib/table/postgresDataTypeHelp.ts
+++ b/apps/desktop/src/lib/table/postgresDataTypeHelp.ts
@@ -103,6 +103,7 @@ const POSTGRES_TYPE_ALIASES: Readonly<Record<string, string>> = {
   float4: "real",
   float8: "double precision",
   bool: "boolean",
+  bpchar: "char",
   character: "char",
   "character varying": "varchar",
   "time without time zone": "time",
@@ -110,6 +111,7 @@ const POSTGRES_TYPE_ALIASES: Readonly<Record<string, string>> = {
   "timestamp without time zone": "timestamp",
   "timestamp with time zone": "timestamptz",
   varbit: "bit varying",
+  int1: "tinyint",
 };
 
 const POSTGRES_MULTIRANGE_TYPES = new Set(["int4multirange", "int8multirange", "nummultirange", "tsmultirange", "tstzmultirange", "datemultirange"]);
@@ -152,4 +154,27 @@ function floatHelpKey(normalizedType: string): "real" | "double" | undefined {
   const value = Number(precision);
   if (value >= 1 && value <= 24) return "real";
   return value >= 25 && value <= 53 ? "double" : undefined;
+}
+
+/**
+ * Converts a GaussDB M-mode PostgreSQL internal type name to its MySQL-style
+ * display name. Returns the original name if no conversion applies.
+ *
+ * GaussDB M mode returns PostgreSQL internal type names (e.g. bpchar, int4,
+ * numeric, int1) but should display MySQL-compatible names.
+ */
+export function gaussdbMTypeDisplayName(typeName: string): string {
+  const s = typeName.trim().toLowerCase();
+  if (s === "bpchar") return "char";
+  if (s === "int4" || s === "integer") return "int";
+  if (s === "int2" || s === "smallint") return "smallint";
+  if (s === "int8" || s === "bigint") return "bigint";
+  if (s === "int1") return "tinyint";
+  if (s === "numeric") return "decimal";
+  if (s === "float4" || s === "real") return "float";
+  if (s === "float8" || s === "double precision") return "double";
+  if (s === "bool" || s === "boolean") return "boolean";
+  if (s === "character varying") return "varchar";
+  if (s === "character") return "char";
+  return typeName;
 }

--- a/apps/desktop/src/lib/table/postgresDataTypeHelp.ts
+++ b/apps/desktop/src/lib/table/postgresDataTypeHelp.ts
@@ -103,7 +103,6 @@ const POSTGRES_TYPE_ALIASES: Readonly<Record<string, string>> = {
   float4: "real",
   float8: "double precision",
   bool: "boolean",
-  bpchar: "char",
   character: "char",
   "character varying": "varchar",
   "time without time zone": "time",
@@ -111,7 +110,6 @@ const POSTGRES_TYPE_ALIASES: Readonly<Record<string, string>> = {
   "timestamp without time zone": "timestamp",
   "timestamp with time zone": "timestamptz",
   varbit: "bit varying",
-  int1: "tinyint",
 };
 
 const POSTGRES_MULTIRANGE_TYPES = new Set(["int4multirange", "int8multirange", "nummultirange", "tsmultirange", "tstzmultirange", "datemultirange"]);

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -73,6 +73,7 @@ import { shouldMarkDisconnected } from "@/lib/connection/connectionHealth";
 import { connectionAttemptOriginalErrorMessage, connectionAttemptTimeoutMessage, connectionAttemptTimeoutMs } from "@/lib/connection/connectionAttemptTimeout";
 import { loadTimeoutInheritanceBackup, saveTimeoutInheritanceBackup } from "@/lib/connection/timeoutInheritanceBackup";
 import { migrateSqlServerLegacyCompatibilityConfig, requiresSqlServerLegacyCompatibilityComponent, SQLSERVER_LEGACY_COMPATIBILITY_DRIVER_KEY } from "@/lib/connection/sqlServerLegacyCompatibility";
+import { gaussdbMTypeDisplayName } from "@/lib/table/postgresDataTypeHelp";
 import { deleteTabResultSnapshotsForOwner } from "@/lib/tabs/tabResultCache";
 import { connectionUsesVisibleSchemaFilter, filterDatabaseNamesForConnection, filterSchemaNamesForConnection, filterVisibleDatabaseNames, normalizeVisibleDatabaseSelection } from "@/lib/database/visibleDatabases";
 import {
@@ -5059,11 +5060,13 @@ export const useConnectionStore = defineStore("connection", () => {
       const columns = await api.getColumns(connectionId, database, querySchema, table, catalog);
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
+      const connConfig = getConfig(connectionId);
+      const isGaussdbM = effectiveDatabaseTypeForConnection(connConfig) === "gaussdb" && connConfig?.driver_profile?.toLowerCase() === "gaussdb-m";
       setChildren(
         targetNode,
         columns.map((col) => ({
           id: `${parentId}:${col.name}`,
-          label: `${col.name} (${col.data_type})`,
+          label: `${col.name} (${isGaussdbM ? gaussdbMTypeDisplayName(col.data_type) : col.data_type})`,
           type: "column" as const,
           connectionId,
           database,


### PR DESCRIPTION
- 新增 gaussdbMTypeDisplayName() 工具函数，将 PostgreSQL 内部类型名 转换为 MySQL 风格显示名（bpchar→char, int4→int, numeric→decimal 等）
- DataGrid 表头、Columns 标签页、ColumnInfoPanel 侧面板应用类型转换
- TableStructureEditor 编辑器中类型下拉选项应用类型转换
- ObjectBrowser 侧边栏 Columns/Indexes 标签页应用类型转换
- SidebarTree 中列节点标签应用类型转换
- Copy Structure as Markdown 导出应用类型转换
- StandardJdbcMetadata.listIndexes 添加 catalog fallback 逻辑， 修复 GaussDB M 模式 JDBC 驱动 getIndexInfo 返回空的问题
