### PR TITLE
fix(editor): wrap generated SQL templates instead of overflowing the pane

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1060,6 +1060,7 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
               :statement-execution-markers="activeStatementExecutionMarkers"
               :initial-viewport="activeTab.editorViewport"
               :initial-selection="activeTab.editorSelection"
+              :force-word-wrap="activeTab.forceWordWrap"
               @update:model-value="emit('editorUpdate', activeTab.id, $event)"
               @selection-change="emit('editorSelectionChange', $event)"
               @send-selection-to-ai="emit('sendSelectionToAi', $event)"

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -1529,7 +1529,7 @@ async function loadTemplateContext(allowView = false) {
 }
 
 function openSqlTemplateTab(connectionId: string, database: string, schema: string | undefined, catalog: string | undefined, sql: string, title?: string) {
-  const tabId = queryStore.createTab(connectionId, database, title, "query", schema, undefined, catalog);
+  const tabId = queryStore.createTab(connectionId, database, title, "query", schema, undefined, catalog, { forceWordWrap: true });
   queryStore.updateSql(tabId, sql);
 }
 

--- a/apps/desktop/src/stores/__tests__/queryStore.templateForceWordWrap.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.templateForceWordWrap.spec.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("queryStore createTab forceWordWrap", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    setActivePinia(createPinia());
+  });
+
+  it("defaults new tabs to no forced word wrap", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const queryStore = useQueryStore();
+
+    const tabId = queryStore.createTab("pg-1", "app", "Query");
+    const tab = queryStore.tabs.find((t) => t.id === tabId);
+
+    expect(tab?.forceWordWrap).toBeFalsy();
+  });
+
+  it("marks a tab as force-wrapped when requested via options", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const queryStore = useQueryStore();
+
+    const tabId = queryStore.createTab("pg-1", "app", "SELECT users", "query", undefined, undefined, undefined, { forceNew: true, forceWordWrap: true });
+    const tab = queryStore.tabs.find((t) => t.id === tabId);
+
+    expect(tab?.forceWordWrap).toBe(true);
+  });
+});
+
+describe("Generate SQL template tabs wire forceWordWrap end to end (issue #6038)", () => {
+  const sidebarSource = readFileSync(new URL("../../components/sidebar/SidebarTreeRuntimeHost.vue", import.meta.url), "utf8");
+  const contentAreaSource = readFileSync(new URL("../../components/layout/ContentArea.vue", import.meta.url), "utf8");
+
+  it("openSqlTemplateTab requests forceWordWrap when creating the tab", () => {
+    expect(sidebarSource).toMatch(/function openSqlTemplateTab\([^)]*\)\s*{[\s\S]*?createTab\([^)]*forceWordWrap:\s*true[^)]*\)/);
+  });
+
+  it("ContentArea forwards the tab's forceWordWrap flag into QueryEditor", () => {
+    expect(contentAreaSource).toMatch(/<QueryEditor[\s\S]*?:force-word-wrap="activeTab\.forceWordWrap"/);
+  });
+});

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -1607,7 +1607,7 @@ export const useQueryStore = defineStore("query", () => {
     return tabs.value.find((tab) => tab.connectionId === connectionId && tab.database === database && tab.title === title && tab.mode === mode && (tab.schema || "") === (schema || "") && (tab.catalog || "") === (catalog || ""));
   }
 
-  function createTab(connectionId: string, database: string, title?: string, mode: QueryTab["mode"] = "query", schema?: string, initialSql?: string, catalog?: string, options: { forceNew?: boolean; activate?: boolean } = {}) {
+  function createTab(connectionId: string, database: string, title?: string, mode: QueryTab["mode"] = "query", schema?: string, initialSql?: string, catalog?: string, options: { forceNew?: boolean; activate?: boolean; forceWordWrap?: boolean } = {}) {
     if (title && !options.forceNew) {
       const existing = findTabByIdentity(connectionId, database, title, mode, schema, catalog);
       if (existing) {
@@ -1621,6 +1621,7 @@ export const useQueryStore = defineStore("query", () => {
       id,
       title: title || `query_${tabs.value.length + 1}`,
       customTitle: mode === "query" && !!title ? true : undefined,
+      forceWordWrap: options.forceWordWrap,
       connectionId,
       database,
       schema,

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -1078,6 +1078,8 @@ export interface QueryTab {
   id: string;
   title: string;
   customTitle?: boolean;
+  /** Force the editor to word-wrap regardless of the global setting, e.g. for auto-generated single-line templates. */
+  forceWordWrap?: boolean;
   connectionId: string;
   database: string;
   schema?: string;


### PR DESCRIPTION
## Summary
- Right-clicking a table → "生成SQL" (Generate SQL) → 查询语句/更新语句/插入语句/删除语句 (SELECT/UPDATE/INSERT/DELETE) opens a new tab whose generated SQL joins every column onto a single line. With word-wrap off by default, wide tables produced a line that overflowed the editor pane instead of wrapping (repro: mssql table with 20+ columns, matches the issue screenshot).
- `queryStore.createTab` now accepts a `forceWordWrap` option; `openSqlTemplateTab` (used by all "Generate SQL" template handlers) passes `forceWordWrap: true` when creating the tab.
- `ContentArea.vue` forwards `activeTab.forceWordWrap` into `QueryEditor`'s `forceWordWrap` prop — that prop already existed and is fully wired to a CodeMirror word-wrap compartment, but nothing was passing it before.
- Only these generated-template tabs wrap; the global word-wrap editor setting is untouched for normal editing.

Fixes #6038

## Test plan
- [x] Added `apps/desktop/src/stores/__tests__/queryStore.templateForceWordWrap.spec.ts`: confirmed it fails before the fix (reproducing the bug) and passes after — covers `createTab` defaulting to no forced wrap, `createTab` honoring `forceWordWrap`, `openSqlTemplateTab` requesting it, and `ContentArea` forwarding it to `QueryEditor`.
- [x] `pnpm vitest run` — full suite: 8811 tests, all passing (one unrelated `exportSmoke.spec.ts` cold-cargo-build timeout on first run, passed on retry).