### PR TITLE
fix: 修复多行粘贴时未自动扩充新增行

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -8718,14 +8718,23 @@ function batchAppendPasteError(reason: string): string {
   return t(messages[reason] ?? "grid.batchAppendPasteInvalidTarget");
 }
 
-function blankCellBatchAppendPasteTarget(pastedRows: readonly (readonly (string | null)[])[]): { rowId: number; columnIndexes: number[] } | null {
+function blankSelectionBatchAppendPasteTarget(pastedRows: readonly (readonly (string | null)[])[]): { rowId: number; columnIndexes: number[] } | null {
   if (pastedRows.length <= 1) return null;
   const range = selectedRange.value;
-  if (!range || range.startRow !== range.endRow || range.startCol !== range.endCol) return null;
-  const item = displayItemAt(range.startRow);
-  if ((!item?.isNew && !item?.isDraft) || item.isDeleted || item.data.some((value) => value !== null && (typeof value !== "string" || value.trim() !== ""))) return null;
+  if (!range || (range.startRow === range.endRow && range.startCol !== range.endCol)) return null;
+  const selectedItems = Array.from({ length: range.endRow - range.startRow + 1 }, (_, offset) => displayItemAt(range.startRow + offset));
+  if (
+    selectedItems.some(
+      (item) =>
+        (!item?.isNew && !item?.isDraft) ||
+        item.isDeleted ||
+        item.data.some((value) => value !== null && (typeof value !== "string" || value.trim() !== "")),
+    )
+  )
+    return null;
+  const item = selectedItems[0];
   const columnIndex = visibleColumnIndexes.value[range.startCol];
-  if (columnIndex === undefined || !canEditCellItem(item, columnIndex)) return null;
+  if (!item || columnIndex === undefined || !canEditCellItem(item, columnIndex)) return null;
   return { rowId: item.id, columnIndexes: visibleColumnIndexes.value.slice(range.startCol) };
 }
 
@@ -8749,7 +8758,7 @@ function pasteTextIntoGrid(text: string): boolean {
   if (targetRowId !== null) {
     return appendParsedRowsToBlankTarget(targetRowId, rows, visibleColumnIndexes.value);
   }
-  const cellTarget = blankCellBatchAppendPasteTarget(rows);
+  const cellTarget = blankSelectionBatchAppendPasteTarget(rows);
   if (cellTarget) return appendParsedRowsToBlankTarget(cellTarget.rowId, rows, cellTarget.columnIndexes);
   return pasteRowsIntoSelection(rows);
 }

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -8723,15 +8723,7 @@ function blankSelectionBatchAppendPasteTarget(pastedRows: readonly (readonly (st
   const range = selectedRange.value;
   if (!range || (range.startRow === range.endRow && range.startCol !== range.endCol)) return null;
   const selectedItems = Array.from({ length: range.endRow - range.startRow + 1 }, (_, offset) => displayItemAt(range.startRow + offset));
-  if (
-    selectedItems.some(
-      (item) =>
-        (!item?.isNew && !item?.isDraft) ||
-        item.isDeleted ||
-        item.data.some((value) => value !== null && (typeof value !== "string" || value.trim() !== "")),
-    )
-  )
-    return null;
+  if (selectedItems.some((item) => (!item?.isNew && !item?.isDraft) || item.isDeleted || item.data.some((value) => value !== null && (typeof value !== "string" || value.trim() !== "")))) return null;
   const item = selectedItems[0];
   const columnIndex = visibleColumnIndexes.value[range.startCol];
   if (!item || columnIndex === undefined || !canEditCellItem(item, columnIndex)) return null;

--- a/apps/desktop/src/components/grid/__tests__/DataGridBatchPasteFromCell.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridBatchPasteFromCell.spec.ts
@@ -180,6 +180,90 @@ afterEach(() => {
 });
 
 describe("DataGrid multi-row paste from a blank cell", () => {
+  it("expands beyond pre-added blank rows when pasted rows exceed them", async () => {
+    const { host } = mountGrid();
+    await settle();
+    for (let index = 0; index < 5; index++) await addBlankRow(host);
+
+    const blankRows = pendingRows(host);
+    expect(blankRows).toHaveLength(5);
+    await selectCell(visibleCells(blankRows[0]!)[0]!);
+    await selectCell(visibleCells(blankRows[4]!)[0]!, { shiftKey: true });
+    await paste(host, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+
+    const rows = pendingRows(host);
+    expect(rows).toHaveLength(10);
+    expect(rows.map((row) => visibleCellTexts(row)[0])).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
+    expect(visibleCellTexts(rows.at(-1)!)[0]).toBe("10");
+  });
+
+  it("reuses exactly enough pre-added blank rows without adding an extra row", async () => {
+    const { host } = mountGrid();
+    await settle();
+    for (let index = 0; index < 10; index++) await addBlankRow(host);
+
+    const blankRows = pendingRows(host);
+    expect(blankRows).toHaveLength(10);
+    await selectCell(visibleCells(blankRows[0]!)[0]!);
+    await selectCell(visibleCells(blankRows[9]!)[0]!, { shiftKey: true });
+    await paste(host, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+
+    const rows = pendingRows(host);
+    expect(rows).toHaveLength(10);
+    expect(rows.map((row) => visibleCellTexts(row)[0])).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
+    expect(visibleCellTexts(rows.at(-1)!)[0]).toBe("10");
+  });
+
+  it("keeps extra pre-added blank rows when the clipboard has fewer rows", async () => {
+    const { host } = mountGrid();
+    await settle();
+    for (let index = 0; index < 10; index++) await addBlankRow(host);
+
+    const blankRows = pendingRows(host);
+    await selectCell(visibleCells(blankRows[0]!)[0]!);
+    await selectCell(visibleCells(blankRows[9]!)[0]!, { shiftKey: true });
+    await paste(host, "1\n2\n3\n4\n5");
+
+    const rows = pendingRows(host);
+    expect(rows).toHaveLength(10);
+    expect(visibleCellTexts(rows[0]!)[0]).toBe("1");
+    expect(visibleCellTexts(rows[4]!)[0]).toBe("5");
+    expect(visibleCellTexts(rows[5]!)[0]).toBe("NULL");
+    expect(visibleCellTexts(rows[9]!)[0]).toBe("NULL");
+  });
+
+  it("keeps single-cell auto expansion with pre-added blank rows", async () => {
+    const { host } = mountGrid();
+    await settle();
+    for (let index = 0; index < 5; index++) await addBlankRow(host);
+
+    const blankRows = pendingRows(host);
+    await selectCell(visibleCells(blankRows[0]!)[0]!);
+    await paste(host, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+
+    const rows = pendingRows(host);
+    expect(rows).toHaveLength(10);
+    expect(rows.map((row) => visibleCellTexts(row)[0])).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
+    expect(visibleCellTexts(rows.at(-1)!)[0]).toBe("10");
+  });
+
+  it("preserves visible column mapping for a multi-row selection", async () => {
+    const { host } = mountGrid({ hideNullColumns: true });
+    await settle();
+    for (let index = 0; index < 5; index++) await addBlankRow(host);
+
+    const blankRows = pendingRows(host);
+    await selectCell(visibleCells(blankRows[0]!)[1]!);
+    await selectCell(visibleCells(blankRows[4]!)[1]!, { shiftKey: true });
+    const clipboardRows = Array.from({ length: 10 }, (_, index) => `value-${index + 1}\tnote-${index + 1}`).join("\n");
+    await paste(host, clipboardRows);
+
+    const rows = pendingRows(host);
+    expect(rows).toHaveLength(10);
+    expect(visibleCellTexts(rows[0]!)).toEqual(["NULL", "value-1", "note-1"]);
+    expect(visibleCellTexts(rows.at(-1)!)).toEqual(["NULL", "value-10", "note-10"]);
+  });
+
   it("starts at the selected visible column, skips hidden columns, and appends rows", async () => {
     const { host } = mountGrid({ hideNullColumns: true });
     await settle();
@@ -218,17 +302,18 @@ describe("DataGrid multi-row paste from a blank cell", () => {
   it("keeps row-number paste priority and starts from the first visible column", async () => {
     const { host } = mountGrid({ hideNullColumns: true });
     await settle();
-    await addBlankRow(host);
+    for (let index = 0; index < 5; index++) await addBlankRow(host);
 
-    const [blankRow] = pendingRows(host);
-    expect(blankRow).toBeDefined();
-    await selectRowNumber(blankRow!);
-    await paste(host, "10\t20\n30\t40");
+    const blankRows = pendingRows(host);
+    expect(blankRows).toHaveLength(5);
+    await selectRowNumber(blankRows[0]!);
+    const clipboardRows = Array.from({ length: 10 }, (_, index) => `${index + 10}\t${index + 20}`).join("\n");
+    await paste(host, clipboardRows);
 
     const rows = pendingRows(host);
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(10);
     expect(visibleCellTexts(rows[0]!)).toEqual(["10", "20", "NULL"]);
-    expect(visibleCellTexts(rows[1]!)).toEqual(["30", "40", "NULL"]);
+    expect(visibleCellTexts(rows.at(-1)!)).toEqual(["19", "29", "NULL"]);
   });
 
   it("keeps nonblank new rows on the ordinary bounded paste path", async () => {
@@ -246,6 +331,24 @@ describe("DataGrid multi-row paste from a blank cell", () => {
     const rows = pendingRows(host);
     expect(rows).toHaveLength(1);
     expect(visibleCellTexts(rows[0]!)[2]).toBe("first");
+  });
+
+  it("does not expand a multi-row selection containing a nonblank new row", async () => {
+    const { host } = mountGrid();
+    await settle();
+    for (let index = 0; index < 5; index++) await addBlankRow(host);
+
+    let rows = pendingRows(host);
+    await selectCell(visibleCells(rows[0]!)[2]!);
+    await paste(host, "occupied");
+    rows = pendingRows(host);
+    await selectCell(visibleCells(rows[0]!)[2]!);
+    await selectCell(visibleCells(rows[4]!)[2]!, { shiftKey: true });
+    await paste(host, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10");
+
+    rows = pendingRows(host);
+    expect(rows).toHaveLength(5);
+    expect(visibleCellTexts(rows.at(-1)!)[2]).toBe("5");
   });
 
   it("keeps existing rows on the ordinary bounded paste path", async () => {


### PR DESCRIPTION
## 问题

修复 #7662。

在表格编辑场景中，如果用户预先新增部分空白行，例如新增 5 行后从新增区域选中并粘贴 10 行数据，现有路径会按照当前显示区域剩余行数截断，导致后半部分 clipboard 数据没有写入。

此前 #6144（`adb757899870de2bdca1b9c693cdcf8f77167f28`）已支持从单个空白新增行或 quick-entry 草稿单元格开始粘贴时自动创建更多行，但多行单元格选择仍会走原有的 bounded paste 路径。

## 根因

`blankCellBatchAppendPasteTarget` 只接受 `startRow === endRow && startCol === endCol` 的单个单元格选择。用户通过 Shift 选择或框选多个预先新增的空白行后，该判断返回 `null`，因此没有进入已有的 `appendPastedRowsToNewRow` 路径。

随后普通 `pasteRowsIntoSelection` 使用 `planDataGridPaste(rows, displayRowCount - start.rowIndex, ...)` 规划粘贴单元格；当当前只有 5 个新增行时，`maxRows` 为 5，clipboard 的剩余行就被截断。已有的 append helper 本身已经能够复用连续空白新增行并为不足部分创建新行，遗漏发生在调用层的 selection 判定。

## 修改

- 允许连续多行选择在所有目标行均为全空、可编辑的新建行或草稿行时进入现有 batch append 路径。
- 保留单行多列选择、普通 persisted row、包含非空新增行、只读列和列映射的原有 bounded paste / 编辑限制。
- 增加预先新增 5/10 行后粘贴 10/5 行、单元格路径、行号路径、隐藏列和中间可见列映射等回归测试。

保持现有单行粘贴、普通数据行、只读列、隐藏列和 quick-entry 行为不变。

## 验证

实际执行：

```text
pnpm vitest run apps/desktop/src/components/grid/__tests__/DataGridBatchPasteFromCell.spec.ts apps/desktop/src/composables/__tests__/useDataGridEditor.spec.ts apps/desktop/src/lib/__tests__/dataGrid/dataGridClipboard.spec.ts
通过：3 个测试文件，70 个测试

pnpm typecheck
通过：vue-tsc --noEmit --project apps/desktop/tsconfig.json

pnpm exec oxlint --vue-plugin apps/desktop/src/components/grid/DataGrid.vue apps/desktop/src/components/grid/__tests__/DataGridBatchPasteFromCell.spec.ts
通过

pnpm exec oxfmt --check apps/desktop/src/components/grid/__tests__/DataGridBatchPasteFromCell.spec.ts
通过
```

新增回归覆盖：

- 预先新增 5 个空白行后选择新增区域粘贴 10 行，10 行数据全部写入，尾行数据为 `10`。
- 预先新增 10 行后粘贴 10 行，不额外生成第 11 行。
- 预先新增 10 行后粘贴 5 行，保留其余空白新增行，不重复填充或删除。
- #6144 原有单空白单元格自动扩展及行号优先路径保持正常。
- 从隐藏列后的可见列开始粘贴时保持列偏移；普通已有数据行和包含非空新增行不会无限扩展。

## 风险

本次调整仅作用于可编辑的新建空白行区域中的表格型批量粘贴，普通 persisted row、单行多列选择和非空新增行继续保持原有 bounded paste 行为，因此影响范围有限。

Closes #7662
