### PR TITLE
fix(transfer): rank exact-prefix matches first in object search

### DIFF
--- a/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
+++ b/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
@@ -116,7 +116,10 @@ const filteredGroups = computed<ObjectTreeGroup[]>(() => {
   }
   return props.groups.map((g) => ({
     ...g,
-    items: g.items.filter((name) => name.toLowerCase().includes(query)),
+    // Exact-prefix matches surface first (e.g. searching "user" ranks
+    // "users_archive" above "abc_users"); ties keep their original order
+    // since Array#sort is stable.
+    items: g.items.filter((name) => name.toLowerCase().includes(query)).sort((a, b) => Number(b.toLowerCase().startsWith(query)) - Number(a.toLowerCase().startsWith(query))),
   }));
 });
 

--- a/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
+++ b/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
@@ -114,13 +114,19 @@ const filteredGroups = computed<ObjectTreeGroup[]>(() => {
   if (!query) {
     return props.groups;
   }
-  return props.groups.map((g) => ({
-    ...g,
-    // Exact-prefix matches surface first (e.g. searching "user" ranks
-    // "users_archive" above "abc_users"); ties keep their original order
-    // since Array#sort is stable.
-    items: g.items.filter((name) => name.toLowerCase().includes(query)).sort((a, b) => Number(b.toLowerCase().startsWith(query)) - Number(a.toLowerCase().startsWith(query))),
-  }));
+  return props.groups.map((group) => {
+    const prefixMatches: string[] = [];
+    const substringMatches: string[] = [];
+    for (const name of group.items) {
+      const normalizedName = name.toLowerCase();
+      if (normalizedName.startsWith(query)) {
+        prefixMatches.push(name);
+      } else if (normalizedName.includes(query)) {
+        substringMatches.push(name);
+      }
+    }
+    return { ...group, items: [...prefixMatches, ...substringMatches] };
+  });
 });
 
 function selectAllEnabled() {

--- a/apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts
+++ b/apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts
@@ -149,12 +149,12 @@ describe("ObjectSelectionTree interaction", () => {
     // "abc_users" contains "user" but doesn't start with it; "users_archive"
     // and "user_log" are both true prefix matches and should be sorted
     // ahead of it, keeping their own relative order (stable sort).
-    const SEARCHABLE: TreeGroup = { kind: "TABLE", label: "Tables", items: ["abc_users", "users_archive", "user_log"] };
+    const SEARCHABLE: TreeGroup = { kind: "TABLE", label: "Tables", items: ["abc_users", "users_archive", "xuser_log", "user_log"] };
     const { container, app } = mountTree({ groups: [SEARCHABLE] });
     cleanup = () => app.unmount();
     await typeSearch(container, "user");
     const order = Array.from(container.querySelectorAll('label[data-test^="item-TABLE-"]')).map((el) => el.getAttribute("data-test")!.replace("item-TABLE-", ""));
-    expect(order).toEqual(["users_archive", "user_log", "abc_users"]);
+    expect(order).toEqual(["users_archive", "user_log", "abc_users", "xuser_log"]);
   });
 
   it("deselect all only clears visible enabled selections, keeping hidden ones", async () => {

--- a/apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts
+++ b/apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts
@@ -145,6 +145,18 @@ describe("ObjectSelectionTree interaction", () => {
     expect(container.querySelector('[data-test="group-FUNCTION"]')?.textContent).toContain("无匹配");
   });
 
+  it("search ranks exact-prefix matches before mid-name matches", async () => {
+    // "abc_users" contains "user" but doesn't start with it; "users_archive"
+    // and "user_log" are both true prefix matches and should be sorted
+    // ahead of it, keeping their own relative order (stable sort).
+    const SEARCHABLE: TreeGroup = { kind: "TABLE", label: "Tables", items: ["abc_users", "users_archive", "user_log"] };
+    const { container, app } = mountTree({ groups: [SEARCHABLE] });
+    cleanup = () => app.unmount();
+    await typeSearch(container, "user");
+    const order = Array.from(container.querySelectorAll('label[data-test^="item-TABLE-"]')).map((el) => el.getAttribute("data-test")!.replace("item-TABLE-", ""));
+    expect(order).toEqual(["users_archive", "user_log", "abc_users"]);
+  });
+
   it("deselect all only clears visible enabled selections, keeping hidden ones", async () => {
     const { state, container, app } = mountTree({
       selection: { VIEW: ["v1", "v2", "v3"], FUNCTION: ["f1", "f2"] },


### PR DESCRIPTION
## Problem

#6115 reported two separate problems with ClickHouse data transfer:
1. The object list didn't show tables at all — **already fixed upstream in `44cb27825`**, unrelated to this PR.
2. The object search box in the Data Transfer dialog ranked results by whatever order the backend returned (effectively alphabetical), not by relevance. Searching e.g. `user` could put `abc_users` ahead of `users_archive` / `user_log`, which are true prefix matches and much more likely what the user is looking for. The maintainer's comment on the issue explicitly left it open for this second part.

This PR addresses only #2.

## Solution

`ObjectSelectionTree.vue`'s `filteredGroups` computed filtered by substring match but never reordered results. After filtering, it now stable-sorts so names starting with the query surface first, keeping each group's original relative order otherwise (`Array#sort` is stable, so no other ordering changes).

## Testing

Reproduced live against a real ClickHouse 24.8 container (via this repo's own `pnpm db:env` test-database tooling) through the actual Data Transfer dialog in a running dev instance:
- Source: ClickHouse connection, database with 4 tables (`abc_users`, `orders`, `user_log`, `users_archive`).
- Searching `user` before the fix: `abc_users, user_log, users_archive` (plain alphabetical — the non-prefix match sits ahead of true prefix matches).
- Searching `user` after the fix: `user_log, users_archive, abc_users` (true prefix matches first).
- Verified by toggling the fix on/off in place (`git apply -R` / `git apply`) against the same running instance and re-running the same steps each time, not two separately staged runs.

Also:
- Added a regression test (`ObjectSelectionTree.spec.ts`) asserting the rendered item order for a mixed prefix/substring-match search; confirmed it fails on the pre-fix code and passes after.
- `pnpm exec vitest run apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts` — 16/16 passing.
- `pnpm exec vue-tsc --noEmit` — clean.
- `pnpm lint` (oxlint) — clean on changed files (repo has pre-existing unrelated warnings elsewhere).

## Note on scope

The maintainer (`@t8y2`) is currently assigned to #6115. I'm submitting this because it's a small, fully-verified, additive fix for the one sub-problem explicitly left open, not a claim on the whole issue — feel free to merge, request changes, or close in favor of your own fix if you're already working on it.

Part of #6115