### PR TITLE
fix(mongodb): use // for editor line comments

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -102,7 +102,7 @@ import {
   type QueryEditorTableReferencePayload,
 } from "@/lib/editor/queryEditorTableDrop";
 import type { SqlHighlighter } from "@/lib/sql/sqlHighlighter";
-import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticColors, editorThemeAppearanceFor, loadEditorTheme, editorFontTheme, sqlCompletionTheme, sqlSemanticHighlightTheme } from "@/lib/editor/editorThemes";
+import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticColors, editorThemeAppearanceFor, loadEditorTheme, editorFontTheme, shellLineCommentTheme, sqlCompletionTheme, sqlSemanticHighlightTheme } from "@/lib/editor/editorThemes";
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
@@ -121,6 +121,8 @@ import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorS
 import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import { computePasteCaretResyncTarget } from "@/lib/editor/queryEditorPasteCaretResync";
+import { queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
+import { createShellLineCommentHighlight } from "@/lib/editor/codemirrorShellLineCommentHighlight";
 import { extendQueryEditorSelection, runQueryEditorAltExtendSelection } from "@/lib/editor/queryEditorExtendSelection";
 import { createQueryEditorCompletionShortcutBindings } from "@/lib/editor/queryEditorCompletionShortcut";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
@@ -4471,7 +4473,7 @@ onMounted(async () => {
     langSql,
     { autocompletion, startCompletion, acceptCompletion, closeBrackets, closeBracketsKeymap, snippetCompletion, completionStatus, completionKeymap, insertCompletionText, nextSnippetField, closeCompletion },
     { copyLineDown, copyLineUp, deleteLine, indentLess, indentMore, insertNewlineKeepIndent, moveLineDown, moveLineUp, redo, selectAll, undo, toggleLineComment, toggleBlockComment, history, defaultKeymap, historyKeymap },
-    { bracketMatching, foldGutter, indentOnInput, indentUnit, syntaxHighlighting, defaultHighlightStyle, foldKeymap, toggleFold, ensureSyntaxTree },
+    { bracketMatching, foldGutter, indentOnInput, indentUnit, syntaxHighlighting, defaultHighlightStyle, foldKeymap, toggleFold, ensureSyntaxTree, highlightingFor },
     { searchKeymap },
   ] = await Promise.all([import("@codemirror/view"), import("@codemirror/state"), import("@codemirror/lang-sql"), import("@codemirror/autocomplete"), import("@codemirror/commands"), import("@codemirror/language"), import("@codemirror/search")]);
   editorViewModule = {
@@ -4741,10 +4743,17 @@ onMounted(async () => {
       override: [async (context: CompletionContext) => provideSqlCompletions(context)],
     });
 
-  buildSqlLanguageExtension = () =>
+  const shellLineCommentHighlightPlugin = createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor });
+  buildSqlLanguageExtension = () => [
     langSql.sql({
       dialect: createDbxCodeMirrorSqlDialect(langSql, props.syntaxDialect ?? props.dialect, props.databaseType, sqlDriverProfile.value),
-    });
+    }),
+    // Non-SQL editors (MongoDB shell) keep the SQL grammar for highlighting, so override the
+    // comment marker that toggleLineComment reads from language data.
+    Prec.highest(EditorState.languageData.of(() => [{ commentTokens: { line: queryEditorLineCommentToken(props.databaseType) } }])),
+    // The SQL grammar does not tokenize `//`, so those comments are highlighted by hand.
+    queryEditorLineCommentToken(props.databaseType) === "//" ? shellLineCommentHighlightPlugin : [],
+  ];
   buildSqlSemanticHighlightExtension = () => [
     ViewPlugin.fromClass(
       class {
@@ -4789,6 +4798,7 @@ onMounted(async () => {
       { decorations: (value) => value.decorations },
     ),
     sqlSemanticHighlightTheme(EditorView),
+    shellLineCommentTheme(EditorView),
   ];
 
   const initialSettings = settingsStore.editorSettings;

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -121,7 +121,7 @@ import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorS
 import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import { computePasteCaretResyncTarget } from "@/lib/editor/queryEditorPasteCaretResync";
-import { queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
+import { queryEditorCommentTokens, queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
 import { createShellLineCommentHighlight } from "@/lib/editor/codemirrorShellLineCommentHighlight";
 import { extendQueryEditorSelection, runQueryEditorAltExtendSelection } from "@/lib/editor/queryEditorExtendSelection";
 import { createQueryEditorCompletionShortcutBindings } from "@/lib/editor/queryEditorCompletionShortcut";
@@ -4473,7 +4473,7 @@ onMounted(async () => {
     langSql,
     { autocompletion, startCompletion, acceptCompletion, closeBrackets, closeBracketsKeymap, snippetCompletion, completionStatus, completionKeymap, insertCompletionText, nextSnippetField, closeCompletion },
     { copyLineDown, copyLineUp, deleteLine, indentLess, indentMore, insertNewlineKeepIndent, moveLineDown, moveLineUp, redo, selectAll, undo, toggleLineComment, toggleBlockComment, history, defaultKeymap, historyKeymap },
-    { bracketMatching, foldGutter, indentOnInput, indentUnit, syntaxHighlighting, defaultHighlightStyle, foldKeymap, toggleFold, ensureSyntaxTree, highlightingFor },
+    { bracketMatching, foldGutter, indentOnInput, indentUnit, syntaxHighlighting, defaultHighlightStyle, foldKeymap, toggleFold, ensureSyntaxTree, highlightingFor, syntaxTree },
     { searchKeymap },
   ] = await Promise.all([import("@codemirror/view"), import("@codemirror/state"), import("@codemirror/lang-sql"), import("@codemirror/autocomplete"), import("@codemirror/commands"), import("@codemirror/language"), import("@codemirror/search")]);
   editorViewModule = {
@@ -4743,14 +4743,14 @@ onMounted(async () => {
       override: [async (context: CompletionContext) => provideSqlCompletions(context)],
     });
 
-  const shellLineCommentHighlightPlugin = createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor });
+  const shellLineCommentHighlightPlugin = createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor, syntaxTree });
   buildSqlLanguageExtension = () => [
     langSql.sql({
       dialect: createDbxCodeMirrorSqlDialect(langSql, props.syntaxDialect ?? props.dialect, props.databaseType, sqlDriverProfile.value),
     }),
     // Non-SQL editors (MongoDB shell) keep the SQL grammar for highlighting, so override the
     // comment marker that toggleLineComment reads from language data.
-    Prec.highest(EditorState.languageData.of(() => [{ commentTokens: { line: queryEditorLineCommentToken(props.databaseType) } }])),
+    Prec.highest(EditorState.languageData.of(() => [{ commentTokens: queryEditorCommentTokens(props.databaseType) }])),
     // The SQL grammar does not tokenize `//`, so those comments are highlighted by hand.
     queryEditorLineCommentToken(props.databaseType) === "//" ? shellLineCommentHighlightPlugin : [],
   ];

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorShellLineCommentHighlight.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorShellLineCommentHighlight.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { HighlightStyle, highlightingFor, syntaxHighlighting } from "@codemirror/language";
+import { HighlightStyle, highlightingFor, syntaxHighlighting, syntaxTree } from "@codemirror/language";
 import { sql } from "@codemirror/lang-sql";
 import { EditorState } from "@codemirror/state";
 import { Decoration, EditorView, ViewPlugin } from "@codemirror/view";
@@ -21,7 +21,7 @@ function mount(doc: string, extensions: import("@codemirror/state").Extension[] 
   view = new EditorView({
     state: EditorState.create({
       doc,
-      extensions: [sql(), ...extensions, createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor })],
+      extensions: [sql(), ...extensions, createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor, syntaxTree })],
     }),
     parent: document.body,
   });
@@ -34,6 +34,13 @@ describe("createShellLineCommentHighlight", () => {
     const decorated = Array.from(editor.dom.querySelectorAll(`.${SHELL_LINE_COMMENT_CLASS}`)).map((node) => node.textContent);
 
     expect(decorated).toEqual(["// list users"]);
+  });
+
+  it("does not decorate // inside parsed block comments or strings", () => {
+    const editor = mount('/* hidden // marker */\nSELECT "https://example.com";\n// shown');
+    const decorated = Array.from(editor.dom.querySelectorAll(`.${SHELL_LINE_COMMENT_CLASS}`)).map((node) => node.textContent);
+
+    expect(decorated).toEqual(["// shown"]);
   });
 
   it("carries the active theme's comment class so // matches SQL --", () => {

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorShellLineCommentHighlight.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorShellLineCommentHighlight.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import { HighlightStyle, highlightingFor, syntaxHighlighting } from "@codemirror/language";
+import { sql } from "@codemirror/lang-sql";
+import { EditorState } from "@codemirror/state";
+import { Decoration, EditorView, ViewPlugin } from "@codemirror/view";
+import { tags } from "@lezer/highlight";
+import { afterEach, describe, expect, it } from "vitest";
+import { SHELL_LINE_COMMENT_CLASS, createShellLineCommentHighlight, shellLineCommentClass } from "@/lib/editor/codemirrorShellLineCommentHighlight";
+
+const commentHighlightStyle = HighlightStyle.define([{ tag: tags.lineComment, color: "#6c7086", fontStyle: "italic" }]);
+
+let view: EditorView | null = null;
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+function mount(doc: string, extensions: import("@codemirror/state").Extension[] = []) {
+  view = new EditorView({
+    state: EditorState.create({
+      doc,
+      extensions: [sql(), ...extensions, createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor })],
+    }),
+    parent: document.body,
+  });
+  return view;
+}
+
+describe("createShellLineCommentHighlight", () => {
+  it("decorates // comments that the SQL grammar leaves untokenized", () => {
+    const editor = mount('// list users\ndb.sites.insertOne({ url: "https://example.com" })');
+    const decorated = Array.from(editor.dom.querySelectorAll(`.${SHELL_LINE_COMMENT_CLASS}`)).map((node) => node.textContent);
+
+    expect(decorated).toEqual(["// list users"]);
+  });
+
+  it("carries the active theme's comment class so // matches SQL --", () => {
+    const editor = mount("// list users", [syntaxHighlighting(commentHighlightStyle)]);
+    const themeClass = highlightingFor(editor.state, [tags.lineComment]);
+    const node = editor.dom.querySelector(`.${SHELL_LINE_COMMENT_CLASS}`);
+
+    expect(themeClass).toBeTruthy();
+    expect(node?.className.split(" ")).toContain(themeClass?.split(" ")[0]);
+  });
+
+  it("falls back to the bare class when the theme styles no comments", () => {
+    const state = EditorState.create({ doc: "// list users", extensions: [sql()] });
+
+    expect(shellLineCommentClass(state, highlightingFor)).toBe(SHELL_LINE_COMMENT_CLASS);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts
@@ -3,10 +3,11 @@ import { toggleLineComment } from "@codemirror/commands";
 import { sql } from "@codemirror/lang-sql";
 import { EditorState, Prec, type Transaction } from "@codemirror/state";
 import { describe, expect, it, vi } from "vitest";
-import { queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
+import { queryEditorCommentTokens, queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
 
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 const editorThemesSource = readFileSync(new URL("../../editor/editorThemes.ts", import.meta.url), "utf8");
+const shellHighlightSource = readFileSync(new URL("../../editor/codemirrorShellLineCommentHighlight.ts", import.meta.url), "utf8");
 
 function runToggleLineComment(doc: string, commentToken: string) {
   let state = EditorState.create({
@@ -32,6 +33,13 @@ describe("queryEditorLineCommentToken", () => {
     expect(queryEditorLineCommentToken("mongodb")).toBe("//");
   });
 
+  it("keeps block comment tokens while overriding MongoDB line comments", () => {
+    expect(queryEditorCommentTokens("mongodb")).toEqual({
+      line: "//",
+      block: { open: "/*", close: "*/" },
+    });
+  });
+
   it("keeps the SQL line comment marker elsewhere", () => {
     expect(queryEditorLineCommentToken(undefined)).toBe("--");
     expect(queryEditorLineCommentToken("mysql")).toBe("--");
@@ -41,15 +49,21 @@ describe("queryEditorLineCommentToken", () => {
 
 describe("QueryEditor line comment", () => {
   it("overrides the language comment tokens in the SQL language compartment", () => {
-    expect(queryEditorSource).toContain("Prec.highest(EditorState.languageData.of(() => [{ commentTokens: { line: queryEditorLineCommentToken(props.databaseType) } }]))");
+    expect(queryEditorSource).toContain("Prec.highest(EditorState.languageData.of(() => [{ commentTokens: queryEditorCommentTokens(props.databaseType) }]))");
   });
 
   it("highlights // comments with the theme's comment style", () => {
     expect(queryEditorSource).toContain('queryEditorLineCommentToken(props.databaseType) === "//" ? shellLineCommentHighlightPlugin : []');
-    expect(queryEditorSource).toContain("const shellLineCommentHighlightPlugin = createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor });");
+    expect(queryEditorSource).toContain("const shellLineCommentHighlightPlugin = createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor, syntaxTree });");
     expect(queryEditorSource).toContain("shellLineCommentTheme(EditorView),");
     expect(editorThemesSource).toContain('".cm-shell-line-comment *"');
     expect(editorThemesSource).toContain('color: "inherit !important"');
+  });
+
+  it("bounds shell comment scanning to syntax-aware visible lines", () => {
+    expect(shellHighlightSource).toContain("view.state.doc.lineAt(visibleRange.from).from");
+    expect(shellHighlightSource).toContain("tree.resolveInner(absoluteFrom, 1)");
+    expect(shellHighlightSource).not.toContain("sliceString(0, end)");
   });
 
   it("comments a MongoDB line with //", () => {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { toggleLineComment } from "@codemirror/commands";
+import { sql } from "@codemirror/lang-sql";
+import { EditorState, Prec, type Transaction } from "@codemirror/state";
+import { describe, expect, it, vi } from "vitest";
+import { queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+const editorThemesSource = readFileSync(new URL("../../editor/editorThemes.ts", import.meta.url), "utf8");
+
+function runToggleLineComment(doc: string, commentToken: string) {
+  let state = EditorState.create({
+    doc,
+    selection: { anchor: 0 },
+    extensions: [sql(), Prec.highest(EditorState.languageData.of(() => [{ commentTokens: { line: commentToken } }]))],
+  });
+  const dispatch = vi.fn((transaction: Transaction) => {
+    state = transaction.state;
+  });
+  const handled = toggleLineComment({
+    get state() {
+      return state;
+    },
+    dispatch,
+  } as never);
+
+  return { handled, state };
+}
+
+describe("queryEditorLineCommentToken", () => {
+  it("uses the MongoDB shell line comment marker", () => {
+    expect(queryEditorLineCommentToken("mongodb")).toBe("//");
+  });
+
+  it("keeps the SQL line comment marker elsewhere", () => {
+    expect(queryEditorLineCommentToken(undefined)).toBe("--");
+    expect(queryEditorLineCommentToken("mysql")).toBe("--");
+    expect(queryEditorLineCommentToken("postgres")).toBe("--");
+  });
+});
+
+describe("QueryEditor line comment", () => {
+  it("overrides the language comment tokens in the SQL language compartment", () => {
+    expect(queryEditorSource).toContain("Prec.highest(EditorState.languageData.of(() => [{ commentTokens: { line: queryEditorLineCommentToken(props.databaseType) } }]))");
+  });
+
+  it("highlights // comments with the theme's comment style", () => {
+    expect(queryEditorSource).toContain('queryEditorLineCommentToken(props.databaseType) === "//" ? shellLineCommentHighlightPlugin : []');
+    expect(queryEditorSource).toContain("const shellLineCommentHighlightPlugin = createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor });");
+    expect(queryEditorSource).toContain("shellLineCommentTheme(EditorView),");
+    expect(editorThemesSource).toContain('".cm-shell-line-comment *"');
+    expect(editorThemesSource).toContain('color: "inherit !important"');
+  });
+
+  it("comments a MongoDB line with //", () => {
+    const result = runToggleLineComment("db.users.find({})", "//");
+
+    expect(result.handled).toBe(true);
+    expect(result.state.doc.toString()).toBe("// db.users.find({})");
+  });
+
+  it("uncomments a MongoDB line commented with //", () => {
+    const result = runToggleLineComment("// db.users.find({})", "//");
+
+    expect(result.state.doc.toString()).toBe("db.users.find({})");
+  });
+
+  it("still comments SQL with --", () => {
+    const result = runToggleLineComment("SELECT 1", "--");
+
+    expect(result.state.doc.toString()).toBe("-- SELECT 1");
+  });
+});

--- a/apps/desktop/src/lib/__tests__/editor/shellLineCommentRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/shellLineCommentRanges.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shellLineCommentRanges } from "@/lib/editor/shellLineCommentRanges";
+
+function commentTexts(doc: string): string[] {
+  return shellLineCommentRanges(doc).map((range) => doc.slice(range.from, range.to));
+}
+
+describe("shellLineCommentRanges", () => {
+  it("finds a whole-line comment", () => {
+    expect(commentTexts("// list users\ndb.users.find({})")).toEqual(["// list users"]);
+  });
+
+  it("finds a trailing comment and stops at the line end", () => {
+    expect(commentTexts("db.users.find({}) // only active\ndb.users.count()")).toEqual(["// only active"]);
+  });
+
+  it("ignores // inside quoted strings", () => {
+    expect(commentTexts('db.sites.insertOne({ url: "https://example.com" })')).toEqual([]);
+    expect(commentTexts("db.sites.insertOne({ url: 'https://example.com' })")).toEqual([]);
+    expect(commentTexts("db.sites.insertOne({ url: `https://example.com` })")).toEqual([]);
+  });
+
+  it("ignores // inside block comments", () => {
+    expect(commentTexts("/* db.users.find({}) // stale */\ndb.users.count()")).toEqual([]);
+  });
+
+  it("handles escaped quotes without swallowing the rest of the document", () => {
+    expect(commentTexts('db.t.find({ a: "x\\"y" }) // note')).toEqual(["// note"]);
+  });
+
+  it("does not let an unterminated quote hide later comments", () => {
+    expect(commentTexts('db.t.find({ a: "oops\n// note')).toEqual(["// note"]);
+  });
+
+  it("keeps carriage returns out of the range", () => {
+    expect(commentTexts("// note\r\ndb.users.count()")).toEqual(["// note"]);
+  });
+
+  it("respects the scan limit", () => {
+    const doc = "db.a.find()\n// second line";
+    expect(shellLineCommentRanges(doc, doc.indexOf("//"))).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/editor/codemirrorShellLineCommentHighlight.ts
+++ b/apps/desktop/src/lib/editor/codemirrorShellLineCommentHighlight.ts
@@ -4,6 +4,10 @@ import { shellLineCommentRanges } from "@/lib/editor/shellLineCommentRanges";
 
 type EditorViewType = import("@codemirror/view").EditorView;
 type DecorationSet = import("@codemirror/view").DecorationSet;
+interface SyntaxNodeLike {
+  name: string;
+  parent: SyntaxNodeLike | null;
+}
 
 export const SHELL_LINE_COMMENT_CLASS = "cm-shell-line-comment";
 
@@ -11,6 +15,7 @@ interface ShellLineCommentHighlightDeps {
   ViewPlugin: typeof import("@codemirror/view").ViewPlugin;
   Decoration: typeof import("@codemirror/view").Decoration;
   highlightingFor: typeof import("@codemirror/language").highlightingFor;
+  syntaxTree: typeof import("@codemirror/language").syntaxTree;
 }
 
 /** Reuses the active theme's comment colour so `//` matches what the SQL grammar gives `--`. */
@@ -19,15 +24,32 @@ export function shellLineCommentClass(state: import("@codemirror/state").EditorS
   return themeClass ? `${SHELL_LINE_COMMENT_CLASS} ${themeClass}` : SHELL_LINE_COMMENT_CLASS;
 }
 
-export function createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor }: ShellLineCommentHighlightDeps): Extension {
+export function createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor, syntaxTree }: ShellLineCommentHighlightDeps): Extension {
   function buildDecorations(view: EditorViewType, className: string): DecorationSet {
-    const visible = view.visibleRanges;
-    const end = visible[visible.length - 1]?.to ?? 0;
-    if (!end) return Decoration.set([]);
-    // Quote tracking needs the text before the viewport, so scan from the start of the document.
-    const ranges = shellLineCommentRanges(view.state.doc.sliceString(0, end));
+    const tree = syntaxTree(view.state);
+    const ranges = new Map<number, number>();
+    for (const visibleRange of view.visibleRanges) {
+      const from = view.state.doc.lineAt(visibleRange.from).from;
+      const to = view.state.doc.lineAt(visibleRange.to).to;
+      const text = view.state.doc.sliceString(from, to);
+      for (const range of shellLineCommentRanges(text)) {
+        const absoluteFrom = from + range.from;
+        const absoluteTo = from + range.to;
+        if (absoluteFrom >= visibleRange.to || absoluteTo <= visibleRange.from) continue;
+        let node: SyntaxNodeLike | null = tree.resolveInner(absoluteFrom, 1);
+        let excluded = false;
+        while (node) {
+          if (node.name === "BlockComment" || node.name === "String" || node.name === "QuotedIdentifier") {
+            excluded = true;
+            break;
+          }
+          node = node.parent;
+        }
+        if (!excluded) ranges.set(absoluteFrom, absoluteTo);
+      }
+    }
     const decoration = Decoration.mark({ class: className });
-    return Decoration.set(ranges.filter((range) => visible.some((visibleRange) => range.from < visibleRange.to && range.to > visibleRange.from)).map((range) => decoration.range(range.from, range.to)));
+    return Decoration.set([...ranges].sort(([left], [right]) => left - right).map(([from, to]) => decoration.range(from, to)));
   }
 
   return ViewPlugin.fromClass(

--- a/apps/desktop/src/lib/editor/codemirrorShellLineCommentHighlight.ts
+++ b/apps/desktop/src/lib/editor/codemirrorShellLineCommentHighlight.ts
@@ -1,0 +1,50 @@
+import type { Extension } from "@codemirror/state";
+import { tags } from "@lezer/highlight";
+import { shellLineCommentRanges } from "@/lib/editor/shellLineCommentRanges";
+
+type EditorViewType = import("@codemirror/view").EditorView;
+type DecorationSet = import("@codemirror/view").DecorationSet;
+
+export const SHELL_LINE_COMMENT_CLASS = "cm-shell-line-comment";
+
+interface ShellLineCommentHighlightDeps {
+  ViewPlugin: typeof import("@codemirror/view").ViewPlugin;
+  Decoration: typeof import("@codemirror/view").Decoration;
+  highlightingFor: typeof import("@codemirror/language").highlightingFor;
+}
+
+/** Reuses the active theme's comment colour so `//` matches what the SQL grammar gives `--`. */
+export function shellLineCommentClass(state: import("@codemirror/state").EditorState, highlightingFor: ShellLineCommentHighlightDeps["highlightingFor"]): string {
+  const themeClass = highlightingFor(state, [tags.lineComment, tags.comment]);
+  return themeClass ? `${SHELL_LINE_COMMENT_CLASS} ${themeClass}` : SHELL_LINE_COMMENT_CLASS;
+}
+
+export function createShellLineCommentHighlight({ ViewPlugin, Decoration, highlightingFor }: ShellLineCommentHighlightDeps): Extension {
+  function buildDecorations(view: EditorViewType, className: string): DecorationSet {
+    const visible = view.visibleRanges;
+    const end = visible[visible.length - 1]?.to ?? 0;
+    if (!end) return Decoration.set([]);
+    // Quote tracking needs the text before the viewport, so scan from the start of the document.
+    const ranges = shellLineCommentRanges(view.state.doc.sliceString(0, end));
+    const decoration = Decoration.mark({ class: className });
+    return Decoration.set(ranges.filter((range) => visible.some((visibleRange) => range.from < visibleRange.to && range.to > visibleRange.from)).map((range) => decoration.range(range.from, range.to)));
+  }
+
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+      className: string;
+      constructor(view: EditorViewType) {
+        this.className = shellLineCommentClass(view.state, highlightingFor);
+        this.decorations = buildDecorations(view, this.className);
+      }
+      update(update: import("@codemirror/view").ViewUpdate) {
+        const className = shellLineCommentClass(update.state, highlightingFor);
+        if (!update.docChanged && !update.viewportChanged && className === this.className) return;
+        this.className = className;
+        this.decorations = buildDecorations(update.view, className);
+      }
+    },
+    { decorations: (plugin) => plugin.decorations },
+  );
+}

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -30,6 +30,21 @@ export function sqlSemanticHighlightTheme(EditorView: typeof import("@codemirror
   });
 }
 
+// MongoDB and other shell-style editors keep the SQL grammar, so their `//` comments are decorated
+// manually. The decoration carries the active theme's comment highlight class, so it only has to
+// keep the SQL grammar's colours from leaking through on the tokens it wraps.
+export function shellLineCommentTheme(EditorView: typeof import("@codemirror/view").EditorView): Extension {
+  return EditorView.theme({
+    ".cm-shell-line-comment": {
+      fontStyle: "italic",
+    },
+    ".cm-shell-line-comment *": {
+      color: "inherit !important",
+      fontStyle: "italic",
+    },
+  });
+}
+
 const SUPPORTS_COLOR_MIX = typeof CSS !== "undefined" && typeof CSS.supports === "function" && CSS.supports("color", "color-mix(in oklch, black 50%, white)");
 const SUPPORTS_OKLCH = typeof CSS !== "undefined" && typeof CSS.supports === "function" && CSS.supports("color", "oklch(0.62 0.19 255)");
 

--- a/apps/desktop/src/lib/editor/queryEditorLineComment.ts
+++ b/apps/desktop/src/lib/editor/queryEditorLineComment.ts
@@ -1,0 +1,13 @@
+import type { DatabaseType } from "@/types/database";
+
+const SQL_LINE_COMMENT_TOKEN = "--";
+
+// Editors that speak a shell/script dialect instead of SQL keep their native line comment marker.
+const LINE_COMMENT_TOKENS: Partial<Record<DatabaseType, string>> = {
+  mongodb: "//",
+};
+
+export function queryEditorLineCommentToken(dbType?: DatabaseType): string {
+  if (!dbType) return SQL_LINE_COMMENT_TOKEN;
+  return LINE_COMMENT_TOKENS[dbType] ?? SQL_LINE_COMMENT_TOKEN;
+}

--- a/apps/desktop/src/lib/editor/queryEditorLineComment.ts
+++ b/apps/desktop/src/lib/editor/queryEditorLineComment.ts
@@ -11,3 +11,10 @@ export function queryEditorLineCommentToken(dbType?: DatabaseType): string {
   if (!dbType) return SQL_LINE_COMMENT_TOKEN;
   return LINE_COMMENT_TOKENS[dbType] ?? SQL_LINE_COMMENT_TOKEN;
 }
+
+export function queryEditorCommentTokens(dbType?: DatabaseType) {
+  return {
+    line: queryEditorLineCommentToken(dbType),
+    block: { open: "/*", close: "*/" },
+  };
+}

--- a/apps/desktop/src/lib/editor/shellLineCommentRanges.ts
+++ b/apps/desktop/src/lib/editor/shellLineCommentRanges.ts
@@ -1,0 +1,59 @@
+export interface ShellLineCommentRange {
+  from: number;
+  to: number;
+}
+
+/**
+ * Finds `//` line comments in shell-style text (the MongoDB editor keeps the SQL grammar for
+ * highlighting, so its comments are not tokenized by the parser). Quoted strings and block
+ * comments are skipped so markers such as `"https://host"` stay uncommented.
+ */
+export function shellLineCommentRanges(text: string, to = text.length): ShellLineCommentRange[] {
+  const ranges: ShellLineCommentRange[] = [];
+  const limit = Math.min(to, text.length);
+  let index = 0;
+
+  while (index < limit) {
+    const char = text[index];
+
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipString(text, index, char);
+      continue;
+    }
+
+    if (char === "/" && text[index + 1] === "*") {
+      const end = text.indexOf("*/", index + 2);
+      index = end === -1 ? text.length : end + 2;
+      continue;
+    }
+
+    if (char === "/" && text[index + 1] === "/") {
+      let end = index + 2;
+      while (end < text.length && text[end] !== "\n" && text[end] !== "\r") end += 1;
+      ranges.push({ from: index, to: end });
+      index = end;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return ranges;
+}
+
+function skipString(text: string, start: number, quote: string): number {
+  let index = start + 1;
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) return index + 1;
+    // Single- and double-quoted strings do not span lines; bail out so an unterminated quote
+    // does not swallow the rest of the document.
+    if ((quote === '"' || quote === "'") && (char === "\n" || char === "\r")) return index;
+    index += 1;
+  }
+  return index;
+}


### PR DESCRIPTION
## Summary

The MongoDB editor keeps the SQL grammar loaded for highlighting, so `Ctrl/Cmd + /` read `--` from its
language data, and `//` comments were left untokenized and unstyled.

This PR overrides `commentTokens` per database type in the language compartment, and decorates `//`
comments with the active theme's comment highlight class so they match what SQL `--` gets in every
theme.

### What changed

- `lib/editor/queryEditorLineComment.ts` — maps a database type to its line comment marker
  (`mongodb` → `//`, everything else → `--`).
- `components/editor/QueryEditor.vue` — adds a `Prec.highest` `EditorState.languageData` override to
  the SQL language compartment, so `toggleLineComment` (both `Cmd + /` and the right-click
  "Comment selection" item) uses that marker. The compartment is already reconfigured when the
  database type changes, so switching connections re-resolves it.
- `lib/editor/shellLineCommentRanges.ts` — scans for `//` comment ranges, skipping quoted strings and
  `/* ... */` blocks so `"https://example.com"` is not treated as a comment. Unterminated `'`/`"`
  strings bail at end of line instead of swallowing the rest of the document.
- `lib/editor/codemirrorShellLineCommentHighlight.ts` — a `ViewPlugin` that marks those ranges. The
  colour is not hard-coded: it resolves the class through
  `highlightingFor(state, [tags.lineComment, tags.comment])`, so it follows whichever theme is
  selected, including the third-party ones (one-dark, vscode, nord, xcode, ...). Scanning is bounded
  by the viewport end, so long scripts do not pay for offscreen text.
- `lib/editor/editorThemes.ts` — `shellLineCommentTheme` adds italics and `color: inherit !important`
  on descendants, so SQL operator/keyword colours from the grammar do not bleed through inside the
  decorated span.

The highlighter is gated on `queryEditorLineCommentToken(...) === "//"`, so only MongoDB is affected;
SQL editors are untouched.

<img width="249" height="111" alt="Screenshot 2026-08-18 at 17 12 53" src="https://github.com/user-attachments/assets/65bf1619-9220-41b3-93b9-c74e8c275b74" />

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Performance
- [ ] Refactor
- [ ] Documentation
- [ ] CI / build

## Frontend changes

<!-- If the PR touches the frontend (UI components, styles, interactions, copy), a screenshot or screen recording is required -->

- [ ] This PR touches the frontend and a screenshot/recording is attached (below)

<!-- Screenshot area -->

> Screenshot still to be attached: MongoDB query editor with a `//` comment line, showing it rendered
> in the theme's comment colour, plus `Cmd + /` toggling it on and off.

## Verification

- [x] `make check` passes
- [x] `make cargo-check-fast` passes
- [x] Related tests pass

Details:

- `make check` (format, lint, typecheck, `vitest run`) — 1042 files / 9902 tests pass.
  Note: the first run failed two cases in the unrelated
  `components/document/__tests__/DocumentBrowserFieldSearch.spec.ts`; they pass in isolation and on a
  re-run. This is the load-related flakiness already documented in `vitest.config.ts`, not a
  regression from this change.
- `make cargo-check-fast` passes (this change is frontend-only).
- New tests:
  - `lib/__tests__/editor/queryEditorLineComment.spec.ts` — the marker per database type, plus
    `toggleLineComment` adding and removing `//` on a MongoDB line and still using `--` for SQL.
  - `lib/__tests__/editor/shellLineCommentRanges.spec.ts` — whole-line and trailing comments, `//`
    inside single/double/backtick strings and block comments, escaped quotes, unterminated quotes,
    CRLF, and the scan limit.
  - `lib/__tests__/editor/codemirrorShellLineCommentHighlight.spec.ts` — a real `EditorView` mounted
    under happy-dom, asserting `// list users` gets the decoration while a URL inside a string does
    not, that the active theme's comment class is applied, and the fallback when a theme styles no
    comments.

Manual check: open a MongoDB connection, type `// list users` above a query in the editor, and press
`Cmd + /` on a query line.

## Related issue

<!-- If applicable, add `Close #xxx` or `Related #xxx` -->

