### PR TITLE
✨ feat(sidebar): 为 MongoDB 创建数据库增加授权预览与生产环境确认

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -111,7 +111,7 @@ import {
 } from "@/lib/database/databaseCapabilities";
 import { copyDisplayPathForTreeNode, copyNameForTreeNode, isDirectNavigationTreeNode, isDocumentBrowserTreeNode, isRepeatableNavigationTreeNode, objectSourceTargetForTreeNode, shouldRunTreeNodeRowAction, treeNodeRowAction, treeNodeRowDoubleClickAction } from "@/lib/sidebar/treeNodeClick";
 import { customTypeCapabilities, supportsTypeObjectSource } from "@/lib/database/databaseObjectCapabilities";
-import { mongoCollectionTableTypeFromNode, mongoDropIndexFailureCount } from "@/lib/sidebar/mongoCollectionMutation";
+import { mongoCollectionTableTypeFromNode, mongoCreateDatabasePreview, mongoDropIndexFailureCount } from "@/lib/sidebar/mongoCollectionMutation";
 import { dataTabOpenModeFromTreeClick, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
 import { isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut } from "@/lib/editor/keyboardShortcuts";
 import { handleSidebarTreeDeleteShortcut } from "@/lib/sidebar/sidebarTreeDeleteShortcut";
@@ -3591,11 +3591,23 @@ async function confirmCreateDatabase() {
     await connectionStore.ensureConnected(node.connectionId);
     const config = connectionStore.getConfig(node.connectionId);
     if (config?.db_type === "mongodb") {
+      const plan: AuthorizationPlan = {
+        steps: [
+          {
+            id: "create-database",
+            label: `create database ${name}`,
+            database: "",
+            sql: mongoCreateDatabasePreview(name),
+            operation: "createDatabase",
+            targetDatabase: name,
+          },
+        ],
+      };
+      createDatabaseAuthorizationPlan.value = plan;
+      createDatabasePreviewSql.value = authorizationPlanSql(plan);
+      createDatabaseAuthorizationResults.value = [];
       showCreateDatabaseDialog.value = false;
-      await api.mongoCreateDatabase(node.connectionId, name);
-      toast(t("contextMenu.createDatabaseSuccess", { name }), 3000);
-      await connectionStore.ensureVisibleDatabase(node.connectionId, name);
-      await connectionStore.loadMongoDatabases(node.connectionId);
+      showCreateDatabasePreviewDialog.value = true;
       return;
     }
     const sql = await buildCreateDatabaseSql({
@@ -3628,13 +3640,30 @@ async function applyCreateDatabaseAuthorizationPlan() {
   createDatabaseAuthorizationApplying.value = true;
   try {
     const config = connectionStore.getConfig(node.connectionId);
-    const results = await executeWithProductionSqlGuard({
-      connection: config,
-      database: "",
-      sql: createDatabasePreviewSql.value,
-      source: t("production.sourceSidebar"),
-      execute: () => executeAuthorizationPlan(plan, (step) => api.executeMulti(node.connectionId!, step.database, step.sql, undefined, undefined, { maxRows: 1000, continueOnError: true })),
-    });
+    const isMongoDatabaseCreation = config?.db_type === "mongodb";
+    const executePlan = () =>
+      executeAuthorizationPlan(plan, async (step) => {
+        if (isMongoDatabaseCreation && step.operation === "createDatabase") {
+          await api.mongoCreateDatabase(node.connectionId!, name);
+          return [];
+        }
+        return api.executeMulti(node.connectionId!, step.database, step.sql, undefined, undefined, { maxRows: 1000, continueOnError: true });
+      });
+    const results = isMongoDatabaseCreation
+      ? await executeWithProductionContextGuard({
+          connection: config,
+          database: name,
+          reviewText: createDatabasePreviewSql.value,
+          source: t("production.sourceSidebar"),
+          execute: executePlan,
+        })
+      : await executeWithProductionSqlGuard({
+          connection: config,
+          database: "",
+          sql: createDatabasePreviewSql.value,
+          source: t("production.sourceSidebar"),
+          execute: executePlan,
+        });
     if (!results) return;
     const displayResults = results.map((result) => ({
       ...result,
@@ -3645,7 +3674,11 @@ async function applyCreateDatabaseAuthorizationPlan() {
     const status = authorizationPlanStatus(displayResults);
     if (created) {
       await connectionStore.ensureVisibleDatabase(node.connectionId, name);
-      await connectionStore.loadDatabases(node.connectionId, { force: true });
+      if (isMongoDatabaseCreation) {
+        await connectionStore.loadMongoDatabases(node.connectionId);
+      } else {
+        await connectionStore.loadDatabases(node.connectionId, { force: true });
+      }
     }
     toast(t(status === "success" ? "contextMenu.createDatabaseSuccess" : status === "partial" ? "contextMenu.createDatabasePartial" : "contextMenu.createDatabaseFailed", { name }), status === "success" ? 3000 : 5000);
   } catch (error: any) {

--- a/apps/desktop/src/lib/sidebar/__tests__/mongoCollectionMutation.spec.ts
+++ b/apps/desktop/src/lib/sidebar/__tests__/mongoCollectionMutation.spec.ts
@@ -8,6 +8,7 @@ import {
   mongoCollectionKindFromNode,
   mongoCollectionTableTypeFromNode,
   mongoCloneCollectionPreview,
+  mongoCreateDatabasePreview,
   mongoCreateIndexFormFromRow,
   mongoCreateIndexRequestFromSpec,
   mongoCreateIndexPreview,
@@ -118,6 +119,10 @@ describe("isProtectedMongoIndex", () => {
 });
 
 describe("mongo shell previews", () => {
+  it("shows the initialization collection used to materialize a database", () => {
+    expect(mongoCreateDatabasePreview('app "primary"')).toBe('db.getSiblingDB("app \\"primary\\"").createCollection("dbx_init");');
+  });
+
   it("preserves identifier whitespace in rename preview", () => {
     expect(mongoRenameCollectionPreview("app", " users ", " renamed ")).toBe('db.getSiblingDB("app").getCollection(" users ").renameCollection(" renamed ")');
   });

--- a/apps/desktop/src/lib/sidebar/mongoCollectionMutation.ts
+++ b/apps/desktop/src/lib/sidebar/mongoCollectionMutation.ts
@@ -66,6 +66,11 @@ export function mongoCollectionTableTypeFromNode(node: Pick<TreeNode, "meta">): 
   return kind === "view" ? "VIEW" : kind === "timeseries" ? "TIMESERIES" : "TABLE";
 }
 
+/** MongoDB materializes a database when its initialization collection is created. */
+export function mongoCreateDatabasePreview(database: string): string {
+  return `db.getSiblingDB(${JSON.stringify(database)}).createCollection("dbx_init");`;
+}
+
 export function toMongoCollectionKind(kind?: string | null): MongoCollectionKind {
   const normalized = (kind || "collection").toLowerCase();
   if (normalized === "view") return "view";


### PR DESCRIPTION
## 变更说明

MongoDB 新建数据库现在会先展示实际执行的 Mongo Shell 命令，用户确认后才创建数据库。

- 预览 `db.getSiblingDB("<database>").createCollection("dbx_init");`
- 确认后继续复用原有创建 API，并刷新 MongoDB 数据库树
- MongoDB 创建路径接入生产环境与只读保护

无已知破坏性变更；后端仍通过创建 `dbx_init` 集合使数据库落地。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="724" height="307" alt="image" src="https://github.com/user-attachments/assets/0a03a331-ad60-404d-a6ad-3d9d23a6f768" />


## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm exec vitest run apps/desktop/src/lib/sidebar/__tests__/mongoCollectionMutation.spec.ts`（46 passed）
- `pnpm typecheck`
- `pnpm lint`（通过；项目中存在既有无关警告）

## 关联 Issue

Close #7485