### PR TITLE
improve(ai): 按界面语言选择 MiniMax 默认 Endpoint

### DIFF
--- a/apps/desktop/src/components/editor/EditorSettingsDialog.vue
+++ b/apps/desktop/src/components/editor/EditorSettingsDialog.vue
@@ -67,6 +67,7 @@ import {
   normalizeAiHeaders,
   getAiProviderPreset,
   getAiProviderPresetId,
+  getAiProviderPresetDefaultEndpoint,
   getAiProviderPresetOption,
   isAiPartnerProviderPreset,
   type AiProvider,
@@ -247,7 +248,7 @@ import { METADATA_CACHE_HARD_MAX_MEMORY_MB, METADATA_CACHE_MIN_MEMORY_MB, normal
 import { databaseManifestEntry, manifestDatabaseTypes } from "@/lib/database/databaseDriverManifest";
 import { buildConnectionGroupIdPathMap, connectionGroupDestinationRows, connectionIdsInGroups } from "@/lib/sidebar/sidebarLayout";
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const { toast } = useToast();
 const settingsStore = useSettingsStore();
 const connectionStore = useConnectionStore();
@@ -4368,7 +4369,7 @@ function aiSelectProvider(presetId: string) {
   aiEditProvider.value = provider;
   aiEditApiKey.value = "";
   aiEditAuthMethod.value = preset.authMethod;
-  aiEditEndpoint.value = preset.endpoint;
+  aiEditEndpoint.value = getAiProviderPresetDefaultEndpoint(preset, locale.value);
   aiEditModel.value = preset.group === "partner" ? preset.model : "";
   aiEditLegacyModels.value = preset.group === "partner" ? [...(preset.models ?? [])] : [];
   aiEditApiStyle.value = preset.apiStyle;

--- a/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
+++ b/apps/desktop/src/stores/__tests__/settingsStore.spec.ts
@@ -7,6 +7,7 @@ import {
   EXECUTE_MODE_CURRENT_DEFAULT_VERSION,
   SIDEBAR_BROWSE_OBJECTS_MIGRATION_VERSION,
   enforceRightSidebarPanelExclusivity,
+  getAiProviderPresetDefaultEndpoint,
   normalizeAiConfig,
   normalizeDesktopSettings,
   normalizeEditorSettings,
@@ -769,6 +770,18 @@ describe("settingsStore AI API key normalization", () => {
       requiresApiKey: true,
     });
     expect(normalizeAiConfig({ endpoint: "https://api.moonshot.cn/v1", model: "kimi-k2.5" }).provider).toBe("kimi");
+  });
+
+  it("uses the mainland MiniMax endpoint only for new zh-CN presets", () => {
+    expect(getAiProviderPresetDefaultEndpoint(AI_PROVIDER_PRESETS.minimax, "zh-CN")).toBe("https://api.minimaxi.com/v1");
+    expect(getAiProviderPresetDefaultEndpoint(AI_PROVIDER_PRESETS.minimax, "zh-TW")).toBe("https://api.minimax.io/v1");
+    expect(getAiProviderPresetDefaultEndpoint(AI_PROVIDER_PRESETS.minimax, "en")).toBe("https://api.minimax.io/v1");
+    expect(getAiProviderPresetDefaultEndpoint(AI_PROVIDER_PRESETS.openai, "zh-CN")).toBe(AI_PROVIDER_PRESETS.openai.endpoint);
+  });
+
+  it("preserves saved MiniMax endpoints during normalization", () => {
+    expect(normalizeAiConfig({ provider: "minimax", endpoint: "https://api.minimaxi.com/v1" }).endpoint).toBe("https://api.minimaxi.com/v1");
+    expect(normalizeAiConfig({ provider: "minimax", endpoint: "https://minimax.example.com/v1" }).endpoint).toBe("https://minimax.example.com/v1");
   });
 
   it("normalizes OpenCode CLI path and environment settings", () => {

--- a/apps/desktop/src/stores/settingsStore.ts
+++ b/apps/desktop/src/stores/settingsStore.ts
@@ -486,6 +486,13 @@ export function getAiProviderPresetOption(id: string): AiProviderPreset | AiPart
   return AI_PROVIDER_PARTNER_PRESETS.find((preset) => preset.id === id) ?? AI_PROVIDER_PRESETS[id as AiProvider] ?? AI_PROVIDER_PRESETS.custom;
 }
 
+export function getAiProviderPresetDefaultEndpoint(preset: AiProviderPreset | AiPartnerProviderPreset, locale: string): string {
+  if (preset.provider === "minimax" && locale === "zh-CN") {
+    return "https://api.minimaxi.com/v1";
+  }
+  return preset.endpoint;
+}
+
 export function getAiProviderPresetId(provider: AiProvider, endpoint = ""): string {
   const preset = getAiProviderPreset(provider, endpoint);
   return "id" in preset ? preset.id : provider;


### PR DESCRIPTION
## 概要

- 简体中文（`zh-CN`）界面中新建 MiniMax 配置时，默认使用国内站 `https://api.minimaxi.com/v1`
- 其他语言（包括繁体中文）继续默认使用海外站 `https://api.minimax.io/v1`
- 只在用户选择 MiniMax 预设创建新配置时应用，不覆盖已有配置或用户手动填写的 Endpoint
- 其他 AI 供应商的默认地址保持不变

## 实现

- 增加基于语言和供应商预设计算新配置默认 Endpoint 的纯函数
- 设置页选择供应商时传入当前界面语言
- 增加国内/海外语言分支、其他供应商以及已有/自定义 MiniMax Endpoint 保留测试

## 本地验证

- `pnpm exec vitest run apps/desktop/src/stores/__tests__/settingsStore.spec.ts`（131 tests passed）
- `pnpm typecheck`
- `pnpm exec oxfmt --check apps/desktop/src/stores/settingsStore.ts apps/desktop/src/components/editor/EditorSettingsDialog.vue apps/desktop/src/stores/__tests__/settingsStore.spec.ts`
- `pnpm exec oxlint apps/desktop/src/stores/settingsStore.ts apps/desktop/src/components/editor/EditorSettingsDialog.vue apps/desktop/src/stores/__tests__/settingsStore.spec.ts`（0 errors；仅有 1 条修改前已存在的 warning）

Fixes #8614