### PR TITLE
fix(desktop): unify double-click selection for long cells

### DIFF
--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -356,7 +356,9 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       if (input) focusDataGridEditorWithoutScrolling(input, scroller);
       if (select && input) {
         if (input instanceof HTMLTextAreaElement && input.dataset.expandedCellEditor === "true") {
-          input.setSelectionRange?.(0, 0);
+          // Expanded editors must match single-line editors: a double-click selects the whole value.
+          input.select();
+          input.setSelectionRange?.(0, input.value.length);
           input.scrollTop = 0;
         } else {
           input.select();


### PR DESCRIPTION
## 变更说明

修复查询结果展示界面中短内容与长内容双击编辑行为不一致的问题。展开的长文本编辑器现在与单行编辑器一样会全选当前值。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本次为编辑选区行为修复，不涉及布局或视觉样式；通过双击短文本和长文本可直接验证两者均全选。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过：`pnpm vitest run apps/desktop/src/components/grid --passWithNoTests`
- [x] 类型检查通过：`pnpm typecheck`

## 关联 Issue

Close #6881

### 根因

短文本使用单行 `<input>` 并调用 `select()`；长文本使用展开 `<textarea>`，原逻辑将选区设置为 `(0, 0)`。现已统一为全选。