### PR TITLE
fix(nacos): stop config list divider from flickering on resize

### DIFF
--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -2500,7 +2500,7 @@ onBeforeUnmount(() => {
             </Button>
           </div>
           <div v-if="configError" class="border-b px-3 py-2 text-xs text-destructive">{{ configError }}</div>
-          <div ref="configListViewport" class="min-h-0 flex-1 overflow-auto">
+          <div ref="configListViewport" class="nacos-config-list-viewport min-h-0 flex-1 overflow-auto">
             <div class="w-max min-w-full" :style="{ minWidth: configListMinWidth }">
               <div class="sticky top-0 z-20 grid border-b bg-muted px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground shadow-sm" :style="{ gridTemplateColumns: configListGridTemplate }">
                 <div v-for="(column, columnIndex) in configListColumns" :key="column" class="relative min-w-0" :class="column === 'dataId' ? 'pr-3' : columnIndex === configListColumns.length - 1 ? 'pl-3 pr-10' : 'px-3'">
@@ -3396,5 +3396,9 @@ onBeforeUnmount(() => {
 
 .nacos-admin-splitpanes :deep(.splitpanes__splitter:hover) {
   background: oklch(0.6 0.15 250) !important;
+}
+
+.nacos-config-list-viewport {
+  scrollbar-gutter: stable;
 }
 </style>


### PR DESCRIPTION
## Problem

Fixes #6140. Reporter: after connecting to Nacos and opening a config file, the divider between the config list and the config content panel (and the panel's own scrollbar) flickers rapidly.

## Root cause

`NacosAdminConsole.vue`'s config-list viewport uses a `ResizeObserver` that feeds the container's `clientWidth` into `useNacosConfigListColumnResize`, which fits the column widths to *exactly* match that width (`fitNacosConfigListColumnWidths`). When the vertical scrollbar toggles (its presence changes `clientWidth`), the observer re-fires, columns re-fit to the new width, and the cycle can repeat — the same feedback-loop class already fixed twice in this repo's `DataGrid.vue` (`42a7ecdbe` "prevent scrollbar flicker during sidebar resize", `ca3e3a2a5` "clamp canvas surface width to eliminate horizontal scrollbar flicker").

## Fix

Reserve a stable scrollbar gutter on the config-list viewport (`scrollbar-gutter: stable`), matching the fix already proven for `DataGrid.vue`. This keeps `clientWidth` constant regardless of whether the vertical scrollbar is showing, removing the trigger for the loop.

## Testing

The trigger depends on a real (non-overlay) scrollbar consuming layout space — Windows' classic scrollbar is ~17px, but headless Chromium/WebKit on macOS only reserves ~2px, so I could not visually reproduce the flicker itself in my environment despite building a full real repro (local Nacos 3.1.1 seeded with 60 configs, real `dbx-web` dev backend/frontend, reaching the exact screen from the report).

What I did verify directly:
- `getComputedStyle(viewport).scrollbarGutter` is `"auto"` before the fix and `"stable"` after, confirming the fix takes effect exactly where the loop is triggered.
- All 30 existing Nacos component tests pass.
- `vue-tsc --noEmit` is clean.
- Full suite (`pnpm test`): 948 files / 9071 tests pass, rebased onto latest `main`.

## Breaking changes

None — CSS-only change, reserves scrollbar space up front rather than letting it toggle.