### PR TITLE
fix(tabs): prevent trackpad taps from starting tab drag

### DIFF
--- a/apps/desktop/src/components/layout/AppTabBar.vue
+++ b/apps/desktop/src/components/layout/AppTabBar.vue
@@ -722,7 +722,7 @@ function handleTabMouseDown(event: PointerEvent, tabId: string) {
     // Don't preventDefault touch pointerdowns: that would cancel the tab
     // strip's native horizontal scroll, which is how touch users browse an
     // overflowing tab bar.
-    if (event.pointerType !== "touch") event.preventDefault();
+    if (event.pointerType !== "touch" && (event.buttons & 1) === 1) event.preventDefault();
   }
   if (isManualTabOrder.value) tabDrag.startDrag(event, tabId);
 }

--- a/apps/desktop/src/composables/__tests__/useTabDrag.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useTabDrag.spec.ts
@@ -12,20 +12,20 @@ function createDragHarness(onDrop = vi.fn(() => true)) {
   return { drag, source, onDrop };
 }
 
-function beginDrag(source: HTMLElement, x = 100, y = 20, pointerType = "mouse") {
-  source.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, clientX: x, clientY: y, pointerType }));
+function beginDrag(source: HTMLElement, x = 100, y = 20, pointerType = "mouse", buttons = 1, pointerId = 1) {
+  source.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, buttons, clientX: x, clientY: y, pointerId, pointerType }));
 }
 
-function movePointer(x: number, y = 20, pointerType = "mouse") {
-  document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, clientX: x, clientY: y, pointerType }));
+function movePointer(x: number, y = 20, pointerType = "mouse", buttons = 1, pointerId = 1) {
+  document.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, buttons, clientX: x, clientY: y, pointerId, pointerType }));
 }
 
-function releasePointer(x = 0, y = 0) {
-  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, clientX: x, clientY: y, screenX: x, screenY: y }));
+function releasePointer(x = 0, y = 0, pointerId = 1) {
+  document.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, clientX: x, clientY: y, pointerId, screenX: x, screenY: y }));
 }
 
-function cancelPointer() {
-  document.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true }));
+function cancelPointer(pointerId = 1) {
+  document.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true, pointerId }));
 }
 
 function enterDropTarget(drag: ReturnType<typeof useTabDrag>, tabId = "target", x = 10) {
@@ -95,6 +95,20 @@ describe("useTabDrag", () => {
     expect(drag.state.suppressClick).toBe(false);
   });
 
+  it("clears completed-drag click suppression on a later trackpad tap", () => {
+    const { drag, source } = createDragHarness();
+    beginDrag(source);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD);
+    enterDropTarget(drag, "target", 90);
+    releasePointer();
+    expect(drag.state.suppressClick).toBe(true);
+
+    beginDrag(source, 100, 20, "mouse", 0);
+
+    expect(drag.state.active).toBe(false);
+    expect(drag.state.suppressClick).toBe(false);
+  });
+
   it("ignores 18px of jitter, matching a typical touchscreen tap reported as generic mouse input", () => {
     const { drag, source, onDrop } = createDragHarness();
     beginDrag(source);
@@ -104,6 +118,52 @@ describe("useTabDrag", () => {
     expect(drag.state.active).toBe(false);
     expect(drag.state.suppressClick).toBe(false);
     expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("does not arm a drag when the primary button is not held", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source, 100, 20, "mouse", 0);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD, 20, "mouse", 0);
+
+    releasePointer();
+
+    expect(drag.state.active).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending drag when the primary button is released before movement", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD, 20, "mouse", 0);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD + 10);
+
+    expect(drag.state.active).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("cancels an active drag when the primary button is no longer held", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD);
+    expect(drag.state.active).toBe(true);
+
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD + 10, 20, "mouse", 0);
+
+    expect(drag.state.active).toBe(false);
+    expect(drag.state.draggedId).toBe(null);
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("ignores movement from a different pointer", () => {
+    const { drag, source, onDrop } = createDragHarness();
+    beginDrag(source, 100, 20, "mouse", 1, 7);
+    movePointer(100 + TAB_DRAG_HORIZONTAL_THRESHOLD, 20, "mouse", 1, 8);
+
+    expect(drag.state.active).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+    releasePointer(0, 0, 7);
   });
 
   it("never arms a drag for touch input, even past the horizontal threshold", () => {

--- a/apps/desktop/src/composables/useTabDrag.ts
+++ b/apps/desktop/src/composables/useTabDrag.ts
@@ -32,6 +32,7 @@ let pending: {
   id: string;
   x: number;
   y: number;
+  pointerId: number;
   sourceEl: HTMLElement | null;
 } | null = null;
 let onDropCallback: ((draggedId: string, targetId: string, position: TabDropPosition) => boolean) | null = null;
@@ -81,22 +82,39 @@ function removeGhost() {
   }
 }
 
+function activateDrag(x: number, y: number) {
+  if (!pending) return;
+
+  activePointerId = pending.pointerId;
+  state.active = true;
+  state.draggedId = pending.id;
+  state.startX = pending.x;
+  state.startY = pending.y;
+  if (pending.sourceEl) {
+    ghostEl = createGhost(pending.sourceEl, x, y);
+  }
+  pending = null;
+  document.body.style.cursor = "grabbing";
+  document.body.style.userSelect = "none";
+}
+
 function onPointerMove(event: PointerEvent) {
   if (!pending && !state.active) return;
+
+  const trackedPointerId = pending?.pointerId ?? activePointerId;
+  if (trackedPointerId !== null && trackedPointerId !== undefined && event.pointerId !== trackedPointerId) return;
+
+  // macOS reports a trackpad tap as a mouse pointer with button=0, but
+  // buttons=0. It is a click gesture, not a held primary-button drag.
+  if ((event.buttons & 1) !== 1) {
+    reset();
+    return;
+  }
 
   if (pending && !state.active) {
     const delta = dragAxis() === "vertical" ? event.clientY - pending.y : event.clientX - pending.x;
     if (Math.abs(delta) < TAB_DRAG_HORIZONTAL_THRESHOLD) return;
-    state.active = true;
-    state.draggedId = pending.id;
-    state.startX = pending.x;
-    state.startY = pending.y;
-    if (pending.sourceEl) {
-      ghostEl = createGhost(pending.sourceEl, event.clientX, event.clientY);
-    }
-    pending = null;
-    document.body.style.cursor = "grabbing";
-    document.body.style.userSelect = "none";
+    activateDrag(event.clientX, event.clientY);
   }
 
   if (state.active) {
@@ -105,6 +123,9 @@ function onPointerMove(event: PointerEvent) {
 }
 
 function onMouseUp(event: PointerEvent) {
+  const trackedPointerId = pending?.pointerId ?? activePointerId;
+  if (trackedPointerId !== null && trackedPointerId !== undefined && event.pointerId !== trackedPointerId) return;
+
   state.suppressClick = false;
   if (state.active && state.draggedId && onDetachCallback && isOutsideDetachBounds(event.clientX, event.clientY)) {
     const scale = typeof window !== "undefined" && Number.isFinite(window.devicePixelRatio) && window.devicePixelRatio > 0 ? window.devicePixelRatio : 1;
@@ -115,7 +136,10 @@ function onMouseUp(event: PointerEvent) {
   reset();
 }
 
-function onPointerCancel() {
+function onPointerCancel(event?: Event) {
+  const trackedPointerId = pending?.pointerId ?? activePointerId;
+  if (event && "pointerId" in event && trackedPointerId !== null && trackedPointerId !== undefined && (event as PointerEvent).pointerId !== trackedPointerId) return;
+
   state.suppressClick = false;
   reset();
 }
@@ -132,6 +156,7 @@ function reset() {
   state.dropPosition = null;
   state.startX = 0;
   state.startY = 0;
+  activePointerId = null;
   pending = null;
   removeGhost();
   document.body.style.cursor = "";
@@ -139,6 +164,7 @@ function reset() {
 }
 
 let listenersAttached = false;
+let activePointerId: number | null = null;
 
 function ensureListeners() {
   if (listenersAttached) return;
@@ -161,6 +187,10 @@ export function useTabDrag(onDrop: (draggedId: string, targetId: string, positio
 
   function startDrag(event: PointerEvent, tabId: string) {
     if (event.button !== 0) return;
+    // Consume click suppression on the next primary-button gesture even when
+    // macOS reports a trackpad tap with buttons=0 and no drag can be armed.
+    state.suppressClick = false;
+    if ((event.buttons & 1) !== 1) return;
     // Touch input has no reliable equivalent of mouse jitter: a real finger's
     // contact point commonly drifts well past TAB_DRAG_HORIZONTAL_THRESHOLD
     // during an ordinary tap, which would misread the tap as a drag. Skip
@@ -169,9 +199,14 @@ export function useTabDrag(onDrop: (draggedId: string, targetId: string, positio
     if (event.pointerType === "touch") return;
     const target = event.target as HTMLElement;
     if (target.closest("button, input, [data-tab-title-input]")) return;
-    state.suppressClick = false;
     const el = (event.currentTarget as HTMLElement) || null;
-    pending = { id: tabId, x: event.clientX, y: event.clientY, sourceEl: el };
+    pending = {
+      id: tabId,
+      x: event.clientX,
+      y: event.clientY,
+      pointerId: event.pointerId,
+      sourceEl: el,
+    };
   }
 
   function updateTarget(event: MouseEvent, tabId: string) {


### PR DESCRIPTION
## 变更说明

macOS 触控板轻点标签页时，WebView 会生成 `pointerType=mouse`、`button=0`、`buttons=0` 的指针事件。原拖拽逻辑只检查 `button`，当轻点伴随位移超过阈值时会误启动标签拖拽。

本 PR：

- 仅在主按钮确实处于按下状态时准备并激活标签拖拽
- 在移动阶段持续校验 `buttons`，按钮已释放时完整清理待定或已激活的拖拽
- 在下一次主按钮手势开始时清除 click 抑制，确保拖拽后的触控板轻点仍能切换标签
- 记录并校验 `pointerId`，避免其他指针事件影响当前拖拽
- 触控板轻点事件不再调用 `preventDefault()`，保留正常标签点击
- 增加触控板轻点、拖拽后轻点、按钮释放和不同指针的回归测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

https://github.com/user-attachments/assets/5afcb5e2-c122-4b5f-97d0-c7c2ae25df81

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已完成：

- `pnpm exec vitest run apps/desktop/src/composables/__tests__/useTabDrag.spec.ts apps/desktop/src/components/layout/__tests__/AppTabBar.spec.ts`（29/29）
- `pnpm typecheck`
- `pnpm build`
- macOS 触控板手动验证：轻点可正常切换标签且不会启动拖拽；触控板物理按压和鼠标拖拽保持正常

`make check` 中 connection-types、format、lint、typecheck 和 12406/12407 个测试通过；未由本分支修改的 `DocumentBrowserFieldSearch.spec.ts` 存在不稳定失败。

## 关联 Issue

Closes #7896