### PR TITLE
fix(core): support named-user tilde paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "mongodb",
  "mysql_async",
  "mysql_common",
+ "nix",
  "notify",
  "openssl",
  "pageant",

--- a/agents/drivers/duckdb/Cargo.lock
+++ b/agents/drivers/duckdb/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "minijinja",
  "mongodb",
  "mysql_async",
+ "nix",
  "notify",
  "openssl",
  "pageant",

--- a/crates/dbx-core/Cargo.toml
+++ b/crates/dbx-core/Cargo.toml
@@ -90,6 +90,9 @@ iana-time-zone = "0.1"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security"] }
 
+[target.'cfg(all(unix, not(target_os = "redox")))'.dependencies]
+nix = { version = "0.31.3", features = ["user"] }
+
 [dev-dependencies]
 mysql_common = { git = "https://github.com/t8y2/rust_mysql_common.git", rev = "47740d85a8277167a5717afac785d37b46a36296", default-features = false }
 tokio = { version = "1", features = ["test-util"] }

--- a/crates/dbx-core/src/db/file_validator.rs
+++ b/crates/dbx-core/src/db/file_validator.rs
@@ -122,9 +122,8 @@ mod tests {
     }
 
     #[test]
-    fn test_tilde_without_slash_not_expanded() {
-        // ~user form is not expanded, treated literally
-        let result = validate_file_path("~nonexistentuser", is_network_path_test);
+    fn test_unknown_named_user_path_remains_literal() {
+        let result = validate_file_path("~dbx-user-that-must-not-exist-7088", is_network_path_test);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains('~'));
     }

--- a/crates/dbx-core/src/db/ssh_tunnel.rs
+++ b/crates/dbx-core/src/db/ssh_tunnel.rs
@@ -1913,10 +1913,18 @@ mod tests {
         assert_eq!(resolve_ssh_agent_socket_path("/tmp/agent.sock"), "/tmp/agent.sock");
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "redox")))]
     #[test]
-    fn ssh_agent_socket_path_preserves_named_user_path() {
-        assert_eq!(resolve_ssh_agent_socket_path("~other/.ssh/agent.sock"), "~other/.ssh/agent.sock");
+    fn ssh_agent_socket_path_expands_named_user_home() {
+        let user = nix::unistd::User::from_uid(nix::unistd::getuid())
+            .expect("current Unix user lookup should succeed")
+            .expect("current Unix user should exist in the account database");
+        let home = user.dir.into_os_string().into_string().expect("current Unix user home should be valid UTF-8");
+
+        assert_eq!(
+            resolve_ssh_agent_socket_path(&format!("~{}/.ssh/agent.sock", user.name)),
+            format!("{home}/.ssh/agent.sock")
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/path_utils.rs
+++ b/crates/dbx-core/src/path_utils.rs
@@ -1,19 +1,106 @@
 pub fn expand_tilde(path: &str) -> String {
+    expand_tilde_with(path, home_dir, named_user_home)
+}
+
+fn expand_tilde_with(
+    path: &str,
+    current_home: impl FnOnce() -> Option<String>,
+    named_home: impl FnOnce(&str) -> Option<String>,
+) -> String {
     if !path.starts_with('~') {
         return path.to_string();
     }
     if path.len() == 1 {
-        return home_dir().unwrap_or_else(|| path.to_string());
+        return current_home().unwrap_or_else(|| path.to_string());
     }
     if path.as_bytes().get(1) == Some(&b'/') {
-        return match home_dir() {
+        return match current_home() {
             Some(home) => home + &path[1..],
             None => path.to_string(),
         };
     }
-    path.to_string()
+
+    let named_path = &path[1..];
+    let (username, suffix) =
+        named_path.find('/').map_or((named_path, ""), |index| (&named_path[..index], &named_path[index..]));
+
+    named_home(username).map_or_else(|| path.to_string(), |home| home + suffix)
 }
 
 fn home_dir() -> Option<String> {
     std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")).ok()
+}
+
+#[cfg(all(unix, not(target_os = "redox")))]
+fn named_user_home(username: &str) -> Option<String> {
+    nix::unistd::User::from_name(username).ok().flatten().and_then(|user| user.dir.into_os_string().into_string().ok())
+}
+
+#[cfg(any(not(unix), target_os = "redox"))]
+fn named_user_home(_username: &str) -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_tilde_with;
+
+    fn no_named_user(_username: &str) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn preserves_paths_without_a_leading_tilde() {
+        assert_eq!(
+            expand_tilde_with(
+                "relative/file",
+                || panic!("ordinary paths must not resolve the current home"),
+                |_| panic!("ordinary paths must not resolve a named home")
+            ),
+            "relative/file"
+        );
+        assert_eq!(
+            expand_tilde_with(
+                "/absolute/file",
+                || panic!("ordinary paths must not resolve the current home"),
+                |_| panic!("ordinary paths must not resolve a named home")
+            ),
+            "/absolute/file"
+        );
+    }
+
+    #[test]
+    fn expands_current_user_home_forms() {
+        assert_eq!(expand_tilde_with("~", || Some("/home/current".into()), no_named_user), "/home/current");
+        assert_eq!(
+            expand_tilde_with(
+                "~/.ssh/config",
+                || Some("/home/current".into()),
+                |_| panic!("current-user paths must not resolve a named home")
+            ),
+            "/home/current/.ssh/config"
+        );
+    }
+
+    #[test]
+    fn preserves_current_user_forms_when_home_is_unavailable() {
+        assert_eq!(expand_tilde_with("~", || None, no_named_user), "~");
+        assert_eq!(expand_tilde_with("~/.ssh/config", || None, no_named_user), "~/.ssh/config");
+    }
+
+    #[test]
+    fn expands_named_user_home_forms() {
+        let named_home = |username: &str| (username == "alice").then(|| "/Users/alice".to_string());
+
+        assert_eq!(expand_tilde_with("~alice", || None, named_home), "/Users/alice");
+        assert_eq!(expand_tilde_with("~alice/.ssh/agent.sock", || None, named_home), "/Users/alice/.ssh/agent.sock");
+        assert_eq!(expand_tilde_with("~alice/", || None, named_home), "/Users/alice/");
+    }
+
+    #[test]
+    fn preserves_unresolved_or_non_posix_named_user_forms() {
+        assert_eq!(expand_tilde_with("~missing/.ssh/agent.sock", || None, no_named_user), "~missing/.ssh/agent.sock");
+        assert_eq!(expand_tilde_with("~alice\\.ssh\\agent.sock", || None, no_named_user), "~alice\\.ssh\\agent.sock");
+        assert_eq!(expand_tilde_with("~~/.ssh/agent.sock", || None, no_named_user), "~~/.ssh/agent.sock");
+    }
 }


### PR DESCRIPTION
## 变更说明

补全 Unix 平台下 POSIX 风格的命名用户主目录路径支持。现有共享路径展开逻辑已经支持 `~` 与 `~/...`，但 `~username` 和 `~username/...` 会被保留为字面量，导致 SSH Agent Socket、SSH 私钥及其他共享路径消费者无法引用指定本地账户的主目录。

- 在 Unix 平台通过系统账户数据库解析 `~username`，不依赖 shell 命令或环境变量
- 同时支持 `~username` 与 `~username/...`，并将后续相对路径安全拼接到对应用户主目录
- 用户不存在、账户查询失败或平台不支持命名用户解析时，保留原始字面路径，避免意外改写
- 保持现有 `~`、`~/...`、普通绝对路径和相对路径行为不变
- 将能力收敛在共享 `expand_tilde` 路径工具中，使 SSH Agent Socket、SSH 私钥及其他现有调用方获得一致行为
- 仅在输入确实采用命名用户形式时查询系统账户信息，避免普通路径产生额外查询

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端代码改动；以下截图用于展示 Desktop 中的手动连接验证结果。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `cargo test -p dbx-core path_utils --lib`（5 个测试通过）
- `cargo test -p dbx-core ssh_agent_socket_path --lib`（3 个测试通过）
- `cargo test -p dbx-core unknown_named_user_path --lib`（1 个测试通过）
- `cargo check -p dbx-core --no-default-features --locked`
- `make check`
- `make cargo-check-fast`

### 命名用户路径手动验证

#### 当前用户成功解析并连接

<img width="1352" height="848" alt="1" src="https://github.com/user-attachments/assets/fff2ead8-3ec3-474b-80d3-b4c7f2019158" />

#### 未知用户保持原始字面路径

<img width="1352" height="848" alt="2" src="https://github.com/user-attachments/assets/186cc6fb-3390-4ee2-962a-462912be2b4a" />

#### 已存在的其他用户 `~root` 解析为对应主目录

<img width="1352" height="848" alt="3" src="https://github.com/user-attachments/assets/82419f74-3632-4ba3-9e3a-bdae67d7cc10" />

## 关联 Issue

Related #7032

Follow-up to #7088
