### PR TITLE
fix(kingbase): 显示表结构字符字段长度

### DIFF
--- a/agents/drivers/kingbase-go/integration_test.go
+++ b/agents/drivers/kingbase-go/integration_test.go
@@ -58,7 +58,7 @@ func TestKingbaseIntegration(t *testing.T) {
 		}
 	})
 
-	mustExecute(t, server, "CREATE TABLE "+qualifiedSchema+"."+quoteIdentifier(parent)+" (id integer PRIMARY KEY, name varchar(64) NOT NULL)")
+	mustExecute(t, server, "CREATE TABLE "+qualifiedSchema+"."+quoteIdentifier(parent)+" (id integer PRIMARY KEY, name varchar(64) NOT NULL, code character(32))")
 	mustExecute(t, server, "COMMENT ON TABLE "+qualifiedSchema+"."+quoteIdentifier(parent)+" IS '订单父表'")
 	mustExecute(t, server, "COMMENT ON COLUMN "+qualifiedSchema+"."+quoteIdentifier(parent)+".id IS '主键编号'")
 	mustExecute(t, server, "COMMENT ON COLUMN "+qualifiedSchema+"."+quoteIdentifier(parent)+".name IS '客户''名称'")
@@ -76,8 +76,14 @@ func TestKingbaseIntegration(t *testing.T) {
 		t.Fatalf("get columns failed: columns=%v err=%v", columns, err)
 	}
 	parentColumns, err := server.getColumns(schema, parent)
-	if err != nil || len(parentColumns) != 2 || parentColumns[0].Comment == nil || *parentColumns[0].Comment != "主键编号" || parentColumns[1].Comment == nil || *parentColumns[1].Comment != "客户'名称" {
+	if err != nil || len(parentColumns) != 3 || parentColumns[0].Comment == nil || *parentColumns[0].Comment != "主键编号" || parentColumns[1].Comment == nil || *parentColumns[1].Comment != "客户'名称" {
 		t.Fatalf("get commented columns failed: columns=%v err=%v", parentColumns, err)
+	}
+	if parentColumns[1].DataType != "character varying(64)" || parentColumns[1].CharacterMaximumLength == nil || *parentColumns[1].CharacterMaximumLength != 64 {
+		t.Fatalf("varchar length metadata mismatch: column=%+v", parentColumns[1])
+	}
+	if parentColumns[2].DataType != "character(32)" || parentColumns[2].CharacterMaximumLength == nil || *parentColumns[2].CharacterMaximumLength != 32 {
+		t.Fatalf("character length metadata mismatch: column=%+v", parentColumns[2])
 	}
 	ddl, err := server.getTableDDL(schema, parent)
 	if err != nil {

--- a/apps/desktop/src/lib/__tests__/table/tableStructureEditorState.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/tableStructureEditorState.spec.ts
@@ -76,6 +76,15 @@ describe("tableStructureEditorState", () => {
           character_maximum_length: 255,
         },
         {
+          name: "fixed_code",
+          data_type: "bpchar",
+          is_nullable: true,
+          column_default: null,
+          is_primary_key: false,
+          extra: null,
+          character_maximum_length: 32,
+        },
+        {
           name: "amount",
           data_type: "numeric",
           is_nullable: false,
@@ -108,9 +117,10 @@ describe("tableStructureEditorState", () => {
       "kingbase",
     );
 
-    expect(columns.map((column) => column.dataType)).toEqual(["varchar(255)", "numeric(12,2)", "integer", "character varying(64)"]);
-    expect(columns.map((column) => column.original?.data_type)).toEqual(["varchar(255)", "numeric(12,2)", "integer", "character varying(64)"]);
+    expect(columns.map((column) => column.dataType)).toEqual(["varchar(255)", "bpchar(32)", "numeric(12,2)", "integer", "character varying(64)"]);
+    expect(columns.map((column) => column.original?.data_type)).toEqual(["varchar(255)", "bpchar(32)", "numeric(12,2)", "integer", "character varying(64)"]);
     expect(dataTypeLengthInputValue("kingbase", columns[0]?.dataType ?? "")).toBe("255");
+    expect(dataTypeLengthInputValue("kingbase", columns[1]?.dataType ?? "")).toBe("32");
   });
 
   it("turns copied metadata into new column drafts instead of existing columns", () => {

--- a/apps/desktop/src/lib/table/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorState.ts
@@ -822,7 +822,7 @@ function columnDefaultForEditor(column: ColumnInfo, databaseType?: DatabaseType)
   return defaultValue;
 }
 
-const CHARACTER_LENGTH_METADATA_TYPES = new Set(["binary", "char", "character", "character varying", "nchar", "nvarchar", "nvarchar2", "varbinary", "varchar", "varchar2"]);
+const CHARACTER_LENGTH_METADATA_TYPES = new Set(["binary", "bpchar", "char", "character", "character varying", "nchar", "nvarchar", "nvarchar2", "varbinary", "varchar", "varchar2"]);
 const NUMERIC_PRECISION_METADATA_TYPES = new Set(["decimal", "number", "numeric"]);
 const XUGU_SINGLE_PRECISION_METADATA_TYPES = new Set(["bit", "time", "time with time zone", "timestamp", "timestamp with time zone", "varbit"]);
 


### PR DESCRIPTION
## 问题

KingbaseES V9 的列元数据可能使用内部类型名 `bpchar`，并通过 `character_maximum_length` 单独返回长度。表结构编辑器的字符长度类型集合遗漏了 `bpchar`，导致 DDL 中可见 `character(n)`，但“字段”页长度为空。

## 修改

- 将 `bpchar` 纳入表结构编辑器的字符长度元数据类型
- 增加 `bpchar + character_maximum_length` 前端回归覆盖
- 扩展 Kingbase 集成测试，同时校验 `varchar(64)` 和 `character(32)` 的类型及长度元数据

## 实际验证

在真实 `KingbaseES V009R001C010` 实例上创建临时测试表并通过当前 Kingbase Go Agent 读取，确认：

- `varchar(64)` 返回 `character varying(64)`，长度为 `64`
- `character(32)` 返回 `character(32)`，长度为 `32`
- 测试结束后临时对象由集成测试自动清理

通过：

- `pnpm vitest run apps/desktop/src/lib/__tests__/table/tableStructureEditorState.spec.ts`：36/36
- `go test ./...`（`agents/drivers/kingbase-go`）
- `go test -run TestKingbaseIntegration -v`（真实 KingbaseES V9）
- `pnpm typecheck`
