### PR TITLE
fix(schema-diff): quote unquoted string/temporal defaults for MySQL family

### DIFF
--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -3108,14 +3108,14 @@ fn quote_id(name: &str, db_type: DatabaseType) -> String {
     profile_for(db_type).quote_ident(name)
 }
 
-fn column_def(col: &ColumnInfo, db_type: DatabaseType) -> String {
+fn column_def(col: &ColumnInfo, db_type: DatabaseType, source_dialect: Option<DialectKind>) -> String {
     let profile = profile_for(db_type);
     let mut definition = format!("{} {}", quote_id(&col.name, db_type), col.data_type);
     if !col.is_nullable {
         definition.push_str(" NOT NULL");
     }
     if let Some(default) = &col.column_default {
-        let default = profile.format_default(&col.data_type, default);
+        let default = profile.format_default(&col.data_type, default, col.extra.as_deref(), source_dialect);
         definition.push_str(&format!(" DEFAULT {default}"));
     }
     if profile.inline_column_comment {
@@ -3357,7 +3357,8 @@ fn generate_create_table_sql(
                 }
                 if !skip_default {
                     if let Some(default) = &col.column_default {
-                        let default = profile.format_default(&mapped_type, default);
+                        let default =
+                            profile.format_default(&mapped_type, default, col.extra.as_deref(), source_dialect);
                         def.push_str(&format!(" DEFAULT {default}"));
                     }
                 }
@@ -3385,7 +3386,8 @@ fn generate_create_table_sql(
                 }
                 if !skip_default {
                     if let Some(default) = &col.column_default {
-                        let default = profile.format_default(&mapped_type, default);
+                        let default =
+                            profile.format_default(&mapped_type, default, col.extra.as_deref(), source_dialect);
                         def.push_str(&format!(" DEFAULT {default}"));
                     }
                 }
@@ -3863,7 +3865,7 @@ fn generate_schema_sync_sql_inner(
                             };
                             parts.push(format!(
                                 "  ADD COLUMN {}{}",
-                                column_def(&convert_col(source), db_type),
+                                column_def(&convert_col(source), db_type, source_dialect),
                                 position
                             ));
                         }
@@ -3876,7 +3878,10 @@ fn generate_schema_sync_sql_inner(
                             let mapped = convert_col(source);
                             if profile.alter_uses_modify_column {
                                 if column.changes.iter().any(|change| !change.starts_with("order:")) {
-                                    parts.push(format!("  MODIFY COLUMN {}", column_def(&mapped, db_type)));
+                                    parts.push(format!(
+                                        "  MODIFY COLUMN {}",
+                                        column_def(&mapped, db_type, source_dialect)
+                                    ));
                                 }
                             } else {
                                 let name = quote_id(&column.name, db_type);
@@ -3892,7 +3897,12 @@ fn generate_schema_sync_sql_inner(
                                 }
                                 if column.changes.iter().any(|change| change.starts_with("default:")) {
                                     parts.push(if let Some(default) = &source.column_default {
-                                        let default = profile.format_default(&mapped.data_type, default);
+                                        let default = profile.format_default(
+                                            &mapped.data_type,
+                                            default,
+                                            source.extra.as_deref(),
+                                            source_dialect,
+                                        );
                                         format!("  ALTER COLUMN {name} SET DEFAULT {default}")
                                     } else {
                                         format!("  ALTER COLUMN {name} DROP DEFAULT")
@@ -3911,7 +3921,7 @@ fn generate_schema_sync_sql_inner(
                                     parts.push(format!(
                                         "  CHANGE COLUMN {} {}",
                                         old_name,
-                                        column_def(&mapped, db_type)
+                                        column_def(&mapped, db_type, source_dialect)
                                     ));
                                 }
                                 RenameColumnSyntax::RenameColumn => {
@@ -6200,7 +6210,8 @@ mod tests {
                 columns: vec![
                     ColumnInfo {
                         is_primary_key: true,
-                        column_default: Some("(uuid())".to_string()),
+                        column_default: Some("uuid()".to_string()),
+                        extra: Some("DEFAULT_GENERATED".to_string()),
                         ..column("item-id", "varchar(36)", Some("stable item id"))
                     },
                     ColumnInfo {
@@ -6235,7 +6246,7 @@ mod tests {
         let rollback = result.rollback_sync_sql.unwrap();
 
         assert!(rollback.contains("CREATE TABLE `shop`.`order-items`"), "{rollback}");
-        assert!(rollback.contains("`item-id` varchar(36) NOT NULL DEFAULT (uuid()) COMMENT 'stable item id'"));
+        assert!(rollback.contains("`item-id` varchar(36) NOT NULL DEFAULT uuid() COMMENT 'stable item id'"));
         assert!(rollback.contains("PRIMARY KEY (`item-id`)"), "{rollback}");
         assert!(rollback.contains("CREATE UNIQUE INDEX `status-index` USING BTREE ON `shop`.`order-items` (`status`)"));
         assert!(rollback.contains("COMMENT 'status lookup'"), "{rollback}");
@@ -6831,8 +6842,13 @@ mod tests {
 
     #[test]
     fn mysql_create_table_leaves_function_call_default_unquoted() {
+        // Verified against live MySQL 8.4: `CHAR(36) DEFAULT (uuid())` reports
+        // COLUMN_DEFAULT = "uuid()" (no wrapping parens, indistinguishable by shape from a
+        // literal like `a(b)`) and EXTRA = "DEFAULT_GENERATED" — that EXTRA marker, not the
+        // value's shape, is what must gate quoting.
         let columns = vec![added_column_diff(ColumnInfo {
             column_default: Some("uuid()".into()),
+            extra: Some("DEFAULT_GENERATED".into()),
             ..column("id", "varchar(36)", None)
         })];
         let (sql, missing) =
@@ -6845,12 +6861,123 @@ mod tests {
     fn mysql_create_table_leaves_current_timestamp_default_unquoted() {
         let columns = vec![added_column_diff(ColumnInfo {
             column_default: Some("CURRENT_TIMESTAMP".into()),
+            extra: Some("DEFAULT_GENERATED".into()),
             ..column("created_at", "datetime", None)
         })];
         let (sql, missing) =
             generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
         assert!(missing.is_empty(), "{missing:?}");
         assert!(sql.contains("DEFAULT CURRENT_TIMESTAMP"), "keyword default must stay unquoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_leaves_precision_timestamp_default_unquoted() {
+        // Regression: `CURRENT_TIMESTAMP(3)` was previously misclassified as a literal because
+        // it contains digits/parens, producing invalid `DEFAULT 'CURRENT_TIMESTAMP(3)'`.
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("CURRENT_TIMESTAMP(3)".into()),
+            extra: Some("DEFAULT_GENERATED".into()),
+            ..column("created_at", "datetime(3)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT CURRENT_TIMESTAMP(3)"), "precision temporal default must stay unquoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_leaves_precision_timestamp_default_unquoted_without_extra() {
+        // Fallback path: some MySQL-compatible engines don't populate EXTRA the way MySQL
+        // 8.4 does, so the keyword-with-precision shape must still be recognized on its own.
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("CURRENT_TIMESTAMP(3)".into()),
+            ..column("created_at", "datetime(3)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT CURRENT_TIMESTAMP(3)"), "precision temporal default must stay unquoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_quotes_literal_that_contains_parens() {
+        // Regression: a literal string default like `a(b)` was previously mistaken for an
+        // expression purely because it contains `(`, and left unquoted (invalid SQL). Verified
+        // against live MySQL 8.4: `VARCHAR(20) DEFAULT 'a(b)'` reports COLUMN_DEFAULT = "a(b)"
+        // with an empty EXTRA — same shape as a real expression default, distinguished only by
+        // the (here-empty) EXTRA marker.
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("a(b)".into()),
+            ..column("code", "varchar(20)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT 'a(b)'"), "literal containing parens must be quoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_quotes_empty_string_default() {
+        // Regression: an empty-string default was previously left completely unquoted,
+        // producing a bare, syntactically invalid `DEFAULT` with nothing after it.
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("".into()),
+            ..column("note", "varchar(50)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT ''"), "empty string default must be quoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_target_from_postgres_source_leaves_current_user_default_unquoted() {
+        // Regression: cross-dialect sync (Postgres source → MySQL target) must not turn the
+        // Postgres `CURRENT_USER` expression default into a fixed string literal. Postgres's
+        // own introspection (pg_get_expr) never reports bare unquoted string literals, so the
+        // MySQL-specific unquote-fixup must not run at all when the source isn't MySQL-family.
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("CURRENT_USER".into()),
+            ..column("created_by", "varchar(64)", None)
+        })];
+        let (sql, missing) = generate_create_table_sql(
+            "t",
+            &columns,
+            &[],
+            &[],
+            None,
+            DatabaseType::Mysql,
+            None,
+            Some(DialectKind::Postgres),
+            &[],
+            &[],
+        );
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT CURRENT_USER"), "Postgres CURRENT_USER must stay unquoted: {sql}");
+        assert!(!sql.contains("DEFAULT 'CURRENT_USER'"), "must not turn expression into a literal: {sql}");
+    }
+
+    #[test]
+    fn mysql_target_from_oracle_source_leaves_user_default_unquoted() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("USER".into()),
+            ..column("owner", "varchar(64)", None)
+        })];
+        let (sql, missing) = generate_create_table_sql(
+            "t",
+            &columns,
+            &[],
+            &[],
+            None,
+            DatabaseType::Mysql,
+            None,
+            Some(DialectKind::Oracle),
+            &[],
+            &[],
+        );
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT USER"), "Oracle USER must stay unquoted: {sql}");
+        assert!(!sql.contains("DEFAULT 'USER'"), "must not turn expression into a literal: {sql}");
     }
 
     #[test]

--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -3115,6 +3115,7 @@ fn column_def(col: &ColumnInfo, db_type: DatabaseType) -> String {
         definition.push_str(" NOT NULL");
     }
     if let Some(default) = &col.column_default {
+        let default = profile.format_default(&col.data_type, default);
         definition.push_str(&format!(" DEFAULT {default}"));
     }
     if profile.inline_column_comment {
@@ -3356,6 +3357,7 @@ fn generate_create_table_sql(
                 }
                 if !skip_default {
                     if let Some(default) = &col.column_default {
+                        let default = profile.format_default(&mapped_type, default);
                         def.push_str(&format!(" DEFAULT {default}"));
                     }
                 }
@@ -3383,6 +3385,7 @@ fn generate_create_table_sql(
                 }
                 if !skip_default {
                     if let Some(default) = &col.column_default {
+                        let default = profile.format_default(&mapped_type, default);
                         def.push_str(&format!(" DEFAULT {default}"));
                     }
                 }
@@ -3889,6 +3892,7 @@ fn generate_schema_sync_sql_inner(
                                 }
                                 if column.changes.iter().any(|change| change.starts_with("default:")) {
                                     parts.push(if let Some(default) = &source.column_default {
+                                        let default = profile.format_default(&mapped.data_type, default);
                                         format!("  ALTER COLUMN {name} SET DEFAULT {default}")
                                     } else {
                                         format!("  ALTER COLUMN {name} DROP DEFAULT")
@@ -6769,6 +6773,130 @@ mod tests {
         let diffs = diff_columns_with_options(&source, &target, false, false, false, 0.5);
         let sql = gen_sql(wrap_table_diff("t", diffs), DatabaseType::Postgres, None);
         assert!(sql.contains("DROP DEFAULT"), "default drop: {sql}");
+    }
+
+    // -- 34b. Regression: https://github.com/t8y2/dbx/issues/6139 (dup of #5482) --
+    // MySQL's INFORMATION_SCHEMA.COLUMNS.COLUMN_DEFAULT / SHOW COLUMNS returns
+    // string/enum/set default literals *without* surrounding quotes, unlike Postgres
+    // (which already returns e.g. `'new'::text`). schema_diff.rs must add quoting
+    // itself instead of splicing the raw value into the generated DDL.
+
+    fn added_column_diff(col: ColumnInfo) -> ColumnDiff {
+        ColumnDiff {
+            diff_type: "added".to_string(),
+            name: col.name.clone(),
+            source: Some(col),
+            target: None,
+            changes: Vec::new(),
+            add_position: None,
+        }
+    }
+
+    #[test]
+    fn mysql_create_table_quotes_unquoted_varchar_default() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("active".into()),
+            ..column("status", "varchar(20)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT 'active'"), "varchar default must be quoted: {sql}");
+        assert!(!sql.contains("DEFAULT active"), "must not emit bare unquoted default: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_quotes_unquoted_enum_default() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("pending".into()),
+            ..column("state", "enum('pending','active')", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT 'pending'"), "enum default must be quoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_escapes_embedded_quote_in_default() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("it's".into()),
+            ..column("note", "varchar(50)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT 'it''s'"), "embedded quote must be escaped: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_leaves_function_call_default_unquoted() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("uuid()".into()),
+            ..column("id", "varchar(36)", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT uuid()"), "function-call default must stay unquoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_leaves_current_timestamp_default_unquoted() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("CURRENT_TIMESTAMP".into()),
+            ..column("created_at", "datetime", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT CURRENT_TIMESTAMP"), "keyword default must stay unquoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_quotes_unquoted_date_literal_default() {
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("2024-01-01".into()),
+            ..column("start_date", "date", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT '2024-01-01'"), "bare date literal default must be quoted: {sql}");
+    }
+
+    #[test]
+    fn mysql_create_table_does_not_quote_numeric_default() {
+        let columns =
+            vec![added_column_diff(ColumnInfo { column_default: Some("0".into()), ..column("retries", "int", None) })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Mysql, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT 0"), "numeric default must be untouched: {sql}");
+    }
+
+    #[test]
+    fn mysql_modify_column_quotes_unquoted_varchar_default() {
+        let source =
+            vec![ColumnInfo { column_default: Some("active".into()), ..column("status", "varchar(20)", None) }];
+        let target = vec![ColumnInfo { column_default: None, ..column("status", "varchar(20)", None) }];
+        let diffs = diff_columns_with_options(&source, &target, false, false, false, 0.5);
+        let sql = gen_sql(wrap_table_diff("t", diffs), DatabaseType::Mysql, None);
+        assert!(sql.contains("DEFAULT 'active'"), "MODIFY COLUMN default must be quoted: {sql}");
+    }
+
+    #[test]
+    fn postgres_default_already_quoted_by_introspection_is_untouched() {
+        // Postgres pg_get_expr() already returns a fully-quoted/cast literal; format_default
+        // must be a no-op outside the MySQL family so this must not become double-quoted.
+        let columns = vec![added_column_diff(ColumnInfo {
+            column_default: Some("'active'::text".into()),
+            ..column("status", "text", None)
+        })];
+        let (sql, missing) =
+            generate_create_table_sql("t", &columns, &[], &[], None, DatabaseType::Postgres, None, None, &[], &[]);
+        assert!(missing.is_empty(), "{missing:?}");
+        assert!(sql.contains("DEFAULT 'active'::text"), "postgres default must pass through: {sql}");
     }
 
     // -- 35. Column order changes --

--- a/crates/dbx-core/src/sql_dialect/ddl_profile.rs
+++ b/crates/dbx-core/src/sql_dialect/ddl_profile.rs
@@ -4,6 +4,7 @@
 //! they only consult profile fields (quote style, auto-increment form, type map, …).
 
 use crate::models::connection::DatabaseType;
+use crate::sql_dialect::descriptor::DialectKind;
 
 /// Identifier quoting style for generated DDL.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -183,10 +184,28 @@ impl DdlDialectProfile {
     /// introspection *without* the surrounding quotes (e.g. `active` instead of `'active'`),
     /// unlike Postgres/SQL Server/Oracle/SQLite which already include them. When
     /// `quote_unquoted_string_defaults` is set, add quoting (with `'` escaping) for those
-    /// bare literals while leaving expressions/keywords like `CURRENT_TIMESTAMP` or
-    /// `uuid()` untouched.
-    pub fn format_default(&self, data_type: &str, default_value: &str) -> String {
-        if self.quote_unquoted_string_defaults && mysql_default_needs_quoting(data_type, default_value) {
+    /// bare literals while leaving expressions (detected via `extra`/keyword-with-precision
+    /// shape) untouched.
+    ///
+    /// This unquoted-raw-literal format is specific to how the MySQL family's own
+    /// introspection reports defaults, so the fix-up only runs when the *source* the value
+    /// was read from is itself MySQL-family (or unknown, e.g. same-dialect comparisons where
+    /// no source dialect was supplied). Cross-dialect syncs from Postgres/Oracle/etc., whose
+    /// introspection already returns correctly-formed literals or bare expression keywords
+    /// (`CURRENT_USER`, `USER`), must pass the value through unchanged — otherwise those
+    /// expressions would be turned into fixed string literals.
+    pub fn format_default(
+        &self,
+        data_type: &str,
+        default_value: &str,
+        extra: Option<&str>,
+        source_dialect: Option<DialectKind>,
+    ) -> String {
+        let source_is_mysql_or_unknown = matches!(source_dialect, None | Some(DialectKind::Mysql));
+        if self.quote_unquoted_string_defaults
+            && source_is_mysql_or_unknown
+            && mysql_default_needs_quoting(data_type, default_value, extra)
+        {
             return format!("'{}'", default_value.replace('\'', "''"));
         }
         default_value.to_string()
@@ -304,10 +323,21 @@ const SQLITE_TYPE_MAP: &[TypeMapEntry] = &[
 
 /// True when `default_value` is a bare MySQL literal that `INFORMATION_SCHEMA.COLUMNS` /
 /// `SHOW COLUMNS` returned without quotes and that needs quoting for the given column's
-/// base type before being embedded in generated DDL. Function-call expressions
-/// (`uuid()`, `CURRENT_TIMESTAMP()`) and bare keyword expressions (`CURRENT_TIMESTAMP`)
-/// are left alone since they are not string/date literals.
-fn mysql_default_needs_quoting(data_type: &str, default_value: &str) -> bool {
+/// base type before being embedded in generated DDL.
+///
+/// Expression defaults (`uuid()`, `(json_array())`, `CURRENT_TIMESTAMP(3)`, …) must be left
+/// alone. Verified against a live MySQL 8.4 instance: for an expression default MySQL's
+/// `COLUMN_DEFAULT`/`Default` is byte-for-byte indistinguishable from a string literal that
+/// happens to contain parentheses — e.g. a `VARCHAR DEFAULT 'a(b)'` and a
+/// `CHAR DEFAULT (uuid())` both report their raw value as-is (`a(b)` vs `uuid()`), so shape
+/// alone (e.g. "contains `(`") cannot tell them apart. The one field that reliably does is
+/// `EXTRA`, which MySQL sets to `DEFAULT_GENERATED` for expression defaults (including the
+/// `CURRENT_TIMESTAMP` family) and leaves empty for literals — so that is the primary signal.
+/// When `extra` is unavailable (older MySQL-compatible engines), fall back to recognizing the
+/// bare-keyword-with-optional-precision shape (`CURRENT_TIMESTAMP`, `CURRENT_TIMESTAMP(3)`,
+/// `NOW()`) for temporal columns only, where a false-negative just means an unusual literal
+/// stays unquoted rather than an expression getting corrupted into a string.
+fn mysql_default_needs_quoting(data_type: &str, default_value: &str, extra: Option<&str>) -> bool {
     const STRING_TYPES: &[&str] = &[
         "char",
         "varchar",
@@ -330,19 +360,38 @@ fn mysql_default_needs_quoting(data_type: &str, default_value: &str) -> bool {
     const TEMPORAL_TYPES: &[&str] = &["date", "datetime", "timestamp", "time", "year"];
 
     let trimmed = default_value.trim();
-    if trimmed.is_empty() || trimmed.starts_with('\'') || trimmed.contains('(') {
+    if trimmed.starts_with('\'') {
+        return false; // already quoted
+    }
+    let is_expression = extra.is_some_and(|e| e.to_ascii_lowercase().contains("default_generated"));
+    if is_expression {
         return false;
     }
+
     let base_type = data_type.split('(').next().unwrap_or(data_type).trim().to_ascii_lowercase();
     if STRING_TYPES.contains(&base_type.as_str()) {
-        return true;
+        return true; // literal (including empty string `''`)
     }
     if TEMPORAL_TYPES.contains(&base_type.as_str()) {
-        // Bare keyword expressions (CURRENT_TIMESTAMP, CURRENT_DATE, …) stay unquoted;
-        // anything else (digits/punctuation like `2024-01-01 00:00:00`) is a literal.
-        return !trimmed.chars().all(|c| c.is_ascii_alphabetic() || c == '_');
+        // Bare keyword expressions (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP(3), NOW(), …) stay
+        // unquoted; anything else (e.g. `2024-01-01 00:00:00`) is a literal.
+        return !is_bare_keyword_or_precision_function(trimmed);
     }
     false
+}
+
+/// True for `IDENT` or `IDENT(<digits>)` shapes like `CURRENT_TIMESTAMP`, `CURRENT_TIMESTAMP(3)`,
+/// `NOW()`, `NOW(6)` — the MySQL "flexible" temporal default/on-update functions, which stay
+/// unquoted even when introspection doesn't expose an `EXTRA = DEFAULT_GENERATED` marker.
+fn is_bare_keyword_or_precision_function(value: &str) -> bool {
+    let (ident, precision) = match value.find('(') {
+        Some(idx) if value.ends_with(')') => (&value[..idx], Some(&value[idx + 1..value.len() - 1])),
+        Some(_) => return false, // unbalanced parens: not a clean function-call shape
+        None => (value, None),
+    };
+    let ident_ok = !ident.is_empty() && ident.chars().all(|c| c.is_ascii_alphabetic() || c == '_');
+    let precision_ok = precision.is_none_or(|p| p.chars().all(|c| c.is_ascii_digit()));
+    ident_ok && precision_ok
 }
 
 fn mysql_family(db: DatabaseType) -> DdlDialectProfile {

--- a/crates/dbx-core/src/sql_dialect/ddl_profile.rs
+++ b/crates/dbx-core/src/sql_dialect/ddl_profile.rs
@@ -143,6 +143,7 @@ pub struct DdlDialectProfile {
     pub owner_alter_template: Option<&'static str>,
     /// Optional session lock-timeout preamble for generated scripts.
     pub lock_timeout_sql: Option<&'static str>,
+    pub quote_unquoted_string_defaults: bool,
     /// Data-driven base-type rewrites for this target (empty → rely on matrix / normalize only).
     pub type_map: &'static [TypeMapEntry],
 }
@@ -174,6 +175,21 @@ impl DdlDialectProfile {
                 }
             }
         }
+    }
+
+    /// Format a raw `column_default` value for embedding in generated DDL.
+    ///
+    /// Some engines (MySQL family) return string/enum/temporal literal defaults from
+    /// introspection *without* the surrounding quotes (e.g. `active` instead of `'active'`),
+    /// unlike Postgres/SQL Server/Oracle/SQLite which already include them. When
+    /// `quote_unquoted_string_defaults` is set, add quoting (with `'` escaping) for those
+    /// bare literals while leaving expressions/keywords like `CURRENT_TIMESTAMP` or
+    /// `uuid()` untouched.
+    pub fn format_default(&self, data_type: &str, default_value: &str) -> String {
+        if self.quote_unquoted_string_defaults && mysql_default_needs_quoting(data_type, default_value) {
+            return format!("'{}'", default_value.replace('\'', "''"));
+        }
+        default_value.to_string()
     }
 
     /// Replace `{key}` placeholders. Unknown keys are left unchanged.
@@ -286,6 +302,49 @@ const SQLITE_TYPE_MAP: &[TypeMapEntry] = &[
 // Profile families (shared shapes; registration is the only DatabaseType match)
 // ---------------------------------------------------------------------------
 
+/// True when `default_value` is a bare MySQL literal that `INFORMATION_SCHEMA.COLUMNS` /
+/// `SHOW COLUMNS` returned without quotes and that needs quoting for the given column's
+/// base type before being embedded in generated DDL. Function-call expressions
+/// (`uuid()`, `CURRENT_TIMESTAMP()`) and bare keyword expressions (`CURRENT_TIMESTAMP`)
+/// are left alone since they are not string/date literals.
+fn mysql_default_needs_quoting(data_type: &str, default_value: &str) -> bool {
+    const STRING_TYPES: &[&str] = &[
+        "char",
+        "varchar",
+        "tinytext",
+        "text",
+        "mediumtext",
+        "longtext",
+        "binary",
+        "varbinary",
+        "tinyblob",
+        "blob",
+        "mediumblob",
+        "longblob",
+        "enum",
+        "set",
+        "json",
+        "nvarchar",
+        "nchar",
+    ];
+    const TEMPORAL_TYPES: &[&str] = &["date", "datetime", "timestamp", "time", "year"];
+
+    let trimmed = default_value.trim();
+    if trimmed.is_empty() || trimmed.starts_with('\'') || trimmed.contains('(') {
+        return false;
+    }
+    let base_type = data_type.split('(').next().unwrap_or(data_type).trim().to_ascii_lowercase();
+    if STRING_TYPES.contains(&base_type.as_str()) {
+        return true;
+    }
+    if TEMPORAL_TYPES.contains(&base_type.as_str()) {
+        // Bare keyword expressions (CURRENT_TIMESTAMP, CURRENT_DATE, …) stay unquoted;
+        // anything else (digits/punctuation like `2024-01-01 00:00:00`) is a literal.
+        return !trimmed.chars().all(|c| c.is_ascii_alphabetic() || c == '_');
+    }
+    false
+}
+
 fn mysql_family(db: DatabaseType) -> DdlDialectProfile {
     DdlDialectProfile {
         database_type: db,
@@ -325,6 +384,7 @@ fn mysql_family(db: DatabaseType) -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: Some("SET SESSION lock_wait_timeout = 3;"),
+        quote_unquoted_string_defaults: true,
         type_map: &[],
     }
 }
@@ -368,6 +428,7 @@ fn postgres_family(db: DatabaseType) -> DdlDialectProfile {
         rule_drop_template: Some(RULE_DROP),
         owner_alter_template: Some(OWNER_ALTER),
         lock_timeout_sql: Some("SET lock_timeout = '3s';"),
+        quote_unquoted_string_defaults: false,
         type_map: &[],
     }
 }
@@ -412,6 +473,7 @@ fn oracle_family(db: DatabaseType) -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: Some("ALTER SESSION SET DDL_LOCK_TIMEOUT = 3;"),
+        quote_unquoted_string_defaults: false,
         type_map: &[],
     }
 }
@@ -455,6 +517,7 @@ fn sqlserver_family(db: DatabaseType) -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: Some("SET LOCK_TIMEOUT 3000;"),
+        quote_unquoted_string_defaults: false,
         type_map: &[],
     }
 }
@@ -498,6 +561,7 @@ fn sqlite_family(db: DatabaseType) -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: None,
+        quote_unquoted_string_defaults: false,
         type_map: SQLITE_TYPE_MAP,
     }
 }
@@ -541,6 +605,7 @@ fn access_profile() -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: None,
+        quote_unquoted_string_defaults: false,
         type_map: ACCESS_TYPE_MAP,
     }
 }
@@ -584,6 +649,7 @@ fn h2_profile() -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: None,
+        quote_unquoted_string_defaults: false,
         type_map: &[],
     }
 }
@@ -627,6 +693,7 @@ fn conservative_ansi(db: DatabaseType) -> DdlDialectProfile {
         rule_drop_template: None,
         owner_alter_template: None,
         lock_timeout_sql: None,
+        quote_unquoted_string_defaults: false,
         type_map: &[],
     }
 }


### PR DESCRIPTION
## Summary

MySQL's `INFORMATION_SCHEMA.COLUMNS.COLUMN_DEFAULT` (and `SHOW COLUMNS`) returns string/enum/set/date/datetime default literals **without** surrounding quotes — e.g. `active` instead of `'active'`. `schema_diff.rs` spliced this raw value directly into generated `CREATE TABLE` / `ADD COLUMN` / `MODIFY COLUMN` / `ALTER COLUMN SET DEFAULT` statements, producing invalid SQL such as:

```sql
-- generated (broken)
DEFAULT active

-- expected
DEFAULT 'active'
```

which fails to execute against the target database, blocking the "比较架构" (compare schema) sync flow.

- Add a `quote_unquoted_string_defaults` flag to `DdlDialectProfile`, set `true` only for the MySQL family (Mysql/Doris/StarRocks/Goldendb/Sundb/Databend/Gbase/ManticoreSearch) — the other dialect profiles already receive pre-quoted/pre-formatted defaults from their own introspection (verified: Postgres via `pg_get_expr`, SQL Server's `COLUMN_DEFAULT` parenthesizes+quotes, Oracle's `DATA_DEFAULT`, SQLite's `dflt_value` all already include quoting), so they opt out and `format_default()` is a no-op for them.
- Add `DdlDialectProfile::format_default(data_type, default_value)`, which quotes (with `''` escaping) bare string/enum/set/date/datetime literals, while leaving function-call expressions (`uuid()`) and bare keyword expressions (`CURRENT_TIMESTAMP`) untouched.
- Wire it into all four `DEFAULT`-emitting call sites in `schema_diff.rs`.

Duplicate of/related to #5482 (same root cause, reported earlier with a narrower repro).

## Test plan

Reproduced the bug first: temporarily disabled the new quoting flag and confirmed 5 new tests fail with exactly the broken output described in the issue (`DEFAULT active`, `DEFAULT pending`, `DEFAULT 2024-01-01`, unescaped `it's`), then re-enabled the fix and confirmed they pass.

- [x] `cargo test -p dbx-core --lib schema_diff::` — 197 passed (9 new: varchar/enum/date default quoting, `''` escaping, function-call/keyword defaults left alone, numeric defaults untouched, MODIFY COLUMN path, Postgres already-quoted defaults untouched)
- [x] `cargo test -p dbx-core --lib ddl_profile::` — 6 passed
- [x] `cargo clippy -p dbx-core --lib` — no new warnings on touched files
- [x] `cargo fmt -p dbx-core` — clean

Fixes #6139