### PR TITLE
fix: GaussDB M模式bool列显示为true/false

### DIFF
--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -3028,10 +3028,7 @@ public final class DbxJdbcPlugin {
     ) throws SQLException {
         int columnType = meta.getColumnType(index);
 
-        // GaussDB M-mode JDBC driver may return boolean columns as byte[]
-        // (0x74 for true, 0x66 for false) instead of java.lang.Boolean.
-        // Use rs.getBoolean() for BIT/BOOLEAN columns to get the correct value.
-        if (columnType == Types.BIT || columnType == Types.BOOLEAN) {
+        if (columnType == Types.BOOLEAN) {
             boolean boolValue = rs.getBoolean(index);
             if (!rs.wasNull()) {
                 return boolValue;
@@ -3044,6 +3041,9 @@ public final class DbxJdbcPlugin {
             return null;
         }
         if (value instanceof byte[] bytes) {
+            if (columnType == Types.BIT && bytes.length == 1 && (bytes[0] == 't' || bytes[0] == 'f')) {
+                return bytes[0] == 't';
+            }
             return binaryToHex(bytes);
         }
         if (value instanceof Clob clob) {

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -3026,6 +3026,19 @@ public final class DbxJdbcPlugin {
         int index,
         boolean preserveOracleDateTime
     ) throws SQLException {
+        int columnType = meta.getColumnType(index);
+
+        // GaussDB M-mode JDBC driver may return boolean columns as byte[]
+        // (0x74 for true, 0x66 for false) instead of java.lang.Boolean.
+        // Use rs.getBoolean() for BIT/BOOLEAN columns to get the correct value.
+        if (columnType == Types.BIT || columnType == Types.BOOLEAN) {
+            boolean boolValue = rs.getBoolean(index);
+            if (!rs.wasNull()) {
+                return boolValue;
+            }
+            return null;
+        }
+
         Object value = rs.getObject(index);
         if (value == null) {
             return null;

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -426,6 +426,39 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void readValueConvertsGaussDbBooleanBytesWithoutCollapsingMultiBitValues() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod(
+            "readValue",
+            ResultSet.class,
+            ResultSetMetaData.class,
+            int.class,
+            boolean.class
+        );
+        method.setAccessible(true);
+
+        assertEquals(true, method.invoke(null, objectResultSet(new byte[] { 't' }), columnMeta(Types.BIT), 1, false));
+        assertEquals(false, method.invoke(null, objectResultSet(new byte[] { 'f' }), columnMeta(Types.BIT), 1, false));
+        assertEquals(null, method.invoke(null, objectResultSet(null), columnMeta(Types.BIT), 1, false));
+        assertEquals("0x0102", method.invoke(null, objectResultSet(new byte[] { 1, 2 }), columnMeta(Types.BIT), 1, false));
+    }
+
+    @Test
+    void readValueUsesJdbcBooleanAccessForBooleanColumns() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod(
+            "readValue",
+            ResultSet.class,
+            ResultSetMetaData.class,
+            int.class,
+            boolean.class
+        );
+        method.setAccessible(true);
+
+        assertEquals(true, method.invoke(null, booleanResultSet(true), columnMeta(Types.BOOLEAN), 1, false));
+        assertEquals(false, method.invoke(null, booleanResultSet(false), columnMeta(Types.BOOLEAN), 1, false));
+        assertEquals(null, method.invoke(null, booleanResultSet(null), columnMeta(Types.BOOLEAN), 1, false));
+    }
+
+    @Test
     void executeQueryPreservesOracleDateTimeComponent() throws Exception {
         List<String> calls = new ArrayList<>();
         Driver driver = new OracleDateDriver(
@@ -2188,6 +2221,29 @@ final class DbxJdbcPluginTest {
                     case "getColumnType" -> columnType;
                     default -> defaultValue(method.getReturnType());
                 };
+            }
+        );
+    }
+
+    private static ResultSet objectResultSet(Object value) {
+        return (ResultSet) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { ResultSet.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getObject" -> value;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static ResultSet booleanResultSet(Boolean value) {
+        return (ResultSet) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { ResultSet.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getBoolean" -> Boolean.TRUE.equals(value);
+                case "wasNull" -> value == null;
+                default -> defaultValue(method.getReturnType());
             }
         );
     }


### PR DESCRIPTION
GaussDB M模式的JDBC驱动将BIT/BOOLEAN类型的列以byte[]
(0x74=true, 0x66=false)形式返回，而非java.lang.Boolean。
readValue方法中byte[]检查优先于Boolean检查，导致
byte[]被转换为十六进制字符串显示。

修复：对BIT/BOOLEAN类型的列优先使用rs.getBoolean()
获取正确的布尔值。
