### PR TITLE
fix(diff): 结构比较生成的部署 SQL 正确引用目标 schema

### DIFF
--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -3277,6 +3277,154 @@ fn qualified_name(name: &str, db_type: DatabaseType, schema: Option<&str>) -> St
         .unwrap_or_else(|| quote_id(name, db_type))
 }
 
+/// `CREATE TABLE`-family header keywords that native source DDL may start
+/// with, longest-prefix-first so e.g. `CREATE FOREIGN TABLE` isn't shadowed
+/// by a naive `CREATE TABLE` match.
+const TABLE_DDL_HEADER_KEYWORDS: &[&str] =
+    &["CREATE FOREIGN TABLE", "CREATE UNLOGGED TABLE", "CREATE TEMPORARY TABLE", "CREATE TEMP TABLE", "CREATE TABLE"];
+
+/// `CREATE VIEW`-family header keywords, covering the `OR REPLACE` and
+/// `MATERIALIZED` variants emitted by the Postgres/MySQL view DDL builders.
+const VIEW_DDL_HEADER_KEYWORDS: &[&str] = &["CREATE MATERIALIZED VIEW", "CREATE OR REPLACE VIEW", "CREATE VIEW"];
+
+/// Case-insensitive ASCII prefix check that avoids allocating an uppercased
+/// copy of `haystack` (which can be a whole multi-KB `CREATE TABLE` body) just
+/// to compare its first few bytes against a short keyword.
+fn starts_with_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    haystack.get(..needle.len()).is_some_and(|prefix| prefix.eq_ignore_ascii_case(needle))
+}
+
+/// Native DDL captured from the source connection is schema/database-qualified
+/// against the *source* schema (see `render_postgres_table_ddl_with_partition_info`
+/// and `build_view_ddl_sql`). When the diff engine reuses that DDL verbatim for a
+/// same-dialect sync script, running it against a different target schema fails
+/// outright — the statement still names the source schema, which may not even
+/// exist on the target connection.
+///
+/// Rewrites the object name in a `CREATE ...` header to `qualified` when the
+/// captured name is already schema/database-qualified (contains a `.`). An
+/// unqualified name (e.g. MySQL DDL relying on the connection's current
+/// database) is left untouched, since it already resolves correctly wherever
+/// the sync script runs.
+fn rewrite_ddl_header_qualifier(ddl: &str, header_keywords: &[&str], schema: Option<&str>, qualified: &str) -> String {
+    let leading_ws = ddl.len() - ddl.trim_start().len();
+    let body = &ddl[leading_ws..];
+    let Some(keyword) = header_keywords.iter().find(|keyword| starts_with_ignore_ascii_case(body, keyword)) else {
+        return ddl.to_string();
+    };
+
+    let mut idx = skip_ascii_whitespace(ddl, leading_ws + keyword.len());
+    if starts_with_ignore_ascii_case(&ddl[idx..], "IF NOT EXISTS") {
+        idx = skip_ascii_whitespace(ddl, idx + "IF NOT EXISTS".len());
+    }
+
+    let ident_start = idx;
+    let Some(parsed) = parse_qualified_identifier(ddl, idx) else {
+        return ddl.to_string();
+    };
+    let Some((schema_start, schema_end)) = parsed.schema_span else {
+        // Unqualified name (e.g. MySQL DDL relying on the connection's
+        // current database) already resolves correctly wherever the sync
+        // script runs — leave it untouched.
+        return ddl.to_string();
+    };
+    let embedded_schema = strip_identifier_quotes(&ddl[schema_start..schema_end]);
+    if schema.map(str::trim).is_some_and(|schema| schema == embedded_schema) {
+        // Already qualified with the target schema — avoid needlessly
+        // reformatting DDL that's already correct.
+        return ddl.to_string();
+    }
+    format!("{}{}{}", &ddl[..ident_start], qualified, &ddl[parsed.end..])
+}
+
+struct ParsedDdlName {
+    end: usize,
+    schema_span: Option<(usize, usize)>,
+}
+
+/// Parses a (possibly dotted, possibly quoted) identifier starting at `idx`.
+/// Returns the byte offset just past it, plus the span of the schema/database
+/// segment if the name was qualified, or `None` if `idx` isn't the start of
+/// an identifier. Handles the quoting styles used across DDL dialects: double
+/// quotes, backticks, and SQL Server brackets.
+fn parse_qualified_identifier(ddl: &str, start: usize) -> Option<ParsedDdlName> {
+    let mut idx = start;
+    let mut schema_span = None;
+    let mut segment_start = start;
+    loop {
+        let segment_end = parse_identifier_segment_end(ddl, idx)?;
+        idx = segment_end;
+        if ddl[idx..].starts_with('.') {
+            schema_span = Some((segment_start, segment_end));
+            idx += 1;
+            segment_start = idx;
+            continue;
+        }
+        break;
+    }
+    Some(ParsedDdlName { end: idx, schema_span })
+}
+
+/// Parses one identifier segment (quoted or bare) starting at `idx` and
+/// returns the byte offset just past it, or `None` if `idx` isn't the start
+/// of a segment.
+fn parse_identifier_segment_end(ddl: &str, mut idx: usize) -> Option<usize> {
+    let start = idx;
+    let ch = ddl[idx..].chars().next()?;
+    let closing_quote = match ch {
+        '"' => Some('"'),
+        '`' => Some('`'),
+        '[' => Some(']'),
+        _ => None,
+    };
+    if let Some(closing_quote) = closing_quote {
+        idx += ch.len_utf8();
+        loop {
+            let next = ddl[idx..].chars().next()?;
+            idx += next.len_utf8();
+            if next == closing_quote {
+                // SQL Server brackets escape a literal `]` the same way
+                // double-quote/backtick identifiers escape their own quote
+                // char: by doubling it (`[a]]b]` is the identifier `a]b`).
+                if ddl[idx..].starts_with(closing_quote) {
+                    idx += closing_quote.len_utf8();
+                    continue;
+                }
+                break;
+            }
+        }
+    } else if ch.is_alphanumeric() || ch == '_' {
+        while let Some(next) = ddl[idx..].chars().next() {
+            if next.is_alphanumeric() || next == '_' {
+                idx += next.len_utf8();
+            } else {
+                break;
+            }
+        }
+    } else {
+        return None;
+    }
+    (idx != start).then_some(idx)
+}
+
+/// Strips a single matching pair of identifier-quoting characters (double
+/// quotes, backticks, or brackets) from `segment`, undoubling an escaped
+/// closing quote. Returns `segment` unchanged if it isn't quoted.
+fn strip_identifier_quotes(segment: &str) -> String {
+    let mut chars = segment.chars();
+    let (Some(first), Some(last)) = (chars.next(), segment.chars().next_back()) else {
+        return segment.to_string();
+    };
+    let matches = matches!((first, last), ('"', '"') | ('`', '`') | ('[', ']'));
+    if !matches || segment.len() < 2 {
+        return segment.to_string();
+    }
+    let inner = &segment[first.len_utf8()..segment.len() - last.len_utf8()];
+    // Brackets escape their closing char the same way same-char quoting
+    // does (`]]` -> `]`), just with a different open/close pair.
+    inner.replace(&format!("{last}{last}"), &last.to_string())
+}
+
 fn drop_index_sql(table_name: &str, index_name: &str, db_type: DatabaseType, schema: Option<&str>) -> String {
     let profile = profile_for(db_type);
     let table = qualified_name(table_name, db_type, schema);
@@ -4870,6 +5018,7 @@ fn generate_schema_sync_sql_inner(
         if diff.diff_type == "added" && diff.object_type.as_deref() == Some("view") {
             if let Some(ddl) = &diff.ddl {
                 if is_same_dialect || source_dialect.is_none() {
+                    let ddl = rewrite_ddl_header_qualifier(ddl, VIEW_DDL_HEADER_KEYWORDS, schema, &table);
                     lines.push(format!("-- Create view: {}", diff.name));
                     lines.push(format!("{};", ddl.trim_end().trim_end_matches(';')));
                     lines.push(String::new());
@@ -4917,6 +5066,11 @@ fn generate_schema_sync_sql_inner(
                 } else if let Some(ddl) = diff.target_ddl.as_deref() {
                     // Inversion places only the removed target table's native
                     // DDL here, validating that it belongs to the dialect restored.
+                    // It's already qualified against the same target schema this
+                    // rollback re-runs against, so the rewrite below is normally a
+                    // no-op — kept for symmetry with the other native-DDL
+                    // passthrough sites in case that invariant ever changes.
+                    let ddl = rewrite_ddl_header_qualifier(ddl, TABLE_DDL_HEADER_KEYWORDS, schema, &table);
                     lines.push(format!("-- Recreate table from native target DDL: {}", diff.name));
                     lines.push(format!("{};", ddl.trim_end_matches(';')));
                     lines.push(String::new());
@@ -4929,8 +5083,9 @@ fn generate_schema_sync_sql_inner(
                 // Prefer native source DDL when the target profile wants it
                 // (MySQL-family), or as fallback without a structured snapshot.
                 if let Some(ddl) = &diff.ddl {
+                    let ddl = rewrite_ddl_header_qualifier(ddl, TABLE_DDL_HEADER_KEYWORDS, schema, &table);
                     lines.push(format!("-- Create {}: {}", diff.object_type.as_deref().unwrap_or("table"), diff.name));
-                    lines.push(format!("{};", ddl));
+                    lines.push(format!("{};", ddl.trim_end().trim_end_matches(';')));
                     lines.push(String::new());
                 } else if let Some(cols) = &diff.columns {
                     let trigger_infos: Vec<TriggerInfo> = diff
@@ -8312,6 +8467,124 @@ mod tests {
             ]
             .join("\n")
         );
+    }
+
+    #[test]
+    fn added_table_native_ddl_rewrites_source_schema_to_target_schema() {
+        // Issue #7249: comparing two Postgres schemas emitted the *source*
+        // schema-qualified CREATE TABLE verbatim, so the generated sync SQL
+        // referenced a schema that may not even exist on the target and
+        // failed 100% of the time.
+        let diffs = vec![TableDiff {
+            diff_type: "added".to_string(),
+            object_type: Some("table".to_string()),
+            name: "orders".to_string(),
+            ddl: Some("CREATE TABLE \"source_schema\".\"orders\" (\n  \"id\" integer\n)".to_string()),
+            ..TableDiff::default()
+        }];
+
+        let sql = generate_schema_sync_sql(
+            &diffs,
+            &[],
+            &[],
+            &[],
+            &[],
+            DatabaseType::Postgres,
+            Some("target_schema"),
+            false,
+            Some(DialectKind::Postgres),
+            &[],
+        );
+
+        assert!(sql.contains("CREATE TABLE \"target_schema\".\"orders\""), "{sql}");
+        assert!(!sql.contains("source_schema"), "{sql}");
+    }
+
+    #[test]
+    fn added_view_native_ddl_rewrites_source_schema_to_target_schema() {
+        let diffs = vec![TableDiff {
+            diff_type: "added".to_string(),
+            object_type: Some("view".to_string()),
+            name: "active_orders".to_string(),
+            ddl: Some("CREATE OR REPLACE VIEW \"source_schema\".\"active_orders\" AS\nSELECT 1".to_string()),
+            ..TableDiff::default()
+        }];
+
+        let sql = generate_schema_sync_sql(
+            &diffs,
+            &[],
+            &[],
+            &[],
+            &[],
+            DatabaseType::Postgres,
+            Some("target_schema"),
+            false,
+            Some(DialectKind::Postgres),
+            &[],
+        );
+
+        assert!(sql.contains("CREATE OR REPLACE VIEW \"target_schema\".\"active_orders\""), "{sql}");
+        assert!(!sql.contains("source_schema"), "{sql}");
+    }
+
+    #[test]
+    fn added_table_unqualified_native_ddl_is_left_unchanged() {
+        // MySQL-family DDL that relies on the connection's current database
+        // (no schema/database qualifier) already resolves correctly wherever
+        // the sync script runs, so it must not be rewritten.
+        let diffs = vec![TableDiff {
+            diff_type: "added".to_string(),
+            object_type: Some("table".to_string()),
+            name: "orders".to_string(),
+            ddl: Some("CREATE TABLE `orders` (\n  `id` int\n)".to_string()),
+            ..TableDiff::default()
+        }];
+
+        let sql = generate_schema_sync_sql(
+            &diffs,
+            &[],
+            &[],
+            &[],
+            &[],
+            DatabaseType::Mysql,
+            Some("shop"),
+            false,
+            Some(DialectKind::Mysql),
+            &[],
+        );
+
+        assert!(sql.contains("CREATE TABLE `orders`"), "{sql}");
+    }
+
+    #[test]
+    fn added_table_native_ddl_rewrites_bracket_quoted_schema_with_escaped_bracket() {
+        // SQL Server escapes a literal `]` inside a bracketed identifier by
+        // doubling it (`[a]]b]` is the identifier `a]b`) — the schema segment
+        // here must still be recognized as "source_schema]" rather than the
+        // parser stopping at the first `]`.
+        let diffs = vec![TableDiff {
+            diff_type: "added".to_string(),
+            object_type: Some("table".to_string()),
+            name: "orders".to_string(),
+            ddl: Some("CREATE TABLE [source_schema]]].[orders] (\n  [id] int\n)".to_string()),
+            ..TableDiff::default()
+        }];
+
+        let sql = generate_schema_sync_sql(
+            &diffs,
+            &[],
+            &[],
+            &[],
+            &[],
+            DatabaseType::SqlServer,
+            Some("target_schema"),
+            false,
+            Some(DialectKind::SqlServer),
+            &[],
+        );
+
+        assert!(sql.contains("[target_schema].[orders]"), "{sql}");
+        assert!(!sql.contains("source_schema"), "{sql}");
     }
 
     // ========================================================================


### PR DESCRIPTION
## 变更说明

比较结构时，如果源库和目标库是同一种数据库方言（如 Postgres → Postgres），对于"需要新建"的表/视图，同步引擎会直接复用从源连接采集到的原生 DDL（`CREATE TABLE "源schema"."表名" (...)`）。但这段 DDL 是按**源端** schema 限定的，直接原样塞进部署脚本后，生成的 SQL 引用的仍然是源端 schema——如果目标连接上根本不存在这个 schema，执行会 100% 失败；即使凑巧同名也只是误打误撞。

修复：在拼装同步 SQL 时，识别 `CREATE TABLE`/`CREATE VIEW`（含 `FOREIGN TABLE`/`TEMP`/`UNLOGGED`/`MATERIALIZED`/`OR REPLACE` 等变体）语句头部已经带 schema 限定符的情况，把限定符改写为目标 schema；如果 DDL 本身没有限定符（例如 MySQL 依赖连接当前库的场景），保持不变，不影响现有行为。同时顺带处理了：
- SQL Server 方括号标识符里 `]]` 转义的正确识别；
- 新建表分支缺失的结尾分号裁剪（避免生成多余的空语句）；
- 回滚路径里对称地复用了同一套改写逻辑。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 仅涉及 `crates/dbx-core/src/schema_diff.rs` 后端逻辑，无前端改动。

## 验证

- [x] `make check` 通过（format/lint/typecheck/test 全绿）
- [x] `make cargo-check-fast` 通过（全工作区 `cargo check --no-default-features`）
- [x] 相关测试通过：`schema_diff` 模块新增 4 个针对性单测（含 postgres 表/视图跨 schema 改写、SQL Server 方括号转义、MySQL 未限定名保持不变的反例），232/232 通过；`cargo clippy`/`cargo fmt` 干净；全量 `cargo test -p dbx-core --lib` 4774/4774 通过（跳过的是与本改动无关、在本机沙箱网络下会挂起的既有 mock-server 类测试）
- [x] 真实复现验证：起独立 dev 后端+前端，连共享测试 Postgres 实例，建两个 schema（一个有表一个没有），走完整"比较架构"UI 流程，修复前生成的部署 SQL 引用源 schema 导致语义错误，修复后正确引用目标 schema，点击执行部署成功，并直接查库确认表落在了正确的目标 schema 下

## 关联 Issue

Fixes #7249