### PR TITLE
fix(grid): keep restored sort out of where clause

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -939,7 +939,7 @@ function refreshQueryEditorCompletionCache(): boolean {
 
 function reloadUnavailableDataTab() {
   const { whereInput, orderBy } = restoredDataTabReloadFilters(props.activeTab);
-  emit("reload", props.activeTab.id, undefined, whereInput, orderBy);
+  emit("reload", props.activeTab.id, undefined, undefined, whereInput, orderBy);
 }
 
 function refreshData(): boolean {

--- a/apps/desktop/src/components/layout/__tests__/ContentArea.unavailableDataReload.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/ContentArea.unavailableDataReload.spec.ts
@@ -15,7 +15,8 @@ describe("ContentArea restored data-tab refresh", () => {
 
   it("passes the restored tab's own WHERE/ORDER BY into the reload event", () => {
     expect(contentAreaSource).toContain("const { whereInput, orderBy } = restoredDataTabReloadFilters(props.activeTab);");
-    // tabId-first contract: the reload event carries the owning tab's id.
-    expect(contentAreaSource).toContain(`emit("reload", props.activeTab.id, undefined, whereInput, orderBy);`);
+    // The tabId-first contract still reserves the sql and searchText slots before
+    // the restored filters. Omitting either placeholder shifts ORDER BY into WHERE.
+    expect(contentAreaSource).toContain(`emit("reload", props.activeTab.id, undefined, undefined, whereInput, orderBy);`);
   });
 });


### PR DESCRIPTION
## Summary

- preserve the optional SQL and search-text slots when reloading a restored data tab
- keep restored WHERE and ORDER BY values in their declared event positions
- add a regression assertion for the full reload event contract

## Tests

- `pnpm exec vitest run apps/desktop/src/components/layout/__tests__/ContentArea.unavailableDataReload.spec.ts apps/desktop/src/lib/table/__tests__/tableDataRefresh.spec.ts apps/desktop/src/composables/__tests__/useDataGridActions.spec.ts --maxWorkers=1`
- `pnpm exec oxfmt --check apps/desktop/src/components/layout/ContentArea.vue apps/desktop/src/components/layout/__tests__/ContentArea.unavailableDataReload.spec.ts`
- `pnpm exec oxlint --vue-plugin apps/desktop/src/components/layout/ContentArea.vue apps/desktop/src/components/layout/__tests__/ContentArea.unavailableDataReload.spec.ts`
- `git diff --check upstream/main...HEAD`

Closes #8410