### PR TITLE
Fix：AI 连接测试使用配置表单中的模型

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -50,6 +50,7 @@ import {
 } from "@/stores/settingsStore";
 import { createRunStatementButtonDom, loadEditorTheme, editorFontTheme } from "@/lib/editor/editorThemes";
 import { orderAiConfigsForDisplay } from "@/lib/ai/aiConfigOrdering";
+import { isAiConnectionTestConfigCurrent } from "@/lib/ai/aiConnectionTest";
 import { MAX_AGENT_TURNS_DEFAULT, MAX_AGENT_TURNS_MAX, MAX_AGENT_TURNS_MIN, maxAgentTurnsOutOfRange, normalizeMaxAgentTurns } from "@/lib/ai/maxAgentTurns";
 import ThemeCustomizerDialog from "./ThemeCustomizerDialog.vue";
 import TunnelProfileManager from "@/components/connection/TunnelProfileManager.vue";
@@ -2712,6 +2713,7 @@ const aiTestResult = ref<"" | "success" | "error">("");
 const aiTestError = ref("");
 const aiTestLatency = ref<number | null>(null);
 const aiTestErrorCopied = ref(false);
+let aiTestRequestId = 0;
 const aiTestErrorCategoryKeys: Record<string, string> = {
   auth: "ai.testErrorAuth",
   modelNotFound: "ai.testErrorModelNotFound",
@@ -2944,6 +2946,8 @@ function currentAiEditConfig() {
 }
 
 function syncAiEditState() {
+  aiTestRequestId += 1;
+  aiTesting.value = false;
   aiTestResult.value = "";
   aiTestError.value = "";
   aiTestLatency.value = null;
@@ -3126,16 +3130,19 @@ async function aiTestConn() {
   aiTestError.value = "";
   aiTestLatency.value = null;
   aiTestErrorCopied.value = false;
+  const requestId = ++aiTestRequestId;
+  const config = currentAiEditConfig();
   try {
-    const config = currentAiEditConfig();
     const result = await aiTestConnection(config);
+    if (requestId !== aiTestRequestId || !isAiConnectionTestConfigCurrent(config, currentAiEditConfig())) return;
     aiTestLatency.value = result.latencyMs ?? null;
     aiTestResult.value = "success";
   } catch (e: any) {
+    if (requestId !== aiTestRequestId || !isAiConnectionTestConfigCurrent(config, currentAiEditConfig())) return;
     aiTestResult.value = "error";
     aiTestError.value = translateBackendError(t, e);
   } finally {
-    aiTesting.value = false;
+    if (requestId === aiTestRequestId) aiTesting.value = false;
   }
 }
 

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -3128,10 +3128,6 @@ async function aiTestConn() {
   aiTestErrorCopied.value = false;
   try {
     const config = currentAiEditConfig();
-    const activeModel = settingsStore.activeModel;
-    if (aiEditConfigId.value && activeModel?.configId === aiEditConfigId.value) {
-      config.model = activeModel.modelId;
-    }
     const result = await aiTestConnection(config);
     aiTestLatency.value = result.latencyMs ?? null;
     aiTestResult.value = "success";

--- a/apps/desktop/src/lib/ai/__tests__/aiConnectionTest.spec.ts
+++ b/apps/desktop/src/lib/ai/__tests__/aiConnectionTest.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { AiConfig } from "@/types/ai";
+import { isAiConnectionTestConfigCurrent } from "../aiConnectionTest";
+
+function config(overrides: Partial<AiConfig> = {}): AiConfig {
+  return {
+    provider: "openai-compatible",
+    apiKey: "key",
+    authMethod: "bearer",
+    endpoint: "https://example.com/v1",
+    model: "model-a",
+    apiStyle: "completions",
+    ...overrides,
+  };
+}
+
+describe("AI connection test configuration", () => {
+  it("accepts a result only while the tested form values remain current", () => {
+    const tested = config();
+
+    expect(isAiConnectionTestConfigCurrent(tested, config())).toBe(true);
+    expect(isAiConnectionTestConfigCurrent(tested, config({ model: "model-b" }))).toBe(false);
+    expect(isAiConnectionTestConfigCurrent(tested, config({ endpoint: "https://other.example/v1" }))).toBe(false);
+    expect(isAiConnectionTestConfigCurrent(tested, config({ apiKey: "new-key" }))).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/ai/aiConnectionTest.ts
+++ b/apps/desktop/src/lib/ai/aiConnectionTest.ts
@@ -1,0 +1,5 @@
+import type { AiConfig } from "@/types/ai";
+
+export function isAiConnectionTestConfigCurrent(testedConfig: AiConfig, currentConfig: AiConfig): boolean {
+  return JSON.stringify(testedConfig) === JSON.stringify(currentConfig);
+}

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -648,6 +648,18 @@ test("API AI provider settings expose and persist a default model ID", () => {
   assert.match(source, /model:\s*aiEditModel\.value/);
 });
 
+test("AI connection test uses the model currently entered in the config form", () => {
+  const source = readFileSync("apps/desktop/src/components/editor/EditorSettingsDialog.vue", "utf8");
+  const testConnectionStart = source.indexOf("async function aiTestConn()");
+  const testConnectionEnd = source.indexOf("async function copyAiTestError()", testConnectionStart);
+  const testConnection = source.slice(testConnectionStart, testConnectionEnd);
+
+  assert.notEqual(testConnectionStart, -1);
+  assert.notEqual(testConnectionEnd, -1);
+  assert.match(testConnection, /const config = currentAiEditConfig\(\);[\s\S]*aiTestConnection\(config\)/);
+  assert.doesNotMatch(testConnection, /activeModel|config\.model\s*=/);
+});
+
 test("normalizes legacy AI config and fills provider defaults", () => {
   const legacy = normalizeAiConfig({
     provider: "openai",


### PR DESCRIPTION
## 修改说明

编辑已保存的 AI 配置时，如果该配置正被聊天面板使用，连接测试会将表单中的“默认模型”替换为聊天面板右下角当前选择的模型，导致测试结果与用户正在编辑、准备保存的配置不一致。

本次修改：

- AI 连接测试始终使用当前配置表单生成的模型参数
- 不再用聊天面板的临时模型选择覆盖“默认模型”
- 补充回归测试，防止测试请求再次依赖 `activeModel`

## CI 兼容修复

首次 CI 运行中，本 PR 自身的 format、lint 和 test 均通过，但最新 `main` 在 `sqlAnalysis.ts` 使用了当前 TypeScript target 不支持的 `Array.prototype.at()`，导致所有前端 PR 的 typecheck 失败。

本 PR 同时将该处改为等价的数组索引写法，不改变查询列分析行为，并恢复前端类型检查。

## 测试

- `pnpm check`
  - format：通过
  - lint：通过
  - typecheck：通过
  - test：通过
- 聚焦测试：`pnpm exec vitest run packages/app-tests/settingsStore.test.ts apps/desktop/src/lib/__tests__/sql/editableQueryHiddenKeys.spec.ts apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts`（110 项通过）
- 全量测试：937 个测试文件、8916 个测试通过