### PR TITLE
fix(editor): 新查询未执行时共享结果面板无法收起

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1342,7 +1342,14 @@ defineExpose({
         </Pane>
         <Pane v-if="(resultsPaneOpen || resultOnly) && !editorOnly" class="min-h-0" :size="resultOnly ? 100 : resultsPaneSize" :min-size="resultOnly ? 100 : 20">
           <div class="h-full flex flex-col">
-            <div v-if="hasQueryOutput" class="flex h-10 shrink-0 items-center gap-1 border-b bg-muted/20 px-2">
+            <!--
+              The shared result surface (resultOnly) is always mounted regardless of
+              whether the active tab has run a query yet, and this toolbar is the only
+              place that renders the "hide results" chevron (see handleHideResultsPane).
+              Gating it on hasQueryOutput alone left users with an always-open, empty
+              shared pane and no way to collapse it (#8233).
+            -->
+            <div v-if="hasQueryOutput || resultOnly" class="flex h-10 shrink-0 items-center gap-1 border-b bg-muted/20 px-2">
               <Button
                 v-if="activeTab.mode === 'query' && activeTab.result"
                 variant="ghost"

--- a/apps/desktop/src/components/layout/__tests__/ContentArea.sharedResultCollapse.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/ContentArea.sharedResultCollapse.spec.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const contentAreaSource = readFileSync(new URL("../ContentArea.vue", import.meta.url), "utf8");
+
+describe("ContentArea shared result pane collapse (#8233)", () => {
+  it("renders the results toolbar (and its hide-results chevron) even with no query output when resultOnly", () => {
+    // The shared result surface (QueryResultSurface -> ContentArea result-only)
+    // is mounted unconditionally by SqlEditorWorkspace regardless of whether the
+    // active tab has run a query. handleHideResultsPane's chevron lives inside
+    // this toolbar and is the only UI to collapse that shared pane, so gating
+    // the toolbar on hasQueryOutput alone left it permanently open with no way
+    // to close it until a query executed.
+    expect(contentAreaSource).not.toMatch(/v-if="hasQueryOutput"\s+class="flex h-10 shrink-0 items-center gap-1 border-b bg-muted\/20 px-2"/);
+    expect(contentAreaSource).toContain(`v-if="hasQueryOutput || resultOnly" class="flex h-10 shrink-0 items-center gap-1 border-b bg-muted/20 px-2"`);
+  });
+
+  it("keeps handleHideResultsPane bubbling a toggle event for the shared (resultOnly) surface", () => {
+    expect(contentAreaSource).toContain('if (props.resultOnly) {\n    emit("toggleResultsPane");');
+  });
+});


### PR DESCRIPTION
## 问题

Fixes #8233

新架构下（`SqlEditorWorkspace` 分栏 + 共享结果面板），查询标签页会无条件挂载一个常驻的"共享结果面板"（`QueryResultSurface` → `ContentArea` 带 `result-only`），与是否已执行查询无关。但 `ContentArea.vue` 里唯一能收起该面板的"收起"按钮（`handleHideResultsPane`）所在的工具栏容器，仍然沿用旧的每标签页独立结果面板年代的判断条件 `v-if="hasQueryOutput"`。

两者不同步导致：新建查询标签页、还没执行任何语句时，结果区强制打开且没有任何按钮/图标可以收起，直到执行一次查询后按钮才会出现。开启"生产环境保护"的连接下现象更明显（如原 issue 截图）。

## 修复

将工具栏容器条件由 `v-if="hasQueryOutput"` 改为 `v-if="hasQueryOutput || resultOnly"`，让共享结果面板（`resultOnly` 模式）下"收起"按钮始终可用；内部各子元素（自动保存、关闭结果、结果集标签页等）本身已有各自独立的判断条件，不受影响。非共享模式（如"数据"类标签页）行为不变。

## 验证

- 新增回归测试 `ContentArea.sharedResultCollapse.spec.ts`：已确认在修复前用 `git apply -R` 还原改动后真实失败，修复后通过
- 相关组件测试（`ContentArea`/`SqlEditorWorkspace`/`QueryResultSurface`）21 项全绿
- `pnpm run typecheck` 通过，改动文件 `oxlint` 干净
- 全量前端 `vitest`：993 files / 9583 tests 全绿
- 真实浏览器复现验证（SQLite `:memory:` 连接 + 开启生产环境保护）：
  - 修复前：新建查询未执行时结果区强制打开且无收起按钮
  - 修复后：收起按钮正常出现，点击后结果区完全收起、编辑器占满，点击"显示结果"可重新展开
  - 回归检查：执行真实查询后收起/展开依旧正常，未破坏原有功能