### PR TITLE
Fix: 修复部分数据库表数据页空白

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -436,6 +436,14 @@ const props = withDefaults(defineProps<DataGridProps>(), {
   allowDeleteRows: undefined,
 });
 
+const tableColumnsByResultIndex = computed(() =>
+  resolveDataGridColumnsByResultIndex({
+    resultColumns: props.result.columns,
+    sourceColumns: props.sourceColumns,
+    tableColumns: props.tableMeta?.columns ?? [],
+  }),
+);
+
 const dataGridTraceId = uuid().slice(0, 8);
 const dataGridCreatedAt = performance.now();
 const dataGridElapsed = () => `${Math.round(performance.now() - dataGridCreatedAt)}ms`;
@@ -3776,14 +3784,6 @@ function measureCellTextWidthCached(text: string, font: string): number {
   }
   return width;
 }
-
-const tableColumnsByResultIndex = computed(() =>
-  resolveDataGridColumnsByResultIndex({
-    resultColumns: props.result.columns,
-    sourceColumns: props.sourceColumns,
-    tableColumns: props.tableMeta?.columns ?? [],
-  }),
-);
 
 function tableColumnForGridColumn(columnIndex: number): ColumnInfo | undefined {
   return tableColumnsByResultIndex.value[columnIndex];

--- a/apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts
@@ -4,6 +4,14 @@ import { describe, expect, it } from "vitest";
 const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
 
 describe("DataGrid setup initialization order", () => {
+  it("initializes table column metadata before column width measurement", () => {
+    const tableColumnMetadataDeclaration = dataGridSource.indexOf("const tableColumnsByResultIndex = computed");
+    const columnResizeInitialization = dataGridSource.indexOf("useDataGridColumnResize({");
+
+    expect(tableColumnMetadataDeclaration).toBeGreaterThanOrEqual(0);
+    expect(columnResizeInitialization).toBeGreaterThan(tableColumnMetadataDeclaration);
+  });
+
   it("initializes where-search capability before the immediate filter preview watcher", () => {
     const canUseWhereSearchDeclaration = dataGridSource.indexOf("const canUseWhereSearch = computed");
     const filterPreviewDeclaration = dataGridSource.indexOf("const filterPreviewVisible = computed");


### PR DESCRIPTION
## 问题

DataGrid 在初始化列宽时会格式化采样值。当查询结果未返回完整的 `column_types`（SQLite 可稳定触发，PostgreSQL 部分结果也可能触发）时，格式化逻辑会读取表字段映射；该映射此时尚未初始化，抛出 `Cannot access tableColumnsByResultIndex before initialization`，导致整个表数据区域空白。

## 修复

- 在列宽计算前初始化结果列与表字段的映射
- 保持现有字段查找与格式化逻辑不变
- 增加 DataGrid 初始化顺序回归测试

## 验证

- 最新 main 实际复现 SQLite `orders` 数据页空白，修复后正常显示 100 行，控制台 0 错误
- PostgreSQL 16 `core.products` 在 Canvas、DOM 两种模式均正常显示 100 行
- `pnpm check`：format、lint、typecheck、test 全部通过（10292 tests）
- rebase 最新 main 后定向测试：3 files / 39 tests 通过


Closes #6768
