### PR TITLE
fix(db2): read view source from SYSCAT.VIEWS

### DIFF
--- a/agents/drivers/db2/src/main/java/com/dbx/agent/db2/Db2Agent.java
+++ b/agents/drivers/db2/src/main/java/com/dbx/agent/db2/Db2Agent.java
@@ -218,7 +218,11 @@ public final class Db2Agent extends AbstractJdbcAgent {
     @Override
     public ObjectSource getObjectSource(String schema, String name, String objectType) {
         return unchecked(() -> {
-            String sql = "SELECT TEXT FROM SYSCAT.ROUTINES WHERE ROUTINESCHEMA = ? AND ROUTINENAME = ?";
+            String normalizedType = objectType == null ? "" : objectType.trim().toUpperCase(Locale.ROOT);
+            // View definitions live in SYSCAT.VIEWS; SYSCAT.ROUTINES only covers procedures and functions.
+            String sql = "VIEW".equals(normalizedType)
+                ? "SELECT TEXT FROM SYSCAT.VIEWS WHERE VIEWSCHEMA = ? AND VIEWNAME = ?"
+                : "SELECT TEXT FROM SYSCAT.ROUTINES WHERE ROUTINESCHEMA = ? AND ROUTINENAME = ?";
             String source;
             try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
                 stmt.setString(1, schema);

--- a/agents/drivers/db2/src/test/java/com/dbx/agent/db2/Db2AgentTest.java
+++ b/agents/drivers/db2/src/test/java/com/dbx/agent/db2/Db2AgentTest.java
@@ -4,6 +4,7 @@ import com.dbx.agent.DatabaseAgent;
 import com.dbx.agent.ConnectParams;
 import com.dbx.agent.MetadataListConstraints;
 import com.dbx.agent.ObjectInfo;
+import com.dbx.agent.ObjectSource;
 import com.dbx.agent.TableInfo;
 import com.dbx.agent.test.JdbcFakeExecutionBehaviorTest;
 import com.dbx.agent.test.JdbcMetadataSqlFake;
@@ -124,6 +125,69 @@ class Db2AgentTest extends JdbcFakeExecutionBehaviorTest {
         assertEquals("MY_VIEW", objects.get(0).getName());
         assertEquals("VIEW", objects.get(0).getObject_type());
         assertEquals("Test view comment", objects.get(0).getComment());
+    }
+
+    @Test
+    void viewObjectSourceReadsDefinitionFromSyscatViews() {
+        Db2Agent agent = new Db2Agent();
+        AtomicReference<String> executedSql = new AtomicReference<>();
+        TestSupport.setPrivateConnection(agent, preparedConnection(
+            executedSql,
+            row("TEXT", "CREATE VIEW APP.EMP_VIEW AS SELECT ID, NAME FROM APP.EMPLOYEE")
+        ));
+
+        ObjectSource source = agent.getObjectSource("APP", "EMP_VIEW", "VIEW");
+
+        assertEquals("CREATE VIEW APP.EMP_VIEW AS SELECT ID, NAME FROM APP.EMPLOYEE", source.getSource());
+        assertEquals("SELECT TEXT FROM SYSCAT.VIEWS WHERE VIEWSCHEMA = ? AND VIEWNAME = ?", executedSql.get());
+    }
+
+    @Test
+    void routineObjectSourceStillReadsSyscatRoutines() {
+        Db2Agent agent = new Db2Agent();
+        AtomicReference<String> executedSql = new AtomicReference<>();
+        TestSupport.setPrivateConnection(agent, preparedConnection(
+            executedSql,
+            row("TEXT", "BEGIN SELECT 1 FROM SYSIBM.SYSDUMMY1; END")
+        ));
+
+        ObjectSource source = agent.getObjectSource("APP", "MY_PROC", "PROCEDURE");
+
+        assertEquals("BEGIN SELECT 1 FROM SYSIBM.SYSDUMMY1; END", source.getSource());
+        assertEquals("SELECT TEXT FROM SYSCAT.ROUTINES WHERE ROUTINESCHEMA = ? AND ROUTINENAME = ?", executedSql.get());
+    }
+
+    private static Connection preparedConnection(AtomicReference<String> executedSql, Map<String, Object>... rows) {
+        final ResultSet resultSet = rows(rows);
+        return proxy(Connection.class, new MethodHandler() {
+            @Override
+            public Object handle(Method method, Object[] args) {
+                String name = method.getName();
+                if ("prepareStatement".equals(name)) {
+                    executedSql.set(String.valueOf(args[0]));
+                    return proxy(PreparedStatement.class, new MethodHandler() {
+                        @Override
+                        public Object handle(Method stmtMethod, Object[] stmtArgs) {
+                            String m = stmtMethod.getName();
+                            if ("setString".equals(m) || "setObject".equals(m) || "setInt".equals(m)) {
+                                return null;
+                            }
+                            if ("executeQuery".equals(m)) {
+                                return resultSet;
+                            }
+                            if ("close".equals(m)) {
+                                return null;
+                            }
+                            return defaultValue(stmtMethod.getReturnType());
+                        }
+                    });
+                }
+                if ("isClosed".equals(name)) {
+                    return false;
+                }
+                return defaultValue(method.getReturnType());
+            }
+        });
     }
 
     private static Connection preparedConnection(Map<String, Object>... rows) {


### PR DESCRIPTION
## 变更说明

修复 DB2 视图无法显示 SQL 的问题。

`Db2Agent.getObjectSource` 忽略了 `objectType` 参数，无论查询什么对象都固定访问 `SYSCAT.ROUTINES`。DB2 的视图定义存放在 `SYSCAT.VIEWS.TEXT`，因此查视图时结果集为空，`rs.next()` 返回 false，`source` 被静默置为 `""`——不抛错，只是内容为空。

「编辑视图」「查看源码」共用 `get_object_source_core`，而「查看 DDL」对 View 类型同样先取 object source 再交给 `build_view_ddl_sql` 拼接，三个入口共用这条坏路径，所以全部显示空白。存储过程/函数不受影响，因为 `SYSCAT.ROUTINES` 恰好是它们的正确目录。

修复方式：按 `objectType` 分支，`VIEW` 查询 `SYSCAT.VIEWS`，其余保持原有 `SYSCAT.ROUTINES` 查询，写法对齐 `SapHanaAgent` 的既有范式。

`SYSCAT.VIEWS.TEXT` 为 `CLOB(2M)`，内容是视图 CREATE 语句原文（IBM 文档：*"Full text of the view or materialized query table CREATE statement, exactly as typed"*），取回即为完整 DDL。Rust 侧无需改动：`build_view_ddl_sql` 会识别以 `CREATE`/`ALTER` 开头的原文并直接透传。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

不涉及前端。改动仅限 `agents/drivers/db2/` 下的 Java agent（1 个源文件 + 1 个测试文件），未触碰任何 Vue/TS/样式/文案。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

**已执行**：`Db2AgentTest` 12/12 通过，含 2 个新增用例：

- `viewObjectSourceReadsDefinitionFromSyscatViews` — 断言 VIEW 走 `SYSCAT.VIEWS` 并返回定义原文
- `routineObjectSourceStillReadsSyscatRoutines` — 防止存储过程路径回归

反向验证：单独编译修复前的 `Db2Agent.java` 重跑，新用例以 bug 特征精确失败（`expected SYSCAT.VIEWS but was SYSCAT.ROUTINES`），routine 用例仍通过。

**未执行**：`make check`（`pnpm check`）与 `make cargo-check-fast`（`cargo check`）。本 PR 未改动任何 TS/Vue 或 Rust 代码，两者均不受影响。

未连接真实 DB2 实例做端到端验证。

## 关联 Issue

Related #8349