### PR TITLE
fix(grid): 修复 Mongo JSON 预览面板因网格列宽计算遗漏而不可见

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -11230,9 +11230,11 @@ const mongoJsonPreviewStyle = computed(() => ({
 
 const contentGridStyle = computed(() => {
   const hasRightCellDetail = !cellDetailPanelIsBottom.value && showCellDetail.value && activeCellDetail.value;
-  const tableInfoAvailableWidth = hasRightCellDetail ? `max(0px, calc(100% - ${detailPanelHeight.value}px))` : "100%";
+  const rightPanelWidth = hasRightCellDetail ? detailPanelHeight.value : mongoJsonPreviewOpen.value ? mongoJsonPreviewWidth.value : 0;
+  const hasRightPanel = hasRightCellDetail || mongoJsonPreviewOpen.value;
+  const tableInfoAvailableWidth = hasRightPanel ? `max(0px, calc(100% - ${rightPanelWidth}px))` : "100%";
   const tableInfoTrack = showTableInfo.value ? `minmax(0, min(${ddlWidth.value}px, ${tableInfoAvailableWidth}))` : "0px";
-  const detailTrack = hasRightCellDetail ? `minmax(0, min(${detailPanelHeight.value}px, 100%))` : "0px";
+  const detailTrack = hasRightPanel ? `minmax(0, min(${rightPanelWidth}px, 100%))` : "0px";
 
   if (cellDetailPanelIsBottom.value && showCellDetail.value && activeCellDetail.value) {
     return {


### PR DESCRIPTION
## 根因

`DataGrid.vue` 的 `contentGridStyle` 在计算共享网格第 3 列（Mongo JSON 预览面板与普通单元格详情面板共用该列、二者互斥使用）宽度时，只判断了 `hasRightCellDetail`（普通详情面板的开关状态），漏掉了 `mongoJsonPreviewOpen`（JSON 预览面板的开关状态）。

这是 v0.6.3 → v0.6.4 之间 `2ba123dd9`（"fix(desktop): align data tab table info display and column widths"）引入的回归：该提交把原本 `auto`（由面板自身内联宽度撑开）的列宽改成按需计算的显式宽度，但只覆盖了单元格详情面板这一种情况。于是只打开 JSON 预览时，该列轨道恒为 `0px`——面板元素其实仍带着 `width: 420px` 正常渲染进 DOM，只是被裁剪成不可见；面板自带的拖拽手柄仍定位在（此时已塌缩为 0 宽的）列边界上，这也是用户反馈里"鼠标变成调整宽度的样式但看不到窗口"的原因。

## 修复

`contentGridStyle` 新增 `rightPanelWidth`/`hasRightPanel`（`hasRightCellDetail || mongoJsonPreviewOpen`），`tableInfoTrack`/`detailTrack` 都基于这两个值计算，不再遗漏 JSON 预览面板这种情况。

## 测试

- 真实复现：共享 MongoDB 8.2.3 测试实例，dev-web 隔离环境下打开表格视图点击「JSON 预览」，按钮变为激活态但面板不可见；DOM 检查确认 `grid-template-columns: minmax(0px, 1fr) 0px 0px`，第 3 列轨道为 `0px`，与根因分析一致
- 修复后 JSON 预览面板正常显示并正确渲染所选文档 JSON
- 回归检查：普通单元格详情面板（右侧布局）网格轨道计算未受影响，与 JSON 预览面板互斥不冲突
- `pnpm exec vue-tsc --noEmit` 通过
- `pnpm exec vitest run apps/desktop/src/components/grid/__tests__`：30 files / 239 tests 全绿
- `pnpm check`（connection-types / format / lint / typecheck / test）全部 ok

Fixes #8211