### PR TITLE
fix(grid): stabilize row drag selection and recover lost mouseup

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4535,6 +4535,10 @@ const selection = useDataGridSelection({
   cellFromClientPoint: dataGridCellFromClientPoint,
   rowFromClientPoint: dataGridRowFromClientPoint,
   onUserCellSelection: invalidateSyntheticContextSelection,
+  // Canvas schedules its draw before the document-level mousemove handler runs,
+  // so its row state must be current before that frame is painted.
+  shouldUpdateDraggedRowsImmediately: () => useCanvasGridRows.value,
+  onDraggedRowSelectionChange: scheduleCanvasDraw,
   runtimeScope: dataGridRuntimeScope,
 });
 

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4853,7 +4853,22 @@ const domSelectionDragOverlayStyle = computed((): CSSProperties | undefined => {
   };
 });
 
-function onCellMouseenter(rowIndex: number, visibleColIdx: number, actualColIdx: number) {
+function stopReleasedSelectionGesture(event: MouseEvent): boolean {
+  if ((event.buttons & 1) !== 0) return false;
+  let stopped = false;
+  if (isSelectingCells.value) {
+    finishCellSelection();
+    stopped = true;
+  }
+  if (selection.isSelectingRows.value) {
+    selection.finishRowSelection();
+    stopped = true;
+  }
+  return stopped;
+}
+
+function onCellMouseenter(rowIndex: number, visibleColIdx: number, actualColIdx: number, event: MouseEvent) {
+  stopReleasedSelectionGesture(event);
   if (!isSelectingCells.value) {
     quickDownloadMenuCell.value = retainBinaryCellDownloadMenuForHover(quickDownloadMenuCell.value, { rowIndex, col: actualColIdx });
     if (!isScrolling.value) hoveredDetailCell.value = { rowIndex, col: actualColIdx };
@@ -6187,6 +6202,7 @@ function onDomGridWheel(event: WheelEvent) {
 }
 
 function onCanvasMouseMove(event: MouseEvent) {
+  stopReleasedSelectionGesture(event);
   if (columnHeaderPointerInteractionActive()) {
     if (canvasRef.value) canvasRef.value.style.cursor = "default";
     onCanvasMouseLeave();
@@ -6216,7 +6232,7 @@ function onCanvasMouseMove(event: MouseEvent) {
     if (previousActualColIdx !== undefined) onCellMouseleave(previous.rowIndex, previousActualColIdx);
   }
   canvasHoverCell.value = next;
-  if (next && actualColIdx !== undefined) onCellMouseenter(next.rowIndex, next.visibleColIdx, actualColIdx);
+  if (next && actualColIdx !== undefined) onCellMouseenter(next.rowIndex, next.visibleColIdx, actualColIdx, event);
   scheduleCanvasDraw();
 }
 
@@ -11667,7 +11683,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                           prepareDataCellMouseDown(item, col.actualColIdx);
                           handleDataCellMousedown(item.displayIndex, col.visibleColIdx, item.id, $event);
                         "
-                        @mouseenter="onCellMouseenter(item.displayIndex, col.visibleColIdx, col.actualColIdx)"
+                        @mouseenter="onCellMouseenter(item.displayIndex, col.visibleColIdx, col.actualColIdx, $event)"
                         @mouseleave="onCellMouseleave(item.displayIndex, col.actualColIdx)"
                         @dblclick="onDomCellDblClick(item, col.actualColIdx, $event)"
                         :data-visible-col-index="col.visibleColIdx"

--- a/apps/desktop/src/components/grid/__tests__/DataGridSelectionGesture.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSelectionGesture.spec.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
+
+describe("DataGrid selection gesture ownership", () => {
+  it("stops released gestures before DOM hover or canvas movement extends them", () => {
+    expect(source).toContain("function stopReleasedSelectionGesture(event: MouseEvent)");
+    expect(source).toContain("if ((event.buttons & 1) !== 0) return false;");
+    expect(source).toContain("function onCellMouseenter(rowIndex: number, visibleColIdx: number, actualColIdx: number, event: MouseEvent)");
+    expect(source).toContain("@mouseenter=\"onCellMouseenter(item.displayIndex, col.visibleColIdx, col.actualColIdx, $event)\"");
+
+    const canvasMove = source.slice(source.indexOf("function onCanvasMouseMove"), source.indexOf("function onCanvasMouseLeave"));
+    expect(canvasMove).toContain("stopReleasedSelectionGesture(event);");
+  });
+});

--- a/apps/desktop/src/components/grid/__tests__/DataGridSelectionGesture.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSelectionGesture.spec.ts
@@ -8,7 +8,7 @@ describe("DataGrid selection gesture ownership", () => {
     expect(source).toContain("function stopReleasedSelectionGesture(event: MouseEvent)");
     expect(source).toContain("if ((event.buttons & 1) !== 0) return false;");
     expect(source).toContain("function onCellMouseenter(rowIndex: number, visibleColIdx: number, actualColIdx: number, event: MouseEvent)");
-    expect(source).toContain("@mouseenter=\"onCellMouseenter(item.displayIndex, col.visibleColIdx, col.actualColIdx, $event)\"");
+    expect(source).toContain('@mouseenter="onCellMouseenter(item.displayIndex, col.visibleColIdx, col.actualColIdx, $event)"');
 
     const canvasMove = source.slice(source.indexOf("function onCanvasMouseMove"), source.indexOf("function onCanvasMouseLeave"));
     expect(canvasMove).toContain("stopReleasedSelectionGesture(event);");

--- a/apps/desktop/src/composables/__tests__/useDataGridSelection.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridSelection.spec.ts
@@ -50,9 +50,11 @@ function rowEvent(options: { meta?: boolean; shift?: boolean } = {}): MouseEvent
 
 function installPointerDocument() {
   const originalDocument = globalThis.document;
+  const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
   const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
   const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  const windowListeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
   const animationFrames: FrameRequestCallback[] = [];
   const fakeDocument = {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
@@ -64,7 +66,18 @@ function installPointerDocument() {
       listeners.get(type)?.delete(listener);
     },
   } as Document;
+  const fakeWindow = {
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const handlers = windowListeners.get(type) ?? new Set();
+      handlers.add(listener);
+      windowListeners.set(type, handlers);
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      windowListeners.get(type)?.delete(listener);
+    },
+  } as Window;
   Object.defineProperty(globalThis, "document", { configurable: true, value: fakeDocument });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: fakeWindow });
   globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
     animationFrames.push(callback);
     return animationFrames.length;
@@ -79,8 +92,16 @@ function installPointerDocument() {
         else listener.handleEvent(event);
       });
     },
+    dispatchWindow(type: string, event: Event = { type } as Event) {
+      windowListeners.get(type)?.forEach((listener) => {
+        if (typeof listener === "function") listener(event);
+        else listener.handleEvent(event);
+      });
+    },
     restore() {
       Object.defineProperty(globalThis, "document", { configurable: true, value: originalDocument });
+      if (originalWindowDescriptor) Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+      else Reflect.deleteProperty(globalThis, "window");
       globalThis.requestAnimationFrame = originalRequestAnimationFrame;
       globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
     },
@@ -355,6 +376,83 @@ describe("useDataGridSelection", () => {
       expect(selection.isSelectingRows.value).toBe(false);
       expect(selection.selectedRowIds.value).toEqual(new Set([2]));
     } finally {
+      selection.finishRowSelection();
+      pointerDocument.restore();
+    }
+  });
+
+  it("ends active cell and row drags when the window loses focus", () => {
+    const pointerDocument = installPointerDocument();
+    let pointerRow = 2;
+    let pointerCell = { rowIndex: 2, colIndex: 2 };
+    const selection = createSelection({
+      cellFromClientPoint: () => pointerCell,
+      rowFromClientPoint: () => pointerRow,
+      shouldUpdateDraggedRowsImmediately: () => true,
+    });
+
+    try {
+      selection.beginCellSelection(0, 0, { button: 0, clientX: 10, clientY: 10, preventDefault() {} } as MouseEvent);
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 30, clientY: 30 } as MouseEvent);
+      expect(selection.selectedRange.value).toEqual({ startRow: 0, endRow: 2, startCol: 0, endCol: 2 });
+
+      pointerDocument.dispatchWindow("blur");
+      expect(selection.isSelectingCells.value).toBe(false);
+      pointerCell = { rowIndex: 3, colIndex: 2 };
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 40, clientY: 40 } as MouseEvent);
+      expect(selection.selectedRange.value).toEqual({ startRow: 0, endRow: 2, startCol: 0, endCol: 2 });
+
+      selection.beginRowSelection(1, 2, { button: 0, clientX: 5, clientY: 10, preventDefault() {} } as MouseEvent);
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 5, clientY: 40 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3]));
+
+      pointerDocument.dispatchWindow("blur");
+      expect(selection.isSelectingRows.value).toBe(false);
+      pointerRow = 3;
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 5, clientY: 70 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3]));
+    } finally {
+      selection.finishCellSelection();
+      selection.finishRowSelection();
+      pointerDocument.restore();
+    }
+  });
+
+  it("recovers from a lost mouseup when mouse movement reports no primary button", () => {
+    const pointerDocument = installPointerDocument();
+    let pointerRow = 2;
+    let pointerCell = { rowIndex: 2, colIndex: 2 };
+    const selection = createSelection({
+      cellFromClientPoint: () => pointerCell,
+      rowFromClientPoint: () => pointerRow,
+      shouldUpdateDraggedRowsImmediately: () => true,
+    });
+
+    try {
+      selection.beginRowSelection(1, 2, { button: 0, clientX: 5, clientY: 10, preventDefault() {} } as MouseEvent);
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 5, clientY: 40 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3]));
+
+      pointerRow = 3;
+      pointerDocument.dispatch("mousemove", { buttons: 0, clientX: 5, clientY: 70 } as MouseEvent);
+      expect(selection.isSelectingRows.value).toBe(false);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3]));
+
+      pointerRow = 0;
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 5, clientY: 90 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3]));
+
+      selection.clearRowSelection();
+      selection.beginCellSelection(0, 0, { button: 0, clientX: 10, clientY: 10, preventDefault() {} } as MouseEvent);
+      pointerDocument.dispatch("mousemove", { buttons: 1, clientX: 30, clientY: 30 } as MouseEvent);
+      expect(selection.selectedRange.value).toEqual({ startRow: 0, endRow: 2, startCol: 0, endCol: 2 });
+
+      pointerCell = { rowIndex: 3, colIndex: 2 };
+      pointerDocument.dispatch("mousemove", { buttons: 0, clientX: 40, clientY: 40 } as MouseEvent);
+      expect(selection.isSelectingCells.value).toBe(false);
+      expect(selection.selectedRange.value).toEqual({ startRow: 0, endRow: 2, startCol: 0, endCol: 2 });
+    } finally {
+      selection.finishCellSelection();
       selection.finishRowSelection();
       pointerDocument.restore();
     }

--- a/apps/desktop/src/composables/__tests__/useDataGridSelection.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridSelection.spec.ts
@@ -2,7 +2,14 @@ import { computed, ref } from "vue";
 import { describe, expect, it, vi } from "vitest";
 import { useDataGridSelection } from "@/composables/useDataGridSelection";
 
-function createSelection(options?: { getScrollElement?: () => HTMLElement | null; cellFromClientPoint?: (clientX: number, clientY: number) => { rowIndex: number; colIndex: number } | null; rowFromClientPoint?: (clientX: number, clientY: number) => number | null; onUserCellSelection?: () => void }) {
+function createSelection(options?: {
+  getScrollElement?: () => HTMLElement | null;
+  cellFromClientPoint?: (clientX: number, clientY: number) => { rowIndex: number; colIndex: number } | null;
+  rowFromClientPoint?: (clientX: number, clientY: number) => number | null;
+  onUserCellSelection?: () => void;
+  shouldUpdateDraggedRowsImmediately?: () => boolean;
+  onDraggedRowSelectionChange?: () => void;
+}) {
   const columns = computed(() => ["id", "name", "email"]);
   const displayItems = computed(() =>
     [1, 2, 3, 4].map((id, index) => ({
@@ -28,6 +35,8 @@ function createSelection(options?: { getScrollElement?: () => HTMLElement | null
     cellFromClientPoint: options?.cellFromClientPoint,
     rowFromClientPoint: options?.rowFromClientPoint,
     onUserCellSelection: options?.onUserCellSelection,
+    shouldUpdateDraggedRowsImmediately: options?.shouldUpdateDraggedRowsImmediately,
+    onDraggedRowSelectionChange: options?.onDraggedRowSelectionChange,
   });
 }
 
@@ -345,6 +354,40 @@ describe("useDataGridSelection", () => {
 
       expect(selection.isSelectingRows.value).toBe(false);
       expect(selection.selectedRowIds.value).toEqual(new Set([2]));
+    } finally {
+      selection.finishRowSelection();
+      pointerDocument.restore();
+    }
+  });
+
+  it("updates row drags synchronously and invalidates the final mouseup selection", () => {
+    const pointerDocument = installPointerDocument();
+    const onDraggedRowSelectionChange = vi.fn();
+    let pointerRow = 1;
+    const selection = createSelection({
+      rowFromClientPoint: () => pointerRow,
+      shouldUpdateDraggedRowsImmediately: () => true,
+      onDraggedRowSelectionChange,
+    });
+
+    try {
+      selection.beginRowSelection(1, 2, { button: 0, clientX: 5, clientY: 10, preventDefault() {} } as MouseEvent);
+      onDraggedRowSelectionChange.mockClear();
+
+      pointerRow = 2;
+      pointerDocument.dispatch("mousemove", { clientX: 5, clientY: 40 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3]));
+      expect(onDraggedRowSelectionChange).toHaveBeenCalledTimes(1);
+
+      pointerRow = 3;
+      pointerDocument.dispatch("mouseup", { clientX: 5, clientY: 66 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3, 4]));
+      expect(onDraggedRowSelectionChange).toHaveBeenCalledTimes(2);
+
+      pointerRow = 0;
+      pointerDocument.dispatch("mousemove", { clientX: 5, clientY: 92 } as MouseEvent);
+      expect(selection.selectedRowIds.value).toEqual(new Set([2, 3, 4]));
+      expect(onDraggedRowSelectionChange).toHaveBeenCalledTimes(2);
     } finally {
       selection.finishRowSelection();
       pointerDocument.restore();

--- a/apps/desktop/src/composables/useDataGridSelection.ts
+++ b/apps/desktop/src/composables/useDataGridSelection.ts
@@ -62,6 +62,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   let selectionPointerDownClientY = 0;
   let selectionDragConfirmed = false;
   let selectionAutoScrollFrame = 0;
+  let selectionInterruptionListenersAttached = false;
   let rowSelectionRangeAnchorIndex = -1;
   let rowSelectionFocusIndex = -1;
   let rowSelectionBaseIds = new Set<number>();
@@ -439,8 +440,40 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     return true;
   }
 
+  function primaryMouseButtonReleased(event: MouseEvent): boolean {
+    return typeof event.buttons === "number" && (event.buttons & 1) === 0;
+  }
+
+  function handleSelectionVisibilityChange() {
+    if (document.visibilityState === "hidden") finishSelection();
+  }
+
+  function attachSelectionInterruptionListeners() {
+    if (selectionInterruptionListenersAttached) return;
+    selectionInterruptionListenersAttached = true;
+    if (typeof window !== "undefined") {
+      window.addEventListener("blur", finishSelection);
+      window.addEventListener("pointercancel", finishSelection, true);
+    }
+    document.addEventListener("visibilitychange", handleSelectionVisibilityChange);
+  }
+
+  function detachSelectionInterruptionListenersIfIdle() {
+    if (!selectionInterruptionListenersAttached || isSelectingCells.value || isSelectingRows.value) return;
+    selectionInterruptionListenersAttached = false;
+    if (typeof window !== "undefined") {
+      window.removeEventListener("blur", finishSelection);
+      window.removeEventListener("pointercancel", finishSelection, true);
+    }
+    document.removeEventListener("visibilitychange", handleSelectionVisibilityChange);
+  }
+
   function handleRowSelectionPointerMove(event: MouseEvent) {
     if (!isSelectingRows.value) return;
+    if (primaryMouseButtonReleased(event)) {
+      finishRowSelection();
+      return;
+    }
     if (!confirmSelectionDrag(event.clientX, event.clientY)) return;
     selectionPointerClientX = event.clientX;
     selectionPointerClientY = event.clientY;
@@ -463,10 +496,12 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     document.removeEventListener("mouseup", finishRowSelection);
     document.removeEventListener("mousemove", handleRowSelectionPointerMove);
     stopSelectionAutoScroll();
+    detachSelectionInterruptionListenersIfIdle();
   }
 
   function beginRowSelection(rowIndex: number, rowId: number, event: MouseEvent) {
     if (event.button !== 0) return;
+    finishSelection();
     event.preventDefault();
     focusGridWithoutScrolling();
     clearCellSelection();
@@ -488,6 +523,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     selectionDragConfirmed = false;
     document.addEventListener("mouseup", finishRowSelection);
     document.addEventListener("mousemove", handleRowSelectionPointerMove);
+    attachSelectionInterruptionListeners();
   }
 
   function finishCellSelection() {
@@ -495,6 +531,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     document.removeEventListener("mouseup", finishCellSelection);
     document.removeEventListener("mousemove", handleSelectionPointerMove);
     stopSelectionAutoScroll();
+    detachSelectionInterruptionListenersIfIdle();
   }
 
   function restoreCellSelectionState(state: RestoredCellSelectionState) {
@@ -554,6 +591,10 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
 
   function handleSelectionPointerMove(event: MouseEvent) {
     if (!isSelectingCells.value) return;
+    if (primaryMouseButtonReleased(event)) {
+      finishCellSelection();
+      return;
+    }
     if (!confirmSelectionDrag(event.clientX, event.clientY)) return;
     selectionPointerClientX = event.clientX;
     selectionPointerClientY = event.clientY;
@@ -568,6 +609,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
   function beginCellSelection(rowIndex: number, colIndex: number, event: MouseEvent) {
     if (event.button !== 0) return;
     if (editingCell.value) return;
+    finishSelection();
     event.preventDefault();
     focusGridWithoutScrolling();
     clearCellSelection();
@@ -582,6 +624,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     if (showTranspose.value) transposeRowIndex.value = rowIndex;
     document.addEventListener("mouseup", finishCellSelection);
     document.addEventListener("mousemove", handleSelectionPointerMove);
+    attachSelectionInterruptionListeners();
   }
 
   function finishSelection() {

--- a/apps/desktop/src/composables/useDataGridSelection.ts
+++ b/apps/desktop/src/composables/useDataGridSelection.ts
@@ -27,6 +27,8 @@ export interface UseDataGridSelectionOptions {
   cellFromClientPoint?: (clientX: number, clientY: number) => CellPosition | null;
   rowFromClientPoint?: (clientX: number, clientY: number) => number | null;
   onUserCellSelection?: () => void;
+  shouldUpdateDraggedRowsImmediately?: () => boolean;
+  onDraggedRowSelectionChange?: () => void;
   runtimeScope?: DataGridRuntimeScope;
 }
 
@@ -420,6 +422,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
       }
     }
     rowSelectionFocusIndex = focusRowIndex;
+    options.onDraggedRowSelectionChange?.();
   }
 
   function updateRowSelectionFromPointer() {
@@ -441,6 +444,7 @@ export function useDataGridSelection(options: UseDataGridSelectionOptions) {
     if (!confirmSelectionDrag(event.clientX, event.clientY)) return;
     selectionPointerClientX = event.clientX;
     selectionPointerClientY = event.clientY;
+    if (options.shouldUpdateDraggedRowsImmediately?.()) updateRowSelectionFromPointer();
     if (!selectionAutoScrollFrame) selectionAutoScrollFrame = requestAnimationFrame(runSelectionAutoScroll);
   }
 


### PR DESCRIPTION
## 变更说明

修复数据网格拖选过程中的两个交互问题：

- 修复 Canvas 模式通过行号拖选时，选区渲染落后鼠标一行的问题。
- Canvas 行选区在鼠标移动阶段同步更新，并在拖选、自动滚动和松开鼠标后显式触发重绘。
- 修复微信截图、窗口切换等场景截获 `mouseup` 后，网格仍然保持拖选状态的问题。
- 拖选期间监听窗口失焦、页面隐藏和 `pointercancel`，异常中断时结束当前拖选。
- 通过 `MouseEvent.buttons` 检测左键是否已经释放，处理应用未收到 `mouseup` 的情况。
- 异常中断时保留最后一个有效选区，不清空已选择的数据，也不使用截图覆盖层中的鼠标坐标更新选区。
- Canvas 和 DOM 模式共用拖选释放逻辑；DOM 模式继续保留原有的 RAF 合并更新策略。
- 增加行拖选同步渲染、窗口失焦和丢失 `mouseup` 场景的回归测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）



1. Canvas 模式下通过行号连续向上、向下拖选，选区与鼠标所在行保持同步，松开后不发生跳动。
修改前：
<img width="912" height="588" alt="iShot_2026-08-18_18 53 37" src="https://github.com/user-attachments/assets/8893ce11-c253-4261-af97-5f0ae5b9126c" />

修改后：
<img width="1104" height="610" alt="iShot_2026-08-18_18 54 50" src="https://github.com/user-attachments/assets/f1f5ef7f-bfbb-44c5-ac4b-ca826406eeb9" />

2. 按住鼠标左键拖选时启动微信截图，退出截图后移动鼠标，网格不再继续扩大选区，选区保持为失焦前的范围


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过
- [x] TypeScript 类型检查通过
- [x] Oxlint 检查通过
- [x] `git diff --check` 通过
- [x] 已手动验证 Canvas 行号拖选与鼠标位置同步
- [x] 已手动验证微信截图退出后拖选状态正常释放
- [x] 已手动验证 DOM 模式拖选行为无回归

相关测试命令：

```bash
./node_modules/.bin/vitest run \
  apps/desktop/src/composables/__tests__/useDataGridSelection.spec.ts \
  packages/app-tests/dataGridSelection.test.ts \
  --maxWorkers=1
```

Fixes #6549