### PR TITLE
fix(tabs): 溢出弹窗搜索不再过滤顶部标签栏

### DIFF
--- a/apps/desktop/src/components/layout/EditorGroupTabBar.vue
+++ b/apps/desktop/src/components/layout/EditorGroupTabBar.vue
@@ -176,9 +176,16 @@ const tabScrollbarThumbStyle = computed<CSSProperties>(() => ({
 // Overflow search lists this group's tabs (mirrors the legacy AppTabBar
 // overflow popover, scoped to the group that owns the strip).
 const tabOverflowOpen = ref(false);
+// The overflow popover's "search opened tabs" query is scoped to the popover
+// list only. It must not reach the strip: with a shared query, typing a term
+// with no match would empty the always-visible top tab bar while the active
+// tab's content stays on screen.
+const tabOverflowSearchQuery = ref("");
+// The strip's own search box lives only in the vertical toolbar, where
+// filtering the strip itself is the point of the search.
 const tabSearchQuery = ref("");
 const filteredGroupTabs = computed(() => {
-  const query = tabSearchQuery.value.trim().toLocaleLowerCase();
+  const query = tabOverflowSearchQuery.value.trim().toLocaleLowerCase();
   if (!query) {
     return props.tabs;
   }
@@ -186,7 +193,7 @@ const filteredGroupTabs = computed(() => {
 });
 
 watch(tabOverflowOpen, (open) => {
-  tabSearchQuery.value = "";
+  tabOverflowSearchQuery.value = "";
   if (open) {
     nextTick(() => document.querySelector<HTMLInputElement>("[data-group-tab-search-input]")?.focus());
   }
@@ -523,8 +530,9 @@ function tabMatchesSearch(tab: QueryTab, query: string) {
 }
 
 /**
- * The strips apply the search box (overflow popover and vertical toolbar
- * share it): sections filter by title before clustering.
+ * The strips apply the vertical toolbar search box: sections filter by title
+ * before clustering. The overflow popover's query (tabOverflowSearchQuery) is
+ * scoped to the popover list and deliberately does not reach the strip.
  */
 const filteredPinnedTabs = computed(() => {
   const query = tabSearchQuery.value.trim().toLocaleLowerCase();
@@ -1201,7 +1209,7 @@ watch(
           <PopoverContent align="end" class="w-auto min-w-56 max-w-80 gap-0 rounded-[6px] p-1" @click.stop @keydown.stop>
             <div class="relative border-b px-1 pb-1">
               <Search class="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input v-model="tabSearchQuery" data-group-tab-search-input type="search" :placeholder="t('tabs.searchOpenTabs')" class="h-8 pl-7 text-sm" />
+              <Input v-model="tabOverflowSearchQuery" data-group-tab-search-input type="search" :placeholder="t('tabs.searchOpenTabs')" class="h-8 pl-7 text-sm" />
             </div>
             <div class="max-h-[min(70vh,28rem)] overflow-y-auto pt-1">
               <CustomContextMenu v-for="tab in filteredGroupTabs" :key="tab.id" :items="getTabMenuItems(tab)" v-slot="{ onContextMenu }">

--- a/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
@@ -97,6 +97,21 @@ describe("EditorGroupTabBar semantic tab groups", () => {
     expect(source).toContain("grouping && !tabSearchQuery.value.trim() && isTabGroupCollapsed(tab)");
   });
 
+  it("keeps the overflow search scoped to the popover list without filtering the strip", () => {
+    // Regression: the popover's "search opened tabs" box shared the strip's
+    // query, so typing a term with no match emptied the top tab bar while the
+    // active tab's content stayed on screen.
+    const overflowFilter = sourceBetween("const filteredGroupTabs", "watch(tabOverflowOpen");
+    expect(overflowFilter).toContain("tabOverflowSearchQuery.value.trim()");
+    expect(overflowFilter).not.toContain("tabSearchQuery");
+    const overflowOpenWatch = sourceBetween("watch(tabOverflowOpen", "const showOverflowControl");
+    expect(overflowOpenWatch).toContain('tabOverflowSearchQuery.value = "";');
+    const stripFilter = sourceBetween("const filteredPinnedTabs", "const stripEntries");
+    expect(stripFilter).toContain("tabSearchQuery.value.trim()");
+    expect(stripFilter).not.toContain("tabOverflowSearchQuery");
+    expect(source).toContain('<Input v-model="tabOverflowSearchQuery" data-group-tab-search-input');
+  });
+
   it("keeps wrap layout out of the vertical placement", () => {
     expect(source).toContain('const isWrapLayout = computed(() => !isVerticalLayout.value && settingsStore.editorSettings.tabLayout === "wrap");');
   });


### PR DESCRIPTION
溢出弹窗里的"搜索已打开的标签页"输入框与顶部标签栏共用了同一个查询状态，所以输入关键词（尤其是没有匹配项的关键词）时会过滤掉始终可见的标签栏，导致所有标签消失，而当前页面内容仍显示在屏幕上。现在弹窗只过滤它自己的列表；标签栏的搜索仍由垂直工具栏的搜索框驱动。

## 变更说明

修复 #8197：溢出弹窗的"搜索已打开的标签页"此前与顶部标签栏共用同一个查询状态，输入时会把过滤作用泄漏到顶部标签栏——无匹配时所有标签瞬间消失，但当前页面仍显示，容易让用户误以为标签被关闭或数据丢失。

修法：弹窗搜索改用独立的 `tabOverflowSearchQuery`，只过滤弹窗列表（`filteredGroupTabs`）；顶部标签栏保留原有的 `tabSearchQuery`，仍由垂直工具栏搜索框驱动（该行为不变）。



## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<img width="2024" height="1424" alt="image" src="https://github.com/user-attachments/assets/e4b52848-98dd-4cc8-a0ce-fb29a414d9da" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

Close #8197
