### PR TITLE
⚡ perf(transfer): 避免大规模对象列表导致数据传输界面卡死

### DIFF
--- a/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
+++ b/apps/desktop/src/components/transfer/ObjectSelectionTree.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
+import { RecycleScroller } from "vue-virtual-scroller";
+import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 import type { TransferObjectKind } from "@/lib/backend/api";
 import { Square, CheckSquare, MinusSquare, Search, ChevronRight } from "@lucide/vue";
 
@@ -11,6 +13,14 @@ export interface ObjectTreeGroup {
   label: string;
   items: string[];
 }
+
+// Keep large groups safe both before and after the user expands them. The
+// complete item arrays remain in the model; only their DOM representation is bounded.
+const VIRTUALIZED_GROUP_ITEM_LIMIT = 200;
+const OBJECT_ITEM_HEIGHT = 28;
+const OBJECT_LIST_HEIGHT = 200;
+const OBJECT_LIST_BUFFER = 160;
+const EMPTY_SELECTION = new Set<string>();
 
 const props = defineProps<{
   groups: ObjectTreeGroup[];
@@ -26,25 +36,6 @@ const emit = defineEmits<{
   "update:search": [value: string];
 }>();
 
-const expanded = ref<Set<string>>(new Set(props.groups.map((g) => g.kind)));
-
-// Groups may arrive after the tree mounts (async object loading); keep newly
-// appearing groups expanded so search results are visible without a manual tap.
-watch(
-  () => props.groups.map((g) => g.kind),
-  (kinds) => {
-    let changed = false;
-    const next = new Set(expanded.value);
-    for (const kind of kinds) {
-      if (!next.has(kind)) {
-        next.add(kind);
-        changed = true;
-      }
-    }
-    if (changed) expanded.value = next;
-  },
-);
-
 // Local search state: the input edits this ref directly and changes are
 // forwarded up via update:search (v-model:search on the parent).
 const localSearch = ref(props.search ?? "");
@@ -59,6 +50,17 @@ watch(localSearch, (v) => {
 });
 
 const searchQuery = computed(() => localSearch.value.trim().toLowerCase());
+
+function isVirtualizedGroup(group: ObjectTreeGroup): boolean {
+  return group.items.length > VIRTUALIZED_GROUP_ITEM_LIMIT;
+}
+
+function hasSearchMatch(items: string[]): boolean {
+  const query = searchQuery.value;
+  return query.length > 0 && items.some((name) => name.toLowerCase().includes(query));
+}
+
+const expanded = ref<Set<string>>(new Set(props.groups.filter((group) => !isVirtualizedGroup(group) || hasSearchMatch(group.items)).map((group) => group.kind)));
 
 function toggleGroup(kind: string) {
   const next = new Set(expanded.value);
@@ -78,6 +80,18 @@ function selectedNames(kind: string): string[] {
   return props.modelValue[kind] ?? [];
 }
 
+const selectedSets = computed<Record<string, Set<string>>>(() => {
+  const next: Record<string, Set<string>> = {};
+  for (const [kind, names] of Object.entries(props.modelValue)) {
+    if (names.length > 0) next[kind] = new Set(names);
+  }
+  return next;
+});
+
+function selectedSet(kind: string): Set<string> {
+  return selectedSets.value[kind] ?? EMPTY_SELECTION;
+}
+
 function updateSelection(kind: string, names: string[]) {
   const next: Record<string, string[]> = { ...props.modelValue };
   if (names.length === 0) {
@@ -90,18 +104,20 @@ function updateSelection(kind: string, names: string[]) {
 
 function toggleItem(kind: string, item: string) {
   const current = selectedNames(kind);
-  const next = current.includes(item) ? current.filter((n) => n !== item) : [...current, item];
+  const next = selectedSet(kind).has(item) ? current.filter((n) => n !== item) : [...current, item];
   updateSelection(kind, next);
 }
 
 function toggleGroupAll(kind: TransferObjectKind, items: string[]) {
   const current = selectedNames(kind);
-  const allVisibleSelected = items.length > 0 && items.every((n) => current.includes(n));
+  const selected = selectedSet(kind);
+  const visibleItems = new Set(items);
+  const allVisibleSelected = items.length > 0 && items.every((n) => selected.has(n));
   if (allVisibleSelected) {
     // uncheck only the visible items, keep selections hidden by the search
     updateSelection(
       kind,
-      current.filter((n) => !items.includes(n)),
+      current.filter((n) => !visibleItems.has(n)),
     );
   } else {
     // check the visible items, merging with existing (possibly hidden) ones
@@ -129,6 +145,49 @@ const filteredGroups = computed<ObjectTreeGroup[]>(() => {
   });
 });
 
+function shouldAutoExpandGroup(group: ObjectTreeGroup): boolean {
+  if (!isVirtualizedGroup(group)) return true;
+  const visibleGroup = filteredGroups.value.find((candidate) => candidate.kind === group.kind);
+  return searchQuery.value.length > 0 && (visibleGroup?.items.length ?? 0) > 0;
+}
+
+// Groups arrive after the tree mounts because object metadata is loaded
+// asynchronously. New small groups keep the existing expanded behavior, while
+// large groups stay collapsed unless search has a visible match.
+watch(
+  () => props.groups,
+  (groups, previousGroups) => {
+    const previousByKind = new Map((previousGroups ?? []).map((group) => [group.kind, group]));
+    const currentKinds = new Set<string>(groups.map((group) => group.kind));
+    const next = new Set([...expanded.value].filter((kind) => currentKinds.has(kind)));
+
+    for (const group of groups) {
+      const previousGroup = previousByKind.get(group.kind);
+      const becameVirtualized = isVirtualizedGroup(group) && (!previousGroup || !isVirtualizedGroup(previousGroup));
+      if (becameVirtualized && searchQuery.value.length === 0) {
+        next.delete(group.kind);
+      } else if (!next.has(group.kind) && shouldAutoExpandGroup(group)) {
+        next.add(group.kind);
+      }
+    }
+
+    const unchanged = next.size === expanded.value.size && [...next].every((kind) => expanded.value.has(kind));
+    if (!unchanged) expanded.value = next;
+  },
+);
+
+// Searching must reveal matching groups even when a large group starts
+// collapsed. The virtualized branch still bounds the resulting DOM.
+watch(searchQuery, (query) => {
+  if (!query) return;
+  const next = new Set(expanded.value);
+  for (const group of filteredGroups.value) {
+    if (group.items.length > 0) next.add(group.kind);
+  }
+  const unchanged = next.size === expanded.value.size && [...next].every((kind) => expanded.value.has(kind));
+  if (!unchanged) expanded.value = next;
+});
+
 function selectAllEnabled() {
   const next: Record<string, string[]> = { ...props.modelValue };
   for (const group of filteredGroups.value) {
@@ -145,7 +204,8 @@ function deselectAll() {
   const next: Record<string, string[]> = { ...props.modelValue };
   for (const group of filteredGroups.value) {
     if (isGroupDisabled(group.kind)) continue;
-    const kept = (next[group.kind] ?? []).filter((n) => !group.items.includes(n));
+    const visibleItems = new Set(group.items);
+    const kept = (next[group.kind] ?? []).filter((n) => !visibleItems.has(n));
     if (kept.length === 0) {
       delete next[group.kind];
     } else {
@@ -162,7 +222,13 @@ function deselectAll() {
 // (fully filtered out by the search) and disabled groups are ignored.
 const allVisibleEnabledSelected = computed(() => {
   const visibleEnabled = filteredGroups.value.filter((g) => !isGroupDisabled(g.kind) && g.items.length > 0);
-  return visibleEnabled.length > 0 && visibleEnabled.every((g) => g.items.every((item) => (props.modelValue[g.kind] ?? []).includes(item)));
+  return (
+    visibleEnabled.length > 0 &&
+    visibleEnabled.every((g) => {
+      const selected = selectedSet(g.kind);
+      return g.items.every((item) => selected.has(item));
+    })
+  );
 });
 
 // Tri-state header checkbox: "all" when every visible item of the group is
@@ -170,8 +236,8 @@ const allVisibleEnabledSelected = computed(() => {
 // toggleGroupAll, which only ever touches the visible items.
 function groupSelectionState(kind: TransferObjectKind, items: string[]): "none" | "partial" | "all" {
   if (items.length === 0) return "none";
-  const selected = props.modelValue[kind] ?? [];
-  const visibleSelected = items.filter((item) => selected.includes(item)).length;
+  const selected = selectedSet(kind);
+  const visibleSelected = items.filter((item) => selected.has(item)).length;
   if (visibleSelected === 0) return "none";
   if (visibleSelected === items.length) return "all";
   return "partial";
@@ -229,18 +295,28 @@ function groupSelectionState(kind: TransferObjectKind, items: string[]): "none" 
           <span v-if="disabledHints[group.kind]" class="rounded bg-amber-500/10 border border-amber-500/20 px-1.5 py-0.5 text-[10px] text-amber-700 font-medium shrink-0">
             {{ disabledHints[group.kind] }}
           </span>
-          <button type="button" class="text-muted-foreground hover:text-foreground shrink-0 p-0.5" @click="toggleGroup(group.kind)">
+          <button data-test="group-expand" type="button" class="text-muted-foreground hover:text-foreground shrink-0 p-0.5" :aria-expanded="expanded.has(group.kind)" @click="toggleGroup(group.kind)">
             <ChevronRight class="h-3.5 w-3.5 text-muted-foreground/80 transition-transform duration-200" :class="{ 'rotate-90': expanded.has(group.kind) }" />
           </button>
         </div>
 
-        <div v-if="expanded.has(group.kind)" class="flex flex-col gap-0.5 pl-6 pr-1 mt-1">
-          <label v-for="item in group.items" :key="item" class="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-xs hover:bg-muted/70 transition-colors" :class="{ 'pointer-events-none opacity-50': isGroupDisabled(group.kind) }" :data-test="`item-${group.kind}-${item}`">
-            <input type="checkbox" class="h-3.5 w-3.5" :checked="(modelValue[group.kind] ?? []).includes(item)" :disabled="isGroupDisabled(group.kind)" @change="toggleItem(group.kind, item)" />
-            <span class="truncate text-foreground/80">{{ item }}</span>
-          </label>
-          <div v-if="group.items.length === 0" class="px-1 py-1 text-xs text-muted-foreground">无匹配</div>
-        </div>
+        <template v-if="expanded.has(group.kind)">
+          <div v-if="!isVirtualizedGroup(group)" class="flex flex-col gap-0.5 pl-6 pr-1 mt-1">
+            <label v-for="item in group.items" :key="item" class="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-xs hover:bg-muted/70 transition-colors" :class="{ 'pointer-events-none opacity-50': isGroupDisabled(group.kind) }" :data-test="`item-${group.kind}-${item}`">
+              <input type="checkbox" class="h-3.5 w-3.5" :checked="selectedSet(group.kind).has(item)" :disabled="isGroupDisabled(group.kind)" @change="toggleItem(group.kind, item)" />
+              <span class="truncate text-foreground/80">{{ item }}</span>
+            </label>
+            <div v-if="group.items.length === 0" class="px-1 py-1 text-xs text-muted-foreground">无匹配</div>
+          </div>
+          <div v-else class="pl-6 pr-1 mt-1" :style="{ height: `${OBJECT_LIST_HEIGHT}px` }">
+            <RecycleScroller v-slot="{ item }" class="h-full" :items="group.items" :item-size="OBJECT_ITEM_HEIGHT" :buffer="OBJECT_LIST_BUFFER">
+              <label class="flex h-7 cursor-pointer items-center gap-2 rounded px-1.5 text-xs hover:bg-muted/70 transition-colors" :class="{ 'pointer-events-none opacity-50': isGroupDisabled(group.kind) }" :data-test="`item-${group.kind}-${item}`">
+                <input type="checkbox" class="h-3.5 w-3.5" :checked="selectedSet(group.kind).has(item)" :disabled="isGroupDisabled(group.kind)" @change="toggleItem(group.kind, item)" />
+                <span class="truncate text-foreground/80">{{ item }}</span>
+              </label>
+            </RecycleScroller>
+          </div>
+        </template>
       </div>
     </div>
   </div>

--- a/apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts
+++ b/apps/desktop/src/components/transfer/__tests__/ObjectSelectionTree.spec.ts
@@ -24,6 +24,22 @@ vi.mock("@lucide/vue", () => {
     ChevronRight: Icon,
   };
 });
+vi.mock("vue-virtual-scroller", () => ({
+  RecycleScroller: defineComponent({
+    inheritAttrs: false,
+    props: { items: { type: Array, default: () => [] } },
+    setup(props, { attrs, slots }) {
+      return () =>
+        h(
+          "div",
+          attrs,
+          // Keep the unit test deterministic while mirroring a viewport-sized
+          // RecycleScroller pool instead of rendering every supplied item.
+          props.items.slice(0, 50).map((item, index) => slots.default?.({ item, index, active: true })),
+        );
+    },
+  }),
+}));
 vi.mock("@/components/ui/button", () => ({ Button: passthrough("button") }));
 
 import ObjectSelectionTree from "../ObjectSelectionTree.vue";
@@ -45,15 +61,20 @@ const POSTGRES_FUNCTIONS: TreeGroup = {
   items: ["_st_beststride", "_st_coveredby", "box", "box2d"],
 };
 const POSTGRES_SEQUENCES: TreeGroup = { kind: "SEQUENCE", label: "Sequences", items: ["biz_banner_id_seq"] };
+const LARGE_TABLES: TreeGroup = {
+  kind: "TABLE",
+  label: "Tables",
+  items: Array.from({ length: 40_000 }, (_, index) => (index === 20_000 ? "customer_order_special" : `table_${String(index).padStart(5, "0")}`)),
+};
 
 function mountTree(init: { groups?: TreeGroup[]; disabledGroups?: Kind[]; disabledHints?: Record<string, string>; selection?: Record<string, string[]>; search?: string }) {
   const { groups = [VIEWS, FUNCTIONS], disabledGroups = [], disabledHints = {}, selection = {}, search = "" } = init;
-  const state = reactive({ selection, search });
+  const state = reactive({ selection, search, groups });
   const Wrapper = defineComponent({
     setup() {
       return () =>
         h(ObjectSelectionTree, {
-          groups,
+          groups: state.groups,
           disabledGroups,
           disabledHints,
           modelValue: state.selection,
@@ -78,6 +99,10 @@ function groupToggle(container: HTMLElement, index = 0): HTMLButtonElement {
   return container.querySelectorAll<HTMLButtonElement>('button[data-test="group-toggle"]')[index];
 }
 
+function expandGroup(container: HTMLElement, kind: string) {
+  container.querySelector<HTMLButtonElement>(`[data-test="group-${kind}"] button[data-test="group-expand"]`)!.click();
+}
+
 function itemCheckbox(container: HTMLElement, kind: string, item: string): HTMLInputElement {
   return container.querySelector<HTMLInputElement>(`label[data-test="item-${kind}-${item}"] input`)!;
 }
@@ -97,7 +122,7 @@ let cleanup: (() => void) | undefined;
 afterEach(() => {
   cleanup?.();
   cleanup = undefined;
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
   vi.clearAllMocks();
 });
 
@@ -109,6 +134,55 @@ describe("ObjectSelectionTree interaction", () => {
     expect(container.querySelector('label[data-test="item-VIEW-v1"]')).not.toBeNull();
     expect(container.querySelector('label[data-test="item-FUNCTION-f2"]')).not.toBeNull();
     expect(container.querySelector('input[data-test="search"]')).not.toBeNull();
+  });
+
+  it("does not render a large group until the user expands it", async () => {
+    const { container, app } = mountTree({ groups: [LARGE_TABLES] });
+    cleanup = () => app.unmount();
+
+    expect(container.querySelector('[data-test="group-TABLE"]')).not.toBeNull();
+    expect(container.querySelectorAll('label[data-test^="item-TABLE-"]')).toHaveLength(0);
+  });
+
+  it("keeps asynchronously loaded large groups collapsed", async () => {
+    const { state, container, app } = mountTree({ groups: [] });
+    cleanup = () => app.unmount();
+
+    state.groups = [LARGE_TABLES];
+    await nextTick();
+    expect(container.querySelector('[data-test="group-TABLE"]')).not.toBeNull();
+    expect(container.querySelectorAll('label[data-test^="item-TABLE-"]')).toHaveLength(0);
+  });
+
+  it("virtualizes expanded large groups while keeping the full selection model", async () => {
+    const { state, container, app } = mountTree({ groups: [LARGE_TABLES] });
+    cleanup = () => app.unmount();
+
+    expandGroup(container, "TABLE");
+    await nextTick();
+    const renderedItems = container.querySelectorAll('label[data-test^="item-TABLE-"]');
+    expect(renderedItems.length).toBeGreaterThan(0);
+    expect(renderedItems.length).toBeLessThan(100);
+    expect(container.querySelector('label[data-test="item-TABLE-table_00000"]')).not.toBeNull();
+    expect(container.querySelector('label[data-test="item-TABLE-table_39999"]')).toBeNull();
+
+    groupToggle(container).click();
+    await nextTick();
+    expect(state.selection.TABLE).toHaveLength(40_000);
+    expect(container.querySelectorAll('label[data-test^="item-TABLE-"]').length).toBeLessThan(100);
+  });
+
+  it("reveals large-group search matches without rendering every result", async () => {
+    const { container, app } = mountTree({ groups: [LARGE_TABLES] });
+    cleanup = () => app.unmount();
+
+    await typeSearch(container, "customer_order");
+    expect(container.querySelector('label[data-test="item-TABLE-customer_order_special"]')).not.toBeNull();
+    expect(container.querySelectorAll('label[data-test^="item-TABLE-"]')).toHaveLength(1);
+
+    await typeSearch(container, "table_");
+    expect(container.querySelector('label[data-test="item-TABLE-table_00000"]')).not.toBeNull();
+    expect(container.querySelectorAll('label[data-test^="item-TABLE-"]').length).toBeLessThan(100);
   });
 
   it("toggles all items of a group through the group header checkbox", async () => {


### PR DESCRIPTION
## 变更说明

修复 #7283。

当数据传输源 Schema 中存在大量对象时，例如用户反馈的 PostgreSQL Schema 包含 40000+ 张表，原实现会在对象加载完成后默认展开 TABLE 分组，并一次性渲染全部对象。

在 40000 张表的场景下，这会直接创建约 40000 个表项 DOM，导致 Vue 渲染和主线程负载过高，表现为数据传输窗口严重卡顿甚至假死。

本 PR 对数据传输对象选择树的大列表场景进行了渲染优化。

### 修复前

使用 synthetic 40000 TABLE 数据复现：

```text
TABLE items: 40000
item DOM count: 40000
```

对象加载完成后会直接渲染全部表项。

### 修复后

* 对象数超过 200 的分组默认保持收起
* 异步加载的大分组同样不会自动展开
* 大列表展开后使用现有 `vue-virtual-scroller` 进行虚拟滚动
* 初始状态下大分组的 item DOM 数量为 0
* 展开后 DOM pool 保持有界，测试环境下不超过约 50 项
* 搜索命中时自动展开对应分组
* 搜索结果继续使用虚拟滚动，不会一次渲染全部 40000 项
* selection hot path 从 `Array.includes()` 优化为 computed `Set`
* 全选、搜索状态下全选、隐藏项保留、disabled group、tri-state 等现有选择语义保持不变

## 性能对比

```text
场景：40000 TABLE items

修复前：
initial item DOM = 40000

修复后：
initial item DOM = 0
expanded item DOM = bounded virtual pool
```

同时，全选 40000 项时仍会在 selection model 中保留完整的 40000 个对象，不通过截断数据来规避性能问题。

## 实现范围

本次仅修改前端对象选择树及相关测试：

* `ObjectSelectionTree.vue`
* `ObjectSelectionTree.spec.ts`

未修改：

* backend
* Rust
* API protocol
* metadata pagination

当前没有证据表明 PostgreSQL metadata SQL 本身是主要瓶颈，因此本 PR 不扩大到后端分页或 metadata API 重构。

## 测试

已通过：

```text
ObjectSelectionTree + DataTransferDialog: 36/36 PASS
pnpm typecheck: PASS
pnpm lint: PASS（仅仓库既有 warning）
pnpm build: PASS
git diff --check: PASS
```

新增 synthetic 40000 TABLE 回归测试，覆盖：

* 大分组初始不渲染全部 item
* 异步加载大分组保持收起
* 主动展开后的 bounded rendering
* 大列表搜索
* 搜索结果自动展开
* 完整 selection model
* 大 selection 下的选择状态正确性

Fixes #7283
