### PR TITLE
修复：达梦部分视图 DDL 查看失败

### DIFF
--- a/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
+++ b/agents/drivers/dameng/src/main/java/com/dbx/agent/dameng/DamengAgent.java
@@ -753,7 +753,11 @@ public final class DamengAgent extends AbstractJdbcAgent {
                     || normalized.contains("all_views")
                     || normalized.contains("all_triggers")
                     || normalized.contains("all_sequences")
-                    || normalized.contains("systexts");
+                    || normalized.contains("systexts")
+                    // DM8 may report a view's metadata failure as an internal
+                    // index lookup error without mentioning DBMS_METADATA.
+                    || normalized.contains("内部索引")
+                    || normalized.contains("internal index");
                 boolean permissionDenied = normalized.contains("权限")
                     || normalized.contains("privilege")
                     || normalized.contains("permission")
@@ -762,6 +766,7 @@ public final class DamengAgent extends AbstractJdbcAgent {
                 boolean missingObject = normalized.contains("解析失败")
                     || normalized.contains("无法解析")
                     || normalized.contains("不存在")
+                    || normalized.contains("未找到")
                     || normalized.contains("not exist")
                     || normalized.contains("does not exist")
                     || normalized.contains("not found")
@@ -1714,6 +1719,10 @@ public final class DamengAgent extends AbstractJdbcAgent {
             if (!isDamengMetadataUnavailableError(error)) {
                 throw error;
             }
+            String catalogDdl = catalogTableLikeDdl(schema, table);
+            if (catalogDdl != null) {
+                return catalogDdl;
+            }
             try {
                 return super.getTableDdl(schema, table);
             } catch (RuntimeException fallbackError) {
@@ -1721,6 +1730,58 @@ public final class DamengAgent extends AbstractJdbcAgent {
                 throw fallbackError;
             }
         }
+    }
+
+    /**
+     * DBMS_METADATA.GET_DDL('TABLE', ...) is also used for views by the generic
+     * table-DDL endpoint. DM8 can reject that call with an internal-index error,
+     * even though the view definition is available in ALL_VIEWS.
+     */
+    private String catalogTableLikeDdl(String schema, String table) throws RuntimeException {
+        if (schemaMatchesConnectedUser(schema)) {
+            try {
+                String materializedQuery = readCatalogText(
+                    "SELECT QUERY FROM USER_MVIEWS WHERE MVIEW_NAME = ?",
+                    table
+                );
+                if (notBlank(materializedQuery)) {
+                    return buildCatalogTableLikeDdl(schema, table, "MATERIALIZED VIEW", materializedQuery);
+                }
+            } catch (RuntimeException error) {
+                if (!isDamengMetadataUnavailableError(error)) {
+                    throw error;
+                }
+            }
+        }
+
+        String viewText = readCatalogText(
+            "SELECT TEXT FROM ALL_VIEWS WHERE OWNER = ? AND VIEW_NAME = ?",
+            schema,
+            table
+        );
+        if (notBlank(viewText)) {
+            return buildCatalogTableLikeDdl(schema, table, "VIEW", viewText);
+        }
+        return null;
+    }
+
+    private String readCatalogText(String sql, String... params) {
+        return unchecked(() -> {
+            try (PreparedStatement stmt = requireConnected().prepareStatement(sql)) {
+                for (int i = 0; i < params.length; i++) {
+                    stmt.setString(i + 1, params[i]);
+                }
+                try (ResultSet rs = stmt.executeQuery()) {
+                    return rs.next() ? coalesce(readTextColumn(rs, 1)) : "";
+                }
+            }
+        });
+    }
+
+    private static String buildCatalogTableLikeDdl(String schema, String table, String objectType, String body) {
+        String normalizedBody = body.trim();
+        String statement = "CREATE " + objectType + " " + qualifiedName(schema, table) + " AS " + normalizedBody;
+        return ensureStatementTerminator(statement);
     }
 
     @Override

--- a/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
+++ b/agents/drivers/dameng/src/test/java/com/dbx/agent/dameng/DamengAgentMetadataTest.java
@@ -609,6 +609,96 @@ class DamengAgentMetadataTest {
     }
 
     @Test
+    void fallsBackToViewCatalogWhenDbmsMetadataReportsInternalIndexError() {
+        DamengAgent agent = new DamengAgent();
+        TestSupport.setPrivateConnection(agent, proxy(Connection.class, (method, args) -> {
+            if ("prepareStatement".equals(method.getName())) {
+                String sql = (String) args[0];
+                if (sql.contains("DBMS_METADATA.GET_DDL")) {
+                    return proxy(PreparedStatement.class, (statementMethod, statementArgs) -> {
+                        if ("executeQuery".equals(statementMethod.getName())) {
+                            throw new SQLException("未找到对象或不允许查询系统定义的内部索引");
+                        }
+                        if ("close".equals(statementMethod.getName())) {
+                            return null;
+                        }
+                        return defaultValue(statementMethod.getReturnType());
+                    });
+                }
+                if (sql.contains("ALL_VIEWS")) {
+                    return metadataStatement(List.of(List.of("SELECT 1 AS ID FROM DUAL")));
+                }
+            }
+            if ("close".equals(method.getName())) {
+                return null;
+            }
+            if ("isClosed".equals(method.getName())) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        }));
+
+        ObjectSource source = agent.getObjectSource("APP", "ACTIVE_VIEW", "VIEW");
+
+        Assertions.assertTrue(source.getSource().contains("SELECT 1 AS ID FROM DUAL"), source.getSource());
+        Assertions.assertTrue(source.getSource().contains("系统字典视图"), source.getSource());
+    }
+
+    @Test
+    void tableDdlFallsBackToViewAndMaterializedViewCatalogDefinitions() {
+        DamengAgent agent = new DamengAgent();
+        TestSupport.setPrivateConnection(agent, proxy(Connection.class, (method, args) -> {
+            if ("prepareStatement".equals(method.getName())) {
+                String sql = (String) args[0];
+                if (sql.contains("DBMS_METADATA.GET_DDL")) {
+                    return failingMetadataStatement(new SQLException("未找到对象或不允许查询系统定义的内部索引"));
+                }
+                if (sql.contains("USER_MVIEWS")) {
+                    String[] boundTable = {null};
+                    return proxy(PreparedStatement.class, (statementMethod, statementArgs) -> {
+                        if ("setString".equals(statementMethod.getName())) {
+                            boundTable[0] = (String) statementArgs[1];
+                            return null;
+                        }
+                        if ("executeQuery".equals(statementMethod.getName())) {
+                            return metadataResultSet("ISSUE_3418_MV".equals(boundTable[0])
+                                ? List.of(List.of("SELECT 1 AS ID FROM DUAL"))
+                                : List.of());
+                        }
+                        if ("close".equals(statementMethod.getName())) {
+                            return null;
+                        }
+                        return defaultValue(statementMethod.getReturnType());
+                    });
+                }
+                if (sql.contains("ALL_VIEWS")) {
+                    return metadataStatement(List.of(List.of("SELECT 2 AS ID FROM DUAL")));
+                }
+            }
+            if ("close".equals(method.getName())) {
+                return null;
+            }
+            if ("isClosed".equals(method.getName())) {
+                return false;
+            }
+            return defaultValue(method.getReturnType());
+        }));
+        setConnectedUsername(agent, "APP");
+
+        String viewDdl = agent.getTableDdl("APP", "ACTIVE_VIEW");
+        String materializedViewDdl = agent.getTableDdl("APP", "ISSUE_3418_MV");
+
+        Assertions.assertEquals(
+            "CREATE VIEW \"APP\".\"ACTIVE_VIEW\" AS SELECT 2 AS ID FROM DUAL;",
+            viewDdl
+        );
+        Assertions.assertEquals(
+            "CREATE MATERIALIZED VIEW \"APP\".\"ISSUE_3418_MV\" AS SELECT 1 AS ID FROM DUAL;",
+            materializedViewDdl
+        );
+    }
+
+    @Test
     void readsViewSourceWithDbmsMetadataType() {
         DamengAgent agent = new DamengAgent();
         List<String> params = new ArrayList<>();
@@ -1623,11 +1713,21 @@ class DamengAgentMetadataTest {
                     return metadataStatement(rows);
                 }
                 if (sql.contains("USER_MVIEWS")) {
+                    if (sql.contains("SELECT QUERY")) {
+                        return metadataStatement(
+                            includeMaterializedView
+                                ? List.of(List.of("SELECT 1 AS ID FROM DUAL"))
+                                : List.of()
+                        );
+                    }
                     return metadataStatement(
                         includeMaterializedView
                             ? List.of(List.of("USER_SUMMARY_MV"))
                             : List.of()
                     );
+                }
+                if (sql.contains("ALL_VIEWS")) {
+                    return metadataStatement(List.of());
                 }
                 if (sql.contains("ALL_COL_COMMENTS") && !sql.contains("ALL_TAB_COLUMNS")) {
                     return metadataStatement(List.of());


### PR DESCRIPTION
## 问题
关闭 #6800

DM8 的通用表 DDL 接口会对视图和物化视图调用 `DBMS_METADATA.GET_DDL('TABLE', ...)`。当对象为部分视图时，DM8 返回“未找到对象或不允许查询系统定义的内部索引”，导致 DBX 查看/生成 DDL 失败。

## 修复内容
- 识别 DM8 内部索引元数据错误。
- 对当前用户的物化视图优先从 `USER_MVIEWS.QUERY` 生成 `CREATE MATERIALIZED VIEW`。
- 其他视图从 `ALL_VIEWS.TEXT` 生成 `CREATE VIEW`。
- 普通表仍使用原有 DBMS_METADATA 和表结构降级逻辑。

## 验证
- DM8 8.1.3.62，原始 Agent 实测：`V_CITY_SALES`、`ISSUE_3418_MV` 均复现原错误。
- 补丁 Agent 实测同一连接：两个对象分别返回完整 `CREATE VIEW` / `CREATE MATERIALIZED VIEW` DDL；`PRODUCTS` 普通表仍正常返回 `CREATE TABLE`。
- `./gradlew :dameng:test --tests com.dbx.agent.dameng.DamengAgentMetadataTest`：73 项通过。
- `./gradlew :dameng:shadowJar`：通过。
- 无 UI 改动，无需截图。

Fixes #6800