### PR TITLE
fix(editor): slim the horizontal scrollbar to match the vertical one

### DIFF
--- a/apps/desktop/src/components/editor/QueryEditor.vue
+++ b/apps/desktop/src/components/editor/QueryEditor.vue
@@ -7450,6 +7450,10 @@ defineExpose({
 
 [data-query-editor-root] :deep(.cm-scroller::-webkit-scrollbar) {
   width: 5px;
+  /* Matching height keeps the horizontal scrollbar as slim as the vertical
+     one; leaving it unset renders a default-thickness bar that permanently
+     reserves editor space. */
+  height: 5px;
 }
 
 [data-query-editor-root] :deep(.cm-scroller::-webkit-scrollbar-track) {

--- a/apps/desktop/src/lib/__tests__/database/dbAdminSql.spec.ts
+++ b/apps/desktop/src/lib/__tests__/database/dbAdminSql.spec.ts
@@ -425,6 +425,44 @@ describe("buildDuplicateTableStructurePlan", () => {
     expect(plan).toEqual({ sql: 'CREATE TABLE "copy" (LIKE "source" INCLUDING ALL);', sourceColumns: undefined, executeAsScript: false });
   });
 
+  it("recreates the SQL Server primary key that SELECT INTO drops", async () => {
+    apiMock.listIndexes.mockResolvedValue([
+      { name: "PK_ORDERS", columns: ["ID", "SEQ"], is_unique: true, is_primary: true },
+      { name: "IDX_ORDERS_CUSTOMER", columns: ["CUSTOMER"], is_unique: false, is_primary: false },
+    ]);
+    apiMock.buildDuplicateTableStructureSql.mockResolvedValue("SELECT TOP 0 * INTO [dbo].[orders_copy] FROM [dbo].[orders];\nALTER TABLE [dbo].[orders_copy] ADD CONSTRAINT [PK_orders_copy] PRIMARY KEY ([ID], [SEQ]);");
+
+    const plan = await buildDuplicateTableStructurePlan({
+      connectionId: "mssql-1",
+      database: "app",
+      databaseType: "sqlserver",
+      schema: "dbo",
+      sourceName: "orders",
+      targetName: "orders_copy",
+    });
+
+    expect(apiMock.listIndexes).toHaveBeenCalledWith("mssql-1", "app", "dbo", "orders", undefined);
+    expect(apiMock.buildDuplicateTableStructureSql).toHaveBeenCalledWith(expect.objectContaining({ databaseType: "sqlserver", primaryKeyColumns: ["ID", "SEQ"] }));
+    expect(plan.executeAsScript).toBe(true);
+  });
+
+  it("keeps primary-key-free SQL Server clones on a single statement", async () => {
+    apiMock.listIndexes.mockResolvedValue([{ name: "IDX_ORDERS_CUSTOMER", columns: ["CUSTOMER"], is_unique: false, is_primary: false }]);
+    apiMock.buildDuplicateTableStructureSql.mockResolvedValue("SELECT TOP 0 * INTO [orders_copy] FROM [orders];");
+
+    const plan = await buildDuplicateTableStructurePlan({
+      connectionId: "mssql-1",
+      database: "app",
+      databaseType: "sqlserver",
+      schema: undefined,
+      sourceName: "orders",
+      targetName: "orders_copy",
+    });
+
+    expect(apiMock.buildDuplicateTableStructureSql).toHaveBeenCalledWith(expect.objectContaining({ databaseType: "sqlserver", primaryKeyColumns: [] }));
+    expect(plan).toEqual({ sql: "SELECT TOP 0 * INTO [orders_copy] FROM [orders];", sourceColumns: undefined, executeAsScript: false });
+  });
+
   it("forwards the connection identifier quote so dual-dialect clones stay executable", async () => {
     // Cloud Spanner's PostgreSQL dialect quotes with double quotes while GoogleSQL uses backticks,
     // and only the connected agent knows which. Dropping the quote here would make the backend fall

--- a/apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/semantic/references.spec.ts
@@ -58,6 +58,34 @@ describe("sqlSemanticReferences shared consumers", () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it("does not flag a SELECT alias used by MySQL HAVING", () => {
+    const sql = `SELECT COUNT(*) AS cnt, g FROM amounts GROUP BY g HAVING cnt > 1`;
+    const aliasStart = sql.indexOf("cnt", sql.indexOf("HAVING"));
+    const analysis: SqlReferenceAnalysis = {
+      tables: [
+        {
+          name: "amounts",
+          span: span(sql.indexOf("amounts") + 1, sql.indexOf("amounts") + "amounts".length),
+        },
+      ],
+      columns: [
+        {
+          name: "cnt",
+          span: span(aliasStart + 1, aliasStart + "cnt".length),
+        },
+      ],
+    };
+
+    const diagnostics = buildSqlSemanticDiagnostics(analysis, {
+      tables: [],
+      columnsByTable: new Map([["amounts", [{ name: "price" }, { name: "g" }]]]),
+      sql,
+      databaseType: "mysql",
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
   it("resolves navigation targets from subquery aliases and projected columns", () => {
     const { sql, cursor } = sqlFixtureCursor("SELECT sq.user_| FROM (SELECT id, name AS user_name FROM users) sq");
     const model = buildSqlSemanticModel(sql, cursor);

--- a/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
+++ b/apps/desktop/src/lib/__tests__/sql/sqlCompletion.context.spec.ts
@@ -1344,3 +1344,41 @@ describe("originForSqlCompletionProvider", () => {
     expect(originForSqlCompletionProvider("explicit", false)).toBe("explicit");
   });
 });
+
+describe("select alias visibility", () => {
+  it("prioritizes SELECT aliases inside HAVING for MySQL", () => {
+    const sql = "SELECT COUNT(*) AS cnt, g FROM orders GROUP BY g HAVING cnt > ";
+    const context = getSqlCompletionContext(sql, sql.length, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prioritizeSelectAliases).toBe(true);
+    expect(context.selectAliases).toContain("cnt");
+  });
+
+  it("prioritizes SELECT aliases inside ORDER BY even with later clauses", () => {
+    const sql = "SELECT SUM(price) AS total FROM orders ORDER BY total LIMIT 10";
+    const cursor = sql.indexOf("total", sql.indexOf("ORDER BY")) + "total".length;
+    const context = getSqlCompletionContext(sql, cursor, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prioritizeSelectAliases).toBe(true);
+    expect(context.selectAliases).toContain("total");
+  });
+
+  it("does not prioritize SELECT aliases inside WHERE", () => {
+    const sql = "SELECT id AS uid FROM orders WHERE uid > ";
+    const context = getSqlCompletionContext(sql, sql.length, { databaseType: "mysql", dialect: "mysql" });
+
+    expect(context.prioritizeSelectAliases).toBe(false);
+    expect(context.selectAliases).toEqual([]);
+  });
+
+  it("offers HAVING alias completion items", () => {
+    const sql = "SELECT COUNT(*) AS cnt, g FROM orders GROUP BY g HAVING cn";
+    const items = buildSqlCompletionItems(sql, sql.length, {
+      dialect: "mysql",
+      tables: [{ name: "orders", type: "table" }],
+      columnsByTable: new Map([["orders", [{ name: "g" } as never]]]),
+    });
+
+    expect(items.some((item) => item.label === "cnt")).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/database/dbAdminSql.ts
+++ b/apps/desktop/src/lib/database/dbAdminSql.ts
@@ -83,6 +83,9 @@ export interface DuplicateTableStructureSqlOptions {
   targetName: string;
   tableComment?: string | null;
   columnComments?: Array<{ name: string; comment: string }>;
+  /** SQL Server only: source primary-key columns recreated on the clone, because
+   * `SELECT ... INTO` copies columns (and IDENTITY) but drops constraints. */
+  primaryKeyColumns?: string[];
   /** Quote character reported by the connected server, for types whose quote is not fixed by the
    * database type alone (Cloud Spanner's two dialects differ). Mirrors `identifierQuote` on the
    * table-data SQL options. */
@@ -262,6 +265,25 @@ export async function buildDuplicateTableStructurePlan(options: DuplicateTableSt
       throw new Error(result.warnings.join("\n") || "Failed to generate Dameng clone DDL.");
     }
     return { sql: result.statements.join("\n"), sourceColumns: columns, executeAsScript: true };
+  }
+
+  // `SELECT TOP 0 * INTO` copies columns and the IDENTITY property but drops constraints, so the
+  // cloned table silently loses its primary key (t8y2/dbx#8931). Load the source primary key and
+  // let the backend append an `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY` for it.
+  if (options.databaseType === "sqlserver") {
+    const indexes = await api.listIndexes(options.connectionId, options.database, options.schema || "", options.sourceName, options.catalog);
+    const primaryKeyColumns = indexes.find((index) => index.is_primary && index.columns.length > 0)?.columns ?? [];
+    const sql = await buildDuplicateTableStructureSql({
+      databaseType: options.databaseType,
+      schema: options.schema,
+      sourceName: options.sourceName,
+      targetName: options.targetName,
+      tableComment: options.tableComment,
+      columnComments: [],
+      primaryKeyColumns,
+      identifierQuote: options.identifierQuote,
+    });
+    return { sql, sourceColumns: options.sourceColumns, executeAsScript: primaryKeyColumns.length > 0 || duplicateTableStructureRequiresScript(sql) };
   }
 
   const sql = await buildDuplicateTableStructureSql({

--- a/apps/desktop/src/lib/sql/sqlCompletion.ts
+++ b/apps/desktop/src/lib/sql/sqlCompletion.ts
@@ -2652,11 +2652,14 @@ function isInOrderOrGroupByContext(beforeCursor: string): boolean {
     .toLowerCase();
   const lastOrderBy = cleaned.lastIndexOf("order by");
   const lastGroupBy = cleaned.lastIndexOf("group by");
-  const lastContext = Math.max(lastOrderBy, lastGroupBy);
+  // MySQL (and DuckDB-like engines) also resolve SELECT aliases inside HAVING,
+  // so aliases stay visible there just like in ORDER BY/GROUP BY.
+  const lastHaving = cleaned.lastIndexOf("having");
+  const lastContext = Math.max(lastOrderBy, lastGroupBy, lastHaving);
   if (lastContext < 0) return false;
 
   const segment = cleaned.slice(lastContext);
-  return !/\b(?:where|having|limit|offset|union|intersect|except|join|from)\b/.test(segment);
+  return !/\b(?:where|limit|offset|union|intersect|except|join|from)\b/.test(segment);
 }
 
 function isInGroupByContext(beforeCursor: string): boolean {

--- a/crates/dbx-core/src/db_admin_sql.rs
+++ b/crates/dbx-core/src/db_admin_sql.rs
@@ -203,6 +203,11 @@ pub struct DuplicateTableStructureSqlOptions {
     pub table_comment: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub column_comments: Vec<DuplicateTableColumnComment>,
+    /// Source primary-key columns to recreate on the clone. SQL Server's
+    /// `SELECT ... INTO` copies columns but drops constraints, so the clone
+    /// needs an explicit `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub primary_key_columns: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier_quote: Option<String>,
 }
@@ -775,10 +780,28 @@ pub fn build_duplicate_table_structure_sql(options: DuplicateTableStructureSqlOp
             Some(format!("COMMENT ON COLUMN {target}.{column_name} IS {}", quote_sql_string(&column.comment)))
         }));
     }
-    if comment_sql.is_empty() {
+
+    // `SELECT ... INTO` copies the IDENTITY property but not constraints, so the cloned table
+    // would silently lose its primary key (t8y2/dbx#8931). Recreate it from the source metadata.
+    let mut constraint_sql = Vec::new();
+    if options.database_type == Some(DatabaseType::SqlServer) && !options.primary_key_columns.is_empty() {
+        let constraint_name = quote_table_identifier(options.database_type, &format!("PK_{}", options.target_name));
+        let key_columns = options
+            .primary_key_columns
+            .iter()
+            .map(|column| quote_table_identifier(options.database_type, column))
+            .collect::<Vec<_>>()
+            .join(", ");
+        constraint_sql
+            .push(format!("ALTER TABLE {target} ADD CONSTRAINT {constraint_name} PRIMARY KEY ({key_columns})"));
+    }
+
+    let mut trailing_sql = constraint_sql;
+    trailing_sql.extend(comment_sql);
+    if trailing_sql.is_empty() {
         return structure_sql;
     }
-    format!("{};\n{};", structure_sql.trim_end_matches(';'), comment_sql.join(";\n"))
+    format!("{};\n{};", structure_sql.trim_end_matches(';'), trailing_sql.join(";\n"))
 }
 
 pub fn build_copy_table_data_sql(options: CopyTableDataSqlOptions) -> String {
@@ -2120,6 +2143,7 @@ mod tests {
                 target_name: "users_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE `users_copy` LIKE `users`;"
@@ -2132,6 +2156,7 @@ mod tests {
                 target_name: "users_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE \"public\".\"users_copy\" (LIKE \"public\".\"users\" INCLUDING ALL);"
@@ -2144,6 +2169,7 @@ mod tests {
                 target_name: "connection_test_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE `dbx_demo`.`connection_test_copy` LIKE `dbx_demo`.`connection_test`;"
@@ -2156,6 +2182,7 @@ mod tests {
                 target_name: "orders_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE `dbx_demo`.`orders_copy` LIKE `dbx_demo`.`orders`;"
@@ -2168,6 +2195,7 @@ mod tests {
                 target_name: "customer_orders_copy".to_string(),
                 table_comment: Some("  Customer's orders; archive  ".to_string()),
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE \"public\".\"customer_orders_copy\" (LIKE \"public\".\"customer_orders\" INCLUDING ALL);\nCOMMENT ON TABLE \"public\".\"customer_orders_copy\" IS '  Customer''s orders; archive  ';"
@@ -2180,6 +2208,7 @@ mod tests {
                 target_name: "users_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE \"public\".\"users_copy\" (LIKE \"public\".\"users\" INCLUDING ALL);"
@@ -2192,6 +2221,7 @@ mod tests {
                 target_name: "users_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "SELECT TOP 0 * INTO [dbo].[users_copy] FROM [dbo].[users];"
@@ -2204,9 +2234,36 @@ mod tests {
                 target_name: "USERS_COPY".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE \"HR\".USERS_COPY AS SELECT * FROM \"HR\".\"USERS\" WHERE 1=0"
+        );
+        assert_eq!(
+            build_duplicate_table_structure_sql(DuplicateTableStructureSqlOptions {
+                database_type: Some(DatabaseType::SqlServer),
+                schema: Some("dbo".to_string()),
+                source_name: "users".to_string(),
+                target_name: "users_copy".to_string(),
+                table_comment: None,
+                column_comments: vec![],
+                primary_key_columns: vec![],
+                identifier_quote: None,
+            }),
+            "SELECT TOP 0 * INTO [dbo].[users_copy] FROM [dbo].[users];"
+        );
+        assert_eq!(
+            build_duplicate_table_structure_sql(DuplicateTableStructureSqlOptions {
+                database_type: Some(DatabaseType::SqlServer),
+                schema: None,
+                source_name: "users".to_string(),
+                target_name: "users_copy".to_string(),
+                table_comment: None,
+                column_comments: vec![],
+                primary_key_columns: vec!["id".to_string(), "seq no".to_string()],
+                identifier_quote: None,
+            }),
+            "SELECT TOP 0 * INTO [users_copy] FROM [users];\nALTER TABLE [users_copy] ADD CONSTRAINT [PK_users_copy] PRIMARY KEY ([id], [seq no]);"
         );
         let dameng_sql = build_duplicate_table_structure_sql(DuplicateTableStructureSqlOptions {
             database_type: Some(DatabaseType::Dameng),
@@ -2222,6 +2279,7 @@ mod tests {
                 DuplicateTableColumnComment { name: "STATUS".to_string(), comment: "active  ".to_string() },
                 DuplicateTableColumnComment { name: "EMPTY".to_string(), comment: " \t\n".to_string() },
             ],
+            primary_key_columns: vec![],
             identifier_quote: None,
         });
         assert_eq!(
@@ -2245,6 +2303,7 @@ mod tests {
             target_name: "users_copy".to_string(),
             table_comment: Some("line1\\path\nline2".to_string()),
             column_comments: vec![],
+            primary_key_columns: vec![],
             identifier_quote: None,
         });
         assert_eq!(
@@ -2260,6 +2319,7 @@ mod tests {
                 target_name: "UsersCopy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE \"APP\".\"UsersCopy\" AS SELECT * FROM \"APP\".\"USERS\" WHERE 1=0"
@@ -2278,6 +2338,7 @@ mod tests {
                 target_name: "copy".to_string(),
                 table_comment: Some("owner\\'s; archive".to_string()),
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             });
             let expected_literal = if database_type == DatabaseType::Redshift {
@@ -2302,6 +2363,7 @@ mod tests {
                 target_name: "tb_a_copy".to_string(),
                 table_comment: None,
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE \"SQLUSER\".\"tb_a_copy\" AS SELECT * FROM \"SQLUSER\".\"tb_a\" WHERE 1=0"
@@ -2314,6 +2376,7 @@ mod tests {
                 target_name: "users_copy".to_string(),
                 table_comment: Some("ignored by QuestDB".to_string()),
                 column_comments: vec![],
+                primary_key_columns: vec![],
                 identifier_quote: None,
             }),
             "CREATE TABLE `users_copy` (LIKE `users`);"


### PR DESCRIPTION
Fixes #8920

## 问题 / Problem

查询编辑器对 `.cm-scroller` 自定义了 WebKit 滚动条样式，但只设置了 `width: 5px`（纵向），漏掉了横向的 `height`。后果：

- 横向滚动条保持浏览器默认厚度（issue 截图中红色框标注的粗条）；
- 因为自定义了 `::-webkit-scrollbar`，WebKit 不再对该滚动容器使用 macOS overlay 自动隐藏，粗滚动条还会**永久占据编辑器底部空间**；
- `border-radius: 999px` 的灰色 thumb 样式两轴共用，粗横向条在视觉上格外突兀。

## 修复 / Fix

`::-webkit-scrollbar` 规则补充 `height: 5px`，横向滚动条与纵向保持一致的 5px 细条（`scrollbar-width: thin` 的 Firefox 回退路径本就两轴生效，无需改动）。

## 测试 / Tests

纯 CSS 修复：与 issue 截图对照，在纵向滚动条已有 5px 样式的编辑器中，横向滚动条随之变细并停止占用额外空间。现有 vitest / vue-tsc 不受影响。