### PR TITLE
fix(rabbitmq): route queue selection to Messages, not cluster Monitoring

### DIFF
--- a/apps/desktop/src/components/mq/MqAdminConsole.vue
+++ b/apps/desktop/src/components/mq/MqAdminConsole.vue
@@ -18,6 +18,7 @@ import {
   resolveInitialMqTab,
   resolveMqSystemKindFromConnection,
   resolveRabbitMqDefaultVhost,
+  resolveTopicSelectedTab,
   type MqTab,
 } from "@/lib/mq/mqConsoleDefaults";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -285,11 +286,7 @@ function handleNamespaceRolesSelected(namespace: string) {
 function handleTopicSelected(topic: TopicInfo) {
   selectedTopic.value = topic;
   selectedSubscriptionName.value = undefined;
-  if (isRocketMqCluster.value) {
-    activeTab.value = canManageSubscriptions.value ? "subscriptions" : "topics";
-  } else {
-    activeTab.value = isFlatMqCluster.value ? "monitoring" : canManageSubscriptions.value ? "subscriptions" : "monitoring";
-  }
+  activeTab.value = resolveTopicSelectedTab({ systemKind: mqSystemKind.value, capabilities: effectiveCapabilities.value });
 }
 
 function handleNavigateTab(payload: { tab: MqTab; topic?: TopicInfo; subscription?: string; preferDlqTopic?: boolean }) {

--- a/apps/desktop/src/lib/mq/__tests__/mqConsoleDefaults.spec.ts
+++ b/apps/desktop/src/lib/mq/__tests__/mqConsoleDefaults.spec.ts
@@ -11,6 +11,7 @@ import {
   resolveMqSystemKindFromConnection,
   resolveRabbitMqDefaultVhost,
   resolveRabbitMqSendNamespace,
+  resolveTopicSelectedTab,
 } from "@/lib/mq/mqConsoleDefaults";
 
 describe("mqConsoleDefaults", () => {
@@ -192,4 +193,30 @@ describe("mqConsoleDefaults", () => {
     // Nothing to go on in all-vhosts mode: fall back to the connection default vhost.
     expect(resolveRabbitMqSendNamespace(undefined, "*", undefined)).toBeUndefined();
   });
+
+  it("routes RabbitMQ queue selection to Messages, not the cluster-wide Monitoring tab (#5984)", () => {
+    // RabbitMqMonitoringPanel is cluster-wide and ignores the selected topic entirely,
+    // so landing there after clicking a queue drops all context about that queue.
+    expect(resolveTopicSelectedTab({ systemKind: "rabbitmq", capabilities: capabilities("rabbitmq") })).toBe("messages");
+  });
+
+  it("falls back RabbitMQ queue selection to Topics when message sending is unsupported", () => {
+    expect(resolveTopicSelectedTab({ systemKind: "rabbitmq", capabilities: { ...capabilities("rabbitmq"), supportsSendMessage: false } })).toBe("topics");
+  });
+
+  it("still routes Kafka/Pulsar topic selection to the per-topic Monitoring tab", () => {
+    // Unlike RabbitMQ, Kafka/Pulsar's MonitoringPanel is scoped to the selected topic,
+    // so routing there after selection is correct and must stay unchanged.
+    expect(resolveTopicSelectedTab({ systemKind: "kafka", capabilities: capabilities("kafka") })).toBe("monitoring");
+    expect(resolveTopicSelectedTab({ systemKind: undefined, capabilities: capabilities(undefined) })).toBe("subscriptions");
+  });
+
+  it("still routes RocketMQ topic selection to Subscriptions, falling back to Topics", () => {
+    expect(resolveTopicSelectedTab({ systemKind: "rocketmq", capabilities: capabilities("rocketmq") })).toBe("subscriptions");
+    expect(resolveTopicSelectedTab({ systemKind: "rocketmq", capabilities: { ...capabilities("rocketmq"), supportsSubscriptions: false } })).toBe("topics");
+  });
 });
+
+function capabilities(systemKind: Parameters<typeof defaultMqCapabilitiesForSystemKind>[0]) {
+  return defaultMqCapabilitiesForSystemKind(systemKind);
+}

--- a/apps/desktop/src/lib/mq/mqConsoleDefaults.ts
+++ b/apps/desktop/src/lib/mq/mqConsoleDefaults.ts
@@ -204,3 +204,24 @@ export function resolveInitialMqTab(options: { initialTab?: MqTab; initialTenant
   if (options.initialTenant) return "namespaces";
   return "tenants";
 }
+
+/**
+ * Resolve which tab to switch to after the user selects a topic/queue row.
+ *
+ * RabbitMQ's "monitoring" tab (RabbitMqMonitoringPanel) is a cluster-wide
+ * overview with no per-topic scoping, unlike Kafka/Pulsar's monitoring tab
+ * (MonitoringPanel), which does take the selected topic and shows its stats.
+ * Routing RabbitMQ topic selection to "monitoring" therefore drops all
+ * context about the queue just clicked (see #5984). "messages" shows a
+ * message browser scoped to the selected queue instead.
+ */
+export function resolveTopicSelectedTab(options: { systemKind?: MqSystemKind; capabilities: MqCapabilities }): MqTab {
+  const { systemKind, capabilities } = options;
+  if (systemKind === "rocketmq") {
+    return capabilities.supportsSubscriptions ? "subscriptions" : "topics";
+  }
+  if (systemKind === "rabbitmq") {
+    return capabilities.supportsSendMessage ? "messages" : "topics";
+  }
+  return isFlatMqSystemKind(systemKind) ? "monitoring" : capabilities.supportsSubscriptions ? "subscriptions" : "monitoring";
+}


### PR DESCRIPTION
## Problem

Fixes #5984.

In the RabbitMQ admin console's Topics > Queues list, clicking any queue row always navigated to the "Monitoring" tab. For RabbitMQ, that tab is `RabbitMqMonitoringPanel` — a cluster-wide overview (total ready messages, queue/exchange counts, node stats) that takes no `topic` prop at all. So after clicking a queue, the user lands on a screen with zero information about the queue they just picked, even though the breadcrumb still shows the queue name.

This differs from Kafka/Pulsar, where the "Monitoring" tab is genuinely per-topic (`MonitoringPanel` takes the selected topic and renders its stats), so `handleTopicSelected`'s shared "flat MQ → monitoring" branch was correct for those systems but wrong for RabbitMQ's separate, topic-agnostic monitoring panel.

## Solution

Route RabbitMQ queue selection to the "Messages" tab instead, which shows a message browser/sender scoped to the selected queue (`SendMessagePanel` with peek support) — much closer to what RabbitMQ's own management UI shows when you open a queue.

Extracted the tab-routing decision out of the component into a pure `resolveTopicSelectedTab()` (`mqConsoleDefaults.ts`) for direct unit testing; Kafka/Pulsar/RocketMQ routing behavior is unchanged.

## Testing

Reproduced end-to-end against a real RabbitMQ 4.1.0 server (dev backend + dev frontend + real browser via Playwright), with an isolated test vhost containing two queues:

- Before: clicking a queue lands on Monitoring showing cluster-wide totals (unrelated to the clicked queue).
- After: clicking a queue lands on Messages with "Target topic" pre-filled to the clicked queue.

Added regression tests in `mqConsoleDefaults.spec.ts` for `resolveTopicSelectedTab()` covering RabbitMQ (with/without send-message support), and confirming Kafka/Pulsar/RocketMQ routing is unchanged. Verified the new tests fail on the pre-fix code (`git apply -R` the diff) and pass after reapplying.

- `pnpm exec vitest run apps/desktop/src`: 684 files / 6388 tests passed
- `pnpm typecheck`: clean
- `pnpm lint`: clean (no new warnings)
- Rebased onto latest `upstream/main`, no conflicts

## Out of scope

The issue's second point ("put Queues and Exchanges as top-level tabs, remove the Topics tab") is a navigation restructuring suggestion, not a bug, and isn't addressed here.