### PR TITLE
Fix：避免 Oracle 常量列查询触发 TTC 读取错误

### DIFF
--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -29,6 +29,7 @@ import (
 const protocolVersion = 1
 const multiSessionProtocolVersion = 2
 const defaultMaxRows = 1000
+const oracleDefaultPrefetchRows = "100"
 const oracleCharsetZHS32GB18030 = 854
 const legacyAgentSessionID = "__legacy__"
 const maxAgentSessions = 256
@@ -1159,10 +1160,18 @@ func (oracleGB18030Converter) Clone() converters.IStringConverter {
 func buildDSN(params connectParams) string {
 	connectionString := strings.TrimSpace(params.ConnectionString)
 	if strings.HasPrefix(strings.ToLower(connectionString), "oracle://") {
-		return connectionString
+		parsed, err := url.Parse(connectionString)
+		if err != nil {
+			return connectionString
+		}
+		values := parsed.Query()
+		setOracleDefaultPrefetchRows(values)
+		parsed.RawQuery = values.Encode()
+		return parsed.String()
 	}
 	username := params.Username
 	options := parseURLParams(params.URLParams)
+	setOracleDefaultPrefetchRowsMap(options)
 	if params.SysDBA {
 		options["AUTH TYPE"] = "SYSDBA"
 	}
@@ -1189,6 +1198,22 @@ func buildDSN(params connectParams) string {
 		port = 1521
 	}
 	return buildGoOraURL(params.Host, port, service, username, params.Password, options)
+}
+
+func setOracleDefaultPrefetchRows(values url.Values) {
+	if hasURLValueKey(values, "PREFETCH_ROWS") {
+		return
+	}
+	values.Set("PREFETCH_ROWS", oracleDefaultPrefetchRows)
+}
+
+func setOracleDefaultPrefetchRowsMap(options map[string]string) {
+	for key := range options {
+		if strings.EqualFold(strings.TrimSpace(key), "PREFETCH_ROWS") {
+			return
+		}
+	}
+	options["PREFETCH_ROWS"] = oracleDefaultPrefetchRows
 }
 
 func oracleConnectionDatabaseName(database string) string {

--- a/agents/drivers/oracle-go/main_test.go
+++ b/agents/drivers/oracle-go/main_test.go
@@ -989,8 +989,58 @@ func TestOracleColumnTypeDDL(t *testing.T) {
 func TestBuildDSNUsesConnectionStringWhenProvided(t *testing.T) {
 	dsn := buildDSN(connectParams{ConnectionString: "oracle://scott:tiger@db.example.com:1521/ORCLPDB1"})
 
-	if dsn != "oracle://scott:tiger@db.example.com:1521/ORCLPDB1" {
-		t.Fatalf("unexpected dsn: %s", dsn)
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Query().Get("PREFETCH_ROWS") != oracleDefaultPrefetchRows {
+		t.Fatalf("raw Oracle DSN should use the DBX prefetch default, got: %s", dsn)
+	}
+}
+
+func TestBuildDSNUsesStableDefaultPrefetchRows(t *testing.T) {
+	dsn := buildDSN(connectParams{
+		Host:     "db.example.com",
+		Port:     1521,
+		Database: "XE",
+		Username: "scott",
+		Password: "tiger",
+	})
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Query().Get("PREFETCH_ROWS") != oracleDefaultPrefetchRows {
+		t.Fatalf("generated Oracle DSN should use the DBX prefetch default, got: %s", dsn)
+	}
+}
+
+func TestBuildDSNPreservesConfiguredPrefetchRows(t *testing.T) {
+	tests := []connectParams{
+		{
+			Host:      "db.example.com",
+			Port:      1521,
+			Database:  "XE",
+			Username:  "scott",
+			Password:  "tiger",
+			URLParams: "prefetch_rows=20",
+		},
+		{ConnectionString: "oracle://scott:tiger@db.example.com:1521/XE?prefetch_rows=50"},
+	}
+
+	for _, params := range tests {
+		dsn := buildDSN(params)
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if parsed.Query().Get("prefetch_rows") == "" {
+			t.Fatalf("configured prefetch rows should be preserved, got: %s", dsn)
+		}
+		if parsed.Query().Get("PREFETCH_ROWS") != "" {
+			t.Fatalf("default prefetch rows should not be added beside a configured value, got: %s", dsn)
+		}
 	}
 }
 

--- a/agents/drivers/oracle-go/tns.go
+++ b/agents/drivers/oracle-go/tns.go
@@ -30,6 +30,7 @@ func buildDSNForConnect(params connectParams) (string, error) {
 		return "", err
 	}
 	options := parseURLParams(params.URLParams)
+	setOracleDefaultPrefetchRowsMap(options)
 	if params.SysDBA {
 		options["AUTH TYPE"] = "SYSDBA"
 	}

--- a/agents/drivers/oracle-go/tns_test.go
+++ b/agents/drivers/oracle-go/tns_test.go
@@ -24,6 +24,37 @@ func TestBuildDSNForConnectResolvesTNSAlias(t *testing.T) {
 	if !strings.Contains(dsn, "connStr=") || !strings.Contains(dsn, "db1.example.com") || !strings.Contains(dsn, "db2.example.com") {
 		t.Fatalf("TNS descriptor should preserve all failover addresses, got: %s", dsn)
 	}
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Query().Get("PREFETCH_ROWS") != oracleDefaultPrefetchRows {
+		t.Fatalf("TNS Oracle DSN should use the DBX prefetch default, got: %s", dsn)
+	}
+}
+
+func TestBuildDSNForConnectPreservesTNSPrefetchRows(t *testing.T) {
+	tnsAdmin := t.TempDir()
+	writeTNSNames(t, tnsAdmin, "DBX = (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=db.example.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=XE)))")
+	dsn, err := buildDSNForConnect(connectParams{
+		ConnectionString: oracleTNSJDBCURL("DBX", tnsAdmin),
+		Username:         "scott",
+		Password:         "tiger",
+		URLParams:        "prefetch_rows=20",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Query().Get("prefetch_rows") != "20" {
+		t.Fatalf("configured TNS prefetch rows should be preserved, got: %s", dsn)
+	}
+	if parsed.Query().Get("PREFETCH_ROWS") != "" {
+		t.Fatalf("default prefetch rows should not be added beside a configured TNS value, got: %s", dsn)
+	}
 }
 
 func TestBuildDSNForConnectRejectsMissingTNSAdmin(t *testing.T) {


### PR DESCRIPTION
## 问题

Oracle 用户执行包含数字常量列且返回行数较多的查询时，可能报错：

```text
Agent RPC error (-1): TTC error: received code 1 during response reading
```

例如：

```sql
select 1 from md_emp_job
```

## 原因

Oracle Go Agent 当前使用 `go-ora/v2 v2.9.0`，其默认 `PREFETCH_ROWS=25`。在 Oracle 11g 中读取包含裸数字常量列的较大结果集时，该预取值会触发 TTC 响应解析异常；字段列、字符常量等查询不受影响。

## 修复

- Oracle Go Agent 默认设置 `PREFETCH_ROWS=100`
- 覆盖普通主机连接、JDBC URL、TNS 别名和原生 `oracle://` 连接字符串
- 用户通过 URL 参数显式配置 `PREFETCH_ROWS` 时保留用户值，不重复注入默认值
- 增加各连接形式的 DSN 回归测试

## 验证

在 Oracle 11g 测试库中进行真实验证：

- 修复前：`select 1 from ORDERS_10K` 读取 300/1000 行可稳定复现 TTC 错误
- 修复后：完整读取 10000 行，共 10 个分页，无错误
- 完整读取后再次查询 1000 行正常
- `PREFETCH_ROWS=50/100/256/1000` 均完成 10000 行读取，选择 100 作为兼容性和性能折中

本地检查：

- `go test ./...`
- `go test -race ./...`
- Windows x64 Agent 交叉构建
- macOS arm64 Agent 交叉构建
