### PR TITLE
perf(editor): skip unrelated schema lookup for cross-database completion

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -5218,7 +5218,10 @@ async function performAsyncCompletionWithResult(epoch: number, completionContext
   let databaseNames = localCompletionDatabaseNames(completionContext);
   let currentDatabaseSchemaNames = localCompletionSchemasForDatabaseDisambiguation(completionContext, databaseNames, scope);
   const mayCompleteDatabaseSchema = mayCompleteDatabaseSchemaQualifier(completionContext);
-  if (!localOnlyMetadata && supportsDatabaseNameCompletion(props.databaseType) && completionContext.suggestTables && !completionContext.insertTable && (!completionContext.qualifier || mayCompleteDatabaseSchema)) {
+  const qualifierParts = completionContext.qualifierParts?.filter(Boolean) ?? completionContext.qualifier?.split(".").filter(Boolean) ?? [];
+  const sqlDatabaseQualifier = supportsDatabaseSchemaQualifierCompletion() && qualifierParts.length >= 2 ? qualifierParts[qualifierParts.length - 2] : undefined;
+  const hasDifferentDatabaseQualifier = !!sqlDatabaseQualifier && sqlDatabaseQualifier.toLowerCase() !== scope.database.toLowerCase();
+  if (!localOnlyMetadata && supportsDatabaseNameCompletion(props.databaseType) && completionContext.suggestTables && !completionContext.insertTable && !hasDifferentDatabaseQualifier && (!completionContext.qualifier || mayCompleteDatabaseSchema)) {
     const [databasesResult, schemasResult] = await Promise.allSettled([connectionStore.listCompletionDatabases(props.connectionId!), mayCompleteDatabaseSchema ? connectionStore.listCompletionSchemas(props.connectionId!, scope.database) : Promise.resolve(currentDatabaseSchemaNames)]);
     databaseNames = databasesResult.status === "fulfilled" ? databasesResult.value : [];
     if (schemasResult.status === "fulfilled") currentDatabaseSchemaNames = mergeSqlCompletionQualifierNames(scope.schema ? [scope.schema] : [], schemasResult.value);


### PR DESCRIPTION
## 变更说明

<!-- 简要描述这个 PR 做了什么 -->

## 变更类型

- [ ] 新功能
- [ ] Bug 修复
- [x] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

   ## Problem                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                             
   When SQL completion targets a database different from the database currently selected in the editor, completion may wait for metadata from the selected database before loading metadata for the SQL target database.                                     
                                                                                                                                                                                                                                                             
   For example, when the selected database is `db_a` and the SQL references `db_b.orders`, the editor may first wait for database and schema metadata associated with `db_a`. This adds unnecessary latency to completion for the explicitly qualified       
 target in `db_b`.                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                             
   ## Solution                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                             
   Detect an explicit database qualifier in the SQL completion context.                                                                                                                                                                                      
                                                                                                                                                                                                                                                             
   When the qualified database differs from the currently selected database:                                                                                                                                                                                 
                                                                                                                                                                                                                                                             
   - Skip the current database schema disambiguation request in the main completion path.                                                                                                                                                                    
   - Continue directly with metadata lookup for the SQL target database.                                                                                                                                                                                     
   - Preserve the existing behavior when the SQL qualifier refers to the currently selected database.                                                                                                                                                        
                                                                                                                                                                                                                                                             
   Examples:                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                             
   ```sql                                                                                                                                                                                                                                                    
   -- Selected database: db_a                                                                                                                                                                                                                                
   -- Keeps the existing completion path                                                                                                                                                                                                                     
   SELECT * FROM db_a.orders;                                                                                                                                                                                                                                
 ```                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                             
 ```sql                                                                                                                                                                                                                                                      
   -- Selected database: db_a                                                                                                                                                                                                                                
   -- Skips unrelated db_a schema lookup                                                                                                                                                                                                                     
   SELECT * FROM db_b.orders;                                                                                                                                                                                                                                
 ```                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                             
 Scope                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                             
 This change only affects SQL completion metadata loading. It does not change SQL execution behavior, database selection, or metadata cache isolation.                                                                                                       
                                                                                                                                                                                                                                                             
 Validation                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                             
 - Verified the branch is based on the latest fork main.                                                                                                                                                                                                     
 - Verified the PR contains one commit and one changed file.                                                                                                                                                                                                 
 - Ran git diff --check.                                                                                                                                                                                                                                     
 - Confirmed GitHub reports that the branches can be automatically merged.                                                                                                                                                                                   
 ```                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                             
   PR 页面当前状态显示 **3 / 15 checks OK**，其余检查仍在运行或等待中。 

## 关联 Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` -->
