### PR TITLE
fix(opengauss): 修复数据库导出 SQL 转义问题

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1436,7 +1436,7 @@ fn normalize_opengauss_comment_statement(statement: &str) -> Option<String> {
     let value = &value[value_leading..];
     let quote_offset = match value.as_bytes() {
         [b'\'', ..] => 0,
-        [prefix, b'\'', ..] if matches!(prefix, b'e' | b'E') => 1,
+        [b'e' | b'E', b'\'', ..] => 1,
         _ => return None,
     };
     let opening_quote = value_start + value_leading + quote_offset;
@@ -5269,7 +5269,7 @@ mod tests {
         );
 
         assert_eq!(
-            format_export_table_ddl(&ddl, Some(DatabaseType::OpenGauss), DdlNormalizeOptions::default()),
+            format_export_table_ddl(ddl, Some(DatabaseType::OpenGauss), DdlNormalizeOptions::default()),
             concat!(
                 "CREATE TABLE \"public\".\"dbx_issue_comment\" (\"flag\" varchar(8));\n",
                 "COMMENT ON COLUMN \"public\".\"dbx_issue_comment\".\"flag\" IS '逻辑删除标志：''0''-未删除，''1''-已删除';"
@@ -5284,7 +5284,7 @@ mod tests {
             "COMMENT ON COLUMN \"public\".\"notes\".\"body\" IS 'owner''s note';"
         );
 
-        assert_eq!(format_export_table_ddl(&ddl, Some(DatabaseType::OpenGauss), DdlNormalizeOptions::default()), ddl);
+        assert_eq!(format_export_table_ddl(ddl, Some(DatabaseType::OpenGauss), DdlNormalizeOptions::default()), ddl);
     }
 
     #[test]

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -542,6 +542,12 @@ fn quote_export_sql_string(text: &str) -> String {
     format!("'{}'", text.replace('\\', "\\\\").replace('\'', "''"))
 }
 
+// OpenGauss exports use standard-conforming strings, so backslashes are
+// literal and only embedded single quotes need doubling.
+fn quote_opengauss_export_sql_string(text: &str) -> String {
+    format!("'{}'", text.replace('\'', "''"))
+}
+
 fn is_sqlserver_unicode_export_type(column_type: &str) -> bool {
     let base = column_type.trim().split(|ch: char| ch == '(' || ch.is_whitespace()).next().unwrap_or("");
     ["nchar", "nvarchar", "ntext", "sysname"].iter().any(|candidate| base.eq_ignore_ascii_case(candidate))
@@ -551,6 +557,7 @@ fn quote_export_sql_string_for_database(text: &str, database_type: Option<Databa
     match database_type {
         Some(DatabaseType::Dameng) => quote_dameng_export_sql_string(text),
         Some(DatabaseType::Postgres) => quote_postgres_string_literal(text),
+        Some(DatabaseType::OpenGauss) => quote_opengauss_export_sql_string(text),
         database_type if is_mysql_compatible_export_literal_target(database_type) => {
             quote_mysql_compatible_export_sql_string(text)
         }
@@ -1383,8 +1390,133 @@ fn normalize_export_table_ddl(
 
 fn format_export_table_ddl(ddl: &str, database_type: Option<DatabaseType>, opts: DdlNormalizeOptions) -> String {
     let ddl = normalize_export_table_ddl(ddl, database_type, opts);
+    let ddl =
+        if database_type == Some(DatabaseType::OpenGauss) { normalize_opengauss_table_ddl_comments(&ddl) } else { ddl };
     let ddl = ddl.trim().trim_end_matches(';').trim_end();
     format!("{ddl};")
+}
+
+/// openGauss 6.x `pg_get_tabledef` can concatenate comment text into a
+/// `COMMENT ON` literal without escaping embedded single quotes. Normalize
+/// only those generated comment statements; all other DDL text remains
+/// untouched.
+fn normalize_opengauss_table_ddl_comments(ddl: &str) -> String {
+    let mut normalized = String::with_capacity(ddl.len());
+    for line in ddl.split_inclusive('\n') {
+        let (line_body, line_ending) = match line.strip_suffix('\n') {
+            Some(body) => match body.strip_suffix('\r') {
+                Some(body) => (body, "\r\n"),
+                None => (body, "\n"),
+            },
+            None => (line, ""),
+        };
+        let leading = line_body.len() - line_body.trim_start_matches(|ch: char| ch.is_ascii_whitespace()).len();
+        let statement = &line_body[leading..];
+        if let Some(statement) = normalize_opengauss_comment_statement(statement) {
+            normalized.push_str(&line_body[..leading]);
+            normalized.push_str(&statement);
+        } else {
+            normalized.push_str(line_body);
+        }
+        normalized.push_str(line_ending);
+    }
+    normalized
+}
+
+fn normalize_opengauss_comment_statement(statement: &str) -> Option<String> {
+    let uppercase = statement.to_ascii_uppercase();
+    if !uppercase.starts_with("COMMENT ON ") {
+        return None;
+    }
+
+    let is_pos = find_opengauss_comment_is_keyword(statement, &uppercase)?;
+    let value_start = is_pos + " IS ".len();
+    let value = &statement[value_start..];
+    let value_leading = value.len() - value.trim_start_matches(|ch: char| ch.is_ascii_whitespace()).len();
+    let value = &value[value_leading..];
+    let quote_offset = match value.as_bytes() {
+        [b'\'', ..] => 0,
+        [prefix, b'\'', ..] if matches!(prefix, b'e' | b'E') => 1,
+        _ => return None,
+    };
+    let opening_quote = value_start + value_leading + quote_offset;
+    let statement_end = statement.trim_end().len();
+    let literal_end = statement[..statement_end]
+        .strip_suffix(';')
+        .map_or(statement_end, |without_terminator| without_terminator.len());
+    if opening_quote >= literal_end {
+        return None;
+    }
+
+    let closing_quote = statement[..literal_end].rfind('\'')?;
+    if closing_quote <= opening_quote || !statement[closing_quote + 1..literal_end].trim().is_empty() {
+        return None;
+    }
+    let literal = &statement[opening_quote..=closing_quote];
+    if opengauss_comment_literal_is_valid(literal) {
+        return Some(statement.to_string());
+    }
+
+    let raw_comment = &statement[opening_quote + 1..closing_quote];
+    let escaped_comment = raw_comment.replace('\'', "''");
+    let mut normalized = String::with_capacity(statement.len() + escaped_comment.len() - raw_comment.len());
+    normalized.push_str(&statement[..opening_quote + 1]);
+    normalized.push_str(&escaped_comment);
+    normalized.push_str(&statement[closing_quote..]);
+    Some(normalized)
+}
+
+fn find_opengauss_comment_is_keyword(statement: &str, uppercase: &str) -> Option<usize> {
+    let mut cursor = "COMMENT ON ".len();
+    while cursor + " IS ".len() <= statement.len() {
+        if statement.as_bytes().get(cursor) == Some(&b'\"') {
+            cursor = skip_opengauss_quoted_identifier(statement, cursor);
+            continue;
+        }
+        if uppercase.get(cursor..cursor + " IS ".len()) == Some(" IS ") {
+            return Some(cursor);
+        }
+        cursor += statement[cursor..].chars().next()?.len_utf8();
+    }
+    None
+}
+
+fn skip_opengauss_quoted_identifier(sql: &str, start: usize) -> usize {
+    let bytes = sql.as_bytes();
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\"' {
+            if bytes.get(cursor + 1) == Some(&b'\"') {
+                cursor += 2;
+            } else {
+                return cursor + 1;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn opengauss_comment_literal_is_valid(literal: &str) -> bool {
+    let bytes = literal.as_bytes();
+    if bytes.len() < 2 || bytes.first() != Some(&b'\'') || bytes.last() != Some(&b'\'') {
+        return false;
+    }
+
+    let mut cursor = 1;
+    while cursor < bytes.len() - 1 {
+        if bytes[cursor] == b'\'' {
+            if cursor + 1 < bytes.len() - 1 && bytes[cursor + 1] == b'\'' {
+                cursor += 2;
+            } else {
+                return false;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    true
 }
 
 fn split_postgres_export_table_triggers(ddl: &str, database_type: DatabaseType) -> (String, Vec<String>) {
@@ -4388,6 +4520,60 @@ mod tests {
     }
 
     #[test]
+    fn opengauss_export_inserts_escape_quotes_without_doubling_backslashes() {
+        let style = r#""{\"paddingTop\":\"20vh\",\"fontSize\":16}""#;
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::OpenGauss),
+            identifier_quote: None,
+            schema: Some("public".to_string()),
+            table_name: Some("dbx_issue_json".to_string()),
+            qualified_table_name: None,
+            columns: vec!["comment_text".to_string(), "style".to_string()],
+            column_types: vec![Some("text".to_string()), Some("json".to_string())],
+            column_extras: Vec::new(),
+            spatial_columns: Vec::new(),
+            spatial_values: Vec::new(),
+            rows: vec![vec![json!("逻辑删除标志：'0'-未删除，'1'-已删除"), json!(style)]],
+            batch_size: Some(10),
+        })
+        .unwrap();
+
+        let expected_style = format!("'{style}'");
+        assert_eq!(
+            statements,
+            vec![format!(
+                "INSERT INTO \"public\".\"dbx_issue_json\" (\"comment_text\", \"style\") VALUES ('逻辑删除标志：''0''-未删除，''1''-已删除', {expected_style});"
+            )]
+        );
+    }
+
+    #[test]
+    fn postgres_export_keeps_json_escape_sequences_for_the_same_value() {
+        let style = r#""{\"paddingTop\":\"20vh\",\"fontSize\":16}""#;
+        let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
+            database_type: Some(DatabaseType::Postgres),
+            identifier_quote: None,
+            schema: Some("public".to_string()),
+            table_name: Some("dbx_issue_json".to_string()),
+            qualified_table_name: None,
+            columns: vec!["style".to_string()],
+            column_types: vec![Some("json".to_string())],
+            column_extras: Vec::new(),
+            spatial_columns: Vec::new(),
+            spatial_values: Vec::new(),
+            rows: vec![vec![json!(style)]],
+            batch_size: Some(10),
+        })
+        .unwrap();
+
+        let expected_style = format!("E'{}'", style.replace('\\', "\\\\"));
+        assert_eq!(
+            statements,
+            vec![format!("INSERT INTO \"public\".\"dbx_issue_json\" (\"style\") VALUES ({expected_style});")]
+        );
+    }
+
+    #[test]
     fn postgres_vector_export_preserves_pgvector_bracket_literals() {
         let statements = build_export_insert_statements(BuildExportInsertStatementsOptions {
             database_type: Some(DatabaseType::Postgres),
@@ -5073,6 +5259,32 @@ mod tests {
             ]
             .join("\n")
         );
+    }
+
+    #[test]
+    fn opengauss_export_escapes_single_quotes_in_comment_ddl() {
+        let ddl = concat!(
+            "CREATE TABLE \"public\".\"dbx_issue_comment\" (\"flag\" varchar(8));\n",
+            "COMMENT ON COLUMN \"public\".\"dbx_issue_comment\".\"flag\" IS '逻辑删除标志：'0'-未删除，'1'-已删除';"
+        );
+
+        assert_eq!(
+            format_export_table_ddl(&ddl, Some(DatabaseType::OpenGauss), DdlNormalizeOptions::default()),
+            concat!(
+                "CREATE TABLE \"public\".\"dbx_issue_comment\" (\"flag\" varchar(8));\n",
+                "COMMENT ON COLUMN \"public\".\"dbx_issue_comment\".\"flag\" IS '逻辑删除标志：''0''-未删除，''1''-已删除';"
+            )
+        );
+    }
+
+    #[test]
+    fn opengauss_export_leaves_other_literals_and_valid_comments_unchanged() {
+        let ddl = concat!(
+            "CREATE TABLE \"public\".\"notes\" (\"body\" text DEFAULT 'O''Hara');\n",
+            "COMMENT ON COLUMN \"public\".\"notes\".\"body\" IS 'owner''s note';"
+        );
+
+        assert_eq!(format_export_table_ddl(&ddl, Some(DatabaseType::OpenGauss), DdlNormalizeOptions::default()), ddl);
     }
 
     #[test]


### PR DESCRIPTION
﻿## 变更说明

修复 OpenGauss 数据库导出 SQL 时的字符串转义问题。

主要修复：

- 修复 `COMMENT ON COLUMN` / `COMMENT ON TABLE` 注释内容包含单引号时导出 SQL 非法的问题；
- 修复 OpenGauss JSON / 文本值中的反斜杠被错误加倍转义的问题；
- OpenGauss 字符串导出行为与其实际 SQL literal 语义保持一致（`standard_conforming_strings=on`）；
- 保持 PostgreSQL 现有导出行为不变。

## 根因

1. 数据库导出在处理 OpenGauss 字符串值时落入通用字符串转义逻辑 `quote_export_sql_string`。通用逻辑会将反斜杠主动加倍（`\` -> `\\`），这与 OpenGauss 在 `standard_conforming_strings=on` 下的反斜杠字面语义不一致，导致包含 `\"` 的 JSON 文本被转义为 `\\\"`，重新导入时解析失败。
2. OpenGauss 6.x 的 `pg_get_tabledef` 生成表结构 DDL 时，若列注释或表注释包含单引号，返回的 `COMMENT ON` 语句未对注释文本内的单引号加倍转义（未变为 `''`），导致导出的 SQL 出现语法错误、字符串截断。

## 修复方式

- 在 `crates/dbx-core/src/database_export.rs` 的 `quote_export_sql_string_for_database` 中为 `DatabaseType::OpenGauss` 显式使用 `quote_opengauss_export_sql_string`，仅对单引号转义（`'` -> `''`），保留反斜杠字面量语义；
- 在 `format_export_table_ddl` 中，对 OpenGauss 导出的表结构 DDL 中的 `COMMENT ON` 语句进行精准的 SQL literal 单引号规范化转义，不影响其他 DDL 语句和合法单引号；
- 保持 PostgreSQL 现有 `quote_postgres_string_literal` 导出逻辑不变；
- 严格控制修改范围，不波及未验证的其他 PG 兼容方言。

## 验证

- [x] OpenGauss INSERT 单引号与 JSON / 反斜杠回归测试（`opengauss_export_inserts_escape_quotes_without_doubling_backslashes`）
- [x] COMMENT ON DDL 单引号转义回归测试（`opengauss_export_escapes_single_quotes_in_comment_ddl`）
- [x] COMMENT ON 保持有效注释与普通字面量不变测试（`opengauss_export_leaves_other_literals_and_valid_comments_unchanged`）
- [x] PostgreSQL 对照测试（`postgres_export_keeps_json_escape_sequences_for_the_same_value`）
- [x] 本机 `cargo fmt --check`
- [x] 本机 `git diff --check`
- [x] 本机定向测试：OpenGauss 3 项、PostgreSQL 对照 1 项全部通过
- [x] CI `rust-fmt-clippy`：通过
- [x] CI workspace `cargo test --workspace --locked`：通过

## 关联 Issue

Closes #8041