### PR TITLE
Fix/issue 6688 7026 实现整行选中时使用更深颜色区分于选区覆盖淡色指示

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -7124,11 +7124,15 @@ function dataGridRowStyle(item: RowItem): CSSProperties {
     "--data-grid-cell-bg": rowBg,
     "--data-grid-row-number-bg": rowNumberBg,
     "--data-grid-cell-selected-bg": dark ? "rgb(20, 40, 60)" : "rgb(239, 246, 255)",
+    // 整行选中背景：比"选区覆盖淡色指示"更深，点击行号选中整行时醒目显示
+    "--data-grid-row-selected-bg": dark ? "rgb(30, 74, 128)" : "rgb(96, 165, 250)",
     "--data-grid-cell-selected-single-bg": dark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)",
     "--data-grid-cell-selected-dirty-bg": dark ? "rgb(76, 66, 38)" : "rgb(235, 224, 184)",
+    // 整行选中行内的脏单元格背景：跟随整行选中色同步加深的黄褐变体
+    "--data-grid-row-selected-dirty-bg": dark ? "rgb(100, 94, 52)" : "rgb(199, 185, 120)",
     "--data-grid-cell-selected-border": dark ? "rgb(96, 165, 250)" : "rgb(59, 130, 246)",
     "--data-grid-row-number-active-bg": activeRowBg,
-    "--data-grid-row-number-selected-bg": dark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)",
+    "--data-grid-row-number-selected-bg": dark ? "rgb(30, 74, 128)" : "rgb(96, 165, 250)",
   } as CSSProperties;
 }
 
@@ -12973,7 +12977,7 @@ function openGridSnapshot() {
                                     <SelectContent>
                                       <SelectItem value="auto">{{ t("grid.formatterUnitAuto") }}</SelectItem>
                                       <SelectItem value="seconds">{{ t("grid.formatterUnitSeconds") }}</SelectItem>
-                                      <SelectItem value="milliseconds">{{ t("grid.formatterUnitMilliseconds") }}</SelectItem>
+                                      <SelectItem value="milliseconds">{{ t("grid.formatterUnitMilliseconds") }} </SelectItem>
                                     </SelectContent>
                                   </Select>
                                 </div>
@@ -14203,13 +14207,13 @@ function openGridSnapshot() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start" class="w-44">
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('empty')">{{ t("grid.generateEmptyString") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('null')">{{ t("grid.generateNull") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('datetime')">{{ t("grid.generateCurrentDatetime") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('date')">{{ t("grid.generateCurrentDate") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('uuid')">{{ t("grid.generateUuid") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="applyGeneratedDetailValue('snowflake')">{{ t("grid.generateSnowflakeId") }}</DropdownMenuItem>
-                      <DropdownMenuItem @click="openGenerateIncrementDialog('detail')">{{ t("grid.generateIncrementId") }}</DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('empty')">{{ t("grid.generateEmptyString") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('null')">{{ t("grid.generateNull") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('datetime')">{{ t("grid.generateCurrentDatetime") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('date')">{{ t("grid.generateCurrentDate") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('uuid')">{{ t("grid.generateUuid") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="applyGeneratedDetailValue('snowflake')">{{ t("grid.generateSnowflakeId") }} </DropdownMenuItem>
+                      <DropdownMenuItem @click="openGenerateIncrementDialog('detail')">{{ t("grid.generateIncrementId") }} </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
                   <Button v-if="activeValueEditorActions.includes('formatJson')" variant="outline" size="sm" class="h-6 text-xs" @mousedown.prevent @click="formatValueEditorJson">
@@ -14542,8 +14546,12 @@ function openGridSnapshot() {
   --data-grid-cell-crosshair-col-bg: rgb(142, 170, 210);
   --data-grid-cell-dirty-bg: rgb(255, 248, 230);
   --data-grid-cell-selected-bg: rgb(239, 246, 255);
+  /* 整行选中背景：比"选区覆盖淡色指示"更深，点击行号选中整行时醒目显示 */
+  --data-grid-row-selected-bg: rgb(96, 165, 250);
   --data-grid-cell-selected-single-bg: rgb(191, 219, 254);
   --data-grid-cell-selected-dirty-bg: rgb(235, 224, 184);
+  /* 整行选中行内的脏单元格背景：跟随整行选中色同步加深的黄褐变体 */
+  --data-grid-row-selected-dirty-bg: rgb(199, 185, 120);
   --data-grid-cell-selected-border: rgb(59, 130, 246);
   --data-grid-cell-hover-bg: rgb(245, 245, 245);
   --data-grid-cell-search-bg: rgb(253, 245, 184);
@@ -14554,7 +14562,7 @@ function openGridSnapshot() {
   --data-grid-row-number-edited-bg: rgb(253, 241, 219);
   --data-grid-row-number-deleted-bg: rgb(255, 244, 244);
   --data-grid-row-number-active-bg: rgb(244, 248, 255);
-  --data-grid-row-number-selected-bg: rgb(191, 219, 254);
+  --data-grid-row-number-selected-bg: rgb(96, 165, 250);
   --data-grid-scrollbar-thumb: color-mix(in oklch, var(--foreground) 30%, transparent);
   --data-grid-scrollbar-thumb-hover: color-mix(in oklch, var(--foreground) 48%, transparent);
   --data-grid-scrollbar-track: transparent;
@@ -14564,6 +14572,7 @@ function openGridSnapshot() {
 [data-grid-root].data-grid--has-save-error {
   --data-grid-cell-dirty-bg: rgb(250, 212, 216) !important;
   --data-grid-cell-selected-dirty-bg: rgb(240, 192, 198) !important;
+  --data-grid-row-selected-dirty-bg: rgb(240, 192, 198) !important;
 }
 
 [data-grid-root].data-grid--dark,
@@ -14576,8 +14585,10 @@ function openGridSnapshot() {
   --data-grid-cell-crosshair-col-bg: rgb(98, 111, 130);
   --data-grid-cell-dirty-bg: rgb(94, 75, 26);
   --data-grid-cell-selected-bg: rgb(20, 40, 60);
+  --data-grid-row-selected-bg: rgb(30, 74, 128);
   --data-grid-cell-selected-single-bg: rgb(30, 64, 96);
   --data-grid-cell-selected-dirty-bg: rgb(76, 66, 38);
+  --data-grid-row-selected-dirty-bg: rgb(100, 94, 52);
   --data-grid-cell-selected-border: rgb(96, 165, 250);
   --data-grid-cell-hover-bg: rgb(46, 47, 51);
   --data-grid-cell-search-bg: rgb(72, 57, 8);
@@ -14588,7 +14599,7 @@ function openGridSnapshot() {
   --data-grid-row-number-edited-bg: rgb(48, 41, 28);
   --data-grid-row-number-deleted-bg: rgb(55, 31, 32);
   --data-grid-row-number-active-bg: rgb(25, 34, 46);
-  --data-grid-row-number-selected-bg: rgb(30, 64, 96);
+  --data-grid-row-number-selected-bg: rgb(30, 74, 128);
   --data-grid-scrollbar-thumb: rgb(82, 82, 91);
   --data-grid-scrollbar-thumb-hover: rgb(113, 113, 122);
   --data-grid-scrollbar-track: rgb(24, 24, 27);
@@ -14599,6 +14610,7 @@ function openGridSnapshot() {
 :global(.dark) [data-grid-root].data-grid--has-save-error {
   --data-grid-cell-dirty-bg: rgb(94, 56, 57) !important;
   --data-grid-cell-selected-dirty-bg: rgb(114, 66, 67) !important;
+  --data-grid-row-selected-dirty-bg: rgb(114, 66, 67) !important;
 }
 
 @supports (background: color-mix(in oklab, white 50%, transparent)) {
@@ -14610,14 +14622,16 @@ function openGridSnapshot() {
     --data-grid-cell-crosshair-row-bg: color-mix(in srgb, var(--primary) 34%, var(--background));
     --data-grid-cell-crosshair-col-bg: color-mix(in srgb, var(--primary) 50%, var(--background));
     --data-grid-cell-selected-bg: color-mix(in oklab, rgb(59 130 246) 12%, var(--background));
+    --data-grid-row-selected-bg: color-mix(in oklab, rgb(59 130 246) 60%, var(--background));
     --data-grid-cell-selected-single-bg: color-mix(in oklab, rgb(59 130 246) 30%, var(--background));
     --data-grid-cell-selected-dirty-bg: color-mix(in oklab, rgb(234 181 50) 30%, color-mix(in oklab, rgb(59 130 246) 18%, var(--background)));
+    --data-grid-row-selected-dirty-bg: color-mix(in oklab, rgb(234 181 50) 30%, var(--data-grid-row-selected-bg));
     --data-grid-cell-selected-border: color-mix(in oklab, rgb(59 130 246) 75%, transparent);
     --data-grid-cell-hover-bg: color-mix(in oklab, var(--accent) 50%, transparent);
     --data-grid-row-number-new-bg: color-mix(in oklab, rgb(16 185 129) 15%, var(--background));
     --data-grid-row-number-edited-bg: color-mix(in oklab, rgb(245 158 11) 15%, var(--background));
     --data-grid-row-number-deleted-bg: color-mix(in oklab, var(--destructive) 15%, var(--background));
-    --data-grid-row-number-selected-bg: color-mix(in oklab, rgb(59 130 246) 30%, var(--background));
+    --data-grid-row-number-selected-bg: color-mix(in oklab, rgb(59 130 246) 60%, var(--background));
   }
   [data-grid-root].data-grid--dark,
   :global(.dark) [data-grid-root] {
@@ -14627,11 +14641,14 @@ function openGridSnapshot() {
   [data-grid-root].data-grid--has-save-error {
     --data-grid-cell-dirty-bg: rgb(250, 212, 216) !important;
     --data-grid-cell-selected-dirty-bg: rgb(240, 192, 198) !important;
+    --data-grid-row-selected-dirty-bg: rgb(240, 192, 198) !important;
   }
+
   [data-grid-root].data-grid--dark.data-grid--has-save-error,
   :global(.dark) [data-grid-root].data-grid--has-save-error {
     --data-grid-cell-dirty-bg: rgb(94, 56, 57) !important;
     --data-grid-cell-selected-dirty-bg: rgb(114, 66, 67) !important;
+    --data-grid-row-selected-dirty-bg: rgb(114, 66, 67) !important;
   }
 }
 
@@ -14666,10 +14683,12 @@ function openGridSnapshot() {
 
 :global(.dark) [data-grid-root] {
   --data-grid-cell-selected-bg: rgb(20, 40, 60);
+  --data-grid-row-selected-bg: rgb(30, 74, 128);
   --data-grid-cell-selected-single-bg: rgb(30, 64, 96);
   --data-grid-cell-selected-dirty-bg: rgb(76, 66, 38);
+  --data-grid-row-selected-dirty-bg: rgb(100, 94, 52);
   --data-grid-cell-selected-border: rgb(96, 165, 250);
-  --data-grid-row-number-selected-bg: rgb(30, 64, 96);
+  --data-grid-row-number-selected-bg: rgb(30, 74, 128);
 }
 
 [data-grid-root].data-grid--dark .data-grid-header-cell--selected,
@@ -15126,7 +15145,7 @@ function openGridSnapshot() {
 }
 
 .row-cell-selected {
-  background-color: var(--data-grid-cell-selected-bg) !important;
+  background-color: var(--data-grid-row-selected-bg) !important;
 }
 
 .cell-dirty {
@@ -15168,7 +15187,7 @@ function openGridSnapshot() {
 }
 
 .row-cell-selected-dirty {
-  background-color: var(--data-grid-cell-selected-dirty-bg) !important;
+  background-color: var(--data-grid-row-selected-dirty-bg) !important;
 }
 
 .data-grid-row-number.bg-emerald-500\/15 {
@@ -15233,69 +15252,83 @@ function openGridSnapshot() {
 .cell-sel-frame-1 {
   box-shadow: inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-2 {
   box-shadow: inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-3 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-4 {
   box-shadow: inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-5 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-6 {
   box-shadow:
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-7 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-8 {
   box-shadow: inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-9 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-10 {
   box-shadow:
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-11 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-12 {
   box-shadow:
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-13 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-14 {
   box-shadow:
     inset -1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 0 -1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),
     inset 1.5px 0 0 0 var(--data-grid-cell-selected-single-border, var(--primary));
 }
+
 .cell-sel-frame-15 {
   box-shadow:
     inset 0 1.5px 0 0 var(--data-grid-cell-selected-single-border, var(--primary)),

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridPaintTheme.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridPaintTheme.spec.ts
@@ -178,6 +178,23 @@ describe("data grid paint theme", () => {
     expect(dark.cellDirty).toBe("rgb(94, 75, 26)");
   });
 
+  it("keeps the whole-row selection clearly deeper than the pale selection overlay", () => {
+    const emptyCssVariable = () => "";
+    const light = resolveDataGridPaintTheme({ getVar: emptyCssVariable, isDark: false });
+    const dark = resolveDataGridPaintTheme({ getVar: emptyCssVariable, isDark: true });
+
+    expect(light.rowSelected).toBe("rgb(96, 165, 250)");
+    expect(light.rowSelectedDirty).toBe("rgb(199, 185, 120)");
+    expect(light.rowNumberSelected).toBe("rgb(96, 165, 250)");
+    expect(dark.rowSelected).toBe("rgb(30, 74, 128)");
+    expect(dark.rowSelectedDirty).toBe("rgb(100, 94, 52)");
+    expect(dark.rowNumberSelected).toBe("rgb(30, 74, 128)");
+
+    // 整行选中必须比选区覆盖淡色指示更醒目：与白色背景的对比度更高
+    expect(contrastRatio(light.rowSelected, "rgb(255, 255, 255)")).toBeGreaterThan(contrastRatio(light.cellSelected, "rgb(255, 255, 255)"));
+    expect(contrastRatio(light.rowSelected, "rgb(255, 255, 255)")).toBeGreaterThanOrEqual(1.5);
+  });
+
   it("honors an explicit --data-grid-cell-selected-border token when provided in light mode", () => {
     const vars: Record<string, string> = {
       "--background": "rgb(255, 255, 255)",

--- a/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
+++ b/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
@@ -147,8 +147,9 @@ export function resolveCanvasBackingStoreMetrics(options: { width: number; heigh
   };
 }
 
-export function resolveCanvasDataGridRowFill(theme: Pick<DataGridPaintTheme, "cellActive" | "cellSelected">, rowBase: string, options: { isActive: boolean; isDeleted: boolean; isSelected: boolean }): string {
-  if (options.isSelected) return theme.cellSelected;
+export function resolveCanvasDataGridRowFill(theme: Pick<DataGridPaintTheme, "cellActive" | "rowSelected">, rowBase: string, options: { isActive: boolean; isDeleted: boolean; isSelected: boolean }): string {
+  // 整行选中用专属深色 token，与选区覆盖淡色指示（cellSelected）区分层级
+  if (options.isSelected) return theme.rowSelected;
   if (options.isActive && !options.isDeleted) return theme.cellActive;
   return rowBase;
 }
@@ -533,7 +534,8 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
         ctx.fillRect(clippedX, y, cellPaintWidth, CANVAS_DATA_GRID_ROW_HEIGHT);
       }
       if (selectedFillVisual && isDirtyCell) {
-        ctx.fillStyle = theme.cellSelectedDirty;
+        // 行选中时脏格跟随整行选中色加深；仅格选中时维持原有选区脏格色
+        ctx.fillStyle = rowSelectionVisual ? theme.rowSelectedDirty : theme.cellSelectedDirty;
         ctx.fillRect(clippedX, y, cellPaintWidth, CANVAS_DATA_GRID_ROW_HEIGHT);
       }
       if (isSearchMatch) {

--- a/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridPaintTheme.ts
@@ -21,6 +21,10 @@ export interface DataGridPaintTheme {
   cellSelectedBorder: string;
   cellSelectedSingle: string;
   cellSelectedSingleBorder: string;
+  /** 整行选中背景：比选区覆盖淡色指示更深，点击行号选中整行时醒目显示 */
+  rowSelected: string;
+  /** 整行选中行内的脏单元格背景：跟随整行选中色同步加深的黄褐变体 */
+  rowSelectedDirty: string;
   cellHover: string;
   cellSearch: string;
   cellCurrentSearch: string;
@@ -280,6 +284,8 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
   const cellSelectedDirty = isDark ? "rgb(76, 66, 38)" : "rgb(235, 224, 184)";
   const cellSelectedBorder = isDark ? "rgb(96, 165, 250)" : "rgb(59, 130, 246)";
   const cellSelectedSingle = isDark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)";
+  const rowSelected = isDark ? "rgb(30, 74, 128)" : "rgb(96, 165, 250)";
+  const rowSelectedDirty = isDark ? "rgb(100, 94, 52)" : "rgb(199, 185, 120)";
   const cellHover = accent;
   const cellSearch = isDark ? DATA_GRID_DARK_SEARCH_COLORS.match : "rgb(253, 245, 184)";
   const cellCurrentSearch = isDark ? DATA_GRID_DARK_SEARCH_COLORS.current : "rgba(253, 224, 71, 0.52)";
@@ -289,7 +295,7 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
   const rowNumberEdited = isDark ? DATA_GRID_DARK_ROW_NUMBER_EDITED_BG : DATA_GRID_LIGHT_ROW_NUMBER_EDITED_BG;
   const rowNumberDeleted = isDark ? DATA_GRID_DARK_ROW_NUMBER_DELETED_BG : DATA_GRID_LIGHT_ROW_NUMBER_DELETED_BG;
   const rowNumberActive = activeSurface;
-  const rowNumberSelected = isDark ? "rgb(30, 64, 96)" : "rgb(191, 219, 254)";
+  const rowNumberSelected = isDark ? "rgb(30, 74, 128)" : "rgb(96, 165, 250)";
   const typeDefaults = defaultDataGridTypeColors(isDark);
   const typeForegrounds = { unknown: foreground } as DataGridTypeForegrounds;
   for (const key of DATA_GRID_TYPE_COLOR_KEYS) {
@@ -314,6 +320,8 @@ export function resolveDataGridPaintTheme(options: { getVar: (name: string) => s
     cellSelectedBorder: paintToken(getVar, "--data-grid-cell-selected-border", cellSelectedBorder),
     cellSelectedSingle: paintToken(getVar, "--data-grid-cell-selected-single-bg", cellSelectedSingle),
     cellSelectedSingleBorder: paintToken(getVar, "--data-grid-cell-selected-single-border", primary),
+    rowSelected: paintToken(getVar, "--data-grid-row-selected-bg", rowSelected),
+    rowSelectedDirty: paintToken(getVar, "--data-grid-row-selected-dirty-bg", rowSelectedDirty),
     cellHover: isDark ? cellHover : paintToken(getVar, "--data-grid-cell-hover-bg", cellHover),
     cellSearch: isDark ? cellSearch : paintToken(getVar, "--data-grid-cell-search-bg", cellSearch),
     cellCurrentSearch: isDark ? cellCurrentSearch : paintToken(getVar, "--data-grid-cell-current-search-bg", cellCurrentSearch),

--- a/packages/app-tests/canvasDataGridRenderer.test.ts
+++ b/packages/app-tests/canvasDataGridRenderer.test.ts
@@ -52,11 +52,25 @@ test("DataGrid forwards hover action reservation only for right-aligned canvas c
 });
 
 test("canvas row fill keeps frozen and scrolling regions on the same selection surface", () => {
-  const theme = { cellActive: "active-blue", cellSelected: "selected-blue" };
+  const theme = { cellActive: "active-blue", rowSelected: "row-selected-blue" };
 
   assert.equal(resolveCanvasDataGridRowFill(theme, "base", { isActive: true, isDeleted: false, isSelected: false }), "active-blue");
-  assert.equal(resolveCanvasDataGridRowFill(theme, "base", { isActive: true, isDeleted: false, isSelected: true }), "selected-blue");
+  assert.equal(resolveCanvasDataGridRowFill(theme, "base", { isActive: true, isDeleted: false, isSelected: true }), "row-selected-blue");
   assert.equal(resolveCanvasDataGridRowFill(theme, "deleted", { isActive: true, isDeleted: true, isSelected: false }), "deleted");
+});
+
+test("paint theme exposes a dedicated deep row-selected token apart from the pale selection overlay", () => {
+  const getVar = () => "";
+
+  const light = resolveDataGridPaintTheme({ getVar, isDark: false });
+  const dark = resolveDataGridPaintTheme({ getVar, isDark: true });
+
+  assert.equal(light.rowSelected, "rgb(96, 165, 250)");
+  assert.equal(light.rowSelectedDirty, "rgb(199, 185, 120)");
+  assert.equal(light.rowNumberSelected, "rgb(96, 165, 250)");
+  assert.equal(dark.rowSelected, "rgb(30, 74, 128)");
+  assert.equal(dark.rowSelectedDirty, "rgb(100, 94, 52)");
+  assert.equal(dark.rowNumberSelected, "rgb(30, 74, 128)");
 });
 
 test("data grid paint themes use the increased striped row contrast", () => {

--- a/packages/app-tests/dataGridSelectionContrast.test.ts
+++ b/packages/app-tests/dataGridSelectionContrast.test.ts
@@ -10,3 +10,16 @@ test("data grid selection colors stay on the classic blue palette", () => {
   assert.doesNotMatch(source, /--data-grid-cell-selected-border:\s*color-mix\(in srgb, var\(--ring\)/);
   assert.doesNotMatch(source, /--data-grid-cell-selected-bg:\s*color-mix\(in srgb, var\(--primary\)/);
 });
+
+test("whole-row selection keeps its own deeper tokens in both render modes", () => {
+  const source = readFileSync("apps/desktop/src/components/grid/DataGrid.vue", "utf8");
+  // DOM 模式：整行选中使用专属深色 token（亮色 blue-400 / 暗色加深蓝）
+  assert.match(source, /--data-grid-row-selected-bg:\s*rgb\(96,\s*165,\s*250\)/);
+  assert.match(source, /--data-grid-row-selected-bg:\s*rgb\(30,\s*74,\s*128\)/);
+  assert.match(source, /"--data-grid-row-selected-bg":\s*dark \? "rgb\(30, 74, 128\)" : "rgb\(96, 165, 250\)"/);
+  assert.match(source, /--data-grid-row-selected-dirty-bg:\s*rgb\(199,\s*185,\s*120\)/);
+  assert.match(source, /\.row-cell-selected\s*\{\s*background-color:\s*var\(--data-grid-row-selected-bg\) !important;/);
+  assert.match(source, /\.row-cell-selected-dirty\s*\{\s*background-color:\s*var\(--data-grid-row-selected-dirty-bg\) !important;/);
+  // 选区覆盖淡色指示保持原浅色，不随整行选中加深
+  assert.match(source, /\.data-grid-row-number--in-selection\s*\{\s*background-color:\s*var\(--data-grid-cell-selected-bg\);/);
+});


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
实现整行选中时使用更深颜色区分于选区覆盖淡色指示

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）
<img width="1458" height="462" alt="20260830100925" src="https://github.com/user-attachments/assets/b2180da0-29fc-400d-871c-78ceab586cac" />

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #6688 #7026