### PR TITLE
fix(formatter): 保留 ClickHouse 日期缩写别名大小写

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -124,6 +124,42 @@ OR inside$$ as note
     expect(formatted).toContain("x -> dictGet");
     expect(formatted).not.toContain("- >");
   });
+
+  it("preserves the ClickHouse table alias from issue #7079", async () => {
+    const formatted = await formatSqlText("SELECT *\nFROM MATERIAL m\nLIMIT 100;", sqlFormatDialectForDbType("clickhouse"));
+
+    expect(formatted).toBe("SELECT\n  *\nFROM\n  MATERIAL m\nLIMIT\n  100;");
+  });
+
+  it.each(["d", "dd", "h", "hh", "m", "mcs", "mi", "mm", "ms", "n", "ns", "q", "qq", "s", "ss", "wk", "ww", "yy", "yyyy"])("preserves ClickHouse identifier-like date part %s while formatting keywords", async (identifier) => {
+    const formatted = await formatSqlText(`select ${identifier}, t.${identifier} from material ${identifier} limit 100;`, sqlFormatDialectForDbType("clickhouse"));
+
+    expect(formatted).toContain(`  ${identifier},`);
+    expect(formatted).toContain(`material ${identifier}`);
+    expect(formatted).toContain("SELECT");
+    expect(formatted).toContain("FROM");
+    expect(formatted).toContain("LIMIT");
+  });
+
+  it("keeps ClickHouse identifier casing independent from keyword casing", async () => {
+    const sql = "SELECT * FROM MATERIAL M LIMIT 100;";
+
+    const lowerKeywords = await formatSqlText(sql, sqlFormatDialectForDbType("clickhouse"), { keywordCase: "lower", identifierCase: "preserve" });
+    const lowerIdentifiers = await formatSqlText(sql, sqlFormatDialectForDbType("clickhouse"), { keywordCase: "upper", identifierCase: "lower" });
+
+    expect(lowerKeywords).toContain("from\n  MATERIAL M");
+    expect(lowerKeywords).toContain("limit\n  100");
+    expect(lowerIdentifiers).toContain("FROM\n  material m");
+    expect(lowerIdentifiers).toContain("LIMIT\n  100");
+  });
+
+  it("still formats unambiguous ClickHouse interval keywords", async () => {
+    const formatted = await formatSqlText("select now() + interval 1 minutes from source_table m;", sqlFormatDialectForDbType("clickhouse"));
+
+    expect(formatted).toContain("INTERVAL 1 MINUTES");
+    expect(formatted).toContain("FROM\n  source_table m");
+  });
+
   it("preserves DBX brace placeholders in generic and MySQL SQL", async () => {
     const sql = "SELECT ${x} AS shell_value, #{x} AS mybatis_value, '${date}' AS quoted_value";
 

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -5,6 +5,27 @@ export type SqlFormatDialect = "mysql" | "postgres" | "sqlite" | "sqlserver" | "
 
 export const MAX_SQL_FORMAT_CHARS = 1_000_000;
 
+type SqlFormatterModule = typeof import("sql-formatter");
+
+// sql-formatter classifies ClickHouse date-part abbreviations as reserved
+// keywords even where ClickHouse accepts them as ordinary identifiers. Keep
+// them identifier-like so keyword casing cannot rewrite aliases such as `m`.
+const CLICKHOUSE_IDENTIFIER_LIKE_DATE_PARTS = new Set(["D", "DD", "H", "HH", "M", "MCS", "MI", "MM", "MS", "N", "NS", "Q", "QQ", "S", "SS", "WK", "WW", "YY", "YYYY"]);
+let clickHouseIdentifierSafeDialect: SqlFormatterModule["clickhouse"] | null = null;
+
+function resolveClickHouseIdentifierSafeDialect(sqlFormatter: SqlFormatterModule): SqlFormatterModule["clickhouse"] {
+  if (clickHouseIdentifierSafeDialect) return clickHouseIdentifierSafeDialect;
+
+  clickHouseIdentifierSafeDialect = {
+    ...sqlFormatter.clickhouse,
+    tokenizerOptions: {
+      ...sqlFormatter.clickhouse.tokenizerOptions,
+      reservedKeywords: sqlFormatter.clickhouse.tokenizerOptions.reservedKeywords.filter((keyword) => !CLICKHOUSE_IDENTIFIER_LIKE_DATE_PARTS.has(keyword)),
+    },
+  };
+  return clickHouseIdentifierSafeDialect;
+}
+
 export function canFormatSqlForDatabaseType(dbType: string | null | undefined): boolean {
   return dbType !== "victoriametrics";
 }
@@ -223,7 +244,8 @@ export async function formatSqlText(sql: string, dialect: SqlFormatDialect = "ge
     throw new UnsupportedStructuredInputError("xml");
   }
 
-  const { format } = await import("sql-formatter");
+  const sqlFormatter = await import("sql-formatter");
+  const { format, formatDialect } = sqlFormatter;
   const normalizedSettings = normalizeSqlFormatterSettings(settings);
   const options = sqlFormatterOptions(normalizedSettings);
   const language = formatterLanguage(dialect);
@@ -244,6 +266,9 @@ export async function formatSqlText(sql: string, dialect: SqlFormatDialect = "ge
       : options;
   const formatWithFallback = (input: string): string => {
     try {
+      if (dialect === "clickhouse") {
+        return formatDialect(input, { ...formatterOptions, dialect: resolveClickHouseIdentifierSafeDialect(sqlFormatter) });
+      }
       return format(input, { language, ...formatterOptions });
     } catch (err) {
       // The generic "sql" dialect can't parse many real-world constructs (PostgreSQL


### PR DESCRIPTION
## 问题

`sql-formatter` 的 ClickHouse 方言将 `M`、`MS`、`D` 等日期/时间缩写归类为保留关键字。启用关键字大写时，普通别名 `m` 会被改写为 `M`，但限定列引用 `m.column` 仍保持原样，可能直接导致查询失败。

## 修复

- 基于 `sql-formatter` 公开的 `formatDialect` API 创建 ClickHouse 方言配置
- 将可作为普通标识符的日期/时间缩写从保留关键字集合中移除
- 保持真正的 ClickHouse 结构关键字继续遵循关键字大小写设置
- 标识符仍独立遵循“保持/大写/小写”配置
- 缓存派生方言，避免重复构造 tokenizer

## 验证

- `pnpm check`：connection-types、format、lint、typecheck、全部测试通过
- formatter 相关测试：5 个文件，135 个测试通过
- 新增 issue 原始 SQL、19 种同类缩写、大小写设置独立性和 `INTERVAL` 关键字回归覆盖
- 真实 ClickHouse `24.8.14.39`：
  - 原始 `system.one m` 查询成功
  - 修复后格式化 SQL 查询成功
  - 旧行为生成“声明为 `M`、引用为 `m`”的 SQL 返回 `UNKNOWN_IDENTIFIER`（code 47）

格式化发生在客户端，与 issue 中服务端 `26.7.5.10` 的版本差异无关。

Closes #7079