### PR TITLE
fix(grid): 修复值编辑器内容在结果刷新时被强制回退的问题

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -599,6 +599,7 @@ let preservedSelectionOnNextResult: {
 } | null = null;
 let preservedDetailsOnNextResult: {
   sideCell?: PersistedDataGridSelection;
+  sideCellHasPendingDraft?: boolean;
   cellDialog?: PersistedDataGridSelection;
   rowDialog?: PersistedDataGridSelection;
   columnDialog?: PersistedDataGridSelection;
@@ -5942,6 +5943,10 @@ function captureColumnTargetForRefresh(columnIndex: number | null): PersistedDat
 function captureDetailsForRefresh() {
   const details = {
     sideCell: showCellDetail.value ? captureCellTargetForRefresh(detailCell.value) : undefined,
+    // A refresh must not silently discard an unsaved value-editor draft: closing
+    // and reopening the panel (even at the "same" cell) would re-derive its text
+    // from the freshly fetched row, wiping whatever the user was typing.
+    sideCellHasPendingDraft: showCellDetail.value && hasPendingDetailEditorDraft.value,
     cellDialog: cellDetailDialogOpen.value ? captureCellTargetForRefresh(cellDetailDialogTarget.value) : undefined,
     rowDialog: rowDetailDialogOpen.value ? captureRowTargetForRefresh(rowDetailDialogRowId.value) : undefined,
     columnDialog: columnDetailDialogOpen.value ? captureColumnTargetForRefresh(columnDetailDialogColumnIndex.value) : undefined,
@@ -5965,11 +5970,17 @@ function restoreDetailCellAfterRefresh(snapshot: PersistedDataGridSelection | un
 }
 
 function restoreDetailsAfterRefresh(details: NonNullable<typeof preservedDetailsOnNextResult>) {
-  const sideCell = restoreDetailCellAfterRefresh(details.sideCell);
-  if (sideCell) {
-    detailCell.value = sideCell;
-    showCellDetail.value = true;
-    hydrateCellDetailTarget(sideCell);
+  // When the side panel was left open with an unsaved value-editor draft, it was
+  // deliberately kept open (not closed) across this refresh, so there is nothing
+  // to restore here - reassigning detailCell would re-derive the editor text from
+  // the freshly fetched row and clobber the draft the user is still editing.
+  if (!details.sideCellHasPendingDraft) {
+    const sideCell = restoreDetailCellAfterRefresh(details.sideCell);
+    if (sideCell) {
+      detailCell.value = sideCell;
+      showCellDetail.value = true;
+      hydrateCellDetailTarget(sideCell);
+    }
   }
 
   const cellDialog = restoreDetailCellAfterRefresh(details.cellDialog);
@@ -6461,6 +6472,12 @@ watch(activeCellDetailTab, (tab) => {
 const detailEditValue = ref("");
 const detailEditOriginalValue = ref("");
 const isEditingDetail = ref(false);
+// commitDetailEdit() intentionally re-triggers the activeCellDetail watch below to
+// re-sync the editor with the canonical committed value. Any other change to the
+// same cell's underlying data while still editing (e.g. a result refresh, or a
+// large-value hydration resolving) must not clobber the user's in-progress draft.
+let allowActiveCellDetailResync = false;
+let lastSyncedDetailCellKey: string | null = null;
 const detailValueDiffOpen = ref(false);
 const detailValueDiffSnapshot = ref<Readonly<JsonValueDiffSnapshot> | null>(null);
 const hasPendingDetailEditorDraft = computed(() => isEditingDetail.value && detailEditValue.value !== detailEditOriginalValue.value);
@@ -6591,6 +6608,15 @@ watch(activeCellDetail, (detail) => {
     resetDetailEdit();
     return;
   }
+  const cellKey = `${detail.rowId}:${detail.colIndex}`;
+  const isSameCellStillEditing = isEditingDetail.value && cellKey === lastSyncedDetailCellKey;
+  lastSyncedDetailCellKey = cellKey;
+  if (isSameCellStillEditing && !allowActiveCellDetailResync) {
+    // The row's underlying data changed (e.g. a result refresh or a large-value
+    // hydration) while the user is still editing this same cell. Keep their draft.
+    return;
+  }
+  allowActiveCellDetailResync = false;
   const value = dataGridCellEditorText({
     value: detail.value,
     databaseType: resolvedDatabaseType.value,
@@ -6668,6 +6694,7 @@ function resetDetailEdit() {
   isEditingDetail.value = false;
   detailEditValue.value = "";
   detailEditOriginalValue.value = "";
+  lastSyncedDetailCellKey = null;
 }
 
 function closeCellDetails() {
@@ -6741,6 +6768,9 @@ function commitDetailEdit() {
   if (!item || item.isDeleted) return;
   applyCellValue(detail.rowId, detail.colIndex, detailEditValue.value);
   detailEditOriginalValue.value = detailEditValue.value;
+  // Force the activeCellDetail watch to re-run so the editor picks up the
+  // canonical (possibly coerced) committed value.
+  allowActiveCellDetailResync = true;
   detailCell.value = detailCell.value ? { ...detailCell.value } : null;
 }
 
@@ -10529,7 +10559,10 @@ watch(
     clearCellSelection();
     clearRowSelection();
     invalidateContextMenuTarget();
-    closeCellDetails();
+    // Don't discard an unsaved value-editor draft just because the result set
+    // refreshed underneath it; leave the panel/editor state as-is and let
+    // restoreDetailsAfterRefresh() below skip re-opening it from fresh data.
+    if (!detailsSnapshot?.sideCellHasPendingDraft) closeCellDetails();
     closeDetailDialogs();
     if (shouldPreserveTranspose) {
       applyTransposeState(nextTransposeStateForRecordCount(showTranspose.value, transposeRowIndex.value, displayRowCount.value));


### PR DESCRIPTION
## 问题

打开值编辑器编辑 JSON 字段（比如点"格式化 JSON"变成多行），只要这时候底层数据发生任何刷新（点结果集"刷新"按钮、大字段异步加载完成等），编辑器里的内容会被无声无息地强制覆盖回原始值，用户还没提交的编辑就丢了。

issue 原文描述的触发动作是"复制粘贴"，实测复制粘贴本身不是根因——只是恰好和"编辑中 + 数据刷新"这个真正触发条件在时间上撞在了一起。

## 根因

`apps/desktop/src/components/grid/DataGrid.vue` 里两处配合导致：

1. 每次结果集刷新（`watch(() => props.result, ...)`）都无条件调用 `closeCellDetails()`，把还没提交的编辑草稿直接清空，再用刷新后的新数据重新打开"同一个"单元格；
2. `watch(activeCellDetail, ...)` 本身也没有对"用户正在编辑同一单元格"做防护，只要底层数据变化就无条件覆盖编辑器内容。

## 修复

- `captureDetailsForRefresh()` 新增 `sideCellHasPendingDraft` 标记，检测到值编辑器有未提交草稿时，刷新流程跳过 `closeCellDetails()` 和重新打开该单元格，面板/草稿保持原样。
- `watch(activeCellDetail, ...)` 增加 `allowActiveCellDetailResync` + `lastSyncedDetailCellKey` 两个标志，只有真正切换单元格、或用户主动提交编辑（`commitDetailEdit()`）时才覆盖编辑器内容，避免后台数据变化误伤正在编辑的草稿。

正常的"编辑→失焦提交→显示正确"、"切换单元格"、"回滚→恢复原值"等流程不受影响。

## 测试

- `pnpm vitest run apps/desktop/src/components/grid`：238 个测试全部通过
- `vue-tsc --noEmit`、`oxlint`、`oxfmt --check`：干净
- 真实复现验证（MySQL 8.4.6）：修复前，格式化后点刷新内容被强制回退为压缩单行；修复后，同样操作内容完整保留
- 手动回归：正常编辑提交、回滚恢复原值均验证无回归

Fixes #7936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYgRAAZBn8LPf9GfYq5A5T