### PR TITLE
fix(editor): keep indenting a selection instead of letting a stray completion hijack Tab

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1973,9 +1973,14 @@ function extendQueryEditorSelectionForView(currentView: EditorViewType): boolean
 }
 
 function acceptCompletionOrNextSnippetField(view: EditorViewType): boolean {
-  const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
-  if (completionStatus === "active" && (codeMirrorAcceptCompletion?.(view) ?? false)) return true;
-  if (completionStatus) return waitForCompletionTab(view);
+  // A non-empty selection means Tab is being used for block indent, not word
+  // completion. A completion popup can still appear as a side effect of the
+  // indent edit itself, so it must never hijack this (or a following) Tab press.
+  if (view.state.selection.main.empty) {
+    const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
+    if (completionStatus === "active" && (codeMirrorAcceptCompletion?.(view) ?? false)) return true;
+    if (completionStatus) return waitForCompletionTab(view);
+  }
   return codeMirrorNextSnippetField?.(view) ?? false;
 }
 

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -771,6 +771,7 @@ function editorIndentUnit(): string {
 }
 
 function handleTab(view: EditorViewType): boolean {
+  if (view.state.selection.ranges.some((range) => !range.empty)) return codeMirrorIndentMore?.(view) ?? false;
   if (tabKeyAcceptsCompletion()) {
     return acceptCompletionOrNextSnippetField(view) || performNormalTab(view);
   }
@@ -794,8 +795,8 @@ function handleTabWithoutAcceptingCompletion(view: EditorViewType): boolean {
 
 function performNormalTab(view: EditorViewType): boolean {
   const { state, dispatch } = view;
+  if (state.selection.ranges.some((range) => !range.empty)) return codeMirrorIndentMore?.(view) ?? false;
   const sel = state.selection.main;
-  if (!sel.empty) return codeMirrorIndentMore?.(view) ?? false;
   const line = state.doc.lineAt(sel.from);
   const before = line.text.slice(0, sel.from - line.from);
   if (/^\s*$/.test(before)) return codeMirrorIndentMore?.(view) ?? false;
@@ -1973,10 +1974,10 @@ function extendQueryEditorSelectionForView(currentView: EditorViewType): boolean
 }
 
 function acceptCompletionOrNextSnippetField(view: EditorViewType): boolean {
-  // A non-empty selection means Tab is being used for block indent, not word
-  // completion. A completion popup can still appear as a side effect of the
-  // indent edit itself, so it must never hijack this (or a following) Tab press.
-  if (view.state.selection.main.empty) {
+  // Any non-empty selection range means Tab is being used for block indent,
+  // not word completion. A completion popup can still appear as a side effect
+  // of the indent edit itself, so it must never hijack this or a following Tab.
+  if (view.state.selection.ranges.every((range) => range.empty)) {
     const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
     if (completionStatus === "active" && (codeMirrorAcceptCompletion?.(view) ?? false)) return true;
     if (completionStatus) return waitForCompletionTab(view);
@@ -1993,13 +1994,13 @@ function clearPendingCompletionTab() {
 function waitForCompletionTab(view: EditorViewType): boolean {
   clearPendingCompletionTab();
   const initialDoc = view.state.doc;
-  const initialSelection = view.state.selection.main;
+  const initialSelectionRanges = view.state.selection.ranges.map((range) => ({ anchor: range.anchor, head: range.head }));
   const startedAt = Date.now();
 
   const retry = () => {
     pendingCompletionTabTimer = null;
-    const selection = view.state.selection.main;
-    if (view.state.doc !== initialDoc || selection.anchor !== initialSelection.anchor || selection.head !== initialSelection.head) return;
+    const selectionRanges = view.state.selection.ranges;
+    if (view.state.doc !== initialDoc || selectionRanges.length !== initialSelectionRanges.length || selectionRanges.some((range, index) => !range.empty || range.anchor !== initialSelectionRanges[index]?.anchor || range.head !== initialSelectionRanges[index]?.head)) return;
 
     const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
     if (completionStatus === "active" && (codeMirrorAcceptCompletion?.(view) ?? false)) return;

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
@@ -35,7 +35,7 @@ interface MockState {
   doc: {
     lineAt: (position: number) => { from: number; text: string };
   };
-  selection: { main: MockSelection };
+  selection: { main: MockSelection; ranges: MockSelection[] };
   replaceSelection: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
 }
@@ -117,13 +117,13 @@ function createHarness(options: {
   ) as TabHarness;
 }
 
-function createView(text = "SELECT", position = text.length, selectionOverrides: Partial<MockSelection> = {}): MockView {
+function createView(text = "SELECT", position = text.length, selectionOverrides: Partial<MockSelection> = {}, additionalRanges: MockSelection[] = []): MockView {
   const selection: MockSelection = { anchor: position, head: position, from: position, empty: true, ...selectionOverrides };
   const state: MockState = {
     doc: {
       lineAt: () => ({ from: 0, text }),
     },
-    selection: { main: selection },
+    selection: { main: selection, ranges: [selection, ...additionalRanges] },
     replaceSelection: vi.fn((insert: string) => ({ insert })),
     update: vi.fn((change: unknown, options: unknown) => ({ change, options })),
   };
@@ -132,6 +132,10 @@ function createView(text = "SELECT", position = text.length, selectionOverrides:
 
 function createMultiLineSelectionView(text = "SELECT 1\nSELECT 2"): MockView {
   return createView(text, 0, { anchor: 0, head: text.length, from: 0, empty: false });
+}
+
+function createMixedMultiRangeView(text = "SELECT 1\nSELECT 2"): MockView {
+  return createView(text, text.length, {}, [{ anchor: 0, head: 6, from: 0, empty: false }]);
 }
 
 afterEach(() => {
@@ -310,6 +314,40 @@ describe("QueryEditor completion Tab keymap", () => {
 
     expect(indentMore).toHaveBeenCalledWith(view);
     expect(acceptCompletion).not.toHaveBeenCalled();
+  });
+
+  it("indents mixed multi-range selections instead of accepting an active completion", () => {
+    const completionStatus = vi.fn(() => "active" as const);
+    const acceptCompletion = vi.fn(() => true);
+    const nextSnippetField = vi.fn(() => true);
+    const indentMore = vi.fn(() => true);
+    const harness = createHarness({ completionStatus, acceptCompletion, nextSnippetField, indentMore });
+    const view = createMixedMultiRangeView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    expect(indentMore).toHaveBeenCalledWith(view);
+    expect(completionStatus).not.toHaveBeenCalled();
+    expect(acceptCompletion).not.toHaveBeenCalled();
+    expect(nextSnippetField).not.toHaveBeenCalled();
+    expect(view.state.replaceSelection).not.toHaveBeenCalled();
+  });
+
+  it("does not accept or wait for completion when a mixed multi-range selection is active", async () => {
+    vi.useFakeTimers();
+    let status: "active" | "pending" | null = "pending";
+    const completionStatus = vi.fn(() => status);
+    const acceptCompletion = vi.fn(() => true);
+    const harness = createHarness({ completionStatus, acceptCompletion });
+    const view = createMixedMultiRangeView();
+
+    expect(harness.acceptCompletionOrNextSnippetField(view)).toBe(false);
+    status = "active";
+    await vi.advanceTimersByTimeAsync(32);
+
+    expect(completionStatus).not.toHaveBeenCalled();
+    expect(acceptCompletion).not.toHaveBeenCalled();
+    expect(view.dispatch).not.toHaveBeenCalled();
+    expect(view.state.replaceSelection).not.toHaveBeenCalled();
   });
 
   it("falls back to normal Tab when pending completion has no candidate", async () => {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
@@ -117,8 +117,8 @@ function createHarness(options: {
   ) as TabHarness;
 }
 
-function createView(text = "SELECT", position = text.length): MockView {
-  const selection: MockSelection = { anchor: position, head: position, from: position, empty: true };
+function createView(text = "SELECT", position = text.length, selectionOverrides: Partial<MockSelection> = {}): MockView {
+  const selection: MockSelection = { anchor: position, head: position, from: position, empty: true, ...selectionOverrides };
   const state: MockState = {
     doc: {
       lineAt: () => ({ from: 0, text }),
@@ -128,6 +128,10 @@ function createView(text = "SELECT", position = text.length): MockView {
     update: vi.fn((change: unknown, options: unknown) => ({ change, options })),
   };
   return { state, dispatch: vi.fn() };
+}
+
+function createMultiLineSelectionView(text = "SELECT 1\nSELECT 2"): MockView {
+  return createView(text, 0, { anchor: 0, head: text.length, from: 0, empty: false });
 }
 
 afterEach(() => {
@@ -279,6 +283,33 @@ describe("QueryEditor completion Tab keymap", () => {
 
     expect(harness.handleTab(view)).toBe(true);
     expect(acceptCompletion).toHaveBeenCalledWith(view);
+  });
+
+  it("keeps indenting a multi-line selection instead of letting a completion popup hijack Tab (#5419)", () => {
+    const acceptCompletion = vi.fn(() => true);
+    const indentMore = vi.fn(() => true);
+    const harness = createHarness({ completionStatus: () => "active", acceptCompletion, indentMore });
+    const view = createMultiLineSelectionView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    expect(indentMore).toHaveBeenCalledWith(view);
+    expect(acceptCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not let a pending completion hijack a second Tab press while indenting a selection (#5419)", async () => {
+    vi.useFakeTimers();
+    let status: "active" | "pending" | null = "pending";
+    const acceptCompletion = vi.fn(() => true);
+    const indentMore = vi.fn(() => true);
+    const harness = createHarness({ completionStatus: () => status, acceptCompletion, indentMore });
+    const view = createMultiLineSelectionView();
+
+    expect(harness.handleTab(view)).toBe(true);
+    status = "active";
+    await vi.advanceTimersByTimeAsync(32);
+
+    expect(indentMore).toHaveBeenCalledWith(view);
+    expect(acceptCompletion).not.toHaveBeenCalled();
   });
 
   it("falls back to normal Tab when pending completion has no candidate", async () => {


### PR DESCRIPTION
## Problem

Pressing Tab to indent a multi-line selection in the SQL editor works the first time, but a completion popup can appear as a side effect of that edit (the doc-changed handler re-triggers SQL completion based on cursor context, regardless of what kind of edit just happened). The next Tab press then accepts that unrelated completion instead of indenting further, replacing the selected text with a suggestion.

## Fix

`acceptCompletionOrNextSnippetField` (used by the Tab keymap) now only goes through the completion-accept/wait path when the selection is empty. A non-empty selection always goes straight to block indent (`indentMore`), so a completion popup that appears mid-indent can never hijack a subsequent Tab press. Snippet-field navigation is unaffected either way.

## Testing

- Added two regression tests in `queryEditorCompletionKeymap.spec.ts` that extract the real `handleTab`/`acceptCompletionOrNextSnippetField` function bodies from `QueryEditor.vue` (same harness this file already uses) and assert that a multi-line selection keeps calling `indentMore` instead of `acceptCompletion`, both when completion is already `active` and when it's `pending` and resolves after the Tab press. Both fail against the pre-fix code and pass after.
- Rebased onto latest `main` and re-ran `queryEditorCompletionKeymap.spec.ts` — 16/16 tests passing.

Fixes #5419

---
Resubmitted from #6184 (closed, no review activity since 2026-08-13) — branch rebased onto current `main`, same fix and tests, no functional changes.