### PR TITLE
fix(rocketmq): 修复 topic 消费组超过 200 条被截断

### DIFF
--- a/crates/dbx-core/src/mq/adapters/rocketmq.rs
+++ b/crates/dbx-core/src/mq/adapters/rocketmq.rs
@@ -144,6 +144,13 @@ impl RocketMqAdmin {
         })
         .await
     }
+
+    async fn list_all_topic_consumer_groups(&self, topic: &str, enrich: bool) -> Result<Vec<SubscriptionInfo>, String> {
+        collect_paginated_consumer_group_pages(|offset| {
+            self.call("mq_list_consumer_groups", rocketmq_topic_consumer_group_page_params(topic, offset, enrich))
+        })
+        .await
+    }
 }
 
 #[async_trait]
@@ -380,20 +387,7 @@ impl MessageQueueAdmin for RocketMqAdmin {
         }
 
         // Topic path: skip list enrich; batch lag in one agent RPC (no N+1).
-        let result: serde_json::Value = self
-            .call(
-                "mq_list_consumer_groups",
-                serde_json::json!({
-                    "topic": topic.topic,
-                    "limit": 200,
-                    "offset": 0,
-                    "enrich": false,
-                    "includeLag": true,
-                }),
-            )
-            .await?;
-        let groups = result.get("groups").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-        Ok(groups.iter().map(rocketmq_subscription_from_group).collect())
+        self.list_all_topic_consumer_groups(&topic.topic, false).await
     }
 
     async fn enrich_subscriptions(&self, topic: &TopicRef) -> Result<Vec<SubscriptionInfo>, String> {
@@ -403,19 +397,7 @@ impl MessageQueueAdmin for RocketMqAdmin {
         }
 
         // Topic path: skip list enrich; batch lag in one agent RPC (no N+1).
-        let mut params = serde_json::json!({
-            "limit": 500,
-            "offset": 0,
-            "enrich": true,
-        });
-        if !topic.topic.is_empty() {
-            params["topic"] = serde_json::json!(topic.topic);
-            params["limit"] = serde_json::json!(200);
-            params["includeLag"] = serde_json::json!(true);
-        }
-        let result: serde_json::Value = self.call("mq_list_consumer_groups", params).await?;
-        let groups = result.get("groups").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-        Ok(groups.iter().map(rocketmq_subscription_from_group).collect())
+        self.list_all_topic_consumer_groups(&topic.topic, true).await
     }
 
     async fn create_subscription(&self, _topic: &TopicRef, _sub: &str, _pos: ResetPosition) -> Result<(), String> {
@@ -790,6 +772,16 @@ fn rocketmq_cluster_consumer_group_page_params(offset: usize, enrich: bool) -> s
         "limit": CONSUMER_GROUP_LIST_PAGE_SIZE,
         "offset": offset,
         "enrich": enrich,
+    })
+}
+
+fn rocketmq_topic_consumer_group_page_params(topic: &str, offset: usize, enrich: bool) -> serde_json::Value {
+    serde_json::json!({
+        "topic": topic,
+        "limit": CONSUMER_GROUP_LIST_PAGE_SIZE,
+        "offset": offset,
+        "enrich": enrich,
+        "includeLag": true,
     })
 }
 
@@ -1463,6 +1455,37 @@ mod tests {
         let enriched = rocketmq_cluster_consumer_group_page_params(500, true);
         assert_eq!(enriched.get("offset").and_then(|value| value.as_u64()), Some(500));
         assert_eq!(enriched.get("enrich").and_then(|value| value.as_bool()), Some(true));
+    }
+
+    #[tokio::test]
+    async fn topic_consumer_group_pagination_loads_list_and_enrich_pages() {
+        let groups: Vec<serde_json::Value> = (1..=201)
+            .map(|index| serde_json::json!({ "groupId": format!("group-{index:04}"), "groupType": "NORMAL" }))
+            .collect();
+        let total = groups.len();
+
+        for enrich in [false, true] {
+            let mut offsets = Vec::new();
+            let subscriptions = collect_paginated_consumer_group_pages(|offset| {
+                offsets.push(offset);
+                let params = rocketmq_topic_consumer_group_page_params("orders", offset, enrich);
+                assert_eq!(params.get("topic").and_then(|value| value.as_str()), Some("orders"));
+                assert_eq!(params.get("limit").and_then(|value| value.as_i64()), Some(500));
+                assert_eq!(params.get("offset").and_then(|value| value.as_u64()), Some(offset as u64));
+                assert_eq!(params.get("enrich").and_then(|value| value.as_bool()), Some(enrich));
+                assert_eq!(params.get("includeLag").and_then(|value| value.as_bool()), Some(true));
+
+                let end = offset.saturating_add(200).min(total);
+                let page = groups[offset..end].to_vec();
+                async move { Ok(serde_json::json!({ "groups": page, "total": total })) }
+            })
+            .await
+            .expect("topic consumer group pages should be collected");
+
+            assert_eq!(offsets, vec![0, 200]);
+            assert_eq!(subscriptions.len(), 201);
+            assert_eq!(subscriptions[200].name, "group-0201");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 背景

修复 #7754。

RocketMQ 在 topic 维度查询消费者组时，Rust adapter 原先只请求
`offset=0、limit=200` 的第一页，因此单个 topic 关联超过 200 个消费者组时，
第 201 条及之后的数据不会进入已加载列表，本地搜索也无法命中。

该问题是 #7736 修复的 cluster-wide consumer group 分页问题在
topic-specific 路径上的同类问题。

## 根因

RocketMQ agent 已支持 `offset` / `limit` 并返回 `total`，
但 topic-specific `list_subscriptions()` 与 `enrich_subscriptions()`
都只进行了单次 RPC。

因此 topic consumer groups 在 200 条处被截断。

## 修改

- topic-specific consumer group 查询复用现有分页聚合逻辑。
- 根据 agent 返回的 `total` 持续加载后续分页。
- 使用实际返回行数推进 `offset`，兼容 agent 单页返回数量小于请求 limit 的情况。
- 保留 topic / includeLag / enrich 参数语义。
- 复用现有 collector 对空页、重复页和异常 offset 的保护，避免死循环或重复结果。
- 移除 topic enrich 路径中已无实际意义的固定 limit 初始化。
- 保持现有排序和其他 MQ 行为不变。

## 测试

- `cargo test -p dbx-core consumer_group_pagination --lib` ✅（4 passed；使用本机既有 Rust/OpenSSL workaround）
- `cargo test -p dbx-core rocketmq --lib` ✅（24 passed；使用本机既有 Rust/OpenSSL workaround）
- `go test ./...`（`agents/drivers/rocketmq`）✅
- `rustfmt --edition 2021 --check crates/dbx-core/src/mq/adapters/rocketmq.rs` ✅
- `git diff --check` ✅

回归测试覆盖超过 200 条、实际 page size 小于请求 limit、list/enrich 两种 topic 参数、空页、重复页及现有排序/去重行为。

## 影响范围

仅影响 RocketMQ topic-specific consumer group 列表与 enrichment 分页。
不改变 Kafka 或其他 MQ adapter 行为；现有前端本地搜索无需修改即可命中后续分页加载的 group。

Closes #7754
