### PR TITLE
fix(ai): replay complete MiniMax incremental reasoning

### DIFF
--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -929,11 +929,7 @@ impl MiniMaxTextAccumulator {
     }
 
     fn replay_text(&self) -> &str {
-        if matches!(self.semantics, MiniMaxStreamSemantics::Incremental) {
-            &self.latest
-        } else {
-            &self.complete
-        }
+        &self.complete
     }
 }
 


### PR DESCRIPTION
## Summary

- replay the complete accumulated reasoning text for MiniMax incremental streams
- keep per-event incremental deltas unchanged

## Root cause

`MiniMaxTextAccumulator` appended incremental fragments to `complete`, but `replay_text()` returned only `latest` in incremental mode. A stream containing `a` followed by `and` therefore emitted correct deltas while persisting only `and` instead of `aand` for tool-call replay.

## Validation

- reproduced the existing regression before the fix
- `cargo fmt --check`
- `minimax_cumulative_text_normalizer_emits_only_new_suffixes`
- `minimax_stream_state_reconstructs_incremental_reasoning_details_for_replay`
- `minimax_china_stream_keeps_incremental_fragments_that_share_a_prefix`
