### PR TITLE
Fix：同步 GBase 版本切换后的类型显示

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -1331,7 +1331,8 @@ function profileForConfig(config: ConnectionConfig) {
 }
 
 function selectedProfile() {
-  return driverProfiles[selectedType.value] ?? driverProfiles.mysql;
+  const profile = selectedType.value === "gbase" && (form.value.driver_profile === "gbase8a" || form.value.driver_profile === "gbase8s") ? form.value.driver_profile : selectedType.value;
+  return driverProfiles[profile] ?? driverProfiles.mysql;
 }
 
 function mqExtraRecord(config?: Partial<MqAdminConfig>): Record<string, unknown> {

--- a/apps/desktop/src/lib/__tests__/connection/gbase8sConnectionDialog.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/gbase8sConnectionDialog.spec.ts
@@ -1,10 +1,47 @@
 import { readFileSync } from "node:fs";
+import { parse } from "vue/compiler-sfc";
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const dialogSource = readFileSync(new URL("../../../components/connection/ConnectionDialog.vue", import.meta.url), "utf8");
+const parsedDialog = parse(dialogSource, { filename: "ConnectionDialog.vue" });
+
+function selectedProfileHarness(selectedTypeValue: string, driverProfile: string) {
+  const script = parsedDialog.descriptor.scriptSetup;
+  expect(parsedDialog.errors).toEqual([]);
+  expect(script).toBeDefined();
+  const source = ts.createSourceFile("ConnectionDialog.vue.ts", script!.content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const declaration = source.statements.find((statement): statement is ts.FunctionDeclaration => ts.isFunctionDeclaration(statement) && statement.name?.text === "selectedProfile");
+  expect(declaration).toBeDefined();
+  const javascript = ts.transpileModule(declaration!.getText(), {
+    compilerOptions: { module: ts.ModuleKind.None, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const selectedProfile = new Function("driverProfiles", "selectedType", "form", `${javascript}\nreturn selectedProfile;`)(
+    {
+      mysql: { label: "MySQL" },
+      gbase: { label: "南大通用 GBase 8a" },
+      gbase8a: { label: "南大通用 GBase 8a" },
+      gbase8s: { label: "南大通用 GBase 8s" },
+    },
+    { value: selectedTypeValue },
+    { value: { driver_profile: driverProfile } },
+  ) as () => { label: string };
+  return selectedProfile();
+}
 
 describe("GBase 8s connection dialog", () => {
   it("hydrates DBSERVERNAME when editing a saved connection", () => {
     expect(dialogSource).toContain('gbase_server: config.gbase_server || ""');
+  });
+
+  it.each([
+    ["gbase8a", "南大通用 GBase 8a"],
+    ["gbase8s", "南大通用 GBase 8s"],
+  ])("shows the active %s profile in the merged GBase type field", (profile, label) => {
+    expect(selectedProfileHarness("gbase", profile).label).toBe(label);
+  });
+
+  it("keeps non-GBase type labels based on the selected picker type", () => {
+    expect(selectedProfileHarness("mysql", "gbase8s").label).toBe("MySQL");
   });
 });


### PR DESCRIPTION
## 问题

新建连接时，GBase 8a / 8s 共用同一个数据库选择入口。切换版本虽然已经更新实际 `driver_profile`，但上方“类型”仍按合并入口 `gbase` 取值，因此始终显示 GBase 8a。

## 修改

- GBase 场景下按当前 `driver_profile` 显示实际类型
- 保持其他数据库类型原有展示逻辑不变
- 增加 GBase 8a、GBase 8s 双向显示及非 GBase 回退测试

## 测试

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/gbase8sConnectionDialog.spec.ts apps/desktop/src/lib/__tests__/connection/connectionDialogProfileSwitch.spec.ts`
- `pnpm check`