### PR TITLE
feat(backup): 在备份连接选择器中显示分组

### DIFF
--- a/apps/desktop/src/components/backup/DatabaseBackupConfigFields.vue
+++ b/apps/desktop/src/components/backup/DatabaseBackupConfigFields.vue
@@ -8,6 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { HelpTooltip } from "@/components/ui/tooltip";
 import { Check, ChevronDown, FolderOpen, Loader2, Search } from "@lucide/vue";
+import ConnectionGroupBadge from "@/components/connection/ConnectionGroupBadge.vue";
 import { databaseBackupFileNamePatternIsValid, type DatabaseBackupExecutionConfig } from "@/lib/backup/scheduledDatabaseBackup";
 import type { ConnectionConfig } from "@/types/database";
 
@@ -123,6 +124,7 @@ watch(
               @click="selectConnection(connection.id)"
             >
               <Check class="h-4 w-4 shrink-0" :class="connection.id === draft.connectionId ? 'opacity-100' : 'opacity-0'" />
+              <ConnectionGroupBadge :connection-id="connection.id" />
               <span class="min-w-0 flex-1 truncate">{{ connection.name }}</span>
             </button>
             <div v-if="filteredConnections.length === 0" class="px-2 py-2 text-sm text-muted-foreground">{{ t("databaseBackup.noMatchingConnections") }}</div>

--- a/apps/desktop/src/components/backup/__tests__/ScheduledDatabaseBackupSettings.spec.ts
+++ b/apps/desktop/src/components/backup/__tests__/ScheduledDatabaseBackupSettings.spec.ts
@@ -63,6 +63,16 @@ vi.mock("@/composables/useToast", () => ({
   useToast: () => ({ toast: mocks.toast }),
 }));
 
+vi.mock("@/components/connection/ConnectionGroupBadge.vue", async () => {
+  const { defineComponent, h } = await import("vue");
+  return {
+    default: defineComponent({
+      props: { connectionId: { type: String, required: true } },
+      setup: (props) => () => h("span", { "data-connection-group-badge": "", "data-connection-id": props.connectionId }),
+    }),
+  };
+});
+
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: mocks.openDirectory,
 }));
@@ -458,6 +468,19 @@ describe("ScheduledDatabaseBackupSettings schedule dialog", () => {
 
     expect(currentDialog().textContent).toContain("{timestamp}");
     expect(currentDialog().querySelector<HTMLElement>("[data-backup-output-path-preview]")?.textContent).toContain("/backups/archive/");
+  });
+
+  it("shows connection group badges in the backup connection picker", async () => {
+    mocks.connections.push({ id: "mysql-primary", name: "Shared name", db_type: "mysql" }, { id: "mysql-archive", name: "Shared name", db_type: "mysql" });
+    await mountSettings();
+
+    addScheduleButton().click();
+    await flush();
+    currentDialog().querySelector<HTMLButtonElement>("[data-backup-connection-picker]")?.click();
+    await flush();
+
+    const connectionIds = Array.from(document.body.querySelectorAll<HTMLElement>("[data-connection-group-badge]")).map((badge) => badge.dataset.connectionId);
+    expect(connectionIds).toEqual(["mysql-primary", "mysql-archive"]);
   });
 
   it("opens an independent one-shot dialog without schedule fields", async () => {


### PR DESCRIPTION
## 变更说明

- 在数据库备份的新建计划和立即备份连接选择器中显示连接分组徽标。
- 复用现有 `ConnectionGroupBadge`，保持与导出对话框、SQL 文件执行对话框一致的分组展示。
- 补充同名连接的分组徽标回归测试。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

### 数据库备份连接分组

![数据库备份连接分组](https://raw.githubusercontent.com/CSXFanMeng/dbx/pr-assets-5476-7821/.github/pr-assets/5476-7821-backup-groups.png)

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

- 最新 `main` 基线下，`ScheduledDatabaseBackupSettings.spec.ts` 共 21 个测试全部通过。
- `oxfmt --check`、`oxlint --vue-plugin` 和 `vue-tsc --noEmit` 均通过。

## 关联 Issue

Close #5476
