### PR TITLE
fix(structure): respect identifier quote preference

### DIFF
--- a/apps/desktop/src/components/structure/TableStructureEditor.charsetCollation.spec.ts
+++ b/apps/desktop/src/components/structure/TableStructureEditor.charsetCollation.spec.ts
@@ -211,7 +211,7 @@ vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ tableStructureRe
 vi.mock("@/stores/historyStore", () => ({ useHistoryStore: () => ({ add: vi.fn() }) }));
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [] },
+    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], generateSqlQuoteIdentifiers: true },
     updateEditorSettings: mocks.updateEditorSettings,
   }),
 }));

--- a/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
+++ b/apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   executeQuery: vi.fn(),
   listDataTypes: vi.fn(),
   buildTableStructureChangeSql: vi.fn(),
+  previewSqliteTableStructureChange: vi.fn(),
   buildMysqlAutoIncrementSql: vi.fn(),
   updateEditorSettings: vi.fn(),
   loadObjectDdl: vi.fn(),
@@ -24,6 +25,12 @@ const mocks = vi.hoisted(() => ({
   getTablePartitionStatus: vi.fn(),
   getTableOwner: vi.fn(),
   buildTableOwnerChangeSql: vi.fn(),
+  editorSettings: {
+    structureEditorDensity: "compact",
+    sqlFormatter: {},
+    tableColumnTemplateFields: [],
+    generateSqlQuoteIdentifiers: true,
+  },
   toast: vi.fn(),
 }));
 
@@ -212,7 +219,7 @@ vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ tableStructureRe
 vi.mock("@/stores/historyStore", () => ({ useHistoryStore: () => ({ add: vi.fn() }) }));
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [] },
+    editorSettings: mocks.editorSettings,
     updateEditorSettings: mocks.updateEditorSettings,
   }),
 }));
@@ -229,6 +236,7 @@ vi.mock("@/lib/backend/api", () => ({
   executeQuery: mocks.executeQuery,
   listDataTypes: mocks.listDataTypes,
   buildTableStructureChangeSql: mocks.buildTableStructureChangeSql,
+  previewSqliteTableStructureChange: mocks.previewSqliteTableStructureChange,
   buildMysqlAutoIncrementSql: mocks.buildMysqlAutoIncrementSql,
   buildTableOwnerChangeSql: mocks.buildTableOwnerChangeSql,
   getTablePartitionStatus: mocks.getTablePartitionStatus,
@@ -352,6 +360,8 @@ function buttonWithText(root: HTMLElement, text: string): HTMLButtonElement {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.editorSettings.generateSqlQuoteIdentifiers = true;
+  mocks.previewSqliteTableStructureChange.mockResolvedValue({ statements: [], warnings: [], schemaRevision: "sqlite-revision" });
   mocks.loadObjectDdl.mockResolvedValue({ ddl: "CREATE TABLE users (id bigint)", cacheStatus: "remote" });
   mocks.invalidateObjectDdl.mockResolvedValue(undefined);
   mocks.invalidateObjectMetadataCache.mockResolvedValue(undefined);
@@ -570,6 +580,32 @@ describe("TableStructureEditor primary key editing", () => {
     await vi.waitFor(() => expect(root.textContent).toContain("ALTER TABLE users ALTER COLUMN id DROP NOT NULL;"));
     expect(buttonWithText(root, "structureEditor.copySql").disabled).toBe(false);
     expect(buttonWithText(root, "structureEditor.apply").disabled).toBe(false);
+  });
+
+  it.each([
+    ["postgres", "public"],
+    ["sqlite", "main"],
+  ] as const)("omits safe identifier quotes from generated %s SQL when quoting is disabled", async (databaseType, schema) => {
+    mocks.editorSettings.generateSqlQuoteIdentifiers = false;
+    const root = await mountEditor(databaseType);
+    mocks.buildTableStructureChangeSql.mockResolvedValueOnce({ statements: [`ALTER TABLE "${schema}"."demo_table" ADD "abc" VARCHAR(20) DEFAULT 'quoted value'`], warnings: [] });
+
+    buttonWithText(root, "structureEditor.addColumn").click();
+
+    await vi.waitFor(() => expect(root.textContent).toContain(`ALTER TABLE ${schema}.demo_table ADD abc VARCHAR(20) DEFAULT 'quoted value'`));
+    expect(root.textContent).not.toContain(`"${schema}"."demo_table"`);
+  });
+
+  it("keeps SQLite rebuild SQL aligned with the guarded apply plan", async () => {
+    mocks.editorSettings.generateSqlQuoteIdentifiers = false;
+    const root = await mountEditor("sqlite");
+    const preview = `ALTER TABLE "main"."demo_table" RENAME COLUMN "old_name" TO "new_name"`;
+    mocks.previewSqliteTableStructureChange.mockResolvedValueOnce({ statements: [preview], warnings: [], schemaRevision: "sqlite-revision" });
+
+    root.querySelector<HTMLButtonElement>('[data-searchable-select="true"]')?.click();
+
+    await vi.waitFor(() => expect(mocks.previewSqliteTableStructureChange).toHaveBeenCalled());
+    expect(root.textContent).toContain(preview);
   });
 
   it("debounces SQL preview generation while editing a column name", async () => {

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -27,6 +27,7 @@ import { createDbxCodeMirrorSqlDialect } from "@/lib/editor/codemirrorSqlDialect
 import { useToast } from "@/composables/useToast";
 import { type SqlHighlighter, createShikiSqlHighlighter } from "@/lib/sql/sqlHighlighter";
 import { joinSqlStatementsForScript } from "@/lib/sql/sqlBatchScript";
+import { omitDdlIdentifierQuotes } from "@/lib/sql/ddlDisplay";
 import { splitSqlStatementRanges } from "@/lib/sql/sqlStatementRanges";
 import { copyToClipboard } from "@/lib/common/clipboard";
 import { formatSqlForDisplay, sqlFormatDialectForDbType } from "@/lib/sql/sqlFormatter";
@@ -1717,7 +1718,9 @@ async function refreshSqlPreview() {
       }),
     ]);
     if (requestId !== sqlPreviewRequestId) return;
-    pendingStatements.value = [...result.statements, ...ownerResult.statements, ...(mysqlAutoIncrementStatement ? [mysqlAutoIncrementStatement] : [])];
+    const statements = [...result.statements, ...ownerResult.statements, ...(mysqlAutoIncrementStatement ? [mysqlAutoIncrementStatement] : [])];
+    // SQLite type-change apply regenerates this revision-checked plan, so its preview must stay byte-for-byte aligned.
+    pendingStatements.value = settingsStore.editorSettings.generateSqlQuoteIdentifiers || hasSqliteTypeChange.value ? statements : statements.map((statement) => omitDdlIdentifierQuotes(statement, sqlFormatDialectForDbType(databaseType.value)));
     warnings.value = [...result.warnings, ...ownerResult.warnings];
     sqliteSchemaRevision.value = "schemaRevision" in result && typeof result.schemaRevision === "string" ? result.schemaRevision : undefined;
   } catch (e: any) {

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.concurrent.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.concurrent.spec.ts
@@ -76,6 +76,27 @@ describe("concurrentIndexNamesInStatements", () => {
     expect(concurrentIndexNamesInStatements([])).toEqual([]);
     expect(concurrentIndexNamesInStatements(['CREATE INDEX "idx" ON "public"."t" ("c");'])).toEqual([]);
   });
+
+  it("extracts names from dequoted statements when the identifier-quote preference is off", () => {
+    expect(
+      concurrentIndexNamesInStatements([
+        "CREATE INDEX CONCURRENTLY idx_users_email ON public.users (email);",
+        "CREATE UNIQUE INDEX CONCURRENTLY uniq_users_name ON public.users (name);",
+        'CREATE INDEX CONCURRENTLY "MixedCase".idx_orders_id ON orders.orders (id);',
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ifne ON public.users (id);",
+      ]),
+    ).toEqual(["idx_users_email", "uniq_users_name", "idx_orders_id", "idx_ifne"]);
+  });
+
+  it("still detects a same-name INVALID index after dequoting (quote preference off)", () => {
+    // Regression for the pre-apply guard at TableStructureEditor applyChanges:
+    // with generateSqlQuoteIdentifiers disabled, pendingStatements are dequoted
+    // before the guard runs, so the extracted name must still match the
+    // listInvalidIndexes result and block the save.
+    const invalidIndexes = ["idx_users_email"];
+    const concurrentIndexNames = concurrentIndexNamesInStatements(["CREATE INDEX CONCURRENTLY idx_users_email ON public.users (email);"]);
+    expect(concurrentIndexNames.filter((name) => invalidIndexes.includes(name))).toEqual(["idx_users_email"]);
+  });
 });
 
 describe("normalizeUnsupportedConcurrentIndexes", () => {

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.concurrentTransition.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.concurrentTransition.spec.ts
@@ -227,7 +227,7 @@ vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ tableStructureRe
 vi.mock("@/stores/historyStore", () => ({ useHistoryStore: () => ({ add: vi.fn() }) }));
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [] },
+    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], generateSqlQuoteIdentifiers: true },
     updateEditorSettings: mocks.updateEditorSettings,
   }),
 }));

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlSearch.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlSearch.spec.ts
@@ -19,6 +19,7 @@ vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
     editorSettings: {
       regexMaxMatchCount: 1000,
+      generateSqlQuoteIdentifiers: true,
     },
   }),
 }));

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlTab.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlTab.spec.ts
@@ -259,7 +259,7 @@ vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ tableStructureRe
 vi.mock("@/stores/historyStore", () => ({ useHistoryStore: () => ({ add: vi.fn() }) }));
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], fontSize: 13, fontFamily: "monospace", theme: "default" },
+    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], fontSize: 13, fontFamily: "monospace", theme: "default", generateSqlQuoteIdentifiers: true },
     updateEditorSettings: mocks.updateEditorSettings,
   }),
 }));

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlTabLifecycle.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlTabLifecycle.spec.ts
@@ -176,7 +176,7 @@ vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ tableStructureRe
 vi.mock("@/stores/historyStore", () => ({ useHistoryStore: () => ({ add: vi.fn() }) }));
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], theme: "default", fontSize: 13, fontFamily: "monospace" },
+    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], theme: "default", fontSize: 13, fontFamily: "monospace", generateSqlQuoteIdentifiers: true },
     updateEditorSettings: vi.fn(),
   }),
 }));

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.initialTab.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.initialTab.spec.ts
@@ -259,7 +259,7 @@ vi.mock("@/stores/queryStore", () => ({ useQueryStore: () => ({ tableStructureRe
 vi.mock("@/stores/historyStore", () => ({ useHistoryStore: () => ({ add: vi.fn() }) }));
 vi.mock("@/stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], fontSize: 13, fontFamily: "monospace", theme: "default" },
+    editorSettings: { structureEditorDensity: "compact", sqlFormatter: {}, tableColumnTemplateFields: [], fontSize: 13, fontFamily: "monospace", theme: "default", generateSqlQuoteIdentifiers: true },
     updateEditorSettings: mocks.updateEditorSettings,
   }),
 }));

--- a/apps/desktop/src/lib/table/concurrentIndexAvailability.ts
+++ b/apps/desktop/src/lib/table/concurrentIndexAvailability.ts
@@ -43,16 +43,19 @@ export function getConcurrentIndexAvailability(input: ConcurrentIndexAvailabilit
 }
 
 /**
- * Unquoted index names referenced by `CREATE [UNIQUE] INDEX CONCURRENTLY`
- * statements, used to detect same-name INVALID leftovers before applying a
- * concurrent build. The PG builder emits the index name as a single
- * double-quoted identifier (optionally schema-qualified).
+ * Index names referenced by `CREATE [UNIQUE] INDEX CONCURRENTLY` statements,
+ * used to detect same-name INVALID leftovers before applying a concurrent
+ * build. The PG builder emits the index name as a double-quoted identifier
+ * (optionally schema-qualified); when the identifier-quote preference is off,
+ * the structure editor dequotes safe names before these statements reach this
+ * check, so unquoted names are accepted as well.
  */
 export function concurrentIndexNamesInStatements(statements: string[]): string[] {
   const names: string[] = [];
   for (const sql of statements) {
-    const match = sql.match(/CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+(?:(?:"[^"]+")\s*\.\s*)?"([^"]+)"/i);
-    if (match?.[1]) names.push(match[1]);
+    const match = sql.match(/CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*)?(?:"([^"]+)"|([A-Za-z_][A-Za-z0-9_$]*))/i);
+    const name = match?.[1] ?? match?.[2];
+    if (name) names.push(name);
   }
   return names;
 }


### PR DESCRIPTION
## 变更说明

- 表结构编辑器生成 DDL 时读取“生成 SQL 时为标识符添加引号”设置
- 关闭后复用现有安全去引号逻辑，保留字符串、保留字、特殊字符和大小写敏感名称所需的引号
- SQLite 普通结构变更同样生效；专用类型重建继续保持与 revision 校验执行计划完全一致

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端行为改动，无布局变化；由组件回归测试覆盖

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] `pnpm exec vitest run apps/desktop/src/components/structure/TableStructureEditor.primaryKey.spec.ts apps/desktop/src/lib/sql/__tests__/ddlDisplay.spec.ts --maxWorkers=1`（53 tests）
- [x] `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`

## 关联 Issue

Close #8680