### PR TITLE
fix(ssh): raise host-key prompt above the connection dialog

### DIFF
--- a/apps/desktop/src/components/ssh/SshHostKeyPromptDialog.vue
+++ b/apps/desktop/src/components/ssh/SshHostKeyPromptDialog.vue
@@ -238,7 +238,16 @@ function submitSecret() {
 
 <template>
   <Dialog v-model:open="visible">
-    <DialogContent class="sm:max-w-[460px]" :show-close-button="false" @interact-outside.prevent @escape-key-down.prevent>
+    <!-- Every dialog portal teleports into <body> when its component mounts, so
+    body order (and therefore paint order at the shared z-50) is fixed by mount
+    order, not by which dialog opened last. This prompt mounts once at app start,
+    so a dialog mounted on demand later (e.g. the connection editor) paints over
+    it while still being demoted to pointer-events:none as the lower modal layer
+    — the prompt is invisible, the dialog is dead, and the window is stuck. This
+    is a blocking prompt, so keep it above every other layer in the app (the
+    tallest today are the image preview at 80/81 and the sidebar overlays at
+    100). -->
+    <DialogContent class="sm:max-w-[460px]" overlay-class="z-[200]" portal-class="z-[200]" :show-close-button="false" @interact-outside.prevent @escape-key-down.prevent>
       <DialogHeader>
         <DialogTitle>
           {{ t(isSecretPrompt ? "connection.sshInteractiveTitle" : "connection.sshHostKeyVerifyTitle") }}

--- a/apps/desktop/src/components/ssh/__tests__/SshHostKeyPromptDialog.spec.ts
+++ b/apps/desktop/src/components/ssh/__tests__/SshHostKeyPromptDialog.spec.ts
@@ -124,6 +124,15 @@ describe("SshHostKeyPromptDialog web bridge", () => {
     expect(dialogSource).not.toContain(':dismissible="false"');
   });
 
+  it("stacks above dialogs that mount later than it does", () => {
+    // Dialog portals teleport into <body> when their component mounts, so paint
+    // order at the shared z-50 follows mount order. This prompt mounts once at
+    // app start, so an on-demand dialog (e.g. the connection editor) would bury
+    // it and block the whole window. It must opt out of the default layer.
+    expect(dialogSource).toContain('overlay-class="z-[200]"');
+    expect(dialogSource).toContain('portal-class="z-[200]"');
+  });
+
   it("shows an SSE host-key prompt and posts the user's acceptance", async () => {
     await mountDialog();
 


### PR DESCRIPTION
Fixes #5989

## Problem

Editing a saved connection → SSH tunnel → add a jump host with an unknown fingerprint → click "Test connection" triggers the SSH host-key confirmation dialog. That dialog is invisible, buried behind the still-open connection editor dialog, and both dialogs stop responding to clicks — the only way out is to force-quit the app.

## Root cause

Every dialog portal teleports into `<body>` on mount, so paint order at the shared `z-50` layer follows *mount* order, not which dialog opened last. `SshHostKeyPromptDialog` is mounted unconditionally at app start (`AppDialogs.vue`), while the connection editor mounts on demand. So the editor's portal always lands after the prompt's in the DOM and paints over it — while the underlying dialog stacking library also demotes the editor to `pointer-events: none` as the lower modal layer. The prompt is invisible, the editor is inert, and the window is stuck.

Confirmed by inspecting real z-index/pointer-events values in a running instance before and after the fix (not just from reading the code).

## Fix

`SshHostKeyPromptDialog`'s `DialogContent` now gets an explicit `overlay-class="z-[200]"` / `portal-class="z-[200]"` (both existing props on the shared dialog component) so it always paints above every other dialog layer in the app — checked the rest of the codebase for existing z-index usage (up to `z-[140]`) to pick a value that stays clear of it.

Added a regression test asserting those classes stay on the component.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm exec oxfmt --check` on the changed files — all pass
- `pnpm test` — full suite passes (909 files / 8449 tests)
- Manually reproduced before/after in a running desktop dev build: before, the host-key prompt is buried and unclickable, and accepting/dismissing it is impossible without force-quitting; after, the prompt renders on top, is clickable, and the connection editor stays intact and usable afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)