### PR TITLE
fix(codeSnapshot): 代码截图行号不生效

### DIFF
--- a/apps/desktop/src/lib/ai/__tests__/aiCodeHighlighter.spec.ts
+++ b/apps/desktop/src/lib/ai/__tests__/aiCodeHighlighter.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createAiShikiBlockCodeHighlighter } from "@/lib/ai/aiCodeHighlighter";
+
+describe("createAiShikiBlockCodeHighlighter", () => {
+  it("wraps every source line in its own .line span with no stray connecting newline", async () => {
+    const highlight = await createAiShikiBlockCodeHighlighter({ appearance: () => "light" });
+
+    const html = highlight("SELECT\n    id,\n        name\nFROM users", "sql");
+
+    expect(html.match(/class="line"/g)).toHaveLength(4);
+    // Issue #6894: shiki's classic structure joins lines with a literal "\n" text
+    // node; since `.line` is already `display:block`, leaving that in doubles the
+    // visual line spacing under `white-space:pre`. It must be stripped.
+    expect(html).not.toMatch(/<\/span>\n/);
+    // Leading indentation must survive (it's rendered as a plain text token).
+    expect(html).toContain("    id,");
+    expect(html).toContain("        name");
+  });
+
+  it("does not leak shiki's own <pre>/<code> wrapper (the caller supplies its own)", async () => {
+    const highlight = await createAiShikiBlockCodeHighlighter({ appearance: () => "dark" });
+
+    const html = highlight("SELECT 1", "sql");
+
+    expect(html).not.toContain("<pre");
+    expect(html).not.toContain("<code");
+  });
+});

--- a/apps/desktop/src/lib/ai/aiCodeHighlighter.ts
+++ b/apps/desktop/src/lib/ai/aiCodeHighlighter.ts
@@ -58,6 +58,38 @@ export async function createAiShikiCodeHighlighter(options: AiShikiCodeHighlight
     });
 }
 
+/**
+ * Like `createAiShikiCodeHighlighter`, but keeps shiki's per-line `.line`
+ * wrappers (structure "classic") instead of flattening them away. Callers
+ * that lay out code as a block — one line per row, e.g. with CSS-counter
+ * line numbers — need this; `structure: "inline"` discards the `.line`
+ * elements entirely, so counters/line-based layout silently no-op.
+ */
+export async function createAiShikiBlockCodeHighlighter(options: AiShikiCodeHighlighterOptions): Promise<AiCodeHighlighter> {
+  const highlighter = await getAiShikiHighlighter();
+  return (content, lang, appearance = options.appearance()) => {
+    const html = highlighter.codeToHtml(content, {
+      lang: resolveShikiLanguage(lang),
+      structure: "classic",
+      theme: SHIKI_THEMES[appearance],
+    });
+    return extractShikiCodeInnerHtml(html);
+  };
+}
+
+/**
+ * Shiki's "classic" structure wraps lines in `<pre ...><code ...>...</code></pre>`;
+ * callers that supply their own `<pre>/<code>` shell only want what's inside.
+ * It also joins `<span class="line">` siblings with a literal "\n" text node —
+ * redundant once `.line{display:block}` already breaks each line, and doubles
+ * the visual line spacing under `white-space:pre` if left in.
+ */
+function extractShikiCodeInnerHtml(html: string): string {
+  const match = /<code[^>]*>([\s\S]*)<\/code>/.exec(html);
+  const inner = match ? match[1] : html;
+  return inner.replace(/<\/span>\n/g, "</span>");
+}
+
 function getAiShikiHighlighter(): Promise<ShikiHighlighter> {
   highlighterPromise ??= loadAiShikiHighlighter();
   return highlighterPromise;

--- a/apps/desktop/src/lib/codeSnapshot/__tests__/codeSnapshot.spec.ts
+++ b/apps/desktop/src/lib/codeSnapshot/__tests__/codeSnapshot.spec.ts
@@ -14,7 +14,7 @@ const { createCodeHighlighter, highlightCode, toPng, isTauriRuntime, save, write
 });
 
 vi.mock("@/lib/ai/aiCodeHighlighter", () => ({
-  createAiShikiCodeHighlighter: createCodeHighlighter,
+  createAiShikiBlockCodeHighlighter: createCodeHighlighter,
 }));
 
 vi.mock("dom-to-image-more", () => ({

--- a/apps/desktop/src/lib/codeSnapshot/codeSnapshot.ts
+++ b/apps/desktop/src/lib/codeSnapshot/codeSnapshot.ts
@@ -12,7 +12,7 @@
  * clones the node into a foreignObject.
  */
 import type { AppThemeAppearance } from "@/lib/app/appTheme";
-import { createAiShikiCodeHighlighter, type AiCodeHighlighter } from "@/lib/ai/aiCodeHighlighter";
+import { createAiShikiBlockCodeHighlighter, type AiCodeHighlighter } from "@/lib/ai/aiCodeHighlighter";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 
 export interface CodeSnapshotSource {
@@ -135,7 +135,7 @@ let highlighterPromise: Promise<AiCodeHighlighter> | undefined;
 
 /** Lazy singleton reusing the AI assistant's shiki highlighter instance. */
 export function getCodeSnapshotHighlighter(): Promise<AiCodeHighlighter> {
-  highlighterPromise ??= createAiShikiCodeHighlighter({
+  highlighterPromise ??= createAiShikiBlockCodeHighlighter({
     appearance: () => "dark",
   }).catch((err: unknown) => {
     // Reset so a transient highlighter failure can be retried on the next


### PR DESCRIPTION
Fixes #6894

## 问题
代码截图（Screenshot Selected Code）导出的图片里没有任何行号，即使"Line Numbers"开关是打开的。

## 根因
截图功能复用了 AI 聊天用的 shiki 高亮器，调用时用了 `structure: "inline"` 模式。这个模式内部会先按行构建 `.line` 包裹元素，随后又显式把这层包裹丢弃、只保留扁平的 token（用 `<br>` 分隔）。而截图的行号是靠 CSS 计数器 `counter-increment` 绑定在 `.line` 选择器上实现的——没有 `.line` 元素，计数器永远不递增，行号也就完全不显示。

## 修复
- 新增 `createAiShikiBlockCodeHighlighter`（`apps/desktop/src/lib/ai/aiCodeHighlighter.ts`），复用同一个 shiki 单例，但用 `structure: "classic"` 保留每行的 `.line` 包裹，再从 shiki 自带的 `<pre><code>` 壳里剥出内层 HTML，交给调用方套自己的样式壳。AI 聊天原有的 `createAiShikiCodeHighlighter`（`structure: "inline"`）完全没有改动，两个功能各用各的，互不影响。
- 代码截图（`apps/desktop/src/lib/codeSnapshot/codeSnapshot.ts`）改用新函数。
- 顺带修了一个衍生问题：shiki 的 classic 结构会用字面 `\n` 文本节点连接相邻的 `.line` 元素，而截图 CSS 已经用 `.line{display:block}` 换行，两者叠加会让行间距翻倍。一并去掉了这个冗余换行符。

## 验证
- 真实复现（独立 dev 环境 + 真实 Chromium 浏览器，直接从系统剪贴板取出真实导出的 PNG，而不是只看 DOM 预览）：修复前导出图片完全没有行号；修复后正确显示 1-N 行号，且行间距正常，亮/暗两个主题都验证过。
- 新增回归测试 `apps/desktop/src/lib/ai/__tests__/aiCodeHighlighter.spec.ts`（覆盖行号 span 数量、无冗余换行、缩进保留、不泄漏 shiki 自带 pre/code 壳），revert 后测试真实失败、reapply 后通过。
- `pnpm exec vitest run` 覆盖 `lib/ai/`、`lib/codeSnapshot/`、`components/codeSnapshot/` 共 14 个文件 71 条全绿。
- `pnpm typecheck` 干净。

## 已知限制
issue 里另外两个现象（缩进丢失、无语法高亮）在本机 Chromium 测试环境下没有复现出来，大概率是桌面版真实 WKWebView 旧版本（issue 报告的 macOS 12.7）特有的问题；这次没能拿到独立证据，如果修复后依然存在，欢迎在 issue 里反馈。