### PR TITLE
🐛 fix: 编辑多结果集某一条后提交不再清空其他结果集

### DIFF
--- a/apps/desktop/src/composables/useDataGridActions.ts
+++ b/apps/desktop/src/composables/useDataGridActions.ts
@@ -315,11 +315,13 @@ export function useDataGridActions(activeTab: ComputedRef<QueryTab | undefined>)
       return;
     }
     if (sql?.trim()) {
+      const hasMultiResults = tab.mode === "query" && (tab.results?.length ?? 0) > 1;
       await queryStore.executeTabSql(tab.id, sql, {
         ...(tab.mode === "query" ? activeQueryTargetOptions(tab) : {}),
         resultBaseSql: sql,
         resultSortedSql: undefined,
         preserveResultDuringExecution: true,
+        ...(hasMultiResults ? { replaceActiveResultInGroup: true, preserveActiveResultIndex: true } : {}),
       });
       return;
     }

--- a/packages/app-tests/useDataGridActions.test.ts
+++ b/packages/app-tests/useDataGridActions.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { computed, toRaw } from "vue";
 import { createPinia, setActivePinia } from "pinia";
-import { test, vi } from "vitest";
+import { describe, test, vi } from "vitest";
 import { useConnectionStore } from "../../apps/desktop/src/stores/connectionStore.ts";
 import { useQueryStore } from "../../apps/desktop/src/stores/queryStore.ts";
 import { useSettingsStore } from "../../apps/desktop/src/stores/settingsStore.ts";
@@ -283,4 +283,227 @@ test("query toolbar refresh reruns the complete multi-result SQL and keeps the a
   } finally {
     restoreStorage();
   }
+});
+
+describe("multi-result preservation after submit", () => {
+  function withConnectionHealthMock(
+    handler: typeof fetch,
+  ): typeof fetch {
+    return async (input, init) => {
+      const url = String(input);
+      if (url === "/api/connection/check-health") {
+        return Response.json(null);
+      }
+      return handler(input, init);
+    };
+  }
+
+  test("submit edit on first result preserves the second result", async () => {
+    const restoreStorage = installMemoryStorage();
+    const originalFetch = globalThis.fetch;
+    const { useDataGridActions } = await import(
+      "../../apps/desktop/src/composables/useDataGridActions.ts",
+    );
+
+    globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+      const url = String(input);
+      if (url === "/api/query/prepare-pagination-plan") {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        return new Response(
+          JSON.stringify({
+            sqlToExecute: body.options.sql,
+            useAgentResultSession: false,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (url === "/api/query/execute-multi") {
+        return new Response(
+          JSON.stringify([
+            {
+              columns: ["id"],
+              rows: [[11]],
+              affected_rows: 0,
+              execution_time_ms: 1,
+              sourceStatement: "select * from users",
+            },
+          ]),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (url === "/api/query/analyze-editability") {
+        return new Response(
+          JSON.stringify({ editable: false, reason: "complex-source" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      return new Response("unexpected request: " + url, {
+        status: 500,
+      });
+    });
+
+    try {
+      setActivePinia(createPinia());
+      const connectionStore = useConnectionStore();
+      const queryStore = useQueryStore();
+      connectionStore.addEphemeralConnection(conn("mysql-1"));
+
+      const tabId = queryStore.createTab("mysql-1", "app", "query", "query");
+      const tab = queryStore.tabs.find((item) => item.id === tabId);
+      assert.ok(tab);
+
+      // Simulate prior multi-statement execution with two results
+      const batchSql = "select * from users; select * from orders";
+      const resultA = {
+        columns: ["id"],
+        rows: [[1]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+        sourceStatement: "select * from users",
+      };
+      const resultB = {
+        columns: ["id"],
+        rows: [[2]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+        sourceStatement: "select * from orders",
+      };
+
+      tab.sql = batchSql;
+      tab.lastExecutedSql = batchSql;
+      tab.resultBaseSql = batchSql;
+      tab.results = [resultA, resultB];
+      tab.activeResultIndex = 0;
+      tab.result = resultA;
+
+      const actions = useDataGridActions(computed(() => tab));
+
+      // Simulate DataGrid submit reload: onReloadData with the current
+      // result's sourceStatement (single statement, not the full batch SQL)
+      await actions.onReloadData("select * from users");
+
+      // The second result must be preserved
+      assert.equal(tab.results?.length, 2, "both results must survive after submit");
+      assert.equal(tab.activeResultIndex, 0, "activeResultIndex must stay on the first result");
+      assert.equal(tab.results![0].rows[0][0], 11, "first result must be refreshed");
+      assert.equal(tab.results![1].rows[0][0], 2, "second result must be the original resultB");
+      assert.equal(tab.result, tab.results![0], "tab.result must point to the refreshed first result");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreStorage();
+    }
+  });
+
+  test("submit edit on second result preserves the first result", async () => {
+    const restoreStorage = installMemoryStorage();
+    const originalFetch = globalThis.fetch;
+    const { useDataGridActions } = await import(
+      "../../apps/desktop/src/composables/useDataGridActions.ts",
+    );
+
+    globalThis.fetch = withConnectionHealthMock(async (input, init) => {
+      const url = String(input);
+      if (url === "/api/query/prepare-pagination-plan") {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        return new Response(
+          JSON.stringify({
+            sqlToExecute: body.options.sql,
+            useAgentResultSession: false,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (url === "/api/query/execute-multi") {
+        return new Response(
+          JSON.stringify([
+            {
+              columns: ["id"],
+              rows: [[22]],
+              affected_rows: 0,
+              execution_time_ms: 1,
+              sourceStatement: "select * from orders",
+            },
+          ]),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (url === "/api/query/analyze-editability") {
+        return new Response(
+          JSON.stringify({ editable: false, reason: "complex-source" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      return new Response("unexpected request: " + url, {
+        status: 500,
+      });
+    });
+
+    try {
+      setActivePinia(createPinia());
+      const connectionStore = useConnectionStore();
+      const queryStore = useQueryStore();
+      connectionStore.addEphemeralConnection(conn("mysql-1"));
+
+      const tabId = queryStore.createTab("mysql-1", "app", "query", "query");
+      const tab = queryStore.tabs.find((item) => item.id === tabId);
+      assert.ok(tab);
+
+      // Simulate prior multi-statement execution with two results
+      const batchSql = "select * from users; select * from orders";
+      const resultA = {
+        columns: ["id"],
+        rows: [[1]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+        sourceStatement: "select * from users",
+      };
+      const resultB = {
+        columns: ["id"],
+        rows: [[2]],
+        affected_rows: 0,
+        execution_time_ms: 1,
+        sourceStatement: "select * from orders",
+      };
+
+      tab.sql = batchSql;
+      tab.lastExecutedSql = batchSql;
+      tab.resultBaseSql = batchSql;
+      tab.results = [resultA, resultB];
+      tab.activeResultIndex = 1;
+      tab.result = resultB;
+
+      const actions = useDataGridActions(computed(() => tab));
+
+      // Simulate DataGrid submit reload on the SECOND result
+      await actions.onReloadData("select * from orders");
+
+      // The first result must be preserved
+      assert.equal(tab.results?.length, 2, "both results must survive after submit on second result");
+      assert.equal(tab.activeResultIndex, 1, "activeResultIndex must stay on the second result");
+      assert.equal(tab.results![0].rows[0][0], 1, "first result must be the original resultA");
+      assert.equal(tab.results![1].rows[0][0], 22, "second result must be refreshed");
+      assert.equal(tab.result, tab.results![1], "tab.result must point to the refreshed second result");
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreStorage();
+    }
+  });
 });


### PR DESCRIPTION
## 问题描述

修复 GitHub Issue #7878：一个查询 SQL 包含两个语句、返回两个结果集时，编辑第一个结果集并点击「提交」后，第二个结果集页面会消失。

期望行为：提交只刷新当前结果集，保留其他结果集。

## 根因

DataGrid 提交触发 `onReloadData()`，其携带的 SQL 是 `tab.result?.sourceStatement`（仅当前语句的单条 SQL），而非完整多语句 SQL。

`onReloadData()` 进入 `sql?.trim()` 分支后调用 `executeTabSql()`，此前**未传入** `replaceActiveResultInGroup`。执行返回 1 个结果集时，`executeTabSql` 走非替换分支：`current.results = undefined; current.activeResultIndex = undefined; current.result = results[0]`，从而把第二个结果集整体清空。

## 修复方案

在 `apps/desktop/src/composables/useDataGridActions.ts` 的 `sql?.trim()` 分支中：

- 当 `tab.mode === "query"` 且 `tab.results?.length > 1`（存在多结果集）时，为 `executeTabSql` 追加 `replaceActiveResultInGroup: true` 和 `preserveActiveResultIndex: true`；
- 使提交只替换当前结果集、保留组内其他结果集，并维持当前激活索引。

## 测试

新增 `packages/app-tests/useDataGridActions.test.ts` 两个回归用例，走真实 `executeTabSql` 路径并 mock `execute-multi` 等 API：

1. 编辑第一个结果集后提交 → 第二个结果集保留，第一个被刷新；
2. 编辑第二个结果集后提交 → 第一个结果集保留，第二个被刷新。

验证结果：

- `useDataGridActions.test.ts`：6/6 通过（含 2 个新增用例）；
- `useDataGridActions.spec.ts`：25/25 通过；
- `vue-tsc typecheck`：通过；
- `oxlint`：无新增告警；
- `git diff --check`：干净。
