### PR TITLE
fix(editor): fix SQL formatter export config button doing nothing in desktop app

### DIFF
--- a/apps/desktop/src/components/editor/SqlFormatterSettingsPanel.vue
+++ b/apps/desktop/src/components/editor/SqlFormatterSettingsPanel.vue
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/composables/useToast";
 import { copyToClipboard } from "@/lib/common/clipboard";
+import { saveTextFile } from "@/lib/export/saveTextFile";
 import {
   DEFAULT_SQL_FORMATTER_SETTINGS,
   SQL_FORMATTER_CONFIG_FORMATTER,
@@ -299,16 +300,8 @@ async function onImportFile(event: Event) {
   }
 }
 
-function exportConfig() {
-  const blob = new Blob([serializeSqlFormatterConfig(settings.value)], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = "dbx-sql-formatter.json";
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
+async function exportConfig() {
+  await saveTextFile(serializeSqlFormatterConfig(settings.value), "dbx-sql-formatter.json", "JSON", "json");
 }
 
 async function copyJsonDraft() {


### PR DESCRIPTION
## Summary
- The "Export config" button in Settings → Editor → SQL Formatter used the browser `Blob` + `<a download>` trick, which silently does nothing in the Tauri desktop WebView.
- Switched it to the shared `saveTextFile()` helper (`apps/desktop/src/lib/export/saveTextFile.ts`), the same helper every other export feature in the app already uses. It opens the native save dialog via `@tauri-apps/plugin-dialog` in the desktop app and falls back to the browser download trick on web.

Fixes #5918

## Test plan
- [x] `pnpm typecheck` passes with no new errors
- [x] Built and ran the actual Tauri desktop app (`pnpm dev:tauri`) on macOS
- [x] Settings → Editor → SQL Formatter → clicked "导出配置" (Export config) — before the fix: no response; after the fix: native macOS save dialog appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)