### PR TITLE
fix: 修复关系图搜索框输入字符丢失 #7661

### DIFF
--- a/apps/desktop/src/components/diagram/DiagramToolbar.vue
+++ b/apps/desktop/src/components/diagram/DiagramToolbar.vue
@@ -127,7 +127,7 @@ function connectionIconType(id: string) {
 
     <div class="relative min-w-40 flex-1">
       <Search class="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-      <Input :value="tableSearch" @input="(e: Event) => emit('update:table-search', (e.target as HTMLInputElement).value)" class="h-8 pl-7 pr-9 text-xs" :placeholder="t('diagram.searchTables')" />
+      <Input :model-value="tableSearch" @update:model-value="(value) => emit('update:table-search', String(value))" class="h-8 pl-7 pr-9 text-xs" :placeholder="t('diagram.searchTables')" />
       <button v-if="tableSearch" type="button" class="absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-muted-foreground/20 hover:bg-muted-foreground/40 flex items-center justify-center transition-colors" @click="emit('update:table-search', '')">
         <X class="h-3 w-3 text-muted-foreground" />
       </button>

--- a/apps/desktop/src/components/diagram/SchemaDiagramDialog.vue
+++ b/apps/desktop/src/components/diagram/SchemaDiagramDialog.vue
@@ -1788,7 +1788,7 @@ function handleKeydown(e: KeyboardEvent) {
       return;
     }
   }
-  if (e.key === " " || e.key === "Spacebar") {
+  if (!typing && (e.key === " " || e.key === "Spacebar")) {
     e.preventDefault();
     isSpacePressed.value = true;
   }

--- a/apps/desktop/src/components/diagram/__tests__/DiagramToolbar.spec.ts
+++ b/apps/desktop/src/components/diagram/__tests__/DiagramToolbar.spec.ts
@@ -1,0 +1,145 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, ref, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@lucide/vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  const Icon = defineComponent({
+    inheritAttrs: false,
+    setup(_props, { attrs }) {
+      return () => h("span", attrs);
+    },
+  });
+  return Object.fromEntries(["Copy", "Download", "Link2", "Loader2", "Maximize2", "Minimize2", "Network", "Plus", "RefreshCw", "Search", "Table2", "Upload", "X", "ZoomIn", "ZoomOut", "LayoutGrid"].map((name) => [name, Icon]));
+});
+
+vi.mock("@/components/ui/input", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    // Keep this stub on Input's public model API so the test catches accidental
+    // reliance on fallthrough value/input attributes.
+    Input: defineComponent({
+      inheritAttrs: false,
+      props: {
+        modelValue: { type: [String, Number], default: "" },
+      },
+      emits: ["update:modelValue"],
+      setup(props, { emit }) {
+        return () =>
+          h("input", {
+            value: props.modelValue,
+            onInput: (event: Event) => emit("update:modelValue", (event.target as HTMLInputElement).value),
+          });
+      },
+    }),
+  };
+});
+
+async function passthrough(tag: string) {
+  const { defineComponent, h } = await import("vue");
+  return defineComponent({
+    inheritAttrs: false,
+    setup(_props, { attrs, slots }) {
+      return () => h(tag, attrs, slots.default?.());
+    },
+  });
+}
+
+vi.mock("@/components/ui/badge", async () => ({ Badge: await passthrough("span") }));
+vi.mock("@/components/ui/button", async () => ({ Button: await passthrough("button") }));
+vi.mock("@/components/ui/dropdown-menu", async () => ({
+  DropdownMenu: await passthrough("div"),
+  DropdownMenuContent: await passthrough("div"),
+  DropdownMenuItem: await passthrough("button"),
+  DropdownMenuTrigger: await passthrough("div"),
+}));
+vi.mock("@/components/ui/select", async () => ({
+  Select: await passthrough("div"),
+  SelectContent: await passthrough("div"),
+  SelectItem: await passthrough("div"),
+  SelectTrigger: await passthrough("button"),
+  SelectValue: await passthrough("span"),
+}));
+vi.mock("@/components/icons/DatabaseIcon.vue", async () => ({ default: await passthrough("span") }));
+vi.mock("@/components/connection/ConnectionGroupBadge.vue", async () => ({ default: await passthrough("span") }));
+
+import DiagramToolbar from "../DiagramToolbar.vue";
+
+const mountedApps: Array<{ app: App; host: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { app, host } of mountedApps.splice(0)) {
+    app.unmount();
+    host.remove();
+  }
+});
+
+function mountToolbar() {
+  const search = ref("");
+  const updates: string[] = [];
+  const host = document.createElement("div");
+  document.body.append(host);
+  const app = createApp(
+    defineComponent({
+      setup() {
+        return () =>
+          h(DiagramToolbar, {
+            connectionId: "",
+            database: "",
+            schema: "",
+            databases: [],
+            schemas: [],
+            sqlConnections: [],
+            selectedConnection: undefined,
+            isSchemaAware: false,
+            loadingDatabases: false,
+            loadingSchemas: false,
+            loadingDiagram: false,
+            diagramReady: false,
+            tablesCount: 0,
+            relationshipsCount: 0,
+            customRelationshipCount: 0,
+            matchRelationshipCount: 0,
+            diagramMode: "table",
+            tableSearch: search.value,
+            showMatchPanel: false,
+            showLayersPanel: false,
+            showAllTables: false,
+            focusTableName: "",
+            generatedJoinSql: "",
+            "onUpdate:table-search": (value: string) => {
+              updates.push(value);
+              search.value = value;
+            },
+          });
+      },
+    }),
+  );
+  app.mount(host);
+  mountedApps.push({ app, host });
+  return { host, search, updates };
+}
+
+describe("DiagramToolbar", () => {
+  it("forwards one search update per typed character through Input's model API", async () => {
+    const { host, search, updates } = mountToolbar();
+    await nextTick();
+
+    const input = host.querySelector("input") as HTMLInputElement;
+    for (const character of "user") {
+      input.value += character;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      await nextTick();
+      await nextTick();
+    }
+
+    expect(updates).toEqual(["u", "us", "use", "user"]);
+    expect(search.value).toBe("user");
+    expect(input.value).toBe("user");
+  });
+});

--- a/apps/desktop/src/components/diagram/__tests__/SchemaDiagramDialog.keyboard.spec.ts
+++ b/apps/desktop/src/components/diagram/__tests__/SchemaDiagramDialog.keyboard.spec.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dialogSource = readFileSync(new URL("../SchemaDiagramDialog.vue", import.meta.url), "utf8");
+
+describe("SchemaDiagramDialog keyboard boundaries", () => {
+  it("does not consume a space typed in an editable control for canvas panning", () => {
+    const keydownSource = dialogSource.slice(dialogSource.indexOf("function handleKeydown"), dialogSource.indexOf("function handleKeyup"));
+
+    expect(keydownSource).toContain('const typing = target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT" || target.isContentEditable);');
+    expect(keydownSource).toContain('if (!typing && (e.key === " " || e.key === "Spacebar"))');
+  });
+});


### PR DESCRIPTION
## 问题

修复 #7661。

在数据库关系图页面中，搜索框存在字符输入被吞的问题。

例如希望输入：

`user`

实际需要输入：

`uusseerr`

才能得到 `user`。

该问题会影响 MySQL / PostgreSQL 等共享关系图界面。

## 原因

关系图工具栏使用了 `<Input :value="tableSearch" @input="...">`，但 dbx 的 `Input.vue` 公共 API 是 `modelValue` / `update:modelValue`，内部原生 `<input>` 也通过 `v-model` 维护自己的状态。原实现同时让父级通过 `value` fallthrough 属性和原生 `input` 事件更新，导致父级状态、Input 内部模型和 DOM value 不是同一个受控状态源。

在 Chromium 复现时，`keydown` / `beforeinput` / `input` / `keyup` 均正常触发，焦点也保持在 `INPUT`，且事件没有被 `preventDefault()`；但每次父级更新后的重渲染会把本次字符从 DOM 中回退，因此每个字符需要再次输入才会留下。该现象与数据库类型无关。

此外，关系图全局键盘处理原本会在编辑控件聚焦时也拦截 Space；这会让搜索框中的空格无法作为普通文本输入。

## 修改

- 将关系图搜索框改为 `Input` 的 `modelValue` / `update:modelValue` 标准绑定，并将更新值转为字符串后传给父级。
- 仅在非编辑控件获得焦点时启用关系图画布的 Space 平移快捷键。
- 保留 Escape、Undo/Redo、画布 Delete/Backspace 等原有非编辑区域行为。

## 测试

- `pnpm test -- apps/desktop/src/components/diagram/__tests__/DiagramToolbar.spec.ts apps/desktop/src/components/diagram/__tests__/SchemaDiagramDialog.keyboard.spec.ts apps/desktop/src/components/diagram/__tests__/DiagramSyncDialog.spec.ts apps/desktop/src/components/diagram/__tests__/ZoomControls.spec.ts apps/desktop/src/components/ui/input/__tests__/Input.spec.ts` ✅（5 个文件、7 个测试通过）
- `pnpm typecheck` ✅
- `pnpm lint` ✅（仅仓库已有的无关 warning）
- Chromium 交互验证 ✅：依次输入 `u` / `s` / `e` / `r` 后直接得到 `user`；同时验证 Backspace、Delete、Home、End、ArrowLeft、Ctrl+A、Ctrl+C、Ctrl+V 和 Space。

新增的 #7661 回归场景：

- 单次依次输入 `u` / `s` / `e` / `r`
- 搜索框最终为 `user`
- 无需重复按键
- 测试确认更新事件恰好发生 4 次

全量 `pnpm test` 另有 3 个与本次改动无关的失败：docs-export 需要本机缺少的 Perl/OpenSSL 构建环境，docs-export 入口测试超时，以及一个既有结构编辑测试在单独重跑时通过。

## 关联 Issue

Closes #7661
