### PR TITLE
fix(grid): persist visual table filters across restart

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -1495,9 +1495,11 @@ function loadStructuredFilterStateForScope() {
     const cacheKey = structuredFilterCacheKey.value;
     const scopeKey = structuredFilterScopeKey.value;
     structuredFilterRules.value = cloneDataGridStructuredFilterRules(cached.rules);
-    whereFilterInput.value = cached.manualWhereInput;
+    appliedStructuredWhereInput.value = cached.appliedWhereInput;
     serverColumnFilters.value = structuredClone(cached.serverColumnFilters ?? {});
-    appliedStructuredWhereInput.value = "";
+    // Restore the applied SQL before the manual input so the whereInput watcher
+    // emits the combined condition instead of a brief empty WHERE (#8831).
+    whereFilterInput.value = cached.manualWhereInput;
     void buildStructuredWhereFromRules(structuredFilterRules.value)
       .then((whereInput) => {
         if (requestId !== structuredFilterHydrationRequestId || structuredFilterCacheKey.value !== cacheKey || structuredFilterScopeKey.value !== scopeKey) return;
@@ -1520,7 +1522,6 @@ function loadStructuredFilterStateForScope() {
   appliedStructuredWhereInput.value = "";
   serverColumnFilters.value = {};
   structuredFilterRules.value = filterBuilderColumnOptions.value.length > 0 ? [defaultStructuredFilterRule()] : [];
-  persistStructuredFilterState();
   markConditionInputsApplied();
   structuredFilterHydrationReady.value = true;
 }

--- a/apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts
@@ -36,21 +36,4 @@ describe("DataGrid setup initialization order", () => {
     expect(dataGridSource).toContain("largeValueRuntime?.scheduleVisibleLargeValuePreviewHydration(delay)");
     expect(dataGridSource).toContain("largeValueRuntime?.hydrateLargeValueCell(rowId, columnIndex) ?? false");
   });
-
-  it("restores the cached applied WHERE before rewriting the manual input (#8831)", () => {
-    const hydrate = dataGridSource.indexOf("function loadStructuredFilterStateForScope()");
-    expect(hydrate).toBeGreaterThanOrEqual(0);
-    const appliedRestore = dataGridSource.indexOf("appliedStructuredWhereInput.value = cached.appliedWhereInput;", hydrate);
-    const manualRestore = dataGridSource.indexOf("whereFilterInput.value = cached.manualWhereInput;", hydrate);
-    expect(appliedRestore).toBeGreaterThan(hydrate);
-    expect(manualRestore).toBeGreaterThan(appliedRestore);
-  });
-
-  it("does not persist an empty default builder on a structured-filter cache miss (#8831)", () => {
-    const hydrate = dataGridSource.indexOf("function loadStructuredFilterStateForScope()");
-    const nextFn = dataGridSource.indexOf("function ensureStructuredFilterRule()", hydrate);
-    expect(hydrate).toBeGreaterThanOrEqual(0);
-    expect(nextFn).toBeGreaterThan(hydrate);
-    expect(dataGridSource.slice(hydrate, nextFn)).not.toContain("persistStructuredFilterState()");
-  });
 });

--- a/apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts
@@ -36,4 +36,21 @@ describe("DataGrid setup initialization order", () => {
     expect(dataGridSource).toContain("largeValueRuntime?.scheduleVisibleLargeValuePreviewHydration(delay)");
     expect(dataGridSource).toContain("largeValueRuntime?.hydrateLargeValueCell(rowId, columnIndex) ?? false");
   });
+
+  it("restores the cached applied WHERE before rewriting the manual input (#8831)", () => {
+    const hydrate = dataGridSource.indexOf("function loadStructuredFilterStateForScope()");
+    expect(hydrate).toBeGreaterThanOrEqual(0);
+    const appliedRestore = dataGridSource.indexOf("appliedStructuredWhereInput.value = cached.appliedWhereInput;", hydrate);
+    const manualRestore = dataGridSource.indexOf("whereFilterInput.value = cached.manualWhereInput;", hydrate);
+    expect(appliedRestore).toBeGreaterThan(hydrate);
+    expect(manualRestore).toBeGreaterThan(appliedRestore);
+  });
+
+  it("does not persist an empty default builder on a structured-filter cache miss (#8831)", () => {
+    const hydrate = dataGridSource.indexOf("function loadStructuredFilterStateForScope()");
+    const nextFn = dataGridSource.indexOf("function ensureStructuredFilterRule()", hydrate);
+    expect(hydrate).toBeGreaterThanOrEqual(0);
+    expect(nextFn).toBeGreaterThan(hydrate);
+    expect(dataGridSource.slice(hydrate, nextFn)).not.toContain("persistStructuredFilterState()");
+  });
 });

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridFilterBuilderPersistence.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridFilterBuilderPersistence.spec.ts
@@ -1,13 +1,14 @@
+/** @vitest-environment happy-dom */
+
 import { beforeEach, describe, expect, it } from "vitest";
-import { clearDataGridStructuredFilterStatesForTab, loadDataGridStructuredFilterState, saveDataGridStructuredFilterState } from "@/lib/dataGrid/dataGridFilterBuilderPersistence";
+import { clearDataGridStructuredFilterStates, clearDataGridStructuredFilterStatesForTab, dropDataGridStructuredFilterMemoryCache, loadDataGridStructuredFilterState, saveDataGridStructuredFilterState } from "@/lib/dataGrid/dataGridFilterBuilderPersistence";
 
 describe("data grid structured filter persistence", () => {
   const cacheKey = "issue-436-filter-view";
   const scopeKey = "mysql\0demo\0users";
 
   beforeEach(() => {
-    clearDataGridStructuredFilterStatesForTab("issue-436-filter-view");
-    clearDataGridStructuredFilterStatesForTab("lru-tab");
+    clearDataGridStructuredFilterStates();
     saveDataGridStructuredFilterState(cacheKey, {
       scopeKey,
       manualWhereInput: "tenant_id = 7",
@@ -77,5 +78,120 @@ describe("data grid structured filter persistence", () => {
 
     expect(loadDataGridStructuredFilterState("lru-tab-0", scopeKey)).toBeDefined();
     expect(loadDataGridStructuredFilterState("lru-tab-1", scopeKey)).toBeUndefined();
+  });
+
+  it("restores visual filter rules after a process restart instead of the combined WHERE (#8831)", () => {
+    saveDataGridStructuredFilterState("data-tab-orders", {
+      scopeKey,
+      manualWhereInput: "",
+      rules: [{ id: "r-id", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" }],
+      appliedWhereInput: "`id` = 1",
+      serverColumnFilters: {},
+    });
+
+    dropDataGridStructuredFilterMemoryCache();
+
+    const restored = loadDataGridStructuredFilterState("data-tab-orders", scopeKey);
+    expect(restored).toMatchObject({
+      manualWhereInput: "",
+      appliedWhereInput: "`id` = 1",
+      rules: [{ columnName: "id", mode: "equals", rawValue: "1" }],
+    });
+  });
+
+  it("keeps a closed tab's filters off disk after restart", () => {
+    saveDataGridStructuredFilterState("tab-1-run-1-0", {
+      scopeKey,
+      manualWhereInput: "id > 1",
+      rules: [],
+      appliedWhereInput: "id > 1",
+      serverColumnFilters: {},
+    });
+    clearDataGridStructuredFilterStatesForTab("tab-1");
+    dropDataGridStructuredFilterMemoryCache();
+
+    expect(loadDataGridStructuredFilterState("tab-1-run-1-0", scopeKey)).toBeUndefined();
+    expect(loadDataGridStructuredFilterState(cacheKey, scopeKey)?.manualWhereInput).toBe("tenant_id = 7");
+  });
+
+  it("does not let a scope-miss empty builder overwrite visual rules (#8831)", () => {
+    saveDataGridStructuredFilterState("data-tab-orders", {
+      scopeKey,
+      manualWhereInput: "",
+      rules: [{ id: "r-id", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" }],
+      appliedWhereInput: "`id` = 1",
+      serverColumnFilters: {},
+    });
+
+    saveDataGridStructuredFilterState("data-tab-orders", {
+      scopeKey: `${scopeKey}\0pending-columns`,
+      manualWhereInput: "`id` = 1",
+      rules: [{ id: "empty", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      appliedWhereInput: "",
+      serverColumnFilters: {},
+    });
+
+    dropDataGridStructuredFilterMemoryCache();
+
+    expect(loadDataGridStructuredFilterState("data-tab-orders", scopeKey)).toMatchObject({
+      manualWhereInput: "",
+      appliedWhereInput: "`id` = 1",
+      rules: [{ columnName: "id", mode: "equals", rawValue: "1" }],
+    });
+  });
+
+  it("still replaces visual rules when the same scope is cleared", () => {
+    saveDataGridStructuredFilterState(cacheKey, {
+      scopeKey,
+      manualWhereInput: "",
+      rules: [{ id: "empty", columnName: "", mode: "equals", rawValue: "", rawEndValue: "", conjunction: "AND" }],
+      appliedWhereInput: "",
+      serverColumnFilters: {},
+    });
+
+    dropDataGridStructuredFilterMemoryCache();
+
+    expect(loadDataGridStructuredFilterState(cacheKey, scopeKey)).toMatchObject({
+      manualWhereInput: "",
+      appliedWhereInput: "",
+      rules: [{ columnName: "" }],
+    });
+  });
+
+  it("ignores corrupt stored payloads", () => {
+    localStorage.setItem("dbx-data-grid-structured-filters", "{not json");
+    dropDataGridStructuredFilterMemoryCache();
+    expect(loadDataGridStructuredFilterState(cacheKey, scopeKey)).toBeUndefined();
+  });
+
+  it("keeps valid filter rules when a stored rule is invalid", () => {
+    localStorage.setItem(
+      "dbx-data-grid-structured-filters",
+      JSON.stringify({
+        version: 1,
+        entries: [
+          [
+            cacheKey,
+            {
+              scopeKey,
+              manualWhereInput: "",
+              appliedWhereInput: "`id` = 1",
+              rules: [
+                { id: "bad", columnName: "status", mode: "not-a-mode", rawValue: "open", rawEndValue: "", conjunction: "AND" },
+                { id: "r-id", columnName: "id", mode: "equals", rawValue: "1", rawEndValue: "", conjunction: "AND" },
+              ],
+              serverColumnFilters: { x: { condition: "bad" }, 0: { condition: "`id` = 1", keys: ["1"], labels: ["1"] } },
+            },
+          ],
+        ],
+      }),
+    );
+    dropDataGridStructuredFilterMemoryCache();
+
+    expect(loadDataGridStructuredFilterState(cacheKey, scopeKey)).toMatchObject({
+      appliedWhereInput: "`id` = 1",
+      rules: [{ id: "r-id", columnName: "id", rawValue: "1" }],
+      serverColumnFilters: { 0: { condition: "`id` = 1", keys: ["1"], labels: ["1"] } },
+    });
   });
 });

--- a/apps/desktop/src/lib/dataGrid/dataGridFilterBuilderPersistence.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridFilterBuilderPersistence.ts
@@ -19,7 +19,7 @@ export type DataGridStructuredFilterCacheState = {
 const STRUCTURED_FILTER_STATE_CACHE_MAX_ENTRIES = 128;
 const STORAGE_KEY = "dbx-data-grid-structured-filters";
 const STORAGE_VERSION = 1;
-const FILTER_MODES = new Set<DataGridContextFilterMode>([
+const FILTER_MODE_LIST = [
   "equals",
   "not-equals",
   "is-null",
@@ -38,7 +38,10 @@ const FILTER_MODES = new Set<DataGridContextFilterMode>([
   "not-in",
   "between",
   "not-between",
-]);
+] as const satisfies readonly DataGridContextFilterMode[];
+// Type-level guard: breaks compilation when DataGridContextFilterMode gains a member missing from FILTER_MODE_LIST.
+type _MissingFilterModes = Exclude<DataGridContextFilterMode, (typeof FILTER_MODE_LIST)[number]>;
+const FILTER_MODES: Set<DataGridContextFilterMode> & ([_MissingFilterModes] extends [never] ? unknown : never) = new Set<DataGridContextFilterMode>(FILTER_MODE_LIST);
 
 const structuredFilterStateCache = new Map<string, DataGridStructuredFilterCacheState>();
 let hydrated = false;

--- a/apps/desktop/src/lib/dataGrid/dataGridFilterBuilderPersistence.ts
+++ b/apps/desktop/src/lib/dataGrid/dataGridFilterBuilderPersistence.ts
@@ -1,4 +1,6 @@
 import type { DataGridStructuredFilterRule } from "@/composables/useDataGridFilterBuilder";
+import { safeLocalStorageGet, safeLocalStorageRemove, safeLocalStorageSet } from "@/lib/backend/safeStorage";
+import type { DataGridContextFilterMode } from "@/lib/dataGrid/dataGridSql";
 
 export type DataGridCachedServerColumnFilter = {
   condition: string;
@@ -15,41 +17,174 @@ export type DataGridStructuredFilterCacheState = {
 };
 
 const STRUCTURED_FILTER_STATE_CACHE_MAX_ENTRIES = 128;
+const STORAGE_KEY = "dbx-data-grid-structured-filters";
+const STORAGE_VERSION = 1;
+const FILTER_MODES = new Set<DataGridContextFilterMode>([
+  "equals",
+  "not-equals",
+  "is-null",
+  "is-not-null",
+  "is-blank",
+  "is-not-blank",
+  "like",
+  "not-like",
+  "begins-with",
+  "ends-with",
+  "less-than",
+  "less-than-or-equal",
+  "greater-than",
+  "greater-than-or-equal",
+  "in",
+  "not-in",
+  "between",
+  "not-between",
+]);
+
 const structuredFilterStateCache = new Map<string, DataGridStructuredFilterCacheState>();
+let hydrated = false;
 
 export function cloneDataGridStructuredFilterRules(rules: readonly DataGridStructuredFilterRule[]): DataGridStructuredFilterRule[] {
   return rules.map((rule) => ({ ...rule }));
 }
 
+function isFilterMode(value: unknown): value is DataGridContextFilterMode {
+  return typeof value === "string" && FILTER_MODES.has(value as DataGridContextFilterMode);
+}
+
+function sanitizeRule(value: unknown): DataGridStructuredFilterRule | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const rule = value as Partial<DataGridStructuredFilterRule>;
+  if (typeof rule.id !== "string" || typeof rule.columnName !== "string") return undefined;
+  if (!isFilterMode(rule.mode)) return undefined;
+  if (typeof rule.rawValue !== "string" || typeof rule.rawEndValue !== "string") return undefined;
+  if (rule.conjunction !== "AND" && rule.conjunction !== "OR") return undefined;
+  return {
+    id: rule.id,
+    columnName: rule.columnName,
+    mode: rule.mode,
+    rawValue: rule.rawValue,
+    rawEndValue: rule.rawEndValue,
+    conjunction: rule.conjunction,
+    ...(rule.disabled === true ? { disabled: true } : {}),
+  };
+}
+
+function sanitizeServerColumnFilter(value: unknown): DataGridCachedServerColumnFilter | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const filter = value as Partial<DataGridCachedServerColumnFilter>;
+  if (typeof filter.condition !== "string" || !Array.isArray(filter.keys) || !Array.isArray(filter.labels)) return undefined;
+  const keys = filter.keys.filter((key): key is string => typeof key === "string");
+  const labels = filter.labels.filter((label): label is string => typeof label === "string");
+  if (keys.length !== filter.keys.length || labels.length !== filter.labels.length) return undefined;
+  return { condition: filter.condition, keys, labels };
+}
+
+function hasNamedFilterRules(state: Pick<DataGridStructuredFilterCacheState, "rules">): boolean {
+  return state.rules.some((rule) => rule.columnName);
+}
+
+function sanitizeState(value: unknown): DataGridStructuredFilterCacheState | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const state = value as Partial<DataGridStructuredFilterCacheState>;
+  if (typeof state.scopeKey !== "string" || typeof state.manualWhereInput !== "string" || typeof state.appliedWhereInput !== "string") return undefined;
+  if (!Array.isArray(state.rules)) return undefined;
+  const rules = state.rules.map(sanitizeRule).filter((rule): rule is DataGridStructuredFilterRule => !!rule);
+  const serverColumnFilters: Record<number, DataGridCachedServerColumnFilter> = {};
+  if (state.serverColumnFilters && typeof state.serverColumnFilters === "object" && !Array.isArray(state.serverColumnFilters)) {
+    for (const [key, filter] of Object.entries(state.serverColumnFilters)) {
+      if (!/^\d+$/.test(key)) continue;
+      const sanitized = sanitizeServerColumnFilter(filter);
+      if (sanitized) serverColumnFilters[Number(key)] = sanitized;
+    }
+  }
+  return {
+    scopeKey: state.scopeKey,
+    manualWhereInput: state.manualWhereInput,
+    rules,
+    appliedWhereInput: state.appliedWhereInput,
+    serverColumnFilters,
+  };
+}
+
+function cloneState(state: DataGridStructuredFilterCacheState): DataGridStructuredFilterCacheState {
+  return {
+    ...state,
+    rules: cloneDataGridStructuredFilterRules(state.rules),
+    serverColumnFilters: structuredClone(state.serverColumnFilters),
+  };
+}
+
+function persistToStorage() {
+  const entries = [...structuredFilterStateCache.entries()];
+  if (entries.length === 0) {
+    safeLocalStorageRemove(STORAGE_KEY);
+    return;
+  }
+  safeLocalStorageSet(STORAGE_KEY, JSON.stringify({ version: STORAGE_VERSION, entries }));
+}
+
+function ensureHydrated() {
+  if (hydrated) return;
+  hydrated = true;
+  const raw = safeLocalStorageGet(STORAGE_KEY);
+  if (!raw) return;
+  try {
+    const parsed = JSON.parse(raw) as { version?: unknown; entries?: unknown };
+    if (parsed.version !== STORAGE_VERSION || !Array.isArray(parsed.entries)) return;
+    for (const entry of parsed.entries) {
+      if (!Array.isArray(entry) || entry.length !== 2 || typeof entry[0] !== "string") continue;
+      const state = sanitizeState(entry[1]);
+      if (!state) continue;
+      structuredFilterStateCache.set(entry[0], state);
+      if (structuredFilterStateCache.size >= STRUCTURED_FILTER_STATE_CACHE_MAX_ENTRIES) break;
+    }
+  } catch {
+    structuredFilterStateCache.clear();
+  }
+}
+
 export function loadDataGridStructuredFilterState(cacheKey: string, scopeKey: string): DataGridStructuredFilterCacheState | undefined {
+  ensureHydrated();
   const cached = structuredFilterStateCache.get(cacheKey);
   if (!cached || cached.scopeKey !== scopeKey) return undefined;
   structuredFilterStateCache.delete(cacheKey);
   structuredFilterStateCache.set(cacheKey, cached);
-  return {
-    ...cached,
-    rules: cloneDataGridStructuredFilterRules(cached.rules),
-    serverColumnFilters: structuredClone(cached.serverColumnFilters),
-  };
+  return cloneState(cached);
 }
 
 export function saveDataGridStructuredFilterState(cacheKey: string, state: DataGridStructuredFilterCacheState) {
+  ensureHydrated();
+  const existing = structuredFilterStateCache.get(cacheKey);
+  // A scope miss hydrates the empty default builder while initialWhereInput still
+  // holds the combined SQL. Do not let that write-through erase visual rules (#8831).
+  if (existing && existing.scopeKey !== state.scopeKey && hasNamedFilterRules(existing) && !hasNamedFilterRules(state)) return;
   structuredFilterStateCache.delete(cacheKey);
-  structuredFilterStateCache.set(cacheKey, {
-    ...state,
-    rules: cloneDataGridStructuredFilterRules(state.rules),
-    serverColumnFilters: structuredClone(state.serverColumnFilters),
-  });
+  structuredFilterStateCache.set(cacheKey, cloneState(state));
   while (structuredFilterStateCache.size > STRUCTURED_FILTER_STATE_CACHE_MAX_ENTRIES) {
     const oldest = structuredFilterStateCache.keys().next().value;
     if (oldest === undefined) break;
     structuredFilterStateCache.delete(oldest);
   }
+  persistToStorage();
 }
 
 export function clearDataGridStructuredFilterStatesForTab(tabId: string) {
+  ensureHydrated();
   structuredFilterStateCache.delete(tabId);
   for (const cacheKey of structuredFilterStateCache.keys()) {
     if (cacheKey.startsWith(`${tabId}-`)) structuredFilterStateCache.delete(cacheKey);
   }
+  persistToStorage();
+}
+
+export function clearDataGridStructuredFilterStates() {
+  structuredFilterStateCache.clear();
+  hydrated = true;
+  persistToStorage();
+}
+
+/** Drop the in-memory cache without touching disk, as if the process restarted. */
+export function dropDataGridStructuredFilterMemoryCache() {
+  structuredFilterStateCache.clear();
+  hydrated = false;
 }


### PR DESCRIPTION
## 变更说明

修复数据表可视化筛选在关闭并重新打开 DBX 后回显成原始 WHERE SQL 的问题。

应用「id 等于 1」这类筛选器规则后，合并后的 `WHERE` 会随标签页落盘，但规则本身原先只存在内存里。重启后 WHERE 栏被填成 `` `id` = 1 ``，筛选器角标和规则丢失。

这次把结构化筛选 cache 写入 `localStorage`，重启后仍还原规则和空的手工 WHERE。scope 对不上时的空默认 builder 不会覆盖已有可视化规则；非法规则只丢弃坏的条目。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方）

重启前（可视化筛选器，预期）：

<img width="1312" height="360" alt="expected visual filter" src="https://github.com/user-attachments/assets/e8d10393-8ab5-4089-acf4-1bf9e896e232" />

重启后（修复前错误回显）：

<img width="942" height="184" alt="bug combined WHERE echo" src="https://github.com/user-attachments/assets/9c9a88c4-c687-4184-8baa-3fd3f39e1274" />

修复后重启应回到第一张图：WHERE 栏为空占位、角标为 1、弹出规则仍是「id 等于 1」。

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

相关测试：

- `apps/desktop/src/lib/__tests__/dataGrid/dataGridFilterBuilderPersistence.spec.ts`
- `apps/desktop/src/components/grid/__tests__/DataGridInitializationOrder.spec.ts`
- `packages/app-tests/dataGridSearchStateRestore.test.ts`

手动回归：打开表 → 筛选器设 `id 等于 1` 并应用 → 关闭再打开 DBX → WHERE 栏为空占位、角标为 1、弹出规则仍是 `id 等于 1`，数据仍只显示 id=1。

## 关联 Issue

Close #8831