### PR TITLE
fix(ssh): negotiate SHA-1 group exchange with legacy SSH servers

### DIFF
--- a/crates/dbx-core/src/db/ssh_tunnel.rs
+++ b/crates/dbx-core/src/db/ssh_tunnel.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
-use russh::client::{self, AuthResult, Config, Handle, KeyboardInteractiveAuthResponse};
+use russh::client::{self, AuthResult, Config, GexParams, Handle, KeyboardInteractiveAuthResponse};
 use russh::keys::agent::{client::AgentClient, AgentIdentity};
 use russh::keys::ssh_key::HashAlg;
 use russh::keys::{decode_secret_key, key::PrivateKeyWithHashAlg, PrivateKey};
@@ -177,7 +177,20 @@ impl SshClient {
 fn ssh_client_config() -> Config {
     let mut preferred = Preferred::default();
     let mut kex = preferred.kex.into_owned();
-    for algorithm in [kex::ECDH_SHA2_NISTP256, kex::ECDH_SHA2_NISTP384, kex::ECDH_SHA2_NISTP521, kex::DH_G14_SHA1] {
+    // Appended after russh's safe defaults, so a modern server still negotiates
+    // a modern algorithm. The SHA-1 group exchange and fixed-group entries are
+    // the last resort for legacy OpenSSH (< 6.7) and appliance/bastion SSH
+    // daemons whose entire offer is `diffie-hellman-group-exchange-sha1` plus
+    // `diffie-hellman-group1-sha1`; without them the handshake aborts with
+    // "No common Kex algorithm" before authentication is ever attempted.
+    for algorithm in [
+        kex::ECDH_SHA2_NISTP256,
+        kex::ECDH_SHA2_NISTP384,
+        kex::ECDH_SHA2_NISTP521,
+        kex::DH_G14_SHA1,
+        kex::DH_GEX_SHA1,
+        kex::DH_G1_SHA1,
+    ] {
         if !kex.contains(&algorithm) {
             kex.push(algorithm);
         }
@@ -193,7 +206,25 @@ fn ssh_client_config() -> Config {
     }
     preferred.mac = Cow::Owned(mac);
 
-    Config { nodelay: true, keepalive_interval: Some(Duration::from_secs(30)), preferred, ..Default::default() }
+    Config {
+        nodelay: true,
+        keepalive_interval: Some(Duration::from_secs(30)),
+        preferred,
+        gex: legacy_gex_params(),
+        ..Default::default()
+    }
+}
+
+/// Group-exchange bounds for the SHA-1 group exchange fallback above.
+///
+/// russh defaults to a 3072-bit minimum, which legacy daemons that only speak
+/// `diffie-hellman-group-exchange-sha1` cannot satisfy: they reject the request
+/// outright, so enabling the algorithm alone would still fail the handshake.
+/// 2048 bits is russh's own floor for a client config and stays within current
+/// guidance, while the preferred and maximum sizes keep russh's defaults so a
+/// capable server is still driven to the largest group it supports.
+fn legacy_gex_params() -> GexParams {
+    GexParams::for_client_config(2048, 8192, 8192).unwrap_or_default()
 }
 
 fn tofu_prompt_deadline(network_deadline: Instant, prompt_started_at: Instant) -> Option<Instant> {
@@ -2088,6 +2119,39 @@ mod tests {
 
         assert!(curve25519_index < ecdh_index);
         assert!(ecdh_index < group14_sha1_index);
+    }
+
+    #[test]
+    fn ssh_client_config_offers_sha1_group_exchange_kex_last() {
+        let config = ssh_client_config();
+        let kex = config.preferred.kex;
+        let position = |needle: russh::kex::Name| kex.iter().position(|algorithm| *algorithm == needle).unwrap();
+
+        // A server advertising only the two SHA-1 exchanges from issue #8722 has
+        // to find a common algorithm, or the handshake fails before auth.
+        let gex_sha1_index = position(russh::kex::DH_GEX_SHA1);
+        let group1_sha1_index = position(russh::kex::DH_G1_SHA1);
+
+        // Both stay behind every safe default, including the SHA-1 fallback that
+        // was already present, so a capable server never downgrades to them.
+        let group14_sha1_index = position(russh::kex::DH_G14_SHA1);
+        let gex_sha256_index = position(russh::kex::DH_GEX_SHA256);
+
+        assert!(gex_sha256_index < group14_sha1_index);
+        assert!(group14_sha1_index < gex_sha1_index);
+        assert!(gex_sha1_index < group1_sha1_index);
+    }
+
+    #[test]
+    fn ssh_client_config_lowers_group_exchange_minimum_for_legacy_servers() {
+        let config = ssh_client_config();
+
+        // russh's 3072-bit default minimum is rejected by the legacy daemons
+        // that need DH_GEX_SHA1 in the first place, which would leave the new
+        // fallback unusable.
+        assert_eq!(config.gex.min_group_size(), 2048);
+        assert_eq!(config.gex.preferred_group_size(), russh::client::GexParams::default().preferred_group_size());
+        assert_eq!(config.gex.max_group_size(), russh::client::GexParams::default().max_group_size());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Reported in #8722. Connecting through an SSH tunnel to an older server fails during the handshake:

```
SSH layer 1 failed: SSH connection failed: No common Kex algorithm
- ours:   ["mlkem768x25519-sha256", "curve25519-sha256", ..., "diffie-hellman-group14-sha1"]
- theirs: ["diffie-hellman-group-exchange-sha1", "diffie-hellman-group1-sha1"]
```

Legacy OpenSSH (< 6.7) and a number of appliance/bastion SSH daemons advertise only those two exchanges. Neither was present in the client's kex list, so the connection aborted before authentication was ever attempted. Other clients (DBeaver/PuTTY/OpenSSH with legacy options) connect to the same host.

## Change

`ssh_client_config()` in `crates/dbx-core/src/db/ssh_tunnel.rs`:

1. Append `kex::DH_GEX_SHA1` and `kex::DH_G1_SHA1` to the kex list, after russh's safe defaults **and** after the SHA-1 fallback that was already there (`DH_G14_SHA1`). Ordering is preserved, so a capable server still negotiates a modern algorithm; only a server with nothing else on offer ever reaches them. This mirrors the existing treatment of the legacy SHA-1 MAC variants right below it.

2. Lower the group-exchange minimum to 2048 bits via `Config.gex`. Enabling `DH_GEX_SHA1` alone is not sufficient: russh's default `GexParams` requests a 3072-bit minimum group, which the same legacy daemons reject, so the handshake would still fail. 2048 is russh's own floor for a client config (`GexParams::for_client_config` rejects anything lower) and remains within current guidance. The preferred and maximum sizes keep russh's defaults, so a capable server is still driven to the largest group it supports.

## Tests

Two unit tests added next to the existing `ssh_client_config_keeps_legacy_kex_after_safe_defaults`:

- `ssh_client_config_offers_sha1_group_exchange_kex_last` — asserts both new algorithms are present and ordered strictly behind every safe default, including `DH_GEX_SHA256` and `DH_G14_SHA1`, so no capable server can be downgraded onto them.
- `ssh_client_config_lowers_group_exchange_minimum_for_legacy_servers` — asserts the 2048-bit minimum, and that the preferred/maximum sizes still match russh's defaults.

`cargo fmt --check -p dbx-core` is clean. I was not able to finish a full `cargo test` run locally (the `dbx-core` lib test link step exceeds the RAM on my machine), so I am relying on CI for the test run — happy to iterate on anything it turns up.

Fixes #8722
