### PR TITLE
fix(editor): 避免惯性滚动误触发字号缩放

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -114,7 +114,7 @@ import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
 import { defaultKeymapForGlobalShortcuts } from "@/lib/editor/codemirrorDefaultKeymap";
 import { appendSqlCompletionSpace } from "@/lib/editor/sqlCompletionInsertion";
 import { compareSqlCompletions, completionLabelPresentation } from "@/lib/editor/sqlCompletionPresentation";
-import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
+import { clampEditorFontSize, createEditorWheelZoomGestureGuard, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
 import { normalizeShortcutSettings, shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
 import { trimmedSelectionLayer } from "@/lib/editor/codemirrorTrimmedSelectionLayer";
 import { currentStatementFrameLayer } from "@/lib/editor/codemirrorCurrentStatementFrameLayer";
@@ -699,6 +699,7 @@ const zoomCommitScheduler = createEditorZoomCommitScheduler((fontSize) => {
   if (settingsStore.editorSettings.fontSize === fontSize) return;
   settingsStore.updateEditorSettings({ fontSize });
 });
+const wheelZoomGestureGuard = createEditorWheelZoomGestureGuard();
 
 const queryEditorAppearanceSettings = computed(() => {
   const settings = settingsStore.editorSettings;
@@ -5388,7 +5389,7 @@ onMounted(async () => {
           return true;
         },
         wheel(event) {
-          if (!event.metaKey && !event.ctrlKey) return false;
+          if (!wheelZoomGestureGuard.accepts(event)) return false;
           event.preventDefault();
           const next = fontSizeFromWheelDelta(liveFontSize.value, event.deltaY);
           applyLiveFontSize(next);

--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -49,7 +49,7 @@ import { copyToClipboard, readTextFromClipboard } from "@/lib/common/clipboard";
 import { trimmedSelectionLayer } from "@/lib/editor/codemirrorTrimmedSelectionLayer";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/backend/safeStorage";
 import { editorFontTheme, loadEditorTheme } from "@/lib/editor/editorThemes";
-import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
+import { clampEditorFontSize, createEditorWheelZoomGestureGuard, createEditorZoomCommitScheduler, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useTheme } from "@/composables/useTheme";
@@ -170,6 +170,7 @@ const configEditorZoomCommitScheduler = createEditorZoomCommitScheduler((fontSiz
   if (settingsStore.editorSettings.fontSize === fontSize) return;
   settingsStore.updateEditorSettings({ fontSize });
 });
+const configEditorWheelZoomGestureGuard = createEditorWheelZoomGestureGuard();
 const knownConfigFormats = ref<Record<string, string>>({});
 const selectedConfigKeys = ref<string[]>([]);
 const searchOpen = ref(false);
@@ -538,7 +539,7 @@ async function mountConfigEditor() {
       keymap.of([...defaultKeymap, ...historyKeymap]),
       EditorView.domEventHandlers({
         wheel(event, eventView) {
-          if (!event.metaKey && !event.ctrlKey) return false;
+          if (!configEditorWheelZoomGestureGuard.accepts(event)) return false;
           event.preventDefault();
           const next = fontSizeFromWheelDelta(configEditorFontSize.value, event.deltaY);
           if (next !== configEditorFontSize.value) {

--- a/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
+++ b/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts
@@ -134,9 +134,10 @@ describe("NacosAdminConsole config workbench layout", () => {
 
   it("keeps the configuration editor zoom behavior aligned with the SQL editor", () => {
     expect(source).toContain("createEditorZoomCommitScheduler");
+    expect(source).toContain("createEditorWheelZoomGestureGuard");
     expect(source).toContain("EditorView.domEventHandlers");
     expect(source).toContain("fontSizeFromWheelDelta(configEditorFontSize.value, event.deltaY)");
-    expect(source).toContain("if (!event.metaKey && !event.ctrlKey) return false;");
+    expect(source).toContain("if (!configEditorWheelZoomGestureGuard.accepts(event)) return false;");
     expect(source).toContain("configEditorZoomCommitScheduler.dispose()");
   });
 

--- a/apps/desktop/src/composables/useCellDetailEditor.ts
+++ b/apps/desktop/src/composables/useCellDetailEditor.ts
@@ -10,7 +10,7 @@ import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, cellDetailActiveL
 import { shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { CELL_DETAIL_JSON_FORMAT_MAX_LENGTH, isJsonColumnType } from "@/lib/dataGrid/cellDetailPresentation";
-import { clampEditorFontSize, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
+import { clampEditorFontSize, createEditorWheelZoomGestureGuard, createEditorZoomCommitScheduler, fontSizeFromGestureScale, fontSizeFromWheelDelta } from "@/lib/editor/editorZoom";
 import i18n from "@/i18n";
 import EditorSearchPanel from "@/components/editor/EditorSearchPanel.vue";
 import type { EditorTheme } from "@/stores/settingsStore";
@@ -94,6 +94,7 @@ export function useCellDetailEditor(options: UseCellDetailEditorOptions): UseCel
     if (settingsStore.editorSettings.fontSize === fontSize) return;
     settingsStore.updateEditorSettings({ fontSize });
   });
+  const wheelZoomGestureGuard = createEditorWheelZoomGestureGuard();
 
   function syncEditorFontCssVars(fontSize = liveFontSize, fontFamily = options.fontFamily()) {
     if (!wrapperEl) return;
@@ -278,7 +279,7 @@ export function useCellDetailEditor(options: UseCellDetailEditorOptions): UseCel
             return true;
           },
           wheel(event) {
-            if (!event.metaKey && !event.ctrlKey) return false;
+            if (!wheelZoomGestureGuard.accepts(event)) return false;
             event.preventDefault();
             const next = fontSizeFromWheelDelta(liveFontSize, event.deltaY);
             applyLiveFontSize(next);

--- a/apps/desktop/src/lib/__tests__/editor/editorZoom.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/editorZoom.spec.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { createEditorWheelZoomGestureGuard } from "@/lib/editor/editorZoom";
+
+function wheelEvent(timeStamp: number, modifier = false) {
+  return { timeStamp, metaKey: modifier, ctrlKey: false };
+}
+
+describe("createEditorWheelZoomGestureGuard", () => {
+  it("ignores a modifier pressed during an existing scroll gesture", () => {
+    const guard = createEditorWheelZoomGestureGuard();
+
+    expect(guard.accepts(wheelEvent(100))).toBe(false);
+    expect(guard.accepts(wheelEvent(140, true))).toBe(false);
+    expect(guard.accepts(wheelEvent(200, true))).toBe(false);
+  });
+
+  it("accepts a wheel gesture that starts with a modifier", () => {
+    const guard = createEditorWheelZoomGestureGuard();
+
+    expect(guard.accepts(wheelEvent(100, true))).toBe(true);
+    expect(guard.accepts(wheelEvent(140, true))).toBe(true);
+  });
+
+  it("starts a new zoom gesture after the wheel stream becomes idle", () => {
+    const guard = createEditorWheelZoomGestureGuard();
+
+    expect(guard.accepts(wheelEvent(100))).toBe(false);
+    expect(guard.accepts(wheelEvent(281, true))).toBe(true);
+  });
+
+  it("starts a new gesture when browser timestamps reset", () => {
+    const guard = createEditorWheelZoomGestureGuard();
+
+    expect(guard.accepts(wheelEvent(500))).toBe(false);
+    expect(guard.accepts(wheelEvent(10, true))).toBe(true);
+  });
+
+  it("can be reset between editor sessions", () => {
+    const guard = createEditorWheelZoomGestureGuard();
+
+    expect(guard.accepts(wheelEvent(100))).toBe(false);
+    guard.reset();
+    expect(guard.accepts(wheelEvent(120, true))).toBe(true);
+  });
+});
+
+describe("editor wheel zoom integration", () => {
+  it.each([
+    ["SQL editor", "../../../components/editor/QueryEditor.vue", "wheelZoomGestureGuard"],
+    ["cell detail editor", "../../../composables/useCellDetailEditor.ts", "wheelZoomGestureGuard"],
+    ["Nacos editor", "../../../components/nacos/NacosAdminConsole.vue", "configEditorWheelZoomGestureGuard"],
+  ])("guards %s wheel zoom by gesture origin", (_name, path, guardName) => {
+    const source = readFileSync(new URL(path, import.meta.url), "utf8");
+
+    expect(source).toContain("createEditorWheelZoomGestureGuard");
+    expect(source).toContain(`if (!${guardName}.accepts(event)) return false;`);
+  });
+});

--- a/apps/desktop/src/lib/editor/editorZoom.ts
+++ b/apps/desktop/src/lib/editor/editorZoom.ts
@@ -1,6 +1,30 @@
 export const EDITOR_MIN_FONT_SIZE = 10;
 export const EDITOR_MAX_FONT_SIZE = 24;
 const WHEEL_FONT_ZOOM_SENSITIVITY = 0.0015;
+const WHEEL_GESTURE_IDLE_MS = 180;
+
+type WheelZoomModifierEvent = Pick<WheelEvent, "ctrlKey" | "metaKey" | "timeStamp">;
+
+export function createEditorWheelZoomGestureGuard(idleMs = WHEEL_GESTURE_IDLE_MS) {
+  let lastEventTime = Number.NEGATIVE_INFINITY;
+  let startedWithModifier = false;
+
+  return {
+    accepts(event: WheelZoomModifierEvent) {
+      const hasModifier = event.metaKey || event.ctrlKey;
+      const eventTime = Number.isFinite(event.timeStamp) ? event.timeStamp : 0;
+      if (eventTime < lastEventTime || eventTime - lastEventTime > idleMs) {
+        startedWithModifier = hasModifier;
+      }
+      lastEventTime = eventTime;
+      return startedWithModifier && hasModifier;
+    },
+    reset() {
+      lastEventTime = Number.NEGATIVE_INFINITY;
+      startedWithModifier = false;
+    },
+  };
+}
 
 export function clampEditorFontSize(value: number): number {
   const clamped = Math.min(EDITOR_MAX_FONT_SIZE, Math.max(EDITOR_MIN_FONT_SIZE, value));


### PR DESCRIPTION
## 问题

macOS 触控板滚动存在惯性事件。用户先普通滚动 SQL 编辑器，再在惯性尚未结束时按下 Cmd（例如准备 Cmd+Tab），后续惯性 `wheel` 事件会带上 `metaKey`。现有实现逐事件检查修饰键，因此会把同一普通滚动手势的尾部误判成 Cmd+滚轮缩放，意外改变编辑器字号。

## 修复

- 增加共享的滚轮缩放手势保护器，以 180ms 空闲间隔划分滚动手势
- 只有手势第一个事件已经按住 Cmd/Ctrl 时才允许缩放
- 查询编辑器、单元格详情编辑器和 Nacos 配置编辑器统一使用该判断
- 增加手势起点、空闲后新手势、时间戳重置和三个编辑器接线的回归测试

## 实际验证

在 MySQL 8.4 查询编辑器中通过浏览器底层滚轮事件复现和回归：

- 修复前：普通滚动后 40ms 按下 Cmd，字号 `13px -> 13.8px`
- 修复后：相同事件序列保持 `13px -> 13px`
- 停顿后主动 Cmd+滚轮仍可正常 `13px -> 13.8px`，反向滚动恢复 `13px`

## 检查

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/editorZoom.spec.ts apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleLayout.spec.ts`：34 项通过
- `pnpm typecheck`：通过
- `pnpm lint`：通过（仅仓库既有 warning）
- `pnpm exec oxfmt --check ...`：通过
- `node scripts/sync-connection-types.mjs --check`：通过
- 本地 `pnpm check` 的全量 Vitest 子进程在无 CPU 活动时未自行退出，因此未将全量检查标记为通过；上述定向测试均正常退出

Fixes #4430
