### PR TITLE
Fix: 修复前端 CI 兼容性检查失败

### DIFF
--- a/apps/desktop/src/lib/sql/sqlAnalysis.ts
+++ b/apps/desktop/src/lib/sql/sqlAnalysis.ts
@@ -323,7 +323,8 @@ function looksLikeComputedExpression(expression: string): boolean {
   const identifier = parseQualifiedIdentifier(trimmed);
   if (identifier?.end === trimmed.length) return false;
   if (/[+\-*/%=<>!|&^,.:]$/u.test(trimmed)) return false;
-  const finalWord = trimmed.split(/\s+/u).at(-1)?.toUpperCase() ?? "";
+  const words = trimmed.split(/\s+/u);
+  const finalWord = words[words.length - 1]?.toUpperCase() ?? "";
   if (new Set(["AND", "OR", "XOR", "NOT", "LIKE", "ILIKE", "IS", "IN", "BETWEEN", "WHEN", "THEN", "ELSE", "AS", "COLLATE", "AT", "DIV", "MOD", "REGEXP", "RLIKE"]).has(finalWord)) return false;
 
   const source = parseQualifiedIdentifier(trimmed);

--- a/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
@@ -2968,17 +2968,15 @@ describe("connectionStore metadata loading", () => {
     }));
     let resolveSearchClearReload!: (tables: TableInfo[]) => void;
     let unfilteredFirstPageCalls = 0;
-    const listTables = vi.fn(
-      (_connectionId: string, _database: string, _schema: string, searchFilter?: string, limit?: number, offset?: number) => {
-        if (searchFilter) return Promise.resolve(tables.filter((table) => table.name.includes(searchFilter)));
-        if ((offset ?? 0) === 0 && ++unfilteredFirstPageCalls === 1) {
-          return new Promise<TableInfo[]>((resolve) => {
-            resolveSearchClearReload = resolve;
-          });
-        }
-        return Promise.resolve(tables.slice(offset ?? 0, (offset ?? 0) + (limit ?? tables.length)));
-      },
-    );
+    const listTables = vi.fn((_connectionId: string, _database: string, _schema: string, searchFilter?: string, limit?: number, offset?: number) => {
+      if (searchFilter) return Promise.resolve(tables.filter((table) => table.name.includes(searchFilter)));
+      if ((offset ?? 0) === 0 && ++unfilteredFirstPageCalls === 1) {
+        return new Promise<TableInfo[]>((resolve) => {
+          resolveSearchClearReload = resolve;
+        });
+      }
+      return Promise.resolve(tables.slice(offset ?? 0, (offset ?? 0) + (limit ?? tables.length)));
+    });
 
     vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
     vi.doMock("@/lib/backend/api", () => ({


### PR DESCRIPTION
## 改动说明

- 按项目 `oxfmt` 规则格式化连接元数据加载测试
- 将 SQL 分析中的 ES2022 `Array.prototype.at()` 改为兼容当前 ES2021 target 的等价索引访问
- 修复当前 `main` 上 `pnpm check` 的 format 与 typecheck 阶段失败
- 不改变测试逻辑或 SQL 分析行为

## 验证

- `pnpm typecheck` 通过
- 全部前端 TypeScript/Vue 文件格式检查通过
- lint 通过
- 连接元数据加载测试 50 项通过
- SQL 可编辑性分析测试 16 项通过
- `git diff --check` 通过

关联：#6137 的 CI 失败日志
