### PR TITLE
修复生成 SQL 后对象浏览器滚动位置跳回顶部

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -445,6 +445,16 @@ function onObjectsScroll() {
   });
 }
 
+function flushObjectBrowserViewport() {
+  if (viewportFrame) {
+    window.cancelAnimationFrame(viewportFrame);
+    viewportFrame = 0;
+  }
+  const el = scrollerElement();
+  if (!el) return;
+  emitViewportChange(el.scrollTop);
+}
+
 function applyObjectBrowserScrollTop(scrollTop: number) {
   const scroller = activeScroller();
   if (scroller && !(scroller instanceof HTMLElement)) {
@@ -1436,6 +1446,7 @@ async function onEventSaved(savedName: string) {
 }
 
 async function openNewQuery(row: ObjectBrowserRow) {
+  flushObjectBrowserViewport();
   const schema = row.schema || selectedSchema.value;
   const tabId = queryStore.createTab(props.connection.id, props.database, row.name, "query", schema, undefined, props.catalog);
   queryStore.updateSql(

--- a/apps/desktop/src/components/objects/__tests__/ObjectBrowserViewportPersistence.spec.ts
+++ b/apps/desktop/src/components/objects/__tests__/ObjectBrowserViewportPersistence.spec.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("../ObjectBrowser.vue", import.meta.url), "utf8");
+
+function functionBody(name: string): string {
+  const signature = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*(?::\\s*[^\\{]+)?\\{`, "m").exec(source);
+  if (!signature) throw new Error(`Missing function ${name}`);
+  const bodyStart = signature.index + signature[0].length;
+  let depth = 1;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    else if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(bodyStart, index);
+  }
+  throw new Error(`Unclosed function ${name}`);
+}
+
+describe("ObjectBrowser viewport persistence", () => {
+  it("flushes the latest scroll position before generating SQL", () => {
+    const body = functionBody("openNewQuery");
+    const flushIndex = body.indexOf("flushObjectBrowserViewport();");
+    const createTabIndex = body.indexOf("queryStore.createTab");
+
+    expect(flushIndex).toBeGreaterThanOrEqual(0);
+    expect(createTabIndex).toBeGreaterThan(flushIndex);
+  });
+});


### PR DESCRIPTION
﻿## 变更说明

修复对象浏览器滚动到底部后立即执行“生成 SQL”时，滚动位置跳回顶部的问题。

`ObjectBrowser` 原本通过 `requestAnimationFrame` 延迟保存 viewport；生成 SQL 会在该帧执行前创建并激活新的 query tab，旧 scroller 随后可能以 `scrollTop = 0` 覆盖已保存位置。现在在创建 query tab 前 flush 当前 viewport，并取消待执行的旧帧，同时保留原有 rAF 节流和恢复/reset 语义。

## 验证

- `pnpm exec vitest run apps/desktop/src/components/objects/__tests__/ObjectBrowserViewportPersistence.spec.ts apps/desktop/src/components/objects/__tests__/ObjectBrowserMetadataRefresh.spec.ts`
- `pnpm exec vitest run apps/desktop/src/stores/__tests__/queryStore.database-open.spec.ts --testTimeout=30000`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/objects/ObjectBrowser.vue apps/desktop/src/components/objects/__tests__/ObjectBrowserViewportPersistence.spec.ts`
- `git diff --check`

Fixes #7781
