### PR TITLE
fix(kafka): 修复跳过证书校验未生效

### DIFF
--- a/agents/drivers/kafka/src/main/java/com/dbx/agent/kafka/DbxInsecureTrustManagerFactory.java
+++ b/agents/drivers/kafka/src/main/java/com/dbx/agent/kafka/DbxInsecureTrustManagerFactory.java
@@ -1,0 +1,72 @@
+package com.dbx.agent.kafka;
+
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactorySpi;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+/** Trust manager used only when a Kafka connection explicitly skips TLS verification. */
+public final class DbxInsecureTrustManagerFactory {
+    static final String ALGORITHM = "DBX_TRUST_ALL";
+    private static final String PROVIDER_NAME = "DBX_KAFKA_INSECURE_TLS";
+
+    private DbxInsecureTrustManagerFactory() {}
+
+    static void ensureRegistered() {
+        if (Security.getProvider(PROVIDER_NAME) != null) return;
+        synchronized (DbxInsecureTrustManagerFactory.class) {
+            if (Security.getProvider(PROVIDER_NAME) != null) return;
+            Provider provider = new Provider(PROVIDER_NAME, "1.0", "DBX Kafka trust-all provider") {};
+            provider.put("TrustManagerFactory." + ALGORITHM, Spi.class.getName());
+            Security.addProvider(provider);
+        }
+    }
+
+    public static final class Spi extends TrustManagerFactorySpi {
+        private static final TrustManager[] TRUST_MANAGERS = { new TrustAllManager() };
+
+        @Override
+        protected void engineInit(KeyStore keyStore) {}
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) {}
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return TRUST_MANAGERS.clone();
+        }
+    }
+
+    private static final class TrustAllManager extends X509ExtendedTrustManager {
+        private static final X509Certificate[] NO_ISSUERS = new X509Certificate[0];
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return NO_ISSUERS.clone();
+        }
+    }
+}

--- a/agents/drivers/kafka/src/main/java/com/dbx/agent/kafka/KafkaAgent.java
+++ b/agents/drivers/kafka/src/main/java/com/dbx/agent/kafka/KafkaAgent.java
@@ -507,16 +507,9 @@ public final class KafkaAgent {
             }
         }
 
+        // TLS properties
         JsonObject tls = conn.has("tls") && conn.get("tls").isJsonObject()
             ? conn.getAsJsonObject("tls") : null;
-        boolean skipVerify = boolOrDefault(conn, "tls_skip_verify", false)
-            || boolOrDefault(conn, "tlsSkipVerify", false)
-            || (tls != null && boolOrDefault(tls, "skip_verify", false));
-        if (skipVerify) {
-            props.put("ssl.endpoint.identification.algorithm", "");
-        }
-
-        // TLS properties
         if (tls != null) {
             String truststorePath = stringOrEmpty(tls, "truststore_path");
             if (!truststorePath.isBlank()) {
@@ -540,6 +533,20 @@ public final class KafkaAgent {
     static void applyConnectionProperties(JsonObject conn, Properties props) {
         applySecurityProperties(conn, props);
         applyExtraProperties(conn, props);
+        applyTlsSkipVerification(conn, props);
+    }
+
+    private static void applyTlsSkipVerification(JsonObject conn, Properties props) {
+        JsonObject tls = conn.has("tls") && conn.get("tls").isJsonObject()
+            ? conn.getAsJsonObject("tls") : null;
+        boolean skipVerify = boolOrDefault(conn, "tls_skip_verify", false)
+            || boolOrDefault(conn, "tlsSkipVerify", false)
+            || (tls != null && boolOrDefault(tls, "skip_verify", false));
+        if (!skipVerify) return;
+
+        DbxInsecureTrustManagerFactory.ensureRegistered();
+        props.put("ssl.endpoint.identification.algorithm", "");
+        props.put("ssl.trustmanager.algorithm", DbxInsecureTrustManagerFactory.ALGORITHM);
     }
 
     static String jaasValue(String value) {

--- a/agents/drivers/kafka/src/test/java/com/dbx/agent/kafka/KafkaAgentTest.java
+++ b/agents/drivers/kafka/src/test/java/com/dbx/agent/kafka/KafkaAgentTest.java
@@ -13,6 +13,8 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -27,6 +29,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -1290,6 +1294,46 @@ class KafkaAgentTest {
             "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true keyTab=\"/tmp/user.keytab\" principal=\"user@EXAMPLE.COM\";",
             props.getProperty("sasl.jaas.config")
         );
+    }
+
+    @Test
+    void skipTlsVerificationDisablesHostnameAndCertificateChainValidation() throws Exception {
+        Properties props = new Properties();
+        KafkaAgent.applyConnectionProperties(JsonParser.parseString("""
+            {
+              "security_protocol": "SASL_SSL",
+              "tls_skip_verify": true,
+              "properties": {
+                "ssl.endpoint.identification.algorithm": "https",
+                "ssl.trustmanager.algorithm": "PKIX"
+              }
+            }
+            """).getAsJsonObject(), props);
+
+        assertEquals("", props.getProperty("ssl.endpoint.identification.algorithm"));
+        assertEquals(
+            DbxInsecureTrustManagerFactory.ALGORITHM,
+            props.getProperty("ssl.trustmanager.algorithm")
+        );
+
+        TrustManagerFactory factory = TrustManagerFactory.getInstance(DbxInsecureTrustManagerFactory.ALGORITHM);
+        factory.init((KeyStore) null);
+        X509TrustManager trustManager = (X509TrustManager) factory.getTrustManagers()[0];
+        assertDoesNotThrow(() -> trustManager.checkServerTrusted(new X509Certificate[0], "RSA"));
+    }
+
+    @Test
+    void verifiedTlsKeepsKafkaDefaultTrustAndHostnameValidation() {
+        Properties props = new Properties();
+        KafkaAgent.applyConnectionProperties(JsonParser.parseString("""
+            {
+              "security_protocol": "SASL_SSL",
+              "tls_skip_verify": false
+            }
+            """).getAsJsonObject(), props);
+
+        assertNull(props.getProperty("ssl.endpoint.identification.algorithm"));
+        assertNull(props.getProperty("ssl.trustmanager.algorithm"));
     }
 
     @Test


### PR DESCRIPTION
## 问题

Kafka 的“跳过证书校验”此前只清空 `ssl.endpoint.identification.algorithm`，因此仅关闭主机名校验；自签名证书或未知 CA 的证书链仍会被 JVM 拒绝，勾选前后都会报 `unable to find valid certification path`。

## 变更

- 为显式启用“跳过证书校验”的 Kafka 连接注册独立 trust-all `TrustManagerFactory`
- 同时关闭证书链和主机名校验，未启用该选项的连接仍使用 JVM/Kafka 默认校验
- 让该选项在高级 Kafka 属性之后应用，避免被 `ssl.trustmanager.algorithm` 或主机名校验属性意外覆盖
- 补充启用和未启用两条回归测试

## 实际验证

搭建隔离的 Kafka 4.1.2 KRaft 单节点，配置：

- `SASL_SSL`
- `SCRAM-SHA-256`
- 自签名证书
- 用户名密码认证

验证结果：

- Kafka 官方客户端配置 truststore 后可正常连接
- 修复前：关闭和开启“跳过证书校验”均报证书链错误
- 修复后：关闭时仍正确拒绝自签名证书；开启时测试连接成功
- 修复后正式连接成功，集群类型为 Kafka，并成功列出测试 topic `dbx-issue-5915`

## 测试

- `./gradlew :kafka:test :kafka:shadowJar --no-daemon`
- `python3 scripts/validate_agents.py`
- `git diff --check`

Fixes #5915