### PR TITLE
feat(sidebar): add setting to disable hover tooltips

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -540,6 +540,7 @@ const editSidebarCopyTableNameIncludeSchema = ref(settingsStore.editorSettings.s
 const editRedisKeyTemplates = ref(normalizeRedisKeyTemplates(settingsStore.editorSettings.redisKeyTemplates).join("\n"));
 const editSidebarObjectInfoMode = ref<SidebarObjectInfoMode>(settingsStore.editorSettings.sidebarObjectInfoMode);
 const editSidebarAllowHorizontalScroll = ref(settingsStore.editorSettings.sidebarAllowHorizontalScroll);
+const editSidebarShowTooltips = ref(settingsStore.editorSettings.sidebarShowTooltips);
 const editSidebarIndent = ref(settingsStore.editorSettings.sidebarIndent);
 const editSidebarFontSize = ref(settingsStore.editorSettings.sidebarFontSize);
 const editExportBatchSize = ref(settingsStore.editorSettings.exportBatchSize);
@@ -685,6 +686,7 @@ function currentEditorSettingsDraft(): EditorSettingsDraft {
     updateNotificationsEnabled: editUpdateNotificationsEnabled.value,
     sidebarObjectInfoMode: editSidebarObjectInfoMode.value,
     sidebarAllowHorizontalScroll: editSidebarAllowHorizontalScroll.value,
+    sidebarShowTooltips: editSidebarShowTooltips.value,
     sidebarIndent: editSidebarIndent.value,
     sidebarFontSize: editSidebarFontSize.value,
     sidebarHiddenTablePrefixes: normalizeSidebarHiddenTablePrefixes(editSidebarHiddenTablePrefixes.value),
@@ -1092,6 +1094,7 @@ function syncEditorSettingsDraftFromStore() {
   editRedisKeyTemplates.value = normalizeRedisKeyTemplates(settingsStore.editorSettings.redisKeyTemplates).join("\n");
   editSidebarObjectInfoMode.value = settingsStore.editorSettings.sidebarObjectInfoMode;
   editSidebarAllowHorizontalScroll.value = settingsStore.editorSettings.sidebarAllowHorizontalScroll;
+  editSidebarShowTooltips.value = settingsStore.editorSettings.sidebarShowTooltips;
   editSidebarIndent.value = settingsStore.editorSettings.sidebarIndent;
   editSidebarFontSize.value = settingsStore.editorSettings.sidebarFontSize;
   editExportBatchSize.value = settingsStore.editorSettings.exportBatchSize;
@@ -1355,6 +1358,7 @@ function resetDefaultsForTab(tab: SettingsCategory) {
     editUpdateNotificationsEnabled.value = DEFAULT_EDITOR_SETTINGS.updateNotificationsEnabled;
     editSidebarObjectInfoMode.value = DEFAULT_EDITOR_SETTINGS.sidebarObjectInfoMode;
     editSidebarAllowHorizontalScroll.value = DEFAULT_EDITOR_SETTINGS.sidebarAllowHorizontalScroll;
+    editSidebarShowTooltips.value = DEFAULT_EDITOR_SETTINGS.sidebarShowTooltips;
     editSidebarIndent.value = DEFAULT_EDITOR_SETTINGS.sidebarIndent;
     editSidebarFontSize.value = DEFAULT_EDITOR_SETTINGS.sidebarFontSize;
     editSidebarHiddenTablePrefixes.value = DEFAULT_EDITOR_SETTINGS.sidebarHiddenTablePrefixes.join("\n");
@@ -1491,6 +1495,7 @@ function resetAllDefaults() {
   editUpdateNotificationsEnabled.value = DEFAULT_EDITOR_SETTINGS.updateNotificationsEnabled;
   editSidebarObjectInfoMode.value = DEFAULT_EDITOR_SETTINGS.sidebarObjectInfoMode;
   editSidebarAllowHorizontalScroll.value = DEFAULT_EDITOR_SETTINGS.sidebarAllowHorizontalScroll;
+  editSidebarShowTooltips.value = DEFAULT_EDITOR_SETTINGS.sidebarShowTooltips;
   editSidebarIndent.value = DEFAULT_EDITOR_SETTINGS.sidebarIndent;
   editSidebarFontSize.value = DEFAULT_EDITOR_SETTINGS.sidebarFontSize;
   editSidebarHiddenTablePrefixes.value = DEFAULT_EDITOR_SETTINGS.sidebarHiddenTablePrefixes.join("\n");
@@ -5761,6 +5766,17 @@ onUnmounted(() => {
                   </HelpTooltip>
                 </div>
                 <Switch id="sidebar-allow-horizontal-scroll" v-model="editSidebarAllowHorizontalScroll" />
+              </div>
+              <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
+                <div class="flex items-center gap-2">
+                  <Label for="sidebar-show-tooltips">
+                    {{ t("settings.sidebarShowTooltips") }}
+                  </Label>
+                  <HelpTooltip :label="t('settings.sidebarShowTooltips')">
+                    {{ t("settings.sidebarShowTooltipsDescription") }}
+                  </HelpTooltip>
+                </div>
+                <Switch id="sidebar-show-tooltips" v-model="editSidebarShowTooltips" />
               </div>
               <div class="flex items-center justify-between gap-4 rounded-md border bg-muted/20 px-3 py-2">
                 <div class="space-y-1">

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -581,6 +581,7 @@ const detailTooltip = computed(() => {
 });
 
 function isTooltipDisabled(): boolean {
+  if (!settingsStore.editorSettings.sidebarShowTooltips) return true;
   if (detailTooltip.value?.rows.length) return isRenamingGroup.value;
   return isRenamingGroup.value || !labelOverflowing.value;
 }
@@ -1033,6 +1034,7 @@ function shouldMeasureLabelOverflow(): boolean {
     hasDetailTooltip: !!detailTooltip.value?.rows.length,
     isRenaming: isRenamingGroup.value || isRenamingSavedSql.value || isRenamingConnection.value,
     usesFullWidthLabel: usesFullWidthLabel.value,
+    tooltipsDisabled: !settingsStore.editorSettings.sidebarShowTooltips,
   });
 }
 

--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.visibleFilterDetail.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.visibleFilterDetail.spec.ts
@@ -69,6 +69,7 @@ vi.mock("@/stores/settingsStore", () => ({
       sidebarAllowHorizontalScroll: false,
       sidebarHiddenTablePrefixes: [],
       sidebarObjectInfoMode: "none",
+      sidebarShowTooltips: true,
     },
   }),
 }));

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6587,6 +6587,8 @@ export default {
     sidebarObjectInfoModeHidden: "None",
     sidebarAllowHorizontalScroll: "Allow sidebar horizontal scroll",
     sidebarAllowHorizontalScrollDescription: "Show long table, view, and collection names in full by allowing horizontal sidebar scrolling.",
+    sidebarShowTooltips: "Sidebar hover tooltips",
+    sidebarShowTooltipsDescription: "Show detail tooltips when hovering connections and database objects in the sidebar. Turn off to stop hover popups.",
     sidebarIndent: "Sidebar indentation",
     sidebarIndentDescription: "Horizontal offset added per tree depth level, in pixels.",
     sidebarFontSize: "Sidebar font size",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6258,6 +6258,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "Ninguna",
     sidebarAllowHorizontalScroll: "Permitir desplazamiento horizontal lateral",
     sidebarAllowHorizontalScrollDescription: "Muestra completos los nombres largos de tablas, vistas y colecciones permitiendo desplazamiento horizontal en la barra lateral.",
+    sidebarShowTooltips: "Sugerencias al pasar el cursor en la barra lateral",
+    sidebarShowTooltipsDescription: "Muestra sugerencias con detalles al pasar el cursor sobre conexiones y objetos de la base de datos en la barra lateral. Desactívalo para ocultarlas.",
     snippetsDescription: "Personaliza plantillas SQL activadas en el editor.",
     syncSnippetProviderGitee: "Fragmentos de Gitee",
     snippetsAdd: "Agregar fragmento",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6258,6 +6258,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "Nessuna",
     sidebarAllowHorizontalScroll: "Consenti scorrimento orizzontale barra laterale",
     sidebarAllowHorizontalScrollDescription: "Mostra i nomi lunghi di tabelle, viste e collezioni per intero consentendo lo scorrimento orizzontale della barra laterale.",
+    sidebarShowTooltips: "Tooltip al passaggio del mouse nella barra laterale",
+    sidebarShowTooltipsDescription: "Mostra tooltip con dettagli al passaggio del mouse su connessioni e oggetti del database nella barra laterale. Disattiva per nasconderli.",
     snippetsDescription: "Personalizza i modelli di snippet SQL attivati nell'editor.",
     syncSnippetProviderGitee: "Snippet Gitee",
     snippetsAdd: "Aggiungi Snippet",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6284,6 +6284,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "表示しない",
     sidebarAllowHorizontalScroll: "サイドバーの横スクロールを許可",
     sidebarAllowHorizontalScrollDescription: "サイドバーの横スクロールを許可して、長いテーブル、ビュー、コレクション名を完全に表示します。",
+    sidebarShowTooltips: "サイドバーのホバーツールチップ",
+    sidebarShowTooltipsDescription: "サイドバーで接続やデータベースオブジェクトにホバーしたときに詳細ツールチップを表示します。オフにすると表示されません。",
     snippetsDescription: "エディタでトリガーされるSQLスニペットテンプレートをカスタマイズします。",
     syncSnippetProviderGitee: "Gitee コードスニペット",
     snippetsAdd: "スニペットを追加",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5979,6 +5979,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "없음",
     sidebarAllowHorizontalScroll: "사이드바 가로 스크롤 허용",
     sidebarAllowHorizontalScrollDescription: "사이드바 가로 스크롤을 허용하여 긴 테이블, 뷰, 컬렉션 이름을 전체로 표시합니다.",
+    sidebarShowTooltips: "사이드바 호버 툴팁",
+    sidebarShowTooltipsDescription: "사이드바에서 연결 및 데이터베이스 개체에 마우스를 올리면 상세 툴팁을 표시합니다. 끄면 표시되지 않습니다.",
     snippetsDescription: "편집기에서 트리거되는 SQL 스니펫 템플릿을 사용자 정의합니다.",
     snippetsAdd: "스니펫 추가",
     snippetsLabel: "라벨",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6260,6 +6260,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "Nenhuma",
     sidebarAllowHorizontalScroll: "Permitir rolagem horizontal da barra lateral",
     sidebarAllowHorizontalScrollDescription: "Mostrar nomes longos de tabelas, views e coleções por completo, permitindo a rolagem horizontal da barra lateral.",
+    sidebarShowTooltips: "Dicas ao passar o mouse na barra lateral",
+    sidebarShowTooltipsDescription: "Mostra dicas com detalhes ao passar o mouse sobre conexões e objetos do banco de dados na barra lateral. Desative para ocultá-las.",
     snippetsDescription: "Personalize os modelos de snippets SQL acionados no editor.",
     syncSnippetProviderGitee: "Snippets do Gitee",
     snippetsAdd: "Adicionar snippet",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6569,6 +6569,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "不显示",
     sidebarAllowHorizontalScroll: "允许侧边栏横向滚动",
     sidebarAllowHorizontalScrollDescription: "完整显示较长的表、视图和集合名称；默认关闭以保留省略号截断。",
+    sidebarShowTooltips: "侧边栏悬浮提示",
+    sidebarShowTooltipsDescription: "在侧边栏的连接和数据库对象上悬浮时显示详情提示；关闭后悬浮不再弹出。",
     sidebarIndent: "侧边栏缩进",
     sidebarIndentDescription: "每个树层级缩进的像素偏移量。",
     sidebarFontSize: "侧边栏字体大小",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5575,6 +5575,8 @@ export default withEnglishFallback({
     sidebarObjectInfoModeHidden: "不顯示",
     sidebarAllowHorizontalScroll: "允許側邊欄水平捲動",
     sidebarAllowHorizontalScrollDescription: "透過啟用側邊欄的水平捲動功能，完整顯示長表格、檢視和集合的名稱",
+    sidebarShowTooltips: "側邊欄懸浮提示",
+    sidebarShowTooltipsDescription: "在側邊欄的連線與資料庫物件上懸浮時顯示詳細提示；關閉後懸浮不再彈出。",
     snippetsDescription: "自訂編輯器中觸發的 SQL 程式碼片段範本。",
     syncSnippetProviderGitee: "Gitee 程式碼片段",
     snippetsAdd: "新增片段",

--- a/apps/desktop/src/lib/__tests__/sidebar/sidebarLabelTooltip.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/sidebarLabelTooltip.spec.ts
@@ -3,9 +3,13 @@ import { shouldMeasureSidebarLabelOverflow } from "@/lib/sidebar/sidebarLabelToo
 
 describe("shouldMeasureSidebarLabelOverflow", () => {
   it("measures only plain truncated-label tooltip candidates", () => {
-    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: false })).toBe(true);
-    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: true, isRenaming: false, usesFullWidthLabel: false })).toBe(false);
-    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: true, usesFullWidthLabel: false })).toBe(false);
-    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: true })).toBe(false);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: false, tooltipsDisabled: false })).toBe(true);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: true, isRenaming: false, usesFullWidthLabel: false, tooltipsDisabled: false })).toBe(false);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: true, usesFullWidthLabel: false, tooltipsDisabled: false })).toBe(false);
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: true, tooltipsDisabled: false })).toBe(false);
+  });
+
+  it("skips measuring when sidebar tooltips are disabled", () => {
+    expect(shouldMeasureSidebarLabelOverflow({ hasDetailTooltip: false, isRenaming: false, usesFullWidthLabel: false, tooltipsDisabled: true })).toBe(false);
   });
 });

--- a/apps/desktop/src/lib/settings/editorSettingsDraft.ts
+++ b/apps/desktop/src/lib/settings/editorSettingsDraft.ts
@@ -80,6 +80,7 @@ export const EDITOR_SETTINGS_DRAFT_KEYS = [
   "updateNotificationsEnabled",
   "sidebarObjectInfoMode",
   "sidebarAllowHorizontalScroll",
+  "sidebarShowTooltips",
   "sidebarIndent",
   "sidebarFontSize",
   "sidebarHiddenTablePrefixes",

--- a/apps/desktop/src/lib/settings/settingsSearch.ts
+++ b/apps/desktop/src/lib/settings/settingsSearch.ts
@@ -174,6 +174,7 @@ export const SETTINGS_SEARCH_DEFINITIONS: readonly SettingsSearchDefinition[] = 
   { id: "navigation-browse-objects-on-database-activation", category: "navigation", titleKey: "settings.sidebarBrowseObjectsOnDatabaseActivation", descriptionKey: "settings.sidebarBrowseObjectsOnDatabaseActivationDescription", targetId: "navigation" },
   { id: "navigation-tabs-restore", category: "navigation", titleKey: "settings.openTabsRestoreMode", descriptionKey: "settings.openTabsRestoreModeDescription", targetId: "navigation" },
   { id: "navigation-sidebar-scroll", category: "navigation", titleKey: "settings.sidebarAllowHorizontalScroll", descriptionKey: "settings.sidebarAllowHorizontalScrollDescription", targetId: "navigation" },
+  { id: "navigation-sidebar-tooltips", category: "navigation", titleKey: "settings.sidebarShowTooltips", descriptionKey: "settings.sidebarShowTooltipsDescription", targetId: "navigation" },
   { id: "navigation-sidebar-indent", category: "navigation", titleKey: "settings.sidebarIndent", descriptionKey: "settings.sidebarIndentDescription", targetId: "navigation" },
   { id: "navigation-sidebar-font-size", category: "navigation", titleKey: "settings.sidebarFontSize", descriptionKey: "settings.sidebarFontSizeDescription", targetId: "navigation" },
   { id: "navigation-hidden-tables", category: "navigation", titleKey: "settings.sidebarHiddenTablePrefixes", descriptionKey: "settings.sidebarHiddenTablePrefixesDescription", targetId: "navigation" },

--- a/apps/desktop/src/lib/sidebar/sidebarLabelTooltip.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarLabelTooltip.ts
@@ -1,3 +1,3 @@
-export function shouldMeasureSidebarLabelOverflow(options: { hasDetailTooltip: boolean; isRenaming: boolean; usesFullWidthLabel: boolean }): boolean {
-  return !options.isRenaming && !options.hasDetailTooltip && !options.usesFullWidthLabel;
+export function shouldMeasureSidebarLabelOverflow(options: { hasDetailTooltip: boolean; isRenaming: boolean; usesFullWidthLabel: boolean; tooltipsDisabled: boolean }): boolean {
+  return !options.tooltipsDisabled && !options.isRenaming && !options.hasDetailTooltip && !options.usesFullWidthLabel;
 }

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -120,6 +120,12 @@ describe("normalizeEditorSettings", () => {
     expect(normalizeEditorSettings({ sidebarShowConnectionNotes: false }).sidebarShowConnectionNotes).toBe(false);
   });
 
+  it("shows sidebar tooltips by default and preserves an explicit opt-out", () => {
+    expect(normalizeEditorSettings({}).sidebarShowTooltips).toBe(true);
+    expect(normalizeEditorSettings({ sidebarShowTooltips: false }).sidebarShowTooltips).toBe(false);
+    expect(normalizeEditorSettings({ sidebarShowTooltips: true }).sidebarShowTooltips).toBe(true);
+  });
+
   it("defaults SQL execution to the current statement and migrates legacy execute-all settings", () => {
     expect(normalizeEditorSettings({}).executeMode).toBe("current");
     expect(normalizeEditorSettings({ executeMode: "all" }).executeMode).toBe("current");

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -748,6 +748,7 @@ export interface EditorSettings {
   sidebarCopyTableNameIncludeSchema: boolean;
   sidebarObjectInfoMode: SidebarObjectInfoMode;
   sidebarShowConnectionNotes: boolean;
+  sidebarShowTooltips: boolean;
   sidebarAllowHorizontalScroll: boolean;
   sidebarIndent: number;
   sidebarFontSize: number;
@@ -972,6 +973,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   sidebarCopyTableNameIncludeSchema: false,
   sidebarObjectInfoMode: "comment-inline",
   sidebarShowConnectionNotes: false,
+  sidebarShowTooltips: true,
   sidebarAllowHorizontalScroll: false,
   sidebarIndent: SIDEBAR_INDENT_DEFAULT,
   sidebarFontSize: SIDEBAR_FONT_SIZE_DEFAULT,
@@ -1441,6 +1443,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
       ).sidebarShowDatabaseSizes,
     ),
     sidebarShowConnectionNotes: settings.sidebarShowConnectionNotes === true,
+    sidebarShowTooltips: settings.sidebarShowTooltips ?? DEFAULT_EDITOR_SETTINGS.sidebarShowTooltips,
     sidebarAllowHorizontalScroll: settings.sidebarAllowHorizontalScroll ?? DEFAULT_EDITOR_SETTINGS.sidebarAllowHorizontalScroll,
     sidebarIndent: normalizeSidebarIndent(settings.sidebarIndent),
     sidebarFontSize: normalizeSidebarFontSize(settings.sidebarFontSize),
@@ -2033,6 +2036,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.sidebarCopyTableNameIncludeSchema !== undefined) editorSettings.value.sidebarCopyTableNameIncludeSchema = partial.sidebarCopyTableNameIncludeSchema === true;
     if (partial.sidebarObjectInfoMode !== undefined) editorSettings.value.sidebarObjectInfoMode = normalizeSidebarObjectInfoMode(partial.sidebarObjectInfoMode);
     if (partial.sidebarShowConnectionNotes !== undefined) editorSettings.value.sidebarShowConnectionNotes = partial.sidebarShowConnectionNotes === true;
+    if (partial.sidebarShowTooltips !== undefined) editorSettings.value.sidebarShowTooltips = partial.sidebarShowTooltips;
     if (partial.sidebarAllowHorizontalScroll !== undefined) editorSettings.value.sidebarAllowHorizontalScroll = partial.sidebarAllowHorizontalScroll;
     if (partial.sidebarIndent !== undefined) editorSettings.value.sidebarIndent = normalizeSidebarIndent(partial.sidebarIndent);
     if (partial.sidebarFontSize !== undefined) editorSettings.value.sidebarFontSize = normalizeSidebarFontSize(partial.sidebarFontSize);


### PR DESCRIPTION
Sidebar tree rows show an instant hover tooltip (connection details, comments, truncated labels) that can occlude the workspace. Add a sidebarShowTooltips editor setting (default on) under Settings -> Navigation so users can turn it off; when off, label-overflow measuring is skipped as well.

Fixes #7822



## 修改内容
左侧栏连接/数据库树的悬浮提示(悬浮即出的详情卡片和截断名称提示)在
工作区容易遮挡。新增"侧边栏悬浮提示"开关:设置 → 导航 → 侧边栏悬浮提示,
关闭后悬浮不再弹出,打开恢复。默认开启,不影响现有行为。

## 实现
- `settingsStore`:新增 `sidebarShowTooltips` 设置(默认 true)
- `TreeItem.vue`:tooltip 禁用逻辑按设置生效(详情卡片/注释/截断提示统一覆盖)
- `sidebarLabelTooltip.ts`:关闭时跳过文本溢出测量
- 设置对话框"导航"分类新增 Switch,注册草稿键与设置搜索索引
- 8 个语言文案

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="3500" height="2196" alt="image" src="https://github.com/user-attachments/assets/4d1297ad-bee6-4cb4-8c5f-e9405795b33a" />

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #7822