### PR TITLE
fix(editor): keep full-width characters from crashing SQL formatting

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -57,6 +57,13 @@ describe("sqlFormatter", () => {
     await expect(formatSqlForEditing(sql, "mysql")).resolves.toBe(sql);
   });
 
+  it("keeps editor SQL unchanged when it contains full-width characters the tokenizer can't parse", async () => {
+    const sql = "update t set a=concat(t.入池时间（审核通过时间）,' 00:00:00') where t.入池时间（审核通过时间） ≠ '';";
+
+    await expect(formatSqlText(sql, "mysql")).rejects.toThrow("Parse error: Unexpected");
+    await expect(formatSqlForEditing(sql, "mysql")).resolves.toBe(sql);
+  });
+
   it("keeps non-parse editor formatting failures visible", async () => {
     const oversizedSql = "x".repeat(MAX_SQL_FORMAT_CHARS + 1);
 

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -339,8 +339,21 @@ function applySqlFormatterLayout(sql: string, settings: SqlFormatterSettings, di
   return formatted;
 }
 
+/**
+ * sql-formatter throws two distinct shapes when it can't parse the input:
+ * - Grammar-level (nearley parser): `Parse error at token: ... ` with `.offset`/`.token`
+ *   set on the error, e.g. valid tokens in an unexpected position (mid-edit SQL).
+ * - Lexer-level (TokenizerEngine): a plain `Parse error: Unexpected "..." at line ...`
+ *   when a character sequence doesn't match any token rule at all — e.g. full-width
+ *   punctuation (`≠`, `（`, `）`) that MySQL accepts in identifiers/expressions but
+ *   sql-formatter's tokenizer doesn't recognize.
+ * Both mean "sql-formatter can't handle this text", so both should fall back to the
+ * original SQL instead of surfacing a failure.
+ */
 function isSqlFormatterParseError(error: unknown): boolean {
-  if (!(error instanceof Error) || !error.message.startsWith("Parse error at token:")) return false;
+  if (!(error instanceof Error)) return false;
+  if (error.message.startsWith("Parse error: Unexpected ")) return true;
+  if (!error.message.startsWith("Parse error at token:")) return false;
   const candidate = error as Error & { offset?: unknown; token?: unknown };
   return typeof candidate.offset === "number" && candidate.token !== undefined;
 }


### PR DESCRIPTION
## Summary

- `sql-formatter`'s tokenizer throws a bare `Parse error: Unexpected "..."` when it hits characters it can't tokenize at all — e.g. full-width `≠`/`（）`, which MySQL accepts in identifiers/expressions but `sql-formatter` doesn't recognize.
- `isSqlFormatterParseError` (used by `formatSqlForEditing`, the function the editor's "Format SQL" command calls) only recognized the *grammar-level* nearley error shape (`Parse error at token: ...` with `.offset`/`.token`), not this *lexer-level* one, so the tokenizer error propagated and surfaced as a "SQL 格式化失败" toast instead of leaving the SQL unchanged like other unparseable-editor-SQL cases already do.
- Widened the check to also recognize the `Parse error: Unexpected ...` shape, so it falls back to the original SQL instead of throwing — consistent with how the existing "incomplete mid-edit SQL" case is already handled.

## Test plan

- [x] Added a regression test in `sqlFormatter.spec.ts` using the exact repro SQL from the issue (full-width `≠` and `（）`), asserting `formatSqlText` still throws (raw formatter behavior unchanged) while `formatSqlForEditing` now resolves to the original SQL unchanged.
- [x] `pnpm test` (`apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts`) — 19/19 passing.
- [x] `vue-tsc --noEmit` — clean.
- [x] Manually verified in the desktop app: pasted the repro SQL into the query editor and clicked "格式化" — before the fix it threw the error toast, after the fix it no-ops silently (no crash) and normal SQL still formats correctly.

Fixes #5988

🤖 Generated with [Claude Code](https://claude.com/claude-code)