### PR TITLE
fix(kingbase): resolve schema for unqualified grid edits

### DIFF
--- a/agents/drivers/kingbase-go/kingbase_metadata.go
+++ b/agents/drivers/kingbase-go/kingbase_metadata.go
@@ -88,6 +88,7 @@ type metadataListConstraints struct {
 type columnInfo struct {
 	Name                   string  `json:"name"`
 	DataType               string  `json:"data_type"`
+	ResolvedSchema         *string `json:"resolved_schema,omitempty"`
 	FullDataType           string  `json:"-"`
 	IsNullable             bool    `json:"is_nullable"`
 	ColumnDefault          *string `json:"column_default"`
@@ -1279,43 +1280,66 @@ func completionNameMatches(name string, request completionAssistantRequest) bool
 }
 
 func (s *server) getColumns(schema, table string) ([]columnInfo, error) {
-	effective, err := s.effectiveSchema(schema)
-	if err != nil {
-		return nil, err
-	}
-	primary, _ := s.primaryKeys(effective, table)
 	if s.mode.mysqlCompat {
+		effective, err := s.effectiveSchema(schema)
+		if err != nil {
+			return nil, err
+		}
+		primary, _ := s.primaryKeys(effective, table)
 		return s.informationSchemaColumns(effective, table, primary)
 	}
 	catalog, prefix := "sys_catalog", "sys"
 	if s.mode.postgresCatalog {
 		catalog, prefix = "pg_catalog", "pg"
-		return s.queryCatalogColumns(effective, table, primary, catalog, prefix, "pg_get_expr")
+		result, err := s.queryCatalogColumns(schema, table, catalog, prefix, "pg_get_expr")
+		return s.finishCatalogColumns(schema, table, result, err)
 	}
 	expression := "sys_get_expr"
 	if s.usePgDefaultExpression {
 		expression = "pg_get_expr"
 	}
-	result, err := s.queryCatalogColumns(effective, table, primary, catalog, prefix, expression)
+	result, err := s.queryCatalogColumns(schema, table, catalog, prefix, expression)
 	if err != nil && expression == "sys_get_expr" && isUndefinedFunction(err, expression) {
 		// Some V8R6 PostgreSQL-mode databases keep sys_catalog while adbin is
 		// pg_node_tree. Cache the compatible function after the exact failure.
 		s.usePgDefaultExpression = true
-		return s.queryCatalogColumns(effective, table, primary, catalog, prefix, "pg_get_expr")
+		result, err = s.queryCatalogColumns(schema, table, catalog, prefix, "pg_get_expr")
 	}
-	return result, err
+	return s.finishCatalogColumns(schema, table, result, err)
+}
+
+func (s *server) finishCatalogColumns(schema, table string, result []columnInfo, err error) ([]columnInfo, error) {
+	if err != nil || len(result) == 0 {
+		return result, err
+	}
+	resolvedSchema := strings.TrimSpace(schema)
+	if result[0].ResolvedSchema != nil {
+		resolvedSchema = *result[0].ResolvedSchema
+	}
+	primary, _ := s.primaryKeys(resolvedSchema, table)
+	for index := range result {
+		result[index].IsPrimaryKey = primary[strings.ToLower(result[index].Name)]
+	}
+	if s.mode.sqlServerIdentity {
+		s.applyIdentityMetadata(resolvedSchema, table, result)
+	}
+	return result, nil
 }
 
 func (s *server) queryCatalogColumns(
 	schema, table string,
-	primary map[string]bool,
 	catalog, prefix, expression string,
 ) ([]columnInfo, error) {
 	identityExpression := "a.attidentity"
 	if s.catalogIdentityUnsupported {
 		identityExpression = "CAST(NULL AS varchar(1)) AS attidentity"
 	}
-	query := fmt.Sprintf(`SELECT a.attname, format_type(a.atttypid, a.atttypmod), NOT a.attnotnull,
+	relationPredicate := fmt.Sprintf("n.nspname = %s AND c.relname = %s", quoteLiteral(schema), quoteLiteral(table))
+	if strings.TrimSpace(schema) == "" {
+		visibilityFunction := kingbaseCatalogFunction(catalog, "sys_table_is_visible", "pg_table_is_visible")
+		relationPredicate = fmt.Sprintf("c.relname = %s AND %s(c.oid)", quoteLiteral(table), visibilityFunction)
+	}
+	query := fmt.Sprintf(`SELECT n.nspname, a.attname, format_type(a.atttypid, a.atttypmod), NOT a.attnotnull,
 	%s(ad.adbin, ad.adrelid), col_description(a.attrelid, a.attnum),
 	CASE WHEN t.typname = 'numeric' AND a.atttypmod > 0 THEN ((a.atttypmod - 4) >> 16) & 65535 END,
 	CASE WHEN t.typname = 'numeric' AND a.atttypmod > 0 THEN (a.atttypmod - 4) & 65535 END,
@@ -1324,11 +1348,11 @@ func (s *server) queryCatalogColumns(
 	FROM %s.%s_attribute a JOIN %s.%s_type t ON t.oid = a.atttypid
 	JOIN %s.%s_class c ON c.oid = a.attrelid JOIN %s.%s_namespace n ON n.oid = c.relnamespace
 	LEFT JOIN %s.%s_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
-WHERE n.nspname = %s AND c.relname = %s AND a.attnum > 0 AND NOT a.attisdropped ORDER BY a.attnum`, expression, identityExpression, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, quoteLiteral(schema), quoteLiteral(table))
+WHERE %s AND a.attnum > 0 AND NOT a.attisdropped ORDER BY a.attnum`, expression, identityExpression, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, catalog, prefix, relationPredicate)
 	rows, err := s.metadataQuery(query)
 	if err != nil && !s.catalogIdentityUnsupported && isUndefinedColumn(err, "attidentity") {
 		s.catalogIdentityUnsupported = true
-		return s.queryCatalogColumns(schema, table, primary, catalog, prefix, expression)
+		return s.queryCatalogColumns(schema, table, catalog, prefix, expression)
 	}
 	if err != nil {
 		return nil, err
@@ -1336,20 +1360,17 @@ WHERE n.nspname = %s AND c.relname = %s AND a.attnum > 0 AND NOT a.attisdropped 
 	defer rows.Close()
 	result := []columnInfo{}
 	for rows.Next() {
-		var name, dataType string
+		var resolvedSchema, name, dataType string
 		var nullable bool
 		var defaultValue, comment, identity sql.NullString
 		var precision, scale, length sql.NullInt64
-		if err := rows.Scan(&name, &dataType, &nullable, &defaultValue, &comment, &precision, &scale, &length, &identity); err != nil {
+		if err := rows.Scan(&resolvedSchema, &name, &dataType, &nullable, &defaultValue, &comment, &precision, &scale, &length, &identity); err != nil {
 			return nil, err
 		}
-		result = append(result, columnInfo{Name: name, DataType: dataType, IsNullable: nullable, ColumnDefault: nullStringPtr(defaultValue), IsPrimaryKey: primary[strings.ToLower(name)], Extra: kingbaseIdentityClause(identity.String), Comment: nullStringPtr(comment), NumericPrecision: nullIntPtr(precision), NumericScale: nullIntPtr(scale), CharacterMaximumLength: nullIntPtr(length)})
+		result = append(result, columnInfo{Name: name, DataType: dataType, ResolvedSchema: stringPtr(resolvedSchema), IsNullable: nullable, ColumnDefault: nullStringPtr(defaultValue), Extra: kingbaseIdentityClause(identity.String), Comment: nullStringPtr(comment), NumericPrecision: nullIntPtr(precision), NumericScale: nullIntPtr(scale), CharacterMaximumLength: nullIntPtr(length)})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
-	}
-	if s.mode.sqlServerIdentity {
-		s.applyIdentityMetadata(schema, table, result)
 	}
 	return result, nil
 }
@@ -1435,7 +1456,7 @@ func (s *server) queryInformationSchemaColumns(schema, table string, primary map
 		if parsed := boundedVarcharLength(dataType); parsed != nil && !length.Valid {
 			length = sql.NullInt64{Int64: int64(*parsed), Valid: true}
 		}
-		result = append(result, columnInfo{Name: name, DataType: resolvedInformationSchemaDataType(dataType, fullDataType.String), FullDataType: fullDataType.String, IsNullable: strings.EqualFold(nullable, "YES"), ColumnDefault: nullStringPtr(defaultValue), IsPrimaryKey: primary[strings.ToLower(name)], Comment: nullStringPtr(comment), NumericPrecision: nullIntPtr(precision), NumericScale: nullIntPtr(scale), CharacterMaximumLength: nullIntPtr(length)})
+		result = append(result, columnInfo{Name: name, DataType: resolvedInformationSchemaDataType(dataType, fullDataType.String), ResolvedSchema: stringPtr(schema), FullDataType: fullDataType.String, IsNullable: strings.EqualFold(nullable, "YES"), ColumnDefault: nullStringPtr(defaultValue), IsPrimaryKey: primary[strings.ToLower(name)], Comment: nullStringPtr(comment), NumericPrecision: nullIntPtr(precision), NumericScale: nullIntPtr(scale), CharacterMaximumLength: nullIntPtr(length)})
 	}
 	return result, rows.Err()
 }

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -228,8 +228,8 @@ func (connection *fallbackConn) QueryContext(_ context.Context, query string, _ 
 			identity = nil
 		}
 		return &valueRows{
-			columns: []string{"column_name", "data_type", "is_nullable", "column_default", "column_comment", "numeric_precision", "numeric_scale", "character_maximum_length", "attidentity"},
-			rows:    [][]driver.Value{{"id", "integer", false, nil, nil, int64(32), int64(0), nil, identity}},
+			columns: []string{"resolved_schema", "column_name", "data_type", "is_nullable", "column_default", "column_comment", "numeric_precision", "numeric_scale", "character_maximum_length", "attidentity"},
+			rows:    [][]driver.Value{{"public", "id", "integer", false, nil, nil, int64(32), int64(0), nil, identity}},
 		}, nil
 	}
 	return nil, errors.New("unexpected query: " + query)
@@ -1075,6 +1075,74 @@ func TestListIndexesFallsBackWhenWithOrdinalityIsUnsupported(t *testing.T) {
 	}
 	if ordinalityQueries != 1 || !server.indexOrdinalityUnsupported {
 		t.Fatalf("unsupported capability was not cached: queries=%v", state.snapshotQueries())
+	}
+}
+
+func TestGetColumnsUsesResolvedSchemaAcrossCatalogMetadata(t *testing.T) {
+	tests := []struct {
+		name               string
+		postgresCatalog    bool
+		requestedSchema    string
+		resolvedSchema     string
+		visibilityFunction string
+		sqlServerIdentity  bool
+	}{
+		{name: "sys catalog search path", resolvedSchema: "tenant_visible", visibilityFunction: "sys_catalog.sys_table_is_visible(c.oid)", sqlServerIdentity: true},
+		{name: "postgres catalog search path", postgresCatalog: true, resolvedSchema: "tenant_pg", visibilityFunction: "pg_catalog.pg_table_is_visible(c.oid)"},
+		{name: "explicit schema", requestedSchema: "tenant_explicit", resolvedSchema: "tenant_explicit"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			catalog := "sys_catalog"
+			prefix := "sys"
+			if test.postgresCatalog {
+				catalog = "pg_catalog"
+				prefix = "pg"
+			}
+			state := &metadataDriverState{query: func(query string) (driver.Rows, error) {
+				switch {
+				case strings.Contains(query, "FROM "+catalog+"."+prefix+"_attribute a"):
+					if test.visibilityFunction != "" {
+						if !strings.Contains(query, test.visibilityFunction) {
+							return nil, fmt.Errorf("unqualified columns query did not use the catalog visibility function: %s", query)
+						}
+					} else if strings.Contains(query, "table_is_visible") || !strings.Contains(query, "n.nspname = '"+test.requestedSchema+"'") {
+						return nil, fmt.Errorf("explicit-schema columns query changed resolution behavior: %s", query)
+					}
+					return &valueRows{
+						columns: []string{"nspname", "attname", "format_type", "nullable", "default", "comment", "precision", "scale", "length", "identity"},
+						rows:    [][]driver.Value{{test.resolvedSchema, "feearea", "character varying", false, nil, nil, nil, nil, nil, nil}},
+					}, nil
+				case strings.Contains(query, "FROM information_schema.table_constraints"):
+					if !strings.Contains(query, "tc.table_schema='"+test.resolvedSchema+"'") {
+						return nil, fmt.Errorf("primary-key lookup did not use resolved schema: %s", query)
+					}
+					return &valueRows{columns: []string{"column_name"}, rows: [][]driver.Value{{"feearea"}}}, nil
+				case strings.Contains(query, "FROM sys.identity_columns"):
+					if !strings.Contains(query, "n.nspname='"+test.resolvedSchema+"'") {
+						return nil, fmt.Errorf("identity lookup did not use resolved schema: %s", query)
+					}
+					return &valueRows{columns: []string{"attname", "seed_value", "increment_value"}, rows: [][]driver.Value{{"feearea", "1", "1"}}}, nil
+				default:
+					return nil, fmt.Errorf("unexpected query: %s", query)
+				}
+			}}
+			server := newServer()
+			server.db = openMetadataDB(t, state)
+			server.mode.postgresCatalog = test.postgresCatalog
+			server.mode.sqlServerIdentity = test.sqlServerIdentity
+
+			columns, err := server.getColumns(test.requestedSchema, "m_workflow")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(columns) != 1 || columns[0].ResolvedSchema == nil || *columns[0].ResolvedSchema != test.resolvedSchema || !columns[0].IsPrimaryKey {
+				t.Fatalf("resolved relation metadata was lost: %#v", columns)
+			}
+			if test.sqlServerIdentity && (columns[0].Extra == nil || *columns[0].Extra != "IDENTITY(1,1)") {
+				t.Fatalf("identity metadata did not use the resolved relation: %#v", columns)
+			}
+		})
 	}
 }
 
@@ -3285,6 +3353,9 @@ func TestMySQLCompatColumnsUsePostgresColumnComments(t *testing.T) {
 	}
 	if columns[0].Extra != nil {
 		t.Fatalf("MySQL-compatible metadata must not infer PostgreSQL identity: %#v", columns[0].Extra)
+	}
+	if columns[0].ResolvedSchema == nil || *columns[0].ResolvedSchema != "public" {
+		t.Fatalf("MySQL-compatible metadata must keep its effective schema: %#v", columns[0])
 	}
 
 	state.mu.Lock()

--- a/apps/desktop/src/lib/metadata/tableMetadataCache.ts
+++ b/apps/desktop/src/lib/metadata/tableMetadataCache.ts
@@ -328,13 +328,13 @@ export async function loadTableMetadata(request: TableMetadataRequest): Promise<
       scope,
       async () => {
         // Column discovery can be especially slow on Oracle. Start row-identity
-        // discovery independently unless an unqualified Vastbase relation must
-        // first report its visible schema for the index lookup.
-        const resolveVastbaseSchema = request.databaseType === "vastbase" && !request.schema;
-        const indexesPromise = resolveVastbaseSchema ? undefined : loadTableIndexes(request).catch((): IndexInfo[] => []);
+        // discovery independently unless an agent-backed PostgreSQL-family
+        // relation must first report its visible schema for the index lookup.
+        const resolveReportedSchema = (request.databaseType === "vastbase" || request.databaseType === "kingbase") && !request.schema;
+        const indexesPromise = resolveReportedSchema ? undefined : loadTableIndexes(request).catch((): IndexInfo[] => []);
         const columnsResult = await columnsPromise;
         const columns = columnsResult.columns;
-        const resolvedSchema = resolveVastbaseSchema ? columns.find((column) => column.resolved_schema)?.resolved_schema : request.schema;
+        const resolvedSchema = resolveReportedSchema ? columns.find((column) => column.resolved_schema)?.resolved_schema : request.schema;
         const indexes = columns.length > 0 ? await (indexesPromise ?? loadTableIndexes({ ...request, schema: resolvedSchema }).catch((): IndexInfo[] => [])) : [];
         const primaryKeys = editableRowIdentifierColumns(request.databaseType as DatabaseType, columns, indexes, request.tableType);
         return {

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -3823,15 +3823,16 @@ export const useQueryStore = defineStore("query", () => {
     // Oracle-family connection databases are service names, not schemas. When
     // the query does not qualify a schema, let the driver resolve the current
     // login user's schema instead of looking up metadata under the service name.
-    // An unqualified Vastbase query runs in the connection's current
-    // search_path. Do not reinterpret the selected database as a schema; the
-    // agent resolves the visible relation's actual namespace with the columns.
-    const useCurrentVastbaseSchema = dbType === "vastbase" && !source.schema && !tab.schema;
+    // Unqualified agent-backed PostgreSQL-family queries run in the
+    // connection's current search_path. Do not reinterpret the selected
+    // database as a schema; the agent reports the visible relation's actual
+    // namespace with the columns.
+    const resolveAgentSearchPathSchema = (dbType === "vastbase" || dbType === "kingbase") && !source.schema && !tab.schema;
     // PostgreSQL-compatible unqualified names also resolve through the
     // connection's search_path. Keep the metadata request unqualified when no
     // schema was selected instead of assuming public (or the database name).
     const useCurrentPostgresSchema = (dbType === "postgres" || dbType === "kwdb") && !source.schema && !tab.schema;
-    const resolvedSchema = (dbType === "sqlserver" && !source.schema) || (ORACLE_LIKE_METADATA_TYPES.has(dbType) && !schema) || useCurrentVastbaseSchema || useCurrentPostgresSchema ? "" : metadataSchemaForConnection(conn, metadataDatabase, schema || undefined);
+    const resolvedSchema = (dbType === "sqlserver" && !source.schema) || (ORACLE_LIKE_METADATA_TYPES.has(dbType) && !schema) || resolveAgentSearchPathSchema || useCurrentPostgresSchema ? "" : metadataSchemaForConnection(conn, metadataDatabase, schema || undefined);
     const metadataSchema = normalizeUppercaseFoldedMetadataIdentifier(dbType, resolvedSchema || undefined, source.schema ? source.schemaQuoted : false) || "";
     const metadataTableName = normalizeUppercaseFoldedMetadataIdentifier(dbType, source.tableName, source.tableNameQuoted)!;
     const metadataCatalog = normalizeUppercaseFoldedMetadataIdentifier(dbType, source.catalog, source.catalogQuoted);
@@ -3863,7 +3864,8 @@ export const useQueryStore = defineStore("query", () => {
   }
 
   function loadedEditableSourceFromMetadata(target: EditableSourceMetadataTarget, metadata: Awaited<ReturnType<typeof loadTableMetadata>>["metadata"]): LoadedEditableSource {
-    const writeSchema = target.request.databaseType === "vastbase" && !target.writeSchema ? metadata.schema : target.writeSchema;
+    const usesReportedSchema = target.request.databaseType === "vastbase" || target.request.databaseType === "kingbase";
+    const writeSchema = usesReportedSchema && !target.writeSchema ? metadata.schema : target.writeSchema;
     return {
       source: target.source,
       analysis: target.analysis,

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -3003,6 +3003,101 @@ test("uses the visible Vastbase relation schema for unqualified query writes", a
   }
 });
 
+test("uses the visible Kingbase relation schema for an unqualified aliased query target", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  const columnRequests: Array<{ database: string | null; schema: string | null; table: string | null }> = [];
+
+  connectionStore.addEphemeralConnection(kingbaseConn("kingbase-1"));
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/query/execute-multi") {
+      return new Response(
+        JSON.stringify([
+          {
+            columns: ["feearea", "month", "status"],
+            rows: [["1010", 202507, "3"]],
+            affected_rows: 0,
+            execution_time_ms: 1,
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/analyze-editability") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      const explicitSchema = body.sql.includes("actual_schema") ? "actual_schema" : undefined;
+      return new Response(
+        JSON.stringify({
+          editable: true,
+          analysis: {
+            schema: explicitSchema,
+            schemaQuoted: false,
+            tableName: "m_workflow",
+            tableNameQuoted: false,
+            tableAlias: "mw",
+            selectStar: true,
+            sources: [{ key: "mw:0", schema: explicitSchema, tableName: "m_workflow", tableNameQuoted: false, schemaQuoted: false, alias: "mw" }],
+            columns: [],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.startsWith("/api/schema/columns?")) {
+      const params = new URL(url, "http://localhost").searchParams;
+      columnRequests.push({ database: params.get("database"), schema: params.get("schema"), table: params.get("table") });
+      const resolvedSchema = params.get("schema") || "workflow_schema";
+      return new Response(
+        JSON.stringify([
+          { name: "feearea", data_type: "varchar", resolved_schema: resolvedSchema, is_nullable: false, column_default: null, is_primary_key: false, extra: null, comment: null },
+          { name: "month", data_type: "integer", resolved_schema: resolvedSchema, is_nullable: false, column_default: null, is_primary_key: false, extra: null, comment: null },
+          { name: "status", data_type: "varchar", resolved_schema: resolvedSchema, is_nullable: false, column_default: null, is_primary_key: false, extra: null, comment: null },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url === "/api/query/prepare-pagination-plan") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      return new Response(JSON.stringify({ sqlToExecute: body.options.sql, useAgentResultSession: false }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected request", { status: 500 });
+  });
+
+  try {
+    const tabId = store.createTab("kingbase-1", "lx_dev_db", "Unqualified", "query");
+    await store.executeTabSql(tabId, "select * from m_workflow AS mw where feearea = '1010' and month = 202507");
+
+    const tab = store.tabs.find((item) => item.id === tabId);
+    await waitFor(() => columnRequests.length > 0 && tab?.tableMeta?.tableName === "m_workflow");
+    assert.deepEqual(columnRequests, [{ database: "lx_dev_db", schema: "", table: "m_workflow" }]);
+    assert.equal(tab?.tableMeta?.database, "lx_dev_db");
+    assert.equal(tab?.tableMeta?.schema, "workflow_schema");
+    assert.deepEqual(tab?.tableMeta?.primaryKeys, []);
+    assert.equal(tab?.queryAnalysis?.tableAlias, "mw");
+    assert.equal(tab?.queryEditabilityReason, undefined);
+
+    const explicitTabId = store.createTab("kingbase-1", "lx_dev_db", "Explicit", "query");
+    await store.executeTabSql(explicitTabId, "select * from actual_schema.m_workflow AS mw where feearea = '1010'");
+
+    const explicitTab = store.tabs.find((item) => item.id === explicitTabId);
+    await waitFor(() => columnRequests.length > 1 && explicitTab?.tableMeta?.tableName === "m_workflow");
+    assert.deepEqual(columnRequests[1], { database: "lx_dev_db", schema: "actual_schema", table: "m_workflow" });
+    assert.equal(explicitTab?.tableMeta?.schema, "actual_schema");
+    assert.equal(explicitTab?.queryAnalysis?.tableAlias, "mw");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test("keeps PostgreSQL quoted primary keys distinct from case-only result columns", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());

--- a/packages/app-tests/tableMetadataCache.test.ts
+++ b/packages/app-tests/tableMetadataCache.test.ts
@@ -61,37 +61,51 @@ test("table metadata loader deduplicates equivalent in-flight requests and cache
   assert.equal(getColumns.mock.calls.length, 1);
 });
 
-test("uses the visible Vastbase relation schema for the index lookup", async () => {
-  const getColumns = vi.fn(async (): Promise<ColumnInfo[]> => [
-    {
-      name: "id",
-      data_type: "bigint",
-      resolved_schema: "tenant_b",
-      is_nullable: false,
-      column_default: null,
-      is_primary_key: true,
-      extra: null,
-    },
-  ]);
+test("uses agent-reported visible schemas for Vastbase and Kingbase index lookups", async () => {
+  const resolvedSchemas: Record<string, string> = {
+    "vastbase-1": "tenant_b",
+    "kingbase-1": "workflow_schema",
+  };
+  const getColumns = vi.fn(async (connectionId: string): Promise<ColumnInfo[]> => {
+    const resolvedSchema = resolvedSchemas[connectionId];
+    assert.ok(resolvedSchema);
+    return [
+      {
+        name: "id",
+        data_type: "bigint",
+        resolved_schema: resolvedSchema,
+        is_nullable: false,
+        column_default: null,
+        is_primary_key: true,
+        extra: null,
+      },
+    ];
+  });
   const listIndexes = vi.fn(async (): Promise<IndexInfo[]> => []);
   vi.doMock("@/lib/backend/api", () => ({ getColumns, listIndexes }));
 
   const { clearTableMetadataCache, loadTableMetadata } = await import("../../apps/desktop/src/lib/metadata/tableMetadataCache.ts");
   clearTableMetadataCache();
 
-  const result = await loadTableMetadata({
-    connectionId: "conn",
-    database: "app",
-    schema: "",
-    tableName: "users",
-    tableType: "TABLE",
-    databaseType: "vastbase",
-    driverProfile: "vastbase",
-  });
+  const testCases = [
+    { connectionId: "vastbase-1", databaseType: "vastbase", resolvedSchema: "tenant_b" },
+    { connectionId: "kingbase-1", databaseType: "kingbase", resolvedSchema: "workflow_schema" },
+  ] as const;
+  for (const [index, testCase] of testCases.entries()) {
+    const result = await loadTableMetadata({
+      connectionId: testCase.connectionId,
+      database: "app",
+      schema: "",
+      tableName: "users",
+      tableType: "TABLE",
+      databaseType: testCase.databaseType,
+      driverProfile: testCase.databaseType,
+    });
 
-  assert.equal(result.metadata.schema, "tenant_b");
-  assert.equal(listIndexes.mock.calls.length, 1);
-  assert.equal(listIndexes.mock.calls[0]?.[2], "tenant_b");
+    assert.equal(result.metadata.schema, testCase.resolvedSchema);
+    assert.equal(listIndexes.mock.calls[index]?.[2], testCase.resolvedSchema);
+  }
+  assert.equal(listIndexes.mock.calls.length, 2);
 });
 
 test("table metadata invalidation keeps unrelated schemas cached", async () => {


### PR DESCRIPTION
## 变更说明

修复 KingbaseES 查询结果页编辑或删除未限定关系时，将数据库名误作 schema，进而生成类似 UPDATE "lx_dev_db"."m_workflow" 并报“关系不存在”的问题。

- 未限定 Kingbase relation 通过 SYS_TABLE_IS_VISIBLE / PG_TABLE_IS_VISIBLE 按 search_path 解析真实 schema，并在 column metadata 中返回 resolved_schema
- PK、identity、index metadata 统一使用解析后的 schema
- tableMetadataCache 将 Kingbase 纳入现有 Vastbase resolved-schema 传播流程
- QueryStore 对未限定 Kingbase relation 不再把 database 当 schema，并以 metadata 返回的 schema 作为 DataGrid 写入目标
- 显式 schema 行为保持不变；MySQL compatibility mode 保持原有 information_schema 路径
- 不修改 DataGrid SQL builder、UI、依赖/version 或 #4228 专属逻辑

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 仅调整 metadata/query store 数据流，没有 UI 组件、样式、文案或视觉交互改动，截图不适用。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] make check 通过
- [ ] make cargo-check-fast 通过
- [x] 相关测试通过

自动化检查：

- GOMAXPROCS=1 go test -count=1 -p=1 ./...（Go 1.22 官方容器，只读挂载）
- corepack pnpm@10.27.0 exec vitest run packages/app-tests/queryStore.test.ts packages/app-tests/tableMetadataCache.test.ts：202 passed
- corepack pnpm@10.27.0 exec vitest run apps/desktop/src/components/grid/__tests__/DataGridEditTableStructureShortcut.spec.ts：10 passed
- corepack pnpm@10.27.0 typecheck：通过
- corepack pnpm@10.27.0 lint：退出码 0；仅 23 条未涉及文件中的既有 warning
- git diff --check：通过

真实 KingbaseES E2E：

- KingbaseES V009R001C010，database_mode=pg
- search_path 设置为 dbx_first, dbx_actual, public；m_workflow 只存在于第二项 dbx_actual
- origin/main 真实复现：未限定 metadata 使用 current_schema() 后找不到表，数据库名作为 schema 的写入目标报 relation 不存在
- 当前修复验证通过：resolved_schema=dbx_actual、复合 PK、主键/自定义 index、qualified UPDATE、qualified DELETE、显式 schema
- 真实验证了 sys_catalog.sys_table_is_visible；同时强制走 postgresCatalog 生产路径验证了 pg_catalog.pg_table_is_visible
- E2E 测试数据库、schema、表及专用容器均已清理

## 关联 Issue

Closes #7141