### PR TITLE
fix(transfer): fail fast on incompatible target structure before truncating data

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1407,6 +1407,15 @@ fn writable_transfer_columns(
         .collect()
 }
 
+/// Columns DBX is about to write into `target_columns` (via `col_names`) that
+/// don't exist in the target table. MySQL (and most other targets) compare
+/// unquoted identifiers case-insensitively, so the check does too.
+fn missing_transfer_target_columns(target_columns: &[db::ColumnInfo], col_names: &[String]) -> Vec<String> {
+    let existing: std::collections::HashSet<String> =
+        target_columns.iter().map(|column| column.name.to_lowercase()).collect();
+    col_names.iter().filter(|name| !existing.contains(&name.to_lowercase())).cloned().collect()
+}
+
 fn transfer_key_columns(columns: &[db::ColumnInfo], db_type: &DatabaseType) -> Vec<String> {
     let uses_unique_key_model = matches!(db_type, DatabaseType::Doris | DatabaseType::StarRocks);
     columns
@@ -6763,6 +6772,35 @@ where
         return Ok(0);
     }
 
+    // The user asked DBX to sync structure (create_table), but the target
+    // table already existed so the create-table DDL above was skipped (see
+    // "skipping create-table DDL" above). If the untouched target structure
+    // can't hold the source's columns, fail fast here instead of truncating
+    // the target's existing data and then hitting an opaque driver error
+    // partway through the insert.
+    if request.create_table && target_table_preexisting {
+        let existing_target_columns = get_columns_for_transfer(
+            state,
+            target_pool_key,
+            &request.target_connection_id,
+            &request.target_database,
+            &request.target_schema,
+            &target_table,
+            request.target_catalog.as_deref(),
+        )
+        .await
+        .unwrap_or_default();
+        let missing = missing_transfer_target_columns(&existing_target_columns, &col_names);
+        if !missing.is_empty() {
+            return Err(format!(
+                "Target table '{target_table}' already exists with a different structure and is missing column(s) \
+                 {} present in the source table. DBX does not alter an existing target table's columns during \
+                 transfer — drop the target table or adjust its structure to match the source first.",
+                missing.join(", ")
+            ));
+        }
+    }
+
     // Truncate target if overwrite mode
     if request.mode == TransferMode::Overwrite {
         let full_table =
@@ -8731,6 +8769,31 @@ mod tests {
         let writable = writable_transfer_columns(&columns, &DatabaseType::Postgres, &DatabaseType::SqlServer);
 
         assert_eq!(writable.iter().map(|column| column.name.as_str()).collect::<Vec<_>>(), vec!["id", "updated_at"]);
+    }
+
+    #[test]
+    fn missing_transfer_target_columns_reports_columns_absent_from_target() {
+        let target_columns = vec![test_column("id", "int"), test_column("name", "varchar(32)")];
+        let col_names = vec!["id".to_string(), "name".to_string(), "extra_col".to_string()];
+
+        assert_eq!(missing_transfer_target_columns(&target_columns, &col_names), vec!["extra_col".to_string()]);
+    }
+
+    #[test]
+    fn missing_transfer_target_columns_ignores_case() {
+        let target_columns = vec![test_column("ID", "int"), test_column("Name", "varchar(32)")];
+        let col_names = vec!["id".to_string(), "name".to_string()];
+
+        assert!(missing_transfer_target_columns(&target_columns, &col_names).is_empty());
+    }
+
+    #[test]
+    fn missing_transfer_target_columns_allows_extra_target_columns() {
+        let target_columns =
+            vec![test_column("id", "int"), test_column("name", "varchar(32)"), test_column("legacy_col", "int")];
+        let col_names = vec!["id".to_string(), "name".to_string()];
+
+        assert!(missing_transfer_target_columns(&target_columns, &col_names).is_empty());
     }
 
     #[test]

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1407,13 +1407,69 @@ fn writable_transfer_columns(
         .collect()
 }
 
-/// Columns DBX is about to write into `target_columns` (via `col_names`) that
-/// don't exist in the target table. MySQL (and most other targets) compare
-/// unquoted identifiers case-insensitively, so the check does too.
-fn missing_transfer_target_columns(target_columns: &[db::ColumnInfo], col_names: &[String]) -> Vec<String> {
-    let existing: std::collections::HashSet<String> =
-        target_columns.iter().map(|column| column.name.to_lowercase()).collect();
-    col_names.iter().filter(|name| !existing.contains(&name.to_lowercase())).cloned().collect()
+fn transfer_column_names_match(target_db_type: &DatabaseType, left: &str, right: &str) -> bool {
+    if matches!(
+        target_db_type,
+        DatabaseType::Mysql
+            | DatabaseType::Goldendb
+            | DatabaseType::Sqlite
+            | DatabaseType::Rqlite
+            | DatabaseType::CloudflareD1
+            | DatabaseType::DuckDb
+            | DatabaseType::SqlServer
+            | DatabaseType::Doris
+            | DatabaseType::StarRocks
+            | DatabaseType::Hive
+            | DatabaseType::Kyuubi
+            | DatabaseType::Impala
+            | DatabaseType::Spark
+            | DatabaseType::Access
+    ) {
+        left.eq_ignore_ascii_case(right)
+    } else {
+        left == right
+    }
+}
+
+fn missing_transfer_target_columns(
+    target_columns: &[db::ColumnInfo],
+    col_names: &[String],
+    target_db_type: &DatabaseType,
+) -> Vec<String> {
+    col_names
+        .iter()
+        .filter(|name| {
+            !target_columns.iter().any(|column| transfer_column_names_match(target_db_type, name, &column.name))
+        })
+        .cloned()
+        .collect()
+}
+
+fn target_column_can_be_omitted(column: &db::ColumnInfo, target_db_type: &DatabaseType) -> bool {
+    let extra = column.extra.as_deref().unwrap_or_default().trim().to_ascii_lowercase();
+    column.is_nullable
+        || column.column_default.as_deref().is_some_and(|value| !value.trim().is_empty())
+        || extra.contains("generated")
+        || extra.contains("identity")
+        || extra.contains("auto_increment")
+        || extra.contains("autoincrement")
+        || extra.contains("computed")
+        || (matches!(target_db_type, DatabaseType::SqlServer) && is_sqlserver_rowversion_type(&column.data_type))
+}
+
+fn required_unmapped_transfer_target_columns(
+    target_columns: &[db::ColumnInfo],
+    col_names: &[String],
+    target_db_type: &DatabaseType,
+) -> Vec<String> {
+    target_columns
+        .iter()
+        .filter(|column| {
+            !target_column_can_be_omitted(column, target_db_type)
+                && !col_names.iter().any(|name| transfer_column_names_match(target_db_type, name, &column.name))
+        })
+        .map(|column| column.name.clone())
+        .collect()
 }
 
 fn transfer_key_columns(columns: &[db::ColumnInfo], db_type: &DatabaseType) -> Vec<String> {
@@ -6772,14 +6828,15 @@ where
         return Ok(0);
     }
 
-    // The user asked DBX to sync structure (create_table), but the target
-    // table already existed so the create-table DDL above was skipped (see
-    // "skipping create-table DDL" above). If the untouched target structure
-    // can't hold the source's columns, fail fast here instead of truncating
-    // the target's existing data and then hitting an opaque driver error
-    // partway through the insert.
-    if request.create_table && target_table_preexisting {
-        let existing_target_columns = get_columns_for_transfer(
+    let needs_target_columns = (request.create_table && target_table_preexisting)
+        || (request.mode == TransferMode::Upsert
+            && !matches!(
+                target_db_type,
+                DatabaseType::ClickHouse | DatabaseType::Hive | DatabaseType::Kyuubi | DatabaseType::Impala
+            ))
+        || matches!(target_db_type, DatabaseType::Postgres | DatabaseType::Dameng);
+    let target_columns = if needs_target_columns {
+        get_columns_for_transfer(
             state,
             target_pool_key,
             &request.target_connection_id,
@@ -6789,14 +6846,35 @@ where
             request.target_catalog.as_deref(),
         )
         .await
-        .unwrap_or_default();
-        let missing = missing_transfer_target_columns(&existing_target_columns, &col_names);
+        .map_err(|error| format!("Failed to inspect target table '{target_table}' columns before transfer: {error}"))?
+    } else {
+        Vec::new()
+    };
+
+    // The user asked DBX to sync structure (create_table), but the target
+    // table already existed so the create-table DDL above was skipped (see
+    // "skipping create-table DDL" above). If the untouched target structure
+    // can't accept the planned insert, fail fast here instead of truncating
+    // the target's existing data and then hitting an opaque driver error.
+    if request.create_table && target_table_preexisting {
+        let missing = missing_transfer_target_columns(&target_columns, &col_names, target_db_type);
         if !missing.is_empty() {
             return Err(format!(
                 "Target table '{target_table}' already exists with a different structure and is missing column(s) \
                  {} present in the source table. DBX does not alter an existing target table's columns during \
                  transfer — drop the target table or adjust its structure to match the source first.",
                 missing.join(", ")
+            ));
+        }
+
+        let required = required_unmapped_transfer_target_columns(&target_columns, &col_names, target_db_type);
+        if !required.is_empty() {
+            return Err(format!(
+                "Target table '{target_table}' already exists with a different structure and has required column(s) \
+                 {} that are not present in the source table and have no default or generated value. DBX does not \
+                 alter an existing target table's columns during transfer — drop the target table or adjust its \
+                 structure to match the source first.",
+                required.join(", ")
             ));
         }
     }
@@ -6813,28 +6891,6 @@ where
         };
         execute_on_pool(state, target_pool_key, &truncate_sql).await.map_err(|e| format!("Failed to truncate: {e}"))?;
     }
-
-    let target_columns = if (request.mode == TransferMode::Upsert
-        && !matches!(
-            target_db_type,
-            DatabaseType::ClickHouse | DatabaseType::Hive | DatabaseType::Kyuubi | DatabaseType::Impala
-        ))
-        || matches!(target_db_type, DatabaseType::Postgres | DatabaseType::Dameng)
-    {
-        get_columns_for_transfer(
-            state,
-            target_pool_key,
-            &request.target_connection_id,
-            &request.target_database,
-            &request.target_schema,
-            &target_table,
-            request.target_catalog.as_deref(),
-        )
-        .await
-        .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
 
     // Determine effective mode and PK columns for upsert
     let (effective_mode, pk_columns) = if request.mode == TransferMode::Upsert {
@@ -8772,28 +8828,77 @@ mod tests {
     }
 
     #[test]
-    fn missing_transfer_target_columns_reports_columns_absent_from_target() {
+    fn transfer_target_column_validation_reports_columns_absent_from_target() {
         let target_columns = vec![test_column("id", "int"), test_column("name", "varchar(32)")];
         let col_names = vec!["id".to_string(), "name".to_string(), "extra_col".to_string()];
 
-        assert_eq!(missing_transfer_target_columns(&target_columns, &col_names), vec!["extra_col".to_string()]);
+        assert_eq!(
+            missing_transfer_target_columns(&target_columns, &col_names, &DatabaseType::Mysql),
+            vec!["extra_col".to_string()]
+        );
     }
 
     #[test]
-    fn missing_transfer_target_columns_ignores_case() {
+    fn transfer_target_column_validation_uses_database_case_rules() {
         let target_columns = vec![test_column("ID", "int"), test_column("Name", "varchar(32)")];
         let col_names = vec!["id".to_string(), "name".to_string()];
 
-        assert!(missing_transfer_target_columns(&target_columns, &col_names).is_empty());
+        assert!(missing_transfer_target_columns(&target_columns, &col_names, &DatabaseType::Mysql).is_empty());
+        assert!(missing_transfer_target_columns(&target_columns, &col_names, &DatabaseType::Kyuubi).is_empty());
+        assert_eq!(
+            missing_transfer_target_columns(&target_columns, &col_names, &DatabaseType::Postgres),
+            vec!["id".to_string(), "name".to_string()]
+        );
     }
 
     #[test]
-    fn missing_transfer_target_columns_allows_extra_target_columns() {
-        let target_columns =
-            vec![test_column("id", "int"), test_column("name", "varchar(32)"), test_column("legacy_col", "int")];
-        let col_names = vec!["id".to_string(), "name".to_string()];
+    fn transfer_target_column_validation_allows_omittable_target_columns() {
+        let target_columns = vec![
+            test_column("id", "int"),
+            test_column("nullable_note", "varchar(32)"),
+            db::ColumnInfo {
+                is_nullable: false,
+                column_default: Some("CURRENT_TIMESTAMP".to_string()),
+                ..test_column("created_at", "timestamp")
+            },
+            db::ColumnInfo {
+                is_nullable: false,
+                extra: Some("generated always as (id + 1) stored".to_string()),
+                ..test_column("generated_id", "int")
+            },
+            db::ColumnInfo {
+                is_nullable: false,
+                extra: Some("identity(1,1)".to_string()),
+                ..test_column("sequence_id", "bigint")
+            },
+            db::ColumnInfo {
+                is_nullable: false,
+                extra: Some("computed".to_string()),
+                ..test_column("computed_id", "int")
+            },
+            db::ColumnInfo { is_nullable: false, ..test_column("row_version", "rowversion") },
+        ];
+        let col_names = vec!["id".to_string()];
 
-        assert!(missing_transfer_target_columns(&target_columns, &col_names).is_empty());
+        assert!(required_unmapped_transfer_target_columns(&target_columns[..6], &col_names, &DatabaseType::Mysql)
+            .is_empty());
+        assert!(
+            required_unmapped_transfer_target_columns(&target_columns, &col_names, &DatabaseType::SqlServer).is_empty()
+        );
+    }
+
+    #[test]
+    fn transfer_target_column_validation_rejects_required_unmapped_columns() {
+        let target_columns = vec![
+            test_column("id", "int"),
+            db::ColumnInfo { is_nullable: false, ..test_column("required_code", "varchar(32)") },
+        ];
+        let col_names = vec!["id".to_string()];
+
+        assert_eq!(
+            required_unmapped_transfer_target_columns(&target_columns, &col_names, &DatabaseType::Mysql),
+            vec!["required_code".to_string()]
+        );
     }
 
     #[test]

--- a/crates/dbx-core/tests/live_mysql_transfer.rs
+++ b/crates/dbx-core/tests/live_mysql_transfer.rs
@@ -457,3 +457,102 @@ async fn live_mysql_transfer_preserves_spatial_values_and_modes() {
     cleanup.unwrap();
     test_result.unwrap();
 }
+
+#[tokio::test]
+#[ignore = "requires a disposable MySQL 5.7+ endpoint via DBX_LIVE_MYSQL_TRANSFER_* variables"]
+async fn live_mysql_transfer_structure_overwrite_rejects_incompatible_target_columns() {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let connection_id = format!("live-mysql-transfer-struct-{suffix}");
+    let source_database = format!("dbx_transfer_struct_src_{}", &suffix[..12]);
+    let target_database = format!("dbx_transfer_struct_dst_{}", &suffix[..12]);
+    let config = live_mysql_config(&connection_id);
+    let setup_pool = mysql::connect(&mysql_url(&config), Duration::from_secs(10)).await.unwrap();
+
+    let setup = format!(
+        "CREATE DATABASE `{source_database}`;\
+         CREATE DATABASE `{target_database}`;\
+         CREATE TABLE `{source_database}`.`orders` (\
+             id INT PRIMARY KEY, name VARCHAR(32), extra_col VARCHAR(32)\
+         );\
+         INSERT INTO `{source_database}`.`orders` VALUES (1, 'alpha', 'x');\
+         CREATE TABLE `{target_database}`.`orders` (\
+             id INT PRIMARY KEY, name VARCHAR(32)\
+         );\
+         INSERT INTO `{target_database}`.`orders` (id, name) VALUES (99, 'stale')"
+    );
+    mysql::execute_query(&setup_pool, &setup, true).await.unwrap();
+
+    let dir = std::env::temp_dir().join(format!("dbx-live-mysql-transfer-struct-{suffix}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let storage = Storage::open(&dir.join("storage.db")).await.unwrap();
+    let state = AppState::new(storage);
+    state.configs.write().await.insert(connection_id.clone(), config);
+    let source_pool_key = state.get_or_create_pool(&connection_id, Some(&source_database)).await.unwrap();
+    let target_pool_key = state.get_or_create_pool(&connection_id, Some(&target_database)).await.unwrap();
+
+    // Mirrors the UI: "structure + data" content always requests create_table,
+    // and the reporter picked overwrite mode. The target table already exists
+    // with a column that's missing from the source ("orders" lacks extra_col).
+    let request = TransferRequest {
+        transfer_id: format!("live-mysql-transfer-struct-overwrite-{suffix}"),
+        source_connection_id: connection_id.clone(),
+        source_database: source_database.clone(),
+        source_schema: source_database.clone(),
+        source_catalog: None,
+        target_connection_id: connection_id.clone(),
+        target_database: target_database.clone(),
+        target_schema: target_database.clone(),
+        target_catalog: None,
+        tables: vec!["orders".to_string()],
+        create_table: true,
+        content: TransferContent::default(),
+        objects: Vec::new(),
+        mode: TransferMode::Overwrite,
+        target_table_name_case: TransferTableNameCase::Preserve,
+        ownership_policy: TransferOwnershipPolicy::Preserve,
+        batch_size: 10,
+    };
+
+    let test_result = async {
+        let result = transfer_table(
+            &state,
+            &request,
+            "orders",
+            0,
+            &DatabaseType::Mysql,
+            &DatabaseType::Mysql,
+            &source_pool_key,
+            &target_pool_key,
+            |_| {},
+        )
+        .await;
+
+        assert!(result.is_err(), "expected transfer to reject the incompatible target structure, got {result:?}");
+
+        // The pre-existing target row must survive: a column-mismatch error must
+        // be raised BEFORE the destructive TRUNCATE, not surface only after the
+        // target has already been wiped by an insert that was doomed to fail.
+        assert_eq!(
+            query_text(
+                &setup_pool,
+                &format!("SELECT CAST(COUNT(*) AS CHAR) FROM `{target_database}`.`orders` WHERE id=99"),
+            )
+            .await,
+            "1",
+            "target row was destroyed by TRUNCATE despite the transfer failing"
+        );
+        Ok::<_, String>(())
+    }
+    .await;
+
+    let cleanup = mysql::execute_query(
+        &setup_pool,
+        &format!("DROP DATABASE `{source_database}`; DROP DATABASE `{target_database}`"),
+        true,
+    )
+    .await;
+    setup_pool.disconnect().await.unwrap();
+    let _ = std::fs::remove_dir_all(dir);
+    cleanup.unwrap();
+    test_result.unwrap();
+}

--- a/crates/dbx-core/tests/live_mysql_transfer.rs
+++ b/crates/dbx-core/tests/live_mysql_transfer.rs
@@ -478,7 +478,15 @@ async fn live_mysql_transfer_structure_overwrite_rejects_incompatible_target_col
          CREATE TABLE `{target_database}`.`orders` (\
              id INT PRIMARY KEY, name VARCHAR(32)\
          );\
-         INSERT INTO `{target_database}`.`orders` (id, name) VALUES (99, 'stale')"
+         INSERT INTO `{target_database}`.`orders` (id, name) VALUES (99, 'stale');\
+         CREATE TABLE `{source_database}`.`required_orders` (\
+             id INT PRIMARY KEY, name VARCHAR(32)\
+         );\
+         INSERT INTO `{source_database}`.`required_orders` VALUES (1, 'alpha');\
+         CREATE TABLE `{target_database}`.`required_orders` (\
+             id INT PRIMARY KEY, name VARCHAR(32), required_code VARCHAR(32) NOT NULL\
+         );\
+         INSERT INTO `{target_database}`.`required_orders` (id, name, required_code) VALUES (99, 'stale', 'keep')"
     );
     mysql::execute_query(&setup_pool, &setup, true).await.unwrap();
 
@@ -527,7 +535,8 @@ async fn live_mysql_transfer_structure_overwrite_rejects_incompatible_target_col
         )
         .await;
 
-        assert!(result.is_err(), "expected transfer to reject the incompatible target structure, got {result:?}");
+        let error = result.expect_err("expected transfer to reject the incompatible target structure");
+        assert!(error.contains("extra_col"), "unexpected missing-source-column error: {error}");
 
         // The pre-existing target row must survive: a column-mismatch error must
         // be raised BEFORE the destructive TRUNCATE, not surface only after the
@@ -540,6 +549,49 @@ async fn live_mysql_transfer_structure_overwrite_rejects_incompatible_target_col
             .await,
             "1",
             "target row was destroyed by TRUNCATE despite the transfer failing"
+        );
+
+        let required_request = TransferRequest {
+            transfer_id: format!("live-mysql-transfer-required-target-overwrite-{suffix}"),
+            source_connection_id: connection_id.clone(),
+            source_database: source_database.clone(),
+            source_schema: source_database.clone(),
+            source_catalog: None,
+            target_connection_id: connection_id.clone(),
+            target_database: target_database.clone(),
+            target_schema: target_database.clone(),
+            target_catalog: None,
+            tables: vec!["required_orders".to_string()],
+            create_table: true,
+            content: TransferContent::default(),
+            objects: Vec::new(),
+            mode: TransferMode::Overwrite,
+            target_table_name_case: TransferTableNameCase::Preserve,
+            ownership_policy: TransferOwnershipPolicy::Preserve,
+            batch_size: 10,
+        };
+        let required_result = transfer_table(
+            &state,
+            &required_request,
+            "required_orders",
+            0,
+            &DatabaseType::Mysql,
+            &DatabaseType::Mysql,
+            &source_pool_key,
+            &target_pool_key,
+            |_| {},
+        )
+        .await;
+        let required_error = required_result.expect_err("expected transfer to reject a required target-only column");
+        assert!(required_error.contains("required_code"), "unexpected required-target-column error: {required_error}");
+        assert_eq!(
+            query_text(
+                &setup_pool,
+                &format!("SELECT CAST(COUNT(*) AS CHAR) FROM `{target_database}`.`required_orders` WHERE id=99"),
+            )
+            .await,
+            "1",
+            "target row was destroyed by TRUNCATE despite the required target column mismatch"
         );
         Ok::<_, String>(())
     }


### PR DESCRIPTION
## Summary

- "Structure + data" transfer always requests `create_table`, but the target's create/sync-structure DDL is silently skipped once the target table already exists — its columns are left untouched.
- In Overwrite mode, DBX then **TRUNCATEs the target's existing data first**, and only afterward discovers via a raw MySQL insert error (`ER_BAD_FIELD_ERROR`) that the untouched target is missing a column the source needs — so the target's data is destroyed even though the transfer ultimately fails.
- Adds a pre-flight column-compatibility check (`missing_transfer_target_columns`) that runs before the TRUNCATE when the target table pre-existed and `create_table` was requested, so a structure mismatch now fails fast with a clear message, before any data is touched.

Fixes #6248

## Test plan

- [x] Added `live_mysql_transfer_structure_overwrite_rejects_incompatible_target_columns` (real MySQL 8.4, not mocked): reproduced the bug against unfixed code first — target's pre-existing row was destroyed by TRUNCATE even though the transfer errored; after the fix, the same test passes (transfer fails fast, target row survives).
- [x] Added 3 unit tests for the new pure `missing_transfer_target_columns` helper.
- [x] `cargo test -p dbx-core --lib transfer::` — 198/198 passed.
- [x] `cargo test -p dbx-core --test live_mysql_transfer` against real MySQL — new test passes; existing `live_mysql_transfer_preserves_spatial_values_and_modes` (covers Overwrite mode) still passes, no regression.
- [x] `cargo fmt --check -p dbx-core` / `cargo clippy -p dbx-core --lib --tests -- -D warnings` — clean.
- [x] Rebased onto latest `upstream/main`, re-ran tests post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)