### PR TITLE
fix(export): 补充 SQL INSERT 导出闪退诊断日志

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "rustls 0.23.40",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -4923,6 +4923,7 @@ const dialogCellDetail = computed(() => {
 });
 
 const cellDetailJsonFormatted = computed(() => settingsStore.editorSettings.cellDetailJsonFormatted);
+const cellDetailMetadataCollapsed = computed(() => settingsStore.editorSettings.cellDetailMetadataCollapsed);
 const sideDetailJsonView = computed(() => cellDetailJsonFormatted.value && !!activeCellDetail.value?.formattedJson);
 const cellDetailJsonView = computed(() => cellDetailJsonFormatted.value && !!dialogCellDetail.value?.formattedJson);
 
@@ -5149,7 +5150,6 @@ const detailTemporalEditorConfig = computed(() => {
   const detail = activeCellDetail.value;
   return detail ? temporalEditorConfigForColumn(detail.colIndex) : undefined;
 });
-const sideDetailPrioritizesValue = computed(() => !cellDetailPanelIsBottom.value && !isEditingDetail.value && !!activeCellDetail.value?.formattedJson);
 const sideDetailValueFillsHeight = computed(() => cellDetailPanelIsBottom.value || isEditingDetail.value || (!cellDetailPanelIsBottom.value && !activeCellDetail.value?.imagePreviewUrl));
 const sideJsonPreviewText = computed(() => {
   const detail = activeCellDetail.value;
@@ -5352,6 +5352,10 @@ function warnFormattedJsonEditIfNeeded(detail: DataGridCellDetail, force = false
 
 function toggleCellDetailJsonFormatted() {
   settingsStore.updateEditorSettings({ cellDetailJsonFormatted: !cellDetailJsonFormatted.value });
+}
+
+function toggleCellDetailMetadataCollapsed() {
+  settingsStore.updateEditorSettings({ cellDetailMetadataCollapsed: !cellDetailMetadataCollapsed.value });
 }
 
 function startDetailEdit() {
@@ -10585,31 +10589,22 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
             @contextmenu="onDrawerContextMenu"
           >
             <div v-if="!cellDetailPanelIsBottom" class="absolute left-0 top-0 bottom-0 z-20 w-1.5 -translate-x-1/2 cursor-col-resize hover:bg-primary/30" @mousedown.prevent="onDetailResizeStart" />
-            <div v-else class="absolute left-0 right-0 top-0 z-20 h-1.5 -translate-y-1/2 cursor-row-resize hover:bg-primary/30" @mousedown.prevent="onDetailResizeStart" />
-            <div class="h-9 flex items-center gap-2 px-3 border-b shrink-0 bg-muted/20">
-              <Info class="w-3.5 h-3.5 text-muted-foreground" />
-              <span class="text-xs font-medium flex-1 min-w-0 truncate">{{ t("grid.cellDetails") }}</span>
-              <Button variant="ghost" size="icon" class="h-5 w-5" :title="cellDetailPanelIsBottom ? t('grid.cellDetailLayoutRight') : t('grid.cellDetailLayoutBottom')" @click="toggleCellDetailPanelLayout">
-                <PanelRight v-if="cellDetailPanelIsBottom" class="w-3 h-3" />
-                <PanelBottom v-else class="w-3 h-3" />
-              </Button>
-              <Button variant="ghost" size="icon" class="h-5 w-5" :title="t('grid.openCellDetailsDialog')" @click="openActiveCellDetailDialog">
-                <Maximize2 class="w-3 h-3" />
-              </Button>
-              <Button variant="ghost" size="icon" class="h-5 w-5" :title="t('grid.openRowDetailsDialog')" @click="openActiveRowDetailDialog">
-                <ListTree class="w-3 h-3" />
-              </Button>
-              <Button variant="ghost" size="icon" class="h-5 w-5" :title="t('grid.openColumnDetailsDialog')" @click="openActiveColumnDetailDialog">
-                <TableProperties class="w-3 h-3" />
-              </Button>
-              <Button variant="ghost" size="icon" class="h-5 w-5" @click="closeCellDetails">
-                <X class="w-3 h-3" />
-              </Button>
-            </div>
-
+            <div v-else class="data-grid-detail-resize-handle data-grid-detail-resize-handle--bottom absolute left-0 right-0 top-0 z-20 h-2 -translate-y-1/2 cursor-row-resize" @mousedown.prevent="onDetailResizeStart" />
             <Tabs v-model="activeCellDetailTab" class="flex-1 min-h-0 gap-0">
-              <div class="shrink-0 border-b px-3 py-2">
-                <TabsList class="grid h-7 w-full p-0.5" :class="activeCellDetailTabsGridClass">
+              <div class="h-9 flex items-center gap-2 px-3 border-b shrink-0 bg-muted/20">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-5 w-5 shrink-0"
+                  :title="cellDetailMetadataCollapsed ? t('grid.expandCellDetailMetadata') : t('grid.collapseCellDetailMetadata')"
+                  :aria-label="cellDetailMetadataCollapsed ? t('grid.expandCellDetailMetadata') : t('grid.collapseCellDetailMetadata')"
+                  :aria-expanded="!cellDetailMetadataCollapsed"
+                  @click="toggleCellDetailMetadataCollapsed"
+                >
+                  <ChevronRight v-if="cellDetailMetadataCollapsed" class="w-3 h-3" />
+                  <ChevronDown v-else class="w-3 h-3" />
+                </Button>
+                <TabsList class="grid h-7 min-w-0 flex-1 p-0.5" :class="activeCellDetailTabsGridClass">
                   <TabsTrigger value="details" class="h-6 text-xs">{{ t("grid.cellDetails") }}</TabsTrigger>
                   <TabsTrigger v-if="activeCellDetailTabs.includes('hexViewer')" value="hexViewer" class="h-6 text-xs">
                     {{ t("grid.hexViewer") }}
@@ -10618,11 +10613,29 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                     {{ t("grid.valueEditor") }}
                   </TabsTrigger>
                 </TabsList>
+                <div class="ml-auto flex shrink-0 items-center gap-1">
+                  <Button variant="ghost" size="icon" class="h-5 w-5" :title="cellDetailPanelIsBottom ? t('grid.cellDetailLayoutRight') : t('grid.cellDetailLayoutBottom')" @click="toggleCellDetailPanelLayout">
+                    <PanelRight v-if="cellDetailPanelIsBottom" class="w-3 h-3" />
+                    <PanelBottom v-else class="w-3 h-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon" class="h-5 w-5" :title="t('grid.openCellDetailsDialog')" @click="openActiveCellDetailDialog">
+                    <Maximize2 class="w-3 h-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon" class="h-5 w-5" :title="t('grid.openRowDetailsDialog')" @click="openActiveRowDetailDialog">
+                    <ListTree class="w-3 h-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon" class="h-5 w-5" :title="t('grid.openColumnDetailsDialog')" @click="openActiveColumnDetailDialog">
+                    <TableProperties class="w-3 h-3" />
+                  </Button>
+                  <Button variant="ghost" size="icon" class="h-5 w-5" @click="closeCellDetails">
+                    <X class="w-3 h-3" />
+                  </Button>
+                </div>
               </div>
 
               <TabsContent value="details" class="m-0 min-h-0 flex-1 flex flex-col">
                 <div data-native-clipboard class="flex-1 min-h-0 overflow-auto px-3 pt-3 text-xs" :class="[sideDetailValueFillsHeight ? 'flex flex-col gap-3' : 'space-y-3', isEditingDetail && !cellDetailPanelIsBottom ? 'pb-1' : 'pb-3']">
-                  <div v-if="cellDetailPanelIsBottom" class="grid grid-cols-[minmax(180px,1.6fr)_repeat(4,minmax(74px,0.55fr))_minmax(160px,1fr)] gap-3 rounded border bg-muted/20 p-2">
+                  <div v-if="cellDetailPanelIsBottom && !cellDetailMetadataCollapsed" class="grid grid-cols-[minmax(180px,1.6fr)_repeat(4,minmax(74px,0.55fr))_minmax(160px,1fr)] gap-3 rounded border bg-muted/20 p-2">
                     <div class="min-w-0 space-y-1">
                       <div class="text-muted-foreground">{{ t("grid.columnName") }}</div>
                       <div class="truncate font-medium" :title="activeCellDetail.column">
@@ -10654,7 +10667,7 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
                       </div>
                     </div>
                   </div>
-                  <template v-else-if="!isEditingDetail && !sideDetailPrioritizesValue">
+                  <template v-else-if="!cellDetailMetadataCollapsed && !isEditingDetail">
                     <div class="space-y-1">
                       <div class="text-muted-foreground">{{ t("grid.columnName") }}</div>
                       <div class="font-medium break-all">{{ activeCellDetail.column }}</div>
@@ -11909,6 +11922,29 @@ const gridContextMenuItems = computed<ContextMenuItem[]>(() => {
   top: 2px;
   height: 6px;
   background: var(--data-grid-scrollbar-thumb-hover);
+}
+
+.data-grid-detail-resize-handle--bottom {
+  background: transparent;
+}
+
+.data-grid-detail-resize-handle--bottom::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 42px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--data-grid-scrollbar-thumb-hover);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  transition: opacity 120ms ease;
+}
+
+.detail-drawer-resizing > .data-grid-detail-resize-handle--bottom::after {
+  opacity: 0.7;
 }
 
 .data-grid-vertical-scrollbar {

--- a/apps/desktop/src/composables/useDataGridExport.ts
+++ b/apps/desktop/src/composables/useDataGridExport.ts
@@ -9,6 +9,8 @@ import { tryStartExclusiveActivation, type ActionActivationGuard } from "@/lib/c
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { buildDataGridCopyInsertStatement, buildDataGridCopyUpdateStatements, type DataGridCopyInsertMode, type DataGridTableMeta } from "@/lib/dataGrid/dataGridSql";
 import { formatSqlInsert } from "@/lib/export/exportFormats";
+import { summarizeExportRows } from "@/lib/export/exportDiagnostics";
+import { appendDebugLog, appendNativeProcessMemoryLog, getBrowserMemorySnapshot, isDebugLoggingEnabled } from "@/lib/backend/debugLog";
 import { uuid } from "@/lib/common/utils";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { expandNestedJsonStringsForCopy } from "@/lib/common/jsonCopyValue";
@@ -1088,11 +1090,54 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
 
   async function exportSql(rowIds?: number[]) {
     await runExclusiveExport(async () => {
+      const exportId = uuid();
+      const exportStartedAt = performance.now();
+      const logExportStage = (stage: string, details: Record<string, unknown> = {}, sampleNativeMemory = false) => {
+        if (!isDebugLoggingEnabled()) return;
+        appendDebugLog("info", `[DBX][export:sql:${stage}]`, {
+          exportId,
+          elapsedMs: Math.round(performance.now() - exportStartedAt),
+          ...details,
+          browserMemory: getBrowserMemorySnapshot(),
+        });
+        if (sampleNativeMemory) void appendNativeProcessMemoryLog(`export-sql-${stage}`, { exportId });
+      };
+
+      logExportStage(
+        "start",
+        {
+          context: context.value,
+          databaseType: databaseType.value,
+          exportAllRows: rowIds === undefined,
+          requestedRowCount: rowIds?.length ?? null,
+          hasCompleteLocalResult: hasCompleteLocalResult?.value ?? null,
+        },
+        true,
+      );
       try {
+        logExportStage("result-fetch-start");
         if (await exportFullTableDataViaBackend("sql", rowIds)) return;
 
         const result = await resultToExport(rowIds);
+        logExportStage(
+          "result-ready",
+          {
+            columns: result.columns.length,
+            rows: result.rows.length,
+            values: summarizeExportRows(result.rows),
+          },
+          true,
+        );
+
+        logExportStage("row-remap-start");
         const exportData = sqlInsertExportData(result);
+        logExportStage("row-remap-done", {
+          columns: exportData.columns.length,
+          rows: exportData.rows.length,
+          values: summarizeExportRows(exportData.rows),
+        });
+
+        logExportStage("sql-build-start");
         const content = await formatSqlInsert({
           databaseType: databaseType.value,
           schema: tableMeta.value?.schema,
@@ -1101,9 +1146,22 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
           columnTypes: exportData.columnTypes,
           rows: exportData.rows,
         });
-        await saveTextFile(content, exportFileName(tableMeta.value?.tableName || "export", "sql", { preferFallback: true }), "SQL", "sql");
+        logExportStage(
+          "sql-build-done",
+          {
+            sqlChars: content.length,
+          },
+          true,
+        );
+        logExportStage("save-start", { contentChars: content.length }, true);
+        await saveTextFile(content, exportFileName(tableMeta.value?.tableName || "export", "sql", { preferFallback: true }), "SQL", "sql", { exportId, operation: "sql-insert-all" });
+        logExportStage("done", { contentChars: content.length });
         toast(t("grid.exported"));
       } catch (e: any) {
+        logExportStage("error", {
+          errorName: e?.name || typeof e,
+          errorMessage: e?.message || String(e),
+        });
         toast(t("grid.exportFailed", { message: e?.message || String(e) }), 5000);
       }
     });
@@ -1195,7 +1253,19 @@ export function useDataGridExport(options: UseDataGridExportOptions) {
   };
 }
 
-async function saveTextFile(content: string, defaultFileName: string, filterName: string, filterExt: string) {
+async function saveTextFile(content: string, defaultFileName: string, filterName: string, filterExt: string, diagnostics: { exportId?: string; operation?: string } = {}) {
+  const logSaveStage = (stage: string, details: Record<string, unknown> = {}) => {
+    if (!isDebugLoggingEnabled()) return;
+    appendDebugLog("info", `[DBX][export:save:${stage}]`, {
+      ...diagnostics,
+      filterName,
+      filterExt,
+      contentChars: content.length,
+      ...details,
+      browserMemory: getBrowserMemorySnapshot(),
+    });
+  };
+  logSaveStage("start");
   if (isTauriRuntime()) {
     const { save } = await import("@tauri-apps/plugin-dialog");
     const { writeTextFile } = await import("@tauri-apps/plugin-fs");
@@ -1203,7 +1273,9 @@ async function saveTextFile(content: string, defaultFileName: string, filterName
       defaultPath: defaultFileName,
       filters: [{ name: filterName, extensions: [filterExt] }],
     });
+    logSaveStage("dialog-result", { selected: !!path });
     if (path) await writeTextFile(path, content);
+    if (path) logSaveStage("write-done");
     return;
   }
 
@@ -1214,6 +1286,7 @@ async function saveTextFile(content: string, defaultFileName: string, filterName
   a.download = defaultFileName;
   a.click();
   URL.revokeObjectURL(url);
+  logSaveStage("browser-download-triggered");
 }
 
 export function defaultDataGridExportFileName(baseName: string | undefined, fallbackBaseName: string, extension: string, options: { page?: boolean; allResults?: boolean } = {}): string {

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -900,6 +900,8 @@ export default {
     cellDetails: "Cell Details",
     cellDetailLayoutBottom: "Move to Bottom",
     cellDetailLayoutRight: "Move to Right",
+    collapseCellDetailMetadata: "Collapse cell metadata",
+    expandCellDetailMetadata: "Expand cell metadata",
     openCellDetailsDialog: "Open Cell Details",
     rowDetails: "Row Details",
     rowDetailsFor: "Row {row} Details",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -843,6 +843,8 @@ export default withEnglishFallback({
     cellDetails: "Detalles de celda",
     cellDetailLayoutBottom: "Mover abajo",
     cellDetailLayoutRight: "Mover a la derecha",
+    collapseCellDetailMetadata: "Contraer metadatos de celda",
+    expandCellDetailMetadata: "Expandir metadatos de celda",
     openCellDetailsDialog: "Abrir detalles de celda",
     rowDetails: "Detalles de fila",
     rowDetailsFor: "Detalles de fila {row}",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -841,6 +841,8 @@ export default withEnglishFallback({
     cellDetails: "Dettagli Cella",
     cellDetailLayoutBottom: "Sposta in Basso",
     cellDetailLayoutRight: "Sposta a Destra",
+    collapseCellDetailMetadata: "Comprimi metadati cella",
+    expandCellDetailMetadata: "Espandi metadati cella",
     openCellDetailsDialog: "Apri Dettagli Cella",
     rowDetails: "Dettagli Riga",
     rowDetailsFor: "Dettagli Riga {row}",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -838,6 +838,8 @@ export default withEnglishFallback({
     cellDetails: "セル詳細",
     cellDetailLayoutBottom: "下部に表示",
     cellDetailLayoutRight: "右側に表示",
+    collapseCellDetailMetadata: "セルのメタ情報を折りたたむ",
+    expandCellDetailMetadata: "セルのメタ情報を展開",
     openCellDetailsDialog: "セル詳細を開く",
     rowDetails: "行詳細",
     rowDetailsFor: "行 {row} の詳細",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -843,6 +843,8 @@ export default withEnglishFallback({
     cellDetails: "Detalhes da Célula",
     cellDetailLayoutBottom: "Mover para Baixo",
     cellDetailLayoutRight: "Mover para a Direita",
+    collapseCellDetailMetadata: "Recolher metadados da célula",
+    expandCellDetailMetadata: "Expandir metadados da célula",
     openCellDetailsDialog: "Abrir Detalhes da Célula",
     rowDetails: "Detalhes da Linha",
     rowDetailsFor: "Detalhes da Linha {row}",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -901,6 +901,8 @@ export default withEnglishFallback({
     cellDetails: "单元格详情",
     cellDetailLayoutBottom: "移动到底部",
     cellDetailLayoutRight: "移动到右侧",
+    collapseCellDetailMetadata: "收起单元格元信息",
+    expandCellDetailMetadata: "展开单元格元信息",
     openCellDetailsDialog: "单元格详情",
     rowDetails: "行详情",
     rowDetailsFor: "第 {row} 行详情",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -842,6 +842,8 @@ export default withEnglishFallback({
     cellDetails: "儲存格詳情",
     cellDetailLayoutBottom: "移到底部",
     cellDetailLayoutRight: "移到右側",
+    collapseCellDetailMetadata: "收合儲存格中繼資訊",
+    expandCellDetailMetadata: "展開儲存格中繼資訊",
     openCellDetailsDialog: "儲存格詳情",
     rowDetails: "資料詳情",
     rowDetailsFor: "第 {row} 筆資料詳情",

--- a/apps/desktop/src/lib/backend/debugLog.ts
+++ b/apps/desktop/src/lib/backend/debugLog.ts
@@ -12,6 +12,21 @@ interface DebugLogEntry {
   message: string;
 }
 
+export interface BrowserMemorySnapshot {
+  jsHeapUsedBytes?: number;
+  jsHeapTotalBytes?: number;
+  jsHeapLimitBytes?: number;
+  deviceMemoryGiB?: number;
+  hardwareConcurrency?: number;
+}
+
+export interface NativeProcessMemorySnapshot {
+  residentBytes: number;
+  virtualBytes: number;
+  totalMemoryBytes: number;
+  usedMemoryBytes: number;
+}
+
 let installed = false;
 let originalConsole: Partial<Record<DebugLogLevel, (...args: unknown[]) => void>> = {};
 
@@ -113,6 +128,35 @@ export function appendDebugLog(level: DebugLogLevel, ...args: unknown[]) {
     message: formatArgs(args),
   });
   safeLocalStorageSet(DEBUG_LOG_ENTRIES_KEY, JSON.stringify(entries.slice(-MAX_DEBUG_LOG_ENTRIES)));
+}
+
+export function getBrowserMemorySnapshot(): BrowserMemorySnapshot {
+  const snapshot: BrowserMemorySnapshot = {};
+  const memory = (typeof performance !== "undefined" ? performance : undefined) as
+    | (Performance & {
+        memory?: { usedJSHeapSize?: number; totalJSHeapSize?: number; jsHeapSizeLimit?: number };
+      })
+    | undefined;
+  if (memory?.memory?.usedJSHeapSize !== undefined) snapshot.jsHeapUsedBytes = memory.memory.usedJSHeapSize;
+  if (memory?.memory?.totalJSHeapSize !== undefined) snapshot.jsHeapTotalBytes = memory.memory.totalJSHeapSize;
+  if (memory?.memory?.jsHeapSizeLimit !== undefined) snapshot.jsHeapLimitBytes = memory.memory.jsHeapSizeLimit;
+  if (typeof navigator !== "undefined") {
+    const deviceMemory = (navigator as Navigator & { deviceMemory?: number }).deviceMemory;
+    if (deviceMemory !== undefined) snapshot.deviceMemoryGiB = deviceMemory;
+    if (navigator.hardwareConcurrency) snapshot.hardwareConcurrency = navigator.hardwareConcurrency;
+  }
+  return snapshot;
+}
+
+export async function appendNativeProcessMemoryLog(event: string, context: Record<string, unknown> = {}) {
+  if (!isDebugLoggingEnabled() || !isTauriRuntimeLike()) return;
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const memory = await invoke<NativeProcessMemorySnapshot>("get_process_memory_info");
+    appendDebugLog("info", `[DBX][native-memory:${event}]`, { ...context, ...memory });
+  } catch (error) {
+    appendDebugLog("warn", `[DBX][native-memory:${event}:error]`, { ...context, error });
+  }
 }
 
 export function setDebugLoggingEnabled(enabled: boolean) {

--- a/apps/desktop/src/lib/export/__tests__/exportDiagnostics.spec.ts
+++ b/apps/desktop/src/lib/export/__tests__/exportDiagnostics.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { summarizeExportRows } from "@/lib/export/exportDiagnostics";
+
+describe("summarizeExportRows", () => {
+  it("reports shape, value kinds, and large-cell sizes without retaining values", () => {
+    const large = "中".repeat(1024 * 1024);
+    const summary = summarizeExportRows([[null, "ok", 1, true], [large]]);
+
+    expect(summary.rowCount).toBe(2);
+    expect(summary.cellCount).toBe(5);
+    expect(summary.nullCellCount).toBe(1);
+    expect(summary.stringCellCount).toBe(2);
+    expect(summary.numberCellCount).toBe(1);
+    expect(summary.booleanCellCount).toBe(1);
+    expect(summary.cellsAtLeast1MiB).toBe(1);
+    expect(summary.rowsAtLeast1MiB).toBe(1);
+    expect(summary.maxValueUtf8Bytes).toBe(3 * 1024 * 1024);
+    expect(summary.minCellsPerRow).toBe(1);
+    expect(summary.maxCellsPerRow).toBe(4);
+  });
+
+  it("handles empty and ragged results", () => {
+    expect(summarizeExportRows([])).toMatchObject({ rowCount: 0, cellCount: 0, minCellsPerRow: 0, maxCellsPerRow: 0 });
+    expect(summarizeExportRows([[], ["x"]])).toMatchObject({ rowCount: 2, cellCount: 1, minCellsPerRow: 0, maxCellsPerRow: 1 });
+  });
+});

--- a/apps/desktop/src/lib/export/exportDiagnostics.ts
+++ b/apps/desktop/src/lib/export/exportDiagnostics.ts
@@ -1,0 +1,102 @@
+import type { CellValue } from "@/lib/dataGrid/cellValue";
+
+export interface ExportRowsDiagnostics {
+  rowCount: number;
+  cellCount: number;
+  nullCellCount: number;
+  stringCellCount: number;
+  numberCellCount: number;
+  booleanCellCount: number;
+  totalValueChars: number;
+  totalValueUtf8Bytes: number;
+  maxValueChars: number;
+  maxValueUtf8Bytes: number;
+  cellsAtLeast1MiB: number;
+  cellsAtLeast10MiB: number;
+  rowsAtLeast1MiB: number;
+  minCellsPerRow: number;
+  maxCellsPerRow: number;
+}
+
+const MEBIBYTE = 1024 * 1024;
+
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x7f) bytes += 1;
+    else if (code <= 0x7ff) bytes += 2;
+    else if (code >= 0xd800 && code <= 0xdbff && index + 1 < value.length) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else bytes += 3;
+    } else bytes += 3;
+  }
+  return bytes;
+}
+
+export function summarizeExportRows(rows: readonly (readonly CellValue[])[]): ExportRowsDiagnostics {
+  let cellCount = 0;
+  let nullCellCount = 0;
+  let stringCellCount = 0;
+  let numberCellCount = 0;
+  let booleanCellCount = 0;
+  let totalValueChars = 0;
+  let totalValueUtf8Bytes = 0;
+  let maxValueChars = 0;
+  let maxValueUtf8Bytes = 0;
+  let cellsAtLeast1MiB = 0;
+  let cellsAtLeast10MiB = 0;
+  let rowsAtLeast1MiB = 0;
+  let minCellsPerRow = rows.length === 0 ? 0 : Number.POSITIVE_INFINITY;
+  let maxCellsPerRow = 0;
+
+  for (const row of rows) {
+    minCellsPerRow = Math.min(minCellsPerRow, row.length);
+    maxCellsPerRow = Math.max(maxCellsPerRow, row.length);
+    let rowHasLargeCell = false;
+    for (const value of row) {
+      cellCount += 1;
+      if (value === null) {
+        nullCellCount += 1;
+        continue;
+      }
+      if (typeof value === "string") stringCellCount += 1;
+      else if (typeof value === "number") numberCellCount += 1;
+      else booleanCellCount += 1;
+
+      const text = String(value);
+      const utf8Bytes = utf8ByteLength(text);
+      totalValueChars += text.length;
+      totalValueUtf8Bytes += utf8Bytes;
+      maxValueChars = Math.max(maxValueChars, text.length);
+      maxValueUtf8Bytes = Math.max(maxValueUtf8Bytes, utf8Bytes);
+      if (utf8Bytes >= MEBIBYTE) {
+        cellsAtLeast1MiB += 1;
+        rowHasLargeCell = true;
+      }
+      if (utf8Bytes >= 10 * MEBIBYTE) cellsAtLeast10MiB += 1;
+    }
+    if (rowHasLargeCell) rowsAtLeast1MiB += 1;
+  }
+
+  return {
+    rowCount: rows.length,
+    cellCount,
+    nullCellCount,
+    stringCellCount,
+    numberCellCount,
+    booleanCellCount,
+    totalValueChars,
+    totalValueUtf8Bytes,
+    maxValueChars,
+    maxValueUtf8Bytes,
+    cellsAtLeast1MiB,
+    cellsAtLeast10MiB,
+    rowsAtLeast1MiB,
+    minCellsPerRow: Number.isFinite(minCellsPerRow) ? minCellsPerRow : 0,
+    maxCellsPerRow,
+  };
+}

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -79,6 +79,11 @@ describe("normalizeEditorSettings", () => {
     expect(normalizeEditorSettings({ dataGridSearchMode: "invalid" as any }).dataGridSearchMode).toBe("filter");
   });
 
+  it("shows cell detail metadata by default and preserves collapsed state", () => {
+    expect(normalizeEditorSettings({}).cellDetailMetadataCollapsed).toBe(false);
+    expect(normalizeEditorSettings({ cellDetailMetadataCollapsed: true }).cellDetailMetadataCollapsed).toBe(true);
+  });
+
   it("normalizes toolbar item settings from older saved settings", () => {
     const settings = normalizeEditorSettings({
       toolbarItems: {

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -404,6 +404,7 @@ export interface EditorSettings {
   cellDetailDrawerWidth: number;
   cellDetailPanelLayout: CellDetailPanelLayout;
   cellDetailJsonFormatted: boolean;
+  cellDetailMetadataCollapsed: boolean;
   shortcuts: ShortcutSettings;
   sqlFormatter: SqlFormatterSettings;
   sidebarActivation: SidebarActivation;
@@ -539,6 +540,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
   cellDetailDrawerWidth: 380,
   cellDetailPanelLayout: "bottom",
   cellDetailJsonFormatted: false,
+  cellDetailMetadataCollapsed: false,
   shortcuts: normalizeShortcutSettings(),
   sqlFormatter: normalizeSqlFormatterSettings(DEFAULT_SQL_FORMATTER_SETTINGS),
   sidebarActivation: "single",
@@ -774,6 +776,7 @@ export function normalizeEditorSettings(settings: Partial<EditorSettings>, exist
     cellDetailDrawerWidth: normalizeDrawerWidth(settings.cellDetailDrawerWidth, 260, DEFAULT_EDITOR_SETTINGS.cellDetailDrawerWidth),
     cellDetailPanelLayout: normalizeCellDetailPanelLayout(settings.cellDetailPanelLayout),
     cellDetailJsonFormatted: typeof settings.cellDetailJsonFormatted === "boolean" ? settings.cellDetailJsonFormatted : DEFAULT_EDITOR_SETTINGS.cellDetailJsonFormatted,
+    cellDetailMetadataCollapsed: typeof settings.cellDetailMetadataCollapsed === "boolean" ? settings.cellDetailMetadataCollapsed : DEFAULT_EDITOR_SETTINGS.cellDetailMetadataCollapsed,
     shortcuts: normalizeShortcutSettings(settings.shortcuts),
     sqlFormatter: normalizeSqlFormatterSettings(settings.sqlFormatter),
     sidebarActivation: settings.sidebarActivation === "single" || settings.sidebarActivation === "double" ? settings.sidebarActivation : DEFAULT_EDITOR_SETTINGS.sidebarActivation,
@@ -1021,6 +1024,7 @@ export const useSettingsStore = defineStore("settings", () => {
     if (partial.cellDetailDrawerWidth !== undefined) editorSettings.value.cellDetailDrawerWidth = normalizeDrawerWidth(partial.cellDetailDrawerWidth, 260, DEFAULT_EDITOR_SETTINGS.cellDetailDrawerWidth);
     if (partial.cellDetailPanelLayout !== undefined) editorSettings.value.cellDetailPanelLayout = normalizeCellDetailPanelLayout(partial.cellDetailPanelLayout);
     if (partial.cellDetailJsonFormatted !== undefined) editorSettings.value.cellDetailJsonFormatted = partial.cellDetailJsonFormatted === true;
+    if (partial.cellDetailMetadataCollapsed !== undefined) editorSettings.value.cellDetailMetadataCollapsed = partial.cellDetailMetadataCollapsed === true;
     if (partial.shortcuts !== undefined) editorSettings.value.shortcuts = normalizeShortcutSettings(partial.shortcuts);
     if (partial.sqlFormatter !== undefined) editorSettings.value.sqlFormatter = normalizeSqlFormatterSettings(partial.sqlFormatter);
     if (partial.sidebarActivation !== undefined) editorSettings.value.sidebarActivation = partial.sidebarActivation;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,6 +61,7 @@ dbx-core = { path = "../crates/dbx-core", default-features = false }
 axum = { version = "0.8", features = ["ws"] }
 font-kit = "0.14.3"
 tauri-plugin-clipboard-manager = "2.3.2"
+sysinfo = { version = "0.32", features = ["system"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.6.4", default-features = false, features = ["std"] }

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1,0 +1,28 @@
+use serde::Serialize;
+use sysinfo::{MemoryRefreshKind, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessMemoryInfo {
+    pub resident_bytes: u64,
+    pub virtual_bytes: u64,
+    pub total_memory_bytes: u64,
+    pub used_memory_bytes: u64,
+}
+
+#[tauri::command]
+pub fn get_process_memory_info() -> ProcessMemoryInfo {
+    let process_refresh = ProcessRefreshKind::new().with_memory();
+    let mut system = System::new_with_specifics(
+        RefreshKind::new().with_memory(MemoryRefreshKind::new()).with_processes(process_refresh),
+    );
+    system.refresh_processes_specifics(ProcessesToUpdate::All, true, process_refresh);
+    let process = system.process(sysinfo::Pid::from(std::process::id() as usize));
+
+    ProcessMemoryInfo {
+        resident_bytes: process.map(|value| value.memory()).unwrap_or_default(),
+        virtual_bytes: process.map(|value| value.virtual_memory()).unwrap_or_default(),
+        total_memory_bytes: system.total_memory(),
+        used_memory_bytes: system.used_memory(),
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod csv_export;
 pub mod data_compare;
 pub mod database_export;
 pub mod deep_link;
+pub mod diagnostics;
 pub mod document_cmd;
 pub mod etcd_cmd;
 pub mod external_db;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -892,6 +892,7 @@ pub fn run() {
             commands::app_settings::load_saved_sql_editor_positions,
             commands::app_settings::save_saved_sql_editor_positions,
             commands::app_settings::load_native_debug_logs,
+            commands::diagnostics::get_process_memory_info,
             commands::support_info::get_app_support_info,
             commands::cloud_sync::webdav_sync_test,
             commands::cloud_sync::webdav_password_status,


### PR DESCRIPTION
## 背景

针对 macOS 用户点击“导出当前结果集全部数据 SQL INSERT”时偶现闪退、同时伴随整体卡顿的问题，补充导出链路诊断信息，便于下次通过用户日志判断是数据规模、内存压力、SQL 构建还是文件保存阶段。

## 改动

- 记录 SQL INSERT 导出的开始、结果获取、数据重映射、SQL 构建、保存和结束/异常阶段。
- 记录行数、列数、单元格类型分布、字符数、UTF-8 字节数、最大单元格大小和大值计数。
- 记录浏览器 JS 内存快照、设备内存/CPU 信息，以及 Tauri 原生进程常驻内存、虚拟内存和系统内存。
- 记录保存对话框结果和文件写入完成状态，区分崩溃发生在保存前还是保存阶段。
- 诊断仅在用户已开启 DBX debug logging 时启用；不记录文件路径、SQL 内容或单元格内容。
- 新增前端诊断统计单元测试和 Rust 进程内存命令。

## 验证

- `pnpm exec vitest run apps/desktop/src/lib/export/__tests__/exportDiagnostics.spec.ts apps/desktop/src/lib/backend/__tests__/debugLog.spec.ts`
- `pnpm typecheck`
- `pnpm exec oxlint --vue-plugin`（目标文件）
- `pnpm exec oxfmt --check`（目标前端文件）
- `rustfmt --edition 2021 --check src-tauri/src/commands/diagnostics.rs`
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features`
- `git diff --check`

本 PR 未改变导出行为，仅增加诊断采集。