### PR TITLE
Fix/issue 6688  为数据表格添加整行选中视觉样式

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -12959,8 +12959,8 @@ function openGridSnapshot() {
                                     <SelectItem value="datetime">{{ t("grid.formatterDatetime") }}</SelectItem>
                                     <SelectItem value="json-path">{{ t("grid.formatterJsonPath") }}</SelectItem>
                                     <SelectItem value="mask">{{ t("grid.formatterMask") }}</SelectItem>
-                                    <SelectItem value="foreign-key-display">{{ t("grid.formatterForeignKeyDisplay") }}</SelectItem>
-                                    <SelectItem value="custom-template">{{ t("grid.formatterCustomTemplate") }}</SelectItem>
+                                    <SelectItem value="foreign-key-display">{{ t("grid.formatterForeignKeyDisplay") }} </SelectItem>
+                                    <SelectItem value="custom-template">{{ t("grid.formatterCustomTemplate") }} </SelectItem>
                                   </SelectContent>
                                 </Select>
                               </div>
@@ -13066,7 +13066,9 @@ function openGridSnapshot() {
 
                                 <template v-else>
                                   <div class="text-[11px] leading-4 text-muted-foreground">{{ t("grid.formatterForeignKeyManualHint") }}</div>
-                                  <div v-if="formatterForeignKeyTargetError" class="rounded border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-[11px] text-destructive">{{ formatterForeignKeyTargetError }}</div>
+                                  <div v-if="formatterForeignKeyTargetError" class="rounded border border-destructive/30 bg-destructive/5 px-2.5 py-2 text-[11px] text-destructive">
+                                    {{ formatterForeignKeyTargetError }}
+                                  </div>
                                   <div class="grid grid-cols-2 gap-2">
                                     <div class="min-w-0 space-y-1.5">
                                       <div class="text-xs font-medium text-muted-foreground">{{ t("grid.formatterForeignKeySchema") }}</div>
@@ -13115,7 +13117,11 @@ function openGridSnapshot() {
                                         @update:model-value="(value: any) => (formatterForeignKeyRefColumn = String(value))"
                                       />
                                       <div v-if="formatterForeignKeyReferenceValidation === 'unavailable'" class="text-[11px] leading-4 text-destructive">
-                                        {{ t("grid.formatterForeignKeyReferenceMetadataUnavailable", { error: formatterForeignKeyReferenceMetadataError }) }}
+                                        {{
+                                          t("grid.formatterForeignKeyReferenceMetadataUnavailable", {
+                                            error: formatterForeignKeyReferenceMetadataError,
+                                          })
+                                        }}
                                       </div>
                                       <div v-else-if="formatterForeignKeyReferenceValidation === 'invalid' && formatterForeignKeyRefColumn" class="text-[11px] leading-4 text-destructive">
                                         {{ t("grid.formatterForeignKeyReferenceInvalid") }}
@@ -13159,7 +13165,9 @@ function openGridSnapshot() {
                                         @update:model-value="(value: any) => (formatterForeignKeyFilterColumn = String(value))"
                                       />
                                       <Select :model-value="formatterForeignKeyFilterMode" @update:model-value="(value: any) => selectFormatterForeignKeyFilterMode(value)">
-                                        <SelectTrigger class="h-8 text-xs"><SelectValue /></SelectTrigger>
+                                        <SelectTrigger class="h-8 text-xs">
+                                          <SelectValue />
+                                        </SelectTrigger>
                                         <SelectContent>
                                           <SelectItem v-for="option in filterModeOptions" :key="option.value" :value="option.value">{{ t(option.labelKey) }}</SelectItem>
                                         </SelectContent>
@@ -13190,7 +13198,7 @@ function openGridSnapshot() {
                                         <SelectValue />
                                       </SelectTrigger>
                                       <SelectContent>
-                                        <SelectItem :value="CUSTOM_FORMATTER_NEW">{{ t("grid.formatterNewCustom") }}</SelectItem>
+                                        <SelectItem :value="CUSTOM_FORMATTER_NEW">{{ t("grid.formatterNewCustom") }} </SelectItem>
                                         <SelectItem v-for="formatter in savedCustomFormatters" :key="formatter.id" :value="formatter.id">
                                           {{ formatter.name }}
                                         </SelectItem>
@@ -13780,9 +13788,20 @@ function openGridSnapshot() {
                       <Loader2 class="h-4 w-4 animate-spin" />
                     </div>
                     <div class="min-w-0 flex-1">
-                      <div class="truncate text-sm font-medium text-foreground">{{ t("grid.pageJumpLoading", { page: pageJumpProgress.targetPage }) }}</div>
+                      <div class="truncate text-sm font-medium text-foreground">
+                        {{
+                          t("grid.pageJumpLoading", {
+                            page: pageJumpProgress.targetPage,
+                          })
+                        }}
+                      </div>
                       <div class="mt-0.5 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
-                        <span>{{ t("grid.pageJumpProgress", { current: pageJumpProgress.completedRequests, total: pageJumpProgress.totalRequests }) }}</span>
+                        <span>{{
+                          t("grid.pageJumpProgress", {
+                            current: pageJumpProgress.completedRequests,
+                            total: pageJumpProgress.totalRequests,
+                          })
+                        }}</span>
                         <span class="shrink-0 tabular-nums">{{ formatElapsedSeconds(loadingElapsed) }}s</span>
                       </div>
                     </div>
@@ -14633,11 +14652,13 @@ function openGridSnapshot() {
     --data-grid-row-number-deleted-bg: color-mix(in oklab, var(--destructive) 15%, var(--background));
     --data-grid-row-number-selected-bg: color-mix(in oklab, rgb(59 130 246) 45%, var(--background));
   }
+
   [data-grid-root].data-grid--dark,
   :global(.dark) [data-grid-root] {
     --data-grid-cell-crosshair-row-bg: color-mix(in srgb, var(--primary) 34%, var(--background));
     --data-grid-cell-crosshair-col-bg: color-mix(in srgb, var(--primary) 50%, var(--background));
   }
+
   [data-grid-root].data-grid--has-save-error {
     --data-grid-cell-dirty-bg: rgb(250, 212, 216) !important;
     --data-grid-cell-selected-dirty-bg: rgb(240, 192, 198) !important;

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -7124,11 +7124,15 @@ function dataGridRowStyle(item: RowItem): CSSProperties {
     "--data-grid-cell-bg": rowBg,
     "--data-grid-row-number-bg": rowNumberBg,
     "--data-grid-cell-selected-bg": dark ? "rgb(20, 40, 60)" : "rgb(239, 246, 255)",
+    // 整行选中背景：比"选区覆盖淡色指示"更深，点击行号选中整行时醒目显示
+    "--data-grid-row-selected-bg": dark ? "rgb(37, 78, 116)" : "rgb(147, 197, 253)",
     "--data-grid-cell-selected-single-bg": dark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)",
     "--data-grid-cell-selected-dirty-bg": dark ? "rgb(76, 66, 38)" : "rgb(235, 224, 184)",
+    // 整行选中行内的脏单元格背景：跟随整行选中色同步加深的黄褐变体
+    "--data-grid-row-selected-dirty-bg": dark ? "rgb(92, 88, 50)" : "rgb(216, 213, 158)",
     "--data-grid-cell-selected-border": dark ? "rgb(96, 165, 250)" : "rgb(59, 130, 246)",
     "--data-grid-row-number-active-bg": activeRowBg,
-    "--data-grid-row-number-selected-bg": dark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)",
+    "--data-grid-row-number-selected-bg": dark ? "rgb(37, 78, 116)" : "rgb(147, 197, 253)",
   } as CSSProperties;
 }
 
@@ -12973,7 +12977,7 @@ function openGridSnapshot() {
                                     <SelectContent>
                                       <SelectItem value="auto">{{ t("grid.formatterUnitAuto") }}</SelectItem>
                                       <SelectItem value="seconds">{{ t("grid.formatterUnitSeconds") }}</SelectItem>
-                                      <SelectItem value="milliseconds">{{ t("grid.formatterUnitMilliseconds") }}</SelectItem>
+                                      <SelectItem value="milliseconds">{{ t("grid.formatterUnitMilliseconds") }} </SelectItem>
                                     </SelectContent>
                                   </Select>
                                 </div>
@@ -14203,13 +14207,13 @@ function openGridSnapshot() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start" class="w-44">
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('empty')">{{ t("grid.generateEmptyString") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('null')">{{ t("grid.generateNull") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('datetime')">{{ t("grid.generateCurrentDatetime") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('date')">{{ t("grid.generateCurrentDate") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('uuid')">{{ t("grid.generateUuid") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('snowflake')">{{ t("grid.generateSnowflakeId") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="openGenerateIncrementDialog('detail')">{{ t("grid.generateIncrementId") }}</DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('empty')">{{ t("grid.generateEmptyString") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('null')">{{ t("grid.generateNull") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('datetime')">{{ t("grid.generateCurrentDatetime") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('date')">{{ t("grid.generateCurrentDate") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('uuid')">{{ t("grid.generateUuid") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('snowflake')">{{ t("grid.generateSnowflakeId") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="openGenerateIncrementDialog('detail')">{{ t("grid.generateIncrementId") }} </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
                   <Button v-if="activeValueEditorActions.includes('formatJson')" variant="outline" size="sm" class="h-6 text-xs" @mousedown.prevent @click="formatValueEditorJson">
@@ -14542,8 +14546,12 @@ function openGridSnapshot() {
   --data-grid-cell-crosshair-col-bg: rgb(142, 170, 210);
   --data-grid-cell-dirty-bg: rgb(255, 248, 230);
   --data-grid-cell-selected-bg: rgb(239, 246, 255);
+  /* 整行选中背景：比"选区覆盖淡色指示"更深，点击行号选中整行时醒目显示 */
+  --data-grid-row-selected-bg: rgb(147, 197, 253);
   --data-grid-cell-selected-single-bg: rgb(191, 219, 254);
   --data-grid-cell-selected-dirty-bg: rgb(235, 224, 184);
+  /* 整行选中行内的脏单元格背景：跟随整行选中色同步加深的黄褐变体 */
+  --data-grid-row-selected-dirty-bg: rgb(216, 213, 158);
   --data-grid-cell-selected-border: rgb(59, 130, 246);
   --data-grid-cell-hover-bg: rgb(245, 245, 245);
   --data-grid-cell-search-bg: rgb(253, 245, 184);
@@ -14554,7 +14562,7 @@ function openGridSnapshot() {
   --data-grid-row-number-edited-bg: rgb(253, 241, 219);
   --data-grid-row-number-deleted-bg: rgb(255, 244, 244);
   --data-grid-row-number-active-bg: rgb(244, 248, 255);
-  --data-grid-row-number-selected-bg: rgb(191, 219, 254);
+  --data-grid-row-number-selected-bg: rgb(147, 197, 253);
   --data-grid-scrollbar-thumb: color-mix(in oklch, var(--foreground) 30%, transparent);
   --data-grid-scrollbar-thumb-hover: color-mix(in oklch, var(--foreground) 48%, transparent);
   --data-grid-scrollbar-track: transparent;
@@ -14564,6 +14572,7 @@ function openGridSnapshot() {
 [data-grid-root].data-grid--has-save-error {
   --data-grid-cell-dirty-bg: rgb(250, 212, 216) !important;
   --data-grid-cell-selected-dirty-bg: rgb(240, 192, 198) !important;
+  --data-grid-row-selected-dirty-bg: rgb(240, 192, 198) !important;
 }
 
 [data-grid-root].data-grid--dark,
@@ -14576,8 +14585,10 @@ function openGridSnapshot() {
   --data-grid-cell-crosshair-col-bg: rgb(98, 111, 130);
   --data-grid-cell-dirty-bg: rgb(94, 75, 26);
   --data-grid-cell-selected-bg: rgb(20, 40, 60);
+  --data-grid-row-selected-bg: rgb(37, 78, 116);
   --data-grid-cell-selected-single-bg: rgb(30, 64, 96);
   --data-grid-cell-selected-dirty-bg: rgb(76, 66, 38);
+  --data-grid-row-selected-dirty-bg: rgb(92, 88, 50);
   --data-grid-cell-selected-border: rgb(96, 165, 250);
   --data-grid-cell-hover-bg: rgb(46, 47, 51);
   --data-grid-cell-search-bg: rgb(72, 57, 8);
@@ -14588,7 +14599,7 @@ function openGridSnapshot() {
   --data-grid-row-number-edited-bg: rgb(48, 41, 28);
   --data-grid-row-number-deleted-bg: rgb(55, 31, 32);
   --data-grid-row-number-active-bg: rgb(25, 34, 46);
-  --data-grid-row-number-selected-bg: rgb(30, 64, 96);
+  --data-grid-row-number-selected-bg: rgb(37, 78, 116);
   --data-grid-scrollbar-thumb: rgb(82, 82, 91);
   --data-grid-scrollbar-thumb-hover: rgb(113, 113, 122);
   --data-grid-scrollbar-track: rgb(24, 24, 27);
@@ -14599,6 +14610,7 @@ function openGridSnapshot() {
 :global(.dark) [data-grid-root].data-grid--has-save-error {
   --data-grid-cell-dirty-bg: rgb(94, 56, 57) !important;
   --data-grid-cell-selected-dirty-bg: rgb(114, 66, 67) !important;
+  --data-grid-row-selected-dirty-bg: rgb(114, 66, 67) !important;
 }
 
 @supports (background: color-mix(in oklab, white 50%, transparent)) {
@@ -14610,14 +14622,16 @@ function openGridSnapshot() {
     --data-grid-cell-crosshair-row-bg: color-mix(in srgb, var(--primary) 34%, var(--background));
     --data-grid-cell-crosshair-col-bg: color-mix(in srgb, var(--primary) 50%, var(--background));
     --data-grid-cell-selected-bg: color-mix(in oklab, rgb(59 130 246) 12%, var(--background));
+    --data-grid-row-selected-bg: color-mix(in oklab, rgb(59 130 246) 45%, var(--background));
     --data-grid-cell-selected-single-bg: color-mix(in oklab, rgb(59 130 246) 30%, var(--background));
     --data-grid-cell-selected-dirty-bg: color-mix(in oklab, rgb(234 181 50) 30%, color-mix(in oklab, rgb(59 130 246) 18%, var(--background)));
+    --data-grid-row-selected-dirty-bg: color-mix(in oklab, rgb(234 181 50) 30%, var(--data-grid-row-selected-bg));
     --data-grid-cell-selected-border: color-mix(in oklab, rgb(59 130 246) 75%, transparent);
     --data-grid-cell-hover-bg: color-mix(in oklab, var(--accent) 50%, transparent);
     --data-grid-row-number-new-bg: color-mix(in oklab, rgb(16 185 129) 15%, var(--background));
     --data-grid-row-number-edited-bg: color-mix(in oklab, rgb(245 158 11) 15%, var(--background));
     --data-grid-row-number-deleted-bg: color-mix(in oklab, var(--destructive) 15%, var(--background));
-    --data-grid-row-number-selected-bg: color-mix(in oklab, rgb(59 130 246) 30%, var(--background));
+    --data-grid-row-number-selected-bg: color-mix(in oklab, rgb(59 130 246) 45%, var(--background));
   }
   [data-grid-root].data-grid--dark,
   :global(.dark) [data-grid-root] {
@@ -14627,11 +14641,14 @@ function openGridSnapshot() {
   [data-grid-root].data-grid--has-save-error {
     --data-grid-cell-dirty-bg: rgb(250, 212, 216) !important;
     --data-grid-cell-selected-dirty-bg: rgb(240, 192, 198) !important;
+    --data-grid-row-selected-dirty-bg: rgb(240, 192, 198) !important;
   }
+
   [data-grid-root].data-grid--dark.data-grid--has-save-error,
   :global(.dark) [data-grid-root].data-grid--has-save-error {
     --data-grid-cell-dirty-bg: rgb(94, 56, 57) !important;
     --data-grid-cell-selected-dirty-bg: rgb(114, 66, 67) !important;
+    --data-grid-row-selected-dirty-bg: rgb(114, 66, 67) !important;
   }
 }
 
@@ -14666,10 +14683,12 @@ function openGridSnapshot() {
 
 :global(.dark) [data-grid-root] {
   --data-grid-cell-selected-bg: rgb(20, 40, 60);
+  --data-grid-row-selected-bg: rgb(37, 78, 116);
   --data-grid-cell-selected-single-bg: rgb(30, 64, 96);
   --data-grid-cell-selected-dirty-bg: rgb(76, 66, 38);
+  --data-grid-row-selected-dirty-bg: rgb(92, 88, 50);
   --data-grid-cell-selected-border: rgb(96, 165, 250);
-  --data-grid-row-number-selected-bg: rgb(30, 64, 96);
+  --data-grid-row-number-selected-bg: rgb(37, 78, 116);
 }
 
 [data-grid-root].data-grid--dark .data-grid-header-cell--selected,
@@ -15126,7 +15145,7 @@ function openGridSnapshot() {
 }
 
 .row-cell-selected {
-  background-color: var(--data-grid-cell-selected-bg) !important;
+  background-color: var(--data-grid-row-selected-bg) !important;
 }
 
 .cell-dirty {
@@ -15168,7 +15187,7 @@ function openGridSnapshot() {
 }
 
 .row-cell-selected-dirty {
-  background-color: var(--data-grid-cell-selected-dirty-bg) !important;
+  background-color: var(--data-grid-row-selected-dirty-bg) !important;
 }
 
 .data-grid-row-number.bg-emerald-500\/15 {
@@ -15233,69 +15252,83 @@ function openGridSnapshot() {
 .cell-sel-frame-1 {
   box-shadow: inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-2 {
   box-shadow: inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-3 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-4 {
   box-shadow: inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-5 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-6 {
   box-shadow:
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-7 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-8 {
   box-shadow: inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-9 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-10 {
   box-shadow:
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-11 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-12 {
   box-shadow:
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-13 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-14 {
   box-shadow:
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-15 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -7,7 +7,12 @@ import { dispatch, findAll, findOne, hostText, mountComponent } from "./vueHostH
 import type { DataGridCellDetail } from "@/lib/dataGrid/dataGridDetail";
 
 const mocks = vi.hoisted(() => ({
-  editor: { create: vi.fn(), destroy: vi.fn(), setValue: vi.fn(), openSearch: vi.fn() },
+  editor: {
+    create: vi.fn(),
+    destroy: vi.fn(),
+    setValue: vi.fn(),
+    openSearch: vi.fn(),
+  },
   updateSettings: vi.fn(),
   renderWkt: vi.fn(),
   panelCancel: vi.fn(),
@@ -47,44 +52,108 @@ vi.mock("@lucide/vue", async () => {
   };
 });
 
-vi.mock("@/components/ui/button", async () => ({ Button: (await import("./vueHostHarness")).createPassthroughStub("Button", "button") }));
-vi.mock("@/components/ui/input", async () => ({ Input: (await import("./vueHostHarness")).createPassthroughStub("Input", "input") }));
+vi.mock("@/components/ui/button", async () => ({
+  Button: (await import("./vueHostHarness")).createPassthroughStub("Button", "button"),
+}));
+vi.mock("@/components/ui/input", async () => ({
+  Input: (await import("./vueHostHarness")).createPassthroughStub("Input", "input"),
+}));
 vi.mock("@/components/ui/dialog", async () => {
   const { createPassthroughStub } = await import("./vueHostHarness");
-  return { Dialog: createPassthroughStub("Dialog"), DialogContent: createPassthroughStub("DialogContent"), DialogFooter: createPassthroughStub("DialogFooter"), DialogHeader: createPassthroughStub("DialogHeader"), DialogTitle: createPassthroughStub("DialogTitle") };
+  return {
+    Dialog: createPassthroughStub("Dialog"),
+    DialogContent: createPassthroughStub("DialogContent"),
+    DialogFooter: createPassthroughStub("DialogFooter"),
+    DialogHeader: createPassthroughStub("DialogHeader"),
+    DialogTitle: createPassthroughStub("DialogTitle"),
+  };
 });
 vi.mock("@/components/ui/dropdown-menu", async () => {
   const { createPassthroughStub } = await import("./vueHostHarness");
-  return { DropdownMenu: createPassthroughStub("DropdownMenu"), DropdownMenuContent: createPassthroughStub("DropdownMenuContent"), DropdownMenuItem: createPassthroughStub("DropdownMenuItem", "button"), DropdownMenuTrigger: createPassthroughStub("DropdownMenuTrigger") };
+  return {
+    DropdownMenu: createPassthroughStub("DropdownMenu"),
+    DropdownMenuContent: createPassthroughStub("DropdownMenuContent"),
+    DropdownMenuItem: createPassthroughStub("DropdownMenuItem", "button"),
+    DropdownMenuTrigger: createPassthroughStub("DropdownMenuTrigger"),
+  };
 });
 vi.mock("@/components/ui/popover", async () => {
   const { createPassthroughStub } = await import("./vueHostHarness");
-  return { Popover: createPassthroughStub("Popover"), PopoverContent: createPassthroughStub("PopoverContent"), PopoverTrigger: createPassthroughStub("PopoverTrigger") };
+  return {
+    Popover: createPassthroughStub("Popover"),
+    PopoverContent: createPassthroughStub("PopoverContent"),
+    PopoverTrigger: createPassthroughStub("PopoverTrigger"),
+  };
 });
 vi.mock("@/components/ui/tooltip", async () => {
   const { createPassthroughStub } = await import("./vueHostHarness");
-  return { Tooltip: createPassthroughStub("Tooltip"), TooltipContent: createPassthroughStub("TooltipContent"), TooltipTrigger: createPassthroughStub("TooltipTrigger") };
+  return {
+    Tooltip: createPassthroughStub("Tooltip"),
+    TooltipContent: createPassthroughStub("TooltipContent"),
+    TooltipTrigger: createPassthroughStub("TooltipTrigger"),
+  };
 });
 vi.mock("@/components/ui/select", async () => {
   const { createPassthroughStub } = await import("./vueHostHarness");
-  return { Select: createPassthroughStub("Select"), SelectContent: createPassthroughStub("SelectContent"), SelectItem: createPassthroughStub("SelectItem"), SelectTrigger: createPassthroughStub("SelectTrigger"), SelectValue: createPassthroughStub("SelectValue") };
+  return {
+    Select: createPassthroughStub("Select"),
+    SelectContent: createPassthroughStub("SelectContent"),
+    SelectItem: createPassthroughStub("SelectItem"),
+    SelectTrigger: createPassthroughStub("SelectTrigger"),
+    SelectValue: createPassthroughStub("SelectValue"),
+  };
 });
-vi.mock("@/components/ui/tabs", async () => ({ TabsContent: (await import("./vueHostHarness")).createPassthroughStub("TabsContent") }));
-vi.mock("@/components/ui/switch", async () => ({ Switch: (await import("./vueHostHarness")).createPassthroughStub("Switch", "button") }));
-vi.mock("@/components/ui/label", async () => ({ Label: (await import("./vueHostHarness")).createPassthroughStub("Label", "label") }));
-vi.mock("@/components/ui/LightDropdown.vue", async () => ({ default: (await import("./vueHostHarness")).createPassthroughStub("LightDropdown") }));
-vi.mock("@/components/ui/LightTooltip.vue", async () => ({ default: (await import("./vueHostHarness")).createPassthroughStub("LightTooltip") }));
-vi.mock("@/components/grid/TemporalCellEditor.vue", async () => ({ default: (await import("./vueHostHarness")).createPassthroughStub("TemporalCellEditor") }));
-vi.mock("@/composables/useCellDetailEditor", () => ({ useCellDetailEditor: () => mocks.editor }));
-vi.mock("@/composables/useTheme", () => ({ useTheme: () => ({ isDark: { value: false }, themePalette: { value: {} } }) }));
-vi.mock("@/stores/settingsStore", () => ({ useSettingsStore: () => ({ editorSettings: { cellDetailJsonFormatted: true, theme: "default", fontSize: 13, fontFamily: "monospace" }, updateEditorSettings: mocks.updateSettings }) }));
-vi.mock("@/lib/dataGrid/geometryPreview", () => ({ isHexGeometry: () => false, renderWktOnCanvas: mocks.renderWkt }));
+vi.mock("@/components/ui/tabs", async () => ({
+  TabsContent: (await import("./vueHostHarness")).createPassthroughStub("TabsContent"),
+}));
+vi.mock("@/components/ui/switch", async () => ({
+  Switch: (await import("./vueHostHarness")).createPassthroughStub("Switch", "button"),
+}));
+vi.mock("@/components/ui/label", async () => ({
+  Label: (await import("./vueHostHarness")).createPassthroughStub("Label", "label"),
+}));
+vi.mock("@/components/ui/LightDropdown.vue", async () => ({
+  default: (await import("./vueHostHarness")).createPassthroughStub("LightDropdown"),
+}));
+vi.mock("@/components/ui/LightTooltip.vue", async () => ({
+  default: (await import("./vueHostHarness")).createPassthroughStub("LightTooltip"),
+}));
+vi.mock("@/components/grid/TemporalCellEditor.vue", async () => ({
+  default: (await import("./vueHostHarness")).createPassthroughStub("TemporalCellEditor"),
+}));
+vi.mock("@/composables/useCellDetailEditor", () => ({
+  useCellDetailEditor: () => mocks.editor,
+}));
+vi.mock("@/composables/useTheme", () => ({
+  useTheme: () => ({ isDark: { value: false }, themePalette: { value: {} } }),
+}));
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings: {
+      cellDetailJsonFormatted: true,
+      theme: "default",
+      fontSize: 13,
+      fontFamily: "monospace",
+    },
+    updateEditorSettings: mocks.updateSettings,
+  }),
+}));
+vi.mock("@/lib/dataGrid/geometryPreview", () => ({
+  isHexGeometry: () => false,
+  renderWktOnCanvas: mocks.renderWkt,
+}));
 vi.mock("@/composables/useDataGridCellDetail", async () => {
   const { ref } = await import("vue");
   return {
     useDataGridCellDetail: ({ onCancel }: { onCancel: () => void }) => {
       mocks.panelCancel.mockImplementation(onCancel);
-      return { geometryPreviewOpen: ref(false), geometryCanvas: ref(), detailsEditorContainer: ref(), sideJsonPreviewContainer: ref(), openSearch: mocks.panelOpenSearch };
+      return {
+        geometryPreviewOpen: ref(false),
+        geometryCanvas: ref(),
+        detailsEditorContainer: ref(),
+        sideJsonPreviewContainer: ref(),
+        openSearch: mocks.panelOpenSearch,
+      };
     },
   };
 });
@@ -142,8 +211,9 @@ describe("DataGrid canvas surfaces", () => {
   });
 
   it("shows stable request progress while an Elasticsearch page jump is running", () => {
-    expect(dataGridSource).toContain('t("grid.pageJumpLoading", { page: pageJumpProgress.targetPage })');
-    expect(dataGridSource).toContain('t("grid.pageJumpProgress", { current: pageJumpProgress.completedRequests, total: pageJumpProgress.totalRequests })');
+    // 插值可能被 oxfmt 折成多行,这里用容忍空白的正则匹配调用与参数,不依赖具体排版
+    expect(dataGridSource).toMatch(/t\("grid\.pageJumpLoading",\s*\{\s*page:\s*pageJumpProgress\.targetPage,?\s*\}\)/);
+    expect(dataGridSource).toMatch(/t\("grid\.pageJumpProgress",\s*\{\s*current:\s*pageJumpProgress\.completedRequests,\s*total:\s*pageJumpProgress\.totalRequests,?\s*\}\)/);
     expect(dataGridSource).toContain('role="progressbar"');
     expect(dataGridSource).toContain(':style="{ width: `${pageJumpProgressPercent}%` }"');
   });
@@ -332,7 +402,11 @@ describe("DataGridPagination", () => {
     expect(nextPage).not.toHaveBeenCalled();
     expect(lastPage).not.toHaveBeenCalled();
 
-    await mounted.setProps({ currentPage: 2, canGoNextPage: true, canJumpLastPage: true });
+    await mounted.setProps({
+      currentPage: 2,
+      canGoNextPage: true,
+      canJumpLastPage: true,
+    });
     const enabledNavigation = findAll(mounted.root, (node) => node.props["data-stub"] === "Button" && node.props.class === "h-5 w-5 shrink-0");
     expect(enabledNavigation.map((node) => node.props.disabled)).toEqual([false, false, false, false]);
     enabledNavigation.forEach((node) => dispatch(node, "click"));
@@ -572,8 +646,14 @@ describe("DataGridColumnHeader", () => {
       columnUniqueIndexLabel: "unique",
       columnRegularIndexLabel: "regular",
     };
-    const nullable = mountComponent(DataGridColumnHeader, { ...baseProps, columnNullability: "nullable" });
-    const required = mountComponent(DataGridColumnHeader, { ...baseProps, columnNullability: "required" });
+    const nullable = mountComponent(DataGridColumnHeader, {
+      ...baseProps,
+      columnNullability: "nullable",
+    });
+    const required = mountComponent(DataGridColumnHeader, {
+      ...baseProps,
+      columnNullability: "required",
+    });
 
     expect(findAll(nullable.root, (node) => node.props["data-grid-header-nullable"] === "")).toHaveLength(0);
     expect(findAll(required.root, (node) => node.props["data-grid-header-nullable"] === "")).toHaveLength(0);
@@ -587,7 +667,16 @@ describe("DataGridFilterBuilder", () => {
     const updateRule = vi.fn();
     const add = vi.fn();
     const mounted = mountComponent(DataGridFilterBuilder, {
-      rules: [{ id: "r1", columnName: "account_id", mode: "equals", rawValue: "7", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "account_id",
+          mode: "equals",
+          rawValue: "7",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["account_id"],
       filteredColumns: ["account_id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -614,8 +703,22 @@ describe("DataGridFilterBuilder", () => {
     dispatch(valueEditor, "keydown", { key: "Enter", shiftKey: true });
     await mounted.setProps({
       rules: [
-        { id: "r1", columnName: "account_id", mode: "equals", rawValue: "7", rawEndValue: "", conjunction: "AND" },
-        { id: "r2", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" },
+        {
+          id: "r1",
+          columnName: "account_id",
+          mode: "equals",
+          rawValue: "7",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+        {
+          id: "r2",
+          columnName: "",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
       ],
     });
     await nextTick();
@@ -634,7 +737,16 @@ describe("DataGridFilterBuilder", () => {
 
   it("opens the first empty rule column search on request", async () => {
     const mounted = mountComponent(DataGridFilterBuilder, {
-      rules: [{ id: "r1", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["id"],
       filteredColumns: ["id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -649,7 +761,16 @@ describe("DataGridFilterBuilder", () => {
 
   it("keeps selected columns and values readable without stretching the controls", () => {
     const mounted = mountComponent(DataGridFilterBuilder, {
-      rules: [{ id: "r1", columnName: "appointmentStatusWithAnExceptionallyLongName", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "appointmentStatusWithAnExceptionallyLongName",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["appointmentStatusWithAnExceptionallyLongName", "name"],
       filteredColumns: ["name"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -675,7 +796,10 @@ describe("DataGridFilterBuilder", () => {
     expect(items.every((item) => String(item.props.class).includes("rounded-none"))).toBe(true);
     expect(searchInput.props.placeholder).toBe("grid.filterBuilderSearchColumns");
     expect(valueEditor.props.placeholder).toBe("grid.filterBuilderValue");
-    expect(filterBuilder.props.style).toEqual({ "--filter-builder-column-width": "178px", "--filter-builder-value-width": "178px" });
+    expect(filterBuilder.props.style).toEqual({
+      "--filter-builder-column-width": "178px",
+      "--filter-builder-value-width": "178px",
+    });
     expect(String(ruleGrid.props.class)).toContain("grid-cols-[18px_var(--filter-builder-column-width)_92px_var(--filter-builder-value-width)_auto]");
     expect(String(ruleGrid.props.class)).toContain("justify-start");
     for (const trigger of triggers) {
@@ -688,7 +812,16 @@ describe("DataGridFilterBuilder", () => {
 
   it("sizes the column control from the longest available column", () => {
     const mounted = mountComponent(DataGridFilterBuilder, {
-      rules: [{ id: "r1", columnName: "id", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "id",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["id", "name"],
       filteredColumns: ["id", "name"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -696,15 +829,33 @@ describe("DataGridFilterBuilder", () => {
     });
     const filterBuilder = findOne(mounted.root, (node) => String(node.props.class).includes("w-fit max-w-full"));
 
-    expect(filterBuilder.props.style).toEqual({ "--filter-builder-column-width": "88px", "--filter-builder-value-width": "178px" });
+    expect(filterBuilder.props.style).toEqual({
+      "--filter-builder-column-width": "88px",
+      "--filter-builder-value-width": "178px",
+    });
   });
 
   it("renders reorder handles and supports keyboard condition moves", () => {
     const move = vi.fn();
     const mounted = mountComponent(DataGridFilterBuilder, {
       rules: [
-        { id: "r1", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" },
-        { id: "r2", columnName: "name", mode: "equals", rawValue: "Alice", rawEndValue: "", conjunction: "AND", disabled: true },
+        {
+          id: "r1",
+          columnName: "id",
+          mode: "equals",
+          rawValue: "1",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+        {
+          id: "r2",
+          columnName: "name",
+          mode: "equals",
+          rawValue: "Alice",
+          rawEndValue: "",
+          conjunction: "AND",
+          disabled: true,
+        },
       ],
       columns: ["id", "name"],
       filteredColumns: ["id", "name"],
@@ -730,7 +881,16 @@ describe("DataGridFilterBuilder", () => {
     const onUpdateRule = vi.fn();
     const onAdd = vi.fn();
     const mounted = mountComponent(DataGridFilterBuilder, {
-      rules: [{ id: "r1", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["id", "image_size_bytes"],
       filteredColumns: ["id", "image_size_bytes"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -746,12 +906,18 @@ describe("DataGridFilterBuilder", () => {
 
     let columnItems = findAll(mounted.root, (node) => node.props["data-stub"] === "SelectItem").slice(0, 2);
     expect(columnItems[0].props["data-filter-active"]).toBe("");
-    const imeKeyCodeEnter = dispatch(searchInput, "keydown", { key: "Enter", keyCode: 229 });
+    const imeKeyCodeEnter = dispatch(searchInput, "keydown", {
+      key: "Enter",
+      keyCode: 229,
+    });
     expect(imeKeyCodeEnter.defaultPrevented).toBe(false);
     expect(imeKeyCodeEnter.propagationStopped).toBe(true);
     dispatch(searchInput, "compositionstart");
     dispatch(searchInput, "compositionend");
-    const imeCompositionEndEnter = dispatch(searchInput, "keydown", { key: "Enter", keyCode: 13 });
+    const imeCompositionEndEnter = dispatch(searchInput, "keydown", {
+      key: "Enter",
+      keyCode: 13,
+    });
     expect(imeCompositionEndEnter.defaultPrevented).toBe(false);
     expect(imeCompositionEndEnter.propagationStopped).toBe(true);
     expect(onUpdateRule).not.toHaveBeenCalled();
@@ -765,14 +931,30 @@ describe("DataGridFilterBuilder", () => {
     columnItems = findAll(mounted.root, (node) => node.props["data-stub"] === "SelectItem").slice(0, 2);
     expect(columnItems[1].props["data-filter-active"]).toBe("");
 
-    const leftInput = { value: "image_", selectionStart: 4, selectionEnd: 4, setSelectionRange: vi.fn() };
-    const leftArrow = dispatch(searchInput, "keydown", { key: "ArrowLeft", currentTarget: leftInput });
+    const leftInput = {
+      value: "image_",
+      selectionStart: 4,
+      selectionEnd: 4,
+      setSelectionRange: vi.fn(),
+    };
+    const leftArrow = dispatch(searchInput, "keydown", {
+      key: "ArrowLeft",
+      currentTarget: leftInput,
+    });
     expect(leftArrow.defaultPrevented).toBe(true);
     expect(leftArrow.propagationStopped).toBe(true);
     expect(leftInput.setSelectionRange).toHaveBeenCalledWith(3, 3);
 
-    const rightInput = { value: "image_", selectionStart: 1, selectionEnd: 4, setSelectionRange: vi.fn() };
-    const rightArrow = dispatch(searchInput, "keydown", { key: "ArrowRight", currentTarget: rightInput });
+    const rightInput = {
+      value: "image_",
+      selectionStart: 1,
+      selectionEnd: 4,
+      setSelectionRange: vi.fn(),
+    };
+    const rightArrow = dispatch(searchInput, "keydown", {
+      key: "ArrowRight",
+      currentTarget: rightInput,
+    });
     expect(rightArrow.defaultPrevented).toBe(true);
     expect(rightArrow.propagationStopped).toBe(true);
     expect(rightInput.setSelectionRange).toHaveBeenCalledWith(4, 4);
@@ -780,20 +962,50 @@ describe("DataGridFilterBuilder", () => {
     const enter = dispatch(searchInput, "keydown", { key: "Enter" });
     expect(enter.defaultPrevented).toBe(true);
     expect(enter.propagationStopped).toBe(true);
-    expect(onUpdateRule).toHaveBeenCalledWith("r1", { columnName: "image_size_bytes" });
+    expect(onUpdateRule).toHaveBeenCalledWith("r1", {
+      columnName: "image_size_bytes",
+    });
     expect(onAdd).not.toHaveBeenCalled();
     expect(dispatch(searchInput, "keydown", { key: "Process", isComposing: true }).propagationStopped).toBe(true);
   });
 
   it("adds another rule after selecting a column with shift-enter", async () => {
     const onUpdateRule = vi.fn();
-    const secondRule = { id: "r2", columnName: "id", mode: "equals" as const, rawValue: "", rawEndValue: "", conjunction: "AND" as const };
+    const secondRule = {
+      id: "r2",
+      columnName: "id",
+      mode: "equals" as const,
+      rawValue: "",
+      rawEndValue: "",
+      conjunction: "AND" as const,
+    };
     let mounted: ReturnType<typeof mountComponent>;
     const onAdd = vi.fn(() => {
-      void mounted.setProps({ rules: [{ id: "r1", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }, secondRule] });
+      void mounted.setProps({
+        rules: [
+          {
+            id: "r1",
+            columnName: "",
+            mode: "equals",
+            rawValue: "",
+            rawEndValue: "",
+            conjunction: "AND",
+          },
+          secondRule,
+        ],
+      });
     });
     mounted = mountComponent(DataGridFilterBuilder, {
-      rules: [{ id: "r1", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["id"],
       filteredColumns: ["id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -806,7 +1018,10 @@ describe("DataGridFilterBuilder", () => {
 
     columnSelect.props["onUpdate:open"](true);
     await nextTick();
-    const shiftEnter = dispatch(searchInput, "keydown", { key: "Enter", shiftKey: true });
+    const shiftEnter = dispatch(searchInput, "keydown", {
+      key: "Enter",
+      shiftKey: true,
+    });
 
     expect(shiftEnter.defaultPrevented).toBe(true);
     expect(shiftEnter.propagationStopped).toBe(true);
@@ -828,8 +1043,22 @@ describe("DataGridFilterBuilder", () => {
     const mountFilterBuilder = () =>
       mountComponent(DataGridFilterBuilder, {
         rules: [
-          { id: "r1", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" },
-          { id: "r2", columnName: "name", mode: "equals", rawValue: "n", rawEndValue: "", conjunction: "AND" },
+          {
+            id: "r1",
+            columnName: "id",
+            mode: "equals",
+            rawValue: "1",
+            rawEndValue: "",
+            conjunction: "AND",
+          },
+          {
+            id: "r2",
+            columnName: "name",
+            mode: "equals",
+            rawValue: "n",
+            rawEndValue: "",
+            conjunction: "AND",
+          },
         ],
         columns: ["id"],
         filteredColumns: ["id"],
@@ -893,18 +1122,28 @@ describe("DataGridFilterBuilder", () => {
     await nextTick();
     expect(hostText(exhaustedMounted.root)).not.toContain("grid.filterBuilderValueShortcutHint");
 
-    const imeKeyCodeEnter = dispatch(secondValueEditor, "keydown", { key: "Enter", keyCode: 229 });
+    const imeKeyCodeEnter = dispatch(secondValueEditor, "keydown", {
+      key: "Enter",
+      keyCode: 229,
+    });
     expect(imeKeyCodeEnter.defaultPrevented).toBe(false);
     expect(imeKeyCodeEnter.propagationStopped).toBe(true);
     dispatch(secondValueEditor, "compositionstart");
     dispatch(secondValueEditor, "compositionend");
-    const imeCompositionEndEnter = dispatch(secondValueEditor, "keydown", { key: "Enter", keyCode: 13 });
+    const imeCompositionEndEnter = dispatch(secondValueEditor, "keydown", {
+      key: "Enter",
+      keyCode: 13,
+    });
     expect(imeCompositionEndEnter.defaultPrevented).toBe(false);
     expect(imeCompositionEndEnter.propagationStopped).toBe(true);
     expect(onAdd).not.toHaveBeenCalled();
     expect(onApply).not.toHaveBeenCalled();
 
-    const shiftEnter = dispatch(secondValueEditor, "keydown", { key: "Enter", shiftKey: true, repeat: false });
+    const shiftEnter = dispatch(secondValueEditor, "keydown", {
+      key: "Enter",
+      shiftKey: true,
+      repeat: false,
+    });
     expect(shiftEnter.defaultPrevented).toBe(true);
     expect(shiftEnter.propagationStopped).toBe(true);
     expect(onAdd).toHaveBeenCalledOnce();
@@ -917,8 +1156,22 @@ describe("DataGridFilterBuilder", () => {
   it("does not show the value editor shortcut hint for list value editors", async () => {
     const mounted = mountComponent(DataGridFilterBuilder, {
       rules: [
-        { id: "r1", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" },
-        { id: "r2", columnName: "name", mode: "in", rawValue: "n", rawEndValue: "", conjunction: "AND" },
+        {
+          id: "r1",
+          columnName: "id",
+          mode: "equals",
+          rawValue: "1",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+        {
+          id: "r2",
+          columnName: "name",
+          mode: "in",
+          rawValue: "n",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
       ],
       columns: ["id"],
       filteredColumns: ["id"],
@@ -940,7 +1193,14 @@ describe("DataGridFilterBuilder", () => {
 describe("DataGridQueryControls", () => {
   it("opens column search when the filter button creates the first rule", async () => {
     let mounted: ReturnType<typeof mountComponent>;
-    const firstRule = { id: "r1", columnName: "", mode: "equals" as const, rawValue: "", rawEndValue: "", conjunction: "AND" as const };
+    const firstRule = {
+      id: "r1",
+      columnName: "",
+      mode: "equals" as const,
+      rawValue: "",
+      rawEndValue: "",
+      conjunction: "AND" as const,
+    };
     const ensureRule = vi.fn(() => {
       void mounted.setProps({ rules: [firstRule], filterBuilderOpen: true });
     });
@@ -1003,7 +1263,16 @@ describe("DataGridQueryControls", () => {
       hasLocalColumnFilters: false,
       localFilterCount: 0,
       localFilterSummaries: [],
-      rules: [{ id: "r1", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "id",
+          mode: "equals",
+          rawValue: "1",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       filteredColumns: ["id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
       columnSearch: "",
@@ -1039,7 +1308,16 @@ describe("DataGridQueryControls", () => {
       hasLocalColumnFilters: false,
       localFilterCount: 0,
       localFilterSummaries: [],
-      rules: [{ id: "r1", columnName: "appointmentStatusWithAnExceptionallyLongName", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "appointmentStatusWithAnExceptionallyLongName",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       filteredColumns: ["appointmentStatusWithAnExceptionallyLongName"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
       columnSearch: "",
@@ -1078,7 +1356,16 @@ describe("DataGridQueryControls", () => {
       hasLocalColumnFilters: false,
       localFilterCount: 0,
       localFilterSummaries: [],
-      rules: [{ id: "r1", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "id",
+          mode: "equals",
+          rawValue: "1",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       filteredColumns: ["id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
       columnSearch: "",
@@ -1136,7 +1423,16 @@ describe("DataGridQueryControls", () => {
       hasLocalColumnFilters: false,
       localFilterCount: 0,
       localFilterSummaries: [],
-      rules: [{ id: "r1", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       filteredColumns: ["id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
       columnSearch: "",
@@ -1149,7 +1445,10 @@ describe("DataGridQueryControls", () => {
     expect(hostText(mounted.root)).not.toContain("grid.filterConditionView");
     expect(findAll(mounted.root, (node) => node.type === "button" && String(node.props.class).includes("-translate-x-1"))).toHaveLength(1);
 
-    await mounted.setProps({ filterEditorView: "conditions", filterBuilderOpen: false });
+    await mounted.setProps({
+      filterEditorView: "conditions",
+      filterBuilderOpen: false,
+    });
     await nextTick();
     expect(findOne(mounted.root, (node) => node.type === "textarea" && node.props.placeholder === "WHERE")).toBeTruthy();
     expect(findAll(mounted.root, (node) => node.type === "button" && String(node.props.class).includes("-translate-x-1"))).toHaveLength(0);
@@ -1162,7 +1461,14 @@ describe("DataGridFilterWorkbench", () => {
       callback(0);
       return 1;
     });
-    const firstRule = { id: "r1", columnName: "id", mode: "equals" as const, rawValue: "1", rawEndValue: "", conjunction: "AND" as const };
+    const firstRule = {
+      id: "r1",
+      columnName: "id",
+      mode: "equals" as const,
+      rawValue: "1",
+      rawEndValue: "",
+      conjunction: "AND" as const,
+    };
     const mounted = mountComponent(DataGridFilterWorkbench, {
       sqlPreview: "WHERE id = 1",
       rules: [firstRule],
@@ -1175,7 +1481,9 @@ describe("DataGridFilterWorkbench", () => {
     scroller.scrollTop = 0;
     scroller.scrollHeight = 480;
 
-    await mounted.setProps({ rules: [firstRule, { ...firstRule, id: "r2", columnName: "name" }] });
+    await mounted.setProps({
+      rules: [firstRule, { ...firstRule, id: "r2", columnName: "name" }],
+    });
     await nextTick();
 
     expect(scroller.scrollTop).toBe(480);
@@ -1185,7 +1493,16 @@ describe("DataGridFilterWorkbench", () => {
   it("does not auto-open field search in the conditions view", async () => {
     const mounted = mountComponent(DataGridFilterWorkbench, {
       sqlPreview: "",
-      rules: [{ id: "r1", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "",
+          mode: "equals",
+          rawValue: "",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["id", "name"],
       filteredColumns: ["id", "name"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -1207,8 +1524,22 @@ describe("DataGridFilterWorkbench", () => {
     const mounted = mountComponent(DataGridFilterWorkbench, {
       sqlPreview: "WHERE (tenant_id = 7) AND (status = 'open')",
       rules: [
-        { id: "r1", columnName: "tenant_id", mode: "equals", rawValue: "7", rawEndValue: "", conjunction: "AND" },
-        { id: "r2", columnName: "status", mode: "equals", rawValue: "open", rawEndValue: "", conjunction: "AND" },
+        {
+          id: "r1",
+          columnName: "tenant_id",
+          mode: "equals",
+          rawValue: "7",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+        {
+          id: "r2",
+          columnName: "status",
+          mode: "equals",
+          rawValue: "open",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
       ],
       columns: ["id", "tenant_id", "status"],
       filteredColumns: ["id", "tenant_id", "status"],
@@ -1289,7 +1620,16 @@ describe("DataGridTextFilterWorkbench", () => {
     const mounted = mountComponent(DataGridTextFilterWorkbench, {
       height: 168,
       sqlPreview: "WHERE account_id = 7",
-      rules: [{ id: "r1", columnName: "account_id", mode: "equals", rawValue: "7", rawEndValue: "", conjunction: "AND" }],
+      rules: [
+        {
+          id: "r1",
+          columnName: "account_id",
+          mode: "equals",
+          rawValue: "7",
+          rawEndValue: "",
+          conjunction: "AND",
+        },
+      ],
       columns: ["account_id"],
       filteredColumns: ["account_id"],
       modeOptions: [{ value: "equals", labelKey: "equals" }],
@@ -1314,7 +1654,10 @@ describe("DataGridTextFilterWorkbench", () => {
 
     rulesArea.focus = vi.fn();
     dispatch(rulesArea, "pointerdown");
-    const addShortcut = dispatch(rulesArea, "keydown", { key: "Enter", shiftKey: true });
+    const addShortcut = dispatch(rulesArea, "keydown", {
+      key: "Enter",
+      shiftKey: true,
+    });
     dispatch(rulesArea, "keydown", { key: "Enter", shiftKey: false });
     expect(rulesArea.focus).toHaveBeenCalledOnce();
     expect(addShortcut.defaultPrevented).toBe(true);
@@ -1383,7 +1726,15 @@ describe("cell detail surfaces", () => {
 
   it("keeps non-MySQL BLOB detail previews in hex", () => {
     const panel = mountComponent(DataGridCellDetailPanel, {
-      detail: detail({ type: "BLOB", value: "0x2332303035383035", rawValue: "0x2332303035383035", rawValuePreview: "0x2332303035383035", displayValue: "BLOB [8 bytes]", displayValuePreview: "BLOB [8 bytes]", formattedJson: "" }),
+      detail: detail({
+        type: "BLOB",
+        value: "0x2332303035383035",
+        rawValue: "0x2332303035383035",
+        rawValuePreview: "0x2332303035383035",
+        displayValue: "BLOB [8 bytes]",
+        displayValuePreview: "BLOB [8 bytes]",
+        formattedJson: "",
+      }),
       panelIsBottom: true,
       metadataCollapsed: false,
       valueFillsHeight: false,
@@ -1406,7 +1757,13 @@ describe("cell detail surfaces", () => {
 
   it("keeps non-text LONG BLOB values in hex", () => {
     const panel = mountComponent(DataGridCellDetailPanel, {
-      detail: detail({ type: "LONGBLOB", value: "0x89504e470d0a1a0a", rawValue: "0x89504e470d0a1a0a", rawValuePreview: "0x89504e470d0a1a0a", formattedJson: "" }),
+      detail: detail({
+        type: "LONGBLOB",
+        value: "0x89504e470d0a1a0a",
+        rawValue: "0x89504e470d0a1a0a",
+        rawValuePreview: "0x89504e470d0a1a0a",
+        formattedJson: "",
+      }),
       panelIsBottom: true,
       metadataCollapsed: false,
       valueFillsHeight: false,
@@ -1462,9 +1819,13 @@ describe("cell detail surfaces", () => {
     );
     expect(importBinaryValue).toHaveBeenCalledOnce();
 
-    await mounted.setProps({ detail: detail({ rawValue: '{"b":2}', formattedJson: '{\n  "b": 2\n}' }) });
+    await mounted.setProps({
+      detail: detail({ rawValue: '{"b":2}', formattedJson: '{\n  "b": 2\n}' }),
+    });
     expect(mocks.editor.setValue).toHaveBeenCalledWith('{\n  "b": 2\n}', "json");
-    await mounted.setProps({ detail: detail({ value: null, rawValue: "", formattedJson: "" }) });
+    await mounted.setProps({
+      detail: detail({ value: null, rawValue: "", formattedJson: "" }),
+    });
     expect(mocks.editor.destroy).toHaveBeenCalledOnce();
 
     const dialog = findOne(mounted.root, (node) => node.props["data-stub"] === "Dialog");
@@ -1527,13 +1888,19 @@ describe("cell detail surfaces", () => {
         }),
       },
     };
-    const lineTarget = { closest: (selector: string) => (selector === ".cm-line" ? textLine : null) };
+    const lineTarget = {
+      closest: (selector: string) => (selector === ".cm-line" ? textLine : null),
+    };
 
     doubleClickCapture({ target: lineTarget, clientX: 60, clientY: 30 });
     expect(startEdit).toHaveBeenCalledTimes(2);
 
     doubleClickCapture({ target: lineTarget, clientX: 160, clientY: 30 });
-    doubleClickCapture({ target: { closest: () => null }, clientX: 60, clientY: 80 });
+    doubleClickCapture({
+      target: { closest: () => null },
+      clientX: 60,
+      clientY: 80,
+    });
     expect(startEdit).toHaveBeenCalledTimes(4);
   });
 

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridPaintTheme.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridPaintTheme.spec.ts
@@ -178,6 +178,23 @@ describe("data grid paint theme", () => {
     expect(dark.cellDirty).toBe("rgb(94, 75, 26)");
   });
 
+  it("keeps the whole-row selection clearly deeper than the pale selection overlay", () => {
+    const emptyCssVariable = () => "";
+    const light = resolveDataGridPaintTheme({ getVar: emptyCssVariable, isDark: false });
+    const dark = resolveDataGridPaintTheme({ getVar: emptyCssVariable, isDark: true });
+
+    expect(light.rowSelected).toBe("rgb(147, 197, 253)");
+    expect(light.rowSelectedDirty).toBe("rgb(216, 213, 158)");
+    expect(light.rowNumberSelected).toBe("rgb(147, 197, 253)");
+    expect(dark.rowSelected).toBe("rgb(37, 78, 116)");
+    expect(dark.rowSelectedDirty).toBe("rgb(92, 88, 50)");
+    expect(dark.rowNumberSelected).toBe("rgb(37, 78, 116)");
+
+    // 整行选中必须比选区覆盖淡色指示更醒目：与白色背景的对比度更高
+    expect(contrastRatio(light.rowSelected, "rgb(255, 255, 255)")).toBeGreaterThan(contrastRatio(light.cellSelected, "rgb(255, 255, 255)"));
+    expect(contrastRatio(light.rowSelected, "rgb(255, 255, 255)")).toBeGreaterThanOrEqual(1.5);
+  });
+
   it("honors an explicit --data-grid-cell-selected-border token when provided in light mode", () => {
     const vars: Record<string, string> = {
       "--background": "rgb(255, 255, 255)",

--- a/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
+++ b/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
@@ -147,8 +147,9 @@ export function resolveCanvasBackingStoreMetrics(options: { width: number; heigh
   };
 }
 
-export function resolveCanvasDataGridRowFill(theme: Pick<DataGridPaintTheme, "cellActive" | "cellSelected">, rowBase: string, options: { isActive: boolean; isDeleted: boolean; isSelected: boolean }): string {
-  if (options.isSelected) return theme.cellSelected;
+export function resolveCanvasDataGridRowFill(theme: Pick<DataGridPaintTheme, "cellActive" | "rowSelected">, rowBase: string, options: { isActive: boolean; isDeleted: boolean; isSelected: boolean }): string {
+  // 整行选中用专属深色 token，与选区覆盖淡色指示（cellSelected）区分层级
+  if (options.isSelected) return theme.rowSelected;
   if (options.isActive && !options.isDeleted) return theme.cellActive;
   return rowBase;
 }
@@ -533,7 +534,8 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
         ctx.fillRect(clippedX, y, cellPaintWidth, CANVAS_DATA_GRID_ROW_HEIGHT);
       }
       if (selectedFillVisual && isDirtyCell) {
-        ctx.fillStyle = theme.cellSelectedDirty;
+        // 行选中时脏格跟随整行选中色加深；仅格选中时维持原有选区脏格色
+        ctx.fillStyle = rowSelectionVisual ? theme.rowSelectedDirty : theme.cellSelectedDirty;
         ctx.fillRect(clippedX, y, cellPaintWidth, CANVAS_DATA_GRID_ROW_HEIGHT);
       }
       if (isSearchMatch) {

--- a/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
@@ -21,6 +21,10 @@ export interface DataGridPaintTheme {
   cellSelectedBorder: string;
   cellSelectedSingle: string;
   cellSelectedSingleBorder: string;
+  /** 整行选中背景：比选区覆盖淡色指示更深，点击行号选中整行时醒目显示 */
+  rowSelected: string;
+  /** 整行选中行内的脏单元格背景：跟随整行选中色同步加深的黄褐变体 */
+  rowSelectedDirty: string;
   cellHover: string;
   cellSearch: string;
   cellCurrentSearch: string;
@@ -280,6 +284,8 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
   const cellSelectedDirty = isDark ? "rgb(76, 66, 38)" : "rgb(235, 224, 184)";
   const cellSelectedBorder = isDark ? "rgb(96, 165, 250)" : "rgb(59, 130, 246)";
   const cellSelectedSingle = isDark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)";
+  const rowSelected = isDark ? "rgb(37, 78, 116)" : "rgb(147, 197, 253)";
+  const rowSelectedDirty = isDark ? "rgb(92, 88, 50)" : "rgb(216, 213, 158)";
   const cellHover = accent;
   const cellSearch = isDark ? DATA_GRID_DARK_SEARCH_COLORS.match : "rgb(253, 245, 184)";
   const cellCurrentSearch = isDark ? DATA_GRID_DARK_SEARCH_COLORS.current : "rgba(253, 224, 71, 0.52)";
@@ -289,7 +295,7 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
   const rowNumberEdited = isDark ? DATA_GRID_DARK_ROW_NUMBER_EDITED_BG : DATA_GRID_LIGHT_ROW_NUMBER_EDITED_BG;
   const rowNumberDeleted = isDark ? DATA_GRID_DARK_ROW_NUMBER_DELETED_BG : DATA_GRID_LIGHT_ROW_NUMBER_DELETED_BG;
   const rowNumberActive = activeSurface;
-  const rowNumberSelected = isDark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)";
+  const rowNumberSelected = isDark ? "rgb(37, 78, 116)" : "rgb(147, 197, 253)";
   const typeDefaults = defaultDataGridTypeColors(isDark);
   const typeForegrounds = { unknown: foreground } as DataGridTypeForegrounds;
   for (const key of DATA_GRID_TYPE_COLOR_KEYS) {
@@ -314,6 +320,8 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
     cellSelectedBorder: paintToken(getVar, "--data-grid-cell-selected-border", cellSelectedBorder),
     cellSelectedSingle: paintToken(getVar, "--data-grid-cell-selected-single-bg", cellSelectedSingle),
     cellSelectedSingleBorder: paintToken(getVar, "--data-grid-cell-selected-single-border", primary),
+    rowSelected: paintToken(getVar, "--data-grid-row-selected-bg", rowSelected),
+    rowSelectedDirty: paintToken(getVar, "--data-grid-row-selected-dirty-bg", rowSelectedDirty),
     cellHover: isDark ? cellHover : paintToken(getVar, "--data-grid-cell-hover-bg", cellHover),
     cellSearch: isDark ? cellSearch : paintToken(getVar, "--data-grid-cell-search-bg", cellSearch),
     cellCurrentSearch: isDark ? cellCurrentSearch : paintToken(getVar, "--data-grid-cell-current-search-bg", cellCurrentSearch),

--- a/apps/desktop/src/stores/__tests__/connectionStore.findConnectionNode.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.findConnectionNode.spec.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TreeNode } from "@/types/database";
 
 function installLocalStorage() {
@@ -17,6 +17,15 @@ describe("connection root lookup", () => {
     vi.unstubAllGlobals();
     installLocalStorage();
     setActivePinia(createPinia());
+  });
+
+  afterEach(async () => {
+    // markConnectionLost 内部会 fire-and-forget 地动态 import queryStore（产品代码
+    // 刻意如此，用于打破 connectionStore 与 queryStore 的循环依赖）。若不等这个
+    // 导入完成就结束测试，CI 高负载下模块加载可能拖到环境销毁之后，产生
+    // EnvironmentTeardownError 的 unhandled rejection 并使整个测试进程以退出码 1
+    // 失败。这里显式等待所有在途动态导入 settle 后再交还控制权。
+    await vi.dynamicImportSettled();
   });
 
   it("finds a connection nested inside connection groups", async () => {

--- a/packages/app-tests/canvasDataGridRenderer.test.ts
+++ b/packages/app-tests/canvasDataGridRenderer.test.ts
@@ -52,11 +52,25 @@ test("DataGrid forwards hover action reservation only for right-aligned canvas c
 });
 
 test("canvas row fill keeps frozen and scrolling regions on the same selection surface", () => {
-  const theme = { cellActive: "active-blue", cellSelected: "selected-blue" };
+  const theme = { cellActive: "active-blue", rowSelected: "row-selected-blue" };
 
   assert.equal(resolveCanvasDataGridRowFill(theme, "base", { isActive: true, isDeleted: false, isSelected: false }), "active-blue");
-  assert.equal(resolveCanvasDataGridRowFill(theme, "base", { isActive: true, isDeleted: false, isSelected: true }), "selected-blue");
+  assert.equal(resolveCanvasDataGridRowFill(theme, "base", { isActive: true, isDeleted: false, isSelected: true }), "row-selected-blue");
   assert.equal(resolveCanvasDataGridRowFill(theme, "deleted", { isActive: true, isDeleted: true, isSelected: false }), "deleted");
+});
+
+test("paint theme exposes a dedicated deep row-selected token apart from the pale selection overlay", () => {
+  const getVar = () => "";
+
+  const light = resolveDataGridPaintTheme({ getVar, isDark: false });
+  const dark = resolveDataGridPaintTheme({ getVar, isDark: true });
+
+  assert.equal(light.rowSelected, "rgb(147, 197, 253)");
+  assert.equal(light.rowSelectedDirty, "rgb(216, 213, 158)");
+  assert.equal(light.rowNumberSelected, "rgb(147, 197, 253)");
+  assert.equal(dark.rowSelected, "rgb(37, 78, 116)");
+  assert.equal(dark.rowSelectedDirty, "rgb(92, 88, 50)");
+  assert.equal(dark.rowNumberSelected, "rgb(37, 78, 116)");
 });
 
 test("data grid paint themes use the increased striped row contrast", () => {

--- a/packages/app-tests/dataGridSelectionContrast.test.ts
+++ b/packages/app-tests/dataGridSelectionContrast.test.ts
@@ -10,3 +10,16 @@ test("data grid selection colors stay on the classic blue palette", () => {
   assert.doesNotMatch(source, /--data-grid-cell-selected-border:\s*color-mix\(in srgb, var\(--ring\)/);
   assert.doesNotMatch(source, /--data-grid-cell-selected-bg:\s*color-mix\(in srgb, var\(--primary\)/);
 });
+
+test("whole-row selection keeps its own deeper tokens in both render modes", () => {
+  const source = readFileSync("apps/desktop/src/components/grid/DataGrid.vue", "utf8");
+  // DOM 模式：整行选中使用专属深色 token（亮色 blue-300 / 暗色加深蓝）
+  assert.match(source, /--data-grid-row-selected-bg:\s*rgb\(147,\s*197,\s*253\)/);
+  assert.match(source, /--data-grid-row-selected-bg:\s*rgb\(37,\s*78,\s*116\)/);
+  assert.match(source, /"--data-grid-row-selected-bg":\s*dark \? "rgb\(37, 78, 116\)" : "rgb\(147, 197, 253\)"/);
+  assert.match(source, /--data-grid-row-selected-dirty-bg:\s*rgb\(216,\s*213,\s*158\)/);
+  assert.match(source, /\.row-cell-selected\s*\{\s*background-color:\s*var\(--data-grid-row-selected-bg\) !important;/);
+  assert.match(source, /\.row-cell-selected-dirty\s*\{\s*background-color:\s*var\(--data-grid-row-selected-dirty-bg\) !important;/);
+  // 选区覆盖淡色指示保持原浅色，不随整行选中加深
+  assert.match(source, /\.data-grid-row-number--in-selection\s*\{\s*background-color:\s*var\(--data-grid-cell-selected-bg\);/);
+});


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
- 实现整行选中时使用更深颜色区分于选区覆盖淡色指示
## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
<img width="2046" height="1369" alt="20260820094655" src="https://github.com/user-attachments/assets/24875114-1690-4067-aea5-49ded86b10c8" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #6688 #7026