### PR TITLE
improve: SQL 参数弹窗支持忽略占位符

### DIFF
--- a/apps/desktop/src/components/editor/SqlParameterDialog.vue
+++ b/apps/desktop/src/components/editor/SqlParameterDialog.vue
@@ -96,6 +96,11 @@ function clearParameterValues() {
   values.value = next;
 }
 
+function ignoreParameters() {
+  open.value = false;
+  emit("execute", props.sql);
+}
+
 function updateValue(name: string, value: string) {
   const matchedHistory = histories.value[name]?.find((entry) => entry.value === value);
   values.value[name] = { ...(values.value[name] ?? { kind: "string" }), ...(matchedHistory ? { kind: matchedHistory.kind } : {}), value };
@@ -226,6 +231,9 @@ async function copyResolvedSql() {
       </div>
 
       <DialogFooter>
+        <Button type="button" variant="outline" data-testid="sql-parameters-ignore" @click="ignoreParameters">
+          {{ t("sqlParameters.ignore") }}
+        </Button>
         <Button variant="outline" @click="open = false">{{ t("dangerDialog.cancel") }}</Button>
         <Button variant="outline" @click="copyResolvedSql">
           <Copy class="mr-1.5 h-4 w-4" />

--- a/apps/desktop/src/components/editor/__tests__/SqlParameterDialog.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/SqlParameterDialog.spec.ts
@@ -86,6 +86,10 @@ function clearActionButton(): HTMLButtonElement | null {
   return document.body.querySelector('[data-testid="sql-parameters-clear-values"]');
 }
 
+function ignoreActionButton(): HTMLButtonElement | null {
+  return document.body.querySelector('[data-testid="sql-parameters-ignore"]');
+}
+
 function clickRawAction() {
   const button = actionButton();
   expect(button).not.toBeNull();
@@ -94,6 +98,12 @@ function clickRawAction() {
 
 function clickClearAction() {
   const button = clearActionButton();
+  expect(button).not.toBeNull();
+  button!.click();
+}
+
+function clickIgnoreAction() {
+  const button = ignoreActionButton();
   expect(button).not.toBeNull();
   button!.click();
 }
@@ -180,6 +190,38 @@ describe("SqlParameterDialog raw parameter action", () => {
     expect(onExecute).toHaveBeenCalledOnce();
     expect(onExecute).toHaveBeenCalledWith(RAW_SQL);
     expect(state.open).toBe(false);
+  });
+});
+
+describe("SqlParameterDialog ignore parameter action", () => {
+  it("closes the dialog and emits the original SQL without remembering or mutating values", async () => {
+    const { state, onExecute } = await mountDialog();
+
+    clickIgnoreAction();
+    await nextTick();
+
+    expect(state.open).toBe(false);
+    expect(onExecute).toHaveBeenCalledOnce();
+    expect(onExecute).toHaveBeenCalledWith(SQL);
+    expect(historyMocks.remember).not.toHaveBeenCalled();
+    expect(parameterInputs().map((input) => input.value)).toEqual(PARAMETERS.map((parameter) => MIXED_VALUES[parameter.key]?.value ?? ""));
+  });
+
+  it("does not apply current parameter edits when ignoring", async () => {
+    const { state, onExecute } = await mountDialog();
+
+    const firstInput = parameterInputs()[0];
+    expect(firstInput).not.toBeUndefined();
+    firstInput!.value = "changed";
+    firstInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    clickIgnoreAction();
+    await nextTick();
+
+    expect(state.open).toBe(false);
+    expect(onExecute).toHaveBeenCalledWith(SQL);
+    expect(historyMocks.remember).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -5313,6 +5313,7 @@ export default {
     execute: "Execute",
     clearValues: "Clear Values",
     useRawForAll: "Use Raw SQL for All",
+    ignore: "Ignore",
     kind: {
       string: "String",
       number: "Number",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -5051,6 +5051,7 @@ export default withEnglishFallback({
     execute: "Ejecutar",
     clearValues: "Borrar valores",
     useRawForAll: "Usar SQL sin procesar para todos",
+    ignore: "Ignorar",
     kind: {
       string: "Cadena",
       number: "Número",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -5049,6 +5049,7 @@ export default withEnglishFallback({
     execute: "Esegui",
     clearValues: "Cancella valori",
     useRawForAll: "Usa SQL non elaborato per tutti",
+    ignore: "Ignora",
     kind: {
       string: "Stringa",
       number: "Numero",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -5078,6 +5078,7 @@ export default withEnglishFallback({
     execute: "実行",
     clearValues: "値をクリア",
     useRawForAll: "すべてを生の SQL に設定",
+    ignore: "無視",
     kind: {
       string: "文字列",
       number: "数値",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -4743,6 +4743,7 @@ export default withEnglishFallback({
     execute: "실행",
     clearValues: "값 지우기",
     useRawForAll: "모두 원시 SQL로 설정",
+    ignore: "무시",
     kind: {
       string: "문자열",
       number: "숫자",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -5051,6 +5051,7 @@ export default withEnglishFallback({
     execute: "Executar",
     clearValues: "Limpar valores",
     useRawForAll: "Usar SQL bruto para todos",
+    ignore: "Ignorar",
     kind: {
       string: "Texto",
       number: "Número",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -5297,6 +5297,7 @@ export default withEnglishFallback({
     execute: "执行",
     clearValues: "清空参数值",
     useRawForAll: "全部使用原始 SQL",
+    ignore: "忽略",
     kind: {
       string: "字符串",
       number: "数字",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -4374,6 +4374,7 @@ export default withEnglishFallback({
     execute: "執行",
     clearValues: "清空參數值",
     useRawForAll: "全部使用原始 SQL",
+    ignore: "忽略",
     kind: {
       string: "字串",
       number: "數字",


### PR DESCRIPTION
## 问题

Fixes #7332, fixes #6473

SQL 参数弹窗在更新带占位符的语句时，只能替换或全部使用原始 SQL，缺少直接忽略并保留原始占位符的操作。用户希望在更新数据表字段时能一键忽略参数。`${name}`（shell 语法）以及单引号字符串内的 `${name}` 同样会被识别为参数，例如达梦里 `'...&SessionKey=${Session.SessionKey}'` 被替换为空，因此同一个“忽略”入口也覆盖了该场景。

## 修改

- `SqlParameterDialog` 新增“忽略”按钮，点击后关闭弹窗并直接执行原始 SQL，不写入参数历史、不修改当前参数
- 补全全部语言文案
- 增加单测覆盖忽略操作的关闭、原样 emit、历史不写入、当前编辑不生效

## 验证

- `pnpm exec vitest run apps/desktop/src/components/editor/__tests__/SqlParameterDialog.spec.ts`（11/11）
- `pnpm typecheck`
- `pnpm lint`
