### PR TITLE
fix(backup): 隐藏不支持的数据库备份入口

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -174,6 +174,7 @@ import { runBatchTableTruncate } from "@/lib/table/batchTableTruncate";
 import { runBatchTableDrop } from "@/lib/table/batchTableDrop";
 import { buildSidebarDdlTemplateSql, sidebarDdlTargetsForExecutionContext } from "@/lib/sidebar/sidebarDdlTemplate";
 import { sidebarStructureExportTargets } from "@/lib/sidebar/sidebarExportRuntime";
+import { supportsScheduledDatabaseBackup } from "@/lib/backup/scheduledDatabaseBackup";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { rankSavedSqlHistory, type SavedSqlHistoryScope } from "@/lib/savedSql/savedSqlHistory";
@@ -4076,6 +4077,10 @@ const canExportAllDatabases = computed(() => {
   return !["redis", "mongodb", "dynamodb", "elasticsearch", "easysearch", "meilisearch", "qdrant", "milvus", "weaviate", "chromadb", "etcd", "zookeeper", "consul", "mq", "nacos"].includes(dbType || "");
 });
 
+const canOpenScheduledBackups = computed(() => {
+  return isTauriRuntime() && supportsScheduledDatabaseBackup(currentDatabaseType());
+});
+
 const canOpenDiagram = computed(() => {
   return !!activeNode.value.database && supportsSchemaDiagram(currentDatabaseType());
 });
@@ -4872,9 +4877,9 @@ function buildConnectionSidebarMenu(context: SidebarMenuFactoryContext): boolean
     }
     if (canExportAllDatabases.value) {
       items.push({ label: t("contextMenu.exportAllDatabases"), action: openAllDatabasesExport, icon: Upload });
-      if (isTauriRuntime()) {
-        items.push({ label: t("databaseBackup.title"), action: openScheduledBackups, icon: CalendarClock });
-      }
+    }
+    if (canOpenScheduledBackups.value) {
+      items.push({ label: t("databaseBackup.title"), action: openScheduledBackups, icon: CalendarClock });
     }
     if (canCreateDatabase.value) {
       items.push({

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -4078,7 +4078,10 @@ const canExportAllDatabases = computed(() => {
 });
 
 const canOpenScheduledBackups = computed(() => {
-  return isTauriRuntime() && supportsScheduledDatabaseBackup(currentDatabaseType());
+  // Match the backup page/engine, which filter and key off the raw db_type
+  // (effectiveDatabaseTypeForConnection maps gbase/mysql-dialect jdbc to "mysql",
+  // which would show an entry the backup dialog then can't list).
+  return isTauriRuntime() && supportsScheduledDatabaseBackup(rawDatabaseType());
 });
 
 const canOpenDiagram = computed(() => {

--- a/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.backupMenu.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.backupMenu.spec.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../SidebarTreeRuntimeHost.vue", import.meta.url), "utf8");
+
+describe("SidebarTreeRuntimeHost database backup menu", () => {
+  it("uses the database backup support matrix independently from full-database export", () => {
+    expect(source).toMatch(/const canOpenScheduledBackups = computed\(\(\) => \{[\s\S]*supportsScheduledDatabaseBackup\(currentDatabaseType\(\)\)/);
+    expect(source).toMatch(/if \(canOpenScheduledBackups\.value\) \{[\s\S]*action: openScheduledBackups/);
+  });
+});

--- a/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.backupMenu.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.backupMenu.spec.ts
@@ -5,7 +5,7 @@ const source = readFileSync(new URL("../SidebarTreeRuntimeHost.vue", import.meta
 
 describe("SidebarTreeRuntimeHost database backup menu", () => {
   it("uses the database backup support matrix independently from full-database export", () => {
-    expect(source).toMatch(/const canOpenScheduledBackups = computed\(\(\) => \{[\s\S]*supportsScheduledDatabaseBackup\(currentDatabaseType\(\)\)/);
+    expect(source).toMatch(/const canOpenScheduledBackups = computed\(\(\) => \{[\s\S]*supportsScheduledDatabaseBackup\(rawDatabaseType\(\)\)/);
     expect(source).toMatch(/if \(canOpenScheduledBackups\.value\) \{[\s\S]*action: openScheduledBackups/);
   });
 });

--- a/packages/app-tests/scheduledDatabaseBackup.test.ts
+++ b/packages/app-tests/scheduledDatabaseBackup.test.ts
@@ -268,6 +268,7 @@ test("explicit backup databases fail when any configured target is missing", () 
 test("scheduled backups are limited to databases with consistent snapshot support", () => {
   assert.equal(supportsScheduledDatabaseBackup("postgres"), true);
   assert.equal(supportsScheduledDatabaseBackup("mysql"), true);
+  assert.equal(supportsScheduledDatabaseBackup("dameng"), false);
   assert.equal(supportsScheduledDatabaseBackup("sqlite"), false);
   assert.equal(supportsScheduledDatabaseBackup("sqlserver"), false);
 });


### PR DESCRIPTION
## 问题

连接右键菜单把“数据库备份”嵌套在“可导出全部数据库”的判断中。达梦支持导出全部数据库，因此桌面端会显示备份入口；但备份引擎和备份页连接下拉框目前只支持 MySQL、PostgreSQL，进入页面后自然找不到刚才的达梦连接。

## 修复

- 将数据库备份入口与导出全部数据库能力拆开
- 仅在桌面端且连接类型通过 `supportsScheduledDatabaseBackup` 支持矩阵时显示备份入口
- 保留达梦原有“导出全部数据库”功能
- 增加侧栏菜单接入支持矩阵的回归测试
- 明确断言达梦不支持一致性数据库备份

## 验证

修复前新增侧栏回归失败，确认当前 main 仍把备份入口绑定在通用导出条件下；修复后通过。

- 备份配置、调度、组件、侧栏及 app-tests：5 个测试文件，43/43 通过
- `pnpm typecheck`
- 目标文件 `oxlint`
- 目标文件 `oxfmt --check`

Fixes #6891
