### PR TITLE
fix(transfer): 修复批量多表传输中连接池瞬时失效后级联失败的问题

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -5148,6 +5148,33 @@ async fn execute_on_pool_with_options(
             PoolErrorAction::Keep => return result,
             PoolErrorAction::Discard => {
                 state.remove_pool_by_key(&current_pool_key).await;
+                // `WriteNoReplay` deliberately downgrades a recoverable connection
+                // error to `Discard` here so this specific write is never replayed
+                // (its outcome on the server is unknown). But leaving the pool
+                // torn down does not just affect this one statement: a bulk
+                // multi-table transfer keeps reusing this same `pool_key` for
+                // every remaining table, so once one table hits a transient
+                // connection drop (a momentary "too many connections"/"connection
+                // closed" from the target server under load), every later table
+                // immediately fails too with "Connection not found" / "Pool not
+                // found" -- turning one blip into a cascade for the rest of the
+                // run. Re-establish a fresh pool under the same key so the next
+                // caller isn't handed a known-dead connection; this never retries
+                // the failed statement above, only prepares the pool for
+                // whichever statement runs next.
+                if pool_error_action(db_type, error) == PoolErrorAction::ReconnectAndRetry {
+                    if let Some(connection_id) = connection_id.as_deref() {
+                        let catalog = catalog_from_pool_key(&current_pool_key).map(str::to_string);
+                        let _ = state
+                            .reconnect_pool_for_session_with_catalog(
+                                connection_id,
+                                database.as_deref(),
+                                catalog.as_deref(),
+                                client_session_id.as_deref(),
+                            )
+                            .await;
+                    }
+                }
                 return result;
             }
             PoolErrorAction::ReconnectAndRetry if attempt == 0 => {


### PR DESCRIPTION
## 问题

批量传输多张表（issue 中 44 张）时，只要目标库在传输过程中出现一次瞬时连接问题（新建库常见的 `max_connections` 较低，或服务器压力导致连接被断开），**从那一刻起剩余所有表都会失败**，报错为 `Pool not found` / `connection closed` 一类的连接错误。

## 根因

`crates/dbx-core/src/transfer.rs` 的 `execute_on_pool_with_options`：

- 批量传输的整个循环只在最外层建立一次连接池 key，所有表复用同一个 `pool_key`。
- 写操作（建表 / 插入）统一使用 `TransferExecutionSafety::WriteNoReplay`：任何可重连的连接错误都被有意降级为 `Discard`，避免重放同一条写语句（其在服务端的执行结果未知，重放有重复写入风险）。
- 但 `Discard` 分支原实现只是移除失效连接池、直接返回错误，**从未重新建立连接**。目标库一旦发生一次真实的瞬时连接问题，该 `pool_key` 就此永久失效，后续每一张表复用同一个已死的 key，直接以 `Connection not found` 失败——一次瞬时抖动就此级联成"剩余全部表都失败"。

## 修复

`Discard` 分支在移除失效连接池后，若原始错误的基础分类确实是可重连的连接错误（而非查询超时、驱动 panic 等其他触发 `Discard` 的原因），额外重新建立一个同 key 的新连接池——不重放本次已失败的语句（保持 `WriteNoReplay` 的安全语义不变），只是让循环里下一张表能拿到健康连接，不再级联失败。

净改动 27 行，仅 `crates/dbx-core/src/transfer.rs` 一个文件。

## 复现与验证

本地用两个 MySQL 8 容器复现（源库 44 张合成表，目标库故意调低 `max_connections` 模拟真实场景下的连接压力），通过真实 DBX 应用（dev:web + Windows VM 桥接，issue 原文环境为 Windows）实际执行 Data Transfer，多次复现出与 issue 截图结构一致的 "Background Tasks" 失败面板（`Failed to create table: Connection not found`）。

修复后重新编译，在同样条件下（`SHOW GLOBAL STATUS` 确认确实发生了服务器级连接拒绝，非测试无效）连续多次运行，44/44 张表全部成功，不再出现级联失败。

`cargo test -p dbx-core --lib transfer::` 全部通过（唯一一个无关的 InfluxDB3 测试失败经核实是本机高负载下的既有环境噪音，在未改动的其他分支上原样复现，与本次改动无关）。

Fixes #8107
