### PR TITLE
fix(mysql): return CHECKSUM TABLE result set instead of dropping it

### DIFF
--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -5291,7 +5291,7 @@ fn prefers_text_protocol_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
 pub(crate) fn is_result_set_query(sql: &str, dialect: MySqlQueryDialect) -> bool {
     starts_with_executable_sql_keyword_for_database(
         sql,
-        &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL"],
+        &["SELECT", "SHOW", "DESCRIBE", "EXPLAIN", "WITH", "CALL", "CHECKSUM"],
         DatabaseType::Mysql,
     ) || mysql_statement_returns_rows(sql)
         || is_xa_recover_query(sql)
@@ -6085,6 +6085,14 @@ mod tests {
     #[test]
     fn mysql_desc_queries_are_treated_as_result_sets() {
         assert!(is_result_set_query("DESC users", MySqlQueryDialect::default()));
+    }
+
+    #[test]
+    fn mysql_checksum_queries_are_treated_as_result_sets() {
+        let dialect = MySqlQueryDialect::default();
+
+        assert!(is_result_set_query("CHECKSUM TABLE `issue6693_repro`", dialect));
+        assert!(prefers_text_protocol_query("CHECKSUM TABLE `issue6693_repro`", dialect));
     }
 
     #[test]

--- a/crates/dbx-core/src/query_execution_sql.rs
+++ b/crates/dbx-core/src/query_execution_sql.rs
@@ -211,7 +211,7 @@ pub fn contains_dangerous_sql_keyword(sql: &str) -> bool {
 /// PRAGMA is intentionally NOT in this list because some PRAGMA statements modify
 /// database or session state (e.g. SQLite `PRAGMA journal_mode=WAL`). Instead,
 /// read-only PRAGMA forms are handled separately in `is_safe_read_pragma`.
-const READ_SQL_KEYWORDS: &[&str] = &["SELECT", "WITH", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "FROM"];
+const READ_SQL_KEYWORDS: &[&str] = &["SELECT", "WITH", "SHOW", "DESCRIBE", "DESC", "EXPLAIN", "FROM", "CHECKSUM"];
 
 /// PRAGMA names that are known to be safe read-only queries in SQLite/DuckDB.
 /// Only the function-call form `PRAGMA name(args)` matching these names is allowed.
@@ -1288,6 +1288,7 @@ mod tests {
         assert!(!is_write_sql("EXPLAIN SELECT * FROM users"));
         assert!(!is_write_sql("PRAGMA table_info(users)"));
         assert!(!is_write_sql("FROM users SELECT *"));
+        assert!(!is_write_sql("CHECKSUM TABLE `issue6693_repro`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `is_result_set_query`'s keyword allow-list (`SELECT`/`SHOW`/`DESCRIBE`/`EXPLAIN`/`WITH`/`CALL`) did not include `CHECKSUM`, so `CHECKSUM TABLE \`t\`;` was routed through the non-result-set execution path in `execute_query_on_conn_with_limits`, which reads only `affected_rows`/warnings/info and explicitly calls `drop_result()` — discarding the one-row `Table`/`Checksum` result set MySQL actually returns. The UI ended up showing an empty/no result.
- Added `CHECKSUM` to that allow-list so the result set is parsed and returned normally, same pattern already used for `SHOW`/`DESCRIBE`/`EXPLAIN`.
- Also added `CHECKSUM` to `READ_SQL_KEYWORDS` in `query_execution_sql.rs`, since the same missing keyword caused `CHECKSUM TABLE` to be misclassified as a **write** statement by the production-safety guard, even though it's a read-only diagnostic command.
- Added unit tests covering both keyword lists.

Fixes #6693

## Test plan

- [x] `cargo test -p dbx-core --lib -- is_write_sql result_set checksum` — 42 tests pass, including new assertions, no regressions to existing `SHOW`/`DESCRIBE`/`EXPLAIN`/`ADMIN SHOW` classification tests.
- [x] Real repro against a live MySQL 5.7.44 instance through `dbx-web` dev backend + web frontend: before the fix, `CHECKSUM TABLE` executed with "Success" but returned 0 rows in the UI; after the fix, the UI shows `Table: dbx_test.issue6693_repro`, `Checksum: 3770035346`, matching the native `mysql` CLI output for the same command exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)