### PR TITLE
fix(completion): show derived table columns

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -4940,6 +4940,13 @@ function buildLocalSqlCompletionResult(completionContext: ReturnType<typeof getS
 
   const cteDefs = extractCteDefinitions(fullDoc);
   for (const refTable of completionContext.referencedTables) {
+    if (refTable.columns?.length) {
+      columnsByTable.set(
+        refTable.name,
+        refTable.columns.map((name) => ({ name, table: refTable.name, schema: refTable.schema })),
+      );
+      continue;
+    }
     if (isVirtualCompletionTableReference(refTable)) continue;
     const cteDef = cteDefs.find((c) => c.name.toLowerCase() === refTable.name.toLowerCase());
     if (cteDef) {

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorInlineColumnCompletion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorInlineColumnCompletion.spec.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from "node:fs";
+import { expect, it } from "vitest";
+
+const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
+
+it("maps inline projected columns into local completion results", () => {
+  expect(queryEditorSource).toMatch(/if \(refTable\.columns\?\.length\) \{[\s\S]*?columnsByTable\.set\([\s\S]*?refTable\.columns\.map/);
+});

--- a/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
@@ -441,6 +441,26 @@ WHERE a.id = b.fk_kpi_set_score_id`,
     expect(items.filter((item) => item.type === "column").map((item) => item.label)).toEqual(["id", "user_name"]);
   });
 
+  it("keeps projected aliases from a multiline derived table", () => {
+    const { items } = semanticCompletion(
+      `SELECT
+  t.DEPTNO,
+  t.|
+FROM (
+  SELECT
+    DEPTNO,
+    AVG(SAL) avg_sal,
+    RANK() OVER (ORDER BY AVG(SAL) DESC) AS rnk
+  FROM emp
+  GROUP BY DEPTNO
+) AS t`,
+      {},
+      { databaseType: "mysql", dialect: "mysql" },
+    );
+
+    expect(items.filter((item) => item.type === "column").map((item) => item.label)).toEqual(["DEPTNO", "avg_sal", "rnk"]);
+  });
+
   it("expands alias star from only the qualified row source", () => {
     const columnsByTable = new Map<string, SqlCompletionColumn[]>([
       ["users", ["id", "name"].map((name) => ({ name, table: "users" }))],


### PR DESCRIPTION
## Summary
- use projected columns already resolved for derived tables in the editor local completion path
- return qualified column suggestions without waiting for remote metadata
- keep inline columns ahead of same-named physical table cache entries

## Tests
- pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/queryEditorInlineColumnCompletion.spec.ts apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts --maxWorkers=1
- pnpm exec oxfmt --check apps/desktop/src/components/editor/QueryEditor.vue apps/desktop/src/lib/__tests__/editor/queryEditorInlineColumnCompletion.spec.ts apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
- pnpm exec oxlint --vue-plugin apps/desktop/src/components/editor/QueryEditor.vue apps/desktop/src/lib/__tests__/editor/queryEditorInlineColumnCompletion.spec.ts apps/desktop/src/lib/__tests__/sql/semantic/completion.spec.ts
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json

Closes #8587