### PR TITLE
fix: use schema instead of database for GaussDB M mode view DDL

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -2998,22 +2998,41 @@ mod tests {
         config.driver_profile = Some("gaussdb-m".to_string());
 
         assert_eq!(
-            gaussdb_m_view_object_source_sql(&config, "tenant`db", "active`users", &db::ObjectSourceKind::View)
-                .as_deref(),
-            Some("SHOW CREATE VIEW `tenant``db`.`active``users`")
+            gaussdb_m_view_object_source_sql(
+                &config,
+                "connection_db",
+                "tenant`schema",
+                "active`users",
+                &db::ObjectSourceKind::View,
+            )
+            .as_deref(),
+            Some("SHOW CREATE VIEW `tenant``schema`.`active``users`")
         );
         assert_eq!(
-            gaussdb_m_view_object_source_sql(&config, "", "active`users", &db::ObjectSourceKind::View).as_deref(),
+            gaussdb_m_view_object_source_sql(&config, "connection_db", "", "active`users", &db::ObjectSourceKind::View)
+                .as_deref(),
             Some("SHOW CREATE VIEW `active``users`")
         );
         assert_eq!(
-            gaussdb_m_view_object_source_sql(&config, "tenant_db", "refresh_users", &db::ObjectSourceKind::Function),
+            gaussdb_m_view_object_source_sql(
+                &config,
+                "connection_db",
+                "tenant_schema",
+                "refresh_users",
+                &db::ObjectSourceKind::Function,
+            ),
             None
         );
 
         config.driver_profile = Some("gaussdb".to_string());
         assert_eq!(
-            gaussdb_m_view_object_source_sql(&config, "tenant_db", "active_users", &db::ObjectSourceKind::View),
+            gaussdb_m_view_object_source_sql(
+                &config,
+                "connection_db",
+                "tenant_schema",
+                "active_users",
+                &db::ObjectSourceKind::View,
+            ),
             None
         );
     }
@@ -6783,6 +6802,7 @@ fn external_driver_uses_mysql_ddl(config: &ConnectionConfig) -> bool {
 
 fn gaussdb_m_view_object_source_sql(
     config: &ConnectionConfig,
+    _database: &str,
     schema: &str,
     name: &str,
     kind: &db::ObjectSourceKind,
@@ -7427,7 +7447,7 @@ async fn get_object_source_once(
             let config = config.clone();
             let session = session.clone();
             drop(connections);
-            if let Some(sql) = gaussdb_m_view_object_source_sql(config.as_ref(), schema, name, &object_type) {
+            if let Some(sql) = gaussdb_m_view_object_source_sql(config.as_ref(), database, schema, name, &object_type) {
                 let result: db::QueryResult = session
                     .invoke_with_timeout(
                         "executeQuery",

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -6783,12 +6783,12 @@ fn external_driver_uses_mysql_ddl(config: &ConnectionConfig) -> bool {
 
 fn gaussdb_m_view_object_source_sql(
     config: &ConnectionConfig,
-    database: &str,
+    schema: &str,
     name: &str,
     kind: &db::ObjectSourceKind,
 ) -> Option<String> {
     (gaussdb_uses_m_jdbc_driver(config) && matches!(kind, db::ObjectSourceKind::View))
-        .then(|| mysql_object_source_sql(database, name, kind))
+        .then(|| mysql_object_source_sql(schema, name, kind))
 }
 
 fn mysql_external_driver_ddl_sql(database: &str, schema: &str, table: &str) -> String {
@@ -7427,7 +7427,7 @@ async fn get_object_source_once(
             let config = config.clone();
             let session = session.clone();
             drop(connections);
-            if let Some(sql) = gaussdb_m_view_object_source_sql(config.as_ref(), database, name, &object_type) {
+            if let Some(sql) = gaussdb_m_view_object_source_sql(config.as_ref(), schema, name, &object_type) {
                 let result: db::QueryResult = session
                     .invoke_with_timeout(
                         "executeQuery",


### PR DESCRIPTION
In GaussDB M mode (MySQL-compatible), the schema parameter received from the frontend is the actual schema name (e.g. dbe_perf), not the database name (e.g. pubdb). The previous code passed the database name to mysql_object_source_sql, generating SHOW CREATE VIEW `pubdb`.`view_name` which failed because pubdb is a database, not a schema.

Fix gaussdb_m_view_object_source_sql to use the schema parameter instead of the database parameter when building the SHOW CREATE VIEW SQL.
