### PR TITLE
✨feat(editor): 支持按数据库分组编辑器标签页

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -5467,6 +5467,7 @@ onUnmounted(() => {
                       <SelectContent>
                         <SelectItem value="none">{{ t("settings.tabGroupNone") }}</SelectItem>
                         <SelectItem value="database-type">{{ t("settings.tabGroupDatabaseType") }}</SelectItem>
+                        <SelectItem value="database">{{ t("settings.tabGroupDatabase") }}</SelectItem>
                         <SelectItem value="connection">{{ t("settings.tabGroupConnection") }}</SelectItem>
                       </SelectContent>
                     </Select>

--- a/apps/desktop/src/components/layout/EditorGroupTabBar.vue
+++ b/apps/desktop/src/components/layout/EditorGroupTabBar.vue
@@ -282,7 +282,7 @@ function tabConnectionLabel(tab: QueryTab) {
 function tabConnectionTargetLabel(tab: QueryTab) {
   const connection = connectionStore.getConfig(tab.connectionId);
   const host = connection?.host.trim();
-  return host ? `${host}:${connection.port}` : tab.connectionId;
+  return connection && host ? `${host}:${connection.port}` : tab.connectionId;
 }
 
 function databaseTabGroupBaseLabel(tab: QueryTab) {
@@ -424,7 +424,6 @@ function groupColorStyle(color: string): CSSProperties {
   return {
     "--tab-group-color": color,
     "--tab-group-soft": hexToRgba(color, 0.12),
-    "--tab-group-rail": hexToRgba(color, 0.3),
   } as CSSProperties;
 }
 

--- a/apps/desktop/src/components/layout/EditorGroupTabBar.vue
+++ b/apps/desktop/src/components/layout/EditorGroupTabBar.vue
@@ -214,6 +214,7 @@ watch(
 const tabGroupItems = computed(() => [
   { value: "none", label: t("settings.tabGroupNone") },
   { value: "database-type", label: t("settings.tabGroupDatabaseType") },
+  { value: "database", label: t("settings.tabGroupDatabase") },
   { value: "connection", label: t("settings.tabGroupConnection") },
 ]);
 const tabSortItems = computed(() => [
@@ -239,7 +240,7 @@ async function persistTabPreferences(partial: TabPreferencePatch) {
 }
 
 function updateTabGroupMode(value: string) {
-  if (value === "none" || value === "database-type" || value === "connection") void persistTabPreferences({ tabGroupMode: value });
+  if (value === "none" || value === "database-type" || value === "database" || value === "connection") void persistTabPreferences({ tabGroupMode: value });
 }
 
 function updateTabSortMode(value: string) {
@@ -250,15 +251,58 @@ function updateTabPlacement(value: string) {
   if (value === "top" || value === "bottom" || value === "left" || value === "right") void persistTabPreferences({ tabPlacement: value });
 }
 
+function databaseTabGroupKey(tab: QueryTab) {
+  const database = tab.database || "";
+  // A connection-level tab has no database scope, so its catalog cannot split the group.
+  return JSON.stringify([tab.connectionId, database ? tab.catalog || "" : "", database]);
+}
+
 function tabGroupKey(tab: QueryTab) {
   const connection = connectionStore.getConfig(tab.connectionId);
   if (settingsStore.editorSettings.tabGroupMode === "connection") return tab.connectionId;
+  if (settingsStore.editorSettings.tabGroupMode === "database") return databaseTabGroupKey(tab);
   return connection?.driver_profile || connection?.db_type || tab.connectionId || "unknown";
+}
+
+function compareTabGroupKeys(left: string, right: string) {
+  if (left === right) return 0;
+  const localized = left.localeCompare(right, undefined, { sensitivity: "base", numeric: true });
+  // Collation may consider case-distinct identities equal; the raw tie-break keeps clusters contiguous.
+  return localized || (left < right ? -1 : 1);
 }
 
 function tabTitleText(tab: QueryTab) {
   return tabDisplayTitle(tab, t);
 }
+
+function tabConnectionLabel(tab: QueryTab) {
+  return connectionStore.getConfig(tab.connectionId)?.name || tab.connectionId;
+}
+
+function tabConnectionTargetLabel(tab: QueryTab) {
+  const connection = connectionStore.getConfig(tab.connectionId);
+  const host = connection?.host.trim();
+  return host ? `${host}:${connection.port}` : tab.connectionId;
+}
+
+function databaseTabGroupBaseLabel(tab: QueryTab) {
+  if (!tab.database) return tabConnectionLabel(tab);
+  return [tab.database, ...(tab.catalog ? [tab.catalog] : [])].join(" · ");
+}
+
+const databaseTabGroupIdentityDisplaysByLabel = computed(() => {
+  const identitiesByLabel = new Map<string, Map<string, { connectionLabel: string; connectionTargetLabel: string }>>();
+  for (const tab of props.tabs) {
+    const label = databaseTabGroupBaseLabel(tab);
+    const identities = identitiesByLabel.get(label) ?? new Map<string, { connectionLabel: string; connectionTargetLabel: string }>();
+    identities.set(databaseTabGroupKey(tab), {
+      connectionLabel: tabConnectionLabel(tab),
+      connectionTargetLabel: tabConnectionTargetLabel(tab),
+    });
+    identitiesByLabel.set(label, identities);
+  }
+  return identitiesByLabel;
+});
 
 /**
  * Sorts a section of this pane's tabs for display. With a group mode active,
@@ -272,7 +316,7 @@ function sortDisplayedTabs(tabs: QueryTab[]) {
     .map((tab, index) => ({ tab, index }))
     .sort((left, right) => {
       if (groupMode !== "none") {
-        const group = tabGroupKey(left.tab).localeCompare(tabGroupKey(right.tab), undefined, { sensitivity: "base", numeric: true });
+        const group = compareTabGroupKeys(tabGroupKey(left.tab), tabGroupKey(right.tab));
         if (group) return group;
       }
       if (sortMode === "manual") return left.index - right.index;
@@ -303,6 +347,17 @@ const editingTabGroupFallbackColor = ref(tabGroupPalette[0]!);
 function tabGroupDefaultLabel(tab: QueryTab) {
   const connection = connectionStore.getConfig(tab.connectionId);
   if (settingsStore.editorSettings.tabGroupMode === "connection") return connection?.name || tab.connectionId;
+  if (settingsStore.editorSettings.tabGroupMode === "database") {
+    const baseLabel = databaseTabGroupBaseLabel(tab);
+    const identityDisplays = databaseTabGroupIdentityDisplaysByLabel.value.get(baseLabel);
+    if ((identityDisplays?.size ?? 0) <= 1) return baseLabel;
+    const connectionLabel = tabConnectionLabel(tab);
+    const sameNameDisplays = [...identityDisplays!.values()].filter((display) => display.connectionLabel === connectionLabel);
+    if (sameNameDisplays.length <= 1) return `${baseLabel} · ${connectionLabel}`;
+    const connectionTargetLabel = tabConnectionTargetLabel(tab);
+    if (sameNameDisplays.filter((display) => display.connectionTargetLabel === connectionTargetLabel).length <= 1) return `${baseLabel} · ${connectionLabel} · ${connectionTargetLabel}`;
+    return `${baseLabel} · ${connectionLabel} · ${connectionTargetLabel} · ${tab.connectionId}`;
+  }
   return connection?.driver_label || connection?.driver_profile || connection?.db_type || tab.connectionId;
 }
 
@@ -320,7 +375,7 @@ function tabGroupLabel(tab: QueryTab) {
 
 // Pinned and regular tabs form separate clusters even under the same key.
 function tabGroupId(tab: QueryTab) {
-  return `${tab.pinned ? "fixed" : "regular"}:${tabGroupKey(tab)}`;
+  return `${tab.pinned ? "fixed" : "regular"}:${settingsStore.editorSettings.tabGroupMode}:${tabGroupKey(tab)}`;
 }
 
 function isTabGroupCollapsed(tab: QueryTab) {

--- a/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
@@ -300,6 +300,32 @@ describe("EditorGroupTabBar group behavior", () => {
     host.remove();
   });
 
+  it("groups by database identity, disambiguating same-name databases across connections", async () => {
+    const store = useQueryStore();
+    const settings = useSettingsStore();
+    settings.editorSettings.tabGroupMode = "database";
+    const pgApp = store.createTab("pg-1", "app", "PG app", "query");
+    store.createTab("mysql-1", "app", "MY app", "query");
+    const pgConn = store.createTab("pg-1", "", "PG conn", "query");
+    const mainGroup = store.groups[0];
+    const { app, host } = mountBar(mainGroup.id, store.tabs.slice(), pgApp, pinia);
+    await settle();
+
+    const headers = Array.from(host.querySelectorAll<HTMLButtonElement>(".tab-group-header"));
+    // Sorted by group key: the same-name "app" databases stay separate clusters
+    // disambiguated by connection label, and the database-less tab clusters by connection.
+    expect(headers.map((header) => header.title)).toEqual(["app · mysql-1", "pg-1", "app · pg-1"]);
+    expect(host.querySelectorAll("[data-tab-id]").length).toBe(3);
+
+    // Collapsing one "app" cluster leaves the other same-name cluster expanded.
+    headers[0]!.click();
+    await settle();
+    expect(Array.from(host.querySelectorAll("[data-tab-id]")).map((pill) => pill.getAttribute("data-tab-id"))).toEqual([pgConn, pgApp]);
+
+    app.unmount();
+    host.remove();
+  });
+
   it("exposes the drag-back hit-test anchor and highlights itself as the detached drop target", async () => {
     const store = useQueryStore();
     const tabId = store.createTab("pg-1", "app", "PG 1", "query");

--- a/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
@@ -29,7 +29,7 @@ const sharedStyles = readFileSync(resolve(specDir, "../appTabBar.css"), "utf8");
 describe("EditorGroupTabBar semantic tab groups", () => {
   it("keeps separate collapsed state for pinned and regular clusters under the same key", () => {
     expect(source).toContain("const collapsedTabGroups = ref<Set<string>>(new Set());");
-    expect(source).toContain('return `${tab.pinned ? "fixed" : "regular"}:${tabGroupKey(tab)}`;');
+    expect(source).toContain('return `${tab.pinned ? "fixed" : "regular"}:${settingsStore.editorSettings.tabGroupMode}:${tabGroupKey(tab)}`;');
     expect(source).toContain("function toggleTabGroup(tab: QueryTab)");
     expect(source).toContain(':aria-expanded="!isTabGroupCollapsed(entry.tab)"');
   });
@@ -165,7 +165,7 @@ describe("EditorGroupTabBar vertical placement", () => {
     expect(sharedStyles).toContain('.vertical-tab-layout .app-tab-pill[data-active-tab="true"]');
     expect(sharedStyles).toContain("inset 0 0 0 1px color-mix");
     expect(sharedStyles).toContain(".vertical-tab-layout .tab-group-header:not(.tab-group-header--collapsed)::after");
-    expect(sharedStyles).toContain("margin-inline: 2.5rem 0.5rem;");
+    expect(sharedStyles).toContain("margin-inline: var(--tab-group-tab-inset) 0.5rem;");
   });
 });
 

--- a/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
@@ -300,32 +300,6 @@ describe("EditorGroupTabBar group behavior", () => {
     host.remove();
   });
 
-  it("groups by database identity, disambiguating same-name databases across connections", async () => {
-    const store = useQueryStore();
-    const settings = useSettingsStore();
-    settings.editorSettings.tabGroupMode = "database";
-    const pgApp = store.createTab("pg-1", "app", "PG app", "query");
-    store.createTab("mysql-1", "app", "MY app", "query");
-    const pgConn = store.createTab("pg-1", "", "PG conn", "query");
-    const mainGroup = store.groups[0];
-    const { app, host } = mountBar(mainGroup.id, store.tabs.slice(), pgApp, pinia);
-    await settle();
-
-    const headers = Array.from(host.querySelectorAll<HTMLButtonElement>(".tab-group-header"));
-    // Sorted by group key: the same-name "app" databases stay separate clusters
-    // disambiguated by connection label, and the database-less tab clusters by connection.
-    expect(headers.map((header) => header.title)).toEqual(["app · mysql-1", "pg-1", "app · pg-1"]);
-    expect(host.querySelectorAll("[data-tab-id]").length).toBe(3);
-
-    // Collapsing one "app" cluster leaves the other same-name cluster expanded.
-    headers[0]!.click();
-    await settle();
-    expect(Array.from(host.querySelectorAll("[data-tab-id]")).map((pill) => pill.getAttribute("data-tab-id"))).toEqual([pgConn, pgApp]);
-
-    app.unmount();
-    host.remove();
-  });
-
   it("exposes the drag-back hit-test anchor and highlights itself as the detached drop target", async () => {
     const store = useQueryStore();
     const tabId = store.createTab("pg-1", "app", "PG 1", "query");

--- a/apps/desktop/src/components/layout/appTabBar.css
+++ b/apps/desktop/src/components/layout/appTabBar.css
@@ -351,6 +351,12 @@
 
 .vertical-tab-layout {
   flex: 0 0 15rem;
+  --tab-group-header-inset: 0.5rem;
+  --tab-group-root-rail-x: 1.16rem;
+  --tab-group-tab-inset: 2.5rem;
+  --tab-group-branch-width: 0.65rem;
+  --tab-group-row-half: 1rem;
+  --tab-group-header-gap: 0.08rem;
 }
 
 .vertical-tab-layout .app-tab-strip {
@@ -440,12 +446,17 @@
   width: calc(100% - 1rem) !important;
   height: 2rem;
   align-self: center;
-  margin: 0.35rem 0.5rem 0.08rem;
+  margin: 0.35rem var(--tab-group-header-inset) var(--tab-group-header-gap);
   padding: 0;
   color: var(--foreground);
   font-size: 0.75rem;
   font-weight: 650;
   line-height: 1rem;
+}
+
+.vertical-tab-layout .tab-group-header,
+.vertical-tab-layout .tab-group-tab {
+  --tab-group-vertical-rail: color-mix(in srgb, var(--tab-group-color) 30%, var(--background));
 }
 
 .vertical-tab-layout .tab-group-header-content {
@@ -474,12 +485,12 @@
   content: "";
   position: absolute;
   z-index: 1;
-  top: 1rem;
-  bottom: -1.08rem;
-  left: 0.66rem;
-  width: 0.7rem;
-  border-bottom: 1px solid var(--tab-group-rail);
-  border-left: 1px solid var(--tab-group-rail);
+  top: 50%;
+  bottom: calc(0rem - var(--tab-group-header-gap) - var(--tab-group-row-half));
+  left: calc(var(--tab-group-root-rail-x) - var(--tab-group-header-inset));
+  width: calc(var(--tab-group-tab-inset) - var(--tab-group-root-rail-x));
+  border-bottom: 1px solid var(--tab-group-vertical-rail);
+  border-left: 1px solid var(--tab-group-vertical-rail);
   border-bottom-left-radius: 0.1875rem;
   pointer-events: none;
 }
@@ -492,7 +503,7 @@
 .vertical-tab-layout .tab-group-tab {
   position: relative;
   width: calc(100% - 3rem);
-  margin-inline: 2.5rem 0.5rem;
+  margin-inline: var(--tab-group-tab-inset) 0.5rem;
   padding-inline-start: 0.65rem !important;
   border-color: transparent;
 }
@@ -500,12 +511,12 @@
 .vertical-tab-layout .tab-group-tab::before {
   content: "";
   position: absolute;
-  top: -0.25rem;
-  bottom: -0.25rem;
-  left: -0.65rem;
+  top: 0;
+  bottom: 0;
+  left: calc(0rem - var(--tab-group-branch-width));
   width: 1px;
   border-radius: 9999px;
-  background: var(--tab-group-rail);
+  background: var(--tab-group-vertical-rail);
   pointer-events: none;
 }
 
@@ -522,10 +533,14 @@
   content: "";
   position: absolute;
   top: calc(50% - 0.5px);
-  left: -0.65rem;
-  width: 0.65rem;
+  left: calc(0rem - var(--tab-group-branch-width));
+  width: var(--tab-group-branch-width);
   height: 1px;
   border-radius: 0 9999px 9999px 0;
-  background: var(--tab-group-rail);
+  background: var(--tab-group-vertical-rail);
   pointer-events: none;
+}
+
+.vertical-tab-layout .tab-group-tab--first::after {
+  display: none;
 }

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6512,6 +6512,7 @@ export default {
     tabGroup: "Group by",
     tabGroupNone: "No grouping",
     tabGroupDatabaseType: "Group by database type",
+    tabGroupDatabase: "Group by database",
     tabGroupConnection: "Group by connection",
     tabSort: "Sort by",
     tabSortManual: "Manual order",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -6179,6 +6179,7 @@ export default withEnglishFallback({
     tabGroup: "Agrupar por",
     tabGroupNone: "Sin agrupación",
     tabGroupDatabaseType: "Agrupar por tipo de base de datos",
+    tabGroupDatabase: "Agrupar por base de datos",
     tabGroupConnection: "Agrupar por conexión",
     tabSort: "Ordenar por",
     tabSortManual: "Orden manual",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -6179,6 +6179,7 @@ export default withEnglishFallback({
     tabGroup: "Raggruppa per",
     tabGroupNone: "Nessun raggruppamento",
     tabGroupDatabaseType: "Raggruppa per tipo di database",
+    tabGroupDatabase: "Raggruppa per database",
     tabGroupConnection: "Raggruppa per connessione",
     tabSort: "Ordina per",
     tabSortManual: "Ordine manuale",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -6217,6 +6217,7 @@ export default withEnglishFallback({
     tabGroup: "グループ化",
     tabGroupNone: "グループ化しない",
     tabGroupDatabaseType: "データベース種別でグループ化",
+    tabGroupDatabase: "データベースごとにグループ化",
     tabGroupConnection: "接続ごとにグループ化",
     tabSort: "並べ替え",
     tabSortManual: "手動順",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5905,6 +5905,7 @@ export default withEnglishFallback({
     tabGroup: "그룹 기준",
     tabGroupNone: "그룹화 안 함",
     tabGroupDatabaseType: "데이터베이스 유형별 그룹화",
+    tabGroupDatabase: "데이터베이스별 그룹화",
     tabGroupConnection: "연결별 그룹화",
     tabSort: "정렬 기준",
     tabSortManual: "수동 순서",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -6181,6 +6181,7 @@ export default withEnglishFallback({
     tabGroup: "Agrupar por",
     tabGroupNone: "Sem agrupamento",
     tabGroupDatabaseType: "Agrupar por tipo de banco de dados",
+    tabGroupDatabase: "Agrupar por banco de dados",
     tabGroupConnection: "Agrupar por conexão",
     tabSort: "Ordenar por",
     tabSortManual: "Ordem manual",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -6502,6 +6502,7 @@ export default withEnglishFallback({
     tabGroup: "Gruplama ölçütü",
     tabGroupNone: "Gruplama yok",
     tabGroupDatabaseType: "Veritabanı türüne göre grupla",
+    tabGroupDatabase: "Veritabanına göre grupla",
     tabGroupConnection: "Bağlantıya göre grupla",
     tabSort: "Sıralama ölçütü",
     tabSortManual: "Elle sıralama",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6495,6 +6495,7 @@ export default withEnglishFallback({
     tabGroup: "分组方式",
     tabGroupNone: "不分组",
     tabGroupDatabaseType: "按数据库类型分组",
+    tabGroupDatabase: "按数据库分组",
     tabGroupConnection: "按连接分组",
     tabSort: "排序方式",
     tabSortManual: "手动排序",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5498,6 +5498,7 @@ export default withEnglishFallback({
     tabGroup: "分組方式",
     tabGroupNone: "不分組",
     tabGroupDatabaseType: "依資料庫類型分組",
+    tabGroupDatabase: "依資料庫分組",
     tabGroupConnection: "依連線分組",
     tabSort: "排序方式",
     tabSortManual: "手動排序",

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -574,7 +574,7 @@ const TAB_LAYOUT_MODES = ["scroll", "wrap"] as const;
 export type TabLayoutMode = (typeof TAB_LAYOUT_MODES)[number];
 const TAB_PLACEMENTS = ["top", "bottom", "left", "right"] as const;
 export type TabPlacement = (typeof TAB_PLACEMENTS)[number];
-const TAB_GROUP_MODES = ["none", "database-type", "connection"] as const;
+const TAB_GROUP_MODES = ["none", "database-type", "database", "connection"] as const;
 export type TabGroupMode = (typeof TAB_GROUP_MODES)[number];
 export interface TabGroupCustomization {
   name?: string;


### PR DESCRIPTION
## 变更说明

新增编辑器标签页“按数据库分组”模式，并优化纵向标签栏分组连接线。

- 分组 identity 按连接、Catalog 和数据库区分；无数据库上下文的标签按连接归组。
- 默认优先展示数据库名，仅在同名组需要区分时追加连接名称、目标地址或连接 ID。
- 分组设置支持持久化；折叠状态按固定/普通分区、分组模式和 identity 隔离。
- 增加 9 种语言的“按数据库分组”文案。
- 修复纵向侧边栏首个连接拐角错层及线段透明叠色。

## 变更类型

- [x] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

原来：

<img width="248" height="450" alt="iShot 2026-09-04 23 39 15" src="https://github.com/user-attachments/assets/110f2213-1b1c-40fc-b5e3-b7952ab28b60" />


现在支持库分组，优化打磨连接线细节

<img width="244" height="589" alt="image" src="https://github.com/user-attachments/assets/60e099d0-df35-44a0-ab91-ad5114e4a437" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

已执行：`git diff --check` 通过。  
未运行测试、构建、lint、类型检查或浏览器视觉验证，遵循本次“不做测试”约束。

## 关联 Issue

