### PR TITLE
fix(sidebar): 折叠数据库的表也能被全局搜索命中，且搜索后自动恢复折叠

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -9,6 +9,7 @@ import { useToast } from "@/composables/useToast";
 import type { ObjectSourceKind, TableInfo, TableNameFilter, TreeNode, TreeNodeType } from "@/types/database";
 import { filterSidebarSearchRootsByConnectionState, filterSidebarTree, filterSidebarTreeToConnectedConnections, resolveSidebarFilterGuards, reuseLiveSidebarTreeNodes } from "@/lib/sidebar/sidebarSearchTree";
 import { matchSidebarLabel } from "@/lib/sidebar/sidebarSearch";
+import { runSidebarSearchAutoLoad, shouldAutoLoadForSidebarSearch } from "@/lib/sidebar/sidebarSearchAutoLoad";
 import { buildTableTreeNodes } from "@/lib/table/tableTree";
 import { isCancelSearchShortcut, isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut, isViewTableDdlShortcut } from "@/lib/editor/keyboardShortcuts";
 import { sidebarNodeSupportsDdlView } from "@/lib/sidebar/sidebarTreeDdlShortcut";
@@ -21,6 +22,7 @@ import { usesTreeSchemaMode } from "@/lib/database/databaseFeatureSupport";
 import { connectionObjectTreeNodeSchema, connectionUsesDatabaseObjectTreeMode, effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 import { activeTabSidebarTarget, findSidebarNodeForActiveTab, findSidebarNodeForTarget, findNodePathForTarget, scrollTopForSidebarNode, shouldScrollActiveSidebarSelection, type ActiveTabSidebarTarget, type SidebarNodeScrollAlign } from "@/lib/sidebar/sidebarActiveTabTarget";
 import { findLoadedTableTargetForCandidate, queryContextTargetFromCandidate, queryCursorTableCandidate, type QueryCursorTableCandidate } from "@/lib/sql/queryCursorTableTarget";
+import { findTreeNodeById } from "@/lib/sql/newQueryContext";
 import { createFlatTreeIndex, SIDEBAR_TREE_ROW_HEIGHT, SIDEBAR_TREE_PRERENDER_COUNT, SIDEBAR_TREE_SCROLL_BUFFER, flattenTree, shouldVirtualizeFlatTree, type FlatTreeNode } from "@/composables/useFlatTree";
 import { sidebarTreeContextKey } from "@/lib/sidebar/sidebarTreeContext";
 import { createSidebarTreeRuntime, sidebarTreeRuntimeKey, type SidebarTreeRuntimeHostInstance } from "@/lib/sidebar/sidebarTreeRuntime";
@@ -327,6 +329,27 @@ const searchableNodeTypes = computed<Set<TreeNodeType> | undefined>(() => {
   return types;
 });
 
+// Global search only matches nodes already held in memory, so a collapsed
+// database hid its tables even while its connection was open. Preload those
+// levels whenever a query is active: the filter then spans every open
+// connection instead of forcing the user to expand databases one at a time.
+let searchAutoLoadToken = 0;
+function startSidebarSearchAutoLoad(): void {
+  const token = ++searchAutoLoadToken;
+  void runSidebarSearchAutoLoad({
+    getTreeNodes: () => store.treeNodes,
+    isConnected: (connectionId) => store.connectedIds.has(connectionId),
+    isChildrenLoaded: (nodeId) => store.isTreeNodeChildrenLoaded(nodeId),
+    loadChildren: (node) => store.loadTreeNodeChildren(node),
+    liveNode: (nodeId) => findTreeNodeById(store.treeNodes, nodeId),
+    isCancelled: () => token !== searchAutoLoadToken || !deferredSearchQuery.value.trim(),
+  });
+}
+
+watch([deferredSearchQuery, searchableNodeTypes], ([query, nodeTypes]) => {
+  if (shouldAutoLoadForSidebarSearch(query, nodeTypes)) startSidebarSearchAutoLoad();
+});
+
 function toggleSearchScope(scope: SearchScope) {
   const idx = selectedSearchScopes.value.indexOf(scope);
   if (idx >= 0) {
@@ -509,7 +532,7 @@ function measureSidebarCommentLabelWidths() {
       id,
       depth,
       alignable: isSidebarCommentAlignableNode(node),
-      hasComment: !!sidebarTreeNodeComment(node),
+      hasComment: !!sidebarTreeNodeComment(node, settingsStore.editorSettings.sidebarShowConnectionNotes),
       labelWidth: context.measureText(sidebarCommentLabel(node)).width,
     })),
   );
@@ -526,7 +549,7 @@ function scheduleSidebarCommentLabelMeasure() {
 
 function sidebarNodeHasTrailingMetadata(node: TreeNode): boolean {
   const mode = settingsStore.editorSettings.sidebarObjectInfoMode;
-  if (mode.startsWith("comment-") && sidebarTreeNodeComment(node)) return true;
+  if (mode.startsWith("comment-") && sidebarTreeNodeComment(node, settingsStore.editorSettings.sidebarShowConnectionNotes)) return true;
   return mode === "size" && sidebarStorageDisplayTypes.has(node.type) && !!formatSidebarObjectStorage(node.sizeBytes);
 }
 
@@ -563,10 +586,14 @@ function scheduleSidebarTreeContentWidthMeasure() {
   sidebarTreeContentMeasureFrame = window.requestAnimationFrame(measureSidebarTreeContentWidth);
 }
 
-watch([flatNodes, () => settingsStore.editorSettings.sidebarObjectInfoMode, () => settingsStore.editorSettings.sidebarHiddenTablePrefixes, () => settingsStore.editorSettings.uiFontFamily, () => settingsStore.editorSettings.uiScale], scheduleSidebarCommentLabelMeasure, {
-  flush: "post",
-  immediate: true,
-});
+watch(
+  [flatNodes, () => settingsStore.editorSettings.sidebarObjectInfoMode, () => settingsStore.editorSettings.sidebarShowConnectionNotes, () => settingsStore.editorSettings.sidebarHiddenTablePrefixes, () => settingsStore.editorSettings.uiFontFamily, () => settingsStore.editorSettings.uiScale],
+  scheduleSidebarCommentLabelMeasure,
+  {
+    flush: "post",
+    immediate: true,
+  },
+);
 
 watch([sidebarTreeNaturalWidthItems, () => settingsStore.editorSettings.uiFontFamily, () => settingsStore.editorSettings.uiScale], scheduleSidebarTreeContentWidthMeasure, {
   flush: "post",

--- a/apps/desktop/src/lib/__tests__/sidebar/sidebarSearchAutoLoad.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/sidebarSearchAutoLoad.spec.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it, vi } from "vitest";
+import { SIDEBAR_SEARCH_AUTO_LOAD_CONCURRENCY, collectSidebarSearchAutoLoadTargets, runSidebarSearchAutoLoad, shouldAutoLoadForSidebarSearch, sidebarSearchAutoLoadKind } from "@/lib/sidebar/sidebarSearchAutoLoad";
+import type { TreeNode, TreeNodeType } from "@/types/database";
+
+function node(overrides: Partial<TreeNode> & Pick<TreeNode, "id" | "type">): TreeNode {
+  return { label: overrides.id, ...overrides };
+}
+
+/** connection -> database, the shape a user sees with the connection open. */
+function connectionWithDatabases(connectionId: string, databases: string[]): TreeNode {
+  return node({
+    id: connectionId,
+    type: "connection",
+    connectionId,
+    isExpanded: true,
+    children: databases.map((database) =>
+      node({
+        id: `${connectionId}:${database}`,
+        type: "database",
+        connectionId,
+        database,
+        isExpanded: false,
+        children: [],
+      }),
+    ),
+  });
+}
+
+/** Grouped display: a loaded database exposes empty object-group placeholders. */
+function objectGroupPlaceholders(databaseNodeId: string, connectionId: string, database: string, schema?: string): TreeNode[] {
+  return (["group-tables", "group-views"] as const).map((type) =>
+    node({
+      id: `${databaseNodeId}:__${type}`,
+      type,
+      connectionId,
+      database,
+      schema,
+      isExpanded: false,
+      children: [],
+    }),
+  );
+}
+
+function tableNode(parentId: string, connectionId: string, database: string, name: string): TreeNode {
+  return node({ id: `${parentId}:${name}`, label: name, type: "table", connectionId, database, tableName: name });
+}
+
+type Harness = {
+  roots: TreeNode[];
+  loaded: Set<string>;
+  loadChildren: (target: TreeNode) => Promise<void>;
+  options: () => Parameters<typeof runSidebarSearchAutoLoad>[0];
+};
+
+/**
+ * Mirrors the store contract the component wires in: a load marks the node id as
+ * loaded, attaches children, and force-expands the node the way the real
+ * metadata loaders do.
+ */
+function harness(roots: TreeNode[], childrenFor: (target: TreeNode) => TreeNode[], hooks: { onLoad?: (target: TreeNode) => Promise<void> | void } = {}): Harness {
+  const loaded = new Set<string>();
+  const loadChildren = async (target: TreeNode) => {
+    await hooks.onLoad?.(target);
+    target.children = childrenFor(target);
+    target.isExpanded = true;
+    loaded.add(target.id);
+  };
+  const findById = (nodes: readonly TreeNode[], id: string): TreeNode | null => {
+    for (const current of nodes) {
+      if (current.id === id) return current;
+      const found = current.children ? findById(current.children, id) : null;
+      if (found) return found;
+    }
+    return null;
+  };
+  return {
+    roots,
+    loaded,
+    loadChildren,
+    options: () => ({
+      getTreeNodes: () => roots,
+      isConnected: () => true,
+      isChildrenLoaded: (nodeId: string) => loaded.has(nodeId),
+      loadChildren,
+      liveNode: (nodeId: string) => findById(roots, nodeId),
+    }),
+  };
+}
+
+describe("sidebarSearchAutoLoadKind", () => {
+  it("classifies the levels that gate table visibility", () => {
+    expect(sidebarSearchAutoLoadKind(node({ id: "d", type: "database", database: "app" }))).toBe("container");
+    expect(sidebarSearchAutoLoadKind(node({ id: "m", type: "mongo-db", database: "app" }))).toBe("container");
+    expect(sidebarSearchAutoLoadKind(node({ id: "v", type: "vector-database", database: "app" }))).toBe("container");
+    expect(sidebarSearchAutoLoadKind(node({ id: "s", type: "schema", schema: "public" }))).toBe("schema");
+    expect(sidebarSearchAutoLoadKind(node({ id: "g", type: "group-tables" }))).toBe("object-group");
+  });
+
+  it("ignores nodes that are not loadable search containers", () => {
+    // Missing database/schema context means the store has nothing to query.
+    expect(sidebarSearchAutoLoadKind(node({ id: "d", type: "database" }))).toBeNull();
+    expect(sidebarSearchAutoLoadKind(node({ id: "s", type: "schema" }))).toBeNull();
+    expect(sidebarSearchAutoLoadKind(node({ id: "c", type: "connection" }))).toBeNull();
+    expect(sidebarSearchAutoLoadKind(node({ id: "t", type: "table" }))).toBeNull();
+    // Procedures/functions are deliberately excluded to bound the metadata cost.
+    expect(sidebarSearchAutoLoadKind(node({ id: "g", type: "group-procedures" }))).toBeNull();
+  });
+});
+
+describe("collectSidebarSearchAutoLoadTargets", () => {
+  it("collects collapsed databases across every open connection", () => {
+    const roots = [connectionWithDatabases("c1", ["app", "logs"]), connectionWithDatabases("c2", ["shop"])];
+
+    const targets = collectSidebarSearchAutoLoadTargets(roots, { isConnected: () => true, isChildrenLoaded: () => false });
+
+    expect(targets.map((target) => target.id)).toEqual(["c1:app", "c1:logs", "c2:shop"]);
+  });
+
+  it("skips databases whose children are already in memory", () => {
+    const roots = [connectionWithDatabases("c1", ["app", "logs"])];
+
+    const targets = collectSidebarSearchAutoLoadTargets(roots, { isConnected: () => true, isChildrenLoaded: (nodeId) => nodeId === "c1:app" });
+
+    expect(targets.map((target) => target.id)).toEqual(["c1:logs"]);
+  });
+
+  it("skips disconnected connections instead of walking their stale subtree", () => {
+    const roots = [connectionWithDatabases("c1", ["app"]), connectionWithDatabases("c2", ["shop"])];
+
+    const targets = collectSidebarSearchAutoLoadTargets(roots, { isConnected: (connectionId) => connectionId === "c1", isChildrenLoaded: () => false });
+
+    expect(targets.map((target) => target.id)).toEqual(["c1:app"]);
+  });
+
+  it("honours the skip list so a retried round only sees new levels", () => {
+    const roots = [connectionWithDatabases("c1", ["app", "logs"])];
+
+    const targets = collectSidebarSearchAutoLoadTargets(roots, { isConnected: () => true, isChildrenLoaded: () => false }, new Set(["c1:app"]));
+
+    expect(targets.map((target) => target.id)).toEqual(["c1:logs"]);
+  });
+});
+
+describe("shouldAutoLoadForSidebarSearch", () => {
+  it("requires a non-blank query", () => {
+    expect(shouldAutoLoadForSidebarSearch("")).toBe(false);
+    expect(shouldAutoLoadForSidebarSearch("   ")).toBe(false);
+    expect(shouldAutoLoadForSidebarSearch("users")).toBe(true);
+  });
+
+  it("loads when the scope filter targets nodes that only exist after a load", () => {
+    const scopes = (types: TreeNodeType[]) => new Set<TreeNodeType>(types);
+
+    expect(shouldAutoLoadForSidebarSearch("users", scopes(["table"]))).toBe(true);
+    expect(shouldAutoLoadForSidebarSearch("users", scopes(["view"]))).toBe(true);
+    expect(shouldAutoLoadForSidebarSearch("users", scopes(["schema"]))).toBe(true);
+    expect(shouldAutoLoadForSidebarSearch("users", scopes(["mongo-collection"]))).toBe(true);
+  });
+
+  it("skips loading when the scope filter only targets already-visible levels", () => {
+    // Connection/database rows are present without any metadata read, so
+    // preloading tables for them would be wasted round-trips.
+    expect(shouldAutoLoadForSidebarSearch("app", new Set<TreeNodeType>(["connection", "database"]))).toBe(false);
+  });
+});
+
+describe("runSidebarSearchAutoLoad", () => {
+  it("loads collapsed databases so their tables become searchable", async () => {
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    const test = harness(roots, (target) => [tableNode(target.id, "c1", "app", "users")]);
+
+    const result = await runSidebarSearchAutoLoad(test.options());
+
+    expect(result.loadedNodeIds).toEqual(["c1:app"]);
+    expect(roots[0].children?.[0].children?.map((child) => child.label)).toEqual(["users"]);
+  });
+
+  it("keeps auto-loaded databases collapsed even though the store force-expands them", async () => {
+    // Regression guard: leaking the forced expansion left every database open
+    // once the query was cleared — the endless directory this feature fixes.
+    const roots = [connectionWithDatabases("c1", ["app", "logs"])];
+    const test = harness(roots, (target) => [tableNode(target.id, "c1", "app", "users")]);
+
+    await runSidebarSearchAutoLoad(test.options());
+
+    expect(roots[0].children?.map((child) => child.isExpanded)).toEqual([false, false]);
+    // The connection the user opened themselves stays open.
+    expect(roots[0].isExpanded).toBe(true);
+  });
+
+  it("preserves an expansion the user had already made", async () => {
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    roots[0].children![0].isExpanded = true;
+    const test = harness(roots, (target) => [tableNode(target.id, "c1", "app", "users")]);
+
+    await runSidebarSearchAutoLoad(test.options());
+
+    expect(roots[0].children?.[0].isExpanded).toBe(true);
+  });
+
+  it("descends into object groups so grouped display finds tables", async () => {
+    // Grouped display (the default) hands back empty group placeholders, so
+    // loading only the database would never surface a single table.
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    const test = harness(roots, (target) => (target.type === "database" ? objectGroupPlaceholders(target.id, "c1", "app") : [tableNode(target.id, "c1", "app", "users")]));
+
+    const result = await runSidebarSearchAutoLoad(test.options());
+
+    expect(result.loadedNodeIds).toEqual(["c1:app", "c1:app:__group-tables", "c1:app:__group-views"]);
+    const groups = roots[0].children?.[0].children ?? [];
+    expect(groups.map((group) => group.children?.map((child) => child.label))).toEqual([["users"], ["users"]]);
+    expect(groups.every((group) => group.isExpanded === false)).toBe(true);
+  });
+
+  it("descends through schemas into their table groups", async () => {
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    const test = harness(roots, (target) => {
+      if (target.type === "database") return [node({ id: `${target.id}:public`, type: "schema", connectionId: "c1", database: "app", schema: "public", isExpanded: false, children: [] })];
+      if (target.type === "schema") return objectGroupPlaceholders(target.id, "c1", "app", "public");
+      return [tableNode(target.id, "c1", "app", "users")];
+    });
+
+    const result = await runSidebarSearchAutoLoad(test.options());
+
+    expect(result.loadedNodeIds).toEqual(["c1:app", "c1:app:public", "c1:app:public:__group-tables", "c1:app:public:__group-views"]);
+    const schema = roots[0].children?.[0].children?.[0];
+    expect(schema?.isExpanded).toBe(false);
+    expect(schema?.children?.[0].children?.map((child) => child.label)).toEqual(["users"]);
+  });
+
+  it("caps concurrent metadata loads", async () => {
+    const roots = [
+      connectionWithDatabases(
+        "c1",
+        Array.from({ length: 12 }, (_, index) => `db${index}`),
+      ),
+    ];
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const test = harness(roots, () => [], {
+      onLoad: async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await Promise.resolve();
+        inFlight -= 1;
+      },
+    });
+
+    await runSidebarSearchAutoLoad({ ...test.options(), concurrency: 3 });
+
+    expect(peakInFlight).toBe(3);
+    expect(test.loaded.size).toBe(12);
+  });
+
+  it("defaults to a bounded pool", () => {
+    expect(SIDEBAR_SEARCH_AUTO_LOAD_CONCURRENCY).toBeLessThanOrEqual(8);
+  });
+
+  it("stops loading once the query is superseded", async () => {
+    const roots = [connectionWithDatabases("c1", ["app", "logs", "shop"])];
+    let cancelled = false;
+    const test = harness(roots, () => [], {
+      onLoad: () => {
+        // The user kept typing: everything after the first load is stale work.
+        cancelled = true;
+      },
+    });
+
+    const result = await runSidebarSearchAutoLoad({ ...test.options(), concurrency: 1, isCancelled: () => cancelled });
+
+    expect(result.cancelled).toBe(true);
+    expect(result.loadedNodeIds).toEqual(["c1:app"]);
+  });
+
+  it("does not start when already cancelled", async () => {
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    const test = harness(roots, () => []);
+    const loadChildren = vi.fn(test.loadChildren);
+
+    const result = await runSidebarSearchAutoLoad({ ...test.options(), loadChildren, isCancelled: () => true });
+
+    expect(loadChildren).not.toHaveBeenCalled();
+    expect(result).toEqual({ loadedNodeIds: [], cancelled: true });
+  });
+
+  it("keeps searching the reachable databases when one fails", async () => {
+    const roots = [connectionWithDatabases("c1", ["broken", "app"])];
+    const test = harness(roots, (target) => [tableNode(target.id, "c1", "app", "users")], {
+      onLoad: (target) => {
+        if (target.database === "broken") throw new Error("connection reset");
+      },
+    });
+
+    const result = await runSidebarSearchAutoLoad({ ...test.options(), concurrency: 1 });
+
+    expect(result.loadedNodeIds).toEqual(["c1:app"]);
+    expect(roots[0].children?.[1].children?.map((child) => child.label)).toEqual(["users"]);
+  });
+
+  it("never retries a node that failed", async () => {
+    const roots = [connectionWithDatabases("c1", ["broken"])];
+    const attempts: string[] = [];
+    const test = harness(roots, () => [], {
+      onLoad: (target) => {
+        attempts.push(target.id);
+        throw new Error("connection reset");
+      },
+    });
+
+    await runSidebarSearchAutoLoad(test.options());
+
+    expect(attempts).toEqual(["c1:broken"]);
+  });
+
+  it("restores expansion on the live node when the store replaced the object", async () => {
+    // Loads can rebuild the tree; the flag has to be restored on whatever node
+    // is currently mounted, not on the stale reference we started from.
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    const stale = roots[0].children![0];
+    const replacement = node({ id: stale.id, type: "database", connectionId: "c1", database: "app", isExpanded: true, children: [] });
+    const test = harness(roots, () => [], {
+      onLoad: () => {
+        roots[0].children = [replacement];
+      },
+    });
+
+    await runSidebarSearchAutoLoad(test.options());
+
+    expect(replacement.isExpanded).toBe(false);
+  });
+
+  it("does nothing when every level is already loaded", async () => {
+    const roots = [connectionWithDatabases("c1", ["app"])];
+    const test = harness(roots, () => []);
+    const loadChildren = vi.fn(test.loadChildren);
+
+    const result = await runSidebarSearchAutoLoad({ ...test.options(), isChildrenLoaded: () => true, loadChildren });
+
+    expect(loadChildren).not.toHaveBeenCalled();
+    expect(result).toEqual({ loadedNodeIds: [], cancelled: false });
+  });
+});

--- a/apps/desktop/src/lib/sidebar/sidebarSearchAutoLoad.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchAutoLoad.ts
@@ -1,0 +1,160 @@
+import type { TreeNode, TreeNodeType } from "@/types/database";
+
+/**
+ * Sidebar global search filters the in-memory tree, so a database whose children
+ * were never loaded contributes nothing to the match set. With many saved
+ * connections the user had to expand every database by hand before a table name
+ * could be found — the directory grew endlessly and the search looked broken.
+ *
+ * This module preloads exactly the levels that make table names searchable while
+ * a query is active. Two properties matter as much as the loading itself:
+ *
+ * 1. The sidebar must look untouched once the query is cleared. Store loaders
+ *    force a node open (so a user-driven expand reveals its children), which
+ *    would leave every database expanded here — recreating the very "endless
+ *    directory" problem. Auto-loaded nodes therefore keep their original
+ *    expansion state.
+ * 2. The work must stay bounded. A workspace with dozens of open connections
+ *    would otherwise fire one metadata read per database simultaneously.
+ */
+
+/** Database-level containers whose children hold schemas or object groups. */
+const AUTO_LOAD_CONTAINER_TYPES = new Set<TreeNodeType>(["database", "mongo-db", "vector-database"]);
+
+/**
+ * Grouped object display (the default) gives a database empty group
+ * placeholders; the objects themselves arrive only when a group is loaded.
+ * Only table-like groups are preloaded — procedures/functions/sequences would
+ * multiply the metadata round-trips for little table-search benefit.
+ */
+const AUTO_LOAD_OBJECT_GROUP_TYPES = new Set<TreeNodeType>(["group-tables", "group-views", "group-materialized-views"]);
+
+/**
+ * Node types that only exist after an auto-load. When a search scope filter is
+ * active and selects none of these (e.g. connection/database only), the loads
+ * would be pure waste and are skipped.
+ */
+const AUTO_LOAD_REVEALED_TYPES: readonly TreeNodeType[] = ["schema", "table", "view", "materialized_view", "mongo-collection", "vector-collection", "elasticsearch-index"];
+
+/** Small pool so a many-connection workspace does not stampede the backend. */
+export const SIDEBAR_SEARCH_AUTO_LOAD_CONCURRENCY = 4;
+
+/** container -> schema -> object group is the deepest chain search needs. */
+export const SIDEBAR_SEARCH_AUTO_LOAD_MAX_ROUNDS = 3;
+
+export type SidebarSearchAutoLoadKind = "container" | "schema" | "object-group";
+
+/** Which auto-load stage a node belongs to, or null when it is not a target. */
+export function sidebarSearchAutoLoadKind(node: TreeNode): SidebarSearchAutoLoadKind | null {
+  if (AUTO_LOAD_CONTAINER_TYPES.has(node.type)) return node.database == null ? null : "container";
+  if (node.type === "schema") return node.schema == null ? null : "schema";
+  if (AUTO_LOAD_OBJECT_GROUP_TYPES.has(node.type)) return "object-group";
+  return null;
+}
+
+export interface SidebarSearchAutoLoadState {
+  isConnected(connectionId: string): boolean;
+  isChildrenLoaded(nodeId: string): boolean;
+}
+
+/**
+ * Collects every node that must be loaded before its objects can match the
+ * query. Already-loaded nodes and disconnected connections are skipped, so a
+ * repeat call after a load round naturally yields only the newly revealed level.
+ */
+export function collectSidebarSearchAutoLoadTargets(nodes: readonly TreeNode[], state: SidebarSearchAutoLoadState, skipNodeIds?: ReadonlySet<string>): TreeNode[] {
+  const targets: TreeNode[] = [];
+
+  const visit = (candidates: readonly TreeNode[]) => {
+    for (const node of candidates) {
+      // A disconnected connection has no live metadata to read; its stale
+      // subtree is not worth walking.
+      if (node.type === "connection" && node.connectionId && !state.isConnected(node.connectionId)) continue;
+      if (node.connectionId && state.isConnected(node.connectionId) && !skipNodeIds?.has(node.id) && sidebarSearchAutoLoadKind(node) !== null && !state.isChildrenLoaded(node.id)) {
+        targets.push(node);
+      }
+      if (node.children?.length) visit(node.children);
+    }
+  };
+
+  visit(nodes);
+  return targets;
+}
+
+/** Whether the active query (and optional scope filter) justifies preloading. */
+export function shouldAutoLoadForSidebarSearch(query: string, searchableNodeTypes?: ReadonlySet<TreeNodeType>): boolean {
+  if (!query.trim()) return false;
+  if (!searchableNodeTypes) return true;
+  return AUTO_LOAD_REVEALED_TYPES.some((nodeType) => searchableNodeTypes.has(nodeType));
+}
+
+export interface SidebarSearchAutoLoadOptions extends SidebarSearchAutoLoadState {
+  /** Read through a getter: the store may swap the root array while loading. */
+  getTreeNodes(): readonly TreeNode[];
+  loadChildren(node: TreeNode): Promise<void>;
+  /** Re-resolves a node after an await so expansion restore hits the live object. */
+  liveNode?(nodeId: string): TreeNode | null;
+  /** Superseded by a newer query, or the query was cleared. */
+  isCancelled?(): boolean;
+  concurrency?: number;
+  maxRounds?: number;
+}
+
+export interface SidebarSearchAutoLoadResult {
+  loadedNodeIds: string[];
+  cancelled: boolean;
+}
+
+async function runWithConcurrencyLimit<T>(items: readonly T[], limit: number, worker: (item: T) => Promise<void>): Promise<void> {
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  let cursor = 0;
+  const runners = Array.from({ length: workerCount }, async () => {
+    while (cursor < items.length) {
+      const item = items[cursor];
+      cursor += 1;
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}
+
+/**
+ * Loads collapsed-but-connected databases (and the schema / table-group levels
+ * beneath them) so the global filter can match table names without the user
+ * expanding anything. Errors are per-node and swallowed: one unreachable
+ * database must never break search for the rest.
+ */
+export async function runSidebarSearchAutoLoad(options: SidebarSearchAutoLoadOptions): Promise<SidebarSearchAutoLoadResult> {
+  const { getTreeNodes, loadChildren, liveNode, isCancelled, concurrency = SIDEBAR_SEARCH_AUTO_LOAD_CONCURRENCY, maxRounds = SIDEBAR_SEARCH_AUTO_LOAD_MAX_ROUNDS } = options;
+  const isStale = () => isCancelled?.() === true;
+  const attemptedNodeIds = new Set<string>();
+  const loadedNodeIds: string[] = [];
+
+  for (let round = 0; round < maxRounds; round += 1) {
+    if (isStale()) return { loadedNodeIds, cancelled: true };
+
+    const targets = collectSidebarSearchAutoLoadTargets(getTreeNodes(), options, attemptedNodeIds);
+    if (targets.length === 0) break;
+    // Recorded up front so a node that fails (or is already in flight) is never
+    // retried in a later round, which would otherwise loop until maxRounds.
+    for (const target of targets) attemptedNodeIds.add(target.id);
+
+    await runWithConcurrencyLimit(targets, concurrency, async (node) => {
+      if (isStale()) return;
+      const wasExpanded = node.isExpanded === true;
+      try {
+        await loadChildren(node);
+        loadedNodeIds.push(node.id);
+      } catch {
+        // Ignored on purpose: search degrades to the reachable databases.
+      } finally {
+        if (!wasExpanded) {
+          const live = liveNode?.(node.id) ?? node;
+          live.isExpanded = false;
+        }
+      }
+    });
+  }
+
+  return { loadedNodeIds, cancelled: isStale() };
+}

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-11T19:02:14.789Z",
-  "stars": 14124,
+  "generatedAt": "2026-08-12T19:02:01.320Z",
+  "stars": 14288,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2914,
+      "commits": 2960,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 506,
-      "mergedPullRequests": 506,
+      "commits": 513,
+      "mergedPullRequests": 513,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-11T16:12:03Z"
+      "latestContributionAt": "2026-08-12T18:10:52Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 143,
-      "mergedPullRequests": 142,
+      "commits": 145,
+      "mergedPullRequests": 144,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-11T18:20:06Z"
+      "latestContributionAt": "2026-08-12T18:10:38Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 88,
-      "mergedPullRequests": 76,
+      "commits": 89,
+      "mergedPullRequests": 77,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-11T16:19:58Z"
+      "latestContributionAt": "2026-08-12T11:34:01Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 59,
-      "mergedPullRequests": 59,
+      "commits": 62,
+      "mergedPullRequests": 62,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-11T16:09:02Z"
+      "latestContributionAt": "2026-08-12T13:05:14Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 54,
-      "mergedPullRequests": 54,
+      "commits": 55,
+      "mergedPullRequests": 55,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-11T16:41:31Z"
+      "latestContributionAt": "2026-08-12T04:36:14Z"
     },
     {
       "login": "onceMisery",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-12T10:24:01Z"
+    },
+    {
       "login": "xddcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
       "profileUrl": "https://github.com/xddcode",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-07-06T09:30:53Z",
       "latestContributionAt": "2026-07-28T14:39:11Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 26,
-      "mergedPullRequests": 26,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-11T13:34:50Z"
     },
     {
       "login": "SuLea-IT",
@@ -274,6 +274,15 @@
       "latestContributionAt": "2026-08-04T05:02:31Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-12T18:12:10Z"
+    },
+    {
       "login": "aiLi0617",
       "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
       "profileUrl": "https://github.com/aiLi0617",
@@ -281,6 +290,15 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
+    },
+    {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-12T04:37:01Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -301,6 +319,15 @@
       "latestContributionAt": "2026-08-11T13:33:16Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-12T12:42:45Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -310,13 +337,13 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
       "commits": 7,
       "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-03T08:58:21Z"
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-12T05:35:03Z"
     },
     {
       "login": "xKrah",
@@ -337,13 +364,22 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
       "commits": 6,
       "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-08T02:40:34Z"
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-08-12T14:22:34Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-12T12:15:58Z"
     },
     {
       "login": "luoianun",
@@ -371,15 +407,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-11T18:05:55Z"
     },
     {
       "login": "antwa",
@@ -416,24 +443,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-08-05T09:25:09Z",
       "latestContributionAt": "2026-08-10T10:51:45Z"
-    },
-    {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-08-07T07:32:16Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-09T17:11:26Z"
     },
     {
       "login": "ZhonFortune",
@@ -641,6 +650,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
       "login": "Michaelxwb",
@@ -1462,15 +1480,6 @@
       "latestContributionAt": "2026-06-27T13:44:36Z"
     },
     {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-07-20T16:10:42Z"
-    },
-    {
       "login": "Quinlevi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24589232?v=4",
       "profileUrl": "https://github.com/Quinlevi",
@@ -1606,15 +1615,6 @@
       "latestContributionAt": "2026-07-06T04:57:27Z"
     },
     {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-10T10:22:17Z"
-    },
-    {
       "login": "xcstatus",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40375067?v=4",
       "profileUrl": "https://github.com/xcstatus",
@@ -1730,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-22T13:57:59Z",
       "latestContributionAt": "2026-07-22T14:20:42Z"
+    },
+    {
+      "login": "zhwq1216",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9948390?v=4",
+      "profileUrl": "https://github.com/zhwq1216",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T05:21:37Z",
+      "latestContributionAt": "2026-08-12T03:51:32Z"
     },
     {
       "login": "zouchao",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-10T18:18:32.191Z",
-  "stars": 13956,
+  "generatedAt": "2026-08-11T19:02:14.789Z",
+  "stars": 14124,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2885,
+      "commits": 2914,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 499,
-      "mergedPullRequests": 499,
+      "commits": 506,
+      "mergedPullRequests": 506,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-10T16:53:43Z"
+      "latestContributionAt": "2026-08-11T16:12:03Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 139,
-      "mergedPullRequests": 138,
+      "commits": 143,
+      "mergedPullRequests": 142,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-10T15:02:38Z"
+      "latestContributionAt": "2026-08-11T18:20:06Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 84,
-      "mergedPullRequests": 72,
+      "commits": 88,
+      "mergedPullRequests": 76,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-09T17:06:44Z"
+      "latestContributionAt": "2026-08-11T16:19:58Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 58,
-      "mergedPullRequests": 58,
+      "commits": 59,
+      "mergedPullRequests": 59,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-10T15:02:43Z"
+      "latestContributionAt": "2026-08-11T16:09:02Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 52,
-      "mergedPullRequests": 52,
+      "commits": 54,
+      "mergedPullRequests": 54,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-10T10:27:04Z"
+      "latestContributionAt": "2026-08-11T16:41:31Z"
     },
     {
       "login": "onceMisery",
@@ -112,6 +112,15 @@
       "latestContributionAt": "2026-07-28T14:39:11Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 26,
+      "mergedPullRequests": 26,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-11T13:34:50Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-04-30T05:56:34Z",
       "latestContributionAt": "2026-07-10T10:15:25Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 24,
-      "mergedPullRequests": 24,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-10T18:12:22Z"
     },
     {
       "login": "rarnu",
@@ -151,10 +151,10 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
-      "commits": 20,
-      "mergedPullRequests": 20,
+      "commits": 21,
+      "mergedPullRequests": 21,
       "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-08-06T08:30:20Z"
+      "latestContributionAt": "2026-08-11T05:05:26Z"
     },
     {
       "login": "yavon007",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-11T07:00:25Z"
+    },
+    {
       "login": "guoyongchang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
       "profileUrl": "https://github.com/guoyongchang",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-02T16:19:01Z",
       "latestContributionAt": "2026-07-27T14:47:00Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-06T15:16:00Z"
     },
     {
       "login": "chenhbb",
@@ -292,6 +292,15 @@
       "latestContributionAt": "2026-08-09T16:07:12Z"
     },
     {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-11T13:33:16Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -308,15 +317,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-03T08:58:21Z"
-    },
-    {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-08-06T06:00:09Z"
     },
     {
       "login": "xKrah",
@@ -371,6 +371,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
+    },
+    {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-11T18:05:55Z"
     },
     {
       "login": "antwa",
@@ -434,15 +443,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-10T11:25:46Z"
     },
     {
       "login": "Caisin",
@@ -542,6 +542,24 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
+    },
+    {
+      "login": "BabyLy233",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
+      "profileUrl": "https://github.com/BabyLy233",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-14T07:55:34Z",
+      "latestContributionAt": "2026-08-11T08:55:53Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-11T13:32:15Z"
     },
     {
       "login": "difagume",
@@ -677,15 +695,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
-    },
-    {
-      "login": "cheshireez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
-      "profileUrl": "https://github.com/cheshireez",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-06T10:14:50Z",
-      "latestContributionAt": "2026-08-08T03:33:38Z"
     },
     {
       "login": "cwatanab",
@@ -1012,15 +1021,6 @@
       "latestContributionAt": "2026-06-30T09:34:14Z"
     },
     {
-      "login": "BabyLy233",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
-      "profileUrl": "https://github.com/BabyLy233",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-14T07:55:34Z",
-      "latestContributionAt": "2026-07-14T11:03:42Z"
-    },
-    {
       "login": "baizhi958216",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46777503?v=4",
       "profileUrl": "https://github.com/baizhi958216",
@@ -1028,6 +1028,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-21T01:48:37Z",
       "latestContributionAt": "2026-05-21T02:24:47Z"
+    },
+    {
+      "login": "bigFish0124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
+      "profileUrl": "https://github.com/bigFish0124",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T08:46:27Z",
+      "latestContributionAt": "2026-08-11T13:31:45Z"
     },
     {
       "login": "BlueSkyXN",
@@ -1118,6 +1127,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T09:14:47Z",
       "latestContributionAt": "2026-07-08T10:53:49Z"
+    },
+    {
+      "login": "easton-shi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/215789663?v=4",
+      "profileUrl": "https://github.com/easton-shi",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-08T07:21:44Z",
+      "latestContributionAt": "2026-08-11T05:05:04Z"
     },
     {
       "login": "ededddy",
@@ -1568,6 +1586,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-22T12:39:46Z",
       "latestContributionAt": "2026-07-22T15:52:15Z"
+    },
+    {
+      "login": "wilyan09007",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/77467499?v=4",
+      "profileUrl": "https://github.com/wilyan09007",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T06:09:28Z",
+      "latestContributionAt": "2026-08-11T13:37:32Z"
     },
     {
       "login": "wnyr",


### PR DESCRIPTION
## 背景与问题

左侧导航栏的全局表名搜索只匹配内存中已加载的树节点。当数据库连接处于打开状态、但其数据库目录处于折叠（未展开）状态时，该库下的表/视图从未进入内存，搜索无法命中——用户必须逐个手动展开数据库目录，连接很多时目录被拉得很长，搜索形同失效。

## 根因

- 搜索过滤 `filterSidebarTree` 仅遍历已加载节点。
- store 加载器在加载子节点时会强制展开节点（供用户手动展开时显示子项），自动加载复用了同一路径却未恢复原始展开状态。

## 方案

新增纯逻辑模块 `apps/desktop/src/lib/sidebar/sidebarSearchAutoLoad.ts`（可独立单测），并在 `ConnectionTree.vue` 中以 watch 驱动：

- **精准加载**：`collectSidebarSearchAutoLoadTargets` 递归收集需要加载的层级（容器库 → schema → 对象组 `group-tables/views/materialized-views`），跳过已加载、未连接、已在 skip 列表中的节点。
- **状态还原**：每个节点加载前记录 `wasExpanded`；加载后若原本未展开，通过 `liveNode(id)` 取回存活节点并强制 `isExpanded = false`，确保搜索结束后目录外观不变。
- **有界并发**：`runWithConcurrencyLimit` 并发池（默认上限 `SIDEBAR_SEARCH_AUTO_LOAD_CONCURRENCY = 4`），最多 `SIDEBAR_SEARCH_AUTO_LOAD_MAX_ROUNDS = 3` 轮（container → schema → object-group 的最深链路）。
- **取消与降级**：watch 依赖 `[deferredSearchQuery, searchableNodeTypes]`，新查询以 `token` 取代旧任务；`isCancelled()` 在查询被清空或取代时中止。单节点加载失败被 per-node `catch` 吞掉，搜索降级为"可达数据库可见"，不影响其余连接。
- **scope 过滤联动**：`shouldAutoLoadForSidebarSearch` 在搜索范围被限定为不揭示对象类型（如仅 connection/database）时跳过预加载，避免无效读取。

## 验证

- Vitest：新增 22 用例全部通过；sidebar 整体回归 76 套件 / 477 用例通过。
- oxlint：改动文件 0 warning / 0 error。
- oxfmt：格式化检查通过。
- vue-tsc：类型检查通过（exit 0）。

## 风险与备注

- **并发元数据读取**：默认并发 4、最多 3 轮，最坏 12 次并发读取；store 自带超时/错误边界兜底。
- **加载期间的手动展开竞争**：自动加载在搜索激活时触发，若用户在加载进行中手动展开某库，`wasExpanded` 捕获的是加载前状态，finally 会将其还原为折叠。概率极低（加载为毫秒级），"保留用户已展开"用例已覆盖"加载前已展开不还原"的语义。
- **不改动 store 加载语义**：仅消费 `loadTreeNodeChildren` 并恢复展开状态，不影响手动展开/收起行为。
