### PR TITLE
🔧 build(sqlite): 在快速开发与检查命令中启用 bundled SQLite 功能

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ dev: node_modules/.modules.yaml check-tauri-dev-port
 	$(PNPM) dev:tauri
 
 dev-fast: node_modules/.modules.yaml check-tauri-dev-port
-	$(PNPM) tauri dev -- --no-default-features --features duckdb-sidecar,dynamodb
+	$(PNPM) tauri dev -- --no-default-features --features duckdb-sidecar,dynamodb,sqlite-bundled
 
 dev-web: node_modules/.modules.yaml
 	$(PNPM) dev:web
@@ -110,10 +110,10 @@ test: node_modules/.modules.yaml
 	$(PNPM) test
 
 cargo-check-fast:
-	cargo check --no-default-features
+	cargo check --no-default-features --features sqlite-bundled
 
 cargo-test-fast:
-	cargo test --no-default-features
+	cargo test --no-default-features --features sqlite-bundled
 
 db-list:
 	@$(PNPM) db:env -- list

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ dynamodb = ["dbx-core/dynamodb"]
 mq-admin = ["dbx-core/mq-admin"]
 sqlite-sqlcipher = ["dbx-core/sqlite-sqlcipher"]
 sqlite-multiple-ciphers = ["dbx-core/sqlite-multiple-ciphers"]
+sqlite-bundled = ["dbx-core/sqlite-bundled"]
 system-fonts = ["dbx-core/system-fonts"]
 
 [build-dependencies]


### PR DESCRIPTION
## 变更说明
<!-- 简要描述本次变更内容和目的 -->

为禁用默认 feature 的快速开发、检查与测试命令显式启用 bundled SQLite，避免回退链接系统 SQLite 后，在 macOS arm64 上出现 `sqlite3_enable_load_extension`、`sqlite3_load_extension` 未定义符号错误。

## 变更类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [x] CI / 构建

## 涉及前端
<!-- 若涉及前端 UI 改动，请勾选并附截图或录屏 -->
- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）
<!-- 截图区域 -->

<img width="1606" height="504" alt="image" src="https://github.com/user-attachments/assets/e0c66d78-7ac6-4397-b090-ed67472613c8" />


## 验证
<!-- 请勾选实际执行的验证项 -->
- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [ ] 相关测试通过

已执行：
- `make cargo-check-fast`：通过。
- `cargo build --manifest-path src-tauri/Cargo.toml --no-default-features --features duckdb-sidecar,dynamodb,sqlite-bundled`：通过，arm64 最终链接成功。
- `make cargo-test-fast`：SQLite 链接正常，但 6 个既有 MCP 包管理器 shim fixture 测试失败（267 个通过）。
- `git diff --check`：通过。

## 关联 Issue
<!-- 如有, Close # -->
