### PR TITLE
fix(transfer): widen gap between object list and dialog scrollbars

### DIFF
--- a/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
+++ b/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
@@ -202,8 +202,10 @@ function groupSelectionState(kind: TransferObjectKind, items: string[]): "none" 
       {{ t("transfer.noObjects") }}
     </div>
 
-    <!-- Independent scroll area for tree groups -->
-    <div v-else class="flex-1 min-h-0 max-h-[240px] flex flex-col gap-1.5 overflow-y-auto rounded-md border border-border/80 bg-muted/10 p-1.5 scrollbar-thin scrollbar-thumb-muted-foreground/20">
+    <!-- Independent scroll area for tree groups. mr-4 keeps this box's own
+         scrollbar clear of the dialog's outer scrollbar (only pr-1 away in
+         DataTransferDialog.vue) so the two hit areas don't overlap. -->
+    <div v-else class="flex-1 min-h-0 max-h-[240px] flex flex-col gap-1.5 overflow-y-auto rounded-md border border-border/80 bg-muted/10 p-1.5 mr-4 scrollbar-thin scrollbar-thumb-muted-foreground/20">
       <div v-for="group in filteredGroups" :key="group.kind" :data-test="`group-${group.kind}`" class="rounded-lg border border-border/60 bg-card/60 transition-all hover:bg-card flex flex-col p-1.5" :class="{ 'opacity-50 bg-muted/5 border-dashed border-muted': isGroupDisabled(group.kind) }">
         <div class="flex items-center gap-2 px-1 py-0.5 select-none">
           <button :data-test="'group-toggle'" :data-state="groupSelectionState(group.kind, group.items)" type="button" class="flex items-center gap-2 text-left shrink-0" :disabled="isGroupDisabled(group.kind)" @click="!isGroupDisabled(group.kind) && toggleGroupAll(group.kind, group.items)">


### PR DESCRIPTION
## Problem

In the Data Transfer dialog, the object-selection tree ("Tables"/"Views"/etc. list) renders its own independently-scrollable box (`max-h-[240px] overflow-y-auto`) nested inside the dialog's own outer scrollable container (`overflow-y-auto pl-4 pr-1`). The two containers' right edges sat only ~4px apart, so on any platform with a real (non-overlay) scrollbar, the two scrollbars' hit-areas overlap or nearly touch — a slight mouse offset while trying to scroll the table list ends up dragging the dialog's own scrollbar instead.

## Root cause

Measured on the live DOM (via `getBoundingClientRect`) with a source database selected (30 tables, enough to force the inner box to scroll):
- Outer dialog scroll container right edge: `x=1243`, `scrollHeight=720 > clientHeight=433`
- Inner object-list box right edge: `x=1239`, `scrollHeight=1192 > clientHeight=238`
- Gap: **4px** — smaller than any realistic scrollbar width (8–18px depending on OS/theme), so the two scrollbar hit-areas necessarily collide.

## Fix

Added `mr-4` to the inner object-list scroll box in `ObjectSelectionTree.vue`, widening the gap from 4px to 20px — comfortably clearing common scrollbar widths (including the ~17px Windows classic scrollbar) so the two hit-areas no longer overlap.

## Testing

- Reproduced against a real MySQL 8.0 database (30 tables) through the actual running app (real `dbx-web` backend + `pnpm dev:web` frontend), measuring the two scroll containers' geometry before and after the fix.
- Could not capture a literal before/after screenshot of overlapping scrollbar thumbs: headless Chromium (this sandbox, macOS) always renders 0-width overlay scrollbars regardless of `--disable-features=OverlayScrollbar` / forced `::-webkit-scrollbar` CSS, so a classic OS scrollbar never paints pixels here. The DOM geometry measurement is the objective substitute.
- `pnpm typecheck` clean, `pnpm lint` (oxlint) clean, full test suite: 6319/6319 passed.
- Rebased cleanly onto latest `upstream/main`.

Fixes #6246