### PR TITLE
fix(editor): 严格匹配替换快捷键修饰键

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -108,7 +108,7 @@ import {
 import type { SqlHighlighter } from "@/lib/sql/sqlHighlighter";
 import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticColors, editorThemeAppearanceFor, loadEditorTheme, editorFontTheme, shellLineCommentTheme, sqlCompletionTheme, sqlSemanticHighlightTheme } from "@/lib/editor/editorThemes";
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
-import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
+import { createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 import { buildQueryEditorLineNumbersExtension } from "@/lib/editor/queryEditorLineNumbers";
 import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
 import { defaultKeymapForGlobalShortcuts } from "@/lib/editor/codemirrorDefaultKeymap";
@@ -1937,7 +1937,20 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
         (currentView) => shouldBlockExecutionShortcut(undefined, currentView),
       );
   const executeInNewResultTabBindings = props.hideExecutionControls ? [] : createQueryEditorExecutionShortcutBindings(shortcuts.executeSqlInNewResultTab, requestExecuteInNewResultTab, (currentView) => shouldBlockExecutionShortcut(undefined, currentView));
+  const replaceShortcutBindings = createQueryEditorReplaceShortcutBindings(shortcuts.replace, openReplace);
+  const replaceShortcutHandler = createQueryEditorReplaceShortcutHandler({
+    shortcut: shortcuts.replace,
+    openReplace,
+    isReadOnly: () => !!props.readOnly,
+  });
   return [
+    editorViewModule
+      ? (Prec?.high(
+          editorViewModule.EditorView.domEventHandlers({
+            keydown: replaceShortcutHandler,
+          }),
+        ) ?? [])
+      : [],
     Prec?.high(
       codeMirrorKeymap.of([
         {
@@ -1945,7 +1958,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
           run: handleEnter,
         },
         ...binding(shortcuts.find, openSearch),
-        ...binding(shortcuts.replace, openReplace),
+        ...replaceShortcutBindings,
         ...executeInNewResultTabBindings,
         ...executeBindings,
         ...binding(shortcuts.saveSql, () => {

--- a/apps/desktop/src/components/editor/__tests__/QueryEditorSearchKeymap.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/QueryEditorSearchKeymap.spec.ts
@@ -1,9 +1,15 @@
 // @vitest-environment happy-dom
 
+// pi-lens-ignore: typescript:2307
 import { EditorState, Prec } from "@codemirror/state";
+// pi-lens-ignore: typescript:2307
 import { EditorView, keymap, runScopeHandlers } from "@codemirror/view";
+// pi-lens-ignore: typescript:2307
 import { describe, expect, it, vi } from "vitest";
-import { createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
+// pi-lens-ignore: typescript:2307
+import { createQueryEditorExecutionShortcutBindings } from "@/lib/editor/queryEditorExecutionShortcut";
+// pi-lens-ignore: typescript:2307
+import { createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 
 describe("QueryEditor search keymap precedence", () => {
   it("runs configured editor actions before the built-in search fallback", () => {
@@ -19,6 +25,53 @@ describe("QueryEditor search keymap precedence", () => {
     expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "f", ctrlKey: true }), "editor")).toBe(true);
     expect(formatSql).toHaveBeenCalledOnce();
     expect(openSearch).not.toHaveBeenCalled();
+    view.destroy();
+  });
+
+  it("executes a custom Shift+Mod+R shortcut instead of the Mod+R replace binding", () => {
+    const openReplace = vi.fn(() => true);
+    const executeSql = vi.fn(() => true);
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [
+          Prec.high(
+            EditorView.domEventHandlers({
+              keydown: createQueryEditorReplaceShortcutHandler({ shortcut: "Mod+R", openReplace, isReadOnly: () => false }),
+            }),
+          ),
+          Prec.high(keymap.of([...createQueryEditorReplaceShortcutBindings("Mod+R", openReplace), ...createQueryEditorExecutionShortcutBindings("Shift+Mod+R", executeSql, () => false)])),
+        ],
+      }),
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "r", ctrlKey: true, shiftKey: true, bubbles: true, cancelable: true });
+    view.contentDOM.dispatchEvent(event);
+    expect(executeSql).toHaveBeenCalledOnce();
+    expect(openReplace).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+    view.destroy();
+  });
+
+  it("keeps the default Mod+R replace action working", () => {
+    const openReplace = vi.fn(() => true);
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [
+          Prec.high(
+            EditorView.domEventHandlers({
+              keydown: createQueryEditorReplaceShortcutHandler({ shortcut: "Mod+R", openReplace, isReadOnly: () => false }),
+            }),
+          ),
+        ],
+      }),
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "r", ctrlKey: true, bubbles: true, cancelable: true });
+    view.contentDOM.dispatchEvent(event);
+    expect(openReplace).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
     view.destroy();
   });
 

--- a/apps/desktop/src/lib/editor/queryEditorSearchKeymap.ts
+++ b/apps/desktop/src/lib/editor/queryEditorSearchKeymap.ts
@@ -1,3 +1,6 @@
+import { matchesShortcut } from "@/lib/editor/keyboardShortcuts";
+import { shortcutToCodeMirrorKey } from "@/lib/editor/shortcutRegistry";
+// pi-lens-ignore: typescript:2307
 import type { KeyBinding } from "@codemirror/view";
 
 interface QueryEditorSearchKeymapOptions {
@@ -20,4 +23,32 @@ export function createQueryEditorSearchKeymap(options: QueryEditorSearchKeymapOp
       run: () => options.isReadOnly() || options.openReplace(),
     },
   ];
+}
+
+export function createQueryEditorReplaceShortcutBindings(shortcut: string, openReplace: () => boolean): KeyBinding[] {
+  const normalizedShortcut = shortcut.trim();
+  return normalizedShortcut && /\s/.test(normalizedShortcut) ? [{ key: shortcutToCodeMirrorKey(normalizedShortcut), preventDefault: true, run: openReplace }] : [];
+}
+
+/**
+ * Handle the configurable replace shortcut outside CodeMirror's character
+ * keymap matching. CodeMirror intentionally lets `Mod-r` match a shifted
+ * character event too, so a `Mod+R` replace binding can consume a custom
+ * `Shift+Mod+R` editor action before its exact binding is considered.
+ *
+ * Multi-stroke shortcuts stay in the regular keymap because this handler only
+ * handles one keyboard event at a time.
+ */
+export function createQueryEditorReplaceShortcutHandler(options: { shortcut: string; openReplace: () => boolean; isReadOnly: () => boolean }): (event: KeyboardEvent) => boolean {
+  const shortcut = options.shortcut.trim();
+  if (!shortcut || /\s/.test(shortcut)) return () => false;
+
+  return (event) => {
+    if (!matchesShortcut(event, shortcut)) return false;
+    // Match the existing keymap's preventDefault behavior even when the
+    // read-only guard prevents the panel from opening.
+    if (options.isReadOnly()) return true;
+    options.openReplace();
+    return true;
+  };
 }


### PR DESCRIPTION
## 问题

当用户将 `Ctrl+Shift+R`（DBX 内部表示为 `Shift+Mod+R`）配置为执行 SQL 快捷键时，实际会错误触发编辑器的替换功能。

修改前实际行为：

```text
configured shortcut: Shift+Mod+R
keyboard event: Ctrl+Shift+R
expected: executeSql
actual: openReplace
event.defaultPrevented: true
```

## 根因

`QueryEditor` 中的 `Mod+R → openReplace` binding 注册在 SQL 执行 binding 之前。

CodeMirror 对字符键 `Mod+R` 的匹配会同时命中带额外 `Shift` 的 `Shift+Mod+R`，因此 `Ctrl+Shift+R` 会先被替换快捷键消费，并设置 `defaultPrevented`，后续配置的 `executeSql` 无法再触发。

已确认该问题不是由：

* `@codemirror/search` 的 `searchKeymap`
* 浏览器 reload 快捷键
* App 全局快捷键 handler

导致。

## 修复

* 单笔划 replace 快捷键改为使用严格的 `KeyboardEvent` 修饰键匹配
* 避免 `Mod+R` 错误吞掉 `Shift+Mod+R`
* 多笔划 replace 快捷键仍沿用 CodeMirror keymap
* 保留默认 `Mod+R` 替换行为
* 未修改快捷键 scope 规则
* 未修改 Vim mode
* 未修改 IME execution guard

## 验证

修改前 regression test 可稳定复现问题，修改后通过。

验证结果：

```text
PASS 8 个 targeted spec，127 tests
PASS pnpm typecheck
PASS oxlint
PASS oxfmt --check
PASS git diff --check
PASS pi-lens 无 blocking findings
```

覆盖：

* 自定义 `Shift+Mod+R` 执行 SQL
* 默认 `Mod+R` replace
* find/search 既有行为
* shortcut precedence
* CodeMirror search keymap
* execution shortcut / IME 相关回归

本次仅修改前端编辑器快捷键匹配逻辑，不涉及 Rust/backend。

Closes #7275