### PR TITLE
✨ feat(grid): 支持 12 小时制日期格式并规范时区名称显示

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -174,6 +174,8 @@ import {
   applyColumnFormatter,
   buildColumnFormatterKey,
   defaultIoTDBTimestampFormatter,
+  DataGridDateTimePatterns,
+  displayTimeZoneOption,
   formatIoTDBTimestampEditorValue,
   getSupportedTimeZoneOptions,
   iotdbTimestampFractionDigits,
@@ -184,7 +186,6 @@ import {
   type ColumnFormatterConfig,
   type DateTimeFormatterUnit,
   type ForeignKeyDisplayFilterConfig,
-  DateTimePatterns,
 } from "@/lib/dataGrid/columnFormatter";
 import { temporalCellEditorConfig, type TemporalCellEditorConfig } from "@/lib/dataGrid/dataGridTemporalEditor";
 import { BOOLEAN_CELL_EDITOR_VALUES, booleanCellEditorValue, isBooleanCellValue, isBooleanColumnType, isPointInBooleanCheckbox, nextBooleanCellValue, normalizeBooleanCellValue, parseBooleanCellEditorValue } from "@/lib/dataGrid/dataGridBooleanColumn";
@@ -12983,7 +12984,7 @@ function openGridSnapshot() {
                                   </div>
                                   <SearchableSelect
                                     :model-value="formatterDatetimePattern"
-                                    :options="DateTimePatterns"
+                                    :options="DataGridDateTimePatterns"
                                     :placeholder="t('grid.formatterDatetimePatternPlaceholder')"
                                     :search-placeholder="t('grid.formatterDatetimePatternPlaceholder')"
                                     :empty-text="t('grid.formatterDatetimePatternEmpty')"
@@ -13002,6 +13003,7 @@ function openGridSnapshot() {
                                   <SearchableSelect
                                     :model-value="formatterDateTimezone"
                                     :options="timezoneOptions"
+                                    :display-name="displayTimeZoneOption"
                                     :placeholder="t('grid.formatterDatetimeTimezonePlaceholder')"
                                     :search-placeholder="t('grid.formatterDatetimeTimezonePlaceholder')"
                                     :empty-text="t('grid.formatterDatetimeTimezonePlaceholder')"

--- a/apps/desktop/src/lib/dataGrid/columnFormatter.ts
+++ b/apps/desktop/src/lib/dataGrid/columnFormatter.ts
@@ -28,6 +28,9 @@ export const DateTimePatterns = [
   "YYYY/MM/DDTHH:mm:ssZ",
   "YYYY/MM/DDTHH:mm:ss.SSSZ",
 ];
+// Keep global date-time formats compatible with the backend; the data grid can
+// additionally render Day.js 12-hour display patterns locally.
+export const DataGridDateTimePatterns = [...DateTimePatterns, "YYYY-MM-DD hh:mm:ss A"];
 const SUPPORTED_DATE_TIME_PATTERN_TOKENS = ["YYYY", "SSS", "ZZ", "MM", "DD", "HH", "mm", "ss", "M", "D", "H", "m", "s", "Z"];
 const STRICT_LOCAL_DATETIME_INPUT_PATTERNS = [
   "YYYY-MM-DD",
@@ -70,6 +73,14 @@ export interface ForeignKeyDisplayFilterConfig {
 
 interface IntlTimeZoneSupport {
   supportedValuesOf?: (key: "timeZone") => string[];
+}
+
+const TIME_ZONE_DISPLAY_ALIASES: Record<string, string> = {
+  "Asia/Calcutta": "Asia/Kolkata",
+};
+
+export function displayTimeZoneOption(timeZone: string): string {
+  return TIME_ZONE_DISPLAY_ALIASES[timeZone] ?? timeZone;
 }
 
 export function getSupportedTimeZoneOptions(intl: IntlTimeZoneSupport, fallbackTimeZone = "UTC"): string[] {


### PR DESCRIPTION
- 日期时间格式选项新增 `YYYY-MM-DD hh:mm:ss A`
- 将 `Asia/Calcutta` 显示为 `Asia/Kolkata`，提升时区兼容性与一致性

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="612" height="203" alt="image" src="https://github.com/user-attachments/assets/c0cb5107-d5fb-4d6c-8bb0-4680c35865b9" />


## 验证

验证 SQL：

```
SET time_zone = '+00:00';

CREATE TABLE `dbx_datetime_format_test` (
  `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
  `event_name` TEXT NOT NULL,
  `occurred_at` TIMESTAMP(3) NOT NULL
);

INSERT INTO `dbx_datetime_format_test` (`event_name`, `occurred_at`) VALUES
  ('issue example', '2026-08-29 16:44:03.983'),
  ('morning boundary', '2026-08-29 00:00:00.000'),
  ('afternoon boundary', '2026-08-29 12:00:00.000'),
  ('midnight after conversion', '2026-08-29 18:30:00.000');

SELECT `id`, `event_name`, `occurred_at`
FROM `dbx_datetime_format_test`
ORDER BY `id`;
```

<p>在 DBX 中对 <code dir="ltr">occurred_at</code> 设置：</p><ul><li>Datetime pattern：<code dir="ltr">YYYY-MM-DD hh:mm:ss A</code></li><li>Timezone：<code dir="ltr">Asia/Kolkata</code></li></ul><p>预期结果：</p><div><div><div>

event_name | 预期显示
-- | --
issue example | 2026-08-29 10:14:03 PM
morning boundary | 2026-08-29 05:30:00 AM
afternoon boundary | 2026-08-29 05:30:00 PM
midnight after conversion | 2026-08-30 12:00:00 AM

</div></div></div>

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #7560