### PR TITLE
✨feat(desktop): 支持固定并自动显示表信息面板

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -47,6 +47,7 @@ import {
   Eraser,
   Columns3,
   PencilRuler,
+  Pin,
   Settings2,
   WandSparkles,
   Camera,
@@ -492,6 +493,7 @@ interface DataGridProps {
     primaryKeys: string[];
   };
   tableInfoTab?: TableInfoTab;
+  autoShowTableInfo?: boolean;
   pageOffset?: number;
   pageLimit?: number;
   countSql?: string;
@@ -10995,6 +10997,8 @@ function clampCellDetailPanelSize(value: number, layout = cellDetailPanelLayout.
 // module-global leaks the drawer into other kept-alive tabs.
 const showTableInfo = ref(false);
 const activeTableInfoTab = ref<TableInfoTab>(settingsStore.editorSettings.tableInfoActiveTab);
+const canPinTableInfo = computed(() => props.context === "table-data");
+const tableInfoDrawerPinned = computed(() => settingsStore.editorSettings.tableInfoDrawerPinned);
 const ddlContent = ref("");
 const tableInfoColumns = ref<ColumnInfo[]>(props.tableMeta?.columns ?? []);
 const tableInfoColumnsLoading = ref(false);
@@ -11327,6 +11331,10 @@ async function toggleTableInfo(tab?: TableInfoTab) {
   await selectTableInfoTab(nextTab);
 }
 
+function toggleTableInfoDrawerPinned() {
+  settingsStore.updateEditorSettings({ tableInfoDrawerPinned: !tableInfoDrawerPinned.value });
+}
+
 async function selectTableInfoTab(tab: TableInfoTab) {
   const tabSupported = tableInfoTabs.value.some((item) => item.id === tab);
   const nextTab = tabSupported ? tab : tableInfoTabs.value[0]?.id;
@@ -11344,6 +11352,16 @@ watch(
   () => [props.tableInfoTab, props.connectionId, props.database, props.tableMeta?.catalog, props.tableMeta?.schema, props.tableMeta?.tableName] as const,
   ([tab]) => {
     if (tab) void selectTableInfoTab(tab);
+  },
+  { immediate: true },
+);
+
+watch(
+  () => props.autoShowTableInfo,
+  (shouldShow) => {
+    if (!shouldShow || !props.tableMeta) return;
+    showTableInfo.value = true;
+    void selectTableInfoTab(activeTableInfoTab.value);
   },
   { immediate: true },
 );
@@ -11638,6 +11656,7 @@ watch(
     if (showIndexIndicatorsInHeader.value && canShowTableIndexes.value && currentIndexTableIdentity.value) {
       void fetchIndexes();
     }
+    if (props.autoShowTableInfo && props.tableMeta) showTableInfo.value = true;
     if (showTableInfo.value) selectTableInfoTab(activeTableInfoTab.value);
     if (showTableInfo.value) void fetchTableOwner();
   },
@@ -14308,6 +14327,19 @@ function openGridSnapshot() {
               <Button v-if="canOpenTableStructureEditor" variant="ghost" size="sm" class="table-info-action-button h-6 px-2 text-xs" :title="t('contextMenu.editStructure')" :aria-label="t('contextMenu.editStructure')" @click="openTableStructureEditor">
                 <PencilRuler class="w-3 h-3" />
                 <span class="table-info-action-label">{{ t("contextMenu.editStructure") }}</span>
+              </Button>
+              <Button
+                v-if="canPinTableInfo"
+                variant="ghost"
+                size="icon"
+                class="h-5 w-5"
+                :class="{ 'bg-accent text-primary': tableInfoDrawerPinned }"
+                :title="tableInfoDrawerPinned ? t('grid.unpinTableInfo') : t('grid.pinTableInfo')"
+                :aria-label="tableInfoDrawerPinned ? t('grid.unpinTableInfo') : t('grid.pinTableInfo')"
+                :aria-pressed="tableInfoDrawerPinned"
+                @click="toggleTableInfoDrawerPinned"
+              >
+                <Pin class="w-3 h-3" :class="{ 'fill-current': tableInfoDrawerPinned }" />
               </Button>
               <Button variant="ghost" size="icon" class="h-5 w-5" @click="showTableInfo = false">
                 <X class="w-3 h-3" />

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -2291,6 +2291,7 @@ defineExpose({
           :execution-database="activeDataTabExecutionDatabase"
           :table-meta="activeDataTabTableMeta"
           :table-info-tab="activeTab.tableInfoTab"
+          :auto-show-table-info="settingsStore.editorSettings.tableInfoDrawerPinned"
           :page-offset="activeTab.resultPageOffset"
           :page-limit="activeTab.resultPageLimit"
           :total-row-count="activeTab.resultTotalRowCount"

--- a/apps/desktop/src/i18n/__tests__/tableInfoPinMessages.spec.ts
+++ b/apps/desktop/src/i18n/__tests__/tableInfoPinMessages.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import en from "../locales/en";
+import es from "../locales/es";
+import it_ from "../locales/it";
+import ja from "../locales/ja";
+import ko from "../locales/ko";
+import ptBR from "../locales/pt-BR";
+import tr from "../locales/tr";
+import zhCN from "../locales/zh-CN";
+import zhTW from "../locales/zh-TW";
+
+const locales: Array<[string, Record<string, unknown>]> = [
+  ["en", en as Record<string, unknown>],
+  ["es", es],
+  ["it", it_],
+  ["ja", ja],
+  ["ko", ko],
+  ["pt-BR", ptBR],
+  ["tr", tr],
+  ["zh-CN", zhCN],
+  ["zh-TW", zhTW],
+];
+
+function gridEntry(locale: Record<string, unknown>, key: string): unknown {
+  const grid = locale["grid"];
+  if (!grid || typeof grid !== "object") return undefined;
+  return (grid as Record<string, unknown>)[key];
+}
+
+describe("table-info pin i18n messages", () => {
+  it.each(["pinTableInfo", "unpinTableInfo"] as const)("en resolves grid.%s to text", (key) => {
+    expect(gridEntry(en as Record<string, unknown>, key), `grid.${key} missing from locales/en.ts`).toBeTypeOf("string");
+  });
+
+  it.each(locales.slice(1))("%s translates table-info pin labels instead of using the English fallback", (_name, locale) => {
+    for (const key of ["pinTableInfo", "unpinTableInfo"] as const) {
+      const value = gridEntry(locale, key);
+      expect(value, `${_name} grid.${key}`).toBeTypeOf("string");
+      expect(value).not.toBe(gridEntry(en as Record<string, unknown>, key));
+    }
+  });
+});

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2152,6 +2152,8 @@ export default {
     rowsPerPageShort: " rows",
     columnDetails: "Column Details",
     tableInfo: "Table Info",
+    pinTableInfo: "Pin table info panel",
+    unpinTableInfo: "Unpin table info panel",
     tableInfoColumns: "Columns",
     tableInfoIndexes: "Indexes",
     columnPrimaryIndex: "Primary key index",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2012,6 +2012,8 @@ export default withEnglishFallback({
     searchColumn: "Buscar columna/comentario...",
     noColumnsFound: "No se encontraron columnas",
     tableInfo: "Información de tabla",
+    pinTableInfo: "Fijar el panel de información de la tabla",
+    unpinTableInfo: "Desfijar el panel de información de la tabla",
     tableInfoColumns: "Columnas",
     tableInfoIndexes: "Índices",
     columnPrimaryIndex: "Índice de clave primaria",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -1999,6 +1999,8 @@ export default withEnglishFallback({
     rowsPerPageShort: " righe",
     columnDetails: "Dettagli Colonna",
     tableInfo: "Informazioni Tabella",
+    pinTableInfo: "Blocca il pannello delle informazioni sulla tabella",
+    unpinTableInfo: "Sblocca il pannello delle informazioni sulla tabella",
     tableInfoColumns: "Colonne",
     tableInfoIndexes: "Indici",
     columnPrimaryIndex: "Indice chiave primaria",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2011,6 +2011,8 @@ export default withEnglishFallback({
     rowsPerPageShort: " 行",
     columnDetails: "列詳細",
     tableInfo: "テーブル情報",
+    pinTableInfo: "テーブル情報パネルを固定",
+    unpinTableInfo: "テーブル情報パネルの固定を解除",
     tableInfoColumns: "列",
     tableInfoIndexes: "インデックス",
     columnPrimaryIndex: "主キーインデックス",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -1975,6 +1975,8 @@ export default withEnglishFallback({
     rowsPerPageShort: "행",
     columnDetails: "컬럼 상세",
     tableInfo: "테이블 정보",
+    pinTableInfo: "테이블 정보 패널 고정",
+    unpinTableInfo: "테이블 정보 패널 고정 해제",
     tableInfoColumns: "컬럼",
     tableInfoIndexes: "인덱스",
     columnPrimaryIndex: "기본 키 인덱스",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2001,6 +2001,8 @@ export default withEnglishFallback({
     rowsPerPageShort: " linhas",
     columnDetails: "Detalhes da Coluna",
     tableInfo: "Informações da Tabela",
+    pinTableInfo: "Fixar painel de informações da tabela",
+    unpinTableInfo: "Desafixar painel de informações da tabela",
     tableInfoColumns: "Colunas",
     tableInfoIndexes: "Índices",
     columnPrimaryIndex: "Índice de chave primária",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -2152,6 +2152,8 @@ export default withEnglishFallback({
     rowsPerPageShort: " satır",
     columnDetails: "Sütun Ayrıntıları",
     tableInfo: "Tablo Bilgisi",
+    pinTableInfo: "Tablo bilgileri panelini sabitle",
+    unpinTableInfo: "Tablo bilgileri panelinin sabitlemesini kaldır",
     tableInfoColumns: "Sütunlar",
     tableInfoIndexes: "Dizinler",
     columnPrimaryIndex: "Birincil anahtar dizini",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2076,6 +2076,8 @@ export default withEnglishFallback({
     rowsPerPageShort: " 行/页",
     columnDetails: "列详情",
     tableInfo: "表属性",
+    pinTableInfo: "固定表属性面板",
+    unpinTableInfo: "取消固定表属性面板",
     tableInfoColumns: "字段",
     tableInfoIndexes: "索引",
     columnPrimaryIndex: "主键索引",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2004,6 +2004,8 @@ export default withEnglishFallback({
     rowsPerPageShort: " 筆/頁",
     columnDetails: "欄位詳情",
     tableInfo: "資料表屬性",
+    pinTableInfo: "固定資料表屬性面板",
+    unpinTableInfo: "取消固定資料表屬性面板",
     tableInfoColumns: "欄位",
     tableInfoIndexes: "索引",
     columnPrimaryIndex: "主鍵索引",

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -23,6 +23,13 @@ describe("normalizeEditorSettings", () => {
     expect(normalizeEditorSettings({ refreshDdlOnOpen: "true" } as any).refreshDdlOnOpen).toBe(false);
   });
 
+  it("keeps table-info drawer pinning disabled unless explicitly enabled", () => {
+    expect(normalizeEditorSettings({}).tableInfoDrawerPinned).toBe(false);
+    expect(normalizeEditorSettings({ tableInfoDrawerPinned: true }).tableInfoDrawerPinned).toBe(true);
+    expect(normalizeEditorSettings({ tableInfoDrawerPinned: false }).tableInfoDrawerPinned).toBe(false);
+    expect(normalizeEditorSettings({ tableInfoDrawerPinned: "true" } as any).tableInfoDrawerPinned).toBe(false);
+  });
+
   it("enables SQL variable substitution by default and only preserves booleans", () => {
     expect(normalizeEditorSettings({}).sqlVariableSubstitutionEnabled).toBe(true);
     expect(normalizeEditorSettings({ sqlVariableSubstitutionEnabled: true }).sqlVariableSubstitutionEnabled).toBe(true);

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -760,6 +760,7 @@ export interface EditorSettings {
   tableFontSize: number;
   structureEditorDensity: StructureEditorDensity;
   tableInfoActiveTab: TableInfoTab;
+  tableInfoDrawerPinned: boolean;
   tableInfoDrawerWidth: number;
   cellDetailDrawerWidth: number;
   cellDetailPanelLayout: CellDetailPanelLayout;
@@ -988,6 +989,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   tableFontSize: TABLE_FONT_SIZE_DEFAULT,
   structureEditorDensity: "compact",
   tableInfoActiveTab: "ddl",
+  tableInfoDrawerPinned: false,
   tableInfoDrawerWidth: 320,
   cellDetailDrawerWidth: 380,
   cellDetailPanelLayout: "bottom",
@@ -1432,6 +1434,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
     tableFontSize: normalizeTableFontSize(settings.tableFontSize),
     structureEditorDensity: normalizeStructureEditorDensity(settings.structureEditorDensity),
     tableInfoActiveTab: normalizeTableInfoTab(settings.tableInfoActiveTab),
+    tableInfoDrawerPinned: settings.tableInfoDrawerPinned === true,
     tableInfoDrawerWidth: normalizeDrawerWidth(settings.tableInfoDrawerWidth, 240, DEFAULT_EDITOR_SETTINGS.tableInfoDrawerWidth),
     cellDetailDrawerWidth: normalizeDrawerWidth(settings.cellDetailDrawerWidth, 260, DEFAULT_EDITOR_SETTINGS.cellDetailDrawerWidth),
     cellDetailPanelLayout: normalizeCellDetailPanelLayout(settings.cellDetailPanelLayout),
@@ -2145,6 +2148,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.tableFontSize !== undefined) editorSettings.value.tableFontSize = normalizeTableFontSize(partial.tableFontSize);
     if (partial.structureEditorDensity !== undefined) editorSettings.value.structureEditorDensity = normalizeStructureEditorDensity(partial.structureEditorDensity);
     if (partial.tableInfoActiveTab !== undefined) editorSettings.value.tableInfoActiveTab = normalizeTableInfoTab(partial.tableInfoActiveTab);
+    if (partial.tableInfoDrawerPinned !== undefined) editorSettings.value.tableInfoDrawerPinned = partial.tableInfoDrawerPinned === true;
     if (partial.tableInfoDrawerWidth !== undefined) editorSettings.value.tableInfoDrawerWidth = normalizeDrawerWidth(partial.tableInfoDrawerWidth, 240, DEFAULT_EDITOR_SETTINGS.tableInfoDrawerWidth);
     if (partial.cellDetailDrawerWidth !== undefined) editorSettings.value.cellDetailDrawerWidth = normalizeDrawerWidth(partial.cellDetailDrawerWidth, 260, DEFAULT_EDITOR_SETTINGS.cellDetailDrawerWidth);
     if (partial.cellDetailPanelLayout !== undefined) editorSettings.value.cellDetailPanelLayout = normalizeCellDetailPanelLayout(partial.cellDetailPanelLayout);


### PR DESCRIPTION
- 新增表信息面板固定功能，并持久化用户设置
- 固定后切换数据表时自动显示表信息面板
- 增加固定与取消固定按钮的多语言文案
- 补充设置规范化及多语言文案测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

表属性界面增加固定按钮，切换表，页面内容随之切换

<img width="323" height="295" alt="image" src="https://github.com/user-attachments/assets/0bdb07c0-2792-497c-8b92-45fb21708f48" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #8178