### PR TITLE
fix(editor): suggest MongoDB collection methods after db.<collection>.

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -3384,7 +3384,7 @@ async function provideMongoCompletions(currentState: import("@codemirror/state")
   return {
     from: completionContext.from,
     options: items.map((item) => completionOptionForItem(item)),
-    validFor: getMongoCompletionResultValidFor(),
+    validFor: getMongoCompletionResultValidFor(completionContext),
   };
 }
 

--- a/apps/desktop/src/lib/mongo/mongoCompletion.ts
+++ b/apps/desktop/src/lib/mongo/mongoCompletion.ts
@@ -158,6 +158,9 @@ const METHOD_ARG_ROLES: Record<string, readonly MongoArgRole[]> = {
 
 const CALL_METHOD_PATTERN = new RegExp(`\\.(${Object.keys(METHOD_ARG_ROLES).join("|")})\\s*\\(`, "g");
 
+/** Modes reached by walking the `db.collection.method` chain, where a `.` switches item source. */
+const DOT_SCOPED_MODES = new Set<MongoCompletionMode>(["root", "collection", "collectionOrMethod", "method", "cursorMethod"]);
+
 /** Stages whose body is a fixed set of option keys rather than a field map. */
 const OPTION_STAGES = new Set(Object.keys(STAGE_OPTION_KEYS));
 
@@ -325,8 +328,19 @@ export function shouldAutoOpenMongoCompletion(text: string, cursor: number): boo
   return false;
 }
 
-export function getMongoCompletionResultValidFor(): RegExp {
-  return /["']?[\w_$.-]*$/;
+/**
+ * How far the editor may keep re-filtering a result before it has to ask us
+ * again. In the `db.…` chain every `.` moves the cursor to a different item
+ * source (root → collection → method → cursor method), so a result must stop
+ * being valid as soon as the typed text gains a dot it did not have — otherwise
+ * the editor keeps filtering collection names against `users.` and shows
+ * nothing. Elsewhere (field paths, quoted collection names) dots are just part
+ * of the identifier and are safe to keep.
+ */
+export function getMongoCompletionResultValidFor(context?: MongoCompletionContext): RegExp {
+  if (!context || !DOT_SCOPED_MODES.has(context.mode)) return /["']?[\w_$.-]*$/;
+  const segments = context.prefix.split(".").length;
+  return new RegExp(`["']?[\\w_$-]*${"\\.[\\w_$-]*".repeat(segments - 1)}$`);
 }
 
 export function inferMongoCompletionFields(documents: unknown[]): MongoCompletionField[] {
@@ -677,6 +691,7 @@ function collectionOrMethodItems(prefix: string, collections: string[]): MongoCo
   const methods = methodItems(methodPrefix).map((item) => ({
     ...item,
     apply: `${collectionRef}.${item.apply}`,
+    filterText: `${collection}.${item.label}`,
     boost: !hasExactCollection && hasDottedCollectionCandidate ? Math.min(item.boost, 110) : item.boost,
   }));
 

--- a/packages/app-tests/mongoCompletion.test.ts
+++ b/packages/app-tests/mongoCompletion.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { buildMongoCompletionItems, getMongoCompletionContext, inferMongoCompletionFields, shouldAutoOpenMongoCompletion } from "../../apps/desktop/src/lib/mongo/mongoCompletion.ts";
+import { buildMongoCompletionItems, getMongoCompletionContext, getMongoCompletionResultValidFor, inferMongoCompletionFields, shouldAutoOpenMongoCompletion } from "../../apps/desktop/src/lib/mongo/mongoCompletion.ts";
 import { ACCUMULATORS, EXPRESSION_OPERATORS, PIPELINE_STAGES, PUSH_MODIFIERS, QUERY_OPERATORS, STAGE_OPTION_KEYS, UPDATE_OPERATORS, VALUE_SNIPPETS } from "../../apps/desktop/src/lib/mongo/mongoCompletionTables.ts";
 
 const collections = ["users", "user_events", "order-items", "audit.logs"];
@@ -60,6 +60,45 @@ test("keeps direct collection method completion while resolving dotted names", (
   const item = buildMongoCompletionItems("db.users.fi", "db.users.fi".length, { collections }).find((candidate) => candidate.label === "find");
 
   assert.equal(item?.apply, "users.find({})");
+});
+
+// The editor filters options against the document text from `from` to the
+// cursor, so every item must be matchable by the whole prefix it replaces —
+// a bare `find` label under a `users.fi` prefix is silently dropped.
+test("makes collection-qualified methods matchable by the prefix they replace", () => {
+  for (const text of ["db.users.", "db.users.fi", "db.audit."]) {
+    const context = getMongoCompletionContext(text, text.length);
+    const prefix = text.slice(context.from);
+    for (const item of buildMongoCompletionItems(text, text.length, { collections })) {
+      const matchable = item.filterText ?? item.label;
+      assert.ok(matchable.toLowerCase().startsWith(prefix.toLowerCase()), `"${matchable}" is not matchable by the typed "${prefix}"`);
+    }
+  }
+
+  const item = buildMongoCompletionItems("db.users.fi", "db.users.fi".length, { collections }).find((candidate) => candidate.label === "find");
+  assert.equal(item?.filterText, "users.find");
+});
+
+test("stops reusing a completion result once the typed text gains a dot", () => {
+  const validFor = (text: string) => {
+    const pattern = getMongoCompletionResultValidFor(getMongoCompletionContext(text, text.length));
+    return (typed: string) => new RegExp(`^(?:${pattern.source})$`).test(typed);
+  };
+
+  // `db.` lists collections; typing `users` keeps that list usable, `users.` does not.
+  const afterDb = validFor("db.");
+  assert.equal(afterDb("users"), true);
+  assert.equal(afterDb("users."), false);
+
+  // `db.users.` lists methods; narrowing to `users.fi` keeps them, a further dot does not.
+  const afterCollection = validFor("db.users.");
+  assert.equal(afterCollection("users.fi"), true);
+  assert.equal(afterCollection("users.find."), false);
+  assert.equal(afterCollection("users"), false);
+
+  // Dots inside a quoted collection name are part of the identifier, not a scope change.
+  const insideGetCollection = validFor('db.getCollection("audit.');
+  assert.equal(insideGetCollection('"audit.logs'), true);
 });
 
 test("suggests dotted names inside getCollection", () => {


### PR DESCRIPTION
## Description

Fixes MongoDB autocomplete not offering collection methods after typing `db.<collection>.` in the query editor.

The completion engine was returning the right items all along — the editor layer was discarding them:

1. **The editor filtered every option out.** For `db.users.`, the context is `collectionOrMethod` and `from` points at the start of the collection name (it has to, so that `db.audit.` can be rewritten into `db.getCollection("audit.logs")`). CodeMirror then filters the returned options against the document text between `from` and the cursor — `"users."` — and matches it against each `option.label`, which are bare method names (`find`, `findOne`, …). `FuzzyMatcher.match` returns `null` immediately when `word.length < pattern.length`, so all options were dropped and no popup appeared. Same for `db.users.fi`.
2. **`validFor` spanned dots.** `/["']?[\w_$.-]*$/` kept a result built for `db.` "still valid" while the user typed `users.`, so the editor went on re-filtering collection names instead of asking for methods.

<img width="486" height="193" alt="Screenshot 2026-08-17 at 11 34 11" src="https://github.com/user-attachments/assets/cf7968a5-aaaf-4bf5-bdc0-7c7611ad6ba7" />
<img width="592" height="367" alt="Screenshot 2026-08-17 at 11 34 57" src="https://github.com/user-attachments/assets/9f8dbb4b-6617-449b-aa82-ffac5f24f014" />


### Changes

- `apps/desktop/src/lib/mongo/mongoCompletion.ts` — collection-qualified method items now carry `filterText` (`users.find`). The editor's existing `completionLabelPresentation` helper turns that into a matchable label while `displayLabel` still renders the bare `find`. This is the same mechanism already used for quoted collection names inside `getCollection("…")`.
- `apps/desktop/src/lib/mongo/mongoCompletion.ts` — `getMongoCompletionResultValidFor` now takes the completion context. For the `db.…` chain modes (`root`, `collection`, `collectionOrMethod`, `method`, `cursorMethod`) it allows only as many dot-separated segments as the current prefix has, so a newly typed `.` forces a fresh query. Field paths and quoted collection names keep the old dot-permissive behaviour, where a dot is part of the identifier rather than a scope change.
- `apps/desktop/src/components/editor/QueryEditor.vue` — passes the context through to `validFor`.
- `packages/app-tests/mongoCompletion.test.ts` — two regression tests.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] CI / build

## Frontend Changes

<!-- If the PR touches anything on the frontend (UI components, styles, interactions, copy, …), a screenshot or screen recording is required -->

- [ ] This PR includes frontend changes, and a screenshot/recording is attached (below)

<!-- TODO: attach a recording of typing `db.users.` in a MongoDB query tab and the method list appearing -->

## Verification

Two regression tests were added in `packages/app-tests/mongoCompletion.test.ts`; both fail on `main` and pass with this change:

- `makes collection-qualified methods matchable by the prefix they replace` — asserts that for `db.users.`, `db.users.fi` and `db.audit.`, every returned item's matchable text (`filterText ?? label`) starts with the prefix it replaces. This is exactly the invariant CodeMirror's filter requires, and the one the old code violated.
- `stops reusing a completion result once the typed text gains a dot` — asserts the `validFor` window closes on a new dot in the `db.…` chain, and stays open for dots inside a quoted collection name.

Manual steps:

1. Open a query tab on a MongoDB connection.
2. Type `db.` → the collection list appears (unchanged).
3. Type a collection name, then `.` → **before:** no popup; **after:** `find`, `findOne`, `aggregate`, … appear.
4. Keep typing (`fi`) → the list narrows instead of disappearing.
5. Accept `find` → inserts `db.users.find({})`; for a name needing quoting, `db.order-items.` + `find` inserts `db.getCollection("order-items").find({})`.

- [x] `make check` passes (`format`, `lint`, `typecheck`, `test` — all ok)
- [x] `make cargo-check-fast` passes (no Rust changed; run for completeness)
- [x] Related tests pass

## Related Issue

<!-- TODO: fill in `Close #xxx` or `Related #xxx` if applicable -->

