### PR TITLE
修复 Kingbase 数据传输时扫描不支持的模式对象

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -6299,13 +6299,11 @@ pub fn should_transfer_schema_objects(
         // Do not enter the PostgreSQL-family schema-object path just because the
         // request also carries the selected table kind. This matters for
         // Kingbase, whose catalog is not a drop-in PostgreSQL catalog.
-        return objects.iter().any(|selection| {
-            selection.object_type != TransferObjectKind::Table && !selection.names.is_empty()
-        });
+        return objects
+            .iter()
+            .any(|selection| selection.object_type != TransferObjectKind::Table && !selection.names.is_empty());
     }
-    if matches!(source_db_type, DatabaseType::Kingbase)
-        || matches!(target_db_type, DatabaseType::Kingbase)
-    {
+    if matches!(source_db_type, DatabaseType::Kingbase) || matches!(target_db_type, DatabaseType::Kingbase) {
         // Kingbase V8 does not expose every PostgreSQL pg_catalog relation used
         // by the optional object scanner. Empty selection means the legacy
         // table-transfer request here, so avoid probing unsupported catalogs.

--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -6295,7 +6295,21 @@ pub fn should_transfer_schema_objects(
         return false;
     }
     if !objects.is_empty() {
-        return true;
+        // A table-only selection is already handled by the table transfer pass.
+        // Do not enter the PostgreSQL-family schema-object path just because the
+        // request also carries the selected table kind. This matters for
+        // Kingbase, whose catalog is not a drop-in PostgreSQL catalog.
+        return objects.iter().any(|selection| {
+            selection.object_type != TransferObjectKind::Table && !selection.names.is_empty()
+        });
+    }
+    if matches!(source_db_type, DatabaseType::Kingbase)
+        || matches!(target_db_type, DatabaseType::Kingbase)
+    {
+        // Kingbase V8 does not expose every PostgreSQL pg_catalog relation used
+        // by the optional object scanner. Empty selection means the legacy
+        // table-transfer request here, so avoid probing unsupported catalogs.
+        return false;
     }
     transfer_object_family(source_db_type) == Some(TransferObjectFamily::Postgres)
         && transfer_object_family(target_db_type) == Some(TransferObjectFamily::Postgres)
@@ -10572,11 +10586,23 @@ mod tests {
                 &TransferContent::StructureOnly,
                 &[]
             ));
-            assert!(should_transfer_schema_objects(
+            assert!(!should_transfer_schema_objects(
                 &DatabaseType::Kingbase,
                 &DatabaseType::Postgres,
                 &TransferContent::StructureAndData,
                 &[]
+            ));
+            assert!(!should_transfer_schema_objects(
+                &DatabaseType::Kingbase,
+                &DatabaseType::Kingbase,
+                &TransferContent::StructureAndData,
+                &[TransferObjectSelection { object_type: TransferObjectKind::Table, names: vec!["orders".into()] }]
+            ));
+            assert!(should_transfer_schema_objects(
+                &DatabaseType::Kingbase,
+                &DatabaseType::Kingbase,
+                &TransferContent::StructureOnly,
+                &[TransferObjectSelection { object_type: TransferObjectKind::View, names: vec!["v_orders".into()] }]
             ));
             assert!(should_transfer_schema_objects(
                 &DatabaseType::Postgres,


### PR DESCRIPTION
## 变更概述

修复 Kingbase 表传输完成后仍进入 PostgreSQL schema objects 扫描的问题。Kingbase V8 不提供 DBX 对 PostgreSQL 对象扫描所依赖的部分 pg_catalog 关系，导致仅传输表时在对象阶段报 `pg_catalog.pg_attribute does not exist`。

- 仅选择表时跳过独立的 schema object 扫描；
- Kingbase 参与且未选择额外对象时跳过不兼容的目录探测；
- 保留显式选择视图等非表对象时的原有处理路径；
- 增加跨数据库类型选择矩阵测试。

## 验证

- `cargo test -p dbx-core --lib --no-default-features --features sqlite-bundled transfer::tests::transfer_cross_family_tests::should_transfer_schema_objects_matrix -- --exact`
- Kingbase V8 实例真实验证：从 `dbx_kingbase_demo.sales.issue_8471_orders` 传输到 `dbx_kingbase_demo2.sales.issue_8471_orders`，终态为 `done`，目标表及 3 行数据均校验通过。

Fixes #8471