### PR TITLE
fix(editor): preserve multi-click selection drags

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -137,7 +137,7 @@ import { sqlBlockFoldService } from "@/lib/editor/codemirrorSqlBlockFolding";
 import { focusEditorView } from "@/lib/editor/queryEditorFocus";
 import { createDbxCodeMirrorSqlDialect, type CodeMirrorSqlDialectName } from "@/lib/editor/codemirrorSqlDialect";
 import { sqlSemanticTableNameSpansForSyntaxTree } from "@/lib/editor/codemirrorSqlSemanticHighlight";
-import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
+import { startsQueryEditorRectangularSelection, startsQueryEditorSelectionDrag, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 import { LARGE_PASTE_HISTORY_USER_EVENT, normalizeQueryEditorPasteText, recoverableNativePasteSuffix, shouldRecoverLargeTauriPaste } from "@/lib/editor/queryEditorLargePaste";
 import { computePasteCaretResyncTarget } from "@/lib/editor/queryEditorPasteCaretResync";
 import { queryEditorCommentTokens, queryEditorLineCommentToken, queryEditorWordLanguageData } from "@/lib/editor/queryEditorLineComment";
@@ -1417,10 +1417,7 @@ function updateEditorSelectionDropCursor(currentView: EditorViewType, event: Mou
 }
 
 function startEditorSelectionDrag(currentView: EditorViewType, event: MouseEvent): boolean {
-  // Shift is CodeMirror's native extend-selection gesture. Keep it out of the
-  // custom selection drag path so a shift-click inside the current selection
-  // extends or shrinks the selection instead of collapsing it to the cursor.
-  if (event.shiftKey) return false;
+  if (!startsQueryEditorSelectionDrag(event)) return false;
 
   const selection = selectedRangeAtPointer(currentView, event);
   if (!selection) return false;

--- a/apps/desktop/src/components/editor/__tests__/QueryEditorContextMenu.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/QueryEditorContextMenu.spec.ts
@@ -199,16 +199,3 @@ describe("QueryEditor batch column selection", () => {
     expect(source).toContain("maxRenderedOptions: batchColumnSelectionExpandedRendering ? Number.MAX_SAFE_INTEGER : 100,");
   });
 });
-
-describe("QueryEditor pointer selection", () => {
-  it("lets CodeMirror handle shift-click instead of starting the selection drag gesture", () => {
-    const start = source.indexOf("function startEditorSelectionDrag");
-    const end = source.indexOf("\n}\n\nfunction executeFromContextMenu", start);
-    const dragSource = source.slice(start, end);
-
-    expect(start).toBeGreaterThanOrEqual(0);
-    expect(end).toBeGreaterThan(start);
-    expect(dragSource).toContain("if (event.shiftKey) return false;");
-    expect(dragSource.indexOf("if (event.shiftKey) return false;")).toBeLessThan(dragSource.indexOf("const selection = selectedRangeAtPointer"));
-  });
-});

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorPointerSelection.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorPointerSelection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { startsQueryEditorRectangularSelection, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
+import { startsQueryEditorRectangularSelection, startsQueryEditorSelectionDrag, usesQueryEditorObjectNavigationModifier } from "@/lib/editor/queryEditorPointerSelection";
 
 describe("query editor pointer selection", () => {
   it("starts rectangular selection for Alt+left drag", () => {
@@ -12,6 +12,14 @@ describe("query editor pointer selection", () => {
 
   it("leaves ordinary left clicks to the normal cursor handler", () => {
     expect(startsQueryEditorRectangularSelection({ altKey: false, button: 0 })).toBe(false);
+  });
+
+  it("leaves multi-click and Shift selection gestures to CodeMirror", () => {
+    expect(startsQueryEditorSelectionDrag({ detail: 0, shiftKey: false })).toBe(true);
+    expect(startsQueryEditorSelectionDrag({ detail: 1, shiftKey: false })).toBe(true);
+    expect(startsQueryEditorSelectionDrag({ detail: 1, shiftKey: true })).toBe(false);
+    expect(startsQueryEditorSelectionDrag({ detail: 2, shiftKey: false })).toBe(false);
+    expect(startsQueryEditorSelectionDrag({ detail: 3, shiftKey: false })).toBe(false);
   });
 
   it("uses Cmd or Ctrl without Alt for object navigation", () => {

--- a/apps/desktop/src/lib/editor/queryEditorPointerSelection.ts
+++ b/apps/desktop/src/lib/editor/queryEditorPointerSelection.ts
@@ -3,6 +3,11 @@ export interface QueryEditorPointerEvent {
   button: number;
 }
 
+export interface QueryEditorSelectionDragEvent {
+  detail: number;
+  shiftKey: boolean;
+}
+
 export interface QueryEditorObjectNavigationModifierEvent {
   altKey: boolean;
   ctrlKey: boolean;
@@ -11,6 +16,10 @@ export interface QueryEditorObjectNavigationModifierEvent {
 
 export function startsQueryEditorRectangularSelection(event: QueryEditorPointerEvent): boolean {
   return event.altKey || event.button === 1;
+}
+
+export function startsQueryEditorSelectionDrag(event: QueryEditorSelectionDragEvent): boolean {
+  return !event.shiftKey && event.detail <= 1;
 }
 
 export function usesQueryEditorObjectNavigationModifier(event: QueryEditorObjectNavigationModifierEvent): boolean {


### PR DESCRIPTION
## 变更说明

- 已选文本的拖动移动逻辑只处理普通单击拖动
- 双击字符串拖选、三击选行和 Shift 扩展选择交还 CodeMirror 原生处理
- 将事件判定放入现有 pointer-selection 工具，并用真实函数测试替换 SFC 源码字符串断言

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动，无布局变化；由鼠标选择行为测试覆盖

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关 Vitest 3 个文件、29 项测试通过
- [x] 定向 oxlint 与 `git diff --check` 通过

## 关联 Issue

Close #8687

Related #8670