### PR TITLE
feat(dbx-core): 支持 MySQL 表维护语句返回结果集

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -5289,9 +5289,14 @@ fn prefers_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
 }
 
 pub(crate) fn is_result_set_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
+    // MySQL 的表维护语句虽然不是 SELECT，但服务器会返回包含表名和执行结果的表格。
+    // 如果把它们当成普通写入语句，后续 drop_result 会直接丢弃这些返回行。
     starts_with_executable_sql_keyword_for_database(
         sql,
-        &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL", "CHECKSUM"],
+        &[
+            "SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL", "CHECKSUM", "ANALYZE", "CHECK", "OPTIMIZE",
+            "REPAIR",
+        ],
         DatabaseType::Mysql,
     ) || mysql_statement_returns_rows(sql)
         || is_xa_recover_query(sql)
@@ -6088,11 +6093,19 @@ mod tests {
     }
 
     #[test]
-    fn mysql_checksum_queries_are_treated_as_result_sets() {
+    fn mysql_table_maintenance_queries_are_treated_as_result_sets() {
         let dialect = MySqlQueryDialect::default();
 
-        assert!(is_result_set_query("CHECKSUM TABLE `issue6693_repro`", dialect));
-        assert!(prefers_text_protocol_query("CHECKSUM TABLE `issue6693_repro`", dialect));
+        for sql in [
+            "CHECKSUM TABLE `users`;",
+            "analyze table users",
+            "-- 检查表状态\nCHECK TABLE users",
+            "/* 整理表 */ OPTIMIZE TABLE users",
+            "repair table users quick",
+        ] {
+            assert!(is_result_set_query(sql, dialect), "{sql}");
+            assert!(prefers_text_protocol_query(sql, dialect), "{sql}");
+        }
     }
 
     #[test]

--- a/crates/dbx-core/src/query_execution_sql.rs
+++ b/crates/dbx-core/src/query_execution_sql.rs
@@ -211,7 +211,7 @@ pub fn contains_dangerous_sql_keyword(sql: &str) -> bool {
 /// PRAGMA is intentionally NOT in this list because some PRAGMA statements modify
 /// database or session state (e.g. SQLite `PRAGMA journal_mode=WAL`). Instead,
 /// read-only PRAGMA forms are handled separately in `is_safe_read_pragma`.
-const READ_SQL_KEYWORDS: &[&str] = &["SELECT", "WITH", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "FROM", "CHECKSUM"];
+const READ_SQL_KEYWORDS: &[&str] = &["SELECT", "WITH", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "FROM"];
 
 /// PRAGMA names that are known to be safe read-only queries in SQLite/DuckDB.
 /// Only the function-call form `PRAGMA name(args)` matching these names is allowed.
@@ -360,9 +360,10 @@ fn is_write_sql_with_database_type(sql: &str, database_type: Option<DatabaseType
         None => crate::sql::split_sql_statements(sql),
     };
 
-    statements
-        .iter()
-        .any(|statement| is_write_sql_statement(statement, detect_mysql_executable_comments, detect_select_into))
+    let allow_mysql_checksum = database_type == Some(DatabaseType::Mysql);
+    statements.iter().any(|statement| {
+        is_write_sql_statement(statement, detect_mysql_executable_comments, detect_select_into, allow_mysql_checksum)
+    })
 }
 
 /// The explain flows toggle plan capture with a standalone SET statement:
@@ -448,7 +449,12 @@ fn contains_unquoted_keyword(sql: &str, dialect: &dyn sqlparser::dialect::Dialec
     })
 }
 
-fn is_write_sql_statement(sql: &str, detect_mysql_executable_comments: bool, detect_select_into: bool) -> bool {
+fn is_write_sql_statement(
+    sql: &str,
+    detect_mysql_executable_comments: bool,
+    detect_select_into: bool,
+    allow_mysql_checksum: bool,
+) -> bool {
     // 1. Strip comments and string literals
     let (cleaned, has_mysql_executable_comment) =
         strip_sql_comments_and_literals_with_metadata(sql, detect_mysql_executable_comments);
@@ -468,7 +474,7 @@ fn is_write_sql_statement(sql: &str, detect_mysql_executable_comments: bool, det
     // 2. Check if first keyword is a read keyword
     let starts_with_read = READ_SQL_KEYWORDS.iter().any(|kw| {
         upper.starts_with(kw) && (upper.len() == kw.len() || !upper.as_bytes()[kw.len()].is_ascii_alphanumeric())
-    });
+    }) || (allow_mysql_checksum && starts_with_keyword(&upper, "CHECKSUM TABLE"));
 
     // 3. Special handling for PRAGMA: only allow safe read-only forms
     if !starts_with_read && starts_with_keyword(&upper, "PRAGMA") {
@@ -1288,7 +1294,6 @@ mod tests {
         assert!(!is_write_sql("EXPLAIN SELECT * FROM users"));
         assert!(!is_write_sql("PRAGMA table_info(users)"));
         assert!(!is_write_sql("FROM users SELECT *"));
-        assert!(!is_write_sql("CHECKSUM TABLE `issue6693_repro`"));
     }
 
     #[test]
@@ -1545,6 +1550,14 @@ mod tests {
             check_read_only("SHOW CREATE TABLE users; DELETE FROM users", "prod-db", DatabaseType::Mysql);
         assert!(show_create_err.is_err());
         assert!(show_create_err.unwrap_err().contains("Write operation"));
+    }
+
+    #[test]
+    fn check_read_only_allows_mysql_checksum_only_for_mysql() {
+        assert_eq!(check_read_only("CHECKSUM TABLE `issue6693_repro`", "mysql", DatabaseType::Mysql), Ok(()));
+        assert!(check_read_only("CHECKSUM TABLE users", "postgres", DatabaseType::Postgres).is_err());
+        assert!(check_read_only("CHECKSUM TABLE users", "sqlite", DatabaseType::Sqlite).is_err());
+        assert!(check_read_only("CHECKSUM TABLE users; DROP TABLE users", "mysql", DatabaseType::Mysql).is_err());
     }
 
     #[test]

--- a/crates/dbx-core/tests/live_mysql57.rs
+++ b/crates/dbx-core/tests/live_mysql57.rs
@@ -103,6 +103,30 @@ async fn live_mysql57_text_protocol_select_succeeds() {
 }
 
 #[tokio::test]
+#[ignore = "requires the remote DBX MySQL 5.7 smoke-test container"]
+async fn live_mysql57_checksum_table_returns_native_result_set() {
+    let url = std::env::var("DBX_LIVE_MYSQL57_URL").expect("DBX_LIVE_MYSQL57_URL");
+    let pool = dbx_core::db::mysql::connect(&url, std::time::Duration::from_secs(5)).await.unwrap();
+
+    // 使用部署脚本预置的表验证 MySQL 5.7 原生 CHECKSUM TABLE 返回值没有被执行器丢弃。
+    let result = dbx_core::db::mysql::execute_query_with_max_rows(
+        &pool,
+        "CHECKSUM TABLE `dbx_smoke`",
+        false,
+        Some(10),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.columns, vec!["Table", "Checksum"]);
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].len(), 2);
+    assert!(result.rows[0][0].as_str().is_some_and(|table| table.ends_with(".dbx_smoke")));
+    assert!(!result.rows[0][1].is_null());
+}
+
+#[tokio::test]
 #[ignore = "requires a MySQL endpoint that permits stored procedure creation"]
 async fn live_mysql_stored_procedure_preserves_all_result_sets() {
     let url = std::env::var("DBX_LIVE_MYSQL57_URL").expect("DBX_LIVE_MYSQL57_URL");


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
- 添加了对 CHECKSUM、ANALYZE、CHECK、OPTIMIZE 和 REPAIR 语句的支持
- 修改 is_result_set_query 函数以正确识别表维护命令的结果集
- 添加注释说明 MySQL 表维护语句返回表格数据的特殊处理逻辑
- 新增测试用例验证表维护查询被正确识别为结果集
- 添加集成测试验证 CHECKSUM TABLE 在 MySQL 5.7 中返回原生结果集
- 确保表维护语句使用文本协议而不是被当作普通写入语句丢弃

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="3317" height="1477" alt="20260819173104" src="https://github.com/user-attachments/assets/da11989d-fa6f-496e-85da-05b54f65397b" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #6693 