### PR TITLE
fix(editor): keep Enter and Tab with the IME during composition

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -2210,6 +2210,10 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
 }
 
 function handleEnter(view: EditorViewType): boolean {
+  // While an IME composition is active, Enter confirms the composition (the
+  // candidate list); intercepting it here would accept a completion popup on
+  // top of the composition instead of committing the typed text (issue #8029).
+  if (isEditorComposing(view)) return false;
   clearPendingCompletionEnter();
   if (isBatchColumnSelectionCompletionActive(codeMirrorCompletionStatus?.(view.state) ?? null) && applySelectedBatchColumnSelection(view)) return true;
   // CodeMirror's default completion keymap is disabled so batch selection can
@@ -2224,6 +2228,7 @@ function handleEnter(view: EditorViewType): boolean {
       selectFirstCompletion: codeMirrorSelectFirstCompletion,
       retryDelayMs: COMPLETION_TAB_RETRY_DELAY_MS,
       maxWaitMs: COMPLETION_ENTER_MAX_WAIT_MS,
+      isComposing: () => isEditorComposing(view),
       onUnavailable: () => insertNewlineWithoutCompletion(view),
       onSettled: () => {
         if (cancelPendingCompletionEnter === cancelRetry) cancelPendingCompletionEnter = null;
@@ -2276,6 +2281,7 @@ function acceptCompletionOrNextSnippetField(view: EditorViewType): boolean {
   // Any non-empty selection range means Tab is being used for block indent,
   // not word completion. A completion popup can still appear as a side effect
   // of the indent edit itself, so it must never hijack this or a following Tab.
+  if (isEditorComposing(view)) return false;
   if (view.state.selection.ranges.every((range) => range.empty)) {
     const completionStatus = codeMirrorCompletionStatus?.(view.state) ?? null;
     if (isBatchColumnSelectionCompletionActive(completionStatus) && applySelectedBatchColumnSelection(view)) return true;
@@ -2299,6 +2305,10 @@ function waitForCompletionTab(view: EditorViewType): boolean {
 
   const retry = () => {
     pendingCompletionTabTimer = null;
+    // The user started an IME composition while waiting for the pending
+    // completion; Tab now belongs to the candidate list, so drop the queued
+    // acceptance (and the normal-Tab fallback) instead of fighting the IME.
+    if (isEditorComposing(view)) return;
     const selectionRanges = view.state.selection.ranges;
     if (view.state.doc !== initialDoc || selectionRanges.length !== initialSelectionRanges.length || selectionRanges.some((range, index) => !range.empty || range.anchor !== initialSelectionRanges[index]?.anchor || range.head !== initialSelectionRanges[index]?.head)) return;
 

--- a/apps/desktop/src/components/editor/__tests__/QueryEditor.imeCompletionAcceptance.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/QueryEditor.imeCompletionAcceptance.spec.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const editorSource = readFileSync(new URL("../QueryEditor.vue", import.meta.url), "utf8");
+
+function functionSource(name: string, nextName: string) {
+  const start = editorSource.indexOf(`function ${name}(`);
+  const end = editorSource.indexOf(`function ${nextName}(`, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return editorSource.slice(start, end);
+}
+
+// Regression test for #8029: while an IME composition is active, Enter and the
+// completion-accept shortcut belong to the IME candidate list. The acceptance
+// handlers gate on the same isEditorComposing helper the completion providers
+// already use, and the delayed retries must drop their queued acceptance once
+// a composition starts instead of accepting over (or after) it.
+describe("QueryEditor IME-safe completion acceptance", () => {
+  it("gates the Enter handler on IME composition before any acceptance", () => {
+    const source = functionSource("handleEnter", "clearPendingCompletionEnter");
+    const composingGuard = source.indexOf("if (isEditorComposing(view)) return false;");
+    const acceptCall = source.indexOf("codeMirrorAcceptCompletion?.(view)");
+
+    expect(composingGuard).toBeGreaterThanOrEqual(0);
+    expect(acceptCall).toBeGreaterThan(composingGuard);
+  });
+
+  it("gates the Tab completion-accept handler on IME composition", () => {
+    const source = functionSource("acceptCompletionOrNextSnippetField", "clearPendingCompletionTab");
+    const composingGuard = source.indexOf("if (isEditorComposing(view)) return false;");
+    const selectionCheck = source.indexOf("view.state.selection.ranges.every");
+
+    expect(composingGuard).toBeGreaterThanOrEqual(0);
+    expect(selectionCheck).toBeGreaterThan(composingGuard);
+  });
+
+  it("drops the pending Tab acceptance retry when an IME composition starts", () => {
+    const source = functionSource("waitForCompletionTab", "wordWrapExtension");
+    const retry = source.indexOf("const retry = () => {");
+    const composingGuard = source.indexOf("if (isEditorComposing(view)) return;", retry);
+
+    expect(retry).toBeGreaterThanOrEqual(0);
+    expect(composingGuard).toBeGreaterThan(retry);
+  });
+
+  it("passes an IME guard to the Enter acceptance retry helper", () => {
+    const source = functionSource("handleEnter", "clearPendingCompletionEnter");
+    expect(source.includes("isComposing: () => isEditorComposing(view)")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionKeymap.spec.ts
@@ -67,6 +67,7 @@ function createHarness(options: {
   indentMore?: (view: MockView) => boolean;
   acceptCompletionShortcut?: string;
   selectFirstCompletionOnOpen?: boolean;
+  imeComposing?: (view: MockView) => boolean;
 }): TabHarness {
   const source = [
     extractDeclaration(/const COMPLETION_REMOTE_LATENCY_BUDGET_MS = \d+;/, "remote completion latency budget"),
@@ -111,6 +112,7 @@ function createHarness(options: {
     "normalizeShortcutSettings",
     "shortcutToCodeMirrorKey",
     "props",
+    "isEditorComposing",
     `${javascript}\nreturn { handleTab, handleEnter, insertNewlineWithoutCompletion, acceptCompletionOrNextSnippetField, clearPendingCompletionTab, consumeSqlCompletionAutoStartSuppression };`,
   );
   return factory(
@@ -137,6 +139,7 @@ function createHarness(options: {
     normalizeShortcutSettings,
     shortcutToCodeMirrorKey,
     { databaseType: "mysql" },
+    options.imeComposing ?? ((view: MockView) => (view as MockView & { composing?: boolean }).composing === true || (view as MockView & { compositionStarted?: boolean }).compositionStarted === true),
   ) as TabHarness;
 }
 
@@ -193,6 +196,42 @@ describe("QueryEditor completion Tab keymap", () => {
     expect(acceptCompletion).toHaveBeenCalledWith(view);
     expect(closeCompletion).not.toHaveBeenCalled();
     expect(insertNewlineKeepIndent).not.toHaveBeenCalled();
+  });
+
+  it("lets the IME keep Enter while a composition is active instead of accepting a completion (#8029)", () => {
+    const acceptCompletion = vi.fn(() => true);
+    const closeCompletion = vi.fn(() => true);
+    const insertNewlineKeepIndent = vi.fn(() => true);
+    const harness = createHarness({
+      completionStatus: () => "active",
+      acceptCompletion,
+      closeCompletion,
+      insertNewlineKeepIndent,
+      selectFirstCompletionOnOpen: true,
+      imeComposing: () => true,
+    });
+    const view = createView();
+
+    expect(harness.handleEnter(view)).toBe(false);
+    expect(acceptCompletion).not.toHaveBeenCalled();
+    expect(closeCompletion).not.toHaveBeenCalled();
+    expect(insertNewlineKeepIndent).not.toHaveBeenCalled();
+  });
+
+  it("lets the IME keep Tab while a composition is active instead of accepting a completion (#8029)", () => {
+    const acceptCompletion = vi.fn(() => true);
+    const nextSnippetField = vi.fn(() => true);
+    const harness = createHarness({
+      completionStatus: () => "active",
+      acceptCompletion,
+      nextSnippetField,
+      imeComposing: () => true,
+    });
+    const view = createView();
+
+    expect(harness.acceptCompletionOrNextSnippetField(view)).toBe(false);
+    expect(acceptCompletion).not.toHaveBeenCalled();
+    expect(nextSnippetField).not.toHaveBeenCalled();
   });
 
   it("does not suppress later completion when Enter cannot insert a newline", () => {

--- a/apps/desktop/src/lib/editor/__tests__/queryEditorCompletionAcceptanceIme.spec.ts
+++ b/apps/desktop/src/lib/editor/__tests__/queryEditorCompletionAcceptanceIme.spec.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { acceptSelectedCompletionWithRetry, type RetryCompletionAcceptanceOptions } from "../queryEditorCompletionAcceptance";
+
+function createFakeView({ composing = false } = {}) {
+  return {
+    composing,
+    compositionStarted: composing,
+    state: {
+      selection: { ranges: [{ anchor: 0, head: 0 }] },
+    },
+  };
+}
+
+type FakeView = ReturnType<typeof createFakeView>;
+
+function createOptions(view: FakeView, overrides: Partial<RetryCompletionAcceptanceOptions> = {}) {
+  const status: { value: "active" | "pending" | null } = { value: "active" };
+  const options = {
+    completionStatus: () => status.value,
+    acceptCompletion: vi.fn(() => false),
+    selectedCompletionIndex: () => null,
+    selectFirstCompletion: vi.fn(() => true),
+    retryDelayMs: 1,
+    maxWaitMs: 10,
+    onUnavailable: vi.fn(),
+    onSettled: vi.fn(),
+    isComposing: () => view.composing,
+    ...overrides,
+  } satisfies RetryCompletionAcceptanceOptions;
+  return { options, status };
+}
+
+describe("acceptSelectedCompletionWithRetry IME guard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("accepts immediately when the completion is active and no retry is needed", () => {
+    const view = createFakeView();
+    const { options } = createOptions(view, {
+      acceptCompletion: vi.fn(() => true),
+    });
+
+    const result = acceptSelectedCompletionWithRetry(view as never, options);
+
+    expect(result.handled).toBe(true);
+    expect(options.acceptCompletion).toHaveBeenCalledTimes(1);
+    expect(options.onUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("drops the queued acceptance without calling onUnavailable once an IME composition starts while waiting", () => {
+    const view = createFakeView();
+    const { options } = createOptions(view);
+
+    const result = acceptSelectedCompletionWithRetry(view as never, options);
+    expect(result.handled).toBe(true);
+
+    // The user started an IME composition before the retry fired: the queued
+    // Enter belongs to the IME candidate list now, so the retry must drop the
+    // acceptance silently instead of accepting a completion over the
+    // composition or falling back to onUnavailable. The only accept attempt is
+    // the initial synchronous one that happened before the composition began.
+    view.composing = true;
+    view.compositionStarted = true;
+    vi.advanceTimersByTime(5);
+
+    expect(options.acceptCompletion).toHaveBeenCalledTimes(1);
+    expect(options.onUnavailable).not.toHaveBeenCalled();
+    expect(options.onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps retrying while waiting when no IME composition starts", () => {
+    const view = createFakeView();
+    const { options } = createOptions(view);
+
+    acceptSelectedCompletionWithRetry(view as never, options);
+    // One synchronous attempt on entry.
+    expect(options.acceptCompletion).toHaveBeenCalledTimes(1);
+
+    // First retry still sees an unacceptable completion and keeps waiting.
+    vi.advanceTimersByTime(1);
+    expect(options.acceptCompletion).toHaveBeenCalledTimes(2);
+    expect(options.onUnavailable).not.toHaveBeenCalled();
+
+    // No composition started, so the retry keeps its original semantics and
+    // accepts as soon as the completion becomes acceptable.
+    options.acceptCompletion.mockReturnValue(true);
+    vi.advanceTimersByTime(1);
+    expect(options.acceptCompletion).toHaveBeenCalledTimes(3);
+    expect(options.onUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("still calls onUnavailable when the completion never becomes acceptable and no composition starts", () => {
+    const view = createFakeView();
+    const { options } = createOptions(view, {
+      isComposing: () => false,
+      maxWaitMs: 10,
+    });
+
+    acceptSelectedCompletionWithRetry(view as never, options);
+    vi.advanceTimersByTime(50);
+
+    expect(options.onUnavailable).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/lib/editor/queryEditorCompletionAcceptance.ts
+++ b/apps/desktop/src/lib/editor/queryEditorCompletionAcceptance.ts
@@ -13,6 +13,8 @@ interface RetryCompletionAcceptanceOptions {
   maxWaitMs: number;
   onUnavailable: () => void;
   onSettled?: () => void;
+  /** Called before each retry; when an IME composition started while waiting, the queued acceptance must be dropped instead of fighting the IME. */
+  isComposing?: () => boolean;
 }
 
 interface CompletionAcceptanceAttempt {
@@ -51,6 +53,11 @@ export function acceptSelectedCompletionWithRetry(view: EditorView, options: Ret
   const retry = () => {
     timer = null;
     if (settled) return;
+
+    if (options.isComposing?.()) {
+      settle();
+      return;
+    }
 
     const selectionRanges = view.state.selection.ranges;
     if (view.state.doc !== initialDoc || selectionRanges.length !== initialSelectionRanges.length || selectionRanges.some((range, index) => range.anchor !== initialSelectionRanges[index]?.anchor || range.head !== initialSelectionRanges[index]?.head)) {


### PR DESCRIPTION
## 问题

Fixes #8029

中文输入法（CJK IME）组合输入期间在 SQL 编辑器中按 Enter 确认候选词时，按键被补全接受逻辑拦截，导致：

1. **SQL 内容被污染**：issue 录屏可见，`where ` 后用拼音输入 "sr"，IME 候选框打开时按 Enter，补全弹层把 Enter 解释为“接受当前项”——插入了 `sr.`，叠加 preedit 上屏后语句变成 `where sr.sr.business_id = ...`。
2. `selectFirstCompletionOnOpen` 开启时，`acceptSelectedCompletionWithRetry` 的延迟重试还会在组合结束**之后**把第一项补全插入文档。
3. Tab 键（默认补全接受快捷键之一）同样被拦截，影响 IME 候选切换。

## 根因

代码库中补全的其它入口（`provideSqlCompletions`、`triggerSqlCompletion`、`scheduleSqlCompletionStart`）都已有 `isEditorComposing` 门控（组合了 `imeCompositionActive` 标志与 CodeMirror 的 `compositionStarted`/`composing` 状态），但**接受路径**完全遗漏：

- `handleEnter`（Enter keymap）→ `codeMirrorAcceptCompletion` / retry 接受
- `acceptCompletionOrNextSnippetField`（补全接受快捷键，默认 Tab）
- `waitForCompletionTab` 与 `acceptSelectedCompletionWithRetry` 的延迟重试回调

## 修改内容

- `handleEnter` / `acceptCompletionOrNextSnippetField`：入口增加 `isEditorComposing(view)` 门控，组合态直接返回 false，按键交还输入法。
- `waitForCompletionTab` 的 retry 回调：组合开始后静默放弃排队的接受（不回退到普通 Tab——组合期间 Tab 语义已被 IME 占用）。
- `acceptSelectedCompletionWithRetry` 新增可选 `isComposing` 回调：重试期间检测到组合即 settle（不触发 `onUnavailable`，避免组合上屏后莫名插入换行）；`handleEnter` 调用点传入该回调。

## 验证

- 新增 `queryEditorCompletionAcceptanceIme.spec.ts`：4 个用例覆盖立即接受、组合期间丢弃排队接受（不触发 onUnavailable）、无组合时保持原重试语义、超时 onUnavailable 回归。
- 新增 `QueryEditor.imeCompletionAcceptance.spec.ts`：4 个源码级回归断言（Enter/Tab 门控先于接受逻辑、retry 带 IME 守卫）。
- `queryEditorCompletionKeymap.spec.ts` harness 注入 `isEditorComposing` mock，并新增 2 个行为用例（组合态 Enter/Tab 不接受补全、不推进 snippet）。
- 编辑器相关 663 个测试全部通过；`vue-tsc` 类型检查无新增错误。

## 说明

- 无法在自动化环境中真实驱动 macOS 输入法做端到端验证，但 issue 录屏 + 代码路径与 #7511 已修复的反序列化问题相互独立，本修复直接覆盖录屏中的按键路径。组合检测使用的三个信号（`imeCompositionActive`、`compositionStarted`、`composing`）与现有补全提供方一致，已在生产路径中验证有效。
- 关联背景：#7511 的根因（Kingbase Agent 大写候选类型反序列化失败）已在 01ce303f4 修复；本 issue 录屏显示的 IME 交互问题是独立缺陷。