### PR TITLE
🐛 fix(grid): 保持 Canvas 绘制表面切换时的悬停状态

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -6893,6 +6893,11 @@ function inactiveCanvasSurface(): HTMLCanvasElement | null {
   return (canvasUsingBackSurface.value ? canvasRef.value : canvasBackRef.value) ?? null;
 }
 const canvasOverlayRef = ref<HTMLElement>();
+
+function isCanvasGridInteractionTarget(target: Node): boolean {
+  return canvasOverlayRef.value?.contains(target) === true || canvasRef.value?.contains(target) === true || canvasBackRef.value?.contains(target) === true;
+}
+
 const canvasViewportWidth = ref(0);
 const canvasViewportHeight = ref(0);
 const canvasScrollTop = ref(0);
@@ -7247,7 +7252,9 @@ function onCanvasMouseMove(event: MouseEvent) {
 
 function onCanvasMouseLeave(event?: MouseEvent) {
   const relatedTarget = event?.relatedTarget;
-  if (relatedTarget instanceof Node && canvasOverlayRef.value?.contains(relatedTarget)) return;
+  // A draw swaps the visible canvas surface. Treat that as an in-grid move so
+  // the action overlay does not disappear between the two surfaces.
+  if (relatedTarget instanceof Node && isCanvasGridInteractionTarget(relatedTarget)) return;
   const previous = canvasHoverCell.value;
   if (previous) {
     const previousActualColIdx = visibleColumnIndexes.value[previous.visibleColIdx];
@@ -7270,7 +7277,7 @@ function keepCanvasDetailHover() {
 
 function clearCanvasDetailHover(event?: MouseEvent) {
   const relatedTarget = event?.relatedTarget;
-  if (relatedTarget instanceof Node && (canvasOverlayRef.value?.contains(relatedTarget) || activeCanvasSurface()?.contains(relatedTarget) || canvasBackRef.value?.contains(relatedTarget))) {
+  if (relatedTarget instanceof Node && isCanvasGridInteractionTarget(relatedTarget)) {
     return;
   }
   onCanvasMouseLeave();

--- a/apps/desktop/src/components/grid/__tests__/DataGridCellDetailSelection.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridCellDetailSelection.spec.ts
@@ -4,6 +4,18 @@ import { describe, expect, it } from "vitest";
 const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
 
 describe("DataGrid cell detail selection", () => {
+  it("keeps Canvas hover state while the renderer swaps drawing surfaces", () => {
+    expect(dataGridSource).toContain("function isCanvasGridInteractionTarget(target: Node): boolean");
+    expect(dataGridSource).toContain("canvasOverlayRef.value?.contains(target) === true");
+    expect(dataGridSource).toContain("canvasRef.value?.contains(target) === true");
+    expect(dataGridSource).toContain("canvasBackRef.value?.contains(target) === true");
+
+    const canvasLeave = dataGridSource.match(/function onCanvasMouseLeave[\s\S]*?\n\}/)?.[0];
+    const detailLeave = dataGridSource.match(/function clearCanvasDetailHover[\s\S]*?\n\}/)?.[0];
+    expect(canvasLeave).toContain("isCanvasGridInteractionTarget(relatedTarget)");
+    expect(detailLeave).toContain("isCanvasGridInteractionTarget(relatedTarget)");
+  });
+
   it("gates only the three hover Info buttons with the visibility setting", () => {
     expect(dataGridSource).toContain("const cellDetailButtonEnabled = computed(() => settingsStore.editorSettings.dataGridCellDetailButtonVisible);");
     expect(dataGridSource.match(/v-if="cellDetailButtonEnabled"/g)).toHaveLength(3);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ dynamodb = ["dbx-core/dynamodb"]
 mq-admin = ["dbx-core/mq-admin"]
 sqlite-sqlcipher = ["dbx-core/sqlite-sqlcipher"]
 sqlite-multiple-ciphers = ["dbx-core/sqlite-multiple-ciphers"]
+sqlite-bundled = ["dbx-core/sqlite-bundled"]
 system-fonts = ["dbx-core/system-fonts"]
 
 [build-dependencies]


### PR DESCRIPTION
- 统一判断网格交互目标，覆盖前景画布、后台画布和操作覆盖层
- 防止渲染交换画布时单元格操作浮层意外消失
- 补充 Canvas 悬停状态回归测试
- 新增 `sqlite-bundled` Tauri 功能透传配置

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="622" height="366" alt="6496D76F-083E-44AA-9889-F31F321EC933" src="https://github.com/user-attachments/assets/517ac760-66bd-495b-a861-ac202be1581d" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #7269