### PR TITLE
Improve: 补充自定义 SQL 代码片段占位符提示

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -6873,6 +6873,15 @@ onUnmounted(() => {
                   {{ t("settings.snippetsAdd") }}
                 </Button>
               </div>
+              <div class="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                <p>{{ t("settings.snippetsPlaceholderHint") }}</p>
+                <pre class="mt-2 overflow-x-auto whitespace-pre-wrap rounded bg-background/70 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-foreground">
+SELECT t.*
+FROM ${1:table} t
+WHERE t.del_flag = 0
+LIMIT 100;</pre
+                >
+              </div>
 
               <div class="overflow-x-auto rounded-md border">
                 <table class="w-full min-w-[720px] text-sm">

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6672,6 +6672,7 @@ export default {
     sidebarFontSize: "Sidebar font size",
     sidebarFontSizeDescription: "Font size for the sidebar object tree, in pixels. Independent of the editor font size.",
     snippetsDescription: "Customize SQL snippet templates triggered in the editor.",
+    snippetsPlaceholderHint: "Use {'${number:default text}'} to create an editable placeholder. Placeholders with the same number stay linked; for example:",
     snippetsAdd: "Add Snippet",
     snippetsLabel: "Label",
     snippetsPrefix: "Prefix",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6330,6 +6330,7 @@ export default withEnglishFallback({
     sidebarShowTooltipsDescription: "Muestra sugerencias con detalles al pasar el cursor sobre conexiones y objetos de la base de datos en la barra lateral. Desactívalo para ocultarlas.",
     snippetsDescription: "Personaliza plantillas SQL activadas en el editor.",
     syncSnippetProviderGitee: "Fragmentos de Gitee",
+    snippetsPlaceholderHint: "Usa {'${número:texto predeterminado}'} para crear un marcador editable. Los marcadores con el mismo número permanecen vinculados. Por ejemplo:",
     snippetsAdd: "Agregar fragmento",
     snippetsLabel: "Etiqueta",
     snippetsPrefix: "Prefijo",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6330,6 +6330,7 @@ export default withEnglishFallback({
     sidebarShowTooltipsDescription: "Mostra tooltip con dettagli al passaggio del mouse su connessioni e oggetti del database nella barra laterale. Disattiva per nasconderli.",
     snippetsDescription: "Personalizza i modelli di snippet SQL attivati nell'editor.",
     syncSnippetProviderGitee: "Snippet Gitee",
+    snippetsPlaceholderHint: "Usa {'${numero:testo predefinito}'} per creare un segnaposto modificabile. I segnaposto con lo stesso numero restano collegati. Ad esempio:",
     snippetsAdd: "Aggiungi Snippet",
     snippetsLabel: "Etichetta",
     snippetsPrefix: "Prefisso",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6356,6 +6356,7 @@ export default withEnglishFallback({
     sidebarShowTooltipsDescription: "サイドバーで接続やデータベースオブジェクトにホバーしたときに詳細ツールチップを表示します。オフにすると表示されません。",
     snippetsDescription: "エディタでトリガーされるSQLスニペットテンプレートをカスタマイズします。",
     syncSnippetProviderGitee: "Gitee コードスニペット",
+    snippetsPlaceholderHint: "{'${番号:デフォルトテキスト}'} で編集可能なプレースホルダーを作成できます。同じ番号のプレースホルダーは連動します。例：",
     snippetsAdd: "スニペットを追加",
     snippetsLabel: "ラベル",
     snippetsPrefix: "プレフィックス",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -6050,6 +6050,7 @@ export default withEnglishFallback({
     sidebarShowTooltips: "사이드바 호버 툴팁",
     sidebarShowTooltipsDescription: "사이드바에서 연결 및 데이터베이스 개체에 마우스를 올리면 상세 툴팁을 표시합니다. 끄면 표시되지 않습니다.",
     snippetsDescription: "편집기에서 트리거되는 SQL 스니펫 템플릿을 사용자 정의합니다.",
+    snippetsPlaceholderHint: "{'${번호:기본 텍스트}'}를 사용하여 편집 가능한 자리 표시자를 만듭니다. 같은 번호의 자리 표시자는 함께 수정됩니다. 예:",
     snippetsAdd: "스니펫 추가",
     snippetsLabel: "라벨",
     snippetsPrefix: "접두사",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6332,6 +6332,7 @@ export default withEnglishFallback({
     sidebarShowTooltipsDescription: "Mostra dicas com detalhes ao passar o mouse sobre conexões e objetos do banco de dados na barra lateral. Desative para ocultá-las.",
     snippetsDescription: "Personalize os modelos de snippets SQL acionados no editor.",
     syncSnippetProviderGitee: "Snippets do Gitee",
+    snippetsPlaceholderHint: "Use {'${número:texto padrão}'} para criar um espaço reservado editável. Espaços reservados com o mesmo número permanecem vinculados. Por exemplo:",
     snippetsAdd: "Adicionar snippet",
     snippetsLabel: "Rótulo",
     snippetsPrefix: "Prefixo",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6654,6 +6654,7 @@ export default withEnglishFallback({
     sidebarFontSize: "侧边栏字体大小",
     sidebarFontSizeDescription: "侧边栏对象树的字体大小（像素），独立于编辑器字体大小。",
     snippetsDescription: "自定义编辑器中触发的 SQL 代码片段模板。",
+    snippetsPlaceholderHint: "使用 {'${编号:默认文本}'} 创建可编辑占位符；编号相同的占位符会同步修改，例如：",
     snippetsAdd: "添加片段",
     snippetsLabel: "显示名",
     snippetsPrefix: "触发键",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5647,6 +5647,7 @@ export default withEnglishFallback({
     sidebarShowTooltipsDescription: "在側邊欄的連線與資料庫物件上懸浮時顯示詳細提示；關閉後懸浮不再彈出。",
     snippetsDescription: "自訂編輯器中觸發的 SQL 程式碼片段範本。",
     syncSnippetProviderGitee: "Gitee 程式碼片段",
+    snippetsPlaceholderHint: "使用 {'${編號:預設文字}'} 建立可編輯的佔位符；編號相同的佔位符會同步修改，例如：",
     snippetsAdd: "新增片段",
     snippetsLabel: "顯示名",
     snippetsPrefix: "觸發鍵",


### PR DESCRIPTION
## 变更说明

- 在“设置 → 代码片段”中增加 `${1:table}` 占位符语法说明和 SQL 示例。
- 补充英文、简体中文、繁体中文、日文、韩文、西班牙文、意大利文、葡萄牙文翻译。
- 使用 vue-i18n 字面量转义，避免占位符示例被误解析为翻译参数。

## 验证

- `vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm build`
- 已通过本地免密网页预览确认设置页可以正常切换并显示示例。

Fixes #4150