### PR TITLE
fix(editor): preserve undo history across data previews

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -7158,7 +7158,7 @@ function resumeQueryEditorBackgroundWork() {
   scheduleSemanticDiagnostics();
   if (view.value) schedulePreviewContextRefresh(view.value);
   restoreEditorSelection();
-  restoreEditorFocus();
+  if (props.autoFocus) restoreEditorFocus();
   restoreEditorViewport();
 }
 

--- a/apps/desktop/src/components/layout/EditorGroup.vue
+++ b/apps/desktop/src/components/layout/EditorGroup.vue
@@ -209,9 +209,11 @@ const groupExecutableSql = computed(() => {
         @clear-default-database="activeTab && toolbar.clearDefaultDatabase(activeTab.id)"
       />
       <div class="relative flex-1 min-h-0">
-        <QueryEditorSurface v-if="activeTab?.mode === 'query'" ref="activeSurfaceRef" v-bind="surfaceBindings" :auto-focus="groupId === queryStore.focusedGroupId" class="h-full" />
-        <ContentArea v-else-if="activeTab" ref="activeSurfaceRef" v-bind="surfaceBindings" class="h-full" />
-        <slot v-else name="empty">
+        <KeepAlive>
+          <QueryEditorSurface v-if="activeTab?.mode === 'query'" ref="activeSurfaceRef" v-bind="surfaceBindings" :auto-focus="groupId === queryStore.focusedGroupId" class="h-full" />
+        </KeepAlive>
+        <ContentArea v-if="activeTab && activeTab.mode !== 'query'" ref="activeSurfaceRef" v-bind="surfaceBindings" class="h-full" />
+        <slot v-if="!activeTab" name="empty">
           <div class="flex h-full items-center justify-center text-sm text-muted-foreground">
             {{ t("tabs.emptyGroup") }}
           </div>

--- a/apps/desktop/src/components/layout/__tests__/EditorGroup.mount.spec.ts
+++ b/apps/desktop/src/components/layout/__tests__/EditorGroup.mount.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { createApp, nextTick } from "vue";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
 import { createPinia, setActivePinia } from "pinia";
 import { createI18n } from "vue-i18n";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,7 +23,8 @@ vi.mock("@/components/layout/QueryEditorSurface.vue", () => ({
   default: {
     name: "QueryEditorSurfaceStub",
     props: ["activeTab", "autoFocus"],
-    template: `<div data-test="query-editor">{{ activeTab.id }}</div>`,
+    data: () => ({ draft: "" }),
+    template: `<div data-test="query-editor">{{ activeTab.id }}<input data-test="query-editor-draft" v-model="draft" /></div>`,
   },
 }));
 
@@ -103,6 +104,53 @@ describe("EditorGroup mount contract", () => {
     const editor = host.querySelector<HTMLElement>('[data-test="query-editor"]');
     expect(editor).not.toBeNull();
     expect(editor?.textContent).toBe("tab-b");
+
+    app.unmount();
+    host.remove();
+  });
+
+  it("keeps the query editor instance across data preview round trips", async () => {
+    const store = useQueryStore();
+    const queryId = store.createTab("pg-1", "app", "Query 1", "query");
+    const dataId = store.createTab("pg-1", "app", "users", "data", "public");
+    const activeTabId = ref(queryId);
+    const root = defineComponent(
+      () => () =>
+        h(EditorGroup, {
+          groupId: "group-1",
+          tabIds: [queryId, dataId],
+          activeTabId: activeTabId.value,
+          activeTab: tab(queryId),
+          activeConnection: undefined,
+          executableSql: "SELECT 1",
+          activeOutputView: "result",
+          formatSqlRequest: null,
+          compressSqlRequest: null,
+          selectedSql: "",
+          cursorPos: 0,
+          blockDangerousRedisCommands: false,
+        }),
+    );
+
+    const host = createHost();
+    const app = createApp(root);
+    app.use(pinia);
+    app.use(i18n);
+    app.mount(host);
+    await nextTick();
+
+    const draft = host.querySelector<HTMLInputElement>('[data-test="query-editor-draft"]')!;
+    draft.value = "undo history";
+    draft.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    activeTabId.value = dataId;
+    await nextTick();
+    expect(host.querySelector('[data-test="query-editor-draft"]')).toBeNull();
+
+    activeTabId.value = queryId;
+    await nextTick();
+    expect(host.querySelector<HTMLInputElement>('[data-test="query-editor-draft"]')?.value).toBe("undo history");
 
     app.unmount();
     host.remove();

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorFocus.spec.ts
@@ -51,6 +51,12 @@ describe("QueryEditor auto focus wiring", () => {
   it("restores focus when the active query tab changes", () => {
     expect(queryEditorSource).toMatch(/if \(tabId !== prevTabId\) \{[\s\S]*?activateTabDocument\(prevTabId, tabId, val\);[\s\S]*?if \(props\.autoFocus\) restoreEditorFocus\(\);/);
   });
+
+  it("does not steal focus when a non-focused editor group is reactivated", () => {
+    const start = queryEditorSource.indexOf("function resumeQueryEditorBackgroundWork()");
+    const end = queryEditorSource.indexOf("\n}", start);
+    expect(queryEditorSource.slice(start, end)).toContain("if (props.autoFocus) restoreEditorFocus();");
+  });
 });
 
 describe("QueryEditor toolbar focus", () => {


### PR DESCRIPTION
## 变更说明

- 查询标签切到数据预览后保留同一 QueryEditorSurface 实例，避免 CodeMirror undo/redo 历史被销毁
- 复用 Vue 原生 KeepAlive 和编辑器已有的 activated/deactivated 生命周期，不新增缓存或依赖
- 非焦点编辑器组重新激活时遵守 autoFocus，避免抢占当前焦点
- 新增查询页 → 数据预览 → 查询页往返的组件生命周期回归测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端交互改动，无布局变化；由组件生命周期回归测试覆盖

## 验证

- [ ] make check 通过
- [ ] make cargo-check-fast 通过
- [x] 相关 Vitest 2 个文件、12 项测试通过
- [x] pnpm typecheck 通过
- [x] 定向 oxlint 与 git diff --check 通过

## 关联 Issue

Close #8801