### PR TITLE
Feature: 默认选中首个补全候选

### DIFF
--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -132,11 +132,11 @@ describe("normalizeEditorSettings", () => {
     expect(normalizeEditorSettings({ insertSpaceAfterCompletion: false }).insertSpaceAfterCompletion).toBe(false);
   });
 
-  it("keeps non-intrusive completion selection as the default", () => {
-    expect(normalizeEditorSettings({}).selectFirstCompletionOnOpen).toBe(false);
+  it("selects the first completion candidate by default and preserves the opt-out", () => {
+    expect(normalizeEditorSettings({}).selectFirstCompletionOnOpen).toBe(true);
     expect(normalizeEditorSettings({ selectFirstCompletionOnOpen: true }).selectFirstCompletionOnOpen).toBe(true);
     expect(normalizeEditorSettings({ selectFirstCompletionOnOpen: false }).selectFirstCompletionOnOpen).toBe(false);
-    expect(normalizeEditorSettings({ selectFirstCompletionOnOpen: "true" } as any).selectFirstCompletionOnOpen).toBe(false);
+    expect(normalizeEditorSettings({ selectFirstCompletionOnOpen: "true" } as any).selectFirstCompletionOnOpen).toBe(true);
   });
 
   it("defaults sidebar connection sorting to manual order and preserves valid alphabetical modes", () => {

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -746,7 +746,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   autoAliasTables: true,
   insertSpaceAfterCompletion: true,
   sortCompletionColumnsAlphabetically: true,
-  selectFirstCompletionOnOpen: false,
+  selectFirstCompletionOnOpen: true,
   wordWrap: false,
   tableDdlWordWrap: true,
   vimModeEnabled: false,

--- a/packages/app-tests/editorSettingsDraft.test.ts
+++ b/packages/app-tests/editorSettingsDraft.test.ts
@@ -51,8 +51,8 @@ test("round-trips completion column ordering through the editor settings draft",
 
 test("round-trips completion selection behavior through the editor settings draft", () => {
   const base = editorSettingsDraftFromSettings(DEFAULT_EDITOR_SETTINGS);
-  const patch = editorSettingsPatchFromDraft({ ...base, selectFirstCompletionOnOpen: true }, base);
+  const patch = editorSettingsPatchFromDraft({ ...base, selectFirstCompletionOnOpen: false }, base);
 
-  assert.deepEqual(patch, { selectFirstCompletionOnOpen: true });
-  assert.equal(editorSettingsDraftFromSettings({ ...DEFAULT_EDITOR_SETTINGS, ...patch }).selectFirstCompletionOnOpen, true);
+  assert.deepEqual(patch, { selectFirstCompletionOnOpen: false });
+  assert.equal(editorSettingsDraftFromSettings({ ...DEFAULT_EDITOR_SETTINGS, ...patch }).selectFirstCompletionOnOpen, false);
 });


### PR DESCRIPTION
## 改动说明

- 将“设置 → 编辑器 → 自动选中首个补全候选”改为默认开启
- 保留用户已明确保存的开关状态，主动关闭过的用户升级后仍保持关闭
- 缺失或无效的旧配置回退为新的默认值

## 验证

- `pnpm exec vitest run apps/desktop/src/stores/__tests__/settingsStore.spec.ts`（105 项通过）
- `pnpm exec oxfmt --check apps/desktop/src/stores/settingsStore.ts apps/desktop/src/stores/__tests__/settingsStore.spec.ts`
- `pnpm typecheck`
- `git diff --check`