### PR TITLE
Feature：新增侧边栏开关“展开数据库时打开浏览器标签页”

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -447,6 +447,7 @@ const editRoutineSourceOpenMode = ref(settingsStore.editorSettings.routineSource
 const editSidebarTableSearchEnabled = ref(settingsStore.editorSettings.sidebarTableSearchEnabled);
 const editAutoSelectActiveSidebarNode = ref(settingsStore.editorSettings.autoSelectActiveSidebarNode);
 const editSidebarOpenDatabaseOnSingleClick = ref(settingsStore.editorSettings.sidebarOpenDatabaseOnSingleClick);
+const editSidebarOpenBrowserTabWhenExpanding = ref(settingsStore.editorSettings.sidebarOpenBrowserTabWhenExpanding);
 const editOpenTabsRestoreMode = ref<OpenTabsRestoreMode>(settingsStore.editorSettings.openTabsRestoreMode);
 const editDisconnectTabHandlingMode = ref<DisconnectTabHandlingMode>(settingsStore.editorSettings.disconnectTabHandlingMode);
 const editDataTabReuseMode = ref<DataTabReuseMode>(settingsStore.editorSettings.dataTabReuseMode);
@@ -582,6 +583,7 @@ function currentEditorSettingsDraft(): EditorSettingsDraft {
     sidebarTableSearchEnabled: editSidebarTableSearchEnabled.value,
     autoSelectActiveSidebarNode: editAutoSelectActiveSidebarNode.value,
     sidebarOpenDatabaseOnSingleClick: editSidebarOpenDatabaseOnSingleClick.value,
+    sidebarOpenBrowserTabWhenExpanding: editSidebarOpenBrowserTabWhenExpanding.value,
     openTabsRestoreMode: editOpenTabsRestoreMode.value,
     disconnectTabHandlingMode: editDisconnectTabHandlingMode.value,
     dataTabReuseMode: editDataTabReuseMode.value,
@@ -875,6 +877,7 @@ function syncEditorSettingsDraftFromStore() {
   editSidebarTableSearchEnabled.value = settingsStore.editorSettings.sidebarTableSearchEnabled;
   editAutoSelectActiveSidebarNode.value = settingsStore.editorSettings.autoSelectActiveSidebarNode;
   editSidebarOpenDatabaseOnSingleClick.value = settingsStore.editorSettings.sidebarOpenDatabaseOnSingleClick;
+  editSidebarOpenBrowserTabWhenExpanding.value = settingsStore.editorSettings.sidebarOpenBrowserTabWhenExpanding;
   editOpenTabsRestoreMode.value = settingsStore.editorSettings.openTabsRestoreMode;
   editDisconnectTabHandlingMode.value = settingsStore.editorSettings.disconnectTabHandlingMode;
   editDataTabReuseMode.value = settingsStore.editorSettings.dataTabReuseMode;
@@ -1127,6 +1130,7 @@ function resetDefaultsForTab(tab: SettingsCategory) {
     editSidebarTableSearchEnabled.value = DEFAULT_EDITOR_SETTINGS.sidebarTableSearchEnabled;
     editAutoSelectActiveSidebarNode.value = DEFAULT_EDITOR_SETTINGS.autoSelectActiveSidebarNode;
     editSidebarOpenDatabaseOnSingleClick.value = DEFAULT_EDITOR_SETTINGS.sidebarOpenDatabaseOnSingleClick;
+    editSidebarOpenBrowserTabWhenExpanding.value = DEFAULT_EDITOR_SETTINGS.sidebarOpenBrowserTabWhenExpanding;
     editOpenTabsRestoreMode.value = DEFAULT_EDITOR_SETTINGS.openTabsRestoreMode;
     editDisconnectTabHandlingMode.value = DEFAULT_EDITOR_SETTINGS.disconnectTabHandlingMode;
     editDataTabReuseMode.value = DEFAULT_EDITOR_SETTINGS.dataTabReuseMode;
@@ -1256,6 +1260,7 @@ function resetAllDefaults() {
   editSidebarTableSearchEnabled.value = DEFAULT_EDITOR_SETTINGS.sidebarTableSearchEnabled;
   editAutoSelectActiveSidebarNode.value = DEFAULT_EDITOR_SETTINGS.autoSelectActiveSidebarNode;
   editSidebarOpenDatabaseOnSingleClick.value = DEFAULT_EDITOR_SETTINGS.sidebarOpenDatabaseOnSingleClick;
+  editSidebarOpenBrowserTabWhenExpanding.value = DEFAULT_EDITOR_SETTINGS.sidebarOpenBrowserTabWhenExpanding;
   editOpenTabsRestoreMode.value = DEFAULT_EDITOR_SETTINGS.openTabsRestoreMode;
   editDisconnectTabHandlingMode.value = DEFAULT_EDITOR_SETTINGS.disconnectTabHandlingMode;
   editDataTabReuseMode.value = DEFAULT_EDITOR_SETTINGS.dataTabReuseMode;
@@ -5006,6 +5011,15 @@ onUnmounted(() => {
                   </HelpTooltip>
                 </div>
                 <Switch id="sidebar-open-database-on-single-click" v-model="editSidebarOpenDatabaseOnSingleClick" />
+              </div>
+              <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
+                <div class="flex items-center gap-2">
+                  <Label for="sidebar-open-browser-tab-when-expanding">{{ t("settings.sidebarOpenBrowserTabWhenExpanding") }}</Label>
+                  <HelpTooltip :label="t('settings.sidebarOpenBrowserTabWhenExpanding')">
+                    {{ t("settings.sidebarOpenBrowserTabWhenExpandingDescription") }}
+                  </HelpTooltip>
+                </div>
+                <Switch id="sidebar-open-browser-tab-when-expanding" v-model="editSidebarOpenBrowserTabWhenExpanding" />
               </div>
               <div class="space-y-2 rounded-md border bg-muted/20 px-3 py-2">
                 <div class="flex items-center gap-2">

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -1000,7 +1000,7 @@ function runRowClickAction(clickDetail: number, requestId: number) {
   } else if (action === "open-object-browser") {
     void openObjectBrowser();
   } else if (action === "open-object-browser-and-expand") {
-    void openObjectBrowser();
+    if (settingsStore.editorSettings.sidebarOpenBrowserTabWhenExpanding !== false) void openObjectBrowser();
     if (!node.isExpanded) void toggle();
   } else if (action === "open-source") {
     openObjectSourceDialog(false);
@@ -1361,7 +1361,7 @@ function onDoubleClick(event: MouseEvent) {
   } else if (action === "open-object-browser") {
     void openObjectBrowser();
   } else if (action === "open-object-browser-and-expand") {
-    void openObjectBrowser();
+    if (settingsStore.editorSettings.sidebarOpenBrowserTabWhenExpanding !== false) void openObjectBrowser();
     if (!activeNode.value.isExpanded) void toggle();
   } else if (action === "open-data") {
     openDataImmediately(activeNode.value);

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6291,6 +6291,8 @@ export default {
     autoSelectActiveSidebarNodeDescription: "When switching tabs, select the matching visible table, collection, or SQL file in the sidebar.",
     sidebarOpenDatabaseOnSingleClick: "Browse objects on database single click",
     sidebarOpenDatabaseOnSingleClickDescription: 'When enabled, single-clicking a database or schema node also expands the sidebar and opens the "Browse Objects" tab.',
+    sidebarOpenBrowserTabWhenExpanding: "Open browser tab when expanding",
+    sidebarOpenBrowserTabWhenExpandingDescription: 'When disabled, opening a database or schema node only expands the sidebar and does not create the "Browse Objects" tab.',
     openTabsRestoreMode: "Restore tabs on launch",
     openTabsRestoreModeDescription: "Choose how DBX restores tabs that were open last time.",
     openTabsRestoreModeAll: "Keep all tabs",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6006,6 +6006,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "Al cambiar de pestaña, selecciona la tabla, colección o archivo SQL visible correspondiente en la barra lateral.",
     sidebarOpenDatabaseOnSingleClick: "Explorar objetos al hacer clic en la base de datos",
     sidebarOpenDatabaseOnSingleClickDescription: 'Si está activado, al hacer un solo clic en un nodo de base de datos o esquema se expande la barra lateral y se abre la pestaña "Explorar objetos".',
+    sidebarOpenBrowserTabWhenExpanding: "Abrir la pestaña del explorador al expandir",
+    sidebarOpenBrowserTabWhenExpandingDescription: 'Si se desactiva, abrir un nodo de base de datos o esquema solo expande la barra lateral y no crea la pestaña "Explorar objetos".',
     openTabsRestoreMode: "Restaurar pestañas al iniciar",
     openTabsRestoreModeDescription: "Elige cómo DBX restaura las pestañas que estaban abiertas la última vez.",
     openTabsRestoreModeAll: "Conservar todas las pestañas",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6006,6 +6006,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "Quando passi da una scheda all'altra, seleziona la tabella, la collezione o il file SQL visibile corrispondente nella barra laterale.",
     sidebarOpenDatabaseOnSingleClick: "Sfoglia oggetti al clic sul database",
     sidebarOpenDatabaseOnSingleClickDescription: 'Se abilitato, un singolo clic su un nodo database o schema espande la barra laterale e apre la scheda "Esplora Oggetti".',
+    sidebarOpenBrowserTabWhenExpanding: "Apri la scheda del browser durante l'espansione",
+    sidebarOpenBrowserTabWhenExpandingDescription: "Se disabilitato, l'apertura di un nodo database o schema espande solo la barra laterale e non crea la scheda Esplora oggetti.",
     openTabsRestoreMode: "Ripristina schede all'avvio",
     openTabsRestoreModeDescription: "Scegli come DBX ripristina le schede aperte l'ultima volta.",
     openTabsRestoreModeAll: "Mantieni tutte le schede",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6032,6 +6032,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "タブ切替時に、サイドバーで一致する表示中のテーブル、コレクション、またはSQLファイルを選択します。",
     sidebarOpenDatabaseOnSingleClick: "データベースのシングルクリックでオブジェクトを参照",
     sidebarOpenDatabaseOnSingleClickDescription: "有効にすると、データベースまたはスキーマノードをシングルクリックした際に、サイドバーを展開すると同時に「オブジェクトを参照」タブを開きます。",
+    sidebarOpenBrowserTabWhenExpanding: "展開時にブラウザータブを開く",
+    sidebarOpenBrowserTabWhenExpandingDescription: "無効にすると、データベースまたはスキーマノードを開いたときはサイドバーだけを展開し、「オブジェクトを参照」タブを作成しません。",
     openTabsRestoreMode: "起動時にタブを復元",
     openTabsRestoreModeDescription: "DBX 起動時に前回開いていたタブをどのように復元するかを選択します。",
     openTabsRestoreModeAll: "すべてのタブを保持",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5687,6 +5687,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "탭을 전환할 때 사이드바에서 일치하는 표시된 테이블, 컬렉션 또는 SQL 파일을 선택합니다.",
     sidebarOpenDatabaseOnSingleClick: "데이터베이스 클릭 시 객체 탐색",
     sidebarOpenDatabaseOnSingleClickDescription: '활성화하면 데이터베이스 또는 스키마 노드를 한 번 클릭할 때 사이드바를 펼치면서 "객체 탐색" 탭을 엽니다.',
+    sidebarOpenBrowserTabWhenExpanding: "확장할 때 브라우저 탭 열기",
+    sidebarOpenBrowserTabWhenExpandingDescription: '비활성화하면 데이터베이스 또는 스키마 노드를 열 때 사이드바만 확장되고 "객체 탐색" 탭은 생성되지 않습니다.',
     openTabsRestoreMode: "실행 시 탭 복원",
     openTabsRestoreModeDescription: "DBX가 지난번에 열려 있던 탭을 복원하는 방법을 선택하세요.",
     openTabsRestoreModeAll: "모든 탭 유지",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6008,6 +6008,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "Ao alternar abas, selecionar a tabela, coleção ou arquivo SQL correspondente visível na barra lateral.",
     sidebarOpenDatabaseOnSingleClick: "Explorar objetos ao clicar no banco de dados",
     sidebarOpenDatabaseOnSingleClickDescription: 'Quando ativado, um clique único em um nó de banco de dados ou esquema expande a barra lateral e abre a aba "Explorar Objetos".',
+    sidebarOpenBrowserTabWhenExpanding: "Abrir a aba do navegador ao expandir",
+    sidebarOpenBrowserTabWhenExpandingDescription: 'Quando desativado, abrir um nó de banco de dados ou esquema apenas expande a barra lateral e não cria a aba "Explorar Objetos".',
     openTabsRestoreMode: "Restaurar abas ao iniciar",
     openTabsRestoreModeDescription: "Escolha como o DBX restaura as abas que estavam abertas na última vez.",
     openTabsRestoreModeAll: "Manter todas as abas",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6275,6 +6275,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "切换标签页时，在侧边栏选中匹配的可见表、集合或 SQL 文件。",
     sidebarOpenDatabaseOnSingleClick: "单击数据库时浏览对象",
     sidebarOpenDatabaseOnSingleClickDescription: "开启后，单击数据库或模式节点时，会同时展开侧边栏并打开“浏览对象”标签页。",
+    sidebarOpenBrowserTabWhenExpanding: "展开数据库时打开浏览器标签页",
+    sidebarOpenBrowserTabWhenExpandingDescription: "关闭后，打开数据库或模式节点时只展开侧边栏列表，不创建顶部“浏览对象”标签页。",
     openTabsRestoreMode: "启动时恢复标签页",
     openTabsRestoreModeDescription: "选择 DBX 启动时如何恢复上次打开的标签页。",
     openTabsRestoreModeAll: "保留所有标签",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5325,6 +5325,8 @@ export default withEnglishFallback({
     autoSelectActiveSidebarNodeDescription: "切換分頁時，在側邊欄選取相符的可見資料表、集合或 SQL 檔案。",
     sidebarOpenDatabaseOnSingleClick: "單擊資料庫時瀏覽物件",
     sidebarOpenDatabaseOnSingleClickDescription: "開啟後，單擊資料庫或結構描述節點時，會同時展開側邊欄並開啟「瀏覽物件」分頁。",
+    sidebarOpenBrowserTabWhenExpanding: "展開資料庫時開啟瀏覽器分頁",
+    sidebarOpenBrowserTabWhenExpandingDescription: "關閉後，開啟資料庫或結構描述節點時只展開側邊欄清單，不建立頂部「瀏覽物件」分頁。",
     openTabsRestoreMode: "啟動時還原分頁",
     openTabsRestoreModeDescription: "選擇 DBX 啟動時如何還原上次開啟的分頁。",
     openTabsRestoreModeAll: "保留所有分頁",

--- a/apps/desktop/src/lib/settings/editorSettingsDraft.ts
+++ b/apps/desktop/src/lib/settings/editorSettingsDraft.ts
@@ -64,6 +64,7 @@ export const EDITOR_SETTINGS_DRAFT_KEYS = [
   "sidebarTableSearchEnabled",
   "autoSelectActiveSidebarNode",
   "sidebarOpenDatabaseOnSingleClick",
+  "sidebarOpenBrowserTabWhenExpanding",
   "openTabsRestoreMode",
   "disconnectTabHandlingMode",
   "dataTabReuseMode",

--- a/apps/desktop/src/lib/settings/settingsSearch.ts
+++ b/apps/desktop/src/lib/settings/settingsSearch.ts
@@ -169,6 +169,7 @@ export const SETTINGS_SEARCH_DEFINITIONS: readonly SettingsSearchDefinition[] = 
   { id: "navigation-table-search", category: "navigation", titleKey: "settings.sidebarTableSearchEnabled", descriptionKey: "settings.sidebarTableSearchEnabledDescription", targetId: "navigation" },
   { id: "navigation-active-node", category: "navigation", titleKey: "settings.autoSelectActiveSidebarNode", descriptionKey: "settings.autoSelectActiveSidebarNodeDescription", targetId: "navigation" },
   { id: "navigation-open-database-on-single-click", category: "navigation", titleKey: "settings.sidebarOpenDatabaseOnSingleClick", descriptionKey: "settings.sidebarOpenDatabaseOnSingleClickDescription", targetId: "navigation" },
+  { id: "navigation-open-browser-tab-when-expanding", category: "navigation", titleKey: "settings.sidebarOpenBrowserTabWhenExpanding", descriptionKey: "settings.sidebarOpenBrowserTabWhenExpandingDescription", targetId: "navigation" },
   { id: "navigation-tabs-restore", category: "navigation", titleKey: "settings.openTabsRestoreMode", descriptionKey: "settings.openTabsRestoreModeDescription", targetId: "navigation" },
   { id: "navigation-sidebar-scroll", category: "navigation", titleKey: "settings.sidebarAllowHorizontalScroll", descriptionKey: "settings.sidebarAllowHorizontalScrollDescription", targetId: "navigation" },
   { id: "navigation-sidebar-indent", category: "navigation", titleKey: "settings.sidebarIndent", descriptionKey: "settings.sidebarIndentDescription", targetId: "navigation" },

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -600,6 +600,7 @@ export interface EditorSettings {
   sidebarGlobalSearchLocal: boolean;
   autoSelectActiveSidebarNode: boolean;
   sidebarOpenDatabaseOnSingleClick: boolean;
+  sidebarOpenBrowserTabWhenExpanding: boolean;
   openTabsRestoreMode: OpenTabsRestoreMode;
   disconnectTabHandlingMode: DisconnectTabHandlingMode;
   dataTabReuseMode: DataTabReuseMode;
@@ -813,6 +814,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   sidebarGlobalSearchLocal: false,
   autoSelectActiveSidebarNode: false,
   sidebarOpenDatabaseOnSingleClick: false,
+  sidebarOpenBrowserTabWhenExpanding: true,
   openTabsRestoreMode: "all",
   disconnectTabHandlingMode: "close-tabs",
   dataTabReuseMode: DEFAULT_DATA_TAB_REUSE_MODE,
@@ -1190,6 +1192,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
     sidebarGlobalSearchLocal: typeof settings.sidebarGlobalSearchLocal === "boolean" ? settings.sidebarGlobalSearchLocal : DEFAULT_EDITOR_SETTINGS.sidebarGlobalSearchLocal,
     autoSelectActiveSidebarNode: settings.autoSelectActiveSidebarNode ?? DEFAULT_EDITOR_SETTINGS.autoSelectActiveSidebarNode,
     sidebarOpenDatabaseOnSingleClick: typeof settings.sidebarOpenDatabaseOnSingleClick === "boolean" ? settings.sidebarOpenDatabaseOnSingleClick : DEFAULT_EDITOR_SETTINGS.sidebarOpenDatabaseOnSingleClick,
+    sidebarOpenBrowserTabWhenExpanding: typeof settings.sidebarOpenBrowserTabWhenExpanding === "boolean" ? settings.sidebarOpenBrowserTabWhenExpanding : DEFAULT_EDITOR_SETTINGS.sidebarOpenBrowserTabWhenExpanding,
     openTabsRestoreMode: normalizeOpenTabsRestoreMode(
       (settings as Partial<EditorSettings>).openTabsRestoreMode,
       (
@@ -1806,6 +1809,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.sidebarGlobalSearchLocal !== undefined) editorSettings.value.sidebarGlobalSearchLocal = partial.sidebarGlobalSearchLocal;
     if (partial.autoSelectActiveSidebarNode !== undefined) editorSettings.value.autoSelectActiveSidebarNode = partial.autoSelectActiveSidebarNode;
     if (partial.sidebarOpenDatabaseOnSingleClick !== undefined) editorSettings.value.sidebarOpenDatabaseOnSingleClick = partial.sidebarOpenDatabaseOnSingleClick === true;
+    if (partial.sidebarOpenBrowserTabWhenExpanding !== undefined) editorSettings.value.sidebarOpenBrowserTabWhenExpanding = partial.sidebarOpenBrowserTabWhenExpanding === true;
     if (partial.openTabsRestoreMode !== undefined) editorSettings.value.openTabsRestoreMode = normalizeOpenTabsRestoreMode(partial.openTabsRestoreMode);
     if (partial.disconnectTabHandlingMode !== undefined) editorSettings.value.disconnectTabHandlingMode = normalizeDisconnectTabHandlingMode(partial.disconnectTabHandlingMode);
     if (partial.dataTabReuseMode !== undefined) editorSettings.value.dataTabReuseMode = normalizeDataTabReuseMode(partial.dataTabReuseMode);


### PR DESCRIPTION
## 变更说明

新增侧边栏开关“展开数据库时打开浏览器标签页”。

开启时保持原有行为：打开数据库或 Schema 节点时，同时展开侧边栏列表并创建顶部“浏览对象”标签页。

关闭时只展开侧边栏列表，不创建顶部“浏览对象”标签页。具体表、视图、物化视图打开数据标签页的行为不变，右键菜单和箭头按钮行为也不变。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1645" height="472" alt="image" src="https://github.com/user-attachments/assets/1079f72f-22e0-4d29-bcaf-a0df6a53f9bf" />

## 关联 Issue

#7211