### PR TITLE
fix(editor): include SQL Server variable prefix in word selection

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -140,7 +140,7 @@ import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorS
 import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import { computePasteCaretResyncTarget } from "@/lib/editor/queryEditorPasteCaretResync";
-import { queryEditorCommentTokens, queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
+import { queryEditorCommentTokens, queryEditorLineCommentToken, queryEditorWordLanguageData } from "@/lib/editor/queryEditorLineComment";
 import { createShellLineCommentHighlight } from "@/lib/editor/codemirrorShellLineCommentHighlight";
 import { extendQueryEditorSelection, runQueryEditorAltExtendSelection } from "@/lib/editor/queryEditorExtendSelection";
 import { addNextQueryEditorSelectionOccurrence, selectAllQueryEditorSelectionOccurrences } from "@/lib/editor/queryEditorOccurrenceSelection";
@@ -6035,6 +6035,7 @@ onMounted(async () => {
     // Non-SQL editors (MongoDB shell) keep the SQL grammar for highlighting, so override the
     // comment marker that toggleLineComment reads from language data.
     Prec.highest(EditorState.languageData.of(() => [{ commentTokens: queryEditorCommentTokens(props.databaseType) }])),
+    Prec.highest(EditorState.languageData.of(() => queryEditorWordLanguageData(props.databaseType))),
     // The SQL grammar does not tokenize `//`, so those comments are highlighted by hand.
     queryEditorLineCommentToken(props.databaseType) === "//" ? shellLineCommentHighlightPlugin : [],
   ];

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts
@@ -3,7 +3,7 @@ import { toggleLineComment } from "@codemirror/commands";
 import { sql } from "@codemirror/lang-sql";
 import { EditorState, Prec, type Transaction } from "@codemirror/state";
 import { describe, expect, it, vi } from "vitest";
-import { queryEditorCommentTokens, queryEditorLineCommentToken } from "@/lib/editor/queryEditorLineComment";
+import { queryEditorCommentTokens, queryEditorLineCommentToken, queryEditorWordLanguageData } from "@/lib/editor/queryEditorLineComment";
 
 const queryEditorSource = readFileSync(new URL("../../../components/editor/QueryEditor.vue", import.meta.url), "utf8");
 const editorThemesSource = readFileSync(new URL("../../editor/editorThemes.ts", import.meta.url), "utf8");
@@ -44,6 +44,18 @@ describe("queryEditorLineCommentToken", () => {
     expect(queryEditorLineCommentToken(undefined)).toBe("--");
     expect(queryEditorLineCommentToken("mysql")).toBe("--");
     expect(queryEditorLineCommentToken("postgres")).toBe("--");
+  });
+});
+
+describe("QueryEditor word selection", () => {
+  it("includes the @ prefix in SQL Server variable words", () => {
+    const sqlServer = EditorState.create({ doc: "@name", extensions: [EditorState.languageData.of(() => queryEditorWordLanguageData("sqlserver"))] });
+    const mysql = EditorState.create({ doc: "@name", extensions: [EditorState.languageData.of(() => queryEditorWordLanguageData("mysql"))] });
+    const systemVariable = EditorState.create({ doc: "@@ROWCOUNT", extensions: [EditorState.languageData.of(() => queryEditorWordLanguageData("sqlserver"))] });
+
+    for (let position = 0; position <= 5; position += 1) expect(sqlServer.wordAt(position)).toMatchObject({ from: 0, to: 5 });
+    expect(mysql.wordAt(2)).toMatchObject({ from: 1, to: 5 });
+    expect(systemVariable.wordAt(1)).toMatchObject({ from: 0, to: 10 });
   });
 });
 

--- a/apps/desktop/src/lib/editor/queryEditorLineComment.ts
+++ b/apps/desktop/src/lib/editor/queryEditorLineComment.ts
@@ -18,3 +18,7 @@ export function queryEditorCommentTokens(dbType?: DatabaseType) {
     block: { open: "/*", close: "*/" },
   };
 }
+
+export function queryEditorWordLanguageData(dbType?: DatabaseType) {
+  return dbType === "sqlserver" ? [{ wordChars: "@" }] : [];
+}


### PR DESCRIPTION
## 变更说明

- 在 SQL Server 编辑器的 CodeMirror 语言数据中将 `@` 归为词字符
- 双击 `@name` 的任意位置时使用原生词选择覆盖完整变量
- `@@ROWCOUNT` 同样作为完整变量处理，其他数据库的词选择保持不变

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动，无布局变化；由 CodeMirror 行为测试覆盖

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] `pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/queryEditorLineComment.spec.ts --maxWorkers=1`（10 tests）
- [x] 定向 oxlint 通过

## 关联 Issue

Close #8699