### PR TITLE
feat(mcp): 新增 DeepSeek Harness 配置

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -112,7 +112,7 @@ import { currentExecutableStatementRange, type SqlTextRange } from "@/lib/sql/sq
 import { executableStatementRangeCacheForDoc, executableStatementRangeStartingAt, type ExecutableStatementRangeCache } from "@/lib/sql/executableStatementRangeCache";
 import { EMPTY_TABLE_COLUMN_TEMPLATE_DATA_TYPE, parseTableColumnTemplateFields, TABLE_COLUMN_TEMPLATE_DATABASE_TYPES, tableColumnTemplateRowsToSettings } from "@/lib/table/tableColumnTemplates";
 import { DEFAULT_SQL_VARIABLE_SYNTAX_TOGGLES, normalizeSqlVariableSyntaxOverrides, SQL_VARIABLE_SYNTAX_DATABASE_TYPES, SQL_VARIABLE_SYNTAX_KEYS, SQL_VARIABLE_SYNTAX_TOKENS, type SqlVariableSyntaxOverrides, type SqlVariableSyntaxToggles } from "@/lib/sql/sqlVariableSyntax";
-import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpPiConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl, type McpLaunchConfig } from "@/lib/mcp/mcpConfigTemplates";
+import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpDeepSeekHarnessConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpPiConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl, type McpLaunchConfig } from "@/lib/mcp/mcpConfigTemplates";
 import { beginMcpStatusRequest, mcpUpdateAvailability } from "@/lib/mcp/mcpUpdateStatus";
 import { isMcpPolicyMutationBlocked, MCP_CAPABILITY_ROWS, MCP_EXECUTION_MODE_COLUMNS, mcpExecutionModeFromPolicy, mcpPolicyFieldsForExecutionMode, type McpExecutionMode } from "@/lib/mcp/mcpPolicySelection";
 import { isMacOS, isWindows } from "@/lib/backend/platform";
@@ -1814,7 +1814,7 @@ async function exportDebugLogs() {
 }
 
 // ---------- MCP Server ----------
-type McpConfigTab = "claude" | "cursor" | "trae" | "vscode" | "windsurf" | "codex" | "opencode" | "pi" | "cherry-studio";
+type McpConfigTab = "claude" | "cursor" | "trae" | "vscode" | "windsurf" | "codex" | "deepseek-harness" | "opencode" | "pi" | "cherry-studio";
 type McpCopyKind = "install" | "uninstall" | `${McpConfigTab}-config`;
 
 const mcpStatus = ref<McpServerStatus | null>(null);
@@ -1924,6 +1924,7 @@ const mcpVsCodeRecommendedConfig = computed(() => buildMcpVsCodeConfig(mcpLaunch
 const mcpCherryStudioRecommendedConfig = computed(() => buildMcpCherryStudioConfig(mcpLaunchConfig.value));
 
 const mcpCodexRecommendedConfig = computed(() => buildMcpCodexConfig(mcpLaunchConfig.value));
+const mcpDeepSeekHarnessRecommendedConfig = computed(() => buildMcpDeepSeekHarnessConfig(mcpLaunchConfig.value));
 
 const mcpOpenCodeRecommendedConfig = computed(() => buildMcpOpenCodeConfig(mcpLaunchConfig.value));
 const mcpPiRecommendedConfig = computed(() => buildMcpPiConfig(mcpLaunchConfig.value));
@@ -6633,6 +6634,7 @@ onUnmounted(() => {
                     <TabsTrigger value="vscode" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">VS Code</TabsTrigger>
                     <TabsTrigger value="windsurf" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Windsurf</TabsTrigger>
                     <TabsTrigger value="codex" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Codex</TabsTrigger>
+                    <TabsTrigger value="deepseek-harness" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">DeepSeek Harness</TabsTrigger>
                     <TabsTrigger value="opencode" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">OpenCode</TabsTrigger>
                     <TabsTrigger value="pi" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Pi</TabsTrigger>
                     <TabsTrigger value="cherry-studio" class="settings-mcp-config-tab h-7 flex-none shrink-0 px-2.5">Cherry Studio</TabsTrigger>
@@ -6717,6 +6719,21 @@ onUnmounted(() => {
                         <pre class="overflow-x-auto whitespace-pre text-xs leading-relaxed"><code>{{ mcpCodexRecommendedConfig }}</code></pre>
                         <Button type="button" variant="outline" size="icon" class="absolute right-2 top-2 h-7 w-7" :title="t('common.copy')" @click="copyMcpText('codex-config', mcpCodexRecommendedConfig)">
                           <CheckCircle2 v-if="mcpCopied === 'codex-config'" class="h-3.5 w-3.5 text-green-500" />
+                          <Copy v-else class="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </TabsContent>
+
+                  <TabsContent value="deepseek-harness" class="m-0">
+                    <div class="space-y-2">
+                      <div class="rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                        {{ t("settings.mcpDeepSeekHarnessConfigPath") }}
+                      </div>
+                      <div class="relative rounded-md border bg-background p-3">
+                        <pre class="overflow-x-auto whitespace-pre text-xs leading-relaxed"><code>{{ mcpDeepSeekHarnessRecommendedConfig }}</code></pre>
+                        <Button type="button" variant="outline" size="icon" class="absolute right-2 top-2 h-7 w-7" :title="t('common.copy')" @click="copyMcpText('deepseek-harness-config', mcpDeepSeekHarnessRecommendedConfig)">
+                          <CheckCircle2 v-if="mcpCopied === 'deepseek-harness-config'" class="h-3.5 w-3.5 text-green-500" />
                           <Copy v-else class="h-3.5 w-3.5" />
                         </Button>
                       </div>
@@ -7172,6 +7189,32 @@ onUnmounted(() => {
 
 .settings-option-stack > * + * {
   margin-top: 0.625rem;
+}
+
+.settings-mcp-config-tabs {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 22%, transparent) transparent;
+}
+
+.settings-mcp-config-tabs:hover {
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 38%, transparent) transparent;
+}
+
+.settings-mcp-config-tabs::-webkit-scrollbar {
+  height: 3px;
+}
+
+.settings-mcp-config-tabs::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.settings-mcp-config-tabs::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--muted-foreground) 22%, transparent);
+}
+
+.settings-mcp-config-tabs:hover::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--muted-foreground) 38%, transparent);
 }
 
 html.dbx-legacy-webview .settings-shortcut-row:hover .settings-shortcut-action-button,

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6388,7 +6388,7 @@ export default {
     mcpScopeSelectedCount: "{count} connection(s) selected",
     mcpCodexConfig: "Codex config",
     mcpCodexConfigPath: "Codex can use ~/.codex/config.toml or a project-level .codex/config.toml.",
-    mcpDeepSeekHarnessConfigPath: "For dsh web, merge this insert entry into ~/.dsh/profiles/web/cordis.patch.yml; replace web for another profile. Do not overwrite existing patch entries. Verify with dsh web --dump-config or let HMR reload the change.",
+    mcpDeepSeekHarnessConfigPath: "For dsh web, merge this insert entry into $DSH_HOME/profiles/web/cordis.patch.yml; replace web for another profile. Do not overwrite existing patch entries. Verify with dsh web --dump-config or let HMR reload the change.",
     mcpCursorConfigPath: "Cursor can use .cursor/mcp.json in the project or ~/.cursor/mcp.json globally.",
     mcpTraeConfigPath: "TRAE: Settings > MCP > Add > Add Manually, then paste the JSON configuration.",
     mcpCherryStudioConfigPath: "Cherry Studio: Settings > MCP Servers > Add Server > Import JSON, then paste the configuration.",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6388,6 +6388,7 @@ export default {
     mcpScopeSelectedCount: "{count} connection(s) selected",
     mcpCodexConfig: "Codex config",
     mcpCodexConfigPath: "Codex can use ~/.codex/config.toml or a project-level .codex/config.toml.",
+    mcpDeepSeekHarnessConfigPath: "For dsh web, merge this insert entry into ~/.dsh/profiles/web/cordis.patch.yml; replace web for another profile. Do not overwrite existing patch entries. Verify with dsh web --dump-config or let HMR reload the change.",
     mcpCursorConfigPath: "Cursor can use .cursor/mcp.json in the project or ~/.cursor/mcp.json globally.",
     mcpTraeConfigPath: "TRAE: Settings > MCP > Add > Add Manually, then paste the JSON configuration.",
     mcpCherryStudioConfigPath: "Cherry Studio: Settings > MCP Servers > Add Server > Import JSON, then paste the configuration.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6076,7 +6076,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count} conexiones seleccionadas",
     mcpCodexConfig: "Configuración de Codex",
     mcpCodexConfigPath: "Codex puede usar ~/.codex/config.toml o .codex/config.toml dentro del proyecto.",
-    mcpDeepSeekHarnessConfigPath: "Para dsh web, combina esta entrada insert con ~/.dsh/profiles/web/cordis.patch.yml; sustituye web para otro perfil. No sobrescribas las entradas patch existentes. Verifica con dsh web --dump-config o deja que HMR recargue el cambio.",
+    mcpDeepSeekHarnessConfigPath: "Para dsh web, combina esta entrada insert con $DSH_HOME/profiles/web/cordis.patch.yml; sustituye web para otro perfil. No sobrescribas las entradas patch existentes. Verifica con dsh web --dump-config o deja que HMR recargue el cambio.",
     mcpCursorConfigPath: "Cursor puede usar .cursor/mcp.json en el proyecto o ~/.cursor/mcp.json globalmente.",
     mcpTraeConfigPath: "TRAE: Configuración > MCP > Agregar > Agregar manualmente; luego pega la configuración JSON.",
     mcpCherryStudioConfigPath: "Cherry Studio: Configuración > Servidores MCP > Agregar servidor > Importar JSON; luego pega la configuración.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6076,6 +6076,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count} conexiones seleccionadas",
     mcpCodexConfig: "Configuración de Codex",
     mcpCodexConfigPath: "Codex puede usar ~/.codex/config.toml o .codex/config.toml dentro del proyecto.",
+    mcpDeepSeekHarnessConfigPath: "Para dsh web, combina esta entrada insert con ~/.dsh/profiles/web/cordis.patch.yml; sustituye web para otro perfil. No sobrescribas las entradas patch existentes. Verifica con dsh web --dump-config o deja que HMR recargue el cambio.",
     mcpCursorConfigPath: "Cursor puede usar .cursor/mcp.json en el proyecto o ~/.cursor/mcp.json globalmente.",
     mcpTraeConfigPath: "TRAE: Configuración > MCP > Agregar > Agregar manualmente; luego pega la configuración JSON.",
     mcpCherryStudioConfigPath: "Cherry Studio: Configuración > Servidores MCP > Agregar servidor > Importar JSON; luego pega la configuración.",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6076,7 +6076,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count} connessioni selezionate",
     mcpCodexConfig: "Configurazione Codex",
     mcpCodexConfigPath: "Codex può utilizzare ~/.codex/config.toml o un .codex/config.toml a livello di progetto.",
-    mcpDeepSeekHarnessConfigPath: "Per dsh web, unisci questa voce insert a ~/.dsh/profiles/web/cordis.patch.yml; sostituisci web per un altro profilo. Non sovrascrivere le voci patch esistenti. Verifica con dsh web --dump-config oppure lascia che HMR ricarichi la modifica.",
+    mcpDeepSeekHarnessConfigPath: "Per dsh web, unisci questa voce insert a $DSH_HOME/profiles/web/cordis.patch.yml; sostituisci web per un altro profilo. Non sovrascrivere le voci patch esistenti. Verifica con dsh web --dump-config oppure lascia che HMR ricarichi la modifica.",
     mcpCursorConfigPath: "Cursor può usare .cursor/mcp.json nel progetto o ~/.cursor/mcp.json globalmente.",
     mcpTraeConfigPath: "TRAE: Impostazioni > MCP > Aggiungi > Aggiungi manualmente, poi incolla la configurazione JSON.",
     mcpCherryStudioConfigPath: "Cherry Studio: Impostazioni > Server MCP > Aggiungi server > Importa JSON, quindi incolla la configurazione.",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6076,6 +6076,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count} connessioni selezionate",
     mcpCodexConfig: "Configurazione Codex",
     mcpCodexConfigPath: "Codex può utilizzare ~/.codex/config.toml o un .codex/config.toml a livello di progetto.",
+    mcpDeepSeekHarnessConfigPath: "Per dsh web, unisci questa voce insert a ~/.dsh/profiles/web/cordis.patch.yml; sostituisci web per un altro profilo. Non sovrascrivere le voci patch esistenti. Verifica con dsh web --dump-config oppure lascia che HMR ricarichi la modifica.",
     mcpCursorConfigPath: "Cursor può usare .cursor/mcp.json nel progetto o ~/.cursor/mcp.json globalmente.",
     mcpTraeConfigPath: "TRAE: Impostazioni > MCP > Aggiungi > Aggiungi manualmente, poi incolla la configurazione JSON.",
     mcpCherryStudioConfigPath: "Cherry Studio: Impostazioni > Server MCP > Aggiungi server > Importa JSON, quindi incolla la configurazione.",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6090,7 +6090,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count}件の接続を選択中",
     mcpCodexConfig: "Codex設定",
     mcpCodexConfigPath: "Codexは ~/.codex/config.toml またはプロジェクトレベルの .codex/config.toml を使用できます。",
-    mcpDeepSeekHarnessConfigPath: "dsh web では、この insert エントリを ~/.dsh/profiles/web/cordis.patch.yml に追加します。別の profile では web を置き換えてください。既存の patch エントリは上書きしないでください。dsh web --dump-config で確認するか、HMR で変更を再読み込みできます。",
+    mcpDeepSeekHarnessConfigPath: "dsh web では、この insert エントリを $DSH_HOME/profiles/web/cordis.patch.yml に追加します。別の profile では web を置き換えてください。既存の patch エントリは上書きしないでください。dsh web --dump-config で確認するか、HMR で変更を再読み込みできます。",
     mcpCursorConfigPath: "Cursorはプロジェクトの .cursor/mcp.json またはグローバル ~/.cursor/mcp.json を使用できます。",
     mcpTraeConfigPath: "TRAE: 設定 > MCP > 追加 > 手動で追加 からJSON設定を貼り付けます。",
     mcpCherryStudioConfigPath: "Cherry Studio: 設定 > MCPサーバー > サーバーを追加 > JSONをインポート から設定を貼り付けます。",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6090,6 +6090,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count}件の接続を選択中",
     mcpCodexConfig: "Codex設定",
     mcpCodexConfigPath: "Codexは ~/.codex/config.toml またはプロジェクトレベルの .codex/config.toml を使用できます。",
+    mcpDeepSeekHarnessConfigPath: "dsh web では、この insert エントリを ~/.dsh/profiles/web/cordis.patch.yml に追加します。別の profile では web を置き換えてください。既存の patch エントリは上書きしないでください。dsh web --dump-config で確認するか、HMR で変更を再読み込みできます。",
     mcpCursorConfigPath: "Cursorはプロジェクトの .cursor/mcp.json またはグローバル ~/.cursor/mcp.json を使用できます。",
     mcpTraeConfigPath: "TRAE: 設定 > MCP > 追加 > 手動で追加 からJSON設定を貼り付けます。",
     mcpCherryStudioConfigPath: "Cherry Studio: 設定 > MCPサーバー > サーバーを追加 > JSONをインポート から設定を貼り付けます。",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5812,7 +5812,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "연결 {count}개 선택됨",
     mcpCodexConfig: "Codex 설정",
     mcpCodexConfigPath: "Codex는 ~/.codex/config.toml 또는 프로젝트 수준의 .codex/config.toml을 사용할 수 있습니다.",
-    mcpDeepSeekHarnessConfigPath: "dsh web에서는 이 insert 항목을 ~/.dsh/profiles/web/cordis.patch.yml에 병합하세요. 다른 profile은 web을 바꾸면 됩니다. 기존 patch 항목을 덮어쓰지 마세요. dsh web --dump-config로 확인하거나 HMR로 변경 사항을 다시 불러올 수 있습니다.",
+    mcpDeepSeekHarnessConfigPath: "dsh web에서는 이 insert 항목을 $DSH_HOME/profiles/web/cordis.patch.yml에 병합하세요. 다른 profile은 web을 바꾸면 됩니다. 기존 patch 항목을 덮어쓰지 마세요. dsh web --dump-config로 확인하거나 HMR로 변경 사항을 다시 불러올 수 있습니다.",
     mcpCursorConfigPath: "Cursor는 프로젝트의 .cursor/mcp.json 또는 전역 ~/.cursor/mcp.json을 사용할 수 있습니다.",
     mcpTraeConfigPath: "TRAE: 설정 > MCP > 추가 > 수동 추가 후 JSON 설정을 붙여넣으세요.",
     mcpCherryStudioConfigPath: "Cherry Studio: 설정 > MCP 서버 > 서버 추가 > JSON 가져오기 후 설정을 붙여넣으세요.",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5812,6 +5812,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "연결 {count}개 선택됨",
     mcpCodexConfig: "Codex 설정",
     mcpCodexConfigPath: "Codex는 ~/.codex/config.toml 또는 프로젝트 수준의 .codex/config.toml을 사용할 수 있습니다.",
+    mcpDeepSeekHarnessConfigPath: "dsh web에서는 이 insert 항목을 ~/.dsh/profiles/web/cordis.patch.yml에 병합하세요. 다른 profile은 web을 바꾸면 됩니다. 기존 patch 항목을 덮어쓰지 마세요. dsh web --dump-config로 확인하거나 HMR로 변경 사항을 다시 불러올 수 있습니다.",
     mcpCursorConfigPath: "Cursor는 프로젝트의 .cursor/mcp.json 또는 전역 ~/.cursor/mcp.json을 사용할 수 있습니다.",
     mcpTraeConfigPath: "TRAE: 설정 > MCP > 추가 > 수동 추가 후 JSON 설정을 붙여넣으세요.",
     mcpCherryStudioConfigPath: "Cherry Studio: 설정 > MCP 서버 > 서버 추가 > JSON 가져오기 후 설정을 붙여넣으세요.",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6078,7 +6078,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count} conexões selecionadas",
     mcpCodexConfig: "Configuração do Codex",
     mcpCodexConfigPath: "O Codex pode usar ~/.codex/config.toml ou um .codex/config.toml no nível do projeto.",
-    mcpDeepSeekHarnessConfigPath: "No dsh web, mescle esta entrada insert em ~/.dsh/profiles/web/cordis.patch.yml; substitua web para outro perfil. Não sobrescreva as entradas patch existentes. Verifique com dsh web --dump-config ou deixe o HMR recarregar a alteração.",
+    mcpDeepSeekHarnessConfigPath: "No dsh web, mescle esta entrada insert em $DSH_HOME/profiles/web/cordis.patch.yml; substitua web para outro perfil. Não sobrescreva as entradas patch existentes. Verifique com dsh web --dump-config ou deixe o HMR recarregar a alteração.",
     mcpCursorConfigPath: "O Cursor pode usar .cursor/mcp.json no projeto ou ~/.cursor/mcp.json globalmente.",
     mcpTraeConfigPath: "TRAE: Configurações > MCP > Adicionar > Adicionar manualmente; depois cole a configuração JSON.",
     mcpCherryStudioConfigPath: "Cherry Studio: Configurações > Servidores MCP > Adicionar servidor > Importar JSON; depois cole a configuração.",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6078,6 +6078,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "{count} conexões selecionadas",
     mcpCodexConfig: "Configuração do Codex",
     mcpCodexConfigPath: "O Codex pode usar ~/.codex/config.toml ou um .codex/config.toml no nível do projeto.",
+    mcpDeepSeekHarnessConfigPath: "No dsh web, mescle esta entrada insert em ~/.dsh/profiles/web/cordis.patch.yml; substitua web para outro perfil. Não sobrescreva as entradas patch existentes. Verifique com dsh web --dump-config ou deixe o HMR recarregar a alteração.",
     mcpCursorConfigPath: "O Cursor pode usar .cursor/mcp.json no projeto ou ~/.cursor/mcp.json globalmente.",
     mcpTraeConfigPath: "TRAE: Configurações > MCP > Adicionar > Adicionar manualmente; depois cole a configuração JSON.",
     mcpCherryStudioConfigPath: "Cherry Studio: Configurações > Servidores MCP > Adicionar servidor > Importar JSON; depois cole a configuração.",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6376,7 +6376,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "已选择 {count} 个连接",
     mcpCodexConfig: "Codex 配置",
     mcpCodexConfigPath: "Codex 可放在 ~/.codex/config.toml 或项目级 .codex/config.toml。",
-    mcpDeepSeekHarnessConfigPath: "dsh web：将此 insert 条目合并到 ~/.dsh/profiles/web/cordis.patch.yml；其他 profile 请替换 web。不要覆盖已有 patch 条目。可用 dsh web --dump-config 验证，或等待 HMR 热加载。",
+    mcpDeepSeekHarnessConfigPath: "dsh web：将此 insert 条目合并到 $DSH_HOME/profiles/web/cordis.patch.yml；其他 profile 请替换 web。不要覆盖已有 patch 条目。可用 dsh web --dump-config 验证，或等待 HMR 热加载。",
     mcpCursorConfigPath: "Cursor 可放在项目级 .cursor/mcp.json 或全局 ~/.cursor/mcp.json。",
     mcpTraeConfigPath: "TRAE：设置 > MCP > 添加 > 手动添加，然后粘贴 JSON 配置。",
     mcpCherryStudioConfigPath: "Cherry Studio：设置 > MCP 服务器 > 添加服务器 > 导入 JSON，然后粘贴配置。",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6376,6 +6376,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "已选择 {count} 个连接",
     mcpCodexConfig: "Codex 配置",
     mcpCodexConfigPath: "Codex 可放在 ~/.codex/config.toml 或项目级 .codex/config.toml。",
+    mcpDeepSeekHarnessConfigPath: "dsh web：将此 insert 条目合并到 ~/.dsh/profiles/web/cordis.patch.yml；其他 profile 请替换 web。不要覆盖已有 patch 条目。可用 dsh web --dump-config 验证，或等待 HMR 热加载。",
     mcpCursorConfigPath: "Cursor 可放在项目级 .cursor/mcp.json 或全局 ~/.cursor/mcp.json。",
     mcpTraeConfigPath: "TRAE：设置 > MCP > 添加 > 手动添加，然后粘贴 JSON 配置。",
     mcpCherryStudioConfigPath: "Cherry Studio：设置 > MCP 服务器 > 添加服务器 > 导入 JSON，然后粘贴配置。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5423,7 +5423,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "已選取 {count} 個連線",
     mcpCodexConfig: "Codex 設定",
     mcpCodexConfigPath: "Codex 可放在 ~/.codex/config.toml 或專案級 .codex/config.toml。",
-    mcpDeepSeekHarnessConfigPath: "dsh web：將此 insert 條目合併到 ~/.dsh/profiles/web/cordis.patch.yml；其他 profile 請替換 web。不要覆蓋現有 patch 條目。可用 dsh web --dump-config 驗證，或等待 HMR 熱載入。",
+    mcpDeepSeekHarnessConfigPath: "dsh web：將此 insert 條目合併到 $DSH_HOME/profiles/web/cordis.patch.yml；其他 profile 請替換 web。不要覆蓋現有 patch 條目。可用 dsh web --dump-config 驗證，或等待 HMR 熱載入。",
     mcpCursorConfigPath: "Cursor 可放在專案級 .cursor/mcp.json 或全域 ~/.cursor/mcp.json。",
     mcpTraeConfigPath: "TRAE：設定 > MCP > 新增 > 手動新增，然後貼上 JSON 設定。",
     mcpCherryStudioConfigPath: "Cherry Studio：設定 > MCP 伺服器 > 新增伺服器 > 匯入 JSON，然後貼上設定。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5423,6 +5423,7 @@ export default withEnglishFallback({
     mcpScopeSelectedCount: "已選取 {count} 個連線",
     mcpCodexConfig: "Codex 設定",
     mcpCodexConfigPath: "Codex 可放在 ~/.codex/config.toml 或專案級 .codex/config.toml。",
+    mcpDeepSeekHarnessConfigPath: "dsh web：將此 insert 條目合併到 ~/.dsh/profiles/web/cordis.patch.yml；其他 profile 請替換 web。不要覆蓋現有 patch 條目。可用 dsh web --dump-config 驗證，或等待 HMR 熱載入。",
     mcpCursorConfigPath: "Cursor 可放在專案級 .cursor/mcp.json 或全域 ~/.cursor/mcp.json。",
     mcpTraeConfigPath: "TRAE：設定 > MCP > 新增 > 手動新增，然後貼上 JSON 設定。",
     mcpCherryStudioConfigPath: "Cherry Studio：設定 > MCP 伺服器 > 新增伺服器 > 匯入 JSON，然後貼上設定。",

--- a/apps/desktop/src/lib/__tests__/mcp/mcpConfigTemplates.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpConfigTemplates.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpPiConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl } from "@/lib/mcp/mcpConfigTemplates";
+import { buildMcpCherryStudioConfig, buildMcpCodexConfig, buildMcpDeepSeekHarnessConfig, buildMcpJsonConfig, buildMcpOpenCodeConfig, buildMcpPiConfig, buildMcpTraeConfig, buildMcpVsCodeConfig, mcpWebBackendUrl } from "@/lib/mcp/mcpConfigTemplates";
 
 describe("MCP config templates", () => {
   it("builds the standard mcpServers JSON used by Claude, Cursor, TRAE, and Windsurf", () => {
@@ -143,6 +143,20 @@ describe("MCP config templates", () => {
 
   it("builds Codex TOML config with a direct node launch command", () => {
     expect(buildMcpCodexConfig({ command: "node", args: ["C:\\dbx\\mcp\\dist\\index.js"] })).toBe(["[mcp_servers.dbx]", 'command = "node"', 'args = ["C:\\\\dbx\\\\mcp\\\\dist\\\\index.js"]'].join("\n"));
+  });
+
+  it("builds the DeepSeek Harness Cordis insert patch", () => {
+    expect(buildMcpDeepSeekHarnessConfig()).toBe(["- insert:", "    - id: mcp-dbx", "      name: '@deepseek-ai/dsh-mcp-client'", "      config:", "        serverName: dbx", "        transport: stdio", '        command: "dbx-mcp-server"'].join("\n"));
+  });
+
+  it("includes launch arguments and explicit environment in the DeepSeek Harness patch", () => {
+    expect(
+      buildMcpDeepSeekHarnessConfig({
+        command: "C:\\Program Files\\nodejs\\node.exe",
+        args: ["C:\\Users\\zhiyo\\AppData\\Roaming\\npm\\node_modules\\@dbx-app\\mcp-server\\dist\\index.js"],
+        env: { DBX_DATA_DIR: "D:\\DBX Data" },
+      }),
+    ).toContain(['        command: "C:\\\\Program Files\\\\nodejs\\\\node.exe"', '        args: ["C:\\\\Users\\\\zhiyo\\\\AppData\\\\Roaming\\\\npm\\\\node_modules\\\\@dbx-app\\\\mcp-server\\\\dist\\\\index.js"]', "        env:", '          "DBX_DATA_DIR": "D:\\\\DBX Data"'].join("\n"));
   });
 
   it("builds OpenCode config without policy environment", () => {

--- a/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts
@@ -123,7 +123,8 @@ describe("MCP policy settings state", () => {
     expect(tabsSource).toContain("overscroll-x-contain");
     expect(tabsSource).not.toContain("flex-wrap");
     expect(tabsSource).not.toContain("grid-cols-");
-    expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(9);
+    expect(tabsSource.match(/flex-none shrink-0/g)).toHaveLength(10);
+    expect(tabsSource).toContain('<TabsTrigger value="deepseek-harness"');
     expect(tabsSource).not.toContain("min-w-0 px-");
   });
 });

--- a/apps/desktop/src/lib/mcp/mcpConfigTemplates.ts
+++ b/apps/desktop/src/lib/mcp/mcpConfigTemplates.ts
@@ -24,7 +24,7 @@ function withLaunchConfig(dbx: Record<string, unknown>, config?: McpLaunchConfig
   return dbx;
 }
 
-function tomlStringArray(values: readonly string[]): string {
+function quotedStringArray(values: readonly string[]): string {
   return `[${values.map((value) => JSON.stringify(value)).join(", ")}]`;
 }
 
@@ -74,12 +74,29 @@ export function buildMcpCodexConfig(config?: McpLaunchConfig): string {
   const lines = ["[mcp_servers.dbx]", `command = ${JSON.stringify(launch.command)}`];
 
   if (launch.args && launch.args.length > 0) {
-    lines.push(`args = ${tomlStringArray(launch.args)}`);
+    lines.push(`args = ${quotedStringArray(launch.args)}`);
   }
   if (launch.env && Object.keys(launch.env).length > 0) {
     lines.push("", "[mcp_servers.dbx.env]");
     for (const [key, value] of Object.entries(launch.env)) {
       lines.push(`${key} = ${JSON.stringify(value)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function buildMcpDeepSeekHarnessConfig(config?: McpLaunchConfig): string {
+  const launch = launchConfig(config);
+  const lines = ["- insert:", "    - id: mcp-dbx", "      name: '@deepseek-ai/dsh-mcp-client'", "      config:", "        serverName: dbx", "        transport: stdio", `        command: ${JSON.stringify(launch.command)}`];
+
+  if (launch.args && launch.args.length > 0) {
+    lines.push(`        args: ${quotedStringArray(launch.args)}`);
+  }
+  if (launch.env && Object.keys(launch.env).length > 0) {
+    lines.push("        env:");
+    for (const [key, value] of Object.entries(launch.env)) {
+      lines.push(`          ${JSON.stringify(key)}: ${JSON.stringify(value)}`);
     }
   }
 

--- a/docs/content/docs/mcp.cn.mdx
+++ b/docs/content/docs/mcp.cn.mdx
@@ -65,11 +65,11 @@ AI 助手 → DBX MCP → 你的数据库 → 返回结果
 | Cursor | `.cursor/mcp.json` |
 | Windsurf | MCP 配置 |
 | VS Code + Copilot | MCP 扩展/配置 |
-| DeepSeek Harness | `~/.dsh/profiles/<profile>/cordis.patch.yml` |
+| DeepSeek Harness | `$DSH_HOME/profiles/<profile>/cordis.patch.yml` |
 
 ### DeepSeek Harness
 
-DeepSeek Harness 通过 Cordis 插件条目加载 MCP Server，不读取 `mcpServers` JSON。安装 `@dbx-app/mcp-server` 后，为 `web` profile 将以下条目合并到 `~/.dsh/profiles/web/cordis.patch.yml`：
+DeepSeek Harness 通过 Cordis 插件条目加载 MCP Server，不读取 `mcpServers` JSON。安装 `@dbx-app/mcp-server` 后，为 `web` profile 将以下条目合并到 `$DSH_HOME/profiles/web/cordis.patch.yml`：未设置 `DSH_HOME` 时默认为 `~/.dsh`。
 
 ```yaml
 - insert:

--- a/docs/content/docs/mcp.cn.mdx
+++ b/docs/content/docs/mcp.cn.mdx
@@ -65,6 +65,25 @@ AI 助手 → DBX MCP → 你的数据库 → 返回结果
 | Cursor | `.cursor/mcp.json` |
 | Windsurf | MCP 配置 |
 | VS Code + Copilot | MCP 扩展/配置 |
+| DeepSeek Harness | `~/.dsh/profiles/<profile>/cordis.patch.yml` |
+
+### DeepSeek Harness
+
+DeepSeek Harness 通过 Cordis 插件条目加载 MCP Server，不读取 `mcpServers` JSON。安装 `@dbx-app/mcp-server` 后，为 `web` profile 将以下条目合并到 `~/.dsh/profiles/web/cordis.patch.yml`：
+
+```yaml
+- insert:
+    - id: mcp-dbx
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: dbx
+        transport: stdio
+        command: dbx-mcp-server
+```
+
+保留最外层的 `- insert:`，不要覆盖文件中已有的 patch 条目。使用其他 DSH profile 时，将路径中的 `web` 替换为对应 profile 名称。DSH 进程的 `PATH` 必须能找到 `dbx-mcp-server`；必要时请改用可执行文件的绝对路径。
+
+运行 `dsh web --dump-config` 检查组合后的配置，再重启 DSH 或等待热加载应用该 patch。模型侧工具名为 `mcp__dbx__<tool>`。请保持 `serverName: dbx` 稳定，避免工具名和权限规则发生变化。连接访问范围和执行模式仍统一在 **DBX 设置 → MCP** 中管理。
 
 ## 工具列表
 

--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -65,11 +65,11 @@ AI agent → DBX MCP → your database → results
 | Cursor | `.cursor/mcp.json` |
 | Windsurf | MCP configuration |
 | VS Code + Copilot | MCP extension/configuration |
-| DeepSeek Harness | `~/.dsh/profiles/<profile>/cordis.patch.yml` |
+| DeepSeek Harness | `$DSH_HOME/profiles/<profile>/cordis.patch.yml` |
 
 ### DeepSeek Harness
 
-DeepSeek Harness loads MCP servers through Cordis plugin entries instead of an `mcpServers` JSON object. After installing `@dbx-app/mcp-server`, merge the following entry into `~/.dsh/profiles/web/cordis.patch.yml` for the `web` profile:
+DeepSeek Harness loads MCP servers through Cordis plugin entries instead of an `mcpServers` JSON object. After installing `@dbx-app/mcp-server`, merge the following entry into `$DSH_HOME/profiles/web/cordis.patch.yml` for the `web` profile: If `DSH_HOME` is unset, it defaults to `~/.dsh`.
 
 ```yaml
 - insert:

--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -65,6 +65,25 @@ AI agent → DBX MCP → your database → results
 | Cursor | `.cursor/mcp.json` |
 | Windsurf | MCP configuration |
 | VS Code + Copilot | MCP extension/configuration |
+| DeepSeek Harness | `~/.dsh/profiles/<profile>/cordis.patch.yml` |
+
+### DeepSeek Harness
+
+DeepSeek Harness loads MCP servers through Cordis plugin entries instead of an `mcpServers` JSON object. After installing `@dbx-app/mcp-server`, merge the following entry into `~/.dsh/profiles/web/cordis.patch.yml` for the `web` profile:
+
+```yaml
+- insert:
+    - id: mcp-dbx
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: dbx
+        transport: stdio
+        command: dbx-mcp-server
+```
+
+Keep the top-level `- insert:` wrapper and do not overwrite other patch entries. For another DSH profile, replace `web` in the path with that profile name. The `dbx-mcp-server` command must be available on the DSH process's `PATH`; use the full executable path when necessary.
+
+Run `dsh web --dump-config` to verify the composed configuration, then restart DSH or let its hot reload apply the patch. The tools are exposed to the model as `mcp__dbx__<tool>`. Keep `serverName: dbx` stable so tool names and permission rules remain stable. Connection access and execution mode continue to be managed in **DBX Settings → MCP**.
 
 ## Tools
 


### PR DESCRIPTION
## 变更内容

- 在“设置 → MCP”中新增 DeepSeek Harness 页签，提供可直接复制的 Cordis patch 配置
- 根据 DBX 检测到的 MCP 启动命令、参数和环境变量生成配置
- 为当前支持的全部界面语言补充 DeepSeek Harness 配置说明
- 在官方中英文 MCP 文档中新增 DeepSeek Harness 配置章节
- 缩小 MCP 客户端页签的横向滚动条，并降低其视觉存在感

## 背景

DeepSeek Harness 通过 `@deepseek-ai/dsh-mcp-client` 和 profile 下的 `cordis.patch.yml` 加载 MCP Server，不使用其他部分客户端采用的 `mcpServers` JSON 格式。DBX 需要像 Claude Code、Codex、Pi 等客户端一样，提供符合 DeepSeek Harness 配置机制的示例。

## 用户影响

用户可以从 DBX 设置页面直接复制 DeepSeek Harness 配置。生成内容会保留 DBX 检测到的可执行文件、启动参数和 Web 模式环境变量，并可通过 `dsh <profile> --dump-config` 验证。MCP 的连接访问范围和执行权限仍由 DBX 统一管理。

## 验证

- `pnpm vitest run apps/desktop/src/lib/__tests__/mcp/mcpConfigTemplates.spec.ts apps/desktop/src/lib/__tests__/mcp/mcpPolicySelection.spec.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- 在 `docs/` 中运行 `pnpm content:check`
- 在 `docs/` 中运行 `pnpm build`
- `git diff --check`
