### PR TITLE
fix(desktop): let data header name chips flex instead of hard truncating

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1902,13 +1902,15 @@ defineExpose({
     <template v-else-if="activeTab.mode === 'data'">
       <div class="flex-1 min-h-0 flex flex-col">
         <div class="h-9 shrink-0 border-b bg-background/80 px-3 flex items-center gap-2 text-xs">
-          <span v-if="activeConnection?.name?.trim()" data-data-header-connection class="inline-flex max-w-48 min-w-0 items-center truncate rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground" :title="activeConnection.name">
+          <!-- No fixed max-w cap on these chips: they must flex (min-w-0 + truncate)
+               so long names only clip when the header row itself runs out of space (#7880). -->
+          <span v-if="activeConnection?.name?.trim()" data-data-header-connection class="inline-flex min-w-0 items-center truncate rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground" :title="activeConnection.name">
             {{ activeConnection.name }}
           </span>
-          <span class="inline-flex max-w-48 min-w-0 items-center truncate rounded border border-border bg-muted/50 px-2 py-0.5 font-medium">
+          <span class="inline-flex min-w-0 items-center truncate rounded border border-border bg-muted/50 px-2 py-0.5 font-medium" :title="activeTab.tableMeta?.tableName || activeTab.title">
             {{ activeTab.tableMeta?.tableName || activeTab.title }}
           </span>
-          <span class="inline-flex max-w-56 min-w-0 items-center truncate rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground">
+          <span class="inline-flex min-w-0 items-center truncate rounded border border-border bg-muted/30 px-2 py-0.5 text-muted-foreground" :title="[activeTab.tableMeta?.schema, databaseDisplayNameForTab(activeTab.connectionId, activeTab.database, t)].filter(Boolean).join('@')">
             <template v-if="activeTab.tableMeta?.schema">{{ activeTab.tableMeta.schema }}@</template>{{ databaseDisplayNameForTab(activeTab.connectionId, activeTab.database, t) }}
           </span>
           <span v-if="activeTab.mode === 'data' && activeTab.tableMeta" class="inline-flex shrink-0 items-center rounded border border-border bg-muted/30 px-2 py-0.5 font-medium text-muted-foreground tabular-nums"> {{ activeTab.tableMeta.columns.length }} {{ t("tree.columns") }} </span>

--- a/apps/desktop/src/components/layout/__tests__/ContentArea.dataHeader.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/ContentArea.dataHeader.spec.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const contentAreaSource = readFileSync(new URL("../ContentArea.vue", import.meta.url), "utf8");
+
+describe("ContentArea data-mode header", () => {
+  it("lets name chips flex to available width and only truncate when the row overflows", () => {
+    const headerIndex = contentAreaSource.indexOf("data-data-header-connection");
+    expect(headerIndex).toBeGreaterThan(-1);
+    const chipsBlock = contentAreaSource.slice(headerIndex, contentAreaSource.indexOf('class="ml-auto"', headerIndex));
+    expect(chipsBlock.length).toBeGreaterThan(0);
+
+    // Fixed max-w-48/max-w-56 caps clipped table names even with plenty of free
+    // space in the header row (#7880); chips must rely on min-w-0 + truncate so
+    // they only clip when the row itself runs out of space.
+    expect(chipsBlock).not.toContain("max-w-48");
+    expect(chipsBlock).not.toContain("max-w-56");
+    expect(chipsBlock).toContain("inline-flex min-w-0 items-center truncate");
+  });
+
+  it("keeps the full table and schema names reachable via title tooltips", () => {
+    expect(contentAreaSource).toContain(':title="activeTab.tableMeta?.tableName || activeTab.title"');
+    expect(contentAreaSource).toContain("[activeTab.tableMeta?.schema, databaseDisplayNameForTab(activeTab.connectionId, activeTab.database, t)].filter(Boolean).join('@')");
+  });
+});

--- a/packages/app-tests/dataTabHeaderConnection.test.ts
+++ b/packages/app-tests/dataTabHeaderConnection.test.ts
@@ -27,5 +27,6 @@ test("data tab header shows the active connection before the table context", () 
   assert.ok(connectionIndex >= 0 && connectionIndex < tableIndex);
   assert.match(template, /v-if="activeConnection\?\.name\?\.trim\(\)"/);
   assert.match(template, /:title="activeConnection\.name"/);
-  assert.match(template, /data-data-header-connection class="[^"]*max-w-48[^"]*truncate/);
+  assert.doesNotMatch(template, /data-data-header-connection class="[^"]*(?:max-w-4[89]|max-w-5[0-9])/);
+  assert.match(template, /data-data-header-connection class="[^"]*min-w-0[^"]*truncate/);
 });


### PR DESCRIPTION
## Problem

In the data-grid header, the table-name chip was hard-capped at `max-w-48`
(192px). Long table names were truncated even when the header row had plenty
of free space on the right — the workaround was manually squeezing the panel
(#7880). The connection and schema chips in the same row had the same fixed
caps (`max-w-48` / `max-w-56`).

## Root cause

The chips rely on truncation, but the fixed `max-w-*` utilities cap them at a
static width that never reacts to available space. The bug is generic UI
behavior, not StarRocks-specific — any database with a table name longer than
~28 characters at 12px triggers it.

## Change

- Remove the fixed `max-w-48` / `max-w-56` caps from the three name chips in
  the data-mode header. They now flex with `min-w-0` + `truncate`, so names
  are shown in full whenever space permits and only clip (with ellipsis) when
  the row itself runs out of space. Right-side toolbar controls were already
  `shrink-0` and are unaffected.
- Add `:title` tooltips to the table and schema chips (the connection chip
  already had one) so the full value stays reachable on hover.
- Add `ContentArea.dataHeader.spec.ts` to guard against reintroducing fixed
  width caps and dropping the tooltips.

## Validation

- New spec fails on the unfixed source (2/2 assertions) and passes after the
  fix; targeted suites pass: `vitest run` → 15/15 (ContentArea output-view,
  data header, column-layout popover).
- `pnpm typecheck` (vue-tsc), `oxlint`, `oxfmt --check` — all clean on the
  touched files.
- Rendered behavior verified against a real Tailwind v4 compile in a browser
  with the exact chip classes and the issue's data: at 1600px the full name
  `warehouse_management_order_detail_wide` is displayed; at 620px chips
  truncate proportionally with ellipsis and the toolbar buttons remain intact.

Closes #7880