### PR TITLE
feat(ai): keep model provider headers visible

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -2934,8 +2934,8 @@ async function openExternalUrl(url: string) {
                     <input v-model="modelSearchQuery" type="text" :placeholder="t('ai.searchModels')" class="w-full rounded-sm border bg-background py-1.5 pl-7 pr-2 text-xs outline-none focus:ring-1 focus:ring-primary" @click.stop />
                   </div>
                   <div class="max-h-80 overflow-auto">
-                    <template v-for="(config, configIndex) in configuredProviders" :key="config.id">
-                      <button type="button" class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-foreground hover:bg-muted" :aria-expanded="!isModelConfigCollapsed(config.id)" @click="toggleModelConfig(config.id)">
+                    <div v-for="(config, configIndex) in configuredProviders" :key="config.id" class="relative">
+                      <button type="button" class="sticky top-0 z-10 flex w-full items-center gap-2 rounded-sm bg-popover px-2 py-1.5 text-left text-xs text-foreground hover:bg-muted" :aria-expanded="!isModelConfigCollapsed(config.id)" @click="toggleModelConfig(config.id)">
                         <ChevronRight class="h-3.5 w-3.5 shrink-0 transition-transform" :class="{ 'rotate-90': !isModelConfigCollapsed(config.id) }" />
                         <AiProviderLogo :provider="config.provider" :label="AI_PROVIDER_PRESETS[config.provider]?.label ?? config.provider" :icon-slug="AI_PROVIDER_PRESETS[config.provider]?.iconSlug" class="h-3.5 w-3.5 shrink-0" />
                         <span class="min-w-0 flex-1 truncate font-medium">{{ config.name }}</span>
@@ -2984,7 +2984,7 @@ async function openExternalUrl(url: string) {
                         </button>
                       </div>
                       <div v-if="configIndex < configuredProviders.length - 1" class="my-1 border-t" />
-                    </template>
+                    </div>
                   </div>
                   <div v-if="settings.activeModel" class="border-t pt-1">
                     <Popover v-model:open="effortMenuOpen">

--- a/packages/app-tests/aiAssistantComposerLayout.test.ts
+++ b/packages/app-tests/aiAssistantComposerLayout.test.ts
@@ -64,7 +64,8 @@ test("AI model menu separates provider groups from model selections", () => {
   const selectorEnd = source.indexOf("</template>", source.indexOf("</Popover>", selectorStart));
   const selector = source.slice(selectorStart, selectorEnd);
 
-  assert.match(selector, /v-for="\(config, configIndex\) in configuredProviders"/);
+  assert.match(selector, /<div v-for="\(config, configIndex\) in configuredProviders" :key="config\.id" class="relative">/);
+  assert.match(selector, /class="sticky top-0 z-10 flex w-full items-center gap-2 rounded-sm bg-popover/);
   assert.match(selector, /class="ml-5 border-l border-border\/60 pl-1"/);
   assert.match(selector, /v-if="configIndex < configuredProviders\.length - 1" class="my-1 border-t"/);
   assert.doesNotMatch(selector, /bg-accent text-accent-foreground.*config\.id === settings\.activeModel/);


### PR DESCRIPTION
## 变更说明

模型选择器中的 Provider 分组标题现在会在模型列表滚动时吸附在顶部，并在下一个分组到达时自然切换，方便在较长的模型列表中持续确认当前模型所属的 Provider。

实现上为每个 Provider 建立独立的分组容器，并让现有的完整分组标题保持吸顶。因此，折叠箭头、Provider 图标、配置名称、默认状态和加载状态都会继续保留；搜索、模型选择和 Effort 设置行为不变。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

https://github.com/user-attachments/assets/90b49714-0877-4d85-b569-f152f89d77ca

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

手动验证：

1. 打开 AI 对话区域的模型选择器。
2. 上下滚动包含多个 Provider 的模型列表。
3. 确认当前 Provider 分组标题保持吸顶，下一个分组到达后自然替换。
4. 展开或收起部分 Provider 的模型分组，确认吸顶与折叠行为正常。

相关测试：

- `pnpm exec vitest run packages/app-tests/aiAssistantComposerLayout.test.ts`

## 关联 Issue

无