### PR TITLE
feat(ai): add message copy actions

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -93,6 +93,7 @@ import { shouldShowReasoningCharCount, reasoningCharCountClass } from "@/lib/ai/
 import { saveTextFile } from "@/lib/export/saveTextFile";
 import { buildAiAnalysisExport } from "@/lib/export/aiAnalysisExport";
 import { buildAiConversationSearchIndex, filterAiConversationSearchIndex } from "@/lib/ai/aiConversationSearch";
+import { resolveAiMessageCopyText } from "@/lib/ai/aiMessageCopy";
 
 const { t } = useI18n();
 const settings = useSettingsStore();
@@ -1962,19 +1963,41 @@ function tempRunSql(code: string) {
   emit("tempRunSql", code);
 }
 
-const copiedIndex = ref("");
+const copiedContentKey = ref("");
 
-async function copyCode(code: string, key: string) {
+async function copyAiContent(content: string, key: string) {
   try {
-    await copyToClipboard(code);
-    copiedIndex.value = key;
+    await copyToClipboard(content);
+    copiedContentKey.value = key;
     setTimeout(() => {
-      if (copiedIndex.value === key) copiedIndex.value = "";
+      if (copiedContentKey.value === key) copiedContentKey.value = "";
     }, 2000);
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : String(e);
     toast(t("grid.copyFailed", { message }), 5000);
   }
+}
+
+function isStreamingMessage(msg: ChatMessage): boolean {
+  return isGenerating.value && msg === messages.value[messages.value.length - 1];
+}
+
+function messageCopyText(msg: ChatMessage): string | null {
+  return resolveAiMessageCopyText(msg, isStreamingMessage(msg));
+}
+
+function canCopyMessage(msg: ChatMessage): boolean {
+  return messageCopyText(msg) !== null;
+}
+
+function messageCopyKey(index: number): string {
+  return `message:${index}`;
+}
+
+async function copyMessage(msg: ChatMessage, index: number) {
+  const text = messageCopyText(msg);
+  if (text === null) return;
+  await copyAiContent(text, `message:${index}`);
 }
 
 async function exportMessageAsMarkdown(msg: ChatMessage) {
@@ -2189,8 +2212,7 @@ const messageRenderer = computed(() => {
  * already-finished segments, so a frame only re-parses the growing tail.
  */
 function renderMessageSegments(msg: ChatMessage) {
-  const streaming = isGenerating.value && msg === messages.value[messages.value.length - 1];
-  return messageRenderer.value.render(msg.content, { streaming });
+  return messageRenderer.value.render(msg.content, { streaming: isStreamingMessage(msg) });
 }
 
 function onMarkdownClick(event: MouseEvent) {
@@ -2337,6 +2359,19 @@ async function openExternalUrl(url: string) {
                       </div>
                       <div v-if="msg.content" class="whitespace-pre-wrap">{{ msg.content }}</div>
                     </div>
+                    <div v-if="canCopyMessage(msg)" class="mt-1 flex justify-end">
+                      <button
+                        data-ai-message-copy="user"
+                        type="button"
+                        class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                        :title="copiedContentKey === messageCopyKey(i) ? t('ai.copied') : t('ai.copyMessage')"
+                        :aria-label="copiedContentKey === messageCopyKey(i) ? t('ai.copied') : t('ai.copyMessage')"
+                        @click="copyMessage(msg, i)"
+                      >
+                        <Check v-if="copiedContentKey === messageCopyKey(i)" class="h-3.5 w-3.5 text-green-500" />
+                        <Copy v-else class="h-3.5 w-3.5" />
+                      </button>
+                    </div>
                   </div>
                 </template>
               </div>
@@ -2409,10 +2444,10 @@ async function openExternalUrl(url: string) {
                         </button>
                         <button
                           class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
-                          :title="copiedIndex === `${i}-${j}` ? t('ai.copied') : t(seg.isSql ? 'ai.copySql' : 'ai.copyCode')"
-                          @click="copyCode(seg.content, `${i}-${j}`)"
+                          :title="copiedContentKey === `code:${i}:${j}` ? t('ai.copied') : t(seg.isSql ? 'ai.copySql' : 'ai.copyCode')"
+                          @click="copyAiContent(seg.content, `code:${i}:${j}`)"
                         >
-                          <Check v-if="copiedIndex === `${i}-${j}`" class="h-3.5 w-3.5 text-green-400" />
+                          <Check v-if="copiedContentKey === `code:${i}:${j}`" class="h-3.5 w-3.5 text-green-400" />
                           <Copy v-else class="h-3.5 w-3.5" />
                         </button>
                       </div>
@@ -2431,12 +2466,25 @@ async function openExternalUrl(url: string) {
                   </Button>
                 </div>
               </div>
-              <div v-if="msg.content && !isGenerating" class="mt-1 flex items-center justify-between">
+              <div v-if="canCopyMessage(msg)" class="mt-1 flex items-center justify-between">
                 <span v-if="msg.tokens" class="text-[10px] text-muted-foreground">&#8593;{{ msg.tokens.input.toLocaleString() }} &#8595;{{ msg.tokens.output.toLocaleString() }} tokens</span>
                 <span v-else />
-                <button class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.exportMarkdown')" @click="exportMessageAsMarkdown(msg)">
-                  <FileDown class="h-3.5 w-3.5" />
-                </button>
+                <div class="flex items-center gap-1">
+                  <button
+                    data-ai-message-copy="assistant"
+                    type="button"
+                    class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200"
+                    :title="copiedContentKey === messageCopyKey(i) ? t('ai.copied') : t('ai.copyMessage')"
+                    :aria-label="copiedContentKey === messageCopyKey(i) ? t('ai.copied') : t('ai.copyMessage')"
+                    @click="copyMessage(msg, i)"
+                  >
+                    <Check v-if="copiedContentKey === messageCopyKey(i)" class="h-3.5 w-3.5 text-green-500" />
+                    <Copy v-else class="h-3.5 w-3.5" />
+                  </button>
+                  <button class="rounded p-0.5 text-zinc-500 hover:bg-zinc-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-200" :title="t('ai.exportMarkdown')" @click="exportMessageAsMarkdown(msg)">
+                    <FileDown class="h-3.5 w-3.5" />
+                  </button>
+                </div>
               </div>
             </div>
           </template>

--- a/apps/desktop/src/components/editor/__tests__/AiAssistant.messageCopy.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/AiAssistant.messageCopy.spec.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../AiAssistant.vue", import.meta.url), "utf8");
+
+describe("AI assistant message copy actions", () => {
+  it("exposes copy actions below user and assistant messages", () => {
+    expect(source).toContain('data-ai-message-copy="user"');
+    expect(source).toContain('data-ai-message-copy="assistant"');
+  });
+
+  it("routes message copies through the body-only copy contract", () => {
+    expect(source).toContain("resolveAiMessageCopyText(msg, isStreamingMessage(msg))");
+    expect(source).toContain("copyAiContent(text, `message:${index}`)");
+  });
+
+  it("keeps code-block and message feedback keys separate", () => {
+    expect(source).toContain("copyAiContent(seg.content, `code:${i}:${j}`)");
+    expect(source).toContain("messageCopyKey(i)");
+  });
+});

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2314,6 +2314,7 @@ export default {
     executeSql: "Execute SQL",
     tempRunSql: "Run without modifying editor",
     copyAll: "Copy All",
+    copyMessage: "Copy message",
     copied: "Copied",
     copyTestResult: "Copy test result",
     testErrorAuth: "Authentication or access failed. Check the API key, project permissions, and API availability.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2352,6 +2352,7 @@ export default withEnglishFallback({
     executeSql: "Ejecutar SQL",
     tempRunSql: "Ejecutar sin modificar",
     copyAll: "Copiar todo",
+    copyMessage: "Copiar mensaje",
     copied: "Copiado",
     copyTestResult: "Copiar resultado de prueba",
     testErrorAuth: "Falló la autenticación o el acceso. Comprueba la clave de API, los permisos del proyecto y que la API esté habilitada.",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2246,6 +2246,7 @@ export default withEnglishFallback({
     executeSql: "Esegui SQL",
     tempRunSql: "Esegui senza modificare",
     copyAll: "Copia Tutto",
+    copyMessage: "Copia messaggio",
     copied: "Copiato",
     copyTestResult: "Copia risultato test",
     testErrorAuth: "Autenticazione o accesso non riusciti. Controlla la chiave API, i permessi del progetto e che l'API sia abilitata.",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2386,6 +2386,7 @@ export default withEnglishFallback({
     executeSql: "SQLを実行",
     tempRunSql: "編集せずに実行",
     copyAll: "すべてコピー",
+    copyMessage: "メッセージをコピー",
     copied: "コピーしました",
     copyTestResult: "テスト結果をコピー",
     testErrorAuth: "認証またはアクセスに失敗しました。API キー、プロジェクト権限、API の有効化状態を確認してください。",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -2172,6 +2172,7 @@ export default withEnglishFallback({
     executeSql: "SQL 실행",
     tempRunSql: "편집기를 수정하지 않고 실행",
     copyAll: "모두 복사",
+    copyMessage: "메시지 복사",
     copied: "복사했습니다",
     copyTestResult: "테스트 결과 복사",
     testErrorAuth: "인증 또는 접근에 실패했습니다. API 키, 프로젝트 권한 및 API 가용성을 확인하세요.",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2354,6 +2354,7 @@ export default withEnglishFallback({
     executeSql: "Executar SQL",
     tempRunSql: "Executar sem modificar",
     copyAll: "Copiar Tudo",
+    copyMessage: "Copiar mensagem",
     copied: "Copiado",
     copyTestResult: "Copiar resultado do teste",
     testErrorAuth: "A autenticação ou o acesso falhou. Verifique a chave de API, as permissões do projeto e se a API está ativada.",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2238,6 +2238,7 @@ export default withEnglishFallback({
     executeSql: "立即执行",
     tempRunSql: "临时运行",
     copyAll: "复制全部",
+    copyMessage: "复制消息",
     copied: "已复制",
     copyTestResult: "复制测试结果",
     testErrorAuth: "身份验证或访问失败，请检查 API Key、项目权限和 API 启用状态。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2247,6 +2247,7 @@ export default withEnglishFallback({
     executeSql: "立即執行",
     tempRunSql: "臨時執行",
     copyAll: "複製全部",
+    copyMessage: "複製訊息",
     copied: "已複製",
     copyTestResult: "複製測試結果",
     testErrorAuth: "驗證或存取失敗，請檢查 API Key、專案權限和 API 啟用狀態。",

--- a/apps/desktop/src/lib/__tests__/ai/aiMessageCopy.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai/aiMessageCopy.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { resolveAiMessageCopyText } from "@/lib/ai/aiMessageCopy";
+
+describe("AI message copy payload", () => {
+  it("preserves user message text exactly", () => {
+    const content = "Check `orders`\n\n```sql\nSELECT * FROM orders;\n```";
+
+    expect(resolveAiMessageCopyText({ role: "user", content }, false)).toBe(content);
+  });
+
+  it("copies only the assistant message body", () => {
+    const message = {
+      role: "assistant" as const,
+      content: "The result is **42**.",
+      reasoning: "private reasoning",
+      agentSteps: [{ toolResult: "tool output" }],
+    };
+
+    expect(resolveAiMessageCopyText(message, false)).toBe(message.content);
+  });
+
+  it("does not expose empty or streaming messages", () => {
+    expect(resolveAiMessageCopyText({ role: "assistant", content: "partial" }, true)).toBeNull();
+    expect(resolveAiMessageCopyText({ role: "assistant", content: "" }, false)).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/ai/aiMessageCopy.ts
+++ b/apps/desktop/src/lib/ai/aiMessageCopy.ts
@@ -1,0 +1,14 @@
+export interface AiMessageCopyCandidate {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/**
+ * Keeps message-level copy payloads scoped to the original message body.
+ * Reasoning, tool activity, mentions, and rendered HTML live outside this
+ * contract and must not be appended by the caller.
+ */
+export function resolveAiMessageCopyText(message: AiMessageCopyCandidate, streaming: boolean): string | null {
+  if (!message.content || streaming) return null;
+  return message.content;
+}


### PR DESCRIPTION
## 变更说明

为 AI 对话中的用户消息和 Agent 回复增加消息级复制入口，方便直接复用完整的对话内容。

- 用户消息的复制按钮显示在消息气泡下方。
- Agent 回复的复制按钮显示在回复底部，与 Markdown 导出入口并列。
- 复制时保留原始 Markdown 和代码围栏，不混入思考过程、工具调用记录或其他界面元数据。
- 复制成功后，按钮会短暂切换为勾选状态。
- 补齐所有现有语言的复制消息文案及无障碍标签。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

### 复制用户消息

<img width="1352" height="878" alt="image" src="https://github.com/user-attachments/assets/4273c83e-f4a2-4e15-b7e8-4b17d01b44ac" />

### 复制 Agent 回复

<img width="1352" height="878" alt="image" src="https://github.com/user-attachments/assets/aba4a615-f7a7-49c6-afd6-d446d55d0547" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

验证内容包括：

- 用户消息与 Agent 回复均能复制原始消息正文。
- Markdown 与代码围栏在剪贴板中保持不变。
- Agent 的思考过程不会混入回复的复制内容。
- 点击复制后会显示成功勾选，且不会与代码块复制状态相互干扰。
- 空消息或正在生成的回复不会显示消息级复制入口。

## 关联 Issue

无。
