### PR TITLE
Fix：修复 SQL Server SET 关键字未高亮

### DIFF
--- a/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
@@ -55,6 +55,13 @@ const POSTGRES_IDENTIFIER_LIKE_KEYWORDS = new Set("COMMENT COUNT DATA DAY HOUR I
 // SQL Server table-valued parameters require READONLY in procedure/function declarations.
 const SQLSERVER_KEYWORDS = "readonly";
 
+function sqlServerBuiltinSyntaxTerms(builtin: string): string {
+  return builtin
+    .split(/\s+/)
+    .filter((term) => term && term.toUpperCase() !== "SET")
+    .join(" ");
+}
+
 const CLICKHOUSE_KEYWORDS = [
   "ATTACH",
   "DETACH",
@@ -216,12 +223,13 @@ export function createDbxCodeMirrorSqlDialect(langSql: CodeMirrorSqlLanguageModu
   const baseKeywords = isClickHouse ? standardSqlKeywordSyntaxTerms(langSql) : isPostgres ? postgresKeywordSyntaxTerms(baseDialect.spec.keywords || "") : baseDialect.spec.keywords || "";
   const baseTypes = isClickHouse ? STANDARD_SQL_TYPES : baseDialect.spec.types || "";
   const commonKeywords = isClickHouse ? DBX_COMMON_SQL_KEYWORDS.toLowerCase() : DBX_COMMON_SQL_KEYWORDS;
+  const baseBuiltin = isSqlServer ? sqlServerBuiltinSyntaxTerms(baseDialect.spec.builtin || "") : baseDialect.spec.builtin || "";
 
   return langSql.SQLDialect.define({
     ...baseDialect.spec,
     keywords: [baseKeywords, commonKeywords, isClickHouse ? CLICKHOUSE_KEYWORDS : "", isPostgres ? POSTGRES_PLPGSQL_KEYWORDS : "", isSqlServer ? SQLSERVER_KEYWORDS : ""].filter(Boolean).join(" "),
     types: [baseTypes, isClickHouse ? CLICKHOUSE_TYPES : "", isPostgres ? POSTGRES_PLPGSQL_TYPES : ""].filter(Boolean).join(" ") || undefined,
-    builtin: [baseDialect.spec.builtin || "", isClickHouse ? CLICKHOUSE_BUILTINS : "", isPostgres ? `${POSTGRES_BUILTINS} ${POSTGRES_PLPGSQL_BUILTIN}` : "", isMysql ? MYSQL_BUILTINS : "", driverProfileSqlBuiltinTerms(driverProfile)].filter(Boolean).join(" ") || undefined,
+    builtin: [baseBuiltin, isClickHouse ? CLICKHOUSE_BUILTINS : "", isPostgres ? `${POSTGRES_BUILTINS} ${POSTGRES_PLPGSQL_BUILTIN}` : "", isMysql ? MYSQL_BUILTINS : "", driverProfileSqlBuiltinTerms(driverProfile)].filter(Boolean).join(" ") || undefined,
     ...(isClickHouse
       ? {
           identifierQuotes: '"`',

--- a/packages/app-tests/codemirrorSqlDialect.test.ts
+++ b/packages/app-tests/codemirrorSqlDialect.test.ts
@@ -27,6 +27,17 @@ test("adds SQL Server READONLY for table-valued procedure parameters", () => {
   assert.equal(countParsedNodes(dialect, "CREATE PROCEDURE [dbo].[gylxcx](@tp2 XTableType5 readonly,@tp xtabletype2 readonly) AS SELECT 1", "Keyword", "readonly"), 2);
 });
 
+test("classifies SQL Server SET as a keyword instead of a builtin", () => {
+  const dialect = createDbxCodeMirrorSqlDialect(langSql, "sqlserver");
+
+  assert.equal(countParsedNodes(dialect, "UPDATE users SET name = 'Alice'", "Keyword", "SET"), 1);
+  assert.equal(countParsedNodes(dialect, "SET NOCOUNT ON", "Keyword", "SET"), 1);
+  assert.equal(
+    dialect.spec.builtin?.split(/\s+/).some((term) => term.toUpperCase() === "SET"),
+    false,
+  );
+});
+
 test("uses MSSQL keywords for an ASE JDBC editor override", () => {
   const dialect = createDbxCodeMirrorSqlDialect(langSql, "sqlserver", "jdbc");
 


### PR DESCRIPTION
## 问题

SQL Server 查询编辑器中，合法的 `SET` 关键字未显示关键字高亮样式。

### 复现 SQL

```sql
UPDATE users SET name = 'Alice' WHERE id = 1;
SET NOCOUNT ON;
```

## 原因

CodeMirror 的 MSSQL 词表同时将 `SET` 配置为 `Keyword` 和 `Builtin`。解析时 `Builtin` 覆盖了 `Keyword`，导致编辑器没有使用关键字高亮样式。

## 修复

- 仅针对 SQL Server 方言从 `Builtin` 词表中移除重复的 `SET`
- 保留 SQL Server 其他内置函数和关键字
- 增加 `UPDATE ... SET` 与独立 `SET NOCOUNT ON` 的解析回归测试

## 验证

- CodeMirror 方言测试：10/10 通过
- TypeScript 类型检查通过
- Oxfmt 格式检查通过
- Tauri 客户端实际验证：`SET` 已与 `UPDATE`、`WHERE` 一样显示关键字高亮

关联 issue：Fixes #7545
