### PR TITLE
fix(editor): 修复 PostgreSQL/MySQL 部分函数不高亮问题

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
@@ -16,6 +16,16 @@ describe("codemirrorSqlDialect", () => {
     expect(keywords.has("count")).toBe(false);
   });
 
+  it("highlights common functions dropped from Postgres/MySQL keyword lists as builtins", () => {
+    const postgresBuiltins = new Set(createDbxCodeMirrorSqlDialect(langSql, "postgres", "postgres").spec.builtin?.split(/\s+/));
+    const mysqlBuiltins = new Set(createDbxCodeMirrorSqlDialect(langSql, "mysql", "mysql").spec.builtin?.split(/\s+/));
+
+    expect(postgresBuiltins.has("count")).toBe(true);
+    expect(postgresBuiltins.has("to_char")).toBe(true);
+    expect(mysqlBuiltins.has("ifnull")).toBe(true);
+    expect(mysqlBuiltins.has("date_format")).toBe(true);
+  });
+
   it("adds Dolt routines to highlighting without changing standard MySQL", () => {
     const doltBuiltins = new Set(createDbxCodeMirrorSqlDialect(langSql, "mysql", "mysql", "dolt").spec.builtin?.split(/\s+/));
     const mysqlBuiltins = new Set(createDbxCodeMirrorSqlDialect(langSql, "mysql", "mysql", "mysql").spec.builtin?.split(/\s+/));

--- a/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
@@ -143,6 +143,36 @@ const CLICKHOUSE_TYPES = [
 
 const CLICKHOUSE_BUILTINS = ["now", "today", "toDate", "toDateTime", "toDateTime64", "toYYYYMM", "count", "sum", "avg", "min", "max", "uniq", "uniqExact", "argMin", "argMax", "groupArray", "arrayJoin", "mapKeys", "mapValues", "JSONExtract", "JSONExtractString"].join(" ").toLowerCase();
 
+// COUNT is stripped from Postgres keywords by postgresKeywordSyntaxTerms() (it's a
+// valid Postgres identifier name), so it's re-added here as a builtin function instead.
+const POSTGRES_BUILTINS = [
+  "count",
+  "coalesce",
+  "nullif",
+  "greatest",
+  "least",
+  "to_char",
+  "to_date",
+  "to_number",
+  "to_timestamp",
+  "extract",
+  "date_trunc",
+  "date_part",
+  "now",
+  "current_date",
+  "current_timestamp",
+  "array_agg",
+  "string_agg",
+  "lower",
+  "upper",
+  "length",
+  "substring",
+  "trim",
+  "concat",
+].join(" ");
+
+const MYSQL_BUILTINS = ["ifnull", "date_format", "str_to_date", "date_add", "date_sub", "curdate", "curtime", "unix_timestamp", "from_unixtime", "group_concat", "concat_ws"].join(" ");
+
 export function postgresKeywordSyntaxTerms(keywords: string): string {
   return keywords
     .split(/\s+/)
@@ -179,6 +209,7 @@ function codeMirrorBaseDialect(langSql: CodeMirrorSqlLanguageModule, dialectName
 export function createDbxCodeMirrorSqlDialect(langSql: CodeMirrorSqlLanguageModule, dialectName: CodeMirrorSqlDialectName = "mysql", databaseType?: DatabaseType, driverProfile?: string): SQLDialect {
   const baseDialect = codeMirrorBaseDialect(langSql, dialectName, databaseType);
   const isPostgres = baseDialect === langSql.PostgreSQL;
+  const isMysql = baseDialect === langSql.MySQL;
   const isSqlServer = baseDialect === langSql.MSSQL;
   const isPlsql = baseDialect === langSql.PLSQL;
   const isClickHouse = databaseType === "clickhouse" || dialectName === "clickhouse";
@@ -190,7 +221,7 @@ export function createDbxCodeMirrorSqlDialect(langSql: CodeMirrorSqlLanguageModu
     ...baseDialect.spec,
     keywords: [baseKeywords, commonKeywords, isClickHouse ? CLICKHOUSE_KEYWORDS : "", isPostgres ? POSTGRES_PLPGSQL_KEYWORDS : "", isSqlServer ? SQLSERVER_KEYWORDS : ""].filter(Boolean).join(" "),
     types: [baseTypes, isClickHouse ? CLICKHOUSE_TYPES : "", isPostgres ? POSTGRES_PLPGSQL_TYPES : ""].filter(Boolean).join(" ") || undefined,
-    builtin: [baseDialect.spec.builtin || "", isClickHouse ? CLICKHOUSE_BUILTINS : "", isPostgres ? POSTGRES_PLPGSQL_BUILTIN : "", driverProfileSqlBuiltinTerms(driverProfile)].filter(Boolean).join(" ") || undefined,
+    builtin: [baseDialect.spec.builtin || "", isClickHouse ? CLICKHOUSE_BUILTINS : "", isPostgres ? `${POSTGRES_BUILTINS} ${POSTGRES_PLPGSQL_BUILTIN}` : "", isMysql ? MYSQL_BUILTINS : "", driverProfileSqlBuiltinTerms(driverProfile)].filter(Boolean).join(" ") || undefined,
     ...(isClickHouse
       ? {
           identifierQuotes: '"`',


### PR DESCRIPTION
## 问题

`select count(*)`、`select to_char(now(), 'YYYY-MM-DD')` 等语句在 PostgreSQL 连接下，`count`、`to_char` 等函数完全没有语法高亮；MySQL 连接下 `ifnull`、`date_format` 等函数同样没有高亮。

## 根因

`apps/desktop/src/lib/editor/codemirrorSqlDialect.ts` 中 `postgresKeywordSyntaxTerms()` 会把 `COUNT` 从 Postgres 的关键字列表里过滤掉（因为它在 Postgres 里也是合法标识符名），但没有把它以及 `to_char` 等真实存在的 Postgres 内置函数补回 `builtin` 列表，导致这些函数彻底失去高亮。MySQL 侧同样缺少 `ifnull`/`date_format` 等常用函数的 builtin 列表。

## 修复

新增 `POSTGRES_BUILTINS`、`MYSQL_BUILTINS` 两个内置函数列表，接入 `builtin` 字段拼接逻辑，写法沿用已有的 `CLICKHOUSE_BUILTINS` 模式，未改动其他逻辑。

## 验证

- 真实浏览器复现：连接真实 PostgreSQL / MySQL 实例，确认修复前 `count`/`to_char` 在 PG 下不高亮、修复后与 `select` 同色高亮；MySQL 下 `count`/`ifnull`/`date_format` 修复前后均正常高亮，无回归。
- 单元测试：`codemirrorSqlDialect.spec.ts` 新增断言全部通过；`src/lib/__tests__/editor` 全目录 344 个测试全部通过；全量前端测试 11424/11425 通过（唯一失败项与本次改动无关，单独重跑已确认是既有 flaky 用例）。

Fixes #7222