### PR TITLE
fix(mcp): allow PL/SQL blocks under selected database scope

### DIFF
--- a/crates/dbx-core/src/production_safety.rs
+++ b/crates/dbx-core/src/production_safety.rs
@@ -26,7 +26,7 @@ static LEADING_TARGET_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 static DDL_OBJECT_TARGET_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(
-        r"(?is)\b(?:CREATE|ALTER|DROP)\s+(?:OR\s+REPLACE\s+)?(?:TABLE|VIEW|MATERIALIZED\s+VIEW|INDEX|SEQUENCE|FUNCTION|PROCEDURE|ROUTINE|TRIGGER|EVENT|TYPE|SYNONYM)\s+(?:IF\s+(?:NOT\s+)?EXISTS\s+)?(?:ONLY\s+)?({TARGET_NAME_PATTERN})"
+        r"(?is)\b(?:CREATE|ALTER|DROP)\s+(?:OR\s+REPLACE\s+)?(?:TABLE|VIEW|MATERIALIZED\s+VIEW|INDEX|SEQUENCE|FUNCTION|PROCEDURE|ROUTINE|TRIGGER|EVENT|TYPE|SYNONYM|PACKAGE(?:\s+BODY)?)\s+(?:IF\s+(?:NOT\s+)?EXISTS\s+)?(?:ONLY\s+)?({TARGET_NAME_PATTERN})"
     ))
     .expect("valid DDL object target regex")
 });
@@ -564,7 +564,7 @@ fn first_keyword(statement: &str) -> Option<String> {
 }
 
 fn is_transaction_keyword(keyword: &str) -> bool {
-    matches!(keyword, "begin" | "start" | "commit" | "rollback" | "abort" | "savepoint" | "release")
+    matches!(keyword, "begin" | "start" | "commit" | "rollback" | "abort" | "savepoint" | "release" | "end" | "declare")
 }
 
 fn sql_target_safety_text(sql: &str) -> SqlTargetSafetyText {
@@ -923,6 +923,36 @@ mod tests {
             &allowed,
         ));
         assert!(!sql_references_disallowed_database("SELECT * FROM dbo.users", &sqlserver, "reporting", &allowed,));
+    }
+
+    #[test]
+    fn plsql_block_terminators_do_not_trip_mcp_database_scope() {
+        // PL/SQL 按分号切分后会产生 "end"/"end loop"/"declare ..." 这类无对象目标的
+        // 碎片；它们不是事务语句但同样不应被误判为无法解析目标的写语句，否则任何
+        // 含 "; end;" 的匿名块、存储过程、包都会被 MCP 库范围整体拒绝。
+        let allowed = vec!["mesdev".to_string()];
+        let oracle = DatabaseType::Oracle;
+        for sql in [
+            "begin null; end;",
+            "BEGIN NULL; END;",
+            "begin\n  insert into reporting_rows values (1);\nend;",
+            "declare\n  v_count number;\nbegin\n  null;\nend;",
+            "create or replace procedure zap as begin null; end;",
+            "create or replace package body zap as procedure go is begin null; end; end;",
+        ] {
+            assert!(
+                !sql_references_disallowed_database(sql, &oracle, "mesdev", &allowed),
+                "PL/SQL must not be rejected by database scope: {sql}"
+            );
+        }
+        // 白名单只豁免歧义启发式；限定名引用的收集不受影响，跨库写入仍然拦截
+        //（Oracle 属 schema-first 方言，两段式名字首段不计为 database，用 MySQL 验证）。
+        assert!(sql_references_disallowed_database(
+            "begin delete from production.audit_log; end;",
+            &DatabaseType::Mysql,
+            "reporting",
+            &["reporting".to_string()],
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

修复数据库范围为「仅指定数据库」时所有 PL/SQL（匿名块、存储过程、包）被 `DATABASE_OUT_OF_SCOPE` 误拦的问题，与执行权限无关。

`sql_references_disallowed_database` 按分号切分 SQL 后逐段提取目标库，两处缺陷叠加导致误拦：

1. PL/SQL 尾部切出的 `end`、`end loop`、`declare ...` 等片段被 `is_write_sql` 判定为写语句，却不在 `is_transaction_keyword` 白名单里（`begin` 在、`end` 不在），落入 `is_ambiguous_production_target_statement` 的"写语句但解析不到目标"分支，整批被标记 `uncertain`（fail-closed 直接判越界）；
2. `DDL_OBJECT_TARGET_RE` 的对象类型清单缺少 `PACKAGE`，`CREATE [OR REPLACE] PACKAGE [BODY]` 解析不到目标，同样落入 uncertain 路径。

修复：`is_transaction_keyword` 白名单增加 `end` / `declare`；DDL 正则补 `PACKAGE (BODY)`。执行拆分器自 v0.5.62（#3656）起已把 Oracle PL/SQL 作为完整单元，本 PR 使引用检查器不再按朴素分号切分产生碎片误判。

**安全边界不变**：白名单只豁免歧义启发式，限定名引用收集与跨库拦截完全保留（回归测试含反向用例：MySQL 下 `begin delete from production.audit_log; end;` 仍被拒）；`USE` 拦截、请求级活动库门控、生产库保护（活动库标记主检查）均不受影响；PL/SQL 仍属高风险分级，仅「完全访问」放行。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

- [x] 本 PR 不涉及前端改动

## 验证

- [x] `make check` 通过
- [x] `make cargo-check-fast` 通过
- [x] 相关测试通过

已执行：

- `cargo test -p dbx-core --lib production_safety`：10/10 通过（含新增回归 `plsql_block_terminators_do_not_trip_mcp_database_scope`：匿名块 / DECLARE 块 / 存储过程 / 包+包体不再被拒 + 跨库引用反向用例；共享语料 `production-safety-corpus.json` 31 例全数通过，未改动）
- `cargo test -p dbx-mcp`：除 2 个本机既有的 pool 替换用例外全部通过（已验证与本次改动无关）
- `cargo build --release -p dbx-mcp` 并实测替换本机 `@dbx-app/mcp-server` 0.4.85 二进制：Oracle 12c + 范围=仅指定（库级完全访问）下，`begin null; end;`、CREATE PROCEDURE、CREATE PACKAGE spec / body（含块内 DML）全部通过且对象 VALID；故意的列名错误返回 Oracle 自身 ORA-00904，证明完整 PL/SQL 原样到达数据库

## 关联 Issue

Close #8842（PL/SQL 在仅指定数据库范围下被 DATABASE_OUT_OF_SCOPE 误拦）

Related #3656（MCP PL/SQL 拆分能力，已修——执行拆分器；本案是引用检查器）、Related #1445（桌面端 PL/SQL 分号拆分，已修）
