### PR TITLE
fix(schema-diff): guard deploy script execution

### DIFF
--- a/apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDdlPanel.vue
@@ -465,10 +465,6 @@ function copyDeploySqlAll() {
             <Copy class="w-3 h-3" />
             {{ t("diff.copy") }}
           </Button>
-          <Button variant="ghost" size="sm" class="h-6 px-2 text-xs gap-1" :disabled="canExecute === false" @click="$emit('executeScript')">
-            <Play class="w-3 h-3" />
-            {{ t("diff.execute") }}
-          </Button>
         </div>
       </div>
       <div class="flex-1 overflow-auto p-3">

--- a/apps/desktop/src/components/diff/SchemaDiffDialog.vue
+++ b/apps/desktop/src/components/diff/SchemaDiffDialog.vue
@@ -51,6 +51,7 @@ import {
   type CompatibilityWarning,
   type PermissionDiff,
   type DependencyGraph,
+  normalizeSchemaDiffDependencyGraph,
 } from "@/lib/schema/schemaDiff";
 import { compileSchemaDiffTableFilter, filterSchemaDiffTables, isSchemaDiffView } from "@/lib/schema/schemaDiffTableFilter";
 import { Splitpanes, Pane } from "splitpanes";
@@ -553,7 +554,7 @@ async function handleCompare() {
     renameCandidates.value = result.renameCandidates ?? [];
     compatibilityWarnings.value = result.compatibilityWarnings ?? [];
     permissionDiffs.value = result.permissionDiffs ?? [];
-    dependencyGraph.value = result.dependencyGraph ?? null;
+    dependencyGraph.value = normalizeSchemaDiffDependencyGraph(result.dependencyGraph);
 
     // Convert to unified objects
     diffObjects.value = convertToSchemaDiffObjects(result.diffs, result.functionDiffs, result.sequenceDiffs, result.ruleDiffs, result.ownerDiffs, result.renameCandidates);
@@ -640,13 +641,19 @@ function formatSchemaSyncPlan(plan: Awaited<ReturnType<typeof api.generateSchema
   return { forwardSql, rollbackSql: nextRollbackSql };
 }
 
+function clearSelectedDeploySql() {
+  selectedForwardDeploySql.value = "";
+  selectedDeploySql.value = "";
+  rollbackSql.value = "";
+  rollbackCompleteness.value = "complete";
+  missingRollbackObjects.value = [];
+}
+
 async function regenerateSelectedDeploySql() {
   const result = lastDiffResult.value;
   const generation = ++selectedDeploySqlGeneration;
+  clearSelectedDeploySql();
   if (!result) {
-    selectedForwardDeploySql.value = "-- No objects selected";
-    selectedDeploySql.value = "-- No objects selected";
-    rollbackSql.value = "";
     return;
   }
 
@@ -672,10 +679,10 @@ async function regenerateSelectedDeploySql() {
 async function regenerateFocusedDeploySql(objectId: string | null = selectedObjectId.value) {
   const result = lastDiffResult.value;
   const generation = ++focusedDeploySqlGeneration;
+  focusedForwardDeploySql.value = "";
+  focusedRollbackSql.value = "";
+  focusedDeploySql.value = "";
   if (!result || !objectId || !findSchemaDiffObject(diffObjects.value, objectId)) {
-    focusedForwardDeploySql.value = "-- No objects selected";
-    focusedRollbackSql.value = "";
-    focusedDeploySql.value = "-- No objects selected";
     return;
   }
 
@@ -713,7 +720,8 @@ const canExecuteDeploy = computed(() => {
   if (deploySqlMode.value === "rollback" && rollbackCompleteness.value === "incomplete") {
     return false;
   }
-  return true;
+  const sql = selectedDeploySql.value.trim();
+  return sql.length > 0 && sql !== "-- No objects selected";
 });
 
 const destructiveStatements = computed(() => {

--- a/apps/desktop/src/components/diff/__tests__/SchemaDiffDdlPanel.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/SchemaDiffDdlPanel.spec.ts
@@ -18,4 +18,12 @@ describe("SchemaDiffDdlPanel diff highlighting", () => {
     expect(panelSource).toContain("rollbackForwardSql?: string;");
     expect(panelSource).toContain("props.rollbackForwardSql ?? props.deploySql");
   });
+
+  it("does not expose selected-SQL execution from the focused script tab", () => {
+    const focusedScript = panelSource.slice(panelSource.indexOf("<!-- Deploy Script -->"), panelSource.indexOf("<!-- Deploy Script All -->"));
+    const selectedScript = panelSource.slice(panelSource.indexOf("<!-- Deploy Script All -->"));
+
+    expect(focusedScript).not.toContain("$emit('executeScript')");
+    expect(selectedScript).toContain("$emit('executeScript')");
+  });
 });

--- a/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
@@ -86,6 +86,6 @@ describe("SchemaDiffDialog fullscreen layout", () => {
     expect(dialogSource).toContain("[selectedDeploySql.value]");
     expect(dialogSource).toContain("selectedObjectId.value !== objectId");
     expect(dialogSource).toContain('selectedDeploySql.value = "";');
-    expect(dialogSource).toContain('const sql = selectedDeploySql.value.trim();');
+    expect(dialogSource).toContain("const sql = selectedDeploySql.value.trim();");
   });
 });

--- a/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
+++ b/apps/desktop/src/components/diff/__tests__/SchemaDiffDialog.spec.ts
@@ -85,5 +85,7 @@ describe("SchemaDiffDialog fullscreen layout", () => {
     expect(dialogSource).toContain("sql: selectedDeploySql.value");
     expect(dialogSource).toContain("[selectedDeploySql.value]");
     expect(dialogSource).toContain("selectedObjectId.value !== objectId");
+    expect(dialogSource).toContain('selectedDeploySql.value = "";');
+    expect(dialogSource).toContain('const sql = selectedDeploySql.value.trim();');
   });
 });

--- a/apps/desktop/src/lib/__tests__/schema/schemaDiffSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/schema/schemaDiffSelection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { convertToSchemaDiffObjects, selectSchemaDiffInput, selectSchemaDiffInputForObject, setSchemaDiffObjectSelected, type SchemaDiffPreparation } from "../../schema/schemaDiff";
+import { convertToSchemaDiffObjects, normalizeSchemaDiffDependencyGraph, selectSchemaDiffInput, selectSchemaDiffInputForObject, setSchemaDiffObjectSelected, type SchemaDiffPreparation } from "../../schema/schemaDiff";
 
 function createPreparation(): SchemaDiffPreparation {
   return {
@@ -72,6 +72,39 @@ describe("schema diff SQL selection projections", () => {
       sequenceDiffs: [],
       ruleDiffs: [],
       ownerDiffs: [],
+    });
+  });
+
+  it("includes the complete predecessor closure in focused table SQL", () => {
+    const result = createPreparation();
+    result.diffs.push({
+      type: "added",
+      objectType: "table",
+      name: "table_c",
+    });
+    result.dependencyGraph = {
+      nodes: [
+        { tableName: "table_a", dependsOn: ["table_b"], dependedBy: [] },
+        { tableName: "table_b", dependsOn: ["table_c"], dependedBy: ["table_a"] },
+        { tableName: "table_c", dependsOn: [], dependedBy: ["table_b"] },
+      ],
+    };
+    const objects = convertToSchemaDiffObjects(result.diffs);
+
+    const focusedInput = selectSchemaDiffInputForObject(result, objects, "table-table_a");
+
+    expect(focusedInput.diffs.map((diff) => diff.name)).toEqual(["table_a", "table_b", "table_c"]);
+  });
+
+  it("normalizes the Rust dependency graph map and snake-case fields", () => {
+    expect(
+      normalizeSchemaDiffDependencyGraph({
+        nodes: {
+          table_a: { table_name: "table_a", depends_on: ["table_b"], depended_by: [] },
+        },
+      }),
+    ).toEqual({
+      nodes: [{ tableName: "table_a", dependsOn: ["table_b"], dependedBy: [] }],
     });
   });
 });

--- a/apps/desktop/src/lib/schema/schemaDiff.ts
+++ b/apps/desktop/src/lib/schema/schemaDiff.ts
@@ -264,6 +264,42 @@ export interface DependencyGraph {
   nodes: DependencyNode[];
 }
 
+interface RawSchemaDiffDependencyNode {
+  tableName?: unknown;
+  table_name?: unknown;
+  dependsOn?: unknown;
+  depends_on?: unknown;
+  dependedBy?: unknown;
+  depended_by?: unknown;
+}
+
+interface RawSchemaDiffDependencyGraph {
+  nodes?: RawSchemaDiffDependencyNode[] | Record<string, RawSchemaDiffDependencyNode>;
+}
+
+export function normalizeSchemaDiffDependencyGraph(graph: unknown): DependencyGraph | null {
+  if (!graph || typeof graph !== "object") return null;
+
+  const rawNodes = (graph as RawSchemaDiffDependencyGraph).nodes;
+  const entries = Array.isArray(rawNodes) ? rawNodes : rawNodes && typeof rawNodes === "object" ? Object.values(rawNodes) : [];
+  const nodes = entries.flatMap((node) => {
+    const tableName = typeof node.tableName === "string" ? node.tableName : typeof node.table_name === "string" ? node.table_name : "";
+    if (!tableName) return [];
+
+    const dependsOn = Array.isArray(node.dependsOn) ? node.dependsOn : Array.isArray(node.depends_on) ? node.depends_on : [];
+    const dependedBy = Array.isArray(node.dependedBy) ? node.dependedBy : Array.isArray(node.depended_by) ? node.depended_by : [];
+    return [
+      {
+        tableName,
+        dependsOn: dependsOn.filter((name): name is string => typeof name === "string"),
+        dependedBy: dependedBy.filter((name): name is string => typeof name === "string"),
+      },
+    ];
+  });
+
+  return nodes.length > 0 ? { nodes } : null;
+}
+
 export interface MissingRollbackObject {
   kind: string;
   name: string;
@@ -802,14 +838,37 @@ export function selectSchemaDiffInput(result: SchemaDiffPreparation, objects: Sc
   };
 }
 
-function projectSchemaDiffObjectSelection(object: SchemaDiffObject, focusedObjectId: string, selectDescendants: boolean): SchemaDiffObject {
+function projectSchemaDiffObjectSelection(object: SchemaDiffObject, focusedObjectId: string, selectDescendants: boolean, dependencyNames: ReadonlySet<string>): SchemaDiffObject {
   const isFocused = object.id === focusedObjectId;
-  const selectChildren = selectDescendants || isFocused;
+  const isDependency = !object.parentId && dependencyNames.has(object.name);
+  const selectChildren = selectDescendants || isFocused || isDependency;
   return {
     ...object,
-    selected: isFocused || selectDescendants,
-    children: object.children?.map((child) => projectSchemaDiffObjectSelection(child, focusedObjectId, selectChildren)),
+    selected: isFocused || selectDescendants || isDependency,
+    children: object.children?.map((child) => projectSchemaDiffObjectSelection(child, focusedObjectId, selectChildren, dependencyNames)),
   };
+}
+
+function schemaDiffDependencyClosure(result: SchemaDiffPreparation, objects: SchemaDiffObject[], objectId: string): Set<string> {
+  const focusedObject = findSchemaDiffObject(objects, objectId);
+  if (!focusedObject) return new Set();
+
+  const rootObject = focusedObject.parentId ? findSchemaDiffObject(objects, focusedObject.parentId) : focusedObject;
+  if (!rootObject) return new Set();
+
+  const dependencyNodes = new Map((normalizeSchemaDiffDependencyGraph(result.dependencyGraph)?.nodes ?? []).map((node) => [node.tableName, node]));
+  const dependencies = new Set<string>();
+  const pending = [rootObject.name];
+  while (pending.length > 0) {
+    const name = pending.pop();
+    if (!name) continue;
+    for (const dependency of dependencyNodes.get(name)?.dependsOn ?? []) {
+      if (dependency === rootObject.name || dependencies.has(dependency)) continue;
+      dependencies.add(dependency);
+      pending.push(dependency);
+    }
+  }
+  return dependencies;
 }
 
 /** Project one focused tree object onto a fresh selection without mutating checkbox state. */
@@ -818,7 +877,8 @@ export function selectSchemaDiffInputForObject(result: SchemaDiffPreparation, ob
     return { diffs: [], functionDiffs: [], sequenceDiffs: [], ruleDiffs: [], ownerDiffs: [] };
   }
 
-  const focusedSelection = objects.map((object) => projectSchemaDiffObjectSelection(object, objectId, false));
+  const dependencyNames = schemaDiffDependencyClosure(result, objects, objectId);
+  const focusedSelection = objects.map((object) => projectSchemaDiffObjectSelection(object, objectId, false, dependencyNames));
   return selectSchemaDiffInput(result, focusedSelection);
 }
 


### PR DESCRIPTION
Follow-up to merged PR #7552.

This patch closes the remaining review findings:

- Remove execution from the focused-only script preview because the execution path uses selected SQL.
- Clear selected SQL before regeneration and block execution when generation fails or returns no SQL, preventing stale SQL execution.
- Normalize the Rust dependency graph shape and include the full recursive dependency closure for focused plans.

Validation:
- focused static/regression checks added
- `git diff --check` passed

The remote environment has no `node_modules`, so Vitest was not available.
