### PR TITLE
Fix：移除左侧连接列表条目圆角

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1506,7 +1506,6 @@ function onKeydown(event: KeyboardEvent) {
             'tree-item-connection-tint': connectionColor,
             'hover:bg-accent': node.type !== 'connection',
             'hover:bg-sidebar-accent': node.type === 'connection',
-            rounded: !selectionVisual.rowSelected,
             'tree-item-active': selectionVisual.rowSelected,
             'tree-item-active--selection-set': selectionVisual.usesSelectionSetHighlight && selectionVisual.rowSelected,
             'tree-item-highlight': highlighted,


### PR DESCRIPTION
## 问题
小圆角和大圆角模式下，左侧连接列表条目使用行级圆角，导致相邻条目之间出现背景空隙。

## 修复
移除树列表行的全局圆角类，使连接、数据库、表等条目连续铺满列表区域；条目内部按钮和输入框的圆角保持不变。

## 验证
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/components/sidebar/TreeItem.vue`
- 本地网页预览确认列表行实际 `border-radius: 0px`

Fixes #8059