### PR TITLE
fix(sql-library): 修正 SQL 文件删除弹窗确认按钮文案

### DIFF
--- a/apps/desktop/src/components/layout/SqlLibraryPanel.vue
+++ b/apps/desktop/src/components/layout/SqlLibraryPanel.vue
@@ -1417,7 +1417,7 @@ function showDropInside(targetId: string) {
         </DialogHeader>
         <DialogFooter>
           <Button variant="outline" size="sm" @click="showDeleteConfirm = false">{{ t("dangerDialog.cancel") }}</Button>
-          <Button variant="destructive" size="sm" @click="executeDelete">{{ t("dangerDialog.confirm") }}</Button>
+          <Button variant="destructive" size="sm" @click="executeDelete">{{ t("dangerDialog.deleteConfirm") }}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -1433,7 +1433,7 @@ function showDropInside(targetId: string) {
         </DialogHeader>
         <DialogFooter>
           <Button variant="outline" size="sm" @click="showBatchDeleteConfirm = false">{{ t("dangerDialog.cancel") }}</Button>
-          <Button variant="destructive" size="sm" @click="executeBatchDelete">{{ t("dangerDialog.confirm") }}</Button>
+          <Button variant="destructive" size="sm" @click="executeBatchDelete">{{ t("dangerDialog.deleteConfirm") }}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## 变更说明

修复 SQL 库侧边栏中右键删除 SQL 文件/文件夹时，确认弹窗的确认按钮文案错误的问题。

该弹窗此前复用了 `dangerDialog.confirm`（"执行" / "Execute"），这个文案是给"危险 SQL 执行"提示用的，用在删除弹窗上会显示为"执行"，语义不符。现改为使用 `dangerDialog.deleteConfirm`（"确认删除" / "Confirm Delete"）。单个删除和批量删除弹窗均已修正。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

改动为纯文案（i18n key）修正：`apps/desktop/src/components/layout/SqlLibraryPanel.vue` 删除确认弹窗按钮由 `t("dangerDialog.confirm")`（"执行"）改为 `t("dangerDialog.deleteConfirm")`（"确认删除"）。

## 关联 Issue

Close #7339