### PR TITLE
修复 SQL Server 覆盖传输时自增列写入失败

### DIFF
--- a/crates/dbx-core/src/transfer.rs
+++ b/crates/dbx-core/src/transfer.rs
@@ -1738,6 +1738,22 @@ pub(crate) fn wrap_dameng_identity_insert_sql_for_table(insert_sql: &str, full_t
     format!("SET IDENTITY_INSERT {full_table} ON;\n{trimmed};\nSET IDENTITY_INSERT {full_table} OFF;")
 }
 
+async fn execute_sqlserver_identity_batch(
+    client: &mut db::sqlserver::SqlServerClient,
+    sql: &str,
+    timeout: Option<std::time::Duration>,
+) -> Result<(), String> {
+    let future = db::sqlserver::execute_simple_batch_with_max_rows(client, sql, None);
+    let result: Vec<db::QueryResult> = match timeout {
+        Some(timeout) => tokio::time::timeout(timeout, future)
+            .await
+            .map_err(|_| format!("Query timed out after {} seconds", timeout.as_secs().max(1)))??,
+        None => future.await?,
+    };
+    drop(result);
+    Ok(())
+}
+
 async fn execute_transfer_write_statement(
     state: &AppState,
     target_pool_key: &str,
@@ -1754,6 +1770,52 @@ async fn execute_transfer_write_statement(
 
     let enable_sql = identity_insert_statement(table, schema, target_db_type, true);
     let disable_sql = identity_insert_statement(table, schema, target_db_type, false);
+
+    if *target_db_type == DatabaseType::SqlServer {
+        // SQL Server scopes IDENTITY_INSERT to the current session. The generic
+        // pool helper may check out a different physical connection for each
+        // statement, so keep all three statements on the same locked client.
+        crate::query::check_read_only_for_connection(state, target_pool_key, sql).await?;
+        let (_, _, _, query_timeout_secs) = transfer_pool_context(state, target_pool_key).await;
+        let query_timeout = query_timeout_duration(query_timeout_secs);
+        let pool_handle = state.pool_handle(target_pool_key).await;
+        let client = match pool_handle.as_ref() {
+            Some(PoolKind::SqlServer(client)) => client.clone(),
+            _ => return Err("SQL Server connection not found".to_string()),
+        };
+        let mut client = client.lock().await;
+
+        let enable_result = execute_sqlserver_identity_batch(&mut client, &enable_sql, query_timeout).await;
+        if let Err(error) = enable_result {
+            drop(client);
+            if is_transfer_query_timeout(&error) {
+                state.remove_pool_by_key(target_pool_key).await;
+            }
+            return Err(format!("Failed to enable IDENTITY_INSERT for {table}: {error}"));
+        }
+
+        let write_result = execute_sqlserver_identity_batch(&mut client, sql, query_timeout).await;
+        let disable_result = execute_sqlserver_identity_batch(&mut client, &disable_sql, query_timeout).await;
+        drop(client);
+
+        if write_result.as_ref().is_err_and(|error| is_transfer_query_timeout(error))
+            || disable_result.as_ref().is_err_and(|error| is_transfer_query_timeout(error))
+        {
+            state.remove_pool_by_key(target_pool_key).await;
+        }
+
+        return match (write_result, disable_result) {
+            (Ok(_), Ok(_)) => Ok(()),
+            (Err(write_error), Ok(_)) => Err(write_error),
+            (Ok(_), Err(disable_error)) => {
+                Err(format!("Failed to disable IDENTITY_INSERT for {table}: {disable_error}"))
+            }
+            (Err(write_error), Err(disable_error)) => {
+                Err(format!("{write_error}; also failed to disable IDENTITY_INSERT for {table}: {disable_error}"))
+            }
+        };
+    }
+
     execute_on_pool(state, target_pool_key, &enable_sql)
         .await
         .map_err(|e| format!("Failed to enable IDENTITY_INSERT for {table}: {e}"))?;

--- a/crates/dbx-core/tests/live_sqlserver_transfer.rs
+++ b/crates/dbx-core/tests/live_sqlserver_transfer.rs
@@ -286,6 +286,118 @@ async fn live_sqlserver_transfer_rebuild_releases_constraint_and_index_names() {
 
 #[tokio::test]
 #[ignore = "requires DBX_LIVE_SQLSERVER_HOST/PORT/USER/PASSWORD pointing at SQL Server"]
+async fn live_sqlserver_transfer_overwrite_handles_existing_identity_target() {
+    let database = std::env::var("DBX_LIVE_SQLSERVER_DATABASE").unwrap_or_else(|_| "dbx_sqlserver_demo".to_string());
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let connection_id = format!("live-sqlserver-8690-{suffix}");
+    let source_schema = format!("dbx_8690_src_{}", &suffix[..12]);
+    let target_schema = format!("dbx_8690_dst_{}", &suffix[..12]);
+    let table = "identity_rows";
+
+    let mut client = sqlserver_connect(&database).await;
+    for statement in [
+        format!("CREATE SCHEMA [{source_schema}]"),
+        format!("CREATE SCHEMA [{target_schema}]"),
+        format!(
+            "CREATE TABLE [{source_schema}].[{table}] (id INT IDENTITY(100,1) NOT NULL CONSTRAINT [PK_8690_src_{suffix}] PRIMARY KEY, name NVARCHAR(64) NOT NULL)"
+        ),
+        format!(
+            "CREATE TABLE [{target_schema}].[{table}] (id INT IDENTITY(1,1) NOT NULL CONSTRAINT [PK_8690_dst_{suffix}] PRIMARY KEY, name NVARCHAR(64) NOT NULL)"
+        ),
+        format!("INSERT INTO [{source_schema}].[{table}] (name) VALUES (N'first'), (N'second')"),
+        format!("INSERT INTO [{target_schema}].[{table}] (name) VALUES (N'stale')"),
+    ] {
+        dbx_core::db::sqlserver::execute_batch(&mut client, &statement)
+            .await
+            .expect("create issue #8690 fixtures");
+    }
+
+    let dir = std::env::temp_dir().join(format!("dbx-live-sqlserver-8690-{suffix}"));
+    std::fs::create_dir_all(&dir).expect("create issue #8690 directory");
+    let storage = Storage::open(&dir.join("storage.db")).await.expect("open issue #8690 storage");
+    let state = Arc::new(AppState::new(storage));
+    state
+        .configs
+        .write()
+        .await
+        .insert(connection_id.clone(), live_sqlserver_config(&connection_id, &database));
+    let pool_key = state
+        .get_or_create_pool(&connection_id, Some(&database))
+        .await
+        .expect("create SQL Server pool");
+    let request = TransferRequest {
+        transfer_id: format!("live-sqlserver-8690-transfer-{suffix}"),
+        source_connection_id: connection_id.clone(),
+        source_database: database.clone(),
+        source_schema: source_schema.clone(),
+        source_catalog: None,
+        target_connection_id: connection_id.clone(),
+        target_database: database.clone(),
+        target_schema: target_schema.clone(),
+        target_catalog: None,
+        tables: vec![table.to_string()],
+        create_table: true,
+        drop_target_before_create: false,
+        drop_target_confirmed: false,
+        content: TransferContent::default(),
+        objects: Vec::new(),
+        mode: TransferMode::Overwrite,
+        target_table_name_case: TransferTableNameCase::Preserve,
+        quote_target_column_names: true,
+        ownership_policy: TransferOwnershipPolicy::Preserve,
+        batch_size: 1,
+    };
+
+    let test_result = async {
+        let transferred = transfer_table(
+            &state,
+            &request,
+            table,
+            0,
+            &DatabaseType::SqlServer,
+            &DatabaseType::SqlServer,
+            &pool_key,
+            &pool_key,
+            &HashMap::new(),
+            &mut Vec::new(),
+            None,
+            |_| {},
+        )
+        .await?;
+        assert_eq!(transferred, 2);
+
+        let rows = dbx_core::db::sqlserver::execute_query(
+            &mut client,
+            &format!("SELECT id, name FROM [{target_schema}].[{table}] ORDER BY id"),
+        )
+        .await
+        .map_err(|error| format!("read transferred rows: {error}"))?;
+        assert_eq!(rows.rows.len(), 2);
+        assert_eq!(rows.rows[0][0].as_i64(), Some(100));
+        assert_eq!(rows.rows[1][0].as_i64(), Some(101));
+        assert_eq!(rows.rows[0][1].as_str(), Some("first"));
+        assert_eq!(rows.rows[1][1].as_str(), Some("second"));
+        Ok::<_, String>(())
+    }
+    .await;
+
+    let cleanup = dbx_core::db::sqlserver::execute_batch(
+        &mut client,
+        &format!(
+            "IF OBJECT_ID(N'[{target_schema}].[{table}]', N'U') IS NOT NULL DROP TABLE [{target_schema}].[{table}]; \
+             IF OBJECT_ID(N'[{source_schema}].[{table}]', N'U') IS NOT NULL DROP TABLE [{source_schema}].[{table}]; \
+             IF SCHEMA_ID(N'{target_schema}') IS NOT NULL DROP SCHEMA [{target_schema}]; \
+             IF SCHEMA_ID(N'{source_schema}') IS NOT NULL DROP SCHEMA [{source_schema}];"
+        ),
+    )
+    .await;
+    let _ = std::fs::remove_dir_all(dir);
+    cleanup.expect("cleanup issue #8690 fixtures");
+    test_result.expect("SQL Server overwrite transfer should preserve explicit identity values");
+}
+
+#[tokio::test]
+#[ignore = "requires DBX_LIVE_SQLSERVER_HOST/PORT/USER/PASSWORD pointing at SQL Server"]
 async fn live_sqlserver_keyset_pagination_copies_every_row() {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let source_db = format!("dbx_keyset_src_{}", &suffix[..12]);

--- a/crates/dbx-core/tests/live_sqlserver_transfer.rs
+++ b/crates/dbx-core/tests/live_sqlserver_transfer.rs
@@ -316,15 +316,8 @@ async fn live_sqlserver_transfer_overwrite_handles_existing_identity_target() {
     std::fs::create_dir_all(&dir).expect("create issue #8690 directory");
     let storage = Storage::open(&dir.join("storage.db")).await.expect("open issue #8690 storage");
     let state = Arc::new(AppState::new(storage));
-    state
-        .configs
-        .write()
-        .await
-        .insert(connection_id.clone(), live_sqlserver_config(&connection_id, &database));
-    let pool_key = state
-        .get_or_create_pool(&connection_id, Some(&database))
-        .await
-        .expect("create SQL Server pool");
+    state.configs.write().await.insert(connection_id.clone(), live_sqlserver_config(&connection_id, &database));
+    let pool_key = state.get_or_create_pool(&connection_id, Some(&database)).await.expect("create SQL Server pool");
     let request = TransferRequest {
         transfer_id: format!("live-sqlserver-8690-transfer-{suffix}"),
         source_connection_id: connection_id.clone(),


### PR DESCRIPTION
## 问题

关联 #8690。SQL Server 目标表已存在 `IDENTITY` 列时，覆盖传输会在写入阶段报 544：当 `IDENTITY_INSERT` 为 OFF 时不能插入 identity 列的显式值。

## 根因

传输流程原先通过连接池分别执行 `SET IDENTITY_INSERT ON`、INSERT 和 `SET IDENTITY_INSERT OFF`。`IDENTITY_INSERT` 是 SQL Server 会话级状态，连接池的多次取连接不能保证三个语句使用同一底层会话，因此 INSERT 可能仍处于 OFF 状态。

## 修复

SQL Server identity 写入改为锁定同一个客户端，并通过同一 TDS batch 会话依次执行开启、写入、关闭。其他数据库和普通写入路径保持不变；超时仍会释放异常连接，失败时仍会尝试关闭 identity 模式。

## 验证

- 真实 SQL Server 2022 Developer（SQL Server 2008 兼容级别之外的同引擎测试库）创建 source/target identity 表，覆盖传输成功，显式 identity 值 `100/101` 保留，旧目标行被替换。
- 原有真实 SQL Server 传输约束/索引重建回归用例通过。
- `cargo test -p dbx-core transfer::tests --lib`：267 passed。
- 新增忽略式真实库回归用例：`live_sqlserver_transfer_overwrite_handles_existing_identity_target`。
