### PR TITLE
Fix：备份历史支持删除 .sql.gz 文件

### DIFF
--- a/src-tauri/src/commands/fs_open.rs
+++ b/src-tauri/src/commands/fs_open.rs
@@ -92,12 +92,11 @@ fn validate_database_backup_file(raw: &str) -> Result<PathBuf, String> {
     if !path.is_absolute() {
         return Err(format!("backup file path is not absolute: {expanded}"));
     }
-    if path.extension().and_then(|extension| extension.to_str()).map(|extension| extension.eq_ignore_ascii_case("sql"))
-        != Some(true)
-    {
-        return Err(format!("backup file must use the .sql extension: {expanded}"));
-    }
     let file_name = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+    let lower_file_name = file_name.to_ascii_lowercase();
+    if !(lower_file_name.ends_with(".sql") || lower_file_name.ends_with(".sql.gz")) {
+        return Err(format!("backup file must use the .sql or .sql.gz extension: {expanded}"));
+    }
     if !file_name.starts_with("dbx-backup__") {
         return Err(format!("backup file name is not managed by DBX: {expanded}"));
     }
@@ -164,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn database_backup_file_requires_absolute_sql_path() {
+    fn database_backup_file_requires_absolute_managed_sql_path() {
         assert!(validate_database_backup_file("relative/backup.sql").is_err());
         let invalid_extension = if cfg!(windows) { "C:/tmp/backup.txt" } else { "/tmp/backup.txt" };
         assert!(validate_database_backup_file(invalid_extension).is_err());
@@ -172,6 +171,20 @@ mod tests {
         assert!(validate_database_backup_file(unmanaged).is_err());
         let valid = if cfg!(windows) { "C:/tmp/dbx-backup__nightly.SQL" } else { "/tmp/dbx-backup__nightly.SQL" };
         assert!(validate_database_backup_file(valid).is_ok());
+        let valid_gzip =
+            if cfg!(windows) { "C:/tmp/dbx-backup__nightly.SQL.GZ" } else { "/tmp/dbx-backup__nightly.SQL.GZ" };
+        assert!(validate_database_backup_file(valid_gzip).is_ok());
+    }
+
+    #[tokio::test]
+    async fn managed_gzip_backup_file_can_be_deleted() {
+        let path = std::env::temp_dir().join(format!("dbx-backup__delete-test-{}.sql.gz", uuid::Uuid::new_v4()));
+        std::fs::write(&path, b"gzip placeholder").unwrap();
+
+        let deleted = delete_database_backup_files(vec![path.to_string_lossy().to_string()]).await.unwrap();
+
+        assert_eq!(deleted, 1);
+        assert!(!path.exists());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Fixes #7786

启用 Gzip 压缩的数据库备份会生成 `.sql.gz` 文件，但在备份历史中删除该文件时，后端路径校验仍只允许 `.sql`，导致删除失败：

```text
backup file must use the .sql extension: ...sql.gz
```

## 修复

- 备份文件删除校验现在同时接受 `.sql` 和 `.sql.gz` 扩展名，并保持大小写不敏感。
- 保留绝对路径和 `dbx-backup__` 文件名前缀校验，其他扩展名和非 DBX 文件仍会被拒绝。
- 增加压缩备份文件实际创建、删除并确认文件消失的回归测试。

## 验证

- [ ] `make check` 通过（未运行）
- [ ] `make cargo-check-fast` 通过（未运行）
- [x] 相关测试通过

已执行：

- `cargo test -p dbx --lib commands::fs_open`：10 passed，0 failed
- `cargo check -p dbx`：通过
- `rustfmt --edition 2021 --check src-tauri/src/commands/fs_open.rs`：通过
- `git diff --check`：通过

## 关联 Issue

Closes #7786
