### PR TITLE
fix(zookeeper): delete non-empty znodes recursively

### DIFF
--- a/agents/drivers/zookeeper/agent_test.go
+++ b/agents/drivers/zookeeper/agent_test.go
@@ -222,9 +222,17 @@ func TestKVOperationsAndPagination(t *testing.T) {
 		t.Fatalf("continuation mismatch error=%v", err)
 	}
 
-	deleted, err := service.delete(json.RawMessage(`{"key":"/app","recursive":true}`))
+	if _, err := service.delete(json.RawMessage(`{"key":"/app","recursive":false}`)); err != zk.ErrNotEmpty {
+		t.Fatalf("non-recursive delete error=%v", err)
+	}
+	deleted, err := service.delete(json.RawMessage(`{"key":"/app"}`))
 	if err != nil || deleted["deleted"].(int) < 4 {
 		t.Fatalf("delete=%#v err=%v", deleted, err)
+	}
+	put(`{"key":"/recursive/child","value":{"data":"v"}}`)
+	deleted, err = service.delete(json.RawMessage(`{"key":"/recursive","recursive":true}`))
+	if err != nil || deleted["deleted"] != 2 {
+		t.Fatalf("explicit recursive delete=%#v err=%v", deleted, err)
 	}
 	missing, err := service.delete(json.RawMessage(`{"key":"/app","recursive":true}`))
 	if err != nil || missing["deleted"] != 0 {

--- a/agents/drivers/zookeeper/operations.go
+++ b/agents/drivers/zookeeper/operations.go
@@ -33,7 +33,7 @@ type putRequest struct {
 
 type deleteRequest struct {
 	Key       string `json:"key"`
-	Recursive bool   `json:"recursive"`
+	Recursive *bool  `json:"recursive"`
 }
 
 type listRequest struct {
@@ -223,7 +223,8 @@ func (service *server) delete(params json.RawMessage) (map[string]any, error) {
 	if !exists {
 		return map[string]any{"deleted": 0}, nil
 	}
-	if !request.Recursive {
+	recursive := request.Recursive == nil || *request.Recursive
+	if !recursive {
 		if err := client.Delete(path); err != nil {
 			if err == zk.ErrNoNode {
 				return map[string]any{"deleted": 0}, nil


### PR DESCRIPTION
## 变更说明

- Treat an omitted ZooKeeper `recursive` delete flag as recursive deletion, matching the desktop and web payload shape.
- Preserve explicit `recursive: false` as single-node deletion.
- Cover omitted, explicit false, explicit true, missing-node, and root-protection behavior with the existing in-memory ZooKeeper service test.

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

No frontend changes.

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过

Run on top of `upstream/main@a4e4fd0d2`:

- `GOMAXPROCS=2 go test ./... -count=1` in `agents/drivers/zookeeper`
- `GOMAXPROCS=2 go vet ./...` in `agents/drivers/zookeeper`
- `gofmt -d operations.go agent_test.go`
- `git diff --check upstream/main...HEAD`

## 关联 Issue

Closes #8470
