### PR TITLE
修复 SQL 编辑器表名高亮丢失

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -6089,6 +6089,7 @@ onMounted(async () => {
           if (this.currentView.dom.isConnected) this.currentView.dispatch({ effects: refreshSqlSemanticHighlightEffect.of(null) });
         }, SQL_SEMANTIC_HIGHLIGHT_DEBOUNCE_MS);
         private cachedDoc: import("@codemirror/state").Text | null = null;
+        private prewarmedDoc: import("@codemirror/state").Text | null = null;
         private cachedSql = "";
         private cachedDialectId = "";
         private cachedDatabaseType: DatabaseType | undefined;
@@ -6099,6 +6100,7 @@ onMounted(async () => {
         }> = [];
 
         constructor(private currentView: import("@codemirror/view").EditorView) {
+          this.decorations = Decoration.none;
           this.decorations = this.buildDecorations(currentView);
         }
 
@@ -6144,13 +6146,17 @@ onMounted(async () => {
           }
 
           const sql = this.cachedSql;
+          const shouldPrewarmFullDocument =
+            this.cachedWindows.length === 0 &&
+            this.prewarmedDoc !== doc &&
+            sql.length <= MAX_FULL_DOCUMENT_SQL_SEMANTIC_HIGHLIGHT_LENGTH;
           const windows: Array<{
             from: number;
             to: number;
             spans: Array<{ start: number; end: number }>;
           }> = [];
           const pendingWindows: Array<{ from: number; to: number }> = [];
-          const rangesToHighlight = this.cachedWindows.length === 0 && sql.length <= MAX_FULL_DOCUMENT_SQL_SEMANTIC_HIGHLIGHT_LENGTH ? [{ from: 0, to: sql.length }] : currentView.visibleRanges;
+          const rangesToHighlight = shouldPrewarmFullDocument ? [{ from: 0, to: sql.length }] : currentView.visibleRanges;
           for (const visibleRange of rangesToHighlight) {
             const cached = this.cachedWindows.find((candidate) => candidate.from <= visibleRange.from && candidate.to >= visibleRange.to);
             if (cached) {
@@ -6174,6 +6180,7 @@ onMounted(async () => {
             const requestedTo = Math.max(...pendingWindows.map((window) => window.to));
             const tree = ensureSyntaxTree(currentView.state, requestedTo, requestedTo === sql.length ? 250 : 25);
             if (!tree) return this.decorations;
+            if (shouldPrewarmFullDocument) this.prewarmedDoc = doc;
             for (const window of pendingWindows) {
               const entry = {
                 ...window,

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -6077,6 +6077,7 @@ onMounted(async () => {
     queryEditorLineCommentToken(props.databaseType) === "//" ? shellLineCommentHighlightPlugin : [],
   ];
   const MAX_SQL_SEMANTIC_HIGHLIGHT_WINDOWS = 32;
+  const MAX_FULL_DOCUMENT_SQL_SEMANTIC_HIGHLIGHT_LENGTH = 128_000;
   const SQL_SEMANTIC_HIGHLIGHT_DEBOUNCE_MS = 100;
   const refreshSqlSemanticHighlightEffect = StateEffect.define<null>();
   buildSqlSemanticHighlightExtension = () => [
@@ -6149,7 +6150,8 @@ onMounted(async () => {
             spans: Array<{ start: number; end: number }>;
           }> = [];
           const pendingWindows: Array<{ from: number; to: number }> = [];
-          for (const visibleRange of currentView.visibleRanges) {
+          const rangesToHighlight = this.cachedWindows.length === 0 && sql.length <= MAX_FULL_DOCUMENT_SQL_SEMANTIC_HIGHLIGHT_LENGTH ? [{ from: 0, to: sql.length }] : currentView.visibleRanges;
+          for (const visibleRange of rangesToHighlight) {
             const cached = this.cachedWindows.find((candidate) => candidate.from <= visibleRange.from && candidate.to >= visibleRange.to);
             if (cached) {
               if (!windows.includes(cached)) windows.push(cached);
@@ -6169,8 +6171,9 @@ onMounted(async () => {
           }
 
           if (pendingWindows.length > 0) {
-            const tree = ensureSyntaxTree(currentView.state, Math.max(...pendingWindows.map((window) => window.to)), 25);
-            if (!tree) return Decoration.set([]);
+            const requestedTo = Math.max(...pendingWindows.map((window) => window.to));
+            const tree = ensureSyntaxTree(currentView.state, requestedTo, requestedTo === sql.length ? 250 : 25);
+            if (!tree) return this.decorations;
             for (const window of pendingWindows) {
               const entry = {
                 ...window,

--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -6146,10 +6146,7 @@ onMounted(async () => {
           }
 
           const sql = this.cachedSql;
-          const shouldPrewarmFullDocument =
-            this.cachedWindows.length === 0 &&
-            this.prewarmedDoc !== doc &&
-            sql.length <= MAX_FULL_DOCUMENT_SQL_SEMANTIC_HIGHLIGHT_LENGTH;
+          const shouldPrewarmFullDocument = this.cachedWindows.length === 0 && this.prewarmedDoc !== doc && sql.length <= MAX_FULL_DOCUMENT_SQL_SEMANTIC_HIGHLIGHT_LENGTH;
           const windows: Array<{
             from: number;
             to: number;

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorSemanticHighlightPerformance.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorSemanticHighlightPerformance.spec.ts
@@ -29,6 +29,13 @@ describe("QueryEditor semantic highlighting while scrolling", () => {
     expect(queryEditorSource).toContain("refreshSqlSemanticHighlightEffect.of(null)");
   });
 
+  it("never exposes undefined decorations and prewarms the full document only once per document", () => {
+    expect(queryEditorSource).toContain("this.decorations = Decoration.none;");
+    expect(queryEditorSource).toContain("private prewarmedDoc: import(\"@codemirror/state\").Text | null = null;");
+    expect(queryEditorSource).toContain("const shouldPrewarmFullDocument =");
+    expect(queryEditorSource).toContain("if (shouldPrewarmFullDocument) this.prewarmedDoc = doc;");
+  });
+
   it("keeps preview and diagnostics on the shared statement-range cache", () => {
     expect(queryEditorSource).toContain("executableStatementRangeCache = executableStatementRangeCacheForDoc");
     expect(queryEditorSource).toContain('props.databaseType === "sqlserver" ? undefined : executableStatementRangeCache?.ranges');

--- a/apps/desktop/src/lib/__tests__/editor/queryEditorSemanticHighlightPerformance.spec.ts
+++ b/apps/desktop/src/lib/__tests__/editor/queryEditorSemanticHighlightPerformance.spec.ts
@@ -31,7 +31,7 @@ describe("QueryEditor semantic highlighting while scrolling", () => {
 
   it("never exposes undefined decorations and prewarms the full document only once per document", () => {
     expect(queryEditorSource).toContain("this.decorations = Decoration.none;");
-    expect(queryEditorSource).toContain("private prewarmedDoc: import(\"@codemirror/state\").Text | null = null;");
+    expect(queryEditorSource).toContain('private prewarmedDoc: import("@codemirror/state").Text | null = null;');
     expect(queryEditorSource).toContain("const shouldPrewarmFullDocument =");
     expect(queryEditorSource).toContain("if (shouldPrewarmFullDocument) this.prewarmedDoc = doc;");
   });

--- a/apps/desktop/src/lib/editor/editorThemes.ts
+++ b/apps/desktop/src/lib/editor/editorThemes.ts
@@ -31,7 +31,10 @@ export function createRunStatementButtonDom(ariaLabel = "Execute statement"): HT
 export function sqlSemanticHighlightTheme(EditorView: typeof import("@codemirror/view").EditorView): Extension {
   return EditorView.theme({
     ".cm-sql-table-name, .cm-sql-table-name *": {
-      color: `var(${SQL_TABLE_COLOR_CSS_VAR}) !important`,
+      // Built-in CodeMirror themes do not define the editor-specific table color
+      // variable. Keep semantic table names visible there as well, while custom
+      // and IDE themes continue to use their configured table color.
+      color: `var(${SQL_TABLE_COLOR_CSS_VAR}, #b4530b) !important`,
     },
   });
 }


### PR DESCRIPTION
## 问题

SQL 编辑器中的有效表名在部分内置主题或长 SQL 文件中没有稳定显示表名颜色：滚动后可能退化为普通文本颜色，切换标签后也可能出现高亮缺失。

## 修复

- 为内置 CodeMirror 主题提供表名颜色兜底，避免编辑器专用 CSS 变量未定义时退化为普通文本色。
- 对首次打开且长度受控的 SQL 文档预热完整语义高亮，减少滚动到新区域才临时着色的现象。
- 语法树尚未准备好时保留已有装饰，避免一次增量计算清空现有高亮。

## 验证

- `pnpm exec vitest run apps/desktop/src/lib/__tests__/editorThemes.spec.ts apps/desktop/src/lib/__tests__/editor/queryEditorSemanticHighlightPerformance.spec.ts`：21 项通过。
- `pnpm typecheck`：通过。
- 本地开发页面实测 `query_12.sql` 滚动前后表名保持橙色高亮。

Fixes #8942