### PR TITLE
fix：修复 GaussDB B 兼容模式查询结果无法提交

### DIFF
--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -312,6 +312,7 @@ pub fn prepare_data_grid_save_for_driver_profile(
             execution_schema: data_grid_save_execution_schema(
                 options.database_type,
                 driver_profile,
+                options.identifier_quote.as_deref(),
                 &options.table_meta,
             ),
         };
@@ -321,7 +322,12 @@ pub fn prepare_data_grid_save_for_driver_profile(
         validation_error: None,
         statements: build_data_grid_save_statements(&options, driver_profile),
         rollback_statements: build_data_grid_rollback_statements(&options, driver_profile),
-        execution_schema: data_grid_save_execution_schema(options.database_type, driver_profile, &options.table_meta),
+        execution_schema: data_grid_save_execution_schema(
+            options.database_type,
+            driver_profile,
+            options.identifier_quote.as_deref(),
+            &options.table_meta,
+        ),
     }
 }
 
@@ -1816,11 +1822,13 @@ fn copy_column_info(
 fn data_grid_save_execution_schema(
     database_type: Option<DatabaseType>,
     driver_profile: Option<&str>,
+    identifier_quote: Option<&str>,
     table_meta: &DataGridTableMeta,
 ) -> Option<String> {
-    let is_gaussdb_m = database_type == Some(DatabaseType::Gaussdb)
-        && driver_profile.is_some_and(|profile| profile.eq_ignore_ascii_case("gaussdb-m"));
-    if matches!(database_type, Some(DatabaseType::Neo4j | DatabaseType::Oracle)) || is_gaussdb_m {
+    let uses_gaussdb_database_namespace = database_type == Some(DatabaseType::Gaussdb)
+        && (driver_profile.is_some_and(|profile| profile.eq_ignore_ascii_case("gaussdb-m"))
+            || identifier_quote.is_some_and(|quote| quote.trim() == "`"));
+    if matches!(database_type, Some(DatabaseType::Neo4j | DatabaseType::Oracle)) || uses_gaussdb_database_namespace {
         return None;
     }
     crate::sql_dialect::table_data_schema(database_type, driver_profile, table_meta.schema.as_deref())
@@ -5551,6 +5559,35 @@ mod tests {
                 new_rows: vec![],
             },
             Some("GaussDB-M"),
+        );
+
+        assert_eq!(result.validation_error, None);
+        assert_eq!(result.statements, vec!["UPDATE muts.mk_sv_busi_param SET name = 'new' WHERE id = 1;"]);
+        assert_eq!(result.execution_schema, None);
+    }
+
+    #[test]
+    fn gaussdb_b_compat_save_preserves_database_qualifier_without_execution_schema() {
+        let result = prepare_data_grid_save_for_driver_profile(
+            DataGridSaveStatementOptions {
+                database_type: Some(DatabaseType::Gaussdb),
+                identifier_quote: Some("`".to_string()),
+                table_meta: DataGridTableMeta {
+                    catalog: None,
+                    database: Some("muts".to_string()),
+                    schema: Some("muts".to_string()),
+                    table_name: "mk_sv_busi_param".to_string(),
+                    primary_keys: vec!["id".to_string()],
+                    columns: Some(vec![column("id", "integer", false, None), column("name", "varchar", false, None)]),
+                },
+                columns: vec!["id".to_string(), "name".to_string()],
+                source_columns: None,
+                rows: vec![vec![json!(1), json!("old")]],
+                dirty_rows: vec![(0, vec![(1, json!("new"))])],
+                deleted_rows: vec![],
+                new_rows: vec![],
+            },
+            Some("gaussdb"),
         );
 
         assert_eq!(result.validation_error, None);


### PR DESCRIPTION
## 问题

这是 #6732 的后续修复。#6732 已合并并解决 GaussDB M 模式问题，但普通 GaussDB 连接到 B 兼容数据库时仍会复现：数据库名 `muts` 被同时作为 `database` 和 `executionSchema`，执行时错误调用 `setSchema("muts")`，报 `schema "muts" does not exist`。

## 修复

- GaussDB 使用反引号标识符语义时，视为 B/M/MySQL 兼容模式，不再返回 `executionSchema`
- 保留 `muts.table` 数据库限定名，生成的 UPDATE SQL 不变
- 双引号标识符语义的 A/PG/Oracle 兼容模式继续返回 schema 执行上下文
- 增加普通 `driver_profile=gaussdb` + 反引号语义的回归测试

## 验证

- 修复前 B 兼容回归用例稳定复现 `executionSchema: muts`
- 修复后 GaussDB 定向测试：3 passed，0 failed
- `data_grid_sql::tests`：131 passed，0 failed
- `cargo fmt --check`、`git diff --check` 和 CI 同款 Clippy 通过
- 免密后端 HTTP 实际验证：B 兼容请求生成 `UPDATE muts.mk_sv_busi_param ...` 且不返回 `executionSchema`；双引号 PG 兼容请求仍返回 `executionSchema: public`

本地没有用户的 GaussDB B 服务端连接配置，因此 B 模式验证覆盖了真实 DBX HTTP 保存接口和 SQL 生成契约，未将其描述为 B 服务端端到端验证。