### PR TITLE
fix(nacos): force full syntax tree before first paint in config editor

### DIFF
--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, useId, watch } from "vue";
 import { Compartment, type Extension } from "@codemirror/state";
-import { StreamLanguage } from "@codemirror/language";
+import { StreamLanguage, ensureSyntaxTree } from "@codemirror/language";
 import type { EditorView } from "@codemirror/view";
 import { Archive, ArrowLeftRight, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, Clipboard, Columns3, Download, FileClock, FileInput, FileText, Loader2, Network, Plus, RefreshCw, Save, Search, Send, Server, Trash2, X } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
@@ -518,69 +518,68 @@ async function mountConfigEditor() {
   configEditorFontSize.value = clampEditorFontSize(editorSettings.fontSize);
   const theme = await loadEditorTheme(editorSettings.theme, editorThemeAppearance(), currentCustomThemeColors(), themePalette.value);
   if (generation !== configEditorGeneration || editorSessionId !== configEditorSessionId || host !== configEditorHost.value || configEditorView.value || !selectedConfig.value) return;
-  const view = new EditorView({
-    parent: host,
-    state: EditorState.create({
-      doc: content,
-      extensions: [
-        cmSearch({
-          top: true,
-          createPanel: () => {
-            const dom = document.createElement("span");
-            dom.style.display = "none";
-            return { dom };
-          },
-        }),
-        basicSetup,
-        EditorState.allowMultipleSelections.of(true),
-        trimmedSelectionLayer(),
-        Prec.highest(keymap.of([{ key: "Mod-f", run: () => configSearchPanelRef.value?.openSearch() ?? false, preventDefault: true }, { key: "Mod-h", run: () => configSearchPanelRef.value?.openReplace() ?? false, preventDefault: true }, indentWithTab])),
-        keymap.of([...defaultKeymap, ...historyKeymap]),
-        EditorView.domEventHandlers({
-          wheel(event, eventView) {
-            if (!event.metaKey && !event.ctrlKey) return false;
-            event.preventDefault();
-            const next = fontSizeFromWheelDelta(configEditorFontSize.value, event.deltaY);
-            if (next !== configEditorFontSize.value) {
-              configEditorFontSize.value = next;
-              eventView.dispatch({
-                effects: configEditorFontTheme.reconfigure(editorFontTheme(EditorView, next, settingsStore.editorSettings.fontFamily, { fixedHeight: true, scrollable: true })),
-              });
-            }
-            configEditorZoomCommitScheduler.schedule(next);
-            return true;
-          },
-        }),
-        configEditorLanguage.of(language),
-        configEditorTheme.of(theme),
-        configEditorFontTheme.of(editorFontTheme(EditorView, editorSettings.fontSize, editorSettings.fontFamily, { fixedHeight: true, scrollable: true })),
-        configEditorWordWrap.of(editorSettings.wordWrap ? EditorView.lineWrapping : []),
-        EditorState.readOnly.of(!!props.readOnly),
-        EditorView.editable.of(!props.readOnly),
-        EditorView.updateListener.of((update) => {
-          if (!update.docChanged || generation !== configEditorGeneration || editorSessionId !== configEditorSessionId) return;
-          configContent.value = update.state.doc.toString();
-          configSaveNotice.value = "";
-        }),
-        EditorView.theme({
-          "&": {
-            height: "100%",
-          },
-          ".cm-scroller": {
-            overflow: "auto",
-          },
-          ".cm-content": {
-            minHeight: "100%",
-            userSelect: "text",
-            WebkitUserSelect: "text",
-          },
-          ".cm-lineNumbers .cm-gutterElement": {
-            padding: "0 10px 0 8px",
-          },
-        }),
-      ],
-    }),
+  const state = EditorState.create({
+    doc: content,
+    extensions: [
+      cmSearch({
+        top: true,
+        createPanel: () => {
+          const dom = document.createElement("span");
+          dom.style.display = "none";
+          return { dom };
+        },
+      }),
+      basicSetup,
+      EditorState.allowMultipleSelections.of(true),
+      trimmedSelectionLayer(),
+      Prec.highest(keymap.of([{ key: "Mod-f", run: () => configSearchPanelRef.value?.openSearch() ?? false, preventDefault: true }, { key: "Mod-h", run: () => configSearchPanelRef.value?.openReplace() ?? false, preventDefault: true }, indentWithTab])),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      EditorView.domEventHandlers({
+        wheel(event, eventView) {
+          if (!event.metaKey && !event.ctrlKey) return false;
+          event.preventDefault();
+          const next = fontSizeFromWheelDelta(configEditorFontSize.value, event.deltaY);
+          if (next !== configEditorFontSize.value) {
+            configEditorFontSize.value = next;
+            eventView.dispatch({
+              effects: configEditorFontTheme.reconfigure(editorFontTheme(EditorView, next, settingsStore.editorSettings.fontFamily, { fixedHeight: true, scrollable: true })),
+            });
+          }
+          configEditorZoomCommitScheduler.schedule(next);
+          return true;
+        },
+      }),
+      configEditorLanguage.of(language),
+      configEditorTheme.of(theme),
+      configEditorFontTheme.of(editorFontTheme(EditorView, editorSettings.fontSize, editorSettings.fontFamily, { fixedHeight: true, scrollable: true })),
+      configEditorWordWrap.of(editorSettings.wordWrap ? EditorView.lineWrapping : []),
+      EditorState.readOnly.of(!!props.readOnly),
+      EditorView.editable.of(!props.readOnly),
+      EditorView.updateListener.of((update) => {
+        if (!update.docChanged || generation !== configEditorGeneration || editorSessionId !== configEditorSessionId) return;
+        configContent.value = update.state.doc.toString();
+        configSaveNotice.value = "";
+      }),
+      EditorView.theme({
+        "&": {
+          height: "100%",
+        },
+        ".cm-scroller": {
+          overflow: "auto",
+        },
+        ".cm-content": {
+          minHeight: "100%",
+          userSelect: "text",
+          WebkitUserSelect: "text",
+        },
+        ".cm-lineNumbers .cm-gutterElement": {
+          padding: "0 10px 0 8px",
+        },
+      }),
+    ],
   });
+  ensureSyntaxTree(state, content.length, 500);
+  const view = new EditorView({ parent: host, state });
   if (generation !== configEditorGeneration || editorSessionId !== configEditorSessionId || host !== configEditorHost.value) {
     view.destroy();
     return;


### PR DESCRIPTION
## Problem

In the Nacos YAML config editor, when a config's content starts with two or more consecutive `#` comment lines, reopening the config after a fresh page load can render the first comment line in plain/default styling (no comment color or italics) while the following comment lines render correctly. Editing/saving looks fine; the issue only shows up right after a fresh (re)load, and any subsequent edit self-heals it.

Fixes #6302

## Root cause

An isolated CodeMirror test confirms the Lezer syntax tree for the same YAML content is byte-identical whether built via `EditorState.create()` with the full document at once (mirrors the reload path) or via incremental typed-in updates (mirrors live editing) — so this is not a grammar/parsing bug.

`mountConfigEditor()` in `NacosAdminConsole.vue` builds `EditorState.create({...})` and immediately constructs a new `EditorView` from it, without forcing the syntax tree for the freshly loaded content to be fully computed first. This leaves a narrow window (worse under system load) where the initial paint can happen before syntax highlighting decorations for the start of the document have caught up.

## Fix

Call `ensureSyntaxTree(state, content.length, 500)` — the same helper already used the same way in `QueryEditor.vue` — right after building the `EditorState` and before constructing the `EditorView`, forcing a synchronous full parse so highlighting is complete before the first paint.

## Testing

- Reproduced in a real environment: `dbx-web` dev backend + a real Nacos server, created a YAML config with 3 leading `#` comment lines via the app's own Nacos config editor, saved, reloaded the page, reopened the config — the first comment line rendered in plain/default color while the following two rendered correctly (confirmed both visually and via `getComputedStyle` on the live DOM, not just a screenshot artifact).
- This is a genuine but low-probability mount-time race — after applying the fix I was not able to re-trigger the original race window in ~25 further attempts (including CPU-throttled and frame-by-frame DOM-sampling runs) to produce a clean isolated "after" capture, so this PR relies on the confirmed root cause plus full regression coverage rather than a repeated live repro.
- `vue-tsc --noEmit`: clean
- Full test suite: 9250/9250 tests passing across 967 files (including all existing Nacos-related specs)
- `oxlint` on the changed file: no new warnings (one pre-existing, unrelated warning at a different line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)