### PR TITLE
fix(desktop): restore query tab cursor position

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -6730,6 +6730,7 @@ watch([() => props.tabId, () => props.modelValue], ([tabId, val], [prevTabId]) =
   if (!view.value) return;
   if (tabId !== prevTabId) {
     activateTabDocument(prevTabId, tabId, val);
+    if (props.autoFocus) restoreEditorFocus();
     return;
   }
   if (val !== view.value.state.doc.toString()) {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
@@ -47,6 +47,10 @@ describe("QueryEditor auto focus wiring", () => {
   it("enables auto focus for query tabs", () => {
     expect(contentAreaSource).toMatch(/<QueryEditor[\s\S]*?:\s*auto-focus="autoFocus !== false"\s[\s\S]*?:model-value="activeTab\.sql"/);
   });
+
+  it("restores focus when the active query tab changes", () => {
+    expect(queryEditorSource).toMatch(/if \(tabId !== prevTabId\) \{[\s\S]*?activateTabDocument\(prevTabId, tabId, val\);[\s\S]*?if \(props\.autoFocus\) restoreEditorFocus\(\);/);
+  });
 });
 
 describe("QueryEditor toolbar focus", () => {


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

- 切换标签自动聚焦光标，聚焦光标记住上次点击位置

<img width="788" height="410" alt="A51247CE-1056-422D-85E9-C9A0E12E6CE9" src="https://github.com/user-attachments/assets/3e16c7a6-86d8-4be6-a69f-66571c8efb34" />


<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #8311