### PR TITLE
fix(phoenix): 修复非默认 schema 下 HBase 表查询

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1686,6 +1686,7 @@ async function newQuery() {
     targetConnectionId: target.connectionId,
     targetDatabase: target.database,
     databaseType: effectiveDatabaseTypeForConnection(conn),
+    driverProfile: conn.driver_profile,
     identifierQuote: connectionStore.connectionIdentifierQuote?.(target.connectionId),
   });
   const tabId = queryStore.createTab(conn.id, target.database, undefined, "query", target.schema, initialSql, target.catalog);

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -1715,7 +1715,7 @@ async function loadTemplateContext(allowView = false) {
   }
 
   const identifierQuote = connectionStore.connectionIdentifierQuote(node.connectionId);
-  return { node, dbType, identifierQuote, tableSchema, columns, tableType };
+  return { node, dbType, driverProfile: config?.driver_profile, identifierQuote, tableSchema, columns, tableType };
 }
 
 function openSqlTemplateTab(connectionId: string, database: string, schema: string | undefined, catalog: string | undefined, sql: string, title?: string) {
@@ -1729,6 +1729,7 @@ async function newSelectTemplate() {
     if (!context) return;
     const sql = buildTableSelectTemplate({
       databaseType: context.dbType,
+      driverProfile: context.driverProfile,
       identifierQuote: context.identifierQuote,
       catalog: context.node.catalog,
       database: context.node.database,
@@ -1748,6 +1749,7 @@ async function newInsertTemplate() {
     if (!context) return;
     const sql = buildTableInsertTemplate({
       databaseType: context.dbType,
+      driverProfile: context.driverProfile,
       identifierQuote: context.identifierQuote,
       catalog: context.node.catalog,
       database: context.node.database,
@@ -1768,6 +1770,7 @@ async function newUpdateTemplate() {
     if (!context) return;
     const sql = buildTableUpdateTemplate({
       databaseType: context.dbType,
+      driverProfile: context.driverProfile,
       identifierQuote: context.identifierQuote,
       catalog: context.node.catalog,
       database: context.node.database,
@@ -1787,6 +1790,7 @@ async function newDeleteTemplate() {
     if (!context) return;
     const sql = buildTableDeleteTemplate({
       databaseType: context.dbType,
+      driverProfile: context.driverProfile,
       identifierQuote: context.identifierQuote,
       catalog: context.node.catalog,
       database: context.node.database,

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -208,6 +208,10 @@ function currentDatabaseType(): DatabaseType | undefined {
   return activeNode.value.connectionId ? effectiveDatabaseTypeForConnection(connectionStore.getConfig(activeNode.value.connectionId)) : undefined;
 }
 
+function currentDriverProfile(): string | undefined {
+  return activeNode.value.connectionId ? connectionStore.getConfig(activeNode.value.connectionId)?.driver_profile : undefined;
+}
+
 function getIconInfo(node: TreeNode): { icon: any; colorClass: string } | null {
   switch (node.type) {
     case "connection":
@@ -1116,6 +1120,7 @@ function tableReferenceDragPayload(): QueryEditorTableReferencePayload | null {
       database: activeNode.value.database,
       referenceType: "database",
       databaseType: currentDatabaseType(),
+      driverProfile: currentDriverProfile(),
     });
   }
   if (activeNode.value.type === "column") {
@@ -1128,6 +1133,7 @@ function tableReferenceDragPayload(): QueryEditorTableReferencePayload | null {
       tableName: activeNode.value.tableName,
       columnName,
       databaseType: currentDatabaseType(),
+      driverProfile: currentDriverProfile(),
     });
   }
   const payload = createTableReferencePayload({
@@ -1136,6 +1142,7 @@ function tableReferenceDragPayload(): QueryEditorTableReferencePayload | null {
     schema: activeNode.value.schema,
     tableName: activeNode.value.label,
     databaseType: currentDatabaseType(),
+    driverProfile: currentDriverProfile(),
   });
   return payload;
 }

--- a/apps/desktop/src/composables/__tests__/useSidebarDataOpenRuntime.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSidebarDataOpenRuntime.spec.ts
@@ -359,6 +359,31 @@ describe("useSidebarDataOpenRuntime", () => {
     });
   });
 
+  it("preserves JDBC table schema through the table-data request", async () => {
+    mocks.databaseType = "jdbc";
+    mocks.loadTableMetadata.mockImplementation(async (request: { database: string; schema?: string; tableName: string; tableType?: string }) => ({
+      metadata: {
+        schema: request.schema,
+        tableName: request.tableName,
+        tableType: request.tableType,
+        database: request.database,
+        columns: [{ name: "id", data_type: "bigint", is_nullable: false, column_default: null, is_primary_key: true, extra: null }],
+        indexes: [],
+        primaryKeys: ["id"],
+        cachedAt: Date.now(),
+      },
+      cacheStatus: "miss",
+      ageMs: 0,
+    }));
+
+    await useSidebarDataOpenRuntime().openData(tableNode);
+
+    await vi.waitFor(() => expect(mocks.tabs[0]?.tableMeta?.primaryKeys).toEqual(["id"]));
+    expect(mocks.loadTableMetadata).toHaveBeenCalledWith(expect.objectContaining({ database: "app", schema: "public" }));
+    expect(mocks.buildTableSelectSql).toHaveBeenCalledWith(expect.objectContaining({ database: "app", schema: "public", tableName: "users" }));
+    expect(mocks.tabs[0]?.tableMeta).toMatchObject({ database: "app", schema: "public", tableName: "users" });
+  });
+
   it("keeps MySQL data-tab identity unqualified after metadata loads", async () => {
     mocks.databaseType = "mysql";
     mocks.loadTableMetadata.mockImplementation(async (request: { database: string; schema?: string; tableName: string; tableType?: string }) => ({

--- a/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
@@ -73,6 +73,17 @@ describe("jdbc dialect inference", () => {
     ).toBe("sqlserver");
   });
 
+  it("keeps Phoenix as generic JDBC while preserving its schema tree", () => {
+    const connection = { db_type: "jdbc" as const, driver_profile: "phoenix" };
+
+    expect(inferJdbcDialect(connection)).toBe("jdbc");
+    expect(effectiveDatabaseTypeForConnection(connection)).toBe("jdbc");
+    expect(connectionUsesDatabaseObjectTreeMode(connection)).toBe(false);
+    expect(connectionObjectTreeQuerySchema(connection, "default", "DEMO")).toBe("DEMO");
+    expect(connectionObjectTreeNodeSchema(connection, "default", "DEMO")).toBe("DEMO");
+    expect(connectionShouldLoadIdentifierQuote(connection)).toBe(true);
+  });
+
   it.each([
     ["jdbc:oracle:thin:@//localhost:1521/XE", "oracle"],
     ["jdbc:dm://localhost:5236/DAMENG", "dameng"],

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorTableDrop.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorTableDrop.spec.ts
@@ -14,6 +14,20 @@ describe("query editor table reference drop", () => {
     expect(tableReferenceInsertText(payload!)).toBe("`app-db`");
   });
 
+  it("preserves the Phoenix schema in dragged table references", () => {
+    const payload = createTableReferencePayload({
+      connectionId: "conn-1",
+      database: "default",
+      schema: "APP",
+      tableName: "USERS",
+      databaseType: "jdbc",
+      driverProfile: "phoenix",
+    })!;
+
+    expect(parseTableReferencePayload(JSON.stringify(payload))).toEqual(payload);
+    expect(tableReferenceInsertText(payload)).toBe("APP.USERS");
+  });
+
   it("round-trips database reference payloads", () => {
     const payload = createTableReferencePayload({
       connectionId: "conn-1",

--- a/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
@@ -204,6 +204,10 @@ describe("buildSelectAllSql", () => {
     expect(buildSelectAllSql("postgres", { schema: "public", tableName: "users" })).toBe('SELECT * FROM "public"."users"');
   });
 
+  it("preserves the Phoenix schema for new-query prefill", () => {
+    expect(buildSelectAllSql("jdbc", { schema: "APP", tableName: "USERS" }, '"', "phoenix")).toBe('SELECT * FROM "APP"."USERS"');
+  });
+
   it("bracket-quotes a SQL Server table", () => {
     expect(buildSelectAllSql("sqlserver", { schema: "dbo", tableName: "users" })).toBe("SELECT * FROM [dbo].[users]");
     expect(buildSelectAllSql("sqlserver", { tableName: "users" })).toBe("SELECT * FROM [users]");
@@ -256,6 +260,20 @@ describe("resolveNewQueryInitialSql", () => {
         databaseType: "postgres",
       }),
     ).toBe('SELECT * FROM "public"."users"');
+  });
+
+  it("passes the Phoenix driver profile into the initial SQL builder", () => {
+    expect(
+      resolveNewQueryInitialSql({
+        activeTab: dataTab({ schema: "APP", tableMeta: { schema: "APP", tableName: "USERS", columns: [], primaryKeys: [] } }),
+        prefillEnabled: true,
+        targetConnectionId: "conn-1",
+        targetDatabase: "app_db",
+        databaseType: "jdbc",
+        driverProfile: "phoenix",
+        identifierQuote: '"',
+      }),
+    ).toBe('SELECT * FROM "APP"."USERS"');
   });
 
   it("leaves new queries empty when the setting is disabled", () => {

--- a/apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts
@@ -34,6 +34,20 @@ describe("qualifiedTableName — SQLite attached databases", () => {
   });
 });
 
+describe("qualifiedTableName — schema-aware JDBC profiles", () => {
+  it("qualifies Phoenix tables without forcing identifier quotes", () => {
+    expect(qualifiedTableName({ databaseType: "jdbc", driverProfile: "phoenix", schema: "DEMO", tableName: "STUDENT" })).toBe("DEMO.STUDENT");
+  });
+
+  it("uses the driver-reported quote for Phoenix special identifiers", () => {
+    expect(qualifiedTableName({ databaseType: "jdbc", driverProfile: "phoenix", identifierQuote: '"', schema: "MY_SCHEMA", tableName: "ORDER" })).toBe('"MY_SCHEMA"."ORDER"');
+  });
+
+  it("keeps an unscoped JDBC table unqualified", () => {
+    expect(qualifiedTableName({ databaseType: "jdbc", driverProfile: "phoenix", tableName: "STUDENT" })).toBe("STUDENT");
+  });
+});
+
 describe("qualifiedTableName — GBase 8s", () => {
   it("omits the metadata owner for GBase 8s table data", () => {
     expect(qualifiedTableName({ databaseType: "informix", driverProfile: "gbase8s", identifierQuote: "", schema: "gbasedbt", tableName: "connection_smoke" })).toBe("connection_smoke");

--- a/apps/desktop/src/lib/database/jdbcDialect.ts
+++ b/apps/desktop/src/lib/database/jdbcDialect.ts
@@ -21,6 +21,9 @@ const CONNECTION_ROOT_SCHEMA_TYPES = new Set<DatabaseType>(["oracle", "dameng", 
 const JDBC_DIALECT_MATCHERS: Array<{ type: DatabaseType; patterns: RegExp[] }> = [
   { type: "databend", patterns: [/jdbc:databend:/i, /com\.databend\.jdbc\.DatabendDriver/i, /databend-jdbc/i] },
   { type: "starrocks", patterns: [/starrocks/i] },
+  // Phoenix remains a generic JDBC connection, but exposes queryable schemas.
+  // Returning `jdbc` keeps its generic SQL behavior while enabling the schema tree.
+  { type: "jdbc", patterns: [/phoenix/i] },
   { type: "doris", patterns: [/doris/i] },
   { type: "goldendb", patterns: [/jdbc:goldendb:/i, /goldendb/i] },
   { type: "mysql", patterns: [/kyuubi/i] },
@@ -52,6 +55,10 @@ export function inferJdbcDialect(connection?: JdbcDialectConnection): DatabaseTy
     .join("\n");
   if (!haystack) return undefined;
   return JDBC_DIALECT_MATCHERS.find((matcher) => matcher.patterns.some((pattern) => pattern.test(haystack)))?.type;
+}
+
+export function jdbcDriverProfileUsesSchemaQualification(driverProfile?: string): boolean {
+  return inferJdbcDialect({ db_type: "jdbc", driver_profile: driverProfile }) === "jdbc";
 }
 
 export function effectiveDatabaseTypeForConnection(connection?: JdbcDialectConnection): DatabaseType | undefined {
@@ -90,7 +97,8 @@ export function connectionShouldLoadIdentifierQuote(connection: JdbcDialectConne
   if (gaussdbIdentifierQuoteStyle(connection) !== "auto") return false;
   if (connection.db_type === "gaussdb") return true;
   if (connection.db_type !== "jdbc") return false;
-  return ["gaussdb", "opengauss", "postgres"].includes(inferJdbcDialect(connection) ?? "");
+  const dialect = inferJdbcDialect(connection);
+  return dialect === "jdbc" || ["gaussdb", "opengauss", "postgres"].includes(dialect ?? "");
 }
 
 export function supportsGaussdbIdentifierQuoteStyle(connection: JdbcDialectConnection | undefined): boolean {

--- a/apps/desktop/src/lib/editor/queryEditorTableDrop.ts
+++ b/apps/desktop/src/lib/editor/queryEditorTableDrop.ts
@@ -13,6 +13,7 @@ export interface QueryEditorTableReferencePayload {
   columnName?: string;
   referenceType?: "database" | "table" | "column";
   databaseType?: DatabaseType;
+  driverProfile?: string;
 }
 
 export interface QueryEditorTableReferenceDropDetail {
@@ -23,7 +24,7 @@ export interface QueryEditorTableReferenceDropDetail {
 
 let activeTableReferencePayload: QueryEditorTableReferencePayload | null = null;
 
-export function createTableReferencePayload(options: { connectionId?: string; database?: string; schema?: string; tableName?: string; columnName?: string; referenceType?: "database" | "table" | "column"; databaseType?: DatabaseType }): QueryEditorTableReferencePayload | null {
+export function createTableReferencePayload(options: { connectionId?: string; database?: string; schema?: string; tableName?: string; columnName?: string; referenceType?: "database" | "table" | "column"; databaseType?: DatabaseType; driverProfile?: string }): QueryEditorTableReferencePayload | null {
   if (!options.connectionId || options.database == null) return null;
   const referenceType = options.referenceType ?? (options.columnName ? "column" : "table");
   if (referenceType !== "database" && !options.tableName) return null;
@@ -43,6 +44,7 @@ export function createTableReferencePayload(options: { connectionId?: string; da
   }
   if (options.schema) payload.schema = options.schema;
   if (options.databaseType) payload.databaseType = options.databaseType;
+  if (options.driverProfile) payload.driverProfile = options.driverProfile;
   return payload;
 }
 
@@ -65,6 +67,7 @@ export function parseTableReferencePayload(value: string | undefined | null): Qu
         referenceType: "database",
       };
       if (parsed.databaseType) payload.databaseType = parsed.databaseType;
+      if (typeof parsed.driverProfile === "string" && parsed.driverProfile) payload.driverProfile = parsed.driverProfile;
       return payload;
     }
     if (typeof parsed.tableName !== "string" || !parsed.tableName) return null;
@@ -83,6 +86,7 @@ export function parseTableReferencePayload(value: string | undefined | null): Qu
     }
     if (typeof parsed.schema === "string" && parsed.schema) payload.schema = parsed.schema;
     if (parsed.databaseType) payload.databaseType = parsed.databaseType;
+    if (typeof parsed.driverProfile === "string" && parsed.driverProfile) payload.driverProfile = parsed.driverProfile;
     return payload;
   } catch {
     return null;
@@ -126,6 +130,7 @@ export function tableReferenceInsertText(payload: QueryEditorTableReferencePaylo
   const tableName = payload.tableName || payload.database;
   return qualifiedTableName({
     databaseType,
+    driverProfile: payload.driverProfile,
     schema: payload.schema,
     tableName,
   });

--- a/apps/desktop/src/lib/sql/newQueryContext.ts
+++ b/apps/desktop/src/lib/sql/newQueryContext.ts
@@ -90,6 +90,7 @@ export interface ResolveNewQueryInitialSqlInput extends ResolveNewQueryTableInpu
   targetConnectionId: string;
   targetDatabase: string;
   databaseType?: DatabaseType;
+  driverProfile?: string;
   identifierQuote?: string;
 }
 
@@ -146,9 +147,9 @@ export function resolveNewQueryTable(input: ResolveNewQueryTableInput): NewQuery
  * the same per-dialect identifier quoting and schema/catalog qualification used
  * by the table-data view.
  */
-export function buildSelectAllSql(databaseType: DatabaseType | undefined, table: Pick<NewQueryTable, "schema" | "catalog" | "tableName"> & Partial<Pick<NewQueryTable, "database">>, identifierQuote?: string): string {
+export function buildSelectAllSql(databaseType: DatabaseType | undefined, table: Pick<NewQueryTable, "schema" | "catalog" | "tableName"> & Partial<Pick<NewQueryTable, "database">>, identifierQuote?: string, driverProfile?: string): string {
   if (databaseType === "victoriametrics") return metricRangeQuery(table.tableName);
-  const ref = qualifiedTableName({ databaseType, identifierQuote, database: table.database, schema: table.schema, catalog: table.catalog, tableName: table.tableName });
+  const ref = qualifiedTableName({ databaseType, driverProfile, identifierQuote, database: table.database, schema: table.schema, catalog: table.catalog, tableName: table.tableName });
   return `SELECT * FROM ${ref}`;
 }
 
@@ -163,5 +164,5 @@ export function resolveNewQueryInitialSql(input: ResolveNewQueryInitialSqlInput)
   const table = resolveNewQueryTable(input);
   if (!table || table.connectionId !== input.targetConnectionId || table.database !== input.targetDatabase) return undefined;
 
-  return buildSelectAllSql(input.databaseType, table, input.identifierQuote);
+  return buildSelectAllSql(input.databaseType, table, input.identifierQuote, input.driverProfile);
 }

--- a/apps/desktop/src/lib/table/tableSelectSql.ts
+++ b/apps/desktop/src/lib/table/tableSelectSql.ts
@@ -1,5 +1,6 @@
 import type { DatabaseType } from "@/types/database.ts";
 import { isSchemaAware, usesDatabaseObjectTreeMode } from "@/lib/database/databaseCapabilities.ts";
+import { jdbcDriverProfileUsesSchemaQualification } from "@/lib/database/jdbcDialect";
 import * as api from "@/lib/backend/api.ts";
 import { parseSqlServerLinkedSchema, sqlServerLinkedTableName } from "@/lib/database/sqlServerLinkedServers.ts";
 import { isExplicitlyQuotedSqlIdentifier, quoteGaussDbJdbcIdentifier } from "@/lib/sql/sqlIdentifier.ts";
@@ -57,6 +58,10 @@ export function quoteTableIdentifier(databaseType: DatabaseType | undefined, nam
 }
 
 export function quoteTableDataIdentifier(databaseType: DatabaseType | undefined, name: string, identifierQuote?: string): string {
+  if (databaseType === "jdbc" && identifierQuote != null) {
+    if (!identifierQuote) return name;
+    return `${identifierQuote}${name.replaceAll(identifierQuote, identifierQuote + identifierQuote)}${identifierQuote}`;
+  }
   if ((databaseType === "gaussdb" || databaseType === "opengauss" || databaseType === "postgres") && identifierQuote != null) return quoteGaussDbJdbcIdentifier(name, identifierQuote);
   if ((databaseType === "kingbase" || databaseType === "informix" || databaseType === "spanner") && identifierQuote != null) {
     if (!identifierQuote) return name;
@@ -102,6 +107,11 @@ export function qualifiedTableName(options: Pick<BuildTableSelectSqlOptions, "da
       return `${quoteTableDataIdentifier(databaseType, trimmedSchema, identifierQuote)}.${quotedTable}`;
     }
     return quotedTable;
+  }
+  if (databaseType === "jdbc" && jdbcDriverProfileUsesSchemaQualification(driverProfile)) {
+    const quotedTable = quoteTableDataIdentifier(databaseType, tableName, identifierQuote);
+    const trimmedSchema = schema?.trim();
+    return trimmedSchema ? `${quoteTableDataIdentifier(databaseType, trimmedSchema, identifierQuote)}.${quotedTable}` : quotedTable;
   }
   // Cloud Spanner mirrors `uses_connection_identifier_quote` on the backend, which
   // counts Spanner unconditionally: the branch must not be gated on a reported

--- a/apps/desktop/src/lib/table/tableSqlTemplates.ts
+++ b/apps/desktop/src/lib/table/tableSqlTemplates.ts
@@ -3,6 +3,7 @@ import { metricRangeQuery, qualifiedTableName, quoteTableDataIdentifier } from "
 
 export interface TableSqlTemplateOptions {
   databaseType?: DatabaseType;
+  driverProfile?: string;
   identifierQuote?: string;
   schema?: string;
   catalog?: string;
@@ -100,6 +101,7 @@ export function buildTableDeleteTemplate(options: TableSqlTemplateOptions): stri
 function templateTableName(options: TableSqlTemplateOptions): string {
   return qualifiedTableName({
     databaseType: options.databaseType,
+    driverProfile: options.driverProfile,
     identifierQuote: options.identifierQuote,
     catalog: options.catalog,
     database: options.database,

--- a/crates/dbx-core/src/data_grid_sql.rs
+++ b/crates/dbx-core/src/data_grid_sql.rs
@@ -4453,6 +4453,19 @@ mod tests {
         );
         assert_eq!(
             build_data_grid_count_sql(DataGridCountSqlOptions {
+                database_type: Some(DatabaseType::Jdbc),
+                identifier_quote: None,
+                catalog: None,
+                database: None,
+                schema: Some("DEMO".to_string()),
+                table_name: "STUDENT".to_string(),
+                where_input: None,
+                count_hint: None,
+            }),
+            "SELECT COUNT(*) AS cnt FROM DEMO.STUDENT"
+        );
+        assert_eq!(
+            build_data_grid_count_sql(DataGridCountSqlOptions {
                 database_type: Some(DatabaseType::Doris),
                 identifier_quote: None,
                 catalog: Some("iceberg_catalog".to_string()),

--- a/crates/dbx-core/src/sql_dialect/table_select.rs
+++ b/crates/dbx-core/src/sql_dialect/table_select.rs
@@ -385,6 +385,10 @@ pub(crate) fn uses_connection_identifier_quote(
     identifier_quote: Option<&str>,
 ) -> bool {
     database_type == Some(DatabaseType::Kingbase)
+        // JDBC table-data requests carry the schema returned by DatabaseMetaData.
+        // Keep the JDBC identifier unquoted when no driver quote was reported, but
+        // still qualify the table with that schema.
+        || database_type == Some(DatabaseType::Jdbc)
         // Spanner is dual-dialect: GoogleSQL uses backticks, the PostgreSQL dialect uses
         // double quotes, and only the connected agent knows which. Unconditional like
         // Kingbase — when no quote was reported the callers fall back to

--- a/crates/dbx-core/src/sql_dialect/tests.rs
+++ b/crates/dbx-core/src/sql_dialect/tests.rs
@@ -379,6 +379,44 @@ fn jdbc_non_tdengine_and_unscoped_tdengine_previews_remain_unqualified() {
 }
 
 #[test]
+fn jdbc_table_data_qualifies_schema_without_forcing_identifier_quotes() {
+    assert_eq!(
+        build_table_data_select_sql(TableDataSelectSqlOptions {
+            database_type: Some(DatabaseType::Jdbc),
+            driver_profile: Some("phoenix".to_string()),
+            schema: Some("DEMO".to_string()),
+            table_name: "STUDENT".to_string(),
+            limit: Some(100),
+            ..Default::default()
+        }),
+        "SELECT * FROM DEMO.STUDENT;"
+    );
+    assert_eq!(
+        build_table_data_select_sql(TableDataSelectSqlOptions {
+            database_type: Some(DatabaseType::Jdbc),
+            driver_profile: Some("phoenix".to_string()),
+            identifier_quote: Some("\"".to_string()),
+            schema: Some("MY_SCHEMA".to_string()),
+            table_name: "ORDER".to_string(),
+            limit: Some(100),
+            ..Default::default()
+        }),
+        "SELECT * FROM \"MY_SCHEMA\".\"ORDER\";"
+    );
+    assert_eq!(
+        build_table_data_select_sql(TableDataSelectSqlOptions {
+            database_type: Some(DatabaseType::Jdbc),
+            driver_profile: Some("phoenix".to_string()),
+            schema: None,
+            table_name: "STUDENT".to_string(),
+            limit: Some(100),
+            ..Default::default()
+        }),
+        "SELECT * FROM STUDENT;"
+    );
+}
+
+#[test]
 fn builds_table_data_where_and_schema_queries() {
     assert_eq!(
         build_count_table_sql(Some(DatabaseType::Kingbase), Some("cqbq_ls"), "actionlogs"),

--- a/packages/app-tests/jdbcDialect.test.ts
+++ b/packages/app-tests/jdbcDialect.test.ts
@@ -139,10 +139,10 @@ test("keeps Phoenix on the generic JDBC metadata and object tree path", () => {
     jdbc_driver_class: "org.apache.phoenix.jdbc.PhoenixDriver",
   };
 
-  assert.equal(inferJdbcDialect(connection), undefined);
+  assert.equal(inferJdbcDialect(connection), "jdbc");
   assert.equal(effectiveDatabaseTypeForConnection(connection), "jdbc");
-  assert.equal(connectionShouldDiscoverJdbcSchemas(connection), true);
-  assert.equal(connectionUsesDatabaseObjectTreeMode(connection), true);
+  assert.equal(connectionShouldDiscoverJdbcSchemas(connection), false);
+  assert.equal(connectionUsesDatabaseObjectTreeMode(connection), false);
 });
 
 test("uses SQL Server editor syntax for ASE without changing its effective JDBC type", () => {

--- a/packages/app-tests/tableSqlTemplates.test.ts
+++ b/packages/app-tests/tableSqlTemplates.test.ts
@@ -98,3 +98,19 @@ test("builds GaussDB M templates with the detected backtick identifier mode", ()
   assert.equal(buildTableUpdateTemplate(options), "UPDATE app_schema.`order`\nSET `DisplayName` = 'DisplayName_value'\nWHERE id = 0;");
   assert.equal(buildTableDeleteTemplate(options), "DELETE FROM app_schema.`order`\nWHERE id = 0;");
 });
+
+test("preserves the Phoenix schema in all SQL templates", () => {
+  const options = {
+    databaseType: "jdbc" as const,
+    driverProfile: "phoenix",
+    identifierQuote: '"',
+    schema: "APP",
+    tableName: "USERS",
+    columns: [col({ name: "ID", data_type: "integer", is_primary_key: true }), col({ name: "NAME", data_type: "varchar" })],
+  };
+
+  assert.equal(buildTableSelectTemplate(options), 'SELECT "ID", "NAME"\nFROM "APP"."USERS";');
+  assert.equal(buildTableInsertTemplate(options), `INSERT INTO "APP"."USERS" ("ID", "NAME")\nVALUES (0, 'NAME_value');`);
+  assert.equal(buildTableUpdateTemplate(options), `UPDATE "APP"."USERS"\nSET "NAME" = 'NAME_value'\nWHERE "ID" = 0;`);
+  assert.equal(buildTableDeleteTemplate(options), `DELETE FROM "APP"."USERS"\nWHERE "ID" = 0;`);
+});


### PR DESCRIPTION
## 变更说明

Phoenix 通过 JDBC 连接 HBase 时，DatabaseMetaData 会把 Phoenix namespace 返回为 schema。对于非默认 schema（例如 `DEMO`），点击表数据后原本生成的是：

```sql
SELECT * FROM STUDENT
```

Phoenix 因此找不到表 `STUDENT`，而实际表位于 `DEMO.STUDENT`。

本 PR 修复 schema 从连接配置、对象树、table-data 请求到 Rust SQL builder 的完整传递链路，使最终 SQL 正确生成：

```sql
SELECT * FROM DEMO.STUDENT;
```

## 根因

- Phoenix profile 未被 JDBC dialect inference 识别为保留 schema 的 generic JDBC profile。
- 前端对象树路径因此丢弃了 Phoenix schema，table-data 请求收到的 `schema` 为空。
- Rust 通用 JDBC table-data qualifier 原本不会使用 schema，即使上游传入 schema 也会生成裸表名。

## 修复内容

- 将 Phoenix 识别为 schema-aware 的 generic JDBC profile，不改变其通用 JDBC SQL 行为。
- 保留 Phoenix schema tree、metadata 请求和 table-data SQL 请求中的 schema。
- JDBC table-data SQL 使用 driver 返回的 identifier quote；未返回 quote 时保持不加引号。
- Rust table-data 和 COUNT SQL 正确生成 schema-qualified table name。
- 增加 frontend 与 Rust 回归测试，覆盖有 schema、无 schema、identifier quote 和请求参数传递。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 的 frontend 修改仅涉及数据库 metadata 和 SQL 生成逻辑，不涉及 UI、样式或交互，因此无需截图。

## 验证

- [ ] `make check`（未运行）
- [ ] `make cargo-check-fast`（未运行）
- [x] `pnpm exec vitest run apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts apps/desktop/src/composables/__tests__/useSidebarDataOpenRuntime.spec.ts`：92/92 通过
- [x] `pnpm typecheck`：通过
- [x] `pnpm exec oxfmt --check apps/desktop/src/lib/database/jdbcDialect.ts apps/desktop/src/lib/table/tableSelectSql.ts apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts apps/desktop/src/composables/__tests__/useSidebarDataOpenRuntime.spec.ts`：通过
- [x] `pnpm exec oxlint --vue-plugin apps/desktop/src/lib/database/jdbcDialect.ts apps/desktop/src/lib/table/tableSelectSql.ts apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts apps/desktop/src/lib/__tests__/table/tableSelectSql.spec.ts apps/desktop/src/composables/__tests__/useSidebarDataOpenRuntime.spec.ts`：通过
- [x] `cargo test --manifest-path crates/dbx-core/Cargo.toml --lib sql_dialect::tests --no-default-features`：26/26 通过
- [x] `cargo test --manifest-path crates/dbx-core/Cargo.toml --lib data_grid_sql::tests::builds_grid_count_sql --no-default-features`：2/2 通过
- [x] `cargo fmt --manifest-path crates/dbx-core/Cargo.toml -- --check`：通过
- [x] `git diff --check`：通过

真实 Phoenix/HBase 环境不可用，未执行 E2E 验证。

## 关联 Issue

Close #6819