### PR TITLE
fix(editor): center executed statement instead of pinning it to viewport edge

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -5608,8 +5608,14 @@ function openReplace(): boolean {
 function scrollCursorIntoView() {
   if (!view.value || !editorViewModule || !editorIsActive) return;
   const pos = view.value.state.selection.main.head;
+  // Use "center" rather than "nearest": by the time this runs, the results pane has already
+  // opened/resized and shrunk the editor viewport, so the cursor's old position is often no
+  // longer visible. "nearest" then pins it right at the new viewport's edge (Fixes #5281: in a
+  // long multi-statement file, the just-executed statement lands flush against the results pane
+  // divider), which is exactly where it's hardest to see and re-click. Centering keeps it
+  // comfortably visible so the user doesn't have to scroll to find/re-run it.
   view.value.dispatch({
-    effects: editorViewModule.EditorView.scrollIntoView(pos, { y: "nearest" }),
+    effects: editorViewModule.EditorView.scrollIntoView(pos, { y: "center" }),
   });
 }
 


### PR DESCRIPTION
## Summary

In a long multi-statement SQL Library file, executing a statement causes the results pane to open/grow, shrinking the editor's visible height. The post-execution `scrollCursorIntoView()` call in `QueryEditor.vue` used `EditorView.scrollIntoView(pos, { y: "nearest" })`, which pins the just-executed statement flush against the new viewport edge (right at the results pane divider) instead of leaving it comfortably visible - so re-locating and re-running the same statement requires scrolling again.

This switches the alignment to `"center"`, the same fix already applied to search-match scrolling in this codebase (b8d37774f, "center search matches in the viewport"). The executed statement now settles near the middle of the editor pane with context on both sides.

Fixes #5281

## Root cause

- `ContentArea.vue` watches `isExecuting` and, once execution completes, calls `queryEditorRef.value?.scrollCursorIntoView()` after `nextTick` + `requestAnimationFrame` (to wait for the results-pane/Splitpanes layout to settle).
- By the time it runs, the results pane has already opened and shrunk the editor's viewport.
- `scrollCursorIntoView()` used `{ y: "nearest" }`, which - correctly per its own semantics - scrolls just enough to bring the cursor into the *new, shorter* viewport, landing it at the nearest edge. For a statement the user had positioned lower in a tall viewport, that edge is now right against the results pane, making it hard to see/re-click.

## Test plan

- [x] Reproduced with a real dev environment (Rust backend + Vite frontend + MySQL) driven by Playwright/headless Chromium: 150-statement SQL file, cursor on statement 60, `Cmd+Enter` to execute.
  - Before: `scrollTop` jumps 461 → 998; the executed line moves from viewport y=878 to y=341 (pinned against the results pane divider).
  - After: the executed line settles at viewport y=228, roughly centered in the shrunk editor pane, with statements above and below visible.
- [x] `apps/desktop/src/lib/__tests__/editor` — 179/179 tests pass
- [x] `vue-tsc --noEmit` — no new type errors introduced (one pre-existing, unrelated error in `sqlAnalysis.ts`)