### PR TITLE
improve: 简化经典紧凑标签选中态

### DIFF
--- a/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts
@@ -159,6 +159,9 @@ describe("EditorGroupTabBar semantic tab groups", () => {
     expect(sharedStyles).toContain(".app-tab-bar:not(.vertical-tab-layout) .tab-group-header");
     expect(sharedStyles).toMatch(/\.app-tab-bar\.classic-tab-layout:not\(\.vertical-tab-layout\) \.tab-group-header-content\s*\{[^}]*height:\s*100%;[^}]*border-radius:\s*0;/s);
     expect(sharedStyles).toMatch(/\.app-tab-bar\.classic-tab-layout:not\(\.vertical-tab-layout\):not\(:has\(\.wrap-mode\)\)\[data-group-mode="none"\] \.app-tab-pill\s*\{[^}]*border-right-width:\s*0\.5px;/s);
+    expect(sharedStyles).toMatch(
+      /\.app-tab-bar\.classic-tab-layout:not\(\.vertical-tab-layout\):not\(:has\(\.wrap-mode\)\)\[data-placement="top"\]\[data-group-mode="none"\] \.app-tab-pill\[data-active-tab="true"\]\s*\{[^}]*border-top-color:\s*transparent;[^}]*border-right-color:\s*transparent;[^}]*border-left-color:\s*transparent;/s,
+    );
     expect(sharedStyles).toMatch(/\.tab-overflow-control\s*\{[^}]*width:\s*34px;[^}]*flex:\s*0 0 34px;/s);
     expect(sharedStyles).toContain("padding-inline-end: 2.125rem;");
     expect(sharedStyles).toContain("inset-inline-end: 2.125rem;");

--- a/apps/desktop/src/components/layout/appTabBar.css
+++ b/apps/desktop/src/components/layout/appTabBar.css
@@ -593,6 +593,15 @@
   border-right-width: 0.5px;
 }
 
+/* In the default classic single-row layout, the bottom indicator is enough to
+ * identify the active tab. Remove its surrounding three-sided outline so the
+ * selected state does not look boxed in. */
+.app-tab-bar.classic-tab-layout:not(.vertical-tab-layout):not(:has(.wrap-mode))[data-placement="top"][data-group-mode="none"] .app-tab-pill[data-active-tab="true"] {
+  border-top-color: transparent;
+  border-right-color: transparent;
+  border-left-color: transparent;
+}
+
 .app-tab-bar:not(.vertical-tab-layout) .tab-group-header:hover .tab-group-header-content,
 .app-tab-bar:not(.vertical-tab-layout) .tab-group-header--active .tab-group-header-content {
   background: color-mix(in srgb, var(--tab-group-color) 18%, transparent);


### PR DESCRIPTION
## 修改内容

- 在经典紧凑、顶部、单行滚动且不分组的默认布局中，选中标签不再显示上、左、右三侧边线。
- 保留底部选中指示条与标签背景，减少选中态的方框感。
- 增加样式范围回归断言，避免影响现代分隔、多行平铺、分组及左侧标签栏。

## 本地验证

- `pnpm exec vitest run apps/desktop/src/components/layout/__tests__/EditorGroupTabBar.groups.spec.ts`
- `git diff --check`
- 免密网页版验收：经典紧凑、顶部、单行滚动、不分组，选中标签三侧边线已隐藏，底部指示条正常保留。

结果：1 个测试文件、43 项测试通过；差异检查通过。