### PR TITLE
fix(webview): change the watchdog time to 60 seconds

### DIFF
--- a/src-tauri/src/startup_recovery.rs
+++ b/src-tauri/src/startup_recovery.rs
@@ -19,7 +19,7 @@ const WINDOWS_APP_DATA_DIR_NAME: &str = "com.dbx.app";
 const COMPATIBILITY_MARKER_FILE: &str = "webview2-enterprise-compat.enabled";
 const COMPATIBILITY_PROFILE_DIR: &str = "webview2-enterprise-compat";
 const STARTUP_LOG_BUFFER_CAPACITY: usize = 256;
-const STARTUP_WATCHDOG_DELAY: Duration = Duration::from_secs(15);
+const STARTUP_WATCHDOG_DELAY: Duration = Duration::from_secs(60);
 #[cfg(target_os = "windows")]
 const RECOVERY_PARENT_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 


### PR DESCRIPTION
## 变更说明

修复webview2启动慢导致dbx app启动失败问题，延长watchdog时间至60s

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->
 
- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

-  本地打包在启动失败的设备上验证

## 关联 Issue
Close #6062

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
