### PR TITLE
Fix：左侧全局搜索支持折叠节点

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -317,23 +317,18 @@ watch([deferredSearchQuery, regexMode], ([newQuery, isRegexMode], [oldQuery, was
     }
     return;
   }
-  const tasks: Promise<void>[] = [];
   const preservesSearchSubtree = newQuery ? createSidebarSearchSubtreePreserver(newQuery, searchableNodeTypes.value) : undefined;
-  for (const root of store.treeNodes) {
-    collectExpandedObjectSearchTargets(root, tasks, newQuery ? searchRefreshedNodeIds : undefined, preservesSearchSubtree);
-  }
-  if (!newQuery && oldQuery) {
-    searchExpansionState.clear();
-  }
+  const restoreTasks = !newQuery && oldQuery ? restoreTrackedSearchTargets() : [];
   let searchGeneration = -1;
-  if (newQuery && tasks.length > 0) {
+  if (newQuery) {
     searchGeneration = sidebarSearchLoadingTracker.begin();
     isSidebarSearchLoading.value = true;
   } else {
     sidebarSearchLoadingTracker.cancel();
     isSidebarSearchLoading.value = false;
   }
-  void Promise.allSettled(tasks)
+  const searchWork = newQuery ? loadSidebarSearchTargets(newQuery, preservesSearchSubtree) : Promise.allSettled(restoreTasks);
+  void searchWork
     .then(() => {
       if (!newQuery && oldQuery) refreshActiveSidebarTableSearches();
     })
@@ -358,34 +353,66 @@ const searchableObjectGroupTypes = new Set<TreeNodeType>([
   "group-types",
 ]);
 const simpleObjectParentTypes = new Set<TreeNodeType>(["database", "schema", "linked-server-schema"]);
-const simpleObjectChildTypes = new Set<TreeNodeType>(["table", "view", "materialized_view", "procedure", "function", "trigger", "event", "sequence", "synonym", "job", "package", "package-body", "type", "type-body", "load-more"]);
 
 function isSimpleObjectSearchParent(node: TreeNode): boolean {
-  return settingsStore.editorSettings.sidebarObjectDisplay === "simple" && simpleObjectParentTypes.has(node.type) && node.isExpanded === true && (!!node.children?.some((child) => simpleObjectChildTypes.has(child.type)) || !!store.sidebarTableSearchQueries[node.id]?.trim());
+  return settingsStore.editorSettings.sidebarObjectDisplay === "simple" && simpleObjectParentTypes.has(node.type) && node.connectionId != null && node.database != null;
 }
 
-function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>[], refreshedNodeIds?: Set<string>, preservesNodeSubtree?: (node: TreeNode) => boolean, ancestorPreservesSearchSubtree = false) {
+function isSidebarSearchContainer(node: TreeNode): boolean {
+  return simpleObjectParentTypes.has(node.type) && node.connectionId != null && node.database != null;
+}
+
+async function loadSidebarSearchTargets(query: string, preservesNodeSubtree?: (node: TreeNode) => boolean) {
+  if (!query) return;
+  const refreshedNodeIds = searchRefreshedNodeIds;
+  const scheduledNodeIds = new Set<string>();
+  let tasks: Promise<void>[] = [];
+  do {
+    tasks = [];
+    for (const root of store.treeNodes) {
+      collectExpandedObjectSearchTargets(root, tasks, refreshedNodeIds, preservesNodeSubtree, false, scheduledNodeIds);
+    }
+    if (tasks.length === 0) return;
+    await Promise.allSettled(tasks);
+  } while (deferredSearchQuery.value === query && store.sidebarSearchQuery === query);
+}
+
+function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>[], refreshedNodeIds?: Set<string>, preservesNodeSubtree?: (node: TreeNode) => boolean, ancestorPreservesSearchSubtree = false, scheduledNodeIds?: Set<string>) {
   const preservesSearchSubtree = ancestorPreservesSearchSubtree || (!!refreshedNodeIds && !!preservesNodeSubtree?.(node));
   if (refreshedNodeIds && node.type === "connection" && node.connectionId) {
-    if (store.connectedIds.has(node.connectionId)) {
+    if (store.connectedIds.has(node.connectionId) && (!scheduledNodeIds || !scheduledNodeIds.has(node.id))) {
+      scheduledNodeIds?.add(node.id);
       tasks.push(store.loadConnectedConnectionRootForSidebarSearch(node.connectionId));
     }
     if (node.connectionId !== store.activeConnectionId) return;
   }
   if (refreshedNodeIds && isSimpleObjectSearchParent(node)) {
-    if (preservesSearchSubtree) {
-      if (refreshedNodeIds.delete(node.id)) {
-        tasks.push(store.loadTreeNodeChildren(node, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
+    if (!scheduledNodeIds || !scheduledNodeIds.has(node.id)) {
+      scheduledNodeIds?.add(node.id);
+      if (preservesSearchSubtree) {
+        if (refreshedNodeIds.delete(node.id)) {
+          tasks.push(store.loadTreeNodeChildren(node, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
+        }
+      } else {
+        const wasCollapsed = node.isExpanded !== true;
+        refreshedNodeIds.add(node.id);
+        if (wasCollapsed) searchExpansionState.markFiltered(node.id, true);
+        tasks.push(store.refreshTreeNode(node));
       }
-    } else {
-      refreshedNodeIds.add(node.id);
-      tasks.push(store.refreshTreeNode(node));
     }
     return;
   }
-  if (refreshedNodeIds && node.isExpanded && node.children) {
+  if (refreshedNodeIds && isSidebarSearchContainer(node) && !node.children?.length && (!scheduledNodeIds || !scheduledNodeIds.has(node.id))) {
+    scheduledNodeIds?.add(node.id);
+    const wasCollapsed = node.isExpanded !== true;
+    searchExpansionState.markFiltered(node.id, wasCollapsed);
+    tasks.push(store.loadTreeNodeChildren(node, { force: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
+  }
+  if (refreshedNodeIds && node.children) {
     for (const child of node.children) {
       if (child.connectionId && searchableObjectGroupTypes.has(child.type)) {
+        if (scheduledNodeIds?.has(child.id)) continue;
+        scheduledNodeIds?.add(child.id);
         if (preservesSearchSubtree) {
           if (searchExpansionState.markUnfiltered(child.id)) {
             tasks.push(store.loadObjectGroupChildren(child, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
@@ -407,12 +434,18 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>
         tasks.push(store.loadObjectGroupChildren(node, { force: true }));
       }
     } else if (simpleObjectParentTypes.has(node.type)) {
-      tasks.push(store.refreshTreeNode(node));
+      const shouldCollapse = searchAutoExpandedNodeIds.has(node.id);
+      const restore = store.refreshTreeNode(node);
+      tasks.push(
+        restore.then(() => {
+          if (shouldCollapse) node.isExpanded = false;
+        }),
+      );
     }
   }
   if (node.children) {
     for (const child of node.children) {
-      collectExpandedObjectSearchTargets(child, tasks, refreshedNodeIds, preservesNodeSubtree, preservesSearchSubtree);
+      collectExpandedObjectSearchTargets(child, tasks, refreshedNodeIds, preservesNodeSubtree, preservesSearchSubtree, scheduledNodeIds);
     }
   }
 }

--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -382,8 +382,9 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: SidebarSearch
   const preservesSearchSubtree = ancestorPreservesSearchSubtree || (!!refreshedNodeIds && !!preservesNodeSubtree?.(node));
   if (refreshedNodeIds && node.type === "connection" && node.connectionId) {
     if (store.connectedIds.has(node.connectionId) && (!scheduledNodeIds || !scheduledNodeIds.has(node.id))) {
+      const connectionId = node.connectionId;
       scheduledNodeIds?.add(node.id);
-      tasks.push(() => store.loadConnectedConnectionRootForSidebarSearch(node.connectionId));
+      tasks.push(() => store.loadConnectedConnectionRootForSidebarSearch(connectionId));
     }
     if (node.connectionId !== store.activeConnectionId) return;
   }

--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -56,6 +56,7 @@ import { createSidebarTreeRuntime, sidebarTreeRuntimeKey, type SidebarTreeRuntim
 import { createSidebarPasteHandlerRegistry } from "@/lib/sidebar/sidebarPasteHandlerRegistry";
 import { insertSidebarTableSearchControls, isSidebarTableSearchControlNode } from "@/lib/sidebar/sidebarTableSearchControl";
 import { createSidebarTableSearchDebouncer, invalidateSidebarTableSearchBuild, loadOrBuildSidebarTableSearchIndex, scheduleExclusiveSidebarTableSearchDebounce } from "@/lib/sidebar/sidebarTableSearchIndex";
+import { runSidebarSearchTasks, type SidebarSearchTask } from "./sidebarSearchTaskRunner";
 import TreeItem from "./TreeItem.vue";
 import ActiveConnectionFilterButton from "./ActiveConnectionFilterButton.vue";
 import SidebarListOptionsIcon from "./SidebarListOptionsIcon.vue";
@@ -297,7 +298,7 @@ watch([deferredSearchQuery, regexMode], ([newQuery, isRegexMode], [oldQuery, was
     const restoreTasks = restoreTrackedSearchTargets();
     const searchGeneration = sidebarSearchLoadingTracker.begin();
     isSidebarSearchLoading.value = true;
-    void Promise.allSettled([loadRegexTableSearchIndexes(), ...restoreTasks])
+    void Promise.allSettled([loadRegexTableSearchIndexes(), runSidebarSearchTasks(restoreTasks)])
       .then(() => {
         if (restoreTasks.length > 0) refreshActiveSidebarTableSearches();
       })
@@ -311,7 +312,7 @@ watch([deferredSearchQuery, regexMode], ([newQuery, isRegexMode], [oldQuery, was
     isSidebarSearchLoading.value = false;
     const restoreTasks = restoreTrackedSearchTargets();
     if (restoreTasks.length > 0) {
-      void Promise.all(restoreTasks)
+      void runSidebarSearchTasks(restoreTasks)
         .then(() => refreshActiveSidebarTableSearches())
         .catch(() => {});
     }
@@ -327,7 +328,7 @@ watch([deferredSearchQuery, regexMode], ([newQuery, isRegexMode], [oldQuery, was
     sidebarSearchLoadingTracker.cancel();
     isSidebarSearchLoading.value = false;
   }
-  const searchWork = newQuery ? loadSidebarSearchTargets(newQuery, preservesSearchSubtree) : Promise.allSettled(restoreTasks);
+  const searchWork = newQuery ? loadSidebarSearchTargets(newQuery, preservesSearchSubtree) : runSidebarSearchTasks(restoreTasks);
   void searchWork
     .then(() => {
       if (!newQuery && oldQuery) refreshActiveSidebarTableSearches();
@@ -366,23 +367,23 @@ async function loadSidebarSearchTargets(query: string, preservesNodeSubtree?: (n
   if (!query) return;
   const refreshedNodeIds = searchRefreshedNodeIds;
   const scheduledNodeIds = new Set<string>();
-  let tasks: Promise<void>[] = [];
+  let tasks: SidebarSearchTask[] = [];
   do {
     tasks = [];
     for (const root of store.treeNodes) {
       collectExpandedObjectSearchTargets(root, tasks, refreshedNodeIds, preservesNodeSubtree, false, scheduledNodeIds);
     }
     if (tasks.length === 0) return;
-    await Promise.allSettled(tasks);
+    await runSidebarSearchTasks(tasks);
   } while (deferredSearchQuery.value === query && store.sidebarSearchQuery === query);
 }
 
-function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>[], refreshedNodeIds?: Set<string>, preservesNodeSubtree?: (node: TreeNode) => boolean, ancestorPreservesSearchSubtree = false, scheduledNodeIds?: Set<string>) {
+function collectExpandedObjectSearchTargets(node: TreeNode, tasks: SidebarSearchTask[], refreshedNodeIds?: Set<string>, preservesNodeSubtree?: (node: TreeNode) => boolean, ancestorPreservesSearchSubtree = false, scheduledNodeIds?: Set<string>) {
   const preservesSearchSubtree = ancestorPreservesSearchSubtree || (!!refreshedNodeIds && !!preservesNodeSubtree?.(node));
   if (refreshedNodeIds && node.type === "connection" && node.connectionId) {
     if (store.connectedIds.has(node.connectionId) && (!scheduledNodeIds || !scheduledNodeIds.has(node.id))) {
       scheduledNodeIds?.add(node.id);
-      tasks.push(store.loadConnectedConnectionRootForSidebarSearch(node.connectionId));
+      tasks.push(() => store.loadConnectedConnectionRootForSidebarSearch(node.connectionId));
     }
     if (node.connectionId !== store.activeConnectionId) return;
   }
@@ -391,13 +392,13 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>
       scheduledNodeIds?.add(node.id);
       if (preservesSearchSubtree) {
         if (refreshedNodeIds.delete(node.id)) {
-          tasks.push(store.loadTreeNodeChildren(node, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
+          tasks.push(() => store.loadTreeNodeChildren(node, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
         }
       } else {
         const wasCollapsed = node.isExpanded !== true;
         refreshedNodeIds.add(node.id);
         if (wasCollapsed) searchExpansionState.markFiltered(node.id, true);
-        tasks.push(store.refreshTreeNode(node));
+        tasks.push(() => store.refreshTreeNode(node));
       }
     }
     return;
@@ -406,7 +407,7 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>
     scheduledNodeIds?.add(node.id);
     const wasCollapsed = node.isExpanded !== true;
     searchExpansionState.markFiltered(node.id, wasCollapsed);
-    tasks.push(store.loadTreeNodeChildren(node, { force: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
+    tasks.push(() => store.loadTreeNodeChildren(node, { force: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
   }
   if (refreshedNodeIds && node.children) {
     for (const child of node.children) {
@@ -415,11 +416,11 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>
         scheduledNodeIds?.add(child.id);
         if (preservesSearchSubtree) {
           if (searchExpansionState.markUnfiltered(child.id)) {
-            tasks.push(store.loadObjectGroupChildren(child, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
+            tasks.push(() => store.loadObjectGroupChildren(child, { force: true, searchFilter: "", allowGlobalSearchMismatch: true, expectedSidebarSearchQuery: store.sidebarSearchQuery }));
           }
         } else {
           searchExpansionState.markFiltered(child.id, !child.isExpanded);
-          tasks.push(store.loadObjectGroupChildren(child, { force: true }));
+          tasks.push(() => store.loadObjectGroupChildren(child, { force: true }));
         }
       }
     }
@@ -431,16 +432,14 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>
         // instead of reloading and leaving it open.
         node.isExpanded = false;
       } else {
-        tasks.push(store.loadObjectGroupChildren(node, { force: true }));
+        tasks.push(() => store.loadObjectGroupChildren(node, { force: true }));
       }
     } else if (simpleObjectParentTypes.has(node.type)) {
       const shouldCollapse = searchAutoExpandedNodeIds.has(node.id);
-      const restore = store.refreshTreeNode(node);
-      tasks.push(
-        restore.then(() => {
-          if (shouldCollapse) node.isExpanded = false;
-        }),
-      );
+      tasks.push(async () => {
+        await store.refreshTreeNode(node);
+        if (shouldCollapse) node.isExpanded = false;
+      });
     }
   }
   if (node.children) {
@@ -450,9 +449,9 @@ function collectExpandedObjectSearchTargets(node: TreeNode, tasks: Promise<void>
   }
 }
 
-function restoreTrackedSearchTargets(): Promise<void>[] {
+function restoreTrackedSearchTargets(): SidebarSearchTask[] {
   if (!searchExpansionState.hasTrackedNodes()) return [];
-  const tasks: Promise<void>[] = [];
+  const tasks: SidebarSearchTask[] = [];
   for (const root of store.treeNodes) {
     collectExpandedObjectSearchTargets(root, tasks);
   }

--- a/apps/desktop/src/components/sidebar/__tests__/ConnectionTree.collapsedSearch.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/ConnectionTree.collapsedSearch.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { runSidebarSearchTasks } from "../sidebarSearchTaskRunner";
 
 const source = readFileSync(new URL("../ConnectionTree.vue", import.meta.url), "utf8");
 
@@ -17,5 +18,23 @@ describe("ConnectionTree global search loading", () => {
     expect(source).toContain("while (deferredSearchQuery.value === query && store.sidebarSearchQuery === query)");
     expect(source).toContain("const restoreTasks = !newQuery && oldQuery ? restoreTrackedSearchTargets() : [];");
     expect(source).toContain("if (shouldCollapse) node.isExpanded = false;");
+  });
+
+  it("limits concurrent metadata loads without dropping a task", async () => {
+    let activeTasks = 0;
+    let maximumActiveTasks = 0;
+    let completedTasks = 0;
+    const tasks = Array.from({ length: 8 }, () => async () => {
+      activeTasks += 1;
+      maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      activeTasks -= 1;
+      completedTasks += 1;
+    });
+
+    await runSidebarSearchTasks(tasks, 2);
+
+    expect(maximumActiveTasks).toBe(2);
+    expect(completedTasks).toBe(tasks.length);
   });
 });

--- a/apps/desktop/src/components/sidebar/__tests__/ConnectionTree.collapsedSearch.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/ConnectionTree.collapsedSearch.spec.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../ConnectionTree.vue", import.meta.url), "utf8");
+
+describe("ConnectionTree global search loading", () => {
+  it("discovers collapsed database and schema containers before searching object groups", () => {
+    expect(source).toContain("function isSidebarSearchContainer(node: TreeNode)");
+    expect(source).toMatch(/isSidebarSearchContainer\(node\) && !node\.children\?\.length/);
+    expect(source).toContain("store.loadTreeNodeChildren(node, { force: true, expectedSidebarSearchQuery: store.sidebarSearchQuery })");
+    expect(source).toContain("searchExpansionState.markFiltered(node.id, wasCollapsed)");
+    expect(source).toMatch(/if \(refreshedNodeIds && node\.children\) \{[\s\S]*?searchableObjectGroupTypes\.has\(child\.type\)/);
+  });
+
+  it("deduplicates each node within a search round and restores tracked nodes", () => {
+    expect(source).toContain("const scheduledNodeIds = new Set<string>();");
+    expect(source).toContain("while (deferredSearchQuery.value === query && store.sidebarSearchQuery === query)");
+    expect(source).toContain("const restoreTasks = !newQuery && oldQuery ? restoreTrackedSearchTargets() : [];");
+    expect(source).toContain("if (shouldCollapse) node.isExpanded = false;");
+  });
+});

--- a/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
+++ b/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
@@ -18,3 +18,5 @@ export async function runSidebarSearchTasks(
       }
     }
   });
+  await Promise.all(workers);
+}

--- a/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
+++ b/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
@@ -14,8 +14,7 @@ export async function runSidebarSearchTasks(
       const task = tasks[nextTaskIndex++];
       try {
         await task();
-      } catch {
-      }
+      } catch {}
     }
   });
   await Promise.all(workers);

--- a/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
+++ b/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
@@ -1,0 +1,20 @@
+export type SidebarSearchTask = () => Promise<void>;
+
+export const SIDEBAR_SEARCH_TASK_CONCURRENCY = 4;
+
+export async function runSidebarSearchTasks(
+  tasks: readonly SidebarSearchTask[],
+  concurrency = SIDEBAR_SEARCH_TASK_CONCURRENCY,
+): Promise<void> {
+  if (tasks.length === 0) return;
+  const workerCount = Math.min(Math.max(1, concurrency), tasks.length);
+  let nextTaskIndex = 0;
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextTaskIndex < tasks.length) {
+      const task = tasks[nextTaskIndex++];
+      try {
+        await task();
+      } catch {
+      }
+    }
+  });

--- a/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
+++ b/apps/desktop/src/components/sidebar/sidebarSearchTaskRunner.ts
@@ -2,10 +2,7 @@ export type SidebarSearchTask = () => Promise<void>;
 
 export const SIDEBAR_SEARCH_TASK_CONCURRENCY = 4;
 
-export async function runSidebarSearchTasks(
-  tasks: readonly SidebarSearchTask[],
-  concurrency = SIDEBAR_SEARCH_TASK_CONCURRENCY,
-): Promise<void> {
+export async function runSidebarSearchTasks(tasks: readonly SidebarSearchTask[], concurrency = SIDEBAR_SEARCH_TASK_CONCURRENCY): Promise<void> {
   if (tasks.length === 0) return;
   const workerCount = Math.min(Math.max(1, concurrency), tasks.length);
   let nextTaskIndex = 0;


### PR DESCRIPTION
## 问题

左侧连接列表的全局搜索依赖已展开的数据库、Schema 和对象分组。折叠这些节点时，即使对象存在也无法搜到，和用户预期不符。

## 修复

- 全局搜索期间按层级加载已连接的连接、数据库/Schema 和对象分组，支持查找折叠节点中的对象
- 搜索触发的展开状态会在清空搜索后恢复
- 为搜索加载轮次增加节点去重，避免重复请求
- 增加回归测试

## 验证

- MySQL 8.4 测试库中折叠数据库和表分组，搜索 `dbx_perf_large_text_660k`，可定位并显示目标表
- 清空搜索后，节点恢复到搜索前的折叠状态
- 侧边栏测试集：23 个测试文件，82 个测试通过
- 新增聚焦测试：2 个测试通过
- `pnpm typecheck` 通过

## 截图

搜索折叠节点中的表：

![折叠节点全局搜索验证](https://raw.githubusercontent.com/zipg/dbx/pr-assets-7052/assets/issue-7052-collapsed-search.jpg)

## 关联 Issue

Closes #7052
