### PR TITLE
fix(postgres): 修复 PostgreSQL 9 下序列查询导致比较架构 500 报错

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -8054,7 +8054,13 @@ pub async fn list_sequences(pool: &Pool, schema: &str, with_last_values: bool) -
     let (rows, is_legacy) = match postgres_query_cached(&client, postgres_sequences_sql(), &[&schema]).await {
         Ok(rows) => (rows, false),
         Err(primary_error) => match postgres_query_cached(&client, postgres_sequences_compat_sql(), &[&schema]).await {
-            Ok(rows) => (rows, true),
+            Ok(rows) => {
+                log::debug!(
+                    "[postgres][sequences:compat-used] pg_sequence catalog unavailable ({}); serving sequence metadata from information_schema.sequences",
+                    pg_error_to_string(primary_error)
+                );
+                (rows, true)
+            }
             Err(_) => return Err(primary_error.to_string()),
         },
     };
@@ -11416,6 +11422,7 @@ mod tests {
 
         let demo_seq = sequences.iter().find(|s| s.name == "demo_seq").expect("demo_seq present");
         assert_eq!(demo_seq.last_value.as_deref(), Some("5"));
+        assert_eq!(demo_seq.start_value.as_deref(), Some("5"));
         assert_eq!(demo_seq.increment, "1");
         assert!(!demo_seq.cycle);
     }

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -11422,7 +11422,7 @@ mod tests {
 
         let demo_seq = sequences.iter().find(|s| s.name == "demo_seq").expect("demo_seq present");
         assert_eq!(demo_seq.last_value.as_deref(), Some("5"));
-        assert_eq!(demo_seq.start_value.as_deref(), Some("5"));
+        assert_eq!(demo_seq.start_value, "5");
         assert_eq!(demo_seq.increment, "1");
         assert!(!demo_seq.cycle);
     }

--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -7966,6 +7966,39 @@ fn postgres_sequence_last_values_sql() -> &'static str {
      WHERE c.relkind = 'S' AND n.nspname = $1"
 }
 
+// PostgreSQL 9.x sibling of `postgres_sequences_sql`: the `pg_sequence` catalog
+// (and the `pg_sequence_last_value` function used below) were only added in
+// PostgreSQL 10. Older servers still expose the same properties through the
+// portable `information_schema.sequences` view, which is what openGauss's
+// tier already relies on for the same reason.
+fn postgres_sequences_compat_sql() -> &'static str {
+    "SELECT s.sequence_name, \
+      COALESCE(s.data_type::text, 'bigint'), \
+      COALESCE(s.start_value::text, '1'), \
+      COALESCE(s.minimum_value::text, '1'), \
+      COALESCE(s.maximum_value::text, '9223372036854775807'), \
+      COALESCE(s.increment::text, '1'), \
+      COALESCE(s.cycle_option::text, 'NO') \
+     FROM information_schema.sequences s \
+     WHERE s.sequence_schema = $1 \
+     ORDER BY s.sequence_name"
+}
+
+// Pre-PG10 servers have no `pg_sequence_last_value(oid)` function to read an
+// arbitrary sequence's current value from a single batched query, so the
+// compat tier falls back to querying each sequence relation directly (the
+// pre-10 way of reading `last_value`), one round trip per sequence.
+async fn postgres_sequence_last_value_compat(
+    client: &deadpool_postgres::Client,
+    schema: &str,
+    sequence_name: &str,
+) -> Result<Option<String>, tokio_postgres::Error> {
+    let qualified = format!("{}.{}", pg_quote_ident(schema), pg_quote_ident(sequence_name));
+    let sql = format!("SELECT last_value::text FROM {qualified}");
+    let rows = postgres_query_cached(client, &sql, &[]).await?;
+    Ok(rows.first().and_then(|row| row.try_get::<_, Option<String>>(0).ok().flatten()))
+}
+
 fn opengauss_sequence_last_values_sql() -> &'static str {
     "SELECT c.relname, (pg_sequence_last_value(c.oid)).last_value::text \
      FROM pg_class c \
@@ -8014,15 +8047,52 @@ async fn list_sequences_with_sql(
 }
 
 pub async fn list_sequences(pool: &Pool, schema: &str, with_last_values: bool) -> Result<Vec<SequenceInfo>, String> {
-    // PostgreSQL 10+ stores sequence properties in pg_sequence.
-    list_sequences_with_sql(
-        pool,
-        schema,
-        with_last_values,
-        postgres_sequences_sql(),
-        postgres_sequence_last_values_sql(),
-    )
-    .await
+    let client = checkout_postgres_client(pool, None, super::connection_timeout()).await?;
+
+    // PostgreSQL 10+ stores sequence properties in pg_sequence; older servers
+    // fall back to the portable information_schema.sequences view.
+    let (rows, is_legacy) = match postgres_query_cached(&client, postgres_sequences_sql(), &[&schema]).await {
+        Ok(rows) => (rows, false),
+        Err(primary_error) => match postgres_query_cached(&client, postgres_sequences_compat_sql(), &[&schema]).await {
+            Ok(rows) => (rows, true),
+            Err(_) => return Err(primary_error.to_string()),
+        },
+    };
+
+    let mut sequences: Vec<SequenceInfo> = rows
+        .iter()
+        .map(|row| SequenceInfo {
+            name: pg_row_try_string(row, 0),
+            data_type: pg_row_try_string(row, 1),
+            start_value: pg_row_try_string(row, 2),
+            min_value: pg_row_try_string(row, 3),
+            max_value: pg_row_try_string(row, 4),
+            increment: pg_row_try_string(row, 5),
+            cycle: pg_row_try_string(row, 6) == "YES",
+            last_value: None,
+        })
+        .collect();
+
+    if with_last_values {
+        if is_legacy {
+            for seq in sequences.iter_mut() {
+                if let Ok(Some(value)) = postgres_sequence_last_value_compat(&client, schema, &seq.name).await {
+                    seq.last_value = Some(value);
+                }
+            }
+        } else if let Ok(rows) = postgres_query_cached(&client, postgres_sequence_last_values_sql(), &[&schema]).await {
+            for row in rows {
+                let name: String = pg_row_try_string(&row, 0);
+                if let Ok(Some(value)) = row.try_get::<_, Option<String>>(1) {
+                    if let Some(seq) = sequences.iter_mut().find(|s| s.name == name) {
+                        seq.last_value = Some(value);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(sequences)
 }
 
 pub async fn list_opengauss_sequences(
@@ -9496,6 +9566,16 @@ mod tests {
     }
 
     async fn start_docker_postgres() -> Option<DockerPostgres> {
+        start_docker_postgres_image("postgres:16-alpine", &[]).await
+    }
+
+    // PostgreSQL 9.3 (pre-pg_sequence/pg_sequence_last_value) only ships an
+    // amd64 image, so Apple Silicon hosts need explicit emulation.
+    async fn start_docker_postgres_9_3() -> Option<DockerPostgres> {
+        start_docker_postgres_image("postgres:9.3", &["--platform", "linux/amd64"]).await
+    }
+
+    async fn start_docker_postgres_image(image: &str, extra_args: &[&str]) -> Option<DockerPostgres> {
         if !docker_ready() {
             eprintln!("skipping docker-backed postgres test because Docker is unavailable");
             return None;
@@ -9505,12 +9585,9 @@ mod tests {
         let container = DockerPostgres { name: format!("dbx-postgres-enum-{}", uuid::Uuid::new_v4()), port };
 
         let status = Command::new("docker")
+            .args(["run", "-d", "--rm", "--name", &container.name])
+            .args(extra_args)
             .args([
-                "run",
-                "-d",
-                "--rm",
-                "--name",
-                &container.name,
                 "-e",
                 "POSTGRES_PASSWORD=postgres",
                 "-e",
@@ -9519,7 +9596,7 @@ mod tests {
                 "POSTGRES_DB=postgres",
                 "-p",
                 &format!("{port}:5432"),
-                "postgres:16-alpine",
+                image,
             ])
             .status()
             .expect("start docker postgres");
@@ -11315,6 +11392,32 @@ mod tests {
     #[test]
     fn postgres_sequence_last_values_are_read_as_text() {
         assert!(postgres_sequence_last_values_sql().contains("pg_sequence_last_value(c.oid)::text"));
+    }
+
+    #[test]
+    fn postgres_sequences_compat_sql_avoids_pg10_only_catalog() {
+        let sql = postgres_sequences_compat_sql();
+        assert!(!sql.contains("pg_sequence"));
+        assert!(sql.contains("information_schema.sequences"));
+        assert!(sql.contains("sequence_schema = $1"));
+    }
+
+    #[tokio::test]
+    async fn list_sequences_falls_back_on_postgres_9_without_pg_sequence_catalog() {
+        let Some(container) = start_docker_postgres_9_3().await else {
+            return;
+        };
+
+        let pool = connect(&container.url(), Duration::from_secs(5)).await.expect("connect postgres 9.3");
+        execute_query(&pool, "CREATE SEQUENCE demo_seq START 5").await.expect("create sequence");
+        execute_query(&pool, "SELECT nextval('demo_seq')").await.expect("advance sequence");
+
+        let sequences = list_sequences(&pool, "public", true).await.expect("list_sequences should not 500 on PG9");
+
+        let demo_seq = sequences.iter().find(|s| s.name == "demo_seq").expect("demo_seq present");
+        assert_eq!(demo_seq.last_value.as_deref(), Some("5"));
+        assert_eq!(demo_seq.increment, "1");
+        assert!(!demo_seq.cycle);
     }
 
     #[test]


### PR DESCRIPTION
## 背景与说明（请务必先看这段）

这个 PR 起因于排查 #8173，但**没有精确复现出 #8173 原文截图里的那条报错**（`invalid reference to FROM-clause entry for table "con"`）。我把仓库里所有用到 `con` 别名的外键相关查询都读过一遍，也直接拿真实 PostgreSQL 9.3 和 16 分别执行过，这些查询本身跑起来都没问题，没能复现出那条具体报错——不确定是某种更具体的边界情况，还是某个自称 "PostgreSQL 9.x" 的国产兼容库和真·PostgreSQL 的解析器差异导致的。

排查过程中，我用真实 PostgreSQL 9.3（docker）+ 真实 DBX 界面操作"比较架构"，**确实复现出了另一个真实、必现的 500 报错**，这个 PR 修的是这一个，跟原 issue 描述的现象同属"比较架构在 PostgreSQL 9 下会报错"，但底层是不是同一个根因，我无法 100% 确认，请核实后再决定是否关联/关闭 #8173。

## 根因

`list_sequences()` 用了 `pg_sequence` 目录表和 `pg_sequence_last_value()` 函数，这两个都是 **PostgreSQL 10** 才引入的。任何真实 PostgreSQL < 10（或走了这条代码路径的兼容库）的连接，只要触发序列查询（"比较架构"会并行拉取两侧的 sequences 列表），就必现 500：

```
ERROR:  relation "pg_sequence" does not exist
LINE 5: LEFT JOIN pg_sequence s ON s.seqrelid = c.oid
```

同文件里外键/索引相关查询早就为 pre-9.4 做了 compat tier 降级，唯独 sequences 这条路径没有。

## 修复

- 新增 `postgres_sequences_compat_sql()`：元数据查询降级用 `information_schema.sequences`（与 openGauss 现有方案一致的思路）。
- 新增 `postgres_sequence_last_value_compat()`：pre-PG10 没有能批量读 last_value 的函数，退化为逐个序列单独查询（标识符经 `pg_quote_ident` 转义）。
- `list_sequences()` 先试主路径（PG10+），失败自动降级到上面两个 compat 查询。

## 验证

- 新增真实集成测试 `list_sequences_falls_back_on_postgres_9_without_pg_sequence_catalog`：自动拉起真实 `postgres:9.3` docker 容器跑，不是纯字符串断言。
- `cargo test -p dbx-core --lib db::postgres::`：225 passed, 0 failed
- `cargo fmt --check` / `cargo clippy -D warnings`：干净
- 真实浏览器操作验证：PostgreSQL 9.3 + DBX 桌面端 web dev 模式，"比较架构"从 500 报错恢复正常，序列元数据（含 `last_value`）正确显示在对比结果里