### PR TITLE
Fix：修复 Vastbase 多语句查询超时

### DIFF
--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -1291,7 +1291,9 @@ fn options_for_sequential_statements(
     db_type: Option<DatabaseType>,
 ) -> QueryExecutionOptions {
     let mut statement_options = options.clone();
-    if statement_count <= 1 || db_type != Some(DatabaseType::Kingbase) || statement_options.result_session_id.is_some()
+    if statement_count <= 1
+        || !matches!(db_type, Some(DatabaseType::Kingbase | DatabaseType::Vastbase))
+        || statement_options.result_session_id.is_some()
     {
         return statement_options;
     }
@@ -3068,10 +3070,9 @@ pub async fn execute_multi_core_with_options_for_client_and_progress_typed(
         .map_err(Into::into);
     }
 
-    // Kingbase Go keeps one physical connection per Agent session, so an open
-    // result cursor prevents the next statement from acquiring that connection.
-    // Multi-result execution therefore reads a bounded first page for each
-    // Kingbase statement without retaining cursors.
+    // Some Agent drivers cannot execute another statement while a paged result
+    // cursor remains open on the same physical connection. Multi-result execution
+    // therefore reads a bounded first page without retaining those cursors.
     let statement_options = options_for_sequential_statements(&options, statements.len(), db_type);
     let mut results = Vec::with_capacity(statements.len());
     for (statement_index, stmt) in statements.iter().enumerate() {
@@ -8837,12 +8838,14 @@ for line in sys.stdin:
             ..Default::default()
         };
 
-        let adjusted = options_for_sequential_statements(&options, 2, Some(DatabaseType::Kingbase));
+        for db_type in [DatabaseType::Kingbase, DatabaseType::Vastbase] {
+            let adjusted = options_for_sequential_statements(&options, 2, Some(db_type));
 
-        assert_eq!(adjusted.page_size, None);
-        assert_eq!(adjusted.max_rows, Some(100));
-        assert_eq!(adjusted.fetch_size, Some(100));
-        assert_eq!(adjusted.timeout_secs, Some(30));
+            assert_eq!(adjusted.page_size, None);
+            assert_eq!(adjusted.max_rows, Some(100));
+            assert_eq!(adjusted.fetch_size, Some(100));
+            assert_eq!(adjusted.timeout_secs, Some(30));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Vastbase 通过 Agent 执行多条查询时，第一条结果会保留分页游标并占用同一 JDBC 物理连接，后续语句因此等待连接直至超时。

## 修复

- 将 Vastbase 纳入多语句执行时不保留分页游标的现有策略。
- 每条语句仍按查询限制读取首批结果，并保留用户设置的更小行数上限。
- 单条 SQL 的正常分页游标行为保持不变。

## 验证

- Vastbase G100 3.0.9 实测：修复前第二条查询单独执行约 204ms，两条一起执行超过 6 秒仍阻塞。
- 修复后连续执行两条查询均成功，结果行数为 100 和 1；最新基线下重复 3 次总耗时约 0.09～0.50 秒。
- 单条 SQL 分页回归：第一页、第二页均返回 100 行，并复用同一结果会话。
- `RUST_MIN_STACK=8388608 cargo test -p dbx-core --no-default-features --features sqlite-bundled --lib multi_statement_execution -- --nocapture`：2 passed。
- `cargo fmt --check -p dbx-core` 通过。

Fixes #7921