### PR TITLE
fix: 修正 GoldenDB 生成 SQL 的标识符引号

### DIFF
--- a/apps/desktop/src/lib/table/tableSelectSql.ts
+++ b/apps/desktop/src/lib/table/tableSelectSql.ts
@@ -29,7 +29,18 @@ export function quoteTableIdentifier(databaseType: DatabaseType | undefined, nam
   // (DatabaseMetaData.getIdentifierQuoteString()) — pass through unquoted.
   if (databaseType === "jdbc") return name;
   if (databaseType === "bigquery") return `\`${name.replace(/`/g, "\\`")}\``;
-  if (databaseType === "mysql" || databaseType === "clickhouse" || databaseType === "hive" || databaseType === "spark" || databaseType === "databend" || databaseType === "tdengine" || databaseType === "access" || databaseType === "doris" || databaseType === "starrocks")
+  if (
+    databaseType === "mysql" ||
+    databaseType === "goldendb" ||
+    databaseType === "clickhouse" ||
+    databaseType === "hive" ||
+    databaseType === "spark" ||
+    databaseType === "databend" ||
+    databaseType === "tdengine" ||
+    databaseType === "access" ||
+    databaseType === "doris" ||
+    databaseType === "starrocks"
+  )
     return `\`${name.replace(/`/g, "``")}\``;
   if (databaseType === "informix" && /^[A-Za-z_][A-Za-z0-9_$]*$/.test(name)) return name;
   if (databaseType === "neo4j") return quoteCypherIdentifier(name);

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-21T18:28:08.295Z",
-  "stars": 16188,
+  "generatedAt": "2026-08-22T18:20:43.168Z",
+  "stars": 16247,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3134,
+      "commits": 3161,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 584,
-      "mergedPullRequests": 584,
+      "commits": 588,
+      "mergedPullRequests": 590,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-21T11:57:22Z"
+      "latestContributionAt": "2026-08-22T17:39:23Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 161,
-      "mergedPullRequests": 160,
+      "commits": 163,
+      "mergedPullRequests": 163,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-21T04:20:58Z"
+      "latestContributionAt": "2026-08-22T17:40:22Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,28 +43,28 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 86,
-      "mergedPullRequests": 86,
+      "commits": 87,
+      "mergedPullRequests": 87,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-20T14:23:37Z"
+      "latestContributionAt": "2026-08-22T04:52:54Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 67,
-      "mergedPullRequests": 67,
+      "commits": 68,
+      "mergedPullRequests": 68,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-20T00:47:05Z"
+      "latestContributionAt": "2026-08-22T07:41:21Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 61,
-      "mergedPullRequests": 61,
+      "commits": 62,
+      "mergedPullRequests": 62,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-21T10:19:48Z"
+      "latestContributionAt": "2026-08-22T04:58:28Z"
     },
     {
       "login": "serenez",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 43,
-      "mergedPullRequests": 41,
+      "commits": 44,
+      "mergedPullRequests": 42,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-19T03:10:12Z"
+      "latestContributionAt": "2026-08-22T07:41:14Z"
     },
     {
       "login": "Illuminated2020",
@@ -130,6 +130,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 26,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-22T17:39:54Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -146,15 +155,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-05-02T07:44:05Z",
       "latestContributionAt": "2026-05-29T05:31:32Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 22,
-      "mergedPullRequests": 22,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-21T04:20:20Z"
     },
     {
       "login": "LwClick",
@@ -643,6 +643,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 3,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-22T17:40:51Z"
+    },
+    {
       "login": "BabyLy233",
       "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
       "profileUrl": "https://github.com/BabyLy233",
@@ -758,15 +767,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-18T10:01:35Z",
       "latestContributionAt": "2026-08-20T13:01:23Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-21T05:03:15Z"
     },
     {
       "login": "vergil-lai",
@@ -1471,6 +1471,15 @@
       "latestContributionAt": "2026-07-28T17:29:20Z"
     },
     {
+      "login": "klinge1011",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
+      "profileUrl": "https://github.com/klinge1011",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-21T12:23:37Z",
+      "latestContributionAt": "2026-08-22T07:41:17Z"
+    },
+    {
       "login": "koco-co",
       "avatarUrl": "https://avatars.githubusercontent.com/u/227195474?v=4",
       "profileUrl": "https://github.com/koco-co",
@@ -1712,6 +1721,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
+    },
+    {
+      "login": "Tara8573",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
+      "profileUrl": "https://github.com/Tara8573",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-22T04:03:32Z",
+      "latestContributionAt": "2026-08-22T11:30:39Z"
     },
     {
       "login": "tatuke",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-13T18:55:30.067Z",
-  "stars": 14433,
+  "generatedAt": "2026-08-14T18:44:38.239Z",
+  "stars": 14743,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3003,
+      "commits": 3033,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 525,
-      "mergedPullRequests": 525,
+      "commits": 535,
+      "mergedPullRequests": 535,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-13T16:11:29Z"
+      "latestContributionAt": "2026-08-14T16:27:35Z"
     },
     {
       "login": "eryajf",
@@ -34,19 +34,19 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 90,
-      "mergedPullRequests": 78,
+      "commits": 91,
+      "mergedPullRequests": 79,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-13T11:44:48Z"
+      "latestContributionAt": "2026-08-14T10:37:53Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 62,
-      "mergedPullRequests": 62,
+      "commits": 63,
+      "mergedPullRequests": 63,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-12T13:05:14Z"
+      "latestContributionAt": "2026-08-14T16:28:12Z"
     },
     {
       "login": "onenewcode",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-08-13T02:51:41Z"
     },
     {
+      "login": "gggaiitx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
+      "profileUrl": "https://github.com/gggaiitx",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-06T09:30:53Z",
+      "latestContributionAt": "2026-08-14T04:56:39Z"
+    },
+    {
       "login": "lexmin0412",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24385370?v=4",
       "profileUrl": "https://github.com/lexmin0412",
@@ -112,13 +121,13 @@
       "latestContributionAt": "2026-08-07T07:57:46Z"
     },
     {
-      "login": "gggaiitx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
-      "profileUrl": "https://github.com/gggaiitx",
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
       "commits": 27,
       "mergedPullRequests": 27,
-      "firstContributionAt": "2026-07-06T09:30:53Z",
-      "latestContributionAt": "2026-07-28T14:39:11Z"
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-14T14:12:45Z"
     },
     {
       "login": "SuLea-IT",
@@ -155,15 +164,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-09T08:33:11Z",
       "latestContributionAt": "2026-08-13T03:40:23Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 18,
-      "mergedPullRequests": 18,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-13T18:06:06Z"
     },
     {
       "login": "yavon007",
@@ -214,10 +214,10 @@
       "login": "amwps290",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
       "profileUrl": "https://github.com/amwps290",
-      "commits": 11,
-      "mergedPullRequests": 11,
+      "commits": 12,
+      "mergedPullRequests": 12,
       "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-11T07:00:25Z"
+      "latestContributionAt": "2026-08-14T09:47:55Z"
     },
     {
       "login": "DASungta",
@@ -265,6 +265,15 @@
       "latestContributionAt": "2026-07-27T14:47:00Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 10,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-14T14:56:29Z"
+    },
+    {
       "login": "chenhbb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
       "profileUrl": "https://github.com/chenhbb",
@@ -290,15 +299,6 @@
       "mergedPullRequests": 10,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-13T04:40:51Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 9,
-      "mergedPullRequests": 9,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-13T16:10:12Z"
     },
     {
       "login": "aiLi0617",
@@ -506,6 +506,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-08-13T14:31:14Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-14T14:18:29Z"
     },
     {
       "login": "James-Leong",
@@ -778,15 +787,6 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-13T04:41:58Z"
-    },
-    {
       "login": "holmesin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
       "profileUrl": "https://github.com/holmesin",
@@ -841,6 +841,15 @@
       "latestContributionAt": "2026-06-09T03:59:49Z"
     },
     {
+      "login": "kir1ito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
+      "profileUrl": "https://github.com/kir1ito",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-13T10:38:51Z",
+      "latestContributionAt": "2026-08-14T10:05:36Z"
+    },
+    {
       "login": "Lan-zk",
       "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
       "profileUrl": "https://github.com/Lan-zk",
@@ -875,6 +884,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T04:57:31Z",
       "latestContributionAt": "2026-08-02T08:35:04Z"
+    },
+    {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-14T10:25:05Z"
     },
     {
       "login": "onlyc0302",
@@ -983,6 +1001,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
+    },
+    {
+      "login": "xiaou61",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
+      "profileUrl": "https://github.com/xiaou61",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-14T09:19:51Z",
+      "latestContributionAt": "2026-08-14T14:46:33Z"
     },
     {
       "login": "xzxlove",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,16 +1,16 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-29T20:17:46.770Z",
-  "stars": 17401,
+  "generatedAt": "2026-08-30T20:24:13.247Z",
+  "stars": 17473,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3306,
-      "mergedPullRequests": 19,
+      "commits": 3310,
+      "mergedPullRequests": 23,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-29T19:54:16Z"
+      "latestContributionAt": "2026-08-30T05:30:01Z"
     },
     {
       "login": "zipg",
@@ -25,10 +25,10 @@
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 187,
-      "mergedPullRequests": 186,
+      "commits": 191,
+      "mergedPullRequests": 190,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-29T19:05:44Z"
+      "latestContributionAt": "2026-08-30T04:26:07Z"
     },
     {
       "login": "q396921921",
@@ -43,10 +43,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 103,
-      "mergedPullRequests": 91,
+      "commits": 104,
+      "mergedPullRequests": 92,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-28T04:37:11Z"
+      "latestContributionAt": "2026-08-30T04:26:55Z"
     },
     {
       "login": "CN-Scars",
@@ -107,7 +107,7 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
       "commits": 36,
-      "mergedPullRequests": 37,
+      "mergedPullRequests": 36,
       "firstContributionAt": "2026-07-17T05:42:50Z",
       "latestContributionAt": "2026-08-25T07:15:42Z"
     },
@@ -193,6 +193,15 @@
       "latestContributionAt": "2026-06-26T10:48:46Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-30T01:59:24Z"
+    },
+    {
       "login": "jischeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49861575?v=4",
       "profileUrl": "https://github.com/jischeng",
@@ -200,15 +209,6 @@
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-06-24T12:52:59Z",
       "latestContributionAt": "2026-07-29T12:41:10Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-28T04:14:04Z"
     },
     {
       "login": "AndrewDi",
@@ -364,6 +364,15 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-29T20:17:33Z"
+    },
+    {
       "login": "hanxuanyu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
       "profileUrl": "https://github.com/hanxuanyu",
@@ -407,15 +416,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-28T03:12:41Z"
     },
     {
       "login": "jeeinn",
@@ -1300,6 +1300,15 @@
       "latestContributionAt": "2026-07-02T08:37:21Z"
     },
     {
+      "login": "debugzhao",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32617253?v=4",
+      "profileUrl": "https://github.com/debugzhao",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-28T14:35:35Z",
+      "latestContributionAt": "2026-08-30T04:25:55Z"
+    },
+    {
       "login": "Dhevenddra",
       "avatarUrl": "https://avatars.githubusercontent.com/u/121691114?v=4",
       "profileUrl": "https://github.com/Dhevenddra",
@@ -1658,6 +1667,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-14T11:25:31Z",
       "latestContributionAt": "2026-07-28T20:32:27Z"
+    },
+    {
+      "login": "mmorella-dev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4561733?v=4",
+      "profileUrl": "https://github.com/mmorella-dev",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-28T19:54:04Z",
+      "latestContributionAt": "2026-08-29T20:36:35Z"
     },
     {
       "login": "monellin",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,25 +1,25 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-14T18:44:38.239Z",
-  "stars": 14743,
+  "generatedAt": "2026-08-15T18:19:28.914Z",
+  "stars": 14957,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3033,
-      "mergedPullRequests": 15,
+      "commits": 3041,
+      "mergedPullRequests": 16,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-07-30T13:10:01Z"
+      "latestContributionAt": "2026-08-15T04:08:41Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 535,
-      "mergedPullRequests": 535,
+      "commits": 540,
+      "mergedPullRequests": 540,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-14T16:27:35Z"
+      "latestContributionAt": "2026-08-15T15:53:32Z"
     },
     {
       "login": "eryajf",
@@ -67,6 +67,15 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 50,
+      "mergedPullRequests": 50,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-15T15:43:10Z"
+    },
+    {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
@@ -88,10 +97,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 29,
-      "mergedPullRequests": 29,
+      "commits": 30,
+      "mergedPullRequests": 30,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-13T02:51:41Z"
+      "latestContributionAt": "2026-08-15T13:55:55Z"
     },
     {
       "login": "gggaiitx",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-07-10T06:34:09Z",
       "latestContributionAt": "2026-08-07T07:57:46Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 27,
-      "mergedPullRequests": 27,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-14T14:12:45Z"
     },
     {
       "login": "SuLea-IT",
@@ -427,6 +427,15 @@
       "latestContributionAt": "2026-08-07T05:43:30Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-15T06:41:54Z"
+    },
+    {
       "login": "fraluc06",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67560467?v=4",
       "profileUrl": "https://github.com/fraluc06",
@@ -479,15 +488,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-02T10:52:18Z",
       "latestContributionAt": "2026-08-02T11:35:45Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-13T18:05:51Z"
     },
     {
       "login": "Dreamescaper",
@@ -580,6 +580,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "azens",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
+      "profileUrl": "https://github.com/azens",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-17T06:34:18Z",
+      "latestContributionAt": "2026-08-15T06:59:05Z"
+    },
+    {
       "login": "BabyLy233",
       "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
       "profileUrl": "https://github.com/BabyLy233",
@@ -614,6 +623,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
+    },
+    {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-15T06:41:42Z"
     },
     {
       "login": "lazyanubis",
@@ -670,6 +688,15 @@
       "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
+      "login": "xzxlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
+      "profileUrl": "https://github.com/xzxlove",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T06:38:59Z",
+      "latestContributionAt": "2026-08-15T06:44:47Z"
+    },
+    {
       "login": "Michaelxwb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34806714?v=4",
       "profileUrl": "https://github.com/Michaelxwb",
@@ -695,15 +722,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-26T03:33:01Z",
       "latestContributionAt": "2026-07-01T08:35:48Z"
-    },
-    {
-      "login": "azens",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
-      "profileUrl": "https://github.com/azens",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-17T06:34:18Z",
-      "latestContributionAt": "2026-08-09T11:51:12Z"
     },
     {
       "login": "bigliangzao",
@@ -841,6 +859,15 @@
       "latestContributionAt": "2026-06-09T03:59:49Z"
     },
     {
+      "login": "kingcanfish",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43931057?v=4",
+      "profileUrl": "https://github.com/kingcanfish",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-05-02T02:18:47Z",
+      "latestContributionAt": "2026-08-15T06:41:17Z"
+    },
+    {
       "login": "kir1ito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
       "profileUrl": "https://github.com/kir1ito",
@@ -848,15 +875,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-13T10:38:51Z",
       "latestContributionAt": "2026-08-14T10:05:36Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-13T18:25:25Z"
     },
     {
       "login": "lc6464",
@@ -1010,15 +1028,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-14T09:19:51Z",
       "latestContributionAt": "2026-08-14T14:46:33Z"
-    },
-    {
-      "login": "xzxlove",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
-      "profileUrl": "https://github.com/xzxlove",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-13T06:38:59Z",
-      "latestContributionAt": "2026-08-13T12:34:54Z"
     },
     {
       "login": "yangqinlong",
@@ -1199,6 +1208,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T05:02:37Z",
       "latestContributionAt": "2026-07-25T00:45:27Z"
+    },
+    {
+      "login": "domye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
+      "profileUrl": "https://github.com/domye",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-15T02:08:13Z",
+      "latestContributionAt": "2026-08-15T06:44:36Z"
     },
     {
       "login": "Driftlux",
@@ -1406,15 +1424,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-23T09:40:04Z",
       "latestContributionAt": "2026-07-28T17:29:20Z"
-    },
-    {
-      "login": "kingcanfish",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43931057?v=4",
-      "profileUrl": "https://github.com/kingcanfish",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-05-02T02:18:47Z",
-      "latestContributionAt": "2026-05-02T02:36:28Z"
     },
     {
       "login": "koco-co",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-26T19:42:14.179Z",
-  "stars": 16698,
+  "generatedAt": "2026-08-28T01:59:57.384Z",
+  "stars": 17031,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3267,
+      "commits": 3287,
       "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-25T16:07:31Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 629,
-      "mergedPullRequests": 629,
+      "commits": 636,
+      "mergedPullRequests": 636,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-26T13:31:55Z"
+      "latestContributionAt": "2026-08-27T14:25:39Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 175,
-      "mergedPullRequests": 174,
+      "commits": 179,
+      "mergedPullRequests": 178,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-26T14:04:42Z"
+      "latestContributionAt": "2026-08-27T09:59:11Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 99,
-      "mergedPullRequests": 99,
+      "commits": 104,
+      "mergedPullRequests": 104,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-26T14:07:35Z"
+      "latestContributionAt": "2026-08-27T14:25:09Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 99,
-      "mergedPullRequests": 87,
+      "commits": 102,
+      "mergedPullRequests": 90,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-26T06:09:09Z"
+      "latestContributionAt": "2026-08-27T14:23:13Z"
     },
     {
       "login": "CN-Scars",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 65,
-      "mergedPullRequests": 65,
+      "commits": 66,
+      "mergedPullRequests": 66,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-26T06:44:20Z"
+      "latestContributionAt": "2026-08-27T02:55:20Z"
     },
     {
       "login": "serenez",
@@ -88,10 +88,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 40,
-      "mergedPullRequests": 40,
+      "commits": 42,
+      "mergedPullRequests": 42,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-26T09:47:15Z"
+      "latestContributionAt": "2026-08-27T00:40:28Z"
     },
     {
       "login": "Illuminated2020",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-08-24T05:29:24Z"
     },
     {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-27T09:17:41Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -254,15 +263,6 @@
       "mergedPullRequests": 12,
       "firstContributionAt": "2026-07-25T02:38:05Z",
       "latestContributionAt": "2026-08-26T13:38:10Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 12,
-      "mergedPullRequests": 12,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-20T14:11:49Z"
     },
     {
       "login": "dienaso",
@@ -364,6 +364,15 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-27T04:21:29Z"
+    },
+    {
       "login": "Jinmoli",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
       "profileUrl": "https://github.com/Jinmoli",
@@ -398,15 +407,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
-    },
-    {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-18T16:30:40Z"
     },
     {
       "login": "jeeinn",
@@ -517,6 +517,15 @@
       "latestContributionAt": "2026-08-13T11:24:49Z"
     },
     {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-27T02:55:06Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -614,15 +623,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-05T16:45:23Z",
       "latestContributionAt": "2026-07-12T13:30:37Z"
-    },
-    {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-18T07:36:37Z"
     },
     {
       "login": "xzxlove",
@@ -994,6 +994,15 @@
       "latestContributionAt": "2026-08-02T08:35:04Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-08-27T09:32:57Z"
+    },
+    {
       "login": "onlyc0302",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24369193?v=4",
       "profileUrl": "https://github.com/onlyc0302",
@@ -1210,6 +1219,15 @@
       "latestContributionAt": "2026-05-10T12:53:40Z"
     },
     {
+      "login": "cdredfox",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315326?v=4",
+      "profileUrl": "https://github.com/cdredfox",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-27T05:57:53Z",
+      "latestContributionAt": "2026-08-27T09:16:58Z"
+    },
+    {
       "login": "CGerAJ",
       "avatarUrl": "https://avatars.githubusercontent.com/u/20548301?v=4",
       "profileUrl": "https://github.com/CGerAJ",
@@ -1370,6 +1388,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-05T11:00:04Z",
       "latestContributionAt": "2026-07-05T11:38:51Z"
+    },
+    {
+      "login": "fanchenggang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20358122?v=4",
+      "profileUrl": "https://github.com/fanchenggang",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-27T07:09:23Z",
+      "latestContributionAt": "2026-08-27T09:37:55Z"
     },
     {
       "login": "fuuulstack",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-15T18:19:28.914Z",
-  "stars": 14957,
+  "generatedAt": "2026-08-16T18:20:13.205Z",
+  "stars": 15086,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3041,
+      "commits": 3046,
       "mergedPullRequests": 16,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-15T04:08:41Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 540,
-      "mergedPullRequests": 540,
+      "commits": 547,
+      "mergedPullRequests": 547,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-15T15:53:32Z"
+      "latestContributionAt": "2026-08-16T18:09:50Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 145,
-      "mergedPullRequests": 144,
+      "commits": 152,
+      "mergedPullRequests": 151,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-12T18:10:38Z"
+      "latestContributionAt": "2026-08-16T17:51:19Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -70,10 +70,10 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 50,
-      "mergedPullRequests": 50,
+      "commits": 57,
+      "mergedPullRequests": 57,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-15T15:43:10Z"
+      "latestContributionAt": "2026-08-16T06:39:43Z"
     },
     {
       "login": "onceMisery",
@@ -580,6 +580,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-16T07:34:03Z"
+    },
+    {
       "login": "azens",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
       "profileUrl": "https://github.com/azens",
@@ -605,6 +614,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-06T10:14:50Z",
       "latestContributionAt": "2026-08-11T13:32:15Z"
+    },
+    {
+      "login": "domye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
+      "profileUrl": "https://github.com/domye",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-15T02:08:13Z",
+      "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
       "login": "jthanh8144",
@@ -1210,15 +1228,6 @@
       "latestContributionAt": "2026-07-25T00:45:27Z"
     },
     {
-      "login": "domye",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
-      "profileUrl": "https://github.com/domye",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-15T02:08:13Z",
-      "latestContributionAt": "2026-08-15T06:44:36Z"
-    },
-    {
       "login": "Driftlux",
       "avatarUrl": "https://avatars.githubusercontent.com/u/96872606?v=4",
       "profileUrl": "https://github.com/Driftlux",
@@ -1514,6 +1523,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-06T06:29:13Z",
       "latestContributionAt": "2026-08-06T18:19:46Z"
+    },
+    {
+      "login": "niubinJD",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22911292?v=4",
+      "profileUrl": "https://github.com/niubinJD",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-15T16:59:21Z",
+      "latestContributionAt": "2026-08-16T03:21:22Z"
     },
     {
       "login": "octo-patch",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-12T18:54:53.390Z",
-  "stars": 14288,
+  "generatedAt": "2026-08-13T18:55:30.067Z",
+  "stars": 14433,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2960,
+      "commits": 3003,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 513,
-      "mergedPullRequests": 513,
+      "commits": 525,
+      "mergedPullRequests": 525,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-12T18:10:52Z"
+      "latestContributionAt": "2026-08-13T16:11:29Z"
     },
     {
       "login": "eryajf",
@@ -34,10 +34,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 89,
-      "mergedPullRequests": 77,
+      "commits": 90,
+      "mergedPullRequests": 78,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-12T11:34:01Z"
+      "latestContributionAt": "2026-08-13T11:44:48Z"
     },
     {
       "login": "CN-Scars",
@@ -49,6 +49,15 @@
       "latestContributionAt": "2026-08-12T13:05:14Z"
     },
     {
+      "login": "onenewcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
+      "profileUrl": "https://github.com/onenewcode",
+      "commits": 59,
+      "mergedPullRequests": 59,
+      "firstContributionAt": "2026-06-30T01:53:31Z",
+      "latestContributionAt": "2026-08-13T11:31:18Z"
+    },
+    {
       "login": "serenez",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38424953?v=4",
       "profileUrl": "https://github.com/serenez",
@@ -58,22 +67,13 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
-      "login": "onenewcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
-      "profileUrl": "https://github.com/onenewcode",
-      "commits": 55,
-      "mergedPullRequests": 55,
-      "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-12T04:36:14Z"
-    },
-    {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 41,
-      "mergedPullRequests": 39,
+      "commits": 42,
+      "mergedPullRequests": 40,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-10T15:45:43Z"
+      "latestContributionAt": "2026-08-13T16:19:09Z"
     },
     {
       "login": "Illuminated2020",
@@ -85,6 +85,15 @@
       "latestContributionAt": "2026-05-12T09:22:36Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 29,
+      "mergedPullRequests": 29,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-13T02:51:41Z"
+    },
+    {
       "login": "lexmin0412",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24385370?v=4",
       "profileUrl": "https://github.com/lexmin0412",
@@ -92,15 +101,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 28,
-      "mergedPullRequests": 28,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-12T10:24:01Z"
     },
     {
       "login": "xddcode",
@@ -151,10 +151,19 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
-      "commits": 21,
-      "mergedPullRequests": 21,
+      "commits": 22,
+      "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-08-11T05:05:26Z"
+      "latestContributionAt": "2026-08-13T03:40:23Z"
+    },
+    {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 18,
+      "mergedPullRequests": 18,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-13T18:06:06Z"
     },
     {
       "login": "yavon007",
@@ -209,6 +218,15 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-21T05:32:24Z",
       "latestContributionAt": "2026-08-11T07:00:25Z"
+    },
+    {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-13T07:26:45Z"
     },
     {
       "login": "guoyongchang",
@@ -268,19 +286,19 @@
       "login": "dienaso",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
       "profileUrl": "https://github.com/dienaso",
-      "commits": 9,
-      "mergedPullRequests": 9,
+      "commits": 10,
+      "mergedPullRequests": 10,
       "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-08-04T05:02:31Z"
+      "latestContributionAt": "2026-08-13T04:40:51Z"
     },
     {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
       "commits": 9,
       "mergedPullRequests": 9,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-12T18:12:10Z"
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-13T16:10:12Z"
     },
     {
       "login": "aiLi0617",
@@ -292,13 +310,13 @@
       "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
       "commits": 8,
       "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-12T04:37:01Z"
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-13T16:22:44Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -319,15 +337,6 @@
       "latestContributionAt": "2026-08-11T13:33:16Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-12T12:42:45Z"
-    },
-    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -337,13 +346,13 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
       "commits": 7,
       "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-12T05:35:03Z"
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-13T11:25:08Z"
     },
     {
       "login": "xKrah",
@@ -371,15 +380,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-02T15:29:53Z",
       "latestContributionAt": "2026-08-12T14:22:34Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-12T12:15:58Z"
     },
     {
       "login": "luoianun",
@@ -445,6 +445,15 @@
       "latestContributionAt": "2026-08-10T10:51:45Z"
     },
     {
+      "login": "wbean",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
+      "profileUrl": "https://github.com/wbean",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-22T07:12:37Z",
+      "latestContributionAt": "2026-08-13T11:24:49Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -472,6 +481,15 @@
       "latestContributionAt": "2026-08-02T11:35:45Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-13T18:05:51Z"
+    },
+    {
       "login": "Dreamescaper",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17177729?v=4",
       "profileUrl": "https://github.com/Dreamescaper",
@@ -479,6 +497,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-09T07:54:46Z",
       "latestContributionAt": "2026-06-26T09:45:45Z"
+    },
+    {
+      "login": "echocde",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
+      "profileUrl": "https://github.com/echocde",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-06-10T13:16:26Z",
+      "latestContributionAt": "2026-08-13T14:31:14Z"
     },
     {
       "login": "James-Leong",
@@ -506,15 +533,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-22T04:43:40Z",
       "latestContributionAt": "2026-07-31T05:54:26Z"
-    },
-    {
-      "login": "wbean",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
-      "profileUrl": "https://github.com/wbean",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-22T07:12:37Z",
-      "latestContributionAt": "2026-07-30T10:19:13Z"
     },
     {
       "login": "wuxiemian",
@@ -569,24 +587,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-06T10:14:50Z",
       "latestContributionAt": "2026-08-11T13:32:15Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-07T07:51:09Z"
-    },
-    {
-      "login": "echocde",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
-      "profileUrl": "https://github.com/echocde",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-06-10T13:16:26Z",
-      "latestContributionAt": "2026-06-25T04:51:02Z"
     },
     {
       "login": "jthanh8144",
@@ -778,6 +778,15 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-13T04:41:58Z"
+    },
+    {
       "login": "holmesin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
       "profileUrl": "https://github.com/holmesin",
@@ -805,6 +814,15 @@
       "latestContributionAt": "2026-06-17T13:16:31Z"
     },
     {
+      "login": "JcEvoX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/74612426?v=4",
+      "profileUrl": "https://github.com/JcEvoX",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-10T11:37:11Z",
+      "latestContributionAt": "2026-08-13T12:11:53Z"
+    },
+    {
       "login": "jing2uo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3081432?v=4",
       "profileUrl": "https://github.com/jing2uo",
@@ -821,6 +839,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-08T09:25:42Z",
       "latestContributionAt": "2026-06-09T03:59:49Z"
+    },
+    {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-13T18:25:25Z"
     },
     {
       "login": "lc6464",
@@ -956,6 +983,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
+    },
+    {
+      "login": "xzxlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
+      "profileUrl": "https://github.com/xzxlove",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-13T06:38:59Z",
+      "latestContributionAt": "2026-08-13T12:34:54Z"
     },
     {
       "login": "yangqinlong",
@@ -1120,6 +1156,15 @@
       "latestContributionAt": "2026-07-02T08:37:21Z"
     },
     {
+      "login": "Dhevenddra",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/121691114?v=4",
+      "profileUrl": "https://github.com/Dhevenddra",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-13T06:37:45Z",
+      "latestContributionAt": "2026-08-13T16:16:06Z"
+    },
+    {
       "login": "digyear",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160373682?v=4",
       "profileUrl": "https://github.com/digyear",
@@ -1201,6 +1246,15 @@
       "latestContributionAt": "2026-07-05T11:38:51Z"
     },
     {
+      "login": "fengyuwusong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
+      "profileUrl": "https://github.com/fengyuwusong",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-13T06:07:00Z",
+      "latestContributionAt": "2026-08-13T07:26:30Z"
+    },
+    {
       "login": "fuuulstack",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38742225?v=4",
       "profileUrl": "https://github.com/fuuulstack",
@@ -1226,15 +1280,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-01T08:54:31Z",
       "latestContributionAt": "2026-06-01T10:04:58Z"
-    },
-    {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-09T16:37:35Z"
     },
     {
       "login": "heyrmi",
@@ -1307,15 +1352,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T12:23:36Z",
       "latestContributionAt": "2026-07-24T13:11:18Z"
-    },
-    {
-      "login": "JcEvoX",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/74612426?v=4",
-      "profileUrl": "https://github.com/JcEvoX",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-10T11:37:11Z",
-      "latestContributionAt": "2026-08-10T15:38:10Z"
     },
     {
       "login": "JeaceLiu",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-20T18:30:31.659Z",
-  "stars": 16032,
+  "generatedAt": "2026-08-21T18:28:08.295Z",
+  "stars": 16188,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3119,
+      "commits": 3134,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 575,
-      "mergedPullRequests": 575,
+      "commits": 584,
+      "mergedPullRequests": 584,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-20T13:38:21Z"
+      "latestContributionAt": "2026-08-21T11:57:22Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 160,
-      "mergedPullRequests": 159,
+      "commits": 161,
+      "mergedPullRequests": 160,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-20T17:15:46Z"
+      "latestContributionAt": "2026-08-21T04:20:58Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 96,
-      "mergedPullRequests": 84,
+      "commits": 97,
+      "mergedPullRequests": 85,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-19T07:49:15Z"
+      "latestContributionAt": "2026-08-21T02:36:18Z"
     },
     {
       "login": "q396921921",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 60,
-      "mergedPullRequests": 60,
+      "commits": 61,
+      "mergedPullRequests": 61,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-20T10:25:12Z"
+      "latestContributionAt": "2026-08-21T10:19:48Z"
     },
     {
       "login": "serenez",
@@ -148,6 +148,15 @@
       "latestContributionAt": "2026-05-29T05:31:32Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 22,
+      "mergedPullRequests": 22,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-21T04:20:20Z"
+    },
+    {
       "login": "LwClick",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38545827?v=4",
       "profileUrl": "https://github.com/LwClick",
@@ -164,15 +173,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-09T08:33:11Z",
       "latestContributionAt": "2026-08-13T03:40:23Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 19,
-      "mergedPullRequests": 19,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-20T12:42:46Z"
     },
     {
       "login": "yavon007",
@@ -670,6 +670,15 @@
       "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
+      "login": "encyc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62669951?v=4",
+      "profileUrl": "https://github.com/encyc",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-29T06:54:05Z",
+      "latestContributionAt": "2026-08-21T10:38:54Z"
+    },
+    {
       "login": "fengyuwusong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
       "profileUrl": "https://github.com/fengyuwusong",
@@ -749,6 +758,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-18T10:01:35Z",
       "latestContributionAt": "2026-08-20T13:01:23Z"
+    },
+    {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-21T05:03:15Z"
     },
     {
       "login": "vergil-lai",
@@ -839,15 +857,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-10T08:32:55Z",
       "latestContributionAt": "2026-06-11T09:29:40Z"
-    },
-    {
-      "login": "encyc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62669951?v=4",
-      "profileUrl": "https://github.com/encyc",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-29T06:54:05Z",
-      "latestContributionAt": "2026-07-31T06:38:50Z"
     },
     {
       "login": "gadfly3173",
@@ -1001,15 +1010,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-13T10:58:52Z",
       "latestContributionAt": "2026-08-09T15:33:24Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-20T14:12:53Z"
     },
     {
       "login": "TangTangH",
@@ -1280,6 +1280,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T09:14:47Z",
       "latestContributionAt": "2026-07-08T10:53:49Z"
+    },
+    {
+      "login": "duminga",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/91080718?v=4",
+      "profileUrl": "https://github.com/duminga",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-20T17:21:17Z",
+      "latestContributionAt": "2026-08-21T04:21:38Z"
     },
     {
       "login": "easton-shi",
@@ -1703,6 +1712,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
+    },
+    {
+      "login": "tatuke",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46305821?v=4",
+      "profileUrl": "https://github.com/tatuke",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-21T08:02:23Z",
+      "latestContributionAt": "2026-08-21T10:12:40Z"
     },
     {
       "login": "Tssshhhh",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,34 +1,34 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-24T18:31:37.649Z",
-  "stars": 16418,
+  "generatedAt": "2026-08-25T18:31:47.394Z",
+  "stars": 16575,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3205,
-      "mergedPullRequests": 17,
+      "commits": 3245,
+      "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-18T04:05:42Z"
+      "latestContributionAt": "2026-08-25T16:07:31Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 606,
-      "mergedPullRequests": 606,
+      "commits": 615,
+      "mergedPullRequests": 615,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-24T16:10:23Z"
+      "latestContributionAt": "2026-08-25T16:27:28Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 170,
-      "mergedPullRequests": 169,
+      "commits": 172,
+      "mergedPullRequests": 171,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-24T12:36:58Z"
+      "latestContributionAt": "2026-08-25T14:00:26Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,19 +43,19 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 90,
-      "mergedPullRequests": 90,
+      "commits": 91,
+      "mergedPullRequests": 91,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-24T10:34:50Z"
+      "latestContributionAt": "2026-08-25T14:36:40Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 70,
-      "mergedPullRequests": 70,
+      "commits": 72,
+      "mergedPullRequests": 72,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-24T12:31:36Z"
+      "latestContributionAt": "2026-08-25T15:57:02Z"
     },
     {
       "login": "onenewcode",
@@ -94,22 +94,22 @@
       "latestContributionAt": "2026-05-12T09:22:36Z"
     },
     {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 35,
-      "mergedPullRequests": 35,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-24T05:31:48Z"
-    },
-    {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 34,
-      "mergedPullRequests": 34,
+      "commits": 36,
+      "mergedPullRequests": 36,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-24T12:28:25Z"
+      "latestContributionAt": "2026-08-25T14:51:27Z"
+    },
+    {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 36,
+      "mergedPullRequests": 36,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-25T07:15:42Z"
     },
     {
       "login": "xddcode",
@@ -490,6 +490,15 @@
       "latestContributionAt": "2026-08-18T15:17:24Z"
     },
     {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-25T06:46:25Z"
+    },
+    {
       "login": "sxhjlzl",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
       "profileUrl": "https://github.com/sxhjlzl",
@@ -578,15 +587,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-08-13T05:20:22Z",
       "latestContributionAt": "2026-08-19T18:26:56Z"
-    },
-    {
-      "login": "lizzzzz777",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
-      "profileUrl": "https://github.com/lizzzzz777",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-14T01:26:28Z",
-      "latestContributionAt": "2026-08-24T05:08:37Z"
     },
     {
       "login": "soddygo",
@@ -731,6 +731,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
+    },
+    {
+      "login": "klinge1011",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
+      "profileUrl": "https://github.com/klinge1011",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-21T12:23:37Z",
+      "latestContributionAt": "2026-08-25T14:35:40Z"
     },
     {
       "login": "lazyanubis",
@@ -949,15 +958,6 @@
       "latestContributionAt": "2026-08-15T06:41:17Z"
     },
     {
-      "login": "klinge1011",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
-      "profileUrl": "https://github.com/klinge1011",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-21T12:23:37Z",
-      "latestContributionAt": "2026-08-24T07:10:10Z"
-    },
-    {
       "login": "lc6464",
       "avatarUrl": "https://avatars.githubusercontent.com/u/64722907?v=4",
       "profileUrl": "https://github.com/lc6464",
@@ -992,6 +992,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-09T10:09:16Z",
       "latestContributionAt": "2026-07-10T05:27:11Z"
+    },
+    {
+      "login": "ordinary-s",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
+      "profileUrl": "https://github.com/ordinary-s",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-18T11:36:48Z",
+      "latestContributionAt": "2026-08-25T13:26:00Z"
     },
     {
       "login": "rainhan99",
@@ -1363,6 +1372,15 @@
       "latestContributionAt": "2026-08-03T07:50:44Z"
     },
     {
+      "login": "gaoruiqiang2017",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26794805?v=4",
+      "profileUrl": "https://github.com/gaoruiqiang2017",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-25T11:28:46Z",
+      "latestContributionAt": "2026-08-25T14:15:41Z"
+    },
+    {
       "login": "gdzhu8023",
       "avatarUrl": "https://avatars.githubusercontent.com/u/21006156?v=4",
       "profileUrl": "https://github.com/gdzhu8023",
@@ -1597,15 +1615,6 @@
       "latestContributionAt": "2026-08-16T03:21:22Z"
     },
     {
-      "login": "octo-patch",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/266937838?v=4",
-      "profileUrl": "https://github.com/octo-patch",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-30T10:58:25Z",
-      "latestContributionAt": "2026-07-30T15:05:13Z"
-    },
-    {
       "login": "OctoBored",
       "avatarUrl": "https://avatars.githubusercontent.com/u/212877535?v=4",
       "profileUrl": "https://github.com/OctoBored",
@@ -1813,6 +1822,15 @@
       "latestContributionAt": "2026-08-18T04:47:53Z"
     },
     {
+      "login": "wzlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/35476126?v=4",
+      "profileUrl": "https://github.com/wzlove",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-25T11:23:05Z",
+      "latestContributionAt": "2026-08-25T14:34:04Z"
+    },
+    {
       "login": "xcstatus",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40375067?v=4",
       "profileUrl": "https://github.com/xcstatus",
@@ -1973,6 +1991,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
+    },
+    {
+      "login": "octo-patch",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/266937838?v=4",
+      "profileUrl": "https://github.com/octo-patch",
+      "commits": 0,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-30T10:58:25Z",
+      "latestContributionAt": "2026-07-30T15:05:13Z"
     }
   ]
 }

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-06T23:53:35.775Z",
-  "stars": 13507,
+  "generatedAt": "2026-08-07T18:46:06.990Z",
+  "stars": 13631,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2828,
+      "commits": 2845,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 467,
-      "mergedPullRequests": 467,
+      "commits": 472,
+      "mergedPullRequests": 472,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-06T18:40:50Z"
+      "latestContributionAt": "2026-08-07T09:06:19Z"
     },
     {
       "login": "eryajf",
@@ -34,10 +34,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 81,
-      "mergedPullRequests": 69,
+      "commits": 82,
+      "mergedPullRequests": 70,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-06T18:56:27Z"
+      "latestContributionAt": "2026-08-07T05:43:42Z"
     },
     {
       "login": "serenez",
@@ -52,19 +52,19 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 54,
-      "mergedPullRequests": 54,
+      "commits": 55,
+      "mergedPullRequests": 55,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-06T19:24:25Z"
+      "latestContributionAt": "2026-08-07T09:06:04Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 49,
-      "mergedPullRequests": 49,
+      "commits": 50,
+      "mergedPullRequests": 50,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-06T09:09:15Z"
+      "latestContributionAt": "2026-08-07T07:31:45Z"
     },
     {
       "login": "Illuminated2020",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-08-07T07:57:46Z"
+    },
+    {
       "login": "gggaiitx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
       "profileUrl": "https://github.com/gggaiitx",
@@ -101,15 +110,6 @@
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-07-06T09:30:53Z",
       "latestContributionAt": "2026-07-28T14:39:11Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 27,
-      "mergedPullRequests": 27,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-08-04T18:03:10Z"
     },
     {
       "login": "SuLea-IT",
@@ -139,6 +139,15 @@
       "latestContributionAt": "2026-07-16T17:17:49Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 21,
+      "mergedPullRequests": 21,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-07T09:05:48Z"
+    },
+    {
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
@@ -146,15 +155,6 @@
       "mergedPullRequests": 20,
       "firstContributionAt": "2026-06-09T08:33:11Z",
       "latestContributionAt": "2026-08-06T08:30:20Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 19,
-      "mergedPullRequests": 19,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-06T19:30:52Z"
     },
     {
       "login": "yavon007",
@@ -364,6 +364,15 @@
       "latestContributionAt": "2026-07-16T09:01:10Z"
     },
     {
+      "login": "ChunMengLu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
+      "profileUrl": "https://github.com/ChunMengLu",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-24T07:06:09Z",
+      "latestContributionAt": "2026-08-07T05:43:30Z"
+    },
+    {
       "login": "fraluc06",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67560467?v=4",
       "profileUrl": "https://github.com/fraluc06",
@@ -382,6 +391,15 @@
       "latestContributionAt": "2026-08-02T08:34:50Z"
     },
     {
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-08-07T07:32:16Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -398,15 +416,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-06T11:21:25Z",
       "latestContributionAt": "2026-06-29T03:16:38Z"
-    },
-    {
-      "login": "ChunMengLu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
-      "profileUrl": "https://github.com/ChunMengLu",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-24T07:06:09Z",
-      "latestContributionAt": "2026-08-06T16:13:34Z"
     },
     {
       "login": "CSXFanMeng",
@@ -434,15 +443,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-07-07T10:09:02Z"
     },
     {
       "login": "possebon",
@@ -517,6 +517,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-07T07:51:09Z"
+    },
+    {
       "login": "echocde",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
       "profileUrl": "https://github.com/echocde",
@@ -524,6 +533,24 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-06-25T04:51:02Z"
+    },
+    {
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-05T09:25:09Z",
+      "latestContributionAt": "2026-08-07T07:40:13Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-07T05:43:09Z"
     },
     {
       "login": "jthanh8144",
@@ -542,6 +569,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
+    },
+    {
+      "login": "lazyanubis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
+      "profileUrl": "https://github.com/lazyanubis",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-12T06:57:24Z",
+      "latestContributionAt": "2026-08-07T05:45:00Z"
     },
     {
       "login": "polemp",
@@ -634,15 +670,6 @@
       "latestContributionAt": "2026-07-31T08:24:13Z"
     },
     {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-03T07:08:09Z"
-    },
-    {
       "login": "Doracoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9206272?v=4",
       "profileUrl": "https://github.com/Doracoin",
@@ -733,15 +760,6 @@
       "latestContributionAt": "2026-07-13T09:03:34Z"
     },
     {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-06T15:15:17Z"
-    },
-    {
       "login": "JinRudy",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28995387?v=4",
       "profileUrl": "https://github.com/JinRudy",
@@ -749,15 +767,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-08T09:25:42Z",
       "latestContributionAt": "2026-06-09T03:59:49Z"
-    },
-    {
-      "login": "lazyanubis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
-      "profileUrl": "https://github.com/lazyanubis",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-12T06:57:24Z",
-      "latestContributionAt": "2026-08-05T07:29:34Z"
     },
     {
       "login": "lc6464",
@@ -1093,6 +1102,15 @@
       "latestContributionAt": "2026-07-08T10:53:49Z"
     },
     {
+      "login": "ededddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43884159?v=4",
+      "profileUrl": "https://github.com/ededddy",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T01:12:45Z",
+      "latestContributionAt": "2026-08-07T07:18:32Z"
+    },
+    {
       "login": "ekesaiting",
       "avatarUrl": "https://avatars.githubusercontent.com/u/36790768?v=4",
       "profileUrl": "https://github.com/ekesaiting",
@@ -1172,15 +1190,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T09:27:49Z",
       "latestContributionAt": "2026-07-06T10:21:15Z"
-    },
-    {
-      "login": "HighBigSky",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
-      "profileUrl": "https://github.com/HighBigSky",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-06T06:25:31Z",
-      "latestContributionAt": "2026-08-06T08:29:27Z"
     },
     {
       "login": "huangyemin",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-02T18:21:44.205Z",
-  "stars": 12970,
+  "generatedAt": "2026-08-03T19:23:42.232Z",
+  "stars": 13084,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2750,
+      "commits": 2776,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 433,
-      "mergedPullRequests": 433,
+      "commits": 441,
+      "mergedPullRequests": 441,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-02T11:09:23Z"
+      "latestContributionAt": "2026-08-03T16:37:43Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 120,
-      "mergedPullRequests": 119,
+      "commits": 122,
+      "mergedPullRequests": 121,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-02T08:34:14Z"
+      "latestContributionAt": "2026-08-03T16:46:13Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 76,
-      "mergedPullRequests": 64,
+      "commits": 77,
+      "mergedPullRequests": 65,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-02T14:46:13Z"
+      "latestContributionAt": "2026-08-03T12:59:40Z"
     },
     {
       "login": "serenez",
@@ -175,6 +175,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-03T12:25:01Z"
+    },
+    {
       "login": "juvevood",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1421513?v=4",
       "profileUrl": "https://github.com/juvevood",
@@ -182,15 +191,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-02T01:02:01Z"
     },
     {
       "login": "SpencerZhang",
@@ -283,6 +283,15 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-03T08:58:21Z"
+    },
+    {
       "login": "tianyifeng-druid",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
       "profileUrl": "https://github.com/tianyifeng-druid",
@@ -301,15 +310,6 @@
       "latestContributionAt": "2026-05-11T14:10:01Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-07-30T17:57:40Z"
-    },
-    {
       "login": "dbin0123",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18297300?v=4",
       "profileUrl": "https://github.com/dbin0123",
@@ -326,6 +326,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-17T05:09:05Z",
       "latestContributionAt": "2026-07-01T11:05:45Z"
+    },
+    {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-03T06:34:07Z"
     },
     {
       "login": "ZionLin2016",
@@ -364,15 +373,6 @@
       "latestContributionAt": "2026-08-02T08:34:50Z"
     },
     {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-07-29T12:33:34Z"
-    },
-    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -380,6 +380,15 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
+    },
+    {
+      "login": "aiLi0617",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
+      "profileUrl": "https://github.com/aiLi0617",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-06-19T14:50:55Z",
+      "latestContributionAt": "2026-08-03T17:38:30Z"
     },
     {
       "login": "Caisin",
@@ -454,6 +463,15 @@
       "latestContributionAt": "2026-07-12T13:30:37Z"
     },
     {
+      "login": "zhuhaoh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/88836213?v=4",
+      "profileUrl": "https://github.com/zhuhaoh",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-06T10:48:19Z",
+      "latestContributionAt": "2026-08-03T08:59:34Z"
+    },
+    {
       "login": "zorohu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24402746?v=4",
       "profileUrl": "https://github.com/zorohu",
@@ -470,15 +488,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
-    },
-    {
-      "login": "aiLi0617",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
-      "profileUrl": "https://github.com/aiLi0617",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-06-19T14:50:55Z",
-      "latestContributionAt": "2026-07-27T15:52:40Z"
     },
     {
       "login": "ChunMengLu",
@@ -553,15 +562,6 @@
       "latestContributionAt": "2026-04-30T09:48:13Z"
     },
     {
-      "login": "zhuhaoh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/88836213?v=4",
-      "profileUrl": "https://github.com/zhuhaoh",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-06T10:48:19Z",
-      "latestContributionAt": "2026-07-08T16:45:29Z"
-    },
-    {
       "login": "Michaelxwb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34806714?v=4",
       "profileUrl": "https://github.com/Michaelxwb",
@@ -616,6 +616,15 @@
       "latestContributionAt": "2026-07-31T08:24:13Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-03T07:08:09Z"
+    },
+    {
       "login": "Doracoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9206272?v=4",
       "profileUrl": "https://github.com/Doracoin",
@@ -668,6 +677,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-13T23:36:43Z",
       "latestContributionAt": "2026-07-26T16:37:41Z"
+    },
+    {
+      "login": "ijevin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
+      "profileUrl": "https://github.com/ijevin",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-30T05:45:30Z",
+      "latestContributionAt": "2026-08-03T08:58:47Z"
     },
     {
       "login": "IT-SDJ",
@@ -731,6 +749,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-09T10:09:16Z",
       "latestContributionAt": "2026-07-10T05:27:11Z"
+    },
+    {
+      "login": "possebon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
+      "profileUrl": "https://github.com/possebon",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-02T17:09:52Z",
+      "latestContributionAt": "2026-08-02T19:42:40Z"
     },
     {
       "login": "rainhan99",
@@ -868,6 +895,15 @@
       "latestContributionAt": "2026-06-06T01:15:09Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-03T13:29:24Z"
+    },
+    {
       "login": "athoune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/74048?v=4",
       "profileUrl": "https://github.com/athoune",
@@ -922,6 +958,15 @@
       "latestContributionAt": "2026-05-10T12:53:40Z"
     },
     {
+      "login": "CGerAJ",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20548301?v=4",
+      "profileUrl": "https://github.com/CGerAJ",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-01T10:52:08Z",
+      "latestContributionAt": "2026-08-03T08:05:57Z"
+    },
+    {
       "login": "chrstphe",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10966918?v=4",
       "profileUrl": "https://github.com/chrstphe",
@@ -965,15 +1010,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-02T07:45:55Z",
       "latestContributionAt": "2026-07-02T08:37:21Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-07-31T06:55:23Z"
     },
     {
       "login": "digyear",
@@ -1039,6 +1075,15 @@
       "latestContributionAt": "2026-07-05T11:38:51Z"
     },
     {
+      "login": "fuuulstack",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38742225?v=4",
+      "profileUrl": "https://github.com/fuuulstack",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-23T06:23:37Z",
+      "latestContributionAt": "2026-08-03T07:50:44Z"
+    },
+    {
       "login": "gdzhu8023",
       "avatarUrl": "https://avatars.githubusercontent.com/u/21006156?v=4",
       "profileUrl": "https://github.com/gdzhu8023",
@@ -1075,6 +1120,15 @@
       "latestContributionAt": "2026-07-06T10:21:15Z"
     },
     {
+      "login": "holmesin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
+      "profileUrl": "https://github.com/holmesin",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-03T12:29:55Z",
+      "latestContributionAt": "2026-08-03T16:46:28Z"
+    },
+    {
       "login": "huangyemin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11872262?v=4",
       "profileUrl": "https://github.com/huangyemin",
@@ -1109,15 +1163,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-16T10:33:05Z",
       "latestContributionAt": "2026-06-16T10:52:02Z"
-    },
-    {
-      "login": "ijevin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
-      "profileUrl": "https://github.com/ijevin",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-30T05:45:30Z",
-      "latestContributionAt": "2026-07-30T09:16:39Z"
     },
     {
       "login": "imhyuk-huno",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-30T20:24:13.247Z",
-  "stars": 17473,
+  "generatedAt": "2026-08-31T22:17:45.069Z",
+  "stars": 17575,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3310,
+      "commits": 3322,
       "mergedPullRequests": 23,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-30T05:30:01Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 644,
-      "mergedPullRequests": 644,
+      "commits": 658,
+      "mergedPullRequests": 658,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-29T19:05:11Z"
+      "latestContributionAt": "2026-08-31T17:59:02Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 191,
-      "mergedPullRequests": 190,
+      "commits": 198,
+      "mergedPullRequests": 197,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-30T04:26:07Z"
+      "latestContributionAt": "2026-08-31T17:17:23Z"
     },
     {
       "login": "q396921921",
@@ -52,19 +52,28 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 74,
-      "mergedPullRequests": 74,
+      "commits": 77,
+      "mergedPullRequests": 77,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-28T08:51:34Z"
+      "latestContributionAt": "2026-08-31T15:49:01Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 66,
-      "mergedPullRequests": 66,
+      "commits": 69,
+      "mergedPullRequests": 69,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-27T02:55:20Z"
+      "latestContributionAt": "2026-08-31T17:18:00Z"
+    },
+    {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 59,
+      "mergedPullRequests": 59,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-31T18:12:56Z"
     },
     {
       "login": "serenez",
@@ -74,15 +83,6 @@
       "mergedPullRequests": 55,
       "firstContributionAt": "2026-04-30T04:27:54Z",
       "latestContributionAt": "2026-07-20T15:31:27Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 47,
-      "mergedPullRequests": 47,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-29T16:47:45Z"
     },
     {
       "login": "onceMisery",
@@ -106,10 +106,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 36,
-      "mergedPullRequests": 36,
+      "commits": 39,
+      "mergedPullRequests": 39,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-25T07:15:42Z"
+      "latestContributionAt": "2026-08-31T16:34:12Z"
     },
     {
       "login": "xddcode",
@@ -211,6 +211,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-31T07:57:16Z"
+    },
+    {
       "login": "AndrewDi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
       "profileUrl": "https://github.com/AndrewDi",
@@ -227,15 +236,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-28T03:11:35Z"
     },
     {
       "login": "DASungta",
@@ -391,6 +391,15 @@
       "latestContributionAt": "2026-08-13T11:25:08Z"
     },
     {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-31T17:19:47Z"
+    },
+    {
       "login": "xKrah",
       "avatarUrl": "https://avatars.githubusercontent.com/u/23560682?v=4",
       "profileUrl": "https://github.com/xKrah",
@@ -454,13 +463,13 @@
       "latestContributionAt": "2026-08-26T05:52:42Z"
     },
     {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
+      "login": "xiaou61",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
+      "profileUrl": "https://github.com/xiaou61",
       "commits": 6,
       "mergedPullRequests": 6,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-29T17:34:00Z"
+      "firstContributionAt": "2026-08-14T09:19:51Z",
+      "latestContributionAt": "2026-08-31T14:29:16Z"
     },
     {
       "login": "ZionLin2016",
@@ -598,6 +607,15 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-08-31T16:22:03Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -623,15 +641,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-05T16:45:23Z",
       "latestContributionAt": "2026-07-12T13:30:37Z"
-    },
-    {
-      "login": "xiaou61",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
-      "profileUrl": "https://github.com/xiaou61",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-14T09:19:51Z",
-      "latestContributionAt": "2026-08-28T04:36:37Z"
     },
     {
       "login": "xzxlove",
@@ -758,15 +767,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
-    },
-    {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-08-28T06:27:56Z"
     },
     {
       "login": "ordinary-s",
@@ -1192,6 +1192,15 @@
       "latestContributionAt": "2026-06-06T01:15:09Z"
     },
     {
+      "login": "andystenhe",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16678274?v=4",
+      "profileUrl": "https://github.com/andystenhe",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T04:15:28Z",
+      "latestContributionAt": "2026-08-31T14:55:42Z"
+    },
+    {
       "login": "athoune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/74048?v=4",
       "profileUrl": "https://github.com/athoune",
@@ -1444,6 +1453,15 @@
       "latestContributionAt": "2026-07-03T16:58:52Z"
     },
     {
+      "login": "guoziyangnb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/136451743?v=4",
+      "profileUrl": "https://github.com/guoziyangnb",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T12:46:35Z",
+      "latestContributionAt": "2026-08-31T15:46:03Z"
+    },
+    {
       "login": "Hank076",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3490170?v=4",
       "profileUrl": "https://github.com/Hank076",
@@ -1469,6 +1487,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-27T12:10:39Z",
       "latestContributionAt": "2026-07-28T18:40:46Z"
+    },
+    {
+      "login": "hhktony",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1276702?v=4",
+      "profileUrl": "https://github.com/hhktony",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-30T07:26:17Z",
+      "latestContributionAt": "2026-08-31T17:19:12Z"
     },
     {
       "login": "hieptuanle",
@@ -1867,6 +1894,15 @@
       "latestContributionAt": "2026-06-19T16:13:09Z"
     },
     {
+      "login": "wangfengxiang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31534139?v=4",
+      "profileUrl": "https://github.com/wangfengxiang",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T09:52:03Z",
+      "latestContributionAt": "2026-08-31T16:21:10Z"
+    },
+    {
       "login": "wfion",
       "avatarUrl": "https://avatars.githubusercontent.com/u/85852251?v=4",
       "profileUrl": "https://github.com/wfion",
@@ -1892,6 +1928,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wojiukankan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32760220?v=4",
+      "profileUrl": "https://github.com/wojiukankan",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T11:36:26Z",
+      "latestContributionAt": "2026-08-31T16:19:59Z"
     },
     {
       "login": "wu-zhao-min",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-03T19:23:42.232Z",
-  "stars": 13084,
+  "generatedAt": "2026-08-04T19:23:43.773Z",
+  "stars": 13194,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2776,
+      "commits": 2794,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 441,
-      "mergedPullRequests": 441,
+      "commits": 444,
+      "mergedPullRequests": 444,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-03T16:37:43Z"
+      "latestContributionAt": "2026-08-04T17:10:58Z"
     },
     {
       "login": "eryajf",
@@ -35,9 +35,9 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
       "commits": 77,
-      "mergedPullRequests": 65,
+      "mergedPullRequests": 66,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-03T12:59:40Z"
+      "latestContributionAt": "2026-08-04T18:59:52Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 44,
-      "mergedPullRequests": 44,
+      "commits": 46,
+      "mergedPullRequests": 46,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-02T14:45:33Z"
+      "latestContributionAt": "2026-08-04T17:02:21Z"
     },
     {
       "login": "Illuminated2020",
@@ -103,6 +103,15 @@
       "latestContributionAt": "2026-07-28T14:39:11Z"
     },
     {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 27,
+      "mergedPullRequests": 27,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-08-04T18:03:10Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-04-30T05:56:34Z",
       "latestContributionAt": "2026-07-10T10:15:25Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 25,
-      "mergedPullRequests": 25,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-07-31T08:27:06Z"
     },
     {
       "login": "rarnu",
@@ -247,6 +247,24 @@
       "latestContributionAt": "2026-08-02T01:04:30Z"
     },
     {
+      "login": "dienaso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
+      "profileUrl": "https://github.com/dienaso",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-24T03:23:39Z",
+      "latestContributionAt": "2026-08-04T05:02:31Z"
+    },
+    {
+      "login": "guoyongchang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
+      "profileUrl": "https://github.com/guoyongchang",
+      "commits": 8,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-07-30T02:45:51Z",
+      "latestContributionAt": "2026-08-04T18:59:20Z"
+    },
+    {
       "login": "amwps290",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
       "profileUrl": "https://github.com/amwps290",
@@ -254,24 +272,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-07-21T05:32:24Z",
       "latestContributionAt": "2026-07-31T14:31:51Z"
-    },
-    {
-      "login": "dienaso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
-      "profileUrl": "https://github.com/dienaso",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-07-30T13:10:20Z"
-    },
-    {
-      "login": "guoyongchang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
-      "profileUrl": "https://github.com/guoyongchang",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-30T02:45:51Z",
-      "latestContributionAt": "2026-07-31T13:22:32Z"
     },
     {
       "login": "czs208112",
@@ -769,6 +769,15 @@
       "latestContributionAt": "2026-07-13T09:51:52Z"
     },
     {
+      "login": "rihkddd",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
+      "profileUrl": "https://github.com/rihkddd",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-30T13:25:21Z",
+      "latestContributionAt": "2026-08-04T17:09:59Z"
+    },
+    {
       "login": "Sanjeever",
       "avatarUrl": "https://avatars.githubusercontent.com/u/78210374?v=4",
       "profileUrl": "https://github.com/Sanjeever",
@@ -1192,6 +1201,24 @@
       "latestContributionAt": "2026-07-17T08:32:50Z"
     },
     {
+      "login": "jean3690",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188204999?v=4",
+      "profileUrl": "https://github.com/jean3690",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T02:43:43Z",
+      "latestContributionAt": "2026-08-04T05:01:50Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-04T11:05:05Z"
+    },
+    {
       "login": "kcheng007",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3156606?v=4",
       "profileUrl": "https://github.com/kcheng007",
@@ -1345,13 +1372,13 @@
       "latestContributionAt": "2026-06-07T18:07:00Z"
     },
     {
-      "login": "rihkddd",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
-      "profileUrl": "https://github.com/rihkddd",
+      "login": "Rson9",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/118523711?v=4",
+      "profileUrl": "https://github.com/Rson9",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-30T13:25:21Z",
-      "latestContributionAt": "2026-07-30T19:09:19Z"
+      "firstContributionAt": "2026-08-03T06:58:44Z",
+      "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
       "login": "shenmo7192",
@@ -1577,6 +1604,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
+    },
+    {
+      "login": "TangTangH",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
+      "profileUrl": "https://github.com/TangTangH",
+      "commits": 0,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T04:55:17Z",
+      "latestContributionAt": "2026-08-04T18:59:34Z"
     }
   ]
 }

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-11T18:54:53.020Z",
-  "stars": 14124,
+  "generatedAt": "2026-08-12T18:54:53.390Z",
+  "stars": 14288,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2914,
+      "commits": 2960,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 506,
-      "mergedPullRequests": 506,
+      "commits": 513,
+      "mergedPullRequests": 513,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-11T16:12:03Z"
+      "latestContributionAt": "2026-08-12T18:10:52Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 143,
-      "mergedPullRequests": 142,
+      "commits": 145,
+      "mergedPullRequests": 144,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-11T18:20:06Z"
+      "latestContributionAt": "2026-08-12T18:10:38Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 88,
-      "mergedPullRequests": 76,
+      "commits": 89,
+      "mergedPullRequests": 77,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-11T16:19:58Z"
+      "latestContributionAt": "2026-08-12T11:34:01Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 59,
-      "mergedPullRequests": 59,
+      "commits": 62,
+      "mergedPullRequests": 62,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-11T16:09:02Z"
+      "latestContributionAt": "2026-08-12T13:05:14Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 54,
-      "mergedPullRequests": 54,
+      "commits": 55,
+      "mergedPullRequests": 55,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-11T16:41:31Z"
+      "latestContributionAt": "2026-08-12T04:36:14Z"
     },
     {
       "login": "onceMisery",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-12T10:24:01Z"
+    },
+    {
       "login": "xddcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
       "profileUrl": "https://github.com/xddcode",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-07-06T09:30:53Z",
       "latestContributionAt": "2026-07-28T14:39:11Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 26,
-      "mergedPullRequests": 26,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-11T13:34:50Z"
     },
     {
       "login": "SuLea-IT",
@@ -274,6 +274,15 @@
       "latestContributionAt": "2026-08-04T05:02:31Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-12T18:12:10Z"
+    },
+    {
       "login": "aiLi0617",
       "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
       "profileUrl": "https://github.com/aiLi0617",
@@ -281,6 +290,15 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
+    },
+    {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-12T04:37:01Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -301,6 +319,15 @@
       "latestContributionAt": "2026-08-11T13:33:16Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-12T12:42:45Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -310,13 +337,13 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
       "commits": 7,
       "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-03T08:58:21Z"
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-12T05:35:03Z"
     },
     {
       "login": "xKrah",
@@ -337,13 +364,22 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
       "commits": 6,
       "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-08T02:40:34Z"
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-08-12T14:22:34Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-12T12:15:58Z"
     },
     {
       "login": "luoianun",
@@ -371,15 +407,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-11T18:05:55Z"
     },
     {
       "login": "antwa",
@@ -416,24 +443,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-08-05T09:25:09Z",
       "latestContributionAt": "2026-08-10T10:51:45Z"
-    },
-    {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-08-07T07:32:16Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-09T17:11:26Z"
     },
     {
       "login": "ZhonFortune",
@@ -641,6 +650,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
       "login": "Michaelxwb",
@@ -1462,15 +1480,6 @@
       "latestContributionAt": "2026-06-27T13:44:36Z"
     },
     {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-07-20T16:10:42Z"
-    },
-    {
       "login": "Quinlevi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24589232?v=4",
       "profileUrl": "https://github.com/Quinlevi",
@@ -1606,15 +1615,6 @@
       "latestContributionAt": "2026-07-06T04:57:27Z"
     },
     {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-10T10:22:17Z"
-    },
-    {
       "login": "xcstatus",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40375067?v=4",
       "profileUrl": "https://github.com/xcstatus",
@@ -1730,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-22T13:57:59Z",
       "latestContributionAt": "2026-07-22T14:20:42Z"
+    },
+    {
+      "login": "zhwq1216",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9948390?v=4",
+      "profileUrl": "https://github.com/zhwq1216",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T05:21:37Z",
+      "latestContributionAt": "2026-08-12T03:51:32Z"
     },
     {
       "login": "zouchao",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-23T18:20:19.981Z",
-  "stars": 16310,
+  "generatedAt": "2026-08-24T18:31:37.649Z",
+  "stars": 16418,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3178,
+      "commits": 3205,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,55 +16,55 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 590,
-      "mergedPullRequests": 590,
+      "commits": 606,
+      "mergedPullRequests": 606,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-22T17:39:23Z"
+      "latestContributionAt": "2026-08-24T16:10:23Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 166,
-      "mergedPullRequests": 165,
+      "commits": 170,
+      "mergedPullRequests": 169,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-22T18:53:52Z"
+      "latestContributionAt": "2026-08-24T12:36:58Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 97,
-      "mergedPullRequests": 85,
+      "commits": 98,
+      "mergedPullRequests": 86,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-21T02:36:18Z"
+      "latestContributionAt": "2026-08-24T12:28:13Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 88,
-      "mergedPullRequests": 88,
+      "commits": 90,
+      "mergedPullRequests": 90,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-23T04:25:45Z"
+      "latestContributionAt": "2026-08-24T10:34:50Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 68,
-      "mergedPullRequests": 68,
+      "commits": 70,
+      "mergedPullRequests": 70,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-22T07:41:21Z"
+      "latestContributionAt": "2026-08-24T12:31:36Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 62,
-      "mergedPullRequests": 62,
+      "commits": 64,
+      "mergedPullRequests": 64,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-22T04:58:28Z"
+      "latestContributionAt": "2026-08-24T12:32:20Z"
     },
     {
       "login": "serenez",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 45,
-      "mergedPullRequests": 43,
+      "commits": 46,
+      "mergedPullRequests": 44,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-23T04:23:46Z"
+      "latestContributionAt": "2026-08-24T10:35:18Z"
     },
     {
       "login": "Illuminated2020",
@@ -97,10 +97,19 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
+      "commits": 35,
+      "mergedPullRequests": 35,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-24T05:31:48Z"
+    },
+    {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
       "commits": 34,
       "mergedPullRequests": 34,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-20T07:14:20Z"
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-24T12:28:25Z"
     },
     {
       "login": "xddcode",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-07-10T06:34:09Z",
       "latestContributionAt": "2026-08-20T02:23:08Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 29,
-      "mergedPullRequests": 29,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-23T10:08:18Z"
     },
     {
       "login": "gggaiitx",
@@ -229,6 +229,15 @@
       "latestContributionAt": "2026-08-20T08:04:22Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-24T05:29:24Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-17T03:22:35Z",
       "latestContributionAt": "2026-07-20T08:54:52Z"
-    },
-    {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 12,
-      "mergedPullRequests": 12,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-23T04:24:47Z"
     },
     {
       "login": "mr-dadong",
@@ -263,6 +263,15 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-18T04:43:31Z"
+    },
+    {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-24T10:58:15Z"
     },
     {
       "login": "guoyongchang",
@@ -317,15 +326,6 @@
       "mergedPullRequests": 10,
       "firstContributionAt": "2026-06-16T09:58:42Z",
       "latestContributionAt": "2026-07-02T06:03:20Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-19T12:23:17Z"
     },
     {
       "login": "aiLi0617",
@@ -490,6 +490,15 @@
       "latestContributionAt": "2026-08-18T15:17:24Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-24T05:26:09Z"
+    },
+    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -571,6 +580,15 @@
       "latestContributionAt": "2026-08-19T18:26:56Z"
     },
     {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-24T05:08:37Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -587,15 +605,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-22T04:43:40Z",
       "latestContributionAt": "2026-07-31T05:54:26Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-22T17:40:51Z"
     },
     {
       "login": "wuxiemian",
@@ -731,15 +740,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
-    },
-    {
-      "login": "lizzzzz777",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
-      "profileUrl": "https://github.com/lizzzzz777",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-14T01:26:28Z",
-      "latestContributionAt": "2026-08-18T02:51:50Z"
     },
     {
       "login": "polemp",
@@ -947,6 +947,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-05-02T02:18:47Z",
       "latestContributionAt": "2026-08-15T06:41:17Z"
+    },
+    {
+      "login": "klinge1011",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
+      "profileUrl": "https://github.com/klinge1011",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-21T12:23:37Z",
+      "latestContributionAt": "2026-08-24T07:10:10Z"
     },
     {
       "login": "lc6464",
@@ -1469,15 +1478,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-23T09:40:04Z",
       "latestContributionAt": "2026-07-28T17:29:20Z"
-    },
-    {
-      "login": "klinge1011",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
-      "profileUrl": "https://github.com/klinge1011",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-21T12:23:37Z",
-      "latestContributionAt": "2026-08-22T07:41:17Z"
     },
     {
       "login": "koco-co",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-22T18:20:43.168Z",
-  "stars": 16247,
+  "generatedAt": "2026-08-23T18:20:19.981Z",
+  "stars": 16310,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3161,
+      "commits": 3178,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,7 +16,7 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 588,
+      "commits": 590,
       "mergedPullRequests": 590,
       "firstContributionAt": "2026-06-22T06:10:59Z",
       "latestContributionAt": "2026-08-22T17:39:23Z"
@@ -25,10 +25,10 @@
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 163,
-      "mergedPullRequests": 163,
+      "commits": 166,
+      "mergedPullRequests": 165,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-22T17:40:22Z"
+      "latestContributionAt": "2026-08-22T18:53:52Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,10 +43,10 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 87,
-      "mergedPullRequests": 87,
+      "commits": 88,
+      "mergedPullRequests": 88,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-22T04:52:54Z"
+      "latestContributionAt": "2026-08-23T04:25:45Z"
     },
     {
       "login": "CN-Scars",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 44,
-      "mergedPullRequests": 42,
+      "commits": 45,
+      "mergedPullRequests": 43,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-22T07:41:14Z"
+      "latestContributionAt": "2026-08-23T04:23:46Z"
     },
     {
       "login": "Illuminated2020",
@@ -112,6 +112,15 @@
       "latestContributionAt": "2026-08-20T02:23:08Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 29,
+      "mergedPullRequests": 29,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-23T10:08:18Z"
+    },
+    {
       "login": "gggaiitx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
       "profileUrl": "https://github.com/gggaiitx",
@@ -128,15 +137,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 26,
-      "mergedPullRequests": 28,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-22T17:39:54Z"
     },
     {
       "login": "SuLea-IT",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 12,
+      "mergedPullRequests": 12,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-23T04:24:47Z"
+    },
+    {
       "login": "mr-dadong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
       "profileUrl": "https://github.com/mr-dadong",
@@ -245,15 +254,6 @@
       "mergedPullRequests": 12,
       "firstContributionAt": "2026-08-17T07:04:42Z",
       "latestContributionAt": "2026-08-20T14:11:49Z"
-    },
-    {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-13T07:26:45Z"
     },
     {
       "login": "dienaso",
@@ -589,6 +589,15 @@
       "latestContributionAt": "2026-07-31T05:54:26Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-22T17:40:51Z"
+    },
+    {
       "login": "wuxiemian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29685283?v=4",
       "profileUrl": "https://github.com/wuxiemian",
@@ -641,15 +650,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 3,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-22T17:40:51Z"
     },
     {
       "login": "BabyLy233",
@@ -1856,6 +1856,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-17T03:34:26Z",
       "latestContributionAt": "2026-08-17T06:57:27Z"
+    },
+    {
+      "login": "Xinbeok",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/174566968?v=4",
+      "profileUrl": "https://github.com/Xinbeok",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-23T09:06:00Z",
+      "latestContributionAt": "2026-08-23T10:29:36Z"
     },
     {
       "login": "YangYuS8",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-16T18:20:13.205Z",
-  "stars": 15086,
+  "generatedAt": "2026-08-17T18:30:19.040Z",
+  "stars": 15319,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3046,
+      "commits": 3057,
       "mergedPullRequests": 16,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-15T04:08:41Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 547,
-      "mergedPullRequests": 547,
+      "commits": 555,
+      "mergedPullRequests": 555,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-16T18:09:50Z"
+      "latestContributionAt": "2026-08-17T11:40:40Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 152,
-      "mergedPullRequests": 151,
+      "commits": 153,
+      "mergedPullRequests": 152,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-16T17:51:19Z"
+      "latestContributionAt": "2026-08-17T06:58:48Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -58,6 +58,15 @@
       "latestContributionAt": "2026-08-13T11:31:18Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 59,
+      "mergedPullRequests": 59,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-17T06:52:01Z"
+    },
+    {
       "login": "serenez",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38424953?v=4",
       "profileUrl": "https://github.com/serenez",
@@ -65,15 +74,6 @@
       "mergedPullRequests": 55,
       "firstContributionAt": "2026-04-30T04:27:54Z",
       "latestContributionAt": "2026-07-20T15:31:27Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 57,
-      "mergedPullRequests": 57,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-16T06:39:43Z"
     },
     {
       "login": "onceMisery",
@@ -220,6 +220,15 @@
       "latestContributionAt": "2026-08-14T09:47:55Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-17T05:11:58Z"
+    },
+    {
       "login": "DASungta",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
       "profileUrl": "https://github.com/DASungta",
@@ -263,15 +272,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-02T16:19:01Z",
       "latestContributionAt": "2026-07-27T14:47:00Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-14T14:56:29Z"
     },
     {
       "login": "chenhbb",
@@ -472,6 +472,24 @@
       "latestContributionAt": "2026-07-08T16:35:34Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-17T08:31:45Z"
+    },
+    {
+      "login": "azens",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
+      "profileUrl": "https://github.com/azens",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-17T06:34:18Z",
+      "latestContributionAt": "2026-08-17T07:54:14Z"
+    },
+    {
       "login": "Caisin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25792786?v=4",
       "profileUrl": "https://github.com/Caisin",
@@ -524,6 +542,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
+    },
+    {
+      "login": "jthanh8144",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
+      "profileUrl": "https://github.com/jthanh8144",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-15T03:09:27Z",
+      "latestContributionAt": "2026-08-17T06:53:34Z"
     },
     {
       "login": "soddygo",
@@ -580,24 +607,6 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-16T07:34:03Z"
-    },
-    {
-      "login": "azens",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
-      "profileUrl": "https://github.com/azens",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-17T06:34:18Z",
-      "latestContributionAt": "2026-08-15T06:59:05Z"
-    },
-    {
       "login": "BabyLy233",
       "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
       "profileUrl": "https://github.com/BabyLy233",
@@ -623,15 +632,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-15T02:08:13Z",
       "latestContributionAt": "2026-08-16T07:33:49Z"
-    },
-    {
-      "login": "jthanh8144",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
-      "profileUrl": "https://github.com/jthanh8144",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-15T03:09:27Z",
-      "latestContributionAt": "2026-07-16T10:21:11Z"
     },
     {
       "login": "kkk000111999",
@@ -740,6 +740,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-26T03:33:01Z",
       "latestContributionAt": "2026-07-01T08:35:48Z"
+    },
+    {
+      "login": "bigFish0124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
+      "profileUrl": "https://github.com/bigFish0124",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-11T08:46:27Z",
+      "latestContributionAt": "2026-08-17T03:20:29Z"
     },
     {
       "login": "bigliangzao",
@@ -1138,15 +1147,6 @@
       "latestContributionAt": "2026-05-21T02:24:47Z"
     },
     {
-      "login": "bigFish0124",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
-      "profileUrl": "https://github.com/bigFish0124",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-11T08:46:27Z",
-      "latestContributionAt": "2026-08-11T13:31:45Z"
-    },
-    {
       "login": "BlueSkyXN",
       "avatarUrl": "https://avatars.githubusercontent.com/u/63384277?v=4",
       "profileUrl": "https://github.com/BlueSkyXN",
@@ -1489,6 +1489,15 @@
       "latestContributionAt": "2026-07-28T15:18:13Z"
     },
     {
+      "login": "luojiyin1987",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6524977?v=4",
+      "profileUrl": "https://github.com/luojiyin1987",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-17T02:51:45Z",
+      "latestContributionAt": "2026-08-17T07:10:31Z"
+    },
+    {
       "login": "ManjusriBuddha",
       "avatarUrl": "https://avatars.githubusercontent.com/u/55905747?v=4",
       "profileUrl": "https://github.com/ManjusriBuddha",
@@ -1739,6 +1748,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-27T13:49:30Z",
       "latestContributionAt": "2026-07-28T19:18:06Z"
+    },
+    {
+      "login": "xiaoyaoqilan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/155608604?v=4",
+      "profileUrl": "https://github.com/xiaoyaoqilan",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-17T03:34:26Z",
+      "latestContributionAt": "2026-08-17T06:57:27Z"
     },
     {
       "login": "YangYuS8",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-05T19:21:57.639Z",
-  "stars": 13317,
+  "generatedAt": "2026-08-06T23:53:35.775Z",
+  "stars": 13507,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2808,
+      "commits": 2828,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 459,
-      "mergedPullRequests": 459,
+      "commits": 467,
+      "mergedPullRequests": 467,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-05T15:58:32Z"
+      "latestContributionAt": "2026-08-06T18:40:50Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 126,
-      "mergedPullRequests": 125,
+      "commits": 132,
+      "mergedPullRequests": 131,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-05T16:55:36Z"
+      "latestContributionAt": "2026-08-06T18:41:28Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 80,
-      "mergedPullRequests": 68,
+      "commits": 81,
+      "mergedPullRequests": 69,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-05T07:52:20Z"
+      "latestContributionAt": "2026-08-06T18:56:27Z"
     },
     {
       "login": "serenez",
@@ -52,19 +52,19 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 52,
-      "mergedPullRequests": 52,
+      "commits": 54,
+      "mergedPullRequests": 54,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-05T15:58:22Z"
+      "latestContributionAt": "2026-08-06T19:24:25Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 47,
-      "mergedPullRequests": 47,
+      "commits": 49,
+      "mergedPullRequests": 49,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-05T06:51:14Z"
+      "latestContributionAt": "2026-08-06T09:09:15Z"
     },
     {
       "login": "Illuminated2020",
@@ -142,10 +142,19 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
+      "commits": 20,
+      "mergedPullRequests": 20,
+      "firstContributionAt": "2026-06-09T08:33:11Z",
+      "latestContributionAt": "2026-08-06T08:30:20Z"
+    },
+    {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
       "commits": 19,
       "mergedPullRequests": 19,
-      "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-07-21T08:59:03Z"
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-06T19:30:52Z"
     },
     {
       "login": "yavon007",
@@ -164,15 +173,6 @@
       "mergedPullRequests": 16,
       "firstContributionAt": "2026-06-17T08:11:49Z",
       "latestContributionAt": "2026-06-26T10:48:46Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 16,
-      "mergedPullRequests": 16,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-05T01:48:04Z"
     },
     {
       "login": "jischeng",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-07-27T14:47:00Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 10,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-06T15:16:00Z"
+    },
+    {
       "login": "chenhbb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
       "profileUrl": "https://github.com/chenhbb",
@@ -256,15 +265,6 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 9,
-      "mergedPullRequests": 9,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-05T03:37:57Z"
-    },
-    {
       "login": "dienaso",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
       "profileUrl": "https://github.com/dienaso",
@@ -272,6 +272,15 @@
       "mergedPullRequests": 9,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-04T05:02:31Z"
+    },
+    {
+      "login": "aiLi0617",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
+      "profileUrl": "https://github.com/aiLi0617",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-06-19T14:50:55Z",
+      "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
       "login": "czs208112",
@@ -301,6 +310,15 @@
       "latestContributionAt": "2026-07-31T08:23:56Z"
     },
     {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-06T06:00:09Z"
+    },
+    {
       "login": "xKrah",
       "avatarUrl": "https://avatars.githubusercontent.com/u/23560682?v=4",
       "profileUrl": "https://github.com/xKrah",
@@ -328,15 +346,6 @@
       "latestContributionAt": "2026-07-01T11:05:45Z"
     },
     {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-08-03T06:34:07Z"
-    },
-    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -344,15 +353,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
-    },
-    {
-      "login": "aiLi0617",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
-      "profileUrl": "https://github.com/aiLi0617",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-06-19T14:50:55Z",
-      "latestContributionAt": "2026-08-05T17:12:31Z"
     },
     {
       "login": "antwa",
@@ -400,6 +400,15 @@
       "latestContributionAt": "2026-06-29T03:16:38Z"
     },
     {
+      "login": "ChunMengLu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
+      "profileUrl": "https://github.com/ChunMengLu",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-24T07:06:09Z",
+      "latestContributionAt": "2026-08-06T16:13:34Z"
+    },
+    {
       "login": "CSXFanMeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
       "profileUrl": "https://github.com/CSXFanMeng",
@@ -418,6 +427,15 @@
       "latestContributionAt": "2026-06-26T09:45:45Z"
     },
     {
+      "login": "James-Leong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
+      "profileUrl": "https://github.com/James-Leong",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-06-08T17:32:08Z",
+      "latestContributionAt": "2026-08-06T04:13:57Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -425,6 +443,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-02T15:29:53Z",
       "latestContributionAt": "2026-07-07T10:09:02Z"
+    },
+    {
+      "login": "possebon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
+      "profileUrl": "https://github.com/possebon",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-02T17:09:52Z",
+      "latestContributionAt": "2026-08-06T19:35:19Z"
     },
     {
       "login": "soddygo",
@@ -490,15 +517,6 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
-      "login": "ChunMengLu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
-      "profileUrl": "https://github.com/ChunMengLu",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-24T07:06:09Z",
-      "latestContributionAt": "2026-07-30T10:19:40Z"
-    },
-    {
       "login": "echocde",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
       "profileUrl": "https://github.com/echocde",
@@ -506,15 +524,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-06-25T04:51:02Z"
-    },
-    {
-      "login": "James-Leong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
-      "profileUrl": "https://github.com/James-Leong",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-06-08T17:32:08Z",
-      "latestContributionAt": "2026-07-23T16:56:05Z"
     },
     {
       "login": "jthanh8144",
@@ -688,6 +697,15 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
+      "login": "holmesin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
+      "profileUrl": "https://github.com/holmesin",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-03T12:29:55Z",
+      "latestContributionAt": "2026-08-06T15:33:29Z"
+    },
+    {
       "login": "ijevin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
       "profileUrl": "https://github.com/ijevin",
@@ -713,6 +731,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-12T13:29:00Z",
       "latestContributionAt": "2026-07-13T09:03:34Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-06T15:15:17Z"
     },
     {
       "login": "JinRudy",
@@ -769,15 +796,6 @@
       "latestContributionAt": "2026-07-10T05:27:11Z"
     },
     {
-      "login": "possebon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
-      "profileUrl": "https://github.com/possebon",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-02T17:09:52Z",
-      "latestContributionAt": "2026-08-02T19:42:40Z"
-    },
-    {
       "login": "rainhan99",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16128160?v=4",
       "profileUrl": "https://github.com/rainhan99",
@@ -803,6 +821,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-01T15:04:40Z",
       "latestContributionAt": "2026-06-09T04:06:39Z"
+    },
+    {
+      "login": "TangTangH",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
+      "profileUrl": "https://github.com/TangTangH",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-04T04:55:17Z",
+      "latestContributionAt": "2026-08-06T06:09:21Z"
     },
     {
       "login": "togls",
@@ -895,6 +922,15 @@
       "latestContributionAt": "2026-05-05T09:30:42Z"
     },
     {
+      "login": "2090230619-syq",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/268813423?v=4",
+      "profileUrl": "https://github.com/2090230619-syq",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T02:22:08Z",
+      "latestContributionAt": "2026-08-06T04:41:24Z"
+    },
+    {
       "login": "adntian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2285733?v=4",
       "profileUrl": "https://github.com/adntian",
@@ -983,6 +1019,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-06T12:18:47Z"
     },
     {
       "login": "cl1107",
@@ -1129,13 +1174,13 @@
       "latestContributionAt": "2026-07-06T10:21:15Z"
     },
     {
-      "login": "holmesin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
-      "profileUrl": "https://github.com/holmesin",
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-03T12:29:55Z",
-      "latestContributionAt": "2026-08-03T16:46:28Z"
+      "firstContributionAt": "2026-08-06T06:25:31Z",
+      "latestContributionAt": "2026-08-06T08:29:27Z"
     },
     {
       "login": "huangyemin",
@@ -1208,15 +1253,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-04T02:43:43Z",
       "latestContributionAt": "2026-08-04T05:01:50Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-04T11:05:05Z"
     },
     {
       "login": "kcheng007",
@@ -1316,6 +1352,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-14T11:25:31Z",
       "latestContributionAt": "2026-07-28T20:32:27Z"
+    },
+    {
+      "login": "monellin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17845081?v=4",
+      "profileUrl": "https://github.com/monellin",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T06:29:13Z",
+      "latestContributionAt": "2026-08-06T18:19:46Z"
     },
     {
       "login": "octo-patch",
@@ -1442,15 +1487,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
-    },
-    {
-      "login": "TangTangH",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
-      "profileUrl": "https://github.com/TangTangH",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-04T04:55:17Z",
-      "latestContributionAt": "2026-08-04T18:59:34Z"
     },
     {
       "login": "Tssshhhh",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-09T18:31:28.680Z",
-  "stars": 13772,
+  "generatedAt": "2026-08-10T18:48:33.509Z",
+  "stars": 13956,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2866,
+      "commits": 2885,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 489,
-      "mergedPullRequests": 489,
+      "commits": 499,
+      "mergedPullRequests": 499,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-09T15:24:37Z"
+      "latestContributionAt": "2026-08-10T16:53:43Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 135,
-      "mergedPullRequests": 134,
+      "commits": 139,
+      "mergedPullRequests": 138,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-09T06:14:09Z"
+      "latestContributionAt": "2026-08-10T15:02:38Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -40,6 +40,15 @@
       "latestContributionAt": "2026-08-09T17:06:44Z"
     },
     {
+      "login": "CN-Scars",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
+      "profileUrl": "https://github.com/CN-Scars",
+      "commits": 58,
+      "mergedPullRequests": 58,
+      "firstContributionAt": "2026-05-30T10:02:05Z",
+      "latestContributionAt": "2026-08-10T15:02:43Z"
+    },
+    {
       "login": "serenez",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38424953?v=4",
       "profileUrl": "https://github.com/serenez",
@@ -49,31 +58,22 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
-      "login": "CN-Scars",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
-      "profileUrl": "https://github.com/CN-Scars",
-      "commits": 56,
-      "mergedPullRequests": 56,
-      "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-08T03:08:18Z"
-    },
-    {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 50,
-      "mergedPullRequests": 50,
+      "commits": 52,
+      "mergedPullRequests": 52,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-07T07:31:45Z"
+      "latestContributionAt": "2026-08-10T10:27:04Z"
     },
     {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 40,
-      "mergedPullRequests": 38,
+      "commits": 41,
+      "mergedPullRequests": 39,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-09T06:24:10Z"
+      "latestContributionAt": "2026-08-10T15:45:43Z"
     },
     {
       "login": "Illuminated2020",
@@ -121,6 +121,15 @@
       "latestContributionAt": "2026-07-10T10:15:25Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 24,
+      "mergedPullRequests": 24,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-10T18:12:22Z"
+    },
+    {
       "login": "rarnu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/209014?v=4",
       "profileUrl": "https://github.com/rarnu",
@@ -137,15 +146,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-26T03:29:22Z",
       "latestContributionAt": "2026-07-16T17:17:49Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 22,
-      "mergedPullRequests": 22,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-08T02:37:59Z"
     },
     {
       "login": "ptma",
@@ -400,6 +400,15 @@
       "latestContributionAt": "2026-06-30T17:35:07Z"
     },
     {
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-05T09:25:09Z",
+      "latestContributionAt": "2026-08-10T10:51:45Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -427,6 +436,15 @@
       "latestContributionAt": "2026-07-08T16:35:34Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-10T11:25:46Z"
+    },
+    {
       "login": "Caisin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25792786?v=4",
       "profileUrl": "https://github.com/Caisin",
@@ -452,15 +470,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-09T07:54:46Z",
       "latestContributionAt": "2026-06-26T09:45:45Z"
-    },
-    {
-      "login": "HighBigSky",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
-      "profileUrl": "https://github.com/HighBigSky",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-05T09:25:09Z",
-      "latestContributionAt": "2026-08-08T02:38:08Z"
     },
     {
       "login": "James-Leong",
@@ -589,6 +598,15 @@
       "latestContributionAt": "2026-07-29T12:48:40Z"
     },
     {
+      "login": "rihkddd",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
+      "profileUrl": "https://github.com/rihkddd",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-30T13:25:21Z",
+      "latestContributionAt": "2026-08-10T16:08:18Z"
+    },
+    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -623,15 +641,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-06T07:06:32Z",
       "latestContributionAt": "2026-07-07T02:34:32Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-05T03:17:02Z"
     },
     {
       "login": "asdlem",
@@ -830,15 +839,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-12T05:47:37Z",
       "latestContributionAt": "2026-07-13T09:51:52Z"
-    },
-    {
-      "login": "rihkddd",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
-      "profileUrl": "https://github.com/rihkddd",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-30T13:25:21Z",
-      "latestContributionAt": "2026-08-04T17:09:59Z"
     },
     {
       "login": "Sanjeever",
@@ -1046,6 +1046,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
+    },
+    {
+      "login": "chenow9",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/302014081?v=4",
+      "profileUrl": "https://github.com/chenow9",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T04:32:47Z",
+      "latestContributionAt": "2026-08-10T02:54:27Z"
     },
     {
       "login": "cl1107",
@@ -1264,6 +1273,15 @@
       "latestContributionAt": "2026-07-24T13:11:18Z"
     },
     {
+      "login": "JcEvoX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/74612426?v=4",
+      "profileUrl": "https://github.com/JcEvoX",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-10T11:37:11Z",
+      "latestContributionAt": "2026-08-10T15:38:10Z"
+    },
+    {
       "login": "JeaceLiu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31269749?v=4",
       "profileUrl": "https://github.com/JeaceLiu",
@@ -1480,6 +1498,15 @@
       "latestContributionAt": "2026-07-30T09:16:18Z"
     },
     {
+      "login": "solarhell",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10279583?v=4",
+      "profileUrl": "https://github.com/solarhell",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-10T07:32:03Z",
+      "latestContributionAt": "2026-08-10T10:26:11Z"
+    },
+    {
       "login": "srako",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18043224?v=4",
       "profileUrl": "https://github.com/srako",
@@ -1550,6 +1577,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-10T10:22:17Z"
     },
     {
       "login": "xcstatus",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-25T18:31:47.394Z",
-  "stars": 16575,
+  "generatedAt": "2026-08-26T19:42:14.179Z",
+  "stars": 16698,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3245,
+      "commits": 3267,
       "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-25T16:07:31Z"
@@ -16,55 +16,55 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 615,
-      "mergedPullRequests": 615,
+      "commits": 629,
+      "mergedPullRequests": 629,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-25T16:27:28Z"
+      "latestContributionAt": "2026-08-26T13:31:55Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 172,
-      "mergedPullRequests": 171,
+      "commits": 175,
+      "mergedPullRequests": 174,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-25T14:00:26Z"
-    },
-    {
-      "login": "Abeautifulsnow",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
-      "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 98,
-      "mergedPullRequests": 86,
-      "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-24T12:28:13Z"
+      "latestContributionAt": "2026-08-26T14:04:42Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 91,
-      "mergedPullRequests": 91,
+      "commits": 99,
+      "mergedPullRequests": 99,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-25T14:36:40Z"
+      "latestContributionAt": "2026-08-26T14:07:35Z"
+    },
+    {
+      "login": "Abeautifulsnow",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
+      "profileUrl": "https://github.com/Abeautifulsnow",
+      "commits": 99,
+      "mergedPullRequests": 87,
+      "firstContributionAt": "2026-05-06T03:16:57Z",
+      "latestContributionAt": "2026-08-26T06:09:09Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 72,
-      "mergedPullRequests": 72,
+      "commits": 73,
+      "mergedPullRequests": 73,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-25T15:57:02Z"
+      "latestContributionAt": "2026-08-26T07:49:49Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 64,
-      "mergedPullRequests": 64,
+      "commits": 65,
+      "mergedPullRequests": 65,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-24T12:32:20Z"
+      "latestContributionAt": "2026-08-26T06:44:20Z"
     },
     {
       "login": "serenez",
@@ -85,6 +85,15 @@
       "latestContributionAt": "2026-08-24T10:35:18Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 40,
+      "mergedPullRequests": 40,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-26T09:47:15Z"
+    },
+    {
       "login": "Illuminated2020",
       "avatarUrl": "https://avatars.githubusercontent.com/u/95458741?v=4",
       "profileUrl": "https://github.com/Illuminated2020",
@@ -92,15 +101,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-12T09:13:51Z",
       "latestContributionAt": "2026-05-12T09:22:36Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 36,
-      "mergedPullRequests": 36,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-25T14:51:27Z"
     },
     {
       "login": "mapan0424",
@@ -247,6 +247,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 12,
+      "mergedPullRequests": 12,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-26T13:38:10Z"
+    },
+    {
       "login": "mr-dadong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
       "profileUrl": "https://github.com/mr-dadong",
@@ -263,15 +272,6 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-18T04:43:31Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-24T10:58:15Z"
     },
     {
       "login": "guoyongchang",
@@ -436,6 +436,15 @@
       "latestContributionAt": "2026-08-08T03:04:17Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-26T05:52:42Z"
+    },
+    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -497,15 +506,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-08-14T01:26:28Z",
       "latestContributionAt": "2026-08-25T06:46:25Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-24T05:26:09Z"
     },
     {
       "login": "wbean",
@@ -751,6 +751,15 @@
       "latestContributionAt": "2026-08-07T05:45:00Z"
     },
     {
+      "login": "ordinary-s",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
+      "profileUrl": "https://github.com/ordinary-s",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-18T11:36:48Z",
+      "latestContributionAt": "2026-08-26T14:00:04Z"
+    },
+    {
       "login": "polemp",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48376445?v=4",
       "profileUrl": "https://github.com/polemp",
@@ -994,15 +1003,6 @@
       "latestContributionAt": "2026-07-10T05:27:11Z"
     },
     {
-      "login": "ordinary-s",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
-      "profileUrl": "https://github.com/ordinary-s",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-18T11:36:48Z",
-      "latestContributionAt": "2026-08-25T13:26:00Z"
-    },
-    {
       "login": "rainhan99",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16128160?v=4",
       "profileUrl": "https://github.com/rainhan99",
@@ -1226,6 +1226,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-06T04:32:47Z",
       "latestContributionAt": "2026-08-10T02:54:27Z"
+    },
+    {
+      "login": "Cherrs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6745593?v=4",
+      "profileUrl": "https://github.com/Cherrs",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-25T09:42:47Z",
+      "latestContributionAt": "2026-08-26T05:21:51Z"
     },
     {
       "login": "cl1107",
@@ -1525,6 +1534,15 @@
       "latestContributionAt": "2026-08-05T01:49:14Z"
     },
     {
+      "login": "LDQONJ",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/128981031?v=4",
+      "profileUrl": "https://github.com/LDQONJ",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-26T02:32:37Z",
+      "latestContributionAt": "2026-08-26T06:43:53Z"
+    },
+    {
       "login": "leic4u",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32786903?v=4",
       "profileUrl": "https://github.com/leic4u",
@@ -1712,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-09T07:01:29Z",
       "latestContributionAt": "2026-06-09T08:23:14Z"
+    },
+    {
+      "login": "StaravenX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
+      "profileUrl": "https://github.com/StaravenX",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-26T11:48:56Z",
+      "latestContributionAt": "2026-08-26T13:37:29Z"
     },
     {
       "login": "sunny0826",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-10T18:48:33.509Z",
-  "stars": 13956,
+  "generatedAt": "2026-08-11T18:54:53.020Z",
+  "stars": 14124,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2885,
+      "commits": 2914,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 499,
-      "mergedPullRequests": 499,
+      "commits": 506,
+      "mergedPullRequests": 506,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-10T16:53:43Z"
+      "latestContributionAt": "2026-08-11T16:12:03Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 139,
-      "mergedPullRequests": 138,
+      "commits": 143,
+      "mergedPullRequests": 142,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-10T15:02:38Z"
+      "latestContributionAt": "2026-08-11T18:20:06Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 84,
-      "mergedPullRequests": 72,
+      "commits": 88,
+      "mergedPullRequests": 76,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-09T17:06:44Z"
+      "latestContributionAt": "2026-08-11T16:19:58Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 58,
-      "mergedPullRequests": 58,
+      "commits": 59,
+      "mergedPullRequests": 59,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-10T15:02:43Z"
+      "latestContributionAt": "2026-08-11T16:09:02Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 52,
-      "mergedPullRequests": 52,
+      "commits": 54,
+      "mergedPullRequests": 54,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-10T10:27:04Z"
+      "latestContributionAt": "2026-08-11T16:41:31Z"
     },
     {
       "login": "onceMisery",
@@ -112,6 +112,15 @@
       "latestContributionAt": "2026-07-28T14:39:11Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 26,
+      "mergedPullRequests": 26,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-11T13:34:50Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-04-30T05:56:34Z",
       "latestContributionAt": "2026-07-10T10:15:25Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 24,
-      "mergedPullRequests": 24,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-10T18:12:22Z"
     },
     {
       "login": "rarnu",
@@ -151,10 +151,10 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
-      "commits": 20,
-      "mergedPullRequests": 20,
+      "commits": 21,
+      "mergedPullRequests": 21,
       "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-08-06T08:30:20Z"
+      "latestContributionAt": "2026-08-11T05:05:26Z"
     },
     {
       "login": "yavon007",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-11T07:00:25Z"
+    },
+    {
       "login": "guoyongchang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
       "profileUrl": "https://github.com/guoyongchang",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-02T16:19:01Z",
       "latestContributionAt": "2026-07-27T14:47:00Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-06T15:16:00Z"
     },
     {
       "login": "chenhbb",
@@ -292,6 +292,15 @@
       "latestContributionAt": "2026-08-09T16:07:12Z"
     },
     {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-11T13:33:16Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -308,15 +317,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-03T08:58:21Z"
-    },
-    {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-08-06T06:00:09Z"
     },
     {
       "login": "xKrah",
@@ -371,6 +371,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
+    },
+    {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-11T18:05:55Z"
     },
     {
       "login": "antwa",
@@ -434,15 +443,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-10T11:25:46Z"
     },
     {
       "login": "Caisin",
@@ -542,6 +542,24 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
+    },
+    {
+      "login": "BabyLy233",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
+      "profileUrl": "https://github.com/BabyLy233",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-14T07:55:34Z",
+      "latestContributionAt": "2026-08-11T08:55:53Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-11T13:32:15Z"
     },
     {
       "login": "difagume",
@@ -677,15 +695,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
-    },
-    {
-      "login": "cheshireez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
-      "profileUrl": "https://github.com/cheshireez",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-06T10:14:50Z",
-      "latestContributionAt": "2026-08-08T03:33:38Z"
     },
     {
       "login": "cwatanab",
@@ -1012,15 +1021,6 @@
       "latestContributionAt": "2026-06-30T09:34:14Z"
     },
     {
-      "login": "BabyLy233",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
-      "profileUrl": "https://github.com/BabyLy233",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-14T07:55:34Z",
-      "latestContributionAt": "2026-07-14T11:03:42Z"
-    },
-    {
       "login": "baizhi958216",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46777503?v=4",
       "profileUrl": "https://github.com/baizhi958216",
@@ -1028,6 +1028,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-21T01:48:37Z",
       "latestContributionAt": "2026-05-21T02:24:47Z"
+    },
+    {
+      "login": "bigFish0124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
+      "profileUrl": "https://github.com/bigFish0124",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T08:46:27Z",
+      "latestContributionAt": "2026-08-11T13:31:45Z"
     },
     {
       "login": "BlueSkyXN",
@@ -1118,6 +1127,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T09:14:47Z",
       "latestContributionAt": "2026-07-08T10:53:49Z"
+    },
+    {
+      "login": "easton-shi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/215789663?v=4",
+      "profileUrl": "https://github.com/easton-shi",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-08T07:21:44Z",
+      "latestContributionAt": "2026-08-11T05:05:04Z"
     },
     {
       "login": "ededddy",
@@ -1568,6 +1586,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-22T12:39:46Z",
       "latestContributionAt": "2026-07-22T15:52:15Z"
+    },
+    {
+      "login": "wilyan09007",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/77467499?v=4",
+      "profileUrl": "https://github.com/wilyan09007",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T06:09:28Z",
+      "latestContributionAt": "2026-08-11T13:37:32Z"
     },
     {
       "login": "wnyr",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,34 +1,34 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-29T01:23:22.980Z",
-  "stars": 17282,
+  "generatedAt": "2026-08-29T20:17:46.770Z",
+  "stars": 17401,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3302,
-      "mergedPullRequests": 18,
+      "commits": 3306,
+      "mergedPullRequests": 19,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-25T16:07:31Z"
+      "latestContributionAt": "2026-08-29T19:54:16Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 641,
-      "mergedPullRequests": 641,
+      "commits": 644,
+      "mergedPullRequests": 644,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-28T09:16:56Z"
+      "latestContributionAt": "2026-08-29T19:05:11Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 183,
-      "mergedPullRequests": 182,
+      "commits": 187,
+      "mergedPullRequests": 186,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-28T09:19:40Z"
+      "latestContributionAt": "2026-08-29T19:05:44Z"
     },
     {
       "login": "q396921921",
@@ -76,6 +76,15 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 47,
+      "mergedPullRequests": 47,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-29T16:47:45Z"
+    },
+    {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
@@ -83,15 +92,6 @@
       "mergedPullRequests": 44,
       "firstContributionAt": "2026-06-10T14:19:43Z",
       "latestContributionAt": "2026-08-24T10:35:18Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 44,
-      "mergedPullRequests": 44,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-28T07:30:09Z"
     },
     {
       "login": "Illuminated2020",
@@ -107,7 +107,7 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
       "commits": 36,
-      "mergedPullRequests": 36,
+      "mergedPullRequests": 37,
       "firstContributionAt": "2026-07-17T05:42:50Z",
       "latestContributionAt": "2026-08-25T07:15:42Z"
     },
@@ -454,6 +454,15 @@
       "latestContributionAt": "2026-08-26T05:52:42Z"
     },
     {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-29T17:34:00Z"
+    },
+    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -499,6 +508,15 @@
       "latestContributionAt": "2026-08-18T15:17:24Z"
     },
     {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-29T19:57:03Z"
+    },
+    {
       "login": "lizzzzz777",
       "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
       "profileUrl": "https://github.com/lizzzzz777",
@@ -515,15 +533,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-22T07:12:37Z",
       "latestContributionAt": "2026-08-13T11:24:49Z"
-    },
-    {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-27T02:55:06Z"
     },
     {
       "login": "ZhonFortune",
@@ -587,15 +596,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-19T18:26:56Z"
     },
     {
       "login": "soddygo",
@@ -1444,6 +1444,15 @@
       "latestContributionAt": "2026-06-01T10:04:58Z"
     },
     {
+      "login": "Hanwn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30523763?v=4",
+      "profileUrl": "https://github.com/Hanwn",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-29T01:18:22Z",
+      "latestContributionAt": "2026-08-29T17:11:09Z"
+    },
+    {
       "login": "heyrmi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/42892759?v=4",
       "profileUrl": "https://github.com/heyrmi",
@@ -1721,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-03T06:58:44Z",
       "latestContributionAt": "2026-08-04T06:23:45Z"
+    },
+    {
+      "login": "s1oopX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/185045939?v=4",
+      "profileUrl": "https://github.com/s1oopX",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-29T11:49:11Z",
+      "latestContributionAt": "2026-08-29T17:02:01Z"
     },
     {
       "login": "shnno13",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-07T18:46:06.990Z",
-  "stars": 13631,
+  "generatedAt": "2026-08-08T18:28:50.496Z",
+  "stars": 13727,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2845,
+      "commits": 2854,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 472,
-      "mergedPullRequests": 472,
+      "commits": 479,
+      "mergedPullRequests": 479,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-07T09:06:19Z"
+      "latestContributionAt": "2026-08-08T03:36:58Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 132,
-      "mergedPullRequests": 131,
+      "commits": 134,
+      "mergedPullRequests": 133,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-06T18:41:28Z"
+      "latestContributionAt": "2026-08-08T03:33:47Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 82,
-      "mergedPullRequests": 70,
+      "commits": 83,
+      "mergedPullRequests": 71,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-07T05:43:42Z"
+      "latestContributionAt": "2026-08-08T04:00:51Z"
     },
     {
       "login": "serenez",
@@ -52,10 +52,10 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 55,
-      "mergedPullRequests": 55,
+      "commits": 56,
+      "mergedPullRequests": 56,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-07T09:06:04Z"
+      "latestContributionAt": "2026-08-08T03:08:18Z"
     },
     {
       "login": "onenewcode",
@@ -142,10 +142,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 21,
-      "mergedPullRequests": 21,
+      "commits": 22,
+      "mergedPullRequests": 22,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-07T09:05:48Z"
+      "latestContributionAt": "2026-08-08T02:37:59Z"
     },
     {
       "login": "ptma",
@@ -337,6 +337,15 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-08T02:40:34Z"
+    },
+    {
       "login": "luoianun",
       "avatarUrl": "https://avatars.githubusercontent.com/u/20828060?v=4",
       "profileUrl": "https://github.com/luoianun",
@@ -344,6 +353,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-17T05:09:05Z",
       "latestContributionAt": "2026-07-01T11:05:45Z"
+    },
+    {
+      "login": "possebon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
+      "profileUrl": "https://github.com/possebon",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-02T17:09:52Z",
+      "latestContributionAt": "2026-08-08T03:04:17Z"
     },
     {
       "login": "ZionLin2016",
@@ -380,15 +398,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-01T08:26:41Z",
       "latestContributionAt": "2026-06-30T17:35:07Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-02T08:34:50Z"
     },
     {
       "login": "jeeinn",
@@ -436,6 +445,15 @@
       "latestContributionAt": "2026-06-26T09:45:45Z"
     },
     {
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-05T09:25:09Z",
+      "latestContributionAt": "2026-08-08T02:38:08Z"
+    },
+    {
       "login": "James-Leong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
       "profileUrl": "https://github.com/James-Leong",
@@ -445,13 +463,13 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
-      "login": "possebon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
-      "profileUrl": "https://github.com/possebon",
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
       "commits": 4,
       "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-02T17:09:52Z",
-      "latestContributionAt": "2026-08-06T19:35:19Z"
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-08T03:56:32Z"
     },
     {
       "login": "soddygo",
@@ -533,24 +551,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-06-25T04:51:02Z"
-    },
-    {
-      "login": "HighBigSky",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
-      "profileUrl": "https://github.com/HighBigSky",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-05T09:25:09Z",
-      "latestContributionAt": "2026-08-07T07:40:13Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-07T05:43:09Z"
     },
     {
       "login": "jthanh8144",
@@ -659,6 +659,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-08T03:33:38Z"
     },
     {
       "login": "cwatanab",
@@ -1028,15 +1037,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
-    },
-    {
-      "login": "cheshireez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
-      "profileUrl": "https://github.com/cheshireez",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-06T10:14:50Z",
-      "latestContributionAt": "2026-08-06T12:18:47Z"
     },
     {
       "login": "cl1107",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-08T18:28:50.496Z",
-  "stars": 13727,
+  "generatedAt": "2026-08-09T18:31:28.680Z",
+  "stars": 13772,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2854,
+      "commits": 2866,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 479,
-      "mergedPullRequests": 479,
+      "commits": 489,
+      "mergedPullRequests": 489,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-08T03:36:58Z"
+      "latestContributionAt": "2026-08-09T15:24:37Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 134,
-      "mergedPullRequests": 133,
+      "commits": 135,
+      "mergedPullRequests": 134,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-08T03:33:47Z"
+      "latestContributionAt": "2026-08-09T06:14:09Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 83,
-      "mergedPullRequests": 71,
+      "commits": 84,
+      "mergedPullRequests": 72,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-08T04:00:51Z"
+      "latestContributionAt": "2026-08-09T17:06:44Z"
     },
     {
       "login": "serenez",
@@ -67,6 +67,15 @@
       "latestContributionAt": "2026-08-07T07:31:45Z"
     },
     {
+      "login": "onceMisery",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
+      "profileUrl": "https://github.com/onceMisery",
+      "commits": 40,
+      "mergedPullRequests": 38,
+      "firstContributionAt": "2026-06-10T14:19:43Z",
+      "latestContributionAt": "2026-08-09T06:24:10Z"
+    },
+    {
       "login": "Illuminated2020",
       "avatarUrl": "https://avatars.githubusercontent.com/u/95458741?v=4",
       "profileUrl": "https://github.com/Illuminated2020",
@@ -74,15 +83,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-12T09:13:51Z",
       "latestContributionAt": "2026-05-12T09:22:36Z"
-    },
-    {
-      "login": "onceMisery",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
-      "profileUrl": "https://github.com/onceMisery",
-      "commits": 39,
-      "mergedPullRequests": 37,
-      "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-05T09:25:22Z"
     },
     {
       "login": "lexmin0412",
@@ -283,6 +283,15 @@
       "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
+      "login": "tianyifeng-druid",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
+      "profileUrl": "https://github.com/tianyifeng-druid",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-06-21T01:57:56Z",
+      "latestContributionAt": "2026-08-09T16:07:12Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -299,15 +308,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-03T08:58:21Z"
-    },
-    {
-      "login": "tianyifeng-druid",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
-      "profileUrl": "https://github.com/tianyifeng-druid",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-06-21T01:57:56Z",
-      "latestContributionAt": "2026-07-31T08:23:56Z"
     },
     {
       "login": "wang-zhengxin",
@@ -409,6 +409,15 @@
       "latestContributionAt": "2026-08-07T07:32:16Z"
     },
     {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-09T17:11:26Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -461,15 +470,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-08T03:56:32Z"
     },
     {
       "login": "soddygo",
@@ -641,6 +641,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-26T03:33:01Z",
       "latestContributionAt": "2026-07-01T08:35:48Z"
+    },
+    {
+      "login": "azens",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
+      "profileUrl": "https://github.com/azens",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-17T06:34:18Z",
+      "latestContributionAt": "2026-08-09T11:51:12Z"
     },
     {
       "login": "bigliangzao",
@@ -841,6 +850,15 @@
       "latestContributionAt": "2026-06-09T04:06:39Z"
     },
     {
+      "login": "shenmo7192",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47873776?v=4",
+      "profileUrl": "https://github.com/shenmo7192",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-13T10:58:52Z",
+      "latestContributionAt": "2026-08-09T15:33:24Z"
+    },
+    {
       "login": "TangTangH",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
       "profileUrl": "https://github.com/TangTangH",
@@ -983,15 +1001,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-14T12:51:26Z",
       "latestContributionAt": "2026-06-14T14:53:10Z"
-    },
-    {
-      "login": "azens",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
-      "profileUrl": "https://github.com/azens",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-17T06:34:18Z",
-      "latestContributionAt": "2026-07-21T14:56:39Z"
     },
     {
       "login": "B022MC",
@@ -1172,6 +1181,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-01T08:54:31Z",
       "latestContributionAt": "2026-06-01T10:04:58Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-09T16:37:35Z"
     },
     {
       "login": "heyrmi",
@@ -1435,15 +1453,6 @@
       "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
-      "login": "shenmo7192",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47873776?v=4",
-      "profileUrl": "https://github.com/shenmo7192",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-13T10:58:52Z",
-      "latestContributionAt": "2026-07-13T11:45:02Z"
-    },
-    {
       "login": "shnno13",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14847218?v=4",
       "profileUrl": "https://github.com/shnno13",
@@ -1505,6 +1514,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T15:20:59Z",
       "latestContributionAt": "2026-07-08T16:32:53Z"
+    },
+    {
+      "login": "tyloryang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38744951?v=4",
+      "profileUrl": "https://github.com/tyloryang",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-09T08:11:27Z",
+      "latestContributionAt": "2026-08-09T15:28:02Z"
     },
     {
       "login": "Wakanlolz",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-19T18:25:41.468Z",
-  "stars": 15899,
+  "generatedAt": "2026-08-20T18:30:31.659Z",
+  "stars": 16032,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3092,
+      "commits": 3119,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 568,
-      "mergedPullRequests": 568,
+      "commits": 575,
+      "mergedPullRequests": 575,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-19T07:08:32Z"
+      "latestContributionAt": "2026-08-20T13:38:21Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 156,
-      "mergedPullRequests": 156,
+      "commits": 160,
+      "mergedPullRequests": 159,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-19T18:16:26Z"
+      "latestContributionAt": "2026-08-20T17:15:46Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,28 +43,28 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 78,
-      "mergedPullRequests": 79,
+      "commits": 86,
+      "mergedPullRequests": 86,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-19T17:59:26Z"
+      "latestContributionAt": "2026-08-20T14:23:37Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 66,
-      "mergedPullRequests": 66,
+      "commits": 67,
+      "mergedPullRequests": 67,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-18T18:04:01Z"
+      "latestContributionAt": "2026-08-20T00:47:05Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 59,
-      "mergedPullRequests": 59,
+      "commits": 60,
+      "mergedPullRequests": 60,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-13T11:31:18Z"
+      "latestContributionAt": "2026-08-20T10:25:12Z"
     },
     {
       "login": "serenez",
@@ -97,19 +97,19 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 31,
-      "mergedPullRequests": 31,
+      "commits": 34,
+      "mergedPullRequests": 34,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-19T17:52:44Z"
+      "latestContributionAt": "2026-08-20T07:14:20Z"
     },
     {
       "login": "xddcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
       "profileUrl": "https://github.com/xddcode",
-      "commits": 29,
-      "mergedPullRequests": 29,
+      "commits": 30,
+      "mergedPullRequests": 30,
       "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-08-19T17:51:58Z"
+      "latestContributionAt": "2026-08-20T02:23:08Z"
     },
     {
       "login": "gggaiitx",
@@ -166,6 +166,15 @@
       "latestContributionAt": "2026-08-13T03:40:23Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 19,
+      "mergedPullRequests": 19,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-20T12:42:46Z"
+    },
+    {
       "login": "yavon007",
       "avatarUrl": "https://avatars.githubusercontent.com/u/27227092?v=4",
       "profileUrl": "https://github.com/yavon007",
@@ -173,15 +182,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-05-02T20:43:01Z",
       "latestContributionAt": "2026-05-20T08:10:15Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 16,
-      "mergedPullRequests": 16,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-19T07:49:27Z"
     },
     {
       "login": "linjianlin",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-20T10:50:22Z"
+    },
+    {
       "login": "juvevood",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1421513?v=4",
       "profileUrl": "https://github.com/juvevood",
@@ -211,13 +220,13 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
       "commits": 13,
       "mergedPullRequests": 13,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-18T15:16:33Z"
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-20T08:04:22Z"
     },
     {
       "login": "SpencerZhang",
@@ -229,13 +238,13 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
       "commits": 12,
       "mergedPullRequests": 12,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-14T09:47:55Z"
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-20T14:11:49Z"
     },
     {
       "login": "DASungta",
@@ -326,15 +335,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-19T17:51:12Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -562,6 +562,15 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-19T18:26:56Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -596,6 +605,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-08-01T01:44:32Z",
       "latestContributionAt": "2026-08-18T07:36:37Z"
+    },
+    {
+      "login": "xzxlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
+      "profileUrl": "https://github.com/xzxlove",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-13T06:38:59Z",
+      "latestContributionAt": "2026-08-20T12:41:52Z"
     },
     {
       "login": "zhuhaoh",
@@ -652,6 +670,24 @@
       "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
+      "login": "fengyuwusong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
+      "profileUrl": "https://github.com/fengyuwusong",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T06:07:00Z",
+      "latestContributionAt": "2026-08-20T08:33:09Z"
+    },
+    {
+      "login": "funnytime75",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/162818986?v=4",
+      "profileUrl": "https://github.com/funnytime75",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-06-20T08:35:12Z",
+      "latestContributionAt": "2026-08-20T01:28:40Z"
+    },
+    {
       "login": "kir1ito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
       "profileUrl": "https://github.com/kir1ito",
@@ -668,15 +704,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-15T06:41:42Z"
     },
     {
       "login": "lazyanubis",
@@ -715,6 +742,15 @@
       "latestContributionAt": "2026-08-10T16:08:18Z"
     },
     {
+      "login": "scstc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
+      "profileUrl": "https://github.com/scstc",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-18T10:01:35Z",
+      "latestContributionAt": "2026-08-20T13:01:23Z"
+    },
+    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -731,15 +767,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
-    },
-    {
-      "login": "xzxlove",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
-      "profileUrl": "https://github.com/xzxlove",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-13T06:38:59Z",
-      "latestContributionAt": "2026-08-15T06:44:47Z"
     },
     {
       "login": "Michaelxwb",
@@ -821,15 +848,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T06:54:05Z",
       "latestContributionAt": "2026-07-31T06:38:50Z"
-    },
-    {
-      "login": "funnytime75",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/162818986?v=4",
-      "profileUrl": "https://github.com/funnytime75",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-06-20T08:35:12Z",
-      "latestContributionAt": "2026-06-30T01:14:44Z"
     },
     {
       "login": "gadfly3173",
@@ -985,6 +1003,15 @@
       "latestContributionAt": "2026-08-09T15:33:24Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-20T14:12:53Z"
+    },
+    {
       "login": "TangTangH",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
       "profileUrl": "https://github.com/TangTangH",
@@ -1091,15 +1118,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-03T18:36:11Z",
       "latestContributionAt": "2026-05-05T09:30:42Z"
-    },
-    {
-      "login": "scstc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
-      "profileUrl": "https://github.com/scstc",
-      "commits": 1,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-18T10:01:35Z",
-      "latestContributionAt": "2026-08-19T18:21:56Z"
     },
     {
       "login": "2090230619-syq",
@@ -1316,15 +1334,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-05T11:00:04Z",
       "latestContributionAt": "2026-07-05T11:38:51Z"
-    },
-    {
-      "login": "fengyuwusong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
-      "profileUrl": "https://github.com/fengyuwusong",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-13T06:07:00Z",
-      "latestContributionAt": "2026-08-13T07:26:30Z"
     },
     {
       "login": "fuuulstack",
@@ -1579,6 +1588,15 @@
       "latestContributionAt": "2026-07-30T15:05:13Z"
     },
     {
+      "login": "OctoBored",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/212877535?v=4",
+      "profileUrl": "https://github.com/OctoBored",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-19T13:26:43Z",
+      "latestContributionAt": "2026-08-20T00:48:49Z"
+    },
+    {
       "login": "Odonno",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6053067?v=4",
       "profileUrl": "https://github.com/Odonno",
@@ -1687,15 +1705,6 @@
       "latestContributionAt": "2026-06-12T03:30:03Z"
     },
     {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-19T07:31:25Z"
-    },
-    {
       "login": "Tssshhhh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109692520?v=4",
       "profileUrl": "https://github.com/Tssshhhh",
@@ -1748,6 +1757,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wu-zhao-min",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/167841690?v=4",
+      "profileUrl": "https://github.com/wu-zhao-min",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-20T03:03:56Z",
+      "latestContributionAt": "2026-08-20T04:24:04Z"
     },
     {
       "login": "wyeye",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-04T19:23:43.773Z",
-  "stars": 13194,
+  "generatedAt": "2026-08-05T19:21:57.639Z",
+  "stars": 13317,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2794,
+      "commits": 2808,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 444,
-      "mergedPullRequests": 444,
+      "commits": 459,
+      "mergedPullRequests": 459,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-04T17:10:58Z"
+      "latestContributionAt": "2026-08-05T15:58:32Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 122,
-      "mergedPullRequests": 121,
+      "commits": 126,
+      "mergedPullRequests": 125,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-03T16:46:13Z"
+      "latestContributionAt": "2026-08-05T16:55:36Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 77,
-      "mergedPullRequests": 66,
+      "commits": 80,
+      "mergedPullRequests": 68,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-04T18:59:52Z"
+      "latestContributionAt": "2026-08-05T07:52:20Z"
     },
     {
       "login": "serenez",
@@ -52,19 +52,19 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 51,
-      "mergedPullRequests": 51,
+      "commits": 52,
+      "mergedPullRequests": 52,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-07-29T19:12:02Z"
+      "latestContributionAt": "2026-08-05T15:58:22Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 46,
-      "mergedPullRequests": 46,
+      "commits": 47,
+      "mergedPullRequests": 47,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-04T17:02:21Z"
+      "latestContributionAt": "2026-08-05T06:51:14Z"
     },
     {
       "login": "Illuminated2020",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 37,
-      "mergedPullRequests": 35,
+      "commits": 39,
+      "mergedPullRequests": 37,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-02T08:37:46Z"
+      "latestContributionAt": "2026-08-05T09:25:22Z"
     },
     {
       "login": "lexmin0412",
@@ -166,6 +166,15 @@
       "latestContributionAt": "2026-06-26T10:48:46Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 16,
+      "mergedPullRequests": 16,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-05T01:48:04Z"
+    },
+    {
       "login": "jischeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49861575?v=4",
       "profileUrl": "https://github.com/jischeng",
@@ -173,15 +182,6 @@
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-06-24T12:52:59Z",
       "latestContributionAt": "2026-07-29T12:41:10Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 15,
-      "mergedPullRequests": 15,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-03T12:25:01Z"
     },
     {
       "login": "juvevood",
@@ -200,6 +200,15 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-17T03:22:35Z",
       "latestContributionAt": "2026-07-20T08:54:52Z"
+    },
+    {
+      "login": "guoyongchang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
+      "profileUrl": "https://github.com/guoyongchang",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-30T02:45:51Z",
+      "latestContributionAt": "2026-08-05T03:10:15Z"
     },
     {
       "login": "haipengno1",
@@ -229,6 +238,15 @@
       "latestContributionAt": "2026-07-27T14:47:00Z"
     },
     {
+      "login": "chenhbb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
+      "profileUrl": "https://github.com/chenhbb",
+      "commits": 10,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-06-20T07:06:56Z",
+      "latestContributionAt": "2026-08-05T03:36:34Z"
+    },
+    {
       "login": "dal1wg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/91363952?v=4",
       "profileUrl": "https://github.com/dal1wg",
@@ -238,13 +256,13 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
-      "login": "chenhbb",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
-      "profileUrl": "https://github.com/chenhbb",
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
       "commits": 9,
       "mergedPullRequests": 9,
-      "firstContributionAt": "2026-06-20T07:06:56Z",
-      "latestContributionAt": "2026-08-02T01:04:30Z"
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-05T03:37:57Z"
     },
     {
       "login": "dienaso",
@@ -254,24 +272,6 @@
       "mergedPullRequests": 9,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-04T05:02:31Z"
-    },
-    {
-      "login": "guoyongchang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
-      "profileUrl": "https://github.com/guoyongchang",
-      "commits": 8,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-30T02:45:51Z",
-      "latestContributionAt": "2026-08-04T18:59:20Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-07-31T14:31:51Z"
     },
     {
       "login": "czs208112",
@@ -346,6 +346,15 @@
       "latestContributionAt": "2026-07-10T11:27:07Z"
     },
     {
+      "login": "aiLi0617",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
+      "profileUrl": "https://github.com/aiLi0617",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-06-19T14:50:55Z",
+      "latestContributionAt": "2026-08-05T17:12:31Z"
+    },
+    {
       "login": "antwa",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5325867?v=4",
       "profileUrl": "https://github.com/antwa",
@@ -380,15 +389,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "aiLi0617",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
-      "profileUrl": "https://github.com/aiLi0617",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-06-19T14:50:55Z",
-      "latestContributionAt": "2026-08-03T17:38:30Z"
     },
     {
       "login": "Caisin",
@@ -580,6 +580,15 @@
       "latestContributionAt": "2026-07-07T02:34:32Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-05T03:17:02Z"
+    },
+    {
       "login": "asdlem",
       "avatarUrl": "https://avatars.githubusercontent.com/u/53173237?v=4",
       "profileUrl": "https://github.com/asdlem",
@@ -713,6 +722,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-08T09:25:42Z",
       "latestContributionAt": "2026-06-09T03:59:49Z"
+    },
+    {
+      "login": "lazyanubis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
+      "profileUrl": "https://github.com/lazyanubis",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-12T06:57:24Z",
+      "latestContributionAt": "2026-08-05T07:29:34Z"
     },
     {
       "login": "lc6464",
@@ -904,15 +922,6 @@
       "latestContributionAt": "2026-06-06T01:15:09Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-03T13:29:24Z"
-    },
-    {
       "login": "athoune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/74048?v=4",
       "profileUrl": "https://github.com/athoune",
@@ -974,15 +983,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
-    },
-    {
-      "login": "chrstphe",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10966918?v=4",
-      "profileUrl": "https://github.com/chrstphe",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-25T08:10:39Z",
-      "latestContributionAt": "2026-07-25T10:41:13Z"
     },
     {
       "login": "cl1107",
@@ -1255,13 +1255,13 @@
       "latestContributionAt": "2026-07-28T16:08:04Z"
     },
     {
-      "login": "lazyanubis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
-      "profileUrl": "https://github.com/lazyanubis",
+      "login": "laosiji66666",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24238046?v=4",
+      "profileUrl": "https://github.com/laosiji66666",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-12T06:57:24Z",
-      "latestContributionAt": "2026-07-12T14:03:57Z"
+      "firstContributionAt": "2026-08-04T15:56:03Z",
+      "latestContributionAt": "2026-08-05T01:49:14Z"
     },
     {
       "login": "leic4u",
@@ -1444,6 +1444,15 @@
       "latestContributionAt": "2026-06-12T03:30:03Z"
     },
     {
+      "login": "TangTangH",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
+      "profileUrl": "https://github.com/TangTangH",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T04:55:17Z",
+      "latestContributionAt": "2026-08-04T18:59:34Z"
+    },
+    {
       "login": "Tssshhhh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109692520?v=4",
       "profileUrl": "https://github.com/Tssshhhh",
@@ -1570,6 +1579,15 @@
       "latestContributionAt": "2026-07-16T10:19:44Z"
     },
     {
+      "login": "Yy-702",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/175375032?v=4",
+      "profileUrl": "https://github.com/Yy-702",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T09:05:09Z",
+      "latestContributionAt": "2026-08-05T15:57:51Z"
+    },
+    {
       "login": "zergmk2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/698746?v=4",
       "profileUrl": "https://github.com/zergmk2",
@@ -1604,15 +1622,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
-    },
-    {
-      "login": "TangTangH",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
-      "profileUrl": "https://github.com/TangTangH",
-      "commits": 0,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-04T04:55:17Z",
-      "latestContributionAt": "2026-08-04T18:59:34Z"
     }
   ]
 }

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,52 +1,61 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-17T18:30:19.040Z",
-  "stars": 15319,
+  "generatedAt": "2026-08-18T18:29:51.674Z",
+  "stars": 15628,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3057,
-      "mergedPullRequests": 16,
+      "commits": 3074,
+      "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-15T04:08:41Z"
+      "latestContributionAt": "2026-08-18T04:05:42Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 555,
-      "mergedPullRequests": 555,
+      "commits": 563,
+      "mergedPullRequests": 563,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-17T11:40:40Z"
+      "latestContributionAt": "2026-08-18T16:34:07Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 153,
-      "mergedPullRequests": 152,
+      "commits": 154,
+      "mergedPullRequests": 153,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-17T06:58:48Z"
+      "latestContributionAt": "2026-08-18T07:23:09Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 91,
-      "mergedPullRequests": 79,
+      "commits": 95,
+      "mergedPullRequests": 83,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-14T10:37:53Z"
+      "latestContributionAt": "2026-08-18T14:04:39Z"
+    },
+    {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 71,
+      "mergedPullRequests": 71,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-18T17:51:55Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 63,
-      "mergedPullRequests": 63,
+      "commits": 66,
+      "mergedPullRequests": 66,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-14T16:28:12Z"
+      "latestContributionAt": "2026-08-18T18:04:01Z"
     },
     {
       "login": "onenewcode",
@@ -56,15 +65,6 @@
       "mergedPullRequests": 59,
       "firstContributionAt": "2026-06-30T01:53:31Z",
       "latestContributionAt": "2026-08-13T11:31:18Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 59,
-      "mergedPullRequests": 59,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-17T06:52:01Z"
     },
     {
       "login": "serenez",
@@ -202,6 +202,24 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-18T17:02:41Z"
+    },
+    {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-18T15:16:33Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -220,15 +238,6 @@
       "latestContributionAt": "2026-08-14T09:47:55Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-17T05:11:58Z"
-    },
-    {
       "login": "DASungta",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
       "profileUrl": "https://github.com/DASungta",
@@ -236,6 +245,15 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-13T07:26:45Z"
+    },
+    {
+      "login": "dienaso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
+      "profileUrl": "https://github.com/dienaso",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-24T03:23:39Z",
+      "latestContributionAt": "2026-08-18T04:43:31Z"
     },
     {
       "login": "guoyongchang",
@@ -292,13 +310,13 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
-      "login": "dienaso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
-      "profileUrl": "https://github.com/dienaso",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-08-13T04:40:51Z"
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-18T03:39:55Z"
     },
     {
       "login": "aiLi0617",
@@ -308,15 +326,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-13T16:22:44Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -364,6 +373,15 @@
       "latestContributionAt": "2026-05-11T14:10:01Z"
     },
     {
+      "login": "antwa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5325867?v=4",
+      "profileUrl": "https://github.com/antwa",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-13T09:25:38Z",
+      "latestContributionAt": "2026-08-18T02:50:36Z"
+    },
+    {
       "login": "dbin0123",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18297300?v=4",
       "profileUrl": "https://github.com/dbin0123",
@@ -371,6 +389,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-18T16:30:40Z"
     },
     {
       "login": "jeeinn",
@@ -409,15 +436,6 @@
       "latestContributionAt": "2026-07-10T11:27:07Z"
     },
     {
-      "login": "antwa",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5325867?v=4",
-      "profileUrl": "https://github.com/antwa",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-13T09:25:38Z",
-      "latestContributionAt": "2026-07-16T09:01:10Z"
-    },
-    {
       "login": "ChunMengLu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
       "profileUrl": "https://github.com/ChunMengLu",
@@ -454,6 +472,24 @@
       "latestContributionAt": "2026-08-10T10:51:45Z"
     },
     {
+      "login": "jthanh8144",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
+      "profileUrl": "https://github.com/jthanh8144",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-15T03:09:27Z",
+      "latestContributionAt": "2026-08-18T15:17:24Z"
+    },
+    {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-18T15:16:59Z"
+    },
+    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -470,15 +506,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-17T08:31:45Z"
     },
     {
       "login": "azens",
@@ -526,15 +553,6 @@
       "latestContributionAt": "2026-08-13T14:31:14Z"
     },
     {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-14T14:18:29Z"
-    },
-    {
       "login": "James-Leong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
       "profileUrl": "https://github.com/James-Leong",
@@ -542,15 +560,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "jthanh8144",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
-      "profileUrl": "https://github.com/jthanh8144",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-15T03:09:27Z",
-      "latestContributionAt": "2026-08-17T06:53:34Z"
     },
     {
       "login": "soddygo",
@@ -578,6 +587,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-05T16:45:23Z",
       "latestContributionAt": "2026-07-12T13:30:37Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-18T07:36:37Z"
     },
     {
       "login": "zhuhaoh",
@@ -634,6 +652,15 @@
       "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
+      "login": "kir1ito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
+      "profileUrl": "https://github.com/kir1ito",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T10:38:51Z",
+      "latestContributionAt": "2026-08-18T15:05:17Z"
+    },
+    {
       "login": "kkk000111999",
       "avatarUrl": "https://avatars.githubusercontent.com/u/296277678?v=4",
       "profileUrl": "https://github.com/kkk000111999",
@@ -659,6 +686,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
+    },
+    {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-18T02:51:50Z"
     },
     {
       "login": "polemp",
@@ -695,15 +731,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
-    },
-    {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
       "login": "xzxlove",
@@ -895,15 +922,6 @@
       "latestContributionAt": "2026-08-15T06:41:17Z"
     },
     {
-      "login": "kir1ito",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
-      "profileUrl": "https://github.com/kir1ito",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-13T10:38:51Z",
-      "latestContributionAt": "2026-08-14T10:05:36Z"
-    },
-    {
       "login": "lc6464",
       "avatarUrl": "https://avatars.githubusercontent.com/u/64722907?v=4",
       "profileUrl": "https://github.com/lc6464",
@@ -929,15 +947,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T04:57:31Z",
       "latestContributionAt": "2026-08-02T08:35:04Z"
-    },
-    {
-      "login": "lizzzzz777",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
-      "profileUrl": "https://github.com/lizzzzz777",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-14T01:26:28Z",
-      "latestContributionAt": "2026-08-14T10:25:05Z"
     },
     {
       "login": "onlyc0302",
@@ -1597,6 +1606,15 @@
       "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
+      "login": "scstc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
+      "profileUrl": "https://github.com/scstc",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-18T10:01:35Z",
+      "latestContributionAt": "2026-08-18T18:04:14Z"
+    },
+    {
       "login": "shnno13",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14847218?v=4",
       "profileUrl": "https://github.com/shnno13",
@@ -1712,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wyeye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/51752290?v=4",
+      "profileUrl": "https://github.com/wyeye",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-17T06:30:17Z",
+      "latestContributionAt": "2026-08-18T04:47:53Z"
     },
     {
       "login": "xcstatus",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-18T18:29:51.674Z",
-  "stars": 15628,
+  "generatedAt": "2026-08-19T18:25:41.468Z",
+  "stars": 15899,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3074,
+      "commits": 3092,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 563,
-      "mergedPullRequests": 563,
+      "commits": 568,
+      "mergedPullRequests": 568,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-18T16:34:07Z"
+      "latestContributionAt": "2026-08-19T07:08:32Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 154,
-      "mergedPullRequests": 153,
+      "commits": 156,
+      "mergedPullRequests": 156,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-18T07:23:09Z"
+      "latestContributionAt": "2026-08-19T18:16:26Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 95,
-      "mergedPullRequests": 83,
+      "commits": 96,
+      "mergedPullRequests": 84,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-18T14:04:39Z"
+      "latestContributionAt": "2026-08-19T07:49:15Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 71,
-      "mergedPullRequests": 71,
+      "commits": 78,
+      "mergedPullRequests": 79,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-18T17:51:55Z"
+      "latestContributionAt": "2026-08-19T17:59:26Z"
     },
     {
       "login": "CN-Scars",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 42,
-      "mergedPullRequests": 40,
+      "commits": 43,
+      "mergedPullRequests": 41,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-13T16:19:09Z"
+      "latestContributionAt": "2026-08-19T03:10:12Z"
     },
     {
       "login": "Illuminated2020",
@@ -97,10 +97,19 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 30,
-      "mergedPullRequests": 30,
+      "commits": 31,
+      "mergedPullRequests": 31,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-15T13:55:55Z"
+      "latestContributionAt": "2026-08-19T17:52:44Z"
+    },
+    {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 29,
+      "mergedPullRequests": 29,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-08-19T17:51:58Z"
     },
     {
       "login": "gggaiitx",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 28,
-      "mergedPullRequests": 28,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-08-07T07:57:46Z"
     },
     {
       "login": "SuLea-IT",
@@ -175,6 +175,15 @@
       "latestContributionAt": "2026-05-20T08:10:15Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 16,
+      "mergedPullRequests": 16,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-19T07:49:27Z"
+    },
+    {
       "login": "linjianlin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46356519?v=4",
       "profileUrl": "https://github.com/linjianlin",
@@ -200,15 +209,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-18T17:02:41Z"
     },
     {
       "login": "AndrewDi",
@@ -313,10 +313,10 @@
       "login": "GIWTO",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
       "profileUrl": "https://github.com/GIWTO",
-      "commits": 9,
-      "mergedPullRequests": 9,
+      "commits": 10,
+      "mergedPullRequests": 10,
       "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-18T03:39:55Z"
+      "latestContributionAt": "2026-08-19T12:23:17Z"
     },
     {
       "login": "aiLi0617",
@@ -326,6 +326,15 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
+    },
+    {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-19T17:51:12Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -479,15 +488,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-15T03:09:27Z",
       "latestContributionAt": "2026-08-18T15:17:24Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-18T15:16:59Z"
     },
     {
       "login": "wbean",
@@ -1093,6 +1093,15 @@
       "latestContributionAt": "2026-05-05T09:30:42Z"
     },
     {
+      "login": "scstc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
+      "profileUrl": "https://github.com/scstc",
+      "commits": 1,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-18T10:01:35Z",
+      "latestContributionAt": "2026-08-19T18:21:56Z"
+    },
+    {
       "login": "2090230619-syq",
       "avatarUrl": "https://avatars.githubusercontent.com/u/268813423?v=4",
       "profileUrl": "https://github.com/2090230619-syq",
@@ -1516,6 +1525,15 @@
       "latestContributionAt": "2026-07-17T03:28:14Z"
     },
     {
+      "login": "Marc-oss-hub",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315200685?v=4",
+      "profileUrl": "https://github.com/Marc-oss-hub",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-14T18:06:15Z",
+      "latestContributionAt": "2026-08-19T13:16:13Z"
+    },
+    {
       "login": "Max29xD",
       "avatarUrl": "https://avatars.githubusercontent.com/u/85517789?v=4",
       "profileUrl": "https://github.com/Max29xD",
@@ -1606,15 +1624,6 @@
       "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
-      "login": "scstc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
-      "profileUrl": "https://github.com/scstc",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-18T10:01:35Z",
-      "latestContributionAt": "2026-08-18T18:04:14Z"
-    },
-    {
       "login": "shnno13",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14847218?v=4",
       "profileUrl": "https://github.com/shnno13",
@@ -1676,6 +1685,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
+    },
+    {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-19T07:31:25Z"
     },
     {
       "login": "Tssshhhh",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-28T01:59:57.384Z",
-  "stars": 17031,
+  "generatedAt": "2026-08-29T01:23:22.980Z",
+  "stars": 17282,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3287,
+      "commits": 3302,
       "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-25T16:07:31Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 636,
-      "mergedPullRequests": 636,
+      "commits": 641,
+      "mergedPullRequests": 641,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-27T14:25:39Z"
+      "latestContributionAt": "2026-08-28T09:16:56Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 179,
-      "mergedPullRequests": 178,
+      "commits": 183,
+      "mergedPullRequests": 182,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-27T09:59:11Z"
+      "latestContributionAt": "2026-08-28T09:19:40Z"
     },
     {
       "login": "q396921921",
@@ -43,19 +43,19 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 102,
-      "mergedPullRequests": 90,
+      "commits": 103,
+      "mergedPullRequests": 91,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-27T14:23:13Z"
+      "latestContributionAt": "2026-08-28T04:37:11Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 73,
-      "mergedPullRequests": 73,
+      "commits": 74,
+      "mergedPullRequests": 74,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-26T07:49:49Z"
+      "latestContributionAt": "2026-08-28T08:51:34Z"
     },
     {
       "login": "onenewcode",
@@ -88,10 +88,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 42,
-      "mergedPullRequests": 42,
+      "commits": 44,
+      "mergedPullRequests": 44,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-27T00:40:28Z"
+      "latestContributionAt": "2026-08-28T07:30:09Z"
     },
     {
       "login": "Illuminated2020",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-28T04:14:04Z"
+    },
+    {
       "login": "AndrewDi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
       "profileUrl": "https://github.com/AndrewDi",
@@ -220,13 +229,13 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-20T08:04:22Z"
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-28T03:11:35Z"
     },
     {
       "login": "DASungta",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-24T05:29:24Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-27T09:17:41Z"
     },
     {
       "login": "SpencerZhang",
@@ -409,6 +409,15 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-28T03:12:41Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -461,15 +470,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-24T07:06:09Z",
       "latestContributionAt": "2026-08-07T05:43:30Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-15T06:41:54Z"
     },
     {
       "login": "fraluc06",
@@ -625,6 +625,15 @@
       "latestContributionAt": "2026-07-12T13:30:37Z"
     },
     {
+      "login": "xiaou61",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
+      "profileUrl": "https://github.com/xiaou61",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-14T09:19:51Z",
+      "latestContributionAt": "2026-08-28T04:36:37Z"
+    },
+    {
       "login": "xzxlove",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
       "profileUrl": "https://github.com/xzxlove",
@@ -749,6 +758,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
+    },
+    {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-08-28T06:27:56Z"
     },
     {
       "login": "ordinary-s",
@@ -994,15 +1012,6 @@
       "latestContributionAt": "2026-08-02T08:35:04Z"
     },
     {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-08-27T09:32:57Z"
-    },
-    {
       "login": "onlyc0302",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24369193?v=4",
       "profileUrl": "https://github.com/onlyc0302",
@@ -1037,6 +1046,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-13T10:58:52Z",
       "latestContributionAt": "2026-08-09T15:33:24Z"
+    },
+    {
+      "login": "StaravenX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
+      "profileUrl": "https://github.com/StaravenX",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-26T11:48:56Z",
+      "latestContributionAt": "2026-08-28T07:29:07Z"
     },
     {
       "login": "TangTangH",
@@ -1109,15 +1127,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
-    },
-    {
-      "login": "xiaou61",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
-      "profileUrl": "https://github.com/xiaou61",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-14T09:19:51Z",
-      "latestContributionAt": "2026-08-14T14:46:33Z"
     },
     {
       "login": "yangqinlong",
@@ -1757,15 +1766,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-09T07:01:29Z",
       "latestContributionAt": "2026-06-09T08:23:14Z"
-    },
-    {
-      "login": "StaravenX",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
-      "profileUrl": "https://github.com/StaravenX",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-26T11:48:56Z",
-      "latestContributionAt": "2026-08-26T13:37:29Z"
     },
     {
       "login": "sunny0826",

--- a/packages/app-tests/tableSqlTemplates.test.ts
+++ b/packages/app-tests/tableSqlTemplates.test.ts
@@ -77,6 +77,19 @@ test("builds DELETE template with TODO WHERE clause when no primary key exists",
   );
 });
 
+test("builds GoldenDB templates with MySQL-style identifier quotes", () => {
+  const options = {
+    databaseType: "goldendb" as const,
+    tableName: "order",
+    columns,
+  };
+
+  assert.equal(buildTableSelectTemplate(options), "SELECT `id`, `name`, `created_at`\nFROM `order`;");
+  assert.equal(buildTableInsertTemplate(options), "INSERT INTO `order` (`name`, `created_at`)\nVALUES ('name_value', CURRENT_TIMESTAMP);");
+  assert.equal(buildTableUpdateTemplate(options), "UPDATE `order`\nSET `name` = 'name_value',\n    `created_at` = CURRENT_TIMESTAMP\nWHERE `id` = 0;");
+  assert.equal(buildTableDeleteTemplate(options), "DELETE FROM `order`\nWHERE `id` = 0;");
+});
+
 test("builds GaussDB M templates with the detected backtick identifier mode", () => {
   const options = {
     databaseType: "gaussdb" as const,


### PR DESCRIPTION
## 问题

GoldenDB 右键生成 SQL 时未匹配 MySQL 兼容方言，表名和字段名错误使用双引号。

## 修改

- 将 GoldenDB 纳入前端 MySQL 风格标识符引用规则
- SELECT、INSERT、UPDATE、DELETE 模板统一生成反引号
- 增加 GoldenDB SQL 模板回归测试

## 验证

- `pnpm check`
- GoldenDB 模板测试：7/7