### PR TITLE
fix(desktop): keep downloading in background on accidental dialog dismiss

### DIFF
--- a/apps/desktop/src/components/layout/UpdateDialog.spec.ts
+++ b/apps/desktop/src/components/layout/UpdateDialog.spec.ts
@@ -119,6 +119,11 @@ async function pressEscape() {
   await flushDialog();
 }
 
+async function clickOutside() {
+  document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+  await flushDialog();
+}
+
 afterEach(() => {
   for (const app of mountedApps.splice(0)) app.unmount();
   document.body.innerHTML = "";
@@ -200,6 +205,24 @@ describe("UpdateDialog close protection", () => {
 
     expect(cancelDownload).toHaveBeenCalledOnce();
     expect(state.open).toBe(false);
+  });
+
+  it("keeps downloading in the background when the dialog is dismissed by clicking outside", async () => {
+    const { state, cancelDownload } = await mountDialog(0, { isDownloadingUpdate: true, downloadProgress: 42 });
+
+    await clickOutside();
+
+    expect(cancelDownload).not.toHaveBeenCalled();
+    expect(state.open).toBe(true);
+  });
+
+  it("keeps downloading in the background when the dialog is dismissed with Escape", async () => {
+    const { state, cancelDownload } = await mountDialog(0, { isDownloadingUpdate: true, downloadProgress: 42 });
+
+    await pressEscape();
+
+    expect(cancelDownload).not.toHaveBeenCalled();
+    expect(state.open).toBe(true);
   });
 
   it("allows closing while a downloaded update is idle", async () => {

--- a/apps/desktop/src/components/layout/UpdateDialog.vue
+++ b/apps/desktop/src/components/layout/UpdateDialog.vue
@@ -37,6 +37,9 @@ const isDesktop = isTauriRuntime();
 const renderedNotes = ref("");
 // Only active file replacement (installation) must trap the dialog.
 const isCloseBlocked = computed(() => props.isInstallingUpdate);
+// Accidental dismiss gestures (outside click, Escape) must not cancel a running download;
+// only the explicit close/cancel buttons should.
+const blocksImplicitDismiss = computed(() => props.isInstallingUpdate || props.isDownloadingUpdate);
 const canIgnoreVersion = computed(() => props.updateInfo?.update_available === true && !props.updateDownloaded && !props.isDownloadingUpdate && !props.isInstallingUpdate && !props.updateReady);
 
 function handleCancel() {
@@ -91,12 +94,12 @@ watch(
       :show-close-button="!isCloseBlocked"
       @interact-outside="
         (e: Event) => {
-          if (isCloseBlocked) e.preventDefault();
+          if (blocksImplicitDismiss) e.preventDefault();
         }
       "
       @escape-key-down="
         (e: Event) => {
-          if (isCloseBlocked) e.preventDefault();
+          if (blocksImplicitDismiss) e.preventDefault();
         }
       "
     >


### PR DESCRIPTION
## Problem

Fixes #6125

While an update is downloading, clicking outside the update dialog (or pressing Escape) closes it via the same `handleOpenChange` path used by the explicit close/cancel buttons. That path emits `cancel-download` whenever `isDownloadingUpdate` is true, so an accidental outside click silently cancels the in-flight download. Since the backend has no resume/checkpoint support, reopening the dialog and clicking "Download & Install" again always restarts from 0%.

## Fix

`UpdateDialog.vue` already has an `isCloseBlocked` guard (installation only) that prevents `@interact-outside` / `@escape-key-down` from closing the dialog. This PR adds a second guard, `blocksImplicitDismiss` (`isInstallingUpdate || isDownloadingUpdate`), applied only to those two implicit-dismiss event handlers.

- Outside click / Escape while downloading: now a no-op — dialog stays open, download keeps running in the background.
- Explicit close (X) button / footer "Cancel" button: unchanged — still cancels the download, exactly as before (covered by the existing `cancels the background download when the close button is clicked` test).

## Testing

- Added two component tests to `UpdateDialog.spec.ts` that dispatch a real `pointerdown` outside the dialog and a real `Escape` keydown while `isDownloadingUpdate` is true, asserting `cancel-download` is not emitted and the dialog stays open. Verified these fail against the pre-fix code (real repro) and pass after the fix.
- `pnpm vitest run` — 931 files / 8803 tests passing, no regressions.
- `pnpm typecheck` and `oxlint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)