### PR TITLE
Fix：切换标签页后保留对象浏览器搜索条件

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -3591,6 +3591,7 @@ onUnmounted(() => {
                       }
                     "
                     @object-schema-change="(tabId: string, schema: string | undefined) => queryStore.updateSchema(tabId, schema)"
+                    @object-browser-search-change="(tabId: string, search: string) => queryStore.updateObjectBrowserSearch(tabId, search)"
                     @object-browser-viewport-change="(tabId: string, viewport: any) => queryStore.updateObjectBrowserViewport(tabId, viewport)"
                     @structure-editor-saved="
                       (tabId: string, commentChanged: boolean) => {

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -2495,9 +2495,11 @@ defineExpose({
           :initial-event-open-request-id="activeTab.objectBrowser?.eventOpenRequestId"
           :initial-event-create-request-id="activeTab.objectBrowser?.eventCreateRequestId"
           :initial-object-filter="activeTab.objectBrowser?.initialObjectFilter"
+          :search="activeTab.objectBrowser?.search"
           :viewport="activeTab.objectBrowser?.viewport"
           @open-table="emit('openObjectTable', activeTab.id, $event)"
           @schema-change="emit('objectSchemaChange', activeTab.id, $event)"
+          @search-change="emit('objectBrowserSearchChange', activeTab.id, $event)"
           @viewport-change="emit('objectBrowserViewportChange', activeTab.id, $event)"
         />
       </div>

--- a/apps/desktop/src/components/layout/querySurfaces.ts
+++ b/apps/desktop/src/components/layout/querySurfaces.ts
@@ -87,6 +87,7 @@ export interface ContentAreaSurfaceEmits {
   openObjectSource: [tabId: string, target: SqlObjectNavigationTarget, initialEditing: boolean];
   openObjectTable: [tabId: string, target: { tableName: string; schema?: string; tableType?: string; catalog?: string }];
   objectSchemaChange: [tabId: string, schema: string | undefined];
+  objectBrowserSearchChange: [tabId: string, search: string];
   objectBrowserViewportChange: [tabId: string, viewport: ObjectBrowserViewport];
   structureEditorSaved: [tabId: string, commentChanged: boolean];
   structureEditorClose: [tabId: string];

--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -176,12 +176,14 @@ const props = defineProps<{
   /** 显式"新建事件"请求号：每次菜单点击递增，用于打开/重新进入 CREATE 编辑器 */
   initialEventCreateRequestId?: number;
   initialObjectFilter?: "tables" | "events";
+  search?: string;
   viewport?: ObjectBrowserViewport;
 }>();
 
 const emit = defineEmits<{
   openTable: [target: { tableName: string; schema?: string; tableType?: string; catalog?: string }];
   schemaChange: [schema: string | undefined];
+  searchChange: [search: string];
   viewportChange: [viewport: ObjectBrowserViewport];
 }>();
 
@@ -200,7 +202,7 @@ const schemas = ref<string[]>([]);
 const selectedSchema = ref<string | undefined>(props.schema);
 const rows = ref<ObjectBrowserRow[]>([]);
 const rootRef = ref<HTMLElement>();
-const search = ref("");
+const search = ref(props.search || "");
 const objectFilter = ref<ObjectFilter>("all");
 const userHasSelectedFilter = ref(false);
 const sortKey = ref<ObjectBrowserSortKey>("name");
@@ -535,6 +537,7 @@ watch([sortKey, sortDirection], () => scrollObjectsToTop());
 // Also jump to the top when the search query or object-type filter changes —
 // filtered results bear no relation to the previous scroll position.
 watch(search, () => scrollObjectsToTop());
+watch(search, (value) => emit("searchChange", value));
 watch(objectFilter, () => {
   if (preserveObjectFilterScrollOnce) {
     preserveObjectFilterScrollOnce = false;

--- a/apps/desktop/src/lib/tabs/contentSurfaceEvents.ts
+++ b/apps/desktop/src/lib/tabs/contentSurfaceEvents.ts
@@ -33,6 +33,7 @@ export const contentSurfaceEventNames = [
   "openObjectSource",
   "openObjectTable",
   "objectSchemaChange",
+  "objectBrowserSearchChange",
   "objectBrowserViewportChange",
   "structureEditorSaved",
   "structureEditorClose",

--- a/apps/desktop/src/stores/__tests__/queryStore.database-open.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.database-open.spec.ts
@@ -80,19 +80,27 @@ describe("queryStore database open state", () => {
     expect(store.tabs.filter((tab) => tab.mode === "dolt-version-control")).toHaveLength(2);
   });
 
-  it("keeps object browser viewport per tab and clears it on schema change", async () => {
+  it("keeps object browser search and viewport per tab and clears them on schema change", async () => {
     const { useQueryStore } = await import("@/stores/queryStore");
     const store = useQueryStore();
 
     const tabId = store.openObjectBrowser("pg-1", "app", "public");
+    store.updateObjectBrowserSearch(tabId, "orders");
     store.updateObjectBrowserViewport(tabId, { scrollTop: 340, viewMode: "list" });
 
     const tab = store.tabs.find((item) => item.id === tabId);
+    expect(tab?.objectBrowser?.search).toBe("orders");
     expect(tab?.objectBrowser?.viewport).toEqual({ scrollTop: 340, viewMode: "list" });
+
+    const otherTabId = store.createTab("pg-1", "app", "query");
+    store.switchTab(otherTabId);
+    store.switchTab(tabId);
+    expect(store.tabs.find((item) => item.id === tabId)?.objectBrowser?.search).toBe("orders");
 
     store.updateSchema(tabId, "archive");
 
     expect(tab?.objectBrowser?.schema).toBe("archive");
+    expect(tab?.objectBrowser?.search).toBeUndefined();
     expect(tab?.objectBrowser?.viewport).toBeUndefined();
   });
 

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -4068,6 +4068,13 @@ export const useQueryStore = defineStore("query", () => {
     queueSavedSqlEditorPositionPersist(tab);
   }
 
+  function updateObjectBrowserSearch(id: string, search: string) {
+    const tab = tabs.value.find((t) => t.id === id);
+    if (!tab || tab.mode !== "objects") return;
+    if (tab.objectBrowser?.search === search) return;
+    tab.objectBrowser = { ...tab.objectBrowser, search };
+  }
+
   function updateObjectBrowserViewport(id: string, viewport: ObjectBrowserViewport) {
     const tab = tabs.value.find((t) => t.id === id);
     if (!tab || tab.mode !== "objects") return;
@@ -4320,7 +4327,7 @@ export const useQueryStore = defineStore("query", () => {
       clearExplain(tab);
     }
     tab.schema = schema;
-    if (tab.mode === "objects") tab.objectBrowser = { ...tab.objectBrowser, schema, viewport: undefined };
+    if (tab.mode === "objects") tab.objectBrowser = { ...tab.objectBrowser, schema, search: undefined, viewport: undefined };
     persistSavedSqlExecutionTarget(tab, options);
   }
 
@@ -7703,6 +7710,7 @@ export const useQueryStore = defineStore("query", () => {
     updateDataGridHiddenColumnKeys,
     updateEditorViewport,
     updateEditorSelection,
+    updateObjectBrowserSearch,
     updateObjectBrowserViewport,
     updateNacosConfigEditorViewport,
     setAutoCommit,

--- a/apps/desktop/src/types/database.ts
+++ b/apps/desktop/src/types/database.ts
@@ -1291,6 +1291,7 @@ export interface QueryTab {
     /** 显式的"新建事件"请求：单调递增，用于让已复用 tab 也能重复进入 CREATE 编辑器 */
     eventCreateRequestId?: number;
     initialObjectFilter?: "tables" | "events";
+    search?: string;
     viewport?: ObjectBrowserViewport;
   };
   objectSource?: {


### PR DESCRIPTION
## 问题

在对象浏览器中输入表名搜索后，切换到其他标签页再切回来，组件重新挂载会将搜索条件重置为空。

## 修改

- 将对象浏览器搜索词保存到对应的 QueryTab 状态
- 切回标签页时恢复该标签页的搜索条件
- 切换 schema 时清除旧 schema 的搜索条件和滚动位置
- 将搜索状态接入当前统一内容区事件转发链路
- 增加标签页切换及 schema 切换的回归测试

## 验证

- `pnpm exec vitest run apps/desktop/src/stores/__tests__/queryStore.database-open.spec.ts`（17 tests passed）
- `pnpm typecheck`
- `pnpm exec oxfmt --check`（本次涉及的 8 个文件）

Fixes #8320