### PR TITLE
Fix：避免浏览对象标签切回后重新加载

### DIFF
--- a/apps/desktop/src/components/objects/ObjectBrowser.vue
+++ b/apps/desktop/src/components/objects/ObjectBrowser.vue
@@ -2854,14 +2854,13 @@ async function loadObjects(options?: { allowCached?: boolean; preserveExistingRo
 
   const cached = options?.allowCached ? getCachedObjectBrowserRowsForScaffold(request.scope) : undefined;
   if (cached) {
-    // Scaffold the last-known rows so returning to this tab shows them instantly
-    // instead of flashing an empty list. A fresh entry (< TTL) is authoritative on
-    // its own; a stale one is presented and then revalidated in the background.
+    // Restore the last-known rows when remounting this tab. The cached list is
+    // authoritative for navigation restores, including entries older than the
+    // freshness TTL; re-querying here makes every tab switch look like a refresh.
+    // Explicit refresh and metadata invalidation still bypass this branch.
     applyObjectBrowserRows(cached.rows);
     finishOnce();
-    if (!cached.stale) return;
-    scaffoldRefresh = true;
-    refreshingObjects.value = true;
+    return;
   } else {
     // No scaffold: first load in this scope, cache invalidated by a DDL mutation,
     // or the caller wants a true reload. If the caller explicitly asked to keep the

--- a/apps/desktop/src/components/objects/__tests__/ObjectBrowserScaffoldRefresh.spec.ts
+++ b/apps/desktop/src/components/objects/__tests__/ObjectBrowserScaffoldRefresh.spec.ts
@@ -17,25 +17,16 @@ function functionBody(name: string): string {
 }
 
 describe("ObjectBrowser scaffold refresh race", () => {
-  // Scope A hits stale cache and starts a background revalidate (refreshingObjects = true);
-  // before it settles, the user switches to scope B which hits fresh cache and early-returns.
-  // A's finally() can no longer run (the load guard's epoch moved on), so the flag must be
-  // cleared by the newest request (B) at entry — otherwise the toolbar icon spins forever.
-  it("resets the transient refresh flags at entry, before the cache decision", () => {
+  it("restores cached rows without revalidating on a tab remount", () => {
     const body = functionBody("loadObjects");
 
-    const loadingReset = body.indexOf("loadingObjects.value = false;");
-    const refreshingReset = body.indexOf("refreshingObjects.value = false;");
     const cachedBranch = body.indexOf("const cached =");
+    const cachedReturn = body.indexOf("finishOnce();\n    return;", cachedBranch);
 
-    expect(loadingReset).toBeGreaterThanOrEqual(0);
-    expect(refreshingReset).toBeGreaterThanOrEqual(0);
-    // Both resets must precede the cached fresh/stale decision so the newest request
-    // owns the spinner state even when a superseded request's finally() cannot run.
-    expect(Math.min(loadingReset, refreshingReset)).toBeLessThan(cachedBranch);
-    // And neither flag may be turned back on before the branch decides the indicator.
-    expect(body.indexOf("refreshingObjects.value = true;")).toBeGreaterThan(cachedBranch);
-    expect(body.indexOf("loadingObjects.value = true;")).toBeGreaterThan(cachedBranch);
+    expect(cachedBranch).toBeGreaterThanOrEqual(0);
+    expect(cachedReturn).toBeGreaterThan(cachedBranch);
+    expect(body.slice(cachedBranch, cachedReturn)).not.toContain("cached.stale");
+    expect(body.slice(cachedBranch, cachedReturn)).not.toContain("refreshingObjects.value = true;");
   });
 
   it("exposes a non-blocking refresh flag distinct from the blocking full-area load", () => {


### PR DESCRIPTION
## 问题

浏览对象标签在切换离开后会被卸载，切回时重新挂载。现有逻辑虽然先恢复缓存列表，但缓存超过 30 秒 freshness TTL 后仍会立即后台重新查询，因此用户会看到对象列表再次刷新。

Fixes #8737

## 修改

- 标签重新挂载且命中对象列表缓存时，直接恢复缓存内容，不再因 freshness TTL 自动重新查询。
- 用户主动点击刷新时仍绕过缓存并重新查询。
- DDL 或元数据变更触发的缓存失效行为保持不变。
- 更新回归测试，覆盖过期缓存用于标签恢复时不触发后台重查。

## 实际验证

- macOS 26 / Apple Silicon。
- 使用达梦 DM8 测试连接，在 `DBX_TEST` 与 `DBX7658_LP` 浏览对象标签间切换。
- 离开 `DBX_TEST` 超过 30 秒后切回，对象列表立即恢复，不再出现重新加载或闪烁。
- 使用 `make dev-fast` 启动免密客户端预览，已由报告者手动验收通过。

## 自动检查

- `pnpm exec vitest run apps/desktop/src/components/objects/__tests__/ObjectBrowserScaffoldRefresh.spec.ts apps/desktop/src/lib/metadata/__tests__/objectBrowserRowsCache.spec.ts`：15 项通过。
- `pnpm typecheck`：通过。
- `pnpm exec oxlint --vue-plugin ...`：通过。
- `pnpm exec oxfmt --check ...`：通过。
- `git diff --check`：通过。