### PR TITLE
fix(cli): Set default rustls CryptoProvider to prevent panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
  "async-trait",
  "dbx-core",
  "dbx-mcp",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/dbx-cli/Cargo.toml
+++ b/crates/dbx-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 dbx-core = { path = "../dbx-core", default-features = false, features = ["sqlite-bundled"] }
 dbx-mcp = { path = "../dbx-mcp" }
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }

--- a/crates/dbx-cli/src/main.rs
+++ b/crates/dbx-cli/src/main.rs
@@ -180,7 +180,7 @@ async fn main() -> ExitCode {
 async fn run(argv: Vec<String>) -> Result<String, (CliError, bool)> {
     // Set aws_lc_rs as the process-level default CryptoProvider to prevent a rustls panic
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-    
+
     let wants_json = argv.iter().any(|arg| arg == "--json");
     let flags = parse_flags(&argv).map_err(|error| (error, wants_json))?;
     let json_output = flags.format == OutputFormat::Json;

--- a/crates/dbx-cli/src/main.rs
+++ b/crates/dbx-cli/src/main.rs
@@ -178,6 +178,9 @@ async fn main() -> ExitCode {
 }
 
 async fn run(argv: Vec<String>) -> Result<String, (CliError, bool)> {
+    // Set aws_lc_rs as the process-level default CryptoProvider to prevent a rustls panic
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    
     let wants_json = argv.iter().any(|arg| arg == "--json");
     let flags = parse_flags(&argv).map_err(|error| (error, wants_json))?;
     let json_output = flags.format == OutputFormat::Json;
@@ -196,8 +199,6 @@ async fn run(argv: Vec<String>) -> Result<String, (CliError, bool)> {
         ensure_arg_count(&flags.args, 1, "dbx capabilities").map_err(|error| (error, json_output))?;
         return format_capabilities(flags.format).map_err(|error| (error, json_output));
     }
-    // Set aws_lc_rs as the process-level default CryptoProvider to prevent a rustls panic
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let backend: Arc<dyn DbxBackend> = if let Ok(base_url) = env::var("DBX_WEB_URL") {
         Arc::new(

--- a/crates/dbx-cli/src/main.rs
+++ b/crates/dbx-cli/src/main.rs
@@ -196,6 +196,8 @@ async fn run(argv: Vec<String>) -> Result<String, (CliError, bool)> {
         ensure_arg_count(&flags.args, 1, "dbx capabilities").map_err(|error| (error, json_output))?;
         return format_capabilities(flags.format).map_err(|error| (error, json_output));
     }
+    // Set aws_lc_rs as the process-level default CryptoProvider to prevent a rustls panic
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     let backend: Arc<dyn DbxBackend> = if let Ok(base_url) = env::var("DBX_WEB_URL") {
         Arc::new(


### PR DESCRIPTION
## Description

Adds this line to the main.rs for dbx-cli:

```rs
// Set aws_lc_rs as the process-level default CryptoProvider to prevent a rustls panic
let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
```

This prevents a panic that occurs when querying MySQL servers:

```text
thread 'main' (4361874) panicked at .../rustls-0.23.43/src/crypto/mod.rs:249:14:

Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.
```

Similar call occurs in the GUI and MCP builds and the Postgres driver, but not the CLI.

<img width="516" height="331" alt="image" src="https://github.com/user-attachments/assets/7deb2cda-5aa1-4657-b07d-b5e2ae9d9345" />

## Change Type

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Code refactoring
- [ ] Documentation update
- [ ] CI / Build

## Verification

<!-- Explain how to verify your changes, e.g., commands, test cases, manual steps -->

- [x] `make check` passed
- [x] `make cargo-check-fast` passed
- [x] Relevant tests passed