### PR TITLE
Fix: 修正数据生成时默认值覆盖生成规则

### DIFF
--- a/apps/desktop/src/lib/dataGrid/dataGenerate.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGenerate.ts
@@ -1204,7 +1204,7 @@ export function defaultGeneratorParams(_columnName: string, attrs: ColumnAttrs, 
   const scale = attrs.numericScale ?? null;
   const charLen = attrs.characterMaximumLength ?? null;
   if (!attrs.isAutoIncrement && generatedDefaultValue(attrs.columnDefault, attrs.dataType) !== undefined) {
-    params.includeDefault = true;
+    params.includeDefault = false;
     params.defaultPercent = 100;
   }
 
@@ -1552,7 +1552,7 @@ export function generateValue(columnName: string, dataType: string, generatorKey
   if (params?.includeNull && params.nullPercent && Math.random() * 100 < params.nullPercent) return null;
   const defaultValue = generatedDefaultValue(columnDefault, dataType);
   if (defaultValue !== undefined) {
-    const includeDefault = params?.includeDefault ?? true;
+    const includeDefault = params?.includeDefault ?? false;
     const defaultPercent = params?.defaultPercent ?? 100;
     if (includeDefault && defaultPercent > 0 && Math.random() * 100 < defaultPercent) return defaultValue;
   }

--- a/packages/app-tests/dataGenerate.test.ts
+++ b/packages/app-tests/dataGenerate.test.ts
@@ -11,7 +11,7 @@ test("recognizes Oracle-compatible NUMBER column types as numeric", () => {
   assert.equal(findGeneratorKey("value", "NUMBER CODE"), "text");
 });
 
-test("enables default values for columns with schema defaults", () => {
+test("keeps schema defaults optional for generated columns", () => {
   const params = defaultGeneratorParams(
     "status",
     {
@@ -21,8 +21,16 @@ test("enables default values for columns with schema defaults", () => {
     "text",
   );
 
-  assert.equal(params.includeDefault, true);
+  assert.equal(params.includeDefault, false);
   assert.equal(params.defaultPercent, 100);
+});
+
+test("does not let schema defaults override generated values unless enabled", () => {
+  const generated = generateValue("age", "bigint", "sequence", 4, { startValue: 1, increment: 1 }, "0");
+  const explicitDefault = generateValue("age", "bigint", "sequence", 4, { includeDefault: true, defaultPercent: 100 }, "0");
+
+  assert.equal(generated, 5);
+  assert.equal(explicitDefault, 0);
 });
 
 test("uses string column defaults instead of random generated values", () => {


### PR DESCRIPTION
## 问题
带数据库默认值的字段会默认以 100% 比例采用默认值，导致自动识别的随机数、序列等生成规则完全不生效。

## 修改
- 默认关闭生成器的“包含默认值”选项，避免字段默认值覆盖生成规则
- 保留显式开启该选项后按比例使用数据库默认值的能力
- 补充默认行为和显式启用行为的回归测试

## 验证
- MySQL 8.4 实测：带 DEFAULT 0 和 DEFAULT 123 的 BIGINT 字段，1000 行预览已按数值规则生成，不再全部为默认值
- pnpm exec vitest run packages/app-tests/dataGenerate.test.ts
- pnpm typecheck
- pnpm exec oxfmt --check apps/desktop/src/lib/dataGrid/dataGenerate.ts packages/app-tests/dataGenerate.test.ts

Fixes #7310