### PR TITLE
fix(kafka): add common.refresh for the messages page

### DIFF
--- a/apps/desktop/src/components/mq/__tests__/KafkaMessagesPanel.spec.ts
+++ b/apps/desktop/src/components/mq/__tests__/KafkaMessagesPanel.spec.ts
@@ -106,6 +106,7 @@ describe("KafkaMessagesPanel", () => {
     const overview = panel.querySelector('[data-testid="kafka-partition-overview"]');
     expect(overview?.textContent).toContain("mqMonitoring.tableBeginOffset");
     expect(overview?.textContent).toContain("mqMonitoring.tableLogEndOffset");
+    expect(overview?.querySelector("button.btn-sm")?.textContent?.trim()).toBe("common.refresh");
     expect(overview?.textContent).toContain("10");
     expect(panel.querySelector('[data-testid="message-browser"]')).not.toBeNull();
     expect(panel.querySelector(".send-message-panel")).not.toBeNull();

--- a/apps/desktop/src/i18n/__tests__/commonRefreshKey.spec.ts
+++ b/apps/desktop/src/i18n/__tests__/commonRefreshKey.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import az from "../locales/az";
+import en from "../locales/en";
+import es from "../locales/es";
+import it_ from "../locales/it";
+import ja from "../locales/ja";
+import ko from "../locales/ko";
+import ptBR from "../locales/pt-BR";
+import tr from "../locales/tr";
+import zhCN from "../locales/zh-CN";
+import zhTW from "../locales/zh-TW";
+
+// Shared actions such as KafkaMessagesPanel and DoltVersionControl render
+// `t("common.refresh")`. When the key is missing everywhere, vue-i18n echoes
+// the key path itself (issue #8768). KafkaMessagesPanel.spec.ts mocks i18n as
+// `t: (key) => key`, so that spec cannot catch a missing-from-everywhere key.
+const locales: Array<[string, Record<string, unknown>]> = [
+  ["az", az as Record<string, unknown>],
+  ["es", es],
+  ["it", it_],
+  ["ja", ja],
+  ["ko", ko],
+  ["pt-BR", ptBR],
+  ["tr", tr],
+  ["zh-CN", zhCN],
+  ["zh-TW", zhTW],
+];
+
+function commonRefresh(locale: Record<string, unknown>): unknown {
+  const common = locale["common"];
+  if (!common || typeof common !== "object") return undefined;
+  return (common as Record<string, unknown>)["refresh"];
+}
+
+describe("common.refresh i18n key", () => {
+  it("en resolves common.refresh to text", () => {
+    const value = commonRefresh(en as Record<string, unknown>);
+    expect(value, "common.refresh missing from locales/en.ts").toBeTypeOf("string");
+    expect(value).not.toBe("");
+    expect(value).not.toBe("common.refresh");
+  });
+
+  it.each(locales)("%s resolves common.refresh to text", (_name, locale) => {
+    const value = commonRefresh(locale);
+    expect(value, `${_name} common.refresh`).toBeTypeOf("string");
+    expect(value).not.toBe("");
+    expect(value).not.toBe("common.refresh");
+  });
+
+  it("zh-CN uses a Chinese refresh label", () => {
+    expect(commonRefresh(zhCN)).toBe("刷新");
+  });
+});

--- a/apps/desktop/src/i18n/locales/az.ts
+++ b/apps/desktop/src/i18n/locales/az.ts
@@ -2377,6 +2377,7 @@ export default withEnglishFallback({
     import: "İdxal et",
     remove: "Çıxar",
     retry: "Yenidən cəhd et",
+    refresh: "Yenilə",
     more: "Daha çox",
     decrease: "Azalt",
     increase: "Artır",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -2378,6 +2378,7 @@ export default {
     import: "Import",
     remove: "Remove",
     retry: "Retry",
+    refresh: "Refresh",
     more: "More",
     decrease: "Decrease",
     increase: "Increase",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -2287,6 +2287,7 @@ export default withEnglishFallback({
     import: "Importar",
     remove: "Eliminar",
     retry: "Reintentar",
+    refresh: "Actualizar",
     more: "Más",
     decrease: "Reducir",
     increase: "Aumentar",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -2285,6 +2285,7 @@ export default withEnglishFallback({
     import: "Importa",
     remove: "Rimuovi",
     retry: "Riprova",
+    refresh: "Aggiorna",
     more: "Altro",
     decrease: "Riduci",
     increase: "Aumenta",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -2309,6 +2309,7 @@ export default withEnglishFallback({
     save: "保存",
     clear: "クリア",
     retry: "再試行",
+    refresh: "更新",
     more: "もっと見る",
     decrease: "縮小",
     increase: "拡大",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -2186,6 +2186,7 @@ export default withEnglishFallback({
     import: "가져오기",
     remove: "제거",
     retry: "다시 시도",
+    refresh: "새로고침",
     more: "더보기",
     decrease: "감소",
     increase: "증가",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -2284,6 +2284,7 @@ export default withEnglishFallback({
     save: "Salvar",
     clear: "Limpar",
     retry: "Tentar novamente",
+    refresh: "Atualizar",
     more: "Mais",
     decrease: "Diminuir",
     increase: "Aumentar",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -2355,6 +2355,7 @@ export default withEnglishFallback({
     import: "İçe Aktar",
     remove: "Kaldır",
     retry: "Yeniden dene",
+    refresh: "Yenile",
     more: "Daha fazla",
     decrease: "Azalt",
     increase: "Artır",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -2301,6 +2301,7 @@ export default withEnglishFallback({
     import: "导入",
     remove: "移除",
     retry: "重试",
+    refresh: "刷新",
     more: "更多",
     decrease: "减小",
     increase: "增大",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -2285,6 +2285,7 @@ export default withEnglishFallback({
     import: "匯入",
     remove: "移除",
     retry: "重試",
+    refresh: "重新整理",
     more: "更多",
     decrease: "縮小",
     increase: "放大",


### PR DESCRIPTION
## 变更说明

Kafka 消息页分区明细的刷新按钮使用 `t("common.refresh")`，但各语言包都没有这个 key，vue-i18n 会直接显示原始路径 `common.refresh`（#8768）。

在 `common` 中补上通用 `refresh` 词条（简体中文为「刷新」），供 Kafka 消息页和后续其它页面复用。组件本身无需改动。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端



- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过：`pnpm exec vitest run 
## 关联 Issue

Close #8768