### PR TITLE
fix(influxdb): apply rolling time window to new-query prefill

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts
@@ -212,6 +212,20 @@ describe("buildSelectAllSql", () => {
     expect(buildSelectAllSql("jdbc", { schema: "APP", tableName: "USERS" }, '"', "phoenix")).toBe('SELECT * FROM "APP"."USERS"');
   });
 
+  it("scopes InfluxDB 1.x / 2.x prefill to a rolling InfluxQL window", () => {
+    // Without a time predicate the InfluxQL query would scan every shard
+    // for the measurement before LIMIT clips the tail; the 5-minute
+    // window matches the sidebar quick-open default so users can run
+    // the prefill safely.
+    expect(buildSelectAllSql("influxdb", { tableName: "cpu" })).toBe('SELECT * FROM "cpu" WHERE time > now() - 5m ORDER BY time DESC LIMIT 100');
+  });
+
+  it("scopes InfluxDB 3.x prefill to a rolling DataFusion INTERVAL window", () => {
+    // v3 goes through DataFusion SQL and needs an ANSI INTERVAL literal
+    // rather than the InfluxQL Go-duration form used by v1 / v2.
+    expect(buildSelectAllSql("influxdb3", { tableName: "cpu" })).toBe(`SELECT * FROM "cpu" WHERE time > now() - INTERVAL '5 minutes' ORDER BY time DESC LIMIT 100`);
+  });
+
   it("bracket-quotes a SQL Server table", () => {
     expect(buildSelectAllSql("sqlserver", { schema: "dbo", tableName: "users" })).toBe("SELECT * FROM [dbo].[users]");
     expect(buildSelectAllSql("sqlserver", { tableName: "users" })).toBe("SELECT * FROM [users]");

--- a/apps/desktop/src/lib/sql/newQueryContext.ts
+++ b/apps/desktop/src/lib/sql/newQueryContext.ts
@@ -147,10 +147,24 @@ export function resolveNewQueryTable(input: ResolveNewQueryTableInput): NewQuery
  * Builds a `SELECT * FROM <table>` statement for the new-query prefill, reusing
  * the same per-dialect identifier quoting and schema/catalog qualification used
  * by the table-data view.
+ *
+ * Time-series engines get the same rolling-window scoping the sidebar
+ * quick-open uses (see `default_time_series_predicate` in
+ * `crates/dbx-core/src/sql_dialect/table_select.rs`). Without a `time`
+ * predicate InfluxDB scans every shard (v1/v2) or every Parquet file
+ * (v3), which turns "let me draft a query against this table" into a
+ * full-history scan the moment the user hits Run. VictoriaMetrics
+ * already has its own metric range template above.
  */
 export function buildSelectAllSql(databaseType: DatabaseType | undefined, table: Pick<NewQueryTable, "schema" | "catalog" | "tableName"> & Partial<Pick<NewQueryTable, "database">>, identifierQuote?: string, driverProfile?: string, includeDatabaseName = false): string {
   if (databaseType === "victoriametrics") return metricRangeQuery(table.tableName);
   const ref = qualifiedTableName({ databaseType, driverProfile, identifierQuote, database: table.database, schema: table.schema, catalog: table.catalog, tableName: table.tableName, includeDatabaseName });
+  if (databaseType === "influxdb") {
+    return `SELECT * FROM ${ref} WHERE time > now() - 5m ORDER BY time DESC LIMIT 100`;
+  }
+  if (databaseType === "influxdb3") {
+    return `SELECT * FROM ${ref} WHERE time > now() - INTERVAL '5 minutes' ORDER BY time DESC LIMIT 100`;
+  }
   return `SELECT * FROM ${ref}`;
 }
 


### PR DESCRIPTION
## 变更说明

Follow-up to #7809 (sidebar quick-open). The **New Query** prefill
takes a different code path (`buildSelectAllSql` in
`apps/desktop/src/lib/sql/newQueryContext.ts`) and still emits the
unbounded form for InfluxDB:

    SELECT * FROM "device_data"

When the user hits Run — the whole point of the prefill is that they
can — this triggers exactly the same full-shard (v1/v2) / full-Parquet
(v3) scan that #7809 fixed for the sidebar. VictoriaMetrics already
has a special case here (`metricRangeQuery` returns
`{__name__="metric"}[1h]`), so time-series scoping is precedented in
this function.

This PR extends that pattern to InfluxDB, matching the sidebar
rolling-window syntax:

- `influxdb` → `SELECT * FROM ref WHERE time > now() - 5m ORDER BY time DESC LIMIT 100`
- `influxdb3` → `SELECT * FROM ref WHERE time > now() - INTERVAL '5 minutes' ORDER BY time DESC LIMIT 100`

Users can still edit the prefill freely; this only affects the initial
text placed in the editor when `prefillNewQueryWithSelect` is enabled.

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏

Editor prefill text only — no visual layout change. Screenshot
optional.

## 验证

- `pnpm typecheck` — clean
- `pnpm vitest run apps/desktop/src/lib/__tests__/sql/newQueryContext.spec.ts` — 41/41
  (two new focused cases: v1/v2 gets the InfluxQL Go-duration form,
   v3 gets the DataFusion INTERVAL form).

- [x] `pnpm typecheck` 通过
- [x] 相关测试通过

## 关联 Issue

Related to #7809 (extends the same fix to the new-query editor path).