### PR TITLE
fix(ui): 修复窄宽度 SQL 编辑器更多菜单显示与点击异常

### DIFF
--- a/apps/desktop/src/components/layout/EditorToolbar.vue
+++ b/apps/desktop/src/components/layout/EditorToolbar.vue
@@ -5,7 +5,7 @@ import { Play, CirclePlay, Loader2, Square, Database, Check, Table2, AlignLeft, 
 import { supportsInsertValueHints } from "@/lib/editor/codemirrorInsertValueHints";
 import { Button } from "@/components/ui/button";
 import { SearchableSelect } from "@/components/ui/searchable-select";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import TruncatedTextTooltip from "@/components/ui/TruncatedTextTooltip.vue";
 import DatabaseIcon from "@/components/icons/DatabaseIcon.vue";
@@ -573,17 +573,20 @@ async function changeCatalog(selectedCatalog: string) {
             <MoreHorizontal class="h-3.5 w-3.5" />
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" class="w-56">
+        <DropdownMenuContent align="start" class="w-max min-w-56 max-w-[calc(100vw-1rem)]">
           <DropdownMenuItem :disabled="activeTab.isExecuting || activeTab.isExplaining || !activeTab.sql.trim()" @select="emit('compressSql')">
             <Minimize2 class="h-3.5 w-3.5" />
             {{ t("toolbar.compressSql") }}
           </DropdownMenuItem>
           <DropdownMenuItem @select="emit('toggleSqlKeywordCase')">
+            <span class="inline-flex h-4 w-4 shrink-0 items-center justify-center font-mono text-xs font-semibold" aria-hidden="true">
+              {{ keywordCaseIsLower ? "A" : "a" }}
+            </span>
             {{ keywordCaseToggleTooltip }}
           </DropdownMenuItem>
-          <DropdownMenuCheckboxItem v-if="supportsSqlSemanticDiagnosticsToggle" :model-value="sqlSemanticDiagnosticsEnabled" @select.prevent @update:model-value="toggleSqlSemanticDiagnostics()">
+          <DropdownMenuCheckboxItem v-if="supportsSqlSemanticDiagnosticsToggle" :model-value="sqlSemanticDiagnosticsEnabled" @select.prevent="toggleSqlSemanticDiagnostics">
             <SpellCheck2 class="h-3.5 w-3.5" />
-            {{ sqlSemanticDiagnosticsToggleTooltip }}
+            {{ t("settings.sqlSemanticDiagnosticsEnabled") }}
           </DropdownMenuCheckboxItem>
           <DropdownMenuItem @select="emit('openSql')">
             <FolderOpen class="h-3.5 w-3.5" />
@@ -605,9 +608,9 @@ async function changeCatalog(selectedCatalog: string) {
             <Eye class="h-3.5 w-3.5" />
             {{ t("editor.previewChanges") }}
           </DropdownMenuItem>
-          <DropdownMenuCheckboxItem v-if="supportsInsertValueHintsToggle" :model-value="insertValueHintsEnabled" @select.prevent @update:model-value="toggleInsertValueHints">
+          <DropdownMenuCheckboxItem v-if="supportsInsertValueHintsToggle" :model-value="insertValueHintsEnabled" @select.prevent="toggleInsertValueHints">
             <BetweenVerticalStart class="h-3.5 w-3.5" />
-            {{ insertValueHintsToggleTooltip }}
+            {{ t("settings.showInsertValueHints") }}
           </DropdownMenuCheckboxItem>
           <template v-if="toolbarTier >= 2">
             <DropdownMenuItem v-if="canFormatSql" :disabled="activeTab.isExecuting || activeTab.isExplaining || !activeTab.sql.trim()" @select="emit('formatSql')">
@@ -623,7 +626,7 @@ async function changeCatalog(selectedCatalog: string) {
               {{ isActiveDatabaseDefault ? t("editor.defaultDatabase") : t("editor.setDefaultDatabase") }}
             </DropdownMenuItem>
           </template>
-          <DropdownMenuCheckboxItem v-if="toolbarTier >= 3 && supportsExplainAnalyze" :model-value="props.explainMode === 'autotrace'" @select.prevent @update:model-value="emit('update:explainMode', props.explainMode === 'autotrace' ? 'explain' : 'autotrace')">
+          <DropdownMenuCheckboxItem v-if="toolbarTier >= 3 && supportsExplainAnalyze" :model-value="props.explainMode === 'autotrace'" @select.prevent="emit('update:explainMode', props.explainMode === 'autotrace' ? 'explain' : 'autotrace')">
             <span class="font-bold" style="font-size: 9px">A</span>
             {{ explainAnalyzeTooltip }}
           </DropdownMenuCheckboxItem>


### PR DESCRIPTION
## 问题

SQL 编辑器宽度被压缩后，工具栏操作会收进“更多操作”菜单。复选菜单组件未在 `EditorToolbar` 中导入，导致 SQL 语义诊断、INSERT 列名提示及更窄层级下的执行计划开关被浏览器当成未知普通元素渲染：

- 图标和文字未应用菜单布局，出现错位、换行；
- 条目没有 `menuitemcheckbox` 语义，也无法正常点击切换；
- SQL 关键字大小写操作缺少图标，和其他操作未对齐。

## 修复

- 正确导入并使用 `DropdownMenuCheckboxItem`；
- 开关项通过菜单选择事件切换，保持菜单展开并更新右侧勾选状态；
- 使用稳定、简短的开关名称，避免把“已开启（点击关闭）”拼进标签；
- 为 SQL 关键字大小写操作补充 `a/A` 图标；
- 菜单按内容自适应宽度，同时限制在当前视口内。

## 验证

- 当前主线浏览器预览中已复现修复前的异常；
- 320px、420px 窄视口下检查菜单，图标与名称均保持单行对齐；
- SQL 语义诊断、INSERT 列名提示均可点击，并可即时切换勾选状态；
- 用户已完成手动测试并确认通过；
- `pnpm typecheck`；
- `pnpm exec oxfmt --check apps/desktop/src/components/layout/EditorToolbar.vue`；
- `pnpm exec oxlint apps/desktop/src/components/layout/EditorToolbar.vue`；
- `pnpm exec vitest run apps/desktop/src/lib/__tests__/tabs/editorToolbarLayout.spec.ts`（9 项通过）；
- `git diff --check`。

Fixes #8764