### PR TITLE
fix(transfer): 支持瀚高 HighGo 数据传输

### DIFF
--- a/apps/desktop/src/lib/database/__tests__/transferObjectKinds.spec.ts
+++ b/apps/desktop/src/lib/database/__tests__/transferObjectKinds.spec.ts
@@ -4,7 +4,7 @@ import { manifestDatabaseTypes } from "@/lib/database/databaseDriverManifest";
 import { supportsTransfer } from "@/lib/database/databaseFeatureSupport";
 import type { DatabaseType } from "@/types/database";
 
-const TABLE_ONLY_TRANSFER_DATABASES: DatabaseType[] = ["sqlite", "rqlite", "turso", "cloudflare-d1", "duckdb", "clickhouse", "mongodb", "goldendb", "questdb", "hive", "argo", "kyuubi", "impala", "spark"];
+const TABLE_ONLY_TRANSFER_DATABASES: DatabaseType[] = ["sqlite", "rqlite", "turso", "cloudflare-d1", "duckdb", "clickhouse", "mongodb", "highgo", "goldendb", "questdb", "hive", "argo", "kyuubi", "impala", "spark"];
 
 describe("transferObjectKinds", () => {
   it("groups databases into transfer families", () => {

--- a/crates/dbx-core/assets/database-drivers.manifest.json
+++ b/crates/dbx-core/assets/database-drivers.manifest.json
@@ -945,7 +945,7 @@
         "tableDataEdit": true,
         "tableStructureEdit": true,
         "tableImport": true,
-        "dataTransfer": false,
+        "dataTransfer": true,
         "sqlFileExecution": true,
         "databaseCreate": true,
         "fieldLineage": false,

--- a/crates/dbx-core/tests/database_capabilities.rs
+++ b/crates/dbx-core/tests/database_capabilities.rs
@@ -455,3 +455,16 @@ fn goldendb_declares_data_transfer_support() {
     assert!(goldendb.capabilities.table_import);
     assert!(goldendb.capabilities.data_transfer);
 }
+
+#[test]
+fn highgo_declares_data_transfer_support() {
+    let manifest = driver_manifest();
+    let highgo = manifest
+        .drivers
+        .iter()
+        .find(|driver| driver.db_type == DatabaseType::Highgo)
+        .expect("HighGo manifest entry");
+
+    assert!(highgo.capabilities.table_import);
+    assert!(highgo.capabilities.data_transfer);
+}

--- a/crates/dbx-core/tests/database_capabilities.rs
+++ b/crates/dbx-core/tests/database_capabilities.rs
@@ -459,11 +459,8 @@ fn goldendb_declares_data_transfer_support() {
 #[test]
 fn highgo_declares_data_transfer_support() {
     let manifest = driver_manifest();
-    let highgo = manifest
-        .drivers
-        .iter()
-        .find(|driver| driver.db_type == DatabaseType::Highgo)
-        .expect("HighGo manifest entry");
+    let highgo =
+        manifest.drivers.iter().find(|driver| driver.db_type == DatabaseType::Highgo).expect("HighGo manifest entry");
 
     assert!(highgo.capabilities.table_import);
     assert!(highgo.capabilities.data_transfer);

--- a/plugins/connection-types/highgo.yaml
+++ b/plugins/connection-types/highgo.yaml
@@ -28,7 +28,7 @@ capabilities:
   tableDataEdit: true
   tableStructureEdit: true
   tableImport: true
-  dataTransfer: false
+  dataTransfer: true
   sqlFileExecution: true
   databaseCreate: true
   fieldLineage: false


### PR DESCRIPTION
## 变更说明

修复 #8950。

瀚高 HighGo 已具备表元数据和查询执行能力，但此前数据库能力清单中未开启数据传输能力，导致 Data Transfer 弹窗通过 `supportsTransfer` 筛选连接时直接排除了 HighGo。

本次修复：

- 开启 HighGo 的 `dataTransfer` capability
- 从 source YAML 同步生成数据库 driver manifest
- 将 HighGo 保持在现有 table-only transfer fallback
- 不额外开放未经验证的 VIEW / FUNCTION / PROCEDURE / TRIGGER / SEQUENCE 等对象传输能力
- 补充对应 capability / transfer object kind 回归测试

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [ ] 文档更新
- [ ] CI / 构建

## 涉及前端

本次未修改前端组件；DataTransferDialog 已有的 `supportsTransfer(transferDatabaseTypeForConnection(c))` 筛选路径会直接使用更新后的 manifest capability。

- [ ] 本 PR 涉及前端改动，已附截图/录屏（见下方）

## 验证

- [x] `pnpm check:connection-types`
- [x] `pnpm exec vitest run apps/desktop/src/lib/database/__tests__/transferObjectKinds.spec.ts apps/desktop/src/components/transfer/__tests__/DataTransferDialog.spec.ts`（2 个文件、38 个测试通过）
- [x] `cargo test -p dbx-core --test database_capabilities --no-default-features --features sqlite-bundled`（11 个测试通过）
- [x] `cargo check --no-default-features -p dbx-core`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [ ] `make check`
- [ ] `make cargo-check-fast`

## 关联 Issue

Closes #8950
