### PR TITLE
fix(ai): surface terminal stream errors

### DIFF
--- a/apps/desktop/src/lib/__tests__/ai/aiContext.spec.ts
+++ b/apps/desktop/src/lib/__tests__/ai/aiContext.spec.ts
@@ -209,3 +209,36 @@ describe("AI schema selector visibility", () => {
     expect(resolveAiDatabaseTarget(queryTab("app", "public"), postgres)).toEqual({ database: "app", schema: "public" });
   });
 });
+
+describe("agent stream terminal errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.listTables.mockResolvedValue([]);
+  });
+
+  it("rejects when the backend reports a terminal error event", async () => {
+    const onEvent = vi.fn();
+    apiMock.aiAgentStream.mockImplementation(async (...args: unknown[]) => {
+      const emit = args[6] as (event: { type: "error"; message: string }) => void;
+      emit({ type: "error", message: "model request failed" });
+      return "done";
+    });
+    const context = await buildAiContext(queryTab("main"), sqliteConnection());
+
+    await expect(
+      runAgentStream(
+        {
+          config: aiConfig(),
+          action: "general",
+          mode: "agent",
+          instruction: "inspect users",
+          context,
+        },
+        [],
+        onEvent,
+        "session-error",
+      ),
+    ).rejects.toThrow("model request failed");
+    expect(onEvent).toHaveBeenCalledWith({ type: "error", message: "model request failed" });
+  });
+});

--- a/apps/desktop/src/lib/ai/ai.ts
+++ b/apps/desktop/src/lib/ai/ai.ts
@@ -220,8 +220,9 @@ export async function runAiStream(input: AiRequestInput, history: api.AiMessage[
 export async function runAgentStream(input: AiRequestInput, history: api.AiMessage[] | undefined, onEvent: (event: AgentEvent) => void, sessionId?: string, custom?: CustomPromptContext): Promise<string> {
   const { messages, systemPrompt, taskContract, maxTokens } = buildAgentRequest(input, history, custom);
   const sid = sessionId || uuid();
+  let terminalError: string | undefined;
 
-  return api.aiAgentStream(
+  const result = await api.aiAgentStream(
     sid,
     {
       config: input.config,
@@ -234,7 +235,10 @@ export async function runAgentStream(input: AiRequestInput, history: api.AiMessa
     input.context.database,
     input.context.schema,
     input.context.databaseType,
-    onEvent,
+    (event) => {
+      if (event.type === "error") terminalError ??= event.message;
+      onEvent(event);
+    },
     input.mode || "ask",
     input.allowWriteSql || false,
     input.confirmedWriteSql,
@@ -242,6 +246,8 @@ export async function runAgentStream(input: AiRequestInput, history: api.AiMessa
     input.confirmedDatabase,
     input.confirmedSchema,
   );
+  if (terminalError !== undefined) throw new Error(terminalError);
+  return result;
 }
 
 export function buildUserPrompt(action: AiAction, context: AiContext, instruction: string, isZh: boolean): string {


### PR DESCRIPTION
## 变更说明

- 将 Agent 流中的终态 error 事件转换为 Promise rejection
- 错误事件仍照常转发给生成状态和步骤链
- 复用 AiAssistant 现有失败消息与后端错误翻译，不新增 UI 状态或文案
- 对齐桌面 Tauri 与 Web SSE 适配器的错误语义

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 涉及 AI 错误展示交互，无布局变化；由流终态契约测试覆盖

## 验证

- [ ] make check 通过
- [ ] make cargo-check-fast 通过
- [x] AI 相关 Vitest 19 个文件、280 项测试通过
- [x] pnpm typecheck 通过
- [x] 定向 oxlint 与 git diff --check 通过

## 关联 Issue

Close #8829