### PR TITLE
fix(dameng): 普通权限账号下自增主键列无法插入

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -68,6 +68,10 @@ public final class DamengAgent extends AbstractJdbcAgent {
     private static final int DBMS_OUTPUT_ENABLE_TIMEOUT_SECS = 5;
     private static final int DBMS_OUTPUT_ENABLE_NETWORK_TIMEOUT_MILLIS = 5_000;
     private static final Pattern DATABASE_VERSION_MAJOR_PATTERN = Pattern.compile("(\\d+)\\.");
+    // Word-boundary match so a type or default merely containing the letters is not mistaken
+    // for the IDENTITY keyword.
+    private static final Pattern DDL_IDENTITY_KEYWORD_PATTERN =
+        Pattern.compile("(?i)(?<![A-Z0-9_$#])IDENTITY(?![A-Z0-9_$#])");
     private static final JdbcAgentProfile DM6_METADATA_PROFILE = new JdbcAgentProfile(
         "dm6.jdbc.driver.DmDriver",
         "jdbc:dm6://{host}:{port}/{database}",
@@ -1719,6 +1723,13 @@ public final class DamengAgent extends AbstractJdbcAgent {
                     }
                 }
             }
+            if (pkColumns.isEmpty()) {
+                // ALL_CONS_COLUMNS/ALL_CONSTRAINTS return no rows — rather than an error — for
+                // accounts that cannot see the constraint dictionary, which is indistinguishable
+                // from a table that genuinely has no primary key. Re-ask through the driver,
+                // which reports primary keys to the table owner regardless of dictionary grants.
+                pkColumns.addAll(primaryKeyColumnsFromJdbcMetadata(schema, table));
+            }
 
             Set<String> identityColumns = identityColumns(schema, table);
             List<ColumnInfo> result = new ArrayList<>();
@@ -1780,6 +1791,23 @@ public final class DamengAgent extends AbstractJdbcAgent {
     }
 
     private Set<String> identityColumns(String schema, String table) {
+        try {
+            return identityColumnsFromSystemCatalog(schema, table);
+        } catch (Exception systemCatalogError) {
+            // SYS.SYSCOLUMNS is not granted to PUBLIC, so ordinary (non-DBA) accounts fail here
+            // with a permission error. Reporting that as an empty set is indistinguishable from
+            // "this table has no identity column", and the data grid then sends the identity
+            // value on INSERT — which the server rejects, while leaving it out trips the NOT NULL
+            // check. Fall back to the table DDL, which the table owner can always read.
+            //
+            // Any failure triggers the fallback, not just a permission error: the server message
+            // is localized, so matching on its text would silently stop working on a non-Chinese
+            // server, and every other failure mode wants the same fallback anyway.
+            return identityColumnsFromTableDdl(schema, table);
+        }
+    }
+
+    private Set<String> identityColumnsFromSystemCatalog(String schema, String table) throws Exception {
         Set<String> result = new java.util.HashSet<>();
         String sql = """
             SELECT /*+ PARALLEL(1) */ c.NAME
@@ -1799,8 +1827,177 @@ public final class DamengAgent extends AbstractJdbcAgent {
                     }
                 }
             }
+        }
+        return result;
+    }
+
+    private Set<String> identityColumnsFromTableDdl(String schema, String table) {
+        String ddl = null;
+        String sql = "SELECT /*+ PARALLEL(1) */ DBMS_METADATA.GET_DDL(?, ?, ?) FROM DUAL";
+        try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
+            stmt.setString(1, "TABLE");
+            stmt.setString(2, table);
+            stmt.setString(3, schema);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    ddl = readTextColumn(rs, 1);
+                }
+            }
         } catch (Exception ignored) {
-            // Some Dameng versions or users do not expose SYS.SYSCOLUMNS.
+            // DBMS_METADATA is unavailable on some deployments (and on views); identity
+            // information stays unknown, which is the best this path can do.
+        }
+        return identityColumnsFromDdlText(ddl);
+    }
+
+    /**
+     * Reads the identity columns out of a {@code CREATE TABLE} statement, e.g.
+     * {@code "ID" INT IDENTITY(1, 1) NOT NULL}. Quoted names and string defaults are skipped so a
+     * column called {@code "IDENTITY"} or a default of {@code 'IDENTITY(1,1)'} is not misread.
+     */
+    static Set<String> identityColumnsFromDdlText(String ddl) {
+        Set<String> result = new java.util.HashSet<>();
+        for (String definition : splitTableDdlDefinitions(ddl)) {
+            String trimmed = definition.trim();
+            if (trimmed.isEmpty() || trimmed.charAt(0) != '"') {
+                // Table-level constraint (PRIMARY KEY(...), CHECK(...)), not a column definition.
+                continue;
+            }
+            StringBuilder name = new StringBuilder();
+            int index = 1;
+            while (index < trimmed.length()) {
+                char ch = trimmed.charAt(index);
+                if (ch == '"') {
+                    if (index + 1 < trimmed.length() && trimmed.charAt(index + 1) == '"') {
+                        name.append('"');
+                        index += 2;
+                        continue;
+                    }
+                    break;
+                }
+                name.append(ch);
+                index++;
+            }
+            if (index >= trimmed.length() || name.length() == 0) {
+                continue;
+            }
+            String rest = stripSingleQuotedLiterals(trimmed.substring(index + 1));
+            if (DDL_IDENTITY_KEYWORD_PATTERN.matcher(rest).find()) {
+                result.add(name.toString());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Splits the column list of a {@code CREATE TABLE} statement on its top-level commas, so that
+     * {@code IDENTITY(1, 1)} and {@code VARCHAR(64)} stay attached to their column.
+     */
+    private static List<String> splitTableDdlDefinitions(String ddl) {
+        List<String> definitions = new ArrayList<>();
+        if (ddl == null) {
+            return definitions;
+        }
+        StringBuilder current = new StringBuilder();
+        int depth = 0;
+        boolean inLiteral = false;
+        boolean inQuotedName = false;
+        for (int i = 0; i < ddl.length(); i++) {
+            char ch = ddl.charAt(i);
+            if (inLiteral) {
+                current.append(ch);
+                if (ch == '\'') {
+                    inLiteral = false;
+                }
+                continue;
+            }
+            if (inQuotedName) {
+                current.append(ch);
+                if (ch == '"') {
+                    inQuotedName = false;
+                }
+                continue;
+            }
+            if (ch == '\'') {
+                inLiteral = true;
+                current.append(ch);
+                continue;
+            }
+            if (ch == '"') {
+                inQuotedName = true;
+                current.append(ch);
+                continue;
+            }
+            if (ch == '(') {
+                depth++;
+                if (depth == 1) {
+                    // Opening paren of the column list; drop the CREATE TABLE prefix before it.
+                    current.setLength(0);
+                } else {
+                    current.append(ch);
+                }
+                continue;
+            }
+            if (ch == ')') {
+                depth--;
+                if (depth == 0) {
+                    addTableDdlDefinition(definitions, current);
+                    break;
+                }
+                current.append(ch);
+                continue;
+            }
+            if (ch == ',' && depth == 1) {
+                addTableDdlDefinition(definitions, current);
+                continue;
+            }
+            if (depth > 0) {
+                current.append(ch);
+            }
+        }
+        return definitions;
+    }
+
+    private static void addTableDdlDefinition(List<String> definitions, StringBuilder current) {
+        String definition = current.toString().trim();
+        current.setLength(0);
+        if (!definition.isEmpty()) {
+            definitions.add(definition);
+        }
+    }
+
+    private static String stripSingleQuotedLiterals(String text) {
+        StringBuilder out = new StringBuilder(text.length());
+        boolean inLiteral = false;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (inLiteral) {
+                if (ch == '\'') {
+                    inLiteral = false;
+                }
+                continue;
+            }
+            if (ch == '\'') {
+                inLiteral = true;
+                out.append(' ');
+                continue;
+            }
+            out.append(ch);
+        }
+        return out.toString();
+    }
+
+    private Set<String> primaryKeyColumnsFromJdbcMetadata(String schema, String table) {
+        Set<String> result = new java.util.HashSet<>();
+        try (ResultSet rs = requireConnected().getMetaData().getPrimaryKeys(null, schema, table)) {
+            while (rs.next()) {
+                String column = rs.getString("COLUMN_NAME");
+                if (notBlank(column)) {
+                    result.add(column);
+                }
+            }
+        } catch (Exception ignored) {
+            // The table is then reported without a primary key, as before this fallback existed.
         }
         return result;
     }

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -1077,6 +1077,148 @@ class DamengAgentMetadataTest {
     }
 
     @Test
+    void readsIdentityColumnsFromDdlText() {
+        Assertions.assertEquals(
+            java.util.Set.of("ID"),
+            DamengAgent.identityColumnsFromDdlText(
+                "CREATE TABLE \"DBX_TEST\".\"T\"\n(\n\"ID\" INT IDENTITY(1, 1) NOT NULL,\n"
+                    + "\"NAME\" VARCHAR(64),\nNOT CLUSTER PRIMARY KEY(\"ID\")) STORAGE(ON \"MAIN\") ;"
+            )
+        );
+    }
+
+    @Test
+    void ignoresIdentityLookalikesInDdlText() {
+        // A column *named* IDENTITY whose default merely contains the word must not be reported,
+        // and neither must a table-level constraint that mentions it.
+        Assertions.assertEquals(
+            java.util.Set.of(),
+            DamengAgent.identityColumnsFromDdlText(
+                "CREATE TABLE \"DBX_TEST\".\"T\"\n(\n\"IDENTITY\" VARCHAR(32) DEFAULT 'IDENTITY(1,1)',\n"
+                    + "\"PLAIN\" INT,\n\"IDENTITY_KIND\" VARCHAR(8)) STORAGE(ON \"MAIN\") ;"
+            )
+        );
+    }
+
+    @Test
+    void readsEveryIdentityColumnFromDdlText() {
+        Assertions.assertEquals(
+            java.util.Set.of("A", "C"),
+            DamengAgent.identityColumnsFromDdlText(
+                "CREATE TABLE \"S\".\"T\"\n(\n\"A\" BIGINT IDENTITY(1, 1),\n\"B\" VARCHAR(9),\n"
+                    + "\"C\" INT identity(100, 5) NOT NULL,\nCLUSTER PRIMARY KEY(\"A\", \"C\")) ;"
+            )
+        );
+    }
+
+    @Test
+    void toleratesDdlTextThatCannotBeParsed() {
+        Assertions.assertEquals(java.util.Set.of(), DamengAgent.identityColumnsFromDdlText(null));
+        Assertions.assertEquals(java.util.Set.of(), DamengAgent.identityColumnsFromDdlText(""));
+        Assertions.assertEquals(java.util.Set.of(), DamengAgent.identityColumnsFromDdlText("CREATE TABLE \"S\".\"T\""));
+    }
+
+    @Test
+    void fallsBackToTableDdlWhenSysColumnsIsNotReadable() {
+        // Ordinary Dameng accounts have no SELECT on SYS.SYSCOLUMNS. Without the fallback the
+        // identity column looks like a plain NOT NULL column and the grid sends its value.
+        List<String> sqls = new ArrayList<>();
+        DamengAgent agent = new DamengAgent();
+        TestSupport.setPrivateConnection(agent, restrictedAccountConnection(sqls, List.of()));
+
+        List<ColumnInfo> columns = agent.getColumns("APP", "USERS");
+
+        Assertions.assertEquals(1, columns.size());
+        Assertions.assertEquals("identity", columns.get(0).getExtra());
+        Assertions.assertTrue(
+            sqls.stream().anyMatch(sql -> sql.contains("DBMS_METADATA.GET_DDL")),
+            sqls.toString()
+        );
+    }
+
+    @Test
+    void fallsBackToJdbcPrimaryKeysWhenConstraintDictionaryIsEmpty() {
+        // ALL_CONS_COLUMNS yields no rows (not an error) for those same accounts.
+        DamengAgent agent = new DamengAgent();
+        TestSupport.setPrivateConnection(agent, restrictedAccountConnection(new ArrayList<>(), List.of()));
+
+        List<ColumnInfo> columns = agent.getColumns("APP", "USERS");
+
+        Assertions.assertEquals(1, columns.size());
+        Assertions.assertTrue(columns.get(0).getIs_primary_key());
+    }
+
+    @Test
+    void keepsPrimaryKeysFromConstraintDictionaryWhenReadable() {
+        // The JDBC fallback must not displace the dictionary answer when that one works.
+        DamengAgent agent = new DamengAgent();
+        TestSupport.setPrivateConnection(agent, restrictedAccountConnection(new ArrayList<>(), List.of(List.of("ID"))));
+
+        List<ColumnInfo> columns = agent.getColumns("APP", "USERS");
+
+        Assertions.assertTrue(columns.get(0).getIs_primary_key());
+    }
+
+    @Test
+    void doesNotReadTableDdlWhenSysColumnsIsReadableButEmpty() {
+        // A readable-but-empty SYS.SYSCOLUMNS means "no identity column" and must stay cheap.
+        List<String> sqls = new ArrayList<>();
+        DamengAgent agent = new DamengAgent();
+        TestSupport.setPrivateConnection(agent, metadataConnection(null, null, false, List.of(), sqls));
+
+        agent.getColumns("APP", "USERS");
+
+        Assertions.assertTrue(
+            sqls.stream().noneMatch(sql -> sql.contains("DBMS_METADATA.GET_DDL")),
+            sqls.toString()
+        );
+    }
+
+    /**
+     * A connection shaped like a non-DBA Dameng account: SYS.SYSCOLUMNS raises a permission error
+     * and the constraint dictionary answers with no rows, while the table DDL and the driver's own
+     * primary-key metadata both still work.
+     */
+    private static Connection restrictedAccountConnection(List<String> sqls, List<List<Object>> constraintRows) {
+        DatabaseMetaData metadata = proxy(DatabaseMetaData.class, (method, args) -> {
+            if ("getPrimaryKeys".equals(method.getName())) {
+                return metadataResultSet(List.of(List.of("ID")));
+            }
+            return defaultValue(method.getReturnType());
+        });
+        return proxy(Connection.class, (method, args) -> {
+            String name = method.getName();
+            if ("getMetaData".equals(name)) {
+                return metadata;
+            }
+            if ("prepareStatement".equals(name)) {
+                String sql = (String) args[0];
+                sqls.add(sql);
+                if (sql.contains("SYS.SYSCOLUMNS")) {
+                    return failingMetadataStatement("没有[SYSCOLUMNS]对象的查询权限");
+                }
+                if (sql.contains("DBMS_METADATA.GET_DDL")) {
+                    return metadataStatement(List.of(List.of(
+                        "CREATE TABLE \"APP\".\"USERS\"\n(\n\"ID\" INT IDENTITY(1, 1) NOT NULL)"
+                            + " STORAGE(ON \"MAIN\", CLUSTERBTR) ;"
+                    )));
+                }
+                if (sql.contains("ALL_CONS_COLUMNS")) {
+                    return metadataStatement(constraintRows);
+                }
+                if (sql.contains("ALL_TAB_COLUMNS")) {
+                    return metadataStatement(defaultColumnMetadataRows("id comment"));
+                }
+                return metadataStatement(List.of());
+            }
+            if ("close".equals(name) || "isClosed".equals(name)) {
+                return "isClosed".equals(name) ? Boolean.FALSE : null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    @Test
     void preservesCharacterLengthUnitsFromMetadata() {
         DamengAgent agent = new DamengAgent();
         TestSupport.setPrivateConnection(agent, metadataConnectionForColumns(List.of(


### PR DESCRIPTION
## 问题

达梦数据库在数据表格里插入一行，自增主键列不填提示不能为 null，填了又提示自增列不能赋值，两条路都走不通。

Fixes #7658

## 根因

`DamengAgent.identityColumns()` 通过 `SYS.SYSCOLUMNS` 判断自增列，但这张系统表默认没有授权给普通业务账号，非 DBA 账号查询会报权限错误：

```
没有[SYSCOLUMNS]对象的查询权限
```

而这个异常被 `catch (Exception ignored)` 吞掉后返回空集合，与「这张表确实没有自增列」无法区分，于是 `extra` 为 null。数据表格因此把自增主键当成普通的非空必填列：留空触发非空校验、填值则被服务端拒绝。

主键是同一类问题：`ALL_CONS_COLUMNS` / `ALL_CONSTRAINTS` 对这类账号返回 0 行且不报错，同样被当成「没有主键」。

## 修复

- 自增列：系统表查询失败时，回落到 `DBMS_METADATA.GET_DDL` 解析建表语句。查询**成功但为空**仍走原路径，不会多余地去读 DDL
- 主键：约束字典返回空时，回落到 JDBC `getPrimaryKeys()`
- 能正常读取数据字典的账号完全走原路径，行为不变

DDL 解析按括号深度切分、跳过引号标识符与字符串字面量、并用词边界匹配关键字，避免把名为 `IDENTITY` 的列或形如 `'IDENTITY(1,1)'` 的默认值误判为自增列。

## 验证

真实达梦实例（DM8 8.1.3.12、DM7 7.1.7.108）上，用 DBA 与普通权限两种账号分别验证修复前后：

| 账号 | 修复前 | 修复后 |
|---|---|---|
| 普通权限 | 自增列/主键识别失败，插入报错 | 识别正确，留空插入成功，自增值由服务端生成 |
| DBA | 正常 | 正常（无变化） |

新增 7 个单元测试，覆盖 DDL 解析（含误判防护）、两条回落路径，以及「系统表可读但为空时不触发回落」。
