### PR TITLE
fix(sidebar): collapse the Queries node by default

### DIFF
--- a/apps/desktop/src/lib/__tests__/savedSql/savedSqlDatabaseTree.spec.ts
+++ b/apps/desktop/src/lib/__tests__/savedSql/savedSqlDatabaseTree.spec.ts
@@ -65,6 +65,11 @@ describe("database saved SQL tree", () => {
     expect(root).toMatchObject({ id: "conn-1:app:__queries", label: "tree.queries", type: "saved-sql-root", children: [] });
   });
 
+  it("collapses the Queries node by default when opening a connection", () => {
+    expect(buildDatabaseSavedSqlRootNode(database, files)?.isExpanded).toBe(false);
+    expect(buildDatabaseSavedSqlRootNode(database, [])?.isExpanded).toBe(false);
+  });
+
   it("adds Queries after database metadata and preserves its expansion state", () => {
     const existingRoot = { ...buildDatabaseSavedSqlRootNode(database, files)!, isExpanded: false };
     const decorated = decorateDatabaseSavedSqlTreeNodes(

--- a/apps/desktop/src/lib/savedSql/savedSqlDatabaseTree.ts
+++ b/apps/desktop/src/lib/savedSql/savedSqlDatabaseTree.ts
@@ -71,7 +71,9 @@ export function buildDatabaseSavedSqlRootNode(databaseNode: Pick<TreeNode, "id" 
     connectionId: databaseNode.connectionId,
     catalog: databaseNode.catalog,
     database: databaseNode.database,
-    isExpanded: existingRoot?.isExpanded ?? true,
+    // Default collapsed: opening a connection should not expand the Queries
+    // node until the user asks for it; an existing node's state is preserved.
+    isExpanded: existingRoot?.isExpanded ?? false,
     children: savedSqlFilesForDatabase(source, {
       connectionId: databaseNode.connectionId,
       catalog: databaseNode.catalog,


### PR DESCRIPTION
Opening a database connection showed the per-database Queries node expanded even before the user interacted with it. Default it to collapsed; manually toggled state is still preserved.

Fixes #7854

## 变更说明

## 问题
打开数据连接后,侧边栏数据库节点下的"查询"(Queries)节点默认是展开状态,
应该是折叠状态。

## 修改
`buildDatabaseSavedSqlRootNode` 创建节点时 `isExpanded` 默认值由 `true` 改为
`false`;已存在节点的展开/折叠状态仍按原逻辑保留。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
Close #7854