### PR TITLE
fix: 修复关闭连接后相关标签页未正确清理的问题

### DIFF
--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -3841,6 +3841,10 @@ export const useConnectionStore = defineStore("connection", () => {
         queryStore.rollbackConnectionTransactions(connectionId);
         break;
     }
+    // Tab handling is synchronous in memory, but persistence is debounced. Flush
+    // the scoped tab state before disconnect returns so a quick reconnect/restart
+    // cannot restore tabs that the selected policy already removed.
+    await queryStore.flushPendingPersist().catch(() => undefined);
     await disconnectRequest;
     if (isCurrentConnectionStateRevision(connectionId, stateRevision)) {
       clearConnectionError(connectionId);
@@ -3879,6 +3883,10 @@ export const useConnectionStore = defineStore("connection", () => {
         queryStore.rollbackDatabaseTransactions(connectionId, database);
         break;
     }
+    // Keep database-level disconnect consistent with connection-level cleanup:
+    // the next restore must observe the post-policy tab set, not the debounced
+    // snapshot from before this database was closed.
+    await queryStore.flushPendingPersist().catch(() => undefined);
     const node = findDatabaseTreeNode(treeNodes.value, connectionId, database);
     if (node) {
       node.isExpanded = false;

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -4449,6 +4449,8 @@ test("disconnecting a connection closes every tab for that connection", async ()
     connectionStore.addEphemeralConnection(conn("conn-2"));
     const queryId = queryStore.createTab("conn-1", "db", "draft query", "query");
     const dataId = queryStore.createTab("conn-1", "db", "users", "data", "public");
+    const objectId = queryStore.openObjectBrowser("conn-1", "db", "public");
+    const structureId = queryStore.openTableStructure("conn-1", "db", "public", "users");
     const otherConnectionId = queryStore.createTab("conn-2", "db", "users", "data", "public");
 
     queryStore.activeTabId = dataId;
@@ -4461,10 +4463,127 @@ test("disconnecting a connection closes every tab for that connection", async ()
     );
     assert.equal(queryStore.activeTabId, otherConnectionId);
     assert.equal(
-      queryStore.tabs.some((tab) => [queryId, dataId].includes(tab.id)),
+      queryStore.tabs.some((tab) => [queryId, dataId, objectId, structureId].includes(tab.id)),
       false,
     );
   } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("disconnecting a connection flushes released tabs before an immediate restore", async () => {
+  const restoreStorage = installMemoryStorage();
+  const originalFetch = globalThis.fetch;
+  vi.useFakeTimers();
+  globalThis.fetch = withConnectionHealthMock(async () => {
+    return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+  });
+
+  try {
+    setActivePinia(createPinia());
+    const connectionStore = useConnectionStore();
+    const queryStore = useQueryStore();
+    useSettingsStore().updateEditorSettings({ disconnectTabHandlingMode: "keep-tabs-clear-results" });
+    connectionStore.addEphemeralConnection(conn("conn-a"));
+    connectionStore.addEphemeralConnection(conn("conn-b"));
+
+    const queryId = queryStore.createTab("conn-a", "app", "query", "query");
+    const dataId = queryStore.createTab("conn-a", "app", "users", "data", "public");
+    const objectId = queryStore.openObjectBrowser("conn-a", "app", "public");
+    const structureId = queryStore.openTableStructure("conn-a", "app", "public", "users");
+    const outsideId = queryStore.createTab("conn-b", "app", "orders", "data", "public");
+    queryStore.activeTabId = dataId;
+    await queryStore.flushPendingPersist();
+
+    await connectionStore.disconnect("conn-a");
+    await nextTick();
+
+    assert.deepEqual(
+      queryStore.tabs.map((tab) => tab.id),
+      [queryId, outsideId],
+    );
+    assert.equal(queryStore.activeTabId, outsideId);
+    const persisted = JSON.parse(localStorage.getItem("dbx-app-state:open_tabs") ?? "null");
+    assert.deepEqual(
+      persisted.tabs.map((tab: { id: string }) => tab.id),
+      [queryId, outsideId],
+    );
+    assert.equal(persisted.activeTabId, outsideId);
+
+    disposePinia(getActivePinia()!);
+    setActivePinia(createPinia());
+    const restored = useQueryStore();
+    await restored.initOpenTabs({ validConnectionIds: ["conn-a", "conn-b"] });
+
+    assert.deepEqual(
+      restored.tabs.map((tab) => tab.id),
+      [queryId, outsideId],
+    );
+    assert.equal(restored.activeTabId, outsideId);
+  } finally {
+    vi.useRealTimers();
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
+test("closing a database flushes only that database's released tabs before restore", async () => {
+  const restoreStorage = installMemoryStorage();
+  const originalFetch = globalThis.fetch;
+  vi.useFakeTimers();
+  globalThis.fetch = withConnectionHealthMock(async () => {
+    return new Response(JSON.stringify(true), { status: 200, headers: { "Content-Type": "application/json" } });
+  });
+
+  try {
+    setActivePinia(createPinia());
+    const connectionStore = useConnectionStore();
+    const queryStore = useQueryStore();
+    useSettingsStore().updateEditorSettings({ disconnectTabHandlingMode: "keep-tabs-clear-results" });
+    connectionStore.addEphemeralConnection(conn("conn-a"));
+    connectionStore.addEphemeralConnection(conn("conn-b"));
+
+    const queryId = queryStore.createTab("conn-a", "app", "query", "query");
+    const dataId = queryStore.createTab("conn-a", "app", "users", "data", "public");
+    const objectId = queryStore.openObjectBrowser("conn-a", "app", "public");
+    const structureId = queryStore.openTableStructure("conn-a", "app", "public", "users");
+    const otherDatabaseId = queryStore.createTab("conn-a", "analytics", "orders", "data", "public");
+    const outsideId = queryStore.createTab("conn-b", "app", "orders", "data", "public");
+    queryStore.activeTabId = dataId;
+    await queryStore.flushPendingPersist();
+
+    await connectionStore.closeDatabaseConnection("conn-a", "app");
+    await nextTick();
+
+    assert.deepEqual(
+      queryStore.tabs.map((tab) => tab.id),
+      [queryId, otherDatabaseId, outsideId],
+    );
+    assert.equal(queryStore.activeTabId, otherDatabaseId);
+    const persisted = JSON.parse(localStorage.getItem("dbx-app-state:open_tabs") ?? "null");
+    assert.deepEqual(
+      persisted.tabs.map((tab: { id: string }) => tab.id),
+      [queryId, otherDatabaseId, outsideId],
+    );
+    assert.equal(persisted.activeTabId, otherDatabaseId);
+
+    disposePinia(getActivePinia()!);
+    setActivePinia(createPinia());
+    const restored = useQueryStore();
+    await restored.initOpenTabs({ validConnectionIds: ["conn-a", "conn-b"] });
+
+    assert.deepEqual(
+      restored.tabs.map((tab) => tab.id),
+      [queryId, otherDatabaseId, outsideId],
+    );
+    assert.equal(restored.activeTabId, otherDatabaseId);
+    assert.equal(
+      restored.tabs.some((tab) => [dataId, objectId, structureId].includes(tab.id)),
+      false,
+    );
+  } finally {
+    vi.useRealTimers();
     globalThis.fetch = originalFetch;
     restoreStorage();
   }


### PR DESCRIPTION
## 问题

关闭连接后的标签页处理设置为“关闭表格页签，保留 SQL 页签”时，表数据、对象浏览和结构页签虽然会从内存中移除，但快速重新连接或恢复应用状态时仍可能重新出现。

## 原因

连接级和数据库级断开路径复用了现有标签页清理逻辑，但 `queryStore` 的 open-tabs persistence 使用 300ms debounce。断开操作在内存清理完成后就返回了，持久化层仍可能保留清理前的快照；随后恢复流程读取旧快照，导致已关闭的对象页签复活。现有标签页 scope 元数据和三种处理策略本身无需新增匹配逻辑。

## 修复

- 在连接级断开执行既有标签页策略后，等待 `queryStore.flushPendingPersist()` 写入最新标签页状态。
- 在数据库级关闭执行相同的持久化 flush，保持两条生命周期路径语义一致。
- 保留现有 `close-tabs`、`keep-tabs-clear-results`、`keep-tabs-keep-results` 策略和未保存 SQL 的确认机制。

## 验证

- `pnpm exec vitest run --config vitest.config.ts packages/app-tests/queryStore.test.ts --reporter=dot` ✅（203 tests）
- `pnpm exec vitest run --config vitest.config.ts packages/app-tests/queryStore.test.ts -t "(disconnecting a connection closes every tab for that connection|disconnecting a connection flushes released tabs before an immediate restore|closing a database flushes only that database's released tabs before restore)" --reporter=dot --silent` ✅（3 tests）
- `pnpm exec vitest run --config vitest.config.ts apps/desktop/src/lib/__tests__/app/openTabsPersistence.spec.ts --reporter=dot --silent` ✅（8 tests）
- `pnpm exec vitest run --config vitest.config.ts apps/desktop/src/stores/__tests__/queryStore.structure-close.spec.ts --testTimeout=30000 --reporter=dot --silent` ✅（7 tests）
- `pnpm typecheck` ✅

重点覆盖：

- 连接断开后清理表数据、对象浏览和结构页签
- 不影响其他连接或同连接下其他数据库
- `activeTabId` 和 open-tabs persistence 同步更新
- 重新初始化/恢复状态后已关闭页签不会复活

Closes #7443
