### PR TITLE
fix(sql): treat GET DIAGNOSTICS targets as MySQL user variables

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts
@@ -292,6 +292,41 @@ describe("extractSqlParameters", () => {
     expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual(["input_id", "tenant_id"]);
   });
 
+  it("ignores MySQL user variables assigned by GET DIAGNOSTICS", () => {
+    const sql = `
+      get diagnostics condition 1 @err_state = returned_sqlstate, @err_msg = message_text;
+      select concat('failed: ', @err_state, ' ', @err_msg) as result;
+    `;
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual([]);
+  });
+
+  it("ignores GET CURRENT/STACKED DIAGNOSTICS targets and the statement-level row count", () => {
+    const sql = `
+      get diagnostics @affected = row_count;
+      get current diagnostics condition 1 @current_state = returned_sqlstate;
+      get stacked diagnostics condition 1 @stacked_state = returned_sqlstate;
+      select @affected, @current_state, @stacked_state;
+    `;
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual([]);
+  });
+
+  it("keeps ordinary MySQL template parameters next to GET DIAGNOSTICS targets", () => {
+    const sql = `
+      get diagnostics condition 1 @err_msg = message_text;
+      select * from audit_log where tenant_id = @tenant_id and note = @err_msg;
+    `;
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual(["tenant_id"]);
+  });
+
+  it("keeps a template parameter on a column named get", () => {
+    const sql = "select get from api_methods where tenant_id = @tenant_id";
+
+    expect(extractSqlParameters(sql, { databaseType: "mysql" })).toEqual(["tenant_id"]);
+  });
+
   it("ignores SQL Server procedure parameters declared in routine definitions", () => {
     const sql = `
       create procedure dbo.search_orders

--- a/apps/desktop/src/lib/sql/sqlParameters.ts
+++ b/apps/desktop/src/lib/sql/sqlParameters.ts
@@ -1278,6 +1278,13 @@ function collectNativeSqlServerParameters(sql: string, databaseType?: DatabaseTy
       i = collectSelectAssignmentVariables(sql, i + "select".length, declared, databaseType);
       continue;
     }
+    if (matchesWord(sql, i, "get")) {
+      const diagnosticsEnd = readGetDiagnosticsEnd(sql, i);
+      if (diagnosticsEnd !== null) {
+        i = collectSetStatementVariables(sql, diagnosticsEnd, declared, databaseType);
+        continue;
+      }
+    }
     if ((matchesWord(sql, i, "create") || matchesWord(sql, i, "alter")) && isRoutineDefinitionStart(sql, i)) {
       i = collectRoutineDefinitionVariables(sql, i, declared, databaseType);
       continue;
@@ -1524,6 +1531,16 @@ function collectExecNamedArgumentStarts(sql: string, start: number, ignoredStart
     i += 1;
   }
   return i;
+}
+
+// MySQL's GET DIAGNOSTICS writes its results into the user variables on the left
+// of each assignment (`GET DIAGNOSTICS CONDITION 1 @err = MESSAGE_TEXT`), exactly
+// as SET and SELECT ... INTO do. Returns the offset just past the statement's
+// leading keywords, or null when `start` is an ordinary `get` identifier.
+function readGetDiagnosticsEnd(sql: string, start: number): number | null {
+  let keyword = readNextKeyword(sql, start + "get".length);
+  if (keyword?.word === "current" || keyword?.word === "stacked") keyword = readNextKeyword(sql, keyword.end);
+  return keyword?.word === "diagnostics" ? keyword.end : null;
 }
 
 function isRoutineDefinitionStart(sql: string, start: number): boolean {


### PR DESCRIPTION
## Problem

Running a MySQL script whose stored procedure reads the diagnostics area fails with `ERROR 1064`. The user variable on the left of each `GET DIAGNOSTICS` assignment is replaced with an empty string before the script reaches the server:

```sql
GET DIAGNOSTICS CONDITION 1 @err_msg = MESSAGE_TEXT;
```

is sent as

```sql
GET DIAGNOSTICS CONDITION 1 '' = MESSAGE_TEXT;
```

which is exactly the fragment quoted in the reporter's error message.

## Root cause

`collectNativeSqlServerParameters` in `apps/desktop/src/lib/sql/sqlParameters.ts` records the MySQL user variables a script assigns to, so the `@name` template-parameter branch skips them. It recognises the three statements that write into one:

- `DECLARE` → `collectDeclareStatementVariables`
- `SET` → `collectSetStatementVariables`
- `SELECT` / `SELECT ... INTO` → `collectSelectAssignmentVariables`

`GET DIAGNOSTICS` writes into user variables the same way but has no branch, so its targets are never declared and fall through to the template-parameter path.

## Fix

Route the statement into `collectSetStatementVariables`, which already handles this exact right-hand side (`@name = source`, comma separated). The new `readGetDiagnosticsEnd` only skips the leading keywords, accepting the optional `CURRENT`/`STACKED` form, and returns `null` for an ordinary identifier called `get` so a column of that name keeps its surrounding template parameters.

## Tests

Four cases in the existing `extractSqlParameters` suite:

- the reported statement, with two targets on one line
- `GET DIAGNOSTICS @affected = ROW_COUNT` plus the `CURRENT` and `STACKED` forms
- a genuine template parameter sitting next to a diagnostics target, which must still be collected
- a column named `get`, which must not disable parameter collection for the rest of the statement

Reverting the source change fails 3 of the 4; they pass with it.

## Verification

- `npx vitest run apps/desktop/src/lib/__tests__/sql/sqlParameters.spec.ts` → 119 passed
- `npx vue-tsc --noEmit --project apps/desktop/tsconfig.json` → exit 0
- `npx oxfmt` on both files, no further changes
- `npx oxlint --vue-plugin` on both files reports one `no-useless-escape` warning, which is present on an unmodified tree at the same source line and is not introduced here

One note in the interest of full disclosure: `apps/desktop/src/lib/__tests__/sql/externalSqlFileTarget.spec.ts` fails all 10 of its tests on my machine. It fails identically with my changes stashed, so it is pre-existing here and unrelated to this change, but I could not confirm whether it is green in CI.
