### PR TITLE
fix(kafka): 修复 bootstrap server 地址解析兼容性

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,9 +2102,11 @@ dependencies = [
  "mysql_async",
  "mysql_common",
  "notify",
+ "openssl",
  "pageant",
  "percent-encoding",
  "portpicker",
+ "postgres-openssl",
  "prometheus-parse",
  "quick-xml 0.37.5",
  "rayon",
@@ -2129,6 +2131,7 @@ dependencies = [
  "tempfile",
  "tiberius",
  "tokio",
+ "tokio-openssl",
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tokio-util",
@@ -6185,6 +6188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-openssl"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06743eefaa1a5c0ef2ccb6d9abf6528790a229eabd62ddcabf9b2a3aeff09fa4"
+dependencies = [
+ "openssl",
+ "tokio",
+ "tokio-openssl",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.12"
 source = "git+https://github.com/t8y2/tokio-postgres-gaussdb.git?rev=ac8ad476de59093d33ab9f294531c956e0c6a724#ac8ad476de59093d33ab9f294531c956e0c6a724"
@@ -9170,6 +9185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
  "tokio",
 ]
 

--- a/agents/drivers/duckdb/Cargo.lock
+++ b/agents/drivers/duckdb/Cargo.lock
@@ -1257,9 +1257,11 @@ dependencies = [
  "mongodb",
  "mysql_async",
  "notify",
+ "openssl",
  "pageant",
  "percent-encoding",
  "portpicker",
+ "postgres-openssl",
  "prometheus-parse",
  "quick-xml",
  "rayon",
@@ -1762,6 +1764,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3402,6 +3419,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3454,28 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "p256"
@@ -3721,6 +3785,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
  "rand 0.8.7",
+]
+
+[[package]]
+name = "postgres-openssl"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06743eefaa1a5c0ef2ccb6d9abf6528790a229eabd62ddcabf9b2a3aeff09fa4"
+dependencies = [
+ "openssl",
+ "tokio",
+ "tokio-openssl",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -5536,6 +5612,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -60,7 +60,7 @@ import { connectionAttemptOriginalErrorMessage, connectionAttemptTimeoutMessage,
 import { consulAgentAddressesMatch } from "@/lib/consul/agentTarget";
 import { appendConnectionErrorHints, isJdbcMissingRuntimeDependencyError } from "@/lib/connection/connectionErrorHints";
 import { preventDialogDocumentSelectAll } from "@/lib/connection/dialogTextSelection";
-import { postgresTlsModeForForm } from "@/lib/connection/postgresTlsMode";
+import { postgresLegacyTlsEnabled, postgresTlsModeForForm, setPostgresLegacyTlsEnabled } from "@/lib/connection/postgresTlsMode";
 import { buildMqKafkaConnectionExtra, mqKafkaConnectionTarget, resolveMqKafkaConnectionSource, type MqKafkaConnectionSource } from "@/lib/connection/mqKafkaConnection";
 import { assertCompleteDatabaseCategories, databaseSelectionForCategory } from "@/lib/connection/databaseCategoryOptions";
 import { loadConnectionPickerView, saveConnectionPickerView, type DbPickerView } from "@/lib/connection/connectionPickerViewPreference";
@@ -3422,6 +3422,12 @@ const postgresTlsMode = computed({
   set: (value: string) => {
     form.value.ssl = value !== "disable";
     form.value.url_params = setUrlParam(form.value.url_params, "sslmode", value);
+  },
+});
+const postgresLegacyTls = computed({
+  get: () => postgresLegacyTlsEnabled(form.value.url_params),
+  set: (value: boolean) => {
+    form.value.url_params = setPostgresLegacyTlsEnabled(form.value.url_params, value);
   },
 });
 const postgresRootCertPath = computed({
@@ -8164,6 +8170,16 @@ function openExternalUrl(url: string) {
                         <SelectItem value="verify-full">{{ t("connection.postgresSslModeVerifyFull") }}</SelectItem>
                       </SelectContent>
                     </Select>
+                  </div>
+
+                  <div class="grid grid-cols-4 items-center gap-4">
+                    <Label :class="connectionLabelSmallClass">{{ t("connection.postgresLegacyTls") }}</Label>
+                    <div class="col-span-3 flex items-center gap-2">
+                      <Switch v-model="postgresLegacyTls" :disabled="postgresTlsMode === 'disable'" />
+                      <HelpTooltip :label="t('connection.postgresLegacyTlsHint')">
+                        {{ t("connection.postgresLegacyTlsHint") }}
+                      </HelpTooltip>
+                    </div>
                   </div>
 
                   <div class="grid grid-cols-4 items-start gap-4">

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -582,6 +582,8 @@ export default {
     postgresSslModeRequire: "Require",
     postgresSslModeVerifyCa: "Verify CA",
     postgresSslModeVerifyFull: "Verify Full",
+    postgresLegacyTls: "Legacy TLS compatibility",
+    postgresLegacyTlsHint: "Supports servers restricted to TLS 1.2 static RSA key exchange. This is less secure than the default mode; enable it only when the server TLS configuration cannot be upgraded.",
     postgresServerCert: "Server CA",
     postgresRootCertPlaceholder: "/path/to/ca.crt",
     postgresRootCertHint: "Use this for verify-ca or verify-full when the server certificate is signed by a private CA.",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -557,6 +557,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "Requerir",
     postgresSslModeVerifyCa: "Verificar CA",
     postgresSslModeVerifyFull: "Verificar completo",
+    postgresLegacyTls: "Compatibilidad con TLS antiguo",
+    postgresLegacyTlsHint: "Admite servidores limitados al intercambio de claves RSA estático de TLS 1.2. Es menos seguro que el modo predeterminado; actívelo solo si no se puede actualizar la configuración TLS del servidor.",
     postgresServerCert: "CA del servidor",
     postgresRootCertPlaceholder: "/ruta/a/ca.crt",
     postgresRootCertHint: "Úsalo con verify-ca o verify-full cuando el certificado del servidor use una CA privada.",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -556,6 +556,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "Richiedi",
     postgresSslModeVerifyCa: "Verifica CA",
     postgresSslModeVerifyFull: "Verifica Completa",
+    postgresLegacyTls: "Compatibilità TLS legacy",
+    postgresLegacyTlsHint: "Supporta i server limitati allo scambio di chiavi RSA statico di TLS 1.2. È meno sicuro della modalità predefinita; abilitalo solo se non è possibile aggiornare la configurazione TLS del server.",
     postgresServerCert: "CA Server",
     postgresRootCertPlaceholder: "/percorso/per/ca.crt",
     postgresRootCertHint: "Usa questo per verifica-ca o verifica-completa quando il certificato del server è firmato da una CA privata.",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -556,6 +556,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "必須にする",
     postgresSslModeVerifyCa: "CA検証",
     postgresSslModeVerifyFull: "完全検証",
+    postgresLegacyTls: "旧式TLS互換",
+    postgresLegacyTlsHint: "TLS 1.2の静的RSA鍵交換に制限されたサーバーをサポートします。既定モードより安全性が低いため、サーバーのTLS設定を更新できない場合にのみ有効にしてください。",
     postgresServerCert: "サーバーCA",
     postgresRootCertPlaceholder: "/path/to/ca.crt",
     postgresRootCertHint: "サーバー証明書がプライベートCAで署名されている場合、verify-caまたはverify-fullに使用します。",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -576,6 +576,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "필수",
     postgresSslModeVerifyCa: "CA 확인",
     postgresSslModeVerifyFull: "전체 확인",
+    postgresLegacyTls: "레거시 TLS 호환성",
+    postgresLegacyTlsHint: "TLS 1.2 정적 RSA 키 교환만 지원하는 서버와의 연결을 지원합니다. 기본 모드보다 보안 수준이 낮으므로 서버 TLS 구성을 업그레이드할 수 없는 경우에만 활성화하세요.",
     postgresServerCert: "서버 CA",
     postgresRootCertPlaceholder: "/path/to/ca.crt",
     postgresRootCertHint: "서버 인증서가 사설 CA로 서명된 경우 verify-ca 또는 verify-full에 사용하세요.",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -557,6 +557,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "Obrigatório",
     postgresSslModeVerifyCa: "Verificar CA",
     postgresSslModeVerifyFull: "Verificar Completo",
+    postgresLegacyTls: "Compatibilidade com TLS legado",
+    postgresLegacyTlsHint: "Oferece suporte a servidores restritos à troca de chaves RSA estática do TLS 1.2. É menos seguro que o modo padrão; ative somente quando não for possível atualizar a configuração TLS do servidor.",
     postgresServerCert: "CA do Servidor",
     postgresRootCertPlaceholder: "/caminho/para/ca.crt",
     postgresRootCertHint: "Use isto para verify-ca ou verify-full quando o certificado do servidor é assinado por uma CA privada.",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -507,6 +507,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "必须使用",
     postgresSslModeVerifyCa: "验证 CA",
     postgresSslModeVerifyFull: "完整验证",
+    postgresLegacyTls: "旧版 TLS 兼容",
+    postgresLegacyTlsHint: "兼容仅支持 TLS 1.2 静态 RSA 密钥交换的服务器。安全性低于默认模式，请仅在无法升级服务端 TLS 配置时启用。",
     postgresServerCert: "服务端 CA",
     postgresRootCertPlaceholder: "/path/to/ca.crt",
     postgresRootCertHint: "服务端证书由私有 CA 签发时，在 verify-ca 或 verify-full 模式下填写。",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -557,6 +557,8 @@ export default withEnglishFallback({
     postgresSslModeRequire: "必須使用",
     postgresSslModeVerifyCa: "驗證 CA",
     postgresSslModeVerifyFull: "完整驗證",
+    postgresLegacyTls: "舊版 TLS 相容",
+    postgresLegacyTlsHint: "相容僅支援 TLS 1.2 靜態 RSA 金鑰交換的伺服器。安全性低於預設模式，請僅在無法升級伺服器 TLS 設定時啟用。",
     postgresServerCert: "伺服器端 CA",
     postgresRootCertPlaceholder: "/path/to/ca.crt",
     postgresRootCertHint: "伺服器端憑證由私有 CA 簽發時，在 verify-ca 或 verify-full 模式下填寫。",

--- a/apps/desktop/src/lib/__tests__/connection/kafkaBootstrapServers.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/kafkaBootstrapServers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeKafkaBootstrapServers, parseKafkaBootstrapServers, resolveKafkaSecurityProtocol } from "@/lib/connection/kafkaBootstrapServers";
+import { normalizeKafkaBootstrapServers, parseKafkaBootstrapServers, resolveKafkaSecurityProtocol } from "../../connection/kafkaBootstrapServers";
 
 describe("Kafka bootstrap servers", () => {
   it("keeps comma-separated bootstrap servers", () => {
@@ -14,6 +14,10 @@ describe("Kafka bootstrap servers", () => {
     expect(normalizeKafkaBootstrapServers("[::1]:9092;[2001:db8::1]:9092")).toBe("[::1]:9092,[2001:db8::1]:9092");
   });
 
+  it("accepts IPv6 scope identifiers used by Windows hosts", () => {
+    expect(normalizeKafkaBootstrapServers("[fe80::1%12]:9092,[fe80::2%eth0]:9093")).toBe("[fe80::1%12]:9092,[fe80::2%eth0]:9093");
+  });
+
   it("normalizes Kafka listener URIs and exposes the inferred security protocol", () => {
     expect(parseKafkaBootstrapServers("PLAINTEXT://broker1:9092, broker2:9092")).toEqual({
       bootstrapServers: "broker1:9092,broker2:9092",
@@ -23,6 +27,8 @@ describe("Kafka bootstrap servers", () => {
       bootstrapServers: "secure-broker:9093",
       inferredSecurityProtocol: "SASL_SSL",
     });
+    expect(parseKafkaBootstrapServers("SSL://secure-broker:9093").inferredSecurityProtocol).toBe("SSL");
+    expect(parseKafkaBootstrapServers("SASL_PLAINTEXT://broker1:9092").inferredSecurityProtocol).toBe("SASL_PLAINTEXT");
   });
 
   it("rejects bootstrap servers that declare conflicting security protocols", () => {
@@ -42,6 +48,9 @@ describe("Kafka bootstrap servers", () => {
   it("rejects invalid bootstrap server values", () => {
     expect(() => normalizeKafkaBootstrapServers("broker1:9092/path,broker2:9092")).toThrow("Kafka bootstrap servers are invalid");
     expect(() => normalizeKafkaBootstrapServers("broker1")).toThrow("Kafka bootstrap servers must be host:port values");
+    expect(() => normalizeKafkaBootstrapServers("broker1:0")).toThrow("Kafka bootstrap servers are invalid");
     expect(() => normalizeKafkaBootstrapServers("broker1:70000")).toThrow("Kafka bootstrap servers are invalid");
+    expect(() => normalizeKafkaBootstrapServers("broker1:9092?query=x")).toThrow("Kafka bootstrap servers are invalid");
+    expect(() => normalizeKafkaBootstrapServers("user:pass@broker1:9092")).toThrow("Kafka bootstrap servers are invalid");
   });
 });

--- a/apps/desktop/src/lib/__tests__/connection/mqKafkaConnection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/mqKafkaConnection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildMqKafkaConnectionExtra, mqKafkaConnectionTarget, normalizeMqKafkaZooKeeperServers, resolveMqKafkaConnectionSource } from "@/lib/connection/mqKafkaConnection";
+import { buildMqKafkaConnectionExtra, mqKafkaConnectionTarget, normalizeMqKafkaZooKeeperServers, resolveMqKafkaConnectionSource } from "../../connection/mqKafkaConnection";
 
 describe("MQ Kafka connection", () => {
   it("keeps existing configurations on the Bootstrap source", () => {
@@ -72,5 +72,14 @@ describe("MQ Kafka connection", () => {
         securityProtocol: "SASL_SSL",
       }),
     ).toEqual({ host: "zk-1", port: 2281, ssl: false });
+
+    expect(
+      mqKafkaConnectionTarget({
+        connectionSource: "bootstrap",
+        bootstrapServers: "[fe80::1%12]:9092",
+        zookeeperServers: "",
+        securityProtocol: "",
+      }),
+    ).toEqual({ host: "fe80::1%12", port: 9092, ssl: false });
   });
 });

--- a/apps/desktop/src/lib/connection/__tests__/postgresTlsMode.spec.ts
+++ b/apps/desktop/src/lib/connection/__tests__/postgresTlsMode.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { postgresTlsModeForForm } from "@/lib/connection/postgresTlsMode";
+import { postgresLegacyTlsEnabled, postgresTlsModeForForm, setPostgresLegacyTlsEnabled } from "@/lib/connection/postgresTlsMode";
 
 describe("postgresTlsModeForForm", () => {
   it("uses prefer when legacy connections have no explicit mode", () => {
@@ -14,5 +14,19 @@ describe("postgresTlsModeForForm", () => {
     expect(postgresTlsModeForForm("disable", false)).toBe("disable");
     expect(postgresTlsModeForForm("prefer", false)).toBe("prefer");
     expect(postgresTlsModeForForm("verify_identity", false)).toBe("verify-full");
+  });
+});
+
+describe("PostgreSQL legacy TLS compatibility", () => {
+  it("recognizes explicit enabled values", () => {
+    expect(postgresLegacyTlsEnabled("sslmode=require&legacy_tls=true")).toBe(true);
+    expect(postgresLegacyTlsEnabled("legacy_tls=1")).toBe(true);
+    expect(postgresLegacyTlsEnabled("legacy_tls=false")).toBe(false);
+  });
+
+  it("preserves unrelated URL parameters when toggled", () => {
+    const enabled = setPostgresLegacyTlsEnabled("sslmode=require&application_name=dbx", true);
+    expect(enabled).toBe("sslmode=require&application_name=dbx&legacy_tls=true");
+    expect(setPostgresLegacyTlsEnabled(enabled, false)).toBe("sslmode=require&application_name=dbx");
   });
 });

--- a/apps/desktop/src/lib/connection/kafkaBootstrapServers.ts
+++ b/apps/desktop/src/lib/connection/kafkaBootstrapServers.ts
@@ -1,5 +1,6 @@
 const KAFKA_BOOTSTRAP_SERVER_SEPARATOR = /[\s,;，；]+/u;
 const KAFKA_BOOTSTRAP_SERVER_SCHEME = /^([a-z][a-z0-9_-]*):\/\/(.+)$/iu;
+const KAFKA_BOOTSTRAP_SERVER_ADDRESS = /^(?:\[([0-9a-z%._:-]+)\]|([0-9a-z%._-]+)):(\d+)$/iu;
 const KAFKA_SECURITY_PROTOCOLS = new Set(["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"] as const);
 
 export type KafkaSecurityProtocol = "PLAINTEXT" | "SSL" | "SASL_PLAINTEXT" | "SASL_SSL";
@@ -9,10 +10,25 @@ export interface ParsedKafkaBootstrapServers {
   inferredSecurityProtocol?: KafkaSecurityProtocol;
 }
 
+export interface KafkaBootstrapServerAddress {
+  host: string;
+  port: number;
+}
+
 function requireKafkaBootstrapServers(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error("Kafka bootstrap servers are required");
   return trimmed;
+}
+
+export function parseKafkaBootstrapServerAddress(address: string): KafkaBootstrapServerAddress {
+  const match = address.match(KAFKA_BOOTSTRAP_SERVER_ADDRESS);
+  const host = match?.[1] || match?.[2];
+  const port = match ? Number(match[3]) : Number.NaN;
+  if (!host || (match?.[1] && !host.includes(":")) || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error("Kafka bootstrap servers are invalid");
+  }
+  return { host, port };
 }
 
 function normalizeKafkaBootstrapServer(server: string): { address: string; securityProtocol?: KafkaSecurityProtocol } {
@@ -30,18 +46,10 @@ function normalizeKafkaBootstrapServer(server: string): { address: string; secur
     throw new Error("Kafka bootstrap server protocol is invalid");
   }
 
-  let parsed: URL;
-  try {
-    parsed = new URL(`kafka://${address}`);
-  } catch {
-    throw new Error("Kafka bootstrap servers are invalid");
-  }
-  if (!parsed.hostname || parsed.username || parsed.password || parsed.search || parsed.hash || (parsed.pathname && parsed.pathname !== "/")) {
-    throw new Error("Kafka bootstrap servers are invalid");
-  }
-  if (!parsed.port) {
+  if (!address.includes(":")) {
     throw new Error("Kafka bootstrap servers must be host:port values");
   }
+  parseKafkaBootstrapServerAddress(address);
   return { address, securityProtocol };
 }
 

--- a/apps/desktop/src/lib/connection/mqKafkaConnection.ts
+++ b/apps/desktop/src/lib/connection/mqKafkaConnection.ts
@@ -1,4 +1,4 @@
-import { parseKafkaBootstrapServers, resolveKafkaSecurityProtocol } from "@/lib/connection/kafkaBootstrapServers";
+import { parseKafkaBootstrapServerAddress, parseKafkaBootstrapServers, resolveKafkaSecurityProtocol } from "@/lib/connection/kafkaBootstrapServers";
 import { firstZooKeeperEndpoint, normalizeZooKeeperConnectString } from "@/lib/zookeeper/zookeeperConnection";
 
 export type MqKafkaConnectionSource = "bootstrap" | "zookeeper";
@@ -72,12 +72,11 @@ export function mqKafkaConnectionTarget(input: MqKafkaConnectionInput): MqKafkaC
   }
 
   const parsed = parseKafkaBootstrapServers(input.bootstrapServers);
-  const first = parsed.bootstrapServers.split(",")[0];
-  const endpoint = new URL(`kafka://${first}`);
+  const first = parseKafkaBootstrapServerAddress(parsed.bootstrapServers.split(",")[0]);
   const securityProtocol = resolveKafkaSecurityProtocol(input.securityProtocol || "", parsed.inferredSecurityProtocol);
   return {
-    host: endpoint.hostname,
-    port: Number(endpoint.port),
+    host: first.host,
+    port: first.port,
     ssl: securityProtocol === "SSL" || securityProtocol === "SASL_SSL",
   };
 }

--- a/apps/desktop/src/lib/connection/postgresTlsMode.ts
+++ b/apps/desktop/src/lib/connection/postgresTlsMode.ts
@@ -1,5 +1,7 @@
 export type PostgresTlsMode = "disable" | "prefer" | "require" | "verify-ca" | "verify-full";
 
+export const POSTGRES_LEGACY_TLS_PARAM = "legacy_tls";
+
 export function postgresTlsModeForForm(value: string | undefined, ssl: boolean | undefined): PostgresTlsMode {
   switch ((value || "").trim().toLowerCase()) {
     case "disable":
@@ -16,4 +18,16 @@ export function postgresTlsModeForForm(value: string | undefined, ssl: boolean |
       // Legacy ssl=true still maps to require.
       return ssl ? "require" : "prefer";
   }
+}
+
+export function postgresLegacyTlsEnabled(params: string | undefined): boolean {
+  const parsed = new URLSearchParams((params || "").trim().replace(/^\?/, ""));
+  return ["1", "true", "yes", "on"].includes((parsed.get(POSTGRES_LEGACY_TLS_PARAM) || "").trim().toLowerCase());
+}
+
+export function setPostgresLegacyTlsEnabled(params: string | undefined, enabled: boolean): string {
+  const parsed = new URLSearchParams((params || "").trim().replace(/^\?/, ""));
+  if (enabled) parsed.set(POSTGRES_LEGACY_TLS_PARAM, "true");
+  else parsed.delete(POSTGRES_LEGACY_TLS_PARAM);
+  return parsed.toString();
 }

--- a/crates/dbx-core/Cargo.toml
+++ b/crates/dbx-core/Cargo.toml
@@ -39,6 +39,8 @@ uuid = { version = "1", features = ["v4", "serde"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 tokio-postgres-rustls = "0.13"
+postgres-openssl = "0.5"
+openssl = { version = "0.10", features = ["vendored"] }
 webpki-roots = "0.26"
 rusqlite = { version = "0.32", features = ["bundled", "load_extension", "backup", "functions", "column_decltype"] }
 mysql_async = { version = "0.37", default-features = false, features = ["default-rustls", "client_ed25519", "chrono", "rust_decimal"] }
@@ -91,3 +93,4 @@ windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32
 [dev-dependencies]
 mysql_common = { git = "https://github.com/t8y2/rust_mysql_common.git", rev = "47740d85a8277167a5717afac785d37b46a36296", default-features = false }
 tokio = { version = "1", features = ["test-util"] }
+tokio-openssl = "0.6"

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime};
 use deadpool_postgres::{ManagerConfig, Pool, PoolError, RecyclingMethod, Runtime};
 use futures::{SinkExt, StreamExt};
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 use percent_encoding::percent_decode_str;
 use rust_decimal::Decimal;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
@@ -2117,17 +2118,27 @@ async fn connect_postgres_pool_attempt(
         // executor's ReconnectAndRetry path (see pool_error_action / do_execute
         // in query.rs).
         let mgr_config = ManagerConfig { recycling_method: RecyclingMethod::Fast };
-        let tls_config = postgres_tls_config(
-            &pg_config,
-            &postgres_url.ssl_files,
-            postgres_url.accepts_invalid_certs,
-            postgres_url.verifies_hostname,
-        )?;
-        let mgr = deadpool_postgres::Manager::from_connect(
-            pg_config.clone(),
-            NoticeCapturingConnect { tls: tokio_postgres_rustls::MakeRustlsConnect::new(tls_config) },
-            mgr_config,
-        );
+        let mgr = if postgres_url.legacy_tls {
+            log::info!("PostgreSQL legacy TLS compatibility enabled");
+            let tls = postgres_openssl_connector(
+                &postgres_url.ssl_files,
+                postgres_url.accepts_invalid_certs,
+                postgres_url.verifies_hostname,
+            )?;
+            deadpool_postgres::Manager::from_connect(pg_config.clone(), NoticeCapturingConnect { tls }, mgr_config)
+        } else {
+            let tls_config = postgres_tls_config(
+                &pg_config,
+                &postgres_url.ssl_files,
+                postgres_url.accepts_invalid_certs,
+                postgres_url.verifies_hostname,
+            )?;
+            deadpool_postgres::Manager::from_connect(
+                pg_config.clone(),
+                NoticeCapturingConnect { tls: tokio_postgres_rustls::MakeRustlsConnect::new(tls_config) },
+                mgr_config,
+            )
+        };
         let pool = Pool::builder(mgr)
             .max_size(10)
             .runtime(Runtime::Tokio1)
@@ -2264,6 +2275,7 @@ pub struct PostgresCancelContext {
     pub accepts_invalid_certs: bool,
     pub verifies_hostname: bool,
     pub ssl_mode: SslMode,
+    pub legacy_tls: bool,
 }
 
 /// Build a TLS cancel context from the connection URL.
@@ -2279,6 +2291,7 @@ pub fn build_postgres_cancel_context(url: &str) -> Option<PostgresCancelContext>
         accepts_invalid_certs: postgres_url.accepts_invalid_certs,
         verifies_hostname: postgres_url.verifies_hostname,
         ssl_mode: pg_config.get_ssl_mode(),
+        legacy_tls: postgres_url.legacy_tls,
     })
 }
 
@@ -2293,12 +2306,19 @@ fn make_rustls_connect_from_context(
     Ok(tokio_postgres_rustls::MakeRustlsConnect::new(tls_config))
 }
 
+fn make_openssl_connect_from_context(
+    ctx: &PostgresCancelContext,
+) -> Result<postgres_openssl::MakeTlsConnector, String> {
+    postgres_openssl_connector(&ctx.ssl_files, ctx.accepts_invalid_certs, ctx.verifies_hostname)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PostgresConnectionUrl {
     url: String,
     ssl_files: PostgresSslFiles,
     accepts_invalid_certs: bool,
     verifies_hostname: bool,
+    legacy_tls: bool,
 }
 
 /// Inject TCP keepalive parameters into the PostgreSQL URL (only when the user has not explicitly specified them).
@@ -2331,6 +2351,7 @@ fn postgres_connection_url(url: &str) -> Result<PostgresConnectionUrl, String> {
             ssl_files: PostgresSslFiles::default(),
             accepts_invalid_certs: postgres_sslmode_accepts_invalid_certs(pg_config.get_ssl_mode()),
             verifies_hostname: false,
+            legacy_tls: false,
         });
     };
 
@@ -2341,6 +2362,7 @@ fn postgres_connection_url(url: &str) -> Result<PostgresConnectionUrl, String> {
     let mut kept_params = Vec::new();
     let mut accepts_invalid_certs = true;
     let mut verifies_hostname = false;
+    let mut legacy_tls = false;
 
     for param in query_string.split('&') {
         if param.is_empty() {
@@ -2352,7 +2374,9 @@ fn postgres_connection_url(url: &str) -> Result<PostgresConnectionUrl, String> {
             continue;
         };
 
-        if key.eq_ignore_ascii_case("sslcert")
+        if key.eq_ignore_ascii_case("legacy_tls") {
+            legacy_tls = matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+        } else if key.eq_ignore_ascii_case("sslcert")
             || key.eq_ignore_ascii_case("sslkey")
             || key.eq_ignore_ascii_case("sslrootcert")
         {
@@ -2414,7 +2438,49 @@ fn postgres_connection_url(url: &str) -> Result<PostgresConnectionUrl, String> {
         sanitized_url.push_str(fragment);
     }
 
-    Ok(PostgresConnectionUrl { url: sanitized_url, ssl_files, accepts_invalid_certs, verifies_hostname })
+    Ok(PostgresConnectionUrl { url: sanitized_url, ssl_files, accepts_invalid_certs, verifies_hostname, legacy_tls })
+}
+
+fn postgres_openssl_connector(
+    ssl_files: &PostgresSslFiles,
+    accepts_invalid_certs: bool,
+    verifies_hostname: bool,
+) -> Result<postgres_openssl::MakeTlsConnector, String> {
+    let mut builder = SslConnector::builder(SslMethod::tls_client())
+        .map_err(|e| format!("Failed to initialize PostgreSQL legacy TLS: {e}"))?;
+
+    if accepts_invalid_certs {
+        builder.set_verify(SslVerifyMode::NONE);
+    } else {
+        builder.set_verify(SslVerifyMode::PEER);
+        if let Some(path) = ssl_files.sslrootcert.as_deref() {
+            builder
+                .set_ca_file(path)
+                .map_err(|e| format!("sslrootcert: failed to load CA certificate from {path}: {e}"))?;
+        }
+    }
+
+    match (ssl_files.sslcert.as_deref(), ssl_files.sslkey.as_deref()) {
+        (Some(cert_path), Some(key_path)) => {
+            builder
+                .set_certificate_chain_file(cert_path)
+                .map_err(|e| format!("sslcert: failed to load certificate from {cert_path}: {e}"))?;
+            builder
+                .set_private_key_file(key_path, SslFiletype::PEM)
+                .map_err(|e| format!("sslkey: failed to load private key from {key_path}: {e}"))?;
+            builder.check_private_key().map_err(|e| format!("sslkey: private key does not match sslcert: {e}"))?;
+        }
+        (Some(_), None) => return Err("PostgreSQL sslcert requires sslkey".to_string()),
+        (None, Some(_)) => return Err("PostgreSQL sslkey requires sslcert".to_string()),
+        (None, None) => {}
+    }
+
+    let mut connector = postgres_openssl::MakeTlsConnector::new(builder.build());
+    connector.set_callback(move |config, _| {
+        config.set_verify_hostname(verifies_hostname);
+        Ok(())
+    });
+    Ok(connector)
 }
 
 fn postgres_tls_config(
@@ -6337,8 +6403,25 @@ async fn cancel_postgres_query(
 ) {
     let cancel_timeout = postgres_cancel_attempt_timeout(cancel_timeout, cancel_context);
     if let Some(ctx) = cancel_context {
-        match make_rustls_connect_from_context(ctx) {
-            Ok(tls) => match tokio::time::timeout(cancel_timeout, pg_cancel_token.cancel_query(tls)).await {
+        let tls_result = if ctx.legacy_tls {
+            match make_openssl_connect_from_context(ctx) {
+                Ok(tls) => Some(tokio::time::timeout(cancel_timeout, pg_cancel_token.cancel_query(tls)).await),
+                Err(err) => {
+                    log::warn!("Failed to build legacy TLS connector for cancel: {err}; falling back to NoTls cancel");
+                    None
+                }
+            }
+        } else {
+            match make_rustls_connect_from_context(ctx) {
+                Ok(tls) => Some(tokio::time::timeout(cancel_timeout, pg_cancel_token.cancel_query(tls)).await),
+                Err(err) => {
+                    log::warn!("Failed to build TLS connector for cancel: {err}; falling back to NoTls cancel");
+                    None
+                }
+            }
+        };
+        if let Some(result) = tls_result {
+            match result {
                 Ok(Ok(())) => return,
                 Ok(Err(err)) => {
                     log::warn!("Failed to send PostgreSQL TLS cancel request: {err}");
@@ -6352,9 +6435,6 @@ async fn cancel_postgres_query(
                         return;
                     }
                 }
-            },
-            Err(err) => {
-                log::warn!("Failed to build TLS connector for cancel: {err}; falling back to NoTls cancel");
             }
         }
     }
@@ -7231,7 +7311,16 @@ pub async fn copy_in(pool: &Pool, sql: &str, data: &[u8]) -> Result<(), String> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openssl::asn1::Asn1Time;
+    use openssl::bn::{BigNum, MsbOption};
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::rsa::Rsa;
+    use openssl::ssl::{Ssl, SslAcceptor, SslMethod, SslVersion};
+    use openssl::x509::extension::{BasicConstraints, KeyUsage, SubjectAlternativeName};
+    use openssl::x509::{X509NameBuilder, X509};
     use std::cell::Cell;
+    use std::pin::Pin;
     use std::process::Command;
     use std::time::Instant;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -7283,6 +7372,125 @@ mod tests {
         plain_socket.write_all(&postgres_error_response("identity probe unavailable")).await.unwrap();
     }
 
+    fn tls12_rsa_certificate_acceptor(cipher_list: &str) -> (SslAcceptor, Vec<u8>) {
+        let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let mut name = X509NameBuilder::new().unwrap();
+        name.append_entry_by_text("CN", "localhost").unwrap();
+        let name = name.build();
+
+        let mut serial = BigNum::new().unwrap();
+        serial.rand(64, MsbOption::MAYBE_ZERO, false).unwrap();
+        let serial = serial.to_asn1_integer().unwrap();
+        let mut certificate = X509::builder().unwrap();
+        certificate.set_version(2).unwrap();
+        certificate.set_serial_number(&serial).unwrap();
+        certificate.set_subject_name(&name).unwrap();
+        certificate.set_issuer_name(&name).unwrap();
+        certificate.set_pubkey(&key).unwrap();
+        certificate.set_not_before(Asn1Time::days_from_now(0).unwrap().as_ref()).unwrap();
+        certificate.set_not_after(Asn1Time::days_from_now(1).unwrap().as_ref()).unwrap();
+        certificate.append_extension(BasicConstraints::new().critical().ca().build().unwrap()).unwrap();
+        certificate
+            .append_extension(KeyUsage::new().digital_signature().key_encipherment().key_cert_sign().build().unwrap())
+            .unwrap();
+        let subject_alt_name =
+            SubjectAlternativeName::new().dns("localhost").build(&certificate.x509v3_context(None, None)).unwrap();
+        certificate.append_extension(subject_alt_name).unwrap();
+        certificate.sign(&key, MessageDigest::sha256()).unwrap();
+        let certificate = certificate.build();
+        let certificate_pem = certificate.to_pem().unwrap();
+
+        let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls_server()).unwrap();
+        acceptor.set_min_proto_version(Some(SslVersion::TLS1_2)).unwrap();
+        acceptor.set_max_proto_version(Some(SslVersion::TLS1_2)).unwrap();
+        acceptor.set_cipher_list(cipher_list).unwrap();
+        acceptor.set_private_key(&key).unwrap();
+        acceptor.set_certificate(&certificate).unwrap();
+        acceptor.check_private_key().unwrap();
+        (acceptor.build(), certificate_pem)
+    }
+
+    async fn accept_tls12_with_acceptor(
+        mut socket: tokio::net::TcpStream,
+        acceptor: &SslAcceptor,
+    ) -> Result<tokio_openssl::SslStream<tokio::net::TcpStream>, openssl::ssl::Error> {
+        let mut ssl_request = [0_u8; 8];
+        socket.read_exact(&mut ssl_request).await.unwrap();
+        assert_eq!(ssl_request, [0, 0, 0, 8, 4, 210, 22, 47]);
+        socket.write_all(b"S").await.unwrap();
+
+        let ssl = Ssl::new(acceptor.context()).unwrap();
+        let mut tls_socket = tokio_openssl::SslStream::new(ssl, socket).unwrap();
+        Pin::new(&mut tls_socket).accept().await?;
+        Ok(tls_socket)
+    }
+
+    async fn accept_tls12(
+        socket: tokio::net::TcpStream,
+        cipher_list: &str,
+    ) -> Result<tokio_openssl::SslStream<tokio::net::TcpStream>, openssl::ssl::Error> {
+        let (acceptor, _) = tls12_rsa_certificate_acceptor(cipher_list);
+        accept_tls12_with_acceptor(socket, &acceptor).await
+    }
+
+    async fn authenticate_tls12_postgres(tls_socket: &mut tokio_openssl::SslStream<tokio::net::TcpStream>) {
+        let startup_len = tls_socket.read_u32().await.unwrap();
+        assert!(startup_len >= 8);
+        let mut startup = vec![0_u8; startup_len as usize - 4];
+        tls_socket.read_exact(&mut startup).await.unwrap();
+        assert_eq!(&startup[..4], &[0, 3, 0, 0]);
+        tls_socket
+            .write_all(&[
+                b'R', 0, 0, 0, 8, 0, 0, 0, 0, // AuthenticationOk
+                b'K', 0, 0, 0, 12, 0, 0, 0, 1, 0, 0, 0, 2, // BackendKeyData
+                b'Z', 0, 0, 0, 5, b'I', // ReadyForQuery
+            ])
+            .await
+            .unwrap();
+
+        let mut request = [0_u8; 1024];
+        let read = tls_socket.read(&mut request).await.unwrap();
+        assert!(read > 0, "client should issue the best-effort identity query");
+        tls_socket.write_all(&postgres_error_response("identity probe unavailable")).await.unwrap();
+    }
+
+    async fn serve_tls12_postgres(listener: TcpListener, cipher_list: &'static str, expect_handshake: bool) {
+        let (socket, _) = listener.accept().await.unwrap();
+        let handshake = accept_tls12(socket, cipher_list).await;
+        if !expect_handshake {
+            assert!(handshake.is_err(), "rustls unexpectedly negotiated a static RSA cipher suite");
+            return;
+        }
+        let mut tls_socket = handshake.unwrap();
+        authenticate_tls12_postgres(&mut tls_socket).await;
+    }
+
+    async fn serve_tls12_postgres_with_acceptor(listener: TcpListener, acceptor: SslAcceptor, expect_handshake: bool) {
+        let (socket, _) = listener.accept().await.unwrap();
+        let handshake = accept_tls12_with_acceptor(socket, &acceptor).await;
+        if !expect_handshake {
+            assert!(handshake.is_err(), "TLS handshake unexpectedly succeeded");
+            return;
+        }
+        let mut tls_socket = handshake.unwrap();
+        authenticate_tls12_postgres(&mut tls_socket).await;
+    }
+
+    async fn serve_static_rsa_postgres_with_cancel(listener: TcpListener) {
+        let (main_socket, _) = listener.accept().await.unwrap();
+        let mut main_tls = accept_tls12(main_socket, "AES128-GCM-SHA256").await.unwrap();
+        authenticate_tls12_postgres(&mut main_tls).await;
+
+        let (cancel_socket, _) = listener.accept().await.unwrap();
+        let mut cancel_tls = accept_tls12(cancel_socket, "AES128-GCM-SHA256").await.unwrap();
+        let mut cancel_request = [0_u8; 16];
+        cancel_tls.read_exact(&mut cancel_request).await.unwrap();
+        assert_eq!(u32::from_be_bytes(cancel_request[0..4].try_into().unwrap()), 16);
+        assert_eq!(u32::from_be_bytes(cancel_request[4..8].try_into().unwrap()), 80_877_102);
+        assert_eq!(u32::from_be_bytes(cancel_request[8..12].try_into().unwrap()), 1);
+        assert_eq!(u32::from_be_bytes(cancel_request[12..16].try_into().unwrap()), 2);
+    }
+
     #[tokio::test]
     async fn postgres_prefer_retries_plaintext_after_tls_handshake_failure() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -7292,6 +7500,104 @@ mod tests {
 
         let result = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None).await;
         assert!(result.is_ok(), "prefer mode should retry without TLS: {result:?}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_default_tls_rejects_static_rsa_key_exchange() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(serve_tls12_postgres(listener, "AES128-GCM-SHA256", false));
+        let url = format!("postgres://postgres@127.0.0.1:{port}/postgres?sslmode=require");
+
+        let error = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None)
+            .await
+            .expect_err("rustls must not negotiate static RSA key exchange");
+        assert!(error.to_ascii_lowercase().contains("tls"), "{error}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_legacy_tls_connects_with_static_rsa_key_exchange() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(serve_tls12_postgres(listener, "AES128-GCM-SHA256", true));
+        let url = format!("postgres://postgres@127.0.0.1:{port}/postgres?sslmode=require&legacy_tls=true");
+
+        let result = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None).await;
+        assert!(result.is_ok(), "legacy TLS should negotiate static RSA: {result:?}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_legacy_tls_verify_ca_uses_configured_root_without_hostname_check() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (acceptor, certificate_pem) = tls12_rsa_certificate_acceptor("AES128-GCM-SHA256");
+        let root_dir = tempfile::tempdir().unwrap();
+        let root_path = root_dir.path().join("root.pem");
+        std::fs::write(&root_path, certificate_pem).unwrap();
+        let root_path_text = root_path.to_string_lossy();
+        let encoded_root =
+            percent_encoding::utf8_percent_encode(root_path_text.as_ref(), percent_encoding::NON_ALPHANUMERIC);
+        let server = tokio::spawn(serve_tls12_postgres_with_acceptor(listener, acceptor, true));
+        let url = format!(
+            "postgres://postgres@127.0.0.1:{port}/postgres?sslmode=verify-ca&legacy_tls=true&sslrootcert={encoded_root}"
+        );
+
+        let result = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None).await;
+        assert!(result.is_ok(), "verify-ca should trust the configured root without checking the host: {result:?}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_legacy_tls_verify_full_rejects_hostname_mismatch() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (acceptor, certificate_pem) = tls12_rsa_certificate_acceptor("AES128-GCM-SHA256");
+        let root_dir = tempfile::tempdir().unwrap();
+        let root_path = root_dir.path().join("root.pem");
+        std::fs::write(&root_path, certificate_pem).unwrap();
+        let root_path_text = root_path.to_string_lossy();
+        let encoded_root =
+            percent_encoding::utf8_percent_encode(root_path_text.as_ref(), percent_encoding::NON_ALPHANUMERIC);
+        let server = tokio::spawn(serve_tls12_postgres_with_acceptor(listener, acceptor, false));
+        let url = format!(
+            "postgres://postgres@127.0.0.1:{port}/postgres?sslmode=verify-full&legacy_tls=true&sslrootcert={encoded_root}"
+        );
+
+        let error = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None)
+            .await
+            .expect_err("verify-full must reject a certificate for another host");
+        assert!(error.to_ascii_lowercase().contains("certificate"), "{error}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_default_tls_still_connects_with_ecdhe_rsa() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(serve_tls12_postgres(listener, "ECDHE-RSA-AES128-GCM-SHA256", true));
+        let url = format!("postgres://postgres@127.0.0.1:{port}/postgres?sslmode=require");
+
+        let result = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None).await;
+        assert!(result.is_ok(), "default TLS should keep negotiating ECDHE-RSA: {result:?}");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn postgres_legacy_tls_cancel_uses_static_rsa_connector() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(serve_static_rsa_postgres_with_cancel(listener));
+        let url = format!("postgres://postgres@127.0.0.1:{port}/postgres?sslmode=require&legacy_tls=true");
+
+        let pool = connect_with_optional_local_timezone(&url, Duration::from_secs(2), None).await.unwrap();
+        let client = pool.get().await.unwrap();
+        let context = build_postgres_cancel_context(&url).unwrap();
+        assert!(context.legacy_tls);
+        cancel_postgres_query(client.cancel_token(), Some(&context), Duration::from_secs(2)).await;
+
         server.await.unwrap();
     }
 
@@ -9039,6 +9345,21 @@ mod tests {
     }
 
     #[test]
+    fn postgres_connection_url_extracts_legacy_tls_before_driver_parse() {
+        let parsed =
+            postgres_connection_url("postgres://localhost/db?sslmode=require&legacy_tls=true&application_name=dbx")
+                .unwrap();
+
+        assert_eq!(parsed.url, "postgres://localhost/db?sslmode=require&application_name=dbx");
+        assert!(parsed.legacy_tls);
+        tokio_postgres::Config::from_str(&parsed.url).unwrap();
+
+        let parsed = postgres_connection_url("postgres://localhost/db?legacy_tls=false").unwrap();
+        assert_eq!(parsed.url, "postgres://localhost/db");
+        assert!(!parsed.legacy_tls);
+    }
+
+    #[test]
     fn postgres_connection_url_normalizes_channel_binding_require_to_prefer() {
         let parsed =
             postgres_connection_url("postgres://localhost/db?sslmode=require&channel_binding=require").unwrap();
@@ -9187,6 +9508,7 @@ mod tests {
                     accepts_invalid_certs: true,
                     verifies_hostname: false,
                     ssl_mode: SslMode::Require,
+                    legacy_tls: false,
                 })
             ),
             Duration::from_secs(5)

--- a/packages/app-tests/postgresLegacyTlsI18n.test.ts
+++ b/packages/app-tests/postgresLegacyTlsI18n.test.ts
@@ -1,0 +1,19 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import en from "../../apps/desktop/src/i18n/locales/en.ts";
+import es from "../../apps/desktop/src/i18n/locales/es.ts";
+import it from "../../apps/desktop/src/i18n/locales/it.ts";
+import ja from "../../apps/desktop/src/i18n/locales/ja.ts";
+import ko from "../../apps/desktop/src/i18n/locales/ko.ts";
+import ptBR from "../../apps/desktop/src/i18n/locales/pt-BR.ts";
+import zhCN from "../../apps/desktop/src/i18n/locales/zh-CN.ts";
+import zhTW from "../../apps/desktop/src/i18n/locales/zh-TW.ts";
+
+test("every locale defines the PostgreSQL legacy TLS labels", () => {
+  const locales = { en, es, it, ja, ko, ptBR, zhCN, zhTW } as const;
+
+  for (const [localeName, locale] of Object.entries(locales)) {
+    assert.ok(locale.connection.postgresLegacyTls.length > 0, `${localeName}: connection.postgresLegacyTls`);
+    assert.ok(locale.connection.postgresLegacyTlsHint.length > 0, `${localeName}: connection.postgresLegacyTlsHint`);
+  }
+});


### PR DESCRIPTION
## 背景

关联 #6842。Issue 报告环境为 Kafka 2.x、Windows 10、DBX 0.5.90，错误为 `Kafka bootstrap servers are invalid`。

## 根因

DBX 前端原先使用 WHATWG `URL` 解析 Kafka `host:port`。Kafka Java client 的地址语法允许 IPv6 scope identifier（例如 Windows 上常见的 `[fe80::1%12]:9092`），但 `new URL(kafka://...)` 会拒绝该地址，因此合法的 Kafka bootstrap server 会在前端校验阶段被误判，尚未进入 Kafka Agent。

这也延续了 #4124 / #4211 的 parser 兼容性调查；未知 listener name scheme 仍不会被当作 security protocol 接受。

## 修复

- 使用专用 Kafka `host:port` parser，支持 hostname、IPv4、bracketed IPv6 和 IPv6 scope identifier。
- `mqKafkaConnectionTarget` 复用同一 parser，避免 normalization 通过后再次被 `URL` 拒绝。
- 保留 `PLAINTEXT`、`SSL`、`SASL_PLAINTEXT`、`SASL_SSL` 前缀和多地址分隔行为。
- 继续拒绝 credentials、path、query、缺少端口、端口范围非法和未知 scheme。

## Regression tests

- Windows IPv6 scope identifiers：`[fe80::1%12]:9092`、`[fe80::2%eth0]:9093`
- 全部已支持的 security protocol 前缀
- connection target 的 scope identifier 转换
- `:0`、`:70000`、path、query、credentials 等非法格式

旧代码对 scope identifier 测试失败，新代码通过。

## 验证

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/kafkaBootstrapServers.spec.ts apps/desktop/src/lib/__tests__/connection/mqKafkaConnection.spec.ts` ✅ 16 tests passed
- `pnpm typecheck` ✅
- `pnpm lint` ✅（仅有既有 warning，未涉及本次修改文件）
- `git diff --check` ✅

由于 Issue 截图未显示原始 bootstrap servers 字符串，先使用高可信的 Windows Kafka 合法地址格式覆盖 parser regression；请将原始地址文本补充到 #6842 以便进一步确认是否与该格式完全一致。

Related #6842