### PR TITLE
fix(sql): 修复 DuckDB ORDER BY 别名误报（#6499）

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts
@@ -31,6 +31,33 @@ describe("sqlSemanticReferences shared consumers", () => {
     expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual(["Unknown column ro.missing"]);
   });
 
+  it("does not flag a SELECT alias used by DuckDB ORDER BY", () => {
+    const sql = `SELECT SUM(price * amount) AS total, api_key_name FROM amounts GROUP BY api_key_name ORDER BY total DESC`;
+    const aliasStart = sql.indexOf("total", sql.indexOf("ORDER BY"));
+    const analysis: SqlReferenceAnalysis = {
+      tables: [
+        {
+          name: "amounts",
+          span: span(sql.indexOf("amounts") + 1, sql.indexOf("amounts") + "amounts".length),
+        },
+      ],
+      columns: [
+        {
+          name: "total",
+          span: span(aliasStart + 1, aliasStart + "total".length),
+        },
+      ],
+    };
+
+    const diagnostics = buildSqlSemanticDiagnostics(analysis, {
+      tables: [],
+      columnsByTable: new Map([["amounts", [{ name: "price" }, { name: "amount" }, { name: "api_key_name" }]]]),
+      sql,
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
   it("resolves navigation targets from subquery aliases and projected columns", () => {
     const { sql, cursor } = sqlFixtureCursor("SELECT sq.user_| FROM (SELECT id, name AS user_name FROM users) sq");
     const model = buildSqlSemanticModel(sql, cursor);

--- a/apps/desktop/src/lib/sql/semantic/diagnostics.ts
+++ b/apps/desktop/src/lib/sql/semantic/diagnostics.ts
@@ -280,6 +280,14 @@ export function buildSqlSemanticDiagnostics(analysis: SqlReferenceAnalysis, sche
       if (tdengineStableTables.has(tableReferenceKey(table))) continue;
     }
 
+    // SQL engines allow SELECT projection aliases in ORDER BY/GROUP BY (and,
+    // for example, DuckDB also allows them in HAVING). The reference parser
+    // reports those aliases as ordinary columns, so metadata-only validation
+    // would otherwise show a false "Unknown column" diagnostic. Reuse the
+    // completion context, which already extracts aliases and knows when they
+    // are visible, to keep diagnostics aligned with executable SQL semantics.
+    if (schema.sql && isVisibleProjectionAlias(schema.sql, column.span, column.name)) continue;
+
     const displayName = column.qualifier ? `${column.qualifier}.${column.name}` : column.name;
     diagnostics.push({
       span: trimSqlTextSpanWhitespace(schema.sql, column.span),
@@ -317,6 +325,14 @@ function isUnquotedOracleSystemValueReference(column: SqlColumnReference, schema
 
 export function isSqlVirtualTableReference(table: { name: string; schema?: string | null }, databaseType?: DatabaseType): boolean {
   return databaseType === "mysql" && !table.schema && normalizeName(table.name) === "dual";
+}
+
+function isVisibleProjectionAlias(sql: string, span: SqlTextSpan, name: string): boolean {
+  const range = sqlTextSpanToOffsetRange(sql, span);
+  if (!range) return false;
+  const context = getSqlCompletionContext(sql, range.to);
+  if (!context.prioritizeSelectAliases) return false;
+  return context.selectAliases.some((alias) => normalizeName(alias) === normalizeName(name));
 }
 
 function trimSqlTextSpanWhitespace(sql: string | undefined, span: SqlTextSpan): SqlTextSpan {


### PR DESCRIPTION
## 摘要
修复 DuckDB 查询中合法的 SELECT 投影别名（例如 `ORDER BY total`）被 SQL 语义诊断误报为 `Unknown column` 的问题。

## 复现与验证
- 修复前：`SUM(price * amount) AS total ... ORDER BY total` 在表元数据不含 `total` 时产生误报。
- 修复后：复用补全上下文识别 ORDER BY/GROUP BY/HAVING 中可见的 SELECT 别名。
- `pnpm vitest run apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts`（5 passed，最新 upstream/main）
- `pnpm vue-tsc --noEmit --project apps/desktop/tsconfig.json` 通过
- 本地 DBX Web 连接 `duckdb://:memory:` 实际执行 issue 形态 SQL，返回 1 行，列为 `total`、`api_key_name`。

Fixes #6499