### PR TITLE
fix：修复 GaussDB B/M 兼容模式查询结果无法提交

### DIFF
--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -1818,7 +1818,9 @@ fn data_grid_save_execution_schema(
     driver_profile: Option<&str>,
     table_meta: &DataGridTableMeta,
 ) -> Option<String> {
-    if matches!(database_type, Some(DatabaseType::Neo4j | DatabaseType::Oracle)) {
+    let is_gaussdb_m = database_type == Some(DatabaseType::Gaussdb)
+        && driver_profile.is_some_and(|profile| profile.eq_ignore_ascii_case("gaussdb-m"));
+    if matches!(database_type, Some(DatabaseType::Neo4j | DatabaseType::Oracle)) || is_gaussdb_m {
         return None;
     }
     crate::sql_dialect::table_data_schema(database_type, driver_profile, table_meta.schema.as_deref())
@@ -5524,6 +5526,36 @@ mod tests {
 
         assert_eq!(result.validation_error, None);
         assert_eq!(result.statements, vec!["UPDATE schema_01.table_01 SET name = 'new' WHERE id = 1;"]);
+        assert_eq!(result.execution_schema.as_deref(), Some("schema_01"));
+    }
+
+    #[test]
+    fn gaussdb_m_save_preserves_database_qualifier_without_execution_schema() {
+        let result = prepare_data_grid_save_for_driver_profile(
+            DataGridSaveStatementOptions {
+                database_type: Some(DatabaseType::Gaussdb),
+                identifier_quote: Some("`".to_string()),
+                table_meta: DataGridTableMeta {
+                    catalog: None,
+                    database: Some("muts".to_string()),
+                    schema: Some("muts".to_string()),
+                    table_name: "mk_sv_busi_param".to_string(),
+                    primary_keys: vec!["id".to_string()],
+                    columns: Some(vec![column("id", "integer", false, None), column("name", "varchar", false, None)]),
+                },
+                columns: vec!["id".to_string(), "name".to_string()],
+                source_columns: None,
+                rows: vec![vec![json!(1), json!("old")]],
+                dirty_rows: vec![(0, vec![(1, json!("new"))])],
+                deleted_rows: vec![],
+                new_rows: vec![],
+            },
+            Some("GaussDB-M"),
+        );
+
+        assert_eq!(result.validation_error, None);
+        assert_eq!(result.statements, vec!["UPDATE muts.mk_sv_busi_param SET name = 'new' WHERE id = 1;"]);
+        assert_eq!(result.execution_schema, None);
     }
 
     #[test]


### PR DESCRIPTION
## 问题

GaussDB B/M 兼容模式下，数据库名会出现在查询结果的两段表名中，例如 `muts.mk_sv_busi_param`。DBX 将 `muts` 同时作为 `database` 和 `executionSchema` 传给 JDBC/执行层，随后错误执行 `setSchema("muts")`，报 `schema "muts" does not exist`。

此前仅按 `driver_profile=gaussdb-m` 处理，普通 GaussDB 连接到 B 兼容数据库时仍会复现。

## 修复

- GaussDB 探测为反引号标识符语义（B/M/MySQL 兼容模式）时，不再返回 `executionSchema`
- 保留 `muts.table` 数据库限定名，更新 SQL 仍按数据库语义生成
- 厂商 M JDBC profile 继续保留兜底判断
- 双引号标识符语义的 A/PG/Oracle 兼容模式继续返回并切换 schema
- 增加 B 兼容模式回归测试，保留原生 schema 模式回归断言

## 验证

- 修复前新增 B 兼容用例稳定复现：`executionSchema` 错误返回 `muts`
- 修复后 `data_grid_sql::tests`：131 passed，0 failed
- CI 同款 feature 组合的 `dbx-core --all-targets` Clippy 通过
- 免密后端 HTTP 实际验证：B 兼容请求生成 `UPDATE muts.mk_sv_busi_param ...` 且不返回 `executionSchema`；双引号 PG 兼容请求仍返回 `executionSchema: public`
- 之前使用真实 GaussDB/openGauss 5.0.0 临时表验证原生 schema 模式 UPDATE 成功，本次修改继续保留该路径

本地没有用户的 GaussDB B 服务端连接配置，因此 B 模式使用真实 DBX HTTP 保存接口和生成 SQL 完成验证，未将模拟请求描述为 B 服务端端到端验证。