### PR TITLE
Fix：补全离线下载页的原生驱动列表

### DIFF
--- a/docs/lib/agentRegistry.test.ts
+++ b/docs/lib/agentRegistry.test.ts
@@ -151,13 +151,16 @@ test("DuckDB native tar.zst packages appear in the native catalog", () => {
     },
   ]);
 
-  assert.deepEqual(entries.map(({ key, platformKey, filename }) => ({ key, platformKey, filename })), [
-    {
-      key: "duckdb",
-      platformKey: "macos-aarch64",
-      filename: "dbx-agent-duckdb-0.1.0-macos-aarch64.tar.zst",
-    },
-  ]);
+  assert.deepEqual(
+    entries.map(({ key, platformKey, filename }) => ({ key, platformKey, filename })),
+    [
+      {
+        key: "duckdb",
+        platformKey: "macos-aarch64",
+        filename: "dbx-agent-duckdb-0.1.0-macos-aarch64.tar.zst",
+      },
+    ],
+  );
 });
 
 test("RabbitMQ native tar.zst packages appear in the native catalog", () => {
@@ -169,12 +172,32 @@ test("RabbitMQ native tar.zst packages appear in the native catalog", () => {
     },
   ]);
 
-  assert.deepEqual(entries.map(({ key, platformKey, filename }) => ({ key, platformKey, filename })), [
-    {
-      key: "rabbitmq",
-      platformKey: "windows-x64",
-      filename: "dbx-agent-rabbitmq-0.1.1-windows-x64.tar.zst",
-    },
-  ]);
+  assert.deepEqual(
+    entries.map(({ key, platformKey, filename }) => ({ key, platformKey, filename })),
+    [
+      {
+        key: "rabbitmq",
+        platformKey: "windows-x64",
+        filename: "dbx-agent-rabbitmq-0.1.1-windows-x64.tar.zst",
+      },
+    ],
+  );
   assert.equal(entries[0]?.label, "RabbitMQ");
+});
+
+test("all current native-only agent packages appear in the native catalog", () => {
+  const nativeKeys = ["cassandra", "duckdb", "hive", "iotdb", "kingbase", "neo4j", "oracle", "rabbitmq", "rocketmq", "tdengine", "vastbase", "xugu", "zookeeper"];
+  const entries = buildNativeAgentEntries(
+    nativeKeys.map((key) => ({
+      name: `dbx-agent-${key}-${driverVersions[key as keyof typeof driverVersions]}-macos-aarch64.tar.zst`,
+      browser_download_url: `https://example.com/dbx-agent-${key}-macos-aarch64.tar.zst`,
+      size: 4096,
+    })),
+  );
+
+  assert.deepEqual(entries.map(({ key }) => key).sort(), nativeKeys);
+  assert.equal(entries.find(({ key }) => key === "cassandra")?.label, "Apache Cassandra");
+  assert.equal(entries.find(({ key }) => key === "hive")?.label, "Apache Hive");
+  assert.equal(entries.find(({ key }) => key === "rocketmq")?.label, "Apache RocketMQ");
+  assert.equal(entries.find(({ key }) => key === "zookeeper")?.label, "Apache ZooKeeper");
 });

--- a/docs/lib/agentRegistry.ts
+++ b/docs/lib/agentRegistry.ts
@@ -91,9 +91,6 @@ const GITHUB_RELEASE_DOWNLOAD_PREFIX = "https://github.com/t8y2/dbx/releases/dow
 const CNB_RELEASE_DOWNLOAD_PREFIX = "https://cnb.cool/dbxio.com/dbx/-/releases/download/";
 const MIN_APP_VERSION = "0.6.0";
 const driverVersionMap = driverVersions as Record<string, string>;
-const nativeDriverKeys = ["duckdb", "oracle", "kingbase", "xugu", "rabbitmq"] as const;
-const nativeDriverKeySet = new Set<string>(nativeDriverKeys);
-const nativeDriverKeyPattern = nativeDriverKeys.join("|");
 
 const platformLabels: Record<string, string> = {
   "macos-aarch64": "macOS (Apple Silicon)",
@@ -107,7 +104,7 @@ const platformLabels: Record<string, string> = {
 const driverLabels: Record<string, string> = {
   access: "Microsoft Access",
   bigquery: "BigQuery",
-  cassandra: "Cassandra",
+  cassandra: "Apache Cassandra",
   dameng: "Dameng",
   databend: "Databend",
   databricks: "Databricks",
@@ -121,7 +118,7 @@ const driverLabels: Record<string, string> = {
   goldendb: "GoldenDB",
   h2: "H2",
   highgo: "HighGo",
-  hive: "Hive",
+  hive: "Apache Hive",
   informix: "Informix",
   iotdb: "Apache IoTDB",
   iris: "InterSystems IRIS",
@@ -132,6 +129,7 @@ const driverLabels: Record<string, string> = {
   "oceanbase-oracle": "OceanBase Oracle Mode",
   oracle: "Oracle",
   rabbitmq: "RabbitMQ",
+  rocketmq: "Apache RocketMQ",
   saphana: "SAP HANA",
   snowflake: "Snowflake",
   sundb: "SunDB",
@@ -143,11 +141,14 @@ const driverLabels: Record<string, string> = {
   vertica: "Vertica",
   xugu: "虚谷 XuguDB",
   yashandb: "YashanDB",
-  zookeeper: "ZooKeeper",
+  zookeeper: "Apache ZooKeeper",
 };
 
 const currentDriverKeys = Object.keys(driverVersionMap).sort((a, b) => labelForDriver(a).localeCompare(labelForDriver(b)));
-const currentJavaDriverKeys = currentDriverKeys.filter((key) => !nativeDriverKeySet.has(key));
+const currentDriverKeyPattern = [...currentDriverKeys]
+  .sort((a, b) => b.length - a.length)
+  .map(escapeRegExp)
+  .join("|");
 
 const jreVersions: Record<string, string> = {
   "21": "21",
@@ -155,6 +156,10 @@ const jreVersions: Record<string, string> = {
 
 function labelForDriver(key: string): string {
   return driverLabels[key] ?? key.replace(/-/g, " ");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function assetInfo(asset: GitHubReleaseAsset): ArtifactInfo {
@@ -281,7 +286,7 @@ export function buildJreEntries(assets: GitHubReleaseAsset[]): JreDisplayEntry[]
 export function buildDriverEntries(assets: GitHubReleaseAsset[]): DriverDisplayEntry[] {
   const byName = assetMap(assets);
 
-  return currentJavaDriverKeys
+  return currentDriverKeys
     .map((key) => {
       const version = driverVersionMap[key] ?? "";
       const asset = byName.get(`dbx-agent-${key}-${version}.tar.zst`) ?? byName.get(`dbx-agent-${key}-${version}.zip`) ?? byName.get(`dbx-agent-${key}-${version}.jar`) ?? byName.get(`dbx-agent-${key}.jar`);
@@ -303,7 +308,7 @@ function buildDriverEntriesFromRegistry(registry: AgentRegistry): DriverDisplayE
   return Object.entries(registry.drivers ?? {})
     .map(([key, driver]) => {
       const jar = driver.jar;
-      if (nativeDriverKeySet.has(key) || !jar?.url || jar.size <= 0) return null;
+      if (!jar?.url || jar.size <= 0) return null;
 
       return {
         key,
@@ -323,9 +328,9 @@ export function buildNativeAgentEntries(assets: GitHubReleaseAsset[]): NativeAge
   const platforms = "macos-aarch64|macos-x64|linux-aarch64|linux-x64|windows-aarch64|windows-x64";
 
   for (const asset of assets) {
-    const packageMatch = new RegExp(`^dbx-agent-(${nativeDriverKeyPattern})-(.+)-(${platforms})\\.(?:tar\\.zst|zip)$`).exec(asset.name);
-    const versionedMatch = new RegExp(`^dbx-agent-(${nativeDriverKeyPattern})-(.+)-(${platforms})(?:\\.exe)?$`).exec(asset.name);
-    const legacyMatch = new RegExp(`^dbx-agent-(${nativeDriverKeyPattern})-(${platforms})(?:\\.exe)?$`).exec(asset.name);
+    const packageMatch = new RegExp(`^dbx-agent-(${currentDriverKeyPattern})-(.+)-(${platforms})\\.(?:tar\\.zst|zip)$`).exec(asset.name);
+    const versionedMatch = new RegExp(`^dbx-agent-(${currentDriverKeyPattern})-(.+)-(${platforms})(?:\\.exe)?$`).exec(asset.name);
+    const legacyMatch = new RegExp(`^dbx-agent-(${currentDriverKeyPattern})-(${platforms})(?:\\.exe)?$`).exec(asset.name);
     const match = packageMatch ?? versionedMatch ?? legacyMatch;
     if (!match) continue;
 
@@ -333,7 +338,6 @@ export function buildNativeAgentEntries(assets: GitHubReleaseAsset[]): NativeAge
     const key = match[1];
     const version = legacyMatch ? (driverVersionMap[key] ?? "") : match[2];
     const platformKey = legacyMatch ? match[2] : match[3];
-    if (!nativeDriverKeySet.has(key)) continue;
     const entryKey = `${key}:${platformKey}`;
     const existing = entries.get(entryKey);
     if (existing?.packaged && !packaged) continue;


### PR DESCRIPTION
## 问题

离线驱动下载页通过硬编码的 `nativeDriverKeys` 识别原生 Agent，目前只包含 DuckDB、Oracle、KingBase、XuguDB 和 RabbitMQ。

因此当前发布版中的以下 7 类单驱动包不会出现在下载页：

- Apache Cassandra
- Apache Hive
- Apache IoTDB
- Neo4j
- Apache RocketMQ
- TDengine
- Vastbase

最新 `main` 已将 ZooKeeper 改为原生 Agent，如果继续使用该硬编码，下一次发布还会漏掉 Apache ZooKeeper。

全量离线包实际包含这些驱动，本问题只影响下载页的单驱动入口。

## 修复

- 移除原生驱动类型硬编码
- Java 驱动列表按实际 JAR 资产判断
- 原生驱动列表根据 `agents/versions.json` 中的已知驱动键和平台文件名自动识别
- 驱动键按长度排序并转义后生成正则，兼容带连字符的驱动名称
- 统一 Cassandra、Hive、RocketMQ、ZooKeeper 的展示名称
- 增加当前 13 类原生 Agent 的回归测试

## 验证

- 使用当前线上注册表验证：33 个 Java 驱动、12 类原生驱动、72 个平台资产，合并后覆盖全部 45 个已发布驱动
- 最新 `main` 的 Apache ZooKeeper 原生资产测试通过
- `pnpm exec vitest run docs/lib/agentRegistry.test.ts`
- `pnpm exec oxlint docs/lib/agentRegistry.ts docs/lib/agentRegistry.test.ts`
- `pnpm exec oxfmt docs/lib/agentRegistry.ts docs/lib/agentRegistry.test.ts`
- `git diff --check`
