### PR TITLE
fix(grid): 统一查询结果导出图标语义

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -8,6 +8,7 @@ import {
   ArrowUpRight,
   ExternalLink,
   Download,
+  Upload,
   FileUp,
   Trash2,
   ChevronDown,
@@ -12481,7 +12482,7 @@ function exportSubmenu(): ContextMenuItem {
       { label: t("grid.exportSelectedRowsTxt"), action: exportSelectedRowsTxt },
     );
   }
-  return { label: t("grid.export"), icon: Download, children: items };
+  return { label: t("grid.export"), icon: Upload, children: items };
 }
 
 const gridContextMenuItems = computed<ContextMenuItem[]>(() => {

--- a/apps/desktop/src/components/grid/DataGridExportMenu.vue
+++ b/apps/desktop/src/components/grid/DataGridExportMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Download } from "@lucide/vue";
+import { Upload } from "@lucide/vue";
 import LightDropdown, { type LightDropdownItem } from "@/components/ui/LightDropdown.vue";
 
 defineProps<{
@@ -14,7 +14,7 @@ defineProps<{
     model-value=""
     :items="items"
     :aria-label="label"
-    :trigger-icon="Download"
+    :trigger-icon="Upload"
     :trigger-label="label"
     trigger-class="inline-flex h-6 shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-md px-2 text-foreground/80 hover:bg-accent hover:text-accent-foreground"
     trigger-icon-class="h-3.5 w-3.5"

--- a/apps/desktop/src/components/grid/DataGridToolbar.vue
+++ b/apps/desktop/src/components/grid/DataGridToolbar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { Check, ChevronDown, Copy, Download, Eye, Loader2, Map, Plus, RefreshCcw, RotateCcw, Rows3, Save, TableProperties, Timer, Trash2 } from "@lucide/vue";
+import { Check, ChevronDown, Copy, Eye, Loader2, Map, Plus, RefreshCcw, RotateCcw, Rows3, Save, TableProperties, Timer, Trash2, Upload } from "@lucide/vue";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -196,7 +196,7 @@ function actionLabelClass(action: DataGridToolbarActionKey) {
         <TooltipTrigger as-child>
           <DropdownMenuTrigger as-child>
             <Button data-toolbar-action="exportData" variant="ghost" size="sm" :class="actionButtonClass('exportData')" :disabled="exportData?.disabled || !exportData?.items.length">
-              <Download class="data-grid-topbar-action-icon h-3 w-3" />
+              <Upload class="data-grid-topbar-action-icon h-3 w-3" />
               <span class="data-grid-topbar-action-label" :class="actionLabelClass('exportData')">{{ exportData?.label }}</span>
             </Button>
           </DropdownMenuTrigger>

--- a/packages/app-tests/queryResultToolbar.test.ts
+++ b/packages/app-tests/queryResultToolbar.test.ts
@@ -6,7 +6,9 @@ import { compileScript, compileTemplate, parse } from "vue/compiler-sfc";
 const contentAreaPath = "apps/desktop/src/components/layout/ContentArea.vue";
 const appPath = "apps/desktop/src/App.vue";
 const dataGridPath = "apps/desktop/src/components/grid/DataGrid.vue";
+const dataGridExportMenuPath = "apps/desktop/src/components/grid/DataGridExportMenu.vue";
 const dataGridToolbarPath = "apps/desktop/src/components/grid/DataGridToolbar.vue";
+const editorToolbarPath = "apps/desktop/src/components/layout/EditorToolbar.vue";
 const viewSwitcherPath = "apps/desktop/src/components/layout/QueryResultViewSwitcher.vue";
 const toolbarActionsPath = "apps/desktop/src/components/layout/QueryResultToolbarActions.vue";
 
@@ -26,7 +28,7 @@ function assertSfcCompiles(path: string): void {
 }
 
 test("query result toolbar SFCs compile", () => {
-  for (const path of [contentAreaPath, dataGridPath, dataGridToolbarPath, viewSwitcherPath, toolbarActionsPath]) assertSfcCompiles(path);
+  for (const path of [contentAreaPath, dataGridPath, dataGridExportMenuPath, dataGridToolbarPath, editorToolbarPath, viewSwitcherPath, toolbarActionsPath]) assertSfcCompiles(path);
 });
 
 test("ContentArea keeps query-result insert and delete capabilities separate", () => {
@@ -38,6 +40,10 @@ test("ContentArea keeps query-result insert and delete capabilities separate", (
 
 test("query result toolbar reuses the production icon contract", () => {
   const contentArea = source(contentAreaPath);
+  const dataGrid = source(dataGridPath);
+  const dataGridExportMenu = source(dataGridExportMenuPath);
+  const dataGridToolbar = source(dataGridToolbarPath);
+  const editorToolbar = source(editorToolbarPath);
   const viewSwitcher = source(viewSwitcherPath);
   const toolbarActions = source(toolbarActionsPath);
 
@@ -46,6 +52,11 @@ test("query result toolbar reuses the production icon contract", () => {
   assert.match(contentArea, /<ChevronDown class="h-3\.5 w-3\.5"/);
   assert.match(viewSwitcher, /import \{ BarChart3, ListChecks, MessageSquareText \} from "@lucide\/vue"/);
   assert.match(toolbarActions, /import \{ GitBranch, Gauge, Loader2, Upload \} from "@lucide\/vue"/);
+  assert.match(editorToolbar, /@click="emit\('importResultArchive'\)"[\s\S]{0,100}<Download/);
+  assert.match(toolbarActions, /@click="emit\('exportArchive'\)"[\s\S]{0,200}<Upload v-else/);
+  assert.match(dataGrid, /return \{ label: t\("grid\.export"\), icon: Upload, children: items \};/);
+  assert.match(dataGridExportMenu, /:trigger-icon="Upload"/);
+  assert.match(dataGridToolbar, /<Upload class="data-grid-topbar-action-icon h-3 w-3"/);
   assert.match(viewSwitcher, /inline-flex h-4 items-center leading-none/);
   assert.match(toolbarActions, /block h-3\.5 w-3\.5 self-center/);
   assert.doesNotMatch(viewSwitcher + toolbarActions, /<svg\b|<symbol\b|<use\b/);


### PR DESCRIPTION
## 问题

SQL 编辑器同一界面中，“导入结果归档”和普通“导出”都使用向下图标，而“保存结果归档”使用向上图标，导致相反动作的视觉语义混用。

![导入、保存结果归档与普通导出图标语义不一致](https://raw.githubusercontent.com/DASungta/dbx/pr-assets-8274/.github/pr-assets/8274/query-export-icon-consistency.png)

## 排查

- 检索历史 Issue，#2392、#2468、#651 均反馈过同类问题，目前没有仍开放的直接相关 Issue。
- #2724 已确立“以 DBX 为容器”的约定：导入使用 `Download`，导出使用 `Upload`。
- 继续追踪代码历史，确认 DataGrid 的导出图标在后续改动中又变回了 `Download`，与结果归档及其他导出入口不一致。

## 修复

- DataGrid 分页栏、工具栏和右键菜单的导出入口统一使用 `Upload`。
- 真正的文件下载动作继续使用 `Download`。
- 增加回归断言，覆盖截图中的导入、保存结果归档和普通导出入口。

## 验证

- `pnpm exec vitest run packages/app-tests/queryResultToolbar.test.ts`：18 tests passed
- `pnpm -s typecheck`
- `git diff --check`

Related #2392
