### PR TITLE
fix(sql): treat HAVING as alias-visible context

### DIFF
--- a/apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts
@@ -58,6 +58,34 @@ describe("sqlSemanticReferences shared consumers", () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it("does not flag a SELECT alias used by MySQL HAVING", () => {
+    const sql = `SELECT COUNT(*) AS cnt, g FROM amounts GROUP BY g HAVING cnt > 1`;
+    const aliasStart = sql.indexOf("cnt", sql.indexOf("HAVING"));
+    const analysis: SqlReferenceAnalysis = {
+      tables: [
+        {
+          name: "amounts",
+          span: span(sql.indexOf("amounts") + 1, sql.indexOf("amounts") + "amounts".length),
+        },
+      ],
+      columns: [
+        {
+          name: "cnt",
+          span: span(aliasStart + 1, aliasStart + "cnt".length),
+        },
+      ],
+    };
+
+    const diagnostics = buildSqlSemanticDiagnostics(analysis, {
+      tables: [],
+      columnsByTable: new Map([["amounts", [{ name: "price" }, { name: "g" }]]]),
+      sql,
+      databaseType: "mysql",
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
   it("resolves navigation targets from subquery aliases and projected columns", () => {
     const { sql, cursor } = sqlFixtureCursor("SELECT sq.user_| FROM (SELECT id, name AS user_name FROM users) sq");
     const model = buildSqlSemanticModel(sql, cursor);

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
@@ -1344,3 +1344,41 @@ describe("originForSqlCompletionProvider", () => {
     expect(originForSqlCompletionProvider("explicit", false)).toBe("explicit");
   });
 });
+
+describe("select alias visibility", () => {
+  it("prioritizes SELECT aliases inside HAVING for MySQL", () => {
+    const sql = "SELECT COUNT(*) AS cnt, g FROM orders GROUP BY g HAVING cnt > ";
+    const context = getSqlCompletionContext(sql, sql.length, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prioritizeSelectAliases).toBe(true);
+    expect(context.selectAliases).toContain("cnt");
+  });
+
+  it("prioritizes SELECT aliases inside ORDER BY even with later clauses", () => {
+    const sql = "SELECT SUM(price) AS total FROM orders ORDER BY total LIMIT 10";
+    const cursor = sql.indexOf("total", sql.indexOf("ORDER BY")) + "total".length;
+    const context = getSqlCompletionContext(sql, cursor, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prioritizeSelectAliases).toBe(true);
+    expect(context.selectAliases).toContain("total");
+  });
+
+  it("does not prioritize SELECT aliases inside WHERE", () => {
+    const sql = "SELECT id AS uid FROM orders WHERE uid > ";
+    const context = getSqlCompletionContext(sql, sql.length, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prioritizeSelectAliases).toBe(false);
+    expect(context.selectAliases).toEqual([]);
+  });
+
+  it("offers HAVING alias completion items", () => {
+    const sql = "SELECT COUNT(*) AS cnt, g FROM orders GROUP BY g HAVING cn";
+    const items = buildSqlCompletionItems(sql, sql.length, {
+      dialect: "mysql",
+      tables: [{ name: "orders", type: "table" }],
+      columnsByTable: new Map([["orders", [{ name: "g" } as never]]]),
+    });
+
+    expect(items.some((item) => item.label === "cnt")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -2652,11 +2652,14 @@ function isInOrderOrGroupByContext(beforeCursor: string): boolean {
     .toLowerCase();
   const lastOrderBy = cleaned.lastIndexOf("order by");
   const lastGroupBy = cleaned.lastIndexOf("group by");
-  const lastContext = Math.max(lastOrderBy, lastGroupBy);
+  // MySQL (and DuckDB-like engines) also resolve SELECT aliases inside HAVING,
+  // so aliases stay visible there just like in ORDER BY/GROUP BY.
+  const lastHaving = cleaned.lastIndexOf("having");
+  const lastContext = Math.max(lastOrderBy, lastGroupBy, lastHaving);
   if (lastContext < 0) return false;
 
   const segment = cleaned.slice(lastContext);
-  return !/\b(?:where|having|limit|offset|union|intersect|except|join|from)\b/.test(segment);
+  return !/\b(?:where|limit|offset|union|intersect|except|join|from)\b/.test(segment);
 }
 
 function isInGroupByContext(beforeCursor: string): boolean {


### PR DESCRIPTION
Fixes #8713

## 问题 / Problem

MySQL 允许在 HAVING 中引用 SELECT 别名（与 ORDER BY / GROUP BY 一致），但别名可见性判断 `isInOrderOrGroupByContext` 把包含 `having` 的片段一律视为非别名上下文。导致形如：

```sql
SELECT COUNT(*) AS cnt, g FROM t GROUP BY g HAVING cnt > 1
```

的查询出现两个症状（与 issue 描述一致）：
1. `cnt` 被语义诊断误报为 `Unknown column cnt`；
2. 在 HAVING 中输入别名前缀时没有 `cnt` 的自动补全。

## 修复 / Fix

- `isInOrderOrGroupByContext` 将 `HAVING` 纳入别名可见上下文（从排除关键词中移除 `having`），ORDER BY / GROUP BY 行为不变；
- 语义诊断经由 `isVisibleProjectionAlias` 复用同一上下文判断，误报随之消除；
- 该函数另外两个调用点（`isInColumnContext`、`isInTableListContext`）语义均不受损：HAVING 内本就应视为列上下文，且不应再触发表名列表补全。

## 测试 / Tests

- `sqlCompletion.context.spec.ts` 新增 4 个用例：HAVING 中 `prioritizeSelectAliases` 为真且包含别名、ORDER BY 后接 LIMIT 仍可见、WHERE 中不启用（MySQL 语义）、HAVING 中别名补全项出现；
- `semantic/references.spec.ts` 新增 MySQL HAVING 别名不产生 `Unknown column` 诊断的回归用例；
- `pnpm vitest run src/lib/__tests__/sql`：除 `externalSqlFileTarget.spec.ts`（main 上同样失败的既有失败，与本改动无关）外全部通过；`vue-tsc` 无新增错误。