### PR TITLE
fix(import): 导入向导选择现有表时字段加载卡死无超时

### DIFF
--- a/apps/desktop/src/components/import/TableImportDialog.vue
+++ b/apps/desktop/src/components/import/TableImportDialog.vue
@@ -537,7 +537,7 @@ async function loadTargetColumns() {
   loadingTarget.value = true;
   errorMessage.value = "";
   try {
-    await withTimeout(store.ensureConnected(props.prefillConnectionId), TARGET_COLUMNS_TIMEOUT_MS);
+    await store.ensureConnected(props.prefillConnectionId);
     const columns = await withTimeout(api.getColumns(props.prefillConnectionId, props.prefillDatabase, targetSchema.value, tableName), TARGET_COLUMNS_TIMEOUT_MS);
     if (requestId !== targetColumnsRequestId) return;
     targetColumns.value = columns;

--- a/apps/desktop/src/components/import/TableImportDialog.vue
+++ b/apps/desktop/src/components/import/TableImportDialog.vue
@@ -64,6 +64,25 @@ interface BatchImportTask {
 }
 
 const SKIP_VALUE = "__skip__";
+const TARGET_COLUMNS_TIMEOUT_MS = 15000;
+const TARGET_COLUMNS_TIMEOUT = Symbol("target-columns-timeout");
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(TARGET_COLUMNS_TIMEOUT), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 const targetColumns = ref<ColumnInfo[]>([]);
 const loadedTargetTableName = ref("");
 const existingTableNames = ref<string[]>([]);
@@ -518,8 +537,8 @@ async function loadTargetColumns() {
   loadingTarget.value = true;
   errorMessage.value = "";
   try {
-    await store.ensureConnected(props.prefillConnectionId);
-    const columns = await api.getColumns(props.prefillConnectionId, props.prefillDatabase, targetSchema.value, tableName);
+    await withTimeout(store.ensureConnected(props.prefillConnectionId), TARGET_COLUMNS_TIMEOUT_MS);
+    const columns = await withTimeout(api.getColumns(props.prefillConnectionId, props.prefillDatabase, targetSchema.value, tableName), TARGET_COLUMNS_TIMEOUT_MS);
     if (requestId !== targetColumnsRequestId) return;
     targetColumns.value = columns;
     loadedTargetTableName.value = tableName;
@@ -529,7 +548,7 @@ async function loadTargetColumns() {
       targetColumns.value = [];
       loadedTargetTableName.value = "";
       columnMapping.value = {};
-      errorMessage.value = String(e?.message || e);
+      errorMessage.value = e === TARGET_COLUMNS_TIMEOUT ? t("tableImport.targetColumnsTimeout") : String(e?.message || e);
     }
   } finally {
     if (requestId === targetColumnsRequestId) loadingTarget.value = false;
@@ -1555,8 +1574,11 @@ watch(rawProgressPercent, (percent) => {
           <Loader2 class="h-3.5 w-3.5 animate-spin" />
           {{ t("common.loading") }}
         </div>
-        <div v-if="errorMessage && wizardStep !== 'execution'" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-          {{ errorMessage }}
+        <div v-if="errorMessage && wizardStep !== 'execution'" class="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <span class="flex-1">{{ errorMessage }}</span>
+          <Button v-if="targetMode === 'existing' && !loadingTarget && !existingTargetMetadataReady" variant="outline" size="sm" class="h-6 px-2 text-xs" @click="loadTargetColumns()">
+            {{ t("tableImport.retry") }}
+          </Button>
         </div>
       </div>
 

--- a/apps/desktop/src/components/import/__tests__/TableImportDialog.existingTarget.spec.ts
+++ b/apps/desktop/src/components/import/__tests__/TableImportDialog.existingTarget.spec.ts
@@ -268,6 +268,7 @@ describe("TableImportDialog existing targets", () => {
     await vi.waitFor(() => {
       expect(mocks.getColumns).toHaveBeenCalledWith("connection-1", "main", "main", "existing_target");
     });
+    await vi.waitFor(() => expect(buttonContaining("Next")?.disabled).toBe(false));
 
     buttonContaining("Next")?.click();
     await flushAsyncUpdates();

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -5530,6 +5530,8 @@ export default {
     searchExistingTables: "Search tables...",
     loadingTables: "Loading tables...",
     noTables: "No tables available",
+    targetColumnsTimeout: "Loading target table columns timed out. Check the connection and try again.",
+    retry: "Retry",
     stepSource: "Source",
     stepOptions: "Options",
     stepMapping: "Mapping",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -5324,6 +5324,8 @@ export default withEnglishFallback({
     status_done: "Import complete",
     status_error: "Import failed",
     status_cancelled: "Import cancelled",
+    targetColumnsTimeout: "Se agotó el tiempo de espera al cargar los campos de la tabla de destino. Compruebe la conexión e inténtelo de nuevo.",
+    retry: "Reintentar",
   },
   dataGenerate: {
     title: "Generación de datos",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -5322,6 +5322,8 @@ export default withEnglishFallback({
     status_done: "Import complete",
     status_error: "Import failed",
     status_cancelled: "Import cancelled",
+    targetColumnsTimeout: "Timeout nel caricamento dei campi della tabella di destinazione. Controlla la connessione e riprova.",
+    retry: "Riprova",
   },
   dataGenerate: {
     title: "Generazione dati",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -5360,6 +5360,8 @@ export default withEnglishFallback({
     titleRow: "ヘッダー行（0 はなし）",
     dataStartRow: "データ開始行",
     lastDataRow: "データ終了行（0 は末尾まで）",
+    targetColumnsTimeout: "ターゲットテーブルのフィールド読み込みがタイムアウトしました。接続を確認して再試行してください。",
+    retry: "再試行",
   },
   dataGenerate: {
     title: "データ生成",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5021,6 +5021,8 @@ export default withEnglishFallback({
     status_done: "가져오기 완료",
     status_error: "가져오기 실패",
     status_cancelled: "가져오기 취소됨",
+    targetColumnsTimeout: "대상 테이블 필드를 로드하는 시간이 초과되었습니다. 연결을 확인한 후 다시 시도하십시오.",
+    retry: "재시도",
   },
   dataGenerate: {
     title: "데이터 생성",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -5324,6 +5324,8 @@ export default withEnglishFallback({
     status_done: "Import complete",
     status_error: "Import failed",
     status_cancelled: "Import cancelled",
+    targetColumnsTimeout: "Tempo esgotado ao carregar os campos da tabela de destino. Verifique a conexão e tente novamente.",
+    retry: "Tentar novamente",
   },
   dataGenerate: {
     title: "Geração de dados",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -5514,6 +5514,8 @@ export default withEnglishFallback({
     searchExistingTables: "搜索表...",
     loadingTables: "正在加载表...",
     noTables: "暂无可用表",
+    targetColumnsTimeout: "加载目标表字段超时，请检查连接后重试。",
+    retry: "重试",
     stepSource: "来源",
     stepOptions: "选项",
     stepMapping: "映射",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -4647,6 +4647,8 @@ export default withEnglishFallback({
     status_done: "匯入完成",
     status_error: "匯入失敗",
     status_cancelled: "匯入已取消",
+    targetColumnsTimeout: "載入目標資料表欄位逾時，請檢查連線後重試。",
+    retry: "重試",
   },
   dataGenerate: {
     title: "資料生成",


### PR DESCRIPTION
## 问题

导入表数据向导中，Target 选择"现有表"时，用来加载该表字段元数据的请求（`ensureConnected` + `getColumns`）没有任何客户端超时保护。一旦这个请求响应变慢或迟迟无响应（远程库延迟、网络抖动、schema 较大排队等——生产环境很常见），弹窗会**无限期卡在"加载中"**，Next 按钮永远禁用，字段自然也就无法自动映射，且没有任何超时提示或重试入口。

Fixes #8127
Fixes #8128（同一 bug 的重复报告）

## 复现

1. 右键一张已有表 → Import Data → 选择 Excel 文件
2. Target 选 **Existing table** → Load Preview
3. 正常网络下几乎瞬间完成；但当底层 `GET /api/schema/columns` 响应变慢时，Options 步骤的 "Loading…" 会一直转，`Next` 保持禁用，没有任何反馈

本地用共享测试库人为注入了一段延迟来稳定复现这个"响应慢"场景，复现后的界面状态与 issue 原始截图完全一致（Preview 已加载完成，但下方 Loading 指示器仍卡死）。

## 修复

`TableImportDialog.vue` 的 `loadTargetColumns()` 给 `ensureConnected`/`getColumns` 两个调用各加 15 秒超时（`withTimeout` 包装原 Promise，成功路径行为不变）。超时后：

- 停止无限期转圈，展示清晰的错误提示（新增 i18n key `tableImport.targetColumnsTimeout`，中英文）
- 提供一个 **Retry** 按钮（`tableImport.retry`）重新触发加载

## 测试

- 已有的 `TableImportDialog.existingTarget.spec.ts`（覆盖"getColumns 慢/失败时 Next 保持禁用"等场景）+ `tableImport.spec.ts`，共 18 个用例全绿
  - 其中 1 个用例因为新增的 Promise 包装多引入一次 microtask，原先的断言依赖"点 Next 前只等 getColumns 被调用、不等其真正 resolve 落地"这种偏紧的时序，顺手改成显式等待 Next 按钮变为可点后再点击（更贴近真实交互）
- `vue-tsc --noEmit` / `oxlint` / `oxfmt --check` 全干净
- 手动验证：人为延迟场景下超时提示+Retry 正常出现，点击 Retry 能重新加载；去掉延迟后正常路径字段 4/4 自动映射成功、Next 正常可点，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Vu5fRW9Uh9kDovhgiWcAU