### PR TITLE
fix(transfer): preserve constraints after deferred foreign keys

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -4958,11 +4958,10 @@ fn transfer_ddl_statements(sql: &str, db_type: &DatabaseType) -> Vec<String> {
 }
 
 /// Strips inline `CONSTRAINT ... FOREIGN KEY ... REFERENCES ...` lines from a
-/// `CREATE TABLE` statement, fixing up the now-dangling trailing comma on the
-/// preceding line. Dialect-agnostic: relies only on the ` FOREIGN KEY ` clause
-/// text, which both Postgres and MySQL-family `SHOW CREATE TABLE` output share,
-/// and on foreign key constraints always being the last items before the closing
-/// paren (true for both dialects' DDL dumps).
+/// `CREATE TABLE` statement, fixing up a trailing comma only when removing the
+/// foreign key leaves one immediately before the table's closing parenthesis.
+/// Dialect-agnostic: relies only on the definition-line shape shared by Postgres
+/// and MySQL-family DDL dumps.
 ///
 /// Only genuine constraint definition lines match (`CONSTRAINT <name> FOREIGN
 /// KEY (` / bare `FOREIGN KEY (`); a column line whose COMMENT or DEFAULT text
@@ -4973,18 +4972,26 @@ fn strip_inline_foreign_key_constraint_lines(statement: &str) -> String {
     }
 
     let mut lines: Vec<String> = Vec::new();
+    let mut removed_foreign_key = false;
     for line in statement.lines() {
         if INLINE_FOREIGN_KEY_CONSTRAINT_LINE_RE.is_match(line) {
-            if let Some(previous) = lines.last_mut() {
-                let trimmed_len = previous.trim_end_matches(char::is_whitespace).len();
-                if previous[..trimmed_len].ends_with(',') {
-                    previous.truncate(trimmed_len - 1);
-                }
-            }
+            removed_foreign_key = true;
             continue;
         }
         lines.push(line.to_string());
     }
+
+    if removed_foreign_key {
+        if let Some(closing_index) = lines.iter().rposition(|line| line.trim_start().starts_with(')')) {
+            if let Some(previous) = lines[..closing_index].iter_mut().rfind(|line| !line.trim().is_empty()) {
+                let trimmed_len = previous.trim_end_matches(char::is_whitespace).len();
+                if previous[..trimmed_len].ends_with(',') {
+                    previous.remove(trimmed_len - 1);
+                }
+            }
+        }
+    }
+
     lines.join("\n")
 }
 
@@ -10533,6 +10540,30 @@ mod tests {
         assert_eq!(
             statements,
             vec!["CREATE TABLE \"public\".\"audit_logs\" (\n  \"id\" integer,\n  \"user_id\" integer\n)".to_string()]
+        );
+    }
+
+    #[test]
+    fn postgres_transfer_ddl_preserves_constraint_after_inline_foreign_key() {
+        let ddl = "CREATE TABLE \"source_7931\".\"dbx_child\" (\n  \"id\" integer NOT NULL,\n  \"parent_id\" integer NOT NULL,\n  \"status\" integer NOT NULL,\n  CONSTRAINT \"dbx_child_parent_fk\" FOREIGN KEY (\"parent_id\") REFERENCES \"source_7931\".\"dbx_parent\"(\"id\"),\n  CONSTRAINT \"dbx_child_status_check\" CHECK (status >= 0)\n);";
+
+        let statements = transfer_ddl_statements(ddl, &DatabaseType::Postgres);
+
+        assert_eq!(
+            statements,
+            vec!["CREATE TABLE \"source_7931\".\"dbx_child\" (\n  \"id\" integer NOT NULL,\n  \"parent_id\" integer NOT NULL,\n  \"status\" integer NOT NULL,\n  CONSTRAINT \"dbx_child_status_check\" CHECK (status >= 0)\n)".to_string()]
+        );
+    }
+
+    #[test]
+    fn postgres_transfer_ddl_removes_multiple_inline_foreign_keys_without_damaging_retained_items() {
+        let ddl = "CREATE TABLE \"public\".\"assignments\" (\n  \"id\" integer NOT NULL,\n  \"owner_id\" integer NOT NULL,\n  \"reviewer_id\" integer NOT NULL,\n  CONSTRAINT \"assignments_owner_fk\" FOREIGN KEY (\"owner_id\") REFERENCES \"users\"(\"id\"),\n  CONSTRAINT \"assignments_owner_check\" CHECK (owner_id > 0),\n  CONSTRAINT \"assignments_reviewer_fk\" FOREIGN KEY (\"reviewer_id\") REFERENCES \"users\"(\"id\"),\n  CONSTRAINT \"assignments_owner_reviewer_unique\" UNIQUE (\"owner_id\", \"reviewer_id\")\n);";
+
+        let statements = transfer_ddl_statements(ddl, &DatabaseType::Postgres);
+
+        assert_eq!(
+            statements,
+            vec!["CREATE TABLE \"public\".\"assignments\" (\n  \"id\" integer NOT NULL,\n  \"owner_id\" integer NOT NULL,\n  \"reviewer_id\" integer NOT NULL,\n  CONSTRAINT \"assignments_owner_check\" CHECK (owner_id > 0),\n  CONSTRAINT \"assignments_owner_reviewer_unique\" UNIQUE (\"owner_id\", \"reviewer_id\")\n)".to_string()]
         );
     }
 


### PR DESCRIPTION
## 变更说明

修复 PostgreSQL 数据传输在延迟创建外键时可能生成无效建表语句的问题。当内联外键后仍有 `CHECK`、`UNIQUE` 等约束时，原逻辑会错误移除前一个保留定义末尾的逗号，导致后续约束前出现 SQL 语法错误。

- 分两阶段处理 PostgreSQL 建表 DDL：先移除需要延迟创建的内联外键，再仅修复右括号前最后一个保留定义的尾逗号
- 保留外键之后的 `CHECK`、`UNIQUE` 等表级约束及其必要分隔符
- 继续使用锚定规则识别真实外键约束，避免误删注释或字段定义中仅包含 `FOREIGN KEY` 文本的内容
- 补充外键后跟 `CHECK`、多个外键与 `CHECK`/`UNIQUE` 混排等回归测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端改动。以下录屏用于展示 PostgreSQL 数据传输的手动端到端验证结果。

### PostgreSQL 数据传输验证

https://github.com/user-attachments/assets/883aa0f3-e14e-40e6-a306-2b02181523fc

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成 PostgreSQL 16.14 手动验证：

- 修复前，带有内联外键且其后存在 `CHECK` 约束的子表会在 `CONSTRAINT` 附近发生建表语法错误
- 修复后成功传输 2/2 张表及 2/2 行数据，源端与目标端数据一致
- 目标端外键正确指向目标 schema 中的父表，`CHECK (status >= 0)` 约束也能正确拒绝非法数据

相关测试：

- `cargo test -p dbx-core postgres_transfer_ddl --lib`
- `cargo test -p dbx-core keeps_columns_whose_comment_mentions_foreign_key --lib`
- `cargo test -p dbx-core strips_only_foreign_key_constraint_lines_regardless_of_other_mentions --lib`

## 关联 Issue

Close #7931
