### PR TITLE
fix(editor): 修复整行高亮遮挡当前语句边框

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { Text } from "@codemirror/state";
-import { currentStatementFrameRect, FRAME_INSET_PX } from "@/lib/editor/codemirrorCurrentStatementFrameLayer";
+import { currentStatementFrameLayer, currentStatementFrameRect, FRAME_INSET_PX } from "@/lib/editor/codemirrorCurrentStatementFrameLayer";
 
 interface CoordRect {
   left: number;
@@ -251,5 +251,16 @@ describe("currentStatementFrameRect", () => {
     // bottom = lineBlockAt(73).bottom = 73 * LINE_HEIGHT
     const expectedHeight = (73 - 47) * LINE_HEIGHT + FRAME_INSET_PX * 2;
     expect(rect!.height).toBe(expectedHeight);
+  });
+});
+
+describe("currentStatementFrameLayer", () => {
+  it("renders above line decorations so active-line backgrounds cannot cover the frame", () => {
+    const layer = vi.fn((config) => config);
+    const RectangleMarker = vi.fn();
+
+    currentStatementFrameLayer({ layer, RectangleMarker } as never, () => ({ from: 0, to: 1 }));
+
+    expect(layer).toHaveBeenCalledWith(expect.objectContaining({ above: true, class: "cm-db-currentStatementFrameLayer" }));
   });
 });

--- a/apps/desktop/src/lib/editor/codemirrorCurrentStatementFrameLayer.ts
+++ b/apps/desktop/src/lib/editor/codemirrorCurrentStatementFrameLayer.ts
@@ -140,7 +140,9 @@ interface CurrentStatementFrameModule {
  */
 export function currentStatementFrameLayer(viewModule: CurrentStatementFrameModule, resolve: StatementFrameResolver): Extension {
   return viewModule.layer({
-    above: false,
+    // Keep the outline above line decorations so opaque active-line colors
+    // from editor themes cannot cover the frame border.
+    above: true,
     class: "cm-db-currentStatementFrameLayer",
     markers(view) {
       const request = resolve(view);


### PR DESCRIPTION
## 问题

SQL 编辑器启用整行高亮时，主题中的实色活动行背景会覆盖当前 SQL 语句绿色外框的中间部分。

## 修复

- 将当前语句外框图层调整到行装饰上方渲染
- 保留外框的 `pointer-events: none`，不影响编辑器点击和选择
- 增加图层顺序回归测试，覆盖不同主题使用实色活动行背景的场景

## 验证

- `pnpm vitest run apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts`（14/14）
- `pnpm typecheck`
- `git diff --check`
- macOS 开发客户端人工验证通过：整行高亮开启时，当前 SQL 语句绿色外框完整显示

Closes #6883