### PR TITLE
Fix：避免达梦连接初始化持续阻塞

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -20,6 +20,7 @@ import com.dbx.agent.TableInfo;
 import com.dbx.agent.TriggerInfo;
 import java.io.PrintStream;
 import java.io.Reader;
+import java.net.SocketTimeoutException;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
@@ -40,7 +41,9 @@ import java.sql.Types;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -50,6 +53,7 @@ import java.util.Set;
 public final class DamengAgent extends AbstractJdbcAgent {
     private static final String AGENT_VERSION = "9999.06.04.1-fix-default";
     private static final int DBMS_OUTPUT_ENABLE_TIMEOUT_SECS = 5;
+    private static final int DBMS_OUTPUT_ENABLE_NETWORK_TIMEOUT_MILLIS = 5_000;
     private static final String DAMENG_CLASSIFIED_OBJECT_TYPE_SQL =
         "CASE WHEN o.OBJECT_TYPE = 'MATERIALIZED VIEW' OR (o.OBJECT_TYPE = 'VIEW' AND mv.MVIEW_NAME IS NOT NULL) "
             + "THEN 'MATERIALIZED_VIEW' ELSE o.OBJECT_TYPE END";
@@ -81,6 +85,7 @@ public final class DamengAgent extends AbstractJdbcAgent {
         ) mv ON mv.OWNER = o.OWNER AND mv.MVIEW_NAME = o.OBJECT_NAME
         """.stripIndent().trim();
     private String connectedUsername;
+    private volatile boolean dbmsOutputInitializationSupported = true;
 
     @Override
     protected String driverClass() {
@@ -111,14 +116,80 @@ public final class DamengAgent extends AbstractJdbcAgent {
 
     @Override
     protected void afterPhysicalConnect(ConnectParams params, Connection connection) throws SQLException {
+        if (!dbmsOutputInitializationSupported) {
+            return;
+        }
+
+        Integer originalNetworkTimeout = applyDbmsOutputNetworkTimeout(connection);
+        SQLException setupError = null;
         try (Statement statement = connection.createStatement()) {
             statement.setQueryTimeout(DBMS_OUTPUT_ENABLE_TIMEOUT_SECS);
             statement.execute("BEGIN DBMS_OUTPUT.ENABLE(1000000); END;");
         } catch (SQLException error) {
-            if (!isIgnorableDbmsOutputError(error)) {
-                throw error;
+            setupError = error;
+        }
+
+        boolean setupTimedOut = setupError != null && isTimeoutError(setupError);
+        if (originalNetworkTimeout != null && !setupTimedOut) {
+            try {
+                connection.setNetworkTimeout(Runnable::run, originalNetworkTimeout);
+            } catch (SQLException restoreError) {
+                dbmsOutputInitializationSupported = false;
+                if (setupError != null) {
+                    restoreError.addSuppressed(setupError);
+                }
+                throw restoreError;
             }
         }
+
+        if (setupError == null) {
+            return;
+        }
+        if (setupTimedOut) {
+            // Force Hikari to discard this connection. Its retry uses the same agent
+            // instance and skips optional DBMS_OUTPUT initialization.
+            dbmsOutputInitializationSupported = false;
+            throw setupError;
+        }
+        if (isIgnorableDbmsOutputError(setupError)) {
+            dbmsOutputInitializationSupported = false;
+            return;
+        }
+        throw setupError;
+    }
+
+    private static Integer applyDbmsOutputNetworkTimeout(Connection connection) throws SQLException {
+        try {
+            int originalNetworkTimeout = connection.getNetworkTimeout();
+            connection.setNetworkTimeout(Runnable::run, DBMS_OUTPUT_ENABLE_NETWORK_TIMEOUT_MILLIS);
+            return originalNetworkTimeout;
+        } catch (SQLFeatureNotSupportedException | AbstractMethodError | UnsupportedOperationException ignored) {
+            return null;
+        }
+    }
+
+    private static boolean isTimeoutError(Throwable error) {
+        return isTimeoutError(error, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static boolean isTimeoutError(Throwable error, Set<Throwable> visited) {
+        if (error == null || !visited.add(error)) {
+            return false;
+        }
+        if (error instanceof SQLTimeoutException || error instanceof SocketTimeoutException) {
+            return true;
+        }
+        String message = error.getMessage();
+        if (message != null) {
+            String normalized = message.toLowerCase(Locale.ROOT);
+            if (normalized.contains("timeout") || normalized.contains("timed out") || normalized.contains("超时")) {
+                return true;
+            }
+        }
+        if (error instanceof SQLException sqlError && isTimeoutError(sqlError.getNextException(), visited)) {
+            return true;
+        }
+        return isTimeoutError(error.getCause(), visited);
     }
 
     private static boolean isIgnorableDbmsOutputError(SQLException error) {

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentTest.java
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.net.SocketTimeoutException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -63,36 +63,49 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
     void physicalConnectionsEnableDbmsOutputWithoutChangingUserSql() throws Exception {
         List<String> executedSql = new ArrayList<>();
         List<Integer> queryTimeouts = new ArrayList<>();
+        List<Integer> networkTimeouts = new ArrayList<>();
         DamengAgent agent = new DamengAgent();
 
-        agent.afterPhysicalConnect(null, printMessageConnection(null, executedSql, queryTimeouts));
+        agent.afterPhysicalConnect(null, printMessageConnection(null, executedSql, queryTimeouts, networkTimeouts));
 
         assertEquals(List.of(5), queryTimeouts);
+        assertEquals(List.of(5_000, 0), networkTimeouts);
         assertEquals(List.of("BEGIN DBMS_OUTPUT.ENABLE(1000000); END;"), executedSql);
     }
 
     @Test
     void physicalConnectionsIgnoreUnsupportedOrRestrictedDbmsOutput() {
-        DamengAgent agent = new DamengAgent();
-
-        assertDoesNotThrow(() -> agent.afterPhysicalConnect(
+        assertDoesNotThrow(() -> new DamengAgent().afterPhysicalConnect(
             null,
             failingDbmsOutputConnection(new SQLFeatureNotSupportedException("unsupported", "0A000"))
         ));
-        assertDoesNotThrow(() -> agent.afterPhysicalConnect(
+        assertDoesNotThrow(() -> new DamengAgent().afterPhysicalConnect(
             null,
             failingDbmsOutputConnection(new SQLException("permission denied", "42000"))
         ));
     }
 
     @Test
-    void physicalConnectionsIgnoreTimedOutDbmsOutputInitialization() {
+    void physicalConnectionsDisableDbmsOutputAfterInitializationTimeout() {
         DamengAgent agent = new DamengAgent();
+        SQLException timeout = new SQLException("network communication failed");
+        timeout.initCause(new SocketTimeoutException("Read timed out"));
+        List<String> retrySql = new ArrayList<>();
+        List<Integer> networkTimeouts = new ArrayList<>();
 
+        assertSame(timeout, assertThrows(
+            SQLException.class,
+            () -> agent.afterPhysicalConnect(
+                null,
+                statementConnection(null, new ArrayList<>(), new ArrayList<>(), networkTimeouts, timeout)
+            )
+        ));
+        assertEquals(List.of(5_000), networkTimeouts);
         assertDoesNotThrow(() -> agent.afterPhysicalConnect(
             null,
-            failingDbmsOutputConnection(new SQLTimeoutException("DBMS_OUTPUT enable timed out"))
+            printMessageConnection(null, retrySql)
         ));
+        assertTrue(retrySql.isEmpty());
     }
 
     @Test
@@ -382,17 +395,27 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
         List<String> executedSql,
         List<Integer> queryTimeouts
     ) {
-        return statementConnection(printMessage, executedSql, queryTimeouts, null);
+        return printMessageConnection(printMessage, executedSql, queryTimeouts, new ArrayList<>());
+    }
+
+    private static Connection printMessageConnection(
+        String printMessage,
+        List<String> executedSql,
+        List<Integer> queryTimeouts,
+        List<Integer> networkTimeouts
+    ) {
+        return statementConnection(printMessage, executedSql, queryTimeouts, networkTimeouts, null);
     }
 
     private static Connection failingDbmsOutputConnection(SQLException failure) {
-        return statementConnection(null, new ArrayList<>(), new ArrayList<>(), failure);
+        return statementConnection(null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), failure);
     }
 
     private static Connection statementConnection(
         String printMessage,
         List<String> executedSql,
         List<Integer> queryTimeouts,
+        List<Integer> networkTimeouts,
         SQLException executeFailure
     ) {
         InvocationHandler statementHandler = (Object unused, Method method, Object[] args) -> {
@@ -420,10 +443,17 @@ class DamengAgentTest extends JdbcFakeExecutionBehaviorTest {
             statementHandler
         );
         InvocationHandler connectionHandler = (Object unused, Method method, Object[] args) -> {
-            if (method.getName().equals("createStatement")) {
-                return statement;
+            switch (method.getName()) {
+                case "createStatement":
+                    return statement;
+                case "getNetworkTimeout":
+                    return 0;
+                case "setNetworkTimeout":
+                    networkTimeouts.add((Integer) args[1]);
+                    return null;
+                default:
+                    return defaultValue(method.getReturnType());
             }
-            return defaultValue(method.getReturnType());
         };
         return (Connection) Proxy.newProxyInstance(
             DamengAgentTest.class.getClassLoader(),


### PR DESCRIPTION
## 问题

达梦连接在“测试连接”成功后，正式连接仍可能等待约 30 秒并报 `Agent RPC call timed out at connect`。

连接建立后会同步执行可选的 `DBMS_OUTPUT.ENABLE`。现有 `Statement.setQueryTimeout(5)` 依赖服务端或驱动主动响应，在部分达梦版本和环境中不能中断底层 Socket 读取，导致连接初始化持续占用 Agent RPC。

## 修复

- 执行 `DBMS_OUTPUT.ENABLE` 时临时设置 5 秒 JDBC 网络超时，客户端可主动终止阻塞读取
- 初始化超时后保留网络超时用于关闭异常连接，并让连接池丢弃该物理连接
- 同一 Agent 后续重试跳过可选的 `DBMS_OUTPUT` 初始化，避免再次阻塞正式连接
- 初始化成功或普通可降级错误时恢复原网络超时，保持正常长查询行为
- 覆盖普通 `SQLException` 包装 `SocketTimeoutException`、网络超时恢复及重试降级路径

## 验证

- `./gradlew :common:test :dameng:test :dameng:shadowJar`
- `python3 scripts/validate_agents.py`
- 真实 DM8 `8.1.3.12` + JDBC `8.1.5.45`：正式连接、Schema 展开和普通查询正常
- 真实 DM7 `7.1.7.108`：正式连接和 Schema 展开正常
- `DBMS_OUTPUT.PUT_LINE` 仍可返回 `Message` 结果

Fixes #6028
