### PR TITLE
perf(oracle): 避免慢索引元数据阻塞首次查询

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
@@ -157,7 +157,7 @@ describe("queryStore hidden primary key editing", () => {
     expect(tab.queryAnalysis).toBeDefined();
     expect(tab.queryAnalysis?.allowInsert).toBe(false);
     expect(tab.queryEditabilityReason).toBeUndefined();
-  });
+  }, 10_000);
 
   it("keeps MySQL expression columns read-only without disabling direct columns", async () => {
     const sql = "SELECT id, status, extra->>'$.mode' mode, extra->>'$.template' tmpl FROM items";

--- a/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts
@@ -801,6 +801,68 @@ describe("queryStore hidden primary key editing", () => {
     await execution;
   });
 
+  it("starts an Oracle star query when index metadata exceeds the preflight budget", async () => {
+    vi.useFakeTimers();
+    const columnsGate = deferred<Awaited<ReturnType<typeof getColumns>>>();
+    const indexesGate = deferred<Awaited<ReturnType<typeof listIndexes>>>();
+    try {
+      getConnectionConfig.mockReturnValue({ id: "oracle-1", name: "Oracle", db_type: "oracle", database: "ORCL", query_timeout_secs: 30 });
+      getColumns.mockReturnValue(columnsGate.promise);
+      listIndexes.mockReturnValue(indexesGate.promise);
+      analyzeEditableQueryEditability.mockImplementation(async () => ({
+        editable: true,
+        analysis: {
+          schema: "APP",
+          tableName: "SLOW_METADATA_TABLE",
+          selectStar: true,
+          columns: [],
+        },
+      }));
+      executeMulti.mockResolvedValue([
+        {
+          columns: ["ID", "NAME"],
+          rows: [[1, "Alice"]],
+          affected_rows: 0,
+          execution_time_ms: 12,
+        },
+      ]);
+
+      const { useQueryStore } = await import("@/stores/queryStore");
+      const store = useQueryStore();
+      const tabId = store.createTab("oracle-1", "ORCL", "Query");
+      store.setAutoCommit(tabId, true);
+
+      const execution = store.executeTabSql(tabId, "SELECT * FROM APP.SLOW_METADATA_TABLE");
+      await vi.waitFor(() => expect(listIndexes).toHaveBeenCalledOnce());
+      expect(executeMulti).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(executeMulti).toHaveBeenCalledOnce());
+      expect(executeMulti).toHaveBeenCalledWith("oracle-1", "ORCL", "SELECT * FROM APP.SLOW_METADATA_TABLE", undefined, expect.any(String), expect.objectContaining({ timeoutSecs: 30 }));
+      await execution;
+
+      indexesGate.resolve([{ name: "PK_SLOW_METADATA_TABLE", columns: ["ID"], is_unique: true, is_primary: true }]);
+      columnsGate.resolve([
+        { name: "ID", data_type: "NUMBER", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "NAME", data_type: "VARCHAR2(100)", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ]);
+      await vi.waitFor(() => expect(store.tabs.find((item) => item.id === tabId)?.tableMeta?.primaryKeys).toEqual(["ID"]));
+
+      await store.executeTabSql(tabId, "SELECT * FROM APP.SLOW_METADATA_TABLE");
+      expect(executeMulti).toHaveBeenCalledTimes(2);
+      expect(listIndexes).toHaveBeenCalledOnce();
+      expect(getColumns).toHaveBeenCalledOnce();
+    } finally {
+      indexesGate.resolve([{ name: "PK_SLOW_METADATA_TABLE", columns: ["ID"], is_unique: true, is_primary: true }]);
+      columnsGate.resolve([
+        { name: "ID", data_type: "NUMBER", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+        { name: "NAME", data_type: "VARCHAR2(100)", is_nullable: true, column_default: null, is_primary_key: false, extra: null },
+      ]);
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for first-run Oracle XMLTYPE metadata before manual transaction execution", async () => {
     const columnsGate = deferred<Awaited<ReturnType<typeof getColumns>>>();
     getConnectionConfig.mockReturnValue({ id: "oracle-1", name: "Oracle", db_type: "oracle", database: "ORCL", query_timeout_secs: 30 });

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -104,6 +104,8 @@ const QUERY_RESULT_EXPORT_UNSUPPORTED_ERROR = "Streaming export is unsupported f
 const BACKGROUND_CLIENT_SESSION_SUFFIXES = ["count", "explain", "export"] as const;
 const CANCEL_QUERY_TIMEOUT_MS = 10_000;
 const CANCEL_ACK_SETTLE_TIMEOUT_MS = 2_000;
+const ORACLE_QUERY_METADATA_PREFLIGHT_BUDGET_MS = 1_000;
+const ORACLE_QUERY_METADATA_PREFLIGHT_TIMEOUT = Symbol("oracle-query-metadata-preflight-timeout");
 const SAVED_SQL_EDITOR_POSITION_PERSIST_DELAY_MS = 500;
 type CloseConfirmContext = "tab" | "batch" | "app";
 
@@ -522,6 +524,20 @@ async function withCancelQueryTimeout<T>(promise: Promise<T>): Promise<T> {
       promise,
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => reject(new Error("Cancel request timed out after 10s.")), CANCEL_QUERY_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function waitForOracleQueryMetadataPreflight<T>(promise: Promise<T>): Promise<T | typeof ORACLE_QUERY_METADATA_PREFLIGHT_TIMEOUT> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof ORACLE_QUERY_METADATA_PREFLIGHT_TIMEOUT>((resolve) => {
+        timer = setTimeout(() => resolve(ORACLE_QUERY_METADATA_PREFLIGHT_TIMEOUT), ORACLE_QUERY_METADATA_PREFLIGHT_BUDGET_MS);
       }),
     ]);
   } finally {
@@ -4051,9 +4067,19 @@ export const useQueryStore = defineStore("query", () => {
           traceLogger: (event) => queryExecutionLog("debug", "metadata:table-trace", { sourceTraceId: traceId, ...event }),
         });
         void fullMetadataPromise.catch((error) => queryExecutionLog("warn", "metadata:table-prefetch:failed", { traceId, error, elapsed: elapsed() }));
-        const indexes = await loadTableIndexes(target.request);
-        if (primaryKeyIndex(indexes) && projectsAllColumnsForSource(target.analysis, target.source.key) && tab.autoCommit !== false) {
-          return unchanged;
+        const wholeSourceAutoCommit = projectsAllColumnsForSource(target.analysis, target.source.key) && tab.autoCommit !== false;
+        if (wholeSourceAutoCommit) {
+          const indexes = await waitForOracleQueryMetadataPreflight(loadTableIndexes(target.request));
+          if (indexes === ORACLE_QUERY_METADATA_PREFLIGHT_TIMEOUT) {
+            queryExecutionLog("info", "metadata:preflight:timeout", {
+              traceId,
+              table: target.request.tableName,
+              budgetMs: ORACLE_QUERY_METADATA_PREFLIGHT_BUDGET_MS,
+              elapsed: elapsed(),
+            });
+            return unchanged;
+          }
+          if (primaryKeyIndex(indexes)) return unchanged;
         }
         loaded = loadedEditableSourceFromMetadata(target, (await fullMetadataPromise).metadata);
       }


### PR DESCRIPTION
## 问题

用户日志显示，Oracle 普通查询的主要耗时发生在前端查询预检，而非 SQL 执行：

- `X27_USER` 首次查询约 18.4 秒，其中 `listIndexes` 约 18.0 秒，`executeMulti` 约 248ms
- `X27_ORG` 首次查询约 10.3 秒，其中 `listIndexes` 约 9.97 秒
- 同表第二次查询约 315ms，说明元数据缓存命中后 SQL 本身并不慢

冷缓存下，DBX 为支持 Oracle 无主键结果通过 ROWID 编辑，会在执行 `SELECT *` 前同步等待索引元数据。索引查询慢时会阻塞首次查询。

## 调整

- Oracle 自动提交、单表全列投影的冷缓存查询，索引元数据预检最多等待 1 秒
- 1 秒内返回时保留原有行为，包括无主键 ROWID 编辑和 LOB 延迟预览
- 超过 1 秒时立即执行原 SQL，完整元数据请求继续在后台完成并写入缓存
- 手动事务和非全列投影继续同步等待元数据，避免改变其执行语义
- 增加 `metadata:preflight:timeout` 日志，记录等待预算和目标表

取舍：元数据超过 1 秒且表无主键时，首次结果可能暂时无法启用 ROWID 编辑或 LOB 延迟预览；后台缓存完成后再次执行即可恢复。

## 验证

- Oracle XE 11g 人为延迟 `/api/schema/indexes` 12 秒：`execute-multi` 在索引请求后 1007ms 启动，没有等待 12 秒；查询响应约 1.1 秒
- 后台元数据完成后立即再次执行：查询 57ms 返回，查询前未再次等待 columns/indexes
- Oracle XE 11g 无延迟实际表查询通过，结果列和编辑状态正常
- Oracle 19c `SELECT * FROM DUAL` 实测返回 1 行，结果列正常
- `pnpm vitest run apps/desktop/src/stores/__tests__/queryStore.hiddenPrimaryKey.spec.ts`：51 项通过
- `pnpm typecheck`：通过
- `pnpm check`：format、lint、typecheck、test 全部通过