### PR TITLE
fix(rabbitmq): 修复非标准端口的 SSH 隧道复用错误

### DIFF
--- a/crates/dbx-core/src/connection.rs
+++ b/crates/dbx-core/src/connection.rs
@@ -5283,6 +5283,10 @@ fn connection_remote_endpoint(config: &ConnectionConfig) -> (String, u16) {
             .and_then(parse_jdbc_host_port)
             .unwrap_or_else(|| (config.host.clone(), config.port))
     } else if config.db_type == DatabaseType::MessageQueue {
+        #[cfg(feature = "mq-admin")]
+        if let Some(endpoint) = parse_rabbitmq_amqp_host_port(config) {
+            return endpoint;
+        }
         parse_mq_admin_host_port(config).unwrap_or_else(|| (config.host.clone(), config.port))
     } else if config.db_type == DatabaseType::Mqtt {
         parse_mqtt_broker_host_port(config).unwrap_or_else(|| (config.host.clone(), config.port))
@@ -5301,6 +5305,15 @@ fn rnacos_console_transport_id(connection_id: &str) -> String {
 
 fn rabbitmq_management_transport_id(connection_id: &str) -> String {
     format!("{connection_id}:rabbitmq-management")
+}
+
+#[cfg(feature = "mq-admin")]
+fn parse_rabbitmq_amqp_host_port(config: &ConnectionConfig) -> Option<(String, u16)> {
+    let mqc = crate::mq::config::MqAdminConfig::from_connection(config).ok()?;
+    if mqc.system_kind != crate::mq::types::MqSystemKind::RabbitMq {
+        return None;
+    }
+    crate::mq::adapters::rabbitmq::primary_amqp_endpoint(&mqc).ok()
 }
 
 fn parse_mq_admin_host_port(config: &ConnectionConfig) -> Option<(String, u16)> {
@@ -9533,6 +9546,52 @@ for line in sys.stdin:
         state.reset_connection_transport_for_config("proxied-rabbitmq", &config).await;
         assert!(state.proxy_tunnels.local_port("proxied-rabbitmq:transport:0").await.is_none());
         assert!(state.proxy_tunnels.local_port("proxied-rabbitmq:rabbitmq-management:transport:0").await.is_none());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(feature = "mq-admin")]
+    #[tokio::test]
+    async fn rabbitmq_transport_does_not_reuse_prestarted_management_tunnel_for_amqp() {
+        let (state, dir) = test_app_state().await;
+        let mut config = mysql_config(None);
+        config.id = "proxied-rabbitmq-custom-ports".to_string();
+        config.db_type = DatabaseType::MessageQueue;
+        config.host = "127.0.0.1".to_string();
+        config.port = 35672;
+        config.external_config = Some(serde_json::json!({
+            "systemKind": "rabbitmq",
+            "adminUrl": "http://127.0.0.1:35673",
+            "auth": { "kind": "none" },
+            "extra": {
+                "addresses": "127.0.0.1:35672",
+                "virtualHost": "/"
+            }
+        }));
+        config.transport_layers = vec![TransportLayerConfig::Proxy(ProxyTunnelConfig {
+            profile_id: String::new(),
+            id: "proxy".to_string(),
+            name: String::new(),
+            enabled: true,
+            proxy_type: ProxyType::Socks5,
+            host: "127.0.0.1".to_string(),
+            port: 65000,
+            username: String::new(),
+            password: String::new(),
+            test_target: None,
+        })];
+
+        assert_eq!(connection_remote_endpoint(&config), ("127.0.0.1".to_string(), 35672));
+
+        let prestarted_amqp_port =
+            state.connection_host_port("proxied-rabbitmq-custom-ports", &config).await.unwrap().1;
+        let mqc = state.mq_admin_config_for_connection("proxied-rabbitmq-custom-ports", &config).await.unwrap();
+        let amqp_override = mqc.connect_override.expect("RabbitMQ AMQP tunnel override");
+        let management_override = mqc.management_connect_override.expect("RabbitMQ Management tunnel override");
+
+        assert_eq!(amqp_override.port, prestarted_amqp_port);
+        assert_ne!(amqp_override.port, management_override.port);
+
+        state.reset_connection_transport_for_config("proxied-rabbitmq-custom-ports", &config).await;
         let _ = std::fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## 问题

RabbitMQ 同时启用 DBX 内置 SSH 隧道、非标准 AMQP 端口和显式 Management URL 时，通用连接流程会先根据 Management URL 预建主隧道。随后 RabbitMQ 专用逻辑使用相同隧道 ID 建立 AMQP 转发，错误复用了已经指向 Management HTTP 端口的本地端口，最终 AMQP 握手收到 `Exception (501) Reason: "EOF"`。

## 修改

- RabbitMQ 启用传输层时，通用主端点优先解析 `extra.addresses` 中的 AMQP 地址。
- 预建主隧道因此始终指向 AMQP 端口；Management API 继续使用现有的独立隧道。
- Pulsar、Kafka 等其他消息队列类型仍保留原有端点解析行为。
- 增加非标准 AMQP/Management 双端口的真实调用顺序回归测试。

## 验证

修复前新增回归测试稳定失败，AMQP 覆盖端口与预建 Management 隧道端口相同。修复后：

- `cargo test -p dbx-core rabbitmq --lib`：46 个测试通过
- `cargo check -p dbx-core`：通过
- `cargo clippy -p dbx-core --lib -- -D warnings`：通过
- `cargo fmt --package dbx-core -- --check`：通过
- `go test ./...`（`agents/drivers/rabbitmq`）：通过
- `git diff --check`：通过

本地通过共享传输层管理器复现了端口复用顺序并验证修复；未连接用户实际 Windows、SSH 主机与 RabbitMQ 环境进行端到端测试。

Fixes #8750