### PR TITLE
fix: 统一转置视图长文本编辑样式

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -8329,6 +8329,15 @@ function transposeCellIsSelected(rowIndex: number, actualColIdx: number) {
   return visibleColIdx >= 0 && cellIsSelected(rowIndex, visibleColIdx);
 }
 
+// Transposed cells render at a compact row height (30px by default), while the
+// expanded editor (long text) grows well beyond that. Like the normal grid cell,
+// the transposed cell must stop clipping its content while the editor / readonly
+// text selection is active, otherwise the editor gets cropped below the row.
+function transposeCellEditorActive(recordIndex: number, valueIndex: number): boolean {
+  const rowId = displayItems.value[recordIndex]?.id;
+  return (editingCell.value?.rowId === rowId && editingCell.value.col === valueIndex) || readonlyTextCellMatches(rowId, valueIndex);
+}
+
 function onTransposeCellMouseenter(rowIndex: number, actualColIdx: number) {
   quickDownloadMenuCell.value = retainBinaryCellDownloadMenuForHover(quickDownloadMenuCell.value, { rowIndex, col: actualColIdx });
   if (isScrolling.value) return;
@@ -12487,10 +12496,12 @@ function openGridSnapshot() {
                     <div
                       v-for="cell in item.values"
                       :key="`${item.id}:${cell.recordIndex}`"
-                      class="relative flex shrink-0 items-center border-r border-border/70 px-2 py-0 truncate"
+                      class="relative flex shrink-0 items-center border-r border-border/70 px-2 py-0"
                       :class="[
                         transposeCellTextColorClass(cell.recordIndex, cell.valueIndex),
                         {
+                          'overflow-visible z-20 border-r-transparent': transposeCellEditorActive(cell.recordIndex, cell.valueIndex),
+                          'overflow-hidden text-ellipsis whitespace-nowrap': !transposeCellEditorActive(cell.recordIndex, cell.valueIndex),
                           'cell-selected': transposeCellIsSelected(cell.recordIndex, cell.valueIndex) && !displayItems[cell.recordIndex]?.isDirtyCol[cell.valueIndex],
                           'cell-selected-dirty': transposeCellIsSelected(cell.recordIndex, cell.valueIndex) && displayItems[cell.recordIndex]?.isDirtyCol[cell.valueIndex],
                           'cell-selected--sparse': transposeCellIsSelected(cell.recordIndex, cell.valueIndex) && !displayItems[cell.recordIndex]?.isDirtyCol[cell.valueIndex],

--- a/apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridTransposePresentation.spec.ts
@@ -33,4 +33,25 @@ describe("DataGrid transpose presentation", () => {
     expect(dataGridSource).toContain("whitespace-pre-wrap break-words select-text");
     expect(dataGridSource).not.toContain("data-grid-transpose-field-popover");
   });
+
+  it("stops clipping the cell while the long-text editor or readonly text selection is active", () => {
+    // Transposed rows are compact (30px by default) while the expanded editor
+    // grows well beyond that; the cell must switch to overflow-visible while the
+    // editor / readonly text selection is active, mirroring the normal grid cell.
+    expect(dataGridSource).toContain("'overflow-visible z-20 border-r-transparent': transposeCellEditorActive(cell.recordIndex, cell.valueIndex)");
+    expect(dataGridSource).toContain("'overflow-hidden text-ellipsis whitespace-nowrap': !transposeCellEditorActive(cell.recordIndex, cell.valueIndex)");
+    expect(dataGridSource).toContain("function transposeCellEditorActive");
+    expect(dataGridSource).toContain("readonlyTextCellMatches(rowId, valueIndex)");
+    // The transposed cell no longer unconditionally truncates (overflow: hidden),
+    // which would crop the expanded editor below the compact row bounds.
+    expect(dataGridSource).not.toContain('class="relative flex shrink-0 items-center border-r border-border/70 px-2 py-0 truncate"');
+  });
+
+  it("shares the normal grid cell's editor overlay contract while editing", () => {
+    // Normal grid cells switch to the same overflow/z/border contract while the
+    // cell editor or readonly text selection is active, so long-text editing
+    // looks identical across both views.
+    expect(dataGridSource).toContain("'overflow-visible z-20 border-r-transparent': (editingCell?.rowId === item.id && editingCell?.col === col.actualColIdx) || readonlyTextCellMatches(item.id, col.actualColIdx),");
+    expect(dataGridSource).toContain("'overflow-hidden': !((editingCell?.rowId === item.id && editingCell?.col === col.actualColIdx) || readonlyTextCellMatches(item.id, col.actualColIdx)),");
+  });
 });


### PR DESCRIPTION
## 问题

转置视图中，当单元格内容较长时，双击进入编辑状态后的编辑框样式与普通 DataGrid 不一致。

长文本会触发展开式编辑器（textarea），该编辑框最小高度约 54px，而转置视图的行高默认只有 30px。普通视图的单元格在编辑 / 只读文本选择期间会把自身的 `overflow: hidden` 切换为 `overflow-visible z-20 border-r-transparent`，让编辑框可以完整溢出显示；而转置视图的单元格始终是 `truncate`（`overflow: hidden`），没有这套切换，因此编辑框超出转置行高的部分被裁剪，视觉上与普通视图明显不一致。

## 修改

- 转置单元格改为与普通单元格一致的编辑态展示契约：编辑 / 只读文本选择激活时切换为 `overflow-visible z-20 border-r-transparent`，其他时候保持 `overflow-hidden text-ellipsis whitespace-nowrap`（沿用原有 `truncate` 的视觉行为）
- 新增 `transposeCellEditorActive()` 帮助函数统一判定编辑 / 只读状态，避免模板内重复表达式
- 未改动现有编辑、保存、键盘操作、值转换等任何行为

## 验证

- [x] 转置视图长文本双击编辑框不再被行高裁剪，样式与普通视图一致
- [x] 普通视图编辑行为无回归（编辑态契约断言仍在）
- [x] `DataGridTransposePresentation.spec.ts`：5 passed（新增 2 个回归测试）
- [x] `useDataGridEditor.spec.ts` / `DataGridInlineBulkEdit.spec.ts`：passed
- [x] `oxlint` / `vue-tsc typecheck` / `git diff --check`：通过
- [ ] `DataGridSurfaces` / `DataGridReadonlyTextSelection` / `DataGridBatchPasteFromCell`：本地 happy-dom 环境下因 `No such built-in module: node:` 预存在失败（未改动相关代码，stash 验证确认与本次修改无关）

Closes #7480
