### PR TITLE
fix(ui): use tabular-nums for live progress counters

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -8304,7 +8304,7 @@ function openExternalUrl(url: string) {
           <div class="flex items-center justify-between gap-3">
             <div class="min-w-0">
               <div class="truncate text-sm font-medium">{{ agentInstallLabel || agentInstallDriverKey }}</div>
-              <div class="mt-1 text-xs text-muted-foreground">{{ agentInstallProgressLabel }}</div>
+              <div class="mt-1 text-xs text-muted-foreground tabular-nums">{{ agentInstallProgressLabel }}</div>
             </div>
             <Loader2 v-if="agentInstallRunning && !agentInstallError" class="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
           </div>

--- a/apps/desktop/src/components/editor/MultiDbExecuteDialog.vue
+++ b/apps/desktop/src/components/editor/MultiDbExecuteDialog.vue
@@ -723,7 +723,7 @@ watch(
       </DialogHeader>
 
       <div v-if="executionStarted && batch" class="flex min-h-0 flex-1 flex-col">
-        <div class="flex shrink-0 flex-wrap items-center gap-2 border-b bg-muted/20 px-5 py-3 text-xs text-muted-foreground">
+        <div class="flex shrink-0 flex-wrap items-center gap-2 border-b bg-muted/20 px-5 py-3 text-xs text-muted-foreground tabular-nums">
           <span>{{ t("multiDbExecute.progress", { completed: progressCompleted, total: batch.items.length }) }}</span>
           <Badge variant="secondary">{{ executionModeLabel() }}</Badge>
           <span class="tabular-nums">{{ t("multiDbExecute.elapsed", { duration: formatDataTransferDuration(elapsedMs) }) }}</span>

--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -893,7 +893,7 @@ watch(
               <div v-else class="h-full rounded-full transition-[width] duration-300" :class="exportError ? 'bg-destructive' : exportCancelled ? 'bg-yellow-500' : exportDone ? 'bg-green-500' : 'bg-primary'" :style="{ width: `${exportDone ? 100 : progressPercent}%` }" />
             </div>
 
-            <div v-if="exportProgress && !isPreparingExport" class="text-xs text-muted-foreground">
+            <div v-if="exportProgress && !isPreparingExport" class="text-xs text-muted-foreground tabular-nums">
               {{ exportAllDatabases ? t("databaseExport.allRowsExported", { count: exportProgress.rowsExported.toLocaleString() }) : t("databaseExport.rowsExported", { current: exportProgress.objectIndex, total: exportProgress.totalObjects, count: exportProgress.rowsExported.toLocaleString() }) }}
             </div>
             <div v-if="exportElapsedText" class="text-xs text-muted-foreground tabular-nums">

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -11249,7 +11249,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
               <div v-if="gridSurfaceBusy" class="absolute inset-0 z-20 bg-background/50 flex items-center justify-center">
                 <div class="flex items-center gap-2 rounded-md border bg-background px-3 py-1.5 text-xs text-muted-foreground shadow-sm">
                   <Loader2 class="w-3.5 h-3.5 animate-spin" />
-                  <span>{{ formatElapsedSeconds(loadingElapsed) }}s</span>
+                  <span class="tabular-nums">{{ formatElapsedSeconds(loadingElapsed) }}s</span>
                 </div>
               </div>
             </template>

--- a/apps/desktop/src/components/import/TableImportDialog.vue
+++ b/apps/desktop/src/components/import/TableImportDialog.vue
@@ -1429,7 +1429,7 @@ watch(rawProgressPercent, (percent) => {
               <FileUp v-else class="h-5 w-5 text-muted-foreground" />
               <div class="min-w-0 flex-1">
                 <div class="text-sm font-medium">{{ t(progressLabelKey) }}</div>
-                <div class="mt-1 text-xs text-muted-foreground">
+                <div class="mt-1 text-xs text-muted-foreground tabular-nums">
                   <template v-if="progress?.totalRowsExact !== false && (progress?.totalRows ?? 0) > 0">{{ progress?.rowsImported ?? 0 }} / {{ progress?.totalRows ?? 0 }}</template>
                   <template v-else>{{ progress?.rowsImported ?? 0 }} {{ t("tableImport.rowsImported") }}</template>
                   · {{ progressPercent }}% ·

--- a/apps/desktop/src/components/layout/UpdateDialog.vue
+++ b/apps/desktop/src/components/layout/UpdateDialog.vue
@@ -154,7 +154,7 @@ watch(
               <Loader2 class="h-4 w-4 animate-spin" />
               {{ t("updates.installing") }}
             </Button>
-            <Button v-else-if="isDownloadingUpdate" class="w-52" disabled>
+            <Button v-else-if="isDownloadingUpdate" class="w-52 tabular-nums" disabled>
               <Loader2 class="h-4 w-4 animate-spin" />
               {{ t("updates.downloading", { progress: downloadProgress }) }}
             </Button>

--- a/apps/desktop/src/components/lineage/FieldLineageDialog.vue
+++ b/apps/desktop/src/components/lineage/FieldLineageDialog.vue
@@ -317,7 +317,7 @@ function openItemTarget(item: FieldLineageItem) {
 
         <div class="min-h-0 flex-1 overflow-y-auto px-6 py-4">
           <div v-if="loading" class="rounded-md border bg-muted/20 p-4">
-            <div class="flex items-center gap-2 text-sm text-muted-foreground">
+            <div class="flex items-center gap-2 text-sm text-muted-foreground tabular-nums">
               <Loader2 class="h-4 w-4 animate-spin" />
               {{ t("lineage.loading", { done: progressDone, total: progressTotal || "-" }) }}
             </div>

--- a/apps/desktop/src/components/search/DatabaseSearchDialog.vue
+++ b/apps/desktop/src/components/search/DatabaseSearchDialog.vue
@@ -309,8 +309,8 @@ function openResult(item: SearchResultItem) {
         </div>
 
         <div v-if="running || progressTotal" class="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-          <span>{{ loadingTables ? t("databaseSearch.loadingTables") : progressLabel }}</span>
-          <span>{{ t("databaseSearch.resultCount", { count: results.length }) }}</span>
+          <span class="tabular-nums">{{ loadingTables ? t("databaseSearch.loadingTables") : progressLabel }}</span>
+          <span class="tabular-nums">{{ t("databaseSearch.resultCount", { count: results.length }) }}</span>
           <span v-if="limitedTables" class="text-amber-600">{{ t("databaseSearch.limitedTables", { count: 200 }) }}</span>
         </div>
 

--- a/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
+++ b/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
@@ -692,7 +692,7 @@ watch(
 
           <div v-if="running && previews.length > 1 && currentFileIndex >= 0" class="flex items-center gap-1.5 text-xs text-muted-foreground">
             <FileCode class="w-3.5 h-3.5 shrink-0" />
-            <span class="truncate">{{ t("sqlFile.fileProgress", { current: currentFileIndex + 1, total: previews.length }) }} — {{ currentFileName }}</span>
+            <span class="truncate tabular-nums">{{ t("sqlFile.fileProgress", { current: currentFileIndex + 1, total: previews.length }) }} — {{ currentFileName }}</span>
           </div>
 
           <template v-if="!running && previews.length > 1 && perFileResults.length > 0">
@@ -741,23 +741,23 @@ watch(
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
               <div class="border rounded-md px-2 py-1.5 min-w-0">
                 <div class="text-muted-foreground truncate">{{ t("sqlFile.statement") }}</div>
-                <div class="font-medium truncate">{{ progress?.statementIndex ?? 0 }}</div>
+                <div class="font-medium truncate tabular-nums">{{ progress?.statementIndex ?? 0 }}</div>
               </div>
               <div class="border rounded-md px-2 py-1.5 min-w-0">
                 <div class="text-muted-foreground truncate">{{ t("sqlFile.succeeded") }}</div>
-                <div class="font-medium text-green-600 truncate">
+                <div class="font-medium text-green-600 truncate tabular-nums">
                   {{ progress?.successCount ?? 0 }}
                 </div>
               </div>
               <div class="border rounded-md px-2 py-1.5 min-w-0">
                 <div class="text-muted-foreground truncate">{{ t("sqlFile.failed") }}</div>
-                <div class="font-medium text-destructive truncate">
+                <div class="font-medium text-destructive truncate tabular-nums">
                   {{ progress?.failureCount ?? 0 }}
                 </div>
               </div>
               <div class="border rounded-md px-2 py-1.5 min-w-0">
                 <div class="text-muted-foreground truncate">{{ t("sqlFile.affectedRows") }}</div>
-                <div class="font-medium truncate">
+                <div class="font-medium truncate tabular-nums">
                   {{ (progress?.affectedRows ?? 0).toLocaleString() }}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Live progress counters (download %, rows imported/exported, elapsed seconds, count badges) jitter because the font uses proportional numerals — `1` is narrower than `0`, so the text reflows as digits change.

This PR adds the `tabular-nums` utility (`font-variant-numeric: tabular-nums`) to all live counters for fixed-width digits. The repo already uses it elsewhere (elapsed timers, grid numeric cells, dashboard metrics); this makes the remaining counters consistent.

## Changes

All in `apps/desktop/src/components/`:

| File | Counter fixed |
| --- | --- |
| `layout/UpdateDialog.vue` | Download % |
| `import/TableImportDialog.vue` | Rows imported + % |
| `export/DatabaseExportDialog.vue` | Rows exported |
| `connection/ConnectionDialog.vue` | Agent install bytes + % |
| `editor/MultiDbExecuteDialog.vue` | Completed/total + count badges |
| `lineage/FieldLineageDialog.vue` | Loading done/total |
| `search/DatabaseSearchDialog.vue` | Table loading + result count |
| `grid/DataGrid.vue` | Elapsed seconds |
| `sql-file/SqlFileExecutionDialog.vue` | File progress + stat counters |

## Video

Side-by-side comparison, same counters cycling 0→100%: **left = without fix** (numbers jitter), **right = with fix** (stable). Same values on both sides, so the only difference is digit width.

https://github.com/user-attachments/assets/e98a4c81-d6b9-45fe-b45d-07bed7bcaaf5


## Testing

UI-only change (one utility class per element). Verified on a temporary dev preview page (`/preview.html`) showing all 9 counters with and without `tabular-nums`; the video above is from that page. No logic changed, no tests needed.