### PR TITLE
fix(redis): handle hash field updates on older Redis

### DIFF
--- a/crates/dbx-core/src/db/redis_driver.rs
+++ b/crates/dbx-core/src/db/redis_driver.rs
@@ -3074,7 +3074,12 @@ where
                 return false
             end
             local detail = string.lower(reply.err)
+            -- Redis < 7.4 reports an HTTL/HEXPIRE pcall as "Unknown Redis
+            -- command called from [Lua] script", not the top-level "unknown
+            -- command" wording. Permission and WRONGTYPE errors use different
+            -- wording and must still fail.
             return string.find(detail, 'unknown command', 1, true) ~= nil
+                or string.find(detail, 'unknown redis command', 1, true) ~= nil
                 or string.find(detail, 'syntax error', 1, true) ~= nil
                 or string.find(detail, 'unsupported', 1, true) ~= nil
         end
@@ -5511,6 +5516,63 @@ mod tests {
         assert!(con.commands[0].contains("redis.pcall('HDEL'"));
         assert!(con.commands[0].contains("local delete_probe"));
         assert!(con.commands[0].contains("if source_ttl == 0 then"));
+        // Regression guard for #7584: Redis < 7.4 answers the HTTL/HEXPIRE
+        // probe with "Unknown Redis command called from [Lua] script", which
+        // has to be recognised as an unsupported-command reply so the update
+        // degrades instead of returning -3.
+        assert!(con.commands[0].contains("'unknown redis command'"));
+    }
+
+    /// End-to-end regression for #7584 against a real Redis < 7.4.
+    ///
+    /// Set `DBX_TEST_REDIS_URL` to a Redis that predates hash-field expiry
+    /// (for example `redis://127.0.0.1:6379` backed by Redis 7.2 or 6.2).
+    /// The HTTL probe inside the Lua script fails there, and before the fix
+    /// the mismatched error wording made both value-only edits and renames
+    /// return "failed before completion". This exercises the actual
+    /// `hash_field_update` path so the Lua matcher runs on the server.
+    #[tokio::test]
+    #[ignore = "requires a Redis without hash-field expiry via DBX_TEST_REDIS_URL"]
+    async fn hash_field_update_degrades_on_redis_without_hash_field_ttl() {
+        let url = std::env::var("DBX_TEST_REDIS_URL").expect("DBX_TEST_REDIS_URL");
+        let mut con = super::connect(&url, std::time::Duration::from_secs(5)).await.unwrap();
+
+        let key = b"dbx-7584-regression";
+        redis::cmd("DEL").arg(&key[..]).query_async::<()>(&mut con).await.unwrap();
+        redis::cmd("HSET").arg(&key[..]).arg("old_field").arg("value1").query_async::<()>(&mut con).await.unwrap();
+
+        // Confirm this server takes the exact unsupported-command path that
+        // triggered the regression rather than merely accepting HTTL.
+        let unsupported_detail: String = redis::cmd("EVAL")
+            .arg(
+                "local reply = redis.pcall('HTTL', KEYS[1], 'FIELDS', 1, ARGV[1]); \
+                 if type(reply) == 'table' and reply.err ~= nil then return reply.err end; \
+                 return 'supported'",
+            )
+            .arg(1)
+            .arg(&key[..])
+            .arg("old_field")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+        assert!(
+            unsupported_detail.to_ascii_lowercase().contains("unknown redis command called from"),
+            "expected Redis without hash-field expiry, got: {unsupported_detail}"
+        );
+
+        // Value-only edit must still succeed even though HTTL is unsupported.
+        super::hash_field_update(&mut con, key, "old_field", "old_field", "value2").await.unwrap();
+        let current: String = redis::cmd("HGET").arg(&key[..]).arg("old_field").query_async(&mut con).await.unwrap();
+        assert_eq!(current, "value2");
+
+        // Field rename must also succeed and leave only the new field behind.
+        super::hash_field_update(&mut con, key, "old_field", "new_field", "value3").await.unwrap();
+        let renamed: String = redis::cmd("HGET").arg(&key[..]).arg("new_field").query_async(&mut con).await.unwrap();
+        assert_eq!(renamed, "value3");
+        let old_exists: i64 = redis::cmd("HEXISTS").arg(&key[..]).arg("old_field").query_async(&mut con).await.unwrap();
+        assert_eq!(old_exists, 0);
+
+        redis::cmd("DEL").arg(&key[..]).query_async::<()>(&mut con).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 变更说明

修复 Redis Hash 修改 field / value 时在部分 Redis 版本下报错的问题。

根因是 PR #7140 引入的原子 `hash_field_update` Lua 脚本在探测 `HTTL` / `HEXPIRE` 时，对「不支持命令」的错误文本匹配过窄。

本次修改：

- 在 `optional_expiry_error` 中补充匹配 `unknown redis command`
- 兼容 Redis 6.x / 7.0 / 7.2 在 Lua 内返回的 `Unknown Redis command called from [Lua] script`
- 保持 Redis 7.4+ Hash Field TTL 保留语义
- 保持旧 Redis 无 field TTL 时的安全降级
- 不改变现有原子 rename / collision protection 设计
- 不吞掉 `NOPERM` / `WRONGTYPE` 等真实错误

## 根因

#7129 / PR #7140（merge commit `0f9d32e1f`）引入 Redis Hash field rename 原子 Lua 后，脚本会 `pcall('HTTL', ...)` 探测 field TTL。

在 Redis < 7.4 环境下，Lua 实际错误文本是：

- Redis 7.2: `ERR Unknown Redis command called from script`
- Redis 6.2: `@user_script: 1: Unknown Redis command called from Lua script`

旧匹配只认小写子串 `unknown command`，上述文本 lower 后是 `unknown redis command ...`，**不包含** `unknown command` 这个连续子串，于是被误判为真正执行失败，返回 `-3`，前端表现为：

```text
Redis hash field update failed before completion.
```

value-only 修改和 field rename 都会踩中同一 HTTL 探测路径。

## 验证

- [x] Redis 7.2：value-only + field rename（live ignored test）
- [x] Redis 6.2：value-only + field rename（live ignored test）
- [x] Redis 7.4：field rename 正常，field TTL 仍保留
- [x] destination collision：拒绝且不破坏既有 field
- [x] 特殊 field 名 `" user "`：仅改 value 不 trim
- [x] NOPERM / WRONGTYPE：不降级、明确失败
- [x] targeted Rust unit tests（8 pass / 1 ignored）
- [x] git diff --check

实际执行命令和结果：

```text
cargo test -p dbx-core --lib hash_field_update
# 8 passed; 0 failed; 1 ignored

DBX_TEST_REDIS_URL=redis://127.0.0.1:26372 \
  cargo test -p dbx-core --lib hash_field_update_degrades_on_redis_without_hash_field_ttl -- --ignored
# 1 passed (Redis 7.2.16)

DBX_TEST_REDIS_URL=redis://127.0.0.1:26362 \
  cargo test -p dbx-core --lib hash_field_update_degrades_on_redis_without_hash_field_ttl -- --ignored
# 1 passed (Redis 6.2.24)

# Redis 7.4.11 manual EVAL of fixed script:
# value-only=1, rename=2, TTL preserved (120), collision=-1 intact, space field preserved
```

## 影响范围

仅影响：

* Redis Hash field 编辑链路（`hash_field_update` Lua 错误分类）
* `crates/dbx-core/src/db/redis_driver.rs`

不改变其他 Redis 数据类型行为，也不退回 `HSET + HDEL` 非原子两请求方案。

## 关联 Issue

Fixes #7584