### PR TITLE
fix(jdbc): use non-empty Java test fixtures

### DIFF
--- a/crates/dbx-core/src/agent_manager.rs
+++ b/crates/dbx-core/src/agent_manager.rs
@@ -77,7 +77,7 @@ mod tests {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).unwrap();
         }
-        fs::write(path, b"").unwrap();
+        fs::write(path, b"test executable").unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -6200,7 +6200,7 @@ mod tests {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
-        std::fs::write(path, b"").unwrap();
+        std::fs::write(path, b"test executable").unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary

- update managed-JRE test fixtures to create non-empty executable files
- align the fixtures with the production installed-runtime validation

## Validation

- `cargo test -p dbx-core --locked --no-default-features --lib agent_manager::tests::resolves_managed_java_runtime_by_default -- --exact`
- `cargo test -p dbx-core --locked --no-default-features --lib connection::tests::jdbc_plugin_env_uses_managed_jre_when_installed -- --exact`
- `cargo fmt --all -- --check`
