### PR TITLE
fix(elasticsearch): treat REST reads as read-only in write guards

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlRisk.elasticsearch.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlRisk.elasticsearch.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { classifySqlRisk, classifySqlStatementRisk } from "@/lib/sql/sqlRisk";
+import { sqlLooksLikeMutation } from "@/lib/database/readOnlyWriteAccess";
+
+const SEARCH_REQUEST = 'POST /demo/_search\n{\n  "from": 0,\n  "size": 100,\n  "sort": [\n    "_doc"\n  ]\n}';
+
+describe("Elasticsearch request risk", () => {
+  it("treats searches and other retrieval requests as reads", () => {
+    for (const dialect of ["elasticsearch", "easysearch"] as const) {
+      expect(classifySqlRisk(SEARCH_REQUEST, { dialect }).risk).toBe("read");
+      expect(classifySqlRisk("GET /demo/_doc/1", { dialect }).risk).toBe("read");
+      expect(classifySqlRisk("GET /_cat/indices?format=json", { dialect }).risk).toBe("read");
+      expect(classifySqlRisk("HEAD /demo", { dialect }).risk).toBe("read");
+      expect(classifySqlRisk('POST /demo/_count\n{"query":{"match_all":{}}}', { dialect }).risk).toBe("read");
+      expect(classifySqlRisk('POST /_sql\n{"query":"SELECT * FROM demo"}', { dialect }).risk).toBe("read");
+    }
+  });
+
+  it("treats document changes as writes and index changes as DDL", () => {
+    expect(classifySqlRisk('POST /demo/_doc\n{"a":1}', { dialect: "elasticsearch" }).risk).toBe("write");
+    expect(classifySqlRisk('PUT /demo/_doc/1\n{"a":1}', { dialect: "elasticsearch" }).risk).toBe("write");
+    expect(classifySqlRisk("DELETE /demo/_doc/1", { dialect: "elasticsearch" }).risk).toBe("write");
+    expect(classifySqlRisk("DELETE /demo", { dialect: "elasticsearch" }).risk).toBe("ddl");
+    expect(classifySqlRisk('PUT /demo\n{"settings":{}}', { dialect: "elasticsearch" }).risk).toBe("ddl");
+    expect(classifySqlRisk('POST /demo/_delete_by_query\n{"query":{"match_all":{}}}', { dialect: "elasticsearch" }).risk).toBe("ddl");
+  });
+
+  it("reports the highest risk across every request in the editor text", () => {
+    const source = `${SEARCH_REQUEST}\n\nDELETE /demo`;
+    expect(classifySqlRisk(source, { dialect: "elasticsearch" }).risk).toBe("ddl");
+    expect(classifySqlStatementRisk(SEARCH_REQUEST, { dialect: "elasticsearch" }).risk).toBe("read");
+  });
+
+  it("reads the request line through query strings, trailing slashes and CRLF endings", () => {
+    expect(classifySqlRisk("GET /demo/_search?size=1", { dialect: "elasticsearch" }).risk).toBe("read");
+    expect(classifySqlRisk("post /demo/_search/\r\n{}", { dialect: "elasticsearch" }).risk).toBe("read");
+    expect(classifySqlRisk("DELETE /demo/_doc/1?refresh=true", { dialect: "elasticsearch" }).risk).toBe("write");
+    expect(classifySqlRisk("  GET /demo/_search  // inline comment", { dialect: "elasticsearch" }).risk).toBe("read");
+  });
+
+  it("ignores commented-out requests", () => {
+    expect(classifySqlRisk(`# DELETE /demo\n// DELETE /demo\n/* DELETE /demo */\n${SEARCH_REQUEST}`, { dialect: "elasticsearch" }).risk).toBe("read");
+    expect(classifySqlRisk("/*\nDELETE /demo\n*/\nGET /demo/_search", { dialect: "elasticsearch" }).risk).toBe("read");
+  });
+
+  it("still classifies Elasticsearch SQL through the SQL rules", () => {
+    expect(classifySqlRisk("SELECT * FROM demo", { dialect: "elasticsearch" }).risk).toBe("read");
+    expect(classifySqlRisk("DROP TABLE demo", { dialect: "elasticsearch" }).risk).toBe("ddl");
+  });
+
+  it("leaves text that does not start with a request line to the SQL rules", () => {
+    // The backend anchors on the first line too, so a stray request line further
+    // down must not turn unparseable text into a read.
+    expect(classifySqlRisk('{"query":{"match_all":{}}}\nGET /demo/_search', { dialect: "elasticsearch" }).risk).toBe("unknown");
+  });
+
+  it("keeps REST requests classified as SQL for other database types", () => {
+    expect(classifySqlRisk(SEARCH_REQUEST, { dialect: "mysql" }).risk).toBe("unknown");
+  });
+
+  it("does not ask a read-only connection to unlock writes for a search", () => {
+    expect(sqlLooksLikeMutation(SEARCH_REQUEST, "elasticsearch")).toBe(false);
+    expect(sqlLooksLikeMutation("GET /demo/_search", "easysearch")).toBe(false);
+    expect(sqlLooksLikeMutation("DELETE /demo", "elasticsearch")).toBe(true);
+    expect(sqlLooksLikeMutation('POST /demo/_doc\n{"a":1}', "elasticsearch")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/database/__tests__/readOnlyWriteAccess.spec.ts
+++ b/apps/desktop/src/lib/database/__tests__/readOnlyWriteAccess.spec.ts
@@ -94,6 +94,20 @@ describe("read-only write unlock", () => {
     expect(connectionWriteUnlockState).not.toHaveBeenCalled();
   });
 
+  it("does not prompt for Elasticsearch searches on a read-only connection", async () => {
+    const store = useReadOnlyUnlockStore();
+    const connection = { id: "es", name: "es-prod", read_only: true, db_type: "elasticsearch" as const };
+
+    await expect(ensureReadOnlyWriteAccess({ connection, sql: 'POST /demo/_search\n{\n  "size": 100\n}' })).resolves.toBe(true);
+    await expect(ensureReadOnlyWriteAccess({ connection, sql: "GET /demo/_doc/1" })).resolves.toBe(true);
+    expect(store.pending).toBeUndefined();
+
+    const pending = ensureReadOnlyWriteAccess({ connection, sql: "DELETE /demo" });
+    await waitForPending("es");
+    store.cancel();
+    await expect(pending).resolves.toBe(false);
+  });
+
   it("reuses an existing backend window without prompting again", async () => {
     connectionWriteUnlockState.mockResolvedValue(45_000);
     const connection = { id: "prod", name: "prod-db", read_only: true, db_type: "mysql" as const };

--- a/apps/desktop/src/lib/elasticsearch/elasticsearchRequestRisk.ts
+++ b/apps/desktop/src/lib/elasticsearch/elasticsearchRequestRisk.ts
@@ -1,0 +1,110 @@
+/**
+ * Read/write classification for Elasticsearch-compatible REST requests.
+ *
+ * Mirrors `classify_search_engine_query_risk` in
+ * `crates/dbx-core/src/query_execution_sql.rs` so the desktop guards (read-only
+ * unlock, production safety) agree with the backend read-only gate instead of
+ * treating every `GET`/`POST` request as an unrecognized — and therefore
+ * unsafe — statement.
+ */
+
+export type ElasticsearchRequestRisk = "read" | "write" | "dangerous";
+
+const REQUEST_LINE = /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\S+)/i;
+const READ_ONLY_POST_ENDPOINTS = ["_search", "_count", "_sql", "_msearch", "_field_caps", "_terms_enum", "_validate", "_explain", "_rank_eval", "_search_shards"];
+const WRITE_POST_ENDPOINTS = ["_doc", "_create", "_update", "_bulk"];
+const RISK_ORDER: Record<ElasticsearchRequestRisk, number> = { read: 0, write: 1, dangerous: 2 };
+
+interface ParsedRequestLine {
+  method: string;
+  segments: string[];
+}
+
+function parseRequestLine(line: string): ParsedRequestLine | null {
+  const match = line.trim().match(REQUEST_LINE);
+  if (!match) return null;
+  const path = (match[2].split("?", 1)[0] ?? "").replace(/\/+$/, "");
+  return { method: match[1].toUpperCase(), segments: path.split("/").filter(Boolean) };
+}
+
+function classifyParsedRequest({ method, segments }: ParsedRequestLine): ElasticsearchRequestRisk {
+  const hasSegment = (candidate: string) => segments.some((segment) => segment.toLowerCase() === candidate);
+  const hasDocumentId = (candidate: string) => {
+    const index = segments.findIndex((segment) => segment.toLowerCase() === candidate);
+    return index >= 0 && !!segments[index + 1];
+  };
+
+  if (method === "GET" || method === "HEAD" || method === "OPTIONS") return "read";
+  if (method === "POST") {
+    if (READ_ONLY_POST_ENDPOINTS.some((endpoint) => hasSegment(endpoint))) return "read";
+    return WRITE_POST_ENDPOINTS.some((endpoint) => hasSegment(endpoint)) ? "write" : "dangerous";
+  }
+  if (method === "PUT" && (hasDocumentId("_doc") || hasDocumentId("_create"))) return "write";
+  if (method === "DELETE" && hasDocumentId("_doc")) return "write";
+  return "dangerous";
+}
+
+/**
+ * Classifies a single request: the request line is the first non-comment line,
+ * everything after it is the JSON/NDJSON body. Returns null when the text is
+ * not a REST request — Elasticsearch also accepts SQL, classified elsewhere.
+ */
+export function classifyElasticsearchRequestRisk(request: string): ElasticsearchRequestRisk | null {
+  const parsed = parseRequestLine(uncommentedLines(request)[0] ?? "");
+  return parsed ? classifyParsedRequest(parsed) : null;
+}
+
+/**
+ * Classifies every request in the editor text and returns the highest risk, so
+ * a read request followed by a write is still guarded. Like the backend, the
+ * text only counts as REST when its first non-comment line is a request line;
+ * anything else is left to the SQL classification.
+ */
+export function classifyElasticsearchSourceRisk(source: string): ElasticsearchRequestRisk | null {
+  const lines = uncommentedLines(source);
+  if (!parseRequestLine(lines[0] ?? "")) return null;
+
+  let highest: ElasticsearchRequestRisk = "read";
+  for (const line of lines) {
+    const parsed = parseRequestLine(line);
+    if (!parsed) continue;
+    const risk = classifyParsedRequest(parsed);
+    if (RISK_ORDER[risk] > RISK_ORDER[highest]) highest = risk;
+  }
+  return highest;
+}
+
+/**
+ * Returns each line with its leading comments removed, dropping lines that hold
+ * nothing else. Block comments spanning several lines are skipped as a whole so
+ * a commented-out request line is never classified.
+ */
+function uncommentedLines(source: string): string[] {
+  const lines: string[] = [];
+  let inBlockComment = false;
+
+  for (const rawLine of source.split("\n")) {
+    let offset = 0;
+    while (offset < rawLine.length) {
+      if (inBlockComment) {
+        const close = rawLine.indexOf("*/", offset);
+        if (close < 0) break;
+        inBlockComment = false;
+        offset = close + 2;
+        continue;
+      }
+      while (offset < rawLine.length && /\s/.test(rawLine[offset] ?? "")) offset += 1;
+      if (offset >= rawLine.length) break;
+      if (rawLine.startsWith("/*", offset)) {
+        inBlockComment = true;
+        offset += 2;
+        continue;
+      }
+      if (rawLine[offset] === "#" || rawLine.startsWith("//", offset)) break;
+      lines.push(rawLine.slice(offset));
+      break;
+    }
+  }
+
+  return lines;
+}

--- a/apps/desktop/src/lib/sql/sqlRisk.ts
+++ b/apps/desktop/src/lib/sql/sqlRisk.ts
@@ -1,4 +1,5 @@
-import type { DatabaseType } from "@/types/database";
+import { classifyElasticsearchRequestRisk, classifyElasticsearchSourceRisk, type ElasticsearchRequestRisk } from "@/lib/elasticsearch/elasticsearchRequestRisk";
+import { isElasticsearchCompatibleDatabaseType, type DatabaseType } from "@/types/database";
 
 export type SqlRiskLevel = "read" | "write" | "ddl" | "transaction" | "unknown";
 
@@ -44,6 +45,11 @@ export function splitSqlStatementsForSafety(sql: string): string[] {
 }
 
 export function classifySqlRisk(sql: string, options: SqlRiskOptions = {}): SqlRiskAssessment {
+  // REST requests carry a JSON body that must not be split on semicolons, and
+  // every request in the text is classified so the highest risk wins.
+  const searchEngineRisk = searchEngineAssessment(sql, options.dialect, classifyElasticsearchSourceRisk);
+  if (searchEngineRisk) return { ...searchEngineRisk, statements: [searchEngineRisk] };
+
   const statements = splitSqlStatementsForSafety(sql).map((statement) => classifySqlStatementRisk(statement, options));
   if (!statements.length) return { risk: "unknown", statements: [] };
   const highest = statements.reduce<SqlRiskStatementAssessment>((current, statement) => (RISK_ORDER[statement.risk] > RISK_ORDER[current.risk] ? statement : current), { risk: "read" });
@@ -53,7 +59,27 @@ export function classifySqlRisk(sql: string, options: SqlRiskOptions = {}): SqlR
 export function classifySqlStatementRisk(sql: string, options: SqlRiskOptions = {}): SqlRiskStatementAssessment {
   const dynamodbRisk = classifyDynamoDbStatementRisk(sql, options.dialect);
   if (dynamodbRisk) return dynamodbRisk;
+  const searchEngineRisk = searchEngineAssessment(sql, options.dialect, classifyElasticsearchRequestRisk);
+  if (searchEngineRisk) return searchEngineRisk;
   return classifyTokens(tokenizeSqlForRisk(sql));
+}
+
+/**
+ * Elasticsearch-compatible connections run REST requests whose method and path
+ * decide the risk; `GET`/`POST _search` reads must not be mistaken for writes.
+ * Text that is not a REST request (Elasticsearch SQL) falls through to the
+ * ordinary SQL classification.
+ *
+ * The HTTP method is deliberately not reported as the first keyword: callers
+ * map that keyword onto SQL semantics (`insert` is a low-risk write, `create`
+ * is a schema change, ...), which a request path does not carry. Reporting
+ * `rest` keeps REST mutations as opaque as they were before this branch existed.
+ */
+function searchEngineAssessment(sql: string, dialect: DatabaseType | string | undefined, classify: (value: string) => ElasticsearchRequestRisk | null): SqlRiskStatementAssessment | null {
+  if (!isElasticsearchCompatibleDatabaseType(dialect as DatabaseType | undefined)) return null;
+  const risk = classify(sql);
+  if (!risk) return null;
+  return { risk: risk === "read" ? "read" : risk === "write" ? "write" : "ddl", firstKeyword: "rest" };
 }
 
 function classifyDynamoDbStatementRisk(sql: string, dialect?: DatabaseType | string): SqlRiskStatementAssessment | null {


### PR DESCRIPTION
## 变更说明

Elasticsearch 连接开启只读保护后，`POST /demo/_search` 这类只读请求会被判定为写操作，弹出「临时解锁写入」对话框（#7652）。

原因在前端：`apps/desktop/src/lib/sql/sqlRisk.ts` 只认识 SQL，Elasticsearch 的 REST 请求没有可识别的首关键字，落到保守的 `unknown` 分支，于是 `sqlLooksLikeMutation()` 判定为写入。后端 `crates/dbx-core/src/query_execution_sql.rs` 的 `classify_search_engine_query_risk` 早已按 method + path 正确分类，只有前端与它不一致。

本 PR 新增 `apps/desktop/src/lib/elasticsearch/elasticsearchRequestRisk.ts`，对 Elasticsearch / Easysearch 的 REST 请求按 method 与 path 分类，规则与后端逐条对齐：

- `GET` / `HEAD` / `OPTIONS` → 读
- `POST` 命中 `_search`、`_count`、`_sql`、`_msearch`、`_field_caps`、`_terms_enum`、`_validate`、`_explain`、`_rank_eval`、`_search_shards` → 读
- `POST` 命中 `_doc`、`_create`、`_update`、`_bulk`，以及 `PUT /_doc/{id}`、`PUT /_create/{id}`、`DELETE /_doc/{id}` → 写
- 其余 `POST` / `PUT` / `PATCH` / `DELETE` → 危险操作

与后端保持一致：只有首个非注释行是请求行时才按 REST 处理，多个请求取最高风险；不是 REST 请求的文本（Elasticsearch SQL）继续走原有 SQL 规则。只读解锁、生产保护确认、AI 执行策略共用这个分类器，一并修正。

不改动其他数据库类型的判定。Meilisearch 后端还没有对应的分类逻辑，若前端先放行只读请求会导致后端直接报错，因此本 PR 不涉及。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）



## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

`make check` 的 connection-types / format / lint / typecheck 四项全部通过；test 一项有两个与本次改动无关的失败：

- `packages/app-tests/aiAgentEventSession.test.ts`：在未改动的 `main` 上同样失败。
- `packages/app-tests/queryStore.test.ts > result cache eviction keeps recently accessed inactive tabs`：全量并发跑时偶发失败，单独运行通过；在 `main` 上同样能复现这类偶发失败。

本次改动相关的测试：

- 新增 `apps/desktop/src/lib/__tests__/sql/sqlRisk.elasticsearch.spec.ts`：读 / 写 / 危险操作分类、多请求取最高风险、注释行、查询串与 CRLF、Elasticsearch SQL 回退、其他数据库类型不受影响。
- 在 `apps/desktop/src/lib/database/__tests__/readOnlyWriteAccess.spec.ts` 补充只读连接下的 Elasticsearch 用例：搜索请求不弹解锁框，`DELETE /demo` 仍然弹框。

```bash
pnpm vitest run apps/desktop/src/lib/__tests__/sql apps/desktop/src/lib/database/__tests__
```

## 关联 Issue

Close #7652
