### PR TITLE
fix(editor): 修复选区完全在字符串字面量内时右键转大写/小写无效的问题

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlSelectionCase.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlSelectionCase.spec.ts
@@ -14,11 +14,18 @@ describe("convertSqlSelectionCase", () => {
     expect(convertSqlSelectionCase(sql, { from: 0, to: sql.length }, "upper")).toBe("SELECT CODE FROM ORDERS WHERE CODE = 'abc001'");
   });
 
-  it("preserves the selected fragment when the selection is inside a string literal", () => {
+  it("converts a selection that is fully contained inside a string literal", () => {
     const sql = "select * from orders where code = 'AbC001'";
     const from = sql.indexOf("bC");
 
-    expect(convertSqlSelectionCase(sql, { from, to: from + 2 }, "lower")).toBe("bC");
+    expect(convertSqlSelectionCase(sql, { from, to: from + 2 }, "lower")).toBe("bc");
+  });
+
+  it("still protects a string literal when the selection extends beyond it", () => {
+    const sql = "select code from orders where code = 'abc001'";
+    const from = sql.indexOf("code =");
+
+    expect(convertSqlSelectionCase(sql, { from, to: sql.length }, "upper")).toBe("CODE = 'abc001'");
   });
 
   it("preserves PostgreSQL dollar-quoted string literals", () => {

--- a/apps/desktop/src/lib/sql/sqlSelectionCase.ts
+++ b/apps/desktop/src/lib/sql/sqlSelectionCase.ts
@@ -23,6 +23,14 @@ export function convertSqlSelectionCase(sql: string, range: SqlSelectionRange, m
   });
   if (protectedTokens.length === 0) return convertCase(sql.slice(from, to), mode);
 
+  // A selection fully contained inside one protected token (e.g. the user selected only
+  // text inside a string literal) carries no risk of collateral damage to surrounding SQL,
+  // so honor the explicit request instead of silently no-oping it.
+  const [only] = protectedTokens;
+  if (protectedTokens.length === 1 && only.span.start <= from && to <= only.span.end) {
+    return convertCase(sql.slice(from, to), mode);
+  }
+
   let converted = "";
   let cursor = from;
   for (const item of protectedTokens) {


### PR DESCRIPTION
## 问题

SQL 编辑器右键菜单的"转为大写/转为小写"，当选区**完全落在字符串字面量（引号）内**时无效，选中的文字不会被转换。

复现：输入 `select * from dba_tables t where t.table_name like '%abc%';`，精确选中引号内的 `abc`，右键"转为大写"，`abc` 依旧是小写。

## 根因

`apps/desktop/src/lib/sql/sqlSelectionCase.ts` 的 `convertSqlSelectionCase()` 会保护字符串字面量（以及 MySQL 下的双引号标识符/可执行注释）不被转换，本意是防止"全选整条 SQL 转大写"时误伤字面量里的数据（例如 `WHERE code = 'abc'` 转大写后变成 `WHERE CODE = 'ABC'` 导致语义变化）。

但该保护没有区分：
- 选区**跨出**字面量边界（有误伤风险）→ 应该保护
- 选区**完全落在**字面量内（用户明确选中这段文字并要求转换，没有任何误伤风险）→ 不该拦

现有逻辑对这两种情况一律不转换，导致用户显式选中引号内文字并主动转换大小写时被无条件挡下。

## 修复

新增一个分支：当命中的受保护 token 只有一个，且该 token 完整包住当前选区时，直接执行转换；选区跨出字面量边界时，原有保护逻辑保持不变。

## 测试

- 更新/新增单测：`apps/desktop/src/lib/__tests__/sql/sqlSelectionCase.spec.ts`（9/9 通过）
  - 原先断言"选区在字面量内 → 不转换"的用例，改为断言"应该转换"
  - 新增一条回归用例："选区跨出字面量边界时仍受保护"
- `pnpm check`（connection-types + format + lint + typecheck + test 全量）全绿
- UI 手动验证（截图见下）：修复前 `abc` 转大写无效；修复后 `abc` → `ABC`；回归检查全选整条 SQL 转大写，关键字变大写但字面量 `'abc001'` 不受影响，原保护逻辑未被破坏

Fixes #8154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Neyiw2q2cjRGYZQb9H58y5