### PR TITLE
fix(sidebar): use sidebar theme color for sticky database rows

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -2806,7 +2806,7 @@ defineExpose({ focusSearch, createNewGroup, collapseAllTreeNodes, locateTabInSid
 
 <style scoped>
 .sticky-database-header {
-  background-color: var(--background);
+  background-color: var(--sidebar);
 }
 
 .connection-tree-scroller {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1773,7 +1773,7 @@ function onKeydown(event: KeyboardEvent) {
   position: sticky;
   top: 0;
   z-index: 2;
-  background-color: var(--background);
+  background-color: var(--sidebar);
 }
 
 .tree-item-connection-tint:hover::before {

--- a/packages/app-tests/sidebarTreeAffordances.test.ts
+++ b/packages/app-tests/sidebarTreeAffordances.test.ts
@@ -24,8 +24,10 @@ test("plain tree sticky headers position the full row wrapper without a divider"
   assert.match(treeItem, /<div v-else :class="\{ 'sidebar-tree-item--sticky': stickyHeader \}" @contextmenu="onTreeItemContextMenu">/);
   assert.doesNotMatch(treeItem, /'tree-item-highlight': highlighted,\s*'sidebar-tree-item--sticky': stickyHeader/);
   assert.match(treeItem, /\.sidebar-tree-item--sticky\s*\{[\s\S]*?position:\s*sticky;/);
+  assert.match(treeItem, /\.sidebar-tree-item--sticky\s*\{[\s\S]*?background-color:\s*var\(--sidebar\);/);
   assert.doesNotMatch(treeItem, /\.sidebar-tree-item--sticky\s*\{[^}]*border-bottom:/);
   assert.doesNotMatch(connectionTree, /sticky-database-header[^\n]*border-b/);
+  assert.match(connectionTree, /\.sticky-database-header\s*\{[\s\S]*?background-color:\s*var\(--sidebar\);/);
   assert.match(connectionTree, /v-for="\(item, index\) in flatNodes"/);
   assert.match(connectionTree, /:sticky-header="isPlainStickyContainerNode\(index\)"/);
   assert.match(connectionTree, /return flatTreeIndex\.value\.stickyContainerIndexByIndex\[index\] === index;/);


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->
问题
各主题下，左侧数据库节点背景色与其他节点不一致。

原因
粘性数据库节点使用了 `--background`，而普通侧栏节点使用 `--sidebar`。

修改
将普通和虚拟滚动两套粘性节点背景统一改为 var(--sidebar)，并增加回归测试。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->
以粉色主题为例

原来:
<img width="503" height="993" alt="image" src="https://github.com/user-attachments/assets/3c09e139-1e44-4677-b85b-c876ff313481" />

修改后:
<img width="503" height="993" alt="image" src="https://github.com/user-attachments/assets/6d58e5b9-4aaf-4060-b347-e0272de3e338" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

侧栏测试通过：15/15
Oxlint 通过
Oxfmt 通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
暂无