### PR TITLE
fix(sql): require whitespace after -- for MySQL line comments

### DIFF
--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -296,14 +296,15 @@ fn sql_file_encoding_error() -> String {
 }
 
 /// Whether a `--` sequence starts a line comment. MySQL (and MySQL-wire-compatible
-/// dialects) requires the second dash to be followed by whitespace or end-of-input —
+/// dialects) requires the second dash to be followed by whitespace, a control character,
+/// or end-of-input —
 /// `5--1` is subtraction (`5 - -1`), not a comment. Other dialects (Postgres, Oracle/DM,
 /// SQL Server, ...) treat `--` as a comment opener unconditionally.
 fn dash_dash_starts_line_comment(profile: SqlDialectProfile, char_after_dashes: Option<char>) -> bool {
     if !profile.requires_whitespace_after_line_comment_dashes {
         return true;
     }
-    char_after_dashes.is_none_or(|ch| ch.is_whitespace())
+    char_after_dashes.is_none_or(|ch| ch.is_whitespace() || ch.is_control())
 }
 
 #[derive(Default)]
@@ -317,6 +318,7 @@ pub struct SqlStatementSplitter {
     dollar_quote_tag: Option<String>,
     postgres_dollar_quoted_routine: bool,
     previous: Option<char>,
+    pending_mysql_line_comment_dashes: bool,
     custom_delimiter: Option<String>,
     options: SqlParsingOptions,
 }
@@ -330,6 +332,13 @@ impl SqlStatementSplitter {
         let mut statements = Vec::new();
         let chars = chunk.chars().collect::<Vec<_>>();
         let mut i = 0;
+
+        if self.pending_mysql_line_comment_dashes {
+            if let Some(first) = chars.first().copied() {
+                self.in_line_comment = dash_dash_starts_line_comment(self.options.profile, Some(first));
+                self.pending_mysql_line_comment_dashes = false;
+            }
+        }
 
         while i < chars.len() {
             if let Some(tag) = &self.dollar_quote_tag {
@@ -375,13 +384,21 @@ impl SqlStatementSplitter {
             }
 
             if !self.in_single_quote && !self.in_double_quote && !self.in_backtick {
-                if self.previous == Some('-') && ch == '-' && dash_dash_starts_line_comment(self.options.profile, next)
-                {
-                    self.in_line_comment = true;
-                    self.buffer.push(ch);
-                    self.previous = Some(ch);
-                    i += 1;
-                    continue;
+                if self.previous == Some('-') && ch == '-' {
+                    if self.options.profile.requires_whitespace_after_line_comment_dashes && next.is_none() {
+                        self.pending_mysql_line_comment_dashes = true;
+                        self.buffer.push(ch);
+                        self.previous = Some(ch);
+                        i += 1;
+                        continue;
+                    }
+                    if dash_dash_starts_line_comment(self.options.profile, next) {
+                        self.in_line_comment = true;
+                        self.buffer.push(ch);
+                        self.previous = Some(ch);
+                        i += 1;
+                        continue;
+                    }
                 }
                 if self.previous == Some('/') && ch == '*' {
                     self.in_block_comment = true;
@@ -533,6 +550,10 @@ impl SqlStatementSplitter {
 
     pub fn finish(mut self) -> Vec<String> {
         let mut statements = Vec::new();
+        if self.pending_mysql_line_comment_dashes {
+            self.in_line_comment = true;
+            self.pending_mysql_line_comment_dashes = false;
+        }
         let trimmed = self.buffer.trim();
         let last_line = trimmed.rsplit('\n').next().unwrap_or(trimmed).trim();
         if self.options.profile.supports_custom_delimiter_commands && parse_delimiter_command(last_line).is_some() {
@@ -564,6 +585,7 @@ impl SqlStatementSplitter {
         self.buffer.clear();
         self.postgres_dollar_quoted_routine = false;
         self.previous = None;
+        self.pending_mysql_line_comment_dashes = false;
     }
 
     fn on_delimiter_line(&self) -> bool {
@@ -2681,6 +2703,7 @@ mod tests {
         let mysql_profile = SqlDialectProfile::mysql();
         assert!(dash_dash_starts_line_comment(mysql_profile, Some(' ')));
         assert!(dash_dash_starts_line_comment(mysql_profile, Some('\n')));
+        assert!(dash_dash_starts_line_comment(mysql_profile, Some('\u{1}')));
         assert!(dash_dash_starts_line_comment(mysql_profile, None));
         assert!(!dash_dash_starts_line_comment(mysql_profile, Some('1')));
 
@@ -2697,6 +2720,22 @@ mod tests {
         assert_eq!(splitter.push_chunk("SELECT 5-"), Vec::<String>::new());
         assert_eq!(splitter.push_chunk("-1;"), vec!["SELECT 5--1"]);
         assert_eq!(splitter.finish(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn mysql_complete_dash_dash_sequence_waits_for_the_next_chunk() {
+        let mut splitter = SqlStatementSplitter::with_options(SqlParsingOptions::mysql_compatible());
+
+        assert_eq!(splitter.push_chunk("SELECT 5--"), Vec::<String>::new());
+        assert_eq!(splitter.push_chunk("1;\nSELECT 2;"), vec!["SELECT 5--1", "SELECT 2"]);
+        assert_eq!(splitter.finish(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn mysql_control_character_after_dashes_starts_a_line_comment() {
+        let statements = split_sql_statements_for_database("SELECT 1--\u{1}; hidden\nSELECT 2;", DatabaseType::Mysql);
+
+        assert_eq!(statements, vec!["SELECT 1--\u{1}; hidden\nSELECT 2"]);
     }
 
     #[test]

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -118,6 +118,7 @@ struct SqlDialectProfile {
     supports_go_batch_separator: bool,
     keeps_sqlserver_module_batch_at_cursor: bool,
     preserves_tdsql_proxy_directive: bool,
+    requires_whitespace_after_line_comment_dashes: bool,
 }
 
 impl Default for SqlDialectProfile {
@@ -134,6 +135,7 @@ impl Default for SqlDialectProfile {
             supports_go_batch_separator: false,
             keeps_sqlserver_module_batch_at_cursor: false,
             preserves_tdsql_proxy_directive: false,
+            requires_whitespace_after_line_comment_dashes: false,
         }
     }
 }
@@ -168,7 +170,12 @@ impl SqlDialectProfile {
     }
 
     fn mysql_compatible() -> Self {
-        Self { supports_hash_line_comments: true, supports_mysql_routine_blocks: true, ..Self::default() }
+        Self {
+            supports_hash_line_comments: true,
+            supports_mysql_routine_blocks: true,
+            requires_whitespace_after_line_comment_dashes: true,
+            ..Self::default()
+        }
     }
 
     fn mysql() -> Self {
@@ -288,6 +295,17 @@ fn sql_file_encoding_error() -> String {
         .to_string()
 }
 
+/// Whether a `--` sequence starts a line comment. MySQL (and MySQL-wire-compatible
+/// dialects) requires the second dash to be followed by whitespace or end-of-input —
+/// `5--1` is subtraction (`5 - -1`), not a comment. Other dialects (Postgres, Oracle/DM,
+/// SQL Server, ...) treat `--` as a comment opener unconditionally.
+fn dash_dash_starts_line_comment(profile: SqlDialectProfile, char_after_dashes: Option<char>) -> bool {
+    if !profile.requires_whitespace_after_line_comment_dashes {
+        return true;
+    }
+    char_after_dashes.is_none_or(|ch| ch.is_whitespace())
+}
+
 #[derive(Default)]
 pub struct SqlStatementSplitter {
     buffer: String,
@@ -357,7 +375,8 @@ impl SqlStatementSplitter {
             }
 
             if !self.in_single_quote && !self.in_double_quote && !self.in_backtick {
-                if self.previous == Some('-') && ch == '-' {
+                if self.previous == Some('-') && ch == '-' && dash_dash_starts_line_comment(self.options.profile, next)
+                {
                     self.in_line_comment = true;
                     self.buffer.push(ch);
                     self.previous = Some(ch);
@@ -366,13 +385,6 @@ impl SqlStatementSplitter {
                 }
                 if self.previous == Some('/') && ch == '*' {
                     self.in_block_comment = true;
-                    self.buffer.push(ch);
-                    self.previous = Some(ch);
-                    i += 1;
-                    continue;
-                }
-                if ch == '-' && next == Some('-') {
-                    self.in_line_comment = true;
                     self.buffer.push(ch);
                     self.previous = Some(ch);
                     i += 1;
@@ -2589,10 +2601,10 @@ mod tests {
     use crate::models::connection::DatabaseType;
 
     use super::{
-        contains_or_fuzzy_match, decode_sql_file_bytes, find_statement_at_cursor_for_database, fuzzy_filter_enabled,
-        fuzzy_like_pattern_with_escape, fuzzy_subsequence_match, optimize_sql_file_import_statements,
-        prepare_sql_file_statement, split_sql_script, split_sql_statement_ranges_with_options,
-        split_sql_statements_for_database, starts_with_executable_sql_keyword,
+        contains_or_fuzzy_match, dash_dash_starts_line_comment, decode_sql_file_bytes,
+        find_statement_at_cursor_for_database, fuzzy_filter_enabled, fuzzy_like_pattern_with_escape,
+        fuzzy_subsequence_match, optimize_sql_file_import_statements, prepare_sql_file_statement, split_sql_script,
+        split_sql_statement_ranges_with_options, split_sql_statements_for_database, starts_with_executable_sql_keyword,
         starts_with_executable_sql_keyword_for_database, SqlDialectProfile, SqlFileStatementAction, SqlParsingOptions,
         SqlStatementSplitter,
     };
@@ -2631,6 +2643,60 @@ mod tests {
     fn mysql_split_skips_comment_only_statement() {
         assert!(split_sql_statements_for_database("-- DBX SQL preview crash reproducer\n\n;", DatabaseType::Mysql)
             .is_empty());
+    }
+
+    #[test]
+    fn mysql_dash_dash_without_trailing_space_is_not_a_comment_per_issue_5382() {
+        // MySQL requires `--` to be followed by whitespace to start a line comment;
+        // `5--1` is subtraction (5 - -1), not a comment.
+        assert_eq!(split_sql_statements_for_database("SELECT 5--1;", DatabaseType::Mysql), vec!["SELECT 5--1"]);
+    }
+
+    #[test]
+    fn mysql_dash_dash_without_trailing_space_does_not_merge_following_statements_per_issue_5382() {
+        let statements = split_sql_statements_for_database(
+            "INSERT INTO t VALUES (1, 5--1);\nINSERT INTO t VALUES (2, 10);",
+            DatabaseType::Mysql,
+        );
+        assert_eq!(statements, vec!["INSERT INTO t VALUES (1, 5--1)", "INSERT INTO t VALUES (2, 10)"]);
+    }
+
+    #[test]
+    fn mysql_dash_dash_with_trailing_space_still_starts_a_line_comment() {
+        // The comment text itself is preserved verbatim in the following statement's
+        // buffer (comments are never stripped, just protected from delimiter parsing) —
+        // this only asserts the embedded `;` inside the comment doesn't split early.
+        let statements = split_sql_statements_for_database(
+            "INSERT INTO t VALUES (1); -- trailing comment; with semicolon\nINSERT INTO t VALUES (2);",
+            DatabaseType::Mysql,
+        );
+        assert_eq!(
+            statements,
+            vec!["INSERT INTO t VALUES (1)", "-- trailing comment; with semicolon\nINSERT INTO t VALUES (2)"]
+        );
+    }
+
+    #[test]
+    fn dash_dash_requires_space_only_for_mysql_compatible_profiles() {
+        let mysql_profile = SqlDialectProfile::mysql();
+        assert!(dash_dash_starts_line_comment(mysql_profile, Some(' ')));
+        assert!(dash_dash_starts_line_comment(mysql_profile, Some('\n')));
+        assert!(dash_dash_starts_line_comment(mysql_profile, None));
+        assert!(!dash_dash_starts_line_comment(mysql_profile, Some('1')));
+
+        // Postgres, Oracle/DM, SQL Server, ... treat `--` as a comment opener unconditionally.
+        let default_profile = SqlDialectProfile::default();
+        assert!(dash_dash_starts_line_comment(default_profile, Some('1')));
+        assert!(dash_dash_starts_line_comment(default_profile, None));
+    }
+
+    #[test]
+    fn mysql_dash_dash_opener_without_space_can_span_chunks() {
+        let mut splitter = SqlStatementSplitter::with_options(SqlParsingOptions::mysql_compatible());
+
+        assert_eq!(splitter.push_chunk("SELECT 5-"), Vec::<String>::new());
+        assert_eq!(splitter.push_chunk("-1;"), vec!["SELECT 5--1"]);
+        assert_eq!(splitter.finish(), Vec::<String>::new());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5382 — specifically the second bug described in the issue body: running a `.sql` script/file with `--` comments doesn't execute correctly, while pasting the same SQL into the query editor works fine.

(The title bug in #5382 — foreign keys/triggers tab not refreshing until manual refresh — was already fixed upstream by `5325c4263`/`7be11f54c`/`560087256` before this PR; I verified that separately and left it alone here.)

## Root cause

MySQL requires the second dash of a `--` comment opener to be followed by whitespace (or end of input) — `5--1` is subtraction (`5 - -1`), not a comment. DBX's `SqlStatementSplitter` (used by both "Run Script" and "Execute SQL File") treated any `--` as a comment opener unconditionally, with no dialect check. So a script like:

```sql
INSERT INTO t VALUES (1, 5--1);
INSERT INTO t VALUES (2, 10);
```

had its first statement's terminating `;` swallowed into the (wrongly detected) comment, silently merging both statements into one multi-statement chunk sent to the driver in a single round trip — under-reporting the statement/row counts in the execution progress UI (3 statements / 1 affected row instead of 4 / 2), and would hard-fail with a syntax error on any connection where multi-statement execution isn't enabled.

The query editor's single-statement execute path sends raw SQL text straight to the server without client-side splitting, so it was never affected — matching the reporter's "works pasted into the editor, fails as a script" observation.

## Fix

Added a `requires_whitespace_after_line_comment_dashes` flag to `SqlDialectProfile`, set only for MySQL-compatible dialects (MySQL, Doris, StarRocks, ManticoreSearch, Goldendb). The splitter now only starts a line comment on `--` when the following character is whitespace or end-of-input, for dialects that require it. Postgres, Oracle/DM, SQL Server, etc. are unaffected — they already treat `--` as an unconditional comment opener, matching their own grammar.

## Test plan

- [x] New unit tests in `crates/dbx-core/src/sql.rs`: `5--1` is not treated as a comment for MySQL, doesn't merge adjacent statements, existing `-- comment` (with space) behavior is unchanged, non-MySQL dialects are unaffected, and the no-space opener correctly handles chunk-boundary splitting.
- [x] `cargo test -p dbx-core --lib sql::` — 865 passed, 0 failed.
- [x] `cargo clippy -p dbx-core --lib -- -D warnings` — clean.
- [x] Manual end-to-end repro against a real local MySQL 8.0 instance via "Execute SQL File": before the fix, a script with `INSERT ... VALUES (1, 5--1); INSERT ...;` reported 3 statements / 1 affected row; after the fix, 4 statements / 2 affected rows, matching the source file's actual statement count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)