### PR TITLE
improve：区分 SQL 文件与 SQL 库的保存提示

### DIFF
--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -133,7 +133,11 @@ const supportsExPaste = computed(() => supportsSqlInListPaste(props.activeConnec
 const supportsTransaction = computed(() => supportsTransactionFeature(props.activeConnection?.db_type));
 const hasDefaultDatabaseOption = computed(() => activeDatabaseOptions.value.includes(""));
 const schemaDatabaseKey = computed(() => props.activeTab.database || (isSingleDb.value ? "_" : ""));
-const saveTooltip = computed(() => (props.activeTab.objectSource ? t("objects.saveSource") : t("toolbar.saveSql")));
+const saveTooltip = computed(() => {
+  if (props.activeTab.objectSource) return t("objects.saveSource");
+  if (props.activeTab.externalSqlPath) return t("toolbar.saveSqlFile");
+  return t("toolbar.saveSql");
+});
 const executeShortcutDisplay = computed(() => formatShortcutDisplay(settingsStore.editorSettings.shortcuts.executeSql));
 const executeShortcutTooltip = computed(() => t("toolbar.executeShortcut", { shortcut: executeShortcutDisplay.value }));
 // executableSql 在无选区时可能是整篇文档；只要有 DML 语句出现就显示预览按钮，

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -173,6 +173,7 @@ export default {
     previewQuery: "Preview query",
     hidePreviewSql: "Hide SQL Preview",
     saveSql: "Save to SQL Library",
+    saveSqlFile: "Save to Original File",
     openSql: "Open SQL file",
     exPasteSqlInCondition: "ExPaste: paste as IN condition",
     theme: "Theme",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -175,6 +175,7 @@ export default withEnglishFallback({
     previewQuery: "Vista previa de la consulta",
     hidePreviewSql: "Ocultar vista previa de SQL",
     saveSql: "Guardar en biblioteca SQL",
+    saveSqlFile: "Guardar en el archivo original",
     openSql: "Abrir archivo SQL",
     exPasteSqlInCondition: "ExPaste: pegar como condición IN",
     theme: "Tema",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -174,6 +174,7 @@ export default withEnglishFallback({
     previewQuery: "Anteprima query",
     hidePreviewSql: "Nascondi anteprima SQL",
     saveSql: "Salva nella Libreria SQL",
+    saveSqlFile: "Salva nel file originale",
     openSql: "Apri file SQL",
     exPasteSqlInCondition: "ExPaste: incolla come condizione IN",
     theme: "Tema",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -175,6 +175,7 @@ export default withEnglishFallback({
     previewQuery: "クエリをプレビュー",
     hidePreviewSql: "SQLプレビューを非表示",
     saveSql: "SQLライブラリに保存",
+    saveSqlFile: "元のファイルに保存",
     openSql: "SQLファイルを開く",
     exPasteSqlInCondition: "ExPaste: IN条件として貼り付け",
     theme: "テーマ",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -187,6 +187,7 @@ export default withEnglishFallback({
     updatableDriverCount: "업데이트 가능한 드라이버 수",
     mcpUpdateAvailable: "MCP 서버 업데이트 가능",
     blockDangerousRedisCommands: "위험한 명령 차단",
+    saveSqlFile: "원본 파일에 저장",
   },
   multiDbExecute: {
     title: "다중 데이터베이스 실행",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -175,6 +175,7 @@ export default withEnglishFallback({
     previewQuery: "Visualizar consulta",
     hidePreviewSql: "Ocultar Visualização SQL",
     saveSql: "Salvar na Biblioteca SQL",
+    saveSqlFile: "Salvar no arquivo original",
     openSql: "Abrir arquivo SQL",
     exPasteSqlInCondition: "ExPaste: colar como condição IN",
     theme: "Tema",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -98,6 +98,7 @@ export default withEnglishFallback({
     previewQuery: "预览查询",
     hidePreviewSql: "隐藏 SQL 预览",
     saveSql: "保存到 SQL 库",
+    saveSqlFile: "保存到原文件",
     openSql: "打开 SQL 文件",
     exPasteSqlInCondition: "ExPaste：粘贴为 IN 条件",
     theme: "主题",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -175,6 +175,7 @@ export default withEnglishFallback({
     previewQuery: "預覽查詢",
     hidePreviewSql: "隱藏 SQL 預覽",
     saveSql: "儲存到 SQL 庫",
+    saveSqlFile: "儲存到原始檔案",
     openSql: "開啟 SQL 檔案",
     exPasteSqlInCondition: "ExPaste：貼上為 IN 條件",
     theme: "主題",


### PR DESCRIPTION
## 问题
打开本地 SQL 文件时，保存按钮仍显示“保存到 SQL 库”，但实际操作会覆盖原始 SQL 文件，提示与行为不一致。

## 处理
- 打开本地 SQL 文件时显示“保存到原文件”
- SQL 库脚本继续显示“保存到 SQL 库”
- 保留对象源码标签的原有保存提示
- 补齐中、英、西、意、日、葡萄牙语及繁体中文文案

## 验证
- `oxfmt --check` 通过
- `vitest run apps/desktop/src/lib/common/__tests__/searchableSelectLayout.spec.ts`：4/4 通过
- `pnpm typecheck` 通过