### PR TITLE
✨ feat(etcd): 支持按认证权限限制 Key 浏览与写入操作

### DIFF
--- a/agents/drivers/etcd-go/auth.go
+++ b/agents/drivers/etcd-go/auth.go
@@ -1,12 +1,131 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
+
+// etcdReadRange is a half-open Key range that the current user can read.
+// It is derived from the user's roles rather than asking etcd to enumerate
+// the global Key space, which a restricted account is not allowed to do.
+type etcdReadRange struct {
+	start string
+	end   string
+}
+
+// etcd uses a single NUL byte as an unbounded range end, meaning every Key
+// greater than or equal to the range start. It is a protocol sentinel, not a
+// byte-string upper bound, so ordinary lexical comparison is incorrect.
+const unboundedRangeEnd = "\x00"
+
+// readableKeyRanges returns whether the user can read every Key and otherwise
+// the smallest set of non-overlapping read ranges granted by its roles.
+func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
+	s.clientMu.Lock()
+	username := s.username
+	authEnabled := s.authEnabled
+	s.clientMu.Unlock()
+	client, clientErr := s.activeClient()
+	if clientErr == nil {
+		authEnabled = s.refreshAuthEnabled(client)
+	}
+	if !authEnabled || username == "root" {
+		return true, nil, nil
+	}
+	if username == "" {
+		return false, nil, nil
+	}
+	if clientErr != nil {
+		return false, nil, clientErr
+	}
+	ctx, cancel := s.beginOperation()
+	defer s.endOperation(cancel)
+	user, err := client.Auth.UserGet(ctx, username)
+	if err != nil {
+		return false, nil, err
+	}
+
+	ranges := make([]etcdReadRange, 0)
+	for _, roleName := range user.Roles {
+		if roleName == "root" {
+			return true, nil, nil
+		}
+		role, err := client.Auth.RoleGet(ctx, roleName)
+		if err != nil {
+			return false, nil, err
+		}
+		for _, permission := range role.Perm {
+			if strings.EqualFold(permission.PermType.String(), "WRITE") {
+				continue
+			}
+			start := string(permission.Key)
+			end := string(permission.RangeEnd)
+			if isAllKeyPermission(start, end) {
+				return true, nil, nil
+			}
+			if end == "" {
+				// An exact Key permission is represented as a one-Key range.
+				end = start + "\x00"
+			}
+			ranges = append(ranges, etcdReadRange{start: start, end: end})
+		}
+	}
+	return false, normalizeReadRanges(ranges), nil
+}
+
+func isAllKeyPermission(start, end string) bool {
+	return (start == "" && (end == "" || end == unboundedRangeEnd)) || (start == unboundedRangeEnd && end == unboundedRangeEnd)
+}
+
+func isUnboundedRangeEnd(end string) bool {
+	return end == unboundedRangeEnd
+}
+
+func rangeStartAtOrAfterEnd(start, end string) bool {
+	return !isUnboundedRangeEnd(end) && bytes.Compare([]byte(start), []byte(end)) >= 0
+}
+
+func rangeEndGreater(left, right string) bool {
+	if left == right {
+		return false
+	}
+	if isUnboundedRangeEnd(left) {
+		return true
+	}
+	if isUnboundedRangeEnd(right) {
+		return false
+	}
+	return bytes.Compare([]byte(left), []byte(right)) > 0
+}
+
+func normalizeReadRanges(ranges []etcdReadRange) []etcdReadRange {
+	sort.Slice(ranges, func(i, j int) bool {
+		return bytes.Compare([]byte(ranges[i].start), []byte(ranges[j].start)) < 0
+	})
+	result := make([]etcdReadRange, 0, len(ranges))
+	for _, candidate := range ranges {
+		if candidate.end == "" || rangeStartAtOrAfterEnd(candidate.start, candidate.end) {
+			continue
+		}
+		if len(result) > 0 {
+			last := &result[len(result)-1]
+			if isUnboundedRangeEnd(last.end) || bytes.Compare([]byte(candidate.start), []byte(last.end)) <= 0 {
+				if rangeEndGreater(candidate.end, last.end) {
+					last.end = candidate.end
+				}
+				continue
+			}
+		}
+		result = append(result, candidate)
+	}
+	return result
+}
 
 func (s *etcdSession) authUserList(params map[string]json.RawMessage) (any, error) {
 	client, err := s.activeClient()
@@ -23,13 +142,27 @@ func (s *etcdSession) authUserList(params map[string]json.RawMessage) (any, erro
 }
 
 func (s *etcdSession) authUserGet(params map[string]json.RawMessage) (any, error) {
-	user, err := requiredString(params, "user")
-	if err != nil {
-		return nil, err
+	user := strings.TrimSpace(stringOrDefault(params, "user", ""))
+	currentUserRequest := user == ""
+	s.clientMu.Lock()
+	authUsername := s.username
+	authEnabled := s.authEnabled
+	s.clientMu.Unlock()
+	client, clientErr := s.activeClient()
+	if currentUserRequest && clientErr == nil {
+		authEnabled = s.refreshAuthEnabled(client)
 	}
-	client, err := s.activeClient()
-	if err != nil {
-		return nil, err
+	if user == "" {
+		user = authUsername
+	}
+	if currentUserRequest && !authEnabled {
+		return map[string]any{"user": user, "roles": []string{}, "authEnabled": false}, nil
+	}
+	if user == "" {
+		return nil, errors.New("user is required")
+	}
+	if clientErr != nil {
+		return nil, clientErr
 	}
 	ctx, cancel := s.beginOperation()
 	defer s.endOperation(cancel)
@@ -37,7 +170,7 @@ func (s *etcdSession) authUserGet(params map[string]json.RawMessage) (any, error
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{"user": user, "roles": response.Roles}, nil
+	return map[string]any{"user": user, "roles": response.Roles, "authEnabled": true}, nil
 }
 
 func (s *etcdSession) authUserAdd(params map[string]json.RawMessage) (any, error) {

--- a/agents/drivers/etcd-go/auth.go
+++ b/agents/drivers/etcd-go/auth.go
@@ -74,6 +74,7 @@ func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
 	ranges := make([]etcdReadRange, 0)
 	for _, roleName := range user.Roles {
 		if roleName == "root" {
+			s.cacheReadAccess(true, nil)
 			return true, nil, nil
 		}
 		role, err := client.Auth.RoleGet(ctx, roleName)

--- a/agents/drivers/etcd-go/auth.go
+++ b/agents/drivers/etcd-go/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -19,6 +20,15 @@ type etcdReadRange struct {
 	end   string
 }
 
+// etcdReadAccess is a short-lived snapshot of the current user's readable
+// ranges. etcd remains the authorization boundary for every Key request; the
+// cache only avoids repeating AuthStatus, UserGet, and RoleGet while browsing.
+type etcdReadAccess struct {
+	allKeys   bool
+	ranges    []etcdReadRange
+	expiresAt time.Time
+}
+
 // etcd uses a single NUL byte as an unbounded range end, meaning every Key
 // greater than or equal to the range start. It is a protocol sentinel, not a
 // byte-string upper bound, so ordinary lexical comparison is incorrect.
@@ -27,6 +37,9 @@ const unboundedRangeEnd = "\x00"
 // readableKeyRanges returns whether the user can read every Key and otherwise
 // the smallest set of non-overlapping read ranges granted by its roles.
 func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
+	if allKeys, ranges, ok := s.cachedReadAccess(time.Now()); ok {
+		return allKeys, ranges, nil
+	}
 	s.clientMu.Lock()
 	username := s.username
 	authEnabled := s.authEnabled
@@ -36,9 +49,11 @@ func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
 		authEnabled = s.refreshAuthEnabled(client)
 	}
 	if !authEnabled || username == "root" {
+		s.cacheReadAccess(true, nil)
 		return true, nil, nil
 	}
 	if username == "" {
+		s.cacheReadAccess(false, nil)
 		return false, nil, nil
 	}
 	if clientErr != nil {
@@ -48,6 +63,11 @@ func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
 	defer s.endOperation(cancel)
 	user, err := client.Auth.UserGet(ctx, username)
 	if err != nil {
+		if isAuthenticationNotEnabled(err) {
+			s.disableAuth()
+			s.cacheReadAccess(true, nil)
+			return true, nil, nil
+		}
 		return false, nil, err
 	}
 
@@ -58,6 +78,11 @@ func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
 		}
 		role, err := client.Auth.RoleGet(ctx, roleName)
 		if err != nil {
+			if isAuthenticationNotEnabled(err) {
+				s.disableAuth()
+				s.cacheReadAccess(true, nil)
+				return true, nil, nil
+			}
 			return false, nil, err
 		}
 		for _, permission := range role.Perm {
@@ -67,6 +92,7 @@ func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
 			start := string(permission.Key)
 			end := string(permission.RangeEnd)
 			if isAllKeyPermission(start, end) {
+				s.cacheReadAccess(true, nil)
 				return true, nil, nil
 			}
 			if end == "" {
@@ -76,7 +102,28 @@ func (s *etcdSession) readableKeyRanges() (bool, []etcdReadRange, error) {
 			ranges = append(ranges, etcdReadRange{start: start, end: end})
 		}
 	}
-	return false, normalizeReadRanges(ranges), nil
+	ranges = normalizeReadRanges(ranges)
+	s.cacheReadAccess(false, ranges)
+	return false, ranges, nil
+}
+
+func (s *etcdSession) cachedReadAccess(now time.Time) (bool, []etcdReadRange, bool) {
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
+	if s.readAccess == nil || !now.Before(s.readAccess.expiresAt) {
+		return false, nil, false
+	}
+	return s.readAccess.allKeys, append([]etcdReadRange(nil), s.readAccess.ranges...), true
+}
+
+func (s *etcdSession) cacheReadAccess(allKeys bool, ranges []etcdReadRange) {
+	s.clientMu.Lock()
+	s.readAccess = &etcdReadAccess{
+		allKeys:   allKeys,
+		ranges:    append([]etcdReadRange(nil), ranges...),
+		expiresAt: time.Now().Add(readAccessCacheTTL),
+	}
+	s.clientMu.Unlock()
 }
 
 func isAllKeyPermission(start, end string) bool {
@@ -168,6 +215,10 @@ func (s *etcdSession) authUserGet(params map[string]json.RawMessage) (any, error
 	defer s.endOperation(cancel)
 	response, err := client.Auth.UserGet(ctx, user)
 	if err != nil {
+		if currentUserRequest && isAuthenticationNotEnabled(err) {
+			s.disableAuth()
+			return map[string]any{"user": user, "roles": []string{}, "authEnabled": false}, nil
+		}
 		return nil, err
 	}
 	return map[string]any{"user": user, "roles": response.Roles, "authEnabled": true}, nil

--- a/agents/drivers/etcd-go/client.go
+++ b/agents/drivers/etcd-go/client.go
@@ -72,7 +72,7 @@ func (s *etcdSession) connect(params map[string]json.RawMessage) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	nextClient, err := buildClient(connection)
+	nextClient, authUsername, err := buildClient(connection)
 	if err != nil {
 		return nil, err
 	}
@@ -81,10 +81,13 @@ func (s *etcdSession) connect(params map[string]json.RawMessage) (any, error) {
 		_ = nextClient.Close()
 		return nil, err
 	}
+	authEnabled := detectAuthEnabled(nextClient, authUsername)
 	s.close()
 	s.clientMu.Lock()
 	s.client = nextClient
 	s.connectedEndpoints = endpointList
+	s.username = authUsername
+	s.authEnabled = authEnabled
 	s.clientMu.Unlock()
 	return map[string]bool{"ok": true}, nil
 }
@@ -127,6 +130,8 @@ func (s *etcdSession) close() error {
 	client := s.client
 	s.client = nil
 	s.connectedEndpoints = nil
+	s.username = ""
+	s.authEnabled = false
 	s.clientMu.Unlock()
 	if client != nil {
 		_ = client.Close()
@@ -134,8 +139,9 @@ func (s *etcdSession) close() error {
 	return nil
 }
 
-func buildClient(connection connectionParams) (*clientv3.Client, error) {
+func buildClient(connection connectionParams) (*clientv3.Client, string, error) {
 	endpoints := connectionEndpoints(connection)
+	authUsername := strings.TrimSpace(connection.Username)
 	config := clientv3.Config{
 		Endpoints:   endpoints,
 		DialTimeout: time.Duration(connectTimeoutSeconds(connection)) * time.Second,
@@ -151,11 +157,48 @@ func buildClient(connection connectionParams) (*clientv3.Client, error) {
 	if connection.SSL {
 		tlsConfig, err := tlsConfigFor(connection)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 		config.TLS = tlsConfig
+		if authUsername == "" {
+			authUsername = clientCertificateUsername(tlsConfig)
+		}
 	}
-	return clientv3.New(config)
+	client, err := clientv3.New(config)
+	return client, authUsername, err
+}
+
+func detectAuthEnabled(client *clientv3.Client, authUsername string) bool {
+	enabled, err := probeAuthEnabled(client)
+	if err == nil {
+		return enabled
+	}
+	// AuthStatus was added after the first v3 releases. For an older server,
+	// configured credentials or a certificate identity are the safest signal.
+	return authUsername != ""
+}
+
+func probeAuthEnabled(client *clientv3.Client) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeoutSeconds*time.Second)
+	defer cancel()
+	statusResponse, err := client.Auth.AuthStatus(ctx)
+	if err != nil {
+		return false, err
+	}
+	return statusResponse.Enabled, nil
+}
+
+// refreshAuthEnabled keeps long-lived sessions in sync when an administrator
+// enables or disables etcd Auth after DBX connected. A failed compatibility
+// probe retains the last known state instead of flipping privileges.
+func (s *etcdSession) refreshAuthEnabled(client *clientv3.Client) bool {
+	enabled, err := probeAuthEnabled(client)
+	s.clientMu.Lock()
+	defer s.clientMu.Unlock()
+	if err == nil && s.client == client {
+		s.authEnabled = enabled
+	}
+	return s.authEnabled
 }
 
 func connectTimeoutSeconds(connection connectionParams) int {
@@ -234,9 +277,22 @@ func tlsConfigFor(connection connectionParams) (*tls.Config, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(pair.Certificate) > 0 {
+			pair.Leaf, err = x509.ParseCertificate(pair.Certificate[0])
+			if err != nil {
+				return nil, err
+			}
+		}
 		tlsConfig.Certificates = []tls.Certificate{pair}
 	}
 	return tlsConfig, nil
+}
+
+func clientCertificateUsername(config *tls.Config) string {
+	if config == nil || len(config.Certificates) == 0 || config.Certificates[0].Leaf == nil {
+		return ""
+	}
+	return strings.TrimSpace(config.Certificates[0].Leaf.Subject.CommonName)
 }
 
 func probeClient(client *clientv3.Client, endpoints []string) (map[string]any, error) {

--- a/agents/drivers/etcd-go/client.go
+++ b/agents/drivers/etcd-go/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -132,6 +133,7 @@ func (s *etcdSession) close() error {
 	s.connectedEndpoints = nil
 	s.username = ""
 	s.authEnabled = false
+	s.readAccess = nil
 	s.clientMu.Unlock()
 	if client != nil {
 		_ = client.Close()
@@ -196,9 +198,23 @@ func (s *etcdSession) refreshAuthEnabled(client *clientv3.Client) bool {
 	s.clientMu.Lock()
 	defer s.clientMu.Unlock()
 	if err == nil && s.client == client {
+		if s.authEnabled != enabled {
+			s.readAccess = nil
+		}
 		s.authEnabled = enabled
 	}
 	return s.authEnabled
+}
+
+func isAuthenticationNotEnabled(err error) bool {
+	return errors.Is(err, rpctypes.ErrAuthNotEnabled)
+}
+
+func (s *etcdSession) disableAuth() {
+	s.clientMu.Lock()
+	s.authEnabled = false
+	s.readAccess = nil
+	s.clientMu.Unlock()
 }
 
 func connectTimeoutSeconds(connection connectionParams) int {

--- a/agents/drivers/etcd-go/integration_test.go
+++ b/agents/drivers/etcd-go/integration_test.go
@@ -388,6 +388,9 @@ func TestLiveEtcdAgent(t *testing.T) {
 	if len(members) == 0 || members[0]["reachable"] != true || members[0]["version"] == nil {
 		t.Fatalf("unexpected member rows: %#v", members)
 	}
+	if errors, ok := members[0]["errors"].([]string); !ok || len(errors) != 0 {
+		t.Fatalf("successful member must include an empty errors list: %#v", members[0])
+	}
 	if keyCount, err := strconvParse(statusRow["keyCount"].(string)); err != nil || keyCount <= 0 {
 		t.Fatalf("keyCount must be a positive numeric string: %#v", statusRow["keyCount"])
 	}

--- a/agents/drivers/etcd-go/kv.go
+++ b/agents/drivers/etcd-go/kv.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +19,10 @@ import (
 
 const defaultListLimit = 100
 const preserveLeaseMaxAttempts = 3
+
+type etcdRangeGetter interface {
+	Get(context.Context, string, ...clientv3.OpOption) (*clientv3.GetResponse, error)
+}
 
 func (s *etcdSession) listPrefix(params map[string]json.RawMessage) (any, error) {
 	client, err := s.activeClient()
@@ -39,6 +45,14 @@ func (s *etcdSession) listPrefix(params map[string]json.RawMessage) (any, error)
 			return nil, err
 		}
 		start = string(decoded)
+	}
+	allKeys, readableRanges, err := s.readableKeyRanges()
+	if err != nil {
+		return nil, err
+	}
+	if !allKeys {
+		readableRanges = intersectReadRanges(readableRanges, prefixStart(prefix), prefixEnd(prefix))
+		return s.listReadableRanges(client, readableRanges, start, limit, revision, includeValues)
 	}
 
 	ctx, cancel := s.beginOperation()
@@ -74,6 +88,98 @@ func (s *etcdSession) listPrefix(params map[string]json.RawMessage) (any, error)
 		result["continuation"] = nil
 	}
 	result["revision"] = longString(response.Header.Revision)
+	return result, nil
+}
+
+// intersectReadRanges limits granted ranges to the requested prefix range.
+// etcd authorizes the complete range in a Range request, so querying a broad
+// prefix directly would be rejected even when it contains readable subranges.
+func intersectReadRanges(ranges []etcdReadRange, start, end string) []etcdReadRange {
+	intersections := make([]etcdReadRange, 0, len(ranges))
+	for _, granted := range ranges {
+		candidate := granted
+		if bytes.Compare([]byte(start), []byte(candidate.start)) > 0 {
+			candidate.start = start
+		}
+		if rangeEndGreater(candidate.end, end) {
+			candidate.end = end
+		}
+		if candidate.end == "" || rangeStartAtOrAfterEnd(candidate.start, candidate.end) {
+			continue
+		}
+		intersections = append(intersections, candidate)
+	}
+	return normalizeReadRanges(intersections)
+}
+
+// listReadableRanges pages through the union of the ranges granted to a
+// restricted user. Each range is queried independently, so etcd never sees an
+// unauthorized global range request.
+func (s *etcdSession) listReadableRanges(client etcdRangeGetter, ranges []etcdReadRange, start string, limit int, revision *int64, includeValues bool) (any, error) {
+	ctx, cancel := s.beginOperation()
+	defer s.endOperation(cancel)
+
+	byKey := make(map[string]*mvccpb.KeyValue)
+	var snapshotRevision int64
+	if revision != nil && *revision > 0 {
+		snapshotRevision = *revision
+	}
+	for _, keyRange := range ranges {
+		requestStart := keyRange.start
+		if bytes.Compare([]byte(start), []byte(requestStart)) > 0 {
+			requestStart = start
+		}
+		if rangeStartAtOrAfterEnd(requestStart, keyRange.end) {
+			continue
+		}
+		options := []clientv3.OpOption{
+			clientv3.WithRange(keyRange.end),
+			clientv3.WithLimit(int64(limit + 1)),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+		}
+		if snapshotRevision > 0 {
+			options = append(options, clientv3.WithRev(snapshotRevision))
+		}
+		response, err := client.Get(ctx, requestStart, options...)
+		if err != nil {
+			return nil, err
+		}
+		if snapshotRevision == 0 {
+			snapshotRevision = response.Header.Revision
+		}
+		for _, item := range response.Kvs {
+			byKey[string(item.Key)] = item
+		}
+	}
+
+	items := make([]*mvccpb.KeyValue, 0, len(byKey))
+	for _, item := range byKey {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return bytes.Compare(items[i].Key, items[j].Key) < 0
+	})
+	more := len(items) > limit
+	if more {
+		items = items[:limit]
+	}
+
+	keys := make([]any, 0, len(items))
+	for _, item := range items {
+		row := metadataMap(item)
+		row["key"] = displayBytes(item.Key)
+		row["keyBytes"] = bytesObject(item.Key)
+		if includeValues {
+			row["value"] = valueObject(item.Value)
+		}
+		keys = append(keys, row)
+	}
+	result := map[string]any{"keys": keys, "revision": longString(snapshotRevision)}
+	if more && len(items) > 0 {
+		result["continuation"] = nextContinuation(items[len(items)-1].Key)
+	} else {
+		result["continuation"] = nil
+	}
 	return result, nil
 }
 

--- a/agents/drivers/etcd-go/main.go
+++ b/agents/drivers/etcd-go/main.go
@@ -21,6 +21,7 @@ const (
 	legacyAgentSessionID = "__legacy__"
 	maxAgentSessions     = 256
 	rpcTimeoutSeconds    = 30
+	readAccessCacheTTL   = 15 * time.Second
 )
 
 var capabilities = []string{
@@ -51,6 +52,7 @@ type etcdSession struct {
 	connectedEndpoints []string
 	username           string
 	authEnabled        bool
+	readAccess         *etcdReadAccess
 
 	watchesMu          sync.Mutex
 	watches            map[string]*watchState

--- a/agents/drivers/etcd-go/main.go
+++ b/agents/drivers/etcd-go/main.go
@@ -49,6 +49,8 @@ type etcdSession struct {
 	clientMu           sync.Mutex
 	client             *clientv3.Client
 	connectedEndpoints []string
+	username           string
+	authEnabled        bool
 
 	watchesMu          sync.Mutex
 	watches            map[string]*watchState

--- a/agents/drivers/etcd-go/main_test.go
+++ b/agents/drivers/etcd-go/main_test.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestHandshakeAdvertisesCapabilities(t *testing.T) {
@@ -162,6 +168,75 @@ func TestTLSConfigRequiresCertAndKeyTogether(t *testing.T) {
 	_, err = tlsConfigFor(connectionParams{SSL: true, CertPath: "/tmp/cert.pem", KeyPath: "/tmp/key.pem"})
 	if err == nil {
 		t.Fatalf("expected key pair load failure for missing files")
+	}
+}
+
+func TestClientCertificateUsername(t *testing.T) {
+	config := &tls.Config{Certificates: []tls.Certificate{{Leaf: &x509.Certificate{Subject: pkix.Name{CommonName: " cert-reader "}}}}}
+	if got := clientCertificateUsername(config); got != "cert-reader" {
+		t.Fatalf("clientCertificateUsername() = %q, want cert-reader", got)
+	}
+	if got := clientCertificateUsername(&tls.Config{}); got != "" {
+		t.Fatalf("empty certificate username = %q, want empty", got)
+	}
+}
+
+func TestReadableKeyRangesUsesAuthStatusAndEffectiveIdentity(t *testing.T) {
+	withoutAuth := newEtcdSession()
+	withoutAuth.username = "cert-reader"
+	allKeys, ranges, err := withoutAuth.readableKeyRanges()
+	if err != nil || !allKeys || len(ranges) != 0 {
+		t.Fatalf("disabled auth should allow all keys: all=%v ranges=%v err=%v", allKeys, ranges, err)
+	}
+
+	missingIdentity := newEtcdSession()
+	missingIdentity.authEnabled = true
+	allKeys, ranges, err = missingIdentity.readableKeyRanges()
+	if err != nil || allKeys || len(ranges) != 0 {
+		t.Fatalf("enabled auth without an identity should expose no ranges: all=%v ranges=%v err=%v", allKeys, ranges, err)
+	}
+}
+
+func TestAuthUserGetReportsDisabledAuthWithoutAClient(t *testing.T) {
+	state := newEtcdSession()
+	state.username = "cert-reader"
+	result, err := state.authUserGet(map[string]json.RawMessage{})
+	if err != nil {
+		t.Fatalf("authUserGet() failed: %v", err)
+	}
+	detail := result.(map[string]any)
+	if detail["user"] != "cert-reader" || detail["authEnabled"] != false {
+		t.Fatalf("unexpected auth detail: %#v", detail)
+	}
+}
+
+type recordingRangeGetter struct {
+	responses []*clientv3.GetResponse
+	revisions []int64
+}
+
+func (g *recordingRangeGetter) Get(_ context.Context, key string, options ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	op := clientv3.OpGet(key, options...)
+	g.revisions = append(g.revisions, op.Rev())
+	response := g.responses[0]
+	g.responses = g.responses[1:]
+	return response, nil
+}
+
+func TestListReadableRangesPinsFirstResponseRevision(t *testing.T) {
+	getter := &recordingRangeGetter{responses: []*clientv3.GetResponse{
+		{Header: &etcdserverpb.ResponseHeader{Revision: 10}, Kvs: []*mvccpb.KeyValue{{Key: []byte("a")}}},
+		{Header: &etcdserverpb.ResponseHeader{Revision: 12}, Kvs: []*mvccpb.KeyValue{{Key: []byte("z")}}},
+	}}
+	result, err := newEtcdSession().listReadableRanges(getter, []etcdReadRange{{start: "a", end: "b"}, {start: "z", end: "zz"}}, "\x00", 10, nil, false)
+	if err != nil {
+		t.Fatalf("listReadableRanges() failed: %v", err)
+	}
+	if len(getter.revisions) != 2 || getter.revisions[0] != 0 || getter.revisions[1] != 10 {
+		t.Fatalf("range revisions = %v, want [0 10]", getter.revisions)
+	}
+	if revision := result.(map[string]any)["revision"]; revision != "10" {
+		t.Fatalf("result revision = %v, want 10", revision)
 	}
 }
 
@@ -466,6 +541,62 @@ func TestPutRejectsConflictingLeaseOptions(t *testing.T) {
 	_, err := state.put(params)
 	if err == nil || err.Error() != "Not connected" {
 		t.Fatalf("expected Not connected before option validation, got %v", err)
+	}
+}
+
+func TestNormalizeReadRangesKeepsOnlyOutermostReadableScopes(t *testing.T) {
+	ranges := normalizeReadRanges([]etcdReadRange{
+		{start: "/team-a/", end: "/team-a0"},
+		{start: "/team-a/config", end: "/team-a/config\x00"},
+		{start: "/team-b/", end: "/team-b0"},
+		{start: "/invalid", end: "/invalid"},
+	})
+	if len(ranges) != 2 {
+		t.Fatalf("readable ranges = %#v, want two outer ranges", ranges)
+	}
+	if ranges[0].start != "/team-a/" || ranges[1].start != "/team-b/" {
+		t.Fatalf("unexpected readable ranges: %#v", ranges)
+	}
+	merged := normalizeReadRanges([]etcdReadRange{{start: "a", end: "d"}, {start: "c", end: "f"}})
+	if len(merged) != 1 || merged[0].start != "a" || merged[0].end != "f" {
+		t.Fatalf("overlapping ranges must merge: %#v", merged)
+	}
+	fromKey := normalizeReadRanges([]etcdReadRange{{start: "/team-c/", end: unboundedRangeEnd}, {start: "/team-d/", end: "/team-e/"}})
+	if len(fromKey) != 1 || fromKey[0].start != "/team-c/" || fromKey[0].end != unboundedRangeEnd {
+		t.Fatalf("from-key permission must remain unbounded: %#v", fromKey)
+	}
+	if rangeStartAtOrAfterEnd("/team-z/", unboundedRangeEnd) {
+		t.Fatal("an unbounded range end must not exclude a later continuation")
+	}
+	if !isAllKeyPermission("", "\x00") || !isAllKeyPermission("\x00", "\x00") {
+		t.Fatal("all-Key permissions must be recognized")
+	}
+}
+
+func TestIntersectReadRangesLimitsBroadPrefixToGrantedScopes(t *testing.T) {
+	granted := []etcdReadRange{
+		{start: "/dbx", end: "/dby"},
+		{start: "/team/secret", end: "/team/secret\x00"},
+	}
+
+	broad := intersectReadRanges(granted, "/", "0")
+	if len(broad) != 2 || broad[0] != granted[0] || broad[1] != granted[1] {
+		t.Fatalf("broad prefix intersections = %#v, want %#v", broad, granted)
+	}
+
+	narrow := intersectReadRanges(granted, "/dbx/config/", "/dbx/config0")
+	if len(narrow) != 1 || narrow[0].start != "/dbx/config/" || narrow[0].end != "/dbx/config0" {
+		t.Fatalf("narrow prefix intersection = %#v", narrow)
+	}
+
+	disjoint := intersectReadRanges(granted, "/other/", "/other0")
+	if len(disjoint) != 0 {
+		t.Fatalf("disjoint prefix intersections = %#v, want none", disjoint)
+	}
+
+	unbounded := intersectReadRanges([]etcdReadRange{{start: "/dbx", end: unboundedRangeEnd}}, "/dbx", unboundedRangeEnd)
+	if len(unbounded) != 1 || unbounded[0].end != unboundedRangeEnd {
+		t.Fatalf("unbounded prefix intersection = %#v", unbounded)
 	}
 }
 

--- a/agents/drivers/etcd-go/main_test.go
+++ b/agents/drivers/etcd-go/main_test.go
@@ -9,10 +9,14 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestHandshakeAdvertisesCapabilities(t *testing.T) {
@@ -194,6 +198,48 @@ func TestReadableKeyRangesUsesAuthStatusAndEffectiveIdentity(t *testing.T) {
 	allKeys, ranges, err = missingIdentity.readableKeyRanges()
 	if err != nil || allKeys || len(ranges) != 0 {
 		t.Fatalf("enabled auth without an identity should expose no ranges: all=%v ranges=%v err=%v", allKeys, ranges, err)
+	}
+}
+
+func TestReadAccessCacheExpiresAndReturnsACopy(t *testing.T) {
+	state := newEtcdSession()
+	state.cacheReadAccess(false, []etcdReadRange{{start: "/team-a/", end: "/team-a0"}})
+
+	allKeys, ranges, ok := state.cachedReadAccess(time.Now())
+	if !ok || allKeys || len(ranges) != 1 || ranges[0].start != "/team-a/" {
+		t.Fatalf("cached read access = all=%v ranges=%#v ok=%v", allKeys, ranges, ok)
+	}
+	ranges[0].start = "/mutated/"
+	_, ranges, ok = state.cachedReadAccess(time.Now())
+	if !ok || ranges[0].start != "/team-a/" {
+		t.Fatalf("cached range was not copied: %#v", ranges)
+	}
+
+	state.clientMu.Lock()
+	state.readAccess.expiresAt = time.Now().Add(-time.Second)
+	state.clientMu.Unlock()
+	if _, _, ok := state.cachedReadAccess(time.Now()); ok {
+		t.Fatal("expired read access cache was returned")
+	}
+}
+
+func TestAuthenticationNotEnabledFallbackClearsCachedRestrictions(t *testing.T) {
+	if !isAuthenticationNotEnabled(rpctypes.ErrAuthNotEnabled) {
+		t.Fatal("authentication-not-enabled status was not recognized")
+	}
+	if isAuthenticationNotEnabled(status.Error(codes.PermissionDenied, "authentication is not enabled")) {
+		t.Fatal("permission-denied status must not disable authentication")
+	}
+
+	state := newEtcdSession()
+	state.authEnabled = true
+	state.cacheReadAccess(false, []etcdReadRange{{start: "/team-a/", end: "/team-a0"}})
+	state.disableAuth()
+	if state.authEnabled {
+		t.Fatal("authentication remained enabled after compatibility fallback")
+	}
+	if _, _, ok := state.cachedReadAccess(time.Now()); ok {
+		t.Fatal("compatibility fallback retained stale restricted ranges")
 	}
 }
 

--- a/agents/drivers/etcd-go/status.go
+++ b/agents/drivers/etcd-go/status.go
@@ -128,6 +128,11 @@ func (s *etcdSession) status(params map[string]json.RawMessage) (any, error) {
 		row["learner"] = memberStatus.IsLearner
 		row["reachable"] = true
 		row["latencyMs"] = time.Since(result.started).Milliseconds()
+		// KvStatusMember.errors is a required field in the desktop protocol.
+		// Successful probes must therefore return an explicit empty list rather
+		// than omitting the field, otherwise the host cannot deserialize the
+		// complete status response.
+		row["errors"] = []string{}
 		memberIDKey := unsignedLongString(int64(memberID))
 		if _, seen := observedMemberIDs[memberIDKey]; seen {
 			continue

--- a/agents/drivers/etcd-go/watch.go
+++ b/agents/drivers/etcd-go/watch.go
@@ -236,7 +236,14 @@ func (s *etcdSession) watchStart(params map[string]json.RawMessage) (any, error)
 		startedRevision = *requestedRevision
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), rpcTimeoutSeconds*time.Second)
-		response, err := client.Get(ctx, "\x00", clientv3.WithRange("\x00"), clientv3.WithCountOnly())
+		// Read the revision from the same Key scope that will be watched. A global
+		// range is forbidden for users that are intentionally limited to one or
+		// more prefixes, even when this individual Key or prefix is readable.
+		revisionOptions := []clientv3.OpOption{clientv3.WithCountOnly()}
+		if scope == "prefix" {
+			revisionOptions = append(revisionOptions, clientv3.WithRange(prefixEnd(key)))
+		}
+		response, err := client.Get(ctx, key, revisionOptions...)
 		cancel()
 		if err != nil {
 			return nil, err

--- a/apps/desktop/src/components/etcd/EtcdKeyBrowser.vue
+++ b/apps/desktop/src/components/etcd/EtcdKeyBrowser.vue
@@ -816,7 +816,7 @@ async function previewTransfer() {
         return { id: `source:${kvValueByteIdentity(source.key)}`, displayKey: shown, source, operation: "skipped" as const, reason: "Leased keys are skipped by default.", selected: false };
       }
       if (!canWriteConnectionKey(targetId, shown, source.key)) {
-        return { id: `source:${kvValueByteIdentity(source.key)}`, displayKey: shown, source, operation: "skipped" as const, reason: "目标连接没有此 Key 的写权限。", selected: false };
+        return { id: `source:${kvValueByteIdentity(source.key)}`, displayKey: shown, source, operation: "skipped" as const, reason: t("etcd.targetKeyWriteDenied"), selected: false };
       }
       const target = await api.etcdGet(targetId, shown, { keyBytes: source.key });
       if (generation !== transferPreviewGeneration) throw new Error("同步预览已被新的请求替换。");
@@ -854,7 +854,7 @@ async function applyTransfer() {
   const rows = [...selectedTransferRows.value];
   if (!targetId || rows.length === 0) return;
   if (!rows.every((row) => row.source && canWriteConnectionKey(targetId, row.displayKey, row.source.key))) {
-    transferError.value = "目标连接没有所选 Key 的写权限，未执行任何写入。";
+    transferError.value = t("etcd.selectedKeysWriteDenied");
     return;
   }
   // Invalidate any preview that is still resolving before writes begin.

--- a/apps/desktop/src/components/etcd/EtcdKeyBrowser.vue
+++ b/apps/desktop/src/components/etcd/EtcdKeyBrowser.vue
@@ -154,11 +154,25 @@ const transferLoadingDetail = ref("");
 const transferPreviewLoaded = ref(false);
 const syncConfigurationExpanded = ref(true);
 
-const readOnly = computed(() => connectionIsEffectivelyReadOnly(connectionStore.getConfig(props.connectionId)));
+const etcdAccess = computed(() => connectionStore.getEtcdAccessCapabilities(props.connectionId));
+const canManageEtcd = computed(() => etcdAccess.value.admin);
+const canWriteEtcdKeys = computed(() => etcdAccess.value.writable);
+const readOnly = computed(() => connectionIsEffectivelyReadOnly(connectionStore.getConfig(props.connectionId)) || !canWriteEtcdKeys.value);
+function canWriteConnectionKey(connectionId: string, key: string, keyBytes?: api.KvValue | null): boolean {
+  const config = connectionStore.getConfig(connectionId);
+  return config?.db_type === "etcd" && !connectionIsEffectivelyReadOnly(config) && connectionStore.canWriteEtcdKey(connectionId, key, keyBytes);
+}
+function canWriteCurrentKey(route: { key: string; keyBytes?: api.KvValue | null }): boolean {
+  return canWriteConnectionKey(props.connectionId, route.key, route.keyBytes);
+}
+function permissionDenied(): Error {
+  return new Error("ETCD_PERMISSION_DENIED: The current etcd user is not authorized to write this Key");
+}
 // etcd 2.x connections speak the v2 API: no key history, no leases, no maintenance.
 const isV2Api = computed(() => connectionStore.getConfig(props.connectionId)?.driver_profile === "etcd-v2");
 const etcdConnections = computed(() => connectionStore.connections.filter((connection) => connection.db_type === "etcd"));
-const targetReadOnly = computed(() => connectionIsEffectivelyReadOnly(connectionStore.getConfig(targetConnectionId.value)));
+const targetReadOnly = computed(() => !targetConnectionId.value || connectionIsEffectivelyReadOnly(connectionStore.getConfig(targetConnectionId.value)) || !connectionStore.getEtcdAccessCapabilities(targetConnectionId.value).writable);
+const selectedTreeKeysWritable = computed(() => selectedTreeKeys.value.length > 0 && selectedTreeKeys.value.every((item) => canWriteCurrentKey(item)));
 const selectedTransferRows = computed(() => transferRows.value.filter((row) => row.selected && isTransferRowSelectable(row)));
 const selectableTransferRows = computed(() => transferRows.value.filter(isTransferRowSelectable));
 const filteredTransferRows = computed(() => {
@@ -274,13 +288,23 @@ const etcdApi = computed(() => ({
     return { ...result, key: shown, keyIdentity: identity };
   },
   getMetadata: (connectionId: string, key: string, options?: api.KvGetOptions | null) => api.etcdGet(connectionId, key, { ...keyOptions(key), ...options, metadataOnly: true }),
-  put: (connectionId: string, key: string, value: api.KvValue, options?: api.KvPutOptions | null) =>
-    api.etcdPut(connectionId, key, value, {
+  put: (connectionId: string, key: string, value: api.KvValue, options?: api.KvPutOptions | null) => {
+    const keyBytes = options?.keyBytes ?? (options?.expectedCreateRevision === "0" ? undefined : keyOptions(key).keyBytes);
+    if (!canWriteConnectionKey(connectionId, key, keyBytes)) throw permissionDenied();
+    return api.etcdPut(connectionId, key, value, {
       ...options,
-      keyBytes: options?.keyBytes ?? (options?.expectedCreateRevision === "0" ? undefined : keyOptions(key).keyBytes),
-    }),
-  deleteKey: (connectionId: string, key: string, options?: api.KvDeleteOptions | null) => api.etcdDelete(connectionId, key, { ...options, keyBytes: options?.keyBytes ?? keyOptions(key).keyBytes }),
-  rename: api.etcdRename,
+      keyBytes,
+    });
+  },
+  deleteKey: (connectionId: string, key: string, options?: api.KvDeleteOptions | null) => {
+    const keyBytes = options?.keyBytes ?? keyOptions(key).keyBytes;
+    if (!canWriteConnectionKey(connectionId, key, keyBytes)) throw permissionDenied();
+    return api.etcdDelete(connectionId, key, { ...options, keyBytes });
+  },
+  rename: (connectionId: string, request: { key: string; keyBytes?: api.KvValue | null; newKey: string; expectedModRevision?: api.KvInt64 | null }) => {
+    if (!canWriteConnectionKey(connectionId, request.key, request.keyBytes) || !canWriteConnectionKey(connectionId, request.newKey)) throw permissionDenied();
+    return api.etcdRename(connectionId, request);
+  },
   // The v2 API has no event history; hiding the entry keeps KvKeyBrowser from
   // offering restore/compare actions it cannot fulfill.
   history: isV2Api.value ? undefined : api.etcdHistory,
@@ -344,6 +368,11 @@ const labels = computed(() => ({
 }));
 
 async function refreshTtlCapability() {
+  if (!canManageEtcd.value) {
+    supportsTtl.value = false;
+    ttlCapabilityKnown.value = true;
+    return;
+  }
   const connectionId = props.connectionId;
   if (ttlCapabilityInFlightConnection === connectionId) return;
   const request = ++ttlCapabilityRequest;
@@ -373,8 +402,16 @@ function stopTtlCapabilityRefresh() {
 
 function startTtlCapabilityRefresh() {
   stopTtlCapabilityRefresh();
-  void refreshTtlCapability();
-  ttlCapabilityRefreshTimer = setInterval(() => void refreshTtlCapability(), ttlCapabilityRefreshIntervalMs);
+  const refreshAccessAndTtl = async () => {
+    try {
+      await connectionStore.ensureEtcdAccessCapabilities(props.connectionId, { force: true, verifyHealth: false });
+    } catch {
+      // The Key browser surfaces connection failures through its own requests.
+    }
+    await refreshTtlCapability();
+  };
+  void refreshAccessAndTtl();
+  ttlCapabilityRefreshTimer = setInterval(() => void refreshAccessAndTtl(), ttlCapabilityRefreshIntervalMs);
 }
 
 watch(
@@ -400,6 +437,7 @@ function normalizedLease(metadata?: api.KvKeyMetadata | null) {
 
 function isTransferRowSelectable(row: TransferRow): boolean {
   if (["unchanged", "skipped", "applied"].includes(row.operation)) return false;
+  if (!row.source || !canWriteConnectionKey(targetConnectionId.value, row.displayKey, row.source.key)) return false;
   if (transferMode.value !== "sync" || row.operation !== "update") return true;
   return transferConflictPolicy.value === "OVERWRITE";
 }
@@ -533,7 +571,7 @@ function selectedTreeKeyDetails(): string {
 
 async function deleteSelectedTreeKeys() {
   const selected = [...selectedTreeKeys.value];
-  if (!selected.length || readOnly.value) return;
+  if (!selected.length || readOnly.value || !selected.every((item) => canWriteCurrentKey(item))) return;
   batchDeleting.value = true;
   const completed: EtcdMultiSelection[] = [];
   let deleted = 0;
@@ -708,6 +746,7 @@ async function onImportFile(event: Event) {
 }
 
 async function openSync() {
+  if (readOnly.value) return;
   transferMode.value = "sync";
   targetConnectionId.value = etcdConnections.value.find((connection) => connection.id !== props.connectionId)?.id || "";
   transferKeyFilter.value = "";
@@ -768,11 +807,16 @@ async function previewTransfer() {
   transferError.value = "";
   transferPreviewLoaded.value = false;
   try {
+    await connectionStore.ensureEtcdAccessCapabilities(targetId, { force: true, verifyHealth: false });
+    if (generation !== transferPreviewGeneration) return;
     let compared = 0;
     const sourceRows = await mapWithConcurrency(bundle.entries, TARGET_LOOKUP_CONCURRENCY, async (source) => {
       const shown = displayKey(source.key);
       if (normalizedLease(source.metadata) !== "0") {
         return { id: `source:${kvValueByteIdentity(source.key)}`, displayKey: shown, source, operation: "skipped" as const, reason: "Leased keys are skipped by default.", selected: false };
+      }
+      if (!canWriteConnectionKey(targetId, shown, source.key)) {
+        return { id: `source:${kvValueByteIdentity(source.key)}`, displayKey: shown, source, operation: "skipped" as const, reason: "目标连接没有此 Key 的写权限。", selected: false };
       }
       const target = await api.etcdGet(targetId, shown, { keyBytes: source.key });
       if (generation !== transferPreviewGeneration) throw new Error("同步预览已被新的请求替换。");
@@ -809,6 +853,10 @@ async function applyTransfer() {
   const targetId = targetConnectionId.value;
   const rows = [...selectedTransferRows.value];
   if (!targetId || rows.length === 0) return;
+  if (!rows.every((row) => row.source && canWriteConnectionKey(targetId, row.displayKey, row.source.key))) {
+    transferError.value = "目标连接没有所选 Key 的写权限，未执行任何写入。";
+    return;
+  }
   // Invalidate any preview that is still resolving before writes begin.
   transferPreviewGeneration++;
   transferApplying.value = true;
@@ -966,8 +1014,16 @@ async function openSearchResult(result: SearchResult) {
 }
 
 async function openOperations(nextMode: Extract<WorkbenchMode, "maintenance" | "watch" | "lease">) {
+  if ((nextMode === "maintenance" || nextMode === "lease") && !canManageEtcd.value) return;
   activeOperation.value = nextMode;
   mode.value = nextMode;
+  operationsStatus.value = null;
+  // A watch is scoped to the Key/prefix supplied by the user. Do not probe
+  // cluster status first: ordinary etcd users normally lack that privilege.
+  if (nextMode === "watch") {
+    operationsLoading.value = false;
+    return;
+  }
   operationsLoading.value = true;
   try {
     operationsStatus.value = await api.etcdStatus(props.connectionId);
@@ -988,6 +1044,7 @@ function openWatchWorkspaceAfterCreate() {
 }
 
 async function refreshLeaseOptions() {
+  if (!canManageEtcd.value) return;
   try {
     leaseOptions.value = (await api.etcdLeaseList(props.connectionId)).leases;
   } catch (error) {
@@ -1034,7 +1091,7 @@ defineExpose({ focusSearch, refresh });
         <Button size="sm" :variant="mode === 'keys' ? 'secondary' : 'ghost'" class="h-8 gap-1.5 px-3 text-sm" @click="mode = 'keys'"><KeyRound class="h-4 w-4" /> {{ t("etcd.key") }}</Button>
         <Button size="sm" :variant="mode === 'search' ? 'secondary' : 'ghost'" class="h-8 gap-1.5 px-3 text-sm" @click="mode = 'search'"><Search class="h-4 w-4" /> {{ t("etcd.globalSearch") }}</Button>
       </div>
-      <Button v-if="!isV2Api" size="sm" :variant="mode === 'maintenance' ? 'secondary' : 'ghost'" class="h-8 gap-1.5 px-2.5 text-sm" @click="openOperations('maintenance')"><Wrench class="h-4 w-4" />{{ t("etcd.admin.maintenance") }}</Button>
+      <Button v-if="!isV2Api && canManageEtcd" size="sm" :variant="mode === 'maintenance' ? 'secondary' : 'ghost'" class="h-8 gap-1.5 px-2.5 text-sm" @click="openOperations('maintenance')"><Wrench class="h-4 w-4" />{{ t("etcd.admin.maintenance") }}</Button>
       <Button
         size="sm"
         :variant="mode === 'watch' ? 'secondary' : 'ghost'"
@@ -1045,7 +1102,7 @@ defineExpose({ focusSearch, refresh });
         "
         ><Activity class="h-4 w-4" />{{ t("etcd.admin.watch") }}</Button
       >
-      <Button v-if="!isV2Api" size="sm" :variant="mode === 'lease' ? 'secondary' : 'ghost'" class="h-8 gap-1.5 px-2.5 text-sm" @click="openOperations('lease')"><KeyRound class="h-4 w-4" />{{ t("etcd.admin.lease") }}</Button>
+      <Button v-if="!isV2Api && canManageEtcd" size="sm" :variant="mode === 'lease' ? 'secondary' : 'ghost'" class="h-8 gap-1.5 px-2.5 text-sm" @click="openOperations('lease')"><KeyRound class="h-4 w-4" />{{ t("etcd.admin.lease") }}</Button>
       <div class="flex-1" />
       <Badge v-if="readOnly" variant="outline">{{ t("connection.readOnly") }}</Badge>
       <DropdownMenu>
@@ -1064,9 +1121,9 @@ defineExpose({ focusSearch, refresh });
           </template>
         </DropdownMenuContent>
       </DropdownMenu>
-      <Button size="sm" variant="destructive" class="h-8 gap-1.5" :disabled="readOnly || selectedTreeKeys.length === 0 || batchDeleting" @click="batchDeleteOpen = true"><Trash2 class="h-3.5 w-3.5" />{{ t("etcd.delete") }}</Button>
+      <Button size="sm" variant="destructive" class="h-8 gap-1.5" :disabled="readOnly || !selectedTreeKeysWritable || batchDeleting" @click="batchDeleteOpen = true"><Trash2 class="h-3.5 w-3.5" />{{ t("etcd.delete") }}</Button>
       <Button size="sm" variant="outline" class="h-8 gap-1.5" :disabled="readOnly" @click="fileInput?.click()"><Upload class="h-3.5 w-3.5" /> {{ t("etcd.import") }}</Button>
-      <Button size="sm" variant="outline" class="h-8 gap-1.5" :disabled="etcdConnections.length < 2" @click="openSync"><ArrowRightLeft class="h-3.5 w-3.5" /> {{ t("etcd.sync") }}</Button>
+      <Button size="sm" variant="outline" class="h-8 gap-1.5" :disabled="readOnly || etcdConnections.length < 2" @click="openSync"><ArrowRightLeft class="h-3.5 w-3.5" /> {{ t("etcd.sync") }}</Button>
       <input ref="fileInput" type="file" accept="application/json,.json" class="hidden" @change="onImportFile" />
     </div>
 
@@ -1077,13 +1134,14 @@ defineExpose({ focusSearch, refresh });
       :connection-id="props.connectionId"
       :api="etcdApi"
       :labels="labels"
-      :supports-ttl="supportsTtl"
-      :supports-lease-binding="!isV2Api"
+      :supports-ttl="supportsTtl && canManageEtcd"
+      :supports-lease-binding="!isV2Api && canManageEtcd"
       :ttl-capability-known="ttlCapabilityKnown"
       :enable-node-actions="true"
       :safe-write="true"
       :allow-binary-edit="true"
       :read-only="readOnly"
+      :can-write-key="canWriteCurrentKey"
       :enable-multi-select="true"
       :on-watch-key="openWatchForKey"
       export-format="dbx-etcd-bundle"
@@ -1164,10 +1222,10 @@ defineExpose({ focusSearch, refresh });
         <div v-else class="flex h-52 items-center justify-center px-6 text-center text-sm text-muted-foreground">输入关键词后开始搜索。可使用 Prefix 限定扫描范围。</div>
       </div>
     </div>
-    <div v-if="operationsStatus || operationsLoading || watchPreset" v-show="isOperationsMode" class="min-h-0 flex-1 overflow-auto p-4">
+    <div v-if="isOperationsMode" class="min-h-0 flex-1 overflow-auto p-4">
       <div v-if="operationsLoading && !operationsStatus" class="flex h-32 items-center justify-center text-sm text-muted-foreground"><Loader2 class="mr-2 h-4 w-4 animate-spin" />加载集群状态...</div>
       <EtcdAdminConsole
-        v-else-if="operationsStatus || watchPreset"
+        v-else-if="operationsStatus || activeOperation === 'watch'"
         :connection-id="connectionId"
         :status="operationsStatus"
         :sections="[activeOperation]"

--- a/apps/desktop/src/components/etcd/__tests__/EtcdKeyBrowser.spec.ts
+++ b/apps/desktop/src/components/etcd/__tests__/EtcdKeyBrowser.spec.ts
@@ -11,9 +11,14 @@ const backend = vi.hoisted(() => ({
   etcdDelete: vi.fn(),
   etcdRename: vi.fn(),
   etcdHistory: vi.fn(),
+  etcdStatus: vi.fn(),
   etcdGetCalls: [] as unknown[][],
   capturedKvBrowserApi: null as any,
+  capturedCanWriteKey: null as any,
+  canWriteEtcdKey: vi.fn(),
+  ensureEtcdAccessCapabilities: vi.fn(),
   selectKeyCalls: [] as unknown[],
+  access: { admin: true, writable: true },
 }));
 
 vi.mock("vue-i18n", () => ({
@@ -27,13 +32,17 @@ vi.mock("@/lib/backend/api", () => ({
   etcdDelete: backend.etcdDelete,
   etcdRename: backend.etcdRename,
   etcdHistory: backend.etcdHistory,
+  etcdStatus: backend.etcdStatus,
   etcdSupportsTtl: backend.etcdSupportsTtl,
 }));
 
 vi.mock("@/stores/connectionStore", () => ({
   useConnectionStore: () => ({
     connections: [],
-    getConfig: () => undefined,
+    getConfig: () => ({ id: "etcd-1", db_type: "etcd" }),
+    getEtcdAccessCapabilities: () => backend.access,
+    ensureEtcdAccessCapabilities: backend.ensureEtcdAccessCapabilities,
+    canWriteEtcdKey: backend.canWriteEtcdKey,
   }),
 }));
 
@@ -45,11 +54,15 @@ vi.mock("@/components/kv/KvKeyBrowser.vue", () => ({
       api: { type: Object, required: true },
       connectionId: { type: String, required: true },
       supportsTtl: { type: Boolean, default: false },
+      supportsLeaseBinding: { type: Boolean, default: false },
       ttlCapabilityKnown: { type: Boolean, default: true },
+      readOnly: { type: Boolean, default: false },
+      canWriteKey: { type: Function, default: undefined },
     },
     emits: ["refreshRequested", "selectionChange"],
     setup(props, { emit, expose }) {
       backend.capturedKvBrowserApi = props.api;
+      backend.capturedCanWriteKey = props.canWriteKey;
       expose({
         focusSearch: () => true,
         selectKey: (route: unknown) => {
@@ -73,7 +86,9 @@ vi.mock("@/components/kv/KvKeyBrowser.vue", () => ({
             {
               id: "kv-browser-stub",
               "data-supports-ttl": String(props.supportsTtl),
+              "data-supports-lease-binding": String(props.supportsLeaseBinding),
               "data-capability-known": String(props.ttlCapabilityKnown),
+              "data-read-only": String(props.readOnly),
               onClick: () => emit("refreshRequested"),
             },
             "refresh",
@@ -108,6 +123,15 @@ vi.mock("@/components/editor/DangerConfirmDialog.vue", () => ({
     emits: ["confirm", "update:open"],
     setup(props, { emit }) {
       return () => (props.open ? h("button", { id: "confirm-batch-delete", onClick: () => emit("confirm") }, "confirm") : null);
+    },
+  }),
+}));
+
+vi.mock("@/components/etcd/EtcdAdminConsole.vue", () => ({
+  default: defineComponent({
+    name: "EtcdAdminConsoleStub",
+    setup() {
+      return () => h("div", { id: "etcd-admin-console-stub" });
     },
   }),
 }));
@@ -175,10 +199,16 @@ beforeEach(() => {
   backend.etcdDelete.mockReset();
   backend.etcdRename.mockReset();
   backend.etcdHistory.mockReset();
+  backend.etcdStatus.mockReset();
   backend.etcdListPrefix.mockResolvedValue({ keys: [], continuation: null, revision: "1" });
   backend.etcdGetCalls.length = 0;
   backend.capturedKvBrowserApi = null;
+  backend.capturedCanWriteKey = null;
+  backend.canWriteEtcdKey.mockReset().mockReturnValue(true);
+  backend.ensureEtcdAccessCapabilities.mockReset().mockImplementation(async () => backend.access);
   backend.selectKeyCalls.length = 0;
+  backend.access.admin = true;
+  backend.access.writable = true;
 });
 
 afterEach(() => {
@@ -233,6 +263,37 @@ describe("EtcdKeyBrowser TTL capability recovery", () => {
     expect(backend.etcdSupportsTtl).toHaveBeenCalledTimes(2);
     expect(browser.dataset.supportsTtl).toBe("true");
     expect(browser.dataset.capabilityKnown).toBe("true");
+  });
+});
+
+describe("EtcdKeyBrowser restricted etcd access", () => {
+  it("loads access capabilities when a restored tab mounts without sidebar expansion", async () => {
+    await mountBrowser();
+
+    await vi.waitFor(() =>
+      expect(backend.ensureEtcdAccessCapabilities).toHaveBeenCalledWith("etcd-1", {
+        force: true,
+        verifyHealth: false,
+      }),
+    );
+  });
+
+  it("hides cluster controls and opens a Key watch without reading cluster status", async () => {
+    backend.access.admin = false;
+    backend.access.writable = false;
+
+    const browser = await mountBrowser();
+    expect(browser.dataset.readOnly).toBe("true");
+    expect(browser.dataset.supportsLeaseBinding).toBe("false");
+    expect(root!.textContent).not.toContain("etcd.admin.maintenance");
+    expect(root!.textContent).not.toContain("etcd.admin.lease");
+
+    const watch = [...root!.querySelectorAll("button")].find((button) => button.textContent?.includes("etcd.admin.watch"));
+    watch?.click();
+    await flushUi();
+
+    expect(root!.querySelector("#etcd-admin-console-stub")).toBeTruthy();
+    expect(backend.etcdStatus).not.toHaveBeenCalled();
   });
 });
 
@@ -455,5 +516,19 @@ describe("EtcdKeyBrowser tree batch operations", () => {
 
     const selectedExports = [...root!.querySelectorAll("button")].filter((button) => button.textContent?.includes("etcd.exportSelection"));
     expect(selectedExports).toHaveLength(0);
+  });
+
+  it("blocks a selected Key outside the user's write ranges before any delete", async () => {
+    backend.canWriteEtcdKey.mockImplementation((_connectionId, _key, keyBytes) => keyBytes?.data !== "/w==");
+
+    await mountBrowser();
+    root!.querySelector<HTMLButtonElement>("#emit-tree-selection")!.click();
+    await flushUi();
+
+    const batchDelete = [...root!.querySelectorAll("button")].find((button) => button.textContent?.includes("etcd.delete")) as HTMLButtonElement;
+    expect(batchDelete.disabled).toBe(true);
+    expect(() => backend.capturedKvBrowserApi.deleteKey("etcd-1", "[base64:/w==]", { keyBytes: { encoding: "base64", data: "/w==" } })).toThrow("ETCD_PERMISSION_DENIED");
+    expect(backend.etcdDelete).not.toHaveBeenCalled();
+    expect(backend.capturedCanWriteKey({ key: "[base64:/w==]", keyBytes: { encoding: "base64", data: "/w==" } })).toBe(false);
   });
 });

--- a/apps/desktop/src/components/kv/KvKeyBrowser.vue
+++ b/apps/desktop/src/components/kv/KvKeyBrowser.vue
@@ -203,6 +203,7 @@ const props = withDefaults(
     exportFileExtension?: string;
     exportFallbackName?: string;
     enableMultiSelect?: boolean;
+    canWriteKey?: (route: KvKeyRoute) => boolean;
     onWatchKey?: (route: KvKeyRoute) => void;
     onDeletePrefix?: (prefix: string) => void;
     watchActiveKey?: string | null;
@@ -413,6 +414,21 @@ const selectedValueClipboardText = computed(() => {
   return selectedValueUsesUtf8Preview.value && preview?.ok ? preview.value : selectedTextValue.value;
 });
 const selectedKeyBytes = computed(() => selectedValue.value?.keyBytes ?? selectedRouteKeyBytes.value ?? null);
+function keyIsWritable(key: string, keyBytes?: KvValue | null): boolean {
+  return !props.readOnly && (props.canWriteKey?.({ key, keyBytes }) ?? true);
+}
+const selectedKeyWritable = computed(() => Boolean(selectedKey.value && keyIsWritable(selectedKey.value, selectedKeyBytes.value)));
+const editKeyWritable = computed(() => {
+  const key = editKey.value.trim();
+  if (!key) return false;
+  const keyBytes = !isCreating.value && key === selectedKey.value ? selectedKeyBytes.value : null;
+  return keyIsWritable(key, keyBytes);
+});
+const renameTargetWritable = computed(() => {
+  const target = renameValue.value.trim();
+  if (!target) return false;
+  return keyIsWritable(target) && (renameMode.value === "copy" || selectedKeyWritable.value);
+});
 const selectedKeyLocked = computed(() => Boolean(String(selectedMetadata.value?.session ?? "").trim()));
 const isWatchingSelectedKey = computed(() => Boolean(selectedKey.value && props.watchActiveKey === selectedKey.value));
 const activeSearchHighlight = computed(() => (props.searchHighlight?.key === selectedKey.value ? props.searchHighlight : null));
@@ -460,8 +476,8 @@ const editValueSize = computed(() => {
   }
   return new TextEncoder().encode(editValue.value).length;
 });
-const canEditSelectedValue = computed(() => !props.readOnly && !selectedKeyLocked.value && (!selectedValueIsBase64.value || props.allowBinaryEdit));
-const canDeleteSelectedValue = computed(() => !props.readOnly && !selectedKeyLocked.value);
+const canEditSelectedValue = computed(() => selectedKeyWritable.value && !selectedKeyLocked.value && (!selectedValueIsBase64.value || props.allowBinaryEdit));
+const canDeleteSelectedValue = computed(() => selectedKeyWritable.value && !selectedKeyLocked.value);
 const consulMetadataRows = computed(() => {
   const metadata = selectedMetadata.value;
   return [
@@ -1258,6 +1274,11 @@ async function saveKey() {
     return;
   }
   const key = props.lazyHierarchy ? normalizeLazyKvPath(rawKey, props.lazyPathStyle) : rawKey;
+  const keyBytes = !isCreating.value && key === selectedKey.value ? selectedKeyBytes.value : null;
+  if (!keyIsWritable(key, keyBytes)) {
+    editError.value = t("connection.readOnly");
+    return;
+  }
   const validationError = validateKvValue(editValue.value, editFormat.value);
   if (validationError) {
     editError.value = validationError;
@@ -1275,6 +1296,7 @@ async function saveKey() {
 async function confirmSaveKey() {
   if (!pendingSave.value) return;
   const { key, value, options } = pendingSave.value;
+  if (!keyIsWritable(key, options?.keyBytes)) return;
   saving.value = true;
   editError.value = "";
   editErrorKind.value = "request";
@@ -1367,7 +1389,8 @@ async function selectNodeForAction(node: BrowserTreeNode) {
 }
 
 async function openDeleteForNode(node: BrowserTreeNode) {
-  if (props.readOnly) return;
+  const route = routeFromNode(node);
+  if (!keyIsWritable(route.key, route.keyBytes)) return;
   await selectNodeForAction(node);
   if (!selectedKey.value || !selectedValue.value?.found || !canDeleteSelectedValue.value) return;
   showDeleteConfirm.value = true;
@@ -1499,7 +1522,7 @@ function onEditFormatChange(value: unknown) {
 }
 
 function openRenameDialog() {
-  if (!selectedKey.value || !props.api.rename || props.readOnly) return;
+  if (!selectedKey.value || !props.api.rename || !selectedKeyWritable.value) return;
   renameMode.value = "rename";
   renameValue.value = selectedKey.value;
   renameError.value = "";
@@ -1513,6 +1536,10 @@ async function moveOrCopySelectedKey() {
   const next = renameValue.value.trim();
   if (!next) {
     renameError.value = props.labels.keyRequired;
+    return;
+  }
+  if (!renameTargetWritable.value) {
+    renameError.value = t("connection.readOnly");
     return;
   }
   renaming.value = true;
@@ -1564,7 +1591,7 @@ function compareHistory(event: KvHistoryEvent) {
 }
 
 async function restoreHistory() {
-  if (!selectedKey.value || !historyRestoreValue.value) return;
+  if (!selectedKey.value || !historyRestoreValue.value || !selectedKeyWritable.value) return;
   restoring.value = true;
   try {
     await props.api.put(props.connectionId, selectedKey.value, historyRestoreValue.value, {
@@ -1584,6 +1611,8 @@ async function restoreHistory() {
 
 function nodeContextMenuItems(node: BrowserTreeNode): ContextMenuItem[] {
   if (!props.enableNodeActions) return [];
+  const route = routeFromNode(node);
+  const nodeWritable = keyIsWritable(route.key, route.keyBytes);
   const items: ContextMenuItem[] = [
     {
       label: props.labels.add || props.labels.newKey,
@@ -1598,7 +1627,7 @@ function nodeContextMenuItems(node: BrowserTreeNode): ContextMenuItem[] {
         label: props.labels.edit,
         icon: Pencil,
         action: () => void loadSelectedKey(routeFromNode(node)).then(openEditDialog),
-        disabled: props.readOnly,
+        disabled: !nodeWritable,
       },
       {
         label: props.labels.clone || "Clone",
@@ -1617,7 +1646,7 @@ function nodeContextMenuItems(node: BrowserTreeNode): ContextMenuItem[] {
         label: props.labels.rename || "Rename",
         icon: Pencil,
         action: () => void loadSelectedKey(routeFromNode(node)).then(openRenameDialog),
-        disabled: props.readOnly,
+        disabled: !nodeWritable,
       });
     }
     if (props.api.history) {
@@ -1649,7 +1678,7 @@ function nodeContextMenuItems(node: BrowserTreeNode): ContextMenuItem[] {
       icon: Trash2,
       variant: "destructive",
       action: () => void openDeleteForNode(node),
-      disabled: props.readOnly || !nodeHasValue(node),
+      disabled: !nodeWritable || !nodeHasValue(node),
     });
   }
   return items;
@@ -2239,7 +2268,7 @@ defineExpose({
         </div>
         <DialogFooter class="mx-0 mb-0 shrink-0 gap-3 border-t bg-muted/10 px-6 py-5">
           <Button variant="outline" class="h-10 min-w-20" @click="showEditDialog = false">{{ t("common.cancel") }}</Button>
-          <Button class="h-10 min-w-20" :disabled="saving || readOnly" @click="saveKey">
+          <Button class="h-10 min-w-20" :disabled="saving || !editKeyWritable" @click="saveKey">
             <Loader2 v-if="saving" class="mr-2 h-4 w-4 animate-spin" />
             {{ t("common.save") }}
           </Button>
@@ -2260,7 +2289,7 @@ defineExpose({
         </div>
         <DialogFooter>
           <Button variant="outline" :disabled="renaming" @click="showRenameDialog = false">{{ t("common.cancel") }}</Button>
-          <Button :disabled="renaming || readOnly" @click="moveOrCopySelectedKey">
+          <Button :disabled="renaming || !renameTargetWritable" @click="moveOrCopySelectedKey">
             <Loader2 v-if="renaming" class="mr-2 h-4 w-4 animate-spin" />
             {{ renameMode === "copy" ? labels.clone || "Clone" : labels.rename || "Rename" }}
           </Button>
@@ -2317,7 +2346,7 @@ defineExpose({
       :before="selectedTextValue"
       :after="historyRestoreValue?.data || ''"
       :loading="restoring"
-      :show-confirm="!readOnly && !!historyRestoreValue"
+      :show-confirm="selectedKeyWritable && !!historyRestoreValue"
       :confirm-label="labels.restore || 'Restore'"
       @confirm="restoreHistory"
     />

--- a/apps/desktop/src/components/kv/__tests__/KvKeyBrowserLayout.spec.ts
+++ b/apps/desktop/src/components/kv/__tests__/KvKeyBrowserLayout.spec.ts
@@ -14,7 +14,7 @@ describe("KvKeyBrowser edit dialog layout", () => {
   it("cancels the shared footer negative margin and preserves bottom safe spacing", () => {
     expect(browserSource).toContain('<DialogFooter class="mx-0 mb-0 shrink-0 gap-3 border-t bg-muted/10 px-6 py-5">');
     expect(browserSource).toContain('variant="outline" class="h-10 min-w-20"');
-    expect(browserSource).toContain('<Button class="h-10 min-w-20" :disabled="saving || readOnly"');
+    expect(browserSource).toContain('<Button class="h-10 min-w-20" :disabled="saving || !editKeyWritable"');
   });
 
   it("applies the same safe spacing to the history dialog footer", () => {

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -248,6 +248,15 @@ const emit = defineEmits<{
 const { t, locale } = useI18n();
 const queryStore = useQueryStore();
 const connectionStore = useConnectionStore();
+const canAccessEtcdAdmin = computed(() => connectionStore.getEtcdAccessCapabilities(props.activeTab.connectionId).admin);
+watch(
+  () => [props.activeTab.connectionId, props.activeTab.mode] as const,
+  ([connectionId, mode]) => {
+    if (mode !== "etcd-dashboard" && mode !== "etcd-access-control") return;
+    void connectionStore.ensureEtcdAccessCapabilities(connectionId, { force: true, verifyHealth: false }).catch(() => undefined);
+  },
+  { immediate: true },
+);
 
 function groupedQueryReadonlyColumnIndexes(tab: QueryTab): number[] | undefined {
   if (!tab.queryAnalysis?.groupByColumns?.length || !tab.querySourceColumns || !tab.tableMeta?.primaryKeys.length) return undefined;
@@ -2259,13 +2268,15 @@ defineExpose({
     <!-- etcd Dashboard: cluster observation -->
     <template v-else-if="activeTab.mode === 'etcd-dashboard'">
       <div class="flex-1 min-h-0">
-        <EtcdDashboard ref="etcdDashboardRef" :key="activeTab.id" :connection-id="activeTab.connectionId" />
+        <EtcdDashboard v-if="canAccessEtcdAdmin" ref="etcdDashboardRef" :key="activeTab.id" :connection-id="activeTab.connectionId" />
+        <div v-else class="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground"><ShieldAlert class="h-4 w-4" />{{ t("etcd.adminPermissionRequired") }}</div>
       </div>
     </template>
 
     <template v-else-if="activeTab.mode === 'etcd-access-control'">
       <div class="flex-1 min-h-0">
-        <EtcdAccessControl :key="activeTab.id" :connection-id="activeTab.connectionId" />
+        <EtcdAccessControl v-if="canAccessEtcdAdmin" :key="activeTab.id" :connection-id="activeTab.connectionId" />
+        <div v-else class="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground"><ShieldAlert class="h-4 w-4" />{{ t("etcd.adminPermissionRequired") }}</div>
       </div>
     </template>
 

--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -696,14 +696,23 @@ function isGroupLabel(node: TreeNode): boolean {
 async function openDirectNavigationNode(node: TreeNode, requestId: number) {
   if (!node.connectionId) return;
   const isNacosNavigation = node.type === "nacos-namespace" || node.type === "nacos-access-control";
-  await connectionStore.ensureConnected(node.connectionId, isNacosNavigation ? { verifyHealth: false } : undefined);
+  const isEtcdNavigation = node.type === "etcd-root" || node.type === "etcd-dashboard" || node.type === "etcd-access-control";
+  await connectionStore.ensureConnected(node.connectionId, isNacosNavigation || isEtcdNavigation ? { verifyHealth: false } : undefined);
   if (!isCurrentNavigationRequest(requestId)) return;
-  const connectionName = connectionStore.getConfig(node.connectionId)?.name || (isNacosNavigation ? "Nacos" : "Consul");
+  if ((node.type === "etcd-dashboard" || node.type === "etcd-access-control") && !connectionStore.getEtcdAccessCapabilities(node.connectionId).admin) return;
+  const connectionName = connectionStore.getConfig(node.connectionId)?.name || (isNacosNavigation ? "Nacos" : isEtcdNavigation ? "etcd" : "Consul");
   if (node.type === "consul-root") {
     queryStore.createTab(node.connectionId, "", `${connectionName}:keys`, "consul");
     refreshActiveKvBrowserAfterOpen("consul", node.connectionId);
   } else if (node.type === "consul-overview") {
     queryStore.createTab(node.connectionId, "", `${connectionName}:${t("consul.ui.overview")}`, "consul-overview");
+  } else if (node.type === "etcd-root") {
+    queryStore.createTab(node.connectionId, "", `${connectionName}:keys`, "etcd");
+    refreshActiveKvBrowserAfterOpen("etcd", node.connectionId);
+  } else if (node.type === "etcd-dashboard") {
+    queryStore.createTab(node.connectionId, "", `${connectionName}:dashboard`, "etcd-dashboard");
+  } else if (node.type === "etcd-access-control") {
+    queryStore.createTab(node.connectionId, "", `${connectionName}:access-control`, "etcd-access-control");
   } else if (node.type === "nacos-namespace") {
     queryStore.openNacosAdmin(node.connectionId, { namespace: node.nacosNamespace || "", namespaceName: node.nacosNamespaceName || node.label });
   } else if (node.type === "nacos-access-control") {
@@ -912,19 +921,6 @@ async function toggle(requestId = beginNavigationRequest()) {
       await connectionStore.ensureConnected(node.connectionId);
       const topicFromId = node.id.endsWith(":mqtt-topic:__console__") ? undefined : node.id.split(":mqtt-topic:")[1] || node.label;
       queryStore.openMqttAdmin(node.connectionId, topicFromId ? { initialTopic: topicFromId } : undefined);
-    } else if (node.type === "etcd-root" && node.connectionId) {
-      await connectionStore.ensureConnected(node.connectionId);
-      const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "etcd"}:keys`;
-      queryStore.createTab(node.connectionId, "", tabTitle, "etcd");
-      refreshActiveKvBrowserAfterOpen("etcd", node.connectionId);
-    } else if (node.type === "etcd-dashboard" && node.connectionId) {
-      await connectionStore.ensureConnected(node.connectionId);
-      const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "etcd"}:dashboard`;
-      queryStore.createTab(node.connectionId, "", tabTitle, "etcd-dashboard");
-    } else if (node.type === "etcd-access-control" && node.connectionId) {
-      await connectionStore.ensureConnected(node.connectionId);
-      const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "etcd"}:access-control`;
-      queryStore.createTab(node.connectionId, "", tabTitle, "etcd-access-control");
     } else if (node.type === "zookeeper-root" && node.connectionId) {
       await connectionStore.ensureConnected(node.connectionId);
       const tabTitle = `${connectionStore.getConfig(node.connectionId)?.name || "ZooKeeper"}:keys`;
@@ -6232,6 +6228,14 @@ function handleRowClick(node: TreeNode, clickDetail: number) {
 }
 
 function handleRowDoubleClick(node: TreeNode, event: MouseEvent) {
+  // Direct-navigation rows already handle every click in the click sequence.
+  // Starting a new request for their trailing dblclick would invalidate the
+  // still-pending single-click navigation without providing a replacement in
+  // single-click activation mode.
+  if (isDirectNavigationTreeNode(node.type)) {
+    activateRuntimeNode(node);
+    return;
+  }
   beginNavigationRequest();
   activateRuntimeNode(node);
   onDoubleClick(event);

--- a/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/SidebarTreeRuntimeHost.expansion.spec.ts
@@ -14,6 +14,7 @@ const connectionStore = {
   canUseLoadedTreeNodeToggle: vi.fn(() => true),
   releaseCollapsedTreeNodeChildren: vi.fn(),
   getConfig: vi.fn(() => ({ db_type: "mysql", name: "connection" })),
+  getEtcdAccessCapabilities: vi.fn(() => ({ admin: true, writable: true, writePermissions: null })),
   ensureConnected: vi.fn(async () => undefined),
   loadPackageMembers: vi.fn(async (node: TreeNode) => {
     node.isExpanded = true;
@@ -59,6 +60,7 @@ afterEach(() => {
   vi.clearAllMocks();
   connectionStore.canUseLoadedTreeNodeToggle.mockReturnValue(true);
   connectionStore.getConfig.mockReturnValue({ db_type: "mysql", name: "connection" });
+  connectionStore.getEtcdAccessCapabilities.mockReturnValue({ admin: true, writable: true, writePermissions: null });
 });
 
 describe("SidebarTreeRuntimeHost expansion", () => {
@@ -225,6 +227,96 @@ describe("SidebarTreeRuntimeHost expansion", () => {
     await vi.waitFor(() => expect(connectionStore.ensureConnected).toHaveBeenCalledWith("meili", undefined));
     expect(queryStore.createTab).toHaveBeenCalledWith("meili", "default", expect.any(String), "meilisearch-system");
     expect(systemNode.isExpanded).toBe(true);
+  });
+
+  it("opens etcd workspaces without waiting for a connection health probe", async () => {
+    connectionStore.getConfig.mockReturnValue({ db_type: "etcd", name: "local-etcd-v3" });
+    connectionStore.ensureConnected.mockImplementation(async (...args: any[]) => {
+      const options = args[1] as { verifyHealth?: boolean } | undefined;
+      if (options?.verifyHealth === false) return;
+      await new Promise<void>(() => undefined);
+    });
+    const nodes: TreeNode[] = [
+      { id: "etcd:root", label: "Keys", type: "etcd-root", connectionId: "etcd" },
+      { id: "etcd:access-control", label: "Users & Roles", type: "etcd-access-control", connectionId: "etcd" },
+      { id: "etcd:dashboard", label: "Dashboard", type: "etcd-dashboard", connectionId: "etcd" },
+    ];
+    connectionStore.treeNodes = nodes;
+
+    const host = ref<InstanceType<typeof SidebarTreeRuntimeHost> | null>(null);
+    const app = createApp(
+      defineComponent({
+        setup: () => () => h(SidebarTreeRuntimeHost, { ref: host, node: nodes[0], depth: 0 }),
+      }),
+    );
+    mountedApps.push(app);
+    const container = document.createElement("div");
+    document.body.append(container);
+    app.use(i18n);
+    app.mount(container);
+    await nextTick();
+
+    for (const [index, node] of nodes.entries()) {
+      host.value!.handleRowClick(node, index + 1);
+      await vi.waitFor(() => expect(queryStore.createTab).toHaveBeenCalledTimes(index + 1));
+    }
+
+    expect(connectionStore.ensureConnected).toHaveBeenNthCalledWith(1, "etcd", { verifyHealth: false });
+    expect(connectionStore.ensureConnected).toHaveBeenNthCalledWith(2, "etcd", { verifyHealth: false });
+    expect(connectionStore.ensureConnected).toHaveBeenNthCalledWith(3, "etcd", { verifyHealth: false });
+    expect(queryStore.createTab).toHaveBeenNthCalledWith(1, "etcd", "", "local-etcd-v3:keys", "etcd");
+    expect(queryStore.createTab).toHaveBeenNthCalledWith(2, "etcd", "", "local-etcd-v3:access-control", "etcd-access-control");
+    expect(queryStore.createTab).toHaveBeenNthCalledWith(3, "etcd", "", "local-etcd-v3:dashboard", "etcd-dashboard");
+  });
+
+  it("does not let the trailing dblclick cancel a pending etcd navigation", async () => {
+    let resolveConnection!: () => void;
+    const connection = new Promise<void>((resolve) => {
+      resolveConnection = resolve;
+    });
+    connectionStore.ensureConnected.mockReturnValue(connection);
+    connectionStore.getConfig.mockReturnValue({ db_type: "etcd", name: "local-etcd-v3" });
+    const node: TreeNode = { id: "etcd:dashboard", label: "Dashboard", type: "etcd-dashboard", connectionId: "etcd" };
+    connectionStore.treeNodes = [node];
+
+    const host = ref<InstanceType<typeof SidebarTreeRuntimeHost> | null>(null);
+    const app = createApp(
+      defineComponent({
+        setup: () => () => h(SidebarTreeRuntimeHost, { ref: host, node, depth: 0 }),
+      }),
+    );
+    mountedApps.push(app);
+    const container = document.createElement("div");
+    document.body.append(container);
+    app.use(i18n);
+    app.mount(container);
+    await nextTick();
+
+    host.value!.handleRowClick(node, 1);
+    host.value!.handleRowDoubleClick(node, new MouseEvent("dblclick", { detail: 2 }));
+    resolveConnection();
+
+    await vi.waitFor(() => expect(queryStore.createTab).toHaveBeenCalledWith("etcd", "", "local-etcd-v3:dashboard", "etcd-dashboard"));
+  });
+
+  it("does not reopen a stale etcd admin node after access becomes restricted", async () => {
+    connectionStore.getConfig.mockReturnValue({ db_type: "etcd", name: "local-etcd-v3" });
+    connectionStore.getEtcdAccessCapabilities.mockReturnValue({ admin: false, writable: true, writePermissions: [] });
+    const node: TreeNode = { id: "etcd:dashboard", label: "Dashboard", type: "etcd-dashboard", connectionId: "etcd" };
+    connectionStore.treeNodes = [node];
+
+    const host = ref<InstanceType<typeof SidebarTreeRuntimeHost> | null>(null);
+    const app = createApp(defineComponent({ setup: () => () => h(SidebarTreeRuntimeHost, { ref: host, node, depth: 0 }) }));
+    mountedApps.push(app);
+    const container = document.createElement("div");
+    document.body.append(container);
+    app.use(i18n);
+    app.mount(container);
+    await nextTick();
+
+    host.value!.handleRowClick(node, 1);
+    await vi.waitFor(() => expect(connectionStore.ensureConnected).toHaveBeenCalled());
+    expect(queryStore.createTab).not.toHaveBeenCalled();
   });
 
   it("expands an unloaded object group without leaking the regex source as a search filter", async () => {

--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.loadMoreActivation.spec.ts
@@ -503,3 +503,25 @@ describe("TreeItem searched connection activation", () => {
     expect(host.handleRowDoubleClick).toHaveBeenCalledWith(node, expect.any(MouseEvent));
   });
 });
+
+describe("TreeItem etcd workspace activation", () => {
+  it.each([
+    ["etcd-root", 1],
+    ["etcd-access-control", 2],
+    ["etcd-dashboard", 3],
+  ] as const)("activates %s with click detail %i even in double-click mode", async (type, detail) => {
+    settingsStore.editorSettings.sidebarActivation = "double";
+    const node: TreeNode = {
+      id: `connection-1:${type}`,
+      label: type,
+      type,
+      connectionId: "connection-1",
+    };
+    const { row, host } = await mountTreeItem(node);
+
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, detail }));
+
+    expect(host.handleRowClick).toHaveBeenCalledWith(node, detail);
+    expect(host.handleRowDoubleClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -4320,6 +4320,7 @@ export default {
     relationshipUpdated: "Relationship updated",
   },
   etcd: {
+    adminPermissionRequired: "This etcd view requires the root role.",
     prefixPlaceholder: "Search Key path, e.g. /app/ or service",
     newKey: "New Key",
     loadingKeys: "Loading keys...",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -4321,6 +4321,8 @@ export default {
   },
   etcd: {
     adminPermissionRequired: "This etcd view requires the root role.",
+    targetKeyWriteDenied: "The target connection does not have permission to write this Key.",
+    selectedKeysWriteDenied: "The target connection does not have permission to write the selected Keys; no changes were made.",
     prefixPlaceholder: "Search Key path, e.g. /app/ or service",
     newKey: "New Key",
     loadingKeys: "Loading keys...",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -4497,6 +4497,7 @@ export default withEnglishFallback({
       leaseGrantCancelled: "Espera cancelada; etcd puede estar procesando aún la solicitud de concesión; actualice para confirmar si se ha creado el Lease.",
       leaseCreated: "Lease {id} creado",
     },
+    adminPermissionRequired: "Esta página de etcd solo está abierta al rol root.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -4498,6 +4498,8 @@ export default withEnglishFallback({
       leaseCreated: "Lease {id} creado",
     },
     adminPermissionRequired: "Esta página de etcd solo está abierta al rol root.",
+    targetKeyWriteDenied: "La conexión de destino no tiene permiso para escribir esta Key.",
+    selectedKeysWriteDenied: "La conexión de destino no tiene permiso para escribir las Keys seleccionadas; no se realizaron cambios.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -4496,6 +4496,8 @@ export default withEnglishFallback({
       leaseCreated: "Lease {id} creato",
     },
     adminPermissionRequired: "Questa pagina etcd è accessibile solo al ruolo root.",
+    targetKeyWriteDenied: "La connessione di destinazione non dispone dell'autorizzazione per scrivere questa Key.",
+    selectedKeysWriteDenied: "La connessione di destinazione non dispone dell'autorizzazione per scrivere le Key selezionate; non è stata eseguita alcuna modifica.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -4495,6 +4495,7 @@ export default withEnglishFallback({
       leaseGrantCancelled: "Attesa annullata; etcd potrebbe ancora elaborare la richiesta di concessione. Aggiorna per verificare se il Lease è stato creato.",
       leaseCreated: "Lease {id} creato",
     },
+    adminPermissionRequired: "Questa pagina etcd è accessibile solo al ruolo root.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -4563,6 +4563,8 @@ export default withEnglishFallback({
       leaseCreated: "リース {id} を作成しました",
     },
     adminPermissionRequired: "この etcd ページは root ロールのみに開放されています。",
+    targetKeyWriteDenied: "対象の接続にはこの Key への書き込み権限がありません。",
+    selectedKeysWriteDenied: "対象の接続には選択した Key への書き込み権限がないため、変更は実行されませんでした。",
   },
   redis: {
     setDatabaseAlias: "データベースの別名を設定",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -4562,6 +4562,7 @@ export default withEnglishFallback({
       leaseGrantCancelled: "待機をキャンセルしました。etcdがまだこの付与リクエストを処理している可能性があります。リースが作成されたかどうかリフレッシュして確認してください。",
       leaseCreated: "リース {id} を作成しました",
     },
+    adminPermissionRequired: "この etcd ページは root ロールのみに開放されています。",
   },
   redis: {
     setDatabaseAlias: "データベースの別名を設定",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -4128,6 +4128,7 @@ export default withEnglishFallback({
         healthy: "정상",
       },
     },
+    adminPermissionRequired: "이 etcd 페이지는 root 역할에만 공개됩니다.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -4129,6 +4129,8 @@ export default withEnglishFallback({
       },
     },
     adminPermissionRequired: "이 etcd 페이지는 root 역할에만 공개됩니다.",
+    targetKeyWriteDenied: "대상 연결에는 이 Key에 쓸 권한이 없습니다.",
+    selectedKeysWriteDenied: "대상 연결에는 선택한 Key에 쓸 권한이 없어 변경 사항이 적용되지 않았습니다.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -4497,6 +4497,7 @@ export default withEnglishFallback({
       leaseGrantCancelled: "Aguardando cancelado; etcd pode ainda estar processando a solicitação de concessão. Atualize para confirmar se o Lease foi criado.",
       leaseCreated: "Lease {id} criado",
     },
+    adminPermissionRequired: "Esta página do etcd está disponível apenas para o papel root.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -4498,6 +4498,8 @@ export default withEnglishFallback({
       leaseCreated: "Lease {id} criado",
     },
     adminPermissionRequired: "Esta página do etcd está disponível apenas para o papel root.",
+    targetKeyWriteDenied: "A conexão de destino não tem permissão para gravar esta Key.",
+    selectedKeysWriteDenied: "A conexão de destino não tem permissão para gravar as Keys selecionadas; nenhuma alteração foi feita.",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -4304,6 +4304,7 @@ export default withEnglishFallback({
     relationshipUpdated: "关系已更新",
   },
   etcd: {
+    adminPermissionRequired: "此 etcd 页面仅对 root 角色开放。",
     prefixPlaceholder: "搜索 Key 路径，例如 /app/ 或 service",
     newKey: "新建键（Key）",
     loadingKeys: "正在加载 Key...",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -4305,6 +4305,8 @@ export default withEnglishFallback({
   },
   etcd: {
     adminPermissionRequired: "此 etcd 页面仅对 root 角色开放。",
+    targetKeyWriteDenied: "目标连接没有此 Key 的写权限。",
+    selectedKeysWriteDenied: "目标连接没有所选 Key 的写权限，未执行任何写入。",
     prefixPlaceholder: "搜索 Key 路径，例如 /app/ 或 service",
     newKey: "新建键（Key）",
     loadingKeys: "正在加载 Key...",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -7528,6 +7528,8 @@ export default withEnglishFallback({
       leaseCreated: "已建立 Lease {id}",
     },
     adminPermissionRequired: "此 etcd 頁面僅對 root 角色開放。",
+    targetKeyWriteDenied: "目標連線沒有此 Key 的寫入權限。",
+    selectedKeysWriteDenied: "目標連線沒有所選 Key 的寫入權限，未執行任何寫入。",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -7527,6 +7527,7 @@ export default withEnglishFallback({
       leaseGrantCancelled: "已取消等待；etcd 可能仍在處理該授權請求，請重新整理確認是否已建立 Lease。",
       leaseCreated: "已建立 Lease {id}",
     },
+    adminPermissionRequired: "此 etcd 頁面僅對 root 角色開放。",
   },
   consul,
   sqlServerTrace,

--- a/apps/desktop/src/lib/__tests__/connection/etcdConnectionDialog.spec.ts
+++ b/apps/desktop/src/lib/__tests__/connection/etcdConnectionDialog.spec.ts
@@ -29,7 +29,7 @@ describe("etcd v2 feature trimming", () => {
   });
 
   it("hides lease binding and the maintenance/lease workspaces for v2 connections", () => {
-    expect(browserSource).toContain(':supports-lease-binding="!isV2Api"');
-    expect(browserSource).toContain('<Button v-if="!isV2Api"');
+    expect(browserSource).toContain(':supports-lease-binding="!isV2Api && canManageEtcd"');
+    expect(browserSource).toContain('<Button v-if="!isV2Api && canManageEtcd"');
   });
 });

--- a/apps/desktop/src/lib/__tests__/sidebar/treeNodeClick.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sidebar/treeNodeClick.spec.ts
@@ -65,6 +65,18 @@ describe("treeNodeClick", () => {
     expect(treeNodeRowAction("meilisearch-system", false, "double")).toBe("toggle");
   });
 
+  it("opens etcd workspaces on one click regardless of object activation preference", () => {
+    for (const type of ["etcd-root", "etcd-access-control", "etcd-dashboard"] as const) {
+      expect(isDirectNavigationTreeNode(type), type).toBe(true);
+      expect(shouldActivateTreeNodeOnSingleClick(type, "double"), type).toBe(true);
+      const action = treeNodeRowAction(type, false, "double");
+      expect(action, type).toBe("toggle");
+      expect(isRepeatableNavigationTreeNode(type), type).toBe(true);
+      expect(shouldRunTreeNodeRowAction(action, 2, isRepeatableNavigationTreeNode(type)), type).toBe(true);
+      expect(shouldRunTreeNodeRowAction(action, 3, isRepeatableNavigationTreeNode(type)), type).toBe(true);
+    }
+  });
+
   it("keeps Nacos namespace and access-control navigation responsive during rapid row switching", () => {
     for (const type of ["nacos-namespace", "nacos-access-control"] as const) {
       expect(isDirectNavigationTreeNode(type), type).toBe(true);

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -3142,6 +3142,7 @@ export interface EtcdAuthUserListResponse {
 export interface EtcdAuthUserDetail {
   user: string;
   roles: string[];
+  authEnabled?: boolean;
 }
 export interface EtcdAuthPermission {
   access: "read" | "write" | "readwrite";

--- a/apps/desktop/src/lib/etcd/__tests__/keyPermissions.spec.ts
+++ b/apps/desktop/src/lib/etcd/__tests__/keyPermissions.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { EtcdAuthPermission, KvValue } from "@/lib/backend/api";
+import { etcdPermissionAllowsKey, etcdPermissionsAllowKey } from "@/lib/etcd/keyPermissions";
+
+const utf8 = (data: string): KvValue => ({ encoding: "utf8", data });
+const base64 = (bytes: number[]): KvValue => ({ encoding: "base64", data: btoa(String.fromCharCode(...bytes)) });
+
+function permission(access: EtcdAuthPermission["access"], key: KvValue, rangeEnd: KvValue, resource: EtcdAuthPermission["resource"]): EtcdAuthPermission {
+  return { access, key, rangeEnd, resource };
+}
+
+describe("etcd Key write permissions", () => {
+  it("matches exact Key grants only", () => {
+    const grant = permission("write", utf8("/app/key"), utf8(""), "key");
+    expect(etcdPermissionAllowsKey(grant, utf8("/app/key"))).toBe(true);
+    expect(etcdPermissionAllowsKey(grant, utf8("/app/key/child"))).toBe(false);
+  });
+
+  it("uses etcd's half-open byte ranges", () => {
+    const grant = permission("readwrite", utf8("/app/"), utf8("/app0"), "prefix");
+    expect(etcdPermissionAllowsKey(grant, utf8("/app/a"))).toBe(true);
+    expect(etcdPermissionAllowsKey(grant, utf8("/app0"))).toBe(false);
+    expect(etcdPermissionAllowsKey(grant, utf8("/other"))).toBe(false);
+  });
+
+  it("supports binary Keys and the unbounded range sentinel", () => {
+    const grant = permission("write", base64([0x80]), base64([0]), "prefix");
+    expect(etcdPermissionAllowsKey(grant, base64([0x80, 0x01]))).toBe(true);
+    expect(etcdPermissionAllowsKey(grant, base64([0x7f]))).toBe(false);
+  });
+
+  it("ignores read-only grants when permissions are combined", () => {
+    const grants = [permission("read", utf8("/readonly/"), utf8("/readonly0"), "prefix"), permission("readwrite", utf8("/editable/"), utf8("/editable0"), "prefix")];
+    expect(etcdPermissionsAllowKey(grants, utf8("/readonly/key"))).toBe(false);
+    expect(etcdPermissionsAllowKey(grants, utf8("/editable/key"))).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/etcd/keyPermissions.ts
+++ b/apps/desktop/src/lib/etcd/keyPermissions.ts
@@ -1,0 +1,45 @@
+import type { EtcdAuthPermission, KvValue } from "@/lib/backend/api";
+
+const unboundedRangeEnd = new Uint8Array([0]);
+
+function decodeBase64(value: string): Uint8Array {
+  const decoded = globalThis.atob(value.replace(/\s+/g, ""));
+  return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+}
+
+export function etcdKvValueBytes(value: KvValue): Uint8Array {
+  return value.encoding === "base64" ? decodeBase64(value.data) : new TextEncoder().encode(value.data);
+}
+
+function compareBytes(left: Uint8Array, right: Uint8Array): number {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = left[index]! - right[index]!;
+    if (difference !== 0) return difference;
+  }
+  return left.length - right.length;
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  return compareBytes(left, right) === 0;
+}
+
+function isUnboundedRangeEnd(value: Uint8Array): boolean {
+  return bytesEqual(value, unboundedRangeEnd);
+}
+
+/** Tests one Key against etcd's byte-oriented, half-open permission range. */
+export function etcdPermissionAllowsKey(permission: EtcdAuthPermission, key: KvValue): boolean {
+  if (permission.access === "read") return false;
+  if (permission.resource === "all") return true;
+
+  const keyBytes = etcdKvValueBytes(key);
+  const start = etcdKvValueBytes(permission.key);
+  const end = etcdKvValueBytes(permission.rangeEnd);
+  if (permission.resource === "key" || end.length === 0) return bytesEqual(keyBytes, start);
+  return compareBytes(keyBytes, start) >= 0 && (isUnboundedRangeEnd(end) || compareBytes(keyBytes, end) < 0);
+}
+
+export function etcdPermissionsAllowKey(permissions: readonly EtcdAuthPermission[], key: KvValue): boolean {
+  return permissions.some((permission) => etcdPermissionAllowsKey(permission, key));
+}

--- a/apps/desktop/src/lib/sidebar/treeNodeClick.ts
+++ b/apps/desktop/src/lib/sidebar/treeNodeClick.ts
@@ -35,8 +35,8 @@ const toggleLeafNodeTypes = new Set<TreeNodeType>([
 // These are application entry points rather than database objects. They should
 // always navigate on a single click, even when the user prefers double-click
 // activation for ordinary tree objects.
-const directNavigationTreeNodeTypes = new Set<TreeNodeType>(["consul-root", "consul-overview", "nacos-namespace", "nacos-access-control", "meilisearch-system"]);
-const repeatableNavigationTreeNodeTypes = new Set<TreeNodeType>(["nacos-namespace", "nacos-access-control"]);
+const directNavigationTreeNodeTypes = new Set<TreeNodeType>(["consul-root", "consul-overview", "etcd-root", "etcd-dashboard", "etcd-access-control", "nacos-namespace", "nacos-access-control", "meilisearch-system"]);
+const repeatableNavigationTreeNodeTypes = new Set<TreeNodeType>(["etcd-root", "etcd-dashboard", "etcd-access-control", "nacos-namespace", "nacos-access-control"]);
 
 export function isDirectNavigationTreeNode(type: TreeNodeType): boolean {
   return directNavigationTreeNodeTypes.has(type);

--- a/apps/desktop/src/stores/__tests__/connectionStore.etcdAccess.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.etcdAccess.spec.ts
@@ -1,0 +1,183 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EtcdAuthPermission, KvValue } from "@/lib/backend/api";
+import type { ConnectionConfig, TreeNode } from "@/types/database";
+
+const utf8 = (data: string): KvValue => ({ encoding: "utf8", data });
+const readPermission: EtcdAuthPermission = { access: "read", key: utf8(""), rangeEnd: utf8("\0"), resource: "all" };
+
+function installLocalStorage() {
+  const data = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => data.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => data.set(key, value)),
+    removeItem: vi.fn((key: string) => data.delete(key)),
+  });
+}
+
+describe("connectionStore etcd access", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    installLocalStorage();
+    setActivePinia(createPinia());
+  });
+
+  async function loadEtcdTree(roles: string[], permissions: EtcdAuthPermission[] = [readPermission], options: { connection?: Partial<ConnectionConfig>; authEnabled?: boolean; authUser?: string; loadRoot?: boolean } = {}) {
+    const connection = {
+      id: "etcd-reader",
+      name: "restricted etcd",
+      db_type: "etcd",
+      host: "127.0.0.1",
+      port: 2379,
+      username: "reader",
+      password: "secret",
+      database: "",
+      ...options.connection,
+    } as ConnectionConfig;
+    const etcdAuthCall = vi.fn((_connectionId: string, operation: string, args: { user?: string; role?: string }) => {
+      if (operation === "user_get") return Promise.resolve({ user: args.user || options.authUser || "reader", roles, authEnabled: options.authEnabled ?? true });
+      if (operation === "role_get") return Promise.resolve({ role: args.role, permissions });
+      throw new Error(`Unexpected etcd auth operation: ${operation}`);
+    });
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      deleteSchemaCachePrefix: vi.fn().mockResolvedValue(undefined),
+      etcdAuthCall,
+      listInstalledAgents: vi.fn().mockResolvedValue([]),
+      loadSchemaCache: vi.fn().mockResolvedValue(null),
+      saveConnections: vi.fn().mockResolvedValue(undefined),
+      saveSchemaCache: vi.fn().mockResolvedValue(undefined),
+      saveSidebarLayout: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    const root: TreeNode = {
+      id: connection.id,
+      label: connection.name,
+      type: "connection",
+      connectionId: connection.id,
+      isExpanded: false,
+      children: [],
+    };
+    store.connections = [connection];
+    store.treeNodes = [root];
+    store.connectedIds.add(connection.id);
+
+    if (options.loadRoot !== false) await store.loadEtcdRoot(connection.id);
+    return { root, etcdAuthCall, store };
+  }
+
+  it("hides management views for a regular etcd user", async () => {
+    const { root, etcdAuthCall, store } = await loadEtcdTree(["reader-role"]);
+
+    expect(etcdAuthCall).toHaveBeenCalledWith("etcd-reader", "user_get", {});
+    expect(etcdAuthCall).toHaveBeenCalledWith("etcd-reader", "role_get", { role: "reader-role" });
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root"]);
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: false, writePermissions: [] });
+  });
+
+  it("shows management views only for the root role", async () => {
+    const { root } = await loadEtcdTree(["reader-role", "root"]);
+
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root", "etcd-access-control", "etcd-dashboard"]);
+  });
+
+  it("keeps Key mutations available to a non-admin role with write access", async () => {
+    const writePermission: EtcdAuthPermission = { access: "readwrite", key: utf8("/editable/"), rangeEnd: utf8("/editable0"), resource: "prefix" };
+    const { root, store } = await loadEtcdTree(["key-writer"], [writePermission]);
+
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root"]);
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: true, writePermissions: [writePermission] });
+    expect(store.canWriteEtcdKey("etcd-reader", "/editable/key")).toBe(true);
+    expect(store.canWriteEtcdKey("etcd-reader", "/readonly/key")).toBe(false);
+  });
+
+  it("loads capabilities without requiring the sidebar connection to be expanded", async () => {
+    const writePermission: EtcdAuthPermission = { access: "readwrite", key: utf8("/editable/"), rangeEnd: utf8("/editable0"), resource: "prefix" };
+    const { root, store } = await loadEtcdTree(["key-writer"], [writePermission], { loadRoot: false });
+
+    expect(root.isExpanded).toBe(false);
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: false, writePermissions: [] });
+
+    await store.ensureEtcdAccessCapabilities("etcd-reader", { force: true, verifyHealth: false });
+
+    expect(root.isExpanded).toBe(false);
+    expect(store.canWriteEtcdKey("etcd-reader", "/editable/key")).toBe(true);
+  });
+
+  it("preserves confirmed write permissions when a forced refresh fails transiently", async () => {
+    const writePermission: EtcdAuthPermission = { access: "readwrite", key: utf8("/editable/"), rangeEnd: utf8("/editable0"), resource: "prefix" };
+    const { etcdAuthCall, store } = await loadEtcdTree(["key-writer"], [writePermission]);
+
+    etcdAuthCall.mockRejectedValueOnce(new Error("temporary auth timeout"));
+    await store.ensureEtcdAccessCapabilities("etcd-reader", { force: true, verifyHealth: false });
+
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: true, writePermissions: [writePermission] });
+    expect(store.canWriteEtcdKey("etcd-reader", "/editable/key")).toBe(true);
+  });
+
+  it("preserves a confirmed root role when a forced refresh fails transiently", async () => {
+    const { etcdAuthCall, store } = await loadEtcdTree(["root"]);
+
+    etcdAuthCall.mockRejectedValueOnce(new Error("temporary auth timeout"));
+    await store.ensureEtcdAccessCapabilities("etcd-reader", { force: true, verifyHealth: false });
+
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: true, writable: true, writePermissions: null });
+  });
+
+  it("fails closed when initial capability discovery fails", async () => {
+    const { etcdAuthCall, store } = await loadEtcdTree(["key-writer"], [readPermission], { loadRoot: false });
+
+    etcdAuthCall.mockRejectedValueOnce(new Error("temporary auth timeout"));
+    await store.ensureEtcdAccessCapabilities("etcd-reader", { force: true, verifyHealth: false });
+
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: false, writePermissions: [] });
+  });
+
+  it("does not let a read grant inherit write access from another range", async () => {
+    const permissions: EtcdAuthPermission[] = [
+      { access: "read", key: utf8("/readonly/"), rangeEnd: utf8("/readonly0"), resource: "prefix" },
+      { access: "readwrite", key: utf8("/editable/"), rangeEnd: utf8("/editable0"), resource: "prefix" },
+    ];
+    const { store } = await loadEtcdTree(["mixed-role"], permissions);
+
+    expect(store.canWriteEtcdKey("etcd-reader", "/readonly/key")).toBe(false);
+    expect(store.canWriteEtcdKey("etcd-reader", "/editable/key")).toBe(true);
+  });
+
+  it("uses the agent's certificate identity for a restricted TLS user", async () => {
+    const { root, etcdAuthCall, store } = await loadEtcdTree(["cert-reader-role"], [readPermission], {
+      connection: { username: "", password: "", client_cert_path: "/tmp/cert.pem", client_key_path: "/tmp/key.pem" },
+      authUser: "cert-reader",
+    });
+
+    expect(etcdAuthCall).toHaveBeenCalledWith("etcd-reader", "user_get", {});
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root"]);
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: false, writePermissions: [] });
+  });
+
+  it("keeps certificate connections unrestricted when server auth is disabled", async () => {
+    const { root } = await loadEtcdTree([], [readPermission], {
+      connection: { username: "", password: "", client_cert_path: "/tmp/cert.pem", client_key_path: "/tmp/key.pem" },
+      authEnabled: false,
+      authUser: "transport-only-cert",
+    });
+
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root", "etcd-access-control", "etcd-dashboard"]);
+  });
+
+  it("keeps anonymous connections unrestricted when server auth is disabled", async () => {
+    const { root, etcdAuthCall, store } = await loadEtcdTree([], [readPermission], {
+      connection: { username: "", password: "", client_cert_path: "", client_key_path: "" },
+      authEnabled: false,
+      authUser: "",
+    });
+
+    expect(etcdAuthCall).toHaveBeenCalledWith("etcd-reader", "user_get", {});
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root", "etcd-access-control", "etcd-dashboard"]);
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: true, writable: true, writePermissions: null });
+  });
+});

--- a/apps/desktop/src/stores/__tests__/connectionStore.etcdAccess.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.etcdAccess.spec.ts
@@ -180,4 +180,38 @@ describe("connectionStore etcd access", () => {
     expect(root.children?.map((child) => child.type)).toEqual(["etcd-root", "etcd-access-control", "etcd-dashboard"]);
     expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: true, writable: true, writePermissions: null });
   });
+
+  it("queries the configured user when resolving etcd v2 capabilities", async () => {
+    const writePermission: EtcdAuthPermission = { access: "write", key: utf8("/editable/"), rangeEnd: utf8("/editable0"), resource: "prefix" };
+    const { root, etcdAuthCall, store } = await loadEtcdTree(["v2-writer"], [writePermission], {
+      connection: { driver_profile: "etcd-v2" },
+    });
+
+    expect(etcdAuthCall).toHaveBeenCalledWith("etcd-reader", "user_get", { user: "reader" });
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root"]);
+    expect(store.canWriteEtcdKey("etcd-reader", "/editable/key")).toBe(true);
+    expect(store.canWriteEtcdKey("etcd-reader", "/readonly/key")).toBe(false);
+  });
+
+  it("keeps anonymous etcd v2 Key operations available without probing an empty user", async () => {
+    const { root, etcdAuthCall, store } = await loadEtcdTree([], [readPermission], {
+      connection: { driver_profile: "etcd-v2", username: "", password: "" },
+    });
+
+    expect(etcdAuthCall).not.toHaveBeenCalled();
+    expect(root.children?.map((child) => child.type)).toEqual(["etcd-root"]);
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: true, writePermissions: null });
+  });
+
+  it("preserves etcd v2 Key operations when auth capability discovery is unavailable", async () => {
+    const { etcdAuthCall, store } = await loadEtcdTree(["v2-writer"], [readPermission], {
+      connection: { driver_profile: "etcd-v2" },
+      loadRoot: false,
+    });
+    etcdAuthCall.mockRejectedValueOnce(new Error("v2 auth endpoint unavailable"));
+
+    await store.ensureEtcdAccessCapabilities("etcd-reader", { force: true, verifyHealth: false });
+
+    expect(store.getEtcdAccessCapabilities("etcd-reader")).toEqual({ admin: false, writable: true, writePermissions: null });
+  });
 });

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -207,6 +207,7 @@ export interface EtcdAccessCapabilities {
 
 const unrestrictedEtcdAccess: EtcdAccessCapabilities = { admin: true, writable: true, writePermissions: null };
 const restrictedEtcdAccess: EtcdAccessCapabilities = { admin: false, writable: false, writePermissions: [] };
+const fallbackEtcdV2Access: EtcdAccessCapabilities = { admin: false, writable: true, writePermissions: null };
 
 function usesShardingSphereLogicalTables(databaseInfo: DatabaseConnectionInfo | undefined): boolean {
   return databaseInfo?.productVersion?.toLowerCase().includes(SHARDINGSPHERE_PROXY_VERSION_MARKER) === true;
@@ -682,7 +683,7 @@ export const useConnectionStore = defineStore("connection", () => {
     // auth-enabled cluster, so keep privileged controls hidden until the
     // agent reports the effective identity and authentication status.
     if (username === "root") return unrestrictedEtcdAccess;
-    return etcdAccessCapabilities.value[connectionId] ?? restrictedEtcdAccess;
+    return etcdAccessCapabilities.value[connectionId] ?? (config.driver_profile === "etcd-v2" ? fallbackEtcdV2Access : restrictedEtcdAccess);
   }
 
   function canWriteEtcdKey(connectionId: string, key: string, keyBytes?: api.KvValue | null): boolean {
@@ -695,10 +696,16 @@ export const useConnectionStore = defineStore("connection", () => {
   async function resolveEtcdAccessCapabilities(connectionId: string, config: ConnectionConfig | undefined): Promise<EtcdAccessCapabilities> {
     const username = config?.username?.trim() || "";
     if (username === "root") return unrestrictedEtcdAccess;
+    // The v2 auth API cannot resolve the identity behind the active HTTP
+    // connection. Query an explicitly configured user, while anonymous v2
+    // connections retain their historical Key access and rely on the server
+    // as the authorization boundary.
+    if (config?.driver_profile === "etcd-v2" && !username) return fallbackEtcdV2Access;
     // An empty user asks the agent for the authenticated identity. This also
     // covers client-certificate CN authentication without duplicating X.509
     // parsing in the UI.
-    const user = await api.etcdAuthCall<api.EtcdAuthUserDetail>(connectionId, "user_get", {});
+    const userParams = config?.driver_profile === "etcd-v2" ? { user: username } : {};
+    const user = await api.etcdAuthCall<api.EtcdAuthUserDetail>(connectionId, "user_get", userParams);
     if (user.authEnabled === false) return unrestrictedEtcdAccess;
     if (user.roles.includes("root")) return unrestrictedEtcdAccess;
     const roles = await Promise.all(user.roles.map((role) => api.etcdAuthCall<api.EtcdAuthRoleDetail>(connectionId, "role_get", { role })));
@@ -728,10 +735,13 @@ export const useConnectionStore = defineStore("connection", () => {
       try {
         access = await resolveEtcdAccessCapabilities(connectionId, currentConfig);
       } catch {
-        // Initial discovery fails closed. Once a capability snapshot has been
-        // confirmed, however, a transient Auth RPC failure must not overwrite
-        // it and make controls flicker between writable/admin and read-only.
-        access = etcdAccessCapabilities.value[connectionId] ?? restrictedEtcdAccess;
+        // Initial v3 discovery fails closed. Once a capability snapshot has
+        // been confirmed, however, a transient Auth RPC failure must not
+        // overwrite it and make controls flicker between states.
+        // The v2 API cannot discover an implicit current user, so preserve its
+        // pre-capability behavior on discovery errors and let etcd authorize
+        // each Key mutation. Administrative views remain hidden.
+        access = etcdAccessCapabilities.value[connectionId] ?? (currentConfig.driver_profile === "etcd-v2" ? fallbackEtcdV2Access : restrictedEtcdAccess);
       }
       if (generation === (etcdAccessCapabilityGenerations.get(connectionId) ?? 0) && connectedIds.value.has(connectionId) && connectionConfigFingerprint(getConfig(connectionId) ?? currentConfig) === configFingerprint) {
         etcdAccessCapabilities.value = { ...etcdAccessCapabilities.value, [connectionId]: access };

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -140,6 +140,7 @@ import { isMongoLegacyDriverProfile } from "@/lib/mongo/mongoCapabilities";
 import { mongoCollectionKindFromNode, toMongoCollectionKind, visibleMongoCollections } from "@/lib/sidebar/mongoCollectionMutation";
 import { completionSchemasFromTree, completionTablesFromTree } from "@/lib/metadata/completionTreeIndex";
 import { kvRootNodeLabel } from "@/lib/kv/kvRootPresentation";
+import { etcdPermissionsAllowKey } from "@/lib/etcd/keyPermissions";
 import { REDIS_SCAN_PAGE_SIZE_DEFAULT } from "@/lib/redis/redisKeyPattern";
 import { normalizeRedisDatabaseAliases, redisDatabaseAlias, redisDatabaseLabel } from "@/lib/redis/redisDatabaseAlias";
 import { normalizeRedisKeyTemplates } from "@/lib/redis/redisKeyTemplates";
@@ -194,6 +195,18 @@ const MONGO_LEGACY_DRIVER_LABEL = "MongoDB (Legacy)";
 const XUGU_TABLE_CHILD_METADATA_AGENT_VERSION = "0.1.23";
 const SUPERSEDED_CONNECTION_ATTEMPT_MESSAGE = "Connection attempt was superseded by a newer attempt";
 const SHARDINGSPHERE_PROXY_VERSION_MARKER = "shardingsphere-proxy";
+
+export interface EtcdAccessCapabilities {
+  /** May access cluster-wide administration APIs such as status and leases. */
+  admin: boolean;
+  /** Has at least one etcd role that permits writes to a Key range. */
+  writable: boolean;
+  /** Null means unrestricted; otherwise writes are limited to these etcd ranges. */
+  writePermissions: api.EtcdAuthPermission[] | null;
+}
+
+const unrestrictedEtcdAccess: EtcdAccessCapabilities = { admin: true, writable: true, writePermissions: null };
+const restrictedEtcdAccess: EtcdAccessCapabilities = { admin: false, writable: false, writePermissions: [] };
 
 function usesShardingSphereLogicalTables(databaseInfo: DatabaseConnectionInfo | undefined): boolean {
   return databaseInfo?.productVersion?.toLowerCase().includes(SHARDINGSPHERE_PROXY_VERSION_MARKER) === true;
@@ -441,6 +454,9 @@ export const useConnectionStore = defineStore("connection", () => {
   const activePinnedTreeNodeReorderKey = ref<string | null>(null);
   let pinnedTreeNodePersistQueue: Promise<void> = Promise.resolve();
   const connectedIds = ref<Set<string>>(new Set());
+  const etcdAccessCapabilities = ref<Record<string, EtcdAccessCapabilities>>({});
+  const etcdAccessCapabilityGenerations = new Map<string, number>();
+  const etcdAccessCapabilityLoads = new Map<string, Promise<EtcdAccessCapabilities>>();
   const identifierQuotes = ref<Record<string, string>>({});
   const lastConnectionHealthCheckAt = ref<Record<string, number>>({});
   const agentDrivers = ref<AgentDriverInstallState[]>([]);
@@ -655,6 +671,90 @@ export const useConnectionStore = defineStore("connection", () => {
 
   function getConfig(connectionId: string) {
     return configById.value.get(connectionId);
+  }
+
+  function getEtcdAccessCapabilities(connectionId: string): EtcdAccessCapabilities {
+    const config = getConfig(connectionId);
+    if (config?.db_type !== "etcd") return unrestrictedEtcdAccess;
+    const username = config.username?.trim() || "";
+    // Only an explicitly configured root user can be trusted before probing
+    // the server. Anonymous and certificate connections may still target an
+    // auth-enabled cluster, so keep privileged controls hidden until the
+    // agent reports the effective identity and authentication status.
+    if (username === "root") return unrestrictedEtcdAccess;
+    return etcdAccessCapabilities.value[connectionId] ?? restrictedEtcdAccess;
+  }
+
+  function canWriteEtcdKey(connectionId: string, key: string, keyBytes?: api.KvValue | null): boolean {
+    const access = getEtcdAccessCapabilities(connectionId);
+    if (!access.writable) return false;
+    if (access.writePermissions === null) return true;
+    return etcdPermissionsAllowKey(access.writePermissions, keyBytes ?? { encoding: "utf8", data: key });
+  }
+
+  async function resolveEtcdAccessCapabilities(connectionId: string, config: ConnectionConfig | undefined): Promise<EtcdAccessCapabilities> {
+    const username = config?.username?.trim() || "";
+    if (username === "root") return unrestrictedEtcdAccess;
+    // An empty user asks the agent for the authenticated identity. This also
+    // covers client-certificate CN authentication without duplicating X.509
+    // parsing in the UI.
+    const user = await api.etcdAuthCall<api.EtcdAuthUserDetail>(connectionId, "user_get", {});
+    if (user.authEnabled === false) return unrestrictedEtcdAccess;
+    if (user.roles.includes("root")) return unrestrictedEtcdAccess;
+    const roles = await Promise.all(user.roles.map((role) => api.etcdAuthCall<api.EtcdAuthRoleDetail>(connectionId, "role_get", { role })));
+    const writePermissions = roles.flatMap((role) => role.permissions.filter((permission) => permission.access === "write" || permission.access === "readwrite"));
+    return {
+      admin: false,
+      writable: writePermissions.length > 0,
+      writePermissions,
+    };
+  }
+
+  async function ensureEtcdAccessCapabilities(connectionId: string, options: { force?: boolean; verifyHealth?: boolean } = {}): Promise<EtcdAccessCapabilities> {
+    const config = getConfig(connectionId);
+    if (config?.db_type !== "etcd") return unrestrictedEtcdAccess;
+    const cached = etcdAccessCapabilities.value[connectionId];
+    if (cached && !options.force) return cached;
+    const existing = etcdAccessCapabilityLoads.get(connectionId);
+    if (existing) return existing;
+
+    const load = (async () => {
+      await ensureConnected(connectionId, { verifyHealth: options.verifyHealth ?? false });
+      const currentConfig = getConfig(connectionId);
+      if (currentConfig?.db_type !== "etcd") return unrestrictedEtcdAccess;
+      const generation = etcdAccessCapabilityGenerations.get(connectionId) ?? 0;
+      const configFingerprint = connectionConfigFingerprint(currentConfig);
+      let access: EtcdAccessCapabilities;
+      try {
+        access = await resolveEtcdAccessCapabilities(connectionId, currentConfig);
+      } catch {
+        // Initial discovery fails closed. Once a capability snapshot has been
+        // confirmed, however, a transient Auth RPC failure must not overwrite
+        // it and make controls flicker between writable/admin and read-only.
+        access = etcdAccessCapabilities.value[connectionId] ?? restrictedEtcdAccess;
+      }
+      if (generation === (etcdAccessCapabilityGenerations.get(connectionId) ?? 0) && connectedIds.value.has(connectionId) && connectionConfigFingerprint(getConfig(connectionId) ?? currentConfig) === configFingerprint) {
+        etcdAccessCapabilities.value = { ...etcdAccessCapabilities.value, [connectionId]: access };
+        return access;
+      }
+      return getEtcdAccessCapabilities(connectionId);
+    })();
+    etcdAccessCapabilityLoads.set(connectionId, load);
+    try {
+      return await load;
+    } finally {
+      if (etcdAccessCapabilityLoads.get(connectionId) === load) etcdAccessCapabilityLoads.delete(connectionId);
+    }
+  }
+
+  function clearEtcdAccessCapabilities(connectionId: string) {
+    etcdAccessCapabilityGenerations.set(connectionId, (etcdAccessCapabilityGenerations.get(connectionId) ?? 0) + 1);
+    etcdAccessCapabilityLoads.delete(connectionId);
+    if (connectionId in etcdAccessCapabilities.value) {
+      const next = { ...etcdAccessCapabilities.value };
+      delete next[connectionId];
+      etcdAccessCapabilities.value = next;
+    }
   }
 
   function connectionIdentifierQuote(connectionId?: string): string | undefined {
@@ -1099,6 +1199,7 @@ export const useConnectionStore = defineStore("connection", () => {
 
   function markConnectionLost(connectionId: string, error: unknown) {
     connectedIds.value.delete(connectionId);
+    clearEtcdAccessCapabilities(connectionId);
     clearSidebarStorageCaches(connectionId);
     clearPrimaryVisibleObjectNames(connectionId);
     clearConnectionIdentifierQuote(connectionId);
@@ -3233,6 +3334,7 @@ export const useConnectionStore = defineStore("connection", () => {
     for (const id of removedIds) {
       clearConnectionError(id);
       connectionErrorRevisions.delete(id);
+      clearEtcdAccessCapabilities(id);
       connectedIds.value.delete(id);
       clearSidebarStorageCaches(id);
       clearPrimaryVisibleObjectNames(id);
@@ -3273,6 +3375,7 @@ export const useConnectionStore = defineStore("connection", () => {
     syncTimeoutInheritanceBackup();
     rebuildTreeNodes();
     if (!runtimeConfigChanged) return;
+    clearEtcdAccessCapabilities(config.id);
     clearPrimaryVisibleObjectNames(config.id);
     connectedIds.value.delete(config.id);
     clearSidebarStorageCaches(config.id);
@@ -3804,6 +3907,7 @@ export const useConnectionStore = defineStore("connection", () => {
     if (!cancelled) return false;
     clearConnectionError(connectionId);
     connectedIds.value.delete(connectionId);
+    clearEtcdAccessCapabilities(connectionId);
     clearSidebarStorageCaches(connectionId);
     clearPrimaryVisibleObjectNames(connectionId);
     clearConnectionIdentifierQuote(connectionId);
@@ -3824,6 +3928,7 @@ export const useConnectionStore = defineStore("connection", () => {
     cancelLocalConnectionAttempt(connectionId);
 
     connectedIds.value.delete(connectionId);
+    clearEtcdAccessCapabilities(connectionId);
     clearSidebarStorageCaches(connectionId);
     clearPrimaryVisibleObjectNames(connectionId);
     clearConnectionIdentifierQuote(connectionId);
@@ -3948,6 +4053,7 @@ export const useConnectionStore = defineStore("connection", () => {
         cancelObjectMetadataLoadsForConnection(connectionId);
         clearMetadataRuntimeCacheForConnection(connectionId);
         connectedIds.value.delete(connectionId);
+        clearEtcdAccessCapabilities(connectionId);
         clearPrimaryVisibleObjectNames(connectionId);
         clearConnectionHealthCheck(connectionId);
         if (activeConnectionId.value === connectionId) activeConnectionId.value = null;
@@ -4483,42 +4589,41 @@ export const useConnectionStore = defineStore("connection", () => {
       load = reclaimTreeNodeLoad(load, node);
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
-      setChildren(
-        targetNode,
-        withSavedSqlRoot(
+      const etcdAccess = await ensureEtcdAccessCapabilities(connectionId, { force: true, verifyHealth: false });
+      const children: TreeNode[] = [
+        {
+          id: `${connectionId}:etcd`,
+          label: kvRootNodeLabel("etcd"),
+          type: "etcd-root" as const,
           connectionId,
-          [
-            {
-              id: `${connectionId}:etcd`,
-              label: kvRootNodeLabel("etcd"),
-              type: "etcd-root" as const,
-              connectionId,
-              database: "",
-              isExpanded: false,
-              children: [],
-            },
-            {
-              id: `${connectionId}:etcd-access-control`,
-              label: "用户和角色",
-              type: "etcd-access-control" as const,
-              connectionId,
-              database: "",
-              isExpanded: false,
-              children: [],
-            },
-            {
-              id: `${connectionId}:etcd-dashboard`,
-              label: "服务仪表盘",
-              type: "etcd-dashboard" as const,
-              connectionId,
-              database: "",
-              isExpanded: false,
-              children: [],
-            },
-          ],
-          targetNode,
-        ),
-      );
+          database: "",
+          isExpanded: false,
+          children: [],
+        },
+      ];
+      if (etcdAccess.admin) {
+        children.push(
+          {
+            id: `${connectionId}:etcd-access-control`,
+            label: "用户和角色",
+            type: "etcd-access-control" as const,
+            connectionId,
+            database: "",
+            isExpanded: false,
+            children: [],
+          },
+          {
+            id: `${connectionId}:etcd-dashboard`,
+            label: "服务仪表盘",
+            type: "etcd-dashboard" as const,
+            connectionId,
+            database: "",
+            isExpanded: false,
+            children: [],
+          },
+        );
+      }
+      setChildren(targetNode, withSavedSqlRoot(connectionId, children, targetNode));
       targetNode.isExpanded = true;
     } catch (e) {
       recordMetadataLoadError(connectionId, e, load);
@@ -8861,6 +8966,9 @@ export const useConnectionStore = defineStore("connection", () => {
     connectionGroupOptions,
     selectedConnectionGroupId,
     getConfig,
+    getEtcdAccessCapabilities,
+    ensureEtcdAccessCapabilities,
+    canWriteEtcdKey,
     connectionIdentifierQuote,
     isTreeNodePinned,
     orderByPinnedTreeNodes,


### PR DESCRIPTION
## 变更说明

修复 etcd 开启认证后，普通用户虽然能够成功测试连接，但无法正常浏览和操作授权范围内 Key 的问题。

主要改动：

- etcd v3 Agent 根据配置用户名或客户端证书 CN 确定当前身份，并读取角色的 Key 权限范围。
- 将普通用户的可读权限拆分成合法区间分别查询，合并结果后完成排序、分页及快照 Revision 固定，避免请求无权限的全局范围。
- 根据角色写权限控制 Key 的新建、编辑、重命名、删除、导入和同步操作。
- 普通用户仅展示 Key 管理和搜索相关功能，隐藏用户与角色、服务仪表盘、维护及租约等管理功能。
- Key 监听直接从目标 Key 或 Prefix 获取 Revision，不再预先访问无权限的集群状态或全局 Key 范围。
- 修复 etcd 状态结果缺少 `errors` 字段导致 root 用户仪表盘反序列化失败的问题。
- 修复左侧 etcd 功能入口偶发单击不切换，以及双击事件取消待完成导航的问题。
- 兼容 etcd v2：
  - 已配置用户时使用实际用户名查询角色权限。
  - 匿名连接或权限探测不可用时保留 Key 操作，由 etcd 服务端执行最终鉴权。
  - 非管理员连接继续隐藏管理入口。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="2206" height="868" alt="9355E51F-6500-4B94-96E0-37D8AB9E6876" src="https://github.com/user-attachments/assets/f76c843f-d025-4ad3-a579-d8127a6a1b94" />


## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `env -u GOROOT GOCACHE=/private/tmp/dbx-etcd-go-cache go test -count=1 ./...`
  - etcd v3 Agent 测试通过。
- `env CI=true pnpm exec vitest run --maxWorkers=4`
  - 1253 个测试文件、12329 个测试通过；该次全量测试执行于最后的 v2 兼容补丁之前。
- `env CI=true pnpm exec vitest run apps/desktop/src/stores/__tests__/connectionStore.etcdAccess.spec.ts apps/desktop/src/components/etcd/__tests__/EtcdKeyBrowser.spec.ts apps/desktop/src/lib/etcd/__tests__/keyPermissions.spec.ts --maxWorkers=2`
  - 最终代码状态下 3 个测试文件、30 个测试通过。
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
  - 通过。
- `git diff --check`
  - 通过。

未执行：

- `make check`
- `make cargo-check-fast`，本次没有 Rust 代码改动。

## 关联 Issue

Close #7897