### PR TITLE
fix(sql): 达梦分页方言改用全版本兼容的 ROWNUM 语法

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.snippet.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.snippet.spec.ts
@@ -76,7 +76,7 @@ describe("buildSnippetItems", () => {
     ["oscar", "SELECT *\nFROM table\nWHERE ROWNUM <= 100;", "SELECT *\nFROM ${table}\nWHERE ROWNUM <= 100;"],
     ["xugu", "SELECT *\nFROM table\nLIMIT 100;", "SELECT *\nFROM ${table}\nLIMIT 100;"],
     ["yashandb", "SELECT *\nFROM table\nLIMIT 100;", "SELECT *\nFROM ${table}\nLIMIT 100;"],
-    ["dameng", "SELECT *\nFROM table\nFETCH FIRST 100 ROWS ONLY;", "SELECT *\nFROM ${table}\nFETCH FIRST 100 ROWS ONLY;"],
+    ["dameng", "SELECT *\nFROM table\nWHERE ROWNUM <= 100;", "SELECT *\nFROM ${table}\nWHERE ROWNUM <= 100;"],
     ["db2", "SELECT *\nFROM table\nFETCH FIRST 100 ROWS ONLY;", "SELECT *\nFROM ${table}\nFETCH FIRST 100 ROWS ONLY;"],
     ["sqlserver", "SELECT TOP 100 *\nFROM table;", "SELECT TOP 100 *\nFROM ${table};"],
     ["access", "SELECT TOP 100 *\nFROM table;", "SELECT TOP 100 *\nFROM ${table};"],

--- a/apps/desktop/src/lib/sql/sqlSnippetTemplates.ts
+++ b/apps/desktop/src/lib/sql/sqlSnippetTemplates.ts
@@ -135,7 +135,7 @@ const SELECT_SNIPPET_LIMIT_STYLE_BY_DATABASE: Partial<Record<DatabaseType, Selec
   oracle: "rownum",
   "oceanbase-oracle": "rownum",
   oscar: "rownum",
-  dameng: "fetch-first",
+  dameng: "rownum",
   db2: "fetch-first",
   sqlserver: "top",
   access: "top",

--- a/crates/dbx-core/src/sql_dialect/capabilities.rs
+++ b/crates/dbx-core/src/sql_dialect/capabilities.rs
@@ -104,7 +104,7 @@ pub fn pagination_strategy(database_type: Option<DatabaseType>, context: Paginat
             TablePaginationStrategy::Rownum
         }
         Some(DatabaseType::Oscar) => TablePaginationStrategy::Unbounded,
-        Some(DatabaseType::Dameng) => TablePaginationStrategy::FetchFirst,
+        Some(DatabaseType::Dameng) => TablePaginationStrategy::Rownum,
         Some(DatabaseType::Db2) => TablePaginationStrategy::Db2FetchFirst,
         Some(DatabaseType::SqlServer) => TablePaginationStrategy::SqlServerTop,
         Some(DatabaseType::Iris) => TablePaginationStrategy::IrisTop,

--- a/crates/dbx-core/src/sql_dialect/tests.rs
+++ b/crates/dbx-core/src/sql_dialect/tests.rs
@@ -136,7 +136,7 @@ fn qualifies_schema_only_for_schema_aware_databases() {
 #[test]
 fn maps_table_pagination_strategy_by_database_type() {
     assert_eq!(table_pagination_strategy(Some(DatabaseType::Mysql)), TablePaginationStrategy::LimitOffset);
-    assert_eq!(table_pagination_strategy(Some(DatabaseType::Dameng)), TablePaginationStrategy::FetchFirst);
+    assert_eq!(table_pagination_strategy(Some(DatabaseType::Dameng)), TablePaginationStrategy::Rownum);
     assert_eq!(table_pagination_strategy(Some(DatabaseType::Db2)), TablePaginationStrategy::Db2FetchFirst);
     assert_eq!(table_pagination_strategy(Some(DatabaseType::SqlServer)), TablePaginationStrategy::SqlServerTop);
     assert_eq!(table_pagination_strategy(Some(DatabaseType::Iris)), TablePaginationStrategy::IrisTop);
@@ -238,6 +238,17 @@ fn builds_select_sql_with_limit_syntax_for_database_type() {
             limit: 100,
         }),
         "SELECT \"id\", \"name\" FROM (SELECT \"id\", \"name\" FROM \"DBXTEST\".\"USERS\" ORDER BY \"id\" ASC) WHERE ROWNUM <= 100"
+    );
+    assert_eq!(
+        build_table_select_sql(TableSelectSqlOptions {
+            database_type: Some(DatabaseType::Dameng),
+            schema: Some("SYSDBA"),
+            table_name: "USERS",
+            columns: &columns,
+            order_columns: &keys,
+            limit: 100,
+        }),
+        "SELECT \"id\", \"name\" FROM (SELECT \"id\", \"name\" FROM \"SYSDBA\".\"USERS\" ORDER BY \"id\" ASC) WHERE ROWNUM <= 100"
     );
     // JDBC connections skip SQL-level row limiting — the JDBC agent handles
     // it via Statement.setMaxRows() which is universally supported.


### PR DESCRIPTION
## 变更说明

1. **问题 1（Schema 扫描不全与元数据缺失）**：已在前序 PR #7432 中处理（字典视图缺失时自动降级使`DatabaseMetaData`），包含在下个版本中。
2. **问题 2 & 3（点击表报错 `FETCH FIRST` 及 SQL 执行失败）**：
   - **根因**：达梦 6 不支持 ANSI `FETCH FIRST ... ROWS ONLY` 语法，导致点击表生成的分页 SQL 在发送给驱动执行时抛出语法错误；但达梦全版本（DM6/DM7/DM8）均支持 `ROWNUM` 伪列。
   - **修复**：本 PR 将达梦的表分页方言调整为 `TablePaginationStrategy::Rownum`，解决分页及 SQL 执行问题。
   - **前端与测试同步**：将前端 select snippet 补全模板风格同步切换为 `rownum`，并更新 Rust 核心方言与前端补全单元测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）
*(非 UI 视觉组件改动)*

## 验证

- [x] 相关测试通过
  - 前端 Vitest `sqlCompletion.snippet.spec.ts` 测试通过
  - Rust `sql_dialect::tests` 核心方言单元测试对齐并通过

## 关联 Issue

Related #7503

