### PR TITLE
Fix：恢复 SQL 编辑器大小写转换快捷键

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -131,6 +131,7 @@ import { createShellLineCommentHighlight } from "@/lib/editor/codemirrorShellLin
 import { extendQueryEditorSelection, runQueryEditorAltExtendSelection } from "@/lib/editor/queryEditorExtendSelection";
 import { createQueryEditorStringMouseSelection } from "@/lib/editor/queryEditorStringMouseSelection";
 import { createQueryEditorCompletionShortcutBindings } from "@/lib/editor/queryEditorCompletionShortcut";
+import { createQueryEditorSelectionCaseShortcutBindings } from "@/lib/editor/queryEditorSelectionCaseShortcut";
 import { acceptSelectedCompletionWithRetry, acceptSelectedOrFirstCompletion } from "@/lib/editor/queryEditorCompletionAcceptance";
 import type { StatementExecutionMarker } from "@/lib/tabs/tabPresentation";
 import { isSchemaAware, isSingleDatabase, supportsDatabaseNameCompletion, supportsDatabaseSchemaQualifier, supportsQueryEditorBlockComments, supportsSqlInListPaste } from "@/lib/database/databaseFeatureSupport";
@@ -1964,8 +1965,8 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
         ...binding(shortcuts.redo, (view) => codeMirrorRedo?.(view) ?? false),
         ...binding(shortcuts.selectAll, (view) => codeMirrorSelectAll?.(view) ?? false),
         ...binding(shortcuts.extendSelection, extendQueryEditorSelectionForView),
-        ...binding(shortcuts.uppercaseSelection, () => convertSelectedSqlCase("upper")),
-        ...binding(shortcuts.lowercaseSelection, () => convertSelectedSqlCase("lower")),
+        ...createQueryEditorSelectionCaseShortcutBindings(shortcuts.uppercaseSelection, () => convertSelectedSqlCase("upper")),
+        ...createQueryEditorSelectionCaseShortcutBindings(shortcuts.lowercaseSelection, () => convertSelectedSqlCase("lower")),
         ...binding(shortcuts.toggleLineComment, (view) => codeMirrorToggleLineComment?.(view) ?? false),
         ...binding(shortcuts.toggleBlockComment, (view) => {
           if (!supportsQueryEditorBlockComments(props.databaseType)) return false;

--- a/apps/desktop/src/lib/__tests__/editor/keyboardShortcuts.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/keyboardShortcuts.spec.ts
@@ -41,6 +41,13 @@ describe("keyboard shortcut matching", () => {
     expect(eventToShortcut({ key: "+", ctrlKey: true, shiftKey: true }, "Win32")).toBe("Shift+Mod+Plus");
   });
 
+  it.each([
+    ["¨", "KeyU", "Shift+Alt+U"],
+    ["Ò", "KeyL", "Shift+Alt+L"],
+  ])("records macOS Option-modified %s by physical letter", (key, code, expected) => {
+    expect(eventToShortcut({ key, code, altKey: true, shiftKey: true }, "MacIntel")).toBe(expected);
+  });
+
   it("keeps Control distinct from Command when recording macOS shortcuts", () => {
     const controlShortcut = eventToShortcut({ key: "b", ctrlKey: true }, "MacIntel");
 

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorSelectionCaseShortcut.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorSelectionCaseShortcut.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+
+import { EditorState, EditorSelection } from "@codemirror/state";
+import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import { createQueryEditorSelectionCaseShortcutBindings } from "@/lib/editor/queryEditorSelectionCaseShortcut";
+
+function createView(shortcut: string, run: (view: EditorView) => boolean, platform: string): EditorView {
+  return new EditorView({
+    parent: document.createElement("div"),
+    state: EditorState.create({
+      doc: "select MixedCase",
+      selection: EditorSelection.range(0, 16),
+      extensions: [keymap.of(createQueryEditorSelectionCaseShortcutBindings(shortcut, run, platform))],
+    }),
+  });
+}
+
+describe("QueryEditor selection case shortcuts", () => {
+  it.each([
+    ["Shift+Alt+U", "U"],
+    ["Shift+Alt+L", "L"],
+  ])("matches macOS %s by physical key when Option transforms event.key", (shortcut, code) => {
+    const run = vi.fn(() => true);
+    const view = createView(shortcut, run, "MacIntel");
+    const event = new KeyboardEvent("keydown", {
+      key: code === "U" ? "¨" : "Ò",
+      code: `Key${code}`,
+      altKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(runScopeHandlers(view, event, "editor")).toBe(true);
+    expect(run).toHaveBeenCalledOnce();
+    view.destroy();
+  });
+
+  it("leaves the shortcut unhandled when the conversion command declines", () => {
+    const run = vi.fn(() => false);
+    const view = createView("Shift+Alt+U", run, "MacIntel");
+    const event = new KeyboardEvent("keydown", {
+      key: "¨",
+      code: "KeyU",
+      altKey: true,
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    expect(runScopeHandlers(view, event, "editor")).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(run).toHaveBeenCalledOnce();
+    view.destroy();
+  });
+
+  it("keeps multi-stroke custom shortcuts on CodeMirror's sequence binding", () => {
+    const run = vi.fn(() => true);
+    expect(createQueryEditorSelectionCaseShortcutBindings("Mod+K Mod+U", run, "MacIntel")).toEqual([
+      {
+        key: "Mod-k Mod-u",
+        preventDefault: true,
+        run,
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/editor/keyboardShortcuts.ts
+++ b/apps/desktop/src/lib/editor/keyboardShortcuts.ts
@@ -37,10 +37,17 @@ function shortcutKeyName(key: string): string | null {
   return key;
 }
 
+function shortcutKeyNameFromEvent(event: ShortcutLikeEvent, platform: string): string | null {
+  if (event.altKey && isMacShortcutPlatform(platform) && /^Key[A-Z]$/.test(event.code ?? "")) {
+    return event.code!.slice(3);
+  }
+  return shortcutKeyName(event.key);
+}
+
 export function eventToShortcut(event: ShortcutLikeEvent, platform = globalThis.navigator?.platform || ""): string | null {
   if (event.isComposing) return null;
 
-  const key = shortcutKeyName(event.key);
+  const key = shortcutKeyNameFromEvent(event, platform);
   if (!key) return null;
 
   const hasModifier = !!event.metaKey || !!event.ctrlKey || !!event.altKey || !!event.shiftKey;

--- a/apps/desktop/src/lib/editor/queryEditorSelectionCaseShortcut.ts
+++ b/apps/desktop/src/lib/editor/queryEditorSelectionCaseShortcut.ts
@@ -1,0 +1,23 @@
+import type { Command, KeyBinding } from "@codemirror/view";
+import { matchesShortcut } from "@/lib/editor/keyboardShortcuts";
+import { parseShortcutStrokes } from "@/lib/editor/shortcutDisplay";
+import { shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
+
+export function createQueryEditorSelectionCaseShortcutBindings(shortcut: string, run: Command, platform = globalThis.navigator?.platform || ""): KeyBinding[] {
+  if (!shortcut) return [];
+
+  // CodeMirror matches event.key, but macOS Option+letter produces a composed
+  // character. Use the shared physical-key fallback for single-stroke bindings.
+  if (parseShortcutStrokes(shortcut).length === 1) {
+    return [
+      {
+        any(view, event) {
+          if (!matchesShortcut(event, shortcut, platform)) return false;
+          return run(view);
+        },
+      },
+    ];
+  }
+
+  return [{ key: shortcutToCodeMirrorKey(shortcut), preventDefault: true, run }];
+}


### PR DESCRIPTION
## 修改说明

- 修复 macOS 下 `Shift+Alt+U`、`Shift+Alt+L` 无法转换 SQL 选区大小写的问题
- 修复快捷键设置录入时，Option 组合导致 `U`、`L` 被保存成变形字符的问题
- 单段快捷键复用现有物理键位匹配逻辑，兼容 Option 改写 `KeyboardEvent.key` 的情况
- 保留自定义多段快捷键、右键菜单和原有 SQL 字面量处理行为

## 测试

- 网页实测：选中 SQL 后，大写/小写快捷键均生效，选区保持不变，字符串字面量内容不被转换
- 网页实测：快捷键设置中录入 `Shift+Option+U` 后显示为 `⇧ ⌥ U`
- 网页实测：无选区时不会误输入 Option 特殊字符，右键菜单转换仍正常
- `pnpm exec vitest run`（5 个相关测试文件，71 项通过）
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Fixes #7191