### PR TITLE
✨ feat(ai): 支持 Kimi 模型专属推理强度配置

### DIFF
--- a/crates/dbx-core/src/ai.rs
+++ b/crates/dbx-core/src/ai.rs
@@ -1271,11 +1271,13 @@ fn decorate_chat_completion_body(body: &mut serde_json::Value, config: &AiConfig
 /// Kimi K2.5+ models (including K2.7-Code) handle thinking flags differently
 /// and reject the OpenAI-compatible `extra_body.chat_template_kwargs` toggle.
 ///
-/// Matches `kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code`, K3+, and future versions,
-/// while excluding older K2 variants (`kimi-k2`, `kimi-k2-thinking`, etc.).
-/// Regex equivalent: /kimi-k(?:2\.[5-9]\d*|[3-9]\d*)/
+/// Matches current Kimi IDs and legacy catalog aliases while excluding older K2
+/// variants (`kimi-k2`, `kimi-k2-thinking`, etc.).
 fn is_kimi_model(model: &str) -> bool {
     let model = model.trim().to_ascii_lowercase();
+    if matches!(model.as_str(), "k3" | "kimi-for-coding" | "kimi-for-coding-highspeed") {
+        return true;
+    }
     if let Some(rest) = model.strip_prefix("kimi-k") {
         if rest.starts_with("2.") && rest.len() > 2 {
             // K2.x — the digit after "2." must be >= 5 (so K2.5+)
@@ -6689,6 +6691,9 @@ mod tests {
         assert!(is_kimi_model("kimi-k2.6"));
         assert!(is_kimi_model("kimi-k2.5"));
         assert!(is_kimi_model("kimi-k3"));
+        assert!(is_kimi_model("K3"));
+        assert!(is_kimi_model("kimi-for-coding"));
+        assert!(is_kimi_model("kimi-for-coding-highspeed"));
 
         // Older K2 variants should not skip OpenAI-compatible thinking toggles.
         assert!(!is_kimi_model("kimi-k2"));
@@ -6920,8 +6925,8 @@ mod tests {
     }
 
     #[test]
-    fn omits_extra_body_for_kimi_test_connection_body() {
-        let config = AiConfig {
+    fn omits_extra_body_for_kimi_model_aliases() {
+        let mut config = AiConfig {
             provider: AiProvider::OpenaiCompatible,
             api_key: "key".to_string(),
             auth_method: AiAuthMethod::Bearer,
@@ -6954,17 +6959,20 @@ mod tests {
             qoder_cli_path: None,
             qoder_cli_env: Default::default(),
         };
-        let mut body = serde_json::json!({
-            "model": &config.model,
-            "messages": [{ "role": "user", "content": TEST_PROMPT }],
-            "max_tokens": 16,
-            "stream": true,
-        });
+        for model in ["kimi-k2.5", "K3", "kimi-for-coding", "kimi-for-coding-highspeed"] {
+            config.model = model.to_string();
+            let mut body = serde_json::json!({
+                "model": &config.model,
+                "messages": [{ "role": "user", "content": TEST_PROMPT }],
+                "max_tokens": 16,
+                "stream": true,
+            });
 
-        apply_chat_completion_thinking_toggle(&mut body, &config);
+            apply_chat_completion_thinking_toggle(&mut body, &config);
 
-        assert!(body.get("extra_body").is_none());
-        assert!(body.get("reasoning_effort").is_none());
+            assert!(body.get("extra_body").is_none(), "{model}");
+            assert!(body.get("reasoning_effort").is_none(), "{model}");
+        }
     }
 
     #[test]

--- a/crates/dbx-core/src/ai_effort.rs
+++ b/crates/dbx-core/src/ai_effort.rs
@@ -6,11 +6,12 @@ use serde_json::{json, Map, Value};
 const OPENAI_REASONING_DOCS: &str = "https://platform.openai.com/docs/guides/reasoning";
 const GEMINI_THINKING_DOCS: &str = "https://ai.google.dev/gemini-api/docs/thinking";
 const DEEPSEEK_THINKING_DOCS: &str = "https://api-docs.deepseek.com/guides/thinking_mode";
+const KIMI_REASONING_DOCS: &str = "https://platform.moonshot.cn/docs/guide/use-reasoning-effort";
 const QWEN_THINKING_DOCS: &str = "https://help.aliyun.com/en/model-studio/deep-thinking";
 const OLLAMA_THINKING_DOCS: &str = "https://docs.ollama.com/capabilities/thinking";
 const MINIMAX_THINKING_DOCS: &str = "https://platform.minimax.io/docs/api-reference/text-chat-openai";
 
-pub const EFFORT_REGISTRY_LAST_VERIFIED: &str = "2026-07-30";
+pub const EFFORT_REGISTRY_LAST_VERIFIED: &str = "2026-09-03";
 
 fn option(id: &str, label: &str, selection: AiEffortSelection) -> AiEffortOption {
     AiEffortOption { id: id.to_string(), label: label.to_string(), description: None, selection }
@@ -75,7 +76,7 @@ pub fn static_effort_capability(config: &AiConfig, model_id: &str) -> Option<AiE
         AiProvider::Openai => openai_capability(&model, source),
         AiProvider::Gemini => gemini_capability(&model, source),
         AiProvider::Deepseek => deepseek_capability(&model, source),
-        AiProvider::Kimi => None,
+        AiProvider::Kimi => kimi_capability(&model, source),
         AiProvider::Qwen => qwen_capability(&model, source),
         AiProvider::Ollama => ollama_capability(&model, source),
         AiProvider::MiniMax if matches_family(&model, "minimax-m3") => Some(boolean_capability(source)),
@@ -157,6 +158,24 @@ fn deepseek_capability(model: &str, source: AiCapabilitySource) -> Option<AiEffo
     None
 }
 
+fn is_kimi_k3_model(model: &str) -> bool {
+    model == "k3" || matches_family(model, "kimi-k3")
+}
+
+fn kimi_capability(model: &str, source: AiCapabilitySource) -> Option<AiEffortCapability> {
+    if is_kimi_k3_model(model) {
+        let mut capability = enum_capability(&["low", "high", "max"], source);
+        if let AiEffortCapability::Enum { default, .. } = &mut capability {
+            *default = AiEffortSelection::Enum("max".to_string());
+        }
+        return Some(capability);
+    }
+    if matches_family(model, "kimi-k2.6") {
+        return Some(boolean_capability(source));
+    }
+    None
+}
+
 fn qwen_capability(model: &str, source: AiCapabilitySource) -> Option<AiEffortCapability> {
     if matches_family(model, "qwen3.8-max-preview") {
         return Some(enum_capability(&["low", "medium", "xhigh"], source));
@@ -187,7 +206,7 @@ pub fn registry_source_url(provider: &AiProvider) -> Option<&'static str> {
         AiProvider::Openai => Some(OPENAI_REASONING_DOCS),
         AiProvider::Gemini => Some(GEMINI_THINKING_DOCS),
         AiProvider::Deepseek => Some(DEEPSEEK_THINKING_DOCS),
-        AiProvider::Kimi => None,
+        AiProvider::Kimi => Some(KIMI_REASONING_DOCS),
         AiProvider::Qwen => Some(QWEN_THINKING_DOCS),
         AiProvider::Ollama => Some(OLLAMA_THINKING_DOCS),
         AiProvider::MiniMax => Some(MINIMAX_THINKING_DOCS),
@@ -266,7 +285,7 @@ pub fn apply_runtime_effort(body: &mut Value, config: &AiConfig) {
         AiProvider::Claude | AiProvider::AnthropicCompatible => apply_claude_effort(object, selection),
         AiProvider::Gemini => apply_gemini_effort(object, &config.model, selection),
         AiProvider::Deepseek => apply_deepseek_effort(object, selection),
-        AiProvider::Kimi => apply_openai_effort(object, &config.api_style, selection),
+        AiProvider::Kimi => apply_kimi_effort(object, &config.model, selection),
         AiProvider::Qwen => apply_qwen_effort(object, selection),
         AiProvider::Ollama => apply_openai_effort(object, &config.api_style, selection),
         AiProvider::MiniMax => apply_minimax_effort(object, selection),
@@ -302,6 +321,25 @@ fn apply_openai_effort(object: &mut Map<String, Value>, api_style: &AiApiStyle, 
         } else {
             object.insert("reasoning_effort".to_string(), Value::String(value));
         }
+    }
+}
+
+fn apply_kimi_effort(object: &mut Map<String, Value>, model_id: &str, selection: &AiEffortSelection) {
+    let model = normalized_model_id(model_id);
+    if is_kimi_k3_model(&model) {
+        if let AiEffortSelection::Enum(value) = selection {
+            object.insert("reasoning_effort".to_string(), Value::String(value.clone()));
+        }
+        return;
+    }
+
+    if matches_family(&model, "kimi-k2.6") {
+        let thinking_type = match selection {
+            AiEffortSelection::Boolean(true) => "enabled",
+            AiEffortSelection::Boolean(false) | AiEffortSelection::Disabled => "disabled",
+            _ => return,
+        };
+        object.insert("thinking".to_string(), json!({ "type": thinking_type }));
     }
 }
 
@@ -408,7 +446,7 @@ fn title_case_effort(value: &str) -> String {
 mod tests {
     use super::{
         apply_runtime_effort, dynamic_enum_capability, registry_source_url, static_effort_capability,
-        validate_runtime_effort, MINIMAX_THINKING_DOCS,
+        validate_runtime_effort, KIMI_REASONING_DOCS, MINIMAX_THINKING_DOCS,
     };
     use crate::ai::{
         AiApiStyle, AiAuthMethod, AiCapabilitySource, AiConfig, AiEffortCapability, AiEffortSelection, AiProvider,
@@ -496,6 +534,49 @@ mod tests {
         apply_runtime_effort(&mut body, &config);
         assert_eq!(body["thinking"]["type"], "disabled");
         assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn kimi_uses_model_specific_reasoning_controls() {
+        let mut k3 = config(AiProvider::Kimi, "K3");
+        let capability = static_effort_capability(&k3, "K3").unwrap();
+        let AiEffortCapability::Enum { options, default, source } = capability else {
+            panic!("expected K3 enum capability");
+        };
+        assert_eq!(options.iter().map(|option| option.id.as_str()).collect::<Vec<_>>(), ["low", "high", "max"]);
+        assert_eq!(default, AiEffortSelection::Enum("max".to_string()));
+        assert_eq!(source, AiCapabilitySource::OfficialRegistry);
+        assert_eq!(registry_source_url(&AiProvider::Kimi), Some(KIMI_REASONING_DOCS));
+        assert!(matches!(static_effort_capability(&k3, "kimi-k3"), Some(AiEffortCapability::Enum { .. })));
+
+        k3.runtime_effort = Some(AiEffortSelection::Enum("high".to_string()));
+        assert!(validate_runtime_effort(&k3).is_ok());
+        let mut body = json!({});
+        apply_runtime_effort(&mut body, &k3);
+        assert_eq!(body["reasoning_effort"], "high");
+        assert!(body.get("thinking").is_none());
+
+        k3.runtime_effort = Some(AiEffortSelection::Enum("medium".to_string()));
+        assert!(validate_runtime_effort(&k3).is_err());
+
+        let mut k26 = config(AiProvider::Kimi, "kimi-k2.6");
+        assert!(matches!(static_effort_capability(&k26, "kimi-k2.6"), Some(AiEffortCapability::Boolean { .. })));
+        k26.runtime_effort = Some(AiEffortSelection::Boolean(true));
+        let mut body = json!({});
+        apply_runtime_effort(&mut body, &k26);
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert!(body.get("reasoning_effort").is_none());
+
+        k26.runtime_effort = Some(AiEffortSelection::Disabled);
+        let mut body = json!({});
+        apply_runtime_effort(&mut body, &k26);
+        assert_eq!(body["thinking"]["type"], "disabled");
+
+        let mut k27 = config(AiProvider::Kimi, "kimi-k2.7-code-highspeed");
+        assert!(static_effort_capability(&k27, "kimi-k2.7-code").is_none());
+        assert!(static_effort_capability(&k27, "kimi-for-coding").is_none());
+        k27.runtime_effort = Some(AiEffortSelection::Enum("high".to_string()));
+        assert!(validate_runtime_effort(&k27).is_err());
     }
 
     #[test]


### PR DESCRIPTION
- 为 K3/Kimi-K3 提供 low、high、max 推理强度，并默认 max
- 为 Kimi-K2.6 支持通过 `thinking.type` 开关思考模式
- 兼容 K3、kimi-for-coding 及 highspeed 别名，避免注入不支持的 OpenAI 思考参数
- 补充 Kimi 推理能力文档来源及覆盖测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="661" height="439" alt="image" src="https://github.com/user-attachments/assets/bbfcd63f-0eb2-4417-8920-dbe9ffc1f340" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

fix #7752