### PR TITLE
fix(tabs): 修复 SQL 库查询分离成独立窗口后内容丢失

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.detachedTab.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.detachedTab.spec.ts
@@ -1,0 +1,96 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DetachedTabHandoff } from "@/lib/app/detachedTabHandoff";
+
+const mocks = vi.hoisted(() => ({
+  loadSavedSqlFile: vi.fn(),
+}));
+
+vi.mock("@/lib/backend/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/backend/api")>()),
+  loadSavedSqlFile: mocks.loadSavedSqlFile,
+}));
+
+describe("queryStore adoptDetachedTab", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    mocks.loadSavedSqlFile.mockReset();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    setActivePinia(createPinia());
+  });
+
+  function handoffFor(overrides: Partial<DetachedTabHandoff["tab"]> = {}): DetachedTabHandoff {
+    return {
+      schemaVersion: 1,
+      tabId: "tab-1",
+      sourceWindowLabel: "main",
+      revision: 1,
+      tab: {
+        id: "tab-1",
+        title: "query_1.sql",
+        customTitle: true,
+        connectionId: "conn-1",
+        database: "main",
+        // A clean saved-SQL-library tab serializes `sql` as "" (see openTabsPersistence's
+        // shouldPersistTabSql) to avoid duplicating on-disk state across app restarts.
+        sql: "",
+        savedSqlId: "saved-1",
+        mode: "query",
+        ...overrides,
+      },
+      runtime: {},
+      updatedAt: Date.now(),
+    };
+  }
+
+  it("hydrates a clean saved-SQL-library tab's content from the backend instead of opening empty", async () => {
+    mocks.loadSavedSqlFile.mockResolvedValue({
+      id: "saved-1",
+      connectionId: "conn-1",
+      name: "query_1.sql",
+      database: "main",
+      sql: "SELECT 1;",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const queryStore = useQueryStore();
+
+    const tabId = await queryStore.adoptDetachedTab(handoffFor());
+
+    expect(mocks.loadSavedSqlFile).toHaveBeenCalledWith("saved-1");
+    const tab = queryStore.tabs.find((candidate) => candidate.id === tabId)!;
+    expect(tab.sql).toBe("SELECT 1;");
+    expect(tab.originalSql).toBe("SELECT 1;");
+    expect(queryStore.isTabDirty(tab)).toBe(false);
+  });
+
+  it("does not touch the backend when the handoff already carries unsaved edits", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const queryStore = useQueryStore();
+
+    const tabId = await queryStore.adoptDetachedTab(handoffFor({ sql: "SELECT 2;", originalSql: "SELECT 1;" }));
+
+    expect(mocks.loadSavedSqlFile).not.toHaveBeenCalled();
+    const tab = queryStore.tabs.find((candidate) => candidate.id === tabId)!;
+    expect(tab.sql).toBe("SELECT 2;");
+    expect(queryStore.isTabDirty(tab)).toBe(true);
+  });
+
+  it("leaves an unsaved (never-linked-to-library) tab's empty content as-is", async () => {
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const queryStore = useQueryStore();
+
+    const tabId = await queryStore.adoptDetachedTab(handoffFor({ savedSqlId: undefined }));
+
+    expect(mocks.loadSavedSqlFile).not.toHaveBeenCalled();
+    const tab = queryStore.tabs.find((candidate) => candidate.id === tabId)!;
+    expect(tab.sql).toBe("");
+  });
+});

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -1899,6 +1899,21 @@ export const useQueryStore = defineStore("query", () => {
     const restored = restoreOpenTabsPayload({ tabs: [handoff.tab], activeTabId: handoff.tabId });
     const restoredTab = restored.tabs[0];
     if (!restoredTab) throw new Error("Unable to restore detached tab");
+    // serializeOpenTabs() blanks `sql` for a clean saved-SQL-library tab to avoid
+    // duplicating on-disk state across app restarts, relying on hydrateSavedSqlTabs()
+    // to refill it afterwards. The detach handoff goes through the same serialization
+    // but skips that hydration step, so do it here too or the new window opens empty.
+    // A freshly created detached window never runs the main-window bootstrap that
+    // populates savedSqlStore's local file index, so useSavedSqlStore().ensureFileContent()
+    // can't find the file locally either — go straight to the backend instead.
+    if (restoredTab.savedSqlId && restoredTab.mode === "query" && !restoredTab.sql) {
+      const file = await api.loadSavedSqlFile(restoredTab.savedSqlId).catch(() => undefined);
+      if (file) {
+        restoredTab.title = restoredTab.customTitle ? restoredTab.title : file.name;
+        restoredTab.sql = file.sql;
+        restoredTab.originalSql = file.sql;
+      }
+    }
     Object.assign(restoredTab, handoff.runtime);
     if (handoff.resultCacheKey) {
       restoredTab.resultCacheKey = handoff.resultCacheKey;


### PR DESCRIPTION
## 问题

从 SQL 库打开一个已保存且未修改（干净）的查询，把它分离成独立窗口后，新窗口的编辑器内容是空的。

Fixes #8102

## 根因

`prepareDetachedTab()` 复用了 `serializeOpenTabs()`——这个函数是为"跨应用重启持久化"设计的，对已保存到 SQL 库且未修改的干净 tab，会故意把 `sql` 序列化为空字符串，避免和库文件内容重复存储，设计上依赖应用重启时的 `hydrateSavedSqlTabs()` 把内容重新读回来。

但"分离成独立窗口"走的是完全不同的路径：新窗口的 `App.vue` 在 `onMounted()` 里检测到是 detached window 后直接 `return`，完全跳过了 `initApp()`（包括 `hydrateSavedSqlTabs()`），导致这份被故意置空的 `sql` 永远没有机会补回来。

## 修复

`adoptDetachedTab()` 新增补水逻辑：还原出的 tab 如果关联了 `savedSqlId` 且 `sql` 为空，直接调用 `api.loadSavedSqlFile()` 从后端取回真实内容（没有走 `savedSqlStore` 的本地索引，因为 detached window 从未跑过 `initFromStorage()`，本地索引本就是空的），同时把 `sql`/`originalSql` 都设为同一份内容，避免还原后的 tab 被误判为"有未保存的修改"。

## 验证

- 新增 3 个单测（`queryStore.detachedTab.spec.ts`）：干净 saved tab 需要补水 / 已有未保存修改的 tab 不触发补水且不被覆盖 / 从未保存过的空白 tab 保持原样
- `pnpm check`（connection-types + format + lint + typecheck + 全量 vitest）全部通过
- 在真实构建的桌面应用上完整走了一遍"新建查询→保存到 SQL 库→分离成独立窗口"，修复前编辑器为空，修复后正确显示保存的 SQL 内容，且不出现"未保存"标记

## Test plan

- [x] `pnpm exec vitest run apps/desktop/src/stores/__tests__/queryStore.detachedTab.spec.ts`
- [x] `pnpm check`
- [x] 真实桌面应用手动复现 + 修复验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyfKsLxenfd4dD41Li3d7W