### PR TITLE
🐛 fix(sidebar): 修复本地表搜索结果置顶状态丢失

### DIFF
--- a/apps/desktop/src/components/sidebar/ConnectionTree.vue
+++ b/apps/desktop/src/components/sidebar/ConnectionTree.vue
@@ -10,6 +10,7 @@ import { useToast } from "@/composables/useToast";
 import type { ObjectSourceKind, QueryTab, TableInfo, TableNameFilter, TreeNode, TreeNodeType } from "@/types/database";
 import type { ElasticsearchIndexMetadataKind } from "@/lib/backend/tauri";
 import {
+  filterLocallySearchedTables,
   createSidebarSearchSubtreePreserver,
   filterSidebarSearchRootsByConnectionState,
   filterSidebarTree,
@@ -18,15 +19,13 @@ import {
   mergeSidebarRegexIndexScopes,
   resolveSidebarFilterGuards,
   resolveSidebarObjectSearchFilter,
-  reuseLiveSidebarTreeNodes,
   type SidebarRegexIndexScope,
   type SidebarRegexScopeIdentity,
 } from "@/lib/sidebar/sidebarSearchTree";
-import { createSidebarLabelMatcher, matchSidebarLabel } from "@/lib/sidebar/sidebarSearch";
+import { createSidebarLabelMatcher } from "@/lib/sidebar/sidebarSearch";
 import { collectSidebarRegexIndexScopes, resolveSidebarRemoteSearchQuery, resolveSidebarSearchDispatchMode } from "@/lib/sidebar/sidebarRegexSearchIndex";
 import { createSidebarSearchExpansionState } from "@/lib/sidebar/sidebarSearchExpansionState";
 import { createSidebarSearchLoadingTracker } from "@/lib/sidebar/sidebarSearchLoadingTracker";
-import { buildTableTreeNodes } from "@/lib/table/tableTree";
 import { isCancelSearchShortcut, isCopySidebarSelectionShortcut, isEditSidebarConnectionShortcut, isPasteSidebarSelectionShortcut, isViewTableDdlShortcut } from "@/lib/editor/keyboardShortcuts";
 import { sidebarNodeSupportsDdlView } from "@/lib/sidebar/sidebarTreeDdlShortcut";
 import { objectSourceTargetForTreeNode } from "@/lib/sidebar/treeNodeClick";
@@ -658,28 +657,6 @@ type InvalidatedTableSearchScope = SidebarRegexScopeIdentity & { parentNodeId: s
 const pendingInvalidatedTableSearchScopes = new Map<string, InvalidatedTableSearchScope>();
 const regexTableSearchScopes = shallowRef<SidebarRegexIndexScope[]>([]);
 
-const localTableSearchParentTypes = new Set<TreeNodeType>(["database", "schema", "linked-server-schema", "group-tables"]);
-const localTableSearchChildTypes = new Set<TreeNodeType>(["table", "view", "materialized_view"]);
-
-function filterLocallySearchedTables(nodes: TreeNode[]): TreeNode[] {
-  return nodes.map((node) => {
-    const children = node.children ? filterLocallySearchedTables(node.children) : undefined;
-    const query = settingsStore.editorSettings.sidebarTableSearchLocal && localTableSearchParentTypes.has(node.type) ? store.sidebarTableSearchQueries[node.id]?.trim() : "";
-    if (!query || !children) return children === node.children ? node : { ...node, children };
-
-    const indexed = localTableSearchResults.value[node.id];
-    // matchSidebarLabel compares case-insensitively internally and needs the
-    // ORIGINAL label (and entry name) so camelCase boundaries stay detectable.
-    const matchingChildren =
-      indexed === null
-        ? children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label, query))
-        : indexed
-          ? reuseLiveSidebarTreeNodes(buildTableTreeNodes({ nodeId: node.id, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, tables: indexed.filter((entry) => !!matchSidebarLabel(entry.name, query)) }), children)
-          : children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label, query));
-    return { ...node, children: matchingChildren };
-  });
-}
-
 async function loadRegexTableSearchIndexes() {
   if (!regexMode.value || !deferredSearchQuery.value) return;
   const loadedScopes = await collectSidebarRegexIndexScopes(
@@ -781,7 +758,7 @@ const filteredNodes = computed(() => {
     nodes = filterSidebarTreeToConnectedConnections(nodes, store.connectedIds);
   }
 
-  nodes = filterLocallySearchedTables(nodes);
+  nodes = filterLocallySearchedTables(nodes, { enabled: settingsStore.editorSettings.sidebarTableSearchLocal, queries: store.sidebarTableSearchQueries, indexedResults: localTableSearchResults.value });
   nodes = filterGloballyIndexedRegexTables(nodes);
 
   const q = deferredSearchQuery.value;

--- a/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
+++ b/apps/desktop/src/lib/sidebar/sidebarSearchTree.ts
@@ -1,5 +1,5 @@
 import type { TableInfo, TreeNode, TreeNodeType } from "@/types/database";
-import { createSidebarLabelMatcher, type SidebarLabelMatcher, type SidebarSearchMatcherOptions } from "@/lib/sidebar/sidebarSearch";
+import { createSidebarLabelMatcher, matchSidebarLabel, type SidebarLabelMatcher, type SidebarSearchMatcherOptions } from "@/lib/sidebar/sidebarSearch";
 import { buildTableTreeNodes } from "@/lib/table/tableTree";
 
 const preserveMatchedSubtreeTypes = new Set(["connection", "database", "schema", "table", "view", "mongo-db", "mongo-collection"]);
@@ -72,6 +72,31 @@ export function reuseLiveSidebarTreeNodes(indexedNodes: TreeNode[], liveNodes: r
   return indexedNodes.map((node) => liveNodesById.get(node.id) ?? node);
 }
 
+const localTableSearchParentTypes = new Set<TreeNodeType>(["database", "schema", "linked-server-schema", "group-tables"]);
+const localTableSearchChildTypes = new Set<TreeNodeType>(["table", "view", "materialized_view"]);
+
+export function filterLocallySearchedTables(nodes: TreeNode[], options: { enabled: boolean; queries: Readonly<Record<string, string>>; indexedResults: Readonly<Record<string, TableInfo[] | null>> }): TreeNode[] {
+  return nodes.map((node) => {
+    const children = node.children ? filterLocallySearchedTables(node.children, options) : undefined;
+    const query = options.enabled && localTableSearchParentTypes.has(node.type) ? options.queries[node.id]?.trim() : "";
+    if (!query || !children) return children === node.children ? node : { ...node, children };
+
+    const indexed = options.indexedResults[node.id];
+    // matchSidebarLabel compares case-insensitively internally and needs the
+    // ORIGINAL label (and entry name) so camelCase boundaries stay detectable.
+    const matchingChildren =
+      indexed === null
+        ? children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label, query))
+        : indexed
+          ? reuseLiveSidebarTreeNodes(
+              buildSidebarIndexedTableNodes({ parentNodeId: node.id, nodeType: node.type, connectionId: node.connectionId || "", database: node.database || "", schema: node.schema, catalog: node.catalog, entries: indexed.filter((entry) => !!matchSidebarLabel(entry.name, query)) }),
+              children,
+            )
+          : children.filter((child) => localTableSearchChildTypes.has(child.type) && !!matchSidebarLabel(child.label, query));
+    return { ...node, children: matchingChildren };
+  });
+}
+
 export interface SidebarRegexIndexScope {
   parentNodeId: string;
   connectionId: string;
@@ -132,7 +157,7 @@ export function findNodePathByIdentity(nodes: readonly TreeNode[], id: string, i
   return undefined;
 }
 
-function indexedTableChildren(scope: SidebarRegexIndexScope): TreeNode[] {
+export function buildSidebarIndexedTableNodes(scope: SidebarRegexIndexScope): TreeNode[] {
   // Reuse the regular table-node builder so index hits share live-node id
   // rules, normalized object types, name sorting, catalog/schema fields, and
   // partition parent/child nesting instead of hand-rolled node literals.
@@ -143,6 +168,10 @@ function indexedTableChildren(scope: SidebarRegexIndexScope): TreeNode[] {
     schema: scope.schema,
     catalog: scope.catalog,
     tables: scope.entries,
+    // Grouped object lists include the schema in each child id; simple table
+    // lists do not. Search must use the same id because persisted pin keys
+    // include it, even when an index hit has not been loaded into the live tree.
+    includeSchemaInId: scope.nodeType === "group-tables",
   });
 }
 
@@ -160,7 +189,7 @@ function syntheticRegexParent(scope: SidebarRegexIndexScope): TreeNode {
     ...(snapshot?.linkedCatalog ? { linkedCatalog: snapshot.linkedCatalog } : {}),
     ...(snapshot?.linkedSchema ? { linkedSchema: snapshot.linkedSchema } : {}),
     isExpanded: true,
-    children: indexedTableChildren(scope),
+    children: buildSidebarIndexedTableNodes(scope),
   };
 }
 

--- a/apps/desktop/src/lib/table/tableTree.ts
+++ b/apps/desktop/src/lib/table/tableTree.ts
@@ -7,7 +7,7 @@ export function normalizeDatabaseObjectName(name: string): string {
   return name.trim();
 }
 
-export function buildTableTreeNodes({ nodeId, connectionId, database, schema, tables, catalog }: { nodeId: string; connectionId: string; database: string; schema?: string; tables: TableInfo[]; catalog?: string }): TreeNode[] {
+export function buildTableTreeNodes({ nodeId, connectionId, database, schema, tables, catalog, includeSchemaInId = false }: { nodeId: string; connectionId: string; database: string; schema?: string; tables: TableInfo[]; catalog?: string; includeSchemaInId?: boolean }): TreeNode[] {
   const entries = tables.flatMap((table) => {
     const name = normalizeDatabaseObjectName(table.name);
     if (!name) return [];
@@ -19,7 +19,7 @@ export function buildTableTreeNodes({ nodeId, connectionId, database, schema, ta
         connectionId,
         database,
         schema: childSchema,
-        includeSchemaInId: false,
+        includeSchemaInId,
         name,
         objectType,
         tableType: table.table_type,

--- a/packages/app-tests/connectionStorePinnedCleanup.test.ts
+++ b/packages/app-tests/connectionStorePinnedCleanup.test.ts
@@ -2,6 +2,9 @@ import { test } from "vitest";
 import assert from "node:assert/strict";
 import { createPinia, setActivePinia } from "pinia";
 import { useConnectionStore } from "../../apps/desktop/src/stores/connectionStore.ts";
+import { filterLocallySearchedTables } from "../../apps/desktop/src/lib/sidebar/sidebarSearchTree.ts";
+import { buildGroupedObjectTreeNodes, buildTableTreeNodes } from "../../apps/desktop/src/lib/table/tableTree.ts";
+import { applyPinnedTreeNodeState } from "../../apps/desktop/src/lib/app/pinnedItems.ts";
 import type { ConnectionConfig } from "../../apps/desktop/src/types/database.ts";
 
 function installMemoryStorage(initial: Record<string, string> = {}) {
@@ -169,6 +172,63 @@ test("removeConnections clears persisted sidebar table filters for every removed
     });
   } finally {
     globalThis.fetch = originalFetch;
+    storage.restore();
+  }
+});
+
+test.each([
+  { label: "PostgreSQL grouped", schema: "public", grouped: true },
+  { label: "PostgreSQL simple", schema: "public", grouped: false },
+  { label: "MySQL grouped", schema: undefined, grouped: true },
+])("$label keeps a search pin after clearing search and allows unpinning", ({ schema, grouped }) => {
+  const storage = installMemoryStorage();
+  try {
+    setActivePinia(createPinia());
+    const store = useConnectionStore();
+    const context = { nodeId: "conn:app", connectionId: "conn", database: "app", schema };
+    const tables = ["aaa", "orders"].map((name) => ({ name, table_type: "TABLE" }));
+    const buildGroup = () => grouped
+      ? buildGroupedObjectTreeNodes({ ...context, objects: tables.map((table) => ({ name: table.name, object_type: table.table_type, schema })) })[0]
+      : { id: context.nodeId, label: "app", type: "schema" as const, ...context, children: buildTableTreeNodes({ ...context, tables }) };
+    const group = buildGroup();
+    store.treeNodes = [group];
+    const liveGroup = store.treeNodes[0];
+    const target = liveGroup.children!.find((node) => node.label === "orders")!;
+    const project = (enabled = true) => filterLocallySearchedTables(store.treeNodes, {
+      enabled, queries: store.sidebarTableSearchQueries, indexedResults: { [group.id]: tables },
+    })[0].children!;
+
+    store.setSidebarTableSearchQuery(group.id, "orders");
+    assert.deepEqual(project().map((node) => node.label), ["orders"]);
+    assert.deepEqual(project(false).map((node) => node.label), ["aaa", "orders"]);
+    store.toggleTreeNodePin(project()[0]);
+    store.setSidebarTableSearchQuery(group.id, "");
+    const cleared = project();
+    assert.deepEqual(cleared.map((node) => node.label), ["orders", "aaa"]);
+    assert.equal(cleared[0].pinned, true);
+    assert.equal(target.pinned, true);
+    assert.equal(store.isTreeNodePinned(cleared[0]), true);
+
+    store.setSidebarTableSearchQuery(group.id, "orders");
+    assert.equal(project()[0].pinned, true);
+    store.toggleTreeNodePin(project()[0]);
+    store.setSidebarTableSearchQuery(group.id, "");
+    assert.deepEqual(project().map((node) => node.label), ["aaa", "orders"]);
+    assert.equal(target.pinned, false);
+    assert.deepEqual(JSON.parse(storage.values.get("dbx-pinned-tree-nodes")!), []);
+
+    // Separate from clearing search: an index-only hit survives metadata reload.
+    liveGroup.children = liveGroup.children!.filter((node) => node.label !== "orders");
+    store.setSidebarTableSearchQuery(group.id, "orders");
+    store.toggleTreeNodePin(project()[0]);
+    const saved = new Set<string>(JSON.parse(storage.values.get("dbx-pinned-tree-nodes")!));
+    const restored = applyPinnedTreeNodeState(buildGroup().children!, saved);
+    assert.equal(restored[0].label, "orders");
+    assert.equal(restored[0].pinned, true);
+    assert.equal(store.isTreeNodePinned(restored[0]), true);
+    store.toggleTreeNodePin(restored[0]);
+    assert.deepEqual(JSON.parse(storage.values.get("dbx-pinned-tree-nodes")!), []);
+  } finally {
     storage.restore();
   }
 });

--- a/packages/app-tests/sidebarTreeAffordances.test.ts
+++ b/packages/app-tests/sidebarTreeAffordances.test.ts
@@ -7,6 +7,7 @@ import type { TreeNode } from "../../apps/desktop/src/types/database.ts";
 const treeItem = readFileSync("apps/desktop/src/components/sidebar/TreeItem.vue", "utf8");
 const runtimeHost = readFileSync("apps/desktop/src/components/sidebar/SidebarTreeRuntimeHost.vue", "utf8");
 const connectionTree = readFileSync("apps/desktop/src/components/sidebar/ConnectionTree.vue", "utf8");
+const sidebarSearchTree = readFileSync("apps/desktop/src/lib/sidebar/sidebarSearchTree.ts", "utf8");
 const connectionStore = readFileSync("apps/desktop/src/stores/connectionStore.ts", "utf8");
 
 test("sidebar rows retain database-specific node affordances", () => {
@@ -87,8 +88,8 @@ test("async tree expansion does not restore a stale rendered clone state", () =>
 });
 
 test("tree filters retain a temporary expansion state", () => {
-  assert.match(connectionTree, /return \{ \.\.\.node, children: matchingChildren \};/);
-  assert.doesNotMatch(connectionTree, /children: matchingChildren,\s*isExpanded:\s*true/);
+  assert.match(sidebarSearchTree, /return \{ \.\.\.node, children: matchingChildren \};/);
+  assert.doesNotMatch(sidebarSearchTree, /children: matchingChildren,\s*isExpanded:\s*true/);
   assert.match(connectionTree, /function onSearchToggle\(node: TreeNode\) \{\s*if \(!isTreeSearchFiltering\.value \|\| !node\.children\) return;/);
   // The search guard must stay the first thing in onNodeToggled (filter toggles
   // must never sync back to the live tree); side-effect-free diagnostics may be


### PR DESCRIPTION
- 统一本地搜索与正则搜索的索引表节点构建逻辑
- 分组对象列表生成节点时保留 schema 标识，确保置顶键一致
- 支持搜索命中未加载到实时树时正确置顶和取消置顶
- 补充 PostgreSQL、MySQL 分组及普通表列表的置顶回归测试

## 变更说明 / Change Description

<!-- 简要描述这个 PR 做了什么 / Briefly describe what this PR changes. -->

## 变更类型 / Change Type

- [ ] 新功能 / New feature
- [ ] Bug 修复 / Bug fix
- [ ] 性能优化 / Performance improvement
- [ ] 代码重构 / Code refactoring
- [ ] 文档更新 / Documentation
- [ ] CI / 构建 / CI or build

## 涉及前端 / Frontend Changes

<!-- 如果 PR 涉及任何前端改动（UI 组件、样式、交互、文案等），必须附截图或录屏 / If this PR changes UI components, styles, interactions, or user-facing text, include screenshots or a recording. -->

- [x] 本 PR 涉及前端改动，已附截图/录屏（见下方） / This PR includes frontend changes and screenshots or a recording are attached below.

<!-- 截图区域 / Screenshots or recording -->

<img width="660" height="734" alt="58409FFC-2EBA-46D0-AC8F-A175DFF5BC11" src="https://github.com/user-attachments/assets/85bdd718-43b1-44ac-b8ce-2b1d07d7e6d3" />


## 验证 / Validation

<!-- 说明如何验证你的改动，例如：命令、测试用例、手动操作步骤 / Explain how you verified the change, including commands, tests, or manual steps. -->

- [ ] `make check` 通过 / `make check` passes
- [ ] `make cargo-check-fast` 通过 / `make cargo-check-fast` passes
- [ ] 相关测试通过 / Relevant tests pass

## 关联 Issue / Related Issue

<!-- 如有，填写 `Close #xxx` 或 `Related #xxx` / If applicable, use `Close #xxx` or `Related #xxx`. -->

close #8964