### PR TITLE
chore(test): fix format drift blocking frontend CI on every PR

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.oneTimeCleanup.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.oneTimeCleanup.spec.ts
@@ -86,9 +86,7 @@ describe("connectionStore one_time runtime cleanup", () => {
   it("initFromDisk preserves an open one_time connection during a persisted-list reload", async () => {
     installApiMocks();
     const { loadConnections } = await import("@/lib/backend/api");
-    vi.mocked(loadConnections).mockResolvedValue([
-      previewConnection({ id: "saved-1", name: "Saved", one_time: false }),
-    ]);
+    vi.mocked(loadConnections).mockResolvedValue([previewConnection({ id: "saved-1", name: "Saved", one_time: false })]);
     const { useConnectionStore } = await import("@/stores/connectionStore");
     const store = useConnectionStore();
     store.connections = [previewConnection({ id: "deeplink-1", name: "Deeplink", one_time: true })];


### PR DESCRIPTION
## What

Re-runs `oxfmt` on `apps/desktop/src/stores/__tests__/connectionStore.oneTimeCleanup.spec.ts` — no logic change, formatting only.

## Why

`2196b743b` ("preserve one-time links across connection reloads") added this test file without matching the repo's `.oxfmtrc.json` (`printWidth: 300`). Since that commit landed on `main`, the frontend CI `format` check (`oxfmt --check`) fails on this file for every PR rebased on top of it — confirmed by checking out a clean `upstream/main` and running `oxfmt --check "apps/desktop/src/**/*.{ts,vue}"` directly, no other files affected.

This is currently breaking CI for unrelated PRs (e.g. #6667, #6675) that never touch this file.

## Test plan
- [x] `oxfmt --check "apps/desktop/src/**/*.{ts,vue}"` passes
- [x] `pnpm lint`, `pnpm typecheck` pass
- [x] `vitest run apps/desktop/src/stores/__tests__/connectionStore.oneTimeCleanup.spec.ts` — 7/7 tests still pass