### PR TITLE
Fix：修复兼容 MySQL 存储过程标签参数误识别

### DIFF
--- a/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
@@ -670,6 +670,69 @@ SELECT @value AS Message;`;
     expect(executeCurrentSql).toHaveBeenCalledWith(sql, {});
   });
 
+  it.each([
+    {
+      label: "JDBC MySQL",
+      config: {
+        ...connection("jdbc"),
+        driver_label: "MySQL JDBC",
+        connection_string: "jdbc:mysql://127.0.0.1:3306/app",
+      },
+    },
+    {
+      label: "GBase MySQL compatibility",
+      config: {
+        ...connection("gbase"),
+        driver_profile: "gbase",
+        driver_label: "GBase 8a",
+      },
+    },
+  ])("executes $label cursor procedures from the gutter without opening the parameter dialog", async ({ config }) => {
+    const sql = `CREATE PROCEDURE process_orders()
+      BEGIN
+        DECLARE done INT DEFAULT FALSE;
+        DECLARE order_id INT;
+        DECLARE cur_orders CURSOR FOR SELECT id FROM orders;
+        DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+        OPEN cur_orders;
+        read_loop:LOOP
+          FETCH cur_orders INTO order_id;
+          IF done THEN LEAVE read_loop; END IF;
+        END LOOP read_loop;
+        CLOSE cur_orders;
+      END`;
+    const activeTab = ref<QueryTab | undefined>({ ...queryTab("app"), sql });
+    const activeConnection = ref<ConnectionConfig | undefined>(config);
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const executeCurrentSql = vi.spyOn(queryStore, "executeCurrentSql").mockImplementation(async () => {
+      if (activeTab.value) activeTab.value.result = { columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 };
+    });
+    vi.spyOn(useHistoryStore(), "add").mockResolvedValue(undefined);
+    vi.spyOn(useConnectionStore(), "refreshObjectListTreeNode").mockResolvedValue(undefined);
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      resolveExecutableSql: async () => sql,
+      activeOutputView,
+    });
+
+    await execution.tryExecute({
+      fullSql: sql,
+      selectedSql: sql,
+      cursorPos: 0,
+      selectionFrom: 0,
+      selectionTo: sql.length,
+      editorViewportRequestId: 1,
+    });
+
+    expect(execution.showSqlParameterDialog.value).toBe(false);
+    expect(execution.sqlParameterNames.value).toEqual([]);
+    expect(executeCurrentSql).toHaveBeenCalledWith(sql, { sourceOffset: 0, onExecutionStarted: expect.any(Function) });
+  });
+
   it("sends Doris STRUCT DDL unchanged without opening the parameter dialog", async () => {
     const sql = `
       create table \`events\` (

--- a/apps/desktop/src/composables/useSqlExecution.ts
+++ b/apps/desktop/src/composables/useSqlExecution.ts
@@ -235,7 +235,8 @@ export function useSqlExecution(deps: {
   }
 
   function prepareSqlParameterDialog(sql: string, sourceOffset?: number, options: SqlExecutionOptions = {}, continuation?: (sql: string, sourceOffset?: number) => Promise<void> | void): boolean {
-    const databaseType = deps.activeConnection.value?.db_type;
+    const connection = deps.activeConnection.value;
+    const databaseType = effectiveDatabaseTypeForConnection(connection) ?? connection?.db_type;
     const toggles = resolveSqlVariableSyntaxToggles(settingsStore.editorSettings.sqlVariableSyntaxOverrides, databaseType, settingsStore.editorSettings.sqlVariableSubstitutionEnabled);
     const enabledSyntaxes = enabledSqlParameterSyntaxes(toggles);
     const parameters = extractSqlParameterDescriptors(sql, { databaseType, enabledSyntaxes });


### PR DESCRIPTION
## 问题现象

MySQL 创建带游标的存储过程时，`read_loop:LOOP` 等过程标签可能被识别为 `:LOOP` SQL 参数，弹出参数输入框并导致执行失败。

## 问题原因

- #6382 已修复原生 MySQL 的过程标签误识别，但参数解析使用连接的原始 `db_type`，因此 JDBC MySQL、GBase 8a 等兼容连接未被覆盖。
- #6458 虽然修改了行号区执行流程，但没有删除 #6382 的逻辑，也没有修改参数解析所用的数据库类型。本次属于补齐遗漏场景，并非该 PR 重新引入问题。

## 修改内容

- SQL 参数解析改用连接的有效数据库方言。
- 补充 JDBC MySQL、GBase 8a 行号区执行带游标存储过程的回归测试。

## 验证

- 相关 Vitest：143 项通过
- `pnpm typecheck`
- `oxlint`
- `oxfmt --check`
- 真实 MySQL 8.4 创建并调用带游标和 `read_loop:LOOP` 标签的存储过程，结果正确，测试对象已清理
