### PR TITLE
Fix：兼容 MongoDB 分片 Count 浮点计数

### DIFF
--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -1368,12 +1368,21 @@ pub async fn count_documents(
 }
 
 async fn estimated_document_count(client: &Client, database: &str, collection: &str) -> Result<u64, String> {
-    let result = client
-        .database(database)
-        .run_command(doc! { "count": collection, "query": {} })
-        .await
-        .map_err(|e| e.to_string())?;
-    parse_count_command_result(&result)
+    let result = client.database(database).run_command(doc! { "count": collection }).await;
+    match result {
+        Ok(result) => parse_count_command_result(&result),
+        Err(error) => parse_count_command_error(&error.kind).ok_or_else(|| error.to_string()),
+    }
+}
+
+/// Resolves a failed `count` command the way the driver's `estimated_document_count` does:
+/// NamespaceNotFound (code 26) means the collection is missing, i.e. an empty count, while any
+/// other error must propagate. Mirrors mongodb's internal `Error::is_ns_not_found`.
+fn parse_count_command_error(kind: &mongodb::error::ErrorKind) -> Option<u64> {
+    match kind {
+        mongodb::error::ErrorKind::Command(error) if error.code == 26 => Some(0),
+        _ => None,
+    }
 }
 
 fn parse_count_command_result(result: &Document) -> Result<u64, String> {
@@ -2900,6 +2909,30 @@ mod tests {
         ] {
             assert!(parse_count_command_result(&response).is_err(), "response should be rejected: {response:?}");
         }
+    }
+
+    /// `CommandError` is `#[non_exhaustive]` with a private field, so tests build it through the
+    /// driver's derived `Deserialize`.
+    fn count_command_error(code: i32, code_name: &str) -> mongodb::error::CommandError {
+        serde_json::from_str(&format!(r#"{{"code": {code}, "codeName": "{code_name}", "errmsg": "count failed"}}"#))
+            .unwrap()
+    }
+
+    #[test]
+    fn maps_mongo_namespace_not_found_count_errors_to_zero() {
+        let kind = mongodb::error::ErrorKind::Command(count_command_error(26, "NamespaceNotFound"));
+
+        assert_eq!(parse_count_command_error(&kind), Some(0));
+    }
+
+    #[test]
+    fn propagates_mongo_count_errors_other_than_namespace_not_found() {
+        for (code, code_name) in [(13, "Unauthorized"), (17405, "CommandNotFound")] {
+            let kind = mongodb::error::ErrorKind::Command(count_command_error(code, code_name));
+
+            assert_eq!(parse_count_command_error(&kind), None, "code {code} should propagate");
+        }
+        assert_eq!(parse_count_command_error(&mongodb::error::ErrorKind::Shutdown), None);
     }
 
     #[test]

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -1240,7 +1240,7 @@ async fn find_documents_with_total(
         }
         Some(count.await.map_err(|e| e.to_string()))
     } else {
-        Some(col.estimated_document_count().await.map_err(|e| e.to_string()))
+        Some(estimated_document_count(client, database, collection).await)
     };
 
     let mut find = col.find(filter_doc).skip(skip).limit(limit);
@@ -1361,10 +1361,38 @@ pub async fn count_documents(
 
     if !accurate && filter_doc.is_empty() {
         // Legacy count() permits the metadata-backed fast path; countDocuments() must scan accurately.
-        col.estimated_document_count().await.map_err(|e| e.to_string())
+        estimated_document_count(client, database, collection).await
     } else {
         col.count_documents(filter_doc).await.map_err(|e| e.to_string())
     }
+}
+
+async fn estimated_document_count(client: &Client, database: &str, collection: &str) -> Result<u64, String> {
+    let result = client
+        .database(database)
+        .run_command(doc! { "count": collection, "query": {} })
+        .await
+        .map_err(|e| e.to_string())?;
+    parse_count_command_result(&result)
+}
+
+fn parse_count_command_result(result: &Document) -> Result<u64, String> {
+    let value = result.get("n").ok_or_else(|| "MongoDB count command response is missing the 'n' field".to_string())?;
+
+    match value {
+        Bson::Int32(value) => u64::try_from(*value),
+        Bson::Int64(value) => u64::try_from(*value),
+        Bson::Double(value)
+            if value.is_finite()
+                && *value >= 0.0
+                && value.fract() == 0.0
+                && *value <= super::JS_MAX_SAFE_INTEGER as f64 =>
+        {
+            Ok(*value as u64)
+        }
+        _ => return Err(format!("MongoDB count command returned an invalid 'n' value: {value:?}")),
+    }
+    .map_err(|_| format!("MongoDB count command returned a negative 'n' value: {value:?}"))
 }
 
 /// Find MongoDB documents in a browser-friendly representation.
@@ -1399,7 +1427,7 @@ pub async fn find_documents_extended_json(
         }
         count.await.map_err(|e| e.to_string())
     } else {
-        col.estimated_document_count().await.map_err(|e| e.to_string())
+        estimated_document_count(client, database, collection).await
     };
 
     let mut find = col.find(filter_doc).skip(skip).limit(limit);
@@ -2841,6 +2869,37 @@ mod tests {
     fn mongo_find_count_success_preserves_count_semantics() {
         assert_eq!(resolve_mongo_find_total(Ok(250), true, 100, 25), (250, true));
         assert_eq!(resolve_mongo_find_total(Ok(250), false, 100, 25), (250, false));
+    }
+
+    #[test]
+    fn parses_sharded_mongo_count_returned_as_integral_double() {
+        let response = doc! {
+            "shards": { "shard01": 887_286_174.0, "shard02": 885_925_656.0 },
+            "n": 1_773_211_830.0,
+            "ok": 1.0,
+        };
+
+        assert_eq!(parse_count_command_result(&response), Ok(1_773_211_830));
+    }
+
+    #[test]
+    fn parses_integer_mongo_count_results() {
+        assert_eq!(parse_count_command_result(&doc! { "n": 42_i32 }), Ok(42));
+        assert_eq!(parse_count_command_result(&doc! { "n": 4_294_967_296_i64 }), Ok(4_294_967_296));
+    }
+
+    #[test]
+    fn rejects_invalid_mongo_count_results() {
+        for response in [
+            doc! {},
+            doc! { "n": -1_i32 },
+            doc! { "n": 1.5 },
+            doc! { "n": f64::NAN },
+            doc! { "n": (super::super::JS_MAX_SAFE_INTEGER as f64) + 1.0 },
+            doc! { "n": "10" },
+        ] {
+            assert!(parse_count_command_result(&response).is_err(), "response should be rejected: {response:?}");
+        }
     }
 
     #[test]

--- a/crates/dbx-core/tests/live_mongodb_count.rs
+++ b/crates/dbx-core/tests/live_mongodb_count.rs
@@ -1,0 +1,37 @@
+//! Live MongoDB count regressions.
+//!
+//! Run with a writable MongoDB server:
+//! ```text
+//! DBX_LIVE_MONGODB_URL='mongodb://127.0.0.1:27017' \
+//!   cargo test -p dbx-core --test live_mongodb_count -- --ignored --nocapture
+//! ```
+
+use std::time::Duration;
+
+use dbx_core::db::mongo_driver;
+
+#[tokio::test]
+#[ignore = "requires DBX_LIVE_MONGODB_URL pointing at a writable MongoDB database"]
+async fn count_supports_fast_accurate_and_browser_total_paths() {
+    let url = std::env::var("DBX_LIVE_MONGODB_URL").expect("DBX_LIVE_MONGODB_URL");
+    let client = mongo_driver::connect(&url, Duration::from_secs(10), Duration::from_secs(60)).await.unwrap();
+    let database = std::env::var("DBX_LIVE_MONGODB_DATABASE").unwrap_or_else(|_| "dbx_live_count".to_string());
+    let collection = format!("count_paths_{}", std::process::id());
+
+    mongo_driver::insert_documents(&client, &database, &collection, r#"[{"n":1},{"n":2},{"n":3}]"#).await.unwrap();
+
+    let fast_count = mongo_driver::count_documents(&client, &database, &collection, None, false).await.unwrap();
+    let accurate_count = mongo_driver::count_documents(&client, &database, &collection, None, true).await.unwrap();
+    let browser_result =
+        mongo_driver::find_documents_extended_json(&client, &database, &collection, 0, 2, None, None, None, None)
+            .await
+            .unwrap();
+
+    assert_eq!(fast_count, 3);
+    assert_eq!(accurate_count, 3);
+    assert_eq!(browser_result.total, 3);
+    assert!(!browser_result.total_is_exact);
+    assert_eq!(browser_result.documents.len(), 2);
+
+    mongo_driver::drop_collection(&client, &database, &collection).await.unwrap();
+}


### PR DESCRIPTION
## 问题

MongoDB 分片集群执行 `db.collection.count({})` 时，`mongos` 可能将响应字段 `n` 返回为 BSON Double。Rust 驱动的 `estimated_document_count()` 固定按 `u64` 反序列化，导致大计数虽然是整数值，仍报 `invalid type: floating point, expected u64`。

## 修复

- 保留 legacy `count()` 的快速统计语义，不改成可能扫描大量文档的 `countDocuments()`
- 通过原生 `count` command 获取未类型化 BSON 响应
- 兼容非负 Int32、Int64，以及安全整数范围内的有限整数 Double
- 脚本 Count 和无筛选的对象浏览分页统计复用同一解析逻辑
- 对负数、小数、NaN、超出安全整数范围和错误类型继续返回明确错误
- 增加可重复运行的 MongoDB live count 回归测试

## 验证

- `cargo fmt --check`
- CI fast features 下 `cargo clippy -p dbx-core --all-targets -- -D warnings`
- CI fast features 下 Mongo 驱动测试：110 passed
- 使用 Issue 捕获的分片响应形态验证 `n: 1773211830.0`：通过
- MongoDB 8.2 native 实测：临时集合写入 3 条数据，快速计数、精确计数、浏览分页总数均返回 3，测试后已删除集合
- MongoDB 4.0 Legacy Agent 的 `count()` / `countDocuments()` 已确认正常，本次未修改该路径

本地没有 17 亿数据的真实分片集群，因此分片场景使用用户错误中捕获的 BSON 响应结构做确定性回归；原生命令路径另在真实 MongoDB 8.2 上验证。

补充：全量默认特性测试完成 6096 项后，现有 `external_driver_preview_retry_preserves_marker_truncation` 因固定 5 秒 JDBC 超时失败；该测试与本次 MongoDB 改动无关，单独复跑结果相同。

Fixes #8674
