### PR TITLE
fix: 单元格编辑器聚焦时只全选一次

### DIFF
--- a/apps/desktop/src/composables/__tests__/useDataGridEditor.spec.ts
+++ b/apps/desktop/src/composables/__tests__/useDataGridEditor.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { computed, nextTick, ref, type Ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { clearDataGridPendingSnapshot, DATA_GRID_QUICK_ENTRY_DRAFT_ROW_ID, useDataGridEditor } from "@/composables/useDataGridEditor";
@@ -872,5 +873,33 @@ describe("useDataGridEditor saveChanges reload", () => {
     expect(customSave).toHaveBeenCalledTimes(1);
     expect(prepareFullReload).not.toHaveBeenCalled();
     expect(emit).not.toHaveBeenCalledWith("reload", expect.anything());
+  });
+});
+
+describe("useDataGridEditor cell edit focus", () => {
+  it("selects the editor value only on the first frame so fast typing is not clobbered (#7336)", async () => {
+    const editor = createEditor(undefined, true, undefined, undefined, [["long json value", "hidden", "last"]]);
+    const select = vi.fn();
+    const setSelectionRange = vi.fn();
+    const focus = vi.fn();
+    const input = { focus, select, setSelectionRange, dataset: {}, value: "long json value" };
+    const rafCallbacks: Array<(time: number) => void> = [];
+    vi.stubGlobal("document", { querySelector: () => input });
+    vi.stubGlobal("requestAnimationFrame", (callback: (time: number) => void) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    });
+
+    editor.startEdit(0, 0);
+    await nextTick();
+    for (let frame = 0; frame < 3; frame += 1) {
+      const callbacks = rafCallbacks.splice(0);
+      callbacks.forEach((callback) => callback(0));
+      await nextTick();
+    }
+
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(setSelectionRange).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/desktop/src/composables/useDataGridEditor.ts
+++ b/apps/desktop/src/composables/useDataGridEditor.ts
@@ -361,13 +361,20 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
   }
 
   function focusEditInput(select = true) {
-    const focusInput = () => {
+    // `selectText` is tri-state: true selects the full value once when the
+    // editor opens, false places the caret at the end, and undefined only
+    // refocuses without touching the selection. The requestAnimationFrame
+    // retry below uses the undefined mode so a user who starts typing or
+    // moving the caret immediately after the editor opens is not clobbered by
+    // a second select-all on a later frame.
+    const focusInput = (selectText?: boolean) => {
       if (typeof document === "undefined") return;
       const scroller = getScrollerElement();
       const root = scroller?.closest("[data-grid-root]");
       const input = (root ?? document).querySelector(".cell-edit-input") as HTMLInputElement | HTMLTextAreaElement | null;
       if (input) focusDataGridEditorWithoutScrolling(input, scroller);
-      if (select && input) {
+      if (selectText === undefined) return;
+      if (selectText && input) {
         if (input instanceof HTMLTextAreaElement && input.dataset.expandedCellEditor === "true") {
           // Expanded editors must match single-line editors: a double-click selects the whole value.
           input.select();
@@ -382,11 +389,11 @@ export function useDataGridEditor(options: UseDataGridEditorOptions) {
       }
     };
     nextTick(() => {
-      focusInput();
+      focusInput(select);
       if (typeof requestAnimationFrame === "undefined") return;
       let attempts = 0;
       const focusNextFrame = () => {
-        focusInput();
+        focusInput(undefined);
         attempts += 1;
         if (attempts < 3) requestAnimationFrame(focusNextFrame);
       };


### PR DESCRIPTION
## 问题

Fixes #7336

编辑 mediumtext/longtext 这类大字段时，`focusEditInput()` 在打开编辑器后的连续 3 帧 `requestAnimationFrame` 里反复执行“全选”。用户双击进入编辑后如果紧接着输入或移动光标，后续帧会再次全选整个值，下一次按键就把原来的长文本整体替换掉，最终保存的内容只剩新输入的一小段。这正是“保存长 JSON 后只剩一部分”的高概率路径。

## 修改

- `focusEditInput(select)` 改为三态：`true` 在首帧全选一次，`false` 把光标放到末尾，`undefined` 只恢复焦点、不碰选区。
- 首帧仍执行一次全选；`requestAnimationFrame` 的重试帧只恢复焦点，不再重复全选，避免和用户输入产生竞态。

## 验证

- 新增 `useDataGridEditor.spec.ts` 回归用例：模拟 `startEdit` 后连续推进 3 帧，断言 `select` 只被调用一次（旧实现会调用多次，测试先失败后通过）。
- `pnpm exec vitest run apps/desktop/src/composables/__tests__/useDataGridEditor.spec.ts`（40/40）

## 说明

原始 issue 还提到“复制也不完整”，那部分可能涉及大字段预览/水合路径，与本次修复的编辑竞态不是同一根因；本次先收窄到已确认的 `focusEditInput` 全选竞态。
