### PR TITLE
feat(sidebar): show table metadata counts

### DIFF
--- a/apps/desktop/src/components/sidebar/TreeItem.vue
+++ b/apps/desktop/src/components/sidebar/TreeItem.vue
@@ -1590,8 +1590,14 @@ function onKeydown(event: KeyboardEvent) {
                   node.type === 'group-materialized-views' ||
                   node.type === 'group-procedures' ||
                   node.type === 'group-functions' ||
+                  node.type === 'group-columns' ||
+                  node.type === 'group-indexes' ||
+                  node.type === 'group-fkeys' ||
                   node.type === 'group-triggers' ||
                   node.type === 'group-events' ||
+                  node.type === 'group-constraints' ||
+                  node.type === 'group-table-partitions' ||
+                  node.type === 'group-table-subpartitions' ||
                   node.type === 'group-sequences' ||
                   node.type === 'group-synonyms' ||
                   node.type === 'group-jobs' ||

--- a/apps/desktop/src/components/sidebar/__tests__/TreeItem.tableMetadataCounts.spec.ts
+++ b/apps/desktop/src/components/sidebar/__tests__/TreeItem.tableMetadataCounts.spec.ts
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, type App } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import TreeItem from "@/components/sidebar/TreeItem.vue";
+import { createSidebarTreeRuntime, sidebarTreeRuntimeKey, type SidebarTreeRuntimeHost } from "@/lib/sidebar/sidebarTreeRuntime";
+import type { TreeNode } from "@/types/database";
+
+const connectionStore = {
+  activeConnectionId: "connection-1",
+  connectedIds: new Set(["connection-1"]),
+  connectingIds: new Set<string>(),
+  connectionMultiSelectActive: false,
+  connections: [],
+  getConfig: () => ({ id: "connection-1", db_type: "postgres" }),
+  isDefaultDatabase: () => false,
+  isDefaultSchema: () => false,
+  isPinnedTreeNodeReorderTarget: () => false,
+  isTreeNodeChildrenLoaded: () => false,
+  isTreeNodePinned: () => false,
+  selectedTreeNodeId: null as string | null,
+  selectedTreeNodeIds: [] as string[],
+  selectedTreeNodeIdsSet: new Set<string>(),
+  sidebarTableSearchQueries: {},
+  tableNameFilterForScope: () => undefined,
+  treeNodes: [],
+  treeSelectionAnchorId: null as string | null,
+};
+
+vi.mock("@/stores/connectionStore", () => ({ useConnectionStore: () => connectionStore }));
+vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ openDatabaseKeys: new Set<string>() }) }));
+vi.mock("@/stores/settingsStore", () => ({
+  useSettingsStore: () => ({
+    editorSettings: {
+      shortcuts: { openDataInNewTab: "" },
+      sidebarActivation: "double",
+      sidebarAllowHorizontalScroll: false,
+      sidebarHiddenTablePrefixes: [],
+      sidebarObjectInfoMode: "none",
+    },
+  }),
+}));
+vi.mock("@/composables/useToast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+const mountedApps: App[] = [];
+
+function runtimeHost(): SidebarTreeRuntimeHost {
+  return {
+    buildContextMenu: vi.fn(() => []),
+    handleRowClick: vi.fn(),
+    handleRowDoubleClick: vi.fn(),
+    handleRowKeydown: vi.fn(),
+    openPrimaryVisibleFilter: vi.fn(),
+    openDataInNewTab: vi.fn(),
+    requestPaste: vi.fn(() => false),
+    toggleNode: vi.fn(),
+  };
+}
+
+async function mountTreeItem(node: TreeNode) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const runtime = createSidebarTreeRuntime();
+  runtime.bindHost(runtimeHost());
+  const app = createApp(defineComponent({ setup: () => () => h(TreeItem, { node, depth: 2 }) }));
+  mountedApps.push(app);
+  app.use(i18n);
+  app.provide(sidebarTreeRuntimeKey, runtime);
+  app.mount(container);
+  await nextTick();
+  return container;
+}
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+  document.body.replaceChildren();
+});
+
+describe("TreeItem table metadata counts", () => {
+  it("renders counts for loaded table metadata groups, including empty groups", async () => {
+    const groups = [
+      ["group-columns", "tree.columns", 2],
+      ["group-indexes", "tree.indexes", 1],
+      ["group-fkeys", "tree.foreignKeys", 3],
+      ["group-triggers", "tree.triggers", 0],
+      ["group-constraints", "tree.constraints", 4],
+      ["group-table-partitions", "tree.partitions", 5],
+      ["group-table-subpartitions", "tree.subpartitions", 6],
+    ] as const;
+
+    for (const [type, label, objectCount] of groups) {
+      const container = await mountTreeItem({
+        id: `connection-1:app:orders:${type}`,
+        label,
+        type,
+        connectionId: "connection-1",
+        database: "app",
+        tableName: "orders",
+        objectCount,
+        children: [],
+      });
+      expect(container.textContent).toContain(String(objectCount));
+    }
+  });
+});

--- a/apps/desktop/src/stores/__tests__/connectionStore.xuguTableChildren.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.xuguTableChildren.spec.ts
@@ -149,6 +149,53 @@ describe("connectionStore Xugu table child metadata", () => {
     expect(subpartitions.isExpanded).toBe(true);
   });
 
+  it("records exact counts for every successfully loaded table metadata group", async () => {
+    const getColumns = vi.fn().mockResolvedValue([
+      { name: "ORDER_ID", data_type: "INT", is_nullable: false, column_default: null, is_primary_key: true, extra: null },
+      { name: "CUSTOMER_ID", data_type: "INT", is_nullable: false, column_default: null, is_primary_key: false, extra: null },
+    ]);
+    const listIndexes = vi.fn().mockResolvedValue([{ name: "IDX_CUSTOMER", columns: ["CUSTOMER_ID"], unique: false }]);
+    const listForeignKeys = vi.fn().mockResolvedValue([{ name: "FK_CUSTOMER", column: "CUSTOMER_ID", ref_table: "CUSTOMERS", ref_column: "ID" }]);
+    const listTriggers = vi.fn().mockResolvedValue([{ name: "TR_AUDIT", timing: "BEFORE", event: "INSERT" }]);
+    const listConstraints = vi.fn().mockResolvedValue([{ name: "PK_SHOP_ORDERS", constraint_type: "PRIMARY KEY", valid: true }]);
+    const listPartitions = vi.fn().mockResolvedValue([]);
+    const listSubpartitions = vi.fn().mockResolvedValue([]);
+    const { store, tableId } = await setup("xugu", {
+      getColumns,
+      listIndexes,
+      listForeignKeys,
+      listTriggers,
+      listConstraints,
+      listPartitions,
+      listSubpartitions,
+    });
+
+    expect(getColumns).not.toHaveBeenCalled();
+    expect(listIndexes).not.toHaveBeenCalled();
+    expect(listForeignKeys).not.toHaveBeenCalled();
+    expect(listTriggers).not.toHaveBeenCalled();
+    expect(listConstraints).not.toHaveBeenCalled();
+    expect(listPartitions).not.toHaveBeenCalled();
+    expect(listSubpartitions).not.toHaveBeenCalled();
+
+    const groupTypes = ["group-columns", "group-indexes", "group-fkeys", "group-triggers", "group-constraints", "group-table-partitions", "group-table-subpartitions"] as const;
+    for (const groupType of groupTypes) {
+      const group = findNode(store.treeNodes, tableId)?.children?.find((node) => node.type === groupType);
+      if (!group) throw new Error(`Missing ${groupType}`);
+      await store.loadTreeNodeChildren(group);
+    }
+
+    expect(findNode(store.treeNodes, tableId)?.children?.map((node) => [node.type, node.objectCount])).toEqual([
+      ["group-columns", 2],
+      ["group-constraints", 1],
+      ["group-fkeys", 1],
+      ["group-triggers", 1],
+      ["group-indexes", 1],
+      ["group-table-partitions", 0],
+      ["group-table-subpartitions", 0],
+    ]);
+  });
+
   it("keeps a rejected Xugu metadata group collapsed and clears its loading state", async () => {
     const listPartitions = vi.fn().mockRejectedValue(new Error("metadata denied"));
     const { store, tableId } = await setup("xugu", { listPartitions });
@@ -159,6 +206,7 @@ describe("connectionStore Xugu table child metadata", () => {
     expect(partitions.isLoading).toBe(false);
     expect(partitions.isExpanded).toBe(false);
     expect(partitions.children).toEqual([]);
+    expect(partitions.objectCount).toBeUndefined();
   });
 
   it("shows Xugu trigger level and status without changing other database labels", async () => {

--- a/apps/desktop/src/stores/__tests__/connectionStore.xuguTableChildren.spec.ts
+++ b/apps/desktop/src/stores/__tests__/connectionStore.xuguTableChildren.spec.ts
@@ -196,6 +196,21 @@ describe("connectionStore Xugu table child metadata", () => {
     ]);
   });
 
+  it("counts the normalized foreign key nodes for a composite foreign key", async () => {
+    const listForeignKeys = vi.fn().mockResolvedValue([
+      { name: "FK_ORDER_CUSTOMER", column: "CUSTOMER_TENANT_ID", ref_table: "CUSTOMERS", ref_column: "TENANT_ID" },
+      { name: "FK_ORDER_CUSTOMER", column: "CUSTOMER_ID", ref_table: "CUSTOMERS", ref_column: "ID" },
+    ]);
+    const { config, store, tableId } = await setup("mysql", { listForeignKeys });
+    const foreignKeys = findNode(store.treeNodes, `${tableId}:__fkeys`)!;
+
+    await store.loadTreeNodeChildren(foreignKeys);
+
+    expect(listForeignKeys).toHaveBeenCalledWith(config.id, "SHOP_DEMO", "SYSDBA", "SHOP_ORDERS", undefined);
+    expect(foreignKeys.children).toHaveLength(1);
+    expect(foreignKeys.objectCount).toBe(1);
+  });
+
   it("keeps a rejected Xugu metadata group collapsed and clears its loading state", async () => {
     const listPartitions = vi.fn().mockRejectedValue(new Error("metadata denied"));
     const { store, tableId } = await setup("xugu", { listPartitions });

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1685,7 +1685,7 @@ export const useConnectionStore = defineStore("connection", () => {
 
   function setLoadedTableMetadataChildren(parent: TreeNode, children: TreeNode[]) {
     setChildren(parent, children);
-    parent.objectCount = children.length;
+    parent.objectCount = parent.children!.length;
   }
 
   function removePinnedTreeNodes(nodes: readonly TreeNode[], canonicalize: PinnedTreeNodeIdentityCanonicalizer = (identity) => identity, legacyKeys: readonly string[] = []): boolean {

--- a/apps/desktop/src/stores/connectionStore.ts
+++ b/apps/desktop/src/stores/connectionStore.ts
@@ -1683,6 +1683,11 @@ export const useConnectionStore = defineStore("connection", () => {
     syncConfirmedEmptyTreeNodeId(parent);
   }
 
+  function setLoadedTableMetadataChildren(parent: TreeNode, children: TreeNode[]) {
+    setChildren(parent, children);
+    parent.objectCount = children.length;
+  }
+
   function removePinnedTreeNodes(nodes: readonly TreeNode[], canonicalize: PinnedTreeNodeIdentityCanonicalizer = (identity) => identity, legacyKeys: readonly string[] = []): boolean {
     const nextPinnedOrder = removePinnedTreeNodesFromOrder(pinnedTreeNodeOrder.value, nodes, canonicalize, legacyKeys);
     if (nextPinnedOrder.length === pinnedTreeNodeOrder.value.length && nextPinnedOrder.every((key, index) => key === pinnedTreeNodeOrder.value[index])) return false;
@@ -6398,7 +6403,7 @@ export const useConnectionStore = defineStore("connection", () => {
         const fields = await listMongoCompletionFields(connectionId, database, table);
         const targetNode = treeNodeLoadTarget(load);
         if (!targetNode) return;
-        setChildren(
+        setLoadedTableMetadataChildren(
           targetNode,
           fields.map((field) => {
             const column = {
@@ -6429,7 +6434,7 @@ export const useConnectionStore = defineStore("connection", () => {
       if (!targetNode) return;
       const connConfig = getConfig(connectionId);
       const isGaussdbM = effectiveDatabaseTypeForConnection(connConfig) === "gaussdb" && connConfig?.driver_profile?.toLowerCase() === "gaussdb-m";
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         columns.map((col) => ({
           id: `${parentId}:${col.name}`,
@@ -6464,7 +6469,7 @@ export const useConnectionStore = defineStore("connection", () => {
       if (!metadataCapabilities.indexes || isMongoView) {
         const targetNode = treeNodeLoadTarget(load);
         if (!targetNode) return;
-        setChildren(targetNode, []);
+        setLoadedTableMetadataChildren(targetNode, []);
         targetNode.isExpanded = true;
         return;
       }
@@ -6473,7 +6478,7 @@ export const useConnectionStore = defineStore("connection", () => {
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
       const mongoCollectionKind = effectiveDbType === "mongodb" && targetNode.type === "group-indexes" ? mongoCollectionKindFromNode(targetNode) : undefined;
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         indexes.map((idx) => ({
           id: `${parentId}:${idx.name}`,
@@ -6506,7 +6511,7 @@ export const useConnectionStore = defineStore("connection", () => {
       if (!metadataCapabilities.foreignKeys) {
         const targetNode = treeNodeLoadTarget(load);
         if (!targetNode) return;
-        setChildren(targetNode, []);
+        setLoadedTableMetadataChildren(targetNode, []);
         targetNode.isExpanded = true;
         return;
       }
@@ -6518,7 +6523,7 @@ export const useConnectionStore = defineStore("connection", () => {
       indexCompletionForeignKeys(connectionId, database, table, schema, sqlCompletionForeignKeys(fkeys));
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         fkeys.map((fk) => ({
           id: `${parentId}:${fk.name}`,
@@ -6551,7 +6556,7 @@ export const useConnectionStore = defineStore("connection", () => {
       if (!metadataCapabilities.triggers) {
         const targetNode = treeNodeLoadTarget(load);
         if (!targetNode) return;
-        setChildren(targetNode, []);
+        setLoadedTableMetadataChildren(targetNode, []);
         targetNode.isExpanded = true;
         return;
       }
@@ -6560,7 +6565,7 @@ export const useConnectionStore = defineStore("connection", () => {
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
       const isXugu = effectiveDatabaseTypeForConnection(getConfig(connectionId)) === "xugu";
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         triggers.map((tr) => {
           const xuguDetails = isXugu ? [tr.timing, tr.event, tr.level, tr.enabled === false ? i18n.global.t("objects.disabled") : null, tr.valid === false ? i18n.global.t("objects.invalid") : null].filter(Boolean).join(" · ") : `${tr.timing} ${tr.event}`;
@@ -6597,7 +6602,7 @@ export const useConnectionStore = defineStore("connection", () => {
       const constraints = await api.listConstraints(connectionId, database, metadataQuerySchema(connectionId, database, schema), table, catalog);
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         constraints.map((constraint) => ({
           id: `${parentId}:${constraint.name}`,
@@ -6628,7 +6633,7 @@ export const useConnectionStore = defineStore("connection", () => {
       const partitions = await api.listPartitions(connectionId, database, metadataQuerySchema(connectionId, database, schema), table, catalog);
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         partitions.map((partition) => ({
           id: `${parentId}:${partition.name}`,
@@ -6659,7 +6664,7 @@ export const useConnectionStore = defineStore("connection", () => {
       const partitions = await api.listSubpartitions(connectionId, database, metadataQuerySchema(connectionId, database, schema), table, catalog);
       const targetNode = treeNodeLoadTarget(load);
       if (!targetNode) return;
-      setChildren(
+      setLoadedTableMetadataChildren(
         targetNode,
         partitions.map((partition) => ({
           id: `${parentId}:${partition.name}`,


### PR DESCRIPTION
## 变更说明

在数据表的元数据分组完成按需加载后，于侧栏显示字段、索引、外键、触发器、约束、分区和子分区的实际数量。

- 保持现有懒加载行为，不在展开数据表时提前发起额外的数据库请求。
- 以 `setChildren` 归一化和去重后的子节点数量为准，复合外键等场景不会重复计数。
- 空分组显示 `0`，失败或过期的加载结果不会写入错误数量。
- 已加载数量会保存在树节点上，折叠后再次显示仍然可见。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

使用实际 `TreeItem` 组件和内存中的已加载元数据分组验证数量展示：

![数据表元数据分组数量](https://raw.githubusercontent.com/tdog54646/dbx/cd92308b3a10737211ed33d044955e576013bca3/8574-table-metadata-counts.png)

## 验证

- [x] `make check` 通过（执行其对应命令 `pnpm check`）
- [ ] `make cargo-check-fast` 通过
- [x] 相关测试通过
  - `RUSTUP_TOOLCHAIN=1.94.1 pnpm check`：connection-types、全仓格式、lint、typecheck、全量测试全部通过
  - `pnpm typecheck`
  - `git diff --check upstream/main...HEAD`
  - 使用实际侧栏树节点组件进行浏览器渲染验证

已同步主分支，并修正上游 `useDataGridExport.ts` 的一处长函数调用格式；该修正仅调整换行，不改变行为。

## 关联 Issue

Close #8574
