### PR TITLE
修复 Oracle 架构比较生成错误的删除索引语句

### DIFF
--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -6222,8 +6222,14 @@ mod tests {
 
     #[test]
     fn oracle_schema_sync_drops_indexes_without_if_exists() {
-        assert_eq!(drop_index_sql("orders", "idx_orders_status", DatabaseType::Oracle, Some("APP")), "DROP INDEX APP.IDX_ORDERS_STATUS;");
-        assert_eq!(drop_index_sql("orders", "idx_orders_status", DatabaseType::OceanbaseOracle, Some("APP")), "DROP INDEX APP.IDX_ORDERS_STATUS;");
+        assert_eq!(
+            drop_index_sql("orders", "idx_orders_status", DatabaseType::Oracle, Some("APP")),
+            "DROP INDEX APP.IDX_ORDERS_STATUS;"
+        );
+        assert_eq!(
+            drop_index_sql("orders", "idx_orders_status", DatabaseType::OceanbaseOracle, Some("APP")),
+            "DROP INDEX APP.IDX_ORDERS_STATUS;"
+        );
     }
 
     #[test]

--- a/crates/dbx-core/src/schema_diff.rs
+++ b/crates/dbx-core/src/schema_diff.rs
@@ -3954,6 +3954,12 @@ fn drop_index_sql(table_name: &str, index_name: &str, db_type: DatabaseType, sch
         return sqlserver_single_statement_batch(&batch);
     }
     let index = qualified_name(index_name, db_type, schema);
+    if matches!(db_type, DatabaseType::Oracle | DatabaseType::OceanbaseOracle) {
+        // Oracle versions before 23c do not support `DROP INDEX IF EXISTS`.
+        // Schema comparison already identified this index as present, so the
+        // direct form is both valid and sufficient for the generated script.
+        return format!("DROP INDEX {index};");
+    }
     if profile.drop_index_uses_on_table {
         format!("DROP INDEX {} ON {table};", quote_id(index_name, db_type))
     } else {
@@ -6212,6 +6218,12 @@ mod tests {
             target_dialect: Some(DialectKind::Mysql),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn oracle_schema_sync_drops_indexes_without_if_exists() {
+        assert_eq!(drop_index_sql("orders", "idx_orders_status", DatabaseType::Oracle, Some("APP")), "DROP INDEX APP.IDX_ORDERS_STATUS;");
+        assert_eq!(drop_index_sql("orders", "idx_orders_status", DatabaseType::OceanbaseOracle, Some("APP")), "DROP INDEX APP.IDX_ORDERS_STATUS;");
     }
 
     #[test]


### PR DESCRIPTION
## 变更概述

修复 Oracle/OceanBase Oracle 架构对比生成部署脚本时使用 `DROP INDEX IF EXISTS` 的问题。Oracle 18c 不支持该语法，而架构对比已经确认目标索引存在，因此可以直接删除。

- Oracle 和 OceanBase Oracle 使用 `DROP INDEX schema.index;`；
- 其他数据库继续沿用现有方言；
- 增加 Oracle 两种数据库类型的 SQL 生成测试。

## 验证

- `cargo test -p dbx-core --lib --no-default-features --features sqlite-bundled schema_diff::tests::oracle_schema_sync_drops_indexes_without_if_exists -- --exact`
- Oracle 18c 实例实测：`DROP INDEX IF EXISTS DBX_TEST.IDX_ISSUE8666` 返回 `ORA-00933`；生成的 `DROP INDEX DBX_TEST.IDX_ISSUE8666` 执行成功。

Fixes #8666