### PR TITLE
✨ feat(sidebar): 添加一键关闭所有活跃连接的功能

### DIFF
--- a/apps/desktop/src/components/layout/AppSidebar.vue
+++ b/apps/desktop/src/components/layout/AppSidebar.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { translateBackendError } from "@/i18n/backend-errors";
-import { Upload, Download, FolderPlus, FolderOpen, RefreshCw, ChevronsLeft, ChevronsUp, Trash2, FolderInput, Check, Minus, Square, X } from "@lucide/vue";
+import { Upload, Download, FolderPlus, FolderOpen, RefreshCw, ChevronsLeft, ChevronsUp, Trash2, FolderInput, Check, Minus, Square, X, Loader2, Unplug } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -10,6 +10,7 @@ import LightDropdown from "@/components/ui/LightDropdown.vue";
 import LightTooltip from "@/components/ui/LightTooltip.vue";
 import ConnectionTree from "@/components/sidebar/ConnectionTree.vue";
 import { applyConnectionMultiSelection, emptyConnectionMultiSelection, isExitConnectionMultiSelectionShortcut } from "@/lib/sidebar/sidebarConnectionMultiSelect";
+import { disconnectSidebarConnections } from "@/lib/sidebar/sidebarConnectionDisconnect";
 import { connectionGroupDestinationRows } from "@/lib/sidebar/sidebarLayout";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useToast } from "@/composables/useToast";
@@ -37,6 +38,7 @@ const { toast } = useToast();
 const connectionTreeRef = ref<InstanceType<typeof ConnectionTree>>();
 const showDeleteSelectedConfirm = ref(false);
 const showCreateSelectedGroupDialog = ref(false);
+const isDisconnectingAllActiveConnections = ref(false);
 const selectedGroupName = ref("");
 const UNGROUPED_GROUP_VALUE = "__ungrouped";
 const importSourceItems = computed(() => [
@@ -73,6 +75,27 @@ async function refreshTree() {
     await connectionStore.refreshAllTree();
   } catch (e: any) {
     toast(t("connection.connectFailed", { message: translateBackendError(t, e) }), 5000);
+  }
+}
+
+async function disconnectAllActiveConnections() {
+  if (isDisconnectingAllActiveConnections.value) return;
+  const connectionIds = [...connectionStore.connectedIds];
+  if (!connectionIds.length) return;
+
+  isDisconnectingAllActiveConnections.value = true;
+  try {
+    const result = await disconnectSidebarConnections(connectionIds, (connectionId) => connectionStore.disconnect(connectionId));
+    if (!result.failed) {
+      toast(t("connection.disconnectedSelected", { count: connectionIds.length }), 2000);
+    } else if (result.succeeded > 0) {
+      toast(t("connection.disconnectSelectedPartial", { succeeded: result.succeeded, failed: result.failed }), 5000);
+    } else {
+      const message = result.firstError instanceof Error ? result.firstError.message : String(result.firstError);
+      toast(t("connection.saveFailed", { message }), 5000);
+    }
+  } finally {
+    isDisconnectingAllActiveConnections.value = false;
   }
 }
 
@@ -264,6 +287,12 @@ defineExpose({ focusSearch, locateTabInSidebar });
           <LightTooltip :text="t('contextMenu.refreshChildren')" side="bottom" :delay="0" :close-delay="0" nowrap>
             <Button variant="ghost" size="icon" class="h-5 w-5" @click="refreshTree">
               <RefreshCw class="h-3 w-3" />
+            </Button>
+          </LightTooltip>
+          <LightTooltip :text="t('sidebar.disconnectAllActiveConnections')" side="bottom" :delay="0" :close-delay="0" nowrap>
+            <Button variant="ghost" size="icon" class="h-5 w-5" :disabled="connectionStore.connectedIds.size === 0 || isDisconnectingAllActiveConnections" @click="disconnectAllActiveConnections">
+              <Loader2 v-if="isDisconnectingAllActiveConnections" class="h-3 w-3 animate-spin" />
+              <Unplug v-else class="h-3 w-3" />
             </Button>
           </LightTooltip>
           <LightTooltip :text="t('sidebar.collapse')" side="bottom" :delay="0" :close-delay="0" nowrap>

--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, shallowRef, computed, nextTick, watch, provide, onMounted, onUnmounted, type Component, type ComponentPublicInstance, type CSSProperties } from "vue";
 import { useI18n } from "vue-i18n";
-import { Search, X, ListFilter, ListOrdered, ArrowDownAZ, ArrowUpZA, CircleDot, Crosshair, Server, Database, FolderTree, Table2, Eye, RotateCcw, Loader2, Unplug } from "@lucide/vue";
+import { Search, X, ListFilter, ListOrdered, ArrowDownAZ, ArrowUpZA, CircleDot, Crosshair, Server, Database, FolderTree, Table2, Eye, RotateCcw } from "@lucide/vue";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useQueryStore } from "@/stores/queryStore";
 import { useSavedSqlStore } from "@/stores/savedSqlStore";
@@ -82,7 +82,6 @@ import { alignedSidebarCommentLabelWidths, isSidebarCommentAlignableNode, sideba
 import { formatSidebarObjectStorage, sidebarTableStorageScopes, supportsSidebarTableStorage } from "@/lib/sidebar/sidebarDatabaseStorage";
 import { sidebarScrollbarGeometry as calculateSidebarScrollbarGeometry } from "@/lib/sidebar/sidebarScrollbar";
 import { createSidebarLayoutMonitor, type SidebarExpandedConnectionInfo } from "@/lib/sidebar/sidebarLayoutMonitor";
-import { disconnectSidebarConnections } from "@/lib/sidebar/sidebarConnectionDisconnect";
 import { compileSearchRegex } from "@/lib/common/searchPattern";
 
 const { t } = useI18n();
@@ -97,7 +96,6 @@ const regexMode = ref(false);
 const sidebarSearchLoadingTracker = createSidebarSearchLoadingTracker();
 const isSidebarSearchLoading = ref(false);
 const showConnectedConnectionsOnly = ref(false);
-const isDisconnectingAllActiveConnections = ref(false);
 const searchInputRef = ref<HTMLInputElement>();
 const rootRef = ref<HTMLElement>();
 const sidebarRootStyle = computed<Record<string, string>>(() => ({ fontSize: `${settingsStore.editorSettings.sidebarFontSize}px` }));
@@ -224,31 +222,6 @@ watch(
   },
   { flush: "sync" },
 );
-
-async function disconnectAllActiveConnections() {
-  if (isDisconnectingAllActiveConnections.value) return;
-  const connectionIds = [...store.connectedIds];
-  if (!connectionIds.length) {
-    showConnectedConnectionsOnly.value = false;
-    return;
-  }
-
-  isDisconnectingAllActiveConnections.value = true;
-  try {
-    const result = await disconnectSidebarConnections(connectionIds, (connectionId) => store.disconnect(connectionId));
-    if (!result.failed) {
-      toast(t("connection.disconnectedSelected", { count: connectionIds.length }), 2000);
-    } else if (result.succeeded > 0) {
-      toast(t("connection.disconnectSelectedPartial", { succeeded: result.succeeded, failed: result.failed }), 5000);
-    } else {
-      const message = result.firstError instanceof Error ? result.firstError.message : String(result.firstError);
-      toast(t("connection.saveFailed", { message }), 5000);
-    }
-  } finally {
-    isDisconnectingAllActiveConnections.value = false;
-    if (store.connectedIds.size === 0) showConnectedConnectionsOnly.value = false;
-  }
-}
 
 function refreshActiveSidebarTableSearches() {
   if (isTreeSearchFiltering.value) return;
@@ -2575,13 +2548,6 @@ defineExpose({ focusSearch, createNewGroup, collapseAllTreeNodes, locateTabInSid
         </div>
       </div>
     </CustomContextMenu>
-    <div v-if="showConnectedConnectionsOnly && store.connectedIds.size > 0" class="shrink-0 border-t border-border bg-background px-2 py-2">
-      <Button type="button" variant="outline" size="sm" class="h-7 w-full justify-center gap-1.5 text-xs" :disabled="isDisconnectingAllActiveConnections" @click="disconnectAllActiveConnections">
-        <Loader2 v-if="isDisconnectingAllActiveConnections" class="h-3.5 w-3.5 animate-spin" />
-        <Unplug v-else class="h-3.5 w-3.5" />
-        {{ t("sidebar.disconnectAllActiveConnections") }}
-      </Button>
-    </div>
     <SidebarDdlViewDialog
       v-if="sidebarDdlTarget"
       v-model:open="sidebarDdlOpen"


### PR DESCRIPTION
## 变更说明

批量断开继续复用既有逻辑：对活跃连接逐个发起断开，支持执行中禁用、成功、部分失败和全部失败反馈。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="378" height="230" alt="iShot 2026-08-25 16 58 59" src="https://github.com/user-attachments/assets/179e5e01-858b-4611-a923-87ad18d5ac30" />


## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：
- `git diff --check`
- 批量断开 helper 的相关 Vitest 用例

## 关联 Issue

Close #7147