### PR TITLE
fix(core): pin etcd metrics client to rustls

### DIFF
--- a/crates/dbx-core/src/agent_kv.rs
+++ b/crates/dbx-core/src/agent_kv.rs
@@ -1224,7 +1224,12 @@ async fn build_etcd_metrics_client_with_identity(
     options: &EtcdMetricsConnectionOptions,
     include_identity: bool,
 ) -> Result<reqwest::Client, String> {
+    // The desktop binary pulls in reqwest's default `default-tls` feature, which unifies with
+    // this crate's `rustls-tls` and makes `Client::builder()` silently select native-tls.
+    // native-tls rejects the PEM client identity built below with `incompatible TLS identity
+    // type`, so an mTLS etcd would lose its client certificate and fail the handshake.
     let mut builder = reqwest::Client::builder()
+        .use_rustls_tls()
         .connect_timeout(ETCD_METRICS_TIMEOUT)
         .timeout(ETCD_METRICS_TIMEOUT)
         .redirect(reqwest::redirect::Policy::none());

--- a/crates/dbx-core/src/consul/client.rs
+++ b/crates/dbx-core/src/consul/client.rs
@@ -19,7 +19,12 @@ pub struct ConsulClient {
 
 impl ConsulClient {
     pub async fn new(mut config: ConsulConfig) -> Result<Self, String> {
+        // The desktop build unifies reqwest with both `default-tls` and `rustls-tls`,
+        // and `TlsBackend` defaults to native-tls there, which rejects the PEM identity
+        // below with `incompatible TLS identity type`. Pin rustls like the etcd metrics
+        // client so mTLS Consul works in every target.
         let mut builder = reqwest::Client::builder()
+            .use_rustls_tls()
             .connect_timeout(Duration::from_secs(config.connect_timeout_secs.max(1)))
             .redirect(reqwest::redirect::Policy::none());
         if config.request_timeout_secs > 0 {


### PR DESCRIPTION
## 变更说明

etcd 概览页在 **mTLS(双向 TLS)** 集群上始终显示「Prometheus 指标暂不可用」,而集群概览、成员列表、Key 数量等数据面功能一切正常。

根因是 TLS 后端被静默选错:`Identity::from_pem` 产出的是 rustls 专用的客户端证书,但这个 metrics 客户端没有钉住后端。桌面版构建中 `src-tauri` 以默认特性依赖 reqwest,`default-tls` 与 dbx-core 的 `rustls-tls` 发生特性统一;两者同时启用时 `TlsBackend::default()` 会选中 native-tls 并绕过 rustls。native-tls 随后以 `incompatible TLS identity type` 拒绝该 PEM 身份,导致客户端无法构建。

修复方式是在该 builder 上显式 `.use_rustls_tls()`,让后端与配套的 `Identity::from_pem` 保持一致。

补充两点供 review 参考:

- **与平台无关。** 拒绝逻辑位于 reqwest 自身代码(`ClientCert::Pem => Err(...)`),不在任何平台后端中,Windows / Linux 同样受影响。
- **仅影响桌面版。** `dbx-web`、`dbx-cli`、`dbx-mcp` 均以 `default-features = false` 依赖 reqwest,本就解析到 rustls,这一行对它们是空操作。

**已知取舍**:此处 rustls 由 `webpki-roots` 提供根证书,而非操作系统信任库。若服务端证书由仅存在于系统钥匙串、且未在连接中配置的企业 CA 签发,将不再通过校验。加入 `rustls-tls-native-roots` 可以补上这个缺口,但会扩大所有 dbx-core 使用方的依赖面,故未纳入本次修复。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [ ] 本 PR 涉及前端改动,已附截图/录屏(见下方)

> 无前端改动,仅 `crates/dbx-core/src/agent_kv.rs` 一处 Rust 修改(+5 行)。

## 验证

- [ ] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过(`cargo test -p dbx-core --lib agent_kv`,24 项全绿)
- [x] 真机验证:桌面版连接 mTLS etcd 集群,`/metrics` 恢复正常显示

## 关联 Issue

无