### PR TITLE
feature(connection): 允许保留连接失败的一次性连接

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -5190,7 +5190,8 @@ async function save() {
         .catch((e: any) => {
           const message = String(e?.message || e);
           if (message.includes(CONNECTION_ATTEMPT_CANCELLED_MESSAGE)) return;
-          if (config.one_time) void store.removeConnection(config.id);
+          // Keep failed one-time connections available for retry and error inspection.
+          // They are still removed by connectionStore.disconnect after a successful session.
           emit("connectFailed", appendConnectionErrorHints(config, mongodbAuthFailureHint(message), t));
         });
       return;

--- a/apps/desktop/src/lib/__tests__/connection/connectionDialog.deepLinkServices.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/connectionDialog.deepLinkServices.spec.ts
@@ -31,4 +31,13 @@ describe("ConnectionDialog service deep-link hydration", () => {
     expect(applyBody).toContain("parseConnectionDeepLink(input) ?? parseServiceConnectionUrl(input)");
     expect(applyBody.indexOf("applyConnectionDraftToForm")).toBeLessThan(applyBody.indexOf("parseConnectionUrl(input"));
   });
+
+  it("keeps failed one-time connections available for error inspection and retry", () => {
+    const saveStart = source.indexOf("async function save()");
+    const saveEnd = source.indexOf('const dialogTitle = ref("")', saveStart);
+    const saveBody = source.slice(saveStart, saveEnd);
+
+    expect(saveBody).not.toContain("store.removeConnection(config.id)");
+    expect(saveBody).toContain('emit("connectFailed"');
+  });
 });


### PR DESCRIPTION
## 修改内容
- 一次性连接失败后保留连接配置，便于修改参数并重试
- 保留侧边栏连接错误状态，可查看完整错误详情
- 成功连接后的断开流程仍会自动清理一次性连接

## 验证
- MySQL 实测连接拒绝场景，失败连接和完整错误详情均保留
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/connection/connectionDialog.deepLinkServices.spec.ts apps/desktop/src/stores/__tests__/connectionStore.oneTimeCleanup.spec.ts`（11 个用例通过）
- `pnpm typecheck`
- Oxlint、Oxfmt、`git diff --check`

## 截图
![一次性连接失败后仍可查看完整错误](https://raw.githubusercontent.com/zipg/dbx/pr-assets-7041/.github/pr-assets/7041/one-time-connection-error-detail.png)

Closes #7041