### PR TITLE
fix(schema-diff): 比较前刷新表列表，避免使用已失效缓存

### DIFF
--- a/apps/desktop/src/components/diff/SchemaDiffDialog.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDialog.vue
@@ -441,7 +441,9 @@ async function handleCompare() {
 
     const sourceTableIdentity: SchemaDiffTableIdentity = { connectionId: sourceConnectionId.value, database: sourceDatabase.value, schema: sourceSchema.value };
     const targetTableIdentity: SchemaDiffTableIdentity = { connectionId: targetConnectionId.value, database: targetDatabase.value, schema: targetSchema.value };
-    const [srcTables, tgtTables] = await Promise.all([schemaDiffTableListLoader.load(sourceTableIdentity), schemaDiffTableListLoader.load(targetTableIdentity)]);
+    // The dialog can remain open while either database changes, so Compare must not reuse
+    // the table list cached while configuring the comparison.
+    const [srcTables, tgtTables] = await Promise.all([schemaDiffTableListLoader.load(sourceTableIdentity, { refresh: true }), schemaDiffTableListLoader.load(targetTableIdentity, { refresh: true })]);
     // Explicit (visual) table selection is applied here, BEFORE any per-table
     // metadata details are loaded, so metadata requests only happen for the
     // final table set. `undefined`/empty means no restriction (legacy path).

--- a/apps/desktop/src/lib/__tests__/schema/schemaDiffTableList.spec.ts
+++ b/apps/desktop/src/lib/__tests__/schema/schemaDiffTableList.spec.ts
@@ -37,7 +37,7 @@ describe("schemaDiffTableList", () => {
     expect(shouldLoadSchemaDiffTableList("target", true, 0, true)).toBe(false);
   });
 
-  it("loads each side at most once and reuses successful results for Compare", async () => {
+  it("loads each side at most once for non-refreshing reads", async () => {
     const listTables = vi.fn(async (connectionId: string) => [table(`${connectionId}_table`)]);
     const loader = createSchemaDiffTableListLoader({ ensureConnected: vi.fn().mockResolvedValue(undefined), listTables });
     const identities: Record<SchemaDiffTableSide, SchemaDiffTableIdentity> = {
@@ -57,6 +57,22 @@ describe("schemaDiffTableList", () => {
     expect(listTables).toHaveBeenCalledTimes(2);
     expect(listTables).toHaveBeenCalledWith("source", "app", "public");
     expect(listTables).toHaveBeenCalledWith("target", "app", "public");
+  });
+
+  it("refreshes table names before a second compare after the database changes", async () => {
+    const listTables = vi
+      .fn()
+      .mockResolvedValueOnce([table("removed_table")])
+      .mockResolvedValueOnce([table("current_table")]);
+    const loader = createSchemaDiffTableListLoader({ ensureConnected: vi.fn().mockResolvedValue(undefined), listTables });
+    const identity: SchemaDiffTableIdentity = { connectionId: "source", database: "app", schema: "public" };
+
+    const firstTables = await loader.load(identity);
+    const refreshedTables = await loader.load(identity, { refresh: true });
+
+    expect(firstTables.map((entry) => entry.name)).toEqual(["removed_table"]);
+    expect(refreshedTables.map((entry) => entry.name)).toEqual(["current_table"]);
+    expect(listTables).toHaveBeenCalledTimes(2);
   });
 
   it("prunes deleted selections only after a successful source load", async () => {

--- a/apps/desktop/src/lib/schema/schemaDiffTableList.ts
+++ b/apps/desktop/src/lib/schema/schemaDiffTableList.ts
@@ -9,7 +9,7 @@ export interface SchemaDiffTableIdentity {
 }
 
 export interface SchemaDiffTableListLoader {
-  load(identity: SchemaDiffTableIdentity): Promise<TableInfo[]>;
+  load(identity: SchemaDiffTableIdentity, options?: { refresh?: boolean }): Promise<TableInfo[]>;
 }
 
 interface SchemaDiffTableListLoaderDependencies {
@@ -46,12 +46,12 @@ export function createSchemaDiffTableListLoader(dependencies: SchemaDiffTableLis
   const pending = new Map<string, Promise<TableInfo[]>>();
 
   return {
-    async load(identity) {
+    async load(identity, options) {
       const key = identityKey(identity);
       const inFlight = pending.get(key);
       if (inFlight) return inFlight;
 
-      const cached = successful.get(key);
+      const cached = options?.refresh ? undefined : successful.get(key);
       if (cached) {
         await dependencies.ensureConnected(identity.connectionId);
         return cached;


### PR DESCRIPTION
## 问题

修复 #7308。

Schema Diff 会缓存已经成功加载过的表列表。

当用户保持“库结构对比”弹窗打开，同时数据库结构发生变化，例如：

- 删除表
- 重命名表
- 表列表发生其他变化

再次点击“比较”时，原先可能继续复用旧的表列表。

这样后续 metadata 加载仍可能访问已经不存在的表。

在 MySQL 中最终可能表现为：

```text
ERROR 1146 (42S02): Table '...' doesn't exist
```

## 根因

配置阶段加载的表列表会按连接、数据库和 schema 缓存。原先点击“比较”时继续使用该成功缓存，没有重新读取当前表列表。

## 修复

- 为 table-list loader 增加可选的强制刷新参数。
- 点击“比较”时分别刷新 source 和 target 的表列表。
- 保留配置阶段普通读取的缓存行为，避免不必要的重复请求。
- 增加回归测试，覆盖首次读取旧表列表、数据库结构变化后再次比较并读取新表列表的场景。

## 验证

- targeted Vitest：5 passed
- `vue-tsc --noEmit`：通过
- `oxlint`：通过
- `oxfmt --check`：通过
- MySQL 8.4.6 下验证删除测试表后，旧表名会导致 1146；刷新表列表后不再继续请求该表

Fixes #7308
