### PR TITLE
fix(kingbase): 无时区的 timestamp/date/time 列不再被错误标记为 UTC 时刻

### DIFF
--- a/agents/drivers/kingbase-go/integration_test.go
+++ b/agents/drivers/kingbase-go/integration_test.go
@@ -559,6 +559,64 @@ func TestKingbaseCustomTypeDetailsIntegration(t *testing.T) {
 	}
 }
 
+// A "timestamp"/"date" column has no timezone meaning; it must be returned as
+// a wall-clock string with no "Z"/offset suffix, or clients that convert it to
+// a display timezone will double-apply the shift (see #7681). A "timestamptz"
+// column is a real absolute instant and must keep its offset.
+func TestKingbaseTimezoneLessDateTimeIsReturnedWithoutOffset(t *testing.T) {
+	host := os.Getenv("KINGBASE_TEST_HOST")
+	portText := os.Getenv("KINGBASE_TEST_PORT")
+	username := os.Getenv("KINGBASE_TEST_USERNAME")
+	password := os.Getenv("KINGBASE_TEST_PASSWORD")
+	if host == "" || portText == "" || username == "" || password == "" {
+		t.Skip("Kingbase integration environment is not configured")
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database := os.Getenv("KINGBASE_TEST_DATABASE")
+	if database == "" {
+		database = "test"
+	}
+	table := "dbx_go_tzless_" + strconv.FormatInt(time.Now().UnixNano(), 36)
+
+	server := newServer()
+	cp := connectParams{
+		Host: host, Port: port, Database: database, Username: username, Password: password,
+		ConnectionString: fmt.Sprintf("jdbc:kingbase8://%s:%d/%s", host, port, database),
+	}
+	if err := server.connect(cp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.disconnect() })
+	t.Cleanup(func() {
+		_, _ = server.executeQuery(queryOptions{SQL: "DROP TABLE IF EXISTS " + quoteIdentifier(table)})
+	})
+
+	mustExecute(t, server, "CREATE TABLE "+quoteIdentifier(table)+" (id integer PRIMARY KEY, ts timestamp, tstz timestamptz)")
+	mustExecute(t, server, "INSERT INTO "+quoteIdentifier(table)+" VALUES (1, '2026-01-30 10:00:03', '2026-01-30 10:00:03+00')")
+
+	result, err := server.executeQuery(queryOptions{SQL: "SELECT ts, tstz FROM " + quoteIdentifier(table) + " WHERE id = 1"})
+	if err != nil {
+		t.Fatalf("select failed: %v", err)
+	}
+	if len(result.Rows) != 1 || len(result.Rows[0]) != 2 {
+		t.Fatalf("unexpected result shape: %#v", result)
+	}
+
+	ts, ok := result.Rows[0][0].(string)
+	if !ok || ts != "2026-01-30T10:00:03" {
+		t.Fatalf("timezone-less timestamp: got %#v, want the wall-clock value with no Z/offset suffix", result.Rows[0][0])
+	}
+	tstz, ok := result.Rows[0][1].(string)
+	_, timeOfDay, foundDateTimeSeparator := strings.Cut(tstz, "T")
+	hasOffsetSuffix := strings.HasSuffix(tstz, "Z") || strings.Contains(timeOfDay, "+") || strings.Contains(timeOfDay, "-")
+	if !ok || !foundDateTimeSeparator || !hasOffsetSuffix {
+		t.Fatalf("timezone-aware timestamptz must keep its Z/offset suffix, got %#v", result.Rows[0][1])
+	}
+}
+
 func rawJSON(value any) json.RawMessage {
 	data, err := json.Marshal(value)
 	if err != nil {

--- a/agents/drivers/kingbase-go/main.go
+++ b/agents/drivers/kingbase-go/main.go
@@ -782,7 +782,7 @@ func readQuerySessionPage(session *querySession, pageSize int) (queryPageResult,
 		if !session.rows.Next() {
 			return result, session.rows.Err()
 		}
-		row, err := scanRow(session.rows, len(session.columns))
+		row, err := scanRow(session.rows, len(session.columns), session.columnTypes)
 		if err != nil {
 			return queryPageResult{}, err
 		}
@@ -794,7 +794,7 @@ func readQuerySessionPage(session *querySession, pageSize int) (queryPageResult,
 		return result, nil
 	}
 	if session.rows.Next() {
-		row, err := scanRow(session.rows, len(session.columns))
+		row, err := scanRow(session.rows, len(session.columns), session.columnTypes)
 		if err != nil {
 			return queryPageResult{}, err
 		}
@@ -810,13 +810,14 @@ func readRows(rows *sql.Rows, maxRows int) (queryResult, error) {
 		return queryResult{}, err
 	}
 	columns = nonNilStrings(columns)
-	result := queryResult{Columns: columns, ColumnTypes: columnTypeNames(rows), Rows: make([][]any, 0, min(maxRows, 1024))}
+	columnTypes := columnTypeNames(rows)
+	result := queryResult{Columns: columns, ColumnTypes: columnTypes, Rows: make([][]any, 0, min(maxRows, 1024))}
 	for rows.Next() {
 		if len(result.Rows) >= maxRows {
 			result.Truncated = true
 			break
 		}
-		row, err := scanRow(rows, len(columns))
+		row, err := scanRow(rows, len(columns), columnTypes)
 		if err != nil {
 			return queryResult{}, err
 		}
@@ -825,7 +826,7 @@ func readRows(rows *sql.Rows, maxRows int) (queryResult, error) {
 	return result, rows.Err()
 }
 
-func scanRow(rows *sql.Rows, count int) ([]any, error) {
+func scanRow(rows *sql.Rows, count int, columnTypes []string) ([]any, error) {
 	storage := make([]any, count*2)
 	values := storage[:count]
 	dest := storage[count:]
@@ -836,9 +837,16 @@ func scanRow(rows *sql.Rows, count int) ([]any, error) {
 		return nil, err
 	}
 	for i, value := range values {
-		values[i] = normalizeValue(value)
+		values[i] = normalizeValue(value, columnTypeAt(columnTypes, i))
 	}
 	return values, nil
+}
+
+func columnTypeAt(columnTypes []string, index int) string {
+	if index < 0 || index >= len(columnTypes) {
+		return ""
+	}
+	return columnTypes[index]
 }
 
 func columnTypeNames(rows *sql.Rows) []string {
@@ -1477,7 +1485,7 @@ func isUTF8Encoding(name string) bool {
 	return s == "utf8" || s == "unicode"
 }
 
-func normalizeValue(value any) any {
+func normalizeValue(value any, columnTypeName string) any {
 	switch typed := value.(type) {
 	case nil:
 		return nil
@@ -1487,6 +1495,13 @@ func normalizeValue(value any) any {
 		}
 		return map[string]string{"$binary": base64.StdEncoding.EncodeToString(typed)}
 	case time.Time:
+		// KingBase "timestamp"/"date" columns are wall-clock values with no timezone
+		// meaning; the gokb driver decodes them into a time.Time labeled with the
+		// process-local zone, which is not a real UTC instant. Formatting those with
+		// an offset (RFC3339Nano) makes clients double-apply the timezone shift.
+		if isKingbaseTimezoneLessDateTime(columnTypeName) {
+			return typed.Format("2006-01-02T15:04:05.999999999")
+		}
 		return typed.Format(time.RFC3339Nano)
 	case int8:
 		return int64(typed)
@@ -1498,6 +1513,16 @@ func normalizeValue(value any) any {
 		return float64(typed)
 	default:
 		return typed
+	}
+}
+
+func isKingbaseTimezoneLessDateTime(columnTypeName string) bool {
+	normalized := strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(columnTypeName), " ", ""))
+	switch normalized {
+	case "DATE", "TIMESTAMP", "TIME":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/agents/drivers/kingbase-go/main_test.go
+++ b/agents/drivers/kingbase-go/main_test.go
@@ -4256,3 +4256,35 @@ func containsString(values []string, target string) bool {
 	}
 	return false
 }
+
+// Regression test for https://github.com/t8y2/dbx/issues/7681: a timezone-less
+// "timestamp"/"date"/"time" column must not be labeled as an absolute UTC
+// instant (RFC3339Nano with a "Z"/offset suffix), or clients that convert it
+// to a display timezone will double-apply the shift.
+func TestNormalizeValueKingbaseTimezoneLessDateTime(t *testing.T) {
+	// gokb decodes "timestamp"/"date" wall-clock values into a time.Time in
+	// the process-local zone, which is not a real UTC instant.
+	wallClock := time.Date(2026, time.January, 30, 10, 0, 3, 0, time.UTC)
+
+	for _, columnType := range []string{"TIMESTAMP", "timestamp", "DATE", "TIME"} {
+		got := normalizeValue(wallClock, columnType)
+		want := "2026-01-30T10:00:03"
+		gotStr, ok := got.(string)
+		if !ok {
+			t.Fatalf("columnType=%s: expected a string, got %#v", columnType, got)
+		}
+		if gotStr != want {
+			t.Fatalf("columnType=%s: got %q, want %q", columnType, gotStr, want)
+		}
+		if strings.ContainsAny(gotStr, "Z+") {
+			t.Fatalf("columnType=%s: timezone-less value must not carry a Z/offset suffix, got %q", columnType, gotStr)
+		}
+	}
+
+	// A real timezone-aware column must keep its absolute-instant encoding.
+	tzAware := normalizeValue(wallClock, "TIMESTAMPTZ")
+	tzAwareStr, ok := tzAware.(string)
+	if !ok || tzAwareStr != "2026-01-30T10:00:03Z" {
+		t.Fatalf("TIMESTAMPTZ column: got %#v, want RFC3339Nano-encoded UTC instant", tzAware)
+	}
+}


### PR DESCRIPTION
## 问题

Fixes #7681

KingBase 8 连接下，对无时区的 `timestamp` 字段使用日期格式化功能（如格式 `YYYY-MM-DD HH:mm:ss`，时区 Asia/Shanghai）后，显示时间比数据库存储的原始值多了 8 小时。Oracle 连接下同样操作完全正常。

## 根因

KingBase 走的是独立的原生 Go agent（`agents/drivers/kingbase-go/`），其 `normalizeValue` 对所有 `time.Time` 值一律使用 `RFC3339Nano` 格式化（带 `Z`/偏移后缀），不区分列是否带时区。`timestamp`/`date`/`time` 这类无时区列本身是墙钟值、没有绝对时刻含义，却被打上了 UTC 标记发给前端；前端按通用逻辑把它当作真实 UTC 时刻，转换到显示时区时又叠加了一次偏移。

`agents/drivers/oracle-go/` 已经用 `isOracleTimezoneLessDateTime` 正确处理了同样的场景（Oracle 的 `DATE`/`TIMESTAMP` 输出不带偏移后缀），本次修复照此实现。

## 修复

- 新增 `isKingbaseTimezoneLessDateTime`，识别 `DATE`/`TIMESTAMP`/`TIME` 三种无时区列类型
- `normalizeValue` 新增 `columnTypeName` 参数，无时区列改用不带偏移的 `"2006-01-02T15:04:05.999999999"` 格式；`timestamptz`/`timetz` 等真正带时区的列不受影响，仍用 `RFC3339Nano`
- `scanRow`/`readRows`/新增的 `columnTypeAt` 打通列类型信息传递（沿用 oracle-go 既有模式）

## 验证

**真实连接共享测试 KingBase 8 实例复现**（驱动层 + UI 层双重证据）：

- 驱动层集成测试直接对比 `timestamp`（无时区）与 `timestamptz`（有时区）两列的原始返回值：修复前 `timestamp` 列被错误打上 `Z`（`2026-01-30T10:00:03Z`），修复后不再带偏移后缀（`2026-01-30T10:00:03`），`timestamptz` 列行为不受影响
- UI 层：起本地 dev 环境，插入已知墙钟值 `2026-01-30 10:00:03`，应用列格式化（时区 Asia/Shanghai）：修复前显示 `2026-01-30 18:00:03`（多 8 小时，与 issue 描述一致），修复后原始值不再带 `Z`；把目标时区设为浏览器本机时区做零偏移校验，显示与数据库原始墙钟值完全一致

**测试**：

- 新增单元测试 `TestNormalizeValueKingbaseTimezoneLessDateTime`
- 新增连接活库的集成测试 `TestKingbaseTimezoneLessDateTimeIsReturnedWithoutOffset`
- `go build` / `go vet` / `gofmt` 干净
- `go test ./...`（含全部既有单测 + 连接活库的集成测试）全部通过，除一个跟本次改动完全无关的既有失败 `TestKingbaseCustomTypeDetailsIntegration`（已用未改动的 upstream/main 单独复测，确认是预先存在、与本次改动无关的问题）

## 测试计划

- [x] 新增单元测试通过
- [x] 新增集成测试（连接真实 KingBase 8 实例）通过
- [x] 既有测试套件无回归（详见上文对既有失败项的排查）
- [x] `go build` / `go vet` / `gofmt` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)