### PR TITLE
fix(connection): hide URL input row for MQ connection types

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -5810,7 +5810,7 @@ function openExternalUrl(url: string) {
 
             <TabsContent value="connection" class="m-0 flex min-h-0 flex-1 flex-col overflow-hidden">
               <div class="connection-form-body grid min-h-0 flex-1 scroll-pb-6 gap-4 overflow-y-auto pt-4 pr-2 pb-6" :class="{ 'connection-form-body--nacos': form.db_type === 'nacos' }">
-                <div v-if="!isJdbcConnection && form.db_type !== 'nacos' && form.db_type !== 'consul'" class="grid grid-cols-4 items-center gap-4">
+                <div v-if="!isJdbcConnection && form.db_type !== 'nacos' && form.db_type !== 'consul' && form.db_type !== 'mq'" class="grid grid-cols-4 items-center gap-4">
                   <Label :class="connectionLabelClass">{{ t("connection.connectionUrlOptional") }}</Label>
                   <div class="col-span-3 flex items-center gap-1">
                     <Input v-model="connectionUrlInput" class="flex-1" :placeholder="connectionUrlPlaceholder" @keydown.enter.prevent="applyConnectionUrl" />


### PR DESCRIPTION
## Problem

When creating an MQ connection, the top "URL (optional)" input has two related defects:

1. **Wrong placeholder**: Pulsar / Kafka / RocketMQ / RabbitMQ all share `db_type` `mq`, but `connectionUrlPlaceholder` has no `mq` branch, so they all fall through to `default` and show the `postgresql://user:password@host:port/database` example.
2. **Parsing always fails**: `SCHEME_PROFILES` does not include the `amqp`/`pulsar`/`kafka`/`rocketmq` schemes, so pasting a real `amqp://...` URL throws `Unsupported connection URL scheme: amqp`.

In other words, the connection-URL input does not work for MQ types at all — offering a correct example would only lead to a parse error.

## Fix

MQ connections are configured via dedicated fields (address / virtual host / Management URL), so the URL input is meaningless for them. Hide the row for the entire `mq` type (a single `v-if` condition).

## Testing

- `pnpm typecheck` / `pnpm lint` pass
- Launched the full app (frontend + backend) and verified the new-connection form for all four MQ types (Pulsar / Kafka / RocketMQ / RabbitMQ) via a browser: the "URL (optional)" row is hidden in each; other traditional database types are unaffected