### PR TITLE
fix(layout): 列模式下关闭设置/驱动标签后再打开显示空白

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -911,8 +911,15 @@ useScheduledDatabaseBackups({ scheduler: true });
 const appVersion = ref("");
 const isClassicLayout = computed(() => settingsStore.editorSettings.appLayout === "classic");
 const isVerticalTabPlacement = computed(() => settingsStore.editorSettings.tabPlacement === "left" || settingsStore.editorSettings.tabPlacement === "right");
+// AppTabBar only renders the settings/driver special-page strip, and that strip
+// is still a horizontal-only "w-full" bar (see AppTabBar.vue's app-tab-bar class).
+// Placing it inside a flex-row/flex-row-reverse workspace squeezes the sibling
+// content pane (EditorSettingsPage/DriverStorePage) to zero width, so fall back
+// to stacking it above the content instead of adopting the vertical layout here.
+const isSpecialPageStripActive = computed(() => driverStoreActive.value || settingsStore.settingsPageActive);
 const tabWorkspaceLayoutClass = computed(() => {
   if (settingsStore.editorSettings.tabPlacement === "bottom") return "flex-col-reverse";
+  if (isVerticalTabPlacement.value && isSpecialPageStripActive.value) return "flex-col";
   if (settingsStore.editorSettings.tabPlacement === "right") return "flex-row-reverse";
   return isVerticalTabPlacement.value ? "flex-row" : "flex-col";
 });

--- a/apps/desktop/src/components/layout/__tests__/tabWorkspaceLayout.column-mode-special-pages.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/tabWorkspaceLayout.column-mode-special-pages.spec.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const appSource = readFileSync(new URL("../../../App.vue", import.meta.url), "utf8");
+const tabBarSource = readFileSync(new URL("../AppTabBar.vue", import.meta.url), "utf8");
+
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(endIndex).toBeGreaterThan(startIndex);
+  return source.slice(startIndex, endIndex);
+}
+
+// Regression test for #8213: AppTabBar's settings/driver special-page strip is
+// still a horizontal-only "w-full" bar. Placing it inside a flex-row /
+// flex-row-reverse workspace (left/right column tab placement) squeezes the
+// sibling content pane (EditorSettingsPage/DriverStorePage) to zero width,
+// making the settings/driver page invisible after it's reopened. The fix
+// falls back to a flex-col workspace while either special page is active.
+describe("tabWorkspaceLayoutClass column-mode special-page fallback", () => {
+  const computedBlock = sourceBetween(appSource, "const tabWorkspaceLayoutClass = computed(() => {", "});");
+
+  it("falls back to flex-col while the settings/driver strip is active, before the vertical branch", () => {
+    const specialPageGuardIndex = computedBlock.indexOf("isSpecialPageStripActive.value");
+    const verticalRowIndex = computedBlock.indexOf('isVerticalTabPlacement.value ? "flex-row" : "flex-col"');
+    expect(specialPageGuardIndex).toBeGreaterThanOrEqual(0);
+    expect(verticalRowIndex).toBeGreaterThan(specialPageGuardIndex);
+    expect(computedBlock).toMatch(/isVerticalTabPlacement\.value\s*&&\s*isSpecialPageStripActive\.value\)\s*return\s*"flex-col"/);
+  });
+
+  it("derives isSpecialPageStripActive from the same flags AppTabBar uses to render", () => {
+    expect(appSource).toContain("const isSpecialPageStripActive = computed(() => driverStoreActive.value || settingsStore.settingsPageActive);");
+    // AppTabBar itself only renders while one of these is true - keep the guard in sync with it.
+    expect(tabBarSource).toContain('v-if="driverStoreActive || settingsPageActive"');
+  });
+
+  it("still stretches the special-page strip full width (the part the flex-col fallback protects against)", () => {
+    expect(tabBarSource).toMatch(/class="app-tab-bar[^"]*\bw-full\b/);
+  });
+});


### PR DESCRIPTION
## 问题

在标签栏"左侧/右侧"列模式下，关闭"设置"或"驱动管理"标签页后，再次点击工具栏的设置/驱动按钮，标签本身能打开，但下方内容区完全空白，无法使用。

Fixes #8213

## 根因

`App.vue` 的 `tabWorkspaceLayoutClass` 在列模式（`tabPlacement` 为 `left`/`right`）下把工作区最外层容器切成 `flex-row`/`flex-row-reverse`。而 `AppTabBar.vue` 里承载"设置/驱动"特殊标签内容的容器写死了 `w-full`——这个类在正常的上下堆叠布局（`flex-col`）下语义正确，但套进 `flex-row` 后会横向抢占几乎全部宽度（实测约 1020px），把同级的真正内容容器（`EditorSettingsPage`/`DriverStorePage`）挤压到 0 宽度并推出视口外（实测 x=1280，完全不可见）。

代码里 `EditorGroupTabBar.vue` 也留有开发者自己的注释，印证列模式下特殊标签的完整适配本就是待办（"vertical strips get them with the #8213 column-mode redesign"）。

## 修复

新增 `isSpecialPageStripActive`（与 `AppTabBar.vue` 自身渲染条件 `driverStoreActive || settingsPageActive` 保持同步），在"列模式 + 设置或驱动处于激活状态"这一组合下让 `tabWorkspaceLayoutClass` 提前回退为 `flex-col`，退回上下堆叠布局。除此之外的所有情况（包括最常见的"列模式下正常编辑查询"）返回值与修复前完全一致，不影响已有的列模式标签布局。

## 验证

- 真实浏览器复现 + 修复验证：左侧、右侧两种列模式下，关闭设置/驱动标签后重新点击对应按钮，界面均从空白恢复为正常显示
- 新增回归测试 `apps/desktop/src/components/layout/__tests__/tabWorkspaceLayout.column-mode-special-pages.spec.ts`，锁定该 fallback 逻辑与 `AppTabBar.vue` 的触发条件同步
- `pnpm check`（connection-types 校验 + oxfmt + oxlint + vue-tsc + 全量 vitest）全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux8737AYKrwmKBweTG31YX