### PR TITLE
fix(grid): parse ambiguous comma numbers by locale

### DIFF
--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts
@@ -250,15 +250,36 @@ describe("coerceDataGridCellValue", () => {
     ).toBe("9007199254740993");
   });
 
-  it("leaves ambiguous single-group values untouched", () => {
+  it("normalizes ambiguous single-comma values using the runtime number format", () => {
     expect(
       coerceDataGridCellValue({
         value: "10,000",
-        oldValue: 10000,
-        databaseType: "sqlserver",
-        columnInfo: { data_type: "int" },
+        oldValue: "0.0000",
+        databaseType: "mysql",
+        columnInfo: { data_type: "decimal(14,4)" },
+        numberFormat: { groupSeparator: ",", decimalSeparator: "." },
       }),
-    ).toBe("10,000");
+    ).toBe("10000");
+
+    expect(
+      coerceDataGridCellValue({
+        value: "114,870",
+        oldValue: "0.0000",
+        databaseType: "mysql",
+        columnInfo: { data_type: "decimal(14,4)" },
+        numberFormat: { groupSeparator: ",", decimalSeparator: "." },
+      }),
+    ).toBe("114870");
+
+    expect(
+      coerceDataGridCellValue({
+        value: "114,870",
+        oldValue: "0.0000",
+        databaseType: "mysql",
+        columnInfo: { data_type: "decimal(14,4)" },
+        numberFormat: { groupSeparator: ".", decimalSeparator: "," },
+      }),
+    ).toBe("114.870");
 
     expect(
       coerceDataGridCellValue({
@@ -266,8 +287,21 @@ describe("coerceDataGridCellValue", () => {
         oldValue: 1000000,
         databaseType: "sqlserver",
         columnInfo: { data_type: "float" },
+        numberFormat: { groupSeparator: ".", decimalSeparator: "," },
       }),
-    ).toBe("1,000e3");
+    ).toBe(1000);
+  });
+
+  it("leaves ambiguous comma values untouched when the runtime format uses neither comma token", () => {
+    expect(
+      coerceDataGridCellValue({
+        value: "10,000",
+        oldValue: 10000,
+        databaseType: "sqlserver",
+        columnInfo: { data_type: "int" },
+        numberFormat: { groupSeparator: "’", decimalSeparator: "." },
+      }),
+    ).toBe("10,000");
   });
 
   it("does not strip commas when the column is not numeric", () => {

--- a/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridCellCoercion.ts
@@ -9,10 +9,18 @@ export interface CoerceDataGridCellValueOptions {
   oldValue: GridCellValue | undefined;
   databaseType: DatabaseType | undefined;
   columnInfo: Pick<ColumnInfo, "data_type"> | undefined;
+  numberFormat?: NumericInputNumberFormat;
   preserveEmptyString?: boolean;
   /** Treat an empty inline bulk edit as SQL NULL before type coercion. */
   emptyStringAsNull?: boolean;
 }
+
+export interface NumericInputNumberFormat {
+  groupSeparator?: string;
+  decimalSeparator?: string;
+}
+
+let cachedRuntimeNumberFormat: NumericInputNumberFormat | undefined;
 
 export function coerceDataGridCellValue(options: CoerceDataGridCellValueOptions): GridCellValue {
   const { value, oldValue } = options;
@@ -22,13 +30,13 @@ export function coerceDataGridCellValue(options: CoerceDataGridCellValueOptions)
   if (blobValue !== undefined) return blobValue;
   const postgresArrayValue = coercePostgresArrayValue(options);
   if (postgresArrayValue !== undefined) return postgresArrayValue;
-  // Excel-pasted values often carry thousands separators (10,000.00) that make
-  // Number() return NaN and the literal fail to convert on the server. Strip
-  // only unambiguous groupings and keep the normalized text for the precision
-  // checks below, so exact values survive as text.
+  // Excel-pasted values often carry separators that make Number() return NaN
+  // and the literal fail to convert on the server. Use the runtime number
+  // format to resolve single-comma values, then keep the normalized text for
+  // the precision checks below so exact values survive as text.
   const useSampledValueType = normalizeDataType(options.columnInfo?.data_type) === "";
   const numericInput = isNumericColumnType(options.columnInfo?.data_type) || (useSampledValueType && typeof oldValue === "number");
-  const numericText = normalizeGroupedNumberText(value, options.columnInfo, oldValue);
+  const numericText = normalizeGroupedNumberText(value, options.columnInfo, oldValue, options.numberFormat ?? runtimeNumberFormat());
   if (isBooleanInputColumn(options) || (useSampledValueType && typeof oldValue === "boolean")) {
     // MySQL exposes TINYINT(1) as an integer in the grid. Keep its numeric
     // 0/1 edits numeric while still accepting explicit TRUE/FALSE aliases.
@@ -155,23 +163,38 @@ function shouldPreserveNumericText(options: CoerceDataGridCellValueOptions, pars
   return shouldPreserveNumericTextForType(options.columnInfo?.data_type, text, parsedNumber);
 }
 
-function normalizeGroupedNumberText(value: string, columnInfo: Pick<ColumnInfo, "data_type"> | undefined, oldValue: GridCellValue | undefined): string {
+function normalizeGroupedNumberText(value: string, columnInfo: Pick<ColumnInfo, "data_type"> | undefined, oldValue: GridCellValue | undefined, numberFormat: NumericInputNumberFormat): string {
   const useSampledNumberType = normalizeDataType(columnInfo?.data_type) === "" && typeof oldValue === "number";
   if (!isNumericColumnType(columnInfo?.data_type) && !useSampledNumberType) return value;
-  return stripUnambiguousThousandSeparators(value);
+  return normalizeCommaSeparatedNumberText(value, numberFormat);
 }
 
-function stripUnambiguousThousandSeparators(value: string): string {
+function normalizeCommaSeparatedNumberText(value: string, numberFormat: NumericInputNumberFormat): string {
   const trimmed = value.trim();
   const match = trimmed.match(/^([+-]?\d{1,3}(?:,\d{3})+(?:\.\d+)?)([eE][+-]?\d+)?$/);
   if (!match) return value;
   const mantissa = match[1];
   const exponent = match[2] ?? "";
-  // A lone "1,000" (one comma group, no decimal point) is ambiguous: in
-  // comma-decimal locales it reads as 1.000. Only strip when a decimal point
-  // is present (1,234.56) or there are multiple comma groups (1,234,567).
-  if (/^[+-]?\d{1,3},\d{3}$/.test(mantissa)) return value;
+  if (/^[+-]?\d{1,3},\d{3}$/.test(mantissa)) {
+    if (numberFormat.groupSeparator === "," && numberFormat.decimalSeparator !== ",") {
+      return `${mantissa.replace(",", "")}${exponent}`;
+    }
+    if (numberFormat.decimalSeparator === ",") {
+      return `${mantissa.replace(",", ".")}${exponent}`;
+    }
+    return value;
+  }
   return `${mantissa.replace(/,/g, "")}${exponent}`;
+}
+
+function runtimeNumberFormat(): NumericInputNumberFormat {
+  if (cachedRuntimeNumberFormat) return cachedRuntimeNumberFormat;
+  const parts = new Intl.NumberFormat().formatToParts(12345.6);
+  cachedRuntimeNumberFormat = {
+    groupSeparator: parts.find((part) => part.type === "group")?.value,
+    decimalSeparator: parts.find((part) => part.type === "decimal")?.value,
+  };
+  return cachedRuntimeNumberFormat;
 }
 
 function postgresArrayElementDataType(dataType: string | undefined): string {


### PR DESCRIPTION
## 变更说明

修复数据网格编辑数值字段时，单组逗号数字可能被数据库静默截断的问题。例如在 MySQL `DECIMAL(14,4)` 字段中输入 `114,870`，此前会将原始字符串提交给数据库，并在非严格模式下保存为 `114.0000`。

- 根据运行环境的数字区域格式解析存在歧义的单组逗号输入
- 逗号作为千分位时，将 `114,870` 规范化为 `114870`
- 逗号作为小数分隔符时，保留其区域语义并规范化为 `114.870`
- 保留现有多组千分位、小数、科学计数法及精度敏感数值的处理逻辑
- 非数值字段、非法分组及当前区域格式无法解释的逗号输入保持原样
- 使用可注入的数字格式信息补充确定性的区域格式回归测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

### MySQL `DECIMAL(14,4)` 输入千分位数字

https://github.com/user-attachments/assets/b14e6274-221d-4e46-b1db-540c9fd3023c

录屏展示在数据网格中将 `0.0000` 修改为 `114,870`，提交并刷新后正确显示为 `114870.0000`。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/dataGrid/dataGridCellCoercion.spec.ts`（37 项通过）
- 区域格式回归：逗号千分位、逗号小数、区域不匹配的歧义输入
- 既有回归：精确小数、超大整数、多组千分位、科学计数法、非法分组和文本字段
- MySQL 8.0 Docker 手动 E2E：`DECIMAL(14,4)` 输入 `114,870`，提交并刷新后由错误的 `114.0000` 修复为 `114870.0000`

## 关联 Issue

Close #7623
