### PR TITLE
修复：拉开表格预览与保存按钮间距

### DIFF
--- a/apps/desktop/src/components/grid/DataGridToolbar.vue
+++ b/apps/desktop/src/components/grid/DataGridToolbar.vue
@@ -272,7 +272,7 @@ function actionLabelClass(action: DataGridToolbarActionKey) {
 
     <Tooltip v-if="isDataGridToolbarCapabilityVisible(save)">
       <TooltipTrigger as-child>
-        <Button data-toolbar-action="save" variant="default" size="sm" :class="[...actionButtonClass('save'), 'data-grid-topbar-action-button--commit relative']" :disabled="isDataGridToolbarCapabilityDisabled(save)" @click="void triggerDataGridToolbarAction(save)">
+        <Button data-toolbar-action="save" variant="default" size="sm" :class="[...actionButtonClass('save'), 'data-grid-topbar-action-button--commit relative ml-2']" :disabled="isDataGridToolbarCapabilityDisabled(save)" @click="void triggerDataGridToolbarAction(save)">
           <Loader2 v-if="save?.loading" class="data-grid-topbar-action-icon h-3 w-3 animate-spin" />
           <Save v-else-if="actionIsCompact('save') || !save?.pendingCount" class="data-grid-topbar-action-icon h-3 w-3" />
           <span


### PR DESCRIPTION
## 问题
Fixes #8037

表格存在待保存修改时，“预览 SQL”和“提交”按钮连续排列，误操作风险较高。

## 修复
为保存按钮增加独立的左侧间距，让预览和提交动作在视觉上明确分组。

## 实际验证
- 使用本地 MySQL 8.4 `dbx_issue_8360.demo_table` 打开表格数据。
- 在 DBX Web 中新增一行，实际触发“预览 SQL”和“提交”按钮，确认两者之间存在清晰间距。
- 截图：`/Users/staff/dbx/output/playwright/issue-8037-preview-save-spacing.png`
- `pnpm vue-tsc --noEmit --project apps/desktop/tsconfig.json`
