### PR TITLE
fix(typos): correct spelling errors in code and variable names

### DIFF
--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -6902,7 +6902,7 @@ mod tests {
                     "type": "reasoning.text",
                     "id": "reasoning-text-1",
                     "index": 0,
-                    "text": "aand"
+                    "text": "and"
                 }]
             }))
         );


### PR DESCRIPTION
## 变更说明

This PR fixes the documentation issue reported in #6420: corrects `aand` to `and` in `crates/dbx-core/src/ai.rs`.

Fixes #6420

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

Fixes #6420