### PR TITLE
fix(mqtt): preserve paused message selection

### DIFF
--- a/apps/desktop/src/components/mqtt/MqttAdminConsole.vue
+++ b/apps/desktop/src/components/mqtt/MqttAdminConsole.vue
@@ -209,6 +209,11 @@ function handleTopicClick(topic: string) {
   void refreshData();
 }
 
+function handleMessageClick(topic: string) {
+  if (messagesPaused.value) return;
+  handleTopicClick(topic);
+}
+
 function handleMessagePublished() {
   void refreshData();
 }
@@ -386,7 +391,7 @@ onUnmounted(stopPolling);
                   ? 'ml-auto max-w-[85%] rounded-l-md border-r-2 border-emerald-400 bg-emerald-50/70 hover:bg-emerald-100/70 dark:border-emerald-500 dark:bg-emerald-950/30 dark:hover:bg-emerald-950/50'
                   : 'mr-auto max-w-[85%] rounded-r-md border-l-2 border-blue-400 bg-blue-50/70 hover:bg-blue-100/70 dark:border-blue-500 dark:bg-blue-950/30 dark:hover:bg-blue-950/50'
               "
-              @click="handleTopicClick(msg.topic)"
+              @click="handleMessageClick(msg.topic)"
             >
               <div class="mb-0.5 flex items-center gap-2">
                 <span v-if="msg.direction === 'sent'" class="shrink-0 text-[10px] font-bold text-emerald-600 dark:text-emerald-400">{{ t("connection.mqttSent") }}</span>

--- a/apps/desktop/src/components/mqtt/__tests__/MqttAdminConsolePause.spec.ts
+++ b/apps/desktop/src/components/mqtt/__tests__/MqttAdminConsolePause.spec.ts
@@ -32,9 +32,9 @@ vi.mock("@/lib/backend/api", () => ({
 
 const mountedApps: App[] = [];
 
-function messageAt(index: number): MqttMessage {
+function messageAt(index: number, topic = "device/status"): MqttMessage {
   return {
-    topic: "device/status",
+    topic,
     payloadBase64: btoa(`payload-${index}`),
     payloadText: `payload-${index}`,
     qos: 0,
@@ -124,5 +124,37 @@ describe("MQTT 控制台消息暂停自动滚动 (issue #5615)", () => {
     await nextTick();
     await vi.advanceTimersByTimeAsync(3000);
     expect(mqttGetMessagesMock).toHaveBeenCalled();
+  });
+});
+
+describe("MQTT 控制台暂停后选择消息 (issue #8353)", () => {
+  it("点击暂停后的消息内容时不会重新获取并替换消息", async () => {
+    mqttGetMessagesMock.mockResolvedValue([messageAt(0, "device/other")]);
+    const container = await mountConsole();
+    await Promise.resolve();
+    await Promise.resolve();
+    await nextTick();
+    expect(container.textContent).toContain("payload-0");
+    expect(container.textContent).toContain("消息：device/status");
+
+    const pauseButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("暂停"));
+    expect(pauseButton).toBeTruthy();
+    pauseButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+
+    mqttGetMessagesMock.mockClear();
+    mqttGetMessagesMock.mockResolvedValue([messageAt(1, "device/other")]);
+    const messageRow = Array.from(container.querySelectorAll(".cursor-pointer")).find((element) => element.textContent?.includes("payload-0"));
+    expect(messageRow).toBeTruthy();
+    messageRow?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await nextTick();
+
+    expect(mqttGetMessagesMock).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("payload-0");
+    expect(container.textContent).not.toContain("payload-1");
+    expect(container.textContent).toContain("消息：device/status");
+    expect(container.textContent).not.toContain("消息：device/other");
   });
 });


### PR DESCRIPTION
## 变更说明

- 暂停 MQTT 消息更新后，点击消息 Payload 不再切换 topic 或触发数据刷新
- 保留未暂停时点击消息筛选 topic，以及 Topic 树点击刷新的现有行为
- 增加回归测试，覆盖暂停点击时请求、消息 DOM 和当前 topic 均保持不变

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动

本修复没有静态视觉变化；它只阻止暂停状态下消息行点击触发刷新。问题报告中的录屏上传失败，因此使用组件回归测试验证该交互。

## 验证

- [ ] `make check` 通过（未运行全仓检查，避免启动不相关的重型检查）
- [ ] `make cargo-check-fast` 通过（纯前端改动）
- [x] 相关测试通过

验证命令：

    pnpm exec vitest run apps/desktop/src/components/mqtt/__tests__ --maxWorkers=1
    pnpm exec oxlint --vue-plugin apps/desktop/src/components/mqtt/MqttAdminConsole.vue apps/desktop/src/components/mqtt/__tests__/MqttAdminConsolePause.spec.ts

结果：4 个测试文件、16 个测试全部通过；目标文件 lint 和 diff check 通过。

## 关联 Issue

Close #8353
