### PR TITLE
Fix：修复数据表单元格首次双击无法编辑

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -12953,6 +12953,7 @@ function currentGridContextMenuItems(): ContextMenuItem[] {
                     width: `${totalWidth}px`,
                     height: `${canvasContentHeight}px`,
                   }"
+                  @dblclick="onCanvasDblClick"
                 >
                   <canvas
                     ref="canvasRef"
@@ -12966,7 +12967,6 @@ function currentGridContextMenuItems(): ContextMenuItem[] {
                     @mouseleave="onCanvasMouseLeave"
                     @mousedown="onCanvasMouseDown"
                     @contextmenu="onCanvasContext"
-                    @dblclick="onCanvasDblClick"
                   />
                   <canvas
                     ref="canvasBackRef"
@@ -12980,9 +12980,8 @@ function currentGridContextMenuItems(): ContextMenuItem[] {
                     @mouseleave="onCanvasMouseLeave"
                     @mousedown="onCanvasMouseDown"
                     @contextmenu="onCanvasContext"
-                    @dblclick="onCanvasDblClick"
                   />
-                  <div ref="canvasOverlayRef" class="canvas-grid-overlay dbx-data-grid-font-family sticky left-0 top-0 z-10 overflow-visible" :style="canvasOverlayStyle">
+                  <div ref="canvasOverlayRef" class="canvas-grid-overlay dbx-data-grid-font-family sticky left-0 top-0 z-10 overflow-visible" :style="canvasOverlayStyle" @dblclick.stop>
                     <div v-if="canvasReadonlyTextCell" class="absolute pointer-events-auto z-20 tabular-nums" :style="canvasReadonlyTextCellStyle" @mousedown.stop @click.stop>
                       <DataGridReadonlyTextSelection :value="canvasReadonlyTextCell.value" :expanded="canvasReadonlyTextCell.expanded" @close="closeReadonlyCellTextSelection" @escape="escapeReadonlyCellTextSelection" />
                     </div>

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -7088,8 +7088,13 @@ function canvasColumnAt(contentX: number): number {
   return low;
 }
 
+function canvasEventSurface(event: MouseEvent): HTMLCanvasElement | null {
+  const currentTarget = event.currentTarget;
+  return currentTarget instanceof HTMLCanvasElement ? currentTarget : activeCanvasSurface();
+}
+
 function canvasHitTest(event: MouseEvent): { rowIndex: number; visibleColIdx: number; rowNumber: boolean } | null {
-  const canvas = activeCanvasSurface();
+  const canvas = canvasEventSurface(event);
   const scroller = canvasScrollerElement();
   if (!canvas || !scroller) return null;
   const rect = canvas.getBoundingClientRect();
@@ -7203,8 +7208,8 @@ function onDomGridWheel(event: WheelEvent) {
 
 function onCanvasMouseMove(event: MouseEvent) {
   stopReleasedSelectionGesture(event);
+  const cursorSurface = canvasEventSurface(event);
   if (columnHeaderPointerInteractionActive()) {
-    const cursorSurface = activeCanvasSurface();
     if (cursorSurface) cursorSurface.style.cursor = "default";
     onCanvasMouseLeave();
     return;
@@ -7219,7 +7224,6 @@ function onCanvasMouseMove(event: MouseEvent) {
         }
       : null;
   const actualColIdx = next ? visibleColumnIndexes.value[next.visibleColIdx] : undefined;
-  const cursorSurface = activeCanvasSurface();
   if (cursorSurface) {
     const overBooleanInteractive =
       booleanCellsUseCheckbox.value && hit != null && !hit.rowNumber && hitItem != null && actualColIdx !== undefined && isBooleanGridCell(hitItem, actualColIdx) && canEditCellItem(hitItem, actualColIdx) && booleanInteractiveHitFromCanvasEvent(hitItem, hit, actualColIdx, event);
@@ -7271,7 +7275,7 @@ function clearCanvasDetailHover(event?: MouseEvent) {
 
 function booleanCheckboxHitFromCanvasEvent(item: RowItem, hit: { rowIndex: number; visibleColIdx: number }, actualColIdx: number, event: MouseEvent): boolean {
   if (item.data[actualColIdx] === null) return false;
-  const canvas = activeCanvasSurface();
+  const canvas = canvasEventSurface(event);
   const canvasRect = canvas?.getBoundingClientRect();
   const cellRect = canvasCellViewportRect(hit.rowIndex, hit.visibleColIdx);
   if (!canvasRect || !cellRect) return false;
@@ -7288,7 +7292,7 @@ function booleanCheckboxHitFromCanvasEvent(item: RowItem, hit: { rowIndex: numbe
 
 function booleanNullTextHitFromCanvasEvent(item: RowItem, hit: { rowIndex: number; visibleColIdx: number }, actualColIdx: number, event: MouseEvent): boolean {
   if (item.data[actualColIdx] !== null) return false;
-  const canvas = activeCanvasSurface();
+  const canvas = canvasEventSurface(event);
   const canvasRect = canvas?.getBoundingClientRect();
   const cellRect = canvasCellViewportRect(hit.rowIndex, hit.visibleColIdx);
   if (!canvasRect || !cellRect) return false;

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -152,6 +152,12 @@ describe("DataGrid canvas surfaces", () => {
     const canvasMouseMove = dataGridSource.slice(dataGridSource.indexOf("function onCanvasMouseMove"), dataGridSource.indexOf("function onCanvasMouseLeave"));
     expect(canvasMouseMove).toContain("const cursorSurface = canvasEventSurface(event);");
   });
+
+  it("handles double clicks on the stable canvas container", () => {
+    expect(dataGridSource).toContain('@dblclick="onCanvasDblClick"');
+    expect(dataGridSource.match(/@dblclick="onCanvasDblClick"/g)).toHaveLength(1);
+    expect(dataGridSource).toContain("@dblclick.stop");
+  });
 });
 
 describe("DataGridSearchBar", () => {

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -142,6 +142,16 @@ describe("DataGrid canvas surfaces", () => {
     expect(dataGridSource).toContain("const canvas = inactiveCanvasSurface();");
     expect(dataGridSource).toContain("canvasUsingBackSurface.value = !canvasUsingBackSurface.value;");
   });
+
+  it("uses the canvas that actually received the event during a surface flip", () => {
+    expect(dataGridSource).toContain("function canvasEventSurface(event: MouseEvent): HTMLCanvasElement | null");
+    expect(dataGridSource).toContain("const currentTarget = event.currentTarget;");
+    expect(dataGridSource).toContain("return currentTarget instanceof HTMLCanvasElement ? currentTarget : activeCanvasSurface();");
+    expect(dataGridSource).toContain("const canvas = canvasEventSurface(event);");
+
+    const canvasMouseMove = dataGridSource.slice(dataGridSource.indexOf("function onCanvasMouseMove"), dataGridSource.indexOf("function onCanvasMouseLeave"));
+    expect(canvasMouseMove).toContain("const cursorSurface = canvasEventSurface(event);");
+  });
 });
 
 describe("DataGridSearchBar", () => {


### PR DESCRIPTION
## 问题

Canvas 数据表使用前后双缓冲绘制。首次点击选中单元格后会切换可见 Canvas，导致浏览器双击序列落在两个不同的 Canvas 元素上，绑定在单个 Canvas 上的 `dblclick` 无法稳定触发，因此首次双击只会选中，后续双击才可能进入编辑。

## 关联 PR

关联 #7127。该 PR 引入双 Canvas 交替显示以解决 macOS WKWebView 残影，但双击监听仍分别绑定在两个 Canvas 上，表面翻转后会导致首次双击事件丢失。

## 修改

- 将双击监听移动到不会随双缓冲切换的稳定容器
- 阻止编辑器浮层的双击事件向网格冒泡
- 增加 Canvas 双击监听位置的回归测试

## 验证

- 最新 main + PostgreSQL 真实表：已复现首次双击不能编辑
- 修复后 UI 手动验证：首次双击可直接进入编辑
- `pnpm vitest run apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts`（42 项通过）
- `pnpm typecheck`
- `git diff --check`
