### PR TITLE
improve(redis): 优化 Key 列表与值视图滚动条

### DIFF
--- a/apps/desktop/src/components/redis/RedisHorizontalScrollbar.vue
+++ b/apps/desktop/src/components/redis/RedisHorizontalScrollbar.vue
@@ -116,7 +116,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="redis-horizontal-scroll-host" :class="{ 'is-scrolling': isScrolling, 'is-dragging': isDragging }">
-    <div ref="scrollRef" class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="onScroll">
+    <div ref="scrollRef" class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="onScroll" @mouseenter="updateMetrics">
       <slot />
     </div>
     <div v-if="hasOverflow" ref="trackRef" class="redis-format-tabs-scrollbar" @pointerdown="onTrackPointerDown">

--- a/apps/desktop/src/components/redis/RedisHorizontalScrollbar.vue
+++ b/apps/desktop/src/components/redis/RedisHorizontalScrollbar.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+
+const HIDE_DELAY = 800;
+
+const scrollRef = ref<HTMLElement>();
+const trackRef = ref<HTMLElement>();
+const thumbRef = ref<HTMLElement>();
+const hasOverflow = ref(false);
+const isScrolling = ref(false);
+const isDragging = ref(false);
+const thumbStyle = ref({ insetInlineStart: "0%", width: "100%" });
+
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let dragState: {
+  pointerOffset: number;
+  trackLeft: number;
+  trackWidth: number;
+  thumbWidth: number;
+  maxScrollLeft: number;
+} | null = null;
+
+function clearHideTimer() {
+  if (!hideTimer) return;
+  clearTimeout(hideTimer);
+  hideTimer = null;
+}
+
+function scheduleHide() {
+  clearHideTimer();
+  hideTimer = setTimeout(() => {
+    isScrolling.value = false;
+    hideTimer = null;
+  }, HIDE_DELAY);
+}
+
+function updateMetrics() {
+  const element = scrollRef.value;
+  if (!element) return;
+
+  const maxScrollLeft = Math.max(0, element.scrollWidth - element.clientWidth);
+  hasOverflow.value = maxScrollLeft > 1;
+  if (!hasOverflow.value) {
+    thumbStyle.value = { insetInlineStart: "0%", width: "100%" };
+    return;
+  }
+
+  const thumbWidth = Math.min(100, Math.max(10, (element.clientWidth / element.scrollWidth) * 100));
+  const thumbTravel = Math.max(0, 100 - thumbWidth);
+  thumbStyle.value = {
+    insetInlineStart: `${(element.scrollLeft / maxScrollLeft) * thumbTravel}%`,
+    width: `${thumbWidth}%`,
+  };
+}
+
+function onScroll() {
+  updateMetrics();
+  isScrolling.value = true;
+  scheduleHide();
+}
+
+function onTrackPointerDown(event: PointerEvent) {
+  const element = scrollRef.value;
+  const track = trackRef.value;
+  const thumb = thumbRef.value;
+  if (!element || !track || !thumb || !hasOverflow.value) return;
+
+  event.preventDefault();
+  const trackRect = track.getBoundingClientRect();
+  const thumbRect = thumb.getBoundingClientRect();
+  const pointerOnThumb = event.target === thumb || thumb.contains(event.target as Node);
+  dragState = {
+    pointerOffset: pointerOnThumb ? event.clientX - thumbRect.left : thumbRect.width / 2,
+    trackLeft: trackRect.left,
+    trackWidth: trackRect.width,
+    thumbWidth: thumbRect.width,
+    maxScrollLeft: element.scrollWidth - element.clientWidth,
+  };
+  isDragging.value = true;
+  isScrolling.value = true;
+  window.addEventListener("pointermove", onPointerMove);
+  window.addEventListener("pointerup", stopDragging);
+  window.addEventListener("pointercancel", stopDragging);
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (!dragState || !scrollRef.value) return;
+  const travel = Math.max(1, dragState.trackWidth - dragState.thumbWidth);
+  const thumbLeft = Math.min(Math.max(event.clientX - dragState.trackLeft - dragState.pointerOffset, 0), travel);
+  scrollRef.value.scrollLeft = (thumbLeft / travel) * dragState.maxScrollLeft;
+  updateMetrics();
+}
+
+function stopDragging() {
+  dragState = null;
+  isDragging.value = false;
+  scheduleHide();
+  window.removeEventListener("pointermove", onPointerMove);
+  window.removeEventListener("pointerup", stopDragging);
+  window.removeEventListener("pointercancel", stopDragging);
+}
+
+onMounted(() => {
+  resizeObserver = new ResizeObserver(updateMetrics);
+  if (scrollRef.value) resizeObserver.observe(scrollRef.value);
+  void nextTick(updateMetrics);
+});
+
+onBeforeUnmount(() => {
+  stopDragging();
+  clearHideTimer();
+  resizeObserver?.disconnect();
+});
+</script>
+
+<template>
+  <div class="redis-horizontal-scroll-host" :class="{ 'is-scrolling': isScrolling, 'is-dragging': isDragging }">
+    <div ref="scrollRef" class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="onScroll">
+      <slot />
+    </div>
+    <div v-if="hasOverflow" ref="trackRef" class="redis-format-tabs-scrollbar" @pointerdown="onTrackPointerDown">
+      <div class="redis-format-tabs-scrollbar__thumb" :style="thumbStyle" ref="thumbRef" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.redis-horizontal-scroll-host {
+  position: relative;
+  min-width: 0;
+  max-width: 100%;
+  flex: 1 1 auto;
+}
+
+.redis-format-tabs-scroll {
+  scrollbar-width: none;
+  scrollbar-gutter: auto;
+  overflow-y: hidden;
+}
+
+.redis-format-tabs-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.redis-format-tabs-scrollbar {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 1px;
+  z-index: 2;
+  height: 7px;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  touch-action: none;
+  transition: opacity 140ms ease;
+}
+
+.redis-horizontal-scroll-host:hover .redis-format-tabs-scrollbar,
+.redis-horizontal-scroll-host.is-scrolling .redis-format-tabs-scrollbar,
+.redis-horizontal-scroll-host.is-dragging .redis-format-tabs-scrollbar {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.redis-format-tabs-scrollbar::before,
+.redis-format-tabs-scrollbar__thumb {
+  position: absolute;
+  top: 1px;
+  height: 5px;
+  border-radius: 999px;
+}
+
+.redis-format-tabs-scrollbar::before {
+  content: "";
+  inset-inline: 0;
+  background: color-mix(in oklch, var(--foreground) 10%, transparent);
+}
+
+.redis-format-tabs-scrollbar__thumb {
+  min-width: 20px;
+  background: color-mix(in oklch, var(--foreground) 38%, transparent);
+}
+</style>

--- a/apps/desktop/src/components/redis/RedisKeyBrowser.vue
+++ b/apps/desktop/src/components/redis/RedisKeyBrowser.vue
@@ -2382,7 +2382,7 @@ defineExpose({ focusSearch, insertCommand, executeCommand: executeAiCommand });
             <template #default="{ item: row }">
               <CustomContextMenu :items="redisKeyContextMenuItems(row.node)" v-slot="{ onContextMenu, isOpen }">
                 <div
-                  class="flex items-center gap-2 border-b px-3 text-[13px] cursor-pointer select-none group"
+                  class="flex items-center gap-2 border-b px-1.5 text-[13px] cursor-pointer select-none group"
                   :class="[
                     isOpen || (row.node.kind === 'leaf' && selectedKeyRaw === row.node.keyRaw) ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/40',
                     row.node.kind === 'leaf' ? (isLeafChecked(row.node.keyRaw) && selectedKeyRaw !== row.node.keyRaw ? 'bg-primary/10' : undefined) : groupSelectedCount(row.node) > 0 ? 'bg-primary/10' : undefined,
@@ -2391,7 +2391,7 @@ defineExpose({ focusSearch, insertCommand, executeCommand: executeAiCommand });
                   @click="onRowClick(row.node, $event)"
                   @contextmenu="(event) => onRedisRowContextMenu(event, row.node, onContextMenu)"
                 >
-                  <div class="min-w-0 flex flex-1 items-center gap-1 overflow-hidden" :style="{ paddingLeft: `${12 + row.depth * 16}px` }">
+                  <div class="min-w-0 flex flex-1 items-center gap-1 overflow-hidden" :style="{ paddingLeft: `${4 + row.depth * 10}px` }">
                     <template v-if="row.node.kind === 'group'">
                       <input
                         type="checkbox"

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -60,6 +60,7 @@ import {
 import { decompressRedisValue, decodeBase64RedisValue, decodePickle, decodeProtobuf, isGzipMagic, type RedisDecompressAlgorithm } from "@/lib/redis/codec";
 import { canFullHighlightRedisText, findRedisTextMatches, nextRedisSearchMatchIndex, REDIS_VALUE_SEARCH_MATCH_LIMIT, renderRedisTextSearchHtml, redisValueSearchStatus } from "@/lib/redis/redisValueSearch";
 import TextContentSearchBar from "@/components/common/TextContentSearchBar.vue";
+import RedisHorizontalScrollbar from "@/components/redis/RedisHorizontalScrollbar.vue";
 import { decodeJsonUnicodeEscapes, formatJsonSource, mapDisplayToRaw } from "@/lib/common/safeJsonFormat";
 import { unixSecondsToCalendarDateTime } from "@/components/ui/date-time-picker/dateTimePicker";
 import { applyRedisExpiryPolicy, type RedisExpiryMode, redisExpiryModeForTtl, validateRedisExpiry } from "@/lib/redis/redisExpiry";
@@ -97,8 +98,6 @@ const REDIS_AUTO_REFRESH_INTERVAL_STORAGE_KEY = "dbx-redis-auto-refresh-interval
 const REDIS_AUTO_REFRESH_INTERVAL_OPTIONS = [1, 3, 5, 10] as const;
 const REDIS_COLLECTION_ROW_HEIGHT = 32;
 const REDIS_STREAM_MIN_ROW_HEIGHT = 96;
-const REDIS_FORMAT_SCROLLBAR_HIDE_DELAY = 800;
-
 const data = ref<RedisValue | null>(null);
 const loading = ref(false);
 const loadingMore = ref(false);
@@ -767,7 +766,6 @@ const canHighlightMemberSurface = computed(() => canHighlightContentSearch.value
 
 let collectionSearchTimer: ReturnType<typeof setTimeout> | null = null;
 let collectionSearchRequestId = 0;
-const redisFormatScrollbarTimers = new Map<HTMLElement, ReturnType<typeof setTimeout>>();
 let hashResizeStartX = 0;
 let hashResizeStartWidth = 0;
 let zsetResizeStartX = 0;
@@ -777,31 +775,6 @@ function shouldPauseAutoValueRefresh(): boolean {
   const loadedPageSize = data.value ? redisValueCollectionItems(data.value).length : 0;
   const hasExpandedCollectionPage = collectionItems.value.length > loadedPageSize;
   return showMemberDetail.value || editingZsetMemberKey.value !== null || showHashFieldTtlDialog.value || valueSearchOpen.value || Boolean(collectionSearchQuery.value.trim()) || Boolean(activeCollectionSearchQuery.value) || searchLoading.value || loadingMore.value || hasExpandedCollectionPage;
-}
-
-function hideRedisFormatScrollbar(element: HTMLElement) {
-  const timer = redisFormatScrollbarTimers.get(element);
-  if (timer) clearTimeout(timer);
-  redisFormatScrollbarTimers.delete(element);
-  element.classList.remove("redis-format-tabs-scroll--active");
-}
-
-function scheduleHideRedisFormatScrollbar(element: HTMLElement) {
-  const timer = redisFormatScrollbarTimers.get(element);
-  if (timer) clearTimeout(timer);
-  redisFormatScrollbarTimers.set(
-    element,
-    setTimeout(() => hideRedisFormatScrollbar(element), REDIS_FORMAT_SCROLLBAR_HIDE_DELAY),
-  );
-}
-
-function showRedisFormatScrollbar(event: Event) {
-  const element = event.currentTarget;
-  if (!(element instanceof HTMLElement)) return;
-  const timer = redisFormatScrollbarTimers.get(element);
-  if (timer) clearTimeout(timer);
-  element.classList.add("redis-format-tabs-scroll--active");
-  scheduleHideRedisFormatScrollbar(element);
 }
 
 type PendingDelete = { kind: "key" } | { kind: "hash"; field: string } | { kind: "list"; index: number } | { kind: "set"; member: string } | { kind: "zset"; member: string };
@@ -2725,8 +2698,6 @@ onBeforeUnmount(() => {
   stopResizeHashColumns();
   stopResizeZsetColumns();
   if (collectionSearchTimer) clearTimeout(collectionSearchTimer);
-  for (const timer of redisFormatScrollbarTimers.values()) clearTimeout(timer);
-  redisFormatScrollbarTimers.clear();
 });
 
 defineExpose({ focusSearch });
@@ -2833,7 +2804,7 @@ defineExpose({ focusSearch });
       <div v-if="isStringLikeKind && stringValueDetail" class="flex-1 flex flex-col overflow-hidden">
         <div class="flex h-9 items-center gap-2 border-b px-4 text-xs shrink-0">
           <span class="shrink-0 text-muted-foreground">{{ t("redis.codecRowLabel") }}</span>
-          <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
+          <RedisHorizontalScrollbar>
             <Button
               v-for="codec in REDIS_VALUE_CODEC_ORDER"
               :key="codec"
@@ -2847,7 +2818,7 @@ defineExpose({ focusSearch });
             >
               {{ redisCodecLabel(codec) }}
             </Button>
-          </div>
+          </RedisHorizontalScrollbar>
           <FileArchive v-if="!isStringValueTruncated && stringGzipBadge && stringValueCodec === 'none'" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" :title="t('redis.gzipBadgeTitle')" :aria-label="t('redis.gzipBadgeTitle')" />
           <span class="flex-1" />
           <label v-if="isTextRedisFormat(stringValueView) || activeStructuredStringDetail || isDecompressCodec(stringValueCodec)" class="flex items-center gap-1.5 text-muted-foreground">
@@ -2858,7 +2829,7 @@ defineExpose({ focusSearch });
         </div>
         <div class="flex h-9 items-center gap-2 border-b px-4 text-xs shrink-0">
           <span class="shrink-0 text-muted-foreground">{{ t("redis.viewRowLabel") }}</span>
-          <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
+          <RedisHorizontalScrollbar>
             <Button
               v-for="format in REDIS_VALUE_FORMAT_DISPLAY_ORDER"
               :key="format"
@@ -2871,7 +2842,7 @@ defineExpose({ focusSearch });
             >
               {{ redisFormatLabel(format, stringValueDetail.rawLabel) }}
             </Button>
-          </div>
+          </RedisHorizontalScrollbar>
           <span class="flex-1" />
           <div v-if="stringValueView === 'json' && stringValueDetail.json && stringValueCodec === 'none'" class="flex shrink-0 overflow-hidden rounded-md border bg-muted/20 p-0.5">
             <Button variant="ghost" size="sm" class="h-6 shrink-0 rounded-[5px] px-2 text-xs" :class="{ 'bg-background shadow-sm': !redisJsonDecoded }" @click="setRedisJsonUnicodeMode('raw')">{{ t("redis.jsonViewRaw") }}</Button>
@@ -3613,11 +3584,11 @@ defineExpose({ focusSearch });
         <template v-else>
           <div class="flex h-9 items-center gap-2 border-b px-5 text-xs">
             <span class="shrink-0 text-muted-foreground">{{ t("redis.codecRowLabel") }}</span>
-            <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
+            <RedisHorizontalScrollbar>
               <Button v-for="codec in REDIS_VALUE_CODEC_ORDER" :key="codec" variant="ghost" size="sm" class="h-6 shrink-0 rounded-[5px] px-2 text-xs" :class="{ 'bg-background shadow-sm': memberValueCodec === codec }" @click="setMemberValueCodec(codec)">
                 {{ redisCodecLabel(codec) }}
               </Button>
-            </div>
+            </RedisHorizontalScrollbar>
             <span class="flex-1" />
             <label v-if="isTextRedisFormat(memberValueView) || activeStructuredMemberDetail || isDecompressCodec(memberValueCodec)" class="flex items-center gap-1.5 text-muted-foreground">
               <WrapText class="h-3.5 w-3.5" />
@@ -3627,7 +3598,7 @@ defineExpose({ focusSearch });
           </div>
           <div class="flex h-9 items-center gap-2 border-b px-5 text-xs">
             <span class="shrink-0 text-muted-foreground">{{ t("redis.viewRowLabel") }}</span>
-            <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
+            <RedisHorizontalScrollbar>
               <Button
                 v-for="format in REDIS_VALUE_FORMAT_DISPLAY_ORDER"
                 :key="format"
@@ -3640,7 +3611,7 @@ defineExpose({ focusSearch });
               >
                 {{ redisFormatLabel(format, selectedMemberDetail.rawLabel) }}
               </Button>
-            </div>
+            </RedisHorizontalScrollbar>
             <span class="flex-1" />
             <div v-if="memberValueView === 'json' && selectedMemberDetail.json && memberValueCodec === 'none'" class="flex shrink-0 overflow-hidden rounded-md border bg-muted/20 p-0.5">
               <Button variant="ghost" size="sm" class="h-6 shrink-0 rounded-[5px] px-2 text-xs" :class="{ 'bg-background shadow-sm': !redisJsonDecoded }" @click="setRedisJsonUnicodeMode('raw')">{{ t("redis.jsonViewRaw") }}</Button>
@@ -3744,54 +3715,6 @@ defineExpose({ focusSearch });
     </Dialog>
   </div>
 </template>
-
-<style scoped>
-.redis-format-tabs-scroll {
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-
-.redis-format-tabs-scroll::-webkit-scrollbar {
-  width: 5px !important;
-  height: 5px !important;
-  -webkit-appearance: none;
-}
-
-.redis-format-tabs-scroll::-webkit-scrollbar:hover,
-.redis-format-tabs-scroll::-webkit-scrollbar:active {
-  width: 5px !important;
-  height: 5px !important;
-}
-
-.redis-format-tabs-scroll::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.redis-format-tabs-scroll::-webkit-scrollbar-thumb {
-  background: transparent;
-  border-radius: 999px;
-}
-
-.redis-format-tabs-scroll--active {
-  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 45%, transparent) transparent;
-}
-
-.redis-format-tabs-scroll--active::-webkit-scrollbar-thumb {
-  background: color-mix(in oklab, var(--muted-foreground) 45%, transparent);
-}
-
-/* WebKit uses the native scrollbar dimensions when scrollbar-color is set. Keep
- * the custom 5px scrollbar active in the desktop WebView as well. */
-@supports (-webkit-appearance: none) {
-  .redis-format-tabs-scroll,
-  .redis-format-tabs-scroll--active {
-    scrollbar-width: auto;
-    scrollbar-color: auto !important;
-  }
-}
-</style>
 
 <style scoped>
 :deep(.document-search-match),

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -3775,6 +3775,15 @@ defineExpose({ focusSearch });
 .redis-format-tabs-scroll--active::-webkit-scrollbar-thumb {
   background: color-mix(in oklab, var(--muted-foreground) 45%, transparent);
 }
+
+/* WebKit uses the native scrollbar dimensions when scrollbar-color is set. Keep
+ * the custom 5px scrollbar active in the desktop WebView as well. */
+@supports selector(::-webkit-scrollbar) {
+  .redis-format-tabs-scroll,
+  .redis-format-tabs-scroll--active {
+    scrollbar-color: auto;
+  }
+}
 </style>
 
 <style scoped>

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -97,6 +97,7 @@ const REDIS_AUTO_REFRESH_INTERVAL_STORAGE_KEY = "dbx-redis-auto-refresh-interval
 const REDIS_AUTO_REFRESH_INTERVAL_OPTIONS = [1, 3, 5, 10] as const;
 const REDIS_COLLECTION_ROW_HEIGHT = 32;
 const REDIS_STREAM_MIN_ROW_HEIGHT = 96;
+const REDIS_FORMAT_SCROLLBAR_HIDE_DELAY = 800;
 
 const data = ref<RedisValue | null>(null);
 const loading = ref(false);
@@ -766,6 +767,7 @@ const canHighlightMemberSurface = computed(() => canHighlightContentSearch.value
 
 let collectionSearchTimer: ReturnType<typeof setTimeout> | null = null;
 let collectionSearchRequestId = 0;
+const redisFormatScrollbarTimers = new Map<HTMLElement, ReturnType<typeof setTimeout>>();
 let hashResizeStartX = 0;
 let hashResizeStartWidth = 0;
 let zsetResizeStartX = 0;
@@ -775,6 +777,31 @@ function shouldPauseAutoValueRefresh(): boolean {
   const loadedPageSize = data.value ? redisValueCollectionItems(data.value).length : 0;
   const hasExpandedCollectionPage = collectionItems.value.length > loadedPageSize;
   return showMemberDetail.value || editingZsetMemberKey.value !== null || showHashFieldTtlDialog.value || valueSearchOpen.value || Boolean(collectionSearchQuery.value.trim()) || Boolean(activeCollectionSearchQuery.value) || searchLoading.value || loadingMore.value || hasExpandedCollectionPage;
+}
+
+function hideRedisFormatScrollbar(element: HTMLElement) {
+  const timer = redisFormatScrollbarTimers.get(element);
+  if (timer) clearTimeout(timer);
+  redisFormatScrollbarTimers.delete(element);
+  element.classList.remove("redis-format-tabs-scroll--active");
+}
+
+function scheduleHideRedisFormatScrollbar(element: HTMLElement) {
+  const timer = redisFormatScrollbarTimers.get(element);
+  if (timer) clearTimeout(timer);
+  redisFormatScrollbarTimers.set(
+    element,
+    setTimeout(() => hideRedisFormatScrollbar(element), REDIS_FORMAT_SCROLLBAR_HIDE_DELAY),
+  );
+}
+
+function showRedisFormatScrollbar(event: Event) {
+  const element = event.currentTarget;
+  if (!(element instanceof HTMLElement)) return;
+  const timer = redisFormatScrollbarTimers.get(element);
+  if (timer) clearTimeout(timer);
+  element.classList.add("redis-format-tabs-scroll--active");
+  scheduleHideRedisFormatScrollbar(element);
 }
 
 type PendingDelete = { kind: "key" } | { kind: "hash"; field: string } | { kind: "list"; index: number } | { kind: "set"; member: string } | { kind: "zset"; member: string };
@@ -2698,6 +2725,8 @@ onBeforeUnmount(() => {
   stopResizeHashColumns();
   stopResizeZsetColumns();
   if (collectionSearchTimer) clearTimeout(collectionSearchTimer);
+  for (const timer of redisFormatScrollbarTimers.values()) clearTimeout(timer);
+  redisFormatScrollbarTimers.clear();
 });
 
 defineExpose({ focusSearch });
@@ -2804,7 +2833,7 @@ defineExpose({ focusSearch });
       <div v-if="isStringLikeKind && stringValueDetail" class="flex-1 flex flex-col overflow-hidden">
         <div class="flex h-9 items-center gap-2 border-b px-4 text-xs shrink-0">
           <span class="shrink-0 text-muted-foreground">{{ t("redis.codecRowLabel") }}</span>
-          <div class="flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5">
+          <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
             <Button
               v-for="codec in REDIS_VALUE_CODEC_ORDER"
               :key="codec"
@@ -2829,7 +2858,7 @@ defineExpose({ focusSearch });
         </div>
         <div class="flex h-9 items-center gap-2 border-b px-4 text-xs shrink-0">
           <span class="shrink-0 text-muted-foreground">{{ t("redis.viewRowLabel") }}</span>
-          <div class="flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5">
+          <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
             <Button
               v-for="format in REDIS_VALUE_FORMAT_DISPLAY_ORDER"
               :key="format"
@@ -3584,7 +3613,7 @@ defineExpose({ focusSearch });
         <template v-else>
           <div class="flex h-9 items-center gap-2 border-b px-5 text-xs">
             <span class="shrink-0 text-muted-foreground">{{ t("redis.codecRowLabel") }}</span>
-            <div class="flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5">
+            <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
               <Button v-for="codec in REDIS_VALUE_CODEC_ORDER" :key="codec" variant="ghost" size="sm" class="h-6 shrink-0 rounded-[5px] px-2 text-xs" :class="{ 'bg-background shadow-sm': memberValueCodec === codec }" @click="setMemberValueCodec(codec)">
                 {{ redisCodecLabel(codec) }}
               </Button>
@@ -3598,7 +3627,7 @@ defineExpose({ focusSearch });
           </div>
           <div class="flex h-9 items-center gap-2 border-b px-5 text-xs">
             <span class="shrink-0 text-muted-foreground">{{ t("redis.viewRowLabel") }}</span>
-            <div class="flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5">
+            <div class="redis-format-tabs-scroll flex max-w-full overflow-x-auto rounded-md border bg-muted/20 p-0.5" @scroll="showRedisFormatScrollbar" @pointerleave="scheduleHideRedisFormatScrollbar($event.currentTarget as HTMLElement)">
               <Button
                 v-for="format in REDIS_VALUE_FORMAT_DISPLAY_ORDER"
                 :key="format"
@@ -3715,6 +3744,38 @@ defineExpose({ focusSearch });
     </Dialog>
   </div>
 </template>
+
+<style scoped>
+.redis-format-tabs-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.redis-format-tabs-scroll::-webkit-scrollbar {
+  width: 5px !important;
+  height: 5px !important;
+  -webkit-appearance: none;
+}
+
+.redis-format-tabs-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.redis-format-tabs-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+}
+
+.redis-format-tabs-scroll--active {
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 45%, transparent) transparent;
+}
+
+.redis-format-tabs-scroll--active::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--muted-foreground) 45%, transparent);
+}
+</style>
 
 <style scoped>
 :deep(.document-search-match),

--- a/apps/desktop/src/components/redis/RedisValueViewer.vue
+++ b/apps/desktop/src/components/redis/RedisValueViewer.vue
@@ -3759,6 +3759,12 @@ defineExpose({ focusSearch });
   -webkit-appearance: none;
 }
 
+.redis-format-tabs-scroll::-webkit-scrollbar:hover,
+.redis-format-tabs-scroll::-webkit-scrollbar:active {
+  width: 5px !important;
+  height: 5px !important;
+}
+
 .redis-format-tabs-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
@@ -3778,10 +3784,11 @@ defineExpose({ focusSearch });
 
 /* WebKit uses the native scrollbar dimensions when scrollbar-color is set. Keep
  * the custom 5px scrollbar active in the desktop WebView as well. */
-@supports selector(::-webkit-scrollbar) {
+@supports (-webkit-appearance: none) {
   .redis-format-tabs-scroll,
   .redis-format-tabs-scroll--active {
-    scrollbar-color: auto;
+    scrollbar-width: auto;
+    scrollbar-color: auto !important;
   }
 }
 </style>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -4947,7 +4947,7 @@ export default {
     codecNone: "None",
     codecRowLabel: "Decode",
     viewRowLabel: "View",
-    codecBase64: "Base64 Decode",
+    codecBase64: "Base64",
     unicodeJsonView: "Unicode JSON",
     codecMismatch: "Unable to decode with the selected codec; showing the original content",
     decompressedView: "Decompressed",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -4742,7 +4742,7 @@ export default withEnglishFallback({
     codecNone: "Ninguno",
     codecRowLabel: "Descodificar",
     viewRowLabel: "Vista",
-    codecBase64: "Descodificación Base64",
+    codecBase64: "Base64",
     codecMismatch: "No se pudo decodificar con el códec seleccionado; se muestra el contenido original",
     unicodeJsonView: "JSON Unicode",
     decompressedView: "Descomprimido",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -4742,7 +4742,7 @@ export default withEnglishFallback({
     codecNone: "Nessuno",
     codecRowLabel: "Decodifica",
     viewRowLabel: "Vista",
-    codecBase64: "Decodifica Base64",
+    codecBase64: "Base64",
     codecMismatch: "Impossibile decodificare con il codec selezionato; viene mostrato il contenuto originale",
     unicodeJsonView: "JSON Unicode",
     decompressedView: "Decompresso",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -4771,7 +4771,7 @@ export default withEnglishFallback({
     codecNone: "なし",
     codecRowLabel: "デコード",
     viewRowLabel: "表示",
-    codecBase64: "Base64 デコード",
+    codecBase64: "Base64",
     codecMismatch: "選択したデコード方式では復元できません。元の内容を表示しています",
     unicodeJsonView: "Unicode JSON",
     decompressedView: "解凍ビュー",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -4368,7 +4368,7 @@ export default withEnglishFallback({
     codecNone: "없음",
     codecRowLabel: "디코딩",
     viewRowLabel: "보기",
-    codecBase64: "Base64 디코딩",
+    codecBase64: "Base64",
     codecMismatch: "선택한 디코딩 방식으로 복원할 수 없어 원본 내용을 표시합니다",
     unicodeJsonView: "Unicode JSON",
     decompressedView: "압축 해제 보기",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -4744,7 +4744,7 @@ export default withEnglishFallback({
     codecNone: "Nenhum",
     codecRowLabel: "Decodificação",
     viewRowLabel: "Visualização",
-    codecBase64: "Decodificação Base64",
+    codecBase64: "Base64",
     codecMismatch: "Não foi possível decodificar com o codec selecionado; exibindo o conteúdo original",
     unicodeJsonView: "JSON Unicode",
     decompressedView: "Descomprimido",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -4944,7 +4944,7 @@ export default withEnglishFallback({
     codecNone: "Yok",
     codecRowLabel: "Çöz",
     viewRowLabel: "Görünüm",
-    codecBase64: "Base64 Çöz",
+    codecBase64: "Base64",
     unicodeJsonView: "Unicode JSON",
     codecMismatch: "Seçili kodekle çözülemedi; özgün içerik gösteriliyor",
     decompressedView: "Sıkıştırma açıldı",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -4931,7 +4931,7 @@ export default withEnglishFallback({
     codecNone: "无",
     codecRowLabel: "解码",
     viewRowLabel: "视图",
-    codecBase64: "Base64 解码",
+    codecBase64: "Base64",
     unicodeJsonView: "Unicode JSON",
     codecMismatch: "无法按所选解码方式还原，已显示原始内容",
     decompressedView: "解压视图",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -4068,7 +4068,7 @@ export default withEnglishFallback({
     codecNone: "無",
     codecRowLabel: "解碼",
     viewRowLabel: "檢視",
-    codecBase64: "Base64 解碼",
+    codecBase64: "Base64",
     codecMismatch: "無法按所選解碼方式還原，已顯示原始內容",
     unicodeJsonView: "Unicode JSON",
     decompressedView: "解壓檢視",


### PR DESCRIPTION
## 改动

- 将 Redis 值查看器中的 Base64 编码选项简化为 `Base64`。
- 收紧 Redis Key 列表左右边距和层级缩进，提升宽度利用率。
- 统一编码方式和视图选项的横向滚动条为 5px。
- 滚动条停止滚动或鼠标移出后延迟隐藏，避免过快消失。

## 验证

- `pnpm typecheck`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/redis/RedisValueViewer.vue`
- `pnpm exec oxfmt --check apps/desktop/src/components/redis/RedisValueViewer.vue`
- `git diff --check`
- 已在本地 Tauri 开发客户端热更新验证。