### PR TITLE
✨ feat(DDL): 支持通过标题栏拖动查看对话框

### DIFF
--- a/apps/desktop/src/components/objects/DdlViewDialog.vue
+++ b/apps/desktop/src/components/objects/DdlViewDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onUnmounted, ref, shallowRef, watch } from "vue";
+import { computed, nextTick, onUnmounted, ref, shallowRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Clipboard, Loader2, RefreshCw } from "@lucide/vue";
 import { useToast } from "@/composables/useToast";
@@ -51,9 +51,60 @@ const ddlEditorContainer = ref<HTMLDivElement>();
 const ddlSearchPanelRef = ref<InstanceType<typeof EditorSearchPanel>>();
 const ddlEditorView = shallowRef<EditorView | null>(null);
 
+// Keep the dialog movable for the duration of one open cycle. This mirrors the
+// existing draggable dialogs without persisting a potentially off-screen position.
+const dragOffset = ref({ x: 0, y: 0 });
+const isDragging = ref(false);
+const dragStartPosition = ref({ x: 0, y: 0 });
+const dragStartOffset = ref({ x: 0, y: 0 });
+const activePointerId = ref<number | null>(null);
+const dialogContentStyle = computed(() => {
+  if (isDragging.value || dragOffset.value.x !== 0 || dragOffset.value.y !== 0) {
+    return {
+      transform: `translate(${dragOffset.value.x}px, ${dragOffset.value.y}px)`,
+      transition: isDragging.value ? "none" : "transform 0.15s ease-out",
+    };
+  }
+  return {};
+});
+
 // The CodeMirror editor (if any) that was focused when this dialog opened, so focus can be
 // restored to it on close. Not a ref: read/written outside of render, never needs reactivity.
 let editorRootToRestoreFocus: HTMLElement | null = null;
+
+function resetDialogDragOffset() {
+  dragOffset.value = { x: 0, y: 0 };
+  isDragging.value = false;
+  activePointerId.value = null;
+}
+
+function startDialogDrag(event: PointerEvent) {
+  if (event.button !== undefined && event.button !== 0) return;
+  isDragging.value = true;
+  activePointerId.value = event.pointerId;
+  dragStartPosition.value = { x: event.clientX, y: event.clientY };
+  dragStartOffset.value = { ...dragOffset.value };
+  (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+}
+
+function moveDialogDrag(event: PointerEvent) {
+  if (!isDragging.value || event.pointerId !== activePointerId.value) return;
+  dragOffset.value = {
+    x: dragStartOffset.value.x + event.clientX - dragStartPosition.value.x,
+    y: dragStartOffset.value.y + event.clientY - dragStartPosition.value.y,
+  };
+}
+
+function endDialogDrag(event: PointerEvent) {
+  if (!isDragging.value || event.pointerId !== activePointerId.value) return;
+  isDragging.value = false;
+  activePointerId.value = null;
+  try {
+    (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+  } catch {
+    // Pointer capture may already have been released by the browser.
+  }
+}
 
 async function loadDdl(force = false) {
   ddlError.value = "";
@@ -84,6 +135,7 @@ async function loadDdl(force = false) {
 watch(
   () => props.open,
   async (open) => {
+    resetDialogDragOffset();
     if (!open) return;
     const active = document.activeElement;
     editorRootToRestoreFocus = active instanceof HTMLElement ? active.closest(".cm-editor") : null;
@@ -224,8 +276,8 @@ function onClose() {
 
 <template>
   <Dialog :open="props.open" @update:open="onClose">
-    <DialogContent class="dbx-ddl-view-dialog sm:max-w-190" @close-auto-focus="onDdlDialogCloseAutoFocus">
-      <DialogHeader>
+    <DialogContent :style="dialogContentStyle" class="dbx-ddl-view-dialog sm:max-w-190" @close-auto-focus="onDdlDialogCloseAutoFocus">
+      <DialogHeader class="cursor-move select-none" @pointerdown="startDialogDrag" @pointermove="moveDialogDrag" @pointerup="endDialogDrag" @pointercancel="endDialogDrag">
         <DialogTitle>DDL - {{ props.tableName }}</DialogTitle>
       </DialogHeader>
       <div class="grid gap-3">


### PR DESCRIPTION
## 变更说明

- 支持通过“查看 DDL”弹窗标题栏拖动窗口，便于查看被遮挡内容。
- 沿用现有弹窗的 Pointer Capture 拖拽模式，并在关闭或重新打开时复位位置。
- 保持 DDL 加载、CodeMirror 文本选择、复制、刷新与关闭焦点恢复行为不变。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="2380" height="1492" alt="0A388649-E115-4D67-8C82-05FCEC6BACDF" src="https://github.com/user-attachments/assets/e7e2a84b-d4da-4b4d-ae32-b58d5a970513" />


## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：
- `pnpm exec vitest run apps/desktop/src/styles/__tests__/legacyWebviewFallback.spec.ts apps/desktop/src/lib/__tests__/editor/editorSearchSelection.spec.ts`
- `pnpm typecheck`

## 关联 Issue

Close #7418