### PR TITLE
fix(sql): preserve empty raw placeholders

### DIFF
--- a/apps/desktop/src/components/editor/__tests__/SqlParameterDialog.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/SqlParameterDialog.spec.ts
@@ -36,7 +36,7 @@ const MIXED_VALUES: Record<string, SqlParameterInput> = {
   empty_value: { kind: "boolean", value: "" },
 };
 const RAW_VALUES = Object.fromEntries(Object.entries(MIXED_VALUES).map(([key, input]) => [key, { ...input, kind: "raw" as const }]));
-const RAW_SQL = "SELECT alpha beta, 42, NULL, current_date, NULL, alpha beta";
+const RAW_SQL = "SELECT alpha beta, 42, NULL, current_date, ${empty_value}, alpha beta";
 
 const mountedApps: App[] = [];
 

--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -674,6 +674,12 @@ describe("Oracle and Dameng trigger pseudo-records", () => {
 });
 
 describe("substituteSqlParameters", () => {
+  it("preserves empty raw placeholders", () => {
+    const sql = "select ${raw_value}, '${raw_value}', 'prefix ${raw_value} suffix'";
+
+    expect(substituteSqlParameters(sql, { raw_value: { kind: "raw", value: "  " } })).toBe(sql);
+  });
+
   it("substitutes dotted names by their complete key", () => {
     const sql = "select ${params.id}, #{params.profile.name}, 'prefix${params.label}'";
     expect(
@@ -908,7 +914,7 @@ describe("substituteSqlParameters", () => {
         empty_raw: { kind: "raw", value: "  " },
         empty_string: { kind: "string", value: "" },
       }),
-    ).toBe("select NULL, NULL, NULL, ''");
+    ).toBe("select NULL, NULL, '${empty_raw}', ''");
   });
 
   it("replaces placeholders embedded in ordinary SQL string values", () => {

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -221,6 +221,13 @@ export function substituteSqlParameters(sql: string, values: Record<string, SqlP
       cursor = occurrence.end;
       continue;
     }
+    // An empty Raw SQL value means that this placeholder is intentionally left
+    // unresolved, rather than replaced with an empty string or NULL.
+    if (input.kind === "raw" && !input.value.trim()) {
+      result += occurrence.token;
+      cursor = occurrence.end;
+      continue;
+    }
     // Embedded placeholders stay inside the surrounding SQL string, so their value
     // must be escaped as text instead of being wrapped in a second SQL literal.
     result += occurrence.replacement === "string-fragment" ? sqlParameterStringFragment(input) : occurrence.replacement === "quoted-string" ? sqlParameterQuotedString(input) : sqlParameterLiteral(input);


### PR DESCRIPTION
Fixes #7450\n\n### What changed\n- Preserve raw SQL placeholders when the selected raw value is empty or whitespace-only.\n- Keep the placeholder intact for standalone, quoted, and embedded occurrences instead of silently producing an empty value or NULL.\n\n### Test\n- pnpm exec vitest run apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts (149 passed)