### PR TITLE
fix(postgres): 修复大字段预览内部列泄漏

### DIFF
--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -397,6 +397,21 @@ struct ServerLargeValueMarkerValue {
     original_bytes: Option<usize>,
 }
 
+/// Some PostgreSQL-compatible servers (for example KingbaseES instances with
+/// case-insensitive identifiers) fold even quoted column aliases, so the
+/// internal preview marker prefix must be matched ASCII case-insensitively.
+fn strip_large_value_marker_prefix(column: &str) -> Option<&str> {
+    let prefix = crate::sql_dialect::DBX_LARGE_VALUE_BYTES_COLUMN_PREFIX;
+    if column.len() < prefix.len() {
+        return None;
+    }
+    let head = column.get(..prefix.len())?;
+    if !head.eq_ignore_ascii_case(prefix) {
+        return None;
+    }
+    column.get(prefix.len()..)
+}
+
 fn server_large_value_alias(
     suffix: &str,
 ) -> Option<(usize, Option<ServerLargeValuePreviewKind>, Option<&'static str>)> {
@@ -406,16 +421,16 @@ fn server_large_value_alias(
     let (kind, source_index) = suffix.split_once('_')?;
     let source_index = source_index.parse::<usize>().ok()?;
     let (preview_kind, source_type) = match kind {
-        "T" => (ServerLargeValuePreviewKind::Text, None),
-        "B" => (ServerLargeValuePreviewKind::Binary, None),
-        "V" => (ServerLargeValuePreviewKind::Vector, Some("vector")),
-        "J" => (ServerLargeValuePreviewKind::Text, Some("json")),
-        "K" => (ServerLargeValuePreviewKind::Text, Some("jsonb")),
-        "S" => (ServerLargeValuePreviewKind::Text, Some("tsvector")),
-        "C" => (ServerLargeValuePreviewKind::Deferred, Some("clob")),
-        "N" => (ServerLargeValuePreviewKind::Deferred, Some("nclob")),
-        "L" => (ServerLargeValuePreviewKind::Deferred, Some("blob")),
-        "F" => (ServerLargeValuePreviewKind::Deferred, Some("bfile")),
+        "T" | "t" => (ServerLargeValuePreviewKind::Text, None),
+        "B" | "b" => (ServerLargeValuePreviewKind::Binary, None),
+        "V" | "v" => (ServerLargeValuePreviewKind::Vector, Some("vector")),
+        "J" | "j" => (ServerLargeValuePreviewKind::Text, Some("json")),
+        "K" | "k" => (ServerLargeValuePreviewKind::Text, Some("jsonb")),
+        "S" | "s" => (ServerLargeValuePreviewKind::Text, Some("tsvector")),
+        "C" | "c" => (ServerLargeValuePreviewKind::Deferred, Some("clob")),
+        "N" | "n" => (ServerLargeValuePreviewKind::Deferred, Some("nclob")),
+        "L" | "l" => (ServerLargeValuePreviewKind::Deferred, Some("blob")),
+        "F" | "f" => (ServerLargeValuePreviewKind::Deferred, Some("bfile")),
         _ => return None,
     };
     Some((source_index, Some(preview_kind), source_type))
@@ -483,9 +498,8 @@ fn truncate_server_large_value_preview(
 fn server_large_value_markers(result: &db::QueryResult) -> Vec<ServerLargeValueMarker> {
     let mut markers = Vec::new();
     for (result_index, column) in result.columns.iter().enumerate() {
-        let Some((source_index, preview_kind, source_type)) = column
-            .strip_prefix(crate::sql_dialect::DBX_LARGE_VALUE_BYTES_COLUMN_PREFIX)
-            .and_then(server_large_value_alias)
+        let Some((source_index, preview_kind, source_type)) =
+            strip_large_value_marker_prefix(column).and_then(server_large_value_alias)
         else {
             continue;
         };
@@ -8985,6 +8999,72 @@ for line in sys.stdin:
                 column_index: 1,
                 original_bytes: SERVER_LARGE_VALUE_UNKNOWN_BYTES,
             }]
+        );
+    }
+
+    #[test]
+    fn extracts_lowercased_server_large_value_markers_from_case_folding_servers() {
+        // KingbaseES instances with case-insensitive identifiers return even
+        // quoted marker aliases folded to lowercase; the markers must still be
+        // consumed and stripped instead of leaking into the data grid.
+        let mut result = db::QueryResult {
+            columns: vec![
+                "id".to_string(),
+                "payload".to_string(),
+                "__dbx_large_value_bytes_t_1".to_string(),
+                "note".to_string(),
+                "__dbx_large_value_bytes_t_2".to_string(),
+            ],
+            column_types: vec![
+                "integer".to_string(),
+                "text".to_string(),
+                "text".to_string(),
+                "text".to_string(),
+                "text".to_string(),
+            ],
+            column_sortables: vec![true; 5],
+            spatial_columns: Vec::new(),
+            spatial_values: Vec::new(),
+            rows: vec![
+                vec![
+                    serde_json::json!(1),
+                    serde_json::json!("长文本预览内容"),
+                    serde_json::json!("T:4"),
+                    serde_json::json!("abcdefgh"),
+                    serde_json::json!("T:4"),
+                ],
+                vec![
+                    serde_json::json!(2),
+                    serde_json::json!("短值"),
+                    serde_json::json!("T:4"),
+                    serde_json::json!("b"),
+                    serde_json::json!("T:4"),
+                ],
+            ],
+            affected_rows: 0,
+            execution_time_ms: 0,
+            truncated: false,
+            session_id: None,
+            has_more: false,
+            elasticsearch_raw_body: None,
+            messages: Vec::new(),
+        };
+
+        let cells = extract_server_large_value_markers(&mut result);
+
+        assert_eq!(result.columns, vec!["id", "payload", "note"]);
+        assert_eq!(result.column_types, vec!["integer", "text", "text"]);
+        assert_eq!(
+            result.rows[0],
+            vec![serde_json::json!(1), serde_json::json!("长文本预..."), serde_json::json!("abcd...")]
+        );
+        assert_eq!(result.rows[1], vec![serde_json::json!(2), serde_json::json!("短值"), serde_json::json!("b")]);
+        assert_eq!(
+            cells,
+            vec![
+                db::LargeValueCell { row_index: 0, column_index: 1, original_bytes: SERVER_LARGE_VALUE_UNKNOWN_BYTES },
+                db::LargeValueCell { row_index: 0, column_index: 2, original_bytes: SERVER_LARGE_VALUE_UNKNOWN_BYTES },
+            ]
         );
     }
 


### PR DESCRIPTION
## 背景

修复 #7774。

使用 PostgreSQL 类型浏览表数据时，大字段预览机制生成的 `__DBX_LARGE_VALUE_BYTES_*` 内部辅助列可能被作为普通字段返回，导致 DataGrid 中显示实际表结构不存在的字段（如 `__dbx_large_value_bytes_t_1`）。

Kingbase V8R6 通过 PostgreSQL 兼容连接同样会触发该问题。

## 原因

表数据大字段预览的 SQL 生成（`build_large_value_preview_columns`）会为 PostgreSQL 的 text/bytea/json 等列追加形如 `'T:8192' AS "__DBX_LARGE_VALUE_BYTES_T_1"` 的内部 marker 列，查询结果回到 Rust 侧后由 `extract_server_large_value_markers` 识别并消费。

但该识别是 ASCII 大小写敏感的：

- `server_large_value_markers` 用 `strip_prefix("__DBX_LARGE_VALUE_BYTES_")` 精确匹配列名前缀；
- `server_large_value_alias` 用 `"T" | "B" | "V" | ...` 精确匹配 alias 中的 kind 字符。

KingbaseES 开启大小写不敏感标识符的实例会把结果列名折叠为小写返回（即使用户 SQL 中用双引号写了大写 alias），`__DBX_LARGE_VALUE_BYTES_T_1` 变成 `__dbx_large_value_bytes_t_1`。此时 marker 无法被识别和消费，内部辅助列直接进入 `QueryResult.columns` / `rows` 并暴露到 DataGrid。

对比之下，MySQL driver 端的 marker 识别（`to_ascii_uppercase().starts_with(...)`）和前端 `canUseTableDataLargeValuePreview`（`toLocaleUpperCase()`）本来就是大小写不敏感的，只有 Rust 侧 server marker 识别遗漏了这一点。

## 修改

- 新增 `strip_large_value_marker_prefix`：以 ASCII 大小写不敏感方式剥离 marker 列名前缀
- `server_large_value_alias` 的 kind 字符匹配扩展为大小写不敏感（`"T" | "t"` 等）
- marker 识别失败的服务端折叠列名现在会被正确消费：从最终用户可见 `columns` / `rows` / `column_types` / `column_sortables` / `spatial_columns` 中移除内部辅助列，并转换为正确的 `large_value_cells`
- 新增回归测试 `extracts_lowercased_server_large_value_markers_from_case_folding_servers`：覆盖小写折叠 marker、截断标记、删除 marker 后多字段的 `column_index` 映射正确性

对标准 PostgreSQL（列名原样返回大写）行为完全不变；MySQL 与 Oracle deferred LOB marker 路径语义不变。

## 测试

- `cargo test -p dbx-core --lib large_value` → 12 passed（含新增回归测试）
- `cargo test -p dbx-core --lib db::postgres::` → 221 passed
- `cargo fmt --check` → PASS

## 影响范围

仅调整 PostgreSQL 表数据大字段预览结果的内部 marker 识别与清理，不修改普通查询语义，也不涉及 Kingbase 序列展示问题。

Fixes #7774
