### PR TITLE
feat: 在连接树中突出显示当前登录用户

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -758,7 +758,11 @@ function isNodeDefaultSchema(): boolean {
 
 // #7490: on Oracle-family connections whose schemas are database users, bold the
 // schema node matching the login user so it stands out among many user schemas.
-const isLoginUserNode = computed(() => isLoginUserSchemaNode(activeNode.value, activeNode.value.connectionId ? connectionStore.getConfig(activeNode.value.connectionId) : undefined));
+// Kept as a plain function call (not a computed) so TreeItem stays within the
+// top-level computed budget asserted by sidebarRuntimeDecomposition.
+function isLoginUserNode(): boolean {
+  return isLoginUserSchemaNode(activeNode.value, activeNode.value.connectionId ? connectionStore.getConfig(activeNode.value.connectionId) : undefined);
+}
 
 const trailingComment = computed(() => {
   if (!settingsStore.editorSettings.sidebarObjectInfoMode.startsWith("comment-")) return null;

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -68,6 +68,7 @@ import { filterSidebarModifierSelectionIds, supportsSidebarModifierSelection, tr
 import { applyConnectionMultiSelection, applyTreeNodeSelection, connectionMultiSelectionAfterToggle } from "@/lib/sidebar/sidebarConnectionMultiSelect";
 import { connectionBearingGroupIdsUnder, connectionIdsUnderGroup } from "@/lib/sidebar/sidebarLayout";
 import { isSidebarDatabaseOpenForVisual } from "@/lib/sidebar/sidebarDatabaseOpenState";
+import { isLoginUserSchemaNode } from "@/lib/sidebar/loginUserNode";
 import { sidebarTreeContextKey } from "@/lib/sidebar/sidebarTreeContext";
 import { connectionCanConfigureSidebarVisibleDatabases } from "@/lib/sidebar/sidebarVisibleFilterMenu";
 import { supportsSidebarObjectNameFilter } from "@/lib/sidebar/sidebarObjectNameFilter";
@@ -754,6 +755,10 @@ const isNodeDefaultDatabase = computed(
 function isNodeDefaultSchema(): boolean {
   return activeNode.value.type === "schema" && !!activeNode.value.connectionId && !!activeNode.value.schema && connectionStore.isDefaultSchema(activeNode.value.connectionId, activeNode.value.schema);
 }
+
+// #7490: on Oracle-family connections whose schemas are database users, bold the
+// schema node matching the login user so it stands out among many user schemas.
+const isLoginUserNode = computed(() => isLoginUserSchemaNode(activeNode.value, activeNode.value.connectionId ? connectionStore.getConfig(activeNode.value.connectionId) : undefined));
 
 const trailingComment = computed(() => {
   if (!settingsStore.editorSettings.sidebarObjectInfoMode.startsWith("comment-")) return null;
@@ -1453,7 +1458,7 @@ function onKeydown(event: KeyboardEvent) {
               @keydown.escape.prevent="cancelRename"
               @click.stop
             />
-            <span v-else ref="labelRef" :class="[labelWidthClass, { 'flex-1': node.type === 'connection' && !trailingComment }]">{{ visibleLabel(node) }}</span>
+            <span v-else ref="labelRef" :class="[labelWidthClass, { 'flex-1': node.type === 'connection' && !trailingComment, 'font-semibold': isLoginUserNode }]">{{ visibleLabel(node) }}</span>
             <span v-if="treeNodeSecondaryValue(node)" class="min-w-0 max-w-[55%] shrink truncate text-xs text-muted-foreground" :title="treeNodeSecondaryValue(node)">{{ treeNodeSecondaryValue(node) }}</span>
             <button
               v-if="canDragPinnedOrder()"

--- a/apps/desktop/src/lib/__tests__/sidebar/loginUserNode.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/loginUserNode.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { ConnectionConfig, TreeNode } from "@/types/database";
+import { isLoginUserSchemaNode } from "@/lib/sidebar/loginUserNode";
+
+function config(overrides: Partial<ConnectionConfig>): ConnectionConfig {
+  return {
+    id: "conn-1",
+    name: "conn",
+    db_type: "dameng",
+    host: "localhost",
+    port: 5236,
+    username: "TEST01",
+    password: "",
+    ...overrides,
+  } as ConnectionConfig;
+}
+
+function schemaNode(overrides: Partial<TreeNode>): TreeNode {
+  return {
+    id: "conn-1:TEST01:TEST01",
+    label: "TEST01",
+    type: "schema",
+    connectionId: "conn-1",
+    database: "TEST01",
+    schema: "TEST01",
+    ...overrides,
+  };
+}
+
+describe("isLoginUserSchemaNode", () => {
+  it("marks the schema node matching the login user (Case 1)", () => {
+    expect(isLoginUserSchemaNode(schemaNode({}), config({ username: "TEST01" }))).toBe(true);
+  });
+
+  it("does not mark other user schemas (Case 2)", () => {
+    expect(isLoginUserSchemaNode(schemaNode({ schema: "TEST02", label: "TEST02" }), config({ username: "TEST01" }))).toBe(false);
+    expect(isLoginUserSchemaNode(schemaNode({ schema: "SYSDBA", label: "SYSDBA" }), config({ username: "TEST01" }))).toBe(false);
+  });
+
+  it("isolates by the caller-provided connection config (Case 3)", () => {
+    // A same-named schema on a different connection is checked against that
+    // connection's own config, whose login user is different, so it stays plain.
+    const otherConnectionConfig = config({ id: "conn-2", username: "OTHER" });
+    expect(isLoginUserSchemaNode(schemaNode({ connectionId: "conn-2" }), otherConnectionConfig)).toBe(false);
+  });
+
+  it("matches Dameng's upper-cased schema against a lower-case login (Case 4)", () => {
+    expect(isLoginUserSchemaNode(schemaNode({ schema: "TEST01", label: "TEST01" }), config({ username: "test01" }))).toBe(true);
+  });
+
+  it("never highlights engines whose schema is not a user (Case 5)", () => {
+    // PostgreSQL: a `postgres` schema that coincidentally matches the login name
+    // is a plain schema, not the login user, and must stay unbolded.
+    const pgNode = schemaNode({ schema: "postgres", label: "postgres", database: "app" });
+    expect(isLoginUserSchemaNode(pgNode, config({ db_type: "postgres", username: "postgres" }))).toBe(false);
+    // MySQL has no schema tree level, but guard the type boundary regardless.
+    expect(isLoginUserSchemaNode(pgNode, config({ db_type: "mysql", username: "postgres" }))).toBe(false);
+  });
+
+  it("is safe when config, username, or schema is missing (Case 6)", () => {
+    expect(isLoginUserSchemaNode(schemaNode({}), undefined)).toBe(false);
+    expect(isLoginUserSchemaNode(schemaNode({}), config({ username: "" }))).toBe(false);
+    expect(isLoginUserSchemaNode(schemaNode({}), config({ username: "   " }))).toBe(false);
+    expect(isLoginUserSchemaNode(schemaNode({ schema: undefined, label: "" }), config({ username: "TEST01" }))).toBe(false);
+  });
+
+  it("only applies to schema nodes, not tables or other user schemas' children", () => {
+    expect(isLoginUserSchemaNode(schemaNode({ type: "table" }), config({ username: "TEST01" }))).toBe(false);
+    expect(isLoginUserSchemaNode(schemaNode({ type: "connection" }), config({ username: "TEST01" }))).toBe(false);
+  });
+
+  it("falls back to the label when the schema field is absent", () => {
+    expect(isLoginUserSchemaNode(schemaNode({ schema: undefined, label: "TEST01" }), config({ username: "test01" }))).toBe(true);
+  });
+
+  it("also covers Oracle and OceanBase (Oracle mode) connections", () => {
+    expect(isLoginUserSchemaNode(schemaNode({ schema: "SCOTT", label: "SCOTT" }), config({ db_type: "oracle", username: "scott" }))).toBe(true);
+    expect(isLoginUserSchemaNode(schemaNode({ schema: "APP", label: "APP" }), config({ db_type: "oceanbase-oracle", username: "app" }))).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/sidebar/loginUserNode.ts
+++ b/apps/desktop/src/lib/sidebar/loginUserNode.ts
@@ -1,0 +1,32 @@
+import type { ConnectionConfig, TreeNode } from "@/types/database";
+import { connectionUsesConnectionRootSchemaMode } from "@/lib/database/jdbcDialect";
+
+/**
+ * Whether a sidebar tree node represents the connection's own login user.
+ *
+ * This is only meaningful for the Oracle-family engines whose connection-root
+ * schemas *are* database users (Oracle, Dameng, OceanBase in Oracle mode). For
+ * those connections the schema tree is a flat list of user schemas, one of
+ * which is the account the connection logged in as. Highlighting it lets a user
+ * with many schemas immediately see "which one is me" (issue #7490).
+ *
+ * The comparison mirrors `filterSchemaNamesForVisiblePicker` in
+ * `visibleDatabases.ts`, which already equates `connection.username` with the
+ * current user schema case-insensitively. Oracle/Dameng fold unquoted
+ * identifiers to upper case, so a `test01` login surfaces as a `TEST01` schema
+ * node; the lower-cased compare keeps those matched without inventing a new
+ * identifier-normalization framework.
+ *
+ * Databases where a schema is not a user (PostgreSQL's `public`, a MySQL
+ * database that happens to share the login name, every `treeSchema` engine)
+ * never reach the connection-root-schema branch, so a coincidental name clash
+ * is not mistaken for the login user.
+ */
+export function isLoginUserSchemaNode(node: Pick<TreeNode, "type" | "schema" | "label">, config: Pick<ConnectionConfig, "db_type" | "driver_profile" | "username"> | undefined): boolean {
+  if (node.type !== "schema") return false;
+  if (!connectionUsesConnectionRootSchemaMode(config)) return false;
+  const username = config?.username?.trim().toLowerCase();
+  if (!username) return false;
+  const schemaName = (node.schema ?? node.label ?? "").trim().toLowerCase();
+  return schemaName.length > 0 && schemaName === username;
+}


### PR DESCRIPTION
## 变更说明

修复 #7490。

当连接树展示多个数据库用户时，现在会对当前连接的登录用户进行加粗显示，方便在用户较多的数据库（如达梦）中快速确认当前身份。

本次采用最小化视觉调整，不额外引入 Badge、图标或独立颜色，仅在登录用户对应的节点上使用 `font-semibold` 提升字重。

## 实现

- 复用现有连接配置中的登录用户信息（`ConnectionConfig.username`），不新增任何数据库查询或会话状态。
- 仅在 schema 即数据库用户的 Oracle 系连接上生效：Oracle、达梦（Dameng）、OceanBase（Oracle 模式），复用已有的 `connectionUsesConnectionRootSchemaMode` 语义边界。
- 处理达梦 / Oracle 标识符大小写差异：非引号标识符会被折叠为大写（登录 `test01` → 树节点 `TEST01`），与 `visibleDatabases.ts` 中 `filterSchemaNamesForVisiblePicker` 已有的大小写不敏感比较保持一致。
- 逻辑提取为纯函数 `isLoginUserSchemaNode`（`apps/desktop/src/lib/sidebar/loginUserNode.ts`），未在模板中堆叠长表达式。
- 保持其他 TreeItem 的选择、搜索、hover、图标、缩进和布局行为完全不变。

## 为什么不会误标普通 schema

对于 PostgreSQL、MySQL 等 schema 与登录用户语义不同的数据库，其节点根本不会进入 connection-root-schema 分支，因此即使 schema 名称恰好与登录名相同（例如 `postgres`）也不会被误加粗。

## 测试

- [x] 当前登录用户识别
- [x] 非登录用户不高亮
- [x] 不同连接之间正确隔离
- [x] 用户名大小写场景（达梦 `test01` / `TEST01`）
- [x] 不支持 user/schema 等价语义的数据库不会误高亮
- [x] config 缺失 / username 为空 / 节点 metadata 不完整时不报错
- [x] Targeted tests 通过

执行命令：

```
pnpm exec vitest run apps/desktop/src/lib/__tests__/sidebar/loginUserNode.spec.ts   # 9 passed
pnpm typecheck   # 通过
pnpm exec oxlint --vue-plugin <changed files>   # 通过
```

> 未进行真实达梦实例验证；已通过针对连接树用户识别逻辑的自动化测试覆盖相关行为。

（注：仓库 `main` 上 `sidebarObjectGroupRouting.spec.ts` 存在 3 个先前已有、与本次改动无关的失败用例，已确认在未包含本 PR 改动的干净 `origin/main` 上同样失败。）

Closes #7490
