### PR TITLE
fix(sidebar): 修复连接搜索结果展示及打开行为

### DIFF
--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts
@@ -4,6 +4,7 @@ import { createApp, defineComponent, h, nextTick, type App } from "vue";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import i18n from "@/i18n";
 import TreeItem from "@/components/sidebar/TreeItem.vue";
+import { filterSidebarTree } from "@/lib/sidebar/sidebarSearchTree";
 import { createSidebarTreeRuntime, sidebarTreeRuntimeKey, type SidebarTreeRuntimeHost } from "@/lib/sidebar/sidebarTreeRuntime";
 import type { TreeNode } from "@/types/database";
 
@@ -11,9 +12,12 @@ const connectionStore = {
   activeConnectionId: "connection-1",
   connectedIds: new Set(["connection-1"]),
   connectingIds: new Set<string>(),
+  connectionErrors: {},
   connectionMultiSelectActive: false,
   connections: [],
   getConfig: () => ({ id: "connection-1", db_type: "sqlserver" }),
+  getSidebarVisibleFilterSummary: () => null,
+  clearConnectionError: vi.fn(),
   isDefaultDatabase: () => false,
   isDefaultSchema: () => false,
   isPinnedTreeNodeReorderTarget: () => false,
@@ -180,5 +184,60 @@ describe("TreeItem load-more activation", () => {
     const unknown = await mountTreeItem(unknownNode);
     expect(unknown.row.textContent).not.toContain("INVALID");
     expect(unknown.row.querySelector('[data-invalid-object-indicator="true"]')).toBeNull();
+  });
+});
+
+describe("TreeItem searched connection activation", () => {
+  function searchedConnection(): TreeNode {
+    const filtered = filterSidebarTree(
+      [
+        {
+          id: "connection-1",
+          label: "1000",
+          type: "connection",
+          connectionId: "connection-1",
+          isExpanded: false,
+          children: [
+            {
+              id: "connection-1:__user_admin",
+              label: "tree.userAdmin",
+              type: "user-admin",
+              connectionId: "connection-1",
+              database: "",
+            },
+          ],
+        },
+      ],
+      "1000",
+      new Set(),
+    )[0];
+    if (!filtered) throw new Error("Expected the matching connection search result");
+    return filtered;
+  }
+
+  it("activates a connection search result on one click in single-click mode", async () => {
+    settingsStore.editorSettings.sidebarActivation = "single";
+    const node = searchedConnection();
+    const { row, host } = await mountTreeItem(node);
+
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+
+    expect(node.children).toEqual([]);
+    expect(node.isExpanded).toBe(false);
+    expect(host.handleRowClick).toHaveBeenCalledWith(node, 1);
+    expect(host.handleRowDoubleClick).not.toHaveBeenCalled();
+  });
+
+  it("waits for a double click before activating a connection search result in double-click mode", async () => {
+    settingsStore.editorSettings.sidebarActivation = "double";
+    const node = searchedConnection();
+    const { row, host } = await mountTreeItem(node);
+
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+    expect(host.handleRowClick).not.toHaveBeenCalled();
+
+    row.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, detail: 2 }));
+
+    expect(host.handleRowDoubleClick).toHaveBeenCalledWith(node, expect.any(MouseEvent));
   });
 });

--- a/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
@@ -2,6 +2,7 @@ import type { TreeNode, TreeNodeType } from "@/types/database";
 import { createSidebarLabelMatcher, type SidebarLabelMatcher } from "@/lib/sidebar/sidebarSearch";
 
 const preserveMatchedSubtreeTypes = new Set(["connection", "database", "schema", "table", "view", "mongo-db", "mongo-collection"]);
+const hiddenSearchNodeTypes = new Set<TreeNodeType>(["user-admin", "dameng-job-admin"]);
 
 function bestMatch(matchLabel: SidebarLabelMatcher, label: string, comment?: string | null) {
   const lm = matchLabel(label);
@@ -43,10 +44,16 @@ function applySearchCollapsedState(node: TreeNode, collapsedIds: ReadonlySet<str
   };
 }
 
+function preservedSearchChildren(node: TreeNode, collapsedIds: ReadonlySet<string>): TreeNode[] | undefined {
+  if (!node.children) return undefined;
+  return node.children.filter((child) => !hiddenSearchNodeTypes.has(child.type)).map((child) => applySearchCollapsedState(child, collapsedIds));
+}
+
 function filterSidebarTreeWithMatcher(nodes: TreeNode[], matchLabel: SidebarLabelMatcher | undefined, collapsedIds: ReadonlySet<string>, searchableNodeTypes?: ReadonlySet<TreeNodeType>): TreeNode[] {
   const filteredNodes: { node: TreeNode; score: number }[] = [];
 
   for (const node of nodes) {
+    if (matchLabel && hiddenSearchNodeTypes.has(node.type)) continue;
     if (node.type === "object-browser" && node.hiddenChildren) {
       const matches = node.hiddenChildren.flatMap((child) => {
         if (searchableNodeTypes && !searchableNodeTypes.has(child.type)) return [];
@@ -67,7 +74,10 @@ function filterSidebarTreeWithMatcher(nodes: TreeNode[], matchLabel: SidebarLabe
     // A type-matched table keeps its loaded detail groups after the text query
     // is cleared instead of being rebuilt with an empty filtered child list.
     const preservesTypeMatchedTable = !matchLabel && !!selfMatch && node.type === "table";
-    const filteredChildren = preservesSubtree ? node.children?.map((child) => applySearchCollapsedState(child, collapsedIds)) : node.children ? filterSidebarTreeWithMatcher(node.children, matchLabel, collapsedIds, searchableNodeTypes) : undefined;
+    // Connection utility entries are synthetic navigation actions, not schema
+    // search results. Keep real loaded descendants for connection-name matches,
+    // but do not let those actions make a disconnected result look expanded.
+    const filteredChildren = preservesSubtree ? preservedSearchChildren(node, collapsedIds) : node.children ? filterSidebarTreeWithMatcher(node.children, matchLabel, collapsedIds, searchableNodeTypes) : undefined;
 
     if (selfMatch || (filteredChildren && filteredChildren.length > 0)) {
       if (!node.children || preservesTypeMatchedTable) {

--- a/packages/app-tests/sidebarSearchTree.test.ts
+++ b/packages/app-tests/sidebarSearchTree.test.ts
@@ -212,6 +212,89 @@ test("preserves loaded children when the connection itself matches search", () =
   assert.equal(filtered[0]?.children?.[0]?.children?.[0]?.label, "products");
 });
 
+test("omits synthetic connection management entries when the connection itself matches search", () => {
+  const nodes: TreeNode[] = [
+    {
+      id: "conn:1",
+      label: "1000-test",
+      type: "connection",
+      connectionId: "conn:1",
+      isExpanded: false,
+      children: [
+        {
+          id: "conn:1:inventory",
+          label: "inventory",
+          type: "database",
+          connectionId: "conn:1",
+          database: "inventory",
+        },
+        {
+          id: "conn:1:__user_admin",
+          label: "tree.userAdmin",
+          type: "user-admin",
+          connectionId: "conn:1",
+          database: "",
+        },
+        {
+          id: "conn:1:__dameng_jobs",
+          label: "tree.damengJobAdmin",
+          type: "dameng-job-admin",
+          connectionId: "conn:1",
+          database: "",
+        },
+      ],
+    },
+  ];
+
+  const filtered = filterSidebarTree(nodes, "1000", new Set());
+
+  assert.deepEqual(
+    filtered[0]?.children?.map((child) => child.type),
+    ["database"],
+  );
+  assert.equal(filtered[0]?.isExpanded, true);
+});
+
+test("keeps a disconnected connection search result collapsed when it only has synthetic management entries", () => {
+  const nodes: TreeNode[] = [
+    {
+      id: "conn:1",
+      label: "1000",
+      type: "connection",
+      connectionId: "conn:1",
+      isExpanded: false,
+      children: [
+        {
+          id: "conn:1:__user_admin",
+          label: "tree.userAdmin",
+          type: "user-admin",
+          connectionId: "conn:1",
+          database: "",
+        },
+      ],
+    },
+  ];
+
+  const filtered = filterSidebarTree(nodes, "1000", new Set());
+
+  assert.deepEqual(filtered[0]?.children, []);
+  assert.equal(filtered[0]?.isExpanded, false);
+});
+
+test("does not return synthetic connection management entries as direct text matches", () => {
+  const nodes: TreeNode[] = [
+    {
+      id: "conn:1:__user_admin",
+      label: "tree.userAdmin",
+      type: "user-admin",
+      connectionId: "conn:1",
+      database: "",
+    },
+  ];
+
+  assert.deepEqual(filterSidebarTree(nodes, "userAdmin", new Set()), []);
+});
+
 test("temporarily collapses an empty object group within a preserved search subtree", () => {
   const tablesGroup: TreeNode = {
     id: "conn:1:inventory:__tables",


### PR DESCRIPTION
## 变更说明

修复按连接名搜索时，“用户与权限”等合成管理入口被错误带入搜索结果，并导致首次打开操作只收起连接的问题。

- 文本搜索期间排除 `user-admin` 和 `dameng-job-admin` 合成管理节点。
- 连接名命中时继续保留已加载的真实数据库、Schema、表等对象子树。
- 如果未连接连接只有合成管理节点，过滤后的搜索结果保持折叠状态，不再伪装成已展开连接。
- 增加搜索树回归测试，以及“单击打开/双击打开”两种设置下的组件交互测试。

## 根因与影响

`11fac631c7` 为了让连接名命中时仍能浏览已加载对象，将 `connection` 加入了“保留命中节点整棵子树”的范围。之后连接下的“用户与权限”等合成导航节点也被无差别保留：

1. 未连接的搜索结果因为存在合成子节点而被投影成展开状态。
2. 第一次按侧边栏打开方式操作时，现有 `toggle()` 只会收起该搜索投影。
3. 用户必须再次操作才能真正连接并加载数据库。

本次修复只过滤不属于数据库对象搜索结果的合成管理节点，不改变 #2899 所需的真实对象子树保留行为，也不影响 #5439、#4940 和 PR #5442 已实现的搜索期间展开/折叠能力。

## 用户影响

- 搜索连接名时不再展示与关键字无关的“用户与权限”或作业管理入口。
- “单击打开”模式下，一次单击即可触发连接打开。
- “双击打开”模式下，单击只选中，双击触发打开。
- 已连接项目仍可在搜索结果中继续浏览真实数据库对象。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 涉及前端搜索树数据投影和点击行为，但不改变视觉样式。复现现象和行为论证见 #5938；交互结果由新增组件测试覆盖。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `pnpm vitest run packages/app-tests/sidebarSearchTree.test.ts apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts apps/desktop/src/lib/__tests__/sidebar/treeNodeClick.spec.ts`（35 项通过）
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] 目标文件 `oxfmt --check`
- [x] 目标文件 `oxlint`
- [x] `git diff --check`
- [ ] `make check`（本次已执行更聚焦的前端检查）
- [ ] `make cargo-check-fast`（未修改 Rust 代码）

## 关联 Issue

Close #5938
