### PR TITLE
feat(editor): show toolbar connection picker as a group tree

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionTreeSelect.vue
+++ b/apps/desktop/src/components/connection/ConnectionTreeSelect.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import type { HTMLAttributes } from "vue";
+import { Check, ChevronDown, ChevronRight, Folder, Search } from "@lucide/vue";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
+import { buildConnectionPickerRows, connectionPickerSelectableRows } from "@/lib/connection/connectionPickerTree";
+import { connectionIconType } from "@/lib/connection/connectionPresentation";
+import { cn } from "@/lib/common/utils";
+import type { ConnectionConfig, SidebarLayout } from "@/types/database";
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string;
+    connections: ConnectionConfig[];
+    layout: SidebarLayout;
+    placeholder: string;
+    searchPlaceholder: string;
+    emptyText: string;
+    disabled?: boolean;
+    triggerClass?: HTMLAttributes["class"];
+    triggerIconClass?: HTMLAttributes["class"];
+    listClass?: HTMLAttributes["class"];
+  }>(),
+  {
+    disabled: false,
+    triggerIconClass: "size-4 text-muted-foreground",
+  },
+);
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+  "update:open": [value: boolean];
+}>();
+
+defineSlots<{
+  "trigger-label"?(props: { value: string; label: string }): any;
+}>();
+
+const open = ref(false);
+const searchText = ref("");
+const searchInput = ref<InstanceType<typeof Input>>();
+const listContainer = ref<HTMLDivElement>();
+const collapsedGroupIds = ref<Set<string>>(new Set());
+const highlightIndex = ref(-1);
+
+const connectionById = computed(() => new Map(props.connections.map((connection) => [connection.id, connection])));
+
+const selectedLabel = computed(() => {
+  if (!props.modelValue) return props.placeholder;
+  return connectionById.value.get(props.modelValue)?.name || props.modelValue;
+});
+
+const rows = computed(() => buildConnectionPickerRows(props.layout, props.connections, collapsedGroupIds.value, searchText.value));
+const selectableRows = computed(() => connectionPickerSelectableRows(rows.value));
+
+function toggleGroup(groupId: string) {
+  const next = new Set(collapsedGroupIds.value);
+  if (next.has(groupId)) next.delete(groupId);
+  else next.add(groupId);
+  collapsedGroupIds.value = next;
+}
+
+function selectConnection(connectionId: string) {
+  emit("update:modelValue", connectionId);
+  open.value = false;
+}
+
+function highlightSelectedConnection() {
+  const selectedIndex = selectableRows.value.findIndex((row) => row.id === props.modelValue);
+  highlightIndex.value = selectedIndex >= 0 ? selectedIndex : 0;
+}
+
+async function scrollHighlightedRowIntoView() {
+  await nextTick();
+  const container = listContainer.value;
+  if (!container || highlightIndex.value < 0) return;
+  const target = container.querySelectorAll("[data-picker-connection]")[highlightIndex.value];
+  target?.scrollIntoView({ block: "nearest" });
+}
+
+watch(open, async (value) => {
+  emit("update:open", value);
+  if (!value) {
+    searchText.value = "";
+    highlightIndex.value = -1;
+    return;
+  }
+  await nextTick();
+  const input = searchInput.value?.$el as HTMLInputElement | undefined;
+  input?.focus();
+  highlightSelectedConnection();
+  void scrollHighlightedRowIntoView();
+});
+
+watch(searchText, () => {
+  highlightIndex.value = selectableRows.value.length ? 0 : -1;
+  void scrollHighlightedRowIntoView();
+});
+
+watch(selectableRows, () => {
+  if (!open.value || searchText.value) return;
+  highlightSelectedConnection();
+});
+
+function rowIndent(depth: number) {
+  return { paddingLeft: `${8 + depth * 14}px` };
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  const total = selectableRows.value.length;
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    if (!total) return;
+    highlightIndex.value = highlightIndex.value < total - 1 ? highlightIndex.value + 1 : 0;
+    void scrollHighlightedRowIntoView();
+  } else if (event.key === "ArrowUp") {
+    event.preventDefault();
+    if (!total) return;
+    highlightIndex.value = highlightIndex.value > 0 ? highlightIndex.value - 1 : total - 1;
+    void scrollHighlightedRowIntoView();
+  } else if (event.key === "Enter") {
+    if (highlightIndex.value < 0 || highlightIndex.value >= total) return;
+    event.preventDefault();
+    selectConnection(selectableRows.value[highlightIndex.value]!.id);
+  } else if (event.key === "Escape") {
+    open.value = false;
+  }
+}
+</script>
+
+<template>
+  <Popover v-model:open="open">
+    <PopoverTrigger as-child>
+      <Button type="button" variant="ghost" :disabled="disabled" :title="selectedLabel" :class="cn('h-6 w-auto max-w-56 min-w-0 justify-between gap-1 border-0 bg-transparent px-1 text-xs font-normal shadow-none hover:bg-muted/50 focus-visible:ring-0', triggerClass)">
+        <slot name="trigger-label" :value="modelValue" :label="selectedLabel">
+          <span class="truncate">{{ selectedLabel }}</span>
+        </slot>
+        <ChevronDown :class="cn('shrink-0 opacity-60', triggerIconClass)" />
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent align="start" :class="cn('w-auto max-w-[calc(100vw-1rem)] border-0 bg-transparent p-0 shadow-none ring-0')">
+      <div :class="cn('shrink-0 rounded-md border bg-popover p-1.5 shadow-md', listClass)">
+        <div class="relative rounded-md border bg-background">
+          <Search class="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+          <span v-if="!searchText" class="pointer-events-none absolute left-[25px] top-1/2 -translate-y-1/2 text-sm text-muted-foreground">{{ searchPlaceholder }}</span>
+          <Input ref="searchInput" :model-value="searchText" class="h-6 border-0 pl-6 pr-2 text-sm caret-foreground shadow-none focus-visible:ring-0" @update:model-value="(value) => (searchText = String(value))" @keydown="handleKeydown" />
+        </div>
+        <div ref="listContainer" class="dbx-connection-tree-select-list max-h-64 overflow-y-auto py-1">
+          <template v-if="rows.length">
+            <template v-for="row in rows" :key="row.key">
+              <button
+                v-if="row.kind === 'group'"
+                type="button"
+                :title="row.label"
+                :style="rowIndent(row.depth)"
+                class="flex h-7 w-full min-w-0 items-center gap-1.5 rounded-md pr-2 text-left text-xs font-medium text-muted-foreground hover:bg-accent/60 hover:text-accent-foreground focus-visible:outline-none"
+                @click="toggleGroup(row.id)"
+              >
+                <ChevronDown v-if="!row.collapsed" class="h-3 w-3 shrink-0" />
+                <ChevronRight v-else class="h-3 w-3 shrink-0" />
+                <Folder class="h-3.5 w-3.5 shrink-0" />
+                <span class="truncate">{{ row.label }}</span>
+              </button>
+              <button
+                v-else
+                type="button"
+                :title="row.label"
+                :style="rowIndent(row.depth)"
+                :data-picker-connection="row.id"
+                :class="
+                  cn(
+                    'flex h-8 w-full min-w-0 items-center gap-2 rounded-md pr-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none',
+                    selectableRows[highlightIndex]?.id === row.id && 'bg-accent text-accent-foreground',
+                  )
+                "
+                @click="selectConnection(row.id)"
+              >
+                <Check :class="cn('h-3.5 w-3.5 shrink-0', row.id === modelValue ? 'opacity-100' : 'opacity-0')" />
+                <DatabaseIcon :db-type="connectionIconType(connectionById.get(row.id))" class="h-3.5 w-3.5 shrink-0" />
+                <span class="min-w-0 flex-1 truncate">{{ row.label }}</span>
+              </button>
+            </template>
+          </template>
+          <div v-else class="px-2 py-2 text-sm text-muted-foreground">
+            {{ emptyText }}
+          </div>
+        </div>
+      </div>
+    </PopoverContent>
+  </Popover>
+</template>
+
+<style>
+.dbx-connection-tree-select-list {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--foreground) 30%, transparent) transparent;
+}
+
+.dbx-connection-tree-select-list::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.dbx-connection-tree-select-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dbx-connection-tree-select-list::-webkit-scrollbar-thumb {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--foreground) 30%, transparent);
+  background-clip: padding-box;
+}
+
+.dbx-connection-tree-select-list:hover::-webkit-scrollbar-thumb {
+  border: 0;
+  background: color-mix(in oklch, var(--foreground) 48%, transparent);
+}
+
+.dark .dbx-connection-tree-select-list {
+  scrollbar-color: rgb(82, 82, 91) transparent;
+}
+
+.dark .dbx-connection-tree-select-list::-webkit-scrollbar-thumb {
+  background: rgb(82, 82, 91);
+}
+
+.dark .dbx-connection-tree-select-list:hover::-webkit-scrollbar-thumb {
+  background: rgb(113, 113, 122);
+}
+</style>

--- a/apps/desktop/src/components/connection/ConnectionTreeSelect.vue
+++ b/apps/desktop/src/components/connection/ConnectionTreeSelect.vue
@@ -55,8 +55,10 @@ const selectedLabel = computed(() => {
 
 const rows = computed(() => buildConnectionPickerRows(props.layout, props.connections, collapsedGroupIds.value, searchText.value));
 const selectableRows = computed(() => connectionPickerSelectableRows(rows.value));
+const isSearchActive = computed(() => Boolean(searchText.value.trim()));
 
 function toggleGroup(groupId: string) {
+  if (isSearchActive.value) return;
   const next = new Set(collapsedGroupIds.value);
   if (next.has(groupId)) next.delete(groupId);
   else next.add(groupId);
@@ -156,7 +158,10 @@ function handleKeydown(event: KeyboardEvent) {
                 type="button"
                 :title="row.label"
                 :style="rowIndent(row.depth)"
-                class="flex h-7 w-full min-w-0 items-center gap-1.5 rounded-md pr-2 text-left text-xs font-medium text-muted-foreground hover:bg-accent/60 hover:text-accent-foreground focus-visible:outline-none"
+                :data-picker-group="row.id"
+                :aria-expanded="!row.collapsed"
+                :disabled="isSearchActive"
+                class="flex h-7 w-full min-w-0 items-center gap-1.5 rounded-md pr-2 text-left text-xs font-medium text-muted-foreground hover:bg-accent/60 hover:text-accent-foreground focus-visible:outline-none disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
                 @click="toggleGroup(row.id)"
               >
                 <ChevronDown v-if="!row.collapsed" class="h-3 w-3 shrink-0" />

--- a/apps/desktop/src/components/connection/__tests__/ConnectionTreeSelect.searchCollapse.spec.ts
+++ b/apps/desktop/src/components/connection/__tests__/ConnectionTreeSelect.searchCollapse.spec.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ConnectionTreeSelect from "@/components/connection/ConnectionTreeSelect.vue";
+import type { ConnectionConfig, SidebarLayout } from "@/types/database";
+
+vi.mock("@/components/ui/button", async () => {
+  const { createPassthroughStub } = await import("@/components/grid/__tests__/vueHostHarness");
+  return { Button: createPassthroughStub("Button", "button") };
+});
+
+vi.mock("@/components/ui/popover", async () => {
+  const { createPassthroughStub } = await import("@/components/grid/__tests__/vueHostHarness");
+  return {
+    Popover: createPassthroughStub("Popover"),
+    PopoverContent: createPassthroughStub("PopoverContent"),
+    PopoverTrigger: createPassthroughStub("PopoverTrigger"),
+  };
+});
+
+vi.mock("@/components/icons/DatabaseIcon.vue", () => ({
+  default: defineComponent({
+    name: "DatabaseIconStub",
+    setup: () => () => h("span"),
+  }),
+}));
+
+const mountedApps: App[] = [];
+
+const connections: ConnectionConfig[] = [
+  {
+    id: "c1",
+    name: "Primary",
+    db_type: "mysql",
+    host: "localhost",
+    port: 3306,
+    username: "root",
+    password: "",
+  },
+];
+
+const layout: SidebarLayout = {
+  groups: [{ id: "g1", name: "Production", collapsed: false }],
+  order: [{ type: "group", id: "g1", children: [{ type: "connection", id: "c1" }] }],
+};
+
+async function mountPicker() {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const app = createApp(ConnectionTreeSelect, {
+    modelValue: "",
+    connections,
+    layout,
+    placeholder: "Select connection",
+    searchPlaceholder: "Search connections",
+    emptyText: "No connections",
+  });
+  mountedApps.push(app);
+  app.mount(container);
+  await nextTick();
+}
+
+async function setSearchText(value: string) {
+  const input = document.body.querySelector("input");
+  if (!(input instanceof HTMLInputElement)) throw new Error("Search input was not rendered");
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+  await nextTick();
+}
+
+function groupButton() {
+  const button = document.body.querySelector('[data-picker-group="g1"]');
+  if (!(button instanceof HTMLButtonElement)) throw new Error("Group button was not rendered");
+  return button;
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.innerHTML = "";
+});
+
+describe("ConnectionTreeSelect search collapse behavior", () => {
+  it("ignores group clicks during search without changing the post-search state", async () => {
+    await mountPicker();
+    await setSearchText("Primary");
+
+    expect(groupButton().disabled).toBe(true);
+    expect(groupButton().getAttribute("aria-expanded")).toBe("true");
+
+    groupButton().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    await setSearchText("");
+
+    expect(groupButton().disabled).toBe(false);
+    expect(groupButton().getAttribute("aria-expanded")).toBe("true");
+    expect(document.body.querySelector('[data-picker-connection="c1"]')).not.toBeNull();
+  });
+
+  it("preserves group collapsing when search is inactive", async () => {
+    await mountPicker();
+
+    groupButton().click();
+    await nextTick();
+    expect(groupButton().getAttribute("aria-expanded")).toBe("false");
+    expect(document.body.querySelector('[data-picker-connection="c1"]')).toBeNull();
+
+    groupButton().click();
+    await nextTick();
+    expect(groupButton().getAttribute("aria-expanded")).toBe("true");
+    expect(document.body.querySelector('[data-picker-connection="c1"]')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -7,6 +7,7 @@ import { SearchableSelect } from "@/components/ui/searchable-select";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import TruncatedTextTooltip from "@/components/ui/TruncatedTextTooltip.vue";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
+import ConnectionTreeSelect from "@/components/connection/ConnectionTreeSelect.vue";
 import ProductionContextBadge from "@/components/common/ProductionContextBadge.vue";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -14,8 +15,6 @@ import { catalogDatabaseOptionsKey, databaseAfterCatalogChange, normalizedQueryT
 import { useSchemaOptions } from "@/composables/useSchemaOptions";
 import { connectionIconType } from "@/lib/connection/connectionPresentation";
 import { formatDatabaseLabel, isDefaultDatabase } from "@/lib/database/defaultDatabase";
-import { connectionDisplayName } from "@/lib/tabs/tabPresentation";
-import { useConnectionGroupLabel } from "@/composables/useConnectionGroupLabel";
 import { isSingleDatabase, supportsClearableQuerySchema, supportsSqlInListPaste, supportsTransaction as supportsTransactionFeature } from "@/lib/database/databaseCapabilities";
 import { supportsQueryExecution } from "@/lib/database/databaseFeatureSupport";
 import { connectionIsDorisFamilyCatalogCapable } from "@/lib/database/databaseFeatureSupport";
@@ -91,8 +90,6 @@ const loadingActiveDatabaseOptions = computed(() => {
 });
 const switchingCatalog = ref(false);
 
-const connectionOptionIds = computed(() => connectionStore.connections.map((connection) => connection.id));
-const { connectionGroupLabel } = useConnectionGroupLabel();
 const activeDatabaseValue = computed(() => props.activeTab.database || "");
 const activeProductionContext = computed(() => productionContextForDatabase(props.activeConnection, props.activeTab.database));
 const showConnectionProductionBadge = computed(() => activeProductionContext.value.reason === "connection");
@@ -223,10 +220,6 @@ function databaseDisplayName(database: string): string {
     defaultDatabase: t("editor.defaultDatabase"),
     noDatabase: t("editor.noDatabase"),
   });
-}
-
-function connectionById(connectionId: string): ConnectionConfig | undefined {
-  return connectionStore.getConfig(connectionId);
 }
 
 function databaseOptionIsProduction(database: string): boolean {
@@ -427,19 +420,16 @@ async function changeCatalog(selectedCatalog: string) {
     <div class="flex items-center gap-2 shrink-0">
       <div class="flex items-center gap-1">
         <span v-if="activeConnection?.color" class="h-4 w-1 rounded-full shrink-0" :style="{ backgroundColor: activeConnection.color }" />
-        <SearchableSelect
+        <ConnectionTreeSelect
           :model-value="activeConnectionValue"
-          :options="connectionOptionIds"
+          :connections="connectionStore.connections"
+          :layout="connectionStore.sidebarLayout"
           :placeholder="t('editor.selectConnection')"
           :search-placeholder="t('editor.searchConnection')"
           :empty-text="t('grid.noSearchResults')"
-          :loading-text="t('common.loading')"
-          trigger-variant="ghost"
           trigger-class="font-medium text-foreground"
           trigger-icon-class="h-3 w-3"
-          :display-name="connectionDisplayName"
           list-class="w-96 max-w-[calc(100vw-2rem)]"
-          item-class="min-h-9 h-auto py-1"
           @update:model-value="(connectionId) => emit('changeConnection', connectionId)"
         >
           <template #trigger-label="{ label }">
@@ -450,18 +440,7 @@ async function changeCatalog(selectedCatalog: string) {
             </div>
             <span v-else class="truncate text-muted-foreground">{{ t("editor.selectConnection") }}</span>
           </template>
-          <template #option-label="{ option, label }">
-            <div class="flex min-w-0 items-center gap-2">
-              <DatabaseIcon :db-type="connectionIconType(connectionById(option))" class="h-3.5 w-3.5 shrink-0" />
-              <div class="flex min-w-0 flex-1 items-center gap-2">
-                <span class="block min-w-0 max-w-48 shrink-0 whitespace-normal break-words rounded-sm bg-muted/70 px-1.5 py-0.5 text-[11px] leading-tight text-muted-foreground">
-                  {{ connectionGroupLabel(option) }}
-                </span>
-                <TruncatedTextTooltip :text="label" class="block min-w-[7rem] flex-1 text-sm font-medium" side="left" :side-offset="8" />
-              </div>
-            </div>
-          </template>
-        </SearchableSelect>
+        </ConnectionTreeSelect>
       </div>
       <div v-if="showCatalogSelector" class="flex items-center gap-1">
         <SearchableSelect

--- a/apps/desktop/src/lib/__tests__/connection/connectionPickerTree.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionPickerTree.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { buildConnectionPickerRows, connectionPickerSelectableRows, type ConnectionPickerRow } from "@/lib/connection/connectionPickerTree";
+import type { SidebarLayout } from "@/types/database";
+
+const connections = [
+  { id: "c1", name: "生产 MySQL" },
+  { id: "c2", name: "测试 MySQL" },
+  { id: "c3", name: "本地 PG" },
+  { id: "c4", name: "孤儿连接" },
+];
+
+function layout(): SidebarLayout {
+  return {
+    groups: [
+      { id: "g1", name: "生产", collapsed: false },
+      { id: "g2", name: "华东", collapsed: false },
+    ],
+    order: [
+      {
+        type: "group",
+        id: "g1",
+        children: [
+          { type: "group", id: "g2", children: [{ type: "connection", id: "c1" }] },
+          { type: "connection", id: "c2" },
+        ],
+      },
+      { type: "connection", id: "c3" },
+    ],
+  };
+}
+
+function kinds(rows: ConnectionPickerRow[]): string[] {
+  return rows.map((row) => `${row.kind}:${row.id}@${row.depth}`);
+}
+
+describe("buildConnectionPickerRows", () => {
+  it("flattens the layout tree with depths in sidebar order", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(), "");
+    expect(kinds(rows)).toEqual(["group:g1@0", "group:g2@1", "connection:c1@2", "connection:c2@1", "connection:c3@0", "connection:c4@0"]);
+  });
+
+  it("appends connections missing from the layout at the top level", () => {
+    const rows = buildConnectionPickerRows({ groups: [], order: [] }, connections, new Set(), "");
+    expect(kinds(rows)).toEqual(["connection:c1@0", "connection:c2@0", "connection:c3@0", "connection:c4@0"]);
+  });
+
+  it("hides children of collapsed groups without dropping them from the fallback", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(["g1"]), "");
+    expect(kinds(rows)).toEqual(["group:g1@0", "connection:c3@0", "connection:c4@0"]);
+    expect(rows[0]?.collapsed).toBe(true);
+  });
+
+  it("keeps deeper groups visible when only a nested group is collapsed", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(["g2"]), "");
+    expect(kinds(rows)).toEqual(["group:g1@0", "group:g2@1", "connection:c2@1", "connection:c3@0", "connection:c4@0"]);
+  });
+
+  it("skips stale layout connection ids that no longer exist", () => {
+    const stale: SidebarLayout = { groups: [], order: [{ type: "connection", id: "gone" }] };
+    const rows = buildConnectionPickerRows(stale, connections, new Set(), "");
+    expect(kinds(rows)).toEqual(["connection:c1@0", "connection:c2@0", "connection:c3@0", "connection:c4@0"]);
+  });
+
+  it("filters connections by name and keeps ancestor groups expanded", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(["g1", "g2"]), "本地");
+    expect(kinds(rows)).toEqual(["connection:c3@0"]);
+  });
+
+  it("matches connections by group path and keeps the hierarchy", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(), "华东");
+    expect(kinds(rows)).toEqual(["group:g1@0", "group:g2@1", "connection:c1@2"]);
+    expect(rows.every((row) => !row.collapsed)).toBe(true);
+  });
+
+  it("matches fallback connections by name during search", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(), "孤儿");
+    expect(kinds(rows)).toEqual(["connection:c4@0"]);
+  });
+
+  it("returns no rows when nothing matches the query", () => {
+    expect(buildConnectionPickerRows(layout(), connections, new Set(), "不存在")).toEqual([]);
+  });
+
+  it("falls back to the connection id when the name is empty", () => {
+    const rows = buildConnectionPickerRows({ groups: [], order: [] }, [{ id: "c9", name: "" }], new Set(), "");
+    expect(rows[0]?.label).toBe("c9");
+  });
+});
+
+describe("connectionPickerSelectableRows", () => {
+  it("keeps only connection rows for keyboard navigation", () => {
+    const rows = buildConnectionPickerRows(layout(), connections, new Set(), "");
+    expect(connectionPickerSelectableRows(rows).map((row) => row.id)).toEqual(["c1", "c2", "c3", "c4"]);
+  });
+});

--- a/apps/desktop/src/lib/common/__tests__/searchableSelectLayout.spec.ts
+++ b/apps/desktop/src/lib/common/__tests__/searchableSelectLayout.spec.ts
@@ -20,10 +20,9 @@ describe("SearchableSelect layout", () => {
     expect(fixedConnectionIcons).toHaveLength(2);
   });
 
-  it("wraps deep connection group paths without hiding connection names", () => {
-    expect(editorToolbarSource).toContain('item-class="min-h-9 h-auto py-1"');
-    expect(editorToolbarSource).toMatch(/<span class="[^"]*max-w-48[^"]*shrink-0[^"]*whitespace-normal[^"]*break-words[^"]*">\s*\{\{ connectionGroupLabel\(option\) \}\}\s*<\/span>/);
-    expect(editorToolbarSource).toContain('<TruncatedTextTooltip :text="label" class="block min-w-[7rem] flex-1 text-sm font-medium"');
-    expect(editorToolbarSource).not.toContain('<TruncatedTextTooltip :text="connectionGroupLabel(option)"');
+  it("renders the toolbar connection picker as a sidebar-like tree", () => {
+    expect(editorToolbarSource).toContain("<ConnectionTreeSelect");
+    expect(editorToolbarSource).toContain(':connections="connectionStore.connections"');
+    expect(editorToolbarSource).toContain(':layout="connectionStore.sidebarLayout"');
   });
 });

--- a/apps/desktop/src/lib/connection/connectionPickerTree.ts
+++ b/apps/desktop/src/lib/connection/connectionPickerTree.ts
@@ -1,0 +1,118 @@
+import type { SidebarLayout, SidebarOrderEntry } from "@/types/database";
+
+export interface ConnectionPickerConnection {
+  id: string;
+  name: string;
+}
+
+export interface ConnectionPickerRow {
+  /** Stable key for list rendering. */
+  key: string;
+  kind: "group" | "connection";
+  id: string;
+  label: string;
+  /** Nesting depth used for indentation; top-level entries are 0. */
+  depth: number;
+  /** Only meaningful for group rows: whether the group is currently collapsed. */
+  collapsed: boolean;
+}
+
+function groupEntryChildren(entry: Extract<SidebarOrderEntry, { type: "group" }>): SidebarOrderEntry[] {
+  return entry.children ?? entry.connectionIds?.map((id) => ({ type: "connection" as const, id })) ?? [];
+}
+
+function collectLayoutConnectionIds(entries: SidebarOrderEntry[], into: Set<string>) {
+  for (const entry of entries) {
+    if (entry.type === "connection") {
+      into.add(entry.id);
+    } else {
+      collectLayoutConnectionIds(groupEntryChildren(entry), into);
+    }
+  }
+}
+
+function connectionMatchesQuery(name: string, groupPath: string[], normalizedQuery: string): boolean {
+  if (name.toLowerCase().includes(normalizedQuery)) return true;
+  return groupPath.join(" / ").toLowerCase().includes(normalizedQuery);
+}
+
+/**
+ * Flattens the sidebar layout into renderable rows for the toolbar connection
+ * picker. Groups are shown as non-selectable rows that mirror the sidebar tree;
+ * connections missing from the layout are appended at the top level so they
+ * stay reachable. With a search query the tree is fully expanded and only
+ * connections matching by name or group path (plus their ancestor groups) are
+ * kept.
+ */
+export function buildConnectionPickerRows(layout: SidebarLayout, connections: readonly ConnectionPickerConnection[], collapsedGroupIds: ReadonlySet<string>, searchQuery: string): ConnectionPickerRow[] {
+  const connectionById = new Map(connections.map((connection) => [connection.id, connection]));
+  const groupById = new Map(layout.groups.map((group) => [group.id, group]));
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+
+  if (normalizedQuery) {
+    const rows: ConnectionPickerRow[] = [];
+    const visitSearch = (entries: SidebarOrderEntry[], depth: number, groupPath: string[]): ConnectionPickerRow[] => {
+      const result: ConnectionPickerRow[] = [];
+      for (const entry of entries) {
+        if (entry.type === "connection") {
+          const connection = connectionById.get(entry.id);
+          if (!connection) continue;
+          const label = connection.name || connection.id;
+          if (connectionMatchesQuery(label, groupPath, normalizedQuery)) {
+            result.push({ key: `connection:${connection.id}`, kind: "connection", id: connection.id, label, depth, collapsed: false });
+          }
+          continue;
+        }
+        const group = groupById.get(entry.id);
+        if (!group) continue;
+        const childRows = visitSearch(groupEntryChildren(entry), depth + 1, [...groupPath, group.name]);
+        if (childRows.length === 0) continue;
+        result.push({ key: `group:${group.id}`, kind: "group", id: group.id, label: group.name, depth, collapsed: false }, ...childRows);
+      }
+      return result;
+    };
+    rows.push(...visitSearch(layout.order, 0, []));
+
+    const layoutConnectionIds = new Set<string>();
+    collectLayoutConnectionIds(layout.order, layoutConnectionIds);
+    for (const connection of connections) {
+      if (layoutConnectionIds.has(connection.id)) continue;
+      const label = connection.name || connection.id;
+      if (connectionMatchesQuery(label, [], normalizedQuery)) {
+        rows.push({ key: `connection:${connection.id}`, kind: "connection", id: connection.id, label, depth: 0, collapsed: false });
+      }
+    }
+    return rows;
+  }
+
+  const rows: ConnectionPickerRow[] = [];
+  const visitTree = (entries: SidebarOrderEntry[], depth: number) => {
+    for (const entry of entries) {
+      if (entry.type === "connection") {
+        const connection = connectionById.get(entry.id);
+        if (!connection) continue;
+        rows.push({ key: `connection:${connection.id}`, kind: "connection", id: connection.id, label: connection.name || connection.id, depth, collapsed: false });
+        continue;
+      }
+      const group = groupById.get(entry.id);
+      if (!group) continue;
+      const collapsed = collapsedGroupIds.has(group.id);
+      rows.push({ key: `group:${group.id}`, kind: "group", id: group.id, label: group.name, depth, collapsed });
+      if (!collapsed) visitTree(groupEntryChildren(entry), depth + 1);
+    }
+  };
+  visitTree(layout.order, 0);
+
+  const layoutConnectionIds = new Set<string>();
+  collectLayoutConnectionIds(layout.order, layoutConnectionIds);
+  for (const connection of connections) {
+    if (layoutConnectionIds.has(connection.id)) continue;
+    rows.push({ key: `connection:${connection.id}`, kind: "connection", id: connection.id, label: connection.name || connection.id, depth: 0, collapsed: false });
+  }
+  return rows;
+}
+
+/** Selectable rows in display order, used for keyboard navigation. */
+export function connectionPickerSelectableRows(rows: readonly ConnectionPickerRow[]): ConnectionPickerRow[] {
+  return rows.filter((row) => row.kind === "connection");
+}


### PR DESCRIPTION
The SQL editor toolbar connection selector rendered the group path and connection name side by side in a flat list, making connections hard to distinguish. Render it as a collapsible group tree mirroring the sidebar layout instead, with search filtering by connection name or group path.

Fixes #6635

## 变更说明

 - SQL 编辑器工具栏的连接选择器原来是扁平列表,分组信息和连接名挤在一起。
 - 现在改为与右侧边栏一致的树形结构:分组可折叠/展开,连接按层级缩进展示。
 - 新增 `connectionPickerTree.ts`:将 sidebarLayout 扁平化为分组/连接行,支持折叠与搜索过滤
 - 新增 `ConnectionTreeSelect.vue` 组件,替换 EditorToolbar 中的 SearchableSelect(不影响其他选择器)
 - 保留搜索(按连接名/分组路径过滤)和键盘导航(↑/↓/Enter/Esc)

## 变更类型

- [ x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="3466" height="2146" alt="image" src="https://github.com/user-attachments/assets/24f4d64f-75eb-49b3-88e2-7b570c7ae1cd" />



## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ x] `make check` 通过
- [x ] `make cargo-check-fast` 通过
- [ x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #6635 