### PR TITLE
fix: 清空积压失败时在确认弹框内显示错误

### DIFF
--- a/apps/desktop/src/components/mq/SubscriptionsPanel.vue
+++ b/apps/desktop/src/components/mq/SubscriptionsPanel.vue
@@ -60,6 +60,7 @@ const showDeleteDialog = ref(false);
 const deleting = ref(false);
 const clearBacklogTarget = ref<SubscriptionInfo>();
 const showClearBacklogDialog = ref(false);
+const clearBacklogError = ref<string>();
 const clearingBacklog = ref(false);
 
 const formData = ref({
@@ -440,6 +441,7 @@ function handleClearBacklog(sub: SubscriptionInfo) {
     return;
   }
   clearBacklogTarget.value = sub;
+  clearBacklogError.value = undefined;
   showClearBacklogDialog.value = true;
 }
 
@@ -450,13 +452,13 @@ async function confirmClearBacklog() {
   const topicRef = getPulsarTopicRef();
   if (!topicRef) return;
   clearingBacklog.value = true;
-  error.value = undefined;
+  clearBacklogError.value = undefined;
   try {
     await mqClearBacklog(props.connectionId, topicRef, sub.name);
     showClearBacklogDialog.value = false;
     await loadSubscriptions();
   } catch (e: unknown) {
-    error.value = formatError(e);
+    clearBacklogError.value = formatError(e);
   } finally {
     clearingBacklog.value = false;
   }
@@ -829,7 +831,11 @@ onBeforeUnmount(() => {
       :loading="clearingBacklog"
       :close-on-confirm="false"
       @confirm="confirmClearBacklog"
-    />
+    >
+      <template #options>
+        <div v-if="clearBacklogError" class="form-error" role="alert">{{ clearBacklogError }}</div>
+      </template>
+    </DangerConfirmDialog>
   </div>
 </template>
 

--- a/apps/desktop/src/components/mq/__tests__/SubscriptionsPanel.spec.ts
+++ b/apps/desktop/src/components/mq/__tests__/SubscriptionsPanel.spec.ts
@@ -27,7 +27,17 @@ vi.mock("@/composables/useMqMutationGuard", () => ({
 }));
 
 vi.mock("@/components/editor/DangerConfirmDialog.vue", () => ({
-  default: { template: "<div />" },
+  default: {
+    props: ["open", "title", "confirmLabel", "loading", "closeOnConfirm"],
+    emits: ["update:open", "confirm"],
+    template: `
+      <div v-if="open" role="dialog" :aria-label="title">
+        <slot name="options" />
+        <button :disabled="loading" @click="$emit('update:open', false)">dangerDialog.cancel</button>
+        <button :disabled="loading" @click="closeOnConfirm !== false && $emit('update:open', false); $emit('confirm')">{{ confirmLabel }}</button>
+      </div>
+    `,
+  },
 }));
 
 vi.mock("@/components/mq/rocketmq/RocketMqConsumerGroupDialogs.vue", () => ({
@@ -66,10 +76,12 @@ function buttonWithExactText(container: ParentNode, text: string): HTMLButtonEle
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function mountPanel(overrides: Record<string, unknown> = {}) {
@@ -82,6 +94,7 @@ async function mountPanel(overrides: Record<string, unknown> = {}) {
     namespace: "default",
     mqSystemKind: "kafka",
     supportsResetCursor: true,
+    supportsClearBacklog: true,
     supportsPeekMessages: true,
     ...overrides,
   });
@@ -202,6 +215,89 @@ describe("SubscriptionsPanel message peek", () => {
 
     expect(panel.textContent).toContain("payments message");
     expect(panel.textContent).not.toContain("orders message");
+  });
+});
+
+describe("SubscriptionsPanel clear backlog", () => {
+  async function openClearBacklog(panel: HTMLDivElement) {
+    buttonWithExactText(panel, "mqSubscriptions.clearBacklog").click();
+    await flushUi();
+    const dialog = panel.querySelector('[role="dialog"][aria-label="mqSubscriptions.clearBacklog"]');
+    expect(dialog).not.toBeNull();
+    return dialog!;
+  }
+
+  it("keeps a failed clear backlog open with the error in the dialog, not the panel", async () => {
+    backend.mqClearBacklog.mockRejectedValueOnce(new Error("Cannot clear an active consumer group"));
+    const panel = await mountPanel();
+    const dialog = await openClearBacklog(panel);
+
+    buttonWithExactText(dialog, "mqSubscriptions.clearBacklog").click();
+    await vi.waitFor(() => expect(dialog.querySelector(".form-error")?.textContent).toContain("Cannot clear an active consumer group"));
+
+    expect(backend.mqClearBacklog).toHaveBeenCalledExactlyOnceWith("mq-1", { tenant: "_kafka", namespace: "default", topic: "events", persistent: true, partitioned: false }, "orders-consumer");
+    expect(dialog.isConnected).toBe(true);
+    expect(buttonWithExactText(dialog, "mqSubscriptions.clearBacklog").disabled).toBe(false);
+    expect(panel.querySelector(".panel-error")).toBeNull();
+    expect(panel.querySelector(".subscriptions-table")?.textContent).toContain("orders-consumer");
+    expect(backend.mqListSubscriptions).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the previous error when the dialog is closed and reopened", async () => {
+    backend.mqClearBacklog.mockRejectedValueOnce(new Error("Previous clear backlog failed"));
+    const panel = await mountPanel();
+    const dialog = await openClearBacklog(panel);
+    buttonWithExactText(dialog, "mqSubscriptions.clearBacklog").click();
+    await vi.waitFor(() => expect(dialog.textContent).toContain("Previous clear backlog failed"));
+
+    buttonWithExactText(dialog, "dangerDialog.cancel").click();
+    await flushUi();
+    expect(dialog.isConnected).toBe(false);
+
+    const reopenedDialog = await openClearBacklog(panel);
+    expect(reopenedDialog.querySelector(".form-error")).toBeNull();
+    expect(panel.textContent).not.toContain("Previous clear backlog failed");
+    expect(panel.querySelector(".panel-error")).toBeNull();
+  });
+
+  it.each(["success", "failure"])("clears the previous error while retrying and handles retry %s", async (outcome) => {
+    const retry = deferred<void>();
+    backend.mqClearBacklog.mockRejectedValueOnce(new Error("First attempt failed")).mockReturnValueOnce(retry.promise);
+    const panel = await mountPanel();
+    const dialog = await openClearBacklog(panel);
+    buttonWithExactText(dialog, "mqSubscriptions.clearBacklog").click();
+    await vi.waitFor(() => expect(dialog.textContent).toContain("First attempt failed"));
+
+    buttonWithExactText(dialog, "mqSubscriptions.clearBacklog").click();
+    await vi.waitFor(() => expect(backend.mqClearBacklog).toHaveBeenCalledTimes(2));
+    expect(dialog.querySelector(".form-error")).toBeNull();
+    expect(dialog.isConnected).toBe(true);
+    expect(buttonWithExactText(dialog, "mqSubscriptions.clearBacklog").disabled).toBe(true);
+
+    if (outcome === "success") {
+      backend.mqListSubscriptions.mockResolvedValue([{ ...subscription("orders-consumer", "shared"), msgBacklog: 123 }]);
+      retry.resolve();
+      await vi.waitFor(() => {
+        expect(dialog.isConnected).toBe(false);
+        expect(backend.mqListSubscriptions).toHaveBeenCalledTimes(2);
+        expect(panel.querySelector(".subscriptions-table")?.textContent).toContain("123");
+      });
+    } else {
+      retry.reject(new Error("Retry failed"));
+      await vi.waitFor(() => expect(dialog.querySelector(".form-error")?.textContent).toContain("Retry failed"));
+      expect(dialog.isConnected).toBe(true);
+      expect(dialog.textContent).not.toContain("First attempt failed");
+      expect(backend.mqListSubscriptions).toHaveBeenCalledTimes(1);
+    }
+    expect(panel.querySelector(".panel-error")).toBeNull();
+  });
+
+  it("keeps subscription list loading failures in the panel", async () => {
+    backend.mqListSubscriptions.mockRejectedValueOnce(new Error("Subscription list failed"));
+    const panel = await mountPanel();
+
+    await vi.waitFor(() => expect(panel.querySelector(".panel-error")?.textContent).toContain("Subscription list failed"));
+    expect(panel.querySelector('[role="dialog"]')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 变更说明

修复 #8917。

Kafka 订阅管理执行“清空积压”失败时，`confirmClearBacklog()` 原先将 backend 异常写入页面级 `error`，导致错误显示在订阅管理页面并被确认弹框遮挡，同时订阅表格被页面错误状态隐藏。

本次仅在 `SubscriptionsPanel.vue` 中局部修复：

- 新增清空积压专用 `clearBacklogError`，通过现有 `DangerConfirmDialog` 的 `#options` slot 和 `.form-error` 样式显示错误，并添加 `role="alert"`
- 清空积压失败时弹框保持打开，错误直接显示在当前弹框内，不再写入页面级错误
- 打开弹框、再次执行清空积压前清除旧错误，关闭后重新打开不会残留上次失败信息
- 成功后保持原有关闭弹框并刷新订阅列表的行为
- 订阅列表加载失败等页面级错误保持原有职责，其他操作不变

未修改公共 `DangerConfirmDialog.vue`、MQ backend API、Rust 或 Kafka Agent。公共 Dialog 已在请求 loading 期间阻止关闭，本次没有额外引入 request version 或状态机。

## 测试

在现有 `SubscriptionsPanel.spec.ts` 中最小扩展 Dialog stub（支持 open、confirm、关闭、loading 和 options slot），新增 5 个行为用例：

- [x] backend 调用参数正确，清空积压失败时错误显示在确认弹框内，弹框保持打开且可重试
- [x] 失败不会显示页面级错误，订阅表格仍然可见
- [x] 关闭并重新打开后旧错误不会残留
- [x] 重试等待期间清除旧错误，再次失败时显示新错误
- [x] 失败后重试成功会关闭弹框并刷新实际列表内容
- [x] 订阅列表加载失败仍显示页面级错误

实际执行：

```text
pnpm test apps/desktop/src/components/mq/__tests__/SubscriptionsPanel.spec.ts
pnpm exec oxlint --vue-plugin apps/desktop/src/components/mq/SubscriptionsPanel.vue apps/desktop/src/components/mq/__tests__/SubscriptionsPanel.spec.ts
pnpm exec oxfmt --check apps/desktop/src/components/mq/SubscriptionsPanel.vue apps/desktop/src/components/mq/__tests__/SubscriptionsPanel.spec.ts
pnpm typecheck
git diff --check
```

结果：

- 回归测试先于修复加入：修复前 4 个清空积压用例失败；修复后该文件 **20/20 测试通过**
- 两个修改文件的 oxlint、oxfmt 检查通过
- 完整前端 typecheck 通过（首次超过 240 秒预算；使用 `NODE_OPTIONS=--max-old-space-size=8192` 并延长预算后重试通过）
- diff 空白检查通过，仅两个任务相关文件，无无关格式化或临时文件

未验证：真实 Kafka 实例、桌面 WebView 和浏览器截图。本次验证为 mock backend 的 Vue 组件行为测试；局部 UI 错误归属修复未运行 Rust 构建或全仓测试。

Closes #8917
