### PR TITLE
feat(mcp): 远程 MCP Web 模式支持系统代理与自定义请求头

### DIFF
--- a/crates/dbx-mcp/Cargo.toml
+++ b/crates/dbx-mcp/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 dbx-core = { path = "../dbx-core", default-features = false }
 dirs = "6"
 rmcp = { version = "2.2.0", features = ["client", "transport-io"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "socks"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/dbx-mcp/src/backend.rs
+++ b/crates/dbx-mcp/src/backend.rs
@@ -280,10 +280,11 @@ pub struct WebBackend {
 // inside `auth`) in plaintext. Redact credentials and skip lockable state.
 impl std::fmt::Debug for WebBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let header_names = self.headers.keys().map(HeaderName::as_str).collect::<Vec<_>>();
         f.debug_struct("WebBackend")
             .field("base_url", &self.base_url)
             .field("password", &"<redacted>")
-            .field("headers", &self.headers)
+            .field("header_names", &header_names)
             .finish_non_exhaustive()
     }
 }
@@ -2311,6 +2312,25 @@ mod tests {
         assert!(list.contains("x-api-key: secret"), "{list}");
         assert!(list.contains("x-tenant: acme"), "{list}");
         assert!(list.contains("x-dbx-mcp-request: 1"), "{list}");
+    }
+
+    #[test]
+    fn web_backend_debug_redacts_custom_header_values() {
+        let backend = WebBackend::new_with_config(
+            "http://127.0.0.1:8976".to_string(),
+            "super-secret-password".to_string(),
+            None,
+            None,
+            Some(r#"{"Authorization":"Bearer secret-token","X-Tenant":"acme"}"#.to_string()),
+        )
+        .unwrap();
+
+        let debug = format!("{backend:?}");
+        assert!(debug.contains("authorization"));
+        assert!(debug.contains("x-tenant"));
+        assert!(!debug.contains("secret-token"));
+        assert!(!debug.contains("Bearer"));
+        assert!(!debug.contains("super-secret-password"));
     }
 
     #[tokio::test]

--- a/crates/dbx-mcp/src/backend.rs
+++ b/crates/dbx-mcp/src/backend.rs
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+
 use crate::mongo::MongoCommand;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -259,7 +261,7 @@ pub struct LocalBackend {
     data_dir: std::path::PathBuf,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct WebAuthState {
     session_cookie: Option<String>,
     checked: bool,
@@ -269,24 +271,58 @@ pub struct WebBackend {
     base_url: String,
     password: String,
     client: reqwest::Client,
+    headers: HeaderMap,
     auth: Mutex<WebAuthState>,
     connected: Mutex<HashMap<String, ConnectionConfig>>,
 }
 
+// Manual impl: the derived one would print `password` (and the session cookie
+// inside `auth`) in plaintext. Redact credentials and skip lockable state.
+impl std::fmt::Debug for WebBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebBackend")
+            .field("base_url", &self.base_url)
+            .field("password", &"<redacted>")
+            .field("headers", &self.headers)
+            .finish_non_exhaustive()
+    }
+}
+
 impl WebBackend {
     pub fn new(base_url: String, password: String) -> Result<Self, String> {
+        let (proxy, no_proxy) = standard_web_proxy(&base_url);
+        Self::new_with_config(base_url, password, proxy, no_proxy, std::env::var("DBX_WEB_HEADERS").ok())
+    }
+
+    fn new_with_config(
+        base_url: String,
+        password: String,
+        proxy: Option<String>,
+        no_proxy: Option<String>,
+        headers_json: Option<String>,
+    ) -> Result<Self, String> {
         let base_url = base_url.trim().trim_end_matches('/').to_string();
         if base_url.is_empty() {
             return Err("DBX_WEB_URL cannot be empty.".to_string());
         }
-        let client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .map_err(|error| error.to_string())?;
+        let mut builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
+        if let Some(proxy_url) = proxy.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            let mut proxy = reqwest::Proxy::all(proxy_url)
+                .map_err(|error| format!("Invalid HTTP(S)_PROXY/ALL_PROXY value: {error}"))?;
+            if let Some(no_proxy) = no_proxy.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+                proxy = proxy.no_proxy(reqwest::NoProxy::from_string(no_proxy));
+            }
+            builder = builder.proxy(proxy);
+        } else {
+            // Unset or empty proxy configuration: connect directly.
+            builder = builder.no_proxy();
+        }
+        let client = builder.build().map_err(|error| error.to_string())?;
         Ok(Self {
             base_url,
             password,
             client,
+            headers: parse_custom_headers(headers_json.as_deref())?,
             auth: Mutex::new(WebAuthState::default()),
             connected: Mutex::new(HashMap::new()),
         })
@@ -303,12 +339,11 @@ impl WebBackend {
             required: bool,
             setup_required: bool,
         }
-        let response = self
-            .client
-            .get(format!("{}/api/auth/check", self.base_url))
-            .send()
-            .await
-            .map_err(|error| format!("Authentication check failed: {error}"))?;
+        let mut request = self.client.get(format!("{}/api/auth/check", self.base_url));
+        for (name, value) in &self.headers {
+            request = request.header(name, value);
+        }
+        let response = request.send().await.map_err(|error| format!("Authentication check failed: {error}"))?;
         if !response.status().is_success() {
             return Err(format!("Authentication check failed: {}", response.status()));
         }
@@ -323,9 +358,11 @@ impl WebBackend {
         if self.password.is_empty() {
             return Err("DBX Web authentication is required. Set DBX_WEB_PASSWORD for MCP Web mode.".to_string());
         }
-        let response = self
-            .client
-            .post(format!("{}/api/auth/login", self.base_url))
+        let mut request = self.client.post(format!("{}/api/auth/login", self.base_url));
+        for (name, value) in &self.headers {
+            request = request.header(name, value);
+        }
+        let response = request
             .json(&json!({ "password": self.password }))
             .send()
             .await
@@ -358,6 +395,9 @@ impl WebBackend {
                 .client
                 .request(method.clone(), format!("{}{}", self.base_url, path))
                 .header("x-dbx-mcp-request", "1");
+            for (name, value) in &self.headers {
+                request = request.header(name, value);
+            }
             if let Some(cookie) = cookie {
                 request = request.header(reqwest::header::COOKIE, format!("dbx_session={cookie}"));
             }
@@ -1420,6 +1460,97 @@ fn extract_session_cookie(header: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+/// Lowercased URL scheme: the part before the first `://` separator, with
+/// surrounding whitespace trimmed. Input without a `://` separator yields the
+/// whole trimmed, lowercased input.
+fn normalize_scheme(base_url: &str) -> String {
+    base_url.trim().split("://").next().unwrap_or_default().to_ascii_lowercase()
+}
+
+/// Resolves the standard proxy environment variables for a DBX Web backend.
+///
+/// Follows the conventional precedence: the scheme-specific variable
+/// (`HTTPS_PROXY`/`https_proxy` for https URLs, `HTTP_PROXY`/`http_proxy`
+/// for http URLs) wins, with `ALL_PROXY`/`all_proxy` as the fallback.
+/// Empty values count as unset. `NO_PROXY`/`no_proxy` is returned alongside
+/// so the client can bypass the proxy for matching hosts.
+fn standard_web_proxy(base_url: &str) -> (Option<String>, Option<String>) {
+    let http_proxy = first_non_empty_env(&["HTTP_PROXY", "http_proxy"]);
+    let https_proxy = first_non_empty_env(&["HTTPS_PROXY", "https_proxy"]);
+    let all_proxy = first_non_empty_env(&["ALL_PROXY", "all_proxy"]);
+    (
+        select_proxy_url(
+            &normalize_scheme(base_url),
+            http_proxy.as_deref(),
+            https_proxy.as_deref(),
+            all_proxy.as_deref(),
+        ),
+        first_non_empty_env(&["NO_PROXY", "no_proxy"]),
+    )
+}
+
+/// Picks the proxy URL for a target scheme. The scheme-specific variable wins;
+/// `ALL_PROXY` is the fallback. Empty or whitespace-only values count as unset.
+/// `None` means "no proxy".
+fn select_proxy_url(
+    scheme: &str,
+    http_proxy: Option<&str>,
+    https_proxy: Option<&str>,
+    all_proxy: Option<&str>,
+) -> Option<String> {
+    fn usable(value: Option<&str>) -> Option<&str> {
+        value.map(str::trim).filter(|value| !value.is_empty())
+    }
+    match scheme {
+        "http" => usable(http_proxy).or_else(|| usable(all_proxy)).map(ToOwned::to_owned),
+        "https" => usable(https_proxy).or_else(|| usable(all_proxy)).map(ToOwned::to_owned),
+        _ => None,
+    }
+}
+
+fn first_non_empty_env(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        std::env::var(name).ok().map(|value| value.trim().to_string()).filter(|value| !value.is_empty())
+    })
+}
+
+/// Parses the `DBX_WEB_HEADERS` JSON object into a `HeaderMap`. Every parsed
+/// header is attached to each DBX Web request, including auth checks.
+fn parse_custom_headers(headers_json: Option<&str>) -> Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+    let Some(value) = headers_json.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(headers);
+    };
+    let entries: serde_json::Map<String, Value> = serde_json::from_str(value)
+        .map_err(|error| format!("Invalid DBX_WEB_HEADERS: expected a JSON object, got {error}"))?;
+    for (name, value) in entries {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|_| format!("Invalid DBX_WEB_HEADERS header name: {name}"))?;
+        // Names the client already manages internally (session cookie, request
+        // marker) or that would corrupt the HTTP framing. Rejecting them
+        // prevents duplicate/conflicting values on the wire.
+        const RESERVED: [&str; 7] = [
+            "cookie",
+            "x-dbx-mcp-request",
+            "host",
+            "content-length",
+            "connection",
+            "transfer-encoding",
+            "proxy-authorization",
+        ];
+        if RESERVED.iter().any(|reserved| header_name.as_str().eq_ignore_ascii_case(reserved)) {
+            return Err(format!("Invalid DBX_WEB_HEADERS header name: {name} (reserved by DBX)"));
+        }
+        let Value::String(header_value) = value else {
+            return Err(format!("Invalid DBX_WEB_HEADERS value for {name}: expected a string"));
+        };
+        let header_value = HeaderValue::from_str(&header_value)
+            .map_err(|error| format!("Invalid DBX_WEB_HEADERS value for {name}: {error}"))?;
+        headers.append(header_name, header_value);
+    }
+    Ok(headers)
+}
+
 fn url_encode(value: &str) -> String {
     url::form_urlencoded::byte_serialize(value.as_bytes()).collect()
 }
@@ -2050,6 +2181,306 @@ mod tests {
         assert_eq!(request["verbosity"], "executionStats");
         assert_eq!(result.columns, ["queryPlanner"]);
         assert_eq!(result.rows.len(), 1);
+    }
+
+    #[test]
+    fn standard_web_proxy_follows_scheme_precedence_and_ignores_empty_values() {
+        // https target: HTTPS_PROXY wins over ALL_PROXY.
+        assert_eq!(
+            select_proxy_url("https", Some("http://http-proxy"), Some("http://https-proxy"), Some("socks5://all")),
+            Some("http://https-proxy".to_string())
+        );
+        // https target without HTTPS_PROXY: ALL_PROXY is the fallback.
+        assert_eq!(
+            select_proxy_url("https", Some("http://http-proxy"), None, Some("socks5://all")),
+            Some("socks5://all".to_string())
+        );
+        // https target with only HTTP_PROXY: no proxy (HTTP_PROXY is not a fallback for https).
+        assert_eq!(select_proxy_url("https", Some("http://http-proxy"), None, None), None);
+        // http target: HTTP_PROXY wins.
+        assert_eq!(
+            select_proxy_url("http", Some("http://http-proxy"), Some("http://https-proxy"), Some("socks5://all")),
+            Some("http://http-proxy".to_string())
+        );
+        // No proxy configured at all.
+        assert_eq!(select_proxy_url("http", None, None, None), None);
+        // Unsupported scheme: never proxied.
+        assert_eq!(select_proxy_url("ftp", None, None, Some("http://all")), None);
+
+        // Empty values behave like unset: no proxy, not an error.
+        assert_eq!(select_proxy_url("https", None, Some(""), None), None);
+        assert_eq!(select_proxy_url("https", None, Some("  "), Some("")), None);
+    }
+
+    #[test]
+    fn normalize_scheme_lowercases_and_trims() {
+        assert_eq!(normalize_scheme("https://host"), "https");
+        assert_eq!(normalize_scheme("HTTPS://host"), "https");
+        assert_eq!(normalize_scheme("  http://host  "), "http");
+        assert_eq!(normalize_scheme("no-scheme"), "no-scheme");
+        assert_eq!(normalize_scheme(""), "");
+    }
+
+    #[tokio::test]
+    async fn web_backend_bypasses_proxy_for_no_proxy_hosts() {
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_address = proxy_listener.local_addr().unwrap();
+        let unused = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_address = unused.local_addr().unwrap();
+        let base_url = format!("http://{base_address}");
+        drop(unused);
+
+        let backend = WebBackend::new_with_config(
+            base_url,
+            String::new(),
+            Some(format!("http://{proxy_address}")),
+            // Target host matches NO_PROXY: the request must go direct.
+            Some("127.0.0.1".to_string()),
+            None,
+        )
+        .unwrap();
+        backend.auth.lock().await.checked = true;
+
+        // Direct connection to the closed port fails; the proxy must never see
+        // the request.
+        let error = backend.load_connections().await.unwrap_err();
+        assert!(error.contains("API request /api/connection/list"), "{error}");
+
+        proxy_listener.set_nonblocking(true).unwrap();
+        assert!(matches!(
+            proxy_listener.accept(),
+            Err(connection_error) if connection_error.kind() == std::io::ErrorKind::WouldBlock
+        ));
+    }
+
+    #[tokio::test]
+    async fn web_backend_applies_custom_headers_to_auth_and_api_requests() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_sender, request_receiver) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let count = stream.read(&mut buffer).unwrap();
+                    request.extend_from_slice(&buffer[..count]);
+                    if count == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let request = String::from_utf8(request).unwrap();
+                request_sender.send(request.clone()).unwrap();
+                let body = if request.starts_with("GET /api/auth/check ") {
+                    r#"{"authenticated":true,"required":false,"setup_required":false}"#
+                } else {
+                    "[]"
+                };
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .unwrap();
+            }
+        });
+
+        let backend = WebBackend::new_with_config(
+            format!("http://{address}"),
+            String::new(),
+            None,
+            None,
+            Some(r#"{"X-API-Key":"secret","X-Tenant":"acme"}"#.to_string()),
+        )
+        .unwrap();
+
+        let connections = backend.load_connections().await.unwrap();
+        assert!(connections.is_empty());
+        server.join().unwrap();
+
+        let auth_check = request_receiver.recv().unwrap().to_ascii_lowercase();
+        assert!(auth_check.starts_with("get /api/auth/check "), "{auth_check}");
+        assert!(auth_check.contains("x-api-key: secret"), "{auth_check}");
+        assert!(auth_check.contains("x-tenant: acme"), "{auth_check}");
+
+        let list = request_receiver.recv().unwrap().to_ascii_lowercase();
+        assert!(list.starts_with("get /api/connection/list "), "{list}");
+        assert!(list.contains("x-api-key: secret"), "{list}");
+        assert!(list.contains("x-tenant: acme"), "{list}");
+        assert!(list.contains("x-dbx-mcp-request: 1"), "{list}");
+    }
+
+    #[tokio::test]
+    async fn web_backend_routes_requests_through_proxy() {
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_address = proxy_listener.local_addr().unwrap();
+        // Port that is guaranteed closed: if the proxy is not used, the direct
+        // connection to this address fails and the test fails.
+        let unused = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_address = unused.local_addr().unwrap();
+        let base_url = format!("http://{base_address}");
+        drop(unused);
+
+        let (request_sender, request_receiver) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = proxy_listener.accept().unwrap();
+            stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let count = stream.read(&mut buffer).unwrap();
+                request.extend_from_slice(&buffer[..count]);
+                if count == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8(request).unwrap();
+            request_sender.send(request.lines().next().unwrap().to_string()).unwrap();
+            let body = "[]";
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        let backend =
+            WebBackend::new_with_config(base_url, String::new(), Some(format!("http://{proxy_address}")), None, None)
+                .unwrap();
+        backend.auth.lock().await.checked = true;
+
+        let connections = backend.load_connections().await.unwrap();
+        assert!(connections.is_empty());
+        server.join().unwrap();
+
+        // HTTP proxies receive the request in absolute-form, proving the
+        // request went through the proxy instead of straight to the target.
+        let request_line = request_receiver.recv().unwrap();
+        assert!(request_line.starts_with(&format!("GET http://{base_address}/api/connection/list ")), "{request_line}");
+    }
+
+    #[tokio::test]
+    async fn web_backend_authenticates_against_proxy_from_url_credentials() {
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_address = proxy_listener.local_addr().unwrap();
+        let unused = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_address = unused.local_addr().unwrap();
+        let base_url = format!("http://{base_address}");
+        drop(unused);
+
+        let (request_sender, request_receiver) = mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = proxy_listener.accept().unwrap();
+            stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let count = stream.read(&mut buffer).unwrap();
+                request.extend_from_slice(&buffer[..count]);
+                if count == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8(request).unwrap();
+            request_sender.send(request.clone()).unwrap();
+            let body = "[]";
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+
+        // Credentials embedded in the proxy URL become Proxy-Authorization.
+        let backend = WebBackend::new_with_config(
+            base_url,
+            String::new(),
+            Some(format!("http://admin:admin123@{proxy_address}")),
+            None,
+            None,
+        )
+        .unwrap();
+        backend.auth.lock().await.checked = true;
+
+        let connections = backend.load_connections().await.unwrap();
+        assert!(connections.is_empty());
+        server.join().unwrap();
+
+        let request = request_receiver.recv().unwrap().to_ascii_lowercase();
+        assert!(request.starts_with(&format!("get http://{base_address}/api/connection/list ")), "{request}");
+        // base64("admin:admin123") = YWRtaW46YWRtaW4xMjM=
+        assert!(request.contains("proxy-authorization: basic ywrtaw46ywrtaw4xmjm="), "{request}");
+    }
+
+    #[test]
+    fn web_backend_rejects_invalid_proxy_and_header_config() {
+        let error = WebBackend::new_with_config(
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            Some("not a url".to_string()),
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(error.contains("HTTP(S)_PROXY"), "{error}");
+
+        let error = WebBackend::new_with_config(
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            None,
+            None,
+            Some("not json".to_string()),
+        )
+        .unwrap_err();
+        assert!(error.contains("DBX_WEB_HEADERS"), "{error}");
+
+        let error = WebBackend::new_with_config(
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            None,
+            None,
+            Some(r#"{"Bad Header Name":"v"}"#.to_string()),
+        )
+        .unwrap_err();
+        assert!(error.contains("header name"), "{error}");
+
+        let error = WebBackend::new_with_config(
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            None,
+            None,
+            Some(r#"{"X-Num":42}"#.to_string()),
+        )
+        .unwrap_err();
+        assert!(error.contains("expected a string"), "{error}");
+
+        // Reserved headers that DBX manages internally are rejected.
+        let error = WebBackend::new_with_config(
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            None,
+            None,
+            Some(r#"{"Cookie":"session=1"}"#.to_string()),
+        )
+        .unwrap_err();
+        assert!(error.contains("reserved by DBX"), "{error}");
+
+        let error = WebBackend::new_with_config(
+            "http://127.0.0.1:1".to_string(),
+            String::new(),
+            None,
+            None,
+            Some(r#"{"x-dbx-mcp-request":"1"}"#.to_string()),
+        )
+        .unwrap_err();
+        assert!(error.contains("reserved by DBX"), "{error}");
     }
 
     #[tokio::test]

--- a/docs/content/docs/mcp.cn.mdx
+++ b/docs/content/docs/mcp.cn.mdx
@@ -128,6 +128,8 @@ Oracle、人大金仓和虚谷需要匹配的 DBX 原生 Agent，但不需要 JR
 
 设置 `DBX_WEB_URL` 后，MCP 会使用部署的 DBX Web 后端，而不是读取本机连接。如果 Web 登录启用了密码保护，还要设置 `DBX_WEB_PASSWORD`，值为 Web 登录页使用的密码。
 
+DBX Web 请求遵循标准系统代理环境变量：https 地址读取 `HTTPS_PROXY`/`https_proxy`，http 地址读取 `HTTP_PROXY`/`http_proxy`，`ALL_PROXY`/`all_proxy` 作为兜底，`NO_PROXY`/`no_proxy`（逗号分隔的主机列表，例如 `localhost,127.0.0.1,.internal.example`）作为绕过列表。代理值为空或未设置时直连（不走代理）。支持 HTTP、HTTPS 与 SOCKS5 代理（`http://127.0.0.1:7890` 或 `socks5://127.0.0.1:1080`）；需要认证的代理使用标准 `user:password@host:port` URL 形式，例如 `http://admin:admin123@127.0.0.1:7890`。如需为每次 DBX Web 请求附加自定义请求头（例如网关前的令牌认证），将 `DBX_WEB_HEADERS` 设置为 JSON 对象，键为请求头名称、值为字符串，例如 `{"Authorization":"Bearer <token>"}`。同样的变量在 DBX CLI 的 Web 模式下同样生效。
+
 DBX Web 和 Docker 同样需要独立 DuckDB 驱动。首次启动后可通过 Driver Manager 安装；Docker 会把驱动保存到 `/app/data/agents`，挂载 `/app/data` 数据卷后升级容器不会丢失。
 
 ### 桌面 UI 工具
@@ -153,6 +155,9 @@ DBX 在 **设置 → MCP** 中保存一份权威策略，并在每次请求时�
 | `DBX_DATA_DIR` | 覆盖本地 DBX 数据目录 |
 | `DBX_WEB_URL` | 使用 DBX Web/Docker 后端 |
 | `DBX_WEB_PASSWORD` | 登录 DBX Web |
+| `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | DBX Web 请求的标准系统代理变量；空值表示不走代理。认证格式 `http://user:pass@host:port` |
+| `NO_PROXY` | 上述代理的标准绕过列表（逗号分隔主机） |
+| `DBX_WEB_HEADERS` | DBX Web 请求附加的请求头 JSON 对象，例如 `{"Authorization":"Bearer token"}` |
 | `DBX_MCP_ALLOW_WRITES` | 仅用于升级兼容：`0`/`false` 使尚未配置的策略保持只读 |
 | `DBX_MCP_SCOPE_CONNECTION_ID` | 兼容旧配置：限制为一个连接 ID |
 | `DBX_MCP_SCOPE_CONNECTION_IDS` | 兼容旧配置：限制为多个连接 ID |

--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -128,6 +128,8 @@ Oracle, KingBase, and XuguDB require their matching native DBX Agent but no JRE.
 
 Set `DBX_WEB_URL` to use a deployed DBX Web backend instead of local connections. If the Web login is protected, also set `DBX_WEB_PASSWORD` to the same login password.
 
+DBX Web requests honor the standard system proxy environment variables: `HTTPS_PROXY`/`https_proxy` for https URLs, `HTTP_PROXY`/`http_proxy` for http URLs, with `ALL_PROXY`/`all_proxy` as the fallback and `NO_PROXY`/`no_proxy` (comma-separated hosts, e.g. `localhost,127.0.0.1,.internal.example`) as the bypass list. An empty or unset proxy value means direct connection (no proxy). HTTP, HTTPS, and SOCKS5 proxies are supported (`http://127.0.0.1:7890` or `socks5://127.0.0.1:1080`); proxies requiring authentication use the standard `user:password@host:port` URL form, e.g. `http://admin:admin123@127.0.0.1:7890`. To attach extra headers to every DBX Web request (for example token auth in front of a gateway), set `DBX_WEB_HEADERS` to a JSON object of header names and string values, e.g. `{"Authorization":"Bearer <token>"}`. The same variables are honored by the DBX CLI in Web mode.
+
 DBX Web and Docker require the same standalone DuckDB driver. Install it from Driver Manager after the first launch. Docker stores installed drivers under `/app/data/agents`, so they persist when `/app/data` is mounted as a volume.
 
 ### Desktop UI tools
@@ -153,6 +155,9 @@ Updated servers do not let `DBX_MCP_ALLOW_WRITES` or `DBX_MCP_ALLOW_DANGEROUS_SQ
 | `DBX_DATA_DIR` | Override the local DBX data directory |
 | `DBX_WEB_URL` | Use a DBX Web/Docker backend |
 | `DBX_WEB_PASSWORD` | Authenticate to DBX Web |
+| `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Standard system proxy variables for DBX Web requests; empty value means no proxy. Auth via `http://user:pass@host:port` |
+| `NO_PROXY` | Standard bypass list for the proxy above (comma-separated hosts) |
+| `DBX_WEB_HEADERS` | JSON object of extra HTTP headers for DBX Web requests, e.g. `{"Authorization":"Bearer token"}` |
 | `DBX_MCP_ALLOW_WRITES` | Upgrade compatibility only: `0`/`false` keeps an unconfigured policy read-only |
 | `DBX_MCP_SCOPE_CONNECTION_ID` | Compatibility scope for one connection ID |
 | `DBX_MCP_SCOPE_CONNECTION_IDS` | Compatibility scope for multiple connection IDs |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -198,6 +198,8 @@ Set `DBX_WEB_URL` to use a deployed DBX Web backend instead of local desktop sto
 
 `DBX_WEB_PASSWORD` is the password used on the DBX Web login page. Desktop-local mode does not use it. Desktop UI tools are hidden in Web mode.
 
+DBX Web requests honor the standard system proxy environment variables (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`, bypass via `NO_PROXY`); an empty value means no proxy. Proxies requiring authentication use the `http://user:pass@host:port` URL form. Extra headers can be attached via `DBX_WEB_HEADERS` (a JSON object, e.g. `{"Authorization":"Bearer <token>"}`) — applied to every request, including authentication.
+
 Docker and DBX Web also require the standalone DuckDB driver. Install it from Driver Manager after the first launch; when `/app/data` is persisted, the driver is stored under `/app/data/agents` and survives container upgrades.
 
 ### Windows portable DBX
@@ -264,6 +266,9 @@ SQL text is not included in normal MCP errors or logged by default. Enable tempo
 | `DBX_DATA_DIR` | Override the local DBX data directory |
 | `DBX_WEB_URL` | Use a DBX Web/Docker backend |
 | `DBX_WEB_PASSWORD` | Authenticate to the DBX Web backend |
+| `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Standard system proxy variables for DBX Web requests; empty value means no proxy. Auth via `http://user:pass@host:port` |
+| `NO_PROXY` | Standard comma-separated bypass list for the proxy above |
+| `DBX_WEB_HEADERS` | JSON object of extra HTTP headers for DBX Web requests, e.g. `{"Authorization":"Bearer token"}` |
 | `DBX_MCP_ALLOW_WRITES` | Upgrade compatibility only: `0`/`false` keeps an unconfigured policy read-only |
 | `DBX_MCP_SCOPE_CONNECTION_ID` | Compatibility scope for one connection ID |
 | `DBX_MCP_SCOPE_CONNECTION_IDS` | Compatibility scope for multiple connection IDs |
@@ -489,6 +494,8 @@ MCP 配置：
 
 Web 模式不会读取本机 DBX 桌面存储，也不会暴露桌面 UI 工具。
 
+DBX Web 请求遵循标准系统代理环境变量：https 地址读取 `HTTPS_PROXY`/`https_proxy`，http 地址读取 `HTTP_PROXY`/`http_proxy`，`ALL_PROXY`/`all_proxy` 作为兜底，`NO_PROXY`/`no_proxy` 作为绕过列表。代理值为空或未设置时直连（不走代理）。需要认证的代理使用标准 `user:password@host:port` URL 形式，例如 `http://admin:admin123@127.0.0.1:7890`。如需为每次 DBX Web 请求附加自定义请求头（例如网关前的令牌认证），将 `DBX_WEB_HEADERS` 设置为 JSON 对象，键为请求头名称、值为字符串，例如 `{"Authorization":"Bearer <token>"}`，该头会附加到包括认证在内的每个请求。
+
 ### Agent/JDBC 数据库
 
 达梦、人大金仓、Oracle、DB2、Hive、Trino、Snowflake、SAP HANA 等数据库通过 DBX Java Agent/JDBC 基础设施运行，而不是通过 Node.js 数据库驱动运行。
@@ -540,6 +547,9 @@ MongoDB 更新和删除在未启用完全访问时必须提供可验证有效的
 | `DBX_DATA_DIR` | 覆盖本地 DBX 数据目录 |
 | `DBX_WEB_URL` | 使用 DBX Web/Docker 后端 |
 | `DBX_WEB_PASSWORD` | DBX Web 登录密码 |
+| `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | DBX Web 请求的标准系统代理变量；空值表示不走代理。认证格式 `http://user:pass@host:port` |
+| `NO_PROXY` | 上述代理的标准逗号分隔绕过列表 |
+| `DBX_WEB_HEADERS` | DBX Web 请求附加的请求头 JSON 对象，例如 `{"Authorization":"Bearer token"}` |
 | `DBX_MCP_ALLOW_WRITES` | 仅用于升级兼容：`0`/`false` 使尚未配置的策略保持只读 |
 | `DBX_MCP_SCOPE_CONNECTION_ID` | 兼容旧配置：限制到指定连接 ID |
 | `DBX_MCP_SCOPE_CONNECTION_IDS` | 兼容旧配置：限制到多个连接 ID |


### PR DESCRIPTION
Closes #6008

## 概述

当 MCP 通过 `DBX_WEB_URL` 连接远程 DBX Web 后端时,本地的 `dbx-mcp` / `dbx-cli` 现在支持:

1. **标准系统代理环境变量** —— http 地址读取 `HTTP_PROXY`/`http_proxy`,https 地址读取 `HTTPS_PROXY`/`https_proxy`,`ALL_PROXY`/`all_proxy` 作为兜底,`NO_PROXY`/`no_proxy` 作为绕过列表;代理值为空或未设置时直连(不走代理)。支持 SOCKS5(reqwest `socks` feature)。
2. **代理认证** —— 使用标准 `user:password@host:port` URL 形式(如 `http://admin:admin123@127.0.0.1:7890`),自动生成 `Proxy-Authorization: Basic`。
3. **自定义请求头透传** —— 通过 `DBX_WEB_HEADERS`(JSON 对象,键为请求头名称、值为字符串)附加到每次 DBX Web 请求,包括 `/api/auth/check` 与 `/api/auth/login`,可对接网关级令牌认证(如 #6008 中的 authelia OIDC)。为避免与内部头冲突,保留头(`Cookie`、`x-dbx-mcp-request`、`Host`、`Content-Length`、`Connection`、`Transfer-Encoding`、`Proxy-Authorization`)会被拒绝。

`dbx-mcp` 与 `dbx-cli` 共用同一 `WebBackend`,两个入口均生效。

## 使用示例

```json
{
  "mcpServers": {
    "dbx": {
      "command": "dbx-mcp-server",
      "env": {
        "DBX_WEB_URL": "https://dbx.example.com",
        "DBX_WEB_PASSWORD": "web-login-password",
        "HTTPS_PROXY": "http://admin:admin123@127.0.0.1:7890",
        "NO_PROXY": "localhost,127.0.0.1",
        "DBX_WEB_HEADERS": "{\"Authorization\":\"Bearer <token>\"}"
      }
    }
  }
}
```

## 测试

- 46 个单元测试 + 集成测试全部通过,覆盖:代理路由(绝对形式请求)、代理认证(`Proxy-Authorization: Basic`)、认证与 API 请求的自定义头、NO_PROXY 绕过、空值直连语义、保留头拒绝、scheme 归一化。
- 已针对真实代理与真实 DBX Web 部署(`fn.azens.cn:4224/dbx`)端到端验证:认证、连接列表、查询执行均经认证代理成功完成。

文档同步更新:`docs/content/docs/mcp.mdx`、`mcp.cn.mdx`、`packages/mcp-server/README.md`(EN/CN 环境变量表)。