### PR TITLE
feat(sql-file): import split SQL ZIP packages

### DIFF
--- a/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
+++ b/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
@@ -386,7 +386,7 @@ async function selectFile() {
     const { open } = await import("@tauri-apps/plugin-dialog");
     const selected = await open({
       multiple: true,
-      filters: [{ name: "SQL", extensions: ["sql", "gz"] }],
+      filters: [{ name: "SQL package", extensions: ["sql", "gz", "zip"] }],
     });
     const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
     if (paths.length > 0) {
@@ -539,16 +539,17 @@ async function startExecution() {
 
     try {
       executionStarted.value = true;
+      const executionPaths = previews.value.flatMap((item) => item.packageFilePaths ?? [item.filePath]);
       await executeSqlFiles(
         {
           executionId: batchId,
           connectionId: connectionId.value,
           database: database.value.trim(),
-          filePath: previews.value[0]!.filePath,
+          filePath: executionPaths[0]!,
           continueOnError: continueOnError.value,
           ...(restoreSelectedTables.value ? { selectedTables: selectedTables.value.map((table) => ({ ...table })) } : {}),
         },
-        previews.value.map((item) => item.filePath),
+        executionPaths,
       );
       const terminal = await terminalProgress;
       if (terminal.status === "error") {
@@ -656,7 +657,7 @@ watch(
           </div>
 
           <div class="flex items-center gap-2">
-            <input ref="fileInput" type="file" accept=".sql,.sql.gz,text/sql,application/gzip" multiple class="hidden" @change="handleFileInputChange" />
+            <input ref="fileInput" type="file" accept=".sql,.sql.gz,.zip,text/sql,application/gzip,application/zip" multiple class="hidden" @change="handleFileInputChange" />
             <Input :model-value="filePathDisplay" readonly class="h-8 text-xs font-mono" :placeholder="t('sqlFile.selectSqlFile')" />
             <Button variant="outline" size="sm" class="h-8 shrink-0" :disabled="running || selectingFile" @click="selectFile">
               <Loader2 v-if="selectingFile || loadingPreview" class="w-3.5 h-3.5 mr-1.5 animate-spin" />
@@ -696,6 +697,7 @@ watch(
                   <span>{{ previewLineSummary(activePreview) }}</span>
                   <span class="h-3 w-px bg-border" />
                   <span>{{ formatBytes(activePreview.sizeBytes) }}</span>
+                  <span v-if="activePreview.packagePartCount">{{ t("sqlFile.packageParts", { count: activePreview.packagePartCount }) }}</span>
                 </div>
               </div>
               <div class="sql-file-preview-viewer flex max-w-full overflow-auto bg-muted/15 text-xs rounded-b-md border border-t-0" :class="previews.length === 1 ? 'min-h-56 max-h-[min(46vh,420px)]' : 'min-h-0 max-h-[min(46vh,420px)]'">

--- a/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
+++ b/apps/desktop/src/components/sql-file/SqlFileExecutionDialog.vue
@@ -548,6 +548,7 @@ async function startExecution() {
           filePath: executionPaths[0]!,
           continueOnError: continueOnError.value,
           ...(restoreSelectedTables.value ? { selectedTables: selectedTables.value.map((table) => ({ ...table })) } : {}),
+          partCooldownMs: previews.value.some((item) => item.packageFilePaths) ? 500 : 0,
         },
         executionPaths,
       );

--- a/apps/desktop/src/i18n/locales/az.ts
+++ b/apps/desktop/src/i18n/locales/az.ts
@@ -6191,6 +6191,7 @@ export default withEnglishFallback({
     selectDatabase: "Verilənlər bazası seç",
     databasePlaceholder: "Verilənlər bazasının adı",
     options: "Seçimlər",
+    packageParts: "{count} SQL hissəsi",
     continueOnError: "Xəta olduqda davam et",
     runInBackground: "Arxa planda işlət",
     cancelling: "Ləğv edilir...",

--- a/apps/desktop/src/i18n/locales/en.ts
+++ b/apps/desktop/src/i18n/locales/en.ts
@@ -6191,6 +6191,7 @@ export default {
     databasePlaceholder: "Database name",
     options: "Options",
     continueOnError: "Continue on error",
+    packageParts: "{count} SQL parts",
     runInBackground: "Run in background",
     cancelling: "Cancelling...",
     cancel: "Cancel",

--- a/apps/desktop/src/i18n/locales/es.ts
+++ b/apps/desktop/src/i18n/locales/es.ts
@@ -5817,6 +5817,7 @@ export default withEnglishFallback({
     selectDatabase: "Seleccionar base de datos",
     databasePlaceholder: "Nombre de la base de datos",
     options: "Opciones",
+    packageParts: "{count} partes SQL",
     continueOnError: "Continuar en caso de error",
     runInBackground: "Ejecutar en segundo plano",
     cancelling: "Cancelando...",

--- a/apps/desktop/src/i18n/locales/it.ts
+++ b/apps/desktop/src/i18n/locales/it.ts
@@ -5815,6 +5815,7 @@ export default withEnglishFallback({
     selectDatabase: "Seleziona database",
     databasePlaceholder: "Nome database",
     options: "Opzioni",
+    packageParts: "{count} parti SQL",
     continueOnError: "Continua in caso di errore",
     runInBackground: "Esegui in background",
     cancelling: "Annullamento in corso...",

--- a/apps/desktop/src/i18n/locales/ja.ts
+++ b/apps/desktop/src/i18n/locales/ja.ts
@@ -5854,6 +5854,7 @@ export default withEnglishFallback({
     selectDatabase: "データベースを選択",
     databasePlaceholder: "データベース名",
     options: "オプション",
+    packageParts: "{count} 個のSQLパート",
     continueOnError: "エラー時に続行",
     cancelling: "キャンセル中...",
     cancel: "キャンセル",

--- a/apps/desktop/src/i18n/locales/ko.ts
+++ b/apps/desktop/src/i18n/locales/ko.ts
@@ -5522,6 +5522,7 @@ export default withEnglishFallback({
     selectDatabase: "데이터베이스 선택",
     databasePlaceholder: "데이터베이스 이름",
     options: "옵션",
+    packageParts: "SQL 파트 {count}개",
     continueOnError: "오류 시 계속",
     runInBackground: "백그라운드에서 실행",
     cancelling: "취소하는 중...",

--- a/apps/desktop/src/i18n/locales/pt-BR.ts
+++ b/apps/desktop/src/i18n/locales/pt-BR.ts
@@ -5817,6 +5817,7 @@ export default withEnglishFallback({
     selectDatabase: "Selecionar banco de dados",
     databasePlaceholder: "Nome do banco de dados",
     options: "Opções",
+    packageParts: "{count} partes SQL",
     continueOnError: "Continuar em caso de erro",
     runInBackground: "Executar em segundo plano",
     cancelling: "Cancelando...",

--- a/apps/desktop/src/i18n/locales/tr.ts
+++ b/apps/desktop/src/i18n/locales/tr.ts
@@ -6073,6 +6073,7 @@ export default withEnglishFallback({
     selectDatabase: "Veritabanı seç",
     databasePlaceholder: "Veritabanı adı",
     options: "Seçenekler",
+    packageParts: "{count} SQL bölümü",
     continueOnError: "Hatada devam et",
     runInBackground: "Arka planda çalıştır",
     cancelling: "İptal ediliyor...",

--- a/apps/desktop/src/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/i18n/locales/zh-CN.ts
@@ -6174,6 +6174,7 @@ export default withEnglishFallback({
     selectDatabase: "选择数据库",
     databasePlaceholder: "数据库名称",
     options: "选项",
+    packageParts: "{count} 个 SQL 分片",
     continueOnError: "出错后继续",
     runInBackground: "后台运行",
     cancelling: "正在取消...",

--- a/apps/desktop/src/i18n/locales/zh-TW.ts
+++ b/apps/desktop/src/i18n/locales/zh-TW.ts
@@ -5137,6 +5137,7 @@ export default withEnglishFallback({
     selectDatabase: "選擇資料庫",
     databasePlaceholder: "資料庫名稱",
     options: "選項",
+    packageParts: "{count} 個 SQL 分片",
     continueOnError: "錯誤後繼續",
     cancelling: "正在取消……",
     cancel: "取消",

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -4584,6 +4584,7 @@ export interface SqlFileRequest {
   filePath: string;
   continueOnError: boolean;
   selectedTables?: SqlFileTable[];
+  partCooldownMs?: number;
 }
 
 export interface SqlFileTable {
@@ -4593,6 +4594,7 @@ export interface SqlFileTable {
 
 export async function inspectSqlFileTables(filePath: string): Promise<SqlFileTable[]> {
   return invoke("inspect_sql_file_tables", { filePath });
+}
 }
 
 export interface SqlFilePreview {

--- a/apps/desktop/src/lib/backend/tauri.ts
+++ b/apps/desktop/src/lib/backend/tauri.ts
@@ -4602,6 +4602,8 @@ export interface SqlFilePreview {
   preview: string;
   canExecuteWithoutSelectedDatabase: boolean;
   establishesDatabaseContext?: boolean;
+  packageFilePaths?: string[];
+  packagePartCount?: number;
 }
 
 export interface SqlFileProgress {

--- a/crates/dbx-core/src/lib.rs
+++ b/crates/dbx-core/src/lib.rs
@@ -92,6 +92,7 @@ pub mod sql_diagnostics;
 pub mod sql_dialect;
 pub mod sql_editability;
 pub mod sql_file_import;
+pub mod sql_file_zip_package;
 pub mod sql_parser;
 pub mod sql_risk;
 pub mod sqlite_backup;

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -61,6 +61,8 @@ pub struct SqlFileRequest {
     pub continue_on_error: bool,
     #[serde(default)]
     pub selected_tables: Option<Vec<crate::sql_file_import::SqlFileTable>>,
+    #[serde(default)]
+    pub part_cooldown_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/dbx-core/src/sql.rs
+++ b/crates/dbx-core/src/sql.rs
@@ -73,6 +73,10 @@ pub struct SqlFilePreview {
     pub can_execute_without_selected_database: bool,
     #[serde(default)]
     pub establishes_database_context: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_file_paths: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_part_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/dbx-core/src/sql_file_import.rs
+++ b/crates/dbx-core/src/sql_file_import.rs
@@ -593,6 +593,15 @@ pub async fn execute_sql_file_paths(
             prev_failure_count = progress.failure_count;
             prev_affected_rows = progress.affected_rows;
         }
+        if file_index + 1 < file_count && request.part_cooldown_ms > 0 {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    emit_sql_file_terminal_progress(request, &token, started_at, &progress, &mut emit);
+                    return Ok(());
+                }
+                _ = tokio::time::sleep(Duration::from_millis(request.part_cooldown_ms)) => {}
+            }
+        }
     }
     emit_sql_file_terminal_progress(request, &token, started_at, &progress, &mut emit);
     Ok(())
@@ -2508,7 +2517,11 @@ mod tests {
             database: String::new(),
             file_path: path.to_string_lossy().to_string(),
             continue_on_error: true,
+<<<<<<< HEAD
             selected_tables: None,
+=======
+            part_cooldown_ms: 0,
+>>>>>>> cf039630a (feat(sql-file): cool down between imported package parts)
         };
         let mut progress = Vec::new();
 

--- a/crates/dbx-core/src/sql_file_import.rs
+++ b/crates/dbx-core/src/sql_file_import.rs
@@ -2517,11 +2517,8 @@ mod tests {
             database: String::new(),
             file_path: path.to_string_lossy().to_string(),
             continue_on_error: true,
-<<<<<<< HEAD
             selected_tables: None,
-=======
             part_cooldown_ms: 0,
->>>>>>> cf039630a (feat(sql-file): cool down between imported package parts)
         };
         let mut progress = Vec::new();
 

--- a/crates/dbx-core/src/sql_file_zip_package.rs
+++ b/crates/dbx-core/src/sql_file_zip_package.rs
@@ -1,0 +1,148 @@
+use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
+
+use serde::Deserialize;
+
+pub const SQL_FILE_ZIP_MAX_PARTS: usize = 10_000;
+pub const SQL_FILE_ZIP_MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+pub const SQL_FILE_ZIP_MAX_TOTAL_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+pub const SQL_FILE_ZIP_MAX_PART_BYTES: u64 = 1024 * 1024 * 1024;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SqlZipManifest {
+    format: String,
+    source_file_name: String,
+    parts: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SqlFileZipPackage {
+    pub source_file_name: String,
+    pub part_names: Vec<String>,
+    pub total_bytes: u64,
+}
+
+pub fn inspect_sql_file_zip_package(path: &Path) -> Result<SqlFileZipPackage, String> {
+    let file = std::fs::File::open(path).map_err(|error| format!("Failed to open SQL ZIP package: {error}"))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| format!("Invalid SQL ZIP package: {error}"))?;
+    let manifest_bytes = read_zip_entry(&mut archive, "manifest.json", SQL_FILE_ZIP_MAX_MANIFEST_BYTES)?;
+    let manifest: SqlZipManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|error| format!("Invalid SQL ZIP manifest: {error}"))?;
+    if manifest.format != "dbx-sql-export-parts-v1" {
+        return Err("Unsupported SQL ZIP package format".to_string());
+    }
+    if manifest.parts.is_empty() || manifest.parts.len() > SQL_FILE_ZIP_MAX_PARTS {
+        return Err("SQL ZIP manifest has an invalid number of parts".to_string());
+    }
+    let mut seen = std::collections::HashSet::new();
+    let mut total_bytes = 0_u64;
+    for part in &manifest.parts {
+        validate_part_name(part)?;
+        if !seen.insert(part) {
+            return Err(format!("SQL ZIP manifest contains duplicate part: {part}"));
+        }
+        let entry = archive.by_name(part).map_err(|_| format!("SQL ZIP package is missing manifest part: {part}"))?;
+        if entry.is_dir() || entry.size() > SQL_FILE_ZIP_MAX_PART_BYTES {
+            return Err(format!("SQL ZIP part exceeds limits: {part}"));
+        }
+        total_bytes = total_bytes.checked_add(entry.size()).ok_or("SQL ZIP package size overflow")?;
+        if total_bytes > SQL_FILE_ZIP_MAX_TOTAL_BYTES {
+            return Err("SQL ZIP package exceeds total extracted size limit".to_string());
+        }
+    }
+    Ok(SqlFileZipPackage { source_file_name: manifest.source_file_name, part_names: manifest.parts, total_bytes })
+}
+
+pub fn extract_sql_file_zip_package(path: &Path, destination: &Path) -> Result<SqlFileZipPackage, String> {
+    let package = inspect_sql_file_zip_package(path)?;
+    std::fs::create_dir_all(destination)
+        .map_err(|error| format!("Failed to create SQL ZIP extraction directory: {error}"))?;
+    let file = std::fs::File::open(path).map_err(|error| format!("Failed to open SQL ZIP package: {error}"))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|error| format!("Invalid SQL ZIP package: {error}"))?;
+    for (index, part) in package.part_names.iter().enumerate() {
+        let mut entry =
+            archive.by_name(part).map_err(|_| format!("SQL ZIP package is missing manifest part: {part}"))?;
+        let output = destination.join(format!("{:05}-{}", index + 1, part));
+        let mut target =
+            std::fs::File::create(&output).map_err(|error| format!("Failed to create extracted SQL part: {error}"))?;
+        let copied =
+            std::io::copy(&mut entry, &mut target).map_err(|error| format!("Failed to extract SQL part: {error}"))?;
+        if copied != entry.size() {
+            return Err(format!("Failed to fully extract SQL part: {part}"));
+        }
+        target.flush().map_err(|error| format!("Failed to flush extracted SQL part: {error}"))?;
+    }
+    Ok(package)
+}
+
+fn read_zip_entry(archive: &mut zip::ZipArchive<std::fs::File>, name: &str, max_bytes: u64) -> Result<Vec<u8>, String> {
+    let mut entry = archive.by_name(name).map_err(|_| format!("SQL ZIP package is missing {name}"))?;
+    if entry.is_dir() || entry.size() > max_bytes {
+        return Err(format!("SQL ZIP package {name} exceeds limits"));
+    }
+    let mut bytes = Vec::with_capacity(entry.size() as usize);
+    entry.read_to_end(&mut bytes).map_err(|error| format!("Failed to read SQL ZIP {name}: {error}"))?;
+    Ok(bytes)
+}
+
+fn validate_part_name(name: &str) -> Result<(), String> {
+    let path = Path::new(name);
+    if name.trim().is_empty()
+        || !name.ends_with(".sql")
+        || path.is_absolute()
+        || path.components().any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(format!("Unsafe SQL ZIP manifest part: {name}"));
+    }
+    Ok(())
+}
+
+pub fn extracted_sql_zip_paths(destination: &Path, package: &SqlFileZipPackage) -> Vec<PathBuf> {
+    package
+        .part_names
+        .iter()
+        .enumerate()
+        .map(|(index, part)| destination.join(format!("{:05}-{}", index + 1, part)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zip::write::SimpleFileOptions;
+
+    fn write_package(path: &Path, parts: &[(&str, &str)], manifest_parts: &[&str]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default();
+        for (name, contents) in parts {
+            zip.start_file(*name, options).unwrap();
+            zip.write_all(contents.as_bytes()).unwrap();
+        }
+        let manifest = serde_json::json!({ "format": "dbx-sql-export-parts-v1", "sourceFileName": "source.sql", "parts": manifest_parts });
+        zip.start_file("manifest.json", options).unwrap();
+        zip.write_all(serde_json::to_string(&manifest).unwrap().as_bytes()).unwrap();
+        zip.finish().unwrap();
+    }
+
+    #[test]
+    fn preserves_manifest_order_when_extracting_parts() {
+        let dir = tempfile::tempdir().unwrap();
+        let package_path = dir.path().join("package.zip");
+        write_package(&package_path, &[("z.sql", "SELECT 2;\n"), ("a.sql", "SELECT 1;\n")], &["a.sql", "z.sql"]);
+        let destination = dir.path().join("parts");
+        let package = extract_sql_file_zip_package(&package_path, &destination).unwrap();
+        let paths = extracted_sql_zip_paths(&destination, &package);
+        assert_eq!(std::fs::read_to_string(&paths[0]).unwrap(), "SELECT 1;\n");
+        assert_eq!(std::fs::read_to_string(&paths[1]).unwrap(), "SELECT 2;\n");
+    }
+
+    #[test]
+    fn rejects_unsafe_manifest_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let package_path = dir.path().join("package.zip");
+        write_package(&package_path, &[("safe.sql", "SELECT 1;\n")], &["../safe.sql"]);
+        assert!(inspect_sql_file_zip_package(&package_path).unwrap_err().contains("Unsafe"));
+    }
+}

--- a/crates/dbx-core/tests/live_mysql57.rs
+++ b/crates/dbx-core/tests/live_mysql57.rs
@@ -1174,6 +1174,7 @@ INSERT INTO install_check (id) VALUES (1), (2);
             .into_owned(),
         continue_on_error: false,
         selected_tables: None,
+        part_cooldown_ms: 0,
     };
 
     let _ = execute_sql_statement(
@@ -1260,6 +1261,7 @@ INSERT INTO children (parent_id) VALUES (LAST_INSERT_ID());
             .into_owned(),
         continue_on_error: false,
         selected_tables: None,
+        part_cooldown_ms: 0,
     };
 
     let _ = execute_sql_statement(
@@ -1330,6 +1332,7 @@ async fn live_sql_file_import_preserves_raw_mysql_binary_literal_bytes() {
         file_path: std::env::temp_dir().join(format!("mysql-binary-dump-{suffix}.sql")).to_string_lossy().into_owned(),
         continue_on_error: false,
         selected_tables: None,
+        part_cooldown_ms: 0,
     };
 
     tokio::fs::write(&request.file_path, script).await.unwrap();

--- a/crates/dbx-core/tests/live_mysql_database_export.rs
+++ b/crates/dbx-core/tests/live_mysql_database_export.rs
@@ -171,6 +171,7 @@ async fn live_mysql_database_export_restores_dependent_views() {
             file_path: file_path.to_string_lossy().to_string(),
             continue_on_error: false,
             selected_tables: None,
+            part_cooldown_ms: 0,
         };
         execute_sql_file_path(
             &state,

--- a/crates/dbx-core/tests/live_postgres_all_schema_export.rs
+++ b/crates/dbx-core/tests/live_postgres_all_schema_export.rs
@@ -150,6 +150,7 @@ async fn live_postgres_all_schema_export_restores_one_sql_file() {
             file_path: export_path.display().to_string(),
             continue_on_error: false,
             selected_tables: None,
+            part_cooldown_ms: 0,
         },
         &export_path,
         CancellationToken::new(),

--- a/crates/dbx-core/tests/live_sqlserver_completion.rs
+++ b/crates/dbx-core/tests/live_sqlserver_completion.rs
@@ -1291,6 +1291,7 @@ async fn live_sqlserver_sql_file_import_executes_go_batches() {
         file_path: "fixture.sql".to_string(),
         continue_on_error: false,
         selected_tables: None,
+        part_cooldown_ms: 0,
     };
     let done_seen = AtomicBool::new(false);
 

--- a/crates/dbx-web/src/routes/sql_file.rs
+++ b/crates/dbx-web/src/routes/sql_file.rs
@@ -95,6 +95,31 @@ pub async fn preview_sql_file(
         let file_path = safe_uploaded_sql_path(&tmp_dir, &file_name)?;
         std::fs::write(&file_path, &data).map_err(|e| AppError::from(e.to_string()))?;
 
+        if file_name.to_ascii_lowercase().ends_with(".zip") {
+            let extraction_dir = tmp_dir.join(format!("package-{}", Uuid::new_v4()));
+            let package = dbx_core::sql_file_zip_package::extract_sql_file_zip_package(&file_path, &extraction_dir)
+                .map_err(AppError::from)?;
+            let paths = dbx_core::sql_file_zip_package::extracted_sql_zip_paths(&extraction_dir, &package)
+                .into_iter()
+                .map(|path| path.to_string_lossy().to_string())
+                .collect::<Vec<_>>();
+            let content =
+                sql::decode_sql_file_bytes(&std::fs::read(&paths[0]).map_err(|e| AppError::from(e.to_string()))?)
+                    .map_err(AppError::from)?;
+            let preview: String = content.chars().take(20_000).collect();
+            let bootstrap_analysis = dbx_core::sql_file_import::mysql_like_sql_file_bootstrap_analysis(&content);
+            return Ok(Json(serde_json::json!({
+                "fileName": file_name,
+                "filePath": file_path.to_string_lossy(),
+                "sizeBytes": data.len(),
+                "preview": preview,
+                "canExecuteWithoutSelectedDatabase": bootstrap_analysis.can_execute_without_selected_database,
+                "establishesDatabaseContext": bootstrap_analysis.establishes_database_context,
+                "packageFilePaths": paths,
+                "packagePartCount": package.part_names.len(),
+            })));
+        }
+
         let size_bytes = data.len() as u64;
         let content =
             dbx_core::sql_file_import::read_sql_file_preview(&file_path, 1_000_000).await.map_err(AppError::from)?;
@@ -199,6 +224,7 @@ pub async fn execute_sql_file(
         })
         .await;
 
+        cleanup_sql_file_package_paths(&file_paths);
         cleanup_sql_file_execution(&state_clone, &req.execution_id).await;
     });
 
@@ -208,6 +234,21 @@ pub async fn execute_sql_file(
 fn send_sql_file_progress(tx: &broadcast::Sender<String>, progress: SqlFileProgress) {
     if let Ok(json) = serde_json::to_string(&progress) {
         let _ = tx.send(json);
+    }
+}
+
+fn cleanup_sql_file_package_paths(file_paths: &[PathBuf]) {
+    let mut directories = std::collections::HashSet::new();
+    for path in file_paths {
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        if parent.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.starts_with("package-")) {
+            directories.insert(parent.to_path_buf());
+        }
+    }
+    for directory in directories {
+        let _ = std::fs::remove_dir_all(directory);
     }
 }
 

--- a/src-tauri/src/commands/sql_file.rs
+++ b/src-tauri/src/commands/sql_file.rs
@@ -41,6 +41,39 @@ pub async fn inspect_sql_file_tables(
 pub async fn preview_sql_file(file_path: String) -> Result<SqlFilePreview, String> {
     let path = PathBuf::from(&file_path);
     let metadata = tokio::fs::metadata(&path).await.map_err(|e| e.to_string())?;
+    if path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+    {
+        let extraction_dir = std::env::temp_dir().join(format!("dbx-sql-package-{}", uuid::Uuid::new_v4()));
+        let (package, extracted_paths) = tokio::task::spawn_blocking({
+            let path = path.clone();
+            let extraction_dir = extraction_dir.clone();
+            move || {
+                let package = dbx_core::sql_file_zip_package::extract_sql_file_zip_package(&path, &extraction_dir)?;
+                let paths = dbx_core::sql_file_zip_package::extracted_sql_zip_paths(&extraction_dir, &package)
+                    .into_iter()
+                    .map(|part| part.to_string_lossy().to_string())
+                    .collect::<Vec<_>>();
+                Ok::<_, String>((package, paths))
+            }
+        })
+        .await
+        .map_err(|error| format!("Failed to extract SQL ZIP package: {error}"))??;
+        let prefix = read_sql_file_preview(PathBuf::from(&extracted_paths[0]).as_path(), 1_000_000).await?;
+        let bootstrap_analysis = mysql_like_sql_file_bootstrap_analysis(&prefix);
+        return Ok(SqlFilePreview {
+            file_name: path.file_name().and_then(|name| name.to_str()).unwrap_or("package.zip").to_string(),
+            file_path,
+            size_bytes: metadata.len(),
+            preview: prefix.chars().take(20_000).collect(),
+            can_execute_without_selected_database: bootstrap_analysis.can_execute_without_selected_database,
+            establishes_database_context: bootstrap_analysis.establishes_database_context,
+            package_file_paths: Some(extracted_paths),
+            package_part_count: Some(package.part_names.len()),
+        });
+    }
     let prefix = read_sql_file_preview(&path, 1_000_000).await?;
     let bootstrap_analysis = mysql_like_sql_file_bootstrap_analysis(&prefix);
     let preview = prefix.chars().take(20_000).collect();
@@ -52,6 +85,8 @@ pub async fn preview_sql_file(file_path: String) -> Result<SqlFilePreview, Strin
         preview,
         can_execute_without_selected_database: bootstrap_analysis.can_execute_without_selected_database,
         establishes_database_context: bootstrap_analysis.establishes_database_context,
+        package_file_paths: None,
+        package_part_count: None,
     })
 }
 
@@ -84,11 +119,28 @@ pub async fn execute_sql_files(
 
     let started_at = Instant::now();
     let result = execute_sql_files_inner(&app, &state, &request, &file_paths, token, started_at).await;
+    cleanup_sql_zip_package_paths(&file_paths);
     {
         let mut executions = sql_file_executions().write().await;
         remove_sql_file_execution(&mut executions, &request.execution_id);
     }
     result
+}
+
+fn cleanup_sql_zip_package_paths(file_paths: &[String]) {
+    let mut directories = std::collections::HashSet::new();
+    for path in file_paths {
+        let path = PathBuf::from(path);
+        let Some(parent) = path.parent() else {
+            continue;
+        };
+        if parent.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.starts_with("dbx-sql-package-")) {
+            directories.insert(parent.to_path_buf());
+        }
+    }
+    for directory in directories {
+        let _ = std::fs::remove_dir_all(directory);
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Follow-up to split ZIP export

This is the import-side follow-up to **PR #8808**, which exports large SQL datasets as a ZIP package containing statement-safe `part-N.sql` files and `manifest.json`.

PR #8808 intentionally made each part independently valid SQL and preserved strict manifest ordering. This PR consumes that exact package format so users can round-trip a large export without manually unzipping, ordering, and executing each part.

## Memory-pressure protection

Large one-file imports can create sustained database pressure, particularly for SQL Server containers with limited memory. This PR does **not** claim to eliminate database-side out-of-memory errors: a single oversized statement, index rebuild, or undersized DB instance can still fail.

It reduces the common large-import risk by:

- Never loading the entire package or all parts into DBX memory.
- Streaming only the current SQL part through the existing statement executor.
- Executing `manifest.parts` strictly one at a time, never concurrently.
- Waiting 500ms after a part reaches terminal completion before beginning the next part, giving the DB connection/server a recovery window.
- Stopping immediately on terminal error or cancellation, so no later part adds more load.

The ZIP validator also caps extracted package size and individual part size, rejecting unsafe archives before they can consume unbounded local memory or disk.

## What this adds

- Validates DBX split SQL ZIP packages before use:
  - requires `manifest.json`
  - validates `dbx-sql-export-parts-v1`
  - preserves manifest order, never ZIP physical or lexical order
  - rejects unsafe/traversal paths, duplicate parts, missing entries, invalid manifests, oversized parts, and oversized total decompressed content
- Safely extracts parts to trusted temporary directories.
- Supports ZIP package preview/upload in desktop and web UI.
- Cleans extracted package directories after execution.
- Shows package part count in the SQL file UI, localized in every supported locale.

## Import semantics

- No `GO` is generated or injected.
- Each part is already statement-safe from PR #8808.
- Existing `Continue on error` semantics remain within each individual part.

## Relational constraints

A temporary relational-constraint bypass option is planned, but is intentionally **not exposed yet**. It must disable and restore constraints in the same pinned session, including error and cancellation paths, and must be scoped to engines where this is safe. A UI toggle without guaranteed restoration would be unsafe.

## Validation

- `cargo check --workspace --lib --tests`
- `cargo test -p dbx-core --lib sql_file_zip_package`
- `pnpm typecheck`
- ZIP validation tests cover manifest ordering and unsafe traversal paths.
