### PR TITLE
fix: 修复达梦 DISTINCT JOIN 结果无法删除

### DIFF
--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -4432,7 +4432,11 @@ export const useQueryStore = defineStore("query", () => {
       const queryAnalysis = {
         ...target.analysis,
         ...(target.analysis.distinct && canInsertIntoEditableQuerySource(tab, dbType as DatabaseType, target, target.sourceColumns) ? { allowInsert: true } : {}),
-        allowDelete: !target.analysis.distinct,
+        // A DISTINCT result is still one-to-one with the selected source row
+        // when that source's complete primary key is present in the projection.
+        // The candidate filter above guarantees that identity before enabling
+        // the primary-key based delete SQL.
+        allowDelete: true,
         allowInsertDelete: false,
         multiSource: true,
       };

--- a/packages/app-tests/queryStore.test.ts
+++ b/packages/app-tests/queryStore.test.ts
@@ -3438,7 +3438,7 @@ test("binds DISTINCT qualified-star edits to the single safe joined source", asy
     assert.equal(tab?.queryAnalysis?.multiSource, true);
     assert.equal(tab?.queryAnalysis?.distinct, true);
     assert.equal(tab?.queryAnalysis?.allowInsert, true);
-    assert.equal(tab?.queryAnalysis?.allowDelete, false);
+    assert.equal(tab?.queryAnalysis?.allowDelete, true);
     assert.equal(tab?.queryAnalysis?.allowInsertDelete, false);
     assert.equal(tab?.tableMeta?.tableName, "users");
     assert.deepEqual(tab?.querySourceColumns, ["id", "name"]);


### PR DESCRIPTION
## 问题

达梦多表关联查询使用 `DISTINCT` 时，查询结果选中行后没有“删除行”操作，无法删除对应的主表记录。

## 修复

- 当查询结果只对应一个来源表，且该表的完整主键包含在结果列中时，允许按主键删除
- `DISTINCT` 只会合并同一来源主键产生的重复关联行，不会改变删除目标
- 无完整主键、多个可编辑来源表或复杂表达式时继续保持只读
- 保留原有非 `DISTINCT` JOIN 删除逻辑

## 验证

- 达梦 DM8 实测 `DISTINCT JOIN` 结果选中行后显示“删除行”，点击可进入危险操作确认
- 达梦 DM8 实测关联重复行会被 `DISTINCT` 合并，删除入口正常
- `pnpm exec vitest run packages/app-tests/queryStore.test.ts packages/app-tests/queryResultToolbar.test.ts`：215/215 通过
- `cargo test -p dbx-core mysql_join_result_delete_targets_only_the_resolved_source_primary_key -- --exact`

Fixes #7084
