### PR TITLE
fix: 保留 MySQL SELECT INTO 用户变量

### DIFF
--- a/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useSqlExecution.spec.ts
@@ -843,6 +843,38 @@ SELECT @value AS Message;`;
     expect(executedSql).toContain("where fp.create_at < @date_start");
   });
 
+  it("sends MySQL SELECT INTO user variables without opening the parameter dialog", async () => {
+    const sql = `
+      select project_id,
+             year(date_sub(review_date, interval 1 month)),
+             month(date_sub(review_date, interval 1 month))
+        into @project_id, @year, @month
+        from cms_dynamic_cost_review
+       where id = '9f03cb27-a553-11f1-8af2-48dc2d090a1c';
+    `;
+    const activeTab = ref<QueryTab | undefined>(queryTab("app"));
+    const activeConnection = ref<ConnectionConfig | undefined>(connection("mysql"));
+    const activeOutputView = ref<"result" | "summary" | "explain" | "chart">("result");
+    const queryStore = useQueryStore();
+    const executeCurrentSql = vi.spyOn(queryStore, "executeCurrentSql").mockImplementation(async () => {
+      if (activeTab.value) activeTab.value.result = { columns: [], rows: [], affected_rows: 0, execution_time_ms: 1 };
+    });
+    vi.spyOn(useHistoryStore(), "add").mockResolvedValue(undefined);
+
+    const execution = useSqlExecution({
+      activeTab: computed(() => activeTab.value),
+      activeConnection: computed(() => activeConnection.value),
+      executableSql: computed(() => sql),
+      activeOutputView,
+    });
+
+    await execution.tryExecute();
+
+    expect(execution.showSqlParameterDialog.value).toBe(false);
+    expect(execution.sqlParameterNames.value).toEqual([]);
+    expect(executeCurrentSql).toHaveBeenCalledWith(sql, {});
+  });
+
   it("executes MySQL cursor procedures with compact labels without opening the parameter dialog", async () => {
     const sql = `
       CREATE PROCEDURE process_orders()

--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -269,6 +269,29 @@ describe("extractSqlParameters", () => {
     expect(extractSqlParameters(sql)).toEqual(["tenant_id"]);
   });
 
+  it("ignores MySQL user variables targeted by SELECT INTO", () => {
+    const sql = `
+      select project_id,
+             year(date_sub(review_date, interval 1 month)),
+             month(date_sub(review_date, interval 1 month))
+        into @project_id, @year, @month
+        from cms_dynamic_cost_review
+       where id = '9f03cb27-a553-11f1-8af2-48dc2d090a1c';
+      select @project_id, @year, @month;
+    `;
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual([]);
+  });
+
+  it("keeps ordinary MySQL template parameters around SELECT INTO targets", () => {
+    const sql = `
+      select project_id from cms_dynamic_cost_review where id = @input_id into @project_id;
+      select @project_id where @tenant_id > 0;
+    `;
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual(["input_id", "tenant_id"]);
+  });
+
   it("ignores SQL Server procedure parameters declared in routine definitions", () => {
     const sql = `
       create procedure dbo.search_orders

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -1374,12 +1374,13 @@ function collectSetStatementVariables(sql: string, start: number, declared: Set<
 
 function collectSelectAssignmentVariables(sql: string, start: number, declared: Set<string>, databaseType?: DatabaseType): number {
   let i = start;
+  let depth = 0;
   while (i < sql.length) {
     const ch = sql[i];
     const next = sql[i + 1];
-    if (ch === ";") return i + 1;
-    if (isLineStatementStart(sql, i) && isSqlStatementKeyword(sql, i)) return i;
-    if (matchesWord(sql, i, "from")) return i;
+    if (ch === ";" && depth === 0) return i + 1;
+    if (depth === 0 && isLineStatementStart(sql, i) && isSqlStatementKeyword(sql, i)) return i;
+    if (databaseType !== "mysql" && matchesWord(sql, i, "from")) return i;
     if (ch === "'" || ch === '"' || ch === "`") {
       i = skipQuoted(sql, i, ch);
       continue;
@@ -1400,6 +1401,23 @@ function collectSelectAssignmentVariables(sql: string, start: number, declared: 
       i = skipLine(sql, i + 1);
       continue;
     }
+    if (databaseType === "mysql" && ch === "(") {
+      depth += 1;
+      i += 1;
+      continue;
+    }
+    if (databaseType === "mysql" && ch === ")") {
+      depth = Math.max(0, depth - 1);
+      i += 1;
+      continue;
+    }
+    if (databaseType === "mysql" && depth === 0 && matchesWord(sql, i, "into")) {
+      const targetEnd = collectMysqlSelectIntoTargets(sql, i + "into".length, declared);
+      if (targetEnd !== null) {
+        i = targetEnd;
+        continue;
+      }
+    }
     if (ch === "@") {
       const name = readParameterName(sql, i + 1);
       if (name && next !== "@" && sql[i - 1] !== "@" && isSetAssignmentTarget(sql, i + 1 + name.length)) {
@@ -1411,6 +1429,21 @@ function collectSelectAssignmentVariables(sql: string, start: number, declared: 
     i += 1;
   }
   return i;
+}
+
+function collectMysqlSelectIntoTargets(sql: string, start: number, declared: Set<string>): number | null {
+  let i = skipSqlWhitespaceAndComments(sql, start);
+  let found = false;
+  while (i < sql.length && sql[i] === "@" && sql[i + 1] !== "@" && sql[i - 1] !== "@") {
+    const name = readParameterName(sql, i + 1);
+    if (!name) break;
+    declared.add(name.toLowerCase());
+    found = true;
+    i = skipSqlWhitespaceAndComments(sql, i + 1 + name.length);
+    if (sql[i] !== ",") break;
+    i = skipSqlWhitespaceAndComments(sql, i + 1);
+  }
+  return found ? i : null;
 }
 
 function collectRoutineDefinitionVariables(sql: string, start: number, declared: Set<string>, databaseType?: DatabaseType): number {


### PR DESCRIPTION
## 问题

MySQL 原生支持通过 `SELECT ... INTO @var` 给用户变量赋值，但 DBX 的 SQL 模板参数解析器只识别了 `SET @var = ...` 和 `SELECT @var := ...`，没有识别 `INTO` 目标列表。

因此 `@project_id`、`@year`、`@month` 会被误识别为客户端模板参数。用户确认参数后，这些变量被替换成普通 SQL 字面量，MySQL 随后返回 `ERROR 1327 (42000): Undeclared variable`。错误中的名称来自替换值，并不是 WHERE 中的 `id` 字段被识别为变量。

## 修改

- MySQL 参数扫描时按括号层级识别顶层 `SELECT ... INTO` 目标列表。
- 将 `INTO` 后的 `@var` 记录为 MySQL 原生用户变量，不再打开参数对话框或执行客户端替换。
- 同时支持 MySQL 的两种合法写法：
  - `SELECT value INTO @target FROM source`
  - `SELECT value FROM source INTO @target`
- 仅豁免 `INTO` 赋值目标，WHERE 等普通表达式中的 `@input_id` 继续作为模板参数。
- 增加参数提取和完整执行流程回归测试。

## 验证

- MySQL 5.7：原始 SQL 通过 MySQL 客户端及 DBX `dbx-core` 驱动执行成功。
- MySQL 8.4：原始 SQL 通过 MySQL 客户端及 DBX `dbx-core` 驱动执行成功。
- 将 `@var` 替换为普通字符串后，两版数据库均可复现 `ERROR 1327`。
- SQL 相关测试：`1251/1251` 通过。
- 变基到最新主线后重点测试：`175/175` 通过。
- `pnpm check`：connection-types、format、lint、typecheck、完整测试全部通过。

Fixes #7922
