### PR TITLE
修复 PostgreSQL/GaussDB 同名 Schema 查询失败

### DIFF
--- a/crates/dbx-core/src/db/postgres.rs
+++ b/crates/dbx-core/src/db/postgres.rs
@@ -6607,7 +6607,16 @@ fn postgres_set_preserved_search_path_sql(
         configured.to_string()
     };
     let selected_schema = pg_quote_ident(schema);
-    let mut path = if baseline.first_resolved_schema.as_deref() == Some(schema) {
+    // The first resolved schema can come from "$user". Once that placeholder is
+    // removed for compatible servers, the selected schema must replace it unless
+    // the configured path also contains that schema explicitly.
+    let selected_schema_is_explicit = configured_elements
+        .iter()
+        .any(|element| !is_postgres_user_placeholder(element) && (*element == schema || *element == selected_schema));
+    let selected_schema_was_removed = drops_user_placeholder
+        && baseline.first_resolved_schema.as_deref() == Some(schema)
+        && !selected_schema_is_explicit;
+    let mut path = if baseline.first_resolved_schema.as_deref() == Some(schema) && !selected_schema_was_removed {
         configured
     } else if configured.is_empty() {
         selected_schema.clone()
@@ -9722,6 +9731,47 @@ mod tests {
             postgres_set_preserved_search_path_sql("dwd_views", PostgresSearchPathContext::Query, &bare_baseline),
             "SET search_path TO \"dwd_views\", public, pg_catalog"
         );
+    }
+
+    #[test]
+    fn postgres_search_path_replaces_matching_user_placeholder_with_selected_schema() {
+        let baseline = PostgresSearchPathBaseline {
+            configured: "\"$user\", public".to_string(),
+            first_resolved_schema: Some("dbx_test".to_string()),
+            has_explicit_pg_catalog: false,
+        };
+
+        assert_eq!(
+            postgres_set_preserved_search_path_sql("dbx_test", PostgresSearchPathContext::Query, &baseline),
+            "SET search_path TO \"dbx_test\", public, pg_catalog"
+        );
+
+        let explicit_baseline = PostgresSearchPathBaseline {
+            configured: "dbx_test, \"$user\", public".to_string(),
+            first_resolved_schema: Some("dbx_test".to_string()),
+            has_explicit_pg_catalog: false,
+        };
+        assert_eq!(
+            postgres_set_preserved_search_path_sql("dbx_test", PostgresSearchPathContext::Query, &explicit_baseline),
+            "SET search_path TO dbx_test, public, pg_catalog"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DBX_TEST_GAUSSDB_URL, DBX_TEST_GAUSSDB_SCHEMA, and DBX_TEST_GAUSSDB_TABLE"]
+    async fn gaussdb_selected_schema_matching_user_is_applied() {
+        let url = std::env::var("DBX_TEST_GAUSSDB_URL").expect("DBX_TEST_GAUSSDB_URL");
+        let schema = std::env::var("DBX_TEST_GAUSSDB_SCHEMA").expect("DBX_TEST_GAUSSDB_SCHEMA");
+        let table = std::env::var("DBX_TEST_GAUSSDB_TABLE").expect("DBX_TEST_GAUSSDB_TABLE");
+        let pool = connect(&url, Duration::from_secs(5)).await.expect("connect gaussdb");
+
+        let current_schema =
+            execute_query_with_schema(&pool, &schema, "SELECT current_schema()").await.expect("query current schema");
+        assert_eq!(current_schema.rows[0][0].as_str(), Some(schema.as_str()));
+
+        execute_query_with_schema(&pool, &schema, &format!("SELECT 1 FROM {} LIMIT 1", pg_quote_ident(&table)))
+            .await
+            .expect("query unqualified table in selected schema");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

PostgreSQL/GaussDB 连接的默认 `search_path` 常包含 `"$user", public`。当查询编辑器选择的 Schema 与登录用户名同名时，`$user` 会解析为该 Schema。

DBX 为兼容 Redshift 等不接受 `$user` 占位符的服务端，会在设置查询上下文时移除该占位符；现有逻辑随后仍依据移除前的解析结果判断“已选 Schema 已在路径首位”，导致最终路径只剩 `public, pg_catalog`，未限定表名查询因此报 `relation does not exist`。

## 修复

- 当已选 Schema 是由即将移除的 `$user` 提供时，显式将该 Schema 补回 `search_path` 首位。
- 如果配置中本来就显式包含该 Schema，不重复添加。
- 保留其他既有路径项、`pg_catalog` 顺序和 Redshift `$user` 兼容行为。
- 增加对应单元测试和可选的 GaussDB 实库回归测试。

## 验证

- DBX v0.6.9 正式版 + GaussDB：已选 `dbx_test` 时，未限定表名查询失败，限定为 `dbx_test."34"` 后成功；`current_schema()` 实际为 `public`。
- 修复后同一 GaussDB 只读验证：`current_schema()` 为 `dbx_test`，未限定表名查询成功。
- PostgreSQL 16 实库对照：未修复代码查询临时同名 Schema 中的未限定表时报 `relation does not exist`；修复代码成功，临时测试对象已清理。
- `cargo test -p dbx-core postgres_search_path_ --lib`：8 条通过。
- `cargo test -p dbx-core gaussdb_selected_schema_matching_user_is_applied --lib -- --ignored --nocapture`：实库通过。
- `cargo check -p dbx-core`：通过。
- `cargo fmt -p dbx-core -- --check`：通过。
- `git diff --check`：通过。

Caché/IRIS 使用 JDBC Agent 和 SQL 限定改写机制，不在本 PR 范围内。

Fixes #8733
