### PR TITLE
fix(jdbc): 缺少 ALL_USERS 视图时降级使用 DatabaseMetaData.getSchemas

### DIFF
--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -3389,6 +3389,7 @@ public final class DbxJdbcPlugin {
                     return rs.getString(1);
                 }
             }
+        } catch (SQLException ignored) {
         }
         return null;
     }
@@ -3402,6 +3403,7 @@ public final class DbxJdbcPlugin {
                     return rs.getString(1);
                 }
             }
+        } catch (SQLException ignored) {
         }
         return null;
     }
@@ -3416,8 +3418,18 @@ public final class DbxJdbcPlugin {
                     result.add(name);
                 }
             }
+            return result;
+        } catch (SQLException e) {
+            try (ResultSet rs = conn.getMetaData().getSchemas()) {
+                while (rs.next()) {
+                    String schema = rs.getString("TABLE_SCHEM");
+                    if (schema != null && !schema.isBlank()) {
+                        result.add(schema);
+                    }
+                }
+            }
+            return result;
         }
-        return result;
     }
 
     private static JsonNode oracleListTables(Connection conn, String owner) throws SQLException {

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -2731,6 +2731,28 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void oracleListSchemasFallsBackToJdbcSchemasWhenAllUsersIsMissing() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleListSchemas", Connection.class);
+        method.setAccessible(true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:dbx_oracle_no_all_users;DB_CLOSE_DELAY=-1", "sa", "")) {
+            conn.createStatement().execute("CREATE SCHEMA DM6_TEST_SCHEMA");
+
+            JsonNode result = (JsonNode) method.invoke(null, conn);
+            assertFalse(result.isNull());
+            assertEquals(true, result.isArray());
+            boolean found = false;
+            for (JsonNode node : result) {
+                if ("DM6_TEST_SCHEMA".equalsIgnoreCase(node.asText())) {
+                    found = true;
+                    break;
+                }
+            }
+            assertEquals(true, found);
+        }
+    }
+
+    @Test
     void oracleEffectiveSchemaUsesExactOwnerBeforeUppercaseFallback() throws Exception {
         Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleEffectiveSchema", Connection.class, String.class);
         method.setAccessible(true);


### PR DESCRIPTION
## 变更说明

在使用通用 JDBC 插件连接 达梦 6 等早期数据库版本时（URL 为 `jdbc:dm:...`），由于系统默认启用了 Oracle 方言特性，在展开左侧模式列表时会执行 `SELECT username FROM all_users`。由于达梦 6 尚未内置 Oracle 的 `ALL_USERS` 兼容字典视图，导致展开树节点时抛出 `无效的表或视图名 'all_users'` 异常并阻断连接。

本 PR 进行了如下修复：
1. **模式列表降级**：在 `DbxJdbcPlugin.oracleListSchemas()` 中捕获查询 `all_users` 抛出的 `SQLException`，平滑回退到标准 JDBC 的 `DatabaseMetaData.getSchemas()` 获取模式列表。
2. **补充容错**：在 `oracleFindIdentifier()` 中捕获字典查询异常并安全返回 `null`，使得后续展开表、查看字段时的 `oracleResolveOwner()` 能够安全回退使用用户输入的原始 Schema 字符串，避免次级崩溃。
3. **单元测试覆盖**：在 `DbxJdbcPluginTest` 中添加了无 `ALL_USERS` 视图场景下的回归测试用例。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] plugins/jdbc 单元测试全部通过

## 关联 Issue
Fixes #7259