### PR TITLE
perf(sidebar): add large schema benchmark

### DIFF
--- a/apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts
@@ -1,0 +1,91 @@
+import { bench, describe } from "vitest";
+
+import { filterSidebarTree } from "@/lib/sidebar/sidebarSearchTree";
+import { buildTableTreeNodes } from "@/lib/table/tableTree";
+import type { TableInfo, TreeNode } from "@/types/database";
+
+const CONNECTION_ID = "benchmark-connection";
+const DATABASE = "benchmark";
+const SCHEMA = "public";
+const EMPTY_COLLAPSED_IDS = new Set<string>();
+const TABLE_COUNTS = [1_000, 10_000] as const;
+
+function tableName(index: number): string {
+  return `customer_orders_${index.toString().padStart(5, "0")}`;
+}
+
+function generateTables(count: number): TableInfo[] {
+  return Array.from({ length: count }, (_, index) => ({
+    name: tableName(index),
+    table_type: "BASE TABLE",
+    comment: index % 10 === 0 ? `benchmark table ${index}` : null,
+    parent_schema: null,
+    parent_name: null,
+  }));
+}
+
+function buildSearchTree(tableNodes: TreeNode[]): TreeNode[] {
+  return [
+    {
+      id: CONNECTION_ID,
+      label: "Benchmark",
+      type: "connection",
+      connectionId: CONNECTION_ID,
+      isExpanded: true,
+      children: [
+        {
+          id: `${CONNECTION_ID}:${SCHEMA}`,
+          label: SCHEMA,
+          type: "schema",
+          connectionId: CONNECTION_ID,
+          database: DATABASE,
+          schema: SCHEMA,
+          isExpanded: true,
+          children: [
+            {
+              id: `${CONNECTION_ID}:${SCHEMA}:__tables`,
+              label: "Tables",
+              type: "group-tables",
+              connectionId: CONNECTION_ID,
+              database: DATABASE,
+              schema: SCHEMA,
+              isExpanded: true,
+              children: tableNodes,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+for (const tableCount of TABLE_COUNTS) {
+  const tables = generateTables(tableCount);
+  const tableNodes = buildTableTreeNodes({
+    nodeId: `${CONNECTION_ID}:${SCHEMA}:__tables`,
+    connectionId: CONNECTION_ID,
+    database: DATABASE,
+    schema: SCHEMA,
+    tables,
+  });
+  const searchTree = buildSearchTree(tableNodes);
+  const tailQuery = tableName(tableCount - 1);
+
+  describe(`large sidebar schema: ${tableCount.toLocaleString()} tables`, () => {
+    bench("build table tree nodes", () => {
+      const nodes = buildTableTreeNodes({
+        nodeId: `${CONNECTION_ID}:${SCHEMA}:__tables`,
+        connectionId: CONNECTION_ID,
+        database: DATABASE,
+        schema: SCHEMA,
+        tables,
+      });
+      if (nodes.length !== tableCount) throw new Error(`expected ${tableCount} table nodes`);
+    });
+
+    bench("filter sidebar tree for a tail table", () => {
+      const filtered = filterSidebarTree(searchTree, tailQuery, EMPTY_COLLAPSED_IDS);
+      if (filtered.length === 0) throw new Error("expected the tail table query to match");
+    });
+  });
+}

--- a/apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts
@@ -8,15 +8,16 @@ const CONNECTION_ID = "benchmark-connection";
 const DATABASE = "benchmark";
 const SCHEMA = "public";
 const EMPTY_COLLAPSED_IDS = new Set<string>();
-const TABLE_COUNTS = [1_000, 10_000] as const;
+const TABLE_COUNTS = [1_000, 10_000, 50_000] as const;
+const STRUCTURE_TABLE_COUNT = 10_000;
 
 function tableName(index: number): string {
   return `customer_orders_${index.toString().padStart(5, "0")}`;
 }
 
-function generateTables(count: number): TableInfo[] {
+function generateTables(count: number, resolveName: (index: number) => string = tableName): TableInfo[] {
   return Array.from({ length: count }, (_, index) => ({
-    name: tableName(index),
+    name: resolveName(index),
     table_type: "BASE TABLE",
     comment: index % 10 === 0 ? `benchmark table ${index}` : null,
     parent_schema: null,
@@ -24,7 +25,34 @@ function generateTables(count: number): TableInfo[] {
   }));
 }
 
+function buildTableNodes(tables: TableInfo[], schema = SCHEMA, nodeId = `${CONNECTION_ID}:${schema}:__tables`): TreeNode[] {
+  return buildTableTreeNodes({
+    nodeId,
+    connectionId: CONNECTION_ID,
+    database: DATABASE,
+    schema,
+    tables,
+  });
+}
+
+function tableGroup(schema: string, tableNodes: TreeNode[]): TreeNode {
+  return {
+    id: `${CONNECTION_ID}:${schema}:__tables`,
+    label: "Tables",
+    type: "group-tables",
+    connectionId: CONNECTION_ID,
+    database: DATABASE,
+    schema,
+    isExpanded: true,
+    children: tableNodes,
+  };
+}
+
 function buildSearchTree(tableNodes: TreeNode[]): TreeNode[] {
+  return buildMultiSchemaSearchTree([{ schema: SCHEMA, tableNodes }]);
+}
+
+function buildMultiSchemaSearchTree(schemas: Array<{ schema: string; tableNodes: TreeNode[] }>): TreeNode[] {
   return [
     {
       id: CONNECTION_ID,
@@ -32,60 +60,130 @@ function buildSearchTree(tableNodes: TreeNode[]): TreeNode[] {
       type: "connection",
       connectionId: CONNECTION_ID,
       isExpanded: true,
-      children: [
-        {
-          id: `${CONNECTION_ID}:${SCHEMA}`,
-          label: SCHEMA,
-          type: "schema",
-          connectionId: CONNECTION_ID,
-          database: DATABASE,
-          schema: SCHEMA,
-          isExpanded: true,
-          children: [
-            {
-              id: `${CONNECTION_ID}:${SCHEMA}:__tables`,
-              label: "Tables",
-              type: "group-tables",
-              connectionId: CONNECTION_ID,
-              database: DATABASE,
-              schema: SCHEMA,
-              isExpanded: true,
-              children: tableNodes,
-            },
-          ],
-        },
-      ],
+      children: schemas.map(({ schema, tableNodes }) => ({
+        id: `${CONNECTION_ID}:${schema}`,
+        label: schema,
+        type: "schema" as const,
+        connectionId: CONNECTION_ID,
+        database: DATABASE,
+        schema,
+        isExpanded: true,
+        children: [tableGroup(schema, tableNodes)],
+      })),
     },
   ];
 }
 
+function visibleTableCount(filtered: TreeNode[]): number {
+  const connection = filtered[0];
+  if (!connection) return 0;
+  return (connection.children ?? []).reduce((count, schema) => count + (schema.children?.[0]?.children?.length ?? 0), 0);
+}
+
+function seededShuffle<T>(items: readonly T[], seed: number): T[] {
+  const shuffled = [...items];
+  let state = seed >>> 0;
+  const random = () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const target = Math.floor(random() * (index + 1));
+    [shuffled[index], shuffled[target]] = [shuffled[target], shuffled[index]];
+  }
+  return shuffled;
+}
+
 for (const tableCount of TABLE_COUNTS) {
   const tables = generateTables(tableCount);
-  const tableNodes = buildTableTreeNodes({
-    nodeId: `${CONNECTION_ID}:${SCHEMA}:__tables`,
-    connectionId: CONNECTION_ID,
-    database: DATABASE,
-    schema: SCHEMA,
-    tables,
-  });
+  const tableNodes = buildTableNodes(tables);
   const searchTree = buildSearchTree(tableNodes);
-  const tailQuery = tableName(tableCount - 1);
+  const queries = [
+    { name: "no match", query: "missing_table", expectedMatches: 0 },
+    { name: "all tables", query: "customer", expectedMatches: tableCount },
+    { name: "first table", query: tableName(0), expectedMatches: 1 },
+    { name: "middle table", query: tableName(Math.floor(tableCount / 2)), expectedMatches: 1 },
+    { name: "last table", query: tableName(tableCount - 1), expectedMatches: 1 },
+    { name: "table comment", query: `benchmark table ${tableCount - 10}`, expectedMatches: 1 },
+  ] as const;
 
   describe(`large sidebar schema: ${tableCount.toLocaleString()} tables`, () => {
     bench("build table tree nodes", () => {
-      const nodes = buildTableTreeNodes({
-        nodeId: `${CONNECTION_ID}:${SCHEMA}:__tables`,
-        connectionId: CONNECTION_ID,
-        database: DATABASE,
-        schema: SCHEMA,
-        tables,
-      });
+      const nodes = buildTableNodes(tables);
       if (nodes.length !== tableCount) throw new Error(`expected ${tableCount} table nodes`);
     });
 
-    bench("filter sidebar tree for a tail table", () => {
-      const filtered = filterSidebarTree(searchTree, tailQuery, EMPTY_COLLAPSED_IDS);
-      if (filtered.length === 0) throw new Error("expected the tail table query to match");
-    });
+    for (const { name, query, expectedMatches } of queries) {
+      bench(`filter sidebar tree: ${name}`, () => {
+        const filtered = filterSidebarTree(searchTree, query, EMPTY_COLLAPSED_IDS);
+        const matches = visibleTableCount(filtered);
+        if (matches !== expectedMatches) throw new Error(`expected ${expectedMatches} table matches, received ${matches}`);
+      });
+    }
   });
 }
+
+describe(`large sidebar schema data shapes: ${STRUCTURE_TABLE_COUNT.toLocaleString()} tables`, () => {
+  const sortedTables = generateTables(STRUCTURE_TABLE_COUNT);
+  const reversedTables = [...sortedTables].reverse();
+  const shuffledTables = seededShuffle(sortedTables, 0x5eed_1234);
+
+  bench("build table tree nodes from reverse order", () => {
+    const nodes = buildTableNodes(reversedTables);
+    if (nodes.length !== STRUCTURE_TABLE_COUNT) throw new Error(`expected ${STRUCTURE_TABLE_COUNT} table nodes`);
+  });
+
+  bench("build table tree nodes from seeded random order", () => {
+    const nodes = buildTableNodes(shuffledTables);
+    if (nodes.length !== STRUCTURE_TABLE_COUNT) throw new Error(`expected ${STRUCTURE_TABLE_COUNT} table nodes`);
+  });
+
+  for (const nameLength of [128, 255] as const) {
+    const suffixLength = nameLength - "long_table_00000_".length;
+    const longNameTables = generateTables(STRUCTURE_TABLE_COUNT, (index) => `long_table_${index.toString().padStart(5, "0")}_${"x".repeat(suffixLength)}`);
+    const longNameTree = buildSearchTree(buildTableNodes(longNameTables));
+    const query = longNameTables[longNameTables.length - 1]?.name ?? "";
+
+    bench(`filter sidebar tree with ${nameLength}-character names`, () => {
+      const filtered = filterSidebarTree(longNameTree, query, EMPTY_COLLAPSED_IDS);
+      if (visibleTableCount(filtered) !== 1) throw new Error("expected one long-name table match");
+    });
+  }
+
+  const unicodeTables = generateTables(STRUCTURE_TABLE_COUNT, (index) => `客户订单_日本語_📦_${index.toString().padStart(5, "0")}`);
+  const unicodeTree = buildSearchTree(buildTableNodes(unicodeTables));
+
+  bench("filter sidebar tree with Unicode names", () => {
+    const filtered = filterSidebarTree(unicodeTree, unicodeTables[unicodeTables.length - 1]?.name ?? "", EMPTY_COLLAPSED_IDS);
+    if (visibleTableCount(filtered) !== 1) throw new Error("expected one Unicode table match");
+  });
+
+  const partitionTables = generateTables(STRUCTURE_TABLE_COUNT).map((table, index, tables) => {
+    if (index % 10 !== 9) return table;
+    return { ...table, parent_schema: SCHEMA, parent_name: tables[index - 1].name };
+  });
+
+  bench("build table tree nodes with ten percent partitions", () => {
+    const nodes = buildTableNodes(partitionTables);
+    const expectedRoots = STRUCTURE_TABLE_COUNT - STRUCTURE_TABLE_COUNT / 10;
+    if (nodes.length !== expectedRoots) throw new Error(`expected ${expectedRoots} root table nodes`);
+  });
+});
+
+describe("large sidebar with ten schemas", () => {
+  const schemaCount = 10;
+  const tablesPerSchema = 1_000;
+  const schemas = Array.from({ length: schemaCount }, (_, schemaIndex) => {
+    const schema = `schema_${schemaIndex.toString().padStart(2, "0")}`;
+    const tables = generateTables(tablesPerSchema, (tableIndex) => `${schema}_${tableName(tableIndex)}`);
+    return { schema, tableNodes: buildTableNodes(tables, schema) };
+  });
+  const searchTree = buildMultiSchemaSearchTree(schemas);
+  const tailQuery = `schema_09_${tableName(tablesPerSchema - 1)}`;
+
+  bench("filter across ten schemas for a tail table", () => {
+    const filtered = filterSidebarTree(searchTree, tailQuery, EMPTY_COLLAPSED_IDS);
+    if (visibleTableCount(filtered) !== 1) throw new Error("expected one cross-schema table match");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:ai-html-canary": "node scripts/ai-html-runtime-canary.mjs",
     "bench:redis-key-search": "node scripts/bench/redis-key-search.mjs",
     "bench:mongodb-count": "node scripts/bench/mongodb-count.mjs",
+    "bench:sidebar-large-schema": "vitest bench apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts",
     "bench:table-import": "cargo run -p dbx-core --no-default-features --example table_import_bench --release --",
     "lint": "oxlint --vue-plugin apps/desktop/src",
     "fmt": "oxfmt \"apps/desktop/src/**/*.{ts,vue}\"",


### PR DESCRIPTION
## 变更说明

新增大型 schema 的侧边栏性能基准。
基准覆盖节点构建和树搜索。
本 PR 不修改产品逻辑。

## 测试数据

基础规模包括 1,000、10,000 和 50,000 张表。

每个规模覆盖以下搜索：

- 无匹配：`missing_table`
- 全部匹配：`customer`
- 首项匹配
- 中间项匹配
- 末项匹配
- 表注释匹配

三个主要搜索场景具有不同的 matcher 成本：

- 无匹配执行完整树遍历。
- 每个表名执行完整 matcher fallback 路径。
- 全部匹配执行完整树遍历。
- 短 prefix query 可以快速匹配。
- 该场景返回大型结果树。
- 单项精确匹配执行完整树遍历。
- 大部分表名执行失败的 matcher 路径。
- 只有一个表名返回精确结果。

10,000 张表还覆盖以下数据形状：

- 逆序输入
- 固定种子的随机输入
- 128 字符表名
- 255 字符表名
- Unicode 表名
- 10% 分区表
- 10 个 schema，每个 schema 1,000 张表

每个基准验证匹配数量。
数据生成不计入测量时间。

## 测试条件

- 提交：`aef8a3bcf`
- 系统：WSL2 Linux 6.18.33.2
- CPU：AMD Ryzen 7 8745HS
- 逻辑 CPU：16
- Node.js：24.15.0
- pnpm：10.27.0
- Vitest：4.1.8
- 命令：`pnpm bench:sidebar-large-schema`

结果来自一次本地运行。
后台负载会影响绝对数值。

## 测试结果

下表单元格格式为“平均值 / P99”，单位为毫秒。

| 表数量 | 构建 | 无匹配 | 全部匹配 | 首项 | 中间项 | 末项 | 注释 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,000 | 0.94 / 4.71 | 2.18 / 3.81 | 0.34 / 0.79 | 3.06 / 5.32 | 3.14 / 5.44 | 3.23 / 5.01 | 2.67 / 4.69 |
| 10,000 | 10.43 / 17.69 | 23.18 / 26.58 | 3.74 / 6.59 | 31.73 / 36.81 | 33.35 / 38.05 | 30.47 / 33.44 | 26.15 / 30.41 |
| 50,000 | 72.70 / 89.42 | 134.40 / 154.95 | 24.10 / 27.77 | 207.14 / 233.96 | 180.91 / 200.32 | 209.73 / 243.88 | 149.11 / 162.33 |

特殊数据形状使用 10,000 张表。

| 数据形状 | 平均值 | P99 |
| --- | ---: | ---: |
| 逆序构建 | 11.49 ms | 17.28 ms |
| 固定随机顺序构建 | 35.94 ms | 45.39 ms |
| 128 字符表名和查询 | 135.77 ms | 167.93 ms |
| 255 字符表名和查询 | 237.02 ms | 251.75 ms |
| Unicode 表名搜索 | 26.73 ms | 32.11 ms |
| 10% 分区表构建 | 13.62 ms | 22.32 ms |
| 10 个 schema 尾部搜索 | 40.09 ms | 48.05 ms |

## 推理

- 首项、中间项和末项耗时接近。
- 搜索位置没有形成明显的提前退出。
- 50,000 张表的单项匹配约需 181 至 210 ms。
- 无匹配比短 prefix 全匹配慢。
- 无匹配会执行完整 matcher fallback 路径。
- 全匹配会快速通过 prefix 判断。
- matcher 路径复杂度可能比结果分配成本更重要。
- 随机输入构建比逆序输入慢约 3.1 倍。
- 排序成本对输入顺序敏感。
- 长标识符场景具有明显更高的搜索成本。
- 当前场景同时改变 label 长度和 query 长度。
- 当前结果不能隔离这两个变量。
- 后续基准应使用固定长度 query。
- 分区表构建比普通构建慢约 31%。
- 10 个 schema 比单 schema 末项搜索慢约 32%。
- Unicode 数据没有显示额外退化。

这些数据适合作为趋势基线。
CI 不应使用固定毫秒阈值。
后续比较应使用相同机器和相同负载。

## 验证

- [x] `pnpm bench:sidebar-large-schema`
- [x] `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- [x] `pnpm exec oxlint apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts`
- [x] `pnpm exec oxfmt --check apps/desktop/src/lib/sidebar/sidebarLargeSchema.bench.ts`
- [x] 相关测试通过：4 个文件，102 个测试
- [ ] `make check` 未完整运行
- [ ] `make cargo-check-fast` 未运行。本 PR 没有 Rust 改动。

## CI 状态

- Database Environments 已通过。
- packages 已通过。
- frontend 在源码检查前失败。
- sccache v0.10.0 下载连续返回 HTTP 500。
- 后续清理找不到 `SCCACHE_PATH`。
- 该失败来自 CI 基础设施。

## 关联 Issue

Closes #8506