### PR TITLE
fix(mcp): 初始化 TLS 连接所需的 rustls provider

### DIFF
--- a/crates/dbx-mcp/Cargo.toml
+++ b/crates/dbx-mcp/Cargo.toml
@@ -19,6 +19,7 @@ dbx-core = { path = "../dbx-core", default-features = false, features = ["sqlite
 dirs = "6"
 rmcp = { version = "2.2.0", features = ["client", "transport-io"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "socks"] }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -27,7 +28,6 @@ uuid = { version = "1", features = ["v4"] }
 url = "2"
 
 [dev-dependencies]
-rustls = { version = "0.23", features = ["aws-lc-rs"] }
 rustls-pemfile = "2.2"
 tempfile = "3"
 tokio = { version = "1", features = ["net", "io-util"] }

--- a/crates/dbx-mcp/src/server.rs
+++ b/crates/dbx-mcp/src/server.rs
@@ -247,6 +247,10 @@ impl DbxMcpServer {
     }
 
     pub fn with_runtime_options(backend: Arc<dyn DbxBackend>, scope: McpScope, web_mode: bool) -> Self {
+        // The workspace enables more than one rustls crypto feature through
+        // transitive dependencies. Native MCP runs outside the desktop/web
+        // startup paths, so select the same provider before any TLS tool call.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let mut tool_router = Self::tool_router();
         if scope.enabled() {
             tool_router.disable_route("dbx_add_connection");

--- a/crates/dbx-mcp/tests/live_mysql_tls.rs
+++ b/crates/dbx-mcp/tests/live_mysql_tls.rs
@@ -1,0 +1,39 @@
+use std::{path::Path, sync::Arc};
+
+use dbx_mcp::{DbxMcpServer, LocalBackend, McpScope};
+use rmcp::{model::CallToolRequestParams, ServiceExt};
+use serde_json::{json, Map};
+
+#[tokio::test]
+#[ignore = "requires DBX_LIVE_MCP_DATA_DIR with a MySQL connection using ssl-mode=preferred"]
+async fn mysql_preferred_tls_with_self_signed_certificate_keeps_mcp_alive() {
+    let data_dir = std::env::var("DBX_LIVE_MCP_DATA_DIR").expect("set DBX_LIVE_MCP_DATA_DIR");
+    let connection_name = std::env::var("DBX_LIVE_MCP_CONNECTION").expect("set DBX_LIVE_MCP_CONNECTION");
+    let database = std::env::var("DBX_LIVE_MCP_DATABASE").expect("set DBX_LIVE_MCP_DATABASE");
+    let backend =
+        Arc::new(LocalBackend::open(&Path::new(&data_dir).join("dbx.db")).await.expect("open copied DBX storage"));
+    let server = DbxMcpServer::with_runtime_options(backend, McpScope::default(), false);
+    let (server_transport, client_transport) = tokio::io::duplex(16 * 1024);
+    let server_task = tokio::spawn(async move { server.serve(server_transport).await });
+    let client = ().serve(client_transport).await.expect("initialize MCP client");
+    let arguments = json!({
+        "connection_name": connection_name,
+        "database": database,
+        "sql": "SELECT 1 AS tls_probe",
+    })
+    .as_object()
+    .cloned()
+    .unwrap_or_else(Map::new);
+
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("dbx_execute_query").with_arguments(arguments))
+        .await
+        .expect("MCP server must stay alive while executing the TLS query");
+    let text = result.content[0].as_text().expect("text query result").text.clone();
+    assert_ne!(result.is_error, Some(true), "preferred TLS query failed: {text}");
+    assert!(text.contains("tls_probe") && text.contains('1'), "unexpected query result: {text}");
+
+    client.cancel().await.expect("close MCP client");
+    server_task.abort();
+}


### PR DESCRIPTION
## 问题

MCP 进程没有经过桌面端或 Web 端的 TLS 初始化路径。工作区同时启用多个 rustls 加密后端时，MySQL 使用 `ssl-mode=preferred` 建立 TLS 连接会触发：

```text
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point...
```

panic 会直接关闭 MCP 连接，因此客户端只看到 `MCP error -32000: Connection closed`。

## 修复

- MCP server 初始化时幂等安装 AWS-LC rustls provider
- 将运行时所需的 rustls 依赖从 dev-dependencies 移入 dependencies
- 增加忽略型真实 MySQL TLS MCP 回归测试

## 验证

使用本地 MySQL 8.4.6、自签名 CA、TLS 1.3 和 `ssl-mode=preferred`，通过完整 MCP server/client 调用执行 `SELECT 1 AS tls_probe`：

- 修复前：稳定触发 CryptoProvider panic，MCP 连接关闭
- 修复后：查询成功返回 `tls_probe = 1`，MCP 服务保持存活
- `cargo test -p dbx-mcp`：53 个单元测试、6 个本地集成测试（3 ignored）、7 个协议测试通过
- 真实 TLS 忽略测试单独运行通过
- `cargo clippy -p dbx-mcp --all-targets --no-deps -- -D warnings` 通过
- `cargo fmt -p dbx-mcp -- --check` 通过
- `git diff --check` 通过

无 UI 改动。

Fixes #7408