### PR TITLE
fix(editor): keep scroll position when closing a view's DDL dialog

### DIFF
--- a/apps/desktop/src/components/objects/DdlViewDialog.vue
+++ b/apps/desktop/src/components/objects/DdlViewDialog.vue
@@ -51,6 +51,10 @@ const ddlEditorContainer = ref<HTMLDivElement>();
 const ddlSearchPanelRef = ref<InstanceType<typeof EditorSearchPanel>>();
 const ddlEditorView = shallowRef<EditorView | null>(null);
 
+// The CodeMirror editor (if any) that was focused when this dialog opened, so focus can be
+// restored to it on close. Not a ref: read/written outside of render, never needs reactivity.
+let editorRootToRestoreFocus: HTMLElement | null = null;
+
 async function loadDdl(force = false) {
   ddlError.value = "";
   ddlLoading.value = true;
@@ -81,11 +85,33 @@ watch(
   () => props.open,
   async (open) => {
     if (!open) return;
+    const active = document.activeElement;
+    editorRootToRestoreFocus = active instanceof HTMLElement ? active.closest(".cm-editor") : null;
     ddlContent.value = "";
     await loadDdl();
   },
   { immediate: true },
 );
+
+/**
+ * Restores focus through CodeMirror's own `EditorView.focus()` instead of the browser default.
+ *
+ * Radix's default close-auto-focus calls the plain DOM `.focus()` on whatever was focused before
+ * the dialog opened. In WebKit (the desktop app's webview on macOS), refocusing a contenteditable
+ * this way resets its caret to the very start of the document; CodeMirror then treats that as a
+ * real selection change and scrolls to follow it, snapping a long query editor to the top (#6067).
+ * `EditorView.focus()` avoids this by suppressing its own selection observer while it restores the
+ * DOM selection to match its actual (unmoved) internal state.
+ */
+function onDdlDialogCloseAutoFocus(event: Event) {
+  const target = editorRootToRestoreFocus;
+  editorRootToRestoreFocus = null;
+  if (!target || !target.isConnected) return;
+  event.preventDefault();
+  void import("@codemirror/view").then(({ EditorView }) => {
+    EditorView.findFromDOM(target)?.focus();
+  });
+}
 
 /**
  * Creates a lightweight read-only CodeMirror editor inside the dialog.
@@ -198,7 +224,7 @@ function onClose() {
 
 <template>
   <Dialog :open="props.open" @update:open="onClose">
-    <DialogContent class="sm:max-w-190">
+    <DialogContent class="sm:max-w-190" @close-auto-focus="onDdlDialogCloseAutoFocus">
       <DialogHeader>
         <DialogTitle>DDL - {{ props.tableName }}</DialogTitle>
       </DialogHeader>


### PR DESCRIPTION
## Problem

Cmd/Ctrl+click on a view name inside the SQL editor opens `DdlViewDialog` to preview its DDL (`onClickTable` in `App.vue`). Closing the dialog snaps a long, scrolled-down query editor back to the very top, losing the user's scroll position, cursor, and selection — reported in #6067 with a stable, every-time repro.

## Root cause

Closing the dialog lets Radix restore focus to whatever element was focused before it opened, via a plain native `element.focus({ preventScroll: true })`. That's normally safe, but in **WebKit** (the actual renderer of the desktop app's webview on macOS) refocusing a `contenteditable` this way resets its native caret to the very start of the element. CodeMirror's DOM observer picks that up as a genuine selection change and scrolls to follow it — snapping the editor to the top.

This only reproduces in WebKit, not Chromium, which is why the codebase already has an established pattern of manually guarding focus restoration in several other Popover/Dialog/DropdownMenu usages (`@close-auto-focus.prevent` in `TemporalCellEditor.vue`, `AiAssistant.vue`, `QueryChart.vue`, `NacosAdminConsole.vue`).

## Fix

`DdlViewDialog.vue`:
- Record the `.cm-editor` ancestor of `document.activeElement` (if any) when the dialog opens.
- On `@close-auto-focus`, if that editor is still in the DOM, call `event.preventDefault()` and restore focus through CodeMirror's own `EditorView.focus()` (found via `EditorView.findFromDOM`) instead of letting the browser do it. `EditorView.focus()` suppresses CodeMirror's selection observer while it restores the DOM selection to match its actual (unmoved) internal state, which avoids the WebKit quirk entirely.
- When the dialog was opened from somewhere other than the query editor (e.g. no `.cm-editor` ancestor), the handler is a no-op and Radix's default behavior is unchanged — no regression there.

## Testing

Reproduced and verified with real browser automation (Playwright) against the actual dev app, connected to a real local MySQL 8.4 database with a genuine view, since this bug does not reproduce in jsdom/happy-dom (not a real browser engine) nor in Chromium (different focus/selection semantics than WebKit):

- **Chromium**: did not reproduce the bug at all (confirms this needed WebKit specifically, matching the desktop app's actual macOS webview).
- **WebKit** (Playwright's webkit engine): reliably reproduced pre-fix (`scrollTop` goes from `822` → `0` after closing via the Close button, and identically via Escape), and confirmed fixed post-fix (`scrollTop` unchanged across close, verified with both the Close button and Escape key).
- To rule out any measurement artifact, I reverted the fix in place, re-captured the broken behavior with screenshots, then reapplied the fix and re-captured the fixed behavior — a genuine A/B comparison, not two independently styled runs.
- `pnpm typecheck` is clean.
- Full `pnpm test`: 9069 passed, 1 pre-existing unrelated failure (`databaseUserAdmin.test.ts`, about `mysqlRenameUserHostSql`) that upstream's `3db119ca4` already fixes independently of this PR.

Fixes #6067