### PR TITLE
✨ feat(meilisearch): 支持通过完整 URL 配置代理基础路径

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -354,7 +354,6 @@ const elasticsearchConnectionPorts = ref<Record<ElasticsearchConnectionMode, num
   direct: 9200,
   kibana: 5601,
 });
-
 function resetElasticsearchProxyFields(externalConfig?: unknown) {
   const mode = elasticsearchConnectionModeFromConfig(externalConfig);
   elasticsearchConnectionMode.value = mode;
@@ -603,6 +602,29 @@ function externalConfigRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...(value as Record<string, unknown>) } : {};
 }
 
+function meilisearchConnectionUrl(config: Pick<ConnectionConfig, "host" | "port" | "ssl" | "external_config">): string {
+  const host = config.host.trim();
+  if (!host) return "";
+
+  const scheme = config.ssl ? "https" : "http";
+  const endpointHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  const externalConfig = externalConfigRecord(config.external_config);
+  const storedBasePath = externalConfig.basePath ?? externalConfig.base_path;
+  const basePath = typeof storedBasePath === "string" && storedBasePath.startsWith("/") ? storedBasePath : "";
+
+  return `${scheme}://${endpointHost}:${config.port}${basePath}`;
+}
+
+function syncMeilisearchHostInput(config: Pick<ConnectionConfig, "host" | "port" | "ssl" | "external_config">) {
+  meilisearchHostInput.value = meilisearchConnectionUrl(config);
+  appliedMeilisearchHostInput.value = meilisearchHostInput.value;
+}
+
+function resetMeilisearchHostInput() {
+  meilisearchHostInput.value = "";
+  appliedMeilisearchHostInput.value = "";
+}
+
 function sqlServerPortExplicitFromConfig(config: Pick<ConnectionConfig, "db_type" | "external_config">): boolean {
   if (config.db_type !== "sqlserver") return false;
   const external = externalConfigRecord(config.external_config);
@@ -651,6 +673,8 @@ const selectedJdbcDriverPath = ref("");
 const jdbcManualClasspathOpen = ref(false);
 const connectionUrlInput = ref("");
 const appliedConnectionUrlInput = ref("");
+const meilisearchHostInput = ref("");
+const appliedMeilisearchHostInput = ref("");
 const oracleTnsAdminPath = ref("");
 const oceanbaseSubMode = ref<"mysql" | "oracle">("mysql");
 const h2ConnectionMode = ref<H2ConnectionMode>("file");
@@ -2319,7 +2343,6 @@ function applyProfile(val: string, preserveConnectionFields = false) {
   if (profile.type !== "elasticsearch" || previousDatabaseType !== "elasticsearch") {
     resetElasticsearchProxyFields();
   }
-
   if (!preserveConnectionFields) {
     oracleTnsAdminPath.value = "";
     form.value.port = profile.port;
@@ -2427,6 +2450,11 @@ function applyProfile(val: string, preserveConnectionFields = false) {
     }
     resetHiveKerberosFields(profile.type === "hive" || profile.type === "kyuubi" || profile.type === "impala" ? form.value : undefined);
   }
+  if (profile.type === "meilisearch") {
+    syncMeilisearchHostInput(form.value);
+  } else {
+    resetMeilisearchHostInput();
+  }
 }
 
 function switchOceanbaseMode(mode: "mysql" | "oracle") {
@@ -2520,6 +2548,11 @@ watch(
       productionProtectionEnabled.value = !!config.is_production || (config.production_databases?.length ?? 0) > 0;
       connectionUrlInput.value = config.db_type === "h2" && config.connection_string ? config.connection_string : "";
       appliedConnectionUrlInput.value = connectionUrlInput.value.trim();
+      if (config.db_type === "meilisearch") {
+        syncMeilisearchHostInput(config);
+      } else {
+        resetMeilisearchHostInput();
+      }
       if (config.db_type === "mq") {
         hydrateMqFields(config.external_config);
       } else {
@@ -3577,6 +3610,11 @@ function applyConnectionUrlToForm(input: string): boolean {
     const draft = parseConnectionDeepLink(input) ?? parseServiceConnectionUrl(input);
     if (draft) {
       applyConnectionDraftToForm({ ...draft, oneTime: undefined });
+      if (form.value.db_type === "meilisearch") {
+        syncMeilisearchHostInput(form.value);
+      } else {
+        resetMeilisearchHostInput();
+      }
       resetTestState();
       appliedConnectionUrlInput.value = input.trim();
       return true;
@@ -3586,6 +3624,11 @@ function applyConnectionUrlToForm(input: string): boolean {
     form.value = applyParsedConnectionUrl(form.value, parsed);
     if (form.value.db_type === "victoriametrics") {
       hydrateVictoriaMetricsFields(form.value.external_config);
+    }
+    if (form.value.db_type === "meilisearch") {
+      syncMeilisearchHostInput(form.value);
+    } else {
+      resetMeilisearchHostInput();
     }
     oracleTnsAdminPath.value = parseOracleTnsConnectionString(parsed.connectionString)?.tnsAdmin || "";
     selectedType.value = parsed.driverProfile;
@@ -3611,21 +3654,46 @@ function hasPendingConnectionUrlInput(): boolean {
   return !!url && url !== appliedConnectionUrlInput.value;
 }
 
+function hasPendingMeilisearchHostInput(): boolean {
+  const url = meilisearchHostInput.value.trim();
+  return url !== appliedMeilisearchHostInput.value;
+}
+
+function applyMeilisearchHostInput(): boolean {
+  try {
+    const input = meilisearchHostInput.value.trim();
+    form.value = applyParsedConnectionUrl(form.value, parseConnectionUrl(input, "meilisearch"));
+    appliedMeilisearchHostInput.value = input;
+    resetTestState();
+    return true;
+  } catch (e: any) {
+    toast(t("connection.parseConnectionUrlFailed", { message: e?.message || String(e) }), 5000);
+    return false;
+  }
+}
+
 function ensureConnectionHostResolvedFromUrl(): boolean {
-  if (!hasPendingConnectionUrlInput()) return true;
-  return applyConnectionUrlToForm(connectionUrlInput.value.trim());
+  if (hasPendingConnectionUrlInput() && !applyConnectionUrlToForm(connectionUrlInput.value.trim())) return false;
+  if (form.value.db_type === "meilisearch" && hasPendingMeilisearchHostInput()) return applyMeilisearchHostInput();
+  return true;
 }
 
 function formValueForSubmit(): Omit<ConnectionConfig, "id"> {
   const url = connectionUrlInput.value.trim();
-  if (!url || url === appliedConnectionUrlInput.value) return form.value;
+  if (url && url !== appliedConnectionUrlInput.value) {
+    const draft = parseConnectionDeepLink(url);
+    if (draft) {
+      return applyConnectionDraftToConfig(form.value, { ...draft, oneTime: undefined });
+    }
 
-  const draft = parseConnectionDeepLink(url);
-  if (draft) {
-    return applyConnectionDraftToConfig(form.value, { ...draft, oneTime: undefined });
+    return applyParsedConnectionUrl(form.value, parseConnectionUrl(url, selectedType.value));
   }
 
-  return applyParsedConnectionUrl(form.value, parseConnectionUrl(url, selectedType.value));
+  if (form.value.db_type === "meilisearch" && hasPendingMeilisearchHostInput()) {
+    return applyParsedConnectionUrl(form.value, parseConnectionUrl(meilisearchHostInput.value.trim(), "meilisearch"));
+  }
+
+  return form.value;
 }
 
 function applyDremioJdbcMetadata(config: LegacyConnectionConfig) {
@@ -3902,7 +3970,6 @@ function connectionConfigForSubmit(id: string, generatedName = ""): ConnectionCo
     config.username = "";
     config.password = config.password.trim();
     config.database = undefined;
-    config.external_config = undefined;
   } else if (config.db_type === "sqlserver") {
     config.external_config = sqlServerPortExplicitFromConfig(config) ? { portExplicit: true } : undefined;
   } else if (supportsGaussdbIdentifierQuoteStyle(config)) {
@@ -4754,6 +4821,7 @@ function resetForm() {
   selectedJdbcDriverPath.value = "";
   connectionUrlInput.value = "";
   appliedConnectionUrlInput.value = "";
+  resetMeilisearchHostInput();
   oracleTnsAdminPath.value = "";
   dialogStep.value = "select";
   dbSearchQuery.value = "";
@@ -6985,6 +7053,10 @@ function openExternalUrl(url: string) {
                       </div>
                     </div>
                   </template>
+                  <div v-else-if="form.db_type === 'meilisearch'" class="grid grid-cols-4 items-center gap-4">
+                    <Label :class="connectionLabelClass">{{ t("connection.host") }}</Label>
+                    <Input v-model="meilisearchHostInput" class="col-span-3" :placeholder="connectionUrlPlaceholder" @input="resetTestState" />
+                  </div>
                   <div v-else-if="form.db_type !== 'oracle' || form.oracle_connection_type !== 'tns'" class="grid grid-cols-4 items-center gap-4">
                     <Label :class="connectionLabelClass">{{ form.db_type === "elasticsearch" && elasticsearchConnectionMode === "kibana" ? t("connection.elasticsearchKibanaHost") : t("connection.host") }}</Label>
                     <Input v-model="form.host" class="col-span-2" />

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -33,7 +33,7 @@ import { useToast } from "@/composables/useToast";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
 import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
-import { applyParsedConnectionUrl, normalizeMongoConnectionString, parseConnectionUrl } from "@/lib/connection/connectionUrl";
+import { applyMeilisearchBasePathToExternalConfig, applyParsedConnectionUrl, normalizeMongoConnectionString, parseConnectionUrl } from "@/lib/connection/connectionUrl";
 import { MAX_CONNECT_TIMEOUT_SECS, MAX_QUERY_TIMEOUT_SECS } from "@/lib/connection/timeoutLimits";
 import { buildOracleTnsConnectionString, normalizeOracleTnsAdminPath, parseOracleTnsConnectionString } from "@/lib/connection/oracleTnsConnection";
 import { connectionDeepLinkServiceHydrationValue, parseConnectionDeepLink, parseServiceConnectionUrl, type ConnectionDeepLinkDraft } from "@/lib/connection/connectionDeepLink";
@@ -602,7 +602,7 @@ function externalConfigRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...(value as Record<string, unknown>) } : {};
 }
 
-function meilisearchConnectionUrl(config: Pick<ConnectionConfig, "host" | "port" | "ssl" | "external_config">): string {
+function meilisearchConnectionUrl(config: Pick<ConnectionConfig, "host" | "port" | "ssl" | "url_params" | "external_config">): string {
   const host = config.host.trim();
   if (!host) return "";
 
@@ -610,12 +610,14 @@ function meilisearchConnectionUrl(config: Pick<ConnectionConfig, "host" | "port"
   const endpointHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
   const externalConfig = externalConfigRecord(config.external_config);
   const storedBasePath = externalConfig.basePath ?? externalConfig.base_path;
-  const basePath = typeof storedBasePath === "string" && storedBasePath.startsWith("/") ? storedBasePath : "";
+  const basePathSegments = typeof storedBasePath === "string" ? storedBasePath.trim().split("/").filter(Boolean) : [];
+  const basePath = basePathSegments.length ? `/${basePathSegments.join("/")}` : "";
+  const urlParams = config.url_params?.trim().replace(/^\?/, "") || "";
 
-  return `${scheme}://${endpointHost}:${config.port}${basePath}`;
+  return `${scheme}://${endpointHost}:${config.port}${basePath}${urlParams ? `?${urlParams}` : ""}`;
 }
 
-function syncMeilisearchHostInput(config: Pick<ConnectionConfig, "host" | "port" | "ssl" | "external_config">) {
+function syncMeilisearchHostInput(config: Pick<ConnectionConfig, "host" | "port" | "ssl" | "url_params" | "external_config">) {
   meilisearchHostInput.value = meilisearchConnectionUrl(config);
   appliedMeilisearchHostInput.value = meilisearchHostInput.value;
 }
@@ -2337,7 +2339,8 @@ function applyProfile(val: string, preserveConnectionFields = false) {
   form.value.db_type = profile.type;
   form.value.driver_profile = val;
   form.value.driver_label = isCustomCompatibleProfile() ? customDriverName.value.trim() || profile.label : profile.label;
-  if (profile.type !== "sqlserver") {
+  const preserveMeilisearchConfig = preserveConnectionFields && previousDatabaseType === "meilisearch" && profile.type === "meilisearch";
+  if (profile.type !== "sqlserver" && !preserveMeilisearchConfig) {
     form.value.external_config = undefined;
   }
   if (profile.type !== "elasticsearch" || previousDatabaseType !== "elasticsearch") {
@@ -4878,6 +4881,7 @@ function applyConnectionDraftToConfig(config: Omit<ConnectionConfig, "id">, draf
     database: draft.database ?? config.database,
     url_params: draft.urlParams ?? config.url_params,
     ssl: draft.ssl ?? config.ssl,
+    external_config: draft.dbType === "meilisearch" && draft.basePath !== undefined ? applyMeilisearchBasePathToExternalConfig(config.external_config, draft.basePath) : config.external_config,
     connection_string: draft.connectionString ?? config.connection_string,
     oracle_connection_type: draft.oracleConnectionType ?? config.oracle_connection_type,
     one_time: draft.oneTime || undefined,

--- a/apps/desktop/src/lib/__tests__/connection/connectionUrl.meilisearch.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionUrl.meilisearch.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyParsedConnectionUrl, connectionProfileForScheme, parseConnectionUrl } from "@/lib/connection/connectionUrl";
+import { parseConnectionDeepLink } from "@/lib/connection/connectionDeepLink";
 import type { ConnectionConfig } from "@/types/database";
 
 describe("Meilisearch connection URLs", () => {
@@ -87,6 +88,18 @@ describe("Meilisearch connection URLs", () => {
 
     expect(parsed.basePath).toBe("");
     expect(config.external_config).toEqual({ custom: true });
+  });
+
+  it("preserves the proxy path when a Meilisearch URL arrives through a deep link", () => {
+    const link = new URL("dbx://connection/new");
+    link.searchParams.set("type", "meilisearch");
+    link.searchParams.set("url", "https://search.example.com/gateway/meili?insecure=true");
+
+    expect(parseConnectionDeepLink(link.toString())).toMatchObject({
+      dbType: "meilisearch",
+      basePath: "/gateway/meili",
+      urlParams: "insecure=true",
+    });
   });
 
   it("exposes the Meilisearch scheme profile", () => {

--- a/apps/desktop/src/lib/__tests__/connection/connectionUrl.meilisearch.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionUrl.meilisearch.spec.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { connectionProfileForScheme, parseConnectionUrl } from "@/lib/connection/connectionUrl";
+import { applyParsedConnectionUrl, connectionProfileForScheme, parseConnectionUrl } from "@/lib/connection/connectionUrl";
+import type { ConnectionConfig } from "@/types/database";
 
 describe("Meilisearch connection URLs", () => {
-  it("parses the dedicated scheme with the default port and API key", () => {
-    expect(parseConnectionUrl("meilisearch://:secret@search.example.com")).toMatchObject({
+  it("rejects an empty host URL", () => {
+    expect(() => parseConnectionUrl("", "meilisearch")).toThrow("Connection URL is empty");
+  });
+
+  it("parses the dedicated scheme with the default port, API key, and proxy path", () => {
+    expect(parseConnectionUrl("meilisearch://:secret@search.example.com/gateway/meili")).toMatchObject({
       dbType: "meilisearch",
       driverProfile: "meilisearch",
       driverLabel: "Meilisearch",
@@ -12,6 +17,7 @@ describe("Meilisearch connection URLs", () => {
       username: "",
       password: "secret",
       ssl: false,
+      basePath: "/gateway/meili",
     });
   });
 
@@ -23,6 +29,64 @@ describe("Meilisearch connection URLs", () => {
       urlParams: "insecure=true",
       ssl: true,
     });
+  });
+
+  it.each([
+    ["http://search.example.com/gateway/meili/", 80, false],
+    ["https://search.example.com/gateway/meili", 443, true],
+    ["https://search.example.com:8443/gateway/meili", 8443, true],
+  ])("parses proxy URL %s", (url, port, ssl) => {
+    expect(parseConnectionUrl(url, "meilisearch")).toMatchObject({
+      dbType: "meilisearch",
+      host: "search.example.com",
+      port,
+      ssl,
+      database: undefined,
+      basePath: "/gateway/meili",
+    });
+  });
+
+  it("stores the proxy path in canonical external config without dropping other fields", () => {
+    const parsed = parseConnectionUrl("http://search.example.com/gateway/meili", "meilisearch");
+    const config = applyParsedConnectionUrl(
+      {
+        db_type: "meilisearch",
+        driver_profile: "meilisearch",
+        driver_label: "Meilisearch",
+        host: "localhost",
+        port: 7700,
+        username: "",
+        password: "",
+        url_params: "",
+        ssl: false,
+        external_config: { base_path: "/legacy", custom: true },
+      } as Omit<ConnectionConfig, "id">,
+      parsed,
+    );
+
+    expect(config.external_config).toEqual({ basePath: "/gateway/meili", custom: true });
+  });
+
+  it("clears stale proxy paths when the parsed URL uses the root path", () => {
+    const parsed = parseConnectionUrl("http://search.example.com/", "meilisearch");
+    const config = applyParsedConnectionUrl(
+      {
+        db_type: "meilisearch",
+        driver_profile: "meilisearch",
+        driver_label: "Meilisearch",
+        host: "localhost",
+        port: 7700,
+        username: "",
+        password: "",
+        url_params: "",
+        ssl: false,
+        external_config: { basePath: "/old", base_path: "/legacy", custom: true },
+      } as Omit<ConnectionConfig, "id">,
+      parsed,
+    );
+
+    expect(parsed.basePath).toBe("");
+    expect(config.external_config).toEqual({ custom: true });
   });
 
   it("exposes the Meilisearch scheme profile", () => {

--- a/apps/desktop/src/lib/connection/connectionDeepLink.ts
+++ b/apps/desktop/src/lib/connection/connectionDeepLink.ts
@@ -23,6 +23,7 @@ export interface ConnectionDeepLinkDraft {
   password?: string;
   database?: string;
   urlParams?: string;
+  basePath?: string;
   ssl?: boolean;
   connectionString?: string;
   oracleConnectionType?: "service_name" | "sid";
@@ -188,6 +189,7 @@ function draftFromConnectionUrl(value: string, preferredProfile?: string): Conne
     password: parsed.password,
     database: parsed.database,
     urlParams: parsed.urlParams,
+    basePath: parsed.basePath,
     ssl: parsed.ssl,
     connectionString: parsed.connectionString,
     oracleConnectionType: parsed.oracleConnectionType,

--- a/apps/desktop/src/lib/connection/connectionPresentation.ts
+++ b/apps/desktop/src/lib/connection/connectionPresentation.ts
@@ -208,12 +208,14 @@ export function connectionUrlPlaceholder(dbType: DatabaseType): string {
 
     case "elasticsearch":
     case "easysearch":
-    case "meilisearch":
     case "qdrant":
     case "milvus":
     case "weaviate":
     case "chromadb":
       return "http://user:password@host:port";
+
+    case "meilisearch":
+      return "http://host:port/base/path";
 
     case "dameng":
       return "dm://user:password@host:port";

--- a/apps/desktop/src/lib/connection/connectionUrl.ts
+++ b/apps/desktop/src/lib/connection/connectionUrl.ts
@@ -716,6 +716,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+export function applyMeilisearchBasePathToExternalConfig(existing: unknown, basePath: string | undefined): unknown {
+  const next = isRecord(existing) ? { ...existing } : {};
+  delete next.base_path;
+  if (basePath) {
+    next.basePath = basePath;
+  } else {
+    delete next.basePath;
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
 function parsedExternalConfig(existing: unknown, parsed: ParsedConnectionUrl): unknown {
   if (parsed.dbType === "victoriametrics") {
     const next = isRecord(existing) ? { ...existing } : {};
@@ -723,14 +734,7 @@ function parsedExternalConfig(existing: unknown, parsed: ParsedConnectionUrl): u
     return next;
   }
   if (parsed.dbType === "meilisearch") {
-    const next = isRecord(existing) ? { ...existing } : {};
-    delete next.base_path;
-    if (parsed.basePath) {
-      next.basePath = parsed.basePath;
-    } else {
-      delete next.basePath;
-    }
-    return Object.keys(next).length > 0 ? next : undefined;
+    return applyMeilisearchBasePathToExternalConfig(existing, parsed.basePath);
   }
   if (parsed.dbType !== "sqlserver") return existing;
 

--- a/apps/desktop/src/lib/connection/connectionUrl.ts
+++ b/apps/desktop/src/lib/connection/connectionUrl.ts
@@ -19,6 +19,7 @@ export interface ParsedConnectionUrl {
   useMongoUrl?: boolean;
   portExplicit?: boolean;
   apiPath?: string;
+  basePath?: string;
 }
 
 export type ConnectionProfile = {
@@ -651,20 +652,24 @@ export function parseConnectionUrl(value: string, preferredProfile?: string): Pa
     };
   }
 
+  const isMeilisearch = profile.type === "meilisearch";
+  const defaultPort = isMeilisearch && scheme === "http" ? 80 : isMeilisearch && scheme === "https" ? 443 : profile.defaultPort;
+
   return {
     ...(name ? { name } : {}),
     dbType: profile.type,
     driverProfile: profile.profile,
     driverLabel: profile.label,
     host: parsed.hostname,
-    port: parsed.port ? Number(parsed.port) : profile.defaultPort,
+    port: parsed.port ? Number(parsed.port) : defaultPort,
     ...(profile.type === "sqlserver" && parsed.port ? { portExplicit: true } : {}),
     username: mysqlCredentials?.username ?? decodeUrlPart(parsed.username),
     password: mysqlCredentials?.password ?? decodeUrlPart(parsed.password),
-    database: profile.type === "victoriametrics" ? "metrics" : databaseFromPath(parsed.pathname),
+    database: profile.type === "victoriametrics" ? "metrics" : isMeilisearch ? undefined : databaseFromPath(parsed.pathname),
     urlParams: effectiveUrlParams,
     ssl: scheme === "rediss" || scheme === "https" || urlParamsRequireTls(profile.type, effectiveUrlParams) || (profile.type === "mysql" && isTidbCloudHost(parsed.hostname)),
     ...(profile.type === "victoriametrics" ? { apiPath: parsed.pathname.replace(/\/+$/, "") } : {}),
+    ...(isMeilisearch ? { basePath: parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/+$/, "") } : {}),
   };
 }
 
@@ -716,6 +721,16 @@ function parsedExternalConfig(existing: unknown, parsed: ParsedConnectionUrl): u
     const next = isRecord(existing) ? { ...existing } : {};
     next.apiPath = parsed.apiPath || "/prometheus";
     return next;
+  }
+  if (parsed.dbType === "meilisearch") {
+    const next = isRecord(existing) ? { ...existing } : {};
+    delete next.base_path;
+    if (parsed.basePath) {
+      next.basePath = parsed.basePath;
+    } else {
+      delete next.basePath;
+    }
+    return Object.keys(next).length > 0 ? next : undefined;
   }
   if (parsed.dbType !== "sqlserver") return existing;
 

--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -2064,11 +2064,12 @@ impl AppState {
                 PoolKind::Easysearch(client)
             }
             DatabaseType::Meilisearch => {
-                let client = db::meilisearch_driver::MeilisearchClient::new(
+                let client = db::meilisearch_driver::MeilisearchClient::new_for_config(
                     &url,
                     Some(&db_config.password),
                     db_config.ssl,
                     db_config.url_params.as_deref(),
+                    db_config.external_config.as_ref(),
                     connect_timeout,
                 )?;
                 db::meilisearch_driver::test_connection(&client, connect_timeout).await?;

--- a/crates/dbx-core/src/db/meilisearch_driver.rs
+++ b/crates/dbx-core/src/db/meilisearch_driver.rs
@@ -57,6 +57,18 @@ impl MeilisearchClient {
         Ok(Self { http, base_url: url.trim_end_matches('/').to_string(), api_key })
     }
 
+    pub fn new_for_config(
+        url: &str,
+        api_key: Option<&str>,
+        tls_enabled: bool,
+        url_params: Option<&str>,
+        external_config: Option<&Value>,
+        timeout: Duration,
+    ) -> Result<Self, String> {
+        let base_url = meilisearch_base_url(url, external_config)?;
+        Self::new(&base_url, api_key, tls_enabled, url_params, timeout)
+    }
+
     fn request(&self, method: Method, path: &str) -> RequestBuilder {
         let request = self.http.request(method, format!("{}{}", self.base_url, path));
         match self.api_key.as_deref() {
@@ -76,6 +88,31 @@ impl MeilisearchClient {
     fn delete(&self, path: &str) -> RequestBuilder {
         self.request(Method::DELETE, path)
     }
+}
+
+fn meilisearch_base_url(url: &str, external_config: Option<&Value>) -> Result<String, String> {
+    let url = url.trim_end_matches('/');
+    let Some(raw_base_path) = external_config
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("basePath").or_else(|| config.get("base_path")))
+        .and_then(Value::as_str)
+    else {
+        return Ok(url.to_string());
+    };
+
+    let input = raw_base_path.trim();
+    if input.is_empty() || input == "/" {
+        return Ok(url.to_string());
+    }
+    if input.contains(['?', '#']) {
+        return Err("Meilisearch base path cannot contain a query or fragment".to_string());
+    }
+
+    let segments = input.split('/').filter(|segment| !segment.is_empty()).collect::<Vec<_>>();
+    if segments.iter().any(|segment| matches!(*segment, "." | "..")) {
+        return Err("Meilisearch base path cannot contain '.' or '..' segments".to_string());
+    }
+    Ok(format!("{url}/{}", segments.join("/")))
 }
 
 fn meilisearch_accept_invalid_certs(tls_enabled: bool, url_params: Option<&str>) -> bool {
@@ -762,9 +799,54 @@ fn raw_response_result(status: u16, body: String, start: Instant, truncated: boo
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_bounded_rest_body, filter_expression, meilisearch_sort_from_request, parse_rest_request_line};
+    use super::{
+        decode_bounded_rest_body, filter_expression, meilisearch_base_url, meilisearch_sort_from_request,
+        parse_rest_request_line, MeilisearchClient,
+    };
     use reqwest::Method;
+    use serde_json::json;
+    use std::time::Duration;
 
+    #[test]
+    fn normalizes_canonical_and_legacy_proxy_base_paths() {
+        assert_eq!(
+            meilisearch_base_url("http://search.example.com:7700/", Some(&json!({ "basePath": "/gateway/meili/" })))
+                .unwrap(),
+            "http://search.example.com:7700/gateway/meili"
+        );
+        assert_eq!(
+            meilisearch_base_url("https://search.example.com", Some(&json!({ "base_path": "gateway//meili" })))
+                .unwrap(),
+            "https://search.example.com/gateway/meili"
+        );
+    }
+
+    #[test]
+    fn keeps_the_origin_unchanged_for_empty_proxy_base_paths() {
+        for external_config in
+            [None, Some(json!({})), Some(json!({ "basePath": "" })), Some(json!({ "basePath": "/" }))]
+        {
+            assert_eq!(
+                meilisearch_base_url("http://search.example.com:7700/", external_config.as_ref()).unwrap(),
+                "http://search.example.com:7700"
+            );
+        }
+    }
+
+    #[test]
+    fn config_aware_client_uses_proxy_base_path() {
+        let client = MeilisearchClient::new_for_config(
+            "https://search.example.com:8443/",
+            None,
+            true,
+            None,
+            Some(&json!({ "basePath": "/gateway/meili/" })),
+            Duration::from_secs(1),
+        )
+        .unwrap();
+
+        assert_eq!(client.base_url, "https://search.example.com:8443/gateway/meili");
+    }
     #[test]
     fn translates_document_filters_to_meilisearch_syntax() {
         let filter = serde_json::json!({

--- a/crates/dbx-core/src/db/meilisearch_driver.rs
+++ b/crates/dbx-core/src/db/meilisearch_driver.rs
@@ -1,4 +1,4 @@
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::{Client as HttpClient, Method, RequestBuilder, StatusCode};
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -769,6 +769,18 @@ fn parse_rest_request_line(line: &str) -> Result<(Method, String), String> {
     if !path.starts_with('/') {
         return Err("Meilisearch REST path must start with '/'".to_string());
     }
+    if path.contains('#') {
+        return Err("Meilisearch REST path must not contain a fragment".to_string());
+    }
+    let raw_path = path.split_once('?').map_or(path, |(path, _)| path);
+    for segment in raw_path.split('/') {
+        let decoded = percent_decode_str(segment)
+            .decode_utf8()
+            .map_err(|_| "Meilisearch REST path contains invalid UTF-8 escaping".to_string())?;
+        if matches!(decoded.as_ref(), "." | "..") || decoded.contains(['/', '\\']) {
+            return Err("Meilisearch REST path cannot contain traversal segments".to_string());
+        }
+    }
     Ok((method, path.to_string()))
 }
 
@@ -890,6 +902,13 @@ mod tests {
     fn parses_rest_request_lines() {
         assert_eq!(parse_rest_request_line("GET /version").unwrap(), (Method::GET, "/version".to_string()));
         assert_eq!(parse_rest_request_line("/health").unwrap(), (Method::GET, "/health".to_string()));
+        assert_eq!(
+            parse_rest_request_line("GET /indexes/movies?limit=1").unwrap(),
+            (Method::GET, "/indexes/movies?limit=1".to_string())
+        );
+        assert!(parse_rest_request_line("GET /../version").unwrap_err().contains("traversal"));
+        assert!(parse_rest_request_line("GET /gateway/%2e%2e/version").unwrap_err().contains("traversal"));
+        assert!(parse_rest_request_line("GET /gateway/%2e%2e%2fversion").unwrap_err().contains("traversal"));
         assert!(parse_rest_request_line("CONNECT /health")
             .unwrap_err()
             .contains("Unsupported Meilisearch HTTP method"));

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -1158,11 +1158,12 @@ async fn test_connection_with_info_inner(
                     .map(|_| "Connection successful".to_string())
             }
             DatabaseType::Meilisearch => {
-                let client = db::meilisearch_driver::MeilisearchClient::new(
+                let client = db::meilisearch_driver::MeilisearchClient::new_for_config(
                     &url,
                     Some(&config.password),
                     config.ssl,
                     config.url_params.as_deref(),
+                    config.external_config.as_ref(),
                     connect_timeout,
                 )?;
                 db::meilisearch_driver::test_connection(&client, connect_timeout)
@@ -1560,11 +1561,12 @@ pub async fn connect_db(
             PoolKind::Easysearch(client)
         }
         DatabaseType::Meilisearch => {
-            let client = db::meilisearch_driver::MeilisearchClient::new(
+            let client = db::meilisearch_driver::MeilisearchClient::new_for_config(
                 &url,
                 Some(&db_config.password),
                 db_config.ssl,
                 db_config.url_params.as_deref(),
+                db_config.external_config.as_ref(),
                 connect_timeout,
             )?;
             db::meilisearch_driver::test_connection(&client, connect_timeout).await?;


### PR DESCRIPTION
## 变更说明

Meilisearch 现在支持通过完整 HTTP(S) URL 配置反向代理基础路径，例如 `https://host/meili`。

- 从完整主机 URL 解析协议、端口和路径；路径保存为 `external_config.basePath`
- HTTP/HTTPS 未显式指定端口时，Meilisearch 分别使用 80/443；`meilisearch://` 仍保持 7700
- Core、连接测试和 Tauri 连接入口统一在请求路径前应用基础路径
- 编辑已有连接时显示完整主机 URL；空主机将阻止保存或测试
- 兼容已有根路径连接和旧 `base_path` 配置

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="560" height="696" alt="image" src="https://github.com/user-attachments/assets/ede05bec-7b43-4c2a-bf87-ce12f3a0b1e3" />



## 验证

- [ ] `make check` 通过（未运行）
- [ ] `make cargo-check-fast` 通过（未运行）
- [x] 相关测试通过
  - `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/connectionUrl.meilisearch.spec.ts`（9/9）
  - `cargo test -p dbx-core meilisearch_driver`（9/9）
  - `pnpm typecheck`
  - `cargo check -p dbx --lib`
  - `git diff --check`
  - 本地 NGINX `/meili/health` 反代验证返回 HTTP 200

## 关联 Issue

Close #6262