### PR TITLE
fix(phoenix): 修复 SYSTEM.CATALOG 特殊类型查询失败

### DIFF
--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -50,6 +50,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class DbxJdbcPlugin {
@@ -59,6 +60,12 @@ public final class DbxJdbcPlugin {
     private static final String JDBCX_EXTENSION_WHITELIST_PROPERTY = "jdbcx.extension.whitelist";
     private static final String JDBCX_HIGH_PRIVILEGE_EXTENSIONS_OPT_IN = "-Ddbx.jdbcx.allowHighPrivilegeExtensions=";
     private static final String JDBCX_SAFE_EXTENSION_WHITELIST = "help,var,version";
+    private static final int PHOENIX_VARBINARY_ENCODED_TYPE = 9000;
+    private static final String PHOENIX_VARBINARY_ENCODED_TYPE_NAME = "VARBINARY_ENCODED";
+    private static final Pattern PHOENIX_SYSTEM_CATALOG_WILDCARD = Pattern.compile(
+        "^SELECT\\s+\\*\\s+FROM\\s+(?:SYSTEM|\\\"SYSTEM\\\")\\s*\\.\\s*(?:CATALOG|\\\"CATALOG\\\")$",
+        Pattern.CASE_INSENSITIVE
+    );
     private static final String[] DEFAULT_TABLE_TYPES = new String[] {
         "TABLE",
         "VIEW",
@@ -743,7 +750,8 @@ public final class DbxJdbcPlugin {
         try (Statement statement = conn.createStatement()) {
             applyStatementOptions(statement, maxRows, fetchSize, timeoutSecs, quirks);
             String trimmedSql = trimStatementSql(sql);
-            ExecutedStatement executed = executeStatementForResult(statement, trimmedSql, quirks);
+            String effectiveSql = rewritePhoenixSystemCatalogQuery(connection, conn, trimmedSql);
+            ExecutedStatement executed = executeStatementForResult(statement, effectiveSql, quirks);
             ObjectNode result = MAPPER.createObjectNode();
             ArrayNode columns = MAPPER.createArrayNode();
             ArrayNode rows = MAPPER.createArrayNode();
@@ -852,7 +860,8 @@ public final class DbxJdbcPlugin {
         try {
             applyStatementOptions(statement, maxRows, fetchSize, timeoutSecs, quirks);
             String trimmedSql = trimStatementSql(sql);
-            ExecutedStatement executed = executeStatementForResult(statement, trimmedSql, quirks);
+            String effectiveSql = rewritePhoenixSystemCatalogQuery(connection, conn, trimmedSql);
+            ExecutedStatement executed = executeStatementForResult(statement, effectiveSql, quirks);
             ResultSet rs = executed.resultSet();
             if (rs == null) {
                 ObjectNode result = MAPPER.createObjectNode();
@@ -3263,6 +3272,14 @@ public final class DbxJdbcPlugin {
             return null;
         }
 
+        // Phoenix exposes VARBINARY_ENCODED as a private type id (9000). Read it through the
+        // binary JDBC accessor before a generic getObject() path can ask the driver for an
+        // unsupported Java representation.
+        if (isPhoenixEncodedBinaryColumn(meta, index, columnType)) {
+            byte[] bytes = rs.getBytes(index);
+            return bytes == null ? null : binaryToHex(bytes);
+        }
+
         Object value = rs.getObject(index);
         if (value == null) {
             return null;
@@ -3345,6 +3362,69 @@ public final class DbxJdbcPlugin {
                  Types.BLOB -> true;
             default -> false;
         };
+    }
+
+    private static boolean isPhoenixEncodedBinaryColumn(
+        ResultSetMetaData meta,
+        int index,
+        int columnType
+    ) throws SQLException {
+        return columnType == PHOENIX_VARBINARY_ENCODED_TYPE
+            && PHOENIX_VARBINARY_ENCODED_TYPE_NAME.equalsIgnoreCase(meta.getColumnTypeName(index));
+    }
+
+    private static boolean isPhoenixEncodedBinaryType(int sqlType, String typeName) {
+        return sqlType == PHOENIX_VARBINARY_ENCODED_TYPE
+            || PHOENIX_VARBINARY_ENCODED_TYPE_NAME.equalsIgnoreCase(typeName);
+    }
+
+    static String rewritePhoenixSystemCatalogQuery(
+        JsonNode connection,
+        Connection jdbcConnection,
+        String sql
+    ) {
+        String url = jdbcUrl(connection);
+        String normalizedSql = stripLeadingSqlComments(trimStatementSql(sql));
+        if (
+            !isPhoenixConnection(connection, url)
+                || !PHOENIX_SYSTEM_CATALOG_WILDCARD.matcher(normalizedSql).matches()
+        ) {
+            return sql;
+        }
+
+        List<String> projections = new ArrayList<>();
+        boolean hasEncodedColumn = false;
+        try (ResultSet columns = jdbcConnection.getMetaData().getColumns(null, "SYSTEM", "CATALOG", "%")) {
+            while (columns.next()) {
+                String columnName = columns.getString("COLUMN_NAME");
+                if (columnName == null || columnName.isBlank()) {
+                    continue;
+                }
+                int sqlType = columns.getInt("DATA_TYPE");
+                String typeName = columns.getString("TYPE_NAME");
+                String quotedColumn = quotePhoenixIdentifier(columnName);
+                if (isPhoenixEncodedBinaryType(sqlType, typeName)) {
+                    projections.add("CAST(" + quotedColumn + " AS VARBINARY) AS " + quotedColumn);
+                    hasEncodedColumn = true;
+                } else {
+                    projections.add(quotedColumn);
+                }
+            }
+        } catch (SQLException | RuntimeException ignored) {
+            // Keep the original SQL when a driver cannot expose its column metadata. The
+            // compatibility path must not turn an optional workaround into a new failure.
+            return sql;
+        }
+
+        if (!hasEncodedColumn || projections.isEmpty()) {
+            return sql;
+        }
+        return "SELECT " + String.join(", ", projections)
+            + " FROM " + quotePhoenixIdentifier("SYSTEM") + "." + quotePhoenixIdentifier("CATALOG");
+    }
+
+    private static String quotePhoenixIdentifier(String identifier) {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
     }
 
     private static String binaryToHex(byte[] bytes) {

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -227,6 +227,72 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void phoenixSystemCatalogWildcardCastsEncodedColumnsToStandardBinary() throws Exception {
+        JsonNode connection = MAPPER.readTree("""
+            {
+              "connection_string": "jdbc:phoenix:localhost"
+            }
+            """);
+        ResultSet columns = rowsResultSet(
+            new String[] { "COLUMN_NAME", "DATA_TYPE", "TYPE_NAME" },
+            new Object[][] {
+                { "TENANT_ID", Types.VARCHAR, "VARCHAR" },
+                { "ROW_KEY_MATCHER", 9000, "VARBINARY_ENCODED" },
+                { "TABLE_NAME", Types.VARCHAR, "VARCHAR" }
+            }
+        );
+
+        String rewritten = DbxJdbcPlugin.rewritePhoenixSystemCatalogQuery(
+            connection,
+            metadataConnection(columns),
+            "/* generated table query */ SELECT * FROM SYSTEM.CATALOG;"
+        );
+
+        assertEquals(
+            "SELECT \"TENANT_ID\", CAST(\"ROW_KEY_MATCHER\" AS VARBINARY) AS \"ROW_KEY_MATCHER\", \"TABLE_NAME\" FROM \"SYSTEM\".\"CATALOG\"",
+            rewritten
+        );
+    }
+
+    @Test
+    void nonPhoenixWildcardQueryIsNotRewrittenForEncodedMetadata() throws Exception {
+        JsonNode connection = MAPPER.readTree("""
+            {
+              "connection_string": "jdbc:h2:mem:dbx"
+            }
+            """);
+        String sql = "SELECT * FROM SYSTEM.CATALOG";
+
+        assertEquals(sql, DbxJdbcPlugin.rewritePhoenixSystemCatalogQuery(connection, null, sql));
+    }
+
+    @Test
+    void readValueReadsPhoenixEncodedBinaryThroughBytesAccessor() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod(
+            "readValue",
+            ResultSet.class,
+            ResultSetMetaData.class,
+            int.class,
+            boolean.class
+        );
+        method.setAccessible(true);
+        ResultSet rs = (ResultSet) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { ResultSet.class },
+            (proxy, invokedMethod, args) -> switch (invokedMethod.getName()) {
+                case "getBytes" -> new byte[] { 0x00, 0x01, (byte) 0xab, (byte) 0xff };
+                case "getObject" -> throw new AssertionError("VARBINARY_ENCODED must use getBytes");
+                default -> defaultValue(invokedMethod.getReturnType());
+            }
+        );
+
+        assertEquals(
+            "0x0001abff",
+            method.invoke(null, rs, columnMeta(9000, "VARBINARY_ENCODED"), 1, false)
+        );
+    }
+
+    @Test
     void executeQueryPreservesChineseTextValues() throws Exception {
         JsonNode response = request("executeQuery", """
             {
@@ -2541,6 +2607,10 @@ final class DbxJdbcPluginTest {
     }
 
     private static ResultSetMetaData columnMeta(int columnType) {
+        return columnMeta(columnType, "");
+    }
+
+    private static ResultSetMetaData columnMeta(int columnType, String typeName) {
         return (ResultSetMetaData) Proxy.newProxyInstance(
             DbxJdbcPluginTest.class.getClassLoader(),
             new Class<?>[] { ResultSetMetaData.class },
@@ -2549,8 +2619,28 @@ final class DbxJdbcPluginTest {
                     case "getColumnCount" -> 1;
                     case "getColumnLabel", "getColumnName" -> "CREATED_AT";
                     case "getColumnType" -> columnType;
+                    case "getColumnTypeName" -> typeName;
                     default -> defaultValue(method.getReturnType());
                 };
+            }
+        );
+    }
+
+    private static Connection metadataConnection(ResultSet columns) {
+        DatabaseMetaData metadata = (DatabaseMetaData) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { DatabaseMetaData.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getColumns" -> columns;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+        return (Connection) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Connection.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getMetaData" -> metadata;
+                default -> defaultValue(method.getReturnType());
             }
         );
     }
@@ -2807,6 +2897,7 @@ final class DbxJdbcPluginTest {
                     return switch (method.getName()) {
                         case "next" -> ++index < rows.length;
                         case "getString" -> stringValue(columns, rows[index], args[0]);
+                        case "getInt" -> ((Number) columnValue(columns, rows[index], args[0])).intValue();
                         case "getBoolean" -> booleanValue(columns, rows[index], args[0]);
                         case "getObject" -> columnValue(columns, rows[index], args[0]);
                         case "close" -> null;


### PR DESCRIPTION
## 变更说明

Phoenix 的 `SELECT * FROM SYSTEM.CATALOG` 会把 `ROW_KEY_MATCHER` 投影到结果集。部分 Phoenix/Query Server 组合将该列暴露为私有 JDBC 类型，导致远程查询在返回结果元数据时失败。

## 根因

- **CONFIRMED**：Apache Phoenix 的 `PDataType.VARBINARY_ENCODED_TYPE` 为 `9000`，类型名为 `VARBINARY_ENCODED`；`SYSTEM.CATALOG.ROW_KEY_MATCHER` 的定义使用该类型。
- **CONFIRMED**：Phoenix `PhoenixResultSetMetaData.getColumnType()` 将该内部类型码直接返回；Calcite Avatica 的 `SqlType.valueOf(9000)` 不包含该私有码，并抛出 `IllegalArgumentException: Unknown SQL type 9000`。
- **CONFIRMED**：`9000` 不是 `java.sql.Types.ROWID`（JDBC `ROWID` 使用 `-8`）。
- **CONFIRMED**：异常发生在远程 JDBC/Avatica 结果元数据构建阶段，早于 DBX 对单元值的读取，因此单纯在结果值转换后置映射不足以覆盖该路径。

## 与 #6824 的关系

**EXPOSED PRE-EXISTING COMPATIBILITY GAP**。

#6824 只修改了 Phoenix schema 的传递和 schema-qualified table SQL 生成，没有修改 JDBC 结果元数据或类型转换链路。本 PR 修复的是该链路中 Phoenix vendor-specific type 的兼容性问题，不是 schema qualification 生成错误 SQL。

## 修复内容

- 仅对 Phoenix 的精确 `SELECT * FROM SYSTEM.CATALOG` wildcard 查询读取 JDBC columns metadata。
- 动态保留系统表列顺序；检测到 `9000` / `VARBINARY_ENCODED` 时将该列转换为标准 `VARBINARY`，避免硬编码 39 列。
- 对能够直接返回该类型的 JDBC driver，使用 `getBytes()` 读取 `VARBINARY_ENCODED`，并沿用 DBX 的 binary hex 表示。
- 其他 Phoenix 查询和非 Phoenix JDBC driver 不改变行为；同时覆盖 `executeQuery` 与分页查询路径。

## 测试

- `X:\plugins\jdbc\gradlew.bat test --no-daemon`：通过（全部 `DbxJdbcPluginTest`）。
- `X:\plugins\jdbc\gradlew.bat build --no-daemon`：通过（含 `shadowJar`）。
- `git diff --check`：通过。

`X:` 是本机映射到本 PR worktree 的 ASCII drive，用于避免 Windows Java test worker 处理中文路径时的 classpath 编码问题。

## E2E

真实 Phoenix/HBase 环境不可用，未执行真实 E2E 验证。

## 关联 Issue

Close #6896
