### PR TITLE
fix(jre): 仅 Java 驱动才阻止卸载 JRE

### DIFF
--- a/crates/dbx-core/src/agent_manager.rs
+++ b/crates/dbx-core/src/agent_manager.rs
@@ -715,6 +715,23 @@ impl AgentManager {
             && !self.driver_launch_config_path(db_type).exists()
     }
 
+    /// The JRE key an installed driver actually depends on, or `None` when the
+    /// installed artifact runs without a managed JRE (native binary or custom
+    /// launch config).
+    ///
+    /// The on-disk artifact is the source of truth. The persisted `jre` string
+    /// is only consulted for genuine Java (jar) drivers, because it is written
+    /// unconditionally at install time and goes stale when a driver is
+    /// refactored from Java to a native language. Every "is this JRE still in
+    /// use?" question must route through here rather than reading `driver.jre`
+    /// directly, so stale metadata can never manufacture a false dependency.
+    pub fn installed_driver_jre_dependency<'a>(&self, state: &'a AgentState, db_type: &str) -> Option<&'a str> {
+        if !self.driver_requires_java_runtime(db_type) {
+            return None;
+        }
+        state.installed_drivers.get(db_type).map(|driver| driver.jre.as_str())
+    }
+
     pub fn resolve_agent_launch_spec(
         &self,
         state: &AgentState,

--- a/crates/dbx-core/src/agent_service.rs
+++ b/crates/dbx-core/src/agent_service.rs
@@ -534,9 +534,9 @@ pub async fn uninstall_agent_jre(am: &AgentManager, jre_key: &str) -> Result<(),
     let local_state = am.load_state();
     let dependents: Vec<&str> = local_state
         .installed_drivers
-        .iter()
-        .filter(|(_, driver)| driver.jre == jre_key)
-        .map(|(k, _)| k.as_str())
+        .keys()
+        .filter(|db_type| am.installed_driver_jre_dependency(&local_state, db_type) == Some(jre_key))
+        .map(|k| k.as_str())
         .collect();
     if !dependents.is_empty() {
         return Err(format!("JRE {jre_key} is in use by drivers: {}. Uninstall them first.", dependents.join(", ")));
@@ -818,13 +818,17 @@ async fn ensure_jre_from_registry(
     Ok(())
 }
 
-/// Stop daemons whose installed driver lists `jre_key` as its runtime.
+/// Stop daemons whose installed driver actually runs on `jre_key`.
 async fn stop_daemons_using_jre(am: &AgentManager, jre_key: &str) {
     let state = am.load_state();
-    for (db_type, driver) in &state.installed_drivers {
-        if driver.jre == jre_key {
-            am.stop_daemon_by_key(db_type).await;
-        }
+    let keys: Vec<String> = state
+        .installed_drivers
+        .keys()
+        .filter(|db_type| am.installed_driver_jre_dependency(&state, db_type) == Some(jre_key))
+        .cloned()
+        .collect();
+    for db_type in keys {
+        am.stop_daemon_by_key(&db_type).await;
     }
 }
 
@@ -2818,6 +2822,56 @@ mod agent_registry_install_tests {
         state.jre_versions.insert(DEFAULT_JRE_KEY.to_string(), "21.0.12+kerberos.ec.2".to_string());
         manager.save_state(&state).unwrap();
         assert!(!jre_needs_install(&manager, &registry, DEFAULT_JRE_KEY));
+    }
+
+    fn install_jre(manager: &AgentManager) {
+        let java_path = manager.jre_java_path(DEFAULT_JRE_KEY);
+        std::fs::create_dir_all(java_path.parent().unwrap()).unwrap();
+        std::fs::write(&java_path, b"java").unwrap();
+        let mut state = manager.load_state();
+        state.jre_versions.insert(DEFAULT_JRE_KEY.to_string(), "21.0.0".to_string());
+        manager.save_state(&state).unwrap();
+    }
+
+    fn record_driver(manager: &AgentManager, db_type: &str) {
+        let mut state = manager.load_state();
+        state.installed_drivers.insert(
+            db_type.to_string(),
+            InstalledDriver {
+                version: "1.0.0".to_string(),
+                installed_at: "2026-01-01T00:00:00Z".to_string(),
+                jre: DEFAULT_JRE_KEY.to_string(),
+            },
+        );
+        manager.save_state(&state).unwrap();
+    }
+
+    #[tokio::test]
+    async fn uninstall_jre_ignores_native_driver_dependents() {
+        // A native (non-Java) driver still records the JRE key in its state
+        // entry, but must not block uninstalling the JRE it never uses.
+        let manager = test_manager("jre-uninstall-native-dependent");
+        install_jre(&manager);
+        std::fs::create_dir_all(manager.driver_dir("kafka")).unwrap();
+        std::fs::write(manager.driver_native_path("kafka"), b"native-binary").unwrap();
+        record_driver(&manager, "kafka");
+
+        uninstall_agent_jre(&manager, DEFAULT_JRE_KEY).await.expect("native driver must not block JRE uninstall");
+    }
+
+    #[tokio::test]
+    async fn uninstall_jre_blocked_by_jar_driver_dependent() {
+        // A JAR (Java) driver genuinely depends on the JRE and must block the
+        // uninstall so the driver keeps a runtime.
+        let manager = test_manager("jre-uninstall-jar-dependent");
+        install_jre(&manager);
+        std::fs::create_dir_all(manager.driver_dir("mysql")).unwrap();
+        std::fs::write(manager.driver_jar_path("mysql"), test_agent_jar()).unwrap();
+        record_driver(&manager, "mysql");
+
+        let err = uninstall_agent_jre(&manager, DEFAULT_JRE_KEY).await.expect_err("jar driver must block uninstall");
+        assert!(err.contains("is in use by drivers"), "unexpected error: {err}");
+        assert!(err.contains("mysql"), "expected dependent driver in error: {err}");
     }
 
     fn registry_with_jre(jre_key: &str, version: &str, url: &str, size: u64) -> AgentRegistry {


### PR DESCRIPTION
# 问题

安装 JRE 运行时后，卸载该 JRE 时，即使当前只装了**非 Java(native)驱动**，也会报错 `JRE 21 is in use by drivers: ...`，把不依赖 JRE 的驱动误判为依赖者。

**成因**：`InstalledDriver.jre` 字段在安装时是**无条件**写入的（`agent_service.rs`，`jre: jre_key.clone()`），native 驱动也会被记上一个 `jre` key。因此该字段的真实语义是「假如它是 Java 驱动会用哪个 JRE」，而非「它实际依赖哪个 JRE」。

这个歧义在**驱动被从 Java 重构为 native 语言（如 Go）**时暴露：升级安装 native 产物时旧 jar 被删除，但 state 里残留的 `jre: "21"` 没被清理。卸载检查 `uninstall_agent_jre` 直接拿这个过时字段做 `driver.jre == jre_key` 比较，于是把早已不用 JRE 的驱动当成依赖者，抛出上述错误。

## 变更说明

将「某个已安装驱动到底依赖哪个 JRE」这一问题收敛到唯一权威入口 `AgentManager::installed_driver_jre_dependency`：

- 以**磁盘上实际安装的产物**为真相源（native / launch-config 返回 `None`，仅真正的 jar 驱动才返回其记录的 JRE key），与 runtime `resolve_agent_launch_spec` 决定是否真的拉起 JRE 的逻辑保持一致；
- `uninstall_agent_jre` 与 `stop_daemons_using_jre` 均改走该入口，消除「各处直接读 `driver.jre` 字段各自误判」这一类问题；
- **无需状态迁移**：对已经重构过、磁盘上已是脏数据的存量安装天然正确。

新增两条回归测试：native 驱动不再阻止 JRE 卸载；jar 驱动仍正确阻止。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

无前端改动，仅 `crates/dbx-core` Rust 代码。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过（`cargo test -p dbx-core uninstall_jre`：2 passed）

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
