### PR TITLE
🐛 fix(doris): show column comments in query results

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.dorisQualifiedColumnComments.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.dorisQualifiedColumnComments.spec.ts
@@ -1,0 +1,139 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeMulti = vi.fn();
+const executeQuery = vi.fn();
+const analyzeEditableQueryEditability = vi.fn();
+const getColumns = vi.fn();
+const listIndexes = vi.fn();
+const listObjects = vi.fn();
+const getConnectionConfig = vi.fn();
+const lookupLocalCompletionTables = vi.fn();
+const buildSortedQuerySql = vi.fn();
+const buildDataGridCountSql = vi.fn();
+const prepareQueryPaginationExecutionPlan = vi.fn(async (options) => ({
+  sqlToExecute: options.sql,
+  pageSql: undefined,
+  pageLimit: undefined,
+  pageOffset: undefined,
+  countSql: undefined,
+  useAgentResultSession: false,
+}));
+const editorSettings = {
+  pageSize: 100,
+  autoCalculateTotalRows: false,
+};
+
+vi.mock("@/lib/backend/api", () => ({
+  analyzeEditableQueryEditability,
+  buildDataGridCountSql,
+  buildSortedQuerySql,
+  closeClientConnectionSession: vi.fn().mockResolvedValue(undefined),
+  closeQuerySession: vi.fn().mockResolvedValue(undefined),
+  executeMulti,
+  executeQuery,
+  getColumns,
+  listIndexes,
+  listObjects,
+  prepareQueryPaginationExecutionPlan,
+  saveOpenTabsState: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => ({
+    ensureConnected: vi.fn().mockResolvedValue(undefined),
+    getConfig: getConnectionConfig,
+    lookupLocalCompletionTables,
+    recordConnectionLostError: vi.fn(),
+  }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings,
+  }),
+}));
+
+function column(name: string, comment: string | null, isPrimaryKey = false) {
+  return { name, data_type: "varchar", is_nullable: true, column_default: null, is_primary_key: isPrimaryKey, extra: null, comment };
+}
+
+const dorisColumns = [column("id", "主键ID"), column("user_name", "用户名称"), column("created_at", "创建时间"), column("extra_field", null)];
+
+describe("queryStore Doris qualified-table metadata target", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { clearTableMetadataCache } = await import("@/lib/metadata/tableMetadataCache");
+    clearTableMetadataCache();
+    setActivePinia(createPinia());
+    // Doris connection WITHOUT a default database: the query tab has no
+    // execution database either, so the only source of the table's namespace
+    // is the database explicitly qualified in the SQL (`dbx6590_test.tbl`).
+    getConnectionConfig.mockReturnValue({ id: "doris-1", name: "Doris", db_type: "doris", database: null, query_timeout_secs: 30 });
+    getColumns.mockResolvedValue(dorisColumns);
+    listIndexes.mockResolvedValue([]);
+    listObjects.mockResolvedValue([]);
+    lookupLocalCompletionTables.mockReturnValue([]);
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        // `dbx6590_test.dbx_comment_test` → the qualified database lands in
+        // `schema` (MySQL-family two-part names), matching the Rust parser.
+        schema: "dbx6590_test",
+        schemaQuoted: false,
+        tableName: "dbx_comment_test",
+        tableNameQuoted: false,
+        tableAlias: undefined,
+        selectStar: true,
+        columns: [],
+        multiSource: false,
+        allowInsertDelete: true,
+      },
+    });
+    buildSortedQuerySql.mockResolvedValue({ ok: true, sql: `${"SELECT *"} ORDER BY 1` });
+    buildDataGridCountSql.mockResolvedValue("SELECT COUNT(*) FROM `dbx6590_test`.`dbx_comment_test`");
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["id", "user_name", "created_at", "extra_field"],
+        rows: [[1, "alice", "2026-01-01 10:00:00", 100]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+    executeQuery.mockResolvedValue({
+      columns: ["id", "user_name", "created_at", "extra_field"],
+      rows: [[1, "alice", "2026-01-01 10:00:00", 100]],
+      affected_rows: 0,
+      execution_time_ms: 1,
+    });
+  });
+
+  afterEach(() => {
+    expect(listObjects).not.toHaveBeenCalled();
+  });
+
+  it("sends the SQL-qualified database in `schema` so the backend can resolve the column lookup", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("doris-1", "", "Query");
+
+    await store.executeTabSql(tabId, "SELECT * FROM dbx6590_test.dbx_comment_test");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.tableMeta).toBeDefined(), { timeout: 8000 });
+
+    // The metadata request carries the empty execution database plus the
+    // qualified database as `schema`. The backend's MySQL-compatible
+    // show-metadata path resolves the effective database from `schema`
+    // (fixes #6590); the query-result header then consumes tableMeta columns.
+    expect(getColumns).toHaveBeenCalledWith("doris-1", "", "dbx6590_test", "dbx_comment_test", undefined);
+
+    // Comments must flow into tableMeta so the data grid can display them.
+    const comments = new Map((tab.tableMeta?.columns ?? []).map((c) => [c.name, c.comment]));
+    expect(comments.get("id")).toBe("主键ID");
+    expect(comments.get("user_name")).toBe("用户名称");
+    expect(comments.get("created_at")).toBe("创建时间");
+    // Uncommented columns stay empty — no placeholder in the header.
+    expect(comments.get("extra_field")).toBeNull();
+  }, 15000);
+});

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -3625,6 +3625,22 @@ for line in sys.stdin:
     }
 
     #[test]
+    fn doris_show_metadata_resolves_effective_database_like_plain_mysql() {
+        // A qualified `db.table` reference in a MySQL-family dialect puts the
+        // database in the `schema` parameter (two-part names), so the
+        // Doris/StarRocks show-metadata column branch must resolve its
+        // effective database with `mysql_table_metadata_catalog` — schema
+        // first, database fallback — exactly like the plain MySQL branch.
+        // Otherwise an empty (or different) tab/execution database sends the
+        // column lookup to the wrong namespace and column comments are lost
+        // (fixes #6590).
+        assert_eq!(super::mysql_table_metadata_catalog("", "analytics"), "analytics");
+        assert_eq!(super::mysql_table_metadata_catalog("default_db", "analytics"), "analytics");
+        assert_eq!(super::mysql_table_metadata_catalog("analytics", ""), "analytics");
+        assert_eq!(super::mysql_table_metadata_catalog("", ""), "");
+    }
+
+    #[test]
     fn doris_database_list_keeps_system_databases() {
         let databases = vec![test_database_info("information_schema"), test_database_info("analytics")];
         let config = test_connection_config(DatabaseType::Doris);
@@ -5881,7 +5897,12 @@ async fn get_columns_core_for_session_inner(
                 db::manticoresearch::get_columns(p, metadata_database, table).await.map(deduplicate_column_infos)
             }
             PoolKind::Mysql(p, _) if db_config.as_ref().is_some_and(db::mysql_compatible::uses_show_metadata) => {
-                let metadata_database = mysql_show_metadata_database_for_config(db_config.as_ref(), database);
+                // Resolve the metadata database exactly like the plain MySQL
+                // branch below: a qualified `db.table` reference puts the
+                // database in `schema` (MySQL-family two-part names), so an
+                // empty or different tab/execution database must not send the
+                // lookup to the wrong namespace (fixes #6590).
+                let effective_db = mysql_table_metadata_catalog(database, schema);
                 // Doris/StarRocks previously went straight to `SHOW COLUMNS` for
                 // speed (see perf(doris) commit), but `SHOW COLUMNS` reports the
                 // `Key` column as `YES`/`NO` rather than MySQL's `PRI`, so primary
@@ -5890,7 +5911,7 @@ async fn get_columns_core_for_session_inner(
                 // correctly identifies primary keys (and only real primary keys,
                 // not duplicate-key sort columns) — and falls back to `SHOW COLUMNS`
                 // automatically when information_schema is unavailable.
-                db::mysql::get_columns(p, metadata_database, table).await.map(deduplicate_column_infos)
+                db::mysql::get_columns(p, effective_db, table).await.map(deduplicate_column_infos)
             }
             PoolKind::Mysql(p, mode) => {
                 let effective_db = mysql_table_metadata_catalog(database, schema);

--- a/crates/dbx-core/tests/live_doris.rs
+++ b/crates/dbx-core/tests/live_doris.rs
@@ -1,0 +1,88 @@
+// Live regression coverage for Issue #6590: Doris query-result column comments
+// are lost when the metadata lookup targets the tab/execution database instead
+// of the database explicitly qualified in the SQL (`db.table` puts the database
+// in the `schema` parameter for MySQL-family dialects).
+//
+// Run with:
+//   DBX_TEST_DORIS_HOST=127.0.0.1 DBX_TEST_DORIS_PORT=9030 DBX_TEST_DORIS_USER=root \
+//   DBX_TEST_DORIS_PASSWORD= cargo test -p dbx-core --test live_doris -- --ignored
+use std::time::Duration;
+
+use dbx_core::connection::{connect_bare_metadata_pool, AppState};
+use dbx_core::models::connection::{ConnectionConfig, DatabaseType};
+use dbx_core::schema::get_columns_core;
+use dbx_core::storage::Storage;
+use mysql_async::prelude::Queryable;
+
+fn live_doris_config(id: &str) -> ConnectionConfig {
+    let host = std::env::var("DBX_TEST_DORIS_HOST").expect("DBX_TEST_DORIS_HOST");
+    let port = std::env::var("DBX_TEST_DORIS_PORT").ok().and_then(|value| value.parse::<u16>().ok()).unwrap_or(9030);
+    let username = std::env::var("DBX_TEST_DORIS_USER").expect("DBX_TEST_DORIS_USER");
+    let password = std::env::var("DBX_TEST_DORIS_PASSWORD").unwrap_or_default();
+
+    serde_json::from_value(serde_json::json!({
+        "id": id,
+        "name": id,
+        "db_type": DatabaseType::Doris,
+        "host": host,
+        "port": port,
+        "username": username,
+        "password": password,
+        "database": null,
+        "connect_timeout_secs": 10,
+        "query_timeout_secs": 30,
+        "idle_timeout_secs": 60,
+        "keepalive_interval_secs": 0
+    }))
+    .expect("live Doris config should deserialize")
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_TEST_DORIS_HOST/DBX_TEST_DORIS_PORT/DBX_TEST_DORIS_USER pointing at a writable Apache Doris 2.1.8 cluster"]
+async fn doris_qualified_table_metadata_resolves_schema_database_with_comments() {
+    let config = live_doris_config("doris-6590-live");
+    let db_path = std::env::temp_dir().join(format!("dbx-doris-6590-{}.db", uuid::Uuid::new_v4().simple()));
+    let storage = Storage::open(&db_path).await.expect("open temp storage");
+    let state = AppState::new(storage);
+    state.configs.write().await.insert(config.id.clone(), config.clone());
+
+    // Setup: a table with two commented columns and one uncommented column.
+    let pool = connect_bare_metadata_pool(&config, &config.host, config.port, Duration::from_secs(10), 3)
+        .await
+        .expect("connect bare Doris metadata pool");
+    let mut conn = pool.get_conn().await.expect("get Doris connection");
+    Queryable::query_drop(&mut conn, "CREATE DATABASE IF NOT EXISTS dbx6590_test")
+        .await
+        .expect("create Doris test database");
+    Queryable::query_drop(
+        &mut conn,
+        "CREATE TABLE IF NOT EXISTS dbx6590_test.dbx_comment_test (\
+             id BIGINT COMMENT '主键ID', \
+             user_name VARCHAR(64) COMMENT '用户名称', \
+             created_at DATETIME COMMENT '创建时间', \
+             extra_field INT \
+         ) DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 3 \
+         PROPERTIES ('replication_num' = '1')",
+    )
+    .await
+    .expect("create Doris test table");
+    drop(conn);
+
+    // The frontend sends the query-tab/execution database in `database` (empty
+    // when the connection has no default database) and the database qualified
+    // in the SQL in `schema`. The column lookup must resolve the effective
+    // database from `schema` for MySQL-family dialects.
+    let columns = get_columns_core(&state, "doris-6590-live", "", "dbx6590_test", "dbx_comment_test")
+        .await
+        .expect("qualified `db.table` metadata must resolve even with an empty execution database");
+    assert_eq!(columns.len(), 4);
+    assert_eq!(columns[0].name, "id");
+    assert_eq!(columns[0].comment.as_deref(), Some("主键ID"));
+    assert_eq!(columns[1].name, "user_name");
+    assert_eq!(columns[1].comment.as_deref(), Some("用户名称"));
+    assert_eq!(columns[2].name, "created_at");
+    assert_eq!(columns[2].comment.as_deref(), Some("创建时间"));
+    // Uncommented columns stay None — the grid must not render a placeholder.
+    assert_eq!(columns[3].name, "extra_field");
+    assert_eq!(columns[3].comment, None);
+}


### PR DESCRIPTION
## Problem

Apache Doris 2.1.8 query results showed column **types** but not column **comments** in the grid header, while an equivalent MySQL query already displayed comments. Issue #6590.

## Root Cause

Every metadata path returned the comments correctly — the loss happened in the **routing layer** of `get_columns_core_for_session_inner` (`crates/dbx-core/src/schema.rs`).

A MySQL-family `db.table` reference puts the database in the **`schema`** parameter. The plain MySQL branch resolves the effective database with `mysql_table_metadata_catalog(database, schema)` (**schema first**), but the Doris/StarRocks show-metadata branch (`uses_show_metadata`) used only `mysql_show_metadata_database_for_config(..., database)` (**database only, schema ignored**).

So for a connection/tab without a default database executing `SELECT * FROM dbx6590_test.dbx_comment_test`, the frontend sent `getColumns(conn, database="", schema="dbx6590_test", table)`, and Doris called `mysql::get_columns(p, "", table)`:

- `information_schema.COLUMNS` with `TABLE_SCHEMA = ''` → 0 rows
- fallback `SHOW FULL COLUMNS FROM \`\`.\`tbl\`` → `ERROR 1046 (3D000): No database selected`

The metadata load failed → `tableMeta` = undefined → the header had nothing to render. The same divergence explains why MySQL worked: it already preferred `schema`.

Verified against a live Doris 2.1.8 cluster — both `SHOW FULL COLUMNS` and `information_schema.COLUMNS` carry the comments; the sole defect was the database-target resolution in the show-metadata branch.

## Fix

Align the Doris/StarRocks (`uses_show_metadata`) column branch with the plain MySQL branch:

```rust
// before
let metadata_database = mysql_show_metadata_database_for_config(db_config.as_ref(), database);
db::mysql::get_columns(p, metadata_database, table)...
// after
let effective_db = mysql_table_metadata_catalog(database, schema);
db::mysql::get_columns(p, effective_db, table)...
```

This is a one-line routing fix at the correct layer (`get_columns_core`), **not** a DataGrid special case. It also fixes the case where the SQL qualifies a database different from the tab/execution database (same root cause, #3939 experience). No frontend or UI change.

## Regression Safety

- **MySQL** behavior unchanged — the plain MySQL branch already used `mysql_table_metadata_catalog`; this only makes the Doris/StarRocks branch consistent with it.
- **No-comment fields** stay `None` → header keeps "name + type" with no placeholder.
- **Primary-key / editability** untouched — `get_columns` still reads `information_schema.COLUMNS` first (`COLUMN_KEY`), identical to before.
- **Doris `list_indexes`** already used `mysql_table_metadata_catalog`; this fixes the one inconsistent path.
- Not expanded to external catalogs (separate 3-part-name path), JOIN/UNION (handled by #6358), or object-browser overhaul.

## Tests

```text
cargo test -p dbx-core --no-default-features --lib 'schema::tests::doris_show_metadata_resolves_effective_database_like_plain_mysql'  → ok (new unit test)
cargo test -p dbx-core --no-default-features --test live_doris -- --ignored (→ real Doris 2.1.8)  → ok (new live test)
cargo test -p dbx-core --no-default-features --lib  → 4773 passed (7 pre-existing environmental failures, verified on baseline)
cargo fmt --all -- --check  → clean
pnpm exec vitest run apps/desktop/src/stores/__tests__  → 55 files / 523 passed
pnpm exec vitest run <queryStore comment specs + DataGridColumnComments>  → 81 passed
pnpm typecheck  → clean
```

## Live Validation

Real **Apache Doris 2.1.8** (docker fe-2.1.8 + be-2.1.8) + self-built **DBX Desktop** UI:

- Connection with **no default database**, `SELECT * FROM dbx6590_test.dbx_comment_test`
- `tableMeta.columns` comments populated: `id→主键ID`, `user_name→用户名称`, `created_at→创建时间`, `extra_field→(none)`
- Rendered DataGrid header DOM shows the comments (identical to MySQL):
  - `id` → `bigint(20)` → **主键ID**
  - `user_name` → `varchar(64)` → **用户名称**
  - `created_at` → `datetime` → **创建时间**
  - `extra_field` → `int(11)` → (no comment, no placeholder)

## Issue

Fixes #6590
