### PR TITLE
feat(sql-file): show all execution failures

### DIFF
--- a/apps/desktop/src/components/export/ExportProgressPopover.vue
+++ b/apps/desktop/src/components/export/ExportProgressPopover.vue
@@ -232,7 +232,15 @@ function toggleFailureDetails(exportId: string) {
 }
 
 function failureDetailCount(task: ExportTask) {
+  if (task.kind === "sql-file") return (task.sqlFileFailures?.length ?? 0) + (task.sqlFileFailuresOmitted ?? 0);
   return (task.transferFailures?.length ?? 0) + (task.transferFailuresOmitted ?? 0);
+}
+
+function hasUnlistedTaskError(task: ExportTask) {
+  if (task.status !== "Error" || !task.errorMessage) return false;
+  if (task.kind === "sql-file") return !(task.sqlFileFailures ?? []).some((failure) => failure.error === task.errorMessage);
+  if (task.kind === "data-transfer") return !(task.transferFailures ?? []).some((failure) => failure.error === task.errorMessage);
+  return true;
 }
 
 function openTask(task: ExportTask): void {
@@ -288,21 +296,35 @@ function openTask(task: ExportTask): void {
               <span class="break-words tabular-nums">{{ rowsText(task) }}</span>
               <span v-if="task.kind !== 'data-transfer' && task.startedAt !== undefined" class="ml-1 tabular-nums">{{ elapsedText(task) }}</span>
               <span v-if="taskStatusText(task)" class="ml-1 font-medium text-primary">{{ taskStatusText(task) }}</span>
-              <span v-if="task.status === 'Error' && task.errorMessage" class="mt-1 block whitespace-normal break-words text-destructive" :title="translateBackendError(t, task.errorMessage)">
-                {{ translateBackendError(t, task.errorMessage) }}
+              <span v-if="hasUnlistedTaskError(task)" class="mt-1 block whitespace-normal break-words text-destructive" :title="translateBackendError(t, task.errorMessage!)">
+                {{ translateBackendError(t, task.errorMessage!) }}
               </span>
-              <template v-if="task.kind === 'data-transfer' && failureDetailCount(task) > 0">
+              <template v-if="(task.kind === 'data-transfer' || task.kind === 'sql-file') && failureDetailCount(task) > 0">
                 <button class="mt-1.5 flex items-center gap-1 text-xs font-medium text-foreground hover:text-primary" :aria-expanded="failureDetailsExpanded(task.exportId)" @click="toggleFailureDetails(task.exportId)">
                   <ChevronRight class="h-3.5 w-3.5 shrink-0 transition-transform" :class="{ 'rotate-90': failureDetailsExpanded(task.exportId) }" />
                   {{ failureDetailsExpanded(task.exportId) ? t("exportProgress.hideFailureDetails") : t("exportProgress.showFailureDetails", { count: failureDetailCount(task) }) }}
                 </button>
                 <div v-if="failureDetailsExpanded(task.exportId)" class="mt-1.5 max-h-44 overflow-y-auto rounded border border-destructive/20 bg-destructive/5">
-                  <div v-for="failure in task.transferFailures" :key="failure.table" class="border-b border-destructive/15 px-2.5 py-2 last:border-b-0">
-                    <div class="break-all font-mono font-medium text-foreground">{{ failure.table }}</div>
-                    <div class="mt-0.5 select-text whitespace-pre-wrap break-words text-destructive">{{ failure.error }}</div>
-                    <div v-if="failure.truncated" class="mt-0.5 text-muted-foreground">{{ t("exportProgress.failureDetailTruncated") }}</div>
-                  </div>
-                  <div v-if="task.transferFailuresOmitted" class="px-2.5 py-2 text-muted-foreground">{{ t("exportProgress.failureDetailsOmitted", { count: task.transferFailuresOmitted }) }}</div>
+                  <template v-if="task.kind === 'data-transfer'">
+                    <div v-for="failure in task.transferFailures" :key="failure.table" class="border-b border-destructive/15 px-2.5 py-2 last:border-b-0">
+                      <div class="break-all font-mono font-medium text-foreground">{{ failure.table }}</div>
+                      <div class="mt-0.5 select-text whitespace-pre-wrap break-words text-destructive">{{ failure.error }}</div>
+                      <div v-if="failure.truncated" class="mt-0.5 text-muted-foreground">{{ t("exportProgress.failureDetailTruncated") }}</div>
+                    </div>
+                    <div v-if="task.transferFailuresOmitted" class="px-2.5 py-2 text-muted-foreground">{{ t("exportProgress.failureDetailsOmitted", { count: task.transferFailuresOmitted }) }}</div>
+                  </template>
+                  <template v-else>
+                    <div v-for="failure in task.sqlFileFailures" :key="`${failure.fileIndex ?? -1}:${failure.statementIndex}`" class="border-b border-destructive/15 px-2.5 py-2 last:border-b-0">
+                      <div class="flex min-w-0 items-center gap-1.5 font-medium text-foreground">
+                        <span class="shrink-0">#{{ failure.statementIndex }}</span>
+                        <span v-if="failure.fileName" class="truncate text-muted-foreground" :title="failure.fileName">{{ failure.fileName }}</span>
+                      </div>
+                      <div v-if="failure.statementSummary" class="mt-0.5 select-text whitespace-pre-wrap break-words font-mono text-foreground">{{ failure.statementSummary }}</div>
+                      <div class="mt-0.5 select-text whitespace-pre-wrap break-words text-destructive">{{ translateBackendError(t, failure.error) }}</div>
+                      <div v-if="failure.truncated" class="mt-0.5 text-muted-foreground">{{ t("exportProgress.failureDetailTruncated") }}</div>
+                    </div>
+                    <div v-if="task.sqlFileFailuresOmitted" class="px-2.5 py-2 text-muted-foreground">{{ t("exportProgress.failureDetailsOmitted", { count: task.sqlFileFailuresOmitted }) }}</div>
+                  </template>
                 </div>
               </template>
             </div>

--- a/apps/desktop/src/components/export/__tests__/ExportProgressPopover.spec.ts
+++ b/apps/desktop/src/components/export/__tests__/ExportProgressPopover.spec.ts
@@ -281,6 +281,45 @@ describe("ExportProgressPopover task duration", () => {
     expect(document.body.textContent).toContain("1 additional failure detail(s) not shown");
     expect(document.body.textContent).not.toContain("failure 100");
   });
+
+  it("keeps SQL-file statement failures inspectable after a successful continue-on-error run", async () => {
+    const tracker = useExportTracker();
+    const task = tracker.addSqlFileTask("sql-failure-details", "migration.sql", "/tmp/migration.sql");
+    tracker.updateSqlFileTask(task.exportId, {
+      executionId: task.exportId,
+      status: "statementFailed",
+      statementIndex: 7,
+      successCount: 6,
+      failureCount: 1,
+      affectedRows: 6,
+      elapsedMs: 10,
+      statementSummary: "ALTER TABLE users ADD missing_type",
+      error: "type missing_type does not exist",
+    });
+    tracker.updateSqlFileTask(task.exportId, {
+      executionId: task.exportId,
+      status: "done",
+      statementIndex: 8,
+      successCount: 7,
+      failureCount: 1,
+      affectedRows: 7,
+      elapsedMs: 12,
+      statementSummary: "INSERT INTO users VALUES (1)",
+      error: null,
+    });
+
+    await mountPopover();
+
+    expect(document.body.textContent).toContain("7 succeeded, 1 failed");
+    const detailsButton = document.body.querySelector<HTMLButtonElement>('button[aria-expanded="false"]');
+    expect(detailsButton?.textContent).toContain("Failure details (1)");
+    detailsButton?.click();
+    await nextTick();
+
+    expect(document.body.textContent).toContain("#7");
+    expect(document.body.textContent).toContain("ALTER TABLE users ADD missing_type");
+    expect(document.body.textContent).toContain("type missing_type does not exist");
+  });
 });
 
 describe("ExportProgressPopover file name and reveal action", () => {

--- a/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.retry.spec.ts
+++ b/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.retry.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { createApp, defineComponent, h, nextTick } from "vue";
+import { createApp, defineComponent, h, nextTick, reactive } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   refreshDatabaseTreeNode: vi.fn(),
   requestConfirmation: vi.fn(),
   toast: vi.fn(),
+  trackerTask: undefined as any,
   unlisten: vi.fn(),
   updateSqlFileTask: vi.fn(),
   uuid: vi.fn(),
@@ -61,7 +62,7 @@ vi.mock("@/lib/backend/api", () => ({
 }));
 vi.mock("@lucide/vue", () => {
   const Icon = passthrough("span");
-  return { Check: Icon, CheckSquare: Icon, FileCode: Icon, FolderOpen: Icon, Loader2: Icon, Play: Icon, Square: Icon, X: Icon };
+  return { Check: Icon, CheckSquare: Icon, ChevronRight: Icon, FileCode: Icon, FolderOpen: Icon, Loader2: Icon, Play: Icon, Square: Icon, X: Icon };
 });
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: passthrough("div"),
@@ -151,6 +152,34 @@ function deferred() {
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.progressHandler = undefined;
+  mocks.trackerTask = undefined;
+  mocks.addSqlFileTask.mockImplementation((exportId: string, tableName: string, filePath: string) => {
+    mocks.trackerTask = reactive({
+      exportId,
+      kind: "sql-file",
+      tableName,
+      format: "sql",
+      filePath,
+      rowsExported: 0,
+      totalRows: null,
+      status: "Running",
+      errorMessage: null,
+      sqlFileFailures: [],
+      sqlFileFailuresOmitted: 0,
+    });
+    return mocks.trackerTask;
+  });
+  mocks.updateSqlFileTask.mockImplementation((_executionId: string, next: Record<string, any>, context?: { fileIndex?: number; fileName?: string }) => {
+    if (next.status === "statementFailed" && next.error) {
+      mocks.trackerTask.sqlFileFailures.push({
+        statementIndex: next.statementIndex,
+        statementSummary: next.statementSummary,
+        error: next.error,
+        ...(context?.fileIndex === undefined ? {} : { fileIndex: context.fileIndex }),
+        ...(context?.fileName ? { fileName: context.fileName } : {}),
+      });
+    }
+  });
   mocks.ensureConnected.mockResolvedValue(undefined);
   mocks.fetchSqlFileTargetOptions.mockResolvedValue([]);
   mocks.openFileDialog.mockResolvedValue(["/tmp/first.sql", "/tmp/second.sql"]);
@@ -216,5 +245,54 @@ describe("SqlFileExecutionDialog retries", () => {
     await vi.waitFor(() => expect(root!.textContent).toContain("sqlFile.status.cancelled"));
     expect(root!.querySelector("table")).toBeNull();
     expect(mocks.executeSqlFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows every statement failure in order after continue-on-error completion", async () => {
+    await mountReadyDialog();
+    mocks.executeSqlFiles.mockImplementationOnce(async (request: { executionId: string }) => {
+      mocks.progressHandler?.(progress(request.executionId, "statementFailed", { statementIndex: 1, failureCount: 1, statementSummary: "INSERT bad_one", error: "unknown column one" }));
+      mocks.progressHandler?.(progress(request.executionId, "statementFailed", { statementIndex: 2, failureCount: 2, statementSummary: "INSERT bad_two", error: "unknown column two" }));
+      mocks.progressHandler?.(progress(request.executionId, "statementFailed", { statementIndex: 3, failureCount: 3, statementSummary: "INSERT bad_three", error: "syntax error three" }));
+      mocks.progressHandler?.(progress(request.executionId, "done", { statementIndex: 4, successCount: 1, failureCount: 3 }));
+    });
+
+    findButton("sqlFile.execute").click();
+    await vi.waitFor(() => expect(root!.textContent).toContain("syntax error three"));
+
+    const text = root!.textContent ?? "";
+    expect(text).toContain("unknown column one");
+    expect(text).toContain("unknown column two");
+    expect(text.indexOf("INSERT bad_one")).toBeLessThan(text.indexOf("INSERT bad_two"));
+    expect(text.indexOf("INSERT bad_two")).toBeLessThan(text.indexOf("INSERT bad_three"));
+  });
+
+  it("shows the first statement failure when stop-on-error becomes terminal", async () => {
+    await mountReadyDialog();
+    mocks.executeSqlFiles.mockImplementationOnce(async (request: { executionId: string }) => {
+      mocks.progressHandler?.(progress(request.executionId, "statementFailed", { statementIndex: 1, failureCount: 1, statementSummary: "INSERT stop_here", error: "stop-on-error failure" }));
+      mocks.progressHandler?.(progress(request.executionId, "error", { statementIndex: 1, failureCount: 1, statementSummary: "INSERT stop_here", error: "stop-on-error failure" }));
+    });
+
+    findButton("sqlFile.execute").click();
+    await vi.waitFor(() => expect(root!.textContent).toContain("stop-on-error failure"));
+
+    expect(root!.textContent?.match(/stop-on-error failure/g)).toHaveLength(1);
+    expect(root!.textContent).toContain("INSERT stop_here");
+  });
+
+  it("clears statement failure details before an early retry failure", async () => {
+    await mountReadyDialog();
+    mocks.executeSqlFiles.mockImplementationOnce(async (request: { executionId: string }) => {
+      mocks.progressHandler?.(progress(request.executionId, "statementFailed", { statementIndex: 1, failureCount: 1, statementSummary: "INSERT stale", error: "stale statement failure" }));
+      mocks.progressHandler?.(progress(request.executionId, "done", { statementIndex: 2, successCount: 1, failureCount: 1 }));
+    });
+    findButton("sqlFile.execute").click();
+    await vi.waitFor(() => expect(root!.textContent).toContain("stale statement failure"));
+
+    mocks.ensureConnected.mockRejectedValueOnce(new Error("retry connection failed"));
+    findButton("sqlFile.execute").click();
+
+    await vi.waitFor(() => expect(root!.textContent).toContain("retry connection failed"));
+    expect(root!.textContent).not.toContain("stale statement failure");
   });
 });

--- a/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
+++ b/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
@@ -21,8 +21,9 @@ import { fetchSqlFileTargetOptions } from "@/composables/useDatabaseOptions";
 import { requiresSqlFileTargetDatabaseSelection } from "@/lib/connection/connectionLevelDatabaseBootstrap";
 import { cancelSqlFileExecution, executeSqlFiles, listenSqlFileProgress, previewSqlFile, type SqlFilePreview, type SqlFileProgress, type SqlFileStatus } from "@/lib/backend/api";
 import { buildDisplayFileNames, tooltipText as computeTooltipText } from "./sqlFilePreviewLabel";
-import { useExportTracker } from "@/composables/useExportTracker";
-import { Check, CheckSquare, FileCode, FolderOpen, Loader2, Play, Square, X } from "@lucide/vue";
+import { useExportTracker, type ExportTask } from "@/composables/useExportTracker";
+import { translateBackendError } from "@/i18n/backend-errors";
+import { Check, CheckSquare, ChevronRight, FileCode, FolderOpen, Loader2, Play, Square, X } from "@lucide/vue";
 
 const { t } = useI18n();
 const { toast } = useToast();
@@ -93,6 +94,8 @@ const executionId = ref("");
 const progress = ref<SqlFileProgress | null>(null);
 const terminalStatus = ref<SqlFileStatus | "idle">("idle");
 const terminalError = ref("");
+const activeExecutionTask = ref<ExportTask | null>(null);
+const failureDetailsExpanded = ref(false);
 const refreshedTarget = ref(false);
 const MAX_WEB_SQL_FILE_BYTES = 200 * 1024 * 1024;
 
@@ -152,6 +155,13 @@ const progressPercent = computed(() => {
   const current = Math.max(progress.value.statementIndex, attempted);
   if (current <= 0) return running.value ? 8 : 0;
   return Math.min(95, Math.max(8, Math.round((attempted / current) * 100)));
+});
+const sqlFileFailures = computed(() => activeExecutionTask.value?.sqlFileFailures ?? []);
+const sqlFileFailureCount = computed(() => sqlFileFailures.value.length + (activeExecutionTask.value?.sqlFileFailuresOmitted ?? 0));
+const unlistedTerminalError = computed(() => {
+  const error = progress.value?.error || terminalError.value;
+  if (!error || sqlFileFailures.value.some((failure) => failure.error === error)) return "";
+  return error;
 });
 function previewLineCount(item: SqlFilePreview) {
   return item.preview.split(/\r\n|\r|\n/).length;
@@ -220,6 +230,8 @@ function resetExecution() {
   progress.value = null;
   terminalStatus.value = "idle";
   terminalError.value = "";
+  activeExecutionTask.value = null;
+  failureDetailsExpanded.value = false;
   refreshedTarget.value = false;
   resetPerFileState();
 }
@@ -391,8 +403,10 @@ async function startExecution() {
   terminalStatus.value = "running";
   terminalError.value = "";
   progress.value = null;
+  activeExecutionTask.value = null;
+  failureDetailsExpanded.value = false;
   const taskLabel = previews.value.length === 1 ? previews.value[0]!.fileName : `${previews.value[0]!.fileName} (+${previews.value.length - 1})`;
-  addSqlFileTask(batchId, taskLabel, filePathDisplay.value);
+  activeExecutionTask.value = addSqlFileTask(batchId, taskLabel, filePathDisplay.value);
 
   try {
     await store.ensureConnected(connectionId.value);
@@ -415,7 +429,6 @@ async function startExecution() {
         progress.value = next;
         terminalStatus.value = next.status;
         terminalError.value = next.error ?? terminalError.value;
-        updateSqlFileTask(batchId, next);
 
         // Detect per-file boundary events from the backend (populated only
         // during multi-file execution).  The backend emits a file-start
@@ -444,6 +457,12 @@ async function startExecution() {
             }
           }
         }
+
+        updateSqlFileTask(batchId, next, {
+          fileIndex: currentFileIndex.value >= 0 ? currentFileIndex.value : previews.value.length === 1 ? 0 : undefined,
+          fileName: currentFileName.value || (previews.value.length === 1 ? (displayFileNames.value.get(previews.value[0]!.filePath) ?? previews.value[0]!.fileName) : undefined),
+        });
+        if (next.status === "statementFailed") failureDetailsExpanded.value = true;
 
         if (isTerminalProgress(next.status)) {
           resolveTerminalProgress(next);
@@ -778,8 +797,29 @@ watch(
             </div>
           </div>
 
-          <div v-if="progress?.error || terminalError" class="max-w-full overflow-auto rounded-md border bg-destructive/5 p-2 text-xs text-destructive whitespace-pre-wrap">
-            {{ progress?.error || terminalError }}
+          <div v-if="sqlFileFailureCount > 0" class="min-w-0 space-y-1.5">
+            <button type="button" class="flex items-center gap-1 text-xs font-medium text-foreground hover:text-primary" :aria-expanded="failureDetailsExpanded" @click="failureDetailsExpanded = !failureDetailsExpanded">
+              <ChevronRight class="h-3.5 w-3.5 shrink-0 transition-transform" :class="{ 'rotate-90': failureDetailsExpanded }" />
+              {{ failureDetailsExpanded ? t("exportProgress.hideFailureDetails") : t("exportProgress.showFailureDetails", { count: sqlFileFailureCount }) }}
+            </button>
+            <div v-if="failureDetailsExpanded" class="max-h-[min(30vh,280px)] min-w-0 overflow-y-auto rounded-md border border-destructive/20 bg-destructive/5 text-xs">
+              <div v-for="failure in sqlFileFailures" :key="`${failure.fileIndex ?? -1}:${failure.statementIndex}`" class="border-b border-destructive/15 p-2.5 last:border-b-0">
+                <div class="flex min-w-0 items-center gap-1.5 font-medium text-foreground">
+                  <span class="shrink-0">#{{ failure.statementIndex }}</span>
+                  <span v-if="failure.fileName" class="truncate text-muted-foreground" :title="failure.fileName">{{ failure.fileName }}</span>
+                </div>
+                <div v-if="failure.statementSummary" class="mt-1 max-w-full overflow-auto font-mono whitespace-pre-wrap break-words text-foreground">{{ failure.statementSummary }}</div>
+                <div class="mt-1 select-text whitespace-pre-wrap break-words text-destructive">{{ translateBackendError(t, failure.error) }}</div>
+                <div v-if="failure.truncated" class="mt-1 text-muted-foreground">{{ t("exportProgress.failureDetailTruncated") }}</div>
+              </div>
+              <div v-if="activeExecutionTask?.sqlFileFailuresOmitted" class="p-2.5 text-muted-foreground">
+                {{ t("exportProgress.failureDetailsOmitted", { count: activeExecutionTask.sqlFileFailuresOmitted }) }}
+              </div>
+            </div>
+          </div>
+
+          <div v-if="unlistedTerminalError" class="max-w-full overflow-auto rounded-md border bg-destructive/5 p-2 text-xs text-destructive whitespace-pre-wrap">
+            {{ translateBackendError(t, unlistedTerminalError) }}
           </div>
         </div>
       </div>

--- a/apps/desktop/src/composables/__tests__/useExportTracker.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useExportTracker.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TransferProgress, TransferRequest } from "@/lib/backend/api";
+import type { SqlFileProgress, TransferProgress, TransferRequest } from "@/lib/backend/api";
 
 vi.mock("@/lib/backend/api", () => ({
   startTransfer: vi.fn(),
@@ -10,7 +10,17 @@ vi.mock("@/lib/backend/api", () => ({
 }));
 
 import * as api from "@/lib/backend/api";
-import { formatDataTransferDuration, MAX_TRANSFER_FAILURE_DETAIL_BYTES, MAX_TRANSFER_FAILURE_DETAILS, MAX_TRANSFER_FAILURE_ERROR_BYTES, useExportTracker } from "@/composables/useExportTracker";
+import {
+  formatDataTransferDuration,
+  MAX_SQL_FILE_FAILURE_DETAIL_BYTES,
+  MAX_SQL_FILE_FAILURE_DETAILS,
+  MAX_SQL_FILE_FAILURE_ERROR_BYTES,
+  MAX_SQL_FILE_FAILURE_SUMMARY_BYTES,
+  MAX_TRANSFER_FAILURE_DETAIL_BYTES,
+  MAX_TRANSFER_FAILURE_DETAILS,
+  MAX_TRANSFER_FAILURE_ERROR_BYTES,
+  useExportTracker,
+} from "@/composables/useExportTracker";
 
 let now = 0;
 
@@ -43,6 +53,21 @@ function transferProgress(transferId: string, status: TransferProgress["status"]
     status,
     error: status === "error" ? "transfer failed" : null,
     terminal,
+  };
+}
+
+function sqlFileProgress(executionId: string, statementIndex: number, overrides: Partial<SqlFileProgress> = {}): SqlFileProgress {
+  return {
+    executionId,
+    status: "statementFailed",
+    statementIndex,
+    successCount: 0,
+    failureCount: statementIndex,
+    affectedRows: 0,
+    elapsedMs: statementIndex,
+    statementSummary: `SELECT missing_${statementIndex}`,
+    error: `failure ${statementIndex}`,
+    ...overrides,
   };
 }
 
@@ -327,6 +352,85 @@ describe("data transfer failure details", () => {
     });
 
     expect(task.transferFailuresOmitted).toBe(4_096);
+  });
+});
+
+describe("SQL-file failure details", () => {
+  it("preserves failures in event order through terminal completion and updates duplicate statements", () => {
+    const tracker = useExportTracker();
+    const task = tracker.addSqlFileTask("sql-failures", "migration.sql", "/tmp/migration.sql");
+
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, 3));
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, 7));
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, 3, { error: "updated failure 3" }));
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, 8, { status: "done", successCount: 5, failureCount: 2, error: null }));
+
+    expect(task.status).toBe("Done");
+    expect(task.sqlFileFailures).toEqual([
+      { statementIndex: 3, statementSummary: "SELECT missing_3", error: "updated failure 3" },
+      { statementIndex: 7, statementSummary: "SELECT missing_7", error: "failure 7" },
+    ]);
+    expect(task.failureCount).toBe(2);
+  });
+
+  it("retains reliable multi-file context for equal per-file statement indexes", () => {
+    const tracker = useExportTracker();
+    const task = tracker.addSqlFileTask("multi-file-failures", "first.sql (+1)", "/tmp/first.sql; /tmp/second.sql");
+
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, 1), { fileIndex: 0, fileName: "first.sql" });
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, 1), { fileIndex: 1, fileName: "second.sql" });
+
+    expect(task.sqlFileFailures).toEqual([
+      { statementIndex: 1, statementSummary: "SELECT missing_1", error: "failure 1", fileIndex: 0, fileName: "first.sql" },
+      { statementIndex: 1, statementSummary: "SELECT missing_1", error: "failure 1", fileIndex: 1, fileName: "second.sql" },
+    ]);
+  });
+
+  it("bounds retained count and reports omitted failures without double-counting replays", () => {
+    const tracker = useExportTracker();
+    const task = tracker.addSqlFileTask("many-sql-failures", "migration.sql", "/tmp/migration.sql");
+
+    for (let index = 1; index <= MAX_SQL_FILE_FAILURE_DETAILS + 2; index += 1) {
+      tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, index));
+    }
+    tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, MAX_SQL_FILE_FAILURE_DETAILS + 1));
+
+    expect(task.sqlFileFailures).toHaveLength(MAX_SQL_FILE_FAILURE_DETAILS);
+    expect(task.sqlFileFailuresOmitted).toBe(2);
+  });
+
+  it("bounds UTF-8 summaries, errors, and total retained bytes", () => {
+    const tracker = useExportTracker();
+    const task = tracker.addSqlFileTask("long-sql-failures", "migration.sql", "/tmp/migration.sql");
+    const longText = "错误🙂".repeat(4_000);
+
+    for (let index = 1; index <= 300; index += 1) {
+      tracker.updateSqlFileTask(task.exportId, sqlFileProgress(task.exportId, index, { statementSummary: longText, error: longText }));
+    }
+
+    const encoder = new TextEncoder();
+    const retainedBytes = task.sqlFileFailures!.reduce((total, failure) => {
+      expect(encoder.encode(failure.statementSummary).length).toBeLessThanOrEqual(MAX_SQL_FILE_FAILURE_SUMMARY_BYTES);
+      expect(encoder.encode(failure.error).length).toBeLessThanOrEqual(MAX_SQL_FILE_FAILURE_ERROR_BYTES);
+      expect(failure.statementSummary.endsWith("\ud83d")).toBe(false);
+      expect(failure.error.endsWith("\ud83d")).toBe(false);
+      expect(failure.truncated).toBe(true);
+      return total + encoder.encode(failure.statementSummary).length + encoder.encode(failure.error).length + encoder.encode(failure.fileName ?? "").length;
+    }, 0);
+
+    expect(retainedBytes).toBeLessThanOrEqual(MAX_SQL_FILE_FAILURE_DETAIL_BYTES);
+    expect(task.sqlFileFailuresOmitted).toBeGreaterThan(0);
+  });
+
+  it("starts a replacement execution with an empty failure list", () => {
+    const tracker = useExportTracker();
+    const first = tracker.addSqlFileTask("reused-id", "first.sql", "/tmp/first.sql");
+    tracker.updateSqlFileTask(first.exportId, sqlFileProgress(first.exportId, 1));
+
+    const replacement = tracker.addSqlFileTask("reused-id", "second.sql", "/tmp/second.sql");
+
+    expect(replacement.sqlFileFailures).toEqual([]);
+    expect(replacement.sqlFileFailuresOmitted).toBe(0);
   });
 });
 

--- a/apps/desktop/src/composables/useExportTracker.ts
+++ b/apps/desktop/src/composables/useExportTracker.ts
@@ -12,6 +12,20 @@ export interface DataTransferFailure {
   truncated?: boolean;
 }
 
+export interface SqlFileFailure {
+  statementIndex: number;
+  statementSummary: string;
+  error: string;
+  fileIndex?: number;
+  fileName?: string;
+  truncated?: boolean;
+}
+
+export interface SqlFileFailureContext {
+  fileIndex?: number;
+  fileName?: string;
+}
+
 export interface ExportTask {
   exportId: string;
   kind: BackgroundTaskKind;
@@ -46,6 +60,8 @@ export interface ExportTask {
   targetTables?: string[];
   transferFailures?: DataTransferFailure[];
   transferFailuresOmitted?: number;
+  sqlFileFailures?: SqlFileFailure[];
+  sqlFileFailuresOmitted?: number;
   multiDbSourceTabId?: string;
   multiDbTotal?: number;
   multiDbCompleted?: number;
@@ -76,6 +92,11 @@ export interface MultiDbExecutionTaskProgress {
 export const MAX_TRANSFER_FAILURE_DETAILS = 100;
 export const MAX_TRANSFER_FAILURE_DETAIL_BYTES = 128 * 1024;
 export const MAX_TRANSFER_FAILURE_ERROR_BYTES = 8 * 1024;
+export const MAX_SQL_FILE_FAILURE_DETAILS = 500;
+export const MAX_SQL_FILE_FAILURE_DETAIL_BYTES = 2 * 1024 * 1024;
+export const MAX_SQL_FILE_FAILURE_ERROR_BYTES = 8 * 1024;
+export const MAX_SQL_FILE_FAILURE_SUMMARY_BYTES = 2 * 1024;
+const MAX_SQL_FILE_FAILURE_NAME_BYTES = 1024;
 const MAX_TRACKED_OMITTED_FAILURES = 4096;
 
 interface TransferFailureState {
@@ -86,10 +107,18 @@ interface TransferFailureState {
   replayOmittedCount: number;
 }
 
+interface SqlFileFailureState {
+  indexes: Map<string, number>;
+  retainedBytes: number;
+  omittedKeys: Set<string>;
+  omittedCount: number;
+}
+
 const taskMap = reactive<Map<string, ExportTask>>(new Map());
 const activeTransferRuns = new Set<string>();
 const taskCancelHandlers = new Map<string, () => void | Promise<void>>();
 const transferFailureStates = new Map<string, TransferFailureState>();
+const sqlFileFailureStates = new Map<string, SqlFileFailureState>();
 const textEncoder = new TextEncoder();
 
 function utf8ByteLength(value: string): number {
@@ -178,6 +207,82 @@ function recordTransferFailure(task: ExportTask, table: string, error: string) {
   state.indexes.set(table, task.transferFailures.length);
   state.retainedBytes += tableBytes + retainedError.bytes;
   task.transferFailures.push(failure);
+}
+
+function sqlFileFailureKey(statementIndex: number, fileIndex?: number): string {
+  return `${fileIndex ?? -1}:${statementIndex}`;
+}
+
+function sqlFileFailureBytes(failure: SqlFileFailure): number {
+  return utf8ByteLength(failure.statementSummary) + utf8ByteLength(failure.error) + utf8ByteLength(failure.fileName ?? "");
+}
+
+function getSqlFileFailureState(task: ExportTask): SqlFileFailureState {
+  let state = sqlFileFailureStates.get(task.exportId);
+  if (state) return state;
+
+  const failures = task.sqlFileFailures ?? [];
+  state = {
+    indexes: new Map(failures.map((failure, index) => [sqlFileFailureKey(failure.statementIndex, failure.fileIndex), index])),
+    retainedBytes: failures.reduce((total, failure) => total + sqlFileFailureBytes(failure), 0),
+    omittedKeys: new Set(),
+    omittedCount: task.sqlFileFailuresOmitted ?? 0,
+  };
+  sqlFileFailureStates.set(task.exportId, state);
+  return state;
+}
+
+function recordOmittedSqlFileFailure(task: ExportTask, state: SqlFileFailureState, key: string) {
+  if (state.omittedKeys.has(key) || state.omittedKeys.size >= MAX_TRACKED_OMITTED_FAILURES) return;
+  state.omittedKeys.add(key);
+  state.omittedCount += 1;
+  task.sqlFileFailuresOmitted = state.omittedCount;
+}
+
+function buildSqlFileFailure(progress: api.SqlFileProgress, context?: SqlFileFailureContext, availableBytes = MAX_SQL_FILE_FAILURE_DETAIL_BYTES): SqlFileFailure | null {
+  const retainedName = truncateUtf8(context?.fileName ?? progress.fileName ?? "", MAX_SQL_FILE_FAILURE_NAME_BYTES);
+  const retainedSummary = truncateUtf8(progress.statementSummary, MAX_SQL_FILE_FAILURE_SUMMARY_BYTES);
+  const fixedBytes = retainedName.bytes + retainedSummary.bytes;
+  if (fixedBytes >= availableBytes) return null;
+
+  const retainedError = truncateUtf8(progress.error ?? "", Math.min(MAX_SQL_FILE_FAILURE_ERROR_BYTES, availableBytes - fixedBytes));
+  const failure: SqlFileFailure = {
+    statementIndex: progress.statementIndex,
+    statementSummary: retainedSummary.value,
+    error: retainedError.value,
+  };
+  const fileIndex = context?.fileIndex ?? progress.fileIndex;
+  if (fileIndex !== undefined) failure.fileIndex = fileIndex;
+  if (retainedName.value) failure.fileName = retainedName.value;
+  if (retainedName.truncated || retainedSummary.truncated || retainedError.truncated) failure.truncated = true;
+  return failure;
+}
+
+function recordSqlFileFailure(task: ExportTask, progress: api.SqlFileProgress, context?: SqlFileFailureContext) {
+  if (progress.status !== "statementFailed" || !progress.error) return;
+  task.sqlFileFailures ??= [];
+  const state = getSqlFileFailureState(task);
+  const fileIndex = context?.fileIndex ?? progress.fileIndex;
+  const key = sqlFileFailureKey(progress.statementIndex, fileIndex);
+  const existingIndex = state.indexes.get(key);
+  const previousBytes = existingIndex === undefined ? 0 : sqlFileFailureBytes(task.sqlFileFailures[existingIndex]!);
+  const availableBytes = MAX_SQL_FILE_FAILURE_DETAIL_BYTES - state.retainedBytes + previousBytes;
+  const failure = buildSqlFileFailure(progress, context, availableBytes);
+
+  if (!failure || (existingIndex === undefined && task.sqlFileFailures.length >= MAX_SQL_FILE_FAILURE_DETAILS)) {
+    recordOmittedSqlFileFailure(task, state, key);
+    return;
+  }
+
+  if (existingIndex !== undefined) {
+    task.sqlFileFailures[existingIndex] = failure;
+    state.retainedBytes += sqlFileFailureBytes(failure) - previousBytes;
+    return;
+  }
+
+  state.indexes.set(key, task.sqlFileFailures.length);
+  state.retainedBytes += sqlFileFailureBytes(failure);
+  task.sqlFileFailures.push(failure);
 }
 
 function normalizeExportStatus(status: string): BackgroundTaskStatus {
@@ -306,6 +411,7 @@ export function useExportTracker() {
   }
 
   function addSqlFileTask(executionId: string, fileName: string, filePath: string): ExportTask {
+    sqlFileFailureStates.delete(executionId);
     const task = reactive<ExportTask>({
       exportId: executionId,
       kind: "sql-file",
@@ -322,6 +428,8 @@ export function useExportTracker() {
       affectedRows: 0,
       elapsedMs: 0,
       statementSummary: "",
+      sqlFileFailures: [],
+      sqlFileFailuresOmitted: 0,
     });
     taskMap.set(executionId, task);
     return task;
@@ -493,9 +601,10 @@ export function useExportTracker() {
     if (task?.kind === "database-export" && task.status === "Cancelling") task.status = "Running";
   }
 
-  function updateSqlFileTask(executionId: string, progress: api.SqlFileProgress) {
+  function updateSqlFileTask(executionId: string, progress: api.SqlFileProgress, context?: SqlFileFailureContext) {
     const task = taskMap.get(executionId);
     if (!task) return;
+    recordSqlFileFailure(task, progress, context);
     task.status = normalizeSqlFileStatus(progress.status);
     task.errorMessage = progress.error || null;
     task.statementIndex = progress.statementIndex;
@@ -537,6 +646,7 @@ export function useExportTracker() {
     taskMap.delete(exportId);
     taskCancelHandlers.delete(exportId);
     transferFailureStates.delete(exportId);
+    sqlFileFailureStates.delete(exportId);
   }
 
   function clearFinished() {
@@ -545,6 +655,7 @@ export function useExportTracker() {
         taskMap.delete(id);
         taskCancelHandlers.delete(id);
         transferFailureStates.delete(id);
+        sqlFileFailureStates.delete(id);
       }
     }
   }


### PR DESCRIPTION
## 变更说明

改进 SQL 文件的「出错后继续」执行结果：此前前端虽然会收到每一条失败语句的进度事件，但后续事件会覆盖前一条错误，最终只能查看最后一条失败信息。现在会按执行顺序保留并展示每条失败语句及其对应错误，便于一次性检查数据库迁移或初始化脚本中的兼容性问题。

- 在共享后台任务状态中按顺序保留 SQL 文件的失败语句编号、语句摘要、文件名和错误信息
- SQL 文件执行窗口提供可折叠、可滚动的失败详情列表，同时保留原有成功数、失败数、影响行数和耗时统计
- 后台运行或关闭执行窗口后，仍可从顶部后台任务入口查看完整失败详情
- 新一轮执行和重试会使用独立的失败列表，不会混入上一次执行结果
- 保持「遇错停止」与「出错后继续」的现有执行语义不变
- 对大量或超长错误设置有界留存，并明确提示已截断或未展示的详情数量，避免静默丢失

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

### 查看 SQL 文件的全部失败详情

https://github.com/user-attachments/assets/c1d41d1f-120d-472c-a587-09a4671d64ee

录屏展示执行包含三条错误的 SQL 文件：启用「出错后继续」后，任务最终完成 9 条语句，其中成功 6 条、失败 3 条；执行窗口按顺序展示 `#4`、`#6`、`#8` 的语句与错误，关闭窗口后仍可从顶部后台任务入口展开「失败详情（3）」查看相同结果。

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `pnpm exec vitest run apps/desktop/src/composables/__tests__/useExportTracker.spec.ts apps/desktop/src/components/sql-file/SqlFileExecutionDialog.retry.spec.ts apps/desktop/src/components/export/__tests__/ExportProgressPopover.spec.ts`（44 个相关测试通过）
- SQL 文件失败详情状态测试覆盖顺序留存、重复事件更新、多文件上下文、UTF-8 安全截断、总容量限制、遗漏计数及新任务重置
- SQL 文件执行窗口测试覆盖「出错后继续」展示多条失败、遇错停止不重复展示错误及重试清理旧结果
- 后台任务面板测试覆盖完成后展开查看 SQL 文件失败详情
- Docker MySQL 8.0.45 手动 E2E：共执行 9 条语句，成功 6 条、失败 3 条、影响 4 行；执行窗口和后台任务均可查看三条失败详情
- `make cargo-check-fast`
- `git diff --check`

`make check` 已执行；connection types、format、lint、typecheck 以及 12,371 条测试通过，仅被未由本分支修改的 `DocumentBrowserFieldSearch.spec.ts` 既有并发时序波动阻断。该文件单独运行时 22 个测试全部通过。

## 关联 Issue

Close #7793
