### PR TITLE
fix(editor): wrap SQL preview text instead of clipping at panel border

### DIFF
--- a/apps/desktop/src/components/editor/SqlPreviewPanel.vue
+++ b/apps/desktop/src/components/editor/SqlPreviewPanel.vue
@@ -67,6 +67,7 @@ async function highlightSql() {
     highlightedHtml.value = highlighter.codeToHtml(displaySql.value, {
       lang: "sql",
       theme,
+      structure: "inline",
     });
   } catch {
     // fallback to plain text
@@ -202,7 +203,7 @@ onBeforeUnmount(() => {
       </div>
 
       <!-- Shiki highlighted SQL -->
-      <div v-else-if="highlightedHtml" data-native-clipboard class="p-3 text-xs leading-relaxed [&_pre]:!bg-transparent [&_pre]:!p-0 [&_code]:!font-mono [&_code]:text-xs" v-html="highlightedHtml" />
+      <pre v-else-if="highlightedHtml" data-native-clipboard class="m-0 p-3 text-xs font-mono leading-relaxed whitespace-pre-wrap break-words select-text" v-html="highlightedHtml"></pre>
 
       <!-- Plain text fallback -->
       <pre v-else data-native-clipboard class="p-3 text-xs font-mono whitespace-pre-wrap select-text">{{ displaySql }}</pre>

--- a/packages/app-tests/sqlPreviewWrap.test.ts
+++ b/packages/app-tests/sqlPreviewWrap.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const sqlPreviewSource = readFileSync("apps/desktop/src/components/editor/SqlPreviewPanel.vue", "utf8");
+
+describe("SQL preview wrapping", () => {
+  it("renders highlighted SQL inline inside a wrapping preformatted block", () => {
+    expect(sqlPreviewSource).toContain('structure: "inline"');
+    expect(sqlPreviewSource).toContain('<pre v-else-if="highlightedHtml"');
+    expect(sqlPreviewSource).toContain("whitespace-pre-wrap break-words");
+    expect(sqlPreviewSource).toContain('v-html="highlightedHtml"');
+  });
+});


### PR DESCRIPTION
## Problem
In the DataGrid row-edit flow, when the generated UPDATE/INSERT SQL is a long single-line statement, the bottom SQL preview panel (`SqlPreviewPanel.vue`) silently clips the text at the panel's right border instead of wrapping or scrolling — the tail of the statement (including the `WHERE` clause) becomes completely invisible.

Root cause: `highlightSql()` calls Shiki's `codeToHtml()` without `structure: "inline"`, so it emits a full `<pre>` block whose default `white-space: pre` doesn't wrap, and the container has no overflow handling for it.

## Fix
- Pass `structure: "inline"` to `codeToHtml()`, matching the existing pattern already used in `sqlHighlighter.ts` elsewhere in the app.
- Render the highlighted output inside a `<pre>` with `whitespace-pre-wrap break-words`, mirroring the analogous SQL preview in `TableStructureEditor.vue`.

## Testing
Reproduced and verified visually via a local dev build (`pnpm dev:web` + `dbx-web` backend) connected to a SQLite test database: edited a long-text cell to generate a long `UPDATE` statement.

- Before: SQL preview showed only the first line, clipped mid-statement, `WHERE` clause invisible.
- After: full statement wraps across multiple lines inside the border, nothing clipped.

Also verified short SQL statements and dark theme still render correctly (no regression).

Fixes #5992