### PR TITLE
feat(connection): 顶部 URL 根据配置自动填充

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -33,7 +33,7 @@ import { useToast } from "@/composables/useToast";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
 import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
-import { applyMeilisearchBasePathToExternalConfig, applyParsedConnectionUrl, normalizeMongoConnectionString, parseConnectionUrl } from "@/lib/connection/connectionUrl";
+import { applyMeilisearchBasePathToExternalConfig, applyParsedConnectionUrl, buildConnectionUrlFromConfig, normalizeMongoConnectionString, parseConnectionUrl } from "@/lib/connection/connectionUrl";
 import { MAX_CONNECT_TIMEOUT_SECS, MAX_QUERY_TIMEOUT_SECS } from "@/lib/connection/timeoutLimits";
 import { buildOracleTnsConnectionString, normalizeOracleTnsAdminPath, parseOracleTnsConnectionString } from "@/lib/connection/oracleTnsConnection";
 import { connectionDeepLinkServiceHydrationValue, parseConnectionDeepLink, parseServiceConnectionUrl, type ConnectionDeepLinkDraft } from "@/lib/connection/connectionDeepLink";
@@ -5112,6 +5112,28 @@ watch(
 watch([() => form.value.db_type, () => form.value.username], () => {
   if (isOracleSysUser(form.value)) form.value.sysdba = true;
 });
+
+/**
+ * Keep the "top URL" input in sync with the edited connection fields. As the
+ * user fills in host / port / username / password / database (or Oracle service
+ * name / SID), the generated URL becomes directly copyable. It is marked as
+ * already-applied so it is purely informational and never re-parsed on save.
+ */
+function syncConnectionUrlFromForm(): void {
+  const url = buildConnectionUrlFromConfig(form.value);
+  if (url === undefined) return;
+  if (url === connectionUrlInput.value) return;
+  connectionUrlInput.value = url;
+  appliedConnectionUrlInput.value = url;
+}
+
+watch(
+  () => [form.value.db_type, form.value.host, form.value.port, form.value.username, form.value.password, form.value.database, form.value.url_params, form.value.ssl, form.value.oracle_connection_type, form.value.external_config],
+  () => {
+    if (open.value) syncConnectionUrlFromForm();
+  },
+  { deep: true },
+);
 
 watch(
   () => connectionConfigSnapshotForVisibleDatabases(),

--- a/apps/desktop/src/lib/__tests__/connection/connectionUrl.build.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionUrl.build.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { buildConnectionUrlFromConfig } from "@/lib/connection/connectionUrl";
+
+describe("buildConnectionUrlFromConfig", () => {
+  it("builds a MySQL URL including default port and credentials", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "mysql",
+      host: "db.example.com",
+      port: 3306,
+      username: "root",
+      password: "secret",
+      database: "app",
+      url_params: "",
+      ssl: false,
+    });
+    expect(url).toBe("mysql://root:secret@db.example.com/app");
+  });
+
+  it("omits a redundant default port", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "postgres",
+      host: "pg.example.com",
+      port: 0,
+      username: "",
+      password: "",
+      database: undefined,
+      url_params: "",
+      ssl: false,
+    });
+    expect(url).toBe("postgresql://pg.example.com");
+  });
+
+  it("keeps raw characters (e.g. @) in the userinfo instead of percent-encoding", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "postgres",
+      host: "192.168.10.72",
+      port: 5432,
+      username: "postgres",
+      password: "@Medic0m",
+      database: "MedicomPIP2DB",
+      url_params: "sslmode=disable",
+      ssl: false,
+    });
+    expect(url).toBe("postgresql://postgres:@Medic0m@192.168.10.72/MedicomPIP2DB?sslmode=disable");
+  });
+
+  it("appends a query parameter when ssl-mode is required for MySQL", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "mysql",
+      host: "db.example.com",
+      port: 3306,
+      username: "root",
+      password: "",
+      database: "app",
+      url_params: "charset=utf8mb4",
+      ssl: true,
+    });
+    expect(url).toBe("mysql://root@db.example.com/app?charset=utf8mb4&ssl-mode=required");
+  });
+
+  it("switches to rediss when Redis SSL is enabled", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "redis",
+      host: "cache.example.com",
+      port: 6379,
+      username: "",
+      password: "p@ss",
+      database: undefined,
+      url_params: "",
+      ssl: true,
+    });
+    expect(url).toBe("rediss://:p@ss@cache.example.com");
+  });
+
+  it("builds a MongoDB URL with a database path", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "mongodb",
+      host: "mongo.example.com",
+      port: 27017,
+      username: "admin",
+      password: "",
+      database: "shop",
+      url_params: "",
+      ssl: false,
+    });
+    expect(url).toBe("mongodb://admin@mongo.example.com/shop");
+  });
+
+  it("uses the https scheme for HTTP datastores when TLS is on", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "elasticsearch",
+      host: "es.example.com",
+      port: 443,
+      username: "",
+      password: "",
+      database: undefined,
+      url_params: "",
+      ssl: true,
+    });
+    expect(url).toBe("https://es.example.com");
+  });
+
+  it("builds an Oracle JDBC thin URL for a service name", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "oracle",
+      host: "ora.example.com",
+      port: 1521,
+      username: "sys",
+      password: "secret",
+      database: "ORCLPDB",
+      url_params: "",
+      ssl: false,
+      oracle_connection_type: "service_name",
+    });
+    expect(url).toBe("jdbc:oracle:thin:@//ora.example.com/ORCLPDB");
+  });
+
+  it("builds an Oracle JDBC thin URL preserving the SID", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "oracle",
+      host: "ora.example.com",
+      port: 1521,
+      username: "sys",
+      password: "secret",
+      database: "ORCL",
+      url_params: "",
+      ssl: false,
+      oracle_connection_type: "sid",
+    });
+    expect(url).toBe("jdbc:oracle:thin:@ora.example.com:ORCL");
+  });
+
+  it("builds a SQL Server URL including the database path", () => {
+    const url = buildConnectionUrlFromConfig({
+      db_type: "sqlserver",
+      host: "sql.example.com",
+      port: 1433,
+      username: "sa",
+      password: "secret",
+      database: "master",
+      url_params: "",
+      ssl: false,
+    });
+    expect(url).toBe("mssql://sa:secret@sql.example.com/master");
+  });
+
+  it("returns undefined when URL cannot be derived (local file / cloud)", () => {
+    for (const db_type of ["sqlite", "duckdb", "access", "dynamodb", "turso", "cloudflare-d1", "bigquery", "jdbc", "nacos", "consul"] as const) {
+      expect(buildConnectionUrlFromConfig({ db_type, host: "x", port: 1, username: "", password: "", database: undefined, url_params: "", ssl: false })).toBeUndefined();
+    }
+  });
+
+  it("returns undefined when the host is empty or a multi-host list", () => {
+    expect(buildConnectionUrlFromConfig({ db_type: "mysql", host: "", port: 3306, username: "", password: "", database: undefined, url_params: "", ssl: false })).toBeUndefined();
+    expect(buildConnectionUrlFromConfig({ db_type: "mysql", host: "a:3306,b:3307", port: 0, username: "", password: "", database: undefined, url_params: "", ssl: false })).toBeUndefined();
+  });
+
+  it("round-trips built URLs back into their source fields", () => {
+    const source = { db_type: "mysql" as const, host: "db.example.com", port: 3306, username: "root", password: "secret", database: "app", url_params: "", ssl: false };
+    const url = buildConnectionUrlFromConfig(source)!;
+    expect(url).toContain("db.example.com");
+    expect(url).toContain("root:secret");
+  });
+});

--- a/apps/desktop/src/lib/connection/connectionUrl.ts
+++ b/apps/desktop/src/lib/connection/connectionUrl.ts
@@ -834,3 +834,194 @@ export function applyParsedConnectionUrl(config: Omit<ConnectionConfig, "id">, p
     external_config: parsedExternalConfig(config.external_config, parsed),
   };
 }
+
+/**
+ * Types whose connection never has a host/edit-form URL (maintained separately).
+ * The connection dialog hides the "top URL" field for these, so we never build one.
+ */
+const URL_BUILD_EXCLUDED_TYPES = new Set<DatabaseType>(["jdbc", "nacos", "consul"]);
+
+/** Local/file-backed database types with no network authority to serialize. */
+const URL_BUILD_LOCAL_TYPES = new Set<DatabaseType>(["sqlite", "duckdb", "access"]);
+
+/** Hosted/cloud database types with no host edit field (or file/API based). */
+const URL_BUILD_HOSTED_TYPES = new Set<DatabaseType>(["dynamodb", "cloudflare-d1", "turso", "bigquery"]);
+
+/** Network scheme keyed by database type (used to build a copyable URL). */
+const URL_BUILD_SCHEME: Partial<Record<DatabaseType, string>> = {
+  mysql: "mysql",
+  doris: "mysql",
+  starrocks: "mysql",
+  manticoresearch: "mysql",
+  postgres: "postgresql",
+  gaussdb: "postgresql",
+  kwdb: "postgresql",
+  yashandb: "postgresql",
+  redshift: "postgresql",
+  questdb: "postgresql",
+  opengauss: "postgresql",
+  redis: "redis",
+  etcd: "etcd",
+  zookeeper: "zookeeper",
+  mongodb: "mongodb",
+  clickhouse: "clickhouse",
+  sqlserver: "mssql",
+  oracle: "oracle",
+  elasticsearch: "http",
+  easysearch: "http",
+  meilisearch: "http",
+  qdrant: "http",
+  milvus: "http",
+  weaviate: "http",
+  chromadb: "http",
+  victoriametrics: "http",
+  rqlite: "http",
+  influxdb: "http",
+  dameng: "dm",
+  kingbase: "kingbase8",
+  tdengine: "tdengine",
+  oscar: "oscar",
+  xugu: "xugu",
+  iotdb: "iotdb",
+  iris: "iris",
+};
+
+/** Databases that take a trailing database/service path in their URL. */
+const URL_BUILD_NAMED_PATH: ReadonlySet<string> = new Set([
+  "mysql",
+  "doris",
+  "starrocks",
+  "manticoresearch",
+  "postgres",
+  "gaussdb",
+  "kwdb",
+  "yashandb",
+  "redshift",
+  "questdb",
+  "opengauss",
+  "mongodb",
+  "clickhouse",
+  "kingbase",
+  "tdengine",
+  "oscar",
+  "xugu",
+  "iotdb",
+  "iris",
+  "influxdb",
+  "sqlserver",
+  "oracle",
+]);
+
+export type UrlBuildConfig = Pick<ConnectionConfig, "db_type" | "driver_profile" | "host" | "port" | "username" | "password" | "database" | "url_params" | "ssl" | "oracle_connection_type" | "external_config">;
+
+function urlBuilderUserinfo(dbType: DatabaseType, username: string, password: string): string {
+  // Keep the raw characters (e.g. a literal "@" in the password) instead of
+  // percent-encoding them. A standard URL parser uses the last "@" as the
+  // userinfo separator, so `user:pass@host` still round-trips correctly.
+  const user = username;
+  const pass = password ? `:${password}` : "";
+  // Redis keeps the password keyed by an empty username (":" before the password).
+  if (dbType === "redis" && !username && password) return `:${password}@`;
+  if (!user && !pass) return "";
+  return `${user}${pass}@`;
+}
+
+function urlBuilderEndpoint(host: string, port: number, defaultPort: number): string {
+  const normalizedHost = host.trim();
+  const hostPart = normalizedHost.includes(":") ? `[${normalizedHost}]` : normalizedHost;
+  const portPart = port > 0 && port !== defaultPort ? `:${port}` : "";
+  return `${hostPart}${portPart}`;
+}
+
+/** SQL datastores that carry an explicit runtime TLS parameter in the URL. */
+const URL_BUILD_SSL_PARAM_TYPES: ReadonlySet<string> = new Set(["mysql", "doris", "starrocks", "manticoresearch", "postgres", "gaussdb", "kwdb", "yashandb", "redshift", "questdb", "opengauss"]);
+
+function urlBuilderParams(dbType: DatabaseType, urlParams: string, ssl: boolean): string {
+  const collected: string[] = [];
+  if (urlParams.trim()) {
+    for (const part of urlParams.split(/[&;]/)) {
+      if (!part.trim()) continue;
+      collected.push(part.trim());
+    }
+  }
+  // HTTP-based datastores express TLS through the "https" scheme; other backends
+  // (redis, sqlserver, ...) convey it via their scheme or driver options.
+  if (ssl && URL_BUILD_SSL_PARAM_TYPES.has(dbType)) {
+    collected.push(dbType === "mysql" || dbType === "doris" || dbType === "starrocks" || dbType === "manticoresearch" ? "ssl-mode=required" : "sslmode=require");
+  }
+  if (collected.length === 0) return "";
+  return `?${collected.join("&")}`;
+}
+
+function urlBuilderBasePath(externalConfig: unknown): string | undefined {
+  if (!externalConfig || typeof externalConfig !== "object") return undefined;
+  const candidate = (externalConfig as Record<string, unknown>).basePath ?? (externalConfig as Record<string, unknown>).apiPath;
+  if (typeof candidate !== "string") return undefined;
+  const trimmed = candidate.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+/**
+ * Build a copyable connection URL from a connection config. This is the inverse
+ * of {@link parseConnectionUrl}: as the user fills in host / port / username /
+ * password / database (or Oracle service name / SID), it produces the URL that
+ * would round-trip back into those same fields.
+ *
+ * Returns `undefined` for database types where no editable-network URL exists
+ * (local files, hosted/cloud endpoints, or types that maintain URL separately),
+ * so callers can leave any existing input untouched.
+ */
+export function buildConnectionUrlFromConfig(config: UrlBuildConfig): string | undefined {
+  const dbType = config.db_type;
+  if (URL_BUILD_EXCLUDED_TYPES.has(dbType) || URL_BUILD_LOCAL_TYPES.has(dbType) || URL_BUILD_HOSTED_TYPES.has(dbType)) return undefined;
+
+  const host = (config.host ?? "").trim();
+  if (!host || host.includes(",")) return undefined;
+
+  const port = Number(config.port) || Number(SCHEME_PROFILES[dbType]?.defaultPort) || 0;
+  const username = (config.username ?? "").trim();
+  const password = config.password ?? "";
+  const database = (config.database ?? "").trim();
+  const ssl = !!config.ssl;
+
+  // Oracle special-casing: service name and SID both live in the database field,
+  // but produce distinct JDBC thin URLs so the SID is preserved.
+  if (dbType === "oracle") {
+    if (config.oracle_connection_type === "tns") return undefined;
+    if (!database) return undefined;
+    const endpoint = urlBuilderEndpoint(host, port, Number(SCHEME_PROFILES.oracle.defaultPort) || 1521);
+    if (config.oracle_connection_type === "sid") {
+      return `jdbc:oracle:thin:@${endpoint}:${database}`;
+    }
+    return `jdbc:oracle:thin:@//${endpoint}/${database}`;
+  }
+
+  let scheme = URL_BUILD_SCHEME[dbType];
+  if (!scheme) return undefined;
+  if (ssl && (scheme === "http" || scheme === "redis")) {
+    scheme = scheme === "redis" ? "rediss" : "https";
+  }
+  const isHttpScheme = scheme === "http" || scheme === "https";
+  // HTTP(S) datastores use the scheme's well-known port, so the port is omitted
+  // when it matches 80/443; other datastores fall back to their product default.
+  const defaultPort = isHttpScheme ? (scheme === "https" ? 443 : 80) : Number(SCHEME_PROFILES[dbType === "postgres" || dbType === "gaussdb" ? "postgres" : dbType]?.defaultPort) || 0;
+
+  const userinfo = urlBuilderUserinfo(dbType, username, password);
+  const endpoint = urlBuilderEndpoint(host, port, defaultPort);
+
+  let url = `${scheme}://${userinfo}${endpoint}`;
+  if (dbType === "sqlserver") {
+    if (database) url += `/${encodeURIComponent(database)}`;
+    const params = urlBuilderParams(dbType, config.url_params ?? "", ssl);
+    return params ? `${url}${params}` : url;
+  }
+  if (URL_BUILD_NAMED_PATH.has(dbType) && database) {
+    url += `/${encodeURIComponent(database)}`;
+  } else if (scheme === "http" || scheme === "https") {
+    const basePath = urlBuilderBasePath(config.external_config) || database;
+    if (basePath) url += `/${encodeURIComponent(basePath)}`;
+  }
+  const params = urlBuilderParams(dbType, config.url_params ?? "", ssl);
+  return params ? `${url}${params}` : url;
+}


### PR DESCRIPTION
## 功能说明
在「新建连接 / 编辑连接」对话框内，当用户填写主机、端口、用户名、密码、数据库（或 Oracle 服务名 / SID）等信息时，顶部「URL（可选）」输入框会根据这些配置**实时自动生成**连接 URL，便于用户直接复制。

## 实现
- 新增 `buildConnectionUrlFromConfig()`（`parseConnectionUrl` 的逆函数），按数据库类型构造可复制的连接 URL。
- 在 `ConnectionDialog.vue` 中新增 watcher：监听 `db_type / host / port / username / password / database / url_params / ssl / oracle_connection_type / external_config`，任一字段变化即刷新顶部 URL。
- 生成的 URL 标记为「已应用」，作为纯展示内容，不会在保存时被再次解析而污染 `db_type`。
- 用户信息中的特殊字符（如密码里的 `@`）按原始字符输出，不再编码为 `%40`（标准 URL 解析以最后一个 `@` 分隔用户信息，round-trip 依然成立）。

## 覆盖类型
- 主流类型：MySQL / PostgreSQL / Redis / MongoDB / ClickHouse / SQL Server / Dameng / Kingbase / TDengine / OSCAR / Xugu / IoTDB / IRIS / InfluxDB 等
- Oracle 特判：服务名 → `jdbc:oracle:thin:@//host/service`；SID → `jdbc:oracle:thin:@host:sid`
- HTTP 系（Elasticsearch、Meilisearch、Qdrant 等）按是否启用 SSL 切换 `http/https`
- 本地文件类（SQLite / DuckDB / Access）与云托管类（DynamoDB / BigQuery / Turso 等）不支持自动生成，保持原行为

## 验证
- typecheck / oxfmt / oxlint 均通过；connectionUrl 相关单测全部通过
- 本地实测：填写主机 / 用户名 / 密码 / 数据库后，顶部 URL 实时更新为 `mysql://root:secret@db.example.com/app`