### PR TITLE
feat(mcp): 支持 pnpm 作为包管理器并适配裸 Node 安装环境

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -1920,7 +1920,7 @@ async function installMcp() {
     // 安装成功后刷新状态
     await refreshMcpStatus();
   } catch (e: any) {
-    mcpInstallMessage.value = e?.message || String(e);
+    mcpInstallMessage.value = translateBackendError(t, e);
     mcpInstallError.value = true;
   } finally {
     mcpInstalling.value = false;
@@ -1942,7 +1942,7 @@ async function uninstallMcp() {
     mcpInstallMessage.value = await uninstallMcpServer();
     await refreshMcpStatus();
   } catch (e: any) {
-    mcpInstallMessage.value = t("settings.mcpUninstallFailed", { error: e?.message || String(e) });
+    mcpInstallMessage.value = t("settings.mcpUninstallFailed", { error: translateBackendError(t, e) });
     mcpInstallError.value = true;
   } finally {
     mcpUninstalling.value = false;
@@ -2915,7 +2915,7 @@ const aiSupportsAnthropicApiStyle = computed(() => aiEditProvider.value === "cus
 const aiCliMcpNeedsInstall = computed(() => aiIsCliProvider.value && (!mcpStatus.value || !mcpStatus.value.installed));
 const aiCliMcpCanInstall = computed(() => {
   const status = mcpStatus.value;
-  return !mcpInstalling.value && !mcpUninstalling.value && !!status?.npm_available && (!status.installed || status.update_available);
+  return !mcpInstalling.value && !mcpUninstalling.value && !!status?.runtime_available && (!status.installed || status.update_available);
 });
 const aiCliMcpActionLabel = computed(() => {
   if (!mcpStatus.value?.installed) return t("settings.mcpInstallButton");
@@ -6359,7 +6359,7 @@ onUnmounted(() => {
                     <CheckCircle2 v-if="mcpCopied === 'install'" class="h-4 w-4 text-green-500" />
                     <Copy v-else class="h-4 w-4" />
                   </Button>
-                  <Button type="button" variant="default" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus?.npm_available || mcpStatus?.managed_automatically === false || (mcpStatus?.installed && !mcpStatus?.update_available)" @click="installMcp">
+                  <Button type="button" variant="default" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus?.runtime_available || mcpStatus?.managed_automatically === false || (mcpStatus?.installed && !mcpStatus?.update_available)" @click="installMcp">
                     <Loader2 v-if="mcpInstalling" class="mr-2 h-4 w-4 animate-spin" />
                     <CheckCircle2 v-if="!mcpInstalling && mcpStatus?.installed && !mcpStatus?.update_available" class="mr-2 h-4 w-4" />
                     {{ mcpInstalling ? t("settings.mcpInstalling") : !mcpStatus?.installed ? t("settings.mcpInstallButton") : mcpStatus?.update_available ? t("settings.mcpUpdateButton") : t("settings.mcpUpToDate") }}
@@ -6386,7 +6386,7 @@ onUnmounted(() => {
                     <CheckCircle2 v-if="mcpCopied === 'uninstall'" class="h-4 w-4 text-green-500" />
                     <Copy v-else class="h-4 w-4" />
                   </Button>
-                  <Button type="button" variant="outline" class="text-destructive hover:text-destructive" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus.npm_available || mcpStatus.managed_automatically === false" @click="uninstallMcp">
+                  <Button type="button" variant="outline" class="text-destructive hover:text-destructive" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus.runtime_available || mcpStatus.managed_automatically === false" @click="uninstallMcp">
                     <Loader2 v-if="mcpUninstalling" class="mr-2 h-4 w-4 animate-spin" />
                     <Trash2 v-else class="mr-2 h-4 w-4" />
                     {{ mcpUninstalling ? t("settings.mcpUninstalling") : t("settings.mcpUninstallButton") }}

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -6348,7 +6348,10 @@ onUnmounted(() => {
 
               <div v-if="!isWeb" class="space-y-2">
                 <Label>{{ mcpStatus?.installed ? t("settings.mcpUpdateCommand") : t("settings.mcpInstallCommand") }}</Label>
-                <div class="flex min-w-0 items-center gap-2">
+                <div v-if="mcpStatus?.installed && mcpStatus?.managed_automatically === false" class="rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                  {{ t("settings.mcpManualManagementHint") }}
+                </div>
+                <div v-else class="flex min-w-0 items-center gap-2">
                   <div class="min-w-0 flex-1 overflow-x-auto rounded-md border bg-background px-3 py-2 font-mono text-xs whitespace-nowrap">
                     {{ mcpCommand }}
                   </div>
@@ -6356,7 +6359,7 @@ onUnmounted(() => {
                     <CheckCircle2 v-if="mcpCopied === 'install'" class="h-4 w-4 text-green-500" />
                     <Copy v-else class="h-4 w-4" />
                   </Button>
-                  <Button type="button" variant="default" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus?.npm_available || (mcpStatus?.installed && !mcpStatus?.update_available)" @click="installMcp">
+                  <Button type="button" variant="default" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus?.npm_available || mcpStatus?.managed_automatically === false || (mcpStatus?.installed && !mcpStatus?.update_available)" @click="installMcp">
                     <Loader2 v-if="mcpInstalling" class="mr-2 h-4 w-4 animate-spin" />
                     <CheckCircle2 v-if="!mcpInstalling && mcpStatus?.installed && !mcpStatus?.update_available" class="mr-2 h-4 w-4" />
                     {{ mcpInstalling ? t("settings.mcpInstalling") : !mcpStatus?.installed ? t("settings.mcpInstallButton") : mcpStatus?.update_available ? t("settings.mcpUpdateButton") : t("settings.mcpUpToDate") }}
@@ -6372,7 +6375,10 @@ onUnmounted(() => {
 
               <div v-if="!isWeb && mcpStatus?.installed" class="space-y-2">
                 <Label>{{ t("settings.mcpUninstallCommand") }}</Label>
-                <div class="flex min-w-0 items-center gap-2">
+                <div v-if="mcpStatus?.managed_automatically === false" class="rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                  {{ t("settings.mcpManualManagementHint") }}
+                </div>
+                <div v-else class="flex min-w-0 items-center gap-2">
                   <div class="min-w-0 flex-1 overflow-x-auto rounded-md border bg-background px-3 py-2 font-mono text-xs whitespace-nowrap">
                     {{ mcpUninstallCommand }}
                   </div>
@@ -6380,7 +6386,7 @@ onUnmounted(() => {
                     <CheckCircle2 v-if="mcpCopied === 'uninstall'" class="h-4 w-4 text-green-500" />
                     <Copy v-else class="h-4 w-4" />
                   </Button>
-                  <Button type="button" variant="outline" class="text-destructive hover:text-destructive" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus.npm_available" @click="uninstallMcp">
+                  <Button type="button" variant="outline" class="text-destructive hover:text-destructive" :disabled="mcpInstalling || mcpUninstalling || !mcpStatus.npm_available || mcpStatus.managed_automatically === false" @click="uninstallMcp">
                     <Loader2 v-if="mcpUninstalling" class="mr-2 h-4 w-4 animate-spin" />
                     <Trash2 v-else class="mr-2 h-4 w-4" />
                     {{ mcpUninstalling ? t("settings.mcpUninstalling") : t("settings.mcpUninstallButton") }}

--- a/apps/desktop/src/composables/__tests__/useMcpUpdateBadge.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useMcpUpdateBadge.spec.ts
@@ -32,6 +32,7 @@ function deferred<T>(): Deferred<T> {
 function makeStatus(update_available: boolean, overrides: Partial<McpServerStatus> = {}): McpServerStatus {
   return {
     installed: true,
+    runtime_available: true,
     npm_available: true,
     node_path: null,
     node_version: null,

--- a/apps/desktop/src/i18n/backend-errors.ts
+++ b/apps/desktop/src/i18n/backend-errors.ts
@@ -143,6 +143,10 @@ const patterns: [RegExp, string][] = [
   // Message queues (crates/dbx-core/src/mq/adapters/kafka.rs)
   [/^Kafka does not support unloading topics$/, "mqClients.unloadTopicUnsupportedKafka"],
 
+  // MCP server management (src-tauri/src/commands/mcp.rs)
+  [/^DBX MCP is installed but its package manager could not be confirmed[\s\S]*$/, "settings.mcpUnknownPackageManager"],
+  [/^npm CLI is not available in this environment$/, "settings.mcpNpmCliUnavailable"],
+
   // Filesystem (src-tauri/src/commands/fs_open.rs)
   [/^file does not exist: (.+)$/, "common.fileNotFound"],
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6202,6 +6202,8 @@ export default {
     mcpUpdateCommand: "Upgrade command",
     mcpUninstallCommand: "Uninstall command",
     mcpManualManagementHint: "DBX MCP is installed but its package manager could not be confirmed. Please update or remove it with the package manager you used.",
+    mcpUnknownPackageManager: "DBX MCP is installed but its package manager could not be confirmed (Yarn, Bun, or a manual copy). DBX does not run npm/pnpm management commands against it; please update or remove it with the package manager you used.",
+    mcpNpmCliUnavailable: "npm CLI is not available in this environment.",
     mcpInstallButton: "Install",
     mcpUpdateButton: "Upgrade",
     mcpUpToDate: "Up to date",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6201,6 +6201,7 @@ export default {
     mcpInstallCommand: "Install command",
     mcpUpdateCommand: "Upgrade command",
     mcpUninstallCommand: "Uninstall command",
+    mcpManualManagementHint: "DBX MCP is installed but its package manager could not be confirmed. Please update or remove it with the package manager you used.",
     mcpInstallButton: "Install",
     mcpUpdateButton: "Upgrade",
     mcpUpToDate: "Up to date",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6191,6 +6191,8 @@ export default withEnglishFallback({
     mcpUpdateCommand: "升级命令",
     mcpUninstallCommand: "卸载命令",
     mcpManualManagementHint: "已检测到 DBX MCP 安装，但无法确认其包管理器来源。请用你当初使用的包管理器手动更新/卸载。",
+    mcpUnknownPackageManager: "已检测到 DBX MCP 安装，但无法确认其包管理器来源（可能是 Yarn、Bun 或手动复制）。DBX 不会对其执行 npm/pnpm 管理命令，请用你当初使用的包管理器手动更新/卸载。",
+    mcpNpmCliUnavailable: "当前环境中没有可用的 npm CLI。",
     mcpInstallButton: "安装",
     mcpUpdateButton: "升级",
     mcpUpToDate: "已是最新",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6190,6 +6190,7 @@ export default withEnglishFallback({
     mcpInstallCommand: "安装命令",
     mcpUpdateCommand: "升级命令",
     mcpUninstallCommand: "卸载命令",
+    mcpManualManagementHint: "已检测到 DBX MCP 安装，但无法确认其包管理器来源。请用你当初使用的包管理器手动更新/卸载。",
     mcpInstallButton: "安装",
     mcpUpdateButton: "升级",
     mcpUpToDate: "已是最新",

--- a/apps/desktop/src/lib/backend/http.ts
+++ b/apps/desktop/src/lib/backend/http.ts
@@ -3931,6 +3931,7 @@ export async function fetchChangelog(lang?: string): Promise<import("@/lib/app/c
 export async function checkMcpServerStatus(): Promise<import("@/lib/backend/tauri").McpServerStatus> {
   return {
     installed: false,
+    runtime_available: false,
     npm_available: false,
     node_path: null,
     node_version: null,

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -2032,6 +2032,7 @@ export interface McpServerStatus {
   bin_path: string | null;
   native_bin_path: string | null;
   script_path: string | null;
+  managed_automatically: boolean;
   data_dir: string | null;
   install_command: string;
   update_command: string;

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -2023,6 +2023,7 @@ export interface UpdateDownloadProgress {
 
 export interface McpServerStatus {
   installed: boolean;
+  runtime_available: boolean;
   npm_available: boolean;
   node_path: string | null;
   node_version: string | null;

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -10,6 +10,7 @@ use tauri::{AppHandle, Manager};
 const MCP_PACKAGE_NAME: &str = "@dbx-app/mcp-server";
 const MCP_LATEST_URL: &str = "https://registry.npmjs.org/@dbx-app%2fmcp-server/latest";
 const MCP_INSTALL_COMMAND: &str = "npm install -g @dbx-app/mcp-server@latest";
+const MCP_PNPM_INSTALL_COMMAND: &str = "pnpm add -g @dbx-app/mcp-server";
 const MCP_PNPM_UPDATE_COMMAND: &str = "pnpm update -g @dbx-app/mcp-server";
 const MCP_UNINSTALL_COMMAND: &str = "npm uninstall -g @dbx-app/mcp-server";
 const MCP_PNPM_UNINSTALL_COMMAND: &str = "pnpm remove -g @dbx-app/mcp-server";
@@ -123,8 +124,13 @@ impl NodeRuntime {
             package.as_ref().filter(|_| package_is_compatible).map(|located| located.package.script_path.clone());
         let mcp_bin_path =
             package.as_ref().and_then(|located| located.bin_path.clone()).or_else(|| mcp_bin_path(&npm_prefix));
-        let package_manager =
-            package.as_ref().map(|located| located.package_manager.clone()).unwrap_or(McpPackageManager::Npm);
+        // Prefer pnpm for install/update/uninstall when pnpm is reachable and no
+        // npm-installed package was located, so pnpm-based setups see pnpm commands.
+        let package_manager = package.as_ref().map(|located| located.package_manager.clone()).unwrap_or_else(|| {
+            locate_command("pnpm")
+                .map(|command_path| McpPackageManager::Pnpm { command_path: PathBuf::from(command_path) })
+                .unwrap_or(McpPackageManager::Npm)
+        });
         // TRAE on Windows splits executable paths containing spaces, so expose the native package binary as a safe direct launch option.
         let mcp_native_bin_path = package_is_compatible
             .then(|| package.as_ref().and_then(|located| mcp_native_binary_path(&located.package_root, &npm_root)))
@@ -163,6 +169,13 @@ impl NodeRuntime {
         }
     }
 
+    fn install_command(&self) -> &'static str {
+        match &self.package_manager {
+            McpPackageManager::Npm => MCP_INSTALL_COMMAND,
+            McpPackageManager::Pnpm { .. } => MCP_PNPM_INSTALL_COMMAND,
+        }
+    }
+
     fn uninstall_command(&self) -> &'static str {
         match &self.package_manager {
             McpPackageManager::Npm => MCP_UNINSTALL_COMMAND,
@@ -174,6 +187,9 @@ impl NodeRuntime {
         match &self.package_manager {
             McpPackageManager::Pnpm { command_path } if self.has_mcp_package() => {
                 run_package_manager_command(command_path, &["update", "-g", MCP_PACKAGE_NAME], &self.node_launcher_path)
+            }
+            McpPackageManager::Pnpm { command_path } => {
+                run_package_manager_command(command_path, &["add", "-g", MCP_PACKAGE_NAME], &self.node_launcher_path)
             }
             _ => self.npm_output(&["install", "-g", "@dbx-app/mcp-server@latest"]),
         }
@@ -243,7 +259,7 @@ pub async fn check_mcp_server_status(app: AppHandle) -> Result<McpServerStatus, 
         native_bin_path,
         script_path,
         data_dir,
-        install_command: MCP_INSTALL_COMMAND.to_string(),
+        install_command: runtime.as_ref().map(NodeRuntime::install_command).unwrap_or(MCP_INSTALL_COMMAND).to_string(),
         update_command: runtime.as_ref().map(NodeRuntime::update_command).unwrap_or(MCP_INSTALL_COMMAND).to_string(),
         uninstall_command: runtime
             .as_ref()

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1374,6 +1374,7 @@ mod tests {
         ));
     }
 
+    #[test]
     fn pnpm_shim_resolves_inline_script_path() {
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1458,7 +1459,6 @@ mod tests {
         let _ = std::fs::remove_dir_all(dir);
     }
 
-    #[test]
     #[test]
     fn installed_runtime_outranks_an_earlier_runtime_without_mcp() {
         let first = runtime("/runtime/node-26", None);

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -25,6 +25,9 @@ const SHELL_COMMAND_MARKER: &str = "__DBX_MCP_COMMAND_OUTPUT_START__";
 #[derive(Debug, Serialize)]
 pub struct McpServerStatus {
     pub installed: bool,
+    /// Whether a compatible Node.js runtime was resolved (npm, pnpm, or bare).
+    pub runtime_available: bool,
+    /// Whether an npm CLI is actually present; pnpm-only setups report false.
     pub npm_available: bool,
     pub node_path: Option<String>,
     pub node_version: Option<String>,
@@ -270,7 +273,10 @@ pub async fn check_mcp_server_status(app: AppHandle) -> Result<McpServerStatus, 
     let latest_version = fetch_latest_mcp_version();
     let (local_status, latest_version) = tokio::join!(local_status, latest_version);
     let (runtime, fallback_bin) = local_status.map_err(|err| err.to_string())?;
-    let npm_available = runtime.is_some();
+    let runtime_available = runtime.is_some();
+    // npm may be absent in pnpm-only / bare-Node environments; report its real
+    // presence separately from runtime availability.
+    let npm_available = runtime.as_ref().is_some_and(|runtime| runtime.npm_cli_path.is_some());
     let node_path = runtime.as_ref().map(|runtime| path_string(&runtime.node_path));
     let node_version = runtime.as_ref().map(|runtime| runtime.node_version.clone());
     let current_version = runtime.as_ref().and_then(|runtime| runtime.mcp_version.clone());
@@ -284,7 +290,7 @@ pub async fn check_mcp_server_status(app: AppHandle) -> Result<McpServerStatus, 
         .as_deref()
         .zip(latest_version.as_deref())
         .is_some_and(|(current, latest)| dbx_core::update::is_newer_version(latest, current));
-    let error = if npm_available {
+    let error = if runtime_available {
         None
     } else {
         Some(format!("Unable to resolve a compatible Node.js ({}) runtime.", MCP_MIN_NODE_VERSION_REQUIREMENT))
@@ -293,6 +299,7 @@ pub async fn check_mcp_server_status(app: AppHandle) -> Result<McpServerStatus, 
 
     Ok(McpServerStatus {
         installed: current_version.is_some() || bin_path.is_some() || script_path.is_some(),
+        runtime_available,
         npm_available,
         node_path,
         node_version,

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -113,7 +113,13 @@ impl NodeRuntime {
         let pnpm_bin_package = locate_command("pnpm")
             .and_then(|command| Path::new(&command).parent().map(Path::to_path_buf))
             .and_then(|dir| mcp_package_from_command_dir(&dir));
-        let package = preferred_mcp_package(npm_package, shim_package.or(pnpm_bin_package), &node_version);
+        // Any package manager that puts a dbx-mcp-server shim on PATH (Yarn, Bun,
+        // manually curated dirs) is detected through the shim itself.
+        let path_shim_package = locate_command("dbx-mcp-server")
+            .and_then(|command| Path::new(&command).parent().map(Path::to_path_buf))
+            .and_then(|dir| mcp_package_from_command_dir(&dir));
+        let package =
+            preferred_mcp_package(npm_package, shim_package.or(pnpm_bin_package).or(path_shim_package), &node_version);
         let package_is_compatible = package
             .as_ref()
             .and_then(|located| located.package.minimum_node_version)

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1717,7 +1717,7 @@ mod tests {
         let probed = NodeRuntime::probe(NodeRuntimeCandidate { node_path: node_alias.clone() }).unwrap();
 
         assert_eq!(probed.node_path, canonical_runtime_path(&node_path).unwrap());
-        assert_eq!(probed.npm_root, canonical_runtime_path(&npm_root).unwrap());
+        assert_eq!(probed.npm_root, Some(canonical_runtime_path(&npm_root).unwrap()));
         assert_eq!(probed.node_version, "v24.16.0");
         assert_eq!(probed.mcp_script_path, canonical_runtime_path(&script_path));
         let install_output = probed.install_or_update().unwrap();
@@ -1802,8 +1802,8 @@ mod tests {
 
         assert_eq!(probed.node_launcher_path, node_alias);
         assert_eq!(probed.node_path, canonical_runtime_path(&node_path).unwrap());
-        assert_eq!(probed.npm_cli_path, canonical_runtime_path(&npm_cli_path).unwrap());
-        assert_eq!(probed.npm_root, canonical_runtime_path(&npm_root).unwrap());
+        assert_eq!(probed.npm_cli_path, Some(canonical_runtime_path(&npm_cli_path).unwrap()));
+        assert_eq!(probed.npm_root, Some(canonical_runtime_path(&npm_root).unwrap()));
         assert_eq!(probed.mcp_script_path, canonical_runtime_path(&script_path));
         assert_eq!(probed.mcp_version.as_deref(), Some("0.4.44"));
         assert_eq!(probed.update_command(), super::MCP_PNPM_UPDATE_COMMAND);

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -138,13 +138,22 @@ impl NodeRuntime {
         let pnpm_bin_package = locate_command("pnpm")
             .and_then(|command| Path::new(&command).parent().map(Path::to_path_buf))
             .and_then(|dir| mcp_package_from_command_dir(&dir));
+        // pnpm writes global shims to its global-bin-dir, which is often the pnpm
+        // home itself rather than the `bin` subdir holding pnpm.CMD; probe both so
+        // a fresh `pnpm add -g` is found wherever pnpm actually put the shim.
+        let pnpm_home_package = locate_command("pnpm")
+            .and_then(|command| pnpm_home_from_command(Path::new(&command)))
+            .and_then(|dir| mcp_package_from_command_dir(&dir));
         // Any package manager that puts a dbx-mcp-server shim on PATH (Yarn, Bun,
         // manually curated dirs) is detected through the shim itself.
         let path_shim_package = locate_command("dbx-mcp-server")
             .and_then(|command| Path::new(&command).parent().map(Path::to_path_buf))
             .and_then(|dir| mcp_package_from_command_dir(&dir));
-        let package =
-            preferred_mcp_package(npm_package, shim_package.or(pnpm_bin_package).or(path_shim_package), &node_version);
+        let package = preferred_mcp_package(
+            npm_package,
+            shim_package.or(pnpm_bin_package).or(pnpm_home_package).or(path_shim_package),
+            &node_version,
+        );
         let package_is_compatible = package
             .as_ref()
             .and_then(|located| located.package.minimum_node_version)
@@ -229,9 +238,10 @@ impl NodeRuntime {
 
     fn install_or_update(&self) -> Result<CommandOutput, String> {
         match &self.package_manager {
-            McpPackageManager::Pnpm { command_path } if self.has_mcp_package() => {
-                run_package_manager_command(command_path, &["update", "-g", MCP_PACKAGE_NAME], &self.node_launcher_path)
-            }
+            // `pnpm add -g` always installs the latest into pnpm's real global dir
+            // and heals legacy/mismatched layouts (e.g. an old `pnpm-global` dir the
+            // current pnpm does not manage); `pnpm update -g` only touches the current
+            // global dir and would silently keep the old version in such setups.
             McpPackageManager::Pnpm { command_path } => {
                 run_package_manager_command(command_path, &["add", "-g", MCP_PACKAGE_NAME], &self.node_launcher_path)
             }
@@ -345,12 +355,16 @@ pub async fn install_mcp_server() -> Result<String, String> {
             )
         })?;
         installed.mcp_script_path.as_ref().ok_or_else(|| {
-            let npm_root = installed
-                .npm_root
-                .as_ref()
-                .map(|root| root.display().to_string())
-                .unwrap_or_else(|| "the package manager's global root".to_string());
-            format!("Installation completed, but {} was not found under {}.", MCP_PACKAGE_NAME, npm_root)
+            let location = match &installed.package_manager {
+                McpPackageManager::Npm => installed
+                    .npm_root
+                    .as_ref()
+                    .map(|root| root.display().to_string())
+                    .unwrap_or_else(|| "the npm global root".to_string()),
+                McpPackageManager::Pnpm { .. } => "the pnpm global directory".to_string(),
+                McpPackageManager::Unknown => "the detected global install".to_string(),
+            };
+            format!("Installation completed, but {} could not be located under {}.", MCP_PACKAGE_NAME, location)
         })?;
         let version = installed.mcp_version.unwrap_or_else(|| "unknown".to_string());
         Ok(format!("Successfully installed @dbx-app/mcp-server@{}", version))
@@ -884,15 +898,25 @@ fn mcp_package_from_command_dir(dir: &Path) -> Option<LocatedMcpPackage> {
         })
     })?;
     let (package_root, package) = mcp_package_from_script(&script_path)?;
+    // A pnpm shim is identified as pnpm when a pnpm command sits next to it, or
+    // when the shim lives inside pnpm's own layout (store links / pnpm-global);
+    // in the latter case fall back to the pnpm on PATH. Anything else (Yarn, Bun,
+    // manual copy) stays unknown/read-only so DBX never runs npm/pnpm management
+    // commands against another manager's install.
     let package_manager = pnpm_command_near(dir)
-        .filter(|command_path| pnpm_package_manageable(&package_root, pnpm_global_dir(command_path).as_deref()))
+        .or_else(|| locate_command("pnpm").map(PathBuf::from))
+        .filter(|_| pnpm_command_near(dir).is_some() || pnpm_located_shim(dir, &script_path))
         .map(|command_path| McpPackageManager::Pnpm { command_path })
         .unwrap_or(McpPackageManager::Unknown);
     Some(LocatedMcpPackage { package_root, package, bin_path: Some(bin_path), package_manager })
 }
 
-fn pnpm_package_manageable(package_root: &Path, pnpm_global_dir: Option<&Path>) -> bool {
-    pnpm_global_dir.is_none_or(|dir| package_root.starts_with(dir))
+/// True when the shim lives in pnpm's own layout, e.g. the store-links dir or an
+/// older `pnpm-global` dir. This is what distinguishes a pnpm shim from a Yarn /
+/// Bun / manual one when pnpm is not sitting right next to it.
+fn pnpm_located_shim(dir: &Path, script_path: &Path) -> bool {
+    let haystack = format!("{} {}", dir.display(), script_path.display()).to_ascii_lowercase();
+    haystack.contains("pnpm-store") || haystack.contains("pnpm-global")
 }
 
 fn mcp_package_from_script(script_path: &Path) -> Option<(PathBuf, McpPackage)> {
@@ -913,17 +937,6 @@ fn pnpm_command_near(dir: &Path) -> Option<PathBuf> {
     [Some(dir), dir.parent()].into_iter().flatten().find_map(|candidate_dir| {
         command_file_names("pnpm").into_iter().map(|name| candidate_dir.join(name)).find(|path| path.is_file())
     })
-}
-
-fn pnpm_global_dir(command_path: &Path) -> Option<PathBuf> {
-    let command = command_path.to_string_lossy();
-    let configured = command_stdout(&command, &["config", "get", "global-dir"]).ok();
-    let value =
-        configured.map(|output| output.trim().to_string()).filter(|value| !value.is_empty() && value != "undefined");
-    if let Some(value) = value {
-        return normalized_reported_path(Path::new(&value));
-    }
-    pnpm_home_from_command(command_path).map(|home| home.join("global"))
 }
 
 fn mcp_native_binary_path(package_root: &Path, npm_root: Option<&Path>) -> Option<PathBuf> {
@@ -1258,7 +1271,7 @@ mod tests {
     use super::{
         canonical_runtime_path, is_mcp_compatible_node_version, mcp_command_for_runtime, mcp_native_binary_path_for,
         mcp_package, mcp_package_from_command_dir, node_script_from_launcher, normalized_reported_path,
-        npm_cli_candidates, parse_minimum_node_version, parse_node_version, pnpm_package_manageable, pnpm_shim_target,
+        npm_cli_candidates, parse_minimum_node_version, parse_node_version, pnpm_located_shim, pnpm_shim_target,
         prefer_runtime, require_managed_mcp_command, resolve_managed_mcp_command, stdout_after_shell_marker,
         McpPackageManager, NodeRuntime, NodeVersion, MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME,
         MCP_UNKNOWN_MANAGEMENT_HINT, SHELL_COMMAND_MARKER,
@@ -1343,6 +1356,24 @@ mod tests {
     }
 
     #[test]
+    fn pnpm_located_shim_recognizes_store_links_and_legacy_layouts() {
+        let store_links = PathBuf::from(r"D:\Environment\pnpm\pnpm-store\v11\links\@pnpm\exe\10.27.0\hash");
+        let script = store_links.join("dbx-mcp-server.js");
+        assert!(pnpm_located_shim(&store_links, &script));
+        assert!(pnpm_located_shim(
+            &PathBuf::from("/home/pnpm-global/v11/hash"),
+            &PathBuf::from("/home/pnpm-global/v11/hash/node_modules/@dbx-app/mcp-server/bin/dbx-mcp-server.js")
+        ));
+        assert!(!pnpm_located_shim(
+            &PathBuf::from("/opt/yarn/bin"),
+            &PathBuf::from("/opt/yarn/global/node_modules/@dbx-app/mcp-server/bin/dbx-mcp-server.js")
+        ));
+        assert!(!pnpm_located_shim(
+            &PathBuf::from("/usr/local/bin"),
+            &PathBuf::from("/usr/local/lib/node_modules/@dbx-app/mcp-server/bin/dbx-mcp-server.js")
+        ));
+    }
+
     fn pnpm_shim_resolves_inline_script_path() {
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1428,19 +1459,6 @@ mod tests {
     }
 
     #[test]
-    fn pnpm_package_manageable_requires_matching_global_dir() {
-        let home = std::path::Path::new("/env/pnpm");
-        let managed = home.join("global").join("5").join("node_modules").join("@dbx-app").join("mcp-server");
-        let legacy =
-            home.join("pnpm-global").join("v11").join("hash").join("node_modules").join("@dbx-app").join("mcp-server");
-        let global_dir = Some(home.join("global").join("5").as_path());
-
-        assert!(pnpm_package_manageable(&managed, global_dir));
-        assert!(!pnpm_package_manageable(&legacy, global_dir));
-        // Unknown global dir (query failed) falls back to manageable.
-        assert!(pnpm_package_manageable(&legacy, None));
-    }
-
     #[test]
     fn installed_runtime_outranks_an_earlier_runtime_without_mcp() {
         let first = runtime("/runtime/node-26", None);

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -772,6 +772,7 @@ fn run_package_manager_command(
 ) -> Result<CommandOutput, String> {
     let mut command = dbx_core::process::new_std_command(command_path);
     command.args(args);
+    let pnpm_home = pnpm_home_from_command(command_path);
     let mut paths = command_path.parent().into_iter().map(Path::to_path_buf).collect::<Vec<_>>();
     if let Some(node_dir) = node_launcher_path.parent() {
         paths.push(node_dir.to_path_buf());
@@ -779,11 +780,15 @@ fn run_package_manager_command(
     if let Some(current_path) = env::var_os("PATH") {
         paths.extend(env::split_paths(&current_path));
     }
+    if let Some(home) = pnpm_home.as_ref() {
+        // pnpm refuses to run when its global bin directory is not on PATH.
+        paths.insert(0, home.clone());
+    }
     if let Ok(path) = env::join_paths(paths) {
         command.env("PATH", path);
     }
-    if let Some(pnpm_home) = pnpm_home_from_command(command_path) {
-        command.env("PNPM_HOME", pnpm_home);
+    if let Some(home) = pnpm_home {
+        command.env("PNPM_HOME", home);
     }
     command_output_from_process(command)
 }
@@ -879,13 +884,15 @@ fn mcp_package_from_command_dir(dir: &Path) -> Option<LocatedMcpPackage> {
         })
     })?;
     let (package_root, package) = mcp_package_from_script(&script_path)?;
-    // A shim found outside npm's global root is only managed automatically when a
-    // recognizable package manager sits next to it; anything else is treated as
-    // unknown so we never run npm/pnpm commands against another manager's install.
     let package_manager = pnpm_command_near(dir)
+        .filter(|command_path| pnpm_package_manageable(&package_root, pnpm_global_dir(command_path).as_deref()))
         .map(|command_path| McpPackageManager::Pnpm { command_path })
         .unwrap_or(McpPackageManager::Unknown);
     Some(LocatedMcpPackage { package_root, package, bin_path: Some(bin_path), package_manager })
+}
+
+fn pnpm_package_manageable(package_root: &Path, pnpm_global_dir: Option<&Path>) -> bool {
+    pnpm_global_dir.is_none_or(|dir| package_root.starts_with(dir))
 }
 
 fn mcp_package_from_script(script_path: &Path) -> Option<(PathBuf, McpPackage)> {
@@ -906,6 +913,17 @@ fn pnpm_command_near(dir: &Path) -> Option<PathBuf> {
     [Some(dir), dir.parent()].into_iter().flatten().find_map(|candidate_dir| {
         command_file_names("pnpm").into_iter().map(|name| candidate_dir.join(name)).find(|path| path.is_file())
     })
+}
+
+fn pnpm_global_dir(command_path: &Path) -> Option<PathBuf> {
+    let command = command_path.to_string_lossy();
+    let configured = command_stdout(&command, &["config", "get", "global-dir"]).ok();
+    let value =
+        configured.map(|output| output.trim().to_string()).filter(|value| !value.is_empty() && value != "undefined");
+    if let Some(value) = value {
+        return normalized_reported_path(Path::new(&value));
+    }
+    pnpm_home_from_command(command_path).map(|home| home.join("global"))
 }
 
 fn mcp_native_binary_path(package_root: &Path, npm_root: Option<&Path>) -> Option<PathBuf> {
@@ -1240,10 +1258,10 @@ mod tests {
     use super::{
         canonical_runtime_path, is_mcp_compatible_node_version, mcp_command_for_runtime, mcp_native_binary_path_for,
         mcp_package, mcp_package_from_command_dir, node_script_from_launcher, normalized_reported_path,
-        npm_cli_candidates, parse_minimum_node_version, parse_node_version, pnpm_shim_target, prefer_runtime,
-        require_managed_mcp_command, resolve_managed_mcp_command, stdout_after_shell_marker, McpPackageManager,
-        NodeRuntime, NodeVersion, MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME, MCP_UNKNOWN_MANAGEMENT_HINT,
-        SHELL_COMMAND_MARKER,
+        npm_cli_candidates, parse_minimum_node_version, parse_node_version, pnpm_package_manageable, pnpm_shim_target,
+        prefer_runtime, require_managed_mcp_command, resolve_managed_mcp_command, stdout_after_shell_marker,
+        McpPackageManager, NodeRuntime, NodeVersion, MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME,
+        MCP_UNKNOWN_MANAGEMENT_HINT, SHELL_COMMAND_MARKER,
     };
     #[cfg(not(windows))]
     use super::{shell_command_script, shell_quote};
@@ -1407,6 +1425,20 @@ mod tests {
         assert!(located_pnpm.package_manager.auto_managed());
 
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn pnpm_package_manageable_requires_matching_global_dir() {
+        let home = std::path::Path::new("/env/pnpm");
+        let managed = home.join("global").join("5").join("node_modules").join("@dbx-app").join("mcp-server");
+        let legacy =
+            home.join("pnpm-global").join("v11").join("hash").join("node_modules").join("@dbx-app").join("mcp-server");
+        let global_dir = Some(home.join("global").join("5").as_path());
+
+        assert!(pnpm_package_manageable(&managed, global_dir));
+        assert!(!pnpm_package_manageable(&legacy, global_dir));
+        // Unknown global dir (query failed) falls back to manageable.
+        assert!(pnpm_package_manageable(&legacy, None));
     }
 
     #[test]

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -107,7 +107,12 @@ impl NodeRuntime {
             })
         });
         let shim_package = launcher_dir.as_deref().and_then(mcp_package_from_command_dir);
-        let package = preferred_mcp_package(npm_package, shim_package, &node_version);
+        // pnpm installs global packages in pnpm's own bin dir instead of npm's global
+        // root; look there when the node-adjacent shim is absent.
+        let pnpm_bin_package = locate_command("pnpm")
+            .and_then(|command| Path::new(&command).parent().map(Path::to_path_buf))
+            .and_then(|dir| mcp_package_from_command_dir(&dir));
+        let package = preferred_mcp_package(npm_package, shim_package.or(pnpm_bin_package), &node_version);
         let package_is_compatible = package
             .as_ref()
             .and_then(|located| located.package.minimum_node_version)
@@ -579,6 +584,13 @@ fn normalize_canonical_path(path: PathBuf) -> PathBuf {
 fn find_npm_cli(node_path: &Path, launcher_dir: Option<&Path>) -> Option<PathBuf> {
     let mut candidates = launcher_dir.map(npm_cli_candidates_in_dir).unwrap_or_default();
     candidates.extend(npm_cli_candidates(node_path));
+    // Bare Node installs (pnpm-managed node, version managers) ship no npm next to
+    // the node binary; fall back to whatever npm is on PATH and resolve its script.
+    if let Some(npm_command) = locate_command("npm") {
+        if let Some(dir) = Path::new(&npm_command).parent() {
+            candidates.extend(npm_cli_candidates_in_dir(dir));
+        }
+    }
     let mut seen = HashSet::new();
 
     candidates.into_iter().find_map(|candidate| {
@@ -616,10 +628,33 @@ fn node_script_from_launcher(path: &Path) -> Option<PathBuf> {
     if let Some(target) = command_shim_target(&canonical) {
         return Some(target);
     }
+    if let Some(target) = pnpm_shim_target(&canonical) {
+        return Some(target);
+    }
     if is_native_npm_launcher(&canonical) || is_shell_script(&canonical) {
         return None;
     }
     Some(canonical)
+}
+
+/// Extracts the real script path embedded in a pnpm launcher shim. pnpm shims
+/// reference the package script inline (for example
+/// `node "%~dp0\..\pnpm-global\v11\<hash>\node_modules\@dbx-app\mcp-server\bin\dbx-mcp-server.js"`
+/// or `$basedir/...`), which the cmd-shim marker parse above does not cover.
+fn pnpm_shim_target(path: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let script = content.split('"').find_map(|token| {
+        let token = token.trim();
+        if !token.ends_with(".js") || !token.contains("node_modules") {
+            return None;
+        }
+        Some(token)
+    })?;
+    let shim_dir = path.parent()?.to_string_lossy().into_owned();
+    let script = script.replace("%~dp0", &shim_dir).replace("$basedir_win", &shim_dir).replace("$basedir", &shim_dir);
+    let target = PathBuf::from(&script);
+    let target = if target.is_absolute() { target } else { path.parent()?.join(target) };
+    canonical_runtime_path(&target)
 }
 
 fn command_shim_target(path: &Path) -> Option<PathBuf> {
@@ -1133,9 +1168,10 @@ mod tests {
     use super::{bash_login_script, prefixed_output_path, NodeRuntimeCandidate};
     use super::{
         canonical_runtime_path, is_mcp_compatible_node_version, mcp_command_for_runtime, mcp_native_binary_path_for,
-        mcp_package, normalized_reported_path, npm_cli_candidates, parse_minimum_node_version, parse_node_version,
-        prefer_runtime, require_managed_mcp_command, resolve_managed_mcp_command, stdout_after_shell_marker,
-        NodeRuntime, NodeVersion, MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME, SHELL_COMMAND_MARKER,
+        mcp_package, node_script_from_launcher, normalized_reported_path, npm_cli_candidates,
+        parse_minimum_node_version, parse_node_version, pnpm_shim_target, prefer_runtime, require_managed_mcp_command,
+        resolve_managed_mcp_command, stdout_after_shell_marker, NodeRuntime, NodeVersion,
+        MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME, SHELL_COMMAND_MARKER,
     };
     #[cfg(not(windows))]
     use super::{shell_command_script, shell_quote};
@@ -1214,6 +1250,33 @@ mod tests {
         let _ = std::fs::remove_dir_all(&path);
 
         assert_eq!(normalized_reported_path(&path), Some(path));
+    }
+
+    #[test]
+    fn pnpm_shim_resolves_inline_script_path() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = std::env::temp_dir().join(format!("dbx-pnpm-shim-test-{}-{nonce}", std::process::id()));
+        let bin_dir = dir.join("bin");
+        let script = dir.join("node_modules").join("@dbx-app").join("mcp-server").join("bin").join("dbx-mcp-server.js");
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(&script, "// launcher\n").unwrap();
+
+        let sep = std::path::MAIN_SEPARATOR;
+        let shim = bin_dir.join("dbx-mcp-server.CMD");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(
+            &shim,
+            format!(
+                "@SETLOCAL\r\nnode  \"%~dp0{sep}..{sep}node_modules{sep}@dbx-app{sep}mcp-server{sep}bin{sep}dbx-mcp-server.js\" %*\r\n"
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(pnpm_shim_target(&shim), canonical_runtime_path(&script));
+        assert_eq!(node_script_from_launcher(&shim), canonical_runtime_path(&script));
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -14,6 +14,10 @@ const MCP_PNPM_INSTALL_COMMAND: &str = "pnpm add -g @dbx-app/mcp-server";
 const MCP_PNPM_UPDATE_COMMAND: &str = "pnpm update -g @dbx-app/mcp-server";
 const MCP_UNINSTALL_COMMAND: &str = "npm uninstall -g @dbx-app/mcp-server";
 const MCP_PNPM_UNINSTALL_COMMAND: &str = "pnpm remove -g @dbx-app/mcp-server";
+const MCP_UNKNOWN_MANAGEMENT_HINT: &str =
+    "DBX MCP is installed but its package manager could not be confirmed; manage it manually";
+const MCP_UNKNOWN_MANAGEMENT_MESSAGE: &str =
+    "DBX MCP is installed but its package manager could not be confirmed (Yarn, Bun or a manual copy). DBX does not run npm/pnpm management commands against it; please update or remove it with the package manager you used.";
 const MCP_MIN_NODE_VERSION: NodeVersion = NodeVersion { major: 18, minor: 18, patch: 0 };
 const MCP_MIN_NODE_VERSION_REQUIREMENT: &str = ">=18.18.0";
 const SHELL_COMMAND_MARKER: &str = "__DBX_MCP_COMMAND_OUTPUT_START__";
@@ -30,6 +34,7 @@ pub struct McpServerStatus {
     pub bin_path: Option<String>,
     pub native_bin_path: Option<String>,
     pub script_path: Option<String>,
+    pub managed_automatically: bool,
     pub data_dir: Option<String>,
     pub install_command: String,
     pub update_command: String,
@@ -51,8 +56,8 @@ struct NodeRuntimeCandidate {
 struct NodeRuntime {
     node_launcher_path: PathBuf,
     node_path: PathBuf,
-    npm_cli_path: PathBuf,
-    npm_root: PathBuf,
+    npm_cli_path: Option<PathBuf>,
+    npm_root: Option<PathBuf>,
     package_manager: McpPackageManager,
     node_version: String,
     mcp_version: Option<String>,
@@ -71,7 +76,18 @@ struct McpPackage {
 #[derive(Debug, Clone)]
 enum McpPackageManager {
     Npm,
-    Pnpm { command_path: PathBuf },
+    Pnpm {
+        command_path: PathBuf,
+    },
+    /// A shim was located but its origin (Yarn, Bun, manual copy, ...) could not
+    /// be confirmed. DBX must not run npm/pnpm management commands against it.
+    Unknown,
+}
+
+impl McpPackageManager {
+    fn auto_managed(&self) -> bool {
+        !matches!(self, McpPackageManager::Unknown)
+    }
 }
 
 #[derive(Debug)]
@@ -90,21 +106,27 @@ impl NodeRuntime {
         if !is_mcp_compatible_node_version(&node_version) {
             return None;
         }
-        let npm_cli_path = find_npm_cli(&node_path, launcher_dir.as_deref())?;
-
-        let npm_root = npm_stdout(&node_path, &npm_cli_path, &["root", "-g"]).ok()?;
-        let npm_root = normalized_reported_path(Path::new(npm_root.trim()))?;
-        let npm_prefix = npm_stdout(&node_path, &npm_cli_path, &["prefix", "-g"])
-            .ok()
+        // npm is optional: pnpm-only and bare-Node environments may have no npm on
+        // PATH, so npm metadata must not gate the whole probe.
+        let npm_cli_path = find_npm_cli(&node_path, launcher_dir.as_deref());
+        let npm_root = npm_cli_path
+            .as_ref()
+            .and_then(|cli| npm_stdout(&node_path, cli, &["root", "-g"]).ok())
+            .and_then(|value| normalized_reported_path(Path::new(value.trim())));
+        let npm_prefix = npm_cli_path
+            .as_ref()
+            .and_then(|cli| npm_stdout(&node_path, cli, &["prefix", "-g"]).ok())
             .and_then(|value| normalized_reported_path(Path::new(value.trim())))
-            .unwrap_or_else(|| npm_prefix_from_root(&npm_root));
-        let npm_package_root = npm_root.join(MCP_PACKAGE_NAME);
-        let npm_package = mcp_package(&npm_package_root).and_then(|package| {
-            Some(LocatedMcpPackage {
-                package_root: canonical_runtime_path(&npm_package_root)?,
-                package,
-                bin_path: mcp_bin_path(&npm_prefix),
-                package_manager: McpPackageManager::Npm,
+            .or_else(|| npm_root.as_ref().map(|root| npm_prefix_from_root(root)));
+        let npm_package_root = npm_root.as_ref().map(|root| root.join(MCP_PACKAGE_NAME));
+        let npm_package = npm_package_root.as_ref().and_then(|package_root| {
+            mcp_package(package_root).and_then(|package| {
+                Some(LocatedMcpPackage {
+                    package_root: canonical_runtime_path(package_root)?,
+                    package,
+                    bin_path: npm_prefix.as_ref().and_then(|prefix| mcp_bin_path(prefix)),
+                    package_manager: McpPackageManager::Npm,
+                })
             })
         });
         let shim_package = launcher_dir.as_deref().and_then(mcp_package_from_command_dir);
@@ -128,8 +150,10 @@ impl NodeRuntime {
         // Resolve the package-declared launcher so npm layout changes do not break the built-in AI assistant.
         let mcp_script_path =
             package.as_ref().filter(|_| package_is_compatible).map(|located| located.package.script_path.clone());
-        let mcp_bin_path =
-            package.as_ref().and_then(|located| located.bin_path.clone()).or_else(|| mcp_bin_path(&npm_prefix));
+        let mcp_bin_path = package
+            .as_ref()
+            .and_then(|located| located.bin_path.clone())
+            .or_else(|| npm_prefix.as_ref().and_then(|prefix| mcp_bin_path(prefix)));
         // Prefer pnpm for install/update/uninstall when pnpm is reachable and no
         // npm-installed package was located, so pnpm-based setups see pnpm commands.
         let package_manager = package.as_ref().map(|located| located.package_manager.clone()).unwrap_or_else(|| {
@@ -139,7 +163,9 @@ impl NodeRuntime {
         });
         // TRAE on Windows splits executable paths containing spaces, so expose the native package binary as a safe direct launch option.
         let mcp_native_bin_path = package_is_compatible
-            .then(|| package.as_ref().and_then(|located| mcp_native_binary_path(&located.package_root, &npm_root)))
+            .then(|| {
+                package.as_ref().and_then(|located| mcp_native_binary_path(&located.package_root, npm_root.as_deref()))
+            })
             .flatten();
 
         Some(Self {
@@ -161,7 +187,9 @@ impl NodeRuntime {
     }
 
     fn npm_output(&self, args: &[&str]) -> Result<CommandOutput, String> {
-        npm_output(&self.node_path, &self.npm_cli_path, args)
+        let cli =
+            self.npm_cli_path.as_ref().ok_or_else(|| "npm CLI is not available in this environment".to_string())?;
+        npm_output(&self.node_path, cli, args)
     }
 
     fn refresh(&self) -> Option<Self> {
@@ -172,6 +200,7 @@ impl NodeRuntime {
         match &self.package_manager {
             McpPackageManager::Npm => MCP_INSTALL_COMMAND,
             McpPackageManager::Pnpm { .. } => MCP_PNPM_UPDATE_COMMAND,
+            McpPackageManager::Unknown => MCP_UNKNOWN_MANAGEMENT_HINT,
         }
     }
 
@@ -179,6 +208,7 @@ impl NodeRuntime {
         match &self.package_manager {
             McpPackageManager::Npm => MCP_INSTALL_COMMAND,
             McpPackageManager::Pnpm { .. } => MCP_PNPM_INSTALL_COMMAND,
+            McpPackageManager::Unknown => MCP_UNKNOWN_MANAGEMENT_HINT,
         }
     }
 
@@ -186,7 +216,12 @@ impl NodeRuntime {
         match &self.package_manager {
             McpPackageManager::Npm => MCP_UNINSTALL_COMMAND,
             McpPackageManager::Pnpm { .. } => MCP_PNPM_UNINSTALL_COMMAND,
+            McpPackageManager::Unknown => MCP_UNKNOWN_MANAGEMENT_HINT,
         }
+    }
+
+    fn auto_managed(&self) -> bool {
+        self.package_manager.auto_managed()
     }
 
     fn install_or_update(&self) -> Result<CommandOutput, String> {
@@ -197,7 +232,8 @@ impl NodeRuntime {
             McpPackageManager::Pnpm { command_path } => {
                 run_package_manager_command(command_path, &["add", "-g", MCP_PACKAGE_NAME], &self.node_launcher_path)
             }
-            _ => self.npm_output(&["install", "-g", "@dbx-app/mcp-server@latest"]),
+            McpPackageManager::Npm => self.npm_output(&["install", "-g", "@dbx-app/mcp-server@latest"]),
+            McpPackageManager::Unknown => Err(MCP_UNKNOWN_MANAGEMENT_MESSAGE.to_string()),
         }
     }
 
@@ -207,6 +243,7 @@ impl NodeRuntime {
                 run_package_manager_command(command_path, &["remove", "-g", MCP_PACKAGE_NAME], &self.node_launcher_path)
             }
             McpPackageManager::Npm => self.npm_output(&["uninstall", "-g", MCP_PACKAGE_NAME]),
+            McpPackageManager::Unknown => Err(MCP_UNKNOWN_MANAGEMENT_MESSAGE.to_string()),
         }
     }
 }
@@ -250,8 +287,9 @@ pub async fn check_mcp_server_status(app: AppHandle) -> Result<McpServerStatus, 
     let error = if npm_available {
         None
     } else {
-        Some(format!("Unable to resolve a compatible Node.js ({}) and npm runtime.", MCP_MIN_NODE_VERSION_REQUIREMENT))
+        Some(format!("Unable to resolve a compatible Node.js ({}) runtime.", MCP_MIN_NODE_VERSION_REQUIREMENT))
     };
+    let managed_automatically = runtime.as_ref().map(NodeRuntime::auto_managed).unwrap_or(true);
 
     Ok(McpServerStatus {
         installed: current_version.is_some() || bin_path.is_some() || script_path.is_some(),
@@ -264,6 +302,7 @@ pub async fn check_mcp_server_status(app: AppHandle) -> Result<McpServerStatus, 
         bin_path,
         native_bin_path,
         script_path,
+        managed_automatically,
         data_dir,
         install_command: runtime.as_ref().map(NodeRuntime::install_command).unwrap_or(MCP_INSTALL_COMMAND).to_string(),
         update_command: runtime.as_ref().map(NodeRuntime::update_command).unwrap_or(MCP_INSTALL_COMMAND).to_string(),
@@ -299,11 +338,12 @@ pub async fn install_mcp_server() -> Result<String, String> {
             )
         })?;
         installed.mcp_script_path.as_ref().ok_or_else(|| {
-            format!(
-                "Installation completed, but {} was not found under {}.",
-                MCP_PACKAGE_NAME,
-                installed.npm_root.display()
-            )
+            let npm_root = installed
+                .npm_root
+                .as_ref()
+                .map(|root| root.display().to_string())
+                .unwrap_or_else(|| "the package manager's global root".to_string());
+            format!("Installation completed, but {} was not found under {}.", MCP_PACKAGE_NAME, npm_root)
         })?;
         let version = installed.mcp_version.unwrap_or_else(|| "unknown".to_string());
         Ok(format!("Successfully installed @dbx-app/mcp-server@{}", version))
@@ -832,9 +872,12 @@ fn mcp_package_from_command_dir(dir: &Path) -> Option<LocatedMcpPackage> {
         })
     })?;
     let (package_root, package) = mcp_package_from_script(&script_path)?;
+    // A shim found outside npm's global root is only managed automatically when a
+    // recognizable package manager sits next to it; anything else is treated as
+    // unknown so we never run npm/pnpm commands against another manager's install.
     let package_manager = pnpm_command_near(dir)
         .map(|command_path| McpPackageManager::Pnpm { command_path })
-        .unwrap_or(McpPackageManager::Npm);
+        .unwrap_or(McpPackageManager::Unknown);
     Some(LocatedMcpPackage { package_root, package, bin_path: Some(bin_path), package_manager })
 }
 
@@ -858,23 +901,22 @@ fn pnpm_command_near(dir: &Path) -> Option<PathBuf> {
     })
 }
 
-fn mcp_native_binary_path(package_root: &Path, npm_root: &Path) -> Option<PathBuf> {
+fn mcp_native_binary_path(package_root: &Path, npm_root: Option<&Path>) -> Option<PathBuf> {
     let (package_name, binary_name) = mcp_native_package()?;
     mcp_native_binary_path_for(package_root, npm_root, package_name, binary_name)
 }
 
 fn mcp_native_binary_path_for(
     package_root: &Path,
-    npm_root: &Path,
+    npm_root: Option<&Path>,
     package_name: &str,
     binary_name: &str,
 ) -> Option<PathBuf> {
-    [
-        package_root.join("node_modules").join(package_name).join("bin").join(binary_name),
-        npm_root.join(package_name).join("bin").join(binary_name),
-    ]
-    .into_iter()
-    .find_map(|path| canonical_runtime_path(&path))
+    let mut candidates = vec![package_root.join("node_modules").join(package_name).join("bin").join(binary_name)];
+    if let Some(npm_root) = npm_root {
+        candidates.push(npm_root.join(package_name).join("bin").join(binary_name));
+    }
+    candidates.into_iter().find_map(|path| canonical_runtime_path(&path))
 }
 
 fn mcp_native_package() -> Option<(&'static str, &'static str)> {
@@ -1190,10 +1232,11 @@ mod tests {
     use super::{bash_login_script, prefixed_output_path, NodeRuntimeCandidate};
     use super::{
         canonical_runtime_path, is_mcp_compatible_node_version, mcp_command_for_runtime, mcp_native_binary_path_for,
-        mcp_package, node_script_from_launcher, normalized_reported_path, npm_cli_candidates,
-        parse_minimum_node_version, parse_node_version, pnpm_shim_target, prefer_runtime, require_managed_mcp_command,
-        resolve_managed_mcp_command, stdout_after_shell_marker, NodeRuntime, NodeVersion,
-        MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME, SHELL_COMMAND_MARKER,
+        mcp_package, mcp_package_from_command_dir, node_script_from_launcher, normalized_reported_path,
+        npm_cli_candidates, parse_minimum_node_version, parse_node_version, pnpm_shim_target, prefer_runtime,
+        require_managed_mcp_command, resolve_managed_mcp_command, stdout_after_shell_marker, McpPackageManager,
+        NodeRuntime, NodeVersion, MCP_MIN_NODE_VERSION_REQUIREMENT, MCP_PACKAGE_NAME, MCP_UNKNOWN_MANAGEMENT_HINT,
+        SHELL_COMMAND_MARKER,
     };
     #[cfg(not(windows))]
     use super::{shell_command_script, shell_quote};
@@ -1212,8 +1255,8 @@ mod tests {
         NodeRuntime {
             node_launcher_path: PathBuf::from(node_path),
             node_path: PathBuf::from(node_path),
-            npm_cli_path: PathBuf::from(format!("{node_path}-npm-cli.js")),
-            npm_root: PathBuf::from(npm_root),
+            npm_cli_path: Some(PathBuf::from(format!("{node_path}-npm-cli.js"))),
+            npm_root: Some(PathBuf::from(npm_root)),
             package_manager: super::McpPackageManager::Npm,
             node_version: node_version.to_string(),
             mcp_version: script_path.map(|_| "0.4.29".to_string()),
@@ -1298,6 +1341,64 @@ mod tests {
 
         assert_eq!(pnpm_shim_target(&shim), canonical_runtime_path(&script));
         assert_eq!(node_script_from_launcher(&shim), canonical_runtime_path(&script));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn unknown_package_manager_shim_is_read_only_and_requires_no_npm() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = std::env::temp_dir().join(format!("dbx-mcp-pm-test-{}-{nonce}", std::process::id()));
+        let bin_dir = dir.join("bin");
+        let script = dir.join("node_modules").join("@dbx-app").join("mcp-server").join("bin").join("dbx-mcp-server.js");
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(&script, "// launcher\n").unwrap();
+        std::fs::write(
+            dir.join("node_modules").join("@dbx-app").join("mcp-server").join("package.json"),
+            r#"{"version":"0.4.62","bin":{"dbx-mcp-server":"bin/dbx-mcp-server.js"}}"#,
+        )
+        .unwrap();
+        let sep = std::path::MAIN_SEPARATOR;
+        let shim = bin_dir.join("dbx-mcp-server.CMD");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(
+            &shim,
+            format!(
+                "@SETLOCAL\r\nnode  \"%~dp0{sep}..{sep}node_modules{sep}@dbx-app{sep}mcp-server{sep}bin{sep}dbx-mcp-server.js\" %*\r\n"
+            ),
+        )
+        .unwrap();
+
+        // No recognizable package manager next to the shim -> Unknown + read-only,
+        // and npm being absent must not matter (bare Node / pnpm-only environments).
+        let located = mcp_package_from_command_dir(&bin_dir).unwrap();
+        assert!(matches!(located.package_manager, McpPackageManager::Unknown));
+        assert!(!located.package_manager.auto_managed());
+        let runtime = NodeRuntime {
+            node_launcher_path: bin_dir.join("node.exe"),
+            node_path: bin_dir.join("node.exe"),
+            npm_cli_path: None,
+            npm_root: None,
+            package_manager: located.package_manager,
+            node_version: "v24.16.0".to_string(),
+            mcp_version: located.package.version,
+            mcp_script_path: Some(located.package.script_path),
+            mcp_bin_path: Some(shim.clone()),
+            mcp_native_bin_path: None,
+        };
+        assert!(runtime.has_mcp_package());
+        assert!(runtime.npm_output(&["--version"]).is_err());
+        assert!(runtime.install_or_update().is_err());
+        assert!(runtime.uninstall().is_err());
+        assert_eq!(runtime.install_command(), MCP_UNKNOWN_MANAGEMENT_HINT);
+
+        // A pnpm command next to the shim -> auto-managed as pnpm.
+        std::fs::write(bin_dir.join("pnpm.CMD"), "@ECHO off\r\n").unwrap();
+        let located_pnpm = mcp_package_from_command_dir(&bin_dir).unwrap();
+        assert!(matches!(located_pnpm.package_manager, McpPackageManager::Pnpm { .. }));
+        assert!(located_pnpm.package_manager.auto_managed());
+
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -1447,7 +1548,7 @@ mod tests {
         std::fs::write(&nested_binary, "nested binary").unwrap();
 
         assert_eq!(
-            mcp_native_binary_path_for(&package_root, &npm_root, package_name, binary_name),
+            mcp_native_binary_path_for(&package_root, Some(&npm_root), package_name, binary_name),
             canonical_runtime_path(&nested_binary)
         );
 
@@ -1457,8 +1558,14 @@ mod tests {
         std::fs::write(&hoisted_binary, "hoisted binary").unwrap();
 
         assert_eq!(
-            mcp_native_binary_path_for(&package_root, &npm_root, package_name, binary_name),
+            mcp_native_binary_path_for(&package_root, Some(&npm_root), package_name, binary_name),
             canonical_runtime_path(&hoisted_binary)
+        );
+
+        // Without an npm root the nested (package-local) copy is still found.
+        assert_eq!(
+            mcp_native_binary_path_for(&package_root, None, package_name, binary_name),
+            canonical_runtime_path(&nested_binary)
         );
 
         let _ = std::fs::remove_dir_all(dir);

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1417,15 +1417,17 @@ mod tests {
         )
         .unwrap();
         let sep = std::path::MAIN_SEPARATOR;
-        let shim = bin_dir.join("dbx-mcp-server.CMD");
+        let shim = bin_dir.join(if cfg!(windows) { "dbx-mcp-server.CMD" } else { "dbx-mcp-server" });
         std::fs::create_dir_all(&bin_dir).unwrap();
-        std::fs::write(
-            &shim,
+        let shim_content = if cfg!(windows) {
             format!(
                 "@SETLOCAL\r\nnode  \"%~dp0{sep}..{sep}node_modules{sep}@dbx-app{sep}mcp-server{sep}bin{sep}dbx-mcp-server.js\" %*\r\n"
-            ),
-        )
-        .unwrap();
+            )
+        } else {
+            "#!/bin/sh\nnode \"$basedir/../node_modules/@dbx-app/mcp-server/bin/dbx-mcp-server.js\" \"$@\"\n"
+                .to_string()
+        };
+        std::fs::write(&shim, shim_content).unwrap();
 
         // No recognizable package manager next to the shim -> Unknown + read-only,
         // and npm being absent must not matter (bare Node / pnpm-only environments).
@@ -1451,7 +1453,8 @@ mod tests {
         assert_eq!(runtime.install_command(), MCP_UNKNOWN_MANAGEMENT_HINT);
 
         // A pnpm command next to the shim -> auto-managed as pnpm.
-        std::fs::write(bin_dir.join("pnpm.CMD"), "@ECHO off\r\n").unwrap();
+        let pnpm_name = if cfg!(windows) { "pnpm.CMD" } else { "pnpm" };
+        std::fs::write(bin_dir.join(pnpm_name), "@ECHO off\r\n").unwrap();
         let located_pnpm = mcp_package_from_command_dir(&bin_dir).unwrap();
         assert!(matches!(located_pnpm.package_manager, McpPackageManager::Pnpm { .. }));
         assert!(located_pnpm.package_manager.auto_managed());
@@ -1815,7 +1818,7 @@ mod tests {
         let update_output = probed.install_or_update().unwrap();
         assert!(update_output.success);
         let pnpm_log = std::fs::read_to_string(&pnpm_log_path).unwrap();
-        assert!(pnpm_log.contains("ARGS=update -g @dbx-app/mcp-server\n"));
+        assert!(pnpm_log.contains("ARGS=add -g @dbx-app/mcp-server\n"));
         assert!(!pnpm_log.contains("--registry"));
         assert!(pnpm_log.contains(&format!("PNPM_HOME={}", dir.display())));
         assert!(pnpm_log.contains(&format!("PATH={}", bin_dir.display())));


### PR DESCRIPTION
 - 修复 find_npm_cli 仅查找 node 同目录 npm-cli.js 的问题：裸 Node（pnpm 管理 / 版本管理器安装，node 旁无 npm）时，回退到 PATH 上解析 npm 并取其真实 npm-cli.js
 - 新增 pnpm_shim_target 解析 pnpm 启动器 shim 内嵌的真实脚本路径（pnpm 的 .CMD shim 不带 cmd-shim-target 标记，与 npm 不同）
 - 包探测新增 pnpm 全局 bin 目录：locate_command("pnpm") 所在目录，识别 pnpm 安装的 @dbx-app/mcp-server 全局包
 - 安装命令跟随包管理器：检测到 pnpm 时显示 pnpm add -g @dbx-app/mcp-server，未装包时 install_or_update 也走 pnpm add 而非 npm install
 - 新增 Rust 单测 pnpm_shim_resolves_inline_script_path

 ### 变更说明

 DBX 的 MCP 服务器状态检测此前依赖 node 与 npm 相邻安装、包位于 npm 全局根目录。当用户使用 pnpm 管理（常见于裸 Node + pnpm 全局包、版本管理器）时：

 - node 是裸安装（无 npm-cli.js），旧 find_npm_cli 直接失败 → 整个探测返回空 → MCP 配置页 Node.js/npm 版本、当前版本全部不显示；
 - dbx-mcp-server 由 pnpm add -g 装入 pnpm 全局 bin（非 npm 全局根），旧逻辑检测不到 → 显示"未检测到全局安装"；
 - 安装命令写死 npm，与 pnpm 用户的实际操作不符。

 本 PR 三处根因修复：
 1. find_npm_cli 增加 PATH 兜底，解析 where npm / which npm 所在目录下的 node_modules/npm/bin/npm-cli.js；
 2. pnpm_shim_target 解析 pnpm shim 内联脚本路径，配合 mcp_package_from_script 还原包根与版
    本；
 3. probe 增加 pnpm 全局 bin 目录候选，且 pnpm 在 PATH 时安装/更新/卸载命令跟随 pnpm（pnpm add / pnpm update / pnpm remove）。

 ### 变更类型

 - [x] Bug 修复
 - [ ] 新功能
 - [ ] 性能优化
 - [ ] 代码重构
 - [ ] 文档更新
 - [ ] CI / 构建

 ### 涉及前端

 - [ ] 本 PR 不涉及前端改动（仅 Rust 后端 src-tauri/src/commands/mcp.rs）

 ### 验证

 - [x] pnpm shim 解析路径实测：对真实环境 D:\Environment\pnpm\bin\dbx-mcp-server.CMD 解析出的 node_modules\@dbx-app\mcp-server\bin\dbx-mcp-server.js 存在，包版本 0.4.62
 - [x] 新增单测 pnpm_shim_resolves_inline_script_path