### PR TITLE
fix(script):修复Makefile检查端口命令Windows环境下报错的问题。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ install:
 docs-install:
 	cd docs && $(PNPM) install --frozen-lockfile
 
+ifeq ($(OS),Windows_NT)
+check-tauri-dev-port:
+	@powershell -NoProfile -Command "if (Get-NetTCPConnection -LocalPort $(TAURI_DEV_PORT) -State Listen -ErrorAction SilentlyContinue) { Write-Host 'Port $(TAURI_DEV_PORT) is already in use. DBX Tauri dev requires http://localhost:$(TAURI_DEV_PORT).'; Write-Host ''; Get-NetTCPConnection -LocalPort $(TAURI_DEV_PORT) -State Listen -ErrorAction SilentlyContinue | Format-Table LocalAddress,LocalPort,OwningProcess -AutoSize; Write-Host 'Stop the process above, then run make dev again.'; exit 1 }"
+else
 check-tauri-dev-port:
 	@if lsof -nP -iTCP:$(TAURI_DEV_PORT) -sTCP:LISTEN >/dev/null 2>&1; then \
 		echo "Port $(TAURI_DEV_PORT) is already in use. DBX Tauri dev requires http://localhost:$(TAURI_DEV_PORT)."; \
@@ -70,6 +74,7 @@ check-tauri-dev-port:
 		echo "Stop the process above, then run make dev again. Example: kill <PID>"; \
 		exit 1; \
 	fi
+endif
 
 dev: node_modules/.modules.yaml check-tauri-dev-port
 	$(PNPM) dev:tauri


### PR DESCRIPTION


## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
修复Makefile检查端口命令Windows环境下报错的问题。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过
- [x] win 11 环境下执行相关mark命令无报错
## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
无