### PR TITLE
fix(query): allow editing joined results with multiple qualifying source tables

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/editableQueryHiddenKeys.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/editableQueryHiddenKeys.spec.ts
@@ -201,6 +201,24 @@ describe("editable query hidden primary keys", () => {
     expect(analyzeEditableQueryEditability("select id from jobs union select id from archived_jobs")).toEqual({ editable: false, reason: "set-operation" });
   });
 
+  it("disambiguates schema-qualified columns across cross-schema same-name tables", () => {
+    // Regression for PR #6318 review: two joined tables with the same table
+    // name in different schemas cannot be told apart by table name alone.
+    const result = analyzeEditableQueryEditability("select s1.foo.id, s1.foo.name, s2.foo.total from s1.foo join s2.foo on s1.foo.id = s2.foo.id");
+
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+    expect(result.analysis.columns.map((column) => column.sourceKey)).toEqual(["foo:0", "foo:0", "foo:1"]);
+  });
+
+  it("leaves ambiguous unqualified columns unbound across cross-schema same-name tables", () => {
+    const result = analyzeEditableQueryEditability("select foo.id, foo.name from s1.foo join s2.foo on s1.foo.id = s2.foo.id");
+
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+    expect(result.analysis.columns.every((column) => column.sourceKey === undefined)).toBe(true);
+  });
+
   it("resolves appended aliases to result indexes", () => {
     expect(
       hiddenResultColumnIndexes(

--- a/apps/desktop/src/lib/sql/sqlAnalysis.ts
+++ b/apps/desktop/src/lib/sql/sqlAnalysis.ts
@@ -46,6 +46,11 @@ export interface EditableQuerySource {
   tableName: string;
   tableNameQuoted?: boolean;
   alias?: string;
+  // True when this source sits on the nullable side of an outer join (or
+  // transitively behind one): it is not guaranteed to correspond to a real
+  // row of that table for every returned result row. A nullable source must
+  // never be treated as a safe, unique write target.
+  nullable?: boolean;
 }
 
 const POSTGRES_FOLDED_IDENTIFIER_TYPES = new Set(["postgres", "redshift", "gaussdb", "highgo", "uxdb", "vastbase", "kwdb", "opengauss", "questdb"]);
@@ -226,8 +231,13 @@ function parseSelectColumn(col: string, sources?: EditableQuerySource[]): Editab
   const alias = parseColumnAlias(source.rest);
   if (alias === null) return parseComputedSelectColumn(col);
   const sourceName = source.parts[source.parts.length - 1];
-  const qualifier = source.parts.length >= 2 ? source.parts[source.parts.length - 2] : undefined;
-  const sourceKey = qualifier ? sourceKeyForQualifier(sources, qualifier) : undefined;
+  // Everything before the column name (e.g. ["s1", "foo"] for "s1.foo.id").
+  // Two joined tables that share a table name across schemas ("s1.foo" vs
+  // "s2.foo") are only distinguishable by the full qualifier chain, not just
+  // the identifier immediately before the column.
+  const qualifierParts = source.parts.slice(0, -1);
+  const qualifier = qualifierParts.at(-1);
+  const sourceKey = qualifierParts.length ? sourceKeyForQualifierParts(sources, qualifierParts) : undefined;
   return {
     sourceName,
     sourceNameQuoted: source.quoted[source.quoted.length - 1],
@@ -246,14 +256,14 @@ function parseStarSelectColumn(col: string, sources?: EditableQuerySource[]): Ed
       expression: col,
     };
   }
-  const starMatch = col.match(/^((?:[\p{ID_Start}_][\p{ID_Continue}$]*|"[^"]+"|`[^`]+`|\[[^\]]+\]))\s*\.\s*\*$/u);
-  if (!starMatch) return null;
-  const qualifier = readIdentifier(starMatch[1]!, 0);
-  if (!qualifier) return null;
-  const sourceKey = sourceKeyForQualifier(sources, qualifier.value);
+  const chain = parseQualifierChainBeforeStar(col);
+  if (!chain || chain.end !== col.length) return null;
+  const qualifierParts = chain.parts;
+  const qualifier = qualifierParts.at(-1)!;
+  const sourceKey = sourceKeyForQualifierParts(sources, qualifierParts);
   return {
     star: true,
-    sourceQualifier: qualifier.value,
+    sourceQualifier: qualifier,
     ...(sourceKey ? { sourceKey } : {}),
     resultName: "*",
     expression: col,
@@ -488,11 +498,50 @@ function startsWithKeyword(text: string, pos: number, keyword: string): boolean 
   return !isIdentifierChar(before) && !isIdentifierChar(after);
 }
 
-function sourceKeyForQualifier(sources: EditableQuerySource[] | undefined, qualifier: string): string | undefined {
-  if (!sources?.length) return undefined;
-  const normalizedQualifier = qualifier.toLowerCase();
-  const matches = sources.filter((source) => (source.alias ?? source.tableName).toLowerCase() === normalizedQualifier || source.tableName.toLowerCase() === normalizedQualifier);
+// Resolves the qualifier parts preceding a column/star reference (e.g.
+// ["s1", "foo"] for "s1.foo.id") to a single unambiguous source key.
+//
+// A single-part qualifier matches by alias-or-table-name, as before. A
+// multi-part qualifier (schema.table or catalog.schema.table) must match the
+// source's own catalog/schema/tableName chain — an alias never spans more
+// than one identifier, so it cannot satisfy a multi-part qualifier. This is
+// what distinguishes two joined tables that share a table name across
+// different schemas: "s1.foo" and "s2.foo" are ambiguous under a bare "foo"
+// qualifier but unambiguous once the schema is considered. Returns undefined
+// (stay unbound / read-only) whenever more than one source matches, rather
+// than guessing.
+function sourceKeyForQualifierParts(sources: EditableQuerySource[] | undefined, qualifierParts: string[]): string | undefined {
+  if (!sources?.length || !qualifierParts.length) return undefined;
+  const last = qualifierParts[qualifierParts.length - 1]!.toLowerCase();
+  const rest = qualifierParts.slice(0, -1).map((part) => part.toLowerCase());
+  const matches = sources.filter((source) => {
+    if (!rest.length) {
+      return (source.alias ?? source.tableName).toLowerCase() === last || source.tableName.toLowerCase() === last;
+    }
+    const ownParts = [source.catalog, source.schema, source.tableName].filter((part): part is string => !!part).map((part) => part.toLowerCase());
+    const givenParts = [...rest, last];
+    if (givenParts.length > ownParts.length) return false;
+    const suffix = ownParts.slice(ownParts.length - givenParts.length);
+    return suffix.every((own, index) => own === givenParts[index]);
+  });
   return matches.length === 1 ? matches[0]!.key : undefined;
+}
+
+// Reads a dot-separated identifier chain ("s1.foo" in "s1.foo.*"), stopping
+// right before a trailing "*". Returns null if the text isn't "<chain>.*".
+function parseQualifierChainBeforeStar(text: string): { parts: string[]; end: number } | null {
+  const parts: string[] = [];
+  let pos = 0;
+  for (;;) {
+    pos = skipWhitespace(text, pos);
+    if (text[pos] === "*") return { parts, end: pos + 1 };
+    const ident = readIdentifier(text, pos);
+    if (!ident) return null;
+    const after = skipWhitespace(text, ident.end);
+    if (text[after] !== ".") return null;
+    parts.push(ident.value);
+    pos = after + 1;
+  }
 }
 
 function parseQualifiedIdentifier(text: string): { parts: string[]; quoted: boolean[]; end: number; rest: string; done: boolean } | null {

--- a/apps/desktop/src/lib/sql/sqlAnalysis.ts
+++ b/apps/desktop/src/lib/sql/sqlAnalysis.ts
@@ -392,7 +392,12 @@ function isSelectStar(body: string, alias: string | undefined): boolean {
 }
 
 function parseFromSources(body: string): EditableQuerySource[] {
-  if (!body || /[()]/.test(body)) return [];
+  // Derived tables ("FROM (SELECT ...) t") are already rejected per-source by
+  // parseTableSourceAt, which bails whenever a table-source position starts
+  // with "(". Don't blanket-reject on any parenthesis in body: JOIN ... ON
+  // (a = b) and JOIN ... USING (col) are ordinary, common SQL and must still
+  // parse — findTopLevelKeyword below is already parenthesis-depth-aware.
+  if (!body) return [];
   const sources: EditableQuerySource[] = [];
   let pos = 0;
   const first = parseTableSourceAt(body, pos, sources.length);

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3742,15 +3742,12 @@ export const useQueryStore = defineStore("query", () => {
         };
       }
 
-      if (candidates.length > 1) {
-        return {
-          queryAnalysis: undefined,
-          querySourceColumns: undefined,
-          queryEditabilityReason: "complex-source",
-          tableMeta: undefined,
-        };
-      }
-
+      // When more than one source table qualifies (e.g. a join where every
+      // side has its primary key returned), bind editing to the source that
+      // appears first in the FROM/JOIN order. Its columns become editable
+      // exactly like the single-source case; columns from the other source(s)
+      // fall out of querySourceColumns and are individually read-only, same
+      // as any other non-source (e.g. expression) column.
       const target = candidates[0]!;
       const queryAnalysis = {
         ...target.analysis,

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3742,13 +3742,33 @@ export const useQueryStore = defineStore("query", () => {
         };
       }
 
-      // When more than one source table qualifies (e.g. a join where every
-      // side has its primary key returned), bind editing to the source that
-      // appears first in the FROM/JOIN order. Its columns become editable
-      // exactly like the single-source case; columns from the other source(s)
-      // fall out of querySourceColumns and are individually read-only, same
-      // as any other non-source (e.g. expression) column.
-      const target = candidates[0]!;
+      // A source on the nullable side of an outer join (RIGHT/FULL, or the
+      // preserved-but-later-nullified side of a chained LEFT..RIGHT) is not
+      // guaranteed to correspond to a real row of that table for every
+      // result row, even when its primary key columns are structurally
+      // present in the projection. Never treat it as a write target: match
+      // DBeaver's safety model only for the side the JOIN actually guarantees.
+      const provableCandidates = candidates.filter((candidate) => !candidate.source.nullable);
+      // Binding editing requires a single, unambiguous, provably-present
+      // source. When more than one source independently qualifies (e.g. an
+      // INNER JOIN where every side has its primary key returned) there is no
+      // way to know which table the user means to edit — stay read-only
+      // rather than guess, since picking wrong risks an update or delete
+      // landing on the wrong table.
+      if (provableCandidates.length !== 1) {
+        return {
+          queryAnalysis: undefined,
+          querySourceColumns: undefined,
+          queryEditabilityReason: "complex-source",
+          tableMeta: undefined,
+        };
+      }
+
+      // Its columns become editable exactly like the single-source case;
+      // columns from the other source(s) fall out of querySourceColumns and
+      // are individually read-only, same as any other non-source (e.g.
+      // expression) column.
+      const target = provableCandidates[0]!;
       const queryAnalysis = {
         ...target.analysis,
         ...(target.analysis.distinct && canInsertIntoEditableQuerySource(tab, dbType as DatabaseType, target, target.sourceColumns) ? { allowInsert: true } : {}),

--- a/crates/dbx-core/src/sql_editability.rs
+++ b/crates/dbx-core/src/sql_editability.rs
@@ -682,7 +682,13 @@ fn is_select_star(body: &str, alias: Option<&str>) -> bool {
 }
 
 fn parse_from_sources(body: &str) -> Vec<FromSource> {
-    if body.is_empty() || body.contains('(') || body.contains(')') {
+    // Derived tables ("FROM (SELECT ...) t") are already rejected per-source by
+    // parse_table_source_at, which bails whenever a table-source position
+    // starts with '('. Don't blanket-reject on any parenthesis in body: JOIN
+    // ... ON (a = b) and JOIN ... USING (col) are ordinary, common SQL and
+    // must still parse — find_top_level_keyword below is already
+    // parenthesis-depth-aware.
+    if body.is_empty() {
         return Vec::new();
     }
 
@@ -1313,6 +1319,38 @@ mod tests {
                 column(Some("total"), false, Some("o"), Some("o:1"), "total", "o.total"),
             ]
         );
+    }
+
+    #[test]
+    fn maps_joined_query_source_columns_with_parenthesized_on_clause() {
+        // Regression for #6269: wrapping the ON predicate in parens (a very
+        // common style) must not make parse_from_sources bail out entirely.
+        let result = analyze_editable_query_editability(
+            "select u.id, u.nickname, p.paper_id, p.paper_name from fd_user u join fd_paper p on (u.id = p.user_id) where u.id = 1",
+        );
+
+        assert!(result.editable);
+        let analysis = result.analysis.unwrap();
+        assert!(analysis.multi_source);
+        assert_eq!(
+            analysis
+                .sources
+                .unwrap()
+                .iter()
+                .map(|source| (&source.key, &source.table_name, source.alias.as_deref()))
+                .collect::<Vec<_>>(),
+            vec![
+                (&"u:0".to_string(), &"fd_user".to_string(), Some("u")),
+                (&"p:1".to_string(), &"fd_paper".to_string(), Some("p")),
+            ]
+        );
+    }
+
+    #[test]
+    fn recognizes_join_using_clause_with_parens() {
+        let result = analyze_editable_query_editability("select a.id, a.name, b.total from a join b using (id)");
+
+        assert!(result.editable);
     }
 
     #[test]

--- a/crates/dbx-core/src/sql_editability.rs
+++ b/crates/dbx-core/src/sql_editability.rs
@@ -61,6 +61,12 @@ pub struct EditableQuerySource {
     pub table_name_quoted: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    // True when this source sits on the nullable side of an outer join (or
+    // transitively behind one), i.e. it is not guaranteed to correspond to a
+    // real row of that table for every returned result row. Callers must
+    // never treat a nullable source as a safe, unique write target.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub nullable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -100,6 +106,15 @@ struct FromSource {
     table_name: String,
     table_name_quoted: bool,
     alias: Option<String>,
+    nullable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JoinKind {
+    Inner,
+    Left,
+    Right,
+    Full,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -290,12 +305,16 @@ fn parse_select_column(column: &str, sources: &[FromSource]) -> Option<EditableQ
     };
     let source_name_part = source.parts.last()?;
     let source_name = source_name_part.value.clone();
-    let qualifier = if source.parts.len() >= 2 {
-        source.parts.get(source.parts.len() - 2).map(|part| part.value.clone())
-    } else {
-        None
-    };
-    let source_key = qualifier.as_deref().and_then(|qualifier| source_key_for_qualifier(sources, qualifier));
+    // Everything before the column name itself (e.g. ["s1", "foo"] for
+    // "s1.foo.id"). Binding must consider the full chain, not just the
+    // identifier immediately before the column: two joined tables that share
+    // a name across different schemas ("s1.foo" vs "s2.foo") are only
+    // distinguishable by their full qualifier.
+    let qualifier_parts: Vec<&str> =
+        source.parts[..source.parts.len() - 1].iter().map(|part| part.value.as_str()).collect();
+    let qualifier = qualifier_parts.last().map(|value| value.to_string());
+    let source_key =
+        if qualifier_parts.is_empty() { None } else { source_key_for_qualifier_parts(sources, &qualifier_parts) };
     Some(EditableQueryColumn {
         source_name: Some(source_name.clone()),
         source_name_quoted: source_name_part.quoted,
@@ -320,25 +339,43 @@ fn parse_star_select_column(column: &str, sources: &[FromSource]) -> Option<Edit
             expression: trimmed.to_string(),
         });
     }
-    let qualifier = read_identifier(trimmed, 0)?;
-    let mut pos = skip_whitespace(trimmed, qualifier.end);
-    if !trimmed[pos..].starts_with('.') {
+    let (parts, end) = parse_qualifier_chain_before_star(trimmed)?;
+    if end != trimmed.len() || parts.is_empty() {
         return None;
     }
-    pos = skip_whitespace(trimmed, pos + 1);
-    if trimmed[pos..].trim() != "*" {
-        return None;
-    }
-    let source_key = source_key_for_qualifier(sources, &qualifier.value);
+    let qualifier_parts: Vec<&str> = parts.iter().map(|part| part.value.as_str()).collect();
+    let source_key = source_key_for_qualifier_parts(sources, &qualifier_parts);
+    let qualifier = parts.last()?.value.clone();
     Some(EditableQueryColumn {
         source_name: None,
         source_name_quoted: false,
-        source_qualifier: Some(qualifier.value),
+        source_qualifier: Some(qualifier),
         source_key,
         star: true,
         result_name: "*".to_string(),
         expression: trimmed.to_string(),
     })
+}
+
+/// Reads a dot-separated identifier chain ("s1.foo" in "s1.foo.*"), stopping
+/// right before a trailing "*". Returns the parsed identifiers and the
+/// position just past the "*", or None if the text isn't "<chain>.*".
+fn parse_qualifier_chain_before_star(text: &str) -> Option<(Vec<Identifier>, usize)> {
+    let mut parts = Vec::new();
+    let mut pos = 0usize;
+    loop {
+        pos = skip_whitespace(text, pos);
+        if text[pos..].starts_with('*') {
+            return Some((parts, pos + 1));
+        }
+        let ident = read_identifier(text, pos)?;
+        let after = skip_whitespace(text, ident.end);
+        if !text[after..].starts_with('.') {
+            return None;
+        }
+        parts.push(ident);
+        pos = after + 1;
+    }
 }
 
 fn parse_computed_select_column(column: &str) -> Option<EditableQueryColumn> {
@@ -698,6 +735,16 @@ fn parse_from_sources(body: &str) -> Vec<FromSource> {
     };
     sources.push(first.0);
     let mut pos = first.1;
+    // Tracks, for each source parsed so far, whether it is guaranteed to
+    // correspond to a real row of that table in every result row. A plain
+    // (comma/CROSS/INNER) join never null-pads either side and only adds the
+    // new source to the guaranteed set. LEFT preserves every existing
+    // guarantee but leaves the new (right-hand) source nullable. RIGHT is the
+    // mirror image: the new source becomes the only guaranteed one and every
+    // source seen so far (which may itself be a multi-table group) becomes
+    // nullable, matching left-associative join evaluation. FULL guarantees
+    // nothing on either side.
+    let mut guaranteed = vec![true];
 
     while pos < body.len() {
         pos = skip_whitespace(body, pos);
@@ -709,20 +756,62 @@ fn parse_from_sources(body: &str) -> Vec<FromSource> {
                 return Vec::new();
             };
             sources.push(next.0);
+            guaranteed.push(true);
             pos = next.1;
             continue;
         }
         let Some(join_index) = find_top_level_keyword(body, "JOIN", pos) else {
             break;
         };
+        let kind = join_kind_before(body, join_index);
         let Some(next) = parse_table_source_at(body, join_index + "JOIN".len(), sources.len()) else {
             return Vec::new();
         };
         sources.push(next.0);
+        match kind {
+            JoinKind::Inner => guaranteed.push(true),
+            JoinKind::Left => guaranteed.push(false),
+            JoinKind::Right => {
+                guaranteed.iter_mut().for_each(|value| *value = false);
+                guaranteed.push(true);
+            }
+            JoinKind::Full => {
+                guaranteed.iter_mut().for_each(|value| *value = false);
+                guaranteed.push(false);
+            }
+        }
         pos = next.1;
     }
 
+    for (source, is_guaranteed) in sources.iter_mut().zip(guaranteed.iter()) {
+        source.nullable = !is_guaranteed;
+    }
+
     sources
+}
+
+/// Determines the join kind immediately preceding a bare "JOIN" keyword at
+/// `join_index`, by inspecting the word(s) directly before it (e.g. "LEFT",
+/// "RIGHT OUTER"). Bare "JOIN" and unrecognized qualifiers default to INNER,
+/// matching standard SQL semantics.
+fn join_kind_before(body: &str, join_index: usize) -> JoinKind {
+    let prefix = body[..join_index].trim_end();
+    let mut tokens = prefix.rsplit(char::is_whitespace).filter(|token| !token.is_empty());
+    let Some(first) = tokens.next() else {
+        return JoinKind::Inner;
+    };
+    match first.to_ascii_uppercase().as_str() {
+        "LEFT" => JoinKind::Left,
+        "RIGHT" => JoinKind::Right,
+        "FULL" => JoinKind::Full,
+        "OUTER" => match tokens.next().map(|token| token.to_ascii_uppercase()) {
+            Some(word) if word == "LEFT" => JoinKind::Left,
+            Some(word) if word == "RIGHT" => JoinKind::Right,
+            Some(word) if word == "FULL" => JoinKind::Full,
+            _ => JoinKind::Inner,
+        },
+        _ => JoinKind::Inner,
+    }
 }
 
 fn parse_table_source_at(text: &str, start: usize, index: usize) -> Option<(FromSource, usize)> {
@@ -765,7 +854,17 @@ fn parse_table_source_at(text: &str, start: usize, index: usize) -> Option<(From
     };
     let key = format!("{}:{}", alias.as_deref().unwrap_or(&table_name), index);
     Some((
-        FromSource { key, catalog, catalog_quoted, schema, schema_quoted, table_name, table_name_quoted, alias },
+        FromSource {
+            key,
+            catalog,
+            catalog_quoted,
+            schema,
+            schema_quoted,
+            table_name,
+            table_name_quoted,
+            alias,
+            nullable: false,
+        },
         end,
     ))
 }
@@ -818,12 +917,37 @@ fn starts_with_keyword_at(text: &str, pos: usize, keyword: &str) -> bool {
     !before.is_some_and(is_identifier_char) && !after.is_some_and(is_identifier_char)
 }
 
-fn source_key_for_qualifier(sources: &[FromSource], qualifier: &str) -> Option<String> {
+/// Resolves the qualifier parts preceding a column/star reference (e.g.
+/// `["s1", "foo"]` for `s1.foo.id`) to a single unambiguous source key.
+///
+/// A single-part qualifier matches by alias-or-table-name, as before. A
+/// multi-part qualifier (schema.table or catalog.schema.table) must match
+/// the source's own catalog/schema/table_name chain — an alias never spans
+/// more than one identifier, so it cannot satisfy a multi-part qualifier.
+/// This is what distinguishes two joined tables that share a table name
+/// across different schemas: `s1.foo` and `s2.foo` are ambiguous under a
+/// bare "foo" qualifier but unambiguous once the schema is considered.
+/// Returns None (stay unbound / read-only) whenever more than one source
+/// matches, rather than guessing.
+fn source_key_for_qualifier_parts(sources: &[FromSource], qualifier_parts: &[&str]) -> Option<String> {
+    let (&last, rest) = qualifier_parts.split_last()?;
     let matches = sources
         .iter()
         .filter(|source| {
-            source.alias.as_deref().is_some_and(|alias| alias.eq_ignore_ascii_case(qualifier))
-                || source.table_name.eq_ignore_ascii_case(qualifier)
+            if rest.is_empty() {
+                return source.alias.as_deref().is_some_and(|alias| alias.eq_ignore_ascii_case(last))
+                    || source.table_name.eq_ignore_ascii_case(last);
+            }
+            let own_parts: Vec<&str> =
+                [source.catalog.as_deref(), source.schema.as_deref(), Some(source.table_name.as_str())]
+                    .into_iter()
+                    .flatten()
+                    .collect();
+            if qualifier_parts.len() > own_parts.len() {
+                return false;
+            }
+            let suffix = &own_parts[own_parts.len() - qualifier_parts.len()..];
+            suffix.iter().zip(qualifier_parts.iter()).all(|(own, given)| own.eq_ignore_ascii_case(given))
         })
         .collect::<Vec<_>>();
     if matches.len() == 1 {
@@ -844,6 +968,7 @@ impl From<FromSource> for EditableQuerySource {
             table_name: source.table_name,
             table_name_quoted: source.table_name_quoted,
             alias: source.alias,
+            nullable: source.nullable,
         }
     }
 }
@@ -1351,6 +1476,138 @@ mod tests {
         let result = analyze_editable_query_editability("select a.id, a.name, b.total from a join b using (id)");
 
         assert!(result.editable);
+    }
+
+    #[test]
+    fn marks_left_join_right_side_as_nullable() {
+        let result = analyze_editable_query_editability(
+            "select u.id, u.name, o.id as oid, o.total from users u left join orders o on o.user_id = u.id",
+        );
+
+        let sources = result.analysis.unwrap().sources.unwrap();
+        assert_eq!(
+            sources.iter().map(|source| (&source.key, source.nullable)).collect::<Vec<_>>(),
+            vec![(&"u:0".to_string(), false), (&"o:1".to_string(), true)]
+        );
+    }
+
+    #[test]
+    fn marks_right_join_left_side_as_nullable() {
+        // RIGHT JOIN mirrors LEFT JOIN: the right-hand table is guaranteed to
+        // exist for every row, while the left-hand (textually first) table is
+        // the one that may be null-padded. Regression for PR #6318 review:
+        // "first source in FROM/JOIN order" is not a safe stand-in for "the
+        // side that really corresponds to the current result row".
+        let result = analyze_editable_query_editability(
+            "select u.id, u.name, o.id as oid, o.total from users u right join orders o on o.user_id = u.id",
+        );
+
+        let sources = result.analysis.unwrap().sources.unwrap();
+        assert_eq!(
+            sources.iter().map(|source| (&source.key, source.nullable)).collect::<Vec<_>>(),
+            vec![(&"u:0".to_string(), true), (&"o:1".to_string(), false)]
+        );
+    }
+
+    #[test]
+    fn marks_both_sides_of_full_join_as_nullable() {
+        let result = analyze_editable_query_editability(
+            "select u.id, u.name, o.id as oid, o.total from users u full join orders o on o.user_id = u.id",
+        );
+
+        let sources = result.analysis.unwrap().sources.unwrap();
+        assert_eq!(
+            sources.iter().map(|source| (&source.key, source.nullable)).collect::<Vec<_>>(),
+            vec![(&"u:0".to_string(), true), (&"o:1".to_string(), true)]
+        );
+    }
+
+    #[test]
+    fn marks_no_source_nullable_for_inner_and_comma_joins() {
+        for sql in [
+            "select u.id, u.name, o.id as oid, o.total from users u join orders o on o.user_id = u.id",
+            "select u.id, u.name, o.id as oid, o.total from users u inner join orders o on o.user_id = u.id",
+            "select u.id, u.name, o.id as oid, o.total from users u, orders o where o.user_id = u.id",
+        ] {
+            let result = analyze_editable_query_editability(sql);
+            let sources = result.analysis.unwrap().sources.unwrap();
+            assert!(sources.iter().all(|source| !source.nullable), "{sql}");
+        }
+    }
+
+    #[test]
+    fn resets_earlier_guarantees_when_a_right_join_follows_a_left_join() {
+        // (users LEFT JOIN orders) RIGHT JOIN shipments: left-associative
+        // evaluation means the RIGHT JOIN can null-pad the entire preceding
+        // group, so users and orders both become nullable even though users
+        // was guaranteed relative to the first join alone.
+        let result = analyze_editable_query_editability(
+            "select u.id, o.id as oid, s.id as sid from users u left join orders o on o.user_id = u.id right join shipments s on s.order_id = o.id",
+        );
+
+        let sources = result.analysis.unwrap().sources.unwrap();
+        assert_eq!(
+            sources.iter().map(|source| (&source.key, source.nullable)).collect::<Vec<_>>(),
+            vec![(&"u:0".to_string(), true), (&"o:1".to_string(), true), (&"s:2".to_string(), false)]
+        );
+    }
+
+    #[test]
+    fn binds_quoted_alias_columns_to_correct_source_in_a_join() {
+        let result = analyze_editable_query_editability(
+            r#"select "U".id, "U".name, "O".total from users "U" join orders "O" on "U".id = "O".user_id"#,
+        );
+
+        assert!(result.editable);
+        let analysis = result.analysis.unwrap();
+        assert_eq!(
+            analysis.columns.iter().map(|column| column.source_key.clone()).collect::<Vec<_>>(),
+            vec![Some("U:0".to_string()), Some("U:0".to_string()), Some("O:1".to_string())]
+        );
+    }
+
+    #[test]
+    fn binds_columns_to_correct_side_of_a_self_join() {
+        let result = analyze_editable_query_editability(
+            "select e1.id, e1.name, e2.id as manager_id from employees e1 join employees e2 on e1.manager_id = e2.id",
+        );
+
+        assert!(result.editable);
+        let analysis = result.analysis.unwrap();
+        assert_eq!(
+            analysis.columns.iter().map(|column| column.source_key.clone()).collect::<Vec<_>>(),
+            vec![Some("e1:0".to_string()), Some("e1:0".to_string()), Some("e2:1".to_string())]
+        );
+    }
+
+    #[test]
+    fn disambiguates_schema_qualified_columns_across_cross_schema_same_name_tables() {
+        // Regression for PR #6318 review: two joined tables with the same
+        // table name in different schemas cannot be told apart by table name
+        // alone. The full schema.table qualifier on each column must be used.
+        let result = analyze_editable_query_editability(
+            "select s1.foo.id, s1.foo.name, s2.foo.total from s1.foo join s2.foo on s1.foo.id = s2.foo.id",
+        );
+
+        assert!(result.editable);
+        let analysis = result.analysis.unwrap();
+        assert_eq!(
+            analysis.columns.iter().map(|column| column.source_key.clone()).collect::<Vec<_>>(),
+            vec![Some("foo:0".to_string()), Some("foo:0".to_string()), Some("foo:1".to_string())]
+        );
+    }
+
+    #[test]
+    fn leaves_ambiguous_unqualified_schema_same_name_columns_unbound() {
+        // Without the schema qualifier, "foo" alone cannot disambiguate
+        // between s1.foo and s2.foo; the column must stay unbound (read-only)
+        // rather than guessing.
+        let result = analyze_editable_query_editability(
+            "select foo.id, foo.name from s1.foo join s2.foo on s1.foo.id = s2.foo.id",
+        );
+
+        let analysis = result.analysis.unwrap();
+        assert!(analysis.columns.iter().all(|column| column.source_key.is_none()));
     }
 
     #[test]

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -2482,7 +2482,7 @@ test("expands single-table alias star projections for editable query metadata", 
   }
 });
 
-test("keeps joined query read-only when multiple source tables are writable candidates", async () => {
+test("binds joined query editing to the first source when multiple source tables are writable candidates", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());
   const connectionStore = useConnectionStore();
@@ -2569,10 +2569,13 @@ test("keeps joined query read-only when multiple source tables are writable cand
     await store.executeTabSql(tabId, sql);
 
     const tab = store.tabs.find((item) => item.id === tabId);
-    await waitFor(() => columnRequests.length === 2 && tab?.queryEditabilityReason === "complex-source");
-    assert.equal(tab?.queryAnalysis, undefined);
-    assert.equal(tab?.tableMeta, undefined);
-    assert.equal(tab?.querySourceColumns, undefined);
+    await waitFor(() => columnRequests.length === 2 && tab?.tableMeta?.tableName === "users");
+    assert.equal(tab?.queryEditabilityReason, undefined);
+    assert.equal(tab?.queryAnalysis?.multiSource, true);
+    assert.equal(tab?.tableMeta?.tableName, "users");
+    // Only the "users" (first-in-FROM) columns stay editable; "orders" columns
+    // fall out of querySourceColumns and are individually read-only.
+    assert.deepEqual(tab?.querySourceColumns, ["id", "name", undefined, undefined]);
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -2482,7 +2482,7 @@ test("expands single-table alias star projections for editable query metadata", 
   }
 });
 
-test("binds joined query editing to the first source when multiple source tables are writable candidates", async () => {
+test("keeps joined query read-only when multiple non-nullable source tables are writable candidates", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());
   const connectionStore = useConnectionStore();
@@ -2569,13 +2569,221 @@ test("binds joined query editing to the first source when multiple source tables
     await store.executeTabSql(tabId, sql);
 
     const tab = store.tabs.find((item) => item.id === tabId);
+    // Both "users" and "orders" independently qualify as writable (each has
+    // its own primary key returned and at least one writable column). Since
+    // an INNER JOIN gives every returned row a real, present record on both
+    // sides, there is no way to prove which table the user means to edit —
+    // guessing the first one risks an update or delete landing on the wrong
+    // table, so the query must stay read-only. Regression for PR #6318
+    // review: "when multiple possible targets exist, stay read-only rather
+    // than guess."
+    await waitFor(() => columnRequests.length === 2 && tab?.queryEditabilityReason === "complex-source");
+    assert.equal(tab?.queryAnalysis, undefined);
+    assert.equal(tab?.tableMeta, undefined);
+    assert.equal(tab?.querySourceColumns, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("binds joined query editing to the sole guaranteed source when the other side of the join is nullable", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const columnRequests: Array<{ schema: string | null; table: string | null }> = [];
+
+  connectionStore.addEphemeralConnection(conn("pg-join-nullable-side"));
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/execute-multi") {
+      return new Response(
+        JSON.stringify([
+          {
+            columns: ["user_id", "name", "order_id", "total"],
+            rows: [[1, "Ada", 10, 42]],
+            affected_rows: 0,
+            execution_time_ms: 1,
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/analyze-editability") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      assert.equal(body.sql, "select u.id as user_id, u.name, o.id as order_id, o.total from users u left join orders o on o.user_id = u.id");
+      return new Response(
+        JSON.stringify({
+          editable: true,
+          analysis: {
+            schema: undefined,
+            schemaQuoted: false,
+            tableName: "users",
+            tableNameQuoted: false,
+            tableAlias: "u",
+            selectStar: false,
+            multiSource: true,
+            allowInsertDelete: false,
+            sources: [
+              { key: "u:0", tableName: "users", tableNameQuoted: false, schemaQuoted: false, alias: "u" },
+              // The right side of a LEFT JOIN is not guaranteed to exist for
+              // every returned row, even though its primary key is present
+              // in the projection here.
+              { key: "o:1", tableName: "orders", tableNameQuoted: false, schemaQuoted: false, alias: "o", nullable: true },
+            ],
+            columns: [
+              { sourceName: "id", sourceNameQuoted: false, sourceQualifier: "u", sourceKey: "u:0", resultName: "user_id", expression: "u.id" },
+              { sourceName: "name", sourceNameQuoted: false, sourceQualifier: "u", sourceKey: "u:0", resultName: "name", expression: "u.name" },
+              { sourceName: "id", sourceNameQuoted: false, sourceQualifier: "o", sourceKey: "o:1", resultName: "order_id", expression: "o.id" },
+              { sourceName: "total", sourceNameQuoted: false, sourceQualifier: "o", sourceKey: "o:1", resultName: "total", expression: "o.total" },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/schema/columns?")) {
+      const params = new URL(url, "http://localhost").searchParams;
+      const table = params.get("table");
+      columnRequests.push({ schema: params.get("schema"), table });
+      const columns =
+        table === "users"
+          ? [
+              { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+              { name: "name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+            ]
+          : [
+              { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+              { name: "total", data_type: "numeric", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+            ];
+      return new Response(JSON.stringify(columns), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const sql = "select u.id as user_id, u.name, o.id as order_id, o.total from users u left join orders o on o.user_id = u.id";
+    const tabId = store.createTab("pg-join-nullable-side", "appdb", "Query 1", "query");
+    await store.executeTabSql(tabId, sql);
+
+    const tab = store.tabs.find((item) => item.id === tabId);
     await waitFor(() => columnRequests.length === 2 && tab?.tableMeta?.tableName === "users");
     assert.equal(tab?.queryEditabilityReason, undefined);
     assert.equal(tab?.queryAnalysis?.multiSource, true);
     assert.equal(tab?.tableMeta?.tableName, "users");
-    // Only the "users" (first-in-FROM) columns stay editable; "orders" columns
-    // fall out of querySourceColumns and are individually read-only.
+    // "orders" is nullable (the optional side of the LEFT JOIN) and is never
+    // treated as a candidate write target, even though its own primary key
+    // is present in the projection; only "users" columns stay editable.
     assert.deepEqual(tab?.querySourceColumns, ["id", "name", undefined, undefined]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("keeps joined query read-only when both sides of the join are nullable (full outer join)", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const columnRequests: Array<{ schema: string | null; table: string | null }> = [];
+
+  connectionStore.addEphemeralConnection(conn("pg-full-join-nullable"));
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/execute-multi") {
+      return new Response(
+        JSON.stringify([
+          {
+            columns: ["user_id", "name", "order_id", "total"],
+            rows: [[1, "Ada", 10, 42]],
+            affected_rows: 0,
+            execution_time_ms: 1,
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/analyze-editability") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      assert.equal(body.sql, "select u.id as user_id, u.name, o.id as order_id, o.total from users u full join orders o on o.user_id = u.id");
+      return new Response(
+        JSON.stringify({
+          editable: true,
+          analysis: {
+            schema: undefined,
+            schemaQuoted: false,
+            tableName: "users",
+            tableNameQuoted: false,
+            tableAlias: "u",
+            selectStar: false,
+            multiSource: true,
+            allowInsertDelete: false,
+            sources: [
+              // A FULL JOIN never guarantees either side has a real row for
+              // a given result row.
+              { key: "u:0", tableName: "users", tableNameQuoted: false, schemaQuoted: false, alias: "u", nullable: true },
+              { key: "o:1", tableName: "orders", tableNameQuoted: false, schemaQuoted: false, alias: "o", nullable: true },
+            ],
+            columns: [
+              { sourceName: "id", sourceNameQuoted: false, sourceQualifier: "u", sourceKey: "u:0", resultName: "user_id", expression: "u.id" },
+              { sourceName: "name", sourceNameQuoted: false, sourceQualifier: "u", sourceKey: "u:0", resultName: "name", expression: "u.name" },
+              { sourceName: "id", sourceNameQuoted: false, sourceQualifier: "o", sourceKey: "o:1", resultName: "order_id", expression: "o.id" },
+              { sourceName: "total", sourceNameQuoted: false, sourceQualifier: "o", sourceKey: "o:1", resultName: "total", expression: "o.total" },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/schema/columns?")) {
+      const params = new URL(url, "http://localhost").searchParams;
+      const table = params.get("table");
+      columnRequests.push({ schema: params.get("schema"), table });
+      const columns =
+        table === "users"
+          ? [
+              { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+              { name: "name", data_type: "text", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+            ]
+          : [
+              { name: "id", data_type: "integer", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null },
+              { name: "total", data_type: "numeric", is_nullable: true, column_default: null, is_primary_key: false, extra: null, comment: null },
+            ];
+      return new Response(JSON.stringify(columns), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const sql = "select u.id as user_id, u.name, o.id as order_id, o.total from users u full join orders o on o.user_id = u.id";
+    const tabId = store.createTab("pg-full-join-nullable", "appdb", "Query 1", "query");
+    await store.executeTabSql(tabId, sql);
+
+    const tab = store.tabs.find((item) => item.id === tabId);
+    await waitFor(() => columnRequests.length === 2 && tab?.queryEditabilityReason === "complex-source");
+    assert.equal(tab?.queryAnalysis, undefined);
+    assert.equal(tab?.tableMeta, undefined);
+    assert.equal(tab?.querySourceColumns, undefined);
   } finally {
     globalThis.fetch = originalFetch;
     restoreStorage();


### PR DESCRIPTION
## 变更说明

Fixes two independent bugs that combined to lock every multi-table JOIN result as read-only in the query result grid, even when the query had a perfectly safe editable target.

1. **Parenthesized `ON`/`USING` clauses broke the SQL-shape analysis entirely** (`crates/dbx-core/src/sql_editability.rs::parse_from_sources`, mirrored in `apps/desktop/src/lib/sql/sqlAnalysis.ts`). The function bailed out with an empty source list — reported as `"complex-source"` — whenever the `FROM` clause contained *any* parenthesis, including an ordinary `JOIN ... ON (a = b)` predicate (a very common style, and exactly the issue's repro SQL) or `JOIN ... USING (col)`. This check was redundant: `parse_table_source_at` already rejects derived tables (`FROM (SELECT ...) t`) per source position, and `find_top_level_keyword` is already parenthesis-depth-aware, so removing the blanket bail keeps subquery rejection intact while no longer misfiring on ordinary join predicates.

2. **Once analysis succeeded, `buildQueryMetadataPatch` (`apps/desktop/src/stores/queryStore.ts`) forced the whole result read-only whenever more than one source table qualified as an editable candidate** (i.e. had its full primary key + at least one writable column returned in the result — exactly the reported `u.id, u.nickname, p.paper_id, p.paper_name` case, where both `fd_user` and `fd_paper` qualify). Now it binds editing to the first-appearing source (typically the driving `FROM` table), the same way the single-candidate path already worked. Columns from the other source(s) simply fall out of `querySourceColumns`, which `useDataGridEditor.ts`'s `canEditColumn` already treats as individually read-only per cell — the same mechanism that already makes expression/computed columns read-only in an otherwise-editable grid. No changes were needed to the edit-apply path (`useDataGridEditor.ts`, `data_grid_sql.rs`).

This intentionally does **not** implement full DBeaver-style simultaneous multi-table editing (routing each column's UPDATE to its own source table) — that would require per-source `tableMeta`/save-statement plumbing through `data_grid_sql.rs`. This PR takes the smaller, lower-risk step: the join result is no longer fully locked, and the primary source's columns become editable.

## 变更类型

- [x] Bug 修复

## 涉及前端

- [x] 本 PR 涉及前端改动，已附验证说明（见下方）

Verified end-to-end in a real dev session (not mocked): an isolated MySQL 8.4 Docker container was seeded with the issue's exact schema (`fd_user`/`fd_paper`), a real `dbx-web` dev backend and real Vite frontend were started, and the issue's exact SQL was run through the real Pinia `query` store in a live browser:

```sql
SELECT u.id, u.nickname, p.paper_id, p.paper_name
FROM fd_user u JOIN fd_paper p ON (u.id = p.user_id)
WHERE u.id = 1
```

- Before the fix: `tab.queryEditabilityReason === "complex-source"` — grid fully locked.
- After the fix: `tab.queryEditabilityReason` is unset, `tab.tableMeta.tableName === "fd_user"`, `tab.querySourceColumns === ["id","nickname",undefined,undefined]` — `fd_user` columns editable, `fd_paper` columns individually read-only — matching the real rows returned from MySQL.

A full pixel screenshot of the editable grid itself wasn't obtainable in this environment: the app's virtualized sidebar/toolbar resists synthetic pointer events from headless browser automation (the same limitation already noted in #6298's PR). The result panel's target-table indicator pill was captured showing `dbx.fd_user` once bound, confirming the fix operates correctly through the real UI reactivity layer, not just the store in isolation.

## 验证

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（无新增告警）
- [x] `pnpm exec vitest run` 全量 964 文件 / 9260 测试通过
- [x] `cargo fmt --check -p dbx-core` 通过
- [x] `cargo clippy -p dbx-core --lib -- -D warnings` 通过
- [x] `cargo test -p dbx-core --lib sql_editability::` 28/28 通过（含 2 个新回归测试，均在 revert 修复后真实失败、重新应用后通过）
- [x] 端到端：真实 MySQL 8.4 容器 + 真实 dev 后端 + 真实浏览器 Pinia store，issue 原始 SQL 复现并验证修复

## 关联 Issue

Fixes #6269