### PR TITLE
Fix：修复 SQL Server 2000 连接不稳定及字段注释缺失

### DIFF
--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -339,9 +339,11 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
                 columns,
                 readSqlServer2000ColumnComments(resolvedSchema, table)
             );
-        } catch (SQLException error) {
+        } catch (SQLException | RuntimeException error) {
             // Comments are optional metadata. Keep the table usable when the
             // legacy catalog is unavailable or the account cannot read it.
+            // Legacy drivers can also throw runtime errors from their catalog
+            // code, mirroring the RuntimeException guards in getTableDdl.
             System.err.println(
                 "[sqlserver-legacy] SQL Server 2000 column comments unavailable: "
                     + error.getClass().getName()

--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -320,7 +320,66 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
 
     @Override
     public List<ColumnInfo> getColumns(String schema, String table) {
-        return super.getColumns(metadataSchema(schema, table), table);
+        String resolvedSchema = metadataSchema(schema, table);
+        List<ColumnInfo> columns = super.getColumns(resolvedSchema, table);
+        if (!sqlServer2000Mode || columns.isEmpty()) {
+            return columns;
+        }
+        try {
+            return mergeSqlServer2000ColumnComments(
+                columns,
+                readSqlServer2000ColumnComments(resolvedSchema, table)
+            );
+        } catch (SQLException error) {
+            // Comments are optional metadata. Keep the table usable when the
+            // legacy catalog is unavailable or the account cannot read it.
+            System.err.println(
+                "[sqlserver-legacy] SQL Server 2000 column comments unavailable: "
+                    + error.getClass().getName()
+                    + ": "
+                    + error.getMessage()
+            );
+            return columns;
+        }
+    }
+
+    private Map<String, String> readSqlServer2000ColumnComments(String schema, String table) throws SQLException {
+        Map<String, String> comments = new LinkedHashMap<>();
+        try (PreparedStatement statement = requireConnection().prepareStatement(sqlServer2000ColumnCommentsSql())) {
+            statement.setString(1, schema);
+            statement.setString(2, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String column = resultSet.getString("column_name");
+                    String comment = resultSet.getString("column_comment");
+                    if (column != null && comment != null && !comment.trim().isEmpty()) {
+                        comments.put(column, comment);
+                    }
+                }
+            }
+        }
+        return comments;
+    }
+
+    static List<ColumnInfo> mergeSqlServer2000ColumnComments(
+        List<ColumnInfo> columns,
+        Map<String, String> comments
+    ) {
+        if (comments.isEmpty()) {
+            return columns;
+        }
+        for (ColumnInfo column : columns) {
+            String comment = comments.get(column.getName());
+            if (comment != null) {
+                column.setComment(comment);
+            }
+        }
+        return columns;
+    }
+
+    static String sqlServer2000ColumnCommentsSql() {
+        return "SELECT objname AS column_name, CONVERT(nvarchar(4000), value) AS column_comment "
+            + "FROM ::fn_listextendedproperty('MS_Description', 'user', ?, 'table', ?, 'column', default)";
     }
 
     @Override

--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -365,7 +365,11 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
                     String column = resultSet.getString("column_name");
                     String comment = resultSet.getString("column_comment");
                     if (column != null && comment != null && !comment.trim().isEmpty()) {
-                        comments.put(column.trim().toLowerCase(Locale.ROOT), comment);
+                        String key = column.trim().toLowerCase(Locale.ROOT);
+                        String property = resultSet.getString("property_name");
+                        if (!comments.containsKey(key) || "MS_Description".equalsIgnoreCase(property)) {
+                            comments.put(key, comment);
+                        }
                     }
                 }
             }
@@ -396,16 +400,18 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
     }
 
     static String sqlServer2000ColumnCommentsSql() {
-        return "SELECT c.name AS column_name, CONVERT(nvarchar(4000), p.value) AS column_comment "
+        return "SELECT c.name AS column_name, p.value AS column_comment, p.name AS property_name "
             + "FROM sysobjects o JOIN sysusers u ON o.uid = u.uid "
             + "JOIN syscolumns c ON c.id = o.id "
-            + "JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid "
+            + "LEFT OUTER JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid "
             + "WHERE u.name = ? AND o.name = ? AND o.xtype IN ('U', 'V') "
-            + "AND p.name = 'MS_Description' ORDER BY c.colid";
+            + "AND p.value IS NOT NULL "
+            + "ORDER BY c.colid, CASE WHEN p.name = 'MS_Description' THEN 0 ELSE 1 END";
     }
 
     static String sqlServer2000ColumnCommentsFunctionSql() {
-        return "SELECT objname AS column_name, CONVERT(nvarchar(4000), value) AS column_comment "
+        return "SELECT objname AS column_name, CONVERT(nvarchar(4000), value) AS column_comment, "
+            + "'MS_Description' AS property_name "
             + "FROM ::fn_listextendedproperty('MS_Description', 'user', ?, 'table', ?, 'column', default)";
     }
 

--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -344,8 +344,20 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
     }
 
     private Map<String, String> readSqlServer2000ColumnComments(String schema, String table) throws SQLException {
+        try {
+            return readColumnCommentsFromQuery(sqlServer2000ColumnCommentsSql(), schema, table);
+        } catch (SQLException error) {
+            System.err.println(
+                "[sqlserver-legacy] SQL Server 2000 direct column comments query failed; trying compatibility function: "
+                    + error.getMessage()
+            );
+            return readColumnCommentsFromQuery(sqlServer2000ColumnCommentsFunctionSql(), schema, table);
+        }
+    }
+
+    private Map<String, String> readColumnCommentsFromQuery(String sql, String schema, String table) throws SQLException {
         Map<String, String> comments = new LinkedHashMap<>();
-        try (PreparedStatement statement = requireConnection().prepareStatement(sqlServer2000ColumnCommentsSql())) {
+        try (PreparedStatement statement = requireConnection().prepareStatement(sql)) {
             statement.setString(1, schema);
             statement.setString(2, table);
             try (ResultSet resultSet = statement.executeQuery()) {
@@ -353,7 +365,7 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
                     String column = resultSet.getString("column_name");
                     String comment = resultSet.getString("column_comment");
                     if (column != null && comment != null && !comment.trim().isEmpty()) {
-                        comments.put(column, comment);
+                        comments.put(column.trim().toLowerCase(Locale.ROOT), comment);
                     }
                 }
             }
@@ -368,8 +380,14 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
         if (comments.isEmpty()) {
             return columns;
         }
+        Map<String, String> normalizedComments = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : comments.entrySet()) {
+            if (entry.getKey() != null) {
+                normalizedComments.put(entry.getKey().trim().toLowerCase(Locale.ROOT), entry.getValue());
+            }
+        }
         for (ColumnInfo column : columns) {
-            String comment = comments.get(column.getName());
+            String comment = normalizedComments.get(column.getName().trim().toLowerCase(Locale.ROOT));
             if (comment != null) {
                 column.setComment(comment);
             }
@@ -378,6 +396,15 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
     }
 
     static String sqlServer2000ColumnCommentsSql() {
+        return "SELECT c.name AS column_name, CONVERT(nvarchar(4000), p.value) AS column_comment "
+            + "FROM sysobjects o JOIN sysusers u ON o.uid = u.uid "
+            + "JOIN syscolumns c ON c.id = o.id "
+            + "JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid "
+            + "WHERE u.name = ? AND o.name = ? AND o.xtype IN ('U', 'V') "
+            + "AND p.name = 'MS_Description' ORDER BY c.colid";
+    }
+
+    static String sqlServer2000ColumnCommentsFunctionSql() {
         return "SELECT objname AS column_name, CONVERT(nvarchar(4000), value) AS column_comment "
             + "FROM ::fn_listextendedproperty('MS_Description', 'user', ?, 'table', ?, 'column', default)";
     }

--- a/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
+++ b/agents/drivers/sqlserver-legacy/src/main/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgent.java
@@ -72,6 +72,15 @@ public final class SqlServerLegacyAgent extends ConfiguredJdbcAgent {
     }
 
     @Override
+    public boolean supportsConnectionPooling() {
+        // The mssql-jdbc -> jTDS fallback is session state on this Agent
+        // instance. A shared JDBC pool could hand a jTDS connection to another
+        // session that still believes it is using mssql-jdbc, and SQL Server
+        // 2000 is particularly prone to resetting those reused connections.
+        return false;
+    }
+
+    @Override
     protected String buildJdbcUrl(ConnectParams params) {
         return sqlServer2000Mode ? jtdsUrl(params) : legacyTlsUrl(params);
     }

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -2,14 +2,25 @@ package com.dbx.agent.sqlserverlegacy;
 
 import com.dbx.agent.ConnectParams;
 import com.dbx.agent.ColumnInfo;
+import com.dbx.agent.test.TestSupport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.security.Security;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 class SqlServerLegacyAgentTest {
@@ -106,20 +117,72 @@ class SqlServerLegacyAgentTest {
     }
 
     @Test
-    void sqlServer2000ColumnCommentsUseLegacyExtendedPropertyFunction() {
-        String sql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsSql();
+    void sqlServer2000ColumnCommentsEnrichJdbcColumnRemarks() {
+        SqlServerLegacyAgent agent = new SqlServerLegacyAgent();
+        TestSupport.setPrivateConnection(agent, sqlServer2000CommentConnection(
+            Arrays.asList(
+                Arrays.asList("ID", "Primary identifier", "MS_Description"),
+                Arrays.asList("NAME", "Custom label", "CUSTOM_PROP"),
+                Arrays.asList("NAME", "Display name", "MS_Description")
+            ),
+            null,
+            null
+        ));
+        setSqlServer2000Mode(agent, true);
 
-        Assertions.assertTrue(sql.contains("LEFT OUTER JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid"));
-        Assertions.assertTrue(sql.contains("u.name = ? AND o.name = ?"));
-        Assertions.assertTrue(sql.contains("p.value AS column_comment"));
-        Assertions.assertTrue(sql.contains("p.name AS property_name"));
-        Assertions.assertTrue(sql.contains("ORDER BY c.colid, CASE WHEN p.name = 'MS_Description' THEN 0 ELSE 1 END"));
-        Assertions.assertFalse(sql.contains("sys.extended_properties"));
+        List<ColumnInfo> columns = agent.getColumns("dbo", "USERS");
 
-        String functionSql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsFunctionSql();
-        Assertions.assertTrue(functionSql.contains("FROM ::fn_listextendedproperty"));
-        Assertions.assertTrue(functionSql.contains("'MS_Description', 'user', ?, 'table', ?, 'column', default"));
-        Assertions.assertTrue(functionSql.contains("'MS_Description' AS property_name"));
+        Assertions.assertEquals(List.of("ID", "NAME", "CREATED_AT"), columns.stream().map(ColumnInfo::getName).toList());
+        Assertions.assertEquals("Primary identifier", columns.get(0).getComment());
+        // MS_Description outranks other extended properties on the same column.
+        Assertions.assertEquals("Display name", columns.get(1).getComment());
+        // Columns without an extended property keep their JDBC remark untouched.
+        Assertions.assertEquals("JDBC remark", columns.get(2).getComment());
+        Assertions.assertTrue(columns.get(0).getIs_nullable());
+        Assertions.assertFalse(columns.get(2).getIs_nullable());
+        Assertions.assertEquals("getdate()", columns.get(2).getColumn_default());
+    }
+
+    @Test
+    void sqlServer2000ColumnCommentsFallBackToCompatibilityFunction() {
+        SqlServerLegacyAgent agent = new SqlServerLegacyAgent();
+        TestSupport.setPrivateConnection(agent, sqlServer2000CommentConnection(
+            null,
+            Arrays.asList(
+                Arrays.asList("NAME", "Display name from extended property", "MS_Description")
+            ),
+            null
+        ));
+        setSqlServer2000Mode(agent, true);
+
+        List<ColumnInfo> columns = agent.getColumns("dbo", "USERS");
+
+        // The sysproperties query is unavailable on this legacy catalog, so the
+        // fn_listextendedproperty compatibility function supplies the comment.
+        Assertions.assertEquals("Display name from extended property", columns.get(1).getComment());
+        Assertions.assertNull(columns.get(0).getComment());
+        Assertions.assertEquals("JDBC remark", columns.get(2).getComment());
+    }
+
+    @Test
+    void sqlServer2000ColumnCommentsFailSoftWhenCatalogThrowsRuntimeError() {
+        SqlServerLegacyAgent agent = new SqlServerLegacyAgent();
+        TestSupport.setPrivateConnection(agent, sqlServer2000CommentConnection(
+            null,
+            null,
+            new IllegalStateException("legacy catalog proxy failed")
+        ));
+        setSqlServer2000Mode(agent, true);
+
+        // Comments are optional enrichment: a runtime failure inside the legacy
+        // catalog must degrade to comment-less columns instead of failing the
+        // whole column listing.
+        List<ColumnInfo> columns = agent.getColumns("dbo", "USERS");
+
+        Assertions.assertEquals(List.of("ID", "NAME", "CREATED_AT"), columns.stream().map(ColumnInfo::getName).toList());
+        Assertions.assertNull(columns.get(0).getComment());
+        Assertions.assertNull(columns.get(1).getComment());
+        Assertions.assertEquals("JDBC remark", columns.get(2).getComment());
     }
 
     @Test
@@ -371,5 +434,173 @@ class SqlServerLegacyAgentTest {
             baseDdl,
             SqlServerLegacyAgent.appendTableCommentDdl(baseDdl, "dbo", "Users", "   ")
         );
+    }
+
+    /**
+     * A connection shaped like a jTDS SQL Server 2000 session: the driver's own
+     * JDBC metadata still reports the table columns, while column comments are
+     * served by the legacy sysproperties catalog or, when that query fails, by
+     * the fn_listextendedproperty compatibility function. Comment rows carry
+     * (column_name, column_comment, property_name).
+     */
+    private static Connection sqlServer2000CommentConnection(
+        List<List<Object>> primaryCommentRows,
+        List<List<Object>> fallbackCommentRows,
+        RuntimeException runtimeError
+    ) {
+        DatabaseMetaData metadata = proxy(DatabaseMetaData.class, (method, args) -> {
+            if ("getColumns".equals(method.getName())) {
+                return metadataResultSet(Arrays.asList(
+                    Arrays.asList("ID", "int", 1, null, null),
+                    Arrays.asList("NAME", "varchar", 1, null, null),
+                    Arrays.asList("CREATED_AT", "datetime", 0, "getdate()", "JDBC remark")
+                ), JDBC_COLUMN_LABELS);
+            }
+            if ("getPrimaryKeys".equals(method.getName())) {
+                return metadataResultSet(List.of(), JDBC_COLUMN_LABELS);
+            }
+            return defaultValue(method.getReturnType());
+        });
+        return proxy(Connection.class, (method, args) -> {
+            String name = method.getName();
+            if ("getMetaData".equals(name)) {
+                return metadata;
+            }
+            if ("prepareStatement".equals(name)) {
+                String sql = (String) args[0];
+                if (runtimeError != null) {
+                    return failingStatement(runtimeError);
+                }
+                if (sql.toUpperCase(Locale.ROOT).contains("SYSPROPERTIES")) {
+                    return primaryCommentRows == null
+                        ? failingStatement(new SQLException("sysproperties catalog unavailable"))
+                        : commentStatement(primaryCommentRows);
+                }
+                return commentStatement(fallbackCommentRows == null ? List.of() : fallbackCommentRows);
+            }
+            if ("close".equals(name) || "isClosed".equals(name)) {
+                return "isClosed".equals(name) ? Boolean.FALSE : null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static PreparedStatement commentStatement(List<List<Object>> rows) {
+        return proxy(PreparedStatement.class, (method, args) -> {
+            if ("executeQuery".equals(method.getName())) {
+                return metadataResultSet(rows, COMMENT_LABELS);
+            }
+            if ("close".equals(method.getName()) || "setMaxRows".equals(method.getName())) {
+                return null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static PreparedStatement failingStatement(Throwable error) {
+        return proxy(PreparedStatement.class, (method, args) -> {
+            if ("executeQuery".equals(method.getName())) {
+                throw error;
+            }
+            if ("close".equals(method.getName()) || "setMaxRows".equals(method.getName())) {
+                return null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static final Map<String, Integer> JDBC_COLUMN_LABELS = Map.of(
+        "COLUMN_NAME", 0,
+        "TYPE_NAME", 1,
+        "NULLABLE", 2,
+        "COLUMN_DEF", 3,
+        "REMARKS", 4
+    );
+
+    private static final Map<String, Integer> COMMENT_LABELS = Map.of(
+        "COLUMN_NAME", 0,
+        "COLUMN_COMMENT", 1,
+        "PROPERTY_NAME", 2
+    );
+
+    private static ResultSet metadataResultSet(List<List<Object>> rows, Map<String, Integer> labels) {
+        int[] index = {-1};
+        return proxy(ResultSet.class, (method, args) -> {
+            String name = method.getName();
+            if ("next".equals(name)) {
+                index[0] += 1;
+                return index[0] < rows.size();
+            }
+            if ("close".equals(name)) {
+                return null;
+            }
+            if ("getString".equals(name) || "getInt".equals(name) || "getObject".equals(name)) {
+                Integer position = args[0] instanceof String label ? labels.get(label.toUpperCase(Locale.ROOT)) : null;
+                Object value = position == null || index[0] < 0 || index[0] >= rows.size()
+                    ? null
+                    : rows.get(index[0]).get(position);
+                if ("getString".equals(name)) {
+                    return value == null ? null : value.toString();
+                }
+                if ("getInt".equals(name)) {
+                    return value instanceof Number number ? number.intValue() : 0;
+                }
+                return value;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    private static void setSqlServer2000Mode(SqlServerLegacyAgent agent, boolean value) {
+        try {
+            Field field = SqlServerLegacyAgent.class.getDeclaredField("sqlServer2000Mode");
+            field.setAccessible(true);
+            field.set(agent, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to set SQL Server 2000 mode", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, MethodHandler handler) {
+        InvocationHandler invocationHandler = new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                return handler.handle(method, args);
+            }
+        };
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, invocationHandler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (Boolean.TYPE.equals(type)) {
+            return false;
+        }
+        if (Byte.TYPE.equals(type)) {
+            return (byte) 0;
+        }
+        if (Short.TYPE.equals(type)) {
+            return (short) 0;
+        }
+        if (Integer.TYPE.equals(type)) {
+            return 0;
+        }
+        if (Long.TYPE.equals(type)) {
+            return 0L;
+        }
+        if (Float.TYPE.equals(type)) {
+            return 0f;
+        }
+        if (Double.TYPE.equals(type)) {
+            return 0.0d;
+        }
+        if (Character.TYPE.equals(type)) {
+            return '\0';
+        }
+        return null;
+    }
+
+    private interface MethodHandler {
+        Object handle(Method method, Object[] args) throws Throwable;
     }
 }

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -109,15 +109,17 @@ class SqlServerLegacyAgentTest {
     void sqlServer2000ColumnCommentsUseLegacyExtendedPropertyFunction() {
         String sql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsSql();
 
-        Assertions.assertTrue(sql.contains("JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid"));
+        Assertions.assertTrue(sql.contains("LEFT OUTER JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid"));
         Assertions.assertTrue(sql.contains("u.name = ? AND o.name = ?"));
-        Assertions.assertTrue(sql.contains("p.name = 'MS_Description'"));
-        Assertions.assertTrue(sql.contains("ORDER BY c.colid"));
+        Assertions.assertTrue(sql.contains("p.value AS column_comment"));
+        Assertions.assertTrue(sql.contains("p.name AS property_name"));
+        Assertions.assertTrue(sql.contains("ORDER BY c.colid, CASE WHEN p.name = 'MS_Description' THEN 0 ELSE 1 END"));
         Assertions.assertFalse(sql.contains("sys.extended_properties"));
 
         String functionSql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsFunctionSql();
         Assertions.assertTrue(functionSql.contains("FROM ::fn_listextendedproperty"));
         Assertions.assertTrue(functionSql.contains("'MS_Description', 'user', ?, 'table', ?, 'column', default"));
+        Assertions.assertTrue(functionSql.contains("'MS_Description' AS property_name"));
     }
 
     @Test

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -109,11 +109,15 @@ class SqlServerLegacyAgentTest {
     void sqlServer2000ColumnCommentsUseLegacyExtendedPropertyFunction() {
         String sql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsSql();
 
-        Assertions.assertTrue(sql.contains("FROM ::fn_listextendedproperty"));
-        Assertions.assertTrue(sql.contains("'MS_Description', 'user', ?, 'table', ?, 'column', default"));
-        Assertions.assertTrue(sql.contains("objname AS column_name"));
-        Assertions.assertTrue(sql.contains("CONVERT(nvarchar(4000), value) AS column_comment"));
+        Assertions.assertTrue(sql.contains("JOIN sysproperties p ON p.id = o.id AND p.smallid = c.colid"));
+        Assertions.assertTrue(sql.contains("u.name = ? AND o.name = ?"));
+        Assertions.assertTrue(sql.contains("p.name = 'MS_Description'"));
+        Assertions.assertTrue(sql.contains("ORDER BY c.colid"));
         Assertions.assertFalse(sql.contains("sys.extended_properties"));
+
+        String functionSql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsFunctionSql();
+        Assertions.assertTrue(functionSql.contains("FROM ::fn_listextendedproperty"));
+        Assertions.assertTrue(functionSql.contains("'MS_Description', 'user', ?, 'table', ?, 'column', default"));
     }
 
     @Test
@@ -135,6 +139,11 @@ class SqlServerLegacyAgentTest {
         Assertions.assertEquals("JDBC remark", untouched.getComment());
         Assertions.assertTrue(id.getIs_primary_key());
         Assertions.assertEquals("getdate()", untouched.getColumn_default());
+
+        comments.clear();
+        comments.put("name", "Case-insensitive match");
+        SqlServerLegacyAgent.mergeSqlServer2000ColumnComments(columns, comments);
+        Assertions.assertEquals("Case-insensitive match", name.getComment());
     }
 
     @Test

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -1,12 +1,16 @@
 package com.dbx.agent.sqlserverlegacy;
 
 import com.dbx.agent.ConnectParams;
+import com.dbx.agent.ColumnInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.security.Security;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 class SqlServerLegacyAgentTest {
     @Test
@@ -99,6 +103,38 @@ class SqlServerLegacyAgentTest {
                 + "ORDER BY c.colid",
             SqlServerLegacyAgent.sqlServer2000ObjectSourceSql()
         );
+    }
+
+    @Test
+    void sqlServer2000ColumnCommentsUseLegacyExtendedPropertyFunction() {
+        String sql = SqlServerLegacyAgent.sqlServer2000ColumnCommentsSql();
+
+        Assertions.assertTrue(sql.contains("FROM ::fn_listextendedproperty"));
+        Assertions.assertTrue(sql.contains("'MS_Description', 'user', ?, 'table', ?, 'column', default"));
+        Assertions.assertTrue(sql.contains("objname AS column_name"));
+        Assertions.assertTrue(sql.contains("CONVERT(nvarchar(4000), value) AS column_comment"));
+        Assertions.assertFalse(sql.contains("sys.extended_properties"));
+    }
+
+    @Test
+    void sqlServer2000ColumnCommentsMergeWithoutDiscardingJdbcMetadata() {
+        ColumnInfo id = new ColumnInfo("ID", "int", false, null, true);
+        ColumnInfo name = new ColumnInfo("NAME", "varchar", true, null, false);
+        ColumnInfo untouched = new ColumnInfo("CREATED_AT", "datetime", false, "getdate()", false);
+        untouched.setComment("JDBC remark");
+        List<ColumnInfo> columns = List.of(id, name, untouched);
+        Map<String, String> comments = new LinkedHashMap<>();
+        comments.put("ID", "Primary identifier");
+        comments.put("NAME", "Display name");
+
+        List<ColumnInfo> merged = SqlServerLegacyAgent.mergeSqlServer2000ColumnComments(columns, comments);
+
+        Assertions.assertSame(columns, merged);
+        Assertions.assertEquals("Primary identifier", id.getComment());
+        Assertions.assertEquals("Display name", name.getComment());
+        Assertions.assertEquals("JDBC remark", untouched.getComment());
+        Assertions.assertTrue(id.getIs_primary_key());
+        Assertions.assertEquals("getdate()", untouched.getColumn_default());
     }
 
     @Test

--- a/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
+++ b/agents/drivers/sqlserver-legacy/src/test/java/com/dbx/agent/sqlserverlegacy/SqlServerLegacyAgentTest.java
@@ -179,6 +179,11 @@ class SqlServerLegacyAgentTest {
     }
 
     @Test
+    void doesNotShareJdbcConnectionsAcrossLegacyAgentSessions() {
+        Assertions.assertFalse(new SqlServerLegacyAgent().supportsConnectionPooling());
+    }
+
+    @Test
     void sqlServer2000AllNulCharacterPaddingBecomesEmptyString() {
         Assertions.assertEquals(
             "",


### PR DESCRIPTION
## Fix：修复 SQL Server 2000 兼容连接不稳定及字段注释缺失

### 变更内容
- 从 SQL Server 2000 的 `sysproperties` 读取字段注释，并保留 `MS_Description` 优先级。
- 当旧版目录查询不可用时，回退到 `fn_listextendedproperty`。
- 禁用 `sqlserver-legacy` Agent 的 JDBC 连接池，避免不同会话复用连接时混淆 mssql-jdbc 与 jTDS 状态，降低连接成功后打开数据库或表失败的概率。

### 影响范围
- 仅影响启用了 SQL Server legacy compatibility component 的连接。
- 普通 SQL Server 连接不加载该 Agent，不改变其连接池、驱动或连接参数。

### 验证
- `:sqlserver-legacy:check` 通过。
- `:sqlserver-legacy:shadowJar` 构建通过。
- 已增加 SQL Server 2000 注释查询、注释合并和连接池隔离测试。
- Windows 自建无签名安装包构建已停止，避免将安全软件可能拦截的未签名包作为正式验收依据。待正式签名版本发布后，再在真实 SQL Server 2000 环境验证连接稳定性。