### PR TITLE
Fix：收窄 MySQL 自动补全反引号

### DIFF
--- a/apps/desktop/src/lib/sql/sqlIdentifier.ts
+++ b/apps/desktop/src/lib/sql/sqlIdentifier.ts
@@ -1,4 +1,5 @@
 const SIMPLE_LOWER_IDENTIFIER = /^[a-z_][a-z0-9_$]*$/;
+const SIMPLE_MYSQL_IDENTIFIER = /^[A-Za-z_$\u0080-\uFFFF][A-Za-z0-9_$\u0080-\uFFFF]*$/u;
 
 // PostgreSQL pg_get_keywords() categories R and T. GaussDB's PostgreSQL-
 // compatible modes use the same identifier constraints for bare names.
@@ -191,14 +192,16 @@ export function requiresPostgresIdentifierQuote(identifier: string, additionalKe
 }
 
 export function requiresMysqlIdentifierQuote(identifier: string, additionalKeywords?: ReadonlySet<string>): boolean {
-  return requiresPostgresIdentifierQuote(identifier, additionalKeywords) || MYSQL_ONLY_RESERVED_IDENTIFIER_KEYWORDS.has(identifier);
+  if (!SIMPLE_MYSQL_IDENTIFIER.test(identifier)) return true;
+  const normalized = identifier.toLowerCase();
+  return POSTGRES_RESERVED_IDENTIFIER_KEYWORDS.has(normalized) || additionalKeywords?.has(normalized) === true || MYSQL_ONLY_RESERVED_IDENTIFIER_KEYWORDS.has(normalized);
 }
 
 export function quoteGaussDbJdbcIdentifier(identifier: string, identifierQuote: string): string {
   if (isExplicitlyQuotedSqlIdentifier(identifier)) return identifier;
   const quote = identifierQuote.trim();
   if (!quote) return identifier;
-  const requiresQuote = quote === "`" ? requiresMysqlIdentifierQuote(identifier) : requiresPostgresIdentifierQuote(identifier);
+  const requiresQuote = quote === "`" ? requiresPostgresIdentifierQuote(identifier) || MYSQL_ONLY_RESERVED_IDENTIFIER_KEYWORDS.has(identifier.toLowerCase()) : requiresPostgresIdentifierQuote(identifier);
   if (!requiresQuote) return identifier;
   return `${quote}${identifier.replaceAll(quote, quote + quote)}${quote}`;
 }

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -558,6 +558,27 @@ test("leaves safe mixed-case MySQL identifiers unquoted when completion inserts 
   assert.equal(columnItems.find((item) => item.type === "column" && item.label === "UPPER_COL")?.apply, "UPPER_COL");
 });
 
+test("does not reuse MySQL backticks for Caché JDBC completion identifiers", () => {
+  const schemaSql = "select top 100 * from SQL";
+  const schemaItems = buildSqlCompletionItems(schemaSql, schemaSql.length, {
+    tables: [],
+    columnsByTable: new Map(),
+    schemas: ["SQLUser"],
+    databaseType: "iris",
+    dialect: "mysql",
+  });
+  assert.equal(schemaItems.find((item) => item.type === "schema" && item.label === "SQLUser")?.apply, "SQLUser.");
+
+  const tableSql = "select top 100 * from SQLUser.PA";
+  const tableItems = buildSqlCompletionItems(tableSql, tableSql.length, {
+    tables: [{ name: "PA_Adm", schema: "SQLUser", type: "table" }],
+    columnsByTable: new Map(),
+    databaseType: "iris",
+    dialect: "mysql",
+  });
+  assert.equal(tableItems.find((item) => item.type === "table" && item.label === "PA_Adm")?.apply, "PA_Adm");
+});
+
 test("quotes MySQL reserved-word column identifiers with backticks when completion inserts them", () => {
   const reservedColumns = ["order", "do", "returning", "ilike", "window", "true"];
   const reservedColumnsByTable = new Map<string, SqlCompletionColumn[]>([["public.bookings", reservedColumns.map((name) => ({ name, table: "bookings", schema: "public", dataType: "text" }))]]);

--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -522,6 +522,42 @@ test("leaves safe MySQL table identifiers unquoted when completion inserts them"
   assert.equal(table?.apply, "article");
 });
 
+test("leaves safe mixed-case MySQL identifiers unquoted when completion inserts them", () => {
+  const schemaSql = "select * from Sales";
+  const schemaItems = buildSqlCompletionItems(schemaSql, schemaSql.length, {
+    tables: [],
+    columnsByTable: new Map(),
+    schemas: ["SalesDB"],
+    dialect: "mysql",
+  });
+  assert.equal(schemaItems.find((item) => item.type === "schema" && item.label === "SalesDB")?.apply, "SalesDB.");
+
+  const tableSql = "select * from OrderI";
+  const tableItems = buildSqlCompletionItems(tableSql, tableSql.length, {
+    tables: [{ name: "OrderItems", schema: "SalesDB", type: "table" }],
+    columnsByTable: new Map(),
+    dialect: "mysql",
+  });
+  assert.equal(tableItems.find((item) => item.type === "table" && item.label === "OrderItems")?.apply, "OrderItems");
+
+  const columnSql = "select  from OrderItems";
+  const columnItems = buildSqlCompletionItems(columnSql, "select ".length, {
+    tables: [{ name: "OrderItems", schema: "SalesDB", type: "table" }],
+    columnsByTable: new Map([
+      [
+        "SalesDB.OrderItems",
+        [
+          { name: "MixedCase", table: "OrderItems", schema: "SalesDB", dataType: "int" },
+          { name: "UPPER_COL", table: "OrderItems", schema: "SalesDB", dataType: "int" },
+        ],
+      ],
+    ]),
+    dialect: "mysql",
+  });
+  assert.equal(columnItems.find((item) => item.type === "column" && item.label === "MixedCase")?.apply, "MixedCase");
+  assert.equal(columnItems.find((item) => item.type === "column" && item.label === "UPPER_COL")?.apply, "UPPER_COL");
+});
+
 test("quotes MySQL reserved-word column identifiers with backticks when completion inserts them", () => {
   const reservedColumns = ["order", "do", "returning", "ilike", "window", "true"];
   const reservedColumnsByTable = new Map<string, SqlCompletionColumn[]>([["public.bookings", reservedColumns.map((name) => ({ name, table: "bookings", schema: "public", dataType: "text" }))]]);
@@ -536,6 +572,17 @@ test("quotes MySQL reserved-word column identifiers with backticks when completi
     const column = items.find((item) => item.type === "column" && item.label === name);
     assert.equal(column?.apply, `\`${name}\``, `expected reserved column "${name}" to be quoted`);
   }
+});
+
+test("quotes MySQL reserved identifiers case-insensitively", () => {
+  const sql = "select Ord from bookings";
+  const items = buildSqlCompletionItems(sql, "select Ord".length, {
+    tables: [{ name: "bookings", schema: "public", type: "table" }],
+    columnsByTable: new Map([["public.bookings", [{ name: "Order", table: "bookings", schema: "public", dataType: "text" }]]]),
+    dialect: "mysql",
+  });
+
+  assert.equal(items.find((item) => item.type === "column" && item.label === "Order")?.apply, "`Order`");
 });
 
 test("quotes MySQL-only reserved identifiers in schema, table, column, and join completions", () => {


### PR DESCRIPTION
## 修改内容

- 为 MySQL 自动补全使用独立的裸标识符规则，普通混合大小写和全大写名称不再添加多余反引号
- 保留 MySQL 保留字、空格及特殊字符名称的反引号处理
- 保持 GaussDB JDBC 标识符兼容逻辑不变
- 补充 schema、表名、字段名及大小写保留字回归测试
- 覆盖 Caché/IRIS JDBC 在 MySQL 语法回退下的 `SQLUser.PA_Adm` 补全场景

## 问题原因

#6235 修复 #6224 时，`requiresMysqlIdentifierQuote` 复用了 PostgreSQL 的 `SIMPLE_LOWER_IDENTIFIER` 规则。PostgreSQL 裸标识符会折叠为小写，因此混合大小写需要引用；MySQL 不适用这一规则，导致 `MixedCase`、`UPPER_COL` 等安全名称也被加上反引号。

Caché/IRIS JDBC 的编辑器语法会回退到 MySQL。#6374 截图中的 `SQLUser.PA_Adm` 因此走到同一错误引用规则，被补全为 `` `SQLUser`.`PA_Adm` `` 并执行失败。

## 真实验证

使用真实 DBX UI 和 MySQL 9.6.0 临时库验证：

- 修复前：`MixedCase` -> `` `MixedCase` ``，`UPPER_COL` -> `` `UPPER_COL` ``
- 修复后：`MixedCase`、`UPPER_COL` 均保持原名，查询执行成功
- 保留字 `order` 仍补全为 `` `order` ``，查询执行成功
- 不引用的 `order` 在真实 MySQL 中报 1064，确认必要引用未被取消
- 临时测试库已删除并确认不存在

针对 #6374 截图中的 Caché 2016 SQL 增加显式 `iris` 回归测试，确认 schema/table 补全结果为 `SQLUser.PA_Adm`，不再生成 MySQL 反引号。该场景未连接用户的 Caché 实例执行。

## 测试

- 聚焦 SQL 补全及表标识符测试：252 tests passed
- `corepack pnpm check`
  - format: passed
  - lint: passed
  - typecheck: passed
  - test: passed

Fixes #6374
Fixes #6376
Regression from #6235
