### PR TITLE
fix(kafka): enable Adjust Partitions button for single-partition topics

### DIFF
--- a/crates/dbx-core/src/mq/adapters/kafka.rs
+++ b/crates/dbx-core/src/mq/adapters/kafka.rs
@@ -1220,5 +1220,4 @@ mod tests {
         let partitions = missing.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
         assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), false);
     }
-
 }

--- a/crates/dbx-core/src/mq/adapters/kafka.rs
+++ b/crates/dbx-core/src/mq/adapters/kafka.rs
@@ -1210,14 +1210,14 @@ mod tests {
         // frontend "Adjust Partitions" button is available (t8y2/dbx#6208).
         let single = serde_json::json!({ "name": "orders", "partitions": 1 });
         let partitions = single.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
-        assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), true);
+        assert!(partitions.map(|p| p > 0).unwrap_or(false));
 
         let multi = serde_json::json!({ "name": "events", "partitions": 3 });
         let partitions = multi.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
-        assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), true);
+        assert!(partitions.map(|p| p > 0).unwrap_or(false));
 
         let missing = serde_json::json!({ "name": "unknown" });
         let partitions = missing.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
-        assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), false);
+        assert!(!partitions.map(|p| p > 0).unwrap_or(false));
     }
 }

--- a/crates/dbx-core/src/mq/adapters/kafka.rs
+++ b/crates/dbx-core/src/mq/adapters/kafka.rs
@@ -197,7 +197,10 @@ impl MessageQueueAdmin for KafkaAdmin {
                 TopicInfo {
                     name: name.clone(),
                     short_name: name,
-                    partitioned: partitions.map(|p| p > 1).unwrap_or(false),
+                    // Kafka topics always have partitions; mark as partitioned so the
+                    // "Adjust Partitions" UI button is available even for single-partition
+                    // topics (fixes t8y2/dbx#6208).
+                    partitioned: partitions.map(|p| p > 0).unwrap_or(false),
                     partitions,
                     persistent: true,
                     internal: t.get("internal").and_then(|v| v.as_bool()).unwrap_or(false),
@@ -1200,4 +1203,22 @@ mod tests {
 
         assert!(kafka_subscription_for_topic("billing-service", "orders", &desc, Some(&lag)).is_none());
     }
+
+    #[test]
+    fn kafka_topic_partitioned_flag_true_for_any_partition_count() {
+        // Single-partition topics must still be marked as partitioned so the
+        // frontend "Adjust Partitions" button is available (t8y2/dbx#6208).
+        let single = serde_json::json!({ "name": "orders", "partitions": 1 });
+        let partitions = single.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
+        assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), true);
+
+        let multi = serde_json::json!({ "name": "events", "partitions": 3 });
+        let partitions = multi.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
+        assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), true);
+
+        let missing = serde_json::json!({ "name": "unknown" });
+        let partitions = missing.get("partitions").and_then(|v| v.as_u64()).map(|v| v as u32);
+        assert_eq!(partitions.map(|p| p > 0).unwrap_or(false), false);
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes t8y2/dbx#6208

Kafka topics with exactly 1 partition did not show the Adjust Partitions button in the Topics panel, because the partitioned flag was only set when partitions > 1.

Since every Kafka topic inherently has partitions, this flag should be true whenever the partition count is known.

## Changes

- crates/dbx-core/src/mq/adapters/kafka.rs: Changed partitioned condition from p > 1 to p > 0
- Added unit test kafka_topic_partitioned_flag_true_for_any_partition_count covering single-partition, multi-partition, and missing-partition cases

## Before

Single-partition Kafka topics: partitioned: false, Adjust Partitions button hidden

## After

Single-partition Kafka topics: partitioned: true, Adjust Partitions button visible and functional