### PR TITLE
Fix：AI 助手中 explain_query 执行计划画布溢出

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -2614,8 +2614,8 @@ async function openExternalUrl(url: string) {
                         <GitBranch class="h-3 w-3" />
                         {{ t("explain.title") }}
                       </Button>
-                      <div v-if="step.toolName === 'explain_query' && step.explainData && connection?.db_type" class="mb-1">
-                        <ExplainPlanViewer :plan="parseExplainFromData(step.explainData, connection.db_type)" class="max-h-64" />
+                      <div v-if="step.toolName === 'explain_query' && step.explainData && connection?.db_type" class="mb-1 h-64 overflow-hidden rounded border">
+                        <ExplainPlanViewer :plan="parseExplainFromData(step.explainData, connection.db_type)" />
                       </div>
                       <div v-else-if="step.isError && step.toolResult" class="text-[10px] text-red-600 dark:text-red-400">{{ step.toolResult }}</div>
                       <div v-else-if="step.toolResult" class="max-h-48 overflow-auto text-[10px] text-muted-foreground whitespace-pre-wrap">{{ step.toolResult }}</div>

--- a/apps/desktop/src/components/editor/__tests__/AiAssistant.explainPlanContainment.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/AiAssistant.explainPlanContainment.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../AiAssistant.vue", import.meta.url), "utf8");
+
+describe("AI assistant explain_query canvas containment", () => {
+  it("bounds the embedded ExplainPlanViewer to a fixed, clipped height", () => {
+    const match = source.match(/<div v-if="step\.toolName === 'explain_query' && step\.explainData[^>]*class="([^"]*)"/);
+    expect(match, "explain_query wrapper div not found").not.toBeNull();
+    const wrapperClass = match![1];
+    expect(wrapperClass).toContain("h-64");
+    expect(wrapperClass).toContain("overflow-hidden");
+  });
+
+  it("does not rely on an unresolvable max-height alone to contain the canvas", () => {
+    expect(source).not.toContain('<ExplainPlanViewer :plan="parseExplainFromData(step.explainData, connection.db_type)" class="max-h-64" />');
+  });
+});

--- a/apps/desktop/src/components/explain/ExplainPlanViewer.vue
+++ b/apps/desktop/src/components/explain/ExplainPlanViewer.vue
@@ -72,18 +72,20 @@ function tableCellText(value: unknown): string {
 
 <template>
   <div class="flex h-full min-h-0 flex-col bg-background">
-    <div class="h-9 shrink-0 border-b px-3 flex items-center gap-2 text-xs">
-      <span class="inline-flex items-center gap-1 rounded border bg-muted px-2 py-0.5 font-medium">
+    <div class="h-9 shrink-0 border-b px-3 flex items-center gap-2 text-xs overflow-x-auto overflow-y-hidden">
+      <span class="shrink-0 whitespace-nowrap inline-flex items-center gap-1 rounded border bg-muted px-2 py-0.5 font-medium">
         <GitBranch class="h-3.5 w-3.5" />
         {{ t("explain.title") }}
       </span>
-      <span v-if="plan || hasTableView" class="text-muted-foreground">
+      <span v-if="plan || hasTableView" class="shrink-0 whitespace-nowrap text-muted-foreground">
         {{ plan?.databaseType.toUpperCase() || "MYSQL" }}<template v-if="plan"> · {{ t("explain.nodeCount", { count: nodeCount }) }}</template>
       </span>
-      <span v-if="plan?.databaseType === 'dameng' && isRawString && rawContent.includes('->')" class="ml-1 inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300" style="font-size: 10px">A-TRACE</span>
-      <span v-if="measuredRowsLabel" class="ml-1 inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300" style="font-size: 10px">{{ measuredRowsLabel }}</span>
-      <span class="flex-1" />
-      <div v-if="plan || hasTableView" class="inline-flex rounded-md border bg-muted/40 p-0.5">
+      <span v-if="plan?.databaseType === 'dameng' && isRawString && rawContent.includes('->')" class="shrink-0 whitespace-nowrap ml-1 inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300" style="font-size: 10px"
+        >A-TRACE</span
+      >
+      <span v-if="measuredRowsLabel" class="shrink-0 whitespace-nowrap ml-1 inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300" style="font-size: 10px">{{ measuredRowsLabel }}</span>
+      <span class="flex-1 min-w-2" />
+      <div v-if="plan || hasTableView" class="shrink-0 inline-flex rounded-md border bg-muted/40 p-0.5">
         <Button v-if="plan" size="sm" :variant="activeView === 'canvas' ? 'secondary' : 'ghost'" class="h-6 px-2 text-xs gap-1" @click="activeView = 'canvas'">
           <Workflow class="h-3.5 w-3.5" />
           {{ t("explain.canvas") }}

--- a/apps/desktop/src/components/explain/__tests__/ExplainPlanViewer.spec.ts
+++ b/apps/desktop/src/components/explain/__tests__/ExplainPlanViewer.spec.ts
@@ -44,3 +44,21 @@ describe("ExplainPlanViewer canvas view", () => {
     expect(tabOrder).toEqual(["canvas", "tree", "summary", "raw", "table"]);
   });
 });
+
+describe("ExplainPlanViewer header at narrow widths", () => {
+  it("keeps the title badge and node-count label on one line instead of letting them wrap", () => {
+    const headerMatch = viewerSource.match(/<div class="h-9 shrink-0[^"]*"[^>]*>([\s\S]*?)<\/div>\s*\n\s*<div v-if="loading/);
+    expect(headerMatch, "explain plan header block not found").not.toBeNull();
+    const header = headerMatch![0];
+    expect(header).toContain("overflow-x-auto");
+    // Title badge and "MYSQL · N nodes" label must not be flex-shrinkable, or a
+    // narrow host (e.g. the AI chat panel) squeezes their text into a
+    // near-zero width and the browser wraps it one character per line.
+    expect(header).toMatch(/<span class="shrink-0 whitespace-nowrap inline-flex[^"]*">\s*<GitBranch/);
+    expect(header).toMatch(/<span v-if="plan \|\| hasTableView" class="shrink-0 whitespace-nowrap text-muted-foreground">/);
+  });
+
+  it("keeps the view-switcher button group from shrinking away", () => {
+    expect(viewerSource).toContain('<div v-if="plan || hasTableView" class="shrink-0 inline-flex rounded-md border bg-muted/40 p-0.5">');
+  });
+});


### PR DESCRIPTION
## 问题

在 AI 助手窗口中，工具调用 `explain_query`（执行计划分析）完成后，展开该工具调用步骤会显示一个内嵌的执行计划画布。该画布没有被正确限制在自己的消息气泡内：标题栏文字（如 "MySQL · N nodes"）会被压缩成逐字符竖排的乱码，且整个画布内容会溢出、压住下方的 AI 回复文本和 token 统计行。其他类型的工具调用结果显示正常。

## 根因

`AiAssistant.vue` 中嵌入的 `<ExplainPlanViewer class="max-h-64">`，其根节点使用百分比高度 `h-full`，但外层包裹 `div` 既没有具体（非百分比）高度、也没有 `overflow` 裁剪。`max-height` 只限制自身盒子大小，不会裁剪溢出的子内容；`h-full` 在没有定高祖先的情况下会退化成 `auto`，导致画布按内容自然大小渲染，从而溢出。

## 修复

1. 把包裹 `div` 改为具体的 `h-64 overflow-hidden`，使 `ExplainPlanViewer` 内部的 `h-full` 能正确解析出 256px 高度，其自身既有的 `flex-1/min-h-0/overflow-auto` 内容裁剪链路随之正常工作。
2. 顺带修复了同一根因下暴露出的次要问题：`ExplainPlanViewer.vue` 头部工具栏（标题徽标、"MySQL · N nodes" 文字、画布/树/摘要/JSON 切换按钮组）默认允许 `flex-shrink`、未设 `whitespace-nowrap`，在 AI 面板这种窄宽度下文字被压缩到逐字符换行；改为 `shrink-0 whitespace-nowrap` + 头部 `overflow-x-auto`，窄宽度下改为横向滚动而不是纵向断行乱码。

**已知范围外的次要问题**：画布视图本身（节点图 + 右侧详情面板）在极窄宽度下仍然比较拥挤，这是更大范围的"窄屏响应式重排"问题，未在本次处理，仅解决本 issue 报告的"溢出到其他消息"这个具体缺陷。

## 验证

- 新增回归测试：`AiAssistant.explainPlanContainment.spec.ts`（新文件）+ `ExplainPlanViewer.spec.ts` 新增 describe 块，通过 `git stash`/`git stash pop` 切换代码状态验证：revert 后 4 个新断言全部真实失败，reapply 后全部通过。
- 真实复现：独立 `dbx-web` dev 后端 + 独立 MySQL 测试库 + 自建本地 OpenAI-compatible stub HTTP 服务模拟 AI 回复，真实走 Agent 模式发消息触发 `explain_query` 工具调用（对目标表执行真实 EXPLAIN），Playwright 驱动真实浏览器截图对比：
  - 修复前：标题栏文字乱码、画布内容压住下方 AI 回复文本
  - 修复后：标题栏单行清晰，画布内容收纳在固定高度盒子内，不再遮挡后续内容
- 全量 `pnpm exec vitest run apps/desktop/src`：759 文件 / 7117 测试全绿
- `pnpm typecheck` / `pnpm lint` 干净
- 已 rebase 到最新 upstream/main，无冲突复测通过

Fixes #6650

🤖 Generated with [Claude Code](https://claude.com/claude-code)