### PR TITLE
fix(docs): 修复文档弹窗关闭按钮遮挡导出 HTML

### DIFF
--- a/apps/desktop/src/components/docs/DatabaseDocsDialog.vue
+++ b/apps/desktop/src/components/docs/DatabaseDocsDialog.vue
@@ -207,7 +207,7 @@ watch(
 <template>
   <Dialog v-model:open="open">
     <DialogContent class="w-[94vw] max-w-[94vw] sm:max-w-[94vw] md:max-w-[94vw] lg:max-w-[94vw] xl:max-w-[94vw] h-[86vh] max-h-[86vh] gap-0 p-0 overflow-hidden flex flex-col">
-      <DialogHeader class="px-4 py-3 border-b">
+      <DialogHeader class="px-4 py-3 border-b pr-12">
         <DialogTitle class="flex items-center gap-2">
           <span>{{ t("docs.title") }}</span>
           <span v-if="statusLabel" class="text-xs font-normal" :class="status.state === 'failed' ? 'text-destructive' : 'text-muted-foreground'">

--- a/apps/desktop/src/components/docs/__tests__/DatabaseDocsDialogLayout.spec.ts
+++ b/apps/desktop/src/components/docs/__tests__/DatabaseDocsDialogLayout.spec.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dialogSource = readFileSync(new URL("../DatabaseDocsDialog.vue", import.meta.url), "utf8");
+
+describe("DatabaseDocsDialog layout", () => {
+  it("reserves header space for the absolute close button", () => {
+    expect(dialogSource).toMatch(/<DialogHeader class="[^"]*\bpr-12\b[^"]*">/);
+  });
+});


### PR DESCRIPTION
## 变更说明

修复 #8186。

文档弹窗的关闭按钮采用右上角绝对定位，而标题栏此前没有为该按钮预留空间，导致它可能遮挡最右侧的“导出 HTML”按钮。本次为文档弹窗标题栏增加右侧内边距，使关闭按钮拥有独立区域。

## 修改内容

- 调整 `DatabaseDocsDialog.vue` 标题栏右侧布局
- 增加标题栏布局回归测试，固定关闭按钮预留空间
- 保持导出 HTML、关系图和关闭逻辑不变
- 不修改通用 `DialogContent.vue` 行为

## 验证

- [x] `pnpm exec vitest run apps/desktop/src/components/docs`（6 个测试通过）
- [x] `pnpm lint`（通过；仅报告仓库现有 warnings）
- [x] `pnpm typecheck`
- [x] `pnpm exec oxfmt --check apps/desktop/src/components/docs/DatabaseDocsDialog.vue apps/desktop/src/components/docs/__tests__/DatabaseDocsDialogLayout.spec.ts`
- [x] `git diff --check`

Closes #8186
