### PR TITLE
fix(xugu): keep package member groups scoped

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -691,7 +691,9 @@ async function toggle(requestId = beginNavigationRequest()) {
   // schema and replace the package's member list with unrelated objects.
   if (currentDatabaseType() === "xugu" && (node.type === "group-procedures" || node.type === "group-functions") && node.parentType === "package") {
     node.isExpanded = !node.isExpanded;
-    if (wasExpanded && !connectionStore.sidebarSearchQuery) connectionStore.releaseCollapsedTreeNodeChildren(node.id);
+    // Package member groups have no group-level reload path: their children
+    // are hydrated together with the owning package. Releasing a large group
+    // here would leave it empty on the next local-only expand.
     emitNodeToggled(node, wasExpanded);
     return;
   }

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -684,6 +684,18 @@ async function toggle(requestId = beginNavigationRequest()) {
     return;
   }
 
+  // Xugu package members are represented with the same visual group types as
+  // schema-level procedures/functions, but their children are already loaded
+  // from the owning package specification.  Keep this scoped group local:
+  // routing it through loadSidebarObjectGroup would query every routine in the
+  // schema and replace the package's member list with unrelated objects.
+  if (currentDatabaseType() === "xugu" && (node.type === "group-procedures" || node.type === "group-functions") && node.parentType === "package") {
+    node.isExpanded = !node.isExpanded;
+    if (wasExpanded && !connectionStore.sidebarSearchQuery) connectionStore.releaseCollapsedTreeNodeChildren(node.id);
+    emitNodeToggled(node, wasExpanded);
+    return;
+  }
+
   // Keep the click path aligned with every object-group definition. In
   // particular, schema-level trigger/type groups have no tableName, so they
   // must use the generic object loader rather than the table-trigger loader.

--- a/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts
@@ -334,23 +334,21 @@ describe("SidebarTreeRuntimeHost expansion", () => {
       connectionId: "xugu",
       database: "SHOP_DEMO",
       schema: "APP_TEST",
-      objectCount: 1,
+      objectCount: 401,
       isExpanded: false,
-      children: [
-        {
-          id: "xugu:SHOP_DEMO:APP_TEST:package:PKG_CUSTOMER:member:function:FUNC_GET_BALANCE:p_id BIGINT",
-          label: "FUNC_GET_BALANCE(p_id BIGINT)",
-          type: "function",
-          parentType: "package",
-          parentName: "PKG_CUSTOMER",
-          parentSchema: "APP_TEST",
-          connectionId: "xugu",
-          database: "SHOP_DEMO",
-          schema: "APP_TEST",
-          objectName: "FUNC_GET_BALANCE",
-          signature: "p_id BIGINT",
-        },
-      ],
+      children: Array.from({ length: 401 }, (_, index) => ({
+        id: `xugu:SHOP_DEMO:APP_TEST:package:PKG_CUSTOMER:member:function:FUNC_${index}`,
+        label: `FUNC_${index}()`,
+        type: "function" as const,
+        parentType: "package" as const,
+        parentName: "PKG_CUSTOMER",
+        parentSchema: "APP_TEST",
+        connectionId: "xugu",
+        database: "SHOP_DEMO",
+        schema: "APP_TEST",
+        objectName: `FUNC_${index}`,
+        signature: "",
+      })),
     };
     connectionStore.treeNodes = [packageFunctionGroup];
     connectionStore.getConfig.mockReturnValue({ db_type: "xugu" });
@@ -381,5 +379,14 @@ describe("SidebarTreeRuntimeHost expansion", () => {
 
     expect(packageFunctionGroup.isExpanded).toBe(false);
     expect(connectionStore.loadObjectGroupChildren).not.toHaveBeenCalled();
+
+    expect(connectionStore.releaseCollapsedTreeNodeChildren).not.toHaveBeenCalled();
+    expect(packageFunctionGroup.children).toHaveLength(401);
+
+    host.value?.toggleNode(packageFunctionGroup);
+    await nextTick();
+
+    expect(packageFunctionGroup.isExpanded).toBe(true);
+    expect(packageFunctionGroup.children).toHaveLength(401);
   });
 });

--- a/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts
@@ -322,4 +322,64 @@ describe("SidebarTreeRuntimeHost expansion", () => {
       }),
     );
   });
+
+  it("toggles Xugu package member groups locally instead of loading schema routines", async () => {
+    const packageFunctionGroup: TreeNode = {
+      id: "xugu:SHOP_DEMO:APP_TEST:package:PKG_CUSTOMER:members:functions",
+      label: "tree.functions",
+      type: "group-functions",
+      parentType: "package",
+      parentName: "PKG_CUSTOMER",
+      parentSchema: "APP_TEST",
+      connectionId: "xugu",
+      database: "SHOP_DEMO",
+      schema: "APP_TEST",
+      objectCount: 1,
+      isExpanded: false,
+      children: [
+        {
+          id: "xugu:SHOP_DEMO:APP_TEST:package:PKG_CUSTOMER:member:function:FUNC_GET_BALANCE:p_id BIGINT",
+          label: "FUNC_GET_BALANCE(p_id BIGINT)",
+          type: "function",
+          parentType: "package",
+          parentName: "PKG_CUSTOMER",
+          parentSchema: "APP_TEST",
+          connectionId: "xugu",
+          database: "SHOP_DEMO",
+          schema: "APP_TEST",
+          objectName: "FUNC_GET_BALANCE",
+          signature: "p_id BIGINT",
+        },
+      ],
+    };
+    connectionStore.treeNodes = [packageFunctionGroup];
+    connectionStore.getConfig.mockReturnValue({ db_type: "xugu" });
+    connectionStore.canUseLoadedTreeNodeToggle.mockReturnValue(false);
+
+    const host = ref<InstanceType<typeof SidebarTreeRuntimeHost> | null>(null);
+    const toggled = vi.fn();
+    const app = createApp(
+      defineComponent({
+        setup: () => () => h(SidebarTreeRuntimeHost, { ref: host, node: packageFunctionGroup, depth: 0, onNodeToggled: toggled }),
+      }),
+    );
+    mountedApps.push(app);
+    const container = document.createElement("div");
+    document.body.append(container);
+    app.use(i18n);
+    app.mount(container);
+
+    host.value?.toggleNode(packageFunctionGroup);
+    await nextTick();
+
+    expect(packageFunctionGroup.isExpanded).toBe(true);
+    expect(connectionStore.loadObjectGroupChildren).not.toHaveBeenCalled();
+    expect(toggled).toHaveBeenCalledWith(packageFunctionGroup, true);
+
+    host.value?.toggleNode(packageFunctionGroup);
+    await nextTick();
+
+    expect(packageFunctionGroup.isExpanded).toBe(false);
+    expect(connectionStore.loadObjectGroupChildren).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/lib/__tests__/sidebar/packageMembers.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/packageMembers.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CompletionAssistantCandidate, TreeNode } from "@/types/database";
-import { buildPackageMemberNodes, markPackageNodesExpandable } from "@/lib/sidebar/packageMembers";
+import { buildPackageMemberNodes, markPackageNodesExpandable, packageMemberGroupOwnerId } from "@/lib/sidebar/packageMembers";
 
 function packageNode(): TreeNode {
   return {
@@ -42,6 +42,9 @@ describe("package member tree", () => {
     expect(result[1]?.children?.map((node) => node.label)).toEqual(["lookup"]);
     expect(result.flatMap((node) => node.children ?? []).every((node) => node.parentName === "business_api" && node.parentSchema === "app_schema" && node.parentType === "package" && node.valid === false)).toBe(true);
     expect(new Set(result.flatMap((node) => node.children ?? []).map((node) => node.id)).size).toBe(3);
+    expect(packageMemberGroupOwnerId(result[0]!)).toBe(packageNode().id);
+    expect(packageMemberGroupOwnerId({ ...result[0]!, parentType: undefined })).toBeNull();
+    expect(packageMemberGroupOwnerId({ ...result[0]!, id: "invalid" })).toBeNull();
   });
 
   it("keeps package body source metadata on the package without adding a duplicate body node", () => {

--- a/apps/desktop/src/lib/sidebar/packageMembers.ts
+++ b/apps/desktop/src/lib/sidebar/packageMembers.ts
@@ -1,5 +1,14 @@
 import type { CompletionAssistantCandidate, DatabaseType, TreeNode, TreeNodeType } from "@/types/database";
 
+const PACKAGE_MEMBER_GROUP_MARKER = ":members:";
+
+export function packageMemberGroupOwnerId(node: TreeNode): string | null {
+  if (node.parentType !== "package" || (node.type !== "group-procedures" && node.type !== "group-functions")) return null;
+  const markerIndex = node.id.lastIndexOf(PACKAGE_MEMBER_GROUP_MARKER);
+  if (markerIndex <= 0) return null;
+  return node.id.slice(0, markerIndex);
+}
+
 export function markPackageNodesExpandable(nodes: TreeNode[]): TreeNode[] {
   return nodes.map((node) => (node.type === "package" ? { ...node, children: node.children ?? [] } : node));
 }

--- a/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts
@@ -175,7 +175,7 @@ describe("connectionStore metadata loading", () => {
       fallback_used: false,
     });
     vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
-    vi.doMock("@/lib/backend/api", () => ({ checkConnectionHealth: vi.fn().mockResolvedValue(undefined), completionAssistantSearch }));
+    vi.doMock("@/lib/backend/api", () => ({ checkConnectionHealth: vi.fn().mockResolvedValue(undefined), completionAssistantSearch, deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined), listInstalledAgents: vi.fn().mockResolvedValue([]) }));
 
     const { useConnectionStore } = await import("@/stores/connectionStore");
     const store = useConnectionStore();
@@ -219,6 +219,18 @@ describe("connectionStore metadata loading", () => {
     ]);
     expect(packageNode.children?.flatMap((group) => group.children ?? []).map((child) => child.label)).toEqual(["process_item(p_id IN INT)", "process_item(p_code IN VARCHAR)", "item_count"]);
     expect(packageNode.children?.flatMap((group) => group.children ?? []).every((child) => child.parentName === "business_api")).toBe(true);
+
+    completionAssistantSearch.mockResolvedValueOnce({
+      candidates: [{ name: "next_item", kind: "function", data_type: "INT" }],
+      incomplete: false,
+      fallback_used: false,
+    });
+    const functionGroup = packageNode.children?.find((child) => child.type === "group-functions");
+    await store.refreshTreeNode(functionGroup!);
+
+    expect(completionAssistantSearch).toHaveBeenCalledTimes(2);
+    expect(packageNode.children?.map((child) => [child.type, child.objectCount])).toEqual([["group-functions", 1]]);
+    expect(packageNode.children?.[0]?.children?.map((child) => child.label)).toEqual(["next_item"]);
   }, 15000);
 
   it("loads Xugu object type members through the scoped completion endpoint", async () => {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -126,7 +126,7 @@ import { appendVisibleDatabaseSelection } from "@/lib/connection/connectionVisib
 import { buildXuguTypeMemberNodes, isXuguTypeMemberContainer } from "@/lib/sidebar/xuguTypeMembers";
 import { isXuguPublicSynonymScope, sortXuguSchemaInfos, xuguSchemaDisplayName, XUGU_PUBLIC_SYNONYM_SCOPE } from "@/lib/sidebar/xuguPublicSynonyms";
 import { filterNacosNamespacesForSidebar, normalizeNacosNamespacesForDisplay } from "@/lib/nacos/nacosNamespaceVisibility";
-import { buildPackageMemberNodes, markPackageNodesExpandable } from "@/lib/sidebar/packageMembers";
+import { buildPackageMemberNodes, markPackageNodesExpandable, packageMemberGroupOwnerId } from "@/lib/sidebar/packageMembers";
 import { configuredDatabaseProductName, connectionConfigFingerprint, normalizeDatabaseConnectionInfo } from "@/lib/connection/connectionDatabaseInfo";
 import { driverProfileObjectTreeProfileForConnection } from "@/lib/database/driverProfileExtensions";
 import { createMetadataLoadTrace, logMetadataLoadTrace, MetadataLoadCoordinator, type MetadataLoadTraceLogger } from "@/lib/metadata/metadataLoadCoordinator";
@@ -5093,6 +5093,14 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   async function loadObjectGroupChildren(node: TreeNode, options?: LoadTreeOptions) {
+    const packageOwnerId = packageMemberGroupOwnerId(node);
+    const packageConfig = node.connectionId ? getConfig(node.connectionId) : undefined;
+    if (packageOwnerId && effectiveDatabaseTypeForConnection(packageConfig) === "xugu") {
+      const packageNode = findNode(treeNodes.value, packageOwnerId);
+      if (packageNode?.type === "package") await loadPackageMembers(packageNode, options);
+      return;
+    }
+
     const configForScope = node.connectionId ? getConfig(node.connectionId) : undefined;
     const objectTypesForScope = objectTypesForGroupNode(node.type);
     const pageSizeForScope = sidebarObjectGroupPageSize();


### PR DESCRIPTION
## Summary

This change fixes two Xugu package-tree issues:

1. Expanding a package procedure/function group could replace the package members with every procedure or function from the containing schema.
2. After navigating between schema-level routines and package members, a package function group could show a non-zero count but fail to expand.

## Root cause

Xugu package members are represented with the existing `group-procedures` and `group-functions` tree node types. Those same node types are also used for schema-level object groups. The sidebar toggle path therefore treated a package-owned group as a database metadata group and invoked the generic object loader. That loader queried the whole schema and overwrote the package-scoped children. The resulting node state also made subsequent package-group expansion unreliable.

## Implementation

- Detect Xugu package-owned procedure/function groups using their `parentType: "package"` metadata.
- Toggle their already-loaded package members locally instead of routing them through the schema-level object-group loader.
- Keep the condition explicitly Xugu-specific so Oracle and other database providers retain their existing behavior.
- Add a regression test that expands and collapses a package function group twice while asserting that no schema-routine metadata load is issued.

## User impact

Package groups now remain scoped to the package specification. Standalone procedures/functions from the same schema are no longer mixed into a package, and package procedure/function groups can be expanded, collapsed, and expanded again consistently.

## Validation

- `go test -count=1 ./...` in `agents/drivers/xugu` — passed.
- `pnpm exec vitest run apps/desktop/src/components/sidebar apps/desktop/src/lib/__tests__/sidebar apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts` — 43 test files and 258 tests passed.
- `pnpm exec oxfmt --check apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts` — passed.
- `git diff --check` — passed.

The workspace-wide Vue typecheck still reports the pre-existing missing `@dbx-app/mongo-shell` workspace package; the changed files introduce no type errors.

## Scope

The change is limited to the desktop sidebar routing and its regression test. No Xugu SQL, metadata query, driver protocol, or non-Xugu database implementation was changed.
