### PR TITLE
fix(sqlserver): 修复 SQL Server 2000 修改数据时连接关闭

### DIFF
--- a/crates/dbx-core/src/query.rs
+++ b/crates/dbx-core/src/query.rs
@@ -832,7 +832,9 @@ async fn connection_database_type_for_pool_key(state: &AppState, pool_key: &str)
 }
 
 fn schema_for_execution_context(db_type: Option<DatabaseType>, schema: Option<&str>) -> Option<&str> {
-    if matches!(db_type, Some(DatabaseType::Iris)) {
+    // SQL Server has no session-level schema switch. Data-grid DML already uses
+    // qualified names, while legacy jTDS can mis-handle schema as catalog.
+    if matches!(db_type, Some(DatabaseType::Iris | DatabaseType::SqlServer)) {
         None
     } else {
         schema
@@ -4965,6 +4967,7 @@ async fn begin_transaction_session(
             (TxnConnection::Mysql(Some(conn)), probe_pool_key.clone())
         }
         TxnPoolHandle::Agent => {
+            let db_type = connection_database_type(state, connection_id).await;
             let client_session_id = format!("manual-txn-{}", uuid::Uuid::new_v4());
             let agent_pool_key =
                 state.get_or_create_pool_for_session(connection_id, pool_database, Some(&client_session_id)).await?;
@@ -4980,7 +4983,9 @@ async fn begin_transaction_session(
             };
             let begin_result = {
                 let mut locked = client.lock().await;
-                locked.begin_manual_transaction::<serde_json::Value>(schema).await
+                locked
+                    .begin_manual_transaction::<serde_json::Value>(schema_for_execution_context(db_type, schema))
+                    .await
             };
             if let Err(error) = begin_result {
                 let _ = state.close_client_session_pool(connection_id, pool_database, &client_session_id).await;
@@ -6821,6 +6826,18 @@ for line in sys.stdin:
             'rows': [[req['params']['sql']]], 'affected_rows': 0, 'execution_time_ms': 1,
             'truncated': False, 'session_id': None, 'has_more': False
         }
+    elif req['method'] in ('execute_batch', 'execute_transaction'):
+        if req['params'].get('schema') is not None:
+            print(json.dumps({
+                'jsonrpc': '2.0', 'id': req['id'],
+                'error': {'code': -1, 'message': 'legacy SQL Server schema switch attempted'}
+            }), flush=True)
+            continue
+        result = {
+            'columns': [], 'column_types': [], 'column_sortables': [], 'rows': [],
+            'affected_rows': 1, 'execution_time_ms': 1, 'truncated': False,
+            'session_id': None, 'has_more': False
+        }
     else:
         result = {}
     print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'result': result}), flush=True)
@@ -6878,6 +6895,25 @@ for line in sys.stdin:
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].result.rows, vec![vec![serde_json::Value::String(sql.to_string())]]);
+
+        runtime.kill();
+        drop(state);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn sqlserver_agent_write_paths_do_not_request_schema_switch() {
+        let (state, dir, runtime) = sqlserver_agent_echo_state().await;
+        let statements = ["UPDATE [dbo].[users] SET [active] = 1 WHERE [id] = 7".to_string()];
+
+        let batch = execute_statements(&state, "conn-1", "", &statements, Some("dbo"), None).await.unwrap();
+        let transaction =
+            execute_statements_in_transaction_on_pool(&state, "conn-1", "conn-1", "", &statements, Some("dbo"), None)
+                .await
+                .unwrap();
+
+        assert_eq!(batch.affected_rows, 1);
+        assert_eq!(transaction.affected_rows, 1);
 
         runtime.kill();
         drop(state);
@@ -9300,8 +9336,9 @@ for line in sys.stdin:
     }
 
     #[test]
-    fn iris_execution_context_omits_schema() {
+    fn agent_execution_context_omits_unsupported_schema_switches() {
         assert_eq!(schema_for_execution_context(Some(DatabaseType::Iris), Some("SQLUser")), None);
+        assert_eq!(schema_for_execution_context(Some(DatabaseType::SqlServer), Some("dbo")), None);
         assert_eq!(schema_for_execution_context(Some(DatabaseType::Oracle), Some("APP")), Some("APP"));
         assert_eq!(schema_for_execution_context(None, Some("APP")), Some("APP"));
     }

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -8887,7 +8887,7 @@ where
         .get(&table)
         .map(|foreign_keys| HashMap::from([(table.clone(), foreign_keys.clone())]))
         .unwrap_or_default();
-    let preexisting_backup_names = preexisting_backup_names.map(|m| m.clone());
+    let preexisting_backup_names = preexisting_backup_names.cloned();
     // Kept outside the spawned task: `request` moves into it, and the error path below
     // still needs the backup's qualified name to point the user at their data.
     let backup_for_this_table = request


### PR DESCRIPTION
## 问题

SQL Server 2000 使用 `sqlserver-legacy` Agent 和 jTDS 1.3.1。数据表编辑保存时，Core 会把表 schema（通常为 `dbo`）作为执行上下文传给 Agent；该 Agent 明确不支持 SQL Server schema 切换，但通用 JDBC 回退仍会依次调用 `Connection.setSchema("dbo")` 和 `Connection.setCatalog("dbo")`。

jTDS 1.3.1 不支持 JDBC 4.1 的 `setSchema`，而 `setCatalog` 会把 schema 错当成数据库名。该错误路径可能使 Hikari 代理连接失效，随后执行 DML 时返回 issue 中一致的 `java.sql.SQLException: Connection is closed`。

## 修复

- SQL Server Agent 的查询、批量写入和事务写入不再传递 schema 执行上下文。
- 手动事务开始阶段同样过滤 SQL Server schema，避免在执行 DML 前触发错误。
- 数据表编辑生成的 SQL 仍使用完整限定名（如 `[dbo].[users]`），不依赖会话级 schema 切换。
- 增加模拟旧版 Agent 的写入回归测试：只要收到非空 schema 就报错，并覆盖 `execute_batch` 与 `execute_transaction` 两条真实分发路径。
- 最新主线在 Rust 1.97 下触发 `clippy::map_clone`，以独立提交将等价写法改为 `.cloned()`，解除本 PR 和同主线 PR 的 CI 阻断。

## 验证

- `cargo test -p dbx-core sqlserver_agent --lib`（5 passed）
- `cargo test -p dbx-core prepares_sqlserver --lib`（5 passed）
- `cargo test -p dbx-core agent_execution_context_omits_unsupported_schema_switches --lib`（1 passed）
- `cargo clippy -p dbx-core --locked --all-targets --no-default-features --features "duckdb-sidecar,dynamodb,mq-admin,sqlite-sqlcipher" -- -D warnings`
- `cd agents && ./gradlew :sqlserver-legacy:test`（BUILD SUCCESSFUL）
- `git diff --check`
- `rustfmt --edition 2021 --check crates/dbx-core/src/query.rs`

当前没有 SQL Server 2000 实机环境，因此以上属于报错特征、JDBC 调用链和模拟 Agent 的代码级复现与回归验证，不宣称已在 SQL Server 2000 上完成端到端验证。

无 UI 改动，不需要截图。

Closes #8299
Closes #8302