### PR TITLE
Fix：修复 Nix pnpm 依赖哈希不匹配

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -197,7 +197,7 @@
             fetcherVersion = 4;
             # Update with the hash reported by a failed fixed-output build:
             #   nix build .#dbx-pnpm-deps 2>&1 | grep 'got:'
-            hash = "sha256-iFr+nYvhdFO6Y3fOs3tlhQL/10rgY3f2T1CbjnNZ3Nc=";
+            hash = "sha256-wkjQz/nNx4D7p5B/5NcdXnMGvOljM+nGKyKDxvMRCgw=";
           };
 
           # ── Step 2: vendor Cargo dependencies ───────────────────────────── #


### PR DESCRIPTION
## 问题

`nix-packaging` 在构建 `dbx-desktop-pnpm-deps` 时检测到 fixed-output hash 不匹配，导致 CI 失败。该问题也阻塞了 #6240 的全绿验证。

## 修改

- 按 GitHub Actions 失败注解给出的实际值更新 `flake.nix` 中的 pnpm 依赖哈希
- 保持修复独立，不向 ZooKeeper 或 Oracle 业务 PR 混入无关改动

## 验证

- `git diff --check` 通过
- 本机未安装 Nix，最终由 PR 的 `nix-packaging` 工作流验证 fixed-output hash