### PR TITLE
修复：TDengine JDBC 查看表时丢失数据库上下文

### DIFF
--- a/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts
@@ -92,6 +92,19 @@ describe("jdbc dialect inference", () => {
     ).toBe("sqlserver");
   });
 
+  it("detects TDengine JDBC connections and keeps the selected database in the object tree", () => {
+    const connection = {
+      db_type: "jdbc" as const,
+      connection_string: "jdbc:TAOS-RS://tdengine.example:6041/",
+      jdbc_driver_class: "com.taosdata.jdbc.rs.RestfulDriver",
+    };
+
+    expect(inferJdbcDialect(connection)).toBe("tdengine");
+    expect(effectiveDatabaseTypeForConnection(connection)).toBe("tdengine");
+    expect(connectionUsesDatabaseObjectTreeMode(connection)).toBe(false);
+    expect(connectionObjectTreeQuerySchema(connection, "dbx_test")).toBe("dbx_test");
+  });
+
   it("keeps Phoenix as generic JDBC while preserving its schema tree", () => {
     const connection = { db_type: "jdbc" as const, driver_profile: "phoenix" };
 

--- a/apps/desktop/src/lib/database/jdbcDialect.ts
+++ b/apps/desktop/src/lib/database/jdbcDialect.ts
@@ -38,6 +38,7 @@ const JDBC_DIALECT_MATCHERS: Array<{ type: DatabaseType; patterns: RegExp[] }> =
   { type: "sqlserver", patterns: [/jdbc:sqlserver:/i, /sqlserver/i, /mssql/i] },
   { type: "oracle", patterns: [/jdbc:oracle:/i, /oracle/i] },
   { type: "clickhouse", patterns: [/jdbc:clickhouse:/i, /clickhouse/i] },
+  { type: "tdengine", patterns: [/jdbc:taos(?:-rs|-ws)?:/i, /taosdata/i, /tdengine/i] },
   { type: "h2", patterns: [/jdbc:h2:/i, /\bh2\b/i] },
   { type: "sqlite", patterns: [/jdbc:sqlite:/i, /sqlite/i] },
   { type: "db2", patterns: [/jdbc:db2:/i, /\bdb2\b/i] },
@@ -214,6 +215,8 @@ export function connectionUsesDatabaseObjectTreeMode(connection?: JdbcDialectCon
   const dialect = inferJdbcDialect(connection);
   if (!dialect) return true;
   if (dialect === "hive" || dialect === "trino") return false;
+  // TDengine exposes databases as the top-level namespace, without schemas.
+  if (dialect === "tdengine") return false;
   if (dialect === "databend") return true;
   return !usesTreeSchemaMode(dialect);
 }


### PR DESCRIPTION
## 问题
Fixes #6832。

TDengine 云 JDBC 连接在未选择数据库时，点击表详情会报 `database not specified`。同一远程实例在请求中指定 `dbx_test` 后可正常返回表列表，已在本地正式版 DBX 后端实际复现。

## 原因
TDengine JDBC URL 和驱动类未参与 JDBC 方言推断，连接被当作通用 JDBC 处理。通用 JDBC 的对象树查询不会传递当前数据库，TDengine 因而无法解析表。

## 修复
- 增加 TDengine JDBC URL、驱动类和名称匹配。
- 对推断出的 TDengine JDBC 连接使用“数据库作为顶层命名空间”的对象树路由，保留选中的数据库上下文；不改变原生 TDengine 的既有 schema 树语义。
- 增加 JDBC 方言和对象树路由回归测试。

## 验证
- 远程 TDengine 实例：空数据库请求复现 `database not specified`；指定 `dbx_test` 返回 `dbx_smoke`。
- `pnpm vitest run apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts apps/desktop/src/lib/__tests__/database/databaseFeatureSupport.spec.ts packages/app-tests/databaseCapabilities.test.ts`：112 项通过。
- `cargo test -p dbx-core --test database_capabilities`：10 项通过。
- `pnpm oxfmt --check apps/desktop/src/lib/database/jdbcDialect.ts apps/desktop/src/lib/__tests__/database/jdbcDialect.spec.ts`：通过。
- `pnpm vue-tsc --noEmit --project apps/desktop/tsconfig.json`：通过。
- 无视觉 UI 改动，不适用截图。
