### PR TITLE
fix(opengauss): 数据传输改用 PostgreSQL 方言路径，修复批量建表失败

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1331,6 +1331,8 @@ fn is_postgres_transfer_dialect(db_type: &DatabaseType) -> bool {
     // openGauss runs the native PostgreSQL wire protocol pool and its server-side
     // pg_get_tabledef() DDL contains multiple statements per table, so it needs the
     // same statement-splitting create-table path (verified against openGauss 6.0.3).
+    // openGauss has no ON CONFLICT support, so upsert routing still excludes it
+    // (see uses_mysql_style_upsert).
     matches!(db_type, DatabaseType::Postgres | DatabaseType::Kingbase | DatabaseType::OpenGauss)
 }
 
@@ -3765,6 +3767,17 @@ pub fn generate_upsert_typed(
     )
 }
 
+/// Upsert targets that take the MySQL-style `INSERT ... ON DUPLICATE KEY UPDATE
+/// ... VALUES(col)` arm. openGauss belongs here instead of the PostgreSQL
+/// `ON CONFLICT` arm: its INSERT grammar has no `ON CONFLICT` clause, but it
+/// does support `ON DUPLICATE KEY UPDATE` with `VALUES(column_name)` references
+/// (openGauss SQL Reference, INSERT — docs.opengauss.org, 5.1.0). Identifier
+/// quoting inside the arm still follows `db_type`, so openGauss keeps
+/// double-quoted PostgreSQL-style names.
+fn uses_mysql_style_upsert(db_type: &DatabaseType) -> bool {
+    matches!(db_type, DatabaseType::Mysql | DatabaseType::Doris | DatabaseType::StarRocks | DatabaseType::OpenGauss)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn generate_upsert_typed_for_transfer(
     columns: &[String],
@@ -3800,8 +3813,10 @@ fn generate_upsert_typed_for_transfer(
     }
 
     match db_type {
+        // openGauss has no ON CONFLICT support; it is routed to the
+        // ON DUPLICATE KEY UPDATE arm below instead (uses_mysql_style_upsert).
         db_type
-            if is_postgres_transfer_dialect(db_type)
+            if (is_postgres_transfer_dialect(db_type) && !matches!(db_type, DatabaseType::OpenGauss))
                 || matches!(db_type, DatabaseType::Sqlite | DatabaseType::CloudflareD1 | DatabaseType::DuckDb) =>
         {
             let pk_list = pk_columns
@@ -3831,7 +3846,7 @@ fn generate_upsert_typed_for_transfer(
             }
             sql
         }
-        DatabaseType::Mysql | DatabaseType::Doris | DatabaseType::StarRocks => {
+        db_type if uses_mysql_style_upsert(db_type) => {
             let mut sql = format!("INSERT INTO {full_table} ({col_list}) VALUES\n{}", value_rows.join(",\n"));
             if non_pk_columns.is_empty() {
                 sql.push_str("\nON DUPLICATE KEY UPDATE ");
@@ -5072,7 +5087,10 @@ fn transfer_ddl_statements(sql: &str, db_type: &DatabaseType) -> Vec<String> {
             statements
                 .into_iter()
                 .map(|statement| strip_inline_foreign_key_constraint_lines(&statement))
-                .filter(|statement| !is_postgres_post_table_index_statement(statement))
+                .filter(|statement| {
+                    !is_postgres_post_table_index_statement(statement)
+                        && !is_postgres_post_table_foreign_key_alter_statement(statement)
+                })
                 .collect()
         }
     } else if matches!(db_type, DatabaseType::Dameng) {
@@ -5130,6 +5148,24 @@ fn is_postgres_post_table_index_statement(statement: &str) -> bool {
     normalized.starts_with("CREATE INDEX ")
         || normalized.starts_with("CREATE UNIQUE INDEX ")
         || normalized.starts_with("COMMENT ON INDEX ")
+}
+
+/// Standalone `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` statements are
+/// dropped from reused PostgreSQL-dialect DDL, mirroring how inline FK lines are
+/// stripped from `CREATE TABLE`: openGauss's `pg_get_tabledef()` emits one ALTER
+/// per foreign key, which would run at create time — failing when the referenced
+/// table does not exist yet — and then collide with the same-named constraint
+/// re-added from source metadata by `restore_postgres_table_schema_objects`
+/// (`duplicate_object` 42710). Foreign keys must come from the restore phase
+/// alone. Non-FK ALTERs (`ADD CONSTRAINT ... CHECK`, `SET (...)`, ...) are kept.
+fn is_postgres_post_table_foreign_key_alter_statement(statement: &str) -> bool {
+    // Mask string literals and comments first so a CHECK expression or comment
+    // that merely mentions "foreign key" cannot match.
+    let (code, _) = protect_sql_literals(statement, true);
+    let normalized = code.trim_start().to_ascii_uppercase();
+    normalized.starts_with("ALTER TABLE ")
+        && normalized.contains(" ADD CONSTRAINT ")
+        && normalized.contains(" FOREIGN KEY ")
 }
 
 pub async fn execute_on_pool_with_max_rows(
@@ -11721,6 +11757,52 @@ mod tests {
     }
 
     #[test]
+    fn opengauss_transfer_ddl_skips_reused_foreign_key_alter_statements() {
+        // openGauss's pg_get_tabledef() emits one `ALTER TABLE ... ADD CONSTRAINT
+        // ... FOREIGN KEY` per foreign key. Keeping them would run the FK at create
+        // time (referenced tables may not exist yet) and then duplicate the named
+        // constraint re-added by restore_postgres_table_schema_objects (42710).
+        let ddl = "SET search_path = public;\n\
+                   CREATE TABLE \"public\".\"items\" (\"id\" integer, \"order_id\" integer);\n\
+                   ALTER TABLE \"public\".\"items\" ADD CONSTRAINT \"items_order_id_fkey\" FOREIGN KEY (\"order_id\") REFERENCES \"public\".\"orders\" (\"id\") ON DELETE CASCADE;\n\
+                   CREATE INDEX \"items_order_id_idx\" ON \"public\".\"items\" (\"order_id\");\n\
+                   COMMENT ON TABLE \"public\".\"items\" IS 'items';";
+
+        let statements = transfer_ddl_statements(ddl, &DatabaseType::OpenGauss);
+
+        assert_eq!(
+            statements,
+            vec![
+                "SET search_path = public".to_string(),
+                "CREATE TABLE \"public\".\"items\" (\"id\" integer, \"order_id\" integer)".to_string(),
+                "COMMENT ON TABLE \"public\".\"items\" IS 'items'".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn postgres_transfer_ddl_keeps_non_foreign_key_alter_statements() {
+        // Only FK-ADD ALTERs are deferred; CHECK/SET ALTERs and literals that merely
+        // mention "foreign key" must survive the filter.
+        let ddl = "CREATE TABLE \"public\".\"items\" (\"id\" integer, \"amount\" integer, \"note\" text);\n\
+                   ALTER TABLE \"public\".\"items\" ADD CONSTRAINT \"items_amount_check\" CHECK (amount > 0);\n\
+                   ALTER TABLE \"public\".\"items\" ADD CONSTRAINT \"items_note_check\" CHECK (note <> 'foreign key (demo)');\n\
+                   ALTER TABLE \"public\".\"items\" SET (autovacuum_enabled = false);";
+
+        let statements = transfer_ddl_statements(ddl, &DatabaseType::Postgres);
+
+        assert_eq!(
+            statements,
+            vec![
+                "CREATE TABLE \"public\".\"items\" (\"id\" integer, \"amount\" integer, \"note\" text)".to_string(),
+                "ALTER TABLE \"public\".\"items\" ADD CONSTRAINT \"items_amount_check\" CHECK (amount > 0)".to_string(),
+                "ALTER TABLE \"public\".\"items\" ADD CONSTRAINT \"items_note_check\" CHECK (note <> 'foreign key (demo)')".to_string(),
+                "ALTER TABLE \"public\".\"items\" SET (autovacuum_enabled = false)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn dameng_transfer_ddl_splits_reused_table_comments() {
         let ddl = "CREATE TABLE \"APP\".\"ITEMS\" (\n\
                      \"ID\" INTEGER,\n\
@@ -14721,6 +14803,44 @@ SELECT 1 FROM dual"#
         );
 
         assert!(sql.contains("ON CONFLICT (\"id\") DO UPDATE SET \"name\" = EXCLUDED.\"name\""), "sql: {sql}");
+    }
+
+    #[test]
+    fn opengauss_upsert_uses_on_duplicate_key_update() {
+        // openGauss has no `ON CONFLICT` support; its INSERT grammar provides the
+        // MySQL-style `ON DUPLICATE KEY UPDATE` with VALUES(col) references
+        // (openGauss SQL Reference, INSERT — docs.opengauss.org, 5.1.0).
+        let sql = generate_upsert_typed(
+            &[String::from("id"), String::from("name")],
+            &[Some(String::from("integer")), Some(String::from("text"))],
+            &[vec![json!(1), json!("updated")]],
+            "items",
+            "public",
+            &DatabaseType::OpenGauss,
+            &[String::from("id")],
+            None,
+        );
+
+        assert!(sql.starts_with("INSERT INTO \"public\".\"items\" (\"id\", \"name\") VALUES"), "sql: {sql}");
+        assert!(sql.contains("ON DUPLICATE KEY UPDATE \"name\" = VALUES(\"name\")"), "sql: {sql}");
+        assert!(!sql.contains("ON CONFLICT"), "sql: {sql}");
+    }
+
+    #[test]
+    fn opengauss_upsert_primary_key_only_updates_nothing() {
+        let sql = generate_upsert_typed(
+            &[String::from("id")],
+            &[Some(String::from("integer"))],
+            &[vec![json!(1)]],
+            "items",
+            "public",
+            &DatabaseType::OpenGauss,
+            &[String::from("id")],
+            None,
+        );
+
+        assert!(sql.contains("ON DUPLICATE KEY UPDATE \"id\" = \"id\""), "sql: {sql}");
+        assert!(!sql.contains("ON CONFLICT"), "sql: {sql}");
     }
 
     #[test]

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1328,7 +1328,10 @@ fn is_postgres_compat_transfer(source_db: &DatabaseType, target_db: &DatabaseTyp
 fn is_postgres_transfer_dialect(db_type: &DatabaseType) -> bool {
     // KingbaseES supports the PostgreSQL DDL, type, and ON CONFLICT paths used by transfer;
     // other PG-wire databases stay opt-in until their transfer behavior is verified.
-    matches!(db_type, DatabaseType::Postgres | DatabaseType::Kingbase)
+    // openGauss runs the native PostgreSQL wire protocol pool and its server-side
+    // pg_get_tabledef() DDL contains multiple statements per table, so it needs the
+    // same statement-splitting create-table path (verified against openGauss 6.0.3).
+    matches!(db_type, DatabaseType::Postgres | DatabaseType::Kingbase | DatabaseType::OpenGauss)
 }
 
 fn transfer_table_needs_inline_postgres_schema_ensure(
@@ -11689,6 +11692,28 @@ mod tests {
         assert_eq!(
             statements,
             vec![
+                "CREATE TABLE \"public\".\"items\" (\"id\" integer)".to_string(),
+                "COMMENT ON TABLE \"public\".\"items\" IS 'items'".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn opengauss_transfer_ddl_splits_reused_multi_statement_table_ddl() {
+        // openGauss reuses the source table DDL verbatim via pg_get_tabledef(), which
+        // emits several statements per table. Without the PostgreSQL dialect path the
+        // whole DDL runs as one prepared statement and fails with "cannot insert
+        // multiple commands into a prepared statement".
+        let ddl = "SET search_path = public;\n\
+                   CREATE TABLE \"public\".\"items\" (\"id\" integer);\n\
+                   COMMENT ON TABLE \"public\".\"items\" IS 'items';";
+
+        let statements = transfer_ddl_statements(ddl, &DatabaseType::OpenGauss);
+
+        assert_eq!(
+            statements,
+            vec![
+                "SET search_path = public".to_string(),
                 "CREATE TABLE \"public\".\"items\" (\"id\" integer)".to_string(),
                 "COMMENT ON TABLE \"public\".\"items\" IS 'items'".to_string(),
             ]


### PR DESCRIPTION
## 变更说明

在 `is_postgres_transfer_dialect`（crates/dbx-core/src/transfer.rs）中加入 `DatabaseType::OpenGauss`，使 openGauss 目标端走 PostgreSQL 传输路径：建表 DDL 先拆分再逐条执行（openGauss 复用源库 `pg_get_tabledef()` 返回的多语句 DDL）、启用 PG 类型映射与内联 schema 确保。openGauss 在 dbx 中本就使用原生 PostgreSQL 协议连接池（`deadpool_postgres`），该判断的全部 23 处调用点均为 PG 方言路径，对 openGauss 同样适用。附一个单元测试验证 openGauss 多语句 DDL 会被正确拆分。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本 PR 为纯 Rust 后端改动（crates/dbx-core/src/transfer.rs），不涉及前端。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- 新增测试 `opengauss_transfer_ddl_splits_reused_multi_statement_table_ddl` 通过；transfer 模块全部单测 261 passed / 0 failed
- 实测 openGauss 6.0.3 全量传输（470 关系，约 2 GB）：修复前 427/470 失败 → 修复后 0 失败、0 行数差异
- `cargo check --no-default-features --features sqlite-bundled` 通过；`cargo fmt` 无差异
- `make check`（前端）未在本机运行：本 PR 未涉及前端改动，且本机无法访问公司内网 npm 源，前端检查由 CI 覆盖

- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

## 关联 Issue

Related #8661