### PR TITLE
fix(ai): keep ordered list markers inside the message bubble

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -3149,6 +3149,11 @@ async function openExternalUrl(url: string) {
 }
 .ai-markdown :deep(ol) {
   list-style-type: decimal;
+  /* Multi-digit markers (100., 101., ...) don't fit the fixed padding-left
+     with the default outside marker position, so they hang past the bubble
+     edge. Keeping the marker inside the content box scales with any digit
+     count. */
+  list-style-position: inside;
 }
 .ai-markdown :deep(li) {
   margin: 0.15em 0;


### PR DESCRIPTION
## Summary
- The AI assistant panel's markdown ordered lists use a fixed `padding-left: 1.4em` with the default `list-style-position: outside`. Once the marker reaches 3+ digits (`100.`, `101.`, ...) it no longer fits that padding and hangs past the message bubble's left edge.
- Move the `ol` marker inside the content box (`list-style-position: inside`) so it scales with any digit count instead of overflowing.

Fixes #6470

## Test plan
- [x] Reproduced with a real running app (dev backend + `pnpm dev:web` + real browser via Playwright, AI provider pointed at a local OpenAI-compatible stub returning a markdown list up to item 102) — before the fix, `100.`/`101.`/`102.` markers visibly overflow the chat bubble's left edge; after the fix they stay inside.
- [x] `pnpm exec vitest run apps/desktop/src` — 740 files / 6869 tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm run lint` — no new warnings