### PR TITLE
fix(grid): work around WKWebView stale canvas layer on right-click

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4265,7 +4265,7 @@ function cellTextOverflowsElement(text: string, target: EventTarget | null): boo
 }
 
 function measureCellTextWidth(text: string, font: string): number {
-  const canvas = canvasRef.value ?? document.createElement("canvas");
+  const canvas = activeCanvasSurface() ?? document.createElement("canvas");
   const context = canvas.getContext("2d");
   if (!context) return 0;
   context.save();
@@ -6878,6 +6878,17 @@ function dataGridRowStyle(item: RowItem): CSSProperties {
 }
 
 const canvasRef = ref<HTMLCanvasElement>();
+const canvasBackRef = ref<HTMLCanvasElement>();
+// WKWebView（macOS）会为 canvas 元素滞留幽灵合成层：屏幕显示旧帧位图，2D 缓冲重绘
+// （甚至改尺寸）都无法清除，只有把显示元素换掉才有效。双 canvas 交替翻转：绘制进
+// 隐藏的那一张，画完移交可见性，幽灵层随旧元素的 display:none 一并废弃。
+const canvasUsingBackSurface = ref(false);
+function activeCanvasSurface(): HTMLCanvasElement | null {
+  return (canvasUsingBackSurface.value ? canvasBackRef.value : canvasRef.value) ?? null;
+}
+function inactiveCanvasSurface(): HTMLCanvasElement | null {
+  return (canvasUsingBackSurface.value ? canvasRef.value : canvasBackRef.value) ?? null;
+}
 const canvasOverlayRef = ref<HTMLElement>();
 const canvasViewportWidth = ref(0);
 const canvasViewportHeight = ref(0);
@@ -6985,7 +6996,7 @@ function syncCanvasViewport(entries?: readonly ResizeObserverEntry[]) {
   if (!dataGridIsActive) return;
   const scroller = canvasScrollerElement();
   if (!scroller) return;
-  const canvas = canvasRef.value;
+  const canvas = activeCanvasSurface();
   const canvasEntry = canvas ? entries?.find((entry) => entry.target === canvas) : undefined;
   if (canvasEntry) canvasMeasuredDevicePixelSize.value = dataGridCanvasDevicePixelSize(canvasEntry);
   canvasViewportWidth.value = scroller.clientWidth;
@@ -7048,7 +7059,7 @@ canvasRuntime = useDataGridCanvasRuntime({
   draw: drawCanvasGrid,
   syncViewport: syncCanvasViewport,
   getViewport: canvasScrollerElement,
-  getSurface: () => canvasRef.value ?? null,
+  getSurface: () => activeCanvasSurface(),
   refreshPixelRatio: () => {
     const next = currentCanvasDevicePixelRatio();
     if (Math.abs(next - canvasDevicePixelRatio.value) > 0.001) {
@@ -7074,7 +7085,7 @@ function canvasColumnAt(contentX: number): number {
 }
 
 function canvasHitTest(event: MouseEvent): { rowIndex: number; visibleColIdx: number; rowNumber: boolean } | null {
-  const canvas = canvasRef.value;
+  const canvas = activeCanvasSurface();
   const scroller = canvasScrollerElement();
   if (!canvas || !scroller) return null;
   const rect = canvas.getBoundingClientRect();
@@ -7189,7 +7200,8 @@ function onDomGridWheel(event: WheelEvent) {
 function onCanvasMouseMove(event: MouseEvent) {
   stopReleasedSelectionGesture(event);
   if (columnHeaderPointerInteractionActive()) {
-    if (canvasRef.value) canvasRef.value.style.cursor = "default";
+    const cursorSurface = activeCanvasSurface();
+    if (cursorSurface) cursorSurface.style.cursor = "default";
     onCanvasMouseLeave();
     return;
   }
@@ -7203,10 +7215,11 @@ function onCanvasMouseMove(event: MouseEvent) {
         }
       : null;
   const actualColIdx = next ? visibleColumnIndexes.value[next.visibleColIdx] : undefined;
-  if (canvasRef.value) {
+  const cursorSurface = activeCanvasSurface();
+  if (cursorSurface) {
     const overBooleanInteractive =
       booleanCellsUseCheckbox.value && hit != null && !hit.rowNumber && hitItem != null && actualColIdx !== undefined && isBooleanGridCell(hitItem, actualColIdx) && canEditCellItem(hitItem, actualColIdx) && booleanInteractiveHitFromCanvasEvent(hitItem, hit, actualColIdx, event);
-    canvasRef.value.style.cursor = hit?.rowNumber ? "default" : overBooleanInteractive ? "pointer" : hitItem && actualColIdx !== undefined ? "text" : "cell";
+    cursorSurface.style.cursor = hit?.rowNumber ? "default" : overBooleanInteractive ? "pointer" : hitItem && actualColIdx !== undefined ? "text" : "cell";
   }
   if (next?.rowIndex === canvasHoverCell.value?.rowIndex && next?.visibleColIdx === canvasHoverCell.value?.visibleColIdx) {
     return;
@@ -7246,7 +7259,7 @@ function keepCanvasDetailHover() {
 
 function clearCanvasDetailHover(event?: MouseEvent) {
   const relatedTarget = event?.relatedTarget;
-  if (relatedTarget instanceof Node && (canvasOverlayRef.value?.contains(relatedTarget) || canvasRef.value?.contains(relatedTarget))) {
+  if (relatedTarget instanceof Node && (canvasOverlayRef.value?.contains(relatedTarget) || activeCanvasSurface()?.contains(relatedTarget) || canvasBackRef.value?.contains(relatedTarget))) {
     return;
   }
   onCanvasMouseLeave();
@@ -7254,7 +7267,7 @@ function clearCanvasDetailHover(event?: MouseEvent) {
 
 function booleanCheckboxHitFromCanvasEvent(item: RowItem, hit: { rowIndex: number; visibleColIdx: number }, actualColIdx: number, event: MouseEvent): boolean {
   if (item.data[actualColIdx] === null) return false;
-  const canvas = canvasRef.value;
+  const canvas = activeCanvasSurface();
   const canvasRect = canvas?.getBoundingClientRect();
   const cellRect = canvasCellViewportRect(hit.rowIndex, hit.visibleColIdx);
   if (!canvasRect || !cellRect) return false;
@@ -7271,7 +7284,7 @@ function booleanCheckboxHitFromCanvasEvent(item: RowItem, hit: { rowIndex: numbe
 
 function booleanNullTextHitFromCanvasEvent(item: RowItem, hit: { rowIndex: number; visibleColIdx: number }, actualColIdx: number, event: MouseEvent): boolean {
   if (item.data[actualColIdx] !== null) return false;
-  const canvas = canvasRef.value;
+  const canvas = activeCanvasSurface();
   const canvasRect = canvas?.getBoundingClientRect();
   const cellRect = canvasCellViewportRect(hit.rowIndex, hit.visibleColIdx);
   if (!canvasRect || !cellRect) return false;
@@ -7527,7 +7540,7 @@ const canvasRightAlignedActionCell = computed(() => {
 });
 
 function drawCanvasGrid() {
-  const canvas = canvasRef.value;
+  const canvas = inactiveCanvasSurface();
   const scroller = canvasScrollerElement();
   if (!canvas || !scroller || !useCanvasGridRows.value) return;
 
@@ -7571,6 +7584,12 @@ function drawCanvasGrid() {
     booleanDisplayMode: booleanDisplayMode.value,
     flatteningMultiLineEnabled: flatteningMultiLineEnabled.value,
   });
+  flipCanvasSurface();
+}
+
+function flipCanvasSurface() {
+  // 双 canvas 翻转：刚绘制的帧离开前景层，幽灵层随隐藏一并废弃，新显画布接到下一帧
+  canvasUsingBackSurface.value = !canvasUsingBackSurface.value;
 }
 
 watch(
@@ -12930,6 +12949,21 @@ function currentGridContextMenuItems(): ContextMenuItem[] {
                     :style="{
                       width: `${canvasSurfaceWidth}px`,
                       height: `${canvasViewportHeight}px`,
+                      display: canvasUsingBackSurface ? 'none' : '',
+                    }"
+                    @mousemove="onCanvasMouseMove"
+                    @mouseleave="onCanvasMouseLeave"
+                    @mousedown="onCanvasMouseDown"
+                    @contextmenu="onCanvasContext"
+                    @dblclick="onCanvasDblClick"
+                  />
+                  <canvas
+                    ref="canvasBackRef"
+                    class="canvas-grid-surface dbx-data-grid-font-family sticky left-0 top-0 z-0 block font-normal"
+                    :style="{
+                      width: `${canvasSurfaceWidth}px`,
+                      height: `${canvasViewportHeight}px`,
+                      display: canvasUsingBackSurface ? '' : 'none',
                     }"
                     @mousemove="onCanvasMouseMove"
                     @mouseleave="onCanvasMouseLeave"

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6950,6 +6950,10 @@ function dataGridSelectionScroller(): HTMLElement | null {
   return canvasScrollerElement();
 }
 
+function canvasMeasurementSurface(): HTMLElement | null {
+  return canvasOverlayRef.value ?? null;
+}
+
 function dataGridCellFromClientPoint(clientX: number, clientY: number): { rowIndex: number; colIndex: number } | null {
   const scroller = dataGridSelectionScroller();
   if (!scroller) return null;
@@ -6996,9 +7000,9 @@ function syncCanvasViewport(entries?: readonly ResizeObserverEntry[]) {
   if (!dataGridIsActive) return;
   const scroller = canvasScrollerElement();
   if (!scroller) return;
-  const canvas = activeCanvasSurface();
-  const canvasEntry = canvas ? entries?.find((entry) => entry.target === canvas) : undefined;
-  if (canvasEntry) canvasMeasuredDevicePixelSize.value = dataGridCanvasDevicePixelSize(canvasEntry);
+  const measurementSurface = canvasMeasurementSurface();
+  const surfaceEntry = measurementSurface ? entries?.find((entry) => entry.target === measurementSurface) : undefined;
+  if (surfaceEntry) canvasMeasuredDevicePixelSize.value = dataGridCanvasDevicePixelSize(surfaceEntry);
   canvasViewportWidth.value = scroller.clientWidth;
   canvasViewportHeight.value = scroller.clientHeight;
   canvasScrollTop.value = scroller.scrollTop;
@@ -7059,7 +7063,7 @@ canvasRuntime = useDataGridCanvasRuntime({
   draw: drawCanvasGrid,
   syncViewport: syncCanvasViewport,
   getViewport: canvasScrollerElement,
-  getSurface: () => activeCanvasSurface(),
+  getSurface: canvasMeasurementSurface,
   refreshPixelRatio: () => {
     const next = currentCanvasDevicePixelRatio();
     if (Math.abs(next - canvasDevicePixelRatio.value) > 0.001) {

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -133,6 +133,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   localStorage.removeItem("dbx-filter-builder-value-shortcut-hint-days");
 });
+describe("DataGrid canvas surfaces", () => {
+  it("uses the stable overlay for viewport and device-pixel measurement", () => {
+    expect(dataGridSource).toContain("function canvasMeasurementSurface(): HTMLElement | null");
+    expect(dataGridSource).toContain("return canvasOverlayRef.value ?? null;");
+    expect(dataGridSource).toContain("const measurementSurface = canvasMeasurementSurface();");
+    expect(dataGridSource).toContain("getSurface: canvasMeasurementSurface,");
+    expect(dataGridSource).toContain("const canvas = inactiveCanvasSurface();");
+    expect(dataGridSource).toContain("canvasUsingBackSurface.value = !canvasUsingBackSurface.value;");
+  });
+});
 
 describe("DataGridSearchBar", () => {
   it("focuses/selects the input and forwards keyboard, navigation, and suggestion interactions", async () => {

--- a/apps/desktop/src/composables/__tests__/useDataGridCanvasRuntime.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridCanvasRuntime.spec.ts
@@ -53,6 +53,55 @@ describe("data grid visual runtimes", () => {
     expect(resize.observe).toHaveBeenNthCalledWith(2, surface, { box: "device-pixel-content-box" });
     runtime.dispose();
   });
+  it("keeps viewport observation on a stable measurement surface while render surfaces flip", () => {
+    const viewport = { children: [] } as unknown as Element;
+    const measurementSurface = { children: [] } as unknown as Element;
+    const frontSurface = { children: [] } as unknown as Element;
+    const backSurface = { children: [] } as unknown as Element;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const syncViewport = vi.fn();
+    let activeSurface = frontSurface;
+    let observerCallback: ResizeObserverCallback | null = null;
+    let observer: ResizeObserver | null = null;
+    const runtime = useDataGridCanvasRuntime({
+      draw: () => {
+        activeSurface = activeSurface === frontSurface ? backSurface : frontSurface;
+      },
+      syncViewport,
+      getViewport: () => viewport,
+      getSurface: () => measurementSurface,
+      createResizeObserver: (callback) => {
+        observerCallback = callback;
+        observer = { observe, disconnect } as unknown as ResizeObserver;
+        return observer;
+      },
+    });
+
+    runtime.observeViewport();
+    runtime.drawNow();
+    runtime.drawNow();
+
+    expect(activeSurface).toBe(frontSurface);
+    expect(observe.mock.calls[0]?.[0]).toBe(viewport);
+    expect(observe.mock.calls[1]?.[0]).toBe(measurementSurface);
+    expect(observe.mock.calls[1]?.[1]).toEqual({ box: "device-pixel-content-box" });
+    expect(observe.mock.calls.map(([target]) => target)).not.toContain(frontSurface);
+    expect(observe.mock.calls.map(([target]) => target)).not.toContain(backSurface);
+    expect(syncViewport).toHaveBeenCalledOnce();
+
+    const entry = {
+      target: measurementSurface,
+      contentRect: { width: 640, height: 320 },
+      devicePixelContentBoxSize: [{ inlineSize: 1280, blockSize: 640 }],
+    } as unknown as ResizeObserverEntry;
+    observerCallback?.([entry], observer as ResizeObserver);
+
+    expect(syncViewport).toHaveBeenCalledTimes(2);
+    expect(syncViewport).toHaveBeenLastCalledWith([entry]);
+    expect(dataGridCanvasDevicePixelSize(entry)).toEqual({ cssWidth: 640, cssHeight: 320, pixelWidth: 1280, pixelHeight: 640 });
+    runtime.dispose();
+  });
 
   it("coalesces canvas frames and cancels all resources on dispose", () => {
     const frames = createFrameDriver();


### PR DESCRIPTION
## 变更说明

修复 macOS（WKWebView）下查询结果表格右键行出现"蓝色全选遮罩"的问题：右键任一行后，整个数据区被选区蓝覆盖（被右键的一行为更深蓝），表头/工具栏正常；网页端与 Windows 版均无此现象。

  根因：WKWebView 会为 <canvas> 元素滞留一个幽灵合成层——屏幕显示该层旧的（全选）帧位图，而 canvas 2D 缓冲早已重绘为最新内容；整帧重绘、清屏甚至修改 canvas 尺寸都无法清除该幽灵层。仅 macOS 的 WKWebView
  触发（网页端 Chromium / Windows WebView2 均不出现），排查通过"移动 canvas 后遮罩跟随 / 隐藏 canvas 后遮罩消失 / 缓冲与屏幕色彩不一致"等对照实验逐步排除逻辑层与 DOM 层，最终定位到该复合层驻留行为。

  修复：双 canvas 翻转。网格数据面改为两枚同尺寸 canvas 交替绘制：每帧绘制进隐藏的一枚，画完立即交换可见性；幽灵层依附于旧元素、随 display:none
  一并废弃，新显示的画布无历史可滞留。命中测试、悬停光标、ResizeObserver 测量等交互路径同步切换到当前活动画布，滚动定位与绘制逻辑不变。

## 变更类型

- [ ] 新功能
- [X] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [X] 本 PR 涉及前端改动，已附截图/录屏（见下方）
修复前：
<img width="5118" height="2616" alt="image" src="https://github.com/user-attachments/assets/81881bd5-e0e5-4782-ac68-3b205d555836" />
修复后：
<img width="2916" height="1832" alt="PixPin_2026-08-25_12-01-01" src="https://github.com/user-attachments/assets/e6edd020-5437-44ee-a01a-c0908dea0a07" />


## 验证

  手动验证（macOS WKWebView 实测）：
  1. 查询结果视图右键任一行 —— 无遮罩
  2. Ctrl+A 全选后右键某行 —— 无遮罩
  3. 滚轮上下/横向滚动 —— 行号与数据对位、无残影
  4. 滚动后点选/右键 —— 命中正确


- [X] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [X] 相关测试通过

## 关联 Issue

Close #7059 