### PR TITLE
Fix：修复字段快捷筛选失效

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4974,10 +4974,6 @@ const contextColumn = computed(() => {
   if (!contextCell.value || contextCell.value.col < 0) return null;
   return props.result.columns[contextCell.value.col] ?? null;
 });
-const contextCellValue = computed<CellValue | null>(() => {
-  if (!contextCell.value || contextCell.value.col < 0) return null;
-  return contextRowItem.value?.data[contextCell.value.col] ?? null;
-});
 const contextCellDetail = computed(() => {
   const cell = contextCell.value;
   if (!cell || cell.col < 0) return null;
@@ -5560,18 +5556,25 @@ function applyContextSort(direction: "asc" | "desc" | null, mode: DataGridSortMo
 }
 
 async function contextFilterCondition(mode: FilterMode): Promise<string | null> {
-  if (!contextColumn.value) return null;
-  if (mode !== "is-null" && mode !== "is-not-null" && contextCell.value) {
-    if (!(await hydrateLargeValueCell(contextCell.value.rowId, contextCell.value.col))) return null;
+  const target = contextCell.value;
+  if (!target) return null;
+  const columnName = props.result.columns[target.col];
+  if (!columnName) return null;
+  // CustomContextMenu closes before invoking its action. Keep the target
+  // stable across hydration after the close lifecycle clears contextCell.
+  if (mode !== "is-null" && mode !== "is-not-null") {
+    if (!(await hydrateLargeValueCell(target.rowId, target.col))) return null;
   }
+  const item = getRowItem(target.rowId);
+  if (!item) return null;
   return (
     (await buildDataGridContextFilterCondition({
       databaseType: resolvedDatabaseType.value,
       identifierQuote: connectionStore.connectionIdentifierQuote?.(props.connectionId),
-      columnName: contextColumn.value,
-      columnInfo: props.tableMeta?.columns.find((column) => column.name === contextColumn.value),
+      columnName,
+      columnInfo: props.tableMeta?.columns.find((column) => column.name === columnName),
       mode,
-      value: contextCellValue.value,
+      value: item.data[target.col] ?? null,
     })) ?? null
   );
 }
@@ -10458,6 +10461,10 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
     previewItems,
   );
 });
+
+function currentGridContextMenuItems(): ContextMenuItem[] {
+  return gridContextMenuItems.value;
+}
 </script>
 
 <template>
@@ -10477,7 +10484,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
     @paste="onGridPaste"
     @focusin="onGridFocusIn"
   >
-    <CustomContextMenu :items="gridContextMenuItems" @open="onGridContextMenuOpen" @close="onGridContextMenuClose" v-slot="{ onContextMenu }">
+    <CustomContextMenu :items="currentGridContextMenuItems" @open="onGridContextMenuOpen" @close="onGridContextMenuClose" v-slot="{ onContextMenu }">
       <div v-if="hasData || canShowWhereSearch" class="flex-1 flex flex-col overflow-hidden" @contextmenu="onContextMenu">
         <!-- Search bar -->
         <!-- Leave real vertical space around the 28px controls instead of fitting them against the border. -->

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5560,13 +5560,19 @@ async function contextFilterCondition(mode: FilterMode): Promise<string | null> 
   if (!target) return null;
   const columnName = props.result.columns[target.col];
   if (!columnName) return null;
+  const sourceResult = props.result;
+  const sourceItem = getRowItem(target.rowId);
+  if (!sourceItem) return null;
+  const sourceIndex = sourceItem.sourceIndex;
+  const requiresHydration = sourceIndex !== undefined && isLargeValuePreview(sourceItem, target.col);
+  const sourceValue = sourceItem.data[target.col] ?? null;
   // CustomContextMenu closes before invoking its action. Keep the target
   // stable across hydration after the close lifecycle clears contextCell.
   if (mode !== "is-null" && mode !== "is-not-null") {
     if (!(await hydrateLargeValueCell(target.rowId, target.col))) return null;
   }
-  const item = getRowItem(target.rowId);
-  if (!item) return null;
+  if (props.result !== sourceResult) return null;
+  const value = requiresHydration && sourceIndex !== undefined ? (sourceResult.rows[sourceIndex]?.[target.col] ?? null) : sourceValue;
   return (
     (await buildDataGridContextFilterCondition({
       databaseType: resolvedDatabaseType.value,
@@ -5574,7 +5580,7 @@ async function contextFilterCondition(mode: FilterMode): Promise<string | null> 
       columnName,
       columnInfo: props.tableMeta?.columns.find((column) => column.name === columnName),
       mode,
-      value: item.data[target.col] ?? null,
+      value,
     })) ?? null
   );
 }

--- a/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
@@ -10,4 +10,23 @@ describe("DataGrid context extractor lifecycle", () => {
     expect(source).toContain("queueMicrotask(() => {");
     expect(source).toContain("invalidateSyntheticContextSelection();");
   });
+
+  it("resolves menu items after the right-click target is updated", () => {
+    expect(source).toContain(':items="currentGridContextMenuItems"');
+    expect(source).toContain("return gridContextMenuItems.value;");
+  });
+
+  it("snapshots the filter target before asynchronous value hydration", () => {
+    const start = source.indexOf("async function contextFilterCondition");
+    const end = source.indexOf("async function applyContextFilter", start);
+    const filterSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    expect(filterSource).toContain("const target = contextCell.value;");
+    expect(filterSource).toContain("await hydrateLargeValueCell(target.rowId, target.col)");
+    expect(filterSource).toContain("const item = getRowItem(target.rowId);");
+    expect(filterSource).not.toContain("contextColumn.value");
+    expect(filterSource).not.toContain("contextCellValue.value");
+  });
 });

--- a/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
@@ -24,8 +24,11 @@ describe("DataGrid context extractor lifecycle", () => {
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
     expect(filterSource).toContain("const target = contextCell.value;");
+    expect(filterSource).toContain("const sourceResult = props.result;");
+    expect(filterSource).toContain("const sourceIndex = sourceItem.sourceIndex;");
     expect(filterSource).toContain("await hydrateLargeValueCell(target.rowId, target.col)");
-    expect(filterSource).toContain("const item = getRowItem(target.rowId);");
+    expect(filterSource).toContain("sourceResult.rows[sourceIndex]?.[target.col]");
+    expect(filterSource).not.toContain("getRowItem(target.rowId);\n  if (!item)");
     expect(filterSource).not.toContain("contextColumn.value");
     expect(filterSource).not.toContain("contextCellValue.value");
   });


### PR DESCRIPTION
## 问题

单元格右键菜单关闭后会清理当前单元格上下文，而“筛选此值”等操作需要先异步补全大字段数据。异步操作结束后再次读取响应式上下文时，目标单元格已经被清空，因此无法生成 WHERE 条件。

同一生命周期还会让首次右键打开菜单时读取到更新前的菜单项。

## 修复

- 在右键事件发生时同步解析最新菜单项，保证首次右键显示完整菜单
- 在异步补全数据前快照目标行、列和字段名
- 补全数据后通过快照重新读取最新单元格值并构造筛选条件
- 保留菜单关闭后的上下文清理，避免重新引入数据提取器上下文泄漏
- 增加菜单解析时机和异步筛选目标的回归测试

## 验证

- MySQL 实际表数据：首次右键可显示完整菜单
- “筛选此值”正确生成 `` `note` = '123123' `` 并重新执行查询
- “排除此值”正确追加 `` `note` <> '123123' ``
- `pnpm exec vitest run apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts apps/desktop/src/lib/__tests__/dataGrid/dataGridContextMenu.spec.ts`
- `pnpm -s typecheck`
- `git diff --check origin/main...HEAD`

Fixes #6599