### PR TITLE
fix(editor): enable backslash escapes for MySQL-family dialects

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
@@ -77,7 +77,7 @@ describe("codemirrorSqlDialect", () => {
   });
 
   it("enables backslashEscapes for MySQL-family dialects and ClickHouse while keeping it disabled for standard dialects", () => {
-    const backslashEscapesTypes: DatabaseType[] = ["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase", "clickhouse", "hive", "spark", "impala", "argo"];
+    const backslashEscapesTypes: DatabaseType[] = ["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase", "clickhouse", "hive", "spark", "impala", "argo", "databend"];
     for (const databaseType of backslashEscapesTypes) {
       expect(createDbxCodeMirrorSqlDialect(langSql, "mysql", databaseType).spec.backslashEscapes, databaseType).toBe(true);
     }

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
@@ -75,4 +75,37 @@ describe("codemirrorSqlDialect", () => {
       expect(createDbxCodeMirrorSqlDialect(langSql, "mysql", databaseType).spec.doubleQuotedStrings, databaseType).toBe(false);
     }
   });
+
+  it("enables backslashEscapes for MySQL-family dialects and ClickHouse while keeping it disabled for standard dialects", () => {
+    const backslashEscapesTypes: DatabaseType[] = ["mysql", "doris", "starrocks", "goldendb", "gbase", "sundb", "databend", "clickhouse", "hive", "spark", "impala", "argo"];
+    for (const databaseType of backslashEscapesTypes) {
+      expect(createDbxCodeMirrorSqlDialect(langSql, "mysql", databaseType).spec.backslashEscapes, databaseType).toBe(true);
+    }
+
+    const standardTypes: DatabaseType[] = ["postgres", "sqlserver", "sqlite", "oracle", "dameng"];
+    for (const databaseType of standardTypes) {
+      expect(createDbxCodeMirrorSqlDialect(langSql, "mysql", databaseType).spec.backslashEscapes, databaseType).toBeUndefined();
+    }
+  });
+
+  it("correctly tokenizes string literals containing escaped quotes in MySQL statements without corrupting trailing code", () => {
+    const dialect = createDbxCodeMirrorSqlDialect(langSql, "mysql", "mysql");
+    const statement = ["SELECT CONCAT('\\'', sl.id) id, sl.settlement_price_tax '本次结算金额含税',", "CASE sc.`type`", "    WHEN 0 THEN '物资'", "    WHEN 1 THEN '设备'", "    ELSE ''", "END AS '合同类型'"].join("\n");
+
+    expect(nodeNameAt(dialect, statement, "'\\''")).toBe("String");
+    expect(nodeNameAt(dialect, statement, "'本次结算金额含税'")).toBe("String");
+    expect(nodeNameAt(dialect, statement, "CASE")).toBe("Keyword");
+    expect(nodeNameAt(dialect, statement, "`type`")).toBe("QuotedIdentifier");
+    expect(nodeNameAt(dialect, statement, "WHEN")).toBe("Keyword");
+    expect(nodeNameAt(dialect, statement, "THEN")).toBe("Keyword");
+    expect(nodeNameAt(dialect, statement, "'物资'")).toBe("String");
+    expect(nodeNameAt(dialect, statement, "'设备'")).toBe("String");
+    expect(nodeNameAt(dialect, statement, "''")).toBe("String");
+    expect(nodeNameAt(dialect, statement, "END")).toBe("Keyword");
+    expect(nodeNameAt(dialect, statement, "'合同类型'")).toBe("String");
+
+    const doubleQuoteStatement = 'SELECT "escaped\\"quote", col FROM tbl';
+    expect(nodeNameAt(dialect, doubleQuoteStatement, '"escaped\\"quote"')).toBe("String");
+    expect(nodeNameAt(dialect, doubleQuoteStatement, "col")).toBe("Identifier");
+  });
 });

--- a/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts
@@ -77,7 +77,7 @@ describe("codemirrorSqlDialect", () => {
   });
 
   it("enables backslashEscapes for MySQL-family dialects and ClickHouse while keeping it disabled for standard dialects", () => {
-    const backslashEscapesTypes: DatabaseType[] = ["mysql", "doris", "starrocks", "goldendb", "gbase", "sundb", "databend", "clickhouse", "hive", "spark", "impala", "argo"];
+    const backslashEscapesTypes: DatabaseType[] = ["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase", "clickhouse", "hive", "spark", "impala", "argo"];
     for (const databaseType of backslashEscapesTypes) {
       expect(createDbxCodeMirrorSqlDialect(langSql, "mysql", databaseType).spec.backslashEscapes, databaseType).toBe(true);
     }

--- a/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
@@ -6,10 +6,11 @@ export type CodeMirrorSqlDialectName = "mysql" | "postgres" | "sqlserver" | "cli
 
 type CodeMirrorSqlLanguageModule = Pick<typeof import("@codemirror/lang-sql"), "Cassandra" | "MSSQL" | "MySQL" | "PLSQL" | "PostgreSQL" | "SQLite" | "SQLDialect" | "StandardSQL">;
 
-const MYSQL_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase"]);
+const MYSQL_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase", "sundb", "databend"]);
 const POSTGRES_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["postgres", "redshift", "gaussdb", "kwdb", "kingbase", "highgo", "uxdb", "vastbase", "opengauss", "questdb"]);
 const ORACLE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["oracle", "dameng", "yashandb", "oscar", "oceanbase-oracle"]);
 const SQLITE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["sqlite", "rqlite", "turso", "cloudflare-d1"]);
+const BACKSLASH_ESCAPE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["hive", "argo", "impala", "spark"]);
 
 const CODEMIRROR_SQLITE_EXTENSION_KEYWORDS = new Set("abort analyze attach autoincrement conflict database detach exclusive fail glob ignore index indexed instead isnull notnull offset plan pragma query raise regexp reindex rename replace temp vacuum virtual".split(" "));
 const STANDARD_SQL_TYPES = "array binary bit boolean char character clob date decimal double float int integer interval large national nchar nclob numeric object precision real smallint time timestamp varchar varying";
@@ -243,6 +244,11 @@ export function createDbxCodeMirrorSqlDialect(langSql: CodeMirrorSqlLanguageModu
           identifierQuotes: '"`',
           backslashEscapes: true,
           spaceAfterDashes: false,
+        }
+      : {}),
+    ...(isMysql || (databaseType && BACKSLASH_ESCAPE_CODEMIRROR_DATABASE_TYPES.has(databaseType))
+      ? {
+          backslashEscapes: true,
         }
       : {}),
     ...(isPlsql ? { doubleQuotedStrings: false } : {}),

--- a/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
@@ -6,7 +6,7 @@ export type CodeMirrorSqlDialectName = "mysql" | "postgres" | "sqlserver" | "cli
 
 type CodeMirrorSqlLanguageModule = Pick<typeof import("@codemirror/lang-sql"), "Cassandra" | "MSSQL" | "MySQL" | "PLSQL" | "PostgreSQL" | "SQLite" | "SQLDialect" | "StandardSQL">;
 
-const MYSQL_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase", "sundb", "databend"]);
+const MYSQL_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["mysql", "doris", "starrocks", "manticoresearch", "goldendb", "gbase"]);
 const POSTGRES_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["postgres", "redshift", "gaussdb", "kwdb", "kingbase", "highgo", "uxdb", "vastbase", "opengauss", "questdb"]);
 const ORACLE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["oracle", "dameng", "yashandb", "oscar", "oceanbase-oracle"]);
 const SQLITE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["sqlite", "rqlite", "turso", "cloudflare-d1"]);

--- a/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
+++ b/apps/desktop/src/lib/editor/codemirrorSqlDialect.ts
@@ -10,7 +10,11 @@ const MYSQL_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["mysql", "doris",
 const POSTGRES_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["postgres", "redshift", "gaussdb", "kwdb", "kingbase", "highgo", "uxdb", "vastbase", "opengauss", "questdb"]);
 const ORACLE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["oracle", "dameng", "yashandb", "oscar", "oceanbase-oracle"]);
 const SQLITE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["sqlite", "rqlite", "turso", "cloudflare-d1"]);
-const BACKSLASH_ESCAPE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["hive", "argo", "impala", "spark"]);
+// Non-MySQL-wire dialects whose servers still interpret backslash escapes in string
+// literals; the mysql-family types are covered by isMysql at the define() site. Mirrors
+// BACKSLASH_ESCAPE_STRING_DIALECTS in lib/sql/sqlStatementRanges.ts so the editor
+// tokenizer and the statement splitter agree on escape semantics per dialect.
+const BACKSLASH_ESCAPE_CODEMIRROR_DATABASE_TYPES = new Set<DatabaseType>(["hive", "argo", "impala", "spark", "databend"]);
 
 const CODEMIRROR_SQLITE_EXTENSION_KEYWORDS = new Set("abort analyze attach autoincrement conflict database detach exclusive fail glob ignore index indexed instead isnull notnull offset plan pragma query raise regexp reindex rename replace temp vacuum virtual".split(" "));
 const STANDARD_SQL_TYPES = "array binary bit boolean char character clob date decimal double float int integer interval large national nchar nclob numeric object precision real smallint time timestamp varchar varying";


### PR DESCRIPTION
## 变更说明

修复 SQL 查询编辑器中 MySQL 系列方言（MySQL、Doris、StarRocks、GoldenDB、GBase、SunDB、Databend 等）及支持反斜杠转义方言（Hive、Spark、Impala、Argo）未启用 `backslashEscapes` 的问题。

当 SQL 中包含如 `CONCAT('\'', sl.id)` 这种使用反斜杠转义单引号的语句时，词法解析器此前会将 `\'` 中的单引号误当作字符串结束标记，导致紧随其后的第三个单引号被误认为新字符串开头，使后续所有合法的 SQL 语句（如 `CASE...WHEN...THEN...END`）的字符串开闭状态颠倒，代码整体被误识别为红色字符串高亮。

本 PR 在 `codemirrorSqlDialect.ts` 中针对上述方言开启了 `backslashEscapes: true`，并在 `codemirrorSqlDialect.spec.ts` 中补充了针对该场景的单元测试。非转义方言（PostgreSQL、SQL Server、SQLite、Oracle 等）保持默认设置，避免受尾部反斜杠影响。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

| 修复前 (Before：单引号开闭颠倒，导致后续 CASE 语句全被高亮为红色字符串) | 修复后 (After：\' 正确识别为转义字符，后续 SQL 恢复正常语法高亮) |
| :---: | :---: |
| <img width="1000" height="697" alt="image" src="https://github.com/user-attachments/assets/9f858dfb-36ef-4f52-8f44-193d0a013c17" /> | <img width="1126" height="596" alt="image" src="https://github.com/user-attachments/assets/6c44e140-2b98-43e2-b12b-4e0a19b607be" /> |

## 验证

- [x] 相关测试通过

**1. 自动化单元测试：**
运行 `pnpm vitest run apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts`，8 项测试全部通过（覆盖了方言属性校验与包含 `CONCAT('\'', sl.id)`、双引号转义等真实语句的词法 Token 解析断言）。

**2. 代码检查与格式化：**
- 运行 `oxlint apps/desktop/src/lib/editor/codemirrorSqlDialect.ts apps/desktop/src/lib/__tests__/editor/codemirrorSqlDialect.spec.ts`，通过（0 errors, 0 warnings）。
- 运行 `oxfmt` 格式化通过。

**3. 手动验证步骤：**
在 SQL 查询编辑器（MySQL 方言环境）输入以下复现语句：
```sql
SELECT CONCAT('\'',sl.id) id,sl.settlement_price_tax ,
    sc.supplier_name , 
    sl.push_yzw_msg ,
    sl.settlement_summary_id as id
FROM bmsdb.settlement_list AS sl