### PR TITLE
fix(duckdb): support table rename

### DIFF
--- a/apps/desktop/src/lib/table/objectRenameSql.ts
+++ b/apps/desktop/src/lib/table/objectRenameSql.ts
@@ -21,7 +21,7 @@ export function supportsObjectRename(databaseType: DatabaseType | undefined, obj
   if (objectType === "PROCEDURE" || objectType === "FUNCTION") {
     return false;
   }
-  if (databaseType === "sqlite" || databaseType === "rqlite" || databaseType === "turso" || databaseType === "cloudflare-d1") return objectType === "TABLE";
+  if (databaseType === "sqlite" || databaseType === "rqlite" || databaseType === "turso" || databaseType === "cloudflare-d1" || databaseType === "duckdb") return objectType === "TABLE";
   if (databaseType === "mysql" || databaseType === "goldendb") return objectType === "TABLE" || objectType === "VIEW";
   if (postgresLikeRenameTypes.has(databaseType)) return objectType === "TABLE" || objectType === "VIEW" || objectType === "MATERIALIZED_VIEW";
   if (oracleLikeRenameTypes.has(databaseType)) return objectType === "TABLE" || objectType === "VIEW" || objectType === "MATERIALIZED_VIEW";

--- a/crates/dbx-core/src/db_admin_sql.rs
+++ b/crates/dbx-core/src/db_admin_sql.rs
@@ -685,7 +685,11 @@ pub fn supports_object_rename(database_type: Option<DatabaseType>, object_type: 
     }
     if matches!(
         database_type,
-        DatabaseType::Sqlite | DatabaseType::Rqlite | DatabaseType::Turso | DatabaseType::CloudflareD1
+        DatabaseType::Sqlite
+            | DatabaseType::Rqlite
+            | DatabaseType::Turso
+            | DatabaseType::CloudflareD1
+            | DatabaseType::DuckDb
     ) {
         return object_type == DatabaseObjectType::Table;
     }
@@ -729,7 +733,13 @@ pub fn build_rename_object_sql(options: RenameObjectSqlOptions) -> Result<String
 
     if matches!(
         database_type,
-        Some(DatabaseType::Sqlite | DatabaseType::Rqlite | DatabaseType::Turso | DatabaseType::CloudflareD1)
+        Some(
+            DatabaseType::Sqlite
+                | DatabaseType::Rqlite
+                | DatabaseType::Turso
+                | DatabaseType::CloudflareD1
+                | DatabaseType::DuckDb
+        )
     ) {
         return Ok(format!(
             "ALTER TABLE {} RENAME TO {};",
@@ -1864,6 +1874,23 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn builds_duckdb_table_rename_sql() {
+        assert!(supports_object_rename(Some(DatabaseType::DuckDb), DatabaseObjectType::Table));
+        assert!(!supports_object_rename(Some(DatabaseType::DuckDb), DatabaseObjectType::View));
+        assert_eq!(
+            build_rename_object_sql(RenameObjectSqlOptions {
+                database_type: Some(DatabaseType::DuckDb),
+                object_type: DatabaseObjectType::Table,
+                schema: Some("main".to_string()),
+                old_name: "users".to_string(),
+                new_name: "app users".to_string(),
+            })
+            .unwrap(),
+            "ALTER TABLE \"main\".\"users\" RENAME TO \"app users\";"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

为 DuckDB 表增加重命名支持。前端会显示表重命名入口，后端生成 DuckDB 原生的 `ALTER TABLE ... RENAME TO ...` 语句，并保持视图、函数和存储过程不可重命名。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本次仅更新已有右键/F2 重命名入口的 DuckDB 能力判断，无新增或变更界面。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过：`cargo test -p dbx-core --no-default-features db_admin_sql::tests::builds_duckdb_table_rename_sql`
- [x] 使用项目 DuckDB 1.3.2 驱动实际执行 `ALTER TABLE "main"."old table" RENAME TO "new table";`

## 关联 Issue

Close #4532