### PR TITLE
Improve：调整表数据页总计刷新按钮位置

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -14086,20 +14086,23 @@ function openGridSnapshot() {
               count: result.rows.length,
             })
           }}
-          <button
-            v-if="showRerunTotalCountAction && !(totalRowCountBusy && !manualTotalRowCountLoading)"
-            type="button"
-            class="mr-1 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm align-middle text-muted-foreground/70 hover:bg-gray-200 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-gray-800"
-            :disabled="manualTotalRowCountLoading"
-            :aria-busy="manualTotalRowCountLoading ? 'true' : undefined"
-            :title="manualTotalRowCountLoading ? t('grid.totalRowCountLoading') : t('grid.calculateTotalRows')"
-            :aria-label="manualTotalRowCountLoading ? t('grid.totalRowCountLoading') : t('grid.calculateTotalRows')"
-            @click="calculateTotalRowCount"
-          >
-            <Loader2 v-if="manualTotalRowCountLoading" aria-hidden="true" class="h-3 w-3 animate-spin" />
-            <RefreshCcw v-else aria-hidden="true" class="h-3 w-3" />
-          </button>
-          <span v-if="typeof displayedTotalRowCount === 'number' && displayedTotalRowCount >= 0" class="text-muted-foreground/70">{{ t(totalRowCountLabelKey, { count: displayedTotalRowCount }) }}</span>
+          <i18n-t v-if="showRerunTotalCountAction && !(totalRowCountBusy && !manualTotalRowCountLoading)" keypath="grid.totalRowCountWithAction" tag="span" class="text-muted-foreground/70" :values="{ count: displayedTotalRowCount }">
+            <template #button>
+              <button
+                type="button"
+                class="mr-1 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm align-middle text-muted-foreground/70 hover:bg-gray-200 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-gray-800"
+                :disabled="manualTotalRowCountLoading"
+                :aria-busy="manualTotalRowCountLoading ? 'true' : undefined"
+                :title="manualTotalRowCountLoading ? t('grid.totalRowCountLoading') : t('grid.calculateTotalRows')"
+                :aria-label="manualTotalRowCountLoading ? t('grid.totalRowCountLoading') : t('grid.calculateTotalRows')"
+                @click="calculateTotalRowCount"
+              >
+                <Loader2 v-if="manualTotalRowCountLoading" aria-hidden="true" class="h-3 w-3 animate-spin" />
+                <RefreshCcw v-else aria-hidden="true" class="h-3 w-3" />
+              </button>
+            </template>
+          </i18n-t>
+          <span v-else-if="typeof displayedTotalRowCount === 'number' && displayedTotalRowCount >= 0" class="text-muted-foreground/70">{{ t(totalRowCountLabelKey, { count: displayedTotalRowCount }) }}</span>
           <span v-if="totalRowCountBusy && !(showRerunTotalCountAction && manualTotalRowCountLoading)" class="text-muted-foreground/70">
             {{ t("grid.totalRowCountLoading") }}
           </span>

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -14086,7 +14086,7 @@ function openGridSnapshot() {
               count: result.rows.length,
             })
           }}
-          <i18n-t v-if="showRerunTotalCountAction && !(totalRowCountBusy && !manualTotalRowCountLoading)" keypath="grid.totalRowCountWithAction" tag="span" class="text-muted-foreground/70" :values="{ count: displayedTotalRowCount }">
+          <i18n-t v-if="showRerunTotalCountAction && !(totalRowCountBusy && !manualTotalRowCountLoading)" keypath="grid.totalRowCountWithAction" tag="span" class="text-muted-foreground/70">
             <template #button>
               <button
                 type="button"
@@ -14101,6 +14101,7 @@ function openGridSnapshot() {
                 <RefreshCcw v-else aria-hidden="true" class="h-3 w-3" />
               </button>
             </template>
+            <template #count>{{ displayedTotalRowCount }}</template>
           </i18n-t>
           <span v-else-if="typeof displayedTotalRowCount === 'number' && displayedTotalRowCount >= 0" class="text-muted-foreground/70">{{ t(totalRowCountLabelKey, { count: displayedTotalRowCount }) }}</span>
           <span v-if="totalRowCountBusy && !(showRerunTotalCountAction && manualTotalRowCountLoading)" class="text-muted-foreground/70">

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -14086,17 +14086,10 @@ function openGridSnapshot() {
               count: result.rows.length,
             })
           }}
-          <span v-if="typeof displayedTotalRowCount === 'number' && displayedTotalRowCount >= 0" class="text-muted-foreground/70">{{ t(totalRowCountLabelKey, { count: displayedTotalRowCount }) }}</span>
-          <span v-if="totalRowCountBusy && !(showRerunTotalCountAction && manualTotalRowCountLoading)" class="text-muted-foreground/70">
-            {{ t("grid.totalRowCountLoading") }}
-          </span>
-          <button v-else-if="showExactTotalCountAction" type="button" class="text-muted-foreground/70 underline underline-offset-2 hover:text-foreground disabled:pointer-events-none" :disabled="manualTotalRowCountLoading" @click="calculateTotalRowCount">
-            {{ t("grid.calculateTotalRowsInline") }}
-          </button>
           <button
-            v-else-if="showRerunTotalCountAction"
+            v-if="showRerunTotalCountAction && !(totalRowCountBusy && !manualTotalRowCountLoading)"
             type="button"
-            class="ml-1 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm align-middle text-muted-foreground/70 hover:bg-gray-200 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-gray-800"
+            class="mr-1 inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm align-middle text-muted-foreground/70 hover:bg-gray-200 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-gray-800"
             :disabled="manualTotalRowCountLoading"
             :aria-busy="manualTotalRowCountLoading ? 'true' : undefined"
             :title="manualTotalRowCountLoading ? t('grid.totalRowCountLoading') : t('grid.calculateTotalRows')"
@@ -14105,6 +14098,13 @@ function openGridSnapshot() {
           >
             <Loader2 v-if="manualTotalRowCountLoading" aria-hidden="true" class="h-3 w-3 animate-spin" />
             <RefreshCcw v-else aria-hidden="true" class="h-3 w-3" />
+          </button>
+          <span v-if="typeof displayedTotalRowCount === 'number' && displayedTotalRowCount >= 0" class="text-muted-foreground/70">{{ t(totalRowCountLabelKey, { count: displayedTotalRowCount }) }}</span>
+          <span v-if="totalRowCountBusy && !(showRerunTotalCountAction && manualTotalRowCountLoading)" class="text-muted-foreground/70">
+            {{ t("grid.totalRowCountLoading") }}
+          </span>
+          <button v-else-if="showExactTotalCountAction" type="button" class="text-muted-foreground/70 underline underline-offset-2 hover:text-foreground disabled:pointer-events-none" :disabled="manualTotalRowCountLoading" @click="calculateTotalRowCount">
+            {{ t("grid.calculateTotalRowsInline") }}
           </button>
         </span>
         <span v-if="showTruncationWarning" class="shrink-0 text-amber-500 text-xs">(truncated)</span>

--- a/apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts
@@ -61,6 +61,7 @@ describe("DataGrid rerun total row count action", () => {
   });
 
   it("renders a spaced rerun icon labelled for the total-count action and disabled while counting", () => {
+    expect(statusRenderSource).toContain('keypath: "grid.totalRowCountWithAction"');
     expect(rerunBranch).toContain('<button type="button" class="mr-1 inline-flex h-3.5 w-3.5');
     expect(rerunBranch).toContain("disabled:pointer-events-none");
     expect(rerunBranch).toContain("disabled:opacity-50");

--- a/apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts
@@ -12,7 +12,7 @@ const statusRenderSource = (() => {
 })();
 
 const rerunBranch = (() => {
-  const start = statusRenderSource.indexOf("} else if ($setup.showRerunTotalCountAction) {");
+  const start = statusRenderSource.indexOf("$setup.showRerunTotalCountAction && !($setup.totalRowCountBusy && !$setup.manualTotalRowCountLoading)");
   return start === -1 ? "" : statusRenderSource.slice(start, statusRenderSource.indexOf("</button>", start));
 })();
 
@@ -48,19 +48,20 @@ describe("DataGrid rerun total row count action", () => {
     expect(showDataGridRerunTotalCountAction({ canCalculateTotalRowCount: true, displayedTotalRowCount: NaN, totalRowCountIsExact: true })).toBe(false);
   });
 
-  it("keeps the numeric total outside the action chain and orders busy, inline link, then rerun icon", () => {
+  it("places the rerun icon before the numeric total and keeps the other actions ordered", () => {
     const numericTotal = statusRenderSource.indexOf('typeof $setup.displayedTotalRowCount === "number" && $setup.displayedTotalRowCount >= 0');
+    const rerunAction = statusRenderSource.indexOf("$setup.showRerunTotalCountAction && !($setup.totalRowCountBusy && !$setup.manualTotalRowCountLoading)");
     const busyBranch = statusRenderSource.indexOf("if ($setup.totalRowCountBusy && !($setup.showRerunTotalCountAction && $setup.manualTotalRowCountLoading)) {");
     const inlineLink = statusRenderSource.indexOf("} else if ($setup.showExactTotalCountAction) {");
-    const rerunAction = statusRenderSource.indexOf("} else if ($setup.showRerunTotalCountAction) {");
     expect(numericTotal).toBeGreaterThan(-1);
+    expect(rerunAction).toBeGreaterThan(-1);
+    expect(rerunAction).toBeLessThan(numericTotal);
     expect(busyBranch).toBeGreaterThan(numericTotal);
     expect(inlineLink).toBeGreaterThan(busyBranch);
-    expect(rerunAction).toBeGreaterThan(inlineLink);
   });
 
   it("renders a spaced rerun icon labelled for the total-count action and disabled while counting", () => {
-    expect(rerunBranch).toContain('<button type="button" class="ml-1 inline-flex h-3.5 w-3.5');
+    expect(rerunBranch).toContain('<button type="button" class="mr-1 inline-flex h-3.5 w-3.5');
     expect(rerunBranch).toContain("disabled:pointer-events-none");
     expect(rerunBranch).toContain("disabled:opacity-50");
     // title/aria-label toggle between idle and busy copy

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1531,6 +1531,7 @@ export default {
     totalRows: "Total {count} rows",
     loadedRows: "Loaded {count} rows",
     totalRowCount: "({count} total)",
+    totalRowCountWithAction: "({button}{count} total)",
     totalRowCountAtLeast: "(at least {count} total)",
     totalRowCountEstimated: "(~{count})",
     totalRowCountLoading: "(counting...)",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1472,6 +1472,7 @@ export default withEnglishFallback({
     totalRows: "Total {count} filas",
     loadedRows: "{count} filas cargadas",
     totalRowCount: "({count} en total)",
+    totalRowCountWithAction: "({button}{count} en total)",
     totalRowCountAtLeast: "(al menos {count} en total)",
     totalRowCountEstimated: "(aprox. {count})",
     totalRowCountLoading: "(contando...)",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1470,6 +1470,7 @@ export default withEnglishFallback({
     totalRows: "Totale {count} righe",
     loadedRows: "{count} righe caricate",
     totalRowCount: "({count} in totale)",
+    totalRowCountWithAction: "({button}{count} in totale)",
     totalRowCountAtLeast: "(almeno {count} in totale)",
     totalRowCountEstimated: "(circa {count})",
     totalRowCountLoading: "(conteggio...)",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1492,6 +1492,7 @@ export default withEnglishFallback({
     totalRows: "{count}件表示",
     loadedRows: "{count}件読み込み済み",
     totalRowCount: "（全{count}件）",
+    totalRowCountWithAction: "（{button}全{count}件）",
     totalRowCountAtLeast: "（少なくとも{count}件）",
     totalRowCountEstimated: "（約 {count}件）",
     totalRowCountLoading: "（カウント中...）",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -1412,6 +1412,7 @@ export default withEnglishFallback({
     totalRows: "전체 {count}행",
     loadedRows: "{count}행 로드됨",
     totalRowCount: "(전체 {count})",
+    totalRowCountWithAction: "({button}전체 {count})",
     totalRowCountAtLeast: "(최소 {count})",
     totalRowCountEstimated: "(약 {count})",
     totalRowCountLoading: "(집계 중...)",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1472,6 +1472,7 @@ export default withEnglishFallback({
     totalRows: "Total de {count} linhas",
     loadedRows: "{count} linhas carregadas",
     totalRowCount: "({count} no total)",
+    totalRowCountWithAction: "({button}{count} no total)",
     totalRowCountAtLeast: "(pelo menos {count} no total)",
     totalRowCountEstimated: "(aprox. {count})",
     totalRowCountLoading: "(contando...)",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1455,6 +1455,7 @@ export default withEnglishFallback({
     totalRows: "共 {count} 行",
     loadedRows: "已加载 {count} 行",
     totalRowCount: "（总计 {count} 行）",
+    totalRowCountWithAction: "（{button}总计 {count} 行）",
     totalRowCountAtLeast: "（至少 {count} 行）",
     totalRowCountEstimated: "（约 {count} 行）",
     totalRowCountLoading: "（统计中...）",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1471,6 +1471,7 @@ export default withEnglishFallback({
     totalRows: "共 {count} 筆",
     loadedRows: "已載入 {count} 筆",
     totalRowCount: "（總計 {count} 筆）",
+    totalRowCountWithAction: "（{button}總計 {count} 筆）",
     totalRowCountAtLeast: "（至少 {count} 筆）",
     totalRowCountEstimated: "（約 {count} 筆）",
     totalRowCountLoading: "（統計中...）",

--- a/packages/app-tests/dataGridPagination.test.ts
+++ b/packages/app-tests/dataGridPagination.test.ts
@@ -269,7 +269,7 @@ test("rerun total-count visibility comes from the shared rule and triggers the m
   assert.match(rerunComputed, /canCalculateTotalRowCount: canCalculateTotalRowCount\.value/);
   assert.match(rerunComputed, /displayedTotalRowCount: displayedTotalRowCount\.value/);
   assert.match(rerunComputed, /totalRowCountIsExact: totalRowCountIsExact\.value/);
-  const rerunButton = source.match(/<button\s+v-else-if="showRerunTotalCountAction"[\s\S]*?<\/button>/)?.[0] ?? "";
+  const rerunButton = source.match(/<i18n-t v-if="showRerunTotalCountAction[\s\S]*?<template #button>[\s\S]*?<button[\s\S]*?<\/button>/)?.[0] ?? "";
   assert.match(rerunButton, /@click="calculateTotalRowCount"/);
 });
 


### PR DESCRIPTION
## 变更说明

- 将表数据页底部用于重新计算总行数的刷新按钮移动到“总计”文本左侧
- 保留原有点击、加载态、禁用态及无障碍标签逻辑
- 更新总计刷新按钮的布局断言，防止位置回退

Fixes #7520

## 验证

- `pnpm vitest run apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts`
- `pnpm exec oxfmt --check apps/desktop/src/components/grid/DataGrid.vue apps/desktop/src/components/grid/__tests__/DataGridTotalRowCount.spec.ts`
- `git diff --check`

说明：`vue-tsc` 受仓库当前 `@dbx-app/mongo-shell` 模块缺失影响，报告的是既有依赖解析错误，与本次改动无关。