### PR TITLE
fix(editor): seed search box with full selection including newlines

### DIFF
--- a/apps/desktop/src/components/editor/EditorSearchPanel.vue
+++ b/apps/desktop/src/components/editor/EditorSearchPanel.vue
@@ -276,7 +276,7 @@ function openSearch(): boolean {
     cmOpenSearchPanel(v);
     const sel = v.state.selection.main;
     const selText = v.state.sliceDoc(sel.from, sel.to);
-    if (selText && !selText.includes("\n")) {
+    if (selText) {
       searchText.value = selText;
     }
     // Set scope when there's a multi-line selection

--- a/apps/desktop/src/components/editor/__tests__/EditorSearchPanel.newlineSeed.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/EditorSearchPanel.newlineSeed.spec.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { createApp, defineComponent, h, nextTick, type App } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings: { regexMaxMatchCount: 1000 },
+  }),
+}));
+
+import EditorSearchPanel from "@/components/editor/EditorSearchPanel.vue";
+
+const mountedApps: Array<{ app: App; host: HTMLElement }> = [];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  for (const { app, host } of mountedApps.splice(0)) {
+    app.unmount();
+    host.remove();
+  }
+  vi.useRealTimers();
+});
+
+describe("EditorSearchPanel openSearch selection seeding (issue #5435)", () => {
+  it("seeds the search query with the full selection, newline included, so cross-line matches are found without manually typing \\n", async () => {
+    // Document is exactly the selected text; a correctly seeded (newline-preserving)
+    // search query must find exactly one match. An HTML <input> always strips \n
+    // from its rendered value (browser sanitization), so we assert on the actual
+    // search outcome (rendered match count) rather than the raw input DOM value.
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({ doc: "line one\nline two" }),
+    });
+    view.dispatch({ selection: { anchor: 0, head: view.state.doc.length } });
+
+    let instance: { openSearch: () => boolean } | null = null;
+    const host = document.createElement("div");
+    document.body.append(host);
+    const app = createApp(
+      defineComponent({
+        setup() {
+          return () =>
+            h(EditorSearchPanel, {
+              view,
+              ref: (el) => {
+                instance = el as unknown as { openSearch: () => boolean };
+              },
+            });
+        },
+      }),
+    );
+    app.mount(host);
+    mountedApps.push({ app, host });
+
+    instance!.openSearch();
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(1000);
+    await nextTick();
+
+    expect(host.textContent).toContain("1/1");
+    expect(host.textContent).not.toContain("noResults");
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
## What

Fixes #5435

`openSearch()` in `EditorSearchPanel.vue` only seeded the search box (`searchText`) from the current editor selection when that selection did **not** contain a newline:

```js
if (selText && !selText.includes("\n")) {
  searchText.value = selText;
}
```

So selecting text that spans multiple lines and pressing Ctrl+F/Cmd+F (or Ctrl+H) left the search box completely empty and showed "no results", forcing the user to manually retype the query (including an escaped `\n`) to search across lines — exactly what the reporter described.

## Fix

Seed the search box from the selection whenever it's non-empty, regardless of whether it contains a newline. The existing multi-line "scope to selection" logic right below is untouched — seeding and scoping are two separate concerns and shouldn't be coupled by a shared guard.

Note: a plain HTML `<input>` cannot visually render an embedded newline (the browser strips it from the rendered value), so a two-line selection shows up in the box with the lines run together with no visible break. That's an inherent `<input>` limitation, not something this fix can change — but the underlying search query still receives the real newline character, so cross-line matching now works correctly (verified below).

## Testing

- Added `apps/desktop/src/components/editor/__tests__/EditorSearchPanel.newlineSeed.spec.ts`, which mounts the real component with a real CodeMirror `EditorView`, selects text spanning a newline, opens search, and asserts the match count renders `1/1` (was `noResults` before the fix).
- `pnpm vitest run` — full suite passes (8802 tests).
- `pnpm vue-tsc --noEmit --project apps/desktop/tsconfig.json` — passes.
- `pnpm oxlint --vue-plugin apps/desktop/src` on the changed files — clean.
- Manually verified in a running `pnpm dev:web` instance (SQLite connection, two-line SQL selected, Cmd+F): before the fix the search box was empty with "无结果" (no results); after the fix the match indicator shows "1/1" and the selection-scope indicator is active, confirming the cross-line query is now found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)