### PR TITLE
fix(sidebar): 优化 schema 与表图标的颜色区分

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -256,7 +256,7 @@ function getIconInfo(node: TreeNode): { icon: any; colorClass: string } | null {
       const databaseType = node.connectionId ? effectiveDatabaseTypeForConnection(connectionStore.getConfig(node.connectionId)) : undefined;
       if (isXuguPublicSynonymTreeNode(databaseType, node.type, node.schema)) return { icon: Link2, colorClass: "text-sky-500" };
       if (isXuguSchedulerJobTreeNode(databaseType, node.type, node.schema)) return { icon: CalendarClock, colorClass: "text-primary" };
-      return { icon: FolderOpen, colorClass: "text-sky-400" };
+      return { icon: FolderOpen, colorClass: "text-amber-500" };
     }
     case "table":
       return { icon: Table, colorClass: "text-green-500" };

--- a/packages/app-tests/treeNodeIcon.test.ts
+++ b/packages/app-tests/treeNodeIcon.test.ts
@@ -1,7 +1,20 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "vitest";
 import { getTreeNodeIconInfo } from "../../apps/desktop/src/lib/sidebar/treeNodeIcon.ts";
 import type { TreeNode } from "../../apps/desktop/src/types/database.ts";
+
+const treeItemSource = readFileSync(new URL("../../apps/desktop/src/components/sidebar/TreeItem.vue", import.meta.url), "utf8");
+
+function treeItemIconColorClass(nodeType: "schema" | "table", iconName: "FolderOpen" | "Table"): string {
+  const caseStart = treeItemSource.indexOf(`case "${nodeType}"`);
+  assert.notEqual(caseStart, -1, `Could not find TreeItem ${nodeType} mapping`);
+  const nextCase = treeItemSource.indexOf("\n    case ", caseStart + 1);
+  const caseBlock = treeItemSource.slice(caseStart, nextCase === -1 ? undefined : nextCase);
+  const colorClass = caseBlock.match(new RegExp(`return \\{ icon: ${iconName}, colorClass: "([^"]+)" \\}`))?.[1];
+  assert.ok(colorClass, `Could not find TreeItem ${nodeType} color`);
+  return colorClass;
+}
 
 test("GridFS sidebar nodes use a dedicated cool-color icon treatment", () => {
   const gridfs = getTreeNodeIconInfo({ type: "mongo-gridfs" } as TreeNode);
@@ -16,4 +29,15 @@ test("GridFS sidebar icon mapping stays distinct from Mongo collections", () => 
   const collection = getTreeNodeIconInfo({ type: "mongo-collection" } as TreeNode);
 
   assert.notEqual(gridfs?.colorClass, collection?.colorClass);
+});
+
+test("schema and table sidebar icon colors stay consistent and distinct", () => {
+  const schema = getTreeNodeIconInfo({ type: "schema" } as TreeNode);
+  const table = getTreeNodeIconInfo({ type: "table" } as TreeNode);
+  const treeItemSchemaColor = treeItemIconColorClass("schema", "FolderOpen");
+  const treeItemTableColor = treeItemIconColorClass("table", "Table");
+
+  assert.equal(treeItemSchemaColor, schema?.colorClass);
+  assert.equal(treeItemTableColor, table?.colorClass);
+  assert.notEqual(treeItemSchemaColor, treeItemTableColor);
 });


### PR DESCRIPTION
## 变更说明

修复 #7674。

调整侧边栏中 schema 与表对象的图标配色，使 PostgreSQL `public` schema 与 table 在视觉上更容易区分。

## 实现

- 将实际 sidebar `TreeItem.vue` 中 schema 图标改为 `text-amber-500`
- 保持现有 table 图标颜色 `text-green-500` 不变
- 补充实际 `TreeItem` 与图标映射一致性、颜色区分的针对性测试

## 测试

- [x] `treeNodeIcon.test.ts`
- [x] 33 个 sidebar 相关 app-tests（281 tests）
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `git diff --check`

Closes #7674
