### PR TITLE
Fix: 修复 Oracle JDBC 数据比较无法选择源表

### DIFF
--- a/apps/desktop/src/components/diff/DataCompareDialog.vue
+++ b/apps/desktop/src/components/diff/DataCompareDialog.vue
@@ -118,6 +118,7 @@ const showRemoved = ref(true);
 const showModified = ref(true);
 
 let syncPlanRequestId = 0;
+let initializingPrefill = false;
 
 const sqlConnections = computed(() => store.connections.filter((connection) => !["redis", "mongodb", "elasticsearch", "easysearch", "meilisearch", "qdrant", "milvus", "weaviate", "chromadb", "etcd", "zookeeper", "consul", "mq", "nacos"].includes(connection.db_type)));
 const selectedSourceTableNames = computed(() => sourceTables.value.filter((table) => selectedSourceTables.value.has(table)));
@@ -780,6 +781,7 @@ function formatModifiedSummary(row: SelectableDataCompareModifiedRow): string {
 }
 
 watch(sourceConnectionId, (id) => {
+  if (initializingPrefill) return;
   clearResult();
   sourceDatabase.value = "";
   sourceSchema.value = "";
@@ -799,6 +801,7 @@ watch(targetConnectionId, (id) => {
   loadDatabases(id, "target").catch((e) => toast(String(e), 5000));
 });
 watch(sourceDatabase, () => {
+  if (initializingPrefill) return;
   clearResult();
   sourceSchema.value = "";
   sourceSchemas.value = [];
@@ -816,6 +819,7 @@ watch(targetDatabase, () => {
   loadSchemas("target").catch((e) => toast(String(e), 5000));
 });
 watch(sourceSchema, () => {
+  if (initializingPrefill) return;
   clearResult();
   sourceTables.value = [];
   sourceTable.value = "";
@@ -853,16 +857,21 @@ watch(
     if (!value) return;
     clearResult();
     if (props.prefillConnectionId) {
-      sourceConnectionId.value = props.prefillConnectionId;
-      await loadDatabases(props.prefillConnectionId, "source");
-      if (props.prefillDatabase) sourceDatabase.value = props.prefillDatabase;
-      if (props.prefillDatabase) await loadSchemas("source", props.prefillSchema);
-      if (props.prefillTable) {
-        await loadTables("source");
-        if (sourceTables.value.includes(props.prefillTable)) {
-          resetSelectedSourceTables([props.prefillTable]);
-          sourceTable.value = props.prefillTable;
+      initializingPrefill = true;
+      try {
+        sourceConnectionId.value = props.prefillConnectionId;
+        await loadDatabases(props.prefillConnectionId, "source");
+        if (props.prefillDatabase) sourceDatabase.value = props.prefillDatabase;
+        if (props.prefillDatabase) await loadSchemas("source", props.prefillSchema);
+        if (props.prefillTable) {
+          await loadTables("source");
+          if (sourceTables.value.includes(props.prefillTable)) {
+            resetSelectedSourceTables([props.prefillTable]);
+            sourceTable.value = props.prefillTable;
+          }
         }
+      } finally {
+        initializingPrefill = false;
       }
     }
   },

--- a/apps/desktop/src/components/diff/__tests__/DataCompareDialog.prefill.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/DataCompareDialog.prefill.spec.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import DataCompareDialog from "@/components/diff/DataCompareDialog.vue";
+
+const mocks = vi.hoisted(() => ({
+  ensureConnected: vi.fn().mockResolvedValue(undefined),
+  listDatabases: vi.fn().mockResolvedValue([{ name: "DBX_TEST" }, { name: "OPS$ORACLE" }]),
+  listSchemas: vi.fn().mockResolvedValue(["DBX_TEST"]),
+  listTables: vi.fn().mockResolvedValue([{ name: "CODEX_7046_META", table_type: "TABLE" }]),
+  getColumns: vi.fn().mockResolvedValue([{ name: "ID", data_type: "NUMBER", is_primary_key: true }]),
+}));
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => ({
+    connections: [{ id: "oracle-11g", name: "Oracle XE 11g", db_type: "oracle", driver_profile: "oracle", database: "XE" }],
+    getConfig: (id: string) => (id === "oracle-11g" ? { id, name: "Oracle XE 11g", db_type: "oracle", driver_profile: "oracle", database: "XE" } : undefined),
+    ensureConnected: mocks.ensureConnected,
+  }),
+}));
+
+vi.mock("@/lib/backend/api", () => ({
+  listDatabases: mocks.listDatabases,
+  listSchemas: mocks.listSchemas,
+  listTables: mocks.listTables,
+  getColumns: mocks.getColumns,
+}));
+
+const mountedApps: App[] = [];
+
+async function flushAsyncSetup() {
+  for (let index = 0; index < 8; index += 1) {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe("DataCompareDialog source prefill", () => {
+  it("keeps the Oracle source table after loading database and schema prefills", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const app = createApp(
+      defineComponent({
+        setup: () => () =>
+          h(DataCompareDialog, {
+            open: true,
+            prefillConnectionId: "oracle-11g",
+            prefillDatabase: "DBX_TEST",
+            prefillSchema: "DBX_TEST",
+            prefillTable: "CODEX_7046_META",
+          }),
+      }),
+    );
+    mountedApps.push(app);
+    app.use(i18n);
+    app.mount(container);
+    await flushAsyncSetup();
+
+    expect(mocks.listTables).toHaveBeenCalledWith("oracle-11g", "DBX_TEST", "DBX_TEST");
+    expect(document.body.textContent).toContain("CODEX_7046_META");
+    expect(document.body.textContent).not.toContain("暂无可比较的表");
+  });
+});


### PR DESCRIPTION
## 问题

Oracle JDBC 连接从表入口打开“比较数据”时，预填的连接、数据库和 Schema 会触发多组异步 watcher。后完成的 watcher 会再次清空源表列表，导致界面显示“暂无可比较的表”。

## 修复

- 初始化预填数据期间暂停源端连接、数据库和 Schema watcher
- 按连接、数据库、Schema、表的顺序完成一次初始化加载
- 初始化完成后恢复正常联动行为
- 增加 Oracle 多 namespace 场景的组件回归测试

## 验证

- Oracle XE 11g：从 `DBX_TEST.CODEX_7046_META` 打开“比较数据”，源端 6 张表正常显示，预填表保持选中
- `pnpm vitest run apps/desktop/src/components/diff/__tests__/DataCompareDialog.prefill.spec.ts`
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/components/diff/DataCompareDialog.vue apps/desktop/src/components/diff/__tests__/DataCompareDialog.prefill.spec.ts`

## 截图

![Oracle 数据比较源表正常加载](https://raw.githubusercontent.com/t8y2/dbx/pr-assets-7206/.github/pr-assets/7206/oracle-data-compare.png)

Fixes #7206