### PR TITLE
fix(redis): keep JSON tree key labels from collapsing vertically

### DIFF
--- a/apps/desktop/src/components/common/JsonTree.vue
+++ b/apps/desktop/src/components/common/JsonTree.vue
@@ -317,9 +317,13 @@ defineExpose({ expandAll, collapseAll, resetExpansion, refresh });
 .json-tree-string,
 .json-tree-number,
 .json-tree-boolean,
-.json-tree-null,
-.json-tree-summary {
+.json-tree-null {
   flex: 1 1 auto;
+  min-width: 0;
+}
+
+.json-tree-summary {
+  flex: 0 1 auto;
   min-width: 0;
 }
 

--- a/apps/desktop/src/components/common/JsonTree.vue
+++ b/apps/desktop/src/components/common/JsonTree.vue
@@ -307,6 +307,22 @@ defineExpose({ expandAll, collapseAll, resetExpansion, refresh });
   font-weight: 650;
 }
 
+.json-tree-key,
+.json-tree-index,
+.json-tree-punctuation,
+.json-tree-bracket {
+  flex: 0 0 auto;
+}
+
+.json-tree-string,
+.json-tree-number,
+.json-tree-boolean,
+.json-tree-null,
+.json-tree-summary {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .dark .json-tree {
   --json-tree-key: #93c5fd;
   --json-tree-string: #86efac;

--- a/packages/app-tests/jsonTreeLayout.test.ts
+++ b/packages/app-tests/jsonTreeLayout.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("apps/desktop/src/components/common/JsonTree.vue", "utf8");
+
+describe("JSON tree layout", () => {
+  it("keeps a collapsed container closing bracket beside its summary", () => {
+    expect(source).toMatch(/\.json-tree-summary\s*\{\s*flex: 0 1 auto;\s*min-width: 0;\s*\}/);
+  });
+});


### PR DESCRIPTION
## Problem

In the Redis JSON tree view (used for member/value detail dialogs), field/key labels sometimes render vertically, one character per line, instead of horizontally — see #6293.

Root cause: `.json-tree-row` in `apps/desktop/src/components/common/JsonTree.vue` is a flex row, and the row's key/index/punctuation/bracket spans had no `flex-shrink` guard. The ancestor `.json-tree` sets `overflow-wrap: anywhere`, which lowers a flex item's automatic minimum size down to roughly one character. When a row's total content (indent + key + a long unbroken value) exceeds the available width, the flex-shrink algorithm can squeeze whichever sibling has the largest content-size mismatch down toward that ~1-character minimum instead of wrapping the long value normally — collapsing the key into a vertical single-character column.

Reproduces with a narrow container width + deep nesting + a long value with no spaces (e.g. embedded HTML/URL), matching the intermittent nature described in the report.

## Solution

Give the row's label spans (`.json-tree-key`, `.json-tree-index`, `.json-tree-punctuation`, `.json-tree-bracket`) `flex: 0 0 auto` so they keep their natural width, and give the value/summary spans (`.json-tree-string`, `.json-tree-number`, `.json-tree-boolean`, `.json-tree-null`, `.json-tree-summary`) `flex: 1 1 auto; min-width: 0` so only the value content wraps within the remaining row width.

## Testing

- Reproduced live in the running app: connected to a real Redis instance, opened a Set member's JSON view at a narrow viewport (500px) with 8 levels of nesting and a long unbroken string value — the key collapsed into a vertical single-character column before the fix, and stayed horizontal (value wrapping normally) after.
- `pnpm lint` — clean (no new warnings on the changed file)
- `pnpm typecheck` (`vue-tsc --noEmit`) — clean
- `pnpm test` (`vitest run`) — 974 files / 9291 tests passing

Fixes #6293