### PR TITLE
fix(editor): dismiss hover tooltip on Ctrl/Cmd+click table navigation

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -4930,6 +4930,7 @@ onMounted(async () => {
         },
         mousedown: (event: MouseEvent) => {
           clearTableNavigationHover();
+          dismissHoverTooltip();
           const currentView = view.value;
           if (currentView && startEditorSelectionDrag(currentView, event)) {
             return true;
@@ -5603,7 +5604,7 @@ function scrollCursorIntoView() {
   });
 }
 
-function closeHoverOnContextMenu() {
+function dismissHoverTooltip() {
   if (!view.value || !hoverCloseEffect) return;
   view.value.dispatch({ effects: hoverCloseEffect });
 }
@@ -5632,7 +5633,7 @@ defineExpose({
           (e: MouseEvent) => {
             if (view) {
               syncContextMenuStateAtEvent(view, e);
-              closeHoverOnContextMenu();
+              dismissHoverTooltip();
             }
             onContextMenu(e);
             contextMenuOpen = true;


### PR DESCRIPTION
## Problem

Hovering a table identifier in the SQL editor shows a table-structure preview tooltip. Ctrl/Cmd+click on that identifier opens the table's data tab, but the hover tooltip stays stuck on screen — closing the new tab and clicking blank editor space is the only way to dismiss it.

Duplicate reports: #5578, #5836.

## Root cause

CodeMirror's `closeHoverTooltips` effect is only dispatched from the editor's `@contextmenu` handler. The Ctrl/Cmd+click object-navigation `mousedown` handler calls `clearTableNavigationHover()` (which only clears a CSS hover class for the identifier underline) but never dispatches the effect that actually closes the hover tooltip.

## Fix

Renamed the existing dismiss helper (`closeHoverOnContextMenu` → `dismissHoverTooltip`) and call it from the Ctrl/Cmd+click `mousedown` handler too, reusing the same CodeMirror effect already proven correct for the context-menu case.

`apps/desktop/src/components/editor/QueryEditor.vue` — 3-line change, no new logic.

## Testing

- `pnpm typecheck` / `pnpm lint` — clean.
- Manual repro via Playwright against a local SQLite connection: hovered a table name to trigger the tooltip, Ctrl+clicked it, confirmed the tooltip disappears and the table's data tab opens correctly. Verified the context-menu dismiss path still works too.

Fixes #5578
Fixes #5836