### PR TITLE
🐛 fix(grid): 保持右键筛选目标以支持异步大字段加载

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -740,6 +740,7 @@ const contextCell = ref<{
   col: number;
 } | null>(null);
 type ContextFilterTarget = {
+  id: number;
   rowId: number;
   rowIndex: number;
   col: number;
@@ -753,6 +754,8 @@ type ContextFilterTarget = {
 // The context menu closes before invoking its action. Keep an immutable target
 // for asynchronous filter actions instead of reading the cleared selection.
 const contextFilterTarget = ref<ContextFilterTarget | null>(null);
+let nextContextFilterTargetId = 0;
+const activeContextFilterActions = new Set<number>();
 // True when onCellContext created a synthetic single-cell selection (the cell
 // was not previously selected). Lets buildRequest distinguish a genuine 1×1
 // selection (user Ctrl+click) from a synthetic one (right-click on unselected).
@@ -775,6 +778,7 @@ function onGridContextMenuOpen() {
   contextFilterTarget.value =
     cell && columnName && sourceItem
       ? {
+          id: ++nextContextFilterTargetId,
           rowId: cell.rowId,
           rowIndex: cell.rowIndex,
           col: cell.col,
@@ -797,9 +801,14 @@ watch(
 
 function onGridContextMenuClose() {
   const lifecycle = ++contextMenuLifecycle;
+  const target = contextFilterTarget.value;
+  const targetId = target?.id;
   queueMicrotask(() => {
     if (lifecycle !== contextMenuLifecycle) return;
     invalidateSyntheticContextSelection();
+    // CustomContextMenu closes before starting an item action. Its action runs
+    // in this turn, so only a menu dismissal leaves this target unclaimed.
+    if (targetId !== undefined && contextFilterTarget.value?.id === targetId && !activeContextFilterActions.has(targetId)) contextFilterTarget.value = null;
   });
 }
 
@@ -5676,9 +5685,7 @@ function applyContextSort(direction: "asc" | "desc" | null, mode: DataGridSortMo
   applyColumnSort(contextColumn.value, contextCell.value.col, direction, mode);
 }
 
-async function contextFilterCondition(mode: FilterMode): Promise<string | null> {
-  const target = contextFilterTarget.value;
-  if (!target) return null;
+async function contextFilterCondition(target: ContextFilterTarget, mode: FilterMode): Promise<string | null> {
   const { columnName, sourceResult, sourceIndex, sourceValue, requiresHydration } = target;
   // CustomContextMenu closes before invoking its action. Keep the target
   // stable across hydration after the close lifecycle clears contextCell.
@@ -5687,25 +5694,32 @@ async function contextFilterCondition(mode: FilterMode): Promise<string | null> 
   }
   if (props.result !== sourceResult) return null;
   const value = requiresHydration && sourceIndex !== undefined ? (sourceResult.rows[sourceIndex]?.[target.col] ?? null) : sourceValue;
-  return (
-    (await buildDataGridContextFilterCondition({
-      databaseType: resolvedDatabaseType.value,
-      identifierQuote: connectionStore.connectionIdentifierQuote?.(props.connectionId),
-      columnName,
-      columnInfo: target.columnInfo,
-      mode,
-      value,
-    })) ?? null
-  );
+  const condition = await buildDataGridContextFilterCondition({
+    databaseType: resolvedDatabaseType.value,
+    identifierQuote: connectionStore.connectionIdentifierQuote?.(props.connectionId),
+    columnName,
+    columnInfo: target.columnInfo,
+    mode,
+    value,
+  });
+  return props.result === sourceResult ? (condition ?? null) : null;
 }
 
 async function applyContextFilter(mode: FilterMode) {
   if (!canUseWhereSearch.value) return;
-  const condition = await contextFilterCondition(mode);
-  if (!condition) return;
-  const existing = whereFilterInput.value.trim();
-  whereFilterInput.value = existing ? `(${existing}) AND (${condition})` : condition;
-  await applyWhereFilter();
+  const target = contextFilterTarget.value;
+  if (!target) return;
+  activeContextFilterActions.add(target.id);
+  try {
+    const condition = await contextFilterCondition(target, mode);
+    if (!condition || props.result !== target.sourceResult) return;
+    const existing = whereFilterInput.value.trim();
+    whereFilterInput.value = existing ? `(${existing}) AND (${condition})` : condition;
+    await applyWhereFilter();
+  } finally {
+    activeContextFilterActions.delete(target.id);
+    if (contextFilterTarget.value?.id === target.id) contextFilterTarget.value = null;
+  }
 }
 
 async function clearContextFilter() {

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -739,6 +739,20 @@ const contextCell = ref<{
   rowIndex: number;
   col: number;
 } | null>(null);
+type ContextFilterTarget = {
+  rowId: number;
+  rowIndex: number;
+  col: number;
+  columnName: string;
+  columnInfo?: ColumnInfo;
+  sourceResult: QueryResult;
+  sourceIndex?: number;
+  sourceValue: CellValue;
+  requiresHydration: boolean;
+};
+// The context menu closes before invoking its action. Keep an immutable target
+// for asynchronous filter actions instead of reading the cleared selection.
+const contextFilterTarget = ref<ContextFilterTarget | null>(null);
 // True when onCellContext created a synthetic single-cell selection (the cell
 // was not previously selected). Lets buildRequest distinguish a genuine 1×1
 // selection (user Ctrl+click) from a synthetic one (right-click on unselected).
@@ -755,7 +769,31 @@ function invalidateSyntheticContextSelection() {
 
 function onGridContextMenuOpen() {
   contextMenuLifecycle += 1;
+  const cell = contextCell.value;
+  const columnName = cell ? props.result.columns[cell.col] : undefined;
+  const sourceItem = cell ? getRowItem(cell.rowId) : undefined;
+  contextFilterTarget.value =
+    cell && columnName && sourceItem
+      ? {
+          rowId: cell.rowId,
+          rowIndex: cell.rowIndex,
+          col: cell.col,
+          columnName,
+          columnInfo: props.tableMeta?.columns.find((column) => column.name === columnName),
+          sourceResult: props.result,
+          sourceIndex: sourceItem.sourceIndex,
+          sourceValue: sourceItem.data[cell.col] ?? null,
+          requiresHydration: sourceItem.sourceIndex !== undefined && isLargeValuePreview(sourceItem, cell.col),
+        }
+      : null;
 }
+
+watch(
+  () => props.result,
+  (result) => {
+    if (contextFilterTarget.value?.sourceResult !== result) contextFilterTarget.value = null;
+  },
+);
 
 function onGridContextMenuClose() {
   const lifecycle = ++contextMenuLifecycle;
@@ -5639,16 +5677,9 @@ function applyContextSort(direction: "asc" | "desc" | null, mode: DataGridSortMo
 }
 
 async function contextFilterCondition(mode: FilterMode): Promise<string | null> {
-  const target = contextCell.value;
+  const target = contextFilterTarget.value;
   if (!target) return null;
-  const columnName = props.result.columns[target.col];
-  if (!columnName) return null;
-  const sourceResult = props.result;
-  const sourceItem = getRowItem(target.rowId);
-  if (!sourceItem) return null;
-  const sourceIndex = sourceItem.sourceIndex;
-  const requiresHydration = sourceIndex !== undefined && isLargeValuePreview(sourceItem, target.col);
-  const sourceValue = sourceItem.data[target.col] ?? null;
+  const { columnName, sourceResult, sourceIndex, sourceValue, requiresHydration } = target;
   // CustomContextMenu closes before invoking its action. Keep the target
   // stable across hydration after the close lifecycle clears contextCell.
   if (mode !== "is-null" && mode !== "is-not-null") {
@@ -5661,7 +5692,7 @@ async function contextFilterCondition(mode: FilterMode): Promise<string | null> 
       databaseType: resolvedDatabaseType.value,
       identifierQuote: connectionStore.connectionIdentifierQuote?.(props.connectionId),
       columnName,
-      columnInfo: props.tableMeta?.columns.find((column) => column.name === columnName),
+      columnInfo: target.columnInfo,
       mode,
       value,
     })) ?? null

--- a/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
@@ -20,14 +20,25 @@ describe("DataGrid context extractor lifecycle", () => {
     const start = source.indexOf("async function contextFilterCondition");
     const end = source.indexOf("async function applyContextFilter", start);
     const filterSource = source.slice(start, end);
+    const openStart = source.indexOf("function onGridContextMenuOpen");
+    const openEnd = source.indexOf("function onGridContextMenuClose", openStart);
+    const openSource = source.slice(openStart, openEnd);
 
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
-    expect(filterSource).toContain("const target = contextCell.value;");
-    expect(filterSource).toContain("const sourceResult = props.result;");
-    expect(filterSource).toContain("const sourceIndex = sourceItem.sourceIndex;");
+    expect(openStart).toBeGreaterThanOrEqual(0);
+    expect(openEnd).toBeGreaterThan(openStart);
+    expect(openSource).toContain("contextFilterTarget.value =");
+    expect(openSource).toContain("cell && columnName && sourceItem");
+    expect(openSource).toContain("sourceResult: props.result,");
+    expect(openSource).toContain("sourceValue: sourceItem.data[cell.col] ?? null,");
+    expect(openSource).toContain("() => props.result,");
+    expect(openSource).toContain("contextFilterTarget.value?.sourceResult !== result");
+    expect(filterSource).toContain("const target = contextFilterTarget.value;");
+    expect(filterSource).toContain("const { columnName, sourceResult, sourceIndex, sourceValue, requiresHydration } = target;");
     expect(filterSource).toContain("await hydrateLargeValueCell(target.rowId, target.col)");
     expect(filterSource).toContain("sourceResult.rows[sourceIndex]?.[target.col]");
+    expect(filterSource).not.toContain("contextCell.value");
     expect(filterSource).not.toContain("getRowItem(target.rowId);\n  if (!item)");
     expect(filterSource).not.toContain("contextColumn.value");
     expect(filterSource).not.toContain("contextCellValue.value");

--- a/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
@@ -1,46 +1,226 @@
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+// @vitest-environment happy-dom
 
-const source = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
+import { createApp, defineComponent, h, markRaw, nextTick, shallowRef, type App, type PropType } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import type { QueryResult } from "@/types/database";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
-describe("DataGrid context extractor lifecycle", () => {
-  it("clears the right-click target after the context-menu action has started", () => {
-    expect(source).toContain('@open="onGridContextMenuOpen"');
-    expect(source).toContain('@close="onGridContextMenuClose"');
-    expect(source).toContain("queueMicrotask(() => {");
-    expect(source).toContain("invalidateSyntheticContextSelection();");
+const mocks = vi.hoisted(() => ({
+  buildDataGridContextFilterCondition: vi.fn(async ({ columnName, value }: { columnName: string; value: unknown }) => `\`${columnName}\` = '${String(value)}'`),
+  buildTableSelectSql: vi.fn(async ({ whereInput }: { whereInput?: string }) => `SELECT payload FROM events${whereInput ? ` WHERE ${whereInput}` : ""}`),
+  executeMulti: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("@/lib/backend/api", () => ({
+  buildDataGridContextFilterCondition: mocks.buildDataGridContextFilterCondition,
+  buildTableSelectSql: mocks.buildTableSelectSql,
+  executeMulti: mocks.executeMulti,
+}));
+
+vi.mock("@/composables/useToast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock("@/composables/useDataGridColumnResize", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/composables/useDataGridColumnResize")>();
+  const { ref } = await import("vue");
+  return {
+    ...actual,
+    useDataGridColumnResize: () => ({
+      initColumnWidths: vi.fn(),
+      onResizeStart: vi.fn(),
+      autoFitColumn: vi.fn(),
+      renderedColumnWidths: ref([120, 180]),
+      totalWidth: ref(300),
+      columnVars: ref({ "--total-w": "300px" }),
+      getIsResizing: () => false,
+    }),
+  };
+});
+
+import DataGrid from "../DataGrid.vue";
+import { useSettingsStore } from "@/stores/settingsStore";
+
+const RecycleScroller = defineComponent({
+  props: {
+    items: {
+      type: Array as PropType<unknown[]>,
+      default: () => [],
+    },
+  },
+  setup(props, { attrs, slots }) {
+    return () =>
+      h(
+        "div",
+        attrs,
+        props.items.map((item) => slots.default?.({ item })),
+      );
+  },
+});
+
+const mountedApps: Array<{ app: App; host: HTMLElement }> = [];
+
+function largeValueResult(id = 1, value = "preview"): QueryResult {
+  return {
+    columns: ["id", "payload"],
+    rows: [[id, value]],
+    affected_rows: 0,
+    execution_time_ms: 0,
+    large_value_cells: [{ row_index: 0, column_index: 1, original_bytes: 4096 }],
+  };
+}
+
+function hydratedResult(id: number, value: string): QueryResult {
+  return {
+    columns: ["id", "payload"],
+    rows: [[id, value]],
+    affected_rows: 0,
+    execution_time_ms: 0,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function mountGrid(initialResult = largeValueResult()) {
+  const result = shallowRef(markRaw(initialResult));
+  const onExecuteSql = vi.fn().mockResolvedValue(undefined);
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const settingsStore = useSettingsStore();
+  settingsStore.updateEditorSettings({ dataGridRenderMode: "canvas" });
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const Root = defineComponent({
+    setup() {
+      return () =>
+        h(
+          TooltipProvider,
+          { delayDuration: 0 },
+          {
+            default: () =>
+              h(DataGrid, {
+                result: result.value,
+                databaseType: "mysql",
+                connectionId: "connection-1",
+                database: "dbx",
+                context: "table-data",
+                editable: true,
+                tableMeta: {
+                  tableName: "events",
+                  columns: [
+                    { name: "id", data_type: "int" },
+                    { name: "payload", data_type: "text" },
+                  ],
+                  primaryKeys: ["id"],
+                },
+                onExecuteSql,
+              }),
+          },
+        );
+    },
+  });
+  const app = createApp(Root);
+  app.use(pinia);
+  app.use(i18n);
+  app.component("RecycleScroller", RecycleScroller);
+  app.mount(host);
+  // Mount once with the production-default Canvas mode so DataGrid finishes
+  // setting up its column-width dependencies, then exercise the DOM grid.
+  settingsStore.updateEditorSettings({ dataGridRenderMode: "dom" });
+  mountedApps.push({ app, host });
+  return { host, onExecuteSql, replaceResult: (nextResult: QueryResult) => (result.value = markRaw(nextResult)) };
+}
+
+async function settle() {
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+}
+
+function contextMenuButton(label: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll<HTMLButtonElement>("[data-dbx-context-menu] button")].find((candidate) => candidate.textContent?.trim() === label);
+  if (!button) throw new Error(`Context menu item not found: ${label}`);
+  return button;
+}
+
+async function startEqualsFilter(host: HTMLElement) {
+  await settle();
+  const cell = host.querySelector<HTMLElement>('[data-row-index="0"] [data-visible-col-index="1"]');
+  if (!cell) throw new Error("Large-value grid cell not found");
+  cell.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 12, clientY: 12 }));
+  await settle();
+  contextMenuButton("Filter").dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+  await settle();
+  contextMenuButton("Filter by This Value").click();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  for (const { app, host } of mountedApps.splice(0)) {
+    app.unmount();
+    host.remove();
+  }
+  document.querySelectorAll("[data-dbx-context-menu]").forEach((menu) => menu.remove());
+});
+
+describe("DataGrid context filter lifecycle", () => {
+  it("keeps the right-click target through menu close and large-value hydration", async () => {
+    const hydration = deferred<QueryResult[]>();
+    mocks.executeMulti.mockReturnValue(hydration.promise);
+    const { host, onExecuteSql } = mountGrid();
+
+    await startEqualsFilter(host);
+    await vi.waitFor(() => expect(mocks.executeMulti).toHaveBeenCalledTimes(1));
+    expect(document.querySelector("[data-dbx-context-menu]")).toBeNull();
+
+    hydration.resolve([hydratedResult(1, "full original value")]);
+    await vi.waitFor(() => expect(onExecuteSql).toHaveBeenCalledTimes(1));
+
+    const sql = onExecuteSql.mock.calls[0]?.[0] as string;
+    expect(sql).toContain("payload");
+    expect(sql).toContain("full original value");
   });
 
-  it("resolves menu items after the right-click target is updated", () => {
-    expect(source).toContain(':items="currentGridContextMenuItems"');
-    expect(source).toContain("return gridContextMenuItems.value;");
+  it("does not apply a completed hydration from a previous result set", async () => {
+    const hydration = deferred<QueryResult[]>();
+    mocks.executeMulti.mockReturnValue(hydration.promise);
+    const { host, onExecuteSql, replaceResult } = mountGrid();
+
+    await startEqualsFilter(host);
+    await vi.waitFor(() => expect(mocks.executeMulti).toHaveBeenCalledTimes(1));
+    replaceResult(largeValueResult(2, "new preview"));
+    await settle();
+    hydration.resolve([hydratedResult(1, "old value")]);
+    await settle();
+
+    expect(onExecuteSql).not.toHaveBeenCalled();
   });
 
-  it("snapshots the filter target before asynchronous value hydration", () => {
-    const start = source.indexOf("async function contextFilterCondition");
-    const end = source.indexOf("async function applyContextFilter", start);
-    const filterSource = source.slice(start, end);
-    const openStart = source.indexOf("function onGridContextMenuOpen");
-    const openEnd = source.indexOf("function onGridContextMenuClose", openStart);
-    const openSource = source.slice(openStart, openEnd);
+  it("does not apply a delayed condition after the result set changes", async () => {
+    const condition = deferred<string | undefined>();
+    mocks.buildDataGridContextFilterCondition.mockReturnValue(condition.promise);
+    const { host, onExecuteSql, replaceResult } = mountGrid(hydratedResult(1, "old value"));
 
-    expect(start).toBeGreaterThanOrEqual(0);
-    expect(end).toBeGreaterThan(start);
-    expect(openStart).toBeGreaterThanOrEqual(0);
-    expect(openEnd).toBeGreaterThan(openStart);
-    expect(openSource).toContain("contextFilterTarget.value =");
-    expect(openSource).toContain("cell && columnName && sourceItem");
-    expect(openSource).toContain("sourceResult: props.result,");
-    expect(openSource).toContain("sourceValue: sourceItem.data[cell.col] ?? null,");
-    expect(openSource).toContain("() => props.result,");
-    expect(openSource).toContain("contextFilterTarget.value?.sourceResult !== result");
-    expect(filterSource).toContain("const target = contextFilterTarget.value;");
-    expect(filterSource).toContain("const { columnName, sourceResult, sourceIndex, sourceValue, requiresHydration } = target;");
-    expect(filterSource).toContain("await hydrateLargeValueCell(target.rowId, target.col)");
-    expect(filterSource).toContain("sourceResult.rows[sourceIndex]?.[target.col]");
-    expect(filterSource).not.toContain("contextCell.value");
-    expect(filterSource).not.toContain("getRowItem(target.rowId);\n  if (!item)");
-    expect(filterSource).not.toContain("contextColumn.value");
-    expect(filterSource).not.toContain("contextCellValue.value");
+    await startEqualsFilter(host);
+    await vi.waitFor(() => expect(mocks.buildDataGridContextFilterCondition).toHaveBeenCalledTimes(1));
+    replaceResult(hydratedResult(2, "new value"));
+    await settle();
+    condition.resolve("`payload` = 'old value'");
+    await settle();
+
+    expect(onExecuteSql).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- 菜单关闭后缓存筛选单元格的列、值及数据源信息，避免上下文选择被清空
- 数据结果切换时清理缓存目标，防止使用过期筛选数据
- 更新上下文筛选生命周期测试断言

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #6641