### PR TITLE
fix(grid): keep the Mongo null sentinel out of inline cell editors

### DIFF
--- a/apps/desktop/src/components/grid/DataGrid.vue
+++ b/apps/desktop/src/components/grid/DataGrid.vue
@@ -3947,6 +3947,11 @@ function isIoTDBTimestampColumn(columnIndex: number): boolean {
 }
 
 function inlineCellEditorText(value: CellValue, columnIndex: number): string {
+  // Keyboard-driven cell edits must match the double-click path: the Mongo
+  // collection grid's internal null sentinel (and escaped strings) must not
+  // leak into the editor as raw text (#8812).
+  const documentGridText = props.mongoCollectionGrid ? mongoDocumentGridEditorText(value) : undefined;
+  if (documentGridText !== undefined) return documentGridText;
   const columnInfo = tableColumnForGridColumn(columnIndex) ?? resultColumnInfoForGridColumn(columnIndex);
   const columnType = props.result.column_types?.[columnIndex] ?? columnInfo?.data_type;
   return (

--- a/apps/desktop/src/components/grid/__tests__/DataGridMongoInlineNullEditor.spec.ts
+++ b/apps/desktop/src/components/grid/__tests__/DataGridMongoInlineNullEditor.spec.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dataGridSource = readFileSync(new URL("../DataGrid.vue", import.meta.url), "utf8");
+
+describe("DataGrid Mongo inline null editor", () => {
+  // #8812: keyboard-driven cell edits read the initial text from
+  // inlineCellEditorText. It must translate the Mongo collection grid's
+  // internal null sentinel (and escaped strings) exactly like the double-click
+  // path (cellEditorTextForValue), instead of leaking the raw sentinel into
+  // the editor.
+  it("routes inline editor text through the Mongo document-grid translation", () => {
+    expect(dataGridSource).toContain("const documentGridText = props.mongoCollectionGrid ? mongoDocumentGridEditorText(value) : undefined;");
+    expect(dataGridSource).toContain("if (documentGridText !== undefined) return documentGridText;");
+  });
+
+  it("keeps the sentinel out of the raw editor fallback for grid edits", () => {
+    const inlineBlock = dataGridSource.slice(dataGridSource.indexOf("function inlineCellEditorText"), dataGridSource.indexOf("function normalizeTemporalCellEditorValue"));
+    expect(inlineBlock).toContain("mongoDocumentGridEditorText(value)");
+  });
+});


### PR DESCRIPTION
Fixes #8812

## 问题 / Problem

MongoDB 集合网格用内部哨兵值区分「BSON null」与「字段不存在 / 字面量 NULL 字符串」。双击进入单元格编辑时会经 `mongoDocumentGridEditorText` 转换为 NULL 文本，但键盘进入编辑（选中后按 Enter 等路径）的初值来自 `inlineCellEditorText`——该函数缺少 Mongo 分支，直接把原始哨兵（含 \0 前缀）塞进编辑框，即 issue 截图中的 `@dbx:mongo-document-grid:null`。

## 修复 / Fix

`inlineCellEditorText` 增加与双击路径（`cellEditorTextForValue`）一致的文档网格转换分支：哨兵 → NULL、转义字符串 → 原文；IoTDB 时间戳与通用回退逻辑不变。提交侧本就统一经 `mongoDocumentGridInputValue` 处理（NULL → BSON null），无需改动。

## 测试 / Tests

新增源码断言 spec（`DataGridMongoInlineNullEditor.spec.ts`，与 DataGrid 组件既有测试约定一致）：inline 编辑初值必须经 `mongoDocumentGridEditorText` 转换；相邻网格编辑 spec（useDataGridEditor / useDataGridCellDetailEdit）59/59 通过，`vue-tsc` 无新增错误。

## 附注

issue 中「NULL 与字符串 'NULL' 颜色无法区分，建议改灰色」属于展示样式偏好，建议维护者另行评估；本 PR 只修哨兵泄露这一明确缺陷。