### PR TITLE
fix: 修复编辑表搜索快捷键焦点

### DIFF
--- a/apps/desktop/src/components/layout/ContentArea.vue
+++ b/apps/desktop/src/components/layout/ContentArea.vue
@@ -278,7 +278,7 @@ const columnInfoError = ref<string | undefined>(undefined);
 const dataGridRef = ref<DataGridHandle>();
 const queryEditorRef = ref<InstanceType<typeof QueryEditor>>();
 const elasticsearchJsonResponsePanelRef = ref<ElasticsearchJsonResponsePanelHandle>();
-const tableStructureEditorRef = ref<{ applyChanges: () => Promise<boolean> }>();
+const tableStructureEditorRef = ref<{ applyChanges: () => Promise<boolean>; focusSearch: () => boolean }>();
 const standaloneResultToolbarRef = ref<HTMLElement | null>(null);
 const standaloneResultToolbarWidth = ref(0);
 const standaloneResultToolbarViewportWidth = ref(0);
@@ -917,6 +917,7 @@ function focusSearch(): boolean {
   if (props.activeTab.mode === "consul") return consulWorkspaceRef.value?.focusSearch() ?? false;
   if (props.activeTab.mode === "databases") return databaseBrowserRef.value?.focusSearch() ?? false;
   if (props.activeTab.mode === "objects") return objectBrowserRef.value?.focusSearch() ?? false;
+  if (props.activeTab.mode === "structure") return tableStructureEditorRef.value?.focusSearch() ?? false;
   if (props.activeTab.mode === "query") {
     // The shared result surface (resultOnly) owns the grid, not the editor;
     // route its search to the DataGrid instead of the missing QueryEditor.

--- a/apps/desktop/src/components/layout/__tests__/SqlEditorWorkspace.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/SqlEditorWorkspace.spec.ts
@@ -30,6 +30,11 @@ describe("SQL editor workspace single-group tracer bullet", () => {
     expect(contentAreaSource).toContain("resultOnly?: boolean");
   });
 
+  it("routes structure-tab search to the table editor instead of the sidebar", () => {
+    expect(contentAreaSource).toContain('if (props.activeTab.mode === "structure") return tableStructureEditorRef.value?.focusSearch() ?? false;');
+    expect(contentAreaSource).toContain("focusSearch: () => boolean");
+  });
+
   it("keeps AppTabBar as the global special-page bar while regular tabs move to groups", () => {
     const tabBarSource = readFileSync(new URL("../AppTabBar.vue", import.meta.url), "utf8");
     expect(tabBarSource).not.toContain("hideRegularTabs");

--- a/apps/desktop/src/components/structure/TableStructureEditor.vue
+++ b/apps/desktop/src/components/structure/TableStructureEditor.vue
@@ -3025,6 +3025,22 @@ function focusIndexSearch() {
   });
 }
 
+function focusSearch(): boolean {
+  if (activeTab.value === "columns") {
+    focusColumnSearch();
+    return true;
+  }
+  if (activeTab.value === "indexes") {
+    focusIndexSearch();
+    return true;
+  }
+  if (activeTab.value === "ddl") {
+    ddlSearchPanelRef.value?.openSearch();
+    return true;
+  }
+  return false;
+}
+
 function scrollToIndexSearchMatch(direction: 1 | -1 = 1) {
   const query = indexSearchText.value.trim();
   if (!query) {
@@ -3653,7 +3669,7 @@ async function applyChanges() {
   }
 }
 
-defineExpose({ applyChanges });
+defineExpose({ applyChanges, focusSearch });
 
 function addItemForActiveTab(): boolean {
   if (activeTab.value === "columns" && canAddColumn.value) {
@@ -3719,10 +3735,10 @@ function onStructureEditorKeydown(event: KeyboardEvent) {
     return;
   }
   if (isPlainModShortcut(event, "f")) {
-    event.preventDefault();
-    event.stopPropagation();
-    if (activeTab.value === "columns") focusColumnSearch();
-    else if (activeTab.value === "ddl") ddlSearchPanelRef.value?.openSearch();
+    if (focusSearch()) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
     return;
   }
   if (isPlainModShortcut(event, "s")) {

--- a/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlSearchSource.spec.ts
+++ b/apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlSearchSource.spec.ts
@@ -7,9 +7,15 @@ describe("TableStructureEditor DDL search wiring", () => {
   it("uses a CodeMirror editor and the shared search panel", () => {
     expect(source).toContain('import EditorSearchPanel from "@/components/editor/EditorSearchPanel.vue";');
     expect(source).toContain('key: "Mod-f"');
-    expect(source).toContain('else if (activeTab.value === "ddl") ddlSearchPanelRef.value?.openSearch();');
+    expect(source).toMatch(/if \(activeTab\.value === "ddl"\) \{\s*ddlSearchPanelRef\.value\?\.openSearch\(\);\s*return true;/);
     expect(source).not.toContain("ddlPreRef");
     expect(source).not.toContain("onDdlKeydown");
+  });
+
+  it("routes the global search command to the active searchable structure tab", () => {
+    expect(source).toMatch(/function focusSearch\(\): boolean \{[\s\S]*activeTab\.value === "columns"[\s\S]*focusColumnSearch\(\);[\s\S]*activeTab\.value === "indexes"[\s\S]*focusIndexSearch\(\);[\s\S]*activeTab\.value === "ddl"[\s\S]*ddlSearchPanelRef\.value\?\.openSearch\(\)/);
+    expect(source).toContain("defineExpose({ applyChanges, focusSearch });");
+    expect(source).toMatch(/if \(isPlainModShortcut\(event, "f"\)\) \{\s*if \(focusSearch\(\)\)/);
   });
 
   it("keeps the DDL editable only where an executable script makes sense", () => {


### PR DESCRIPTION
## 问题

在编辑表结构标签中按 `Ctrl+F` 时，全局搜索路由没有识别 `structure` 模式，当前结构编辑器返回未处理后，快捷键会回退到左侧连接列表搜索框。

## 修改内容

- 为表结构编辑器暴露统一的 `focusSearch()` 入口。
- 根据当前结构子页，将搜索焦点路由到字段搜索、索引搜索或 DDL 搜索。
- `ContentArea` 在 `structure` 模式下优先调用表结构编辑器搜索，不再回退到侧栏。
- 让表结构编辑器自身的 `Ctrl+F` 处理复用同一入口，并补充路由回归断言。

## 本地验证

- 免密网页版实际验证：打开 MySQL 表 `cms_dynamic_cost_review` 的“编辑表结构”标签。
- 字段页按 `Ctrl+F` 后，“搜索字段/注释”输入框获得焦点，左侧连接搜索框未获得焦点。
- 索引页按 `Ctrl+F` 后，“搜索索引”输入框获得焦点。
- `pnpm exec vitest run apps/desktop/src/components/structure/__tests__/TableStructureEditor.ddlSearchSource.spec.ts apps/desktop/src/components/layout/__tests__/SqlEditorWorkspace.spec.ts`
- `pnpm exec vue-tsc --noEmit --project apps/desktop/tsconfig.json`
- `git diff --check`

结果：2 个测试文件、16 项测试通过；TypeScript 类型检查及差异检查通过。