### PR TITLE
fix(elasticsearch): support fuzzy index completion

### DIFF
--- a/apps/desktop/src/lib/elasticsearch/elasticsearchCompletion.ts
+++ b/apps/desktop/src/lib/elasticsearch/elasticsearchCompletion.ts
@@ -242,7 +242,7 @@ function pathItems(context: ElasticsearchCompletionContext, indices: string[]): 
 
 function indexItems(prefix: string, indices: string[]): ElasticsearchCompletionItem[] {
   return indices
-    .filter((index) => matchesFuzzyPrefix(index, prefix))
+    .filter((index) => matchesIndexFuzzyPrefix(index, prefix))
     .slice(0, 100)
     .map((index) => ({
       label: index,
@@ -371,6 +371,18 @@ function readWordPrefix(text: string, cursor: number): { prefix: string; from: n
 
 function matchesPrefix(value: string, prefix: string): boolean {
   return value.toLowerCase().startsWith(prefix.toLowerCase());
+}
+
+function matchesIndexFuzzyPrefix(value: string, prefix: string): boolean {
+  const normalizedValue = value.toLowerCase();
+  const normalizedPrefix = prefix.toLowerCase();
+  let from = 0;
+  for (const char of normalizedPrefix) {
+    const position = normalizedValue.indexOf(char, from);
+    if (position < 0) return false;
+    from = position + char.length;
+  }
+  return true;
 }
 
 function matchesFuzzyPrefix(value: string, prefix: string): boolean {

--- a/packages/app-tests/elasticsearchCompletion.test.ts
+++ b/packages/app-tests/elasticsearchCompletion.test.ts
@@ -60,6 +60,18 @@ test("suggests Elasticsearch indices by prefix", () => {
   );
 });
 
+test("suggests Elasticsearch indices by case-insensitive ordered cross-segment match", () => {
+  const text = "GET /MiM";
+  const items = buildElasticsearchCompletionItems(text, text.length, {
+    indices: ["my_index_misc_20260907", "my_index_logs_20260907"],
+  });
+
+  assert.deepEqual(
+    items.filter((item) => item.detail === "index").map((item) => item.label),
+    ["my_index_misc_20260907"],
+  );
+});
+
 test("index completion preserves endpoint suffix after cursor", () => {
   const text = "GET /ord/_search";
   const cursor = "GET /ord".length;


### PR DESCRIPTION
## 变更说明

- Elasticsearch 索引名称补全支持大小写不敏感的有序跨段模糊匹配，例如 `MiM` 可以匹配 `my_index_misc_20260907`
- 保留现有前缀排序、候选结构和插入行为
- API endpoint 与 JSON key/snippet 仍使用原有连续子串匹配，避免扩大行为范围

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

补全筛选逻辑变更，不涉及布局、样式或文案。未启动 Tauri；通过 issue 示例的定向回归测试验证实际候选输出。

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `pnpm exec vitest run packages/app-tests/elasticsearchCompletion.test.ts --maxWorkers=1` — 17/17 通过
- `pnpm exec oxlint apps/desktop/src/lib/elasticsearch/elasticsearchCompletion.ts packages/app-tests/elasticsearchCompletion.test.ts`
- `pnpm exec oxfmt --check apps/desktop/src/lib/elasticsearch/elasticsearchCompletion.ts`
- `git diff --check upstream/main...HEAD`

TDD 复现：修复前新增用例返回空候选并失败；修复后 `MiM` 仅匹配 `my_index_misc_20260907`，不会误匹配 `my_index_logs_20260907`。

未运行全量检查或 Rust 检查：改动仅涉及前端 TypeScript 索引候选过滤，并已执行对应定向测试。

## 关联 Issue

Fixes #8322