### PR TITLE
Fix：结构化查询超时错误显示修改超时时间入口

### DIFF
--- a/apps/desktop/src/components/common/QueryErrorActions.vue
+++ b/apps/desktop/src/components/common/QueryErrorActions.vue
@@ -2,10 +2,12 @@
 import { Bot, Wrench } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "@/components/ui/button";
+import type { BackendError } from "@/lib/backend/errorUtils";
 import { isQueryTimeoutErrorMessage } from "@/lib/sql/queryError";
 
 const props = defineProps<{
   errorMessage: string;
+  backendError?: BackendError;
   connectionId?: string;
 }>();
 
@@ -18,7 +20,7 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <Button v-if="connectionId && isQueryTimeoutErrorMessage(errorMessage)" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeQueryTimeout')">
+  <Button v-if="connectionId && isQueryTimeoutErrorMessage(errorMessage, backendError)" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeQueryTimeout')">
     <Wrench class="h-3.5 w-3.5" />
     {{ t("editor.changeQueryTimeout") }}
   </Button>

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1635,8 +1635,8 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
                   <QueryErrorActions
                     :error-message="String(errorMessage)"
                     :backend-error="activeTab.result.error"
-                    :connection-id="activeTab.connectionId"
-                    @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')"
+                    :connection-id="activeResultConnectionId"
+                    @change-query-timeout="activeResultConnectionId && emit('openConnectionSettings', activeResultConnectionId, 'advanced')"
                     @fix-with-ai="(message) => emit('fixWithAi', message)"
                   />
                 </template>
@@ -1969,8 +1969,8 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
             <QueryErrorActions
               :error-message="String(errorMessage)"
               :backend-error="activeTab.result.error"
-              :connection-id="activeTab.connectionId"
-              @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')"
+              :connection-id="activeResultConnectionId"
+              @change-query-timeout="activeResultConnectionId && emit('openConnectionSettings', activeResultConnectionId, 'advanced')"
               @fix-with-ai="(message) => emit('fixWithAi', message)"
             />
           </template>

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1632,7 +1632,7 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
                   />
                 </template>
                 <template v-if="activeTab.result && isQueryExecutionErrorResult(activeTab.result)" #error-actions="{ errorMessage }">
-                  <QueryErrorActions :error-message="String(errorMessage)" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
+                  <QueryErrorActions :error-message="String(errorMessage)" :backend-error="activeTab.result.error" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
                 </template>
               </DataGrid>
               <QueryLoadingState
@@ -1960,7 +1960,7 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
           @sort="(column: string, columnIndex: number, direction: 'asc' | 'desc' | null, whereInput?: string, mode?: DataGridSortMode) => emit('sort', column, columnIndex, direction, whereInput, mode)"
         >
           <template v-if="activeTab.result && isQueryExecutionErrorResult(activeTab.result)" #error-actions="{ errorMessage }">
-            <QueryErrorActions :error-message="String(errorMessage)" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
+            <QueryErrorActions :error-message="String(errorMessage)" :backend-error="activeTab.result.error" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
           </template>
         </DataGrid>
         <QueryLoadingState v-else-if="activeTab.isExecuting" class="h-full" :label-key="queryExecutionLabelKey(activeTab)" :elapsed-seconds="queryRunningElapsedSeconds" show-cancel :cancel-disabled="!canCancelQueryExecution(activeTab)" :cancelling="activeTab.isCancelling" @cancel="emit('cancel')" />

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1632,7 +1632,13 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
                   />
                 </template>
                 <template v-if="activeTab.result && isQueryExecutionErrorResult(activeTab.result)" #error-actions="{ errorMessage }">
-                  <QueryErrorActions :error-message="String(errorMessage)" :backend-error="activeTab.result.error" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
+                  <QueryErrorActions
+                    :error-message="String(errorMessage)"
+                    :backend-error="activeTab.result.error"
+                    :connection-id="activeTab.connectionId"
+                    @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')"
+                    @fix-with-ai="(message) => emit('fixWithAi', message)"
+                  />
                 </template>
               </DataGrid>
               <QueryLoadingState
@@ -1960,7 +1966,13 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
           @sort="(column: string, columnIndex: number, direction: 'asc' | 'desc' | null, whereInput?: string, mode?: DataGridSortMode) => emit('sort', column, columnIndex, direction, whereInput, mode)"
         >
           <template v-if="activeTab.result && isQueryExecutionErrorResult(activeTab.result)" #error-actions="{ errorMessage }">
-            <QueryErrorActions :error-message="String(errorMessage)" :backend-error="activeTab.result.error" :connection-id="activeTab.connectionId" @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')" @fix-with-ai="(message) => emit('fixWithAi', message)" />
+            <QueryErrorActions
+              :error-message="String(errorMessage)"
+              :backend-error="activeTab.result.error"
+              :connection-id="activeTab.connectionId"
+              @change-query-timeout="activeTab.connectionId && emit('openConnectionSettings', activeTab.connectionId, 'advanced')"
+              @fix-with-ai="(message) => emit('fixWithAi', message)"
+            />
           </template>
         </DataGrid>
         <QueryLoadingState v-else-if="activeTab.isExecuting" class="h-full" :label-key="queryExecutionLabelKey(activeTab)" :elapsed-seconds="queryRunningElapsedSeconds" show-cancel :cancel-disabled="!canCancelQueryExecution(activeTab)" :cancelling="activeTab.isCancelling" @cancel="emit('cancel')" />

--- a/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
@@ -26,6 +26,33 @@ describe("isQueryTimeoutErrorMessage", () => {
     expect(isQueryTimeoutErrorMessage("Agent RPC error (-1): Agent RPC call timed out (120s)")).toBe(true);
   });
 
+  it("detects structured query operation timeouts before localized text matching", () => {
+    const timeoutError = {
+      version: 1,
+      code: "DBX-JDBC-2002",
+      messageKey: "backendErrors.jdbc.operationTimedOut",
+      messageParams: { stage: "execute" },
+      source: "jdbcAgent",
+      operationOutcome: "unknown" as const,
+    } as const;
+
+    expect(isQueryTimeoutErrorMessage("数据库操作超时（阶段：execute）。", timeoutError)).toBe(true);
+    expect(isQueryTimeoutErrorMessage("Database operation timed out (stage: fetch).", { ...timeoutError, messageParams: { stage: "fetch" } })).toBe(true);
+  });
+
+  it("does not offer query timeout settings for structured infrastructure timeouts", () => {
+    const timeoutError = {
+      version: 1,
+      code: "DBX-JDBC-2001",
+      messageKey: "backendErrors.jdbc.operationTimedOut",
+      messageParams: { stage: "connect" },
+      source: "jdbcAgent",
+      operationOutcome: "not_started" as const,
+    } as const;
+
+    expect(isQueryTimeoutErrorMessage("Database operation timed out (stage: connect).", timeoutError)).toBe(false);
+  });
+
   it("does not classify unrelated errors as query timeouts", () => {
     expect(isQueryTimeoutErrorMessage('syntax error at or near "select"')).toBe(false);
     expect(isQueryTimeoutErrorMessage("Connection timed out while loading databases")).toBe(false);

--- a/apps/desktop/src/lib/sql/queryError.ts
+++ b/apps/desktop/src/lib/sql/queryError.ts
@@ -1,4 +1,12 @@
-export function isQueryTimeoutErrorMessage(message: string): boolean {
+import type { BackendError } from "@/lib/backend/errorUtils";
+
+const QUERY_TIMEOUT_STAGES = new Set(["execute", "fetch"]);
+
+export function isQueryTimeoutErrorMessage(message: string, backendError?: BackendError): boolean {
+  if (backendError?.messageKey === "backendErrors.jdbc.operationTimedOut") {
+    const stage = String(backendError.messageParams.stage ?? "").toLowerCase();
+    return QUERY_TIMEOUT_STAGES.has(stage);
+  }
   const lower = message.toLowerCase();
   if (lower.includes("query timed out") || lower.includes("查询超时") || lower.includes("查詢逾時")) return true;
   // Agent RPC client-side timeout (tokio::time::timeout in agent_driver.rs). This is the

--- a/packages/app-tests/queryTimeout.test.ts
+++ b/packages/app-tests/queryTimeout.test.ts
@@ -1,6 +1,9 @@
 import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
 import { test } from "vitest";
 import { DEFAULT_QUERY_TIMEOUT_SECS, frontendQueryTimeoutSecsForSql, queryTimeoutSecsForConnection } from "../../apps/desktop/src/lib/sql/queryTimeout.ts";
+
+const contentAreaSource = readFileSync("apps/desktop/src/components/layout/ContentArea.vue", "utf8");
 
 test("queryTimeoutSecsForConnection falls back to the default timeout", () => {
   assert.equal(DEFAULT_QUERY_TIMEOUT_SECS, 30);
@@ -16,4 +19,15 @@ test("frontend query timeout scales with SQL statement count", () => {
   assert.equal(frontendQueryTimeoutSecsForSql("INSERT INTO users VALUES (1); INSERT INTO users VALUES (2); INSERT INTO users VALUES (3);", "mysql", 10), 180);
   assert.equal(frontendQueryTimeoutSecsForSql("/* prep */\nINSERT INTO users VALUES (1);\n-- keep batching\nINSERT INTO users VALUES (2);", "mysql", 30), 120);
   assert.equal(frontendQueryTimeoutSecsForSql("INSERT INTO users VALUES (1); INSERT INTO users VALUES (2);", "mysql", 0), 0);
+});
+
+test("query timeout actions target the connection that produced the result", () => {
+  const resultErrorActions = [...contentAreaSource.matchAll(/<QueryErrorActions[\s\S]*?\/>/g)].map((match) => match[0]).filter((tag) => tag.includes(':backend-error="activeTab.result.error"'));
+
+  assert.equal(resultErrorActions.length, 2);
+  for (const tag of resultErrorActions) {
+    assert.match(tag, /:connection-id="activeResultConnectionId"/);
+    assert.match(tag, /emit\('openConnectionSettings', activeResultConnectionId, 'advanced'\)/);
+    assert.doesNotMatch(tag, /activeTab\.connectionId/);
+  }
 });


### PR DESCRIPTION
## 问题

查询执行返回新的结构化超时错误后，结果页只显示“复制”和“用 AI 修复”，没有显示“修改查询超时时间”。

例如达梦查询返回：

```text
数据库操作超时（阶段：execute）。
```

该问题与具体数据库类型无关。达梦、Oracle、Kingbase 等连接只要返回统一的 `backendErrors.jdbc.operationTimedOut` 结构化错误，都会经过相同的结果页操作逻辑。

## 原因

查询结果已经保留结构化后端错误，但 `QueryErrorActions` 仍只根据翻译后的错误文本识别超时。新的本地化文案不属于旧匹配范围，因此按钮被隐藏。

## 修复

- 将查询结果中的结构化错误传给错误操作组件
- 直接识别 `backendErrors.jdbc.operationTimedOut`
- `execute`、`fetch` 阶段显示“修改查询超时时间”
- `connect` 等基础设施阶段不显示，避免将用户引导到无关设置
- 保留旧版纯文本超时错误的兼容判断

该实现不依赖具体语言文案，所有已支持语言统一生效。

## 验证

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/sql/queryError.spec.ts`：7 项通过
- `pnpm typecheck`：通过
- `git diff --check`：通过
