### PR TITLE
fix(macos): prevent Escape from exiting native fullscreen

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,7 +75,7 @@ tauri = { version = "2.10.3", features = ["test"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.6.4", default-features = false, features = ["std"] }
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSControl", "NSDockTile", "NSImage", "NSResponder", "NSView", "NSWindow"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSApplication", "NSButton", "NSControl", "NSDockTile", "NSEvent", "NSImage", "NSResponder", "NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSData", "NSString"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ mod data_dir;
 mod db;
 #[cfg(target_os = "macos")]
 mod macos_app_delegate;
+#[cfg(target_os = "macos")]
+mod macos_escape_guard;
 mod models;
 #[cfg(any(target_os = "windows", test))]
 mod startup_recovery;
@@ -1488,6 +1490,8 @@ pub fn run() {
             commands::ssh_prompt::install_ssh_notice_bridge(app.handle());
             #[cfg(target_os = "macos")]
             macos_app_delegate::install_dock_quit_handler(app.handle());
+            #[cfg(target_os = "macos")]
+            macos_escape_guard::install_escape_fullscreen_guard();
             #[cfg(target_os = "windows")]
             webview2_recovery::install(app.handle());
             let startup_links = commands::deep_link::connection_deep_links_from_args(std::env::args().skip(1));

--- a/src-tauri/src/macos_escape_guard.rs
+++ b/src-tauri/src/macos_escape_guard.rs
@@ -5,10 +5,13 @@ use objc2::{
     runtime::{AnyClass, AnyObject, Imp, Sel},
     sel,
 };
-use objc2_app_kit::NSWindowStyleMask;
+use objc2_app_kit::{NSApplication, NSEventModifierFlags, NSEventType, NSWindowStyleMask};
+use objc2_foundation::MainThreadMarker;
 
 static ORIGINAL_DO_COMMAND: OnceLock<Imp> = OnceLock::new();
 static INSTALL_ESCAPE_FULLSCREEN_GUARD: Once = Once::new();
+
+const ESCAPE_KEY_CODE: u16 = 53;
 
 pub(crate) fn install_escape_fullscreen_guard() {
     INSTALL_ESCAPE_FULLSCREEN_GUARD.call_once(|| unsafe {
@@ -24,6 +27,21 @@ pub(crate) fn install_escape_fullscreen_guard() {
         let guard: Imp = std::mem::transmute(do_command_guard as extern "C-unwind" fn(&AnyObject, Sel, Sel));
         do_command.set_implementation(guard);
     });
+}
+
+fn current_event_is_unmodified_escape() -> bool {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return false;
+    };
+    let Some(event) = NSApplication::sharedApplication(mtm).currentEvent() else {
+        return false;
+    };
+    if event.r#type() != NSEventType::KeyDown || event.keyCode() != ESCAPE_KEY_CODE {
+        return false;
+    }
+    let mut modifiers = event.modifierFlags() & NSEventModifierFlags::DeviceIndependentFlagsMask;
+    modifiers.remove(NSEventModifierFlags::CapsLock);
+    modifiers.is_empty()
 }
 
 /// Whether the responder's window is in native fullscreen.
@@ -48,10 +66,11 @@ fn responder_in_fullscreen(any: &AnyObject) -> bool {
 }
 
 extern "C-unwind" fn do_command_guard(self_: &AnyObject, sel: Sel, command: Sel) {
-    if command == sel!(cancelOperation:) && responder_in_fullscreen(self_) {
-        // Swallow the "leave fullscreen" command while fullscreen. The
-        // Escape keydown already reached web content, so JS handlers (e.g.
-        // closing in-app dialogs) keep working. Ctrl+Cmd+F still exits.
+    if command == sel!(cancelOperation:) && current_event_is_unmodified_escape() && responder_in_fullscreen(self_) {
+        // Swallow only an unmodified physical Escape while fullscreen. The
+        // keydown already reached web content, so JS handlers (e.g. closing
+        // in-app dialogs) keep working. Other cancellation commands and
+        // Ctrl+Cmd+F continue through the original responder implementation.
         return;
     }
     let Some(original) = ORIGINAL_DO_COMMAND.get() else {

--- a/src-tauri/src/macos_escape_guard.rs
+++ b/src-tauri/src/macos_escape_guard.rs
@@ -1,0 +1,62 @@
+use std::sync::{Once, OnceLock};
+
+use objc2::{
+    msg_send,
+    runtime::{AnyClass, AnyObject, Imp, Sel},
+    sel,
+};
+use objc2_app_kit::NSWindowStyleMask;
+
+static ORIGINAL_DO_COMMAND: OnceLock<Imp> = OnceLock::new();
+static INSTALL_ESCAPE_FULLSCREEN_GUARD: Once = Once::new();
+
+pub(crate) fn install_escape_fullscreen_guard() {
+    INSTALL_ESCAPE_FULLSCREEN_GUARD.call_once(|| unsafe {
+        let Some(responder) = AnyClass::get(c"NSResponder") else {
+            eprintln!("[WARN] failed to install macOS Escape fullscreen guard: NSResponder class not found");
+            return;
+        };
+        let Some(do_command) = responder.instance_method(sel!(doCommandBySelector:)) else {
+            eprintln!("[WARN] failed to install macOS Escape fullscreen guard: doCommandBySelector: not found");
+            return;
+        };
+        let _ = ORIGINAL_DO_COMMAND.set(do_command.implementation());
+        let guard: Imp = std::mem::transmute(do_command_guard as extern "C-unwind" fn(&AnyObject, Sel, Sel));
+        do_command.set_implementation(guard);
+    });
+}
+
+/// Whether the responder's window is in native fullscreen.
+///
+/// `isFullscreen` is overridden by tao and returns false while the window is
+/// fullscreen, so the styleMask bit is the only reliable signal. Responders
+/// without a window (or without the selector) answer false.
+fn responder_in_fullscreen(any: &AnyObject) -> bool {
+    unsafe {
+        if !msg_send![any, respondsToSelector: sel!(window)] {
+            return false;
+        }
+        let Some(window): Option<&AnyObject> = msg_send![any, window] else {
+            return false;
+        };
+        if !msg_send![window, respondsToSelector: sel!(styleMask)] {
+            return false;
+        }
+        let style: NSWindowStyleMask = msg_send![window, styleMask];
+        style.contains(NSWindowStyleMask::FullScreen)
+    }
+}
+
+extern "C-unwind" fn do_command_guard(self_: &AnyObject, sel: Sel, command: Sel) {
+    if command == sel!(cancelOperation:) && responder_in_fullscreen(self_) {
+        // Swallow the "leave fullscreen" command while fullscreen. The
+        // Escape keydown already reached web content, so JS handlers (e.g.
+        // closing in-app dialogs) keep working. Ctrl+Cmd+F still exits.
+        return;
+    }
+    let Some(original) = ORIGINAL_DO_COMMAND.get() else {
+        return;
+    };
+    let original: unsafe extern "C-unwind" fn(&AnyObject, Sel, Sel) = unsafe { std::mem::transmute(*original) };
+    unsafe { original(self_, sel, command) }
+}


### PR DESCRIPTION
  ## 变更说明

  阻止在 macOS 上按 Esc 退出原生全屏。

  macOS 全屏时按 Esc 会退出全屏，但 DBX 应用内窗口（如"新建连接"）需要 Esc 来关闭。本 PR 在 AppKit 响应链的命令派发层拦截：全屏时吞掉 `cancelOperation:` 命令，Esc 的 keydown 仍到达 Web
  内容（对话框照常关闭），`Ctrl+Cmd+F` 仍可退出全屏。

  根因（实测）：
  - Esc 的"退出全屏"命令通过 `NSResponder doCommandBySelector: cancelOperation:` 沿响应链派发（WebKit 转发给 web 内容后触发），**不**直接调用窗口的 `cancelOperation:` 方法——窗口级 swizzle 无效；
  - `isFullscreen` 被 tao 覆盖，全屏时恒返回 false——`styleMask & NSWindowStyleMaskFullScreen` 是唯一可靠的全屏信号。

  实现：新增 `src-tauri/src/macos_escape_guard.rs`（swizzle `doCommandBySelector:`，全屏时吞掉 `cancelOperation:` 命令），`src-tauri/src/lib.rs` 接线。

  ## 变更类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] 性能优化
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] CI / 构建

  ## 涉及前端

  - [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

  不涉及前端改动。

  ## 验证

  - [x] `make check` 通过
  - [x] `make cargo-check-fast` 通过
  - [x] 相关测试通过

  手动验证（macOS 26 / Tauri 2.10 / wry 0.55 / tao 0.35）：
  1. 绿色按钮进入全屏 → 按 Esc → 全屏保持
  2. 全屏 + 打开"新建连接" → 按 Esc → 对话框关闭，全屏保持
  3. `Ctrl+Cmd+F` → 正常退出全屏
  4. 非全屏按 Esc → 行为不变


  ## 关联 Issue

  无