### PR TITLE
Fix：避免连接超时重复显示超时设置按钮

### DIFF
--- a/apps/desktop/src/components/common/QueryErrorActions.vue
+++ b/apps/desktop/src/components/common/QueryErrorActions.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { Bot, Wrench } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "@/components/ui/button";
@@ -18,14 +19,16 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+const showConnectionTimeout = computed(() => !!props.connectionId && isConnectionTimeoutErrorMessage(props.errorMessage, props.backendError));
+const showQueryTimeout = computed(() => !!props.connectionId && !showConnectionTimeout.value && isQueryTimeoutErrorMessage(props.errorMessage, props.backendError));
 </script>
 
 <template>
-  <Button v-if="connectionId && isConnectionTimeoutErrorMessage(errorMessage, backendError)" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeConnectionTimeout')">
+  <Button v-if="showConnectionTimeout" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeConnectionTimeout')">
     <Wrench class="h-3.5 w-3.5" />
     {{ t("editor.changeConnectionTimeout") }}
   </Button>
-  <Button v-if="connectionId && isQueryTimeoutErrorMessage(errorMessage, backendError)" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeQueryTimeout')">
+  <Button v-if="showQueryTimeout" variant="outline" size="sm" class="h-7 gap-1.5 px-2.5 text-xs" @click="emit('changeQueryTimeout')">
     <Wrench class="h-3.5 w-3.5" />
     {{ t("editor.changeQueryTimeout") }}
   </Button>

--- a/apps/desktop/src/components/common/__tests__/QueryErrorActions.spec.ts
+++ b/apps/desktop/src/components/common/__tests__/QueryErrorActions.spec.ts
@@ -49,4 +49,12 @@ describe("QueryErrorActions", () => {
     expect(labels).toContain("Change connection timeout");
     expect(labels).not.toContain("Change query timeout");
   });
+
+  it("does not offer query timeout settings for non-query Agent RPC stages", async () => {
+    for (const stage of ["request", "validate", "cancel", "close"]) {
+      const { host } = await mountActions(`Agent RPC call timed out at ${stage}`);
+
+      expect(host.textContent).not.toContain("Change query timeout");
+    }
+  });
 });

--- a/apps/desktop/src/components/common/__tests__/QueryErrorActions.spec.ts
+++ b/apps/desktop/src/components/common/__tests__/QueryErrorActions.spec.ts
@@ -41,4 +41,12 @@ describe("QueryErrorActions", () => {
     expect(host.textContent).not.toContain("Change connection timeout");
     expect(host.textContent).toContain("Change query timeout");
   });
+
+  it("shows only connection timeout settings for connect-stage agent RPC timeouts", async () => {
+    const { host } = await mountActions("Agent RPC call timed out at connect");
+    const labels = Array.from(host.querySelectorAll("button"), (button) => button.textContent?.trim());
+
+    expect(labels).toContain("Change connection timeout");
+    expect(labels).not.toContain("Change query timeout");
+  });
 });

--- a/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
@@ -64,11 +64,16 @@ describe("isQueryTimeoutErrorMessage", () => {
     expect(isQueryTimeoutErrorMessage("Agent RPC error (-1): Agent RPC call timed out (120s)")).toBe(true);
   });
 
-  it("does not classify connect-stage agent RPC timeouts as query timeouts", () => {
-    const message = "Agent RPC call timed out at connect";
+  it("classifies only execute and fetch Agent RPC stages as query timeouts", () => {
+    for (const stage of ["execute", "fetch"]) {
+      expect(isQueryTimeoutErrorMessage(`Agent RPC call timed out at ${stage}`)).toBe(true);
+    }
 
-    expect(isConnectionTimeoutErrorMessage(message)).toBe(true);
-    expect(isQueryTimeoutErrorMessage(message)).toBe(false);
+    for (const stage of ["request", "checkout", "connect", "validate", "cancel", "close"]) {
+      expect(isQueryTimeoutErrorMessage(`Agent RPC call timed out at ${stage}`)).toBe(false);
+    }
+
+    expect(isConnectionTimeoutErrorMessage("Agent RPC call timed out at connect")).toBe(true);
   });
 
   it("detects structured query operation timeouts before localized text matching", () => {

--- a/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/queryError.spec.ts
@@ -64,6 +64,13 @@ describe("isQueryTimeoutErrorMessage", () => {
     expect(isQueryTimeoutErrorMessage("Agent RPC error (-1): Agent RPC call timed out (120s)")).toBe(true);
   });
 
+  it("does not classify connect-stage agent RPC timeouts as query timeouts", () => {
+    const message = "Agent RPC call timed out at connect";
+
+    expect(isConnectionTimeoutErrorMessage(message)).toBe(true);
+    expect(isQueryTimeoutErrorMessage(message)).toBe(false);
+  });
+
   it("detects structured query operation timeouts before localized text matching", () => {
     const timeoutError = {
       version: 1,

--- a/apps/desktop/src/lib/sql/queryError.ts
+++ b/apps/desktop/src/lib/sql/queryError.ts
@@ -26,8 +26,11 @@ export function isQueryTimeoutErrorMessage(message: string, backendError?: Backe
   // Agent RPC client-side timeout (tokio::time::timeout in agent_driver.rs). This is the
   // fallback when JDBC setQueryTimeout never fires (unsupported/unresponsive driver), so the
   // backend already treats it as a query timeout (is_agent_rpc_timeout_error in query.rs) —
-  // surface the same action here to stay consistent with the backend.
-  if (/\bagent rpc call timed out\b/.test(lower)) return true;
+  // surface the same action here to stay consistent with the backend. Connection and other
+  // infrastructure stages must be excluded first because their messages can share this prefix.
+  if (/\bagent rpc call timed out\b/.test(lower)) {
+    return !/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower);
+  }
   if (/\b(?:canceling|cancelling|canceled|cancelled)\b[\s\S]{0,80}\bstatement\b[\s\S]{0,80}\btimeout\b/.test(lower)) return true;
   if (/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower)) return false;
   return (

--- a/apps/desktop/src/lib/sql/queryError.ts
+++ b/apps/desktop/src/lib/sql/queryError.ts
@@ -28,8 +28,10 @@ export function isQueryTimeoutErrorMessage(message: string, backendError?: Backe
   // backend already treats it as a query timeout (is_agent_rpc_timeout_error in query.rs) —
   // surface the same action here to stay consistent with the backend. Connection and other
   // infrastructure stages must be excluded first because their messages can share this prefix.
-  if (/\bagent rpc call timed out\b/.test(lower)) {
-    return !/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower);
+  const agentTimeout = /\bagent rpc call timed out(?: at ([a-z_]+))?\b/.exec(lower);
+  if (agentTimeout) {
+    const stage = agentTimeout[1];
+    return stage === undefined || QUERY_TIMEOUT_STAGES.has(stage);
   }
   if (/\b(?:canceling|cancelling|canceled|cancelled)\b[\s\S]{0,80}\bstatement\b[\s\S]{0,80}\btimeout\b/.test(lower)) return true;
   if (/\b(?:connection|connect|pool|checkout|metadata|loading|health check|cancel request|ssh|tunnel)\b/.test(lower)) return false;


### PR DESCRIPTION
## 问题

连接阶段的 `Agent RPC call timed out at connect` 同时被识别为连接超时和查询超时，错误页因此重复显示两个超时设置按钮。

## 修改

- 带连接、元数据等基础设施上下文的 Agent RPC 超时不再归类为查询超时
- 错误页增加互斥保护，连接超时按钮出现时不再同时显示查询超时按钮
- 补充 issue 原始报错的分类与组件回归测试

## 验证

- `pnpm test`（999 个测试文件、9517 项测试通过）
- `pnpm typecheck`
- `pnpm build`

Related to #6400