### PR TITLE
fix(sidebar): don't force-expand located tables before their groups load

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -1065,7 +1065,11 @@ async function locateActiveTabInSidebar() {
   if (!nodePath) return;
 
   for (const ancestor of nodePath) {
-    if (!ancestor.isExpanded) {
+    // Only flip the arrow when this node's own children are already loaded
+    // (e.g. by ensureTreeLoadedForTarget above). Forcing isExpanded on a
+    // table/collection whose column/index groups were never fetched shows an
+    // "expanded" arrow with no content underneath (issue #5850).
+    if (!ancestor.isExpanded && store.canUseLoadedTreeNodeToggle(ancestor)) {
       ancestor.isExpanded = true;
     }
   }


### PR DESCRIPTION
## What

Fixes #5850

Locating a table in the sidebar (via the SQL editor cursor / active tab context) always forced every ancestor node in its tree path — including the table itself — into the expanded state, regardless of whether that node's children were actually loaded yet.

For a table that had never been expanded before, this flipped the arrow to "expanded" while the Columns/Indexes/etc. groups underneath were never fetched, so the tree showed an expanded arrow with nothing inside. Previously-expanded tables looked fine because their children were already cached — hence the "不统一" (inconsistent) behavior reported in the issue.

## Fix

`locateActiveTabInSidebar` now only auto-expands a node in the located path when `connectionStore.canUseLoadedTreeNodeToggle(node)` is true — the same check the normal click-to-expand handler (`SidebarTreeRuntimeHost.vue`'s `toggle()`) uses to decide whether cached children can be shown without a reload. Database/schema ancestors are unaffected since `ensureTreeLoadedForTarget` already populates their children before this loop runs; only a not-yet-expanded table/collection leaf is left collapsed, matching the reporter's own suggestion that locate should just reveal/select the table rather than force its structure open.

## Testing

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/sidebar/treeLoadedChildrenMarker.spec.ts` — pass (covers the reused `canUseLoadedTreeNodeToggle` semantics)
- `pnpm exec vitest run apps/desktop/src/stores/__tests__/connectionStore.treeMemory.spec.ts apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts` — pass
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json` — pass

I wasn't able to exercise this against a live DB connection in my current environment (no GUI/Tauri runtime available here), so I'd appreciate a sanity check from anyone who can reproduce with a real connection: locate a table via cursor position in the SQL editor that has never been expanded in the sidebar before, and confirm it now stays collapsed (arrow not flipped) instead of showing an empty expanded state.