### PR TITLE
fix(sidebar): 修复开启侧边栏横向滚动后连接列表滚动区域异常

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -2838,6 +2838,13 @@ defineExpose({ focusSearch, createNewGroup, collapseAllTreeNodes, locateTabInSid
   scrollbar-width: none;
   -ms-overflow-style: none;
   overflow-anchor: none;
+  /* Lets TreeItem's full-bleed row/search-box backgrounds (see
+     tree-item-connection-tint / tree-table-search-control in TreeItem.vue)
+     size themselves off this scroller's own width via cqw instead of a
+     fixed -9999px offset, so they can't inflate this element's own
+     scrollWidth when sidebarAllowHorizontalScroll turns on overflow-x. */
+  container-type: inline-size;
+  container-name: sidebar-tree;
 }
 
 .connection-tree-scroller::-webkit-scrollbar {

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1752,8 +1752,11 @@ function onKeydown(event: KeyboardEvent) {
   /* Bleed the tint to the sidebar scroller's own width (see container-type on
      .connection-tree-scroller) rather than an unbounded -9999px, which used
      to inflate the scroller's scrollWidth once sidebarAllowHorizontalScroll
-     turned on overflow-x (issue #8061). */
-  width: 100cqw;
+     turned on overflow-x (issue #8061). max() keeps the tint on rows wider
+     than the scroller; the plain % line is the fallback for engines that
+     drop cqw units. */
+  width: 100%;
+  width: max(100%, 100cqw);
   z-index: 0;
   background-color: var(--tree-connection-row-bg);
   border-radius: inherit;
@@ -1813,7 +1816,8 @@ function onKeydown(event: KeyboardEvent) {
   left: 0;
   /* See .tree-item-connection-tint::before above: bound to the scroller's
      own width instead of -9999px so this can't inflate scrollWidth. */
-  width: 100cqw;
+  width: 100%;
+  width: max(100%, 100cqw);
   z-index: 0;
   background-color: var(--tree-table-search-row-bg);
   pointer-events: none;

--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1746,7 +1746,14 @@ function onKeydown(event: KeyboardEvent) {
 .tree-item-connection-tint::before {
   content: "";
   position: absolute;
-  inset: 0 -9999px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  /* Bleed the tint to the sidebar scroller's own width (see container-type on
+     .connection-tree-scroller) rather than an unbounded -9999px, which used
+     to inflate the scroller's scrollWidth once sidebarAllowHorizontalScroll
+     turned on overflow-x (issue #8061). */
+  width: 100cqw;
   z-index: 0;
   background-color: var(--tree-connection-row-bg);
   border-radius: inherit;
@@ -1801,7 +1808,12 @@ function onKeydown(event: KeyboardEvent) {
 .tree-table-search-control::before {
   content: "";
   position: absolute;
-  inset: 0 -9999px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  /* See .tree-item-connection-tint::before above: bound to the scroller's
+     own width instead of -9999px so this can't inflate scrollWidth. */
+  width: 100cqw;
   z-index: 0;
   background-color: var(--tree-table-search-row-bg);
   pointer-events: none;


### PR DESCRIPTION
## 问题

开启"允许侧边栏横向滚动"后，使用库内表搜索时，连接列表会出现异常过长的横向滚动条，右侧还可能出现深色背景块。

实测发现比描述更严重：只要稍微拖动这根滚动条，整个连接树的真实内容会完全滚出可视区域，侧边栏直接变成空白。

Fixes #8061

## 根因

连接行和"库内表搜索"行的背景高亮都是通过一个 `::before` 伪元素叠加实现的：

```css
.tree-item-connection-tint::before,
.tree-table-search-control::before {
  position: absolute;
  inset: 0 -9999px;
  ...
}
```

这个写法的本意是：即使行本身宽度较窄（自然宽度模式），背景色也能视觉上铺满整个侧边栏。行元素通过 `contain: layout style` 成为该伪元素的绝对定位包含块，所以 `-9999px` 是相对**行自身**宽度计算的。

侧边栏默认是 `overflow-x: hidden`，这块巨大的（约 2 万像素宽）不可见溢出区域被静默吞掉，不会产生滚动条，长期没有暴露问题。但一旦"允许侧边栏横向滚动"把容器切换为 `overflow-x: auto`，浏览器必须为这块理论上可达的溢出区域生成真实的、可滚动的 `scrollWidth`，缺陷才会显现出来。

## 修复

给滚动容器 `.connection-tree-scroller` 增加 `container-type: inline-size`，把两处 `::before` 的 `inset: 0 -9999px` 改成绑定容器自身宽度的 `width: 100cqw`（CSS 容器查询单位）：

- 背景依旧能视觉上铺满侧边栏可视宽度，效果不变；
- 但不再越过滚动容器自身边界，因此不会再撑大 `scrollWidth`。

`container-type`/`@container` 在代码库中已有多处先例（`ObjectBrowser.vue`、`RedisKeyBrowser.vue`、`DataGrid.vue` 等），不引入新的浏览器兼容性风险。

## 测试

真实复现（`pnpm dev:web` 隔离环境 + 真实浏览器操作）：新建连接并建表，设置中依次开启"允许侧边栏横向滚动"+"启用库下表搜索框"，展开表分组：

- 修复前：`.sidebar-tree-horizontal-scroll` 元素 `scrollWidth: 10259` vs `clientWidth: 260`，底部出现异常滚动条，拖动后内容完全消失。
- 修复后：`scrollWidth: 260 === clientWidth: 260`，滚动条消失，搜索框正常显示，拖动无内容丢失。

`pnpm exec vitest run apps/desktop/src/components/sidebar`：25 个测试文件、97 个用例全部通过。

`pnpm check`（connection-types + format + lint + typecheck + 全量 vitest）全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAUgu1SpWp8jd4tMRtJtMj