### PR TITLE
Fix：ArgoDB 默认使用无 SASL 认证

### DIFF
--- a/agents/drivers/hive-go/config.go
+++ b/agents/drivers/hive-go/config.go
@@ -170,7 +170,10 @@ func parseConnectionConfig(params connectParams) (connectionConfig, error) {
 			CanonicalHostname: true,
 		},
 	}
-	if strings.EqualFold(params.DatabaseType, "impala") {
+	if config.DatabaseType == "argo" {
+		config.Auth = "NOSASL"
+	}
+	if config.DatabaseType == "impala" {
 		config.Auth = "NOSASL"
 		config.Kerberos.Service = defaultImpalaService
 	}

--- a/agents/drivers/hive-go/config_test.go
+++ b/agents/drivers/hive-go/config_test.go
@@ -296,6 +296,50 @@ func TestImpalaDefaultsToNoSASL(t *testing.T) {
 	}
 }
 
+func TestArgoDefaultsToNoSASL(t *testing.T) {
+	config, err := parseConnectionConfig(connectParams{
+		DatabaseType: "argo",
+		Host:         "argo.example.com",
+		Port:         10000,
+		Database:     "analytics",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Auth != "NOSASL" {
+		t.Fatalf("unexpected ArgoDB auth mode: %q", config.Auth)
+	}
+}
+
+func TestArgoExplicitAuthenticationOverridesDefault(t *testing.T) {
+	config, err := parseConnectionConfig(connectParams{
+		DatabaseType: "argo",
+		Host:         "argo.example.com",
+		Port:         10000,
+		URLParams:    "auth=NONE",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Auth != "NONE" || !config.AuthExplicit {
+		t.Fatalf("explicit ArgoDB authentication was not preserved: %#v", config)
+	}
+}
+
+func TestHiveDefaultAuthenticationRemainsSASL(t *testing.T) {
+	config, err := parseConnectionConfig(connectParams{
+		DatabaseType: "hive",
+		Host:         "hive.example.com",
+		Port:         10000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Auth != "NONE" {
+		t.Fatalf("unexpected Hive auth mode: %q", config.Auth)
+	}
+}
+
 func TestImpalaExplicitAuthenticationOverridesDefaults(t *testing.T) {
 	config, err := parseConnectionConfig(connectParams{
 		DatabaseType: "impala",

--- a/apps/desktop/src/lib/__tests__/database/connectionProfiles.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/connectionProfiles.spec.ts
@@ -12,6 +12,7 @@ describe("generated connection profiles", () => {
     expect(CONNECTION_PROFILES.mariadb).toMatchObject({ type: "mysql", port: 3306, user: "root" });
     expect(CONNECTION_PROFILES.rabbitmq).toMatchObject({ type: "mq", port: 5672, host: "127.0.0.1" });
     expect(CONNECTION_PROFILES.nacos).toMatchObject({ type: "nacos", port: 8848, user: "nacos" });
+    expect(CONNECTION_PROFILES.argo).toMatchObject({ type: "argo", urlParams: "auth=noSasl" });
   });
 
   it("keeps internal variants out of the main picker", () => {

--- a/apps/desktop/src/types/generated/connectionProfiles.ts
+++ b/apps/desktop/src/types/generated/connectionProfiles.ts
@@ -86,7 +86,7 @@ export const CONNECTION_PROFILES = {
   prestosql: { type: "prestosql", port: 8080, user: "", label: "PrestoSQL", icon: "presto" },
   hive: { type: "hive", port: 10000, user: "", label: "Apache Hive", icon: "hive" },
   kyuubi: { type: "kyuubi", port: 10009, user: "", label: "Apache Kyuubi", icon: "kyuubi", urlParams: "auth=NONE" },
-  argo: { type: "argo", port: 10000, user: "", label: "ArgoDB (Transwarp)", icon: "hive" },
+  argo: { type: "argo", port: 10000, user: "", label: "ArgoDB (Transwarp)", icon: "hive", urlParams: "auth=noSasl" },
   impala: { type: "impala", port: 21050, user: "", label: "Apache Impala", icon: "impala", urlParams: "auth=noSasl" },
   spark: { type: "spark", port: 10015, user: "", label: "Apache Spark", icon: "spark" },
   db2: { type: "db2", port: 50000, user: "db2inst1", label: "IBM DB2", icon: "db2" },

--- a/plugins/connection-types/profiles/catalog.yaml
+++ b/plugins/connection-types/profiles/catalog.yaml
@@ -476,6 +476,7 @@ profiles:
     icon: hive
     port: 10000
     user: ""
+    urlParams: auth=noSasl
     category: domestic
     pickerLabel: ArgoDB
   - id: impala


### PR DESCRIPTION
## 变更说明

- ArgoDB 新建连接默认填入 `auth=noSasl`
- Hive Go Agent 在 ArgoDB 未显式指定认证方式时默认使用 `NOSASL`，覆盖已有连接、导入连接及 API 创建的连接
- 保留显式认证配置的优先级，用户配置的 `NONE`、`LDAP`、`KERBEROS` 等模式不会被覆盖
- 增加回归测试，确认普通 Hive 仍默认使用 `NONE`

## 问题原因

Hive Go Agent 原先将 ArgoDB 与普通 Hive 一样默认配置为 `auth=NONE`。在 binary transport 下，`NONE` 仍会发起 SASL PLAIN 协商；无 SASL 的 ArgoDB 服务端会直接关闭连接，最终报错：

```text
gohive connect: reading SASL negotiation header: EOF
```

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

不涉及 UI 组件、样式或文案调整，仅修改 ArgoDB 连接 profile 的默认高级参数。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `go test ./...`（`agents/drivers/hive-go`）
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/database/connectionProfiles.spec.ts`（4 passed）
- `pnpm check:connection-types`
- `git diff --check`

由于没有用户内网 ArgoDB 的账号及访问条件，本次未对 `192.168.101.104:8529` 执行真实连接验证。用户可在旧版本中先通过高级参数 `auth=noSasl` 验证服务端认证模式。

## 关联 Issue

Close #7899
