### PR TITLE
fix(sql): 修复 SELECT * 混合显式字段时丢失结果列注释

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/starProjectionColumnMapping.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/starProjectionColumnMapping.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { analyzeEditableQueryEditability, resolveSourceColumnsByOrdinal } from "@/lib/sql/sqlAnalysis";
+
+/**
+ * An unqualified `*` is unambiguous when the query has exactly one source,
+ * so it must bind to that source the same way a qualified `alias.*` does.
+ * Regression coverage for #8015: `SELECT *, col FROM t` (bare star mixed
+ * with an explicit column, single source, no alias) was dropping the star
+ * expansion entirely because the bare-star projection carried no
+ * `sourceKey`, misaligning every result column from that point on.
+ */
+describe("single-source star projection column mapping", () => {
+  it("expands a bare unqualified star mixed with an explicit column", () => {
+    const result = analyzeEditableQueryEditability("SELECT *, amount FROM orders");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const source = { key: "orders:0", tableName: "orders" };
+    const resolved = resolveSourceColumnsByOrdinal("mysql", result.analysis, [{ source, columns: [{ name: "id" }, { name: "user_id" }, { name: "amount" }] }], 4);
+    expect(resolved).toEqual([
+      { sourceKey: "orders:0", sourceColumn: "id" },
+      { sourceKey: "orders:0", sourceColumn: "user_id" },
+      { sourceKey: "orders:0", sourceColumn: "amount" },
+      { sourceKey: "orders:0", sourceColumn: "amount" },
+    ]);
+  });
+
+  it("expands a bare unqualified star mixed with an aliased source and leading explicit columns", () => {
+    // Matches the issue's own repro shape: qualified explicit columns before
+    // a trailing bare `*`, single aliased source, no primary key.
+    const result = analyzeEditableQueryEditability("SELECT fl.sqlicenseno, fl.sqtypetext, * FROM flow_licenseapprove AS fl");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+
+    const source = { key: "fl:0", tableName: "flow_licenseapprove" };
+    const resolved = resolveSourceColumnsByOrdinal("kingbase", result.analysis, [{ source, columns: [{ name: "sqlicenseno" }, { name: "sqtypetext" }, { name: "uniformid" }, { name: "sqtypeid" }] }], 5);
+    expect(resolved).toEqual([
+      { sourceKey: "fl:0", sourceColumn: "sqlicenseno" },
+      { sourceKey: "fl:0", sourceColumn: "sqtypetext" },
+      { sourceKey: "fl:0", sourceColumn: "sqlicenseno" },
+      { sourceKey: "fl:0", sourceColumn: "sqtypetext" },
+      { sourceKey: "fl:0", sourceColumn: "uniformid" },
+    ]);
+  });
+
+  it("still expands a plain unqualified star with no other columns (baseline, unchanged)", () => {
+    const result = analyzeEditableQueryEditability("SELECT * FROM orders");
+    expect(result.editable).toBe(true);
+    if (!result.editable) return;
+    expect(result.analysis.selectStar).toBe(true);
+
+    const source = { key: "orders:0", tableName: "orders" };
+    const resolved = resolveSourceColumnsByOrdinal("mysql", result.analysis, [{ source, columns: [{ name: "id" }, { name: "amount" }] }], 2);
+    expect(resolved).toEqual([
+      { sourceKey: "orders:0", sourceColumn: "id" },
+      { sourceKey: "orders:0", sourceColumn: "amount" },
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/sql/sqlAnalysis.ts
+++ b/apps/desktop/src/lib/sql/sqlAnalysis.ts
@@ -452,8 +452,17 @@ function parseSelectColumn(col: string, sources?: EditableQuerySource[]): Editab
 
 function parseStarSelectColumn(col: string, sources?: EditableQuerySource[]): EditableQueryColumn | null {
   if (col === "*") {
+    // An unqualified `*` is unambiguous when the query has exactly one
+    // source, so it can bind to that source like a qualified `alias.*`
+    // would. Without this, expandProjectionColumnsForSources cannot find a
+    // matching table source (no sourceKey) and drops the star expansion
+    // entirely, misaligning every result column that follows it — e.g.
+    // `SELECT *, amount FROM orders` loses all result-column comments even
+    // though the table has no ambiguity to resolve.
+    const sourceKey = sources?.length === 1 ? sources[0]!.key : undefined;
     return {
       star: true,
+      ...(sourceKey ? { sourceKey } : {}),
       resultName: "*",
       expression: col,
     };

--- a/crates/dbx-core/src/sql_editability.rs
+++ b/crates/dbx-core/src/sql_editability.rs
@@ -310,11 +310,23 @@ fn parse_select_column(column: &str, sources: &[FromSource]) -> Option<EditableQ
 fn parse_star_select_column(column: &str, sources: &[FromSource]) -> Option<EditableQueryColumn> {
     let trimmed = column.trim();
     if trimmed == "*" {
+        // An unqualified `*` is unambiguous when the query has exactly one
+        // source, so it can bind to that source like a qualified `alias.*`
+        // would. Without this, the star projection carries no source_key and
+        // the ordinal column-comment resolver (apps/desktop TS side) cannot
+        // expand it against the table's columns, misaligning every result
+        // column from that point on — e.g. `SELECT *, amount FROM orders`
+        // loses all result-column comments even though the table has no
+        // ambiguity to resolve.
+        let source_key = match sources {
+            [only] => Some(only.key.clone()),
+            _ => None,
+        };
         return Some(EditableQueryColumn {
             source_name: None,
             source_name_quoted: false,
             source_qualifier: None,
-            source_key: None,
+            source_key,
             star: true,
             result_name: "*".to_string(),
             expression: trimmed.to_string(),
@@ -1222,6 +1234,49 @@ mod tests {
             vec![
                 column(Some("create_date"), false, Some("t"), Some("t:0"), "create_date", "t.create_date"),
                 star_column(Some("t"), Some("t:0"), "t.*"),
+            ]
+        );
+    }
+
+    #[test]
+    fn maps_single_table_bare_star_mixed_with_explicit_column() {
+        // Regression for #8015: a bare, unqualified `*` mixed with another
+        // projected column is unambiguous when the query has exactly one
+        // source, so it must bind to that source (source_key) the same way
+        // a qualified `t.*` does. Previously it carried no source_key,
+        // which made the ordinal column-comment resolver drop the star
+        // expansion entirely and lose comments for the whole result set.
+        let result = analyze_editable_query_editability("SELECT *, amount FROM orders");
+
+        assert!(result.editable);
+        let analysis = result.analysis.unwrap();
+        assert_eq!(analysis.table_name, "orders");
+        assert_eq!(
+            analysis.columns,
+            vec![
+                star_column(None, Some("orders:0"), "*"),
+                column(Some("amount"), false, None, None, "amount", "amount"),
+            ]
+        );
+    }
+
+    #[test]
+    fn maps_single_aliased_table_bare_trailing_star_after_qualified_columns() {
+        // Matches the issue's own repro shape: qualified explicit columns
+        // followed by a trailing bare `*`, single aliased source.
+        let result = analyze_editable_query_editability(
+            "SELECT fl.sqlicenseno, fl.sqtypetext, * FROM flow_licenseapprove AS fl",
+        );
+
+        assert!(result.editable);
+        let analysis = result.analysis.unwrap();
+        assert_eq!(analysis.table_alias.as_deref(), Some("fl"));
+        assert_eq!(
+            analysis.columns,
+            vec![
+                column(Some("sqlicenseno"), false, Some("fl"), Some("fl:0"), "sqlicenseno", "fl.sqlicenseno"),
+                column(Some("sqtypetext"), false, Some("fl"), Some("fl:0"), "sqtypetext", "fl.sqtypetext"),
+                star_column(None, Some("fl:0"), "*"),
             ]
         );
     }


### PR DESCRIPTION
## 问题

裸星号 `*`（不带表别名限定）在 SQL 解析时未绑定任何数据源。下游按序号把结果列映射回源表列以取字段注释时，因为找不到裸星号对应的数据源，会把它整个跳过（而不是按物理列展开成多个条目），导致星号之后的所有结果列整体错位，字段注释随之错乱或丢失。

复现条件：单一数据源 + 无主键的表（走 `resultColumnComments` 这条注释解析路径）+ 查询里同时出现裸 `*` 和至少一个显式字段，例如：

```sql
SELECT *, sqtypeid FROM issue8015_nopk;   -- 无主键表
```

这与 issue 里的两张截图完全吻合：`select fl.sqlicenseno, ..., * from t AS fl`（裸星号）丢注释，改成 `fl.*`（显式限定）后注释恢复正常——即"带别名就正常"实际指的是"星号本身有没有被显式限定"，而不是"表有没有别名"。

多数据源（JOIN）场景不受影响：未限定的裸 `*` 在那种场景下本身有歧义，已经被现有的 `sources.length > 1 && ...` 检查整体拒绝为不可编辑，逻辑不变。

## 根因

这套 SQL 解析在仓库里有两份重复实现——前端 TS（`apps/desktop/src/lib/sql/sqlAnalysis.ts`）和后端 Rust（`crates/dbx-core/src/sql_editability.rs`，web/desktop 运行时实际生效的那份）。两处的裸星号分支都硬编码为不绑定数据源，只有显式 `alias.*` 才会绑定。

## 修复

单一数据源时裸 `*` 本身没有歧义，改为绑定到该唯一数据源，前后端各改一处对应分支。

## 测试

- 前端：新增 `apps/desktop/src/lib/__tests__/sql/starProjectionColumnMapping.spec.ts`（3 用例，含 issue 原文的查询形状），全量 vitest（1261 文件 / 12518 用例）通过
- 后端：`crates/dbx-core/src/sql_editability.rs` 新增 2 个单测，`cargo test -p dbx-core --lib sql_editability::` 28/28 通过
- 真机验证：在测试库上用同一条 SQL 修复前后各截图对比，注释从缺失变为正确显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZJT47LYzG3rvNFgrzHfvj