### PR TITLE
feat(sidebar): put close database connection first in context menu

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -4665,8 +4665,8 @@ function buildDatabaseSidebarMenu(context: SidebarMenuFactoryContext): boolean {
       return true;
     }
     if (canCloseDatabaseConnection.value) {
-      items.push({ label: t("contextMenu.closeDatabaseConnection"), action: closeDatabaseConnection, icon: Unplug });
-      items.push({ label: "", separator: true });
+      items.unshift({ label: "", separator: true });
+      items.unshift({ label: t("contextMenu.closeDatabaseConnection"), action: closeDatabaseConnection, icon: Unplug });
     }
     items.push(copyNameMenuItem());
     items.push({ label: "", separator: true });


### PR DESCRIPTION
## What

将已打开 database 节点的右键菜单首项由「置顶」调整为「关闭数据库连接」,置顶作为低频操作后移。

Closes #6268

## Why

用户反馈(见 issue):置顶是低频操作,关闭数据库连接是高频操作,放在首项更顺手。

## Changes

- `apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue`:在 `buildDatabaseSidebarMenu` 中将 `closeDatabaseConnection` 项由 `items.push` 改为两次 `items.unshift`,插入菜单最前。
- 仅对「已打开的 database 节点」生效(`canCloseDatabaseConnection` 仅对 `database` 类型为真);connection / schema / 未打开的 database / 其他对象节点的菜单顺序保持不变。

渲染顺序(已打开 database 右键菜单):关闭数据库连接 → 分隔线 → 置顶 → …

## Verification

- `pnpm typecheck`:通过
- `pnpm lint` + `oxfmt --check`:通过
- `pnpm test`(sidebar 套件 + docsMenuPlacement):44 文件 / 229 用例全通过
- 开发环境手动验证:右键已打开的数据库节点,「关闭数据库连接」现为第一项

## Checklist

- [x] 改动聚焦,无无关变更
- [x] `make check` 对应项已跑(typecheck / lint / test)
- [x] 关联 issue #6268