### PR TITLE
Fix：减少 Vim 模式方向键连续移动卡顿

### DIFF
--- a/apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
@@ -287,4 +287,54 @@ describe("currentStatementFrameLayer", () => {
 
     expect(layer).toHaveBeenCalledWith(expect.objectContaining({ above: true, class: "cm-db-currentStatementFrameLayer" }));
   });
+
+  it("does not rebuild the frame while the cursor stays in the same statement", () => {
+    const layer = vi.fn((config) => config);
+    const RectangleMarker = vi.fn();
+    const view = buildView(["SELECT 1;", "SELECT 2;"]);
+    const resolver = vi.fn(() => ({ from: 0, to: 8 }));
+    const config = currentStatementFrameLayer({ layer, RectangleMarker } as never, resolver) as unknown as {
+      markers: (currentView: typeof view) => unknown;
+      update: (update: { docChanged: boolean; selectionSet: boolean; viewportChanged: boolean; geometryChanged: boolean; transactions: never[]; view: typeof view }) => boolean;
+    };
+
+    config.markers(view);
+
+    expect(
+      config.update({
+        docChanged: false,
+        selectionSet: true,
+        viewportChanged: false,
+        geometryChanged: false,
+        transactions: [],
+        view,
+      }),
+    ).toBe(false);
+    expect(resolver).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds the frame when the cursor enters another statement", () => {
+    const layer = vi.fn((config) => config);
+    const RectangleMarker = vi.fn();
+    const view = buildView(["SELECT 1;", "SELECT 2;"]);
+    let range = { from: 0, to: 8 };
+    const config = currentStatementFrameLayer({ layer, RectangleMarker } as never, () => range) as unknown as {
+      markers: (currentView: typeof view) => unknown;
+      update: (update: { docChanged: boolean; selectionSet: boolean; viewportChanged: boolean; geometryChanged: boolean; transactions: never[]; view: typeof view }) => boolean;
+    };
+
+    config.markers(view);
+    range = { from: 9, to: 17 };
+
+    expect(
+      config.update({
+        docChanged: false,
+        selectionSet: true,
+        viewportChanged: false,
+        geometryChanged: false,
+        transactions: [],
+        view,
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/desktop/src/lib/editor/codemirrorCurrentStatementFrameLayer.ts
+++ b/apps/desktop/src/lib/editor/codemirrorCurrentStatementFrameLayer.ts
@@ -151,6 +151,10 @@ interface CurrentStatementFrameModule {
  * returning null hides the frame.
  */
 export function currentStatementFrameLayer(viewModule: CurrentStatementFrameModule, resolve: StatementFrameResolver): Extension {
+  let lastRequest: StatementFrameRequest | null | undefined;
+
+  const sameRequest = (left: StatementFrameRequest | null | undefined, right: StatementFrameRequest | null): boolean => left === right || (!!left && !!right && left.from === right.from && left.to === right.to);
+
   return viewModule.layer({
     // Keep the outline above line decorations so opaque active-line colors
     // from editor themes cannot cover the frame border.
@@ -158,13 +162,25 @@ export function currentStatementFrameLayer(viewModule: CurrentStatementFrameModu
     class: "cm-db-currentStatementFrameLayer",
     markers(view) {
       const request = resolve(view);
+      lastRequest = request;
       if (!request || request.to < request.from) return [];
       const rect = currentStatementFrameRect(view, request.from, request.to);
       if (!rect) return [];
       return [new viewModule.RectangleMarker("cm-db-currentStatementFrame", rect.left, rect.top, rect.width, rect.height)];
     },
     update(update) {
-      return update.docChanged || update.selectionSet || update.viewportChanged || update.geometryChanged || update.transactions.some((transaction) => transaction.reconfigured);
+      if (update.docChanged || update.viewportChanged || update.geometryChanged || update.transactions.some((transaction) => transaction.reconfigured)) {
+        lastRequest = undefined;
+        return true;
+      }
+      if (!update.selectionSet) return false;
+
+      // Moving inside one statement does not change its frame. Avoid repeating
+      // the per-line DOM geometry probes for every auto-repeated key event.
+      const request = resolve(update.view);
+      if (sameRequest(lastRequest, request)) return false;
+      lastRequest = undefined;
+      return true;
     },
   });
 }


### PR DESCRIPTION
Fixes #8880

问题原因：Vim 模式下连续移动光标时，当前语句外框层会对每次 selection change 重新执行逐行 DOM 几何测量。SQL 较长或按键连发时，这些同步测量会阻塞编辑器事件处理，造成光标移动逐渐滞后。

本次改动缓存当前语句范围。同一语句内移动光标时复用已有外框，仅在跨语句、文档内容、视口或布局变化时重新计算，保留外框在必要场景下的刷新行为。

验证：
- 使用 issue 中的 SQL，在本地 0.6.10 开发客户端开启 Vim 模式并定位到末行
- macOS 下通过系统级真实按键事件长按 Up/Down 2 秒，光标可连续移动且未出现逐渐滞后；单步方向键和跨语句外框刷新正常
- pnpm exec vitest run apps/desktop/src/lib/__tests__/editor/currentStatementFrameLayer.spec.ts
- pnpm typecheck
- make dev-fast 构建通过

说明：issue 报告环境为 Linux AppImage，当前验证机器为 macOS，未将 macOS 结果表述为 Linux 同平台验证。