### PR TITLE
✨ feat(tabbar): 为溢出标签菜单添加搜索功能

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -2,12 +2,13 @@
 import { computed, ref, watch, nextTick, onUnmounted } from "vue";
 import type { CSSProperties } from "vue";
 import { useI18n } from "vue-i18n";
-import { X, Pin, ChevronDown, Table2, Code2, TableProperties, PencilRuler, KeyRound, Pencil, Package, Lock, Copy, AlertTriangle, Network, Minimize2, Maximize2, Settings, CalendarClock, Activity, Gauge, ShieldCheck, Database, GitBranch } from "@lucide/vue";
+import { X, Pin, ChevronDown, Search, Table2, Code2, TableProperties, PencilRuler, KeyRound, Pencil, Package, Lock, Copy, AlertTriangle, Network, Minimize2, Maximize2, Settings, CalendarClock, Activity, Gauge, ShieldCheck, Database, GitBranch } from "@lucide/vue";
 import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomContextMenu.vue";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
@@ -518,8 +519,24 @@ const showFixedTabScrollbar = computed(() => hasFixedTabOverflow.value && !isWra
 const showRegularTabOverflowControls = computed(() => regularTabs.value.length > 0 && hasTabOverflow.value && !isWrapLayout.value);
 const regularTabOverflowOpen = ref(false);
 const fixedTabOverflowOpen = ref(false);
+const tabSearchQuery = ref("");
+const filteredOpenTabs = computed(() => {
+  const query = tabSearchQuery.value.trim().toLocaleLowerCase();
+  if (!query) return queryStore.tabs;
+  return queryStore.tabs.filter((tab) => tabTitleText(tab).toLocaleLowerCase().includes(query) || tab.title.toLocaleLowerCase().includes(query));
+});
 const tabBarClass = computed(() => [isClassicLayout.value ? "bg-muted" : "border-b bg-background", hasFixedTabs.value ? "flex-col" : "", isClassicLayout.value && hasFixedTabs.value ? "border-b" : ""]);
 const regularTabRowClass = computed(() => [isClassicLayout.value ? "h-9 items-stretch" : "h-10 items-center px-2", isClassicLayout.value && !hasFixedTabs.value ? "border-b" : ""]);
+
+watch(regularTabOverflowOpen, (open) => {
+  tabSearchQuery.value = "";
+  if (open) nextTick(() => document.querySelector<HTMLInputElement>('[data-tab-search-input="regular"]')?.focus());
+});
+
+watch(fixedTabOverflowOpen, (open) => {
+  tabSearchQuery.value = "";
+  if (open) nextTick(() => document.querySelector<HTMLInputElement>('[data-tab-search-input="fixed"]')?.focus());
+});
 
 function tabMenuIcon(tab: QueryTab) {
   if (tab.externalSqlFileMissing) return AlertTriangle;
@@ -794,40 +811,47 @@ function onOverflowItemKeydown(event: KeyboardEvent, tabId: string, kind: "regul
               <ChevronDown class="h-4 w-4" />
             </button>
           </PopoverTrigger>
-          <PopoverContent align="end" class="w-auto min-w-56 max-w-80 max-h-[min(70vh,28rem)] gap-0 overflow-y-auto rounded-[6px] p-1" @click.stop @keydown.stop>
-            <CustomContextMenu v-for="tab in queryStore.tabs" :key="tab.id" :items="getTabMenuItems(tab)" v-slot="{ onContextMenu }">
-              <div
-                class="group flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-hidden hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
-                :class="tab.id === queryStore.activeTabId && !driverStoreActive && !settingsPageActive ? 'bg-accent/70 text-accent-foreground' : ''"
-                :title="tabTitleLabel(tab)"
-                role="menuitem"
-                tabindex="0"
-                @click="activateTabFromOverflow(tab.id, 'regular')"
-                @contextmenu="onContextMenu"
-                @keydown="onOverflowItemKeydown($event, tab.id, 'regular')"
-              >
-                <DatabaseIcon v-if="tab.mode === 'mq'" :db-type="tabDatabaseIconType(tab)" class="h-3.5 w-3.5 shrink-0" />
-                <component :is="tabMenuIcon(tab)" v-else :class="['h-3.5 w-3.5 shrink-0', tabIconClass(tab)]" />
-                <span class="inline-flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
-                  <span v-if="isDirtyTab(tab)" aria-hidden="true" class="dirty-tab-marker">*</span>
-                  <span class="min-w-0 flex-1 truncate" :style="tabTitleStyle(tab)">{{ tabTitleText(tab) }}</span>
-                </span>
-                <Lock v-if="isConnectionReadonly(tab.connectionId)" class="h-3 w-3 shrink-0 text-muted-foreground" />
-                <Pin v-if="tab.pinned" class="h-3 w-3 shrink-0 fill-current text-primary" />
-                <span class="w-5 shrink-0">
-                  <button
-                    type="button"
-                    class="inline-flex rounded p-1 text-muted-foreground opacity-70 hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100"
-                    :aria-label="t('contextMenu.closeTab')"
-                    :title="t('contextMenu.closeTab')"
-                    @click="closeTabFromOverflow(tab.id, $event)"
-                    @mousedown.stop
-                  >
-                    <X class="h-3 w-3" />
-                  </button>
-                </span>
-              </div>
-            </CustomContextMenu>
+          <PopoverContent align="end" class="w-auto min-w-56 max-w-80 gap-0 rounded-[6px] p-1" @click.stop @keydown.stop>
+            <div class="relative border-b px-1 pb-1">
+              <Search class="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input data-tab-search-input="regular" v-model="tabSearchQuery" type="search" :placeholder="t('tabs.searchOpenTabs')" class="h-8 pl-7 text-sm" />
+            </div>
+            <div class="max-h-[min(70vh,28rem)] overflow-y-auto pt-1">
+              <CustomContextMenu v-for="tab in filteredOpenTabs" :key="tab.id" :items="getTabMenuItems(tab)" v-slot="{ onContextMenu }">
+                <div
+                  class="group flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-hidden hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+                  :class="tab.id === queryStore.activeTabId && !driverStoreActive && !settingsPageActive ? 'bg-accent/70 text-accent-foreground' : ''"
+                  :title="tabTitleLabel(tab)"
+                  role="menuitem"
+                  tabindex="0"
+                  @click="activateTabFromOverflow(tab.id, 'regular')"
+                  @contextmenu="onContextMenu"
+                  @keydown="onOverflowItemKeydown($event, tab.id, 'regular')"
+                >
+                  <DatabaseIcon v-if="tab.mode === 'mq'" :db-type="tabDatabaseIconType(tab)" class="h-3.5 w-3.5 shrink-0" />
+                  <component :is="tabMenuIcon(tab)" v-else :class="['h-3.5 w-3.5 shrink-0', tabIconClass(tab)]" />
+                  <span class="inline-flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
+                    <span v-if="isDirtyTab(tab)" aria-hidden="true" class="dirty-tab-marker">*</span>
+                    <span class="min-w-0 flex-1 truncate" :style="tabTitleStyle(tab)">{{ tabTitleText(tab) }}</span>
+                  </span>
+                  <Lock v-if="isConnectionReadonly(tab.connectionId)" class="h-3 w-3 shrink-0 text-muted-foreground" />
+                  <Pin v-if="tab.pinned" class="h-3 w-3 shrink-0 fill-current text-primary" />
+                  <span class="w-5 shrink-0">
+                    <button
+                      type="button"
+                      class="inline-flex rounded p-1 text-muted-foreground opacity-70 hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100"
+                      :aria-label="t('contextMenu.closeTab')"
+                      :title="t('contextMenu.closeTab')"
+                      @click="closeTabFromOverflow(tab.id, $event)"
+                      @mousedown.stop
+                    >
+                      <X class="h-3 w-3" />
+                    </button>
+                  </span>
+                </div>
+              </CustomContextMenu>
+              <p v-if="filteredOpenTabs.length === 0" class="px-2 py-4 text-center text-sm text-muted-foreground">{{ t("tabs.noMatchingTabs") }}</p>
+            </div>
           </PopoverContent>
         </Popover>
       </div>
@@ -935,44 +959,51 @@ function onOverflowItemKeydown(event: KeyboardEvent, tabId: string, kind: "regul
       <div v-if="showFixedTabScrollbar" class="relative z-30 flex shrink-0 items-center">
         <Popover v-model:open="fixedTabOverflowOpen">
           <PopoverTrigger as-child>
-            <button type="button" :class="['inline-flex shrink-0 items-center justify-center', tabOverflowControlClass].join(' ')" :aria-label="t('tabs.fixedTabs')" :title="t('tabs.fixedTabs')">
+            <button type="button" :class="['inline-flex shrink-0 items-center justify-center', tabOverflowControlClass].join(' ')" :aria-label="t('tabs.openTabs')" :title="t('tabs.openTabs')">
               <ChevronDown class="h-4 w-4" />
             </button>
           </PopoverTrigger>
-          <PopoverContent align="end" class="w-auto min-w-56 max-w-80 max-h-[min(70vh,28rem)] gap-0 overflow-y-auto rounded-[6px] p-1" @click.stop @keydown.stop>
-            <CustomContextMenu v-for="tab in fixedTabs" :key="tab.id" :items="getTabMenuItems(tab)" v-slot="{ onContextMenu }">
-              <div
-                class="group flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-hidden hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
-                :class="tab.id === queryStore.activeTabId && !driverStoreActive && !settingsPageActive ? 'bg-accent/70 text-accent-foreground' : ''"
-                :title="tabTitleLabel(tab)"
-                role="menuitem"
-                tabindex="0"
-                @click="activateTabFromOverflow(tab.id, 'fixed')"
-                @contextmenu="onContextMenu"
-                @keydown="onOverflowItemKeydown($event, tab.id, 'fixed')"
-              >
-                <DatabaseIcon v-if="tab.mode === 'mq'" :db-type="tabDatabaseIconType(tab)" class="h-3.5 w-3.5 shrink-0" />
-                <component :is="tabMenuIcon(tab)" v-else :class="['h-3.5 w-3.5 shrink-0', tabIconClass(tab)]" />
-                <span class="inline-flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
-                  <span v-if="isDirtyTab(tab)" aria-hidden="true" class="dirty-tab-marker">*</span>
-                  <span class="min-w-0 flex-1 truncate" :style="tabTitleStyle(tab)">{{ tabTitleText(tab) }}</span>
-                </span>
-                <Lock v-if="isConnectionReadonly(tab.connectionId)" class="h-3 w-3 shrink-0 text-muted-foreground" />
-                <Pin class="h-3 w-3 shrink-0 fill-current text-primary" />
-                <span class="w-5 shrink-0">
-                  <button
-                    type="button"
-                    class="inline-flex rounded p-1 text-muted-foreground opacity-70 hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100"
-                    :aria-label="t('contextMenu.closeTab')"
-                    :title="t('contextMenu.closeTab')"
-                    @click="closeTabFromOverflow(tab.id, $event)"
-                    @mousedown.stop
-                  >
-                    <X class="h-3 w-3" />
-                  </button>
-                </span>
-              </div>
-            </CustomContextMenu>
+          <PopoverContent align="end" class="w-auto min-w-56 max-w-80 gap-0 rounded-[6px] p-1" @click.stop @keydown.stop>
+            <div class="relative border-b px-1 pb-1">
+              <Search class="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input data-tab-search-input="fixed" v-model="tabSearchQuery" type="search" :placeholder="t('tabs.searchOpenTabs')" class="h-8 pl-7 text-sm" />
+            </div>
+            <div class="max-h-[min(70vh,28rem)] overflow-y-auto pt-1">
+              <CustomContextMenu v-for="tab in filteredOpenTabs" :key="tab.id" :items="getTabMenuItems(tab)" v-slot="{ onContextMenu }">
+                <div
+                  class="group flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-hidden hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+                  :class="tab.id === queryStore.activeTabId && !driverStoreActive && !settingsPageActive ? 'bg-accent/70 text-accent-foreground' : ''"
+                  :title="tabTitleLabel(tab)"
+                  role="menuitem"
+                  tabindex="0"
+                  @click="activateTabFromOverflow(tab.id, 'fixed')"
+                  @contextmenu="onContextMenu"
+                  @keydown="onOverflowItemKeydown($event, tab.id, 'fixed')"
+                >
+                  <DatabaseIcon v-if="tab.mode === 'mq'" :db-type="tabDatabaseIconType(tab)" class="h-3.5 w-3.5 shrink-0" />
+                  <component :is="tabMenuIcon(tab)" v-else :class="['h-3.5 w-3.5 shrink-0', tabIconClass(tab)]" />
+                  <span class="inline-flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
+                    <span v-if="isDirtyTab(tab)" aria-hidden="true" class="dirty-tab-marker">*</span>
+                    <span class="min-w-0 flex-1 truncate" :style="tabTitleStyle(tab)">{{ tabTitleText(tab) }}</span>
+                  </span>
+                  <Lock v-if="isConnectionReadonly(tab.connectionId)" class="h-3 w-3 shrink-0 text-muted-foreground" />
+                  <Pin v-if="tab.pinned" class="h-3 w-3 shrink-0 fill-current text-primary" />
+                  <span class="w-5 shrink-0">
+                    <button
+                      type="button"
+                      class="inline-flex rounded p-1 text-muted-foreground opacity-70 hover:bg-muted-foreground/20 hover:text-foreground group-hover:opacity-100"
+                      :aria-label="t('contextMenu.closeTab')"
+                      :title="t('contextMenu.closeTab')"
+                      @click="closeTabFromOverflow(tab.id, $event)"
+                      @mousedown.stop
+                    >
+                      <X class="h-3 w-3" />
+                    </button>
+                  </span>
+                </div>
+              </CustomContextMenu>
+              <p v-if="filteredOpenTabs.length === 0" class="px-2 py-4 text-center text-sm text-muted-foreground">{{ t("tabs.noMatchingTabs") }}</p>
+            </div>
           </PopoverContent>
         </Popover>
       </div>

--- a/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
@@ -66,3 +66,19 @@ describe("AppTabBar right-side close action", () => {
     expect(tabBarSource).toMatch(/emit\("close-driver-store"\);\s*if \(shouldActivateSettings\) emit\("activate-settings-page"\);/);
   });
 });
+
+describe("AppTabBar overflow search", () => {
+  it("filters every open tab by its display and source titles", () => {
+    expect(tabBarSource).toContain('const tabSearchQuery = ref("");');
+    expect(tabBarSource).toContain("const filteredOpenTabs = computed(() => {");
+    expect(tabBarSource).toContain("return queryStore.tabs.filter((tab) => tabTitleText(tab).toLocaleLowerCase().includes(query) || tab.title.toLocaleLowerCase().includes(query));");
+  });
+
+  it("provides the same focused search control and empty state in both overflow menus", () => {
+    expect(tabBarSource.match(/<Input data-tab-search-input=/g)).toHaveLength(2);
+    expect(tabBarSource.match(/v-for="tab in filteredOpenTabs"/g)).toHaveLength(2);
+    expect(tabBarSource.match(/tabs\.noMatchingTabs/g)).toHaveLength(2);
+    expect(tabBarSource).toContain('[data-tab-search-input="regular"]');
+    expect(tabBarSource).toContain('[data-tab-search-input="fixed"]');
+  });
+});

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1400,6 +1400,8 @@ export default {
     scrollLeft: "Scroll tabs left",
     scrollRight: "Scroll tabs right",
     openTabs: "Open tabs",
+    searchOpenTabs: "Search open tabs...",
+    noMatchingTabs: "No matching tabs",
     fixedTabs: "Fixed tabs",
     openDataTabs: "Open tables",
   },

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1377,6 +1377,8 @@ export default withEnglishFallback({
     scrollLeft: "Desplazar pestañas a la izquierda",
     scrollRight: "Desplazar pestañas a la derecha",
     openTabs: "Pestañas abiertas",
+    searchOpenTabs: "Buscar pestañas abiertas...",
+    noMatchingTabs: "No se encontraron pestañas",
     fixedTabs: "Pestañas fijadas",
     openDataTabs: "Tablas abiertas",
     gridfs: "GridFS",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1375,6 +1375,8 @@ export default withEnglishFallback({
     scrollLeft: "Scorri schede a sinistra",
     scrollRight: "Scorri schede a destra",
     openTabs: "Schede aperte",
+    searchOpenTabs: "Cerca schede aperte...",
+    noMatchingTabs: "Nessuna scheda corrispondente",
     fixedTabs: "Schede bloccate",
     openDataTabs: "Tabelle aperte",
     gridfs: "GridFS",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1394,6 +1394,8 @@ export default withEnglishFallback({
     scrollLeft: "タブを左にスクロール",
     scrollRight: "タブを右にスクロール",
     openTabs: "開いているタブ",
+    searchOpenTabs: "開いているタブを検索...",
+    noMatchingTabs: "一致するタブがありません",
     fixedTabs: "固定タブ",
     openDataTabs: "開いているテーブル",
     zookeeper: "ZooKeeper",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -1281,6 +1281,8 @@ export default withEnglishFallback({
     scrollLeft: "탭을 왼쪽으로 스크롤",
     scrollRight: "탭을 오른쪽으로 스크롤",
     openTabs: "열린 탭",
+    searchOpenTabs: "열린 탭 검색...",
+    noMatchingTabs: "일치하는 탭이 없습니다",
     fixedTabs: "고정 탭",
     openDataTabs: "열린 테이블",
   },

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1377,6 +1377,8 @@ export default withEnglishFallback({
     scrollLeft: "Rolar abas para a esquerda",
     scrollRight: "Rolar abas para a direita",
     openTabs: "Abas abertas",
+    searchOpenTabs: "Pesquisar abas abertas...",
+    noMatchingTabs: "Nenhuma aba correspondente",
     fixedTabs: "Abas fixadas",
     openDataTabs: "Tabelas abertas",
     gridfs: "GridFS",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1324,6 +1324,8 @@ export default withEnglishFallback({
     scrollLeft: "向左滚动标签页",
     scrollRight: "向右滚动标签页",
     openTabs: "已打开的标签页",
+    searchOpenTabs: "搜索已打开的标签页...",
+    noMatchingTabs: "未找到匹配的标签页",
     fixedTabs: "固定标签页",
     openDataTabs: "已打开的数据表",
   },

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1376,6 +1376,8 @@ export default withEnglishFallback({
     scrollLeft: "向左捲動分頁",
     scrollRight: "向右捲動分頁",
     openTabs: "已開啟的分頁",
+    searchOpenTabs: "搜尋已開啟的分頁...",
+    noMatchingTabs: "找不到符合的分頁",
     fixedTabs: "固定分頁",
     openDataTabs: "已開啟的資料表",
     gridfs: "GridFS",


### PR DESCRIPTION
- 支持按显示标题和原始标题筛选全部已打开标签
- 常规与固定标签菜单统一提供自动聚焦的搜索框及空结果提示
- 补充多语言文案和搜索行为测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="294" height="401" alt="image" src="https://github.com/user-attachments/assets/f46e060c-d297-4407-b58d-4152e8831775" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #6595