### PR TITLE
Test(rust): 修复整库导出回归测试栈溢出

### DIFF
--- a/crates/dbx-core/tests/database_export_prefetch.rs
+++ b/crates/dbx-core/tests/database_export_prefetch.rs
@@ -143,8 +143,25 @@ fn postgres_test_config(id: &str, port: u16) -> ConnectionConfig {
     }
 }
 
-#[tokio::test]
-async fn database_export_writes_structure_and_data_for_all_tables() {
+#[test]
+fn database_export_writes_structure_and_data_for_all_tables() {
+    let handle = std::thread::Builder::new()
+        .name("database-export-prefetch".to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build database export prefetch test runtime")
+                .block_on(run_database_export_writes_structure_and_data_for_all_tables());
+        })
+        .expect("spawn database export prefetch test thread");
+    if let Err(panic) = handle.join() {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+async fn run_database_export_writes_structure_and_data_for_all_tables() {
     let Some(container) = start_docker_postgres() else {
         return;
     };


### PR DESCRIPTION
## 问题

PR #6569 的 Rust CI 在 `database_export_prefetch` 集成测试中稳定复现栈溢出：

```text
thread 'database_export_writes_structure_and_data_for_all_tables' has overflowed its stack
fatal runtime error: stack overflow
```

失败发生在未被 #6569 修改的整库导出回归测试。相同导出路径的 `database_export_partition_ddl` 测试已使用 8 MB 测试线程栈，但该预取测试仍由 `#[tokio::test]` 在默认测试线程栈上运行。

## 修改

- 保留原异步测试主体和断言不变
- 使用命名线程和 8 MB 栈运行测试
- 在线程内创建 current-thread Tokio runtime
- 将子线程 panic 继续传回测试线程

## 验证

- `cargo fmt --check` 通过
- `cargo test -p dbx-core --locked --no-default-features --features 'duckdb-sidecar,dynamodb,mq-admin,sqlite-sqlcipher' --test database_export_prefetch -- --nocapture` 通过
- 对应定向 `cargo clippy ... -- -D warnings` 通过
- 本机无 Docker，定向测试验证了编译、runtime 包装和无 Docker 跳过路径；真实 PostgreSQL 导出路径由本 PR CI 验证

关联：#6569