### PR TITLE
fix(editor): keep indenting a selection instead of letting a stray completion hijack Tab

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1973,9 +1973,14 @@ function extendQueryEditorSelectionForView(currentView: EditorViewType): boolean
 }
 
 function acceptCompletionOrNextSnippetField(view: EditorViewType): boolean {
-  const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
-  if (completionStatus === "active" && (codeMirrorAcceptCompletion?.(view) ?? false)) return true;
-  if (completionStatus) return waitForCompletionTab(view);
+  // A non-empty selection means Tab is being used for block indent, not word
+  // completion. A completion popup can still appear as a side effect of the
+  // indent edit itself, so it must never hijack this (or a following) Tab press.
+  if (view.state.selection.main.empty) {
+    const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
+    if (completionStatus === "active" && (codeMirrorAcceptCompletion?.(view) ?? false)) return true;
+    if (completionStatus) return waitForCompletionTab(view);
+  }
   return codeMirrorNextSnippetField?.(view) ?? false;
 }
 

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
@@ -117,8 +117,8 @@ function createHarness(options: {
   ) as TabHarness;
 }
 
-function createView(text = "SELECT", position = text.length): MockView {
-  const selection: MockSelection = { anchor: position, head: position, from: position, empty: true };
+function createView(text = "SELECT", position = text.length, selectionOverrides: Partial<MockSelection> = {}): MockView {
+  const selection: MockSelection = { anchor: position, head: position, from: position, empty: true, ...selectionOverrides };
   const state: MockState = {
     doc: {
       lineAt: () => ({ from: 0, text }),
@@ -128,6 +128,10 @@ function createView(text = "SELECT", position = text.length): MockView {
     update: vi.fn((change: unknown, options: unknown) => ({ change, options })),
   };
   return { state, dispatch: vi.fn() };
+}
+
+function createMultiLineSelectionView(text = "SELECT 1\nSELECT 2"): MockView {
+  return createView(text, 0, { anchor: 0, head: text.length, from: 0, empty: false });
 }
 
 afterEach(() => {
@@ -279,6 +283,33 @@ describe("QueryEditor completion Tab keymap", () => {
 
     expect(harness.handleTab(view)).toBe(true);
     expect(acceptCompletion).toHaveBeenCalledWith(view);
+  });
+
+  it("keeps indenting a multi-line selection instead of letting a completion popup hijack Tab (#5419)", () => {
+    const acceptCompletion = vi.fn(() => true);
+    const indentMore = vi.fn(() => true);
+    const harness = createHarness({ completionStatus: () => "active", acceptCompletion, indentMore });
+    const view = createMultiLineSelectionView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    expect(indentMore).toHaveBeenCalledWith(view);
+    expect(acceptCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not let a pending completion hijack a second Tab press while indenting a selection (#5419)", async () => {
+    vi.useFakeTimers();
+    let status: "active" | "pending" | null = "pending";
+    const acceptCompletion = vi.fn(() => true);
+    const indentMore = vi.fn(() => true);
+    const harness = createHarness({ completionStatus: () => status, acceptCompletion, indentMore });
+    const view = createMultiLineSelectionView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    status = "active";
+    await vi.advanceTimersByTimeAsync(32);
+
+    expect(indentMore).toHaveBeenCalledWith(view);
+    expect(acceptCompletion).not.toHaveBeenCalled();
   });
 
   it("falls back to normal Tab when pending completion has no candidate", async () => {


### PR DESCRIPTION
## Problem

Pressing Tab to indent a multi-line selection in the SQL editor works the first time, but a completion popup can appear as a side effect of that edit (the doc-changed handler re-triggers SQL completion based on cursor context, regardless of what kind of edit just happened). The next Tab press then accepts that unrelated completion instead of indenting further, replacing the selected text with a suggestion.

## Fix

`acceptCompletionOrNextSnippetField` (used by the Tab keymap) now only goes through the completion-accept/wait path when the selection is empty. A non-empty selection always goes straight to block indent (`indentMore`), so a completion popup that appears mid-indent can never hijack a subsequent Tab press. Snippet-field navigation is unaffected either way.

## Testing

- Added two regression tests in `queryEditorCompletionKeymap.spec.ts` that extract the real `handleTab`/`acceptCompletionOrNextSnippetField` function bodies from `QueryEditor.vue` (same harness this file already uses) and assert that a multi-line selection keeps calling `indentMore` instead of `acceptCompletion`, both when completion is already `active` and when it's `pending` and resolves after the Tab press. Both fail against the pre-fix code and pass after.
- Full suite: `pnpm test` — 937 files / 8926 tests passing.

Fixes #5419