### PR TITLE
🌐 feat(i18n): 补充多语言更新检查中的提示文案

### DIFF
--- a/apps/desktop/src/i18n/locales/az.ts
+++ b/apps/desktop/src/i18n/locales/az.ts
@@ -300,6 +300,7 @@ export default withEnglishFallback({
     retryDownload: "Endirməni yenidən sınayın",
     title: "Yeniləmələr",
     check: "Yeniləmələri yoxla",
+    checking: "Yeniləmələr yoxlanılır…",
     updateReadyTooltip: "Yeniləmə hazırdır — quraşdırmaq üçün klikləyin",
     restartRequiredTooltip: "Yeniləmə quraşdırılıb — tamamlamaq üçün yenidən başladın",
     availableTitle: "Yeniləmə mövcuddur",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -301,6 +301,7 @@ export default {
     retryDownload: "Retry Download",
     title: "Updates",
     check: "Check for updates",
+    checking: "Checking for updates…",
     updateReadyTooltip: "Update ready — click to install",
     restartRequiredTooltip: "Update installed — restart to finish",
     availableTitle: "Update available",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -303,6 +303,7 @@ export default withEnglishFallback({
     retryDownload: "Reintentar descarga",
     title: "Actualizaciones",
     check: "Buscar actualizaciones",
+    checking: "Buscando actualizaciones…",
     updateReadyTooltip: "Actualización lista, haz clic para instalar",
     restartRequiredTooltip: "Actualización instalada, reinicia para finalizar",
     availableTitle: "Actualización disponible",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -302,6 +302,7 @@ export default withEnglishFallback({
     retryDownload: "Riprova download",
     title: "Aggiornamenti",
     check: "Verifica aggiornamenti",
+    checking: "Verifica degli aggiornamenti in corso…",
     updateReadyTooltip: "Aggiornamento pronto, clicca per installare",
     restartRequiredTooltip: "Aggiornamento installato, riavvia per completare",
     availableTitle: "Aggiornamento disponibile",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -303,6 +303,7 @@ export default withEnglishFallback({
     retryDownload: "ダウンロードを再試行",
     title: "アップデート",
     check: "アップデートを確認",
+    checking: "アップデートを確認中…",
     updateReadyTooltip: "アップデートの準備ができました。クリックしてインストール",
     restartRequiredTooltip: "アップデートがインストールされました。再起動して完了してください",
     availableTitle: "アップデートがあります",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -301,6 +301,7 @@ export default withEnglishFallback({
     retryDownload: "다운로드 재시도",
     title: "업데이트",
     check: "업데이트 확인",
+    checking: "업데이트 확인 중…",
     updateReadyTooltip: "업데이트 준비 완료 — 클릭하여 설치",
     restartRequiredTooltip: "업데이트 설치 완료 — 다시 시작하여 완료하세요",
     availableTitle: "업데이트 가능",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -303,6 +303,7 @@ export default withEnglishFallback({
     retryDownload: "Tentar baixar novamente",
     title: "Atualizações",
     check: "Verificar atualizações",
+    checking: "Verificando atualizações…",
     updateReadyTooltip: "Atualização pronta, clique para instalar",
     restartRequiredTooltip: "Atualização instalada, reinicie para concluir",
     availableTitle: "Atualização disponível",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -302,6 +302,7 @@ export default withEnglishFallback({
     retryDownload: "İndirmeyi yeniden dene",
     title: "Güncellemeler",
     check: "Güncellemeleri denetle",
+    checking: "Güncellemeler denetleniyor…",
     updateReadyTooltip: "Güncelleme hazır — kurmak için tıklayın",
     restartRequiredTooltip: "Güncelleme kuruldu — bitirmek için yeniden başlatın",
     availableTitle: "Güncelleme mevcut",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -226,6 +226,7 @@ export default withEnglishFallback({
     retryDownload: "重试下载",
     title: "更新",
     check: "检查更新",
+    checking: "正在检查更新…",
     updateReadyTooltip: "更新已就绪，点击安装",
     restartRequiredTooltip: "更新已安装，重启以完成更新",
     availableTitle: "发现新版本",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -303,6 +303,7 @@ export default withEnglishFallback({
     retryDownload: "重試下載",
     title: "更新",
     check: "檢查更新",
+    checking: "正在檢查更新…",
     updateReadyTooltip: "更新已就緒，點擊安裝",
     restartRequiredTooltip: "更新已安裝，重新啟動以完成更新",
     availableTitle: "發現新版本",


### PR DESCRIPTION
- 为阿塞拜疆语、英语、西班牙语、意大利语、日语、韩语、葡萄牙语、土耳其语及中英文语言包新增 `checking` 文案
- 完善检查更新过程中的本地化状态提示

## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 -->

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

<!-- 截图区域 -->

## 验证

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 -->

- [ ] `make check` 通过
- [ ] `make cargo-check-fast` 通过
- [ ] 相关测试通过

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->

close #8804