### PR TITLE
fix(mongodb): support the upsert update option in the legacy agent

### DIFF
--- a/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
+++ b/agents/drivers/mongodb/src/main/java/com/dbx/agent/mongodb/MongoAgent.java
@@ -1609,9 +1609,16 @@ public final class MongoAgent {
         }
         Document options = Document.parse(optionsJson);
         for (String key : options.keySet()) {
-            if (!"arrayFilters".equals(key)) {
+            if (!"arrayFilters".equals(key) && !"upsert".equals(key)) {
                 throw new IllegalArgumentException("Unsupported update option: " + key);
             }
+        }
+        Object rawUpsert = options.get("upsert");
+        if (rawUpsert != null) {
+            if (!(rawUpsert instanceof Boolean)) {
+                throw new IllegalArgumentException("upsert must be a boolean");
+            }
+            result.upsert((Boolean) rawUpsert);
         }
         Object rawFilters = options.get("arrayFilters");
         if (rawFilters == null) {

--- a/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
+++ b/agents/drivers/mongodb/src/test/java/com/dbx/agent/mongodb/MongoAgentTest.java
@@ -982,12 +982,38 @@ class MongoAgentTest {
     }
 
     @Test
+    void parsesUpsertUpdateOption() {
+        assertTrue(MongoAgent.updateOptionsForWrite("{\"upsert\":true}").isUpsert());
+        assertFalse(MongoAgent.updateOptionsForWrite("{\"upsert\":false}").isUpsert());
+        assertFalse(MongoAgent.updateOptionsForWrite("{}").isUpsert());
+    }
+
+    @Test
+    void parsesUpsertAlongsideArrayFilters() {
+        UpdateOptions options = MongoAgent.updateOptionsForWrite(
+            "{\"upsert\":true,\"arrayFilters\":[{\"item.id\":322678}]}"
+        );
+
+        assertTrue(options.isUpsert());
+        assertEquals(1, options.getArrayFilters().size());
+    }
+
+    @Test
+    void rejectsNonBooleanUpsertUpdateOption() {
+        IllegalArgumentException error = assertThrows(
+            IllegalArgumentException.class,
+            () -> MongoAgent.updateOptionsForWrite("{\"upsert\":\"yes\"}")
+        );
+        assertEquals("upsert must be a boolean", error.getMessage());
+    }
+
+    @Test
     void rejectsUnsupportedUpdateOptions() {
         IllegalArgumentException error = assertThrows(
             IllegalArgumentException.class,
-            () -> MongoAgent.updateOptionsForWrite("{\"upsert\":true}")
+            () -> MongoAgent.updateOptionsForWrite("{\"collation\":{\"locale\":\"en\"}}")
         );
-        assertEquals("Unsupported update option: upsert", error.getMessage());
+        assertEquals("Unsupported update option: collation", error.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Problem

`upsert` is rejected by the MongoDB Legacy Agent, so any update carrying it fails before reaching the server:

```
Agent RPC error (-1): Unsupported update option: upsert
```

```js
db.reports.updateOne(
  { phone_number: "+84905421172", code: "VN" },
  { $set: { report_count: 99 } },
  { upsert: true }
)
```

The same statement works on a native MongoDB connection, so the behaviour depends on which driver profile the connection happens to use.

## Cause

`updateOptionsForWrite` whitelists exactly one key:

```java
for (String key : options.keySet()) {
    if (!"arrayFilters".equals(key)) {
        throw new IllegalArgumentException("Unsupported update option: " + key);
    }
}
```

This is not a compatibility restriction for old servers. It arrived with 9a09bd49c ("fix(mongodb): support array filters in updates"), which introduced the options channel — before that the agent passed no options at all (`col.updateOne(filter, update)`). The whitelist was a fail-loud guard around the single option being implemented.

Worth noting that `arrayFilters`, the one permitted option, was itself introduced in MongoDB 3.6, while `upsert` dates back to MongoDB 1.0 — so the whitelist admits the newest update option and rejects the oldest.

## Change

Accept `upsert` and pass it to `UpdateOptions.upsert(...)`, keeping the fail-loud guard for everything still unimplemented.

This matches the native driver, whose `MongoUpdateOptions` supports exactly `upsert` and `arrayFilters`, so both paths now accept the same set. The result shape is deliberately unchanged: both drivers report only `modified_count`, which is `0` when an upsert inserts rather than updates.

## Testing

`./gradlew :mongodb:test` — 88 passed, including three added cases: `upsert` alone, `upsert` alongside `arrayFilters`, and a non-boolean `upsert`. The existing `rejectsUnsupportedUpdateOptions` asserted the bug, so it now pins a genuinely unimplemented option (`collation`) instead.

Verified against a live MongoDB 3.6 server over the agent's JSON-RPC interface, on a scratch collection that was dropped afterwards:

| | old jar | this change |
| --- | --- | --- |
| upsert onto a missing document | `Unsupported update option: upsert`, nothing written | document created, `modified_count: 0` |
| upsert onto an existing document | `Unsupported update option: upsert`, nothing written | document updated, `modified_count: 1` |

Per CONTRIBUTING, `agents/versions.json` is left for the release workflow to bump.
