### PR TITLE
fix(oracle): 加速大存储过程源码读取

### DIFF
--- a/agents/drivers/oracle-go/main.go
+++ b/agents/drivers/oracle-go/main.go
@@ -2959,6 +2959,39 @@ func (s *server) getMetadataObjectSource(schema, name, objectType string) (map[s
 }
 
 func (s *server) loadObjectSourceText(schema, name, objectType string) (string, bool, error) {
+	source, found, err := s.loadAggregatedObjectSourceText(schema, name, objectType)
+	if err == nil {
+		return source, found, nil
+	}
+	return s.loadObjectSourceTextRows(schema, name, objectType)
+}
+
+func (s *server) loadAggregatedObjectSourceText(schema, name, objectType string) (string, bool, error) {
+	rows, err := s.queryRows(`
+SELECT DBMS_XMLGEN.CONVERT(
+  XMLAGG(XMLELEMENT(E, TEXT) ORDER BY LINE).EXTRACT('//text()').GETCLOBVAL(),
+  1
+)
+FROM ALL_SOURCE
+WHERE OWNER = :1 AND NAME = :2 AND TYPE = :3`, []any{schema, name, objectType})
+	if err != nil {
+		return "", false, err
+	}
+	defer s.closeRows(rows)
+	if !rows.Next() {
+		return "", false, rows.Err()
+	}
+	var source sql.NullString
+	if err := rows.Scan(&source); err != nil {
+		return "", false, err
+	}
+	if err := rows.Err(); err != nil {
+		return "", false, err
+	}
+	return source.String, source.Valid, nil
+}
+
+func (s *server) loadObjectSourceTextRows(schema, name, objectType string) (string, bool, error) {
 	rows, err := s.queryRows(`
 SELECT TEXT
 FROM ALL_SOURCE

--- a/agents/drivers/oracle-go/main_test.go
+++ b/agents/drivers/oracle-go/main_test.go
@@ -2534,6 +2534,83 @@ func TestGetObjectSourceUsesDBMSMetadataForSequence(t *testing.T) {
 	}
 }
 
+func TestGetObjectSourceAggregatesProcedureSourceInOracle(t *testing.T) {
+	const source = "PROCEDURE DBX_LARGE_SOURCE AS\nBEGIN\n  -- preserve <xml> & special characters\n  NULL;\nEND;"
+	db, scripted := openOracleViewSourceTestDB(t, []oracleViewSourceQueryStep{
+		{
+			queryContains: "DBMS_XMLGEN.CONVERT",
+			args:          []driver.Value{"DBX_TEST", "DBX_LARGE_SOURCE", "PROCEDURE"},
+			rows:          [][]driver.Value{{source}},
+		},
+	})
+	s := newServer()
+	s.db = db
+
+	result, err := s.getObjectSource("DBX_TEST", "DBX_LARGE_SOURCE", "PROCEDURE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["source"] != source || result["object_type"] != "PROCEDURE" {
+		t.Fatalf("unexpected procedure source: %#v", result)
+	}
+	if scripted.next != len(scripted.steps) {
+		t.Fatalf("expected %d queries, got %d", len(scripted.steps), scripted.next)
+	}
+}
+
+func TestGetObjectSourceReturnsEmptyWhenAggregatedSourceIsNull(t *testing.T) {
+	db, scripted := openOracleViewSourceTestDB(t, []oracleViewSourceQueryStep{
+		{
+			queryContains: "DBMS_XMLGEN.CONVERT",
+			args:          []driver.Value{"DBX_TEST", "MISSING_PROC", "PROCEDURE"},
+			rows:          [][]driver.Value{{nil}},
+		},
+	})
+	s := newServer()
+	s.db = db
+
+	result, err := s.getObjectSource("DBX_TEST", "MISSING_PROC", "PROCEDURE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["source"] != "" {
+		t.Fatalf("missing procedure source should be empty: %#v", result)
+	}
+	if scripted.next != len(scripted.steps) {
+		t.Fatalf("expected %d queries, got %d", len(scripted.steps), scripted.next)
+	}
+}
+
+func TestGetObjectSourceFallsBackWhenOracleAggregationFails(t *testing.T) {
+	const firstLine = "PROCEDURE DBX_SOURCE_FALLBACK AS\n"
+	const secondLine = "BEGIN NULL; END;"
+	db, scripted := openOracleViewSourceTestDB(t, []oracleViewSourceQueryStep{
+		{
+			queryContains: "DBMS_XMLGEN.CONVERT",
+			args:          []driver.Value{"DBX_TEST", "DBX_SOURCE_FALLBACK", "PROCEDURE"},
+			err:           errors.New("ORA-19011: Character string buffer too small"),
+		},
+		{
+			queryContains: "SELECT TEXT",
+			args:          []driver.Value{"DBX_TEST", "DBX_SOURCE_FALLBACK", "PROCEDURE"},
+			rows:          [][]driver.Value{{firstLine}, {secondLine}},
+		},
+	})
+	s := newServer()
+	s.db = db
+
+	result, err := s.getObjectSource("DBX_TEST", "DBX_SOURCE_FALLBACK", "PROCEDURE")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["source"] != firstLine+secondLine {
+		t.Fatalf("unexpected fallback procedure source: %#v", result)
+	}
+	if scripted.next != len(scripted.steps) {
+		t.Fatalf("expected %d queries, got %d", len(scripted.steps), scripted.next)
+	}
+}
+
 func TestGetObjectSourcePreservesQuotedSynonymName(t *testing.T) {
 	const synonym = "MixedSynonym"
 	const ddl = `CREATE OR REPLACE EDITIONABLE SYNONYM "AP"."MixedSynonym" FOR "ADM"."S_SPECS"`


### PR DESCRIPTION
## 问题

Oracle 存储过程源码当前通过 Agent 从 `ALL_SOURCE` 逐行读取。大过程会产生大量驱动取行操作：在 Oracle 11g 上用 20,004 行、608,936 字符的过程实测，源码接口需要约 16.65 秒，期间界面持续加载，符合 issue 中的软件无响应现象。

## 改动

- 在 Oracle 端使用 `XMLAGG` 按 `LINE` 聚合源码，只向 Agent 返回一个 CLOB，避免逐行跨驱动读取
- 使用 `DBMS_XMLGEN.CONVERT(..., 1)` 还原 XML 实体，保证单引号、双引号、`<`、`>`、`&` 等源码字符不被改写
- 聚合查询失败时回退原有逐行读取路径，兼容异常数据库环境
- 补充聚合读取、空源码和失败回退回归测试

## 实测

- Oracle XE 11g：608,936 字符源码接口从约 16.65 秒降至约 2.20 秒，修复前后 SHA-256 完全一致
- Oracle 19c：608,940 字符源码接口约 1.24 秒，SHA-256 与写入源码一致
- Oracle 11g 特殊字符过程：单引号、双引号、`<`、`>`、`&` 均原样返回
- 前端实际双击 11g 大过程，到源码标签可用约 3.24 秒，编辑器内容正常显示
- `go test ./...`（Oracle Agent）通过
- `pnpm check` 通过（11,422 个测试）

Fixes #5072