### PR TITLE
fix(sidebar): 修复登录用户高亮导致连接树全部加粗

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1478,7 +1478,7 @@ function onKeydown(event: KeyboardEvent) {
               @keydown.escape.prevent="cancelRename"
               @click.stop
             />
-            <span v-else ref="labelRef" :class="[labelWidthClass, { 'flex-1': node.type === 'connection' && !trailingComment, 'font-semibold': isLoginUserNode }]">{{ visibleLabel(node) }}</span>
+            <span v-else ref="labelRef" :class="[labelWidthClass, { 'flex-1': node.type === 'connection' && !trailingComment, 'font-semibold': isLoginUserNode() }]">{{ visibleLabel(node) }}</span>
             <span v-if="treeNodeSecondaryValue(node)" class="min-w-0 max-w-[55%] shrink truncate text-xs text-muted-foreground" :title="treeNodeSecondaryValue(node)">{{ treeNodeSecondaryValue(node) }}</span>
             <button
               v-if="canDragPinnedOrder()"

--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import TreeItem from "@/components/sidebar/TreeItem.vue";
+import { createSidebarTreeRuntime, sidebarTreeRuntimeKey, type SidebarTreeRuntimeHost } from "@/lib/sidebar/sidebarTreeRuntime";
+import type { ConnectionConfig, SidebarLayout, TreeNode } from "@/types/database";
+
+const connectionId = "connection-1";
+
+function connectionConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: connectionId,
+    name: "Test connection",
+    db_type: "oracle",
+    host: "127.0.0.1",
+    port: 1521,
+    username: "SCOTT",
+    password: "",
+    ...overrides,
+  } as ConnectionConfig;
+}
+
+const state = {
+  config: connectionConfig(),
+};
+
+const connectionStore = {
+  activeConnectionId: connectionId,
+  connectedIds: new Set([connectionId]),
+  connectingIds: new Set<string>(),
+  connectionErrors: {},
+  connectionMultiSelectActive: false,
+  connections: [] as { id: string }[],
+  getConfig: () => state.config,
+  getSidebarVisibleFilterSummary: () => null,
+  clearConnectionError: vi.fn(),
+  isDefaultDatabase: () => false,
+  isDefaultSchema: () => false,
+  isPinnedTreeNodeReorderTarget: () => false,
+  isTreeNodeChildrenLoaded: () => false,
+  isTreeNodePinned: () => false,
+  selectedTreeNodeId: null as string | null,
+  selectedTreeNodeIds: [] as string[],
+  selectedTreeNodeIdsSet: new Set<string>(),
+  sidebarLayout: { groups: [], order: [] } as SidebarLayout,
+  sidebarTableSearchQueries: {},
+  tableNameFilterForScope: () => undefined,
+  treeNodes: [] as TreeNode[],
+  treeSelectionAnchorId: null as string | null,
+};
+
+const settingsStore = {
+  editorSettings: {
+    shortcuts: { openDataInNewTab: "" },
+    sidebarActivation: "double" as const,
+    sidebarAllowHorizontalScroll: false,
+    sidebarHiddenTablePrefixes: [],
+    sidebarObjectInfoMode: "none",
+  },
+};
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => connectionStore,
+}));
+
+vi.mock("@/stores/queryStore", () => ({
+  useQueryStore: () => ({ openDatabaseKeys: new Set<string>() }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => settingsStore,
+}));
+
+vi.mock("@/composables/useToast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/components/icons/DatabaseIcon.vue", () => ({ default: { template: "<span />" } }));
+vi.mock("@/components/connection/ConnectionErrorIndicator.vue", () => ({ default: { template: "<span />" } }));
+vi.mock("@/components/common/ProductionContextBadge.vue", () => ({ default: { template: "<span />" } }));
+vi.mock("@/components/ui/badge", () => ({ Badge: { template: "<span><slot /></span>" } }));
+vi.mock("@/components/ui/input", () => ({ Input: { template: "<input />" } }));
+vi.mock("@/components/ui/switch", () => ({ Switch: { template: "<input />" } }));
+vi.mock("@/components/ui/LightTooltip.vue", () => ({ default: { template: "<span><slot /></span>" } }));
+
+const mountedApps: App[] = [];
+
+function runtimeHost(): SidebarTreeRuntimeHost {
+  return {
+    buildContextMenu: vi.fn(() => []),
+    handleRowClick: vi.fn(),
+    handleRowDoubleClick: vi.fn(),
+    handleRowKeydown: vi.fn(),
+    openPrimaryVisibleFilter: vi.fn(),
+    openDataInNewTab: vi.fn(),
+    requestPaste: vi.fn(() => false),
+    toggleNode: vi.fn(),
+  };
+}
+
+function connectionNode(): TreeNode {
+  return {
+    id: connectionId,
+    label: "Test connection",
+    type: "connection",
+    connectionId,
+    children: [],
+  };
+}
+
+function schemaNode(schema: string): TreeNode {
+  return {
+    id: `${connectionId}:${schema}`,
+    label: schema,
+    type: "schema",
+    connectionId,
+    database: "ORCL",
+    schema,
+    children: [],
+  };
+}
+
+async function mountTreeItem(node: TreeNode, config: ConnectionConfig) {
+  state.config = config;
+  const container = document.createElement("div");
+  document.body.append(container);
+  const runtime = createSidebarTreeRuntime();
+  runtime.bindHost(runtimeHost());
+  const app = createApp(
+    defineComponent({
+      setup: () => () => h(TreeItem, { node, depth: 2 }),
+    }),
+  );
+  mountedApps.push(app);
+  app.use(i18n);
+  app.provide(sidebarTreeRuntimeKey, runtime);
+  app.mount(container);
+  await nextTick();
+
+  const label = [...container.querySelectorAll<HTMLElement>("span")].find((element) => element.textContent === node.label && element.children.length === 0);
+  if (!label) throw new Error(`Tree item label was not rendered: ${container.innerHTML}`);
+  return label;
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.replaceChildren();
+  state.config = connectionConfig();
+  connectionStore.selectedTreeNodeId = null;
+  connectionStore.selectedTreeNodeIds = [];
+  connectionStore.selectedTreeNodeIdsSet = new Set<string>();
+});
+
+describe("TreeItem login user highlight", () => {
+  it("does not bold an ordinary connection row", async () => {
+    const label = await mountTreeItem(connectionNode(), connectionConfig({ db_type: "oracle", username: "SCOTT" }));
+
+    expect(label.classList).not.toContain("font-semibold");
+  });
+
+  it.each([
+    ["PostgreSQL", "postgres" as const],
+    ["MySQL", "mysql" as const],
+  ])("does not bold a matching schema name for %s", async (_name, dbType) => {
+    const schema = "app_user";
+    const label = await mountTreeItem(schemaNode(schema), connectionConfig({ db_type: dbType, username: schema }));
+
+    expect(label.classList).not.toContain("font-semibold");
+  });
+
+  it.each([
+    ["Oracle", "oracle" as const, "SCOTT", "scott"],
+    ["Dameng", "dameng" as const, "TEST01", "test01"],
+    ["OceanBase Oracle mode", "oceanbase-oracle" as const, "APP", "app"],
+  ])("bolds the current login-user schema for %s", async (_name, dbType, schema, username) => {
+    const label = await mountTreeItem(schemaNode(schema), connectionConfig({ db_type: dbType, username }));
+
+    expect(label.classList).toContain("font-semibold");
+  });
+
+  it("does not bold another Oracle-family schema", async () => {
+    const label = await mountTreeItem(schemaNode("HR"), connectionConfig({ db_type: "oracle", username: "SCOTT" }));
+
+    expect(label.classList).not.toContain("font-semibold");
+  });
+});


### PR DESCRIPTION
## 问题

#7594 为实现 #7490，在连接树中对当前登录用户 schema 使用 `font-semibold`。

后续为了满足 `sidebarRuntimeDecomposition` 的 computed budget，`isLoginUserNode` 从 `computed` 调整为普通函数，但模板中的 class 条件仍然直接引用：

```vue
'font-semibold': isLoginUserNode
```

普通函数对象在 class condition 中始终为 truthy，因此普通 connection、PostgreSQL/MySQL 等节点以及其他 schema 都可能被误加粗。

## 修复

将 class 条件修改为实际调用：

```vue
'font-semibold': isLoginUserNode()
```

继续保留普通函数实现和现有 `isLoginUserSchemaNode` 判断逻辑，不改变 #7490 的业务范围，也不重新引入 computed。

## 回归保护

新增真实 mount `TreeItem` 的组件回归测试，验证：

- 普通 connection 不会误加粗；
- PostgreSQL / MySQL 中与登录名相同的 schema 不会误加粗；
- Oracle、达梦、OceanBase Oracle mode 仅当前登录用户 schema 加粗；
- Oracle 系其他用户 schema 保持原有字重。

测试可在错误实现 `'font-semibold': isLoginUserNode` 下失败。

## 验证

- [x] `TreeItem.loginUserHighlight.spec.ts` 与 `loginUserNode.spec.ts`：16 passed
- [x] 4 个相关 `TreeItem` 测试：26 passed
- [x] `TreeItem.mqttI18n.spec.ts`：1 passed
- [x] `pnpm typecheck`
- [x] `pnpm exec oxlint --vue-plugin`（修改文件）
- [x] `pnpm exec oxfmt --check`（修改文件）
- [x] `git diff --check`

Regression related to #7594.

Related to #7490.
