### PR TITLE
Fix：修复 Impala 长查询被误判为执行失败

### DIFF
--- a/agents/go-common/gohive/hive.go
+++ b/agents/go-common/gohive/hive.go
@@ -1490,9 +1490,14 @@ func (c *cursor) pollUntilData(ctx context.Context, n int) (err error) {
 			}
 			c.response = responseFetch
 
-			if !success(safeStatus(responseFetch.GetStatus())) {
-				rowsAvailable <- hiveStatusError("fetching results", responseFetch.GetStatus())
+			resultsReady, statusErr := fetchResultsReady(responseFetch.GetStatus())
+			if statusErr != nil {
+				rowsAvailable <- statusErr
 				return
+			}
+			if !resultsReady {
+				time.Sleep(time.Duration(c.conn.configuration.PollIntervalInMillis) * time.Millisecond)
+				continue
 			}
 			err = c.parseResults(responseFetch)
 			if err != nil {
@@ -1640,6 +1645,18 @@ func hiveStatusError(action string, status *hiveserver.TStatus) error {
 		Message:   diagnostic,
 		ErrorCode: int(status.GetErrorCode()),
 		SQLState:  status.GetSqlState(),
+	}
+}
+
+func fetchResultsReady(status *hiveserver.TStatus) (bool, error) {
+	status = safeStatus(status)
+	switch status.GetStatusCode() {
+	case hiveserver.TStatusCode_SUCCESS_STATUS, hiveserver.TStatusCode_SUCCESS_WITH_INFO_STATUS:
+		return true, nil
+	case hiveserver.TStatusCode_STILL_EXECUTING_STATUS:
+		return false, nil
+	default:
+		return false, hiveStatusError("fetching results", status)
 	}
 }
 

--- a/agents/go-common/gohive/hive_status_error_test.go
+++ b/agents/go-common/gohive/hive_status_error_test.go
@@ -41,3 +41,28 @@ func TestHiveStatusErrorPreservesUsefulServerDiagnostics(t *testing.T) {
 		t.Fatalf("unexpected Hive error payload: %#v", err)
 	}
 }
+
+func TestFetchResultsReadyPollsWhileOperationIsStillExecuting(t *testing.T) {
+	ready, err := fetchResultsReady(&hiveserver.TStatus{
+		StatusCode: hiveserver.TStatusCode_STILL_EXECUTING_STATUS,
+	})
+	if err != nil || ready {
+		t.Fatalf("still-executing fetch must be retried: ready=%v err=%v", ready, err)
+	}
+}
+
+func TestFetchResultsReadyAcceptsSuccessAndRejectsErrors(t *testing.T) {
+	ready, err := fetchResultsReady(&hiveserver.TStatus{
+		StatusCode: hiveserver.TStatusCode_SUCCESS_WITH_INFO_STATUS,
+	})
+	if err != nil || !ready {
+		t.Fatalf("successful fetch was rejected: ready=%v err=%v", ready, err)
+	}
+
+	ready, err = fetchResultsReady(&hiveserver.TStatus{
+		StatusCode: hiveserver.TStatusCode_ERROR_STATUS,
+	})
+	if err == nil || ready || !strings.Contains(err.Error(), "ERROR_STATUS") {
+		t.Fatalf("failed fetch did not preserve the server status: ready=%v err=%v", ready, err)
+	}
+}


### PR DESCRIPTION
## 问题

Impala 4.1 执行耗时较长的查询时，`FetchResults` 可能返回 `STILL_EXECUTING_STATUS`，表示查询仍在服务端执行。当前 Go Hive Agent 将所有非成功状态直接作为 SQL 错误返回，导致查询在结果就绪前失败。

用户日志显示查询约 20 秒后命中该状态，与查询超时无关。

## 修复

- 将 `STILL_EXECUTING_STATUS` 识别为可继续轮询的中间状态
- 保持成功、带信息成功和真实失败状态的原有处理不变
- 添加状态分支回归测试

## 验证

- `go test ./...`（`agents/go-common/gohive`）
- `go test ./...`（`agents/drivers/hive-go`）
- 真实 Impala 4.5.0 执行约 30 秒的慢查询，成功返回 3 行结果

当前没有 Impala 4.1 测试环境；4.5 会阻塞 `FetchResults` 直到结果就绪，不会返回该中间状态。4.1 行为由 Issue 附件日志及 HiveServer2 协议状态共同确认。

Closes #6573
