### PR TITLE
fix(editor): apply default transaction mode when binding unbound tabs

### DIFF
--- a/apps/desktop/src/stores/__tests__/queryStore.defaultTransactionMode.spec.ts
+++ b/apps/desktop/src/stores/__tests__/queryStore.defaultTransactionMode.spec.ts
@@ -102,4 +102,34 @@ describe("queryStore default transaction mode", () => {
     const tab = store.tabs.find((item) => item.id === tabId)!;
     expect(tab.autoCommit).toBe(true);
   });
+
+  it("applies the manual default when an unbound file tab binds to a transactional connection", async () => {
+    editorSettings.defaultTransactionMode = "manual";
+    mocks.getConnectionConfig.mockImplementation((connectionId: string) => (connectionId === "mysql-1" ? { id: "mysql-1", name: "MySQL", db_type: "mysql", database: "app" } : undefined));
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    // Externally opened SQL files and saved-SQL tabs start unbound
+    // (connectionId ""), so their initial mode falls back to auto-commit.
+    const tabId = store.createTab("", "", "Query", "query");
+    expect(store.tabs.find((item) => item.id === tabId)!.autoCommit).toBe(true);
+
+    store.updateConnection(tabId, "mysql-1", "app");
+
+    expect(store.tabs.find((item) => item.id === tabId)!.autoCommit).toBe(false);
+  });
+
+  it("keeps the manual default when switching between transactional connections", async () => {
+    editorSettings.defaultTransactionMode = "manual";
+    mocks.getConnectionConfig.mockImplementation((connectionId: string) => (connectionId === "mysql-1" ? { id: "mysql-1", name: "MySQL", db_type: "mysql", database: "app" } : { id: "oracle-1", name: "Oracle", db_type: "oracle", database: "ORCL" }));
+
+    const { useQueryStore } = await import("@/stores/queryStore");
+    const store = useQueryStore();
+    const tabId = store.createTab("oracle-1", "ORCL", "Query", "query", "APP");
+    expect(store.tabs.find((item) => item.id === tabId)!.autoCommit).toBe(false);
+
+    store.updateConnection(tabId, "mysql-1", "app");
+
+    expect(store.tabs.find((item) => item.id === tabId)!.autoCommit).toBe(false);
+  });
 });

--- a/apps/desktop/src/stores/queryStore.ts
+++ b/apps/desktop/src/stores/queryStore.ts
@@ -4165,10 +4165,14 @@ export const useQueryStore = defineStore("query", () => {
     if (tab.oracleTxnPossiblyDirty !== undefined) tab.oracleTxnPossiblyDirty = false;
   }
 
-  function rollbackTabTransaction(tab: QueryTab, options?: { resetAutoCommit?: boolean }) {
+  function rollbackTabTransaction(tab: QueryTab, options?: { resetAutoCommit?: boolean; resetAutoCommitDbType?: string }) {
     if (tab.txnSessionId) void rollbackTransaction(tab.id);
     if (options?.resetAutoCommit) {
-      const dbType = useConnectionStore().getConfig(tab.connectionId)?.db_type;
+      // Callers switching a tab to another connection pass the target db type
+      // explicitly: the tab still carries the previous connectionId at reset
+      // time, and unbound file/saved-SQL tabs have none at all (which would
+      // force auto-commit even when the default mode is manual, #8863).
+      const dbType = options.resetAutoCommitDbType ?? useConnectionStore().getConfig(tab.connectionId)?.db_type;
       tab.autoCommit = defaultAutoCommitForDbTypeWithSetting(dbType);
     }
     clearOracleTxnPossiblyDirty(tab);
@@ -4512,7 +4516,7 @@ export const useQueryStore = defineStore("query", () => {
   function updateConnection(id: string, connectionId: string, database = "", options: UpdateExecutionTargetOptions = {}) {
     const tab = tabs.value.find((t) => t.id === id);
     if (!tab || tab.connectionId === connectionId) return;
-    rollbackTabTransaction(tab, { resetAutoCommit: true });
+    rollbackTabTransaction(tab, { resetAutoCommit: true, resetAutoCommitDbType: useConnectionStore().getConfig(connectionId)?.db_type });
     void closeResultSession(tab);
     void closeClientConnectionSession(tab);
     tab.connectionId = connectionId;


### PR DESCRIPTION
Fixes #8863

## 问题 / Problem

默认事务提交方式设为「手动事务」后，通过 **SQL 库**（保存的 SQL）或**打开 SQL 文件**产生的标签页仍是自动提交：

1. 这两类标签页打开时通常尚未绑定连接（`connectionId: ""`），建 tab 时 dbType 未知，`defaultAutoCommitForDbType` 按设计回退为自动提交；
2. 用户随后在标签页工具栏选择 MySQL 等事务型连接时，`updateConnection` 调用 `rollbackTabTransaction(tab, { resetAutoCommit: true })` 的时机在 `tab.connectionId` 更新**之前**——reset 用的还是旧连接（空）的 dbType，再次推导出自动提交；
3. 结果：全局默认是手动事务，绑定了 MySQL 的 tab 却保持自动提交，语句立即提交，用户在不知情中修改了数据（issue 的 P0 描述）。

## 修复 / Fix

`rollbackTabTransaction` 增加 `resetAutoCommitDbType` 选项；`updateConnection` 显式传入**目标连接**的 dbType，让绑定时按新连接重新应用「默认事务提交方式」设置：

- 未绑定 → MySQL：tab 正确进入手动事务；
- 事务型 → 事务型切换：行为不变（同一设置下推导结果相同）；
- 事务型 → 非事务型：直接得到自动提交（与原先经执行期守卫纠正后的最终状态一致）。

## 测试 / Tests

`queryStore.defaultTransactionMode.spec.ts` 新增 2 个用例：

- 未绑定 tab 绑定到 MySQL 后 `autoCommit === false`（该用例在修复前失败、修复后通过，已用 stash 验证）；
- 事务型连接之间切换保持手动默认（回归保护）。

`vitest` 7/7 通过，`vue-tsc` 无新增错误。