### PR TITLE
修复 PostgreSQL 自增序列被重复创建

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -5969,7 +5969,7 @@ const POSTGRES_OWNED_SEQUENCES_SQL: &str = "SELECT c.relname, \
              JOIN pg_depend d ON d.classid = 'pg_class'::regclass \
                AND d.objid = c.oid \
                AND d.refclassid = 'pg_class'::regclass \
-               AND d.deptype IN ('a', 'i') \
+               AND d.deptype = 'a' \
              JOIN pg_class t ON t.oid = d.refobjid \
              JOIN pg_namespace tn ON tn.oid = t.relnamespace AND tn.nspname = n.nspname \
              JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid \
@@ -11428,11 +11428,11 @@ mod tests {
         fn postgres_owned_sequence_queries_support_pre_ten_catalogs() {
             assert!(!POSTGRES_OWNED_SEQUENCES_SQL.contains("pg_sequence"));
             assert!(!POSTGRES_SEQUENCE_SNAPSHOTS_SQL.contains("pg_sequence"));
-            for sql in [POSTGRES_OWNED_SEQUENCES_SQL, POSTGRES_SEQUENCE_SNAPSHOTS_SQL] {
-                assert!(sql.contains("c.relkind = 'S'"));
-                assert!(sql.contains("pg_depend"));
-                assert!(sql.contains("d.deptype IN ('a', 'i')"));
-            }
+            assert!(POSTGRES_OWNED_SEQUENCES_SQL.contains("c.relkind = 'S'"));
+            assert!(POSTGRES_OWNED_SEQUENCES_SQL.contains("pg_depend"));
+            assert!(POSTGRES_OWNED_SEQUENCES_SQL.contains("d.deptype = 'a'"));
+            assert!(!POSTGRES_OWNED_SEQUENCES_SQL.contains("d.deptype IN ('a', 'i')"));
+            assert!(POSTGRES_SEQUENCE_SNAPSHOTS_SQL.contains("d.deptype IN ('a', 'i')"));
         }
 
         #[test]


### PR DESCRIPTION
## 变更概述

修复 PostgreSQL 数据传输时，identity 序列同时从列依赖和独立序列对象路径恢复，导致目标表生成同名冲突序列的问题。

- 独立序列同步只处理 `pg_depend.deptype = 'a'` 的序列；
- `deptype = 'i'` 的 identity 序列由目标列的 identity 定义负责创建；
- 保留序列快照路径对 identity 序列的值同步；
- 增加 PostgreSQL 目录查询回归断言，避免重新把 identity 序列纳入独立序列路径。

## 验证

- `cargo test -p dbx-core --lib --no-default-features --features sqlite-bundled transfer::tests::transfer_postgres_executor_tests::postgres_owned_sequence_queries_support_pre_ten_catalogs -- --exact`
- PostgreSQL 16 实例对照验证：未修改主干传输后同时生成 `rules_id_seq`（`deptype='a'`）和 `rules_id_seq1`（`deptype='i'`）；修复后只保留实际使用的 `rules_id_seq1`，并在源序列值为 8 时完成结构+数据传输后执行默认插入成功，生成 id=9。

Fixes #8859