### PR TITLE
fix(import): honor connection query timeout for non-mysql sql file execution

### DIFF
--- a/crates/dbx-core/src/sql_file_import.rs
+++ b/crates/dbx-core/src/sql_file_import.rs
@@ -1783,6 +1783,10 @@ async fn execute_sql_file_statement(
         })
     };
 
+    let timeout_secs = {
+        let configs = state.configs.read().await;
+        configs.get(&request.connection_id).map(|config| config.effective_query_timeout_secs())
+    };
     let result = execute_sql_statement_with_options(
         state,
         &request.connection_id,
@@ -1790,7 +1794,7 @@ async fn execute_sql_file_statement(
         sql,
         None,
         Some(child_token),
-        QueryExecutionOptions { execution_id: Some(execution_id), ..Default::default() },
+        QueryExecutionOptions { execution_id: Some(execution_id), timeout_secs, ..Default::default() },
     )
     .await;
 


### PR DESCRIPTION
## Problem

Executing a SQL file against a non-MySQL connection always times out at 30s, regardless of the connection's configured query timeout.

## Root cause

`execute_sql_file_statement` (`crates/dbx-core/src/sql_file_import.rs`) builds `QueryExecutionOptions { execution_id, ..Default::default() }`, leaving `timeout_secs` as `None`. `resolve_query_timeout(None)` falls back to the hardcoded `QUERY_TIMEOUT` (30s, `query.rs:31`), so the connection's `query_timeout_secs` is never read.

The MySQL path already honors the config via `DbOperationBudget::from_connection_config`; only the non-MySQL path was broken.

## Fix

Read the connection's `effective_query_timeout_secs()` and pass it as `timeout_secs`, so `Some(0)` (unlimited) and any configured value are respected.

## Verification

`cargo check -p dbx-core` and `cargo test -p dbx-core --lib sql_file_import` (33 passed).