### PR TITLE
feat(objects): add clear button to database and object browser search

### DIFF
--- a/apps/desktop/src/components/objects/DatabaseBrowser.vue
+++ b/apps/desktop/src/components/objects/DatabaseBrowser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from "vue";
-import { ArrowDown, ArrowUp, Database, GripVertical, LayoutGrid, List, Loader2, RefreshCw, Search } from "@lucide/vue";
+import { ArrowDown, ArrowUp, Database, GripVertical, LayoutGrid, List, Loader2, RefreshCw, Search, X } from "@lucide/vue";
 import { useI18n } from "vue-i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,7 +32,7 @@ const props = defineProps<{
 const { t } = useI18n();
 const queryStore = useQueryStore();
 const settingsStore = useSettingsStore();
-const searchInput = ref<HTMLInputElement>();
+const searchInput = ref<InstanceType<typeof Input>>();
 const search = ref("");
 const rows = ref<DatabaseRow[]>([]);
 const loading = ref(false);
@@ -206,8 +206,13 @@ async function refresh(): Promise<boolean> {
 }
 
 function focusSearch(): boolean {
-  searchInput.value?.focus();
+  searchInput.value?.$el?.focus();
   return true;
+}
+
+function clearDatabaseSearch() {
+  search.value = "";
+  searchInput.value?.$el?.focus();
 }
 
 watch(sortKeyOptions, (options) => {
@@ -239,7 +244,10 @@ defineExpose({ focusSearch, refresh });
       </span>
       <div class="relative min-w-0 flex-1">
         <Search class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-        <Input ref="searchInput" v-model="search" class="h-7 pl-8 text-xs" :placeholder="t('databaseBrowser.search')" />
+        <Input ref="searchInput" v-model="search" class="h-7 pl-8 pr-6 text-xs" :placeholder="t('databaseBrowser.search')" />
+        <button v-if="search" type="button" class="absolute right-1.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :aria-label="t('common.clear')" @click="clearDatabaseSearch">
+          <X class="h-3 w-3" />
+        </button>
       </div>
       <div class="flex h-7 shrink-0 items-center rounded border bg-muted/20 p-0.5">
         <select

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -2602,7 +2602,12 @@ function focusSearch(): boolean {
 function onSearchKeydown(event: KeyboardEvent) {
   if (!isCancelSearchShortcut(event)) return;
   event.preventDefault();
+  clearObjectSearch();
+}
+
+function clearObjectSearch() {
   search.value = "";
+  getSearchInput()?.focus();
 }
 
 defineExpose({ focusSearch, refresh });
@@ -2847,7 +2852,10 @@ function getObjectBrowserMenuItems(item: ObjectBrowserRow): ContextMenuItem[] {
       <div class="flex min-w-0 flex-1 items-center gap-2">
         <div class="relative min-w-0 flex-1">
           <Search class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input v-model="search" data-object-search-input class="h-7 pl-8 text-xs" :placeholder="t('objects.search')" @keydown="onSearchKeydown" />
+          <Input v-model="search" data-object-search-input class="h-7 pl-8 pr-6 text-xs" :placeholder="t('objects.search')" @keydown="onSearchKeydown" />
+          <button v-if="search" type="button" class="absolute right-1.5 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground" :aria-label="t('common.clear')" @click="clearObjectSearch">
+            <X class="h-3 w-3" />
+          </button>
         </div>
         <div v-if="showObjectFilter" class="flex h-7 shrink-0 items-center rounded border bg-muted/20 p-0.5">
           <button

--- a/apps/desktop/src/components/objects/__tests__/SearchClearButtons.spec.ts
+++ b/apps/desktop/src/components/objects/__tests__/SearchClearButtons.spec.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const objectBrowserSource = readFileSync(new URL("../ObjectBrowser.vue", import.meta.url), "utf8");
+const databaseBrowserSource = readFileSync(new URL("../DatabaseBrowser.vue", import.meta.url), "utf8");
+
+function functionBody(source: string, name: string): string {
+  const signature = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*(?::\\s*[^\\{]+)?\\{`, "m").exec(source);
+  if (!signature) throw new Error(`Missing function ${name}`);
+  const bodyStart = signature.index + signature[0].length;
+  let depth = 1;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    else if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(bodyStart, index);
+  }
+  throw new Error(`Unclosed function ${name}`);
+}
+
+describe("database and object browser search clear controls", () => {
+  it("renders a clear button with input padding on both search surfaces", () => {
+    expect(objectBrowserSource).toContain('class="h-7 pl-8 pr-6 text-xs"');
+    expect(objectBrowserSource).toContain(':aria-label="t(\'common.clear\')" @click="clearObjectSearch"');
+    expect(objectBrowserSource).toContain('<button v-if="search" type="button"');
+
+    expect(databaseBrowserSource).toContain('class="h-7 pl-8 pr-6 text-xs"');
+    expect(databaseBrowserSource).toContain(':aria-label="t(\'common.clear\')" @click="clearDatabaseSearch"');
+    expect(databaseBrowserSource).toContain('<button v-if="search" type="button"');
+  });
+
+  it("clears and refocuses each search input", () => {
+    expect(functionBody(objectBrowserSource, "clearObjectSearch")).toContain('search.value = "";');
+    expect(functionBody(objectBrowserSource, "clearObjectSearch")).toContain("getSearchInput()?.focus();");
+    expect(functionBody(databaseBrowserSource, "clearDatabaseSearch")).toContain('search.value = "";');
+    expect(functionBody(databaseBrowserSource, "clearDatabaseSearch")).toContain("searchInput.value?.$el?.focus();");
+  });
+
+  it("keeps the ObjectBrowser keyboard clear path on the shared handler", () => {
+    expect(functionBody(objectBrowserSource, "onSearchKeydown")).toContain("clearObjectSearch();");
+  });
+});


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
## Problem

The database browser and object browser search fields have no visible way to
clear the active filter. Users must manually select the text and delete it.
Additionally, the database browser's global Cmd/Ctrl+F focus path is a silent
no-op. (Closes #6476)

## Root cause

The search inputs only supported clearing via the keyboard. On the database
browser, the template ref attached to the `Input` component resolves to the
component's closed public instance, which has no `.focus()` method, so both
the new clear action and the existing `focusSearch()` shortcut were silently
dropped.

## Fix

- Add a clear (`X`) button inside both search inputs (`v-if="search"`,
  `type="button"`, `aria-label` from `common.clear`), plus right padding
  (`pr-6`) so typed text never runs under the button.
- Clicking the button clears the query and refocuses the input.
- In `ObjectBrowser`, extract the shared clear logic so the Escape shortcut and
  (`pr-6`) so typed text never runs under the button.
- Clicking the button clears the query and refocuses the input.
- In `ObjectBrowser`, extract the shared clear logic so the Escape shortcut and
  the new button use the same handler.
- In `DatabaseBrowser`, resolve the input ref to the actual DOM element via
  `.$el?.focus()` (the pattern already used by `RedisValueViewer`), which fixes
  both the new refocus and the previously broken `focusSearch()`.

## Compatibility

- Default behavior unchanged; the button appears only while text is entered.
- Escape-key behavior in the object browser is preserved (clear + keep focus).
- Pure UI change — no database/driver/platform impact.

## Validation

- `npx vitest run apps/desktop/src/components/objects/__tests__/SearchClearButtons.spec.ts` — passed
- `npx vitest run apps/desktop/src/components/objects/__tests__/` — passed (9 files / 27 tests)
- `npx vue-tsc --noEmit --project apps/desktop/tsconfig.json` — passed
- `npx oxlint --vue-plugin apps/desktop/src/components/objects/{DatabaseBrowser,ObjectBrowser}.vue apps/desktop/src/components/objects/__tests__/SearchClearButtons.spec.ts` — passed
- `git diff --check` — passed
- lint-staged hook (oxfmt + oxlint) on commit — passed

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="1556" height="986" alt="323a65a3-598e-41f2-9aa0-a4830f7266d9" src="https://github.com/user-attachments/assets/da36457e-ce00-4ac9-93a7-9d21aab00a73" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Related #6476 
