### PR TITLE
fix(postgres): 存储过程含 DEFAULT 参数时查看 DDL 报 Object source not found

### DIFF
--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -8477,6 +8477,37 @@ fn opengauss_sequence_object_source_sql(schema: &str, name: &str, include_cache:
     )
 }
 
+/// Servers without `pg_get_function_identity_arguments` (Redshift-compatible,
+/// some legacy PostgreSQL forks like TBase) have their object *list* signature
+/// built with the older `pg_get_function_arguments` formatter instead, which
+/// includes `DEFAULT ...` clauses for parameters with default values. Matching
+/// that signature against `pg_get_function_identity_arguments` (which never
+/// includes `DEFAULT` clauses) then always misses for routines with default
+/// parameters. This mirrors the signature filter but uses the same legacy
+/// formatter so it matches what the list query actually produced.
+fn postgres_function_object_source_sql_with_legacy_signature(
+    schema: &str,
+    name: &str,
+    kind: &db::ObjectSourceKind,
+    signature: Option<&str>,
+) -> String {
+    let prokind = if matches!(kind, db::ObjectSourceKind::Procedure) { "p" } else { "f" };
+    let signature_filter = signature
+        .map(|value| format!(" AND pg_get_function_arguments(p.oid) = {}", sql_string(value)))
+        .unwrap_or_default();
+    format!(
+        "SELECT pg_get_functiondef(p.oid) \
+         FROM pg_proc p \
+         JOIN pg_namespace n ON n.oid = p.pronamespace \
+         WHERE n.nspname = {} AND p.proname = {} AND p.prokind = '{}'{} \
+         ORDER BY p.oid LIMIT 1",
+        sql_string(schema),
+        sql_string(name),
+        prokind,
+        signature_filter
+    )
+}
+
 fn postgres_function_object_source_sql_without_prokind(
     schema: &str,
     name: &str,
@@ -9609,6 +9640,19 @@ async fn postgres_object_source(
                 .and_then(first_string_cell)
                 .map_err(|fallback_err| format!("{primary_err}; prokind fallback failed: {fallback_err}"))
         }
+        Err(primary_err)
+            if !unwrap_opengauss_record
+                && primary_err == "Object source not found"
+                && signature.is_some()
+                && matches!(object_type, db::ObjectSourceKind::Procedure | db::ObjectSourceKind::Function) =>
+        {
+            let fallback_sql =
+                postgres_function_object_source_sql_with_legacy_signature(schema, name, object_type, signature);
+            db::postgres::execute_query(pool, &fallback_sql)
+                .await
+                .and_then(first_string_cell)
+                .map_err(|fallback_err| format!("{primary_err}; legacy signature fallback failed: {fallback_err}"))
+        }
         Err(primary_err) if matches!(object_type, db::ObjectSourceKind::View) => {
             let fallback_sql = postgres_view_source_fallback_sql_inner(schema, name, isolate_view_search_path);
             db::postgres::execute_query(pool, &fallback_sql)
@@ -9712,6 +9756,16 @@ mod object_source_tests {
         assert_eq!(
             postgres_object_source_sql("public", "recalc_score", &ObjectSourceKind::Function, Some("integer, integer")),
             "SELECT pg_get_functiondef(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'recalc_score' AND p.prokind = 'f' AND pg_get_function_identity_arguments(p.oid) = 'integer, integer' ORDER BY p.oid LIMIT 1"
+        );
+
+        assert_eq!(
+            postgres_function_object_source_sql_with_legacy_signature(
+                "public",
+                "recalc_score",
+                &ObjectSourceKind::Procedure,
+                Some("i_id numeric DEFAULT 0, OUT o_code integer"),
+            ),
+            "SELECT pg_get_functiondef(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'public' AND p.proname = 'recalc_score' AND p.prokind = 'p' AND pg_get_function_arguments(p.oid) = 'i_id numeric DEFAULT 0, OUT o_code integer' ORDER BY p.oid LIMIT 1"
         );
 
         let opengauss_view_sql = opengauss_object_source_sql("public", "active_users", &ObjectSourceKind::View, None);


### PR DESCRIPTION
## 问题

在探测不到 `pg_get_function_identity_arguments`（真实发生在腾讯 TBase 10.23 等兼容分支）的 PostgreSQL 兼容服务器上，对象列表查询会退回用 `pg_get_function_arguments` 生成签名——该函数会包含参数的 `DEFAULT ...` 子句。而查看存储过程/函数 DDL 时无条件用 `pg_get_function_identity_arguments` 做签名匹配——该函数不包含 `DEFAULT` 子句。只要routine 带默认参数，两侧签名格式永远对不上，查询返回 0 行，报错 `Object source not found`。

## 修复

新增 `postgres_function_object_source_sql_with_legacy_signature()`，构造与对象列表 legacy 兼容模式一致（`pg_get_function_arguments`）的签名过滤条件；在 `postgres_object_source()` 中新增一条窄范围 fallback：仅当非 openGauss 家族、类型为 Function/Procedure、带 signature、且主查询恰好报 `"Object source not found"` 时，用该 legacy 签名查询重试一次。不影响 View/Sequence/Trigger、不影响 openGauss 已有 fallback 链、不影响任何现有成功路径。

## 复现与验证

共享测试环境是原生 PostgreSQL（探测器返回真，走不到 legacy 分支），本机也没有可用的 TBase 实例，因此复现分两步、均为真实数据库 + 真实运行的应用：

1. 在真实 PostgreSQL 上创建一个带 `DEFAULT` 参数的存储过程，验证 `pg_get_function_arguments`（含 `DEFAULT 0`）与 `pg_get_function_identity_arguments`（不含）确实不同——根因坐实。
2. 用真实运行的 `cargo run -p dbx-web` 后端 + 真实网络请求，手工传入该库里真实存在的 legacy 格式签名值（模拟探针失败后前端本应传入的值）：

- 修复前：`GET /api/schema/object-source?...&signature=IN i_id numeric, IN i_page numeric DEFAULT 0` → `HTTP 500 {"detail":"Object source not found"}`，与 issue 描述完全一致。
- 修复后：同一请求 → `HTTP 200`，正确返回 `CREATE OR REPLACE PROCEDURE ...` DDL。
- 回归：不带 signature 的正常路径、以及无默认参数存储过程的正常 identity_arguments 签名路径，均验证仍正常返回，未受影响。
- `cargo test -p dbx-core --lib schema::`：184/184 通过（含新增 1 条针对 legacy 签名 SQL 构造的单测）。
- `cargo clippy -p dbx-core --lib -- -D warnings`：干净。
- `cargo fmt --check -p dbx-core`：改动文件无格式问题。

Fixes #8279

🤖 Generated with [Claude Code](https://claude.com/claude-code)