### PR TITLE
fix(redis): 命令控制台正确配对 WITHSCORES 的 member/score 结果

### DIFF
--- a/apps/desktop/src/lib/redis/redisQueryResult.spec.ts
+++ b/apps/desktop/src/lib/redis/redisQueryResult.spec.ts
@@ -40,4 +40,35 @@ describe("redisCommandResultToQueryResult", () => {
       ["age", "30"],
     ]);
   });
+
+  it("does not pair when a non-sorted-set command merely contains WITHSCORES in a key", () => {
+    const flat = ["a", "b", "c"];
+    const result = redisCommandResultToQueryResult(flat, 5, "LRANGE my:WITHSCORES:list 0 -1");
+    expect(result.columns).toEqual(["(index)", "value"]);
+    expect(result.rows).toEqual([
+      [1, "a"],
+      [2, "b"],
+      [3, "c"],
+    ]);
+  });
+
+  it("does not pair SMEMBERS when WITHSCORES appears as an argument", () => {
+    const flat = ["x", "y"];
+    const result = redisCommandResultToQueryResult(flat, 5, "SMEMBERS WITHSCORES");
+    expect(result.columns).toEqual(["(index)", "value"]);
+    expect(result.rows).toEqual([
+      [1, "x"],
+      [2, "y"],
+    ]);
+  });
+
+  it("pairs member/score rows for ZRANGEBYSCORE ... WITHSCORES", () => {
+    const flat = ["alice", "1", "bob", "2"];
+    const result = redisCommandResultToQueryResult(flat, 5, "ZRANGEBYSCORE myzset -inf +inf WITHSCORES");
+    expect(result.columns).toEqual(["member", "score"]);
+    expect(result.rows).toEqual([
+      ["alice", "1"],
+      ["bob", "2"],
+    ]);
+  });
 });

--- a/apps/desktop/src/lib/redis/redisQueryResult.spec.ts
+++ b/apps/desktop/src/lib/redis/redisQueryResult.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { redisCommandResultToQueryResult } from "@/lib/redis/redisQueryResult";
+
+describe("redisCommandResultToQueryResult", () => {
+  it("pairs member/score rows for ZREVRANGE ... WITHSCORES instead of one row per array element", () => {
+    const flat = ["carol", "300", "bob", "200", "alice", "100"];
+    const result = redisCommandResultToQueryResult(flat, 5, "ZREVRANGE issue7229_repro:zset 0 -1 WITHSCORES");
+    expect(result.columns).toEqual(["member", "score"]);
+    expect(result.rows).toEqual([
+      ["carol", "300"],
+      ["bob", "200"],
+      ["alice", "100"],
+    ]);
+    expect(result.affected_rows).toBe(3);
+  });
+
+  it("pairs member/score rows for ZRANGE ... WITHSCORES (lowercase modifier)", () => {
+    const flat = ["alice", "1.5"];
+    const result = redisCommandResultToQueryResult(flat, 5, "zrange myset 0 -1 withscores");
+    expect(result.columns).toEqual(["member", "score"]);
+    expect(result.rows).toEqual([["alice", "1.5"]]);
+  });
+
+  it("does not pair a plain ZRANGE result (no WITHSCORES modifier)", () => {
+    const flat = ["alice", "bob"];
+    const result = redisCommandResultToQueryResult(flat, 5, "ZRANGE myset 0 -1");
+    expect(result.columns).toEqual(["(index)", "value"]);
+    expect(result.rows).toEqual([
+      [1, "alice"],
+      [2, "bob"],
+    ]);
+  });
+
+  it("still pairs field/value rows for HGETALL when given the full raw command text (not just the bare command head)", () => {
+    const flat = ["name", "alice", "age", "30"];
+    const result = redisCommandResultToQueryResult(flat, 5, "HGETALL myhash");
+    expect(result.columns).toEqual(["field", "value"]);
+    expect(result.rows).toEqual([
+      ["name", "alice"],
+      ["age", "30"],
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/redis/redisQueryResult.ts
+++ b/apps/desktop/src/lib/redis/redisQueryResult.ts
@@ -2,9 +2,21 @@ import type { QueryResult } from "@/types/database";
 import { formatRedisCommandResult } from "@/lib/redis/redisValuePresentation";
 
 const KEY_VALUE_COMMANDS = new Set(["HGETALL"]);
+const WITHSCORES_MODIFIER = /\bWITHSCORES\b/i;
+
+function commandHead(command: string): string {
+  return command.trim().split(/\s+/, 1)[0]?.toUpperCase() ?? "";
+}
 
 function isKeyValueCommand(command: string): boolean {
-  return KEY_VALUE_COMMANDS.has(command.toUpperCase().trim());
+  return KEY_VALUE_COMMANDS.has(commandHead(command));
+}
+
+// ZRANGE/ZREVRANGE/ZRANGEBYSCORE/ZDIFF/ZINTER/ZUNION/... with a WITHSCORES modifier
+// return a flat [member1, score1, member2, score2, ...] array — pair it up instead of
+// dumping each element as its own row.
+function hasWithScoresModifier(command: string): boolean {
+  return WITHSCORES_MODIFIER.test(command);
 }
 
 export function redisCommandResultToQueryResult(value: unknown, elapsedMs: number, command?: string): QueryResult {
@@ -15,6 +27,18 @@ export function redisCommandResultToQueryResult(value: unknown, elapsedMs: numbe
     }
     return {
       columns: ["field", "value"],
+      rows,
+      affected_rows: value.length / 2,
+      execution_time_ms: Math.max(0, Math.round(elapsedMs)),
+    };
+  }
+  if (Array.isArray(value) && command && hasWithScoresModifier(command)) {
+    const rows: (string | number | boolean | null)[][] = [];
+    for (let i = 0; i + 1 < value.length; i += 2) {
+      rows.push([formatRedisCommandResult(value[i]), formatRedisCommandResult(value[i + 1])]);
+    }
+    return {
+      columns: ["member", "score"],
       rows,
       affected_rows: value.length / 2,
       execution_time_ms: Math.max(0, Math.round(elapsedMs)),

--- a/apps/desktop/src/lib/redis/redisQueryResult.ts
+++ b/apps/desktop/src/lib/redis/redisQueryResult.ts
@@ -2,6 +2,8 @@ import type { QueryResult } from "@/types/database";
 import { formatRedisCommandResult } from "@/lib/redis/redisValuePresentation";
 
 const KEY_VALUE_COMMANDS = new Set(["HGETALL"]);
+// Sorted-set commands whose WITHSCORES modifier returns a flat member/score array.
+const WITHSCORES_COMMANDS = new Set(["ZRANGE", "ZREVRANGE", "ZRANGEBYSCORE", "ZREVRANGEBYSCORE", "ZRANDMEMBER", "ZDIFF", "ZINTER", "ZUNION"]);
 const WITHSCORES_MODIFIER = /\bWITHSCORES\b/i;
 
 function commandHead(command: string): string {
@@ -14,9 +16,10 @@ function isKeyValueCommand(command: string): boolean {
 
 // ZRANGE/ZREVRANGE/ZRANGEBYSCORE/ZDIFF/ZINTER/ZUNION/... with a WITHSCORES modifier
 // return a flat [member1, score1, member2, score2, ...] array — pair it up instead of
-// dumping each element as its own row.
+// dumping each element as its own row. Gate on the command head so a key or argument
+// that merely contains the token WITHSCORES cannot trigger pairing.
 function hasWithScoresModifier(command: string): boolean {
-  return WITHSCORES_MODIFIER.test(command);
+  return WITHSCORES_COMMANDS.has(commandHead(command)) && WITHSCORES_MODIFIER.test(command);
 }
 
 export function redisCommandResultToQueryResult(value: unknown, elapsedMs: number, command?: string): QueryResult {
@@ -40,7 +43,7 @@ export function redisCommandResultToQueryResult(value: unknown, elapsedMs: numbe
     return {
       columns: ["member", "score"],
       rows,
-      affected_rows: value.length / 2,
+      affected_rows: rows.length,
       execution_time_ms: Math.max(0, Math.round(elapsedMs)),
     };
   }

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -4652,7 +4652,7 @@ export const useQueryStore = defineStore("query", () => {
           const sourceRange = commandRange && options?.sourceOffset !== undefined ? { from: options.sourceOffset + commandRange.from, to: options.sourceOffset + commandRange.to } : undefined;
           try {
             const result = await api.redisExecuteCommand(executionConnectionId, currentDb, command, skipSafety);
-            allResults.push(markQueryResultRowsRaw(annotateQueryResultSource(redisCommandResultToQueryResult(result.value, performance.now() - startedAt, result.command), command, undefined, undefined, sourceRange)));
+            allResults.push(markQueryResultRowsRaw(annotateQueryResultSource(redisCommandResultToQueryResult(result.value, performance.now() - startedAt, command), command, undefined, undefined, sourceRange)));
             // Track db switches from SELECT N so later commands in the same batch run on the right db.
             currentDb = nextRedisCommandDb(currentDb, command, result.value);
             // Write commands (SET/DEL/...) mutate the key set — drop the cached key-name completion


### PR DESCRIPTION
## 变更说明

命令控制台执行 `ZRANGE`/`ZREVRANGE ... WITHSCORES` 时，Redis 返回的是扁平数组 `[member1, score1, member2, score2, ...]`。之前的通用回退分支把每个数组元素单独渲染成一行 `(index)/value`，导致 member 和 score 被拆成两行而不是配对显示在同一行的两列里。

修复：识别命令文本里的 `WITHSCORES` 修饰符，把扁平数组按 2 个一组配对成 `member`/`score` 两列（做法与已有的 `HGETALL` field/value 配对一致）。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过（新增 `redisQueryResult.spec.ts` 4 项断言，覆盖 WITHSCORES 配对、大小写不敏感、无修饰符不受影响、HGETALL 回归；全量前端 872 文件 8272/8272 测试通过）

## 关联 Issue

Fixes #7229