### PR TITLE
fix(editor): 修复内置 SQL 函数（count/date_format 等）不高亮的问题

### DIFF
--- a/apps/desktop/src/lib/__tests__/editorThemes.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editorThemes.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildEditorFontThemeRules, buildSqlCompletionThemeRules, editorDiagnosticColors, editorThemeAppearanceFor, resolveCustomThemeBackgrounds, resolveEditorTheme } from "@/lib/editor/editorThemes";
+import { buildEditorFontThemeRules, buildSqlCompletionThemeRules, editorDiagnosticColors, editorThemeAppearanceFor, resolveCustomThemeBackgrounds, resolveEditorTheme, SQL_BUILTIN_HIGHLIGHT_TAG } from "@/lib/editor/editorThemes";
 import { DEFAULT_APP_CUSTOM_UI_COLORS, wcagContrastRatio, type AppThemePalette } from "@/lib/app/appTheme";
 import type { EditorTheme } from "@/stores/settingsStore";
+import { createDbxCodeMirrorSqlDialect } from "@/lib/editor/codemirrorSqlDialect";
+import * as langSql from "@codemirror/lang-sql";
 
 describe("resolveEditorTheme", () => {
   it("maps only the follow-app editor theme to application IDE palettes", () => {
@@ -188,6 +190,34 @@ describe("SQL completion theme", () => {
       maskPosition: "center",
     });
     expect(rules[".cm-completionIcon"]).toMatchObject({ width: "15px", height: "15px", overflow: "hidden" });
+  });
+});
+
+describe("SQL builtin highlight tag", () => {
+  // #7950: count/date_format/etc. were added to the dialect builtin word lists (#7222) but
+  // never actually rendered in a distinct color, because the theme's highlight rule matched
+  // standard(variableName) while @codemirror/lang-sql tags builtin words as standard(name) —
+  // variableName is a *child* tag of name, so a rule keyed on the child never matches the
+  // token's actual (parent) tag.
+  it("gives builtin SQL functions their own highlight class, distinct from plain identifiers and keywords", async () => {
+    const { highlightTree } = await import("@lezer/highlight");
+    const { HighlightStyle } = await import("@codemirror/language");
+    const { tags } = await import("@lezer/highlight");
+    const style = HighlightStyle.define([
+      { tag: tags.keyword, color: "keyword" },
+      { tag: [tags.name, tags.variableName], color: "variable" },
+      { tag: SQL_BUILTIN_HIGHLIGHT_TAG, color: "builtin" },
+    ]);
+
+    const dialect = createDbxCodeMirrorSqlDialect(langSql, "postgres", "postgres");
+    const doc = "select count(*) from t";
+    const tree = dialect.language.parser.parse(doc);
+    const classesByToken = new Map<string, string>();
+    highlightTree(tree, style, (from, to, cls) => classesByToken.set(doc.slice(from, to), cls));
+
+    expect(classesByToken.get("count")).toBeDefined();
+    expect(classesByToken.get("count")).not.toBe(classesByToken.get("t"));
+    expect(classesByToken.get("count")).not.toBe(classesByToken.get("select"));
   });
 });
 

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -4,6 +4,12 @@ import { customUiAppearance, type AppCustomUiColors, type AppThemeAppearance, ty
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { tags } from "@lezer/highlight";
 
+// @codemirror/lang-sql tags dialect builtin-list words (COUNT, DATE_FORMAT, ...) as
+// standard(name) — not standard(variableName), which is a *child* tag of name and so never
+// matches a token tagged with the parent. Shared so both editor theme builders below stay in
+// sync with what the SQL tokenizer actually emits.
+export const SQL_BUILTIN_HIGHLIGHT_TAG = tags.standard(tags.name);
+
 type CodeMirrorStyleSpec = Parameters<typeof import("@codemirror/view").EditorView.theme>[0];
 type LucideIconNode = Array<[string, Record<string, string>]>;
 
@@ -165,7 +171,7 @@ function createCustomTheme(EditorView: typeof import("@codemirror/view").EditorV
     { tag: tags.definition(tags.variableName), color: c.variable },
     { tag: tags.function(tags.variableName), color: c.function },
     { tag: tags.function(tags.propertyName), color: c.function },
-    { tag: tags.standard(tags.variableName), color: c.builtin },
+    { tag: SQL_BUILTIN_HIGHLIGHT_TAG, color: c.builtin },
     { tag: tags.propertyName, color: c.property },
     { tag: tags.operator, color: c.operator },
     { tag: tags.compareOperator, color: c.operator },
@@ -563,7 +569,7 @@ function createIdeEditorTheme(EditorView: typeof import("@codemirror/view").Edit
     { tag: [tags.typeName, tags.typeOperator, tags.unit], color: c.type },
     { tag: [tags.name, tags.variableName, tags.definition(tags.variableName)], color: c.variable },
     { tag: [tags.function(tags.variableName), tags.function(tags.propertyName), tags.function(tags.name), tags.macroName], color: c.function },
-    { tag: [tags.standard(tags.variableName), tags.special(tags.name)], color: c.builtin },
+    { tag: [SQL_BUILTIN_HIGHLIGHT_TAG, tags.special(tags.name)], color: c.builtin },
     { tag: [tags.propertyName, tags.labelName, tags.annotation], color: c.property },
     { tag: [tags.operator, tags.compareOperator, tags.logicOperator, tags.arithmeticOperator, tags.derefOperator], color: c.operator },
     { tag: [tags.punctuation, tags.separator, tags.paren, tags.brace, tags.bracket, tags.angleBracket], color: c.punctuation },


### PR DESCRIPTION
## 问题

Fixes #7950

用户在 #7222（已由本账号在 PR #7253 修复并发布）下反馈：更新到新版本后，`count(*)` 等内置函数在编辑器里依然不高亮，并主动提出疑问——是不是因为使用了 JetBrains 配色主题。

## 根因

`apps/desktop/src/lib/editor/editorThemes.ts` 里两处 `HighlightStyle` 定义（DBX 默认主题 `createCustomTheme`，以及覆盖 IDEA/JetBrains/Cursor/VSCode/Xcode 等导入主题的 `createIdeEditorTheme`）都把内置函数的着色规则写成：

```ts
{ tag: tags.standard(tags.variableName), color: c.builtin }
```

但 `@codemirror/lang-sql` 实际给 dialect `builtin` 词表命中的 token 打的标签是 `tags.standard(tags.name)`。`@lezer/highlight` 里 `variableName` 是 `name` 的**子标签**而非别名，`HighlightStyle` 的匹配规则要求"规则标签是 token 标签本身或其祖先"，这里恰好反过来——规则写的是子标签，token 实际打的是父标签，永远匹配不上，于是这些函数只能落回更靠前的"普通标识符"规则，和字段名/表名同色。

这个 bug **早于 #7222 就存在**，且与它相互独立：#7222 把 `count`/`date_format` 等词加进 `builtin` 词表（PR #7253）是必要但不充分的修复——词表加对了，但主题这边的着色规则一直是错的，看起来就像"没修好"，在所有主题下（不只是 JetBrains）都会复现，与用户自己怀疑的"配色主题问题"无关（主题选对选错都一样不高亮）。

## 修复

新增导出常量 `SQL_BUILTIN_HIGHLIGHT_TAG = tags.standard(tags.name)`，两处 `tags.standard(tags.variableName)` 都改用这个常量，避免两份定义各写一次、以后又写错。

## 验证

- 新增回归测试 `editorThemes.spec.ts`「SQL builtin highlight tag」：用真实 tokenizer + 真实 `HighlightStyle` 规则数组断言内置函数拿到独立于关键字/普通标识符的高亮 class（而不是依赖读代码猜测）。
- `pnpm check`（connection-types + format + lint + typecheck + 全量 vitest）全绿。
- 真实浏览器复现，PostgreSQL（`select count(*), coalesce(1,2), lower('X') from generate_series(1,1)`）+ MySQL（`select date_format(now(), '%Y-%m-%d'), ifnull(1,2), curdate()`），JetBrains 暗色主题 + DBX 默认「洁白」主题下前后对比：
  - 修复前：`count`/`coalesce`/`lower`/`date_format`/`ifnull`/`curdate` 均与普通标识符同色，未在词表里的 `generate_series` 同样未高亮（对照组）。
  - 修复后：上述内置函数均正确显示为与 `select`/`from` 一致的内置函数色；`generate_series` 依然保持不高亮，证明修复精确、未误伤非内置函数。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyfKsLxenfd4dD41Li3d7W