### PR TITLE
fix: 保留查询编辑器 Shift 点击选区

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1337,6 +1337,11 @@ function updateEditorSelectionDropCursor(currentView: EditorViewType, event: Mou
 }
 
 function startEditorSelectionDrag(currentView: EditorViewType, event: MouseEvent): boolean {
+  // Shift is CodeMirror's native extend-selection gesture. Keep it out of the
+  // custom selection drag path so a shift-click inside the current selection
+  // extends or shrinks the selection instead of collapsing it to the cursor.
+  if (event.shiftKey) return false;
+
   const selection = selectedRangeAtPointer(currentView, event);
   if (!selection) return false;
 

--- a/apps/desktop/src/components/editor/__tests__/QueryEditorContextMenu.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/QueryEditorContextMenu.spec.ts
@@ -165,3 +165,16 @@ describe("QueryEditor batch column selection", () => {
     expect(source).toContain("maxRenderedOptions: batchColumnSelectionExpandedRendering ? Number.MAX_SAFE_INTEGER : 100,");
   });
 });
+
+describe("QueryEditor pointer selection", () => {
+  it("lets CodeMirror handle shift-click instead of starting the selection drag gesture", () => {
+    const start = source.indexOf("function startEditorSelectionDrag");
+    const end = source.indexOf("\n}\n\nfunction executeFromContextMenu", start);
+    const dragSource = source.slice(start, end);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    expect(dragSource).toContain("if (event.shiftKey) return false;");
+    expect(dragSource.indexOf("if (event.shiftKey) return false;")).toBeLessThan(dragSource.indexOf("const selection = selectedRangeAtPointer"));
+  });
+});


### PR DESCRIPTION
Fixes #7451

## 原因
`startEditorSelectionDrag` 把 Shift+点击当成自定义选区拖动，抢走了 CodeMirror 原生扩展/收缩选区的手势。因此在已有选区内部按住 Shift 点击时，选区会被塌缩而不是按原生逻辑调整。

## 修改
`apps/desktop/src/components/editor/QueryEditor.vue`
- `startEditorSelectionDrag` 在 `event.shiftKey` 时直接返回 `false`，交给 CodeMirror 原生处理。

## 验证
- 新增单测：`QueryEditorContextMenu.spec.ts`，9/9 通过。
- 真实浏览器 Playwright E2E：在 CodeMirror 中设置 `[0,8]` 选区后，对位置 3 执行 Shift+点击，得到选区 `[0,3]`，确认原生扩展选区生效。
- `oxlint` 相关文件通过。
- 已知无关 typecheck 失败仍存在：`fast-xml-parser` / `smol-toml` 等依赖缺失。