### PR TITLE
feat(xugu): distinguish public synonym scope in sidebar

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -78,6 +78,7 @@ import { focusSidebarRenameInput } from "@/lib/sidebar/sidebarRenameFocus";
 import { ensureSqlExtension, stripSqlExtension } from "@/lib/savedSql/savedSqlFileName";
 import { savedSqlErrorMessage } from "@/lib/savedSql/savedSqlErrors";
 import { useSavedSqlStore } from "@/stores/savedSqlStore";
+import { isXuguPublicSynonymTreeNode } from "@/lib/sidebar/xuguPublicSynonyms";
 // --- Drag and Drop ---
 import { useDragSort } from "@/composables/useDragSort";
 import { sidebarTreeRuntimeKey } from "@/lib/sidebar/sidebarTreeRuntime";
@@ -235,8 +236,11 @@ function getIconInfo(node: TreeNode): { icon: any; colorClass: string } | null {
       return { icon: Database, colorClass: "text-yellow-500" };
     case "linked-server-schema":
       return { icon: FolderOpen, colorClass: "text-sky-400" };
-    case "schema":
+    case "schema": {
+      const databaseType = node.connectionId ? effectiveDatabaseTypeForConnection(connectionStore.getConfig(node.connectionId)) : undefined;
+      if (isXuguPublicSynonymTreeNode(databaseType, node.type, node.schema)) return { icon: Link2, colorClass: "text-sky-500" };
       return { icon: FolderOpen, colorClass: "text-sky-400" };
+    }
     case "table":
       return { icon: Table, colorClass: "text-green-500" };
     case "view":

--- a/apps/desktop/src/components/sidebar/__tests__/xuguPublicSynonymActions.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/xuguPublicSynonymActions.spec.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const runtimeSource = readFileSync(fileURLToPath(new URL("../SidebarTreeRuntimeHost.vue", import.meta.url)), "utf8");
+const treeItemSource = readFileSync(fileURLToPath(new URL("../TreeItem.vue", import.meta.url)), "utf8");
 
 function functionSource(name: string): string {
   const start = runtimeSource.indexOf(`function ${name}(`);
@@ -24,5 +25,10 @@ describe("Xugu public synonym actions", () => {
   it("guards both the drop request and confirmed execution", () => {
     expect(functionSource("dropSchema")).toContain("isXuguPublicSynonymTreeNode");
     expect(functionSource("confirmDropSchema")).toContain("isXuguPublicSynonymTreeNode");
+  });
+
+  it("uses a distinct link icon for the database-global synonym scope", () => {
+    expect(treeItemSource).toContain("isXuguPublicSynonymTreeNode(databaseType, node.type, node.schema)");
+    expect(treeItemSource).toContain('return { icon: Link2, colorClass: "text-sky-500" }');
   });
 });


### PR DESCRIPTION
## Summary

Xugu public synonyms are database-global aliases, not ordinary user schemas. The sidebar already exposes them through a dedicated synthetic `Public synonyms` scope, but the root still used the same folder icon as a real schema.

This focused UI change gives only that Xugu synthetic scope the existing blue link icon used by synonym objects. Real schemas, including a real schema named `GUEST`, keep their existing folder icon and behavior.

## Design

The icon is selected only when all three conditions match: the connection is Xugu, the node is a schema node, and its schema key is the reserved public-synonym scope. The reserved key is retained for routing; no naming, ordering, metadata query, permission, or context-menu behavior changes.

This makes the database-global namespace visually distinguishable from ordinary owners while avoiding any behavior change for other database types.

## Validation

- Focused Vitest checks: 2 files / 8 tests passed, including the public-synonym identity guard and the dedicated icon mapping.
- `pnpm typecheck`
- Frontend formatting check and `git diff --check`
- Fresh debug Tauri bundle completed successfully.
- The isolated packaged build was launched separately from the installed DBX application; the Xugu system tree displayed `Public synonyms` with the distinct link icon.

## Scope

- Xugu only.
- Two frontend files only: the tree-item icon mapping and its focused regression test.
- No database driver, metadata, SQL, or object-action behavior is changed.