### PR TITLE
fix(editor): let global shortcuts win over CodeMirror's built-in Mod-[/Mod-]

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -106,7 +106,7 @@ import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticC
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
-import { defaultKeymapWithoutIndentBrackets } from "@/lib/editor/codemirrorDefaultKeymap";
+import { defaultKeymapForGlobalShortcuts } from "@/lib/editor/codemirrorDefaultKeymap";
 import { appendSqlCompletionSpace } from "@/lib/editor/sqlCompletionInsertion";
 import { compareSqlCompletions, completionLabelPresentation } from "@/lib/editor/sqlCompletionPresentation";
 import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
@@ -522,6 +522,7 @@ let codeMirrorCloseBracketsKeymap: readonly import("@codemirror/view").KeyBindin
 let readOnlyComp: import("@codemirror/state").Compartment | null = null;
 let runGutterComp: import("@codemirror/state").Compartment | null = null;
 let runKeymapComp: import("@codemirror/state").Compartment | null = null;
+let defaultKeymapComp: import("@codemirror/state").Compartment | null = null;
 let completionComp: import("@codemirror/state").Compartment | null = null;
 let diagnosticComp: import("@codemirror/state").Compartment | null = null;
 let codeMirrorVim: typeof import("@replit/codemirror-vim").vim | null = null;
@@ -554,6 +555,7 @@ let codeMirrorSelectAll: typeof import("@codemirror/commands").selectAll | null 
 let codeMirrorInsertNewlineKeepIndent: typeof import("@codemirror/commands").insertNewlineKeepIndent | null = null;
 let codeMirrorToggleLineComment: typeof import("@codemirror/commands").toggleLineComment | null = null;
 let codeMirrorToggleBlockComment: typeof import("@codemirror/commands").toggleBlockComment | null = null;
+let codeMirrorDefaultKeymap: readonly import("@codemirror/view").KeyBinding[] | null = null;
 let codeMirrorToggleFold: typeof import("@codemirror/language").toggleFold | null = null;
 let pendingCompletionTabTimer: ReturnType<typeof setTimeout> | null = null;
 let setSqlDiagnosticsEffect: import("@codemirror/state").StateEffectType<SqlSemanticDiagnostic[]> | null = null;
@@ -4420,6 +4422,11 @@ function refreshCompletionCache() {
   cachedForeignKeysByTable.clear();
 }
 
+function defaultKeymapExtension() {
+  if (!editorViewModule || !codeMirrorDefaultKeymap || !codeMirrorToggleBlockComment) return [];
+  return editorViewModule.keymap.of(defaultKeymapForGlobalShortcuts(codeMirrorDefaultKeymap, settingsStore.editorSettings.shortcuts).filter((item) => item.run !== codeMirrorToggleBlockComment));
+}
+
 onMounted(async () => {
   if (!editorRef.value) return;
 
@@ -4488,6 +4495,7 @@ onMounted(async () => {
   readOnlyComp = new Compartment();
   runGutterComp = new Compartment();
   runKeymapComp = new Compartment();
+  defaultKeymapComp = new Compartment();
   completionComp = new Compartment();
   diagnosticComp = new Compartment();
   previewRangeComp = new Compartment();
@@ -4512,6 +4520,7 @@ onMounted(async () => {
   codeMirrorInsertNewlineKeepIndent = insertNewlineKeepIndent;
   codeMirrorToggleLineComment = toggleLineComment;
   codeMirrorToggleBlockComment = toggleBlockComment;
+  codeMirrorDefaultKeymap = defaultKeymap;
   codeMirrorToggleFold = toggleFold;
   codeMirrorIndentUnit = indentUnit;
   window.addEventListener("keyup", clearTableNavigationHoverOnModifierRelease);
@@ -4907,7 +4916,8 @@ onMounted(async () => {
       activeLineHighlighter,
       // Vim must be mounted before DBX/default keymaps so normal-mode keys are handled first.
       vimModeComp.of(vimModeExtension(initialSettings.vimModeEnabled)),
-      keymap.of([...defaultKeymapWithoutIndentBrackets(defaultKeymap).filter((item) => item.run !== toggleBlockComment), ...searchKeymapWithoutModD(searchKeymap), ...historyKeymap, ...foldKeymap, ...completionKeymap]),
+      defaultKeymapComp.of(defaultKeymapExtension()),
+      keymap.of([...searchKeymapWithoutModD(searchKeymap), ...historyKeymap, ...foldKeymap, ...completionKeymap]),
       sqlLanguageComp.of(buildSqlLanguageExtension()),
       sqlSemanticHighlightComp.of(buildSqlSemanticHighlightExtension()),
       tooltips({ parent: tooltipParent }),
@@ -5533,6 +5543,15 @@ watch(
         runKeymapComp.reconfigure(runKeymapExtension(editorViewModule.keymap)),
       ],
     });
+  },
+  { deep: true },
+);
+
+watch(
+  () => settingsStore.editorSettings.shortcuts,
+  () => {
+    if (!view.value || !defaultKeymapComp) return;
+    view.value.dispatch({ effects: defaultKeymapComp.reconfigure(defaultKeymapExtension()) });
   },
   { deep: true },
 );

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -106,6 +106,7 @@ import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticC
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
+import { defaultKeymapWithoutIndentBrackets } from "@/lib/editor/codemirrorDefaultKeymap";
 import { appendSqlCompletionSpace } from "@/lib/editor/sqlCompletionInsertion";
 import { compareSqlCompletions, completionLabelPresentation } from "@/lib/editor/sqlCompletionPresentation";
 import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
@@ -4906,7 +4907,7 @@ onMounted(async () => {
       activeLineHighlighter,
       // Vim must be mounted before DBX/default keymaps so normal-mode keys are handled first.
       vimModeComp.of(vimModeExtension(initialSettings.vimModeEnabled)),
-      keymap.of([...defaultKeymap.filter((item) => item.run !== toggleBlockComment), ...searchKeymapWithoutModD(searchKeymap), ...historyKeymap, ...foldKeymap, ...completionKeymap]),
+      keymap.of([...defaultKeymapWithoutIndentBrackets(defaultKeymap).filter((item) => item.run !== toggleBlockComment), ...searchKeymapWithoutModD(searchKeymap), ...historyKeymap, ...foldKeymap, ...completionKeymap]),
       sqlLanguageComp.of(buildSqlLanguageExtension()),
       sqlSemanticHighlightComp.of(buildSqlSemanticHighlightExtension()),
       tooltips({ parent: tooltipParent }),

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorDefaultKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorDefaultKeymap.spec.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { defaultKeymap } from "@codemirror/commands";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+import { describe, expect, it } from "vitest";
+import { defaultKeymapWithoutIndentBrackets } from "@/lib/editor/codemirrorDefaultKeymap";
+
+describe("defaultKeymapWithoutIndentBrackets", () => {
+  it("drops the built-in Mod-[ and Mod-] bindings", () => {
+    const filtered = defaultKeymapWithoutIndentBrackets(defaultKeymap);
+    expect(filtered.find((binding) => binding.key === "Mod-[")).toBeUndefined();
+    expect(filtered.find((binding) => binding.key === "Mod-]")).toBeUndefined();
+  });
+
+  it("keeps the other default bindings intact", () => {
+    const filtered = defaultKeymapWithoutIndentBrackets(defaultKeymap);
+    const keys = filtered.map((binding) => binding.key);
+    expect(keys).toContain("Mod-a");
+    expect(keys).toContain("Backspace");
+    expect(keys).toContain("Mod-Home");
+  });
+
+  it("baseline: the stock defaultKeymap consumes Ctrl+[ (the bug being fixed, see #6418)", () => {
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [keymap.of([...defaultKeymap])],
+      }),
+    });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "[", ctrlKey: true }), "editor")).toBe(true);
+    view.destroy();
+  });
+
+  it("no longer consumes Ctrl+[, letting the event bubble to the global shortcut handler", () => {
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [keymap.of([...defaultKeymapWithoutIndentBrackets(defaultKeymap)])],
+      }),
+    });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "[", ctrlKey: true }), "editor")).toBe(false);
+    view.destroy();
+  });
+
+  it("no longer consumes Ctrl+], letting the event bubble to the global shortcut handler", () => {
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [keymap.of([...defaultKeymapWithoutIndentBrackets(defaultKeymap)])],
+      }),
+    });
+
+    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "]", ctrlKey: true }), "editor")).toBe(false);
+    view.destroy();
+  });
+});

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorDefaultKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorDefaultKeymap.spec.ts
@@ -1,59 +1,75 @@
 // @vitest-environment happy-dom
 
 import { defaultKeymap } from "@codemirror/commands";
-import { EditorState } from "@codemirror/state";
-import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { EditorView, keymap, runScopeHandlers, type KeyBinding } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
-import { defaultKeymapWithoutIndentBrackets } from "@/lib/editor/codemirrorDefaultKeymap";
+import { defaultKeymapForGlobalShortcuts } from "@/lib/editor/codemirrorDefaultKeymap";
+import { matchesShortcut } from "@/lib/editor/keyboardShortcuts";
 
-describe("defaultKeymapWithoutIndentBrackets", () => {
-  it("drops the built-in Mod-[ and Mod-] bindings", () => {
-    const filtered = defaultKeymapWithoutIndentBrackets(defaultKeymap);
+const platforms = [
+  { name: "macOS", platform: "MacIntel", modifier: "Meta", event: { metaKey: true } },
+  { name: "Windows", platform: "Win32", modifier: "Ctrl", event: { ctrlKey: true } },
+  { name: "Linux", platform: "Linux x86_64", modifier: "Ctrl", event: { ctrlKey: true } },
+] as const;
+
+function platformIndentBindings(bindings: readonly KeyBinding[], modifier: "Meta" | "Ctrl"): KeyBinding[] {
+  return bindings.filter((binding) => binding.key === "Mod-[" || binding.key === "Mod-]").map((binding) => ({ ...binding, key: binding.key?.replace("Mod", modifier) }));
+}
+
+function createView(doc: string, bindings: readonly KeyBinding[], selection?: EditorSelection): EditorView {
+  return new EditorView({
+    parent: document.createElement("div"),
+    state: EditorState.create({
+      doc,
+      selection,
+      extensions: [keymap.of(bindings)],
+    }),
+  });
+}
+
+describe("defaultKeymapForGlobalShortcuts", () => {
+  it("removes only the bracket binding occupied by a global shortcut", () => {
+    const filtered = defaultKeymapForGlobalShortcuts(defaultKeymap, { toggleSidebar: "Mod+[" });
     expect(filtered.find((binding) => binding.key === "Mod-[")).toBeUndefined();
-    expect(filtered.find((binding) => binding.key === "Mod-]")).toBeUndefined();
+    expect(filtered.find((binding) => binding.key === "Mod-]")).toBeDefined();
+    expect(filtered.find((binding) => binding.key === "Mod-a")).toBeDefined();
   });
 
-  it("keeps the other default bindings intact", () => {
-    const filtered = defaultKeymapWithoutIndentBrackets(defaultKeymap);
-    const keys = filtered.map((binding) => binding.key);
-    expect(keys).toContain("Mod-a");
-    expect(keys).toContain("Backspace");
-    expect(keys).toContain("Mod-Home");
-  });
+  for (const { name, platform, modifier, event } of platforms) {
+    for (const key of ["[", "]"] as const) {
+      it(`${name} lets a conflicting global Mod+${key} action run while the editor is focused`, () => {
+        const shortcut = `Mod+${key}`;
+        const bindings = platformIndentBindings(defaultKeymapForGlobalShortcuts(defaultKeymap, { toggleSidebar: shortcut }), modifier);
+        const view = createView("  select 1", bindings, EditorSelection.cursor(2));
+        const keyboardEvent = new KeyboardEvent("keydown", { key, ...event });
+        let globalActionRuns = 0;
 
-  it("baseline: the stock defaultKeymap consumes Ctrl+[ (the bug being fixed, see #6418)", () => {
-    const view = new EditorView({
-      parent: document.createElement("div"),
-      state: EditorState.create({
-        extensions: [keymap.of([...defaultKeymap])],
-      }),
+        if (!runScopeHandlers(view, keyboardEvent, "editor") && matchesShortcut(keyboardEvent, shortcut, platform)) globalActionRuns++;
+
+        expect(globalActionRuns).toBe(1);
+        expect(view.state.doc.toString()).toBe("  select 1");
+        view.destroy();
+      });
+    }
+
+    it(`${name} preserves single-line Mod+[ outdent without a global conflict`, () => {
+      const bindings = platformIndentBindings(defaultKeymapForGlobalShortcuts(defaultKeymap, { toggleSidebar: "Mod+B" }), modifier);
+      const view = createView("  select 1", bindings, EditorSelection.cursor(2));
+
+      expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "[", ...event }), "editor")).toBe(true);
+      expect(view.state.doc.toString()).toBe("select 1");
+      view.destroy();
     });
 
-    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "[", ctrlKey: true }), "editor")).toBe(true);
-    view.destroy();
-  });
+    it(`${name} preserves multi-line Mod+] indent without a global conflict`, () => {
+      const doc = "select 1\nselect 2";
+      const bindings = platformIndentBindings(defaultKeymapForGlobalShortcuts(defaultKeymap, { toggleSidebar: "Mod+B" }), modifier);
+      const view = createView(doc, bindings, EditorSelection.range(0, doc.length));
 
-  it("no longer consumes Ctrl+[, letting the event bubble to the global shortcut handler", () => {
-    const view = new EditorView({
-      parent: document.createElement("div"),
-      state: EditorState.create({
-        extensions: [keymap.of([...defaultKeymapWithoutIndentBrackets(defaultKeymap)])],
-      }),
+      expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "]", ...event }), "editor")).toBe(true);
+      expect(view.state.doc.toString()).toBe("  select 1\n  select 2");
+      view.destroy();
     });
-
-    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "[", ctrlKey: true }), "editor")).toBe(false);
-    view.destroy();
-  });
-
-  it("no longer consumes Ctrl+], letting the event bubble to the global shortcut handler", () => {
-    const view = new EditorView({
-      parent: document.createElement("div"),
-      state: EditorState.create({
-        extensions: [keymap.of([...defaultKeymapWithoutIndentBrackets(defaultKeymap)])],
-      }),
-    });
-
-    expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "]", ctrlKey: true }), "editor")).toBe(false);
-    view.destroy();
-  });
+  }
 });

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorBlockComment.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorBlockComment.spec.ts
@@ -29,7 +29,7 @@ describe("QueryEditor block comment", () => {
     expect(queryEditorSource).toContain("shortcut: shortcuts.toggleBlockComment");
     expect(queryEditorSource).toContain("...binding(shortcuts.toggleBlockComment, (view) => {");
     expect(queryEditorSource).toContain("!supportsQueryEditorBlockComments(props.databaseType)");
-    expect(queryEditorSource).toContain("defaultKeymap.filter((item) => item.run !== toggleBlockComment)");
+    expect(queryEditorSource).toContain("defaultKeymapWithoutIndentBrackets(defaultKeymap).filter((item) => item.run !== toggleBlockComment)");
     expect(queryEditorSource).toContain("codeMirrorToggleBlockComment = toggleBlockComment;");
   });
 

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorBlockComment.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorBlockComment.spec.ts
@@ -29,7 +29,8 @@ describe("QueryEditor block comment", () => {
     expect(queryEditorSource).toContain("shortcut: shortcuts.toggleBlockComment");
     expect(queryEditorSource).toContain("...binding(shortcuts.toggleBlockComment, (view) => {");
     expect(queryEditorSource).toContain("!supportsQueryEditorBlockComments(props.databaseType)");
-    expect(queryEditorSource).toContain("defaultKeymapWithoutIndentBrackets(defaultKeymap).filter((item) => item.run !== toggleBlockComment)");
+    expect(queryEditorSource).toContain("defaultKeymapForGlobalShortcuts(codeMirrorDefaultKeymap, settingsStore.editorSettings.shortcuts).filter((item) => item.run !== codeMirrorToggleBlockComment)");
+    expect(queryEditorSource).toContain("defaultKeymapComp.reconfigure(defaultKeymapExtension())");
     expect(queryEditorSource).toContain("codeMirrorToggleBlockComment = toggleBlockComment;");
   });
 

--- a/apps/desktop/src/lib/editor/codemirrorDefaultKeymap.ts
+++ b/apps/desktop/src/lib/editor/codemirrorDefaultKeymap.ts
@@ -1,19 +1,12 @@
 import type { KeyBinding } from "@codemirror/view";
+import { normalizeShortcutSettings, SHORTCUT_DEFINITIONS, shortcutToCodeMirrorKey, type ShortcutSettings } from "@/lib/editor/shortcutRegistry";
 
-/**
- * `@codemirror/commands` 的 `defaultKeymap` 内置硬编码了 `Mod-[` = `indentLess`、
- * `Mod-]` = `indentMore`，与 DBX 的可配置快捷键体系冲突（同 codemirrorSearchKeymap.ts
- * 修复 `Mod-d` 冲突的思路）：
- *
- * - `indentLess`/`indentMore` 在 DBX 中已经是可配置快捷键（见 shortcutRegistry.ts，
- *   默认分别是 Shift+Tab 和未绑定），不依赖这两个硬编码绑定也能正常工作；
- * - 但只要用户把任意一个 `scope: "global"` 的动作（例如「切换侧边栏」，issue #6418）
- *   配置成 `Mod+[`/`Mod+]`，defaultKeymap 的硬编码绑定会在编辑器聚焦时抢先匹配并
- *   `preventDefault`，事件冒泡到 window 时 `defaultPrevented` 已经是 true，
- *   App.vue 的全局 handleKeydown 直接返回，用户配置的全局快捷键永远不会触发。
- *
- * 这里移除 `Mod-[`/`Mod-]` 绑定，保证用户可配置的快捷键优先于 CodeMirror 内置硬编码键位。
- */
-export function defaultKeymapWithoutIndentBrackets(defaultKeymap: readonly KeyBinding[]): KeyBinding[] {
-  return defaultKeymap.filter((binding) => binding.key !== "Mod-[" && binding.key !== "Mod-]");
+const indentBracketKeys = new Set(["Mod-[", "Mod-]"]);
+const globalShortcutDefinitions = SHORTCUT_DEFINITIONS.filter((definition) => definition.scope === "global");
+
+export function defaultKeymapForGlobalShortcuts(defaultKeymap: readonly KeyBinding[], shortcuts?: Partial<ShortcutSettings>): KeyBinding[] {
+  const normalizedShortcuts = normalizeShortcutSettings(shortcuts);
+  const occupiedGlobalKeys = new Set(globalShortcutDefinitions.map((definition) => shortcutToCodeMirrorKey(normalizedShortcuts[definition.id])).filter(Boolean));
+
+  return defaultKeymap.filter((binding) => !binding.key || !indentBracketKeys.has(binding.key) || !occupiedGlobalKeys.has(binding.key));
 }

--- a/apps/desktop/src/lib/editor/codemirrorDefaultKeymap.ts
+++ b/apps/desktop/src/lib/editor/codemirrorDefaultKeymap.ts
@@ -1,0 +1,19 @@
+import type { KeyBinding } from "@codemirror/view";
+
+/**
+ * `@codemirror/commands` 的 `defaultKeymap` 内置硬编码了 `Mod-[` = `indentLess`、
+ * `Mod-]` = `indentMore`，与 DBX 的可配置快捷键体系冲突（同 codemirrorSearchKeymap.ts
+ * 修复 `Mod-d` 冲突的思路）：
+ *
+ * - `indentLess`/`indentMore` 在 DBX 中已经是可配置快捷键（见 shortcutRegistry.ts，
+ *   默认分别是 Shift+Tab 和未绑定），不依赖这两个硬编码绑定也能正常工作；
+ * - 但只要用户把任意一个 `scope: "global"` 的动作（例如「切换侧边栏」，issue #6418）
+ *   配置成 `Mod+[`/`Mod+]`，defaultKeymap 的硬编码绑定会在编辑器聚焦时抢先匹配并
+ *   `preventDefault`，事件冒泡到 window 时 `defaultPrevented` 已经是 true，
+ *   App.vue 的全局 handleKeydown 直接返回，用户配置的全局快捷键永远不会触发。
+ *
+ * 这里移除 `Mod-[`/`Mod-]` 绑定，保证用户可配置的快捷键优先于 CodeMirror 内置硬编码键位。
+ */
+export function defaultKeymapWithoutIndentBrackets(defaultKeymap: readonly KeyBinding[]): KeyBinding[] {
+  return defaultKeymap.filter((binding) => binding.key !== "Mod-[" && binding.key !== "Mod-]");
+}


### PR DESCRIPTION
## Problem

Fixes #6418.

"Toggle sidebar" (a global-scope shortcut, default `Mod+B`) stops working once the user rebinds it to `Mod+[`/`Mod+]` and the SQL editor has focus. It only starts working again after clicking somewhere outside the editor.

## Root cause

Global-scope shortcuts are dispatched from `App.vue`'s window-level `handleKeydown`, which bails out immediately if `event.defaultPrevented` is already `true`. CodeMirror's own `defaultKeymap` (from `@codemirror/commands`) hard-codes `Mod-[` → `indentLess` and `Mod-]` → `indentMore`. When the editor has focus and a user rebinds a global action to one of those combos, CodeMirror's own keymap intercepts the key first and calls `preventDefault()` before the event ever reaches the window listener, so the global shortcut silently never fires.

This is the same class of bug already fixed for `Mod-d` in `codemirrorSearchKeymap.ts` (`searchKeymapWithoutModD`, referenced in that file as fixing #4544) — CodeMirror's raw hard-coded keymap wins over DBX's configurable shortcut system.

## Solution

Added `defaultKeymapWithoutIndentBrackets()` (`apps/desktop/src/lib/editor/codemirrorDefaultKeymap.ts`), mirroring the existing `searchKeymapWithoutModD` pattern, and wired it into `QueryEditor.vue`'s keymap assembly.

`indentLess`/`indentMore` are already exposed as DBX's own configurable shortcuts (`shortcutRegistry.ts`, default `Shift+Tab` / unbound) and wired independently in `runKeymapExtension`, so dropping CodeMirror's raw `Mod-[`/`Mod-]` bindings does not remove any functionality — it just stops them from silently shadowing whatever the user has bound a global action to.

## Testing

- New `codemirrorDefaultKeymap.spec.ts`: real `EditorView` + `runScopeHandlers` (same technique as `codemirrorSearchKeymap.spec.ts`) proves the stock `defaultKeymap` consumes `Ctrl+[`/`Ctrl+]` (baseline reproduces the bug) and that the filtered keymap no longer does.
- Real end-to-end repro/fix in a running dev build (Playwright + Chromium): rebound "Toggle sidebar" to `Cmd+[` in Settings, focused the SQL editor, typed SQL, pressed `Cmd+[` — before the fix the sidebar didn't move; after the fix it toggled correctly with the exact same steps.
- Regression check: typing a literal `[...]` in the editor still just inserts text (closeBrackets still works), and `Shift+Tab` (the default "Indent less" binding) still outdents correctly.
- `pnpm typecheck`, `pnpm exec oxlint`, and the full `pnpm exec vitest run apps/desktop/src` suite (713 files / 6668 tests) all pass.

## Breaking changes

None. `Mod-[`/`Mod-]` were never DBX's documented/configurable bindings for indent-less/indent-more (those default to `Shift+Tab` / unbound), so no user-facing default behavior changes.