### PR TITLE
Fix: 补全 SQL Server 日期函数的 datepart 参数

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
@@ -26,6 +26,40 @@ describe("sqlCompletion keyword snippets", () => {
   });
 });
 
+describe("SQL Server datepart completion", () => {
+  it.each(["DATEADD", "DATEDIFF", "DATEPART", "DATENAME"])("suggests datepart values for the first %s argument", (functionName) => {
+    const sql = `SELECT ${functionName}(d`;
+    const items = buildSqlCompletionItems(sql, sql.length, {
+      tables: [],
+      columnsByTable: new Map(),
+      databaseType: "sqlserver",
+      dialect: "sqlserver",
+      keywordCase: "lower",
+    });
+
+    expect(items).toEqual(expect.arrayContaining([expect.objectContaining({ label: "day", type: "keyword" }), expect.objectContaining({ label: "dayofyear", type: "keyword" })]));
+    expect(items.some((item) => item.label === "deadlock_priority")).toBe(false);
+  });
+
+  it("auto-opens the datepart list immediately after the opening parenthesis", () => {
+    const sql = "SELECT DATEADD(";
+
+    expect(shouldAutoOpenSqlCompletion(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" })).toBe(true);
+  });
+
+  it("stops offering datepart values after the first argument", () => {
+    const sql = "SELECT DATEADD(day, d";
+
+    expect(getSqlCompletionContext(sql, sql.length, { databaseType: "sqlserver", dialect: "sqlserver" }).preferredValueKeywords).toBeUndefined();
+  });
+
+  it("does not apply SQL Server datepart values to other dialects", () => {
+    const sql = "SELECT DATEADD(d";
+
+    expect(getSqlCompletionContext(sql, sql.length, { databaseType: "mysql", dialect: "mysql" }).preferredValueKeywords).toBeUndefined();
+  });
+});
+
 describe("MySQL DESCRIBE table completion", () => {
   it.each(["DESC", "DESCRIBE"])("treats %s as a table-name context", (keyword) => {
     const sql = `${keyword} ord`;

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -1067,6 +1067,9 @@ const SQLSERVER_FUNCTION_SIGNATURES = new Map<string, string[]>([
   ["ISNULL", ["expression", "replacement"]],
 ]);
 
+const SQLSERVER_DATEPART_FUNCTIONS = new Set(["DATEADD", "DATEDIFF", "DATEPART", "DATENAME"]);
+const SQLSERVER_DATEPART_VALUES = ["year", "quarter", "month", "dayofyear", "day", "week", "weekday", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond", "tzoffset", "iso_week"];
+
 const MANTICORESEARCH_FUNCTION_SIGNATURES = new Map<string, string[]>([
   ["MATCH", ["query"]],
   ["BM25F", ["field=weight", "...fields"]],
@@ -1335,6 +1338,7 @@ export type SqlCompletionContextKind = "table" | "schema" | "catalog" | "routine
 export interface SqlCompletionContext {
   prefix: string;
   replacementRange?: { start: number; end: number };
+  preferredValueKeywords?: string[];
   qualifier?: string;
   qualifierParts?: string[];
   suggestTables: boolean;
@@ -1515,6 +1519,10 @@ class SqlCompletionProvider {
       return dedupeAndSort(buildMongoCompletionItemsFromContext({ mode: "root", prefix: context.prefix, from: 0 }).map(mongoCompletionItemToSqlCompletionItem));
     }
 
+    if (context.preferredValueKeywords?.length) {
+      return dedupeAndSort(buildPreferredKeywordItems(context.prefix, context.preferredValueKeywords, this.input.keywordCase));
+    }
+
     const preferReferencedColumns = hasMatchingReferencedColumnPrefix(context, this.input.columnsByTable);
     if (!pendingJoinKeyword && !context.exclusiveTableSuggestions && !context.exclusiveColumnSuggestions && !context.exclusiveRoutineSuggestions) {
       const snippets = this.databaseType === "manticoresearch" ? [...(this.input.snippets ?? DEFAULT_SQL_SNIPPETS), ...MANTICORESEARCH_SQL_SNIPPETS] : (this.input.snippets ?? DEFAULT_SQL_SNIPPETS);
@@ -1638,7 +1646,7 @@ export function shouldAutoOpenSqlCompletion(sql: string, cursor: number, options
   if (isAfterJoinModifierContext(sql.slice(0, cursor))) return true;
   if (/\bcall\s+(?:[A-Za-z_][\w$]*\.)?$/i.test(sql.slice(0, cursor))) return true;
   const context = getSqlCompletionContext(sql, cursor, options);
-  if (previousChar === "(" && context.insertTable) return true;
+  if (previousChar === "(" && (context.insertTable || context.preferredValueKeywords?.length)) return true;
   if (/[,;()[\]]/.test(previousChar)) return false;
   if (context.exclusiveTableSuggestions || context.exclusiveRoutineSuggestions || context.suggestTables) {
     return true;
@@ -2266,6 +2274,7 @@ export function getSqlCompletionContext(sql: string, cursor: number, options: Sq
 
   const statementKind = detectStatementKind(beforeCursor || fullStatement);
   const dataTypeContext = isCreateTableColumnTypeContext(beforeToken);
+  const preferredValueKeywords = sqlServerDatepartCompletionValues(beforeCursor, options.databaseType);
   const preferredKeywords = qualifier ? [] : preferredKeywordsForCompletion(beforeCursor, beforeToken, selectListColumnContext, exclusiveTableSuggestions, updateInfo, deleteInfo);
   const contextKind = detectCompletionContextKind({
     qualifier,
@@ -2284,6 +2293,7 @@ export function getSqlCompletionContext(sql: string, cursor: number, options: Sq
 
   return {
     prefix,
+    preferredValueKeywords,
     qualifier: insertInfo ? undefined : qualifier,
     qualifierParts: insertInfo ? undefined : qualifierParts,
     suggestTables: insertInfo ? false : afterTableTrigger,
@@ -2318,6 +2328,13 @@ export function getSqlCompletionContext(sql: string, cursor: number, options: Sq
     contextKind,
     dataTypeContext,
   };
+}
+
+function sqlServerDatepartCompletionValues(beforeCursor: string, databaseType?: DatabaseType): string[] | undefined {
+  if (databaseType !== "sqlserver") return undefined;
+  const call = findActiveFunctionCall(beforeCursor);
+  if (!call || call.activeGroup !== 0 || !SQLSERVER_DATEPART_FUNCTIONS.has(call.name.toUpperCase())) return undefined;
+  return countTopLevelCommas(call.groupText) === 0 ? SQLSERVER_DATEPART_VALUES : undefined;
 }
 
 function isCreateTableColumnTypeContext(beforeToken: string): boolean {


### PR DESCRIPTION
## 问题

SQL Server 的 `DATEADD`、`DATEDIFF` 等函数虽然能显示参数签名，但第一个 `datepart` 参数仍走普通 SQL 关键字补全。例如输入 `DATEADD(d` 时会出现 `DEADLOCK_PRIORITY`，而不是 `DAY`、`DAYOFYEAR`。

当前主线已确认 `UPDATE ... SET` 首字段和逗号后的后续字段均能根据真实表元数据补全，本 PR 处理 issue 中仍存在的 datepart 部分。

## 修复

- 识别 `DATEADD`、`DATEDIFF`、`DATEPART`、`DATENAME` 的首参数上下文
- 首参数只显示 SQL Server 支持的 datepart 候选
- 输入左括号后即可自动打开候选列表
- 进入第二个参数后恢复普通补全
- 不影响其他数据库类型

## 验证

- SQL Server `dbx_sqlserver_demo`：`SELECT DATEADD(d` 只显示 `DAY`、`DAYOFYEAR`，不再显示普通 `D*` 关键字
- SQL Server 真实表 `dbo.codex_pr5667_nullability`：`UPDATE` 首字段及逗号后的第二字段补全正常
- `pnpm vitest run apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts apps/desktop/src/lib/__tests__/sql/sqlCompletion.signature.spec.ts`（103 个测试通过）
- `pnpm typecheck`
- 格式检查通过

## 截图

![SQL Server datepart 补全](https://raw.githubusercontent.com/t8y2/dbx/pr-assets-7240/.github/pr-assets/7240/sqlserver-datepart-completion.png)

Fixes #7240