### PR TITLE
fix(mongodb): stop suggesting extended JSON wrapper keys as fields

### DIFF
--- a/apps/desktop/src/lib/mongo/mongoCompletion.ts
+++ b/apps/desktop/src/lib/mongo/mongoCompletion.ts
@@ -1,3 +1,4 @@
+import { mongoExtendedJsonValueType } from "@/lib/mongo/mongoDocumentValues";
 import { ACCUMULATORS, COMMON_OPERATORS, EXPRESSION_OPERATORS, PIPELINE_STAGES, PUSH_MODIFIERS, QUERY_OPERATORS, STAGE_OPTION_KEYS, UPDATE_OPERATORS, UPDATE_OPERATOR_LABELS, VALUE_SNIPPETS, mongoOperatorItemType, type MongoOperatorSpec } from "@/lib/mongo/mongoCompletionTables";
 
 /**
@@ -1015,6 +1016,9 @@ function extractActiveCollection(text: string, cursor: number): string | undefin
 
 function collectFieldTypes(value: unknown, prefix: string, out: Map<string, Set<string>>, depth: number) {
   if (depth > 4 || value == null || typeof value !== "object") return;
+  // A wrapper such as {$oid: "..."} is one BSON value. Walking into it would offer
+  // `_id.$oid`, a path that exists only in transport and matches nothing on the server.
+  if (mongoExtendedJsonValueType(value)) return;
   if (Array.isArray(value)) {
     for (const item of value.slice(0, 3)) collectFieldTypes(item, prefix, out, depth + 1);
     return;
@@ -1031,7 +1035,7 @@ function describeMongoValueType(value: unknown): string {
   if (value == null) return "null";
   if (Array.isArray(value)) return "array";
   if (value instanceof Date) return "date";
-  return typeof value === "object" ? "object" : typeof value;
+  return mongoExtendedJsonValueType(value) ?? (typeof value === "object" ? "object" : typeof value);
 }
 
 function quoteMongoFieldName(field: string, prefix: string): string {

--- a/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
+++ b/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
@@ -15,7 +15,38 @@ export const MONGO_DOCUMENT_GRID_NULL = `${MONGO_DOCUMENT_GRID_PREFIX}null`;
 const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 const MIN_BSON_INT64 = -9223372036854775808n;
 const MAX_BSON_INT64 = 9223372036854775807n;
-const MONGO_EXTENDED_JSON_VALUE_KEYS = new Set(["$binary", "$code", "$date", "$dbPointer", "$maxKey", "$minKey", "$numberDecimal", "$numberDouble", "$numberInt", "$numberLong", "$oid", "$regularExpression", "$symbol", "$timestamp", "$undefined", "$uuid"]);
+/** Extended JSON wrapper key -> the BSON scalar it stands for. */
+const MONGO_EXTENDED_JSON_VALUE_TYPES = new Map([
+  ["$binary", "binary"],
+  ["$code", "javascript"],
+  ["$date", "date"],
+  ["$dbPointer", "dbPointer"],
+  ["$maxKey", "maxKey"],
+  ["$minKey", "minKey"],
+  ["$numberDecimal", "decimal128"],
+  ["$numberDouble", "double"],
+  ["$numberInt", "int32"],
+  ["$numberLong", "int64"],
+  ["$oid", "objectId"],
+  ["$regularExpression", "regex"],
+  ["$symbol", "symbol"],
+  ["$timestamp", "timestamp"],
+  ["$undefined", "undefined"],
+  ["$uuid", "uuid"],
+]);
+const MONGO_EXTENDED_JSON_VALUE_KEYS = new Set(MONGO_EXTENDED_JSON_VALUE_TYPES.keys());
+
+/**
+ * The BSON scalar an extended JSON wrapper stands for, or undefined when the value is
+ * a plain object. `{$oid: "..."}` is how the driver ships an ObjectId over JSON; it is
+ * one value, not a subdocument with a `$oid` field.
+ */
+export function mongoExtendedJsonValueType(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 2 && keys.includes("$code") && keys.includes("$scope")) return "javascript";
+  return keys.length === 1 ? MONGO_EXTENDED_JSON_VALUE_TYPES.get(keys[0] ?? "") : undefined;
+}
 const MONGO_EXTENDED_JSON_NUMERIC_TYPES = new Map([
   ["$numberInt", "int32"],
   ["$numberLong", "int64"],

--- a/packages/app-tests/mongoCompletion.test.ts
+++ b/packages/app-tests/mongoCompletion.test.ts
@@ -466,6 +466,35 @@ test("snippet templates use placeholder syntax CodeMirror actually honours", () 
   }
 });
 
+test("treats extended JSON wrappers as scalars, not subdocuments", () => {
+  // The driver ships BSON scalars as extended JSON. Walking into them would offer
+  // `_id.$oid`, which is valid syntax that matches nothing on the server.
+  const inferred = inferMongoCompletionFields([
+    {
+      _id: { $oid: "6743e4bfa3f6f84bc3fff6c8" },
+      created_at: { $date: "2025-01-01T00:00:00Z" },
+      count: { $numberLong: "42" },
+      raw: { $binary: { base64: "AQID", subType: "00" } },
+      profile: { email: "a@example.com" },
+    },
+  ]);
+
+  for (const phantom of ["_id.$oid", "created_at.$date", "count.$numberLong", "raw.$binary"]) {
+    assert.equal(
+      inferred.some((field) => field.name === phantom),
+      false,
+      phantom,
+    );
+  }
+
+  assert.ok(inferred.find((field) => field.name === "_id" && field.type === "objectId"));
+  assert.ok(inferred.find((field) => field.name === "created_at" && field.type === "date"));
+  assert.ok(inferred.find((field) => field.name === "count" && field.type === "int64"));
+  assert.ok(inferred.find((field) => field.name === "raw" && field.type === "binary"));
+  // Genuine subdocuments are still walked.
+  assert.ok(inferred.find((field) => field.name === "profile.email" && field.type === "string"));
+});
+
 test("infers dotted MongoDB fields from sampled documents", () => {
   const inferred = inferMongoCompletionFields([
     { _id: "1", profile: { email: "a@example.com" }, tags: ["a"] },


### PR DESCRIPTION
## Problem

Autocomplete offers `_id.$oid` as a field. Picking it produces a query that is valid, runs without error, and matches nothing:

```js
db.reports.find({ "_id.$oid": "6743e4bfa3f6f84bc3fff6c8" })   // 0 documents
```

On the server `_id` is an ObjectId scalar, not a subdocument with an `$oid` key — that key exists only in the extended JSON used to ship BSON over the wire. Because the query succeeds, there is nothing to suggest the field is wrong; it reads as "the document isn't there".

The same applies to `created_at.$date`, `count.$numberLong`, `raw.$binary`, and every other wrapper.

## Cause

`collectFieldTypes` in `mongoCompletion.ts` walks into every object it meets, with no notion of extended JSON. Sampling one document yields:

```
_id                (object)
_id.$oid           (string)   <- phantom
created_at         (object)
created_at.$date   (string)   <- phantom
count.$numberLong  (string)   <- phantom
```

The phantom paths are then offered as completions, and the wrapper types are reported as `object`.

The app already knows better elsewhere: `mongoDocumentValues.ts` keeps the canonical wrapper list and the data grid uses it to type its columns correctly. Only the completion path was unaware.

## Change

Add `mongoExtendedJsonValueType` next to that existing list, mapping each wrapper key to the BSON scalar it stands for, and use it in the completion to stop at a wrapper instead of descending into it.

The previous `MONGO_EXTENDED_JSON_VALUE_KEYS` set is now derived from that map, so the wrapper keys stay in one place.

Field types improve as a side effect, since the scalar is now named rather than reported as `object`:

| field | before | after |
| --- | --- | --- |
| `_id` | `object`, plus `_id.$oid` | `objectId` |
| `created_at` | `object`, plus `created_at.$date` | `date` |
| `count` | `object`, plus `count.$numberLong` | `int64` |
| `raw` | `object`, plus `raw.$binary` | `binary` |

Genuine subdocuments and arrays are untouched: `profile.email` and `profile.tags.id` are still inferred as before.

## Testing

- `pnpm test` — 13912 passed
- `pnpm typecheck`, `oxlint`, `oxfmt` clean
- New test asserts the four phantom paths are absent, the four scalar types are correct, and nested `profile.email` still resolves
