### PR TITLE
fix: 格式化 OceanBase-Oracle 视图 DDL 预览

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -20,7 +20,7 @@ import { executableStatementRangeAtCursor, executableStatementRangeCacheForDoc, 
 import { currentStatementFrameRangeTo } from "@/lib/sql/currentStatementFrame";
 import { expandToSqlStatementWindow } from "@/lib/sql/insertValueHints";
 import { insertValueHintColumnNames } from "@/lib/sql/insertValueHintColumns";
-import { canFormatSqlForDatabaseType, formatSqlForEditing, compressSqlText, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
+import { canFormatSqlForDatabaseType, formatSqlForDisplay, formatSqlForEditing, compressSqlText, sqlFormatDialectForDbType, type SqlFormatDialect } from "@/lib/sql/sqlFormatter";
 import { detectAndFormatStructured } from "@/lib/sql/autoFormat";
 import { enabledSqlParameterSyntaxes, resolveSqlVariableSyntaxToggles } from "@/lib/sql/sqlVariableSyntax";
 import { blankLineDeletionChanges, replaceSelectedEditorText } from "@/lib/editor/queryEditorTextEdits";
@@ -2825,7 +2825,13 @@ async function resolveSqlHoverTooltip(currentView: EditorViewType, pos: number) 
         const { ddl } = await loadObjectDdl(objectMetadataRequest);
         const rawDdl = ddlForHoverPreview(ddl);
         if (rawDdl && rawDdl.trim()) {
-          sqlContent = reformatHoverDdl(rawDdl, quoteQualifiedName(hoverQualifiedName));
+          // A view's display DDL wraps the raw (often single-line) view source
+          // in `CREATE ... VIEW ... AS`; the table-oriented reformatter cannot
+          // lay out a SELECT body, so views reuse the shared display formatter
+          // (the same one the sidebar/object-source viewers use). Tables keep
+          // the aligned column layout from reformatHoverDdl.
+          const isViewObject = objectMetadataRequest.objectType === "VIEW" || objectMetadataRequest.objectType === "MATERIALIZED_VIEW";
+          sqlContent = isViewObject ? await formatSqlForDisplay(rawDdl, props.formatDialect ?? sqlFormatDialectForDbType(props.databaseType), settingsStore.editorSettings.sqlFormatter) : reformatHoverDdl(rawDdl, quoteQualifiedName(hoverQualifiedName));
         }
       } catch (error) {
         console.warn(`[DBX] Failed to load table DDL for ${hoverDatabase}.${hoverSchema}.${table.name}:`, error);

--- a/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts
@@ -60,9 +60,63 @@ describe("sqlFormatter", () => {
     expect(sqlFormatDialectForDbType("duckdb")).toBe("duckdb");
   });
 
-  it("maps only Oracle to the PL/SQL formatter dialect", () => {
+  it("maps Oracle and OceanBase Oracle mode to the PL/SQL formatter dialect", () => {
     expect(sqlFormatDialectForDbType("oracle")).toBe("oracle");
-    expect(sqlFormatDialectForDbType("oceanbase-oracle")).toBe("generic");
+    // OceanBase Oracle mode speaks Oracle SQL — issue #7540: it must reuse the
+    // Oracle dialect so view DDL previews are formatted instead of one line.
+    expect(sqlFormatDialectForDbType("oceanbase-oracle")).toBe("oracle");
+  });
+
+  it("formats an OceanBase Oracle single-line view DDL into readable multi-line SQL (issue #7540)", async () => {
+    const singleLine = `CREATE OR REPLACE VIEW "APP"."ACTIVE_USERS" AS SELECT ID, NAME FROM USERS WHERE STATUS = 'ACTIVE'`;
+    const formatted = await formatSqlForDisplay(singleLine, sqlFormatDialectForDbType("oceanbase-oracle"));
+
+    expect(formatted).not.toBe(singleLine);
+    expect(formatted.split("\n").length).toBeGreaterThan(1);
+    expect(formatted).toContain("CREATE OR REPLACE VIEW");
+    expect(formatted).toMatch(/\bSELECT\b/);
+    expect(formatted).toMatch(/\bFROM\b/);
+    expect(formatted).toMatch(/\bWHERE\b/);
+    // String literals and quoted identifiers must survive formatting untouched.
+    expect(formatted).toContain("'ACTIVE'");
+    expect(formatted).toContain('"ACTIVE_USERS"');
+  });
+
+  it("formats a bare OceanBase Oracle view source wrapped as CREATE VIEW (issue #7540)", async () => {
+    // Mirrors the backend build_view_ddl_sql output for a fallback ALL_VIEWS.TEXT
+    // body: `CREATE VIEW <name> AS <single-line SELECT>`.
+    const wrapped = `CREATE VIEW "APP"."ACTIVE_USERS" AS
+SELECT ID, NAME FROM USERS WHERE STATUS = 'ACTIVE';`;
+    const formatted = await formatSqlForDisplay(wrapped, sqlFormatDialectForDbType("oceanbase-oracle"));
+
+    expect(formatted.split("\n").length).toBeGreaterThan(2);
+    expect(formatted).toMatch(/\bSELECT\b/);
+    expect(formatted).toMatch(/\bFROM\b/);
+    expect(formatted).toMatch(/\bWHERE\b/);
+    expect(formatted).toContain("'ACTIVE'");
+  });
+
+  it("does not split string literals when formatting an OceanBase Oracle view (issue #7540)", async () => {
+    const singleLine = `CREATE OR REPLACE VIEW "APP"."V" AS SELECT 'SELECT X FROM Y' AS TXT FROM DUAL`;
+    const formatted = await formatSqlForDisplay(singleLine, sqlFormatDialectForDbType("oceanbase-oracle"));
+
+    expect(formatted).toContain("'SELECT X FROM Y'");
+  });
+
+  it("leaves an already multi-line OceanBase Oracle view DDL semantically intact (issue #7540)", async () => {
+    const multiLine = `CREATE OR REPLACE VIEW "APP"."ACTIVE_USERS" AS
+SELECT
+  ID,
+  NAME
+FROM USERS
+WHERE STATUS = 'ACTIVE';`;
+    const formatted = await formatSqlForDisplay(multiLine, sqlFormatDialectForDbType("oceanbase-oracle"));
+
+    expect(formatted).toContain('"ACTIVE_USERS"');
+    expect(formatted).toContain("'ACTIVE'");
+    expect(formatted).toMatch(/\bID\b/);
+    expect(formatted).toMatch(/\bNAME\b/);
+    expect(formatted).toMatch(/\bWHERE\b/);
   });
 
   it("keeps issue #7138 Oracle hierarchy clauses intact", async () => {

--- a/apps/desktop/src/lib/sql/sqlFormatter.ts
+++ b/apps/desktop/src/lib/sql/sqlFormatter.ts
@@ -77,6 +77,8 @@ export function sqlFormatDialectForDbType(dbType: string | null | undefined): Sq
     case "sqlserver":
       return "sqlserver";
     case "oracle":
+    // OceanBase Oracle mode speaks Oracle SQL, so it reuses the PL/SQL grammar.
+    case "oceanbase-oracle":
       return "oracle";
     case "clickhouse":
       return "clickhouse";


### PR DESCRIPTION
## 问题

OceanBase-Oracle 模式下，视图源码通过 `DBMS_METADATA.GET_DDL` 或回退的 `ALL_VIEWS.TEXT` 返回，往往是**单行 SQL**。在 SQL 编辑器中鼠标悬浮预览视图时，DDL 被原样显示成一整行，完全无法阅读。

Closes #7540

## 根因

经完整调查确认，问题由两处叠加造成，均在**前端展示层**：

1. **hover 预览链路对视图不做格式化**
   SQL 编辑器 hover 预览（`QueryEditor.vue` 的 `resolveSqlHoverTooltip`）拿到 DDL 后统一走 `reformatHoverDdl`。而 `reformatHoverDdl` 只针对 `CREATE TABLE` 做列对齐排版，遇到视图（`CREATE ... VIEW ... AS <SELECT>`）时找不到 `CREATE TABLE`，直接返回原始 DDL —— 也就是那一整行。
   对比可知：侧边栏 DDL、对象源码查看器、结构编辑器等其它 DDL 展示面均调用了统一的 `formatSqlForDisplay`，唯独 hover 视图这条路径漏掉了。

2. **OceanBase-Oracle 未映射到 Oracle formatter dialect**
   `sqlFormatDialectForDbType("oceanbase-oracle")` 返回的是 `generic` 而非 `oracle`。即使调用格式化，OceanBase-Oracle 也拿不到 Oracle(PL/SQL) 语法，Oracle 特有 SQL 无法被正确解析格式化。

后端 `build_view_ddl_sql` 对 OceanBase-Oracle（Oracle-like）会生成 `CREATE VIEW <name> AS\n<source>`，其中 `<source>` 保持单行 —— 这是**正确的原始 ObjectSource 语义**，不应改动，格式化应在展示层完成。

## 修复

均为最小的展示层改动，不触碰原始 ObjectSource / 后端驱动：

- `apps/desktop/src/lib/sql/sqlFormatter.ts`
  在 `sqlFormatDialectForDbType` 中将 `oceanbase-oracle` 与 `oracle` 一并映射到 `oracle` dialect（OceanBase Oracle 模式即 Oracle SQL 语义），复用已有的 PL/SQL formatter。

- `apps/desktop/src/components/editor/QueryEditor.vue`
  hover 预览中，当对象为 `VIEW` / `MATERIALIZED_VIEW` 时改用共享的 `formatSqlForDisplay`（与侧边栏、对象源码查看器同一个 formatter），并按 `props.formatDialect ?? sqlFormatDialectForDbType(props.databaseType)` 选择方言；表仍保留 `reformatHoverDdl` 的列对齐排版。

**为什么修在这一层**：格式化只影响 hover 展示。原始 `getObjectSource` / `build_view_ddl_sql` 的返回值保持不变，因此对象源码编辑、schema compare、保存、导出等复用同一 source 的场景完全不受影响 —— 严格遵循「展示层问题在展示层解决」。同时全程复用项目已有 `formatSqlForDisplay`（内部为 `sql-formatter` parser），未引入任何新依赖，也没有用脆弱正则硬插换行。

## 验证

- `npx vitest run apps/desktop/src/lib/__tests__/sql/sqlFormatter.spec.ts` ✅（76 passed）
- `npx vitest run apps/desktop/src/lib/__tests__/sql apps/desktop/src/components/editor/__tests__ apps/desktop/src/lib/editor` ✅（1344 passed；`QueryEditorContextMenu.spec.ts` 在本地因 `node:fs` 外部化的环境问题**无法加载**，该失败在未改动的 origin/main 上同样存在，与本次修改无关）
- `npx vue-tsc --noEmit --project apps/desktop/tsconfig.json` ✅（无错误）
- `npx oxlint --vue-plugin`（改动文件）✅（仅剩 sqlFormatter.ts 一处 **既有** `no-control-regex` 警告）

新增 regression 用例覆盖：

- 单行完整 `CREATE OR REPLACE VIEW` → 格式化为多行，保留 `SELECT/FROM/WHERE` 语义
- bare SELECT 被后端包成 `CREATE VIEW ... AS` 的视图源码 → 正常多行格式化
- 字符串字面量 `'SELECT X FROM Y'` 不被破坏
- 已经是多行的视图 DDL → 语义不变、不丢字符、quoted identifier / string literal 完好
- `oceanbase-oracle` → `oracle` dialect 映射，且其它数据库类型的映射保持不变
