### PR TITLE
fix(sqlite): SSH 隧道下加密数据库限制提示消失导致报错误导用户

### DIFF
--- a/apps/desktop/src/components/connection/ConnectionDialog.vue
+++ b/apps/desktop/src/components/connection/ConnectionDialog.vue
@@ -6307,6 +6307,9 @@ function openExternalUrl(url: string) {
                       <p v-if="sqliteUsesSsh" class="text-xs text-muted-foreground">
                         {{ t("connection.sqliteRemotePathHint") }}
                       </p>
+                      <p v-if="sqliteUsesSsh" class="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs leading-5 text-amber-700 dark:text-amber-400">
+                        {{ t("connection.sqliteSshCipherUnsupportedHint") }}
+                      </p>
                       <p v-else-if="supportsMemoryDatabasePath" class="text-xs text-muted-foreground">
                         {{ t("connection.memoryDatabasePathHint") }}
                       </p>

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -1111,6 +1111,7 @@ export default {
     sqliteTransportSshOnly: "Remote SQLite only supports SSH hops. Proxy and HTTP tunnel layers cannot be used.",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "Enter an absolute path on the final SSH hop.",
+    sqliteSshCipherUnsupportedHint: "Encrypted (SQLCipher) SQLite databases are not supported over SSH yet.",
     sqliteWorkerPlacement: "SQLite worker",
     sqliteWorkerPlacementSession: "Session",
     sqliteWorkerPlacementPersist: "Persist",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -1095,6 +1095,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "SQLite remoto solo admite saltos SSH. No se pueden usar capas de proxy ni túnel HTTP.",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "Introduce una ruta absoluta en el último salto SSH.",
+    sqliteSshCipherUnsupportedHint: "Las bases de datos SQLite cifradas (SQLCipher) aún no son compatibles a través de SSH.",
     sqliteWorkerPlacement: "Worker de SQLite",
     sqliteWorkerPlacementSession: "Sesión",
     sqliteWorkerPlacementPersist: "Persistente",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1093,6 +1093,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "SQLite remoto supporta solo salti SSH. Impossibile usare livelli proxy o tunnel HTTP.",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "Inserisci un percorso assoluto sull'ultimo salto SSH.",
+    sqliteSshCipherUnsupportedHint: "I database SQLite cifrati (SQLCipher) non sono ancora supportati tramite SSH.",
     sqliteWorkerPlacement: "Worker SQLite",
     sqliteWorkerPlacementSession: "Sessione",
     sqliteWorkerPlacementPersist: "Persistente",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -1093,6 +1093,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "リモート SQLite は SSH ホップのみ対応です。プロキシ層や HTTP トンネルは使用できません。",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "最終 SSH ホップ上の絶対パスを入力してください。",
+    sqliteSshCipherUnsupportedHint: "SSH 経由での暗号化（SQLCipher）SQLite データベースの接続にはまだ対応していません。",
     sqliteWorkerPlacement: "SQLite ワーカー",
     sqliteWorkerPlacementSession: "セッション",
     sqliteWorkerPlacementPersist: "永続化",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -1003,6 +1003,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "원격 SQLite는 SSH 홉만 지원합니다. 프록시 및 HTTP 터널 계층은 사용할 수 없습니다.",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "마지막 SSH 홉의 절대 경로를 입력하세요.",
+    sqliteSshCipherUnsupportedHint: "SSH를 통한 암호화(SQLCipher)된 SQLite 데이터베이스 연결은 아직 지원되지 않습니다.",
     sqliteWorkerPlacement: "SQLite 워커",
     sqliteWorkerPlacementSession: "세션",
     sqliteWorkerPlacementPersist: "영속",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -1094,6 +1094,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "O SQLite remoto suporta apenas saltos SSH. Camadas de proxy e túnel HTTP não podem ser usadas.",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "Informe um caminho absoluto no último salto SSH.",
+    sqliteSshCipherUnsupportedHint: "Bancos de dados SQLite criptografados (SQLCipher) ainda não são suportados via SSH.",
     sqliteWorkerPlacement: "Worker do SQLite",
     sqliteWorkerPlacementSession: "Sessão",
     sqliteWorkerPlacementPersist: "Persistente",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -1112,6 +1112,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "Uzak SQLite yalnızca SSH atlamalarını destekler. Proxy ve HTTP tünel katmanları kullanılamaz.",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "Son SSH atlamasındaki mutlak bir yol girin.",
+    sqliteSshCipherUnsupportedHint: "Şifrelenmiş (SQLCipher) SQLite veritabanları henüz SSH üzerinden desteklenmiyor.",
     sqliteWorkerPlacement: "SQLite worker'ı",
     sqliteWorkerPlacementSession: "Oturum",
     sqliteWorkerPlacementPersist: "Kalıcı",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -1038,6 +1038,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "远程 SQLite 只支持 SSH 跳板，不能使用代理或 HTTP 隧道。",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "请填写最后一跳 SSH 主机上的绝对路径。",
+    sqliteSshCipherUnsupportedHint: "暂不支持通过 SSH 打开加密（SQLCipher）的 SQLite 数据库。",
     sqliteWorkerPlacement: "SQLite worker",
     sqliteWorkerPlacementSession: "会话",
     sqliteWorkerPlacementPersist: "持久",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -1095,6 +1095,7 @@ export default withEnglishFallback({
     sqliteTransportSshOnly: "遠端 SQLite 僅支援 SSH 跳板，無法使用代理或 HTTP 通道。",
     sqliteRemotePathPlaceholder: "/var/lib/app/data.db",
     sqliteRemotePathHint: "請填寫最後一跳 SSH 主機上的絕對路徑。",
+    sqliteSshCipherUnsupportedHint: "暫不支援透過 SSH 開啟加密（SQLCipher）的 SQLite 資料庫。",
     sqliteWorkerPlacement: "SQLite worker",
     sqliteWorkerPlacementSession: "工作階段",
     sqliteWorkerPlacementPersist: "持續",


### PR DESCRIPTION
## 问题

SQLite 连接表单里的"SQLite 加密密码"（SQLCipher Key）输入框，只要把传输层切到 SSH 隧道就会**整个消失**，没有任何提示告诉用户为什么。

后端其实早就写好了明确的拦截报错（"Remote SQLite over SSH does not support SQLCipher in v1"），但因为前端把密码框藏起来了，密码字段永远是空字符串，这条清楚的报错永远走不到——用户只会撞上后续环节里更无关、更困惑的报错（如本 issue 原文里的 `File does not exist:xxx`，实际来自远程路径存在性检查，跟加密与否毫无关系）。

对应 issue 标题"sqlite SSH 连接加密数据库，打不开"：加密数据库确实没法通过 SSH 打开，但用户完全不知道原因。

## 根因

- `apps/desktop/src/components/connection/ConnectionDialog.vue`：`SQLite Encryption Key` 字段用 `v-if="!sqliteUsesSsh"` 包裹，启用 SSH 后完全隐藏，周围没有任何解释性文字。
- `crates/dbx-core/src/db/sqlite_worker.rs`：已有拦截 `if !config.password.is_empty() { return Err("...does not support SQLCipher in v1") }`，但因前端字段被藏、密码永远为空，这条报错不可达。

## 修复

在原字段位置新增一条提示（复用项目已有的琥珀色警示样式），明确告知"加密（SQLCipher）SQLite 数据库暂不支持通过 SSH 打开"，9 个语言文件同步补充翻译（en/zh-CN/zh-TW/ja/ko/es/it/pt-BR/tr）。未改动后端逻辑——v1 不支持 SQLCipher 本身是既有设计决策，不在本次修复范围，本次只解决"用户被无关报错误导"的体验问题。

## 验证

- 真实复现：Playwright 经 Windows VM 里的真实浏览器，在隔离 `dev:web` 环境下操作实际的连接表单——启用 SSH 前加密密码字段正常显示，启用 SSH 后字段静默消失（修复前），修复后同一位置显示清晰提示。
- `pnpm check`（connection-types + format + lint + typecheck + test）全部通过，无回归。

Fixes #7829