### PR TITLE
Fix: 修复驱动管理与设置页切换及标签选中状态

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -535,6 +535,13 @@ function openSettings(initialTab = "appearance", initialSection?: string) {
   activateSettingsPage();
 }
 
+type MainContentSurface = "query" | "settings" | "driverStore";
+
+function activateMainContentSurface(surface: MainContentSurface) {
+  settingsStore.settingsPageActive = surface === "settings";
+  driverStoreActive.value = surface === "driverStore";
+}
+
 watch(
   () => settingsStore.settingsNavigationRequest,
   (request) => {
@@ -546,23 +553,20 @@ watch(
 
 function activateSettingsPage() {
   settingsPageTabOpen.value = true;
-  settingsStore.settingsPageActive = true;
-  driverStoreActive.value = false;
+  activateMainContentSurface("settings");
 }
 
 function activateQuerySurface() {
-  driverStoreActive.value = false;
-  settingsStore.settingsPageActive = false;
+  activateMainContentSurface("query");
 }
 
 function closeSettingsPage() {
   settingsPageTabOpen.value = false;
-  settingsStore.settingsPageActive = false;
   if (settingsReturnSurface.value === "driverStore" && driverStoreTabOpen.value) {
-    driverStoreActive.value = true;
+    activateMainContentSurface("driverStore");
     return;
   }
-  driverStoreActive.value = false;
+  activateMainContentSurface("query");
 }
 
 const driverStoreFocus = ref<DriverStoreFocus | null>(null);
@@ -578,13 +582,12 @@ function openDriverStorePage(target?: "agent" | "jdbc" | "storage" | "runtime" |
     driverStoreFocus.value = target ?? null;
   }
   driverStoreTabOpen.value = true;
-  driverStoreActive.value = true;
-  settingsStore.settingsPageActive = false;
+  activateMainContentSurface("driverStore");
 }
 
 function closeDriverStorePage() {
   driverStoreTabOpen.value = false;
-  driverStoreActive.value = false;
+  activateMainContentSurface("query");
   driverStoreActiveTab.value = "agent";
   driverStoreFocus.value = null;
 }

--- a/apps/desktop/src/components/config/DriverStoreDialog.vue
+++ b/apps/desktop/src/components/config/DriverStoreDialog.vue
@@ -2224,8 +2224,8 @@ watch(driverStoreTab, (tab) => {
         </Tabs>
       </div>
     </div>
+    <AgentOfflineExportDialog v-model:open="offlineExportDialogOpen" :preview="offlineExportPreview" :loading="offlineExportLoading" :exporting="offlineExporting" :error="offlineExportError" @confirm="exportOfflinePackage" />
   </div>
-  <AgentOfflineExportDialog v-model:open="offlineExportDialogOpen" :preview="offlineExportPreview" :loading="offlineExportLoading" :exporting="offlineExporting" :error="offlineExportError" @confirm="exportOfflinePackage" />
 </template>
 
 <style>

--- a/apps/desktop/src/components/config/__tests__/DriverStoreDialog.visibility.spec.ts
+++ b/apps/desktop/src/components/config/__tests__/DriverStoreDialog.visibility.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../DriverStoreDialog.vue", import.meta.url), "utf8");
+const templateStart = source.indexOf("<template>");
+const template = source.slice(templateStart, source.indexOf("\n<style", templateStart)).trim();
+
+describe("DriverStoreDialog visibility", () => {
+  it("keeps the page and its auxiliary dialog under one root so component v-show works", () => {
+    expect(template).toMatch(/^<template>\s*<div class="driver-store-view[^"]*">[\s\S]*<AgentOfflineExportDialog[^>]*\/>\s*<\/div>\s*<\/template>$/);
+  });
+});

--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -500,6 +500,11 @@ function tabColorStyle(tab: QueryTab) {
   };
 }
 
+function specialTabActiveStyle(active: boolean | undefined): CSSProperties | undefined {
+  if (!active) return undefined;
+  return isClassicLayout.value ? { boxShadow: "inset 0 -2px 0 var(--ring)" } : { borderColor: "var(--ring)" };
+}
+
 function tabIconClass(tab: QueryTab) {
   if (tab.externalSqlFileMissing) return "text-amber-600 dark:text-amber-400";
   if (tab.mode === "mq") return "";
@@ -764,7 +769,7 @@ function onOverflowItemKeydown(event: KeyboardEvent, tabId: string, kind: "regul
                     ? ['h-full border-r border-border/80 dark:border-border/45 font-medium', settingsPageActive ? 'bg-background text-foreground' : 'text-foreground/70 hover:text-foreground/90']
                     : ['h-7 rounded-md border font-medium', settingsPageActive ? 'border-ring text-foreground' : 'border-border/60 text-foreground/70 hover:border-border hover:text-foreground/90']
                 "
-                :style="isClassicLayout && settingsPageActive ? { boxShadow: '0 1px 0 0 var(--color-background)' } : {}"
+                :style="specialTabActiveStyle(settingsPageActive)"
                 :data-active-tab="settingsPageActive"
                 @click="emit('activate-settings-page')"
                 @mousedown.middle.prevent="emit('close-settings-page')"
@@ -791,7 +796,7 @@ function onOverflowItemKeydown(event: KeyboardEvent, tabId: string, kind: "regul
                     ? ['h-full border-r border-border/80 dark:border-border/45 font-medium', driverStoreActive ? 'bg-background text-foreground' : 'text-foreground/70 hover:text-foreground/90']
                     : ['h-7 rounded-md border font-medium', driverStoreActive ? 'border-ring text-foreground' : 'border-border/60 text-foreground/70 hover:border-border hover:text-foreground/90']
                 "
-                :style="isClassicLayout && driverStoreActive ? { boxShadow: '0 1px 0 0 var(--color-background)' } : {}"
+                :style="specialTabActiveStyle(driverStoreActive)"
                 :data-active-tab="driverStoreActive"
                 @click="emit('activate-driver-store')"
                 @mousedown.middle.prevent="emit('close-driver-store')"

--- a/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts
@@ -95,6 +95,15 @@ describe("AppTabBar right-side close action", () => {
   });
 });
 
+describe("AppTabBar special page selection", () => {
+  it("shows the active settings or driver-manager tab with the same ring used by regular tabs", () => {
+    expect(tabBarSource).toContain("function specialTabActiveStyle(active: boolean | undefined)");
+    expect(tabBarSource).toContain('return isClassicLayout.value ? { boxShadow: "inset 0 -2px 0 var(--ring)" } : { borderColor: "var(--ring)" };');
+    expect(tabBarSource).toContain(':style="specialTabActiveStyle(settingsPageActive)"');
+    expect(tabBarSource).toContain(':style="specialTabActiveStyle(driverStoreActive)"');
+  });
+});
+
 describe("AppTabBar overflow search", () => {
   it("filters every open tab by its display and source titles", () => {
     expect(tabBarSource).toContain('const tabSearchQuery = ref("");');

--- a/apps/desktop/src/lib/settings/__tests__/settingsPageNavigation.spec.ts
+++ b/apps/desktop/src/lib/settings/__tests__/settingsPageNavigation.spec.ts
@@ -5,6 +5,14 @@ const appSource = readFileSync(new URL("../../../App.vue", import.meta.url), "ut
 const settingsDialogSource = readFileSync(new URL("../../../components/editor/EditorSettingsDialog.vue", import.meta.url), "utf8");
 
 describe("settings page navigation", () => {
+  it("keeps query, settings, and driver-manager surfaces mutually exclusive", () => {
+    expect(appSource).toContain('type MainContentSurface = "query" | "settings" | "driverStore";');
+    expect(appSource).toMatch(/function activateMainContentSurface\(surface: MainContentSurface\) \{\s*settingsStore\.settingsPageActive = surface === "settings";\s*driverStoreActive\.value = surface === "driverStore";/);
+    expect(appSource).toMatch(/function activateSettingsPage\(\) \{\s*settingsPageTabOpen\.value = true;\s*activateMainContentSurface\("settings"\);/);
+    expect(appSource).toMatch(/function activateQuerySurface\(\) \{\s*activateMainContentSurface\("query"\);/);
+    expect(appSource).toMatch(/driverStoreTabOpen\.value = true;\s*activateMainContentSurface\("driverStore"\);/);
+  });
+
   it("replays repeated navigation requests for the same tab", () => {
     expect(appSource).toContain("settingsNavigationRequestId.value += 1");
     expect(appSource).toContain(':navigation-request-id="settingsNavigationRequestId"');


### PR DESCRIPTION
## 问题

驱动管理组件包含多个根节点，导致父组件写在组件上的 `v-show` 无法正确控制可见性。打开驱动管理后再进入设置页时，驱动管理内容仍会覆盖设置页；同时设置和驱动管理标签缺少清晰的选中状态。

## 修改

- 将驱动管理页面及其辅助弹窗收拢到单一根节点，恢复 `v-show` 的可见性控制
- 统一查询、设置、驱动管理三类主内容页的激活逻辑，确保状态互斥
- 为设置和驱动管理标签补充与普通标签一致的选中样式
- 新增驱动管理根节点结构和页面切换状态的回归测试

## 验证

- 浏览器实际验证：驱动管理、设置、普通查询之间切换时仅显示当前页面，标签选中状态正确
- 相关回归测试：4 个文件、30 项测试通过
- `pnpm check` 全部通过（connection-types、format、lint、typecheck、test）
- `git diff --check origin/main...HEAD`