### PR TITLE
修复 SQL 编辑器光标在部分界面缩放比例下可能不显示的问题

### DIFF
--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -772,9 +772,16 @@ export function buildEditorFontThemeRules(opts?: { fixedHeight?: boolean; scroll
     ".cm-selectionLayer .cm-selectionBackground": {
       display: "none",
     },
+    // 光标是零宽元素，可见部分只来自 border-left。在 WebView 页面缩放（uiScale）下
+    // 1 CSS px 不再映射为整数设备像素，1.2px 的小数边框加上 transform 造成的独立绘制层
+    // 会被 WebKit 舍入丢弃，表现为光标在部分列/部分窗口宽度下不显示。
+    // 因此：用 margin-top 代替 transform（不产生绘制层），并给边框整数宽度。
+    // 颜色仍由各主题的 borderLeftColor 提供，无需改动主题。
     ".cm-cursor": {
       height: "1.6em !important",
-      transform: "translateY(-0.3em)",
+      marginTop: "-0.3em",
+      borderLeftWidth: "2px",
+      marginLeft: "-1px",
     },
     ".cm-trimmedSelection": {
       backgroundColor: `var(${EDITOR_SELECTION_BACKGROUND_CSS_VAR}, rgb(148 163 184 / 38%))`,


### PR DESCRIPTION
Fixes #7398

### 问题现象

macOS 桌面端 SQL 编辑器中，光标在部分位置不显示：

- 方向键逐字符移动时，有的列显示、有的列不显示，即 issue 标题所说的「只有在某些符号左右可以显示」；
- 拖动左侧连接栏与编辑区之间的分割线，可在「正常 / 不正常」之间稳定切换；
- 与主题无关（亮/暗、全部主题均可复现），与焦点无关（光标不显示时仍可正常输入、方向键仍可移动）。

### 原因

CodeMirror 绘制空选区光标时，`RectangleMarker.forRange()` 不设置 `width`，因此光标是一个**零宽元素，可见部分完全来自 `border-left: 1.2px`**，且 `left` 是 `coordsAtPos()` 返回的浮点值。

而本项目的界面缩放走的是 WebView 页面缩放（`App.vue` 的 `getCurrentWebview().setZoom(scale)`），缩放后 1 CSS px 不再映射为整数设备像素（如 120% + Retina → 1 CSS px = 2.4 设备像素）。「零宽元素 + 小数边框 + 浮点定位」在 WebKit 下会因设备像素舍入在部分位置被丢弃；`.cm-cursor` 上原有的 `transform: translateY(-0.3em)` 使其进入独立绘制路径，进一步放大了该问题。

这解释了全部现象：每列的浮点余数不同 → 部分列丢失；拖分割线改变编辑区左偏移 → 整体平移后翻转；不同缩放比例下「坏掉的列」分布不同（实测 0.9 / 0.95 / 1.2 / 1.25 可复现，0.75 / 1.1 / 1.15 未复现出）。issue 报告者的缩放比例为 95%，与此吻合。

### 修改内容

仅 `apps/desktop/src/lib/editor/editorThemes.ts` 中 `.cm-cursor` 一处：

- `transform: translateY(-0.3em)` → `margin-top: -0.3em`：视觉位移完全等价，但不再产生独立绘制层；
- `border-left-width` 由 CodeMirror 默认的 `1.2px` 改为 `2px`，`margin-left` 相应由 `-0.6px` 改为 `-1px`：整数宽度保证任意缩放比例下都覆盖满设备像素，且仍以字符边界为中心。

### 验证

- macOS 26.5 / aarch64 桌面端开发版，在 **90% ~ 125% 区间内各缩放比例**下逐一测试：方向键从行首逐列走到行尾每列均有光标，反复拖动分割线不再出现切换；修改前相同比例可稳定复现。
- 100% 缩放下光标粗细（1.2px → 2px，与 VS Code / JetBrains 一致）观感确认可接受；亮/暗主题均检查。
- `pnpm typecheck`、`pnpm lint`、`pnpm test`（1257 个文件 / 12403 项）全部通过。

### 前后对比
120%缩放比例下
修复前：
<img width="354" height="178" alt="光标显示修复前" src="https://github.com/user-attachments/assets/3813a3ba-130a-4f7b-a4fb-f816ab10f13b" />
修复后：
<img width="334" height="172" alt="光标显示修复后" src="https://github.com/user-attachments/assets/dbf378f0-2ddd-489c-9a5b-da983aa1b75a" />

