### PR TITLE
fix(grid): keep new top row visible after a toolbar refresh

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -5997,6 +5997,11 @@ function captureViewportAnchorForRefresh(): { row?: PersistedDataGridSelection; 
   if (showTranspose.value || displayItems.value.length === 0) return null;
   const scroller = useCanvasGridRows.value ? canvasScrollerElement() : gridScrollerElement();
   if (!scroller) return null;
+  // Already viewing the top of the grid: don't anchor to the row currently
+  // there. Anchoring would re-pin that row to the same on-screen offset even
+  // after a refresh prepends new rows above it (e.g. newly inserted rows
+  // under a DESC sort), pushing the new rows above the visible area (#8339).
+  if (scroller.scrollTop <= 0) return null;
   const rowHeight = useCanvasGridRows.value ? CANVAS_DATA_GRID_ROW_HEIGHT : DOM_DATA_GRID_ROW_HEIGHT;
   const fallbackDisplayIndex = Math.max(0, Math.min(displayItems.value.length - 1, Math.floor(scroller.scrollTop / rowHeight)));
   const item = displayItems.value[fallbackDisplayIndex];

--- a/apps/desktop/src/components/grid/__tests__/DataGridExternalResultScroll.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridExternalResultScroll.spec.ts
@@ -11,6 +11,14 @@ function resultWatchSource(): string {
   return dataGridSource.slice(start, end);
 }
 
+function captureViewportAnchorForRefreshSource(): string {
+  const start = dataGridSource.indexOf("function captureViewportAnchorForRefresh()");
+  const end = dataGridSource.indexOf("function restoreViewportAnchorAfterRefresh(");
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return dataGridSource.slice(start, end);
+}
+
 describe("DataGrid result-replacement vertical scroll", () => {
   it("resets to the first row when the result is replaced without an internal grid action", () => {
     const watchSource = resultWatchSource();
@@ -52,5 +60,20 @@ describe("DataGrid result-replacement vertical scroll", () => {
     expect(appendReturn).toBeGreaterThanOrEqual(0);
     expect(appendEarlyReturn).toBeGreaterThan(appendReturn);
     expect(resetBranch).toBeGreaterThan(appendEarlyReturn);
+  });
+
+  it("does not anchor a toolbar refresh to the current top row when already scrolled to the top (#8339)", () => {
+    // Anchoring the row that happens to be at scrollTop 0 would re-pin it to the
+    // same on-screen offset after refresh, which pushes newly inserted rows
+    // (e.g. rows prepended by an external insert under a DESC sort) above the
+    // visible viewport instead of showing them. Skipping the anchor when already
+    // at the top lets the toolbar-refresh path land on the freshest first row.
+    const anchorSource = captureViewportAnchorForRefreshSource();
+
+    expect(anchorSource).toContain("#8339");
+    const guard = anchorSource.indexOf("if (scroller.scrollTop <= 0) return null;");
+    const rowHeightUse = anchorSource.indexOf("const rowHeight =");
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(rowHeightUse).toBeGreaterThan(guard);
   });
 });


### PR DESCRIPTION
## Summary
- Toolbar refresh anchors the row sitting at `scrollTop 0` back to the same on-screen offset after re-fetching. When a row is inserted externally while the grid is sorted descending, the new row now sorts above that anchored row and gets pushed above the visible viewport instead of being shown — matching the reported "need to scroll up to see the new row" behavior.
- Skip capturing a viewport anchor when the grid is already scrolled to the top, so a manual refresh lands on the freshest first row instead of re-pinning the old top row in place.

Fixes #8339

## Test plan
- [x] Reproduced on a real MySQL 8.4 instance: sorted a table DESC, inserted a row via an external client (not through the DBX UI), clicked the toolbar Refresh button — the new row was pushed above the visible viewport, requiring a manual scroll up (matches the issue).
- [x] Applied the fix and repeated the exact same steps — the new row now appears at the top immediately after refresh, no scrolling needed.
- [x] Regression-checked the "already scrolled into the middle of the grid" refresh case against the pre-fix baseline with the same script — behavior is identical before/after this change (not affected by this fix).
- [x] `apps/desktop/src/components/grid` test suite: 30 files / 240 tests passing, including a new regression test for this fix.
- [x] `oxlint` clean on the changed files.