### PR TITLE
chore(gitignore): ignore Python cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ docs/superpowers/
 /docs/aegis/
 src-tauri/*.dylib
 
+# Python
+__pycache__/
+*.py[cod]
+
 # OS files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## 变更说明

在仓库根 `.gitignore` 中补充 Python 缓存规则，忽略任意目录下的 `__pycache__/` 以及 `*.py[cod]` 字节码产物。

此前运行 Agent 发布脚本相关测试时会生成 `agents/scripts/__pycache__`，并作为未跟踪内容出现在工作区。本次修改不会删除本地缓存，只会避免这些可再生文件进入 Git 状态和后续提交。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [x] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

相关验证：

- `cd agents/scripts && python3.11 -m unittest driver_release_packages_test.py`
- 测试后 `agents/scripts/__pycache__` 仍存在于磁盘，但 `git status` 不再显示该目录。
- `git check-ignore -v agents/scripts/__pycache__/*.pyc` 正确命中根 `.gitignore` 规则。

## 关联 Issue

无
