### PR TITLE
fix(jdbc): stop forcing Connector/J cursor fetching

### DIFF
--- a/plugins/jdbc/README.md
+++ b/plugins/jdbc/README.md
@@ -36,6 +36,18 @@ lib/dbx-jdbc-plugin.jar
 
 DBX does not bundle Java or JDBC drivers. Install Java locally and add database-specific driver JAR paths in the DBX JDBC connection form.
 
+## MySQL-compatible cursor fetching
+
+DBX uses standard JDBC result-set paging, but does not automatically set Connector/J's `useCursorFetch` property.
+That property enables a MySQL-specific server cursor protocol; it is not part of JDBC and may be unsupported by
+MySQL-compatible servers. If a server and driver are known to support it, opt in explicitly in the connection URL:
+
+```text
+jdbc:mysql://host:3306/database?useCursorFetch=true
+```
+
+Leave the property unset for generic JDBC or compatibility drivers that need to shield non-standard server behavior.
+
 The first-class JDBCX profile uses `io.github.jdbcx.WrappedDriver` and
 `jdbcx:[extension:][vendor://host:port/database]` URLs. Install a JDBCX Maven bundle such as
 `io.github.jdbcx:jdbcx-driver:0.8.0` in the DBX JDBC driver store, together with the database vendor's JDBC driver.

--- a/plugins/jdbc/build.gradle
+++ b/plugins/jdbc/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'app.dbx'
-version = '0.1.29'
+version = '0.1.30'
 
 java {
     toolchain {

--- a/plugins/jdbc/manifest.json
+++ b/plugins/jdbc/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "jdbc",
   "name": "DBX JDBC Plugin",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "protocol_version": 1,
   "description": "Adds optional JDBC driver support to DBX.",
   "executable": "bin/dbx-jdbc-plugin",

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -535,7 +535,6 @@ public final class DbxJdbcPlugin {
             properties.setProperty("password", password);
         }
         applyConnectTimeout(connection, properties);
-        applyPagedFetchProperties(connection, url, properties);
         applyJdbcxExtensionSecurity(connection, url, properties);
         if (isOracleUrl(url)) {
             applyOracleProperties(connection, properties);
@@ -624,25 +623,6 @@ public final class DbxJdbcPlugin {
         return normalized.equals("com.mysql.cj.jdbc.driver") ||
             normalized.equals("com.mysql.jdbc.driver") ||
             normalized.equals("org.mariadb.jdbc.driver");
-    }
-
-    private static void applyPagedFetchProperties(JsonNode connection, String url, Properties properties) {
-        if (!isMysqlConnection(connection, url) || jdbcUrlHasParameter(url, "useCursorFetch")) {
-            return;
-        }
-        properties.putIfAbsent("useCursorFetch", "true");
-    }
-
-    private static boolean isMysqlConnection(JsonNode connection, String url) {
-        if (urlMatchesPrefix(url, "jdbc:mysql:")) {
-            return true;
-        }
-        String driverClass = optionalText(connection, "jdbc_driver_class");
-        if (driverClass == null) {
-            return false;
-        }
-        String normalized = driverClass.toLowerCase(Locale.ROOT);
-        return normalized.equals("com.mysql.cj.jdbc.driver") || normalized.equals("com.mysql.jdbc.driver");
     }
 
     private static boolean isPostgresConnection(JsonNode connection) {

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -766,51 +766,24 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
-    void mysqlPagedQueriesEnableConnectorCursorFetchingByDefault() throws Exception {
-        Method method = DbxJdbcPlugin.class.getDeclaredMethod(
-            "applyPagedFetchProperties",
-            JsonNode.class,
-            String.class,
-            Properties.class
-        );
-        method.setAccessible(true);
-        Properties properties = new Properties();
-        JsonNode connection = MAPPER.readTree("""
-            {
-              "connection_string": "jdbc:mysql://127.0.0.1:3306/app",
-              "jdbc_driver_class": "com.mysql.cj.jdbc.Driver"
-            }
-            """);
+    void mysqlConnectionsDoNotForceCursorFetch() throws Exception {
+        RecordingConnectDriver driver = new RecordingConnectDriver("jdbc:mysql:dbx-capture:");
+        DriverManager.registerDriver(driver);
+        try {
+            JsonNode response = request("testConnection", """
+                {
+                  "connection": {
+                    "connection_string": "jdbc:mysql:dbx-capture:demo",
+                    "connect_timeout_secs": 30
+                  }
+                }
+                """);
 
-        method.invoke(null, connection, "jdbc:mysql://127.0.0.1:3306/app", properties);
-
-        assertEquals("true", properties.getProperty("useCursorFetch"));
-    }
-
-    @Test
-    void mysqlPagedQueriesPreserveExplicitCursorFetchSetting() throws Exception {
-        Method method = DbxJdbcPlugin.class.getDeclaredMethod(
-            "applyPagedFetchProperties",
-            JsonNode.class,
-            String.class,
-            Properties.class
-        );
-        method.setAccessible(true);
-        Properties properties = new Properties();
-        JsonNode connection = MAPPER.readTree("""
-            {
-              "connection_string": "jdbc:mysql://127.0.0.1:3306/app?useCursorFetch=false"
-            }
-            """);
-
-        method.invoke(
-            null,
-            connection,
-            "jdbc:mysql://127.0.0.1:3306/app?useCursorFetch=false",
-            properties
-        );
-
-        assertFalse(properties.containsKey("useCursorFetch"));
+            assertFalse(response.has("error"), response.toString());
+            assertFalse(driver.properties.get(0).containsKey("useCursorFetch"));
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Stop automatically injecting Connector/J's `useCursorFetch=true` for generic JDBC/MySQL connections.
- Release the JDBC plugin as `0.1.30` and document explicit cursor-fetch opt-in through the connection URL.
- Add a regression test proving DBX does not add the vendor property to driver connection properties.

## Why
JDBC standardizes `ResultSet` traversal and `Statement#setFetchSize` as a driver hint; it does not standardize a MySQL server-cursor protocol. `useCursorFetch` is a Connector/J-specific property that changes driver/server behavior.

A `jdbc:mysql:` URL can target a MySQL-compatible server rather than MySQL itself. Forcing that property made even `SELECT 1` block until DBX's 30-second timeout against a compatible backend, with both the official Connector/J driver and the compatibility driver.

Cursor fetching is now an explicit driver/server capability: users who have verified support can configure `useCursorFetch=true` in the JDBC URL. Compatibility drivers can keep the property unset or normalize it for their server behavior.

## Validation
- `cd plugins/jdbc && ./gradlew --no-daemon --rerun-tasks test shadowJar`
- Direct JSON-RPC verification with the rebuilt plugin against the affected backend: `SELECT 1`, a table read, and a two-page table result all completed without the 30-second timeout.