### PR TITLE
fix(grid): 修复表数据超过 10 万行时分页被限制的问题

### DIFF
--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -5249,7 +5249,7 @@ export const useQueryStore = defineStore("query", () => {
         return producedResult;
       }
 
-      const queryResultMaxRows = effectiveQueryResultMaxRows(settingsStore.editorSettings.queryResultMaxRowsEnabled, settingsStore.editorSettings.queryResultMaxRows);
+      const queryResultMaxRows = tab.mode === "query" ? effectiveQueryResultMaxRows(settingsStore.editorSettings.queryResultMaxRowsEnabled, settingsStore.editorSettings.queryResultMaxRows) : undefined;
 
       if (tab.mode === "query") {
         const prepared = await prepareEditableQueryExecution(tab, sqlToExecute, conn, effectiveDbType, executionDatabase, traceId, elapsed);

--- a/packages/app-tests/dataGridPagination.test.ts
+++ b/packages/app-tests/dataGridPagination.test.ts
@@ -62,6 +62,28 @@ test("exact display totals keep pagination inside the configured result cap", ()
   );
 });
 
+test("large table pagination keeps the real last page and deep page offset", () => {
+  const totalRows = 3_374_023;
+  const pageSize = 100;
+  const tablePaginationTotal = resolveDataGridPaginationTotal({
+    serverKnownTotalRowCount: totalRows,
+    totalRowCountIsExact: true,
+  });
+  const queryPaginationTotal = resolveDataGridPaginationTotal({
+    serverKnownTotalRowCount: totalRows,
+    totalRowCountIsExact: true,
+    maxRows: 100_000,
+  });
+
+  assert.equal(tablePaginationTotal, totalRows);
+  assert.equal(queryPaginationTotal, 100_000);
+
+  const lastPage = Math.max(1, Math.ceil((tablePaginationTotal ?? 0) / pageSize));
+  assert.equal(lastPage, 33_741);
+  assert.equal((lastPage - 1) * pageSize, 3_374_000);
+  assert.equal((2_000 - 1) * pageSize, 199_900);
+});
+
 test("first query page is complete when its known total is already loaded", () => {
   assert.equal(
     hasCompleteLocalDataGridResult({

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -7729,6 +7729,52 @@ test("data tab execution uses a tab-scoped client session", async () => {
   }
 });
 
+test("table-data pagination is not clamped by the query result row cap", async () => {
+  const restoreStorage = installMemoryStorage();
+  setActivePinia(createPinia());
+  const connectionStore = useConnectionStore();
+  const settingsStore = useSettingsStore();
+  const store = useQueryStore();
+  const originalFetch = globalThis.fetch;
+  let executeBody: any;
+
+  settingsStore.updateEditorSettings({ queryResultMaxRowsEnabled: true, queryResultMaxRows: 100_000 });
+  connectionStore.addEphemeralConnection(conn("table-data-deep-page"));
+  const tabId = store.createTab("table-data-deep-page", "db", "users", "data", "public");
+  const tab = store.tabs.find((item) => item.id === tabId);
+  assert.ok(tab);
+
+  globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+    if (String(input) !== "/api/query/execute-multi") return new Response("unexpected request", { status: 500 });
+    executeBody = JSON.parse(String(init?.body ?? "{}"));
+    return Response.json([
+      {
+        columns: ["id"],
+        rows: Array.from({ length: 100 }, (_, index) => [199_901 + index]),
+        affected_rows: 0,
+        execution_time_ms: 1,
+      },
+    ]);
+  });
+
+  try {
+    await store.executeTabSql(tabId, 'SELECT * FROM "users" LIMIT 100 OFFSET 199900', {
+      pagination: { limit: 100, offset: 199_900 },
+    });
+
+    assert.match(executeBody.sql, /OFFSET 199900/);
+    assert.equal(executeBody.maxRows, 100);
+    assert.equal(executeBody.fetchSize, 100);
+    assert.equal(tab.resultPageLimit, 100);
+    assert.equal(tab.resultPageOffset, 199_900);
+    assert.equal(tab.result?.truncated, undefined);
+    assert.equal(tab.resultTotalRowCount, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreStorage();
+  }
+});
+
 test("closing a data tab releases its tab-scoped client session", async () => {
   const restoreStorage = installMemoryStorage();
   setActivePinia(createPinia());


### PR DESCRIPTION
﻿## 问题

修复 #7642。

在表数据总行数超过查询结果最大行数限制时，`queryStore` 会错误地将 `queryResultMaxRows` 应用于表数据分页。以实际行数 3,374,023、每页 100 行、上限 100,000 为例，跳转第 2000 页的 offset 会被错误改写为 99,900，最后一页也无法访问 10 万行之后的数据。

## 原因

`queryResultMaxRows` 在执行分页和结果回写时没有区分 SQL 查询结果与表数据上下文，导致表数据请求被 `limitQueryPagination` 截断，并被错误标记为已达到结果行数上限。

## 修复

- 仅在普通 SQL 查询结果上下文启用 `queryResultMaxRows`
- 表数据分页保留调用方请求的 page size 和 offset
- 普通 SQL 查询结果继续遵守配置的最大行数限制
- 表数据深分页不再被错误标记为 `truncated`

## 测试

补充回归测试，覆盖：

- 3,374,023 行、每页 100 行时最后一页为第 33,741 页
- 手工跳转第 2000 页时 offset 为 199,900
- 表数据分页请求不会被 100,000 行上限截断
- 查询结果上下文仍保留最大行数限制

实际运行：

- `pnpm exec vitest run apps/desktop/src/lib/dataGrid/__tests__/dataGridPagination.spec.ts apps/desktop/src/lib/dataGrid/__tests__/queryResultRowLimit.spec.ts packages/app-tests/dataGridPagination.test.ts packages/app-tests/queryStore.test.ts`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/stores/queryStore.ts`

Closes #7642
