### PR TITLE
fix(mongodb): reconcile execution summary status for Mongo commands

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.mongoExecutionSummary.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.mongoExecutionSummary.spec.ts
@@ -1,0 +1,121 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { splitMongoCommandRanges } from "@/lib/mongo/mongoShellCommand";
+
+const mocks = vi.hoisted(() => ({
+  ensureConnected: vi.fn(),
+  getConnectionConfig: vi.fn(),
+  mongoFindDocuments: vi.fn(),
+  mongoParseShellCommand: vi.fn(),
+}));
+
+vi.mock("@/lib/backend/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/backend/api")>();
+  return {
+    ...actual,
+    mongoFindDocuments: mocks.mongoFindDocuments,
+    mongoParseShellCommand: mocks.mongoParseShellCommand,
+  };
+});
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => ({
+    ensureConnected: mocks.ensureConnected,
+    getConfig: mocks.getConnectionConfig,
+    recordConnectionLostError: vi.fn(),
+  }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings: { autoCalculateTotalRows: false, pageSize: 100, continueOnErrorOnBatch: false, queryResultMaxRowsEnabled: false, queryResultMaxRows: 0 },
+  }),
+}));
+
+function installLocalStorage() {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => data.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => data.set(key, value)),
+    removeItem: vi.fn((key: string) => data.delete(key)),
+  });
+}
+
+describe("queryStore MongoDB execution summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    installLocalStorage();
+    setActivePinia(createPinia());
+    mocks.ensureConnected.mockResolvedValue(undefined);
+    mocks.getConnectionConfig.mockReturnValue({
+      id: "mongo-1",
+      name: "MongoDB",
+      db_type: "mongodb",
+      database: "app",
+    });
+    mocks.mongoParseShellCommand.mockImplementation(async (source: string) => splitMongoCommandRanges(source)[0]!.command);
+  });
+
+  it("marks a successful find command as success with the returned row count, instead of leaving it stuck at 'skipped'", async () => {
+    mocks.mongoFindDocuments.mockResolvedValue({
+      documents: [
+        { _id: "1", name: "alice" },
+        { _id: "2", name: "bob" },
+        { _id: "3", name: "carol" },
+      ],
+      extended_documents: [],
+      total: 3,
+      total_is_exact: true,
+    });
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mongo-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "db.users.find()");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    expect(tab.result?.rows).toHaveLength(3);
+    expect(tab.batchSqlExecution).toMatchObject({
+      total: 1,
+      completed: 1,
+      items: [{ status: "success", statementIndex: 0 }],
+    });
+    expect(tab.batchSqlExecution?.items[0]?.status).not.toBe("skipped");
+  });
+
+  it("marks a failing mongo command as error instead of leaving it stuck at 'skipped'", async () => {
+    mocks.mongoFindDocuments.mockRejectedValue(new Error("collection not found"));
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mongo-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "db.missing.find()");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    expect(tab.batchSqlExecution).toMatchObject({
+      total: 1,
+      completed: 1,
+      items: [{ status: "error", statementIndex: 0 }],
+    });
+  });
+
+  it("reconciles each command in a multi-command mongo batch by position", async () => {
+    mocks.mongoFindDocuments.mockResolvedValue({ documents: [{ _id: "1" }], extended_documents: [], total: 1, total_is_exact: true });
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mongo-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "db.users.find();\ndb.orders.find()");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    expect(tab.batchSqlExecution).toMatchObject({
+      total: 2,
+      completed: 2,
+      items: [
+        { status: "success", statementIndex: 0 },
+        { status: "success", statementIndex: 1 },
+      ],
+    });
+  });
+});

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -275,7 +275,7 @@ function clearLiveBatchSqlExecution(tab: QueryTab, executionId: string) {
 }
 
 function createBatchSqlExecution(executionId: string, editorSql: string, submittedSql: string, databaseType: DatabaseType | undefined, sourceOffset: number | undefined): BatchSqlExecution | undefined {
-  const statements = splitSqlStatementRanges(submittedSql, databaseType);
+  const statements = databaseType === "mongodb" ? splitMongoCommandRanges(submittedSql).map(({ from, to, text }) => ({ from, to, sql: text })) : splitSqlStatementRanges(submittedSql, databaseType);
   if (statements.length === 0) return undefined;
   if (statements.length > 1 && databaseType && NON_STREAMING_BATCH_DATABASE_TYPES.has(databaseType)) return undefined;
   const offset = sourceOffset ?? 0;
@@ -4423,6 +4423,7 @@ export const useQueryStore = defineStore("query", () => {
 
         const current = findExecutionTab(id);
         if (current?.executionId === executionId) {
+          reconcileBatchSqlResults(current, executionId, allResults);
           if (captureResultRun && current.isCancelling && restorePendingResultRun(current, executionId)) return false;
           const activeGroupIndex = current.activeResultIndex;
           const activeGroupResults = current.results;


### PR DESCRIPTION
## Problem

Running a MongoDB command from the query editor (e.g. `db.users.find()`) leaves the **Summary** panel stuck showing "Execution finished 0/1", 0%, status "Not run" (i.e. skipped), and rows "—" — even though the query actually succeeded and the Table Data tab shows the correct rows.

Root cause is two-fold:
1. `createBatchSqlExecution` always split the editor text with the **SQL** statement splitter regardless of database type, instead of the Mongo-aware command splitter already used elsewhere (`statementRanges()` in `tabPresentation.ts`).
2. The MongoDB execution branch in `executeTabSql` never fed its per-command results back into the batch execution state (`reconcileBatchSqlResults`) the way the SQL path does. So every Mongo command's summary item stayed at its initial `pending`/`running` status and got downgraded to `skipped` ("Not run") once execution finished, regardless of whether it actually succeeded or failed.

## Fix

- Split with `splitMongoCommandRanges` when the connection's database type is `mongodb`, so the batch item list matches the commands that will actually run.
- Call `reconcileBatchSqlResults` with the real per-command results after the Mongo execution loop finishes, mirroring the existing SQL streaming path. Mongo results don't carry `statement_index`, so this reconciles positionally, which is safe because each parsed Mongo command pushes exactly one result (success or error) in order.

## Testing

- Added `apps/desktop/src/stores/__tests__/queryStore.mongoExecutionSummary.spec.ts` (3 new tests: successful find, failing command, multi-command batch). Confirmed they fail against the pre-fix code (reproducing the exact "skipped"/`completed: 0` bug) and pass after the fix.
- Real end-to-end repro: local MongoDB 7.0 + `dbx-web` dev backend + `pnpm dev:web`, ran `db.users.find()` against a 3-document collection.
  - Before: Summary showed "Execution finished 0/1", status "Not run", rows "—".
  - After: Summary shows "Execution finished 1/1", status "Success", rows "3".
- Full suite: `pnpm vitest run apps/desktop/src` — 682 files / 6361 tests pass.
- `pnpm typecheck` and `pnpm lint` clean.

Fixes #6085