### PR TITLE
feat(ai): add OrcaRouter as a built-in AI provider

### DIFF
--- a/apps/desktop/public/icons/ai/orcarouter.svg
+++ b/apps/desktop/public/icons/ai/orcarouter.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="#000000" d="M12 2 21 7v10l-9 5-9-5V7zm-5.2 4.6L12 9.4l5.2-2.8-5.2-2.8zM6.8 8.2v7.2L11 17.9v-7.2zM12 10.4v7.5l4.2-2.4V8.2z"/></svg>

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -215,6 +215,16 @@ export const AI_PROVIDER_PRESETS: Record<AiProvider, AiProviderPreset> = {
     authMethod: "bearer",
     requiresApiKey: false,
   },
+  orcarouter: {
+    label: "OrcaRouter",
+    iconSlug: "orcarouter",
+    provider: "orcarouter",
+    endpoint: "https://api.orcarouter.ai/v1",
+    model: "orcarouter/fusion-flash",
+    apiStyle: "completions",
+    authMethod: "bearer",
+    requiresApiKey: true,
+  },
   "claude-code-cli": {
     label: "Claude Code CLI",
     iconSlug: "claudecode",
@@ -370,6 +380,7 @@ function normalizeAiConfigItem(config: AiConfigItem): AiConfigItem {
 function inferAiProviderFromConfig(config: Partial<AiConfig> | null | undefined): AiProvider {
   const endpoint = config?.endpoint?.toLowerCase() ?? "";
   const model = config?.model?.toLowerCase() ?? "";
+  if (endpoint.includes("orcarouter") || model.includes("orcarouter")) return "orcarouter";
   if (endpoint.includes("deepseek") || model.includes("deepseek")) return "deepseek";
   if (endpoint.includes("dashscope") || endpoint.includes("aliyuncs") || model.includes("qwen")) return "qwen";
   if (endpoint.includes("generativelanguage.googleapis.com") || model.includes("gemini")) return "gemini";

--- a/apps/desktop/src/types/ai.ts
+++ b/apps/desktop/src/types/ai.ts
@@ -1,4 +1,23 @@
-export type AiProvider = "claude" | "openai" | "gemini" | "deepseek" | "qwen" | "minimax" | "ollama" | "anthropic-compatible" | "openai-compatible" | "orcarouter" | "claude-code-cli" | "pi-agent-cli" | "codex-cli" | "opencode-cli" | "cursor-cli" | "grok-cli" | "codebuddy-cli" | "qoder-cli" | "custom";
+export type AiProvider =
+  | "claude"
+  | "openai"
+  | "gemini"
+  | "deepseek"
+  | "qwen"
+  | "minimax"
+  | "ollama"
+  | "anthropic-compatible"
+  | "openai-compatible"
+  | "orcarouter"
+  | "claude-code-cli"
+  | "pi-agent-cli"
+  | "codex-cli"
+  | "opencode-cli"
+  | "cursor-cli"
+  | "grok-cli"
+  | "codebuddy-cli"
+  | "qoder-cli"
+  | "custom";
 export type AiApiStyle = "completions" | "responses" | "anthropic-messages";
 export type AiAuthMethod = "api-key" | "bearer";
 export type AiEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";

--- a/apps/desktop/src/types/ai.ts
+++ b/apps/desktop/src/types/ai.ts
@@ -1,4 +1,4 @@
-export type AiProvider = "claude" | "openai" | "gemini" | "deepseek" | "qwen" | "minimax" | "ollama" | "anthropic-compatible" | "openai-compatible" | "claude-code-cli" | "pi-agent-cli" | "codex-cli" | "opencode-cli" | "cursor-cli" | "grok-cli" | "codebuddy-cli" | "qoder-cli" | "custom";
+export type AiProvider = "claude" | "openai" | "gemini" | "deepseek" | "qwen" | "minimax" | "ollama" | "anthropic-compatible" | "openai-compatible" | "orcarouter" | "claude-code-cli" | "pi-agent-cli" | "codex-cli" | "opencode-cli" | "cursor-cli" | "grok-cli" | "codebuddy-cli" | "qoder-cli" | "custom";
 export type AiApiStyle = "completions" | "responses" | "anthropic-messages";
 export type AiAuthMethod = "api-key" | "bearer";
 export type AiEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -73,6 +73,7 @@ pub enum AiProvider {
     Ollama,
     #[serde(rename = "openai-compatible")]
     OpenaiCompatible,
+    OrcaRouter,
     #[serde(rename = "codex-cli")]
     CodexCli,
     #[serde(rename = "claude-code-cli")]
@@ -104,6 +105,7 @@ impl AiProvider {
             AiProvider::MiniMax => "minimax",
             AiProvider::Ollama => "ollama",
             AiProvider::OpenaiCompatible => "openai-compatible",
+            AiProvider::OrcaRouter => "orcarouter",
             AiProvider::ClaudeCodeCli => "claude-code-cli",
             AiProvider::PiAgentCli => "pi-agent-cli",
             AiProvider::OpenCodeCli => "opencode-cli",
@@ -658,6 +660,7 @@ pub fn resolve_endpoint(config: &AiConfig) -> String {
         | AiProvider::MiniMax
         | AiProvider::Ollama
         | AiProvider::OpenaiCompatible
+        | AiProvider::OrcaRouter
         | AiProvider::Custom => {
             let base = ensure_openai_version_prefix(ep);
             if config.api_style == AiApiStyle::Responses {
@@ -1761,7 +1764,8 @@ pub async fn list_models_core(config: &AiConfig) -> Result<Vec<AiModelInfo>, Str
                 | AiProvider::Deepseek
                 | AiProvider::Qwen
                 | AiProvider::MiniMax
-                | AiProvider::OpenaiCompatible => list_openai_compatible_models(&client, config).await?,
+                | AiProvider::OpenaiCompatible
+                | AiProvider::OrcaRouter => list_openai_compatible_models(&client, config).await?,
                 AiProvider::Custom => {
                     if uses_anthropic_messages_api(config) {
                         list_claude_models(&client, config).await?
@@ -2802,7 +2806,8 @@ pub async fn complete(request: &AiCompletionRequest) -> Result<String, String> {
                 | AiProvider::Qwen
                 | AiProvider::MiniMax
                 | AiProvider::Ollama
-                | AiProvider::OpenaiCompatible => {
+                | AiProvider::OpenaiCompatible
+                | AiProvider::OrcaRouter => {
                     if request.config.api_style == AiApiStyle::Responses {
                         call_responses_api(&client, request).await
                     } else {
@@ -2863,7 +2868,8 @@ pub async fn stream(
         | AiProvider::Qwen
         | AiProvider::MiniMax
         | AiProvider::Ollama
-        | AiProvider::OpenaiCompatible => {
+        | AiProvider::OpenaiCompatible
+        | AiProvider::OrcaRouter => {
             if request.config.api_style == AiApiStyle::Responses {
                 stream_responses_api(&client, session_id, request, cancelled, &on_chunk).await
             } else {

--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -1337,6 +1337,7 @@ fn provider_requires_api_key(provider: &AiProvider) -> bool {
             | AiProvider::Deepseek
             | AiProvider::Qwen
             | AiProvider::MiniMax
+            | AiProvider::OrcaRouter
     )
 }
 
@@ -1449,12 +1450,18 @@ pub fn build_ai_http_client(config: &AiConfig, timeout_secs: u64) -> Result<reqw
 // Model listing
 // ---------------------------------------------------------------------------
 
-fn parse_model_list_response(data: &serde_json::Value) -> Result<Vec<AiModelInfo>, String> {
+fn parse_model_list_response_with_filter(
+    data: &serde_json::Value,
+    mut include_item: impl FnMut(&serde_json::Value) -> bool,
+) -> Result<Vec<AiModelInfo>, String> {
     let items = data["data"].as_array().ok_or_else(|| "Invalid model list response".to_string())?;
     let mut seen = HashSet::new();
     let mut models = Vec::new();
 
     for item in items {
+        if !include_item(item) {
+            continue;
+        }
         let Some(id) = item["id"].as_str().filter(|id| !id.trim().is_empty()) else {
             continue;
         };
@@ -1474,6 +1481,10 @@ fn parse_model_list_response(data: &serde_json::Value) -> Result<Vec<AiModelInfo
     }
 
     Ok(models)
+}
+
+fn parse_model_list_response(data: &serde_json::Value) -> Result<Vec<AiModelInfo>, String> {
+    parse_model_list_response_with_filter(data, |_| true)
 }
 
 fn parse_dynamic_effort_capability(
@@ -1647,7 +1658,13 @@ async fn list_openai_compatible_models(
         return Err(extract_error(&data).unwrap_or_else(|| format!("Model list API error: {status}")));
     }
 
-    parse_model_list_response(&data)
+    if matches!(config.provider, AiProvider::OrcaRouter) {
+        parse_model_list_response_with_filter(&data, |item| {
+            crate::ai_model_filter::orcarouter_item_supports_api_style(item, &config.api_style)
+        })
+    } else {
+        parse_model_list_response(&data)
+    }
 }
 
 fn resolve_ollama_show_endpoint(config: &AiConfig) -> Result<String, String> {
@@ -4591,6 +4608,16 @@ mod tests {
         config
     }
 
+    fn orcarouter_test_config(endpoint: impl Into<String>, api_style: AiApiStyle) -> AiConfig {
+        let mut config = test_config(AiProvider::OrcaRouter);
+        config.api_key = "secret".to_string();
+        config.auth_method = AiAuthMethod::Bearer;
+        config.endpoint = endpoint.into();
+        config.model = "orcarouter/fusion-flash".to_string();
+        config.api_style = api_style;
+        config
+    }
+
     fn minimax_test_request(endpoint: impl Into<String>) -> AiCompletionRequest {
         AiCompletionRequest {
             config: minimax_test_config(endpoint),
@@ -5428,11 +5455,28 @@ mod tests {
             AiProvider::Deepseek,
             AiProvider::Qwen,
             AiProvider::MiniMax,
+            AiProvider::OrcaRouter,
         ] {
             let config = AiConfig { provider, ..base.clone() };
             assert_eq!(validate_config(&config).unwrap_err(), "API key is required");
             assert_eq!(validate_model_list_config(&config).unwrap_err(), "API key is required");
         }
+    }
+
+    #[test]
+    fn orcarouter_requires_api_key_for_completion_and_model_discovery() {
+        let mut config = orcarouter_test_config("https://api.orcarouter.ai/v1", AiApiStyle::Completions);
+        config.api_key.clear();
+
+        assert!(provider_requires_api_key(&config.provider));
+        assert_eq!(validate_config(&config).unwrap_err(), "API key is required");
+        assert_eq!(validate_model_list_config(&config).unwrap_err(), "API key is required");
+
+        config.api_key = "secret".to_string();
+        let headers = maybe_bearer_headers(&config).unwrap();
+        assert_eq!(headers.get(AUTHORIZATION).unwrap(), "Bearer secret");
+        assert_eq!(resolve_endpoint(&config), "https://api.orcarouter.ai/v1/chat/completions");
+        assert_eq!(resolve_model_list_endpoint(&config).unwrap(), "https://api.orcarouter.ai/v1/models");
     }
 
     #[test]
@@ -6462,6 +6506,34 @@ mod tests {
         let request = server.await.unwrap().to_ascii_lowercase();
         assert!(request.starts_with("get /v1/models "));
         assert!(request.contains("authorization: bearer secret"));
+    }
+
+    #[tokio::test]
+    async fn orcarouter_model_list_matches_configured_openai_api_style() {
+        let response_body = r#"{"data":[
+            {"id":"deepseek/deepseek-chat","supported_endpoint_types":["openai"]},
+            {"id":"openai/gpt-response-only","supported_endpoint_types":["openai-response"]},
+            {"id":"orcarouter/fusion-flash","supported_endpoint_types":["openai","openai-response"]},
+            {"id":"google/gemini-embedding-001","supported_endpoint_types":["embeddings"]},
+            {"id":"openai/gpt-image-1","supported_endpoint_types":["image-generation"]},
+            {"id":"kling/kling-v3","supported_endpoint_types":["openai-video"]},
+            {"id":"vendor/missing-metadata"}
+        ]}"#;
+
+        for (api_style, expected_ids) in [
+            (AiApiStyle::Completions, vec!["deepseek/deepseek-chat", "orcarouter/fusion-flash"]),
+            (AiApiStyle::Responses, vec!["openai/gpt-response-only", "orcarouter/fusion-flash"]),
+        ] {
+            let (origin, server) = spawn_get_response_server("200 OK", response_body).await;
+            let config = orcarouter_test_config(format!("{origin}/v1"), api_style);
+
+            let models = list_models_core(&config).await.unwrap();
+
+            assert_eq!(models.iter().map(|model| model.id.as_str()).collect::<Vec<_>>(), expected_ids);
+            let request = server.await.unwrap().to_ascii_lowercase();
+            assert!(request.starts_with("get /v1/models "));
+            assert!(request.contains("authorization: bearer secret"));
+        }
     }
 
     #[tokio::test]

--- a/crates/dbx-core/src/ai_effort.rs
+++ b/crates/dbx-core/src/ai_effort.rs
@@ -79,7 +79,7 @@ pub fn static_effort_capability(config: &AiConfig, model_id: &str) -> Option<AiE
         AiProvider::Ollama => ollama_capability(&model, source),
         AiProvider::MiniMax if matches_family(&model, "minimax-m3") => Some(boolean_capability(source)),
         AiProvider::MiniMax => None,
-        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::Custom => {
+        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::OrcaRouter | AiProvider::Custom => {
             Some(AiEffortCapability::FreeText { placeholder: None, source: AiCapabilitySource::Custom })
         }
         AiProvider::Claude
@@ -192,6 +192,7 @@ pub fn registry_source_url(provider: &AiProvider) -> Option<&'static str> {
         AiProvider::Claude
         | AiProvider::AnthropicCompatible
         | AiProvider::OpenaiCompatible
+        | AiProvider::OrcaRouter
         | AiProvider::CodexCli
         | AiProvider::ClaudeCodeCli
         | AiProvider::PiAgentCli
@@ -267,7 +268,7 @@ pub fn apply_runtime_effort(body: &mut Value, config: &AiConfig) {
         AiProvider::Qwen => apply_qwen_effort(object, selection),
         AiProvider::Ollama => apply_openai_effort(object, &config.api_style, selection),
         AiProvider::MiniMax => apply_minimax_effort(object, selection),
-        AiProvider::Openai | AiProvider::OpenaiCompatible => apply_openai_effort(object, &config.api_style, selection),
+        AiProvider::Openai | AiProvider::OpenaiCompatible | AiProvider::OrcaRouter => apply_openai_effort(object, &config.api_style, selection),
         AiProvider::Custom => {
             if config.api_style == AiApiStyle::AnthropicMessages {
                 apply_claude_effort(object, selection);

--- a/crates/dbx-core/src/ai_effort.rs
+++ b/crates/dbx-core/src/ai_effort.rs
@@ -79,7 +79,10 @@ pub fn static_effort_capability(config: &AiConfig, model_id: &str) -> Option<AiE
         AiProvider::Ollama => ollama_capability(&model, source),
         AiProvider::MiniMax if matches_family(&model, "minimax-m3") => Some(boolean_capability(source)),
         AiProvider::MiniMax => None,
-        AiProvider::AnthropicCompatible | AiProvider::OpenaiCompatible | AiProvider::OrcaRouter | AiProvider::Custom => {
+        AiProvider::AnthropicCompatible
+        | AiProvider::OpenaiCompatible
+        | AiProvider::OrcaRouter
+        | AiProvider::Custom => {
             Some(AiEffortCapability::FreeText { placeholder: None, source: AiCapabilitySource::Custom })
         }
         AiProvider::Claude
@@ -268,7 +271,9 @@ pub fn apply_runtime_effort(body: &mut Value, config: &AiConfig) {
         AiProvider::Qwen => apply_qwen_effort(object, selection),
         AiProvider::Ollama => apply_openai_effort(object, &config.api_style, selection),
         AiProvider::MiniMax => apply_minimax_effort(object, selection),
-        AiProvider::Openai | AiProvider::OpenaiCompatible | AiProvider::OrcaRouter => apply_openai_effort(object, &config.api_style, selection),
+        AiProvider::Openai | AiProvider::OpenaiCompatible | AiProvider::OrcaRouter => {
+            apply_openai_effort(object, &config.api_style, selection)
+        }
         AiProvider::Custom => {
             if config.api_style == AiApiStyle::AnthropicMessages {
                 apply_claude_effort(object, selection);

--- a/crates/dbx-core/src/ai_model_filter.rs
+++ b/crates/dbx-core/src/ai_model_filter.rs
@@ -93,6 +93,7 @@ pub(crate) fn model_is_assistant_compatible(provider: &AiProvider, model_id: &st
         | AiProvider::Deepseek
         | AiProvider::Ollama
         | AiProvider::OpenaiCompatible
+        | AiProvider::OrcaRouter
         | AiProvider::CodexCli
         | AiProvider::ClaudeCodeCli
         | AiProvider::PiAgentCli

--- a/crates/dbx-core/src/ai_model_filter.rs
+++ b/crates/dbx-core/src/ai_model_filter.rs
@@ -1,4 +1,4 @@
-use crate::ai::{AiModelInfo, AiProvider};
+use crate::ai::{AiApiStyle, AiModelInfo, AiProvider};
 use serde_json::Value;
 
 // Provider model-family exclusions last checked against official catalogs on 2026-07-27.
@@ -131,6 +131,21 @@ pub(crate) fn gemini_item_is_assistant_compatible(item: &Value) -> bool {
     })
 }
 
+pub(crate) fn orcarouter_item_supports_api_style(item: &Value, api_style: &AiApiStyle) -> bool {
+    let required_endpoint_type = match api_style {
+        AiApiStyle::Completions => "openai",
+        AiApiStyle::Responses => "openai-response",
+        AiApiStyle::AnthropicMessages => return false,
+    };
+
+    item["supported_endpoint_types"].as_array().is_some_and(|endpoint_types| {
+        endpoint_types
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|endpoint_type| endpoint_type.eq_ignore_ascii_case(required_endpoint_type))
+    })
+}
+
 fn ollama_capability(data: &Value, expected: &str) -> Option<bool> {
     let capabilities = data["capabilities"].as_array()?;
     if capabilities.is_empty() {
@@ -151,9 +166,9 @@ pub(crate) fn ollama_tool_capability(data: &Value) -> Option<bool> {
 mod tests {
     use super::{
         gemini_item_is_assistant_compatible, model_is_assistant_compatible, ollama_completion_capability,
-        ollama_tool_capability,
+        ollama_tool_capability, orcarouter_item_supports_api_style,
     };
-    use crate::ai::AiProvider;
+    use crate::ai::{AiApiStyle, AiProvider};
 
     #[test]
     fn openai_filter_keeps_assistant_models_and_hides_specialized_endpoints() {
@@ -251,6 +266,24 @@ mod tests {
         assert!(gemini_item_is_assistant_compatible(&serde_json::json!({
             "name": "models/future-chat-model"
         })));
+    }
+
+    #[test]
+    fn orcarouter_filter_matches_configured_openai_api_style() {
+        let chat_model = serde_json::json!({
+            "id": "orcarouter/fusion-flash",
+            "supported_endpoint_types": ["openai", "openai-response"]
+        });
+        assert!(orcarouter_item_supports_api_style(&chat_model, &AiApiStyle::Completions));
+        assert!(orcarouter_item_supports_api_style(&chat_model, &AiApiStyle::Responses));
+        assert!(!orcarouter_item_supports_api_style(&chat_model, &AiApiStyle::AnthropicMessages));
+
+        for endpoint_type in ["embeddings", "image-generation", "openai-video"] {
+            let specialized_model = serde_json::json!({ "supported_endpoint_types": [endpoint_type] });
+            assert!(!orcarouter_item_supports_api_style(&specialized_model, &AiApiStyle::Completions));
+            assert!(!orcarouter_item_supports_api_style(&specialized_model, &AiApiStyle::Responses));
+        }
+        assert!(!orcarouter_item_supports_api_style(&serde_json::json!({}), &AiApiStyle::Completions));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add [OrcaRouter](https://www.orcarouter.ai) as a built-in named AI provider, mirroring the existing named-provider pattern (OpenAI, Claude, Deepseek, Ollama, etc.) instead of requiring users to configure it as a generic OpenAI-compatible endpoint.

OrcaRouter is an OpenAI-compatible gateway at `https://api.orcarouter.ai/v1` exposing 199 models across many families (`orcarouter/free`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `anthropic/*`, `deepseek/*`, `google/*`, …). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes
- `crates/dbx-core/src/ai.rs`: add `OrcaRouter` to the `AiProvider` enum; route through `resolve_endpoint`, `list_models_core`, `complete`, and `stream` via the OpenAI-compatible code paths.
- `crates/dbx-core/src/ai_effort.rs`, `crates/dbx-core/src/ai_model_filter.rs`: include OrcaRouter in the OpenAI-compatible effort/model-handling arms.
- `apps/desktop/src/types/ai.ts`: add `"orcarouter"` to the `AiProvider` union.
- `apps/desktop/src/stores/settingsStore.ts`: add an `orcarouter` entry to `AI_PROVIDER_PRESETS` (endpoint `https://api.orcarouter.ai/v1`, default model `orcarouter/fusion-flash`, bearer auth, API key required) and inference in `inferAiProviderFromConfig`.
- `apps/desktop/public/icons/ai/orcarouter.svg`: new provider icon.

## Verification
- Audited every exhaustive `AiProvider` match arm across the crate (the only exhaustive matches are in the three Rust files above; storage round-trips and the snippet-sync provider are serde/other-enum based).
- `cargo check -p dbx-core` could not run in my environment: `openssl-sys` vendored OpenSSL build fails on this Windows box due to a broken Git-Bash perl (missing core CPAN modules). This is pre-existing and unrelated to this change.
- Frontend types are consistent with the `Record<AiProvider, AiProviderPreset>` constraint.

Closes #6287

---
_I'm an engineer on the OrcaRouter team._
