### PR TITLE
fix: 修复 PostgreSQL Explain 未处理 SQL 变量的问题

### DIFF
--- a/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
@@ -1290,6 +1290,128 @@ SELECT @value AS Message;`;
     expect(explainTabSql).toHaveBeenCalledWith("tab-1", sql, "oracle", "explain");
   });
 
+  it("explains the resolved PostgreSQL statement after SQL parameter input", async () => {
+    const sql = "SELECT :var;";
+    const resolvedSql = "SELECT 123;";
+    const activeTab = ref<QueryTab | undefined>({ ...queryTab("app"), sql });
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("postgres"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const explainTabSql = vi.spyOn(queryStore, "explainTabSql").mockResolvedValue({ ok: true, sql: resolvedSql });
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+
+    await execution.tryExplain();
+
+    expect(execution.showSqlParameterDialog.value).toBe(true);
+    expect(execution.sqlParameterNames.value.map((parameter) => parameter.name)).toEqual(["var"]);
+    expect(explainTabSql).not.toHaveBeenCalled();
+
+    await execution.onSqlParametersConfirm(resolvedSql);
+
+    expect(explainTabSql).toHaveBeenCalledWith("tab-1", resolvedSql, "postgres", "explain");
+  });
+
+  it("explains the analyzed PostgreSQL statement after SQL parameter input", async () => {
+    const sql = "SELECT :var;";
+    const resolvedSql = "SELECT 123;";
+    const activeTab = ref<QueryTab | undefined>({ ...queryTab("app"), sql });
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("postgres"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const explainTabSql = vi.spyOn(queryStore, "explainTabSql").mockResolvedValue({ ok: true, sql: resolvedSql });
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+    execution.explainMode.value = "autotrace";
+
+    await execution.tryExplain();
+
+    expect(execution.showSqlParameterDialog.value).toBe(true);
+    expect(explainTabSql).not.toHaveBeenCalled();
+
+    await execution.onSqlParametersConfirm(resolvedSql);
+
+    expect(explainTabSql).toHaveBeenCalledWith("tab-1", resolvedSql, "postgres", "autotrace");
+  });
+
+  it("explains the string-parameter statement with the dialog's escaped substitution", async () => {
+    const sql = "SELECT :name;";
+    const resolvedSql = "SELECT 'O''Reilly';";
+    const activeTab = ref<QueryTab | undefined>({ ...queryTab("app"), sql });
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("postgres"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const explainTabSql = vi.spyOn(queryStore, "explainTabSql").mockResolvedValue({ ok: true, sql: resolvedSql });
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+
+    await execution.tryExplain();
+
+    expect(execution.showSqlParameterDialog.value).toBe(true);
+
+    await execution.onSqlParametersConfirm(resolvedSql);
+
+    expect(explainTabSql).toHaveBeenCalledWith("tab-1", resolvedSql, "postgres", "explain");
+  });
+
+  it("explains a PostgreSQL cast statement without opening the parameter dialog", async () => {
+    const sql = "SELECT '1'::int;";
+    const activeTab = ref<QueryTab | undefined>({ ...queryTab("app"), sql });
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("postgres"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const explainTabSql = vi.spyOn(queryStore, "explainTabSql").mockResolvedValue({ ok: true, sql });
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+
+    await execution.tryExplain();
+
+    expect(execution.showSqlParameterDialog.value).toBe(false);
+    expect(execution.sqlParameterNames.value).toEqual([]);
+    expect(explainTabSql).toHaveBeenCalledWith("tab-1", sql, "postgres", "explain");
+  });
+
+  it("explains a parameter-free statement without opening the parameter dialog", async () => {
+    const sql = "SELECT * FROM orders;";
+    const activeTab = ref<QueryTab | undefined>({ ...queryTab("app"), sql });
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("postgres"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const explainTabSql = vi.spyOn(queryStore, "explainTabSql").mockResolvedValue({ ok: true, sql });
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+
+    await execution.tryExplain();
+
+    expect(execution.showSqlParameterDialog.value).toBe(false);
+    expect(explainTabSql).toHaveBeenCalledWith("tab-1", sql, "postgres", "explain");
+  });
+
   it("keeps the new-result-tab intent through Redis command confirmation", async () => {
     const sql = "DEL user:1";
     const activeTab = ref<QueryTab | undefined>({ ...queryTab("0"), sql });

--- a/apps/desktop/src/composables/useSqlExecution.ts
+++ b/apps/desktop/src/composables/useSqlExecution.ts
@@ -541,9 +541,8 @@ export function useSqlExecution(deps: {
     return t("explain.emptySql");
   }
 
-  async function tryExplain(sqlOverride?: SqlExecutionOverride) {
+  async function runExplain(sql: string) {
     const tab = deps.activeTab.value;
-    const { sql } = await resolvedExecutableSql(sqlOverride);
     if (!tab || !sql.trim()) {
       toast(t("explain.emptySql"));
       return;
@@ -560,6 +559,19 @@ export function useSqlExecution(deps: {
 
     const current = deps.activeTab.value;
     if (current?.explainError) toast(current.explainError, 5000);
+  }
+
+  async function tryExplain(sqlOverride?: SqlExecutionOverride) {
+    const tab = deps.activeTab.value;
+    const { sql, sourceOffset } = await resolvedExecutableSql(sqlOverride);
+    if (!tab || !sql.trim()) {
+      toast(t("explain.emptySql"));
+      return;
+    }
+    // Resolve SQL template variables exactly like tryExecute so EXPLAIN never runs the raw
+    // placeholders (e.g. `EXPLAIN (FORMAT JSON) SELECT :var;` fails on PostgreSQL).
+    if (supportsSqlTemplateParameters(deps.activeConnection.value, sql) && prepareSqlParameterDialog(sql, sourceOffset, {}, (resolvedSql) => runExplain(resolvedSql))) return;
+    await runExplain(sql);
   }
 
   async function onDangerConfirm() {

--- a/apps/desktop/src/stores/__tests__/queryStore.postgresExplain.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.postgresExplain.spec.ts
@@ -151,4 +151,26 @@ describe("queryStore PostgreSQL EXPLAIN ANALYZE", () => {
 
     expect(mocks.buildExplainSql).toHaveBeenCalledWith("questdb", SOURCE_SQL);
   });
+
+  it("wraps a resolved statement whose variables were substituted before explain", async () => {
+    const resolvedSql = "SELECT 123";
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "shop", "Query", "query", "public");
+
+    await store.explainTabSql(tabId, resolvedSql, "postgres");
+
+    expect(mocks.buildExplainSql).toHaveBeenCalledWith("postgres", resolvedSql);
+  });
+
+  it("keeps the analyze flag for a resolved statement whose variables were substituted", async () => {
+    const resolvedSql = "SELECT 123";
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("pg-1", "shop", "Query", "query", "public");
+
+    await store.explainTabSql(tabId, resolvedSql, "postgres", "autotrace");
+
+    expect(mocks.buildExplainSql).toHaveBeenCalledWith("postgres", resolvedSql, "json", true);
+  });
 });


### PR DESCRIPTION
## 问题

修复 #7852。

PostgreSQL 对包含 DBX SQL 模板变量的语句执行 Explain 时，变量没有经过普通查询执行路径中的参数解析，导致类似：

```sql
SELECT :var;
```

被直接包装为 `EXPLAIN (FORMAT JSON) SELECT :var;` 发送给 PostgreSQL，最终在 `:` 处报语法错误。

## Root Cause

`tryExecute` 在执行前会走 `supportsSqlTemplateParameters` → `prepareSqlParameterDialog`（弹出 SQL Parameter Dialog）→ `substituteSqlParameters` → `continueExecute` 流程，而 `tryExplain` 直接把编辑器 SQL 传给 `queryStore.explainTabSql`，完全绕过了这一参数解析流程。

## 修复

* `tryExplain` 复用普通执行相同的 `prepareSqlParameterDialog` 流程：检测到模板变量时弹出同一个 SQL Parameter Dialog，用户确认后将替换后的 SQL 传入 Explain
* 原有 Explain 逻辑抽取为 `runExplain`，作为参数确认后的 continuation 执行，Explain 与 Explain Analyze 行为保持一致
* 参数替换复用现有 `sqlParameters.ts` 机制（含字符串转义），未新增任何解析器
* 无参数 SQL、PostgreSQL `::` cast 等语句不会弹出参数框，行为完全不变

## 测试

* `pnpm vitest run apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts`：64 passed（含新增 5 个：named parameter Explain / Explain Analyze / 字符串转义 / `::` cast 不误识别 / 无参数不弹框）
* `pnpm vitest run apps/desktop/src/stores/__tests__/queryStore.postgresExplain.spec.ts`：9 passed（含新增 2 个：resolved SQL 进入 `buildExplainSql`、Explain Analyze 保留 analyze 标志；原有 isolated session / `postgres_read_only_transaction` / unsafe SQL 拒绝等行为不变）
* `pnpm vitest run apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts` + `apps/desktop/src/components/editor/__tests__/SqlParameterDialog.spec.ts`：122 passed
* `pnpm vitest run apps/desktop/src/stores/__tests__/queryStore.mysqlExplain.spec.ts apps/desktop/src/stores/__tests__/queryStore.sqlserverExplain.spec.ts apps/desktop/src/stores/__tests__/queryStore.oracleExplain.spec.ts`：19 passed
* `pnpm typecheck`：通过
* `pnpm lint`：通过（无本次改动相关告警）
* `oxfmt --check`（husky lint-staged）：通过

Fixes #7852
