### PR TITLE
fix(connection): 修复 Windows 全局超时帮助图标不显示

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -8154,14 +8154,9 @@ function openExternalUrl(url: string) {
                       <input id="connect-timeout-global" v-model="form.connect_timeout_inherit" type="radio" name="connect-timeout-scope" :value="true" class="h-3.5 w-3.5 shrink-0 accent-primary" />
                       <div class="flex min-w-0 flex-1 items-center gap-1">
                         <label for="connect-timeout-global" class="min-w-0 cursor-pointer truncate text-xs" :title="t('connection.useGlobalQueryTimeout')">{{ t("connection.useGlobalQueryTimeout") }}</label>
-                        <Tooltip>
-                          <TooltipTrigger as-child>
-                            <CircleHelp class="h-3.5 w-3.5 shrink-0 cursor-help text-muted-foreground hover:text-foreground" />
-                          </TooltipTrigger>
-                          <TooltipContent side="top" align="center" class="max-w-[280px] text-xs leading-relaxed">
-                            {{ t("connection.globalConnectTimeoutHint") }}
-                          </TooltipContent>
-                        </Tooltip>
+                        <HelpTooltip :label="t('connection.globalConnectTimeoutHint')" content-class="max-w-[280px]">
+                          {{ t("connection.globalConnectTimeoutHint") }}
+                        </HelpTooltip>
                       </div>
                       <Input
                         v-model.number="editGlobalConnectTimeoutSecs"
@@ -8204,14 +8199,9 @@ function openExternalUrl(url: string) {
                       <input id="query-timeout-global" v-model="form.query_timeout_inherit" type="radio" name="query-timeout-scope" :value="true" class="h-3.5 w-3.5 shrink-0 accent-primary" />
                       <div class="flex min-w-0 flex-1 items-center gap-1">
                         <label for="query-timeout-global" class="min-w-0 cursor-pointer truncate text-xs" :title="t('connection.useGlobalQueryTimeout')">{{ t("connection.useGlobalQueryTimeout") }}</label>
-                        <Tooltip>
-                          <TooltipTrigger as-child>
-                            <CircleHelp class="h-3.5 w-3.5 shrink-0 cursor-help text-muted-foreground hover:text-foreground" />
-                          </TooltipTrigger>
-                          <TooltipContent side="top" align="center" class="max-w-[280px] text-xs leading-relaxed">
-                            {{ t("connection.globalQueryTimeoutHint") }}
-                          </TooltipContent>
-                        </Tooltip>
+                        <HelpTooltip :label="t('connection.globalQueryTimeoutHint')" content-class="max-w-[280px]">
+                          {{ t("connection.globalQueryTimeoutHint") }}
+                        </HelpTooltip>
                       </div>
                       <Input v-model.number="editGlobalQueryTimeoutSecs" type="number" min="0" :max="MAX_QUERY_TIMEOUT_SECS" step="1" class="col-span-2 h-7 w-full shrink-0 sm:col-span-1 sm:w-20" :disabled="form.query_timeout_inherit !== true" @input="clampQueryTimeoutInput($event, 'global')" />
                     </div>

--- a/apps/desktop/src/lib/__tests__/connection/connectionDialogTimeouts.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionDialogTimeouts.spec.ts
@@ -25,8 +25,13 @@ describe("ConnectionDialog timeout controls", () => {
     expect(dialogSource).not.toContain("Number(config.connect_timeout_secs)");
   });
 
-  it("shows range help beside both global timeout labels", () => {
-    expect(dialogSource).toContain('t("connection.globalConnectTimeoutHint")');
-    expect(dialogSource).toContain('t("connection.globalQueryTimeoutHint")');
+  it("uses button-backed help tooltips beside both global timeout labels", () => {
+    const connectGlobalControl = dialogSource.slice(dialogSource.indexOf('id="connect-timeout-global"'), dialogSource.indexOf('id="connect-timeout-connection"'));
+    const queryGlobalControl = dialogSource.slice(dialogSource.indexOf('id="query-timeout-global"'), dialogSource.indexOf('id="query-timeout-connection"'));
+
+    expect(connectGlobalControl).toContain(`<HelpTooltip :label="t('connection.globalConnectTimeoutHint')"`);
+    expect(queryGlobalControl).toContain(`<HelpTooltip :label="t('connection.globalQueryTimeoutHint')"`);
+    expect(connectGlobalControl).not.toContain("<TooltipTrigger");
+    expect(queryGlobalControl).not.toContain("<TooltipTrigger");
   });
 });


### PR DESCRIPTION
## 变更说明

修复 Windows 用户在「编辑连接 > 高级」中看不到连接超时和查询超时“全局”帮助图标的问题。

- 将直接以 SVG 作为 Reka Tooltip 触发节点的两处实现替换为现有 `HelpTooltip`。
- 使用真实按钮承载问号图标，避免旧版 Windows WebView2 对 SVG 交互触发节点的兼容问题。
- 保持原有位置、文案、超时逻辑和输入框行为不变。
- 增加回归断言，确保两个全局超时帮助入口继续使用按钮式提示组件。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已完成 Chromium 页面验证

Chromium 中已确认两个问号均渲染为可访问的按钮，提示文案正常弹出；macOS 页面也已人工确认。Windows WebView2 实机效果待反馈用户安装构建后确认。

## 验证

- [ ] `make check` 通过（改动范围较小，执行下列聚焦检查）
- [ ] `make cargo-check-fast` 通过（未修改 Rust）
- [x] `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/connectionDialogTimeouts.spec.ts`
- [x] `pnpm typecheck`
- [x] 目标文件 `oxlint`
- [x] 目标文件 `oxfmt --check`
- [x] `git diff --check`

## 关联 Issue

无。