### PR TITLE
feat(sidebar): add New Query to table context menu

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -1558,7 +1558,19 @@ async function newQuery() {
     connectionStore.activeConnectionId = node.connectionId;
     if (hasTreeNodeDatabaseContext(node)) {
       if (node.type === "table" || node.type === "view" || node.type === "materialized_view") {
-        await newSelectTemplate();
+        const config = connectionStore.getConfig(node.connectionId);
+        const dbType = config ? effectiveDatabaseTypeForConnection(config) : undefined;
+        const identifierQuote = connectionStore.connectionIdentifierQuote(node.connectionId);
+        const sql = buildTableSelectTemplate({
+          databaseType: dbType,
+          identifierQuote,
+          catalog: node.catalog,
+          database: node.database,
+          schema: node.schema,
+          tableName: node.label,
+          columns: [],
+        });
+        openSqlTemplateTab(node.connectionId, node.database, node.schema, node.catalog, sql);
         return;
       }
       queryStore.createTab(node.connectionId, node.database, undefined, "query", node.schema, undefined, node.catalog);
@@ -4979,6 +4991,7 @@ function buildObjectSidebarMenu(context: SidebarMenuFactoryContext): boolean {
     }
     const destructiveActions: ContextMenuItem[] = [];
     items.push(copyNameMenuItem());
+    items.push({ label: t("contextMenu.newQuery"), action: newQuery, icon: TerminalSquare });
     items.push({ label: "", separator: true });
     items.push({ label: t("contextMenu.viewData"), action: openDataImmediately, icon: TableProperties });
     items.push({


### PR DESCRIPTION
## Description
Add "New Query" below "Copy name" in the table/view context menu, reusing the existing newQuery() handler used by connection/schema nodes. Also aligns it to plain `SELECT * FROM <table>`, matching the appbar's New Query button instead of listing every column.

## Type of Change

- [X] New Feature
- [ ] Bug Fix
- [ ] Performance Optimization
- [ ] Code Refactoring
- [ ] Documentation Update
- [ ] CI / Build

## Frontend Changes
- [x] This PR involves frontend changes, and screenshots/screen recordings are attached below
<img width="304" height="97" alt="image" src="https://github.com/user-attachments/assets/e6ec570d-dae9-4a94-abdb-3cd9bd7ad6be" />

## Verification
- [x] `pnpm test` — 40/40 pass di apps/desktop/src/components/sidebar/__tests__
- [x] `vue-tsc --noEmit` (typecheck) — clean, no error

