### PR TITLE
Fix：修复 ZooKeeper SASL CI 配置读取失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,6 +844,7 @@ jobs:
             user_dbx="dbx-secret";
           };
           EOF
+          chmod 0644 "$jaas_file"
           docker rm -fv "$name" >/dev/null 2>&1 || true
           docker run -d --name "$name" -p 2181:2181 \
             -v "$jaas_file:/conf/server-jaas.conf:ro" \


### PR DESCRIPTION
## 问题

ZooKeeper SASL 集成测试使用 `mktemp` 创建 JAAS 配置，文件默认权限为 `0600`。`zookeeper:3.7.0` 入口脚本启动后会从 root 降权为 `zookeeper` 用户，导致容器内进程无法读取挂载的配置；首次 SASL 连接被重置后服务退出。

该问题已在主干 ZooKeeper Agents job 以及 #6207 的三轮 Agents job 中复现，均失败于 `ZooKeeper SASL DIGEST-MD5 integration test`，Oracle Agent 测试与构建本身已通过。

## 修改

- 挂载 JAAS 配置前设置为 `0644`，允许降权后的容器进程只读访问。
- 不修改 ZooKeeper Agent 或其他业务实现。

## 验证

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- 核对 `zookeeper:3.7.0` 镜像配置及 `/docker-entrypoint.sh`，确认其通过 `gosu zookeeper` 降权运行。
