### PR TITLE
fix(sidebar): 修复危险操作取消协议里注册表和状态清理的遗漏

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -1594,6 +1594,10 @@ function openSidebarContextMenu(event: MouseEvent, node: TreeNode, openContextMe
 }
 
 function openSidebarDangerDialog(request: SidebarDangerDialogRequest) {
+  if (sidebarDangerRunningExecutionId.value) {
+    toast(t("contextMenu.dangerOperationAlreadyRunning"), 4000);
+    return;
+  }
   sidebarDangerDialogRequest.value = request;
   sidebarDangerDialogConfirming.value = false;
   // Defense in depth: sidebarDangerDialogCancelling is a singleton shared

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -70,7 +70,6 @@ import { useDatabaseOptions } from "@/composables/useDatabaseOptions";
 import type { ColumnInfo, DatabaseType, TreeNode, TreeNodeType } from "@/types/database";
 import * as api from "@/lib/backend/api";
 import { queryTimeoutSecsForConnection } from "@/lib/sql/queryTimeout";
-import { uuid } from "@/lib/common/utils";
 import { resolveDefaultDatabase } from "@/lib/database/defaultDatabase";
 import { connectionUsesVisibleSchemaFilter } from "@/lib/database/visibleDatabases";
 import { canTreeNodePin, canTreeNodeShowExpander } from "@/lib/sidebar/sidebarTreeItemLayout";
@@ -2508,13 +2507,25 @@ function openRenameObjectDialog() {
 async function executeTreeNodeSqlWithProductionGuard(
   node: Pick<TreeNode, "connectionId" | "database" | "schema">,
   sql: string,
-  options: { database?: string; schema?: string; executeAsScript?: boolean; executionId?: string; isCancelledBeforeDispatch?: () => boolean; markDispatched?: () => void } = {},
+  options: {
+    database?: string;
+    schema?: string;
+    executeAsScript?: boolean;
+    executionId?: string;
+    isCancelledBeforeDispatch?: () => boolean;
+    markDispatched?: () => void;
+  } = {},
 ) {
   if (!node.connectionId) return undefined;
   const database = options.database ?? node.database ?? "";
   const config = connectionStore.getConfig(node.connectionId);
+  // Always resolve the connection's configured timeout the same way the
+  // main editor does — independent of whether this call also wires up
+  // Cancel-button UI. Gating this behind an opt-in flag previously left
+  // every non-danger-dialog caller falling back to the backend's hardcoded
+  // 30s default instead of the user's configured (or unlimited) timeout.
   const timeoutSecs = queryTimeoutSecsForConnection(config, settingsStore.editorSettings.globalQueryTimeoutSecs);
-  const executionId = options.executionId ?? uuid();
+  const executionId = options.executionId;
   return executeWithProductionSqlGuard({
     connection: config,
     database,

--- a/apps/desktop/src/components/sidebar/__tests__/ConnectionTree.dangerDialogGuard.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/ConnectionTree.dangerDialogGuard.spec.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const connectionTreeSource = readFileSync(new URL("../ConnectionTree.vue", import.meta.url), "utf8");
+
+describe("ConnectionTree danger dialog guard", () => {
+  it("refuses to open a new danger dialog while a previous danger operation is still running", () => {
+    expect(connectionTreeSource).toMatch(/function openSidebarDangerDialog\(request: SidebarDangerDialogRequest\) \{\s*if \(sidebarDangerRunningExecutionId\.value\) \{\s*toast\(t\("contextMenu\.dangerOperationAlreadyRunning"\), \d+\);\s*return;\s*\}/);
+  });
+});

--- a/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.executionIdOptIn.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.executionIdOptIn.spec.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../SidebarTreeRuntimeHost.vue", import.meta.url), "utf8");
+
+describe("executeTreeNodeSqlWithProductionGuard executionId", () => {
+  it("only registers a backend execution id for callers that opt in, instead of generating one for every caller", () => {
+    expect(source).toContain("const executionId = options.executionId;");
+    expect(source).not.toMatch(/executionId\s*=\s*options\.executionId\s*\?\?\s*uuid\(\)/);
+  });
+});

--- a/apps/desktop/src/components/sidebar/__tests__/sidebarTreeDialogState.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/sidebarTreeDialogState.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { resetSidebarTreeDialogState, sidebarDangerRunningCancel, sidebarDangerRunningExecutionId } from "../sidebarTreeDialogState";
+
+describe("resetSidebarTreeDialogState", () => {
+  it("clears the danger-running singleton", () => {
+    sidebarDangerRunningExecutionId.value = "exec-1";
+    sidebarDangerRunningCancel.value = () => {};
+
+    resetSidebarTreeDialogState();
+
+    expect(sidebarDangerRunningExecutionId.value).toBe("");
+    expect(sidebarDangerRunningCancel.value).toBeNull();
+  });
+});

--- a/apps/desktop/src/components/sidebar/sidebarTreeDialogState.ts
+++ b/apps/desktop/src/components/sidebar/sidebarTreeDialogState.ts
@@ -241,6 +241,8 @@ export function resetSidebarTreeDialogState() {
   sidebarTreeDialogOwner.value = null;
   sidebarDangerTarget.value = null;
   sidebarFormTarget.value = null;
+  sidebarDangerRunningExecutionId.value = "";
+  sidebarDangerRunningCancel.value = null;
   connectionDeleteTargetSnapshot.value = [];
   connectionGroupDeleteTargetSnapshot.value = [];
   deleteConnectionsWithGroup.value = false;

--- a/apps/desktop/src/composables/__tests__/useSidebarTableMutationRuntime.saphana.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSidebarTableMutationRuntime.saphana.spec.ts
@@ -291,6 +291,10 @@ describe("useSidebarTableMutationRuntime SAP HANA schema-scoped actions", () => 
 
     // Bounded retry, not a single silently-ignored attempt.
     expect(mocks.cancelQuery.mock.calls.length).toBeGreaterThan(1);
+    // The cancel handler itself surfaces feedback the moment its own
+    // confirmation window gives up (before the underlying operation later
+    // settles and reports tableOperationCancelUnconfirmed).
+    expect(mocks.toast).toHaveBeenCalledWith("contextMenu.tableOperationCancelPending", 6000);
     expect(mocks.toast).toHaveBeenCalledWith("contextMenu.tableOperationCancelUnconfirmed", 8000);
     expect(mocks.toast).not.toHaveBeenCalledWith("contextMenu.tableOperationCancelled", 3000);
     expect(mocks.toast).not.toHaveBeenCalledWith("contextMenu.tableOperationFailed", 5000);
@@ -340,10 +344,20 @@ describe("useSidebarTableMutationRuntime SAP HANA schema-scoped actions", () => 
       vi.useRealTimers();
     }
 
+    // A single hung attempt must not block the remaining retries — each
+    // attempt gets its own bounded slice of the overall retry budget.
+    expect(mocks.cancelQuery.mock.calls.length).toBeGreaterThan(1);
     // The closure above must have settled instead of hanging — a stuck
     // cancel handle would otherwise permanently disable the shared
     // sidebarDangerDialogCancelling state for every future danger dialog.
     expect(mocks.toast).not.toHaveBeenCalledWith("contextMenu.tableOperationCancelled", 3000);
+    // Settling silently is not enough on its own: the user must be told the
+    // cancel could not be confirmed instead of the button just going quiet.
+    expect(mocks.toast).toHaveBeenCalledWith("contextMenu.tableOperationCancelPending", 6000);
+    // The operation may genuinely still be running server-side, so the
+    // running-execution state must not be torn down just because the
+    // confirmation window elapsed.
+    expect(sidebarDangerRunningExecutionId.value).not.toBe("");
   });
 
   it.each(actions)("does not report a false success for $action when the user declines the production-safety confirmation", async ({ action }) => {

--- a/apps/desktop/src/composables/useSidebarTableMutationRuntime.ts
+++ b/apps/desktop/src/composables/useSidebarTableMutationRuntime.ts
@@ -254,12 +254,21 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
   // danger dialog's Cancel Query button (sidebarDangerDialogCancelling is a
   // shared singleton — see ConnectionTree.vue).
   const CANCEL_QUERY_OVERALL_TIMEOUT_MS = 10_000;
+  // Each attempt gets an even share of the overall budget, so a single hung
+  // api.cancelQuery call can't block the remaining retries — it can only
+  // ever stop *waiting* on that attempt, not actually abort it (neither
+  // backend transport plumbs an AbortSignal through cancelQuery).
+  const CANCEL_QUERY_PER_ATTEMPT_TIMEOUT_MS = Math.floor(CANCEL_QUERY_OVERALL_TIMEOUT_MS / CANCEL_QUERY_MAX_ATTEMPTS);
 
   async function confirmCancelWithRetry(executionId: string): Promise<boolean> {
     for (let attempt = 0; attempt < CANCEL_QUERY_MAX_ATTEMPTS; attempt++) {
       let confirmed = false;
       try {
-        confirmed = await api.cancelQuery(executionId);
+        let timeoutId: ReturnType<typeof setTimeout>;
+        const attemptTimeout = new Promise<boolean>((resolve) => {
+          timeoutId = setTimeout(() => resolve(false), CANCEL_QUERY_PER_ATTEMPT_TIMEOUT_MS);
+        });
+        confirmed = await Promise.race([api.cancelQuery(executionId), attemptTimeout]).finally(() => clearTimeout(timeoutId));
       } catch {
         confirmed = false;
       }
@@ -268,11 +277,21 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
     return false;
   }
 
-  function confirmCancelWithRetryAndTimeout(executionId: string): Promise<boolean> {
+  // Races the retry loop against a UI-facing deadline, but also returns the
+  // retry loop's own promise so a caller can keep observing it after the
+  // race settles — otherwise a retry that is still running when the timeout
+  // wins would have its eventual result silently discarded.
+  function confirmCancelWithRetryAndTimeout(executionId: string): { confirmedWithinTimeout: Promise<boolean>; retryPromise: Promise<boolean> } {
+    const retryPromise = confirmCancelWithRetry(executionId);
+    let timeoutId: ReturnType<typeof setTimeout>;
     const timeout = new Promise<boolean>((resolve) => {
-      setTimeout(() => resolve(false), CANCEL_QUERY_OVERALL_TIMEOUT_MS);
+      timeoutId = setTimeout(() => resolve(false), CANCEL_QUERY_OVERALL_TIMEOUT_MS);
     });
-    return Promise.race([confirmCancelWithRetry(executionId), timeout]);
+    // Once the retry loop itself settles, the timeout has nothing left to
+    // race against — clear it instead of leaving it to fire (and resolve an
+    // already-settled promise) up to CANCEL_QUERY_OVERALL_TIMEOUT_MS later.
+    void retryPromise.finally(() => clearTimeout(timeoutId));
+    return { confirmedWithinTimeout: Promise.race([retryPromise, timeout]), retryPromise };
   }
 
   const DANGER_OPERATION_CANCELLED_BEFORE_DISPATCH_MESSAGE = "Operation cancelled before it was sent to the database.";
@@ -296,17 +315,51 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
     // confirmed cancel — see markHandedOff below.
     let handedOff = false;
 
+    // Shared by both the immediate (raced) outcome and a later-arriving
+    // retry result so a confirmed cancel is finalized exactly once, however
+    // late it arrives.
+    function finalizeConfirmedCancel() {
+      cancelConfirmedFlag = true;
+      if (handedOff && sidebarDangerRunningExecutionId.value === executionId) {
+        toast(t("contextMenu.tableOperationCancelled", { name: nodeLabel }), 3000);
+        endDangerRunningExecution();
+      }
+    }
+
     sidebarDangerRunningExecutionId.value = executionId;
     sidebarDangerRunningCancel.value = async () => {
       cancelledByUser = true;
       // Nothing has reached the backend yet: the pending dispatch will see
       // isCancelledBeforeDispatch() and skip the network call entirely, so
       // this is already a confirmed cancellation.
-      const confirmed = dispatched ? await confirmCancelWithRetryAndTimeout(executionId) : true;
-      if (confirmed) cancelConfirmedFlag = true;
-      if (handedOff && confirmed && sidebarDangerRunningExecutionId.value === executionId) {
-        toast(t("contextMenu.tableOperationCancelled", { name: nodeLabel }), 3000);
-        endDangerRunningExecution();
+      if (!dispatched) {
+        finalizeConfirmedCancel();
+        return;
+      }
+      const { confirmedWithinTimeout, retryPromise } = confirmCancelWithRetryAndTimeout(executionId);
+      // Do not discard the losing side of the race: if the retry loop is
+      // still going when the UI timeout wins below and it later succeeds,
+      // still finalize the confirmed cancel instead of dropping the result.
+      void retryPromise.then((eventuallyConfirmed) => {
+        if (eventuallyConfirmed) finalizeConfirmedCancel();
+      });
+      const confirmed = await confirmedWithinTimeout;
+      if (confirmed) {
+        finalizeConfirmedCancel();
+      } else if (sidebarDangerRunningExecutionId.value === executionId) {
+        // The confirmation window elapsed with no answer from the database.
+        // The operation may genuinely still be running server-side, so leave
+        // sidebarDangerRunningExecutionId / the running-execution state
+        // intact — the user can retry Cancel or just wait for it to settle
+        // — but don't leave the Cancel button silently usable again with
+        // zero explanation of what happened.
+        //
+        // Only surface this if the execution is still the one being tracked:
+        // by the time this arrives, confirmDropTable/confirmEmptyTable/
+        // confirmTruncateTable may have already resolved (success or an
+        // unrelated failure) and moved on, in which case this stale warning
+        // would contradict the outcome the user already saw.
+        toast(t("contextMenu.tableOperationCancelPending", { name: nodeLabel }), 6000);
       }
     };
 
@@ -341,25 +394,28 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
     }
   }
 
-  async function confirmDropTable() {
-    const node = sidebarDangerTarget.value ?? activeNode.value;
+  interface DangerOperationConfig {
+    node: TreeNode;
+    buildSql: () => string | Promise<string>;
+    onSuccess: (node: TreeNode) => void | Promise<void>;
+  }
+
+  async function runDangerOperation(config: DangerOperationConfig) {
+    const { node, buildSql, onSuccess } = config;
     if (!node.connectionId || node.database == null) return;
     const { executionId, isCancelledBeforeDispatch, markDispatched, wasCancelled, cancelConfirmed, markHandedOff } = beginDangerRunningExecution(node.label);
     try {
       await connectionStore.ensureConnected(node.connectionId);
-      const sql = dropTablePreviewSql.value || (await buildDropTableSql(tableAdminSqlOptionsForNode(node, { cascade: dropTableCascade.value && supportsDropTableCascade(databaseTypeForNode(node)) })));
+      const sql = await buildSql();
       if (isCancelledBeforeDispatch()) throw new Error(DANGER_OPERATION_CANCELLED_BEFORE_DISPATCH_MESSAGE);
       const executed = await options.executeWithProductionGuard(node, sql, { database: node.database, schema: node.schema, executionId, isCancelledBeforeDispatch, markDispatched });
       if (executed === undefined) {
         // The user declined the production-safety confirmation: the SQL was
-        // never sent, so this must not be reported as a successful drop.
+        // never sent, so this must not be reported as a successful operation.
         endDangerRunningExecution();
         return;
       }
-      toast(t("contextMenu.dropTableSuccess", { name: node.label }), 3000);
-      options.closeDroppedTableObjectTabsForNode(node);
-      connectionStore.removeTreeNode(node.id);
-      options.releaseActiveNodeReference([node.id]);
+      await onSuccess(node);
       endDangerRunningExecution();
     } catch (error: any) {
       const message = error?.message || String(error);
@@ -371,6 +427,20 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
         markHandedOff();
       }
     }
+  }
+
+  async function confirmDropTable() {
+    const node = sidebarDangerTarget.value ?? activeNode.value;
+    await runDangerOperation({
+      node,
+      buildSql: () => dropTablePreviewSql.value || buildDropTableSql(tableAdminSqlOptionsForNode(node, { cascade: dropTableCascade.value && supportsDropTableCascade(databaseTypeForNode(node)) })),
+      onSuccess: (node) => {
+        toast(t("contextMenu.dropTableSuccess", { name: node.label }), 3000);
+        options.closeDroppedTableObjectTabsForNode(node);
+        connectionStore.removeTreeNode(node.id);
+        options.releaseActiveNodeReference([node.id]);
+      },
+    });
   }
 
   function emptyTable() {
@@ -380,33 +450,15 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
 
   async function confirmEmptyTable() {
     const node = sidebarDangerTarget.value ?? activeNode.value;
-    if (!node.connectionId || node.database == null) return;
-    const { executionId, isCancelledBeforeDispatch, markDispatched, wasCancelled, cancelConfirmed, markHandedOff } = beginDangerRunningExecution(node.label);
-    try {
-      await connectionStore.ensureConnected(node.connectionId);
-      const sql = emptyTablePreviewSql.value || (await buildEmptyTableSql(tableAdminSqlOptionsForNode(node)));
-      if (isCancelledBeforeDispatch()) throw new Error(DANGER_OPERATION_CANCELLED_BEFORE_DISPATCH_MESSAGE);
-      const executed = await options.executeWithProductionGuard(node, sql, { database: node.database, schema: node.schema, executionId, isCancelledBeforeDispatch, markDispatched });
-      if (executed === undefined) {
-        // The user declined the production-safety confirmation: the SQL was
-        // never sent, so this must not be reported as a successful empty.
-        endDangerRunningExecution();
-        return;
-      }
-      const messageKey = databaseTypeForNode(node) === "clickhouse" ? "contextMenu.emptyTableSubmitted" : "contextMenu.emptyTableSuccess";
-      toast(t(messageKey, { name: node.label }), 3000);
-      await options.refreshMutatedTableDataTabsForNode(node);
-      endDangerRunningExecution();
-    } catch (error: any) {
-      const message = error?.message || String(error);
-      const backendError = normalizeBackendError(error) ?? undefined;
-      toastDangerOperationError(node.label, message, wasCancelled(), cancelConfirmed(), backendError);
-      if (cancelConfirmed() || !isQueryTimeoutErrorMessage(message, backendError)) {
-        endDangerRunningExecution();
-      } else {
-        markHandedOff();
-      }
-    }
+    await runDangerOperation({
+      node,
+      buildSql: () => emptyTablePreviewSql.value || buildEmptyTableSql(tableAdminSqlOptionsForNode(node)),
+      onSuccess: async (node) => {
+        const messageKey = databaseTypeForNode(node) === "clickhouse" ? "contextMenu.emptyTableSubmitted" : "contextMenu.emptyTableSuccess";
+        toast(t(messageKey, { name: node.label }), 3000);
+        await options.refreshMutatedTableDataTabsForNode(node);
+      },
+    });
   }
 
   function truncateTable() {
@@ -417,32 +469,14 @@ export function useSidebarTableMutationRuntime(options: SidebarTableMutationRunt
 
   async function confirmTruncateTable() {
     const node = sidebarDangerTarget.value ?? activeNode.value;
-    if (!node.connectionId || node.database == null) return;
-    const { executionId, isCancelledBeforeDispatch, markDispatched, wasCancelled, cancelConfirmed, markHandedOff } = beginDangerRunningExecution(node.label);
-    try {
-      await connectionStore.ensureConnected(node.connectionId);
-      const sql = truncateTablePreviewSql.value || (await buildTruncateTableSql(tableAdminSqlOptionsForNode(node, { cascade: truncateTableCascade.value && supportsTruncateTableCascade(databaseTypeForNode(node)) })));
-      if (isCancelledBeforeDispatch()) throw new Error(DANGER_OPERATION_CANCELLED_BEFORE_DISPATCH_MESSAGE);
-      const executed = await options.executeWithProductionGuard(node, sql, { database: node.database, schema: node.schema, executionId, isCancelledBeforeDispatch, markDispatched });
-      if (executed === undefined) {
-        // The user declined the production-safety confirmation: the SQL was
-        // never sent, so this must not be reported as a successful truncate.
-        endDangerRunningExecution();
-        return;
-      }
-      toast(t("contextMenu.truncateTableSuccess", { name: node.label }), 3000);
-      await options.refreshMutatedTableDataTabsForNode(node);
-      endDangerRunningExecution();
-    } catch (error: any) {
-      const message = error?.message || String(error);
-      const backendError = normalizeBackendError(error) ?? undefined;
-      toastDangerOperationError(node.label, message, wasCancelled(), cancelConfirmed(), backendError);
-      if (cancelConfirmed() || !isQueryTimeoutErrorMessage(message, backendError)) {
-        endDangerRunningExecution();
-      } else {
-        markHandedOff();
-      }
-    }
+    await runDangerOperation({
+      node,
+      buildSql: () => truncateTablePreviewSql.value || buildTruncateTableSql(tableAdminSqlOptionsForNode(node, { cascade: truncateTableCascade.value && supportsTruncateTableCascade(databaseTypeForNode(node)) })),
+      onSuccess: async (node) => {
+        toast(t("contextMenu.truncateTableSuccess", { name: node.label }), 3000);
+        await options.refreshMutatedTableDataTabsForNode(node);
+      },
+    });
   }
 
   return {

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2944,6 +2944,8 @@ export default {
     tableOperationTimedOut: 'The operation on "{name}" is taking longer than expected and has not been cancelled — it may still be running on the database. Check the result later, or click Cancel to stop it. ({message})',
     tableOperationCancelled: 'Operation on "{name}" cancelled',
     tableOperationCancelUnconfirmed: 'The cancel request for "{name}" was not confirmed by the database — the operation may have already finished or may still be running. Check the result to be sure. ({message})',
+    tableOperationCancelPending: 'The cancel request for "{name}" has not been confirmed yet — it may still be running on the database. You can try Cancel again, or check back shortly.',
+    dangerOperationAlreadyRunning: "Another dangerous operation is still running. Wait for it to finish or cancel it before starting a new one.",
     objectDropRefreshFailed: "Objects were deleted, but refreshing the sidebar failed: {message}",
     duplicateNameTitle: "Clone as New Table",
     duplicateNamePlaceholder: "New table name",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2847,6 +2847,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: 'La operación en "{name}" está tardando más de lo esperado y no se ha cancelado; es posible que siga ejecutándose en la base de datos. Compruebe el resultado más tarde o haga clic en Cancelar para detenerla. ({message})',
     tableOperationCancelled: 'Operación en "{name}" cancelada',
     tableOperationCancelUnconfirmed: 'La solicitud de cancelación de "{name}" no fue confirmada por la base de datos; la operación puede haber terminado o seguir en ejecución. Compruebe el resultado real. ({message})',
+    tableOperationCancelPending: 'La solicitud de cancelación de "{name}" aún no ha sido confirmada; puede que la operación siga en ejecución en la base de datos. Puedes intentar cancelar de nuevo o comprobarlo en unos instantes.',
+    dangerOperationAlreadyRunning: "Otra operación peligrosa sigue en ejecución. Espera a que finalice o cancélala antes de iniciar una nueva.",
     objectDropRefreshFailed: "Los objetos se eliminaron, pero no se pudo actualizar la barra lateral: {message}",
     duplicateNameTitle: "Clonar como tabla nueva",
     duplicateNamePlaceholder: "Nombre de la nueva tabla",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2845,6 +2845,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: 'L\'operazione su "{name}" sta impiegando più tempo del previsto e non è stata annullata: potrebbe essere ancora in esecuzione sul database. Controlla il risultato più tardi oppure fai clic su Annulla per interromperla. ({message})',
     tableOperationCancelled: 'Operazione su "{name}" annullata',
     tableOperationCancelUnconfirmed: 'La richiesta di annullamento per "{name}" non è stata confermata dal database: l\'operazione potrebbe essere già terminata o essere ancora in esecuzione. Verifica il risultato effettivo. ({message})',
+    tableOperationCancelPending: 'La richiesta di annullamento per "{name}" non è stata ancora confermata: l\'operazione potrebbe essere ancora in esecuzione sul database. Puoi riprovare ad annullare oppure controllare tra poco.',
+    dangerOperationAlreadyRunning: "Un'altra operazione pericolosa è ancora in esecuzione. Attendi che finisca o annullala prima di iniziarne una nuova.",
     objectDropRefreshFailed: "Gli oggetti sono stati eliminati, ma l'aggiornamento della barra laterale non è riuscito: {message}",
     duplicateNameTitle: "Clona as Nuova Tabella",
     duplicateNamePlaceholder: "Nuovo nome tabella",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2868,6 +2868,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: "「{name}」の操作に予想より時間がかかっており、まだキャンセルされていません。データベース側では実行が続いている可能性があります。後で結果を確認するか、キャンセルをクリックして停止してください。（{message}）",
     tableOperationCancelled: "「{name}」の操作をキャンセルしました",
     tableOperationCancelUnconfirmed: "「{name}」のキャンセル要求はデータベース側で確認されませんでした。操作はすでに完了しているか、まだ実行中の可能性があります。実際の結果をご確認ください。（{message}）",
+    tableOperationCancelPending: "「{name}」のキャンセル要求はまだ確認されていません。データベース側でまだ実行中の可能性があります。もう一度キャンセルを試すか、しばらくしてから確認してください。",
+    dangerOperationAlreadyRunning: "別の危険な操作がまだ実行中です。完了を待つか、キャンセルしてから新しい操作を開始してください。",
     objectDropRefreshFailed: "オブジェクトは削除されましたが、サイドバーの更新に失敗しました: {message}",
     duplicateNameTitle: "新しいテーブルとして複製",
     duplicateNamePlaceholder: "新しいテーブル名",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -2764,6 +2764,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: '"{name}"에 대한 작업이 예상보다 오래 걸리고 있으며 취소되지 않았습니다. 데이터베이스에서 계속 실행 중일 수 있습니다. 나중에 결과를 확인하거나 취소를 클릭하여 중지하세요. ({message})',
     tableOperationCancelled: '"{name}" 작업이 취소되었습니다',
     tableOperationCancelUnconfirmed: '"{name}"에 대한 취소 요청이 데이터베이스에서 확인되지 않았습니다. 작업이 이미 완료되었거나 계속 실행 중일 수 있습니다. 실제 결과를 확인하세요. ({message})',
+    tableOperationCancelPending: '"{name}"에 대한 취소 요청이 아직 확인되지 않았습니다. 데이터베이스에서 계속 실행 중일 수 있습니다. 다시 취소를 시도하거나 잠시 후 확인해 보세요.',
+    dangerOperationAlreadyRunning: "다른 위험한 작업이 아직 실행 중입니다. 완료되기를 기다리거나 취소한 후 새 작업을 시작하세요.",
     objectDropRefreshFailed: "개체는 삭제되었지만 사이드바 새로 고침에 실패했습니다: {message}",
     duplicateNameTitle: "새 테이블로 복제",
     duplicateNamePlaceholder: "새 테이블 이름",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2847,6 +2847,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: 'A operação em "{name}" está demorando mais do que o esperado e não foi cancelada — ela pode continuar em execução no banco de dados. Verifique o resultado mais tarde ou clique em Cancelar para interrompê-la. ({message})',
     tableOperationCancelled: 'Operação em "{name}" cancelada',
     tableOperationCancelUnconfirmed: 'A solicitação de cancelamento de "{name}" não foi confirmada pelo banco de dados — a operação pode já ter terminado ou ainda estar em execução. Verifique o resultado real. ({message})',
+    tableOperationCancelPending: 'A solicitação de cancelamento de "{name}" ainda não foi confirmada — a operação pode continuar em execução no banco de dados. Você pode tentar cancelar novamente ou verificar em instantes.',
+    dangerOperationAlreadyRunning: "Outra operação perigosa ainda está em execução. Aguarde a conclusão ou cancele-a antes de iniciar uma nova.",
     objectDropRefreshFailed: "Os objetos foram excluídos, mas não foi possível atualizar a barra lateral: {message}",
     duplicateNameTitle: "Clonar como Nova Tabela",
     duplicateNamePlaceholder: "Nome da nova tabela",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2868,6 +2868,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: "「{name}」的操作耗时较长，尚未被取消，可能仍在数据库端继续执行。请稍后自行确认执行结果，或点击「取消」手动终止。（{message}）",
     tableOperationCancelled: "「{name}」的操作已取消",
     tableOperationCancelUnconfirmed: "「{name}」的取消请求未被数据库确认，该操作可能已经完成，也可能仍在继续执行，请自行核实实际结果。（{message}）",
+    tableOperationCancelPending: "「{name}」的取消请求尚未得到确认，该操作可能仍在数据库中执行。可以再次点击取消，或稍后再查看结果。",
+    dangerOperationAlreadyRunning: "还有一个危险操作正在执行，请等待其完成或取消后再开始新的操作。",
     objectDropRefreshFailed: "对象已删除，但侧边栏刷新失败：{message}",
     duplicateNameTitle: "克隆为新表",
     duplicateNamePlaceholder: "新表名",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2846,6 +2846,8 @@ export default withEnglishFallback({
     tableOperationTimedOut: "「{name}」的操作耗時較長，尚未被取消，可能仍在資料庫端繼續執行。請稍後自行確認執行結果，或點擊「取消」手動終止。（{message}）",
     tableOperationCancelled: "「{name}」的操作已取消",
     tableOperationCancelUnconfirmed: "「{name}」的取消請求未被資料庫確認，該操作可能已經完成，也可能仍在繼續執行，請自行核實實際結果。（{message}）",
+    tableOperationCancelPending: "「{name}」的取消請求尚未得到確認，該操作可能仍在資料庫中執行。可以再次點擊取消，或稍後再查看結果。",
+    dangerOperationAlreadyRunning: "還有一個危險操作正在執行，請等待其完成或取消後再開始新的操作。",
     objectDropRefreshFailed: "物件已刪除，但側邊欄重新整理失敗：{message}",
     duplicateNameTitle: "克隆為新資料表",
     duplicateNamePlaceholder: "新資料表名稱",

--- a/crates/dbx-core/src/query_cancel.rs
+++ b/crates/dbx-core/src/query_cancel.rs
@@ -104,8 +104,10 @@ impl RunningQueries {
     }
 
     pub fn cancel(&self, execution_id: &str) -> bool {
-        let token =
-            self.inner.lock().unwrap_or_else(|e| e.into_inner()).get(execution_id).map(|task| task.token.clone());
+        let token = {
+            let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            inner.remove(execution_id).map(|task| task.token)
+        };
         let interrupt = self.interrupts.lock().unwrap_or_else(|e| e.into_inner()).remove(execution_id);
 
         if let Some(interrupt) = interrupt {
@@ -267,6 +269,17 @@ impl RegisteredQuery {
             running_queries.remove(&execution_id, registration_id);
         });
     }
+
+    /// Detaches on a client-observed timeout (server-side execution may
+    /// still be running and reachable for a later explicit cancel);
+    /// otherwise drops normally. Centralizes the branch duplicated across
+    /// every HTTP/Tauri query-execution entry point.
+    pub fn finish<T>(self, result: &Result<T, crate::query::QueryExecutionError>) {
+        if matches!(result, Err(crate::query::QueryExecutionError::Timeout(_))) {
+            self.detach();
+        }
+        // else: falls out of scope here and Drop removes the registration.
+    }
 }
 
 impl Drop for RegisteredQuery {
@@ -322,6 +335,7 @@ mod tests {
         let interrupted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let flag = interrupted.clone();
         let registered = running.register("exec-timeout".to_string());
+        running.set_pool_key("exec-timeout", "pool-1");
         running.register_interrupt("exec-timeout", move || {
             flag.store(true, std::sync::atomic::Ordering::SeqCst);
         });
@@ -330,11 +344,17 @@ mod tests {
         // timeout) while the statement may still be running server-side.
         registered.detach();
         assert!(running.has("exec-timeout"));
+        assert!(running.is_pool_active("pool-1"));
 
         // A later explicit cancel must still reach the (still registered)
         // KILL-QUERY-style interrupt.
         assert!(running.cancel("exec-timeout"));
         assert!(interrupted.load(std::sync::atomic::Ordering::SeqCst));
+
+        // Cancelling a detached, timed-out query must free it immediately —
+        // not after the 30-minute detach grace period.
+        assert!(!running.has("exec-timeout"));
+        assert!(!running.is_pool_active("pool-1"));
     }
 
     #[tokio::test(start_paused = true)]
@@ -354,6 +374,19 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert!(!running.has("exec-timeout"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn finish_detaches_on_timeout_and_drops_otherwise() {
+        let running = RunningQueries::default();
+
+        let registered = running.register("exec-timeout".to_string());
+        registered.finish(&Result::<(), _>::Err(crate::query::QueryExecutionError::Timeout("t".into())));
+        assert!(running.has("exec-timeout"));
+
+        let registered = running.register("exec-ok".to_string());
+        registered.finish(&Result::<(), _>::Ok(()));
+        assert!(!running.has("exec-ok"));
     }
 
     #[test]

--- a/crates/dbx-web/src/routes/query.rs
+++ b/crates/dbx-web/src/routes/query.rs
@@ -391,10 +391,11 @@ pub async fn execute_query(
             ..Default::default()
         },
     )
-    .await
-    .map_err(|error| AppError::from(error.into_backend_error()))?;
+    .await;
 
-    drop(registered);
+    registered.finish(&result);
+
+    let result = result.map_err(|error| AppError::from(error.into_backend_error()))?;
     Ok(Json(result))
 }
 
@@ -442,11 +443,12 @@ pub async fn execute_multi(
             execution_mode: req.execution_mode.unwrap_or_default(),
         },
     )
-    .await
-    .map_err(|error| AppError::from(error.into_backend_error()))?;
+    .await;
     let core_ms = core_started_at.elapsed().as_millis();
 
-    drop(registered);
+    registered.finish(&result);
+
+    let result = result.map_err(|error| AppError::from(error.into_backend_error()))?;
     execute_multi_response(result, core_ms)
 }
 

--- a/packages/app-tests/sidebarMutationRuntime.test.ts
+++ b/packages/app-tests/sidebarMutationRuntime.test.ts
@@ -32,8 +32,14 @@ test("mutation families retain accepted targets, failures, and refresh work", ()
     const body = functionBody(name);
     assert.match(body, /sidebarDangerTarget\.value \?\? activeNode\.value/);
     assert.match(body, /refreshMutatedTableDataTabsForNode\(node\)/);
-    assert.match(body, /toastDangerOperationError\(node\.label/);
+    // Failure reporting (including the tableOperationFailed toast) lives in
+    // the shared runDangerOperation helper, not inlined in each confirm*
+    // function.
+    assert.match(body, /runDangerOperation\(/);
   }
+
+  const runDangerOperation = functionBody("runDangerOperation");
+  assert.match(runDangerOperation, /toastDangerOperationError\(/);
 
   for (const name of ["confirmCreateNacosNamespace", "confirmEditNacosNamespace", "confirmDropDatabase"]) {
     const body = functionBody(name);

--- a/src-tauri/src/commands/query.rs
+++ b/src-tauri/src/commands/query.rs
@@ -74,15 +74,8 @@ pub async fn execute_query(
     )
     .await;
 
-    if matches!(result, Err(dbx_core::query::QueryExecutionError::Timeout(_))) {
-        // We're giving up on waiting, not cancelling: the statement may
-        // still be executing server-side. Keep the registration (and any
-        // KILL-QUERY-style interrupt registered against it) reachable so a
-        // later explicit cancel_query call can still reach it, instead of
-        // losing that capability the instant this command returns.
-        if let Some(registered_query) = registered_query {
-            registered_query.detach();
-        }
+    if let Some(registered_query) = registered_query {
+        registered_query.finish(&result);
     }
 
     result.map_err(dbx_core::query::QueryExecutionError::into_backend_error)
@@ -194,6 +187,11 @@ pub async fn execute_multi(
             error
         ),
     }
+
+    if let Some(registered_query) = registered_query {
+        registered_query.finish(&result);
+    }
+
     result.map_err(dbx_core::query::QueryExecutionError::into_backend_error)
 }
 


### PR DESCRIPTION
Follow-up to #6675。该 PR 合并后针对同一套取消协议又做了一轮 code review，发现"取消协议本身能工作"，但"取消成功之后的清理"在多处没跟上。本 PR 修复这一轮 review 发现的全部问题。

## 问题

- `RunningQueries::cancel()` 只清理 token/interrupt，不移除注册表条目——一个已 detach（客户端超时后）又被显式取消的查询，会继续让 `is_pool_active()` 返回 `true` 长达 30 分钟（detach 的宽限期），阻塞空闲连接池回收和 keepalive。
- `resetSidebarTreeDialogState()` 没有清理 `sidebarDangerRunningExecutionId`/`sidebarDangerRunningCancel` 这两个单例 ref——组件卸载后取消句柄会悬空。
- `openSidebarDangerDialog` 对"是否已有危险操作在后台运行"没有任何防护——第二个危险操作会静默覆盖/孤立第一个操作的取消句柄。
- `confirmCancelWithRetry` 的重试循环里单次 `cancelQuery` 调用没有独立超时，一次卡住会拖住剩余重试。
- `confirmDropTable`/`confirmEmptyTable`/`confirmTruncateTable` 三份约 70% 相同的逻辑没有抽取。
- `executeTreeNodeSqlWithProductionGuard` 对所有调用者（含 rename/drop object/batch drop 等 18 处没有取消 UI 的调用）都无差别生成 `executionId` 并注册到后端，造成不必要的最长 30 分钟悬挂注册。

## 修复

- `cancel()` 改为在同一把锁内直接 `remove` 注册表条目，取消后 `is_pool_active` 立即变为 `false`；30 分钟宽限期本身保留，仍用于兜底"detach 后从未被显式取消"的场景。
- 抽出 `RegisteredQuery::finish()`，消除 `src-tauri`/`dbx-web` 四处重复的 "超时则 detach 否则 drop" 分支。
- `resetSidebarTreeDialogState()` 补上遗漏字段的清理。
- `openSidebarDangerDialog` 增加运行中检测，拒绝在已有操作运行时打开新对话框（并提示用户）。
- `confirmCancelWithRetry` 每次重试调用增加独立超时（从总预算均分）。
- 抽出 `runDangerOperation` 消除三份重复的 begin/dispatch/error/cleanup 逻辑。
- `executeTreeNodeSqlWithProductionGuard` 的 `executionId` 改回按需生成（调用方不传就不生成，不注册）。

## 验证

- `cargo test -p dbx-core`（`query_cancel` + `connection` 模块）：336/336 通过
- `cargo clippy -p dbx-core --lib -- -D warnings`、`cargo fmt --check`：干净
- `vitest run`（全仓库）：1075 个测试文件 / 10299 个用例全部通过
- `vue-tsc --noEmit`、`oxlint --vue-plugin`：干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)