### PR TITLE
Fix：修复 Oracle 默认 ORCL 未生效

### DIFF
--- a/crates/dbx-core/src/agent_connection.rs
+++ b/crates/dbx-core/src/agent_connection.rs
@@ -775,6 +775,23 @@ mod tests {
     }
 
     #[test]
+    fn oracle_form_connections_use_orcl_when_database_is_omitted() {
+        for (mode, expected_url) in [
+            ("service_name", "jdbc:oracle:thin:@//oracle.example.com:1521/ORCL"),
+            ("sid", "jdbc:oracle:thin:@oracle.example.com:1521:ORCL"),
+        ] {
+            let mut cfg = config(DatabaseType::Oracle, None);
+            cfg.oracle_connection_type = Some(mode.to_string());
+            let database = cfg.effective_database().unwrap_or("");
+
+            let params = agent_connect_params(&cfg, "oracle.example.com", 1521, database).unwrap();
+
+            assert_eq!(params["database"], "ORCL");
+            assert_eq!(params["connection_string"], expected_url);
+        }
+    }
+
+    #[test]
     fn structured_hive_uses_current_url_params_for_zookeeper_detection() {
         let mut cfg = config(DatabaseType::Hive, Some("default"));
         cfg.connection_string = Some(

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -856,6 +856,11 @@ impl ConnectionConfig {
             DatabaseType::Highgo => Some("highgo"),
             DatabaseType::Uxdb => Some("uxdb"),
             DatabaseType::Yashandb => Some("yasdb"),
+            DatabaseType::Oracle
+                if !self.oracle_connection_type.as_deref().is_some_and(|mode| mode.eq_ignore_ascii_case("tns")) =>
+            {
+                Some("ORCL")
+            }
             DatabaseType::Oscar => Some("osrdb"),
             DatabaseType::Firebird => Some("employee"),
             DatabaseType::H2 => Some("test"),
@@ -2830,6 +2835,20 @@ mod tests {
 
         config.db_type = DatabaseType::Postgres;
         assert_eq!(config.effective_database(), Some("postgres"));
+    }
+
+    #[test]
+    fn oracle_database_defaults_to_orcl_except_for_tns_aliases() {
+        let mut config = mysql_config("system", "oracle", None);
+        config.db_type = DatabaseType::Oracle;
+
+        for mode in [None, Some("service_name"), Some("sid")] {
+            config.oracle_connection_type = mode.map(str::to_string);
+            assert_eq!(config.effective_database(), Some("ORCL"));
+        }
+
+        config.oracle_connection_type = Some("tns".to_string());
+        assert_eq!(config.effective_database(), None);
     }
 
     fn mongodb_config(username: &str, password: &str, database: Option<&str>) -> ConnectionConfig {


### PR DESCRIPTION
## 问题

Oracle 新建连接界面提示“服务名/SID 可选，默认 ORCL”，但 `ORCL` 之前只用于占位文案。留空提交时 Agent 实际收到空服务名和 SID，导致连接报错；手动填写 `ORCL` 才能连接。

## 改动

- 为普通 Oracle 服务名和 SID 连接补齐统一默认数据库 `ORCL`
- 保留显式填写的服务名或 SID，不覆盖用户配置
- TNS 模式不应用 `ORCL`，仍要求填写明确的 TNS 别名
- 补充最终 Agent 参数测试，覆盖服务名和 SID 两种 JDBC URL

## 验证

- 179 项 Oracle 相关 `dbx-core` 测试通过
- `cargo check -p dbx-core` 通过
- Rust 格式检查和 diff 检查通过