### PR TITLE
fix(kingbase): 兼容升级前的空数据库连接

### DIFF
--- a/crates/dbx-core/src/agent_connection.rs
+++ b/crates/dbx-core/src/agent_connection.rs
@@ -930,6 +930,26 @@ mod tests {
     }
 
     #[test]
+    fn kingbase_agent_params_keep_legacy_postgres_default_when_database_is_empty() {
+        let cfg = config(DatabaseType::Kingbase, None);
+
+        let params = agent_connect_params(&cfg, "kingbase.example.com", 54321, "").unwrap();
+
+        assert_eq!(params["database"], "postgres");
+        assert_eq!(params["connection_string"], "jdbc:kingbase8://kingbase.example.com:54321/postgres");
+    }
+
+    #[test]
+    fn kingbase_agent_params_preserve_explicit_database() {
+        let cfg = config(DatabaseType::Kingbase, Some("application"));
+
+        let params = agent_connect_params(&cfg, "kingbase.example.com", 54321, "application").unwrap();
+
+        assert_eq!(params["database"], "application");
+        assert_eq!(params["connection_string"], "jdbc:kingbase8://kingbase.example.com:54321/application");
+    }
+
+    #[test]
     fn uxdb_agent_params_use_vendor_jdbc_url() {
         let cfg = config(DatabaseType::Uxdb, Some("uxdb"));
 

--- a/crates/dbx-core/src/models/connection.rs
+++ b/crates/dbx-core/src/models/connection.rs
@@ -857,7 +857,10 @@ impl ConnectionConfig {
             DatabaseType::Rqlite | DatabaseType::Turso | DatabaseType::CloudflareD1 => Some("main"),
             DatabaseType::Gaussdb | DatabaseType::OpenGauss => Some("postgres"),
             DatabaseType::Kwdb => Some("defaultdb"),
-            DatabaseType::Vastbase => Some("postgres"),
+            // Keep saved Kingbase connections from before the database field became
+            // required working after upgrade. New and edited desktop connections
+            // still require an explicit existing database in the connection form.
+            DatabaseType::Kingbase | DatabaseType::Vastbase => Some("postgres"),
             DatabaseType::Highgo => Some("highgo"),
             DatabaseType::Uxdb => Some("uxdb"),
             DatabaseType::Yashandb => Some("yasdb"),
@@ -3444,13 +3447,17 @@ mod tests {
     }
 
     #[test]
-    fn kingbase_empty_database_has_no_default() {
+    fn kingbase_empty_database_uses_legacy_postgres_default() {
         let mut config = mysql_config("SYSTEM", "secret", None);
         config.db_type = DatabaseType::Kingbase;
         config.port = 54321;
 
-        assert_eq!(config.effective_database(), None);
-        assert_eq!(config.connection_url(), "kingbase://SYSTEM:secret@10.1.2.3:54321");
+        assert_eq!(config.effective_database(), Some("postgres"));
+        assert_eq!(config.connection_url(), "kingbase://SYSTEM:secret@10.1.2.3:54321/postgres");
+
+        config.database = Some("application".to_string());
+        assert_eq!(config.effective_database(), Some("application"));
+        assert_eq!(config.connection_url(), "kingbase://SYSTEM:secret@10.1.2.3:54321/application");
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

- 为数据库字段为空的旧 KingbaseES 保存连接恢复 `postgres` 默认值，避免升级后原生 Agent 将登录用户名 `system` 当作目标数据库。
- 保留新建和编辑 KingbaseES 连接时必须填写已有数据库的前端校验，不放宽新配置要求。
- 增加核心连接 URL 和 Agent 参数回归测试，确认空旧配置使用 `postgres`，显式数据库名保持不变。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端改动。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo test -p dbx-core kingbase --lib -- --nocapture`：55 passed
- `cargo test -p dbx-core vastbase_empty_database_uses_postgres_for_connection --lib -- --nocapture`：1 passed
- `cargo test -p dbx-core vastbase_agent_url_defaults_to_postgres_database_when_empty --lib -- --nocapture`：1 passed
- `cargo fmt --check -- crates/dbx-core/src/models/connection.rs crates/dbx-core/src/agent_connection.rs`
- `git diff upstream/main...HEAD --check`

用户现场已确认：为原连接填写真实数据库名后可恢复连接。当前没有可用的 KingbaseES V8 实例，因此未执行本地真实数据库 E2E。

## 关联 Issue

Close #7913
