### PR TITLE
fix: 修正连接树子层级错误加粗

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1486,6 +1486,7 @@ function onKeydown(event: KeyboardEvent) {
                 {
                   'flex-1': node.type === 'connection' && !trailingComment,
                   'tree-connection-label': node.type === 'connection' || node.type === 'connection-group',
+                  'tree-object-label': node.type !== 'connection' && node.type !== 'connection-group',
                   'font-semibold': isLoginUserNode(),
                 },
               ]"
@@ -1650,6 +1651,16 @@ function onKeydown(event: KeyboardEvent) {
 .tree-connection-label {
   font-weight: 400;
   font-variation-settings: "wght" 480;
+}
+
+.tree-object-label {
+  font-weight: 400;
+  font-variation-settings: "wght" 430;
+}
+
+.tree-object-label.font-semibold {
+  font-weight: 600;
+  font-variation-settings: "wght" 600;
 }
 
 .tree-item-connection-tint {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1648,7 +1648,8 @@ function onKeydown(event: KeyboardEvent) {
 }
 
 .tree-connection-label {
-  font-weight: 350;
+  font-weight: 400;
+  font-variation-settings: "wght" 480;
 }
 
 .tree-item-connection-tint {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1486,7 +1486,7 @@ function onKeydown(event: KeyboardEvent) {
                 {
                   'flex-1': node.type === 'connection' && !trailingComment,
                   'tree-connection-label': node.type === 'connection' || node.type === 'connection-group',
-                  'font-semibold': isLoginUserNode,
+                  'font-semibold': isLoginUserNode(),
                 },
               ]"
               >{{ visibleLabel(node) }}</span

--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import TreeItem from "@/components/sidebar/TreeItem.vue";
+import { createSidebarTreeRuntime, sidebarTreeRuntimeKey, type SidebarTreeRuntimeHost } from "@/lib/sidebar/sidebarTreeRuntime";
+import type { ConnectionConfig, TreeNode } from "@/types/database";
+
+let connectionConfig: ConnectionConfig;
+
+const connectionStore = {
+  activeConnectionId: "connection-1",
+  connectedIds: new Set(["connection-1"]),
+  connectingIds: new Set<string>(),
+  connectionErrors: {},
+  connectionMultiSelectActive: false,
+  connections: [],
+  getConfig: () => connectionConfig,
+  getSidebarVisibleFilterSummary: () => null,
+  clearConnectionError: vi.fn(),
+  isDefaultDatabase: () => false,
+  isDefaultSchema: () => false,
+  isPinnedTreeNodeReorderTarget: () => false,
+  isTreeNodeChildrenLoaded: () => false,
+  isTreeNodePinned: () => false,
+  selectedTreeNodeId: null as string | null,
+  selectedTreeNodeIds: [] as string[],
+  selectedTreeNodeIdsSet: new Set<string>(),
+  sidebarTableSearchQueries: {},
+  tableNameFilterForScope: () => undefined,
+  treeNodes: [],
+  treeSelectionAnchorId: null as string | null,
+};
+
+vi.mock("@/stores/connectionStore", () => ({
+  useConnectionStore: () => connectionStore,
+}));
+
+vi.mock("@/stores/queryStore", () => ({
+  useQueryStore: () => ({ openDatabaseKeys: new Set<string>() }),
+}));
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings: {
+      shortcuts: { openDataInNewTab: "" },
+      sidebarActivation: "double",
+      sidebarAllowHorizontalScroll: false,
+      sidebarHiddenTablePrefixes: [],
+      sidebarObjectInfoMode: "none",
+    },
+  }),
+}));
+
+vi.mock("@/composables/useToast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const mountedApps: App[] = [];
+
+function runtimeHost(): SidebarTreeRuntimeHost {
+  return {
+    buildContextMenu: vi.fn(() => []),
+    handleRowClick: vi.fn(),
+    handleRowDoubleClick: vi.fn(),
+    handleRowKeydown: vi.fn(),
+    openPrimaryVisibleFilter: vi.fn(),
+    openDataInNewTab: vi.fn(),
+    requestPaste: vi.fn(() => false),
+    toggleNode: vi.fn(),
+  };
+}
+
+function config(dbType: ConnectionConfig["db_type"], username: string): ConnectionConfig {
+  return {
+    id: "connection-1",
+    name: "Test connection",
+    db_type: dbType,
+    host: "127.0.0.1",
+    port: dbType === "oracle" ? 1521 : 5432,
+    username,
+    password: "",
+    database: dbType === "oracle" ? "ORCL" : "app",
+  } as ConnectionConfig;
+}
+
+async function mountSchema(label: string) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const node: TreeNode = {
+    id: `connection-1:${label}`,
+    label,
+    type: "schema",
+    connectionId: "connection-1",
+    database: connectionConfig.database,
+    schema: label,
+  };
+  const app = createApp(
+    defineComponent({
+      setup: () => () => h(TreeItem, { node, depth: 1 }),
+    }),
+  );
+  mountedApps.push(app);
+  const runtime = createSidebarTreeRuntime();
+  runtime.bindHost(runtimeHost());
+  app.use(i18n);
+  app.provide(sidebarTreeRuntimeKey, runtime);
+  app.mount(container);
+  await nextTick();
+
+  const labelElement = [...container.querySelectorAll<HTMLElement>("span.min-w-0.truncate")].find((element) => element.textContent?.trim() === label);
+  if (!labelElement) throw new Error(`Schema label was not rendered: ${container.innerHTML}`);
+  return labelElement;
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.replaceChildren();
+});
+
+describe("TreeItem login user highlighting", () => {
+  it("keeps PostgreSQL schema nodes at the normal weight", async () => {
+    connectionConfig = config("postgres", "postgres");
+
+    const label = await mountSchema("postgres");
+
+    expect(label.classList.contains("font-semibold")).toBe(false);
+  });
+
+  it("highlights only the matching Oracle login user schema", async () => {
+    connectionConfig = config("oracle", "scott");
+
+    const loginSchema = await mountSchema("SCOTT");
+    const otherSchema = await mountSchema("SYSTEM");
+
+    expect(loginSchema.classList.contains("font-semibold")).toBe(true);
+    expect(otherSchema.classList.contains("font-semibold")).toBe(false);
+  });
+});

--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts
@@ -125,6 +125,7 @@ describe("TreeItem login user highlighting", () => {
 
     const label = await mountSchema("postgres");
 
+    expect(label.classList.contains("tree-object-label")).toBe(true);
     expect(label.classList.contains("font-semibold")).toBe(false);
   });
 
@@ -134,7 +135,9 @@ describe("TreeItem login user highlighting", () => {
     const loginSchema = await mountSchema("SCOTT");
     const otherSchema = await mountSchema("SYSTEM");
 
+    expect(loginSchema.classList.contains("tree-object-label")).toBe(true);
     expect(loginSchema.classList.contains("font-semibold")).toBe(true);
+    expect(otherSchema.classList.contains("tree-object-label")).toBe(true);
     expect(otherSchema.classList.contains("font-semibold")).toBe(false);
   });
 });


### PR DESCRIPTION
## 问题

PR #7656 合并后，连接名称的可变字体字重仍需按实际预览结果微调；同时连接内部的数据库、模式和对象分组均显示为粗体。

进一步排查发现，`TreeItem` 模板将 `isLoginUserNode` 函数本身传给了 class 条件。函数对象恒为真，导致所有树节点都错误获得 `font-semibold`（字重 600），而不是只强调 Oracle 家族数据库中的登录用户模式。

## 修改

- 将连接名称的 Geist 可变字体字重调整为实际验收确认的 `wght 480`
- 修正模板条件为 `isLoginUserNode()`，避免连接内部所有层级被错误设置为字重 600
- 根据实际预览验收，将数据库、模式和对象分组等连接内部层级设置为 Geist `wght 430`
- 保留 Oracle、达梦、OceanBase Oracle 模式中匹配登录用户名的模式加粗行为
- 增加 `TreeItem` 组件级回归测试，覆盖 PostgreSQL 普通模式、Oracle 登录用户模式和其他模式

## 验证

- `pnpm -s typecheck`
- `pnpm vitest run apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts apps/desktop/src/components/sidebar/__tests__/TreeItem.connectionRename.spec.ts apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts apps/desktop/src/components/sidebar/__tests__/TreeItem.tableReferenceDrag.spec.ts apps/desktop/src/components/sidebar/__tests__/TreeItem.visibleFilterDetail.spec.ts apps/desktop/src/lib/__tests__/sidebar/loginUserNode.spec.ts packages/app-tests/sidebarTreeItemLayout.test.ts`（7 个文件，42 项测试通过）
- `pnpm exec oxfmt --check apps/desktop/src/components/sidebar/TreeItem.vue apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts`
- `pnpm exec oxlint apps/desktop/src/components/sidebar/TreeItem.vue apps/desktop/src/components/sidebar/__tests__/TreeItem.loginUserHighlight.spec.ts`
- 免密网页预览连接真实 PostgreSQL 数据库并展开层级，浏览器计算样式确认连接名称为 `wght 480`，普通子层级为 `wght 430`

PR #7656 的跟进修复。
