### PR TITLE
fix(opengauss): 修复 pg_get_tabledef 注释单引号未转义导致的建表失败

### DIFF
--- a/crates/dbx-core/src/database_export.rs
+++ b/crates/dbx-core/src/database_export.rs
@@ -1428,133 +1428,13 @@ fn normalize_export_table_ddl(
 
 fn format_export_table_ddl(ddl: &str, database_type: Option<DatabaseType>, opts: DdlNormalizeOptions) -> String {
     let ddl = normalize_export_table_ddl(ddl, database_type, opts);
-    let ddl =
-        if database_type == Some(DatabaseType::OpenGauss) { normalize_opengauss_table_ddl_comments(&ddl) } else { ddl };
+    let ddl = if database_type == Some(DatabaseType::OpenGauss) {
+        crate::schema::normalize_opengauss_table_ddl_comments(&ddl)
+    } else {
+        ddl
+    };
     let ddl = ddl.trim().trim_end_matches(';').trim_end();
     format!("{ddl};")
-}
-
-/// openGauss 6.x `pg_get_tabledef` can concatenate comment text into a
-/// `COMMENT ON` literal without escaping embedded single quotes. Normalize
-/// only those generated comment statements; all other DDL text remains
-/// untouched.
-fn normalize_opengauss_table_ddl_comments(ddl: &str) -> String {
-    let mut normalized = String::with_capacity(ddl.len());
-    for line in ddl.split_inclusive('\n') {
-        let (line_body, line_ending) = match line.strip_suffix('\n') {
-            Some(body) => match body.strip_suffix('\r') {
-                Some(body) => (body, "\r\n"),
-                None => (body, "\n"),
-            },
-            None => (line, ""),
-        };
-        let leading = line_body.len() - line_body.trim_start_matches(|ch: char| ch.is_ascii_whitespace()).len();
-        let statement = &line_body[leading..];
-        if let Some(statement) = normalize_opengauss_comment_statement(statement) {
-            normalized.push_str(&line_body[..leading]);
-            normalized.push_str(&statement);
-        } else {
-            normalized.push_str(line_body);
-        }
-        normalized.push_str(line_ending);
-    }
-    normalized
-}
-
-fn normalize_opengauss_comment_statement(statement: &str) -> Option<String> {
-    let uppercase = statement.to_ascii_uppercase();
-    if !uppercase.starts_with("COMMENT ON ") {
-        return None;
-    }
-
-    let is_pos = find_opengauss_comment_is_keyword(statement, &uppercase)?;
-    let value_start = is_pos + " IS ".len();
-    let value = &statement[value_start..];
-    let value_leading = value.len() - value.trim_start_matches(|ch: char| ch.is_ascii_whitespace()).len();
-    let value = &value[value_leading..];
-    let quote_offset = match value.as_bytes() {
-        [b'\'', ..] => 0,
-        [b'e' | b'E', b'\'', ..] => 1,
-        _ => return None,
-    };
-    let opening_quote = value_start + value_leading + quote_offset;
-    let statement_end = statement.trim_end().len();
-    let literal_end = statement[..statement_end]
-        .strip_suffix(';')
-        .map_or(statement_end, |without_terminator| without_terminator.len());
-    if opening_quote >= literal_end {
-        return None;
-    }
-
-    let closing_quote = statement[..literal_end].rfind('\'')?;
-    if closing_quote <= opening_quote || !statement[closing_quote + 1..literal_end].trim().is_empty() {
-        return None;
-    }
-    let literal = &statement[opening_quote..=closing_quote];
-    if opengauss_comment_literal_is_valid(literal) {
-        return Some(statement.to_string());
-    }
-
-    let raw_comment = &statement[opening_quote + 1..closing_quote];
-    let escaped_comment = raw_comment.replace('\'', "''");
-    let mut normalized = String::with_capacity(statement.len() + escaped_comment.len() - raw_comment.len());
-    normalized.push_str(&statement[..opening_quote + 1]);
-    normalized.push_str(&escaped_comment);
-    normalized.push_str(&statement[closing_quote..]);
-    Some(normalized)
-}
-
-fn find_opengauss_comment_is_keyword(statement: &str, uppercase: &str) -> Option<usize> {
-    let mut cursor = "COMMENT ON ".len();
-    while cursor + " IS ".len() <= statement.len() {
-        if statement.as_bytes().get(cursor) == Some(&b'\"') {
-            cursor = skip_opengauss_quoted_identifier(statement, cursor);
-            continue;
-        }
-        if uppercase.get(cursor..cursor + " IS ".len()) == Some(" IS ") {
-            return Some(cursor);
-        }
-        cursor += statement[cursor..].chars().next()?.len_utf8();
-    }
-    None
-}
-
-fn skip_opengauss_quoted_identifier(sql: &str, start: usize) -> usize {
-    let bytes = sql.as_bytes();
-    let mut cursor = start + 1;
-    while cursor < bytes.len() {
-        if bytes[cursor] == b'\"' {
-            if bytes.get(cursor + 1) == Some(&b'\"') {
-                cursor += 2;
-            } else {
-                return cursor + 1;
-            }
-        } else {
-            cursor += 1;
-        }
-    }
-    bytes.len()
-}
-
-fn opengauss_comment_literal_is_valid(literal: &str) -> bool {
-    let bytes = literal.as_bytes();
-    if bytes.len() < 2 || bytes.first() != Some(&b'\'') || bytes.last() != Some(&b'\'') {
-        return false;
-    }
-
-    let mut cursor = 1;
-    while cursor < bytes.len() - 1 {
-        if bytes[cursor] == b'\'' {
-            if cursor + 1 < bytes.len() - 1 && bytes[cursor + 1] == b'\'' {
-                cursor += 2;
-            } else {
-                return false;
-            }
-        } else {
-            cursor += 1;
-        }
-    }
-    true
 }
 
 fn split_postgres_export_table_triggers(ddl: &str, database_type: DatabaseType) -> (String, Vec<String>) {

--- a/crates/dbx-core/src/schema.rs
+++ b/crates/dbx-core/src/schema.rs
@@ -10892,6 +10892,40 @@ mod ddl_tests {
     }
 
     #[test]
+    fn opengauss_ddl_comment_normalization_escapes_unescaped_quotes() {
+        // openGauss 6.x pg_get_tabledef concatenates the stored comment into
+        // the COMMENT ON literal verbatim; embedded single quotes make the
+        // statement invalid. Everything downstream (transfer table creation,
+        // export, UI display) executes this DDL, so the quotes must be doubled.
+        let ddl = concat!(
+            "SET search_path = public;\n",
+            "CREATE TABLE \"public\".\"dpms_doctor_surgery_record\" (\"del_flag\" char(1));\n",
+            "COMMENT ON COLUMN \"public\".\"dpms_doctor_surgery_record\".\"del_flag\" IS '逻辑删除标志：'0'-未删除，'1'-已删除';"
+        );
+
+        assert_eq!(
+            normalize_opengauss_table_ddl_comments(ddl),
+            concat!(
+                "SET search_path = public;\n",
+                "CREATE TABLE \"public\".\"dpms_doctor_surgery_record\" (\"del_flag\" char(1));\n",
+                "COMMENT ON COLUMN \"public\".\"dpms_doctor_surgery_record\".\"del_flag\" IS '逻辑删除标志：''0''-未删除，''1''-已删除';"
+            )
+        );
+    }
+
+    #[test]
+    fn opengauss_ddl_comment_normalization_leaves_valid_ddl_unchanged() {
+        let ddl = concat!(
+            "SET search_path = public;\n",
+            "CREATE TABLE \"public\".\"notes\" (\"body\" text DEFAULT 'O''Hara');\n",
+            "COMMENT ON TABLE \"public\".\"notes\" IS 'owner''s note';\n",
+            "GRANT SELECT ON TABLE \"public\".\"notes\" TO \"auditor's role\";"
+        );
+
+        assert_eq!(normalize_opengauss_table_ddl_comments(ddl), ddl);
+    }
+
+    #[test]
     fn mysql_display_ddl_gets_statement_terminator() {
         let ddl = "CREATE TABLE `users` (\n  `id` int NOT NULL\n) ENGINE=InnoDB";
 
@@ -11767,12 +11801,139 @@ pub async fn opengauss_table_ddl(pool: &deadpool_postgres::Pool, schema: &str, t
         db::postgres::list_trigger_definitions(pool, schema, table),
     )?;
 
+    // Repair the server's comment literals before anything downstream executes
+    // this DDL: every consumer (transfer table creation, export, UI display)
+    // must receive executable SQL, not the raw pg_get_tabledef output.
+    let ddl = normalize_opengauss_table_ddl_comments(&ddl);
     Ok(append_opengauss_trigger_definitions(ddl, &trigger_definitions))
 }
 
 pub fn opengauss_table_ddl_sql(schema: &str, table: &str) -> String {
     let qualified_name = format!("{}.{}", pg_ident(schema), pg_ident(table));
     format!("SELECT pg_get_tabledef({})", sql_string(&qualified_name))
+}
+
+/// openGauss 6.x `pg_get_tabledef` can concatenate comment text into a
+/// `COMMENT ON` literal without escaping embedded single quotes. Normalize
+/// only those generated comment statements; all other DDL text remains
+/// untouched.
+pub(crate) fn normalize_opengauss_table_ddl_comments(ddl: &str) -> String {
+    let mut normalized = String::with_capacity(ddl.len());
+    for line in ddl.split_inclusive('\n') {
+        let (line_body, line_ending) = match line.strip_suffix('\n') {
+            Some(body) => match body.strip_suffix('\r') {
+                Some(body) => (body, "\r\n"),
+                None => (body, "\n"),
+            },
+            None => (line, ""),
+        };
+        let leading = line_body.len() - line_body.trim_start_matches(|ch: char| ch.is_ascii_whitespace()).len();
+        let statement = &line_body[leading..];
+        if let Some(statement) = normalize_opengauss_comment_statement(statement) {
+            normalized.push_str(&line_body[..leading]);
+            normalized.push_str(&statement);
+        } else {
+            normalized.push_str(line_body);
+        }
+        normalized.push_str(line_ending);
+    }
+    normalized
+}
+
+fn normalize_opengauss_comment_statement(statement: &str) -> Option<String> {
+    let uppercase = statement.to_ascii_uppercase();
+    if !uppercase.starts_with("COMMENT ON ") {
+        return None;
+    }
+
+    let is_pos = find_opengauss_comment_is_keyword(statement, &uppercase)?;
+    let value_start = is_pos + " IS ".len();
+    let value = &statement[value_start..];
+    let value_leading = value.len() - value.trim_start_matches(|ch: char| ch.is_ascii_whitespace()).len();
+    let value = &value[value_leading..];
+    let quote_offset = match value.as_bytes() {
+        [b'\'', ..] => 0,
+        [b'e' | b'E', b'\'', ..] => 1,
+        _ => return None,
+    };
+    let opening_quote = value_start + value_leading + quote_offset;
+    let statement_end = statement.trim_end().len();
+    let literal_end = statement[..statement_end]
+        .strip_suffix(';')
+        .map_or(statement_end, |without_terminator| without_terminator.len());
+    if opening_quote >= literal_end {
+        return None;
+    }
+
+    let closing_quote = statement[..literal_end].rfind('\'')?;
+    if closing_quote <= opening_quote || !statement[closing_quote + 1..literal_end].trim().is_empty() {
+        return None;
+    }
+    let literal = &statement[opening_quote..=closing_quote];
+    if opengauss_comment_literal_is_valid(literal) {
+        return Some(statement.to_string());
+    }
+
+    let raw_comment = &statement[opening_quote + 1..closing_quote];
+    let escaped_comment = raw_comment.replace('\'', "''");
+    let mut normalized = String::with_capacity(statement.len() + escaped_comment.len() - raw_comment.len());
+    normalized.push_str(&statement[..opening_quote + 1]);
+    normalized.push_str(&escaped_comment);
+    normalized.push_str(&statement[closing_quote..]);
+    Some(normalized)
+}
+
+fn find_opengauss_comment_is_keyword(statement: &str, uppercase: &str) -> Option<usize> {
+    let mut cursor = "COMMENT ON ".len();
+    while cursor + " IS ".len() <= statement.len() {
+        if statement.as_bytes().get(cursor) == Some(&b'"') {
+            cursor = skip_opengauss_quoted_identifier(statement, cursor);
+            continue;
+        }
+        if uppercase.get(cursor..cursor + " IS ".len()) == Some(" IS ") {
+            return Some(cursor);
+        }
+        cursor += statement[cursor..].chars().next()?.len_utf8();
+    }
+    None
+}
+
+fn skip_opengauss_quoted_identifier(sql: &str, start: usize) -> usize {
+    let bytes = sql.as_bytes();
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'"' {
+            if bytes.get(cursor + 1) == Some(&b'"') {
+                cursor += 2;
+            } else {
+                return cursor + 1;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn opengauss_comment_literal_is_valid(literal: &str) -> bool {
+    let bytes = literal.as_bytes();
+    if bytes.len() < 2 || bytes.first() != Some(&b'\'') || bytes.last() != Some(&b'\'') {
+        return false;
+    }
+
+    let mut cursor = 1;
+    while cursor < bytes.len() - 1 {
+        if bytes[cursor] == b'\'' {
+            if cursor + 1 < bytes.len() - 1 && bytes[cursor + 1] == b'\'' {
+                cursor += 2;
+            } else {
+                return false;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    true
 }
 
 fn append_postgres_trigger_definitions(mut ddl: String, trigger_definitions: &[String]) -> String {


### PR DESCRIPTION
## 变更说明

openGauss 6.x 的服务端函数 `pg_get_tabledef()` 会把存储的注释原文拼接进 `COMMENT ON` 字面量，**不对其中的单引号加倍**。任何注释含单引号的表（如 `逻辑删除标志：'0'-未删除，'1'-已删除`）拿到的 DDL 都是非法 SQL，直接执行报 `syntax error at or near ...`：

```
COMMENT ON COLUMN "public"."table_name"."del_flag" IS '逻辑删除标志：'0'-未删除，'1'-已删除';   -- 非法
```

导出路径此前已经有一份针对该问题的规范化逻辑（`normalize_opengauss_table_ddl_comments`，仅重写 `COMMENT ON` 语句、其余 DDL 原样保留），但只覆盖了导出；**数据传输建表路径和 UI 的"表 DDL"展示拿到的仍是服务端原始输出**，导致含此类注释的表在数据传输中建表失败。

本 PR 把这份规范化逻辑从 `database_export.rs` 移到 `schema.rs`（`opengauss_table_ddl` 旁边），并在 `opengauss_table_ddl()` 入口统一生效——UI 显示、数据传输、导出三条路径现在拿到的都是可执行 SQL。导出路径改为引用同一实现（规范化幂等：合法字面量原样通过，不会二次改写）。

实测（openGauss 6.0.3，含上述注释的真实表 ）：修复前该表传输失败 `syntax error at or near "0"`；与 #8661 的方言修复合在一起做全量传输复验，425 张表 + 43 个视图 + 7 个序列 129 秒全部成功，0 建表失败、0 行数差异。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

（无前端改动；纯 Rust 后端，`crates/dbx-core/src/schema.rs` + `crates/dbx-core/src/database_export.rs`）

## 验证

- [x] `make check` 通过（lint、typecheck 通过；其余 3 项失败均已归因为 main 既有或 Windows 环境问题，与本 PR 无关，见下）
- [x] `make cargo-check-fast` 通过（本机跑等价命令 `cargo check --no-default-features --features sqlite-bundled`）
- [x] 相关测试通过

测试明细：
- 新增单测 2 条：`opengauss_ddl_comment_normalization_escapes_unescaped_quotes`（含单引号注释被正确加倍，其余语句不动）、`opengauss_ddl_comment_normalization_leaves_valid_ddl_unchanged`（合法 DDL/含引号标识符的 GRANT 原样保留）
- 原导出路径 2 条既有测试（`opengauss_export_escapes_single_quotes_in_comment_ddl` 等）继续通过，证明迁移后行为不变
- `cargo test -p dbx-core --lib` 全量：5781 通过；4 个失败（agent_manager/jdbc 路径分隔符、storage 文件锁、agent_driver 时序抖动）在未改动的 `main` 上同样失败，为 Windows 环境既有问题，与本 PR 无关
- `pnpm check`（Windows 本机）：lint ✓、typecheck ✓（13482 个前端测试通过）；3 项失败归因——connection-types：check 脚本在 Windows 把 `node` 解析成不存在的 `node_modules\.bin\node.CMD`，且 `core.autocrlf` 使 manifest 工作区副本恒为 CRLF 触发字节比较假阳性（Linux CI 不受影响）；format：`SidebarTreeRuntimeHost.vue` 一处 oxfmt 违规为 `main` 既有（a4e4fd0d2 引入，本 PR 无前端改动）；test：1 个 suite 需要编译 openssl（依赖本机 Perl PATH）、1 个 `legacyWebViewRegexCompat` 为 main 既有违规、1 个 `TableImportDialog.existingTarget` 为并发 flaky（main 与本分支单独运行均通过）
- 真实环境复验：openGauss 6.0.3 全量传输（425 表 + 43 视图 + 7 序列），0 失败、0 行数差异（与 #8661 方言修复叠加验证）

## 关联 Issue

Related #8661