### PR TITLE
improve：修复 SQL 编辑器横向滚动条过粗

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -7450,6 +7450,7 @@ defineExpose({
 
 [data-query-editor-root] :deep(.cm-scroller::-webkit-scrollbar) {
   width: 5px;
+  height: 5px;
 }
 
 [data-query-editor-root] :deep(.cm-scroller::-webkit-scrollbar-track) {


### PR DESCRIPTION
## 变更说明

- 为 SQL 编辑器的 WebKit 滚动条补充 `height: 5px`。
- 使横向滚动条与现有 5px 纵向滚动条保持一致。
- 样式仅作用于 SQL 编辑器，不影响数据表等其他滚动区域。

## 验证

- 本地开发页面验证 Chromium 下横向滚动条高度由约 16px 降为 5px。
- `git diff --check` 通过。

Fixes #8940