### PR TITLE
improve：增强 MySQL 存储过程语法诊断

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -93,6 +93,7 @@ import {
 import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, normalizeAlignedSqlWhitespace, quoteIdentifier, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
 import { constrainSqlHoverLayout } from "@/lib/editor/sqlHoverLayout";
 import { lineColumnToOffset, sqlErrorDecorationRange as resolveSqlErrorDecorationRange } from "@/lib/sql/sqlDiagnostics";
+import { analyzeMysqlRoutineSyntax } from "@/lib/sql/mysqlRoutineSyntaxDiagnostics";
 import {
   DBX_TABLE_REFERENCE_MIME,
   DBX_TABLE_REFERENCE_DROP_EVENT,
@@ -3046,7 +3047,17 @@ async function refreshSemanticDiagnostics(options: { preserveOutsideRanges?: boo
   }
 
   const nextDiagnostics: SqlSemanticDiagnostic[] = [];
+  const mysqlRoutineAnalysis = props.databaseType === "mysql" ? analyzeMysqlRoutineSyntax(sql) : null;
+  if (mysqlRoutineAnalysis) {
+    nextDiagnostics.push(
+      ...mysqlRoutineAnalysis.diagnostics.filter((diagnostic) => {
+        const diagnosticRange = sqlTextSpanToRange(sql, diagnostic.span);
+        return !!diagnosticRange && diagnosticRanges.some((range) => rangesOverlap(diagnosticRange, range));
+      }),
+    );
+  }
   for (const range of diagnosticRanges) {
+    if (mysqlRoutineAnalysis?.routineRanges.some((routineRange) => rangesOverlap(routineRange, range))) continue;
     try {
       const analysis = await api.analyzeSqlReferences(
         range.sql,

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -93,7 +93,7 @@ import {
 import { buildHoverTableSql, ddlForHoverPreview, hoverTableMatchesScope, normalizeAlignedSqlWhitespace, quoteIdentifier, quoteQualifiedName, reformatHoverDdl, scopeHoverTables, type HoverTableScope } from "@/lib/editor/hoverTableSql";
 import { constrainSqlHoverLayout } from "@/lib/editor/sqlHoverLayout";
 import { lineColumnToOffset, sqlErrorDecorationRange as resolveSqlErrorDecorationRange } from "@/lib/sql/sqlDiagnostics";
-import { analyzeMysqlRoutineSyntax } from "@/lib/sql/mysqlRoutineSyntaxDiagnostics";
+import { analyzeMysqlRoutineSyntax, supportsMysqlRoutineSyntaxDiagnostics } from "@/lib/sql/mysqlRoutineSyntaxDiagnostics";
 import {
   DBX_TABLE_REFERENCE_MIME,
   DBX_TABLE_REFERENCE_DROP_EVENT,
@@ -3047,7 +3047,7 @@ async function refreshSemanticDiagnostics(options: { preserveOutsideRanges?: boo
   }
 
   const nextDiagnostics: SqlSemanticDiagnostic[] = [];
-  const mysqlRoutineAnalysis = props.databaseType === "mysql" ? analyzeMysqlRoutineSyntax(sql) : null;
+  const mysqlRoutineAnalysis = props.databaseType === "mysql" && supportsMysqlRoutineSyntaxDiagnostics(sqlDriverProfile.value) ? analyzeMysqlRoutineSyntax(sql) : null;
   if (mysqlRoutineAnalysis) {
     nextDiagnostics.push(
       ...mysqlRoutineAnalysis.diagnostics.filter((diagnostic) => {

--- a/apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts
+++ b/apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts
@@ -1,0 +1,239 @@
+import type { SqlTextSpan } from "@/types/database";
+
+export interface MysqlRoutineSyntaxDiagnostic {
+  span: SqlTextSpan;
+  message: string;
+  severity: "error";
+}
+
+export interface MysqlRoutineSyntaxAnalysis {
+  diagnostics: MysqlRoutineSyntaxDiagnostic[];
+  hasRoutine: boolean;
+  routineRanges: Array<{ from: number; to: number }>;
+}
+
+interface RoutineToken {
+  kind: "word" | "leftParen" | "rightParen" | "comma" | "semicolon" | "other";
+  value: string;
+  from: number;
+  to: number;
+}
+
+interface RoutineDeclaration {
+  kind: "PROCEDURE" | "FUNCTION";
+  createTokenIndex: number;
+  tokenIndex: number;
+}
+
+const NON_ROUTINE_CREATE_TYPES = new Set(["DATABASE", "INDEX", "LOGFILE", "ROLE", "SCHEMA", "SERVER", "SPATIAL", "TABLE", "TEMPORARY", "UNIQUE", "USER", "VIEW"]);
+const CONTROL_BLOCK_SUFFIXES = new Set(["IF", "LOOP", "CASE", "REPEAT", "WHILE"]);
+
+export function analyzeMysqlRoutineSyntax(sql: string): MysqlRoutineSyntaxAnalysis {
+  const tokens = tokenizeMysqlRoutineSql(sql);
+  const declarations = findRoutineDeclarations(tokens);
+  const diagnostics: MysqlRoutineSyntaxDiagnostic[] = [];
+  const routineRanges: Array<{ from: number; to: number }> = [];
+
+  declarations.forEach((declaration, declarationIndex) => {
+    const nextDeclarationTokenIndex = declarations[declarationIndex + 1]?.createTokenIndex ?? tokens.length;
+    const parameterStart = findTokenKind(tokens, declaration.tokenIndex + 1, nextDeclarationTokenIndex, "leftParen");
+    if (parameterStart === -1) return;
+    const parameterEnd = findMatchingRightParen(tokens, parameterStart, nextDeclarationTokenIndex);
+    if (parameterEnd === -1) return;
+    const routineEnd = findRoutineEndToken(tokens, parameterEnd + 1, nextDeclarationTokenIndex);
+    const routineEndOffset = routineEnd === -1 ? (tokens[nextDeclarationTokenIndex]?.from ?? sql.length) : tokens[routineEnd].to;
+    routineRanges.push({ from: tokens[declaration.createTokenIndex].from, to: routineEndOffset });
+
+    const previousParameterToken = tokens[parameterEnd - 1];
+    if (previousParameterToken?.kind === "comma") {
+      diagnostics.push(diagnosticAtOffset(sql, previousParameterToken.from, previousParameterToken.to, "Trailing comma is not allowed in a MySQL routine parameter list"));
+    }
+
+    const bodyEnd = routineEnd === -1 ? nextDeclarationTokenIndex : routineEnd + 1;
+    for (let index = parameterEnd + 1; index < bodyEnd; index += 1) {
+      const token = tokens[index];
+      if (token.kind !== "word" || token.value !== "RETURN") continue;
+      if (declaration.kind === "PROCEDURE") {
+        diagnostics.push(diagnosticAtOffset(sql, token.from, token.to, "RETURN is not valid in a MySQL procedure; use LEAVE with a block label"));
+        continue;
+      }
+      const nextToken = tokens[index + 1];
+      if (!nextToken || nextToken.kind === "semicolon") {
+        diagnostics.push(diagnosticAtOffset(sql, token.from, token.to, "RETURN in a MySQL function requires an expression"));
+      }
+    }
+  });
+
+  return { diagnostics, hasRoutine: declarations.length > 0, routineRanges };
+}
+
+function findRoutineDeclarations(tokens: readonly RoutineToken[]): RoutineDeclaration[] {
+  const declarations: RoutineDeclaration[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index]?.kind !== "word" || tokens[index]?.value !== "CREATE") continue;
+    for (let lookahead = index + 1; lookahead < Math.min(tokens.length, index + 24); lookahead += 1) {
+      const token = tokens[lookahead];
+      if (token.kind === "semicolon" || (token.kind === "word" && token.value === "CREATE")) break;
+      if (token.kind !== "word") continue;
+      if (token.value === "PROCEDURE" || token.value === "FUNCTION") {
+        declarations.push({ kind: token.value, createTokenIndex: index, tokenIndex: lookahead });
+        break;
+      }
+      if (NON_ROUTINE_CREATE_TYPES.has(token.value)) break;
+    }
+  }
+  return declarations;
+}
+
+function findRoutineEndToken(tokens: readonly RoutineToken[], from: number, to: number): number {
+  const bodyStart = findWordToken(tokens, from, to, "BEGIN");
+  if (bodyStart === -1) return findTokenKind(tokens, from, to, "semicolon");
+
+  let depth = 0;
+  for (let index = bodyStart; index < to; index += 1) {
+    const token = tokens[index];
+    if (token.kind !== "word") continue;
+    if (token.value === "BEGIN") {
+      if (previousWordToken(tokens, index, bodyStart) !== "END") depth += 1;
+      continue;
+    }
+    if (token.value !== "END" || CONTROL_BLOCK_SUFFIXES.has(nextWordToken(tokens, index, to) ?? "")) continue;
+    depth = Math.max(0, depth - 1);
+    if (depth === 0) return index;
+  }
+  return -1;
+}
+
+function findWordToken(tokens: readonly RoutineToken[], from: number, to: number, value: string): number {
+  for (let index = from; index < to; index += 1) {
+    if (tokens[index]?.kind === "word" && tokens[index]?.value === value) return index;
+  }
+  return -1;
+}
+
+function previousWordToken(tokens: readonly RoutineToken[], from: number, lowerBound: number): string | null {
+  for (let index = from - 1; index >= lowerBound; index -= 1) {
+    if (tokens[index]?.kind === "word") return tokens[index].value;
+  }
+  return null;
+}
+
+function nextWordToken(tokens: readonly RoutineToken[], from: number, upperBound: number): string | null {
+  for (let index = from + 1; index < upperBound; index += 1) {
+    if (tokens[index]?.kind === "word") return tokens[index].value;
+  }
+  return null;
+}
+
+function findTokenKind(tokens: readonly RoutineToken[], from: number, to: number, kind: RoutineToken["kind"]): number {
+  for (let index = from; index < to; index += 1) {
+    if (tokens[index]?.kind === kind) return index;
+  }
+  return -1;
+}
+
+function findMatchingRightParen(tokens: readonly RoutineToken[], start: number, to: number): number {
+  let depth = 0;
+  for (let index = start; index < to; index += 1) {
+    if (tokens[index]?.kind === "leftParen") depth += 1;
+    if (tokens[index]?.kind !== "rightParen") continue;
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+  return -1;
+}
+
+function diagnosticAtOffset(sql: string, from: number, to: number, message: string): MysqlRoutineSyntaxDiagnostic {
+  const start = offsetToPosition(sql, from);
+  const end = offsetToPosition(sql, Math.max(from + 1, to));
+  return {
+    span: {
+      start_line: start.line,
+      start_column: start.column,
+      end_line: end.line,
+      end_column: Math.max(end.column - 1, start.column),
+    },
+    message,
+    severity: "error",
+  };
+}
+
+function offsetToPosition(sql: string, offset: number): { line: number; column: number } {
+  const boundedOffset = Math.max(0, Math.min(offset, sql.length));
+  let line = 1;
+  let lineStart = 0;
+  for (let index = 0; index < boundedOffset; index += 1) {
+    if (sql[index] !== "\n") continue;
+    line += 1;
+    lineStart = index + 1;
+  }
+  return { line, column: boundedOffset - lineStart + 1 };
+}
+
+function tokenizeMysqlRoutineSql(sql: string): RoutineToken[] {
+  const tokens: RoutineToken[] = [];
+  let index = 0;
+
+  while (index < sql.length) {
+    const char = sql[index];
+    const next = sql[index + 1] ?? "";
+    if (char === "-" && next === "-" && /\s/.test(sql[index + 2] ?? "")) {
+      index = skipLine(sql, index + 2);
+      continue;
+    }
+    if (char === "#") {
+      index = skipLine(sql, index + 1);
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      const end = sql.indexOf("*/", index + 2);
+      index = end === -1 ? sql.length : end + 2;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      const end = skipQuoted(sql, index, char);
+      tokens.push({ kind: "other", value: sql.slice(index, end), from: index, to: end });
+      index = end;
+      continue;
+    }
+
+    const kind = char === "(" ? "leftParen" : char === ")" ? "rightParen" : char === "," ? "comma" : char === ";" ? "semicolon" : null;
+    if (kind) {
+      tokens.push({ kind, value: char, from: index, to: index + 1 });
+      index += 1;
+      continue;
+    }
+
+    const word = /^[A-Za-z_][A-Za-z0-9_]*/.exec(sql.slice(index))?.[0];
+    if (word) {
+      tokens.push({ kind: "word", value: word.toUpperCase(), from: index, to: index + word.length });
+      index += word.length;
+      continue;
+    }
+    if (!/\s/.test(char)) tokens.push({ kind: "other", value: char, from: index, to: index + 1 });
+    index += 1;
+  }
+  return tokens;
+}
+
+function skipLine(sql: string, from: number): number {
+  const newline = sql.indexOf("\n", from);
+  return newline === -1 ? sql.length : newline + 1;
+}
+
+function skipQuoted(sql: string, start: number, quote: string): number {
+  let index = start + 1;
+  while (index < sql.length) {
+    if (sql[index] === "\\" && index + 1 < sql.length) {
+      index += 2;
+      continue;
+    }
+    if (sql[index] === quote && sql[index + 1] === quote) {
+      index += 2;
+      continue;
+    }
+    if (sql[index] === quote) return index + 1;
+    index += 1;
+  }
+  return sql.length;
+}

--- a/apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts
+++ b/apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts
@@ -1,3 +1,4 @@
+import { executableStatementRanges } from "@/lib/sql/sqlStatementRanges";
 import type { SqlTextSpan } from "@/types/database";
 
 export interface MysqlRoutineSyntaxDiagnostic {
@@ -26,45 +27,49 @@ interface RoutineDeclaration {
 }
 
 const NON_ROUTINE_CREATE_TYPES = new Set(["DATABASE", "INDEX", "LOGFILE", "ROLE", "SCHEMA", "SERVER", "SPATIAL", "TABLE", "TEMPORARY", "UNIQUE", "USER", "VIEW"]);
-const CONTROL_BLOCK_SUFFIXES = new Set(["IF", "LOOP", "CASE", "REPEAT", "WHILE"]);
+
+export function supportsMysqlRoutineSyntaxDiagnostics(driverProfile?: string): boolean {
+  const profile = driverProfile?.trim().toLowerCase();
+  return !profile || profile === "mysql" || profile === "custom_mysql";
+}
 
 export function analyzeMysqlRoutineSyntax(sql: string): MysqlRoutineSyntaxAnalysis {
-  const tokens = tokenizeMysqlRoutineSql(sql);
-  const declarations = findRoutineDeclarations(tokens);
   const diagnostics: MysqlRoutineSyntaxDiagnostic[] = [];
   const routineRanges: Array<{ from: number; to: number }> = [];
 
-  declarations.forEach((declaration, declarationIndex) => {
-    const nextDeclarationTokenIndex = declarations[declarationIndex + 1]?.createTokenIndex ?? tokens.length;
-    const parameterStart = findTokenKind(tokens, declaration.tokenIndex + 1, nextDeclarationTokenIndex, "leftParen");
-    if (parameterStart === -1) return;
-    const parameterEnd = findMatchingRightParen(tokens, parameterStart, nextDeclarationTokenIndex);
-    if (parameterEnd === -1) return;
-    const routineEnd = findRoutineEndToken(tokens, parameterEnd + 1, nextDeclarationTokenIndex);
-    const routineEndOffset = routineEnd === -1 ? (tokens[nextDeclarationTokenIndex]?.from ?? sql.length) : tokens[routineEnd].to;
-    routineRanges.push({ from: tokens[declaration.createTokenIndex].from, to: routineEndOffset });
+  for (const statement of executableStatementRanges(sql, "mysql")) {
+    const tokens = tokenizeMysqlRoutineSql(statement.sql, statement.from);
+    const declarations = findRoutineDeclarations(tokens);
 
-    const previousParameterToken = tokens[parameterEnd - 1];
-    if (previousParameterToken?.kind === "comma") {
-      diagnostics.push(diagnosticAtOffset(sql, previousParameterToken.from, previousParameterToken.to, "Trailing comma is not allowed in a MySQL routine parameter list"));
-    }
+    declarations.forEach((declaration, declarationIndex) => {
+      const nextDeclarationTokenIndex = declarations[declarationIndex + 1]?.createTokenIndex ?? tokens.length;
+      const parameterStart = findTokenKind(tokens, declaration.tokenIndex + 1, nextDeclarationTokenIndex, "leftParen");
+      if (parameterStart === -1) return;
+      const parameterEnd = findMatchingRightParen(tokens, parameterStart, nextDeclarationTokenIndex);
+      if (parameterEnd === -1) return;
+      routineRanges.push({ from: tokens[declaration.createTokenIndex].from, to: statement.to });
 
-    const bodyEnd = routineEnd === -1 ? nextDeclarationTokenIndex : routineEnd + 1;
-    for (let index = parameterEnd + 1; index < bodyEnd; index += 1) {
-      const token = tokens[index];
-      if (token.kind !== "word" || token.value !== "RETURN") continue;
-      if (declaration.kind === "PROCEDURE") {
-        diagnostics.push(diagnosticAtOffset(sql, token.from, token.to, "RETURN is not valid in a MySQL procedure; use LEAVE with a block label"));
-        continue;
+      const previousParameterToken = tokens[parameterEnd - 1];
+      if (previousParameterToken?.kind === "comma") {
+        diagnostics.push(diagnosticAtOffset(sql, previousParameterToken.from, previousParameterToken.to, "Trailing comma is not allowed in a MySQL routine parameter list"));
       }
-      const nextToken = tokens[index + 1];
-      if (!nextToken || nextToken.kind === "semicolon") {
-        diagnostics.push(diagnosticAtOffset(sql, token.from, token.to, "RETURN in a MySQL function requires an expression"));
-      }
-    }
-  });
 
-  return { diagnostics, hasRoutine: declarations.length > 0, routineRanges };
+      for (let index = parameterEnd + 1; index < nextDeclarationTokenIndex; index += 1) {
+        const token = tokens[index];
+        if (token.kind !== "word" || token.value !== "RETURN") continue;
+        if (declaration.kind === "PROCEDURE") {
+          diagnostics.push(diagnosticAtOffset(sql, token.from, token.to, "RETURN is not valid in a MySQL procedure; use LEAVE with a block label"));
+          continue;
+        }
+        const nextToken = tokens[index + 1];
+        if (!nextToken || nextToken.kind === "semicolon") {
+          diagnostics.push(diagnosticAtOffset(sql, token.from, token.to, "RETURN in a MySQL function requires an expression"));
+        }
+      }
+    });
+  }
+
+  return { diagnostics, hasRoutine: routineRanges.length > 0, routineRanges };
 }
 
 function findRoutineDeclarations(tokens: readonly RoutineToken[]): RoutineDeclaration[] {
@@ -83,46 +88,6 @@ function findRoutineDeclarations(tokens: readonly RoutineToken[]): RoutineDeclar
     }
   }
   return declarations;
-}
-
-function findRoutineEndToken(tokens: readonly RoutineToken[], from: number, to: number): number {
-  const bodyStart = findWordToken(tokens, from, to, "BEGIN");
-  if (bodyStart === -1) return findTokenKind(tokens, from, to, "semicolon");
-
-  let depth = 0;
-  for (let index = bodyStart; index < to; index += 1) {
-    const token = tokens[index];
-    if (token.kind !== "word") continue;
-    if (token.value === "BEGIN") {
-      if (previousWordToken(tokens, index, bodyStart) !== "END") depth += 1;
-      continue;
-    }
-    if (token.value !== "END" || CONTROL_BLOCK_SUFFIXES.has(nextWordToken(tokens, index, to) ?? "")) continue;
-    depth = Math.max(0, depth - 1);
-    if (depth === 0) return index;
-  }
-  return -1;
-}
-
-function findWordToken(tokens: readonly RoutineToken[], from: number, to: number, value: string): number {
-  for (let index = from; index < to; index += 1) {
-    if (tokens[index]?.kind === "word" && tokens[index]?.value === value) return index;
-  }
-  return -1;
-}
-
-function previousWordToken(tokens: readonly RoutineToken[], from: number, lowerBound: number): string | null {
-  for (let index = from - 1; index >= lowerBound; index -= 1) {
-    if (tokens[index]?.kind === "word") return tokens[index].value;
-  }
-  return null;
-}
-
-function nextWordToken(tokens: readonly RoutineToken[], from: number, upperBound: number): string | null {
-  for (let index = from + 1; index < upperBound; index += 1) {
-    if (tokens[index]?.kind === "word") return tokens[index].value;
-  }
-  return null;
 }
 
 function findTokenKind(tokens: readonly RoutineToken[], from: number, to: number, kind: RoutineToken["kind"]): number {
@@ -170,7 +135,7 @@ function offsetToPosition(sql: string, offset: number): { line: number; column: 
   return { line, column: boundedOffset - lineStart + 1 };
 }
 
-function tokenizeMysqlRoutineSql(sql: string): RoutineToken[] {
+function tokenizeMysqlRoutineSql(sql: string, baseOffset = 0): RoutineToken[] {
   const tokens: RoutineToken[] = [];
   let index = 0;
 
@@ -192,25 +157,25 @@ function tokenizeMysqlRoutineSql(sql: string): RoutineToken[] {
     }
     if (char === "'" || char === '"' || char === "`") {
       const end = skipQuoted(sql, index, char);
-      tokens.push({ kind: "other", value: sql.slice(index, end), from: index, to: end });
+      tokens.push({ kind: "other", value: sql.slice(index, end), from: baseOffset + index, to: baseOffset + end });
       index = end;
       continue;
     }
 
     const kind = char === "(" ? "leftParen" : char === ")" ? "rightParen" : char === "," ? "comma" : char === ";" ? "semicolon" : null;
     if (kind) {
-      tokens.push({ kind, value: char, from: index, to: index + 1 });
+      tokens.push({ kind, value: char, from: baseOffset + index, to: baseOffset + index + 1 });
       index += 1;
       continue;
     }
 
     const word = /^[A-Za-z_][A-Za-z0-9_]*/.exec(sql.slice(index))?.[0];
     if (word) {
-      tokens.push({ kind: "word", value: word.toUpperCase(), from: index, to: index + word.length });
+      tokens.push({ kind: "word", value: word.toUpperCase(), from: baseOffset + index, to: baseOffset + index + word.length });
       index += word.length;
       continue;
     }
-    if (!/\s/.test(char)) tokens.push({ kind: "other", value: char, from: index, to: index + 1 });
+    if (!/\s/.test(char)) tokens.push({ kind: "other", value: char, from: baseOffset + index, to: baseOffset + index + 1 });
     index += 1;
   }
   return tokens;

--- a/packages/app-tests/mysqlRoutineSyntaxDiagnostics.test.ts
+++ b/packages/app-tests/mysqlRoutineSyntaxDiagnostics.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from "node:assert";
+import { test } from "vitest";
+import { analyzeMysqlRoutineSyntax } from "../../apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts";
+
+const reportedSql = `drop procedure if exists proc_check_gys;
+CREATE PROCEDURE proc_check_gys(
+   in in_gys_name varchar(100), -- 供应商账号
+   in in_yys varchar(100), -- 运营商账号
+)
+run:
+BEGIN
+ set @yys='';
+ set @uid=0;
+ select uid,yys INTO @uid, @yys from uchome_space AS us where username=in_gys_name limit 1;
+ if @uid=0 THEN
+     select 1 as code,'供应商不存在' as msg;
+     return;
+ END if;
+ if @yys<> in_gys_name THEN
+     select 2 as code,'运营商不正确' as msg;
+     return;
+ end if;
+ select 0 as code,'' as msg;
+end`;
+
+test("reports deterministic MySQL procedure syntax errors", () => {
+  const analysis = analyzeMysqlRoutineSyntax(reportedSql);
+
+  assert.equal(analysis.hasRoutine, true);
+  assert.equal(analysis.routineRanges.length, 1);
+  assert.equal(reportedSql.slice(analysis.routineRanges[0].from, analysis.routineRanges[0].to).startsWith("CREATE PROCEDURE"), true);
+  assert.deepEqual(
+    analysis.diagnostics.map((diagnostic) => diagnostic.message),
+    ["Trailing comma is not allowed in a MySQL routine parameter list", "RETURN is not valid in a MySQL procedure; use LEAVE with a block label", "RETURN is not valid in a MySQL procedure; use LEAVE with a block label"],
+  );
+  assert.deepEqual(
+    analysis.diagnostics.map((diagnostic) => [diagnostic.span.start_line, diagnostic.span.start_column]),
+    [
+      [4, 26],
+      [13, 6],
+      [17, 6],
+    ],
+  );
+});
+
+test("accepts a labeled MySQL procedure that exits with LEAVE", () => {
+  const analysis = analyzeMysqlRoutineSyntax(`CREATE DEFINER=CURRENT_USER PROCEDURE proc_check_gys(
+  IN in_gys_name VARCHAR(100),
+  IN amount DECIMAL(10, 2),
+  IN mode_name ENUM('direct', 'proxy')
+)
+run: BEGIN
+  IF in_gys_name = '' THEN
+    LEAVE run;
+  END IF;
+  SELECT 'RETURN;,)' AS message;
+  -- RETURN in a comment must be ignored
+END`);
+
+  assert.equal(analysis.hasRoutine, true);
+  assert.deepEqual(analysis.diagnostics, []);
+});
+
+test("checks bare RETURN only for MySQL functions", () => {
+  const validNumber = analyzeMysqlRoutineSyntax("CREATE FUNCTION answer() RETURNS INT BEGIN RETURN -1; END");
+  const validString = analyzeMysqlRoutineSyntax("CREATE FUNCTION answer() RETURNS VARCHAR(10) BEGIN RETURN 'ok'; END");
+  const invalid = analyzeMysqlRoutineSyntax("CREATE FUNCTION answer() RETURNS INT BEGIN RETURN; END");
+  const invalidWithComment = analyzeMysqlRoutineSyntax("CREATE FUNCTION answer() RETURNS INT BEGIN RETURN /* missing value */; END");
+
+  assert.deepEqual(validNumber.diagnostics, []);
+  assert.deepEqual(validString.diagnostics, []);
+  assert.deepEqual(
+    invalid.diagnostics.map((diagnostic) => diagnostic.message),
+    ["RETURN in a MySQL function requires an expression"],
+  );
+  assert.deepEqual(
+    invalidWithComment.diagnostics.map((diagnostic) => diagnostic.message),
+    ["RETURN in a MySQL function requires an expression"],
+  );
+});
+
+test("ignores ordinary SQL and quoted routine keywords", () => {
+  assert.deepEqual(analyzeMysqlRoutineSyntax("SELECT 'CREATE PROCEDURE p() RETURN;' AS body"), { diagnostics: [], hasRoutine: false, routineRanges: [] });
+});
+
+test("keeps multiple routine ranges separate from ordinary SQL", () => {
+  const sql = `CREATE PROCEDURE first_proc() BEGIN RETURN; END$$
+SELECT missing_column FROM users;
+CREATE FUNCTION second_func() RETURNS INT BEGIN RETURN 1; END$$`;
+  const analysis = analyzeMysqlRoutineSyntax(sql);
+
+  assert.equal(analysis.routineRanges.length, 2);
+  assert.equal(
+    analysis.routineRanges.some((range) => sql.slice(range.from, range.to).includes("SELECT missing_column")),
+    false,
+  );
+  assert.deepEqual(
+    analysis.diagnostics.map((diagnostic) => diagnostic.message),
+    ["RETURN is not valid in a MySQL procedure; use LEAVE with a block label"],
+  );
+});

--- a/packages/app-tests/mysqlRoutineSyntaxDiagnostics.test.ts
+++ b/packages/app-tests/mysqlRoutineSyntaxDiagnostics.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
-import { analyzeMysqlRoutineSyntax } from "../../apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts";
+import { analyzeMysqlRoutineSyntax, supportsMysqlRoutineSyntaxDiagnostics } from "../../apps/desktop/src/lib/sql/mysqlRoutineSyntaxDiagnostics.ts";
 
 const reportedSql = `drop procedure if exists proc_check_gys;
 CREATE PROCEDURE proc_check_gys(
@@ -84,9 +84,11 @@ test("ignores ordinary SQL and quoted routine keywords", () => {
 });
 
 test("keeps multiple routine ranges separate from ordinary SQL", () => {
-  const sql = `CREATE PROCEDURE first_proc() BEGIN RETURN; END$$
-SELECT missing_column FROM users;
-CREATE FUNCTION second_func() RETURNS INT BEGIN RETURN 1; END$$`;
+  const sql = `DELIMITER $$
+CREATE PROCEDURE first_proc() BEGIN RETURN; END$$
+CREATE FUNCTION second_func() RETURNS INT BEGIN RETURN 1; END$$
+DELIMITER ;
+SELECT missing_column FROM users;`;
   const analysis = analyzeMysqlRoutineSyntax(sql);
 
   assert.equal(analysis.routineRanges.length, 2);
@@ -98,4 +100,53 @@ CREATE FUNCTION second_func() RETURNS INT BEGIN RETURN 1; END$$`;
     analysis.diagnostics.map((diagnostic) => diagnostic.message),
     ["RETURN is not valid in a MySQL procedure; use LEAVE with a block label"],
   );
+});
+
+test("keeps CASE expression endings inside the routine statement", () => {
+  const sql = `CREATE PROCEDURE update_status()
+BEGIN
+  SET @status_code = CASE WHEN 1 = 1 THEN 1 ELSE 0 END;
+  RETURN;
+END;
+SELECT missing_column FROM users;`;
+  const analysis = analyzeMysqlRoutineSyntax(sql);
+
+  assert.deepEqual(
+    analysis.diagnostics.map((diagnostic) => diagnostic.message),
+    ["RETURN is not valid in a MySQL procedure; use LEAVE with a block label"],
+  );
+  assert.equal(sql.slice(analysis.routineRanges[0].from, analysis.routineRanges[0].to).includes("RETURN;"), true);
+  assert.equal(sql.slice(analysis.routineRanges[0].from, analysis.routineRanges[0].to).includes("SELECT missing_column"), false);
+});
+
+test("uses custom delimiters to bound single-statement functions", () => {
+  const sql = `DELIMITER $$
+CREATE FUNCTION answer() RETURNS INT
+RETURN$$
+DELIMITER ;
+SELECT missing_column FROM users;`;
+  const analysis = analyzeMysqlRoutineSyntax(sql);
+
+  assert.deepEqual(
+    analysis.diagnostics.map((diagnostic) => diagnostic.message),
+    ["RETURN in a MySQL function requires an expression"],
+  );
+  assert.equal(sql.slice(analysis.routineRanges[0].from, analysis.routineRanges[0].to), "CREATE FUNCTION answer() RETURNS INT\nRETURN");
+});
+
+test("limits routine diagnostics to native and custom MySQL profiles", () => {
+  assert.equal(supportsMysqlRoutineSyntaxDiagnostics(), true);
+  assert.equal(supportsMysqlRoutineSyntaxDiagnostics("mysql"), true);
+  assert.equal(supportsMysqlRoutineSyntaxDiagnostics("custom_mysql"), true);
+  assert.equal(supportsMysqlRoutineSyntaxDiagnostics("mariadb"), false);
+  assert.equal(supportsMysqlRoutineSyntaxDiagnostics("tidb"), false);
+  assert.equal(supportsMysqlRoutineSyntaxDiagnostics("oceanbase"), false);
+});
+
+test("leaves MySQL triggers and events to the existing diagnostics path", () => {
+  const trigger = analyzeMysqlRoutineSyntax("CREATE TRIGGER before_insert BEFORE INSERT ON users FOR EACH ROW SET NEW.created_at = NOW()");
+  const event = analyzeMysqlRoutineSyntax("CREATE EVENT purge_logs ON SCHEDULE EVERY 1 DAY DO DELETE FROM logs WHERE created_at < NOW() - INTERVAL 30 DAY");
+
+  assert.deepEqual(trigger, { diagnostics: [], hasRoutine: false, routineRanges: [] });
+  assert.deepEqual(event, { diagnostics: [], hasRoutine: false, routineRanges: [] });
 });


### PR DESCRIPTION
## 改动

- 增加 MySQL 存储过程和函数的本地语法诊断
- 检测参数列表尾逗号、过程内非法 `RETURN`、函数裸 `RETURN`
- 正确处理标签块、注释、字符串及复杂参数类型
- 存储程序范围内跳过不兼容的通用解析器，避免误报合法的 `BEGIN`、`SELECT INTO` 和 `END IF`
- 保留同一编辑器中普通 SQL 的原有语义诊断

## 验证

- 使用真实 MySQL 8.4 验证尾逗号和过程内 `RETURN` 均被服务端拒绝
- 改为带标签的 `LEAVE` 后，存储过程可创建并成功调用
- 编辑器实测可准确标出用户脚本中的 3 处错误，无额外解析器误报
- 相关 238 项测试通过
- 前端类型检查、格式检查和 lint 通过