### PR TITLE
fix: 开启SQL语义诊断后PostgreSQL CREATE OR REPLACE PROCEDURE 不再误报解析错误

### DIFF
--- a/crates/dbx-core/src/sql_analysis.rs
+++ b/crates/dbx-core/src/sql_analysis.rs
@@ -24,9 +24,6 @@ static CLICKHOUSE_STRICTNESS_FIRST_JOIN_RE: LazyLock<Regex> = LazyLock::new(|| {
 static POSTGRES_DEFAULT_PRIVILEGES_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)^\s*ALTER\s+DEFAULT\s+PRIVILEGES\b").expect("valid PostgreSQL default privileges regex")
 });
-static POSTGRES_CREATE_PROCEDURE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\b").expect("valid PostgreSQL create procedure regex")
-});
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SqlReferenceAnalysis {
@@ -102,7 +99,7 @@ pub fn analyze_sql_references(sql: &str, dialect: Option<&str>) -> Result<SqlRef
         sql.to_string()
     };
 
-    let statements = match normalized_dialect.as_str() {
+    let parsed_statements = match normalized_dialect.as_str() {
         "postgres" => Parser::parse_sql(&PostgreSqlDialect {}, &parser_sql),
         "mysql" => Parser::parse_sql(&MySqlDialect {}, &parser_sql),
         "sqlite" => Parser::parse_sql(&SQLiteDialect {}, &parser_sql),
@@ -110,8 +107,21 @@ pub fn analyze_sql_references(sql: &str, dialect: Option<&str>) -> Result<SqlRef
         "clickhouse" => Parser::parse_sql(&ClickHouseDialect {}, &parser_sql),
         "duckdb" => Parser::parse_sql(&DuckDbDialect {}, &parser_sql),
         _ => Parser::parse_sql(&GenericDialect {}, &parser_sql),
-    }
-    .map_err(|err| err.to_string())?;
+    };
+    let statements = match parsed_statements {
+        Ok(statements) => {
+            if normalized_dialect == "postgres" && postgres_create_procedure_is_missing_body(&parser_sql) {
+                return Err("Expected: procedure body after AS, found: EOF".to_string());
+            }
+            statements
+        }
+        Err(error)
+            if normalized_dialect == "postgres" && is_postgres_create_procedure_parser_gap(&parser_sql, &error) =>
+        {
+            return Ok(SqlReferenceAnalysis { tables: vec![], columns: vec![], scopes: vec![] });
+        }
+        Err(error) => return Err(error.to_string()),
+    };
 
     let mut analyzer = Analyzer { is_sqlserver: normalized_dialect == "sqlserver", ..Analyzer::default() };
     for statement in statements {
@@ -546,11 +556,190 @@ fn starts_with_duckdb_parser_gap_sql(sql: &str) -> bool {
 }
 
 fn starts_with_postgres_parser_gap_sql(sql: &str) -> bool {
-    // sqlparser's Postgres CREATE PROCEDURE support can't parse the dollar-quoted plpgsql
-    // bodies Postgres itself requires (`AS $$ ... $$`), and separately rejects `OR REPLACE`
-    // before ever reaching the PROCEDURE keyword. Both are upstream parser gaps, not real
-    // syntax errors, so skip diagnostics rather than show a false "sql parser error".
-    POSTGRES_DEFAULT_PRIVILEGES_RE.is_match(sql) || POSTGRES_CREATE_PROCEDURE_RE.is_match(sql)
+    POSTGRES_DEFAULT_PRIVILEGES_RE.is_match(sql)
+}
+
+struct PostgresCreateProcedureLayout {
+    tokens: Vec<TokenWithSpan>,
+    significant_indexes: Vec<usize>,
+    or_replace_indexes: Option<[usize; 2]>,
+    parameters_open_position: usize,
+    parameters_close_position: usize,
+}
+
+fn postgres_create_procedure_layout(sql: &str) -> Option<PostgresCreateProcedureLayout> {
+    let dialect = PostgreSqlDialect {};
+    let tokens = Tokenizer::new(&dialect, sql).tokenize_with_location().ok()?;
+    let significant_indexes: Vec<usize> = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, token)| (!matches!(token.token, Token::Whitespace(_))).then_some(index))
+        .collect();
+    let mut position = 0;
+
+    if significant_indexes.get(position).and_then(|index| token_keyword(&tokens[*index])) != Some(Keyword::CREATE) {
+        return None;
+    }
+    position += 1;
+
+    let or_replace_indexes = if significant_indexes.get(position).and_then(|index| token_keyword(&tokens[*index]))
+        == Some(Keyword::OR)
+        && significant_indexes.get(position + 1).and_then(|index| token_keyword(&tokens[*index]))
+            == Some(Keyword::REPLACE)
+    {
+        let indexes = [significant_indexes[position], significant_indexes[position + 1]];
+        position += 2;
+        Some(indexes)
+    } else {
+        None
+    };
+
+    if significant_indexes.get(position).and_then(|index| token_keyword(&tokens[*index])) != Some(Keyword::PROCEDURE) {
+        return None;
+    }
+    position += 1;
+
+    if !matches!(tokens[significant_indexes.get(position).copied()?].token, Token::Word(_)) {
+        return None;
+    }
+    position += 1;
+    while matches!(significant_indexes.get(position).map(|index| &tokens[*index].token), Some(Token::Period)) {
+        position += 1;
+        if !matches!(tokens[significant_indexes.get(position).copied()?].token, Token::Word(_)) {
+            return None;
+        }
+        position += 1;
+    }
+
+    let parameters_open_index = significant_indexes.get(position).copied()?;
+    if !matches!(tokens[parameters_open_index].token, Token::LParen) {
+        return None;
+    }
+    let parameters_close_index = matching_parenthesis_index(&tokens, parameters_open_index)?;
+    let parameters_close_position = significant_indexes.iter().position(|index| *index == parameters_close_index)?;
+    if !postgres_procedure_parameters_are_nonempty(&tokens, &significant_indexes, position, parameters_close_position) {
+        return None;
+    }
+
+    Some(PostgresCreateProcedureLayout {
+        tokens,
+        significant_indexes,
+        or_replace_indexes,
+        parameters_open_position: position,
+        parameters_close_position,
+    })
+}
+
+fn postgres_procedure_parameters_are_nonempty(
+    tokens: &[TokenWithSpan],
+    significant_indexes: &[usize],
+    open_position: usize,
+    close_position: usize,
+) -> bool {
+    if close_position == open_position + 1 {
+        return true;
+    }
+
+    let mut depth = 1;
+    let mut parameter_has_tokens = false;
+    for index in significant_indexes.iter().take(close_position).skip(open_position + 1).copied() {
+        match tokens[index].token {
+            Token::LParen => {
+                depth += 1;
+                parameter_has_tokens = true;
+            }
+            Token::RParen => depth -= 1,
+            Token::Comma if depth == 1 => {
+                if !parameter_has_tokens {
+                    return false;
+                }
+                parameter_has_tokens = false;
+            }
+            _ if depth == 1 => parameter_has_tokens = true,
+            _ => {}
+        }
+    }
+    parameter_has_tokens
+}
+
+fn postgres_create_procedure_is_missing_body(sql: &str) -> bool {
+    let Some(layout) = postgres_create_procedure_layout(sql) else {
+        return false;
+    };
+    let mut tail = &layout.significant_indexes[layout.parameters_close_position + 1..];
+    while let Some(index) = tail.last() {
+        if matches!(layout.tokens[*index].token, Token::SemiColon) {
+            tail = &tail[..tail.len() - 1];
+        } else {
+            break;
+        }
+    }
+    tail.last().and_then(|index| token_keyword(&layout.tokens[*index])) == Some(Keyword::AS)
+}
+
+fn is_postgres_create_procedure_parser_gap(sql: &str, error: &ParserError) -> bool {
+    let Some(mut layout) = postgres_create_procedure_layout(sql) else {
+        return false;
+    };
+    let Some(body_position) =
+        (layout.parameters_close_position + 1..layout.significant_indexes.len()).find(|position| {
+            matches!(layout.tokens[layout.significant_indexes[*position]].token, Token::DollarQuotedString(_))
+        })
+    else {
+        return false;
+    };
+    let as_index = layout.significant_indexes[body_position - 1];
+    if token_keyword(&layout.tokens[as_index]) != Some(Keyword::AS) {
+        return false;
+    }
+    let trailing = &layout.significant_indexes[body_position + 1..];
+    if !(trailing.is_empty() || trailing.len() == 1 && matches!(layout.tokens[trailing[0]].token, Token::SemiColon)) {
+        return false;
+    }
+
+    let ParserError::ParserError(message) = error else {
+        return false;
+    };
+    let error_matches_gap = if layout.or_replace_indexes.is_some() {
+        message.starts_with(
+            "Expected: [EXTERNAL] TABLE or [MATERIALIZED] VIEW or FUNCTION after CREATE OR REPLACE, found: PROCEDURE at ",
+        )
+    } else {
+        message.starts_with(&format!(
+            "Expected: an SQL statement, found: {} at ",
+            layout.tokens[layout.significant_indexes[body_position]]
+        ))
+    };
+    if !error_matches_gap {
+        return false;
+    }
+
+    let mut depth = 1;
+    for position in layout.parameters_open_position + 1..layout.parameters_close_position {
+        let index = layout.significant_indexes[position];
+        match layout.tokens[index].token {
+            Token::LParen => depth += 1,
+            Token::RParen => depth -= 1,
+            _ if depth == 1 && token_keyword(&layout.tokens[index]) == Some(Keyword::DEFAULT) => {
+                layout.tokens[index].token = Token::Eq;
+            }
+            _ => {}
+        }
+    }
+
+    let dialect = PostgreSqlDialect {};
+    let body_index = layout.significant_indexes[body_position];
+    let replacement = match Tokenizer::new(&dialect, "BEGIN SELECT 1; END").tokenize_with_location() {
+        Ok(tokens) => tokens,
+        Err(_) => return false,
+    };
+    layout.tokens.splice(body_index..=body_index, replacement);
+    if let Some([or_index, replace_index]) = layout.or_replace_indexes {
+        layout.tokens.remove(replace_index);
+        layout.tokens.remove(or_index);
+    }
+
+    Parser::new(&dialect).with_tokens_with_locations(layout.tokens).parse_statements().is_ok()
 }
 
 fn normalize_clickhouse_join_order_for_parser(sql: &str) -> String {

--- a/crates/dbx-core/src/sql_analysis.rs
+++ b/crates/dbx-core/src/sql_analysis.rs
@@ -24,6 +24,9 @@ static CLICKHOUSE_STRICTNESS_FIRST_JOIN_RE: LazyLock<Regex> = LazyLock::new(|| {
 static POSTGRES_DEFAULT_PRIVILEGES_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)^\s*ALTER\s+DEFAULT\s+PRIVILEGES\b").expect("valid PostgreSQL default privileges regex")
 });
+static POSTGRES_CREATE_PROCEDURE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\b").expect("valid PostgreSQL create procedure regex")
+});
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SqlReferenceAnalysis {
@@ -543,7 +546,11 @@ fn starts_with_duckdb_parser_gap_sql(sql: &str) -> bool {
 }
 
 fn starts_with_postgres_parser_gap_sql(sql: &str) -> bool {
-    POSTGRES_DEFAULT_PRIVILEGES_RE.is_match(sql)
+    // sqlparser's Postgres CREATE PROCEDURE support can't parse the dollar-quoted plpgsql
+    // bodies Postgres itself requires (`AS $$ ... $$`), and separately rejects `OR REPLACE`
+    // before ever reaching the PROCEDURE keyword. Both are upstream parser gaps, not real
+    // syntax errors, so skip diagnostics rather than show a false "sql parser error".
+    POSTGRES_DEFAULT_PRIVILEGES_RE.is_match(sql) || POSTGRES_CREATE_PROCEDURE_RE.is_match(sql)
 }
 
 fn normalize_clickhouse_join_order_for_parser(sql: &str) -> String {

--- a/crates/dbx-core/tests/sql_analysis.rs
+++ b/crates/dbx-core/tests/sql_analysis.rs
@@ -650,12 +650,28 @@ fn sqlserver_option_functions_and_invalid_hints_are_not_suppressed() {
 fn postgres_create_procedure_bodies_do_not_raise_syntax_errors() {
     let or_replace_with_default_param = "CREATE OR REPLACE PROCEDURE dwd.lzshklx_batch_update_device_id(\n    p_batch_size INT DEFAULT 100,\n    p_total_batches INT DEFAULT NULL\n)\nLANGUAGE plpgsql\nAS $$\nDECLARE\n    v_affected_rows INT;\nBEGIN\n    NULL;\nEND;\n$$;";
     let plain_dollar_quoted = "CREATE PROCEDURE dwd.foo(p_id INT) LANGUAGE plpgsql AS $tag$ BEGIN NULL; END; $tag$;";
+    let block_comment_separated = "CREATE /* create */ OR /* or */ REPLACE /* replace */ PROCEDURE dwd.foo() LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$;";
+    let line_comment_separated = "CREATE -- create\nOR -- or\nREPLACE -- replace\nPROCEDURE dwd.foo() LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$;";
 
-    for sql in [or_replace_with_default_param, plain_dollar_quoted] {
+    for sql in [or_replace_with_default_param, plain_dollar_quoted, block_comment_separated, line_comment_separated] {
         let analysis = analyze_sql_references(sql, Some("postgres"))
             .expect("postgres CREATE PROCEDURE should not surface a false parser error");
         assert!(analysis.tables.is_empty());
         assert!(analysis.columns.is_empty());
+    }
+}
+
+#[test]
+fn postgres_create_procedure_syntax_errors_are_not_suppressed() {
+    for sql in [
+        "CREATE PROCEDURE",
+        "CREATE PROCEDURE dwd.foo() LANGUAGE plpgsql AS",
+        "CREATE OR REPLACE PROCEDURE dwd.foo(p_id INT,, p_name TEXT) LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$;",
+        "CREATE PROCEDURE dwd.foo() LANGUAGE plpgsql AS $$ BEGIN NULL; END; $$ trailing",
+    ] {
+        let error = analyze_sql_references(sql, Some("postgres"))
+            .expect_err("invalid postgres CREATE PROCEDURE must keep its parser error");
+        assert!(!error.is_empty(), "invalid postgres CREATE PROCEDURE returned an empty error: {sql}");
     }
 }
 

--- a/crates/dbx-core/tests/sql_analysis.rs
+++ b/crates/dbx-core/tests/sql_analysis.rs
@@ -647,6 +647,19 @@ fn sqlserver_option_functions_and_invalid_hints_are_not_suppressed() {
 }
 
 #[test]
+fn postgres_create_procedure_bodies_do_not_raise_syntax_errors() {
+    let or_replace_with_default_param = "CREATE OR REPLACE PROCEDURE dwd.lzshklx_batch_update_device_id(\n    p_batch_size INT DEFAULT 100,\n    p_total_batches INT DEFAULT NULL\n)\nLANGUAGE plpgsql\nAS $$\nDECLARE\n    v_affected_rows INT;\nBEGIN\n    NULL;\nEND;\n$$;";
+    let plain_dollar_quoted = "CREATE PROCEDURE dwd.foo(p_id INT) LANGUAGE plpgsql AS $tag$ BEGIN NULL; END; $tag$;";
+
+    for sql in [or_replace_with_default_param, plain_dollar_quoted] {
+        let analysis = analyze_sql_references(sql, Some("postgres"))
+            .expect("postgres CREATE PROCEDURE should not surface a false parser error");
+        assert!(analysis.tables.is_empty());
+        assert!(analysis.columns.is_empty());
+    }
+}
+
+#[test]
 fn duckdb_parser_gap_queries_do_not_raise_syntax_errors() {
     for sql in ["FROM users;", "SUMMARIZE users;", "SUMMARISE users;"] {
         let analysis = analyze_sql_references(sql, Some("duckdb")).expect("duckdb parser gap query should analyze");


### PR DESCRIPTION
Fixes #6703

## 问题

开启"SQL 语义诊断"后，编辑合法的 PostgreSQL 存储过程语句（如 issue 截图中的 `CREATE OR REPLACE PROCEDURE ... LANGUAGE plpgsql AS $$ ... $$`）时，`PROCEDURE` 关键字下方会出现红色波浪线，提示：

```
sql parser error: Expected: [EXTERNAL] TABLE or [MATERIALIZED] VIEW or FUNCTION
```

这是一个误报——语句本身完全合法。

## 根因

`crates/dbx-core/src/sql_analysis.rs` 依赖的 sqlparser-rs 0.62.0 对 Postgres `CREATE PROCEDURE` 有两处解析空白：

1. `Parser::parse_create` 里 `OR REPLACE` 分支在检查到 `PROCEDURE` 关键字之前就已经短路报错——`CREATE OR REPLACE PROCEDURE` 从未被正确分派过，与函数体写法无关。
2. 即便不带 `OR REPLACE`，`parse_create_procedure` 的函数体解析器（`parse_conditional_statements`）也无法处理 Postgres 惯用的 `$$...$$` / `$tag$...$tag$` dollar-quoted 函数体（只支持内联真实 SQL 语句体）。

两者都是上游解析库的已知限制，不是真实语法错误——`CREATE OR REPLACE FUNCTION ... AS $$...$$` 已验证能正常解析，因为 `parse_create_function` 单独处理了 dollar-quoted body，只有 `PROCEDURE` 这条路径漏了。

## 修复

沿用文件里已有的"已知 parser 缺口 → 跳过语义诊断而不是报假错"惯例（此前只处理 `ALTER DEFAULT PRIVILEGES`），新增一条正则匹配 `CREATE [OR REPLACE] PROCEDURE`，命中时跳过语义分析、不再展示误报错误。改动范围很小，只影响 Postgres 方言下 `CREATE PROCEDURE` 语句的诊断展示，不影响其他语句的诊断，也不影响实际 SQL 执行（诊断功能是纯前端静态提示，与查询执行是两套独立代码路径）。

## 测试

- 新增回归测试 `postgres_create_procedure_bodies_do_not_raise_syntax_errors`，覆盖 issue 原文的 `OR REPLACE` + `DEFAULT` 参数场景，以及不带 `OR REPLACE` 的纯 dollar-quoted body 场景。用 `git apply -R`/`git apply` 验证过：revert 后测试真实失败（报出与截图完全相同的错误文本），reapply 后真实通过。
- `cargo test -p dbx-core --test sql_analysis`：34/34 全绿。
- `cargo fmt --check` / `cargo clippy -p dbx-core --lib -- -D warnings` 干净。
- 真实起 `dbx-web` dev 后端 + 真实浏览器（Playwright）连接共享测试 PostgreSQL 16.14 复现：修复前后 before/after 截图对比，`PROCEDURE` 下方红色波浪线在修复后完全消失，其余诊断行为（如未知表名提示）不受影响。