### PR TITLE
fix(schema-diff): 部署确认框在检测到破坏性操作时按钮被裁掉

### DIFF
--- a/apps/desktop/src/components/diff/SchemaDiffDialog.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDialog.vue
@@ -1026,7 +1026,7 @@ const targetConnectionInfo = computed(() => {
             </DialogTitle>
           </DialogHeader>
 
-          <div class="py-2 space-y-3">
+          <div class="py-2 space-y-3 min-w-0">
             <p class="text-sm text-muted-foreground">{{ t("diff.deployConfirmMessage") }}</p>
 
             <div class="bg-muted p-3 rounded text-xs font-mono space-y-1">

--- a/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
@@ -22,4 +22,8 @@ describe("SchemaDiffDialog fullscreen layout", () => {
     expect(dialogSource).toContain("event.preventDefault();");
     expect(dialogSource).toContain("showOptionsPanel.value = false;");
   });
+
+  it("lets the deploy confirm dialog body shrink so a long destructive statement can't push the footer buttons off-screen", () => {
+    expect(dialogSource).toContain('<div class="py-2 space-y-3 min-w-0">');
+  });
 });


### PR DESCRIPTION
Fixes #6477

## 问题

比较架构（Compare Schemas）功能里，部署到目标数据库前弹出的"Final Confirmation"确认框，在检测到破坏性操作（如 `ALTER TABLE ... DROP COLUMN`）时，右下角的 "Confirm Deploy" 按钮会被裁切，只剩下开头一两个字（如 "Con"），视觉上等同于"看不到确认按钮"。

## 根因

`SchemaDiffDialog.vue` 的确认框里，检测到破坏性 DDL 后会显示一段警告文字，直接把完整的 SQL 语句（如 `ALTER TABLE ... DROP COLUMN xxx`）渲染成不换行的等宽文本。这段文字所在的容器是对话框（`grid`、`overflow-hidden`、固定 `max-w-[520px]`）里的一个 grid 子项，默认 `min-width: auto`，导致这段超长文本把该 grid 列撑宽到超出 520px；`DialogFooter`（包含 Cancel / Confirm Deploy 按钮）在同一个 grid 容器里，也被一起撑宽，右侧超出对话框可视宽度的部分被 `overflow-hidden` 裁掉——正好裁到 "Confirm Deploy" 按钮上。

按钮本身其实一直存在于 DOM 里（程序化点击仍能点中并成功执行部署），只是**视觉上**被裁没了，普通用户看到的就是"确认框没有确认按钮"。

## 修复

给确认框内容的最外层 `<div>` 加一个 `min-w-0`，让这个 grid 子项可以收缩到小于其内容的固有宽度，使得内部长 SQL 文本原本就写好的 `truncate` / `overflow-auto` 样式真正生效（改成显示省略号截断，而不是撑爆容器）。一行 CSS class 改动，不涉及任何逻辑变更。

## 复现与验证

真实复现（真实 `dbx-web` dev 后端 + `pnpm dev:web` + 真实浏览器 Playwright，独立 MySQL 8.0 测试库，用完已清理）：让目标表比源表多一个字段，触发 `DROP COLUMN` 这个破坏性操作，走完整的 Compare Schemas → Review Deploy → Deploy to Server 流程，确认修复前按钮被裁、修复后完整可见（像素级测量：修复前 Confirm Deploy 按钮右边界超出对话框可视区域 86px；修复后完全落在可视区域内）。

同时验证了 issue 截图里的"正常操作"场景（多对象 diff、无破坏性操作）不受影响，两个按钮修复前后均正常显示。

- 新增回归测试断言 `min-w-0` 存在；revert 后测试真实失败，reapply 后真实通过。
- 该组件原有测试全绿。
- 全量前端测试 `pnpm exec vitest run apps/desktop/src`：712 文件 / 6664 测试，仅 1 个已知的、与本次改动无关的 MongoDB UI flake，其余全绿。
- `pnpm typecheck`、`oxlint` 均干净。

修复前后对比截图见下方评论。