### PR TITLE
fix(agents): ignore nested Java bin outputs

### DIFF
--- a/agents/.gitignore
+++ b/agents/.gitignore
@@ -3,7 +3,7 @@
 !drivers/uxdb/libs/uxdbjdbc-2.1.2.3p.jre8.jar
 gradle.properties
 build/
-*/bin/
+bin/
 .gradle/
 .DS_Store
 openspec


### PR DESCRIPTION
## 变更说明

修正 `agents/.gitignore` 中 Java `bin/` 产物的忽略范围，将只能覆盖直属子项目的 `*/bin/` 调整为可覆盖 `agents/` 下任意层级的 `bin/`。

Red Hat JDT Language Server 会在 Gradle 子项目内生成 `bin/main`、`bin/test` 等增量编译产物。原规则能够忽略 `agents/common/bin/`，但无法匹配 `agents/drivers/<name>/bin/` 这类更深层路径，导致生成的 `.class` 文件出现在 Git 工作区中。

新规则继续限定在 `agents/` 目录内，不影响仓库其他模块；当前也没有任何 `agents/**/bin/**` 文件被 Git 追踪。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [x] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

不涉及前端改动。

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

验证详情：

- `./gradlew test shadowJar --continue`：通过（132 tasks）
- `git diff --check`：通过
- 实际生成 220 个 `agents/**/bin/` 文件后，普通 `git status` 中没有出现这些产物；使用 `--ignored` 检查时均显示为 `!!`
- `git check-ignore -v`：确认直属和嵌套的 `bin/` 路径均命中新规则
- `git ls-files 'agents/**/bin/**'`：返回 0 个已追踪文件
- `make check`：format、lint、typecheck 通过；test 阶段有 28 个与本改动无关的既有前端测试失败，原因是测试环境中的 `localStorage` 不可用（`DataGridSurfaces.spec.ts` 与 `externalSqlFileTarget.spec.ts`）

## 关联 Issue

无。
