### PR TITLE
fix(mq): 隐藏消息队列连接的「查看资源对象」入口

### DIFF
--- a/apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts
@@ -57,6 +57,17 @@ describe("connection database browser", () => {
     expect(supportsConnectionDatabaseBrowser("redis")).toBe(false);
     expect(supportsConnectionDatabaseBrowser("mongodb")).toBe(false);
   });
+
+  it("hides the browse-databases entry for message brokers", () => {
+    // Kafka/Pulsar/RocketMQ/RabbitMQ/NATS all share db_type "mq" and differ only by
+    // driver_profile, so one exclusion covers every broker. They keep the
+    // objectBrowser capability for the tenant/topic tree, but have no database
+    // namespace, so the connection-level browser tab rendered an empty
+    // "no databases found" state (issue #8515). MQTT never had the entry.
+    expect(supportsObjectBrowser("mq")).toBe(true);
+    expect(supportsConnectionDatabaseBrowser("mq")).toBe(false);
+    expect(supportsConnectionDatabaseBrowser("mqtt")).toBe(false);
+  });
 });
 
 describe("object browser tree nodes", () => {

--- a/apps/desktop/src/lib/database/databaseFeatureSupport.ts
+++ b/apps/desktop/src/lib/database/databaseFeatureSupport.ts
@@ -228,7 +228,13 @@ export function supportsObjectBrowser(dbType?: DatabaseType): boolean {
 
 export function supportsConnectionDatabaseBrowser(dbType?: DatabaseType): boolean {
   // MongoDB reuses the object browser for collections, not the SQL database list.
-  return supportsObjectBrowser(dbType) && dbType !== "mongodb";
+  //
+  // Message brokers (`mq` — Kafka/Pulsar/RocketMQ/RabbitMQ/NATS, separated only by
+  // driver_profile) keep the objectBrowser capability for their tenant/topic tree,
+  // but they expose no database namespace: the connection-level browser tab listed
+  // nothing and rendered "no databases found" (issue #8515). Their workbench is the
+  // MQ admin tab instead. MQTT is already excluded: it has no objectBrowser at all.
+  return supportsObjectBrowser(dbType) && dbType !== "mongodb" && dbType !== "mq";
 }
 
 export function supportsObjectBrowserTreeNode(dbType: DatabaseType | undefined, nodeType: TreeNodeType): boolean {


### PR DESCRIPTION
## 变更说明

Kafka 连接的右键菜单里有「查看资源对象」，但消息队列没有数据库命名空间，打开后只显示「没有找到数据库」（#8515）。

`supportsConnectionDatabaseBrowser()` 直接沿用了 manifest 的 `objectBrowser` 能力（`mq` 需要它渲染 tenant/topic 树），只单独排除了 MongoDB。本 PR 把 `mq` 一并排除，与 #8415 隐藏「新建查询」的做法一致。

- Kafka / Pulsar / RocketMQ / RabbitMQ / NATS 共用 `db_type=mq`，仅靠 `driver_profile` 区分，判断只看 `db_type`，一处排除覆盖全部 broker；MQTT 本身 `objectBrowser=false`，此前就没有该入口。
- 右键菜单项与「单击激活模式下双击连接节点」共用 `canOpenConnectionDatabaseBrowser`，双击打开空标签页的问题一并修复。
- 未改 manifest：MQ 的 tenant/topic 树确实是对象浏览器，改能力位会让产品能力矩阵失真；`supportsObjectBrowserTreeNode()` 不受影响（MQ 节点是 `mq-tenant`，本就不在白名单内）。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

仅从连接右键菜单移除一个条目，无组件、样式、文案改动。

**修复前** —— Kafka 连接右键菜单包含「查看资源对象」：

<img width="1440" alt="修复前：Kafka 连接右键菜单包含「查看资源对象」" src="https://github.com/user-attachments/assets/82862aca-3b4b-43bf-a8b0-24145ef287cb" />

**修复后** —— 该项消失，其余条目与顺序不变：

<img width="1440" alt="修复后：该菜单项已移除" src="https://github.com/user-attachments/assets/3bf41f75-7d55-4da6-9568-a24eefc47f98" />

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过


## 关联 Issue

Close #8515
