### PR TITLE
fix(sql-file): preserve mysql statement boundaries

### DIFF
--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -1671,11 +1671,15 @@ pub fn optimize_sql_file_import_statements(
                 });
             }
             SqlFileStatementAction::Execute(sql) => {
-                let options = db_type.map(SqlParsingOptions::for_database_type).unwrap_or_default();
                 // Combining separate MySQL INSERT statements changes session
                 // semantics such as LAST_INSERT_ID(), so execute them with the
                 // same statement boundaries as the source file.
-                let mergeable_insert = merge_adjacent_inserts.then(|| parse_mergeable_insert(&sql, options)).flatten();
+                let mergeable_insert = merge_adjacent_inserts
+                    .then(|| {
+                        let options = db_type.map(SqlParsingOptions::for_database_type).unwrap_or_default();
+                        parse_mergeable_insert(&sql, options)
+                    })
+                    .flatten();
                 if let Some(insert) = mergeable_insert {
                     match pending_insert.as_mut() {
                         Some(batch) if batch.can_accept(&insert) => batch.push(insert),

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -1651,6 +1651,8 @@ pub fn optimize_sql_file_import_statements(
 ) -> Vec<SqlFileImportStatement> {
     let mut optimized = Vec::new();
     let mut pending_insert: Option<PendingInsertBatch> = None;
+    let merge_adjacent_inserts =
+        db_type.as_ref().is_none_or(|db_type| !is_mysql_compatible_import_target(db_type, driver_profile));
 
     for statement in statements {
         let action = db_type
@@ -1670,7 +1672,11 @@ pub fn optimize_sql_file_import_statements(
             }
             SqlFileStatementAction::Execute(sql) => {
                 let options = db_type.map(SqlParsingOptions::for_database_type).unwrap_or_default();
-                if let Some(insert) = parse_mergeable_insert(&sql, options) {
+                // Combining separate MySQL INSERT statements changes session
+                // semantics such as LAST_INSERT_ID(), so execute them with the
+                // same statement boundaries as the source file.
+                let mergeable_insert = merge_adjacent_inserts.then(|| parse_mergeable_insert(&sql, options)).flatten();
+                if let Some(insert) = mergeable_insert {
                     match pending_insert.as_mut() {
                         Some(batch) if batch.can_accept(&insert) => batch.push(insert),
                         Some(_) => {
@@ -3191,19 +3197,56 @@ mod tests {
     }
 
     #[test]
-    fn optimizes_adjacent_single_row_inserts_into_multi_row_insert() {
+    fn optimizes_adjacent_postgres_single_row_inserts_into_multi_row_insert() {
         let statements = vec![
             "INSERT INTO users (id, name) VALUES (1, 'Ada')".to_string(),
             "insert into users (id, name) values (2, 'Linus')".to_string(),
             "SELECT 1".to_string(),
         ];
 
-        let optimized = optimize_sql_file_import_statements(&statements, Some(DatabaseType::Mysql), None);
+        let optimized = optimize_sql_file_import_statements(&statements, Some(DatabaseType::Postgres), None);
 
         assert_eq!(optimized.len(), 2);
         assert_eq!(optimized[0].source_statement_count, 2);
         assert_eq!(optimized[0].sql, "INSERT INTO users (id, name) VALUES\n(1, 'Ada'),\n(2, 'Linus')");
         assert_eq!(optimized[1].sql, "SELECT 1");
+    }
+
+    #[test]
+    fn keeps_mysql_insert_statements_separate_to_preserve_session_semantics() {
+        let statements = vec![
+            "INSERT INTO parents (name) VALUES ('first')".to_string(),
+            "INSERT INTO parents (name) VALUES ('second')".to_string(),
+            "INSERT INTO children (parent_id) VALUES (LAST_INSERT_ID())".to_string(),
+        ];
+
+        for (db_type, driver_profile) in
+            [(DatabaseType::Mysql, None), (DatabaseType::Jdbc, Some("mariadb")), (DatabaseType::Doris, None)]
+        {
+            let optimized = optimize_sql_file_import_statements(&statements, Some(db_type), driver_profile);
+
+            assert_eq!(optimized.len(), 3, "{db_type:?}/{driver_profile:?}");
+            assert!(
+                optimized.iter().all(|statement| statement.source_statement_count == 1),
+                "{db_type:?}/{driver_profile:?}"
+            );
+            assert_eq!(
+                optimized.iter().map(|statement| statement.sql.as_str()).collect::<Vec<_>>(),
+                statements,
+                "{db_type:?}/{driver_profile:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_existing_mysql_multi_row_insert_unchanged() {
+        let statements = vec!["INSERT INTO users (id) VALUES (1), (2)".to_string()];
+
+        let optimized = optimize_sql_file_import_statements(&statements, Some(DatabaseType::Mysql), None);
+
+        assert_eq!(optimized.len(), 1);
+        assert_eq!(optimized[0].source_statement_count, 1);
+        assert_eq!(optimized[0].sql, statements[0]);
     }
 
     #[test]
@@ -3221,7 +3264,7 @@ mod tests {
     }
 
     #[test]
-    fn optimized_sql_file_import_keeps_skipped_mysql_dump_statements() {
+    fn mysql_dump_import_keeps_skips_and_insert_statement_boundaries() {
         let statements = vec![
             "LOCK TABLES `users` WRITE".to_string(),
             "INSERT INTO `users` VALUES (1)".to_string(),
@@ -3231,10 +3274,11 @@ mod tests {
 
         let optimized = optimize_sql_file_import_statements(&statements, Some(DatabaseType::Mysql), None);
 
-        assert_eq!(optimized.len(), 3);
+        assert_eq!(optimized.len(), 4);
         assert_eq!(optimized[0].kind, super::SqlFileImportStatementKind::Skip);
-        assert_eq!(optimized[1].source_statement_count, 2);
-        assert_eq!(optimized[2].kind, super::SqlFileImportStatementKind::Skip);
+        assert_eq!(optimized[1].source_statement_count, 1);
+        assert_eq!(optimized[2].source_statement_count, 1);
+        assert_eq!(optimized[3].kind, super::SqlFileImportStatementKind::Skip);
     }
 
     #[test]

--- a/crates/dbx-core/tests/live_mysql57.rs
+++ b/crates/dbx-core/tests/live_mysql57.rs
@@ -1220,6 +1220,91 @@ INSERT INTO install_check (id) VALUES (1), (2);
 
 #[tokio::test]
 #[ignore = "requires DBX_LIVE_SQL_FILE_MYSQL_* env vars pointing at a writable MySQL connection without a required default database"]
+async fn live_sql_file_import_preserves_last_insert_id_across_adjacent_inserts() {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let connection_id = format!("sql-file-order-{suffix}");
+    let config = live_mysql_sql_file_config(&connection_id);
+    let (state, db_path) = app_state_with_config(config.clone()).await;
+    let database_name = format!("dbx_issue_7738_{suffix}");
+    let script = format!(
+        r#"
+CREATE DATABASE `{database_name}`;
+USE `{database_name}`;
+CREATE TABLE parents (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(32) NOT NULL
+);
+CREATE TABLE children (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    parent_id INT NOT NULL,
+    CONSTRAINT fk_parent FOREIGN KEY (parent_id) REFERENCES parents(id)
+);
+INSERT INTO parents (name) VALUES ('first');
+INSERT INTO parents (name) VALUES ('second');
+DELETE FROM parents WHERE name = 'first';
+INSERT INTO children (parent_id) VALUES (LAST_INSERT_ID());
+"#
+    );
+    let request = SqlFileRequest {
+        execution_id: format!("exec-{suffix}"),
+        connection_id: config.id.clone(),
+        database: String::new(),
+        file_path: std::env::temp_dir()
+            .join(format!("issue-7738-mysql-order-{suffix}.sql"))
+            .to_string_lossy()
+            .into_owned(),
+        continue_on_error: false,
+    };
+
+    let _ = execute_sql_statement(
+        &state,
+        &config.id,
+        "",
+        &format!("DROP DATABASE IF EXISTS `{database_name}`"),
+        None,
+        None,
+    )
+    .await;
+
+    tokio::fs::write(&request.file_path, &script).await.unwrap();
+    let result = execute_sql_file_path(
+        &state,
+        &request,
+        std::path::Path::new(&request.file_path),
+        CancellationToken::new(),
+        std::time::Instant::now(),
+        |_| {},
+    )
+    .await;
+    let verify = execute_sql_statement(
+        &state,
+        &config.id,
+        &database_name,
+        "SELECT p.name FROM children c JOIN parents p ON p.id = c.parent_id",
+        None,
+        None,
+    )
+    .await;
+    let _ = execute_sql_statement(
+        &state,
+        &config.id,
+        "",
+        &format!("DROP DATABASE IF EXISTS `{database_name}`"),
+        None,
+        None,
+    )
+    .await;
+    let _ = std::fs::remove_file(db_path);
+    let _ = std::fs::remove_file(&request.file_path);
+
+    result.expect("SQL file import should preserve LAST_INSERT_ID() semantics between statements");
+    let verify = verify.expect("verify the child references the second inserted parent");
+    assert_eq!(verify.columns, vec!["name"]);
+    assert_eq!(verify.rows, vec![vec![serde_json::json!("second")]]);
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_LIVE_SQL_FILE_MYSQL_* env vars pointing at a writable MySQL connection without a required default database"]
 async fn live_sql_file_import_preserves_raw_mysql_binary_literal_bytes() {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let config = live_mysql_sql_file_config(&format!("sql-file-binary-{suffix}"));


### PR DESCRIPTION
## Summary

- preserve source statement boundaries for MySQL-compatible SQL file imports instead of merging separate single-row `INSERT` statements
- keep PostgreSQL insert batching and existing source multi-row `INSERT` statements unchanged
- add unit coverage for MySQL, MariaDB-profile JDBC, Doris, dump controls, and multi-row passthrough
- add a real MySQL regression test for `LAST_INSERT_ID()` dependent statements

## Root cause

The SQL file optimizer combined adjacent compatible MySQL `INSERT` statements into one multi-row statement. Execution remained sequential, but the merge changed session semantics: after two auto-increment inserts, `LAST_INSERT_ID()` referred to the first row of the merged statement instead of the second source statement. A later dependent insert could then fail even though the same SQL executed statement-by-statement in the editor succeeded.

## Verification

- reproduced on MySQL 8 before the fix: the regression script failed with foreign-key `ERROR 1452`
- verified the same script after the fix: import succeeded and the child referenced the second parent
- `cargo test -p dbx-core --no-default-features --features sqlite-bundled --lib` focused SQL import tests
- ignored live MySQL regression and existing create/use/import live test
- `make cargo-check-fast`
- scoped `rustfmt --check` and `git diff --check`

The full fast suite was also attempted. Its SQL import tests passed, while unrelated existing MCP pnpm-fixture tests failed; a separate `query.rs` external-driver timeout was reproduced unchanged on the exact upstream main base.

Closes #7738