### PR TITLE
fix(grid): recognize MySQL bit and bit(1) as boolean columns

### DIFF
--- a/apps/desktop/src/lib/dataGrid/dataGridBooleanColumn.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridBooleanColumn.ts
@@ -3,11 +3,14 @@ import type { DatabaseType } from "@/types/database";
 export const BOOLEAN_CHECKBOX_SIZE = 13;
 export const BOOLEAN_CELL_EDITOR_VALUES = ["true", "false"];
 
+const MYSQL_BIT_BOOLEAN_DATABASE_TYPES = new Set<DatabaseType>(["mysql"]);
+
 export function isBooleanColumnType(dataType: string | undefined, databaseType?: DatabaseType): boolean {
   if (!dataType) return false;
   const normalized = dataType.trim().toLowerCase();
   if (normalized === "boolean" || normalized === "bool") return true;
   if (databaseType === "sqlserver") return normalized === "bit";
+  if (databaseType && MYSQL_BIT_BOOLEAN_DATABASE_TYPES.has(databaseType)) return normalized === "bit" || normalized === "bit(1)";
   return false;
 }
 

--- a/packages/app-tests/dataGridBooleanColumn.test.ts
+++ b/packages/app-tests/dataGridBooleanColumn.test.ts
@@ -22,6 +22,8 @@ test("detects boolean types using database semantics", () => {
   assert.equal(isBooleanColumnType("bit", "sqlserver"), true);
   assert.equal(isBooleanColumnType("boolean", "mysql"), true);
   assert.equal(isBooleanColumnType("  BOOLEAN ", "postgres"), true);
+  assert.equal(isBooleanColumnType("bit", "mysql"), true);
+  assert.equal(isBooleanColumnType("bit(1)", "mysql"), true);
 });
 
 test("does not treat database bit strings or MySQL integer aliases as boolean", () => {
@@ -31,8 +33,6 @@ test("does not treat database bit strings or MySQL integer aliases as boolean", 
   assert.equal(isBooleanColumnType("varbit", "postgres"), false);
   assert.equal(isBooleanColumnType("bit", "opengauss"), false);
   assert.equal(isBooleanColumnType("bit", undefined), false);
-  assert.equal(isBooleanColumnType("bit", "mysql"), false);
-  assert.equal(isBooleanColumnType("bit(1)", "mysql"), false);
   assert.equal(isBooleanColumnType("bit(8)", "mysql"), false);
   assert.equal(isBooleanColumnType("tinyint(1)", "mysql"), false);
   assert.equal(isBooleanColumnType(undefined, "mysql"), false);


### PR DESCRIPTION
## Description

Restores MySQL `bit` and `bit(1)` detection as boolean columns in the data grid.

The maintainer's original patch on #5100 handled MySQL `bit`/`bit(1)` as boolean, but this was accidentally lost in a later boolean editing refactor. As a result, in v0.5.82 MySQL `bit` fields render as plain text instead of the boolean editor.

## Change Type

- Bug fix

## Files Changed

| File | Change |
| --- | --- |
| `apps/desktop/src/lib/dataGrid/dataGridBooleanColumn.ts` | Add `MYSQL_BIT_BOOLEAN_DATABASE_TYPES` and recognize `bit` / `bit(1)` for MySQL; `bit(8)` and `tinyint(1)` remain non-boolean |
| `packages/app-tests/dataGridBooleanColumn.test.ts` | Update tests to expect `bit` / `bit(1)` as boolean for MySQL |

## Verification

- `pnpm exec vitest run packages/app-tests/dataGridBooleanColumn.test.ts` - 9 tests passed
- `pnpm typecheck` - passed
- `pnpm exec oxlint <files>` - 0 warnings, 0 errors
- `pnpm exec oxfmt --check <files>` - passed

## Related Issue

Reported by [@WvvvWv](https://github.com/WvvvWv) in a [comment on #5100](https://github.com/t8y2/dbx/pull/5100#issuecomment-5276299834): MySQL `bit` is not recognized as boolean in v0.5.82.

## Screenshot

<img width="350" height="262" alt="image" src="https://github.com/user-attachments/assets/82c8620b-6aa4-4d38-9f00-fac098eecfa8" />
<img width="356" height="265" alt="image" src="https://github.com/user-attachments/assets/55294365-74e7-4378-9541-4c895c9ca782" />
