### PR TITLE
test: 补充 SQL 补全前缀替换回归测试

### DIFF
--- a/packages/app-tests/sqlCompletion.test.ts
+++ b/packages/app-tests/sqlCompletion.test.ts
@@ -948,6 +948,27 @@ test("replaces partially typed quoted identifiers without duplicating quotes", (
   }
 });
 
+test("replaces typed unquoted prefixes through semantic SQL completion", () => {
+  for (const prefix of ["n", "na"] as const) {
+    const sql = `select * from test where ${prefix}`;
+    const cursor = sql.length;
+    const options = { databaseType: "sqlserver", dialect: "sqlserver" } as const;
+    const context = sqlCompletionContextFromSemantic(buildSqlSemanticModel(sql, cursor, options), getSqlCompletionContext(sql, cursor, options));
+    const items = buildSqlCompletionItemsFromContext(context, {
+      tables: [{ name: "test", schema: "dbo", type: "table" }],
+      columnsByTable: new Map([["test", [{ name: "name", table: "test", schema: "dbo" }]]]),
+      ...options,
+    });
+    const replacement = prepareSqlCompletionReplacement(sql, cursor, context, items);
+    const column = replacement.items.find((item) => item.type === "column" && item.label === "name");
+
+    assert.ok(column, prefix);
+    assert.deepEqual(context.replacementRange, { start: cursor - prefix.length, end: cursor }, prefix);
+    assert.equal(replacement.from, cursor - prefix.length, prefix);
+    assert.equal(`${sql.slice(0, replacement.from)}${column.apply ?? column.label}${sql.slice(cursor)}`, "select * from test where name", prefix);
+  }
+});
+
 test("suggests same-prefix tables while editing double-quoted Oracle-family identifiers", () => {
   for (const databaseType of ["oracle", "dameng"] as const) {
     const markedSql = 'SELECT * FROM "Fo|"';


### PR DESCRIPTION
## 问题

补充并固化 #7811 的 SQL 补全回归覆盖。

在 SQL 编辑器中输入字段名前缀后接受补全候选时，已输入的前缀必须被候选覆盖，而不能继续追加完整候选文本：

```sql
select * from test where n
```

选择 `name` 后应保持为：

```sql
select * from test where name
```

## 原因

补全接受由 CodeMirror completion result 的 `from` 范围控制。当前公共 SQL completion 路径已经通过 `prepareSqlCompletionReplacement` 使用语义模型计算出的当前 identifier replacement range；如果范围从光标位置开始，候选就会被追加而不是替换前缀。

## 修改

* 补充 SQL Server 语义补全路径的回归测试
* 覆盖单字符前缀 `n` 和双字符前缀 `na`
* 断言 `replacementRange`、completion `from` 以及最终 SQL 文本

本 PR 固化当前 main 中已有的公共 replacement-range 修复，避免 #7811 场景回归。

## 验证

* `pnpm --dir E:\AI生成代码\dbx_base\dbx-7811 exec vitest run packages/app-tests/sqlCompletion.test.ts` ✅ 244 passed
* `pnpm --dir E:\AI生成代码\dbx_base\dbx-7811 exec vitest run apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts apps/desktop/src/lib/__tests__/editor/sqlCompletionPresentation.spec.ts apps/desktop/src/lib/__tests__/editor/sqlCompletionInsertion.spec.ts apps/desktop/src/lib/__tests__/editor/queryEditorCompletionSelection.spec.ts apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts` ✅ 239 passed
* `git diff --check` ✅

覆盖场景：

* `n` + `name` → `name`
* `na` + `name` → `name`
* SQL Server `WHERE` 条件中的字段补全不会产生 `nname`

## 关联 Issue

Fixes #7811
