### PR TITLE
feat(editor): add explain plan shortcut

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -204,6 +204,8 @@ const props = defineProps<{
   autoFocus?: boolean;
   forceWordWrap?: boolean;
   hideExecutionControls?: boolean;
+  enableExplainShortcut?: boolean;
+  canExplain?: boolean;
   initialViewport?: { scrollTop: number; scrollLeft: number };
   initialSelection?: { anchor: number; head: number };
   statementExecutionMarkers?: StatementExecutionMarker[];
@@ -235,6 +237,7 @@ const emit = defineEmits<{
   formatError: [message: string];
   execute: [source: SqlExecutionOverride];
   executeInNewResultTab: [source: SqlExecutionOverride];
+  explain: [];
   exportQuery: [payload: { sql: string; format: "csv" | "xlsx" | "txt"; columnComments?: (string | null)[] }];
   save: [];
   clickTable: [target: SqlObjectNavigationTarget];
@@ -2173,6 +2176,17 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
         (currentView) => shouldBlockExecutionShortcut(undefined, currentView),
       );
   const executeInNewResultTabBindings = props.hideExecutionControls ? [] : createQueryEditorExecutionShortcutBindings(shortcuts.executeSqlInNewResultTab, requestExecuteInNewResultTab, (currentView) => shouldBlockExecutionShortcut(undefined, currentView));
+  const explainBindings = props.enableExplainShortcut
+    ? createQueryEditorExecutionShortcutBindings(
+        shortcuts.explainSql,
+        () => {
+          emit("explain");
+          return true;
+        },
+        (currentView) => shouldBlockExecutionShortcut(undefined, currentView),
+        () => !!props.canExplain,
+      )
+    : [];
   const replaceShortcutBindings = createQueryEditorReplaceShortcutBindings(shortcuts.replace, openReplace);
   const replaceShortcutHandler = createQueryEditorReplaceShortcutHandler({
     shortcut: shortcuts.replace,
@@ -2221,6 +2235,7 @@ function runKeymapExtension(codeMirrorKeymap: (typeof import("@codemirror/view")
         ...replaceShortcutBindings,
         ...executeInNewResultTabBindings,
         ...executeBindings,
+        ...explainBindings,
         ...binding(shortcuts.saveSql, () => {
           emit("save");
           return true;

--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -1298,6 +1298,8 @@ defineExpose({
               :initial-viewport="activeTab.editorViewport"
               :initial-selection="activeTab.editorSelection"
               :force-word-wrap="activeTab.forceWordWrap"
+              enable-explain-shortcut
+              :can-explain="!activeTab.isExecuting && !activeTab.isExplaining && !!executableSql.trim()"
               @update:model-value="emit('editorUpdate', activeTab.id, $event)"
               @selection-change="emit('editorSelectionChange', activeTab.id, $event)"
               @send-selection-to-ai="emit('sendSelectionToAi', activeTab.id, $event)"
@@ -1309,6 +1311,7 @@ defineExpose({
               @format-error="emit('formatError', activeTab.id)"
               @execute="emit('execute', activeTab.id, $event)"
               @execute-in-new-result-tab="emit('executeInNewResultTab', activeTab.id, $event)"
+              @explain="emit('explain', activeTab.id)"
               @export-query="handleExportQuery"
               @save="emit('saveSql', props.activeTab.id)"
               @click-table="onHandleClickTable"

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorExecutionShortcut.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorExecutionShortcut.spec.ts
@@ -39,6 +39,24 @@ describe("QueryEditor execution shortcuts", () => {
     view.destroy();
   });
 
+  it("checks shortcut eligibility at dispatch time without rebuilding the keymap", () => {
+    let enabled = false;
+    const explain = vi.fn(() => true);
+    const view = createView([createQueryEditorExecutionShortcutBindings("Mod+E", explain, isComposing, () => enabled)]);
+
+    expect(runScopeHandlers(view, executeEvent("e"), "editor")).toBe(true);
+    expect(explain).not.toHaveBeenCalled();
+
+    enabled = true;
+    expect(runScopeHandlers(view, executeEvent("e"), "editor")).toBe(true);
+    expect(explain).toHaveBeenCalledOnce();
+
+    enabled = false;
+    expect(runScopeHandlers(view, executeEvent("e"), "editor")).toBe(true);
+    expect(explain).toHaveBeenCalledOnce();
+    view.destroy();
+  });
+
   it("consumes the SQL shortcut without executing during IME composition", () => {
     const execute = vi.fn(() => true);
     const view = createView([createQueryEditorExecutionShortcutBindings("Mod+Enter", execute, isComposing)]);

--- a/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/shortcutRegistry.spec.ts
@@ -152,6 +152,14 @@ describe("shortcutRegistry editor actions", () => {
     expect(findShortcutConflict("expandSelectStar", DEFAULT_SHORTCUT_SETTINGS.expandSelectStar, DEFAULT_SHORTCUT_SETTINGS)).toBeNull();
   });
 
+  it("registers a configurable editor shortcut for the explain plan", () => {
+    const definition = SHORTCUT_DEFINITIONS.find((item) => item.id === "explainSql");
+
+    expect(definition).toMatchObject({ labelKey: "toolbar.explainPlan", scope: "editor", defaultShortcut: "Mod+E" });
+    expect(shortcutToCodeMirrorKey(DEFAULT_SHORTCUT_SETTINGS.explainSql)).toBe("Mod-e");
+    expect(findShortcutConflict("explainSql", "Mod+E", DEFAULT_SHORTCUT_SETTINGS)).toBeNull();
+  });
+
   it("keeps current-view search and editor find contextual on Mod+F", () => {
     const focusSearch = SHORTCUT_DEFINITIONS.find((item) => item.id === "focusSearch");
     const find = SHORTCUT_DEFINITIONS.find((item) => item.id === "find");

--- a/apps/desktop/src/lib/editor/queryEditorExecutionShortcut.ts
+++ b/apps/desktop/src/lib/editor/queryEditorExecutionShortcut.ts
@@ -59,14 +59,14 @@ export function createQueryEditorPostCompositionKeyGuard(options: { navigator?: 
  * document, so the app-level shortcut fallback also checks the editor state.
  * This guard covers the keymap path when CodeMirror still dispatches it.
  */
-export function createQueryEditorExecutionShortcutBindings(shortcut: string, run: Command, isComposing: (view: EditorView) => boolean): KeyBinding[] {
+export function createQueryEditorExecutionShortcutBindings(shortcut: string, run: Command, isComposing: (view: EditorView) => boolean, isEnabled: () => boolean = () => true): KeyBinding[] {
   if (!shortcut) return [];
   return [
     {
       key: shortcutToCodeMirrorKey(shortcut),
       preventDefault: true,
       run(view) {
-        if (isComposing(view)) return true;
+        if (isComposing(view) || !isEnabled()) return true;
         return run(view);
       },
     },

--- a/apps/desktop/src/lib/editor/shortcutRegistry.ts
+++ b/apps/desktop/src/lib/editor/shortcutRegistry.ts
@@ -3,6 +3,7 @@ import { isMacShortcutPlatform, parseShortcutStrokes, shortcutDisplayParts } fro
 export type ShortcutActionId =
   | "executeSql"
   | "executeSqlInNewResultTab"
+  | "explainSql"
   | "formatSql"
   | "expandSelectStar"
   | "toggleLineComment"
@@ -150,6 +151,12 @@ export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
     labelKey: "settings.shortcutExecuteSqlInNewResultTab",
     scope: "editor",
     defaultShortcut: "Mod+\\",
+  },
+  {
+    id: "explainSql",
+    labelKey: "toolbar.explainPlan",
+    scope: "editor",
+    defaultShortcut: "Mod+E",
   },
   {
     id: "formatSql",


### PR DESCRIPTION
## 变更说明

- 新增可配置的执行计划快捷键，默认 Windows/Linux 为 `Ctrl+E`、macOS 为 `Cmd+E`
- 复用现有快捷键设置 UI、IME 防护和 explain 事件链，不新增翻译或依赖
- 绑定仅安装在主查询编辑器；空 SQL、执行中或分析中不会重复触发
- 快捷键可用性在按键时读取，输入 SQL 或状态变化无需重建编辑器 keymap

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动，无布局变化；由真实 CodeMirror 分发测试覆盖

## 验证

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [x] 相关 Vitest 2 个文件、39 项测试通过
- [x] `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- [x] 定向 oxlint 与 `git diff --check` 通过

## 关联 Issue

Close #8388