### PR TITLE
🐛 fix(doris): restore single external catalog visibility

### DIFF
--- a/apps/desktop/src/lib/__tests__/database/dorisCatalogCapability.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/dorisCatalogCapability.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { connectionIsDorisFamilyCatalogCapable, isDorisFamilyCatalogCapable, isInternalDorisCatalog } from "@/lib/database/databaseFeatureSupport";
+import { connectionIsDorisFamilyCatalogCapable, isDorisFamilyCatalogCapable, isInternalDorisCatalog, shouldShowDorisCatalogTree } from "@/lib/database/databaseFeatureSupport";
 import type { ConnectionConfig } from "@/types/database";
 
 function conn(db_type: ConnectionConfig["db_type"], driver_profile?: string | null): Pick<ConnectionConfig, "db_type" | "driver_profile"> {
@@ -40,6 +40,23 @@ describe("connectionIsDorisFamilyCatalogCapable", () => {
 
   it("returns false for a plain MySQL connection", () => {
     expect(connectionIsDorisFamilyCatalogCapable(conn("mysql"))).toBe(false);
+  });
+});
+
+describe("shouldShowDorisCatalogTree", () => {
+  const catalog = (name: string, catalog_type: string): { name: string; catalog_type: string } => ({ name, catalog_type });
+
+  it("keeps a single external catalog scoped in the tree", () => {
+    expect(shouldShowDorisCatalogTree([catalog("hive_catalog", "hive")])).toBe(true);
+  });
+
+  it("flattens a single built-in catalog", () => {
+    expect(shouldShowDorisCatalogTree([catalog("internal", "internal")])).toBe(false);
+    expect(shouldShowDorisCatalogTree([catalog("default_catalog", "Internal")])).toBe(false);
+  });
+
+  it("keeps the catalog layer when internal and external catalogs are visible", () => {
+    expect(shouldShowDorisCatalogTree([catalog("internal", "internal"), catalog("iceberg", "iceberg")])).toBe(true);
   });
 });
 

--- a/apps/desktop/src/lib/database/databaseFeatureSupport.ts
+++ b/apps/desktop/src/lib/database/databaseFeatureSupport.ts
@@ -1,4 +1,4 @@
-import type { ConnectionConfig, DatabaseType, TreeNodeType } from "@/types/database";
+import type { CatalogInfo, ConnectionConfig, DatabaseType, TreeNodeType } from "@/types/database";
 import { supportsDatabaseFeature } from "@/lib/database/databaseDriverManifest";
 import { canEditTableStructure } from "@/lib/table/tableStructureCapabilities";
 import { CLEARABLE_QUERY_SCHEMA_TYPES, DATABASE_OBJECT_TREE_TYPES, DATABASE_SCHEMA_QUALIFIED_TYPES, FETCH_FIRST_TYPES, PG_LIKE_STRUCTURE_TYPES, PG_VACUUM_TYPES, SCHEMA_AWARE_TYPES, SINGLE_DATABASE_TYPES, TREE_SCHEMA_TYPES } from "@/lib/database/databaseCapabilitySets";
@@ -43,6 +43,15 @@ export function isInternalDorisCatalog(catalogType?: string | null, catalogName?
   const type = (catalogType ?? "").trim().toLowerCase();
   if (type) return type === "internal";
   return (catalogName ?? "").trim() === "internal";
+}
+
+/**
+ * Keep the catalog grouping layer whenever SHOW CATALOGS exposes an external
+ * catalog. A single visible external catalog still carries namespace
+ * information that cannot be represented by the flat database tree.
+ */
+export function shouldShowDorisCatalogTree(catalogs: readonly CatalogInfo[]): boolean {
+  return catalogs.some((catalog) => !isInternalDorisCatalog(catalog.catalog_type, catalog.name));
 }
 
 export function usesTreeSchemaMode(dbType?: DatabaseType): boolean {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -68,7 +68,7 @@ import { mergeSqlObjectNavigationType, sqlObjectNavigationTypeFromTableType } fr
 import * as api from "@/lib/backend/api";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { useTunnelProfileStore } from "@/stores/tunnelProfileStore";
-import { connectionIsDorisFamilyCatalogCapable, isInternalDorisCatalog, isSchemaAware, normalizeSidebarObjectKind, schemaNodeHasLoadableName, sidebarObjectKindsForDatabase, supportsPackageMemberExpansion, usesTreeSchemaMode } from "@/lib/database/databaseCapabilities";
+import { connectionIsDorisFamilyCatalogCapable, isInternalDorisCatalog, isSchemaAware, normalizeSidebarObjectKind, schemaNodeHasLoadableName, shouldShowDorisCatalogTree, sidebarObjectKindsForDatabase, supportsPackageMemberExpansion, usesTreeSchemaMode } from "@/lib/database/databaseCapabilities";
 import {
   connectionDatabaseMetadataSchema,
   connectionObjectTreeNodeSchema,
@@ -3851,7 +3851,7 @@ export const useConnectionStore = defineStore("connection", () => {
                 return null;
               });
             }
-            if (dorisCatalogs && dorisCatalogs.length > 1) {
+            if (dorisCatalogs && shouldShowDorisCatalogTree(dorisCatalogs)) {
               const cacheKey = schemaCacheKey(connectionId, "doris-catalogs");
               if (!options?.force) {
                 const cached = await loadPersistedTreeChildren(node, cacheKey, load);


### PR DESCRIPTION
Fixes #6797

## 根因

Doris / StarRocks sidebar 原先用 `dorisCatalogs.length > 1` 判断是否保留 Catalog 层级。

Doris `SHOW CATALOGS` 会按当前用户权限过滤结果，因此可能只返回一个外部 Catalog。该结果被错误地当作单内置 Catalog，随后退化为普通 `Database` tree，导致 Catalog 不显示。

#2778 的原设计是：只有内置 Catalog 时扁平显示；只要存在外部 Catalog，就保留 `Catalog → Database → Table` 层级。

## 修复

- 新增 `shouldShowDorisCatalogTree`，按 Catalog 类型判断是否存在外部 Catalog。
- 单个外部 Catalog 也保留 Catalog 节点和 catalog scope。
- 单 `internal` 或 StarRocks 单 `default_catalog` 仍保持原有扁平展示。
- 未修改普通 MySQL、ManticoreSearch 或 Doris/StarRocks Catalog parser 路径。

## 回归范围

- Doris 单外部 Catalog
- Doris `internal + external` Catalog
- Doris 仅 `internal` Catalog
- StarRocks 仅 `default_catalog`

## Tests

- `pnpm vitest run apps/desktop/src/lib/__tests__/database/dorisCatalogCapability.spec.ts`：14 passed
- `pnpm typecheck`：通过
- `pnpm lint`：通过，仅有仓库已有 warnings
- `pnpm exec oxfmt --check ...`：通过

`connectionStore.dorisCatalog.spec.ts` 中两个既有测试仍受旧 mock/超时问题影响，未经过本次新增判断。

## Live Doris validation

未完成 live Doris 2.1.11-rc01 验证；本 PR 基于 Doris `SHOW CATALOGS` 权限过滤行为、#2778 历史设计和 code-level regression test 修复。