### PR TITLE
feat(sidebar): 展开表分组时显示估算行数 (MySQL/PostgreSQL)

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -80,7 +80,7 @@ import { SidebarDangerConfirmDialog, SidebarDdlViewDialog, SidebarObjectSourceDi
 import { sortConnectionListForDisplay } from "@/lib/sidebar/connectionListSort";
 import { sidebarDisplayTableName } from "@/lib/sidebar/sidebarTableNameDisplay";
 import { alignedSidebarCommentLabelWidths, isSidebarCommentAlignableNode, sidebarTreeNaturalContentWidth, sidebarTreeNodeComment, usesFullWidthTreeLabel } from "@/lib/sidebar/sidebarTreeItemLayout";
-import { formatSidebarObjectStorage, sidebarTableStorageScopes, supportsSidebarTableStorage } from "@/lib/sidebar/sidebarDatabaseStorage";
+import { formatSidebarObjectRowCount, formatSidebarObjectStorage, sidebarTableStorageScopes, supportsSidebarRowCount, supportsSidebarTableStorage } from "@/lib/sidebar/sidebarDatabaseStorage";
 import { sidebarScrollbarGeometry as calculateSidebarScrollbarGeometry } from "@/lib/sidebar/sidebarScrollbar";
 import { createSidebarLayoutMonitor, type SidebarExpandedConnectionInfo } from "@/lib/sidebar/sidebarLayoutMonitor";
 import { disconnectSidebarConnections } from "@/lib/sidebar/sidebarConnectionDisconnect";
@@ -871,7 +871,9 @@ function scheduleSidebarCommentLabelMeasure() {
 function sidebarNodeHasTrailingMetadata(node: TreeNode): boolean {
   const mode = settingsStore.editorSettings.sidebarObjectInfoMode;
   if (mode.startsWith("comment-") && sidebarTreeNodeComment(node, settingsStore.editorSettings.sidebarShowConnectionNotes)) return true;
-  return mode === "size" && sidebarStorageDisplayTypes.has(node.type) && !!formatSidebarObjectStorage(node.sizeBytes);
+  if (mode === "size" && sidebarStorageDisplayTypes.has(node.type) && !!formatSidebarObjectStorage(node.sizeBytes)) return true;
+  // Row count (#3305) is independent of sidebarObjectInfoMode — mirrors TreeItem.vue's formattedTableRowCount().
+  return node.type === "table" && !!node.connectionId && supportsSidebarRowCount(store.getConfig(node.connectionId)) && !!formatSidebarObjectRowCount(node.rowCount);
 }
 
 const sidebarTreeNaturalWidthItems = computed(() =>
@@ -930,8 +932,11 @@ watch([sidebarTreeNaturalWidthItems, () => settingsStore.editorSettings.uiFontFa
 });
 
 const visibleSidebarTableStorageScopes = computed(() => {
-  if (settingsStore.editorSettings.sidebarObjectInfoMode !== "size") return [];
-  return sidebarTableStorageScopes(flatNodes.value.map(({ node }) => node)).filter((scope) => supportsSidebarTableStorage(store.getConfig(scope.connectionId)));
+  const wantsSize = settingsStore.editorSettings.sidebarObjectInfoMode === "size";
+  return sidebarTableStorageScopes(flatNodes.value.map(({ node }) => node)).filter((scope) => {
+    const config = store.getConfig(scope.connectionId);
+    return (wantsSize && supportsSidebarTableStorage(config)) || supportsSidebarRowCount(config);
+  });
 });
 
 watch(

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -55,7 +55,7 @@ import type { ColumnInfo, ConnectionConfig, CustomTypeTreeMemberMeta, DatabaseTy
 import { alignedCommentLeadingWidth, canTreeNodePin, canTreeNodeShowExpander, sidebarTreeNodeComment, trailingCommentAvailableWidth, trailingCommentGapPx, treeItemPaddingLeft, treeLabelWidthClass, usesFullWidthTreeLabel } from "@/lib/sidebar/sidebarTreeItemLayout";
 import { clearActiveTableReferencePayload, createTableReferencePayload, createTableReferenceDropEvent, setActiveTableReferencePayload, type QueryEditorTableReferencePayload } from "@/lib/editor/queryEditorTableDrop";
 import { AI_ASSISTANT_TABLE_DROP_ROOT_SELECTOR } from "@/lib/ai/aiTableReferenceDrop";
-import { formatSidebarObjectStorage } from "@/lib/sidebar/sidebarDatabaseStorage";
+import { formatSidebarObjectRowCount, formatSidebarObjectStorage, supportsSidebarRowCount } from "@/lib/sidebar/sidebarDatabaseStorage";
 import { dataTabOpenModeFromTreeClick } from "@/lib/sidebar/dataTabOpenPolicy";
 import { effectiveDatabaseTypeForConnection } from "@/lib/database/jdbcDialect";
 import { connectionDisplayUrlScheme } from "@/lib/connection/connectionPresentation";
@@ -815,6 +815,18 @@ function formattedObjectStorage(): string {
   return formatSidebarObjectStorage(activeNode.value.sizeBytes);
 }
 
+function formattedTableRowCount(): string {
+  if (activeNode.value.type !== "table" || !activeNode.value.connectionId) return "";
+  if (!supportsSidebarRowCount(connectionStore.getConfig(activeNode.value.connectionId))) return "";
+  return formatSidebarObjectRowCount(activeNode.value.rowCount);
+}
+
+// Combines the "对象大小" and row-count (#3305) trailing badges into one slot so they
+// never fight over the same ml-auto position; row count is independent of sidebarObjectInfoMode.
+function formattedTrailingObjectStats(): string {
+  return [formattedObjectStorage(), formattedTableRowCount()].filter(Boolean).join(" · ");
+}
+
 // 连接节点不参与 aligned 对齐：顶层连接各自独立，按同层最大 label 宽对齐只会让短连接名
 // 后留下一大段空白。无论全局是 aligned 还是 inline，连接节点的 comment 都紧跟 label。
 const alignedCommentLabelWidth = computed(() => (settingsStore.editorSettings.sidebarObjectInfoMode === "comment-aligned" && activeNode.value.type !== "connection" ? props.commentLabelWidth : undefined));
@@ -825,7 +837,7 @@ function alignedCommentLeadingStyle(): { width: string } | undefined {
 }
 
 function hasTrailingMetadata(): boolean {
-  return !!trailingComment.value || !!formattedObjectStorage();
+  return !!trailingComment.value || !!formattedTrailingObjectStats();
 }
 
 const usesFullWidthLabel = computed(() => usesFullWidthTreeLabel(activeNode.value.type, settingsStore.editorSettings.sidebarAllowHorizontalScroll, hasTrailingMetadata()));
@@ -1431,7 +1443,7 @@ function onKeydown(event: KeyboardEvent) {
           <CircleX v-if="node.valid === false" data-invalid-object-indicator="true" class="pointer-events-none absolute -right-1 -bottom-1 h-2.5 w-2.5 rounded-full bg-background text-destructive stroke-[3]" aria-hidden="true" />
         </span>
         <div ref="trailingCommentLayoutRef" :class="hasTrailingMetadata() ? 'flex flex-1 min-w-0 items-center' : 'contents'">
-          <div ref="trailingCommentLeadingRef" :class="trailingComment ? 'flex max-w-full min-w-0 shrink-0 items-center gap-2' : formattedObjectStorage() ? 'flex min-w-0 flex-1 items-center gap-2' : 'contents'" :style="alignedCommentLeadingStyle()">
+          <div ref="trailingCommentLeadingRef" :class="trailingComment ? 'flex max-w-full min-w-0 shrink-0 items-center gap-2' : formattedTrailingObjectStats() ? 'flex min-w-0 flex-1 items-center gap-2' : 'contents'" :style="alignedCommentLeadingStyle()">
             <input
               v-if="isRenamingGroup || isRenamingSavedSql || isRenamingConnection"
               ref="renameInputRef"
@@ -1501,7 +1513,7 @@ function onKeydown(event: KeyboardEvent) {
         <span v-if="databaseOpenVisual.showsIndicator" class="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
         <Badge v-if="isConnectionReadonly" variant="secondary" class="h-4 px-1.5 text-[10px] gap-0.5"> <Lock class="w-2.5 h-2.5" />{{ t("connection.readOnlyBadge") }} </Badge>
         <ConnectionErrorIndicator v-if="node.type === 'connection'" :connection-id="node.connectionId" trigger-class="h-4 w-4" />
-        <span v-if="formattedObjectStorage()" class="ml-auto shrink-0 text-right text-xs tabular-nums text-muted-foreground">{{ formattedObjectStorage() }}</span>
+        <span v-if="formattedTrailingObjectStats()" class="ml-auto shrink-0 text-right text-xs tabular-nums text-muted-foreground" :title="formattedTableRowCount() ? t('objects.statisticsHint') : undefined">{{ formattedTrailingObjectStats() }}</span>
         <button
           v-if="isConnecting"
           type="button"

--- a/apps/desktop/src/lib/__tests__/sidebar/sidebarDatabaseStorage.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/sidebarDatabaseStorage.spec.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { applySidebarDatabaseStorage, applySidebarTableStorage, formatSidebarObjectStorage, sidebarDatabaseNames, sidebarTableStorageScopes, supportsSidebarDatabaseStorage, supportsSidebarTableStorage } from "@/lib/sidebar/sidebarDatabaseStorage";
+import {
+  applySidebarDatabaseStorage,
+  applySidebarTableStorage,
+  formatSidebarObjectRowCount,
+  formatSidebarObjectStorage,
+  sidebarDatabaseNames,
+  sidebarTableStorageScopes,
+  supportsSidebarDatabaseStorage,
+  supportsSidebarRowCount,
+  supportsSidebarTableStorage,
+} from "@/lib/sidebar/sidebarDatabaseStorage";
 import type { ConnectionConfig, TreeNode } from "@/types/database";
 
 function config(dbType: ConnectionConfig["db_type"]): ConnectionConfig {
@@ -61,5 +71,29 @@ describe("sidebar database storage", () => {
     const table: TreeNode = { id: "products", label: "products", type: "table", connectionId: "connection", database: "shop" };
     expect(applySidebarTableStorage([table], { connectionId: "connection", database: "shop", schema: "" }, [{ name: "products", schema: "shop", total_bytes: 49152 }])).toBe(true);
     expect(table.sizeBytes).toBe(49152);
+  });
+
+  it("gates row count to the v1 engine allowlist (#3305), independent of the size allowlist", () => {
+    expect(supportsSidebarRowCount(config("mysql"))).toBe(true);
+    expect(supportsSidebarRowCount(config("postgres"))).toBe(true);
+    expect(supportsSidebarRowCount({ ...config("postgres"), driver_profile: "cockroachdb" })).toBe(false);
+    for (const dbType of ["sqlserver", "oracle", "clickhouse", "dameng", "gaussdb", "kingbase", "gbase", "sqlite", "mongo", "jdbc"] as const) {
+      expect(supportsSidebarRowCount(config(dbType))).toBe(false);
+    }
+  });
+
+  it("applies estimated_rows alongside total_bytes from the same statistics payload", () => {
+    const table: TreeNode = { id: "orders", label: "orders", type: "table", connectionId: "connection", database: "shop" };
+    expect(applySidebarTableStorage([table], { connectionId: "connection", database: "shop", schema: "" }, [{ name: "orders", schema: "shop", total_bytes: 4096, estimated_rows: 107 }])).toBe(true);
+    expect(table.sizeBytes).toBe(4096);
+    expect(table.rowCount).toBe(107);
+  });
+
+  it("keeps unavailable row counts blank and formats known counts with thousands separators", () => {
+    expect(formatSidebarObjectRowCount(null)).toBe("");
+    expect(formatSidebarObjectRowCount(undefined)).toBe("");
+    expect(formatSidebarObjectRowCount(0)).toBe("(0)");
+    expect(formatSidebarObjectRowCount(107)).toBe("(107)");
+    expect(formatSidebarObjectRowCount(1234567)).toBe(`(${new Intl.NumberFormat().format(1234567)})`);
   });
 });

--- a/apps/desktop/src/lib/sidebar/sidebarDatabaseStorage.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarDatabaseStorage.ts
@@ -1,6 +1,12 @@
+import { formatObjectBrowserCount } from "@/lib/table/objectBrowserRows";
 import type { ConnectionConfig, DatabaseStorageInfo, ObjectStatistics, TreeNode } from "@/types/database";
 
 const sidebarTableStorageTypes = new Set<ConnectionConfig["db_type"]>(["mysql", "postgres", "sqlserver", "oracle", "clickhouse", "dameng", "gaussdb", "kingbase", "gbase"]);
+
+// Row-count-in-sidebar (#3305) v1: intentionally a narrower, separate allowlist from
+// sidebarTableStorageTypes so extending it doesn't change behavior for other engines.
+// MongoDB etc. need new backend statistics support before they can be added here.
+const sidebarRowCountTypes = new Set<ConnectionConfig["db_type"]>(["mysql", "postgres"]);
 
 export function supportsSidebarDatabaseStorage(connection: ConnectionConfig | undefined): boolean {
   return connection?.db_type === "postgres" && connection.driver_profile !== "cockroachdb";
@@ -9,6 +15,11 @@ export function supportsSidebarDatabaseStorage(connection: ConnectionConfig | un
 export function supportsSidebarTableStorage(connection: ConnectionConfig | undefined): boolean {
   if (!connection || !sidebarTableStorageTypes.has(connection.db_type)) return false;
   if (connection.db_type === "gbase" && connection.driver_profile === "gbase8s") return false;
+  return connection.db_type !== "postgres" || connection.driver_profile !== "cockroachdb";
+}
+
+export function supportsSidebarRowCount(connection: ConnectionConfig | undefined): boolean {
+  if (!connection || !sidebarRowCountTypes.has(connection.db_type)) return false;
   return connection.db_type !== "postgres" || connection.driver_profile !== "cockroachdb";
 }
 
@@ -49,14 +60,18 @@ export function sidebarTableStorageScopes(nodes: readonly TreeNode[]): SidebarTa
 
 export function applySidebarTableStorage(nodes: readonly TreeNode[] | undefined, scope: SidebarTableStorageScope, statistics: readonly ObjectStatistics[]): boolean {
   if (!nodes?.length || !statistics.length) return false;
-  const sizeByName = new Map(statistics.filter((item) => !scope.schema || !item.schema || item.schema === scope.schema).map((item) => [item.name, item.total_bytes ?? null] as const));
+  const statByName = new Map(statistics.filter((item) => !scope.schema || !item.schema || item.schema === scope.schema).map((item) => [item.name, { sizeBytes: item.total_bytes ?? null, rowCount: item.estimated_rows ?? null }] as const));
   let changed = false;
   const visit = (items: readonly TreeNode[]) => {
     for (const node of items) {
-      if ((node.type === "table" || node.type === "materialized_view") && node.connectionId === scope.connectionId && node.database === scope.database && (node.schema || "") === scope.schema && sizeByName.has(node.label)) {
-        const sizeBytes = sizeByName.get(node.label) ?? null;
-        if (node.sizeBytes !== sizeBytes) {
-          node.sizeBytes = sizeBytes;
+      if ((node.type === "table" || node.type === "materialized_view") && node.connectionId === scope.connectionId && node.database === scope.database && (node.schema || "") === scope.schema && statByName.has(node.label)) {
+        const stat = statByName.get(node.label)!;
+        if (node.sizeBytes !== stat.sizeBytes) {
+          node.sizeBytes = stat.sizeBytes;
+          changed = true;
+        }
+        if (node.rowCount !== stat.rowCount) {
+          node.rowCount = stat.rowCount;
           changed = true;
         }
       }
@@ -81,4 +96,9 @@ export function formatSidebarObjectStorage(value: number | null | undefined): st
   const rounded = size.toFixed(fractionDigits);
   const displaySize = rounded.includes(".") ? rounded.replace(/0+$/, "").replace(/\.$/, "") : rounded;
   return `${displaySize} ${units[unitIndex]}`;
+}
+
+export function formatSidebarObjectRowCount(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return "";
+  return `(${formatObjectBrowserCount(value)})`;
 }

--- a/apps/desktop/src/stores/__tests__/connectionStore.sidebarTableStorage.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.sidebarTableStorage.spec.ts
@@ -186,4 +186,59 @@ describe("connectionStore sidebar table storage", () => {
     expect(listDatabaseStorage).toHaveBeenCalledTimes(2);
     expect(store.treeNodes[0]?.children?.[0]?.sizeBytes).toBe(16384);
   });
+
+  it("fetches row counts for MySQL/PostgreSQL (#3305 v1) even when sidebarObjectInfoMode is not 'size'", async () => {
+    const listObjectStatistics = vi.fn().mockResolvedValue([{ name: "ORDERS", schema: "public", total_bytes: 4096, estimated_rows: 107 }]);
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      listInstalledAgents: vi.fn().mockResolvedValue([]),
+      listObjectStatistics,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const store = useConnectionStore();
+    useSettingsStore().editorSettings.sidebarObjectInfoMode = "comment-inline";
+    const connection = { id: "pg-1", name: "PostgreSQL", db_type: "postgres", host: "127.0.0.1", port: 5432, username: "postgres", password: "" } as ConnectionConfig;
+    const tableNode: TreeNode = { id: "pg-1:app:public:ORDERS", label: "ORDERS", type: "table", connectionId: connection.id, database: "app", schema: "public" };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [{ id: connection.id, label: connection.name, type: "connection", connectionId: connection.id, children: [tableNode] }];
+
+    await store.loadSidebarTableStorage({ connectionId: connection.id, database: "app", schema: "public" });
+
+    expect(listObjectStatistics).toHaveBeenCalledTimes(1);
+    expect(tableNode.rowCount).toBe(107);
+    expect(tableNode.sizeBytes).toBe(4096);
+  });
+
+  it("does not fetch anything for engines outside the row-count allowlist when sidebarObjectInfoMode is not 'size'", async () => {
+    const listObjectStatistics = vi.fn().mockResolvedValue([{ name: "USERS", schema: "APP", total_bytes: 4096, estimated_rows: 107 }]);
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      listInstalledAgents: vi.fn().mockResolvedValue([]),
+      listObjectStatistics,
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const { useSettingsStore } = await import("@/stores/settingsStore");
+    const store = useConnectionStore();
+    useSettingsStore().editorSettings.sidebarObjectInfoMode = "comment-inline";
+    const connection = { id: "oracle-1", name: "Oracle", db_type: "oracle", host: "127.0.0.1", port: 1521, username: "APP", password: "", database: "ORCL" } as ConnectionConfig;
+    const tableNode: TreeNode = { id: "oracle-1:ORCL:APP:USERS", label: "USERS", type: "table", connectionId: connection.id, database: connection.database, schema: "APP" };
+    store.connections = [connection];
+    store.connectedIds.add(connection.id);
+    store.treeNodes = [{ id: connection.id, label: connection.name, type: "connection", connectionId: connection.id, children: [tableNode] }];
+
+    await store.loadSidebarTableStorage({ connectionId: connection.id, database: connection.database, schema: "APP" });
+
+    expect(listObjectStatistics).not.toHaveBeenCalled();
+    expect(tableNode.rowCount).toBeUndefined();
+  });
 });

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -165,7 +165,7 @@ import { TreeNodeLoadRegistry, type TreeNodeLoadHandle } from "@/lib/metadata/tr
 import i18n from "@/i18n";
 import type { MqAdminConfig } from "@/types/mq";
 import { RABBITMQ_MQ_TENANT, resolveMqSystemKindFromConnection } from "@/lib/mq/mqConsoleDefaults";
-import { applySidebarDatabaseStorage, applySidebarTableStorage, sidebarDatabaseNames, supportsSidebarDatabaseStorage, supportsSidebarTableStorage, type SidebarTableStorageScope } from "@/lib/sidebar/sidebarDatabaseStorage";
+import { applySidebarDatabaseStorage, applySidebarTableStorage, sidebarDatabaseNames, supportsSidebarDatabaseStorage, supportsSidebarRowCount, supportsSidebarTableStorage, type SidebarTableStorageScope } from "@/lib/sidebar/sidebarDatabaseStorage";
 import { connectionHasConfiguredSidebarVisibleFilter, nacosVisibleNamespaceSummary, sidebarVisibleFilterSummary } from "@/lib/sidebar/sidebarVisibleFilterSummary";
 import { connectionCanConfigureSidebarVisibleDatabases } from "@/lib/sidebar/sidebarVisibleFilterMenu";
 import { isTdengineStableTableType } from "@/lib/table/tableEditing";
@@ -4068,8 +4068,10 @@ export const useConnectionStore = defineStore("connection", () => {
   }
 
   async function loadSidebarTableStorage(scope: SidebarTableStorageScope, options?: { force?: boolean }): Promise<void> {
-    if (settingsStore.editorSettings.sidebarObjectInfoMode !== "size" || !connectedIds.value.has(scope.connectionId)) return;
-    if (!supportsSidebarTableStorage(getConfig(scope.connectionId))) return;
+    if (!connectedIds.value.has(scope.connectionId)) return;
+    const config = getConfig(scope.connectionId);
+    const wantsSize = settingsStore.editorSettings.sidebarObjectInfoMode === "size" && supportsSidebarTableStorage(config);
+    if (!wantsSize && !supportsSidebarRowCount(config)) return;
     const requestKey = sidebarTableStorageRequestKey(scope);
     const cacheScope = sidebarTableStorageCacheScope(scope);
     const cached = sidebarTableStorageCache.get(cacheScope);

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -980,6 +980,8 @@ export interface TreeNode {
   comment?: string | null;
   valid?: boolean | null;
   sizeBytes?: number | null;
+  /** Estimated row count (from database statistics, not a live COUNT(*)); populated for a narrower engine allowlist than sizeBytes. */
+  rowCount?: number | null;
   objectCount?: number;
   loadedKeyCount?: number;
   totalKeyCount?: number;


### PR DESCRIPTION
## 做了什么

展开侧边栏某个数据库下的"表"分组时，自动在每张表名旁显示估算行数，不用再手写 `SELECT COUNT(*)`。这次先支持 MySQL / PostgreSQL，其他引擎作为后续跟进（详见下方"后续"）。

## 实现方式

复用了侧边栏"对象大小"功能已有的统计接口 `list_object_statistics`——其 `ObjectStatistics` 本身就同时返回 `estimated_rows` 和 `total_bytes`，之前前端只用了后者。这次改动**后端零改动**，纯粹是把已经取到的字段接上：

- `sidebarDatabaseStorage.ts` 新增 `supportsSidebarRowCount` 白名单（v1 仅 `mysql`/`postgres`），与现有 size 白名单独立，不影响其他引擎行为
- `applySidebarTableStorage` 同时写入 `rowCount` 与 `sizeBytes`
- 抓取触发条件从"仅 size 模式才抓取"放宽为"size 模式 或 属于行数白名单"（`ConnectionTree.vue` 的可见 scope 计算 + `connectionStore.ts` 的 `loadSidebarTableStorage`），展开即抓取一次，复用已有缓存/去重逻辑，折叠再展开不会重复请求
- `TreeItem.vue` 合并渲染大小/行数徽标（用 `·` 分隔），互不冲突；行数用括号包裹（如 `(1,234)`），hover 提示"估算值，不执行 COUNT(*)"
- 同步修复 `ConnectionTree.vue` 的 `sidebarNodeHasTrailingMetadata()` 遗漏行数徽标判断的问题（会影响开启"允许侧边栏横向滚动"时的宽度计算，导致行数徽标被裁切）

## 测试

- `sidebarDatabaseStorage.spec.ts` + `connectionStore.sidebarTableStorage.spec.ts` 新增用例�covers 白名单判断、`applySidebarTableStorage` 同时写入两个字段、格式化边界值、非 size 模式下仍会为白名单引擎抓取（且非白名单引擎不受影响）
- 侧边栏相关全量测试 150/150 通过；`vue-tsc` 类型检查、`oxlint` 干净

真实验证：共享测试 MySQL 8.4.6（`114.66.55.245:20084`）与 PostgreSQL 16.14（`114.66.55.245:20033`），各建一张已知行数的测试表，独立 dev 后端+前端+真实浏览器验证：表名旁正确显示估算行数（与插入行数完全一致）、悬浮提示正常、折叠再展开只发一次请求（不会重复计算）。

## 后续（不在本次范围内）

- MongoDB 等引擎的 `list_object_statistics` 目前没有实现，需要新写后端统计逻辑（如 `estimatedDocumentCount`/`collStats`）
- 是否需要在设置里做成可关闭的开关，视这次上线后的反馈再评估

Fixes #3305