### PR TITLE
fix(grid): 修复右键「筛选此值」丢失目标列导致筛选不生效

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4974,10 +4974,6 @@ const contextColumn = computed(() => {
   if (!contextCell.value || contextCell.value.col < 0) return null;
   return props.result.columns[contextCell.value.col] ?? null;
 });
-const contextCellValue = computed<CellValue | null>(() => {
-  if (!contextCell.value || contextCell.value.col < 0) return null;
-  return contextRowItem.value?.data[contextCell.value.col] ?? null;
-});
 const contextCellDetail = computed(() => {
   const cell = contextCell.value;
   if (!cell || cell.col < 0) return null;
@@ -5560,18 +5556,29 @@ function applyContextSort(direction: "asc" | "desc" | null, mode: DataGridSortMo
 }
 
 async function contextFilterCondition(mode: FilterMode): Promise<string | null> {
-  if (!contextColumn.value) return null;
-  if (mode !== "is-null" && mode !== "is-not-null" && contextCell.value) {
-    if (!(await hydrateLargeValueCell(contextCell.value.rowId, contextCell.value.col))) return null;
+  // Snapshot the context-menu target before any `await` below: closing the
+  // context menu clears `contextCell`/`contextColumn` via a queued microtask,
+  // which otherwise races this function and wipes the column out from under
+  // it once we resume (see onGridContextMenuClose/invalidateSyntheticContextSelection).
+  const columnName = contextColumn.value;
+  if (!columnName) return null;
+  const cell = contextCell.value;
+  const columnInfo = props.tableMeta?.columns.find((column) => column.name === columnName);
+  if (mode !== "is-null" && mode !== "is-not-null" && cell) {
+    if (!(await hydrateLargeValueCell(cell.rowId, cell.col))) return null;
   }
+  // Read the cell value fresh via the snapshot above (not a computed off
+  // `contextCell`), since hydration may have just updated the underlying row
+  // data and `contextCell` may already be cleared by the time we get here.
+  const cellValue = cell && cell.col >= 0 ? (getRowItem(cell.rowId)?.data[cell.col] ?? null) : null;
   return (
     (await buildDataGridContextFilterCondition({
       databaseType: resolvedDatabaseType.value,
       identifierQuote: connectionStore.connectionIdentifierQuote?.(props.connectionId),
-      columnName: contextColumn.value,
-      columnInfo: props.tableMeta?.columns.find((column) => column.name === contextColumn.value),
+      columnName,
+      columnInfo,
       mode,
-      value: contextCellValue.value,
+      value: cellValue,
     })) ?? null
   );
 }

--- a/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
@@ -10,4 +10,20 @@ describe("DataGrid context extractor lifecycle", () => {
     expect(source).toContain("queueMicrotask(() => {");
     expect(source).toContain("invalidateSyntheticContextSelection();");
   });
+
+  it("snapshots the context column before awaiting, so the close-menu microtask above can't null it out mid-build", () => {
+    // contextFilterCondition ("Filter by This Value" etc.) awaits hydrateLargeValueCell
+    // before building the request. onGridContextMenuClose's queueMicrotask (asserted
+    // above) fires in that same window and nulls contextCell/contextColumn — so the
+    // function must capture what it needs into locals up front instead of re-reading
+    // the live refs afterward, or the built request silently gets a null columnName.
+    const fn = source.slice(source.indexOf("async function contextFilterCondition"), source.indexOf("async function applyContextFilter"));
+    expect(fn).toMatch(/const columnName = contextColumn\.value;/);
+    expect(fn).toMatch(/await hydrateLargeValueCell/);
+    const awaitIndex = fn.indexOf("await hydrateLargeValueCell");
+    const afterAwait = fn.slice(awaitIndex);
+    expect(afterAwait).not.toContain("contextColumn.value");
+    expect(afterAwait).not.toContain("contextCellValue.value");
+    expect(afterAwait).toContain("columnName,");
+  });
 });


### PR DESCRIPTION
## 问题

Fixes #6517

右键数据网格中的单元格，选择「筛选此值」（Filter by This Value，含 Filter 子菜单下的其他选项）后没有任何效果——WHERE 输入框仍为空、网格数据也没有被过滤。实际复现下来，**表（TABLE）和视图（VIEW）表现完全一致**，并非仅视图模式下才有问题（与 issue 标题所述范围不同）。

## 根因

`DataGrid.vue` 的 `contextFilterCondition()` 在 `await hydrateLargeValueCell(...)` **之后**才读取 `contextColumn.value` / `contextCellValue.value`（两者都由 `contextCell` 这个 ref 派生）。而右键菜单一关闭，就会通过 `queueMicrotask` 调度 `invalidateSyntheticContextSelection()`，在同一个时间窗口内把 `contextCell`/`contextColumn` 清空为 `null`——所以函数 `await` 恢复执行时，`contextColumn.value` 已经变成了 `null`。构造出的请求带着 `columnName: null` 发给后端，Rust 端直接以 HTTP 422 拒绝（而且是静默失败：一个未捕获的 Promise rejection，界面上没有任何提示）。

这是一个确定性的时序竞争（不是偶发），只要右键菜单关闭时机早于 `await` 恢复，就必然触发——因此在我本机用真实 MySQL 5.7 + 真实浏览器操作复现时，表和视图 100% 复现，无一例外。

## 修复

在 `await` 之前，把 `columnName`/`cell`/`columnInfo` 快照进局部变量；`await` 结束后不再读可能已被清空的响应式引用，而是用快照里的 `cell` 坐标通过 `getRowItem` 重新取一次最新的单元格值（保证走完 `hydrateLargeValueCell` 后拿到的仍是刷新过的值）。

`DataGridContextExtractor.spec.ts` 新增一条回归测试：断言 `contextFilterCondition` 在 `await hydrateLargeValueCell` 之后不再直接读 `contextColumn.value`/`contextCellValue.value`。已验证这条测试在修复前的代码上会失败，修复后通过。

## 复现与验证

真实环境复现（非代码推测）：独立本地 `dbx-web` 后端 + `pnpm dev:web` 前端，连接共享测试环境的 MySQL 5.7.42 实例，建了一张表 `issue6517_orders` 及其视图 `issue6517_orders_view`，用 Playwright 驱动真实浏览器操作：

- 修复前：右键 `status` 列的 `paid` 单元格 → 筛选此值 → WHERE 栏仍为空、4 行数据原样显示，控制台报 `422 Unprocessable Entity: options.columnName: invalid type: null, expected a string`。
- 修复后：同样操作，WHERE 栏变为 `` `status` = 'paid' ``，网格正确过滤为 2 行。表和视图两种场景均已验证通过，互不影响。

其他验证：
- `pnpm typecheck`：干净
- `pnpm lint`：无新增告警
- `pnpm exec vitest run apps/desktop/src`：740 文件 / 6870 测试全部通过
- 已 rebase 到最新 `upstream/main`（无冲突，fetch 时确认无新增改动）

Before/after 截图见后续 PR 评论。