### PR TITLE
🐛 fix(editor): 保留工具栏点击执行时的 SQL 选区

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -422,6 +422,7 @@ async function resolveActiveExecutableSql(snapshot?: SqlExecutionSnapshot) {
 const blockDangerousRedisCommands = ref(true);
 const databaseRequiredSignal = ref(0);
 const databaseRequiredTabId = ref<string | null>(null);
+const pendingToolbarExecutionSnapshot = ref<SqlExecutionSnapshot>();
 const sqlExecutionDangerStore = useSqlExecutionDangerStore();
 const productionSafetyStore = useProductionSafetyStore();
 
@@ -465,7 +466,19 @@ const {
   onExecutionStarted: (editorViewportRequestId) => contentAreaRef.value?.acceptQueryEditorExecutionViewport(editorViewportRequestId),
 });
 
-function requestActiveEditorExecute() {
+function captureActiveEditorExecutionSnapshot() {
+  pendingToolbarExecutionSnapshot.value = contentAreaRef.value?.captureQueryEditorExecutionSnapshot?.();
+}
+
+function requestActiveEditorExecute(source?: "pointer" | "keyboard") {
+  const snapshot = pendingToolbarExecutionSnapshot.value;
+  pendingToolbarExecutionSnapshot.value = undefined;
+  if (source === "pointer") {
+    if (snapshot) {
+      void tryExecute(snapshot);
+      return;
+    }
+  }
   if (contentAreaRef.value?.requestQueryEditorExecute?.()) return;
   void tryExecute();
 }
@@ -3078,7 +3091,8 @@ onUnmounted(() => {
                   @commit="activeTab && queryStore.commitTransaction(activeTab.id)"
                   @rollback="activeTab && queryStore.rollbackTransaction(activeTab.id)"
                   @dismiss-txn-rolled-back="activeTab && (activeTab.txnAutoRolledBack = false)"
-                  @execute="requestActiveEditorExecute()"
+                  @execute-pointer-down="captureActiveEditorExecutionSnapshot()"
+                  @execute="requestActiveEditorExecute($event)"
                   @multi-execute="requestMultiDbExecute()"
                   @cancel="cancelActiveExecution()"
                   @explain="tryExplain()"

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -867,6 +867,18 @@ function emitExecutionRequest(source: SqlExecutionOverride, openInNewResultTab =
   }
 }
 
+/**
+ * Captures a manual selection before a toolbar click can cause a platform
+ * focus transition. The snapshot is immutable, so downstream execution keeps
+ * the exact SQL and source offsets that were visible when the button was
+ * pressed.
+ */
+function captureExecutionSnapshot(): SqlExecutionSnapshot | undefined {
+  const currentView = view.value;
+  if (!currentView || currentView.state.selection.main.empty) return undefined;
+  return sqlExecutionSnapshotFromView(currentView);
+}
+
 function requestExecute(options: RequestExecuteOptions = {}) {
   executionViewportOwnership.cancelPendingRequest();
   const currentView = view.value;
@@ -6267,6 +6279,7 @@ defineExpose({
   shouldBlockExecutionShortcut,
   requestExecute,
   requestExecuteInNewResultTab,
+  captureExecutionSnapshot,
   pasteClipboardAsSqlInCondition,
   focusStatementRange,
   previewStatementRange,

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1117,6 +1117,10 @@ function requestQueryEditorExecute() {
   return queryEditorRef.value?.requestExecute();
 }
 
+function captureQueryEditorExecutionSnapshot() {
+  return queryEditorRef.value?.captureExecutionSnapshot();
+}
+
 function requestQueryEditorExecuteInNewResultTab() {
   return queryEditorRef.value?.requestExecuteInNewResultTab();
 }
@@ -1168,6 +1172,7 @@ defineExpose({
   refreshQueryEditorCompletionCache,
   handleModRTarget,
   requestQueryEditorExecute,
+  captureQueryEditorExecutionSnapshot,
   requestQueryEditorExecuteInNewResultTab,
   shouldBlockQueryEditorExecutionShortcut,
   acceptQueryEditorExecutionViewport,

--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -43,7 +43,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  execute: [];
+  execute: [source: "pointer" | "keyboard"];
+  executePointerDown: [];
   cancel: [];
   explain: [];
   "update:explainMode": [mode: "explain" | "autotrace"];
@@ -251,6 +252,20 @@ function databaseOptionIsProduction(database: string): boolean {
   if (!database || props.activeConnection?.is_production) return false;
   return productionContextForDatabase(props.activeConnection, database).reason === "database";
 }
+
+function onExecutePointerDown(event: MouseEvent) {
+  if (props.activeTab.isExecuting || event.button !== 0) return;
+  emit("executePointerDown");
+}
+
+function onExecuteClick(event: MouseEvent) {
+  if (props.activeTab.isExecuting) {
+    emit("cancel");
+    return;
+  }
+  emit("execute", event.detail > 0 ? "pointer" : "keyboard");
+}
+
 async function changeCatalog(selectedCatalog: string) {
   const connection = props.activeConnection;
   if (!connection) return;
@@ -276,8 +291,8 @@ async function changeCatalog(selectedCatalog: string) {
             class="h-6 w-6"
             :class="executeButtonClass"
             :disabled="activeTab.isCancelling || activeTab.isExplaining || (!activeTab.isExecuting && !executableSql.trim())"
-            @mousedown.prevent
-            @click="activeTab.isExecuting ? emit('cancel') : emit('execute')"
+            @mousedown.prevent="onExecutePointerDown"
+            @click="onExecuteClick"
           >
             <Loader2 v-if="activeTab.isCancelling" class="h-3.5 w-3.5 animate-spin" />
             <Square v-else-if="activeTab.isExecuting" class="h-3.5 w-3.5 fill-current" />

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorExecution.spec.ts
@@ -4,6 +4,7 @@ import { createQueryEditorExecutionViewportOwnership, isQueryEditorPositionVisib
 
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 const contentAreaSource = readFileSync(new URL("../../../components/layout/ContentArea.vue", import.meta.url), "utf8");
+const editorToolbarSource = readFileSync(new URL("../../../components/layout/EditorToolbar.vue", import.meta.url), "utf8");
 const appSource = readFileSync(new URL("../../../App.vue", import.meta.url), "utf8");
 const sqlExecutionSource = readFileSync(new URL("../../../composables/useSqlExecution.ts", import.meta.url), "utf8");
 const queryStoreSource = readFileSync(new URL("../../../stores/queryStore.ts", import.meta.url), "utf8");
@@ -48,6 +49,21 @@ describe("QueryEditor execution routing", () => {
 
     expect(selectionBranch).toBeGreaterThan(-1);
     expect(executeModeBranch).toBeGreaterThan(selectionBranch);
+  });
+
+  it("captures the toolbar selection before the click event can change focus", () => {
+    expect(queryEditorSource).toContain("function captureExecutionSnapshot(): SqlExecutionSnapshot | undefined");
+    expect(queryEditorSource).toContain("return sqlExecutionSnapshotFromView(currentView);");
+    expect(contentAreaSource).toContain("function captureQueryEditorExecutionSnapshot()");
+    expect(contentAreaSource).toContain("queryEditorRef.value?.captureExecutionSnapshot();");
+    expect(appSource).toContain("const pendingToolbarExecutionSnapshot = ref<SqlExecutionSnapshot>();");
+    expect(appSource).toContain("pendingToolbarExecutionSnapshot.value = contentAreaRef.value?.captureQueryEditorExecutionSnapshot?.();");
+    expect(appSource).toContain('if (source === "pointer")');
+    expect(appSource).toContain("pendingToolbarExecutionSnapshot.value = undefined;");
+    expect(appSource).toContain("void tryExecute(snapshot);");
+    expect(appSource).toContain('@execute-pointer-down="captureActiveEditorExecutionSnapshot()"');
+    expect(appSource).toContain('@execute="requestActiveEditorExecute($event)"');
+    expect(editorToolbarSource).toContain("function onExecutePointerDown(event: MouseEvent)");
   });
 
   it("uses the opt-in blank-line fallback and otherwise reports the missing cursor statement", () => {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
@@ -51,7 +51,7 @@ describe("QueryEditor auto focus wiring", () => {
 
 describe("QueryEditor toolbar focus", () => {
   it("does not move focus from the editor when clicking execute", () => {
-    expect(editorToolbarSource).toMatch(/:disabled="activeTab\.isCancelling[\s\S]*?@mousedown\.prevent[\s\S]*?@click="activeTab\.isExecuting \? emit\('cancel'\) : emit\('execute'\)"/);
+    expect(editorToolbarSource).toMatch(/:disabled="activeTab\.isCancelling[\s\S]*?@mousedown\.prevent="onExecutePointerDown"[\s\S]*?@click="onExecuteClick"/);
     expect(queryEditorSource).toMatch(/function requestExecute\([\s\S]*?const currentView = view\.value;[\s\S]*?currentView\.focus\(\);[\s\S]*?requestExecuteFromView\(currentView/);
   });
 });


### PR DESCRIPTION
- 在鼠标按下阶段捕获编辑器选区快照，避免焦点变化导致选区丢失
- 点击执行时优先使用捕获的快照，确保执行按钮按下时可见的 SQL
- 区分鼠标与键盘触发方式，保持快捷键执行逻辑不变
- 补充工具栏选区捕获与焦点行为测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #7510