### PR TITLE
fix(postgres): 未选择模式时按 search_path 加载结果元数据

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts
@@ -402,6 +402,39 @@ describe("queryStore multi-source result column comments", () => {
     expect(tab.queryEditabilityReason).toBeUndefined();
   });
 
+  it("resolves unqualified PostgreSQL metadata through search_path when no schema is selected", async () => {
+    getConnectionConfig.mockReturnValue({ id: "pg-1", name: "PostgreSQL", db_type: "postgres", database: "app", query_timeout_secs: 30 });
+    analyzeEditableQueryEditability.mockResolvedValue({
+      editable: true,
+      analysis: {
+        schema: undefined,
+        tableName: "people",
+        selectStar: true,
+        columns: [],
+      },
+    });
+    getColumns.mockResolvedValue([column("name", "姓名"), column("email", "邮箱")]);
+    executeMulti.mockResolvedValue([
+      {
+        columns: ["name", "email"],
+        rows: [["Alice", "alice@example.com"]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "app", "Query");
+
+    await store.executeTabSql(tabId, "SELECT * FROM people");
+
+    const tab = store.tabs.find((item) => item.id === tabId)!;
+    await vi.waitFor(() => expect(tab.resultColumnComments).toEqual(["姓名", "邮箱"]));
+    expect(getColumns).toHaveBeenCalledWith("pg-1", "app", "", "people", undefined);
+    expect(listIndexes).toHaveBeenCalledWith("pg-1", "app", "", "people", undefined);
+  });
+
   it("does not add explicit result comments to an adjacent keyed PostgreSQL query", async () => {
     getConnectionConfig.mockReturnValue({ id: "pg-1", name: "PostgreSQL", db_type: "postgres", database: "app", query_timeout_secs: 30 });
     analyzeEditableQueryEditability.mockResolvedValue({

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3582,11 +3582,7 @@ export const useQueryStore = defineStore("query", () => {
     // unqualified object reference. Resolve metadata through the login's
     // default schema (with the driver's dbo fallback) so metadata and writes
     // target the same object as the original SELECT.
-    let schema = source.schema || (dbType === "sqlserver" ? "" : tab.schema);
-    if (!schema) {
-      if (dbType === "postgres" || dbType === "kwdb") schema = "public";
-      else schema = "";
-    }
+    const schema = source.schema || (dbType === "sqlserver" ? "" : tab.schema) || "";
     // Oracle-family connection databases are service names, not schemas. When
     // the query does not qualify a schema, let the driver resolve the current
     // login user's schema instead of looking up metadata under the service name.
@@ -3594,7 +3590,11 @@ export const useQueryStore = defineStore("query", () => {
     // search_path. Do not reinterpret the selected database as a schema; the
     // agent resolves the visible relation's actual namespace with the columns.
     const useCurrentVastbaseSchema = dbType === "vastbase" && !source.schema && !tab.schema;
-    const resolvedSchema = (dbType === "sqlserver" && !source.schema) || (ORACLE_LIKE_METADATA_TYPES.has(dbType) && !schema) || useCurrentVastbaseSchema ? "" : metadataSchemaForConnection(conn, metadataDatabase, schema || undefined);
+    // PostgreSQL-compatible unqualified names also resolve through the
+    // connection's search_path. Keep the metadata request unqualified when no
+    // schema was selected instead of assuming public (or the database name).
+    const useCurrentPostgresSchema = (dbType === "postgres" || dbType === "kwdb") && !source.schema && !tab.schema;
+    const resolvedSchema = (dbType === "sqlserver" && !source.schema) || (ORACLE_LIKE_METADATA_TYPES.has(dbType) && !schema) || useCurrentVastbaseSchema || useCurrentPostgresSchema ? "" : metadataSchemaForConnection(conn, metadataDatabase, schema || undefined);
     const metadataSchema = normalizeUppercaseFoldedMetadataIdentifier(dbType, resolvedSchema || undefined, source.schema ? source.schemaQuoted : false) || "";
     const metadataTableName = normalizeUppercaseFoldedMetadataIdentifier(dbType, source.tableName, source.tableNameQuoted)!;
     const metadataCatalog = normalizeUppercaseFoldedMetadataIdentifier(dbType, source.catalog, source.catalogQuoted);

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -5216,6 +5216,8 @@ const POSTGRES_COLUMNS_SQL: &str = "SELECT a.attname AS column_name, \
                               FROM pg_enum e WHERE e.enumtypid = enum_t.oid), '[]') END AS enum_values \
              FROM pg_attribute a \
              JOIN pg_type t ON t.oid = a.atttypid \
+             JOIN pg_class relation_class ON relation_class.oid = a.attrelid \
+             JOIN pg_namespace relation_namespace ON relation_namespace.oid = relation_class.relnamespace \
              LEFT JOIN pg_type enum_t ON enum_t.oid = CASE WHEN t.typtype = 'd' THEN t.typbasetype WHEN t.typtype = 'e' THEN t.oid ELSE NULL END AND enum_t.typtype = 'e' \
              LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum \
              LEFT JOIN LATERAL ( \
@@ -5241,8 +5243,8 @@ const POSTGRES_COLUMNS_SQL: &str = "SELECT a.attname AS column_name, \
              ) dep ON TRUE \
              LEFT JOIN pg_sequence pseq ON pseq.seqrelid = dep.objid \
              LEFT JOIN information_schema.columns c \
-               ON c.table_schema = $1 AND c.table_name = $2 AND c.column_name = a.attname \
-             WHERE a.attrelid = (quote_ident($1) || '.' || quote_ident($2))::regclass \
+               ON c.table_schema = relation_namespace.nspname AND c.table_name = relation_class.relname AND c.column_name = a.attname \
+             WHERE a.attrelid = (CASE WHEN $1 = '' THEN quote_ident($2) ELSE quote_ident($1) || '.' || quote_ident($2) END)::regclass \
              AND a.attnum > 0 AND NOT a.attisdropped \
              ORDER BY a.attnum";
 
@@ -5275,6 +5277,8 @@ const POSTGRES_COLUMNS_COMPAT_SQL: &str = "SELECT a.attname AS column_name, \
              NULL::text AS enum_values \
              FROM pg_attribute a \
              JOIN pg_type t ON t.oid = a.atttypid \
+             JOIN pg_class relation_class ON relation_class.oid = a.attrelid \
+             JOIN pg_namespace relation_namespace ON relation_namespace.oid = relation_class.relnamespace \
              LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum \
              LEFT JOIN pg_catalog.pg_class serial_seq ON serial_seq.oid = ( \
                SELECT sequence_dep.objid \
@@ -5297,8 +5301,8 @@ const POSTGRES_COLUMNS_COMPAT_SQL: &str = "SELECT a.attname AS column_name, \
                LIMIT 1 \
              ) AND serial_seq.relkind = 'S' \
              LEFT JOIN information_schema.columns c \
-               ON c.table_schema = $1 AND c.table_name = $2 AND c.column_name = a.attname \
-             WHERE a.attrelid = (quote_ident($1) || '.' || quote_ident($2))::regclass \
+               ON c.table_schema = relation_namespace.nspname AND c.table_name = relation_class.relname AND c.column_name = a.attname \
+             WHERE a.attrelid = (CASE WHEN $1 = '' THEN quote_ident($2) ELSE quote_ident($1) || '.' || quote_ident($2) END)::regclass \
              AND a.attnum > 0 AND NOT a.attisdropped \
              ORDER BY a.attnum";
 
@@ -5425,7 +5429,6 @@ async fn get_columns_with_sql(
 }
 
 pub async fn get_columns(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ColumnInfo>, String> {
-    let schema = if schema.is_empty() { "public" } else { schema };
     let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
     let tiers = [POSTGRES_COLUMNS_SQL, POSTGRES_COLUMNS_COMPAT_SQL, POSTGRES_COLUMNS_INFORMATION_SCHEMA_SQL];
     query_with_compat_fallback("get_columns", &tiers, |sql| get_columns_with_sql(&client, sql, schema, table)).await
@@ -6449,7 +6452,7 @@ const POSTGRES_INDEXES_SQL: &str = "SELECT i.relname AS index_name, \
              JOIN pg_am am ON am.oid = i.relam \
              JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, n) ON true \
              LEFT JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum AND k.attnum > 0 \
-             WHERE n.nspname = $1 AND t.relname = $2 \
+             WHERE t.oid = (CASE WHEN $1 = '' THEN quote_ident($2) ELSE quote_ident($1) || '.' || quote_ident($2) END)::regclass \
              GROUP BY i.relname, i.oid, ix.indisunique, ix.indisprimary, ix.indpred, ix.indrelid, am.amname, ix.indnkeyatts, ix.indkey \
              ORDER BY i.relname";
 
@@ -6486,7 +6489,7 @@ const POSTGRES_INDEXES_COMPAT_SQL: &str = "SELECT i.relname AS index_name, \
              JOIN pg_class i ON i.oid = ix.indexrelid \
              JOIN pg_namespace n ON n.oid = t.relnamespace \
              JOIN pg_am am ON am.oid = i.relam \
-             WHERE n.nspname = $1 AND t.relname = $2 \
+             WHERE t.oid = (CASE WHEN $1 = '' THEN quote_ident($2) ELSE quote_ident($1) || '.' || quote_ident($2) END)::regclass \
              ORDER BY i.relname";
 
 const POSTGRES_OWNERS_SQL: &str =
@@ -9434,6 +9437,17 @@ mod tests {
     }
 
     #[test]
+    fn postgres_single_relation_metadata_can_resolve_through_search_path() {
+        for sql in [POSTGRES_COLUMNS_SQL, POSTGRES_COLUMNS_COMPAT_SQL] {
+            assert!(sql.contains("CASE WHEN $1 = '' THEN quote_ident($2)"));
+            assert!(sql.contains("c.table_schema = relation_namespace.nspname"));
+        }
+        for sql in [POSTGRES_INDEXES_SQL, POSTGRES_INDEXES_COMPAT_SQL] {
+            assert!(sql.contains("t.oid = (CASE WHEN $1 = '' THEN quote_ident($2)"));
+        }
+    }
+
+    #[test]
     fn postgres_column_metadata_marks_only_owned_integer_sequence_defaults_as_serial() {
         let modern_sql = [POSTGRES_COLUMNS_SQL, postgres_columns_for_relations_sql()];
         let compat_sql = [POSTGRES_COLUMNS_COMPAT_SQL, postgres_columns_for_relations_compat_sql()];
@@ -9599,6 +9613,48 @@ mod tests {
             state_enum_values(&columns),
             Some(vec!["pending".to_string(), "active".to_string(), "archived".to_string()])
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DBX_TEST_POSTGRES_URL pointing at a writable PostgreSQL database"]
+    async fn postgres_unqualified_metadata_follows_search_path() {
+        let url = std::env::var("DBX_TEST_POSTGRES_URL").expect("DBX_TEST_POSTGRES_URL");
+        let pool = connect(&url, Duration::from_secs(5)).await.expect("connect postgres");
+        let client =
+            checkout_postgres_client(&pool, None, crate::db::connection_timeout()).await.expect("checkout client");
+        let suffix = std::process::id();
+        let schema = format!("dbx_search_path_meta_{suffix}");
+        let table = format!("comments_{suffix}");
+        let schema_ident = format!("\"{}\"", schema.replace('\"', "\"\""));
+        let table_ident = format!("\"{}\"", table.replace('\"', "\"\""));
+
+        client
+            .batch_execute(&format!(
+                "CREATE SCHEMA {schema_ident}; \
+                 CREATE TABLE {schema_ident}.{table_ident} (id integer PRIMARY KEY, display_name text); \
+                 COMMENT ON COLUMN {schema_ident}.{table_ident}.display_name IS '客户姓名'; \
+                 SET search_path TO {schema_ident}, public;"
+            ))
+            .await
+            .expect("create search_path metadata fixtures");
+
+        let columns = get_columns_with_sql(&client, POSTGRES_COLUMNS_SQL, "", &table)
+            .await
+            .expect("load columns through search_path");
+        assert_eq!(
+            columns.iter().find(|column| column.name == "display_name").and_then(|column| column.comment.as_deref()),
+            Some("客户姓名")
+        );
+
+        let indexes = list_indexes_with_sql(&client, POSTGRES_INDEXES_SQL, "", &table)
+            .await
+            .expect("load indexes through search_path");
+        assert!(indexes.iter().any(|index| index.is_primary && index.columns == ["id"]));
+
+        client
+            .batch_execute(&format!("RESET search_path; DROP SCHEMA {schema_ident} CASCADE"))
+            .await
+            .expect("clean search_path metadata fixtures");
     }
 
     #[tokio::test]

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -2379,8 +2379,8 @@ test("binds DISTINCT qualified-star edits to the single safe joined source", asy
     const tab = store.tabs.find((item) => item.id === tabId);
     await waitFor(() => columnRequests.length === 2 && tab?.tableMeta?.tableName === "users");
     assert.deepEqual(columnRequests, [
-      { schema: "public", table: "users" },
-      { schema: "public", table: "orders" },
+      { schema: "", table: "users" },
+      { schema: "", table: "orders" },
     ]);
     assert.equal(tab?.queryEditabilityReason, undefined);
     assert.equal(tab?.queryAnalysis?.multiSource, true);
@@ -2560,7 +2560,7 @@ test("expands single-table alias star projections for editable query metadata", 
 
     const tab = store.tabs.find((item) => item.id === tabId);
     await waitFor(() => columnRequests.length === 1 && tab?.tableMeta?.tableName === "tt_kd_material_container_sap");
-    assert.deepEqual(columnRequests, [{ schema: "public", table: "tt_kd_material_container_sap" }]);
+    assert.deepEqual(columnRequests, [{ schema: "", table: "tt_kd_material_container_sap" }]);
     assert.equal(tab?.queryEditabilityReason, undefined);
     assert.equal(tab?.queryAnalysis?.selectStar, false);
     assert.equal(tab?.tableMeta?.tableName, "tt_kd_material_container_sap");


### PR DESCRIPTION
## 问题

这是 #6748 的补充修复。

原修复已支持 PostgreSQL 无主键查询结果显示列注释，但当 SQL 编辑器未选择模式、查询使用未限定表名时仍可能不显示：PostgreSQL 会按连接的 `search_path` 解析表，DBX 的结果元数据请求却固定查询 `public`。表位于用户 Schema 或自定义 `search_path` 时，查询可以成功，列注释和主键信息却无法加载。

## 修复

- PostgreSQL/KWDB 查询未显式限定 Schema 且编辑器未选择模式时，前端保持空 Schema 元数据请求，不再假定 `public` 或数据库名。
- PostgreSQL 列元数据通过未限定 `regclass` 按当前 `search_path` 解析实际 relation，并使用实际 namespace 关联 `information_schema.columns`。
- 索引元数据使用相同的 relation 解析逻辑，避免有主键表因 Schema 不一致被误判为无主键。
- 显式 Schema 查询继续按指定 Schema 加载，不改变现有行为；兼容查询仍避免 PostgreSQL 9.x 不支持的索引元数据语法。

## 验证

- PostgreSQL 16 真实实例：在非 `public` Schema 创建无主键表及中文列注释，确认未限定 SQL 按 `search_path` 查询成功。
- DBX Web 真实操作：模式按钮保持“选择模式”时执行未限定表名查询，结果表头正确显示“客户姓名”“联系邮箱”；显式 Schema 查询也正常。
- Rust live test：空 Schema 元数据请求可按 `search_path` 返回中文列注释，并正确识别主键索引。
- `pnpm exec vitest run apps/desktop/src/stores/__tests__/queryStore.multiSourceColumnComments.spec.ts --reporter=dot`：11/11 通过。
- `pnpm exec vitest run packages/app-tests/queryStore.test.ts -t "binds DISTINCT qualified-star edits|expands single-table alias star projections" --reporter=dot`：2/2 通过。
- `cargo test -p dbx-core postgres_column_metadata --lib`：5 项通过，3 项环境测试忽略。
- `cargo test -p dbx-core postgres_index_metadata --lib`：2/2 通过。
- `pnpm typecheck` 通过。
- `git diff --check` 通过。

关联：#6748
