### PR TITLE
improve: 统一侧边栏刷新快捷键

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -119,7 +119,7 @@ import { copyDisplayPathForTreeNode, copyNameForTreeNode, isDirectNavigationTree
 import { customTypeCapabilities, supportsTypeObjectSource } from "@/lib/database/databaseObjectCapabilities";
 import { mongoCollectionTableTypeFromNode, mongoCreateDatabasePreview, mongoDropIndexFailureCount } from "@/lib/sidebar/mongoCollectionMutation";
 import { dataTabOpenModeFromTreeClick, type DataTabOpenMode } from "@/lib/sidebar/dataTabOpenPolicy";
-import { isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut } from "@/lib/editor/keyboardShortcuts";
+import { isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isModRShortcut, isPasteSidebarSelectionShortcut } from "@/lib/editor/keyboardShortcuts";
 import { handleSidebarTreeDeleteShortcut } from "@/lib/sidebar/sidebarTreeDeleteShortcut";
 import { dataTableDoubleClickAction } from "@/lib/tabs/dataTabActivation";
 import { attachedDatabaseNameFromPath, buildCreateDatabaseSql, buildDuckDbAttachDatabaseSql, buildSqliteAttachDatabaseSql, supportsCreateDatabaseCharset, uniqueAttachedDatabaseName } from "@/lib/database/createDatabaseSql";
@@ -1145,7 +1145,7 @@ function onKeydown(event: KeyboardEvent) {
     event.stopPropagation();
     return;
   }
-  if (!event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && event.key === "F5") {
+  if (isModRShortcut(event) || (!event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && event.key === "F5")) {
     if (!requestRefreshSelectedNode()) return;
     event.preventDefault();
     event.stopPropagation();


### PR DESCRIPTION
## 问题

侧边栏表、数据库或 Schema 节点使用 `F5` 刷新，而进入表数据页面后使用 `Ctrl/Cmd+R` 刷新，快捷键体验不一致。

## 原因

侧边栏树节点在 `SidebarTreeRuntimeHost` 中单独处理 `F5`，表数据网格的 `Ctrl/Cmd+R` 则由全局快捷键按当前页面上下文处理。若直接全局改写，会影响 SQL 编辑器中的替换和单元格详情中的搜索功能。

## 修复

- 侧边栏可刷新的节点同时支持 `F5` 和 `Ctrl/Cmd+R`
- 保留表数据页面现有的 `F5` 和 `Ctrl/Cmd+R` 刷新行为
- 保留 SQL 编辑器中 `Ctrl/Cmd+R` 的替换功能，以及单元格详情中的搜索功能

## 验证

- `git diff --check` 通过
- 当前工作树前端依赖链接不完整，Vitest、oxfmt 和类型检查未能启动
