### PR TITLE
fix(oracle): 导出表结构时移除物理存储属性

### DIFF
--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +42,9 @@ SELECT VERSION
 FROM PRODUCT_COMPONENT_VERSION
 WHERE PRODUCT LIKE 'Oracle Database%'
   AND ROWNUM = 1`
+
+const oracleDisableSegmentAttributesSQL = `BEGIN DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'SEGMENT_ATTRIBUTES', FALSE); END;`
+const oracleEnableSegmentAttributesSQL = `BEGIN DBMS_METADATA.SET_TRANSFORM_PARAM(DBMS_METADATA.SESSION_TRANSFORM, 'SEGMENT_ATTRIBUTES', TRUE); END;`
 
 var (
 	oraclePlSQLBlockStartRegexp          = regexp.MustCompile(`(?is)^\s*(?:DECLARE|BEGIN|CREATE\s+(?:OR\s+REPLACE\s+)?(?:(?:EDITIONABLE|NONEDITIONABLE)\s+)?(?:FUNCTION|PROCEDURE|TRIGGER|PACKAGE(?:\s+BODY)?|TYPE(?:\s+BODY)?))\b`)
@@ -843,7 +847,7 @@ func (s *server) dispatch(method string, params map[string]json.RawMessage) (any
 		schema := stringParam(params, "schema")
 		table := stringParam(params, "table")
 		objectType := stringParam(params, "object_type")
-		ddl, err := s.getTableDDL(schema, table, objectType)
+		ddl, err := s.getTableDDLWithOptions(schema, table, objectType, boolParam(params, "portable"))
 		return ddl, false, err
 	case "execute_query":
 		var opts queryOptions
@@ -2881,6 +2885,10 @@ func (s *server) normalizeSchemaForIdentity(schema string) (string, error) {
 }
 
 func (s *server) getTableDDL(schema, table, objectType string) (string, error) {
+	return s.getTableDDLWithOptions(schema, table, objectType, false)
+}
+
+func (s *server) getTableDDLWithOptions(schema, table, objectType string, portable bool) (string, error) {
 	var err error
 	schema, err = s.normalizeSchema(schema)
 	if err != nil {
@@ -2898,9 +2906,32 @@ func (s *server) getTableDDL(schema, table, objectType string) (string, error) {
 		return s.buildViewDDL(schema, table)
 	}
 	var ddl string
-	err = db.QueryRow("SELECT DBMS_METADATA.GET_DDL(:1, :2, :3) FROM DUAL", objectType, table, schema).Scan(&ddl)
+	var indexDDLs []string
+	if portable && objectType == "TABLE" {
+		var metadataErr error
+		err = withOraclePortableMetadataSession(db, func(conn *sql.Conn) error {
+			metadataErr = conn.QueryRowContext(
+				context.Background(),
+				"SELECT DBMS_METADATA.GET_DDL(:1, :2, :3) FROM DUAL",
+				objectType,
+				table,
+				schema,
+			).Scan(&ddl)
+			indexDDLs, _ = loadTableIndexDDLsFromConn(conn, schema, table)
+			return nil
+		})
+		if err != nil {
+			return "", err
+		}
+		err = metadataErr
+	} else {
+		err = db.QueryRow("SELECT DBMS_METADATA.GET_DDL(:1, :2, :3) FROM DUAL", objectType, table, schema).Scan(&ddl)
+	}
 	if err == nil && strings.TrimSpace(ddl) != "" {
 		if objectType == "TABLE" {
+			if portable {
+				return s.appendTableDependentDDLWithIndexes(schema, table, ddl, indexDDLs), nil
+			}
 			return s.appendTableDependentDDL(schema, table, ddl), nil
 		}
 		return ddl, nil
@@ -2910,12 +2941,41 @@ func (s *server) getTableDDL(schema, table, objectType string) (string, error) {
 		if fallbackErr != nil {
 			return "", fallbackErr
 		}
+		if portable {
+			return s.appendTableDependentDDLWithIndexes(schema, table, fallback, indexDDLs), nil
+		}
 		return s.appendTableDependentDDL(schema, table, fallback), nil
 	}
 	return "", err
 }
 
+func withOraclePortableMetadataSession(db *sql.DB, operation func(*sql.Conn) error) (err error) {
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		return err
+	}
+	if _, err = conn.ExecContext(context.Background(), oracleDisableSegmentAttributesSQL); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("failed to disable Oracle segment attributes: %w", err)
+	}
+	defer func() {
+		if _, resetErr := conn.ExecContext(context.Background(), oracleEnableSegmentAttributesSQL); resetErr != nil {
+			_ = conn.Raw(func(any) error { return driver.ErrBadConn })
+			if err == nil {
+				err = fmt.Errorf("failed to restore Oracle segment attributes: %w", resetErr)
+			}
+		}
+		_ = conn.Close()
+	}()
+	return operation(conn)
+}
+
 func (s *server) appendTableDependentDDL(schema, table, tableDDL string) string {
+	indexDDLs, _ := s.loadTableIndexDDLs(schema, table)
+	return s.appendTableDependentDDLWithIndexes(schema, table, tableDDL, indexDDLs)
+}
+
+func (s *server) appendTableDependentDDLWithIndexes(schema, table, tableDDL string, indexDDLs []string) string {
 	var builder strings.Builder
 	baseDDL := strings.TrimSpace(tableDDL)
 	builder.WriteString(baseDDL)
@@ -2931,10 +2991,8 @@ func (s *server) appendTableDependentDDL(schema, table, tableDDL string) string 
 		dependentAppended = true
 	}
 
-	if indexDDLs, err := s.loadTableIndexDDLs(schema, table); err == nil {
-		for _, ddl := range indexDDLs {
-			appendDependent(ddl)
-		}
+	for _, ddl := range indexDDLs {
+		appendDependent(ddl)
 	}
 	if triggerDDLs, err := s.loadTableTriggerDDLs(schema, table); err == nil {
 		for _, ddl := range triggerDDLs {
@@ -2949,8 +3007,7 @@ func (s *server) appendTableDependentDDL(schema, table, tableDDL string) string 
 	return builder.String()
 }
 
-func (s *server) loadTableIndexDDLs(schema, table string) ([]string, error) {
-	rows, err := s.queryRows(`
+const oracleTableIndexDDLsSQL = `
 SELECT DBMS_METADATA.GET_DDL('INDEX', i.INDEX_NAME, i.OWNER)
 FROM ALL_INDEXES i
 WHERE i.TABLE_OWNER = :1
@@ -2964,11 +3021,27 @@ WHERE i.TABLE_OWNER = :1
       AND c.CONSTRAINT_TYPE IN ('P', 'U')
       AND c.INDEX_NAME IS NOT NULL
   )
-ORDER BY i.INDEX_NAME`, []any{schema, table, schema, table})
+ORDER BY i.INDEX_NAME`
+
+func (s *server) loadTableIndexDDLs(schema, table string) ([]string, error) {
+	rows, err := s.queryRows(oracleTableIndexDDLsSQL, []any{schema, table, schema, table})
 	if err != nil {
 		return nil, err
 	}
 	defer s.closeRows(rows)
+	return scanOracleDDLs(rows)
+}
+
+func loadTableIndexDDLsFromConn(conn *sql.Conn, schema, table string) ([]string, error) {
+	rows, err := conn.QueryContext(context.Background(), oracleTableIndexDDLsSQL, schema, table, schema, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanOracleDDLs(rows)
+}
+
+func scanOracleDDLs(rows *sql.Rows) ([]string, error) {
 	var result []string
 	for rows.Next() {
 		var ddl sql.NullString
@@ -4741,6 +4814,15 @@ func intParam(params map[string]json.RawMessage, key string) int {
 		return 0
 	}
 	var value int
+	_ = json.Unmarshal(params[key], &value)
+	return value
+}
+
+func boolParam(params map[string]json.RawMessage, key string) bool {
+	if params == nil || len(params[key]) == 0 {
+		return false
+	}
+	var value bool
 	_ = json.Unmarshal(params[key], &value)
 	return value
 }

--- a/agents/drivers/oracle-go/main_test.go
+++ b/agents/drivers/oracle-go/main_test.go
@@ -627,6 +627,64 @@ func TestGetTableDDLAppendsIndexesTriggersAndComments(t *testing.T) {
 	}
 }
 
+func TestGetPortableTableDDLDisablesAndRestoresSegmentAttributes(t *testing.T) {
+	const schema = "HR"
+	const table = "ORDERS"
+	const tableDDL = `CREATE TABLE "HR"."ORDERS" ("ID" NUMBER)`
+	const indexDDL = `CREATE INDEX "HR"."IDX_ORDERS" ON "HR"."ORDERS" ("ID")`
+	db, scripted := openOracleViewSourceTestDB(t, []oracleViewSourceQueryStep{
+		{
+			queryContains: "'SEGMENT_ATTRIBUTES', FALSE",
+			exec:          true,
+		},
+		{
+			queryContains: "DBMS_METADATA.GET_DDL(:1, :2, :3)",
+			args:          []driver.Value{"TABLE", table, schema},
+			rows:          [][]driver.Value{{tableDDL}},
+		},
+		{
+			queryContains: "FROM ALL_INDEXES",
+			args:          []driver.Value{schema, table, schema, table},
+			rows:          [][]driver.Value{{indexDDL}},
+		},
+		{
+			queryContains: "'SEGMENT_ATTRIBUTES', TRUE",
+			exec:          true,
+		},
+		{
+			queryContains: "FROM ALL_TRIGGERS",
+			args:          []driver.Value{schema, table},
+			rows:          nil,
+		},
+		{
+			queryContains: "FROM ALL_TAB_COMMENTS",
+			args:          []driver.Value{schema, table},
+			rows:          nil,
+		},
+		{
+			queryContains: "FROM ALL_COL_COMMENTS",
+			args:          []driver.Value{schema, table},
+			rows:          nil,
+		},
+	})
+	s := newServer()
+	s.db = db
+
+	got, err := s.getTableDDLWithOptions(schema, table, "TABLE", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, tableDDL) || !strings.Contains(got, indexDDL) {
+		t.Fatalf("portable DDL should include table and index definitions:\n%s", got)
+	}
+	if strings.Contains(got, "TABLESPACE") || strings.Contains(got, "STORAGE") {
+		t.Fatalf("portable DDL should omit physical storage attributes:\n%s", got)
+	}
+	if scripted.next != len(scripted.steps) {
+		t.Fatalf("expected %d queries, got %d", len(scripted.steps), scripted.next)
+	}
+}
+
 func TestListIndexesSeparatesQuotedCloneTableNamesByCase(t *testing.T) {
 	const schema = "HR"
 	db, scripted := openOracleViewSourceTestDB(t, []oracleViewSourceQueryStep{
@@ -2461,6 +2519,7 @@ type oracleViewSourceQueryStep struct {
 	columns       []string
 	rows          [][]driver.Value
 	err           error
+	exec          bool
 }
 
 type oracleViewSourceDriver struct {
@@ -2498,6 +2557,9 @@ func (c *oracleViewSourceConn) QueryContext(
 	}
 	step := c.driver.steps[c.driver.next]
 	c.driver.next++
+	if step.exec {
+		return nil, errors.New("expected ExecContext call: " + query)
+	}
 	if !strings.Contains(query, step.queryContains) {
 		return nil, errors.New("unexpected query: " + query)
 	}
@@ -2516,6 +2578,32 @@ func (c *oracleViewSourceConn) QueryContext(
 		columns = []string{"SOURCE"}
 	}
 	return &oracleViewSourceRows{columns: columns, values: step.rows}, nil
+}
+
+func (c *oracleViewSourceConn) ExecContext(
+	_ context.Context,
+	query string,
+	args []driver.NamedValue,
+) (driver.Result, error) {
+	if c.driver.next >= len(c.driver.steps) {
+		return nil, errors.New("unexpected extra exec: " + query)
+	}
+	step := c.driver.steps[c.driver.next]
+	c.driver.next++
+	if !step.exec || !strings.Contains(query, step.queryContains) {
+		return nil, errors.New("unexpected exec: " + query)
+	}
+	values := make([]driver.Value, len(args))
+	for index, arg := range args {
+		values[index] = arg.Value
+	}
+	if (len(values) > 0 || len(step.args) > 0) && !reflect.DeepEqual(values, step.args) {
+		return nil, errors.New("unexpected exec arguments")
+	}
+	if step.err != nil {
+		return nil, step.err
+	}
+	return driver.RowsAffected(0), nil
 }
 
 type oracleViewSourceRows struct {

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -1806,7 +1806,7 @@ async function confirmBatchEmptyTables() {
 async function exportStructure(row: ObjectBrowserRow) {
   try {
     const schema = row.schema || selectedSchema.value || props.database;
-    const ddl = await api.getTableDdl(props.connection.id, props.database, schema, row.name, tableDdlObjectType(row.type), props.catalog);
+    const ddl = await api.getTableDdl(props.connection.id, props.database, schema, row.name, tableDdlObjectType(row.type), props.catalog, true);
     await saveFileContent(buildSingleDdlExportFileContent(ddl), `${row.name}.sql`, "SQL", "sql");
   } catch (e: any) {
     console.error("Export structure failed:", e);

--- a/apps/desktop/src/composables/__tests__/useSidebarTreeExportRuntime.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSidebarTreeExportRuntime.spec.ts
@@ -80,8 +80,8 @@ describe("useSidebarTreeExportRuntime", () => {
 
     expect(connectionStore.ensureConnected).toHaveBeenNthCalledWith(1, first.connectionId);
     expect(connectionStore.ensureConnected).toHaveBeenNthCalledWith(2, second.connectionId);
-    expect(apiMock.getTableDdl).toHaveBeenNthCalledWith(1, first.connectionId, first.database, first.schema, first.label, undefined, undefined);
-    expect(apiMock.getTableDdl).toHaveBeenNthCalledWith(2, second.connectionId, second.database, second.schema, second.label, "VIEW", undefined);
+    expect(apiMock.getTableDdl).toHaveBeenNthCalledWith(1, first.connectionId, first.database, first.schema, first.label, undefined, undefined, true);
+    expect(apiMock.getTableDdl).toHaveBeenNthCalledWith(2, second.connectionId, second.database, second.schema, second.label, "VIEW", undefined, true);
     expect(structurePreviewSql.value).toBe("CREATE TABLE one (id INT);\n\nCREATE VIEW two AS SELECT 1;\n");
     expect(structurePreviewTitle.value).toBe("contextMenu.exportStructurePreviewTitleMultiple");
     expect(showStructurePreviewDialog.value).toBe(true);

--- a/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarTreeExportRuntime.ts
@@ -75,7 +75,7 @@ export function useSidebarTreeExportRuntime(options: SidebarTreeExportRuntimeOpt
       const parts: string[] = [];
       for (const target of targets) {
         await connectionStore.ensureConnected(target.connectionId);
-        const ddl = await api.getTableDdl(target.connectionId, target.database, target.schema || target.database, target.label, tableDdlObjectTypeForNode(target.type), target.catalog);
+        const ddl = await api.getTableDdl(target.connectionId, target.database, target.schema || target.database, target.label, tableDdlObjectTypeForNode(target.type), target.catalog, true);
         parts.push(ddl.trim());
       }
       structurePreviewSql.value = joinExportedDdls(parts);

--- a/apps/desktop/src/lib/__tests__/table/contentAreaObjectBrowserCatalog.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/contentAreaObjectBrowserCatalog.spec.ts
@@ -52,7 +52,7 @@ describe("ObjectBrowser DDL API boundaries", () => {
   });
 
   it("keeps structure exports on the portable base DDL", () => {
-    expect(exportStructureSource).toMatch(/api\.getTableDdl\([\s\S]*?props\.catalog\);/);
+    expect(exportStructureSource).toMatch(/api\.getTableDdl\([\s\S]*?props\.catalog, true\);/);
     expect(exportStructureSource).not.toContain("api.getTableDisplayDdl(");
   });
 });

--- a/apps/desktop/src/lib/backend/http.ts
+++ b/apps/desktop/src/lib/backend/http.ts
@@ -873,8 +873,8 @@ export async function listSubpartitions(connectionId: string, database: string, 
   return get(`/api/schema/subpartitions?${qs({ connection_id: connectionId, database, schema, table, catalog })}`);
 }
 
-export async function getTableDdl(connectionId: string, database: string, schema: string, table: string, objectType?: ObjectSourceKind, catalog?: string): Promise<string> {
-  return get(`/api/schema/ddl?${qs({ connection_id: connectionId, database, schema, table, object_type: objectType, catalog })}`);
+export async function getTableDdl(connectionId: string, database: string, schema: string, table: string, objectType?: ObjectSourceKind, catalog?: string, portable = false): Promise<string> {
+  return get(`/api/schema/ddl?${qs({ connection_id: connectionId, database, schema, table, object_type: objectType, catalog, portable })}`);
 }
 
 export async function getTableDisplayDdl(connectionId: string, database: string, schema: string, table: string, objectType?: ObjectSourceKind, catalog?: string): Promise<string> {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -1654,7 +1654,7 @@ export async function listSubpartitions(connectionId: string, database: string, 
   });
 }
 
-export async function getTableDdl(connectionId: string, database: string, schema: string, table: string, objectType?: ObjectSourceKind, catalog?: string): Promise<string> {
+export async function getTableDdl(connectionId: string, database: string, schema: string, table: string, objectType?: ObjectSourceKind, catalog?: string, portable = false): Promise<string> {
   return invoke("get_table_ddl", {
     connectionId,
     database,
@@ -1662,6 +1662,7 @@ export async function getTableDdl(connectionId: string, database: string, schema
     table,
     objectType,
     catalog,
+    portable,
   });
 }
 
@@ -1674,6 +1675,7 @@ export async function getTableDisplayDdl(connectionId: string, database: string,
     objectType,
     catalog,
     includePostgresAccess: true,
+    portable: false,
   });
 }
 

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1898,7 +1898,7 @@ pub async fn export_database_sql_core(
                 }
                 let ddl = if request.include_structure {
                     Some(
-                        crate::schema::get_table_ddl_core(
+                        crate::schema::get_table_export_ddl_core(
                             state,
                             &request.connection_id,
                             &request.database,
@@ -2056,7 +2056,7 @@ pub async fn export_database_sql_core(
             {
                 Some(result) => result,
                 None => {
-                    crate::schema::get_table_ddl_core(
+                    crate::schema::get_table_export_ddl_core(
                         state,
                         &request.connection_id,
                         &request.database,

--- a/crates/dbx-core/src/db/agent_driver.rs
+++ b/crates/dbx-core/src/db/agent_driver.rs
@@ -2203,12 +2203,20 @@ impl AgentDriverClient {
         table: &str,
         timeout_duration: Option<Duration>,
     ) -> Result<T, String> {
-        self.call_method_with_timeout(
-            AgentMethod::GetTableDdl,
-            agent_schema_table_params(database, schema, table),
-            timeout_duration,
-        )
-        .await
+        self.get_table_ddl_with_options(database, schema, table, false, timeout_duration).await
+    }
+
+    pub async fn get_table_ddl_with_options<T: DeserializeOwned + Send + 'static>(
+        &mut self,
+        database: &str,
+        schema: &str,
+        table: &str,
+        portable: bool,
+        timeout_duration: Option<Duration>,
+    ) -> Result<T, String> {
+        let mut params = agent_schema_table_params(database, schema, table);
+        params["portable"] = serde_json::json!(portable);
+        self.call_method_with_timeout(AgentMethod::GetTableDdl, params, timeout_duration).await
     }
 
     pub async fn execute_query<T: DeserializeOwned + Send + 'static>(&mut self, params: Value) -> Result<T, String> {

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -6446,7 +6446,18 @@ pub async fn get_table_ddl_core(
     table: &str,
     object_type: Option<db::ObjectSourceKind>,
 ) -> Result<String, String> {
-    get_table_ddl_core_with_options(state, connection_id, database, schema, table, object_type, false).await
+    get_table_ddl_core_with_options(state, connection_id, database, schema, table, object_type, false, false).await
+}
+
+pub async fn get_table_export_ddl_core(
+    state: &AppState,
+    connection_id: &str,
+    database: &str,
+    schema: &str,
+    table: &str,
+    object_type: Option<db::ObjectSourceKind>,
+) -> Result<String, String> {
+    get_table_ddl_core_with_options(state, connection_id, database, schema, table, object_type, false, true).await
 }
 
 pub async fn get_table_display_ddl_core(
@@ -6457,7 +6468,7 @@ pub async fn get_table_display_ddl_core(
     table: &str,
     object_type: Option<db::ObjectSourceKind>,
 ) -> Result<String, String> {
-    get_table_ddl_core_with_options(state, connection_id, database, schema, table, object_type, true).await
+    get_table_ddl_core_with_options(state, connection_id, database, schema, table, object_type, true, false).await
 }
 
 async fn get_table_ddl_core_with_options(
@@ -6468,6 +6479,7 @@ async fn get_table_ddl_core_with_options(
     table: &str,
     object_type: Option<db::ObjectSourceKind>,
     include_postgres_access: bool,
+    portable_oracle: bool,
 ) -> Result<String, String> {
     if crate::sql_dialect::parse_sqlserver_linked_schema_ref(schema).is_some() {
         return Err("DDL is not supported for SQL Server linked server tables".to_string());
@@ -6513,7 +6525,7 @@ async fn get_table_ddl_core_with_options(
     }
 
     retry_metadata_connection(state, connection_id, Some(database), || {
-        get_table_ddl_once(state, connection_id, database, schema, table, include_postgres_access)
+        get_table_ddl_once(state, connection_id, database, schema, table, include_postgres_access, portable_oracle)
     })
     .await
 }
@@ -6525,6 +6537,7 @@ async fn get_table_ddl_once(
     schema: &str,
     table: &str,
     include_postgres_access: bool,
+    portable_oracle: bool,
 ) -> Result<String, String> {
     let pool_key = state.get_or_create_metadata_pool_for_session(connection_id, Some(database), None).await?;
     let db_config = connection_config(state, connection_id).await;
@@ -6604,6 +6617,7 @@ async fn get_table_ddl_once(
                     database,
                     schema,
                     table,
+                    portable_oracle,
                     agent_metadata_timeout(db_config.as_ref()),
                 )
                 .await;
@@ -7712,10 +7726,11 @@ async fn oracle_agent_table_ddl(
     database: &str,
     schema: &str,
     table: &str,
+    portable: bool,
     timeout_duration: Option<Duration>,
 ) -> Result<String, String> {
     let mut client = client.lock().await;
-    let ddl = client.get_table_ddl::<String>(database, schema, table, timeout_duration).await?;
+    let ddl = client.get_table_ddl_with_options::<String>(database, schema, table, portable, timeout_duration).await?;
     match append_oracle_table_comment_ddl(&mut client, database, schema, table, &ddl, timeout_duration).await {
         Ok(ddl) => Ok(ddl),
         Err(error) => {

--- a/crates/dbx-web/src/routes/schema.rs
+++ b/crates/dbx-web/src/routes/schema.rs
@@ -28,6 +28,7 @@ pub struct SchemaQuery {
     pub apply_visible_filter: Option<bool>,
     pub client_session_id: Option<String>,
     pub include_postgres_access: Option<bool>,
+    pub portable: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -646,6 +647,17 @@ pub async fn get_ddl(
         dbx_core::schema::get_doris_catalog_table_ddl_core(&state.app, &q.connection_id, &catalog, database, table)
             .await
             .map_err(AppError::from)?
+    } else if q.portable.unwrap_or(false) {
+        dbx_core::schema::get_table_export_ddl_core(
+            &state.app,
+            &q.connection_id,
+            database,
+            schema,
+            table,
+            q.object_type,
+        )
+        .await
+        .map_err(AppError::from)?
     } else if q.include_postgres_access.unwrap_or(false) {
         dbx_core::schema::get_table_display_ddl_core(
             &state.app,

--- a/src-tauri/src/commands/schema.rs
+++ b/src-tauri/src/commands/schema.rs
@@ -474,12 +474,16 @@ pub async fn get_table_ddl(
     object_type: Option<db::ObjectSourceKind>,
     catalog: Option<String>,
     include_postgres_access: Option<bool>,
+    portable: Option<bool>,
 ) -> Result<String, String> {
     if let Some(catalog) = external_doris_catalog(&state, &connection_id, catalog.as_deref()).await {
         return dbx_core::schema::get_doris_catalog_table_ddl_core(&state, &connection_id, &catalog, &database, &table)
             .await;
     }
-    if include_postgres_access.unwrap_or(false) {
+    if portable.unwrap_or(false) {
+        dbx_core::schema::get_table_export_ddl_core(&state, &connection_id, &database, &schema, &table, object_type)
+            .await
+    } else if include_postgres_access.unwrap_or(false) {
         dbx_core::schema::get_table_display_ddl_core(&state, &connection_id, &database, &schema, &table, object_type)
             .await
     } else {


### PR DESCRIPTION
## 变更说明

Oracle 导出表结构时默认生成可迁移 DDL，移除以下与源环境绑定的物理存储属性：

- `TABLESPACE`
- `STORAGE`
- `PCTFREE` / `PCTUSED`
- `INITRANS` / `MAXTRANS`
- `SEGMENT CREATION` 等 segment attributes

实现上通过 Oracle `DBMS_METADATA.SESSION_TRANSFORM` 在同一数据库会话内临时关闭 `SEGMENT_ATTRIBUTES`，同时处理表和独立索引 DDL，完成后恢复会话设置；恢复失败时会丢弃连接，避免污染连接池。

侧边栏导出、对象浏览器导出和整库 SQL 导出使用可迁移 DDL。普通“查看 DDL”、Schema Diff 和字段血缘保持原有行为，仍可查看完整 Oracle 物理属性。其他数据库类型不受影响。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

无可见 UI 改动，仅为导出入口增加可迁移 DDL 请求参数。

## 验证

- [x] `make check` 通过（9569 项测试）
- [x] `make cargo-check-fast` 通过
- [x] Oracle Go Agent `go test ./...` 通过
- [x] 前端定向测试通过（2 个文件，11 项）
- [x] Oracle XE 18c、19c、XE 21c、Free 23 实库验证通过
- [x] 验证导出后普通 DDL 会恢复物理属性，连接池会话未被污染
- [x] Oracle XE 11g 原有回退 DDL 路径验证通过

实库验证覆盖表、独立索引和表注释：可迁移 DDL 保留对象定义与注释，不再包含物理存储属性。

## 关联 Issue

暂无关联 Issue。