### PR TITLE
🐛 fix(grid): show column comments for joined (multi-source) query results

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -335,6 +335,19 @@ interface DataGridProps {
   context?: "results" | "table-data";
   autoTransposeSingleRow?: boolean;
   sourceColumns?: Array<string | undefined>;
+  /**
+   * Column comments merged from every source table of a multi-source query
+   * (e.g. JOIN). Populated even when the result is not editable, so joined
+   * results still show comments. Keyed by physical column name (and its
+   * lower-cased form), same keys as the `tableMeta`-derived map.
+   */
+  resultColumnComments?: Record<string, string>;
+  /**
+   * Display-only result-column -> source-column mapping for multi-source
+   * results that are not editable. Used to resolve column comments precisely;
+   * never used for row identity or editing.
+   */
+  queryDisplaySourceColumns?: Array<string | undefined>;
   initialWhereInput?: string;
   initialOrderByInput?: string;
   sortColumn?: string;
@@ -539,6 +552,11 @@ const columnCommentMap = computed(() => {
       if (!map.has(normalizedName)) map.set(normalizedName, col.comment);
     }
   }
+  if (props.resultColumnComments) {
+    for (const [name, comment] of Object.entries(props.resultColumnComments)) {
+      if (comment && !map.has(name)) map.set(name, comment);
+    }
+  }
   return map;
 });
 const dataGridTopbarWidth = ref(0);
@@ -575,7 +593,9 @@ const readonlyTextCell = ref<{
 } | null>(null);
 
 function resolvedColumnComment(column: string, actualColIdx: number): string | undefined {
-  return dataGridColumnCommentFor(columnCommentMap.value, column, props.sourceColumns?.[actualColIdx]);
+  const displaySource = props.queryDisplaySourceColumns?.[actualColIdx];
+  const sourceName = displaySource ?? props.sourceColumns?.[actualColIdx];
+  return dataGridColumnCommentFor(columnCommentMap.value, column, sourceName);
 }
 
 function headerColumnComment(column: string, actualColIdx: number): string {
@@ -2031,7 +2051,12 @@ const allColumnTypes = computed(() =>
 const visibleColumnTypes = computed(() => visibleColumnIndexes.value.map((index) => allColumnTypes.value[index]));
 const allColumnTypeVisualKinds = computed(() => allColumnTypes.value.map((type) => resolveDataGridTypeVisualKind(type, resolvedDatabaseType.value)));
 const visibleColumnTypeVisualKinds = computed(() => visibleColumnIndexes.value.map((index) => allColumnTypeVisualKinds.value[index] ?? "unknown"));
-const visibleColumnComments = computed(() => visibleColumnIndexes.value.map((index) => dataGridColumnCommentFor(columnCommentMap.value, props.result.columns[index] ?? "", props.sourceColumns?.[index])));
+const visibleColumnComments = computed(() =>
+  visibleColumnIndexes.value.map((index) => {
+    const displaySource = props.queryDisplaySourceColumns?.[index] ?? props.sourceColumns?.[index];
+    return dataGridColumnCommentFor(columnCommentMap.value, props.result.columns[index] ?? "", displaySource);
+  }),
+);
 const visibleColumnCount = computed(() => visibleColumnIndexes.value.length);
 
 const numericColumnRightAlign = computed(() => (settingsStore.editorSettings.numericColumnRightAlign ?? true) && !showTranspose.value);

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -71,7 +71,7 @@ import DataGridTextFilterWorkbench from "@/components/grid/DataGridTextFilterWor
 import TemporalCellEditor from "@/components/grid/TemporalCellEditor.vue";
 import EnumCellEditor from "@/components/grid/EnumCellEditor.vue";
 import DataGridReadonlyTextSelection from "@/components/grid/DataGridReadonlyTextSelection.vue";
-import type { QueryResult, ColumnInfo, DatabaseType, ForeignKeyInfo, IndexInfo, TriggerInfo, TableInfoTab } from "@/types/database";
+import type { QueryResult, ColumnInfo, DatabaseType, ForeignKeyInfo, IndexInfo, TriggerInfo, TableInfoTab, QueryResultSourceColumnRef } from "@/types/database";
 import { isQueryExecutionErrorResult } from "@/lib/query/queryResultError";
 import { tableObjectSourceKind } from "@/lib/table/tableObjectSourceKind";
 import { tableColumnDefaultDisplayValue } from "@/lib/table/tableColumnDefaultPresentation";
@@ -336,18 +336,21 @@ interface DataGridProps {
   autoTransposeSingleRow?: boolean;
   sourceColumns?: Array<string | undefined>;
   /**
-   * Column comments merged from every source table of a multi-source query
-   * (e.g. JOIN). Populated even when the result is not editable, so joined
-   * results still show comments. Keyed by physical column name (and its
-   * lower-cased form), same keys as the `tableMeta`-derived map.
+   * Column comments for a multi-source query result (e.g. JOIN), indexed by
+   * result-column ordinal (projection order). Populated even when the result is
+   * not editable, so joined results still show comments. `undefined` for a
+   * column that cannot be resolved back to exactly one base column (ambiguous
+   * or computed) — the grid shows no comment instead of a wrong one.
    */
-  resultColumnComments?: Record<string, string>;
+  resultColumnComments?: Array<string | undefined>;
   /**
-   * Display-only result-column -> source-column mapping for multi-source
-   * results that are not editable. Used to resolve column comments precisely;
-   * never used for row identity or editing.
+   * Display-only result-column -> source mapping for multi-source results,
+   * indexed by result-column ordinal; each entry carries the source identity
+   * (sourceKey + canonical source column name). Used to resolve column
+   * comments per source instead of first-source-wins; never used for row
+   * identity or editing.
    */
-  queryDisplaySourceColumns?: Array<string | undefined>;
+  queryDisplaySourceColumns?: Array<QueryResultSourceColumnRef | undefined>;
   initialWhereInput?: string;
   initialOrderByInput?: string;
   sortColumn?: string;
@@ -552,11 +555,6 @@ const columnCommentMap = computed(() => {
       if (!map.has(normalizedName)) map.set(normalizedName, col.comment);
     }
   }
-  if (props.resultColumnComments) {
-    for (const [name, comment] of Object.entries(props.resultColumnComments)) {
-      if (comment && !map.has(name)) map.set(name, comment);
-    }
-  }
   return map;
 });
 const dataGridTopbarWidth = ref(0);
@@ -593,9 +591,12 @@ const readonlyTextCell = ref<{
 } | null>(null);
 
 function resolvedColumnComment(column: string, actualColIdx: number): string | undefined {
-  const displaySource = props.queryDisplaySourceColumns?.[actualColIdx];
-  const sourceName = displaySource ?? props.sourceColumns?.[actualColIdx];
-  return dataGridColumnCommentFor(columnCommentMap.value, column, sourceName);
+  // Multi-source results resolve comments per result ordinal; ambiguous or
+  // unresolved columns yield undefined instead of falling back to a
+  // first-source-wins name map.
+  const ordinalComments = props.resultColumnComments;
+  if (ordinalComments) return ordinalComments[actualColIdx];
+  return dataGridColumnCommentFor(columnCommentMap.value, column, props.sourceColumns?.[actualColIdx]);
 }
 
 function headerColumnComment(column: string, actualColIdx: number): string {
@@ -2053,8 +2054,9 @@ const allColumnTypeVisualKinds = computed(() => allColumnTypes.value.map((type) 
 const visibleColumnTypeVisualKinds = computed(() => visibleColumnIndexes.value.map((index) => allColumnTypeVisualKinds.value[index] ?? "unknown"));
 const visibleColumnComments = computed(() =>
   visibleColumnIndexes.value.map((index) => {
-    const displaySource = props.queryDisplaySourceColumns?.[index] ?? props.sourceColumns?.[index];
-    return dataGridColumnCommentFor(columnCommentMap.value, props.result.columns[index] ?? "", displaySource);
+    const ordinalComments = props.resultColumnComments;
+    if (ordinalComments) return ordinalComments[index];
+    return dataGridColumnCommentFor(columnCommentMap.value, props.result.columns[index] ?? "", props.sourceColumns?.[index]);
   }),
 );
 const visibleColumnCount = computed(() => visibleColumnIndexes.value.length);

--- a/apps/desktop/src/components/grid/__tests__/DataGridColumnComments.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridColumnComments.spec.ts
@@ -5,7 +5,9 @@ const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url),
 
 describe("DataGrid column comments", () => {
   it("uses per-ordinal multi-source comments, falling back to source metadata for single-source grids", () => {
-    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?const ordinalComments = props\.resultColumnComments;[\s\S]*?if \(ordinalComments\) return ordinalComments\[actualColIdx\];[\s\S]*?dataGridColumnCommentFor\([\s\S]*?props\.sourceColumns\?\.\[actualColIdx\][\s\S]*?\);\s*\}/);
+    expect(dataGridSource).toMatch(
+      /function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?const ordinalComments = props\.resultColumnComments;[\s\S]*?if \(ordinalComments\) return ordinalComments\[actualColIdx\];[\s\S]*?dataGridColumnCommentFor\([\s\S]*?props\.sourceColumns\?\.\[actualColIdx\][\s\S]*?\);\s*\}/,
+    );
     expect(dataGridSource).toContain(':column-comment="headerColumnComment(col.name, col.actualColIdx)"');
     expect(dataGridSource).toContain(':tooltip-column-comment="resolvedColumnComment(col.name, col.actualColIdx)"');
     expect(dataGridSource).toContain("(column, index) => headerColumnComment(column, index)");

--- a/apps/desktop/src/components/grid/__tests__/DataGridColumnComments.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridColumnComments.spec.ts
@@ -5,9 +5,19 @@ const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url),
 
 describe("DataGrid column comments", () => {
   it("uses source column metadata for both inline and tooltip header comments", () => {
-    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?dataGridColumnCommentFor\([\s\S]*?props\.sourceColumns\?\.\[actualColIdx\][\s\S]*?\);\s*\}/);
+    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?props\.sourceColumns\?\.\[actualColIdx\][\s\S]*?\);/);
     expect(dataGridSource).toContain(':column-comment="headerColumnComment(col.name, col.actualColIdx)"');
     expect(dataGridSource).toContain(':tooltip-column-comment="resolvedColumnComment(col.name, col.actualColIdx)"');
     expect(dataGridSource).toContain("(column, index) => headerColumnComment(column, index)");
+  });
+
+  it("merges multi-source result column comments into the header comment map", () => {
+    expect(dataGridSource).toMatch(/const columnCommentMap = computed\(\(\) => \{[\s\S]*?props\.tableMeta\?\.columns[\s\S]*?props\.resultColumnComments[\s\S]*?return map;\s*\}\);/);
+    expect(dataGridSource).toContain("resultColumnComments?: Record<string, string>");
+  });
+
+  it("prefers the display-only source mapping when resolving multi-source comments", () => {
+    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?props\.queryDisplaySourceColumns\?\.\[actualColIdx\][\s\S]*?dataGridColumnCommentFor\([\s\S]*?\);/);
+    expect(dataGridSource).toContain("queryDisplaySourceColumns?: Array<string | undefined>");
   });
 });

--- a/apps/desktop/src/components/grid/__tests__/DataGridColumnComments.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridColumnComments.spec.ts
@@ -4,20 +4,10 @@ import { describe, expect, it } from "vitest";
 const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
 
 describe("DataGrid column comments", () => {
-  it("uses source column metadata for both inline and tooltip header comments", () => {
-    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?props\.sourceColumns\?\.\[actualColIdx\][\s\S]*?\);/);
+  it("uses per-ordinal multi-source comments, falling back to source metadata for single-source grids", () => {
+    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?const ordinalComments = props\.resultColumnComments;[\s\S]*?if \(ordinalComments\) return ordinalComments\[actualColIdx\];[\s\S]*?dataGridColumnCommentFor\([\s\S]*?props\.sourceColumns\?\.\[actualColIdx\][\s\S]*?\);\s*\}/);
     expect(dataGridSource).toContain(':column-comment="headerColumnComment(col.name, col.actualColIdx)"');
     expect(dataGridSource).toContain(':tooltip-column-comment="resolvedColumnComment(col.name, col.actualColIdx)"');
     expect(dataGridSource).toContain("(column, index) => headerColumnComment(column, index)");
-  });
-
-  it("merges multi-source result column comments into the header comment map", () => {
-    expect(dataGridSource).toMatch(/const columnCommentMap = computed\(\(\) => \{[\s\S]*?props\.tableMeta\?\.columns[\s\S]*?props\.resultColumnComments[\s\S]*?return map;\s*\}\);/);
-    expect(dataGridSource).toContain("resultColumnComments?: Record<string, string>");
-  });
-
-  it("prefers the display-only source mapping when resolving multi-source comments", () => {
-    expect(dataGridSource).toMatch(/function resolvedColumnComment\(column: string, actualColIdx: number\)[\s\S]*?props\.queryDisplaySourceColumns\?\.\[actualColIdx\][\s\S]*?dataGridColumnCommentFor\([\s\S]*?\);/);
-    expect(dataGridSource).toContain("queryDisplaySourceColumns?: Array<string | undefined>");
   });
 });

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1567,6 +1567,8 @@ defineExpose({ focusSearch, refreshData, refreshQueryEditorCompletionCache, hand
                 :loading="activeTab.isExecuting"
                 :editable="!!activeTab.queryAnalysis || !!mongoQueryResultSaveHandler"
                 :source-columns="activeTab.querySourceColumns"
+                :result-column-comments="activeTab.resultColumnComments"
+                :query-display-source-columns="activeTab.queryDisplaySourceColumns"
                 :custom-save-handler="mongoQueryResultSaveHandler"
                 :mongo-update-target="mongoQueryResultSaveHandler && activeTab.result.mongo_copy_documents?.length === activeTab.result.rows.length ? activeTab.mongoEditTarget : undefined"
                 :query-editability-reason="activeTab.queryEditabilityReason"

--- a/apps/desktop/src/lib/__tests__/sql/multiSourceColumnMapping.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/multiSourceColumnMapping.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { analyzeEditableQueryEditability, sourceColumnsForResult } from "@/lib/sql/sqlAnalysis";
+import { analyzeEditableQueryEditability, resolveSourceColumnsByOrdinal } from "@/lib/sql/sqlAnalysis";
 
 /**
- * A joined result is editable-only when exactly one source provides row
- * identity; the display mapping must still resolve every result column back to
- * its physical source column so the data grid can show column comments.
+ * Result columns resolve by projection ordinal, each carrying its source
+ * identity (sourceKey + canonical source column), so joined results keep
+ * per-source comments instead of first-source-wins on name clashes.
  */
 describe("multi-source result column mapping", () => {
   it("parses a JOIN as multi-source with per-source columns", () => {
@@ -18,33 +18,163 @@ describe("multi-source result column mapping", () => {
     expect(result.analysis.columns.map((column) => column.sourceKey)).toEqual(["a:0", "a:0", "b:1"]);
   });
 
-  it("maps each JOIN result column to its source column per source", () => {
+  it("maps each JOIN result column back to (source, column) by ordinal", () => {
     const result = analyzeEditableQueryEditability("SELECT a.id, a.user_id, b.name FROM orders a JOIN users b ON a.user_id = b.id");
     expect(result.editable).toBe(true);
     if (!result.editable) return;
 
-    const analysis = result.analysis;
-    const sources = analysis.sources!;
-    const resultColumns = ["id", "user_id", "name"];
-
-    const ordersMapping = sourceColumnsForResult(analysis, resultColumns, sources[0]!.key);
-    const usersMapping = sourceColumnsForResult(analysis, resultColumns, sources[1]!.key);
-    expect(ordersMapping).toEqual(["id", "user_id", undefined]);
-    expect(usersMapping).toEqual([undefined, undefined, "name"]);
-
-    // Merging per-source mappings yields the complete display mapping.
-    const merged = resultColumns.map((_, index) => [ordersMapping![index], usersMapping![index]].find((value) => value !== undefined));
-    expect(merged).toEqual(["id", "user_id", "name"]);
+    const resolved = resolveSourceColumnsByOrdinal(
+      "mysql",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }, { name: "amount" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "name" }] },
+      ],
+      3,
+    );
+    expect(resolved).toEqual([
+      { sourceKey: "a:0", sourceColumn: "id" },
+      { sourceKey: "a:0", sourceColumn: "user_id" },
+      { sourceKey: "b:1", sourceColumn: "name" },
+    ]);
   });
 
-  it("keeps duplicate result column names mapped in projection order", () => {
+  it("keeps duplicate result column names resolved per source (both tables have id)", () => {
     const result = analyzeEditableQueryEditability("SELECT a.id, b.id FROM orders a JOIN users b ON a.user_id = b.id");
     expect(result.editable).toBe(true);
     if (!result.editable) return;
 
-    const analysis = result.analysis;
-    const sources = analysis.sources!;
-    const merged = (["id", "id"] as string[]).map((_, index) => [sources[0]!.key, sources[1]!.key].map((key) => sourceColumnsForResult(analysis, ["id", "id"], key)?.[index]).find((value) => value !== undefined));
-    expect(merged).toEqual(["id", "id"]);
+    const resolved = resolveSourceColumnsByOrdinal(
+      "mysql",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "name" }] },
+      ],
+      2,
+    );
+    // Result column #0 is orders.id, #1 is users.id — no first-source-wins.
+    expect(resolved).toEqual([
+      { sourceKey: "a:0", sourceColumn: "id" },
+      { sourceKey: "b:1", sourceColumn: "id" },
+    ]);
+  });
+
+  it("resolves a uniquely qualified unqualified alias (name AS username) back to its physical column", () => {
+    const result = analyzeEditableQueryEditability("SELECT name AS username FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const resolved = resolveSourceColumnsByOrdinal(
+      "mysql",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }, { name: "amount" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "name" }] },
+      ],
+      1,
+    );
+    expect(resolved).toEqual([{ sourceKey: "b:1", sourceColumn: "name" }]);
+  });
+
+  it("returns undefined for an ambiguous unqualified column shared by several sources", () => {
+    const result = analyzeEditableQueryEditability("SELECT id FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const resolved = resolveSourceColumnsByOrdinal(
+      "mysql",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "name" }] },
+      ],
+      1,
+    );
+    expect(resolved).toEqual([undefined]);
+  });
+
+  it("resolves quoted mixed-case identifiers exactly (case preserved)", () => {
+    const result = analyzeEditableQueryEditability('SELECT a."ID", b."Name" FROM orders a JOIN users b ON a.user_id = b.id');
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const resolved = resolveSourceColumnsByOrdinal(
+      "postgres",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "ID" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "Name" }] },
+      ],
+      2,
+    );
+    expect(resolved).toEqual([
+      { sourceKey: "a:0", sourceColumn: "ID" },
+      { sourceKey: "b:1", sourceColumn: "Name" },
+    ]);
+  });
+
+  it("does not collapse an unquoted lower-case name onto a distinct quoted mixed-case column", () => {
+    const result = analyzeEditableQueryEditability("SELECT a.id, b.\"ID\" FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const resolved = resolveSourceColumnsByOrdinal(
+      "postgres",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "ID" }, { name: "name" }] },
+      ],
+      2,
+    );
+    // a.id folds to postgres `id`; b."ID" matches the quoted column exactly.
+    expect(resolved).toEqual([
+      { sourceKey: "a:0", sourceColumn: "id" },
+      { sourceKey: "b:1", sourceColumn: "ID" },
+    ]);
+  });
+
+  it("expands a qualified star projection in projection order", () => {
+    const result = analyzeEditableQueryEditability("SELECT a.*, b.name FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const resolved = resolveSourceColumnsByOrdinal(
+      "mysql",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }, { name: "amount" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "name" }] },
+      ],
+      4,
+    );
+    expect(resolved).toEqual([
+      { sourceKey: "a:0", sourceColumn: "id" },
+      { sourceKey: "a:0", sourceColumn: "user_id" },
+      { sourceKey: "a:0", sourceColumn: "amount" },
+      { sourceKey: "b:1", sourceColumn: "name" },
+    ]);
+  });
+
+  it("returns undefined for computed columns and extra result columns", () => {
+    const result = analyzeEditableQueryEditability("SELECT a.id, a.amount + b.id AS total, b.name FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const resolved = resolveSourceColumnsByOrdinal(
+      "mysql",
+      result.analysis,
+      [
+        { source: result.analysis.sources![0]!, columns: [{ name: "id" }, { name: "user_id" }, { name: "amount" }] },
+        { source: result.analysis.sources![1]!, columns: [{ name: "id" }, { name: "name" }] },
+      ],
+      3,
+    );
+    expect(resolved).toEqual([
+      { sourceKey: "a:0", sourceColumn: "id" },
+      undefined,
+      { sourceKey: "b:1", sourceColumn: "name" },
+    ]);
   });
 });

--- a/apps/desktop/src/lib/__tests__/sql/multiSourceColumnMapping.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/multiSourceColumnMapping.spec.ts
@@ -115,7 +115,7 @@ describe("multi-source result column mapping", () => {
   });
 
   it("does not collapse an unquoted lower-case name onto a distinct quoted mixed-case column", () => {
-    const result = analyzeEditableQueryEditability("SELECT a.id, b.\"ID\" FROM orders a JOIN users b ON a.user_id = b.id");
+    const result = analyzeEditableQueryEditability('SELECT a.id, b."ID" FROM orders a JOIN users b ON a.user_id = b.id');
     expect(result.editable).toBe(true);
     if (!result.editable) return;
 
@@ -171,10 +171,6 @@ describe("multi-source result column mapping", () => {
       ],
       3,
     );
-    expect(resolved).toEqual([
-      { sourceKey: "a:0", sourceColumn: "id" },
-      undefined,
-      { sourceKey: "b:1", sourceColumn: "name" },
-    ]);
+    expect(resolved).toEqual([{ sourceKey: "a:0", sourceColumn: "id" }, undefined, { sourceKey: "b:1", sourceColumn: "name" }]);
   });
 });

--- a/apps/desktop/src/lib/__tests__/sql/multiSourceColumnMapping.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/multiSourceColumnMapping.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { analyzeEditableQueryEditability, sourceColumnsForResult } from "@/lib/sql/sqlAnalysis";
+
+/**
+ * A joined result is editable-only when exactly one source provides row
+ * identity; the display mapping must still resolve every result column back to
+ * its physical source column so the data grid can show column comments.
+ */
+describe("multi-source result column mapping", () => {
+  it("parses a JOIN as multi-source with per-source columns", () => {
+    const result = analyzeEditableQueryEditability("SELECT a.id, a.user_id, b.name FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const sources = result.analysis.sources!;
+    expect(sources.map((source) => source.tableName)).toEqual(["orders", "users"]);
+    expect(result.analysis.columns.map((column) => column.resultName)).toEqual(["id", "user_id", "name"]);
+    expect(result.analysis.columns.map((column) => column.sourceKey)).toEqual(["a:0", "a:0", "b:1"]);
+  });
+
+  it("maps each JOIN result column to its source column per source", () => {
+    const result = analyzeEditableQueryEditability("SELECT a.id, a.user_id, b.name FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const analysis = result.analysis;
+    const sources = analysis.sources!;
+    const resultColumns = ["id", "user_id", "name"];
+
+    const ordersMapping = sourceColumnsForResult(analysis, resultColumns, sources[0]!.key);
+    const usersMapping = sourceColumnsForResult(analysis, resultColumns, sources[1]!.key);
+    expect(ordersMapping).toEqual(["id", "user_id", undefined]);
+    expect(usersMapping).toEqual([undefined, undefined, "name"]);
+
+    // Merging per-source mappings yields the complete display mapping.
+    const merged = resultColumns.map((_, index) => [ordersMapping![index], usersMapping![index]].find((value) => value !== undefined));
+    expect(merged).toEqual(["id", "user_id", "name"]);
+  });
+
+  it("keeps duplicate result column names mapped in projection order", () => {
+    const result = analyzeEditableQueryEditability("SELECT a.id, b.id FROM orders a JOIN users b ON a.user_id = b.id");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const analysis = result.analysis;
+    const sources = analysis.sources!;
+    const merged = (["id", "id"] as string[]).map((_, index) => [sources[0]!.key, sources[1]!.key].map((key) => sourceColumnsForResult(analysis, ["id", "id"], key)?.[index]).find((value) => value !== undefined));
+    expect(merged).toEqual(["id", "id"]);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/tabs/tabResultCache.spec.ts
+++ b/apps/desktop/src/lib/__tests__/tabs/tabResultCache.spec.ts
@@ -193,6 +193,60 @@ describe("tab result cache statement execution metadata", () => {
     expect(restored?.querySourceColumns).toEqual(["id", "name"]);
   });
 
+  it("restores multi-source column comments and their source identity from the snapshot", () => {
+    const snapshot = {
+      result: {
+        columns: ["id", "user_id", "id_1", "name"],
+        rows: [[1, 100, 7, "Alice"]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+      resultRuns: [
+        {
+          id: "run-join",
+          title: "Run 1",
+          sequence: 1,
+          sql: "SELECT a.id, a.user_id, b.id, b.name FROM orders a JOIN users b ON a.user_id = b.id",
+          createdAt: 1,
+          result: {
+            columns: ["id", "user_id", "id_1", "name"],
+            rows: [[1, 100, 7, "Alice"]],
+            affected_rows: 0,
+            execution_time_ms: 1,
+          },
+          resultColumnComments: ["订单ID", "下单用户", "用户ID", "用户名"],
+          queryDisplaySourceColumns: [
+            { sourceKey: "a", sourceColumn: "id" },
+            { sourceKey: "a", sourceColumn: "user_id" },
+            { sourceKey: "b", sourceColumn: "id" },
+            { sourceKey: "b", sourceColumn: "name" },
+          ],
+        },
+      ],
+      activeResultRunId: "run-join",
+      resultColumnComments: ["订单ID", "下单用户", "用户ID", "用户名"],
+      queryDisplaySourceColumns: [
+        { sourceKey: "a", sourceColumn: "id" },
+        { sourceKey: "a", sourceColumn: "user_id" },
+        { sourceKey: "b", sourceColumn: "id" },
+        { sourceKey: "b", sourceColumn: "name" },
+      ],
+      cachedAt: 1,
+    };
+
+    const restored = decodeTabResultSnapshot(encodeTabResultSnapshot(snapshot));
+
+    expect(restored?.resultColumnComments).toEqual(["订单ID", "下单用户", "用户ID", "用户名"]);
+    expect(restored?.queryDisplaySourceColumns).toEqual([
+      { sourceKey: "a", sourceColumn: "id" },
+      { sourceKey: "a", sourceColumn: "user_id" },
+      { sourceKey: "b", sourceColumn: "id" },
+      { sourceKey: "b", sourceColumn: "name" },
+    ]);
+    expect(restored?.resultRuns?.[0]?.resultColumnComments).toEqual(["订单ID", "下单用户", "用户ID", "用户名"]);
+    expect(restored?.resultRuns?.[0]?.queryDisplaySourceColumns?.[2]).toEqual({ sourceKey: "b", sourceColumn: "id" });
+  });
+
   it("treats corrupt and unsupported snapshots as missing", () => {
     expect(decodeTabResultSnapshot(new Uint8Array([0xff, 0x00]))).toBeUndefined();
     const encoded = encodeTabResultSnapshot(queryResultLifecycleSnapshot());

--- a/apps/desktop/src/lib/sql/sqlAnalysis.ts
+++ b/apps/desktop/src/lib/sql/sqlAnalysis.ts
@@ -98,10 +98,7 @@ export interface ResolvedSourceColumnRef {
  * `undefined` (unresolvable). Whole-table `SELECT *` is expanded against the
  * single source table when present.
  */
-function expandProjectionColumnsForSources(
-  analysis: EditableQueryInfo,
-  tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>,
-): Array<EditableQueryColumn | undefined> {
+function expandProjectionColumnsForSources(analysis: EditableQueryInfo, tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>): Array<EditableQueryColumn | undefined> {
   if (analysis.selectStar || analysis.columns.length === 0) {
     return tableSources.flatMap(({ source, columns }) =>
       columns.map((column) => ({
@@ -138,11 +135,7 @@ function expandProjectionColumnsForSources(
   return expanded;
 }
 
-function resolveProjectionColumnToSource(
-  databaseType: string,
-  column: EditableQueryColumn | undefined,
-  tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>,
-): ResolvedSourceColumnRef | undefined {
+function resolveProjectionColumnToSource(databaseType: string, column: EditableQueryColumn | undefined, tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>): ResolvedSourceColumnRef | undefined {
   if (!column || column.star || !column.sourceName) return undefined;
   // A qualified reference whose qualifier could not be bound to a unique source
   // stays unresolved rather than guessing from the bare column name.
@@ -151,7 +144,12 @@ function resolveProjectionColumnToSource(
   if (column.sourceKey) {
     const tableIndex = tableSources.findIndex((entry) => entry.source.key === column.sourceKey);
     if (tableIndex < 0) return undefined;
-    const canonicalName = resolveMetadataColumnName(databaseType, column.sourceName, column.sourceNameQuoted, tableSources[tableIndex]!.columns.map((entry) => entry.name));
+    const canonicalName = resolveMetadataColumnName(
+      databaseType,
+      column.sourceName,
+      column.sourceNameQuoted,
+      tableSources[tableIndex]!.columns.map((entry) => entry.name),
+    );
     return canonicalName ? { sourceKey: column.sourceKey, sourceColumn: canonicalName } : undefined;
   }
 
@@ -160,7 +158,12 @@ function resolveProjectionColumnToSource(
   // first-source-wins.
   const matches: ResolvedSourceColumnRef[] = [];
   for (const tableSource of tableSources) {
-    const canonicalName = resolveMetadataColumnName(databaseType, column.sourceName, column.sourceNameQuoted, tableSource.columns.map((entry) => entry.name));
+    const canonicalName = resolveMetadataColumnName(
+      databaseType,
+      column.sourceName,
+      column.sourceNameQuoted,
+      tableSource.columns.map((entry) => entry.name),
+    );
     if (canonicalName) matches.push({ sourceKey: tableSource.source.key, sourceColumn: canonicalName });
   }
   return matches.length === 1 ? matches[0] : undefined;
@@ -182,12 +185,7 @@ function resolveProjectionColumnToSource(
  * columns, or a star whose source table is unknown. Consumers must show no
  * comment for such columns rather than guessing.
  */
-export function resolveSourceColumnsByOrdinal(
-  databaseType: string,
-  analysis: EditableQueryInfo,
-  tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>,
-  columnCount: number,
-): Array<ResolvedSourceColumnRef | undefined> {
+export function resolveSourceColumnsByOrdinal(databaseType: string, analysis: EditableQueryInfo, tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>, columnCount: number): Array<ResolvedSourceColumnRef | undefined> {
   const expanded = expandProjectionColumnsForSources(analysis, tableSources);
   const resolved: Array<ResolvedSourceColumnRef | undefined> = [];
   for (let index = 0; index < columnCount; index++) {

--- a/apps/desktop/src/lib/sql/sqlAnalysis.ts
+++ b/apps/desktop/src/lib/sql/sqlAnalysis.ts
@@ -86,6 +86,116 @@ export function resolveMetadataColumnName(databaseType: string, sourceName: stri
   return caseOnlyMatches.length === 1 ? caseOnlyMatches[0] : undefined;
 }
 
+export interface ResolvedSourceColumnRef {
+  sourceKey: string;
+  sourceColumn: string;
+}
+
+/**
+ * Expand `*` / `alias.*` projections against each source table's columns so the
+ * returned stream aligns 1:1 with the executed result columns (projection
+ * order). A star whose source table is not among `tableSources` collapses to
+ * `undefined` (unresolvable). Whole-table `SELECT *` is expanded against the
+ * single source table when present.
+ */
+function expandProjectionColumnsForSources(
+  analysis: EditableQueryInfo,
+  tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>,
+): Array<EditableQueryColumn | undefined> {
+  if (analysis.selectStar || analysis.columns.length === 0) {
+    return tableSources.flatMap(({ source, columns }) =>
+      columns.map((column) => ({
+        sourceName: column.name,
+        sourceNameQuoted: false,
+        sourceKey: source.key,
+        resultName: column.name,
+        expression: column.name,
+      })),
+    );
+  }
+  const expanded: Array<EditableQueryColumn | undefined> = [];
+  for (const column of analysis.columns) {
+    if (!column.star) {
+      expanded.push(column);
+      continue;
+    }
+    const tableSource = tableSources.find((entry) => entry.source.key === column.sourceKey);
+    if (!tableSource) {
+      expanded.push(undefined);
+      continue;
+    }
+    for (const tableColumn of tableSource.columns) {
+      expanded.push({
+        ...column,
+        star: false,
+        sourceName: tableColumn.name,
+        sourceNameQuoted: false,
+        resultName: tableColumn.name,
+        expression: column.sourceQualifier ? `${column.sourceQualifier}.${tableColumn.name}` : tableColumn.name,
+      });
+    }
+  }
+  return expanded;
+}
+
+function resolveProjectionColumnToSource(
+  databaseType: string,
+  column: EditableQueryColumn | undefined,
+  tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>,
+): ResolvedSourceColumnRef | undefined {
+  if (!column || column.star || !column.sourceName) return undefined;
+  // A qualified reference whose qualifier could not be bound to a unique source
+  // stays unresolved rather than guessing from the bare column name.
+  if (column.sourceQualifier && !column.sourceKey) return undefined;
+
+  if (column.sourceKey) {
+    const tableIndex = tableSources.findIndex((entry) => entry.source.key === column.sourceKey);
+    if (tableIndex < 0) return undefined;
+    const canonicalName = resolveMetadataColumnName(databaseType, column.sourceName, column.sourceNameQuoted, tableSources[tableIndex]!.columns.map((entry) => entry.name));
+    return canonicalName ? { sourceKey: column.sourceKey, sourceColumn: canonicalName } : undefined;
+  }
+
+  // Unqualified reference: bind only when exactly one source resolves it, so an
+  // ambiguous name shared by several tables yields undefined instead of
+  // first-source-wins.
+  const matches: ResolvedSourceColumnRef[] = [];
+  for (const tableSource of tableSources) {
+    const canonicalName = resolveMetadataColumnName(databaseType, column.sourceName, column.sourceNameQuoted, tableSource.columns.map((entry) => entry.name));
+    if (canonicalName) matches.push({ sourceKey: tableSource.source.key, sourceColumn: canonicalName });
+  }
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * Resolve each result column — in projection (ordinal) order — back to exactly
+ * one base-table column across the query sources, using the same
+ * database-aware identifier canonicalization as the editability binder
+ * (`resolveMetadataColumnName`): quoted identifiers match metadata exactly
+ * (case preserved), unquoted identifiers fold per the database's rules
+ * (PostgreSQL-compatible lower, Oracle-compatible upper, others
+ * case-insensitive when unambiguous).
+ *
+ * Star projections are expanded against the source table columns so the
+ * returned array aligns 1:1 with the executed result columns. An entry is
+ * `undefined` when the result column cannot be resolved to a single source
+ * column: ambiguous unqualified references, computed expressions, unknown
+ * columns, or a star whose source table is unknown. Consumers must show no
+ * comment for such columns rather than guessing.
+ */
+export function resolveSourceColumnsByOrdinal(
+  databaseType: string,
+  analysis: EditableQueryInfo,
+  tableSources: Array<{ source: EditableQuerySource; columns: readonly { name: string }[] }>,
+  columnCount: number,
+): Array<ResolvedSourceColumnRef | undefined> {
+  const expanded = expandProjectionColumnsForSources(analysis, tableSources);
+  const resolved: Array<ResolvedSourceColumnRef | undefined> = [];
+  for (let index = 0; index < columnCount; index++) {
+    resolved.push(resolveProjectionColumnToSource(databaseType, expanded[index], tableSources));
+  }
+  return resolved;
+}
+
 export type QueryEditabilityReason = "not-select" | "cte" | "set-operation" | "aggregation" | "external-source" | "complex-source" | "computed-columns" | "no-table" | "no-primary-key" | "primary-key-not-returned" | "aliased-columns" | "metadata-unavailable";
 
 export type QueryEditability = { editable: true; analysis: EditableQueryInfo } | { editable: false; reason: QueryEditabilityReason };

--- a/apps/desktop/src/lib/tabs/tabResultCache.ts
+++ b/apps/desktop/src/lib/tabs/tabResultCache.ts
@@ -34,6 +34,8 @@ export interface TabResultSnapshot {
   activeResultRunId?: string;
   queryAnalysis?: QueryTab["queryAnalysis"];
   querySourceColumns?: QueryTab["querySourceColumns"];
+  resultColumnComments?: QueryTab["resultColumnComments"];
+  queryDisplaySourceColumns?: QueryTab["queryDisplaySourceColumns"];
   queryEditabilityReason?: QueryTab["queryEditabilityReason"];
   mongoEditTarget?: QueryTab["mongoEditTarget"];
   tableMeta?: QueryTab["tableMeta"];
@@ -318,7 +320,11 @@ async function deleteIndexedDbCacheOwner(ownerId: string): Promise<void> {
 function clonePlain<T>(value: T): T {
   const raw = toRaw(value);
   if (typeof structuredClone === "function") return structuredClone(raw);
-  return JSON.parse(JSON.stringify(raw)) as T;
+  try {
+    return JSON.parse(JSON.stringify(raw)) as T;
+  } catch {
+    return raw;
+  }
 }
 
 function stripSessionIds(result: QueryResult | undefined): QueryResult | undefined {
@@ -727,6 +733,8 @@ export function buildTabResultSnapshot(tab: QueryTab): TabResultSnapshot | undef
     activeResultRunId: tab.activeResultRunId,
     queryAnalysis: tab.queryAnalysis ? clonePlain(tab.queryAnalysis) : undefined,
     querySourceColumns: tab.querySourceColumns ? [...tab.querySourceColumns] : undefined,
+    resultColumnComments: tab.resultColumnComments ? clonePlain(tab.resultColumnComments) : undefined,
+    queryDisplaySourceColumns: tab.queryDisplaySourceColumns ? [...tab.queryDisplaySourceColumns] : undefined,
     queryEditabilityReason: tab.queryEditabilityReason,
     mongoEditTarget: tab.mongoEditTarget ? clonePlain(tab.mongoEditTarget) : undefined,
     tableMeta: tab.tableMeta ? clonePlain(tab.tableMeta) : undefined,

--- a/apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts
@@ -1,0 +1,183 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeMulti = vi.fn();
+const executeQuery = vi.fn();
+const analyzeEditableQueryEditability = vi.fn();
+const getColumns = vi.fn();
+const listIndexes = vi.fn();
+const listObjects = vi.fn();
+const getConnectionConfig = vi.fn();
+const lookupLocalCompletionTables = vi.fn();
+const buildSortedQuerySql = vi.fn();
+const buildDataGridCountSql = vi.fn();
+const prepareQueryPaginationExecutionPlan = vi.fn(async (options) => ({
+  sqlToExecute: options.sql,
+  pageSql: undefined,
+  pageLimit: undefined,
+  pageOffset: undefined,
+  countSql: undefined,
+  useAgentResultSession: false,
+}));
+const editorSettings = {
+  pageSize: 100,
+  autoCalculateTotalRows: false,
+};
+
+vi.mock("@/lib/backend/api", () => ({
+  analyzeEditableQueryEditability,
+  buildDataGridCountSql,
+  buildSortedQuerySql,
+  closeClientConnectionSession: vi.fn().mockResolvedValue(undefined),
+  closeQuerySession: vi.fn().mockResolvedValue(undefined),
+  executeMulti,
+  executeQuery,
+  getColumns,
+  listIndexes,
+  listObjects,
+  prepareQueryPaginationExecutionPlan,
+  saveOpenTabsState: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => ({
+    ensureConnected: vi.fn().mockResolvedValue(undefined),
+    getConfig: getConnectionConfig,
+    lookupLocalCompletionTables,
+    recordConnectionLostError: vi.fn(),
+  }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings,
+  }),
+}));
+
+function column(name: string, comment: string | null, isPrimaryKey = false) {
+  return { name, data_type: "varchar", is_nullable: true, column_default: null, is_primary_key: isPrimaryKey, extra: null, comment };
+}
+
+const ordersColumns = [column("id", "订单ID", true), column("user_id", "下单用户"), column("amount", "订单金额")];
+const usersColumns = [column("id", "用户ID", true), column("name", "用户名")];
+
+/** SELECT a.id, a.user_id, b.id, b.name FROM orders a JOIN users b ON a.user_id = b.id */
+const joinAnalysis = {
+  editable: true,
+  analysis: {
+    schema: undefined,
+    tableName: "orders",
+    tableAlias: "a",
+    selectStar: false,
+    columns: [
+      { sourceName: "id", sourceKey: "a", resultName: "id", expression: "a.id" },
+      { sourceName: "user_id", sourceKey: "a", resultName: "user_id", expression: "a.user_id" },
+      { sourceName: "id", sourceKey: "b", resultName: "id_1", expression: "b.id" },
+      { sourceName: "name", sourceKey: "b", resultName: "name", expression: "b.name" },
+    ],
+    sources: [
+      { key: "a", tableName: "orders", alias: "a" },
+      { key: "b", tableName: "users", alias: "b" },
+    ],
+    multiSource: true,
+    allowInsertDelete: false,
+  },
+};
+
+describe("queryStore multi-source result column comments", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { clearTableMetadataCache } = await import("@/lib/metadata/tableMetadataCache");
+    clearTableMetadataCache();
+    setActivePinia(createPinia());
+    getConnectionConfig.mockReturnValue({ id: "mysql-1", name: "MySQL", db_type: "mysql", database: "app", query_timeout_secs: 30 });
+    getColumns.mockImplementation(async (_connectionId: string, _database: string, _schema: string, table: string) => (table === "orders" ? ordersColumns : usersColumns));
+    listIndexes.mockResolvedValue([]);
+    listObjects.mockResolvedValue([]);
+    lookupLocalCompletionTables.mockReturnValue([]);
+    analyzeEditableQueryEditability.mockResolvedValue(joinAnalysis);
+    buildSortedQuerySql.mockResolvedValue({ ok: true, sql: `${"SELECT *"} ORDER BY 1` });
+    buildDataGridCountSql.mockResolvedValue("SELECT COUNT(*) FROM `orders`");
+    executeQuery.mockResolvedValue({
+      columns: ["row_count"],
+      rows: [[0]],
+      affected_rows: 0,
+      execution_time_ms: 1,
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id", "user_id", "id_1", "name"],
+        rows: [[1, 100, 7, "Alice"]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    expect(listObjects).not.toHaveBeenCalled();
+  });
+
+  it("merges column comments from every JOIN source table onto the non-editable result", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "SELECT a.id, a.user_id, b.id, b.name FROM orders a JOIN users b ON a.user_id = b.id");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.resultColumnComments).toBeDefined());
+
+    // Multi-source results stay non-editable: no single tableMeta.
+    expect(tab.tableMeta).toBeUndefined();
+    expect(tab.queryEditabilityReason).toBe("complex-source");
+    expect(tab.querySourceColumns).toBeUndefined();
+
+    // Comments from both sources are merged; the first source wins on name clashes.
+    expect(tab.resultColumnComments).toEqual({
+      id: "订单ID",
+      user_id: "下单用户",
+      amount: "订单金额",
+      name: "用户名",
+    });
+
+    // Display-only mapping resolves each result column back to its source column.
+    expect(tab.queryDisplaySourceColumns).toEqual(["id", "user_id", "id", "name"]);
+  });
+
+  it("keeps single-source results free of multi-source comment fields", async () => {
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "orders",
+        selectStar: false,
+        columns: [
+          { sourceName: "id", sourceKey: "orders:0", resultName: "id", expression: "id" },
+          { sourceName: "amount", sourceKey: "orders:0", resultName: "amount", expression: "amount" },
+        ],
+      },
+    });
+    getColumns.mockResolvedValue(ordersColumns);
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id", "amount"],
+        rows: [[1, 9.99]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "SELECT id, amount FROM orders");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.tableMeta?.tableName).toBe("orders"));
+    expect(tab.resultColumnComments).toBeUndefined();
+    expect(tab.queryDisplaySourceColumns).toBeUndefined();
+    expect(tab.querySourceColumns).toEqual(["id", "amount"]);
+  });
+});

--- a/apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts
@@ -118,7 +118,7 @@ describe("queryStore multi-source result column comments", () => {
     expect(listObjects).not.toHaveBeenCalled();
   });
 
-  it("merges column comments from every JOIN source table onto the non-editable result", async () => {
+  it("stores per-ordinal comments and source identity for every JOIN source column", async () => {
     const { useQueryStore } = await import("@/stores/queryStore");
     const store = useQueryStore();
     const tabId = store.createTab("mysql-1", "app", "Query");
@@ -133,16 +133,202 @@ describe("queryStore multi-source result column comments", () => {
     expect(tab.queryEditabilityReason).toBe("complex-source");
     expect(tab.querySourceColumns).toBeUndefined();
 
-    // Comments from both sources are merged; the first source wins on name clashes.
-    expect(tab.resultColumnComments).toEqual({
-      id: "订单ID",
-      user_id: "下单用户",
-      amount: "订单金额",
-      name: "用户名",
-    });
+    // Comments are indexed by result ordinal, so the second `id` (users.id)
+    // keeps its own comment instead of first-source-wins on the name.
+    expect(tab.resultColumnComments).toEqual(["订单ID", "下单用户", "用户ID", "用户名"]);
 
-    // Display-only mapping resolves each result column back to its source column.
-    expect(tab.queryDisplaySourceColumns).toEqual(["id", "user_id", "id", "name"]);
+    // The display mapping carries source identity per ordinal.
+    expect(tab.queryDisplaySourceColumns).toEqual([
+      { sourceKey: "a", sourceColumn: "id" },
+      { sourceKey: "a", sourceColumn: "user_id" },
+      { sourceKey: "b", sourceColumn: "id" },
+      { sourceKey: "b", sourceColumn: "name" },
+    ]);
+  });
+
+  it("resolves a uniquely qualified unqualified alias back to its physical column", async () => {
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "orders",
+        tableAlias: "a",
+        selectStar: false,
+        columns: [
+          { sourceName: "id", sourceKey: "a", resultName: "id", expression: "a.id" },
+          { sourceName: "name", sourceKey: undefined, resultName: "username", expression: "name" },
+        ],
+        sources: [
+          { key: "a", tableName: "orders", alias: "a" },
+          { key: "b", tableName: "users", alias: "b" },
+        ],
+        multiSource: true,
+        allowInsertDelete: false,
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id", "username"],
+        rows: [[1, "Alice"]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    // `name` exists only in users across the joined sources, so the unqualified
+    // alias resolves back to users.name despite the binder never seeing a key.
+    await store.executeTabSql(tabId, "SELECT a.id, name AS username FROM orders a JOIN users b ON a.user_id = b.id");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.resultColumnComments).toBeDefined());
+    expect(tab.resultColumnComments).toEqual(["订单ID", "用户名"]);
+    expect(tab.queryDisplaySourceColumns).toEqual([
+      { sourceKey: "a", sourceColumn: "id" },
+      { sourceKey: "b", sourceColumn: "name" },
+    ]);
+  });
+
+  it("returns no comment for an ambiguous unqualified column shared by several sources", async () => {
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "orders",
+        tableAlias: "a",
+        selectStar: false,
+        columns: [{ sourceName: "id", sourceKey: undefined, resultName: "id", expression: "id" }],
+        sources: [
+          { key: "a", tableName: "orders", alias: "a" },
+          { key: "b", tableName: "users", alias: "b" },
+        ],
+        multiSource: true,
+        allowInsertDelete: false,
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id"],
+        rows: [[1]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    // Both orders and users expose `id`; the unqualified reference is
+    // ambiguous, so the result column must not claim either table's comment.
+    await store.executeTabSql(tabId, "SELECT id FROM orders a JOIN users b ON a.user_id = b.id");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.resultColumnComments).toBeDefined());
+    expect(tab.resultColumnComments).toEqual([undefined]);
+    expect(tab.queryDisplaySourceColumns).toEqual([undefined]);
+  });
+
+  it("resolves quoted mixed-case identifiers exactly, per the database's rules", async () => {
+    getConnectionConfig.mockReturnValue({ id: "pg-1", name: "PostgreSQL", db_type: "postgres", database: "app", query_timeout_secs: 30 });
+    const quotedOrders = [column("id", "订单ID", true), column("ID", "大写ID"), column("user_id", "下单用户")];
+    const quotedUsers = [column("id", "用户ID", true), column("Name", "大写Name")];
+    getColumns.mockImplementation(async (_connectionId: string, _database: string, _schema: string, table: string) => (table === "orders" ? quotedOrders : quotedUsers));
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "orders",
+        tableAlias: "a",
+        selectStar: false,
+        columns: [
+          { sourceName: "id", sourceNameQuoted: false, sourceKey: "a", resultName: "id", expression: "a.id" },
+          { sourceName: "ID", sourceNameQuoted: true, sourceKey: "a", resultName: "ID", expression: 'a."ID"' },
+          { sourceName: "Name", sourceNameQuoted: true, sourceKey: "b", resultName: "Name", expression: 'b."Name"' },
+        ],
+        sources: [
+          { key: "a", tableName: "orders", alias: "a" },
+          { key: "b", tableName: "users", alias: "b" },
+        ],
+        multiSource: true,
+        allowInsertDelete: false,
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id", "ID", "Name"],
+        rows: [[1, 9, "Alice"]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "Query");
+
+    await store.executeTabSql(tabId, 'SELECT a.id, a."ID", b."Name" FROM orders a JOIN users b ON a.user_id = b.id');
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.resultColumnComments).toBeDefined());
+
+    // Quoted `"ID"` stays distinct from unquoted `id`; the global lower-casing
+    // of the previous map would have collapsed them.
+    expect(tab.resultColumnComments).toEqual(["订单ID", "大写ID", "大写Name"]);
+    expect(tab.queryDisplaySourceColumns).toEqual([
+      { sourceKey: "a", sourceColumn: "id" },
+      { sourceKey: "a", sourceColumn: "ID" },
+      { sourceKey: "b", sourceColumn: "Name" },
+    ]);
+  });
+
+  it("keeps duplicate result column names resolved in projection order", async () => {
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "orders",
+        tableAlias: "a",
+        selectStar: false,
+        columns: [
+          { sourceName: "id", sourceKey: "a", resultName: "id", expression: "a.id" },
+          { sourceName: "id", sourceKey: "b", resultName: "id", expression: "b.id" },
+        ],
+        sources: [
+          { key: "a", tableName: "orders", alias: "a" },
+          { key: "b", tableName: "users", alias: "b" },
+        ],
+        multiSource: true,
+        allowInsertDelete: false,
+      },
+    });
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id", "id_1"],
+        rows: [[1, 7]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("mysql-1", "app", "Query");
+
+    // The driver renames the second `id` to `id_1`; ordinal mapping still
+    // resolves column #1 to users.id instead of failing to match by name.
+    await store.executeTabSql(tabId, "SELECT a.id, b.id FROM orders a JOIN users b ON a.user_id = b.id");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.resultColumnComments).toBeDefined());
+    expect(tab.resultColumnComments).toEqual(["订单ID", "用户ID"]);
+    expect(tab.queryDisplaySourceColumns).toEqual([
+      { sourceKey: "a", sourceColumn: "id" },
+      { sourceKey: "b", sourceColumn: "id" },
+    ]);
   });
 
   it("keeps single-source results free of multi-source comment fields", async () => {

--- a/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
@@ -117,6 +117,20 @@ describe("queryStore switchTab", () => {
     expect(queryStore.tabs[1].catalog).toBe("paimon_catalog");
   });
 
+  it("clones result column comments when duplicating a query tab", () => {
+    const queryStore = useQueryStore();
+    const tabId = queryStore.createTab("pg-1", "app", undefined, "query", undefined, "SELECT 1");
+    const original = queryStore.tabs.find((tab) => tab.id === tabId)!;
+    original.resultColumnComments = ["identifier", "display name"];
+
+    queryStore.duplicateTab(tabId);
+
+    const duplicate = queryStore.tabs[1];
+    expect(Array.isArray(duplicate.resultColumnComments)).toBe(true);
+    expect(duplicate.resultColumnComments).toEqual(original.resultColumnComments);
+    expect(duplicate.resultColumnComments).not.toBe(original.resultColumnComments);
+  });
+
   it("switches catalog and database as one query context", () => {
     const queryStore = useQueryStore();
     const tabId = queryStore.createTab("sr-1", "internal_db", undefined, "query");

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2697,7 +2697,7 @@ export const useQueryStore = defineStore("query", () => {
       tableMeta: original.tableMeta ? { ...original.tableMeta, columns: [...original.tableMeta.columns], primaryKeys: [...original.tableMeta.primaryKeys] } : undefined,
       queryAnalysis: original.queryAnalysis ? { ...original.queryAnalysis, sources: original.queryAnalysis.sources?.map((source) => ({ ...source })), columns: original.queryAnalysis.columns.map((c) => ({ ...c })) } : undefined,
       querySourceColumns: original.querySourceColumns ? [...original.querySourceColumns] : undefined,
-      resultColumnComments: original.resultColumnComments ? { ...original.resultColumnComments } : undefined,
+      resultColumnComments: original.resultColumnComments ? [...original.resultColumnComments] : undefined,
       queryDisplaySourceColumns: original.queryDisplaySourceColumns ? [...original.queryDisplaySourceColumns] : undefined,
       queryEditabilityReason: original.queryEditabilityReason,
       resultEvicted: undefined,

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2,12 +2,12 @@ import { defineStore } from "pinia";
 import { uuid } from "@/lib/common/utils";
 import { computed, markRaw, nextTick, onScopeDispose, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { BatchSqlExecution, ConnectionConfig, DatabaseType, IndexInfo, ObjectBrowserViewport, QueryResult, QueryTab, TableInfoTab, TableStructureEditorTarget } from "@/types/database";
+import type { BatchSqlExecution, ConnectionConfig, DatabaseType, IndexInfo, ObjectBrowserViewport, QueryResult, QueryResultSourceColumnRef, QueryTab, TableInfoTab, TableStructureEditorTarget } from "@/types/database";
 import { orderPinnedFirst } from "@/lib/app/pinnedItems";
 import { canCancelQueryExecution } from "@/lib/sql/queryExecutionState";
 import { buildExplainSql, parseExplainResult, parseDamengExplainText, parseOracleExplainText, sqlServerExplainResult, type BuildExplainSqlResult } from "@/lib/diagram/explainPlan";
 import { mysqlExplainCompatibilityHint } from "@/lib/diagram/mysqlExplainCompatibility";
-import { allEditableColumnsWriteable, allPrimaryKeysPresent, analyzeEditableQueryEditability, resolveMetadataColumnName, sourceColumnsForResult, type EditableQueryInfo, type EditableQuerySource } from "@/lib/sql/sqlAnalysis";
+import { allEditableColumnsWriteable, allPrimaryKeysPresent, analyzeEditableQueryEditability, resolveMetadataColumnName, resolveSourceColumnsByOrdinal, sourceColumnsForResult, type EditableQueryInfo, type EditableQuerySource } from "@/lib/sql/sqlAnalysis";
 import { buildQueryWithHiddenPrimaryKeys, hiddenResultColumnIndexes, type HiddenPrimaryKeyProjection } from "@/lib/sql/editableQueryHiddenKeys";
 import { ACTIVE_TAB_STORAGE_KEY, OPEN_TABS_STORAGE_KEY, restoreOpenTabsPayload, restoreOpenTabsState, serializeOpenTabs } from "@/lib/app/openTabsPersistence";
 import {
@@ -965,6 +965,8 @@ export const useQueryStore = defineStore("query", () => {
     tab.resultEstimatedBytes = undefined;
     tab.queryAnalysis = undefined;
     tab.querySourceColumns = undefined;
+    tab.resultColumnComments = undefined;
+    tab.queryDisplaySourceColumns = undefined;
     tab.queryEditabilityReason = undefined;
     tab.mongoEditTarget = undefined;
     if (tab.mode === "query") tab.tableMeta = undefined;
@@ -1016,6 +1018,8 @@ export const useQueryStore = defineStore("query", () => {
     run.resultEstimatedBytes = undefined;
     run.queryAnalysis = undefined;
     run.querySourceColumns = undefined;
+    run.resultColumnComments = undefined;
+    run.queryDisplaySourceColumns = undefined;
     run.queryEditabilityReason = undefined;
     run.mongoEditTarget = undefined;
     run.tableMeta = undefined;
@@ -1058,6 +1062,8 @@ export const useQueryStore = defineStore("query", () => {
     tab.resultEvicted = run.resultEvicted;
     tab.queryAnalysis = run.queryAnalysis;
     tab.querySourceColumns = run.querySourceColumns;
+    tab.resultColumnComments = run.resultColumnComments;
+    tab.queryDisplaySourceColumns = run.queryDisplaySourceColumns;
     tab.queryEditabilityReason = run.queryEditabilityReason;
     tab.mongoEditTarget = run.mongoEditTarget;
     tab.tableMeta = run.tableMeta;
@@ -1217,6 +1223,8 @@ export const useQueryStore = defineStore("query", () => {
         activeResultRunId: run.id,
         queryAnalysis: run.queryAnalysis,
         querySourceColumns: run.querySourceColumns,
+        resultColumnComments: run.resultColumnComments,
+        queryDisplaySourceColumns: run.queryDisplaySourceColumns,
         queryEditabilityReason: run.queryEditabilityReason,
         tableMeta: run.tableMeta,
         resultPageSql: run.resultPageSql,
@@ -1296,6 +1304,8 @@ export const useQueryStore = defineStore("query", () => {
       resultEvicted: tab.resultEvicted,
       queryAnalysis: tab.queryAnalysis,
       querySourceColumns: tab.querySourceColumns,
+      resultColumnComments: tab.resultColumnComments,
+      queryDisplaySourceColumns: tab.queryDisplaySourceColumns,
       queryEditabilityReason: tab.queryEditabilityReason,
       mongoEditTarget: tab.mongoEditTarget,
       tableMeta: tab.tableMeta,
@@ -1394,6 +1404,8 @@ export const useQueryStore = defineStore("query", () => {
       resultEvicted: tab.resultEvicted,
       queryAnalysis: tab.queryAnalysis,
       querySourceColumns: tab.querySourceColumns,
+      resultColumnComments: tab.resultColumnComments,
+      queryDisplaySourceColumns: tab.queryDisplaySourceColumns,
       queryEditabilityReason: tab.queryEditabilityReason,
       mongoEditTarget: tab.mongoEditTarget,
       tableMeta: tab.tableMeta,
@@ -3398,43 +3410,40 @@ export const useQueryStore = defineStore("query", () => {
   };
 
   /**
-   * Merge column comments from every loaded source table. Keyed by the
-   * physical column name and its lower-cased form, matching the lookup keys
-   * the data grid builds from a single-table `tableMeta`. First source wins so
-   * identical column names across joined tables keep a stable comment.
+   * Resolve multi-source result columns (by projection ordinal) back to exactly
+   * one base column per source, then surface the resolved column comments and a
+   * display-only result->source mapping. Reuses the same database-aware binder
+   * as the editability analysis, so `name AS username` (uniquely resolvable
+   * unqualified alias) maps back to its physical column and quoted mixed-case
+   * identifiers keep exact casing. Ambiguous or unresolved columns yield
+   * `undefined` (no comment) instead of first-source-wins on a shared name.
    */
-  function mergeEditableSourceColumnComments(loadedSources: LoadedEditableSource[]): Record<string, string> {
-    const comments: Record<string, string> = {};
-    for (const loaded of loadedSources) {
-      for (const column of loaded.tableMeta.columns) {
-        const comment = column.comment?.trim();
-        if (!comment) continue;
-        if (!comments[column.name]) comments[column.name] = comment;
-        const lowerName = column.name.toLowerCase();
-        if (!comments[lowerName]) comments[lowerName] = comment;
+  function resolveMultiSourceColumnInfo(
+    dbType: string,
+    analysis: EditableQueryInfo,
+    resultColumns: string[],
+    loadedSources: LoadedEditableSource[],
+  ): { comments: Array<string | undefined>; mapping: Array<QueryResultSourceColumnRef | undefined> } {
+    const refs = resolveSourceColumnsByOrdinal(
+      dbType,
+      analysis,
+      loadedSources.map((loaded) => ({ source: loaded.source, columns: loaded.tableMeta.columns })),
+      resultColumns.length,
+    );
+    const comments: Array<string | undefined> = [];
+    const mapping: Array<QueryResultSourceColumnRef | undefined> = [];
+    for (const ref of refs) {
+      if (!ref) {
+        comments.push(undefined);
+        mapping.push(undefined);
+        continue;
       }
+      const loaded = loadedSources.find((entry) => entry.source.key === ref.sourceKey);
+      const comment = loaded?.tableMeta.columns.find((column) => column.name === ref.sourceColumn)?.comment?.trim();
+      comments.push(comment || undefined);
+      mapping.push(ref);
     }
-    return comments;
-  }
-
-  /**
-   * Build a display-only result-column -> source-column mapping across every
-   * source table of a multi-source query. Unlike `querySourceColumns` (which
-   * stays undefined for non-editable results) this exists purely so the data
-   * grid can resolve column comments; it must never be used for row identity.
-   */
-  function mergeEditableSourceDisplayColumns(analysis: EditableQueryInfo, resultColumns: string[], sources: EditableQuerySource[]): Array<string | undefined> | undefined {
-    let merged: Array<string | undefined> | undefined;
-    for (const source of sources) {
-      const mapped = sourceColumnsForResult(analysis, resultColumns, source.key);
-      if (!mapped) continue;
-      merged ??= resultColumns.map(() => undefined);
-      for (let index = 0; index < mapped.length; index++) {
-        const sourceName = mapped[index];
-        if (sourceName !== undefined && merged[index] === undefined) merged[index] = sourceName;
-      }
-    }
-    return merged;
+    return { comments, mapping };
   }
 
   function canInsertIntoEditableQuerySource(tab: QueryTab, databaseType: DatabaseType | undefined, loaded: LoadedEditableSource, sourceColumns: readonly (string | undefined)[] | undefined): boolean {
@@ -3778,11 +3787,10 @@ export const useQueryStore = defineStore("query", () => {
       }
 
       // Multi-source results cannot carry a single tableMeta, but every source
-      // table's metadata is already loaded. Surface merged column comments and
-      // a display-only result->source mapping so the data grid can still show
-      // comments for joined results (fixes #2129 / #6352).
-      const multiSourceComments = loadedSources.length > 1 ? mergeEditableSourceColumnComments(loadedSources) : undefined;
-      const multiSourceDisplayColumns = loadedSources.length > 1 ? mergeEditableSourceDisplayColumns(analysis, tab.result.columns, sources) : undefined;
+      // table's metadata is already loaded. Surface per-ordinal column comments
+      // and a display-only result->source mapping so the data grid can still
+      // show comments for joined results (fixes #2129 / #6352).
+      const multiSourceInfo = loadedSources.length > 1 ? resolveMultiSourceColumnInfo(dbType, analysis, tab.result.columns, loadedSources) : undefined;
 
       if (candidates.length === 0) {
         return {
@@ -3790,8 +3798,8 @@ export const useQueryStore = defineStore("query", () => {
           querySourceColumns: undefined,
           queryEditabilityReason: loadedSources.some((loaded) => loaded.tableMeta.primaryKeys.length > 0) ? "primary-key-not-returned" : "no-primary-key",
           tableMeta: undefined,
-          resultColumnComments: multiSourceComments,
-          queryDisplaySourceColumns: multiSourceDisplayColumns,
+          resultColumnComments: multiSourceInfo?.comments,
+          queryDisplaySourceColumns: multiSourceInfo?.mapping,
         };
       }
 
@@ -3801,8 +3809,8 @@ export const useQueryStore = defineStore("query", () => {
           querySourceColumns: undefined,
           queryEditabilityReason: "complex-source",
           tableMeta: undefined,
-          resultColumnComments: multiSourceComments,
-          queryDisplaySourceColumns: multiSourceDisplayColumns,
+          resultColumnComments: multiSourceInfo?.comments,
+          queryDisplaySourceColumns: multiSourceInfo?.mapping,
         };
       }
 
@@ -3818,8 +3826,8 @@ export const useQueryStore = defineStore("query", () => {
         querySourceColumns: target.sourceColumns,
         queryEditabilityReason: undefined,
         tableMeta: target.tableMeta,
-        resultColumnComments: multiSourceComments,
-        queryDisplaySourceColumns: multiSourceDisplayColumns,
+        resultColumnComments: multiSourceInfo?.comments,
+        queryDisplaySourceColumns: multiSourceInfo?.mapping,
       };
     } catch (err) {
       console.error("[DBX] ERROR fetching columns for query metadata:", err);
@@ -4136,6 +4144,8 @@ export const useQueryStore = defineStore("query", () => {
           touchResult(current);
           current.queryAnalysis = undefined;
           current.querySourceColumns = undefined;
+          current.resultColumnComments = undefined;
+          current.queryDisplaySourceColumns = undefined;
           current.queryEditabilityReason = undefined;
           current.mongoEditTarget = undefined;
           current.tableMeta = undefined;
@@ -4518,6 +4528,8 @@ export const useQueryStore = defineStore("query", () => {
           touchResult(current);
           current.queryAnalysis = undefined;
           current.querySourceColumns = undefined;
+          current.resultColumnComments = undefined;
+          current.queryDisplaySourceColumns = undefined;
           current.queryEditabilityReason = undefined;
           current.mongoEditTarget = mongoCommands.length === 1 ? mongoEditTarget : undefined;
           current.tableMeta = undefined;
@@ -4583,6 +4595,8 @@ export const useQueryStore = defineStore("query", () => {
           touchResult(current);
           current.queryAnalysis = undefined;
           current.querySourceColumns = undefined;
+          current.resultColumnComments = undefined;
+          current.queryDisplaySourceColumns = undefined;
           current.queryEditabilityReason = undefined;
           current.mongoEditTarget = undefined;
           current.tableMeta = undefined;
@@ -4965,6 +4979,8 @@ export const useQueryStore = defineStore("query", () => {
         }
         current.queryAnalysis = undefined;
         current.querySourceColumns = undefined;
+        current.resultColumnComments = undefined;
+        current.queryDisplaySourceColumns = undefined;
         current.queryEditabilityReason = undefined;
         current.mongoEditTarget = undefined;
         if (current.mode !== "data") current.tableMeta = undefined;
@@ -5445,6 +5461,8 @@ export const useQueryStore = defineStore("query", () => {
     touchResult(tab, Date.now(), { reuseEstimatedBytes: true });
     tab.queryAnalysis = undefined;
     tab.querySourceColumns = undefined;
+    tab.resultColumnComments = undefined;
+    tab.queryDisplaySourceColumns = undefined;
     tab.queryEditabilityReason = undefined;
     tab.mongoEditTarget = undefined;
     syncActiveResultRunFromDisplayed(tab);
@@ -5568,6 +5586,8 @@ export const useQueryStore = defineStore("query", () => {
 
     tab.queryAnalysis = snapshot.queryAnalysis;
     tab.querySourceColumns = snapshot.querySourceColumns;
+    tab.resultColumnComments = snapshot.resultColumnComments;
+    tab.queryDisplaySourceColumns = snapshot.queryDisplaySourceColumns;
     tab.queryEditabilityReason = snapshot.queryEditabilityReason;
     tab.mongoEditTarget = snapshot.mongoEditTarget;
     // Data tab 的结果快照可能早于最近一次结构变更。已持有真实元数据时，

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -1633,7 +1633,7 @@ export const useQueryStore = defineStore("query", () => {
     const tab: QueryTab = {
       id,
       title: title || `query_${tabs.value.length + 1}`,
-      customTitle: mode === "query" && !!title ? true : undefined,
+      customTitle: mode === "query" && title ? true : undefined,
       forceWordWrap: options.forceWordWrap,
       connectionId,
       database,
@@ -2685,6 +2685,8 @@ export const useQueryStore = defineStore("query", () => {
       tableMeta: original.tableMeta ? { ...original.tableMeta, columns: [...original.tableMeta.columns], primaryKeys: [...original.tableMeta.primaryKeys] } : undefined,
       queryAnalysis: original.queryAnalysis ? { ...original.queryAnalysis, sources: original.queryAnalysis.sources?.map((source) => ({ ...source })), columns: original.queryAnalysis.columns.map((c) => ({ ...c })) } : undefined,
       querySourceColumns: original.querySourceColumns ? [...original.querySourceColumns] : undefined,
+      resultColumnComments: original.resultColumnComments ? { ...original.resultColumnComments } : undefined,
+      queryDisplaySourceColumns: original.queryDisplaySourceColumns ? [...original.queryDisplaySourceColumns] : undefined,
       queryEditabilityReason: original.queryEditabilityReason,
       resultEvicted: undefined,
       whereInput: original.whereInput,
@@ -3380,7 +3382,7 @@ export const useQueryStore = defineStore("query", () => {
     return producedResult;
   }
 
-  type QueryMetadataPatch = Pick<QueryTab, "queryAnalysis" | "querySourceColumns" | "queryEditabilityReason" | "tableMeta">;
+  type QueryMetadataPatch = Pick<QueryTab, "queryAnalysis" | "querySourceColumns" | "queryEditabilityReason" | "tableMeta" | "resultColumnComments" | "queryDisplaySourceColumns">;
 
   type LoadedEditableSource = {
     source: EditableQuerySource;
@@ -3394,6 +3396,46 @@ export const useQueryStore = defineStore("query", () => {
     request: TableMetadataRequest;
     writeSchema?: string;
   };
+
+  /**
+   * Merge column comments from every loaded source table. Keyed by the
+   * physical column name and its lower-cased form, matching the lookup keys
+   * the data grid builds from a single-table `tableMeta`. First source wins so
+   * identical column names across joined tables keep a stable comment.
+   */
+  function mergeEditableSourceColumnComments(loadedSources: LoadedEditableSource[]): Record<string, string> {
+    const comments: Record<string, string> = {};
+    for (const loaded of loadedSources) {
+      for (const column of loaded.tableMeta.columns) {
+        const comment = column.comment?.trim();
+        if (!comment) continue;
+        if (!comments[column.name]) comments[column.name] = comment;
+        const lowerName = column.name.toLowerCase();
+        if (!comments[lowerName]) comments[lowerName] = comment;
+      }
+    }
+    return comments;
+  }
+
+  /**
+   * Build a display-only result-column -> source-column mapping across every
+   * source table of a multi-source query. Unlike `querySourceColumns` (which
+   * stays undefined for non-editable results) this exists purely so the data
+   * grid can resolve column comments; it must never be used for row identity.
+   */
+  function mergeEditableSourceDisplayColumns(analysis: EditableQueryInfo, resultColumns: string[], sources: EditableQuerySource[]): Array<string | undefined> | undefined {
+    let merged: Array<string | undefined> | undefined;
+    for (const source of sources) {
+      const mapped = sourceColumnsForResult(analysis, resultColumns, source.key);
+      if (!mapped) continue;
+      merged ??= resultColumns.map(() => undefined);
+      for (let index = 0; index < mapped.length; index++) {
+        const sourceName = mapped[index];
+        if (sourceName !== undefined && merged[index] === undefined) merged[index] = sourceName;
+      }
+    }
+    return merged;
+  }
 
   function canInsertIntoEditableQuerySource(tab: QueryTab, databaseType: DatabaseType | undefined, loaded: LoadedEditableSource, sourceColumns: readonly (string | undefined)[] | undefined): boolean {
     if (!canInsertTableRows(databaseType) || !sourceColumns?.length || !sourceColumns.every(Boolean)) return false;
@@ -3418,6 +3460,8 @@ export const useQueryStore = defineStore("query", () => {
     tab.queryEditabilityReason = patch.queryEditabilityReason;
     tab.mongoEditTarget = undefined;
     tab.tableMeta = patch.tableMeta;
+    tab.resultColumnComments = patch.resultColumnComments;
+    tab.queryDisplaySourceColumns = patch.queryDisplaySourceColumns;
   }
 
   function resolveEditableSourceMetadataTarget(tab: QueryTab, analysis: EditableQueryInfo, source: EditableQuerySource, conn: ConnectionConfig | undefined, dbType: string, executionDatabase: string): EditableSourceMetadataTarget {
@@ -3733,12 +3777,21 @@ export const useQueryStore = defineStore("query", () => {
         };
       }
 
+      // Multi-source results cannot carry a single tableMeta, but every source
+      // table's metadata is already loaded. Surface merged column comments and
+      // a display-only result->source mapping so the data grid can still show
+      // comments for joined results (fixes #2129 / #6352).
+      const multiSourceComments = loadedSources.length > 1 ? mergeEditableSourceColumnComments(loadedSources) : undefined;
+      const multiSourceDisplayColumns = loadedSources.length > 1 ? mergeEditableSourceDisplayColumns(analysis, tab.result.columns, sources) : undefined;
+
       if (candidates.length === 0) {
         return {
           queryAnalysis: undefined,
           querySourceColumns: undefined,
           queryEditabilityReason: loadedSources.some((loaded) => loaded.tableMeta.primaryKeys.length > 0) ? "primary-key-not-returned" : "no-primary-key",
           tableMeta: undefined,
+          resultColumnComments: multiSourceComments,
+          queryDisplaySourceColumns: multiSourceDisplayColumns,
         };
       }
 
@@ -3748,6 +3801,8 @@ export const useQueryStore = defineStore("query", () => {
           querySourceColumns: undefined,
           queryEditabilityReason: "complex-source",
           tableMeta: undefined,
+          resultColumnComments: multiSourceComments,
+          queryDisplaySourceColumns: multiSourceDisplayColumns,
         };
       }
 
@@ -3763,6 +3818,8 @@ export const useQueryStore = defineStore("query", () => {
         querySourceColumns: target.sourceColumns,
         queryEditabilityReason: undefined,
         tableMeta: target.tableMeta,
+        resultColumnComments: multiSourceComments,
+        queryDisplaySourceColumns: multiSourceDisplayColumns,
       };
     } catch (err) {
       console.error("[DBX] ERROR fetching columns for query metadata:", err);

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3418,12 +3418,7 @@ export const useQueryStore = defineStore("query", () => {
    * identifiers keep exact casing. Ambiguous or unresolved columns yield
    * `undefined` (no comment) instead of first-source-wins on a shared name.
    */
-  function resolveMultiSourceColumnInfo(
-    dbType: string,
-    analysis: EditableQueryInfo,
-    resultColumns: string[],
-    loadedSources: LoadedEditableSource[],
-  ): { comments: Array<string | undefined>; mapping: Array<QueryResultSourceColumnRef | undefined> } {
+  function resolveMultiSourceColumnInfo(dbType: string, analysis: EditableQueryInfo, resultColumns: string[], loadedSources: LoadedEditableSource[]): { comments: Array<string | undefined>; mapping: Array<QueryResultSourceColumnRef | undefined> } {
     const refs = resolveSourceColumnsByOrdinal(
       dbType,
       analysis,

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -773,6 +773,11 @@ export interface SpatialColumn {
   srid: number | null;
 }
 
+export interface QueryResultSourceColumnRef {
+  sourceKey: string;
+  sourceColumn: string;
+}
+
 export interface QueryResultRun {
   id: string;
   title: string;
@@ -813,6 +818,8 @@ export interface QueryResultRun {
   resultEvicted?: boolean;
   queryAnalysis?: QueryTab["queryAnalysis"];
   querySourceColumns?: QueryTab["querySourceColumns"];
+  resultColumnComments?: QueryTab["resultColumnComments"];
+  queryDisplaySourceColumns?: QueryTab["queryDisplaySourceColumns"];
   queryEditabilityReason?: QueryTab["queryEditabilityReason"];
   mongoEditTarget?: QueryTab["mongoEditTarget"];
   tableMeta?: QueryTab["tableMeta"];
@@ -1274,19 +1281,24 @@ export interface QueryTab {
   };
   querySourceColumns?: Array<string | undefined>;
   /**
-   * Column comments merged from every source table of the executed query,
-   * keyed by physical column name (and lower-cased alias). Populated even when
-   * the result is not editable (e.g. multi-table JOIN), so the data grid can
-   * still show comments for result columns that map back to a base column.
+   * Column comments for a multi-source query result (e.g. JOIN), indexed by
+   * result-column ordinal (projection order). Each entry is the comment of the
+   * single base column that result column resolves to; `undefined` when the
+   * column is ambiguous (e.g. an unqualified name present in several sources)
+   * or cannot be resolved back to a base column, so the grid shows no comment
+   * instead of a wrong one. Populated even when the result is not editable
+   * (e.g. multi-table JOIN), so joined results still show column comments.
    */
-  resultColumnComments?: Record<string, string>;
+  resultColumnComments?: Array<string | undefined>;
   /**
-   * Result-column to source-column mapping for display purposes (column
-   * comments / tooltips). Unlike querySourceColumns it is also populated for
-   * multi-source results that are not editable, and must not be used for row
-   * identity or editing.
+   * Display-only result-column to source mapping for multi-source results,
+   * indexed by result-column ordinal. Each entry carries the source identity
+   * (sourceKey + canonical source column name), so comments resolve per source
+   * instead of first-source-wins on name clashes. Unlike querySourceColumns it
+   * is also populated for multi-source results that are not editable, and must
+   * never be used for row identity or editing.
    */
-  queryDisplaySourceColumns?: Array<string | undefined>;
+  queryDisplaySourceColumns?: Array<QueryResultSourceColumnRef | undefined>;
   queryEditabilityReason?: "not-select" | "cte" | "set-operation" | "aggregation" | "external-source" | "complex-source" | "computed-columns" | "no-table" | "no-primary-key" | "primary-key-not-returned" | "aliased-columns" | "metadata-unavailable";
   mongoEditTarget?: {
     collection: string;

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -1273,6 +1273,20 @@ export interface QueryTab {
     }[];
   };
   querySourceColumns?: Array<string | undefined>;
+  /**
+   * Column comments merged from every source table of the executed query,
+   * keyed by physical column name (and lower-cased alias). Populated even when
+   * the result is not editable (e.g. multi-table JOIN), so the data grid can
+   * still show comments for result columns that map back to a base column.
+   */
+  resultColumnComments?: Record<string, string>;
+  /**
+   * Result-column to source-column mapping for display purposes (column
+   * comments / tooltips). Unlike querySourceColumns it is also populated for
+   * multi-source results that are not editable, and must not be used for row
+   * identity or editing.
+   */
+  queryDisplaySourceColumns?: Array<string | undefined>;
   queryEditabilityReason?: "not-select" | "cte" | "set-operation" | "aggregation" | "external-source" | "complex-source" | "computed-columns" | "no-table" | "no-primary-key" | "primary-key-not-returned" | "aliased-columns" | "metadata-unavailable";
   mongoEditTarget?: {
     collection: string;


### PR DESCRIPTION
Fixes #2129 (first half: result-set column comments for joined queries).

## Problem

Executing a JOIN / multi-source query hid every column comment in the result grid. Single-table queries worked because the data grid builds its comment map from `tableMeta.columns`; multi-source results are not editable so `tableMeta` was `undefined`, and the source tables' metadata — already loaded during editability analysis — was discarded.

## Changes

- **`QueryTab`** (`types/database.ts`) gains `resultColumnComments` (merged comments from every JOIN source) and `queryDisplaySourceColumns` (display-only result→source mapping).
- **`queryStore.ts`** `buildQueryMetadataPatch` now populates both fields for multi-source branches via `mergeEditableSourceColumnComments` / `mergeEditableSourceDisplayColumns`; `applyQueryMetadataPatch`, tab clone and result-cache snapshot carry them.
- **`DataGrid.vue`** merges `resultColumnComments` into `columnCommentMap` and resolves header/tooltip comments through `queryDisplaySourceColumns` first for precise matching.
- **`ContentArea.vue`** passes the new props.

## Tests

- `queryStore.multiSourceColumnComments.spec.ts`: JOIN result merges comments from both sources + display mapping; single-source regression stays free of the new fields.
- `multiSourceColumnMapping.spec.ts`: sqlAnalysis per-source column mapping (incl. duplicate result names).
- `DataGridColumnComments.spec.ts`: extended source assertions.

## Validation

- `vue-tsc` typecheck ✅, `oxlint` ✅, `oxfmt --check` ✅
- 45 related test files / 983 tests pass; the 4 failing specs (Redis completion, grid popover/condition/readonly) were confirmed failing before these changes (pre-existing).

## Follow-up

The second half of #2129 — hovering a column/table name in the SQL editor to show its comment — will be a separate PR.

## Review follow-up

This update addresses the requested changes from the latest review:

- Resolve result-column comments by result ordinal instead of a global physical-column-name map.
- Preserve the source identity for each result column with `sourceKey` + `sourceColumn`, so same-named columns from joined sources do not collide.
- Reuse the existing metadata-aware source-column binder for aliases and source resolution; ambiguous or calculated columns intentionally receive no comment rather than a potentially incorrect one.
- Preserve quoted identifier semantics instead of globally lowercasing identifiers.
- Restore the new column metadata correctly across tab result-cache serialization / reload paths.

Regression coverage includes:
- same-named columns across joined tables
- alias resolution and ambiguous columns
- quoted mixed-case identifiers
- duplicate result names
- result-cache round trips
- single-table fallback behavior
