### PR TITLE
Fix：修复 Win7 RabbitMQ Agent 启动崩溃

### DIFF
--- a/.github/workflows/agents-release.yml
+++ b/.github/workflows/agents-release.yml
@@ -272,7 +272,6 @@ jobs:
             ["linux-aarch64"]="linux/arm64"
             ["linux-x64"]="linux/amd64"
             ["windows-aarch64"]="windows/arm64"
-            ["windows-x64"]="windows/amd64"
           )
           for platform in "${!TARGETS[@]}"; do
             IFS=/ read -r goos goarch <<< "${TARGETS[$platform]}"
@@ -284,6 +283,20 @@ jobs:
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags="-s -w" -o "$output" .
           done
           ls -lh ../../../release-native
+      # Go 1.20 is the last release that supports Windows 7; keep other targets on Go 1.22.
+      - name: Set up Go for Windows 7-compatible RabbitMQ agent
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.20.14"
+          cache-dependency-path: agents/drivers/rabbitmq/go.sum
+      - name: Build Windows 7-compatible RabbitMQ agent
+        shell: bash
+        working-directory: agents/drivers/rabbitmq
+        run: |
+          output="../../../release-native/dbx-agent-rabbitmq-windows-x64.exe"
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o "$output" .
+          go version -m "$output" | tee /tmp/rabbitmq-windows-x64-build-info.txt
+          grep -q ': go1\.20\.14$' /tmp/rabbitmq-windows-x64-build-info.txt
       - uses: actions/upload-artifact@v4
         with:
           name: rabbitmq-native

--- a/agents/drivers/rabbitmq/go.mod
+++ b/agents/drivers/rabbitmq/go.mod
@@ -1,5 +1,5 @@
 module github.com/t8y2/dbx/agents/drivers/rabbitmq
 
-go 1.22
+go 1.20
 
 require github.com/rabbitmq/amqp091-go v1.13.0


### PR DESCRIPTION
## 修复内容

- 将 RabbitMQ Agent 的 Go 兼容版本调整为 1.20。
- 其他平台继续使用 Go 1.22 构建，仅 Windows x64 使用最后支持 Windows 7 的 Go 1.20.14。
- 发布构建中校验 Windows x64 产物的实际 Go 版本，避免后续意外升级导致兼容性回退。

## 验证

- Go 1.20.14 下 RabbitMQ Agent 全量测试通过。
- 成功交叉编译 Windows x64 PE，`go version -m` 确认为 `go1.20.14`、`CGO_ENABLED=0`、`GOAMD64=v1`。
- Go 1.22.12 下其余五个平台产物均构建成功。
- Agent 清单校验、工作流 YAML 解析及版本管理 18 个测试通过。
- 当前无 Windows 7 真机环境，最终启动及 RabbitMQ 连接需在 Win7 上回归。

Closes #6899