### PR TITLE
fix(windows): 自动恢复不可见的启动主窗口

### DIFF
--- a/src-tauri/src/commands/app_settings.rs
+++ b/src-tauri/src/commands/app_settings.rs
@@ -101,7 +101,8 @@ pub fn mark_frontend_ready(app: AppHandle) -> Result<(), String> {
     let state =
         app.try_state::<CloseBehaviorState>().ok_or_else(|| "close behavior state is unavailable".to_string())?;
     state.set_frontend_ready(true);
-    clear_startup_probe_after_frontend_ready();
+    let main_window_visible = app.get_webview_window("main").is_some_and(|window| window.is_visible().unwrap_or(false));
+    clear_startup_probe_after_frontend_ready(main_window_visible);
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,8 +170,8 @@ fn append_startup_probe(message: impl AsRef<str>) {
     startup_recovery::record(message);
 }
 
-pub(crate) fn clear_startup_probe_after_frontend_ready() {
-    startup_recovery::mark_frontend_ready();
+pub(crate) fn clear_startup_probe_after_frontend_ready(main_window_visible: bool) {
+    startup_recovery::mark_frontend_ready(main_window_visible);
 }
 
 fn should_confirm_app_exit_request(target_os: &str, exit_code: Option<i32>, confirmed_exit: bool) -> bool {

--- a/src-tauri/src/startup_recovery.rs
+++ b/src-tauri/src/startup_recovery.rs
@@ -444,9 +444,6 @@ pub(crate) fn start_watchdog<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
             show_recovery_failure_message();
             std::process::exit(1);
         }
-        if run_event_count > 0 && !main_exists {
-            return;
-        }
     });
 }
 

--- a/src-tauri/src/startup_recovery.rs
+++ b/src-tauri/src/startup_recovery.rs
@@ -368,8 +368,16 @@ fn should_attempt_enterprise_recovery(
     enterprise_compat_disabled: bool,
     run_event_count: usize,
     main_exists: bool,
+    main_visible: bool,
 ) -> bool {
-    active && !enterprise_compat && !enterprise_compat_disabled && run_event_count == 0 && !main_exists
+    if !active || enterprise_compat || enterprise_compat_disabled {
+        return false;
+    }
+
+    // A window object can exist even when WebView2 or a security product has
+    // prevented it from being presented. The event loop may already be
+    // running in that state, so run_event_count cannot be used as a veto.
+    (!main_exists && run_event_count == 0) || (main_exists && !main_visible)
 }
 
 pub(crate) fn start_watchdog<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
@@ -392,9 +400,11 @@ pub(crate) fn start_watchdog<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
         if !active {
             return;
         }
-        let main_exists = app.get_webview_window("main").is_some();
+        let main_window = app.get_webview_window("main");
+        let main_exists = main_window.is_some();
+        let main_visible = main_window.as_ref().is_some_and(|window| window.is_visible().unwrap_or(false));
         record(format!(
-            "startup watchdog after {}s run_event_count={run_event_count} main_exists={main_exists}",
+            "startup watchdog after {}s run_event_count={run_event_count} main_exists={main_exists} main_visible={main_visible}",
             STARTUP_WATCHDOG_DELAY.as_secs()
         ));
         if should_attempt_enterprise_recovery(
@@ -403,9 +413,10 @@ pub(crate) fn start_watchdog<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
             enterprise_compat_disabled,
             run_event_count,
             main_exists,
+            main_visible,
         ) {
             persist_buffer();
-            record("startup stalled before event loop; restarting once with enterprise compatibility mode");
+            record("startup main window was not visible; restarting once with enterprise compatibility mode");
             let restart_result = std::env::current_exe().and_then(|executable| {
                 let mut command = std::process::Command::new(executable);
                 command.args(std::env::args_os().skip(1));
@@ -424,15 +435,17 @@ pub(crate) fn start_watchdog<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
                 }
             }
         }
-        if run_event_count > 0 || main_exists {
-            return;
-        }
-
-        persist_buffer();
         if enterprise_compat {
+            if main_visible {
+                return;
+            }
+            persist_buffer();
             record("enterprise compatibility startup failed; automatic recovery stopped");
             show_recovery_failure_message();
             std::process::exit(1);
+        }
+        if run_event_count > 0 && !main_exists {
+            return;
         }
     });
 }
@@ -455,7 +468,15 @@ fn deactivate_probe() {
     STARTUP_PROBE_STATE.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).lines.clear();
 }
 
-pub(crate) fn mark_frontend_ready() {
+pub(crate) fn mark_frontend_ready(main_window_visible: bool) {
+    if !main_window_visible {
+        // Frontend readiness alone is not enough to declare startup healthy:
+        // the WebView can load while the native window remains hidden.
+        record("frontend ready but main window is not visible; keeping startup watchdog active");
+        persist_buffer();
+        return;
+    }
+
     let recovery_attempt = RECOVERY_ATTEMPT.load(Ordering::Acquire);
     let keep_requested = env_flag(KEEP_STARTUP_LOG_ENV);
 
@@ -537,10 +558,10 @@ fn show_recovery_failure_message() {
         startup_log_path().map(|path| path.display().to_string()).unwrap_or_else(|| "startup.log".to_string());
     let locale = sys_locale::get_locale().unwrap_or_default().to_ascii_lowercase();
     let body = if locale.starts_with("zh") {
-        format!("DBX 已尝试企业环境兼容模式，但主窗口仍未创建。\n\n请将此日志发给维护者：{log_path}")
+        format!("DBX 已尝试企业环境兼容模式，但主窗口仍未显示。\n\n请将此日志发给维护者：{log_path}")
     } else {
         format!(
-            "DBX tried enterprise environment compatibility mode, but the main window was still not created.\n\nPlease send this log to the maintainer: {log_path}"
+            "DBX tried enterprise environment compatibility mode, but the main window was still not visible.\n\nPlease send this log to the maintainer: {log_path}"
         )
     };
     windows_ok_message("DBX", &body);
@@ -607,16 +628,24 @@ mod tests {
 
     #[test]
     fn recovery_only_triggers_for_the_observed_hard_startup_stall() {
-        assert!(should_attempt_enterprise_recovery(true, false, false, 0, false));
-        assert!(!should_attempt_enterprise_recovery(false, false, false, 0, false));
-        assert!(!should_attempt_enterprise_recovery(true, true, false, 0, false));
-        assert!(!should_attempt_enterprise_recovery(true, false, false, 1, false));
-        assert!(!should_attempt_enterprise_recovery(true, false, false, 0, true));
+        assert!(should_attempt_enterprise_recovery(true, false, false, 0, false, false));
+        assert!(!should_attempt_enterprise_recovery(false, false, false, 0, false, false));
+        assert!(!should_attempt_enterprise_recovery(true, true, false, 0, false, false));
+        assert!(!should_attempt_enterprise_recovery(true, false, false, 1, false, false));
+        assert!(!should_attempt_enterprise_recovery(true, false, false, 0, true, true));
+    }
+
+    #[test]
+    fn recovery_triggers_when_existing_main_window_is_still_hidden() {
+        assert!(should_attempt_enterprise_recovery(true, false, false, 1, true, false));
+        assert!(should_attempt_enterprise_recovery(true, false, false, 0, true, false));
+        assert!(!should_attempt_enterprise_recovery(true, false, false, 1, true, true));
     }
 
     #[test]
     fn disable_enterprise_compat_prevents_recovery_during_a_hard_stall() {
-        assert!(!should_attempt_enterprise_recovery(true, false, true, 0, false));
+        assert!(!should_attempt_enterprise_recovery(true, false, true, 0, false, false));
+        assert!(!should_attempt_enterprise_recovery(true, false, true, 1, true, false));
     }
 
     #[test]

--- a/src-tauri/src/startup_recovery_noop.rs
+++ b/src-tauri/src/startup_recovery_noop.rs
@@ -2,7 +2,7 @@ pub(crate) fn initialize() {}
 
 pub(crate) fn record(_message: impl AsRef<str>) {}
 
-pub(crate) fn mark_frontend_ready() {}
+pub(crate) fn mark_frontend_ready(_main_window_visible: bool) {}
 
 pub(crate) fn record_run_event() {}
 


### PR DESCRIPTION
## 变更说明

修复 Windows 企业环境下 DBX 进程和托盘已启动，但主窗口对象存在且仍不可见时，启动恢复 watchdog 提前结束、不会进入企业兼容模式的问题。

- 将 `main_exists && !main_visible` 纳入一次性企业兼容模式恢复
- 前端 ready 只在主窗口可见时结束启动探针
- 兼容模式失败时提示“主窗口仍未显示”，并保留 `startup.log` 路径
- 增加隐藏主窗口恢复策略的单元测试

## 验证

- `cargo test -p dbx startup_recovery --lib`
  - 10 passed, 0 failed
- `cargo check -p dbx --target x86_64-pc-windows-msvc --lib`
  - 当前 macOS 环境缺少 MSVC/Windows SDK，交叉编译在依赖 `ring` 的 C 编译阶段因缺少 `assert.h` 失败，未能完成 Windows 目标检查
- 未修改现有工作区分支中的用户未提交改动

Windows 11 + 奇安信环境仍需在实机上验证 WebView2 是否能够通过兼容模式恢复。