### PR TITLE
fix(ci): 同步侧边栏表粘贴断言

### DIFF
--- a/packages/app-tests/sidebarContextMenuHost.test.ts
+++ b/packages/app-tests/sidebarContextMenuHost.test.ts
@@ -119,7 +119,7 @@ test("successful tree table paste consumes only the clipboard used to start it",
   const confirmPasteTableBody = functionBody(runtimeHost, "confirmPasteTable");
 
   assert.match(confirmPasteTableBody, /const clipboardAtPasteStart = connectionStore\.treeClipboard/);
-  assert.match(confirmPasteTableBody, /if \(pasteFailCount === 0\)/);
+  assert.match(confirmPasteTableBody, /if \(pasteFeedback\.failedCount === 0\)/);
   assert.match(confirmPasteTableBody, /connectionStore\.treeClipboard === clipboardAtPasteStart/);
   assert.match(confirmPasteTableBody, /connectionStore\.treeClipboard = null/);
 });
@@ -142,7 +142,7 @@ test("tree table paste consumes the clipboard even if only the object-list refre
   assert.match(confirmPasteTableBody, /let refreshFailCount = 0/);
   assert.match(confirmPasteTableBody, /pasteFailCount\+\+/);
   assert.match(confirmPasteTableBody, /refreshFailCount\+\+/);
-  assert.match(confirmPasteTableBody, /if \(pasteFailCount === 0\)[\s\S]*?connectionStore\.treeClipboard = null/);
+  assert.match(confirmPasteTableBody, /if \(pasteFeedback\.failedCount === 0\)[\s\S]*?connectionStore\.treeClipboard = null/);
   assert.match(confirmPasteTableBody, /if \(refreshFailCount > 0\)[\s\S]*?pasteTableRefreshFailed/);
 });
 


### PR DESCRIPTION
## 问题

`72bb880e` 将粘贴结果判断切换为 `pasteFeedback.failedCount`，但侧边栏静态测试仍匹配旧的 `pasteFailCount`，导致 `main` 和后续前端 PR 的 CI 失败。

## 修改

- 同步两条侧边栏表粘贴断言到当前实现
- 保留剪贴板仅在粘贴成功时清空的行为校验

## 验证

- `pnpm exec vitest run packages/app-tests/sidebarContextMenuHost.test.ts`（14 项通过）
- `pnpm check`（全部通过）