### PR TITLE
fix(editor): anchor wrapped line numbers via inline style

### DIFF
--- a/apps/desktop/src/lib/__tests__/editorThemes.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editorThemes.spec.ts
@@ -175,7 +175,7 @@ describe("SQL completion theme", () => {
 });
 
 describe("editor gutters", () => {
-  it("anchors line numbers to the first visual row of wrapped lines", () => {
+  it("keeps single line numbers vertically centered in the base rule", () => {
     const rules = buildEditorFontThemeRules();
 
     expect(rules[".cm-lineNumbers .cm-gutterElement"]).toMatchObject({
@@ -183,6 +183,5 @@ describe("editor gutters", () => {
       display: "flex",
       justifyContent: "flex-end",
     });
-    expect(rules[".cm-lineNumbers .cm-gutterElement.cm-db-wrapped-line-number"]).toMatchObject({ alignItems: "flex-start" });
   });
 });

--- a/apps/desktop/src/lib/editor/__tests__/queryEditorLineNumbers.spec.ts
+++ b/apps/desktop/src/lib/editor/__tests__/queryEditorLineNumbers.spec.ts
@@ -2,7 +2,7 @@
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView, GutterMarker, gutter, lineNumbers } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildQueryEditorLineNumbersExtension, isWrappedLineNumberGutter } from "@/lib/editor/queryEditorLineNumbers";
+import { buildQueryEditorLineNumbersExtension, isWrappedLineNumberGutter, setQueryEditorLineNumberAlignment } from "@/lib/editor/queryEditorLineNumbers";
 
 class StatementRunMarker extends GutterMarker {}
 
@@ -45,6 +45,21 @@ describe("query editor line numbers", () => {
     expect(isWrappedLineNumberGutter(20.8, 20.8)).toBe(false);
     expect(isWrappedLineNumberGutter(21.6, 20.8)).toBe(false);
     expect(isWrappedLineNumberGutter(42, 20.8)).toBe(true);
+  });
+
+  it("keeps wrapped-line alignment when CodeMirror rebuilds a gutter marker class", () => {
+    const element = document.createElement("div");
+    element.className = "cm-gutterElement";
+
+    setQueryEditorLineNumberAlignment(element, true);
+    // GutterElement#setMarkers owns and replaces className for active-line and
+    // selection marker changes. The measured alignment must survive it.
+    element.className = "cm-gutterElement cm-activeLineGutter";
+
+    expect(element.style.alignItems).toBe("flex-start");
+
+    setQueryEditorLineNumberAlignment(element, false);
+    expect(element.style.alignItems).toBe("");
   });
 
   it("keeps line selection behavior when enabled", () => {

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -810,6 +810,10 @@ export function buildEditorFontThemeRules(opts?: { fixedHeight?: boolean; scroll
       width: "1px",
       zIndex: "10",
     },
+    // Single lines render vertically centered here. Wrapped lines are anchored
+    // to the first visual row by createQueryEditorLineNumberAlignmentExtension,
+    // which sets an inline `align-items: flex-start` (inline style survives
+    // CodeMirror's className rebuild, unlike a toggled class).
     ".cm-lineNumbers .cm-gutterElement": {
       alignItems: "center",
       cursor: "pointer",
@@ -817,9 +821,6 @@ export function buildEditorFontThemeRules(opts?: { fixedHeight?: boolean; scroll
       justifyContent: "flex-end",
       paddingRight: "8px",
       userSelect: "none",
-    },
-    ".cm-lineNumbers .cm-gutterElement.cm-db-wrapped-line-number": {
-      alignItems: "flex-start",
     },
     ".cm-run-statement-gutter": {
       minWidth: "28px",

--- a/apps/desktop/src/lib/editor/queryEditorLineNumbers.ts
+++ b/apps/desktop/src/lib/editor/queryEditorLineNumbers.ts
@@ -4,14 +4,19 @@ import type { lineNumbers } from "@codemirror/view";
 type LineNumbersFactory = typeof lineNumbers;
 type LineNumbersConfig = NonNullable<Parameters<LineNumbersFactory>[0]>;
 
-export const WRAPPED_LINE_NUMBER_GUTTER_CLASS = "cm-db-wrapped-line-number";
-
 export function isWrappedLineNumberGutter(gutterHeight: number, lineHeight: number): boolean {
   return gutterHeight > lineHeight + 1;
 }
 
 export function buildQueryEditorLineNumbersExtension(factory: LineNumbersFactory | null, enabled: boolean, config: LineNumbersConfig): Extension {
   return enabled && factory ? factory(config) : [];
+}
+
+export function setQueryEditorLineNumberAlignment(element: HTMLElement, wrapped: boolean): void {
+  // CodeMirror rebuilds gutter class names as marker state changes. Keep this
+  // measured layout state inline so selection and active-line updates cannot
+  // restore the base centered alignment for a wrapped line.
+  element.style.alignItems = wrapped ? "flex-start" : "";
 }
 
 export function createQueryEditorLineNumberAlignmentExtension(ViewPlugin: typeof import("@codemirror/view").ViewPlugin): Extension {
@@ -44,7 +49,7 @@ export function createQueryEditorLineNumberAlignmentExtension(ViewPlugin: typeof
           },
           write: (measurements) => {
             this.measureScheduled = false;
-            for (const { element, wrapped } of measurements) element.classList.toggle(WRAPPED_LINE_NUMBER_GUTTER_CLASS, wrapped);
+            for (const { element, wrapped } of measurements) setQueryEditorLineNumberAlignment(element, wrapped);
           },
         });
       }


### PR DESCRIPTION
## Problem

Fixes #7920.

In the query editor, the line number of a soft-wrapped line drifts between
two alignments: anchored to the first visual row for a while, then reverting
to vertically centered over the whole wrapped block, then top-anchored again.
The reversion is triggered by selection changes / cursor movement /
active-line refreshes; scrolling, editing or resizing restores the correct
alignment. Single-line numbers must stay vertically centered.

## Root cause

Line-number gutter elements are styled `align-items: center`, and the query
editor's measuring ViewPlugin temporarily added a `cm-db-wrapped-line-number`
class (`align-items: flex-start`) to wrapped ones. CodeMirror rebuilds the
gutter element's `className` from its markers on every marker update
(`GutterElement#setMarkers` in @codemirror/view), which wipes that toggled
class on active-line and selection updates. The plugin only re-measured on
doc/geometry/viewport changes — not on selection updates — so the class was
not re-added immediately, leaving the number centered until the next
scroll/edit/resize.

## Fix

Anchor only wrapped lines by writing an inline `align-items: flex-start`
from the measuring plugin instead of toggling a class
(`setQueryEditorLineNumberAlignment`). `setMarkers` rewrites `className` but
never touches `element.style`, so the wrapped-line alignment survives
selection/active-line updates and viewport virtualization without widening
the re-measure triggers. Single lines keep the theme's centered rule — the
inline style is cleared for them — so their appearance is unchanged.

Removed the now-unused `cm-db-wrapped-line-number` theme rule and added a
regression test proving the alignment survives a gutter className rebuild.
`buildQueryEditorLineNumbersExtension` (show/hide toggle + line-selection
`mousedown`) is unchanged.

## Compatibility

- Single lines: vertically centered, visually unchanged.
- Wrapped lines: anchored to the first visual row, stable under interaction.
- Other gutters (statement run, fold) untouched.
- No database / persistence / public API impact.

## Validation

- `pnpm exec vitest run .../queryEditorLineNumbers.spec.ts .../editorThemes.spec.ts` — passed (18/18)
- `pnpm exec oxlint --vue-plugin` (4 changed files) — passed
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json` — passed
- `git diff --check` — passed
- Visual check in the running editor (wrapped line number stays top-anchored
  while moving the cursor / changing selection; single lines centered) — passed

## Known limitations

None.