### PR TITLE
fix(completion): 修复 JDBC 连接到 Oracle 时字段补全无法识别当前 schema 的问题

### DIFF
--- a/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.completion.spec.ts
@@ -60,6 +60,19 @@ function oracleConnection(): ConnectionConfig {
   } as ConnectionConfig;
 }
 
+function jdbcOracleConnection(): ConnectionConfig {
+  return {
+    ...postgresConnection(),
+    id: "jdbc-oracle-1",
+    name: "Oracle via JDBC",
+    db_type: "jdbc",
+    port: 1521,
+    username: "APP",
+    database: "ORCL",
+    connection_string: "jdbc:oracle:thin:@127.0.0.1:1521/ORCL",
+  } as ConnectionConfig;
+}
+
 function oceanBaseOracleConnection(): ConnectionConfig {
   return {
     ...oracleConnection(),
@@ -611,6 +624,36 @@ describe("connectionStore completion assistant", () => {
     expect(getColumns).toHaveBeenCalledWith("oracle-1", "ORCL", "", "ORDERS", undefined, "tab-a");
     expect(columns).toEqual([expect.objectContaining({ name: "REPORT_ID", table: "ORDERS", schema: undefined, dataType: "NUMBER" })]);
     expect(store.lookupLocalCompletionColumns("oracle-1", "ORCL", "ORDERS")).toEqual([]);
+  });
+
+  it("lets a JDBC connection to Oracle resolve CURRENT_SCHEMA for unqualified column completion, same as the native Oracle driver", async () => {
+    const completionAssistantSearch = vi.fn().mockResolvedValue({
+      candidates: [],
+      incomplete: false,
+      fallback_used: false,
+    });
+    const getColumns = vi.fn().mockResolvedValue([{ name: "REPORT_ID", data_type: "NUMBER", is_nullable: false, column_default: null, is_primary_key: true, extra: null, comment: null }]);
+
+    vi.doMock("@/lib/backend/tauriRuntime", () => ({ isTauriRuntime: () => false }));
+    vi.doMock("@/lib/backend/api", () => ({
+      checkConnectionHealth: vi.fn().mockResolvedValue(undefined),
+      completionAssistantSearch,
+      getColumns,
+    }));
+
+    const { useConnectionStore } = await import("@/stores/connectionStore");
+    const store = useConnectionStore();
+    store.connections = [jdbcOracleConnection()];
+    store.connectedIds.add("jdbc-oracle-1");
+
+    // No schema is selected (undefined) — before the fix this fell through
+    // both the Oracle current-schema completion path and the schema-required
+    // guard, silently returning [] without ever calling getColumns.
+    const columns = await store.listCompletionColumns("jdbc-oracle-1", "ORCL", "ORDERS", undefined, { clientSessionId: "tab-a", version: 0 });
+
+    expect(completionAssistantSearch).not.toHaveBeenCalled();
+    expect(getColumns).toHaveBeenCalledWith("jdbc-oracle-1", "ORCL", "", "ORDERS", undefined, "tab-a");
+    expect(columns).toEqual([expect.objectContaining({ name: "REPORT_ID", table: "ORDERS", schema: undefined, dataType: "NUMBER" })]);
   });
 
   it("uses the Dameng login schema for unqualified column completion", async () => {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -8094,12 +8094,19 @@ export const useConnectionStore = defineStore("connection", () => {
 
   async function listCompletionColumns(connectionId: string, database: string, table: string, schema?: string, context?: { clientSessionId?: string; version?: number; tableQuoted?: boolean; schemaQuoted?: boolean }, catalog?: string): Promise<SqlCompletionColumn[]> {
     const config = getConfig(connectionId);
-    const oracleIdentifier = config?.db_type === "oracle" || config?.db_type === "oceanbase-oracle";
-    const uppercaseUnquotedIdentifier = oracleIdentifier || config?.db_type === "saphana";
+    // Use the effective database type (e.g. a JDBC connection whose URL is
+    // `jdbc:oracle:...` resolves to "oracle") rather than the raw db_type.
+    // Otherwise a JDBC-Oracle connection with no schema selected falls
+    // through neither the Oracle current-schema completion path nor the
+    // schema-required early return below finds a schema, and every star
+    // expansion silently returns no columns.
+    const effectiveDbType = effectiveDatabaseTypeForConnection(config);
+    const oracleIdentifier = effectiveDbType === "oracle" || effectiveDbType === "oceanbase-oracle";
+    const uppercaseUnquotedIdentifier = oracleIdentifier || effectiveDbType === "saphana";
     const completionTable = uppercaseUnquotedIdentifier && context?.tableQuoted === false ? table.toUpperCase() : table;
-    const rawCompletionSchema = schema?.trim() || (config?.db_type === "dameng" ? config.username?.trim() || undefined : undefined);
+    const rawCompletionSchema = schema?.trim() || (effectiveDbType === "dameng" ? config?.username?.trim() || undefined : undefined);
     const completionSchema = uppercaseUnquotedIdentifier && rawCompletionSchema && context?.schemaQuoted === false ? rawCompletionSchema.toUpperCase() : rawCompletionSchema;
-    const usesCurrentSchema = usesOracleCurrentSchemaCompletion(config?.db_type, completionSchema);
+    const usesCurrentSchema = usesOracleCurrentSchemaCompletion(effectiveDbType, completionSchema);
     if (isSchemaAwareDatabase(connectionId) && !connectionUsesDatabaseObjectTreeMode(config) && !completionSchema && !usesCurrentSchema) {
       return [];
     }


### PR DESCRIPTION
## 问题

Fixes #8005

通过 JDBC 方式连接 Oracle（而非内置的原生 Oracle 驱动）时，在 SQL 编辑器中对 `*` 执行"展开为字段"（右键菜单或快捷键）会报错"无法读取该表的字段信息"，且不区分 `select *` 还是 `select t.*` 这种带别名限定符的写法。使用内置原生 Oracle 驱动连接同一个库则完全正常。

## 根因

`apps/desktop/src/stores/connectionStore.ts` 的 `listCompletionColumns()` 在判断"是否走 Oracle CURRENT_SCHEMA 补全逻辑"时，用的是连接的**原始** `config?.db_type`。JDBC 类型连接的 `db_type` 恒为字面量 `"jdbc"`，即使 JDBC URL 实际指向的是 Oracle，也无法被 `usesOracleCurrentSchemaCompletion()` 识别为 Oracle。

仓库里其他多处地方（如 `tableStructureDatabaseTypeForConnection`、`sqlSnippetDatabaseTypeForConnection`，以及 `QueryEditor.vue` 传给自身的 `props.databaseType`）已经统一改用 `effectiveDatabaseTypeForConnection()`（能够从 JDBC URL 正确推断出真实方言）来处理这类场景，唯独 `listCompletionColumns()` 里这几处判断还在用原始 `db_type`。

结果是：当用户没有在界面上显式选择 Schema 时，JDBC-Oracle 连接会同时落入"非当前 schema 模式"和"schema 必填"两个分支，`listCompletionColumns()` 直接 `return []`，请求根本没有发到后端。

## 修复

将 `oracleIdentifier`、Dameng 登录 schema 兜底、`usesOracleCurrentSchemaCompletion()` 调用统一改为使用 `effectiveDatabaseTypeForConnection(config)`，使 JDBC-Oracle 连接与原生 Oracle 连接走同一套逻辑。改动范围很小（4 行判断），不影响其他数据库类型的行为。

## 验证

- 新增单测 `connectionStore.completion.spec.ts`：对照已有的原生 Oracle 用例编写 JDBC-Oracle 版本；revert 修复后该用例真实失败（`getColumns` 从未被调用），恢复后通过
- `pnpm exec vitest run apps/desktop/src/stores/__tests__/`：70 files / 709 tests 全绿
- `pnpm check`（connection-types + format + lint + typecheck + 全量 test）全绿
- 真实环境复现（共享 Oracle 11g XE 实例，与 issue 描述环境一致）：
  - 修复前：JDBC 连接下 `select *`/`select t.*` 均报错，原生驱动连接正常
  - 修复后：JDBC 连接下两种写法均能正确展开为完整字段列表，原生驱动连接行为无变化（无回归）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Neyiw2q2cjRGYZQb9H58y5