### PR TITLE
Fix PostgreSQL reg type display

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -587,8 +587,40 @@ fn pg_scalar_type_requires_text_protocol(oid: u32, col_type: PgColType) -> bool 
     Type::from_oid(oid).is_none() && !matches!(col_type, PgColType::Vector | PgColType::Geometry)
 }
 
+/// PostgreSQL `reg*` types are OID-backed, but their useful representation is
+/// the catalog name returned by the text protocol (for example `regtype`
+/// returns `integer`). Decoding their binary payload as a generic value leaves
+/// the raw four-byte OID on the UI boundary, which is rendered as gibberish.
+fn pg_type_is_reg_type(pg_type: &Type) -> bool {
+    matches!(
+        pg_type.oid(),
+        oid if [
+            Type::REGPROC.oid(),
+            Type::REGPROCEDURE.oid(),
+            Type::REGOPER.oid(),
+            Type::REGOPERATOR.oid(),
+            Type::REGCLASS.oid(),
+            Type::REGTYPE.oid(),
+            Type::REGNAMESPACE.oid(),
+            Type::REGROLE.oid(),
+            Type::REGCOLLATION.oid(),
+            Type::REGPROC_ARRAY.oid(),
+            Type::REGPROCEDURE_ARRAY.oid(),
+            Type::REGOPER_ARRAY.oid(),
+            Type::REGOPERATOR_ARRAY.oid(),
+            Type::REGCLASS_ARRAY.oid(),
+            Type::REGTYPE_ARRAY.oid(),
+            Type::REGNAMESPACE_ARRAY.oid(),
+            Type::REGROLE_ARRAY.oid(),
+            Type::REGCOLLATION_ARRAY.oid(),
+        ]
+        .contains(&oid)
+    )
+}
+
 fn pg_type_requires_text_protocol(pg_type: &Type, col_type: PgColType) -> bool {
-    if pg_type.oid() == Type::RECORD.oid() || pg_type.oid() == Type::RECORD_ARRAY.oid() {
+    if pg_type.oid() == Type::RECORD.oid() || pg_type.oid() == Type::RECORD_ARRAY.oid() || pg_type_is_reg_type(pg_type)
+    {
         return true;
     }
 
@@ -6320,6 +6352,35 @@ mod tests {
             Type::new("_record".to_string(), Type::RECORD_ARRAY.oid(), Kind::Simple, "pg_catalog".to_string());
         assert!(pg_type_requires_text_protocol(&dynamic_record, PgColType::Other));
         assert!(pg_type_requires_text_protocol(&dynamic_record_array, PgColType::GenericArray));
+    }
+
+    #[test]
+    fn postgres_reg_types_use_text_protocol_for_catalog_names() {
+        // Binary reg* values are OIDs, while PostgreSQL's text output is the
+        // human-readable object/type name users expect to see in the grid.
+        for pg_type in [
+            Type::REGPROC,
+            Type::REGPROCEDURE,
+            Type::REGOPER,
+            Type::REGOPERATOR,
+            Type::REGCLASS,
+            Type::REGTYPE,
+            Type::REGNAMESPACE,
+            Type::REGROLE,
+            Type::REGCOLLATION,
+            Type::REGPROC_ARRAY,
+            Type::REGPROCEDURE_ARRAY,
+            Type::REGOPER_ARRAY,
+            Type::REGOPERATOR_ARRAY,
+            Type::REGCLASS_ARRAY,
+            Type::REGTYPE_ARRAY,
+            Type::REGNAMESPACE_ARRAY,
+            Type::REGROLE_ARRAY,
+            Type::REGCOLLATION_ARRAY,
+        ] {
+            assert!(pg_type_is_reg_type(&pg_type));
+            assert!(pg_type_requires_text_protocol(&pg_type, PgColType::Other));
+        }
     }
 
     #[test]

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -604,6 +604,8 @@ fn pg_type_is_reg_type(pg_type: &Type) -> bool {
             Type::REGNAMESPACE.oid(),
             Type::REGROLE.oid(),
             Type::REGCOLLATION.oid(),
+            Type::REGCONFIG.oid(),
+            Type::REGDICTIONARY.oid(),
             Type::REGPROC_ARRAY.oid(),
             Type::REGPROCEDURE_ARRAY.oid(),
             Type::REGOPER_ARRAY.oid(),
@@ -613,6 +615,8 @@ fn pg_type_is_reg_type(pg_type: &Type) -> bool {
             Type::REGNAMESPACE_ARRAY.oid(),
             Type::REGROLE_ARRAY.oid(),
             Type::REGCOLLATION_ARRAY.oid(),
+            Type::REGCONFIG_ARRAY.oid(),
+            Type::REGDICTIONARY_ARRAY.oid(),
         ]
         .contains(&oid)
     )
@@ -6368,6 +6372,8 @@ mod tests {
             Type::REGNAMESPACE,
             Type::REGROLE,
             Type::REGCOLLATION,
+            Type::REGCONFIG,
+            Type::REGDICTIONARY,
             Type::REGPROC_ARRAY,
             Type::REGPROCEDURE_ARRAY,
             Type::REGOPER_ARRAY,
@@ -6377,6 +6383,8 @@ mod tests {
             Type::REGNAMESPACE_ARRAY,
             Type::REGROLE_ARRAY,
             Type::REGCOLLATION_ARRAY,
+            Type::REGCONFIG_ARRAY,
+            Type::REGDICTIONARY_ARRAY,
         ] {
             assert!(pg_type_is_reg_type(&pg_type));
             assert!(pg_type_requires_text_protocol(&pg_type, PgColType::Other));


### PR DESCRIPTION
## 变更说明

修复 PostgreSQL `regtype`、`regproc` 等 `reg*` 类型查询结果显示乱码的问题。相关类型现在使用文本协议返回可读的目录名称。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] `cargo test -p dbx-core postgres_reg_types_use_text_protocol_for_catalog_names` 通过

## 关联 Issue

Close #6056,