### PR TITLE
fix(kafka): 恢复消息页签纵向滚动

### DIFF
--- a/apps/desktop/src/components/mq/KafkaMessagesPanel.vue
+++ b/apps/desktop/src/components/mq/KafkaMessagesPanel.vue
@@ -156,7 +156,21 @@ watch(selectedTopic, (topic) => emit("topicSelected", topic));
 }
 
 .kafka-messages-panel {
+  height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+  overflow: hidden;
   padding: 16px;
+}
+
+.panel-toolbar {
+  flex-shrink: 0;
+}
+
+.kafka-messages-content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .kafka-topic-section,

--- a/apps/desktop/src/components/mq/__tests__/KafkaMessagesPanel.spec.ts
+++ b/apps/desktop/src/components/mq/__tests__/KafkaMessagesPanel.spec.ts
@@ -152,4 +152,20 @@ describe("KafkaMessagesPanel", () => {
     expect(panel.querySelector('[data-testid="message-browser"]')).not.toBeNull();
     warning.mockRestore();
   });
+
+  it("keeps the topic toolbar outside the scrolling content area (issue #6267)", async () => {
+    const panel = await mountPanel();
+    const panelRoot = panel.querySelector<HTMLElement>(".kafka-messages-panel");
+    const toolbar = panelRoot?.querySelector<HTMLElement>(".panel-toolbar");
+    const content = panelRoot?.querySelector<HTMLElement>(".kafka-messages-content");
+
+    expect(panelRoot).not.toBeNull();
+    expect(toolbar).not.toBeNull();
+    expect(content).not.toBeNull();
+    // The toolbar must not live inside the scroll container so topic refresh
+    // stays reachable after scrolling; it must also precede it in layout order.
+    expect(content!.contains(toolbar!)).toBe(false);
+    const children = [...panelRoot!.children].map((child) => child.className);
+    expect(children.indexOf("panel-toolbar")).toBeLessThan(children.indexOf("kafka-messages-content"));
+  });
 });


### PR DESCRIPTION
## 变更说明

- 恢复 Kafka 消息页签受限高度下的纵向滚动
- 将 Topic 工具栏保留在滚动区域之外，滚动后仍可操作
- 增加工具栏与内容区结构的回归测试

## 问题原因

MQ 内容容器会裁剪溢出内容，但 Kafka 消息组合面板没有定义受限高度下的纵向滚动区域。分区概览、消息浏览器和嵌入式消息发送表单的总高度超过可用空间后，超出部分会被直接裁剪，页面也不会出现滚动条。

本次调整让 Kafka 消息面板占满可用高度，并由内容区域统一承担纵向滚动；Topic 工具栏保持固定可见。

Fixes #6267

## 验证结果

- `pnpm vitest run apps/desktop/src/components/mq/__tests__/KafkaMessagesPanel.spec.ts`：4 项测试通过
- `pnpm typecheck`：通过
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/mq/KafkaMessagesPanel.vue apps/desktop/src/components/mq/__tests__/KafkaMessagesPanel.spec.ts`：通过

