### PR TITLE
fix(editor): resolve table structure preview for quoted identifiers with hyphens

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -66,6 +66,7 @@ import {
 import { usesOracleSessionCompletionColumns as shouldUseOracleSessionCompletionColumns } from "@/lib/sql/oracleCompletionSession";
 import {
   extractIdentifierDetailsAt,
+  extractQualifiedIdentifierAt,
   isSqlKeyword,
   matchSqlObject,
   matchTable,
@@ -79,7 +80,7 @@ import {
   sqlObjectNavigationTypeFromCompletionObjectType,
   type SqlObjectNavigationTarget,
 } from "@/lib/sql/sqlNavigation";
-import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
+import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, quoteIdentifier, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
 import { constrainSqlHoverLayout } from "@/lib/editor/sqlHoverLayout";
 import { lineColumnToOffset, sqlErrorDecorationRange as resolveSqlErrorDecorationRange } from "@/lib/sql/sqlDiagnostics";
 import {
@@ -1986,18 +1987,23 @@ function sqlExecutionSnapshotForRange(currentView: EditorViewType, range: Pick<S
   };
 }
 
+/**
+ * Locate the qualified identifier at `pos`, delegating to the same quote-aware
+ * parser used by Ctrl+click navigation. A plain word-character scan (the
+ * previous approach here) breaks on quoted identifiers containing characters
+ * outside `[\w$]` (hyphens, spaces, ...), e.g. `schema."my-table"`.
+ *
+ * Every part is re-quoted in the returned text (regardless of whether it was
+ * originally quoted) so downstream re-parsing via `splitQualifiedIdentifier`
+ * round-trips correctly even when a part's raw value isn't a bare word.
+ */
 function identifierRangeAt(sql: string, pos: number): { from: number; to: number; text: string } | null {
-  const isIdentifierChar = (ch: string | undefined) => !!ch && /[\w$.]/.test(ch);
-  if (!isIdentifierChar(sql[pos]) && !isIdentifierChar(sql[pos - 1])) return null;
-
-  let from = pos;
-  while (from > 0 && isIdentifierChar(sql[from - 1])) from--;
-  let to = pos;
-  while (to < sql.length && isIdentifierChar(sql[to])) to++;
-
-  const text = sql.slice(from, to).replace(/^\.+|\.+$/g, "");
-  if (!text || isSqlKeyword(text)) return null;
-  return { from, to, text };
+  const located = extractQualifiedIdentifierAt(sql, pos);
+  if (!located) return null;
+  if (located.parts.length === 1 && !located.parts[0].quoted && isSqlKeyword(located.parts[0].value)) return null;
+  const text = located.parts.map((part) => quoteIdentifier(part.value)).join(".");
+  if (!text) return null;
+  return { from: located.start, to: located.end, text };
 }
 
 type CompletionMetadataScope = Pick<SqlCompletionScope, "database" | "schema">;

--- a/apps/desktop/src/lib/__tests__/sql/sqlNavigation.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlNavigation.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { quoteIdentifier } from "@/lib/editor/hoverTableSql";
 import {
   extractIdentifierAt,
   extractIdentifierDetailsAt,
+  extractQualifiedIdentifierAt,
   isSqlCallSiteIdentifierAt,
   isSqlKeyword,
   isSqlObjectNavigationRoutineType,
@@ -72,6 +74,25 @@ describe("splitQualifiedIdentifier", () => {
   it("splits quoted and multi-part identifiers", () => {
     expect(splitQualifiedIdentifier('catalog."MAAC00".Accounts')).toEqual(["catalog", "MAAC00", "Accounts"]);
     expect(splitQualifiedIdentifier("`MAAC00`.Accounts")).toEqual(["MAAC00", "Accounts"]);
+  });
+});
+
+describe("extractQualifiedIdentifierAt", () => {
+  it("keeps the full quoted segment when it contains a hyphen", () => {
+    const sql = 'select * from log."public-rate_kingdee"';
+
+    const located = extractQualifiedIdentifierAt(sql, sql.indexOf("rate_kingdee"));
+
+    expect(located?.parts.map((part) => part.value)).toEqual(["log", "public-rate_kingdee"]);
+  });
+
+  it("re-quoting each part before rejoining survives a splitQualifiedIdentifier round trip", () => {
+    const sql = 'select * from log."public-rate_kingdee"';
+    const located = extractQualifiedIdentifierAt(sql, sql.indexOf("rate_kingdee"));
+
+    const requoted = located!.parts.map((part) => quoteIdentifier(part.value)).join(".");
+
+    expect(splitQualifiedIdentifier(requoted)).toEqual(["log", "public-rate_kingdee"]);
   });
 });
 


### PR DESCRIPTION
## Problem

Hovering a schema-qualified table reference like `log."public-rate_kingdee"` in the SQL editor to preview its structure resolves the wrong table (or shows nothing at all if the mangled name happens not to collide with any real table).

## Root cause

The hover tooltip's `identifierRangeAt` in `QueryEditor.vue` scanned characters with a plain `/[\w$.]/` class, which has no notion of quoted identifiers. On a quoted identifier containing a hyphen, it truncates at the hyphen and drops the surrounding quotes — e.g. hovering `"public-rate_kingdee"` extracts just `rate_kingdee`, which then gets looked up against the connection's *default* schema instead of the actual `log` schema, producing a wrong (or missing) preview.

Ctrl+click "go to definition" navigation on the same identifier already works correctly because it goes through the quote-aware `extractQualifiedIdentifierAt` parser in `sqlNavigation.ts` — the hover tooltip path just never used it.

## Fix

`identifierRangeAt` now delegates to `extractQualifiedIdentifierAt`, re-quoting each returned part so the identifier still round-trips correctly through `splitQualifiedIdentifier` downstream.

## Testing

- Added a regression test in `sqlNavigation.spec.ts` covering the exact `log."public-rate_kingdee"` scenario, both for `extractQualifiedIdentifierAt` directly and for the re-quote round trip through `splitQualifiedIdentifier`.
- `pnpm typecheck` — clean
- `pnpm lint` — no new warnings
- `pnpm vitest run apps/desktop/src` — full suite passes (628 files / 5726 tests)
- Manually verified against a live KingbaseES connection: created `log."public-rate_kingdee"`, ran `select * from log."public-rate_kingdee"`, and confirmed the hover preview now correctly shows `create table "systems"."log"."public-rate_kingdee" (...)` instead of resolving to an unrelated table / showing nothing.

Fixes #5983