### PR TITLE
Fix：MySQL 存储过程 CASE 代码块识别不完整

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/executableStatementRangeCache.spec.ts
@@ -37,6 +37,24 @@ describe("executableStatementRangeCacheForDoc", () => {
     expect(executableStatementRangeStartingAt(cache, secondStatementLine.from)?.sql).toBe("SELECT *\nFROM menus AS mn\nLIMIT 100");
   });
 
+  it("only exposes the routine start as executable when a MySQL procedure contains a CASE expression", () => {
+    const sql = [
+      "CREATE PROCEDURE p_case()",
+      "BEGIN",
+      "  INSERT INTO audit_log (status_text)",
+      "  SELECT CASE WHEN active = 1 THEN 'active' ELSE 'inactive' END;",
+      "  CASE WHEN active = 1 THEN SET @status_code = 1; ELSE SET @status_code = 0; END CASE;",
+      "  DELETE FROM stale_rows WHERE expires_at < NOW();",
+      "END;",
+    ].join("\n");
+    const doc = Text.of(sql.split("\n"));
+    const cache = executableStatementRangeCacheForDoc(null, doc, "mysql");
+
+    expect(executableStatementRangeStartingAt(cache, doc.line(1).from)?.sql).toBe(sql.slice(0, -1));
+    expect(executableStatementRangeStartingAt(cache, doc.line(6).from)).toBeNull();
+    expect(executableStatementRangeAtCursor(cache, doc.line(6).from + 4)?.sql).toBe(sql.slice(0, -1));
+  });
+
   it("keeps MyBatis parameters in a Kingbase gutter execution range", () => {
     const sql = ["SELECT sum(nvl(a.medfee_sumamt, 0)) AS medfee_sumamt, a.insutype", "FROM yd_org_decla_detail a", "WHERE a.busin_type = '1' AND a.clr_ym = #{ym}", "GROUP BY a.clr_ym, a.insutype;"].join("\n");
     const doc = Text.of(sql.split("\n"));

--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -230,6 +230,24 @@ BEGIN
 END;
 SELECT 2;`;
 
+const mysqlRoutineWithCaseExpressionFixture = `CREATE PROCEDURE p_case()
+BEGIN
+  INSERT INTO audit_log (status_text)
+  SELECT CASE
+    WHEN active = 1 THEN 'active'
+    ELSE 'inactive'
+  END;
+
+  CASE
+    WHEN active = 1 THEN SET @status_code = 1;
+    ELSE SET @status_code = 0;
+  END CASE;
+
+  DELETE FROM stale_rows
+  WHERE expires_at < NOW();
+END;
+SELECT 2;`;
+
 const mysqlDelimitedRoutineFixture = `DELIMITER //
 CREATE PROCEDURE sp_insert_random_users(IN p_count INT)
 BEGIN
@@ -1103,6 +1121,10 @@ describe("executableStatementRanges", () => {
 
   it("does not split executable MySQL routine ranges at WHILE and REPEAT endings", () => {
     expect(rangeSqlTexts(executableStatementRanges(mysqlRoutineWithLoopsFixture, "mysql"))).toEqual([mysqlRoutineWithLoopsFixture.slice(0, mysqlRoutineWithLoopsFixture.indexOf("\nSELECT 2;")).replace(/;$/, "").trim(), "SELECT 2"]);
+  });
+
+  it("does not treat a CASE expression ending as the end of a MySQL routine", () => {
+    expect(rangeSqlTexts(executableStatementRanges(mysqlRoutineWithCaseExpressionFixture, "mysql"))).toEqual([mysqlRoutineWithCaseExpressionFixture.slice(0, mysqlRoutineWithCaseExpressionFixture.indexOf("\nSELECT 2;")).replace(/;$/, "").trim(), "SELECT 2"]);
   });
 
   it("does not expose run targets for statements inside a delimited MySQL routine", () => {

--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -248,6 +248,21 @@ BEGIN
 END;
 SELECT 2;`;
 
+const mysqlRoutineWithNestedCaseBlockFixture = `CREATE PROCEDURE p_nested_case()
+BEGIN
+  CASE
+    WHEN active = 1 THEN
+      BEGIN
+        SET @status_code = 1;
+      END;
+    ELSE SET @status_code = 0;
+  END CASE;
+
+  DELETE FROM stale_rows
+  WHERE expires_at < NOW();
+END;
+SELECT 2;`;
+
 const mysqlDelimitedRoutineFixture = `DELIMITER //
 CREATE PROCEDURE sp_insert_random_users(IN p_count INT)
 BEGIN
@@ -358,6 +373,10 @@ describe("splitSqlStatementRanges", () => {
     expect(ranges[0].sql).toContain("SELECT 1;");
     expect(ranges[0].sql).toContain("END IF;");
     expect(ranges[0].sql).not.toMatch(/END;$/);
+  });
+
+  it("closes nested MySQL CASE and BEGIN blocks in their opening order", () => {
+    expect(rangeSqlTexts(splitSqlStatementRanges(mysqlRoutineWithNestedCaseBlockFixture, "mysql"))).toEqual([mysqlRoutineWithNestedCaseBlockFixture.slice(0, mysqlRoutineWithNestedCaseBlockFixture.indexOf("\nSELECT 2;")).replace(/;$/, "").trim(), "SELECT 2"]);
   });
 
   it("does not merge regular MySQL transaction statements as routine blocks", () => {
@@ -1125,6 +1144,10 @@ describe("executableStatementRanges", () => {
 
   it("does not treat a CASE expression ending as the end of a MySQL routine", () => {
     expect(rangeSqlTexts(executableStatementRanges(mysqlRoutineWithCaseExpressionFixture, "mysql"))).toEqual([mysqlRoutineWithCaseExpressionFixture.slice(0, mysqlRoutineWithCaseExpressionFixture.indexOf("\nSELECT 2;")).replace(/;$/, "").trim(), "SELECT 2"]);
+  });
+
+  it("does not split MySQL routine ranges when a CASE branch contains a BEGIN block", () => {
+    expect(rangeSqlTexts(executableStatementRanges(mysqlRoutineWithNestedCaseBlockFixture, "mysql"))).toEqual([mysqlRoutineWithNestedCaseBlockFixture.slice(0, mysqlRoutineWithNestedCaseBlockFixture.indexOf("\nSELECT 2;")).replace(/;$/, "").trim(), "SELECT 2"]);
   });
 
   it("does not expose run targets for statements inside a delimited MySQL routine", () => {

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -1521,6 +1521,7 @@ function mysqlRoutineBlockIsComplete(sql: string, parameterOptions?: SqlParamete
 
   const tokens = mysqlRoutineTokens(sql, parameterOptions);
   let beginDepth = 0;
+  let caseDepth = 0;
   let sawBegin = false;
 
   for (let index = 0; index < tokens.length; index += 1) {
@@ -1532,13 +1533,27 @@ function mysqlRoutineBlockIsComplete(sql: string, parameterOptions?: SqlParamete
       beginDepth += 1;
       continue;
     }
+    if (token.value === "CASE") {
+      if (previousWordToken(tokens, index) === "END") continue;
+      caseDepth += 1;
+      continue;
+    }
     if (token.value === "END" && sawBegin) {
-      if (MYSQL_CONTROL_BLOCK_SUFFIXES.has(nextWordToken(tokens, index) ?? "")) continue;
+      const suffix = nextWordToken(tokens, index) ?? "";
+      if (suffix === "CASE") {
+        caseDepth = Math.max(0, caseDepth - 1);
+        continue;
+      }
+      if (MYSQL_CONTROL_BLOCK_SUFFIXES.has(suffix)) continue;
+      if (caseDepth > 0) {
+        caseDepth -= 1;
+        continue;
+      }
       beginDepth = Math.max(0, beginDepth - 1);
     }
   }
 
-  return sawBegin && beginDepth === 0 && tokens[tokens.length - 1]?.kind === "semicolon";
+  return sawBegin && beginDepth === 0 && caseDepth === 0 && tokens[tokens.length - 1]?.kind === "semicolon";
 }
 
 function mysqlRoutineWords(sql: string, parameterOptions?: SqlParameterOptions): string[] {

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -1520,8 +1520,7 @@ function mysqlRoutineBlockIsComplete(sql: string, parameterOptions?: SqlParamete
   if (!startsWithMysqlRoutineBlock(sql, parameterOptions)) return false;
 
   const tokens = mysqlRoutineTokens(sql, parameterOptions);
-  let beginDepth = 0;
-  let caseDepth = 0;
+  const blockStack: Array<"BEGIN" | "CASE"> = [];
   let sawBegin = false;
 
   for (let index = 0; index < tokens.length; index += 1) {
@@ -1530,30 +1529,26 @@ function mysqlRoutineBlockIsComplete(sql: string, parameterOptions?: SqlParamete
     if (token.value === "BEGIN") {
       if (previousWordToken(tokens, index) === "END") continue;
       sawBegin = true;
-      beginDepth += 1;
+      blockStack.push("BEGIN");
       continue;
     }
     if (token.value === "CASE") {
       if (previousWordToken(tokens, index) === "END") continue;
-      caseDepth += 1;
+      blockStack.push("CASE");
       continue;
     }
     if (token.value === "END" && sawBegin) {
       const suffix = nextWordToken(tokens, index) ?? "";
       if (suffix === "CASE") {
-        caseDepth = Math.max(0, caseDepth - 1);
+        if (blockStack[blockStack.length - 1] === "CASE") blockStack.pop();
         continue;
       }
       if (MYSQL_CONTROL_BLOCK_SUFFIXES.has(suffix)) continue;
-      if (caseDepth > 0) {
-        caseDepth -= 1;
-        continue;
-      }
-      beginDepth = Math.max(0, beginDepth - 1);
+      blockStack.pop();
     }
   }
 
-  return sawBegin && beginDepth === 0 && caseDepth === 0 && tokens[tokens.length - 1]?.kind === "semicolon";
+  return sawBegin && blockStack.length === 0 && tokens[tokens.length - 1]?.kind === "semicolon";
 }
 
 function mysqlRoutineWords(sql: string, parameterOptions?: SqlParameterOptions): string[] {

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -1171,6 +1171,7 @@ fn mysql_routine_block_is_complete(sql: &str) -> bool {
 
     let tokens = mysql_routine_tokens(sql);
     let mut begin_depth = 0usize;
+    let mut case_depth = 0usize;
     let mut saw_begin = false;
 
     for (index, token) in tokens.iter().enumerate() {
@@ -1186,15 +1187,32 @@ fn mysql_routine_block_is_complete(sql: &str) -> bool {
             begin_depth += 1;
             continue;
         }
+        if token.eq_ignore_ascii_case("CASE") {
+            if previous_mysql_routine_word(&tokens, index).is_some_and(|previous| previous.eq_ignore_ascii_case("END"))
+            {
+                continue;
+            }
+            case_depth += 1;
+            continue;
+        }
         if token.eq_ignore_ascii_case("END") && saw_begin {
-            if next_mysql_routine_word(&tokens, index).is_some_and(is_mysql_control_block_suffix) {
+            let suffix = next_mysql_routine_word(&tokens, index);
+            if suffix.is_some_and(|next| next.eq_ignore_ascii_case("CASE")) {
+                case_depth = case_depth.saturating_sub(1);
+                continue;
+            }
+            if suffix.is_some_and(is_mysql_control_block_suffix) {
+                continue;
+            }
+            if case_depth > 0 {
+                case_depth -= 1;
                 continue;
             }
             begin_depth = begin_depth.saturating_sub(1);
         }
     }
 
-    saw_begin && begin_depth == 0 && tokens.last().is_some_and(|token| token == ";")
+    saw_begin && begin_depth == 0 && case_depth == 0 && tokens.last().is_some_and(|token| token == ";")
 }
 
 fn is_mysql_control_block_suffix(token: &str) -> bool {
@@ -3184,6 +3202,40 @@ SELECT 2;";
             split_sql_statements_for_database(sql, DatabaseType::Mysql),
             vec![
                 "CREATE PROCEDURE p_loop()\nBEGIN\n  WHILE 1 = 0 DO\n    SELECT 'while; still body';\n  END WHILE;\n  REPEAT\n    SELECT 'repeat; still body';\n  UNTIL 1 = 1 END REPEAT;\nEND",
+                "SELECT 2",
+            ]
+        );
+    }
+
+    #[test]
+    fn mysql_routine_without_delimiter_handles_case_endings() {
+        let expression = "\
+CREATE PROCEDURE p_case()
+BEGIN
+  INSERT INTO audit_log (status_text)
+  SELECT CASE WHEN active = 1 THEN 'active' ELSE 'inactive' END;
+  DELETE FROM stale_rows WHERE expires_at < NOW();
+END;
+SELECT 2;";
+        assert_eq!(
+            split_sql_statements_for_database(expression, DatabaseType::Mysql),
+            vec![
+                "CREATE PROCEDURE p_case()\nBEGIN\n  INSERT INTO audit_log (status_text)\n  SELECT CASE WHEN active = 1 THEN 'active' ELSE 'inactive' END;\n  DELETE FROM stale_rows WHERE expires_at < NOW();\nEND",
+                "SELECT 2",
+            ]
+        );
+
+        let statement = "\
+CREATE PROCEDURE p_case_statement()
+BEGIN
+  CASE WHEN active = 1 THEN SELECT 1; ELSE SELECT 0; END CASE;
+  DELETE FROM stale_rows WHERE expires_at < NOW();
+END;
+SELECT 2;";
+        assert_eq!(
+            split_sql_statements_for_database(statement, DatabaseType::Mysql),
+            vec![
+                "CREATE PROCEDURE p_case_statement()\nBEGIN\n  CASE WHEN active = 1 THEN SELECT 1; ELSE SELECT 0; END CASE;\n  DELETE FROM stale_rows WHERE expires_at < NOW();\nEND",
                 "SELECT 2",
             ]
         );

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -1164,14 +1164,19 @@ fn is_mysql_routine_ddl_start(sql: &str) -> bool {
     false
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MysqlRoutineBlockType {
+    Begin,
+    Case,
+}
+
 fn mysql_routine_block_is_complete(sql: &str) -> bool {
     if !starts_with_mysql_routine_block(sql) {
         return false;
     }
 
     let tokens = mysql_routine_tokens(sql);
-    let mut begin_depth = 0usize;
-    let mut case_depth = 0usize;
+    let mut block_stack = Vec::new();
     let mut saw_begin = false;
 
     for (index, token) in tokens.iter().enumerate() {
@@ -1184,7 +1189,7 @@ fn mysql_routine_block_is_complete(sql: &str) -> bool {
                 continue;
             }
             saw_begin = true;
-            begin_depth += 1;
+            block_stack.push(MysqlRoutineBlockType::Begin);
             continue;
         }
         if token.eq_ignore_ascii_case("CASE") {
@@ -1192,27 +1197,25 @@ fn mysql_routine_block_is_complete(sql: &str) -> bool {
             {
                 continue;
             }
-            case_depth += 1;
+            block_stack.push(MysqlRoutineBlockType::Case);
             continue;
         }
         if token.eq_ignore_ascii_case("END") && saw_begin {
             let suffix = next_mysql_routine_word(&tokens, index);
             if suffix.is_some_and(|next| next.eq_ignore_ascii_case("CASE")) {
-                case_depth = case_depth.saturating_sub(1);
+                if block_stack.last() == Some(&MysqlRoutineBlockType::Case) {
+                    block_stack.pop();
+                }
                 continue;
             }
             if suffix.is_some_and(is_mysql_control_block_suffix) {
                 continue;
             }
-            if case_depth > 0 {
-                case_depth -= 1;
-                continue;
-            }
-            begin_depth = begin_depth.saturating_sub(1);
+            block_stack.pop();
         }
     }
 
-    saw_begin && begin_depth == 0 && case_depth == 0 && tokens.last().is_some_and(|token| token == ";")
+    saw_begin && block_stack.is_empty() && tokens.last().is_some_and(|token| token == ";")
 }
 
 fn is_mysql_control_block_suffix(token: &str) -> bool {
@@ -3236,6 +3239,24 @@ SELECT 2;";
             split_sql_statements_for_database(statement, DatabaseType::Mysql),
             vec![
                 "CREATE PROCEDURE p_case_statement()\nBEGIN\n  CASE WHEN active = 1 THEN SELECT 1; ELSE SELECT 0; END CASE;\n  DELETE FROM stale_rows WHERE expires_at < NOW();\nEND",
+                "SELECT 2",
+            ]
+        );
+    }
+
+    #[test]
+    fn mysql_routine_without_delimiter_closes_nested_case_begin_blocks_in_order() {
+        let sql = "\
+CREATE PROCEDURE p_nested_case()
+BEGIN
+  CASE WHEN active = 1 THEN BEGIN SELECT 1; END; ELSE SELECT 0; END CASE;
+  DELETE FROM stale_rows WHERE expires_at < NOW();
+END;
+SELECT 2;";
+        assert_eq!(
+            split_sql_statements_for_database(sql, DatabaseType::Mysql),
+            vec![
+                "CREATE PROCEDURE p_nested_case()\nBEGIN\n  CASE WHEN active = 1 THEN BEGIN SELECT 1; END; ELSE SELECT 0; END CASE;\n  DELETE FROM stale_rows WHERE expires_at < NOW();\nEND",
                 "SELECT 2",
             ]
         );

--- a/crates/dbx-core/tests/live_mysql57.rs
+++ b/crates/dbx-core/tests/live_mysql57.rs
@@ -630,30 +630,44 @@ END
 async fn live_mysql_splitter_executes_routine_without_delimiter() {
     let url = std::env::var("DBX_LIVE_MYSQL_PROCEDURE_URL").expect("DBX_LIVE_MYSQL_PROCEDURE_URL");
     let pool = dbx_core::db::mysql::connect(&url, std::time::Duration::from_secs(10)).await.unwrap();
-    let procedure = "dbx_issue_2695_proc";
+    let procedure = format!("dbx_routine_range_{}", uuid::Uuid::new_v4().simple());
 
     let sql = format!(
         "\
 DROP PROCEDURE IF EXISTS {procedure};
 CREATE PROCEDURE {procedure}()
 BEGIN
-    SET @dbx_issue_2695_value = 2695;
-    SELECT @dbx_issue_2695_value AS value;
+    SET @dbx_routine_range_value = CASE WHEN 1 = 1 THEN 2695 ELSE 0 END;
+    SELECT @dbx_routine_range_value AS value;
 END;
 CALL {procedure}();
 DROP PROCEDURE IF EXISTS {procedure};"
     );
     let statements = split_sql_statements_for_database(&sql, DatabaseType::Mysql);
     assert_eq!(statements.len(), 4);
-    assert!(statements[1].contains("SET @dbx_issue_2695_value = 2695;"));
-    assert!(statements[1].contains("SELECT @dbx_issue_2695_value AS value;"));
+    assert!(statements[1].contains("CASE WHEN 1 = 1 THEN 2695 ELSE 0 END;"));
+    assert!(statements[1].contains("SELECT @dbx_routine_range_value AS value;"));
     assert!(statements[1].ends_with("END"));
 
-    for statement in statements {
-        dbx_core::db::mysql::execute_query_with_max_rows(&pool, &statement, false, Some(10), Default::default())
-            .await
-            .unwrap();
+    let execution = async {
+        for statement in &statements[..3] {
+            dbx_core::db::mysql::execute_query_with_max_rows(&pool, statement, false, Some(10), Default::default())
+                .await?;
+        }
+        Ok::<(), String>(())
     }
+    .await;
+    let cleanup = dbx_core::db::mysql::execute_query_with_max_rows(
+        &pool,
+        statements.last().expect("cleanup statement"),
+        false,
+        Some(10),
+        Default::default(),
+    )
+    .await;
+
+    execution.unwrap();
+    cleanup.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 问题

MySQL 存储过程包含 `CASE ... END;` 表达式时，编辑器会把 `CASE` 的 `END` 误认为过程结尾，导致后续 SQL 被拆成独立语句并显示额外运行按钮。后端执行分段也存在相同误判。

## 修复

- 在前端语句范围解析中跟踪 MySQL `CASE` 嵌套深度。
- 同步修复 Rust 执行层 SQL 分段，避免完整选中后仍被二次拆分。
- 同时兼容 `CASE` 表达式和 `CASE ... END CASE` 存储程序语句块。
- 补充编辑器运行按钮、当前语句范围及后端分段回归测试。

## 验证

- 前端定向测试：2 个文件，196 项通过。
- Rust MySQL 例程分段测试：4 项通过。
- `cargo fmt --all -- --check` 通过。
- `cargo clippy -p dbx-core --lib --tests -- -D warnings` 通过。
- MySQL 8.4 实例真实验证：创建、调用、删除包含 `CASE` 表达式的临时存储过程成功，测试对象已清理。
- 全量前端检查中 lint、typecheck、930 个测试文件/8802 项测试通过；docs-export 首轮因并行 Cargo artifact 锁超时，串行重跑通过。当前 main 自带的 `connectionStore.metadataLoading.spec.ts` 格式问题可独立复现，与本 PR 无关。