### PR TITLE
fix(editor): split Doris range partition statements

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
@@ -1375,6 +1375,20 @@ FROM orders;`;
 });
 
 describe("executableStatementRanges", () => {
+  it.each(["doris", "starrocks"] as const)("keeps %s half-open range partitions from swallowing the next statement", (databaseType) => {
+    const first = `CREATE TABLE fixed_partitions_1 (
+  sale_date date NULL,
+  product_id int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(sale_date, product_id)
+PARTITION BY RANGE(sale_date) (
+  PARTITION p_2024_01 VALUES [('2024-02-01'), ('2024-03-01'))
+)
+DISTRIBUTED BY HASH(product_id) BUCKETS 1`;
+    const second = first.replace("fixed_partitions_1", "fixed_partitions_2");
+
+    expect(rangeSqlTexts(executableStatementRanges(`${first};\n\n${second};`, databaseType))).toEqual([first, second]);
+  });
   it("returns statement ranges starting only at statement starts", () => {
     const sql = "SELECT *\nFROM users\nWHERE active = 1;\nSELECT 2;";
     const ranges = executableStatementRanges(sql);

--- a/apps/desktop/src/lib/sql/sqlStatementRanges.ts
+++ b/apps/desktop/src/lib/sql/sqlStatementRanges.ts
@@ -196,6 +196,10 @@ function splitElasticsearchRestRequestRanges(sql: string): RawStatement[] | unde
 
 type QuoteState = "none" | "single" | "double" | "backtick" | "bracket" | "dollar";
 
+function usesBracketIdentifierQuotes(databaseType?: DatabaseType): boolean {
+  return databaseType !== "doris" && databaseType !== "starrocks";
+}
+
 const COMMON_SOFT_STATEMENT_START_KEYWORDS = [
   "SELECT",
   "WITH",
@@ -564,7 +568,7 @@ export function splitSqlStatementRanges(sql: string, databaseType?: DatabaseType
       i += 1;
       continue;
     }
-    if (ch === "[") {
+    if (ch === "[" && usesBracketIdentifierQuotes(databaseType)) {
       markContent(i);
       state = "bracket";
       i += 1;
@@ -984,7 +988,7 @@ function topLevelSoftStatementLineStarts(sql: string, statement: RawStatement, d
       i += 1;
       continue;
     }
-    if (ch === "[") {
+    if (ch === "[" && usesBracketIdentifierQuotes(databaseType)) {
       state = "bracket";
       i += 1;
       continue;
@@ -1187,7 +1191,7 @@ function topLevelWordsBefore(sql: string, from: number, to: number, limit: numbe
       i += 1;
       continue;
     }
-    if (ch === "[") {
+    if (ch === "[" && usesBracketIdentifierQuotes(databaseType)) {
       state = "bracket";
       i += 1;
       continue;
@@ -1541,7 +1545,7 @@ function trimRangeEndBeforeNextBoundary(sql: string, from: number, nextBoundaryF
       i += 1;
       continue;
     }
-    if (ch === "[") {
+    if (ch === "[" && usesBracketIdentifierQuotes(databaseType)) {
       state = "bracket";
       lastContentEnd = i + 1;
       i += 1;


### PR DESCRIPTION
## Summary
- treat Doris and StarRocks square brackets as range boundaries instead of quoted identifiers
- keep all statement-range scanners on the same dialect rule
- restore separate executable ranges and gutter run buttons after half-open partition clauses

## Tests
- pnpm exec vitest run apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts --maxWorkers=1
- pnpm exec oxfmt --check apps/desktop/src/lib/sql/sqlStatementRanges.ts apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
- pnpm exec oxlint apps/desktop/src/lib/sql/sqlStatementRanges.ts apps/desktop/src/lib/__tests__/sql/sqlStatementRanges.spec.ts
- pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json

Closes #8620