### PR TITLE
fix(h2): 远程连接通过 H2VERSION() 探测真实服务器版本

### DIFF
--- a/agents/drivers/h2/build.gradle
+++ b/agents/drivers/h2/build.gradle
@@ -36,5 +36,6 @@ tasks.named('test') {
     dependsOn tasks.named('shadowJar')
     doFirst {
         systemProperty 'dbx.h2.agent.jar', tasks.named('shadowJar').get().archiveFile.get().asFile.absolutePath
+        systemProperty 'dbx.h2.v1.driver.jar', configurations.h2V1.asPath
     }
 }

--- a/agents/drivers/h2/src/main/java/com/dbx/agent/h2/H2Agent.java
+++ b/agents/drivers/h2/src/main/java/com/dbx/agent/h2/H2Agent.java
@@ -92,7 +92,29 @@ public class H2Agent extends AbstractJdbcAgent {
     @Override
     protected void afterConnect(ConnectParams params, Connection connection) {
         databaseName = params.getDatabase();
-        databaseMajorVersion = unchecked(() -> connection.getMetaData().getDatabaseMajorVersion());
+        databaseMajorVersion = detectDatabaseMajorVersion(connection);
+    }
+
+    // For a remote (TCP/SSL) connection, JDBC metadata such as
+    // getDatabaseMajorVersion() reflects the *loaded driver's* own version, not
+    // the server's, whenever the driver profile could not be auto-detected from
+    // a local database file (see H2FileFormatDetector) and fell back to the
+    // newest bundled driver. H2VERSION() is evaluated by the server itself, so
+    // it reports the real engine version regardless of which driver connected.
+    private static int detectDatabaseMajorVersion(Connection connection) {
+        try (java.sql.Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery("SELECT H2VERSION()")) {
+            if (resultSet.next()) {
+                String version = resultSet.getString(1);
+                int dot = version == null ? -1 : version.indexOf('.');
+                if (dot > 0) {
+                    return Integer.parseInt(version.substring(0, dot));
+                }
+            }
+        } catch (SQLException | NumberFormatException ignored) {
+            // Fall back to JDBC driver metadata below.
+        }
+        return unchecked(() -> connection.getMetaData().getDatabaseMajorVersion());
     }
 
     H2DriverVersion driverVersion() {

--- a/agents/drivers/h2/src/test/java/com/dbx/agent/h2/H2AgentProcessTest.java
+++ b/agents/drivers/h2/src/test/java/com/dbx/agent/h2/H2AgentProcessTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -95,6 +96,123 @@ class H2AgentProcessTest {
                 String sessionId = "session-" + profile;
                 Assertions.assertTrue(rpc.result(rpc.request("close_session", sessionParams(sessionId))).get("ok").getAsBoolean());
                 Assertions.assertTrue(rpc.request("validate_session", sessionParams(sessionId)).has("error"));
+            }
+        }
+    }
+
+    // Regression test for a legacy (H2 1.x) *remote* server: the file-format
+    // auto-detector (H2FileFormatDetector) cannot inspect a TCP database's
+    // storage file, so driver selection falls back to the newest bundled
+    // driver (H2 2.4.240). That mismatched driver's own JDBC metadata
+    // (getDatabaseMajorVersion()) then reports its own version rather than the
+    // server's, which used to make the agent send an H2 2.x-only
+    // INFORMATION_SCHEMA.ROUTINES query to a database that doesn't have that
+    // catalog table, failing list_objects entirely (dbx#8356).
+    @Test
+    @Timeout(45)
+    void listObjectsAutoDetectsLegacyServerOverTcp() throws Exception {
+        Path h2V1Jar = Path.of(System.getProperty("dbx.h2.v1.driver.jar"));
+        Assertions.assertTrue(Files.isRegularFile(h2V1Jar), () -> "Missing bundled H2 1.4.200 driver jar: " + h2V1Jar);
+        Path agentJar = Path.of(System.getProperty("dbx.h2.agent.jar"));
+        Assertions.assertTrue(Files.isRegularFile(agentJar), () -> "Missing shaded H2 Agent: " + agentJar);
+
+        try (LegacyTcpServer server = new LegacyTcpServer(h2V1Jar)) {
+            try (RpcProcess rpc = new RpcProcess(agentJar)) {
+                String sessionId = "session-legacy-tcp";
+                JsonObject params = sessionParams(sessionId);
+                params.addProperty("host", "127.0.0.1");
+                params.addProperty("port", server.port());
+                // A fresh, unique database per run: the TCP server process's
+                // working directory (and any .mv.db file it writes) persists
+                // across separate test invocations, so a fixed name would leak
+                // schema objects between runs.
+                params.addProperty("database", "./legacy-tcp-test-" + java.util.UUID.randomUUID());
+                params.addProperty("username", "sa");
+                params.addProperty("password", "");
+                params.addProperty("connection_string", "");
+                params.addProperty("ssl", false);
+                // driver_profile intentionally omitted: exercise the "auto" path.
+
+                JsonObject connected = rpc.result(rpc.request("open_session", params));
+                Assertions.assertTrue(connected.get("ok").getAsBoolean());
+
+                rpc.result(rpc.request("execute_query", queryParams(sessionId, "CREATE TABLE LEGACY_TABLE (ID INT PRIMARY KEY)")));
+                rpc.result(rpc.request("execute_query", queryParams(sessionId, "CREATE ALIAS LEGACY_FUNC FOR \"java.lang.Integer.reverse\"")));
+
+                JsonArray objects = rpc.resultArray(rpc.request("list_objects", metadataParams(sessionId, "PUBLIC")));
+                List<String> names = objects.asList().stream().map(value -> value.getAsJsonObject().get("name").getAsString()).toList();
+                Assertions.assertTrue(names.contains("LEGACY_TABLE"), names.toString());
+                Assertions.assertTrue(names.contains("LEGACY_FUNC"), names.toString());
+
+                Assertions.assertTrue(rpc.result(rpc.request("close_session", sessionParams(sessionId))).get("ok").getAsBoolean());
+            }
+        }
+    }
+
+    private static final class LegacyTcpServer implements AutoCloseable {
+        private final Process process;
+        private final int port;
+
+        private LegacyTcpServer(Path h2V1Jar) throws Exception {
+            this.port = findFreePort();
+            Path java = Path.of(System.getProperty("java.home"), "bin", "java");
+            process = new ProcessBuilder(
+                java.toString(), "-cp", h2V1Jar.toString(), "org.h2.tools.Server",
+                "-tcp", "-tcpPort", Integer.toString(port), "-ifNotExists"
+            ).redirectErrorStream(true).start();
+            // -tcpDaemon is intentionally omitted: it marks the *listener* thread
+            // as a daemon for embedding inside a host JVM that outlives it. Here
+            // the server *is* the whole process, so a daemon-only listener thread
+            // would let the JVM exit (dropping sessions) the moment main() returns.
+            drainOutput();
+            waitUntilListening();
+        }
+
+        private void drainOutput() {
+            Thread thread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    while (reader.readLine() != null) {
+                        // Discard: only draining to prevent the pipe buffer from filling.
+                    }
+                } catch (java.io.IOException ignored) {
+                }
+            }, "legacy-h2-server-stdout");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        private int port() {
+            return port;
+        }
+
+        private static int findFreePort() throws Exception {
+            try (java.net.ServerSocket socket = new java.net.ServerSocket(0)) {
+                return socket.getLocalPort();
+            }
+        }
+
+        private void waitUntilListening() throws Exception {
+            long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+            while (System.nanoTime() < deadline) {
+                try (java.net.Socket probe = new java.net.Socket()) {
+                    probe.connect(new java.net.InetSocketAddress("127.0.0.1", port), 200);
+                    return;
+                } catch (java.io.IOException notReady) {
+                    Thread.sleep(100);
+                }
+            }
+            throw new AssertionError("Legacy H2 TCP server never started listening on port " + port);
+        }
+
+        @Override
+        public void close() {
+            process.destroy();
+            try {
+                if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                }
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
             }
         }
     }


### PR DESCRIPTION
## 问题

远程（TCP/SSL）连接 H2 时，DBX 无法像本地文件那样探测数据库存储格式，会回退使用最新的 H2 驱动。此时 `getDatabaseMajorVersion()` 返回的是**驱动自身**的版本，而不是远端服务器的真实版本。当服务器实际是老版本（如 1.4.200）时会被误判为 2.x，`listObjects()` 会执行仅 2.x 才支持的 `INFORMATION_SCHEMA.ROUTINES` 查询，报错 `Table "ROUTINES" not found`，并且这次查询失败会连带丢弃已经查到的表列表——这就是"表也不显示、点函数也报错"这两个现象背后的同一个根因。

## 修复

改为直接对服务器执行 `SELECT H2VERSION()` 来获取真实引擎版本（服务端计算，不受客户端驱动影响），只有这条查询失败时才回退到原来的 JDBC 驱动元数据判断。

## 验证

真实连接 H2 1.4.200 TCP server 复现：
```
{"error":{"code":-1,"message":"org.h2.jdbc.JdbcSQLSyntaxErrorException: Table \"ROUTINES\" not found; ... [42102-200]"}}
```
应用修复后同样的请求正常返回表和函数列表。

- 新增回归测试 `H2AgentProcessTest#listObjectsAutoDetectsLegacyServerOverTcp`，真实起一个 H2 1.4.200 TCP server 复现并验证修复。
- `:h2:test` 全量套件 32/32 通过；把修复临时移除后重跑，**只有**这个新增回归测试失败，其余 31 个照常通过，确认测试确实覆盖了这个 bug。
- 额外验证现代 H2 2.4.240、内嵌文件模式、显式指定 `driver_profile` 三种场景均无回归。

Fixes #8356