### PR TITLE
fix(editor): center search match instead of scrolling to viewport edge

### DIFF
--- a/apps/desktop/src/components/editor/EditorSearchPanel.vue
+++ b/apps/desktop/src/components/editor/EditorSearchPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, nextTick, onBeforeUnmount, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { EditorSelection } from "@codemirror/state";
 import { setSearchQuery, openSearchPanel as cmOpenSearchPanel, findNext as cmFindNext, findPrevious as cmFindPrevious, replaceNext as cmReplaceNext, replaceAll as cmReplaceAll } from "@codemirror/search";
 import { ChevronUp, ChevronDown, ChevronRight, TextSelect, X } from "@lucide/vue";
@@ -171,7 +171,10 @@ function findInScope(direction: "next" | "prev"): boolean {
   if (target) {
     v.dispatch({
       selection: EditorSelection.range(target.from, target.to),
-      scrollIntoView: true,
+      // Center the match instead of the default "nearest" alignment, which
+      // often lands the match flush against the viewport edge and makes an
+      // immediate drag-select there trigger CodeMirror's edge autoscroll.
+      effects: EditorView.scrollIntoView(target.from, { y: "center" }),
     });
     return true;
   }

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -4679,6 +4679,10 @@ onMounted(async () => {
           dom.style.display = "none";
           return { dom };
         },
+        // Center the match instead of the default "nearest" alignment, which
+        // often lands the match flush against the viewport edge and makes an
+        // immediate drag-select there trigger CodeMirror's edge autoscroll.
+        scrollToMatch: (range) => EditorView.scrollIntoView(range, { y: "center" }),
       }),
       runGutterComp.of(runStatementGutterExtension()),
       lineNumbers({


### PR DESCRIPTION
## Problem

Fixes #5520

When searching in the SQL editor (Cmd/Ctrl+F) with a long statement, jumping to a match and then dragging to select text on that line could cause the editor to suddenly scroll a large distance, with the resulting selection spanning far more than the user intended.

## Root cause

The search-jump dispatched `scrollIntoView: true`, which uses CodeMirror's default `"nearest"` alignment — it scrolls the *minimum* distance needed to bring the match into view, which frequently leaves the matched line sitting flush against the very top or bottom edge of the viewport. Starting a drag-selection from that edge-adjacent line then triggers CodeMirror's own built-in "autoscroll while dragging near the viewport edge" behavior, producing a large, unexpected scroll jump and an over-extended selection — even for a purely horizontal drag within one line.

Confirmed with an automated repro (headless browser driving real mouse events): before the fix, a 60px horizontal drag on the match's line caused `scrollTop` to climb continuously from 171 to 1227 (the whole document), with the selection jumping from the match's line to the very end of the document. After the fix, `scrollTop` stayed constant throughout the same drag.

## Fix

Scroll the match into view with `y: "center"` alignment instead of the default `"nearest"`, in both search paths:
- `EditorSearchPanel.vue`'s scoped `findInScope()` jump
- `QueryEditor.vue`'s full-document search (via the `scrollToMatch` config option on CodeMirror's `search()` extension, which backs the built-in `findNext`/`findPrevious` commands)

## Testing

- `pnpm typecheck` — passes
- `vitest run apps/desktop/src/components/editor/__tests__/EditorSearchPanel.spec.ts` — passes
- Automated before/after repro via Playwright driving the running dev app (search-jump → real mouse drag), confirming the scroll no longer runs away