### PR TITLE
fix: 修复 Windows 下 SSH SQLite 绝对路径误判

### DIFF
--- a/crates/dbx-core/src/db/sqlite_worker.rs
+++ b/crates/dbx-core/src/db/sqlite_worker.rs
@@ -315,7 +315,7 @@ pub async fn connect_sqlite_worker(
     if db_path.is_empty() {
         return Err("Remote SQLite path is empty".to_string());
     }
-    if !Path::new(db_path).is_absolute() && !db_path.starts_with("~/") {
+    if !is_remote_linux_path_absolute_or_home_relative(db_path) {
         return Err("Remote SQLite path must be an absolute path on the final SSH hop".to_string());
     }
     validate_remote_path(db_path)?;
@@ -744,6 +744,11 @@ fn validate_remote_path(path: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn is_remote_linux_path_absolute_or_home_relative(path: &str) -> bool {
+    // The remote host is Linux even when the DBX Desktop client runs on Windows.
+    path.starts_with('/') || path.starts_with("~/")
+}
+
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
@@ -812,6 +817,14 @@ mod tests {
         assert!(remote_sqlite_exists_from_output("/remote/data/app.db", "ok\n").is_ok());
         let error = remote_sqlite_exists_from_output("/remote/data/app.db", "").unwrap_err();
         assert!(error.contains("File does not exist"), "{error}");
+    }
+
+    #[test]
+    fn remote_sqlite_path_uses_linux_semantics_on_every_desktop_platform() {
+        assert!(is_remote_linux_path_absolute_or_home_relative("/volume1/music/library.db"));
+        assert!(is_remote_linux_path_absolute_or_home_relative("~/data/library.db"));
+        assert!(!is_remote_linux_path_absolute_or_home_relative("volume1/music/library.db"));
+        assert!(!is_remote_linux_path_absolute_or_home_relative(r"C:\data\library.db"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 问题

Windows 客户端通过 SSH 打开远端 Linux 主机上的 SQLite 文件时，即使填写 `/volume1/.../database.db` 这类 Linux 绝对路径，仍会提示：

```text
Remote SQLite path must be an absolute path on the final SSH hop
```

## 原因

远程 SQLite v1 的文件主机只支持 Linux，但路径校验使用了 `std::path::Path::is_absolute()`。该 API 按 DBX 客户端所在系统解释路径；在 Windows 上，Linux 的 `/...` 路径不符合 Windows 绝对路径规则，因此被误判。

## 修复

- 远端 SQLite 数据库路径改为按 Linux 语义校验
- 接受 `/...` 绝对路径，并保留已有的 `~/...` 支持
- 继续拒绝相对路径和 Windows 本地路径，后续远端文件存在性与非法字符校验保持不变
- 增加平台无关回归测试，防止 Windows 客户端再次使用本机路径语义

## 验证

- `CARGO_TARGET_DIR=/private/tmp/dbx-ssh-sqlite-path-target RUST_MIN_STACK=8388608 cargo test -p dbx-core --lib --no-default-features --features sqlite-bundled sqlite_worker`（13 项通过）
- `CARGO_TARGET_DIR=/private/tmp/dbx-ssh-sqlite-path-target cargo check -p dbx-core --no-default-features --features sqlite-bundled`
- `rustfmt --edition 2021 --check crates/dbx-core/src/db/sqlite_worker.rs`
- `git diff --check`

补充：在 macOS 上尝试 Windows target 交叉检查时，`ring` 构建依赖 Windows SDK C 头文件，当前环境无法完成；PR CI 的 Windows runner 将继续验证 Windows 构建。

这是远程 SQLite SSH 功能 PR #7289 的后续修复。
