### PR TITLE
fix(windows): 修复旧系统专用包被错误拦截

### DIFF
--- a/apps/desktop/src/lib/__tests__/windowsInstallerTemplate.spec.ts
+++ b/apps/desktop/src/lib/__tests__/windowsInstallerTemplate.spec.ts
@@ -21,7 +21,10 @@ describe("Windows offline installer template", () => {
   it("routes supported legacy Windows users from generic installers to the fixed-runtime package", () => {
     expect(template).toContain("ManifestSupportedOS all");
     expect(template).toContain("!include WinVer.nsh");
-    expect(template).toContain('!if "${INSTALLWEBVIEW2MODE}" != "fixedRuntime"');
+    // Tauri 2.11 renders fixedRuntime as an empty NSIS install mode instead of
+    // the literal "fixedRuntime" string.
+    expect(template).toContain('!if "${INSTALLWEBVIEW2MODE}" != ""');
+    expect(template).not.toContain('!if "${INSTALLWEBVIEW2MODE}" != "fixedRuntime"');
     expect(template).toContain("${If} ${IsWin7}");
     expect(template).toContain("${OrIf} ${IsWin2012R2}");
     expect(template).toContain('MessageBox MB_ICONSTOP|MB_YESNO|MB_DEFBUTTON1 "$(dbxWin7InstallerRequired)" IDYES dbx_open_win7_installer');

--- a/src-tauri/windows/nsis/installer.nsi
+++ b/src-tauri/windows/nsis/installer.nsi
@@ -530,9 +530,10 @@ Function .onInit
     !insertmacro MUI_LANGDLL_DISPLAY
   !endif
 
-  ; Evergreen WebView2 installers no longer run on Windows 7. Route interactive
-  ; users to the fixed WebView2 109 bundle before the generic installer fails.
-  !if "${INSTALLWEBVIEW2MODE}" != "fixedRuntime"
+  ; Tauri renders fixedRuntime (and skip) as an empty install mode in NSIS;
+  ; DBX does not ship a skip-mode installer. Only route builds that actually
+  ; install an Evergreen WebView2 runtime to the fixed WebView2 109 bundle.
+  !if "${INSTALLWEBVIEW2MODE}" != ""
     ${If} ${IsWin7}
     ${OrIf} ${IsWin2012R2}
       ${If} ${Silent}


### PR DESCRIPTION
## 问题

0.6.1 的 Win7 / Server 2012 R2 专用安装包在 Server 2012 R2 上启动时，仍提示“此安装包不支持 Windows 7 或 Windows Server 2012 R2”。

经核对用户反馈与官方发布产物，用户使用的确实是专用包，不是普通安装包误改名：

- 官方文件：`DBX_0.6.1_x64-win7-server2012r2-webview2-109-offline-setup.exe`
- 官方 SHA256：`10d878a14204bf8cf1b7bb163c9fa91838803ec69c878b14137c8c5c61e0d366`
- 安装器内包含完整 WebView2 109 fixed runtime

## 根因

Tauri CLI 2.11.2 生成 NSIS 模板数据时，只为以下模式输出非空的 `INSTALLWEBVIEW2MODE`：

- `downloadBootstrapper`
- `embedBootstrapper`
- `offlineInstaller`

`fixedRuntime` 会落入默认分支并输出空字符串，而不是字面量 `fixedRuntime`。原判断：

```nsi
!if "${INSTALLWEBVIEW2MODE}" != "fixedRuntime"
```

因此对专用 fixed-runtime 安装包也始终成立，导致 Win7 / Server 2012 R2 被错误拦截。

## 修复

- 改为仅在 `INSTALLWEBVIEW2MODE` 非空时执行旧系统分流
- DBX 不发布 `skip` 模式 NSIS 包，因此空值在当前发布矩阵中只对应 fixed-runtime 专用包
- 增加回归断言，禁止恢复为错误的 `fixedRuntime` 字面量比较

普通在线包和普通离线包仍会在 Win7 / Server 2012 R2 上显示专用包引导。

## 验证

- 使用 NSIS 3.12 `makensis` 实测预处理条件：
  - 空模式不进入拦截分支
  - `downloadBootstrapper` 进入拦截分支
  - `offlineInstaller` 进入拦截分支
- `pnpm exec oxfmt --check apps/desktop/src/lib/__tests__/windowsInstallerTemplate.spec.ts`：通过
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/windowsInstallerTemplate.spec.ts`：17/17 通过
- `git diff --check`：通过
- `zipg/dbx` 独立构建：Win7 目标编译、PE 兼容审计、旧版 WebView2 Loader 审计、NSIS 打包及安装包内容审计均通过
- 产物核验：安装包内包含 WebView2 fixed runtime `109.0.1518.78`
- Win7 真机验证：安装实测通过，未再出现专用包被错误拦截的问题

Fix：0.6.1 Win7 / Server 2012 R2 专用安装包被错误识别为普通安装包。