### PR TITLE
fix(kv): hide internal Agent error data in KV and etcd browser messages

### DIFF
--- a/apps/desktop/src/components/etcd/EtcdKeyBrowser.vue
+++ b/apps/desktop/src/components/etcd/EtcdKeyBrowser.vue
@@ -14,6 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useToast } from "@/composables/useToast";
 import { useTabUiState } from "@/lib/tabs/tabUiState";
 import * as api from "@/lib/backend/api";
+import { formatError } from "@/lib/backend/errorUtils";
 import { isTauriRuntime } from "@/lib/backend/tauriRuntime";
 import { isKeyInKvExportScope, kvExportFilenameStem, kvValueByteIdentity, type KvExportScopeKind, type KvExportScopeRequest } from "@/lib/kv/kvExportScope";
 import { detectKvValueFormat } from "@/lib/kv/kvValueFormat";
@@ -596,7 +597,7 @@ async function exportTreeSelection(format: EtcdExportFormat) {
     const exported = await downloadExport(file);
     if (exported) toast(t("etcd.exported", { count: entries.length }), 2500);
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 4000);
+    toast(formatError(error), 4000);
   }
 }
 
@@ -623,7 +624,7 @@ async function deleteSelectedTreeKeys() {
     toast(t("etcd.batchDeleteSuccess", { count: deleted }), 3000);
   } catch (error) {
     failed = true;
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatError(error);
     toast(t("etcd.batchDeletePartial", { count: deleted, error: message }), 5000);
   } finally {
     if (failed) browserRef.value?.clearMultiSelection();
@@ -711,7 +712,7 @@ async function exportAll(format: EtcdExportFormat) {
     const exported = await downloadExport(file);
     if (exported) toast(t("etcd.exported", { count: scan.entries.length }), 2500);
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 4000);
+    toast(formatError(error), 4000);
   }
 }
 
@@ -744,7 +745,7 @@ async function exportEtcdNodeScope(connectionId: string, request: KvExportScopeR
     const exported = await downloadExport(file);
     if (exported) toast(t("etcd.exported", { count: entries.length }), 2500);
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 4000);
+    toast(formatError(error), 4000);
   }
 }
 
@@ -776,7 +777,7 @@ async function onImportFile(event: Event) {
     transferOpen.value = true;
     await previewTransfer();
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 4000);
+    toast(formatError(error), 4000);
   }
 }
 
@@ -825,7 +826,7 @@ async function loadSyncPreview() {
     transferBundle.value = bundleFromSummaries(scan.entries, prefix, scan.revision);
     await previewTransfer();
   } catch (error) {
-    transferError.value = error instanceof Error ? error.message : String(error);
+    transferError.value = formatError(error);
   } finally {
     transferLoading.value = false;
     transferLoadingDetail.value = "";
@@ -870,7 +871,7 @@ async function previewTransfer() {
     if (transferMode.value === "sync") syncConfigurationExpanded.value = false;
   } catch (error) {
     if (generation !== transferPreviewGeneration) return;
-    transferError.value = error instanceof Error ? error.message : String(error);
+    transferError.value = formatError(error);
     transferPreviewLoaded.value = false;
   } finally {
     if (generation === transferPreviewGeneration) {
@@ -915,7 +916,7 @@ async function applyTransfer() {
     transferOpen.value = false;
     if (targetId === props.connectionId) browserRef.value?.refresh();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatError(error);
     // Rebuild the preview so an ambiguous network failure or a successful
     // prefix of the batch is reflected before the user retries.
     let previewError = "";
@@ -1032,7 +1033,7 @@ async function runSearch() {
       return { id: `${identity}:${summary.modRevision || ""}`, displayKey: shown, keyIdentity: identity, summary: { ...summary, key: shown, keyBytes: bytes, keyIdentity: identity }, matchesKey, matchesValue, selected: true };
     });
   } catch (error) {
-    searchError.value = error instanceof Error ? error.message : String(error);
+    searchError.value = formatError(error);
   } finally {
     searchRunning.value = false;
   }
@@ -1063,7 +1064,7 @@ async function openOperations(nextMode: Extract<WorkbenchMode, "maintenance" | "
   try {
     operationsStatus.value = await api.etcdStatus(props.connectionId);
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 5000);
+    toast(formatError(error), 5000);
   } finally {
     operationsLoading.value = false;
   }
@@ -1083,7 +1084,7 @@ async function refreshLeaseOptions() {
   try {
     leaseOptions.value = (await api.etcdLeaseList(props.connectionId)).leases;
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 4000);
+    toast(formatError(error), 4000);
   }
 }
 
@@ -1099,7 +1100,7 @@ async function exportSearchResults(format: EtcdExportFormat) {
     const exported = await downloadExport(file);
     if (exported) toast(t("etcd.exported", { count: selected.length }), 2500);
   } catch (error) {
-    toast(error instanceof Error ? error.message : String(error), 4000);
+    toast(formatError(error), 4000);
   }
 }
 

--- a/apps/desktop/src/components/kv/KvKeyBrowser.vue
+++ b/apps/desktop/src/components/kv/KvKeyBrowser.vue
@@ -18,6 +18,7 @@ import CustomContextMenu, { type ContextMenuItem } from "@/components/ui/CustomC
 import NacosConfigDiffDialog from "@/components/nacos/NacosConfigDiffDialog.vue";
 import KvValueEditor from "@/components/kv/KvValueEditor.vue";
 import type { KvCreateMode, KvDeleteOptions, KvGetOptions, KvGetResponse, KvHistoryEvent, KvHistoryResponse, KvInt64, KvKeySummary, KvListPrefixOptions, KvPutOptions, KvPutResponse, KvValue } from "@/lib/backend/api";
+import { formatError } from "@/lib/backend/errorUtils";
 import type { KvExportScopeRequest } from "@/lib/kv/kvExportScope";
 import { buildKvKeyTree, flattenVisibleKvKeyTree, kvKeyTreeNodePath, preserveKvExpandedGroupIds, type KvKeyTreeNode } from "@/lib/kv/kvKeyTree";
 import { decideKvMetadataRefresh, hasPositiveKvLease, knownKvLeaseSummaries, mergeKvKeyMetadata, mergeKvValueRefresh, nextKvLeaseRefreshDelay, removeMissingKvKey, updateKvResponseTtl } from "@/lib/kv/kvMetadataRefresh";
@@ -712,7 +713,7 @@ async function loadKeys(reset = true, options: LoadKeysOptions = {}) {
     }
   } catch (error) {
     if (reset && generation === keyLoadGeneration && props.connectionId === connectionId) {
-      listError.value = error instanceof Error ? error.message : String(error);
+      listError.value = formatError(error);
     }
   } finally {
     if (generation === keyLoadGeneration && props.connectionId === connectionId) {
@@ -792,7 +793,7 @@ async function loadLazyRoot(reset = true, options: LoadKeysOptions = {}) {
     }
   } catch (error) {
     if (lazyLoadContextValid(context)) {
-      listError.value = error instanceof Error ? error.message : String(error);
+      listError.value = formatError(error);
     }
   } finally {
     if (lazyLoadContextValid(context)) loading.value = false;
@@ -966,7 +967,7 @@ async function loadSelectedKey(input: string | KvKeyRoute) {
     startKeyListRefresh();
   } catch (error) {
     if (requestId !== detailRequestId || selectedKey.value !== key || connectionId !== props.connectionId) return;
-    detailError.value = error instanceof Error ? error.message : String(error);
+    detailError.value = formatError(error);
   } finally {
     if (requestId === detailRequestId && connectionId === props.connectionId) detailLoading.value = false;
   }
@@ -1414,7 +1415,7 @@ async function deleteSelectedKey() {
     }
     toast(props.labels.deleted, 2500);
   } catch (error) {
-    detailError.value = error instanceof Error ? error.message : String(error);
+    detailError.value = formatError(error);
     showDeleteConfirm.value = false;
   } finally {
     deleting.value = false;
@@ -1471,7 +1472,7 @@ async function copySelectedValue() {
     }, 1500);
   } catch (error) {
     selectedValueCopied.value = false;
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatError(error);
     const failureTemplate = props.labels.copyFailed || "Copy failed: {message}";
     toast(failureTemplate.includes("{message}") ? failureTemplate.replace("{message}", message) : `${failureTemplate}: ${message}`, 3500);
   }
@@ -1603,7 +1604,7 @@ async function moveOrCopySelectedKey() {
     await loadSelectedKey({ key: next, keyIdentity: next, keyBytes: { encoding: "utf8", data: next } });
     toast(props.labels.saved, 2500);
   } catch (error) {
-    renameError.value = error instanceof Error ? error.message : String(error);
+    renameError.value = formatError(error);
   } finally {
     renaming.value = false;
   }
@@ -1626,7 +1627,7 @@ async function openHistory() {
     historyEvents.value = response.events;
   } catch (error) {
     historyEvents.value = [];
-    historyError.value = error instanceof Error ? error.message : String(error);
+    historyError.value = formatError(error);
   } finally {
     historyLoading.value = false;
   }
@@ -1650,7 +1651,7 @@ async function restoreHistory() {
     await loadKeys(true, { preserveSelection: true });
     toast(props.labels.saved, 2500);
   } catch (error) {
-    historyError.value = error instanceof Error ? error.message : String(error);
+    historyError.value = formatError(error);
   } finally {
     restoring.value = false;
   }

--- a/apps/desktop/src/components/kv/__tests__/KvKeyBrowserErrorMessages.spec.ts
+++ b/apps/desktop/src/components/kv/__tests__/KvKeyBrowserErrorMessages.spec.ts
@@ -1,9 +1,5 @@
-import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { formatError, sanitizeBackendErrorMessage } from "@/lib/backend/errorUtils";
-
-const browserSource = readFileSync(new URL("../KvKeyBrowser.vue", import.meta.url), "utf8");
-const etcdBrowserSource = readFileSync(new URL("../../etcd/EtcdKeyBrowser.vue", import.meta.url), "utf8");
 
 // Reported in #8860: an etcd revision that has already been compacted surfaces
 // its internal Agent contract payload in the history dialog.
@@ -23,12 +19,5 @@ describe("KV browser error presentation", () => {
 
     expect(formatError(new Error(message))).toBe(message);
     expect(formatError(message)).toBe(message);
-  });
-
-  it("routes every displayed KV and etcd browser error through formatError", () => {
-    for (const source of [browserSource, etcdBrowserSource]) {
-      expect(source).toContain('import { formatError } from "@/lib/backend/errorUtils";');
-      expect(source).not.toContain("error instanceof Error ? error.message : String(error)");
-    }
   });
 });

--- a/apps/desktop/src/components/kv/__tests__/KvKeyBrowserErrorMessages.spec.ts
+++ b/apps/desktop/src/components/kv/__tests__/KvKeyBrowserErrorMessages.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { formatError, sanitizeBackendErrorMessage } from "@/lib/backend/errorUtils";
+
+const browserSource = readFileSync(new URL("../KvKeyBrowser.vue", import.meta.url), "utf8");
+const etcdBrowserSource = readFileSync(new URL("../../etcd/EtcdKeyBrowser.vue", import.meta.url), "utf8");
+
+// Reported in #8860: an etcd revision that has already been compacted surfaces
+// its internal Agent contract payload in the history dialog.
+const COMPACTED_HISTORY_ERROR =
+  'ETCD_COMPACTED: requested history was compacted at revision 6538169\nDBX_AGENT_ERROR_DATA:{"contractVersion":1,"category":"protocol","retryable":false,"sessionDisposition":"keep","stage":"execute","operationOutcome":"unknown","agentSessionId":null,"sqlState":null,"vendorCode":null,"exceptionClass":"ETCD_COMPACTED:requestedhistorywascompactedatrevision6538169"}';
+
+describe("KV browser error presentation", () => {
+  it("keeps the internal Agent payload out of a compacted-revision history error", () => {
+    const expected = "ETCD_COMPACTED: requested history was compacted at revision 6538169";
+
+    expect(sanitizeBackendErrorMessage(COMPACTED_HISTORY_ERROR)).toBe(expected);
+    expect(formatError(new Error(COMPACTED_HISTORY_ERROR))).toBe(expected);
+  });
+
+  it("leaves an error without the internal marker untouched", () => {
+    const message = "etcdserver: permission denied";
+
+    expect(formatError(new Error(message))).toBe(message);
+    expect(formatError(message)).toBe(message);
+  });
+
+  it("routes every displayed KV and etcd browser error through formatError", () => {
+    for (const source of [browserSource, etcdBrowserSource]) {
+      expect(source).toContain('import { formatError } from "@/lib/backend/errorUtils";');
+      expect(source).not.toContain("error instanceof Error ? error.message : String(error)");
+    }
+  });
+});

--- a/apps/desktop/src/components/kv/__tests__/KvKeyBrowserSearchAndSplit.spec.ts
+++ b/apps/desktop/src/components/kv/__tests__/KvKeyBrowserSearchAndSplit.spec.ts
@@ -42,7 +42,7 @@ describe("KvKeyBrowser search and split layout", () => {
 
   it("shows list request errors instead of the empty-state message", () => {
     expect(browserSource).toContain('const listError = ref("");');
-    expect(browserSource.match(/listError\.value = error instanceof Error \? error\.message : String\(error\);/g)).toHaveLength(2);
+    expect(browserSource.match(/listError\.value = formatError\(error\);/g)).toHaveLength(2);
     expect(browserSource.indexOf('v-else-if="listError"')).toBeLessThan(browserSource.indexOf('v-else-if="visibleRows.length === 0"'));
   });
 


### PR DESCRIPTION
## Problem

Reported in #8860. When an etcd revision has already been compacted, the history dialog shows the backend's internal contract payload appended to the message, which overflows the dialog and hides the readable part:

```
ETCD_COMPACTED: requested history was compacted at revision 6538169 DBX_AGENT_ERROR_DATA:{"contractVersion":1,"category":"protocol","retryable":false,"sessionDisposition":"keep","stage":"execute","operationOutcome":"unknown","agentSessionId":null,"sqlState":null,"vendorCode":null,"exceptionClass":"ETCD_COMPACTED:requestedhistorywascompactedatrevision6538169"}
```

Expected:

```
ETCD_COMPACTED: requested history was compacted at revision 6538169
```

`ETCD_COMPACTED` itself is correct behaviour; only its presentation is wrong.

## Cause

`agent_driver.rs` appends the `\nDBX_AGENT_ERROR_DATA:` marker plus a JSON blob so the core can classify an Agent failure. The frontend already strips it: `sanitizeBackendErrorMessage` in `apps/desktop/src/lib/backend/errorUtils.ts`, reached through `formatError`, and used consistently across `components/mq/*`.

The KV browsers never went through it — both display paths formatted the raw value:

```ts
historyError.value = error instanceof Error ? error.message : String(error);
```

So any Agent-backed failure surfaced in these two components carries the payload, not just the compacted-revision case. `formatError` also resolves structured `BackendError` values, which the inline expression stringifies as `[object Object]`.

## Change

Replace the inline expression with `formatError(error)` at every displayed error site in the two KV browser components:

- `apps/desktop/src/components/kv/KvKeyBrowser.vue` — 8 sites (key list, lazy root, key detail, delete, copy-failure toast, rename, and the two history paths from the report)
- `apps/desktop/src/components/etcd/EtcdKeyBrowser.vue` — 12 sites (export, batch delete, import, sync preview, transfer apply, search, operations, lease list)

All 20 are pure presentation — the value is assigned to an error ref or passed to `toast`. No control flow reads the message, so nothing depends on the marker surviving. Error classification is unaffected: `classifyKvMutationError` receives the original error object, not this string.

Deliberately scoped: the reporter counted ~139 occurrences of this expression across the frontend. This PR covers only the two components in the report. The rest span unrelated subsystems and should be converged separately if you want that — happy to follow up.

## Tests

New `apps/desktop/src/components/kv/__tests__/KvKeyBrowserErrorMessages.spec.ts`, using the exact error string from the issue:

- the compacted-revision message keeps only its readable part through `sanitizeBackendErrorMessage` and `formatError`
- an error without the marker (`etcdserver: permission denied`) passes through unchanged
- both components import `formatError` and no longer contain the raw expression

`KvKeyBrowserSearchAndSplit.spec.ts` asserted the old expression appeared exactly twice for `listError`; updated to the new call while keeping the count.

Verified locally:

```
npx vue-tsc --noEmit --project apps/desktop/tsconfig.json    # clean
npx oxfmt --check "apps/desktop/src/**/*.{ts,vue}"           # all files correctly formatted
npx vitest run apps/desktop/src/components/kv apps/desktop/src/components/etcd \
  apps/desktop/src/components/zookeeper apps/desktop/src/components/consul \
  apps/desktop/src/components/nacos                          # 17 files, 143 tests passed
```

A full `npx vitest run` on this machine leaves 17 spec files failing with `TypeError: Cannot read properties of undefined (reading 'clear')` on `localStorage`. I confirmed those same 17 files fail identically on an unmodified `main` here — my local Node is 26.x while the repo pins 22.13.0 — so they are environmental, not from this change. None of them touch the KV or etcd components.

`oxlint` reports two pre-existing warnings in `EtcdKeyBrowser.vue` (`no-unused-expressions`, `no-new-array`); they are present on unmodified `main` and only shift by one line from the added import.

Fixes #8860
