### PR TITLE
feat(mcp): list stored routines and fetch routine source via MCP

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -2286,6 +2286,8 @@ const mcpToolOptions = [
   { name: "dbx_list_databases", labelKey: "settings.mcpToolListDatabases" },
   { name: "dbx_list_tables", labelKey: "settings.mcpToolListTables" },
   { name: "dbx_describe_table", labelKey: "settings.mcpToolDescribeTable" },
+  { name: "dbx_list_routines", labelKey: "settings.mcpToolListRoutines" },
+  { name: "dbx_get_routine_source", labelKey: "settings.mcpToolGetRoutineSource" },
   { name: "dbx_get_schema_context", labelKey: "settings.mcpToolGetSchemaContext" },
   { name: "dbx_execute_query", labelKey: "settings.mcpToolExecuteQuery" },
   { name: "dbx_open_session", labelKey: "settings.mcpToolOpenSession" },

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -7184,6 +7184,8 @@ export default {
     mcpToolListDatabases: "List databases",
     mcpToolListTables: "List tables",
     mcpToolDescribeTable: "Describe table",
+    mcpToolListRoutines: "List routines",
+    mcpToolGetRoutineSource: "Routine source",
     mcpToolGetSchemaContext: "Schema context",
     mcpToolExecuteQuery: "Execute SQL / Mongo commands",
     mcpToolOpenSession: "Open query session",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6806,6 +6806,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "Listar bases de datos",
     mcpToolListTables: "Listar tablas",
     mcpToolDescribeTable: "Estructura de tabla",
+    mcpToolListRoutines: "Listar rutinas",
+    mcpToolGetRoutineSource: "Código de rutina",
     mcpToolGetSchemaContext: "Contexto de Schema",
     mcpToolExecuteQuery: "Ejecutar SQL / comandos Mongo",
     mcpToolOpenSession: "Abrir sesión de consulta",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6806,6 +6806,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "Elenca database",
     mcpToolListTables: "Elenca tabelle",
     mcpToolDescribeTable: "Struttura tabella",
+    mcpToolListRoutines: "Elenca routine",
+    mcpToolGetRoutineSource: "Sorgente routine",
     mcpToolGetSchemaContext: "Contesto Schema",
     mcpToolExecuteQuery: "Esegui SQL / comandi Mongo",
     mcpToolOpenSession: "Apri sessione di query",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6813,6 +6813,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "データベースを一覧",
     mcpToolListTables: "テーブルを一覧",
     mcpToolDescribeTable: "テーブル構造",
+    mcpToolListRoutines: "ルーチン一覧",
+    mcpToolGetRoutineSource: "ルーチンソース",
     mcpToolGetSchemaContext: "Schema コンテキスト",
     mcpToolExecuteQuery: "SQL / Mongo コマンドを実行",
     mcpToolOpenSession: "クエリセッションを開く",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -6554,6 +6554,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "데이터베이스 나열",
     mcpToolListTables: "테이블 나열",
     mcpToolDescribeTable: "테이블 구조",
+    mcpToolListRoutines: "루틴 목록",
+    mcpToolGetRoutineSource: "루틴 소스",
     mcpToolGetSchemaContext: "Schema 컨텍스트",
     mcpToolExecuteQuery: "SQL / Mongo 명령 실행",
     mcpToolOpenSession: "쿼리 세션 열기",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6808,6 +6808,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "Listar bancos de dados",
     mcpToolListTables: "Listar tabelas",
     mcpToolDescribeTable: "Estrutura da tabela",
+    mcpToolListRoutines: "Listar rotinas",
+    mcpToolGetRoutineSource: "Código da rotina",
     mcpToolGetSchemaContext: "Contexto do Schema",
     mcpToolExecuteQuery: "Executar SQL / comandos Mongo",
     mcpToolOpenSession: "Abrir sessão de consulta",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -7168,6 +7168,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "列出数据库",
     mcpToolListTables: "列出表",
     mcpToolDescribeTable: "表结构",
+    mcpToolListRoutines: "存储过程列表",
+    mcpToolGetRoutineSource: "存储过程源码",
     mcpToolGetSchemaContext: "Schema 上下文",
     mcpToolExecuteQuery: "执行 SQL / Mongo 命令",
     mcpToolOpenSession: "打开查询会话",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -6148,6 +6148,8 @@ export default withEnglishFallback({
     mcpToolListDatabases: "列出資料庫",
     mcpToolListTables: "列出資料表",
     mcpToolDescribeTable: "資料表結構",
+    mcpToolListRoutines: "預存程序列表",
+    mcpToolGetRoutineSource: "預存程序原始碼",
     mcpToolGetSchemaContext: "Schema 上下文",
     mcpToolExecuteQuery: "執行 SQL / Mongo 命令",
     mcpToolOpenSession: "開啟查詢工作階段",

--- a/crates/dbx-mcp/src/backend.rs
+++ b/crates/dbx-mcp/src/backend.rs
@@ -739,6 +739,8 @@ impl DbxBackend for LocalBackend {
         schema: &str,
         routine_types: Option<&[String]>,
     ) -> Result<Vec<dbx_core::db::ObjectInfo>, String> {
+        let default_types = ["PROCEDURE".to_string(), "FUNCTION".to_string()];
+        let object_types = routine_types.unwrap_or(default_types.as_slice());
         let objects = dbx_core::schema::list_objects_core(
             &self.state,
             &connection.id,
@@ -747,7 +749,7 @@ impl DbxBackend for LocalBackend {
             None,
             None,
             None,
-            routine_types,
+            Some(object_types),
             None,
         )
         .await?;
@@ -1225,7 +1227,7 @@ impl DbxBackend for WebBackend {
         self.request(
             reqwest::Method::GET,
             &format!(
-                "/api/schema/objects?connection_id={}&database={}&schema={}&objectTypes={}",
+                "/api/schema/objects?connection_id={}&database={}&schema={}&object_types={}",
                 url_encode(&connection.id),
                 url_encode(database),
                 url_encode(schema),

--- a/crates/dbx-mcp/src/backend.rs
+++ b/crates/dbx-mcp/src/backend.rs
@@ -228,6 +228,32 @@ pub trait DbxBackend: Send + Sync {
         let _ = (connection, database, schema, table);
         Err("Column metadata is not supported by this backend.".to_string())
     }
+    /// List stored routines (procedures/functions) for a schema. `routine_types`
+    /// filters by object type ("PROCEDURE"/"FUNCTION"); `None` returns both.
+    async fn list_routines(
+        &self,
+        connection: &ConnectionConfig,
+        database: &str,
+        schema: &str,
+        routine_types: Option<&[String]>,
+    ) -> Result<Vec<dbx_core::db::ObjectInfo>, String> {
+        let _ = (connection, database, schema, routine_types);
+        Err("Routine metadata is not supported by this backend.".to_string())
+    }
+    /// Fetch a stored routine's full source text. `object_type` is
+    /// `PROCEDURE` or `FUNCTION` (SCREAMING_SNAKE_CASE, as in the desktop API).
+    async fn get_routine_source(
+        &self,
+        connection: &ConnectionConfig,
+        database: &str,
+        schema: &str,
+        name: &str,
+        object_type: &str,
+        signature: Option<&str>,
+    ) -> Result<dbx_core::db::ObjectSource, String> {
+        let _ = (connection, database, schema, name, object_type, signature);
+        Err("Routine source is not supported by this backend.".to_string())
+    }
     async fn execute_redis_command(
         &self,
         connection: &ConnectionConfig,
@@ -544,6 +570,21 @@ fn local_plugin_dir(settings: &DesktopSettings, data_dir: &Path) -> PathBuf {
         .unwrap_or_else(|| data_dir.join("plugins"))
 }
 
+/// Whether an object listing entry is a stored routine (procedure or function).
+fn is_routine_object(object_type: &str) -> bool {
+    object_type.eq_ignore_ascii_case("PROCEDURE") || object_type.eq_ignore_ascii_case("FUNCTION")
+}
+
+/// Parse a routine type string ("PROCEDURE"/"FUNCTION", case-insensitive) into
+/// the core `ObjectSourceKind` used by `get_object_source_core`.
+fn parse_routine_kind(object_type: &str) -> Result<dbx_core::db::ObjectSourceKind, String> {
+    match object_type.trim().to_ascii_uppercase().as_str() {
+        "PROCEDURE" => Ok(dbx_core::db::ObjectSourceKind::Procedure),
+        "FUNCTION" => Ok(dbx_core::db::ObjectSourceKind::Function),
+        other => Err(format!("Unsupported routine type \"{other}\"; use PROCEDURE or FUNCTION.")),
+    }
+}
+
 fn local_agent_dir(settings: &DesktopSettings, data_dir: &Path) -> PathBuf {
     let legacy_driver_base =
         settings.driver_store_dir.as_ref().filter(|value| !value.trim().is_empty()).map(PathBuf::from);
@@ -689,6 +730,51 @@ impl DbxBackend for LocalBackend {
         table: &str,
     ) -> Result<Vec<ColumnInfo>, String> {
         dbx_core::schema::get_columns_core(&self.state, &connection.id, database, schema, table).await
+    }
+
+    async fn list_routines(
+        &self,
+        connection: &ConnectionConfig,
+        database: &str,
+        schema: &str,
+        routine_types: Option<&[String]>,
+    ) -> Result<Vec<dbx_core::db::ObjectInfo>, String> {
+        let objects = dbx_core::schema::list_objects_core(
+            &self.state,
+            &connection.id,
+            database,
+            schema,
+            None,
+            None,
+            None,
+            routine_types,
+            None,
+        )
+        .await?;
+        Ok(objects.into_iter().filter(|object| is_routine_object(&object.object_type)).collect())
+    }
+
+    async fn get_routine_source(
+        &self,
+        connection: &ConnectionConfig,
+        database: &str,
+        schema: &str,
+        name: &str,
+        object_type: &str,
+        signature: Option<&str>,
+    ) -> Result<dbx_core::db::ObjectSource, String> {
+        let kind = parse_routine_kind(object_type)?;
+        dbx_core::schema::get_object_source_core(
+            &self.state,
+            &connection.id,
+            database,
+            schema,
+            name,
+            kind,
+            signature,
+            None,
+        )
+        .await
     }
 
     async fn collect_docs_snapshot(
@@ -1125,6 +1211,67 @@ impl DbxBackend for WebBackend {
         .json()
         .await
         .map_err(|error| format!("Invalid column list response: {error}"))
+    }
+
+    async fn list_routines(
+        &self,
+        connection: &ConnectionConfig,
+        database: &str,
+        schema: &str,
+        routine_types: Option<&[String]>,
+    ) -> Result<Vec<dbx_core::db::ObjectInfo>, String> {
+        self.ensure_connected(connection).await?;
+        let types = routine_types.map(|types| types.join(",")).unwrap_or_else(|| "PROCEDURE,FUNCTION".to_string());
+        self.request(
+            reqwest::Method::GET,
+            &format!(
+                "/api/schema/objects?connection_id={}&database={}&schema={}&objectTypes={}",
+                url_encode(&connection.id),
+                url_encode(database),
+                url_encode(schema),
+                url_encode(&types)
+            ),
+            None,
+        )
+        .await?
+        .json::<Vec<dbx_core::db::ObjectInfo>>()
+        .await
+        .map(|objects| objects.into_iter().filter(|object| is_routine_object(&object.object_type)).collect())
+        .map_err(|error| format!("Invalid routine list response: {error}"))
+    }
+
+    async fn get_routine_source(
+        &self,
+        connection: &ConnectionConfig,
+        database: &str,
+        schema: &str,
+        name: &str,
+        object_type: &str,
+        signature: Option<&str>,
+    ) -> Result<dbx_core::db::ObjectSource, String> {
+        let kind = parse_routine_kind(object_type)?;
+        let kind_name = match kind {
+            dbx_core::db::ObjectSourceKind::Procedure => "PROCEDURE",
+            dbx_core::db::ObjectSourceKind::Function => "FUNCTION",
+            _ => unreachable!("parse_routine_kind only yields routines"),
+        };
+        self.ensure_connected(connection).await?;
+        let mut query = format!(
+            "/api/schema/object-source?connection_id={}&database={}&schema={}&table={}&object_type={}",
+            url_encode(&connection.id),
+            url_encode(database),
+            url_encode(schema),
+            url_encode(name),
+            url_encode(kind_name),
+        );
+        if let Some(signature) = signature.filter(|value| !value.trim().is_empty()) {
+            query.push_str(&format!("&signature={}", url_encode(signature)));
+        }
+        self.request(reqwest::Method::GET, &query, None)
+            .await?
+            .json()
+            .await
+            .map_err(|error| format!("Invalid routine source response: {error}"))
     }
 
     async fn collect_docs_snapshot(

--- a/crates/dbx-mcp/src/server.rs
+++ b/crates/dbx-mcp/src/server.rs
@@ -74,6 +74,42 @@ pub struct DescribeTableRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListRoutinesRequest {
+    #[serde(flatten)]
+    pub selector: ConnectionSelector,
+    #[schemars(description = "Database name")]
+    #[schemars(extend("type" = "string"))]
+    pub database: Option<String>,
+    #[schemars(description = "Schema name")]
+    #[schemars(extend("type" = "string"))]
+    pub schema: Option<String>,
+    #[schemars(
+        description = "Optional routine type filter: PROCEDURE or FUNCTION. Omit to list both. Unsupported databases return an empty list."
+    )]
+    #[schemars(extend("type" = "string"))]
+    pub routine_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetRoutineSourceRequest {
+    #[serde(flatten)]
+    pub selector: ConnectionSelector,
+    #[schemars(description = "Routine name (as returned by dbx_list_routines)")]
+    pub name: String,
+    #[schemars(description = "Routine type: PROCEDURE or FUNCTION")]
+    pub object_type: String,
+    #[schemars(description = "Optional routine signature for databases that overload routine names (e.g. Oracle)")]
+    #[schemars(extend("type" = "string"))]
+    pub signature: Option<String>,
+    #[schemars(description = "Database name")]
+    #[schemars(extend("type" = "string"))]
+    pub database: Option<String>,
+    #[schemars(description = "Schema name")]
+    #[schemars(extend("type" = "string"))]
+    pub schema: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ExecuteQueryRequest {
     #[serde(flatten)]
     pub selector: ConnectionSelector,
@@ -435,6 +471,76 @@ impl DbxMcpServer {
             Ok(columns) if columns.is_empty() => text("No columns found."),
             Ok(columns) => text(format_columns(&columns)),
             Err(error) => tool_error("TABLE_DESCRIPTION_ERROR", error),
+        }
+    }
+
+    #[tool(name = "dbx_list_routines", description = "List stored procedures and functions for a database schema")]
+    async fn list_routines(&self, Parameters(request): Parameters<ListRoutinesRequest>) -> CallToolResult {
+        if let Err(error) = self.ensure_tool_allowed("dbx_list_routines").await {
+            return error;
+        }
+        let resolved = match self.resolve_connection(&request.selector).await {
+            Ok(resolved) => resolved,
+            Err(error) => return error,
+        };
+        let database = match self.resolve_database(request.database, &resolved) {
+            Ok(database) => database,
+            Err(error) => return error,
+        };
+        let schema = match self.resolve_schema(request.schema) {
+            Ok(schema) => schema,
+            Err(error) => return error,
+        };
+        let routine_types = match request.routine_type.as_deref() {
+            None => None,
+            Some(kind) => match normalize_routine_type(kind) {
+                Ok(kind) => Some(vec![kind]),
+                Err(error) => return tool_error("ROUTINE_LIST_ERROR", error),
+            },
+        };
+        match self.backend.list_routines(&resolved.connection, &database, &schema, routine_types.as_deref()).await {
+            Ok(routines) if routines.is_empty() => text("No routines found."),
+            Ok(routines) => text(format_routines(&routines)),
+            Err(error) => tool_error("ROUTINE_LIST_ERROR", error),
+        }
+    }
+
+    #[tool(name = "dbx_get_routine_source", description = "Get the full source text of a stored procedure or function")]
+    async fn get_routine_source(&self, Parameters(request): Parameters<GetRoutineSourceRequest>) -> CallToolResult {
+        if let Err(error) = self.ensure_tool_allowed("dbx_get_routine_source").await {
+            return error;
+        }
+        let resolved = match self.resolve_connection(&request.selector).await {
+            Ok(resolved) => resolved,
+            Err(error) => return error,
+        };
+        let database = match self.resolve_database(request.database, &resolved) {
+            Ok(database) => database,
+            Err(error) => return error,
+        };
+        let schema = match self.resolve_schema(request.schema) {
+            Ok(schema) => schema,
+            Err(error) => return error,
+        };
+        let object_type = match normalize_routine_type(&request.object_type) {
+            Ok(kind) => kind,
+            Err(error) => return tool_error("ROUTINE_SOURCE_ERROR", error),
+        };
+        match self
+            .backend
+            .get_routine_source(
+                &resolved.connection,
+                &database,
+                &schema,
+                &request.name,
+                &object_type,
+                request.signature.as_deref(),
+            )
+            .await
+        {
+            Ok(source) if source.source.trim().is_empty() => text("Routine source is empty."),
+            Ok(source) => text(source.source),
+            Err(error) => tool_error("ROUTINE_SOURCE_ERROR", error),
         }
     }
 
@@ -1703,6 +1809,32 @@ fn format_connections(connections: &[ConnectionSummary]) -> String {
     output
 }
 
+/// Normalize a user-supplied routine type ("procedure", "PROCEDURE", ...) to
+/// the canonical SCREAMING form used by the object listing protocol.
+fn normalize_routine_type(value: &str) -> Result<String, String> {
+    match value.trim().to_ascii_uppercase().as_str() {
+        "PROCEDURE" => Ok("PROCEDURE".to_string()),
+        "FUNCTION" => Ok("FUNCTION".to_string()),
+        other => Err(format!("Unsupported routine type \"{other}\"; use PROCEDURE or FUNCTION.")),
+    }
+}
+
+fn format_routines(routines: &[dbx_core::db::ObjectInfo]) -> String {
+    let rows = routines
+        .iter()
+        .map(|routine| {
+            vec![
+                routine.name.clone(),
+                routine.object_type.clone(),
+                routine.schema.clone().unwrap_or_default(),
+                routine.signature.clone().unwrap_or_default(),
+                routine.comment.clone().unwrap_or_default(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    markdown_table(&["Routine", "Type", "Schema", "Signature", "Comment"], &rows)
+}
+
 fn format_columns(columns: &[dbx_core::db::ColumnInfo]) -> String {
     let rows = columns
         .iter()
@@ -1943,13 +2075,15 @@ mod tests {
         let tools = server.tool_router.list_all();
         let names = tools.iter().map(|tool| tool.name.as_ref()).collect::<Vec<_>>();
         #[cfg(feature = "mq-admin")]
-        assert_eq!(tools.len(), 15);
+        assert_eq!(tools.len(), 17);
         #[cfg(not(feature = "mq-admin"))]
-        assert_eq!(tools.len(), 14);
+        assert_eq!(tools.len(), 16);
         assert!(names.contains(&"dbx_list_connections"));
         assert!(names.contains(&"dbx_list_databases"));
         assert!(names.contains(&"dbx_list_tables"));
         assert!(names.contains(&"dbx_describe_table"));
+        assert!(names.contains(&"dbx_list_routines"));
+        assert!(names.contains(&"dbx_get_routine_source"));
         assert!(names.contains(&"dbx_execute_query"));
         assert!(names.contains(&"dbx_add_connection"));
         assert!(names.contains(&"dbx_duplicate_connection"));
@@ -2060,6 +2194,8 @@ mod tests {
         let mut checks: Vec<(&str, &[&str])> = vec![
             ("dbx_list_tables", &["database", "schema"]),
             ("dbx_describe_table", &["database", "schema"]),
+            ("dbx_list_routines", &["database", "schema", "routine_type"]),
+            ("dbx_get_routine_source", &["database", "schema", "signature"]),
             ("dbx_execute_query", &["database", "session_id", "cell_char_offset", "cell_char_limit"]),
             ("dbx_open_session", &["database"]),
             ("dbx_open_table", &["database", "schema"]),
@@ -2183,14 +2319,16 @@ mod tests {
         );
         let names = server.tool_router.list_all().into_iter().map(|tool| tool.name).collect::<Vec<_>>();
         #[cfg(feature = "mq-admin")]
-        assert_eq!(names.len(), 10);
+        assert_eq!(names.len(), 12);
         #[cfg(not(feature = "mq-admin"))]
-        assert_eq!(names.len(), 9);
+        assert_eq!(names.len(), 11);
         assert!(!names.iter().any(|name| name == "dbx_add_connection"));
         assert!(!names.iter().any(|name| name == "dbx_duplicate_connection"));
         assert!(!names.iter().any(|name| name == "dbx_remove_connection"));
         assert!(!names.iter().any(|name| name == "dbx_open_table"));
         assert!(!names.iter().any(|name| name == "dbx_execute_and_show"));
+        assert!(names.iter().any(|name| name == "dbx_list_routines"));
+        assert!(names.iter().any(|name| name == "dbx_get_routine_source"));
         assert!(names.iter().any(|name| name == "dbx_open_session"));
         assert!(names.iter().any(|name| name == "dbx_close_session"));
         #[cfg(feature = "mq-admin")]

--- a/crates/dbx-mcp/tests/protocol.rs
+++ b/crates/dbx-mcp/tests/protocol.rs
@@ -285,9 +285,9 @@ async fn initializes_lists_tools_and_calls_a_tool() {
     let tools = client.peer().list_tools(None).await.expect("list tools");
     let names = tools.tools.iter().map(|tool| tool.name.as_ref()).collect::<Vec<_>>();
     #[cfg(feature = "mq-admin")]
-    assert_eq!(names.len(), 15);
+    assert_eq!(names.len(), 17);
     #[cfg(not(feature = "mq-admin"))]
-    assert_eq!(names.len(), 14);
+    assert_eq!(names.len(), 16);
     assert!(names.contains(&"dbx_list_connections"));
     assert!(names.contains(&"dbx_list_databases"));
     assert!(names.contains(&"dbx_duplicate_connection"));

--- a/docs/content/docs/mcp.cn.mdx
+++ b/docs/content/docs/mcp.cn.mdx
@@ -87,7 +87,7 @@ DeepSeek Harness 通过 Cordis 插件条目加载 MCP Server，不读取 `mcpSer
 
 ## 工具列表
 
-DBX MCP 当前提供 15 个工具：
+DBX MCP 当前提供 17 个工具：
 
 | 工具 | 说明 |
 | --- | --- |
@@ -98,6 +98,8 @@ DBX MCP 当前提供 15 个工具：
 | `dbx_remove_connection` | 从 DBX 存储删除连接 |
 | `dbx_list_tables` | 列出表、视图或集合 |
 | `dbx_describe_table` | 返回列定义和表元数据 |
+| `dbx_list_routines` | 列出 Schema 中的存储过程和函数，支持可选的 `routine_type` 过滤（PROCEDURE 或 FUNCTION） |
+| `dbx_get_routine_source` | 按名称返回存储过程或函数的源码，重载场景可用可选的 `signature` 区分 |
 | `dbx_get_schema_context` | 返回适合 AI 使用的紧凑 Schema 上下文 |
 | `dbx_execute_query` | 执行 SQL 或支持的 MongoDB shell 命令，最多返回 100 行 |
 | `dbx_open_session` | 为 SQL 连接打开固定后端连接的有状态查询会话 |

--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -87,7 +87,7 @@ Run `dsh web --dump-config` to verify the composed configuration, then restart D
 
 ## Tools
 
-DBX MCP currently provides 15 tools:
+DBX MCP currently provides 17 tools:
 
 | Tool | Description |
 | --- | --- |
@@ -98,6 +98,8 @@ DBX MCP currently provides 15 tools:
 | `dbx_remove_connection` | Remove a connection from DBX storage |
 | `dbx_list_tables` | List tables, views, or collections |
 | `dbx_describe_table` | Return columns and table metadata |
+| `dbx_list_routines` | List stored procedures and functions in a schema, with an optional `routine_type` filter (PROCEDURE or FUNCTION) |
+| `dbx_get_routine_source` | Return the source of a stored procedure or function by name, with an optional `signature` for overloaded names |
 | `dbx_get_schema_context` | Return compact schema context for an AI model |
 | `dbx_execute_query` | Execute SQL or a supported MongoDB shell command, returning at most 100 rows |
 | `dbx_open_session` | Open a stateful SQL query session pinned to one backend connection |

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -17,7 +17,7 @@ The MCP protocol, connection loading, SQL safety, schema access, Redis support, 
 
 ## Features
 
-- **15 MCP tools** for connection and database discovery, schemas, SQL, Redis, sessions, messages, and DBX UI integration
+- **17 MCP tools** for connection and database discovery, schemas, SQL, Redis, sessions, messages, and DBX UI integration
 - **Precompiled native binaries** with no local Rust, Cargo, Python, or C/C++ build requirement
 - **No `better-sqlite3` runtime dependency** and no Node native-addon ABI coupling
 - **Local, Web, and Docker modes** using the same tool interface
@@ -149,6 +149,8 @@ Ask the MCP client to:
 | `dbx_remove_connection` | Remove a connection from DBX storage |
 | `dbx_list_tables` | List tables, views, collections, or message queue topics |
 | `dbx_describe_table` | Return columns and table metadata |
+| `dbx_list_routines` | List stored procedures and functions in a schema, with an optional `routine_type` filter (PROCEDURE or FUNCTION) |
+| `dbx_get_routine_source` | Return the source of a stored procedure or function by name, with an optional `signature` for overloaded names |
 | `dbx_get_schema_context` | Return compact schema context suitable for an AI model |
 | `dbx_execute_query` | Execute SQL or a supported MongoDB shell command, returning at most 100 rows |
 | `dbx_open_session` | Open a stateful SQL query session pinned to one backend connection |
@@ -433,7 +435,7 @@ MCP 协议、连接读取、SQL 安全检查、Schema、Redis、MongoDB、Web �
 
 ### 主要能力
 
-- 15 个 MCP 工具，涵盖连接和数据库发现、Schema、SQL、Redis、会话、消息队列和 DBX 桌面集成
+- 17 个 MCP 工具，涵盖连接和数据库发现、Schema、SQL、Redis、会话、消息队列和 DBX 桌面集成
 - 不依赖 `better-sqlite3`，没有 Node 原生模块 ABI 问题
 - 支持本地 DBX、DBX Web 和 Docker
 - 可选 Streamable HTTP 传输，使用 Bearer Token 保护；stdio 仍为默认方式


### PR DESCRIPTION
## Summary

Adds two read-only MCP tools so clients can browse stored procedures/functions without dropping to raw SQL:

- **`dbx_list_routines`** — lists procedures and functions for a schema as a markdown table (name, type, schema, signature, comment). Optional `routine_type` filter (`PROCEDURE` / `FUNCTION`); omit for both.
- **`dbx_get_routine_source`** — returns a routine's full source text, with optional `signature` for databases that overload routine names (e.g. Oracle).

## Design: generic, no per-database code

The tools are thin wrappers over machinery that already exists — every database family's routine support is already implemented for the desktop sidebar:

- **LocalBackend** → `dbx-core` `list_objects_core(object_types=[...])` / `get_object_source_core`, which dispatch per connection type (JDBC `DatabaseMetaData.getProcedures`, Hive-family `system.procedures_v`/`functions_v`, MySQL `information_schema.ROUTINES`, Postgres `pg_proc`, ...).
- **WebBackend** → reuses the existing `/api/schema/objects` and `/api/schema/object-source` routes the desktop app already calls.
- Routines are re-filtered locally after listing, so agents that ignore the `objectTypes` hint cannot leak tables into the results.
- Unsupported databases (sqlite, duckdb, ...) surface their normal "not supported" errors through the standard tool error path.

Both tools honor the existing `ensure_tool_allowed` fine-grained authorization and are registered in the settings-page MCP tool allowlist with localized labels (en / zh-CN / zh-TW / ja / ko / es / pt-BR / it).

## Testing

- `cargo test -p dbx-mcp` green (tool registration counts and JSON-schema optionality checks updated)
- `cargo fmt --check` clean
- `pnpm typecheck` green