### PR TITLE
fix(objects): support ctrl/shift-click multi-select in database browser

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -120,7 +120,7 @@ import {
   type ObjectBrowserSortKey,
 } from "@/lib/table/objectBrowserRows";
 import { isSourceOnlyObjectBrowserRow, resolveRowClickAction, shouldDeferSingleClick, type ObjectBrowserRowAction } from "@/lib/table/objectBrowserRowAction";
-import { objectBrowserTableSelectionRange } from "@/lib/table/objectBrowserSelection";
+import { objectBrowserTableSelectionAnchor, objectBrowserTableSelectionRange } from "@/lib/table/objectBrowserSelection";
 import { customTypeCapabilities, supportsTypeObjectSource } from "@/lib/database/databaseObjectCapabilities";
 import { filterObjectBrowserTableColumns } from "@/lib/table/objectBrowserTableInfo";
 import { createSidePanelRequestGuard } from "@/lib/table/sidePanelRequestGuard";
@@ -860,7 +860,8 @@ function toggleTableSelectionWithAnchor(row: ObjectBrowserRow) {
 }
 
 function selectTableRangeFromAnchor(row: ObjectBrowserRow) {
-  const anchorId = tableSelectionAnchorId.value ?? row.id;
+  const anchorId = objectBrowserTableSelectionAnchor(filteredRows.value, tableSelectionAnchorId.value, row.id);
+  tableSelectionAnchorId.value = anchorId;
   setSelectedTableIds(new Set(objectBrowserTableSelectionRange(filteredRows.value, anchorId, row.id)));
 }
 

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -120,6 +120,7 @@ import {
   type ObjectBrowserSortKey,
 } from "@/lib/table/objectBrowserRows";
 import { isSourceOnlyObjectBrowserRow, resolveRowClickAction, shouldDeferSingleClick, type ObjectBrowserRowAction } from "@/lib/table/objectBrowserRowAction";
+import { objectBrowserTableSelectionRange } from "@/lib/table/objectBrowserSelection";
 import { customTypeCapabilities, supportsTypeObjectSource } from "@/lib/database/databaseObjectCapabilities";
 import { filterObjectBrowserTableColumns } from "@/lib/table/objectBrowserTableInfo";
 import { createSidePanelRequestGuard } from "@/lib/table/sidePanelRequestGuard";
@@ -247,6 +248,7 @@ const duplicateTableName = ref("");
 const showProcedureExecutionConfirm = ref(false);
 const procedureExecutionTarget = ref<ObjectBrowserRow | null>(null);
 const selectedTableIds = ref<Set<string>>(new Set());
+const tableSelectionAnchorId = ref<string | null>(null);
 const expandedPartitionParentIds = ref<Set<string>>(new Set());
 const showBatchDropConfirm = ref(false);
 const batchDropExecuting = ref(false);
@@ -852,7 +854,26 @@ function executeRowAction(row: ObjectBrowserRow, action: ObjectBrowserRowAction)
   }
 }
 
+function toggleTableSelectionWithAnchor(row: ObjectBrowserRow) {
+  toggleTableSelection(row);
+  tableSelectionAnchorId.value = row.id;
+}
+
+function selectTableRangeFromAnchor(row: ObjectBrowserRow) {
+  const anchorId = tableSelectionAnchorId.value ?? row.id;
+  setSelectedTableIds(new Set(objectBrowserTableSelectionRange(filteredRows.value, anchorId, row.id)));
+}
+
 function onRowClick(row: ObjectBrowserRow, event: MouseEvent) {
+  if (row.type === "TABLE" && event.shiftKey) {
+    selectTableRangeFromAnchor(row);
+    return;
+  }
+  if (row.type === "TABLE" && (event.metaKey || event.ctrlKey)) {
+    toggleTableSelectionWithAnchor(row);
+    return;
+  }
+  if (row.type === "TABLE") tableSelectionAnchorId.value = row.id;
   const activation = settingsStore.editorSettings.sidebarActivation;
   const { action, isDouble } = resolveRowClickAction(row, event.detail, activation, effectiveDatabaseType.value);
   // Double click: cancel any pending single-click and fire immediately

--- a/apps/desktop/src/lib/__tests__/table/objectBrowserSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/objectBrowserSelection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { objectBrowserTableSelectionRange } from "@/lib/table/objectBrowserSelection";
+import { objectBrowserTableSelectionAnchor, objectBrowserTableSelectionRange } from "@/lib/table/objectBrowserSelection";
 import type { ObjectBrowserRow } from "@/lib/table/objectBrowserRows";
 
 function row(type: ObjectBrowserRow["type"], name: string): ObjectBrowserRow {
@@ -35,5 +35,18 @@ describe("objectBrowserTableSelectionRange", () => {
   it("collapses to a single row when anchor and current are the same table", () => {
     const rows = [row("TABLE", "a"), row("TABLE", "b")];
     expect(objectBrowserTableSelectionRange(rows, "TABLE-a", "TABLE-a")).toEqual(["TABLE-a"]);
+  });
+});
+
+describe("objectBrowserTableSelectionAnchor", () => {
+  it("keeps a visible table anchor", () => {
+    const rows = [row("TABLE", "a"), row("TABLE", "b")];
+    expect(objectBrowserTableSelectionAnchor(rows, "TABLE-a", "TABLE-b")).toBe("TABLE-a");
+  });
+
+  it("uses the current table when the anchor is missing or no longer visible", () => {
+    const rows = [row("TABLE", "a"), row("TABLE", "b")];
+    expect(objectBrowserTableSelectionAnchor(rows, null, "TABLE-b")).toBe("TABLE-b");
+    expect(objectBrowserTableSelectionAnchor(rows, "TABLE-filtered-out", "TABLE-b")).toBe("TABLE-b");
   });
 });

--- a/apps/desktop/src/lib/__tests__/table/objectBrowserSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/objectBrowserSelection.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { objectBrowserTableSelectionRange } from "@/lib/table/objectBrowserSelection";
+import type { ObjectBrowserRow } from "@/lib/table/objectBrowserRows";
+
+function row(type: ObjectBrowserRow["type"], name: string): ObjectBrowserRow {
+  return { id: `${type}-${name}`, name, displayName: name, type };
+}
+
+describe("objectBrowserTableSelectionRange", () => {
+  it("selects every table between anchor and current row, inclusive", () => {
+    const rows = [row("TABLE", "a"), row("TABLE", "b"), row("TABLE", "c"), row("TABLE", "d")];
+    expect(objectBrowserTableSelectionRange(rows, "TABLE-a", "TABLE-c")).toEqual(["TABLE-a", "TABLE-b", "TABLE-c"]);
+  });
+
+  it("supports selecting upward when the current row precedes the anchor", () => {
+    const rows = [row("TABLE", "a"), row("TABLE", "b"), row("TABLE", "c"), row("TABLE", "d")];
+    expect(objectBrowserTableSelectionRange(rows, "TABLE-d", "TABLE-b")).toEqual(["TABLE-b", "TABLE-c", "TABLE-d"]);
+  });
+
+  it("drops non-table rows inside the span, since only tables are selectable", () => {
+    const rows = [row("TABLE", "a"), row("VIEW", "v1"), row("PROCEDURE", "p1"), row("TABLE", "b")];
+    expect(objectBrowserTableSelectionRange(rows, "TABLE-a", "TABLE-b")).toEqual(["TABLE-a", "TABLE-b"]);
+  });
+
+  it("returns just the current row when the anchor is not selectable and current is a table", () => {
+    const rows = [row("TABLE", "a"), row("TABLE", "b")];
+    expect(objectBrowserTableSelectionRange(rows, "missing-anchor", "TABLE-b")).toEqual(["TABLE-b"]);
+  });
+
+  it("returns an empty range when the anchor is missing and current row is not a table", () => {
+    const rows = [row("VIEW", "v1"), row("TABLE", "b")];
+    expect(objectBrowserTableSelectionRange(rows, "missing-anchor", "VIEW-v1")).toEqual([]);
+  });
+
+  it("collapses to a single row when anchor and current are the same table", () => {
+    const rows = [row("TABLE", "a"), row("TABLE", "b")];
+    expect(objectBrowserTableSelectionRange(rows, "TABLE-a", "TABLE-a")).toEqual(["TABLE-a"]);
+  });
+});

--- a/apps/desktop/src/lib/table/objectBrowserSelection.ts
+++ b/apps/desktop/src/lib/table/objectBrowserSelection.ts
@@ -1,0 +1,20 @@
+import type { ObjectBrowserRow } from "@/lib/table/objectBrowserRows";
+
+/**
+ * Compute the contiguous table-id range for a shift-click in the object
+ * browser, mirroring the sidebar tree's range-select behavior
+ * (sidebarTreeSelection.ts): the range spans every row between the anchor
+ * and the clicked row in visible order, but only TABLE rows are selectable
+ * so non-table rows inside the span are dropped from the result.
+ */
+export function objectBrowserTableSelectionRange(rows: readonly ObjectBrowserRow[], anchorId: string, currentId: string): string[] {
+  const anchorIndex = rows.findIndex((row) => row.id === anchorId);
+  const currentIndex = rows.findIndex((row) => row.id === currentId);
+  if (anchorIndex < 0 || currentIndex < 0) return rows.some((row) => row.id === currentId && row.type === "TABLE") ? [currentId] : [];
+  const start = Math.min(anchorIndex, currentIndex);
+  const end = Math.max(anchorIndex, currentIndex);
+  return rows
+    .slice(start, end + 1)
+    .filter((row) => row.type === "TABLE")
+    .map((row) => row.id);
+}

--- a/apps/desktop/src/lib/table/objectBrowserSelection.ts
+++ b/apps/desktop/src/lib/table/objectBrowserSelection.ts
@@ -1,5 +1,10 @@
 import type { ObjectBrowserRow } from "@/lib/table/objectBrowserRows";
 
+export function objectBrowserTableSelectionAnchor(rows: readonly ObjectBrowserRow[], anchorId: string | null, currentId: string): string {
+  if (anchorId && rows.some((row) => row.id === anchorId && row.type === "TABLE")) return anchorId;
+  return currentId;
+}
+
 /**
  * Compute the contiguous table-id range for a shift-click in the object
  * browser, mirroring the sidebar tree's range-select behavior


### PR DESCRIPTION
## Summary

The sidebar tree already supports ctrl/cmd-click toggle and shift-click range-select for tables (merged just before this issue was filed). The database detail view (`ObjectBrowser.vue`, opened via "浏览对象" / entering a database) only offered a checkbox-toggle mode: click a toolbar button to reveal a checkbox column, then click each row's checkbox individually — no way to ctrl/cmd-click or shift-click rows directly.

- Adds a pure helper `objectBrowserTableSelectionRange` (mirrors the sidebar's existing `sidebarTreeSelection.ts` range logic) that computes the contiguous TABLE-row range between an anchor and the clicked row
- Wires ctrl/cmd-click (toggle) and shift-click (range-select) into `onRowClick`, gated to `TABLE` rows since only tables are selectable
- The existing bulk-action toolbar (export/delete/clear selection) already reacts to the same selection state, so no other changes were needed

Fixes #6152

## Test plan

- [x] `objectBrowserSelection.spec.ts`: 6 new unit tests covering forward/backward range, non-table rows inside the span being dropped, missing-anchor fallback, and single-row collapse
- [x] Full suite: 8813 tests passing
- [x] Manual verification in a real dev build: created a throwaway SQLite connection with 6 tables, drove real clicks via CDP raw input (Cmd-click on macOS is the actual modifier — Ctrl+Click is intercepted as right-click by macOS/Chrome). Confirmed Cmd-click toggles individual tables and shift-click selects the contiguous range from the anchor, with the bulk-action toolbar updating correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)