### PR TITLE
fix(ssh): expand custom agent socket paths

### DIFF
--- a/crates/dbx-core/src/db/ssh_tunnel.rs
+++ b/crates/dbx-core/src/db/ssh_tunnel.rs
@@ -609,6 +609,11 @@ enum AgentAuthenticationOutcome {
     KeyboardInteractiveRequired,
 }
 
+#[cfg(unix)]
+fn resolve_ssh_agent_socket_path(path: &str) -> String {
+    expand_tilde(path)
+}
+
 /// Try to authenticate using ssh-agent identities. A key may be only the first
 /// successful factor, so preserve a server request to continue with
 /// keyboard-interactive instead of discarding it and trying the next identity.
@@ -627,12 +632,13 @@ async fn try_authenticate_with_agent(
             }
         }
     } else {
-        match AgentClient::connect_uds(ssh_agent_sock_path).await {
+        let resolved_path = resolve_ssh_agent_socket_path(ssh_agent_sock_path);
+        match AgentClient::connect_uds(&resolved_path).await {
             Ok(a) => a,
             Err(e) => {
                 return Err(format!(
                     "No SSH password or key provided, and ssh-agent at '{}' is unavailable: {e}",
-                    ssh_agent_sock_path
+                    resolved_path
                 ));
             }
         }
@@ -1863,6 +1869,8 @@ fn plan_chain(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use super::resolve_ssh_agent_socket_path;
     use super::SshClient;
     use super::PROMPT_TEST_LOCK;
     use super::{
@@ -1890,6 +1898,26 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
     use tokio::sync::mpsc;
     use tokio::time::{Duration, Instant};
+
+    #[cfg(unix)]
+    #[test]
+    fn ssh_agent_socket_path_expands_current_user_home() {
+        let home = std::env::var("HOME").expect("HOME should be set on Unix test environments");
+
+        assert_eq!(resolve_ssh_agent_socket_path("~/.ssh/agent.sock"), format!("{home}/.ssh/agent.sock"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ssh_agent_socket_path_preserves_absolute_path() {
+        assert_eq!(resolve_ssh_agent_socket_path("/tmp/agent.sock"), "/tmp/agent.sock");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ssh_agent_socket_path_preserves_named_user_path() {
+        assert_eq!(resolve_ssh_agent_socket_path("~other/.ssh/agent.sock"), "~other/.ssh/agent.sock");
+    }
 
     #[test]
     fn tofu_prompt_deadline_uses_the_actual_prompt_start() {


### PR DESCRIPTION
## 变更说明

修复 Unix 平台下自定义 SSH Agent Socket 路径不会展开 `~` 的问题。此前连接配置和界面允许填写 `~/.ssh/agent.sock`，但该值会被原样传给 Unix Socket API，最终因查找字面量 `~` 目录而连接失败。

- 在建立自定义 SSH Agent Socket 连接前复用现有的 tilde 展开逻辑
- 仅在运行时解析路径，连接配置仍保留可迁移的 `~/.ssh/...` 写法
- 连接失败时展示实际解析后的 Socket 路径，便于定位问题
- 保持空路径继续使用 `SSH_AUTH_SOCK`，绝对路径行为不变
- 不影响 Windows Pageant 认证路径
- 固定 SSH 隧道、SOCKS5 代理和多跳 SSH 链路通过共享认证入口统一获得修复

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端代码改动。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `cargo test -p dbx-core ssh_agent_socket_path --lib`：3 个回归测试通过，覆盖 `~/...` 展开、绝对路径保持不变和 `~user/...` 保持现有语义
- 源码版 Web E2E：通过自定义 `~/.ssh/dbx-issue-7032-agent.sock` 经 SSH 隧道连接 Docker MySQL 成功
- 绝对 Agent Socket 路径回归连接成功
- 不存在的 `~/...` 路径会在错误中展示展开后的实际绝对路径
- Desktop 手动 E2E：连接配置保留 `~/.ssh/...`，连接测试成功

### Desktop 手动验证

<img width="1352" height="848" alt="截屏2026-08-24 19 20 37" src="https://github.com/user-attachments/assets/27ea9810-2ab8-4cb4-8463-e56c60835579" />

## 关联 Issue

Close #7032

Related #1384
