### PR TITLE
fix(editor): 修复结果自动刷新导致 SQL 编辑器失去焦点的问题

### DIFF
--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridNativeSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridNativeSelection.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { beginDataGridNativeSelectionBlock, DATA_GRID_NATIVE_SELECTION_BLOCK_CLASS, DATA_GRID_NATIVE_SELECTION_RELEASE_DELAY_MS, finishDataGridNativeSelectionBlock } from "@/lib/dataGrid/dataGridNativeSelection";
 
-function selectionEnvironment() {
+function selectionEnvironment(options: { editableActiveElement?: boolean } = {}) {
   const classes = new Set<string>();
   const removeAllRanges = vi.fn();
   return {
@@ -16,6 +16,11 @@ function selectionEnvironment() {
             remove: (className: string) => classes.delete(className),
           },
         },
+        activeElement: options.editableActiveElement
+          ? {
+              closest: vi.fn(() => ({})),
+            }
+          : null,
       },
       getSelection: () => ({ removeAllRanges }),
       setTimeout,
@@ -37,6 +42,16 @@ describe("data grid native selection block", () => {
 
     expect(classes.has(DATA_GRID_NATIVE_SELECTION_BLOCK_CLASS)).toBe(true);
     expect(removeAllRanges).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the native selection while an editable control is focused", () => {
+    const { classes, removeAllRanges, environment } = selectionEnvironment({ editableActiveElement: true });
+    const owner = {};
+
+    beginDataGridNativeSelectionBlock(owner, environment);
+
+    expect(classes.has(DATA_GRID_NATIVE_SELECTION_BLOCK_CLASS)).toBe(true);
+    expect(removeAllRanges).not.toHaveBeenCalled();
   });
 
   it("keeps the application-level block across a fast component replacement", () => {

--- a/apps/desktop/src/lib/dataGrid/dataGridNativeSelection.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridNativeSelection.ts
@@ -9,6 +9,9 @@ interface NativeSelectionBlockEnvironment {
         remove(className: string): void;
       };
     };
+    activeElement?: {
+      closest?(selector: string): unknown;
+    } | null;
   };
   getSelection?: () => { removeAllRanges(): void } | null;
   setTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout>;
@@ -40,10 +43,17 @@ function hasActiveBlockForEnvironment(environment: NativeSelectionBlockEnvironme
   return [...activeSelectionBlocks.values()].some((activeBlock) => activeBlock.environment.document?.documentElement === documentElement);
 }
 
+function activeElementUsesNativeSelection(environment: NativeSelectionBlockEnvironment): boolean {
+  return !!environment.document?.activeElement?.closest?.("input, textarea, [contenteditable='true'], [role='textbox']");
+}
+
 export function beginDataGridNativeSelectionBlock(owner: DataGridNativeSelectionBlockOwner, environment: NativeSelectionBlockEnvironment = defaultEnvironment()) {
   clearReleaseTimer(owner);
   activeSelectionBlocks.set(owner, { environment });
   environment.document?.documentElement?.classList.add(DATA_GRID_NATIVE_SELECTION_BLOCK_CLASS);
+  // Clearing the document selection while a text editor is focused can leave
+  // CodeMirror's caret visible but detach the browser's active editing range.
+  if (activeElementUsesNativeSelection(environment)) return;
   environment.getSelection?.()?.removeAllRanges();
 }
 


### PR DESCRIPTION
## 变更说明

修复结果自动刷新期间全局 `removeAllRanges()` 清除 SQL 编辑器原生选区，导致编辑器出现光标闪烁但无法正常输入的问题。

刷新期间仍保留 DataGrid 的选区保护逻辑，但当焦点位于 SQL 编辑器或其他可编辑控件时，不再清理全局原生选区。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

修复前，编辑器输入内容时会被自动刷新打断，导致无法继续输入内容：
<img width="1454" height="710" alt="修复前" src="https://github.com/user-attachments/assets/7288dc7c-43f5-4419-b6bf-4e90fc336f3d" />

修复后，编辑器持续输入内容时，自动刷新触发后，不会打断编辑器的输入，可以持续输入内容：
<img width="1414" height="734" alt="修复后" src="https://github.com/user-attachments/assets/579e35f2-08db-4992-be95-6fbda655839f" />


## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `node_modules/.bin/vitest run apps/desktop/src/lib/__tests__/dataGrid/dataGridNativeSelection.spec.ts`
- `node_modules/.bin/oxlint --vue-plugin apps/desktop/src/lib/dataGrid/dataGridNativeSelection.ts apps/desktop/src/lib/__tests__/dataGrid/dataGridNativeSelection.spec.ts`
- `node_modules/.bin/vue-tsc --noEmit --project apps/desktop/tsconfig.json`

手动验证步骤：

1. 打开查询结果页面并聚焦 SQL 编辑器。
2. 开启结果自动刷新。
3. 等待自动刷新触发。
4. 在刷新前后持续输入 SQL，确认编辑器焦点、光标和输入行为保持正常。

## 关联 Issue

无