### PR TITLE
fix(backup): match db.schema.table exclude patterns when database equals schema

### DIFF
--- a/apps/desktop/src/lib/__tests__/backup/scheduledDatabaseBackup.spec.ts
+++ b/apps/desktop/src/lib/__tests__/backup/scheduledDatabaseBackup.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { databaseBackupRunsToPrune, normalizeDatabaseBackupRun, type DatabaseBackupRun } from "../../backup/scheduledDatabaseBackup";
+import { databaseBackupRunsToPrune, databaseBackupTableMatchesPattern, normalizeDatabaseBackupRun, resolveScheduledDatabaseBackupTableScope, type DatabaseBackupRun } from "../../backup/scheduledDatabaseBackup";
 
 const startedAt = "2026-08-12T00:00:00.000Z";
 
@@ -44,5 +44,25 @@ describe("database backup run persistence", () => {
 
     const normalizedRuns = [...scheduledRuns, oneShotRun].map((value) => normalizeDatabaseBackupRun(value)!).filter((value): value is DatabaseBackupRun => !!value);
     expect(databaseBackupRunsToPrune(normalizedRuns, "schedule-1", 1).map((value) => value.id)).toEqual(["scheduled-old"]);
+  });
+});
+
+describe("database backup table pattern matching", () => {
+  it("matches a fully-qualified db.schema.table pattern when the database and schema share the same name", () => {
+    // Regression for #7314: PostgreSQL commonly has a schema with the same
+    // name as its database, and the fully-qualified candidate was previously
+    // suppressed whenever database === schema, silently breaking exclude
+    // rules written as "db.schema.table".
+    expect(databaseBackupTableMatchesPattern("vector_data", ["issue7314.issue7314.vector_data"], "issue7314", "issue7314")).toBe(true);
+  });
+
+  it("still matches a fully-qualified db.schema.table pattern when the database and schema differ", () => {
+    expect(databaseBackupTableMatchesPattern("vector_data", ["mydb.myschema.vector_data"], "mydb", "myschema")).toBe(true);
+  });
+
+  it("excludes the matched table from the backup scope when database and schema share the same name", () => {
+    const scope = resolveScheduledDatabaseBackupTableScope("exclude", ["issue7314.issue7314.vector_data"], ["vector_data", "keep_rows"], "issue7314", "issue7314");
+    expect(scope.includedTables).toEqual(["keep_rows"]);
+    expect(scope.excludedTables).toEqual(["vector_data"]);
   });
 });

--- a/apps/desktop/src/lib/backup/scheduledDatabaseBackup.ts
+++ b/apps/desktop/src/lib/backup/scheduledDatabaseBackup.ts
@@ -79,7 +79,7 @@ function tablePatternRegex(pattern: string, caseSensitive: boolean): RegExp {
 export function databaseBackupTableMatchesPattern(table: string, patterns: readonly string[], database = "", schema = "", caseSensitive = true): boolean {
   const candidates = [table];
   if (schema) candidates.push(`${schema}.${table}`);
-  if (database && schema && database !== schema) candidates.push(`${database}.${schema}.${table}`);
+  if (database && schema) candidates.push(`${database}.${schema}.${table}`);
   return patterns.some((pattern) => {
     const matcher = tablePatternRegex(pattern, caseSensitive);
     return candidates.some((candidate) => matcher.test(candidate));


### PR DESCRIPTION
## Summary

`databaseBackupTableMatchesPattern` (used by scheduled database backups' table include/exclude filters) skips generating the fully-qualified `database.schema.table` candidate whenever `database === schema`. This is a common case in PostgreSQL, where a schema frequently shares its name with the database (as in the reporter's example, `agentsview.agentsview.vector_chunks_g1`).

As a result, an **Exclude matches** rule written in the fully-qualified `db.schema.table` form silently never matches, and the table meant to be excluded is still exported in full — including all of its data.

## Root cause

```ts
// before
if (database && schema && database !== schema) candidates.push(`${database}.${schema}.${table}`);
```

The extra `database !== schema` check suppresses the three-part candidate exactly when database and schema names coincide — the opposite of what's needed, since that's precisely when a user is most likely to write the fully-qualified pattern to disambiguate.

## Fix

Drop the redundant `database !== schema` condition; only require both to be non-empty:

```ts
// after
if (database && schema) candidates.push(`${database}.${schema}.${table}`);
```

## Evidence (non-visual — see PR comment for real repro details)

This bug can't be judged by a screenshot: a saved schedule's UI looks identical whether the exclude rule works or not. The real evidence is the exported SQL content itself.

Reproduced end-to-end against a real PostgreSQL 16 instance with database `issue7314` and schema `issue7314` (same name), one excluded table `vector_data` (50 rows) and one kept table `keep_rows`:

- **Before fix**: exported SQL contained the full `CREATE TABLE`/`INSERT` for `vector_data` despite the exclude rule `issue7314.issue7314.vector_data` being configured.
- **After fix**: exported SQL contains only `keep_rows`; `vector_data` does not appear at all.

Fixes #7314

## Test plan

- [x] New unit tests in `scheduledDatabaseBackup.spec.ts` covering the same-name and different-name cases, verified to fail on the pre-fix code and pass after
- [x] Full frontend suite: 883 files / 8465 tests passing
- [x] `vue-tsc --noEmit` clean
- [x] `oxlint` clean (no new warnings on touched files)
- [x] Rebased onto latest `upstream/main`, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)