### PR TITLE
fix(mongodb): suggest extended JSON values and complete inside $in arrays

### DIFF
--- a/apps/desktop/src/lib/mongo/mongoCompletion.ts
+++ b/apps/desktop/src/lib/mongo/mongoCompletion.ts
@@ -1,5 +1,19 @@
 import { mongoExtendedJsonValueType } from "@/lib/mongo/mongoDocumentValues";
-import { ACCUMULATORS, COMMON_OPERATORS, EXPRESSION_OPERATORS, PIPELINE_STAGES, PUSH_MODIFIERS, QUERY_OPERATORS, STAGE_OPTION_KEYS, UPDATE_OPERATORS, UPDATE_OPERATOR_LABELS, VALUE_SNIPPETS, mongoOperatorItemType, type MongoOperatorSpec } from "@/lib/mongo/mongoCompletionTables";
+import {
+  ACCUMULATORS,
+  COMMON_OPERATORS,
+  EXPRESSION_OPERATORS,
+  EXTENDED_JSON_VALUES,
+  PIPELINE_STAGES,
+  PUSH_MODIFIERS,
+  QUERY_OPERATORS,
+  STAGE_OPTION_KEYS,
+  UPDATE_OPERATORS,
+  UPDATE_OPERATOR_LABELS,
+  VALUE_SNIPPETS,
+  mongoOperatorItemType,
+  type MongoOperatorSpec,
+} from "@/lib/mongo/mongoCompletionTables";
 
 /**
  * What the cursor may usefully be completed with. Each mode maps to exactly one
@@ -11,7 +25,26 @@ import { ACCUMULATORS, COMMON_OPERATORS, EXPRESSION_OPERATORS, PIPELINE_STAGES, 
  * the editor turns into "no popup" — deliberately better than falling back to
  * `root` and showing unrelated `db.…` snippets mid-document.
  */
-export type MongoCompletionMode = "none" | "root" | "collection" | "collectionOrMethod" | "collectionRef" | "method" | "cursorMethod" | "field" | "fieldPath" | "fieldRef" | "value" | "queryOperator" | "updateOperator" | "pushModifier" | "expression" | "accumulator" | "stage" | "stageOption";
+export type MongoCompletionMode =
+  | "none"
+  | "root"
+  | "collection"
+  | "collectionOrMethod"
+  | "collectionRef"
+  | "method"
+  | "cursorMethod"
+  | "field"
+  | "fieldPath"
+  | "fieldRef"
+  | "value"
+  | "valueWrapper"
+  | "queryOperator"
+  | "updateOperator"
+  | "pushModifier"
+  | "expression"
+  | "accumulator"
+  | "stage"
+  | "stageOption";
 
 export interface MongoCompletionField {
   name: string;
@@ -157,6 +190,12 @@ const METHOD_ARG_ROLES: Record<string, readonly MongoArgRole[]> = {
   sort: ["sortKeys"],
 };
 
+/** `{ $oid: "..." }` for a bare value position, where the user has not typed the braces yet. */
+const BRACED_EXTENDED_JSON_VALUES: MongoOperatorSpec[] = EXTENDED_JSON_VALUES.map((spec) => ({ ...spec, apply: `{ ${spec.apply} }` }));
+
+/** Query operators whose array holds plain values, unlike `$and` / `$or` / `$nor` which hold sub-filters. */
+const VALUE_ARRAY_OPERATORS = new Set(["$in", "$nin", "$all"]);
+
 const CALL_METHOD_PATTERN = new RegExp(`\\.(${Object.keys(METHOD_ARG_ROLES).join("|")})\\s*\\(`, "g");
 
 /** Modes reached by walking the `db.collection.method` chain, where a `.` switches item source. */
@@ -278,10 +317,15 @@ export function buildMongoCompletionItemsFromContext(context: MongoCompletionCon
       items = fieldRefItems(prefix, fields);
       break;
     case "value":
-      items = specItems(VALUE_SNIPPETS, prefix, "value", 100);
+      // Shell constructors first; the extended JSON spellings need their own braces here.
+      items = [...specItems(VALUE_SNIPPETS, prefix, "value", 100), ...specItems(BRACED_EXTENDED_JSON_VALUES, prefix, "extended JSON value", 90)];
+      break;
+    case "valueWrapper":
+      items = specItems(EXTENDED_JSON_VALUES, prefix, "extended JSON value", 100);
       break;
     case "queryOperator":
-      items = specItems(QUERY_OPERATORS, prefix, "query operator", 100);
+      // `{ _id: { $oid: ... } }` is as valid here as `{ _id: { $gt: ... } }`.
+      items = [...specItems(QUERY_OPERATORS, prefix, "query operator", 100), ...specItems(EXTENDED_JSON_VALUES, prefix, "extended JSON value", 90)];
       break;
     case "updateOperator":
       items = specItems(UPDATE_OPERATORS, prefix, "update operator", 100);
@@ -496,14 +540,20 @@ function innermost(scan: MongoCallScan): MongoContainer | undefined {
 function classifyFilter(scan: MongoCallScan, rootIndex: number): MongoCompletionMode {
   const inner = innermost(scan);
   if (!inner || innerDepth(scan, rootIndex) < 0) return "none";
+  // Elements of `$in: [...]` are values, so `{ _id: { $in: [ObjectId(...)] } }` completes like any value.
+  if (inner.kind === "array") return VALUE_ARRAY_OPERATORS.has(inner.key ?? "") && !scan.inString ? "value" : "none";
   if (inner.kind !== "object") return "none";
   if (scan.inValue) return scan.inString ? "none" : "value";
   if (innerDepth(scan, rootIndex) === 0) return "field";
 
   // Inside a nested object: whose value is it?
   switch (inner.key) {
-    case null:
-      return "field"; // an element of `$and` / `$or` / `$nor`
+    case null: {
+      // An object inside an array: a sub-filter under `$and` / `$or` / `$nor`,
+      // or an extended JSON wrapper such as `{ $oid: ... }` under `$in`.
+      const parent = scan.stack[scan.stack.length - 2];
+      return parent?.kind === "array" && VALUE_ARRAY_OPERATORS.has(parent.key ?? "") ? "valueWrapper" : "field";
+    }
     case "$elemMatch":
       return "field";
     case "$expr":

--- a/apps/desktop/src/lib/mongo/mongoCompletionTables.ts
+++ b/apps/desktop/src/lib/mongo/mongoCompletionTables.ts
@@ -353,9 +353,36 @@ export const VALUE_SNIPPETS: MongoOperatorSpec[] = specs([
   ["ISODate", "MongoDB ISODate value", 'ISODate("${date}")'],
   ["new Date", "JavaScript date value", 'new Date("${date}")'],
   ["NumberLong", "64-bit integer value", 'NumberLong("${value}")'],
+  ["NumberInt", "32-bit integer value", "NumberInt(${value})"],
+  ["NumberDecimal", "128-bit decimal value", 'NumberDecimal("${value}")'],
+  ["UUID", "UUID value", 'UUID("${uuid}")'],
+  ["BinData", "Binary value", 'BinData(0, "${base64}")'],
+  ["Timestamp", "Internal timestamp value", "Timestamp(${seconds}, ${ordinal})"],
+  ["MinKey", "Sorts before every other value", "MinKey"],
+  ["MaxKey", "Sorts after every other value", "MaxKey"],
   ["null", "Null value", "null"],
   ["true", "Boolean true", "true"],
   ["false", "Boolean false", "false"],
+]);
+
+/**
+ * Extended JSON spellings of the same values, as the driver returns them and
+ * as they may be typed directly. Each entry is the wrapper's body; in a bare
+ * value position the completion adds the surrounding braces.
+ */
+export const EXTENDED_JSON_VALUES: MongoOperatorSpec[] = specs([
+  ["$oid", "ObjectId as extended JSON", '$oid: "${id}"'],
+  ["$date", "Date as extended JSON", '$date: "${date}"'],
+  ["$numberLong", "64-bit integer as extended JSON", '$numberLong: "${value}"'],
+  ["$numberInt", "32-bit integer as extended JSON", '$numberInt: "${value}"'],
+  ["$numberDouble", "Double as extended JSON", '$numberDouble: "${value}"'],
+  ["$numberDecimal", "128-bit decimal as extended JSON", '$numberDecimal: "${value}"'],
+  ["$uuid", "UUID as extended JSON", '$uuid: "${uuid}"'],
+  ["$binary", "Binary as extended JSON", '$binary: { base64: "${base64}", subType: "00" }'],
+  ["$timestamp", "Internal timestamp as extended JSON", "$timestamp: { t: ${seconds}, i: ${ordinal} }"],
+  ["$regularExpression", "Regular expression as extended JSON", '$regularExpression: { pattern: "${pattern}", options: "" }'],
+  ["$minKey", "MinKey as extended JSON", "$minKey: 1"],
+  ["$maxKey", "MaxKey as extended JSON", "$maxKey: 1"],
 ]);
 
 /**
@@ -382,6 +409,9 @@ export const COMMON_OPERATORS: ReadonlySet<string> = new Set([
   "$regex",
   "$elemMatch",
   "$expr",
+  // extended JSON values
+  "$oid",
+  "$date",
   // update
   "$set",
   "$unset",

--- a/crates/dbx-core/src/db/mongo_driver.rs
+++ b/crates/dbx-core/src/db/mongo_driver.rs
@@ -2695,13 +2695,22 @@ fn json_filter_value_to_bson(value: &serde_json::Value, field_name: Option<&str>
         }
         serde_json::Value::Object(obj) => {
             if obj.len() == 1 {
-                // Shell constructor wrappers (UUID/BinData/Timestamp/MinKey/MaxKey)
-                // and $regularExpression decode through the shared extended JSON
-                // parser, following the same precedent as $date below.
+                // Shell constructor wrappers (UUID/BinData/Timestamp/MinKey/MaxKey),
+                // $regularExpression, and the numeric type wrappers decode through
+                // the shared extended JSON parser, following the same precedent as
+                // $date below, so typed number literals compare correctly in filters.
                 if obj.keys().next().is_some_and(|key| {
                     matches!(
                         key.as_str(),
-                        "$regularExpression" | "$uuid" | "$binary" | "$timestamp" | "$minKey" | "$maxKey"
+                        "$regularExpression"
+                            | "$uuid"
+                            | "$binary"
+                            | "$timestamp"
+                            | "$minKey"
+                            | "$maxKey"
+                            | "$numberInt"
+                            | "$numberDouble"
+                            | "$numberDecimal"
                     )
                 }) {
                     if let Ok(Some(value)) = parse_extended_json_value(obj) {
@@ -3419,6 +3428,51 @@ mod tests {
             blob.get("$eq"),
             Some(Bson::Binary(binary)) if binary.subtype == mongodb::bson::spec::BinarySubtype::Generic && binary.bytes == [1, 2, 3]
         ));
+    }
+
+    #[test]
+    fn json_filter_to_document_decodes_extended_json_number_wrappers() {
+        // Typed number literals must compare against the typed BSON value, not a
+        // raw { "$numberInt": ... } document the server rejects with
+        // "unknown operator" (or that silently matches nothing).
+        let filter = serde_json::json!({
+            "score": { "$numberInt": "5" },
+            "ratio": { "$numberDouble": "1.5" },
+            "price": { "$numberDecimal": "3.14" },
+        });
+        let doc = json_filter_to_document(&filter).unwrap();
+
+        assert_eq!(doc.get("score"), Some(&Bson::Int32(5)));
+        assert_eq!(doc.get("ratio"), Some(&Bson::Double(1.5)));
+        let expected_decimal: mongodb::bson::Decimal128 = "3.14".parse().unwrap();
+        assert_eq!(doc.get("price"), Some(&Bson::Decimal128(expected_decimal)));
+    }
+
+    #[test]
+    fn json_filter_to_document_decodes_number_wrappers_inside_operators() {
+        // Range and $in operands must decode too, exactly like extended JSON
+        // dates: { score: { $gte: {"$numberInt": "5"} } } would otherwise
+        // compare against a sub-document and silently match nothing.
+        let filter = serde_json::json!({
+            "score": { "$gte": { "$numberInt": "5" } },
+            "tags": { "$in": [{ "$numberDecimal": "3.14" }, { "$numberDouble": "1.5" }] },
+        });
+        let doc = json_filter_to_document(&filter).unwrap();
+
+        let Some(Bson::Document(score)) = doc.get("score") else {
+            panic!("expected score operator document");
+        };
+        assert_eq!(score.get("$gte"), Some(&Bson::Int32(5)));
+
+        let Some(Bson::Document(tags)) = doc.get("tags") else {
+            panic!("expected tags operator document");
+        };
+        let Some(Bson::Array(values)) = tags.get("$in") else {
+            panic!("expected tags $in array");
+        };
+        let expected_decimal: mongodb::bson::Decimal128 = "3.14".parse().unwrap();
+        assert_eq!(values.first(), Some(&Bson::Decimal128(expected_decimal)));
+        assert_eq!(values.get(1), Some(&Bson::Double(1.5)));
     }
 
     #[test]

--- a/packages/app-tests/mongoCompletion.test.ts
+++ b/packages/app-tests/mongoCompletion.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
 import { test } from "vitest";
 import { buildMongoCompletionItems, getMongoCompletionContext, getMongoCompletionResultValidFor, inferMongoCompletionFields, shouldAutoOpenMongoCompletion } from "../../apps/desktop/src/lib/mongo/mongoCompletion.ts";
-import { ACCUMULATORS, EXPRESSION_OPERATORS, PIPELINE_STAGES, PUSH_MODIFIERS, QUERY_OPERATORS, STAGE_OPTION_KEYS, UPDATE_OPERATORS, VALUE_SNIPPETS } from "../../apps/desktop/src/lib/mongo/mongoCompletionTables.ts";
+import { ACCUMULATORS, EXPRESSION_OPERATORS, EXTENDED_JSON_VALUES, PIPELINE_STAGES, PUSH_MODIFIERS, QUERY_OPERATORS, STAGE_OPTION_KEYS, UPDATE_OPERATORS, VALUE_SNIPPETS } from "../../apps/desktop/src/lib/mongo/mongoCompletionTables.ts";
 
 const collections = ["users", "user_events", "order-items", "audit.logs"];
 const fields = [
@@ -210,6 +210,49 @@ test("suggests query operators inside field value objects", () => {
     items.some((item) => item.label === "name"),
     false,
   );
+});
+
+test("suggests extended JSON wrappers in value positions", () => {
+  const apply = (text: string, label: string) => buildMongoCompletionItems(text, text.length, { fields }).find((item) => item.label === label)?.apply;
+
+  // A bare value gets the braces added; inside `{` the wrapper body is enough.
+  assert.equal(apply("db.users.find({ _id: $o", "$oid"), '{ $oid: "${id}" }');
+  assert.equal(apply("db.users.find({ _id: { $oi", "$oid"), '$oid: "${id}"');
+  assert.equal(apply("db.users.updateOne({}, { $set: { seen: $d", "$date"), '{ $date: "${date}" }');
+  assert.equal(apply("db.users.insertOne({ key: $u", "$uuid"), '{ $uuid: "${uuid}" }');
+
+  // Query operators stay available alongside the wrappers under a field.
+  const under = buildMongoCompletionItems("db.users.find({ _id: { $", "db.users.find({ _id: { $".length, { fields });
+  assert.ok(under.find((item) => item.label === "$gt"));
+  assert.ok(under.find((item) => item.label === "$oid"));
+
+  // The most common wrappers sort first at a bare `$`.
+  const bare = buildMongoCompletionItems("db.users.find({ _id: $", "db.users.find({ _id: $".length, { fields });
+  assert.deepEqual(
+    bare.slice(0, 2).map((item) => item.label),
+    ["$date", "$oid"],
+  );
+});
+
+test("treats $in, $nin and $all elements as values rather than sub-filters", () => {
+  const labels = (text: string) => buildMongoCompletionItems(text, text.length, { fields }).map((item) => item.label);
+
+  assert.ok(labels("db.users.find({ _id: { $in: [").includes("ObjectId"));
+  assert.ok(labels("db.users.find({ _id: { $in: [{ $o").includes("$oid"));
+  assert.equal(labels("db.users.find({ _id: { $in: [{ $o").includes("_id"), false);
+  assert.ok(labels("db.users.find({ tags: { $all: [").includes("ObjectId"));
+  assert.equal(labels('db.users.find({ _id: { $in: ["').length, 0);
+
+  // `$or` / `$and` arrays still hold sub-filters, so their objects complete fields.
+  assert.ok(labels("db.users.find({ $or: [{ ").includes("name"));
+  assert.equal(labels("db.users.find({ $or: [{ ").includes("$oid"), false);
+});
+
+test("offers the newer shell value constructors", () => {
+  const labels = buildMongoCompletionItems("db.users.find({ _id: ", "db.users.find({ _id: ".length, { fields }).map((item) => item.label);
+  for (const constructor of ["NumberInt", "NumberDecimal", "UUID", "BinData", "Timestamp", "MinKey", "MaxKey"]) {
+    assert.ok(labels.includes(constructor), constructor);
+  }
 });
 
 test("suggests query and update operators", () => {
@@ -454,7 +497,7 @@ test("ranks everyday operators above the long tail", () => {
 });
 
 test("snippet templates use placeholder syntax CodeMirror actually honours", () => {
-  const templates = [...QUERY_OPERATORS, ...UPDATE_OPERATORS, ...PUSH_MODIFIERS, ...PIPELINE_STAGES, ...ACCUMULATORS, ...EXPRESSION_OPERATORS, ...VALUE_SNIPPETS, ...Object.values(STAGE_OPTION_KEYS).flat()];
+  const templates = [...QUERY_OPERATORS, ...UPDATE_OPERATORS, ...PUSH_MODIFIERS, ...PIPELINE_STAGES, ...ACCUMULATORS, ...EXPRESSION_OPERATORS, ...VALUE_SNIPPETS, ...EXTENDED_JSON_VALUES, ...Object.values(STAGE_OPTION_KEYS).flat()];
   assert.ok(templates.length > 200);
 
   for (const { label, apply } of templates) {


### PR DESCRIPTION
## Problem

The editor never suggests the extended JSON spellings of BSON values, even though the parser and driver accept them. Typing `$` in a value position goes silent right as you spell what you want:

| you type | suggestions |
| --- | --- |
| `db.c.find({_id: $` | *(none)* |
| `db.c.find({_id: {$oi` | *(none)* |
| `db.c.find({_id: {$in: [` | *(none)* |
| `db.c.find({_id: {$in: [{$` | *(none)* |

`{_id: {$oid: "…"}}` is valid and runs, but there is no way to discover it. `$in` is the worst case: it is the usual place to paste a list of ids, and it gets no help at all — the classifier treats its array like `$and` / `$or`, whose elements are sub-filters, so it offers field names for what are actually values.

The shell-constructor snippets are also stale: `NumberInt`, `NumberDecimal`, `UUID`, `BinData`, `Timestamp`, `MinKey` and `MaxKey` all parse since #8694 and #8861 but are never offered.

## Change

**A table of extended JSON wrappers** (`$oid`, `$date`, `$uuid`, `$binary`, `$timestamp`, `$numberLong`, …), offered wherever a value can go:

- in a bare value position the braces are added for you: `{_id: $o` → `{ $oid: "…" }`
- inside a `{` the body is enough: `{_id: {$oi` → `$oid: "…"`
- under a field, alongside the query operators, since `{_id: {$oid: …}}` is as valid there as `{_id: {$gt: …}}`
- in update `$set` values and insert documents, which share the value position

`$oid` and `$date` get the existing common-operator boost, so they sort first at a bare `$` rather than `$binary`.

**`$in`, `$nin` and `$all` arrays hold values.** Their elements now complete like any value, and an object inside them completes as a wrapper. `$and` / `$or` / `$nor` are unchanged and still complete fields.

**The shell-constructor snippets catch up with the parser**: the seven constructors above are now offered.

## Testing

- `pnpm test` — 13899 passed
- `pnpm typecheck`, `oxlint`, `oxfmt` clean
- Three new tests: braced vs. bare wrapper insertion across find/update/insert, operators and wrappers coexisting under a field, `$oid`/`$date` sorting first; `$in`/`$nin`/`$all` as values with `$or` still completing fields and nothing offered inside a string; the seven constructors present
- The new table is included in the existing placeholder-syntax sweep

Not in scope, deliberately: `QUERY_OPERATORS` is still one flat list, so `{_id: {$o` also offers `$or` (invalid there) and a top-level `{$` offers nothing. That is a separate position-awareness change and would be its own PR.
