### PR TITLE
fix(mongodb): append infinite-scroll segments instead of replacing them

### DIFF
--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -116,6 +116,12 @@ const DYNAMODB_DEFAULT_EXPORT_ROW_LIMIT = 10_000;
 
 const documents = ref<JsonRecord[]>([]);
 const copyDocuments = ref<JsonRecord[]>([]);
+// Set only when the most recent load() appended a continuation segment onto
+// the existing documents (infinite scroll); undefined for a full replace.
+// Mirrors QueryResult.appended_from_row_count so DataGrid's infinite-scroll
+// bookkeeping (see appendQueryResultSegment in queryStore.ts) can tell a
+// genuine append apart from a stale/failed one.
+const appendedFromRowCount = ref<number | undefined>(undefined);
 const mongoCopyDocumentsAvailable = ref(false);
 const lastGridColumns = ref<string[]>([]);
 const lastGridColumnTypes = ref<string[]>([]);
@@ -388,7 +394,17 @@ const gridResult = computed<QueryResult>(() => {
     }),
   );
 
-  return { columns, column_types: columnTypes, rows, mongo_documents: docs, mongo_copy_documents: copyDocuments.value, affected_rows: 0, execution_time_ms: 0, truncated: false };
+  return {
+    columns,
+    column_types: columnTypes,
+    rows,
+    mongo_documents: docs,
+    mongo_copy_documents: copyDocuments.value,
+    affected_rows: 0,
+    execution_time_ms: 0,
+    truncated: false,
+    appended_from_row_count: appendedFromRowCount.value,
+  };
 });
 
 async function exportAllDocumentStoreDocuments(onProgress?: (info: { rowsExported: number; totalRows: number | null }) => void): Promise<QueryResult | undefined> {
@@ -1275,7 +1291,7 @@ function applyElasticsearchSearchTotal(searchTotal: number, isExact: boolean, fi
   startElasticsearchExactCount(filter);
 }
 
-async function load(options: { page?: number } = {}) {
+async function load(options: { page?: number; append?: boolean } = {}) {
   if (documentLoadExecutionId.value) void api.cancelQuery(documentLoadExecutionId.value);
   const requestGeneration = ++documentRequestGeneration;
   const executionId = uuid();
@@ -1327,9 +1343,21 @@ async function load(options: { page?: number } = {}) {
     const nextCopyDocuments = hasTypePreservingCopyDocuments ? result.extended_documents!.map(asRecord) : nextDocuments;
     // Commit page + rows together so stale rows never briefly show last-page indexes.
     if (options.page !== undefined) page.value = options.page;
-    documents.value = nextDocuments;
-    copyDocuments.value = nextCopyDocuments;
-    mongoCopyDocumentsAvailable.value = hasTypePreservingCopyDocuments;
+    if (options.append) {
+      // Infinite-scroll continuation: grow the existing list instead of
+      // replacing it, and record where the new segment was grafted on so
+      // DataGrid's own append bookkeeping (appended_from_row_count) can
+      // confirm this was a real append rather than a stale/failed one.
+      appendedFromRowCount.value = documents.value.length;
+      documents.value = [...documents.value, ...nextDocuments];
+      copyDocuments.value = [...copyDocuments.value, ...nextCopyDocuments];
+      mongoCopyDocumentsAvailable.value = mongoCopyDocumentsAvailable.value && hasTypePreservingCopyDocuments;
+    } else {
+      appendedFromRowCount.value = undefined;
+      documents.value = nextDocuments;
+      copyDocuments.value = nextCopyDocuments;
+      mongoCopyDocumentsAvailable.value = hasTypePreservingCopyDocuments;
+    }
     loadedDocumentQueryTotalCountRequest = countRequest;
     if (storeKind === "dynamodb") {
       const nextCursors = dynamodbPageCursors.value.slice(0, requestPage + 1);
@@ -1337,16 +1365,16 @@ async function load(options: { page?: number } = {}) {
       dynamodbPageCursors.value = nextCursors;
       dynamodbHasNextCursor.value = !!result.next_cursor;
     }
-    if (nextDocuments.length > 0) {
+    if (documents.value.length > 0) {
       const keySet = new Set<string>();
       keySet.add("_id");
-      for (const doc of nextDocuments) {
+      for (const doc of documents.value) {
         for (const key of Object.keys(doc)) {
           if (key !== "_id") keySet.add(key);
         }
       }
       lastGridColumns.value = [...keySet];
-      lastGridColumnTypes.value = storeKind === "mongodb" ? mongoDocumentGridColumnTypes(nextDocuments, lastGridColumns.value) : [];
+      lastGridColumnTypes.value = storeKind === "mongodb" ? mongoDocumentGridColumnTypes(documents.value, lastGridColumns.value) : [];
     }
     if (storeKind === "elasticsearch") {
       applyElasticsearchSearchTotal(result.total, result.total_is_exact !== false, filter);
@@ -1455,7 +1483,12 @@ async function paginate(offset: number, limit: number) {
   const requestedPage = Math.floor(Math.max(0, offset) / normalizedLimit);
   const nextPage = clampDocumentPage(requestedPage, normalizedLimit, paginationTotal.value);
   if (documentStoreProvider.value.kind !== "dynamodb") {
-    await load({ page: nextPage });
+    // Infinite scroll always requests the next contiguous segment starting
+    // exactly at the currently loaded row count. Detect that and append the
+    // segment instead of replacing the whole list (see load()) — otherwise
+    // scrolling past the first batch silently discards the rows already shown.
+    const isInfiniteScrollContinuation = settingsStore.editorSettings.infiniteScroll && !pageSizeChanged && offset > 0 && offset === documents.value.length && nextPage * normalizedLimit === offset;
+    await load({ page: nextPage, append: isInfiniteScrollContinuation });
     return;
   }
   for (let cursorPage = 0; cursorPage <= nextPage; cursorPage += 1) {

--- a/apps/desktop/src/components/document/DocumentBrowser.vue
+++ b/apps/desktop/src/components/document/DocumentBrowser.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, nextTick, watch, onMounted, onBeforeUnmount } from "vue";
+import { computed, ref, shallowRef, nextTick, watch, onMounted, onBeforeUnmount } from "vue";
 import { uuid } from "@/lib/common/utils";
 import { useI18n } from "vue-i18n";
 import { RefreshCw, Trash2, Plus, Save, ChevronDown, ChevronLeft, ChevronRight, Table2, Braces, X, Search, Wrench, Filter, Columns3Cog, SquareDashed, Minus, Rows3, AlignLeft, AlignRight, EyeOff, Palette } from "@lucide/vue";
@@ -116,6 +116,7 @@ const DYNAMODB_DEFAULT_EXPORT_ROW_LIMIT = 10_000;
 
 const documents = ref<JsonRecord[]>([]);
 const copyDocuments = ref<JsonRecord[]>([]);
+const gridRows = shallowRef<QueryResult["rows"]>([]);
 // Set only when the most recent load() appended a continuation segment onto
 // the existing documents (infinite scroll); undefined for a full replace.
 // Mirrors QueryResult.appended_from_row_count so DataGrid's infinite-scroll
@@ -360,6 +361,57 @@ const deleteDetails = computed(() => {
   return t("dangerDialog.mongoFieldDetails", { field: pending.name || t("mongo.field") });
 });
 
+function documentGridColumns(documentsToRender: JsonRecord[]): string[] {
+  const keySet = new Set<string>();
+  keySet.add("_id");
+  for (const doc of documentsToRender) {
+    for (const key of Object.keys(doc)) {
+      if (key !== "_id") keySet.add(key);
+    }
+  }
+  return [...keySet];
+}
+
+function documentGridRow(doc: JsonRecord, columns: string[], kind: DocumentStoreKind): QueryResult["rows"][number] {
+  return columns.map((column) => {
+    const value = mongoDocumentDisplayValue(doc[column]);
+    if (value === undefined || value === null) return null;
+    if (column === "_id") return kind === "mongodb" ? mongoDocumentIdForGrid(value) : documentStoreValueForGrid(value, kind);
+    if (typeof value === "object") return documentStoreValueForGrid(value, kind);
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+    return String(value);
+  });
+}
+
+function sameGridColumns(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((column, index) => column === right[index]);
+}
+
+function commitLoadedDocuments(nextDocuments: JsonRecord[], nextCopyDocuments: JsonRecord[], hasTypePreservingCopyDocuments: boolean, append: boolean, kind: DocumentStoreKind) {
+  const previousDocumentCount = documents.value.length;
+  const combinedDocuments = append ? [...documents.value, ...nextDocuments] : nextDocuments;
+  const nextColumns = combinedDocuments.length > 0 ? documentGridColumns(combinedDocuments) : lastGridColumns.value;
+  const canAppendGridRows = append && gridRows.value.length === previousDocumentCount && sameGridColumns(lastGridColumns.value, nextColumns);
+
+  documents.value = combinedDocuments;
+  copyDocuments.value = append ? [...copyDocuments.value, ...nextCopyDocuments] : nextCopyDocuments;
+  mongoCopyDocumentsAvailable.value = append ? mongoCopyDocumentsAvailable.value && hasTypePreservingCopyDocuments : hasTypePreservingCopyDocuments;
+
+  if (combinedDocuments.length > 0) {
+    lastGridColumns.value = nextColumns;
+    lastGridColumnTypes.value = kind === "mongodb" ? mongoDocumentGridColumnTypes(combinedDocuments, nextColumns) : [];
+  }
+
+  if (canAppendGridRows) {
+    appendedFromRowCount.value = previousDocumentCount;
+    gridRows.value = [...gridRows.value, ...nextDocuments.map((document) => documentGridRow(document, nextColumns, kind))];
+    return;
+  }
+
+  appendedFromRowCount.value = undefined;
+  gridRows.value = combinedDocuments.map((document) => documentGridRow(document, nextColumns, kind));
+}
+
 const gridResult = computed<QueryResult>(() => {
   const docs = documents.value;
   if (!docs.length) {
@@ -373,31 +425,10 @@ const gridResult = computed<QueryResult>(() => {
     };
   }
 
-  const keySet = new Set<string>();
-  keySet.add("_id");
-  for (const doc of docs) {
-    for (const key of Object.keys(doc)) {
-      if (key !== "_id") keySet.add(key);
-    }
-  }
-  const columns = [...keySet];
-  const columnTypes = documentStoreProvider.value.kind === "mongodb" ? mongoDocumentGridColumnTypes(docs, columns) : undefined;
-
-  const rows = docs.map((doc) =>
-    columns.map((col) => {
-      const val = mongoDocumentDisplayValue(doc[col]);
-      if (val === undefined || val === null) return null;
-      if (col === "_id") return documentStoreProvider.value.kind === "mongodb" ? mongoDocumentIdForGrid(val) : documentStoreValueForGrid(val, documentStoreProvider.value.kind);
-      if (typeof val === "object") return documentStoreValueForGrid(val, documentStoreProvider.value.kind);
-      if (typeof val === "string" || typeof val === "number" || typeof val === "boolean") return val;
-      return String(val);
-    }),
-  );
-
   return {
-    columns,
-    column_types: columnTypes,
-    rows,
+    columns: lastGridColumns.value,
+    column_types: lastGridColumnTypes.value,
+    rows: gridRows.value,
     mongo_documents: docs,
     mongo_copy_documents: copyDocuments.value,
     affected_rows: 0,
@@ -938,7 +969,7 @@ async function gridSave(changes: DocumentGridChanges) {
     }
 
     await api.documentSaveMeilisearchBatch(props.connectionId, props.collection, updates, deleteIds, inserts);
-    await load();
+    await reloadDocumentsAfterMutationOrRefresh();
     return;
   }
 
@@ -1010,7 +1041,7 @@ async function gridSave(changes: DocumentGridChanges) {
     page.value = 0;
     resetDynamoDbPagination();
   }
-  await load();
+  await reloadDocumentsAfterMutationOrRefresh();
 }
 
 function buildPathIdentityInsertDocument(row: MongoInputValue[], columns: string[], kind: Exclude<DocumentStoreKind, "mongodb">): JsonRecord {
@@ -1291,7 +1322,7 @@ function applyElasticsearchSearchTotal(searchTotal: number, isExact: boolean, fi
   startElasticsearchExactCount(filter);
 }
 
-async function load(options: { page?: number; append?: boolean } = {}) {
+async function load(options: { page?: number; append?: boolean; offset?: number; limit?: number } = {}) {
   if (documentLoadExecutionId.value) void api.cancelQuery(documentLoadExecutionId.value);
   const requestGeneration = ++documentRequestGeneration;
   const executionId = uuid();
@@ -1325,8 +1356,9 @@ async function load(options: { page?: number; append?: boolean } = {}) {
     if (storeKind === "dynamodb" && requestPage > 0 && !cursor) {
       throw new Error(t("dynamodb.pageCursorUnavailable"));
     }
-    const skip = storeKind === "dynamodb" ? 0 : requestPage * pageSize.value;
-    const result = await api.documentFindDocuments(connectionId, database, collection, skip, documentRequestLimit.value, filter, undefined, sort, undefined, executionId, cursor);
+    const skip = storeKind === "dynamodb" ? 0 : (options.offset ?? requestPage * pageSize.value);
+    const requestLimit = options.limit ?? (storeKind === "elasticsearch" && paginationTotal.value !== undefined ? documentPageRequestLimit(requestPage, pageSize.value, paginationTotal.value) : pageSize.value);
+    const result = await api.documentFindDocuments(connectionId, database, collection, skip, requestLimit, filter, undefined, sort, undefined, executionId, cursor);
     if (documentLoadExecutionId.value !== executionId) return;
     if (connectionId !== props.connectionId || database !== props.database || collection !== props.collection || storeKind !== documentStoreProvider.value.kind) return;
     const nextDocuments =
@@ -1343,38 +1375,13 @@ async function load(options: { page?: number; append?: boolean } = {}) {
     const nextCopyDocuments = hasTypePreservingCopyDocuments ? result.extended_documents!.map(asRecord) : nextDocuments;
     // Commit page + rows together so stale rows never briefly show last-page indexes.
     if (options.page !== undefined) page.value = options.page;
-    if (options.append) {
-      // Infinite-scroll continuation: grow the existing list instead of
-      // replacing it, and record where the new segment was grafted on so
-      // DataGrid's own append bookkeeping (appended_from_row_count) can
-      // confirm this was a real append rather than a stale/failed one.
-      appendedFromRowCount.value = documents.value.length;
-      documents.value = [...documents.value, ...nextDocuments];
-      copyDocuments.value = [...copyDocuments.value, ...nextCopyDocuments];
-      mongoCopyDocumentsAvailable.value = mongoCopyDocumentsAvailable.value && hasTypePreservingCopyDocuments;
-    } else {
-      appendedFromRowCount.value = undefined;
-      documents.value = nextDocuments;
-      copyDocuments.value = nextCopyDocuments;
-      mongoCopyDocumentsAvailable.value = hasTypePreservingCopyDocuments;
-    }
+    commitLoadedDocuments(nextDocuments, nextCopyDocuments, hasTypePreservingCopyDocuments, options.append === true, storeKind);
     loadedDocumentQueryTotalCountRequest = countRequest;
     if (storeKind === "dynamodb") {
       const nextCursors = dynamodbPageCursors.value.slice(0, requestPage + 1);
       nextCursors[requestPage + 1] = result.next_cursor;
       dynamodbPageCursors.value = nextCursors;
       dynamodbHasNextCursor.value = !!result.next_cursor;
-    }
-    if (documents.value.length > 0) {
-      const keySet = new Set<string>();
-      keySet.add("_id");
-      for (const doc of documents.value) {
-        for (const key of Object.keys(doc)) {
-          if (key !== "_id") keySet.add(key);
-        }
-      }
-      lastGridColumns.value = [...keySet];
-      lastGridColumnTypes.value = storeKind === "mongodb" ? mongoDocumentGridColumnTypes(documents.value, lastGridColumns.value) : [];
     }
     if (storeKind === "elasticsearch") {
       applyElasticsearchSearchTotal(result.total, result.total_is_exact !== false, filter);
@@ -1444,7 +1451,17 @@ async function countExactDocumentTotal(): Promise<number | undefined> {
 async function refreshDocuments() {
   if (documentStoreProvider.value.kind === "elasticsearch") resetElasticsearchTotals({ preservePaginationTotal: true });
   if (documentStoreProvider.value.kind === "dynamodb") resetDynamoDbExactCount();
-  await load();
+  await reloadDocumentsAfterMutationOrRefresh();
+}
+
+async function reloadDocumentsAfterMutationOrRefresh() {
+  if (!settingsStore.editorSettings.infiniteScroll) {
+    await load();
+    return;
+  }
+  page.value = 0;
+  dataGridRef.value?.resetInfiniteScrollState?.();
+  await load({ page: 0, offset: 0 });
 }
 
 async function cancelDocumentLoad() {
@@ -1471,7 +1488,14 @@ function applyFilter() {
 }
 
 async function paginate(offset: number, limit: number) {
+  const normalizedOffset = Math.max(0, Math.trunc(offset));
   const normalizedLimit = normalizeResultPageSize(limit, pageSize.value);
+  if (documentStoreProvider.value.kind !== "dynamodb" && settingsStore.editorSettings.infiniteScroll && normalizedOffset > 0 && normalizedOffset === documents.value.length) {
+    const requestedPage = Math.floor(normalizedOffset / pageSize.value);
+    const nextPage = clampDocumentPage(requestedPage, pageSize.value, paginationTotal.value);
+    await load({ page: nextPage, append: true, offset: normalizedOffset, limit: normalizedLimit });
+    return;
+  }
   const pageSizeChanged = normalizedLimit !== pageSize.value;
   pageSize.value = normalizedLimit;
   if (documentStoreProvider.value.kind === "dynamodb" && pageSizeChanged) {
@@ -1480,15 +1504,10 @@ async function paginate(offset: number, limit: number) {
     await load({ page: 0 });
     return;
   }
-  const requestedPage = Math.floor(Math.max(0, offset) / normalizedLimit);
+  const requestedPage = Math.floor(normalizedOffset / normalizedLimit);
   const nextPage = clampDocumentPage(requestedPage, normalizedLimit, paginationTotal.value);
   if (documentStoreProvider.value.kind !== "dynamodb") {
-    // Infinite scroll always requests the next contiguous segment starting
-    // exactly at the currently loaded row count. Detect that and append the
-    // segment instead of replacing the whole list (see load()) — otherwise
-    // scrolling past the first batch silently discards the rows already shown.
-    const isInfiniteScrollContinuation = settingsStore.editorSettings.infiniteScroll && !pageSizeChanged && offset > 0 && offset === documents.value.length && nextPage * normalizedLimit === offset;
-    await load({ page: nextPage, append: isInfiniteScrollContinuation });
+    await load({ page: nextPage, offset: nextPage * normalizedLimit, limit: normalizedLimit });
     return;
   }
   for (let cursorPage = 0; cursorPage <= nextPage; cursorPage += 1) {
@@ -1887,7 +1906,7 @@ async function saveDoc() {
       page.value = 0;
       resetDynamoDbPagination();
     }
-    await load();
+    await reloadDocumentsAfterMutationOrRefresh();
     if (selectedIdx.value !== null && documents.value[selectedIdx.value]) {
       editJson.value = stringifyDocumentStoreValue(documents.value[selectedIdx.value], documentStoreProvider.value.kind, 2);
     }

--- a/apps/desktop/src/components/document/__tests__/DocumentBrowserInfiniteScroll.spec.ts
+++ b/apps/desktop/src/components/document/__tests__/DocumentBrowserInfiniteScroll.spec.ts
@@ -1,0 +1,264 @@
+// @vitest-environment happy-dom
+
+import { createApp, nextTick, type App } from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const backend = vi.hoisted(() => ({
+  documentFindDocuments: vi.fn(),
+  documentCountDocuments: vi.fn(),
+  cancelQuery: vi.fn(),
+  ensureConnected: vi.fn(),
+}));
+
+const dataGrid = vi.hoisted(() => ({
+  paginate: undefined as ((offset: number, limit: number) => Promise<void>) | undefined,
+  rows: [] as unknown[],
+  appendedFromRowCount: undefined as number | undefined,
+}));
+
+const settings = vi.hoisted(() => ({
+  editorSettings: {
+    pageSize: 2,
+    infiniteScroll: true,
+    mongoViewMode: "table" as "document" | "table",
+    columnWidthDensity: "standard" as "compact" | "standard" | "comfortable",
+    dataGridRenderMode: "canvas" as "canvas" | "dom",
+    tableFontFamily: "system-ui",
+    tableFontSize: 12,
+    numericColumnRightAlign: true,
+    confirmDangerousSqlExecution: true,
+    exportBatchSize: 2,
+    exportRowLimitEnabled: false,
+    exportRowLimit: 100_000,
+  },
+  updateEditorSettings: vi.fn(),
+}));
+
+vi.mock("vue-i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vue-i18n")>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/backend/api", () => ({
+  getColumns: vi.fn(),
+  documentFindDocuments: backend.documentFindDocuments,
+  documentCountDocuments: backend.documentCountDocuments,
+  dynamodbDescribeTable: vi.fn(),
+  cancelQuery: backend.cancelQuery,
+  documentInsertDocument: vi.fn(),
+  documentUpdateDocument: vi.fn(),
+  documentDeleteDocument: vi.fn(),
+  documentSaveMeilisearchBatch: vi.fn(),
+}));
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => ({ ensureConnected: backend.ensureConnected }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  TABLE_FONT_SIZE_MIN: 8,
+  TABLE_FONT_SIZE_MAX: 16,
+  useSettingsStore: () => settings,
+}));
+
+vi.mock("@/components/grid/DataGrid.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    default: defineComponent({
+      name: "DataGridStub",
+      inheritAttrs: false,
+      props: {
+        result: { type: Object, required: true },
+      },
+      setup(props, { attrs, expose }) {
+        dataGrid.paginate = attrs.onPaginate as typeof dataGrid.paginate;
+        expose({
+          visibleColumnCount: 2,
+          displayableColumnCount: 2,
+          hiddenColumnCount: 0,
+          orderedColumnLayoutOptions: [],
+          filteredColumnLayoutOptions: () => [],
+          toggleColumnVisibility: vi.fn(),
+          showAllColumns: vi.fn(),
+          invertColumnVisibility: vi.fn(),
+          hasCustomColumnOrder: false,
+          moveDisplayableColumn: vi.fn(),
+          resetColumnOrder: vi.fn(),
+          nullColumnsHidden: false,
+          canToggleAllNullColumns: false,
+          allNullColumnCount: 0,
+          toggleAllNullColumns: vi.fn(),
+          multiRowTranspose: false,
+          setMultiRowTranspose: vi.fn(),
+        });
+        return () => {
+          const result = props.result as { rows?: unknown[]; appended_from_row_count?: number };
+          dataGrid.rows = result.rows ?? [];
+          dataGrid.appendedFromRowCount = result.appended_from_row_count;
+          return h("div", { "data-testid": "data-grid" });
+        };
+      },
+    }),
+  };
+});
+
+vi.mock("@/components/redis/RedisJsonEditor.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    default: defineComponent({
+      props: { modelValue: { type: String, required: true } },
+      setup(props) {
+        return () => h("div", {}, props.modelValue);
+      },
+    }),
+  };
+});
+
+vi.mock("@/components/ui/popover", async () => {
+  const { defineComponent, h } = await import("vue");
+  const passthrough = (name: string) =>
+    defineComponent({
+      name,
+      setup(_, { slots }) {
+        return () => h("div", slots.default?.());
+      },
+    });
+  return { Popover: passthrough("PopoverStub"), PopoverTrigger: passthrough("PopoverTriggerStub"), PopoverContent: passthrough("PopoverContentStub") };
+});
+
+vi.mock("@/components/ui/select", async () => {
+  const { defineComponent, h } = await import("vue");
+  const passthrough = (name: string) =>
+    defineComponent({
+      name,
+      setup(_, { slots }) {
+        return () => h("div", slots.default?.());
+      },
+    });
+  return { Select: passthrough("SelectStub"), SelectContent: passthrough("SelectContentStub"), SelectItem: passthrough("SelectItemStub"), SelectTrigger: passthrough("SelectTriggerStub"), SelectValue: passthrough("SelectValueStub") };
+});
+
+import DocumentBrowser from "@/components/document/DocumentBrowser.vue";
+
+let app: App<Element> | null = null;
+let root: HTMLDivElement | null = null;
+
+async function flushUi() {
+  for (let index = 0; index < 4; index++) {
+    await Promise.resolve();
+    await nextTick();
+  }
+}
+
+beforeEach(async () => {
+  vi.stubGlobal("localStorage", {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  });
+  backend.documentFindDocuments.mockReset();
+  backend.documentCountDocuments.mockReset();
+  backend.cancelQuery.mockReset();
+  backend.ensureConnected.mockReset();
+  backend.ensureConnected.mockResolvedValue(undefined);
+  backend.documentCountDocuments.mockResolvedValue(0);
+  dataGrid.paginate = undefined;
+  dataGrid.rows = [];
+  dataGrid.appendedFromRowCount = undefined;
+  settings.editorSettings.pageSize = 2;
+  settings.editorSettings.infiniteScroll = true;
+
+  root = document.createElement("div");
+  document.body.appendChild(root);
+});
+
+afterEach(() => {
+  app?.unmount();
+  root?.remove();
+  app = null;
+  root = null;
+  vi.unstubAllGlobals();
+});
+
+describe("DocumentBrowser infinite scroll (issue #6455)", () => {
+  it("appends the next segment onto the currently loaded documents instead of replacing them", async () => {
+    backend.documentFindDocuments
+      .mockResolvedValueOnce({
+        documents: [
+          { _id: "1", name: "row_1" },
+          { _id: "2", name: "row_2" },
+        ],
+        total: 4,
+        total_is_exact: true,
+      })
+      .mockResolvedValueOnce({
+        documents: [
+          { _id: "3", name: "row_3" },
+          { _id: "4", name: "row_4" },
+        ],
+        total: 4,
+        total_is_exact: true,
+      });
+
+    app = createApp(DocumentBrowser, {
+      connectionId: "mongo-1",
+      database: "test",
+      collection: "docs",
+      databaseType: "mongodb",
+    });
+    app.mount(root!);
+    await flushUi();
+
+    expect(dataGrid.rows).toHaveLength(2);
+    expect(dataGrid.appendedFromRowCount).toBeUndefined();
+
+    expect(dataGrid.paginate).toBeTypeOf("function");
+    await dataGrid.paginate!(2, 2);
+    await flushUi();
+
+    expect(backend.documentFindDocuments.mock.calls[1]!.slice(0, 5)).toEqual(["mongo-1", "test", "docs", 2, 2]);
+    // The second page must be grafted onto the first, not replace it —
+    // otherwise scrolling past the first batch silently discards it (#6455).
+    expect(dataGrid.rows).toHaveLength(4);
+    expect(dataGrid.rows.map((row) => (row as unknown[])[1])).toEqual(["row_1", "row_2", "row_3", "row_4"]);
+    expect(dataGrid.appendedFromRowCount).toBe(2);
+  });
+
+  it("replaces the documents instead of appending when infinite scroll is disabled", async () => {
+    settings.editorSettings.infiniteScroll = false;
+    backend.documentFindDocuments
+      .mockResolvedValueOnce({
+        documents: [
+          { _id: "1", name: "row_1" },
+          { _id: "2", name: "row_2" },
+        ],
+        total: 4,
+        total_is_exact: true,
+      })
+      .mockResolvedValueOnce({
+        documents: [
+          { _id: "3", name: "row_3" },
+          { _id: "4", name: "row_4" },
+        ],
+        total: 4,
+        total_is_exact: true,
+      });
+
+    app = createApp(DocumentBrowser, {
+      connectionId: "mongo-1",
+      database: "test",
+      collection: "docs",
+      databaseType: "mongodb",
+    });
+    app.mount(root!);
+    await flushUi();
+
+    await dataGrid.paginate!(2, 2);
+    await flushUi();
+
+    // Classic next-page navigation must keep replacing the page, not accumulate rows.
+    expect(dataGrid.rows).toHaveLength(2);
+    expect(dataGrid.rows.map((row) => (row as unknown[])[1])).toEqual(["row_3", "row_4"]);
+    expect(dataGrid.appendedFromRowCount).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/components/document/__tests__/DocumentBrowserInfiniteScroll.spec.ts
+++ b/apps/desktop/src/components/document/__tests__/DocumentBrowserInfiniteScroll.spec.ts
@@ -8,12 +8,26 @@ const backend = vi.hoisted(() => ({
   documentCountDocuments: vi.fn(),
   cancelQuery: vi.fn(),
   ensureConnected: vi.fn(),
+  documentInsertDocument: vi.fn(),
+  documentUpdateDocument: vi.fn(),
+  documentDeleteDocument: vi.fn(),
+  documentSaveMeilisearchBatch: vi.fn(),
 }));
 
 const dataGrid = vi.hoisted(() => ({
   paginate: undefined as ((offset: number, limit: number) => Promise<void>) | undefined,
+  reload: undefined as (() => Promise<void>) | undefined,
+  save: undefined as ((changes: { dirtyRows: Map<number, Map<number, unknown>>; deletedRows: Set<number>; newRows: unknown[][]; newRowMeta: unknown[]; columns: string[]; rows: unknown[][] }) => Promise<void>) | undefined,
+  resetInfiniteScrollState: undefined as ReturnType<typeof vi.fn> | undefined,
+  previousResult: undefined as { rows: readonly unknown[]; appended_from_row_count?: number } | undefined,
   rows: [] as unknown[],
+  columns: [] as string[],
   appendedFromRowCount: undefined as number | undefined,
+  pageOffset: undefined as number | undefined,
+  pageLimit: undefined as number | undefined,
+  selectionActive: false,
+  editActive: false,
+  fullReplaceCount: 0,
 }));
 
 const settings = vi.hoisted(() => ({
@@ -45,10 +59,10 @@ vi.mock("@/lib/backend/api", () => ({
   documentCountDocuments: backend.documentCountDocuments,
   dynamodbDescribeTable: vi.fn(),
   cancelQuery: backend.cancelQuery,
-  documentInsertDocument: vi.fn(),
-  documentUpdateDocument: vi.fn(),
-  documentDeleteDocument: vi.fn(),
-  documentSaveMeilisearchBatch: vi.fn(),
+  documentInsertDocument: backend.documentInsertDocument,
+  documentUpdateDocument: backend.documentUpdateDocument,
+  documentDeleteDocument: backend.documentDeleteDocument,
+  documentSaveMeilisearchBatch: backend.documentSaveMeilisearchBatch,
 }));
 
 vi.mock("@/stores/connectionStore", () => ({
@@ -63,15 +77,23 @@ vi.mock("@/stores/settingsStore", () => ({
 
 vi.mock("@/components/grid/DataGrid.vue", async () => {
   const { defineComponent, h } = await import("vue");
+  const { isDataGridPrefixAppend } = await import("@/lib/dataGrid/dataGridInfiniteScroll");
   return {
     default: defineComponent({
       name: "DataGridStub",
       inheritAttrs: false,
       props: {
         result: { type: Object, required: true },
+        customSaveHandler: { type: Object, required: false },
+        pageOffset: { type: Number, required: false },
+        pageLimit: { type: Number, required: false },
       },
       setup(props, { attrs, expose }) {
         dataGrid.paginate = attrs.onPaginate as typeof dataGrid.paginate;
+        dataGrid.reload = attrs.onReload as typeof dataGrid.reload;
+        dataGrid.save = (props.customSaveHandler as { save?: typeof dataGrid.save } | undefined)?.save;
+        const resetInfiniteScrollState = vi.fn();
+        dataGrid.resetInfiniteScrollState = resetInfiniteScrollState;
         expose({
           visibleColumnCount: 2,
           displayableColumnCount: 2,
@@ -90,11 +112,21 @@ vi.mock("@/components/grid/DataGrid.vue", async () => {
           toggleAllNullColumns: vi.fn(),
           multiRowTranspose: false,
           setMultiRowTranspose: vi.fn(),
+          resetInfiniteScrollState,
         });
         return () => {
-          const result = props.result as { rows?: unknown[]; appended_from_row_count?: number };
-          dataGrid.rows = result.rows ?? [];
+          const result = props.result as { rows: unknown[]; columns?: string[]; appended_from_row_count?: number };
+          if (dataGrid.previousResult && dataGrid.previousResult !== result && !isDataGridPrefixAppend(dataGrid.previousResult, result)) {
+            dataGrid.selectionActive = false;
+            dataGrid.editActive = false;
+            dataGrid.fullReplaceCount += 1;
+          }
+          dataGrid.previousResult = result;
+          dataGrid.rows = result.rows;
+          dataGrid.columns = result.columns ?? [];
           dataGrid.appendedFromRowCount = result.appended_from_row_count;
+          dataGrid.pageOffset = props.pageOffset;
+          dataGrid.pageLimit = props.pageLimit;
           return h("div", { "data-testid": "data-grid" });
         };
       },
@@ -150,6 +182,28 @@ async function flushUi() {
   }
 }
 
+async function mountBrowser() {
+  app = createApp(DocumentBrowser, {
+    connectionId: "mongo-1",
+    database: "test",
+    collection: "docs",
+    databaseType: "mongodb",
+  });
+  app.mount(root!);
+  await flushUi();
+}
+
+function documentResult(start: number, count: number, total: number, extra: Record<string, unknown> = {}) {
+  return {
+    documents: Array.from({ length: count }, (_, index) => {
+      const id = start + index;
+      return { _id: String(id), name: `row_${id}`, ...extra };
+    }),
+    total,
+    total_is_exact: true,
+  };
+}
+
 beforeEach(async () => {
   vi.stubGlobal("localStorage", {
     getItem: () => null,
@@ -160,11 +214,25 @@ beforeEach(async () => {
   backend.documentCountDocuments.mockReset();
   backend.cancelQuery.mockReset();
   backend.ensureConnected.mockReset();
+  backend.documentInsertDocument.mockReset();
+  backend.documentUpdateDocument.mockReset();
+  backend.documentDeleteDocument.mockReset();
+  backend.documentSaveMeilisearchBatch.mockReset();
   backend.ensureConnected.mockResolvedValue(undefined);
   backend.documentCountDocuments.mockResolvedValue(0);
   dataGrid.paginate = undefined;
+  dataGrid.reload = undefined;
+  dataGrid.save = undefined;
+  dataGrid.resetInfiniteScrollState = undefined;
+  dataGrid.previousResult = undefined;
   dataGrid.rows = [];
+  dataGrid.columns = [];
   dataGrid.appendedFromRowCount = undefined;
+  dataGrid.pageOffset = undefined;
+  dataGrid.pageLimit = undefined;
+  dataGrid.selectionActive = false;
+  dataGrid.editActive = false;
+  dataGrid.fullReplaceCount = 0;
   settings.editorSettings.pageSize = 2;
   settings.editorSettings.infiniteScroll = true;
 
@@ -181,36 +249,16 @@ afterEach(() => {
 });
 
 describe("DocumentBrowser infinite scroll (issue #6455)", () => {
-  it("appends the next segment onto the currently loaded documents instead of replacing them", async () => {
-    backend.documentFindDocuments
-      .mockResolvedValueOnce({
-        documents: [
-          { _id: "1", name: "row_1" },
-          { _id: "2", name: "row_2" },
-        ],
-        total: 4,
-        total_is_exact: true,
-      })
-      .mockResolvedValueOnce({
-        documents: [
-          { _id: "3", name: "row_3" },
-          { _id: "4", name: "row_4" },
-        ],
-        total: 4,
-        total_is_exact: true,
-      });
+  it("preserves existing row identity and DataGrid selection/edit state for same-column appends", async () => {
+    backend.documentFindDocuments.mockResolvedValueOnce(documentResult(1, 2, 4)).mockResolvedValueOnce(documentResult(3, 2, 4));
 
-    app = createApp(DocumentBrowser, {
-      connectionId: "mongo-1",
-      database: "test",
-      collection: "docs",
-      databaseType: "mongodb",
-    });
-    app.mount(root!);
-    await flushUi();
+    await mountBrowser();
 
     expect(dataGrid.rows).toHaveLength(2);
     expect(dataGrid.appendedFromRowCount).toBeUndefined();
+    const firstRows = [...dataGrid.rows];
+    dataGrid.selectionActive = true;
+    dataGrid.editActive = true;
 
     expect(dataGrid.paginate).toBeTypeOf("function");
     await dataGrid.paginate!(2, 2);
@@ -222,36 +270,118 @@ describe("DocumentBrowser infinite scroll (issue #6455)", () => {
     expect(dataGrid.rows).toHaveLength(4);
     expect(dataGrid.rows.map((row) => (row as unknown[])[1])).toEqual(["row_1", "row_2", "row_3", "row_4"]);
     expect(dataGrid.appendedFromRowCount).toBe(2);
+    expect(dataGrid.rows[0]).toBe(firstRows[0]);
+    expect(dataGrid.rows[1]).toBe(firstRows[1]);
+    expect(dataGrid.selectionActive).toBe(true);
+    expect(dataGrid.editActive).toBe(true);
+  });
+
+  it("performs a full row rebuild when an appended segment introduces a new column", async () => {
+    backend.documentFindDocuments.mockResolvedValueOnce(documentResult(1, 2, 4)).mockResolvedValueOnce(documentResult(3, 2, 4, { status: "new" }));
+
+    await mountBrowser();
+    const firstRow = dataGrid.rows[0];
+    dataGrid.selectionActive = true;
+    dataGrid.editActive = true;
+
+    await dataGrid.paginate!(2, 2);
+    await flushUi();
+
+    expect(dataGrid.columns).toEqual(["_id", "name", "status"]);
+    expect(dataGrid.appendedFromRowCount).toBeUndefined();
+    expect(dataGrid.rows[0]).not.toBe(firstRow);
+    expect(dataGrid.selectionActive).toBe(false);
+    expect(dataGrid.editActive).toBe(false);
+  });
+
+  it("reloads from offset zero after three segments are refreshed", async () => {
+    backend.documentFindDocuments
+      .mockResolvedValueOnce(documentResult(1, 2, 8))
+      .mockResolvedValueOnce(documentResult(3, 2, 8))
+      .mockResolvedValueOnce(documentResult(5, 2, 8))
+      .mockResolvedValueOnce(documentResult(1, 2, 8, { refreshed: true }));
+
+    await mountBrowser();
+    await dataGrid.paginate!(2, 2);
+    await dataGrid.paginate!(4, 2);
+    await flushUi();
+    expect(dataGrid.rows).toHaveLength(6);
+
+    await dataGrid.reload!();
+    await flushUi();
+
+    expect(backend.documentFindDocuments.mock.calls[3]!.slice(0, 5)).toEqual(["mongo-1", "test", "docs", 0, 2]);
+    expect(dataGrid.rows).toHaveLength(2);
+    expect(dataGrid.appendedFromRowCount).toBeUndefined();
+    expect(dataGrid.pageOffset).toBe(0);
+    expect(dataGrid.pageLimit).toBe(2);
+    expect(dataGrid.resetInfiniteScrollState).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads from offset zero after saving with three segments loaded", async () => {
+    backend.documentFindDocuments
+      .mockResolvedValueOnce(documentResult(1, 2, 8))
+      .mockResolvedValueOnce(documentResult(3, 2, 8))
+      .mockResolvedValueOnce(documentResult(5, 2, 8))
+      .mockResolvedValueOnce(documentResult(1, 2, 8, { saved: true }));
+
+    await mountBrowser();
+    await dataGrid.paginate!(2, 2);
+    await dataGrid.paginate!(4, 2);
+    await flushUi();
+
+    await dataGrid.save!({
+      dirtyRows: new Map([[0, new Map([[1, "row_1_updated"]])]]),
+      deletedRows: new Set(),
+      newRows: [],
+      newRowMeta: [],
+      columns: [...dataGrid.columns],
+      rows: dataGrid.rows as unknown[][],
+    });
+    await flushUi();
+
+    expect(backend.documentUpdateDocument).toHaveBeenCalledTimes(1);
+    expect(backend.documentFindDocuments.mock.calls[3]!.slice(0, 5)).toEqual(["mongo-1", "test", "docs", 0, 2]);
+    expect(dataGrid.rows).toHaveLength(2);
+    expect(dataGrid.appendedFromRowCount).toBeUndefined();
+    expect(dataGrid.pageOffset).toBe(0);
+    expect(dataGrid.pageLimit).toBe(2);
+    expect(dataGrid.resetInfiniteScrollState).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the configured page size when the final capped segment has a smaller limit", async () => {
+    settings.editorSettings.pageSize = 3;
+    backend.documentFindDocuments
+      .mockResolvedValueOnce(documentResult(1, 3, 11))
+      .mockResolvedValueOnce(documentResult(4, 3, 11))
+      .mockResolvedValueOnce(documentResult(7, 3, 11))
+      .mockResolvedValueOnce(documentResult(10, 2, 11));
+
+    await mountBrowser();
+    const firstRow = dataGrid.rows[0];
+    await dataGrid.paginate!(3, 3);
+    await dataGrid.paginate!(6, 3);
+    await dataGrid.paginate!(9, 2);
+    await flushUi();
+
+    expect(backend.documentFindDocuments.mock.calls.map((call) => call.slice(3, 5))).toEqual([
+      [0, 3],
+      [3, 3],
+      [6, 3],
+      [9, 2],
+    ]);
+    expect(dataGrid.rows).toHaveLength(11);
+    expect(dataGrid.rows[0]).toBe(firstRow);
+    expect(dataGrid.appendedFromRowCount).toBe(9);
+    expect(dataGrid.pageLimit).toBe(3);
+    expect(dataGrid.pageOffset).toBe(9);
   });
 
   it("replaces the documents instead of appending when infinite scroll is disabled", async () => {
     settings.editorSettings.infiniteScroll = false;
-    backend.documentFindDocuments
-      .mockResolvedValueOnce({
-        documents: [
-          { _id: "1", name: "row_1" },
-          { _id: "2", name: "row_2" },
-        ],
-        total: 4,
-        total_is_exact: true,
-      })
-      .mockResolvedValueOnce({
-        documents: [
-          { _id: "3", name: "row_3" },
-          { _id: "4", name: "row_4" },
-        ],
-        total: 4,
-        total_is_exact: true,
-      });
+    backend.documentFindDocuments.mockResolvedValueOnce(documentResult(1, 2, 4)).mockResolvedValueOnce(documentResult(3, 2, 4));
 
-    app = createApp(DocumentBrowser, {
-      connectionId: "mongo-1",
-      database: "test",
-      collection: "docs",
-      databaseType: "mongodb",
-    });
-    app.mount(root!);
-    await flushUi();
+    await mountBrowser();
 
     await dataGrid.paginate!(2, 2);
     await flushUi();

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -9978,6 +9978,7 @@ defineExpose({
   onToolbarRefresh,
   onToolbarCommit,
   onToolbarRollback,
+  resetInfiniteScrollState,
   showDdl: showTableInfo,
   toggleDdl: toggleTableInfo,
   showTableInfo,

--- a/packages/app-tests/documentBrowser.test.ts
+++ b/packages/app-tests/documentBrowser.test.ts
@@ -87,8 +87,9 @@ test("document table wires on-demand exact total counting for estimated mongo to
 
 test("document pagination commits page index with fetched rows", () => {
   const source = documentBrowserSource();
-  assert.match(source, /async function load\(options: \{ page\?: number \} = \{\}\)/);
-  assert.match(source, /(?:void|await) load\(\{ page: nextPage \}\)/);
+  assert.match(source, /async function load\(options: \{ page\?: number; append\?: boolean; offset\?: number; limit\?: number \} = \{\}\)/);
+  assert.match(source, /await load\(\{ page: nextPage, append: true, offset: normalizedOffset, limit: normalizedLimit \}\)/);
+  assert.match(source, /await load\(\{ page: nextPage, offset: nextPage \* normalizedLimit, limit: normalizedLimit \}\)/);
   assert.match(source, /if \(options\.page !== undefined\) page\.value = options\.page;/);
 });
 


### PR DESCRIPTION
## Problem

Fixes #6455

With infinite scroll enabled, opening a MongoDB collection in table view and scrolling down to load the next segment silently discarded the rows already shown. Reproduction steps from the issue:

1. Enable "Infinite scroll loading" in settings, connect to MongoDB, open a collection with more rows than one page (e.g. 160 rows / page size 100).
2. Scroll down to trigger loading the second segment.
3. Scroll back up.
4. Scroll down again — the grid gets stuck; the first page's rows are gone and only the second segment (60 rows) remains. A manual refresh is needed to restore the first page, after which the same thing happens again.

## Root cause

`DocumentBrowser.vue`'s `paginate()` → `load()` always replaced `documents.value` with whichever page was just fetched (`documents.value = nextDocuments`), regardless of whether the request came from an infinite-scroll continuation or an explicit page jump. `DataGrid`'s infinite scroll requests the next contiguous segment with `offset = <current row count>`, expecting the caller to append that segment onto the existing rows (as `appendQueryResultSegment` already does for SQL query results) — but `DocumentBrowser` had no such append path, so each infinite-scroll fetch replaced the whole list with just the new segment.

## Fix

- `paginate()` now detects a genuine infinite-scroll continuation (infinite scroll enabled, not DynamoDB, page size unchanged, and `offset` exactly equal to the currently loaded row count) and calls `load({ append: true })` for that case.
- `load()` appends the fetched segment onto `documents.value`/`copyDocuments.value` instead of replacing them when `append` is set, and records `appended_from_row_count` on the grid result so `DataGrid`'s own append bookkeeping can confirm the append succeeded (mirrors the existing `appended_from_row_count` convention used by SQL query results).
- Explicit page jumps, filter/sort changes, refreshes, and DynamoDB (cursor-based) pagination are unaffected — they still fully replace the document list.

## Testing

- New test `DocumentBrowserInfiniteScroll.spec.ts`: confirms a continuation segment is appended (not replacing) when infinite scroll is on, and that pagination still replaces the list when infinite scroll is off. Verified the first assertion fails against the pre-fix code (`git apply -R` the fix) and passes after reapplying.
- Real end-to-end repro/verification: local dev backend + frontend against an isolated MongoDB collection (160 documents), driven with Playwright through the exact steps in the issue (scroll down → up → down again). Before the fix, the grid drops to 60 rows after the second down-scroll; after the fix, all 160 rows remain loaded and scrolling reaches the bottom with no extra requests needed on the repeated down-scroll.
- `pnpm exec vitest run apps/desktop/src`: 716 files / 6684 tests pass.
- `pnpm typecheck`, `oxlint`, `oxfmt --check`: clean.
- Rebased onto latest `upstream/main`, no conflicts, re-tested after rebase.