### PR TITLE
🐛 fix(sqlserver): execute comment-prefixed CTE selections without wrapping (#6645)

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlExecutionTarget.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlExecutionTarget.spec.ts
@@ -25,6 +25,15 @@ describe("resolveExecutableSql", () => {
 
     expect(resolveExecutableSql("SELECT 1;", selectedSql, { mode: "current", cursorPos: 0 })).toBe(selectedSql);
   });
+
+  it("keeps a manually selected comment-prefixed SQL Server CTE unchanged", () => {
+    // Issue #6645: the selected region is passed verbatim to the backend so the
+    // pagination plan can recognize the leading comment and execute the CTE as-is
+    // instead of wrapping it into a derived table (SQL Server error 156).
+    const selectedSql = "/* \u67e5\u8be2\u9500\u552e\u5458-\u5ba2\u6237\u53ef\u63a7 */\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff";
+
+    expect(resolveExecutableSql("SELECT 1;", selectedSql, { mode: "current", cursorPos: 0 })).toBe(selectedSql);
+  });
 });
 
 describe("executionCandidateForMode", () => {

--- a/crates/dbx-core/src/query_result_sql.rs
+++ b/crates/dbx-core/src/query_result_sql.rs
@@ -142,11 +142,13 @@ pub fn build_query_pagination_execution_plan(
         single_execution: false,
     };
 
+    let is_sqlserver_leading_cte =
+        options.database_type == Some(DatabaseType::SqlServer) && starts_with_cte(&options.query_base_sql);
     let counted = build_count_query_sql(CountQuerySqlOptions {
         original_sql: options.query_base_sql.clone(),
         database_type: options.database_type,
     });
-    if counted.ok {
+    if counted.ok && !is_sqlserver_leading_cte {
         plan.count_sql = counted.sql;
     }
 
@@ -157,7 +159,7 @@ pub fn build_query_pagination_execution_plan(
         return plan;
     }
 
-    if options.database_type == Some(DatabaseType::SqlServer) && starts_with_cte(&options.query_base_sql) {
+    if is_sqlserver_leading_cte {
         return plan;
     }
 
@@ -451,7 +453,13 @@ fn single_statement_matches_base_sql(statement: &str, base_sql: &str) -> bool {
 }
 
 fn starts_with_cte(sql: &str) -> bool {
-    sql.trim_start().trim_start_matches(';').trim_start().to_ascii_uppercase().starts_with("WITH")
+    let sql = sql.trim().trim_start_matches(';').trim_start();
+    // A leading comment (`--` line or `/* */` block, including optimizer hints
+    // and proxy/TDSQL-style directives) may sit between the start of the selected
+    // text and the actual statement. SQL Server has no `#` line comments, so
+    // temporary-table names like #Temp are never mistaken for comments here.
+    let sql = &sql[skip_leading_sql_comments(sql, 0)..];
+    sql.trim_start().to_ascii_uppercase().starts_with("WITH")
 }
 
 fn cte_main_statement_is_select(sql: &str) -> bool {
@@ -2631,6 +2639,207 @@ mod tests {
         assert!(plan.count_sql.is_none());
         assert_eq!(plan.page_limit, None);
         assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_comment_cte_pagination_plan_executes_original_sql() {
+        // Issue #6645: when the user manually selects a comment-prefixed CTE
+        // ("/* ... */\nWITH ..."), the selected text is passed to the backend
+        // verbatim. The pagination plan must still recognize the leading comment
+        // and execute the CTE as-is instead of wrapping it into a derived table
+        // (`SELECT TOP (n) * FROM (WITH ...) [dbx_page]`), which SQL Server
+        // rejects with error 156 "keyword 'with' nearby". The non-selected
+        // (current statement) path was immune because cursor resolution strips
+        // leading comments before the plan is built.
+        let sql = "/* 查询销售员-客户可控 */\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_line_comment_cte_pagination_plan_executes_original_sql() {
+        let sql = "-- 查询销售员\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_multi_line_comment_cte_pagination_plan_executes_original_sql() {
+        let sql =
+            "/* 查询销售员\n * 客户可控\n */\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_semicolon_then_comment_then_cte_pagination_plan_executes_original_sql() {
+        let sql = ";/* 查询 */\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_comment_cte_with_inner_and_trailing_comments_executes_original_sql() {
+        let sql = "/* 查询销售员-客户可控 */\nWITH staff AS (/* inner */ SELECT id FROM dbo.users) SELECT * FROM staff -- trailing".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_optimizer_hint_cte_pagination_plan_executes_original_sql() {
+        // The hint is a meaningful leading directive and must be preserved in
+        // the executed SQL, never stripped (see #3569 / PR #3697).
+        let sql = "/*+ MAXDOP(2) */\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_proxy_directive_cte_pagination_plan_executes_original_sql() {
+        let sql = "/*proxy*/\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_tdsql_directive_cte_pagination_plan_executes_original_sql() {
+        let sql = "/*sets:allsets */\nWITH staff AS (SELECT id FROM dbo.users) SELECT * FROM staff".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, sql);
+        assert!(plan.page_sql.is_none());
+        assert!(plan.count_sql.is_none());
+        assert_eq!(plan.page_limit, None);
+        assert_eq!(plan.page_offset, None);
+    }
+
+    #[test]
+    fn sqlserver_leading_comment_plain_select_still_paginates() {
+        // A leading comment before a plain SELECT must keep paginating (TOP
+        // wrap inside a derived table is legal for ordinary SELECTs); only
+        // CTE statements must execute untouched.
+        let sql = "/* 查询订单 */\nSELECT [id], [amount] FROM [sales].[orders_10k]".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert_eq!(plan.sql_to_execute, "SELECT TOP (100) [id], [amount] FROM [sales].[orders_10k]");
+        assert!(plan.page_limit.is_some());
+        assert_eq!(plan.page_offset, Some(0));
+    }
+
+    #[test]
+    fn sqlserver_hash_temp_table_select_is_not_mistaken_for_comment_or_cte() {
+        // #Temp / ##GlobalTemp are SQL Server temporary table names, not hash
+        // comments or CTEs; pagination must keep working on them (see #4689).
+        let sql = "SELECT [id] FROM #Temp".to_string();
+        let plan = build_query_pagination_execution_plan(QueryPaginationExecutionPlanOptions {
+            sql: sql.clone(),
+            query_base_sql: sql.clone(),
+            database_type: Some(DatabaseType::SqlServer),
+            pagination: QueryPagination { limit: 100, offset: 0, session_id: None },
+            use_agent_cursor: false,
+            first_page_uses_actual_sql: false,
+        });
+
+        assert!(plan.page_sql.is_some());
+        assert_eq!(plan.page_limit, Some(100));
+        assert_eq!(plan.page_offset, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
# Issue #6645 — SQL Server 选区执行「注释 + SELECT(SQL)」报语法错误

## 背景

- P0，模块 `db/sqlserver`，assignee = 0verme（本次提交作者）。
- 复现：SQL Server 下 SELECT 语句首行是块注释，用户手动选中「注释 + SQL」执行报错
  （SQL Server 错误 156「关键字 'with' 附近有语法错误」，line 1）；不选区（current-statement）执行同一 SQL 正常（43 行）。
- 复现 SQL 为 CTE 查询：`/* 查询销售员-客户可控 */` + `with staff as (select ...) select ...`。

## 根因

- 选区路径（`resolveExecutableSqlWithBackend`）把 `selectedSql.trim()` 原样传给后端，不经解析。
- 后端 `build_query_pagination_execution_plan` 用 `starts_with_cte(query_base_sql)` 判断 SQL Server 是否 CTE；
  该函数只跳过空白/分号、**不跳过前导注释**，导致「注释+CTE」被误判为普通 SELECT。
- 误判后走 `build_paginated_query_sql` → SQL Server 分支 `add_sql_server_top`（offset=0）
  对非 SELECT 开头语句走 else 分支：
  `SELECT TOP (n) * FROM (/* 注释 */\nWITH ...) [dbx_page]`
  → CTE 被包进派生表 → SQL Server 156 语法错误；offset>0 的 ROW_NUMBER 包装同样非法。
- 不选区 normal 的原因：current 路径经 `find_statement_at_cursor` 切片（`executable_sql_bounds` 跳过前导注释），
  返回以 `WITH` 开头、无注释的语句 → 命中 CTE 保护分支 → 原样执行。
- 衍生：`build_count_query_sql` 在保护分支之前运行，对「注释+CTE」会产出
  `SELECT COUNT(*) FROM (WITH ...) [dbx_count]` 非法 count SQL（与纯 CTE 行为不一致）。

## 修复（最小，2 个文件）

- `crates/dbx-core/src/query_result_sql.rs`
  - `starts_with_cte`：先跳过空白/分号，再复用 `skip_leading_sql_comments`（跳过 `--` / `/* */`，
    含 optimizer hint / proxy / TDSQL 指令；SQL Server 无 `#` 注释，`#Temp` 不受影响）后判断是否 `WITH` 开头。
  - `build_query_pagination_execution_plan`：提前计算 `is_sqlserver_leading_cte`，
    对 SQL Server CTE 跳过 count 派生表包装（count_sql 保持 None，与纯 CTE 一致）；
    `session_id` 分页路径等其它逻辑保持不变。
- `apps/desktop/src/lib/__tests__/sql/sqlExecutionTarget.spec.ts`
  - 新增 SQL Server 选区「注释+CTE」原样透传锁定用例。

## 回归矩阵（先 FAIL 后 PASS，新增 9 后端 + 1 前端用例）

- 块注释、行注释、多行注释、内嵌+尾部注释、`;`+注释
- optimizer hint `/*+ MAXDOP(2) */`（语义保留）、proxy 指令 `/*proxy*/`、TDSQL 指令 `/*sets:allsets */`
- `#Temp` 临时表不被误判为注释/CTE
- 前导注释+普通 SELECT 仍正常 TOP 分页（不回归）

## 验证

- `cargo test -p dbx-core --lib query_result_sql`：157 passed / 0 failed（149 既有 + 8 新增）
  （构建环境：本机 openssl 构建需 perl，使用 D:\Git\usr\bin\perl.exe + miniconda OPENSSL_DIR；
   rustc 1.97.1 的 ICE 与本改动无关，用 CARGO_PROFILE_*_DEBUG=0 规避。）
- `pnpm vitest run src/lib/__tests__/sql/sqlExecutionTarget.spec.ts`：8 passed / 0 failed
- `git diff --check`：通过
- SQL Server live validation: **NOT RUN** —— 本机无 SQL Server 实例，团队共享测试库（dbx_test_db.xlsx）无 SQL Server 条目。

## 历史规避参考

- `e20669ddc` fix(sqlserver): execute cte queries without wrapping（引出 starts_with_cte，但未覆盖前导注释）
- `11c47d125` fix(sql): preserve leading hints through pagination（hint 保留）
- `3bd194679` fix(sqlserver): preserve temporary table names in statement ranges（#Temp 哈希注释）
