### PR TITLE
fix(agents): drop stale hive row from metadata coverage matrix

### DIFF
--- a/agents/metadata-constraint-coverage.tsv
+++ b/agents/metadata-constraint-coverage.tsv
@@ -9,7 +9,6 @@ gbase8a	native-pushdown	java-sql	Uses information_schema with type, filter, stab
 gbase8s	native-pushdown	java-sql	Uses systables with type, filter, stable order, and SKIP/FIRST.
 goldendb	native-pushdown	java-sql	Uses information_schema with type, filter, stable order, and LIMIT/OFFSET.
 h2	native-pushdown	java-sql	Uses INFORMATION_SCHEMA with type, filter, stable order, and LIMIT/OFFSET.
-hive	intentional-fallback	java-sql	Uses Hive metadata paths where stable server-side fuzzy paging is not portable, common constraints filter locally.
 hive-go	shared-fallback	native-go	Uses HiveServer2 metadata APIs, then applies stable filtering and paging in the native agent with a SHOW TABLES fallback.
 informix	native-pushdown	java-sql	Uses systables/sysprocedures with type, filter, stable order, and SKIP/FIRST.
 iotdb	shared-fallback	native-go	Uses SHOW DEVICES or SHOW TABLES DETAILS for Tree/Table metadata, then applies stable filtering and paging in the native agent.


### PR DESCRIPTION
## 变更说明

- `3b189c23e refactor(hive): remove retired Java agent` 删除了 `agents/drivers/hive/`，
但把 `agents/metadata-constraint-coverage.tsv` 里的 `hive` 行留下了。

- `MetadataConstraintCoverageTest.everyCustomMetadataDriverIsListedInCoverageMatrix` 断言
`assertEquals(discovered, coverage.keySet())`，而 `discoverCustomMetadataDrivers` 是从
`agents/drivers/` 下的目录名推导 `discovered` 的。目录已不存在，这一行就永远匹配不上，
所以该测试目前在 `main` 上是失败的。
- `hive-go` 解析成它自己的 `hive-go` key，不受影响。

### 为什么 CI 没拦住

查了那个提交的 check-runs，`agents` job 的结论是 **`cancelled`**，既不是 success 也不是 failure：

```
agents                          →  cancelled
rust / frontend / packages / …  →  skipped
```

三个因素叠加，让这个失败一直没有浮现：

1. `agents` job 是路径过滤的（`if: needs.changes.outputs.agents == 'true'`）。那次改动确实动了
   `agents/`，所以 job **被触发了**。
2. 但 `ci.yml` 配置了 `concurrency.cancel-in-progress: true`，group 是 `workflow-ref`。
   `agents` job 要装 JDK 8 + 21 与 Go，再跑全模块 `./gradlew test shadowJar`，是耗时最长的
   job 之一，很容易在跑完之前被同分支的下一次 push 取消。
3. 该提交没有关联 PR（`commits/<sha>/pulls` 为空），是直接推到 `main` 的，也就没有 PR 状态检查拦截。

此后只要没有改动再落到 `agents/`，路径过滤就会让这个 job 一直 skip，红色状态就此隐身。

这个 job 被 concurrency 静默吞掉的风险是结构性的，不属于本 PR 的修复范围。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

不涉及。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

本 PR 只改一行 TSV 数据，不涉及前端与 Rust，故未跑那两项。

用 JDK 21 在两个独立 worktree 上做了正反验证：

```
[改动前] ./gradlew :common:test --tests '*MetadataConstraintCoverageTest*'
         → everyCustomMetadataDriverIsListedInCoverageMatrix() FAILED
           org.opentest4j.AssertionFailedError at MetadataConstraintCoverageTest.java:38

[改动后] 同一命令 → BUILD SUCCESSFUL
```

补充确认：删除后 `cd agents && ./gradlew test shadowJar`（全模块）为 BUILD SUCCESSFUL，
`validate_agents.py` 与 `validate_agent_jars.py` 均通过。CI 走的是同一个 gate。

## 关联 Issue

无。发现于为 #5384 新增 Spanner 支持时 —— 该 agent 需要往同一个矩阵登记一行，而这是双向断言，遗留的 `hive` 行不删则无法通过。