### PR TITLE
fix(ssh): 隧道维护支持 SSH Agent 认证

### DIFF
--- a/apps/desktop/src/components/connection/TunnelProfileManager.vue
+++ b/apps/desktop/src/components/connection/TunnelProfileManager.vue
@@ -13,6 +13,7 @@ import { useToast } from "@/composables/useToast";
 import { useTunnelProfileStore } from "@/stores/tunnelProfileStore";
 import { createTunnelProfile, createTunnelProfileTestGuard, tunnelProfileSummary, type TunnelProfileType } from "@/lib/connection/tunnelProfiles";
 import { applySshConfigHostAliasPrefill as prefillSshConfigHostAlias } from "@/lib/connection/sshConfigHosts";
+import { applySshAuthMethod } from "@/lib/connection/sshAuthMethod";
 import * as api from "@/lib/backend/api";
 import type { SshConfigHostEntry, TunnelProfile } from "@/types/database";
 import { translateBackendError } from "@/i18n/backend-errors";
@@ -118,15 +119,12 @@ function removeSelected() {
   selectedId.value = draft.value[0]?.id || null;
 }
 
+// Shared with the connection editor so both SSH entry points keep one single
+// auth-method <-> credential mapping (see sshAuthMethod.ts).
 function updateSshAuthMethod(value: unknown) {
   const profile = selectedSsh.value;
   if (!profile) return;
-  profile.auth_method = value === "key" ? "key" : value === "key+password" ? "key+password" : value === "none" ? "none" : "password";
-  if (profile.auth_method !== "password" && profile.auth_method !== "key+password") profile.password = "";
-  if (profile.auth_method !== "key" && profile.auth_method !== "key+password") {
-    profile.key_path = "";
-    profile.key_passphrase = "";
-  }
+  applySshAuthMethod(profile, value);
 }
 
 function updateProxyType(value: unknown) {
@@ -252,6 +250,7 @@ async function testSelected() {
               <SelectItem value="password">{{ t("connection.sshAuthMethodPassword") }}</SelectItem>
               <SelectItem value="key">{{ t("connection.sshAuthMethodKey") }}</SelectItem>
               <SelectItem value="key+password">{{ t("connection.sshAuthMethodKeyPassword") }}</SelectItem>
+              <SelectItem value="agent">{{ t("connection.sshUseAgent") }}</SelectItem>
               <SelectItem value="none">{{ t("connection.sshAuthMethodNone") }}</SelectItem>
             </SelectContent>
           </Select>
@@ -281,6 +280,10 @@ async function testSelected() {
         <div v-if="selectedSsh.auth_method === 'none'" class="grid grid-cols-4 items-center gap-4">
           <span />
           <p class="col-span-3 text-xs text-muted-foreground">{{ t("connection.sshAuthMethodNoneHint") }}</p>
+        </div>
+        <div v-if="selectedSsh.auth_method === 'agent'" class="grid grid-cols-4 items-center gap-4">
+          <Label class="text-xs">{{ t("connection.sshAgentSockPath") }}</Label>
+          <Input v-model="selectedSsh.ssh_agent_sock_path" class="col-span-3" :placeholder="t('connection.sshAgentSockPathPlaceholder')" />
         </div>
         <div class="grid grid-cols-4 items-center gap-4">
           <span />

--- a/apps/desktop/src/lib/__tests__/connection/sshAgentTunnelProfileManager.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/sshAgentTunnelProfileManager.spec.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const managerSource = readFileSync(new URL("../../../components/connection/TunnelProfileManager.vue", import.meta.url), "utf8");
+
+describe("SSH agent tunnel profile form", () => {
+  it("offers the same SSH agent login method as the connection editor", () => {
+    expect(managerSource).toContain('<SelectItem value="agent">{{ t("connection.sshUseAgent") }}</SelectItem>');
+  });
+
+  it("exposes the custom agent socket path while keeping the shared auth mapping", () => {
+    expect(managerSource).toContain(`<div v-if="selectedSsh.auth_method === 'agent'" class="grid grid-cols-4 items-center gap-4">`);
+    expect(managerSource).toContain('v-model="selectedSsh.ssh_agent_sock_path"');
+    expect(managerSource).toContain('import { applySshAuthMethod } from "@/lib/connection/sshAuthMethod";');
+    expect(managerSource).toContain("applySshAuthMethod(profile, value);");
+  });
+
+  it("does not keep a second auth-method mapping that could drift from applySshAuthMethod", () => {
+    expect(managerSource).not.toContain('value === "key+password" ? "key+password"');
+  });
+});


### PR DESCRIPTION
## 变更说明

修复 #7866。

设置中的「隧道维护」此前缺少 SSH Agent 登录方式，与数据库连接编辑中的 SSH 隧道能力不一致。

根因有两层：

1. `TunnelProfileManager.vue` 的登录方式下拉框只渲染了 `password / key / key+password / none`，没有 `agent` 选项；
2. 该组件自己维护了一套私有的认证方式映射，任何未识别的值都会被折叠回 `password`，因此即使补上 UI 选项，选择 agent 也会被静默改写、无法持久化。

本次修改：

- 在 SSH 隧道配置的登录方式中补充 SSH Agent 选项，位置与外层连接编辑保持一致
- 删除重复的私有认证映射，改为复用公共 `applySshAuthMethod()`，统一 `auth_method` / `use_ssh_agent` / `password` / `key_path` / `key_passphrase` 的清理语义，避免两套 SSH 认证行为继续漂移
- Agent 模式下显示并支持编辑 `ssh_agent_sock_path`，留空时后端继续回退到 `SSH_AUTH_SOCK`
- 全部复用现有 i18n key（`connection.sshUseAgent`、`connection.sshAgentSockPath`、`connection.sshAgentSockPathPlaceholder`，8 个语言包均已存在），未新增翻译
- 补充针对性回归测试

后端无需改动：`TunnelProfile` 在 Rust 侧就是 `TransportLayerConfig`，`use_ssh_agent` / `ssh_agent_sock_path` / `auth_method` 在保存、连接时 profile 解析（`resolved_from_profile`）以及隧道维护的 Test 按钮路径（`test_tunnel_profile` → `start_tunnel`）中均已完整传递，`UI → TunnelProfile → 保存 → Core → SSH tunnel` 链路本就打通，属于纯前端能力遗漏。

兼容性：`applySshAuthMethod()` 对 `password / key / key+password / none` 四种既有取值的映射结果与原私有实现完全一致，历史 Tunnel Profile 的显示、编辑、保存不受影响，无迁移问题。

## 测试

- `pnpm exec vitest run src/lib/connection/__tests__/sshAuthMethod.spec.ts src/lib/__tests__/connection/sshAgentConnectionDialog.spec.ts src/lib/__tests__/connection/sshAgentTunnelProfileManager.spec.ts --root apps/desktop` ✅（3 个测试文件 / 10 个用例全部通过）
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json` ✅（exit 0）
- `pnpm exec oxlint --vue-plugin apps/desktop/src` ✅（exit 0，改动文件零告警）
- `pnpm exec oxfmt` 对两个改动文件 ✅（无格式变更）
- `git diff --check` ✅（无空白问题）

新增回归测试 `apps/desktop/src/lib/__tests__/connection/sshAgentTunnelProfileManager.spec.ts` 覆盖：存在 `value="agent"`、复用 `connection.sshUseAgent`、Agent 模式显示 `ssh_agent_sock_path`、以及不再保留第二套认证映射。`agent → use_ssh_agent=true` 与认证方式互相切换的底层转换已由现有 `sshAuthMethod.spec.ts` 覆盖，未重复测试。

未验证：真机 SSH Agent 端到端连接（需桌面端运行时与真实 ssh-agent 环境）；后端认证逻辑本身未改动。

Closes #7866
