### PR TITLE
修复 MongoDB 单元格 NULL 编辑和显示

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -2018,14 +2018,14 @@ const columnAligns = computed<("left" | "right")[]>(() => {
 
 function gridCellTextColorClass(item: RowItem, actualColIdx: number, visibleColIdx: number): string {
   const value = item.data[actualColIdx];
-  const isGridNull = value === null || (props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL);
-  if (isGridNull) return "text-muted-foreground italic";
+  const isMongoDocumentNull = props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL;
+  if (isMongoDocumentNull) return "text-muted-foreground italic";
   if (!colorizeDataGridCellTypes.value) return "text-foreground";
   const checkbox = booleanCellsUseCheckbox.value && isBooleanGridCell(item, actualColIdx) && value !== null;
   return dataGridCellTextClass({
     colorizeTypes: colorizeDataGridCellTypes.value,
     typeKind: allColumnTypeVisualKinds.value[actualColIdx] ?? "unknown",
-    isNull: isGridNull,
+    isNull: value === null,
     isDraft: item.isDraft && value === null,
     isEditing: editingCell.value?.rowId === item.id && editingCell.value.col === actualColIdx,
     isControl: checkbox,
@@ -2041,13 +2041,13 @@ function transposeCellTextColorClass(recordIndex: number, actualColIdx: number):
   const item = displayItems.value[recordIndex];
   if (!item) return "text-foreground";
   const value = item.data[actualColIdx];
-  const isGridNull = value === null || (props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL);
-  if (isGridNull) return "text-muted-foreground italic";
+  const isMongoDocumentNull = props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL;
+  if (isMongoDocumentNull) return "text-muted-foreground italic";
   if (!colorizeDataGridCellTypes.value) return "text-foreground";
   return dataGridCellTextClass({
     colorizeTypes: colorizeDataGridCellTypes.value,
     typeKind: allColumnTypeVisualKinds.value[actualColIdx] ?? "unknown",
-    isNull: isGridNull,
+    isNull: value === null,
     isDraft: item.isDraft && value === null,
     isEditing: editingCell.value?.rowId === item.id && editingCell.value.col === actualColIdx,
     isControl: booleanCellsUseCheckbox.value && isBooleanGridCell(item, actualColIdx) && value !== null,

--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -99,7 +99,7 @@ import type { BuildSingleColumnAlterSqlOptions } from "@/lib/table/tableStructur
 import { buildTableSelectSql, qualifyTableReferencesInSql, quoteTableDataIdentifier } from "@/lib/table/tableSelectSql";
 import { uuid } from "@/lib/common/utils";
 import { generateCellValues, type CellValueGenerationKind } from "@/lib/dataGrid/cellValueGeneration";
-import { MONGO_DOCUMENT_GRID_NULL, mongoDocumentGridDisplayText, mongoDocumentGridEditorText, mongoDocumentGridExternalValue, mongoDocumentGridInputValue } from "@/lib/mongo/mongoDocumentValues";
+import { MONGO_DOCUMENT_GRID_NULL, mongoDocumentGridClipboardText, mongoDocumentGridDisplayText, mongoDocumentGridEditorText, mongoDocumentGridExternalValue, mongoDocumentGridInputValue } from "@/lib/mongo/mongoDocumentValues";
 import { compactHeaderColumnType, formatMetadataColumnTypeLabel, isNumericColumnType, resolveDataGridTypeVisualKind, resolveHeaderColumnType, resolveResultColumnType } from "@/lib/dataGrid/dataGridColumnType";
 import { dataGridCellTextClass, dataGridTypeVisualClass } from "@/lib/dataGrid/dataGridCellTextVisual";
 import { DATA_GRID_TYPE_COLOR_KEYS, resolveActiveDataGridTypeColors } from "@/lib/dataGrid/dataGridTypeColorScheme";
@@ -2017,13 +2017,15 @@ const columnAligns = computed<("left" | "right")[]>(() => {
 });
 
 function gridCellTextColorClass(item: RowItem, actualColIdx: number, visibleColIdx: number): string {
-  if (!colorizeDataGridCellTypes.value) return "text-foreground";
   const value = item.data[actualColIdx];
+  const isGridNull = value === null || (props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL);
+  if (isGridNull) return "text-muted-foreground italic";
+  if (!colorizeDataGridCellTypes.value) return "text-foreground";
   const checkbox = booleanCellsUseCheckbox.value && isBooleanGridCell(item, actualColIdx) && value !== null;
   return dataGridCellTextClass({
     colorizeTypes: colorizeDataGridCellTypes.value,
     typeKind: allColumnTypeVisualKinds.value[actualColIdx] ?? "unknown",
-    isNull: value === null,
+    isNull: isGridNull,
     isDraft: item.isDraft && value === null,
     isEditing: editingCell.value?.rowId === item.id && editingCell.value.col === actualColIdx,
     isControl: checkbox,
@@ -2036,14 +2038,16 @@ function gridCellTextColorClass(item: RowItem, actualColIdx: number, visibleColI
 }
 
 function transposeCellTextColorClass(recordIndex: number, actualColIdx: number): string {
-  if (!colorizeDataGridCellTypes.value) return "text-foreground";
   const item = displayItems.value[recordIndex];
   if (!item) return "text-foreground";
   const value = item.data[actualColIdx];
+  const isGridNull = value === null || (props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL);
+  if (isGridNull) return "text-muted-foreground italic";
+  if (!colorizeDataGridCellTypes.value) return "text-foreground";
   return dataGridCellTextClass({
     colorizeTypes: colorizeDataGridCellTypes.value,
     typeKind: allColumnTypeVisualKinds.value[actualColIdx] ?? "unknown",
-    isNull: value === null,
+    isNull: isGridNull,
     isDraft: item.isDraft && value === null,
     isEditing: editingCell.value?.rowId === item.id && editingCell.value.col === actualColIdx,
     isControl: booleanCellsUseCheckbox.value && isBooleanGridCell(item, actualColIdx) && value !== null,
@@ -3947,6 +3951,10 @@ function isIoTDBTimestampColumn(columnIndex: number): boolean {
 }
 
 function inlineCellEditorText(value: CellValue, columnIndex: number): string {
+  if (props.mongoCollectionGrid) {
+    const documentGridText = mongoDocumentGridEditorText(value);
+    if (documentGridText !== undefined) return documentGridText;
+  }
   const columnInfo = tableColumnForGridColumn(columnIndex) ?? resultColumnInfoForGridColumn(columnIndex);
   const columnType = props.result.column_types?.[columnIndex] ?? columnInfo?.data_type;
   return (
@@ -7073,6 +7081,7 @@ function drawCanvasGrid() {
     searchMatchKeys: searchMatchSet.value,
     currentSearchMatch: currentSearchMatch.value,
     formatCell: (value, columnIndex, row) => formatCellCached(visibleLargeValuePreviewValue(row, columnIndex, value), columnIndex, largeValueOriginalBytes(row, columnIndex)),
+    isNullValue: (value) => value === null || (props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL),
     newRowCellPlaceholder,
     isRowActive,
     rowCellsUseSelectionVisual,
@@ -7395,7 +7404,7 @@ const {
   columnComments: visibleColumnComments,
   allColumnComments,
   displayValue: formatCellCached,
-  cellClipboardText: (value) => (props.mongoCollectionGrid ? mongoDocumentGridEditorText(value) : undefined),
+  cellClipboardText: (value) => (props.mongoCollectionGrid ? mongoDocumentGridClipboardText(value) : undefined),
   externalCellValue: (value) => (props.mongoCollectionGrid ? mongoDocumentGridExternalValue(value) : value),
   mongoDocuments: computed(() => props.result.mongo_copy_documents ?? props.result.mongo_documents),
   spatialColumns: computed(() => props.result.spatial_columns),
@@ -8933,7 +8942,7 @@ async function onGridKeydown(event: KeyboardEvent) {
 
 function detailClipboardText(detail: DataGridCellDetail): string {
   if (props.mongoCollectionGrid) {
-    const documentGridText = mongoDocumentGridEditorText(detail.value);
+    const documentGridText = mongoDocumentGridClipboardText(detail.value);
     if (documentGridText !== undefined) return documentGridText;
   }
   if (detail.value === null) return "";

--- a/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellTypeVisual.spec.ts
+++ b/apps/desktop/src/lib/__tests__/dataGrid/dataGridCellTypeVisual.spec.ts
@@ -103,9 +103,10 @@ describe("data grid cell text visual priority", () => {
     expect(dataGridSource).toContain("'cursor-text hover:bg-gray-200 hover:text-foreground dark:hover:bg-gray-800':");
   });
 
-  it("returns before reading cell state when type colors are disabled", () => {
-    expect(dataGridSource).toContain('function gridCellTextColorClass(item: RowItem, actualColIdx: number, visibleColIdx: number): string {\n  if (!colorizeDataGridCellTypes.value) return "text-foreground";\n  const value = item.data[actualColIdx];');
-    expect(dataGridSource).toContain('function transposeCellTextColorClass(recordIndex: number, actualColIdx: number): string {\n  if (!colorizeDataGridCellTypes.value) return "text-foreground";\n  const item = displayItems.value[recordIndex];');
+  it("keeps Mongo BSON null muted when type colors are disabled", () => {
+    const mongoNullPriority = 'const isMongoDocumentNull = props.mongoCollectionGrid === true && value === MONGO_DOCUMENT_GRID_NULL;\n  if (isMongoDocumentNull) return "text-muted-foreground italic";\n  if (!colorizeDataGridCellTypes.value) return "text-foreground";';
+
+    expect(dataGridSource.split(mongoNullPriority)).toHaveLength(3);
   });
 
   it("places data-grid type selectors in the components layer", () => {

--- a/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
+++ b/apps/desktop/src/lib/dataGrid/canvasDataGridRenderer.ts
@@ -80,6 +80,7 @@ export interface DrawCanvasDataGridOptions {
   searchMatchKeys: ReadonlySet<number>;
   currentSearchMatch: CanvasSearchMatch | null;
   formatCell: (value: CellValue, columnIndex: number, row: CanvasDataGridRow) => string;
+  isNullValue?: (value: CellValue) => boolean;
   columnIsBoolean?: (columnIndex: number) => boolean;
   newRowCellPlaceholder?: (row: CanvasDataGridRow, columnIndex: number) => string | null;
   isRowActive: (rowIndex: number) => boolean;
@@ -345,6 +346,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
     searchMatchKeys,
     currentSearchMatch,
     formatCell,
+    isNullValue,
     newRowCellPlaceholder,
     isRowActive,
     rowCellsUseSelectionVisual,
@@ -558,6 +560,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
       ctx.rect(clippedX, y, Math.min(cellPaintWidth, width - clippedX), CANVAS_DATA_GRID_ROW_HEIGHT);
       ctx.clip();
       const value = item.data[actualColIdx];
+      const isNullCell = isNullValue?.(value) ?? value === null;
       const isBooleanCell = columnIsBoolean?.(actualColIdx) === true && isBooleanCellValue(value);
       const isRightAlign = columnAligns?.[visibleColIdx] === "right";
       const isEditingThisCell = editingCell?.rowId === item.id && editingCell.col === actualColIdx;
@@ -567,7 +570,7 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
       const textRole = resolveDataGridCellTextRole({
         colorizeTypes: colorizeDataTypes,
         typeKind,
-        isNull: value === null,
+        isNull: isNullCell,
         isDraft: item.isDraft && value === null,
         isEditing: isEditingThisCell,
         isControl: shouldRenderBooleanCheckbox,
@@ -580,8 +583,8 @@ export function drawCanvasDataGrid(options: DrawCanvasDataGridOptions) {
       const cellTextColor = textRole === "muted" ? theme.mutedForeground : textRole === "type" ? dataGridTypeForeground(theme, typeKind) : theme.foreground;
       ctx.textAlign = isBooleanNullCell ? "center" : isRightAlign ? "right" : "left";
       ctx.fillStyle = cellTextColor;
-      ctx.font = value === null ? italicFont : tabularFont;
-      setCanvasNumericVariant(ctx, value === null ? "normal" : "tabular-nums");
+      ctx.font = isNullCell ? italicFont : tabularFont;
+      setCanvasNumericVariant(ctx, isNullCell ? "normal" : "tabular-nums");
       const reservedWidth = rightAlignedActionCell?.rowIndex === item.displayIndex && rightAlignedActionCell.visibleColIdx === visibleColIdx ? rightAlignedActionCell.reservedWidth : 0;
       const { textAnchorX, maxWidth: cellMaxWidth } = resolveCanvasCellTextLayout({ drawX, colWidth, dpr: scaleX, isRightAlign, reservedWidth });
       if (shouldRenderBooleanCheckbox) {

--- a/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
+++ b/apps/desktop/src/lib/mongo/mongoDocumentValues.ts
@@ -145,8 +145,16 @@ function mongoDocumentGridEscapedString(value: unknown): string | undefined {
 
 /** Returns the text presented in a collection-grid editor, when customized. */
 export function mongoDocumentGridEditorText(value: unknown): string | undefined {
-  if (value === MONGO_DOCUMENT_GRID_NULL) return "NULL";
+  // An existing BSON null is represented as NULL in the grid, but editing it
+  // starts with an empty input. The private marker must never be user-facing.
+  if (value === MONGO_DOCUMENT_GRID_NULL) return "";
   return mongoDocumentGridEscapedString(value);
+}
+
+/** Returns the text used when copying a collection-grid cell. */
+export function mongoDocumentGridClipboardText(value: unknown): string | undefined {
+  if (value === MONGO_DOCUMENT_GRID_NULL) return "NULL";
+  return mongoDocumentGridEditorText(value);
 }
 
 /** Returns the custom display text required by collection-grid BSON values. */

--- a/packages/app-tests/mongoDocumentValues.test.ts
+++ b/packages/app-tests/mongoDocumentValues.test.ts
@@ -11,6 +11,7 @@ import {
   MONGO_DOCUMENT_GRID_NULL,
   mongoDocumentDisplayValue,
   mongoDocumentGridDisplayText,
+  mongoDocumentGridClipboardText,
   mongoDocumentGridEditorText,
   mongoDocumentGridExternalValue,
   mongoDocumentGridInputValue,
@@ -401,6 +402,13 @@ test("escapes Mongo collection-grid values reserved for BSON null state", () => 
   assert.deepEqual(buildMongoUpdateDocument(new Map([[1, gridValue as string]]), columns, { _id: "1", value: reservedString }), {
     $set: { value: reservedString },
   });
+});
+
+test("keeps BSON null empty in editors while preserving a copy marker", () => {
+  assert.equal(mongoDocumentGridEditorText(MONGO_DOCUMENT_GRID_NULL), "");
+  assert.equal(mongoDocumentGridClipboardText(MONGO_DOCUMENT_GRID_NULL), "NULL");
+  assert.equal(mongoDocumentGridEditorText("NULL"), undefined);
+  assert.equal(mongoDocumentGridClipboardText("NULL"), undefined);
 });
 
 test("restores internal Mongo collection-grid values for external output", () => {


### PR DESCRIPTION
## 变更说明

Fixes #8812

MongoDB 文档表格内部使用私有标记表示 BSON `null`。此前 DOM、Canvas 和行列转置渲染路径处理不一致，单元格进入编辑时还可能把编辑器内容重新覆盖为内部标记，导致用户看到 `dbx:mongo-document-grid:null`；同时 `NULL` 的显示样式与普通字符串不易区分。

本次修复：

- BSON `null` 进入编辑器时显示为空内容，不再暴露内部标记。
- BSON `null` 在 DOM、Canvas 和转置视图中统一使用弱化、斜体样式。
- 复制 BSON `null` 时仍保留 `NULL` 文本，普通字符串 `NULL` 不受影响。
- 增加 MongoDB NULL 编辑、复制和视觉优先级回归测试。
- 保持本 PR 的样式变更仅针对 MongoDB BSON `null`，不改变其他数据库的 NULL 显示策略。

## 验证结果

- 已通过本地免密浏览器预览，实际确认 BSON `null` 显示样式、编辑内容和复制结果正确。
- MongoDB NULL、单元格详情、编辑器和 Canvas 相关回归：6 个测试文件、161 个测试通过。
- 完整前端测试：1335 个测试文件、14012 个测试通过。
- `pnpm typecheck` 通过。
- `pnpm exec oxfmt --check` 通过。
- `git diff --check` 通过。
