### PR TITLE
docs(icons): correct license attribution for databricks and teradata marks

### DIFF
--- a/apps/desktop/public/icons/database/databricks.svg
+++ b/apps/desktop/public/icons/database/databricks.svg
@@ -1,4 +1,8 @@
-<!-- Source: Simple Icons (CC0 1.0 Universal). -->
+<!-- Databricks brand mark. Path data from Simple Icons (slug: databricks), which records the source as
+     https://www.databricks.com. Simple Icons' project code is CC0 1.0, but that dedication does not extend
+     to the brand marks it redistributes: this icon carries no `license` entry in Simple Icons' own metadata,
+     and Databricks publishes no redistribution grant. Used here descriptively, to identify Databricks as a
+     supported data source. Path geometry and color (#FF3621) are unchanged. -->
 <svg fill="#FF3621" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <title>Databricks</title>
   <path d="M.95 14.184L12 20.403l9.919-5.55v2.21L12 22.662l-10.484-5.96-.565.308v.77L12 24l11.05-6.218v-4.317l-.515-.309L12 19.118l-9.867-5.653v-2.21L12 16.805l11.05-6.218V6.32l-.515-.308L12 11.974 2.647 6.681 12 1.388l7.76 4.368.668-.411v-.566L12 0 .95 6.27v.72L12 13.207l9.919-5.55v2.26L12 15.52 1.516 9.56l-.565.308Z"/>

--- a/apps/desktop/public/icons/database/databricks.svg
+++ b/apps/desktop/public/icons/database/databricks.svg
@@ -1,8 +1,6 @@
-<!-- Databricks brand mark. Path data from Simple Icons (slug: databricks), which records the source as
-     https://www.databricks.com. Simple Icons' project code is CC0 1.0, but that dedication does not extend
-     to the brand marks it redistributes: this icon carries no `license` entry in Simple Icons' own metadata,
-     and Databricks publishes no redistribution grant. Used here descriptively, to identify Databricks as a
-     supported data source. Path geometry and color (#FF3621) are unchanged. -->
+<!-- Attribution: path data from Simple Icons 16.21.0 (slug: databricks).
+     Simple Icons metadata source: https://www.databricks.com
+     Simple Icons disclaimer: https://github.com/simple-icons/simple-icons/blob/16.21.0/DISCLAIMER.md -->
 <svg fill="#FF3621" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <title>Databricks</title>
   <path d="M.95 14.184L12 20.403l9.919-5.55v2.21L12 22.662l-10.484-5.96-.565.308v.77L12 24l11.05-6.218v-4.317l-.515-.309L12 19.118l-9.867-5.653v-2.21L12 16.805l11.05-6.218V6.32l-.515-.308L12 11.974 2.647 6.681 12 1.388l7.76 4.368.668-.411v-.566L12 0 .95 6.27v.72L12 13.207l9.919-5.55v2.26L12 15.52 1.516 9.56l-.565.308Z"/>

--- a/apps/desktop/public/icons/database/teradata.svg
+++ b/apps/desktop/public/icons/database/teradata.svg
@@ -1,4 +1,9 @@
-<!-- Source: Simple Icons (CC0 1.0 Universal). -->
+<!-- Teradata brand mark. Path data from Simple Icons (slug: teradata), which records the source as
+     https://github.com/Teradata/teradata.github.io/blob/0fb3886aaeefea7bea4951c300f49ac8f9c2476f/src/assets/icons/teradata-icon.svg
+     (that repository carries no LICENSE file). Simple Icons' project code is CC0 1.0, but that dedication
+     does not extend to the brand marks it redistributes: this icon carries no `license` entry in Simple
+     Icons' own metadata, and Teradata publishes no redistribution grant. Used here descriptively, to
+     identify Teradata as a supported data source. Path geometry and color (#F37440) are unchanged. -->
 <svg fill="#F37440" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <title>Teradata</title>
   <path d="M12 0C5 0 0 5.65 0 12.08C0 18.83 5 24 12 24S24 18.83 24 12.08C24 5.65 19 0 12 0M8.47 3.44H11.97V6.7H15.55V9.56H11.97V14.78C11.97 16.36 12.74 17.05 13.9 17.05C14.32 17.05 14.88 16.93 15.41 16.73C15.79 17.73 16.46 18.63 17.18 19.35A7 7 0 0 1 13.66 20.32C10.54 20.32 8.47 18.67 8.47 15.04V3.45Z"/>

--- a/apps/desktop/public/icons/database/teradata.svg
+++ b/apps/desktop/public/icons/database/teradata.svg
@@ -1,9 +1,7 @@
-<!-- Teradata brand mark. Path data from Simple Icons (slug: teradata), which records the source as
+<!-- Attribution: path data from Simple Icons 16.21.0 (slug: teradata).
+     Simple Icons metadata source:
      https://github.com/Teradata/teradata.github.io/blob/0fb3886aaeefea7bea4951c300f49ac8f9c2476f/src/assets/icons/teradata-icon.svg
-     (that repository carries no LICENSE file). Simple Icons' project code is CC0 1.0, but that dedication
-     does not extend to the brand marks it redistributes: this icon carries no `license` entry in Simple
-     Icons' own metadata, and Teradata publishes no redistribution grant. Used here descriptively, to
-     identify Teradata as a supported data source. Path geometry and color (#F37440) are unchanged. -->
+     Simple Icons disclaimer: https://github.com/simple-icons/simple-icons/blob/16.21.0/DISCLAIMER.md -->
 <svg fill="#F37440" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <title>Teradata</title>
   <path d="M12 0C5 0 0 5.65 0 12.08C0 18.83 5 24 12 24S24 18.83 24 12.08C24 5.65 19 0 12 0M8.47 3.44H11.97V6.7H15.55V9.56H11.97V14.78C11.97 16.36 12.74 17.05 13.9 17.05C14.32 17.05 14.88 16.93 15.41 16.73C15.79 17.73 16.46 18.63 17.18 19.35A7 7 0 0 1 13.66 20.32C10.54 20.32 8.47 18.67 8.47 15.04V3.45Z"/>


### PR DESCRIPTION
## 变更说明

`databricks.svg` 与 `teradata.svg` 的头部注释写的是 `Source: Simple Icons (CC0 1.0 Universal).`，
这个说法过宽：Simple Icons 的**项目代码**是 CC0 1.0，但该献出声明**不延伸到它转发的品牌标识本身**。

两个图标在 Simple Icons 自己的元数据里都**没有 `license` 条目**，上游厂商也未公开发布再分发许可：

- `databricks`：Simple Icons 记录来源为 <https://www.databricks.com>
- `teradata`：来源为 Teradata 官方仓库中的 `teradata-icon.svg`，而该仓库**没有 LICENSE 文件**

因此注释改为如实描述来源与许可状态，并说明此处属**描述性使用** —— 用于标识受支持的数据源，
与本目录下其它厂商标识同一处置方式。

**仅改注释。** path 几何与 `fill` 颜色（`#FF3621` / `#F37440`）一字未动，渲染结果完全不变。

> 若维护者认为这两个标识应改用中性图标或直接移除，请告知，我照办。
> 提为 draft 是因为许可判断最终应由维护者拍板，而非由我在注释里单方面陈述。

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏

改动仅为 SVG 文件内的 XML 注释，`path` 与 `fill` 未变，渲染像素级一致，故无截图。

## 验证

- [x] `git diff` 仅含两处注释块，无 path / fill / 文件名改动
- [x] 仓库内无测试或脚本引用被替换的注释文本（`grep -r "CC0 1.0 Universal" --include=spec/test/mjs/py` 无命中）
- [x] 与 `upstream/main` 无冲突（`git merge-tree` 无 CONFLICT 输出）

## 关联 Issue

无。此改动源自为 #5384 新增 Spanner 图标时的旁支发现：在为新图标撰写来源注释、核对
Simple Icons 的许可元数据时，发现这两个既有图标的注释把 CC0 的适用范围说宽了。
