### PR TITLE
fix(postgres): GIN索引操作符类丢失修复

### DIFF
--- a/apps/desktop/src/components/diagram/DiagramSyncDialog.vue
+++ b/apps/desktop/src/components/diagram/DiagramSyncDialog.vue
@@ -122,7 +122,7 @@ async function copySql() {
 }
 
 async function execute() {
-  if (!sqlText.value || validationErrors.value.length) return;
+  if (!sqlText.value || validationErrors.value.length || warnings.value.length) return;
   executing.value = true;
   execError.value = "";
   try {
@@ -190,7 +190,7 @@ function syncTableLabel(table: DiagramTable): string {
       <DialogFooter class="gap-2 sm:gap-2">
         <Button type="button" variant="outline" size="sm" :disabled="!sqlText" @click="copySql">{{ t("diagram.copySql") }}</Button>
         <Button type="button" variant="ghost" size="sm" @click="openModel = false">{{ t("common.cancel") }}</Button>
-        <Button type="button" size="sm" :disabled="!sqlText || !!validationErrors.length || executing || building" @click="execute">
+        <Button type="button" size="sm" :disabled="!sqlText || !!validationErrors.length || !!warnings.length || executing || building" @click="execute">
           {{ executing ? t("diagram.syncing") : t("diagram.executeSync") }}
         </Button>
       </DialogFooter>

--- a/apps/desktop/src/components/diagram/DiagramSyncDialog.vue
+++ b/apps/desktop/src/components/diagram/DiagramSyncDialog.vue
@@ -41,6 +41,11 @@ const structureCapabilities = computed(() => getTableStructureCapabilities(props
 const validationErrors = ref<string[]>([]);
 const sqlText = ref("");
 const warnings = ref<string[]>([]);
+// 仅 GIN 缺 opclass 警告阻断同步；其余降级类警告（如 “… not supported … ignored”）保持可继续。
+// Match the warning's stable semantic core ("has no operator class specified")
+// rather than its prefix, so rewording the leading "GIN index …" doesn't
+// silently disable the gate.
+const hasBlockingWarning = computed(() => warnings.value.some((w) => w.includes("has no operator class specified")));
 const building = ref(false);
 const executing = ref(false);
 const execError = ref("");
@@ -122,7 +127,7 @@ async function copySql() {
 }
 
 async function execute() {
-  if (!sqlText.value || validationErrors.value.length || warnings.value.length) return;
+  if (!sqlText.value || validationErrors.value.length || hasBlockingWarning.value) return;
   executing.value = true;
   execError.value = "";
   try {
@@ -190,7 +195,7 @@ function syncTableLabel(table: DiagramTable): string {
       <DialogFooter class="gap-2 sm:gap-2">
         <Button type="button" variant="outline" size="sm" :disabled="!sqlText" @click="copySql">{{ t("diagram.copySql") }}</Button>
         <Button type="button" variant="ghost" size="sm" @click="openModel = false">{{ t("common.cancel") }}</Button>
-        <Button type="button" size="sm" :disabled="!sqlText || !!validationErrors.length || !!warnings.length || executing || building" @click="execute">
+        <Button type="button" size="sm" :disabled="!sqlText || !!validationErrors.length || hasBlockingWarning || executing || building" @click="execute">
           {{ executing ? t("diagram.syncing") : t("diagram.executeSync") }}
         </Button>
       </DialogFooter>

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -3173,6 +3173,7 @@ function addIndex() {
     includedColumns: [],
     comment: "",
     concurrently: false,
+    columnOpclasses: [],
     markedForDrop: false,
   });
   void nextTick(() => {

--- a/apps/desktop/src/lib/diagram/draft-table.ts
+++ b/apps/desktop/src/lib/diagram/draft-table.ts
@@ -40,6 +40,7 @@ export function createDraftIndex(tableName: string, columns: string[], existingI
     includedColumns: [],
     comment: "",
     concurrently: false,
+    columnOpclasses: [],
     markedForDrop: false,
   };
 }

--- a/apps/desktop/src/lib/table/tableStructureEditorSql.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorSql.ts
@@ -46,6 +46,8 @@ export interface EditableStructureIndex {
   comment: string;
   /** Build the index with PostgreSQL `CREATE INDEX CONCURRENTLY` (PostgreSQL only, default off). */
   concurrently?: boolean;
+  /** Parallel to `columns`: operator class for each key column (PostgreSQL). `null` means default. */
+  columnOpclasses?: (string | null)[];
   original?: IndexInfo;
   markedForDrop: boolean;
 }

--- a/apps/desktop/src/lib/table/tableStructureEditorState.ts
+++ b/apps/desktop/src/lib/table/tableStructureEditorState.ts
@@ -1029,6 +1029,7 @@ export function createIndexDrafts(indexes: IndexInfo[]): EditableStructureIndex[
     indexType: normalizeStructureIndexType(index.index_type),
     includedColumns: index.included_columns ? [...index.included_columns] : [],
     comment: index.comment ?? "",
+    columnOpclasses: index.column_opclasses ? [...index.column_opclasses] : [],
     original: index,
     markedForDrop: false,
   }));

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -552,6 +552,8 @@ export interface IndexInfo {
   comment?: string | null;
   /** Parallel to `columns`: true at index i means columns[i] is a raw expression, not a plain column name. */
   key_is_expression?: boolean[] | null;
+  /** Parallel to `columns`: operator class name for each key column (PostgreSQL), if non-default. */
+  column_opclasses?: (string | null)[] | null;
 }
 
 export interface ReferenceKeyInfo {

--- a/crates/dbx-core/src/db/clickhouse_driver.rs
+++ b/crates/dbx-core/src/db/clickhouse_driver.rs
@@ -541,6 +541,7 @@ fn clickhouse_index_from_skipping_row(row: &[serde_json::Value]) -> IndexInfo {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     }
 }
 
@@ -792,6 +793,7 @@ pub async fn list_indexes(client: &ChClient, database: &str, table: &str) -> Res
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
     }
 

--- a/crates/dbx-core/src/db/cloudflare_d1/mod.rs
+++ b/crates/dbx-core/src/db/cloudflare_d1/mod.rs
@@ -200,6 +200,7 @@ pub async fn list_indexes(client: &CloudflareD1Client, _schema: &str, table: &st
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
     }
     Ok(indexes)

--- a/crates/dbx-core/src/db/manticoresearch.rs
+++ b/crates/dbx-core/src/db/manticoresearch.rs
@@ -210,6 +210,7 @@ fn index_info_from_row(row: &mysql_async::Row) -> IndexInfo {
         included_columns: None,
         comment: (!comment_parts.is_empty()).then(|| comment_parts.join(", ")),
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     }
 }
 

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -904,6 +904,7 @@ fn index_info_from_model(model: IndexModel) -> IndexInfo {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     }
 }
 
@@ -3637,6 +3638,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
 
         assert_eq!(spec.name, "email_1");
@@ -3662,6 +3664,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
 
         assert_eq!(
@@ -3905,6 +3908,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             },
             IndexInfo {
                 name: "users_email_unique".to_string(),
@@ -3916,6 +3920,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             },
             IndexInfo {
                 name: "users_status_idx".to_string(),
@@ -3927,6 +3932,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             },
         ];
         let after = vec![before[0].clone(), before[2].clone()];

--- a/crates/dbx-core/src/db/mysql.rs
+++ b/crates/dbx-core/src/db/mysql.rs
@@ -5775,6 +5775,7 @@ pub async fn list_indexes(pool: &MySqlPool, database: &str, table: &str) -> Resu
                     included_columns: None,
                     comment: get_opt_str(&row, "INDEX_COMMENT").filter(|value| !value.is_empty()),
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 });
                 index_position
             };

--- a/crates/dbx-core/src/db/mysql_compatible.rs
+++ b/crates/dbx-core/src/db/mysql_compatible.rs
@@ -325,6 +325,7 @@ fn table_key_index(name: &str, line: &str, is_unique: bool, is_primary: bool, in
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     })
 }
 
@@ -345,6 +346,7 @@ fn secondary_index(line: &str) -> Option<IndexInfo> {
         included_columns: None,
         comment: mysql_quoted_string_argument(after_name, "COMMENT"),
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     })
 }
 

--- a/crates/dbx-core/src/db/ob_oracle.rs
+++ b/crates/dbx-core/src/db/ob_oracle.rs
@@ -242,6 +242,7 @@ pub async fn list_indexes(pool: &mysql_async::Pool, schema: &str, table: &str) -
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             }
         })
         .collect())

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3829,7 +3829,7 @@ fn postgres_indexes_for_relations_query_tiers() -> [&'static str; 2] {
 fn postgres_indexes_for_relations_sql() -> &'static str {
     "SELECT t.oid::bigint AS relid, i.relname AS index_name, \
              array_agg(COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, k.n::int, false)) ORDER BY k.n) AS columns, \
-             array_agg(CASE WHEN a.attname IS NULL THEN NULL WHEN oc.opcdefault THEN NULL ELSE quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname) END ORDER BY k.n) AS column_opclasses, \
+             array_agg(CASE WHEN oc.opcdefault THEN NULL ELSE quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname) END ORDER BY k.n) AS column_opclasses, \
              (ix.indisunique AND ix.indisvalid) AS is_unique, \
              ix.indisprimary AS is_primary, \
              pg_get_expr(ix.indpred, ix.indrelid) AS filter_expr, \
@@ -3865,8 +3865,7 @@ fn postgres_indexes_for_relations_compat_sql() -> &'static str {
                ORDER BY pos.n \
              ) AS columns, \
              ARRAY( \
-               SELECT CASE WHEN a.attname IS NULL THEN NULL \
-                           WHEN oc.opcdefault THEN NULL \
+               SELECT CASE WHEN oc.opcdefault THEN NULL \
                            ELSE oc.opcname \
                       END \
                FROM generate_series(1, array_length(string_to_array(ix.indkey::text, ' '), 1)) AS pos(n) \
@@ -7324,7 +7323,7 @@ async fn execute_query_with_max_rows_inner(
 // (schema, table) instead of a batch of oids — see the note there.
 const POSTGRES_INDEXES_SQL: &str = "SELECT i.relname AS index_name, \
              array_agg(COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, k.n::int, false)) ORDER BY k.n) AS columns, \
-             array_agg(CASE WHEN a.attname IS NULL THEN NULL WHEN oc.opcdefault THEN NULL ELSE quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname) END ORDER BY k.n) AS column_opclasses, \
+             array_agg(CASE WHEN oc.opcdefault THEN NULL ELSE quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname) END ORDER BY k.n) AS column_opclasses, \
              (ix.indisunique AND ix.indisvalid) AS is_unique, \
              ix.indisprimary AS is_primary, \
              pg_get_expr(ix.indpred, ix.indrelid) AS filter_expr, \
@@ -7359,8 +7358,7 @@ const POSTGRES_INDEXES_COMPAT_SQL: &str = "SELECT i.relname AS index_name, \
                ORDER BY pos.n \
              ) AS columns, \
              ARRAY( \
-               SELECT CASE WHEN a.attname IS NULL THEN NULL \
-                           WHEN oc.opcdefault THEN NULL \
+               SELECT CASE WHEN oc.opcdefault THEN NULL \
                            ELSE oc.opcname \
                       END \
                FROM generate_series(1, array_length(string_to_array(ix.indkey::text, ' '), 1)) AS pos(n) \
@@ -7474,10 +7472,12 @@ pub(crate) async fn postgres_relation_relkind(
 /// `pg_index.indclass`. For each key column position, the schema-qualified
 /// opclass (`quote_ident(nspname) || '.' || quote_ident(opcname)`) is returned
 /// unless the class is the type's default (`oc.opcdefault`), so DDL regeneration
-/// resolves the opclass regardless of `search_path`. Expression columns (where
-/// `a.attname IS NULL`) always have `NULL` for opclass — their operator class is
-/// embedded in the `pg_get_indexdef` expression text, which the generator emits
-/// verbatim (appending a separate opclass would duplicate it).
+/// resolves the opclass regardless of `search_path`. This applies to every key
+/// position, including expression keys (`a.attname IS NULL`): the per-column
+/// `pg_get_indexdef(indexrelid, colno, pretty)` call returns only the bare
+/// expression text (PostgreSQL sets `attrsOnly = (colno != 0)`, so the
+/// opclass/COLLATE/DESC block is skipped — see `ruleutils.c`), so the opclass
+/// must be read from `indclass` rather than parsed out of that text.
 async fn list_indexes_with_sql(
     client: &deadpool_postgres::Client,
     sql: &str,

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -3788,23 +3788,30 @@ async fn list_indexes_for_relations_with_sql(
     for row in &rows {
         let Ok(relid) = row.try_get::<_, i64>(0) else { continue };
         let all_cols: Vec<String> = row.try_get::<_, Vec<String>>(2).unwrap_or_default();
-        let nkeyatts = row.try_get::<_, Option<i16>>(7).ok().flatten().unwrap_or(all_cols.len() as i16) as usize;
+        let all_opclasses: Vec<Option<String>> = row.try_get::<_, Vec<Option<String>>>(3).unwrap_or_default();
+        let nkeyatts = row.try_get::<_, Option<i16>>(8).ok().flatten().unwrap_or(all_cols.len() as i16) as usize;
         let split_at = nkeyatts.min(all_cols.len());
         let key_cols = all_cols[..split_at].to_vec();
+        let key_opclasses = if all_opclasses.len() == all_cols.len() {
+            all_opclasses[..split_at].to_vec()
+        } else {
+            vec![None; split_at]
+        };
         let included = if split_at < all_cols.len() { all_cols[split_at..].to_vec() } else { vec![] };
-        let all_is_expr: Vec<bool> = row.try_get::<_, Vec<bool>>(10).unwrap_or_default();
+        let all_is_expr: Vec<bool> = row.try_get::<_, Vec<bool>>(11).unwrap_or_default();
         let key_is_expression =
             if all_is_expr.len() == all_cols.len() { all_is_expr[..split_at].to_vec() } else { Vec::new() };
         result.entry(relid).or_default().push(IndexInfo {
             name: pg_row_try_string(row, 1),
             columns: key_cols,
-            is_unique: pg_row_try_bool(row, 3).unwrap_or(false),
-            is_primary: pg_row_try_bool(row, 4).unwrap_or(false),
-            filter: row.try_get::<_, Option<String>>(5).ok().flatten(),
-            index_type: row.try_get::<_, Option<String>>(6).ok().flatten(),
+            is_unique: pg_row_try_bool(row, 4).unwrap_or(false),
+            is_primary: pg_row_try_bool(row, 5).unwrap_or(false),
+            filter: row.try_get::<_, Option<String>>(6).ok().flatten(),
+            index_type: row.try_get::<_, Option<String>>(7).ok().flatten(),
             included_columns: if included.is_empty() { None } else { Some(included) },
-            comment: row.try_get::<_, Option<String>>(9).ok().flatten(),
+            comment: row.try_get::<_, Option<String>>(10).ok().flatten(),
             key_is_expression,
+            column_opclasses: key_opclasses,
         });
     }
     Ok(result)
@@ -3821,7 +3828,8 @@ fn postgres_indexes_for_relations_query_tiers() -> [&'static str; 2] {
 // line up, and result columns are read positionally.
 fn postgres_indexes_for_relations_sql() -> &'static str {
     "SELECT t.oid::bigint AS relid, i.relname AS index_name, \
-             array_agg(COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, k.n::int, true)) ORDER BY k.n) AS columns, \
+             array_agg(COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, k.n::int, false)) ORDER BY k.n) AS columns, \
+             array_agg(CASE WHEN a.attname IS NULL THEN NULL WHEN oc.opcdefault THEN NULL ELSE quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname) END ORDER BY k.n) AS column_opclasses, \
              (ix.indisunique AND ix.indisvalid) AS is_unique, \
              ix.indisprimary AS is_primary, \
              pg_get_expr(ix.indpred, ix.indrelid) AS filter_expr, \
@@ -3834,8 +3842,10 @@ fn postgres_indexes_for_relations_sql() -> &'static str {
              JOIN pg_class t ON t.oid = ix.indrelid \
              JOIN pg_class i ON i.oid = ix.indexrelid \
              JOIN pg_am am ON am.oid = i.relam \
-             JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, n) ON true \
+             JOIN LATERAL unnest(ix.indkey, ix.indclass) WITH ORDINALITY AS k(attnum, class_oid, n) ON true \
              LEFT JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum AND k.attnum > 0 \
+             LEFT JOIN pg_opclass oc ON oc.oid = k.class_oid \
+             LEFT JOIN pg_namespace opcns ON opcns.oid = oc.opcnamespace \
              WHERE t.oid = ANY($1::bigint[]) \
              GROUP BY t.oid, i.relname, i.oid, ix.indisunique, ix.indisvalid, ix.indisprimary, ix.indpred, ix.indrelid, am.amname, ix.indnkeyatts, ix.indkey \
              ORDER BY t.oid, i.relname"
@@ -3846,7 +3856,7 @@ fn postgres_indexes_for_relations_sql() -> &'static str {
 fn postgres_indexes_for_relations_compat_sql() -> &'static str {
     "SELECT t.oid::bigint AS relid, i.relname AS index_name, \
              ARRAY( \
-               SELECT COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, pos.n, true)) \
+               SELECT COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, pos.n, false)) \
                FROM generate_series(1, array_length(string_to_array(ix.indkey::text, ' '), 1)) AS pos(n) \
                LEFT JOIN pg_attribute a \
                  ON a.attrelid = t.oid \
@@ -3854,6 +3864,20 @@ fn postgres_indexes_for_relations_compat_sql() -> &'static str {
                 AND a.attnum > 0 \
                ORDER BY pos.n \
              ) AS columns, \
+             ARRAY( \
+               SELECT CASE WHEN a.attname IS NULL THEN NULL \
+                           WHEN oc.opcdefault THEN NULL \
+                           ELSE oc.opcname \
+                      END \
+               FROM generate_series(1, array_length(string_to_array(ix.indkey::text, ' '), 1)) AS pos(n) \
+               LEFT JOIN pg_attribute a \
+                 ON a.attrelid = t.oid \
+                AND a.attnum = (string_to_array(ix.indkey::text, ' '))[pos.n]::int2 \
+                AND a.attnum > 0 \
+               LEFT JOIN pg_opclass oc \
+                 ON oc.oid = (string_to_array(ix.indclass::text, ' '))[pos.n]::oid \
+               ORDER BY pos.n \
+             ) AS column_opclasses, \
              (ix.indisunique AND ix.indisvalid) AS is_unique, \
              ix.indisprimary AS is_primary, \
              pg_get_expr(ix.indpred, ix.indrelid) AS filter_expr, \
@@ -7299,7 +7323,8 @@ async fn execute_query_with_max_rows_inner(
 // Sibling of `postgres_indexes_for_relations_sql` (~line 3288), for a single
 // (schema, table) instead of a batch of oids — see the note there.
 const POSTGRES_INDEXES_SQL: &str = "SELECT i.relname AS index_name, \
-             array_agg(COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, k.n::int, true)) ORDER BY k.n) AS columns, \
+             array_agg(COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, k.n::int, false)) ORDER BY k.n) AS columns, \
+             array_agg(CASE WHEN a.attname IS NULL THEN NULL WHEN oc.opcdefault THEN NULL ELSE quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname) END ORDER BY k.n) AS column_opclasses, \
              (ix.indisunique AND ix.indisvalid) AS is_unique, \
              ix.indisprimary AS is_primary, \
              pg_get_expr(ix.indpred, ix.indrelid) AS filter_expr, \
@@ -7313,8 +7338,10 @@ const POSTGRES_INDEXES_SQL: &str = "SELECT i.relname AS index_name, \
              JOIN pg_class i ON i.oid = ix.indexrelid \
              JOIN pg_namespace n ON n.oid = t.relnamespace \
              JOIN pg_am am ON am.oid = i.relam \
-             JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, n) ON true \
+             JOIN LATERAL unnest(ix.indkey, ix.indclass) WITH ORDINALITY AS k(attnum, class_oid, n) ON true \
              LEFT JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum AND k.attnum > 0 \
+             LEFT JOIN pg_opclass oc ON oc.oid = k.class_oid \
+             LEFT JOIN pg_namespace opcns ON opcns.oid = oc.opcnamespace \
              WHERE t.oid = (CASE WHEN $1 = '' THEN quote_ident($2) ELSE quote_ident($1) || '.' || quote_ident($2) END)::regclass \
              GROUP BY i.relname, i.oid, ix.indisunique, ix.indisvalid, ix.indisprimary, ix.indpred, ix.indrelid, am.amname, ix.indnkeyatts, ix.indkey \
              ORDER BY i.relname";
@@ -7323,7 +7350,7 @@ const POSTGRES_INDEXES_SQL: &str = "SELECT i.relname AS index_name, \
 // 3312) — see the note on `POSTGRES_INDEXES_SQL` above.
 const POSTGRES_INDEXES_COMPAT_SQL: &str = "SELECT i.relname AS index_name, \
              ARRAY( \
-               SELECT COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, pos.n, true)) \
+               SELECT COALESCE(a.attname, pg_get_indexdef(ix.indexrelid, pos.n, false)) \
                FROM generate_series(1, array_length(string_to_array(ix.indkey::text, ' '), 1)) AS pos(n) \
                LEFT JOIN pg_attribute a \
                  ON a.attrelid = t.oid \
@@ -7331,6 +7358,20 @@ const POSTGRES_INDEXES_COMPAT_SQL: &str = "SELECT i.relname AS index_name, \
                 AND a.attnum > 0 \
                ORDER BY pos.n \
              ) AS columns, \
+             ARRAY( \
+               SELECT CASE WHEN a.attname IS NULL THEN NULL \
+                           WHEN oc.opcdefault THEN NULL \
+                           ELSE oc.opcname \
+                      END \
+               FROM generate_series(1, array_length(string_to_array(ix.indkey::text, ' '), 1)) AS pos(n) \
+               LEFT JOIN pg_attribute a \
+                 ON a.attrelid = t.oid \
+                AND a.attnum = (string_to_array(ix.indkey::text, ' '))[pos.n]::int2 \
+                AND a.attnum > 0 \
+               LEFT JOIN pg_opclass oc \
+                 ON oc.oid = (string_to_array(ix.indclass::text, ' '))[pos.n]::oid \
+               ORDER BY pos.n \
+             ) AS column_opclasses, \
              (ix.indisunique AND ix.indisvalid) AS is_unique, \
              ix.indisprimary AS is_primary, \
              pg_get_expr(ix.indpred, ix.indrelid) AS filter_expr, \
@@ -7429,6 +7470,14 @@ pub(crate) async fn postgres_relation_relkind(
     row.map(|row| row.try_get::<_, String>(0)).transpose().map_err(pg_error_to_string)
 }
 
+/// Compute per-column operator classes from `pg_opclass` joined via
+/// `pg_index.indclass`. For each key column position, the schema-qualified
+/// opclass (`quote_ident(nspname) || '.' || quote_ident(opcname)`) is returned
+/// unless the class is the type's default (`oc.opcdefault`), so DDL regeneration
+/// resolves the opclass regardless of `search_path`. Expression columns (where
+/// `a.attname IS NULL`) always have `NULL` for opclass — their operator class is
+/// embedded in the `pg_get_indexdef` expression text, which the generator emits
+/// verbatim (appending a separate opclass would duplicate it).
 async fn list_indexes_with_sql(
     client: &deadpool_postgres::Client,
     sql: &str,
@@ -7441,25 +7490,32 @@ async fn list_indexes_with_sql(
         .iter()
         .map(|row| {
             let all_cols: Vec<String> = row.try_get::<_, Vec<String>>(1).unwrap_or_default();
-            let nkeyatts = row.try_get::<_, Option<i16>>(6).ok().flatten().unwrap_or(all_cols.len() as i16) as usize;
+            let all_opclasses: Vec<Option<String>> = row.try_get::<_, Vec<Option<String>>>(2).unwrap_or_default();
+            let nkeyatts = row.try_get::<_, Option<i16>>(7).ok().flatten().unwrap_or(all_cols.len() as i16) as usize;
             let split_at = nkeyatts.min(all_cols.len());
             let key_cols = all_cols[..split_at].to_vec();
+            let key_opclasses = if all_opclasses.len() == all_cols.len() {
+                all_opclasses[..split_at].to_vec()
+            } else {
+                vec![None; split_at]
+            };
             let included = if split_at < all_cols.len() { all_cols[split_at..].to_vec() } else { vec![] };
             // `a.attname IS NULL` at a given key position means that key part came back from
             // pg_get_indexdef (a functional/expression key part), not from a real column (#6295).
-            let all_is_expr: Vec<bool> = row.try_get::<_, Vec<bool>>(9).unwrap_or_default();
+            let all_is_expr: Vec<bool> = row.try_get::<_, Vec<bool>>(10).unwrap_or_default();
             let key_is_expression =
                 if all_is_expr.len() == all_cols.len() { all_is_expr[..split_at].to_vec() } else { Vec::new() };
             IndexInfo {
                 name: pg_row_try_string(row, 0),
                 columns: key_cols,
-                is_unique: pg_row_try_bool(row, 2).unwrap_or(false),
-                is_primary: pg_row_try_bool(row, 3).unwrap_or(false),
-                filter: row.try_get::<_, Option<String>>(4).ok().flatten(),
-                index_type: row.try_get::<_, Option<String>>(5).ok().flatten(),
+                is_unique: pg_row_try_bool(row, 3).unwrap_or(false),
+                is_primary: pg_row_try_bool(row, 4).unwrap_or(false),
+                filter: row.try_get::<_, Option<String>>(5).ok().flatten(),
+                index_type: row.try_get::<_, Option<String>>(6).ok().flatten(),
                 included_columns: if included.is_empty() { None } else { Some(included) },
-                comment: row.try_get::<_, Option<String>>(8).ok().flatten(),
+                comment: row.try_get::<_, Option<String>>(9).ok().flatten(),
                 key_is_expression,
+                column_opclasses: key_opclasses,
             }
         })
         .collect())
@@ -12278,6 +12334,26 @@ mod tests {
         assert!(POSTGRES_INDEXES_SQL.contains("array_agg(a.attname IS NULL ORDER BY k.n) AS key_is_expression"));
         assert!(POSTGRES_INDEXES_COMPAT_SQL.contains("SELECT a.attname IS NULL"));
         assert!(POSTGRES_INDEXES_COMPAT_SQL.contains("AS key_is_expression"));
+    }
+
+    #[test]
+    fn postgres_index_metadata_schema_qualifies_opclass() {
+        // The LATERAL (modern) index-introspection SQL returns each non-default
+        // opclass schema-qualified (`quote_ident(nspname) || '.' || quote_ident(opcname)`)
+        // and joins `pg_namespace` on `opcnamespace`, so DDL regeneration resolves
+        // opclasses (e.g. `gin_trgm_ops` from `pg_trgm`) regardless of `search_path`.
+        // The compat (pre-LATERAL) fallback keeps bare `oc.opcname` — no regression,
+        // just no schema-qualification for the rare old-PG × non-default-schema case.
+        for sql in [POSTGRES_INDEXES_SQL, postgres_indexes_for_relations_sql()] {
+            assert!(
+                sql.contains("quote_ident(opcns.nspname) || '.' || quote_ident(oc.opcname)"),
+                "expected schema-qualified opclass in {sql}"
+            );
+            assert!(
+                sql.contains("LEFT JOIN pg_namespace opcns ON opcns.oid = oc.opcnamespace"),
+                "expected opcnamespace join in {sql}"
+            );
+        }
     }
 
     #[test]

--- a/crates/dbx-core/src/db/questdb.rs
+++ b/crates/dbx-core/src/db/questdb.rs
@@ -177,6 +177,7 @@ pub async fn list_indexes(pool: &Pool, _schema: &str, table: &str) -> Result<Vec
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             }
         })
         .collect())

--- a/crates/dbx-core/src/db/rqlite_driver.rs
+++ b/crates/dbx-core/src/db/rqlite_driver.rs
@@ -180,6 +180,7 @@ pub async fn list_indexes(client: &RqliteClient, _schema: &str, table: &str) -> 
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
     }
 

--- a/crates/dbx-core/src/db/sqlite.rs
+++ b/crates/dbx-core/src/db/sqlite.rs
@@ -2493,6 +2493,7 @@ pub async fn list_indexes(pool: &SqliteHandle, schema: &str, table: &str) -> Res
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             });
         }
         return Ok(indexes);
@@ -2546,6 +2547,7 @@ pub async fn list_indexes(pool: &SqliteHandle, schema: &str, table: &str) -> Res
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 });
             }
             Ok(indexes)

--- a/crates/dbx-core/src/db/sqlserver.rs
+++ b/crates/dbx-core/src/db/sqlserver.rs
@@ -2940,6 +2940,7 @@ pub async fn list_indexes(client: &mut SqlServerClient, schema: &str, table: &st
                 },
                 comment: row.get::<&str, _>(7).filter(|s: &&str| !s.is_empty()).map(|s: &str| s.to_string()),
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             }
         })
         .collect())

--- a/crates/dbx-core/src/db/turso_driver.rs
+++ b/crates/dbx-core/src/db/turso_driver.rs
@@ -222,6 +222,7 @@ pub async fn list_indexes(client: &TursoClient, _schema: &str, table: &str) -> R
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
     }
 

--- a/crates/dbx-core/src/docs/dbml.rs
+++ b/crates/dbx-core/src/docs/dbml.rs
@@ -600,6 +600,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let table = doc_table("orders", vec![col("user_id", "integer")], vec![index]);
 
@@ -623,6 +624,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let table = doc_table("orders", vec![col("reference", "text")], vec![index]);
         let mut warnings = Vec::new();
@@ -642,6 +644,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let mut id = col("id", "integer");
         id.is_primary_key = true;
@@ -664,6 +667,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let table = doc_table("orders", vec![col("status", "text")], vec![index]);
 
@@ -866,6 +870,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let out =
             to_dbml(&snapshot(vec![doc_table("orders", vec![col("status", "text")], vec![index])], vec!["public"]));

--- a/crates/dbx-core/src/docs/relations.rs
+++ b/crates/dbx-core/src/docs/relations.rs
@@ -194,6 +194,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         }
     }
 

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -3107,6 +3107,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let mut filtered = index("uq_active_code", &["active_code"], true, false);
         filtered.filter = Some("active = true".to_string());
@@ -8053,6 +8054,7 @@ async fn external_driver_gaussdb_m_indexes(
                     included_columns: None,
                     comment: current_comment.clone(),
                     key_is_expression: current_is_expression.clone(),
+                    column_opclasses: vec![],
                 });
             }
             // Start new index
@@ -8122,6 +8124,7 @@ async fn external_driver_gaussdb_m_indexes(
             included_columns: None,
             comment: current_comment,
             key_is_expression: current_is_expression,
+            column_opclasses: vec![],
         });
     }
 
@@ -10123,6 +10126,7 @@ mod ddl_tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         }];
         let partition_info = db::postgres::PostgresTablePartitionInfo {
             is_partition: true,
@@ -10173,6 +10177,7 @@ mod ddl_tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         }];
         let partition_info = db::postgres::PostgresTablePartitionInfo {
             is_partition: true,
@@ -11762,7 +11767,24 @@ fn render_postgres_table_ddl_with_partition_info(
             continue;
         }
         let unique = if idx.is_unique { "UNIQUE " } else { "" };
-        let cols = idx.columns.iter().map(|c| pg_ident(c)).collect::<Vec<_>>().join(", ");
+        let cols = idx
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let is_expr = idx.key_is_expression.get(i).copied().unwrap_or(false);
+                if is_expr {
+                    c.clone()
+                } else {
+                    let mut col = pg_ident(c);
+                    if let Some(opclass) = idx.column_opclasses.get(i).and_then(|o| o.as_deref()) {
+                        col.push_str(&format!(" {opclass}"));
+                    }
+                    col
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
         let using = idx.index_type.as_deref().map(|t| format!(" USING {t}")).unwrap_or_default();
         let include = idx
             .included_columns

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -10113,6 +10113,35 @@ mod ddl_tests {
     }
 
     #[test]
+    fn postgres_table_ddl_appends_opclass_to_expression_index_key() {
+        // The per-column `pg_get_indexdef(indexrelid, colno, pretty)` returns only the
+        // bare expression (PostgreSQL sets `attrsOnly = (colno != 0)`, so the opclass
+        // block is skipped — see `ruleutils.c`). The opclass is read separately from
+        // `indclass` into `column_opclasses`, so table DDL must append it to an
+        // expression key just like a real column.
+        let id = column("id", "integer");
+        let indexes = vec![db::IndexInfo {
+            name: "users_lower_email_trgm_idx".to_string(),
+            columns: vec!["lower(email)".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: Some("gin".to_string()),
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![true],
+            column_opclasses: vec![Some("gin_trgm_ops".to_string())],
+        }];
+
+        let ddl = render_postgres_table_ddl("public", "users", &[id], &indexes, &[], None);
+
+        assert!(
+            ddl.contains("USING gin (lower(email) gin_trgm_ops)"),
+            "expected expression key with appended opclass, got: {ddl}"
+        );
+    }
+
+    #[test]
     fn postgres_table_ddl_renders_partition_children_and_subpartitions() {
         let mut id = column("id", "integer");
         id.is_primary_key = true;
@@ -11772,16 +11801,20 @@ fn render_postgres_table_ddl_with_partition_info(
             .iter()
             .enumerate()
             .map(|(i, c)| {
+                // A real column is quoted via `pg_ident`; an expression/functional key part
+                // arrives as raw expression text (the per-column `pg_get_indexdef` omits the
+                // opclass — see `crates/dbx-core/src/db/postgres.rs`), so quoting the whole
+                // thing as an identifier would turn it into a nonexistent column reference
+                // (#6295).
                 let is_expr = idx.key_is_expression.get(i).copied().unwrap_or(false);
-                if is_expr {
-                    c.clone()
-                } else {
-                    let mut col = pg_ident(c);
-                    if let Some(opclass) = idx.column_opclasses.get(i).and_then(|o| o.as_deref()) {
-                        col.push_str(&format!(" {opclass}"));
-                    }
-                    col
+                let mut col = if is_expr { c.clone() } else { pg_ident(c) };
+                // The opclass is read separately from `pg_index.indclass` for every key
+                // position (including expression keys) and appended uniformly — it never
+                // lives inside the expression text, so there is no duplication risk.
+                if let Some(opclass) = idx.column_opclasses.get(i).and_then(|o| o.as_deref()) {
+                    col.push_str(&format!(" {opclass}"));
                 }
+                col
             })
             .collect::<Vec<_>>()
             .join(", ");

--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -2866,6 +2866,14 @@ pub fn diff_indexes(source: &[IndexInfo], target: &[IndexInfo]) -> Vec<IndexDiff
                 if source_included.is_empty() { "none".to_string() } else { source_included.join(", ") }
             ));
         }
+        if source_index.column_opclasses != target_index.column_opclasses {
+            let fmt_opclass = |o: &Option<String>| -> String {
+                o.as_deref().filter(|v| !v.is_empty()).unwrap_or("default").to_string()
+            };
+            let src_str = source_index.column_opclasses.iter().map(fmt_opclass).collect::<Vec<_>>().join(", ");
+            let tgt_str = target_index.column_opclasses.iter().map(fmt_opclass).collect::<Vec<_>>().join(", ");
+            changes.push(format!("opclass: {} → {}", tgt_str, src_str));
+        }
         if !changes.is_empty() {
             diffs.push(IndexDiff {
                 diff_type: "modified".to_string(),
@@ -5645,6 +5653,7 @@ mod tests {
             included_columns: overrides.included_columns,
             comment: overrides.comment,
             key_is_expression: overrides.key_is_expression,
+            column_opclasses: vec![],
         }
     }
 
@@ -6591,6 +6600,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let diff = TableDiff {
             diff_type: "modified".into(),
@@ -6652,6 +6662,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let unchanged_fk = ForeignKeyInfo {
             name: "fk_events_parent".into(),
@@ -6989,6 +7000,7 @@ mod tests {
             included_columns: Some(vec!["payload".into()]),
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         let btree_sql = create_index_sql("events", &btree, DatabaseType::SqlServer, Some("dbo"));
         assert_eq!(
@@ -7007,6 +7019,7 @@ mod tests {
             included_columns: Some(vec!["status".into(), "payload".into()]),
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         };
         assert_eq!(
             create_index_sql("events", &columnstore, DatabaseType::SqlServer, Some("dbo")),
@@ -7702,6 +7715,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_orders_status".to_string(),
@@ -7713,12 +7727,51 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
 
         assert_eq!(diffs.len(), 1);
         assert_eq!(diffs[0].diff_type, "modified");
         assert_eq!(diffs[0].changes, vec!["unique: YES → NO", "columns: status → status, created_at"]);
+    }
+
+    #[test]
+    fn detects_opclass_change_in_postgres_index() {
+        let source_index = index(IndexInfo {
+            name: "idx_name_trgm".to_string(),
+            columns: vec!["name".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: Some("gin".to_string()),
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![false],
+            column_opclasses: vec![Some("gin_trgm_ops".to_string())],
+        });
+        let target_index = index(IndexInfo {
+            name: "idx_name_trgm".to_string(),
+            columns: vec!["name".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: Some("gin".to_string()),
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![false],
+            column_opclasses: vec![None],
+        });
+
+        let diffs = diff_indexes(&[source_index], &[target_index]);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].diff_type, "modified");
+        assert!(
+            diffs[0].changes.iter().any(|c| c.contains("opclass")),
+            "Expected opclass change line, got: {:?}",
+            diffs[0].changes
+        );
     }
 
     #[test]
@@ -7734,6 +7787,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
         let target_index = index(IndexInfo {
             name: "test_UNIQUE".to_string(),
@@ -7745,6 +7799,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: Vec::new(),
+            column_opclasses: vec![],
         });
 
         let diffs = diff_indexes(std::slice::from_ref(&source_index), &[target_index]);
@@ -7806,6 +7861,7 @@ mod tests {
             included_columns: None,
             comment: None,
             key_is_expression: vec![false, false, false, true],
+            column_opclasses: vec![],
         });
 
         let sql = generate_schema_sync_sql(
@@ -7865,6 +7921,7 @@ mod tests {
                 expression_key_part.to_string(),
             ],
             key_is_expression: vec![false, false, false, true],
+            column_opclasses: vec![],
             is_unique: true,
             is_primary: false,
             filter: None,
@@ -7931,6 +7988,7 @@ mod tests {
                 name: "idx_weird_columns".to_string(),
                 columns: vec!["order item".to_string(), "a(b)".to_string(), "a::b".to_string()],
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
                 is_unique: false,
                 is_primary: false,
                 filter: None,
@@ -8116,6 +8174,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })),
                 target: None,
                 changes: Vec::new(),
@@ -8459,6 +8518,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })),
                 target: None,
                 changes: Vec::new(),
@@ -9181,6 +9241,7 @@ mod tests {
                     included_columns: Some(vec!["User ID".to_string()]),
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })],
                 foreign_keys: vec![foreign_key(ForeignKeyInfo {
                     name: "Order User FK".to_string(),
@@ -9244,6 +9305,7 @@ mod tests {
                     included_columns: None,
                     comment: Some("status lookup".to_string()),
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })],
                 foreign_keys: vec![foreign_key(ForeignKeyInfo {
                     name: "user-fk".to_string(),
@@ -9297,6 +9359,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })],
                 foreign_keys: vec![foreign_key(ForeignKeyInfo {
                     name: "parent item fk".to_string(),
@@ -10369,6 +10432,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })),
                 target: None,
                 changes: vec![],
@@ -10410,6 +10474,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 })),
                 changes: vec![],
             }]),
@@ -10808,6 +10873,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_t".into(),
@@ -10819,6 +10885,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
         assert_eq!(diffs.len(), 1, "index type diff detected");
@@ -10838,6 +10905,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_t".into(),
@@ -10849,6 +10917,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
         assert_eq!(diffs[0].changes.iter().filter(|c| c.contains("FULLTEXT")).count(), 1, "fulltext change");
@@ -10868,6 +10937,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_t".into(),
@@ -10879,6 +10949,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
         assert_eq!(diffs.len(), 1, "order diff detected");
@@ -10899,6 +10970,7 @@ mod tests {
                 included_columns: Some(vec!["b".into(), "c".into()]),
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_t".into(),
@@ -10910,6 +10982,7 @@ mod tests {
                 included_columns: Some(vec!["b".into()]),
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
         assert_eq!(diffs.len(), 1, "included columns diff detected");
@@ -10929,6 +11002,7 @@ mod tests {
                 included_columns: Some(vec!["b".into()]),
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_t".into(),
@@ -10940,6 +11014,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
         assert_eq!(diffs.len(), 1, "included added");
@@ -10959,6 +11034,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
             &[index(IndexInfo {
                 name: "idx_t".into(),
@@ -10970,6 +11046,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             })],
         );
         assert_eq!(diffs.len(), 1, "filter diff");
@@ -10991,6 +11068,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 }),
                 index(IndexInfo {
                     name: "idx_modified".into(),
@@ -11002,6 +11080,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 }),
             ],
             &[
@@ -11015,6 +11094,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 }),
                 index(IndexInfo {
                     name: "idx_modified".into(),
@@ -11026,6 +11106,7 @@ mod tests {
                     included_columns: None,
                     comment: None,
                     key_is_expression: Vec::new(),
+                    column_opclasses: vec![],
                 }),
             ],
         );
@@ -11394,6 +11475,7 @@ mod tests {
                         included_columns: None,
                         comment: None,
                         key_is_expression: Vec::new(),
+                        column_opclasses: vec![],
                     })),
                     target: None,
                     changes: vec![],
@@ -11412,6 +11494,7 @@ mod tests {
                         included_columns: None,
                         comment: None,
                         key_is_expression: Vec::new(),
+                        column_opclasses: vec![],
                     })),
                     changes: vec![],
                 },
@@ -11807,6 +11890,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             }),
             target: None,
             changes: vec![],
@@ -12059,6 +12143,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             }),
             target: None,
             changes: vec![],

--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -5653,7 +5653,7 @@ mod tests {
             included_columns: overrides.included_columns,
             comment: overrides.comment,
             key_is_expression: overrides.key_is_expression,
-            column_opclasses: vec![],
+            column_opclasses: overrides.column_opclasses,
         }
     }
 

--- a/crates/dbx-core/src/table_structure_sql/indexes.rs
+++ b/crates/dbx-core/src/table_structure_sql/indexes.rs
@@ -114,6 +114,45 @@ pub(super) fn has_existing_index_change(index: &EditableStructureIndex) -> bool 
         || index_list_changed(&index.included_columns, original.included_columns.as_ref())
         || clean(&index.filter) != clean(original.filter.as_deref().unwrap_or(""))
         || clean(&index.comment) != clean(original.comment.as_deref().unwrap_or(""))
+        || index_opclasses_changed(
+            &index.column_opclasses,
+            &original.column_opclasses,
+            &index.columns,
+            &original.columns,
+        )
+}
+
+/// Compare opclass arrays positionally, skipping expression columns.
+/// When the column list has changed we already detect that above; here we only
+/// compare opclasses for columns that exist in both the edited and original lists.
+fn index_opclasses_changed(
+    next: &[Option<String>],
+    previous: &[Option<String>],
+    next_cols: &[String],
+    prev_cols: &[String],
+) -> bool {
+    // If the edited side has explicit opclasses, compare positionally.
+    if !next.is_empty() {
+        // Length mismatch (shouldn't happen when columns are in lockstep, but
+        // defend against it): any difference in length is a change.
+        if next.len() != previous.len() {
+            return true;
+        }
+        return next.iter().zip(previous.iter()).any(|(n, p)| {
+            let n_flat = n.as_deref().map(|v| clean(v)).filter(|v| !v.is_empty());
+            let p_flat = p.as_deref().map(|v| clean(v)).filter(|v| !v.is_empty());
+            n_flat != p_flat
+        });
+    }
+    // If the edited side has no opclasses, check whether the original side
+    // had any non-default opclasses for columns still present.
+    if previous.iter().any(|o| o.as_deref().map(|v| !clean(v).is_empty()).unwrap_or(false)) {
+        let prev_set: std::collections::HashSet<_> = prev_cols.iter().map(|c| clean(c)).collect();
+        return next_cols.iter().zip(previous.iter()).any(|(nc, po)| {
+            po.as_deref().map(|v| !clean(v).is_empty()).unwrap_or(false) && prev_set.contains(&clean(nc))
+        });
+    }
+    false
 }
 
 pub(super) fn index_list_changed(next: &[String], previous: Option<&Vec<String>>) -> bool {
@@ -170,14 +209,18 @@ fn mysql_index_column_sql(column: &str) -> String {
     }
 }
 
-fn postgres_index_column_sql(column: &str, is_expression: bool) -> String {
+fn postgres_index_column_sql(column: &str, is_expression: bool, opclass: Option<&str>) -> String {
     // Expression/functional index key parts arrive as raw expression text, not a plain
     // column name; quoting the whole expression as an identifier turns it into a literal
     // column reference that doesn't exist (#6295).
     if is_expression {
         column.trim().to_string()
     } else {
-        quote_ident(StructureDialect::Postgres, column)
+        let base = quote_ident(StructureDialect::Postgres, column.trim());
+        match opclass.filter(|o| !o.is_empty()) {
+            Some(opc) => format!("{} {}", base, opc),
+            None => base,
+        }
     }
 }
 
@@ -214,6 +257,49 @@ fn key_expression_flags(index: &EditableStructureIndex, columns: &[String]) -> V
                     original.key_is_expression.get(i).copied().unwrap_or(false)
                 }
                 None => false,
+            }
+        })
+        .collect()
+}
+
+/// Per-key operator class provenance for `columns` (the edited/current key list).
+///
+/// Honors explicit per-key opclasses (`index.column_opclasses`) positionally when
+/// they are aligned to `columns` (non-empty, same length) and represent a genuine
+/// edit: either there is no `original` (a newly created index, where the UI
+/// authors `column_opclasses` in lockstep with `columns`), or the edited
+/// opclasses differ from the round-tripped `original.column_opclasses`. A stale
+/// copy left behind by a column toggle/reorder — still equal to the original —
+/// falls through to the order-independent text-matching below, so opclasses are
+/// never misassigned positionally before the editor maintains `column_opclasses`
+/// in lockstep with `columns`. Once that lockstep is in place the guard always
+/// passes and the honor branch is authoritative.
+fn key_opclasses(index: &EditableStructureIndex, columns: &[String]) -> Vec<Option<String>> {
+    if !index.column_opclasses.is_empty()
+        && index.column_opclasses.len() == columns.len()
+        && index.original.as_ref().map_or(true, |original| original.column_opclasses != index.column_opclasses)
+    {
+        return index.column_opclasses.iter().cloned().collect();
+    }
+    let original = match &index.original {
+        Some(original) if !original.column_opclasses.is_empty() => original,
+        _ => return vec![None; columns.len()],
+    };
+    let mut consumed = vec![false; original.columns.len()];
+    columns
+        .iter()
+        .map(|column| {
+            let claimed = original
+                .columns
+                .iter()
+                .enumerate()
+                .find(|(i, original_column)| !consumed[*i] && *original_column == column);
+            match claimed {
+                Some((i, _)) => {
+                    consumed[i] = true;
+                    original.column_opclasses.get(i).cloned().flatten()
+                }
+                None => None,
             }
         })
         .collect()
@@ -278,6 +364,7 @@ pub(super) fn build_create_index_statements(
     let unique = if index.is_unique { "UNIQUE " } else { "" };
     let replace = if or_replace { "OR REPLACE " } else { "" };
     let key_is_expression = key_expression_flags(index, &columns);
+    let key_opclasses = key_opclasses(index, &columns);
     let cols = columns
         .iter()
         .enumerate()
@@ -287,7 +374,7 @@ pub(super) fn build_create_index_statements(
             } else if dialect == StructureDialect::GaussdbM {
                 gaussdbm_index_column_sql(column, key_is_expression[i])
             } else if dialect == StructureDialect::Postgres {
-                postgres_index_column_sql(column, key_is_expression[i])
+                postgres_index_column_sql(column, key_is_expression[i], key_opclasses[i].as_deref())
             } else if for_new_table {
                 quote_new_ident(database_type, dialect, column)
             } else {

--- a/crates/dbx-core/src/table_structure_sql/indexes.rs
+++ b/crates/dbx-core/src/table_structure_sql/indexes.rs
@@ -139,8 +139,8 @@ fn index_opclasses_changed(
             return true;
         }
         return next.iter().zip(previous.iter()).any(|(n, p)| {
-            let n_flat = n.as_deref().map(|v| clean(v)).filter(|v| !v.is_empty());
-            let p_flat = p.as_deref().map(|v| clean(v)).filter(|v| !v.is_empty());
+            let n_flat = n.as_deref().map(clean).filter(|v| !v.is_empty());
+            let p_flat = p.as_deref().map(clean).filter(|v| !v.is_empty());
             n_flat != p_flat
         });
     }
@@ -210,17 +210,18 @@ fn mysql_index_column_sql(column: &str) -> String {
 }
 
 fn postgres_index_column_sql(column: &str, is_expression: bool, opclass: Option<&str>) -> String {
-    // Expression/functional index key parts arrive as raw expression text, not a plain
-    // column name; quoting the whole expression as an identifier turns it into a literal
-    // column reference that doesn't exist (#6295).
-    if is_expression {
-        column.trim().to_string()
-    } else {
-        let base = quote_ident(StructureDialect::Postgres, column.trim());
-        match opclass.filter(|o| !o.is_empty()) {
-            Some(opc) => format!("{} {}", base, opc),
-            None => base,
-        }
+    // The base key text: a real column is quoted as an identifier; an expression/functional
+    // key part arrives as raw expression text (from the per-column `pg_get_indexdef`, which
+    // omits the opclass — see `list_indexes_with_sql`), so quoting the whole thing as an
+    // identifier would turn it into a nonexistent column reference (#6295).
+    let base =
+        if is_expression { column.trim().to_string() } else { quote_ident(StructureDialect::Postgres, column.trim()) };
+    // The opclass is read separately from `pg_index.indclass` for every key position
+    // (including expression keys) and appended uniformly — it never lives inside the
+    // expression text, so there is no duplication risk.
+    match opclass.filter(|o| !o.is_empty()) {
+        Some(opc) => format!("{} {}", base, opc),
+        None => base,
     }
 }
 
@@ -277,9 +278,9 @@ fn key_expression_flags(index: &EditableStructureIndex, columns: &[String]) -> V
 fn key_opclasses(index: &EditableStructureIndex, columns: &[String]) -> Vec<Option<String>> {
     if !index.column_opclasses.is_empty()
         && index.column_opclasses.len() == columns.len()
-        && index.original.as_ref().map_or(true, |original| original.column_opclasses != index.column_opclasses)
+        && index.original.as_ref().is_none_or(|original| original.column_opclasses != index.column_opclasses)
     {
-        return index.column_opclasses.iter().cloned().collect();
+        return index.column_opclasses.to_vec();
     }
     let original = match &index.original {
         Some(original) if !original.column_opclasses.is_empty() => original,

--- a/crates/dbx-core/src/table_structure_sql/sqlite_rebuild.rs
+++ b/crates/dbx-core/src/table_structure_sql/sqlite_rebuild.rs
@@ -1694,6 +1694,7 @@ mod tests {
             filter: String::new(),
             index_type: String::new(),
             included_columns: Vec::new(),
+            column_opclasses: Vec::new(),
             comment: String::new(),
             concurrently: false,
             original: None,
@@ -2013,6 +2014,7 @@ mod tests {
             filter: String::new(),
             index_type: String::new(),
             included_columns: Vec::new(),
+            column_opclasses: Vec::new(),
             comment: String::new(),
             concurrently: false,
             original: Some(IndexInfo {
@@ -2025,6 +2027,7 @@ mod tests {
                 included_columns: None,
                 comment: None,
                 key_is_expression: Vec::new(),
+                column_opclasses: vec![],
             }),
             marked_for_drop: true,
         });

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -120,6 +120,7 @@ fn index(name: &str, columns: &[&str]) -> EditableStructureIndex {
         filter: String::new(),
         index_type: String::new(),
         included_columns: Vec::new(),
+        column_opclasses: Vec::new(),
         comment: String::new(),
         concurrently: false,
         original: None,
@@ -140,6 +141,7 @@ fn existing_index(name: &str, columns: &[&str], is_unique: bool) -> EditableStru
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
     index
 }
@@ -231,6 +233,7 @@ fn builds_mysql_column_and_index_changes() {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
     let mut email_index = index("uniq_users_email", &["email"]);
     email_index.is_unique = true;
@@ -870,6 +873,7 @@ fn builds_informix_column_and_index_changes() {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
     let mut email_index = index("uniq_users_email", &["email"]);
     email_index.is_unique = true;
@@ -1305,6 +1309,7 @@ fn iris_drop_index_includes_table_name() {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
 
     let result = build_table_structure_change_sql(TableStructureSqlOptions {
@@ -1609,6 +1614,7 @@ fn gbase8a_uses_limited_mysql_ddl() {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
 
     let result = build_table_structure_change_sql(TableStructureSqlOptions {
@@ -2226,6 +2232,7 @@ fn qualifies_attached_sqlite_table_and_index_changes() {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
     let email_index = index("idx_users_email", &["email"]);
 
@@ -6728,6 +6735,7 @@ fn oscar_drop_index_with_schema_qualifier() {
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
 
     let result = build_table_structure_change_sql(TableStructureSqlOptions {
@@ -7184,6 +7192,7 @@ fn gaussdb_m_index(name: &str, columns: &[&str]) -> EditableStructureIndex {
         filter: String::new(),
         index_type: String::new(),
         included_columns: Vec::new(),
+        column_opclasses: Vec::new(),
         comment: String::new(),
         concurrently: false,
         original: None,
@@ -7210,6 +7219,7 @@ fn gaussdb_m_existing_index(
         included_columns: None,
         comment: None,
         key_is_expression: Vec::new(),
+        column_opclasses: vec![],
     });
     idx
 }
@@ -7541,4 +7551,239 @@ fn mysql_add_column_nullable_timestamp_without_default_gets_explicit_null() {
 
     assert_eq!(result.warnings, Vec::<String>::new());
     assert_eq!(result.statements, vec!["ALTER TABLE `u7_game_order_step` ADD COLUMN `updated_at` timestamp NULL;"]);
+}
+
+// ── PostgreSQL operator class tests ──
+
+#[test]
+fn postgres_gin_index_with_explicit_opclass_generates_opclass_in_ddl() {
+    let mut idx = index("idx_name_trgm", &["name"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("gin_trgm_ops".to_string())];
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
+    assert!(sql.contains(r#""name" gin_trgm_ops"#), "Expected opclass in DDL, got: {sql}");
+    assert!(sql.contains("USING gin"), "Expected USING gin, got: {sql}");
+}
+
+#[test]
+fn postgres_index_opclass_from_original_when_editable_empty() {
+    // When the editable side has no opclass, fall back to original matching.
+    let mut idx = index("idx_name_trgm", &["name"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![]; // empty: fall back to original
+    idx.original = Some(IndexInfo {
+        name: "idx_name_trgm".to_string(),
+        columns: vec!["name".to_string()],
+        is_unique: false,
+        is_primary: false,
+        filter: None,
+        index_type: Some("gin".to_string()),
+        included_columns: None,
+        comment: None,
+        key_is_expression: vec![false],
+        column_opclasses: vec![Some("gin_trgm_ops".to_string())],
+    });
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
+    assert!(sql.contains(r#""name" gin_trgm_ops"#), "Expected opclass from original, got: {sql}");
+}
+
+#[test]
+fn postgres_index_no_rebuild_when_original_has_opclass_and_edit_is_identical() {
+    // When the edited index matches the original (including opclass), no rebuild.
+    let mut idx = index("idx_name_trgm", &["name"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("gin_trgm_ops".to_string())];
+    idx.original = Some(IndexInfo {
+        name: "idx_name_trgm".to_string(),
+        columns: vec!["name".to_string()],
+        is_unique: false,
+        is_primary: false,
+        filter: None,
+        index_type: Some("gin".to_string()),
+        included_columns: None,
+        comment: None,
+        key_is_expression: vec![false],
+        column_opclasses: vec![Some("gin_trgm_ops".to_string())],
+    });
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    assert!(result.statements.is_empty(), "Expected no rebuild for unchanged index, got: {:?}", result.statements);
+}
+
+#[test]
+fn postgres_index_rebuild_when_opclass_changed() {
+    // When opclass changes, the index should be rebuilt.
+    let mut idx = index("idx_name_trgm", &["name"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("gin_trgm_ops".to_string())];
+    idx.original = Some(IndexInfo {
+        name: "idx_name_trgm".to_string(),
+        columns: vec!["name".to_string()],
+        is_unique: false,
+        is_primary: false,
+        filter: None,
+        index_type: Some("gin".to_string()),
+        included_columns: None,
+        comment: None,
+        key_is_expression: vec![false],
+        column_opclasses: vec![None], // was default, now gin_trgm_ops
+    });
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    assert!(!result.statements.is_empty(), "Expected rebuild when opclass changes");
+    let sql = result.statements.join("\n");
+    assert!(sql.contains("DROP INDEX"), "Expected DROP INDEX, got: {sql}");
+    assert!(sql.contains("gin_trgm_ops"), "Expected new opclass in DDL, got: {sql}");
+}
+
+#[test]
+fn postgres_gin_varchar_no_opclass_warns() {
+    let mut idx = index("idx_name_search", &["name"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![];
+
+    let mut options = index_change_options(DatabaseType::Postgres, Some("public"), idx);
+    // Add a varchar column for the warning to match against.
+    options.columns.push(EditableStructureColumn {
+        id: "col_name".to_string(),
+        name: "name".to_string(),
+        data_type: "character varying(255)".to_string(),
+        is_nullable: true,
+        default_value: String::new(),
+        comment: String::new(),
+        is_primary_key: false,
+        extra: None,
+        original: None,
+        original_position: None,
+        marked_for_drop: false,
+        character_set: String::new(),
+        collation: String::new(),
+    });
+
+    let result = build_table_structure_change_sql(options);
+
+    assert!(
+        result.warnings.iter().any(|w| w.contains("operator class") && w.contains("idx_name_search")),
+        "Expected opclass warning for GIN+varchar, got: {:?}",
+        result.warnings
+    );
+}
+
+#[test]
+fn postgres_gin_text_column_with_explicit_opclass_no_warning() {
+    let mut idx = index("idx_body_search", &["body"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("gin_trgm_ops".to_string())];
+
+    let mut options = index_change_options(DatabaseType::Postgres, Some("public"), idx);
+    options.columns.push(EditableStructureColumn {
+        id: "col_body".to_string(),
+        name: "body".to_string(),
+        data_type: "text".to_string(),
+        is_nullable: true,
+        default_value: String::new(),
+        comment: String::new(),
+        is_primary_key: false,
+        extra: None,
+        original: None,
+        original_position: None,
+        marked_for_drop: false,
+        character_set: String::new(),
+        collation: String::new(),
+    });
+
+    let result = build_table_structure_change_sql(options);
+
+    assert!(
+        !result.warnings.iter().any(|w| w.contains("operator class")),
+        "Expected NO warning when opclass is set, got: {:?}",
+        result.warnings
+    );
+}
+
+#[test]
+fn postgres_expression_index_skips_opclass() {
+    // Expression columns don't get opclass appended.
+    let mut idx = index("idx_lower_email", &["lower(email)"]);
+    idx.column_opclasses = vec![Some("gin_trgm_ops".to_string())];
+    idx.original = Some(IndexInfo {
+        name: "idx_lower_email".to_string(),
+        columns: vec!["lower(email)".to_string()],
+        is_unique: false,
+        is_primary: false,
+        filter: None,
+        index_type: None,
+        included_columns: None,
+        comment: None,
+        key_is_expression: vec![true],
+        column_opclasses: vec![None],
+    });
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
+    // Expression key part should NOT have " gin_trgm_ops" appended.
+    assert!(!sql.contains("lower(email) gin_trgm_ops"), "Expression should not have opclass appended, got: {sql}");
+}
+
+#[test]
+fn postgres_jsonb_gin_with_jsonb_path_ops() {
+    let mut idx = index("idx_metadata", &["metadata"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("jsonb_path_ops".to_string())];
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
+    assert!(sql.contains(r#""metadata" jsonb_path_ops"#), "Expected jsonb_path_ops in DDL, got: {sql}");
+    assert!(sql.contains("USING gin"), "Expected USING gin, got: {sql}");
+}
+
+#[test]
+fn postgres_expression_index_preserves_opclass_embedded_in_text() {
+    // PostgreSQL introspection bundles an expression key's operator class inside
+    // the `pg_get_indexdef` text (e.g. `lower(email) gin_trgm_ops`) and reads
+    // `NULL` for that position's `column_opclasses` — see the note on
+    // `list_indexes_with_sql`. The verbatim expression path must emit the text
+    // as-is so the opclass survives a rebuild; appending a separate opclass would
+    // duplicate it (`lower(email) gin_trgm_ops gin_trgm_ops`).
+    let mut idx = index("idx_lower_email_trgm", &["lower(email) gin_trgm_ops"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![None];
+    idx.original = Some(IndexInfo {
+        name: "idx_lower_email_trgm_old".to_string(), // different name → forces rebuild
+        columns: vec!["lower(email) gin_trgm_ops".to_string()],
+        is_unique: false,
+        is_primary: false,
+        filter: None,
+        index_type: Some("gin".to_string()),
+        included_columns: None,
+        comment: None,
+        key_is_expression: vec![true],
+        column_opclasses: vec![None],
+    });
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
+    assert!(sql.contains("lower(email) gin_trgm_ops"), "Expected expression opclass preserved verbatim, got: {sql}");
+    assert!(
+        !sql.contains("lower(email) gin_trgm_ops gin_trgm_ops"),
+        "Opclass must not be duplicated for expression keys, got: {sql}"
+    );
 }

--- a/crates/dbx-core/src/table_structure_sql/tests.rs
+++ b/crates/dbx-core/src/table_structure_sql/tests.rs
@@ -7566,7 +7566,7 @@ fn postgres_gin_index_with_explicit_opclass_generates_opclass_in_ddl() {
     assert!(result.warnings.is_empty());
     let sql = result.statements.join("\n");
     assert!(sql.contains(r#""name" gin_trgm_ops"#), "Expected opclass in DDL, got: {sql}");
-    assert!(sql.contains("USING gin"), "Expected USING gin, got: {sql}");
+    assert!(sql.contains("USING GIN"), "Expected USING GIN, got: {sql}");
 }
 
 #[test]
@@ -7714,59 +7714,19 @@ fn postgres_gin_text_column_with_explicit_opclass_no_warning() {
 }
 
 #[test]
-fn postgres_expression_index_skips_opclass() {
-    // Expression columns don't get opclass appended.
+fn postgres_expression_index_appends_opclass() {
+    // The per-column `pg_get_indexdef(indexrelid, colno, pretty)` returns only the
+    // bare expression (PostgreSQL sets `attrsOnly = (colno != 0)`, so the
+    // opclass/COLLATE/DESC block is skipped — see `ruleutils.c` and the note on
+    // `list_indexes_with_sql`). The opclass is read separately from `indclass`
+    // into `column_opclasses`, so the generator must append it to an expression
+    // key just like a real column.
     let mut idx = index("idx_lower_email", &["lower(email)"]);
+    idx.index_type = "GIN".to_string();
     idx.column_opclasses = vec![Some("gin_trgm_ops".to_string())];
     idx.original = Some(IndexInfo {
         name: "idx_lower_email".to_string(),
         columns: vec!["lower(email)".to_string()],
-        is_unique: false,
-        is_primary: false,
-        filter: None,
-        index_type: None,
-        included_columns: None,
-        comment: None,
-        key_is_expression: vec![true],
-        column_opclasses: vec![None],
-    });
-
-    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
-
-    assert!(result.warnings.is_empty());
-    let sql = result.statements.join("\n");
-    // Expression key part should NOT have " gin_trgm_ops" appended.
-    assert!(!sql.contains("lower(email) gin_trgm_ops"), "Expression should not have opclass appended, got: {sql}");
-}
-
-#[test]
-fn postgres_jsonb_gin_with_jsonb_path_ops() {
-    let mut idx = index("idx_metadata", &["metadata"]);
-    idx.index_type = "GIN".to_string();
-    idx.column_opclasses = vec![Some("jsonb_path_ops".to_string())];
-
-    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
-
-    assert!(result.warnings.is_empty());
-    let sql = result.statements.join("\n");
-    assert!(sql.contains(r#""metadata" jsonb_path_ops"#), "Expected jsonb_path_ops in DDL, got: {sql}");
-    assert!(sql.contains("USING gin"), "Expected USING gin, got: {sql}");
-}
-
-#[test]
-fn postgres_expression_index_preserves_opclass_embedded_in_text() {
-    // PostgreSQL introspection bundles an expression key's operator class inside
-    // the `pg_get_indexdef` text (e.g. `lower(email) gin_trgm_ops`) and reads
-    // `NULL` for that position's `column_opclasses` — see the note on
-    // `list_indexes_with_sql`. The verbatim expression path must emit the text
-    // as-is so the opclass survives a rebuild; appending a separate opclass would
-    // duplicate it (`lower(email) gin_trgm_ops gin_trgm_ops`).
-    let mut idx = index("idx_lower_email_trgm", &["lower(email) gin_trgm_ops"]);
-    idx.index_type = "GIN".to_string();
-    idx.column_opclasses = vec![None];
-    idx.original = Some(IndexInfo {
-        name: "idx_lower_email_trgm_old".to_string(), // different name → forces rebuild
-        columns: vec!["lower(email) gin_trgm_ops".to_string()],
         is_unique: false,
         is_primary: false,
         filter: None,
@@ -7781,9 +7741,55 @@ fn postgres_expression_index_preserves_opclass_embedded_in_text() {
 
     assert!(result.warnings.is_empty());
     let sql = result.statements.join("\n");
-    assert!(sql.contains("lower(email) gin_trgm_ops"), "Expected expression opclass preserved verbatim, got: {sql}");
+    assert!(sql.contains("lower(email) gin_trgm_ops"), "Expression should have opclass appended, got: {sql}");
+}
+
+#[test]
+fn postgres_jsonb_gin_with_jsonb_path_ops() {
+    let mut idx = index("idx_metadata", &["metadata"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("jsonb_path_ops".to_string())];
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
+    assert!(sql.contains(r#""metadata" jsonb_path_ops"#), "Expected jsonb_path_ops in DDL, got: {sql}");
+    assert!(sql.contains("USING GIN"), "Expected USING GIN, got: {sql}");
+}
+
+#[test]
+fn postgres_expression_index_opclass_round_trips_from_indclass() {
+    // Real PostgreSQL introspection: the expression text from
+    // `pg_get_indexdef(indexrelid, colno, false)` is the BARE expression
+    // (`attrsOnly = (colno != 0)` drops the opclass block — see `ruleutils.c`).
+    // The opclass is read separately from `pg_index.indclass` (schema-qualified)
+    // into `column_opclasses`, so the generator appends it to the bare expression
+    // rather than expecting it to be embedded in the text.
+    let mut idx = index("idx_lower_email_trgm", &["lower(email)"]);
+    idx.index_type = "GIN".to_string();
+    idx.column_opclasses = vec![Some("public.gin_trgm_ops".to_string())];
+    idx.original = Some(IndexInfo {
+        name: "idx_lower_email_trgm_old".to_string(), // different name → forces rebuild
+        columns: vec!["lower(email)".to_string()],
+        is_unique: false,
+        is_primary: false,
+        filter: None,
+        index_type: Some("gin".to_string()),
+        included_columns: None,
+        comment: None,
+        key_is_expression: vec![true],
+        column_opclasses: vec![Some("public.gin_trgm_ops".to_string())],
+    });
+
+    let result = build_table_structure_change_sql(index_change_options(DatabaseType::Postgres, Some("public"), idx));
+
+    assert!(result.warnings.is_empty());
+    let sql = result.statements.join("\n");
     assert!(
-        !sql.contains("lower(email) gin_trgm_ops gin_trgm_ops"),
-        "Opclass must not be duplicated for expression keys, got: {sql}"
+        sql.contains("lower(email) public.gin_trgm_ops"),
+        "Expected bare expression + schema-qualified opclass, got: {sql}"
     );
+    // The bare expression text no longer carries the opclass, so it cannot be duplicated.
+    assert!(!sql.contains("gin_trgm_ops gin_trgm_ops"), "Opclass must not be duplicated, got: {sql}");
 }

--- a/crates/dbx-core/src/table_structure_sql/types.rs
+++ b/crates/dbx-core/src/table_structure_sql/types.rs
@@ -94,6 +94,11 @@ pub struct EditableStructureIndex {
     pub index_type: String,
     #[serde(default)]
     pub included_columns: Vec<String>,
+    /// Parallel to `columns`: operator class for each key column (PostgreSQL).
+    /// `None` means default operator class. The UI keeps this array in lockstep
+    /// with `columns`; when empty, opclasses fall back to `original` matching.
+    #[serde(default)]
+    pub column_opclasses: Vec<Option<String>>,
     #[serde(default)]
     pub comment: String,
     #[serde(default)]
@@ -125,6 +130,9 @@ pub struct IndexInfo {
     /// (e.g. sourced from `pg_get_indexdef`), not a plain column name.
     #[serde(default)]
     pub key_is_expression: Vec<bool>,
+    /// Parallel to `columns`: operator class name for each key column, if non-default.
+    #[serde(default)]
+    pub column_opclasses: Vec<Option<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/dbx-core/src/table_structure_sql/validation.rs
+++ b/crates/dbx-core/src/table_structure_sql/validation.rs
@@ -43,6 +43,7 @@ pub(super) fn validate_draft(options: &TableStructureSqlOptions) -> Vec<String> 
     let active_columns: Vec<_> = options.columns.iter().filter(|column| !column.marked_for_drop).collect();
     validate_columns(&active_columns, &mut warnings);
     validate_dameng_identity(options, &active_columns, &mut warnings);
+    validate_gin_opclass_warnings(options, &mut warnings);
     for index in options
         .indexes
         .iter()
@@ -98,6 +99,70 @@ pub(super) fn validate_columns(columns: &[&EditableStructureColumn], warnings: &
         let key = clean(&column.name).to_lowercase();
         if !key.is_empty() && !names.insert(key) {
             warnings.push(format!("Column \"{}\" is duplicated.", column.name));
+        }
+    }
+}
+
+/// PostgreSQL GIN indexes on varchar/text/character columns without an explicit
+/// operator class are a common trap: the default `array_ops` class is rarely what
+/// the user wants, and `gin_trgm_ops` (from `pg_trgm` extension) or similar
+/// classes are almost always needed. This is a warning, not an error, because
+/// the default class may be deliberate in some cases.
+fn validate_gin_opclass_warnings(options: &TableStructureSqlOptions, warnings: &mut Vec<String>) {
+    let capabilities = capabilities_for(options.database_type);
+    if capabilities.dialect != StructureDialect::Postgres {
+        return;
+    }
+
+    // Build a lookup: column name (lowercased) → data type for active columns.
+    let col_types: std::collections::HashMap<String, &str> = options
+        .columns
+        .iter()
+        .filter(|col| !col.marked_for_drop)
+        .map(|col| (clean(&col.name).to_lowercase(), col.data_type.as_str()))
+        .collect();
+
+    let text_like = |dt: &str| -> bool {
+        let lower = dt.to_lowercase();
+        lower == "text"
+            || lower.starts_with("character varying")
+            || lower.starts_with("varchar")
+            || lower.starts_with("character")
+            || lower == "char"
+    };
+
+    for index in options.indexes.iter().filter(|idx| {
+        !idx.marked_for_drop
+            && clean(&idx.index_type).to_ascii_uppercase() == "GIN"
+            && (idx.original.is_none() || has_existing_index_change(idx))
+    }) {
+        for (i, col) in index.columns.iter().enumerate() {
+            let col_name = clean(col);
+            if col_name.is_empty() {
+                continue;
+            }
+            // Expression columns are not matched against table column types.
+            let is_expr =
+                index.original.as_ref().and_then(|orig| orig.key_is_expression.get(i).copied()).unwrap_or(false);
+            if is_expr {
+                continue;
+            }
+            // Check if this column has a text-like type.
+            let Some(dt) = col_types.get(&col_name.to_lowercase()) else {
+                continue;
+            };
+            if !text_like(dt) {
+                continue;
+            }
+            // Check if opclass is explicitly provided.
+            let has_opclass =
+                index.column_opclasses.get(i).and_then(|o| o.as_deref()).map(|v| !clean(v).is_empty()).unwrap_or(false);
+            if !has_opclass {
+                warnings.push(format!(
+                    "GIN index \"{}\" on column \"{}\" (type {}) has no operator class specified. Consider adding an operator class, e.g. `gin_trgm_ops` (requires pg_trgm extension) for text search.",
+                    index.name, col_name, dt
+                ));
+            }
         }
     }
 }

--- a/crates/dbx-core/src/table_structure_sql/validation.rs
+++ b/crates/dbx-core/src/table_structure_sql/validation.rs
@@ -133,7 +133,7 @@ fn validate_gin_opclass_warnings(options: &TableStructureSqlOptions, warnings: &
 
     for index in options.indexes.iter().filter(|idx| {
         !idx.marked_for_drop
-            && clean(&idx.index_type).to_ascii_uppercase() == "GIN"
+            && clean(&idx.index_type).eq_ignore_ascii_case("GIN")
             && (idx.original.is_none() || has_existing_index_change(idx))
     }) {
         for (i, col) in index.columns.iter().enumerate() {

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -2004,14 +2004,17 @@ fn sqlserver_row_number_page_sql(
 }
 
 fn postgres_index_column_sql(column: &str, is_expression: bool, opclass: Option<&str>) -> String {
-    if is_expression {
-        column.to_string()
-    } else {
-        let base = quote_identifier(column, &DatabaseType::Postgres);
-        match opclass.filter(|o| !o.is_empty()) {
-            Some(opc) => format!("{base} {opc}"),
-            None => base,
-        }
+    // The base key text: a real column is quoted as an identifier; an expression/functional
+    // key part arrives as raw expression text (the per-column `pg_get_indexdef` omits the
+    // opclass — see `crates/dbx-core/src/db/postgres.rs`), so quoting the whole thing as
+    // an identifier would turn it into a nonexistent column reference (#6295).
+    let base = if is_expression { column.to_string() } else { quote_identifier(column, &DatabaseType::Postgres) };
+    // The opclass is read separately from `pg_index.indclass` for every key position
+    // (including expression keys) and appended uniformly — it never lives inside the
+    // expression text, so there is no duplication risk.
+    match opclass.filter(|o| !o.is_empty()) {
+        Some(opc) => format!("{base} {opc}"),
+        None => base,
     }
 }
 
@@ -11756,14 +11759,19 @@ mod tests {
     }
 
     #[test]
-    fn postgres_index_ddl_expression_skips_opclass() {
+    fn postgres_index_ddl_expression_appends_opclass() {
+        // The per-column `pg_get_indexdef(indexrelid, colno, pretty)` returns only the
+        // bare expression (PostgreSQL sets `attrsOnly = (colno != 0)`, so the opclass
+        // block is skipped — see `ruleutils.c`). The opclass is read separately from
+        // `indclass` into `column_opclasses`, so transfer DDL must append it to an
+        // expression key just like a real column.
         let indexes = vec![db::IndexInfo {
             name: "users_lower_email_idx".to_string(),
             columns: vec!["lower(email)".to_string()],
             is_unique: false,
             is_primary: false,
             filter: None,
-            index_type: None,
+            index_type: Some("gin".to_string()),
             included_columns: None,
             comment: None,
             key_is_expression: vec![true],
@@ -11774,7 +11782,7 @@ mod tests {
 
         assert_eq!(
             sql,
-            vec!["CREATE INDEX IF NOT EXISTS \"users_lower_email_idx\" ON \"public\".\"users\" (lower(email))"
+            vec!["CREATE INDEX IF NOT EXISTS \"users_lower_email_idx\" ON \"public\".\"users\" USING gin (lower(email) gin_trgm_ops)"
                 .to_string()]
         );
     }

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1276,17 +1276,6 @@ fn query_result_has_rows(result: &db::QueryResult) -> bool {
     !result.rows.is_empty()
 }
 
-fn is_simple_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first.is_ascii_alphabetic()) {
-        return false;
-    }
-    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
 fn is_postgres_compat_transfer(source_db: &DatabaseType, target_db: &DatabaseType) -> bool {
     is_postgres_transfer_dialect(source_db) && is_postgres_transfer_dialect(target_db)
 }
@@ -2014,11 +2003,15 @@ fn sqlserver_row_number_page_sql(
     )
 }
 
-fn postgres_index_column_sql(column: &str) -> String {
-    if is_simple_identifier(column) {
-        quote_identifier(column, &DatabaseType::Postgres)
-    } else {
+fn postgres_index_column_sql(column: &str, is_expression: bool, opclass: Option<&str>) -> String {
+    if is_expression {
         column.to_string()
+    } else {
+        let base = quote_identifier(column, &DatabaseType::Postgres);
+        match opclass.filter(|o| !o.is_empty()) {
+            Some(opc) => format!("{base} {opc}"),
+            None => base,
+        }
     }
 }
 
@@ -2037,8 +2030,17 @@ fn generate_postgres_index_ddl(indexes: &[db::IndexInfo], table: &str, schema: &
             .filter(|value| !value.is_empty())
             .map(|value| format!(" USING {value}"))
             .unwrap_or_default();
-        let columns =
-            index.columns.iter().map(|column| postgres_index_column_sql(column)).collect::<Vec<_>>().join(", ");
+        let columns = index
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, column)| {
+                let is_expr = index.key_is_expression.get(i).copied().unwrap_or(false);
+                let opclass = index.column_opclasses.get(i).and_then(|o| o.as_deref());
+                postgres_index_column_sql(column, is_expr, opclass)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
         let include_clause = index
             .included_columns
             .as_ref()
@@ -11664,7 +11666,8 @@ mod tests {
             index_type: Some("btree".to_string()),
             included_columns: Some(vec!["created_at".to_string()]),
             comment: Some("lookup index".to_string()),
-            key_is_expression: Vec::new(),
+            key_is_expression: vec![true],
+            column_opclasses: vec![],
         }];
         let foreign_keys = vec![
             db::ForeignKeyInfo {
@@ -11702,6 +11705,123 @@ mod tests {
             vec![
                 "ALTER TABLE \"archive\".\"orders\" ADD CONSTRAINT \"orders_user_id_fkey\" FOREIGN KEY (\"user_id\", \"tenant_id\") REFERENCES \"archive\".\"users\" (\"id\", \"tenant_id\")".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn postgres_index_ddl_includes_opclass_for_gin_trigram() {
+        let indexes = vec![db::IndexInfo {
+            name: "users_name_trgm_idx".to_string(),
+            columns: vec!["name".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: Some("gin".to_string()),
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![false],
+            column_opclasses: vec![Some("gin_trgm_ops".to_string())],
+        }];
+
+        let sql = generate_postgres_index_ddl(&indexes, "users", "public");
+
+        assert_eq!(
+            sql,
+            vec!["CREATE INDEX IF NOT EXISTS \"users_name_trgm_idx\" ON \"public\".\"users\" USING gin (\"name\" gin_trgm_ops)".to_string()]
+        );
+    }
+
+    #[test]
+    fn postgres_index_ddl_no_opclass_when_all_default() {
+        let indexes = vec![db::IndexInfo {
+            name: "users_name_idx".to_string(),
+            columns: vec!["name".to_string(), "status".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: None,
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![false, false],
+            column_opclasses: vec![None, None],
+        }];
+
+        let sql = generate_postgres_index_ddl(&indexes, "users", "public");
+
+        assert_eq!(
+            sql,
+            vec!["CREATE INDEX IF NOT EXISTS \"users_name_idx\" ON \"public\".\"users\" (\"name\", \"status\")"
+                .to_string()]
+        );
+    }
+
+    #[test]
+    fn postgres_index_ddl_expression_skips_opclass() {
+        let indexes = vec![db::IndexInfo {
+            name: "users_lower_email_idx".to_string(),
+            columns: vec!["lower(email)".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: None,
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![true],
+            column_opclasses: vec![Some("gin_trgm_ops".to_string())],
+        }];
+
+        let sql = generate_postgres_index_ddl(&indexes, "users", "public");
+
+        assert_eq!(
+            sql,
+            vec!["CREATE INDEX IF NOT EXISTS \"users_lower_email_idx\" ON \"public\".\"users\" (lower(email))"
+                .to_string()]
+        );
+    }
+
+    #[test]
+    fn postgres_index_ddl_mixed_opclass_and_default() {
+        let indexes = vec![db::IndexInfo {
+            name: "users_name_status_idx".to_string(),
+            columns: vec!["name".to_string(), "status".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: Some("btree".to_string()),
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![false, false],
+            column_opclasses: vec![Some("text_pattern_ops".to_string()), None],
+        }];
+
+        let sql = generate_postgres_index_ddl(&indexes, "users", "public");
+
+        assert_eq!(
+            sql,
+            vec!["CREATE INDEX IF NOT EXISTS \"users_name_status_idx\" ON \"public\".\"users\" USING btree (\"name\" text_pattern_ops, \"status\")".to_string()]
+        );
+    }
+
+    #[test]
+    fn postgres_index_ddl_empty_column_opclasses_vec_falls_back_to_no_opclass() {
+        let indexes = vec![db::IndexInfo {
+            name: "users_name_idx".to_string(),
+            columns: vec!["name".to_string()],
+            is_unique: false,
+            is_primary: false,
+            filter: None,
+            index_type: None,
+            included_columns: None,
+            comment: None,
+            key_is_expression: vec![false],
+            column_opclasses: vec![],
+        }];
+
+        let sql = generate_postgres_index_ddl(&indexes, "users", "public");
+
+        assert_eq!(
+            sql,
+            vec!["CREATE INDEX IF NOT EXISTS \"users_name_idx\" ON \"public\".\"users\" (\"name\")".to_string()]
         );
     }
 

--- a/crates/dbx-core/src/types.rs
+++ b/crates/dbx-core/src/types.rs
@@ -456,6 +456,11 @@ pub struct IndexInfo {
     /// introspection source doesn't track this (provenance unknown for that dialect/path).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub key_is_expression: Vec<bool>,
+    /// Parallel to `columns`: operator class name for each key column, if non-default.
+    /// For example, a GIN trigram index on a varchar column will have `"gin_trgm_ops"`.
+    /// `None` means the default operator class is used (can be omitted in DDL).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub column_opclasses: Vec<Option<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/dbx-core/tests/live_postgres_concurrent_index.rs
+++ b/crates/dbx-core/tests/live_postgres_concurrent_index.rs
@@ -25,6 +25,7 @@ fn concurrent_index(columns: Vec<&str>) -> EditableStructureIndex {
         filter: String::new(),
         index_type: String::new(),
         included_columns: Vec::new(),
+        column_opclasses: Vec::new(),
         comment: String::new(),
         concurrently: true,
         original: None,


### PR DESCRIPTION
# GIN 索引操作符类丢失修复

> 分支：`fix/postgres-gin-index`
> 修复：GIN/GiST 索引 DDL 丢失 `gin_trgm_ops` 等操作符类；并补齐 schema 限定、变更检测、校验拦截、表达式索引保留

---

## 变更说明

修复 PostgreSQL GIN/GiST 索引在结构编辑器及 DDL 预览中丢失操作符类（如 `gin_trgm_ops`、`gist_trgm_ops`）的问题，并补齐一整套闭环。

**根因**：索引列回读只取列名（`COALESCE(a.attname, pg_get_indexdef(...))`），没有读取 `pg_index.indclass` 对应的 `pg_opclass`，所以普通列的操作符类被丢弃；重新生成 DDL 时变成裸列名，PG 执行报：

```
ERROR: data type character varying has no default operator class for access method "gin"
```

**修复（分层）**：

1. **模型**：`EditableStructureIndex` / `IndexInfo` 新增 `column_opclasses: Vec<Option<String>>`，与 `columns` 平行；`None` 表示默认操作符类。
2. **回读**：4 条索引 SQL（`POSTGRES_INDEXES_SQL` / `POSTGRES_INDEXES_COMPAT_SQL` / `postgres_indexes_for_relations_sql` / `postgres_indexes_for_relations_compat_sql`）经 `indclass` join `pg_opclass` 读出每列 opclass；非默认返回 **schema 限定名** `quote_ident(nspname) || '.' || quote_ident(opcname)`，默认返回 `NULL`；表达式键（`a.attname IS NULL`）同样按位读取 opclass——按列调用的 `pg_get_indexdef(indexrelid, colno, pretty)` 只返回裸表达式文本（PostgreSQL 对 `colno != 0` 强制 attrsOnly，opclass/COLLATE/DESC 块会被跳过，见 `ruleutils.c`），因此 opclass 必须从 `indclass` 读取而不是从该文本解析。另外 4 条 SQL 中 `pg_get_indexdef` 的 pretty 参数统一为 `false`：pretty 模式会重排/折叠表达式文本，raw 输出才能保证往返保真。
3. **生成**：`postgres_index_column_sql` 对列键追加 opclass（如 `"name" public.gin_trgm_ops`），列名一律双引号引用；表达式键输出裸表达式文本并统一追加按位读取的 opclass（如 `lower(email) public.gin_trgm_ops`）——文本中不含 opclass，无重复风险。
4. **编辑器显式 opclass**：`key_opclasses` 现在尊重编辑后的 `column_opclasses`（当其与列对齐且确有改动、或为新建索引时按位取值），否则回退到按列名匹配原索引——保证新建/改 opclass 的值能真正落到 SQL。
5. **变更检测**：`index_opclasses_changed` 比较 opclass；改 opclass 触发重建，未改不重建（避免无意义 DROP/CREATE）。
6. **校验拦截**：`validate_gin_opclass_warnings` 对 `varchar`/`text`/`char` 列 + GIN 且未指定 opclass 出警告；结构编辑器 `canApply` 仍按全部警告禁用（既有逻辑），图同步 `execute` 收窄为**仅在 GIN 缺 opclass 警告时禁用**（`hasBlockingWarning`，其余降级类警告不阻断同步）——避免生成必报错的 SQL 被执行。
7. **表达式索引**：单测锁定表达式键从 `indclass` 回读 opclass 并在生成侧统一追加、往返一致且不重复。

## 变更类型

- [X] Bug 修复
- [X] 增强（schema 限定 opclass、opclass 变更检测、保存前校验拦截）

## 涉及前端

- [X] 本 PR 涉及前端改动（TS 类型同步、新建索引草稿默认 `columnOpclasses: []`、图同步 `execute` 警告 gate）
  - 注：结构编辑器「应用」按钮在有警告时禁用（`canApply` 早有 `warnings.length === 0` gate）、索引类型 Select 含 GIN/GiST 均为**既有逻辑**，非本 PR 新增；本 PR 通过后端新增 `validate_gin_opclass_warnings` 让 GIN 无 opclass 警告真正流到前端，从而激活上述既有 gate
  - 注2：图同步门禁在评审修订中**收窄**——由「任意警告即禁用」改为「仅 GIN 缺 opclass 警告阻断」（`hasBlockingWarning = warnings.some(w => w.includes("has no operator class specified"))`，匹配后端警告的语义核心，见 `validation.rs`）。降级类警告（如「… not supported … ignored」）不再卡住同步，而必报错的 GIN 无 opclass 仍拦截；结构编辑器 `canApply` 不变（仍按全部警告禁用）。
- [ ] **不含** opclass 输入 UI——编辑器尚不能手动指定/修改 opclass，只能原样往返已有索引的 opclass；新建 `varchar`+GIN 索引会触发警告并阻止保存（见测试场景 9），等 opclass 输入 UI 上线后可在编辑器内填 `gin_trgm_ops` 解决（后续 PR）

---


## 截图 / 录屏

重跑后预期：非默认 opclass 带 `public.` 前缀（前缀 = pg_trgm 所在 schema，默认 `public`），不再显示裸 `gin_trgm_ops`。完整步骤见测试指南场景 1–9，下方场景编号与指南一一对应。

### 1. GIN/GiST 索引 DDL 预览 — 含操作符类（带 schema 前缀）

右键 `test_gin_opclass` 表 → 查看 DDL，确认 GIN/GiST 索引列包含 opclass 且带 `public.` 前缀；`jsonb`/数组列的 GIN 索引不出现多余 opclass。

```sql
CREATE TABLE "public"."test_gin_opclass" (
  "id" serial NOT NULL,
  "name" character varying(255),
  "description" text,
  "tags" jsonb,
  "items" TEXT[],
  PRIMARY KEY ("id")
);

CREATE INDEX "idx_desc_trgm" ON "public"."test_gin_opclass" USING gin ("description" public.gin_trgm_ops);
CREATE INDEX "idx_items_array" ON "public"."test_gin_opclass" USING gin ("items");
CREATE INDEX "idx_multi_gin" ON "public"."test_gin_opclass" USING gin (
  "name" public.gin_trgm_ops,
  "description" public.gin_trgm_ops
);
CREATE INDEX "idx_name_gist" ON "public"."test_gin_opclass" USING gist ("name" public.gist_trgm_ops);
CREATE INDEX "idx_name_trgm_v2" ON "public"."test_gin_opclass" USING gin ("name" public.gin_trgm_ops);
CREATE INDEX "idx_tags_jsonb" ON "public"."test_gin_opclass" USING gin ("tags");
```

> ✅ 通过 — GIN/GiST 索引均带 `public.` 前缀（`public.gin_trgm_ops` / `public.gist_trgm_ops`）；`jsonb`（`idx_tags_jsonb`）与数组（`idx_items_array`）的 GIN 索引无多余 opclass。注：`idx_name_trgm` 已在场景 4 重命名为 `idx_name_trgm_v2`，opclass 仍保留。

### 2. B-tree 索引 DDL 预览 — 回归检查

确认 B-tree 索引列不包含多余操作符类，与修复前一致。

```sql
CREATE UNIQUE INDEX "idx_id_unique" ON "public"."test_gin_opclass" USING btree ("id");
CREATE INDEX "idx_multi_btree" ON "public"."test_gin_opclass" USING btree ("name", "description");
CREATE INDEX "idx_name_btree" ON "public"."test_gin_opclass" USING btree ("name");
```

> ✅ 通过 — 三条 B-tree 索引均无操作符类，与修复前一致。

### 3. 特殊列名 — 列名正确引用 + opclass

右键 `test_special_col` 表 → 查看 DDL，确认 `"My Column"`、`"my-column"` 正确引用，opclass 紧跟。

```sql
CREATE INDEX "idx_special_btree" ON "public"."test_special_col" USING btree ("my-column");
CREATE INDEX "idx_special_gin" ON "public"."test_special_col" USING gin ("My Column" public.gin_trgm_ops);
```

> ✅ 通过 — 含空格列名 `"My Column"` 正确引用且 opclass 带 `public.` 前缀紧跟；含短横线列名 `"my-column"` 正确引用，B-tree 无多余 opclass。

### 4. 结构编辑器 — 修改 GIN 索引（opclass 保留）

打开 `test_gin_opclass` 结构编辑器，将 `idx_name_trgm` 改名为 `idx_name_trgm_v2`，预览 SQL 确认保留 opclass。

```sql
DROP INDEX "public"."idx_name_trgm";
CREATE INDEX "idx_name_trgm_v2" ON "public"."test_gin_opclass" USING GIN ("name" public.gin_trgm_ops);
```

> ✅ 通过 — 应用后表 DDL 中重命名后的 `idx_name_trgm_v2` 仍带 `public.gin_trgm_ops`，确认 opclass 在重命名后保留。（场景 4 的「重建预览 SQL」未单独截取，此处以应用后 DDL 作为结果佐证。）

### 5. 结构编辑器 — 无修改回归（不误重建）

打开结构编辑器不做任何修改，点击应用，确认不生成任何索引变更语句。

<img width="1448" height="725" alt="预览为空" src="https://github.com/user-attachments/assets/f80b30e1-fb26-4ddc-8049-42729b141f3e" />


### 6. 结构编辑器 — B-tree 回归

修改 `idx_name_btree` 索引名，确认生成的 DDL 不包含多余操作符类。

```SQL
DROP INDEX "public"."idx_name_btree";
CREATE INDEX "idx_name_btree_v2" ON "public"."test_gin_opclass" USING BTREE ("name");
```

### 7. 数据传输

将 `test_gin_opclass` 表传输到另一个 PostgreSQL 数据库，确认目标库索引创建成功且含 opclass。

```SQL
CREATE TABLE "public"."test_gin_opclass" (
  "id" serial NOT NULL,
  "name" character varying(255),
  "description" text,
  "tags" jsonb,
  "items" TEXT[],
  PRIMARY KEY ("id")
);

CREATE INDEX "idx_desc_trgm" ON "public"."test_gin_opclass" USING gin ("description" public.gin_trgm_ops);

CREATE UNIQUE INDEX "idx_id_unique" ON "public"."test_gin_opclass" USING btree ("id");

CREATE INDEX "idx_items_array" ON "public"."test_gin_opclass" USING gin ("items");

CREATE INDEX "idx_multi_btree" ON "public"."test_gin_opclass" USING btree ("name", "description");

CREATE INDEX "idx_multi_gin" ON "public"."test_gin_opclass" USING gin (
  "name" public.gin_trgm_ops,
  "description" public.gin_trgm_ops
);

CREATE INDEX "idx_name_btree" ON "public"."test_gin_opclass" USING btree ("name");

CREATE INDEX "idx_name_gist" ON "public"."test_gin_opclass" USING gist ("name" public.gist_trgm_ops);

CREATE INDEX "idx_name_trgm" ON "public"."test_gin_opclass" USING gin ("name" public.gin_trgm_ops);

CREATE INDEX "idx_tags_jsonb" ON "public"."test_gin_opclass" USING gin ("tags");

ALTER TABLE "public"."test_gin_opclass" OWNER TO "postgres";
```

### 8. 非 PostgreSQL 数据库回归

连接 MySQL / SQLite 等数据库，右键任意表 → 查看 DDL，确认正常显示、无异常字符。

```sql
CREATE TABLE test_sqlite (id INTEGER PRIMARY KEY, name TEXT, email TEXT)
```

> ✅ 通过 — 连接 SQLite（`D:\Program\sqlite\test_opclass.db`），`test_sqlite` 表 DDL 正常渲染：类型/列名无乱码、无 opclass 字样、无报错。本 PR 对非 PG 驱动仅为机械的 `column_opclasses: vec![]` 默认值（无逻辑变更），opclass 生成/校验逻辑均锁在 PG 方言路径，故 SQLite 索引 DDL 生成行为不受影响。

### 9. 新建 GIN 未指定 opclass → 警告 + 应用禁用

在结构编辑器新建 `varchar` + GIN 索引但不指定 opclass，确认出警告且「应用」禁用。
<img width="1979" height="837" alt="暂不支持修改" src="https://github.com/user-attachments/assets/d1013d59-f0f1-40c0-b712-0eba636907b5" />

---

## 变更范围

| 层               | 文件                                                                                                         | 改动                                                                                                                                                                                                  |
| ---------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 后端·回读       | `crates/dbx-core/src/db/postgres.rs`                                                                       | 4 条索引 SQL 经`indclass` join `pg_opclass` 读 `column_opclasses`；现代（LATERAL）2 条做 schema 限定（join `pg_namespace opcns`）；2 个解析函数按 `indnkeyatts` 切分 key/included opclasses |
| 类型定义         | `crates/dbx-core/src/table_structure_sql/types.rs`                                                         | `EditableStructureIndex.column_opclasses` + `IndexInfo.column_opclasses`                                                                                                                          |
| DDL 生成         | `crates/dbx-core/src/table_structure_sql/indexes.rs`                                                       | `postgres_index_column_sql`(opclass 参数)、`key_opclasses`(尊重编辑值+原索引回退)、`index_opclasses_changed`(变更检测)                                                                          |
| 校验             | `crates/dbx-core/src/table_structure_sql/validation.rs`                                                    | `validate_gin_opclass_warnings`(varchar/text/char + GIN 无 opclass 出警告)                                                                                                                          |
| 入口             | `crates/dbx-core/src/table_structure_sql.rs`                                                               | `validate_draft` 接入 opclass 警告                                                                                                                                                                  |
| 前端·类型       | `apps/desktop/src/types/database.ts`、`apps/desktop/src/lib/table/tableStructureEditorSql.ts`            | `column_opclasses` / `columnOpclasses` 类型                                                                                                                                                       |
| 前端·状态       | `apps/desktop/src/lib/table/tableStructureEditorState.ts`、`apps/desktop/src/lib/diagram/draft-table.ts` | 加载/默认 opclass 数组                                                                                                                                                                                |
| 前端·结构编辑器 | `apps/desktop/src/components/structure/TableStructureEditor.vue`                                           | 新建索引草稿默认带`columnOpclasses: []`（`canApply` 警告 gate、索引类型 Select 含 GIN/GiST 均为既有逻辑，由后端新增警告激活）                                                                     |
| 前端·图同步     | `apps/desktop/src/components/diagram/DiagramSyncDialog.vue`                                                | `execute`/「执行」按钮门禁收窄：仅在 GIN 缺 opclass 警告时禁用（`hasBlockingWarning`）；其余降级类警告不阻断同步                                                                                                                                                              |
| 测试             | `crates/dbx-core/src/table_structure_sql/tests.rs`                                                         | opclass 生成/回退/变更检测/警告/表达式保留/jsonb_path_ops 单测（schema 限定由回读 SQL 文本保证，手测场景 1 验证）                                                                                     |
| 其他             | 多处`IndexInfo` / `EditableStructureIndex` 构造（含 `crates/dbx-core/tests/live_postgres_concurrent_index.rs` 测试 fixture）                                                          | 补`column_opclasses: vec![]` 默认值（live 测试 fixture 在评审修订中补齐以保持编译）                                                                                                                                                                 |

---

## 测试数据

在 PostgreSQL 14+ 中执行（pg_trgm 默认装到 `public`，故下方预期 DDL 带 `public.` 前缀）：

```sql
CREATE EXTENSION IF NOT EXISTS pg_trgm;

CREATE TABLE test_gin_opclass (
    id SERIAL PRIMARY KEY,
    name VARCHAR(255),
    description TEXT,
    tags JSONB,
    items TEXT[]
);

CREATE INDEX idx_name_trgm    ON test_gin_opclass USING gin  (name gin_trgm_ops);
CREATE INDEX idx_desc_trgm    ON test_gin_opclass USING gin  (description gin_trgm_ops);
CREATE INDEX idx_tags_jsonb   ON test_gin_opclass USING gin  (tags);
CREATE INDEX idx_items_array  ON test_gin_opclass USING gin  (items);
CREATE INDEX idx_multi_gin    ON test_gin_opclass USING gin  (name gin_trgm_ops, description gin_trgm_ops);
CREATE INDEX idx_name_gist    ON test_gin_opclass USING gist (name gist_trgm_ops);
CREATE INDEX idx_name_btree   ON test_gin_opclass USING btree (name);
CREATE UNIQUE INDEX idx_id_unique ON test_gin_opclass USING btree (id);
CREATE INDEX idx_multi_btree  ON test_gin_opclass USING btree (name, description);

CREATE TABLE test_special_col (
    id SERIAL PRIMARY KEY,
    "My Column" VARCHAR(255),
    "my-column" TEXT
);
CREATE INDEX idx_special_gin   ON test_special_col USING gin  ("My Column" gin_trgm_ops);
CREATE INDEX idx_special_btree ON test_special_col USING btree ("my-column");
```

---

## 测试清单

| # | 场景                                              | 结果 | 通过 |
| - | ------------------------------------------------- | ---- | ---- |
| 1 | GIN/GiST DDL 预览 — 操作符类保留且带 schema 前缀 | DDL  | ✅   |
| 2 | B-tree DDL 预览 — 不受影响                       | DDL  | ✅   |
| 3 | 特殊列名 — 引用正确 + opclass 带 schema          | DDL  | ✅   |
| 4 | 结构编辑器 — 修改 GIN 索引（opclass 保留）       | DDL  | ✅   |
| 5 | 结构编辑器 — 无修改回归（不误重建）              | 截图 | ✅   |
| 6 | 结构编辑器 — B-tree 回归                         | 截图 | ✅   |
| 7 | 数据传输                                          | 截图 | ✅   |
| 8 | 非 PostgreSQL 数据库回归                          | DDL | ✅   |
| 9 | 新建 GIN 未指定 opclass → 警告 + 应用禁用        | 截图 | ✅   |

---

## 单测对照

> 运行 `cargo test -p dbx-core`；当前环境若 `openssl-sys` vendored 构建失败（缺 Perl `Locale::Maketext::Simple`），需先装好该模块或换 Strawberry Perl。

| 单测                                                                          | 覆盖点                                                              |
| ----------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| `postgres_gin_index_with_explicit_opclass_generates_opclass_in_ddl`         | 新建索引显式 opclass 落到 DDL                                       |
| `postgres_index_opclass_from_original_when_editable_empty`                  | 编辑侧为空时回退原索引 opclass                                      |
| `postgres_index_no_rebuild_when_original_has_opclass_and_edit_is_identical` | 未改 opclass 不重建                                                 |
| `postgres_index_rebuild_when_opclass_changed`                               | 改 opclass 触发重建且用新值                                         |
| `postgres_gin_varchar_no_opclass_warns`                                     | varchar + GIN 无 opclass 出警告                                     |
| `postgres_gin_text_column_with_explicit_opclass_no_warning`                 | 指定 opclass 后不出警告                                             |
| `postgres_expression_index_appends_opclass`                                 | 表达式键统一追加 indclass 读取的 opclass                           |
| `postgres_expression_index_opclass_round_trips_from_indclass`               | 表达式 opclass 经 indclass 往返一致且不重复                        |
| `postgres_jsonb_gin_with_jsonb_path_ops`                                    | jsonb + GIN +`jsonb_path_ops`（非默认 opclass）不出警告且落到 DDL |

> 注：回读 SQL 对 opclass 做 schema 限定（`public.gin_trgm_ops`）由 `postgres.rs` 的 4 条查询文本保证，需真实 PG 连接才能验证，故由**手测场景 1**覆盖，无独立单测。

---

## 已知不在本修复范围

- **opclass 输入 UI**：结构编辑器尚不能选/输入 opclass，只能原样往返已有索引的 opclass；新建 `varchar`+GIN 索引会出警告并阻止保存（场景 9）。
- **兼容（pre-LATERAL）回读 SQL 的 schema 限定**：现代 LATERAL 2 条已 schema 限定；兼容 2 条保持裸 `oc.opcname`（旧 PG × 非默认 schema 扩展极少见，无回归）。
- **表达式索引 opclass 的手动验证**：由单测覆盖（表达式 key 的 opclass 同样从 `indclass` 按位读取，与列 key 一致）。


## 关联 Issue
Close #7166
