### PR TITLE
✨ feat(editor): 为悬浮 DDL 提示新增复制按钮

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -2515,6 +2515,34 @@ function createHoverDom(title: string, detail: string, sqlContent?: string, rows
   let handleCopy: ((event: ClipboardEvent) => void) | null = null;
 
   if (sqlContent) {
+    heading.className = "flex items-center justify-between gap-3 font-medium";
+
+    const copyButton = document.createElement("button");
+    copyButton.type = "button";
+    copyButton.className = "rounded border border-border/60 px-1.5 py-0.5 text-[11px] leading-none text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+    copyButton.textContent = t("grid.copyDdl");
+    copyButton.title = t("grid.copyDdl");
+    copyButton.setAttribute("aria-label", t("grid.copyDdl"));
+    copyButton.addEventListener("pointerdown", (event) => {
+      // Keep CodeMirror's editor gestures from dismissing the tooltip before
+      // the click can reach the copy action.
+      event.preventDefault();
+      event.stopPropagation();
+    });
+    copyButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void (async () => {
+        try {
+          await copyToClipboard(normalizeAlignedSqlWhitespace(sqlContent));
+          toast(t("contextMenu.ddlCopied"), 2000);
+        } catch (error: any) {
+          toast(t("grid.copyFailed", { message: error?.message || String(error) }), 5000);
+        }
+      })();
+    });
+    heading.appendChild(copyButton);
+
     const separator = document.createElement("div");
     separator.className = "mt-2 border-t border-border/60";
     dom.appendChild(separator);

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorHoverDdlCopy.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorHoverDdlCopy.spec.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+describe("QueryEditor hover DDL copy", () => {
+  it("adds an accessible copy button that preserves SQL whitespace semantics", () => {
+    expect(queryEditorSource).toContain('copyButton.textContent = t("grid.copyDdl");');
+    expect(queryEditorSource).toContain('copyButton.setAttribute("aria-label", t("grid.copyDdl"));');
+    expect(queryEditorSource).toContain('copyButton.addEventListener("pointerdown"');
+    expect(queryEditorSource).toContain("event.stopPropagation();");
+    expect(queryEditorSource).toContain("await copyToClipboard(normalizeAlignedSqlWhitespace(sqlContent));");
+    expect(queryEditorSource).toContain('toast(t("contextMenu.ddlCopied"), 2000);');
+    expect(queryEditorSource).toContain('toast(t("grid.copyFailed", { message: error?.message || String(error) }), 5000);');
+  });
+});


### PR DESCRIPTION
## 变更说明

在 SQL 编辑器的表名悬浮 DDL 提示中增加“复制 DDL”按钮，支持一键复制展示的 DDL。

- 复制内容会规范化仅用于视觉对齐的空白，同时保留 SQL 字面量、注释与标识符中的语义空白。
- 复用现有跨端剪贴板能力，并提供成功与失败提示。
- 阻止编辑器手势提前关闭提示框，确保按钮可正常点击。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1042" height="410" alt="image" src="https://github.com/user-attachments/assets/de9b5bc3-d420-4569-9275-41bde83f2991" />



## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过
  - `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/queryEditorHoverDdlCopy.spec.ts apps/desktop/src/lib/editor/__tests__/hoverTableSql.spec.ts`
  - `pnpm typecheck`
  - `pnpm lint`（仅现有无关警告）

## 关联 Issue

Close #6999