### PR TITLE
fix(imports): 修复 DBeaver DB2 连接导入后误传驱动类名导致 ClassNotFoundException

### DIFF
--- a/apps/desktop/src/lib/__tests__/imports/dbeaverImport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/imports/dbeaverImport.spec.ts
@@ -222,7 +222,7 @@ describe("DBeaver folder import", () => {
     expect(connection?.database).toBeUndefined();
   });
 
-  it("keeps the default database empty for DB2 connections (fallback to JDBC) without database configured", async () => {
+  it("maps DB2 connections to DBX's native db2 type instead of falling back to generic JDBC", async () => {
     const [connection] = await parseDbeaverConnections(
       payload({
         connections: {
@@ -243,11 +243,54 @@ describe("DBeaver folder import", () => {
 
     expect(connection).toMatchObject({
       name: "DB2",
-      db_type: "jdbc",
+      db_type: "db2",
+      driver_profile: "db2",
       host: "192.168.10.60",
       port: 50000,
     });
     expect(connection?.database).toBeUndefined();
+    expect(connection?.jdbc_driver_class).toBeUndefined();
+  });
+
+  it("does not pass DBeaver's short driver id through as a JDBC driver class for unmapped drivers", async () => {
+    const [connection] = await parseDbeaverConnections(
+      payload({
+        connections: {
+          vertica: {
+            id: "vertica",
+            name: "Vertica",
+            provider: "vertica",
+            driver: "vertica",
+            configuration: {
+              url: "jdbc:vertica://192.168.10.61:5433/vdb",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(connection).toMatchObject({ name: "Vertica", db_type: "jdbc" });
+    expect(connection?.jdbc_driver_class).toBeUndefined();
+  });
+
+  it("still trusts a package-qualified DBeaver driver id as the JDBC driver class", async () => {
+    const [connection] = await parseDbeaverConnections(
+      payload({
+        connections: {
+          opaque: {
+            id: "opaque",
+            name: "Custom Driver",
+            provider: "generic",
+            driver: "com.example.Driver",
+            configuration: {
+              url: "jdbc:example:db.example.com:1234",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(connection).toMatchObject({ db_type: "jdbc", jdbc_driver_class: "com.example.Driver" });
   });
 
   it("does not treat an opaque JDBC host and port as the database", async () => {

--- a/apps/desktop/src/lib/imports/dbeaverImport.ts
+++ b/apps/desktop/src/lib/imports/dbeaverImport.ts
@@ -47,6 +47,7 @@ const profileMap: Record<string, ConnectionProfile> = {
   sqlserver: { dbType: "sqlserver", profile: "sqlserver", label: "SQL Server", port: 1433, user: "sa" },
   mssql: { dbType: "sqlserver", profile: "sqlserver", label: "SQL Server", port: 1433, user: "sa" },
   oracle: { dbType: "oracle", profile: "oracle", label: "Oracle", port: 1521, user: "system" },
+  db2: { dbType: "db2", profile: "db2", label: "IBM DB2", port: 50000, user: "db2inst1" },
   clickhouse: { dbType: "clickhouse", profile: "clickhouse", label: "ClickHouse", port: 8123, user: "default" },
   duckdb: { dbType: "duckdb", profile: "duckdb", label: "DuckDB", port: 0, user: "" },
   mongodb: { dbType: "mongodb", profile: "mongodb", label: "MongoDB", port: 27017, user: "" },
@@ -79,6 +80,15 @@ function getString(value: unknown) {
 function getNumber(value: unknown) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+// DBeaver's own driver id (e.g. "db2", "mysql8") is a short internal registry
+// key, not a Java class name; passing it straight to the JDBC agent as
+// `jdbc_driver_class` makes it try `Class.forName("db2")` and fail with
+// ClassNotFoundException. Only fall back to it when it is actually
+// package-qualified, which is how DBeaver identifies genuinely custom drivers.
+function looksLikeJdbcDriverClassName(value: string) {
+  return /^[a-zA-Z_$][\w$]*(\.[a-zA-Z_$][\w$]*)+$/.test(value);
 }
 
 function firstNonEmptyString(...values: unknown[]) {
@@ -258,7 +268,7 @@ function buildConnection(entry: DbeaverConnectionEntry, credentials: ReturnType<
     ssl: false,
     oracle_connection_type: profile.dbType === "oracle" ? parsedUrl.oracleConnectionType || "service_name" : undefined,
     connection_string: profile.dbType === "jdbc" || profile.dbType === "mongodb" ? url || undefined : undefined,
-    jdbc_driver_class: profile.dbType === "jdbc" ? getString(config["driver-class"] || (profile.profile === "jdbcx" ? JDBCX_JDBC_DRIVER_CLASS : entry.driver)) || undefined : undefined,
+    jdbc_driver_class: profile.dbType === "jdbc" ? getString(config["driver-class"] || (profile.profile === "jdbcx" ? JDBCX_JDBC_DRIVER_CLASS : looksLikeJdbcDriverClassName(getString(entry.driver)) ? entry.driver : undefined)) || undefined : undefined,
     jdbc_driver_paths: [],
   };
 


### PR DESCRIPTION
## 问题

导入 DBeaver 的 DB2 连接后，DBX 未识别为原生 DB2 类型，而是回退成通用 JDBC 类型，并把 DBeaver 内部的短驱动 id（如 `"db2"`）当作 Java 类名直接传给 `jdbc_driver_class`，导致连接时抛出 `ClassNotFoundException`。

## 原因

`dbeaverImport.ts` 中缺少 DB2 的 profile 映射；同时对 `entry.driver` 没有做校验，只要 profile 是 `jdbc` 就会把它原样透传为 `jdbc_driver_class`，但 DBeaver 的 `driver` 字段很多情况下只是内部注册表的短 id（如 `db2`、`vertica`），不是包限定的 Java 类名（如 `com.example.Driver`），无法被 `Class.forName` 正确加载。

## 修复

- 在 `profileMap` 中新增 `db2` → DBX 原生 `db2` 类型的映射。
- 新增 `looksLikeJdbcDriverClassName` 校验：只有当 `entry.driver` 看起来是包限定的类名时，才把它作为 `jdbc_driver_class` 回退值使用；否则不透传，避免 `Class.forName("db2")` 这类错误。

## 测试

- 更新/新增了 `dbeaverImport.spec.ts` 中的用例：DB2 连接正确映射为原生类型、未映射驱动（如 vertica）不再误传短 id 作为驱动类名、包限定类名（如自定义驱动）仍能正常透传。
- `npx vitest run apps/desktop/src/lib/__tests__/imports/dbeaverImport.spec.ts` 全部通过（18/18）。

Fixes #8137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L43DNnLaWqbqU2bYgYyEAt