### PR TITLE
fix: 修复表节点“展开全部”失效

### DIFF
--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -2374,9 +2374,11 @@ fn sqlserver_list_tables_sql_with_kind(
 
     // Use SELECT TOP for broad SQL Server version compatibility.
     // OFFSET / FETCH NEXT is only available in SQL Server 2012+.
+    // Keep the requested limit intact: the sidebar requests page_size + 1 to
+    // detect whether it should render a load-more node.
     match (limit, offset) {
         (Some(limit), Some(offset)) if offset > 0 => {
-            let end = offset + limit.min(1000);
+            let end = offset + limit;
             format!(
                 "SELECT * FROM (\
                  SELECT {base_columns}, ROW_NUMBER() OVER ({order_by}) AS __dbx_rn \
@@ -2385,7 +2387,7 @@ fn sqlserver_list_tables_sql_with_kind(
             )
         }
         (Some(limit), _) => {
-            format!("SELECT TOP ({}) {base_columns} {base_from} {base_where} {order_by}", limit.min(1000))
+            format!("SELECT TOP ({}) {base_columns} {base_from} {base_where} {order_by}", limit)
         }
         _ => {
             format!("SELECT {base_columns} {base_from} {base_where} {order_by}")
@@ -4245,6 +4247,15 @@ mod tests {
         assert!(!sql.contains("o.type IN ('U','V')"));
         assert!(sql.contains("ROW_NUMBER() OVER (ORDER BY o.name)"));
         assert!(sql.contains("__dbx_rn > 100 AND __dbx_rn <= 201"));
+    }
+
+    #[test]
+    fn sqlserver_table_objects_sql_preserves_sidebar_probe_limits_above_1000() {
+        let first_page = sqlserver_table_objects_sql("dbo", None, Some(1001), None);
+        let next_page = sqlserver_table_objects_sql("dbo", None, Some(1001), Some(1000));
+
+        assert!(first_page.contains("SELECT TOP (1001)"));
+        assert!(next_page.contains("__dbx_rn > 1000 AND __dbx_rn <= 2001"));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

修复 #7572：SQL Server 用户在近期版本中使用「表 → 展开全部」时，超过默认分页数量的表无法继续加载，菜单操作看起来失效。

调查确认，这里的「展开全部」不是递归展开每张表的列等子节点，而是加载 table group 的完整对象列表：侧边栏首次请求 `pageSize + 1` 条元数据，用第 `pageSize + 1` 条判断是否需要渲染 `load-more` 节点；随后 `loadAllObjectGroupChildren` 逐页排空这些节点。

## 根因

确认是 SQL Server 元数据分页回归，回归提交为 `ff4667b93f`（`feat(structure): search and paginate source table picker for copy columns`）。

该提交让 SQL Server 的 table-only 请求直接走新的 `list_table_objects` 快速路径，并把分页参数下推到 SQL Server 查询。此前该路径会先取得完整列表，再由核心层做分页；新的 SQL 生成器却将 `TOP` / `ROW_NUMBER` 的 limit 强制截断为 `1000`。

DBX 默认侧边栏 page size 同样是 `1000`，因此前端探测请求的 `1001` 条被 SQL Server 后端截成恰好 `1000` 条，前端判断 `tables.length > pageSize` 为 false，不生成 `load-more` 节点。于是「展开全部」没有后续分页可排空。

这是 SQL Server 专有的后端分页契约回归，不是菜单 action、connection/database/schema scope 或其他数据库的 sidebar loader 问题。

## 修复

- 保留 SQL Server `TOP` 和 `ROW_NUMBER` 分页调用方传入的完整 limit。
- 使 sidebar 的 `pageSize + 1` 探测在默认值 `1000` 时真正返回第 `1001` 条。
- 保留旧版 SQL Server 的 `TOP` / `ROW_NUMBER` 兼容写法，不改变默认分页数量，也不重新设计侧边栏。
- 新增回归测试，覆盖 `1001` 条探测和下一页 `1000..2001` 的边界。

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts --testTimeout=30000`
- [x] `pnpm exec vitest run apps/desktop/src/stores/__tests__/connectionStore.metadataLoading.spec.ts -t "restores and drains unfiltered pages when expand-all races a search clear reload" --testTimeout=30000`
- [x] sidebar metadata pagination / load-more 相关 5 个 Vitest 用例
- [x] `cargo test -p dbx-core --no-default-features --features sqlite-bundled --lib -- db::sqlserver::tests::sqlserver_table_objects_sql_preserves_sidebar_probe_limits_above_1000 --exact`
- [x] `rustfmt --edition 2021 --check crates/dbx-core/src/db/sqlserver.rs`
- [x] `pnpm exec oxfmt --check`（相关 sidebar 文件）
- [x] `git diff --check`

未在报告者同款 SQL Server + Windows 环境进行真实 GUI 验证；当前机器没有可用的 SQL Server 测试实例。已通过 SQL Server SQL 生成单元测试和针对 metadata/sidebar 加载链路的自动化测试覆盖。

`oxlint` 已执行；当前 `connectionStore.ts` 存在本次改动前已有的 2 条 `unicorn` warning，本 PR 未修改该文件。

## Scope

- 不修改默认分页数量。
- 不修改普通展开、Load More、搜索或 selection / expansion state 的 sidebar 逻辑。
- 不增加 dependency。
- 不修改其他数据库的分页路径。
- 修复位于 SQL Server backend metadata pagination，恢复现有 table group「展开全部」契约。

Fixes #7572