### PR TITLE
feat: 数据库备份遵循连接查询超时

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -3744,6 +3744,10 @@ onUnmounted(() => {
             setConnectionDialogOpen(false);
             openSettings('tunnels');
           "
+          @open-connection-settings="
+            setConnectionDialogOpen(false);
+            openConnectionSettings($event, 'advanced');
+          "
           @open-lineage-target="openLineageTarget"
           @open-database-search-target="openDatabaseSearchTarget"
           @open-diagram-target="openDiagramTarget"

--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -17,8 +17,9 @@ import { buildSelectedTablesPayload, isDatabaseExportTableSelectionValid } from 
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { useToast } from "@/composables/useToast";
 import { Input } from "@/components/ui/input";
-import { Download, Square, CheckSquare, Search, X, Loader2 } from "@lucide/vue";
+import { Download, Square, CheckSquare, Search, X, Loader2, Wrench } from "@lucide/vue";
 import { formatDataTransferDuration, useExportTracker } from "@/composables/useExportTracker";
+import { isQueryTimeoutErrorMessage } from "@/lib/sql/queryError";
 
 const { t } = useI18n();
 const { toast } = useToast();
@@ -33,6 +34,10 @@ const props = defineProps<{
   prefillTable?: string;
   prefillTables?: string[];
   prefillAllDatabases?: boolean;
+}>();
+
+const emit = defineEmits<{
+  openConnectionSettings: [connectionId: string];
 }>();
 
 // Connection / Database / Schema selectors
@@ -72,6 +77,7 @@ const exportProgress = ref<ExportProgress | null>(null);
 const exportId = ref("");
 const exportDone = ref(false);
 const exportError = ref<string | null>(null);
+const exportWarning = ref<string | null>(null);
 const exportCancelled = ref(false);
 const exportStartedAt = ref<number | null>(null);
 const exportFinishedAt = ref<number | null>(null);
@@ -162,6 +168,12 @@ function toastDatabaseExportCompletion(errorCount: number, errorSummary: string 
   }
   toast(t("databaseExport.exportSuccess"), 3000);
 }
+
+const canChangeQueryTimeout = computed(() =>
+  !!connectionId.value &&
+  !!exportWarning.value &&
+  isQueryTimeoutErrorMessage(exportWarning.value),
+);
 
 async function loadDatabases(connId: string) {
   if (!connId) return;
@@ -334,6 +346,7 @@ async function startExport() {
   exportFinishedAt.value = null;
   exportDone.value = false;
   exportError.value = null;
+  exportWarning.value = null;
   exportCancelled.value = false;
   exportProgress.value = {
     exportId: exportId.value,
@@ -380,11 +393,13 @@ async function startExport() {
           if (progress.status === "Done") {
             finishExportTiming();
             exportDone.value = true;
+            exportWarning.value = progress.errorSummary ?? null;
             isExporting.value = false;
             toastDatabaseExportCompletion(progress.errorCount ?? 0, progress.errorSummary ?? null);
           } else if (progress.status === "Error") {
             finishExportTiming();
             exportError.value = progress.error;
+            exportWarning.value = null;
             isExporting.value = false;
           } else if (progress.status === "Cancelled") {
             finishExportTiming();
@@ -397,6 +412,7 @@ async function startExport() {
     );
   } catch (e: any) {
     exportError.value = e?.message || String(e);
+    exportWarning.value = null;
     const lastProgress = exportProgress.value as api.ExportProgress | null;
     const fallbackProgress: api.ExportProgress = {
       exportId: exportId.value,
@@ -440,6 +456,7 @@ async function startAllDatabasesExport() {
   exportFinishedAt.value = null;
   exportDone.value = false;
   exportError.value = null;
+  exportWarning.value = null;
   exportCancelled.value = false;
   batchDatabaseIndex.value = 0;
   batchRowsExported.value = 0;
@@ -532,6 +549,7 @@ async function startAllDatabasesExport() {
               if (progress.status === "Error") {
                 finishExportTiming();
                 exportError.value = progress.error;
+                exportWarning.value = null;
                 isExporting.value = false;
               } else if (progress.status === "Cancelled") {
                 finishExportTiming();
@@ -551,6 +569,7 @@ async function startAllDatabasesExport() {
 
     if (!exportError.value && !exportCancelled.value) {
       exportDone.value = true;
+      exportWarning.value = batchFirstErrorSummary;
       finishExportTiming();
       isExporting.value = false;
       const finalProgress: api.ExportProgress = {
@@ -575,6 +594,7 @@ async function startAllDatabasesExport() {
     }
   } catch (e: any) {
     exportError.value = e?.message || String(e);
+    exportWarning.value = null;
     updateDatabaseExportTask(batchId, {
       exportId: batchId,
       currentObject: t("databaseExport.allDatabasesTask", { count: dbs.length }),
@@ -629,6 +649,7 @@ function resetState() {
   exportProgress.value = null;
   exportDone.value = false;
   exportError.value = null;
+  exportWarning.value = null;
   exportCancelled.value = false;
   exportStartedAt.value = null;
   exportFinishedAt.value = null;
@@ -939,6 +960,15 @@ watch(
           <!-- Status messages -->
           <div v-if="exportDone" class="text-xs text-green-600 font-medium">
             {{ t("databaseExport.exportSuccess") }}
+          </div>
+          <div v-if="exportDone && exportWarning" class="space-y-2">
+            <div class="whitespace-pre-wrap break-words text-xs text-amber-600 dark:text-amber-400">
+              {{ exportWarning }}
+            </div>
+            <Button v-if="canChangeQueryTimeout" variant="outline" size="sm" @click="emit('openConnectionSettings', connectionId)">
+              <Wrench class="mr-1 h-3.5 w-3.5" />
+              {{ t("editor.changeQueryTimeout") }}
+            </Button>
           </div>
           <div v-else-if="exportError" class="text-xs text-destructive font-medium">
             {{ t("databaseExport.exportError", { error: exportError }) }}

--- a/apps/desktop/src/components/export/DatabaseExportDialog.vue
+++ b/apps/desktop/src/components/export/DatabaseExportDialog.vue
@@ -169,11 +169,7 @@ function toastDatabaseExportCompletion(errorCount: number, errorSummary: string 
   toast(t("databaseExport.exportSuccess"), 3000);
 }
 
-const canChangeQueryTimeout = computed(() =>
-  !!connectionId.value &&
-  !!exportWarning.value &&
-  isQueryTimeoutErrorMessage(exportWarning.value),
-);
+const canChangeQueryTimeout = computed(() => !!connectionId.value && !!exportWarning.value && isQueryTimeoutErrorMessage(exportWarning.value));
 
 async function loadDatabases(connId: string) {
   if (!connId) return;

--- a/apps/desktop/src/components/layout/AppDialogs.vue
+++ b/apps/desktop/src/components/layout/AppDialogs.vue
@@ -59,6 +59,7 @@ const emit = defineEmits<{
   connectFailed: [message: string];
   openDriverStore: [focus?: DriverStoreFocus];
   openTunnelProfileSettings: [];
+  openConnectionSettings: [connectionId: string, initialTab: "advanced"];
   openLineageTarget: [
     target: {
       connectionId: string;
@@ -319,6 +320,7 @@ watch(
     :prefill-table="dialogs.databaseExportPrefillTable.value"
     :prefill-tables="dialogs.databaseExportPrefillTables.value"
     :prefill-all-databases="dialogs.databaseExportAllDatabases.value"
+    @open-connection-settings="emit('openConnectionSettings', $event, 'advanced')"
   />
   <ConfigConnectionSelectDialog
     v-if="dialogs.showConfigConnectionSelectDialog.value"

--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -34,6 +34,30 @@ pub fn database_export_client_session_id(export_id: &str) -> String {
     task_client_session_id("database-export", export_id)
 }
 
+async fn database_export_query_options(
+    state: &crate::connection::AppState,
+    connection_id: &str,
+    client_session_id: &str,
+    max_rows: Option<usize>,
+) -> crate::query::QueryExecutionOptions {
+    let timeout_secs =
+        state.configs.read().await.get(connection_id).map(|config| config.effective_query_timeout_secs()).unwrap_or(0);
+    database_export_query_options_for_timeout(timeout_secs, client_session_id, max_rows)
+}
+
+fn database_export_query_options_for_timeout(
+    timeout_secs: u64,
+    client_session_id: &str,
+    max_rows: Option<usize>,
+) -> crate::query::QueryExecutionOptions {
+    crate::query::QueryExecutionOptions {
+        max_rows,
+        timeout_secs: Some(timeout_secs),
+        client_session_id: Some(client_session_id.to_string()),
+        ..Default::default()
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DatabaseExportOutputCompression {
@@ -196,7 +220,9 @@ async fn list_mysql_export_view_dependencies(
     state: &crate::connection::AppState,
     connection_id: &str,
     database: &str,
+    client_session_id: &str,
 ) -> Result<Vec<(String, String)>, String> {
+    let options = database_export_query_options(state, connection_id, client_session_id, Some(usize::MAX)).await;
     let result = crate::query::execute_sql_statement_with_options(
         state,
         connection_id,
@@ -204,7 +230,7 @@ async fn list_mysql_export_view_dependencies(
         &mysql_view_dependencies_sql(database),
         None,
         None,
-        crate::query::QueryExecutionOptions { max_rows: Some(usize::MAX), ..Default::default() },
+        options,
     )
     .await?;
     Ok(mysql_view_dependencies_from_rows(&result.rows))
@@ -237,18 +263,21 @@ fn mysql_database_export_preamble(database: &str, charset: Option<&str>, collati
 async fn mysql_database_export_preamble_for_request(
     state: &crate::connection::AppState,
     request: &DatabaseExportRequest,
+    client_session_id: &str,
 ) -> String {
     let metadata_sql = format!(
         "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = {}",
         mysql_sql_string_literal(&request.database)
     );
-    let metadata = crate::query::execute_sql_statement(
+    let options = database_export_query_options(state, &request.connection_id, client_session_id, Some(1)).await;
+    let metadata = crate::query::execute_sql_statement_with_options(
         state,
         &request.connection_id,
         &request.database,
         &metadata_sql,
         None,
         None,
+        options,
     )
     .await
     .ok()
@@ -2663,7 +2692,7 @@ async fn export_database_sql_core_inner(
     };
 
     let create_database_preamble = if request.include_create_database && matches!(db_type, DatabaseType::Mysql) {
-        Some(mysql_database_export_preamble_for_request(state, request).await)
+        Some(mysql_database_export_preamble_for_request(state, request, &client_session_id).await)
     } else {
         None
     };
@@ -2739,7 +2768,9 @@ async fn export_database_sql_core_inner(
     let mut tables: Vec<_> = all_tables.iter().filter(|t| !t.table_type.contains("VIEW")).collect();
     let mut views: Vec<_> = all_tables.iter().filter(|t| t.table_type.contains("VIEW")).collect();
     if request.include_objects && db_type == DatabaseType::Mysql && views.len() > 1 {
-        match list_mysql_export_view_dependencies(state, &request.connection_id, &request.database).await {
+        match list_mysql_export_view_dependencies(state, &request.connection_id, &request.database, &client_session_id)
+            .await
+        {
             Ok(dependencies) => views = sort_export_views_by_dependencies(&views, &dependencies),
             Err(error) => {
                 log::debug!(
@@ -3270,7 +3301,24 @@ async fn export_database_sql_core_inner(
                             );
                             replace_database_export_select_list(sql, &col_names, &col_types, &db_type)
                         };
-                        let result = match crate::transfer::execute_read_on_pool(state, &pool_key, &sql).await {
+                        let options = database_export_query_options(
+                            state,
+                            &request.connection_id,
+                            &client_session_id,
+                            Some(batch_size),
+                        )
+                        .await;
+                        let result = match crate::query::execute_sql_statement_with_options(
+                            state,
+                            &request.connection_id,
+                            &request.database,
+                            &sql,
+                            Some(&request.schema),
+                            None,
+                            options,
+                        )
+                        .await
+                        {
                             Ok(result) => result,
                             Err(error) => {
                                 record_export_error(
@@ -3605,18 +3653,18 @@ mod tests {
     };
     use super::{
         build_database_export_object_source_sql, build_database_sql_export, build_export_insert_statements,
-        database_export_select_sql, database_export_total_objects, drop_table_if_exists_sql,
-        ensure_export_destination_dir, export_destination_identity_mismatch, filter_export_table_infos,
-        format_export_sql_literal, format_export_table_ddl, format_mysql_spatial_export_literal,
-        format_xugu_spatial_export_literal, generate_postgres_extension_ddl, generate_postgres_sequence_create_ddl,
-        generate_postgres_sequence_owner_ddl, generate_postgres_sequence_setval_sql,
-        is_postgres_extension_member_routine, mysql_database_export_preamble, mysql_view_dependencies_from_rows,
-        mysql_view_dependencies_sql, normalize_export_table_ddl, record_export_destination_identity,
-        record_export_error, replace_database_export_select_list, sort_export_views_by_dependencies,
-        split_postgres_export_table_triggers, write_database_export_rows, BuildDatabaseSqlExportOptions,
-        BuildExportInsertStatementsOptions, DatabaseExportObjectCounts, DatabaseExportRequest, DatabaseExportWriter,
-        DdlNormalizeOptions, ExportedTableSql, PostgresExportExtension, PostgresExportSequence,
-        PostgresExtensionMembers, DATABASE_EXPORT_INSERT_BATCH_SIZE, DATABASE_EXPORT_ROW_LIMIT,
+        database_export_query_options_for_timeout, database_export_select_sql, database_export_total_objects,
+        drop_table_if_exists_sql, ensure_export_destination_dir, export_destination_identity_mismatch,
+        filter_export_table_infos, format_export_sql_literal, format_export_table_ddl,
+        format_mysql_spatial_export_literal, format_xugu_spatial_export_literal, generate_postgres_extension_ddl,
+        generate_postgres_sequence_create_ddl, generate_postgres_sequence_owner_ddl,
+        generate_postgres_sequence_setval_sql, is_postgres_extension_member_routine, mysql_database_export_preamble,
+        mysql_view_dependencies_from_rows, mysql_view_dependencies_sql, normalize_export_table_ddl,
+        record_export_destination_identity, record_export_error, replace_database_export_select_list,
+        sort_export_views_by_dependencies, split_postgres_export_table_triggers, write_database_export_rows,
+        BuildDatabaseSqlExportOptions, BuildExportInsertStatementsOptions, DatabaseExportObjectCounts,
+        DatabaseExportRequest, DatabaseExportWriter, DdlNormalizeOptions, ExportedTableSql, PostgresExportExtension,
+        PostgresExportSequence, PostgresExtensionMembers, DATABASE_EXPORT_INSERT_BATCH_SIZE, DATABASE_EXPORT_ROW_LIMIT,
     };
     use super::{ExportProgress, LenientExportErrors};
     use crate::connection::AppState;
@@ -3631,6 +3679,19 @@ mod tests {
         Arc, Mutex,
     };
     use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn database_export_query_options_preserve_connection_timeout() {
+        let options = database_export_query_options_for_timeout(7, "database-export-session", Some(500));
+
+        assert_eq!(options.timeout_secs, Some(7));
+        assert_eq!(options.max_rows, Some(500));
+        assert_eq!(options.client_session_id.as_deref(), Some("database-export-session"));
+
+        let unlimited = database_export_query_options_for_timeout(0, "database-export-session", None);
+        assert_eq!(unlimited.timeout_secs, Some(0));
+        assert_eq!(unlimited.max_rows, None);
+    }
 
     #[tokio::test]
     async fn await_export_operation_drops_pending_metadata_after_cancel() {

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -1233,7 +1233,7 @@ pub fn is_connection_error(err: &str) -> bool {
         || is_os_connection_error(&lower)
 }
 
-fn is_dbx_query_timeout_error(lower: &str) -> bool {
+pub(crate) fn is_dbx_query_timeout_error(lower: &str) -> bool {
     lower.starts_with("query timed out after ")
 }
 
@@ -5446,7 +5446,15 @@ where
             }
         }
         TxnConnection::Mysql(Some(conn)) => {
-            wait_for_result_opt(cancel_token, operation_budget.query_timeout, async {
+            // The query timeout is an inactivity budget reset by every received row,
+            // not a cap on the total duration of a long backup/export stream.
+            let progress_clock = Arc::new(StreamProgressClock::new());
+            let progress_clock_for_rows = progress_clock.clone();
+            let timeout_error = format!(
+                "Query timed out after {} seconds",
+                operation_budget.query_timeout.map_or(0, |timeout| timeout.as_secs())
+            );
+            let stream_future = async {
                 let mut result = conn.query_iter(sql).await.map_err(|error| format!("Query failed: {error}"))?;
                 let Some(mut stream) =
                     result.stream::<mysql_async::Row>().await.map_err(|error| format!("Query failed: {error}"))?
@@ -5470,12 +5478,20 @@ where
                         }
                         Err(err) => return Err(format!("Query failed: {err}")),
                     }
+                    progress_clock_for_rows.mark();
                 }
                 if !batch.is_empty() {
                     on_batch(batch)?;
                 }
                 Ok(total_rows)
-            })
+            };
+            await_stream_with_progress_timeout(
+                stream_future,
+                operation_budget.query_timeout,
+                progress_clock,
+                cancel_token.as_ref(),
+                timeout_error,
+            )
             .await
         }
         TxnConnection::Mysql(None) => Err(MANUAL_TRANSACTION_SESSION_NOT_FOUND_ERROR.to_string()),

--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -5446,82 +5446,37 @@ where
             }
         }
         TxnConnection::Mysql(Some(conn)) => {
-            let query_result = match cancel_token.as_ref() {
-                Some(cancel_token) => {
-                    tokio::select! {
-                        _ = cancel_token.cancelled() => Err(QUERY_CANCELED.to_string()),
-                        result = conn.query_iter(sql) => result.map_err(|error| format!("Query failed: {error}")),
+            wait_for_result_opt(cancel_token, operation_budget.query_timeout, async {
+                let mut result = conn.query_iter(sql).await.map_err(|error| format!("Query failed: {error}"))?;
+                let Some(mut stream) =
+                    result.stream::<mysql_async::Row>().await.map_err(|error| format!("Query failed: {error}"))?
+                else {
+                    return Err("Empty result set stream".to_string());
+                };
+
+                let mut batch = Vec::with_capacity(batch_size);
+                let mut total_rows = 0_u64;
+                while let Some(row_result) = stream.next().await {
+                    match row_result {
+                        Ok(row) => {
+                            batch.push(
+                                (0..row.len()).map(|index| db::mysql::mysql_value_to_json(&row, index)).collect(),
+                            );
+                            total_rows += 1;
+                            if batch.len() >= batch_size {
+                                on_batch(std::mem::take(&mut batch))?;
+                                batch = Vec::with_capacity(batch_size);
+                            }
+                        }
+                        Err(err) => return Err(format!("Query failed: {err}")),
                     }
                 }
-                None => conn.query_iter(sql).await.map_err(|error| format!("Query failed: {error}")),
-            };
-            match query_result {
-                Ok(mut result) => {
-                    let stream_result = match cancel_token.as_ref() {
-                        Some(cancel_token) => {
-                            tokio::select! {
-                                _ = cancel_token.cancelled() => Err(QUERY_CANCELED.to_string()),
-                                stream = result.stream::<mysql_async::Row>() => stream.map_err(|error| format!("Query failed: {error}")),
-                            }
-                        }
-                        None => {
-                            result.stream::<mysql_async::Row>().await.map_err(|error| format!("Query failed: {error}"))
-                        }
-                    };
-                    match stream_result {
-                        Ok(Some(mut stream)) => {
-                            let mut batch = Vec::with_capacity(batch_size);
-                            let mut total_rows = 0_u64;
-                            let mut error = None;
-                            loop {
-                                let next_row = match cancel_token.as_ref() {
-                                    Some(cancel_token) => {
-                                        tokio::select! {
-                                            _ = cancel_token.cancelled() => {
-                                                error = Some(QUERY_CANCELED.to_string());
-                                                break;
-                                            }
-                                            row = stream.next() => row,
-                                        }
-                                    }
-                                    None => stream.next().await,
-                                };
-                                let Some(row_result) = next_row else { break };
-                                match row_result {
-                                    Ok(row) => {
-                                        batch.push(
-                                            (0..row.len())
-                                                .map(|index| db::mysql::mysql_value_to_json(&row, index))
-                                                .collect(),
-                                        );
-                                        total_rows += 1;
-                                        if batch.len() >= batch_size {
-                                            if let Err(err) = on_batch(std::mem::take(&mut batch)) {
-                                                error = Some(err);
-                                                break;
-                                            }
-                                            batch = Vec::with_capacity(batch_size);
-                                        }
-                                    }
-                                    Err(err) => {
-                                        error = Some(format!("Query failed: {err}"));
-                                        break;
-                                    }
-                                }
-                            }
-                            if error.is_none() && !batch.is_empty() {
-                                if let Err(err) = on_batch(batch) {
-                                    error = Some(err);
-                                }
-                            }
-                            error.map_or(Ok(total_rows), Err)
-                        }
-                        Ok(None) => Err("Empty result set stream".to_string()),
-                        Err(error) => Err(error),
-                    }
+                if !batch.is_empty() {
+                    on_batch(batch)?;
                 }
-                Err(error) => Err(error),
-            }
+                Ok(total_rows)
+            })
+            .await
         }
         TxnConnection::Mysql(None) => Err(MANUAL_TRANSACTION_SESSION_NOT_FOUND_ERROR.to_string()),
         TxnConnection::Agent { .. } => {

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -11,8 +11,8 @@ use crate::db::mongo_driver::MongoDocumentResult;
 use crate::models::connection::{ConnectionConfig, DatabaseType};
 use crate::object_source_sql::{build_executable_object_source_statements, EditableObjectSourceSqlInput};
 use crate::query::{
-    agent_execute_query_params, pool_error_action, query_timeout_duration, wait_for_query_opt, PoolErrorAction,
-    QueryExecutionOptions, AGENT_PROTOCOL_MAX_ROWS,
+    agent_execute_query_params, is_dbx_query_timeout_error, pool_error_action, query_timeout_duration,
+    wait_for_query_opt, PoolErrorAction, QueryExecutionOptions, AGENT_PROTOCOL_MAX_ROWS,
 };
 use crate::sql::{split_sql_statements, split_sql_statements_for_database};
 use crate::sql_dialect::{
@@ -5131,7 +5131,7 @@ fn client_session_id_from_pool_key(pool_key: &str) -> Option<&str> {
 
 fn is_transfer_query_timeout(error: &str) -> bool {
     let lower = error.to_ascii_lowercase();
-    lower.contains("query timed out") || lower.contains("查询超时") || lower.contains("查詢逾時")
+    is_dbx_query_timeout_error(&lower) || lower.contains("查询超时") || lower.contains("查詢逾時")
 }
 
 async fn execute_on_pool_with_options(

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -11,7 +11,8 @@ use crate::db::mongo_driver::MongoDocumentResult;
 use crate::models::connection::{ConnectionConfig, DatabaseType};
 use crate::object_source_sql::{build_executable_object_source_statements, EditableObjectSourceSqlInput};
 use crate::query::{
-    agent_execute_query_params, pool_error_action, PoolErrorAction, QueryExecutionOptions, AGENT_PROTOCOL_MAX_ROWS,
+    agent_execute_query_params, pool_error_action, query_timeout_duration, wait_for_query_opt, PoolErrorAction,
+    QueryExecutionOptions, AGENT_PROTOCOL_MAX_ROWS,
 };
 use crate::sql::{split_sql_statements, split_sql_statements_for_database};
 use crate::sql_dialect::{
@@ -5113,18 +5114,24 @@ fn transfer_pool_error_action(
 async fn transfer_pool_context(
     state: &AppState,
     pool_key: &str,
-) -> (Option<String>, Option<String>, Option<DatabaseType>) {
+) -> (Option<String>, Option<String>, Option<DatabaseType>, Option<u64>) {
     let configs = state.configs.read().await;
     let config = config_for_pool_key(pool_key, &configs);
     (
         config.map(|config| config.id.clone()),
         database_from_pool_key(pool_key).map(str::to_string),
         config.map(|config| config.db_type),
+        config.map(|config| config.effective_query_timeout_secs()),
     )
 }
 
 fn client_session_id_from_pool_key(pool_key: &str) -> Option<&str> {
     pool_key.split_once(":session:").map(|(_, session)| session).filter(|session| !session.is_empty())
+}
+
+fn is_transfer_query_timeout(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("query timed out") || lower.contains("查询超时") || lower.contains("查詢逾時")
 }
 
 async fn execute_on_pool_with_options(
@@ -5134,7 +5141,7 @@ async fn execute_on_pool_with_options(
     max_rows: Option<usize>,
     safety: TransferExecutionSafety,
 ) -> Result<db::QueryResult, String> {
-    let (connection_id, database, db_type) = transfer_pool_context(state, pool_key).await;
+    let (connection_id, database, db_type, _query_timeout_secs) = transfer_pool_context(state, pool_key).await;
     let client_session_id = client_session_id_from_pool_key(pool_key).map(str::to_string);
     let mut current_pool_key = pool_key.to_string();
 
@@ -5208,81 +5215,111 @@ async fn execute_on_pool_once(
     sql: &str,
     max_rows: Option<usize>,
 ) -> Result<db::QueryResult, String> {
-    // Read-only check: block transfer operations in readonly mode
+    let (_connection_id, _database, _db_type, query_timeout_secs) = transfer_pool_context(state, pool_key).await;
+    let query_timeout = query_timeout_duration(query_timeout_secs);
+
+    // Read-only check: block transfer operations in readonly mode.
     crate::query::check_read_only_for_connection(state, pool_key, sql).await?;
     let pool_handle = state.pool_handle(pool_key).await;
     let pool = pool_handle.as_ref().ok_or("Connection not found")?;
 
-    match pool {
+    let result = match pool {
         PoolKind::Mysql(p, mode) => {
             let p = p.clone();
             let bare = *mode == crate::connection::MysqlMode::Bare;
-            db::mysql::execute_query_with_max_rows(&p, sql, bare, max_rows, Default::default()).await
+            wait_for_query_opt(
+                None,
+                query_timeout,
+                db::mysql::execute_query_with_max_rows(&p, sql, bare, max_rows, Default::default()),
+            )
+            .await
         }
         PoolKind::Postgres(p) => {
             let p = p.clone();
-            db::postgres::execute_query_with_max_rows(&p, sql, max_rows).await
+            wait_for_query_opt(None, query_timeout, db::postgres::execute_query_with_max_rows(&p, sql, max_rows)).await
         }
         PoolKind::Sqlite(p) => {
             let p = p.clone();
-            db::sqlite::execute_query_with_max_rows(&p, sql, max_rows).await
+            wait_for_query_opt(None, query_timeout, db::sqlite::execute_query_with_max_rows(&p, sql, max_rows)).await
         }
         PoolKind::ClickHouse(client) => {
             let client = client.clone();
             let database = database_from_pool_key(pool_key).unwrap_or("default").to_string();
-            db::clickhouse_driver::execute_query_with_max_rows(&client, &database, sql, max_rows).await
+            wait_for_query_opt(
+                None,
+                query_timeout,
+                db::clickhouse_driver::execute_query_with_max_rows(&client, &database, sql, max_rows),
+            )
+            .await
         }
         PoolKind::InfluxDb(client) => {
             let client = client.clone();
             let database = database_from_pool_key(pool_key).unwrap_or("default").to_string();
-            db::influxdb_driver::execute_query(&client, &database, sql).await
+            wait_for_query_opt(None, query_timeout, db::influxdb_driver::execute_query(&client, &database, sql)).await
         }
         PoolKind::InfluxDb3(client) => {
             let client = client.clone();
             let database = database_from_pool_key(pool_key).unwrap_or("default").to_string();
-            db::influxdb3_driver::execute_query(&client, &database, sql, max_rows).await
+            wait_for_query_opt(
+                None,
+                query_timeout,
+                db::influxdb3_driver::execute_query(&client, &database, sql, max_rows),
+            )
+            .await
         }
         PoolKind::SqlServer(client) => {
             let client = client.clone();
             let mut client = client.lock().await;
-            let result = db::sqlserver::execute_query_with_max_rows(&mut client, sql, max_rows).await;
+            let result = wait_for_query_opt(
+                None,
+                query_timeout,
+                db::sqlserver::execute_query_with_max_rows(&mut client, sql, max_rows),
+            )
+            .await;
             drop(client);
             result
         }
         PoolKind::Agent(client) => {
             let client = client.clone();
             let database = database_from_pool_key(pool_key).map(str::to_string);
-            let sql = sql.to_string();
+            let options = QueryExecutionOptions {
+                max_rows,
+                fetch_size: max_rows,
+                timeout_secs: query_timeout_secs,
+                ..QueryExecutionOptions::default()
+            };
+            let params = agent_execute_query_params(sql, database.as_deref(), None, options);
             let mut client = client.lock().await;
-            let params = agent_execute_query_params(
-                &sql,
-                database.as_deref(),
-                None,
-                QueryExecutionOptions { max_rows, fetch_size: max_rows, ..QueryExecutionOptions::default() },
-            );
-            client.execute_query(params).await
+            client.execute_query_with_timeout(params, query_timeout).await
         }
         PoolKind::ExternalDriver { config, session, .. } => {
             let database = database_from_pool_key(pool_key)
                 .map(str::to_string)
                 .unwrap_or_else(|| config.effective_database().unwrap_or("").to_string());
-            let params = crate::query::external_driver_query_params(
-                config.as_ref(),
-                sql,
-                &database,
-                None,
-                &QueryExecutionOptions { max_rows, fetch_size: max_rows, ..QueryExecutionOptions::default() },
-            );
-            session.invoke_with_timeout("executeQuery", params, None).await
+            let options = QueryExecutionOptions {
+                max_rows,
+                fetch_size: max_rows,
+                timeout_secs: query_timeout_secs,
+                ..QueryExecutionOptions::default()
+            };
+            let params = crate::query::external_driver_query_params(config.as_ref(), sql, &database, None, &options);
+            session.invoke_with_timeout("executeQuery", params, query_timeout).await
         }
         #[cfg(feature = "duckdb-sidecar")]
         PoolKind::DuckDbWorker(client) => {
             let client = client.clone();
-            let sql = sql.to_string();
-            client.execute(None, sql, max_rows, None, None).await
+            client.execute(None, sql.to_string(), max_rows, None, query_timeout).await
         }
         _ => Err("Unsupported database type for transfer".to_string()),
+    };
+    drop(pool_handle);
+    if result.as_ref().is_err_and(|error| is_transfer_query_timeout(error)) {
+        // A timed-out native driver future may still own a checked-out
+        // connection. Discard the pool so a late server response cannot be
+        // reused by the next transfer statement.
+        state.remove_pool_by_key(pool_key).await;
     }
+    result
 }
 
 fn database_from_pool_key(pool_key: &str) -> Option<&str> {
@@ -8556,6 +8593,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transfer_query_timeout_errors_are_classified() {
+        assert!(is_transfer_query_timeout("Query timed out after 1 seconds"));
+        assert!(is_transfer_query_timeout("查询超时 (1s)"));
+        assert!(is_transfer_query_timeout("查詢逾時 (1s)"));
+        assert!(!is_transfer_query_timeout("Connection timed out while loading tables"));
+    }
 
     fn jdbc_transfer_config(connection_string: &str, driver_class: &str, profile: &str) -> ConnectionConfig {
         ConnectionConfig {


### PR DESCRIPTION
## 变更
- 数据库备份的数据查询遵循连接设置中的查询超时时间。
- 导出完成但对象因查询超时失败时，界面显示错误摘要，并提供“修改查询超时时间”入口，直接打开连接设置的“高级”页。

## 验证
- 本地 MySQL 8.4 使用元数据锁实际触发 1 秒查询超时。
- Playwright 实测按钮可用并打开连接编辑的“高级”页。
- 截图：`output/playwright/database-backup-timeout-button.png`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `cargo check -p dbx-web`