### PR TITLE
fix: restore copy current row shortcut Mod+D

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/keyboardShortcuts.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/keyboardShortcuts.spec.ts
@@ -125,8 +125,9 @@ describe("keyboard shortcut matching", () => {
   });
 
   it("matches the edit-table-structure shortcut on Windows and macOS", () => {
-    expect(isEditTableStructureShortcut({ key: "d", ctrlKey: true }, undefined, "Win32")).toBe(true);
-    expect(isEditTableStructureShortcut({ key: "d", metaKey: true }, undefined, "MacIntel")).toBe(true);
+    expect(isEditTableStructureShortcut({ key: "d", ctrlKey: true, shiftKey: true }, undefined, "Win32")).toBe(true);
+    expect(isEditTableStructureShortcut({ key: "d", metaKey: true, shiftKey: true }, undefined, "MacIntel")).toBe(true);
+    expect(isEditTableStructureShortcut({ key: "d", ctrlKey: true }, undefined, "Win32")).toBe(false);
     expect(isEditTableStructureShortcut({ key: "d", ctrlKey: true }, undefined, "MacIntel")).toBe(false);
   });
 

--- a/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
@@ -96,30 +96,32 @@ describe("shortcutRegistry editor actions", () => {
   it("detects go-to-column conflicts only within the grid scope", () => {
     const shortcuts = normalizeShortcutSettings({ goToColumn: "Mod+D" });
 
-    expect(findShortcutConflict("goToColumn", shortcuts.goToColumn, shortcuts)).toBe("editTableStructure");
+    expect(findShortcutConflict("goToColumn", shortcuts.goToColumn, shortcuts)).toBe("copyCurrentRow");
     expect(findShortcutConflict("goToColumn", "Mod+F", shortcuts)).toBeNull();
   });
 
-  it("registers edit table structure as the conflict-free default Mod+D grid action", () => {
+  it("registers copy-current-row Mod+D and edit-table-structure Mod+Shift+D as conflict-free grid defaults", () => {
     const definition = SHORTCUT_DEFINITIONS.find((item) => item.id === "editTableStructure");
 
     expect(definition).toMatchObject({
       labelKey: "settings.shortcutEditTableStructure",
       scope: "grid",
-      defaultShortcut: "Mod+D",
+      defaultShortcut: "Mod+Shift+D",
     });
-    expect(DEFAULT_SHORTCUT_SETTINGS.editTableStructure).toBe("Mod+D");
-    expect(DEFAULT_SHORTCUT_SETTINGS.copyCurrentRow).toBe("");
+    expect(DEFAULT_SHORTCUT_SETTINGS.editTableStructure).toBe("Mod+Shift+D");
+    expect(DEFAULT_SHORTCUT_SETTINGS.copyCurrentRow).toBe("Mod+D");
     expect(findShortcutConflict("editTableStructure", DEFAULT_SHORTCUT_SETTINGS.editTableStructure, DEFAULT_SHORTCUT_SETTINGS)).toBeNull();
+    expect(findShortcutConflict("copyCurrentRow", DEFAULT_SHORTCUT_SETTINGS.copyCurrentRow, DEFAULT_SHORTCUT_SETTINGS)).toBeNull();
     expect(findShortcutConflict("duplicateLine", DEFAULT_SHORTCUT_SETTINGS.duplicateLine, DEFAULT_SHORTCUT_SETTINGS)).toBeNull();
   });
 
-  it("migrates the legacy copy-row Mod+D default without overwriting explicit shortcuts", () => {
-    expect(normalizeShortcutSettings()).toMatchObject({ editTableStructure: "Mod+D", copyCurrentRow: "" });
-    expect(normalizeShortcutSettings({ copyCurrentRow: "Mod+D" })).toMatchObject({ editTableStructure: "Mod+D", copyCurrentRow: "" });
-    expect(normalizeShortcutSettings({ copyCurrentRow: "Shift+Mod+C" })).toMatchObject({ editTableStructure: "Mod+D", copyCurrentRow: "Shift+Mod+C" });
+  it("restores copy-current-row Mod+D after the previous edit-structure migration", () => {
+    expect(normalizeShortcutSettings()).toMatchObject({ editTableStructure: "Mod+Shift+D", copyCurrentRow: "Mod+D" });
+    expect(normalizeShortcutSettings({ copyCurrentRow: "Mod+D" })).toMatchObject({ editTableStructure: "Mod+Shift+D", copyCurrentRow: "Mod+D" });
+    expect(normalizeShortcutSettings({ copyCurrentRow: "Shift+Mod+C" })).toMatchObject({ editTableStructure: "Mod+Shift+D", copyCurrentRow: "Shift+Mod+C" });
     expect(normalizeShortcutSettings({ editTableStructure: "", copyCurrentRow: "Mod+D" })).toMatchObject({ editTableStructure: "", copyCurrentRow: "Mod+D" });
     expect(normalizeShortcutSettings({ editTableStructure: "Shift+Mod+D", copyCurrentRow: "Mod+D" })).toMatchObject({ editTableStructure: "Shift+Mod+D", copyCurrentRow: "Mod+D" });
+    expect(normalizeShortcutSettings({ editTableStructure: "Mod+D", copyCurrentRow: "" })).toMatchObject({ editTableStructure: "Mod+Shift+D", copyCurrentRow: "Mod+D" });
   });
 
   it("registers the new-data-tab mouse modifier as a configurable sidebar shortcut", () => {

--- a/apps/desktop/src/lib/editor/shortcutRegistry.ts
+++ b/apps/desktop/src/lib/editor/shortcutRegistry.ts
@@ -126,6 +126,7 @@ const PLATFORM_DEFAULT_SHORTCUTS: Partial<Record<ShortcutActionId, ReadonlySet<s
 };
 const LEGACY_CLOSE_TAB_DEFAULT = "Meta+W";
 const LEGACY_COPY_CURRENT_ROW_DEFAULT = "Mod+D";
+const EDIT_TABLE_STRUCTURE_DEFAULT = "Mod+Shift+D";
 const TAB_NAVIGATION_HISTORY_ACTIONS: ShortcutActionId[] = ["navigateTabHistoryBack", "navigateTabHistoryForward"];
 
 export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
@@ -307,13 +308,13 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     id: "editTableStructure",
     labelKey: "settings.shortcutEditTableStructure",
     scope: "grid",
-    defaultShortcut: "Mod+D",
+    defaultShortcut: EDIT_TABLE_STRUCTURE_DEFAULT,
   },
   {
     id: "copyCurrentRow",
     labelKey: "settings.shortcutCopyCurrentRow",
     scope: "grid",
-    defaultShortcut: "",
+    defaultShortcut: LEGACY_COPY_CURRENT_ROW_DEFAULT,
   },
   {
     id: "deleteCurrentRow",
@@ -635,9 +636,9 @@ export function normalizeShortcutSettings(settings?: Partial<ShortcutSettings>, 
     }),
   ) as ShortcutSettings;
 
-  if (!hasExplicitShortcut(settings, "editTableStructure") && settings?.copyCurrentRow === LEGACY_COPY_CURRENT_ROW_DEFAULT) {
-    normalized.editTableStructure = LEGACY_COPY_CURRENT_ROW_DEFAULT;
-    normalized.copyCurrentRow = "";
+  if (settings?.copyCurrentRow === "" && settings?.editTableStructure === LEGACY_COPY_CURRENT_ROW_DEFAULT) {
+    normalized.editTableStructure = EDIT_TABLE_STRUCTURE_DEFAULT;
+    normalized.copyCurrentRow = LEGACY_COPY_CURRENT_ROW_DEFAULT;
   }
 
   for (const actionId of TAB_NAVIGATION_HISTORY_ACTIONS) {

--- a/packages/app-tests/keyboardShortcuts.test.ts
+++ b/packages/app-tests/keyboardShortcuts.test.ts
@@ -392,8 +392,8 @@ test("matches Cmd+S for saving", () => {
   assert.equal(isSaveShortcut({ key: "s", metaKey: true }), true);
 });
 
-test("leaves copy current row disabled by default while honoring custom shortcuts", () => {
-  assert.equal(isCopyCurrentRowShortcut({ key: "d", metaKey: true }), false);
+test("matches copy current row Mod+D by default while honoring custom shortcuts", () => {
+  assert.equal(isCopyCurrentRowShortcut({ key: "d", metaKey: true }), true);
   assert.equal(isCopyCurrentRowShortcut({ key: "d", altKey: true }, { copyCurrentRow: "Alt+D" }), true);
 });
 

--- a/packages/app-tests/settingsStore.test.ts
+++ b/packages/app-tests/settingsStore.test.ts
@@ -412,8 +412,8 @@ test("defaults shortcut settings", () => {
   assert.equal(settings.shortcuts.executeSql, "Mod+Enter");
   assert.equal(settings.shortcuts.saveSql, "Mod+S");
   assert.equal(settings.shortcuts.extendSelection, "Alt+W");
-  assert.equal(settings.shortcuts.editTableStructure, "Mod+D");
-  assert.equal(settings.shortcuts.copyCurrentRow, "");
+  assert.equal(settings.shortcuts.editTableStructure, "Mod+Shift+D");
+  assert.equal(settings.shortcuts.copyCurrentRow, "Mod+D");
   assert.equal(settings.shortcuts.deleteCurrentRow, "Delete");
   assert.equal(settings.shortcuts.goToFirstPage, "");
   assert.equal(settings.shortcuts.goToPreviousPage, "");


### PR DESCRIPTION
## Problem

Issue #7391: Command/Ctrl+D for "copy current row" was rebound to "edit table structure".

## Change

- Restore `copyCurrentRow` default to `Mod+D`.
- Move `editTableStructure` default to `Mod+Shift+D`.
- Migrate the prior normalized state back without overwriting explicit user shortcuts.

## Verification

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts apps/desktop/src/lib/__tests__/editor/keyboardShortcuts.spec.ts apps/desktop/src/components/grid/__tests__/DataGridEditTableStructureShortcut.spec.ts` (66 passed)

Fixes #7391