### PR TITLE
feat(editor): 新增 Pi MCP 配置支持

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -110,7 +110,7 @@ import { currentExecutableStatementRange, type SqlTextRange } from "@/lib/sql/sq
 import { executableStatementRangeCacheForDoc, executableStatementRangeStartingAt, type ExecutableStatementRangeCache } from "@/lib/sql/executableStatementRangeCache";
 import { EMPTY_TABLE_COLUMN_TEMPLATE_DATA_TYPE, parseTableColumnTemplateFields, TABLE_COLUMN_TEMPLATE_DATABASE_TYPES, tableColumnTemplateRowsToSettings } from "@/lib/table/tableColumnTemplates";
 import { DEFAULT_SQL_VARIABLE_SYNTAX_TOGGLES, normalizeSqlVariableSyntaxOverrides, SQL_VARIABLE_SYNTAX_DATABASE_TYPES, SQL_VARIABLE_SYNTAX_KEYS, SQL_VARIABLE_SYNTAX_TOKENS, type SqlVariableSyntaxOverrides, type SqlVariableSyntaxToggles } from "@/lib/sql/sqlVariableSyntax";
-import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl, type McpLaunchConfig } from "@/lib/mcp/mcpConfigTemplates";
+import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpPiConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl, type McpLaunchConfig } from "@/lib/mcp/mcpConfigTemplates";
 import { beginMcpStatusRequest, mcpUpdateAvailability } from "@/lib/mcp/mcpUpdateStatus";
 import { isMcpPolicyMutationBlocked, MCP_CAPABILITY_ROWS, MCP_EXECUTION_MODE_COLUMNS, mcpExecutionModeFromPolicy, mcpPolicyFieldsForExecutionMode, type McpExecutionMode } from "@/lib/mcp/mcpPolicySelection";
 import { isMacOS, isWindows } from "@/lib/backend/platform";
@@ -1740,7 +1740,7 @@ async function exportDebugLogs() {
 }
 
 // ---------- MCP Server ----------
-type McpConfigTab = "claude" | "cursor" | "trae" | "vscode" | "windsurf" | "codex" | "opencode" | "cherry-studio";
+type McpConfigTab = "claude" | "cursor" | "trae" | "vscode" | "windsurf" | "codex" | "opencode" | "pi" | "cherry-studio";
 type McpCopyKind = "install" | "uninstall" | `${McpConfigTab}-config`;
 
 const mcpStatus = ref<McpServerStatus | null>(null);
@@ -1852,6 +1852,7 @@ const mcpCherryStudioRecommendedConfig = computed(() => buildMcpCherryStudioConf
 const mcpCodexRecommendedConfig = computed(() => buildMcpCodexConfig(mcpLaunchConfig.value));
 
 const mcpOpenCodeRecommendedConfig = computed(() => buildMcpOpenCodeConfig(mcpLaunchConfig.value));
+const mcpPiRecommendedConfig = computed(() => buildMcpPiConfig(mcpLaunchConfig.value));
 
 const mcpStatusTone = computed<"ok" | "warning" | "muted">(() => {
   if (!mcpStatus.value) return "muted";
@@ -6523,6 +6524,7 @@ onUnmounted(() => {
                     <TabsTrigger value="windsurf" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Windsurf</TabsTrigger>
                     <TabsTrigger value="codex" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Codex</TabsTrigger>
                     <TabsTrigger value="opencode" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">OpenCode</TabsTrigger>
+                    <TabsTrigger value="pi" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Pi</TabsTrigger>
                     <TabsTrigger value="cherry-studio" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Cherry Studio</TabsTrigger>
                   </TabsList>
 
@@ -6620,6 +6622,21 @@ onUnmounted(() => {
                         <pre class="overflow-x-auto whitespace-pre text-xs leading-relaxed"><code>{{ mcpOpenCodeRecommendedConfig }}</code></pre>
                         <Button type="button" variant="outline" size="icon" class="absolute right-2 top-2 h-7 w-7" :title="t('common.copy')" @click="copyMcpText('opencode-config', mcpOpenCodeRecommendedConfig)">
                           <CheckCircle2 v-if="mcpCopied === 'opencode-config'" class="h-3.5 w-3.5 text-green-500" />
+                          <Copy v-else class="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </TabsContent>
+
+                  <TabsContent value="pi" class="m-0">
+                    <div class="space-y-2">
+                      <div class="rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                        {{ t("settings.mcpPiConfigPath") }}
+                      </div>
+                      <div class="relative rounded-md border bg-background p-3">
+                        <pre class="overflow-x-auto whitespace-pre text-xs leading-relaxed"><code>{{ mcpPiRecommendedConfig }}</code></pre>
+                        <Button type="button" variant="outline" size="icon" class="absolute right-2 top-2 h-7 w-7" :title="t('common.copy')" @click="copyMcpText('pi-config', mcpPiRecommendedConfig)">
+                          <CheckCircle2 v-if="mcpCopied === 'pi-config'" class="h-3.5 w-3.5 text-green-500" />
                           <Copy v-else class="h-3.5 w-3.5" />
                         </Button>
                       </div>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6253,6 +6253,7 @@ export default {
     mcpVsCodeConfigPath: "VS Code/Copilot can use .vscode/mcp.json in the workspace or mcp.json in the user profile.",
     mcpWindsurfConfigPath: "Windsurf can use ~/.codeium/windsurf/mcp_config.json.",
     mcpOpenCodeConfigPath: "~/.config/opencode/opencode.json globally, or opencode.json at the project level.",
+    mcpPiConfigPath: "First install the Pi MCP adapter plugin: pi install npm:pi-mcp-adapter. Then save to ~/.pi/agent/mcp.json (global) or .mcp.json (project), run /mcp to verify, and /reload to pick it up in Pi.",
     mcpExecutionMode: "MCP execution permission",
     mcpExecutionModeDescription: "Choose the permission level DBX enforces for every MCP client. Client-side read/write settings cannot change this level.",
     mcpExecutionModeReadOnly: "Read only",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6242,6 +6242,7 @@ export default withEnglishFallback({
     mcpVsCodeConfigPath: "VS Code/Copilot 可放在工作区 .vscode/mcp.json 或用户配置文件 mcp.json。",
     mcpWindsurfConfigPath: "Windsurf 可放在 ~/.codeium/windsurf/mcp_config.json。",
     mcpOpenCodeConfigPath: "全局 ~/.config/opencode/opencode.json，项目级 opencode.json。",
+    mcpPiConfigPath: "先安装 Pi MCP 适配器插件：pi install npm:pi-mcp-adapter。然后保存到 ~/.pi/agent/mcp.json（全局）或 .mcp.json（项目），在 Pi 中运行 /mcp 确认、/reload 生效。",
     mcpExecutionMode: "MCP 执行权限",
     mcpExecutionModeDescription: "选择 DBX 对所有 MCP 客户端强制执行的权限级别。客户端的读写权限配置无法更改此级别。",
     mcpExecutionModeReadOnly: "只读",

--- a/apps/desktop/src/lib/__tests__/mcp/mcpConfigTemplates.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpConfigTemplates.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl } from "@/lib/mcp/mcpConfigTemplates";
+import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpPiConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl } from "@/lib/mcp/mcpConfigTemplates";
 
 describe("MCP config templates", () => {
   it("builds the standard mcpServers JSON used by Claude, Cursor, TRAE, and Windsurf", () => {
@@ -12,6 +12,17 @@ describe("MCP config templates", () => {
         },
       },
     });
+  });
+
+  it("builds the standard mcpServers JSON used by the Pi agent", () => {
+    expect(JSON.parse(buildMcpPiConfig())).toEqual({
+      mcpServers: {
+        dbx: {
+          command: "dbx-mcp-server",
+        },
+      },
+    });
+    expect(buildMcpPiConfig({ command: "npx", args: ["-y", "@dbx-app/mcp-server"] })).toContain('"npx"');
   });
 
   it("builds standard JSON configs with a direct node launch command", () => {

--- a/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
@@ -123,7 +123,7 @@ describe("MCP policy settings state", () => {
     expect(tabsSource).toContain("overscroll-x-contain");
     expect(tabsSource).not.toContain("flex-wrap");
     expect(tabsSource).not.toContain("grid-cols-");
-    expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(8);
+    expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(9);
     expect(tabsSource).not.toContain("min-w-0 px-");
   });
 });

--- a/apps/desktop/src/lib/mcp/mcpConfigTemplates.ts
+++ b/apps/desktop/src/lib/mcp/mcpConfigTemplates.ts
@@ -98,3 +98,7 @@ export function buildMcpOpenCodeConfig(config?: McpLaunchConfig): string {
 
   return JSON.stringify({ mcp: { dbx } }, null, 2);
 }
+
+export function buildMcpPiConfig(config?: McpLaunchConfig): string {
+  return buildMcpJsonConfig(config);
+}


### PR DESCRIPTION
- 在 MCP 配置页新增「Pi」配置 Tab（位于 OpenCode 之后），提供 Pi 智能体的 DBX MCP 配置示例
- 新增 buildMcpPiConfig() 生成标准 mcpServers JSON（Pi 原生读取，无需额外 MCP 服务器插件）
- 配置提示包含完整三步：先安装 Pi MCP 适配器插件 pi install npm:pi-mcp-adapter，再保存到 ~/.pi/agent/mcp.json（全局）或 .mcp.json（项目），最后在 Pi 中运行 /mcp 确认、/reload 生效
- 新增中英文翻译与配置模板单测

 ### 变更说明

 DBX 的 MCP 配置页此前支持 Claude Code、Cursor、TRAE、VS Code、Windsurf、Codex、OpenCode、Cherry Studio，缺少 Pi（Pi
 编程助手）的接入示例。本 PR 在其后新增「Pi」Tab：

 - 配置内容与 Claude 相同格式（标准 mcpServers JSON），因为 Pi 通过内置的 pi-mcp-adapter 原生读取该格式，不需要单独的
   MCP 服务器插件；
 - 但 Pi 需要先安装适配器插件 pi install npm:pi-mcp-adapter（官方 README 安装命令），装完重启 Pi；
 - 配置落点与生效方式在提示中说明：~/.pi/agent/mcp.json（全局）或 .mcp.json（项目），/mcp 验证、/reload 生效。

 ### 变更类型

 - [x] 新功能
 - [ ] Bug 修复
 - [ ] 性能优化
 - [ ] 代码重构
 - [ ] 文档更新
 - [ ] CI / 构建

 ### 涉及前端

 - [x] 本 PR 涉及前端改动（MCP 配置页新增 Tab 与提示
<img width="1438" height="770" alt="PixPin_2026-08-16_14-25-12" src="https://github.com/user-attachments/assets/c27e780f-a5e9-4f89-b3f6-ef992f3cb7e9" />


 ### 验证

 - [x] pnpm typecheck 通过
 - [x] pnpm lint 通过（改动文件 0 警告）
 - [x] 相关测试通过：mcpConfigTemplates.spec.ts 共 14 项全部通过（含新增 buildMcpPiConfig 用例）
 - 说明：Pi 适配器安装命令 pi install npm:pi-mcp-adapter 已与 pi-mcp-adapter 官方 README 核对一致