### PR TITLE
✨ feat(nacos): 恢复配置编辑器选中项与滚动位置

### DIFF
--- a/apps/desktop/src/components/nacos/NacosAdminConsole.vue
+++ b/apps/desktop/src/components/nacos/NacosAdminConsole.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, useId, watch } from "vue";
+import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, shallowRef, useId, watch } from "vue";
 import { Compartment, type Extension } from "@codemirror/state";
 import { StreamLanguage, ensureSyntaxTree } from "@codemirror/language";
 import type { EditorView } from "@codemirror/view";
@@ -56,6 +56,7 @@ import { useTheme } from "@/composables/useTheme";
 import { executeWithProductionContextGuard } from "@/lib/database/productionExecutionGuard";
 import { productionContextForDatabase } from "@/lib/database/productionSafety";
 import { connectionIsEffectivelyReadOnly } from "@/lib/database/readOnlyWriteAccess";
+import type { NacosConfigEditorViewport } from "@/types/database";
 import type {
   NacosBatchPreview,
   NacosBatchReport,
@@ -167,6 +168,10 @@ const configEditorHost = ref<HTMLDivElement | null>(null);
 const configEditorView = shallowRef<EditorView | null>(null);
 const configSearchPanelRef = ref<InstanceType<typeof EditorSearchPanel>>();
 const configEditorFontSize = ref(clampEditorFontSize(settingsStore.editorSettings.fontSize));
+let configEditorViewportFrame: number | null = null;
+let configEditorViewportRestoreFrame: number | null = null;
+let latestConfigEditorViewport: NacosConfigEditorViewport | undefined;
+let configEditorIsActive = true;
 const configEditorZoomCommitScheduler = createEditorZoomCommitScheduler((fontSize) => {
   if (settingsStore.editorSettings.fontSize === fontSize) return;
   settingsStore.updateEditorSettings({ fontSize });
@@ -589,12 +594,138 @@ async function mountConfigEditor() {
     return;
   }
   configEditorView.value = view;
+  view.scrollDOM.addEventListener("scroll", scheduleConfigEditorViewportCapture, { passive: true });
+  restoreConfigEditorViewport();
 }
 
 function destroyConfigEditor() {
   configEditorGeneration += 1;
+  flushConfigEditorViewport();
+  if (configEditorViewportRestoreFrame !== null) {
+    cancelAnimationFrame(configEditorViewportRestoreFrame);
+    configEditorViewportRestoreFrame = null;
+  }
+  configEditorView.value?.scrollDOM.removeEventListener("scroll", scheduleConfigEditorViewportCapture);
   configEditorView.value?.destroy();
   configEditorView.value = null;
+}
+
+function configEditorViewportIdentity() {
+  const config = selectedConfig.value;
+  if (!config) return undefined;
+  return {
+    namespace: config.namespace || namespace.value || "",
+    dataId: config.dataId,
+    group: config.group || "DEFAULT_GROUP",
+  };
+}
+
+function isCurrentConfigEditorViewport(viewport: NacosConfigEditorViewport) {
+  const identity = configEditorViewportIdentity();
+  return !!identity && viewport.namespace === identity.namespace && viewport.dataId === identity.dataId && viewport.group === identity.group;
+}
+
+function storedConfigEditorViewport() {
+  const viewport = savedConfigEditorViewport();
+  return viewport && isCurrentConfigEditorViewport(viewport) ? viewport : undefined;
+}
+
+function savedConfigEditorViewport() {
+  const tab = queryStore.tabs.find((candidate) => candidate.mode === "nacos" && candidate.connectionId === props.connectionId && (candidate.nacosNamespace || "") === namespace.value);
+  return tab?.nacosConfigEditorViewport;
+}
+
+function initializeConfigEditorViewport() {
+  const identity = configEditorViewportIdentity();
+  if (!identity) return;
+  const saved = savedConfigEditorViewport();
+  const viewport = latestConfigEditorViewport && isCurrentConfigEditorViewport(latestConfigEditorViewport) ? latestConfigEditorViewport : saved && isCurrentConfigEditorViewport(saved) ? saved : { ...identity, scrollTop: 0, scrollLeft: 0 };
+  latestConfigEditorViewport = viewport;
+  queryStore.updateNacosConfigEditorViewport(props.connectionId, namespace.value, viewport);
+}
+
+async function restoreSelectedConfig() {
+  const viewport = savedConfigEditorViewport();
+  if (!viewport?.dataId) return;
+  await selectConfig({
+    namespace: viewport.namespace,
+    dataId: viewport.dataId,
+    group: viewport.group,
+  });
+}
+
+function captureConfigEditorViewport() {
+  const view = configEditorView.value;
+  const identity = configEditorViewportIdentity();
+  if (!view || !identity) return false;
+  const viewport = {
+    ...identity,
+    scrollTop: Math.max(0, view.scrollDOM.scrollTop),
+    scrollLeft: Math.max(0, view.scrollDOM.scrollLeft),
+  };
+  if (
+    latestConfigEditorViewport?.namespace === viewport.namespace &&
+    latestConfigEditorViewport.dataId === viewport.dataId &&
+    latestConfigEditorViewport.group === viewport.group &&
+    latestConfigEditorViewport.scrollTop === viewport.scrollTop &&
+    latestConfigEditorViewport.scrollLeft === viewport.scrollLeft
+  ) {
+    return false;
+  }
+  latestConfigEditorViewport = viewport;
+  return true;
+}
+
+function persistConfigEditorViewport() {
+  const viewport = latestConfigEditorViewport;
+  if (!viewport || !isCurrentConfigEditorViewport(viewport)) return;
+  queryStore.updateNacosConfigEditorViewport(props.connectionId, namespace.value, viewport);
+}
+
+function scheduleConfigEditorViewportCapture() {
+  if (!configEditorIsActive) return;
+  captureConfigEditorViewport();
+  if (configEditorViewportFrame !== null) return;
+  configEditorViewportFrame = requestAnimationFrame(() => {
+    configEditorViewportFrame = null;
+    persistConfigEditorViewport();
+  });
+}
+
+function flushConfigEditorViewport() {
+  if (configEditorViewportFrame !== null) {
+    cancelAnimationFrame(configEditorViewportFrame);
+    configEditorViewportFrame = null;
+  }
+  persistConfigEditorViewport();
+}
+
+function restoreConfigEditorViewport() {
+  const view = configEditorView.value;
+  const viewport = latestConfigEditorViewport && isCurrentConfigEditorViewport(latestConfigEditorViewport) ? latestConfigEditorViewport : storedConfigEditorViewport();
+  if (!view || !viewport) return;
+  const restore = () => {
+    if (configEditorView.value !== view) return;
+    view.scrollDOM.scrollTo({ top: viewport.scrollTop, left: viewport.scrollLeft });
+    view.scrollDOM.scrollTop = viewport.scrollTop;
+    view.scrollDOM.scrollLeft = viewport.scrollLeft;
+  };
+  restore();
+  nextTick(() => {
+    restore();
+    let attempts = 0;
+    const restoreNextFrame = () => {
+      restore();
+      attempts += 1;
+      if (attempts >= 8) {
+        configEditorViewportRestoreFrame = null;
+        return;
+      }
+      configEditorViewportRestoreFrame = requestAnimationFrame(restoreNextFrame);
+    };
+    if (configEditorViewportRestoreFrame !== null) cancelAnimationFrame(configEditorViewportRestoreFrame);
+    configEditorViewportRestoreFrame = requestAnimationFrame(restoreNextFrame);
+  });
 }
 
 async function refreshConfigEditor() {
@@ -829,6 +960,7 @@ async function selectConfig(item: NacosConfigItem) {
     group: item.group,
   };
   selectedConfig.value = { ...item };
+  initializeConfigEditorViewport();
   configContent.value = item.content || "";
   configType.value = configFormatValue(item) || "text";
   rememberOriginalConfigState(item, configContent.value, configType.value);
@@ -891,6 +1023,7 @@ function newConfig() {
   };
   configContent.value = "";
   configType.value = selectedConfig.value.configType || "text";
+  initializeConfigEditorViewport();
   rememberOriginalConfigState(selectedConfig.value, "", configType.value);
   configAdvancedOpen.value = false;
   void mountConfigEditor();
@@ -908,6 +1041,7 @@ function saveConfigAsCopy() {
   configContent.value = copy.content || "";
   originalConfigContent.value = "";
   configType.value = copy.configType || configType.value || "text";
+  initializeConfigEditorViewport();
   originalConfigType.value = configType.value;
   originalConfigMetadata.value = {
     appName: copy.appName || "",
@@ -2377,7 +2511,25 @@ onMounted(async () => {
   await loadInfo();
   await Promise.all([loadConfigsWithRetry(1), loadServicesWithRetry(1)]);
   if (props.targetDataId) await openTargetConfig(props.targetDataId, props.targetGroup || "DEFAULT_GROUP", props.targetKeyword);
+  else await restoreSelectedConfig();
 });
+
+function pauseConfigEditorViewportWork() {
+  flushConfigEditorViewport();
+  configEditorIsActive = false;
+  if (configEditorViewportRestoreFrame !== null) {
+    cancelAnimationFrame(configEditorViewportRestoreFrame);
+    configEditorViewportRestoreFrame = null;
+  }
+}
+
+function resumeConfigEditorViewportWork() {
+  configEditorIsActive = true;
+  restoreConfigEditorViewport();
+}
+
+onActivated(resumeConfigEditorViewportWork);
+onDeactivated(pauseConfigEditorViewportWork);
 
 onBeforeUnmount(() => {
   configListRequestGuard.invalidate();
@@ -2396,6 +2548,7 @@ onBeforeUnmount(() => {
   if (activeSearchOperationId.value) void api.nacosCancelConfigContentSearch(activeSearchOperationId.value);
   configListResizeObserver?.disconnect();
   configEditorZoomCommitScheduler.dispose();
+  pauseConfigEditorViewportWork();
   destroyConfigEditor();
 });
 </script>

--- a/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleDelete.spec.ts
+++ b/apps/desktop/src/components/nacos/__tests__/NacosAdminConsoleDelete.spec.ts
@@ -1,15 +1,18 @@
 // @vitest-environment happy-dom
 
-import { createApp, nextTick, type App, type ComponentPublicInstance } from "vue";
+import { createApp, defineComponent, h, KeepAlive, nextTick, ref, type App, type ComponentPublicInstance } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NacosConfigItem, NacosConfigKey, NacosConfigList } from "@/types/nacos";
 
 const mocks = vi.hoisted(() => ({
   ensureConnected: vi.fn(),
   nacosDeleteConfig: vi.fn(),
+  nacosGetConfig: vi.fn(),
   nacosListConfigs: vi.fn(),
   nacosListServices: vi.fn(),
   nacosTestConnection: vi.fn(),
+  queryTabs: [] as Array<Record<string, unknown>>,
+  updateNacosConfigEditorViewport: vi.fn(),
   toast: vi.fn(),
 }));
 
@@ -17,6 +20,7 @@ vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
 
 vi.mock("@/lib/backend/api", () => ({
   nacosDeleteConfig: mocks.nacosDeleteConfig,
+  nacosGetConfig: mocks.nacosGetConfig,
   nacosListConfigs: mocks.nacosListConfigs,
   nacosListServices: mocks.nacosListServices,
   nacosTestConnection: mocks.nacosTestConnection,
@@ -34,6 +38,8 @@ vi.mock("@/stores/queryStore", () => ({
   useQueryStore: () => ({
     clearNacosNavigationTarget: vi.fn(),
     openNacosAdmin: vi.fn(),
+    tabs: mocks.queryTabs,
+    updateNacosConfigEditorViewport: mocks.updateNacosConfigEditorViewport,
   }),
 }));
 
@@ -111,6 +117,7 @@ type NacosAdminSetupState = {
   configGroup: string;
   configPageNo: number;
   configPageSize: number;
+  configEditorView: { scrollDOM: HTMLElement } | null;
   configs: NacosConfigItem[];
   deleteConfig: () => Promise<void>;
   deleteSelectedConfigs: () => Promise<void>;
@@ -119,6 +126,7 @@ type NacosAdminSetupState = {
   selectedConfig: NacosConfigItem | null;
   selectedConfigKeys: string[];
   selectedConfigOriginalKey: NacosConfigKey | null;
+  selectConfig: (item: NacosConfigItem) => Promise<void>;
   toggleConfigSelection: (item: NacosConfigItem, checked: boolean) => void;
 };
 
@@ -139,9 +147,16 @@ async function flushUi() {
   }
 }
 
+async function flushAnimationFrames(count: number) {
+  for (let index = 0; index < count; index += 1) {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+}
+
 beforeEach(async () => {
   mocks.ensureConnected.mockReset().mockResolvedValue(undefined);
   mocks.nacosDeleteConfig.mockReset().mockResolvedValue(undefined);
+  mocks.nacosGetConfig.mockReset().mockResolvedValue(configA);
   mocks.nacosListConfigs.mockReset().mockResolvedValue(configList(1, 20, 2, [configA, configB]));
   mocks.nacosListServices.mockReset().mockResolvedValue({ pageNo: 1, pageSize: 20, totalCount: 0, items: [] });
   mocks.nacosTestConnection.mockReset().mockResolvedValue({
@@ -152,6 +167,8 @@ beforeEach(async () => {
     capabilities: { supportsConfigManagement: true, supportsConfigHistory: true, supportsServiceManagement: true, supportsInstanceUpdate: true, supportsRawApi: true },
   });
   mocks.toast.mockReset();
+  mocks.updateNacosConfigEditorViewport.mockReset();
+  mocks.queryTabs.splice(0);
 
   host = document.createElement("div");
   document.body.append(host);
@@ -209,5 +226,78 @@ describe("NacosAdminConsole config deletion", () => {
       { namespace: "public", group: "DEFAULT_GROUP", dataId: "config-b" },
     ]);
     expect(mocks.nacosListConfigs.mock.calls.map(([, query]) => query)).toEqual([expect.objectContaining({ pageNo: 2, pageSize: 50 }), expect.objectContaining({ pageNo: 1, pageSize: 50 })]);
+  });
+});
+
+describe("NacosAdminConsole cached tab restoration", () => {
+  it("does not let a hidden editor overwrite its viewport before reactivation", async () => {
+    app?.unmount();
+    host?.remove();
+    const active = ref(true);
+    const nacosRef = ref<ComponentPublicInstance | null>(null);
+    const CachedNacos = defineComponent({
+      setup() {
+        return () =>
+          h(KeepAlive, null, {
+            default: () => [active.value ? h(NacosAdminConsole, { ref: nacosRef, connectionId: "connection-1", namespace: "public" }) : h("div", "other-tab")],
+          });
+      },
+    });
+    host = document.createElement("div");
+    document.body.append(host);
+    app = createApp(CachedNacos);
+    app.mount(host);
+    await flushUi();
+
+    state = nacosRef.value?.$.setupState as unknown as NacosAdminSetupState;
+    await state.selectConfig(configA);
+    await flushUi();
+    const editor = state.configEditorView;
+    expect(editor).not.toBeNull();
+    if (!editor) throw new Error("Expected the Nacos config editor to mount");
+
+    editor.scrollDOM.scrollTop = 96;
+    editor.scrollDOM.dispatchEvent(new Event("scroll"));
+    await flushAnimationFrames(1);
+
+    active.value = false;
+    await nextTick();
+    editor.scrollDOM.scrollTop = 0;
+    editor.scrollDOM.dispatchEvent(new Event("scroll"));
+    await flushAnimationFrames(1);
+
+    active.value = true;
+    await nextTick();
+    await flushAnimationFrames(9);
+
+    expect(mocks.updateNacosConfigEditorViewport).toHaveBeenLastCalledWith("connection-1", "public", expect.objectContaining({ scrollTop: 96 }));
+    expect(editor.scrollDOM.scrollTop).toBe(96);
+  });
+
+  it("reselects the configuration saved with an evicted tab viewport", async () => {
+    app?.unmount();
+    host?.remove();
+    mocks.queryTabs.push({
+      mode: "nacos",
+      connectionId: "connection-1",
+      nacosNamespace: "public",
+      nacosConfigEditorViewport: {
+        namespace: "public",
+        dataId: "config-a",
+        group: "DEFAULT_GROUP",
+        scrollTop: 96,
+        scrollLeft: 0,
+      },
+    });
+    host = document.createElement("div");
+    document.body.append(host);
+    app = createApp(NacosAdminConsole, { connectionId: "connection-1", namespace: "public" });
+    const instance = app.mount(host) as ComponentPublicInstance;
+    state = instance.$.setupState as unknown as NacosAdminSetupState;
+
+    await flushUi();
+
+    expect(mocks.nacosGetConfig).toHaveBeenCalledWith("connection-1", { namespace: "public", dataId: "config-a", group: "DEFAULT_GROUP" });
+    expect(state.selectedConfig?.dataId).toBe("config-a");
   });
 });

--- a/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.switchTab.spec.ts
@@ -241,4 +241,33 @@ describe("queryStore switchTab", () => {
     expect(queryStore.tabs.filter((tab) => tab.mode === "nacos-dashboard")).toHaveLength(1);
     expect(queryStore.activeTabId).toBe(tabId);
   });
+
+  it("keeps the active Nacos configuration editor viewport on its matching tab", () => {
+    const queryStore = useQueryStore();
+    const tabId = queryStore.openNacosAdmin("nacos-1", { namespace: "team-a" });
+
+    queryStore.updateNacosConfigEditorViewport("nacos-1", "team-a", {
+      namespace: "team-a",
+      dataId: "application.yaml",
+      group: "DEFAULT_GROUP",
+      scrollTop: 82.6,
+      scrollLeft: -8,
+    });
+    queryStore.updateNacosConfigEditorViewport("nacos-1", "team-b", {
+      namespace: "team-b",
+      dataId: "ignored.yaml",
+      group: "DEFAULT_GROUP",
+      scrollTop: 12,
+      scrollLeft: 4,
+    });
+
+    const tab = queryStore.tabs.find((candidate) => candidate.id === tabId);
+    expect(tab?.nacosConfigEditorViewport).toEqual({
+      namespace: "team-a",
+      dataId: "application.yaml",
+      group: "DEFAULT_GROUP",
+      scrollTop: 83,
+      scrollLeft: 0,
+    });
+  });
 });

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { uuid } from "@/lib/common/utils";
 import { computed, markRaw, nextTick, onScopeDispose, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { BatchSqlExecution, ConnectionConfig, DatabaseType, IndexInfo, ObjectBrowserViewport, QueryResult, QueryResultSourceColumnRef, QueryTab, TableInfoTab, TableStructureEditorTarget } from "@/types/database";
+import type { BatchSqlExecution, ConnectionConfig, DatabaseType, IndexInfo, NacosConfigEditorViewport, ObjectBrowserViewport, QueryResult, QueryResultSourceColumnRef, QueryTab, TableInfoTab, TableStructureEditorTarget } from "@/types/database";
 import { orderPinnedFirst } from "@/lib/app/pinnedItems";
 import { canCancelQueryExecution } from "@/lib/sql/queryExecutionState";
 import { buildExplainSql, parseExplainResult, parseDamengExplainText, parseOracleExplainText, sqlServerExplainResult, type BuildExplainSqlResult } from "@/lib/diagram/explainPlan";
@@ -3395,6 +3395,22 @@ export const useQueryStore = defineStore("query", () => {
     const previous = tab.objectBrowser?.viewport;
     if (previous?.scrollTop === viewport.scrollTop && previous.viewMode === viewport.viewMode) return;
     tab.objectBrowser = { ...tab.objectBrowser, viewport };
+  }
+
+  function updateNacosConfigEditorViewport(connectionId: string, namespace: string, viewport: NacosConfigEditorViewport) {
+    if (!Number.isFinite(viewport.scrollTop) || !Number.isFinite(viewport.scrollLeft)) return;
+    const tab = tabs.value.find((candidate) => candidate.mode === "nacos" && candidate.connectionId === connectionId && (candidate.nacosNamespace || "") === namespace);
+    if (!tab) return;
+    const next = {
+      ...viewport,
+      scrollTop: Math.max(0, Math.round(viewport.scrollTop)),
+      scrollLeft: Math.max(0, Math.round(viewport.scrollLeft)),
+    };
+    const previous = tab.nacosConfigEditorViewport;
+    if (previous?.namespace === next.namespace && previous.dataId === next.dataId && previous.group === next.group && previous.scrollTop === next.scrollTop && previous.scrollLeft === next.scrollLeft) {
+      return;
+    }
+    tab.nacosConfigEditorViewport = next;
   }
 
   function renameTab(id: string, title: string) {
@@ -6977,6 +6993,7 @@ export const useQueryStore = defineStore("query", () => {
     updateEditorViewport,
     updateEditorSelection,
     updateObjectBrowserViewport,
+    updateNacosConfigEditorViewport,
     setAutoCommit,
     commitTransaction,
     rollbackTransaction,

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -1109,6 +1109,15 @@ export interface ObjectBrowserViewport {
   viewMode: ObjectBrowserViewMode;
 }
 
+/** Runtime-only viewport state for the selected configuration in a Nacos tab. */
+export interface NacosConfigEditorViewport {
+  namespace: string;
+  dataId: string;
+  group: string;
+  scrollTop: number;
+  scrollLeft: number;
+}
+
 export interface ExternalSqlFileVersion {
   sizeBytes: number;
   modifiedNs: string;
@@ -1257,6 +1266,7 @@ export interface QueryTab {
   nacosTargetGroup?: string;
   nacosTargetKeyword?: string;
   nacosTargetRequestId?: number;
+  nacosConfigEditorViewport?: NacosConfigEditorViewport;
   structureTableName?: string;
   structureInitialTab?: TableInfoTab;
   structureInitialTabRequestId?: number;


### PR DESCRIPTION
- 在 Nacos 标签页中保存当前配置及编辑器横纵向滚动位置
- 缓存标签页重新激活时恢复滚动位置，避免隐藏编辑器覆盖状态
- 标签页被回收后重新打开时自动选中并加载上次配置
- 增加视口状态归一化及缓存恢复相关测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #7895