### PR TITLE
Fix：修复连接列表横向滚动区域异常

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1746,7 +1746,7 @@ function onKeydown(event: KeyboardEvent) {
 .tree-item-connection-tint::before {
   content: "";
   position: absolute;
-  inset: 0 -9999px;
+  inset: 0;
   z-index: 0;
   background-color: var(--tree-connection-row-bg);
   border-radius: inherit;
@@ -1801,7 +1801,7 @@ function onKeydown(event: KeyboardEvent) {
 .tree-table-search-control::before {
   content: "";
   position: absolute;
-  inset: 0 -9999px;
+  inset: 0;
   z-index: 0;
   background-color: var(--tree-table-search-row-bg);
   pointer-events: none;


### PR DESCRIPTION
## 问题
开启“允许侧边栏横向滚动”后，使用库内表搜索时，连接列表会出现异常过长的横向滚动条，右侧还可能出现深色背景块。

## 原因
连接行和库内表搜索行的背景伪元素使用 `inset: 0 -9999px`，导致虚拟列表的 `scrollWidth` 被异常撑大。

## 修复
将两个背景伪元素限制在当前行范围内，避免扩大侧边栏横向滚动区域，同时保留原有背景显示逻辑。

## 验证
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/components/sidebar/TreeItem.vue`
- `git diff --check`
- 本地预览确认横向滚动区域恢复正常

Fixes #8061