### PR TITLE
fix(mysql): 避免导出期间误判连接池失效

### DIFF
--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -3352,10 +3352,14 @@ impl AppState {
                     checked_mysql_pool = Some(pool.clone());
                     drop(connections);
                     match db::mysql::checkout_mysql_conn(&pool, HEALTH_CHECK_POOL_ACQUIRE_TIMEOUT).await {
-                        // Pool saturation means active work, not a dead connection. Removing this pool would
-                        // start a competing reconnect while foreground queries and metadata are still running.
-                        Err(err) if err.is_pool_saturation() => {
-                            log::debug!("MySQL connection pool '{pool_key}' is busy; skipping health probe: {err}");
+                        // The 500 ms probe budget is intentionally shorter than a foreground checkout. A timeout
+                        // while waiting, creating, or recycling is inconclusive: slow remote handshakes and active
+                        // metadata exports can legitimately exceed it. Removing the pool here would start competing
+                        // reconnects while useful work is still running.
+                        Err(err @ db::PoolCheckoutError::Timeout { .. }) => {
+                            log::debug!(
+                                "MySQL connection pool '{pool_key}' did not finish a health checkout; keeping pool: {err}"
+                            );
                             false
                         }
                         Err(err) => {
@@ -7002,6 +7006,40 @@ mod tests {
         assert!(state.connections.read().await.contains_key("conn"));
         drop(held_connection);
         state.remove_connection_pools_detached("conn").await;
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn mysql_health_check_keeps_pool_when_connection_creation_exceeds_probe_budget() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let pool_options =
+            mysql_async::PoolOpts::new().with_constraints(mysql_async::PoolConstraints::new(1, 2).unwrap());
+        let options = mysql_async::OptsBuilder::default()
+            .ip_or_hostname(address.ip().to_string())
+            .tcp_port(address.port())
+            .user(Some("fault-injection"))
+            .pass(Some("fault-injection"))
+            .pool_opts(Some(pool_options));
+        let pool = db::mysql::MySqlPool::new(options, 2);
+        let (state, dir) = test_app_state().await;
+        state.connections.write().await.insert("conn".to_string(), PoolKind::Mysql(pool.clone(), MysqlMode::Normal));
+
+        let started = Instant::now();
+        assert!(!state.remove_stale_connection_pool("conn").await);
+
+        assert!(started.elapsed() >= super::HEALTH_CHECK_POOL_ACQUIRE_TIMEOUT);
+        assert!(matches!(
+            state.connections.read().await.get("conn"),
+            Some(PoolKind::Mysql(current, _)) if pool.is_same_pool(current)
+        ));
+        state.connections.write().await.remove("conn");
+        server.abort();
+        let _ = tokio::time::timeout(Duration::from_secs(1), pool.disconnect()).await;
         let _ = std::fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## 背景

这是 #6882 / #7172 的后续回归修复。用户在 v0.5.97、MySQL 8.0.35 中仅导出 DDL 时仍会遇到：

```text
Agent runtime is unavailable while publishing the connection pool
```

最新日志确认，#7172 增加的连接池代际保护已经生效，但导出期间仍会反复判定连接池失效并重建。

## 原因

MySQL 健康探针只等待 500ms 获取连接。远端连接创建或回收耗时超过 500ms 时，会返回 `stage=create/recycle` 超时；现有逻辑将其直接视为连接池失效。

导出元数据并发期间，这种短时超时不能证明连接池已失效，误删连接池会触发并发重建和发布竞争，最终把错误写入导出文件。

## 修改

- MySQL 健康探针获取连接超时时保留当前连接池，不再触发重建。
- 获取连接后 `ping` 失败、连接立即返回真实错误时，仍按原逻辑清理失效连接池。
- 增加本地 TCP 故障注入测试，覆盖连接创建超过 500ms 探针预算的场景。

## 验证

- `cargo test -p dbx-core --lib mysql_health_check_keeps_pool_when_connection_creation_exceeds_probe_budget -- --nocapture`
- `cargo test -p dbx-core --lib mysql_checkout_fault_injection -- --nocapture`：3 项通过，1 项需额外真实库环境而忽略
- 真实 MySQL：创建 80 张临时表，连续完整导出 5 次；导出文件均不包含 `-- ERROR` 或 `Agent runtime is unavailable`
- `cargo fmt -p dbx-core -- --check`
- `git diff --check`

关联：#6882