### PR TITLE
Fix：兼容 StarRocks 空外部数据库的表列表加载

### DIFF
--- a/crates/dbx-core/src/db/starrocks.rs
+++ b/crates/dbx-core/src/db/starrocks.rs
@@ -12,8 +12,34 @@ use super::mysql::{
 pub use super::mysql_compatible::{
     get_columns_show_from as get_catalog_columns, list_catalog_indexes, list_catalogs,
     list_databases_show_from as list_catalog_databases, list_indexes_with_ddl_fallback as list_indexes,
-    list_tables_show_from as list_catalog_tables, show_create_table_ddl_from as get_catalog_table_ddl,
+    show_create_table_ddl_from as get_catalog_table_ddl,
 };
+
+pub async fn list_catalog_tables(pool: &MySqlPool, catalog: &str, database: &str) -> Result<Vec<TableInfo>, String> {
+    match super::mysql_compatible::list_tables_show_from(pool, catalog, database).await {
+        Ok(tables) => Ok(tables),
+        Err(error) if should_retry_catalog_table_listing(&error) => {
+            match super::mysql_compatible::list_databases_show_from(pool, catalog).await {
+                Ok(databases) if catalog_database_exists(&databases, database) => {
+                    log::debug!(
+                        "Treating StarRocks external database `{catalog}`.`{database}` as empty after its qualified table lookup failed: {error}"
+                    );
+                    Ok(Vec::new())
+                }
+                _ => Err(error),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn should_retry_catalog_table_listing(error: &str) -> bool {
+    error.to_ascii_lowercase().contains("unknown database")
+}
+
+fn catalog_database_exists(databases: &[crate::types::DatabaseInfo], database: &str) -> bool {
+    databases.iter().any(|candidate| candidate.name == database)
+}
 
 pub fn is_config(config: &ConnectionConfig) -> bool {
     is_profile(&config.db_type, config.driver_profile.as_deref())
@@ -131,6 +157,24 @@ mod tests {
         assert!(is_profile(&DatabaseType::Mysql, Some("STARROCKS")));
         assert!(!is_profile(&DatabaseType::Mysql, Some("doris")));
         assert!(!is_profile(&DatabaseType::Postgres, Some("starrocks")));
+    }
+
+    #[test]
+    fn catalog_table_listing_retries_only_unknown_database_errors() {
+        assert!(should_retry_catalog_table_listing(
+            "ERROR 5501 (3F000): Getting analyzing error. Detail message: Unknown database 'edw_dwt'."
+        ));
+        assert!(!should_retry_catalog_table_listing("Access denied on database edw_dwt"));
+        assert!(!should_retry_catalog_table_listing("Connection timed out"));
+    }
+
+    #[test]
+    fn catalog_database_existence_requires_an_exact_name_match() {
+        let databases = vec![crate::types::DatabaseInfo { name: "edw_dwt".to_string(), ..Default::default() }];
+
+        assert!(catalog_database_exists(&databases, "edw_dwt"));
+        assert!(!catalog_database_exists(&databases, "EDW_DWT"));
+        assert!(!catalog_database_exists(&databases, "missing"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更内容

- StarRocks 外部 catalog 查询表列表遇到 `Unknown database` 时，额外核实该数据库是否存在于 catalog 中
- 对已存在但为空的外部数据库返回空表列表
- 保留真实不存在数据库、权限错误和连接超时等原始错误

## 修复原因

在 StarRocks 5.1.0 的 Paimon 外部 catalog 中，空数据库可以通过 `SHOW DATABASES FROM <catalog>` 正常列出，但执行全限定 `SHOW TABLES FROM <catalog>.<database>` 会错误返回 `ERROR 5501 (3F000): Unknown database`，导致 DBX 无法打开该数据库。

## 测试

- `cargo test -p dbx-core --lib db::starrocks::tests`：8 项通过
- 真实 StarRocks 验证：空外部数据库返回空列表
- 真实 StarRocks 验证：有表数据库仍正常返回表
- 真实 StarRocks 验证：不存在的数据库仍返回 `Unknown database`
- `cargo fmt --all --check`
- `git diff --check`