### PR TITLE
fix(etcd): bound member status probe timeout

### DIFF
--- a/agents/drivers/etcd-go/main.go
+++ b/agents/drivers/etcd-go/main.go
@@ -21,6 +21,7 @@ const (
 	legacyAgentSessionID = "__legacy__"
 	maxAgentSessions     = 256
 	rpcTimeoutSeconds    = 30
+	statusProbeSeconds   = 10
 	readAccessCacheTTL   = 15 * time.Second
 )
 

--- a/agents/drivers/etcd-go/status.go
+++ b/agents/drivers/etcd-go/status.go
@@ -72,7 +72,7 @@ func (s *etcdSession) status(params map[string]json.RawMessage) (any, error) {
 		statusRequests[index] = channel
 		go func(endpoint string, channel chan *statusResult) {
 			started := time.Now()
-			ctx, cancel := context.WithTimeout(context.Background(), rpcTimeoutSeconds*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), statusProbeSeconds*time.Second)
 			response, err := client.Maintenance.Status(ctx, endpoint)
 			cancel()
 			channel <- &statusResult{response: response, err: err, started: started}


### PR DESCRIPTION
# fix(etcd): bound member status probe timeout

## 变更说明

per-member `Maintenance.Status` 探测超时 30s → 10s（新增常量 `statusProbeSeconds = 10`），解决 K8s 部署 etcd 概览页 `ETCD_CONNECTION_TIMEOUT`。

## 变更文件

| 文件 | 改动 |
| --- | --- |
| `agents/drivers/etcd-go/main.go` | 新增 `statusProbeSeconds = 10` |
| `agents/drivers/etcd-go/status.go` | per-member Status context：`rpcTimeoutSeconds` → `statusProbeSeconds` |

## 根因

K8s 部署的 etcd，member `advertise-client-urls` 是集群内部 DNS（`etcd-0.etcd-headless.component.svc.cluster.local`），集群外不可达。`status.go` 对每个 member 发 `Maintenance.Status`，不可达 member 卡住整个概览。

etcd clientv3 的 retry interceptor 在 Status context 内反复重试 DNS 失败（`no such host` 秒失败但一直重试到 context 到期），30s context → 每个 member 等满 30s → 4 个并行 max=30s + 串行 RPC → 超过 host 侧 JSON-RPC 30s 超时 → 概览 timeout。

> 注：缩短 `DialTimeout` 无效——失败在 DNS 解析（秒失败），不在拨号；retry interceptor 在 RPC context 内重试。真正控制耗时的是 Status context。

## 验证

### 自动化测试
- [x] `cd agents/drivers/etcd-go && go test -count=1 ./...` 通过
- [ ] `cargo check -p dbx-core` 通过（无 Rust 改动）
- [ ] `pnpm test` 通过（无前端改动）

### K8s etcd 实测（10.253.146.76:32379）
- 改前：概览页报 `ETCD_CONNECTION_TIMEOUT`，无法显示
- 改后：概览页不报错，正常显示集群状态（leader / clusterId / keyCount / revision / alarms）与 member 列表
<img width="2015" height="1245" alt="修复后" src="https://github.com/user-attachments/assets/ae51abaf-c5e7-44f8-89ed-59e041771072" />

### 本地 etcd 回归
- 改后：概览正常显示，无回归

