### PR TITLE
🐛 fix(grid): 支持条件与文本筛选视图切换面板开关

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -5991,7 +5991,7 @@ onUnmounted(() => {
                     <div class="flex h-8 min-w-0 items-center gap-2 border-t bg-background/35 px-2 text-[11px]">
                       <span class="shrink-0 text-muted-foreground">{{ t("grid.filterSqlPreview") }}</span>
                       <code class="min-w-0 flex-1 truncate rounded bg-muted/35 px-1.5 py-0.5">WHERE status = 'ACTIVE'</code>
-                      <span class="shrink-0 rounded bg-primary px-2 py-1 text-primary-foreground">{{ t("grid.applyFilter") }}</span>
+                      <span class="shrink-0 text-muted-foreground/70">{{ t("grid.applyFilter") }}</span>
                     </div>
                   </div>
 
@@ -6009,7 +6009,7 @@ onUnmounted(() => {
                     <div class="flex h-8 min-w-0 items-center gap-2 border-t bg-background/45 px-2 text-[11px]">
                       <span class="shrink-0 text-muted-foreground">{{ t("grid.filterSqlPreview") }}</span>
                       <code class="min-w-0 flex-1 truncate">WHERE status = 'ACTIVE'</code>
-                      <span class="shrink-0 rounded bg-primary px-2 py-1 text-primary-foreground">{{ t("grid.applyFilter") }}</span>
+                      <span class="shrink-0 text-muted-foreground/70">{{ t("grid.applyFilter") }}</span>
                     </div>
                   </div>
                 </div>

--- a/apps/desktop/src/components/editor/__tests__/EditorSettingsDialog.previewPosition.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/EditorSettingsDialog.previewPosition.spec.ts
@@ -169,6 +169,8 @@ describe("EditorSettingsDialog live preview placement", () => {
     expect(dataSection).toContain("data-data-grid-filter-preview-quick");
     expect(dataSection).toContain("data-data-grid-filter-preview-conditions");
     expect(dataSection).toContain("data-data-grid-filter-preview-text");
+    expect(dataSection.match(/text-muted-foreground\/70">\{\{ t\("grid.applyFilter"\) \}\}/g)).toHaveLength(2);
+    expect(dataSection).not.toContain('rounded bg-primary px-2 py-1 text-primary-foreground">{{ t("grid.applyFilter") }}');
     expect(dataSection.match(/editDataGridFilterEditorView = '(quick|conditions|text)'/g)).toHaveLength(3);
     expect(dataSection).not.toContain('<SelectTrigger id="data-grid-filter-view"');
 

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -12713,7 +12713,7 @@ function openGridSnapshot() {
           </DataGridToolbar>
         </div>
         <DataGridFilterWorkbench
-          v-if="canUseWhereSearch && filterEditorView === 'conditions'"
+          v-if="canUseWhereSearch && filterEditorView === 'conditions' && filterBuilderOpen"
           :sql-preview="filterSqlPreview"
           :rules="structuredFilterRules"
           :columns="filterBuilderColumnOptions"
@@ -12733,7 +12733,7 @@ function openGridSnapshot() {
           @update-rule="updateStructuredFilterRule"
         />
         <DataGridTextFilterWorkbench
-          v-if="canUseWhereSearch && filterEditorView === 'text'"
+          v-if="canUseWhereSearch && filterEditorView === 'text' && filterBuilderOpen"
           :height="settingsStore.editorSettings.dataGridTextFilterPanelHeight"
           :sql-preview="filterSqlPreview"
           :rules="structuredFilterRules"

--- a/apps/desktop/src/components/grid/DataGridQueryControls.vue
+++ b/apps/desktop/src/components/grid/DataGridQueryControls.vue
@@ -134,6 +134,13 @@ async function openPendingFirstEmptyRuleColumnSearch() {
 }
 
 async function handleFilterButtonClick() {
+  if (props.filterEditorView !== "quick") {
+    const nextOpen = !props.filterBuilderOpen;
+    emit("update:filterBuilderOpen", nextOpen);
+    if (nextOpen) emit("ensureRule");
+    return;
+  }
+
   const shouldFocusColumnSearch = !props.filterBuilderOpen && props.rules.every((rule) => !rule.columnName);
   pendingFirstEmptyRuleColumnSearch.value = shouldFocusColumnSearch;
   emit("ensureRule");
@@ -158,6 +165,7 @@ onUnmounted(onResizeEnd);
               class="relative flex h-5 w-5 -translate-x-1 shrink-0 items-center justify-center rounded border text-[11px] font-medium transition-colors"
               :class="filterButtonActive ? 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/15' : 'border-border/70 text-muted-foreground hover:bg-accent hover:text-foreground'"
               :disabled="!canUseWhereSearch"
+              :aria-label="t('grid.filter')"
               @click="handleFilterButtonClick"
             >
               <Filter class="h-3 w-3" />
@@ -212,6 +220,19 @@ onUnmounted(onResizeEnd);
           </PopoverContent>
         </Popover>
       </template>
+      <button
+        v-else
+        type="button"
+        class="relative flex h-5 w-5 -translate-x-1 shrink-0 items-center justify-center rounded border text-[11px] font-medium transition-colors"
+        :class="filterButtonActive ? 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/15' : 'border-border/70 text-muted-foreground hover:bg-accent hover:text-foreground'"
+        :disabled="!canUseWhereSearch"
+        :aria-label="t('grid.filter')"
+        :aria-expanded="filterBuilderOpen"
+        @click="handleFilterButtonClick"
+      >
+        <Filter class="h-3 w-3" />
+        <span v-if="filterButtonCount" class="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] leading-none text-primary-foreground">{{ filterButtonCount }}</span>
+      </button>
       <DataGridConditionEditor
         :model-value="whereInput"
         kind="where"

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -1144,7 +1144,9 @@ describe("DataGridQueryControls", () => {
     expect(applyFilters).toHaveBeenCalledOnce();
   });
 
-  it("keeps view selection out of the data grid controls", async () => {
+  it("keeps the filter toggle available when switching filter views", async () => {
+    const updateFilterBuilderOpen = vi.fn();
+    const ensureRule = vi.fn();
     const mounted = mountComponent(DataGridQueryControls, {
       whereInput: "",
       orderByInput: "",
@@ -1168,16 +1170,26 @@ describe("DataGridQueryControls", () => {
       applyWhere: vi.fn(),
       applyOrderBy: vi.fn(),
       clearOrderBy: vi.fn(),
+      "onUpdate:filterBuilderOpen": updateFilterBuilderOpen,
+      onEnsureRule: ensureRule,
     });
 
     expect(hostText(mounted.root)).not.toContain("grid.filterQuickView");
     expect(hostText(mounted.root)).not.toContain("grid.filterConditionView");
-    expect(findAll(mounted.root, (node) => node.type === "button" && String(node.props.class).includes("-translate-x-1"))).toHaveLength(1);
+    const quickFilterButtons = findAll(mounted.root, (node) => node.type === "button" && String(node.props.class).includes("-translate-x-1"));
+    expect(quickFilterButtons).toHaveLength(1);
+    expect(quickFilterButtons[0].props["aria-label"]).toBe("grid.filter");
 
     await mounted.setProps({ filterEditorView: "conditions", filterBuilderOpen: false });
     await nextTick();
     expect(findOne(mounted.root, (node) => node.type === "textarea" && node.props.placeholder === "WHERE")).toBeTruthy();
-    expect(findAll(mounted.root, (node) => node.type === "button" && String(node.props.class).includes("-translate-x-1"))).toHaveLength(0);
+    const filterButtons = findAll(mounted.root, (node) => node.type === "button" && String(node.props.class).includes("-translate-x-1"));
+    expect(filterButtons).toHaveLength(1);
+    expect(filterButtons[0].props["aria-label"]).toBe("grid.filter");
+    expect(filterButtons[0].props["aria-expanded"]).toBe(false);
+    dispatch(filterButtons[0], "click");
+    expect(updateFilterBuilderOpen).toHaveBeenCalledWith(true);
+    expect(ensureRule).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
- 在非快捷筛选视图保留筛选按钮，可展开或收起筛选编辑器
- 仅在筛选面板展开时渲染条件和文本筛选工作台
- 调整设置预览中的应用筛选按钮样式，避免误导为可交互控件
- 补充筛选按钮无障碍属性及相关测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="3044" height="580" alt="198350D7-202F-4071-A3AE-77F0B2169628" src="https://github.com/user-attachments/assets/7cc00e69-d599-44f5-96a5-98645aa8e505" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #7747