### PR TITLE
feat(editor): add configurable manual completion shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ Thumbs.db
 
 # Temp
 tmp/
-outputs/
 
 # Code review tool artifacts
 review_diff.json

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Thumbs.db
 
 # Temp
 tmp/
+outputs/
 
 # Code review tool artifacts
 review_diff.json

--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -889,6 +889,7 @@ const formatterEditorShortcutIds: ShortcutActionId[] = [
   "replace",
   "saveSql",
   "acceptCompletion",
+  "triggerCompletion",
   "indentMore",
   "indentLess",
   "insertLineBelow",

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1922,6 +1922,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
           return true;
         }),
         ...binding(shortcuts.sqlIntentionActions, handleSqlIntentionActions),
+        ...binding(shortcuts.triggerCompletion, triggerSqlCompletion),
         ...createQueryEditorSearchKeymap({
           openSearch,
           openReplace,
@@ -3633,6 +3634,15 @@ async function provideSqlCompletions(context: CompletionContext) {
 
 function isEditorComposing(currentView: EditorViewType): boolean {
   return imeCompositionActive || currentView.compositionStarted || currentView.composing;
+}
+
+// Manual-trigger shortcut (default Alt+/). Opens the completion popup on the
+// explicit path so auto-trigger mode gating is bypassed. Unlike
+// scheduleSqlCompletionStart, it must NOT mark the activation as typed, or the
+// session would be misclassified as typing and gated for 500ms.
+function triggerSqlCompletion(currentView: EditorViewType): boolean {
+  if (!codeMirrorStartCompletion || isEditorComposing(currentView)) return false;
+  return codeMirrorStartCompletion(currentView);
 }
 
 function scheduleSqlCompletionStart(currentView: EditorViewType, delayMs = 0) {

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -120,6 +120,7 @@ import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationM
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import { computePasteCaretResyncTarget } from "@/lib/editor/queryEditorPasteCaretResync";
 import { extendQueryEditorSelection, runQueryEditorAltExtendSelection } from "@/lib/editor/queryEditorExtendSelection";
+import { createQueryEditorCompletionShortcutBindings } from "@/lib/editor/queryEditorCompletionShortcut";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
 import { isSchemaAware, isSingleDatabase, supportsDatabaseNameCompletion, supportsDatabaseSchemaQualifier, supportsQueryEditorBlockComments, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
 import { metadataSchemaForConnection, sqlSnippetDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
@@ -1922,7 +1923,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
           return true;
         }),
         ...binding(shortcuts.sqlIntentionActions, handleSqlIntentionActions),
-        ...binding(shortcuts.triggerCompletion, triggerSqlCompletion),
+        ...createQueryEditorCompletionShortcutBindings(shortcuts.triggerCompletion, triggerSqlCompletion),
         ...createQueryEditorSearchKeymap({
           openSearch,
           openReplace,

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6097,6 +6097,7 @@ export default {
     shortcutReplace: "Replace",
     shortcutSaveSql: "Save SQL",
     shortcutAcceptCompletion: "Accept completion",
+    shortcutTriggerCompletion: "Trigger completion",
     shortcutFormatSql: "Format SQL",
     shortcutExpandSelectStar: "Expand * to columns",
     shortcutToggleLineComment: "Toggle line comment",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -5789,6 +5789,7 @@ export default withEnglishFallback({
     shortcutReplace: "Reemplazar",
     shortcutSaveSql: "Guardar SQL",
     shortcutAcceptCompletion: "Aceptar completado",
+    shortcutTriggerCompletion: "Activar completado",
     shortcutFormatSql: "Formatear SQL",
     shortcutExpandSelectStar: "Expandir * a columnas",
     shortcutToggleLineComment: "Alternar comentario de línea",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -5789,6 +5789,7 @@ export default withEnglishFallback({
     shortcutReplace: "Sostituisci",
     shortcutSaveSql: "Salva SQL",
     shortcutAcceptCompletion: "Accetta completamento",
+    shortcutTriggerCompletion: "Attiva completamento",
     shortcutFormatSql: "Formatta SQL",
     shortcutExpandSelectStar: "Espandi * in colonne",
     shortcutToggleLineComment: "Attiva/disattiva commento di riga",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -5804,6 +5804,7 @@ export default withEnglishFallback({
     shortcutReplace: "置換",
     shortcutSaveSql: "SQLを保存",
     shortcutAcceptCompletion: "補完を受け入れる",
+    shortcutTriggerCompletion: "補完をトリガー",
     shortcutFormatSql: "SQLをフォーマット",
     shortcutExpandSelectStar: "* を列に展開",
     shortcutToggleLineComment: "行コメントを切り替え",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5547,6 +5547,7 @@ export default withEnglishFallback({
     shortcutReplace: "바꾸기",
     shortcutSaveSql: "SQL 저장",
     shortcutAcceptCompletion: "완성 수락",
+    shortcutTriggerCompletion: "완성 트리거",
     shortcutFormatSql: "SQL 서식",
     shortcutExpandSelectStar: "*을(를) 열로 확장",
     shortcutToggleLineComment: "줄 주석 전환",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -5791,6 +5791,7 @@ export default withEnglishFallback({
     shortcutReplace: "Substituir",
     shortcutSaveSql: "Salvar SQL",
     shortcutAcceptCompletion: "Aceitar autocompletar",
+    shortcutTriggerCompletion: "Acionar autocompletar",
     shortcutFormatSql: "Formatar SQL",
     shortcutExpandSelectStar: "Expandir * em colunas",
     shortcutToggleLineComment: "Alternar comentário de linha",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6083,6 +6083,7 @@ export default withEnglishFallback({
     shortcutReplace: "替换",
     shortcutSaveSql: "保存 SQL",
     shortcutAcceptCompletion: "接受补全",
+    shortcutTriggerCompletion: "触发补全",
     shortcutFormatSql: "格式化 SQL",
     shortcutExpandSelectStar: "将 * 展开为字段",
     shortcutToggleLineComment: "切换行注释",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5115,6 +5115,7 @@ export default withEnglishFallback({
     shortcutReplace: "取代",
     shortcutSaveSql: "儲存 SQL",
     shortcutAcceptCompletion: "接受補全",
+    shortcutTriggerCompletion: "觸發補全",
     shortcutFormatSql: "格式化 SQL",
     shortcutExpandSelectStar: "將 * 展開為欄位",
     shortcutToggleLineComment: "切換行註解",

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
@@ -294,4 +294,25 @@ describe("QueryEditor completion Tab keymap", () => {
     expect(view.state.replaceSelection).toHaveBeenCalledWith("  ");
     expect(view.dispatch).toHaveBeenCalledOnce();
   });
+
+  it("triggers completion on Alt+/ through the manual shortcut and skips while composing", () => {
+    const source = [extractDeclaration(/const COMPLETION_DEBOUNCE_DELAY_MS = \d+;/, "completion debounce delay"), "let imeCompositionActive = false;", extractFunction("isEditorComposing"), extractFunction("triggerSqlCompletion")].join("\n");
+    const javascript = ts.transpileModule(source, {
+      compilerOptions: { module: ts.ModuleKind.None, target: ts.ScriptTarget.ES2022 },
+    }).outputText;
+    const factory = new Function("codeMirrorStartCompletion", `${javascript}\nreturn { triggerSqlCompletion, isEditorComposing };`);
+    const startCompletion = vi.fn(() => true);
+    const { triggerSqlCompletion } = factory(startCompletion) as {
+      triggerSqlCompletion: (view: MockView) => boolean;
+    };
+    const view = createView();
+
+    expect(triggerSqlCompletion(view)).toBe(true);
+    expect(startCompletion).toHaveBeenCalledWith(view);
+
+    startCompletion.mockClear();
+    (view as MockView & { composing: boolean }).composing = true;
+    expect(triggerSqlCompletion(view)).toBe(false);
+    expect(startCompletion).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionShortcut.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionShortcut.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import { createQueryEditorCompletionShortcutBindings } from "@/lib/editor/queryEditorCompletionShortcut";
+
+function createView(shortcut: string, run: (view: EditorView) => boolean, platform: string): EditorView {
+  return new EditorView({
+    parent: document.createElement("div"),
+    state: EditorState.create({
+      extensions: [keymap.of(createQueryEditorCompletionShortcutBindings(shortcut, run, platform))],
+    }),
+  });
+}
+
+describe("QueryEditor manual completion shortcut", () => {
+  it("dispatches macOS Option+/ by the physical Slash key", () => {
+    const run = vi.fn(() => true);
+    const view = createView("Alt+/", run, "MacIntel");
+    const event = new KeyboardEvent("keydown", {
+      key: "÷",
+      code: "Slash",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(runScopeHandlers(view, event, "editor")).toBe(true);
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith(view);
+    view.destroy();
+  });
+
+  it("leaves macOS Option+/ unhandled during IME composition", () => {
+    const run = vi.fn(() => true);
+    const view = createView("Alt+/", run, "MacIntel");
+    const event = new KeyboardEvent("keydown", {
+      key: "/",
+      code: "Slash",
+      altKey: true,
+      isComposing: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(runScopeHandlers(view, event, "editor")).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+    view.destroy();
+  });
+
+  it("does not force-handle a configured shortcut when completion does not start", () => {
+    const run = vi.fn(() => false);
+    const view = createView("Alt+K", run, "MacIntel");
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(runScopeHandlers(view, event, "editor")).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(run).toHaveBeenCalledOnce();
+    view.destroy();
+  });
+
+  it("keeps an empty configured shortcut disabled", () => {
+    expect(createQueryEditorCompletionShortcutBindings("", () => true, "MacIntel")).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
@@ -154,6 +154,17 @@ describe("shortcutRegistry editor actions", () => {
     expect(DEFAULT_SHORTCUT_SETTINGS.extendSelection).toBe("Alt+W");
   });
 
+  it("registers an IDEA/DataGrip-style Alt+/ shortcut for manually triggering completion", () => {
+    const definition = SHORTCUT_DEFINITIONS.find((item) => item.id === "triggerCompletion");
+
+    expect(definition).toMatchObject({ scope: "editor", defaultShortcut: "Alt+/" });
+    expect(DEFAULT_SHORTCUT_SETTINGS.triggerCompletion).toBe("Alt+/");
+    expect(formatShortcut(DEFAULT_SHORTCUT_SETTINGS.triggerCompletion, "Win32")).toBe("Alt+/");
+    expect(formatShortcut(DEFAULT_SHORTCUT_SETTINGS.triggerCompletion, "MacIntel")).toBe("Alt+/");
+    expect(shortcutToCodeMirrorKey(DEFAULT_SHORTCUT_SETTINGS.triggerCompletion)).toBe("Alt-/");
+    expect(findShortcutConflict("triggerCompletion", DEFAULT_SHORTCUT_SETTINGS.triggerCompletion, DEFAULT_SHORTCUT_SETTINGS)).toBeNull();
+  });
+
   it("detects conflicts between formatter editor shortcuts and other editor shortcuts", () => {
     const shortcuts = normalizeShortcutSettings({ duplicateLine: "Mod+F" });
 

--- a/apps/desktop/src/lib/editor/queryEditorCompletionShortcut.ts
+++ b/apps/desktop/src/lib/editor/queryEditorCompletionShortcut.ts
@@ -1,0 +1,26 @@
+import type { Command, KeyBinding } from "@codemirror/view";
+import { matchesShortcut, type ShortcutLikeEvent } from "@/lib/editor/keyboardShortcuts";
+import { isMacShortcutPlatform } from "@/lib/editor/shortcutDisplay";
+import { shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
+
+function matchesMacOptionSlash(event: ShortcutLikeEvent, shortcut: string, platform: string): boolean {
+  if (!isMacShortcutPlatform(platform) || shortcut !== "Alt+/" || event.isComposing) return false;
+  if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return false;
+  return event.code === "Slash";
+}
+
+export function createQueryEditorCompletionShortcutBindings(shortcut: string, run: Command, platform = globalThis.navigator?.platform || ""): KeyBinding[] {
+  if (!shortcut) return [];
+  if (!isMacShortcutPlatform(platform) || shortcut !== "Alt+/") {
+    return [{ key: shortcutToCodeMirrorKey(shortcut), run }];
+  }
+  return [
+    {
+      any(view, event) {
+        if (event.isComposing) return false;
+        if (!matchesShortcut(event, shortcut, platform) && !matchesMacOptionSlash(event, shortcut, platform)) return false;
+        return run(view);
+      },
+    },
+  ];
+}

--- a/apps/desktop/src/lib/editor/shortcutRegistry.ts
+++ b/apps/desktop/src/lib/editor/shortcutRegistry.ts
@@ -9,6 +9,7 @@ export type ShortcutActionId =
   | "toggleBlockComment"
   | "saveSql"
   | "acceptCompletion"
+  | "triggerCompletion"
   | "indentMore"
   | "indentLess"
   | "insertLineBelow"
@@ -137,6 +138,12 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     labelKey: "settings.shortcutAcceptCompletion",
     scope: "editor",
     defaultShortcut: "Tab",
+  },
+  {
+    id: "triggerCompletion",
+    labelKey: "settings.shortcutTriggerCompletion",
+    scope: "editor",
+    defaultShortcut: "Alt+/",
   },
   {
     id: "indentMore",


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
## Problem

  Fixes #6428.

  SQL completion can currently be opened manually only through CodeMirror’s built-in `Ctrl+Space` binding. This shortcut is not configurable and commonly conflicts with
  CJK IME switching, forcing users to modify text to reopen completion.

  ## Root cause

  The query editor already supports CodeMirror’s explicit completion path, but DBX did not expose it as a configurable shortcut action.

  ## Fix

  - Add an editor-scoped `triggerCompletion` shortcut with default `Alt+/`.
  - Invoke CodeMirror `startCompletion` through the explicit completion path.
  - Preserve the IME composition guard and avoid marking manual activation as typed input.
  - Surface the shortcut in Editor Settings, settings search, and eight locale files.

  ## Compatibility

  - Existing `Ctrl+Space` and macOS completion bindings remain available.
  - Automatic completion trigger modes are unchanged.
  - Users can rebind or clear the new shortcut in Editor Settings.

  ## Validation

  - `git diff --check` — passed
  - `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts` —
  passed (35 tests)
  - `pnpm lint` — passed with existing unrelated warnings
  - `pnpm typecheck` — passed
## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1564" height="949" alt="ce99b9d4-2f0c-4d48-9385-c49f4376b104" src="https://github.com/user-attachments/assets/2bef79fe-b31b-449c-936e-168d456827ed" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #6428
