### PR TITLE
fix(postgres): WITH 语句包裹的 UPDATE/DELETE 正确返回受影响行数，CTE 列名补全不再强制加前缀

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
@@ -1021,6 +1021,57 @@ describe("sqlCompletion scoped context classification", () => {
     expect(context.referencedTables).toEqual(expect.arrayContaining([expect.objectContaining({ name: "recent_orders", columns: ["id", "total"] }), expect.objectContaining({ name: "recent_orders", alias: "ro" })]));
   });
 
+  it("scopes CTE bodies out of the outer query's referenced tables", () => {
+    const sql = "WITH cte AS (SELECT id, name FROM orders) SELECT id, na FROM cte";
+    const cursor = sql.indexOf(" FROM cte");
+    const context = getSqlCompletionContext(sql, cursor);
+
+    expect(context.referencedTables.map((table) => table.name)).toEqual(["cte"]);
+  });
+
+  it("suggests bare CTE column names instead of forcing a cte. qualifier (issue #7396)", () => {
+    const sql = "WITH cte AS (SELECT id, name FROM orders) SELECT id, na FROM cte";
+    const cursor = sql.indexOf(" FROM cte");
+    const items = buildSqlCompletionItems(sql, cursor, {
+      tables: [],
+      columnsByTable: new Map([
+        [
+          "orders",
+          [
+            { name: "id", table: "orders", dataType: "int" },
+            { name: "name", table: "orders", dataType: "text" },
+          ],
+        ],
+        [
+          "cte",
+          [
+            { name: "id", table: "cte" },
+            { name: "name", table: "cte" },
+          ],
+        ],
+      ]),
+    });
+
+    expect(items).toEqual(expect.arrayContaining([expect.objectContaining({ label: "name", type: "column" })]));
+    expect(items.filter((item) => item.type === "column").map((item) => item.label)).not.toContain("orders.name");
+  });
+
+  it("keeps the CTE body's own tables while completing inside that body", () => {
+    const sql = "WITH cte AS (SELECT id, na FROM orders) SELECT * FROM cte";
+    const cursor = sql.indexOf(" FROM orders");
+    const context = getSqlCompletionContext(sql, cursor);
+
+    expect(context.referencedTables.map((table) => table.name)).toEqual(expect.arrayContaining(["orders", "cte"]));
+  });
+
+  it("keeps the underlying table when a CTE body projects an unresolved star", () => {
+    const sql = "WITH cte AS (SELECT * FROM orders) SELECT na FROM cte";
+    const cursor = sql.indexOf(" FROM cte");
+    const context = getSqlCompletionContext(sql, cursor);
+
+    expect(context.referencedTables.map((table) => table.name)).toEqual(expect.arrayContaining(["orders", "cte"]));
+  });
+
   it("extracts subquery aliases and projected columns", () => {
     const sql = "SELECT * FROM (SELECT id, name AS user_name FROM users) sq WHERE sq.";
     const context = getSqlCompletionContext(sql, sql.length);

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -2210,7 +2210,9 @@ function skipSqlWhitespaceAndComments(sql: string, pos: number): number {
 export function getSqlCompletionContext(sql: string, cursor: number, options: SqlSemanticBuildOptions = {}): SqlCompletionContext {
   const statementSpan = sqlCompletionStatementSpan(sql, cursor, options);
   // Extract the full statement at cursor position for referenced tables
-  const fullStatement = sql.slice(statementSpan.start, statementSpan.end).trim();
+  const rawStatement = sql.slice(statementSpan.start, statementSpan.end);
+  const fullStatement = rawStatement.trim();
+  const cursorInStatement = cursor - statementSpan.start - (rawStatement.length - rawStatement.trimStart().length);
 
   // Content before cursor within the current statement
   const beforeCursor = sql.slice(statementSpan.start, cursor);
@@ -2223,10 +2225,10 @@ export function getSqlCompletionContext(sql: string, cursor: number, options: Sq
   const beforeToken = beforeCursor.slice(0, Math.max(0, bareStart)).trimEnd();
   const lastWord = /([A-Za-z_][\w$]*)$/.exec(beforeToken)?.[1]?.toLowerCase() ?? "";
 
-  let referencedTables = extractReferencedTables(fullStatement, options.databaseType);
-
-  // Merge CTE definitions into referenced tables
-  const cteDefs = extractCteDefinitions(fullStatement);
+  // CTE bodies are their own scope: resolve them first so the outer query's
+  // referenced tables are read from a statement with those bodies blanked out.
+  const cteDefs = scanCteDefinitions(fullStatement);
+  let referencedTables = extractReferencedTables(maskResolvedCteBodies(fullStatement, cursorInStatement, cteDefs), options.databaseType);
   for (const cte of cteDefs) {
     if (!referencedTables.some((rt) => rt.name.toLowerCase() === cte.name.toLowerCase())) {
       referencedTables.push({ name: cte.name, columns: cte.columns });
@@ -3287,8 +3289,21 @@ function extractSelectColumnNames(sql: string): string[] {
   return names;
 }
 
-export function extractCteDefinitions(sql: string): Array<{ name: string; columns: string[] }> {
-  const ctes: Array<{ name: string; columns: string[] }> = [];
+interface ScannedCteDefinition {
+  name: string;
+  columns: string[];
+  /** Index of the `(` opening the CTE body. */
+  bodyStart: number;
+  /** Index of the `)` closing the CTE body. */
+  bodyEnd: number;
+}
+
+/**
+ * Scans `WITH` definitions, keeping each body's span so callers can tell which
+ * part of the statement belongs to a CTE rather than to the outer query.
+ */
+function scanCteDefinitions(sql: string): ScannedCteDefinition[] {
+  const ctes: ScannedCteDefinition[] = [];
   let lower = sql.toLowerCase();
   const withMatch = /\bwith\b/.exec(lower);
   if (!withMatch) return ctes;
@@ -3347,11 +3362,39 @@ export function extractCteDefinitions(sql: string): Array<{ name: string; column
       columns = extractSelectColumnNames(body);
     }
 
-    ctes.push({ name: cteName, columns });
+    ctes.push({ name: cteName, columns, bodyStart: pos, bodyEnd });
     pos = bodyEnd + 1;
   }
 
   return ctes;
+}
+
+export function extractCteDefinitions(sql: string): Array<{ name: string; columns: string[] }> {
+  return scanCteDefinitions(sql).map(({ name, columns }) => ({ name, columns }));
+}
+
+/**
+ * Blanks out CTE bodies whose projected columns are already known, so the outer
+ * query's referenced tables stay scoped to its own row sources. Without this the
+ * tables read inside a CTE (`WITH cte AS (SELECT id, name FROM t) SELECT na|`)
+ * would count as extra outer row sources and force every column suggestion to be
+ * qualified, hiding the bare `name` candidate the CTE actually provides.
+ *
+ * The body holding the cursor is never blanked -- completion inside a CTE body
+ * still needs that body's own tables -- and neither is a body whose columns could
+ * not be resolved (e.g. `SELECT *`), where the underlying table remains the only
+ * source of column names.
+ */
+function maskResolvedCteBodies(statement: string, cursorOffset: number, ctes: readonly ScannedCteDefinition[]): string {
+  let masked = statement;
+  for (const cte of ctes) {
+    if (cte.columns.length === 0) continue;
+    if (cursorOffset > cte.bodyStart && cursorOffset <= cte.bodyEnd) continue;
+    const bodyLength = cte.bodyEnd - cte.bodyStart - 1;
+    if (bodyLength <= 0) continue;
+    masked = `${masked.slice(0, cte.bodyStart + 1)}${" ".repeat(bodyLength)}${masked.slice(cte.bodyEnd)}`;
+  }
+  return masked;
 }
 
 function extractSubqueryReferences(sql: string): SqlCompletionReferencedTable[] {

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -9,7 +9,7 @@ use rustls::client::verify_server_cert_signed_by_trust_anchor;
 use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::server::ParsedCertificate;
-use sqlparser::ast::Statement;
+use sqlparser::ast::{SetExpr, Statement};
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -5956,27 +5956,60 @@ fn query_result_row_limit(max_rows: Option<usize>) -> usize {
     max_rows.unwrap_or(crate::query::MAX_ROWS).max(1)
 }
 
+/// Returns whether a parsed DML statement produces a result set, or `None` when
+/// the statement is not DML.
+fn postgres_dml_statement_returns_rows(statement: &Statement) -> Option<bool> {
+    match statement {
+        Statement::Insert(insert) => Some(insert.returning.is_some()),
+        Statement::Update(update) => Some(update.returning.is_some()),
+        Statement::Delete(delete) => Some(delete.returning.is_some()),
+        Statement::Merge(merge) => Some(merge.output.is_some()),
+        _ => None,
+    }
+}
+
+/// `WITH cte AS (...) UPDATE ...` parses as a query whose body is the wrapped
+/// DML statement; returns that statement so its `RETURNING` clause can decide.
+fn postgres_query_body_dml(body: &SetExpr) -> Option<&Statement> {
+    match body {
+        SetExpr::Insert(statement)
+        | SetExpr::Update(statement)
+        | SetExpr::Delete(statement)
+        | SetExpr::Merge(statement) => Some(statement),
+        _ => None,
+    }
+}
+
 /// Returns whether PostgreSQL should execute this statement through the row
 /// retrieval path. DML without `RETURNING` needs `execute` for its command
 /// tag/affected-row count, while DML with `RETURNING` produces a result set.
 pub(crate) fn postgres_statement_returns_rows(sql: &str) -> bool {
-    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "EXPLAIN", "WITH", "TABLE"]) {
+    if starts_with_executable_sql_keyword(sql, &["SELECT", "SHOW", "EXPLAIN", "TABLE"]) {
         return true;
     }
 
+    // A leading `WITH` is usually a CTE query, but PostgreSQL also allows a CTE
+    // to be followed directly by INSERT/UPDATE/DELETE/MERGE, which only returns
+    // rows with `RETURNING`. The prefix alone cannot decide, so parse it and
+    // keep the row-returning assumption whenever parsing does not say otherwise.
+    let leads_with_cte = starts_with_executable_sql_keyword(sql, &["WITH"]);
+
     let Ok(statements) = Parser::parse_sql(&PostgreSqlDialect {}, sql) else {
-        return false;
+        return leads_with_cte;
     };
     let [statement] = statements.as_slice() else {
-        return false;
+        return leads_with_cte;
     };
 
+    if let Some(returns_rows) = postgres_dml_statement_returns_rows(statement) {
+        return returns_rows;
+    }
+
     match statement {
-        Statement::Insert(insert) => insert.returning.is_some(),
-        Statement::Update(update) => update.returning.is_some(),
-        Statement::Delete(delete) => delete.returning.is_some(),
-        Statement::Merge(merge) => merge.output.is_some(),
-        _ => false,
+        Statement::Query(query) => {
+            postgres_query_body_dml(&query.body).and_then(postgres_dml_statement_returns_rows).unwrap_or(true)
+        }
+        _ => leads_with_cte,
     }
 }
 
@@ -8492,6 +8525,47 @@ mod tests {
             "DELETE FROM users WHERE id = 1",
             "MERGE INTO users AS target USING updates AS source ON target.id = source.id WHEN MATCHED THEN UPDATE SET name = source.name",
             "INSERT INTO users (note) VALUES ('RETURNING is text')",
+        ] {
+            assert!(!postgres_statement_returns_rows(sql), "expected command result for: {sql}");
+        }
+    }
+
+    #[test]
+    fn cte_wrapped_dml_parses_as_query_body() {
+        let statements = Parser::parse_sql(
+            &PostgreSqlDialect {},
+            "WITH cte AS (SELECT id FROM t) UPDATE t SET x = 1 WHERE id IN (SELECT id FROM cte)",
+        )
+        .expect("CTE-wrapped UPDATE should parse");
+        let [Statement::Query(query)] = statements.as_slice() else {
+            panic!("expected a single Statement::Query, got: {statements:?}");
+        };
+        assert!(query.with.is_some(), "expected the CTE to be attached to the query");
+        assert!(
+            matches!(postgres_query_body_dml(&query.body), Some(Statement::Update(_))),
+            "expected an UPDATE body, got: {:?}",
+            query.body
+        );
+    }
+
+    #[test]
+    fn postgres_statement_returns_rows_for_cte_wrapped_dml() {
+        for sql in [
+            "WITH cte AS (SELECT id FROM t) SELECT * FROM cte",
+            "WITH cte AS (SELECT id FROM t) UPDATE t SET x = 1 WHERE id IN (SELECT id FROM cte) RETURNING id",
+            "WITH cte AS (SELECT id FROM t) DELETE FROM t WHERE id IN (SELECT id FROM cte) RETURNING id",
+            "WITH cte AS (SELECT id FROM t) INSERT INTO u (id) SELECT id FROM cte RETURNING id",
+            // Not parseable by sqlparser: keep assuming a CTE query returns rows.
+            "WITH RECURSIVE cte AS MATERIALIZED (SELECT 1) SELECT * FROM cte",
+        ] {
+            assert!(postgres_statement_returns_rows(sql), "expected result rows for: {sql}");
+        }
+
+        for sql in [
+            "WITH cte AS (SELECT id FROM t) UPDATE t SET x = 1 WHERE id IN (SELECT id FROM cte)",
+            "WITH cte AS (SELECT id FROM t) DELETE FROM t WHERE id IN (SELECT id FROM cte)",
+            "WITH cte AS (SELECT id FROM t) INSERT INTO u (id) SELECT id FROM cte",
+            "  with cte as (select id from t)\n  update t set x = 1 where id in (select id from cte)  ",
         ] {
             assert!(!postgres_statement_returns_rows(sql), "expected command result for: {sql}");
         }


### PR DESCRIPTION
## 问题

Fixes #7396

PostgreSQL 下使用 `WITH`（CTE）语法时存在两个问题：

1. `WITH cte AS (...) UPDATE/DELETE ...`（不带 `RETURNING`）实际执行是成功的、数据也确实被修改了，但界面上"受影响行数"错误显示为 0。
2. 在 CTE 内部使用的表列会被补全为要求加 `cte.` 前缀，直接输入裸列名（如 `name`）时补全列表里没有对应建议。

## 根因

1. `crates/dbx-core/src/db/postgres.rs` 的 `postgres_statement_returns_rows()` 只要 SQL 以 `WITH` 开头就直接判定为"会返回结果集"，因而走了查询路径而不是 `execute()`，导致拿不到真实的受影响行数（命令执行本身没问题，只是统计路径错了）。
2. `apps/desktop/src/lib/sql/sqlCompletion.ts` 在计算外层查询"可见的表"时，把 CTE 内部子查询用到的表也一并算了进去，导致所有列建议都被强制要求加表名限定。

## 修复

1. 去掉 `WITH` 的直接短路判断，交给 sqlparser 解析后按内层真实语句（`INSERT`/`UPDATE`/`DELETE`/`MERGE`）是否带 `RETURNING`/`OUTPUT` 判断是否有结果集；解析失败时保留原有"当作查询"的假设（不影响正常的 `WITH ... SELECT`）。
2. 在提取外层引用表之前，先把已经解析出列的 CTE 子查询体"遮蔽"掉，使其不再污染外层的引用表集合；光标在 CTE 体内部时不遮蔽（该场景下仍需要看到 CTE 内部自己的表）。

## 测试

- 新增 2 条 Rust 单测（`postgres.rs`）：覆盖 `WITH...UPDATE/DELETE/INSERT`（无 `RETURNING` → 无结果集；带 `RETURNING` → 有结果集）及 `WITH...SELECT` 不受影响。
- 新增 4 条前端单测（`sqlCompletion.context.spec.ts`）：裸列名补全、光标在 CTE 体内部时补全不受影响、CTE 投影为 `SELECT *`（列未知）时保留原表作为补全来源。
- `cargo test -p dbx-core --lib`、`pnpm exec vitest run`（涉及模块）均通过。
- 真实浏览器对照复现（PostgreSQL 16.14）：修复前受影响行数显示 0（数据实际已改），修复后正确显示 3；修复前裸列名 `na` 无法补全出 `name`，修复后正常出现；带 `RETURNING` 的 CTE 语句结果集行为无回归。