### PR TITLE
修复：恢复侧边栏文件格式检查

### DIFF
--- a/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
+++ b/apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue
@@ -1533,9 +1533,7 @@ function openMongoTreeData(node: TreeNode) {
     return;
   }
   if (node.type !== "mongo-collection") return;
-  const existing = queryStore.tabs.find(
-    (tab) => tab.mode === "mongo" && tab.connectionId === node.connectionId && tab.database === node.database && tab.tableMeta?.tableName === node.label,
-  );
+  const existing = queryStore.tabs.find((tab) => tab.mode === "mongo" && tab.connectionId === node.connectionId && tab.database === node.database && tab.tableMeta?.tableName === node.label);
   if (existing) {
     queryStore.switchTab(existing.id);
     return;


### PR DESCRIPTION
## 问题

最新 `main` 中 `SidebarTreeRuntimeHost.vue` 的 MongoDB 标签复用判断不符合当前 oxfmt 输出，导致主分支以及基于该分支创建合并测试提交的 PR 在 `pnpm check` 的 format 阶段失败。

受影响的主分支 CI：

- https://github.com/t8y2/dbx/actions/runs/34303891111
- https://github.com/t8y2/dbx/actions/runs/34306706684

## 修复

仅使用仓库锁定版本的 oxfmt 重新格式化该表达式，不改变运行逻辑。

## 验证

- `oxfmt --check apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue`：通过。
- `git diff --check`：通过。
