### PR TITLE
fix(objects): stop object type labels from matching object browser search

### DIFF
--- a/apps/desktop/src/lib/table/objectBrowserRows.ts
+++ b/apps/desktop/src/lib/table/objectBrowserRows.ts
@@ -231,9 +231,14 @@ export function filterObjectBrowserRows(rows: ObjectBrowserRow[], query: string)
   if (!q) return rows;
   const regex = parseSlashDelimitedRegexQuery(query.trim());
   if (regex) {
-    return rows.filter((row) => [row.displayName, row.name, row.type, row.comment].filter(Boolean).some((value) => regex.test(String(value))));
+    // Object type labels ("TABLE", "VIEW", "PROCEDURE", ...) are deliberately
+    // not searchable: a query like "TAB" would otherwise match every TABLE row
+    // via its type label (issue #6488). The type filter buttons cover type
+    // scoping, and every other search path (sidebar tree, backend metadata)
+    // matches names and comments only.
+    return rows.filter((row) => [row.displayName, row.name, row.comment].filter(Boolean).some((value) => regex.test(String(value))));
   }
-  return rows.filter((row) => [row.displayName, row.name, row.type, row.comment].filter(Boolean).some((value) => String(value).toLowerCase().includes(q)));
+  return rows.filter((row) => [row.displayName, row.name, row.comment].filter(Boolean).some((value) => String(value).toLowerCase().includes(q)));
 }
 
 export function countObjectBrowserRowsByFilter(rows: ObjectBrowserRow[]): ObjectBrowserFilterCounts {

--- a/packages/app-tests/objectBrowserRows.test.ts
+++ b/packages/app-tests/objectBrowserRows.test.ts
@@ -94,7 +94,7 @@ test("object browser rows normalize space separated materialized views", () => {
   );
 });
 
-test("object browser search matches names, types, and comments but not schema names", () => {
+test("object browser search matches names and comments but not schema names", () => {
   const rows = buildObjectBrowserRows({
     objects: [
       { name: "users", object_type: "TABLE", schema: "exam_hub", comment: "account records" },
@@ -110,6 +110,37 @@ test("object browser search matches names, types, and comments but not schema na
     filterObjectBrowserRows(rows, "exam").map((row) => row.name),
     ["orders", "refresh_exam_stats"],
   );
+});
+
+test("object browser search matches names, never object type labels", () => {
+  const rows = buildObjectBrowserRows({
+    objects: [
+      { name: "tab_history", object_type: "TABLE", schema: "public" },
+      { name: "user_accounts", object_type: "TABLE", schema: "public", comment: "user account records" },
+      { name: "v_sales_summary", object_type: "VIEW", schema: "public" },
+      { name: "refresh_sales", object_type: "PROCEDURE", schema: "public" },
+    ],
+    database: "app",
+    fallbackSchema: "public",
+    needsSchema: true,
+  });
+
+  const names = (query: string) => filterObjectBrowserRows(rows, query).map((row) => row.name);
+
+  // "TAB" must not surface every TABLE row through its type label (issue #6488).
+  assert.deepEqual(names("TAB"), ["tab_history"]);
+  assert.deepEqual(names("tab"), ["tab_history"]);
+  assert.deepEqual(names("Tab"), ["tab_history"]);
+  assert.deepEqual(names("TABLE"), []);
+  assert.deepEqual(names("VIEW"), []);
+  // Name prefix and middle-substring matching keep working.
+  assert.deepEqual(names("sales"), ["v_sales_summary", "refresh_sales"]);
+  assert.deepEqual(names("history"), ["tab_history"]);
+  // Comment matching keeps working.
+  assert.deepEqual(names("accounts"), ["user_accounts"]);
+  // Non-existent keywords return nothing; empty queries keep everything.
+  assert.deepEqual(names("TAB1"), []);
+  assert.equal(names("   ").length, rows.length);
 });
 
 test("object browser search supports slash-delimited regular expression queries", () => {


### PR DESCRIPTION
## Summary

- 修复对象浏览器（Object Browser）搜索：输入 `TAB` 时不再把全部 TABLE 行都当作匹配结果。
- 将对象搜索的匹配字段从 `[displayName, name, type, comment]` 收敛为 `[displayName, name, comment]`，与侧边栏树搜索、后端元数据搜索（均只匹配名称与注释）保持一致。
- 对象类型过滤仍由页面上的类型按钮（全部/表/视图/存储过程/函数…）承担，不依赖搜索关键字。

## Root cause

`filterObjectBrowserRows`（`apps/desktop/src/lib/table/objectBrowserRows.ts`）把对象的**类型标签**（`TABLE` / `VIEW` / `PROCEDURE` …）纳入搜索字段。

- 输入 `TAB` 时，小写化后为 `tab`，而每个 TABLE 行的类型字符串 `TABLE` 包含子串 `tab` → 所有表全部"匹配"，看起来搜索完全没有生效（截图 1："全部 204"）。
- 输入 `TAB1` 时，类型标签不含 `tab1`、名称也不匹配 → 零结果（截图 2："没有找到对象"）。

这解释了 issue 中"输入 TAB 一个都没变、输入 TAB1 就全没了"的现象，且与具体数据库无关（通用）。

## Tests

新增回归测试 `object browser search matches names, never object type labels`，覆盖：`TAB` / `tab` / `Tab` / `TABLE` / `VIEW` / 前缀 / 中间子串 / 注释匹配 / 空查询 / 不存在关键字。

实际执行并 PASS：

- `pnpm exec vitest run packages/app-tests/objectBrowserRows.test.ts` — 19 passed
- 对象浏览器相关 7 个测试文件 — 85 passed
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json` — 无错误
- `pnpm exec oxlint apps/desktop/src/lib/table/objectBrowserRows.ts packages/app-tests/objectBrowserRows.test.ts` — 通过
- `pnpm exec oxfmt --check apps/desktop/src/lib/table/objectBrowserRows.ts` — 通过

## Issue

Fixes #6488
