### PR TITLE
fix(transfer): preserve PostgreSQL pgvector literals

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -17,9 +17,10 @@ use crate::mysql_ddl_normalize::DdlNormalizeOptions;
 use crate::object_source_sql::build_export_object_source_sql;
 use crate::sql_dialect::{qualified_table_name, uses_single_row_insert_statements};
 use crate::transfer::{
-    format_ch_array_sql_literal, format_pg_array_sql_literal, is_identity_column_extra,
-    is_mysql_generated_column_extra, keyset_pagination_sql_with_identifier_quote, quote_identifier,
-    quote_postgres_string_literal, wrap_dameng_identity_insert_sql_for_table,
+    format_ch_array_sql_literal, format_pg_array_sql_literal, format_postgres_vector_sql_literal,
+    is_identity_column_extra, is_mysql_generated_column_extra, is_postgres_vector_type,
+    keyset_pagination_sql_with_identifier_quote, quote_identifier, quote_postgres_string_literal,
+    wrap_dameng_identity_insert_sql_for_table,
 };
 use crate::types::{ObjectSourceKind, SpatialColumn};
 
@@ -441,8 +442,8 @@ fn format_export_sql_literal_typed(
     if is_postgres_json_export_column(database_type, column_type) {
         return format_postgres_json_export_literal(value);
     }
-    if is_postgres_vector_export_column(database_type, column_type) {
-        return format_postgres_vector_export_literal(value);
+    if database_type == Some(DatabaseType::Postgres) && is_postgres_vector_type(column_type) {
+        return format_postgres_vector_sql_literal(value);
     }
     if matches!(database_type, Some(DatabaseType::Mysql)) && column_type.is_some_and(is_mysql_bit_type) {
         return format_mysql_bit_literal(value);
@@ -507,35 +508,6 @@ fn format_postgres_json_export_literal(value: &Value) -> String {
     // PostgreSQL standard strings keep backslashes literal; JSON text needs its
     // own escape sequences, so only SQL-escape the surrounding string delimiter.
     quote_postgres_string_literal(&text)
-}
-
-fn format_postgres_vector_export_literal(value: &Value) -> String {
-    if value.is_null() {
-        return "NULL".to_string();
-    }
-    let text = match value {
-        // pgvector vector/halfvec are scalar extension types whose importable
-        // literal grammar uses square brackets, unlike PostgreSQL arrays.
-        Value::Array(arr) => format_postgres_vector_export_text(arr),
-        Value::String(text) => text.to_string(),
-        _ => value.to_string(),
-    };
-    quote_postgres_string_literal(&text)
-}
-
-fn format_postgres_vector_export_text(arr: &[Value]) -> String {
-    let elements = arr.iter().map(format_postgres_vector_export_element).collect::<Vec<_>>();
-    format!("[{}]", elements.join(","))
-}
-
-fn format_postgres_vector_export_element(value: &Value) -> String {
-    match value {
-        Value::String(text) => text.trim().to_string(),
-        Value::Number(number) => number.to_string(),
-        Value::Bool(value) => value.to_string(),
-        Value::Null => "NULL".to_string(),
-        _ => value.to_string(),
-    }
 }
 
 fn quote_export_sql_string(text: &str) -> String {
@@ -1270,17 +1242,6 @@ fn is_postgres_bytea_export_column(database_type: Option<DatabaseType>, column_t
             .map(|column_type| {
                 let normalized = column_type.trim().trim_matches('"').to_ascii_lowercase();
                 normalized == "bytea" || normalized.ends_with(".bytea")
-            })
-            .unwrap_or(false)
-}
-
-fn is_postgres_vector_export_column(database_type: Option<DatabaseType>, column_type: Option<&str>) -> bool {
-    database_type == Some(DatabaseType::Postgres)
-        && column_type
-            .map(|column_type| {
-                let normalized = column_type.trim().trim_matches('"').to_ascii_lowercase();
-                let base = normalized.split(['(', ' ', '\t', '\n']).next().unwrap_or("").trim_matches('"');
-                matches!(base, "vector" | "halfvec") || base.ends_with(".vector") || base.ends_with(".halfvec")
             })
             .unwrap_or(false)
 }
@@ -4399,18 +4360,29 @@ mod tests {
                 "id".to_string(),
                 "embedding".to_string(),
                 "qualified_embedding".to_string(),
+                "compact_embedding".to_string(),
                 "labels".to_string(),
+                "embedding_history".to_string(),
             ],
             column_types: vec![
                 Some("integer".to_string()),
                 Some("vector(2)".to_string()),
                 Some("public.vector".to_string()),
+                Some("halfvec(2)".to_string()),
                 Some("text[]".to_string()),
+                Some("public.vector(2)[]".to_string()),
             ],
             column_extras: Vec::new(),
             spatial_columns: Vec::new(),
             spatial_values: Vec::new(),
-            rows: vec![vec![json!(1), json!([1.2, 3.4]), json!(["5", "6"]), json!(["x", "y"])]],
+            rows: vec![vec![
+                json!(1),
+                json!([1.2, 3.4]),
+                json!(["5", "6"]),
+                json!([-0.25, 4]),
+                json!(["x", "y"]),
+                json!([[1.2, 3.4], [5, 6]]),
+            ]],
             batch_size: Some(10),
         })
         .unwrap();
@@ -4418,7 +4390,7 @@ mod tests {
         assert_eq!(
             statements,
             vec![
-                r#"INSERT INTO "public"."items" ("id", "embedding", "qualified_embedding", "labels") VALUES (1, '[1.2,3.4]', '[5,6]', '{"x","y"}');"#
+                r#"INSERT INTO "public"."items" ("id", "embedding", "qualified_embedding", "compact_embedding", "labels", "embedding_history") VALUES (1, '[1.2,3.4]', '[5,6]', '[-0.25,4]', '{"x","y"}', '{{1.2,3.4},{5,6}}');"#
             ]
         );
     }

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -2613,10 +2613,15 @@ pub fn escape_value_typed(val: &serde_json::Value, db_type: &DatabaseType, colum
                 _ => format!("'{escaped}'"),
             }
         }
-        serde_json::Value::Array(arr) => match db_type {
-            DatabaseType::ClickHouse | DatabaseType::Databend => format_ch_array_sql_literal(arr),
-            _ => format_pg_array_sql_literal(arr),
-        },
+        serde_json::Value::Array(arr) => {
+            if *db_type == DatabaseType::Postgres && is_postgres_vector_type(column_type) {
+                return format_postgres_vector_sql_literal(val);
+            }
+            match db_type {
+                DatabaseType::ClickHouse | DatabaseType::Databend => format_ch_array_sql_literal(arr),
+                _ => format_pg_array_sql_literal(arr),
+            }
+        }
         _ => {
             let s = val.to_string();
             format!("'{}'", s.replace('\\', "\\\\").replace('\'', "''"))
@@ -2828,6 +2833,46 @@ pub fn format_pg_array_sql_literal(arr: &[serde_json::Value]) -> String {
     let elements: Vec<String> = arr.iter().map(format_pg_array_element).collect();
     let inner = format!("{{{}}}", elements.join(","));
     format!("'{}'", inner.replace('\\', "\\\\").replace('\'', "''"))
+}
+
+pub(crate) fn is_postgres_vector_type(column_type: Option<&str>) -> bool {
+    column_type
+        .map(|column_type| {
+            let normalized = column_type.trim().trim_matches('"').to_ascii_lowercase();
+            if normalized.trim_end().ends_with("[]") {
+                return false;
+            }
+            let base = normalized.split(['(', ' ', '\t', '\n']).next().unwrap_or("").trim_matches('"');
+            matches!(base, "vector" | "halfvec") || base.ends_with(".vector") || base.ends_with(".halfvec")
+        })
+        .unwrap_or(false)
+}
+
+pub(crate) fn format_postgres_vector_sql_literal(value: &serde_json::Value) -> String {
+    if value.is_null() {
+        return "NULL".to_string();
+    }
+    let text = match value {
+        // pgvector vector/halfvec are scalar extension types whose importable
+        // literal grammar uses square brackets, unlike PostgreSQL arrays.
+        serde_json::Value::Array(arr) => {
+            let elements = arr.iter().map(format_postgres_vector_element).collect::<Vec<_>>();
+            format!("[{}]", elements.join(","))
+        }
+        serde_json::Value::String(text) => text.to_string(),
+        _ => value.to_string(),
+    };
+    quote_postgres_string_literal(&text)
+}
+
+fn format_postgres_vector_element(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.trim().to_string(),
+        serde_json::Value::Number(number) => number.to_string(),
+        serde_json::Value::Bool(value) => value.to_string(),
+        serde_json::Value::Null => "NULL".to_string(),
+        _ => value.to_string(),
+    }
 }
 
 fn format_pg_array_element(val: &serde_json::Value) -> String {
@@ -12114,6 +12159,50 @@ mod tests {
             r#"INSERT INTO "public"."files" ("path") VALUES
 (E'C:\\tmp\\file.txt')"#
         );
+    }
+
+    #[test]
+    fn postgres_insert_preserves_pgvector_literals_and_array_controls() {
+        let sql = generate_insert_typed(
+            &[
+                String::from("embedding"),
+                String::from("qualified_embedding"),
+                String::from("compact_embedding"),
+                String::from("scores"),
+                String::from("embedding_history"),
+            ],
+            &[
+                Some(String::from("vector(3)")),
+                Some(String::from("public.vector(3)")),
+                Some(String::from("extensions.halfvec(3)")),
+                Some(String::from("real[]")),
+                Some(String::from("vector(3)[]")),
+            ],
+            &[vec![
+                json!([1.25, -2.5, 3.75]),
+                json!([0, 0.875, -0.014]),
+                json!(["0.5", "-0.25", "4"]),
+                json!([1.25, -2.5, 3.75]),
+                json!([[1.25, -2.5, 3.75], [0, 0.875, -0.014]]),
+            ]],
+            "pgvector_probe",
+            "target_7955",
+            &DatabaseType::Postgres,
+            None,
+        );
+
+        assert_eq!(
+            sql,
+            r#"INSERT INTO "target_7955"."pgvector_probe" ("embedding", "qualified_embedding", "compact_embedding", "scores", "embedding_history") VALUES
+('[1.25,-2.5,3.75]', '[0,0.875,-0.014]', '[0.5,-0.25,4]', '{1.25,-2.5,3.75}', '{{1.25,-2.5,3.75},{0,0.875,-0.014}}')"#
+        );
+    }
+
+    #[test]
+    fn postgres_vector_literal_keeps_null_and_preformatted_string_behavior() {
+        assert_eq!(escape_value_typed(&serde_json::Value::Null, &DatabaseType::Postgres, Some("vector(3)")), "NULL");
+        assert_eq!(escape_value_typed(&json!("[1,2,3]"), &DatabaseType::Postgres, Some("halfvec(3)")), "'[1,2,3]'");
+        assert_eq!(escape_value_typed(&json!([1, 2, 3]), &DatabaseType::Postgres, Some("integer[]")), "'{1,2,3}'");
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复 PostgreSQL 数据传输对 pgvector 标量值使用错误数组字面量的问题。

原实现会将解码为 JSON 数组的 `vector` / `halfvec` 与普通 PostgreSQL 数组统一格式化为 `{...}`，导致目标数据库拒绝写入，并报告 `Vector contents must start with "["`。本次修改根据目标字段类型保留 pgvector 所需的 `[...]` 语法，同时保持 `real[]`、`integer[]` 及 `vector(n)[]` 等真正数组的 `{...}` 语法不变。

- 为 PostgreSQL `vector`、schema-qualified `vector` 和 `halfvec` 生成方括号字面量
- 保持普通 PostgreSQL 数组及 pgvector 数组的现有花括号行为
- 在数据传输与 SQL 导出之间复用类型识别及格式化逻辑，避免两条写入路径发生偏差
- 扩展现有 SQL 导出回归覆盖，确保此前 #2982 的行为保持不变

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

本 PR 不涉及前端改动。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

相关测试：

- `cargo test -p dbx-core postgres_insert_preserves_pgvector_literals_and_array_controls --lib`
- `cargo test -p dbx-core postgres_vector_literal_keeps_null_and_preformatted_string_behavior --lib`
- `cargo test -p dbx-core postgres_vector_export_preserves_pgvector_bracket_literals --lib`
- `cargo test -p dbx-core pgvector_binary_to_json_preserves_component_precision --lib`

手动 E2E：

- 在 PostgreSQL 18.6 + pgvector 0.8.6 中确认未修复版本会将 `vector(3)` 写成 `{...}` 并稳定复现报错
- 使用修复版本传输包含 `vector(3)`、`real[]` 和 `integer[]` 的两行数据成功
- 从数据库侧逐字段比较源表与目标表，差异行数为 0

## 关联 Issue

Close #7955

Related #2982（相同的 pgvector 字面量根因；#2982 的 SQL 文件导出路径已修复，本 PR 补齐数据传输路径）
