### PR TITLE
Improve：为 Windows 安装器添加中文及管理员权限提示

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -57,6 +57,7 @@
     "windows": {
       "nsis": {
         "installMode": "currentUser",
+        "languages": ["English", "SimpChinese", "TradChinese"],
         "template": "windows/nsis/installer.nsi"
       }
     },

--- a/src-tauri/windows/nsis/installer.nsi
+++ b/src-tauri/windows/nsis/installer.nsi
@@ -495,6 +495,16 @@ FunctionEnd
   !include "{{this}}"
 {{/each}}
 
+; Keep the standard write-error actions while explaining how to upgrade legacy
+; installations restored from Program Files without changing the install mode.
+LangString dbxFileWriteError ${LANG_ENGLISH} "Error opening file for writing:$\r$\n$\r$\n$0$\r$\n$\r$\nIf you are upgrading DBX installed under Program Files, abort this installation, right-click the installer, and select Run as administrator.$\r$\n$\r$\nClick Abort to stop the installation,$\r$\nRetry to try again, or$\r$\nIgnore to skip this file."
+LangString dbxFileWriteErrorNoIgnore ${LANG_ENGLISH} "Error opening file for writing:$\r$\n$\r$\n$0$\r$\n$\r$\nIf you are upgrading DBX installed under Program Files, cancel this installation, right-click the installer, and select Run as administrator.$\r$\n$\r$\nClick Retry to try again, or$\r$\nCancel to stop the installation."
+LangString dbxFileWriteError ${LANG_SIMPCHINESE} "无法打开要写入的文件：$\r$\n$\r$\n$0$\r$\n$\r$\n如果正在升级安装于 Program Files 的 DBX，请中止本次安装，然后右键单击安装程序并选择“以管理员身份运行”。$\r$\n$\r$\n单击“中止”停止安装，$\r$\n单击“重试”再次尝试，或$\r$\n单击“忽略”跳过此文件。"
+LangString dbxFileWriteErrorNoIgnore ${LANG_SIMPCHINESE} "无法打开要写入的文件：$\r$\n$\r$\n$0$\r$\n$\r$\n如果正在升级安装于 Program Files 的 DBX，请取消本次安装，然后右键单击安装程序并选择“以管理员身份运行”。$\r$\n$\r$\n单击“重试”再次尝试，或$\r$\n单击“取消”停止安装。"
+LangString dbxFileWriteError ${LANG_TRADCHINESE} "無法開啟要寫入的檔案：$\r$\n$\r$\n$0$\r$\n$\r$\n如果正在升級安裝於 Program Files 的 DBX，請中止本次安裝，然後以滑鼠右鍵按一下安裝程式並選擇「以系統管理員身分執行」。$\r$\n$\r$\n按一下「中止」以停止安裝，$\r$\n按一下「重試」以再次嘗試，或$\r$\n按一下「忽略」以略過此檔案。"
+LangString dbxFileWriteErrorNoIgnore ${LANG_TRADCHINESE} "無法開啟要寫入的檔案：$\r$\n$\r$\n$0$\r$\n$\r$\n如果正在升級安裝於 Program Files 的 DBX，請取消本次安裝，然後以滑鼠右鍵按一下安裝程式並選擇「以系統管理員身分執行」。$\r$\n$\r$\n按一下「重試」以再次嘗試，或$\r$\n按一下「取消」以停止安裝。"
+FileErrorText "$(dbxFileWriteError)" "$(dbxFileWriteErrorNoIgnore)"
+
 Function .onInit
   ${GetOptions} $CMDLINE "/P" $PassiveMode
   ${IfNot} ${Errors}


### PR DESCRIPTION
## 问题

Windows 安装器此前只启用了英文。中文 Windows 用户升级旧版本时，如果安装目录位于 `Program Files` 且安装器未以管理员身份运行，会遇到文件写入失败弹框，但原始提示没有说明对应的处理方式。

## 修改

- 为 NSIS 安装器启用 `English`、`SimpChinese`、`TradChinese`
- 根据 Windows 系统语言自动选择安装器语言，不增加语言选择弹框
- 为文件写入失败提示补充英文、简体中文和繁体中文文案
- 明确提示升级 `Program Files` 中的 DBX 时，需要中止或取消安装，并以管理员身份重新运行安装器
- 保持现有 `currentUser` 安装模式，不主动提权，也不改变普通安装路径

## 测试

- `makensis 3.12` 编译通过，生成 English、SimpChinese、TradChinese 三张语言表
- `pnpm tauri info` 成功解析 Tauri 配置
- `pnpm exec oxfmt --check` 通过
- `pnpm exec oxlint --vue-plugin apps/desktop/src` 通过（仅有主分支已有警告）
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json` 通过
- `git diff --check` 通过