### PR TITLE
fix: gaussdbCountQueryDop 配置保存后自动重置为禁用的问题

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -4018,9 +4018,11 @@ function connectionConfigForSubmit(id: string, generatedName = ""): ConnectionCo
   } else if (supportsGaussdbIdentifierQuoteStyle(config)) {
     const style = gaussdbIdentifierQuoteStyle(config);
     const targetServerType = gaussdbTargetServerType(config);
+    const countQueryDop = gaussdbCountQueryDop(config);
     config.external_config = undefined;
     setGaussdbIdentifierQuoteStyle(config, style);
     setGaussdbTargetServerType(config, targetServerType);
+    setGaussdbCountQueryDop(config, countQueryDop);
   } else if (!isDoltDriverProfile(config.driver_profile)) {
     config.external_config = undefined;
   }

--- a/apps/desktop/src/lib/__tests__/connection/gaussdbConnectionDialog.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/gaussdbConnectionDialog.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("GaussDB connection dialog persistence", () => {
+  it("preserves count-query DOP in submitted connection configs", () => {
+    const source = readFileSync(new URL("../../../components/connection/ConnectionDialog.vue", import.meta.url), "utf8");
+    const submitConfig = source.slice(source.indexOf("function connectionConfigForSubmit"), source.indexOf("function connectionNameForSubmit"));
+
+    expect(submitConfig).toContain("const countQueryDop = gaussdbCountQueryDop(config);");
+    expect(submitConfig).toContain("setGaussdbCountQueryDop(config, countQueryDop);");
+  });
+});


### PR DESCRIPTION
在 connectionConfigForSubmit 函数中，当数据库类型为 GaussDB 时， external_config 被重置为 undefined，导致 gaussdbCountQueryDop 配置丢失。 修复方式是在重置前保存 countQueryDop 值，重置后重新写入。


