### PR TITLE
fix(argo,jdbc): 对齐星环 Inceptor 原生 ArgoDB 与 JDBC 的存储过程/视图 DDL 元数据能力

### DIFF
--- a/agents/drivers/hive-go/main.go
+++ b/agents/drivers/hive-go/main.go
@@ -407,7 +407,11 @@ func (server *server) dispatch(method string, params map[string]json.RawMessage)
 		result, err := server.getTableComment(stringParam(params, "schema"), stringParam(params, "table"))
 		return result, false, err
 	case "list_objects":
-		result, err := server.listObjects(stringParam(params, "schema"), metadataListConstraintsFromParams(params))
+		result, err := server.listObjects(
+			stringParam(params, "database"),
+			stringParam(params, "schema"),
+			metadataListConstraintsFromParams(params),
+		)
 		return result, false, err
 	case "list_data_types":
 		result, err := server.listDataTypes()
@@ -432,6 +436,7 @@ func (server *server) dispatch(method string, params map[string]json.RawMessage)
 		return []any{}, false, nil
 	case "get_object_source":
 		result, err := server.getObjectSource(
+			stringParam(params, "database"),
 			stringParam(params, "schema"),
 			firstNonEmpty(stringParam(params, "name"), stringParam(params, "table")),
 			stringParam(params, "object_type"),

--- a/agents/drivers/hive-go/metadata.go
+++ b/agents/drivers/hive-go/metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -437,7 +438,7 @@ func showViewsUnsupported(err error) bool {
 	return false
 }
 
-func (server *server) listObjects(schema string, constraints metadataListConstraints) ([]objectInfo, error) {
+func (server *server) listObjects(database, schema string, constraints metadataListConstraints) ([]objectInfo, error) {
 	if !acceptsHiveTable(constraints.ObjectTypes) && !(server.supportsRoutines() && acceptsHiveRoutine(constraints.ObjectTypes)) {
 		return []objectInfo{}, nil
 	}
@@ -453,14 +454,14 @@ func (server *server) listObjects(schema string, constraints metadataListConstra
 		}
 	}
 	if server.supportsRoutines() && acceptsRoutineType(constraints.ObjectTypes, "PROCEDURE") {
-		procedures, err := server.listRoutines(schema, constraints, "PROCEDURE")
+		procedures, err := server.listRoutines(database, schema, constraints, "PROCEDURE")
 		if err != nil {
 			return nil, err
 		}
 		values = append(values, procedures...)
 	}
 	if server.supportsRoutines() && acceptsRoutineType(constraints.ObjectTypes, "FUNCTION") {
-		functions, err := server.listRoutines(schema, constraints, "FUNCTION")
+		functions, err := server.listRoutines(database, schema, constraints, "FUNCTION")
 		if err != nil {
 			return nil, err
 		}
@@ -484,6 +485,31 @@ func (server *server) supportsRoutines() bool {
 	}
 }
 
+// routineDatabaseCandidates returns the database_name filters to try against
+// system.procedures_v / system.functions_v. The sidebar may pass the active
+// database through either the schema or database RPC parameter, so mirror the
+// JDBC plugin and try both before falling back to the connection default.
+func routineDatabaseCandidates(schema, database, connectionDatabase string) []string {
+	seen := map[string]bool{}
+	values := make([]string, 0, 3)
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			return
+		}
+		key := strings.ToLower(candidate)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		values = append(values, candidate)
+	}
+	add(database)
+	add(schema)
+	add(connectionDatabase)
+	return values
+}
+
 // listRoutines queries the server's procedure / function catalog views when the
 // driver supports them. Hive and most forks (ArgoDB, Inceptor, Transwarp) expose
 // stored procedures / functions through the system.procedures_v / system.functions_v
@@ -493,42 +519,53 @@ func (server *server) supportsRoutines() bool {
 // The query is best-effort: when the view is missing or the server rejects it
 // (older Hive without procedure support), the call returns an empty slice and
 // nil error so the caller can fall back to listing tables.
-func (server *server) listRoutines(schema string, constraints metadataListConstraints, routineType string) ([]objectInfo, error) {
+func (server *server) listRoutines(database, schema string, constraints metadataListConstraints, routineType string) ([]objectInfo, error) {
 	nameColumn := "procedure_name"
 	viewName := "system.procedures_v"
 	if strings.EqualFold(routineType, "FUNCTION") {
 		nameColumn = "function_name"
 		viewName = "system.functions_v"
 	}
-	// Routine listings are pinned to the active schema (or the connection's default
-	// database when the caller passes an empty schema). system.procedures_v /
-	// system.functions_v only contain rows for one specific database per query;
-	// there is no wildcard form. Falling back to the connection default keeps
-	// callers like the sidebar schema tree happy when they pass "" as the schema.
-	targetSchema := firstNonEmpty(schema, server.config.Database)
-	likePattern := buildRoutineLikePattern(constraints.Filter)
-	// database_name is a string column, so the schema filter must be a single-quoted
-	// literal — not a backtick-quoted identifier. ArgoDB/Inceptor reject lower(`ods`)
-	// against system.procedures_v with an ERROR_STATUS, while lower('ods') works.
-	schemaLiteral := "'" + strings.ReplaceAll(targetSchema, "'", "''") + "'"
-	sql := "SELECT " + nameColumn + " FROM " + viewName +
-		" WHERE lower(database_name) = lower(" + schemaLiteral + ")" +
-		" AND lower(" + nameColumn + ") LIKE " + likePattern +
-		" ORDER BY " + nameColumn
-	result, err := server.executeQuery(queryOptions{SQL: sql, MaxRows: metadataQueryLimit})
-	if err != nil {
-		// View missing or not supported — silently return empty list.
+	candidates := routineDatabaseCandidates(schema, database, server.config.Database)
+	if len(candidates) == 0 {
 		return []objectInfo{}, nil
 	}
-	values := make([]objectInfo, 0, len(result.Rows))
-	for _, row := range result.Rows {
-		name := rowString(row, 0)
-		if name == "" {
+	likePattern := buildRoutineLikePattern(constraints.Filter)
+	resolvedSchema := firstNonEmpty(schema, database, server.config.Database)
+	for _, targetSchema := range candidates {
+		// database_name is a string column, so the schema filter must be a single-quoted
+		// literal — not a backtick-quoted identifier. ArgoDB/Inceptor reject lower(`ods`)
+		// against system.procedures_v with an ERROR_STATUS, while lower('ods') works.
+		schemaLiteral := "'" + strings.ReplaceAll(targetSchema, "'", "''") + "'"
+		sql := "SELECT " + nameColumn + " FROM " + viewName +
+			" WHERE lower(database_name) = lower(" + schemaLiteral + ")" +
+			" AND lower(" + nameColumn + ") LIKE " + likePattern +
+			" ORDER BY " + nameColumn
+		result, err := server.executeQuery(queryOptions{SQL: sql, MaxRows: metadataQueryLimit})
+		if err != nil {
+			log.Printf(
+				"[hive-go][listRoutines] query failed: database=%q schema=%q routineType=%s sql=%q err=%v",
+				targetSchema,
+				resolvedSchema,
+				routineType,
+				sql,
+				err,
+			)
 			continue
 		}
-		values = append(values, objectInfo{Name: name, ObjectType: strings.ToUpper(routineType), Schema: schema, Comment: nil})
+		values := make([]objectInfo, 0, len(result.Rows))
+		for _, row := range result.Rows {
+			name := rowString(row, 0)
+			if name == "" {
+				continue
+			}
+			values = append(values, objectInfo{Name: name, ObjectType: strings.ToUpper(routineType), Schema: resolvedSchema, Comment: nil})
+		}
+		if len(values) > 0 {
+			return values, nil
+		}
 	}
-	return values, nil
+	return []objectInfo{}, nil
 }
 
 // buildRoutineLikePattern turns a user-supplied filter into a Hive-safe LIKE
@@ -692,8 +729,8 @@ func (server *server) getTableDDL(schema, table string) (string, error) {
 	return strings.Join(lines, "\n") + "\n", nil
 }
 
-func (server *server) getObjectSource(schema, name, objectType string) (objectSource, error) {
-	schema = firstNonEmpty(schema, server.config.Database)
+func (server *server) getObjectSource(database, schema, name, objectType string) (objectSource, error) {
+	schema = firstNonEmpty(schema, database, server.config.Database)
 	var source string
 	var err error
 	switch strings.ToUpper(objectType) {
@@ -701,7 +738,7 @@ func (server *server) getObjectSource(schema, name, objectType string) (objectSo
 		if !server.supportsRoutines() {
 			return objectSource{}, fmt.Errorf("routine source is not supported for %s connections", server.params.DatabaseType)
 		}
-		source, err = server.getRoutineSource(schema, name, strings.ToUpper(objectType))
+		source, err = server.getRoutineSource(database, schema, name, strings.ToUpper(objectType))
 	default:
 		source, err = server.getTableDDL(schema, name)
 	}
@@ -721,30 +758,47 @@ func (server *server) getObjectSource(schema, name, objectType string) (objectSo
 // string when the view is missing or the routine is not found, so callers can
 // fall back to other sources. full_text may span multiple rows (the underlying
 // query driver splits long strings), so we join them like getTableDDL does.
-func (server *server) getRoutineSource(schema, name, routineType string) (string, error) {
+func (server *server) getRoutineSource(database, schema, name, routineType string) (string, error) {
 	nameColumn := "procedure_name"
 	viewName := "system.procedures_v"
 	if strings.EqualFold(routineType, "FUNCTION") {
 		nameColumn = "function_name"
 		viewName = "system.functions_v"
 	}
-	sql := "SELECT full_text FROM " + viewName +
-		" WHERE lower(database_name) = lower('" + strings.ReplaceAll(schema, "'", "''") + "')" +
-		" AND " + nameColumn + " = '" + strings.ReplaceAll(name, "'", "''") + "'"
-	result, err := server.executeQuery(queryOptions{SQL: sql, MaxRows: metadataQueryLimit})
-	if err != nil {
+	candidates := routineDatabaseCandidates(schema, database, server.config.Database)
+	if len(candidates) == 0 {
 		return "", nil
 	}
-	lines := make([]string, 0, len(result.Rows))
-	for _, row := range result.Rows {
-		if line := firstRowValue(row); line != "" {
-			lines = append(lines, line)
+	escapedName := strings.ReplaceAll(name, "'", "''")
+	for _, targetSchema := range candidates {
+		sql := "SELECT full_text FROM " + viewName +
+			" WHERE lower(database_name) = lower('" + strings.ReplaceAll(targetSchema, "'", "''") + "')" +
+			" AND " + nameColumn + " = '" + escapedName + "'"
+		result, err := server.executeQuery(queryOptions{SQL: sql, MaxRows: metadataQueryLimit})
+		if err != nil {
+			log.Printf(
+				"[hive-go][getRoutineSource] query failed: database=%q schema=%q name=%q routineType=%s sql=%q err=%v",
+				targetSchema,
+				schema,
+				name,
+				routineType,
+				sql,
+				err,
+			)
+			continue
 		}
+		lines := make([]string, 0, len(result.Rows))
+		for _, row := range result.Rows {
+			if line := firstRowValue(row); line != "" {
+				lines = append(lines, line)
+			}
+		}
+		if len(lines) == 0 {
+			continue
+		}
+		return strings.Join(lines, "\n") + "\n", nil
 	}
-	if len(lines) == 0 {
-		return "", nil
-	}
-	return strings.Join(lines, "\n") + "\n", nil
+	return "", nil
 }
 
 func (server *server) getExplainInfo(sqlText string) (string, error) {

--- a/agents/drivers/hive-go/metadata.go
+++ b/agents/drivers/hive-go/metadata.go
@@ -488,7 +488,10 @@ func (server *server) supportsRoutines() bool {
 // routineDatabaseCandidates returns the database_name filters to try against
 // system.procedures_v / system.functions_v. The sidebar may pass the active
 // database through either the schema or database RPC parameter, so mirror the
-// JDBC plugin and try both before falling back to the connection default.
+// JDBC plugin and try both. The connection default is only a candidate when
+// the caller supplied neither parameter: appending it unconditionally would
+// return the default database's routines under an explicit database node that
+// has none of its own.
 func routineDatabaseCandidates(schema, database, connectionDatabase string) []string {
 	seen := map[string]bool{}
 	values := make([]string, 0, 3)
@@ -506,7 +509,9 @@ func routineDatabaseCandidates(schema, database, connectionDatabase string) []st
 	}
 	add(database)
 	add(schema)
-	add(connectionDatabase)
+	if strings.TrimSpace(database) == "" && strings.TrimSpace(schema) == "" {
+		add(connectionDatabase)
+	}
 	return values
 }
 

--- a/agents/drivers/hive-go/metadata_test.go
+++ b/agents/drivers/hive-go/metadata_test.go
@@ -612,8 +612,8 @@ func TestGetObjectSourceRoutesFunctionsToSystemFunctionsView(t *testing.T) {
 }
 
 func TestListRoutinesUsesDatabaseParameterWhenSchemaEmpty(t *testing.T) {
-	proceduresQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('ods') AND lower(procedure_name) LIKE '%' ORDER BY procedure_name"
-	defaultQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('default') AND lower(procedure_name) LIKE '%' ORDER BY procedure_name"
+	proceduresQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('ods') AND lower(procedure_name) LIKE '%%' ORDER BY procedure_name"
+	defaultQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('default') AND lower(procedure_name) LIKE '%%' ORDER BY procedure_name"
 	behavior := &scriptedBehavior{
 		query: func(_ context.Context, query string) (driver.Rows, error) {
 			switch query {

--- a/agents/drivers/hive-go/metadata_test.go
+++ b/agents/drivers/hive-go/metadata_test.go
@@ -503,7 +503,7 @@ func TestListObjectsIncludesProceduresAndFunctionsFromSystemViews(t *testing.T) 
 	server.params.DatabaseType = "argo"
 	defer server.disconnect()
 
-	values, err := server.listObjects("ods", metadataListConstraints{
+	values, err := server.listObjects("ods", "ods", metadataListConstraints{
 		ObjectTypes: []string{"PROCEDURE", "FUNCTION"},
 		Filter:      "sp", // "sp" overlaps the procedure filter; both lists get "%sp%" applied
 	})
@@ -611,6 +611,74 @@ func TestGetObjectSourceRoutesFunctionsToSystemFunctionsView(t *testing.T) {
 	}
 }
 
+func TestListRoutinesUsesDatabaseParameterWhenSchemaEmpty(t *testing.T) {
+	proceduresQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('ods') AND lower(procedure_name) LIKE '%' ORDER BY procedure_name"
+	defaultQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('default') AND lower(procedure_name) LIKE '%' ORDER BY procedure_name"
+	behavior := &scriptedBehavior{
+		query: func(_ context.Context, query string) (driver.Rows, error) {
+			switch query {
+			case defaultQuery:
+				return newScriptedRows(context.Background(), []string{"procedure_name"}, []string{"STRING"}, [][]driver.Value{}), nil
+			case proceduresQuery:
+				return newScriptedRows(context.Background(), []string{"procedure_name"}, []string{"STRING"}, [][]driver.Value{
+					{"sp_daily_etl"},
+				}), nil
+			default:
+				return nil, errors.New("unexpected query: " + query)
+			}
+		},
+	}
+	server := newScriptedServer(t, behavior)
+	server.params.DatabaseType = "argo"
+	server.config.Database = "default"
+	defer server.disconnect()
+
+	values, err := server.listObjects("ods", "", metadataListConstraints{
+		ObjectTypes: []string{"PROCEDURE"},
+	})
+	if err != nil {
+		t.Fatalf("listObjects: %v", err)
+	}
+	if len(values) != 1 || values[0].Name != "sp_daily_etl" {
+		t.Fatalf("expected procedure from database parameter, got %+v", values)
+	}
+}
+
+func TestGetObjectSourceUsesDatabaseParameterForRoutineSource(t *testing.T) {
+	expectedSQL := "SELECT full_text FROM system.procedures_v WHERE lower(database_name) = lower('ods') AND procedure_name = 'sp_daily_etl'"
+	behavior := &scriptedBehavior{
+		query: func(_ context.Context, query string) (driver.Rows, error) {
+			if query != expectedSQL {
+				return nil, errors.New("unexpected query: " + query)
+			}
+			return newScriptedRows(context.Background(), []string{"full_text"}, []string{"STRING"}, [][]driver.Value{
+				{"CREATE PROCEDURE sp_daily_etl() BEGIN SELECT 1; END"},
+			}), nil
+		},
+	}
+	server := newScriptedServer(t, behavior)
+	server.params.DatabaseType = "argo"
+	server.config.Database = "default"
+	defer server.disconnect()
+
+	result, _, err := server.dispatch("get_object_source", map[string]json.RawMessage{
+		"database":    json.RawMessage(`"ods"`),
+		"schema":      json.RawMessage(`""`),
+		"name":        json.RawMessage(`"sp_daily_etl"`),
+		"object_type": json.RawMessage(`"PROCEDURE"`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, ok := result.(objectSource)
+	if !ok {
+		t.Fatalf("get_object_source returned %T instead of objectSource", result)
+	}
+	if source.Source != "CREATE PROCEDURE sp_daily_etl() BEGIN SELECT 1; END\n" {
+		t.Fatalf("unexpected procedure source: %q", source.Source)
+	}
+}
+
 func TestListObjectsDoesNotQueryRoutinesForVanillaHive(t *testing.T) {
 	behavior := &scriptedBehavior{
 		query: func(ctx context.Context, query string) (driver.Rows, error) {
@@ -624,7 +692,7 @@ func TestListObjectsDoesNotQueryRoutinesForVanillaHive(t *testing.T) {
 	server.params.DatabaseType = "hive"
 	defer server.disconnect()
 
-	values, err := server.listObjects("ods", metadataListConstraints{
+	values, err := server.listObjects("ods", "ods", metadataListConstraints{
 		ObjectTypes: []string{"PROCEDURE", "FUNCTION"},
 	})
 	if err != nil {

--- a/agents/drivers/hive-go/metadata_test.go
+++ b/agents/drivers/hive-go/metadata_test.go
@@ -644,6 +644,36 @@ func TestListRoutinesUsesDatabaseParameterWhenSchemaEmpty(t *testing.T) {
 	}
 }
 
+func TestListRoutinesDoesNotFallbackToConnectionDefaultForExplicitSchema(t *testing.T) {
+	defaultQuery := "SELECT procedure_name FROM system.procedures_v WHERE lower(database_name) = lower('default') AND lower(procedure_name) LIKE '%%' ORDER BY procedure_name"
+	behavior := &scriptedBehavior{
+		query: func(_ context.Context, query string) (driver.Rows, error) {
+			if query == defaultQuery {
+				// Serving this row proves the driver fell back to the
+				// connection default after the explicit schema came back empty.
+				return newScriptedRows(context.Background(), []string{"procedure_name"}, []string{"STRING"}, [][]driver.Value{
+					{"sp_should_not_leak"},
+				}), nil
+			}
+			return newScriptedRows(context.Background(), []string{"procedure_name"}, []string{"STRING"}, [][]driver.Value{}), nil
+		},
+	}
+	server := newScriptedServer(t, behavior)
+	server.params.DatabaseType = "argo"
+	server.config.Database = "default"
+	defer server.disconnect()
+
+	values, err := server.listObjects("", "ods", metadataListConstraints{
+		ObjectTypes: []string{"PROCEDURE"},
+	})
+	if err != nil {
+		t.Fatalf("listObjects: %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected no routines to leak from the connection default database, got %+v", values)
+	}
+}
+
 func TestGetObjectSourceUsesDatabaseParameterForRoutineSource(t *testing.T) {
 	expectedSQL := "SELECT full_text FROM system.procedures_v WHERE lower(database_name) = lower('ods') AND procedure_name = 'sp_daily_etl'"
 	behavior := &scriptedBehavior{

--- a/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
+++ b/plugins/jdbc/src/main/java/app/dbx/jdbc/DbxJdbcPlugin.java
@@ -3979,6 +3979,9 @@ public final class DbxJdbcPlugin {
         if (isHive2RoutinesConnection(connection)) {
             String routineName = stripRoutineSignature(name);
             String normalizedType = normalizeObjectType(objectType);
+            if ("VIEW".equals(normalizedType) || "TABLE".equals(normalizedType) || "MATERIALIZED_VIEW".equals(normalizedType)) {
+                return hive2ShowCreateObjectSource(conn, database, schema, name, objectType);
+            }
 
             LinkedHashSet<String> candidates = new LinkedHashSet<>();
             String db = emptyToNull(database);
@@ -4026,6 +4029,83 @@ public final class DbxJdbcPlugin {
         }
 
         throw new SQLException("Object source is not supported by this JDBC driver");
+    }
+
+    private static JsonNode hive2ShowCreateObjectSource(
+        Connection conn,
+        String database,
+        String schema,
+        String name,
+        String objectType
+    ) throws SQLException {
+        LinkedHashSet<String> candidates = hive2DatabaseCandidates(database, schema);
+        if (candidates.isEmpty()) {
+            throw new SQLException("Object source requires database context for Hive/Inceptor objects");
+        }
+
+        SQLException lastError = null;
+        for (String candidateSchema : candidates) {
+            String sql = "SHOW CREATE TABLE " + qualifiedHiveName(candidateSchema, name);
+            try (Statement statement = conn.createStatement();
+                 ResultSet rs = statement.executeQuery(sql)) {
+                StringBuilder source = new StringBuilder();
+                while (rs.next()) {
+                    String line = rs.getString(1);
+                    if (line == null || line.isBlank()) {
+                        continue;
+                    }
+                    if (!source.isEmpty()) {
+                        source.append('\n');
+                    }
+                    source.append(line);
+                }
+                if (source.isEmpty()) {
+                    continue;
+                }
+                if (source.charAt(source.length() - 1) != '\n') {
+                    source.append('\n');
+                }
+                ObjectNode item = MAPPER.createObjectNode();
+                item.put("name", name);
+                item.put("object_type", objectType);
+                putNullable(item, "schema", emptyToNull(schema) != null ? schema : candidateSchema);
+                putNullable(item, "source", source.toString());
+                return item;
+            } catch (SQLException error) {
+                lastError = error;
+            }
+        }
+
+        if (lastError != null) {
+            throw lastError;
+        }
+        throw new SQLException("Object source not found");
+    }
+
+    private static LinkedHashSet<String> hive2DatabaseCandidates(String database, String schema) {
+        LinkedHashSet<String> candidates = new LinkedHashSet<>();
+        String db = emptyToNull(database);
+        if (db != null) {
+            candidates.add(db);
+        }
+        String sc = emptyToNull(schema);
+        if (sc != null) {
+            candidates.add(sc);
+        }
+        return candidates;
+    }
+
+    private static String qualifiedHiveName(String schema, String table) {
+        String trimmedSchema = schema == null ? "" : schema.trim();
+        String trimmedTable = table == null ? "" : table.trim();
+        if (trimmedSchema.isEmpty()) {
+            return quoteHiveBacktickIdentifier(trimmedTable);
+        }
+        return quoteHiveBacktickIdentifier(trimmedSchema) + "." + quoteHiveBacktickIdentifier(trimmedTable);
+    }
+
+    private static String quoteHiveBacktickIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
     }
 
     private static String oracleMetadataObjectType(String objectType) {

--- a/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
+++ b/plugins/jdbc/src/test/java/app/dbx/jdbc/DbxJdbcPluginTest.java
@@ -2172,6 +2172,43 @@ final class DbxJdbcPluginTest {
     }
 
     @Test
+    void getObjectSourceReturnsHive2ViewDdlFromShowCreateTable() throws Exception {
+        List<String> executedSql = new ArrayList<>();
+        Driver driver = new Hive2ViewDdlDriver(executedSql);
+        DriverManager.registerDriver(driver);
+        String connection = """
+            {
+              "connection_string": "jdbc:hive2://hive2-view-ddl-test:10000/default"
+            }
+            """;
+        try {
+            JsonNode response = request("getObjectSource", """
+                {
+                  "connection": %s,
+                  "database": "ods",
+                  "schema": "",
+                  "name": "active_users",
+                  "object_type": "VIEW"
+                }
+                """.formatted(connection));
+
+            assertFalse(response.has("error"), response.toString());
+            assertEquals(List.of("SHOW CREATE TABLE `ods`.`active_users`"), executedSql);
+            assertEquals(
+                "CREATE VIEW `ods`.`active_users` AS SELECT 1\n",
+                response.path("result").path("source").asText()
+            );
+            assertEquals("VIEW", response.path("result").path("object_type").asText());
+            assertEquals("active_users", response.path("result").path("name").asText());
+        } finally {
+            request("close", """
+                { "connection": %s }
+                """.formatted(connection));
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
     void listDataTypesUsesJdbcTypeInfo() throws Exception {
         JsonNode response = request("listDataTypes", """
             { "connection": %s }
@@ -4672,6 +4709,99 @@ final class DbxJdbcPluginTest {
         if (returnType == double.class) return 0d;
         if (returnType == char.class) return '\0';
         return null;
+    }
+
+    private static final class Hive2ViewDdlDriver implements Driver {
+        private final List<String> executedSql;
+
+        private Hive2ViewDdlDriver(List<String> executedSql) {
+            this.executedSql = executedSql;
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) {
+            if (!acceptsURL(url)) {
+                return null;
+            }
+            return (Connection) Proxy.newProxyInstance(
+                DbxJdbcPluginTest.class.getClassLoader(),
+                new Class<?>[] { Connection.class },
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "createStatement" -> hive2ViewDdlStatement(executedSql);
+                    case "isClosed" -> false;
+                    case "close" -> null;
+                    default -> defaultValue(method.getReturnType());
+                }
+            );
+        }
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return url != null && url.startsWith("jdbc:hive2://hive2-view-ddl-test:");
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public java.util.logging.Logger getParentLogger() {
+            return java.util.logging.Logger.getGlobal();
+        }
+    }
+
+    private static Statement hive2ViewDdlStatement(List<String> executedSql) {
+        return (Statement) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { Statement.class },
+            (proxy, method, args) -> switch (method.getName()) {
+                case "executeQuery" -> {
+                    executedSql.add(String.valueOf(args[0]));
+                    yield hive2ViewDdlResultSet();
+                }
+                case "close" -> null;
+                default -> defaultValue(method.getReturnType());
+            }
+        );
+    }
+
+    private static ResultSet hive2ViewDdlResultSet() {
+        final String[] lines = {
+            "CREATE VIEW `ods`.`active_users` AS SELECT 1"
+        };
+        return (ResultSet) Proxy.newProxyInstance(
+            DbxJdbcPluginTest.class.getClassLoader(),
+            new Class<?>[] { ResultSet.class },
+            new java.lang.reflect.InvocationHandler() {
+                private int index = -1;
+
+                @Override
+                public Object invoke(Object proxy, Method method, Object[] args) {
+                    return switch (method.getName()) {
+                        case "next" -> ++index < lines.length;
+                        case "getString" -> lines[index];
+                        case "close" -> null;
+                        default -> defaultValue(method.getReturnType());
+                    };
+                }
+            }
+        );
     }
 
     private static final class AdhocFailingHiveDriver implements Driver {


### PR DESCRIPTION
## Summary

- **原生 ArgoDB（hive-go）**：`listRoutines` / `getRoutineSource` 按 `database` → `schema` → 连接默认库多候选查询 `system.procedures_v` / `system.functions_v`；RPC 传入 `database` 参数；查询失败时打 warn 日志，避免静默空列表。
- **JDBC Inceptor（hive2）**：`getObjectSource` 对 `VIEW` / `TABLE` / `MATERIALIZED_VIEW` 执行 `SHOW CREATE TABLE`，与 hive-go 行为一致，补齐 JDBC 连星环时无法查看视图 DDL 的缺口。

Fixes #7859

## Test plan

- [ ] 原生 ArgoDB：侧边栏 PROCEDURE/FUNCTION 有数据；打开源码可见 `full_text`
- [ ] 原生 ArgoDB：视图 DDL 仍正常（回归）
- [ ] JDBC Inceptor：右键视图「查看源码/DDL」成功
- [ ] JDBC Inceptor：存储过程列表/源码仍正常（回归）
- [ ] `cd agents/drivers/hive-go && go test -run 'TestListRoutines|TestGetObjectSource' -v`
- [ ] `cd plugins/jdbc && ./gradlew test --tests app.dbx.jdbc.DbxJdbcPluginTest.getObjectSourceReturnsHive2ViewDdlFromShowCreateTable`