### PR TITLE
feat(ui): 在备份连接中显示分组并统一单元格双击编辑

### DIFF
--- a/apps/desktop/src/components/backup/DatabaseBackupConfigFields.vue
+++ b/apps/desktop/src/components/backup/DatabaseBackupConfigFields.vue
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Check, ChevronDown, FolderOpen, Loader2, Search } from "@lucide/vue";
+import ConnectionGroupBadge from "@/components/connection/ConnectionGroupBadge.vue";
 import type { DatabaseBackupExecutionConfig } from "@/lib/backup/scheduledDatabaseBackup";
 import type { ConnectionConfig } from "@/types/database";
 
@@ -90,6 +91,7 @@ watch(
               @click="selectConnection(connection.id)"
             >
               <Check class="h-4 w-4 shrink-0" :class="connection.id === draft.connectionId ? 'opacity-100' : 'opacity-0'" />
+              <ConnectionGroupBadge :connection-id="connection.id" />
               <span class="min-w-0 flex-1 truncate">{{ connection.name }}</span>
             </button>
             <div v-if="filteredConnections.length === 0" class="px-2 py-2 text-sm text-muted-foreground">{{ t("databaseBackup.noMatchingConnections") }}</div>

--- a/apps/desktop/src/components/backup/__tests__/ScheduledDatabaseBackupSettings.spec.ts
+++ b/apps/desktop/src/components/backup/__tests__/ScheduledDatabaseBackupSettings.spec.ts
@@ -57,6 +57,16 @@ vi.mock("@/composables/useToast", () => ({
   useToast: () => ({ toast: mocks.toast }),
 }));
 
+vi.mock("@/components/connection/ConnectionGroupBadge.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    default: defineComponent({
+      props: { connectionId: { type: String, required: true } },
+      setup: (props) => () => h("span", { "data-connection-group-badge": "", "data-connection-id": props.connectionId }),
+    }),
+  };
+});
+
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(async () => "/backups"),
 }));
@@ -334,6 +344,19 @@ describe("ScheduledDatabaseBackupSettings schedule dialog", () => {
     expect(dialog?.textContent).toContain(String(i18n.global.t("databaseBackup.scheduleName")));
     expect(mocks.ensureConnected).toHaveBeenCalledWith("mysql-1");
     expect(mocks.listDatabases).toHaveBeenCalledWith("mysql-1");
+  });
+
+  it("shows connection group badges in the backup connection picker", async () => {
+    mocks.connections.push({ id: "mysql-primary", name: "Shared name", db_type: "mysql" }, { id: "mysql-archive", name: "Shared name", db_type: "mysql" });
+    await mountSettings();
+
+    addScheduleButton().click();
+    await flush();
+    currentDialog().querySelector<HTMLButtonElement>("[data-backup-connection-picker]")?.click();
+    await flush();
+
+    const connectionIds = Array.from(document.body.querySelectorAll<HTMLElement>("[data-connection-group-badge]")).map((badge) => badge.dataset.connectionId);
+    expect(connectionIds).toEqual(["mysql-primary", "mysql-archive"]);
   });
 
   it("opens an independent one-shot dialog without schedule fields", async () => {

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4611,22 +4611,6 @@ async function startCellEdit(rowId: number, columnIndex: number, expanded: boole
   return true;
 }
 
-async function startDomCellEdit(rowId: number, columnIndex: number, displayText: string, event: MouseEvent) {
-  const target = event.currentTarget;
-  if (!(await hydrateLargeValueCell(rowId, columnIndex))) return;
-  const item = getRowItem(rowId);
-  const editText = item ? cellEditorTextForValue(item.data[columnIndex], columnIndex) : displayText;
-  await startCellEdit(
-    rowId,
-    columnIndex,
-    cellEditContentNeedsExpandedEditor({
-      displayText,
-      editText,
-      target,
-    }),
-  );
-}
-
 function readonlyTextCellMatches(rowId: number | undefined, columnIndex: number): boolean {
   return !!readonlyTextCell.value && readonlyTextCell.value.rowId === rowId && readonlyTextCell.value.col === columnIndex;
 }
@@ -4660,7 +4644,7 @@ async function onDomCellDblClick(item: RowItem, actualColIdx: number, event: Mou
     await startReadonlyCellTextSelection(item.id, actualColIdx, displayText, cellEditContentNeedsExpandedEditor({ displayText, editText: cellEditorTextForValue(item.data[actualColIdx], actualColIdx), target: event.currentTarget }));
     return;
   }
-  await startDomCellEdit(item.id, actualColIdx, formatCellCached(item.data[actualColIdx], actualColIdx), event);
+  await startCellEdit(item.id, actualColIdx, true);
 }
 
 function cellEditContentNeedsExpandedEditor(options: { displayText: string; editText: string; target: EventTarget | null }): boolean {
@@ -7868,7 +7852,7 @@ async function onCanvasDblClick(event: MouseEvent) {
     return;
   }
   if (booleanCellsUseCheckbox.value && isBooleanGridCell(item, actualColIdx) && canEditCellItem(item, actualColIdx)) return;
-  await startCellEdit(item.id, actualColIdx, canvasCellContentOverflows(item, actualColIdx, hit.visibleColIdx));
+  await startCellEdit(item.id, actualColIdx, true);
 }
 
 function canvasCellContentOverflows(item: RowItem, actualColIdx: number, visibleColIdx: number): boolean {
@@ -8807,7 +8791,7 @@ async function onTransposeCellDblClick(rowIndex: number, actualColIdx: number, d
     await startReadonlyCellTextSelection(item.id, actualColIdx, displayText, cellEditContentNeedsExpandedEditor({ displayText, editText: cellEditorTextForValue(item.data[actualColIdx], actualColIdx), target }));
     return;
   }
-  await startDomCellEdit(item.id, actualColIdx, displayText, event);
+  await startCellEdit(item.id, actualColIdx, true);
 }
 
 function onTransposeCellContext(rowIndex: number, actualColIdx: number, event: MouseEvent) {

--- a/apps/desktop/src/components/grid/__tests__/DataGridExpandedCellEditing.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridExpandedCellEditing.spec.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, markRaw, nextTick, type App, type PropType } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import i18n from "@/i18n";
+import { useSettingsStore } from "@/stores/settingsStore";
+import type { QueryResult } from "@/types/database";
+
+vi.mock("@/composables/useDataGridColumnResize", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/composables/useDataGridColumnResize")>();
+  const { ref } = await import("vue");
+  return {
+    ...actual,
+    useDataGridColumnResize: () => ({
+      initColumnWidths: vi.fn(),
+      onResizeStart: vi.fn(),
+      autoFitColumn: vi.fn(),
+      renderedColumnWidths: ref([120, 180]),
+      totalWidth: ref(300),
+      columnVars: ref({ "--total-w": "300px" }),
+      getIsResizing: () => false,
+    }),
+  };
+});
+
+import DataGrid from "../DataGrid.vue";
+
+const RecycleScroller = defineComponent({
+  props: {
+    items: {
+      type: Array as PropType<unknown[]>,
+      default: () => [],
+    },
+  },
+  setup(props, { attrs, slots }) {
+    return () => h("div", attrs, [slots.before?.(), ...props.items.map((item, index) => slots.default?.({ item, index })), slots.after?.()]);
+  },
+});
+
+const mountedApps: Array<{ app: App; host: HTMLElement }> = [];
+
+function result(): QueryResult {
+  return {
+    columns: ["id", "notes"],
+    rows: [[1, "short value"]],
+    affected_rows: 0,
+    execution_time_ms: 0,
+  };
+}
+
+function mountGrid(renderMode: "canvas" | "dom") {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  useSettingsStore().updateEditorSettings({ dataGridRenderMode: renderMode });
+  const gridResult = markRaw(result());
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const Root = defineComponent({
+    setup() {
+      return () =>
+        h(
+          TooltipProvider,
+          { delayDuration: 0 },
+          {
+            default: () =>
+              h(DataGrid, {
+                result: gridResult,
+                databaseType: "mysql",
+                context: "table-data",
+                editable: true,
+                tableMeta: {
+                  tableName: "editing_target",
+                  columns: [
+                    { name: "id", data_type: "int" },
+                    { name: "notes", data_type: "varchar" },
+                  ],
+                  primaryKeys: ["id"],
+                },
+              }),
+          },
+        );
+    },
+  });
+  const app = createApp(Root);
+  app.use(pinia);
+  app.use(i18n);
+  app.component("RecycleScroller", RecycleScroller);
+  app.mount(host);
+  mountedApps.push({ app, host });
+  return host;
+}
+
+async function settle() {
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+}
+
+async function doubleClick(target: HTMLElement, options: MouseEventInit = {}) {
+  target.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true, ...options }));
+  await settle();
+}
+
+function expandedEditor(host: HTMLElement): HTMLTextAreaElement | null {
+  return host.querySelector<HTMLTextAreaElement>('textarea[data-expanded-cell-editor="true"]');
+}
+
+afterEach(() => {
+  for (const { app, host } of mountedApps.splice(0)) {
+    app.unmount();
+    host.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("DataGrid expanded cell editing", () => {
+  it("opens the expanded editor when a DOM cell is double-clicked", async () => {
+    const host = mountGrid("dom");
+    await settle();
+    const cell = host.querySelector<HTMLElement>('[data-row-index="0"] [data-visible-col-index="1"]');
+
+    expect(cell).not.toBeNull();
+    await doubleClick(cell!);
+
+    expect(expandedEditor(host)?.value).toBe("short value");
+  });
+
+  it("opens the expanded editor when a Canvas cell is double-clicked", async () => {
+    const host = mountGrid("canvas");
+    await settle();
+    const scroller = host.querySelector<HTMLElement>(".canvas-grid-scroller");
+    const eventSurface = scroller?.querySelector<HTMLElement>(":scope > .relative");
+    const rect = { x: 0, y: 0, left: 0, top: 0, right: 400, bottom: 120, width: 400, height: 120, toJSON: () => ({}) } as DOMRect;
+    vi.spyOn(HTMLCanvasElement.prototype, "getBoundingClientRect").mockReturnValue(rect);
+
+    expect(eventSurface).not.toBeNull();
+    await doubleClick(eventSurface!, { clientX: 200, clientY: 13 });
+
+    expect(expandedEditor(host)?.value).toBe("short value");
+  });
+
+  it("opens the expanded editor when a transposed cell is double-clicked", async () => {
+    const host = mountGrid("dom");
+    await settle();
+    const rowNumber = host.querySelector<HTMLElement>('[data-row-index="0"] .data-grid-row-number');
+
+    expect(rowNumber).not.toBeNull();
+    await doubleClick(rowNumber!);
+    const cell = host.querySelector<HTMLElement>('.data-grid-transpose-row [title="short value"]');
+    expect(cell).not.toBeNull();
+    await doubleClick(cell!);
+
+    expect(expandedEditor(host)?.value).toBe("short value");
+  });
+});

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -173,18 +173,6 @@ describe("DataGrid canvas surfaces", () => {
     expect(dataGridSource.match(/@dblclick="onCanvasDblClick"/g)).toHaveLength(1);
     expect(dataGridSource).toContain("@dblclick.stop");
   });
-
-  it("opens editable cells in the expanded editor on double click across grid layouts", () => {
-    const domHandler = dataGridSource.slice(dataGridSource.indexOf("async function onDomCellDblClick"), dataGridSource.indexOf("function cellEditContentNeedsExpandedEditor"));
-    const canvasHandler = dataGridSource.slice(dataGridSource.indexOf("async function onCanvasDblClick"), dataGridSource.indexOf("function canvasCellContentOverflows"));
-    const transposeHandler = dataGridSource.slice(dataGridSource.indexOf("async function onTransposeCellDblClick"), dataGridSource.indexOf("function onTransposeCellContext"));
-
-    expect(domHandler).toContain("await startCellEdit(item.id, actualColIdx, true);");
-    expect(canvasHandler).toContain("await startCellEdit(item.id, actualColIdx, true);");
-    expect(transposeHandler).toContain("await startCellEdit(item.id, actualColIdx, true);");
-    expect(dataGridSource).not.toContain("startDomCellEdit");
-    expect(dataGridSource).toContain('data-expanded-cell-editor="true"');
-  });
 });
 
 describe("DataGridSearchBar", () => {

--- a/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridSurfaces.spec.ts
@@ -173,6 +173,18 @@ describe("DataGrid canvas surfaces", () => {
     expect(dataGridSource.match(/@dblclick="onCanvasDblClick"/g)).toHaveLength(1);
     expect(dataGridSource).toContain("@dblclick.stop");
   });
+
+  it("opens editable cells in the expanded editor on double click across grid layouts", () => {
+    const domHandler = dataGridSource.slice(dataGridSource.indexOf("async function onDomCellDblClick"), dataGridSource.indexOf("function cellEditContentNeedsExpandedEditor"));
+    const canvasHandler = dataGridSource.slice(dataGridSource.indexOf("async function onCanvasDblClick"), dataGridSource.indexOf("function canvasCellContentOverflows"));
+    const transposeHandler = dataGridSource.slice(dataGridSource.indexOf("async function onTransposeCellDblClick"), dataGridSource.indexOf("function onTransposeCellContext"));
+
+    expect(domHandler).toContain("await startCellEdit(item.id, actualColIdx, true);");
+    expect(canvasHandler).toContain("await startCellEdit(item.id, actualColIdx, true);");
+    expect(transposeHandler).toContain("await startCellEdit(item.id, actualColIdx, true);");
+    expect(dataGridSource).not.toContain("startDomCellEdit");
+    expect(dataGridSource).toContain('data-expanded-cell-editor="true"');
+  });
 });
 
 describe("DataGridSearchBar", () => {


### PR DESCRIPTION
## 变更说明

- 在数据库备份的新建计划和立即备份连接下拉中显示连接分组徽标，嵌套分组沿用现有路径展示，便于区分同名连接。
- 统一数据网格的双击编辑行为：DOM、Canvas 和转置布局中的普通可编辑单元格均直接打开展开式多行编辑器，同时保留布尔、枚举和时间类型的专用编辑器。
- 补充备份连接分组回归测试，并通过真实双击交互覆盖 DOM、Canvas 和转置布局的展开编辑行为。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

### 数据库备份连接分组

![数据库备份连接分组](https://raw.githubusercontent.com/CSXFanMeng/dbx/pr-assets-5476-7821/.github/pr-assets/5476-7821-backup-groups.png)

### 双击单元格展开编辑

![双击单元格展开编辑](https://raw.githubusercontent.com/CSXFanMeng/dbx/pr-assets-5476-7821/.github/pr-assets/5476-7821-expanded-cell-editor.png)

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

- GitHub `frontend` CI 在干净安装后执行 `pnpm check` 并通过。
- 最新 `main` 基线下，相关测试共 3 个文件、66 个测试全部通过。
- `oxfmt --check`、`oxlint --vue-plugin` 和 `vue-tsc --noEmit` 均通过。

## 关联 Issue

Close #5476
Close #7821
