### PR TITLE
feat(ai): support dragging sidebar table names into AI chat

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -131,8 +131,8 @@ import ExplainPlanViewer from "@/components/explain/ExplainPlanViewer.vue";
 import { parseExplainResult, parseOracleExplainText, type ParsedExplainPlan } from "@/lib/diagram/explainPlan";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { AI_TABLE_MENTION_CANDIDATE_LIMIT, AI_TABLE_MENTION_SCHEMA_LIMIT, filterAiTableMentionCandidates, formatAiTableMention, parseAiTableMentions, type AiTableMention } from "@/lib/ai/aiTableMentions";
-import { aiTableMentionFromTableReference } from "@/lib/ai/aiTableReferenceDrop";
-import { DBX_TABLE_REFERENCE_DROP_EVENT, clearActiveTableReferencePayload, type QueryEditorTableReferenceDropDetail } from "@/lib/editor/queryEditorTableDrop";
+import { handleAiTableReferenceDropEvent } from "@/lib/ai/aiTableReferenceDrop";
+import { DBX_TABLE_REFERENCE_DROP_EVENT, clearActiveTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
 import { isAiPromptImeCompositionEvent, shouldSubmitAiPromptOnKeydown } from "@/lib/ai/aiPromptKeyboard";
 import { isActionableWriteProposalMessage, isActionableWriteSqlProposal, looksLikeActionProposal, looksLikeWriteSqlProposal, shouldGrantWriteSqlOnShortAffirmative } from "@/lib/ai/aiProposalDetect";
 import { visibleToActualIndex } from "@/lib/ai/aiMessageEdit";
@@ -2289,16 +2289,19 @@ function onTauriFileDrop(event: Event) {
 }
 
 function onTableReferenceDropEvent(event: Event) {
-  if (!(event instanceof CustomEvent)) return;
-  const detail = event.detail as QueryEditorTableReferenceDropDetail | undefined;
-  if (!detail?.payload) return;
-  const mention = aiTableMentionFromTableReference(detail.payload);
-  if (!mention) return;
-  const target = document.elementFromPoint(detail.clientX, detail.clientY);
-  if (!(target instanceof Element) || !assistantRootRef.value?.contains(target)) return;
-  addSelectedMention({ kind: "table", schema: mention.schema, name: mention.table, tableType: "table" });
-  clearActiveTableReferencePayload(detail.payload);
-  nextTick(() => promptTextareaRef.value?.focus());
+  handleAiTableReferenceDropEvent(event, {
+    context: {
+      connectionId: props.tab?.connectionId || props.connection?.id,
+      database: props.tab?.database || props.connection?.database || "",
+    },
+    assistantRoot: assistantRootRef.value,
+    elementFromPoint: (x, y) => document.elementFromPoint(x, y),
+    onMention: (mention, payload) => {
+      addSelectedMention({ kind: "table", schema: mention.schema, name: mention.table, tableType: "table" });
+      clearActiveTableReferencePayload(payload);
+      nextTick(() => promptTextareaRef.value?.focus());
+    },
+  });
 }
 
 async function send() {

--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -1,4 +1,4 @@
-﻿<script setup lang="ts">
+<script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, toRaw, watch, type Component } from "vue";
 import { uuid } from "@/lib/common/utils";
 import { useI18n } from "vue-i18n";
@@ -131,6 +131,8 @@ import ExplainPlanViewer from "@/components/explain/ExplainPlanViewer.vue";
 import { parseExplainResult, parseOracleExplainText, type ParsedExplainPlan } from "@/lib/diagram/explainPlan";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { AI_TABLE_MENTION_CANDIDATE_LIMIT, AI_TABLE_MENTION_SCHEMA_LIMIT, filterAiTableMentionCandidates, formatAiTableMention, parseAiTableMentions, type AiTableMention } from "@/lib/ai/aiTableMentions";
+import { aiTableMentionFromTableReference } from "@/lib/ai/aiTableReferenceDrop";
+import { DBX_TABLE_REFERENCE_DROP_EVENT, clearActiveTableReferencePayload, type QueryEditorTableReferenceDropDetail } from "@/lib/editor/queryEditorTableDrop";
 import { isAiPromptImeCompositionEvent, shouldSubmitAiPromptOnKeydown } from "@/lib/ai/aiPromptKeyboard";
 import { isActionableWriteProposalMessage, isActionableWriteSqlProposal, looksLikeActionProposal, looksLikeWriteSqlProposal, shouldGrantWriteSqlOnShortAffirmative } from "@/lib/ai/aiProposalDetect";
 import { visibleToActualIndex } from "@/lib/ai/aiMessageEdit";
@@ -2286,6 +2288,19 @@ function onTauriFileDrop(event: Event) {
   void addDroppedAttachmentPaths(payload.paths);
 }
 
+function onTableReferenceDropEvent(event: Event) {
+  if (!(event instanceof CustomEvent)) return;
+  const detail = event.detail as QueryEditorTableReferenceDropDetail | undefined;
+  if (!detail?.payload) return;
+  const mention = aiTableMentionFromTableReference(detail.payload);
+  if (!mention) return;
+  const target = document.elementFromPoint(detail.clientX, detail.clientY);
+  if (!(target instanceof Element) || !assistantRootRef.value?.contains(target)) return;
+  addSelectedMention({ kind: "table", schema: mention.schema, name: mention.table, tableType: "table" });
+  clearActiveTableReferencePayload(detail.payload);
+  nextTick(() => promptTextareaRef.value?.focus());
+}
+
 async function send() {
   const text = prompt.value.trim();
   if ((!text && !selectedMentions.value.length && !selectedSqlFileMentions.value.length && !selectedCsvAttachments.value.length && !selectedImageAttachments.value.length) || isGenerating.value) return;
@@ -2891,6 +2906,7 @@ onMounted(async () => {
 
   window.addEventListener("resize", handlePanelResize);
   document.addEventListener("dbx:tauri-file-drop", onTauriFileDrop as EventListener);
+  window.addEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, onTableReferenceDropEvent);
   if (typeof ResizeObserver !== "undefined" && assistantRootRef.value) {
     promptPanelResizeObserver = new ResizeObserver(handlePanelResize);
     promptPanelResizeObserver.observe(assistantRootRef.value);
@@ -2969,6 +2985,7 @@ onUnmounted(() => {
   document.body.style.cursor = "";
   window.removeEventListener("resize", handlePanelResize);
   document.removeEventListener("dbx:tauri-file-drop", onTauriFileDrop as EventListener);
+  window.removeEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, onTableReferenceDropEvent);
   promptPanelResizeObserver?.disconnect();
 });
 
@@ -3042,7 +3059,7 @@ async function openExternalUrl(url: string) {
 </script>
 
 <template>
-  <div ref="assistantRootRef" class="flex h-full min-h-0 flex-col overflow-hidden" @dragenter="onAttachmentDragEnter" @dragover="onAttachmentDragOver" @dragleave="onAttachmentDragLeave" @drop="onAttachmentDrop">
+  <div ref="assistantRootRef" data-ai-assistant-root class="flex h-full min-h-0 flex-col overflow-hidden" @dragenter="onAttachmentDragEnter" @dragover="onAttachmentDragOver" @dragleave="onAttachmentDragLeave" @drop="onAttachmentDrop">
     <div class="flex items-center gap-2 border-b px-3 shrink-0" :class="settings.editorSettings.appLayout === 'classic' ? 'h-9' : 'h-10'">
       <span class="flex flex-1 self-stretch items-center truncate text-xs font-medium" data-tauri-drag-region>
         {{ chatTitle }}

--- a/apps/desktop/src/components/editor/__tests__/AiAssistant.tableReferenceDrop.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/AiAssistant.tableReferenceDrop.spec.ts
@@ -1,28 +1,53 @@
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+// @vitest-environment happy-dom
 
-const aiAssistantSource = readFileSync(new URL("../AiAssistant.vue", import.meta.url), "utf8");
-const treeItemSource = readFileSync(new URL("../../sidebar/TreeItem.vue", import.meta.url), "utf8");
+import { afterEach, describe, expect, it } from "vitest";
+import { handleAiTableReferenceDropEvent, type AiTableReferenceDropContext } from "@/lib/ai/aiTableReferenceDrop";
+import { createTableReferenceDropEvent, createTableReferencePayload, DBX_TABLE_REFERENCE_DROP_EVENT, type QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
+
+function dispatchTableReferenceDrop(payload: QueryEditorTableReferencePayload, context: AiTableReferenceDropContext) {
+  const assistantRoot = document.createElement("div");
+  const target = document.createElement("span");
+  assistantRoot.append(target);
+  document.body.append(assistantRoot);
+  const mentions: string[] = [];
+  const listener = (event: Event) => {
+    handleAiTableReferenceDropEvent(event, {
+      context,
+      assistantRoot,
+      elementFromPoint: () => target,
+      onMention: (mention) => mentions.push(mention.raw),
+    });
+  };
+  window.addEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, listener);
+  window.dispatchEvent(createTableReferenceDropEvent({ payload, clientX: 12, clientY: 24 }));
+  window.removeEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, listener);
+  return mentions;
+}
+
+function tablePayload(overrides: Partial<QueryEditorTableReferencePayload> = {}) {
+  return createTableReferencePayload({
+    connectionId: overrides.connectionId ?? "conn-1",
+    database: overrides.database ?? "app-db",
+    schema: "public",
+    tableName: "users",
+    databaseType: "postgres",
+  })!;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
 
 describe("AI assistant table reference drop", () => {
-  it("marks the assistant root as a table-reference drop target", () => {
-    expect(aiAssistantSource).toContain("data-ai-assistant-root");
+  it("accepts a table dropped from the active connection and database", () => {
+    expect(dispatchTableReferenceDrop(tablePayload(), { connectionId: "conn-1", database: "app-db" })).toEqual(["@public.users"]);
   });
 
-  it("listens for table-reference drop events while mounted", () => {
-    expect(aiAssistantSource).toContain("window.addEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, onTableReferenceDropEvent);");
-    expect(aiAssistantSource).toContain("window.removeEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, onTableReferenceDropEvent);");
+  it("rejects a table dropped from another connection", () => {
+    expect(dispatchTableReferenceDrop(tablePayload({ connectionId: "conn-2" }), { connectionId: "conn-1", database: "app-db" })).toEqual([]);
   });
 
-  it("turns dropped table references into table mention chips", () => {
-    expect(aiAssistantSource).toContain("const mention = aiTableMentionFromTableReference(detail.payload);");
-    expect(aiAssistantSource).toContain("!assistantRootRef.value?.contains(target)");
-    expect(aiAssistantSource).toContain('addSelectedMention({ kind: "table", schema: mention.schema, name: mention.table, tableType: "table" });');
-    expect(aiAssistantSource).toContain("clearActiveTableReferencePayload(detail.payload);");
-  });
-
-  it("dispatches sidebar drags released over the AI assistant", () => {
-    expect(treeItemSource).toContain("AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR");
-    expect(treeItemSource).toContain("target.closest(`[data-query-editor-root], ${AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR}`)");
+  it("rejects a table dropped from another database", () => {
+    expect(dispatchTableReferenceDrop(tablePayload({ database: "analytics" }), { connectionId: "conn-1", database: "app-db" })).toEqual([]);
   });
 });

--- a/apps/desktop/src/components/editor/__tests__/AiAssistant.tableReferenceDrop.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/AiAssistant.tableReferenceDrop.spec.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const aiAssistantSource = readFileSync(new URL("../AiAssistant.vue", import.meta.url), "utf8");
+const treeItemSource = readFileSync(new URL("../../sidebar/TreeItem.vue", import.meta.url), "utf8");
+
+describe("AI assistant table reference drop", () => {
+  it("marks the assistant root as a table-reference drop target", () => {
+    expect(aiAssistantSource).toContain("data-ai-assistant-root");
+  });
+
+  it("listens for table-reference drop events while mounted", () => {
+    expect(aiAssistantSource).toContain("window.addEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, onTableReferenceDropEvent);");
+    expect(aiAssistantSource).toContain("window.removeEventListener(DBX_TABLE_REFERENCE_DROP_EVENT, onTableReferenceDropEvent);");
+  });
+
+  it("turns dropped table references into table mention chips", () => {
+    expect(aiAssistantSource).toContain("const mention = aiTableMentionFromTableReference(detail.payload);");
+    expect(aiAssistantSource).toContain("!assistantRootRef.value?.contains(target)");
+    expect(aiAssistantSource).toContain('addSelectedMention({ kind: "table", schema: mention.schema, name: mention.table, tableType: "table" });');
+    expect(aiAssistantSource).toContain("clearActiveTableReferencePayload(detail.payload);");
+  });
+
+  it("dispatches sidebar drags released over the AI assistant", () => {
+    expect(treeItemSource).toContain("AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR");
+    expect(treeItemSource).toContain("target.closest(`[data-query-editor-root], ${AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR}`)");
+  });
+});

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -54,6 +54,7 @@ import LightTooltip from "@/components/ui/LightTooltip.vue";
 import type { ColumnInfo, ConnectionConfig, CustomTypeTreeMemberMeta, DatabaseType, TreeNode, TriggerInfo } from "@/types/database";
 import { alignedCommentLeadingWidth, canTreeNodePin, canTreeNodeShowExpander, sidebarTreeNodeComment, trailingCommentAvailableWidth, trailingCommentGapPx, treeItemPaddingLeft, treeLabelWidthClass, usesFullWidthTreeLabel } from "@/lib/sidebar/sidebarTreeItemLayout";
 import { clearActiveTableReferencePayload, createTableReferencePayload, createTableReferenceDropEvent, setActiveTableReferencePayload, type QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
+import { AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR } from "@/lib/ai/aiTableReferenceDrop";
 import { formatSidebarObjectStorage } from "@/lib/sidebar/sidebarDatabaseStorage";
 import { dataTabOpenModeFromTreeClick } from "@/lib/sidebar/dataTabOpenPolicy";
 import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
@@ -1189,7 +1190,7 @@ function onTableReferenceMouseUp(event: MouseEvent) {
   if (payload) {
     suppressNextTableReferenceClick = true;
     const target = document.elementFromPoint(event.clientX, event.clientY);
-    if (target instanceof Element && target.closest("[data-query-editor-root]")) {
+    if (target instanceof Element && target.closest(`[data-query-editor-root], ${AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR}`)) {
       window.dispatchEvent(
         createTableReferenceDropEvent({
           payload,

--- a/apps/desktop/src/lib/__tests__/ai/aiTableReferenceDrop.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai/aiTableReferenceDrop.spec.ts
@@ -3,6 +3,8 @@ import { aiTableMentionFromTableReference } from "@/lib/ai/aiTableReferenceDrop"
 import { createTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
 
 describe("ai table reference drop", () => {
+  const context = { connectionId: "conn-1", database: "app-db" };
+
   it("maps a table payload to a table mention", () => {
     const payload = createTableReferencePayload({
       connectionId: "conn-1",
@@ -12,7 +14,7 @@ describe("ai table reference drop", () => {
       databaseType: "postgres",
     });
 
-    expect(aiTableMentionFromTableReference(payload)).toEqual({
+    expect(aiTableMentionFromTableReference(payload, context)).toEqual({
       raw: "@public.users",
       schema: "public",
       table: "users",
@@ -27,7 +29,7 @@ describe("ai table reference drop", () => {
       databaseType: "mysql",
     });
 
-    expect(aiTableMentionFromTableReference(payload)).toEqual({
+    expect(aiTableMentionFromTableReference(payload, context)).toEqual({
       raw: '@"order items"',
       schema: undefined,
       table: "order items",
@@ -42,7 +44,7 @@ describe("ai table reference drop", () => {
       databaseType: "mysql",
     });
 
-    expect(aiTableMentionFromTableReference(payload)).toBeNull();
+    expect(aiTableMentionFromTableReference(payload, context)).toBeNull();
   });
 
   it("ignores column references", () => {
@@ -55,11 +57,11 @@ describe("ai table reference drop", () => {
       databaseType: "postgres",
     });
 
-    expect(aiTableMentionFromTableReference(payload)).toBeNull();
+    expect(aiTableMentionFromTableReference(payload, context)).toBeNull();
   });
 
   it("ignores empty payloads", () => {
-    expect(aiTableMentionFromTableReference(null)).toBeNull();
-    expect(aiTableMentionFromTableReference(undefined)).toBeNull();
+    expect(aiTableMentionFromTableReference(null, context)).toBeNull();
+    expect(aiTableMentionFromTableReference(undefined, context)).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/__tests__/ai/aiTableReferenceDrop.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai/aiTableReferenceDrop.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { aiTableMentionFromTableReference } from "@/lib/ai/aiTableReferenceDrop";
+import { createTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
+
+describe("ai table reference drop", () => {
+  it("maps a table payload to a table mention", () => {
+    const payload = createTableReferencePayload({
+      connectionId: "conn-1",
+      database: "app-db",
+      schema: "public",
+      tableName: "users",
+      databaseType: "postgres",
+    });
+
+    expect(aiTableMentionFromTableReference(payload)).toEqual({
+      raw: "@public.users",
+      schema: "public",
+      table: "users",
+    });
+  });
+
+  it("quotes mention parts that are not simple identifiers", () => {
+    const payload = createTableReferencePayload({
+      connectionId: "conn-1",
+      database: "app-db",
+      tableName: "order items",
+      databaseType: "mysql",
+    });
+
+    expect(aiTableMentionFromTableReference(payload)).toEqual({
+      raw: '@"order items"',
+      schema: undefined,
+      table: "order items",
+    });
+  });
+
+  it("ignores database references", () => {
+    const payload = createTableReferencePayload({
+      connectionId: "conn-1",
+      database: "app-db",
+      referenceType: "database",
+      databaseType: "mysql",
+    });
+
+    expect(aiTableMentionFromTableReference(payload)).toBeNull();
+  });
+
+  it("ignores column references", () => {
+    const payload = createTableReferencePayload({
+      connectionId: "conn-1",
+      database: "app-db",
+      schema: "public",
+      tableName: "users",
+      columnName: "email",
+      databaseType: "postgres",
+    });
+
+    expect(aiTableMentionFromTableReference(payload)).toBeNull();
+  });
+
+  it("ignores empty payloads", () => {
+    expect(aiTableMentionFromTableReference(null)).toBeNull();
+    expect(aiTableMentionFromTableReference(undefined)).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/ai/aiTableReferenceDrop.ts
+++ b/apps/desktop/src/lib/ai/aiTableReferenceDrop.ts
@@ -1,0 +1,18 @@
+import { formatAiTableMention, type AiTableMention } from "@/lib/ai/aiTableMentions";
+import type { QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
+
+/** Selector marking the AI assistant panel root as a table-reference drop target. */
+export const AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR = "[data-ai-assistant-root]";
+
+/**
+ * Maps a sidebar table-reference drag payload to an AI table mention chip.
+ * Only plain table/view references become mentions; database and column
+ * references are not representable as table mentions and return null.
+ */
+export function aiTableMentionFromTableReference(payload: QueryEditorTableReferencePayload | null | undefined): AiTableMention | null {
+  if (!payload || payload.referenceType === "database" || payload.columnName) return null;
+  const table = payload.tableName;
+  if (!table) return null;
+  const schema = payload.schema;
+  return { raw: formatAiTableMention(schema, table), schema, table };
+}

--- a/apps/desktop/src/lib/ai/aiTableReferenceDrop.ts
+++ b/apps/desktop/src/lib/ai/aiTableReferenceDrop.ts
@@ -1,18 +1,43 @@
 import { formatAiTableMention, type AiTableMention } from "@/lib/ai/aiTableMentions";
-import type { QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
+import type { QueryEditorTableReferenceDropDetail, QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
 
 /** Selector marking the AI assistant panel root as a table-reference drop target. */
 export const AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR = "[data-ai-assistant-root]";
+
+export interface AiTableReferenceDropContext {
+  connectionId?: string;
+  database?: string;
+}
+
+export interface AiTableReferenceDropHandlerOptions {
+  context: AiTableReferenceDropContext;
+  assistantRoot: Element | null | undefined;
+  elementFromPoint: (x: number, y: number) => Element | null;
+  onMention: (mention: AiTableMention, payload: QueryEditorTableReferencePayload) => void;
+}
 
 /**
  * Maps a sidebar table-reference drag payload to an AI table mention chip.
  * Only plain table/view references become mentions; database and column
  * references are not representable as table mentions and return null.
  */
-export function aiTableMentionFromTableReference(payload: QueryEditorTableReferencePayload | null | undefined): AiTableMention | null {
+export function aiTableMentionFromTableReference(payload: QueryEditorTableReferencePayload | null | undefined, context: AiTableReferenceDropContext): AiTableMention | null {
   if (!payload || payload.referenceType === "database" || payload.columnName) return null;
+  if (!context.connectionId || context.database == null || payload.connectionId !== context.connectionId || payload.database !== context.database) return null;
   const table = payload.tableName;
   if (!table) return null;
   const schema = payload.schema;
   return { raw: formatAiTableMention(schema, table), schema, table };
+}
+
+export function handleAiTableReferenceDropEvent(event: Event, options: AiTableReferenceDropHandlerOptions): boolean {
+  if (!(event instanceof CustomEvent)) return false;
+  const detail = event.detail as QueryEditorTableReferenceDropDetail | undefined;
+  if (!detail?.payload) return false;
+  const target = options.elementFromPoint(detail.clientX, detail.clientY);
+  if (!target || !options.assistantRoot?.contains(target)) return false;
+  const mention = aiTableMentionFromTableReference(detail.payload, options.context);
+  if (!mention) return false;
+  options.onMention(mention, detail.payload);
+  return true;
 }

--- a/apps/desktop/src/lib/editor/queryEditorTableDrop.ts
+++ b/apps/desktop/src/lib/editor/queryEditorTableDrop.ts
@@ -24,7 +24,16 @@ export interface QueryEditorTableReferenceDropDetail {
 
 let activeTableReferencePayload: QueryEditorTableReferencePayload | null = null;
 
-export function createTableReferencePayload(options: { connectionId?: string; database?: string; schema?: string; tableName?: string; columnName?: string; referenceType?: "database" | "table" | "column"; databaseType?: DatabaseType; driverProfile?: string }): QueryEditorTableReferencePayload | null {
+export function createTableReferencePayload(options: {
+  connectionId?: string;
+  database?: string;
+  schema?: string;
+  tableName?: string;
+  columnName?: string;
+  referenceType?: "database" | "table" | "column";
+  databaseType?: DatabaseType;
+  driverProfile?: string;
+}): QueryEditorTableReferencePayload | null {
   if (!options.connectionId || options.database == null) return null;
   const referenceType = options.referenceType ?? (options.columnName ? "column" : "table");
   if (referenceType !== "database" && !options.tableName) return null;


### PR DESCRIPTION
## 变更说明

支持将侧边栏的表/视图节点直接拖拽到 AI 对话框，松开后自动插入 `@表名` mention 芯片（与手动输入 `@` 选择表的效果完全一致，AI 可获取表结构上下文）。

  - 复用现有的侧边栏表引用拖拽机制（`dbx-table-reference-drop` 事件，原用于拖拽表名到 SQL 编辑器）
  - `TreeItem.vue`：drop 目标判断从仅 SQL 编辑器扩展为同时匹配 AI 助手面板（`[data-ai-assistant-root]`）
  - `AiAssistant.vue`：面板根节点新增 `data-ai-assistant-root` 标记；监听 drop 事件，确认落点在本面板后调用现有 `addSelectedMention()` 插入 mention 芯片（自带去重）并聚焦输入框
  - 新增 `lib/ai/aiTableReferenceDrop.ts`：将拖拽 payload 映射为 table mention；数据库节点和列节点的拖拽不支持 mention，保持不变（无反应）
  - 拖到 SQL 编辑器插入限定表名的原有行为不受影响（两个监听器各自校验落点容器，不会重复插入）

## 测试

  - 新增 `lib/__tests__/ai/aiTableReferenceDrop.spec.ts`（5 例：带 schema 映射、特殊字符加引号、database/column/空 payload 忽略）
  - 新增 `components/editor/__tests__/AiAssistant.tableReferenceDrop.spec.ts`（4 例接线断言）
  - 已通过 `pnpm typecheck`、`pnpm lint`、相关 vitest 用例全部通过
  - 全量 `pnpm test` 中 5 个失败文件（DataGridSurfaces、MqttPublishDialog 等）在未修改的 main 上同样失败，与本次改动无关
  - 已人工验证：拖表名到 AI 输入框出现 `@schema.table` 芯片；拖到 SQL 编辑器行为不回归；拖数据库/列节点到 AI 面板无反应

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="1580" height="1442" alt="image" src="https://github.com/user-attachments/assets/a175a693-9299-4253-ad09-ee70c0d334ec" />

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #6850