### PR TITLE
fix(mcp): refresh pools after connection changes

### DIFF
--- a/crates/dbx-mcp/src/backend.rs
+++ b/crates/dbx-mcp/src/backend.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use dbx_core::{
     agent_events::{ToolCall, ToolResult},
     agent_tools::{self, format_query_result_as_text, AgentSqlPermissions, QueryCellWindow},
-    connection::AppState,
+    connection::{connection_configs_pool_equivalent, AppState},
     db::{mongo_driver::MongoIndexSpec, redis_driver::RedisCommandResult, ColumnInfo, TableInfo},
     mcp_policy::{connection_group_paths, McpConnectionGroupPath},
     models::connection::{ConnectionConfig, DatabaseType},
@@ -598,19 +598,34 @@ impl LocalBackend {
     /// needs this — WebBackend talks HTTP and holds no local AppState, and the desktop mcp_bridge
     /// shares the DBX process so it is unaffected by this cache desync.
     async fn sync_runtime_configs(&self, configs: &[ConnectionConfig]) {
-        let mut runtime = self.state.configs.write().await;
-        for config in configs {
-            match runtime.get(&config.id) {
-                Some(existing) if existing == config => {}
-                _ => {
-                    runtime.insert(config.id.clone(), config.clone());
+        let pool_ids_to_drop = {
+            let mut runtime = self.state.configs.write().await;
+            let mut pool_ids_to_drop = Vec::new();
+            for config in configs {
+                match runtime.get(&config.id) {
+                    Some(existing) if existing == config => {}
+                    Some(existing) => {
+                        if !connection_configs_pool_equivalent(existing, config) {
+                            pool_ids_to_drop.push(config.id.clone());
+                        }
+                        runtime.insert(config.id.clone(), config.clone());
+                    }
+                    None => {
+                        runtime.insert(config.id.clone(), config.clone());
+                    }
                 }
             }
-        }
-        let stale_ids: Vec<String> =
-            runtime.keys().filter(|id| !configs.iter().any(|config| &config.id == *id)).cloned().collect();
-        for id in stale_ids {
-            runtime.remove(&id);
+            let stale_ids: Vec<String> =
+                runtime.keys().filter(|id| !configs.iter().any(|config| &config.id == *id)).cloned().collect();
+            for id in &stale_ids {
+                runtime.remove(id);
+            }
+            pool_ids_to_drop.extend(stale_ids);
+            pool_ids_to_drop
+        };
+
+        for id in pool_ids_to_drop {
+            self.state.remove_connection_pools_detached(&id).await;
         }
     }
 }
@@ -817,6 +832,7 @@ impl DbxBackend for LocalBackend {
         let removed = self.state.storage.remove_connection_for_mcp(connection_id).await?;
         if removed {
             self.state.configs.write().await.remove(connection_id);
+            self.state.remove_connection_pools_detached(connection_id).await;
         }
         Ok(removed)
     }

--- a/crates/dbx-mcp/tests/local.rs
+++ b/crates/dbx-mcp/tests/local.rs
@@ -353,6 +353,94 @@ async fn local_backend_picks_up_connections_added_after_startup_without_reload()
 }
 
 #[tokio::test]
+async fn local_backend_replaces_pool_after_connection_config_changes() {
+    let directory = tempdir().expect("temporary data directory");
+    let db_path = directory.path().join("dbx.db");
+    let first_data_path = directory.path().join("first.sqlite");
+    let second_data_path = directory.path().join("second.sqlite");
+    drop(Storage::open(&first_data_path).await.expect("create first SQLite database"));
+    drop(Storage::open(&second_data_path).await.expect("create second SQLite database"));
+    let first_data_path = first_data_path.canonicalize().expect("canonicalize first SQLite path");
+    let second_data_path = second_data_path.canonicalize().expect("canonicalize second SQLite path");
+
+    let storage = Storage::open(&db_path).await.expect("open storage");
+    let mut connection: ConnectionConfig = serde_json::from_value(json!({
+        "id": "updated-sqlite",
+        "name": "updated-sqlite",
+        "db_type": "sqlite",
+        "host": first_data_path.to_string_lossy(),
+        "port": 0,
+        "username": "",
+        "password": "",
+        "database": "",
+        "ssl": false
+    }))
+    .expect("initial connection config");
+    storage.save_connections(std::slice::from_ref(&connection)).await.expect("save initial connection");
+
+    let backend = LocalBackend::open(&db_path).await.expect("open local backend");
+    let initial_result = backend
+        .execute_query(&connection, "", "PRAGMA database_list", None, None)
+        .await
+        .expect("query initial database");
+    assert_eq!(initial_result.rows[0][2], json!(first_data_path.to_string_lossy()));
+
+    connection.host = second_data_path.to_string_lossy().into_owned();
+    storage.save_connections(std::slice::from_ref(&connection)).await.expect("save updated connection");
+    let updated = backend.load_connections().await.expect("reload updated connection");
+    let updated = updated.first().expect("updated connection");
+
+    let updated_result =
+        backend.execute_query(updated, "", "PRAGMA database_list", None, None).await.expect("query updated database");
+    assert_eq!(updated_result.rows[0][2], json!(second_data_path.to_string_lossy()));
+}
+
+#[tokio::test]
+async fn local_backend_replaces_pool_after_connection_is_deleted_and_recreated() {
+    let directory = tempdir().expect("temporary data directory");
+    let db_path = directory.path().join("dbx.db");
+    let first_data_path = directory.path().join("first.sqlite");
+    let second_data_path = directory.path().join("second.sqlite");
+    drop(Storage::open(&first_data_path).await.expect("create first SQLite database"));
+    drop(Storage::open(&second_data_path).await.expect("create second SQLite database"));
+    let first_data_path = first_data_path.canonicalize().expect("canonicalize first SQLite path");
+    let second_data_path = second_data_path.canonicalize().expect("canonicalize second SQLite path");
+
+    let storage = Storage::open(&db_path).await.expect("open storage");
+    let connection: ConnectionConfig = serde_json::from_value(json!({
+        "id": "recreated-sqlite",
+        "name": "recreated-sqlite",
+        "db_type": "sqlite",
+        "host": first_data_path.to_string_lossy(),
+        "port": 0,
+        "username": "",
+        "password": "",
+        "database": "",
+        "ssl": false
+    }))
+    .expect("initial connection config");
+    storage.save_connections(std::slice::from_ref(&connection)).await.expect("save initial connection");
+
+    let backend = LocalBackend::open(&db_path).await.expect("open local backend");
+    let initial_result = backend
+        .execute_query(&connection, "", "PRAGMA database_list", None, None)
+        .await
+        .expect("query initial database");
+    assert_eq!(initial_result.rows[0][2], json!(first_data_path.to_string_lossy()));
+
+    assert!(backend.remove_connection_for_mcp(&connection.id).await.expect("remove connection"));
+    let mut recreated = connection;
+    recreated.host = second_data_path.to_string_lossy().into_owned();
+    let recreated = backend.add_connection_for_mcp(recreated).await.expect("recreate connection");
+
+    let recreated_result = backend
+        .execute_query(&recreated, "", "PRAGMA database_list", None, None)
+        .await
+        .expect("query recreated database");
+    assert_eq!(recreated_result.rows[0][2], json!(second_data_path.to_string_lossy()));
+}
+
+#[tokio::test]
 #[cfg(feature = "duckdb-sidecar")]
 async fn local_backend_uses_the_installed_duckdb_sidecar() {
     let directory = tempdir().expect("temporary data directory");


### PR DESCRIPTION
## Summary

- invalidate LocalBackend connection pools when persisted connection settings change
- evict pools when MCP deletes a connection so recreating the same ID cannot reuse stale credentials
- cover update and delete/recreate flows with real file-backed SQLite regression tests

## Testing

- `nice -n 10 cargo test -j 1 -p dbx-mcp --no-default-features --features sqlite-bundled --test local` (6 passed, 3 ignored: require external MongoDB)
- `rustfmt --edition 2021 --check crates/dbx-mcp/src/backend.rs crates/dbx-mcp/tests/local.rs`
- `git diff --check upstream/main...HEAD`

Closes #8385