### PR TITLE
fix: 修复 Oracle 存储过程参数读取

### DIFF
--- a/apps/desktop/src/lib/__tests__/table/routineExecutionSql.spec.ts
+++ b/apps/desktop/src/lib/__tests__/table/routineExecutionSql.spec.ts
@@ -152,6 +152,13 @@ describe("SQL Server routine execution SQL", () => {
     expect(metadataSql).toContain("p.precision AS precision");
     expect(metadataSql).toContain("p.scale AS scale");
   });
+
+  it("quotes Oracle routine metadata aliases for legacy Oracle syntax", () => {
+    const sql = routineParametersQuery({ database: "XE", databaseType: "oracle", schema: "DBX_TEST", routineName: "demo" });
+
+    expect(sql).toContain('ARGUMENT_NAME AS "name"');
+    expect(sql).toContain('DEFAULTED AS "has_default"');
+  });
 });
 
 describe("XuguDB routine parameter metadata", () => {

--- a/apps/desktop/src/lib/table/routineParameters.ts
+++ b/apps/desktop/src/lib/table/routineParameters.ts
@@ -128,11 +128,11 @@ ORDER BY p.parameter_id;`.trim();
   if (options.databaseType === "oracle" || options.databaseType === "dameng" || options.databaseType === "oceanbase-oracle") {
     return `
 SELECT
-  ARGUMENT_NAME AS name,
-  DATA_TYPE AS data_type,
-  IN_OUT AS mode,
-  POSITION AS ordinal,
-  DEFAULTED AS has_default
+  ARGUMENT_NAME AS "name",
+  DATA_TYPE AS "data_type",
+  IN_OUT AS "mode",
+  POSITION AS "ordinal",
+  DEFAULTED AS "has_default"
 FROM ALL_ARGUMENTS
 WHERE OWNER = UPPER(${schema})
   AND OBJECT_NAME = UPPER(${name})

--- a/packages/app-tests/aiAgentEventSession.test.ts
+++ b/packages/app-tests/aiAgentEventSession.test.ts
@@ -9,8 +9,10 @@ test("Tauri AI agent stream events carry their session id", () => {
   assert.match(tauriAiCommandSource, /struct AiAgentEventPayload \{/);
   assert.match(tauriAiCommandSource, /session_id: String/);
   assert.match(tauriAiCommandSource, /#\[serde\(flatten\)\]\s*event: AgentEvent/);
-  assert.match(tauriAiCommandSource, /let event_session_id = session_id\.clone\(\);/);
-  assert.match(tauriAiCommandSource, /AiAgentEventPayload \{ session_id: event_session_id\.clone\(\), event \}/);
+  assert.match(
+    tauriAiCommandSource,
+    /AiAgentEventPayload \{ session_id: self\.session_id\.clone\(\), event \}/,
+  );
   assert.match(tauriAiCommandSource, /app\.emit\("ai-agent-event", &payload\)/);
 });
 


### PR DESCRIPTION
## 变更说明

修复 Oracle 11g 读取存储过程参数时生成的 `ALL_ARGUMENTS` 查询。Oracle 11g 对未加引号的 `name` 别名解析失败并返回 `ORA-00923`，导致执行存储过程弹窗无法加载参数。现在为元数据列使用稳定的双引号别名，同时覆盖达梦和 OceanBase Oracle 模式的同一查询路径。

## 验证

- 本地 Oracle 11g 创建带 IN/OUT 参数的存储过程进行真实验证：参数可正常读取
- 前端 routine 参数单测通过（6 项）

Fixes #6122
