### PR TITLE
fix(jdbc): 缺少 Oracle 字典视图时降级使用 DatabaseMetaData 获取表和列等元数据

### DIFF
--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -3452,7 +3452,7 @@ public final class DbxJdbcPlugin {
     private static Set<String> safePrimaryKeys(DatabaseMetaData meta, String database, String schema, String table) {
         try {
             return primaryKeys(meta, database, schema, table);
-        } catch (SQLException ignored) {
+        } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
             return Collections.emptySet();
         }
     }
@@ -3733,13 +3733,12 @@ public final class DbxJdbcPlugin {
             }
             return result;
         } catch (SQLException e) {
-            try (ResultSet rs = conn.getMetaData().getSchemas()) {
-                while (rs.next()) {
-                    String schema = rs.getString("TABLE_SCHEM");
-                    if (schema != null && !schema.isBlank()) {
-                        result.add(schema);
-                    }
+            result.removeAll();
+            try {
+                try (ResultSet rs = conn.getMetaData().getSchemas()) {
+                    appendSchemas(result, rs, false);
                 }
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
             }
             return result;
         }
@@ -3765,9 +3764,16 @@ public final class DbxJdbcPlugin {
                     putNullable(item, "comment", rs.getString("comments"));
                     result.add(item);
                 }
+                return result;
             }
+        } catch (SQLException e) {
+            result.removeAll();
+            try {
+                appendTables(result, conn.getMetaData(), null, owner, new String[]{"TABLE", "VIEW"}, null, 0, 0);
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
+            }
+            return result;
         }
-        return result;
     }
 
     private static JsonNode oracleListObjects(Connection conn, String owner, String schemaLabel) throws SQLException {
@@ -3787,6 +3793,12 @@ public final class DbxJdbcPlugin {
                     result.add(item);
                 }
             }
+        } catch (SQLException e) {
+            result.removeAll();
+            try {
+                appendTableObjects(result, conn.getMetaData(), null, owner, schemaLabel, new String[]{"TABLE", "VIEW"});
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
+            }
         }
         String procSql =
             "SELECT object_name AS name, object_type " +
@@ -3804,6 +3816,21 @@ public final class DbxJdbcPlugin {
                     result.add(item);
                 }
             }
+        } catch (SQLException e) {
+            try {
+                DatabaseMetaData meta = conn.getMetaData();
+                try (ResultSet rs = meta.getProcedures(null, owner, "%")) {
+                    while (rs != null && rs.next()) {
+                        ObjectNode item = MAPPER.createObjectNode();
+                        item.put("name", rs.getString("PROCEDURE_NAME"));
+                        item.put("object_type", "PROCEDURE");
+                        putNullable(item, "schema", schemaLabel);
+                        putNullable(item, "comment", rs.getString("REMARKS"));
+                        result.add(item);
+                    }
+                }
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
+            }
         }
         String packageSql =
             "SELECT object_name AS name, CASE object_type WHEN 'PACKAGE BODY' THEN 'PACKAGE_BODY' ELSE object_type END AS object_type " +
@@ -3820,6 +3847,7 @@ public final class DbxJdbcPlugin {
                     result.add(item);
                 }
             }
+        } catch (SQLException ignored) {
         }
         String sequenceSql = "SELECT sequence_name AS name FROM all_sequences WHERE sequence_owner = ? ORDER BY sequence_name";
         try (PreparedStatement ps = conn.prepareStatement(sequenceSql)) {
@@ -3834,6 +3862,7 @@ public final class DbxJdbcPlugin {
                     result.add(item);
                 }
             }
+        } catch (SQLException ignored) {
         }
         String synonymSql = "SELECT synonym_name AS name FROM all_synonyms WHERE owner = ? ORDER BY synonym_name";
         try (PreparedStatement ps = conn.prepareStatement(synonymSql)) {
@@ -3847,6 +3876,11 @@ public final class DbxJdbcPlugin {
                     item.putNull("comment");
                     result.add(item);
                 }
+            }
+        } catch (SQLException e) {
+            try {
+                appendTableObjects(result, conn.getMetaData(), null, owner, schemaLabel, new String[]{"SYNONYM", "ALIAS"});
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
             }
         }
         return result;
@@ -3885,6 +3919,15 @@ public final class DbxJdbcPlugin {
                         ((ArrayNode) item.path("columns")).add(column);
                     }
                 }
+            }
+        } catch (SQLException e) {
+            indexes.clear();
+            try {
+                DatabaseMetaData meta = conn.getMetaData();
+                try (ResultSet rs = meta.getIndexInfo(null, owner, table, false, false)) {
+                    appendJdbcIndexes(indexes, Collections.emptySet(), rs);
+                }
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
             }
         }
         ArrayNode result = MAPPER.createArrayNode();
@@ -4012,13 +4055,21 @@ public final class DbxJdbcPlugin {
                     putNullableInt(item, "numeric_scale", rs.getObject("data_scale"));
                     putNullableInt(item, "character_maximum_length", rs.getObject("char_length"));
                 }
+                return result;
             }
+        } catch (SQLException e) {
+            result.removeAll();
+            try {
+                DatabaseMetaData meta = conn.getMetaData();
+                appendColumns(result, meta, null, owner, resolvedTable);
+                markPrimaryKeyColumns(result, pks);
+            } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
+            }
+            return result;
         }
-        return result;
     }
 
     private static Set<String> oraclePrimaryKeys(Connection conn, String owner, String table) throws SQLException {
-        Set<String> keys = new HashSet<>();
         String sql =
             "SELECT cols.column_name FROM all_constraints cons " +
             "JOIN all_cons_columns cols ON cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner " +
@@ -4027,12 +4078,15 @@ public final class DbxJdbcPlugin {
             ps.setString(1, owner);
             ps.setString(2, table);
             try (ResultSet rs = ps.executeQuery()) {
+                Set<String> keys = new HashSet<>();
                 while (rs.next()) {
                     keys.add(rs.getString("column_name"));
                 }
+                return keys;
             }
+        } catch (SQLException e) {
+            return safePrimaryKeys(conn.getMetaData(), null, owner, table);
         }
-        return keys;
     }
 
     private static Object readValue(

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -3924,9 +3924,25 @@ public final class DbxJdbcPlugin {
             indexes.clear();
             try {
                 DatabaseMetaData meta = conn.getMetaData();
-                try (ResultSet rs = meta.getIndexInfo(null, owner, table, false, false)) {
-                    appendJdbcIndexes(indexes, Collections.emptySet(), rs);
+                Set<String> primaryIndexNames = new HashSet<>();
+                Map<Integer, String> primaryColumnsBySequence = new TreeMap<>();
+                try (ResultSet rs = meta.getPrimaryKeys(null, owner, table)) {
+                    while (rs != null && rs.next()) {
+                        String name = rs.getString("PK_NAME");
+                        if (name != null && !name.isBlank()) {
+                            primaryIndexNames.add(name);
+                        }
+                        String column = rs.getString("COLUMN_NAME");
+                        if (column != null && !column.isBlank()) {
+                            primaryColumnsBySequence.put((int) rs.getShort("KEY_SEQ"), column);
+                        }
+                    }
+                } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
                 }
+                try (ResultSet rs = meta.getIndexInfo(null, owner, table, false, false)) {
+                    appendJdbcIndexes(indexes, primaryIndexNames, rs);
+                }
+                markPrimaryIndexByColumns(indexes.values(), new ArrayList<>(primaryColumnsBySequence.values()));
             } catch (SQLException | AbstractMethodError | UnsupportedOperationException ignored) {
             }
         }

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -2962,6 +2962,20 @@ final class DbxJdbcPluginTest {
                 }
             }
             assertEquals(true, found);
+            boolean primaryMarked = false;
+            for (JsonNode node : result) {
+                boolean idColumn = false;
+                for (JsonNode column : node.path("columns")) {
+                    if ("ID".equalsIgnoreCase(column.asText())) {
+                        idColumn = true;
+                        break;
+                    }
+                }
+                if (idColumn && node.path("is_primary").asBoolean()) {
+                    primaryMarked = true;
+                }
+            }
+            assertEquals(true, primaryMarked);
         }
     }
 

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -2852,6 +2852,120 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void oracleListTablesFallsBackToJdbcTablesWhenAllTabCommentsIsMissing() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleListTables", Connection.class, String.class);
+        method.setAccessible(true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:dbx_oracle_no_tab_comments;DB_CLOSE_DELAY=-1", "sa", "")) {
+            conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS DM6_SCHEMA");
+            conn.createStatement().execute("CREATE TABLE DM6_SCHEMA.DM6_TABLE (id INT PRIMARY KEY)");
+
+            JsonNode result = (JsonNode) method.invoke(null, conn, "DM6_SCHEMA");
+            assertFalse(result.isNull());
+            assertEquals(true, result.isArray());
+            boolean found = false;
+            for (JsonNode node : result) {
+                if ("DM6_TABLE".equalsIgnoreCase(node.path("name").asText())) {
+                    found = true;
+                    break;
+                }
+            }
+            assertEquals(true, found);
+        }
+    }
+
+    @Test
+    void oracleGetColumnsFallsBackToJdbcColumnsWhenAllTabColumnsIsMissing() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleGetColumns", Connection.class, String.class, String.class);
+        method.setAccessible(true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:dbx_oracle_no_tab_cols;DB_CLOSE_DELAY=-1", "sa", "")) {
+            conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS DM6_SCHEMA");
+            conn.createStatement().execute("CREATE TABLE DM6_SCHEMA.DM6_TABLE (id INT PRIMARY KEY, name VARCHAR(64))");
+
+            JsonNode result = (JsonNode) method.invoke(null, conn, "DM6_SCHEMA", "DM6_TABLE");
+            assertFalse(result.isNull());
+            assertEquals(true, result.isArray());
+            assertEquals(2, result.size());
+            assertEquals("ID", result.path(0).path("name").asText().toUpperCase());
+            assertEquals("NAME", result.path(1).path("name").asText().toUpperCase());
+        }
+    }
+
+    @Test
+    void oraclePrimaryKeysFallsBackToJdbcWhenAllConstraintsIsMissing() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("oraclePrimaryKeys", Connection.class, String.class, String.class);
+        method.setAccessible(true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:dbx_oracle_no_constraints;DB_CLOSE_DELAY=-1", "sa", "")) {
+            conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS DM6_SCHEMA");
+            conn.createStatement().execute("CREATE TABLE DM6_SCHEMA.DM6_TABLE (id INT PRIMARY KEY, name VARCHAR(64))");
+
+            @SuppressWarnings("unchecked")
+            Set<String> pks = (Set<String>) method.invoke(null, conn, "DM6_SCHEMA", "DM6_TABLE");
+            assertFalse(pks.isEmpty());
+            assertEquals(true, pks.contains("ID") || pks.contains("id"));
+        }
+    }
+
+    @Test
+    void oracleListObjectsFallsBackToJdbcWhenOracleViewsAreMissing() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleListObjects", Connection.class, String.class, String.class);
+        method.setAccessible(true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:dbx_oracle_no_objects;DB_CLOSE_DELAY=-1", "sa", "")) {
+            conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS DM6_SCHEMA");
+            conn.createStatement().execute("CREATE TABLE DM6_SCHEMA.DM6_TABLE (id INT PRIMARY KEY)");
+            conn.createStatement().execute("CREATE VIEW DM6_SCHEMA.DM6_VIEW AS SELECT * FROM DM6_SCHEMA.DM6_TABLE");
+            conn.createStatement().execute("CREATE ALIAS DM6_SCHEMA.DM6_PROC AS 'String proc() { return \"\"; }'");
+
+            JsonNode result = (JsonNode) method.invoke(null, conn, "DM6_SCHEMA", "DM6_SCHEMA");
+            assertFalse(result.isNull());
+            assertEquals(true, result.isArray());
+            boolean foundTable = false;
+            boolean foundView = false;
+            boolean foundProc = false;
+            for (JsonNode node : result) {
+                String name = node.path("name").asText();
+                if ("DM6_TABLE".equalsIgnoreCase(name)) {
+                    foundTable = true;
+                } else if ("DM6_VIEW".equalsIgnoreCase(name)) {
+                    foundView = true;
+                } else if ("DM6_PROC".equalsIgnoreCase(name)) {
+                    foundProc = true;
+                }
+            }
+            assertEquals(true, foundTable);
+            assertEquals(true, foundView);
+            assertEquals(true, foundProc);
+        }
+    }
+
+    @Test
+    void oracleListIndexesFallsBackToJdbcIndexesWhenAllIndexesIsMissing() throws Exception {
+        Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleListIndexes", Connection.class, String.class, String.class);
+        method.setAccessible(true);
+
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:dbx_oracle_no_indexes;DB_CLOSE_DELAY=-1", "sa", "")) {
+            conn.createStatement().execute("CREATE SCHEMA IF NOT EXISTS DM6_SCHEMA");
+            conn.createStatement().execute("CREATE TABLE DM6_SCHEMA.DM6_TABLE (id INT PRIMARY KEY, code VARCHAR(32))");
+            conn.createStatement().execute("CREATE INDEX DM6_SCHEMA.idx_code ON DM6_SCHEMA.DM6_TABLE(code)");
+
+            JsonNode result = (JsonNode) method.invoke(null, conn, "DM6_SCHEMA", "DM6_TABLE");
+            assertFalse(result.isNull());
+            assertEquals(true, result.isArray());
+            boolean found = false;
+            for (JsonNode node : result) {
+                if ("IDX_CODE".equalsIgnoreCase(node.path("name").asText())) {
+                    found = true;
+                    break;
+                }
+            }
+            assertEquals(true, found);
+        }
+    }
+
+    @Test
     void oracleEffectiveSchemaUsesExactOwnerBeforeUppercaseFallback() throws Exception {
         Method method = DbxJdbcPlugin.class.getDeclaredMethod("oracleEffectiveSchema", Connection.class, String.class);
         method.setAccessible(true);


### PR DESCRIPTION
## 变更说明

本 PR 作为 **#7311 的 Follow-up**：在上一个 PR 修复了模式列表（`ALL_USERS`）降级后，本次继续补齐后续的数据表、列字段、主键、索引等全套元数据降级：

1. **元数据降级**：当 Oracle 字典视图（`ALL_TAB_COMMENTS`、`ALL_TAB_COLUMNS`、`ALL_CONSTRAINTS`、`ALL_INDEXES` 等）不存在时，自动回退并复用原生 `appendTables`、`appendColumns`、`safePrimaryKeys`、`appendJdbcIndexes`（基于 `DatabaseMetaData`）。
2. **防御性增强**：降级前重置容器防止中途断开产生脏数据，统一捕获 `SQLException`、 `AbstractMethodError` 与 `UnsupportedOperationException`。
3. **测试覆盖**：新增 5 个专属单元测试，1:1 覆盖表、字段、主键、对象树、索引的降级场景。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `plugins/jdbc` 测试全部通过

## 关联 Issue

Related #7259
