### PR TITLE
修复：选择 MongoDB OIDC 后连接表单布局错乱

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -6964,9 +6964,12 @@ function openExternalUrl(url: string) {
                         </SelectContent>
                       </Select>
                     </div>
-                    <p v-if="mongoAuthMechanism === 'MONGODB-OIDC'" class="col-start-2 col-span-3 text-xs text-muted-foreground">
-                      {{ t("connection.oidcBrowserAuthHint") }}
-                    </p>
+                    <div v-if="mongoAuthMechanism === 'MONGODB-OIDC'" class="grid grid-cols-4 items-start gap-4">
+                      <span />
+                      <p class="col-span-3 text-xs text-muted-foreground">
+                        {{ t("connection.oidcBrowserAuthHint") }}
+                      </p>
+                    </div>
                     <div class="grid grid-cols-4 items-center gap-4">
                       <Label :class="connectionLabelClass">{{ t("connection.urlParams") }}</Label>
                       <Input v-model="form.url_params" class="col-span-3" placeholder="replicaSet=rs0&authSource=admin" />

--- a/apps/desktop/src/lib/__tests__/connection/mongodbOidcConnectionDialog.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/mongodbOidcConnectionDialog.spec.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dialogSource = readFileSync(new URL("../../../components/connection/ConnectionDialog.vue", import.meta.url), "utf8");
+
+describe("MongoDB OIDC connection form", () => {
+  it("keeps the browser authentication hint inside a complete form row", () => {
+    expect(dialogSource).toContain(`<div v-if="mongoAuthMechanism === 'MONGODB-OIDC'" class="grid grid-cols-4 items-start gap-4">`);
+    expect(dialogSource).not.toContain(`<p v-if="mongoAuthMechanism === 'MONGODB-OIDC'" class="col-start-2 col-span-3`);
+  });
+});


### PR DESCRIPTION
问题

选择 MongoDB 的 MONGODB-OIDC 认证机制后，浏览器认证提示直接作为外层表单网格的子元素，并使用了 `col-start-2 col-span-3`。这会让外层网格生成隐式列，导致后续表单行横向排列，页面布局错乱。

修复

将 OIDC 提示放入完整的四列表单行中，保持提示与其他表单字段相同的布局边界，并增加回归测试，防止再次将提示渲染为外层网格的直接跨列子元素。

验证

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/mongodbOidcConnectionDialog.spec.ts`
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/components/connection/ConnectionDialog.vue apps/desktop/src/lib/__tests__/connection/mongodbOidcConnectionDialog.spec.ts`
- `git diff --check`
- 使用 `make dev-fast` 实际检查 MongoDB OIDC 表单布局，表单行恢复纵向排列。