### PR TITLE
fix(portable): 避免数据目录切换时丢失设置和代码片段

### DIFF
--- a/crates/dbx-core/src/storage.rs
+++ b/crates/dbx-core/src/storage.rs
@@ -45,11 +45,20 @@ const USER_DATA_TABLES: &[&str] = &[
     "connections",
     "connection_secrets",
     "history",
+    "ai_config",
+    "ai_provider_configs",
     "ai_conversations",
     "ai_runs",
+    "sidebar_layout",
+    "app_settings",
+    "app_state",
+    "tunnel_profiles",
     "mq_token_records",
     "saved_sql_folders",
     "saved_sql_files",
+    "ai_configs",
+    "state_store",
+    "prompt_templates",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -5520,16 +5529,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn import_user_data_db_recognizes_settings_and_snippets_as_user_data() {
+        let source_dir = temp_data_dir("import-settings-only-source");
+        let source_storage = Storage::open(&source_dir.join("dbx.db")).await.unwrap();
+        source_storage
+            .save_desktop_settings(&DesktopSettings { debug_logging_enabled: true, ..DesktopSettings::default() })
+            .await
+            .unwrap();
+        source_storage
+            .save_editor_settings(&serde_json::json!({
+                "snippets": [{ "id": "custom", "prefix": "selc", "body": "SELECT 42" }]
+            }))
+            .await
+            .unwrap();
+        drop(source_storage);
+        let target_dir = temp_data_dir("import-settings-only-target");
+
+        let result = maybe_import_user_data_db(&target_dir, Some(&source_dir)).unwrap();
+
+        assert_eq!(result, DataDbImportResult::Imported);
+        let storage = Storage::open(&target_dir.join("dbx.db")).await.unwrap();
+        assert!(storage.load_desktop_settings().await.unwrap().debug_logging_enabled);
+        assert_eq!(storage.load_editor_settings().await.unwrap().unwrap()["snippets"][0]["body"], "SELECT 42");
+    }
+
+    #[tokio::test]
+    async fn import_user_data_db_does_not_overwrite_target_with_settings() {
+        let source_dir =
+            create_data_dir_with_connection("import-source-settings-target", "source-connection", "source-token").await;
+        let target_dir = temp_data_dir("import-target-settings-only");
+        let target_storage = Storage::open(&target_dir.join("dbx.db")).await.unwrap();
+        target_storage
+            .save_editor_settings(&serde_json::json!({
+                "snippets": [{ "id": "target", "prefix": "tgt", "body": "SELECT 7" }]
+            }))
+            .await
+            .unwrap();
+        drop(target_storage);
+
+        let result = maybe_import_user_data_db(&target_dir, Some(&source_dir)).unwrap();
+
+        assert_eq!(result, DataDbImportResult::SkippedTargetHasData);
+        let storage = Storage::open(&target_dir.join("dbx.db")).await.unwrap();
+        assert_eq!(storage.load_editor_settings().await.unwrap().unwrap()["snippets"][0]["body"], "SELECT 7");
+    }
+
+    #[tokio::test]
     async fn import_user_data_db_replaces_empty_target_schema() {
         let source_dir =
             create_data_dir_with_connection("import-source-empty-target", "source-connection", "source-token").await;
         let target_dir = temp_data_dir("import-empty-target");
-        let target_storage = Storage::open(&target_dir.join("dbx.db")).await.unwrap();
-        target_storage
-            .save_desktop_settings(&DesktopSettings { debug_logging_enabled: true, ..DesktopSettings::default() })
-            .await
-            .unwrap();
-        drop(target_storage);
+        let _target_storage = Storage::open(&target_dir.join("dbx.db")).await.unwrap();
 
         let result = maybe_import_user_data_db(&target_dir, Some(&source_dir)).unwrap();
 


### PR DESCRIPTION
## 问题

Windows 便携版的数据目录发生切换时，启动兜底迁移仅将连接、历史和 SQL 库等表识别为用户数据。`app_settings` 和 `app_state` 未被识别，导致仅保存了设置或自定义代码片段的数据库被误判为空，启动后表现为恢复默认。

## 修复

- 将设置、编辑器状态、代码片段及其他持久化用户表纳入数据存在性判断
- 允许仅包含设置和代码片段的源数据库参与兜底迁移
- 目标数据库已有设置时保持不覆盖
- 修正“空目标数据库”测试，使其只包含初始化 schema

## 验证

- `cargo test -p dbx-core import_user_data_db --lib`：7 passed
- `cargo test -p dbx-core --lib`：5164 passed, 0 failed, 59 ignored（变基前全量验证）
- `cargo test --manifest-path src-tauri/Cargo.toml data_dir --lib`：9 passed（变基前验证）
- `cargo fmt --all -- --check`
- `git diff --check`

## 待验证

当前开发环境为 macOS，尚未完成 Windows 便携版实际退出、重启及数据目录切换验证，因此先提交为草稿 PR。