### PR TITLE
fix(export): keep MySQL database export table order alphabetical

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1776,8 +1776,12 @@ pub async fn export_database_sql_core(
     };
 
     // Sort tables by foreign key dependency so referenced (parent) tables are
-    // exported before referencing (child) tables.
-    if tables.len() > 1 {
+    // exported before referencing (child) tables. MySQL exports always emit
+    // `SET FOREIGN_KEY_CHECKS = 0`, so both the generated DDL and any INSERTs
+    // already tolerate child-before-parent ordering; reordering away from the
+    // alphabetical listing there only makes the output look shuffled to users
+    // without providing any correctness benefit.
+    if tables.len() > 1 && db_type != DatabaseType::Mysql {
         let table_names: Vec<String> = tables.iter().map(|t| t.name.clone()).collect();
         match crate::transfer::sort_tables_by_fk_dependency(
             state,

--- a/crates/dbx-core/tests/live_mysql_export_table_order.rs
+++ b/crates/dbx-core/tests/live_mysql_export_table_order.rs
@@ -1,0 +1,137 @@
+use dbx_core::connection::AppState;
+use dbx_core::database_export::{export_database_sql_core, DatabaseExportRequest};
+use dbx_core::models::connection::{ConnectionConfig, DatabaseType};
+use dbx_core::query::execute_sql_statement;
+use dbx_core::storage::Storage;
+
+fn live_mysql_config(id: &str) -> ConnectionConfig {
+    let host = std::env::var("DBX_LIVE_SQL_FILE_MYSQL_HOST").expect("DBX_LIVE_SQL_FILE_MYSQL_HOST");
+    let port =
+        std::env::var("DBX_LIVE_SQL_FILE_MYSQL_PORT").ok().and_then(|value| value.parse::<u16>().ok()).unwrap_or(3306);
+    let username = std::env::var("DBX_LIVE_SQL_FILE_MYSQL_USER").expect("DBX_LIVE_SQL_FILE_MYSQL_USER");
+    let password = std::env::var("DBX_LIVE_SQL_FILE_MYSQL_PASSWORD").expect("DBX_LIVE_SQL_FILE_MYSQL_PASSWORD");
+
+    serde_json::from_value(serde_json::json!({
+        "id": id,
+        "name": id,
+        "db_type": DatabaseType::Mysql,
+        "host": host,
+        "port": port,
+        "username": username,
+        "password": password,
+        "database": null,
+        "connect_timeout_secs": 10,
+        "query_timeout_secs": 30,
+        "idle_timeout_secs": 60,
+        "keepalive_interval_secs": 0
+    }))
+    .expect("live MySQL export config should deserialize")
+}
+
+/// Extracts the order tables appear in exported DDL, by scanning for
+/// `CREATE TABLE ... \`name\`` occurrences in file order.
+fn exported_table_order(sql: &str, candidate_names: &[&str]) -> Vec<String> {
+    let mut hits: Vec<(usize, String)> = Vec::new();
+    for name in candidate_names {
+        if let Some(pos) = regex::Regex::new(&format!(r"(?is)\bCREATE\s+TABLE\s+`{}`", regex::escape(name)))
+            .unwrap()
+            .find(sql)
+            .map(|m| m.start())
+        {
+            hits.push((pos, name.to_string()));
+        }
+    }
+    hits.sort_by_key(|(pos, _)| *pos);
+    hits.into_iter().map(|(_, name)| name).collect()
+}
+
+#[tokio::test]
+#[ignore = "requires a disposable MySQL endpoint"]
+async fn live_mysql_database_export_table_order_is_not_alphabetical_when_fk_reordered() {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let connection_id = format!("live-mysql-export-order-{suffix}");
+    let database = format!("dbx_export_order_{suffix}");
+    let dir = std::env::temp_dir().join(format!("dbx-live-mysql-export-order-{suffix}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let storage = Storage::open(&dir.join("storage.db")).await.unwrap();
+    let state = AppState::new(storage);
+    state.configs.write().await.insert(connection_id.clone(), live_mysql_config(&connection_id));
+
+    for sql in [
+        format!("DROP DATABASE IF EXISTS `{database}`"),
+        format!("CREATE DATABASE `{database}`"),
+        format!("CREATE TABLE `{database}`.`alpha` (id INT PRIMARY KEY)"),
+        format!("CREATE TABLE `{database}`.`bravo` (id INT PRIMARY KEY)"),
+        format!("CREATE TABLE `{database}`.`mango` (id INT PRIMARY KEY)"),
+        format!("CREATE TABLE `{database}`.`zoo` (id INT PRIMARY KEY)"),
+        format!(
+            "CREATE TABLE `{database}`.`orders` (id INT PRIMARY KEY, alpha_id INT, \
+             FOREIGN KEY (alpha_id) REFERENCES `{database}`.`alpha`(id))"
+        ),
+        format!(
+            "CREATE TABLE `{database}`.`order_items` (id INT PRIMARY KEY, orders_id INT, mango_id INT, \
+             FOREIGN KEY (orders_id) REFERENCES `{database}`.`orders`(id), \
+             FOREIGN KEY (mango_id) REFERENCES `{database}`.`mango`(id))"
+        ),
+    ] {
+        execute_sql_statement(&state, &connection_id, "", &sql, None, None).await.unwrap();
+    }
+
+    let names = ["alpha", "bravo", "mango", "order_items", "orders", "zoo"];
+    let alphabetical: Vec<String> = {
+        let mut v: Vec<String> = names.iter().map(|s| s.to_string()).collect();
+        v.sort();
+        v
+    };
+
+    let file_path = dir.join("export.sql");
+    let export_request = DatabaseExportRequest {
+        export_id: format!("live-mysql-export-order-{suffix}"),
+        connection_id: connection_id.clone(),
+        database: database.clone(),
+        schema: database.clone(),
+        file_path: file_path.to_string_lossy().to_string(),
+        selected_tables: Vec::new(),
+        excluded_tables: Vec::new(),
+        include_structure: true,
+        include_data: false,
+        include_objects: false,
+        include_create_database: false,
+        drop_table_if_exists: false,
+        omit_auto_increment: false,
+        fail_on_error: true,
+        snapshot_session_id: None,
+        batch_size: 1000,
+    };
+
+    let test_result = async {
+        export_database_sql_core(&state, &export_request, |_| {}).await?;
+        let exported_1 = std::fs::read_to_string(&file_path).map_err(|error| error.to_string())?;
+        let order_1 = exported_table_order(&exported_1, &names);
+
+        // Export a second time against the exact same, unchanged schema.
+        export_database_sql_core(&state, &export_request, |_| {}).await?;
+        let exported_2 = std::fs::read_to_string(&file_path).map_err(|error| error.to_string())?;
+        let order_2 = exported_table_order(&exported_2, &names);
+
+        Ok::<_, String>((order_1, order_2))
+    }
+    .await;
+
+    let cleanup =
+        execute_sql_statement(&state, &connection_id, "", &format!("DROP DATABASE `{database}`"), None, None).await;
+    cleanup.unwrap();
+    std::fs::remove_dir_all(dir).unwrap();
+
+    let (order_1, order_2) = test_result.unwrap();
+    eprintln!("run 1 order: {order_1:?}");
+    eprintln!("run 2 order: {order_2:?}");
+    eprintln!("alphabetical (expected by user): {alphabetical:?}");
+
+    assert_eq!(order_1, order_2, "export order should at least be stable across repeated runs of the same schema");
+    assert_eq!(
+        order_1, alphabetical,
+        "exported table structure order should match the alphabetical order tables are shown in, \
+         not the FK-dependency topological order"
+    );
+}


### PR DESCRIPTION
## Summary

`export_database_sql_core` unconditionally re-sorted a database's tables by foreign-key dependency (topological order, parent-before-child) after the already-alphabetical table listing. For MySQL specifically, this reorder is pure noise: MySQL exports always emit `SET FOREIGN_KEY_CHECKS = 0` up front, so neither the generated DDL nor the INSERT statements ever need dependency-safe ordering. The result was that table structure exports came out in a foreign-key-dependency order that didn't match the alphabetical order tables are shown in everywhere else in the app, which reads as "shuffled"/"unordered" to users.

This PR skips the dependency sort for MySQL and keeps tables in their already-alphabetical listing order. Other database types (e.g. Postgres, which does not disable constraint checking during import) keep the existing dependency-ordering behavior unchanged.

I also investigated the ClickHouse part of the issue (same complaint) but could not reproduce it: ClickHouse has no foreign key support, so `list_foreign_keys_core` already returns an empty list for it and the dependency sort is already a no-op — a live-container test confirms ClickHouse table structure export is already alphabetical. Left ClickHouse untouched; likely the reporter conflated observations from both databases.

The issue's secondary point (MySQL EVENT objects missing from the export/object-type options) is a separate, unrelated gap and is out of scope for this PR.

## Root cause

- `crates/dbx-core/src/db/mysql.rs` `list_tables_sql` already has `ORDER BY TABLE_NAME` — alphabetical, deterministic.
- `crates/dbx-core/src/database_export.rs` (`export_database_sql_core`) then re-sorts via `crate::transfer::sort_tables_by_fk_dependency` regardless of database type, moving FK-bearing tables after the tables they reference.
- For MySQL this reorder has no correctness purpose, since `SET FOREIGN_KEY_CHECKS = 0` is always written for MySQL exports (`database_export.rs`), covering both DDL and DML ordering safety already.

## Fix

`database_export.rs`: gate the dependency-sort block on `db_type != DatabaseType::Mysql`.

## Test plan

- [x] New regression test `crates/dbx-core/tests/live_mysql_export_table_order.rs` against a real disposable MySQL 8.4 container: 6 tables including cross-table foreign keys chosen so FK order and alphabetical order diverge. Reverting the fix makes the test fail with the FK-topological order (`alpha,bravo,mango,zoo,orders,order_items`); with the fix it passes with alphabetical order (`alpha,bravo,mango,order_items,orders,zoo`). Also asserts two consecutive exports of the same unchanged schema produce identical output (already deterministic — the perceived "inconsistent between runs" was really "doesn't match the alphabetical order shown elsewhere").
- [x] `cargo test -p dbx-core --lib database_export::` — 62/62 passed
- [x] `cargo test -p dbx-core --lib transfer::` — 195/195 passed
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` — clean
- [x] Rebased onto latest `upstream/main`, no conflicts
- [ ] Full `cargo test -p dbx-core --lib` — attempted but the run stalled for ~2 hours with near-zero CPU usage in my environment (unrelated to this change, likely a local environment issue); killed and relied on the scoped module tests above instead.

Refs #6229