### PR TITLE
Fix：修复 SQL 文件列表滚动时文件夹标题穿透

### DIFF
--- a/apps/desktop/src/components/layout/SqlFilePanel.vue
+++ b/apps/desktop/src/components/layout/SqlFilePanel.vue
@@ -455,8 +455,8 @@ function clearContextTarget() {
             <div v-for="(folder, fi) in folders" :key="folder.path" class="border-b last:border-b-0">
               <div
                 data-sql-file-row="true"
-                class="flex cursor-default items-center gap-1 px-2 py-1.5 text-[11px] font-medium text-muted-foreground bg-muted/10 sticky top-0 select-none"
-                :class="isPathHighlighted(folder.path) ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/40'"
+                class="flex cursor-default items-center gap-1 px-2 py-1.5 text-[11px] font-medium text-muted-foreground bg-[color-mix(in_oklab,var(--muted)_10%,var(--background))] sticky top-0 select-none"
+                :class="isPathHighlighted(folder.path) ? 'bg-accent text-accent-foreground' : 'hover:bg-[color-mix(in_oklab,var(--accent)_40%,var(--background))]'"
                 @click.stop="handlePathClick(folder.path, 'folderHeader', $event, () => toggleFolderCollapse(folder))"
                 @contextmenu.capture="
                   contextTarget = { kind: 'folderHeader', folderPath: folder.path };

--- a/apps/desktop/src/components/layout/__tests__/SqlFilePanel.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/SqlFilePanel.spec.ts
@@ -22,3 +22,11 @@ describe("SqlFilePanel selection", () => {
     expect(panelSource).toContain('data-sql-file-row="true"');
   });
 });
+
+describe("SqlFilePanel folder headers", () => {
+  it("keeps sticky folder headers opaque while the file list scrolls", () => {
+    expect(panelSource).toContain("bg-[color-mix(in_oklab,var(--muted)_10%,var(--background))] sticky top-0");
+    expect(panelSource).toContain("hover:bg-[color-mix(in_oklab,var(--accent)_40%,var(--background))]");
+    expect(panelSource).not.toContain("bg-muted/10 sticky top-0");
+  });
+});


### PR DESCRIPTION
## 问题
SQL 文件面板内容超过窗口高度后，粘性文件夹标题使用半透明背景，滚动时下方文件内容会穿透显示。

## 修改
- 将文件夹标题的普通和悬浮背景改为与页面背景混合后的实体颜色
- 保留原有明暗效果及选中状态
- 增加粘性标题背景回归测试

## 验证
- 客户端导入 4 个文件夹、144 个 SQL 文件并实际滚动验证
- `pnpm vitest run apps/desktop/src/components/layout/__tests__/SqlFilePanel.spec.ts`
- `pnpm typecheck`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/layout/SqlFilePanel.vue apps/desktop/src/components/layout/__tests__/SqlFilePanel.spec.ts`
- `pnpm build`