### PR TITLE
fix(elasticsearch): format Kibana-console-style REST requests

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -27,6 +27,7 @@ import { buildSqlInConditionFromPasteSource, insertTextForSqlInCondition } from 
 import { resolveSqlSingleQuoteKeyAction } from "@/lib/sql/sqlQuoteCaret";
 import { convertSqlSelectionCase, type SqlSelectionCaseMode } from "@/lib/sql/sqlSelectionCase";
 import { formatMongoShellText } from "@/lib/mongo/mongoFormatter";
+import { detectAndFormatElasticsearchRequests } from "@/lib/elasticsearch/elasticsearchFormatter";
 import { useConnectionStore, COMPLETION_METADATA_CONCURRENCY } from "@/stores/connectionStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTheme } from "@/composables/useTheme";
@@ -2932,19 +2933,27 @@ async function formatCurrentSql() {
     if (props.databaseType === "mongodb") {
       formatted = formatMongoShellText(source, settingsStore.editorSettings.sqlFormatter);
     } else {
-      const structured = detectAndFormatStructured(source, {
-        indentSize: settingsStore.editorSettings.sqlFormatter.tabWidth,
-        useTabs: settingsStore.editorSettings.sqlFormatter.useTabs,
-      });
-      if (structured.kind === "json" || structured.kind === "xml") {
-        formatted = structured.formatted;
-      } else if (structured.kind === "unsupported") {
-        // Keep invalid structured text untouched — the SQL formatter would
-        // silently corrupt XML-looking content.
+      const esRequest = detectAndFormatElasticsearchRequests(source, props.databaseType, settingsStore.editorSettings.sqlFormatter.tabWidth);
+      if (esRequest.kind === "elasticsearch") {
+        formatted = esRequest.formatted;
+      } else if (esRequest.kind === "unsupported") {
         toast(t("toolbar.formatAutoDetectFailed"), 3000);
         return;
       } else {
-        formatted = await formatSqlForEditing(source, props.formatDialect ?? props.dialect ?? "generic", settingsStore.editorSettings.sqlFormatter);
+        const structured = detectAndFormatStructured(source, {
+          indentSize: settingsStore.editorSettings.sqlFormatter.tabWidth,
+          useTabs: settingsStore.editorSettings.sqlFormatter.useTabs,
+        });
+        if (structured.kind === "json" || structured.kind === "xml") {
+          formatted = structured.formatted;
+        } else if (structured.kind === "unsupported") {
+          // Keep invalid structured text untouched — the SQL formatter would
+          // silently corrupt XML-looking content.
+          toast(t("toolbar.formatAutoDetectFailed"), 3000);
+          return;
+        } else {
+          formatted = await formatSqlForEditing(source, props.formatDialect ?? props.dialect ?? "generic", settingsStore.editorSettings.sqlFormatter);
+        }
       }
     }
     if (view.value !== currentView || currentView.state !== originalState || currentView.state.sliceDoc(from, to) !== source) {

--- a/apps/desktop/src/lib/__tests__/elasticsearch/elasticsearchFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/elasticsearch/elasticsearchFormatter.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { detectAndFormatElasticsearchRequests } from "@/lib/elasticsearch/elasticsearchFormatter";
+
+describe("elasticsearchFormatter", () => {
+  describe("detectAndFormatElasticsearchRequests", () => {
+    it("pretty-prints a single-line GET request with a JSON body", () => {
+      const source = `GET /master_base/_search {"query":{"bool":{"must":[{"term":{"masterId":"47526596395"}}]}}}`;
+      const result = detectAndFormatElasticsearchRequests(source, "elasticsearch", 2);
+      expect(result).toEqual({
+        kind: "elasticsearch",
+        formatted: `GET /master_base/_search
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "term": {
+            "masterId": "47526596395"
+          }
+        }
+      ]
+    }
+  }
+}`,
+      });
+    });
+
+    it("leaves a request with no body as just the method/path line", () => {
+      const result = detectAndFormatElasticsearchRequests("GET /_cat/indices", "elasticsearch", 2);
+      expect(result).toEqual({ kind: "elasticsearch", formatted: "GET /_cat/indices" });
+    });
+
+    it("formats multiple requests separated by a blank line, keeping the separator", () => {
+      const source = `GET /a/_search {"query":{"match_all":{}}}\n\nPOST /b/_refresh`;
+      const result = detectAndFormatElasticsearchRequests(source, "easysearch", 2);
+      expect(result).toEqual({
+        kind: "elasticsearch",
+        formatted: `GET /a/_search\n{\n  "query": {\n    "match_all": {}\n  }\n}\n\nPOST /b/_refresh`,
+      });
+    });
+
+    it("reports unsupported (and keeps caller from touching the text) for an invalid JSON body", () => {
+      const result = detectAndFormatElasticsearchRequests(`GET /a/_search {"query":`, "elasticsearch", 2);
+      expect(result).toEqual({ kind: "unsupported" });
+    });
+
+    it("reports not-elasticsearch for bare JSON with no method/path line", () => {
+      const result = detectAndFormatElasticsearchRequests(`{"query":{"match_all":{}}}`, "elasticsearch", 2);
+      expect(result).toEqual({ kind: "not-elasticsearch" });
+    });
+
+    it("reports not-elasticsearch for non-elasticsearch database types", () => {
+      const source = `GET /master_base/_search {"query":{"match_all":{}}}`;
+      expect(detectAndFormatElasticsearchRequests(source, "mysql", 2)).toEqual({ kind: "not-elasticsearch" });
+      expect(detectAndFormatElasticsearchRequests(source, undefined, 2)).toEqual({ kind: "not-elasticsearch" });
+    });
+
+    it("formats meilisearch requests too", () => {
+      const result = detectAndFormatElasticsearchRequests(`POST /indexes/movies/search {"q":"batman"}`, "meilisearch", 2);
+      expect(result).toEqual({
+        kind: "elasticsearch",
+        formatted: `POST /indexes/movies/search\n{\n  "q": "batman"\n}`,
+      });
+    });
+  });
+});

--- a/apps/desktop/src/lib/elasticsearch/elasticsearchFormatter.ts
+++ b/apps/desktop/src/lib/elasticsearch/elasticsearchFormatter.ts
@@ -1,0 +1,45 @@
+import { formatJsonSource } from "@/lib/common/safeJsonFormat";
+import { elasticsearchRestRequestRanges } from "@/lib/sql/sqlStatementRanges";
+import type { DatabaseType } from "@/types/database";
+
+const ELASTICSEARCH_REQUEST_LINE = /^(GET|POST|PUT|PATCH|DELETE|HEAD)\s+(\S+)/i;
+
+export type ElasticsearchFormatResult = { kind: "elasticsearch"; formatted: string } | { kind: "unsupported" } | { kind: "not-elasticsearch" };
+
+function formatSingleElasticsearchRequest(requestText: string, indentSize: number): string | null {
+  const match = requestText.match(ELASTICSEARCH_REQUEST_LINE);
+  if (!match) return null;
+  const method = match[1].toUpperCase();
+  const rawPath = match[2];
+  const path = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  const body = requestText.slice(match[0].length).trim();
+  if (!body) return `${method} ${path}`;
+  try {
+    return `${method} ${path}\n${formatJsonSource(body, indentSize)}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Formats Kibana-console-style Elasticsearch/Meilisearch REST requests
+ * (`METHOD /path {json body}`, possibly several in one document) by
+ * pretty-printing each request's JSON body and normalizing its method/path
+ * onto its own line. Text between requests (blank lines, comments) is kept
+ * as-is via {@link elasticsearchRestRequestRanges}.
+ */
+export function detectAndFormatElasticsearchRequests(text: string, databaseType: DatabaseType | undefined, indentSize: number): ElasticsearchFormatResult {
+  const ranges = elasticsearchRestRequestRanges(text, databaseType);
+  if (ranges.length === 0) return { kind: "not-elasticsearch" };
+
+  let result = "";
+  let cursor = 0;
+  for (const range of ranges) {
+    const formattedOne = formatSingleElasticsearchRequest(range.sql, indentSize);
+    if (formattedOne === null) return { kind: "unsupported" };
+    result += text.slice(cursor, range.from) + formattedOne;
+    cursor = range.to;
+  }
+  result += text.slice(cursor);
+  return { kind: "elasticsearch", formatted: result };
+}


### PR DESCRIPTION
## Problem

Fixes #6230.

The query editor's Format toolbar action did nothing for Elasticsearch/Meilisearch queries written in Kibana-console style (`METHOD /path {json body}`, e.g. `GET /master_base/_search {"query":{"bool":{"must":[...]}}}`).

Root cause: `QueryEditor.vue`'s `formatCurrentSql()` dispatches by database type, but had no case for this REST-request syntax. It fell through to `detectAndFormatStructured` (which only recognizes text starting with `{`/`[`/XML markers) and then to the generic SQL formatter, which threw a parse error on the non-SQL `GET ...` text. That error is caught by an existing guard (`formatSqlForEditing`, added to avoid corrupting incomplete SQL while typing) that silently returns the original text unchanged — so clicking Format produced no visible error and no change.

## Solution

Added `apps/desktop/src/lib/elasticsearch/elasticsearchFormatter.ts`:
- Reuses the existing `elasticsearchRestRequestRanges` statement splitter (already used for execution/danger-checks) to detect one or more Kibana-console-style requests in the document, handling multi-request documents and preserving separators/comments between them.
- For each request, normalizes the `METHOD /path` onto its own line and pretty-prints the JSON body via the existing `formatJsonSource` helper (same one used for plain-JSON auto-formatting).
- Falls back cleanly: non-REST-request text (e.g. bare JSON, or non-ES database types) is untouched and continues through the existing JSON/XML/SQL detection path unchanged.

Wired into `QueryEditor.vue`'s `formatCurrentSql()` ahead of the existing structured/SQL fallback. Zero behavior change for every other database type.

## Testing

- Added 7 unit tests in `apps/desktop/src/lib/__tests__/elasticsearch/elasticsearchFormatter.spec.ts` covering: single-line request with JSON body, request with no body, multiple requests separated by a blank line, invalid JSON body (falls back to "unsupported" toast instead of corrupting text), bare JSON without a method line, non-Elasticsearch database types, and Meilisearch (which shares the same REST syntax).
- Full suite: `pnpm test` — 951 files / 9107 tests passing.
- `pnpm typecheck` clean.
- Manually reproduced and verified against a real Elasticsearch 8.15 instance (Docker) via a real browser: before the fix, clicking Format on the query from the issue's screenshot left it unchanged; after the fix, it pretty-prints into the expected multi-line JSON. Also confirmed the formatted query still executes correctly and returns the expected document (fix doesn't corrupt the request).

## Breaking changes

None — the new formatting path is only reached for Elasticsearch/Meilisearch text that actually matches the `METHOD /path` request syntax; everything else is untouched.