### PR TITLE
improve: 优化超大 SQL 的表名语义着色性能

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/model.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/model.spec.ts
@@ -358,6 +358,16 @@ describe("sqlSemanticModel baseline fixtures", () => {
     expect(spans.map((span) => sql.slice(span.start, span.end))).toEqual(["users", "orders", "audit_log", "events"]);
   });
 
+  it("keeps table highlighting linear for a 24,000-line Oracle select list", () => {
+    const sql = `SELECT\n${Array.from({ length: 23_997 }, (_, index) => `  t.col_${index} AS alias_${index},`).join("\n")}\n  t.final_col\nFROM app.huge_table t`;
+    const startedAt = performance.now();
+    const spans = sqlSemanticTableNameSpans(sql, { databaseType: "oracle" });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(spans.map((span) => sql.slice(span.start, span.end))).toEqual(["huge_table"]);
+    expect(elapsedMs).toBeLessThan(2_000);
+  });
+
   it("highlights mutation targets but ignores strings, comments, and table functions", () => {
     const sql = "UPDATE users SET name = 'FROM fake'; INSERT INTO audit_log(id) VALUES (1); -- FROM ignored\nSELECT * FROM read_csv('events.csv') e";
     const spans = sqlSemanticTableNameSpans(sql);

--- a/apps/desktop/src/lib/sql/semantic/model.ts
+++ b/apps/desktop/src/lib/sql/semantic/model.ts
@@ -131,18 +131,6 @@ function updateIntroducesMutationTarget(tokens: readonly SqlSemanticToken[], upd
   return true;
 }
 
-function commaContinuesTableList(tokens: readonly SqlSemanticToken[], commaIndex: number): boolean {
-  const comma = tokens[commaIndex];
-  if (comma?.text !== ",") return false;
-  for (let index = commaIndex - 1; index >= 0; index -= 1) {
-    const item = tokens[index];
-    if (!item || item.depth !== comma.depth || item.kind !== "word") continue;
-    if (item.normalized === "from") return true;
-    if (item.normalized === "select" || item.normalized === "join" || TABLE_INTRODUCERS.has(item.normalized) || CLAUSE_BOUNDARIES.has(item.normalized)) return false;
-  }
-  return false;
-}
-
 /**
  * Finds concrete table-name tokens for visual highlighting without consulting
  * metadata. Only the final identifier in a qualified name is returned, so
@@ -153,11 +141,18 @@ export function sqlSemanticTableNameSpans(sql: string, options: SqlSemanticBuild
   const tokens = significantTokens(tokenizeSqlSemantic(sql, dialect.id));
   const spans: SqlSemanticSpan[] = [];
   const seen = new Set<string>();
+  const commaContinuesTableListByDepth = new Map<number, boolean>();
 
   for (let index = 0; index < tokens.length; index += 1) {
     const item = tokens[index];
+    if (!item) continue;
+    const commaContinuesTableList = item.text === "," && commaContinuesTableListByDepth.get(item.depth) === true;
+    if (item.kind === "word") {
+      if (item.normalized === "from") commaContinuesTableListByDepth.set(item.depth, true);
+      else if (item.normalized === "select" || item.normalized === "join" || TABLE_INTRODUCERS.has(item.normalized) || CLAUSE_BOUNDARIES.has(item.normalized)) commaContinuesTableListByDepth.set(item.depth, false);
+    }
     const introduced = item?.kind === "word" && TABLE_INTRODUCERS.has(item.normalized) && (item.normalized !== "update" || updateIntroducesMutationTarget(tokens, index));
-    if (!introduced && !commaContinuesTableList(tokens, index)) continue;
+    if (!introduced && !commaContinuesTableList) continue;
 
     let target = index + 1;
     while (TABLE_TARGET_MODIFIERS.has(tokens[target]?.normalized ?? "")) target += 1;


### PR DESCRIPTION
## 问题

打开约 2.4 万行、包含大量查询列的 Oracle SQL 时，即使没有启用语义诊断，SQL 编辑器仍会长时间阻塞，整个客户端几乎无法交互。

表名语义着色是独立且始终启用的功能。原实现遇到逗号时会反向扫描当前括号层级，判断它是否延续 `FROM` 表列表。对于包含大量逗号的 `SELECT` 列表，每个逗号都会重复扫描到 `SELECT`，时间复杂度退化为 O(n²)。

## 修改

- 按括号深度单遍维护当前是否处于 `FROM a, b` 表列表，消除每个逗号的反向扫描。
- 保留普通表名、子查询、逗号表列表和 DML 目标的语义着色行为。
- 增加 2.4 万行 Oracle `SELECT` 性能回归测试，同时校验实际表名着色结果。

同一份约 2.4 万行、681 KB 的 Oracle SQL 本地基准：

- 修复前：约 33,174 ms
- 修复后：约 41 ms

## 验证

- `pnpm check`
  - connection-types：通过
  - format：通过
  - lint：通过
  - typecheck：通过
  - 完整测试：通过（12,270 项通过，1 项跳过）
- 超长 `IN`、PL/SQL 块及 2.4 万条短语句的表名着色均在几十毫秒内完成。

Fixes #7910
