### PR TITLE
fix(schema-diff): 修复比较架构未能识别 MySQL 整数显示宽度差异

### DIFF
--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -2643,26 +2643,39 @@ pub fn diff_columns(source: &[ColumnInfo], target: &[ColumnInfo]) -> Vec<ColumnD
     diff_columns_with_options(source, target, false, false, false, 0.5)
 }
 
-fn normalize_mysql_integer_type_for_comparison(data_type: &str) -> String {
+/// Signature of a MySQL column type used to decide whether an integer display
+/// width difference is real or just MySQL echoing back its own default width.
+struct MysqlIntegerTypeSignature {
+    /// Whole normalized type string, used to compare non-integer types as-is.
+    normalized: String,
+    /// `"{base} {suffix}"` (e.g. `"int unsigned"`) when `normalized` is a
+    /// recognized integer type, regardless of whether a width is present.
+    integer_key: Option<String>,
+    /// The explicit display width, when present on a recognized integer type.
+    width: Option<u32>,
+}
+
+fn parse_mysql_integer_type(data_type: &str) -> MysqlIntegerTypeSignature {
     let normalized = data_type.split_whitespace().collect::<Vec<_>>().join(" ").to_ascii_lowercase();
+    let is_integer_base =
+        |base: &str| matches!(base, "tinyint" | "smallint" | "mediumint" | "int" | "integer" | "bigint" | "year");
     let Some(open) = normalized.find('(') else {
-        return normalized;
+        let base = normalized.split(' ').next().unwrap_or(&normalized);
+        let integer_key = is_integer_base(base).then(|| normalized.clone());
+        return MysqlIntegerTypeSignature { normalized, integer_key, width: None };
     };
     let Some(close) = normalized[open + 1..].find(')').map(|index| open + 1 + index) else {
-        return normalized;
+        return MysqlIntegerTypeSignature { normalized, integer_key: None, width: None };
     };
     let base = normalized[..open].trim();
-    let width = normalized[open + 1..close].trim();
-    let integer_type = matches!(base, "tinyint" | "smallint" | "mediumint" | "int" | "integer" | "bigint" | "year");
-    if !integer_type || width.is_empty() || !width.bytes().all(|byte| byte.is_ascii_digit()) {
-        return normalized;
+    let width_str = normalized[open + 1..close].trim();
+    if !is_integer_base(base) || width_str.is_empty() || !width_str.bytes().all(|byte| byte.is_ascii_digit()) {
+        return MysqlIntegerTypeSignature { normalized, integer_key: None, width: None };
     }
     let suffix = normalized[close + 1..].trim();
-    if suffix.is_empty() {
-        base.to_string()
-    } else {
-        format!("{base} {suffix}")
-    }
+    let integer_key = Some(if suffix.is_empty() { base.to_string() } else { format!("{base} {suffix}") });
+    let width = width_str.parse().ok();
+    MysqlIntegerTypeSignature { normalized, integer_key, width }
 }
 
 fn column_types_equal_for_dialects(
@@ -2674,10 +2687,25 @@ fn column_types_equal_for_dialects(
     if source_type.eq_ignore_ascii_case(target_type) {
         return true;
     }
-    source_dialect == Some(DialectKind::Mysql)
-        && target_dialect == Some(DialectKind::Mysql)
-        && normalize_mysql_integer_type_for_comparison(source_type)
-            == normalize_mysql_integer_type_for_comparison(target_type)
+    if source_dialect != Some(DialectKind::Mysql) || target_dialect != Some(DialectKind::Mysql) {
+        return false;
+    }
+    let source = parse_mysql_integer_type(source_type);
+    let target = parse_mysql_integer_type(target_type);
+    match (source.integer_key, target.integer_key) {
+        // Same integer family (e.g. both "int unsigned"): a display width present on only one
+        // side is MySQL filling in its own default and not a real difference, but two explicit,
+        // differing widths (e.g. int(11) vs int(15)) are a genuine schema difference.
+        (Some(source_key), Some(target_key)) => {
+            source_key == target_key
+                && match (source.width, target.width) {
+                    (Some(a), Some(b)) => a == b,
+                    _ => true,
+                }
+        }
+        (None, None) => source.normalized == target.normalized,
+        _ => false,
+    }
 }
 
 fn column_type_similarity_score(source_type: &str, target_type: &str) -> f64 {
@@ -10066,6 +10094,49 @@ mod tests {
 
         assert_eq!(diffs.iter().map(|diff| diff.name.as_str()).collect::<Vec<_>>(), vec!["amount", "name"]);
         assert!(diffs.iter().all(|diff| diff.changes.iter().any(|change| change.starts_with("type:"))));
+    }
+
+    // Regression for #7615: comparing two MySQL databases where an integer column has
+    // different EXPLICIT display widths on both sides (e.g. `int(11)` vs `int(15)`) must
+    // still be reported as a type difference. `data_type` values below are exactly what
+    // `information_schema.COLUMNS.COLUMN_TYPE` returns on a real MySQL 5.7 server for the
+    // DDL in the issue (MySQL 8.0.19+ drops these widths entirely, so this only reproduces
+    // on pre-8.0.19 servers, which is why the issue's own repro needed a specific version).
+    #[test]
+    fn mysql_same_dialect_detects_explicit_integer_display_width_mismatch() {
+        let source = vec![column("id", "int(11)", Some("ID")), column("name", "varchar(20)", Some("名称"))];
+        let target = vec![column("id", "int(15)", Some("ID")), column("name", "varchar(20)", Some("名称"))];
+
+        let diffs = diff_columns_with_dialect_options(
+            &source,
+            &target,
+            false,
+            false,
+            false,
+            0.5,
+            Some(DialectKind::Mysql),
+            Some(DialectKind::Mysql),
+        );
+
+        assert_eq!(diffs.iter().map(|diff| diff.name.as_str()).collect::<Vec<_>>(), vec!["id"]);
+        assert!(diffs[0].changes.iter().any(|change| change.starts_with("type:")), "{:?}", diffs[0].changes);
+
+        // Same scenario the maintainer's own regression test already covers must keep passing:
+        // tinyint(1) (a common MySQL boolean idiom) vs tinyint(4) (the server's own default
+        // display width for tinyint) is likewise a real, explicit difference, not noise.
+        let source = vec![column("flag", "tinyint(1)", None)];
+        let target = vec![column("flag", "tinyint(4)", None)];
+        let diffs = diff_columns_with_dialect_options(
+            &source,
+            &target,
+            false,
+            false,
+            false,
+            0.5,
+            Some(DialectKind::Mysql),
+            Some(DialectKind::Mysql),
+        );
+        assert_eq!(diffs.iter().map(|diff| diff.name.as_str()).collect::<Vec<_>>(), vec!["flag"]);
     }
 
     #[test]


### PR DESCRIPTION
## 问题

比较两个 MySQL 数据库时，如果某个整数列在两边有**不同的显式**显示宽度（如 `int(11)` vs `int(15)`），比较架构功能完全识别不出这个差异，导致该列（甚至整张表）不会出现在待同步列表里，也生成不了部署脚本。

复现：

```sql
-- 数据库1
CREATE TABLE `test` (
  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'ID',
  `name` varchar(20) DEFAULT '' COMMENT '名称',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='测试表';

-- 数据库2
CREATE TABLE `test` (
  `id` int(15) NOT NULL AUTO_INCREMENT COMMENT 'ID',
  `name` varchar(20) DEFAULT '' COMMENT '名称',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='测试表';
```

对这两个库执行"比较架构"，结果里"要修改/要创建/要删除/无操作"四栏全部是 0，`test` 表没有被识别出任何差异。

（注：MySQL 8.0.19+ 已经不再保留整数显示宽度，建表后 `int(11)`/`int(15)` 都会被服务端归一化为裸 `int`，所以复现需要用 8.0.19 之前的版本，比如 MySQL 5.7。）

## 根因

`crates/dbx-core/src/schema_diff.rs` 里，`normalize_mysql_integer_type_for_comparison` 会无条件剥离 MySQL 整数类型的显示宽度再比较。这个逻辑是 e2eabc9d5（"fix(schema): keep MySQL schema sync convergent"）引入的，本意是解决"一侧没写宽度、一侧是数据库自己补的默认宽度"导致同步脚本反复生成无效 ALTER 的问题（比如 `int` vs `int(11)` 应该视为相同）。

但实现没有区分"一侧省略宽度"和"两侧都显式指定但取值确实不同"，把后一种真实差异也一并当成了噪音过滤掉。

## 修复

把归一化逻辑重构为 `parse_mysql_integer_type`，同时返回类型的归一化 key 和可选的显式宽度。比较时：

- 两侧类型 key 相同的前提下，只有当**至少一侧没有显式宽度**时才忽略宽度差异（保留原有的收敛行为）；
- 两侧都显式指定了宽度、且取值不同，判定为真实的类型差异。

## 测试

新增回归测试 `mysql_same_dialect_detects_explicit_integer_display_width_mismatch`，使用真实 MySQL 5.7 `information_schema.COLUMNS.COLUMN_TYPE` 返回的 `int(11)`/`int(15)` 字符串，覆盖本 issue 的场景，以及 `tinyint(1)` vs `tinyint(4)` 场景。

`cargo test -p dbx-core --lib schema_diff::` 238/238 全部通过，包含此前为解决同步收敛问题添加的回归测试 `mysql_same_dialect_ignores_only_integer_display_widths`，未受影响。

真实复现前后对比（本地起 MySQL 5.7 容器，两库分别建 `int(11)`/`int(15)` 的同名表，通过应用界面实际执行"比较架构"）：

- 修复前：比较结果为空，`test` 表未被识别出任何差异
- 修复后：`test` 表被正确识别为"要修改的对象"，DDL 对比清楚高亮出 `int(11)` vs `int(15)` 这一行差异

Fixes #7615