### PR TITLE
fix(sidebar): 修复删除仅剩的可见数据库后侧边栏节点不刷新

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -3714,7 +3714,14 @@ async function confirmDropDatabase() {
     const executed = await executeTreeNodeSqlWithProductionGuard(node, sql, { database: "" });
     if (!executed) return;
     toast(t("contextMenu.dropDatabaseSuccess", { name: node.label }), 3000);
-    await connectionStore.loadDatabases(connectionId, { force: true });
+    try {
+      await connectionStore.loadDatabases(connectionId, { force: true });
+    } catch {
+      // The database was already dropped successfully above; if this refresh
+      // itself fails (e.g. a network blip), evict the node directly instead
+      // of leaving the deleted database showing in the tree.
+      connectionStore.removeTreeNode(node.id);
+    }
     showDropDatabaseConfirm.value = false;
   } catch (e: any) {
     toast(t("contextMenu.tableOperationFailed", { message: e?.message || String(e) }), 5000);

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1365,8 +1365,16 @@ export const useConnectionStore = defineStore("connection", () => {
     return connectionMetadataChildren(children).length > 0;
   }
 
-  function preserveExistingConnectionMetadataChildren(parent: TreeNode, children: TreeNode[]): TreeNode[] {
+  // `trustEmptyMetadataChildren` distinguishes two very different reasons this
+  // reload's metadata children can come back empty: the backend's raw fetch
+  // returned nothing at all (still ambiguous/possibly transient — keep the
+  // stale-preserve protection below), vs. the raw fetch had data but our own
+  // visible-databases/visible-schemas filter deterministically reduced it to
+  // zero (e.g. the only visible database was just dropped) — that emptiness
+  // is legitimate and must not be overridden by stale cached children.
+  function preserveExistingConnectionMetadataChildren(parent: TreeNode, children: TreeNode[], trustEmptyMetadataChildren = false): TreeNode[] {
     if (parent.type !== "connection" || hasConnectionMetadataChildren(children)) return children;
+    if (trustEmptyMetadataChildren) return children;
 
     const existingMetadataChildren = connectionMetadataChildren(parent.children);
     const nextUtilityChildren = children.filter(isConnectionUtilityNode);
@@ -1467,9 +1475,9 @@ export const useConnectionStore = defineStore("connection", () => {
     return deduped;
   }
 
-  function setChildren(parent: TreeNode, children: TreeNode[]) {
+  function setChildren(parent: TreeNode, children: TreeNode[], options?: { trustEmptyConnectionChildren?: boolean }) {
     // Compare markers against the resolved child list (after connection preserve), not the raw loader payload.
-    children = preserveExistingConnectionMetadataChildren(parent, children);
+    children = preserveExistingConnectionMetadataChildren(parent, children, options?.trustEmptyConnectionChildren === true);
     children = decorateDatabaseSavedSqlTreeNodes(children, savedSqlFilesByDatabase, parent.children);
     if (parent.type === "database") {
       children = withDatabaseSavedSqlRoot(parent, children, savedSqlFilesByDatabase);
@@ -4130,7 +4138,7 @@ export const useConnectionStore = defineStore("connection", () => {
             const targetNode = treeNodeLoadTarget(load);
             if (!targetNode) return;
             recordPrimaryVisibleObjectNames(connectionId, databaseNames);
-            setChildren(targetNode, children);
+            setChildren(targetNode, children, { trustEmptyConnectionChildren: databaseNames.length > 0 && visibleNames.length === 0 });
             await savePersistedConnectionTreeChildren(cacheKey, targetNode.children || children);
           } else if (config && connectionUsesVisibleSchemaFilter(config)) {
             const schemaFilterConfig = config;
@@ -4161,7 +4169,7 @@ export const useConnectionStore = defineStore("connection", () => {
             const targetNode = treeNodeLoadTarget(load);
             if (!targetNode) return;
             recordPrimaryVisibleObjectNames(connectionId, schemas);
-            setChildren(targetNode, withSavedSqlRoot(connectionId, schemaNodes, targetNode));
+            setChildren(targetNode, withSavedSqlRoot(connectionId, schemaNodes, targetNode), { trustEmptyConnectionChildren: schemas.length > 0 && visibleSchemas.length === 0 });
             await savePersistedConnectionTreeChildren(cacheKey, targetNode.children || schemaNodes);
           } else {
             // Doris / StarRocks multi-catalog: when external catalogs exist,
@@ -4252,7 +4260,7 @@ export const useConnectionStore = defineStore("connection", () => {
                 connectionId,
                 databases.map((database) => database.name),
               );
-              setChildren(targetNode, children);
+              setChildren(targetNode, children, { trustEmptyConnectionChildren: databases.length > 0 && visibleNames.length === 0 });
               await savePersistedConnectionTreeChildren(cacheKey, targetNode.children || children);
             }
           }
@@ -4683,6 +4691,7 @@ export const useConnectionStore = defineStore("connection", () => {
           })),
           targetNode,
         ),
+        { trustEmptyConnectionChildren: dbs.length > 0 && visibleDbs.length === 0 },
       );
       targetNode.isExpanded = true;
     } catch (e) {

--- a/packages/app-tests/connectionStoreErrorState.test.ts
+++ b/packages/app-tests/connectionStoreErrorState.test.ts
@@ -498,6 +498,63 @@ test("empty root metadata does not replace existing databases with only user adm
   }
 });
 
+test("dropping the last visible database removes the stale node instead of preserving it", async () => {
+  const restoreStorage = installMemoryStorage();
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input);
+    if (url.startsWith("/api/schema/cache?")) {
+      return jsonResponse(null);
+    }
+    if (url.startsWith("/api/schema/databases?")) {
+      // The backend still reports its own system databases; only the
+      // previously-visible user database ("app") is gone after the drop.
+      return jsonResponse([{ name: "information_schema" }, { name: "mysql" }, { name: "performance_schema" }, { name: "sys" }]);
+    }
+    if (url === "/api/schema/cache" && init?.method === "POST") {
+      return jsonResponse(null);
+    }
+    return new Response("unexpected request", { status: 500 });
+  }) as typeof fetch;
+
+  try {
+    setActivePinia(createPinia());
+    const store = useConnectionStore();
+    store.addEphemeralConnection({ ...conn("conn-1"), db_type: "mysql", port: 3306, visible_databases: ["app"] });
+    store.treeNodes.push({
+      id: "conn-1",
+      label: "conn-1",
+      type: "connection",
+      connectionId: "conn-1",
+      children: [
+        {
+          id: "conn-1:app",
+          label: "app",
+          type: "database",
+          connectionId: "conn-1",
+          database: "app",
+          children: [],
+        },
+      ],
+    });
+
+    await store.loadDatabases("conn-1");
+
+    assert.deepEqual(
+      store.treeNodes[0].children?.map((child) => child.type),
+      ["user-admin"],
+    );
+    assert.equal(
+      store.treeNodes[0].children?.some((child) => child.id === "conn-1:app"),
+      false,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test.each([
   ["redis", "loadRedisDatabases", "/api/redis/list-databases", "Redis databases"],
   ["mq", "loadMqTenants", "/api/mq/tenants/list", "message queue tenants"],


### PR DESCRIPTION
## 问题

通过侧边栏右键菜单执行"删除数据库"后会提示删除成功，但如果被删除的数据库是该连接在"选择可见数据库"（`visible_databases`）过滤后仅剩的一个，被删除的数据库节点会一直留在侧边栏树里，需要手动全量刷新（或断开重连）才会消失。

## 根因

`confirmDropDatabase` 执行 `DROP DATABASE` 成功后，唯一的树刷新手段是 `connectionStore.loadDatabases(connectionId, { force: true })`。`loadDatabases` 本身能正确地从后端重新拉库、按 `visible_databases` 过滤，仅剩库被删后能正确算出空的数据库列表。

但这份"正确的空列表"传给 `setChildren` 时，其内部的 `preserveExistingConnectionMetadataChildren` 防御性 guard（本意是防止后端偶发/异常返回空列表时把整棵树误清空）无法区分"后端真的什么都没返回"和"后端有数据、只是被我们自己的可见数据库过滤器筛成了空"——于是把连接节点里还残留的、刚被删除的旧数据库节点重新拼接了回去。

`loadDatabases`、`loadMongoDatabases` 中另外 3 处同样"按 visible_databases/visible_schemas 过滤后调用 setChildren(connection 节点, ...)"的调用点存在同一类问题。

## 修复

给 `setChildren` / `preserveExistingConnectionMetadataChildren` 增加一个显式的 `trustEmptyConnectionChildren` 参数，由 4 个受影响的调用点在"原始拉取结果非空、但过滤后为空"时显式传入，跳过 stale-preserve 逻辑，让合法的空结果直接生效。其余 ~49 处 `setChildren` 调用不受影响（新参数默认关闭）。

顺带在 `confirmDropDatabase` 的 catch 分支里加了一行 `removeTreeNode` 兜底（与 Mongo/Milvus 的删除路径保持一致）：如果 `DROP DATABASE` 执行成功后紧跟着的刷新请求本身失败（比如网络抖动），也能把节点摘掉，而不是留着假装还在。

## 测试

- 新增回归测试 `packages/app-tests/connectionStoreErrorState.test.ts`：验证仅剩的可见数据库被删除后，`setChildren` 不会把已删除的节点拼接回去。该测试在修复前会失败，修复后通过。
- 真实复现：起本地 dev 环境（真实 MySQL 8 实例，Playwright 驱动的真实浏览器），把连接的"选择可见数据库"改成只剩 1 个库，删除该库 —— 修复前节点残留、需手动刷新；修复后节点在 toast 提示后立即消失。
- `pnpm typecheck`、`pnpm lint`、`oxfmt --check` 全部通过。
- 完整 vitest 套件通过（11423 个测试）。

Fixes #7171