### PR TITLE
fix(gaussdb): align delete button height with input fields in multi-h…

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -7117,7 +7117,7 @@ function openExternalUrl(url: string) {
                         <div v-for="(entry, idx) in gaussdbHostEntries" :key="idx" class="flex items-start gap-2">
                           <Input v-model="entry.host" class="flex-1 min-w-0 break-all" placeholder="127.0.0.1" />
                           <Input v-model.number="entry.port" type="number" class="w-24 shrink-0" />
-                          <Button type="button" variant="outline" size="icon" class="h-9 w-9 shrink-0 mt-0.5" :disabled="gaussdbHostEntries.length <= 1" @click="removeGaussdbHostEntry(idx)">
+                          <Button type="button" variant="outline" size="icon" class="h-8 w-8 shrink-0" :disabled="gaussdbHostEntries.length <= 1" @click="removeGaussdbHostEntry(idx)">
                             <Trash2 class="h-4 w-4" />
                           </Button>
                         </div>


### PR DESCRIPTION
将 GaussDB 多主机动态列表中的删除按钮高度从 `h-9`（36px）改为 `h-8`（32px），与 Input 组件高度对齐，同时去掉多余的 `mt-0.5` 上边距。