### PR TITLE
fix(agent): accept legacy H2 offline packages

### DIFF
--- a/crates/dbx-core/src/agent_catalog.rs
+++ b/crates/dbx-core/src/agent_catalog.rs
@@ -46,6 +46,7 @@ const H2_PROFILES: &[AgentDriverProfile] = &[
 
 const EXTRA_AGENT_LABELS: &[(&str, &str)] = &[
     ("duckdb", "DuckDB"),
+    ("h2-legacy", "H2 2.1 Legacy"),
     ("kafka", "Apache Kafka"),
     ("rocketmq", "Apache RocketMQ"),
     ("rabbitmq", "RabbitMQ"),
@@ -432,6 +433,7 @@ mod tests {
         assert_eq!(agent_key(&DatabaseType::H2, Some("h2-v2")), Some("h2"));
         assert_eq!(agent_key(&DatabaseType::H2, Some("h2-v3")), Some("h2"));
         assert_eq!(agent_key(&DatabaseType::H2, Some("h2-custom")), Some("h2"));
+        assert_eq!(label_for_key("h2-legacy"), Some("H2 2.1 Legacy"));
         assert!(!driver_store_entries().any(|(key, _)| key == "h2-legacy"));
     }
 

--- a/crates/dbx-core/tests/agent_service.rs
+++ b/crates/dbx-core/tests/agent_service.rs
@@ -814,6 +814,20 @@ fn offline_zip_import_rejects_unknown_driver_type() {
     assert!(err.contains("unknown driver type"));
 }
 
+#[tokio::test]
+async fn offline_zip_import_accepts_hidden_legacy_h2_driver() {
+    let manager = test_manager("offline-h2-legacy-driver");
+    let zip_path = test_path("offline-h2-legacy-driver").join("agents.zip");
+    std::fs::create_dir_all(zip_path.parent().unwrap()).unwrap();
+    write_offline_driver_zip_with_jar(&zip_path, "h2-legacy", "0.1.18", test_agent_jar_bytes());
+
+    let result = import_agents_from_zip(&manager, &zip_path, |_| {}).await.unwrap();
+
+    assert_eq!(result.drivers_installed, vec!["h2-legacy"]);
+    assert!(manager.is_driver_installed("h2-legacy"));
+    assert_eq!(manager.load_state().installed_drivers["h2-legacy"].version, "0.1.18");
+}
+
 #[test]
 fn offline_zip_import_rejects_unsafe_entry_path() {
     let zip_path = test_path("offline-unsafe-entry").join("agents.zip");


### PR DESCRIPTION
## 概述

- 修复最新离线驱动整包因包含 `h2-legacy` 而无法导入的问题
- 将已发布的 `h2-legacy` 识别为合法的隐藏兼容键
- H2 新连接仍统一使用 `h2` Agent，驱动商店不会重新展示旧版独立入口
- 未知驱动类型仍会被拒绝

## 根因

H2 多版本支持将 `h2-legacy` profile 合并到统一的 `h2` Agent，但发布流程仍会在离线整包中包含历史 `h2-legacy` Agent。客户端目录不再识别该独立键，导致整包在导入前置检查阶段失败。

## 验证

- 使用 GitHub 正式发布的 `agents-v0.2.90` Windows x64 离线整包复现原错误
- 修复后同一整包可成功生成包含 `h2` 和 `h2-legacy` 的导入计划
- `cargo test -p dbx-core --no-default-features --test agent_service`：41 passed
- `cargo test -p dbx-core --no-default-features --lib agent_catalog::tests`：4 passed
- 定向 `rustfmt --check` 与 `git diff --check` 通过
