### PR TITLE
feat(ai): show AI panel connection picker as a group tree

### DIFF
--- a/apps/desktop/src/components/editor/AiAssistant.vue
+++ b/apps/desktop/src/components/editor/AiAssistant.vue
@@ -57,7 +57,7 @@ import { useSavedSqlStore } from "@/stores/savedSqlStore";
 import { usePromptTemplateStore } from "@/stores/promptTemplateStore";
 import { connectionIconType } from "@/lib/connection/connectionPresentation";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
-import ConnectionGroupBadge from "@/components/connection/ConnectionGroupBadge.vue";
+import ConnectionTreeSelect from "@/components/connection/ConnectionTreeSelect.vue";
 import { useQueryStore } from "@/stores/queryStore";
 import { useToast } from "@/composables/useToast";
 import { useNavigationTargets } from "@/composables/useNavigationTargets";
@@ -3428,27 +3428,18 @@ async function openExternalUrl(url: string) {
             <template v-if="connectionStore.connections.length">
               <DatabaseIcon v-if="connection" :db-type="connectionIconType(connection)" class="h-3 w-3 shrink-0" />
               <Server v-else class="h-3 w-3 shrink-0" />
-              <Select
+              <ConnectionTreeSelect
                 :model-value="connection?.id || ''"
-                @update:model-value="
-                  (v) => {
-                    if (typeof v === 'string') changeConnection(v);
-                  }
-                "
-              >
-                <SelectTrigger class="h-5 w-auto border-0 rounded-md bg-transparent dark:bg-transparent p-0 px-1 text-xs text-foreground/80 shadow-none focus:ring-0 focus-visible:ring-0 [&_svg]:size-3">
-                  <SelectValue :placeholder="t('editor.selectConnection')">{{ connection?.name || t("editor.selectConnection") }}</SelectValue>
-                </SelectTrigger>
-                <SelectContent class="min-w-48">
-                  <SelectItem v-for="conn in connectionStore.connections" :key="conn.id" :value="conn.id">
-                    <div class="flex min-w-0 items-center gap-2">
-                      <DatabaseIcon :db-type="connectionIconType(conn)" class="h-3.5 w-3.5 shrink-0" />
-                      <ConnectionGroupBadge :connection-id="conn.id" />
-                      <span class="truncate">{{ conn.name }}</span>
-                    </div>
-                  </SelectItem>
-                </SelectContent>
-              </Select>
+                :connections="connectionStore.connections"
+                :layout="connectionStore.sidebarLayout"
+                :placeholder="t('editor.selectConnection')"
+                :search-placeholder="t('editor.searchConnection')"
+                :empty-text="t('grid.noSearchResults')"
+                trigger-class="h-5 px-1 text-foreground/80"
+                trigger-icon-class="h-3 w-3"
+                list-class="w-72 max-w-[calc(100vw-2rem)]"
+                @update:model-value="(v) => changeConnection(v)"
+              />
               <template v-if="connection">
                 <Database class="h-3 w-3 shrink-0 text-foreground/40" />
                 <Select


### PR DESCRIPTION
The AI assistant's connection selector listed every connection flat with the group badge inline, which gets hard to scan with many connections. Reuse the toolbar's ConnectionTreeSelect so the picker mirrors the sidebar's collapsible group tree, with search by connection or group name.

Fixes #6952

## 变更说明

## 修改内容
AI 对话框底部的连接选择器原来是扁平列表,连接多的时候难以定位所属分组。
改为复用工具栏的树形连接选择器(ConnectionTreeSelect),与右侧边栏分组结构一致:
- 分组可折叠/展开,连接按层级缩进
- 支持按连接名/分组名搜索
- 支持键盘 ↑/↓ + Enter 选择

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1094" height="876" alt="image" src="https://github.com/user-attachments/assets/48f87e10-a530-42d7-b19b-b7494f76c376" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #6952