### PR TITLE
fix(editor): honor the configured accept-completion shortcut on Tab

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -748,7 +748,25 @@ function editorIndentUnit(): string {
 }
 
 function handleTab(view: EditorViewType): boolean {
-  return acceptCompletionOrNextSnippetField(view) || performNormalTab(view);
+  if (tabKeyAcceptsCompletion()) {
+    return acceptCompletionOrNextSnippetField(view) || performNormalTab(view);
+  }
+  return handleTabWithoutAcceptingCompletion(view) || performNormalTab(view);
+}
+
+// The Tab key is always wired up for indentation and snippet-field navigation,
+// but it must only accept an open completion popup when the user's configured
+// "accept completion" shortcut is actually Tab — otherwise a user who remapped
+// that shortcut (e.g. to Enter) would find Tab silently accepting completions
+// anyway, ignoring their setting (dbx#6236).
+function tabKeyAcceptsCompletion(): boolean {
+  const shortcuts = normalizeShortcutSettings(settingsStore.editorSettings.shortcuts);
+  return shortcutToCodeMirrorKey(shortcuts.acceptCompletion) === "Tab";
+}
+
+function handleTabWithoutAcceptingCompletion(view: EditorViewType): boolean {
+  if (codeMirrorCompletionStatus?.(view.state)) return false;
+  return codeMirrorNextSnippetField?.(view) ?? false;
 }
 
 function performNormalTab(view: EditorViewType): boolean {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import ts from "typescript";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SHORTCUT_SETTINGS, normalizeShortcutSettings, shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
 
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 
@@ -59,6 +60,7 @@ function createHarness(options: {
   insertNewlineKeepIndent?: (view: MockView) => boolean;
   nextSnippetField?: (view: MockView) => boolean;
   indentMore?: (view: MockView) => boolean;
+  acceptCompletionShortcut?: string;
 }): TabHarness {
   const source = [
     extractDeclaration(/const COMPLETION_REMOTE_LATENCY_BUDGET_MS = \d+;/, "remote completion latency budget"),
@@ -69,6 +71,8 @@ function createHarness(options: {
     "let suppressNextSqlCompletionAutoStartUntil = 0;",
     extractFunction("editorIndentUnit"),
     extractFunction("handleTab"),
+    extractFunction("tabKeyAcceptsCompletion"),
+    extractFunction("handleTabWithoutAcceptingCompletion"),
     extractFunction("performNormalTab"),
     extractFunction("insertNewlineWithoutCompletion"),
     extractFunction("acceptCompletionOrNextSnippetField"),
@@ -87,11 +91,26 @@ function createHarness(options: {
     "codeMirrorNextSnippetField",
     "codeMirrorIndentMore",
     "settingsStore",
+    "normalizeShortcutSettings",
+    "shortcutToCodeMirrorKey",
     `${javascript}\nreturn { handleTab, insertNewlineWithoutCompletion, acceptCompletionOrNextSnippetField, clearPendingCompletionTab, consumeSqlCompletionAutoStartSuppression };`,
   );
-  return factory(options.completionStatus, options.acceptCompletion ?? (() => false), options.closeCompletion ?? (() => false), options.insertNewlineKeepIndent ?? (() => false), options.nextSnippetField ?? (() => false), options.indentMore ?? (() => false), {
-    editorSettings: { sqlFormatter: { useTabs: false, tabWidth: 2 } },
-  }) as TabHarness;
+  return factory(
+    options.completionStatus,
+    options.acceptCompletion ?? (() => false),
+    options.closeCompletion ?? (() => false),
+    options.insertNewlineKeepIndent ?? (() => false),
+    options.nextSnippetField ?? (() => false),
+    options.indentMore ?? (() => false),
+    {
+      editorSettings: {
+        sqlFormatter: { useTabs: false, tabWidth: 2 },
+        shortcuts: { ...DEFAULT_SHORTCUT_SETTINGS, acceptCompletion: options.acceptCompletionShortcut ?? DEFAULT_SHORTCUT_SETTINGS.acceptCompletion },
+      },
+    },
+    normalizeShortcutSettings,
+    shortcutToCodeMirrorKey,
+  ) as TabHarness;
 }
 
 function createView(text = "SELECT", position = text.length): MockView {
@@ -235,6 +254,27 @@ describe("QueryEditor completion Tab keymap", () => {
     expect(acceptCompletion).toHaveBeenCalledTimes(2);
     expect(acceptCompletion).toHaveBeenLastCalledWith(view);
     expect(view.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not accept an open completion popup on Tab when the configured accept-completion shortcut is Enter (dbx#6236)", () => {
+    const acceptCompletion = vi.fn(() => true);
+    const nextSnippetField = vi.fn(() => true);
+    const harness = createHarness({ completionStatus: () => "active", acceptCompletion, nextSnippetField, acceptCompletionShortcut: "Enter" });
+    const view = createView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    expect(acceptCompletion).not.toHaveBeenCalled();
+    expect(nextSnippetField).not.toHaveBeenCalled();
+    expect(view.state.replaceSelection).toHaveBeenCalledWith("  ");
+  });
+
+  it("still accepts an open completion popup on Tab when the configured shortcut is left at its Tab default", () => {
+    const acceptCompletion = vi.fn(() => true);
+    const harness = createHarness({ completionStatus: () => "active", acceptCompletion, acceptCompletionShortcut: "Tab" });
+    const view = createView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    expect(acceptCompletion).toHaveBeenCalledWith(view);
   });
 
   it("falls back to normal Tab when pending completion has no candidate", async () => {


### PR DESCRIPTION
## Problem

The completion popup in the SQL editor always accepted on Tab, even when the user remapped the "Accept completion" shortcut in Settings to something else (e.g. Enter). That made the shortcut setting effectively decorative for the Tab key: users had no way to stop Tab from silently accepting a completion they didn't want.

## Root cause

`QueryEditor.vue` wires Tab up in two independent places:

1. A shortcut-aware binding driven by `settings.shortcuts.acceptCompletion` — this one correctly respects the user's configured key.
2. A separate `Prec.highest` **hardcoded** `{ key: "Tab", run: handleTab }` binding, used to handle plain indentation and snippet-field navigation when Tab is pressed.

`handleTab` unconditionally called `acceptCompletionOrNextSnippetField`, which accepts any currently-active completion popup — regardless of what the user configured as their accept-completion shortcut. Since this binding has the highest precedence, it silently overrode the user's setting.

## Fix

`handleTab` now only accepts an active completion via Tab when the configured `acceptCompletion` shortcut actually resolves to Tab (`tabKeyAcceptsCompletion()`). When it doesn't, Tab falls through to `handleTabWithoutAcceptingCompletion` (keeps snippet-field navigation, skips accepting completion) and then normal indentation, leaving the completion popup open so the user can accept it with their configured key instead.

## Testing

Reproduced against real production code with vitest (`QueryEditor.vue`'s `handleTab` extracted and exercised directly, per this repo's existing test convention for this file):

- Added a regression test that configures the accept-completion shortcut to `Enter` and presses Tab while a completion is active. Against the pre-fix code this test genuinely fails (`acceptCompletion` gets called once despite the config). Against the fix it passes.
- Added a second regression test confirming Tab still accepts completion when the shortcut is left at its default (`Tab`) — no behavior change for the default/unconfigured case.
- `pnpm exec vitest run`: 967 files / 9252 tests passing.
- `pnpm typecheck`: clean.
- `pnpm lint`: clean (no new warnings; pre-existing warnings are all in unrelated files).

Fixes #6236