### PR TITLE
Improve:优化大表长值元数据合并性能

### DIFF
--- a/apps/desktop/src/lib/backend/__tests__/httpErrorParsing.spec.ts
+++ b/apps/desktop/src/lib/backend/__tests__/httpErrorParsing.spec.ts
@@ -1,5 +1,34 @@
 import { describe, expect, test, vi } from "vitest";
-import { backendResponseError, importAgentDriver, installJdbcPluginLocal } from "@/lib/backend/http";
+import { backendResponseError, executeMulti, importAgentDriver, installJdbcPluginLocal } from "@/lib/backend/http";
+import { getDebugLogText } from "@/lib/backend/debugLog";
+
+class MemoryStorage implements Storage {
+  private data = new Map<string, string>();
+
+  get length() {
+    return this.data.size;
+  }
+
+  clear() {
+    this.data.clear();
+  }
+
+  getItem(key: string) {
+    return this.data.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.data.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.data.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.data.set(key, value);
+  }
+}
 import { BackendErrorException } from "@/lib/backend/errorUtils";
 
 const envelope = {
@@ -66,6 +95,63 @@ describe("HTTP backend error parsing", () => {
     expect(error).toMatchObject({
       backendError: expect.objectContaining({ code: envelope.code, detail: envelope.detail }),
     });
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("HTTP query transport diagnostics", () => {
+  test("records timing and payload sizes without logging query contents", async () => {
+    vi.stubGlobal("localStorage", new MemoryStorage());
+    const sql = "SELECT 'private-query-marker'";
+    localStorage.setItem("dbx-debug-logging-enabled", "1");
+    localStorage.removeItem("dbx-debug-log-entries");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify([{ columns: ["value"], rows: [["private-cell-marker"]] }]), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-dbx-core-ms": "41",
+            "x-dbx-serialize-ms": "7",
+          },
+        }),
+      ),
+    );
+
+    await executeMulti("private-connection-marker", "private-database-marker", sql, undefined, "trace-12345678");
+
+    const logs = getDebugLogText();
+    expect(logs).toContain("[DBX][query-transport:http]");
+    expect(logs).toContain('"backendCoreMs":"41"');
+    expect(logs).toContain('"backendSerializeMs":"7"');
+    expect(logs).toContain('"requestBytes":');
+    expect(logs).toContain('"responseBytes":');
+    expect(logs).toContain('"jsonParseMs":');
+    expect(logs).not.toContain("private-query-marker");
+    expect(logs).not.toContain("private-cell-marker");
+    expect(logs).not.toContain("private-connection-marker");
+    expect(logs).not.toContain("private-database-marker");
+
+    vi.unstubAllGlobals();
+  });
+
+  test("preserves structured backend errors while logging only safe failure metadata", async () => {
+    vi.stubGlobal("localStorage", new MemoryStorage());
+    localStorage.setItem("dbx-debug-logging-enabled", "1");
+    localStorage.removeItem("dbx-debug-log-entries");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(envelope), { status: 400 })));
+
+    const error = await executeMulti("connection-1", "database-1", "SELECT 'failed-query-marker'", undefined, "trace-87654321").catch((value: unknown) => value);
+
+    expect(error).toBeInstanceOf(BackendErrorException);
+    expect(error).toMatchObject({ backendError: expect.objectContaining({ code: envelope.code }) });
+    const logs = getDebugLogText();
+    expect(logs).toContain("[DBX][query-transport:http:error]");
+    expect(logs).toContain('"status":400');
+    expect(logs).not.toContain("failed-query-marker");
+    expect(logs).not.toContain(envelope.detail);
 
     vi.unstubAllGlobals();
   });

--- a/apps/desktop/src/lib/backend/http.ts
+++ b/apps/desktop/src/lib/backend/http.ts
@@ -203,6 +203,7 @@ import type {
   NacosSearchProgress,
 } from "@/types/nacos";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
+import { appendDebugLog, isDebugLoggingEnabled } from "@/lib/backend/debugLog";
 import { normalizeConnectionTestResult } from "@/lib/connection/connectionDatabaseInfo";
 import type { AnnotationFile, SchemaSnapshot } from "@/docs/types";
 
@@ -234,6 +235,55 @@ async function post<T>(url: string, body: unknown): Promise<T> {
   });
   if (!res.ok) throw await backendResponseError(res);
   return res.json();
+}
+
+async function postQueryWithDiagnostics<T>(url: string, body: unknown, traceId?: string): Promise<T> {
+  if (!isDebugLoggingEnabled()) return post(url, body);
+
+  const startedAt = performance.now();
+  const serializedBody = JSON.stringify(body);
+  const response = await fetch(apiUrl(url), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: serializedBody,
+  });
+  const headersAt = performance.now();
+  const responseText = await response.text();
+  const bodyAt = performance.now();
+  if (!response.ok) {
+    appendDebugLog("warn", "[DBX][query-transport:http:error]", {
+      traceId: traceId?.slice(0, 8),
+      status: response.status,
+      requestBytes: new TextEncoder().encode(serializedBody).byteLength,
+      responseBytes: new TextEncoder().encode(responseText).byteLength,
+      responseHeadersMs: Math.round(headersAt - startedAt),
+      responseBodyMs: Math.round(bodyAt - headersAt),
+      totalMs: Math.round(bodyAt - startedAt),
+      backendCoreMs: response.headers.get("x-dbx-core-ms"),
+      backendSerializeMs: response.headers.get("x-dbx-serialize-ms"),
+    });
+    throw await backendResponseError(
+      new Response(responseText, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      }),
+    );
+  }
+  const result = JSON.parse(responseText) as T;
+  const parsedAt = performance.now();
+  appendDebugLog("info", "[DBX][query-transport:http]", {
+    traceId: traceId?.slice(0, 8),
+    requestBytes: new TextEncoder().encode(serializedBody).byteLength,
+    responseBytes: new TextEncoder().encode(responseText).byteLength,
+    responseHeadersMs: Math.round(headersAt - startedAt),
+    responseBodyMs: Math.round(bodyAt - headersAt),
+    jsonParseMs: Math.round(parsedAt - bodyAt),
+    totalMs: Math.round(parsedAt - startedAt),
+    backendCoreMs: response.headers.get("x-dbx-core-ms"),
+    backendSerializeMs: response.headers.get("x-dbx-serialize-ms"),
+  });
+  return result;
 }
 
 async function get<T>(url: string): Promise<T> {
@@ -940,14 +990,18 @@ export async function executeMulti(
     executionMode?: "simple";
   },
 ): Promise<QueryResult[]> {
-  return post("/api/query/execute-multi", {
-    connectionId,
-    database,
-    sql,
-    schema,
+  return postQueryWithDiagnostics(
+    "/api/query/execute-multi",
+    {
+      connectionId,
+      database,
+      sql,
+      schema,
+      executionId,
+      ...options,
+    },
     executionId,
-    ...options,
-  });
+  );
 }
 
 export interface ExecuteMultiProgress {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -3,6 +3,7 @@ import { BackendErrorException, type BackendError } from "@/lib/backend/errorUti
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { normalizeRustMongoCommand, type MongoCommand } from "@/lib/mongo/mongoShellCommand";
 import { ExternalSqlFileTooLargeError } from "@/lib/sql/sqlFileOpen";
+import { appendDebugLog, isDebugLoggingEnabled } from "@/lib/backend/debugLog";
 
 /** Normalize Tauri rejections once at the public backend boundary. */
 async function invokeBackend<T>(command: string, args?: Record<string, unknown>): Promise<T> {
@@ -1159,8 +1160,10 @@ export async function executeMulti(
     executionMode?: "simple";
   },
 ): Promise<QueryResult[]> {
+  const diagnosticsEnabled = isDebugLoggingEnabled();
+  const startedAt = diagnosticsEnabled ? performance.now() : 0;
   try {
-    return await invoke("execute_multi", {
+    const results = await invoke<QueryResult[]>("execute_multi", {
       connectionId,
       database,
       sql,
@@ -1168,7 +1171,23 @@ export async function executeMulti(
       executionId,
       ...options,
     });
+    if (diagnosticsEnabled) {
+      appendDebugLog("info", "[DBX][query-transport:tauri]", {
+        traceId: executionId?.slice(0, 8),
+        totalMs: Math.round(performance.now() - startedAt),
+        resultCount: results.length,
+        rowCounts: results.map((result) => result.rows.length),
+        columnCounts: results.map((result) => result.columns.length),
+      });
+    }
+    return results;
   } catch (error) {
+    if (diagnosticsEnabled) {
+      appendDebugLog("warn", "[DBX][query-transport:tauri:error]", {
+        traceId: executionId?.slice(0, 8),
+        totalMs: Math.round(performance.now() - startedAt),
+      });
+    }
     throw new BackendErrorException(error);
   }
 }

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -4127,9 +4127,13 @@ async fn execute_result_set_with_text_protocol_on_conn(
     max_rows: Option<usize>,
     max_result_bytes: Option<usize>,
     result_key_columns: &[String],
+    diagnostic_trace_id: Option<&str>,
     start: Instant,
 ) -> Result<MySqlQueryResult, String> {
+    let diagnostics_enabled = diagnostic_trace_id.is_some() && log::log_enabled!(log::Level::Info);
+    let dispatch_started_at = diagnostics_enabled.then(Instant::now);
     let mut result = conn.query_iter(sql).await.map_err(|e| e.to_string())?;
+    let dispatch_ms = dispatch_started_at.map_or(0, |started_at| started_at.elapsed().as_millis());
     if !advance_to_result_set_with_columns(&mut result).await? {
         let affected_rows = result.affected_rows();
         let warnings = result.warnings();
@@ -4199,19 +4203,28 @@ async fn execute_result_set_with_text_protocol_on_conn(
     let mut spatial_values: Vec<Vec<Option<u32>>> = Vec::new();
     let mut large_value_cells = Vec::new();
     let mut truncated = false;
+    let mut row_read_time = Duration::ZERO;
+    let mut row_convert_time = Duration::ZERO;
     let mut stream = result
         .stream::<mysql_async::Row>()
         .await
         .map_err(|e| e.to_string())?
         .ok_or_else(|| "Empty result set stream".to_string())?;
 
-    while let Some(row) = stream.next().await {
+    loop {
+        let read_started_at = diagnostics_enabled.then(Instant::now);
+        let next_row = stream.next().await;
+        if let Some(started_at) = read_started_at {
+            row_read_time += started_at.elapsed();
+        }
+        let Some(row) = next_row else { break };
         let row = row.map_err(|e| e.to_string())?;
         if result_rows.len() >= row_limit {
             truncated = true;
             break;
         }
         let row_index = result_rows.len();
+        let convert_started_at = diagnostics_enabled.then(Instant::now);
         let (values, srids, mut row_large_values) = mysql_row_to_json_with_srids_and_previews(
             &row,
             &mut spatial_columns,
@@ -4222,6 +4235,9 @@ async fn execute_result_set_with_text_protocol_on_conn(
         result_rows.push(values);
         spatial_values.push(srids);
         large_value_cells.append(&mut row_large_values);
+        if let Some(started_at) = convert_started_at {
+            row_convert_time += started_at.elapsed();
+        }
     }
     drop(stream);
 
@@ -4229,6 +4245,7 @@ async fn execute_result_set_with_text_protocol_on_conn(
     // terminator packet arrived, so `result.warnings()`/`result.info()` still
     // hold the previous statement's values; skip capture instead of reporting
     // stale messages.
+    let finalize_started_at = diagnostics_enabled.then(Instant::now);
     let messages = if truncated {
         drop(result);
         Vec::new()
@@ -4238,6 +4255,20 @@ async fn execute_result_set_with_text_protocol_on_conn(
         drop(result);
         collect_mysql_server_messages(conn, warnings, &info).await
     };
+    if diagnostics_enabled {
+        log::info!(
+            "[query][mysql-result] trace_id={} protocol=text dispatch_ms={} row_read_ms={} row_convert_ms={} finalize_ms={} rows={} columns={} truncated={} preview_cells={}",
+            diagnostic_trace_id.unwrap_or("none"),
+            dispatch_ms,
+            row_read_time.as_millis(),
+            row_convert_time.as_millis(),
+            finalize_started_at.map_or(0, |started_at| started_at.elapsed().as_millis()),
+            result_rows.len(),
+            columns.len(),
+            truncated,
+            large_value_cells.len()
+        );
+    }
 
     Ok(MySqlQueryResult {
         result: QueryResult {
@@ -4266,6 +4297,7 @@ async fn execute_result_sets_with_text_protocol_on_conn(
     max_rows: Option<usize>,
     max_result_bytes: Option<usize>,
     result_key_columns: &[String],
+    diagnostic_trace_id: Option<&str>,
     start: Instant,
 ) -> Result<Vec<MySqlQueryResult>, String> {
     // Per-set warnings/info read after each `collect()` are only accurate when
@@ -4279,9 +4311,14 @@ async fn execute_result_sets_with_text_protocol_on_conn(
     // per-set messages stay empty and only the final SHOW WARNINGS attachment
     // on the last result set reports warnings.
     let capture_per_set_messages = conn.opts().deprecate_eof();
+    let diagnostics_enabled = diagnostic_trace_id.is_some() && log::log_enabled!(log::Level::Info);
+    let dispatch_started_at = diagnostics_enabled.then(Instant::now);
     let mut result = conn.query_iter(sql).await.map_err(|e| e.to_string())?;
+    let dispatch_ms = dispatch_started_at.map_or(0, |started_at| started_at.elapsed().as_millis());
     let mut results: Vec<MySqlQueryResult> = Vec::new();
     let mut result_set_warnings: Vec<u16> = Vec::new();
+    let mut row_read_time = Duration::ZERO;
+    let mut row_convert_time = Duration::ZERO;
 
     while advance_to_result_set_with_columns(&mut result).await? {
         let columns: Vec<String> = result.columns_ref().iter().map(|c| c.name_str().to_string()).collect();
@@ -4295,16 +4332,26 @@ async fn execute_result_sets_with_text_protocol_on_conn(
         let protected_indexes = mysql_result_protected_column_indexes(result.columns_ref(), result_key_columns);
 
         let rows = if max_result_bytes.is_none() && should_collect_text_result_set(sql, row_limit, max_rows) {
+            let read_started_at = diagnostics_enabled.then(Instant::now);
             let rows: Vec<mysql_async::Row> = result.collect().await.map_err(|e| e.to_string())?;
+            if let Some(started_at) = read_started_at {
+                row_read_time += started_at.elapsed();
+            }
             truncated = rows.len() > row_limit;
-            rows.iter()
+            let convert_started_at = diagnostics_enabled.then(Instant::now);
+            let converted_rows = rows
+                .iter()
                 .take(row_limit)
                 .map(|row| {
                     let (values, srids) = mysql_row_to_json_with_srids(row, &mut spatial_columns);
                     spatial_values.push(srids);
                     values
                 })
-                .collect()
+                .collect::<Vec<_>>();
+            if let Some(started_at) = convert_started_at {
+                row_convert_time += started_at.elapsed();
+            }
+            converted_rows
         } else {
             let mut rows = Vec::new();
             let mut stream = result
@@ -4313,10 +4360,17 @@ async fn execute_result_sets_with_text_protocol_on_conn(
                 .map_err(|e| e.to_string())?
                 .ok_or_else(|| "Empty result set stream".to_string())?;
 
-            while let Some(row) = stream.next().await {
+            loop {
+                let read_started_at = diagnostics_enabled.then(Instant::now);
+                let next_row = stream.next().await;
+                if let Some(started_at) = read_started_at {
+                    row_read_time += started_at.elapsed();
+                }
+                let Some(row) = next_row else { break };
                 let row = row.map_err(|e| e.to_string())?;
                 if rows.len() < row_limit {
                     let row_index = rows.len();
+                    let convert_started_at = diagnostics_enabled.then(Instant::now);
                     let (values, srids, mut row_large_values) = mysql_row_to_json_with_srids_and_previews(
                         &row,
                         &mut spatial_columns,
@@ -4327,6 +4381,9 @@ async fn execute_result_sets_with_text_protocol_on_conn(
                     rows.push(values);
                     spatial_values.push(srids);
                     large_value_cells.append(&mut row_large_values);
+                    if let Some(started_at) = convert_started_at {
+                        row_convert_time += started_at.elapsed();
+                    }
                 } else {
                     truncated = true;
                 }
@@ -4362,6 +4419,7 @@ async fn execute_result_sets_with_text_protocol_on_conn(
     }
 
     if results.is_empty() {
+        let finalize_started_at = diagnostics_enabled.then(Instant::now);
         let affected_rows = result.affected_rows();
         let warnings = result.warnings();
         let info = result.info().into_owned();
@@ -4382,6 +4440,16 @@ async fn execute_result_sets_with_text_protocol_on_conn(
             elasticsearch_raw_body: None,
             messages,
         }));
+        if diagnostics_enabled {
+            log::info!(
+                "[query][mysql-result] trace_id={} protocol=text-multi dispatch_ms={} row_read_ms={} row_convert_ms={} finalize_ms={} result_count=1 row_counts=[0] column_counts=[0] truncated_sets=0 preview_cells=0",
+                diagnostic_trace_id.unwrap_or("none"),
+                dispatch_ms,
+                row_read_time.as_millis(),
+                row_convert_time.as_millis(),
+                finalize_started_at.map_or(0, |started_at| started_at.elapsed().as_millis())
+            );
+        }
         return Ok(results);
     }
     // Without per-set capture (no CLIENT_DEPRECATE_EOF) the per-iteration
@@ -4392,6 +4460,7 @@ async fn execute_result_sets_with_text_protocol_on_conn(
         let last_index = result_set_warnings.len() - 1;
         result_set_warnings[last_index] = result.warnings();
     }
+    let finalize_started_at = diagnostics_enabled.then(Instant::now);
     drop(result);
 
     // SHOW WARNINGS only reports the last executed statement, so detailed
@@ -4408,6 +4477,22 @@ async fn execute_result_sets_with_text_protocol_on_conn(
         } else {
             results[index].result.messages.push(mysql_warnings_fallback_message(warnings));
         }
+    }
+
+    if diagnostics_enabled {
+        log::info!(
+            "[query][mysql-result] trace_id={} protocol=text-multi dispatch_ms={} row_read_ms={} row_convert_ms={} finalize_ms={} result_count={} row_counts={:?} column_counts={:?} truncated_sets={} preview_cells={}",
+            diagnostic_trace_id.unwrap_or("none"),
+            dispatch_ms,
+            row_read_time.as_millis(),
+            row_convert_time.as_millis(),
+            finalize_started_at.map_or(0, |started_at| started_at.elapsed().as_millis()),
+            results.len(),
+            results.iter().map(|result| result.result.rows.len()).collect::<Vec<_>>(),
+            results.iter().map(|result| result.result.columns.len()).collect::<Vec<_>>(),
+            results.iter().filter(|result| result.result.truncated).count(),
+            results.iter().map(|result| result.large_value_cells.len()).sum::<usize>()
+        );
     }
 
     Ok(results)
@@ -4431,9 +4516,13 @@ async fn execute_result_set_with_prepared_protocol_on_conn(
     row_limit: usize,
     max_result_bytes: Option<usize>,
     result_key_columns: &[String],
+    diagnostic_trace_id: Option<&str>,
     start: Instant,
 ) -> Result<MySqlQueryResult, String> {
+    let diagnostics_enabled = diagnostic_trace_id.is_some() && log::log_enabled!(log::Level::Info);
+    let dispatch_started_at = diagnostics_enabled.then(Instant::now);
     let mut result = conn.exec_iter(sql, ()).await.map_err(|e| e.to_string())?;
+    let dispatch_ms = dispatch_started_at.map_or(0, |started_at| started_at.elapsed().as_millis());
     let columns: Vec<String> = result.columns_ref().iter().map(|c| c.name_str().to_string()).collect();
     let column_types: Vec<String> = result.columns_ref().iter().map(mysql_column_type_name).collect();
     let mut spatial_columns = mysql_spatial_column_builder(result.columns_ref());
@@ -4445,19 +4534,28 @@ async fn execute_result_set_with_prepared_protocol_on_conn(
     let mut spatial_values: Vec<Vec<Option<u32>>> = Vec::new();
     let mut large_value_cells = Vec::new();
     let mut truncated = false;
+    let mut row_read_time = Duration::ZERO;
+    let mut row_convert_time = Duration::ZERO;
     let mut stream = result
         .stream::<mysql_async::Row>()
         .await
         .map_err(|e| e.to_string())?
         .ok_or_else(|| "Empty result set stream".to_string())?;
 
-    while let Some(row) = stream.next().await {
+    loop {
+        let read_started_at = diagnostics_enabled.then(Instant::now);
+        let next_row = stream.next().await;
+        if let Some(started_at) = read_started_at {
+            row_read_time += started_at.elapsed();
+        }
+        let Some(row) = next_row else { break };
         let row = row.map_err(|e| e.to_string())?;
         if result_rows.len() >= row_limit {
             truncated = true;
             break;
         }
         let row_index = result_rows.len();
+        let convert_started_at = diagnostics_enabled.then(Instant::now);
         let (values, srids, mut row_large_values) = mysql_row_to_json_with_srids_and_previews(
             &row,
             &mut spatial_columns,
@@ -4468,6 +4566,9 @@ async fn execute_result_set_with_prepared_protocol_on_conn(
         result_rows.push(values);
         spatial_values.push(srids);
         large_value_cells.append(&mut row_large_values);
+        if let Some(started_at) = convert_started_at {
+            row_convert_time += started_at.elapsed();
+        }
     }
     drop(stream);
 
@@ -4475,6 +4576,7 @@ async fn execute_result_set_with_prepared_protocol_on_conn(
     // terminator packet arrived, so `result.warnings()`/`result.info()` still
     // hold the previous statement's values; skip capture instead of reporting
     // stale messages.
+    let finalize_started_at = diagnostics_enabled.then(Instant::now);
     let messages = if truncated {
         drop(result);
         Vec::new()
@@ -4484,6 +4586,20 @@ async fn execute_result_set_with_prepared_protocol_on_conn(
         drop(result);
         collect_mysql_server_messages(conn, warnings, &info).await
     };
+    if diagnostics_enabled {
+        log::info!(
+            "[query][mysql-result] trace_id={} protocol=prepared dispatch_ms={} row_read_ms={} row_convert_ms={} finalize_ms={} rows={} columns={} truncated={} preview_cells={}",
+            diagnostic_trace_id.unwrap_or("none"),
+            dispatch_ms,
+            row_read_time.as_millis(),
+            row_convert_time.as_millis(),
+            finalize_started_at.map_or(0, |started_at| started_at.elapsed().as_millis()),
+            result_rows.len(),
+            columns.len(),
+            truncated,
+            large_value_cells.len()
+        );
+    }
 
     Ok(MySqlQueryResult {
         result: QueryResult {
@@ -4732,7 +4848,9 @@ pub async fn execute_query_on_conn_with_max_rows(
     max_rows: Option<usize>,
     dialect: MySqlQueryDialect,
 ) -> Result<QueryResult, String> {
-    execute_query_on_conn_with_limits(conn, sql, bare, max_rows, None, &[], dialect).await.map(|result| result.result)
+    execute_query_on_conn_with_limits(conn, sql, bare, max_rows, None, &[], dialect, None)
+        .await
+        .map(|result| result.result)
 }
 
 pub async fn execute_query_on_conn_with_limits(
@@ -4743,6 +4861,7 @@ pub async fn execute_query_on_conn_with_limits(
     max_result_bytes: Option<usize>,
     result_key_columns: &[String],
     dialect: MySqlQueryDialect,
+    diagnostic_trace_id: Option<&str>,
 ) -> Result<MySqlQueryResult, String> {
     let start = Instant::now();
     let row_limit = query_result_row_limit(max_rows);
@@ -4756,6 +4875,7 @@ pub async fn execute_query_on_conn_with_limits(
                 max_rows,
                 max_result_bytes,
                 result_key_columns,
+                diagnostic_trace_id,
                 start,
             )
             .await
@@ -4766,6 +4886,7 @@ pub async fn execute_query_on_conn_with_limits(
                 row_limit,
                 max_result_bytes,
                 result_key_columns,
+                diagnostic_trace_id,
                 start,
             )
             .await
@@ -4779,6 +4900,7 @@ pub async fn execute_query_on_conn_with_limits(
                         max_rows,
                         max_result_bytes,
                         result_key_columns,
+                        diagnostic_trace_id,
                         start,
                     )
                     .await
@@ -4831,7 +4953,7 @@ pub async fn execute_query_results_on_conn_with_max_rows(
     max_rows: Option<usize>,
     dialect: MySqlQueryDialect,
 ) -> Result<Vec<QueryResult>, String> {
-    execute_query_results_on_conn_with_limits(conn, sql, bare, max_rows, None, &[], dialect)
+    execute_query_results_on_conn_with_limits(conn, sql, bare, max_rows, None, &[], dialect, None)
         .await
         .map(|results| results.into_iter().map(|result| result.result).collect())
 }
@@ -4844,6 +4966,7 @@ pub async fn execute_query_results_on_conn_with_limits(
     max_result_bytes: Option<usize>,
     result_key_columns: &[String],
     dialect: MySqlQueryDialect,
+    diagnostic_trace_id: Option<&str>,
 ) -> Result<Vec<MySqlQueryResult>, String> {
     if is_result_set_query(sql, dialect) && (bare || prefers_text_protocol_query(sql, dialect)) {
         let start = Instant::now();
@@ -4854,13 +4977,23 @@ pub async fn execute_query_results_on_conn_with_limits(
             max_rows,
             max_result_bytes,
             result_key_columns,
+            diagnostic_trace_id,
             start,
         )
         .await
     } else {
-        execute_query_on_conn_with_limits(conn, sql, bare, max_rows, max_result_bytes, result_key_columns, dialect)
-            .await
-            .map(|result| vec![result])
+        execute_query_on_conn_with_limits(
+            conn,
+            sql,
+            bare,
+            max_rows,
+            max_result_bytes,
+            result_key_columns,
+            dialect,
+            diagnostic_trace_id,
+        )
+        .await
+        .map(|result| vec![result])
     }
 }
 

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -6,7 +6,7 @@ use sqlparser::ast::{
 };
 use sqlparser::dialect::{GenericDialect, PostgreSqlDialect};
 use sqlparser::parser::Parser;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::sync::{
@@ -527,13 +527,23 @@ fn merge_large_value_cells(
     mut driver_cells: Vec<db::LargeValueCell>,
     server_cells: Vec<db::LargeValueCell>,
 ) -> Vec<db::LargeValueCell> {
+    if driver_cells.is_empty() {
+        return server_cells;
+    }
+    if server_cells.is_empty() {
+        return driver_cells;
+    }
+    let mut driver_indexes = driver_cells
+        .iter()
+        .enumerate()
+        .map(|(index, cell)| ((cell.row_index, cell.column_index), index))
+        .collect::<HashMap<_, _>>();
     for server_cell in server_cells {
-        if let Some(driver_cell) = driver_cells
-            .iter_mut()
-            .find(|cell| cell.row_index == server_cell.row_index && cell.column_index == server_cell.column_index)
-        {
-            *driver_cell = server_cell;
+        let key = (server_cell.row_index, server_cell.column_index);
+        if let Some(index) = driver_indexes.get(&key).copied() {
+            driver_cells[index] = server_cell;
         } else {
+            driver_indexes.insert(key, driver_cells.len());
             driver_cells.push(server_cell);
         }
     }
@@ -6085,6 +6095,53 @@ for line in sys.stdin:
             serialized.get("large_value_cells"),
             Some(&serde_json::json!([{"row_index": 2, "column_index": 3, "original_bytes": 65_536}]))
         );
+    }
+
+    #[test]
+    fn large_value_cell_merge_replaces_driver_entries_and_appends_server_entries() {
+        let driver_cells = vec![
+            db::LargeValueCell { row_index: 1, column_index: 2, original_bytes: 10 },
+            db::LargeValueCell { row_index: 3, column_index: 4, original_bytes: 20 },
+        ];
+        let server_cells = vec![
+            db::LargeValueCell { row_index: 1, column_index: 2, original_bytes: 100 },
+            db::LargeValueCell { row_index: 5, column_index: 6, original_bytes: 200 },
+        ];
+
+        assert_eq!(
+            merge_large_value_cells(driver_cells, server_cells),
+            vec![
+                db::LargeValueCell { row_index: 1, column_index: 2, original_bytes: 100 },
+                db::LargeValueCell { row_index: 3, column_index: 4, original_bytes: 20 },
+                db::LargeValueCell { row_index: 5, column_index: 6, original_bytes: 200 },
+            ]
+        );
+    }
+
+    #[test]
+    fn large_value_cell_merge_preserves_single_source_inputs() {
+        let driver_cell = db::LargeValueCell { row_index: 1, column_index: 2, original_bytes: 10 };
+        let server_cell = db::LargeValueCell { row_index: 3, column_index: 4, original_bytes: 20 };
+
+        assert_eq!(merge_large_value_cells(vec![driver_cell.clone()], Vec::new()), vec![driver_cell]);
+        assert_eq!(merge_large_value_cells(Vec::new(), vec![server_cell.clone()]), vec![server_cell]);
+    }
+
+    #[test]
+    fn large_value_cell_merge_handles_large_disjoint_inputs() {
+        const CELL_COUNT: usize = 100_000;
+        let driver_cells = (0..CELL_COUNT)
+            .map(|row_index| db::LargeValueCell { row_index, column_index: 0, original_bytes: 10 })
+            .collect();
+        let server_cells = (0..CELL_COUNT)
+            .map(|row_index| db::LargeValueCell { row_index, column_index: 1, original_bytes: 20 })
+            .collect();
+
+        let merged = merge_large_value_cells(driver_cells, server_cells);
+
+        assert_eq!(merged.len(), CELL_COUNT * 2);
+        assert_eq!(merged[CELL_COUNT].row_index, 0);
+        assert_eq!(merged[CELL_COUNT * 2 - 1].row_index, CELL_COUNT - 1);
     }
 
     #[test]

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -1685,6 +1685,7 @@ async fn do_execute_typed(
                     max_result_bytes,
                     &options.result_key_columns,
                     mysql_dialect,
+                    options.execution_id.as_deref(),
                 ),
             )
             .await
@@ -2732,6 +2733,7 @@ struct MysqlBatchConnection<'a> {
     result_key_columns: &'a [String],
     table_data_preview: bool,
     dialect: db::mysql::MySqlQueryDialect,
+    diagnostic_trace_id: Option<&'a str>,
 }
 
 impl MysqlBatchStatementExecutor for MysqlBatchConnection<'_> {
@@ -2751,6 +2753,7 @@ impl MysqlBatchStatementExecutor for MysqlBatchConnection<'_> {
                 self.max_result_bytes,
                 self.result_key_columns,
                 self.dialect,
+                self.diagnostic_trace_id,
             ),
         )
         .await
@@ -2948,6 +2951,8 @@ async fn execute_multi_mysql(
     options: QueryExecutionOptions,
     progress: Option<&ExecuteMultiProgressCallback>,
 ) -> Result<Vec<ExecuteMultiResult>, String> {
+    let trace_id = options.execution_id.as_deref().unwrap_or("none");
+    let total_started_at = std::time::Instant::now();
     let query_timeout = resolve_query_timeout(options.timeout_secs);
     let operation_budget = operation_budget_for_pool_key(state, pool_key, query_timeout).await;
     let bare = mode == crate::connection::MysqlMode::Bare;
@@ -2955,6 +2960,7 @@ async fn execute_multi_mysql(
     let max_result_bytes = options.max_result_bytes.filter(|value| *value > 0);
     let pipeline_non_result_statements =
         mysql_non_result_pipeline_enabled(statements.len(), options.continue_on_error, mode);
+    let checkout_started_at = std::time::Instant::now();
     let mut conn = match db::mysql::get_conn_with_health_check_with_cancel(
         pool,
         operation_budget.checkout_timeout,
@@ -2973,13 +2979,16 @@ async fn execute_multi_mysql(
             return Ok(vec![ExecuteMultiResult::execution_error(error_query_result(err))]);
         }
     };
+    let checkout_ms = checkout_started_at.elapsed().as_millis();
     apply_oceanbase_mysql_session_timeout(state, pool_key, &mut conn, options.timeout_secs).await?;
+    let catalog_started_at = std::time::Instant::now();
     wait_for_result_opt(
         cancel_token.clone(),
         query_timeout,
         db::mysql::apply_catalog_database_context(&mut conn, catalog_dialect, options.catalog.as_deref(), database),
     )
     .await?;
+    let catalog_ms = catalog_started_at.elapsed().as_millis();
     let pipeline_non_result_max_bytes = if pipeline_non_result_statements {
         db::mysql::max_allowed_packet_on_conn(&mut conn)
             .await
@@ -3000,7 +3009,9 @@ async fn execute_multi_mysql(
         result_key_columns: &options.result_key_columns,
         table_data_preview: options.table_data_preview,
         dialect,
+        diagnostic_trace_id: options.execution_id.as_deref(),
     };
+    let statements_started_at = std::time::Instant::now();
     let (results, error_action) = execute_mysql_batch_statements(
         &mut executor,
         statements,
@@ -3012,7 +3023,19 @@ async fn execute_multi_mysql(
         progress,
     )
     .await;
+    let statements_ms = statements_started_at.elapsed().as_millis();
     drop(executor);
+
+    log::info!(
+        "[query][mysql-batch] trace_id={} checkout_ms={} catalog_ms={} statements_ms={} total_ms={} result_count={} row_counts={:?}",
+        trace_id,
+        checkout_ms,
+        catalog_ms,
+        statements_ms,
+        total_started_at.elapsed().as_millis(),
+        results.len(),
+        results.iter().map(|result| result.result.rows.len()).collect::<Vec<_>>()
+    );
 
     if matches!(error_action, Some(PoolErrorAction::Discard | PoolErrorAction::ReconnectAndRetry)) {
         state.remove_pool_by_key(pool_key).await;

--- a/crates/dbx-web/src/routes/query.rs
+++ b/crates/dbx-web/src/routes/query.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::HeaderMap;
+use axum::http::{header, HeaderMap, HeaderValue};
+use axum::response::Response;
 use axum::Json;
 use serde::Deserialize;
 
@@ -389,7 +390,7 @@ pub async fn execute_multi(
     State(state): State<Arc<WebState>>,
     headers: HeaderMap,
     Json(req): Json<ExecuteQueryRequest>,
-) -> Result<Json<Vec<dbx_core::query::ExecuteMultiResult>>, AppError> {
+) -> Result<Response, AppError> {
     let allow_database_switch = req.client_session_id.as_deref().is_some_and(|id| !id.trim().is_empty());
     super::mcp_policy::ensure_sql(&state, &headers, &req.connection_id, &req.database, &req.sql, allow_database_switch)
         .await?;
@@ -403,6 +404,7 @@ pub async fn execute_multi(
 
     tracing::debug!(connection_id = %req.connection_id, "execute_multi");
 
+    let core_started_at = std::time::Instant::now();
     let result = dbx_core::query::execute_multi_core_with_options_for_client_typed(
         &state.app,
         &req.connection_id,
@@ -430,15 +432,30 @@ pub async fn execute_multi(
     )
     .await
     .map_err(|error| AppError::from(error.into_backend_error()))?;
+    let core_ms = core_started_at.elapsed().as_millis();
 
     drop(registered);
-    Ok(execute_multi_response(result))
+    execute_multi_response(result, core_ms)
 }
 
 fn execute_multi_response(
     result: Vec<dbx_core::query::ExecuteMultiResult>,
-) -> Json<Vec<dbx_core::query::ExecuteMultiResult>> {
-    Json(result)
+    core_ms: u128,
+) -> Result<Response, AppError> {
+    let serialize_started_at = std::time::Instant::now();
+    let body = serde_json::to_vec(&result).map_err(|error| AppError::internal(error.to_string()))?;
+    let serialize_ms = serialize_started_at.elapsed().as_millis();
+    let mut response = Response::new(axum::body::Body::from(body));
+    response.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    response.headers_mut().insert(
+        "x-dbx-core-ms",
+        HeaderValue::from_str(&core_ms.to_string()).map_err(|error| AppError::internal(error.to_string()))?,
+    );
+    response.headers_mut().insert(
+        "x-dbx-serialize-ms",
+        HeaderValue::from_str(&serialize_ms.to_string()).map_err(|error| AppError::internal(error.to_string()))?,
+    );
+    Ok(response)
 }
 
 pub async fn execute_batch(
@@ -1054,8 +1071,8 @@ mod tests {
         assert_eq!(log.metadata["blocked"], "destructive_confirmation_required");
     }
 
-    #[test]
-    fn execute_multi_response_preserves_nested_original_error_detail() {
+    #[tokio::test]
+    async fn execute_multi_response_preserves_nested_original_error_detail() {
         let result = dbx_core::query::ExecuteMultiResult {
             result: dbx_core::db::QueryResult {
                 columns: vec!["Error".to_string()],
@@ -1081,7 +1098,14 @@ mod tests {
             server_message: false,
         };
 
-        let payload = serde_json::to_value(execute_multi_response(vec![result]).0).unwrap();
+        let response = execute_multi_response(vec![result], 17).unwrap();
+        assert_eq!(response.headers()["x-dbx-core-ms"], "17");
+        assert!(response.headers()["x-dbx-serialize-ms"].to_str().unwrap().parse::<u128>().is_ok());
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+        let body = response.into_body();
+        let payload =
+            serde_json::from_slice::<serde_json::Value>(&axum::body::to_bytes(body, usize::MAX).await.unwrap())
+                .unwrap();
 
         assert_eq!(payload[0]["statement_index"], 1);
         assert_eq!(payload[0]["error"]["code"], "DBX-JDBC-4001");


### PR DESCRIPTION
## 背景

PR #6048 已降低大字段表格首屏传输量和内存占用，但用户反馈打开约 3GB、66 万行的 MySQL 长文本表仍需十几秒。

本 PR 先补充端到端性能诊断日志，并按用户表结构在 MySQL 8.4 测试库生成 66 万行、3.52GB 的长文本表。将“打开表默认每页行数”设为 100000 后可稳定复现：数据库已完成取数，但 DBX 服务端仍长时间高 CPU，核心请求耗时达到 575 秒。

定位原因是驱动预览标记与服务端大值标记逐项线性查找合并，10 万行产生大量标记后退化为 O(n²)。

## 改动

- 将大值元数据合并改为基于 `(row_index, column_index)` 的线性索引：
  - 已有位置保持服务端标记覆盖驱动标记的原语义
  - 新位置保持追加顺序
  - 任一来源为空时直接返回，避免为 50 万条服务端标记建立无用索引
- 增加 10 万 + 10 万标记的大批量回归测试，以及覆盖替换、追加、单来源快速路径的语义测试
- 为 MySQL 查询增加同一执行追踪 ID 下的阶段耗时：
  - 连接池获取与健康检查
  - catalog/database 上下文切换
  - SQL 派发
  - 网络读取结果行
  - Rust 行值转换
  - 结果收尾与 warnings
  - 总耗时、结果集/行/列数量、截断与大字段预览数量
- Web 查询响应增加核心执行和 JSON 序列化耗时响应头
- HTTP/Tauri 前端补充传输、JSON 解析、invoke 和结果规模耗时日志
- 调试日志关闭时跳过新增的逐行细粒度计时，避免影响正常查询性能
- 保留原有结构化后端错误解析

## 实测

环境：MySQL 8.4.6，远程测试库；表结构与用户提供结构一致。

测试表：

- 精确行数：660000
- 平均 `remark`：4113 字节
- `data_length + index_length`：3.52GB
- 请求：表数据预览，100000 行，32MiB 大值预算，保留主键，最终响应约 50MB、50 万条大值元数据

结果：

| 阶段 | 修复前 | 修复后 |
| --- | ---: | ---: |
| DBX 核心耗时 | 575.2s | 4.50s |
| JSON 序列化 | 未完成返回 | 1.52s |
| 完整 HTTP 返回 | 超过 9 分钟 | 6.10s |

核心耗时降低约 99.2%（约 128 倍）。修复前后完整响应去除波动的 `execution_time_ms` 后 SHA-256 相同，确认列、行值和大值元数据语义一致。

测试表 `dbx_test.dbx_perf_large_text_660k` 已保留，后续可继续做大表回归。

## 验证

- `cargo test -p dbx-core --lib large_value_cell_merge -- --nocapture`
  - 3 项通过，包含 20 万标记合并，测试体执行 0.21s
- `cargo test -p dbx-core --lib server_large_value -- --nocapture`
- `cargo clippy -p dbx-core --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- MySQL 8.4.6 真实 3.52GB 表、10 万行 DBX Web 请求前后对比
- 修复前后完整响应语义哈希对比一致

## 隐私

新增诊断项不记录 SQL 内容、连接 ID/名称、数据库名、账号密码或单元格值，只记录追踪 ID、阶段耗时、字节数和结果规模。

## CI 基线修复

首次 CI 同时暴露主分支已有的两项前端检查失败，本 PR 以独立提交做最小兼容处理：

- 将当前 TypeScript lib 目标不支持的 `Array.prototype.at(-1)` 改为等价下标读取
- 按仓库格式化器整理现有 `connectionStore.metadataLoading.spec.ts`
