### PR TITLE
fix(sidebar): search connections by host and username

### DIFF
--- a/apps/desktop/src/lib/sidebar/sidebarLayout.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarLayout.ts
@@ -121,11 +121,16 @@ export function remapSidebarLayoutConnectionIds(layout: SidebarLayout, connectio
   };
 }
 
+export function connectionSidebarSearchAliases(config: Pick<ConnectionConfig, "host" | "username">): string[] {
+  return [config.host, config.username].filter((value) => value.trim().length > 0);
+}
+
 function makeConnectionNode(config: ConnectionConfig, pinned: boolean): TreeNode {
   return {
     id: config.id,
     label: config.name,
     type: "connection",
+    searchAliases: connectionSidebarSearchAliases(config),
     connectionId: config.id,
     isExpanded: false,
     children: [],

--- a/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
@@ -4,12 +4,14 @@ import { createSidebarLabelMatcher, type SidebarLabelMatcher } from "@/lib/sideb
 const preserveMatchedSubtreeTypes = new Set(["connection", "database", "schema", "table", "view", "mongo-db", "mongo-collection"]);
 const hiddenSearchNodeTypes = new Set<TreeNodeType>(["user-admin", "dameng-job-admin"]);
 
-function bestMatch(matchLabel: SidebarLabelMatcher, label: string, comment?: string | null) {
-  const lm = matchLabel(label);
-  if (!comment) return lm;
-  const cm = matchLabel(comment);
-  if (lm && cm) return lm.score >= cm.score ? lm : cm;
-  return lm ?? cm;
+function bestMatch(matchLabel: SidebarLabelMatcher, label: string, comment?: string | null, aliases?: readonly string[]) {
+  let best = matchLabel(label);
+  for (const candidate of [comment, ...(aliases ?? [])]) {
+    if (!candidate) continue;
+    const match = matchLabel(candidate);
+    if (match && (!best || match.score > best.score)) best = match;
+  }
+  return best;
 }
 
 function normalizedLabel(node: TreeNode): string {
@@ -67,7 +69,7 @@ function filterSidebarTreeWithMatcher(nodes: TreeNode[], matchLabel: SidebarLabe
 
     const label = normalizedLabel(node);
     const canSelfMatch = !searchableNodeTypes || searchableNodeTypes.has(node.type);
-    const selfMatch = canSelfMatch ? (matchLabel ? bestMatch(matchLabel, label, node.comment) : { score: 0 }) : null;
+    const selfMatch = canSelfMatch ? (matchLabel ? bestMatch(matchLabel, label, node.comment, node.searchAliases) : { score: 0 }) : null;
     // Type-only filtering keeps matching rows and their ancestor path, but not
     // unrelated descendants that would make the selected type appear ignored.
     const preservesSubtree = !!matchLabel && !!selfMatch && preserveMatchedSubtreeTypes.has(node.type);

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -55,6 +55,7 @@ import {
   remapSidebarLayoutConnectionIds,
   reorderEntry as reorderEntryOp,
   buildConnectionGroupPathMap,
+  connectionSidebarSearchAliases,
   type DropPosition,
 } from "@/lib/sidebar/sidebarLayout";
 import type { SqlCompletionColumn, SqlCompletionForeignKey, SqlCompletionObject, SqlCompletionTable } from "@/lib/sql/sqlCompletion";
@@ -2882,6 +2883,7 @@ export const useConnectionStore = defineStore("connection", () => {
       if (existing) {
         existing.label = config.name;
         existing.type = "connection";
+        existing.searchAliases = connectionSidebarSearchAliases(config);
         existing.connectionId = id;
         existing.comment = config.note || null;
         existing.children = existing.children || [];
@@ -2890,6 +2892,7 @@ export const useConnectionStore = defineStore("connection", () => {
           id,
           label: config.name,
           type: "connection",
+          searchAliases: connectionSidebarSearchAliases(config),
           connectionId: id,
           isExpanded: false,
           children: [],
@@ -6917,6 +6920,7 @@ export const useConnectionStore = defineStore("connection", () => {
             ...existing,
             label: node.label,
             comment: node.comment,
+            searchAliases: node.searchAliases,
             pinned: node.pinned,
             children: withSavedSqlRoot(node.connectionId!, existing.children || [], existing),
           });

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -968,6 +968,8 @@ export interface TreeNode {
   id: string;
   label: string;
   type: TreeNodeType;
+  /** Additional values matched by sidebar search without rendering them. */
+  searchAliases?: string[];
   children?: TreeNode[];
   isLoading?: boolean;
   isExpanded?: boolean;

--- a/packages/app-tests/sidebarLayout.test.ts
+++ b/packages/app-tests/sidebarLayout.test.ts
@@ -164,6 +164,16 @@ test("buildTreeNodesFromLayout creates group nodes with connection children", ()
   assert.equal(nodes[1].id, "c");
 });
 
+test("buildTreeNodesFromLayout adds connection host and username as search aliases", () => {
+  const connection = conn("a", "Production reporting");
+  connection.host = "192.168.0.27";
+  connection.username = "report_user";
+
+  const nodes = buildTreeNodesFromLayout({ groups: [], order: [{ type: "connection", id: "a" }] }, [connection], new Set());
+
+  assert.deepEqual(nodes[0]?.searchAliases, ["192.168.0.27", "report_user"]);
+});
+
 test("buildTreeNodesFromLayout respects collapsed groups", () => {
   const layout: SidebarLayout = {
     groups: [{ id: "g1", name: "G", collapsed: true }],

--- a/packages/app-tests/sidebarSearchTree.test.ts
+++ b/packages/app-tests/sidebarSearchTree.test.ts
@@ -212,6 +212,22 @@ test("preserves loaded children when the connection itself matches search", () =
   assert.equal(filtered[0]?.children?.[0]?.children?.[0]?.label, "products");
 });
 
+test("matches connections by host and username search aliases", () => {
+  const connection: TreeNode = {
+    id: "conn:1",
+    label: "Production reporting",
+    type: "connection",
+    connectionId: "conn:1",
+    searchAliases: ["192.168.0.27", "report_user"],
+    isExpanded: false,
+    children: [],
+  };
+
+  assert.equal(filterSidebarTree([connection], "192.168.0", new Set())[0]?.id, connection.id);
+  assert.equal(filterSidebarTree([connection], "report_user", new Set())[0]?.id, connection.id);
+  assert.deepEqual(filterSidebarTree([connection], "unrelated", new Set()), []);
+});
+
 test("omits synthetic connection management entries when the connection itself matches search", () => {
   const nodes: TreeNode[] = [
     {


### PR DESCRIPTION
## 变更说明

- 为连接树节点增加隐藏搜索别名
- 支持通过连接主机/IP 和用户名筛选连接
- 在连接加载、重建及连接状态更新时同步搜索别名
- 补充主机/IP、用户名匹配及别名构建测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及视觉改动，已附截图/录屏
- 无视觉样式变化，仅扩展现有连接搜索的匹配字段

## 验证

- [x] `pnpm vitest run packages/app-tests/sidebarSearchTree.test.ts packages/app-tests/sidebarLayout.test.ts`
- [x] `pnpm typecheck`
- [x] 相关测试通过（46 项）

## 关联 Issue

Closes #6093