### PR TITLE
fix(editor): stop replaying stale format/compress requests on tab switch

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -1,3 +1,18 @@
+<script lang="ts">
+// Replay guard for the toolbar format/compress requests. The ids are global
+// monotonic counters shared by every tab, and ContentArea delivers them by
+// gating the inactive tab's prop back to `undefined`; returning to the tab
+// re-arms the same stale id on the reused editor instance (a replay, not a new
+// command). The cursors live at module scope — not in `<script setup>` — so
+// they also survive an editor unmount/remount (data-page switches), letting a
+// freshly mounted editor consume the stale id instead of replaying it. The
+// check is strictly monotonic (`>`), not `!==`: because ids are shared across
+// tabs, a lower id is always an already-handled request from an active tab
+// (delivery is same-tick), never a pending undelivered one.
+let lastHandledFormatRequestId = 0;
+let lastHandledCompressRequestId = 0;
+</script>
+
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount, onActivated, onDeactivated, watch, shallowRef, computed, nextTick } from "vue";
 import { AlignLeft, Camera, CaseLower, CaseSensitive, CaseUpper, ClipboardPaste, Code2, Download, Eye, FileCode, MessageSquareText, Minimize2, Pencil, PencilRuler, Play, Copy, List, Scissors, Search, Sparkles, Table2, TextSelect, Trash2 } from "@lucide/vue";
@@ -6909,15 +6924,21 @@ watch([() => props.tabId, () => props.modelValue], ([tabId, val], [prevTabId]) =
 
 watch(
   () => props.formatRequestId,
-  (val, oldVal) => {
-    if (val && val !== oldVal) formatCurrentSql();
+  (val) => {
+    if (val && val > lastHandledFormatRequestId) {
+      lastHandledFormatRequestId = val;
+      formatCurrentSql();
+    }
   },
 );
 
 watch(
   () => props.compressRequestId,
-  (val, oldVal) => {
-    if (val && val !== oldVal) compressCurrentSql();
+  (val) => {
+    if (val && val > lastHandledCompressRequestId) {
+      lastHandledCompressRequestId = val;
+      compressCurrentSql();
+    }
   },
 );
 

--- a/apps/desktop/src/components/editor/__tests__/QueryEditor.formatCompressRequestReplay.spec.ts
+++ b/apps/desktop/src/components/editor/__tests__/QueryEditor.formatCompressRequestReplay.spec.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+
+import { createApp, defineComponent, h, nextTick, reactive } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import QueryEditor from "@/components/editor/QueryEditor.vue";
+import { compressSqlText, formatSqlForEditing } from "@/lib/sql/sqlFormatter";
+import { DEFAULT_SQL_FORMATTER_SETTINGS } from "@/lib/sql/sqlFormatterConfig";
+
+// The request ids are per-kind global counters in App.vue, so ids keep
+// increasing for the lifetime of the process. The module-scope replay cursor in
+// QueryEditor.vue survives across the editor mounts in this file, so every test
+// must advance its ids monotonically (never reuse a smaller id) to mirror the
+// production counter.
+const ORIGINAL_SQL = "select id, name\nfrom users\nwhere id = 1";
+const COMPRESSED_SQL = compressSqlText(ORIGINAL_SQL, "mysql");
+const FORMATTED_SQL = await formatSqlForEditing(COMPRESSED_SQL, "mysql", DEFAULT_SQL_FORMATTER_SETTINGS);
+
+const cleanups: Array<() => void> = [];
+
+type EditorState = {
+  tabId: string;
+  modelValue: string;
+  formatRequestId: number | undefined;
+  compressRequestId: number | undefined;
+};
+
+const WAIT = { timeout: 5000, interval: 20 };
+
+function mountEditor(initial: { modelValue: string; tabId: string; formatRequestId?: number; compressRequestId?: number }) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const state = reactive<EditorState>({
+    tabId: initial.tabId,
+    modelValue: initial.modelValue,
+    formatRequestId: initial.formatRequestId,
+    compressRequestId: initial.compressRequestId,
+  });
+  const emits: string[] = [];
+  const root = defineComponent({
+    setup: () => () =>
+      h(QueryEditor, {
+        modelValue: state.modelValue,
+        tabId: state.tabId,
+        databaseType: "mysql",
+        dialect: "mysql",
+        formatDialect: "mysql",
+        autoFocus: false,
+        formatRequestId: state.formatRequestId,
+        compressRequestId: state.compressRequestId,
+        "onUpdate:modelValue": (value: string) => {
+          emits.push(value);
+          // Mirror the app: App.vue writes the emitted text back into the tab
+          // store, so the modelValue prop follows the editor document.
+          state.modelValue = value;
+        },
+      }),
+  });
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const app = createApp(root);
+  app.use(pinia);
+  app.use(createI18n({ legacy: false, locale: "en", messages: { en: {} }, missingWarn: false, fallbackWarn: false }));
+  app.mount(host);
+  cleanups.push(() => {
+    app.unmount();
+    host.remove();
+  });
+  return { state, emits, host, unmount: () => app.unmount() };
+}
+
+async function waitForEditor(host: HTMLElement) {
+  await vi.waitFor(() => {
+    expect(host.querySelector(".cm-editor")).not.toBeNull();
+  }, WAIT);
+}
+
+// Flush the watcher queue, the microtask queue and the timers the editor uses
+// for its async format path in one go.
+async function settle() {
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("QueryEditor format/compress request replay", () => {
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) cleanup();
+  });
+
+  it("does not replay the stale compress/format requests when the ids re-arm after a tab switch", async () => {
+    // Preconditions: the sample must be recompressible and format must produce
+    // a distinct multi-line document, otherwise the replay would be a no-op.
+    expect(COMPRESSED_SQL).not.toBe(ORIGINAL_SQL);
+    expect(FORMATTED_SQL).not.toBe(COMPRESSED_SQL);
+    expect(FORMATTED_SQL).toContain("\n");
+
+    const { state, emits, host } = mountEditor({ modelValue: ORIGINAL_SQL, tabId: "tab-a" });
+    await waitForEditor(host);
+
+    // Toolbar compress, then toolbar format, on the active tab.
+    state.compressRequestId = 1;
+    await vi.waitFor(() => expect(emits.at(-1)).toBe(COMPRESSED_SQL), WAIT);
+
+    state.formatRequestId = 1;
+    await vi.waitFor(() => expect(emits.at(-1)).toBe(FORMATTED_SQL), WAIT);
+
+    // Switch to another SQL file: ContentArea gates the inactive tab's request
+    // props back to undefined on the same reused editor instance.
+    state.tabId = "tab-b";
+    state.formatRequestId = undefined;
+    state.compressRequestId = undefined;
+    await settle();
+
+    // Switch back: the same stale ids re-arm, which is the replay trigger.
+    state.tabId = "tab-a";
+    state.formatRequestId = 1;
+    state.compressRequestId = 1;
+    await settle();
+    await settle();
+
+    // The replayed compress must not undo the user's later format.
+    expect(emits.at(-1)).toBe(FORMATTED_SQL);
+  });
+
+  it("still applies a genuinely new request id", async () => {
+    const { state, emits, host } = mountEditor({ modelValue: ORIGINAL_SQL, tabId: "tab-a" });
+    await waitForEditor(host);
+
+    state.compressRequestId = 2;
+    await vi.waitFor(() => expect(emits.at(-1)).toBe(COMPRESSED_SQL), WAIT);
+
+    state.formatRequestId = 2;
+    await vi.waitFor(() => expect(emits.at(-1)).toBe(FORMATTED_SQL), WAIT);
+  });
+
+  it("does not replay a stale id on a fresh mount", async () => {
+    const first = mountEditor({ modelValue: ORIGINAL_SQL, tabId: "tab-a" });
+    await waitForEditor(first.host);
+
+    first.state.formatRequestId = 3;
+    await vi.waitFor(() => expect(first.emits.at(-1)).toBe(FORMATTED_SQL), WAIT);
+    first.unmount();
+
+    // Data-page remount path: a new editor instance mounts while the global
+    // request still holds the stale id for this tab.
+    const second = mountEditor({ modelValue: COMPRESSED_SQL, tabId: "tab-a", formatRequestId: 3, compressRequestId: 3 });
+    await waitForEditor(second.host);
+    await settle();
+    await settle();
+
+    expect(second.emits).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem

Fixes #8827 

On a SQL editor tab, clicking **Compress** and then **Format** and then switching to
another SQL file tab and back silently reverted the format: the text collapsed back
to the compressed single line, and the tab was flipped dirty. Going back and forth
between the two tabs reproduced it on every round trip (alternating between the
formatted and compressed text, which made it look "unstable"). Switching to a data
page did *not* reproduce it.

Reported-by: QA repro (compress → format → switch to another SQL file → switch back)

### Root cause

Toolbar format/compress requests travel as global monotonic `{ id, tabId }` refs
(`formatSqlRequest` / `compressSqlRequest`) that are never cleared. `ContentArea`
delivers them to the editor gated on the active tab
(`formatSqlRequest?.tabId === activeTab.id ? formatSqlRequest.id : undefined`), so
switching away sets the prop to `undefined` and switching back re-arms the **same
stale id** on the same reused `QueryEditor` instance (query tabs share one editor;
documents are swapped per tab via `activateTabDocument`).

Both request watchers only guarded with `val !== oldVal`, so the stale re-arm
re-fired them. `compressCurrentSql` is fully synchronous and dispatched first;
`formatCurrentSql` suspends at its `await` and then bails on its stale-state guard
— so the replayed compress won and the user's format was silently undone (and
written back into the tab store, flipping the dirty marker).

This also explains the report's details: a data page unmounts the editor (fresh
instance → no watcher fire), and only the compress-then-format order leaves both
requests armed with a non-idempotent replay.

### Fix

Guard both request watchers with **module-scope monotonic last-handled cursors**:

```ts
if (val && val > lastHandledFormatRequestId) {
  lastHandledFormatRequestId = val;
  formatCurrentSql();
}
```

- Strictly monotonic `>` (not `!==`) because the ids are a single global counter
  shared by all tabs — a lower id is always an already-handled request, never a
  pending one (delivery is same-tick to the active tab's instance).
- **Module scope** (a plain `<script lang="ts">` block, matching
  `EditorGroupTabBar.vue`) rather than `<script setup>` so the cursor also survives
  editor unmount/remount: a remounted editor consumes the stale id instead of
  replaying it.

First-time compress/format via toolbar, the editor context menu (which calls these
actions directly and never went through the request refs), keyboard shortcuts, and
selection-scoped formatting are all unchanged.

### Testing

- New regression spec `QueryEditor.formatCompressRequestReplay.spec.ts` (real
  component, real prop oscillation mirroring the App → ContentArea → editor loop):
  - replay after tab switch-away-and-back must leave the formatted text intact —
    **fails on `main`**, passes with this fix (verified by reverting the fix in a
    dirty-tree run);
  - a genuinely greater id still fires (over-blocking guard);
  - a stale id preset on a fresh mount does not fire (data-page remount path).
- `editor` + `layout` suites: 53 files / 391 tests green; `vue-tsc` typecheck clean;
  `oxlint` / `oxfmt` clean.

### Notes for reviewers

- The one semantic change: a request id delivered while the editor view is not
  ready is now consumed without acting and will not be retried on tab return.
  Previously it *could* retry — that retry *was* the replay bug, so this corner is
  the intended behavior change.
- The replay-guard contract is documented in the task's spec notes so future
  toolbar actions added to this request plumbing inherit the same cursor pattern.