### PR TITLE
fix(sqlserver): highlight SET as a keyword

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from "vitest";
 import * as langSql from "@codemirror/lang-sql";
-import { createDbxCodeMirrorSqlDialect, postgresKeywordSyntaxTerms } from "@/lib/editor/codemirrorSqlDialect";
+import { createDbxCodeMirrorSqlDialect, postgresKeywordSyntaxTerms, sqlServerBuiltinSyntaxTerms } from "@/lib/editor/codemirrorSqlDialect";
 import type { DatabaseType } from "@/types/database";
+
+function nodeNameAt(dialect: langSql.SQLDialect, statement: string, word: string): string | undefined {
+  const cursor = dialect.language.parser.parse(statement).cursor();
+
+  do {
+    if (statement.slice(cursor.from, cursor.to) === word) return cursor.name;
+  } while (cursor.next());
+
+  return undefined;
+}
 
 describe("codemirrorSqlDialect", () => {
   it("keeps common PostgreSQL identifier names out of keyword highlighting", () => {
@@ -33,6 +43,29 @@ describe("codemirrorSqlDialect", () => {
     expect(doltBuiltins.has("dolt_branch")).toBe(true);
     expect(doltBuiltins.has("dolt_merge")).toBe(true);
     expect(mysqlBuiltins.has("dolt_branch")).toBe(false);
+  });
+
+  it("highlights SQL Server clause words as keywords instead of builtin functions", () => {
+    const builtins = new Set(sqlServerBuiltinSyntaxTerms(langSql.MSSQL.spec.builtin || "").split(/\s+/));
+
+    expect(builtins.has("set")).toBe(false);
+    expect(builtins.has("next")).toBe(false);
+    expect(builtins.has("for")).toBe(false);
+    expect(builtins.has("getdate")).toBe(true);
+    expect(builtins.has("count")).toBe(true);
+    expect(builtins.has("left")).toBe(true);
+  });
+
+  it("tokenizes SET as a keyword for SQL Server statements", () => {
+    const dialect = createDbxCodeMirrorSqlDialect(langSql, "sqlserver", "sqlserver");
+    const statements = ["UPDATE users SET name = 'Alice' WHERE id = 1", "SET NOCOUNT ON", "SET @total = 5"];
+
+    for (const statement of statements) {
+      expect(nodeNameAt(dialect, statement, "SET"), statement).toBe("Keyword");
+    }
+
+    expect(nodeNameAt(dialect, "SELECT COUNT(*) FROM users", "COUNT")).toBe("Builtin");
+    expect(nodeNameAt(dialect, "SELECT GETDATE()", "GETDATE")).toBe("Builtin");
   });
 
   it("keeps double quotes as identifier delimiters for Oracle-family dialects", () => {

--- a/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
@@ -55,6 +55,21 @@ const POSTGRES_IDENTIFIER_LIKE_KEYWORDS = new Set("COMMENT COUNT DATA DAY HOUR I
 // SQL Server table-valued parameters require READONLY in procedure/function declarations.
 const SQLSERVER_KEYWORDS = "readonly";
 
+// CodeMirror's MSSQL builtin list registers a few T-SQL clause words as functions:
+// `set` arrives with the query hint terms, while `next`/`for` come from the
+// `NEXT VALUE FOR` sequence expression being split into single words. Builtin terms are
+// applied after keywords when the dialect vocabulary is built, so those entries shadow the
+// reserved-keyword highlighting for statements like `UPDATE ... SET` and `SET NOCOUNT ON`.
+// None of them is callable on its own, so drop them and let the keyword classification win.
+const SQLSERVER_NON_FUNCTION_BUILTIN_TERMS = new Set(["set", "next", "for"]);
+
+export function sqlServerBuiltinSyntaxTerms(builtin: string): string {
+  return builtin
+    .split(/\s+/)
+    .filter((term) => term && !SQLSERVER_NON_FUNCTION_BUILTIN_TERMS.has(term.toLowerCase()))
+    .join(" ");
+}
+
 const CLICKHOUSE_KEYWORDS = [
   "ATTACH",
   "DETACH",
@@ -216,12 +231,13 @@ export function createDbxCodeMirrorSqlDialect(langSql: CodeMirrorSqlLanguageModu
   const baseKeywords = isClickHouse ? standardSqlKeywordSyntaxTerms(langSql) : isPostgres ? postgresKeywordSyntaxTerms(baseDialect.spec.keywords || "") : baseDialect.spec.keywords || "";
   const baseTypes = isClickHouse ? STANDARD_SQL_TYPES : baseDialect.spec.types || "";
   const commonKeywords = isClickHouse ? DBX_COMMON_SQL_KEYWORDS.toLowerCase() : DBX_COMMON_SQL_KEYWORDS;
+  const baseBuiltin = isSqlServer ? sqlServerBuiltinSyntaxTerms(baseDialect.spec.builtin || "") : baseDialect.spec.builtin || "";
 
   return langSql.SQLDialect.define({
     ...baseDialect.spec,
     keywords: [baseKeywords, commonKeywords, isClickHouse ? CLICKHOUSE_KEYWORDS : "", isPostgres ? POSTGRES_PLPGSQL_KEYWORDS : "", isSqlServer ? SQLSERVER_KEYWORDS : ""].filter(Boolean).join(" "),
     types: [baseTypes, isClickHouse ? CLICKHOUSE_TYPES : "", isPostgres ? POSTGRES_PLPGSQL_TYPES : ""].filter(Boolean).join(" ") || undefined,
-    builtin: [baseDialect.spec.builtin || "", isClickHouse ? CLICKHOUSE_BUILTINS : "", isPostgres ? `${POSTGRES_BUILTINS} ${POSTGRES_PLPGSQL_BUILTIN}` : "", isMysql ? MYSQL_BUILTINS : "", driverProfileSqlBuiltinTerms(driverProfile)].filter(Boolean).join(" ") || undefined,
+    builtin: [baseBuiltin, isClickHouse ? CLICKHOUSE_BUILTINS : "", isPostgres ? `${POSTGRES_BUILTINS} ${POSTGRES_PLPGSQL_BUILTIN}` : "", isMysql ? MYSQL_BUILTINS : "", driverProfileSqlBuiltinTerms(driverProfile)].filter(Boolean).join(" ") || undefined,
     ...(isClickHouse
       ? {
           identifierQuotes: '"`',


### PR DESCRIPTION
## 问题

SQL Server 查询编辑器中的 `SET` 关键字未按关键字样式高亮。

```sql
UPDATE users SET name = 'Alice' WHERE id = 1;
SET NOCOUNT ON;
```

## 原因

CodeMirror 的 MSSQL 词表在构建时按 `keywords`、`types`、`builtin` 的顺序写入。由于 `builtin` 最后写入，词表中同时存在的词会被归类为 `Builtin`。

MSSQL 的 `builtin` 词表中除 `set` 外，还包含从 `NEXT VALUE FOR` 拆出的 `next` 和 `for`。这三个词不是独立可调用的函数，应保留为关键字分类。

## 修复

- 让 SQL Server 的 `set`、`next`、`for` 不再覆盖关键字分类
- 保留 `COUNT`、`LEFT`、`GETDATE`、`CAST`、`YEAR`、`COALESCE` 等真实内置函数
- 增加 `UPDATE ... SET`、`SET NOCOUNT ON`、`SET @var = ...` 的解析回归测试

## 验证

- CodeMirror、编辑器、SQL 及 `packages/app-tests` 测试通过
- TypeScript 类型检查通过
- Oxfmt 格式检查通过
- 使用 DBX 自身的方言和主题渲染验证：`SET` 被识别为 `Keyword`，真实函数仍被识别为 `Builtin`

关联 issue：Fixes #7545

> 说明：完整测试中的 `table_export::tests::external_driver_table_export_closes_cursor_after_fetch_error` 在最新 `main` 上也存在，与本 PR 无关。
