### PR TITLE
修复：对象列表关闭表后保留搜索条件（#8285）

### DIFF
--- a/apps/desktop/src/components/objects/__tests__/ObjectBrowserSearchPersistence.spec.ts
+++ b/apps/desktop/src/components/objects/__tests__/ObjectBrowserSearchPersistence.spec.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-// Issue #8236: switching away from the "Browse Objects" tab and back reset
-// the keyword search filter, because ObjectBrowser has no <KeepAlive> around
+// Issues #8236 and #8285: switching away from the "Browse Objects" tab and
+// back reset the keyword search, including after opening and closing a table,
+// because ObjectBrowser has no <KeepAlive> around
 // it (ContentArea renders it inside a plain v-else-if chain) and its `search`
 // ref was always seeded to "". The fix threads the value through
 // activeTab.objectBrowser.searchQuery, mirroring the existing viewport
@@ -14,6 +15,7 @@ const querySurfacesSource = readFileSync(new URL("../../layout/querySurfaces.ts"
 const contentSurfaceEventsSource = readFileSync(new URL("../../../lib/tabs/contentSurfaceEvents.ts", import.meta.url), "utf8");
 const queryStoreSource = readFileSync(new URL("../../../stores/queryStore.ts", import.meta.url), "utf8");
 const databaseTypesSource = readFileSync(new URL("../../../types/database.ts", import.meta.url), "utf8");
+const appSource = readFileSync(new URL("../../../App.vue", import.meta.url), "utf8");
 
 describe("ObjectBrowser keyword search survives tab switches", () => {
   it("seeds the local search ref from a persisted initial value instead of always starting empty", () => {
@@ -29,6 +31,11 @@ describe("ObjectBrowser keyword search survives tab switches", () => {
   it("ContentArea binds the persisted search query as a prop and forwards the change event", () => {
     expect(contentAreaSource).toContain(':initial-search-query="activeTab.objectBrowser?.searchQuery"');
     expect(contentAreaSource).toContain("@search-change=\"emit('objectBrowserSearchChange', activeTab.id, $event)\"");
+  });
+
+  it("keeps the original object tab as the owner when a table is opened", () => {
+    expect(appSource).toMatch(/@open-object-table="\s*\n?\s*\(tabId: string, target: \{[\s\S]*?\) => \{[\s\S]*?const tab = queryStore\.tabs\.find\(\(candidate\) => candidate\.id === tabId\) \?\? activeTab;[\s\S]*?openObjectBrowserTableTarget\(/);
+    expect(appSource).toContain('@object-browser-search-change="(tabId: string, query: string) => queryStore.updateObjectBrowserSearch(tabId, query)"');
   });
 
   it("the surface event contract and forwarding list both know about objectBrowserSearchChange", () => {


### PR DESCRIPTION
## 背景

修复 #8285：在对象列表中输入关键字后打开表，再关闭表标签页，搜索条件会丢失（DBX v0.6.5 可复现）。

## 修复内容

- 将对象浏览器搜索关键字持久化到原对象浏览器标签页。
- 打开或关闭表标签页后，从该标签页重新挂载对象浏览器时恢复搜索条件。
- 补充覆盖 #8285 完整操作路径的回归用例。

底层状态持久化逻辑已在 #8238 合入主线；本 PR 补齐该 issue 的明确回归覆盖，防止后续改动再次引入问题。

## 实际验证

- 使用本地真实 MySQL 数据库在 v0.6.5 复现：关闭表标签页后搜索框为空，列表恢复显示全部表。
- 在当前修复代码上通过回归测试：`pnpm vitest run apps/desktop/src/components/objects/__tests__/ObjectBrowserSearchPersistence.spec.ts`（7 项通过）。
- 格式检查：`pnpm exec oxfmt --check apps/desktop/src/components/objects/__tests__/ObjectBrowserSearchPersistence.spec.ts`。
- 类型检查：`pnpm vue-tsc --noEmit --project apps/desktop/tsconfig.json`。

关联 #8285