### PR TITLE
Fix：MySQL 存储过程标签被误识别为 SQL 参数

### DIFF
--- a/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
@@ -630,6 +630,46 @@ SELECT @value AS Message;`;
     expect(executedSql).toContain("where fp.create_at < @date_start");
   });
 
+  it("executes MySQL cursor procedures with compact labels without opening the parameter dialog", async () => {
+    const sql = `
+      CREATE PROCEDURE process_orders()
+      BEGIN
+        DECLARE done INT DEFAULT FALSE;
+        DECLARE order_id INT;
+        DECLARE cur_orders CURSOR FOR SELECT id FROM orders;
+        DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+        OPEN cur_orders;
+        read_loop:LOOP
+          FETCH cur_orders INTO order_id;
+          IF done THEN LEAVE read_loop; END IF;
+        END LOOP read_loop;
+        CLOSE cur_orders;
+      END
+    `;
+    const activeTab = ref<QueryTab | undefined>(queryTab("app"));
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("mysql"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const executeCurrentSql = vi.spyOn(queryStore, "executeCurrentSql").mockImplementation(async () => {
+      if (activeTab.value) activeTab.value.result = { columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 };
+    });
+    vi.spyOn(useHistoryStore(), "add").mockResolvedValue(undefined);
+    vi.spyOn(useConnectionStore(), "refreshObjectListTreeNode").mockResolvedValue(undefined);
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+
+    await execution.tryExecute();
+
+    expect(execution.showSqlParameterDialog.value).toBe(false);
+    expect(execution.sqlParameterNames.value).toEqual([]);
+    expect(executeCurrentSql).toHaveBeenCalledWith(sql, {});
+  });
+
   it("sends Doris STRUCT DDL unchanged without opening the parameter dialog", async () => {
     const sql = `
       create table \`events\` (

--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -455,6 +455,39 @@ describe("extractSqlParameters", () => {
     `);
   });
 
+  it("ignores compact MySQL routine labels in cursor procedures", () => {
+    const sql = `
+      CREATE PROCEDURE process_orders()
+      BEGIN
+        DECLARE done INT DEFAULT FALSE;
+        DECLARE order_id INT;
+        DECLARE cur_orders CURSOR FOR SELECT id FROM orders;
+        DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+        OPEN cur_orders;
+        read_loop:LOOP
+          FETCH cur_orders INTO order_id;
+          IF done THEN
+            LEAVE read_loop;
+          END IF;
+        END LOOP read_loop;
+        CLOSE cur_orders;
+      END
+    `;
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual([]);
+    expect(substituteSqlParameters(sql, {}, { databaseType: "mysql" })).toBe(sql);
+  });
+
+  it("limits MySQL routine label handling to label contexts", () => {
+    const labels = "BEGIN outer_block:BEGIN retry_loop:WHILE ready DO repeat_block:REPEAT work_loop:LOOP END LOOP work_loop; END";
+
+    expect(extractSqlParameters(labels, { databaseType: "mysql" })).toEqual([]);
+    expect(extractSqlParameters("SELECT * FROM jobs WHERE state = :LOOP", { databaseType: "mysql" })).toEqual(["LOOP"]);
+    expect(extractSqlParameters("BEGIN SELECT :LOOP; END", { databaseType: "mysql" })).toEqual(["LOOP"]);
+    expect(extractSqlParameters("read_loop:LOOP")).toEqual(["LOOP"]);
+  });
+
   it("ignores HANA SQLScript variable references", () => {
     const sql = "DO BEGIN Dummy1 = SELECT 1 FROM DUMMY; SELECT * FROM :Dummy1; END";
     expect(extractSqlParameters(sql, { databaseType: "saphana" })).toEqual([]);

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -58,6 +58,9 @@ const PARAMETER_NAME_RE = /^[\p{L}_][\p{L}\p{N}_]*(?:\.[\p{L}_][\p{L}\p{N}_]*)*$
 const PARAMETER_NAME_START_RE = /[\p{L}_]/u;
 const PARAMETER_NAME_CHAR_RE = /[\p{L}\p{N}_]/u;
 const SQL_SERVER_TEMP_TABLE_CONTEXT_KEYWORDS = new Set(["table", "from", "join", "into", "update", "truncate"]);
+const MYSQL_ROUTINE_LABEL_STATEMENTS = new Set(["begin", "loop", "while", "repeat"]);
+const MYSQL_ROUTINE_LABEL_CONTEXTS = new Set(["begin", "then", "else", "do", "loop", "repeat"]);
+const MYSQL_ROUTINE_LABEL_RE = /(?:`(?:``|[^`])+`|[\p{L}_][\p{L}\p{N}_]*)$/u;
 const POSTGRES_QUESTION_PARAMETER_PREFIX_KEYWORDS = new Set([
   "all",
   "and",
@@ -431,7 +434,16 @@ function findSqlParameterOccurrences(sql: string, options?: SqlParameterOptions)
     }
     if (ch === ":" && supportsNamedParameters && isSyntaxEnabled("named")) {
       const name = readParameterName(sql, i + 1);
-      if (name && sql[i - 1] !== ":" && sql[i + 1] !== "=" && !complexTypeFieldSeparators.has(i) && !duckDbStructFieldSeparators.has(i) && !isDuckDbCompactPrefixAliasSeparator(sql, i, options?.databaseType) && !triggerPseudoRecordFieldStarts.has(i)) {
+      if (
+        name &&
+        sql[i - 1] !== ":" &&
+        sql[i + 1] !== "=" &&
+        !complexTypeFieldSeparators.has(i) &&
+        !duckDbStructFieldSeparators.has(i) &&
+        !isDuckDbCompactPrefixAliasSeparator(sql, i, options?.databaseType) &&
+        !triggerPseudoRecordFieldStarts.has(i) &&
+        !isMysqlRoutineLabelSeparator(sql, i, name, options?.databaseType)
+      ) {
         occurrences.push({
           key: name,
           name,
@@ -483,6 +495,16 @@ function findSqlParameterOccurrences(sql: string, options?: SqlParameterOptions)
   }
 
   return occurrences;
+}
+
+function isMysqlRoutineLabelSeparator(sql: string, colonIndex: number, followingName: string, databaseType?: DatabaseType): boolean {
+  if (databaseType !== "mysql" || !MYSQL_ROUTINE_LABEL_STATEMENTS.has(followingName.toLowerCase())) return false;
+
+  const label = sql.slice(0, colonIndex).match(MYSQL_ROUTINE_LABEL_RE);
+  if (!label) return false;
+  const labelStart = colonIndex - label[0].length;
+  const prefix = sql.slice(0, labelStart).trimEnd();
+  return prefix.length === 0 || prefix.endsWith(";") || MYSQL_ROUTINE_LABEL_CONTEXTS.has(previousKeyword(sql, labelStart));
 }
 
 function readMyBatisForeachAt(sql: string, start: number): { collection: string; render: MyBatisForeach; end: number } | null {


### PR DESCRIPTION
## 问题原因

MySQL/MariaDB 存储过程中的紧凑标签（例如 `read_loop:LOOP`）会被 SQL 参数解析器误识别为 `:LOOP` 参数。执行时因此弹出参数输入框，并在替换后破坏原始过程语句，最终导致游标过程执行报错。

## 修改内容

- 在 MySQL 参数解析中识别 `label:BEGIN`、`label:LOOP`、`label:WHILE`、`label:REPEAT` 过程标签
- 仅在合法的过程控制上下文中忽略标签，普通 `:LOOP` 参数仍正常工作
- 保持其他数据库的命名参数行为不变
- 增加参数解析和执行流程回归测试，确保执行游标过程时不再弹出参数窗口

## 测试

- 相关 Vitest：141 项通过
- `pnpm typecheck`
- `oxlint`
- `oxfmt --check`
- 真实 MySQL 9.6：创建并执行包含游标及 `read_loop:LOOP` 标签的存储过程，结果正确；测试对象已清理