### PR TITLE
fix(xugu): exclude synthetic scopes from schema export

### DIFF
--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -12,7 +12,7 @@ import * as api from "@/lib/backend/api";
 import type { ExportProgress } from "@/lib/backend/api";
 import { isSchemaAware, isSingleDatabase } from "@/lib/database/databaseFeatureSupport";
 import { databaseOptionsForConnection, fetchNamespaceOptionsForConnection } from "@/composables/useDatabaseOptions";
-import { buildAllDatabaseExportPlan, generateDatabaseExportId, runDatabaseExportUntilTerminal, runWithDatabaseBackupSnapshot, shouldUseDatabaseBackupSnapshot, type AllDatabaseExportPlanItem } from "@/lib/export/databaseExport";
+import { buildAllDatabaseExportPlan, filterExportableSchemas, generateDatabaseExportId, runDatabaseExportUntilTerminal, runWithDatabaseBackupSnapshot, shouldUseDatabaseBackupSnapshot, type AllDatabaseExportPlanItem } from "@/lib/export/databaseExport";
 import { buildSelectedTablesPayload, isDatabaseExportTableSelectionValid } from "@/lib/export/databaseExportSelection";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { useToast } from "@/composables/useToast";
@@ -204,7 +204,7 @@ async function loadSchemas(preferredSchema = "") {
     return;
   }
 
-  const schemaList = await api.listSchemas(connectionId.value, database.value);
+  const schemaList = filterExportableSchemas(await api.listSchemas(connectionId.value, database.value), config?.db_type);
   const selected = preferredSchema && schemaList.includes(preferredSchema) ? preferredSchema : schemaList.includes("public") ? "public" : (schemaList[0] ?? "");
   schemas.value = schemaList;
   schema.value = selected;
@@ -278,7 +278,7 @@ async function buildExportPlanForDatabases(dbs: string[]): Promise<AllDatabaseEx
   const schemasByDatabase: Record<string, string[]> = {};
   if (schemaAware) {
     for (const db of dbs) {
-      schemasByDatabase[db] = await api.listSchemas(connectionId.value, db);
+      schemasByDatabase[db] = filterExportableSchemas(await api.listSchemas(connectionId.value, db), dbType);
     }
   }
   return buildAllDatabaseExportPlan({ databases: dbs, schemaAware, schemasByDatabase, dbType });

--- a/apps/desktop/src/lib/export/__tests__/databaseExport.spec.ts
+++ b/apps/desktop/src/lib/export/__tests__/databaseExport.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildAllDatabaseExportPlan, filterExportableSchemas } from "@/lib/export/databaseExport";
+import { XUGU_PUBLIC_SYNONYM_SCOPE, XUGU_SCHEDULER_JOB_SCOPE } from "@/lib/sidebar/xuguPublicSynonyms";
+
+describe("database export schema selection", () => {
+  it("hides Xugu synthetic tree scopes while preserving real schemas", () => {
+    const schemas = ["APP_TEST", "GUEST", XUGU_PUBLIC_SYNONYM_SCOPE, XUGU_SCHEDULER_JOB_SCOPE];
+
+    expect(filterExportableSchemas(schemas, "xugu")).toEqual(["APP_TEST", "GUEST"]);
+  });
+
+  it("does not apply Xugu filtering to other database types", () => {
+    const schemas = ["APP_TEST", XUGU_PUBLIC_SYNONYM_SCOPE, XUGU_SCHEDULER_JOB_SCOPE];
+
+    expect(filterExportableSchemas(schemas, "postgres")).toEqual(schemas);
+  });
+
+  it("excludes synthetic scopes from an all-database Xugu export plan", () => {
+    expect(
+      buildAllDatabaseExportPlan({
+        databases: ["SHOP_DEMO"],
+        schemaAware: true,
+        dbType: "xugu",
+        schemasByDatabase: {
+          SHOP_DEMO: ["APP_TEST", XUGU_PUBLIC_SYNONYM_SCOPE, XUGU_SCHEDULER_JOB_SCOPE],
+        },
+      }),
+    ).toEqual([
+      {
+        database: "SHOP_DEMO",
+        schema: "APP_TEST",
+        fileStem: "SHOP_DEMO",
+        displayName: "SHOP_DEMO",
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/export/databaseExport.ts
+++ b/apps/desktop/src/lib/export/databaseExport.ts
@@ -3,6 +3,7 @@ import * as api from "@/lib/backend/api.ts";
 import { buildTableSelectSql } from "@/lib/table/tableSelectSql.ts";
 import { uuid } from "@/lib/common/utils.ts";
 import { SINGLE_DATABASE_TYPES } from "@/lib/database/databaseCapabilitySets";
+import { isXuguSyntheticScope } from "@/lib/sidebar/xuguPublicSynonyms";
 
 export const DATABASE_EXPORT_ROW_LIMIT = 10_000;
 export const DATABASE_EXPORT_PAGE_SIZE = 500;
@@ -74,6 +75,19 @@ export interface AllDatabaseExportPlanItem {
   schema: string;
   fileStem: string;
   displayName: string;
+}
+
+/**
+ * Return schemas that can be exported as ordinary schema-owned objects.
+ *
+ * Xugu exposes database-global namespaces (public synonyms and scheduler jobs)
+ * through reserved synthetic schema names so the sidebar can reuse its normal
+ * tree loading path. They are not real schemas and must not be offered by the
+ * schema export selector.
+ */
+export function filterExportableSchemas(schemas: readonly string[], databaseType?: DatabaseType): string[] {
+  if (databaseType !== "xugu") return [...schemas];
+  return schemas.filter((schema) => !isXuguSyntheticScope(schema));
 }
 
 export interface DatabaseBackupSnapshotOptions {
@@ -153,7 +167,7 @@ export function buildAllDatabaseExportPlan(options: AllDatabaseExportPlanInput):
     }));
   }
   return options.databases.flatMap((database) => {
-    const schemas = options.schemaAware ? (options.schemasByDatabase?.[database] ?? []).filter((schema) => schema.trim()) : [database];
+    const schemas = options.schemaAware ? filterExportableSchemas(options.schemasByDatabase?.[database] ?? [], options.dbType).filter((schema) => schema.trim()) : [database];
     const exportSchemas = schemas.length > 0 ? schemas : [database];
     const includeSchemaInFileName = options.schemaAware && exportSchemas.length > 1;
 


### PR DESCRIPTION
## Summary

Xugu exposes Public synonyms and Scheduled jobs through reserved synthetic scope names so the sidebar can display them as database-level nodes. The database export dialog was treating those protocol-only scopes as ordinary schemas and listing them in the schema selector.

This change keeps the synthetic scopes available to the sidebar while excluding them from schema export selection and all-database export planning.

## Root cause

`listSchemas` intentionally returns Xugu synthetic scopes for tree navigation. The export UI consumed that result without distinguishing real schemas from protocol-only namespaces, so both synthetic entries appeared in the export schema dropdown.

## Changes

- Added a shared Xugu-aware schema filter for export boundaries.
- Applied the filter to single-database schema selection.
- Applied the filter to all-database export plan generation.
- Kept the filter scoped to `xugu`; other database types are unchanged.
- Preserved real schema names, including names that may resemble system or guest schemas.
- Added regression coverage for Xugu filtering, non-Xugu compatibility, and all-database export planning.

## Validation

- Export schema regression tests passed.
- Xugu synthetic-scope tests passed.
- Type checking passed.
- Frontend production build passed.
- Debug macOS desktop bundle built successfully with updater artifact generation disabled for local testing.
- Manual packaged UI verification confirmed that the export schema selector shows only real schemas while the sidebar still shows Public synonyms and Scheduled jobs.

## Compatibility

This is a desktop export-boundary change only. No Agent behavior, database metadata SQL, or non-Xugu export behavior was changed.