### PR TITLE
fix(sql): 保留带引号参数占位符的字符串语义

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -60,7 +60,7 @@ describe("extractSqlParameters", () => {
     `;
     expect(extractSqlParameters(sql)).toEqual(["quoted", "identifier", "embedded", "partial", "id"]);
     expect(extractSqlParameterDescriptors("select * from t where dt='${date}' and flag=\"#{enabled}\"")).toEqual([
-      { key: "date", name: "date", syntax: "shell", token: "'${date}'" },
+      { key: "date", name: "date", syntax: "shell", token: "${date}" },
       { key: "enabled", name: "enabled", syntax: "mybatis", token: '"#{enabled}"' },
     ]);
   });
@@ -877,7 +877,7 @@ describe("substituteSqlParameters", () => {
     ).toBe("select * from t where dt >= '2026-06-26' and amount > 100.50 and enabled = TRUE");
   });
 
-  it("replaces exact quoted braced placeholders as whole tokens without double-quoting", () => {
+  it("preserves single-quoted string contexts for exact braced placeholders", () => {
     const sql = "select * from t where dt = '${date}' and name = \"${name}\" and flag = '#{enabled}' and id = ${id}";
     expect(
       substituteSqlParameters(sql, {
@@ -886,7 +886,17 @@ describe("substituteSqlParameters", () => {
         enabled: { kind: "boolean", value: "true" },
         id: { kind: "number", value: "7" },
       }),
-    ).toBe("select * from t where dt = '2026-06-26' and name = 'O''Reilly' and flag = TRUE and id = 7");
+    ).toBe("select * from t where dt = '2026-06-26' and name = 'O''Reilly' and flag = 'true' and id = 7");
+  });
+
+  it("keeps explicit quotes around raw and numeric parameter values", () => {
+    const sql = "select ${raw_value}, '${raw_value}', ${number_value}, '${number_value}'";
+    expect(
+      substituteSqlParameters(sql, {
+        raw_value: { kind: "raw", value: "current_date" },
+        number_value: { kind: "number", value: "42" },
+      }),
+    ).toBe("select current_date, 'current_date', 42, '42'");
   });
 
   it("replaces placeholders embedded in ordinary SQL string values", () => {

--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -60,7 +60,7 @@ describe("extractSqlParameters", () => {
     `;
     expect(extractSqlParameters(sql)).toEqual(["quoted", "identifier", "embedded", "partial", "id"]);
     expect(extractSqlParameterDescriptors("select * from t where dt='${date}' and flag=\"#{enabled}\"")).toEqual([
-      { key: "date", name: "date", syntax: "shell", token: "${date}" },
+      { key: "date", name: "date", syntax: "shell", token: "'${date}'" },
       { key: "enabled", name: "enabled", syntax: "mybatis", token: '"#{enabled}"' },
     ]);
   });
@@ -897,6 +897,18 @@ describe("substituteSqlParameters", () => {
         number_value: { kind: "number", value: "42" },
       }),
     ).toBe("select current_date, 'current_date', 42, '42'");
+  });
+
+  it("replaces exact quoted null and empty typed values with SQL NULL", () => {
+    const sql = "select '${null_value}', '${empty_number}', '${empty_raw}', '${empty_string}'";
+    expect(
+      substituteSqlParameters(sql, {
+        null_value: { kind: "null", value: "NULL" },
+        empty_number: { kind: "number", value: "" },
+        empty_raw: { kind: "raw", value: "  " },
+        empty_string: { kind: "string", value: "" },
+      }),
+    ).toBe("select NULL, NULL, NULL, ''");
   });
 
   it("replaces placeholders embedded in ordinary SQL string values", () => {

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -25,7 +25,7 @@ export interface SqlBracedParameter extends SqlParameterDescriptor {
 interface ParameterOccurrence extends SqlParameterDescriptor {
   start: number;
   end: number;
-  replacement?: "string-fragment" | "mybatis-foreach" | "mybatis-where";
+  replacement?: "string-fragment" | "quoted-string" | "mybatis-foreach" | "mybatis-where";
   foreach?: MyBatisForeach;
   where?: MyBatisWhere;
 }
@@ -223,7 +223,7 @@ export function substituteSqlParameters(sql: string, values: Record<string, SqlP
     }
     // Embedded placeholders stay inside the surrounding SQL string, so their value
     // must be escaped as text instead of being wrapped in a second SQL literal.
-    result += occurrence.replacement === "string-fragment" ? sqlParameterStringFragment(input) : sqlParameterLiteral(input);
+    result += occurrence.replacement === "string-fragment" ? sqlParameterStringFragment(input) : occurrence.replacement === "quoted-string" ? sqlParameterQuotedString(input) : sqlParameterLiteral(input);
     cursor = occurrence.end;
   }
   result += sql.slice(cursor);
@@ -428,11 +428,7 @@ function findSqlParameterOccurrences(sql: string, options?: SqlParameterOptions)
     }
 
     if (ch === "'" || ch === '"') {
-      // Double-quoted exact placeholders retain their historical typed-literal
-      // behavior. Single quotes define a string context, including when the
-      // placeholder occupies the whole string, so interpolation below must
-      // preserve those quotes.
-      const quoted = ch === '"' ? tryReadQuotedBracedPlaceholder(sql, i, ch, isSyntaxEnabled) : null;
+      const quoted = tryReadQuotedBracedPlaceholder(sql, i, ch, isSyntaxEnabled);
       if (quoted) {
         occurrences.push(quoted);
         i = quoted.end;
@@ -1585,6 +1581,7 @@ function tryReadQuotedBracedPlaceholder(sql: string, start: number, quote: "'" |
     name,
     syntax,
     token: sql.slice(start, end),
+    ...(quote === "\'" ? { replacement: "quoted-string" as const } : {}),
     start,
     end,
   };
@@ -1745,6 +1742,11 @@ function quoteSqlString(value: string): string {
 
 function sqlParameterStringFragment(input: SqlParameterInput): string {
   return input.value.replace(/'/g, "''");
+}
+
+function sqlParameterQuotedString(input: SqlParameterInput): string {
+  if (input.kind === "null" || ((input.kind === "number" || input.kind === "raw") && !input.value.trim())) return "NULL";
+  return quoteSqlString(input.value);
 }
 
 function normalizeBooleanLiteral(value: string): string {

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -428,9 +428,11 @@ function findSqlParameterOccurrences(sql: string, options?: SqlParameterOptions)
     }
 
     if (ch === "'" || ch === '"') {
-      // Exact quoted placeholders use SQL-literal replacement; embedded placeholders
-      // in ordinary single-quoted values use escaped text replacement below.
-      const quoted = tryReadQuotedBracedPlaceholder(sql, i, ch as "'" | '"', isSyntaxEnabled);
+      // Double-quoted exact placeholders retain their historical typed-literal
+      // behavior. Single quotes define a string context, including when the
+      // placeholder occupies the whole string, so interpolation below must
+      // preserve those quotes.
+      const quoted = ch === '"' ? tryReadQuotedBracedPlaceholder(sql, i, ch, isSyntaxEnabled) : null;
       if (quoted) {
         occurrences.push(quoted);
         i = quoted.end;


### PR DESCRIPTION
## 修改

- 单引号内的 `${name}` / `#{name}` 保留原有字符串边界
- 参数值按字符串片段转义，避免原始 SQL、数字和布尔参数移除显式引号
- 保持未加引号及双引号占位符的现有行为

## 验证

- `pnpm vitest run apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts`
- `pnpm typecheck`
- PostgreSQL 16 实测：原始 SQL 参数 `abc=123` 生成并成功执行 `SELECT 123::int, '123'::text`

Fixes #7093
