### PR TITLE
Fix：兼容腾讯云 MySQL 列存引擎的大字段预览

### DIFF
--- a/crates/dbx-core/src/sql_dialect/table_select.rs
+++ b/crates/dbx-core/src/sql_dialect/table_select.rs
@@ -148,7 +148,7 @@ fn build_large_value_preview_columns(options: &TableDataSelectSqlOptions) -> Opt
             _ => return None,
         };
         let marker = if database_type == Some(DatabaseType::Mysql) {
-            format!("CONCAT('{marker_kind}:{preview_size}:', OCTET_LENGTH({quoted})) AS {marker_alias}")
+            format!("CONCAT('{marker_kind}:{preview_size}:', LENGTH({quoted})) AS {marker_alias}")
         } else {
             format!("'{marker_kind}:{preview_size}' AS {marker_alias}")
         };

--- a/crates/dbx-core/src/sql_dialect/tests.rs
+++ b/crates/dbx-core/src/sql_dialect/tests.rs
@@ -705,11 +705,12 @@ fn builds_mysql_table_data_large_value_previews_without_truncating_keys() {
     });
 
     assert!(sql.starts_with("SELECT `id`, LEFT(`payload`, 4097) AS `payload`"));
-    assert!(sql.contains("CONCAT('T:4096:', OCTET_LENGTH(`payload`)) AS `__DBX_LARGE_VALUE_BYTES_T_1`"));
+    assert!(sql.contains("CONCAT('T:4096:', LENGTH(`payload`)) AS `__DBX_LARGE_VALUE_BYTES_T_1`"));
     assert!(sql.contains("LEFT(`raw_value`, 4097) AS `raw_value`"));
-    assert!(sql.contains("CONCAT('B:4096:', OCTET_LENGTH(`raw_value`)) AS `__DBX_LARGE_VALUE_BYTES_B_2`"));
+    assert!(sql.contains("CONCAT('B:4096:', LENGTH(`raw_value`)) AS `__DBX_LARGE_VALUE_BYTES_B_2`"));
     assert!(sql.contains("LEFT(`metadata`, 4097) AS `metadata`"));
-    assert!(sql.contains("CONCAT('T:4096:', OCTET_LENGTH(`metadata`)) AS `__DBX_LARGE_VALUE_BYTES_J_3`"));
+    assert!(sql.contains("CONCAT('T:4096:', LENGTH(`metadata`)) AS `__DBX_LARGE_VALUE_BYTES_J_3`"));
+    assert!(!sql.contains("OCTET_LENGTH"));
     assert!(!sql.contains("__DBX_LARGE_VALUE_BYTES_0"));
 }
 
@@ -741,10 +742,10 @@ fn previews_mysql_bounded_string_columns_only_above_the_active_budget() {
     });
 
     assert!(sql.starts_with("SELECT `id`, `image_mime`, LEFT(`image_data`, 420) AS `image_data`"));
-    assert!(sql.contains("CONCAT('B:419:', OCTET_LENGTH(`image_data`)) AS `__DBX_LARGE_VALUE_BYTES_B_2`, LEFT(`image_url`, 420) AS `image_url`"));
-    assert!(sql.contains("CONCAT('T:419:', OCTET_LENGTH(`image_url`)) AS `__DBX_LARGE_VALUE_BYTES_T_3`"));
+    assert!(sql.contains("CONCAT('B:419:', LENGTH(`image_data`)) AS `__DBX_LARGE_VALUE_BYTES_B_2`, LEFT(`image_url`, 420) AS `image_url`"));
+    assert!(sql.contains("CONCAT('T:419:', LENGTH(`image_url`)) AS `__DBX_LARGE_VALUE_BYTES_T_3`"));
     assert!(sql.contains("LEFT(`large_note`, 420) AS `large_note`"));
-    assert!(sql.contains("CONCAT('T:419:', OCTET_LENGTH(`large_note`)) AS `__DBX_LARGE_VALUE_BYTES_T_4`"));
+    assert!(sql.contains("CONCAT('T:419:', LENGTH(`large_note`)) AS `__DBX_LARGE_VALUE_BYTES_T_4`"));
     assert!(sql.contains("LEFT(`large_binary`, 420) AS `large_binary`"));
     assert!(!sql.contains("LEFT(`image_mime`"));
 }


### PR DESCRIPTION
## 问题原因

MySQL 表数据的大字段预览会使用 `OCTET_LENGTH` 获取原始字节数。腾讯云 Libra 列存引擎不支持该函数，导致包含 `TEXT`、`BLOB`、`JSON` 或超长字符串字段的部分表无法打开，并返回 `ERROR 9803 (HY000)`。

该行为由 0.5.85 的大字段预览优化引入，因此 0.5.84 不受影响。

## 修改内容

- 将 MySQL 大字段预览使用的 `OCTET_LENGTH` 替换为语义等价的 `LENGTH`
- 保持原始字节数统计、预览截断和完整值按需加载协议不变
- 修改仅作用于 MySQL 表数据的大字段预览 SQL，不影响用户 SQL 和其他数据库
- 增加断言，避免生成的 MySQL 预览 SQL 再次包含 `OCTET_LENGTH`

## 测试

- `cargo test -p dbx-core sql_dialect::tests`：22 项通过
- `cargo fmt --all --check`
- `git diff --check`
- 真实 MySQL 9.6：使用现有 `LONGBLOB` 图片样例执行生成后的预览 SQL，8 条记录均成功返回，字节数覆盖 69 B、85,875 B 和 5,763,018 B 等不同大小

腾讯云 Libra 环境仍需反馈用户进行最终兼容性验证。