### PR TITLE
fix(grid): use native context menu in filter inputs

### DIFF
--- a/apps/desktop/src/components/grid/DataGridConditionEditor.vue
+++ b/apps/desktop/src/components/grid/DataGridConditionEditor.vue
@@ -528,6 +528,7 @@ defineExpose({ focus, dismiss: editor.dismiss, rememberHistory: editor.rememberH
           @compositionstart="onCompositionStart"
           @compositionend="onCompositionEnd"
           @input="onInput"
+          @contextmenu.stop
           @keydown="onKeydown"
         />
       </div>
@@ -562,6 +563,7 @@ defineExpose({ focus, dismiss: editor.dismiss, rememberHistory: editor.rememberH
           @compositionstart="onCompositionStart"
           @compositionend="onCompositionEnd"
           @input="onInput"
+          @contextmenu.stop
           @keydown="onKeydown"
         />
         <div class="data-grid-topbar-condition-floating-controls pointer-events-none absolute inset-x-2 z-[2] flex h-6 min-w-0 items-center gap-1">

--- a/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts
@@ -295,6 +295,77 @@ describe("DataGrid context menu target lifecycle", () => {
     expect(contextMenuLabels()).toContain("Freeze Selected Columns");
   });
 
+  it.each(["WHERE", "ORDER BY"] as const)("keeps the native context menu for the %s condition editor", async (placeholder) => {
+    const { host } = mountGrid(hydratedResult(1, "value"));
+    await settle();
+
+    const input = host.querySelector<HTMLTextAreaElement>(`textarea[placeholder="${placeholder}"]`);
+    expect(input).not.toBeNull();
+
+    const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 12, clientY: 12 });
+    input!.dispatchEvent(event);
+    await settle();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.querySelector("[data-dbx-context-menu]")).toBeNull();
+  });
+
+  it("keeps the DataGrid context menu for a regular cell", async () => {
+    const { host } = mountGrid(hydratedResult(1, "value"));
+    await settle();
+
+    openContextMenu(gridCell(host));
+    await settle();
+
+    expect(contextMenuLabels()).toContain("Filter");
+  });
+
+  it("keeps the native context menu for the expanded condition editor", async () => {
+    const { host } = mountGrid(hydratedResult(1, "abcdefghijklmnopqrstuvwxyz"));
+    await settle();
+
+    const input = host.querySelector<HTMLTextAreaElement>('textarea[placeholder="WHERE"]');
+    expect(input).not.toBeNull();
+    input!.value = "abcdefghijklmnopqrstuvwxyz";
+    input!.setSelectionRange(input!.value.length, input!.value.length);
+    Object.defineProperties(input!, {
+      clientWidth: { configurable: true, value: 80 },
+      scrollWidth: { configurable: true, value: 320 },
+      clientHeight: { configurable: true, value: 24 },
+      scrollHeight: { configurable: true, value: 24 },
+    });
+
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+      if (this === input) return { x: 0, y: 0, left: 0, top: 0, right: 80, bottom: 24, width: 80, height: 24, toJSON: () => ({}) } as DOMRect;
+      if (this instanceof HTMLSpanElement && this.style.position === "fixed") return { x: 0, y: 0, left: 0, top: 0, right: 320, bottom: 24, width: 320, height: 24, toJSON: () => ({}) } as DOMRect;
+      return originalGetBoundingClientRect.call(this);
+    });
+
+    try {
+      input!.focus();
+      input!.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+      await settle();
+
+      const expanded = document.body.querySelector<HTMLTextAreaElement>('.data-grid-topbar-condition-input--expanded[placeholder="WHERE"]');
+      expect(expanded).not.toBeNull();
+
+      const documentContextMenu = vi.fn((event: MouseEvent) => event.preventDefault());
+      document.addEventListener("contextmenu", documentContextMenu);
+      try {
+        const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 12, clientY: 12 });
+        expanded!.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(documentContextMenu).not.toHaveBeenCalled();
+      } finally {
+        document.removeEventListener("contextmenu", documentContextMenu);
+      }
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
   it("preserves a newly opened header target and same-turn menu actions", async () => {
     const { host } = mountGrid(hydratedResult(1, "value"));
     await settle();


### PR DESCRIPTION
## Summary

- 修复表数据 WHERE / ORDER BY 条件编辑器右键被 DataGrid 自定义菜单拦截的问题
- 文本编辑区域恢复 WebView 原生 context menu，可使用复制、粘贴等系统菜单
- DataGrid 单元格原有自定义右键菜单保持不变

## Root Cause

`DataGrid.vue` 在 `CustomContextMenu` 的 slot 外层容器上统一监听 `contextmenu`，事件会从 `DataGridConditionEditor` 的 textarea 冒泡到该 handler。`CustomContextMenu` 的 `onContextMenu` 会调用 `preventDefault()` 和 `stopPropagation()`，因此 WHERE / ORDER BY 文本控件的 WebView 原生菜单不会出现。

## Implementation

在共享的 `DataGridConditionEditor.vue` 中，仅对普通和 expanded 两个 textarea 使用 `@contextmenu.stop`：阻止事件到达 DataGrid 自定义菜单，但不调用 `preventDefault()`，从而保留 WebView 默认 context menu。没有修改 DataGrid 通用菜单分类逻辑，也没有新增 clipboard/menu 实现。

## Validation

- `pnpm exec vitest run apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts packages/app-tests/dataGridContextMenu.test.ts`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json --pretty false`
- `pnpm exec oxfmt --check apps/desktop/src/components/grid/DataGridConditionEditor.vue apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/grid/DataGridConditionEditor.vue apps/desktop/src/components/grid/__tests__/DataGridContextExtractor.spec.ts`

测试覆盖 WHERE、ORDER BY、expanded editor 的原生 context menu，以及普通 DataGrid cell 自定义菜单保持不变。

未进行 Windows WebView 手工验证。

## Scope

仅调整文本编辑区域与 DataGrid context menu 的事件边界，不新增自定义 clipboard/menu 实现。

Closes #7105
