### PR TITLE
fix: 保留 Ctrl+Shift+F 格式化快捷键，不再弹出查找框

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -116,7 +116,7 @@ import type { SqlHighlighter } from "@/lib/sql/sqlHighlighter";
 import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticColors, editorThemeAppearanceFor, loadEditorTheme, editorFontTheme, shellLineCommentTheme, sqlCompletionTheme, sqlSemanticHighlightTheme } from "@/lib/editor/editorThemes";
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSqlShortcutDomHandler, isCharacterProducingShortcut } from "@/lib/editor/queryEditorSqlShortcut";
-import { createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
+import { createQueryEditorFindShortcutHandler, createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 import { buildQueryEditorLineNumbersExtension, createQueryEditorLineNumberAlignmentExtension } from "@/lib/editor/queryEditorLineNumbers";
 import { searchKeymapWithoutModD } from "@/lib/editor/codemirrorSearchKeymap";
 import { defaultKeymapForGlobalShortcuts } from "@/lib/editor/codemirrorDefaultKeymap";
@@ -2057,6 +2057,10 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
     openReplace,
     isReadOnly: () => !!props.readOnly,
   });
+  const findShortcutHandler = createQueryEditorFindShortcutHandler({
+    shortcut: shortcuts.find,
+    openSearch,
+  });
   const sqlShortcutActions = enabledSqlShortcutActions(settingsStore.editorSettings.sqlShortcuts);
   const sqlShortcutKeymapActions = sqlShortcutActions.filter((action) => !isCharacterProducingShortcut(action.shortcut));
   const sqlShortcutBindings = sqlShortcutKeymapActions.flatMap((action) => binding(action.shortcut, (currentView) => runSqlShortcutAction(action, currentView)));
@@ -2065,6 +2069,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
     (action, currentView, event) => runSqlShortcutAction(action, currentView, event),
   );
   const combinedDomKeydownHandler = (event: KeyboardEvent, view: EditorViewType) => {
+    if (findShortcutHandler(event)) return true;
     if (replaceShortcutHandler(event)) return true;
     return sqlShortcutDomHandler(event, view);
   };
@@ -2153,6 +2158,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
           openSearch,
           openReplace,
           isReadOnly: () => !!props.readOnly,
+          includeFind: false,
         }),
         ...sqlShortcutBindings,
       ]),

--- a/apps/desktop/src/components/editor/__tests__/QueryEditorSearchKeymap.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/QueryEditorSearchKeymap.spec.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 // pi-lens-ignore: typescript:2307
 import { createQueryEditorExecutionShortcutBindings } from "@/lib/editor/queryEditorExecutionShortcut";
 // pi-lens-ignore: typescript:2307
-import { createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
+import { createQueryEditorFindShortcutHandler, createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
 
 describe("QueryEditor search keymap precedence", () => {
   it("runs configured editor actions before the built-in search fallback", () => {
@@ -88,6 +88,36 @@ describe("QueryEditor search keymap precedence", () => {
     expect(runScopeHandlers(view, new KeyboardEvent("keydown", { key: "f", ctrlKey: true }), "editor")).toBe(true);
     expect(openSearch).toHaveBeenCalledOnce();
     expect(lowerPrioritySearch).not.toHaveBeenCalled();
+    view.destroy();
+  });
+
+  it("handles Mod+F exactly without consuming a Shift+Mod+F format binding", () => {
+    const openSearch = vi.fn(() => true);
+    const formatSql = vi.fn(() => true);
+    const findShortcutHandler = createQueryEditorFindShortcutHandler({ shortcut: "Mod+F", openSearch });
+    const view = new EditorView({
+      parent: document.createElement("div"),
+      state: EditorState.create({
+        extensions: [
+          Prec.high(
+            EditorView.domEventHandlers({
+              keydown: findShortcutHandler,
+            }),
+          ),
+          Prec.high(keymap.of([{ key: "Shift-Mod-f", preventDefault: true, run: formatSql }, ...createQueryEditorSearchKeymap({ openSearch, openReplace: () => true, isReadOnly: () => false, includeFind: false })])),
+        ],
+      }),
+    });
+
+    const shifted = new KeyboardEvent("keydown", { key: "f", ctrlKey: true, shiftKey: true, bubbles: true, cancelable: true });
+    expect(runScopeHandlers(view, shifted, "editor")).toBe(true);
+    expect(formatSql).toHaveBeenCalledOnce();
+    expect(openSearch).not.toHaveBeenCalled();
+
+    const find = new KeyboardEvent("keydown", { key: "f", ctrlKey: true, bubbles: true, cancelable: true });
+    view.contentDOM.dispatchEvent(find);
+    expect(openSearch).toHaveBeenCalledOnce();
+    expect(find.defaultPrevented).toBe(true);
     view.destroy();
   });
 });

--- a/apps/desktop/src/lib/editor/queryEditorSearchKeymap.ts
+++ b/apps/desktop/src/lib/editor/queryEditorSearchKeymap.ts
@@ -7,27 +7,48 @@ interface QueryEditorSearchKeymapOptions {
   openSearch: () => boolean;
   openReplace: () => boolean;
   isReadOnly: () => boolean;
+  includeFind?: boolean;
 }
 
 export function createQueryEditorSearchKeymap(options: QueryEditorSearchKeymapOptions): KeyBinding[] {
-  return [
-    {
+  const bindings: KeyBinding[] = [];
+  if (options.includeFind !== false) {
+    bindings.push({
       key: "Mod-f",
       preventDefault: true,
       run: options.openSearch,
-    },
-    {
-      key: "Mod-h",
-      preventDefault: true,
-      // Consume the shortcut in previews without exposing mutation controls.
-      run: () => options.isReadOnly() || options.openReplace(),
-    },
-  ];
+    });
+  }
+  bindings.push({
+    key: "Mod-h",
+    preventDefault: true,
+    // Consume the shortcut in previews without exposing mutation controls.
+    run: () => options.isReadOnly() || options.openReplace(),
+  });
+  return bindings;
 }
 
 export function createQueryEditorReplaceShortcutBindings(shortcut: string, openReplace: () => boolean): KeyBinding[] {
   const normalizedShortcut = shortcut.trim();
   return normalizedShortcut && /\s/.test(normalizedShortcut) ? [{ key: shortcutToCodeMirrorKey(normalizedShortcut), preventDefault: true, run: openReplace }] : [];
+}
+
+/**
+ * Handle the configurable find shortcut outside CodeMirror's character keymap.
+ * The same shifted-character matching issue described for replace applies to
+ * `Mod+F`: CodeMirror lets it match `Shift+Mod+F`, so a bare `Mod+F` find
+ * binding can consume a custom `Shift+Mod+F` format action before the exact
+ * format binding is considered.
+ */
+export function createQueryEditorFindShortcutHandler(options: { shortcut: string; openSearch: () => boolean }): (event: KeyboardEvent) => boolean {
+  const shortcut = options.shortcut.trim();
+  if (!shortcut || /\s/.test(shortcut)) return () => false;
+
+  return (event) => {
+    if (!matchesShortcut(event, shortcut)) return false;
+    options.openSearch();
+    return true;
+  };
 }
 
 /**


### PR DESCRIPTION
## 问题

SQL 格式化快捷键 `Ctrl+Shift+F` 会被 `Mod+F` 搜索快捷键抢占，导致按下格式化快捷键时弹出查找框而不是执行格式化。根因是 CodeMirror 的裸 `Mod-F` 绑定会先匹配 Shift 修饰键事件。

## 修改

- 将可配置的查找快捷键改到 CodeMirror 字符 keymap 之外，用精确匹配的 DOM handler 处理 `Mod+F`
- 内置搜索 keymap 增加 `includeFind: false`，避免裸 `Mod-f` 再次抢占 `Shift+Mod+F`
- 补充对应键位优先级测试

## 验证

- `pnpm exec vitest run apps/desktop/src/components/editor/__tests__/QueryEditorSearchKeymap.spec.ts apps/desktop/src/components/editor/__tests__/EditorSearchPanel.spec.ts`
- `pnpm exec oxfmt --check` 通过
- `pnpm lint` 通过

Fixes #7357