### PR TITLE
fix: 执行期间保留用户调整后的 SQL 编辑器位置

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -226,7 +226,7 @@ let viewportEmitFrame: number | null = null;
 let viewportRestoreFrame: number | null = null;
 let latestViewport: { scrollTop: number; scrollLeft: number } | undefined = props.initialViewport;
 let lastEmittedViewport: { scrollTop: number; scrollLeft: number } | undefined = props.initialViewport;
-const gutterExecutionViewport = createQueryEditorExecutionViewportOwnership();
+const executionViewportOwnership = createQueryEditorExecutionViewportOwnership();
 let latestSelection: { anchor: number; head: number } | undefined = props.initialSelection;
 const connectionStore = useConnectionStore();
 const settingsStore = useSettingsStore();
@@ -830,7 +830,7 @@ interface RequestExecuteOptions {
 
 function emitExecutionRequest(source: SqlExecutionOverride, openInNewResultTab = false) {
   if (typeof source === "string" || source.editorViewportRequestId === undefined) {
-    gutterExecutionViewport.cancelPendingRequest();
+    executionViewportOwnership.cancelPendingRequest();
   }
   if (openInNewResultTab) {
     emit("executeInNewResultTab", source);
@@ -840,7 +840,7 @@ function emitExecutionRequest(source: SqlExecutionOverride, openInNewResultTab =
 }
 
 function requestExecute(options: RequestExecuteOptions = {}) {
-  gutterExecutionViewport.cancelPendingRequest();
+  executionViewportOwnership.cancelPendingRequest();
   const currentView = view.value;
   if (!currentView) return false;
   currentView.focus();
@@ -1689,7 +1689,7 @@ function executeSqlStatementFromGutter(currentView: EditorViewType, line: { from
   event.stopPropagation();
   // Gutter play is always scoped to the statement/command for that line, even
   // when the main editor execute action would run the full document.
-  const editorViewportRequestId = gutterExecutionViewport.beginRequest();
+  const editorViewportRequestId = executionViewportOwnership.beginRequest();
   emitExecutionRequest({ ...sqlExecutionSnapshotForRange(currentView, statementRange), editorViewportRequestId });
   // 不主动聚焦编辑器，否则 CodeMirror 会把屏幕滚回之前的光标位置。
   // currentView.focus();
@@ -5819,7 +5819,7 @@ function pauseQueryEditorBackgroundWork() {
   flushEditorSelection();
   clearTableNavigationHover();
   clearPendingCompletionTab();
-  gutterExecutionViewport.reset();
+  executionViewportOwnership.reset();
   editorIsActive = false;
   clearScheduledSemanticDiagnostics();
   completionEpoch++;
@@ -5978,7 +5978,7 @@ function openReplace(): boolean {
 }
 
 function scrollCursorIntoView() {
-  const preserveViewport = gutterExecutionViewport.consumeAcceptedRequest();
+  const preserveViewport = executionViewportOwnership.consumeCompletionPreservation();
   if (!view.value || !editorViewModule || !editorIsActive || preserveViewport) return;
   const pos = view.value.state.selection.main.head;
   // Use "center" rather than "nearest": by the time this runs, the results pane has already
@@ -5992,19 +5992,28 @@ function scrollCursorIntoView() {
   });
 }
 
+function beginExecutionViewportTracking() {
+  executionViewportOwnership.beginExecution();
+}
+
+function recordExecutionViewportInteraction() {
+  executionViewportOwnership.recordUserInteraction();
+}
+
 function dismissHoverTooltip() {
   if (!view.value || !hoverCloseEffect) return;
   view.value.dispatch({ effects: hoverCloseEffect });
 }
 
 function acceptGutterExecutionViewport(requestId: number) {
-  return gutterExecutionViewport.acceptRequest(requestId);
+  return executionViewportOwnership.acceptRequest(requestId);
 }
 
 defineExpose({
   openSearch,
   openReplace,
   scrollCursorIntoView,
+  beginExecutionViewportTracking,
   acceptGutterExecutionViewport,
   requestExecute,
   requestExecuteInNewResultTab,
@@ -6016,7 +6025,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="h-full w-full overflow-hidden relative" @gesturestart="onEditorGestureStart" @gesturechange="onEditorGestureChange" @gestureend="onEditorGestureEnd">
+  <div class="h-full w-full overflow-hidden relative" @wheel="recordExecutionViewportInteraction" @pointerdown="recordExecutionViewportInteraction" @gesturestart="onEditorGestureStart" @gesturechange="onEditorGestureChange" @gestureend="onEditorGestureEnd">
     <CustomContextMenu :items="currentContextMenuItems" @close="contextMenuOpen = false" v-slot="{ onContextMenu }">
       <div
         ref="editorRef"

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -751,6 +751,9 @@ watch(
 watch(
   () => props.activeTab.isExecuting,
   (isExecuting, wasExecuting) => {
+    if (isExecuting && !wasExecuting) {
+      queryEditorRef.value?.beginExecutionViewportTracking();
+    }
     if (!isExecuting && wasExecuting) {
       nextTick(() => {
         requestAnimationFrame(() => {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
@@ -50,7 +50,7 @@ describe("QueryEditor execution routing", () => {
   });
 
   it("preserves the source range when executing from the statement gutter", () => {
-    expect(queryEditorSource).toContain("const editorViewportRequestId = gutterExecutionViewport.beginRequest()");
+    expect(queryEditorSource).toContain("const editorViewportRequestId = executionViewportOwnership.beginRequest()");
     expect(queryEditorSource).toContain("emitExecutionRequest({ ...sqlExecutionSnapshotForRange(currentView, statementRange), editorViewportRequestId })");
     expect(queryEditorSource).not.toContain('emit("execute", statementRange.sql)');
   });
@@ -60,6 +60,13 @@ describe("QueryEditor execution routing", () => {
     expect(contentAreaSource).toContain("acceptGutterExecutionViewport(requestId)");
     expect(sqlExecutionSource).toContain("onExecutionStarted: () => deps.onExecutionStarted?.(options.editorViewportRequestId!)");
     expect(queryStoreSource.indexOf("tab.isExecuting = true")).toBeLessThan(queryStoreSource.indexOf("options?.onExecutionStarted?.()"));
+  });
+
+  it("tracks editor interaction while a query is executing", () => {
+    expect(contentAreaSource).toContain("queryEditorRef.value?.beginExecutionViewportTracking()");
+    expect(queryEditorSource).toContain('@wheel="recordExecutionViewportInteraction"');
+    expect(queryEditorSource).toContain('@pointerdown="recordExecutionViewportInteraction"');
+    expect(queryEditorSource).toContain("executionViewportOwnership.recordUserInteraction()");
   });
 
   it("lets the shortcut skip the picker without affecting other execution entry points", () => {
@@ -75,7 +82,33 @@ describe("QueryEditor execution routing", () => {
   });
 });
 
-describe("QueryEditor gutter execution viewport ownership", () => {
+describe("QueryEditor execution viewport ownership", () => {
+  it("keeps automatic cursor centering when the user does not interact during execution", () => {
+    const ownership = createQueryEditorExecutionViewportOwnership();
+
+    ownership.beginExecution();
+
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
+  });
+
+  it("preserves the viewport once after user interaction during execution", () => {
+    const ownership = createQueryEditorExecutionViewportOwnership();
+
+    ownership.beginExecution();
+    ownership.recordUserInteraction();
+
+    expect(ownership.consumeCompletionPreservation()).toBe(true);
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
+  });
+
+  it("ignores editor interaction outside an active execution", () => {
+    const ownership = createQueryEditorExecutionViewportOwnership();
+
+    ownership.recordUserInteraction();
+
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
+  });
+
   it("does not let a cancelled or early-returned gutter request affect the next ordinary execution", () => {
     const ownership = createQueryEditorExecutionViewportOwnership();
     const cancelledRequestId = ownership.beginRequest();
@@ -83,7 +116,7 @@ describe("QueryEditor gutter execution viewport ownership", () => {
     ownership.cancelPendingRequest();
 
     expect(ownership.acceptRequest(cancelledRequestId)).toBe(false);
-    expect(ownership.consumeAcceptedRequest()).toBe(false);
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
   });
 
   it("preserves the viewport once for the matching accepted execution", () => {
@@ -91,8 +124,9 @@ describe("QueryEditor gutter execution viewport ownership", () => {
     const requestId = ownership.beginRequest();
 
     expect(ownership.acceptRequest(requestId)).toBe(true);
-    expect(ownership.consumeAcceptedRequest()).toBe(true);
-    expect(ownership.consumeAcceptedRequest()).toBe(false);
+    ownership.beginExecution();
+    expect(ownership.consumeCompletionPreservation()).toBe(true);
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
   });
 
   it("clears pending and accepted ownership when the editor becomes inactive", () => {
@@ -106,7 +140,17 @@ describe("QueryEditor gutter execution viewport ownership", () => {
     expect(ownership.acceptRequest(acceptedRequestId)).toBe(true);
     ownership.reset();
 
-    expect(ownership.consumeAcceptedRequest()).toBe(false);
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
+  });
+
+  it("clears execution interaction when the editor becomes inactive", () => {
+    const ownership = createQueryEditorExecutionViewportOwnership();
+    ownership.beginExecution();
+    ownership.recordUserInteraction();
+
+    ownership.reset();
+
+    expect(ownership.consumeCompletionPreservation()).toBe(false);
   });
 });
 

--- a/apps/desktop/src/lib/editor/queryEditorExecutionViewport.ts
+++ b/apps/desktop/src/lib/editor/queryEditorExecutionViewport.ts
@@ -2,6 +2,8 @@ export function createQueryEditorExecutionViewportOwnership() {
   let nextRequestId = 0;
   let pendingRequestId: number | undefined;
   let acceptedRequestId: number | undefined;
+  let executionActive = false;
+  let userInteractedDuringExecution = false;
 
   return {
     beginRequest(): number {
@@ -18,14 +20,25 @@ export function createQueryEditorExecutionViewportOwnership() {
       acceptedRequestId = requestId;
       return true;
     },
-    consumeAcceptedRequest(): boolean {
-      if (acceptedRequestId === undefined) return false;
+    beginExecution() {
+      executionActive = true;
+      userInteractedDuringExecution = false;
+    },
+    recordUserInteraction() {
+      if (executionActive) userInteractedDuringExecution = true;
+    },
+    consumeCompletionPreservation(): boolean {
+      const preserveViewport = acceptedRequestId !== undefined || userInteractedDuringExecution;
       acceptedRequestId = undefined;
-      return true;
+      executionActive = false;
+      userInteractedDuringExecution = false;
+      return preserveViewport;
     },
     reset() {
       pendingRequestId = undefined;
       acceptedRequestId = undefined;
+      executionActive = false;
+      userInteractedDuringExecution = false;
     },
   };
 }


### PR DESCRIPTION
## 修改内容

- 查询执行期间记录编辑器滚轮和指针操作
- 用户已调整视口时，执行完成不再强制滚回上一条 SQL
- 未发生用户操作时保留原有的自动定位行为

## 验证

- MySQL 8.4：执行 `SELECT SLEEP(2);` 期间滚动并点击底部 SQL，完成后位置保持不变
- MySQL 8.4：执行期间不操作视口，当前 SQL 仍会自动定位到可见区域
- `pnpm vitest run apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts`
- `pnpm typecheck`
- 变更文件 `oxlint`

Closes #4013