### PR TITLE
fix(editor): 停止在每次打开标签页时无条件预加载数据网格组件

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -232,12 +232,14 @@ const { toast } = useToast();
 const DEFAULT_QUERY_RESULTS_PANE_SIZE = 68;
 
 onMounted(() => {
-  const preload = () => preloadDataGridComponent();
-  if ("requestIdleCallback" in window) {
-    window.requestIdleCallback(preload, { timeout: 1500 });
-  } else {
-    setTimeout(preload, 300);
-  }
+  // Deliberately not preloading DataGrid here for every tab: evaluating that
+  // chunk is expensive (large component graph) and previously ran
+  // unconditionally shortly after any tab mounted, including source-only
+  // tabs (e.g. viewing a large object's DDL) that never need a grid. That
+  // turned a "warm the cache" optimization into a multi-second main-thread
+  // freeze right when the user was trying to read the newly-opened tab (see
+  // issue #8103). The watcher below still preloads it eagerly for tabs that
+  // actually need one.
   window.addEventListener("dbx-refresh-active-kv-browser", onRefreshActiveKvBrowser);
   window.addEventListener("resize", updateStandaloneResultToolbarDimensions);
   window.visualViewport?.addEventListener("resize", updateStandaloneResultToolbarDimensions);


### PR DESCRIPTION
## 问题

打开较大的 package（或任何对象源码）标签页时，软件卡住不动、无法操作。

## 根因

与 package/对象源码大小本身**无关**。`ContentArea.vue` 中，每个内容标签页挂载时都会用 `requestIdleCallback(preload, { timeout: 1500 })` **无条件**预加载 `DataGrid.vue` 这个异步组件 chunk，即使当前标签页只是查看源码、完全不涉及数据网格。

生产构建下该 chunk 是一个独立的 620KB（min）/173KB（gzip）文件。虽然网络请求和后台流式编译很快，但**模块求值（module evaluation）是在主线程同步执行的**：用 Chrome CPU Profile 实测，一次 `RunMicrotasks` 耗时 1,560,208 微秒（约 1.56 秒），期间伴随大量增量 GC 和一次因布局脏对象触发的强制 layout。这 1.56 秒会让整个应用卡死。

打开较大 package 之所以"看起来"更容易触发，只是因为渲染耗时更长，恰好与这个 1.5 秒左右的空闲预加载窗口重叠，让用户在这段时间尝试交互——包大小和该 bug 并无直接因果关系。

## 修复

移除了 `onMounted` 里这段无条件预加载逻辑。原有的按需 `watch`（`mode === "data" || hasResult` 时预加载）保留不变，真正需要数据网格的标签页仍会尽早加载。

## 验证

用共享 Oracle 19c 测试库，构造了 400/1500 个存储过程（5202/24002 行）的两个测试 package，通过生产构建（`vite build --mode web` + `vite preview`）复现 —— dev server 模式下 DataGrid.vue 是原生 ESM 逐文件加载，不会触发这个问题，必须用生产构建才能复现。

- **修复前**：打开 24002 行的 package 源码，CPU Profile 记录到 1 次 1.56 秒的主线程阻塞，含 DataGrid chunk 求值。
- **修复后**：同样操作，CPU Profile 中 DataGrid 相关事件为 0，最长单次任务从 1,560,208μs 降到 117,983μs（约 13 倍），无肉眼可感知卡顿。
- **回归验证**：打开真实表的数据网格标签页，点击刷新后数据网格正常渲染（表头、字段类型、分页信息均正常），确认按需预加载路径未受影响。
- `ContentArea.unavailableDataReload/outputView/dataHeader.spec.ts` 全部通过；全量 `pnpm exec vitest run apps/desktop/src`（954 文件 / 9263 用例）全绿；`vue-tsc --noEmit` 干净；`oxlint` 改动文件无告警。

Fixes #8103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Neyiw2q2cjRGYZQb9H58y5