### PR TITLE
修复 Oracle 11g 视图分页首屏性能和排序问题

### DIFF
--- a/crates/dbx-core/src/sql_dialect/table_select.rs
+++ b/crates/dbx-core/src/sql_dialect/table_select.rs
@@ -276,9 +276,6 @@ pub fn build_table_data_select_sql_with_database(
     let include_xugu_row_id =
         options.include_row_id && uses_xugu_row_id(database_type) && !is_view_table_type(options.table_type.as_deref());
     let offset = options.offset.unwrap_or(0);
-    let oracle_view_first_page =
-        database_type == Some(DatabaseType::Oracle) && is_view_table_type(options.table_type.as_deref()) && offset == 0;
-
     let select_columns = if include_oracle_row_id {
         format!("ROWIDTOCHAR(t.ROWID) AS \"{DBX_ROWID_COLUMN}\", t.*")
     } else if let Some(preview_columns) = build_large_value_preview_columns(&options) {
@@ -362,9 +359,6 @@ pub fn build_table_data_select_sql_with_database(
             )
         }
         TablePaginationStrategy::Rownum => {
-            if oracle_view_first_page {
-                return format!("SELECT {page_select_columns} FROM {table_alias}{where_clause}{order}");
-            }
             let rownum_inner_select_columns =
                 if include_oracle_row_id { &select_columns } else { &rownum_select_columns };
             build_rownum_table_select_sql(

--- a/crates/dbx-core/src/sql_dialect/tests.rs
+++ b/crates/dbx-core/src/sql_dialect/tests.rs
@@ -1423,7 +1423,7 @@ fn builds_oracle_and_neo4j_table_data_queries() {
             include_row_id: true,
             ..Default::default()
         }),
-        "SELECT \"ID\", \"NAME\" FROM \"DBXTEST\".\"DBX_JOIN_VIEW\""
+        "SELECT \"ID\", \"NAME\" FROM (SELECT \"ID\", \"NAME\" FROM \"DBXTEST\".\"DBX_JOIN_VIEW\") WHERE ROWNUM <= 100"
     );
     assert_eq!(
             build_table_data_select_sql(TableDataSelectSqlOptions {
@@ -1490,7 +1490,7 @@ fn builds_oracle_rowid_wrapped_large_value_reload_sql() {
 }
 
 #[test]
-fn oracle_view_first_page_preserves_filter_and_sort_without_rownum() {
+fn oracle_view_first_page_is_bounded_and_preserves_filter_and_sort() {
     assert_eq!(
         build_table_data_select_sql(TableDataSelectSqlOptions {
             database_type: Some(DatabaseType::Oracle),
@@ -1505,7 +1505,7 @@ fn oracle_view_first_page_preserves_filter_and_sort_without_rownum() {
             include_row_id: true,
             ..Default::default()
         }),
-        "SELECT \"ID\", \"NAME\" FROM \"DBXTEST\".\"DBX_JOIN_VIEW\" WHERE (STATUS = 'A') ORDER BY \"ID\" DESC"
+        "SELECT \"ID\", \"NAME\" FROM (SELECT \"ID\", \"NAME\" FROM \"DBXTEST\".\"DBX_JOIN_VIEW\" WHERE (STATUS = 'A') ORDER BY \"ID\" DESC) WHERE ROWNUM <= 100"
     );
 }
 
@@ -1518,12 +1518,13 @@ fn oracle_view_later_pages_keep_rownum_pagination() {
             table_name: "DBX_JOIN_VIEW".to_string(),
             table_type: Some("VIEW".to_string()),
             columns: vec!["ID".to_string(), "NAME".to_string()],
+            order_by: Some("\"ID\" DESC".to_string()),
             limit: Some(100),
             offset: Some(100),
             include_row_id: true,
             ..Default::default()
         }),
-        "SELECT \"ID\", \"NAME\" FROM (SELECT dbx_inner.*, ROWNUM AS \"__dbx_row_num\" FROM (SELECT \"ID\", \"NAME\" FROM \"DBXTEST\".\"DBX_JOIN_VIEW\") dbx_inner WHERE ROWNUM <= 200) WHERE \"__dbx_row_num\" > 100"
+        "SELECT \"ID\", \"NAME\" FROM (SELECT dbx_inner.*, ROWNUM AS \"__dbx_row_num\" FROM (SELECT \"ID\", \"NAME\" FROM \"DBXTEST\".\"DBX_JOIN_VIEW\" ORDER BY \"ID\" DESC) dbx_inner WHERE ROWNUM <= 200) WHERE \"__dbx_row_num\" > 100"
     );
 }
 


### PR DESCRIPTION
## 问题

Oracle 11g 视图分页第一页没有生成 ROWNUM 上限，Oracle 会先执行完整视图查询，再由客户端截断结果，导致首屏和翻页耗时偏高。视图分页第一页与后续页使用不同 SQL 形态，也增加了分页边界和排序异常的风险。

## 修复

- 移除 Oracle 视图第一页绕过 ROWNUM 分页的特殊路径。
- 统一使用 Oracle 11g 兼容的 ROWNUM 分页 SQL。
- 保留 WHERE 和 ORDER BY 到内层查询，确保第一页、后续页使用一致的过滤和排序。
- 增加 Oracle 视图第一页和后续页的回归测试。

## 实测

- 使用真实 Oracle XE 11g 连接创建 250 行临时测试表和视图。
- 修复前生成的第一页 SQL 不含 ROWNUM 上限，实际执行后由客户端截断。
- 修复后第一页返回 ID 250..151，第二页返回 150..51，顺序连续且无重复；两条 SQL 均保留 `EVENT_TIME DESC`。
- 测试表和视图已清理。

## 验证

- `cargo fmt --package dbx-core -- --check`
- `cargo test -p dbx-core --lib sql_dialect`（127 项通过）
- `cargo check -p dbx-core -p dbx-web`
- `git diff --check`

## 关联 Issue

Fixes #8936