### PR TITLE
fix(postgres): query foreign keys via pg_catalog for read-only users

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3854,6 +3854,9 @@ fn postgres_foreign_keys_for_relations_sql() -> &'static str {
 // PostgreSQL 9.3 and older only accept one array argument to unnest(). Pair
 // the schema/table arrays through their shared subscript so the fallback stays
 // one bounded query and preserves each relation tuple's position.
+// WITH ORDINALITY is equally unavailable before 9.4, so pair conkey/confkey
+// positions with generate_series over the array length plus plain subscripts —
+// the same pre-9.4 technique the index compat SQL relies on.
 fn postgres_foreign_keys_for_relations_compat_sql() -> &'static str {
     "SELECT rel.rel_schema, rel.rel_table, \
      con.conname AS constraint_name, \
@@ -3872,10 +3875,9 @@ fn postgres_foreign_keys_for_relations_compat_sql() -> &'static str {
      JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
      JOIN pg_catalog.pg_class ref_c ON ref_c.oid = con.confrelid \
      JOIN pg_catalog.pg_namespace ref_n ON ref_n.oid = ref_c.relnamespace \
-     JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS fk(attnum, ord) ON true \
-     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = fk.attnum AND NOT a.attisdropped \
-     JOIN LATERAL unnest(con.confkey) WITH ORDINALITY AS pk(attnum, ord) ON pk.ord = fk.ord \
-     JOIN pg_catalog.pg_attribute ref_a ON ref_a.attrelid = ref_c.oid AND ref_a.attnum = pk.attnum AND NOT ref_a.attisdropped \
+     CROSS JOIN generate_series(1, array_length(con.conkey, 1)) AS fk(ord) \
+     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = (con.conkey)[fk.ord] AND NOT a.attisdropped \
+     JOIN pg_catalog.pg_attribute ref_a ON ref_a.attrelid = ref_c.oid AND ref_a.attnum = (con.confkey)[fk.ord] AND NOT ref_a.attisdropped \
      WHERE con.contype = 'f' AND n.nspname = rel.rel_schema AND c.relname = rel.rel_table \
      ORDER BY rel.rel_schema, rel.rel_table, con.conname, fk.ord"
 }
@@ -7422,12 +7424,36 @@ fn postgres_foreign_keys_sql() -> &'static str {
      ORDER BY con.conname, fk.ord"
 }
 
-pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ForeignKeyInfo>, String> {
-    let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
-    let rows = postgres_query_cached(&client, postgres_foreign_keys_sql(), &[&schema, &table])
-        .await
-        .map_err(|e| e.to_string())?;
+// Pre-9.4 sibling of `postgres_foreign_keys_sql`: WITH ORDINALITY requires
+// PostgreSQL 9.4, so pair conkey/confkey positions with generate_series over
+// the array length plus plain subscripts.
+fn postgres_foreign_keys_compat_sql() -> &'static str {
+    "SELECT con.conname AS constraint_name, \
+     a.attname AS column_name, \
+     ref_n.nspname AS ref_schema, \
+     ref_c.relname AS ref_table, \
+     ref_a.attname AS ref_column, \
+     con.confupdtype::text AS on_update_raw, \
+     con.confdeltype::text AS on_delete_raw \
+     FROM pg_catalog.pg_constraint con \
+     JOIN pg_catalog.pg_class c ON c.oid = con.conrelid \
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+     JOIN pg_catalog.pg_class ref_c ON ref_c.oid = con.confrelid \
+     JOIN pg_catalog.pg_namespace ref_n ON ref_n.oid = ref_c.relnamespace \
+     CROSS JOIN generate_series(1, array_length(con.conkey, 1)) AS fk(ord) \
+     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = (con.conkey)[fk.ord] AND NOT a.attisdropped \
+     JOIN pg_catalog.pg_attribute ref_a ON ref_a.attrelid = ref_c.oid AND ref_a.attnum = (con.confkey)[fk.ord] AND NOT ref_a.attisdropped \
+     WHERE con.contype = 'f' AND n.nspname = $1 AND c.relname = $2 \
+     ORDER BY con.conname, fk.ord"
+}
 
+async fn list_foreign_keys_with_sql(
+    client: &deadpool_postgres::Client,
+    sql: &'static str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<ForeignKeyInfo>, tokio_postgres::Error> {
+    let rows = postgres_query_cached(client, sql, &[&schema, &table]).await?;
     Ok(rows
         .iter()
         .map(|row| ForeignKeyInfo {
@@ -7440,6 +7466,84 @@ pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result
             on_delete: postgres_fk_action_label(pg_row_try_optional_text(row, 6)),
         })
         .collect())
+}
+
+pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ForeignKeyInfo>, String> {
+    let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
+    let tiers = [postgres_foreign_keys_sql(), postgres_foreign_keys_compat_sql()];
+    query_with_compat_fallback("list_foreign_keys", &tiers, |sql| {
+        list_foreign_keys_with_sql(&client, sql, schema, table)
+    })
+    .await
+}
+
+/// OpenGauss-safe foreign key metadata. Mirrors `list_opengauss_constraints`:
+/// older OpenGauss releases may reject WITH ORDINALITY or decode catalog arrays
+/// differently on the wire, so read conkey/confkey as text and resolve the
+/// attribute numbers in Rust.
+pub async fn list_opengauss_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ForeignKeyInfo>, String> {
+    let schema = if schema.is_empty() { "public" } else { schema };
+    let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
+    let rows = postgres_query_cached(&client, opengauss_foreign_keys_sql(), &[&schema, &table])
+        .await
+        .map_err(|e| e.to_string())?;
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let local_relation_oid =
+        pg_row_try_u32(&rows[0], 7).ok_or("OpenGauss foreign key metadata did not return a local relation OID")?;
+    let local_attributes = opengauss_relation_attributes(&client, local_relation_oid).await?;
+    let mut referenced_attributes: HashMap<u32, HashMap<i16, String>> = HashMap::new();
+    let mut result = Vec::new();
+
+    for row in &rows {
+        let name = pg_row_try_string(row, 0);
+        let column_numbers = parse_opengauss_attribute_numbers(&pg_row_try_string(row, 3))
+            .map_err(|error| format!("failed to parse OpenGauss foreign key {name} columns: {error}"))?;
+        let ref_column_numbers = parse_opengauss_attribute_numbers(&pg_row_try_string(row, 4))
+            .map_err(|error| format!("failed to parse OpenGauss foreign key {name} referenced columns: {error}"))?;
+        let ref_schema = pg_row_try_string(row, 1);
+        let ref_table = pg_row_try_string(row, 2);
+        let on_update = postgres_fk_action_label(pg_row_try_optional_text(row, 5));
+        let on_delete = postgres_fk_action_label(pg_row_try_optional_text(row, 6));
+        let Some(referenced_relation_oid) = pg_row_try_u32(row, 8).filter(|oid| *oid != 0) else {
+            continue;
+        };
+        if let std::collections::hash_map::Entry::Vacant(entry) = referenced_attributes.entry(referenced_relation_oid) {
+            entry.insert(opengauss_relation_attributes(&client, referenced_relation_oid).await?);
+        }
+        let ref_attributes = referenced_attributes.get(&referenced_relation_oid).unwrap();
+        for (fk_number, pk_number) in column_numbers.iter().zip(ref_column_numbers.iter()) {
+            let Some(column) = local_attributes.get(fk_number) else { continue };
+            let Some(ref_column) = ref_attributes.get(pk_number) else { continue };
+            result.push(ForeignKeyInfo {
+                name: name.clone(),
+                column: column.clone(),
+                ref_schema: Some(ref_schema.clone()),
+                ref_table: ref_table.clone(),
+                ref_column: ref_column.clone(),
+                on_update: on_update.clone(),
+                on_delete: on_delete.clone(),
+            });
+        }
+    }
+    Ok(result)
+}
+
+fn opengauss_foreign_keys_sql() -> &'static str {
+    "SELECT con.conname, \
+            ref_n.nspname, ref_c.relname, \
+            COALESCE(con.conkey::text, ''), COALESCE(con.confkey::text, ''), \
+            con.confupdtype::text, con.confdeltype::text, \
+            con.conrelid::oid, con.confrelid::oid \
+     FROM pg_catalog.pg_constraint con \
+     JOIN pg_catalog.pg_class c ON c.oid = con.conrelid \
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+     JOIN pg_catalog.pg_class ref_c ON ref_c.oid = con.confrelid \
+     JOIN pg_catalog.pg_namespace ref_n ON ref_n.oid = ref_c.relnamespace \
+     WHERE con.contype = 'f' AND n.nspname = $1 AND c.relname = $2 \
+     ORDER BY con.conname"
 }
 
 fn postgres_table_dependencies_sql() -> &'static str {
@@ -9803,6 +9907,29 @@ mod tests {
         assert!(sql.contains("NOT a.attisdropped"));
         assert!(sql.contains("JOIN LATERAL"));
         assert!(!sql.contains("information_schema"));
+    }
+
+    #[test]
+    fn postgres_foreign_key_metadata_has_legacy_catalog_fallback() {
+        // The compat tiers exist for pre-9.4 servers, so they must avoid WITH
+        // ORDINALITY (a 9.4 feature) and pair conkey/confkey positions through
+        // generate_series + plain array subscripts instead, mirroring the index
+        // compat invariant.
+        for compat_sql in [postgres_foreign_keys_compat_sql(), postgres_foreign_keys_for_relations_compat_sql()] {
+            assert!(!compat_sql.contains("WITH ORDINALITY"));
+            assert!(compat_sql.contains("generate_series"));
+            assert!(compat_sql.contains("array_length(con.conkey, 1)"));
+            assert!(compat_sql.contains("con.contype = 'f'"));
+            assert!(compat_sql.contains("NOT a.attisdropped"));
+            assert!(!compat_sql.contains("information_schema"));
+        }
+        // OpenGauss resolves attribute numbers in Rust, so its SQL must not
+        // expand catalog arrays at all.
+        let opengauss_sql = opengauss_foreign_keys_sql();
+        assert!(!opengauss_sql.contains("WITH ORDINALITY"));
+        assert!(!opengauss_sql.contains("unnest"));
+        assert!(opengauss_sql.contains("con.conkey::text"));
+        assert!(opengauss_sql.contains("con.confkey::text"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3786,8 +3786,7 @@ fn postgres_indexes_for_relations_compat_sql() -> &'static str {
              ORDER BY t.oid, i.relname"
 }
 
-/// Batched sibling of `list_foreign_keys`, keyed by `(schema, table)` since
-/// this query is `information_schema`-based rather than oid-based.
+/// Batched sibling of `list_foreign_keys`, keyed by `(schema, table)`.
 pub async fn list_foreign_keys_for_relations(
     pool: &Pool,
     relations: &[(String, String)],
@@ -3818,8 +3817,8 @@ async fn list_foreign_keys_for_relations_with_sql(
             ref_schema: Some(pg_row_try_string(row, 4)),
             ref_table: pg_row_try_string(row, 5),
             ref_column: pg_row_try_string(row, 6),
-            on_update: postgres_foreign_key_action(pg_row_try_string(row, 7)),
-            on_delete: postgres_foreign_key_action(pg_row_try_string(row, 8)),
+            on_update: postgres_fk_action_label(pg_row_try_optional_text(row, 7)),
+            on_delete: postgres_fk_action_label(pg_row_try_optional_text(row, 8)),
         });
     }
     Ok(result)
@@ -3831,26 +3830,25 @@ fn postgres_foreign_keys_for_relations_query_tiers() -> [&'static str; 2] {
 
 fn postgres_foreign_keys_for_relations_sql() -> &'static str {
     "SELECT rel.rel_schema, rel.rel_table, \
-     fk.constraint_name, fk.column_name, \
-     pk.table_schema AS ref_schema, pk.table_name AS ref_table, pk.column_name AS ref_column, \
-     rc.update_rule AS on_update, rc.delete_rule AS on_delete \
+     con.conname AS constraint_name, \
+     a.attname AS column_name, \
+     ref_n.nspname AS ref_schema, \
+     ref_c.relname AS ref_table, \
+     ref_a.attname AS ref_column, \
+     con.confupdtype::text AS on_update_raw, \
+     con.confdeltype::text AS on_delete_raw \
      FROM unnest($1::text[], $2::text[]) AS rel(rel_schema, rel_table) \
-     JOIN information_schema.table_constraints tc \
-       ON tc.table_schema = rel.rel_schema AND tc.table_name = rel.rel_table \
-     JOIN information_schema.key_column_usage fk \
-       ON fk.constraint_name = tc.constraint_name \
-       AND fk.constraint_schema = tc.constraint_schema \
-       AND fk.table_schema = tc.table_schema \
-       AND fk.table_name = tc.table_name \
-     JOIN information_schema.referential_constraints rc \
-       ON rc.constraint_name = tc.constraint_name \
-       AND rc.constraint_schema = tc.constraint_schema \
-     JOIN information_schema.key_column_usage pk \
-       ON pk.constraint_name = rc.unique_constraint_name \
-       AND pk.constraint_schema = rc.unique_constraint_schema \
-       AND pk.ordinal_position = fk.position_in_unique_constraint \
-     WHERE tc.constraint_type = 'FOREIGN KEY' \
-     ORDER BY rel.rel_schema, rel.rel_table, fk.constraint_name, fk.ordinal_position"
+     JOIN pg_catalog.pg_constraint con ON true \
+     JOIN pg_catalog.pg_class c ON c.oid = con.conrelid \
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+     JOIN pg_catalog.pg_class ref_c ON ref_c.oid = con.confrelid \
+     JOIN pg_catalog.pg_namespace ref_n ON ref_n.oid = ref_c.relnamespace \
+     JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS fk(attnum, ord) ON true \
+     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = fk.attnum AND NOT a.attisdropped \
+     JOIN LATERAL unnest(con.confkey) WITH ORDINALITY AS pk(attnum, ord) ON pk.ord = fk.ord \
+     JOIN pg_catalog.pg_attribute ref_a ON ref_a.attrelid = ref_c.oid AND ref_a.attnum = pk.attnum AND NOT ref_a.attisdropped \
+     WHERE con.contype = 'f' AND n.nspname = rel.rel_schema AND c.relname = rel.rel_table \
+     ORDER BY rel.rel_schema, rel.rel_table, con.conname, fk.ord"
 }
 
 // PostgreSQL 9.3 and older only accept one array argument to unnest(). Pair
@@ -3858,29 +3856,28 @@ fn postgres_foreign_keys_for_relations_sql() -> &'static str {
 // one bounded query and preserves each relation tuple's position.
 fn postgres_foreign_keys_for_relations_compat_sql() -> &'static str {
     "SELECT rel.rel_schema, rel.rel_table, \
-     fk.constraint_name, fk.column_name, \
-     pk.table_schema AS ref_schema, pk.table_name AS ref_table, pk.column_name AS ref_column, \
-     rc.update_rule AS on_update, rc.delete_rule AS on_delete \
+     con.conname AS constraint_name, \
+     a.attname AS column_name, \
+     ref_n.nspname AS ref_schema, \
+     ref_c.relname AS ref_table, \
+     ref_a.attname AS ref_column, \
+     con.confupdtype::text AS on_update_raw, \
+     con.confdeltype::text AS on_delete_raw \
      FROM ( \
        SELECT ($1::text[])[rel.i] AS rel_schema, ($2::text[])[rel.i] AS rel_table \
        FROM generate_subscripts($1::text[], 1) AS rel(i) \
      ) AS rel \
-     JOIN information_schema.table_constraints tc \
-       ON tc.table_schema = rel.rel_schema AND tc.table_name = rel.rel_table \
-     JOIN information_schema.key_column_usage fk \
-       ON fk.constraint_name = tc.constraint_name \
-       AND fk.constraint_schema = tc.constraint_schema \
-       AND fk.table_schema = tc.table_schema \
-       AND fk.table_name = tc.table_name \
-     JOIN information_schema.referential_constraints rc \
-       ON rc.constraint_name = tc.constraint_name \
-       AND rc.constraint_schema = tc.constraint_schema \
-     JOIN information_schema.key_column_usage pk \
-       ON pk.constraint_name = rc.unique_constraint_name \
-       AND pk.constraint_schema = rc.unique_constraint_schema \
-       AND pk.ordinal_position = fk.position_in_unique_constraint \
-     WHERE tc.constraint_type = 'FOREIGN KEY' \
-     ORDER BY rel.rel_schema, rel.rel_table, fk.constraint_name, fk.ordinal_position"
+     JOIN pg_catalog.pg_constraint con ON true \
+     JOIN pg_catalog.pg_class c ON c.oid = con.conrelid \
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+     JOIN pg_catalog.pg_class ref_c ON ref_c.oid = con.confrelid \
+     JOIN pg_catalog.pg_namespace ref_n ON ref_n.oid = ref_c.relnamespace \
+     JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS fk(attnum, ord) ON true \
+     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = fk.attnum AND NOT a.attisdropped \
+     JOIN LATERAL unnest(con.confkey) WITH ORDINALITY AS pk(attnum, ord) ON pk.ord = fk.ord \
+     JOIN pg_catalog.pg_attribute ref_a ON ref_a.attrelid = ref_c.oid AND ref_a.attnum = pk.attnum AND NOT ref_a.attisdropped \
+     WHERE con.contype = 'f' AND n.nspname = rel.rel_schema AND c.relname = rel.rel_table \
+     ORDER BY rel.rel_schema, rel.rel_table, con.conname, fk.ord"
 }
 
 /// Batched sibling of `get_table_comment`.
@@ -4356,7 +4353,7 @@ fn postgres_constraint_type_label(contype: &str) -> String {
 }
 
 /// Normalize a `confupdtype`/`confdeltype` letter to an `information_schema`
-/// style referential-action label, mirroring `postgres_foreign_key_action`.
+/// style referential-action label.
 fn postgres_fk_action_label(action: Option<String>) -> Option<String> {
     action
         .as_deref()
@@ -7405,34 +7402,24 @@ pub async fn list_invalid_indexes(pool: &Pool, schema: &str, table: &str) -> Res
 }
 
 fn postgres_foreign_keys_sql() -> &'static str {
-    "SELECT fk.constraint_name, fk.column_name, \
-     pk.table_schema AS ref_schema, pk.table_name AS ref_table, pk.column_name AS ref_column, \
-     rc.update_rule AS on_update, rc.delete_rule AS on_delete \
-     FROM information_schema.table_constraints tc \
-     JOIN information_schema.key_column_usage fk \
-       ON fk.constraint_name = tc.constraint_name \
-       AND fk.constraint_schema = tc.constraint_schema \
-       AND fk.table_schema = tc.table_schema \
-       AND fk.table_name = tc.table_name \
-     JOIN information_schema.referential_constraints rc \
-       ON rc.constraint_name = tc.constraint_name \
-       AND rc.constraint_schema = tc.constraint_schema \
-     JOIN information_schema.key_column_usage pk \
-       ON pk.constraint_name = rc.unique_constraint_name \
-       AND pk.constraint_schema = rc.unique_constraint_schema \
-       AND pk.ordinal_position = fk.position_in_unique_constraint \
-     WHERE tc.constraint_type = 'FOREIGN KEY' \
-       AND fk.table_schema = $1 AND fk.table_name = $2 \
-     ORDER BY fk.constraint_name, fk.ordinal_position"
-}
-
-fn postgres_foreign_key_action(value: String) -> Option<String> {
-    let value = value.trim();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
+    "SELECT con.conname AS constraint_name, \
+     a.attname AS column_name, \
+     ref_n.nspname AS ref_schema, \
+     ref_c.relname AS ref_table, \
+     ref_a.attname AS ref_column, \
+     con.confupdtype::text AS on_update_raw, \
+     con.confdeltype::text AS on_delete_raw \
+     FROM pg_catalog.pg_constraint con \
+     JOIN pg_catalog.pg_class c ON c.oid = con.conrelid \
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+     JOIN pg_catalog.pg_class ref_c ON ref_c.oid = con.confrelid \
+     JOIN pg_catalog.pg_namespace ref_n ON ref_n.oid = ref_c.relnamespace \
+     JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS fk(attnum, ord) ON true \
+     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = fk.attnum AND NOT a.attisdropped \
+     JOIN LATERAL unnest(con.confkey) WITH ORDINALITY AS pk(attnum, ord) ON pk.ord = fk.ord \
+     JOIN pg_catalog.pg_attribute ref_a ON ref_a.attrelid = ref_c.oid AND ref_a.attnum = pk.attnum AND NOT ref_a.attisdropped \
+     WHERE con.contype = 'f' AND n.nspname = $1 AND c.relname = $2 \
+     ORDER BY con.conname, fk.ord"
 }
 
 pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ForeignKeyInfo>, String> {
@@ -7449,8 +7436,8 @@ pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result
             ref_schema: Some(pg_row_try_string(row, 2)),
             ref_table: pg_row_try_string(row, 3),
             ref_column: pg_row_try_string(row, 4),
-            on_update: postgres_foreign_key_action(pg_row_try_string(row, 5)),
-            on_delete: postgres_foreign_key_action(pg_row_try_string(row, 6)),
+            on_update: postgres_fk_action_label(pg_row_try_optional_text(row, 5)),
+            on_delete: postgres_fk_action_label(pg_row_try_optional_text(row, 6)),
         })
         .collect())
 }
@@ -9805,9 +9792,17 @@ mod tests {
     fn postgres_foreign_keys_sql_selects_referential_actions() {
         let sql = postgres_foreign_keys_sql();
 
-        assert!(sql.contains("rc.update_rule AS on_update"));
-        assert!(sql.contains("rc.delete_rule AS on_delete"));
-        assert!(sql.contains("information_schema.referential_constraints rc"));
+        assert!(sql.contains("pg_catalog.pg_constraint"));
+        assert!(sql.contains("con.confupdtype::text AS on_update_raw"));
+        assert!(sql.contains("con.confdeltype::text AS on_delete_raw"));
+        assert!(sql.contains("confdeltype"));
+        assert!(sql.contains("ref_n.nspname"));
+        assert!(sql.contains("unnest(con.conkey) WITH ORDINALITY"));
+        assert!(sql.contains("n.nspname = $1 AND c.relname = $2"));
+        assert!(sql.contains("con.contype = 'f'"));
+        assert!(sql.contains("NOT a.attisdropped"));
+        assert!(sql.contains("JOIN LATERAL"));
+        assert!(!sql.contains("information_schema"));
     }
 
     #[test]
@@ -9828,14 +9823,6 @@ mod tests {
         assert!(compat_sql.contains("pg_catalog.pg_inherits"));
         assert!(compat_sql.contains("con.contype = 'f'"));
         assert!(compat_sql.contains("ORDER BY table_name, ref_table"));
-    }
-
-    #[test]
-    fn postgres_foreign_key_action_keeps_non_empty_action() {
-        assert_eq!(postgres_foreign_key_action("CASCADE".to_string()), Some("CASCADE".to_string()));
-        assert_eq!(postgres_foreign_key_action(" SET NULL ".to_string()), Some("SET NULL".to_string()));
-        assert_eq!(postgres_foreign_key_action("".to_string()), None);
-        assert_eq!(postgres_foreign_key_action("  ".to_string()), None);
     }
 
     #[test]
@@ -10855,14 +10842,24 @@ mod tests {
         assert_eq!(modern_sql, postgres_foreign_keys_for_relations_sql());
         assert!(modern_sql.contains("unnest($1::text[], $2::text[])"));
         assert!(!modern_sql.contains("generate_subscripts"));
+        assert!(modern_sql.contains("pg_catalog.pg_constraint"));
+        assert!(!modern_sql.contains("information_schema"));
+        assert!(modern_sql.contains("con.confupdtype::text"));
+        assert!(modern_sql.contains("confdeltype"));
+        assert!(modern_sql.contains("con.contype = 'f'"));
+        assert!(modern_sql.contains("ORDER BY rel.rel_schema, rel.rel_table, con.conname, fk.ord"));
 
         let compat_sql = tiers[1];
         assert_eq!(compat_sql, postgres_foreign_keys_for_relations_compat_sql());
-        assert!(!compat_sql.contains("unnest("));
+        assert!(!compat_sql.contains("unnest($1::text[]"));
         assert!(compat_sql.contains("generate_subscripts($1::text[], 1)"));
         assert!(compat_sql.contains("($1::text[])[rel.i] AS rel_schema"));
         assert!(compat_sql.contains("($2::text[])[rel.i] AS rel_table"));
-        assert!(compat_sql.contains("ORDER BY rel.rel_schema, rel.rel_table, fk.constraint_name, fk.ordinal_position"));
+        assert!(compat_sql.contains("pg_catalog.pg_constraint"));
+        assert!(!compat_sql.contains("information_schema"));
+        assert!(compat_sql.contains("confdeltype"));
+        assert!(compat_sql.contains("con.contype = 'f'"));
+        assert!(compat_sql.contains("ORDER BY rel.rel_schema, rel.rel_table, con.conname, fk.ord"));
     }
 
     #[test]

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -7481,7 +7481,11 @@ pub async fn list_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result
 /// older OpenGauss releases may reject WITH ORDINALITY or decode catalog arrays
 /// differently on the wire, so read conkey/confkey as text and resolve the
 /// attribute numbers in Rust.
-pub async fn list_opengauss_foreign_keys(pool: &Pool, schema: &str, table: &str) -> Result<Vec<ForeignKeyInfo>, String> {
+pub async fn list_opengauss_foreign_keys(
+    pool: &Pool,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<ForeignKeyInfo>, String> {
     let schema = if schema.is_empty() { "public" } else { schema };
     let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
     let rows = postgres_query_cached(&client, opengauss_foreign_keys_sql(), &[&schema, &table])

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -7027,6 +7027,9 @@ async fn list_foreign_keys_core_for_session(
                     db::mysql::list_foreign_keys(p, mysql_table_metadata_catalog(database, schema), table).await
                 }
             }
+            PoolKind::Postgres(p) if db_config.as_ref().is_some_and(is_opengauss_constraint_config) => {
+                db::postgres::list_opengauss_foreign_keys(p, schema, table).await
+            }
             PoolKind::Postgres(p) => db::postgres::list_foreign_keys(p, schema, table).await,
             PoolKind::Sqlite(p) => db::sqlite::list_foreign_keys(p, schema, table).await,
             PoolKind::Rqlite(client) => db::rqlite_driver::list_foreign_keys(client, schema, table).await,


### PR DESCRIPTION
### Summary

Migrates PostgreSQL foreign key metadata queries from `information_schema` views (`table_constraints`, `key_column_usage`, `referential_constraints`) to system catalogs (`pg_catalog.pg_constraint`, `pg_class`, `pg_namespace`, and `pg_attribute`).

### Context & Motivation

Standard `information_schema` views restrict returned rows based on the current user's table privileges. Consequently, read-only roles (e.g. users granted only `SELECT`) observe zero foreign keys even when constraints exist. Querying `pg_catalog.pg_constraint` ensures foreign key metadata is consistently visible regardless of role privilege limitations, aligning with existing catalog patterns used in `postgres_check_constraints_sql` and `postgres_constraints_sql`.

### Screenshots
(current situation)
<img width="719" height="249" alt="image" src="https://github.com/user-attachments/assets/0f0d8494-95e3-4214-9879-6206382acca7" />

### Key Changes

- **Queries Migrated to `pg_catalog`**:
  - `postgres_foreign_keys_sql` (single relation lookup).
  - `postgres_foreign_keys_for_relations_sql` (batched relation lookup via array `unnest`).
  - `postgres_foreign_keys_for_relations_compat_sql` (batched relation lookup via `generate_subscripts`).
- **Composite Key Handling**: Joined `LATERAL unnest(con.conkey) WITH ORDINALITY` and `LATERAL unnest(con.confkey) WITH ORDINALITY` on `pk.ord = fk.ord` to guarantee declared column pairing and ordering.
- **Action Label Mapping**: Mapped `confupdtype` and `confdeltype` action codes (`a`, `r`, `c`, `n`, `d`) through `postgres_fk_action_label` to preserve standard referential action strings (`CASCADE`, `SET NULL`, `NO ACTION`, etc.).
- **Tests**: Updated unit test assertions in `crates/dbx-core/src/db/postgres.rs` to validate catalog query construction and clauses (`JOIN LATERAL`, `ORDINALITY`, `pg_catalog.pg_constraint`).

### Verification

- Fast PostgreSQL test suite passed:
  ```bash
  cargo test -p dbx-core --lib -- db::postgres::tests
  ```
  *(219 unit tests passing)*
