### PR TITLE
修复 Schema Diff 部署脚本预览与勾选集合不一致

### DIFF
--- a/apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue
@@ -39,6 +39,7 @@ const props = defineProps<{
   focusedObject?: SchemaDiffObject | null;
   deploySql: string;
   deploySqlAll: string;
+  rollbackForwardSql?: string;
   compatibilityWarnings?: CompatibilityWarning[];
   rollbackSql?: string;
   deploySqlMode?: "forward" | "rollback";
@@ -71,7 +72,7 @@ const rollbackConnectorKey = ref(0);
 
 const rollbackHunks = computed(() => {
   if (!props.rollbackSql) return [];
-  return buildHunks(props.deploySql, props.rollbackSql);
+  return buildHunks(props.rollbackForwardSql ?? props.deploySql, props.rollbackSql);
 });
 
 const hunks = computed(() => {

--- a/apps/desktop/src/components/diff/SchemaDiffDialog.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDialog.vue
@@ -33,6 +33,7 @@ import {
   flattenSchemaDiffObjects,
   schemaDiffSelectionTargets,
   selectSchemaDiffInput,
+  selectSchemaDiffInputForObject,
   selectedSchemaDiffObjects,
   setSchemaDiffObjectSelected,
   setSchemaDiffObjectSelectedWithDependencies,
@@ -108,8 +109,11 @@ const loading = ref(false);
 const diffObjects = ref<SchemaDiffObject[]>([]);
 const diffGroups = ref<OperationGroup[]>([]);
 const selectedObjectId = ref<string | null>(null);
-const deploySql = ref("");
-const deploySqlAll = ref("");
+const focusedDeploySql = ref("");
+const focusedForwardDeploySql = ref("");
+const focusedRollbackSql = ref("");
+const selectedDeploySql = ref("");
+const selectedForwardDeploySql = ref("");
 const executing = ref(false);
 const lastDiffResult = ref<SchemaDiffPreparation | null>(null);
 const targetDbVersion = ref<string | null>(null);
@@ -124,7 +128,8 @@ const renameCandidates = ref<RenameCandidate[]>([]);
 const compatibilityWarnings = ref<CompatibilityWarning[]>([]);
 const permissionDiffs = ref<PermissionDiff[]>([]);
 const dependencyGraph = ref<DependencyGraph | null>(null);
-let deploySqlGeneration = 0;
+let selectedDeploySqlGeneration = 0;
+let focusedDeploySqlGeneration = 0;
 
 // Rename candidates panel
 const showRenamePanel = ref(true);
@@ -274,13 +279,17 @@ const canDeploy = computed(() => {
 });
 
 function resetComparisonResultState() {
-  deploySqlGeneration++;
+  selectedDeploySqlGeneration++;
+  focusedDeploySqlGeneration++;
   step.value = "config";
   diffObjects.value = [];
   diffGroups.value = [];
   selectedObjectId.value = null;
-  deploySql.value = "";
-  deploySqlAll.value = "";
+  focusedDeploySql.value = "";
+  focusedForwardDeploySql.value = "";
+  focusedRollbackSql.value = "";
+  selectedDeploySql.value = "";
+  selectedForwardDeploySql.value = "";
   lastDiffResult.value = null;
   rollbackSql.value = "";
   rollbackCompleteness.value = "complete";
@@ -552,17 +561,12 @@ async function handleCompare() {
     // Group by operation type and object kind
     diffGroups.value = groupDiffObjects(diffObjects.value);
 
-    // Save full result and apply column rename detection to SQL
+    // Save the structured result; both script previews are generated from the
+    // current selection projection below rather than from the initial full SQL.
     lastDiffResult.value = result;
-    deploySqlAll.value = result.syncSql;
-    if (opts?.detectRenames && opts.renameThreshold) {
-      deploySqlAll.value = injectColumnRenameSql(deploySqlAll.value, result.diffs, opts.renameThreshold);
-      if (rollbackSql.value) {
-        rollbackSql.value = injectColumnRenameSql(rollbackSql.value, result.diffs, opts.renameThreshold, true);
-      }
-    }
     deploySqlMode.value = "forward";
-    await regenerateDeploySql();
+    await regenerateSelectedDeploySql();
+    await regenerateFocusedDeploySql();
 
     step.value = "result";
   } catch (e: any) {
@@ -585,7 +589,7 @@ function handleToggleGroupSelection(operationType: DiffOperationType, selected: 
     }
   }
   rebuildDiffGroups();
-  void regenerateDeploySql();
+  void regenerateSelectedDeploySql();
 }
 
 function handleToggleObjectSelection(object: SchemaDiffObject, selected: boolean) {
@@ -595,7 +599,7 @@ function handleToggleObjectSelection(object: SchemaDiffObject, selected: boolean
   }
   if (!changed) return;
   rebuildDiffGroups();
-  void regenerateDeploySql();
+  void regenerateSelectedDeploySql();
 }
 
 function updateObjectSelection(objectId: string, selected: boolean): boolean {
@@ -615,43 +619,81 @@ function rebuildDiffGroups() {
   }));
 }
 
-async function regenerateDeploySql() {
-  const result = lastDiffResult.value;
-  if (!result) {
-    deploySql.value = "-- No objects selected";
-    rollbackSql.value = "";
-    return;
-  }
+function buildSchemaSyncPlanOptions(options: SchemaDiffCompareOptions) {
+  return {
+    databaseType: getDbType(),
+    targetSchema: schemaDiffDeployTargetSchema(getDbType(), targetDatabase.value, targetSchema.value),
+    cascadeDelete: options.cascadeDelete,
+    sourceDialect: options.sourceDialect ? normalizeDialectKind(options.sourceDialect) : sourceDbType.value ? databaseTypeToDialectKind(sourceDbType.value) : undefined,
+    fieldMappings: options.fieldMappings,
+    enableRollback: options.enableRollback,
+  };
+}
 
-  const generation = ++deploySqlGeneration;
-  const options = normalizeSchemaDiffCompareOptions(activeConfig.value?.options, getDbType());
-  const input = selectSchemaDiffInput(result, diffObjects.value);
-  let plan;
-  try {
-    plan = await api.generateSchemaSyncPlan(input, {
-      databaseType: getDbType(),
-      targetSchema: schemaDiffDeployTargetSchema(getDbType(), targetDatabase.value, targetSchema.value),
-      cascadeDelete: options.cascadeDelete,
-      sourceDialect: options.sourceDialect ? normalizeDialectKind(options.sourceDialect) : sourceDbType.value ? databaseTypeToDialectKind(sourceDbType.value) : undefined,
-      fieldMappings: options.fieldMappings,
-      enableRollback: options.enableRollback,
-    });
-  } catch (error: any) {
-    if (generation === deploySqlGeneration) toast(error?.message || String(error), 5000);
-    return;
-  }
-  if (generation !== deploySqlGeneration) return;
-
+function formatSchemaSyncPlan(plan: Awaited<ReturnType<typeof api.generateSchemaSyncPlan>>, input: ReturnType<typeof selectSchemaDiffInput>, options: SchemaDiffCompareOptions) {
   let forwardSql = plan.syncSql || "-- No objects selected";
   let nextRollbackSql = plan.rollbackSyncSql ?? "";
-  rollbackCompleteness.value = plan.rollbackCompleteness ?? "complete";
-  missingRollbackObjects.value = plan.missingRollbackObjects ?? [];
   if (options.detectRenames && options.renameThreshold) {
     forwardSql = injectColumnRenameSql(forwardSql, input.diffs, options.renameThreshold);
     if (nextRollbackSql) nextRollbackSql = injectColumnRenameSql(nextRollbackSql, input.diffs, options.renameThreshold, true);
   }
-  rollbackSql.value = nextRollbackSql;
-  deploySql.value = deploySqlMode.value === "rollback" && nextRollbackSql ? nextRollbackSql : forwardSql;
+  return { forwardSql, rollbackSql: nextRollbackSql };
+}
+
+async function regenerateSelectedDeploySql() {
+  const result = lastDiffResult.value;
+  const generation = ++selectedDeploySqlGeneration;
+  if (!result) {
+    selectedForwardDeploySql.value = "-- No objects selected";
+    selectedDeploySql.value = "-- No objects selected";
+    rollbackSql.value = "";
+    return;
+  }
+
+  const options = normalizeSchemaDiffCompareOptions(activeConfig.value?.options, getDbType());
+  const input = selectSchemaDiffInput(result, diffObjects.value);
+  let plan;
+  try {
+    plan = await api.generateSchemaSyncPlan(input, buildSchemaSyncPlanOptions(options));
+  } catch (error: any) {
+    if (generation === selectedDeploySqlGeneration) toast(error?.message || String(error), 5000);
+    return;
+  }
+  if (generation !== selectedDeploySqlGeneration) return;
+
+  const formatted = formatSchemaSyncPlan(plan, input, options);
+  rollbackCompleteness.value = plan.rollbackCompleteness ?? "complete";
+  missingRollbackObjects.value = plan.missingRollbackObjects ?? [];
+  selectedForwardDeploySql.value = formatted.forwardSql;
+  rollbackSql.value = formatted.rollbackSql;
+  selectedDeploySql.value = deploySqlMode.value === "rollback" && formatted.rollbackSql ? formatted.rollbackSql : formatted.forwardSql;
+}
+
+async function regenerateFocusedDeploySql(objectId: string | null = selectedObjectId.value) {
+  const result = lastDiffResult.value;
+  const generation = ++focusedDeploySqlGeneration;
+  if (!result || !objectId || !findSchemaDiffObject(diffObjects.value, objectId)) {
+    focusedForwardDeploySql.value = "-- No objects selected";
+    focusedRollbackSql.value = "";
+    focusedDeploySql.value = "-- No objects selected";
+    return;
+  }
+
+  const options = normalizeSchemaDiffCompareOptions(activeConfig.value?.options, getDbType());
+  const input = selectSchemaDiffInputForObject(result, diffObjects.value, objectId);
+  let plan;
+  try {
+    plan = await api.generateSchemaSyncPlan(input, buildSchemaSyncPlanOptions(options));
+  } catch (error: any) {
+    if (generation === focusedDeploySqlGeneration && selectedObjectId.value === objectId) toast(error?.message || String(error), 5000);
+    return;
+  }
+  if (generation !== focusedDeploySqlGeneration || selectedObjectId.value !== objectId) return;
+
+  const formatted = formatSchemaSyncPlan(plan, input, options);
+  focusedForwardDeploySql.value = formatted.forwardSql;
+  focusedRollbackSql.value = formatted.rollbackSql;
+  focusedDeploySql.value = deploySqlMode.value === "rollback" && formatted.rollbackSql ? formatted.rollbackSql : formatted.forwardSql;
 }
 
 function switchDeploySqlMode(mode: "forward" | "rollback") {
@@ -660,10 +702,10 @@ function switchDeploySqlMode(mode: "forward" | "rollback") {
     return;
   }
   deploySqlMode.value = mode;
-  if (mode === "rollback" && rollbackSql.value) {
-    deploySql.value = rollbackSql.value;
-  } else {
-    void regenerateDeploySql();
+  selectedDeploySql.value = mode === "rollback" && rollbackSql.value ? rollbackSql.value : selectedForwardDeploySql.value;
+  focusedDeploySql.value = mode === "rollback" && focusedRollbackSql.value ? focusedRollbackSql.value : focusedForwardDeploySql.value;
+  if (mode === "rollback" && !rollbackSql.value) {
+    void regenerateSelectedDeploySql();
   }
 }
 
@@ -676,7 +718,7 @@ const canExecuteDeploy = computed(() => {
 
 const destructiveStatements = computed(() => {
   const databaseType = store.getConfig(targetConnectionId.value)?.db_type;
-  return detectDestructiveSchemaDiffStatements(deploySql.value, databaseType);
+  return detectDestructiveSchemaDiffStatements(selectedDeploySql.value, databaseType);
 });
 
 function applyRename(rc: RenameCandidate) {
@@ -703,7 +745,8 @@ function applyRename(rc: RenameCandidate) {
   }
   if (found) {
     rebuildDiffGroups();
-    void regenerateDeploySql();
+    void regenerateSelectedDeploySql();
+    void regenerateFocusedDeploySql();
     toast(t("diff.renameApplied"), 2000);
   }
 }
@@ -720,11 +763,12 @@ function ignoreRename(index: number) {
   }
   renameCandidates.value.splice(index, 1);
   rebuildDiffGroups();
-  void regenerateDeploySql();
+  void regenerateSelectedDeploySql();
+  void regenerateFocusedDeploySql();
 }
 
 async function handleExecuteScript() {
-  if (!deploySql.value.trim() || deploySql.value.trim() === "-- No objects selected") {
+  if (!selectedDeploySql.value.trim() || selectedDeploySql.value.trim() === "-- No objects selected") {
     toast(t("diff.noObjectsSelected"), 3000);
     return;
   }
@@ -743,10 +787,10 @@ async function executeDeploySql() {
     const failed = await executeWithProductionSqlGuard({
       connection: targetConnection,
       database: targetDatabase.value,
-      sql: deploySql.value,
+      sql: selectedDeploySql.value,
       source: t("production.sourceSchemaDiff"),
       execute: async () => {
-        const txLog = await api.executeScriptWith2pc(targetConnectionId.value, targetDatabase.value, [deploySql.value], targetSchema.value, destructiveStatements.value.length > 0);
+        const txLog = await api.executeScriptWith2pc(targetConnectionId.value, targetDatabase.value, [selectedDeploySql.value], targetSchema.value, destructiveStatements.value.length > 0);
         return txLog;
       },
     });
@@ -769,6 +813,7 @@ function showDeployTxResult(txLog: any) {
 }
 async function handleSelectObject(reviewObject: SchemaDiffObject) {
   selectedObjectId.value = reviewObject.id;
+  void regenerateFocusedDeploySql(reviewObject.id);
   const obj = reviewObject.parentId ? (findSchemaDiffObject(diffObjects.value, reviewObject.parentId) ?? reviewObject) : reviewObject;
 
   // Dynamically fetch DDL for objects that don't have pre-generated DDL
@@ -1035,8 +1080,9 @@ const targetConnectionInfo = computed(() => {
               <SchemaDiffDdlPanel
                 :selected-object="selectedObject"
                 :focused-object="selectedTreeObject"
-                :deploy-sql="deploySql"
-                :deploy-sql-all="deploySqlAll"
+                :deploy-sql="focusedDeploySql"
+                :deploy-sql-all="selectedDeploySql"
+                :rollback-forward-sql="selectedForwardDeploySql"
                 :compatibility-warnings="selectedCompatibilityWarnings"
                 :rollback-sql="rollbackSql"
                 :deploy-sql-mode="deploySqlMode"
@@ -1055,7 +1101,7 @@ const targetConnectionInfo = computed(() => {
         <!-- Deploy Review Step -->
         <template v-else-if="step === 'deploy-review'">
           <SchemaDiffDeployStep
-            v-model:deploy-sql="deploySql"
+            v-model:deploy-sql="selectedDeploySql"
             :selected-objects="diffObjects"
             :target-connection-id="targetConnectionId"
             :target-database="targetDatabase"

--- a/apps/desktop/src/components/diff/__tests__/SchemaDiffDdlPanel.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/SchemaDiffDdlPanel.spec.ts
@@ -13,4 +13,9 @@ describe("SchemaDiffDdlPanel diff highlighting", () => {
   it("never applies the focused-row outline to empty padding lines", () => {
     expect(panelSource).toContain('if (line.isPadding || focusedLineNumber === null) return "";');
   });
+
+  it("keeps rollback comparison based on the selected forward SQL", () => {
+    expect(panelSource).toContain("rollbackForwardSql?: string;");
+    expect(panelSource).toContain("props.rollbackForwardSql ?? props.deploySql");
+  });
 });

--- a/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
@@ -71,4 +71,19 @@ describe("SchemaDiffDialog fullscreen layout", () => {
     expect(targetMatch).toBeGreaterThan(comparisonScope);
     expect(targetMatch).toBeLessThan(options);
   });
+
+  it("keeps focused and selected deployment SQL projections separate", () => {
+    expect(dialogSource).toContain('const focusedDeploySql = ref("");');
+    expect(dialogSource).toContain('const selectedDeploySql = ref("");');
+    expect(dialogSource).toContain("const input = selectSchemaDiffInputForObject(result, diffObjects.value, objectId);");
+    expect(dialogSource).toContain(':deploy-sql="focusedDeploySql"');
+    expect(dialogSource).toContain(':deploy-sql-all="selectedDeploySql"');
+    expect(dialogSource).not.toContain("deploySqlAll.value = result.syncSql");
+  });
+
+  it("executes the selected SQL rather than the focused preview", () => {
+    expect(dialogSource).toContain("sql: selectedDeploySql.value");
+    expect(dialogSource).toContain("[selectedDeploySql.value]");
+    expect(dialogSource).toContain("selectedObjectId.value !== objectId");
+  });
 });

--- a/apps/desktop/src/lib/__tests__/schema/schemaDiffSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/schema/schemaDiffSelection.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { convertToSchemaDiffObjects, selectSchemaDiffInput, selectSchemaDiffInputForObject, setSchemaDiffObjectSelected, type SchemaDiffPreparation } from "../../schema/schemaDiff";
+
+function createPreparation(): SchemaDiffPreparation {
+  return {
+    diffs: [
+      {
+        type: "modified",
+        objectType: "table",
+        name: "table_a",
+        columns: [
+          { type: "added", name: "a_col" },
+          { type: "added", name: "a_other_col" },
+        ],
+      },
+      {
+        type: "modified",
+        objectType: "table",
+        name: "table_b",
+        columns: [{ type: "added", name: "b_col" }],
+      },
+    ],
+    syncSql: "-- table_a and table_b",
+  };
+}
+
+describe("schema diff SQL selection projections", () => {
+  it("keeps the focused table SQL separate from the full selected SQL", () => {
+    const result = createPreparation();
+    const objects = convertToSchemaDiffObjects(result.diffs);
+
+    const selectedInput = selectSchemaDiffInput(result, objects);
+    const focusedInput = selectSchemaDiffInputForObject(result, objects, "table-table_a");
+
+    expect(selectedInput.diffs.map((diff) => diff.name)).toEqual(["table_a", "table_b"]);
+    expect(focusedInput.diffs.map((diff) => diff.name)).toEqual(["table_a"]);
+    expect(focusedInput.diffs[0]?.columns?.map((column) => column.name)).toEqual(["a_col", "a_other_col"]);
+  });
+
+  it("projects a child object without including sibling or parent changes", () => {
+    const result = createPreparation();
+    const objects = convertToSchemaDiffObjects(result.diffs);
+
+    const focusedInput = selectSchemaDiffInputForObject(result, objects, "col-table_a-a_col");
+
+    expect(focusedInput.diffs.map((diff) => diff.name)).toEqual(["table_a"]);
+    expect(focusedInput.diffs[0]?.columns?.map((column) => column.name)).toEqual(["a_col"]);
+  });
+
+  it("updates the selected input after a checkbox change while leaving focused projection independent", () => {
+    const result = createPreparation();
+    const objects = convertToSchemaDiffObjects(result.diffs);
+
+    setSchemaDiffObjectSelected(objects, "table-table_b", false);
+    setSchemaDiffObjectSelected(objects, "col-table_a-a_col", false);
+
+    const selectedInput = selectSchemaDiffInput(result, objects);
+    const focusedInput = selectSchemaDiffInputForObject(result, objects, "table-table_a");
+
+    expect(selectedInput.diffs.map((diff) => diff.name)).toEqual(["table_a"]);
+    expect(selectedInput.diffs[0]?.columns?.map((column) => column.name)).toEqual(["a_other_col"]);
+    expect(focusedInput.diffs[0]?.columns?.map((column) => column.name)).toEqual(["a_col", "a_other_col"]);
+  });
+
+  it("returns an empty input for an object that is no longer present", () => {
+    const result = createPreparation();
+    const objects = convertToSchemaDiffObjects(result.diffs);
+
+    expect(selectSchemaDiffInputForObject(result, objects, "missing-object")).toEqual({
+      diffs: [],
+      functionDiffs: [],
+      sequenceDiffs: [],
+      ruleDiffs: [],
+      ownerDiffs: [],
+    });
+  });
+});

--- a/apps/desktop/src/lib/schema/schemaDiff.ts
+++ b/apps/desktop/src/lib/schema/schemaDiff.ts
@@ -802,6 +802,26 @@ export function selectSchemaDiffInput(result: SchemaDiffPreparation, objects: Sc
   };
 }
 
+function projectSchemaDiffObjectSelection(object: SchemaDiffObject, focusedObjectId: string, selectDescendants: boolean): SchemaDiffObject {
+  const isFocused = object.id === focusedObjectId;
+  const selectChildren = selectDescendants || isFocused;
+  return {
+    ...object,
+    selected: isFocused || selectDescendants,
+    children: object.children?.map((child) => projectSchemaDiffObjectSelection(child, focusedObjectId, selectChildren)),
+  };
+}
+
+/** Project one focused tree object onto a fresh selection without mutating checkbox state. */
+export function selectSchemaDiffInputForObject(result: SchemaDiffPreparation, objects: SchemaDiffObject[], objectId: string): SelectedSchemaDiffInput {
+  if (!findSchemaDiffObject(objects, objectId)) {
+    return { diffs: [], functionDiffs: [], sequenceDiffs: [], ruleDiffs: [], ownerDiffs: [] };
+  }
+
+  const focusedSelection = objects.map((object) => projectSchemaDiffObjectSelection(object, objectId, false));
+  return selectSchemaDiffInput(result, focusedSelection);
+}
+
 export function buildDeploySqlForObjects(objects: SchemaDiffObject[]): string {
   const selected = objects.filter((o) => {
     return o.selected && o.operationType !== "none" && !o.parentId;


### PR DESCRIPTION
Closes #7489

## 问题

Schema Diff 结果页中，当前点击对象的“部署脚本”和当前 checkbox 勾选集合的“全部部署脚本”使用了混淆的状态：

- 切换当前对象后，单对象部署脚本没有随对象更新。
- checkbox 选择变化后，全部部署脚本可能仍显示初次比较结果。
- 实际执行 SQL 与预览状态职责混用。

## 根因

初次比较结果的 `result.syncSql` 被长期作为全部部署 SQL 保存；对象点击只更新 DDL focus，没有重新生成对象级 SQL。selection 功能引入后，focused object 与 selected objects 的 SQL 状态没有分离。

## 修复内容

- 增加 focused object 的独立 SQL preview。
- 根据当前 checkbox selection 重新生成全部部署脚本。
- 实际执行和部署审核继续使用当前 selected SQL。
- 增加 focused / selected 两套异步 generation guard，避免切换对象或快速修改选择时出现竞态覆盖。
- 保留 child/dependency selection、forward / rollback、生产环境执行保护。
- rollback 对比使用 selected forward SQL，避免与 focused preview 混用。
- 新增对象 selection projection，不修改实际 checkbox 状态。

## 修复后的语义

- “部署脚本”：当前点击对象对应的 SQL。
- “全部部署脚本”：当前 checkbox 勾选对象集合对应的 SQL。
- 实际执行：当前 checkbox 勾选对象集合对应的 SQL。

## 验证

- [x] 相关 Vitest：10 个测试文件、47 个测试通过
- [x] `pnpm typecheck`
- [x] `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- [x] `oxfmt --check`
- [x] `oxlint`
- [x] `git diff --check`

未执行真实数据库或 UI 手工验证；本次改动未涉及 DDL generator。
