### PR TITLE
fix(linux): bundle AppImage input method modules

### DIFF
--- a/.github/scripts/verify-appimage-input-methods.sh
+++ b/.github/scripts/verify-appimage-input-methods.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  echo "AppImage input-method verification failed: $*" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  die "usage: $0 <AppImage file or bundle directory>"
+fi
+
+input_path=$1
+if [[ -f "$input_path" ]]; then
+  appimage=$input_path
+elif [[ -d "$input_path" ]]; then
+  appimages=()
+  while IFS= read -r -d '' candidate; do
+    appimages+=("$candidate")
+  done < <(find "$input_path" -maxdepth 1 -type f -name '*.AppImage' -print0)
+  [[ ${#appimages[@]} -eq 1 ]] \
+    || die "expected exactly one AppImage in $input_path, found ${#appimages[@]}"
+  appimage=${appimages[0]}
+else
+  die "path does not exist: $input_path"
+fi
+appimage=$(realpath "$appimage")
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/dbx-appimage-input-methods.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT
+
+(
+  cd "$work_dir"
+  "$appimage" --appimage-extract >/dev/null
+)
+appdir="$work_dir/squashfs-root"
+[[ -d "$appdir" ]] || die "AppImage extraction did not create squashfs-root"
+appdir=$(realpath "$appdir")
+
+require_artifact() {
+  local basename=$1
+  local match
+  local resolved
+  match=$(find "$appdir" \( -type f -o -type l \) -name "$basename" -print -quit)
+  [[ -n "$match" ]] || die "missing bundled artifact: $basename"
+  [[ -e "$match" ]] || die "bundled artifact is a broken symbolic link: ${match#"$appdir"/}"
+  resolved=$(realpath "$match")
+  [[ "$resolved" == "$appdir"/* ]] \
+    || die "bundled artifact resolves outside the AppImage: ${match#"$appdir"/}"
+  echo "Found $basename at ${match#"$appdir"/}"
+}
+
+require_artifact im-fcitx5.so
+require_artifact im-ibus.so
+require_artifact libFcitx5GClient.so.2
+require_artifact libibus-1.0.so.5
+
+cache=''
+while IFS= read -r -d '' candidate; do
+  if grep -Fq 'im-fcitx5.so' "$candidate" && grep -Fq 'im-ibus.so' "$candidate"; then
+    cache=$candidate
+    break
+  fi
+done < <(find "$appdir" -type f -path '*/gtk-3.0/*/immodules.cache' -print0)
+
+[[ -n "$cache" ]] || die "no private GTK 3 immodules.cache registers both Fcitx 5 and IBus"
+echo "Verified GTK input-method cache at ${cache#"$appdir"/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,9 @@ jobs:
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev xdg-utils
+          # Bundle GTK input-method modules from the same Jammy ABI baseline
+          # instead of loading potentially incompatible modules from the host.
+          sudo apt-get install -y fcitx5-frontend-gtk3 ibus-gtk3 libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf libssl-dev xdg-utils
 
       - name: Setup Tauri signing key
         shell: bash
@@ -267,6 +269,11 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseDraft: true
           args: --target ${{ matrix.target }}
+
+      - name: Verify AppImage input methods
+        if: startsWith(matrix.platform, 'ubuntu')
+        shell: bash
+        run: ./.github/scripts/verify-appimage-input-methods.sh "target/${{ matrix.target }}/release/bundle/appimage"
 
       - name: Show sccache stats
         if: always()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -464,19 +464,6 @@ fn linux_webkit_environment_override<'a>(
 }
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn linux_system_gtk3_immodules_cache_path() -> Option<&'static str> {
-    [
-        "/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache",
-        "/usr/lib/aarch64-linux-gnu/gtk-3.0/3.0.0/immodules.cache",
-        "/usr/lib64/gtk-3.0/3.0.0/immodules.cache",
-        "/usr/lib/gtk-3.0/3.0.0/immodules.cache",
-    ]
-    .iter()
-    .copied()
-    .find(|path| std::path::Path::new(path).is_file())
-}
-
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn linux_appimage_wayland_backend_override(
     appimage: Option<&std::ffi::OsStr>,
     wayland_display: Option<&std::ffi::OsStr>,
@@ -514,31 +501,6 @@ fn linux_uses_native_wayland(
             .next()
             .is_some_and(|backend| backend.trim().eq_ignore_ascii_case("wayland"))
     })
-}
-
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn linux_appimage_system_gtk_immodules_cache(
-    appimage: Option<&std::ffi::OsStr>,
-    appdir: Option<&std::ffi::OsStr>,
-    gtk_im_module: Option<&std::ffi::OsStr>,
-    gtk_im_module_file: Option<&std::ffi::OsStr>,
-    system_cache_path: Option<&'static str>,
-) -> Option<&'static str> {
-    let system_cache_path = system_cache_path?;
-    if appimage.is_none() || gtk_im_module.is_none() {
-        return None;
-    }
-
-    let Some(gtk_im_module_file) = gtk_im_module_file else {
-        return Some(system_cache_path);
-    };
-    let appdir = appdir?;
-
-    if std::path::Path::new(gtk_im_module_file).starts_with(std::path::Path::new(appdir)) {
-        Some(system_cache_path)
-    } else {
-        None
-    }
 }
 
 #[cfg(target_os = "linux")]
@@ -579,18 +541,6 @@ fn apply_linux_webkit_rendering_workarounds() {
         std::env::var_os("GDK_BACKEND").as_deref(),
     ) {
         std::env::set_var("GDK_BACKEND", gdk_backend);
-    }
-    if let Some(gtk_im_module_file) = linux_appimage_system_gtk_immodules_cache(
-        std::env::var_os("APPIMAGE").as_deref(),
-        std::env::var_os("APPDIR").as_deref(),
-        std::env::var_os("GTK_IM_MODULE").as_deref(),
-        std::env::var_os("GTK_IM_MODULE_FILE").as_deref(),
-        linux_system_gtk3_immodules_cache_path(),
-    ) {
-        // linuxdeploy-plugin-gtk points GTK_IM_MODULE_FILE at the bundled
-        // cache. That hides host IM modules such as fcitx5/ibus, so prefer the
-        // host GTK cache when the user has configured a GTK input method.
-        std::env::set_var("GTK_IM_MODULE_FILE", gtk_im_module_file);
     }
 }
 
@@ -1003,21 +953,18 @@ pub(crate) fn apply_desktop_settings(app: &tauri::AppHandle, desktop_settings: &
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::{
-        app_menu_copy_support_info_label, app_menu_quit_label, linux_appimage_system_gtk_immodules_cache,
-        linux_appimage_wayland_backend_override, linux_drm_driver_is_software_only,
-        linux_drm_render_devices_from_paths, linux_nvidia_driver_from_state, linux_pci_id_from_sysfs_value,
-        linux_selected_drm_render_device, linux_uses_native_wayland, linux_webkit_environment_override,
-        linux_webkit_rendering_workarounds, native_window_decorations_override, should_confirm_app_exit_request,
-        should_enable_single_instance, should_fallback_to_native_quit, should_hide_window_on_close,
-        should_setup_desktop_tray, should_show_main_window_after_setup, should_show_main_window_before_setup_tasks,
-        startup_data_dir_mode, tray_menu_labels_for_locale, uses_application_level_icon, LinuxDrmRenderDevice,
-        LinuxNvidiaDriver,
+        app_menu_copy_support_info_label, app_menu_quit_label, linux_appimage_wayland_backend_override,
+        linux_drm_driver_is_software_only, linux_drm_render_devices_from_paths, linux_nvidia_driver_from_state,
+        linux_pci_id_from_sysfs_value, linux_selected_drm_render_device, linux_uses_native_wayland,
+        linux_webkit_environment_override, linux_webkit_rendering_workarounds, native_window_decorations_override,
+        should_confirm_app_exit_request, should_enable_single_instance, should_fallback_to_native_quit,
+        should_hide_window_on_close, should_setup_desktop_tray, should_show_main_window_after_setup,
+        should_show_main_window_before_setup_tasks, startup_data_dir_mode, tray_menu_labels_for_locale,
+        uses_application_level_icon, LinuxDrmRenderDevice, LinuxNvidiaDriver,
     };
     use crate::data_dir::DataDirMode;
     use std::ffi::OsStr;
     use std::path::{Path, PathBuf};
-
-    const TEST_GTK3_IMMODULES_CACHE: &str = "/usr/lib/test/gtk-3.0/3.0.0/immodules.cache";
 
     #[test]
     fn tray_menu_labels_follow_locale() {
@@ -1436,78 +1383,6 @@ mod tests {
         );
         assert_eq!(linux_appimage_wayland_backend_override(Some(OsStr::new("/tmp/DBX.AppImage")), None, None), None);
         assert_eq!(linux_appimage_wayland_backend_override(None, Some(OsStr::new("wayland-0")), None), None);
-    }
-
-    #[test]
-    fn prefers_system_gtk_immodules_cache_for_appimage_input_methods() {
-        assert_eq!(
-            linux_appimage_system_gtk_immodules_cache(
-                Some(OsStr::new("/tmp/DBX.AppImage")),
-                Some(OsStr::new("/tmp/.mount_DBX123")),
-                Some(OsStr::new("fcitx5")),
-                Some(OsStr::new("/tmp/.mount_DBX123/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache")),
-                Some(TEST_GTK3_IMMODULES_CACHE),
-            ),
-            Some(TEST_GTK3_IMMODULES_CACHE)
-        );
-        assert_eq!(
-            linux_appimage_system_gtk_immodules_cache(
-                Some(OsStr::new("/tmp/DBX.AppImage")),
-                Some(OsStr::new("/tmp/.mount_DBX123")),
-                Some(OsStr::new("ibus")),
-                None,
-                Some(TEST_GTK3_IMMODULES_CACHE),
-            ),
-            Some(TEST_GTK3_IMMODULES_CACHE)
-        );
-    }
-
-    #[test]
-    fn preserves_external_gtk_immodules_cache_overrides() {
-        assert_eq!(
-            linux_appimage_system_gtk_immodules_cache(
-                Some(OsStr::new("/tmp/DBX.AppImage")),
-                Some(OsStr::new("/tmp/.mount_DBX123")),
-                Some(OsStr::new("fcitx5")),
-                Some(OsStr::new("/opt/custom/immodules.cache")),
-                Some(TEST_GTK3_IMMODULES_CACHE),
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn skips_system_gtk_immodules_cache_without_required_context() {
-        assert_eq!(
-            linux_appimage_system_gtk_immodules_cache(
-                None,
-                Some(OsStr::new("/tmp/.mount_DBX123")),
-                Some(OsStr::new("fcitx5")),
-                Some(OsStr::new("/tmp/.mount_DBX123/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache")),
-                Some(TEST_GTK3_IMMODULES_CACHE),
-            ),
-            None
-        );
-        assert_eq!(
-            linux_appimage_system_gtk_immodules_cache(
-                Some(OsStr::new("/tmp/DBX.AppImage")),
-                Some(OsStr::new("/tmp/.mount_DBX123")),
-                None,
-                Some(OsStr::new("/tmp/.mount_DBX123/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache")),
-                Some(TEST_GTK3_IMMODULES_CACHE),
-            ),
-            None
-        );
-        assert_eq!(
-            linux_appimage_system_gtk_immodules_cache(
-                Some(OsStr::new("/tmp/DBX.AppImage")),
-                Some(OsStr::new("/tmp/.mount_DBX123")),
-                Some(OsStr::new("fcitx5")),
-                Some(OsStr::new("/tmp/.mount_DBX123/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules.cache")),
-                None,
-            ),
-            None
-        );
     }
 }
 


### PR DESCRIPTION
## 变更说明

修复 Linux AppImage 在 Fcitx 5、IBus 等 GTK 输入法环境中可能无法输入文字的问题。此前 AppImage 启动时会将其私有 `GTK_IM_MODULE_FILE` 替换为宿主系统的 GTK 3 输入法缓存，导致宿主输入法模块及客户端库与 AppImage 内较旧的 GLib 混合加载；在较新的 Linux 发行版上可能出现未定义符号并使 GTK 输入法上下文加载失败。

- 不再用宿主 GTK 3 输入法缓存覆盖 AppImage 私有的 `immodules.cache`
- 在项目现有的 Ubuntu 22.04 Linux release runner 中安装并打包 Fcitx 5 与 IBus 的 GTK 3 输入法模块，使模块、客户端库和 AppImage 内运行库保持同一 ABI 基线
- 保留现有 AppImage 私有 GTK 模块发现机制，不影响 deb、源码构建及用户显式设置的其它 Linux 环境变量
- 新增 AppImage 产物检查，确认包内包含 Fcitx 5、IBus 模块及对应客户端库，并确认私有 `immodules.cache` 同时注册两种输入法
- 校验符号链接最终仍位于 AppImage 内部，避免把宿主库误判为已打包依赖

该修复面向 Fcitx 5 与 IBus 的 GTK 3 集成层，而非只适配某个拼音引擎；Fcitx 5 下的拼音、Rime 等输入引擎均复用同一 GTK 前端。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [x] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 未修改前端组件、样式、交互或文案；下图用于展示修复后的 Linux AppImage 手动 E2E 结果。

### Ubuntu 26.04 arm64 桌面会话 + Fcitx 5 拼音验证

<img width="1440" height="900" alt="issue-4863-fcitx5-appimage" src="https://github.com/user-attachments/assets/4273c502-491a-498d-bf5c-ed0725ed8046" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

当前已完成：

- `make check`（connection-types、format、lint、typecheck、test 均通过）
- `make cargo-check-fast`
- `cargo test -p dbx --lib linux_`（14 个测试通过）
- `bash -n .github/scripts/verify-appimage-input-methods.sh`
- AppImage 校验器正向用例及缺失 IBus 模块的负向用例
- release workflow YAML 解析与 `git diff --check`
- 原生 arm64 `ubuntu:22.04` 干净容器打包探针：确认 linuxdeploy GTK 插件能自动收集 Fcitx 5、IBus 模块、传递依赖及缓存注册
- 原生 arm64 `ubuntu:22.04` 容器完整构建 AppImage，并通过新增的产物校验脚本；该环境对应项目现有 `ubuntu-22.04-arm` release runner 的发行基线
- Ubuntu 26.04 arm64 虚拟机桌面及 Fcitx 5 会话 + Ubuntu 24.04 Noble chroot 运行时手动 E2E：在此前可稳定复现失败的 Fcitx 5 拼音环境中，候选词可正常显示并可向 DBX 输入框提交中文；运行日志不再出现 Fcitx/GLib 未定义符号或输入法上下文加载失败

## 关联 Issue

Close #4863
