### PR TITLE
✨ feat(editor): 延迟高亮 SQL 补全首个候选项

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -117,6 +117,7 @@ import {
 import { isPointOverElementRoot } from "@/lib/editor/tableReferenceDragFeedback";
 import type { SqlHighlighter } from "@/lib/sql/sqlHighlighter";
 import { EDITOR_FONT_FAMILY_CSS_VAR, EDITOR_FONT_SIZE_CSS_VAR, editorDiagnosticColors, editorThemeAppearanceFor, loadEditorTheme, editorFontTheme, shellLineCommentTheme, sqlCompletionTheme, sqlSemanticHighlightTheme } from "@/lib/editor/editorThemes";
+import { createQueryEditorCompletionHighlight } from "@/lib/editor/queryEditorCompletionHighlight";
 import { createStatementGutterMarkerDom, shouldShowStatementGutter } from "@/lib/editor/codemirrorStatementGutter";
 import { createQueryEditorSqlShortcutDomHandler, isCharacterProducingShortcut } from "@/lib/editor/queryEditorSqlShortcut";
 import { createQueryEditorReplaceShortcutBindings, createQueryEditorReplaceShortcutHandler, createQueryEditorSearchKeymap } from "@/lib/editor/queryEditorSearchKeymap";
@@ -6309,6 +6310,7 @@ onMounted(async () => {
       tooltips({ parent: tooltipParent }),
       completionComp.of(buildSqlCompletionExtension()),
       sqlCompletionTheme(EditorView),
+      createQueryEditorCompletionHighlight({ StateEffect, StateField, ViewPlugin, autocompletion, currentCompletions, selectedCompletionIndex }),
       codeMirrorTheme.of(theme),
       closeBracketsComp.of(closeBracketsExtension(initialSettings.autoCloseBrackets)),
       bracketMatching(),

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionHighlight.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorCompletionHighlight.spec.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { acceptCompletion, autocompletion, closeCompletion, currentCompletions, moveCompletionSelection, selectedCompletionIndex, startCompletion } from "@codemirror/autocomplete";
+import { EditorState, StateEffect, StateField, Transaction } from "@codemirror/state";
+import { EditorView, ViewPlugin } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQueryEditorCompletionHighlight } from "@/lib/editor/queryEditorCompletionHighlight";
+
+let view: EditorView | undefined;
+
+async function openCompletion(selectOnOpen = false) {
+  vi.useFakeTimers();
+  view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      extensions: [
+        autocompletion({
+          selectOnOpen,
+          interactionDelay: 0,
+          activateOnTypingDelay: 0,
+          override: [() => ({ from: 0, options: [{ label: "select" }, { label: "set" }], validFor: /^\w*$/ })],
+        }),
+        createQueryEditorCompletionHighlight({ StateEffect, StateField, ViewPlugin, autocompletion, currentCompletions, selectedCompletionIndex }),
+      ],
+    }),
+  });
+  startCompletion(view);
+  await vi.advanceTimersByTimeAsync(60);
+  expect(currentCompletions(view.state)).toHaveLength(2);
+  return view;
+}
+
+function pending() {
+  return !!document.querySelector(".cm-tooltip-autocomplete.cm-completion-highlight-pending");
+}
+
+afterEach(() => {
+  view?.destroy();
+  view = undefined;
+  vi.useRealTimers();
+  document.body.replaceChildren();
+});
+
+describe("completion highlight debounce", () => {
+  it("waits for typing to settle without selecting the first candidate", async () => {
+    const editor = await openCompletion();
+    expect(pending()).toBe(true);
+    for (const text of ["s", "e", "l"]) {
+      editor.dispatch({ changes: { from: editor.state.doc.length, insert: text }, selection: { anchor: editor.state.doc.length + 1 }, annotations: Transaction.userEvent.of("input.type") });
+      await vi.advanceTimersByTimeAsync(75);
+      expect(pending()).toBe(true);
+    }
+    await vi.advanceTimersByTimeAsync(25);
+    expect(pending()).toBe(false);
+    expect(selectedCompletionIndex(editor.state)).toBeNull();
+    expect(acceptCompletion(editor)).toBe(false);
+  });
+
+  it("shows explicit keyboard selection immediately", async () => {
+    const editor = await openCompletion();
+    expect(pending()).toBe(true);
+    expect(moveCompletionSelection(true)(editor)).toBe(true);
+    expect(pending()).toBe(false);
+    expect(selectedCompletionIndex(editor.state)).toBe(0);
+    expect(acceptCompletion(editor)).toBe(true);
+  });
+
+  it("does not delay acceptance when automatic selection is enabled", async () => {
+    const editor = await openCompletion(true);
+    expect(pending()).toBe(true);
+    expect(selectedCompletionIndex(editor.state)).toBe(0);
+    expect(acceptCompletion(editor)).toBe(true);
+    expect(editor.state.doc.toString()).toBe("select");
+  });
+
+  it("cancels pending coloring when closed or destroyed", async () => {
+    const editor = await openCompletion();
+    closeCompletion(editor);
+    const dispatch = vi.spyOn(editor, "dispatch");
+    await vi.advanceTimersByTimeAsync(300);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(document.querySelector(".cm-tooltip-autocomplete")).toBeNull();
+    startCompletion(editor);
+    await vi.advanceTimersByTimeAsync(60);
+    editor.destroy();
+    view = undefined;
+    dispatch.mockClear();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -944,6 +944,11 @@ export function editorFontTheme(EditorView: typeof import("@codemirror/view").Ed
 }
 
 export function buildSqlCompletionThemeRules(): CodeMirrorStyleSpec {
+  const selectedOptionStyle = {
+    background: `${colorMixValue("var(--accent)", "color-mix(in oklch, var(--primary) 14%, var(--popover))")} !important`,
+    color: "var(--popover-foreground) !important",
+    outline: colorMixValue("1px solid var(--border)", "1px solid color-mix(in oklch, var(--primary) 22%, transparent)"),
+  };
   return {
     ".cm-tooltip.cm-tooltip-autocomplete": {
       background: "var(--popover)",
@@ -992,10 +997,16 @@ export function buildSqlCompletionThemeRules(): CodeMirrorStyleSpec {
       transition: "background-color 90ms ease, color 90ms ease",
       whiteSpace: "nowrap",
     },
-    ".cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]": {
-      background: `${colorMixValue("var(--accent)", "color-mix(in oklch, var(--primary) 14%, var(--popover))")} !important`,
+    ".cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]": selectedOptionStyle,
+    // Hint at the first candidate without selecting it, so Enter and Tab keep
+    // their configured behavior. Hide the hint once a real selection exists,
+    // and never mistake the start of a virtualized window for the first option.
+    ".cm-tooltip.cm-tooltip-autocomplete:not(.cm-tooltip-autocomplete-disabled):not(.cm-completion-highlight-pending) > ul:not(.cm-completionListIncompleteTop):not(:has(> li[aria-selected])) > li[role=option]:first-of-type": selectedOptionStyle,
+    ".cm-tooltip.cm-tooltip-autocomplete.cm-completion-highlight-pending > ul > li[aria-selected]": {
+      background: "transparent !important",
       color: "var(--popover-foreground) !important",
-      outline: colorMixValue("1px solid var(--border)", "1px solid color-mix(in oklch, var(--primary) 22%, transparent)"),
+      outline: "none",
+      transition: "none",
     },
     ".cm-tooltip.cm-tooltip-autocomplete > ul > li.cm-batch-column-selection-action": {
       background: "var(--popover)",

--- a/apps/desktop/src/lib/editor/queryEditorCompletionHighlight.ts
+++ b/apps/desktop/src/lib/editor/queryEditorCompletionHighlight.ts
@@ -1,0 +1,65 @@
+import type { EditorState, Extension } from "@codemirror/state";
+import type { EditorView, ViewUpdate } from "@codemirror/view";
+
+interface CompletionHighlightDeps {
+  StateEffect: typeof import("@codemirror/state").StateEffect;
+  StateField: typeof import("@codemirror/state").StateField;
+  ViewPlugin: typeof import("@codemirror/view").ViewPlugin;
+  autocompletion: typeof import("@codemirror/autocomplete").autocompletion;
+  currentCompletions: typeof import("@codemirror/autocomplete").currentCompletions;
+  selectedCompletionIndex: typeof import("@codemirror/autocomplete").selectedCompletionIndex;
+}
+
+// Candidate lists are rebuilt while typing. Debounce their automatic highlight
+// independently of completion selection, acceptance, and result delivery.
+export function createQueryEditorCompletionHighlight({ StateEffect, StateField, ViewPlugin, autocompletion, currentCompletions, selectedCompletionIndex }: CompletionHighlightDeps): Extension {
+  const showHighlight = StateEffect.define<void>();
+  const candidatesChanged = (before: EditorState, after: EditorState) => currentCompletions(before) !== currentCompletions(after);
+  const highlightReady = StateField.define<boolean>({
+    create: () => false,
+    update(ready, tr) {
+      if (tr.docChanged || candidatesChanged(tr.startState, tr.state) || currentCompletions(tr.state).length === 0) return false;
+      // Explicit navigation should respond immediately, even during the delay.
+      if (selectedCompletionIndex(tr.state) !== selectedCompletionIndex(tr.startState)) return selectedCompletionIndex(tr.state) !== null;
+      if (tr.effects.some((effect) => effect.is(showHighlight))) return true;
+      return ready;
+    },
+  });
+
+  return [
+    highlightReady,
+    autocompletion({ tooltipClass: (state) => (state.field(highlightReady) ? "" : "cm-completion-highlight-pending") }),
+    ViewPlugin.fromClass(
+      class {
+        timer: ReturnType<typeof setTimeout> | null = null;
+
+        constructor(view: EditorView) {
+          this.schedule(view);
+        }
+
+        update(update: ViewUpdate) {
+          if (update.docChanged || candidatesChanged(update.startState, update.state) || update.state.field(highlightReady)) this.clearTimer();
+          this.schedule(update.view);
+        }
+
+        schedule(view: EditorView) {
+          if (this.timer !== null || view.state.field(highlightReady) || currentCompletions(view.state).length === 0) return;
+          this.timer = setTimeout(() => {
+            this.timer = null;
+            view.dispatch({ effects: showHighlight.of() });
+          }, 100);
+        }
+
+        clearTimer() {
+          if (this.timer === null) return;
+          clearTimeout(this.timer);
+          this.timer = null;
+        }
+
+        destroy() {
+          this.clearTimer();
+        }
+      },
+    ),
+  ];
+}


### PR DESCRIPTION
- 输入期间延迟展示首项高亮，避免影响 Enter 和 Tab 的既有行为
- 键盘显式选择候选项时立即高亮
- 支持自动选中及关闭、销毁补全列表时取消待处理高亮
- 补充补全高亮行为测试

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

<img width="920" height="614" alt="6180BC09-6075-4045-BB39-38CEB90ECE51" src="https://github.com/user-attachments/assets/d641c937-aa27-43d6-b9f7-6e17087c9f5c" />


## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #8540