### PR TITLE
fix(editor): remove hardcoded Mod-d search binding that hijacks user Ctrl+D shortcut

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -103,6 +103,7 @@ import type { SqlHighlighter } from "@/lib/sql/sqlHighlighter";
 import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, loadEditorTheme, editorFontTheme, sqlCompletionTheme, sqlSemanticHighlightTheme } from "@/lib/editor/editorThemes";
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
+import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
 import { appendSqlCompletionSpace } from "@/lib/editor/sqlCompletionInsertion";
 import { compareSqlCompletions, completionLabelPresentation } from "@/lib/editor/sqlCompletionPresentation";
 import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
@@ -4839,7 +4840,7 @@ onMounted(async () => {
       activeLineHighlighter,
       // Vim must be mounted before DBX/default keymaps so normal-mode keys are handled first.
       vimModeComp.of(vimModeExtension(initialSettings.vimModeEnabled)),
-      keymap.of([...defaultKeymap, ...searchKeymap, ...historyKeymap, ...foldKeymap, ...completionKeymap]),
+      keymap.of([...defaultKeymap, ...searchKeymapWithoutModD(searchKeymap), ...historyKeymap, ...foldKeymap, ...completionKeymap]),
       sqlLanguageComp.of(buildSqlLanguageExtension()),
       sqlSemanticHighlightComp.of(buildSqlSemanticHighlightExtension()),
       tooltips({ parent: tooltipParent }),

--- a/apps/desktop/src/components/editor/SqlFormatterSettingsPanel.vue
+++ b/apps/desktop/src/components/editor/SqlFormatterSettingsPanel.vue
@@ -10,6 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/composables/useToast";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { saveTextFile } from "@/lib/export/saveTextFile";
+import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
 import {
   DEFAULT_SQL_FORMATTER_SETTINGS,
   SQL_FORMATTER_CONFIG_FORMATTER,
@@ -361,7 +362,7 @@ function jsonEditorKeymapExtension(modules: CodeMirrorModules) {
   const { keymap } = modules.view;
   const commands = modules.commands;
   const search = modules.search;
-  return keymap.of([...search.searchKeymap, ...commands.historyKeymap, ...commands.defaultKeymap]);
+  return keymap.of([...searchKeymapWithoutModD(search.searchKeymap), ...commands.historyKeymap, ...commands.defaultKeymap]);
 }
 
 async function initJsonEditor() {

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorSearchKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorSearchKeymap.spec.ts
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+import { searchKeymap } from "@codemirror/search";
+import { describe, expect, it } from "vitest";
+import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
+
+describe("searchKeymapWithoutModD", () => {
+  it("drops the built-in Mod-d binding from the search keymap", () => {
+    const filtered = searchKeymapWithoutModD(searchKeymap);
+    expect(filtered.find((binding) => binding.key === "Mod-d")).toBeUndefined();
+  });
+
+  it("keeps the other search bindings intact", () => {
+    const filtered = searchKeymapWithoutModD(searchKeymap);
+    const keys = filtered.map((binding) => binding.key);
+    expect(keys).toContain("Mod-f");
+    expect(keys).toContain("Mod-g");
+    expect(keys).toContain("Mod-Alt-g");
+    expect(keys).toContain("Mod-Shift-l");
+    expect(keys).toContain("F3");
+  });
+
+  it("baseline: the stock searchKeymap consumes Ctrl+D (the bug being fixed)", () => {
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [keymap.of([...searchKeymap])],
+      }),
+    });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "d", ctrlKey: true }), "editor")).toBe(true);
+    view.destroy();
+  });
+
+  it("no longer consumes Ctrl+D, letting the event bubble to the global shortcut handler", () => {
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [keymap.of([...searchKeymapWithoutModD(searchKeymap)])],
+      }),
+    });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "d", ctrlKey: true }), "editor")).toBe(false);
+    view.destroy();
+  });
+});

--- a/apps/desktop/src/lib/editor/codemirrorSearchKeymap.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSearchKeymap.ts
@@ -1,0 +1,17 @@
+import type { KeyBinding } from "@codemirror/view";
+
+/**
+ * `@codemirror/search` 的 `searchKeymap` 内置硬编码了 `Mod-d` = `selectNextOccurrence`
+ * （多光标选择下一个匹配词），与 DBX 的可配置快捷键体系冲突：
+ *
+ * - DBX 中 `Mod+D` 默认绑定「复制行 / 复制当前行」等用户可配置动作（见 shortcutRegistry.ts）；
+ *   一旦用户把 `Mod+D` 配置给其他动作（例如把「新建查询」改为 Ctrl+D），searchKeymap 的
+ *   `Mod-d` 会在编辑器中抢先匹配并 `preventDefault`，事件冒泡到 window 时
+ *   `defaultPrevented=true`，App.vue 的全局 handleKeydown 直接返回，用户配置的快捷键永不触发。
+ *
+ * 这里移除 `Mod-d` 绑定，保证用户可配置的快捷键优先于 CodeMirror 内置硬编码键位
+ * （与 #4544 修复 Mod+F / Mod+H 冲突的思路一致）。
+ */
+export function searchKeymapWithoutModD(searchKeymap: readonly KeyBinding[]): KeyBinding[] {
+  return searchKeymap.filter((binding) => binding.key !== "Mod-d");
+}


### PR DESCRIPTION
Fixes #6351

## 背景

用户把「新建查询」（默认 `Ctrl+T`）与「复制行」（默认 `Ctrl+D`）的快捷键互换后，`Ctrl+T` 正常，但 `Ctrl+D` 在 SQL 编辑器中失效。

## 根因

`@codemirror/search` 的 `searchKeymap` 内置硬编码 `{ key: "Mod-d", run: selectNextOccurrence, preventDefault: true }`。默认配置下 `Mod+D`（复制行）注册在应用的高优先级自定义 keymap（`Prec.high`）中会先命中，问题被掩盖；一旦用户把 `Mod+D` 让出给其他动作，`Ctrl+D` 落入 `searchKeymap` 的 `Mod-d`，执行 `selectNextOccurrence` 并 `preventDefault`，事件冒泡到 window 时 `defaultPrevented=true`，`App.vue` 的全局 `handleKeydown` 直接返回，用户配置的全局快捷键永不触发。

同类问题见 #4544（用户自定义 `Mod+F` 被硬编码搜索绑定覆盖），已在 `267310ced` 修复，但只调整了 `Mod+F`/`Mod+H` 的优先级，`Mod-d` 未处理。

## 改动

- 新增 `apps/desktop/src/lib/editor/codemirrorSearchKeymap.ts`：`searchKeymapWithoutModD()` 过滤 `searchKeymap` 中的 `Mod-d` 绑定
- `QueryEditor.vue`：装配 CodeMirror keymap 时使用过滤后的 searchKeymap
- `SqlFormatterSettingsPanel.vue`：JSON 格式化预览编辑器同样处理

## 验证

- 新增 4 个单测（`codemirrorSearchKeymap.spec.ts`）：Mod-d 被移除、其余绑定保留、基线对比（原始 searchKeymap 会消费 Ctrl+D）
- editor 目录 33 个测试文件 212 个测试全部通过
- `vue-tsc` typecheck 通过
- `oxlint` 无新增告警
- lint-staged（oxfmt）通过

## 说明

`basicSetup`（codemirror 包）同样包含 `searchKeymap`，DdlViewDialog / KvValueEditor 等只读或内嵌编辑器存在同类问题；为控制改动范围，本次未涉及，可在后续 PR 中统一处理。
