### PR TITLE
Fix：修复 Windows 桌面端 SQLite 链接失败

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "libsqlite3-hotbundle"
 version = "1.510300.0"
-source = "git+https://github.com/nikescar/libsqlite3-hotbundle.git?rev=a208c7ef1447a02bf5ecb8c6a297aca012d41244#a208c7ef1447a02bf5ecb8c6a297aca012d41244"
+source = "git+https://github.com/zipg/libsqlite3-hotbundle.git?rev=7f12f203b4f4694a273410bd9b02d77f82b6114e#7f12f203b4f4694a273410bd9b02d77f82b6114e"
 dependencies = [
  "cc",
 ]
@@ -8958,7 +8958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/dbx-core/Cargo.toml
+++ b/crates/dbx-core/Cargo.toml
@@ -47,7 +47,7 @@ postgres-openssl = "0.5"
 openssl = { version = "0.10", features = ["vendored"] }
 webpki-roots = "0.26"
 rusqlite = { version = "0.32", default-features = false, features = ["load_extension", "backup", "functions", "column_decltype"] }
-libsqlite3-hotbundle = { git = "https://github.com/nikescar/libsqlite3-hotbundle.git", rev = "a208c7ef1447a02bf5ecb8c6a297aca012d41244", features = ["cipher-sqlcipher"], optional = true }
+libsqlite3-hotbundle = { git = "https://github.com/zipg/libsqlite3-hotbundle.git", rev = "7f12f203b4f4694a273410bd9b02d77f82b6114e", features = ["cipher-sqlcipher"], optional = true }
 mysql_async = { version = "0.37", default-features = false, features = ["default-rustls", "client_ed25519", "chrono", "rust_decimal"] }
 sqlparser = { version = "0.62.0", features = ["visitor"] }
 redis = { version = "0.32.2", features = ["tokio-comp", "tls-rustls", "tls-rustls-insecure", "tokio-rustls-comp", "sentinel", "cluster-async"] }


### PR DESCRIPTION
## 问题

Windows 桌面发布构建启用 SQLite3MultipleCiphers 后，MSVC 在最终链接阶段检测到 `sqlite3_open`、`sqlite3_close`、`sqlite3_exec`、`sqlite3_libversion` 重复定义，导致 `LNK2005` / `LNK1169`。

## 修复

- 原生目标仅使用 `sqlite3mc.c` 提供的 SQLite 符号，WASM 专用导出只在 `wasm32` 编译。
- 将 DBX 的 `libsqlite3-hotbundle` 依赖固定到已通过多平台验证的修复提交。
- 保持桌面 SQLite3MultipleCiphers、Web SQLCipher、CLI/MCP bundled SQLite 的 provider 隔离不变。

## 验证

- `libsqlite3-hotbundle` Windows MSVC、Linux、macOS：SQLCipher 模式测试及 release 链接通过。
- DBX SQLite3MultipleCiphers 专项测试：49 项通过，包含 RC4 Legacy 和 SQLCipher 兼容场景。
- DBX Web SQLCipher 专项测试：48 项通过。
- DBX CLI/MCP bundled SQLite：`cargo check --locked` 通过。
- DBX Tauri 桌面完整 `cargo build --locked --package dbx --features custom-protocol` 通过。
- Docker GNU 与 musl 的 `dbx-web` 依赖树均未引入 `libsqlite3-hotbundle`。