### PR TITLE
fix(sidebar): expand connection node on double-click activation

### DIFF
--- a/apps/desktop/src/lib/__tests__/sidebar/treeNodeClick.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/treeNodeClick.spec.ts
@@ -78,6 +78,12 @@ describe("treeNodeClick", () => {
     expect(treeNodeRowDoubleClickAction("connection", false, "double", true, "postgres", false)).toBe("toggle");
   });
 
+  it("expands the connection node on double-click activation even when the database browser is available", () => {
+    expect(treeNodeRowDoubleClickAction("connection", false, "double", true, "postgres", true)).toBe("toggle");
+    expect(treeNodeRowDoubleClickAction("connection", false, "double", true, "mysql", true)).toBe("toggle");
+    expect(treeNodeRowDoubleClickAction("connection", false, "double", false, "postgres", true)).toBe("none");
+  });
+
   it("opens the object browser on single click when the database single-click switch is on", () => {
     expect(treeNodeRowAction("database", true, "single", "postgres", true, true)).toBe("open-object-browser-and-expand");
     expect(treeNodeRowAction("database", false, "single", "postgres", true, true)).toBe("open-object-browser");

--- a/apps/desktop/src/lib/sidebar/treeNodeClick.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeClick.ts
@@ -147,7 +147,9 @@ export function treeNodeRowDoubleClickAction(type: TreeNodeType, canOpenObjectBr
   // sequence. Only double-click activation needs a second-stage table action.
   if (type === "table") return activation === "double" ? "activate-data" : "none";
   if (openDatabaseOnSingleClick && canOpenObjectBrowser && shouldOpenObjectBrowserOnSingleClick(type, true)) return "none";
-  if (type === "connection" && canOpenDatabaseBrowser) return "open-database-browser";
+  // 双击激活模式下，双击连接节点应当展开树（与单击模式下单击展开一致），
+  // “打开数据库浏览”只保留给单击激活模式下的双击手势。
+  if (type === "connection" && canOpenDatabaseBrowser && activation !== "double") return "open-database-browser";
   if (activation === "double") {
     if (type === "extension") return "open-extension-details";
     if (dataNodeTypes.has(type)) return "open-data";


### PR DESCRIPTION
## 问题

导航激活方式设置为「双击」时，双击侧边栏中 PostgreSQL / MySQL 这类数据库的连接节点不会展开树（单击和点击展开图标正常）；Redis、Elasticsearch 等双击展开正常。

## 根因

`treeNodeRowDoubleClickAction`（`apps/desktop/src/lib/sidebar/treeNodeClick.ts`）中，connection 节点的 `open-database-browser` 分支（只要 manifest 里 `objectBrowser: true` 就命中）排在双击激活模式的 `toggle` 分支之前。PG/MySQL 的 `objectBrowser: true`，双击被劫持为「打开数据库浏览标签页」而不展开；Redis/ES 的 `objectBrowser: false`，不命中该分支，双击正常落到 `toggle`。

## 修复

`open-database-browser` 分支增加 `activation !== "double"` 条件：

- 双击激活模式：双击 connection 节点落到 `canExpand → "toggle"`，正常展开树；
- 单击激活模式：双击打开数据库浏览标签页的行为保持不变。

## 测试

- 新增回归用例：双击激活 + `canOpenDatabaseBrowser=true` 时 PG/MySQL 连接节点返回 `toggle`、不可展开时返回 `none`；
- `treeNodeClick.spec.ts` 全部 21 个用例通过。