### PR TITLE
fix(data-grid): 支持格式化 Mongo Shell 日期值

### DIFF
--- a/apps/desktop/src/lib/dataGrid/columnFormatter.ts
+++ b/apps/desktop/src/lib/dataGrid/columnFormatter.ts
@@ -263,15 +263,19 @@ function resolveDateTimeValue(value: string | number, unit: DateTimeFormatterUni
     if (!trimmed) {
       return undefined;
     }
-    const normalized = unwrapMongoShellDate(trimmed) ?? trimmed;
-    const timestamp = parseTimestampMilliseconds(normalized, unit);
+    const mongoShellDate = unwrapMongoShellDate(trimmed);
+    if (mongoShellDate !== undefined) {
+      return parseStrictDateTimeString(mongoShellDate);
+    }
+
+    const timestamp = parseTimestampMilliseconds(trimmed, unit);
     if (timestamp !== undefined) {
       const parsedTimestamp = dayjs(timestamp);
       return parsedTimestamp.isValid() ? parsedTimestamp : undefined;
     }
-    if (isIntegerString(normalized)) return undefined;
+    if (isIntegerString(trimmed)) return undefined;
 
-    return parseStrictDateTimeString(normalized);
+    return parseStrictDateTimeString(trimmed);
   }
 
   const timestamp = parseTimestampMilliseconds(value, unit);

--- a/apps/desktop/src/lib/dataGrid/columnFormatter.ts
+++ b/apps/desktop/src/lib/dataGrid/columnFormatter.ts
@@ -51,6 +51,7 @@ const STRICT_LOCAL_DATETIME_INPUT_PATTERNS = [
 ];
 const ISO_OFFSET_DATETIME_PATTERN = /^(\d{4})([-/])(\d{2})\2(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})$/;
 const FRACTIONAL_LOCAL_DATETIME_PATTERN = /^(\d{4})([-/])(\d{1,2})\2(\d{1,2})([ T])(\d{1,2}):(\d{1,2}):(\d{1,2})\.(\d{1,9})$/;
+const MONGO_SHELL_DATE_PATTERN = /^(?:ISODate|new Date)\(\s*(["'])(.+)\1\s*\)$/;
 
 export interface CustomColumnFormatterConfig {
   id: string;
@@ -262,14 +263,15 @@ function resolveDateTimeValue(value: string | number, unit: DateTimeFormatterUni
     if (!trimmed) {
       return undefined;
     }
-    const timestamp = parseTimestampMilliseconds(trimmed, unit);
+    const normalized = unwrapMongoShellDate(trimmed) ?? trimmed;
+    const timestamp = parseTimestampMilliseconds(normalized, unit);
     if (timestamp !== undefined) {
       const parsedTimestamp = dayjs(timestamp);
       return parsedTimestamp.isValid() ? parsedTimestamp : undefined;
     }
-    if (isIntegerString(trimmed)) return undefined;
+    if (isIntegerString(normalized)) return undefined;
 
-    return parseStrictDateTimeString(trimmed);
+    return parseStrictDateTimeString(normalized);
   }
 
   const timestamp = parseTimestampMilliseconds(value, unit);
@@ -277,6 +279,10 @@ function resolveDateTimeValue(value: string | number, unit: DateTimeFormatterUni
 
   const parsedTimestamp = dayjs(timestamp);
   return parsedTimestamp.isValid() ? parsedTimestamp : undefined;
+}
+
+function unwrapMongoShellDate(value: string): string | undefined {
+  return value.match(MONGO_SHELL_DATE_PATTERN)?.[2];
 }
 
 function normalizeDateTimePattern(pattern: unknown): string {

--- a/packages/app-tests/columnFormatter.test.ts
+++ b/packages/app-tests/columnFormatter.test.ts
@@ -85,6 +85,14 @@ test("formats Oracle timestamp fractional precision in the data grid", () => {
   assert.equal(applyColumnFormatter("2024-02-25 13:02:15.123456", { kind: "datetime", unit: "auto", pattern: "YYYY/MM/DD HH:mm:ss.SSS", timezone: undefined }), "2024/02/25 13:02:15.123");
 });
 
+test("formats Mongo shell dates with the selected pattern and timezone", () => {
+  const formatter: ColumnFormatterConfig = { kind: "datetime", unit: "seconds", pattern: "YYYY-MM-DD HH:mm:ss.SSSZ", timezone: "Asia/Shanghai" };
+
+  assert.equal(applyColumnFormatter('ISODate("2024-06-28T09:15:36.439Z")', formatter), "2024-06-28 17:15:36.439+08:00");
+  assert.equal(applyColumnFormatter("new Date('2024-06-28T09:15:36.439Z')", formatter), "2024-06-28 17:15:36.439+08:00");
+  assert.equal(applyColumnFormatter('ISODate("not-a-date")', formatter), 'ISODate("not-a-date")');
+});
+
 test("does not treat compact date strings as unix timestamps", () => {
   dayjs.extend(utc);
   dayjs.extend(timezone);

--- a/packages/app-tests/columnFormatter.test.ts
+++ b/packages/app-tests/columnFormatter.test.ts
@@ -85,12 +85,20 @@ test("formats Oracle timestamp fractional precision in the data grid", () => {
   assert.equal(applyColumnFormatter("2024-02-25 13:02:15.123456", { kind: "datetime", unit: "auto", pattern: "YYYY/MM/DD HH:mm:ss.SSS", timezone: undefined }), "2024/02/25 13:02:15.123");
 });
 
-test("formats Mongo shell dates with the selected pattern and timezone", () => {
-  const formatter: ColumnFormatterConfig = { kind: "datetime", unit: "seconds", pattern: "YYYY-MM-DD HH:mm:ss.SSSZ", timezone: "Asia/Shanghai" };
+test("formats only strict Mongo shell date wrappers", () => {
+  for (const unit of ["auto", "seconds", "milliseconds"] as const) {
+    const formatter: ColumnFormatterConfig = { kind: "datetime", unit, pattern: "YYYY-MM-DD HH:mm:ss.SSSZ", timezone: "Asia/Shanghai" };
 
-  assert.equal(applyColumnFormatter('ISODate("2024-06-28T09:15:36.439Z")', formatter), "2024-06-28 17:15:36.439+08:00");
-  assert.equal(applyColumnFormatter("new Date('2024-06-28T09:15:36.439Z')", formatter), "2024-06-28 17:15:36.439+08:00");
-  assert.equal(applyColumnFormatter('ISODate("not-a-date")', formatter), 'ISODate("not-a-date")');
+    assert.equal(applyColumnFormatter('ISODate("2024-06-28T09:15:36.439Z")', formatter), "2024-06-28 17:15:36.439+08:00");
+    assert.equal(applyColumnFormatter("  new Date(  '2024-06-28T09:15:36.439Z'  )  ", formatter), "2024-06-28 17:15:36.439+08:00");
+
+    for (const value of ['ISODate("not-a-date")', "new Date('2024-02-30T09:15:36.439Z')", 'ISODate("1715758200")', "new Date('1715758200001')"]) {
+      assert.equal(applyColumnFormatter(value, formatter), value);
+    }
+  }
+
+  assert.equal(applyColumnFormatter("1715758200", { kind: "datetime", unit: "seconds", pattern: "YYYY-MM-DD HH:mm:ssZ", timezone: "Asia/Shanghai" }), "2024-05-15 15:30:00+08:00");
+  assert.equal(applyColumnFormatter("1715758200001", { kind: "datetime", unit: "milliseconds", pattern: "YYYY-MM-DD HH:mm:ss.SSSZ", timezone: "Asia/Shanghai" }), "2024-05-15 15:30:00.001+08:00");
 });
 
 test("does not treat compact date strings as unix timestamps", () => {


### PR DESCRIPTION
## 问题原因

MongoDB BSON Date 在表格中以 `ISODate("...")` 字符串展示，但现有日期格式器只识别数字时间戳、裸 ISO 日期和本地日期字符串，解析失败后会直接返回原值，因此日期格式与时区设置均不生效。

## 变更内容

- 在通用日期格式器中解包 `ISODate(...)` 和 `new Date(...)`
- 继续复用现有严格日期解析与时区转换逻辑
- 非法 Mongo 日期保持原文展示
- 补充 Mongo Shell 日期格式化回归测试

## 验证

- `pnpm exec vitest run packages/app-tests/columnFormatter.test.ts apps/desktop/src/lib/__tests__/dataGrid/columnFormatter.spec.ts`
- `pnpm exec oxlint apps/desktop/src/lib/dataGrid/columnFormatter.ts packages/app-tests/columnFormatter.test.ts`