### PR TITLE
fix(editor): 点击摘要面板长 SQL 行时高亮显示完整语句

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -5763,7 +5763,27 @@ onMounted(async () => {
       },
       provide: (field) => lineNumberMarkers.from(field),
     });
-    return field;
+
+    const highlightField = StateField.define({
+      create() {
+        return Decoration.none;
+      },
+      update(decorations, transaction) {
+        for (const effect of transaction.effects) {
+          if (effect.is(effectType)) {
+            const range = effect.value;
+            if (!range) return Decoration.none;
+            const from = Math.max(0, Math.min(range.from, transaction.state.doc.length));
+            const to = Math.max(from, Math.min(range.to, transaction.state.doc.length));
+            return from === to ? Decoration.none : Decoration.set([Decoration.mark({ class: "cm-db-result-source-highlight" }).range(from, to)]);
+          }
+        }
+        if (transaction.docChanged || transaction.selection) return Decoration.none;
+        return decorations;
+      },
+      provide: (field) => EditorView.decorations.from(field),
+    });
+    return [field, highlightField];
   };
 
   class StatementExecutionStateMarker extends GutterMarker {
@@ -7120,6 +7140,10 @@ defineExpose({
 
 :deep(.cm-db-execution-preview) {
   background: var(--dbx-editor-selection-background, rgba(59, 130, 246, 0.35));
+}
+
+:deep(.cm-db-result-source-highlight) {
+  background: var(--dbx-editor-selection-background, rgba(126, 34, 206, 0.2));
 }
 
 :deep(.cm-lineNumbers .cm-db-result-source-line-number) {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorResultSourceHighlight.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorResultSourceHighlight.spec.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+// Regression test for issue #8096: clicking a long SQL statement in the
+// execution-summary panel (previewStatementRange) used to only recolor the
+// gutter line number, which is easy to miss and reads as "click does
+// nothing" for statements that are already scrolled into view. The fix adds
+// a visible text-highlight decoration alongside the existing gutter marker.
+describe("QueryEditor result-source preview highlight", () => {
+  it("builds a highlight decoration field in addition to the gutter line-number field", () => {
+    const extensionStart = queryEditorSource.indexOf("buildResultSourceRangeExtension = () => {");
+    expect(extensionStart).toBeGreaterThan(-1);
+    const extensionEnd = queryEditorSource.indexOf("\n  };", extensionStart);
+    const extensionBody = queryEditorSource.slice(extensionStart, extensionEnd);
+
+    expect(extensionBody).toContain("lineNumberMarkers.from(field)");
+    expect(extensionBody).toContain("const highlightField = StateField.define({");
+    expect(extensionBody).toContain('Decoration.mark({ class: "cm-db-result-source-highlight" })');
+    expect(extensionBody).toContain("EditorView.decorations.from(field)");
+    expect(extensionBody).toContain("return [field, highlightField];");
+  });
+
+  it("drives both the gutter marker and the highlight decoration from the same effect", () => {
+    const extensionStart = queryEditorSource.indexOf("buildResultSourceRangeExtension = () => {");
+    const extensionEnd = queryEditorSource.indexOf("\n  };", extensionStart);
+    const extensionBody = queryEditorSource.slice(extensionStart, extensionEnd);
+    const effectUses = extensionBody.match(/effect\.is\(effectType\)/g) ?? [];
+
+    expect(effectUses.length).toBe(2);
+  });
+
+  it("defines a visible background style for the highlight class", () => {
+    expect(queryEditorSource).toMatch(/:deep\(\.cm-db-result-source-highlight\)\s*{\s*background:/);
+  });
+
+  it("keeps previewStatementRange wired to setResultSourceRangeEffect via setResultSourceRange", () => {
+    const fnStart = queryEditorSource.indexOf("function previewStatementRange(");
+    const fnEnd = queryEditorSource.indexOf("\n}", fnStart);
+    const fnBody = queryEditorSource.slice(fnStart, fnEnd);
+
+    expect(fnBody).toContain("setResultSourceRangeEffect.of({ from, to })");
+  });
+});


### PR DESCRIPTION
## 问题

Fixes #8096

执行长 SQL 后切到「摘要」面板，SQL 列因样式截断只显示省略号；点击该行触发的“预览”实际上只是把编辑器行号变色 + 光标移动到一个零长度选区，没有任何肉眼可见的效果，用户感知为“点击预览也不行”。

## 根因

`QueryEditor.vue` 的 `buildResultSourceRangeExtension()` 只注册了行号 gutter 着色（`lineNumberMarkers`），从未 `provide` 任何 `EditorView.decorations` 做正文高亮；`previewStatementRange()` 的选区只设置了 `anchor`，未设置 `head`，等于零长度选区。真正可见的高亮 mark class（`cm-db-execution-preview`）被另一套无关功能（多语句候选选择器的 hover 预览）占用。双击对应的 `focusStatementRange()` 其实是正确实现（选中 + 聚焦），但用户点击的是单击。

## 修复

`buildResultSourceRangeExtension()` 新增第二个 `StateField`，监听同一个 `setResultSourceRangeEffect`，命中时用 `Decoration.mark` 高亮整个匹配到的语句文本区间并 `provide` 给 `EditorView.decorations`；扩展函数返回 `[field, highlightField]`。新增对应的高亮 CSS，不改变双击的既有行为，也不改变摘要列本身的截断显示。

## 验证

- 真实复现：SQLite `:memory:` 连接执行一条超长 SQL，切到摘要面板点击 SQL 行——修复前编辑器无任何可见变化，修复后对应整行 SQL 出现明显高亮背景并自动滚动到可视区域。
- 新增回归测试 `queryEditorResultSourceHighlight.spec.ts`（4 个用例）：revert 修复后重跑 3/4 真实失败，恢复后 4/4 通过。
- `pnpm exec vitest run` editor/layout/tabs 相关目录：103 files / 791 tests 全绿。
- `vue-tsc --noEmit` / `oxlint` / `oxfmt --check`（改动文件范围）均干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L43DNnLaWqbqU2bYgYyEAt