### PR TITLE
✨ feat(grid): 将筛选列搜索框移至下拉顶部并优化样式

### DIFF
--- a/apps/desktop/src/components/grid/DataGridFilterBuilder.vue
+++ b/apps/desktop/src/components/grid/DataGridFilterBuilder.vue
@@ -578,13 +578,14 @@ function blurValueRule(id: string) {
                 {{ column }}
               </SelectItem>
               <div v-if="!props.filteredColumns.length" class="px-2 py-2 text-xs text-muted-foreground">{{ t("grid.filterBuilderNoMatchingColumns") }}</div>
-              <template #footer>
-                <div class="flex items-center gap-1.5 border-t bg-popover px-2 py-1">
+              <template #header>
+                <div data-filter-column-search class="flex items-center gap-1.5 border-b bg-popover px-2 py-1.5">
                   <Search class="h-3.5 w-3.5 text-muted-foreground" />
                   <input
                     :ref="(element) => setColumnSearchInput(rule.id, element)"
                     :value="props.columnSearch"
-                    class="h-6 min-w-0 flex-1 bg-transparent text-xs outline-none"
+                    :aria-label="t('grid.filterBuilderSearchColumns')"
+                    class="h-7 min-w-0 flex-1 rounded-sm border border-input bg-background/60 px-2 text-xs outline-none placeholder:text-muted-foreground focus-visible:border-primary focus-visible:ring-1 focus-visible:ring-primary"
                     :placeholder="t('grid.filterBuilderSearchColumns')"
                     @input="updateColumnSearch(rule.id, $event)"
                     @click.stop

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -623,6 +623,7 @@ describe("DataGridFilterBuilder", () => {
     const filterBuilder = findOne(mounted.root, (node) => String(node.props.class).includes("w-fit max-w-full"));
     const ruleGrid = findOne(mounted.root, (node) => String(node.props.class).includes("grid-cols-[18px_var(--filter-builder-column-width)_92px_var(--filter-builder-value-width)_auto]"));
     const searchInput = findOne(mounted.root, (node) => node.type === "input" && node.props.placeholder === "grid.filterBuilderSearchColumns");
+    const columnSearch = findOne(mounted.root, (node) => node.props["data-filter-column-search"] === "");
     const valueEditor = findOne(mounted.root, (node) => node.props["data-filter-value-editor"] === "");
 
     expect(selects).toHaveLength(2);
@@ -634,6 +635,8 @@ describe("DataGridFilterBuilder", () => {
     expect(items).toHaveLength(2);
     expect(items.every((item) => String(item.props.class).includes("rounded-none"))).toBe(true);
     expect(searchInput.props.placeholder).toBe("grid.filterBuilderSearchColumns");
+    expect(searchInput.props["aria-label"]).toBe("grid.filterBuilderSearchColumns");
+    expect(String(columnSearch.props.class)).toContain("border-b");
     expect(valueEditor.props.placeholder).toBe("grid.filterBuilderValue");
     expect(filterBuilder.props.style).toEqual({ "--filter-builder-column-width": "178px", "--filter-builder-value-width": "178px" });
     expect(String(ruleGrid.props.class)).toContain("grid-cols-[18px_var(--filter-builder-column-width)_92px_var(--filter-builder-value-width)_auto]");

--- a/apps/desktop/src/components/grid/__tests__/vueHostHarness.ts
+++ b/apps/desktop/src/components/grid/__tests__/vueHostHarness.ts
@@ -110,7 +110,7 @@ export function createPassthroughStub(name: string, tag = "div") {
     name,
     inheritAttrs: false,
     setup(_props, { attrs, slots }) {
-      return () => h(tag, { ...attrs, "data-stub": name }, [slots.default?.(), slots.content?.(), slots.footer?.()]);
+      return () => h(tag, { ...attrs, "data-stub": name }, [slots.default?.(), slots.content?.(), slots.header?.(), slots.footer?.()]);
     },
   });
 }

--- a/apps/desktop/src/components/ui/select/SelectContent.vue
+++ b/apps/desktop/src/components/ui/select/SelectContent.vue
@@ -44,14 +44,17 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits);
       :class="
         cn(
           'text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 cn-menu-translucent relative z-50 max-h-(--reka-select-content-available-height) origin-(--reka-select-content-transform-origin) overflow-x-hidden data-[align-trigger=true]:animate-none',
-          slots.footer ? 'flex flex-col overflow-y-hidden' : 'overflow-y-auto',
+          slots.header || slots.footer ? 'flex flex-col overflow-y-hidden' : 'overflow-y-auto',
           position === 'popper' && 'w-fit min-w-[var(--reka-select-trigger-width)] data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           props.class,
         )
       "
     >
+      <div v-if="slots.header" class="shrink-0">
+        <slot name="header" />
+      </div>
       <SelectScrollUpButton v-if="!hideScrollButtons" />
-      <SelectViewport :data-position="position" :class="cn('data-[position=popper]:h-[var(--reka-select-trigger-height)] data-[position=popper]:w-full', slots.footer && 'min-h-0 overflow-y-auto overscroll-none')">
+      <SelectViewport :data-position="position" :class="cn('data-[position=popper]:h-[var(--reka-select-trigger-height)] data-[position=popper]:w-full', (slots.header || slots.footer) && 'min-h-0 overflow-y-auto overscroll-none')">
         <slot />
       </SelectViewport>
       <div v-if="slots.footer" class="shrink-0">


### PR DESCRIPTION
- 为 SelectContent 新增 header 插槽支持，确保带头部时列表区域可滚动
- 优化筛选列搜索框的边框、焦点态与无障碍标签
- 补充下拉头部插槽及搜索框相关测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="512" height="244" alt="image" src="https://github.com/user-attachments/assets/9f928919-2a4d-476a-bc48-67734aeee5b5" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #7447