### PR TITLE
fix(editor): 大型 Oracle 包体源码滚动卡死

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { Text } from "@codemirror/state";
-import { currentStatementFrameLayer, currentStatementFrameRect, FRAME_INSET_PX } from "@/lib/editor/codemirrorCurrentStatementFrameLayer";
+import { currentStatementFrameLayer, currentStatementFrameRect, FRAME_INSET_PX, MAX_FRAME_STATEMENT_LINES } from "@/lib/editor/codemirrorCurrentStatementFrameLayer";
 
 interface CoordRect {
   left: number;
@@ -251,6 +251,30 @@ describe("currentStatementFrameRect", () => {
     // bottom = lineBlockAt(73).bottom = 73 * LINE_HEIGHT
     const expectedHeight = (73 - 47) * LINE_HEIGHT + FRAME_INSET_PX * 2;
     expect(rect!.height).toBe(expectedHeight);
+  });
+
+  it("skips huge multi-thousand-line statements instead of probing every line (dbx#7226)", () => {
+    // A large Oracle package body is parsed as one statement spanning the
+    // whole file. Without a cap, this loop would issue two coordsAtPos
+    // calls per logical line, freezing the UI on every scroll frame.
+    const lineCount = MAX_FRAME_STATEMENT_LINES + 2000;
+    const lines = Array.from({ length: lineCount }, (_, i) => `  proc_body_line_${i};`);
+    const view = buildView(lines);
+    const coords = vi.spyOn(view, "coordsAtPos");
+
+    const rect = currentStatementFrameRect(view, 0, view.state.doc.length);
+
+    expect(rect).toBeNull();
+    expect(coords).not.toHaveBeenCalled();
+  });
+
+  it("still frames a statement right at the line-count cap", () => {
+    const lines = Array.from({ length: MAX_FRAME_STATEMENT_LINES + 1 }, (_, i) => `-- line ${i}`);
+    const view = buildView(lines);
+
+    const rect = currentStatementFrameRect(view, 0, view.state.doc.length);
+
+    expect(rect).not.toBeNull();
   });
 });
 

--- a/apps/desktop/src/lib/editor/codemirrorCurrentStatementFrameLayer.ts
+++ b/apps/desktop/src/lib/editor/codemirrorCurrentStatementFrameLayer.ts
@@ -37,6 +37,17 @@ function spansVisualRows(start: PositionRect, end: PositionRect): boolean {
 }
 
 /**
+ * Statements spanning more logical lines than this render no frame. The
+ * horizontal-bounds loop below does a constant number of geometry probes
+ * per logical line, so its cost is O(logical lines) — fine for ordinary
+ * statements, but a multi-thousand-line PL/SQL package body (Oracle, and
+ * other dialects with BEGIN/END routine bodies) is parsed as a single
+ * statement spanning the whole file, turning routine scrolling into
+ * thousands of `coordsAtPos` calls per frame. See dbx#7226.
+ */
+export const MAX_FRAME_STATEMENT_LINES = 500;
+
+/**
  * Measure the pixel rectangle of one statement rendered in `view`.
  *
  * The frame is a single continuous rectangle: it starts at the first
@@ -62,6 +73,7 @@ export function currentStatementFrameRect(view: Viewish, from: number, to: numbe
 
   const startLine = doc.lineAt(from);
   const endLine = doc.lineAt(to);
+  if (endLine.number - startLine.number > MAX_FRAME_STATEMENT_LINES) return null;
   const base = view.scrollDOM.getBoundingClientRect();
 
   // Vertical bounds: convert screen coords to content-layer coords.


### PR DESCRIPTION
## 问题

#7226：查看超过 2000 行的 Oracle package body 源码，打开正常，但向下滚动到约 2000 行位置时界面完全卡死无响应。

## 根因

`ObjectSourceDialog.vue`（查看源码对话框）复用了完整的 `QueryEditor.vue`（CodeMirror 封装），其中画"当前语句"外框线的 `currentStatementFrameLayer` 无条件接入、不受只读/隐藏执行控件影响，且每次 `viewportChanged`（滚动即触发）都会重新计算：`currentStatementFrameRect` 内部按逻辑行数循环，每行调用 2 次 `coordsAtPos`，设计假设是"语句通常只有几行"。

Oracle package body 会被 `sqlStatementRanges.ts`（已有的 dialect 感知拆分逻辑）正确识别为**一整条语句**，因此这个循环会对着全文档跑——实测一个 2472 行的包体，`.cm-db-currentStatementFrame` 的渲染高度确实等于整个文档滚动高度的 99%，每次滚动触发近 5000 次 `coordsAtPos` 调用。这与 issue 补充信息里"关闭 SQL 语义诊断后仍卡死"的排查结果吻合（语义诊断是完全独立的另一个开关，不影响这个图层）。

## 修复

`currentStatementFrameRect` 新增 `MAX_FRAME_STATEMENT_LINES = 500` 上限：语句跨越的逻辑行数超过阈值时直接跳过画框（不进入昂贵的逐行测量循环）。阈值内的正常语句（含主查询编辑器里常规大小的存储过程/包体）行为不变。

## 验证

- 真实复现：共享测试 Oracle 19c 建了 2472 行 package body，独立 dev 环境 + 真实浏览器打开"查看源码"、滚动
- Before/after 对比（同一份 60 步滚动手势模拟）：13.66s → 3.17s；`.cm-db-currentStatementFrame` 从"高度=全文档"变为"不再渲染"
- 回归验证：主查询编辑器里普通大小语句（如 `SELECT * FROM dual`）外框线渲染不受影响
- 新增 2 条单测覆盖阈值边界；`apps/desktop/src/lib/__tests__/editor` + `apps/desktop/src/components/editor` 61 文件 442/442 全绿；全量前端 `vitest` 全绿；`vue-tsc --noEmit` 干净；`oxlint`/`oxfmt` 干净

Fixes #7226