### PR TITLE
fix(jdbc): 修复 Oracle 大整数 NUMBER 列显示为科学计数法

### DIFF
--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -2,6 +2,7 @@ package app.dbx.jdbc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -58,7 +59,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public final class DbxJdbcPlugin {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER =
+        new ObjectMapper().configure(SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN, true);
     private static final int MAX_ROWS = 10_000;
     private static final String JDBCX_URL_PREFIX = "jdbcx:";
     private static final String JDBCX_EXTENSION_WHITELIST_PROPERTY = "jdbcx.extension.whitelist";

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.Clob;
 import java.sql.DatabaseMetaData;
@@ -522,6 +524,53 @@ final class DbxJdbcPluginTest {
         } finally {
             closeAndDeregister(connection, driver);
         }
+    }
+
+    @Test
+    void readValueKeepsBigDecimalWithNegativeScaleAsIs() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod(
+            "readValue",
+            ResultSet.class,
+            ResultSetMetaData.class,
+            int.class,
+            boolean.class
+        );
+        method.setAccessible(true);
+        // Oracle NUMBER(28) columns without a fixed scale can come back from the driver as a
+        // BigDecimal with a negative scale, whose toString() renders in scientific notation.
+        BigDecimal huge = new BigDecimal("2.0260818101758001E+27");
+        ResultSet rs = objectResultSet(huge);
+
+        Object result = method.invoke(null, rs, columnMeta(Types.NUMERIC, "NUMBER"), 1, false);
+
+        assertEquals(huge, result);
+    }
+
+    @Test
+    void bigDecimalValuesSerializeWithoutScientificNotation() throws Exception {
+        ObjectMapper mapper = jdbcPluginMapper();
+        BigDecimal huge = new BigDecimal("2.0260818101758001E+27");
+
+        String json = mapper.writeValueAsString(mapper.valueToTree(huge));
+
+        assertEquals(huge.toPlainString(), json);
+        assertFalse(json.toUpperCase(java.util.Locale.ROOT).contains("E"), json);
+    }
+
+    @Test
+    void ordinaryBigDecimalValuesSerializeUnchanged() throws Exception {
+        ObjectMapper mapper = jdbcPluginMapper();
+        BigDecimal ordinary = new BigDecimal("123.45");
+        BigDecimal negative = new BigDecimal("-9876.5");
+
+        assertEquals("123.45", mapper.writeValueAsString(mapper.valueToTree(ordinary)));
+        assertEquals("-9876.5", mapper.writeValueAsString(mapper.valueToTree(negative)));
+    }
+
+    private static ObjectMapper jdbcPluginMapper() throws Exception {
+        Field field = DbxJdbcPlugin.class.getDeclaredField("MAPPER");
+        field.setAccessible(true);
+        return (ObjectMapper) field.get(null);
     }
 
     @Test


### PR DESCRIPTION
## 问题

Oracle NUMBER 大整数列（如 `number(28)`）在网格里被显示为科学计数法，例如 `2.0260818101758001e+27`，而非完整数值。

Fixes #7263

## 根因

JDBC 插件（`plugins/jdbc`）读取到的 `BigDecimal`（Oracle 大整数常见负 scale 表示）原样传给 Jackson `ObjectMapper` 做 JSON 序列化，该 Mapper 是默认配置，Jackson 对负 scale 的 `BigDecimal` 使用 `toString()` 会输出科学计数法。

## 修复

给插件的 `ObjectMapper` 开启 Jackson 内置的 `SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN`，序列化时按完整数字输出，字段仍是 JSON number 类型，不影响下游排序/对齐/编辑等依赖数字类型的逻辑。改动范围最小（2 行核心代码）。

## 测试

- 真实复现：连共享测试 Oracle 19c，建表插入触发值（大整数 NUMBER 列），装"修复前"插件版本在真实浏览器界面复现出科学计数法；换"修复后"版本重跑同一查询，数字完整显示，正常大小数字列无回归。
- 新增 3 条单测覆盖负 scale BigDecimal 序列化、普通 BigDecimal 不受影响；revert 代码后测试真实失败，加回代码后通过。
- `./gradlew test`：122/122 全绿。
- 已 rebase 到最新 `upstream/main`，无冲突。

## Test plan

- [x] Oracle 大整数 NUMBER 列不再显示为科学计数法
- [x] 普通数字列（整数/小数）显示无回归
- [x] `plugins/jdbc` 单测全绿