### PR TITLE
feat(ddl): DDL 页面搜索统一与 Hover 快捷导航

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -241,6 +241,7 @@ const settingsNavigationRequestId = ref(0);
 const settingsAiConfigDraft = ref<AiConfigDeepLinkDraft | null>(null);
 const settingsAiConfigRequestId = ref(0);
 const showQueryEditorDdlDialog = ref(false);
+const queryEditorDdlAutoSearch = ref(false);
 const showQueryEditorObjectSourceDialog = ref(false);
 const driverStoreTabOpen = ref(false);
 const driverStoreActive = ref(false);
@@ -2000,6 +2001,7 @@ async function onClickTable(table: SqlObjectNavigationTarget) {
   if (objectType) {
     // Definition navigation for views must not run the view query, which may be expensive or have side effects upstream.
     queryEditorDdlTarget.value = { ...target, objectType };
+    queryEditorDdlAutoSearch.value = false;
     showQueryEditorDdlDialog.value = true;
     return;
   }
@@ -2028,6 +2030,16 @@ function onViewTableDdl(table: SqlObjectNavigationTarget) {
   const target = tableTargetFromActiveTab(table);
   if (!target) return;
   queryEditorDdlTarget.value = { ...target, objectType: sqlObjectNavigationSourceKind(table) };
+  queryEditorDdlAutoSearch.value = false;
+  showQueryEditorDdlDialog.value = true;
+}
+
+function openDdlViewerFromHover(event: Event) {
+  if (!(event instanceof CustomEvent) || !event.detail) return;
+  const target = event.detail as typeof queryEditorDdlTarget.value;
+  if (!target?.connectionId || !target.database || !target.tableName) return;
+  queryEditorDdlTarget.value = target;
+  queryEditorDdlAutoSearch.value = Boolean((event.detail as any)?.autoOpenSearch);
   showQueryEditorDdlDialog.value = true;
 }
 
@@ -2871,6 +2883,7 @@ onMounted(async () => {
   window.addEventListener("blur", handleTabSwitcherWindowBlur);
   document.addEventListener("visibilitychange", handleTabSwitcherVisibilityChange);
   window.addEventListener("dbx-open-driver-store", openDriverStoreFromEvent);
+  window.addEventListener("dbx-open-ddl-viewer", openDdlViewerFromHover);
   window.addEventListener("dbx:activate-query-surface", activateQuerySurface);
   window.addEventListener("dbx-mcp-status-changed", handleMcpStatusChanged);
   window.addEventListener("dbx:ai-run-notify", handleAiRunNotify);
@@ -2934,6 +2947,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  window.removeEventListener("dbx-open-ddl-viewer", openDdlViewerFromHover);
   cleanupTauriListeners();
   cleanupCloseActionPromptListener();
   if (updateCheckTimer) {
@@ -3401,6 +3415,7 @@ onUnmounted(() => {
         :object-type="queryEditorDdlTarget.objectType"
         :database-type="queryEditorDdlDatabaseType"
         :dialect="queryEditorDdlDialect"
+        :auto-open-search="queryEditorDdlAutoSearch"
       />
       <QueryEditorObjectSourceDialog
         v-if="queryEditorObjectSourceTarget"

--- a/apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue
@@ -11,7 +11,7 @@ import { buildHunks, type DiffLine } from "@/components/diff/DiffHunkBuilder";
 import { buildSchemaDiffHighlightSegments, type SchemaDiffHighlightSegment } from "@/lib/schema/schemaDiffHighlight";
 import { findSchemaDiffDdlLineNumber } from "@/lib/schema/schemaDiffDdlLocate";
 import DiffSvgConnector from "@/components/diff/DiffSvgConnector.vue";
-import { FileCode, ScrollText, Copy, Play, FileDiff } from "@lucide/vue";
+import { FileCode, ScrollText, Copy, Play, FileDiff, Search, ChevronUp, ChevronDown, X } from "@lucide/vue";
 import { Splitpanes, Pane } from "splitpanes";
 import "splitpanes/dist/splitpanes.css";
 import type { SchemaDiffObject, CompatibilityWarning, DependencyGraph, PermissionDiff, MissingRollbackObject, RollbackCompleteness } from "@/lib/schema/schemaDiff";
@@ -62,6 +62,44 @@ const containerSize = ref({ width: 0, height: 0 });
 const connectorKey = ref(0);
 const focusedSourceLineNumber = ref<number | null>(null);
 const focusedTargetLineNumber = ref<number | null>(null);
+const ddlSearchQuery = ref("");
+const ddlSearchIndex = ref(0);
+
+type DdlSearchMatch = { side: "source" | "target"; lineNumber: number; hunkId: string | number };
+const ddlSearchMatches = computed<DdlSearchMatch[]>(() => {
+  const query = ddlSearchQuery.value.trim().toLocaleLowerCase();
+  if (!query) return [];
+  const matches: DdlSearchMatch[] = [];
+  for (const hunk of hunks.value) {
+    for (const line of hunk.leftLines) if (!line.isPadding && line.content.toLocaleLowerCase().includes(query)) matches.push({ side: "source", lineNumber: line.lineNumber ?? 0, hunkId: hunk.id });
+    for (const line of hunk.rightLines) if (!line.isPadding && line.content.toLocaleLowerCase().includes(query)) matches.push({ side: "target", lineNumber: line.lineNumber ?? 0, hunkId: hunk.id });
+  }
+  return matches;
+});
+const activeDdlSearchMatch = computed(() => ddlSearchMatches.value[ddlSearchIndex.value] ?? null);
+watch(ddlSearchQuery, () => {
+  ddlSearchIndex.value = 0;
+});
+
+function navigateDdlSearch(delta: number) {
+  const count = ddlSearchMatches.value.length;
+  if (!count) return;
+  ddlSearchIndex.value = (ddlSearchIndex.value + delta + count) % count;
+  const match = activeDdlSearchMatch.value;
+  if (!match) return;
+  const pane = match.side === "source" ? leftPaneRef.value : rightPaneRef.value;
+  scrollPaneToLine(pane, match.lineNumber);
+}
+
+function isDdlSearchMatch(line: DiffLine, side: "source" | "target", hunkId: string | number): boolean {
+  const query = ddlSearchQuery.value.trim().toLocaleLowerCase();
+  return !!query && !line.isPadding && line.content.toLocaleLowerCase().includes(query) && ddlSearchMatches.value.some((m) => m.side === side && m.hunkId === hunkId && m.lineNumber === line.lineNumber);
+}
+
+function isActiveDdlSearchMatch(line: DiffLine, side: "source" | "target", hunkId: string | number): boolean {
+  const match = activeDdlSearchMatch.value;
+  return !!match && match.side === side && match.hunkId === hunkId && match.lineNumber === line.lineNumber;
+}
 
 const rollbackDiffContainerRef = ref<HTMLDivElement>();
 const rollbackLeftPaneRef = ref<HTMLDivElement>();
@@ -183,6 +221,7 @@ function rollbackUpdateContainerSize() {
 }
 
 watch([() => props.selectedObject?.id, () => props.focusedObject?.id, hunks], async () => {
+  ddlSearchIndex.value = 0;
   if (props.focusedObject?.parentId) activeTab.value = "ddl";
   await nextTick();
   updateContainerSize();
@@ -332,6 +371,17 @@ function copyDeploySqlAll() {
       </button>
     </div>
 
+    <div v-if="activeTab === 'ddl'" class="flex items-center gap-1.5 px-3 py-1.5 border-b bg-background shrink-0">
+      <div class="relative min-w-0 flex-1 max-w-sm">
+        <Search class="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <input v-model="ddlSearchQuery" class="h-7 w-full rounded border bg-muted/30 pl-7 pr-7 text-xs outline-none focus:border-primary/50" :placeholder="t('grid.search')" @keydown.enter.prevent="navigateDdlSearch($event.shiftKey ? -1 : 1)" />
+        <button v-if="ddlSearchQuery" type="button" class="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground" :aria-label="t('common.clear')" @click="ddlSearchQuery = ''"><X class="h-3 w-3" /></button>
+      </div>
+      <span class="w-12 text-center text-[11px] tabular-nums text-muted-foreground">{{ ddlSearchQuery ? `${ddlSearchMatches.length ? ddlSearchIndex + 1 : 0}/${ddlSearchMatches.length}` : "" }}</span>
+      <button type="button" class="h-7 w-7 rounded text-muted-foreground hover:bg-muted disabled:opacity-40" :disabled="!ddlSearchMatches.length" :aria-label="t('search.prevMatch')" @click="navigateDdlSearch(-1)"><ChevronUp class="h-3.5 w-3.5 mx-auto" /></button>
+      <button type="button" class="h-7 w-7 rounded text-muted-foreground hover:bg-muted disabled:opacity-40" :disabled="!ddlSearchMatches.length" :aria-label="t('search.nextMatch')" @click="navigateDdlSearch(1)"><ChevronDown class="h-3.5 w-3.5 mx-auto" /></button>
+    </div>
+
     <!-- DDL Compare -->
     <div v-if="activeTab === 'ddl'" class="flex-1 overflow-hidden relative">
       <!-- No object selected -->
@@ -352,7 +402,14 @@ function copyDeploySqlAll() {
                 {{ t("diff.sourceDdl") }}
               </div>
               <div v-for="hunk in hunks" :key="`left-${hunk.id}`" :data-hunk-id="hunk.id">
-                <div v-for="(line, idx) in hunk.leftLines" :key="`l-${hunk.id}-${idx}`" class="flex min-h-[1.5em]" :class="focusedLineClass(line, 'source')" :data-ddl-line-number="line.lineNumber ?? undefined" :style="{ backgroundColor: lineBackground(line) }">
+                <div
+                  v-for="(line, idx) in hunk.leftLines"
+                  :key="`l-${hunk.id}-${idx}`"
+                  class="flex min-h-[1.5em]"
+                  :class="[focusedLineClass(line, 'source'), isDdlSearchMatch(line, 'source', hunk.id) ? 'bg-amber-500/15' : '', isActiveDdlSearchMatch(line, 'source', hunk.id) ? 'outline outline-1 -outline-offset-1 outline-primary' : '']"
+                  :data-ddl-line-number="line.lineNumber ?? undefined"
+                  :style="{ backgroundColor: lineBackground(line) }"
+                >
                   <span class="text-muted-foreground w-8 text-right pr-2 select-none shrink-0">
                     {{ line.lineNumber ?? "" }}
                   </span>
@@ -376,7 +433,14 @@ function copyDeploySqlAll() {
                 {{ t("diff.targetDdl") }}
               </div>
               <div v-for="hunk in hunks" :key="`right-${hunk.id}`" :data-hunk-id="hunk.id">
-                <div v-for="(line, idx) in hunk.rightLines" :key="`r-${hunk.id}-${idx}`" class="flex min-h-[1.5em]" :class="focusedLineClass(line, 'target')" :data-ddl-line-number="line.lineNumber ?? undefined" :style="{ backgroundColor: lineBackground(line) }">
+                <div
+                  v-for="(line, idx) in hunk.rightLines"
+                  :key="`r-${hunk.id}-${idx}`"
+                  class="flex min-h-[1.5em]"
+                  :class="[focusedLineClass(line, 'target'), isDdlSearchMatch(line, 'target', hunk.id) ? 'bg-amber-500/15' : '', isActiveDdlSearchMatch(line, 'target', hunk.id) ? 'outline outline-1 -outline-offset-1 outline-primary' : '']"
+                  :data-ddl-line-number="line.lineNumber ?? undefined"
+                  :style="{ backgroundColor: lineBackground(line) }"
+                >
                   <span class="text-muted-foreground w-8 text-right pr-2 select-none shrink-0">
                     {{ line.lineNumber ?? "" }}
                   </span>

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -2605,8 +2605,9 @@ async function ensureForeignKeysForTables(tables: Array<{ name: string; database
   }
 }
 
-function createHoverDom(title: string, detail: string, sqlContent?: string, rows: string[] = []): { dom: HTMLElement; mount?: () => void; destroy?: () => void } {
+function createHoverDom(title: string, detail: string, sqlContent?: string, rows: string[] = [], openDdlTarget?: Record<string, unknown>): { dom: HTMLElement; mount?: () => void; destroy?: () => void } {
   const dom = document.createElement("div");
+  dom.tabIndex = 0;
   dom.className = "rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md";
 
   const heading = document.createElement("div");
@@ -2621,6 +2622,7 @@ function createHoverDom(title: string, detail: string, sqlContent?: string, rows
 
   let layoutController: ReturnType<typeof constrainSqlHoverLayout> | null = null;
   let handleCopy: ((event: ClipboardEvent) => void) | null = null;
+  let handleHoverKeydown: ((event: KeyboardEvent) => void) | null = null;
 
   if (sqlContent) {
     heading.className = "flex items-center justify-between gap-3 font-medium";
@@ -2650,6 +2652,27 @@ function createHoverDom(title: string, detail: string, sqlContent?: string, rows
       })();
     });
     heading.appendChild(copyButton);
+
+    handleHoverKeydown = (event) => {
+      if (!(event instanceof KeyboardEvent) || !(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "f" || !openDdlTarget) return;
+      event.preventDefault();
+      event.stopPropagation();
+      window.dispatchEvent(new CustomEvent("dbx-open-ddl-viewer", { detail: { ...openDdlTarget, autoOpenSearch: true } }));
+    };
+
+    if (openDdlTarget) {
+      const openButton = document.createElement("button");
+      openButton.type = "button";
+      openButton.className = "rounded border border-border/60 px-1.5 py-0.5 text-[11px] leading-none text-muted-foreground hover:bg-accent hover:text-accent-foreground";
+      openButton.textContent = t("contextMenu.viewDdl");
+      openButton.title = t("contextMenu.viewDdl");
+      openButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        window.dispatchEvent(new CustomEvent("dbx-open-ddl-viewer", { detail: openDdlTarget }));
+      });
+      heading.appendChild(openButton);
+    }
 
     const separator = document.createElement("div");
     separator.className = "mt-2 border-t border-border/60";
@@ -2703,6 +2726,7 @@ function createHoverDom(title: string, detail: string, sqlContent?: string, rows
         ? () => {
             layoutController?.mount();
             if (handleCopy) document.addEventListener("copy", handleCopy);
+            if (handleHoverKeydown) document.addEventListener("keydown", handleHoverKeydown, true);
           }
         : undefined,
     destroy:
@@ -2710,6 +2734,7 @@ function createHoverDom(title: string, detail: string, sqlContent?: string, rows
         ? () => {
             layoutController?.destroy();
             if (handleCopy) document.removeEventListener("copy", handleCopy);
+            if (handleHoverKeydown) document.removeEventListener("keydown", handleHoverKeydown, true);
           }
         : undefined,
   };
@@ -2835,7 +2860,7 @@ async function resolveSqlHoverTooltip(currentView: EditorViewType, pos: number) 
       return {
         pos: range.from,
         end: range.to,
-        create: () => createHoverDom(table.name, sqlObjectHoverDetail(table), sqlContent, metadataLoadFailed ? ["[DBX] Failed to load table structure — check connection"] : undefined),
+        create: () => createHoverDom(table.name, sqlObjectHoverDetail(table), sqlContent, metadataLoadFailed ? ["[DBX] Failed to load table structure — check connection"] : undefined, { ...objectMetadataRequest }),
       };
     }
 

--- a/apps/desktop/src/components/objects/DdlViewDialog.vue
+++ b/apps/desktop/src/components/objects/DdlViewDialog.vue
@@ -31,6 +31,8 @@ const props = withDefaults(
     dialect: "mysql" | "postgres" | "sqlserver";
     /** SQL formatter dialect. Kept separate from the syntax-highlighting dialect because several PG-compatible DBs highlight as MySQL. */
     formatDialect?: SqlFormatDialect;
+    /** Open the search panel automatically when opened from a hover shortcut. */
+    autoOpenSearch?: boolean;
   }>(),
   {},
 );
@@ -89,6 +91,11 @@ watch(
     editorRootToRestoreFocus = active instanceof HTMLElement ? active.closest(".cm-editor") : null;
     ddlContent.value = "";
     await loadDdl();
+    if (props.autoOpenSearch) {
+      await nextTick();
+      await nextTick();
+      ddlSearchPanelRef.value?.openSearch();
+    }
   },
   { immediate: true },
 );

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -277,6 +277,15 @@ async function initDdlEditor(content: string) {
 function scheduleDdlEditorInit() {
   void nextTick(() => {
     if (activeTab.value !== "ddl" || loading.value || ddlLoading.value) return;
+    // TabsContent may mount its panel one tick after the active tab changes.
+    // Retry once when the container ref is not available; otherwise the old
+    // editor is destroyed on tab leave and never recreated on return.
+    if (!ddlEditorContainer.value) {
+      window.setTimeout(() => {
+        if (activeTab.value === "ddl" && !loading.value && !ddlLoading.value) void initDdlEditor(ddlEditorDocument());
+      }, 0);
+      return;
+    }
     void initDdlEditor(ddlEditorDocument());
   });
 }


### PR DESCRIPTION
- 为 Schema Diff DDL 对比页增加 Source / Target 双栏全文搜索
- 复用 DDL 查看窗口的搜索交互，支持匹配统计、上下跳转和自动定位
- 为 SQL 编辑器表名 Hover DDL 增加“查看 DDL”入口
- 拦截 Hover 状态下的 Ctrl/Cmd + F，避免误触发 SQL 编辑器搜索
- 从 Hover 打开完整 DDL 时自动展开搜索面板
- 修复表结构编辑器在“DDL -> 字段 -> DDL”切换后内容为空的问题

## 变更说明

本 PR 补齐 DDL 相关页面的字段搜索能力，并统一不同入口的搜索路径。

Schema Diff DDL 搜索
Schema Diff 原先只展示左右两份静态 DDL diff，没有搜索框，也无法通过字段名定位差异。现在在 DDL Compare 标签页增加统一搜索栏：

同时搜索 Source DDL 和 Target DDL；
匹配字段名、字段类型、默认值、注释、索引、约束等 DDL 文本；
显示当前匹配序号和总匹配数；
支持上一个/下一个按钮；
支持 Enter 跳转下一个，Shift+Enter 跳转上一个；
当前匹配自动滚动到对应的 Source 或 Target pane；
所有匹配行使用淡色高亮，当前匹配使用边框强调；
切换对象或 DDL 内容后重置当前匹配位置。
原有的左右滚动同步、字符级差异高亮、对象定位和 SVG 差异连线均保留。

Hover DDL 快捷导航
SQL 编辑器中的表名 Hover DDL 仍然保持轻量预览和复制能力，并新增“查看 DDL”按钮。点击后通过统一的 DdlViewDialog 打开完整 DDL 页面，从而使用 CodeMirror 和 EditorSearchPanel 提供完整搜索能力。

Hover Tooltip 存在期间，Ctrl/Cmd + F 会在捕获阶段被拦截，不再打开 SQL 编辑器自身的搜索面板；应用会打开完整 DDL 查看窗口，并自动展开 DDL 搜索面板。普通 SQL 编辑器没有 Hover Tooltip 时，快捷键行为保持不变。

Hover 和完整 DDL 页面继续共享 loadObjectDdl() 及对象 DDL 缓存，不创建第二份 DDL 数据源。

表结构编辑器切换修复
表结构编辑器切换到字段页时会销毁 DDL CodeMirror 实例。由于 TabsContent 的容器可能延迟挂载，切回 DDL 时初始化函数偶尔会在容器不存在的情况下提前返回，导致 DDL 区域为空。

现在切回 DDL 时，如果容器尚未完成挂载，会在下一个事件循环重新尝试创建编辑器。已有 DDL 内容会继续复用，不会额外重复请求数据库。

## 变更类型

- [x] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [x] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 主要文件

| 文件 | 变更 |
| --- | --- |
| `apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue` | 双栏 DDL 搜索、匹配高亮、计数、上下跳转和滚动定位 |
| `apps/desktop/src/components/editor/QueryEditor.vue` | Hover DDL 查看按钮和 `Ctrl/Cmd + F` 拦截 |
| `apps/desktop/src/components/objects/DdlViewDialog.vue` | 支持从 Hover 打开时自动展开搜索面板 |
| `apps/desktop/src/App.vue` | 接收 Hover DDL 打开事件并路由到统一 DDL 查看窗口 |
| `apps/desktop/src/components/structure/TableStructureEditor.vue` | 修复 DDL Tab 延迟挂载导致的空白问题 |

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="1496" height="346" alt="image" src="https://github.com/user-attachments/assets/3e398544-79f9-4585-b4cd-c6010b02ff09" />

## 验证


### Schema Diff

1. 打开 Schema Diff 并进入 DDL Compare 标签。
2. 在搜索框输入字段名或类型关键字。
3. 确认 Source / Target 两侧命中行均被高亮，并显示匹配数量。
4. 点击上下按钮，确认当前匹配在两侧正确循环跳转。
5. 使用 Enter / Shift+Enter，确认跳转方向正确且对应 pane 自动滚动。
6. 切换对象后确认搜索位置重置，原有 diff 高亮和滚动同步仍可用。

### Hover DDL

1. 在 SQL 编辑器中将鼠标悬停到表名上。
2. 确认 Hover 中显示 DDL、复制按钮和“查看 DDL”按钮。
3. 点击“查看 DDL”，确认打开完整 DDL 窗口。
4. 在 Hover 显示期间按 Ctrl/Cmd+F，确认不会打开 SQL 编辑器搜索，而是打开完整 DDL 并自动显示搜索面板。
5. 关闭 Hover 后再次按 Ctrl/Cmd+F，确认恢复 SQL 编辑器搜索行为。

### 表结构编辑器

1. 打开表结构编辑器并进入 DDL 标签。
2. 切换到字段标签，再切回 DDL 标签。
3. 确认 DDL 内容正常显示，且 Ctrl/Cmd+F 搜索仍可用。
4. 确认切换过程不会清空已加载 DDL，也不会产生不必要的重复请求。


- [x] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue
