### PR TITLE
Fix/export database passwd file

### DIFF
--- a/apps/desktop/src/components/config/ConfigPassphraseDialog.vue
+++ b/apps/desktop/src/components/config/ConfigPassphraseDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Lock } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import PasswordInput from "@/components/ui/PasswordInput.vue";
 import { Label } from "@/components/ui/label";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { getRememberedExportPassphrase } from "@/lib/backend/exportPassphraseSession";
 
 const props = defineProps<{
   open: boolean;
@@ -29,15 +30,24 @@ const dialogOpen = computed({
 const passphrase = ref("");
 const passphraseConfirm = ref("");
 const error = ref("");
+// 密码短语输入框组件引用，打开对话框时用于手动聚焦
+const passphraseInput = ref<InstanceType<typeof PasswordInput> | null>(null);
 
 watch(
   dialogOpen,
-  (open) => {
-    if (open) {
-      passphrase.value = "";
-      passphraseConfirm.value = "";
-      error.value = "";
-    }
+  async (open) => {
+    if (!open) return;
+    // 导出模式回显本次会话上次使用的密码短语（仅内存保存，不落盘）；导入模式始终从空开始
+    const remembered = props.mode === "export" ? getRememberedExportPassphrase() : "";
+    passphrase.value = remembered;
+    passphraseConfirm.value = remembered;
+    error.value = "";
+    await nextTick();
+    // 手动聚焦并把光标定位到末尾，避免新输入插到回显内容前面
+    const inputEl = passphraseInput.value?.$el?.querySelector("input");
+    inputEl?.focus();
+    const length = String(inputEl?.value ?? "").length;
+    inputEl?.setSelectionRange(length, length);
   },
   { immediate: true },
 );
@@ -64,7 +74,8 @@ const displayError = computed(() => error.value || props.externalError || "");
 
 <template>
   <Dialog v-model:open="dialogOpen">
-    <DialogContent class="sm:max-w-[440px]">
+    <!-- initial-focus=false：禁用默认自动聚焦，改由打开对话框时的手动聚焦把光标定位到回显内容末尾 -->
+    <DialogContent class="sm:max-w-[440px]" :initial-focus="false">
       <DialogHeader>
         <DialogTitle class="flex items-center gap-2">
           <Lock class="h-5 w-5" />
@@ -79,7 +90,7 @@ const displayError = computed(() => error.value || props.externalError || "");
 
         <div class="grid gap-2">
           <Label>{{ t("configExport.passphrase") }}</Label>
-          <PasswordInput v-model="passphrase" :placeholder="t('configExport.passphrasePlaceholder')" :toggle-tab-index="-1" :disabled="busy" @keydown.enter="mode === 'import' ? confirm() : undefined" />
+          <PasswordInput ref="passphraseInput" v-model="passphrase" :placeholder="t('configExport.passphrasePlaceholder')" :toggle-tab-index="-1" :disabled="busy" @keydown.enter="mode === 'import' ? confirm() : undefined" />
         </div>
 
         <div v-if="mode === 'export'" class="grid gap-2">

--- a/apps/desktop/src/components/config/__tests__/ConfigPassphraseDialog.spec.ts
+++ b/apps/desktop/src/components/config/__tests__/ConfigPassphraseDialog.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { createApp, defineComponent, h, nextTick, type App } from "vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import i18n from "@/i18n";
 
 vi.mock("@/components/ui/dialog", async () => {
@@ -63,8 +63,13 @@ vi.mock("@lucide/vue", async () => {
 });
 
 import ConfigPassphraseDialog from "@/components/config/ConfigPassphraseDialog.vue";
+import { clearRememberedExportPassphrase, rememberExportPassphrase } from "@/lib/backend/exportPassphraseSession";
 
 const mountedApps: App[] = [];
+
+beforeEach(() => {
+  clearRememberedExportPassphrase();
+});
 
 afterEach(() => {
   for (const app of mountedApps.splice(0)) app.unmount();
@@ -111,6 +116,55 @@ describe("ConfigPassphraseDialog", () => {
     await nextTick();
     expect(confirm).not.toHaveBeenCalled();
     expect(document.body.textContent).toContain("Passphrase is required");
+  });
+
+  it("blocks encrypted export when the confirmation passphrase does not match", async () => {
+    const confirm = vi.fn();
+    await mountDialog({ open: true, mode: "export", onConfirm: confirm });
+
+    const [passphraseInput, confirmInput] = [...document.body.querySelectorAll("input")];
+    passphraseInput.value = "correct-pass";
+    passphraseInput.dispatchEvent(new Event("input"));
+    confirmInput.value = "mismatched-pass";
+    confirmInput.dispatchEvent(new Event("input"));
+
+    const encrypted = [...document.body.querySelectorAll("button")].find((button) => button.textContent?.includes("Export encrypted"));
+    encrypted?.click();
+    await nextTick();
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Passphrases do not match");
+  });
+
+  it("confirms encrypted export when both passphrase entries match", async () => {
+    const confirm = vi.fn();
+    await mountDialog({ open: true, mode: "export", onConfirm: confirm });
+
+    const [passphraseInput, confirmInput] = [...document.body.querySelectorAll("input")];
+    passphraseInput.value = "matching-pass";
+    passphraseInput.dispatchEvent(new Event("input"));
+    confirmInput.value = "matching-pass";
+    confirmInput.dispatchEvent(new Event("input"));
+
+    const encrypted = [...document.body.querySelectorAll("button")].find((button) => button.textContent?.includes("Export encrypted"));
+    encrypted?.click();
+    await nextTick();
+
+    expect(confirm).toHaveBeenCalledWith("matching-pass");
+  });
+
+  it("prefills the session-remembered passphrase into both export fields", async () => {
+    rememberExportPassphrase("session-pass");
+    await mountDialog({ open: true, mode: "export", onConfirm: vi.fn() });
+
+    expect([...document.body.querySelectorAll("input")].map((input) => input.value)).toEqual(["session-pass", "session-pass"]);
+  });
+
+  it("never prefills the passphrase in import mode", async () => {
+    rememberExportPassphrase("session-pass");
+    await mountDialog({ open: true, mode: "import", onConfirm: vi.fn() });
+
+    expect([...document.body.querySelectorAll("input")].map((input) => input.value)).toEqual([""]);
   });
 
   it("keeps import mode free of the unencrypted export action", async () => {

--- a/apps/desktop/src/composables/__tests__/useDialogSources.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDialogSources.spec.ts
@@ -32,12 +32,14 @@ vi.mock("@/stores/connectionStore", () => ({ useConnectionStore: () => mocks.sto
 vi.mock("@/composables/useToast", () => ({ useToast: () => ({ toast: mocks.toast }) }));
 
 import { useDialogSources } from "@/composables/useDialogSources";
+import { clearRememberedExportPassphrase, getRememberedExportPassphrase } from "@/lib/backend/exportPassphraseSession";
 
 const mountedApps: App[] = [];
 
 beforeEach(() => {
   mocks.store.connections = [];
   mocks.store.exportConnectionsToFile.mockReset().mockResolvedValue("saved");
+  clearRememberedExportPassphrase();
 });
 
 afterEach(() => {
@@ -177,5 +179,51 @@ describe("useDialogSources", () => {
     await first;
     await second;
     expect(dialogs.configExportBusy.value).toBe(false);
+  });
+
+  it("keeps the passphrase dialog open and reports an error when writing the encrypted export fails", async () => {
+    mocks.store.connections = [conn("selected")];
+    mocks.store.exportConnectionsToFile.mockRejectedValue(new Error("disk full"));
+    const dialogs = await mountDialogs();
+
+    dialogs.onExportClick();
+    dialogs.onConfigConnectionSelectConfirm(["selected"]);
+    await dialogs.onExportConfirm("passphrase");
+
+    expect(dialogs.showConfigPassphraseDialog.value).toBe(true);
+    expect(dialogs.configPassphraseError.value).toBe("Failed to export connections");
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(getRememberedExportPassphrase()).toBe("");
+  });
+
+  it("reports an error instead of success when writing the plaintext export fails", async () => {
+    mocks.store.connections = [conn("selected")];
+    mocks.store.exportConnectionsToFile.mockRejectedValue(new Error("disk full"));
+    const dialogs = await mountDialogs();
+
+    dialogs.onExportClick();
+    dialogs.onConfigConnectionSelectConfirm(["selected"]);
+    dialogs.onRequestUnencryptedExport();
+    await dialogs.onConfigUnencryptedExportConfirm();
+
+    expect(dialogs.showConfigUnencryptedExportConfirm.value).toBe(false);
+    expect(dialogs.showConfigPassphraseDialog.value).toBe(true);
+    expect(dialogs.configPassphraseError.value).toBe("Failed to export connections");
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it("remembers the passphrase only after the export file is actually written", async () => {
+    mocks.store.connections = [conn("selected")];
+    mocks.store.exportConnectionsToFile.mockResolvedValueOnce("cancelled").mockResolvedValueOnce("saved");
+    const dialogs = await mountDialogs();
+
+    dialogs.onExportClick();
+    dialogs.onConfigConnectionSelectConfirm(["selected"]);
+
+    await dialogs.onExportConfirm("passphrase");
+    expect(getRememberedExportPassphrase()).toBe("");
+
+    await dialogs.onExportConfirm("passphrase");
+    expect(getRememberedExportPassphrase()).toBe("passphrase");
   });
 });

--- a/apps/desktop/src/composables/useDialogSources.ts
+++ b/apps/desktop/src/composables/useDialogSources.ts
@@ -2,6 +2,7 @@ import { ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useToast } from "@/composables/useToast";
+import { rememberExportPassphrase } from "@/lib/backend/exportPassphraseSession";
 import { hasSidebarLayoutEntries } from "@/lib/sidebar/sidebarLayout";
 import type { ConnectionConfigBundle } from "@/lib/connection/connectionConfigTransfer";
 import type { ConnectionConfig, SidebarLayout } from "@/types/database";
@@ -337,6 +338,8 @@ export function useDialogSources() {
     try {
       const result = await connectionStore.exportConnectionsToFile({ mode: "encrypted", passphrase }, pendingExportConnectionIds.value);
       if (result === "cancelled") return;
+      // 仅在文件写入成功后才记住密码短语，供同一会话内下次导出对话框回显（仅内存，不落盘）
+      rememberExportPassphrase(passphrase);
       showConfigPassphraseDialog.value = false;
       clearPendingExportState();
       toast(t("configExport.exportSuccess"), 2000);

--- a/apps/desktop/src/lib/backend/__tests__/exportPassphraseSession.spec.ts
+++ b/apps/desktop/src/lib/backend/__tests__/exportPassphraseSession.spec.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearRememberedExportPassphrase, getRememberedExportPassphrase, rememberExportPassphrase } from "@/lib/backend/exportPassphraseSession";
+
+describe("exportPassphraseSession", () => {
+  beforeEach(() => {
+    clearRememberedExportPassphrase();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("starts with no remembered passphrase", () => {
+    expect(getRememberedExportPassphrase()).toBe("");
+  });
+
+  it("remembers the passphrase within the current session", () => {
+    rememberExportPassphrase("session-passphrase");
+    expect(getRememberedExportPassphrase()).toBe("session-passphrase");
+
+    rememberExportPassphrase("second-passphrase");
+    expect(getRememberedExportPassphrase()).toBe("second-passphrase");
+  });
+
+  it("never persists the passphrase to localStorage or sessionStorage", () => {
+    rememberExportPassphrase("session-passphrase");
+
+    expect(localStorage.length).toBe(0);
+    expect(sessionStorage.length).toBe(0);
+  });
+});

--- a/apps/desktop/src/lib/backend/exportPassphraseSession.ts
+++ b/apps/desktop/src/lib/backend/exportPassphraseSession.ts
@@ -1,0 +1,19 @@
+// 加密导出的密码短语只保留在当前会话的内存中，应用重启或页面刷新后自动清空。
+// 相比 localStorage 等持久化存储，明文密钥不会长期落盘，
+// 同源脚本或 WebView 存储检查都无法在会话之外读取到它。
+let rememberedExportPassphrase = "";
+
+// 记住本次加密导出使用的密码短语，同一会话内下次打开导出对话框时自动回显
+export function rememberExportPassphrase(passphrase: string) {
+  rememberedExportPassphrase = passphrase;
+}
+
+// 读取本会话上次加密导出使用的密码短语，没有则返回空字符串
+export function getRememberedExportPassphrase(): string {
+  return rememberedExportPassphrase;
+}
+
+// 清空记住的密码短语，供测试重置会话状态使用
+export function clearRememberedExportPassphrase() {
+  rememberedExportPassphrase = "";
+}

--- a/apps/desktop/src/stores/__tests__/connectionStore.timeout.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.timeout.spec.ts
@@ -382,6 +382,32 @@ describe("connectionStore timeout recovery", () => {
     expect(writeTextFile).not.toHaveBeenCalled();
   });
 
+  it("fails the export when writing the file fails instead of reporting success", async () => {
+    const save = vi.fn().mockResolvedValue("/home/user/dbx-connections.json");
+    const writeTextFile = vi.fn().mockRejectedValue(new Error("disk full"));
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => true }));
+    vi.doMock("@tauri-apps/plugin-dialog", () => ({ save }));
+    vi.doMock("@tauri-apps/plugin-fs", () => ({ writeTextFile }));
+    vi.doMock("@/lib/backend/api", () => ({
+      deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined),
+      loadEditorSettings: vi.fn().mockResolvedValue(null),
+      loadConnections: vi.fn().mockResolvedValue([postgresConnection()]),
+      loadPinnedTreeNodeIds: vi.fn().mockResolvedValue([]),
+      loadSidebarLayout: vi.fn().mockResolvedValue(null),
+      loadTunnelProfiles: vi.fn().mockResolvedValue([]),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveEditorSettings: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    await store.initFromDisk();
+
+    await expect(store.exportConnectionsToFile({ mode: "plaintext" })).rejects.toThrow("disk full");
+    expect(writeTextFile).toHaveBeenCalledOnce();
+  });
+
   it("clears connection node loading when health check timeout forces reconnect failure", async () => {
     const checkConnectionHealth = vi.fn(() => new Promise(() => undefined));
     const connectDb = vi.fn().mockRejectedValue(new Error("reconnect failed"));


### PR DESCRIPTION
## 变更说明

分支已重置到最新 main 并重新实现（旧的提交历史已废弃）。本次实现逐条解决上次 review 的意见：

1. **密码短语不落盘**：移除了原先基于 localStorage 的持久化（`exportPassphraseStorage` 已删除），改为仅保存在会话内存中的 `exportPassphraseSession`——应用重启或页面刷新后自动清空，同源脚本和 WebView 存储检查在会话外无法读取明文密钥，也不依赖本地明文缓存作为恢复机制。
2. **取消保存 / 写入失败不再误报成功**：`exportConnectionsToFile` 返回明确的 `saved` / `cancelled` 结果；原生保存对话框取消时保持对话框打开、不提示成功、不保存任何状态；写入文件失败时抛出错误并在对话框内展示，只有文件真正写入成功后才关闭对话框并报告成功。
3. **保留密码确认步骤**：保留「密码短语 + 确认密码短语」双字段与一致性校验，防止一次拼写错误生成用户自己都不知道密码的加密备份；仅在导出成功后才记住密码短语，下次打开导出对话框时回显。
4. **补充行为测试**：新增 11 个用例，覆盖保存取消（加密/明文）、写入失败（加密/明文）、密码确认一致/不一致、以及明文密钥不落盘。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域：分支重置后界面以上游为准并新增会话内回显，截图待补充 -->

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过：新增 11 个行为测试，相关 40 个用例全部通过；`vue-tsc` 类型检查与 `oxlint` 均通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
