### PR TITLE
fix(sql): resolve MyBatis <where> tags before executing SQL

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -666,6 +666,56 @@ describe("substituteSqlParameters", () => {
     expect(substituteSqlParameters(sql, {}, { enabledSyntaxes: ["shell"] })).toBe(sql);
   });
 
+  it("strips a MyBatis <where> wrapper and prefixes its body with WHERE", () => {
+    const sql = "select * from tasks <where> status = #{status} </where>";
+
+    expect(substituteSqlParameters(sql, { status: { kind: "string", value: "open" } }, { enabledSyntaxes: ["mybatis"] })).toBe("select * from tasks WHERE status = 'open'");
+  });
+
+  it("strips a leading AND/OR from a MyBatis <where> body, case-insensitively", () => {
+    const andSql = "select * from tasks <where> AND status = #{status} </where>";
+    const orSql = "select * from tasks <where> or status = #{status} </where>";
+
+    expect(substituteSqlParameters(andSql, { status: { kind: "string", value: "open" } }, { enabledSyntaxes: ["mybatis"] })).toBe("select * from tasks WHERE status = 'open'");
+    expect(substituteSqlParameters(orSql, { status: { kind: "string", value: "open" } }, { enabledSyntaxes: ["mybatis"] })).toBe("select * from tasks WHERE status = 'open'");
+  });
+
+  it("renders an empty MyBatis <where> body as no WHERE clause at all", () => {
+    const sql = "select * from tasks <where>   </where> order by id";
+
+    expect(substituteSqlParameters(sql, {}, { enabledSyntaxes: ["mybatis"] })).toBe("select * from tasks  order by id");
+  });
+
+  it("does not surface <where> itself as a SQL parameter, but does surface placeholders nested inside it", () => {
+    const sql = "select * from tasks <where> status = #{status} </where>";
+
+    expect(extractSqlParameterDescriptors(sql, { enabledSyntaxes: ["mybatis"] })).toEqual([{ key: "status", name: "status", syntax: "mybatis", token: "#{status}" }]);
+  });
+
+  it("resolves a MyBatis <foreach> nested inside a <where> wrapper", () => {
+    const sql = 'select * from tasks <where> task_id in <foreach collection="taskIds" item="taskId" open="(" separator="," close=")">#{taskId}</foreach> </where>';
+
+    expect(extractSqlParameterDescriptors(sql, { enabledSyntaxes: ["mybatis"] })).toEqual([{ key: "taskIds", name: "taskIds", syntax: "mybatis", token: "<foreach>", collection: true }]);
+    expect(substituteSqlParameters(sql, { taskIds: { kind: "number", value: "[1,2]" } }, { enabledSyntaxes: ["mybatis"] })).toBe("select * from tasks WHERE task_id in (1,2)");
+  });
+
+  it("ignores where-like tags in SQL strings and comments when matching the closing tag", () => {
+    const sql = `select * from tasks <where>
+      status = #{status} /* </where> */ || '<where>fake</where>'
+      -- <where>fake</where>
+    </where>`;
+
+    expect(substituteSqlParameters(sql, { status: { kind: "string", value: "open" } }, { enabledSyntaxes: ["mybatis"] })).toBe(`select * from tasks WHERE status = 'open' /* </where> */ || '<where>fake</where>'
+      -- <where>fake</where>`);
+  });
+
+  it("leaves MyBatis <where> tags untouched when MyBatis substitution is disabled", () => {
+    const sql = "select * from tasks <where> status = #{status} </where>";
+
+    expect(extractSqlParameterDescriptors(sql, { enabledSyntaxes: ["shell"] })).toEqual([]);
+    expect(substituteSqlParameters(sql, {}, { enabledSyntaxes: ["shell"] })).toBe(sql);
+  });
+
   it("decodes XML comparison entities when substituting MyBatis parameters", () => {
     const sql = "select * from orders where created_at &gt;= #{start} and created_at &lt; #{end} and owner_id = #{owner_id} or reviewer_id = #{owner_id}";
 

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -25,8 +25,13 @@ export interface SqlBracedParameter extends SqlParameterDescriptor {
 interface ParameterOccurrence extends SqlParameterDescriptor {
   start: number;
   end: number;
-  replacement?: "string-fragment" | "mybatis-foreach";
+  replacement?: "string-fragment" | "mybatis-foreach" | "mybatis-where";
   foreach?: MyBatisForeach;
+  where?: MyBatisWhere;
+}
+
+interface MyBatisWhere {
+  body: string;
 }
 
 interface MyBatisForeach {
@@ -176,6 +181,10 @@ export function extractSqlParameterDescriptors(sql: string, options?: SqlParamet
     descriptors.push(descriptor);
   };
   for (const occurrence of findSqlParameterOccurrences(sql, options)) {
+    if (occurrence.replacement === "mybatis-where" && occurrence.where) {
+      for (const nested of extractSqlParameterDescriptors(occurrence.where.body, options)) appendDescriptor(nested);
+      continue;
+    }
     appendDescriptor({
       key: occurrence.key,
       name: occurrence.name,
@@ -201,6 +210,11 @@ export function substituteSqlParameters(sql: string, values: Record<string, SqlP
   let cursor = 0;
   for (const occurrence of occurrences) {
     result += sql.slice(cursor, occurrence.start);
+    if (occurrence.replacement === "mybatis-where" && occurrence.where) {
+      result += renderMyBatisWhere(occurrence.where, values, options);
+      cursor = occurrence.end;
+      continue;
+    }
     const input = values[occurrence.key] ?? { kind: "string", value: "" };
     if (occurrence.replacement === "mybatis-foreach" && occurrence.foreach) {
       result += renderMyBatisForeach(occurrence.foreach, input, values, options);
@@ -214,6 +228,14 @@ export function substituteSqlParameters(sql: string, values: Record<string, SqlP
   }
   result += sql.slice(cursor);
   return decodeMyBatisEntities ? decodeMyBatisXmlComparisonEntities(result) : result;
+}
+
+const MYBATIS_WHERE_LEADING_CONJUNCTION_RE = /^(?:AND|OR)\s+/i;
+
+function renderMyBatisWhere(where: MyBatisWhere, values: Record<string, SqlParameterInput>, options?: SqlParameterOptions): string {
+  const body = substituteSqlParameters(where.body, values, options).trim();
+  if (!body) return "";
+  return `WHERE ${body.replace(MYBATIS_WHERE_LEADING_CONJUNCTION_RE, "")}`;
 }
 
 function renderMyBatisForeach(foreach: MyBatisForeach, input: SqlParameterInput, values: Record<string, SqlParameterInput>, options?: SqlParameterOptions): string {
@@ -385,6 +407,21 @@ function findSqlParameterOccurrences(sql: string, options?: SqlParameterOptions)
         i = foreach.end;
         continue;
       }
+      const where = readMyBatisWhereAt(sql, i);
+      if (where) {
+        occurrences.push({
+          key: "",
+          name: "",
+          syntax: "mybatis",
+          token: "<where>",
+          replacement: "mybatis-where",
+          where: { body: where.body },
+          start: i,
+          end: where.end,
+        });
+        i = where.end;
+        continue;
+      }
     }
 
     if (ch === "'" || ch === '"') {
@@ -519,7 +556,7 @@ function readMyBatisForeachAt(sql: string, start: number): { collection: string;
   const index = attributes.get("index")?.trim();
   if (!PARAMETER_NAME_RE.test(collection) || !PARAMETER_NAME_RE.test(item) || (index !== undefined && !PARAMETER_NAME_RE.test(index))) return null;
 
-  const close = findMatchingForeachClose(sql, openingEnd + 1);
+  const close = findMatchingXmlTagClose(sql, openingEnd + 1, "foreach");
   if (!close) return null;
   return {
     collection,
@@ -533,6 +570,16 @@ function readMyBatisForeachAt(sql: string, start: number): { collection: string;
     },
     end: close.end,
   };
+}
+
+function readMyBatisWhereAt(sql: string, start: number): { body: string; end: number } | null {
+  if (!/^<where(?:\s|>)/i.test(sql.slice(start))) return null;
+  const openingEnd = findXmlTagEnd(sql, start);
+  if (openingEnd === -1) return null;
+
+  const close = findMatchingXmlTagClose(sql, openingEnd + 1, "where");
+  if (!close) return null;
+  return { body: sql.slice(openingEnd + 1, close.start), end: close.end };
 }
 
 function findXmlTagEnd(source: string, start: number): number {
@@ -577,7 +624,7 @@ function decodeXmlAttribute(value: string): string {
   return value.replace(/&(?:lt|gt|amp|quot|apos);/g, (entity) => ({ "&lt;": "<", "&gt;": ">", "&amp;": "&", "&quot;": '"', "&apos;": "'" })[entity] ?? entity);
 }
 
-function findMatchingForeachClose(sql: string, start: number): { start: number; end: number } | null {
+function findMatchingXmlTagClose(sql: string, start: number, tagName: string): { start: number; end: number } | null {
   let depth = 1;
   let i = start;
 
@@ -614,7 +661,7 @@ function findMatchingForeachClose(sql: string, start: number): { start: number; 
       }
     }
     if (ch === "<") {
-      const tag = readForeachTagAt(sql, i);
+      const tag = readXmlTagAt(sql, i, tagName);
       if (tag) {
         depth += tag.closing ? -1 : 1;
         if (depth === 0) return { start: i, end: tag.end };
@@ -627,11 +674,11 @@ function findMatchingForeachClose(sql: string, start: number): { start: number; 
   return null;
 }
 
-function readForeachTagAt(sql: string, start: number): { closing: boolean; end: number } | null {
+function readXmlTagAt(sql: string, start: number, tagName: string): { closing: boolean; end: number } | null {
   const closing = sql[start + 1] === "/";
   const nameStart = start + (closing ? 2 : 1);
-  if (sql.slice(nameStart, nameStart + "foreach".length).toLowerCase() !== "foreach") return null;
-  const boundary = sql[nameStart + "foreach".length];
+  if (sql.slice(nameStart, nameStart + tagName.length).toLowerCase() !== tagName) return null;
+  const boundary = sql[nameStart + tagName.length];
   if (boundary !== ">" && !/\s/.test(boundary ?? "")) return null;
   const tagEnd = findXmlTagEnd(sql, start);
   return tagEnd === -1 ? null : { closing, end: tagEnd + 1 };


### PR DESCRIPTION
## Problem

`sqlParameters.ts` only recognized `<foreach>` as a MyBatis dynamic-SQL tag. A `<where>` wrapper (a very common MyBatis pattern, often nesting a `<foreach>`) was left completely untouched: the "SQL Parameters" dialog substituted the bound values inside it, but the literal `<where>` / `</where>` tags stayed in the SQL text sent to the database — causing a real syntax error at execution time (e.g. MySQL `ERROR 1064`), not just a missing highlight as the title suggests.

Example from the issue:

```sql
SELECT collect.collect_uid, count(1) AS bagNum
FROM collect_info collect
JOIN collect_big_bag bag ON collect.collect_uid = bag.collect_uid
<where>
  collect.collect_uid IN
  <foreach collection="collectUidList" item="uid" open="(" separator="," close=")">
    #{uid}
  </foreach>
</where>
GROUP BY ...
```

`<foreach>` correctly expanded, but the SQL preview kept `<where>` / `</where>` as literal text, which MySQL then rejected with a syntax error.

## Solution

- Generalized the existing foreach-closing-tag matcher (`findMatchingForeachClose` / `readForeachTagAt`) into tag-name-agnostic `findMatchingXmlTagClose` / `readXmlTagAt`, and reused it to recognize `<where>...</where>` the same way `<foreach>` is recognized (still comment/string/dollar-quote aware, so a fake `<where>` inside a comment or string literal doesn't confuse the matcher).
- On substitution, the `<where>` body is resolved recursively first (so nested placeholders and a nested `<foreach>` still work), then trimmed, a leading `AND`/`OR` is stripped (case-insensitive), and the result is prefixed with `WHERE ` when non-empty — or dropped entirely when the body is empty. This matches real MyBatis `WhereSqlNode` semantics.
- `<where>` itself is not surfaced as a bindable SQL parameter in the "SQL Parameters" dialog (it has no value of its own), but placeholders nested inside it (including a nested `<foreach>`) still are.

## Testing

- Added 8 new unit tests in `sqlParameters.spec.ts` covering: basic `<where>` stripping, leading `AND`/`OR` removal, empty-body handling (no `WHERE` at all), that `<where>` itself isn't listed as a parameter while nested placeholders are, a `<foreach>` nested inside `<where>`, ignoring where-like tags inside strings/comments, and the `enabledSyntaxes` opt-out path.
- Full existing suite still green: `sqlParameters.spec.ts` 99/99, plus `useSqlExecution` / `sqlVariableSyntax` / `executableStatementRangeCache` / `sqlFormatter` 132/132, plus the whole `apps/desktop/src/lib/__tests__/sql/` directory 1032/1032. `vue-tsc --noEmit` is clean.
- Manually reproduced against a real MySQL 8.4.6 instance through the actual UI (dev build): before the fix, executing a `<where><foreach>...</foreach></where>` template SQL through the "SQL Parameters" dialog produced a real `ERROR 1064` syntax error from MySQL. After the fix, the same steps produce a valid `WHERE ... IN (...)` clause that executes successfully.

Fixes #6902