### PR TITLE
修复：macOS 编辑表结构快捷键不生效

### DIFF
--- a/vendor/wry/src/wkwebview/class/wry_web_view_parent.rs
+++ b/vendor/wry/src/wkwebview/class/wry_web_view_parent.rs
@@ -6,10 +6,10 @@
 use objc2::DefinedClass;
 use objc2::{define_class, msg_send, rc::Retained, MainThreadOnly};
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSEvent, NSView, NSWindow, NSWindowButton};
+use objc2_app_kit::{NSApplication, NSEvent, NSEventModifierFlags, NSView, NSWindow, NSWindowButton};
 use objc2_foundation::MainThreadMarker;
 #[cfg(target_os = "macos")]
-use objc2_foundation::NSRect;
+use objc2_foundation::{NSArray, NSRect};
 #[cfg(target_os = "ios")]
 use objc2_ui_kit::UIView as NSView;
 
@@ -28,11 +28,39 @@ define_class!(
     #[cfg(target_os = "macos")]
     #[unsafe(method(keyDown:))]
     fn key_down(&self, event: &NSEvent) {
-      let mtm = MainThreadMarker::new().unwrap();
-      let app = NSApplication::sharedApplication(mtm);
-      if let Some(menu) = app.mainMenu() {
-        menu.performKeyEquivalent(event);
+      let flags = event.modifierFlags();
+
+      // Only attempt menu key equivalents when Command or Control modifiers
+      // are held. Without this guard, ALL keyDown events (including bare
+      // number keys, symbols, and arrow keys) are sent to
+      // `performKeyEquivalent` which silently swallows them when no menu
+      // item matches, preventing the events from ever reaching the
+      // WKWebView content - especially problematic for iframe-based apps.
+      //
+      // Note: Option (Alt) is intentionally excluded - Option+key
+      // combinations are used for special character input (e.g.,
+      // Option+e for accent marks) and routing them to
+      // performKeyEquivalent would break dead-key / compose input.
+      //
+      // Refs: https://github.com/tauri-apps/wry/issues/1175
+      //       https://github.com/tauri-apps/wry/issues/1177
+      if flags.intersects(NSEventModifierFlags::Command | NSEventModifierFlags::Control) {
+        let mtm = MainThreadMarker::new().unwrap();
+        let app = NSApplication::sharedApplication(mtm);
+        if let Some(menu) = app.mainMenu() {
+          if menu.performKeyEquivalent(event) {
+            return;
+          }
+        }
       }
+
+      // Events reaching here were not handled by the WKWebView (first
+      // responder) or matched a menu shortcut. We call interpretKeyEvents
+      // on self (the parent NSView) purely to suppress the NSBeep that
+      // super.keyDown would produce (see PR #742). The parent has no
+      // NSTextInputClient, so this is effectively a no-op sink for
+      // unhandled keys.
+      self.interpretKeyEvents(&NSArray::from_slice(&[event]));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## 问题
在 macOS 桌面端选中表格单元格后按 Cmd+Shift+D，编辑表结构快捷键没有响应。官方 DBX v0.6.8 可稳定复现。

## 根因
Wry macOS 父视图将所有 keyDown 事件交给原生菜单，并忽略 performKeyEquivalent 的未处理结果，未匹配菜单快捷键的事件因此无法继续传递到 WebView。

## 修复
仅对包含 Command 或 Control 修饰键的事件尝试原生菜单；菜单未处理时继续调用 interpretKeyEvents，保证 WebView 快捷键可以收到事件。

## 实际验证
- 官方 DBX v0.6.8：本地 MySQL 8.4，MacMini / dbx_codex_1382 / biz_orders，选中单元格后 Cmd+Shift+D 无响应。
- 修复版桌面端：同一连接、同一张表、同一操作，已实际打开“编辑表结构”页面。
- 验证截图：https://raw.githubusercontent.com/zipg/dbx/codex/pr-assets-7245/pr-assets/issue-7245/after.png

## 自动化检查
- cargo check -p dbx --locked
- 相关前端 Vitest：69 tests passed
- pnpm vue-tsc --noEmit --project apps/desktop/tsconfig.json
- git diff --check

参考 Wry PR #1711。

Fixes #7245