### PR TITLE
fix: 避免 SQL Server 2000 展开数据库节点触发火绒误报

### DIFF
--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-05T19:48:58.447Z",
-  "stars": 18078,
+  "generatedAt": "2026-09-06T19:52:45.102Z",
+  "stars": 18128,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3410,
+      "commits": 3421,
       "mergedPullRequests": 26,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-02T10:17:27Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 709,
-      "mergedPullRequests": 710,
+      "commits": 711,
+      "mergedPullRequests": 712,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-04T16:42:08Z"
+      "latestContributionAt": "2026-09-06T16:54:59Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 217,
-      "mergedPullRequests": 216,
+      "commits": 221,
+      "mergedPullRequests": 221,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-05T02:01:55Z"
+      "latestContributionAt": "2026-09-06T18:18:29Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 141,
-      "mergedPullRequests": 141,
+      "commits": 144,
+      "mergedPullRequests": 144,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-09-05T15:26:20Z"
+      "latestContributionAt": "2026-09-06T14:14:30Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -61,10 +61,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 84,
-      "mergedPullRequests": 84,
+      "commits": 87,
+      "mergedPullRequests": 87,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-05T01:52:52Z"
+      "latestContributionAt": "2026-09-06T10:24:45Z"
     },
     {
       "login": "onenewcode",
@@ -97,10 +97,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 42,
-      "mergedPullRequests": 42,
+      "commits": 44,
+      "mergedPullRequests": 44,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-09-04T08:46:37Z"
+      "latestContributionAt": "2026-09-06T02:52:51Z"
     },
     {
       "login": "Illuminated2020",
@@ -229,6 +229,15 @@
       "latestContributionAt": "2026-08-20T10:50:22Z"
     },
     {
+      "login": "dienaso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
+      "profileUrl": "https://github.com/dienaso",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-07-24T03:23:39Z",
+      "latestContributionAt": "2026-09-06T07:00:01Z"
+    },
+    {
       "login": "juvevood",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1421513?v=4",
       "profileUrl": "https://github.com/juvevood",
@@ -272,15 +281,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-02T16:19:01Z",
       "latestContributionAt": "2026-09-02T17:45:09Z"
-    },
-    {
-      "login": "dienaso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
-      "profileUrl": "https://github.com/dienaso",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-08-18T04:43:31Z"
     },
     {
       "login": "guoyongchang",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,34 +1,34 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-01T20:24:34.300Z",
-  "stars": 17677,
+  "generatedAt": "2026-09-02T20:24:52.802Z",
+  "stars": 17802,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3336,
-      "mergedPullRequests": 24,
+      "commits": 3351,
+      "mergedPullRequests": 26,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-09-01T09:38:19Z"
+      "latestContributionAt": "2026-09-02T10:17:27Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 668,
-      "mergedPullRequests": 669,
+      "commits": 688,
+      "mergedPullRequests": 689,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-01T16:27:45Z"
+      "latestContributionAt": "2026-09-02T19:35:22Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 202,
-      "mergedPullRequests": 201,
+      "commits": 206,
+      "mergedPullRequests": 205,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-01T15:36:15Z"
+      "latestContributionAt": "2026-09-02T12:20:26Z"
     },
     {
       "login": "q396921921",
@@ -43,37 +43,37 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 105,
-      "mergedPullRequests": 93,
+      "commits": 106,
+      "mergedPullRequests": 94,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-01T03:01:00Z"
+      "latestContributionAt": "2026-09-02T12:37:40Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 78,
-      "mergedPullRequests": 78,
+      "commits": 82,
+      "mergedPullRequests": 82,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-09-01T15:45:33Z"
-    },
-    {
-      "login": "onenewcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
-      "profileUrl": "https://github.com/onenewcode",
-      "commits": 70,
-      "mergedPullRequests": 70,
-      "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-01T05:18:42Z"
+      "latestContributionAt": "2026-09-02T17:53:42Z"
     },
     {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 68,
-      "mergedPullRequests": 68,
+      "commits": 75,
+      "mergedPullRequests": 75,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-01T08:18:58Z"
+      "latestContributionAt": "2026-09-02T12:36:34Z"
+    },
+    {
+      "login": "onenewcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
+      "profileUrl": "https://github.com/onenewcode",
+      "commits": 71,
+      "mergedPullRequests": 71,
+      "firstContributionAt": "2026-06-30T01:53:31Z",
+      "latestContributionAt": "2026-09-02T06:17:49Z"
     },
     {
       "login": "serenez",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-08-24T10:35:18Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 41,
+      "mergedPullRequests": 41,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-09-02T17:53:55Z"
+    },
+    {
       "login": "Illuminated2020",
       "avatarUrl": "https://avatars.githubusercontent.com/u/95458741?v=4",
       "profileUrl": "https://github.com/Illuminated2020",
@@ -101,15 +110,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-12T09:13:51Z",
       "latestContributionAt": "2026-05-12T09:22:36Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 39,
-      "mergedPullRequests": 39,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-31T16:34:12Z"
     },
     {
       "login": "xddcode",
@@ -265,6 +265,15 @@
       "latestContributionAt": "2026-08-26T13:38:10Z"
     },
     {
+      "login": "DengQingNian",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/117324885?v=4",
+      "profileUrl": "https://github.com/DengQingNian",
+      "commits": 11,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-06-02T16:19:01Z",
+      "latestContributionAt": "2026-09-02T17:45:09Z"
+    },
+    {
       "login": "dienaso",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
       "profileUrl": "https://github.com/dienaso",
@@ -301,15 +310,6 @@
       "latestContributionAt": "2026-05-09T06:42:25Z"
     },
     {
-      "login": "DengQingNian",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/117324885?v=4",
-      "profileUrl": "https://github.com/DengQingNian",
-      "commits": 10,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-06-02T16:19:01Z",
-      "latestContributionAt": "2026-07-27T14:47:00Z"
-    },
-    {
       "login": "chenhbb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
       "profileUrl": "https://github.com/chenhbb",
@@ -335,6 +335,24 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-09-02T06:12:36Z"
+    },
+    {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-09-02T17:13:06Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -371,15 +389,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-31T04:15:42Z",
       "latestContributionAt": "2026-08-29T20:17:33Z"
-    },
-    {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-27T04:21:29Z"
     },
     {
       "login": "Jinmoli",
@@ -445,6 +454,15 @@
       "latestContributionAt": "2026-07-01T11:05:45Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-09-02T06:15:04Z"
+    },
+    {
       "login": "possebon",
       "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
       "profileUrl": "https://github.com/possebon",
@@ -452,15 +470,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-08-02T17:09:52Z",
       "latestContributionAt": "2026-08-08T03:04:17Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-26T05:52:42Z"
     },
     {
       "login": "xiaou61",
@@ -535,15 +544,6 @@
       "latestContributionAt": "2026-08-25T06:46:25Z"
     },
     {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-09-01T05:11:59Z"
-    },
-    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -560,6 +560,15 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
+    },
+    {
+      "login": "1320209572",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
+      "profileUrl": "https://github.com/1320209572",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-09-01T05:03:42Z",
+      "latestContributionAt": "2026-09-02T17:53:31Z"
     },
     {
       "login": "azens",
@@ -697,6 +706,15 @@
       "latestContributionAt": "2026-08-11T13:32:15Z"
     },
     {
+      "login": "Clarence404",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36807519?v=4",
+      "profileUrl": "https://github.com/Clarence404",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-01T05:51:25Z",
+      "latestContributionAt": "2026-09-02T08:56:13Z"
+    },
+    {
       "login": "domye",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
       "profileUrl": "https://github.com/domye",
@@ -805,6 +823,15 @@
       "latestContributionAt": "2026-08-20T13:01:23Z"
     },
     {
+      "login": "StaravenX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
+      "profileUrl": "https://github.com/StaravenX",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-26T11:48:56Z",
+      "latestContributionAt": "2026-09-02T01:15:10Z"
+    },
+    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -812,6 +839,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-13T11:23:45Z",
       "latestContributionAt": "2026-06-24T06:53:47Z"
+    },
+    {
+      "login": "wangfengxiang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31534139?v=4",
+      "profileUrl": "https://github.com/wangfengxiang",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-31T09:52:03Z",
+      "latestContributionAt": "2026-09-02T18:09:49Z"
     },
     {
       "login": "wds824",
@@ -893,6 +929,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-27T10:43:39Z",
       "latestContributionAt": "2026-09-01T03:09:45Z"
+    },
+    {
+      "login": "doersa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6913871?v=4",
+      "profileUrl": "https://github.com/doersa",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-01T03:09:57Z",
+      "latestContributionAt": "2026-09-02T12:38:17Z"
     },
     {
       "login": "Doracoin",
@@ -1057,15 +1102,6 @@
       "latestContributionAt": "2026-08-09T15:33:24Z"
     },
     {
-      "login": "StaravenX",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
-      "profileUrl": "https://github.com/StaravenX",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-26T11:48:56Z",
-      "latestContributionAt": "2026-08-28T07:29:07Z"
-    },
-    {
       "login": "TangTangH",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
       "profileUrl": "https://github.com/TangTangH",
@@ -1172,15 +1208,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-03T18:36:11Z",
       "latestContributionAt": "2026-05-05T09:30:42Z"
-    },
-    {
-      "login": "1320209572",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
-      "profileUrl": "https://github.com/1320209572",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-01T05:03:42Z",
-      "latestContributionAt": "2026-09-01T05:55:38Z"
     },
     {
       "login": "2090230619-syq",
@@ -1309,15 +1336,6 @@
       "latestContributionAt": "2026-06-09T08:46:00Z"
     },
     {
-      "login": "Clarence404",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/36807519?v=4",
-      "profileUrl": "https://github.com/Clarence404",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-01T05:51:25Z",
-      "latestContributionAt": "2026-09-01T07:28:09Z"
-    },
-    {
       "login": "clj1566317",
       "avatarUrl": "https://avatars.githubusercontent.com/u/295271018?v=4",
       "profileUrl": "https://github.com/clj1566317",
@@ -1361,15 +1379,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T05:02:37Z",
       "latestContributionAt": "2026-07-25T00:45:27Z"
-    },
-    {
-      "login": "doersa",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6913871?v=4",
-      "profileUrl": "https://github.com/doersa",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-01T03:09:57Z",
-      "latestContributionAt": "2026-09-01T04:34:00Z"
     },
     {
       "login": "Driftlux",
@@ -1487,6 +1496,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-03T16:19:58Z",
       "latestContributionAt": "2026-07-03T16:58:52Z"
+    },
+    {
+      "login": "githubasda",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/86922868?v=4",
+      "profileUrl": "https://github.com/githubasda",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-02T01:23:28Z",
+      "latestContributionAt": "2026-09-02T07:45:24Z"
     },
     {
       "login": "guoziyangnb",
@@ -1777,6 +1795,15 @@
       "latestContributionAt": "2026-06-15T09:01:01Z"
     },
     {
+      "login": "omerfarukalkilic",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/178777569?v=4",
+      "profileUrl": "https://github.com/omerfarukalkilic",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-01T13:13:31Z",
+      "latestContributionAt": "2026-09-02T03:52:59Z"
+    },
+    {
       "login": "orwenxiang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1335999?v=4",
       "profileUrl": "https://github.com/orwenxiang",
@@ -1919,15 +1946,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-19T07:11:53Z",
       "latestContributionAt": "2026-06-19T16:13:09Z"
-    },
-    {
-      "login": "wangfengxiang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/31534139?v=4",
-      "profileUrl": "https://github.com/wangfengxiang",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-31T09:52:03Z",
-      "latestContributionAt": "2026-08-31T16:21:10Z"
     },
     {
       "login": "wfion",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-03T20:24:01.289Z",
-  "stars": 17916,
+  "generatedAt": "2026-09-04T20:09:54.627Z",
+  "stars": 18044,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3368,
+      "commits": 3388,
       "mergedPullRequests": 26,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-02T10:17:27Z"
@@ -16,55 +16,55 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 698,
-      "mergedPullRequests": 699,
+      "commits": 709,
+      "mergedPullRequests": 710,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-03T18:05:08Z"
+      "latestContributionAt": "2026-09-04T16:42:08Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 214,
-      "mergedPullRequests": 213,
+      "commits": 216,
+      "mergedPullRequests": 215,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-03T17:23:25Z"
-    },
-    {
-      "login": "Abeautifulsnow",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
-      "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 109,
-      "mergedPullRequests": 97,
-      "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-03T10:50:06Z"
+      "latestContributionAt": "2026-09-04T17:03:39Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 108,
-      "mergedPullRequests": 108,
+      "commits": 123,
+      "mergedPullRequests": 123,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-09-03T09:52:08Z"
+      "latestContributionAt": "2026-09-04T12:41:41Z"
+    },
+    {
+      "login": "Abeautifulsnow",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
+      "profileUrl": "https://github.com/Abeautifulsnow",
+      "commits": 111,
+      "mergedPullRequests": 99,
+      "firstContributionAt": "2026-05-06T03:16:57Z",
+      "latestContributionAt": "2026-09-04T12:38:26Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 85,
-      "mergedPullRequests": 85,
+      "commits": 90,
+      "mergedPullRequests": 90,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-09-03T11:28:20Z"
+      "latestContributionAt": "2026-09-04T17:03:31Z"
     },
     {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 79,
-      "mergedPullRequests": 79,
+      "commits": 83,
+      "mergedPullRequests": 83,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-03T16:29:04Z"
+      "latestContributionAt": "2026-09-04T16:41:59Z"
     },
     {
       "login": "onenewcode",
@@ -97,10 +97,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 41,
-      "mergedPullRequests": 41,
+      "commits": 42,
+      "mergedPullRequests": 42,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-09-02T17:53:55Z"
+      "latestContributionAt": "2026-09-04T08:46:37Z"
     },
     {
       "login": "Illuminated2020",
@@ -124,10 +124,10 @@
       "login": "gggaiitx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
       "profileUrl": "https://github.com/gggaiitx",
-      "commits": 28,
-      "mergedPullRequests": 28,
+      "commits": 29,
+      "mergedPullRequests": 29,
       "firstContributionAt": "2026-07-06T09:30:53Z",
-      "latestContributionAt": "2026-08-14T04:56:39Z"
+      "latestContributionAt": "2026-09-04T12:24:32Z"
     },
     {
       "login": "lexmin0412",
@@ -148,6 +148,15 @@
       "latestContributionAt": "2026-07-10T10:15:25Z"
     },
     {
+      "login": "ptma",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
+      "profileUrl": "https://github.com/ptma",
+      "commits": 23,
+      "mergedPullRequests": 23,
+      "firstContributionAt": "2026-06-09T08:33:11Z",
+      "latestContributionAt": "2026-09-04T05:42:30Z"
+    },
+    {
       "login": "rarnu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/209014?v=4",
       "profileUrl": "https://github.com/rarnu",
@@ -164,15 +173,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-26T03:29:22Z",
       "latestContributionAt": "2026-07-16T17:17:49Z"
-    },
-    {
-      "login": "ptma",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
-      "profileUrl": "https://github.com/ptma",
-      "commits": 22,
-      "mergedPullRequests": 22,
-      "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-08-13T03:40:23Z"
     },
     {
       "login": "yavon007",
@@ -445,6 +445,15 @@
       "latestContributionAt": "2026-08-12T14:22:34Z"
     },
     {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-09-04T06:44:04Z"
+    },
+    {
       "login": "luoianun",
       "avatarUrl": "https://avatars.githubusercontent.com/u/20828060?v=4",
       "profileUrl": "https://github.com/luoianun",
@@ -524,15 +533,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-15T03:09:27Z",
       "latestContributionAt": "2026-08-18T15:17:24Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-29T19:57:03Z"
     },
     {
       "login": "lizzzzz777",
@@ -859,6 +859,15 @@
       "latestContributionAt": "2026-04-30T09:48:13Z"
     },
     {
+      "login": "yanguibao1997",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39548181?v=4",
+      "profileUrl": "https://github.com/yanguibao1997",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-29T06:58:27Z",
+      "latestContributionAt": "2026-09-04T08:52:47Z"
+    },
+    {
       "login": "Michaelxwb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34806714?v=4",
       "profileUrl": "https://github.com/Michaelxwb",
@@ -1102,6 +1111,15 @@
       "latestContributionAt": "2026-08-09T15:33:24Z"
     },
     {
+      "login": "sineld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/445349?v=4",
+      "profileUrl": "https://github.com/sineld",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-03T16:48:39Z",
+      "latestContributionAt": "2026-09-04T01:51:36Z"
+    },
+    {
       "login": "TangTangH",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
       "profileUrl": "https://github.com/TangTangH",
@@ -1109,6 +1127,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-04T04:55:17Z",
       "latestContributionAt": "2026-08-06T06:09:21Z"
+    },
+    {
+      "login": "Tara8573",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
+      "profileUrl": "https://github.com/Tara8573",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-22T04:03:32Z",
+      "latestContributionAt": "2026-09-04T06:48:42Z"
     },
     {
       "login": "togls",
@@ -1174,6 +1201,15 @@
       "latestContributionAt": "2026-07-30T07:13:36Z"
     },
     {
+      "login": "wnyr",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8221975?v=4",
+      "profileUrl": "https://github.com/wnyr",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-06T03:39:01Z",
+      "latestContributionAt": "2026-09-04T16:54:00Z"
+    },
+    {
       "login": "xiaoge19961220",
       "avatarUrl": "https://avatars.githubusercontent.com/u/76191330?v=4",
       "profileUrl": "https://github.com/xiaoge19961220",
@@ -1190,15 +1226,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-22T18:14:03Z",
       "latestContributionAt": "2026-07-29T10:42:44Z"
-    },
-    {
-      "login": "yanguibao1997",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39548181?v=4",
-      "profileUrl": "https://github.com/yanguibao1997",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-29T06:58:27Z",
-      "latestContributionAt": "2026-07-31T08:27:37Z"
     },
     {
       "login": "Mukesh-234234",
@@ -1588,6 +1615,15 @@
       "latestContributionAt": "2026-07-26T09:52:33Z"
     },
     {
+      "login": "huyphams",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/3654622?v=4",
+      "profileUrl": "https://github.com/huyphams",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-04T02:43:39Z",
+      "latestContributionAt": "2026-09-04T04:08:41Z"
+    },
+    {
       "login": "idxdy",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10395284?v=4",
       "profileUrl": "https://github.com/idxdy",
@@ -1694,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-17T14:08:31Z",
       "latestContributionAt": "2026-06-17T14:12:59Z"
+    },
+    {
+      "login": "Lem26",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38876848?v=4",
+      "profileUrl": "https://github.com/Lem26",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-04T14:44:45Z",
+      "latestContributionAt": "2026-09-04T16:41:15Z"
     },
     {
       "login": "LSvKing",
@@ -1876,15 +1921,6 @@
       "latestContributionAt": "2026-06-01T10:12:20Z"
     },
     {
-      "login": "sineld",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/445349?v=4",
-      "profileUrl": "https://github.com/sineld",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-03T16:48:39Z",
-      "latestContributionAt": "2026-09-03T18:22:21Z"
-    },
-    {
       "login": "SnowArk",
       "avatarUrl": "https://avatars.githubusercontent.com/u/44255555?v=4",
       "profileUrl": "https://github.com/SnowArk",
@@ -1921,6 +1957,15 @@
       "latestContributionAt": "2026-06-05T10:16:18Z"
     },
     {
+      "login": "sunzhengbo",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/29298020?v=4",
+      "profileUrl": "https://github.com/sunzhengbo",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-03T08:14:23Z",
+      "latestContributionAt": "2026-09-04T02:25:15Z"
+    },
+    {
       "login": "sweetwisdom",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57869305?v=4",
       "profileUrl": "https://github.com/sweetwisdom",
@@ -1928,15 +1973,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
-    },
-    {
-      "login": "Tara8573",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
-      "profileUrl": "https://github.com/Tara8573",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-22T04:03:32Z",
-      "latestContributionAt": "2026-08-22T11:30:39Z"
     },
     {
       "login": "tatuke",
@@ -2000,15 +2036,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-11T06:09:28Z",
       "latestContributionAt": "2026-08-11T13:37:32Z"
-    },
-    {
-      "login": "wnyr",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8221975?v=4",
-      "profileUrl": "https://github.com/wnyr",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-06T03:39:01Z",
-      "latestContributionAt": "2026-07-06T04:57:27Z"
     },
     {
       "login": "wojiukankan",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-04T20:09:54.627Z",
-  "stars": 18044,
+  "generatedAt": "2026-09-05T19:48:58.447Z",
+  "stars": 18078,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3388,
+      "commits": 3410,
       "mergedPullRequests": 26,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-02T10:17:27Z"
@@ -25,19 +25,19 @@
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 216,
-      "mergedPullRequests": 215,
+      "commits": 217,
+      "mergedPullRequests": 216,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-04T17:03:39Z"
+      "latestContributionAt": "2026-09-05T02:01:55Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 123,
-      "mergedPullRequests": 123,
+      "commits": 141,
+      "mergedPullRequests": 141,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-09-04T12:41:41Z"
+      "latestContributionAt": "2026-09-05T15:26:20Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -61,10 +61,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 83,
-      "mergedPullRequests": 83,
+      "commits": 84,
+      "mergedPullRequests": 84,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-04T16:41:59Z"
+      "latestContributionAt": "2026-09-05T01:52:52Z"
     },
     {
       "login": "onenewcode",
@@ -88,10 +88,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 46,
-      "mergedPullRequests": 44,
+      "commits": 47,
+      "mergedPullRequests": 45,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-24T10:35:18Z"
+      "latestContributionAt": "2026-09-05T14:22:55Z"
     },
     {
       "login": "mapan0424",
@@ -328,6 +328,15 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-09-05T14:17:02Z"
+    },
+    {
       "login": "aiLi0617",
       "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
       "profileUrl": "https://github.com/aiLi0617",
@@ -335,15 +344,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
-    },
-    {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-09-02T06:12:36Z"
     },
     {
       "login": "sxhjlzl",
@@ -643,6 +643,15 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
+      "login": "ordinary-s",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
+      "profileUrl": "https://github.com/ordinary-s",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-18T11:36:48Z",
+      "latestContributionAt": "2026-09-05T14:18:04Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -785,15 +794,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
-    },
-    {
-      "login": "ordinary-s",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
-      "profileUrl": "https://github.com/ordinary-s",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-18T11:36:48Z",
-      "latestContributionAt": "2026-08-26T14:00:04Z"
     },
     {
       "login": "polemp",
@@ -1057,6 +1057,15 @@
       "latestContributionAt": "2026-06-29T13:21:46Z"
     },
     {
+      "login": "Lem26",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38876848?v=4",
+      "profileUrl": "https://github.com/Lem26",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-04T14:44:45Z",
+      "latestContributionAt": "2026-09-05T05:02:42Z"
+    },
+    {
       "login": "libondev",
       "avatarUrl": "https://avatars.githubusercontent.com/u/47918504?v=4",
       "profileUrl": "https://github.com/libondev",
@@ -1217,6 +1226,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
+    },
+    {
+      "login": "xiaomizhou2",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47807926?v=4",
+      "profileUrl": "https://github.com/xiaomizhou2",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-27T13:49:30Z",
+      "latestContributionAt": "2026-09-05T05:25:04Z"
     },
     {
       "login": "yangqinlong",
@@ -1732,15 +1750,6 @@
       "latestContributionAt": "2026-06-17T14:12:59Z"
     },
     {
-      "login": "Lem26",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/38876848?v=4",
-      "profileUrl": "https://github.com/Lem26",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-04T14:44:45Z",
-      "latestContributionAt": "2026-09-04T16:41:15Z"
-    },
-    {
       "login": "LSvKing",
       "avatarUrl": "https://avatars.githubusercontent.com/u/255360?v=4",
       "profileUrl": "https://github.com/LSvKing",
@@ -1883,6 +1892,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-07T03:43:59Z",
       "latestContributionAt": "2026-06-07T18:07:00Z"
+    },
+    {
+      "login": "Resheba",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/74815401?v=4",
+      "profileUrl": "https://github.com/Resheba",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-04T09:14:31Z",
+      "latestContributionAt": "2026-09-05T06:03:58Z"
     },
     {
       "login": "Rson9",
@@ -2099,15 +2117,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-02T05:54:07Z",
       "latestContributionAt": "2026-07-02T06:28:58Z"
-    },
-    {
-      "login": "xiaomizhou2",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47807926?v=4",
-      "profileUrl": "https://github.com/xiaomizhou2",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-27T13:49:30Z",
-      "latestContributionAt": "2026-07-28T19:18:06Z"
     },
     {
       "login": "xiaoyaoqilan",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,79 +1,79 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-31T22:17:45.069Z",
-  "stars": 17575,
+  "generatedAt": "2026-09-01T20:24:34.300Z",
+  "stars": 17677,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3322,
-      "mergedPullRequests": 23,
+      "commits": 3336,
+      "mergedPullRequests": 24,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-30T05:30:01Z"
+      "latestContributionAt": "2026-09-01T09:38:19Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 658,
-      "mergedPullRequests": 658,
+      "commits": 668,
+      "mergedPullRequests": 669,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-31T17:59:02Z"
+      "latestContributionAt": "2026-09-01T16:27:45Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 198,
-      "mergedPullRequests": 197,
+      "commits": 202,
+      "mergedPullRequests": 201,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-31T17:17:23Z"
+      "latestContributionAt": "2026-09-01T15:36:15Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 104,
-      "mergedPullRequests": 104,
+      "commits": 106,
+      "mergedPullRequests": 106,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-27T14:25:09Z"
+      "latestContributionAt": "2026-09-01T08:21:40Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 104,
-      "mergedPullRequests": 92,
+      "commits": 105,
+      "mergedPullRequests": 93,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-30T04:26:55Z"
+      "latestContributionAt": "2026-09-01T03:01:00Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 77,
-      "mergedPullRequests": 77,
+      "commits": 78,
+      "mergedPullRequests": 78,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-31T15:49:01Z"
+      "latestContributionAt": "2026-09-01T15:45:33Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 69,
-      "mergedPullRequests": 69,
+      "commits": 70,
+      "mergedPullRequests": 70,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-31T17:18:00Z"
+      "latestContributionAt": "2026-09-01T05:18:42Z"
     },
     {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 59,
-      "mergedPullRequests": 59,
+      "commits": 68,
+      "mergedPullRequests": 68,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-31T18:12:56Z"
+      "latestContributionAt": "2026-09-01T08:18:58Z"
     },
     {
       "login": "serenez",
@@ -193,6 +193,15 @@
       "latestContributionAt": "2026-06-26T10:48:46Z"
     },
     {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 16,
+      "mergedPullRequests": 16,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-09-01T04:18:39Z"
+    },
+    {
       "login": "amwps290",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
       "profileUrl": "https://github.com/amwps290",
@@ -209,15 +218,6 @@
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-06-24T12:52:59Z",
       "latestContributionAt": "2026-07-29T12:41:10Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 15,
-      "mergedPullRequests": 15,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-31T07:57:16Z"
     },
     {
       "login": "AndrewDi",
@@ -535,6 +535,15 @@
       "latestContributionAt": "2026-08-25T06:46:25Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-09-01T05:11:59Z"
+    },
+    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -605,15 +614,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-08-31T16:22:03Z"
     },
     {
       "login": "soddygo",
@@ -886,6 +886,15 @@
       "latestContributionAt": "2026-07-31T08:24:13Z"
     },
     {
+      "login": "debugzhao",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32617253?v=4",
+      "profileUrl": "https://github.com/debugzhao",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-27T10:43:39Z",
+      "latestContributionAt": "2026-09-01T03:09:45Z"
+    },
+    {
       "login": "Doracoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9206272?v=4",
       "profileUrl": "https://github.com/Doracoin",
@@ -1084,6 +1093,15 @@
       "latestContributionAt": "2026-07-23T09:29:45Z"
     },
     {
+      "login": "Tssshhhh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/109692520?v=4",
+      "profileUrl": "https://github.com/Tssshhhh",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-08T15:20:59Z",
+      "latestContributionAt": "2026-09-01T15:36:01Z"
+    },
+    {
       "login": "uicky",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48382673?v=4",
       "profileUrl": "https://github.com/uicky",
@@ -1154,6 +1172,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-03T18:36:11Z",
       "latestContributionAt": "2026-05-05T09:30:42Z"
+    },
+    {
+      "login": "1320209572",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
+      "profileUrl": "https://github.com/1320209572",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-01T05:03:42Z",
+      "latestContributionAt": "2026-09-01T05:55:38Z"
     },
     {
       "login": "2090230619-syq",
@@ -1282,6 +1309,15 @@
       "latestContributionAt": "2026-06-09T08:46:00Z"
     },
     {
+      "login": "Clarence404",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/36807519?v=4",
+      "profileUrl": "https://github.com/Clarence404",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-01T05:51:25Z",
+      "latestContributionAt": "2026-09-01T07:28:09Z"
+    },
+    {
       "login": "clj1566317",
       "avatarUrl": "https://avatars.githubusercontent.com/u/295271018?v=4",
       "profileUrl": "https://github.com/clj1566317",
@@ -1309,15 +1345,6 @@
       "latestContributionAt": "2026-07-02T08:37:21Z"
     },
     {
-      "login": "debugzhao",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32617253?v=4",
-      "profileUrl": "https://github.com/debugzhao",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-28T14:35:35Z",
-      "latestContributionAt": "2026-08-30T04:25:55Z"
-    },
-    {
       "login": "Dhevenddra",
       "avatarUrl": "https://avatars.githubusercontent.com/u/121691114?v=4",
       "profileUrl": "https://github.com/Dhevenddra",
@@ -1334,6 +1361,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T05:02:37Z",
       "latestContributionAt": "2026-07-25T00:45:27Z"
+    },
+    {
+      "login": "doersa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6913871?v=4",
+      "profileUrl": "https://github.com/doersa",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-01T03:09:57Z",
+      "latestContributionAt": "2026-09-01T04:34:00Z"
     },
     {
       "login": "Driftlux",
@@ -1865,15 +1901,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-21T08:02:23Z",
       "latestContributionAt": "2026-08-21T10:12:40Z"
-    },
-    {
-      "login": "Tssshhhh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/109692520?v=4",
-      "profileUrl": "https://github.com/Tssshhhh",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-08T15:20:59Z",
-      "latestContributionAt": "2026-07-08T16:32:53Z"
     },
     {
       "login": "tyloryang",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-02T20:24:52.802Z",
-  "stars": 17802,
+  "generatedAt": "2026-09-03T20:24:01.289Z",
+  "stars": 17916,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3351,
+      "commits": 3368,
       "mergedPullRequests": 26,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-02T10:17:27Z"
@@ -16,64 +16,64 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 688,
-      "mergedPullRequests": 689,
+      "commits": 698,
+      "mergedPullRequests": 699,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-02T19:35:22Z"
+      "latestContributionAt": "2026-09-03T18:05:08Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 206,
-      "mergedPullRequests": 205,
+      "commits": 214,
+      "mergedPullRequests": 213,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-02T12:20:26Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 106,
-      "mergedPullRequests": 106,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-09-01T08:21:40Z"
+      "latestContributionAt": "2026-09-03T17:23:25Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 106,
-      "mergedPullRequests": 94,
+      "commits": 109,
+      "mergedPullRequests": 97,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-02T12:37:40Z"
+      "latestContributionAt": "2026-09-03T10:50:06Z"
+    },
+    {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 108,
+      "mergedPullRequests": 108,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-09-03T09:52:08Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 82,
-      "mergedPullRequests": 82,
+      "commits": 85,
+      "mergedPullRequests": 85,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-09-02T17:53:42Z"
+      "latestContributionAt": "2026-09-03T11:28:20Z"
     },
     {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 75,
-      "mergedPullRequests": 75,
+      "commits": 79,
+      "mergedPullRequests": 79,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-02T12:36:34Z"
+      "latestContributionAt": "2026-09-03T16:29:04Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 71,
-      "mergedPullRequests": 71,
+      "commits": 72,
+      "mergedPullRequests": 72,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-02T06:17:49Z"
+      "latestContributionAt": "2026-09-03T03:56:46Z"
     },
     {
       "login": "serenez",
@@ -544,6 +544,15 @@
       "latestContributionAt": "2026-08-25T06:46:25Z"
     },
     {
+      "login": "Staroon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26004564?v=4",
+      "profileUrl": "https://github.com/Staroon",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-22T04:43:40Z",
+      "latestContributionAt": "2026-09-03T12:45:27Z"
+    },
+    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -578,6 +587,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-17T06:34:18Z",
       "latestContributionAt": "2026-08-17T07:54:14Z"
+    },
+    {
+      "login": "BabyLy233",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
+      "profileUrl": "https://github.com/BabyLy233",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-14T07:55:34Z",
+      "latestContributionAt": "2026-09-03T16:29:30Z"
     },
     {
       "login": "Caisin",
@@ -634,15 +652,6 @@
       "latestContributionAt": "2026-07-27T08:11:54Z"
     },
     {
-      "login": "Staroon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/26004564?v=4",
-      "profileUrl": "https://github.com/Staroon",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-22T04:43:40Z",
-      "latestContributionAt": "2026-07-31T05:54:26Z"
-    },
-    {
       "login": "wuxiemian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29685283?v=4",
       "profileUrl": "https://github.com/wuxiemian",
@@ -686,15 +695,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
-    },
-    {
-      "login": "BabyLy233",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
-      "profileUrl": "https://github.com/BabyLy233",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-14T07:55:34Z",
-      "latestContributionAt": "2026-08-11T08:55:53Z"
     },
     {
       "login": "cheshireez",
@@ -1318,6 +1318,15 @@
       "latestContributionAt": "2026-08-10T02:54:27Z"
     },
     {
+      "login": "cherish-ltt",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/125760530?v=4",
+      "profileUrl": "https://github.com/cherish-ltt",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-03T10:55:39Z",
+      "latestContributionAt": "2026-09-03T13:07:19Z"
+    },
+    {
       "login": "Cherrs",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6745593?v=4",
       "profileUrl": "https://github.com/Cherrs",
@@ -1867,6 +1876,15 @@
       "latestContributionAt": "2026-06-01T10:12:20Z"
     },
     {
+      "login": "sineld",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/445349?v=4",
+      "profileUrl": "https://github.com/sineld",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-03T16:48:39Z",
+      "latestContributionAt": "2026-09-03T18:22:21Z"
+    },
+    {
       "login": "SnowArk",
       "avatarUrl": "https://avatars.githubusercontent.com/u/44255555?v=4",
       "profileUrl": "https://github.com/SnowArk",
@@ -1946,6 +1964,24 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-19T07:11:53Z",
       "latestContributionAt": "2026-06-19T16:13:09Z"
+    },
+    {
+      "login": "wang122818",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/192289271?v=4",
+      "profileUrl": "https://github.com/wang122818",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-03T08:35:45Z",
+      "latestContributionAt": "2026-09-03T13:07:37Z"
+    },
+    {
+      "login": "Weiki886",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188135055?v=4",
+      "profileUrl": "https://github.com/Weiki886",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-03T06:49:26Z",
+      "latestContributionAt": "2026-09-03T10:10:27Z"
     },
     {
       "login": "wfion",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-21T18:28:08.295Z",
-  "stars": 16188,
+  "generatedAt": "2026-08-22T18:20:43.168Z",
+  "stars": 16247,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3134,
+      "commits": 3161,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 584,
-      "mergedPullRequests": 584,
+      "commits": 588,
+      "mergedPullRequests": 590,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-21T11:57:22Z"
+      "latestContributionAt": "2026-08-22T17:39:23Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 161,
-      "mergedPullRequests": 160,
+      "commits": 163,
+      "mergedPullRequests": 163,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-21T04:20:58Z"
+      "latestContributionAt": "2026-08-22T17:40:22Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,28 +43,28 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 86,
-      "mergedPullRequests": 86,
+      "commits": 87,
+      "mergedPullRequests": 87,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-20T14:23:37Z"
+      "latestContributionAt": "2026-08-22T04:52:54Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 67,
-      "mergedPullRequests": 67,
+      "commits": 68,
+      "mergedPullRequests": 68,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-20T00:47:05Z"
+      "latestContributionAt": "2026-08-22T07:41:21Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 61,
-      "mergedPullRequests": 61,
+      "commits": 62,
+      "mergedPullRequests": 62,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-21T10:19:48Z"
+      "latestContributionAt": "2026-08-22T04:58:28Z"
     },
     {
       "login": "serenez",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 43,
-      "mergedPullRequests": 41,
+      "commits": 44,
+      "mergedPullRequests": 42,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-19T03:10:12Z"
+      "latestContributionAt": "2026-08-22T07:41:14Z"
     },
     {
       "login": "Illuminated2020",
@@ -130,6 +130,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 26,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-22T17:39:54Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -146,15 +155,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-05-02T07:44:05Z",
       "latestContributionAt": "2026-05-29T05:31:32Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 22,
-      "mergedPullRequests": 22,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-21T04:20:20Z"
     },
     {
       "login": "LwClick",
@@ -643,6 +643,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 3,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-22T17:40:51Z"
+    },
+    {
       "login": "BabyLy233",
       "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
       "profileUrl": "https://github.com/BabyLy233",
@@ -758,15 +767,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-18T10:01:35Z",
       "latestContributionAt": "2026-08-20T13:01:23Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-21T05:03:15Z"
     },
     {
       "login": "vergil-lai",
@@ -1471,6 +1471,15 @@
       "latestContributionAt": "2026-07-28T17:29:20Z"
     },
     {
+      "login": "klinge1011",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
+      "profileUrl": "https://github.com/klinge1011",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-21T12:23:37Z",
+      "latestContributionAt": "2026-08-22T07:41:17Z"
+    },
+    {
       "login": "koco-co",
       "avatarUrl": "https://avatars.githubusercontent.com/u/227195474?v=4",
       "profileUrl": "https://github.com/koco-co",
@@ -1712,6 +1721,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
+    },
+    {
+      "login": "Tara8573",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
+      "profileUrl": "https://github.com/Tara8573",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-22T04:03:32Z",
+      "latestContributionAt": "2026-08-22T11:30:39Z"
     },
     {
       "login": "tatuke",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-13T18:55:30.067Z",
-  "stars": 14433,
+  "generatedAt": "2026-08-14T18:44:38.239Z",
+  "stars": 14743,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3003,
+      "commits": 3033,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 525,
-      "mergedPullRequests": 525,
+      "commits": 535,
+      "mergedPullRequests": 535,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-13T16:11:29Z"
+      "latestContributionAt": "2026-08-14T16:27:35Z"
     },
     {
       "login": "eryajf",
@@ -34,19 +34,19 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 90,
-      "mergedPullRequests": 78,
+      "commits": 91,
+      "mergedPullRequests": 79,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-13T11:44:48Z"
+      "latestContributionAt": "2026-08-14T10:37:53Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 62,
-      "mergedPullRequests": 62,
+      "commits": 63,
+      "mergedPullRequests": 63,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-12T13:05:14Z"
+      "latestContributionAt": "2026-08-14T16:28:12Z"
     },
     {
       "login": "onenewcode",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-08-13T02:51:41Z"
     },
     {
+      "login": "gggaiitx",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
+      "profileUrl": "https://github.com/gggaiitx",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-06T09:30:53Z",
+      "latestContributionAt": "2026-08-14T04:56:39Z"
+    },
+    {
       "login": "lexmin0412",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24385370?v=4",
       "profileUrl": "https://github.com/lexmin0412",
@@ -112,13 +121,13 @@
       "latestContributionAt": "2026-08-07T07:57:46Z"
     },
     {
-      "login": "gggaiitx",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
-      "profileUrl": "https://github.com/gggaiitx",
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
       "commits": 27,
       "mergedPullRequests": 27,
-      "firstContributionAt": "2026-07-06T09:30:53Z",
-      "latestContributionAt": "2026-07-28T14:39:11Z"
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-14T14:12:45Z"
     },
     {
       "login": "SuLea-IT",
@@ -155,15 +164,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-09T08:33:11Z",
       "latestContributionAt": "2026-08-13T03:40:23Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 18,
-      "mergedPullRequests": 18,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-13T18:06:06Z"
     },
     {
       "login": "yavon007",
@@ -214,10 +214,10 @@
       "login": "amwps290",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
       "profileUrl": "https://github.com/amwps290",
-      "commits": 11,
-      "mergedPullRequests": 11,
+      "commits": 12,
+      "mergedPullRequests": 12,
       "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-11T07:00:25Z"
+      "latestContributionAt": "2026-08-14T09:47:55Z"
     },
     {
       "login": "DASungta",
@@ -265,6 +265,15 @@
       "latestContributionAt": "2026-07-27T14:47:00Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 10,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-14T14:56:29Z"
+    },
+    {
       "login": "chenhbb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
       "profileUrl": "https://github.com/chenhbb",
@@ -290,15 +299,6 @@
       "mergedPullRequests": 10,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-13T04:40:51Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 9,
-      "mergedPullRequests": 9,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-13T16:10:12Z"
     },
     {
       "login": "aiLi0617",
@@ -506,6 +506,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-08-13T14:31:14Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-14T14:18:29Z"
     },
     {
       "login": "James-Leong",
@@ -778,15 +787,6 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-13T04:41:58Z"
-    },
-    {
       "login": "holmesin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
       "profileUrl": "https://github.com/holmesin",
@@ -841,6 +841,15 @@
       "latestContributionAt": "2026-06-09T03:59:49Z"
     },
     {
+      "login": "kir1ito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
+      "profileUrl": "https://github.com/kir1ito",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-13T10:38:51Z",
+      "latestContributionAt": "2026-08-14T10:05:36Z"
+    },
+    {
       "login": "Lan-zk",
       "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
       "profileUrl": "https://github.com/Lan-zk",
@@ -875,6 +884,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T04:57:31Z",
       "latestContributionAt": "2026-08-02T08:35:04Z"
+    },
+    {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-14T10:25:05Z"
     },
     {
       "login": "onlyc0302",
@@ -983,6 +1001,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
+    },
+    {
+      "login": "xiaou61",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
+      "profileUrl": "https://github.com/xiaou61",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-14T09:19:51Z",
+      "latestContributionAt": "2026-08-14T14:46:33Z"
     },
     {
       "login": "xzxlove",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,16 +1,16 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-29T20:17:46.770Z",
-  "stars": 17401,
+  "generatedAt": "2026-08-30T20:24:13.247Z",
+  "stars": 17473,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3306,
-      "mergedPullRequests": 19,
+      "commits": 3310,
+      "mergedPullRequests": 23,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-29T19:54:16Z"
+      "latestContributionAt": "2026-08-30T05:30:01Z"
     },
     {
       "login": "zipg",
@@ -25,10 +25,10 @@
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 187,
-      "mergedPullRequests": 186,
+      "commits": 191,
+      "mergedPullRequests": 190,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-29T19:05:44Z"
+      "latestContributionAt": "2026-08-30T04:26:07Z"
     },
     {
       "login": "q396921921",
@@ -43,10 +43,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 103,
-      "mergedPullRequests": 91,
+      "commits": 104,
+      "mergedPullRequests": 92,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-28T04:37:11Z"
+      "latestContributionAt": "2026-08-30T04:26:55Z"
     },
     {
       "login": "CN-Scars",
@@ -107,7 +107,7 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
       "commits": 36,
-      "mergedPullRequests": 37,
+      "mergedPullRequests": 36,
       "firstContributionAt": "2026-07-17T05:42:50Z",
       "latestContributionAt": "2026-08-25T07:15:42Z"
     },
@@ -193,6 +193,15 @@
       "latestContributionAt": "2026-06-26T10:48:46Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-30T01:59:24Z"
+    },
+    {
       "login": "jischeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49861575?v=4",
       "profileUrl": "https://github.com/jischeng",
@@ -200,15 +209,6 @@
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-06-24T12:52:59Z",
       "latestContributionAt": "2026-07-29T12:41:10Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-28T04:14:04Z"
     },
     {
       "login": "AndrewDi",
@@ -364,6 +364,15 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-29T20:17:33Z"
+    },
+    {
       "login": "hanxuanyu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
       "profileUrl": "https://github.com/hanxuanyu",
@@ -407,15 +416,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-28T03:12:41Z"
     },
     {
       "login": "jeeinn",
@@ -1300,6 +1300,15 @@
       "latestContributionAt": "2026-07-02T08:37:21Z"
     },
     {
+      "login": "debugzhao",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32617253?v=4",
+      "profileUrl": "https://github.com/debugzhao",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-28T14:35:35Z",
+      "latestContributionAt": "2026-08-30T04:25:55Z"
+    },
+    {
       "login": "Dhevenddra",
       "avatarUrl": "https://avatars.githubusercontent.com/u/121691114?v=4",
       "profileUrl": "https://github.com/Dhevenddra",
@@ -1658,6 +1667,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-14T11:25:31Z",
       "latestContributionAt": "2026-07-28T20:32:27Z"
+    },
+    {
+      "login": "mmorella-dev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4561733?v=4",
+      "profileUrl": "https://github.com/mmorella-dev",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-28T19:54:04Z",
+      "latestContributionAt": "2026-08-29T20:36:35Z"
     },
     {
       "login": "monellin",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,25 +1,25 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-14T18:44:38.239Z",
-  "stars": 14743,
+  "generatedAt": "2026-08-15T18:19:28.914Z",
+  "stars": 14957,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3033,
-      "mergedPullRequests": 15,
+      "commits": 3041,
+      "mergedPullRequests": 16,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-07-30T13:10:01Z"
+      "latestContributionAt": "2026-08-15T04:08:41Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 535,
-      "mergedPullRequests": 535,
+      "commits": 540,
+      "mergedPullRequests": 540,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-14T16:27:35Z"
+      "latestContributionAt": "2026-08-15T15:53:32Z"
     },
     {
       "login": "eryajf",
@@ -67,6 +67,15 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 50,
+      "mergedPullRequests": 50,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-15T15:43:10Z"
+    },
+    {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
@@ -88,10 +97,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 29,
-      "mergedPullRequests": 29,
+      "commits": 30,
+      "mergedPullRequests": 30,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-13T02:51:41Z"
+      "latestContributionAt": "2026-08-15T13:55:55Z"
     },
     {
       "login": "gggaiitx",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-07-10T06:34:09Z",
       "latestContributionAt": "2026-08-07T07:57:46Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 27,
-      "mergedPullRequests": 27,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-14T14:12:45Z"
     },
     {
       "login": "SuLea-IT",
@@ -427,6 +427,15 @@
       "latestContributionAt": "2026-08-07T05:43:30Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-15T06:41:54Z"
+    },
+    {
       "login": "fraluc06",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67560467?v=4",
       "profileUrl": "https://github.com/fraluc06",
@@ -479,15 +488,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-02T10:52:18Z",
       "latestContributionAt": "2026-08-02T11:35:45Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-13T18:05:51Z"
     },
     {
       "login": "Dreamescaper",
@@ -580,6 +580,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "azens",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
+      "profileUrl": "https://github.com/azens",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-17T06:34:18Z",
+      "latestContributionAt": "2026-08-15T06:59:05Z"
+    },
+    {
       "login": "BabyLy233",
       "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
       "profileUrl": "https://github.com/BabyLy233",
@@ -614,6 +623,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
+    },
+    {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-15T06:41:42Z"
     },
     {
       "login": "lazyanubis",
@@ -670,6 +688,15 @@
       "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
+      "login": "xzxlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
+      "profileUrl": "https://github.com/xzxlove",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T06:38:59Z",
+      "latestContributionAt": "2026-08-15T06:44:47Z"
+    },
+    {
       "login": "Michaelxwb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34806714?v=4",
       "profileUrl": "https://github.com/Michaelxwb",
@@ -695,15 +722,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-26T03:33:01Z",
       "latestContributionAt": "2026-07-01T08:35:48Z"
-    },
-    {
-      "login": "azens",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
-      "profileUrl": "https://github.com/azens",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-17T06:34:18Z",
-      "latestContributionAt": "2026-08-09T11:51:12Z"
     },
     {
       "login": "bigliangzao",
@@ -841,6 +859,15 @@
       "latestContributionAt": "2026-06-09T03:59:49Z"
     },
     {
+      "login": "kingcanfish",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43931057?v=4",
+      "profileUrl": "https://github.com/kingcanfish",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-05-02T02:18:47Z",
+      "latestContributionAt": "2026-08-15T06:41:17Z"
+    },
+    {
       "login": "kir1ito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
       "profileUrl": "https://github.com/kir1ito",
@@ -848,15 +875,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-13T10:38:51Z",
       "latestContributionAt": "2026-08-14T10:05:36Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-13T18:25:25Z"
     },
     {
       "login": "lc6464",
@@ -1010,15 +1028,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-14T09:19:51Z",
       "latestContributionAt": "2026-08-14T14:46:33Z"
-    },
-    {
-      "login": "xzxlove",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
-      "profileUrl": "https://github.com/xzxlove",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-13T06:38:59Z",
-      "latestContributionAt": "2026-08-13T12:34:54Z"
     },
     {
       "login": "yangqinlong",
@@ -1199,6 +1208,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T05:02:37Z",
       "latestContributionAt": "2026-07-25T00:45:27Z"
+    },
+    {
+      "login": "domye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
+      "profileUrl": "https://github.com/domye",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-15T02:08:13Z",
+      "latestContributionAt": "2026-08-15T06:44:36Z"
     },
     {
       "login": "Driftlux",
@@ -1406,15 +1424,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-23T09:40:04Z",
       "latestContributionAt": "2026-07-28T17:29:20Z"
-    },
-    {
-      "login": "kingcanfish",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43931057?v=4",
-      "profileUrl": "https://github.com/kingcanfish",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-05-02T02:18:47Z",
-      "latestContributionAt": "2026-05-02T02:36:28Z"
     },
     {
       "login": "koco-co",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-26T19:42:14.179Z",
-  "stars": 16698,
+  "generatedAt": "2026-08-28T01:59:57.384Z",
+  "stars": 17031,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3267,
+      "commits": 3287,
       "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-25T16:07:31Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 629,
-      "mergedPullRequests": 629,
+      "commits": 636,
+      "mergedPullRequests": 636,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-26T13:31:55Z"
+      "latestContributionAt": "2026-08-27T14:25:39Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 175,
-      "mergedPullRequests": 174,
+      "commits": 179,
+      "mergedPullRequests": 178,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-26T14:04:42Z"
+      "latestContributionAt": "2026-08-27T09:59:11Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 99,
-      "mergedPullRequests": 99,
+      "commits": 104,
+      "mergedPullRequests": 104,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-26T14:07:35Z"
+      "latestContributionAt": "2026-08-27T14:25:09Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 99,
-      "mergedPullRequests": 87,
+      "commits": 102,
+      "mergedPullRequests": 90,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-26T06:09:09Z"
+      "latestContributionAt": "2026-08-27T14:23:13Z"
     },
     {
       "login": "CN-Scars",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 65,
-      "mergedPullRequests": 65,
+      "commits": 66,
+      "mergedPullRequests": 66,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-26T06:44:20Z"
+      "latestContributionAt": "2026-08-27T02:55:20Z"
     },
     {
       "login": "serenez",
@@ -88,10 +88,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 40,
-      "mergedPullRequests": 40,
+      "commits": 42,
+      "mergedPullRequests": 42,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-26T09:47:15Z"
+      "latestContributionAt": "2026-08-27T00:40:28Z"
     },
     {
       "login": "Illuminated2020",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-08-24T05:29:24Z"
     },
     {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-27T09:17:41Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -254,15 +263,6 @@
       "mergedPullRequests": 12,
       "firstContributionAt": "2026-07-25T02:38:05Z",
       "latestContributionAt": "2026-08-26T13:38:10Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 12,
-      "mergedPullRequests": 12,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-20T14:11:49Z"
     },
     {
       "login": "dienaso",
@@ -364,6 +364,15 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-27T04:21:29Z"
+    },
+    {
       "login": "Jinmoli",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
       "profileUrl": "https://github.com/Jinmoli",
@@ -398,15 +407,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
-    },
-    {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-18T16:30:40Z"
     },
     {
       "login": "jeeinn",
@@ -517,6 +517,15 @@
       "latestContributionAt": "2026-08-13T11:24:49Z"
     },
     {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-27T02:55:06Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -614,15 +623,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-05T16:45:23Z",
       "latestContributionAt": "2026-07-12T13:30:37Z"
-    },
-    {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-18T07:36:37Z"
     },
     {
       "login": "xzxlove",
@@ -994,6 +994,15 @@
       "latestContributionAt": "2026-08-02T08:35:04Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-08-27T09:32:57Z"
+    },
+    {
       "login": "onlyc0302",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24369193?v=4",
       "profileUrl": "https://github.com/onlyc0302",
@@ -1210,6 +1219,15 @@
       "latestContributionAt": "2026-05-10T12:53:40Z"
     },
     {
+      "login": "cdredfox",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315326?v=4",
+      "profileUrl": "https://github.com/cdredfox",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-27T05:57:53Z",
+      "latestContributionAt": "2026-08-27T09:16:58Z"
+    },
+    {
       "login": "CGerAJ",
       "avatarUrl": "https://avatars.githubusercontent.com/u/20548301?v=4",
       "profileUrl": "https://github.com/CGerAJ",
@@ -1370,6 +1388,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-05T11:00:04Z",
       "latestContributionAt": "2026-07-05T11:38:51Z"
+    },
+    {
+      "login": "fanchenggang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20358122?v=4",
+      "profileUrl": "https://github.com/fanchenggang",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-27T07:09:23Z",
+      "latestContributionAt": "2026-08-27T09:37:55Z"
     },
     {
       "login": "fuuulstack",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-15T18:19:28.914Z",
-  "stars": 14957,
+  "generatedAt": "2026-08-16T18:20:13.205Z",
+  "stars": 15086,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3041,
+      "commits": 3046,
       "mergedPullRequests": 16,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-15T04:08:41Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 540,
-      "mergedPullRequests": 540,
+      "commits": 547,
+      "mergedPullRequests": 547,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-15T15:53:32Z"
+      "latestContributionAt": "2026-08-16T18:09:50Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 145,
-      "mergedPullRequests": 144,
+      "commits": 152,
+      "mergedPullRequests": 151,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-12T18:10:38Z"
+      "latestContributionAt": "2026-08-16T17:51:19Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -70,10 +70,10 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 50,
-      "mergedPullRequests": 50,
+      "commits": 57,
+      "mergedPullRequests": 57,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-15T15:43:10Z"
+      "latestContributionAt": "2026-08-16T06:39:43Z"
     },
     {
       "login": "onceMisery",
@@ -580,6 +580,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-16T07:34:03Z"
+    },
+    {
       "login": "azens",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
       "profileUrl": "https://github.com/azens",
@@ -605,6 +614,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-06T10:14:50Z",
       "latestContributionAt": "2026-08-11T13:32:15Z"
+    },
+    {
+      "login": "domye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
+      "profileUrl": "https://github.com/domye",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-15T02:08:13Z",
+      "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
       "login": "jthanh8144",
@@ -1210,15 +1228,6 @@
       "latestContributionAt": "2026-07-25T00:45:27Z"
     },
     {
-      "login": "domye",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
-      "profileUrl": "https://github.com/domye",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-15T02:08:13Z",
-      "latestContributionAt": "2026-08-15T06:44:36Z"
-    },
-    {
       "login": "Driftlux",
       "avatarUrl": "https://avatars.githubusercontent.com/u/96872606?v=4",
       "profileUrl": "https://github.com/Driftlux",
@@ -1514,6 +1523,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-06T06:29:13Z",
       "latestContributionAt": "2026-08-06T18:19:46Z"
+    },
+    {
+      "login": "niubinJD",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/22911292?v=4",
+      "profileUrl": "https://github.com/niubinJD",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-15T16:59:21Z",
+      "latestContributionAt": "2026-08-16T03:21:22Z"
     },
     {
       "login": "octo-patch",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-12T18:54:53.390Z",
-  "stars": 14288,
+  "generatedAt": "2026-08-13T18:55:30.067Z",
+  "stars": 14433,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2960,
+      "commits": 3003,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 513,
-      "mergedPullRequests": 513,
+      "commits": 525,
+      "mergedPullRequests": 525,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-12T18:10:52Z"
+      "latestContributionAt": "2026-08-13T16:11:29Z"
     },
     {
       "login": "eryajf",
@@ -34,10 +34,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 89,
-      "mergedPullRequests": 77,
+      "commits": 90,
+      "mergedPullRequests": 78,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-12T11:34:01Z"
+      "latestContributionAt": "2026-08-13T11:44:48Z"
     },
     {
       "login": "CN-Scars",
@@ -49,6 +49,15 @@
       "latestContributionAt": "2026-08-12T13:05:14Z"
     },
     {
+      "login": "onenewcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
+      "profileUrl": "https://github.com/onenewcode",
+      "commits": 59,
+      "mergedPullRequests": 59,
+      "firstContributionAt": "2026-06-30T01:53:31Z",
+      "latestContributionAt": "2026-08-13T11:31:18Z"
+    },
+    {
       "login": "serenez",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38424953?v=4",
       "profileUrl": "https://github.com/serenez",
@@ -58,22 +67,13 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
-      "login": "onenewcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
-      "profileUrl": "https://github.com/onenewcode",
-      "commits": 55,
-      "mergedPullRequests": 55,
-      "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-12T04:36:14Z"
-    },
-    {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 41,
-      "mergedPullRequests": 39,
+      "commits": 42,
+      "mergedPullRequests": 40,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-10T15:45:43Z"
+      "latestContributionAt": "2026-08-13T16:19:09Z"
     },
     {
       "login": "Illuminated2020",
@@ -85,6 +85,15 @@
       "latestContributionAt": "2026-05-12T09:22:36Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 29,
+      "mergedPullRequests": 29,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-13T02:51:41Z"
+    },
+    {
       "login": "lexmin0412",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24385370?v=4",
       "profileUrl": "https://github.com/lexmin0412",
@@ -92,15 +101,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 28,
-      "mergedPullRequests": 28,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-12T10:24:01Z"
     },
     {
       "login": "xddcode",
@@ -151,10 +151,19 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
-      "commits": 21,
-      "mergedPullRequests": 21,
+      "commits": 22,
+      "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-08-11T05:05:26Z"
+      "latestContributionAt": "2026-08-13T03:40:23Z"
+    },
+    {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 18,
+      "mergedPullRequests": 18,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-13T18:06:06Z"
     },
     {
       "login": "yavon007",
@@ -209,6 +218,15 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-21T05:32:24Z",
       "latestContributionAt": "2026-08-11T07:00:25Z"
+    },
+    {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-13T07:26:45Z"
     },
     {
       "login": "guoyongchang",
@@ -268,19 +286,19 @@
       "login": "dienaso",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
       "profileUrl": "https://github.com/dienaso",
-      "commits": 9,
-      "mergedPullRequests": 9,
+      "commits": 10,
+      "mergedPullRequests": 10,
       "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-08-04T05:02:31Z"
+      "latestContributionAt": "2026-08-13T04:40:51Z"
     },
     {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
       "commits": 9,
       "mergedPullRequests": 9,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-12T18:12:10Z"
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-13T16:10:12Z"
     },
     {
       "login": "aiLi0617",
@@ -292,13 +310,13 @@
       "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
       "commits": 8,
       "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-12T04:37:01Z"
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-13T16:22:44Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -319,15 +337,6 @@
       "latestContributionAt": "2026-08-11T13:33:16Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-12T12:42:45Z"
-    },
-    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -337,13 +346,13 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
       "commits": 7,
       "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-12T05:35:03Z"
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-13T11:25:08Z"
     },
     {
       "login": "xKrah",
@@ -371,15 +380,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-02T15:29:53Z",
       "latestContributionAt": "2026-08-12T14:22:34Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-12T12:15:58Z"
     },
     {
       "login": "luoianun",
@@ -445,6 +445,15 @@
       "latestContributionAt": "2026-08-10T10:51:45Z"
     },
     {
+      "login": "wbean",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
+      "profileUrl": "https://github.com/wbean",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-22T07:12:37Z",
+      "latestContributionAt": "2026-08-13T11:24:49Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -472,6 +481,15 @@
       "latestContributionAt": "2026-08-02T11:35:45Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-13T18:05:51Z"
+    },
+    {
       "login": "Dreamescaper",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17177729?v=4",
       "profileUrl": "https://github.com/Dreamescaper",
@@ -479,6 +497,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-09T07:54:46Z",
       "latestContributionAt": "2026-06-26T09:45:45Z"
+    },
+    {
+      "login": "echocde",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
+      "profileUrl": "https://github.com/echocde",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-06-10T13:16:26Z",
+      "latestContributionAt": "2026-08-13T14:31:14Z"
     },
     {
       "login": "James-Leong",
@@ -506,15 +533,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-22T04:43:40Z",
       "latestContributionAt": "2026-07-31T05:54:26Z"
-    },
-    {
-      "login": "wbean",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
-      "profileUrl": "https://github.com/wbean",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-22T07:12:37Z",
-      "latestContributionAt": "2026-07-30T10:19:13Z"
     },
     {
       "login": "wuxiemian",
@@ -569,24 +587,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-06T10:14:50Z",
       "latestContributionAt": "2026-08-11T13:32:15Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-07T07:51:09Z"
-    },
-    {
-      "login": "echocde",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
-      "profileUrl": "https://github.com/echocde",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-06-10T13:16:26Z",
-      "latestContributionAt": "2026-06-25T04:51:02Z"
     },
     {
       "login": "jthanh8144",
@@ -778,6 +778,15 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-13T04:41:58Z"
+    },
+    {
       "login": "holmesin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
       "profileUrl": "https://github.com/holmesin",
@@ -805,6 +814,15 @@
       "latestContributionAt": "2026-06-17T13:16:31Z"
     },
     {
+      "login": "JcEvoX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/74612426?v=4",
+      "profileUrl": "https://github.com/JcEvoX",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-10T11:37:11Z",
+      "latestContributionAt": "2026-08-13T12:11:53Z"
+    },
+    {
       "login": "jing2uo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3081432?v=4",
       "profileUrl": "https://github.com/jing2uo",
@@ -821,6 +839,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-08T09:25:42Z",
       "latestContributionAt": "2026-06-09T03:59:49Z"
+    },
+    {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-13T18:25:25Z"
     },
     {
       "login": "lc6464",
@@ -956,6 +983,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
+    },
+    {
+      "login": "xzxlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
+      "profileUrl": "https://github.com/xzxlove",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-13T06:38:59Z",
+      "latestContributionAt": "2026-08-13T12:34:54Z"
     },
     {
       "login": "yangqinlong",
@@ -1120,6 +1156,15 @@
       "latestContributionAt": "2026-07-02T08:37:21Z"
     },
     {
+      "login": "Dhevenddra",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/121691114?v=4",
+      "profileUrl": "https://github.com/Dhevenddra",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-13T06:37:45Z",
+      "latestContributionAt": "2026-08-13T16:16:06Z"
+    },
+    {
       "login": "digyear",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160373682?v=4",
       "profileUrl": "https://github.com/digyear",
@@ -1201,6 +1246,15 @@
       "latestContributionAt": "2026-07-05T11:38:51Z"
     },
     {
+      "login": "fengyuwusong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
+      "profileUrl": "https://github.com/fengyuwusong",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-13T06:07:00Z",
+      "latestContributionAt": "2026-08-13T07:26:30Z"
+    },
+    {
       "login": "fuuulstack",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38742225?v=4",
       "profileUrl": "https://github.com/fuuulstack",
@@ -1226,15 +1280,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-01T08:54:31Z",
       "latestContributionAt": "2026-06-01T10:04:58Z"
-    },
-    {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-09T16:37:35Z"
     },
     {
       "login": "heyrmi",
@@ -1307,15 +1352,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T12:23:36Z",
       "latestContributionAt": "2026-07-24T13:11:18Z"
-    },
-    {
-      "login": "JcEvoX",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/74612426?v=4",
-      "profileUrl": "https://github.com/JcEvoX",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-10T11:37:11Z",
-      "latestContributionAt": "2026-08-10T15:38:10Z"
     },
     {
       "login": "JeaceLiu",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-20T18:30:31.659Z",
-  "stars": 16032,
+  "generatedAt": "2026-08-21T18:28:08.295Z",
+  "stars": 16188,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3119,
+      "commits": 3134,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 575,
-      "mergedPullRequests": 575,
+      "commits": 584,
+      "mergedPullRequests": 584,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-20T13:38:21Z"
+      "latestContributionAt": "2026-08-21T11:57:22Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 160,
-      "mergedPullRequests": 159,
+      "commits": 161,
+      "mergedPullRequests": 160,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-20T17:15:46Z"
+      "latestContributionAt": "2026-08-21T04:20:58Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 96,
-      "mergedPullRequests": 84,
+      "commits": 97,
+      "mergedPullRequests": 85,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-19T07:49:15Z"
+      "latestContributionAt": "2026-08-21T02:36:18Z"
     },
     {
       "login": "q396921921",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 60,
-      "mergedPullRequests": 60,
+      "commits": 61,
+      "mergedPullRequests": 61,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-20T10:25:12Z"
+      "latestContributionAt": "2026-08-21T10:19:48Z"
     },
     {
       "login": "serenez",
@@ -148,6 +148,15 @@
       "latestContributionAt": "2026-05-29T05:31:32Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 22,
+      "mergedPullRequests": 22,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-21T04:20:20Z"
+    },
+    {
       "login": "LwClick",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38545827?v=4",
       "profileUrl": "https://github.com/LwClick",
@@ -164,15 +173,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-09T08:33:11Z",
       "latestContributionAt": "2026-08-13T03:40:23Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 19,
-      "mergedPullRequests": 19,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-20T12:42:46Z"
     },
     {
       "login": "yavon007",
@@ -670,6 +670,15 @@
       "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
+      "login": "encyc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/62669951?v=4",
+      "profileUrl": "https://github.com/encyc",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-29T06:54:05Z",
+      "latestContributionAt": "2026-08-21T10:38:54Z"
+    },
+    {
       "login": "fengyuwusong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
       "profileUrl": "https://github.com/fengyuwusong",
@@ -749,6 +758,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-18T10:01:35Z",
       "latestContributionAt": "2026-08-20T13:01:23Z"
+    },
+    {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-21T05:03:15Z"
     },
     {
       "login": "vergil-lai",
@@ -839,15 +857,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-10T08:32:55Z",
       "latestContributionAt": "2026-06-11T09:29:40Z"
-    },
-    {
-      "login": "encyc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/62669951?v=4",
-      "profileUrl": "https://github.com/encyc",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-29T06:54:05Z",
-      "latestContributionAt": "2026-07-31T06:38:50Z"
     },
     {
       "login": "gadfly3173",
@@ -1001,15 +1010,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-13T10:58:52Z",
       "latestContributionAt": "2026-08-09T15:33:24Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-20T14:12:53Z"
     },
     {
       "login": "TangTangH",
@@ -1280,6 +1280,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T09:14:47Z",
       "latestContributionAt": "2026-07-08T10:53:49Z"
+    },
+    {
+      "login": "duminga",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/91080718?v=4",
+      "profileUrl": "https://github.com/duminga",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-20T17:21:17Z",
+      "latestContributionAt": "2026-08-21T04:21:38Z"
     },
     {
       "login": "easton-shi",
@@ -1703,6 +1712,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
+    },
+    {
+      "login": "tatuke",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46305821?v=4",
+      "profileUrl": "https://github.com/tatuke",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-21T08:02:23Z",
+      "latestContributionAt": "2026-08-21T10:12:40Z"
     },
     {
       "login": "Tssshhhh",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,34 +1,34 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-24T18:31:37.649Z",
-  "stars": 16418,
+  "generatedAt": "2026-08-25T18:31:47.394Z",
+  "stars": 16575,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3205,
-      "mergedPullRequests": 17,
+      "commits": 3245,
+      "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-18T04:05:42Z"
+      "latestContributionAt": "2026-08-25T16:07:31Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 606,
-      "mergedPullRequests": 606,
+      "commits": 615,
+      "mergedPullRequests": 615,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-24T16:10:23Z"
+      "latestContributionAt": "2026-08-25T16:27:28Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 170,
-      "mergedPullRequests": 169,
+      "commits": 172,
+      "mergedPullRequests": 171,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-24T12:36:58Z"
+      "latestContributionAt": "2026-08-25T14:00:26Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,19 +43,19 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 90,
-      "mergedPullRequests": 90,
+      "commits": 91,
+      "mergedPullRequests": 91,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-24T10:34:50Z"
+      "latestContributionAt": "2026-08-25T14:36:40Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 70,
-      "mergedPullRequests": 70,
+      "commits": 72,
+      "mergedPullRequests": 72,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-24T12:31:36Z"
+      "latestContributionAt": "2026-08-25T15:57:02Z"
     },
     {
       "login": "onenewcode",
@@ -94,22 +94,22 @@
       "latestContributionAt": "2026-05-12T09:22:36Z"
     },
     {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 35,
-      "mergedPullRequests": 35,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-24T05:31:48Z"
-    },
-    {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 34,
-      "mergedPullRequests": 34,
+      "commits": 36,
+      "mergedPullRequests": 36,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-24T12:28:25Z"
+      "latestContributionAt": "2026-08-25T14:51:27Z"
+    },
+    {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 36,
+      "mergedPullRequests": 36,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-25T07:15:42Z"
     },
     {
       "login": "xddcode",
@@ -490,6 +490,15 @@
       "latestContributionAt": "2026-08-18T15:17:24Z"
     },
     {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-25T06:46:25Z"
+    },
+    {
       "login": "sxhjlzl",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
       "profileUrl": "https://github.com/sxhjlzl",
@@ -578,15 +587,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-08-13T05:20:22Z",
       "latestContributionAt": "2026-08-19T18:26:56Z"
-    },
-    {
-      "login": "lizzzzz777",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
-      "profileUrl": "https://github.com/lizzzzz777",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-14T01:26:28Z",
-      "latestContributionAt": "2026-08-24T05:08:37Z"
     },
     {
       "login": "soddygo",
@@ -731,6 +731,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
+    },
+    {
+      "login": "klinge1011",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
+      "profileUrl": "https://github.com/klinge1011",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-21T12:23:37Z",
+      "latestContributionAt": "2026-08-25T14:35:40Z"
     },
     {
       "login": "lazyanubis",
@@ -949,15 +958,6 @@
       "latestContributionAt": "2026-08-15T06:41:17Z"
     },
     {
-      "login": "klinge1011",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
-      "profileUrl": "https://github.com/klinge1011",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-21T12:23:37Z",
-      "latestContributionAt": "2026-08-24T07:10:10Z"
-    },
-    {
       "login": "lc6464",
       "avatarUrl": "https://avatars.githubusercontent.com/u/64722907?v=4",
       "profileUrl": "https://github.com/lc6464",
@@ -992,6 +992,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-09T10:09:16Z",
       "latestContributionAt": "2026-07-10T05:27:11Z"
+    },
+    {
+      "login": "ordinary-s",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
+      "profileUrl": "https://github.com/ordinary-s",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-18T11:36:48Z",
+      "latestContributionAt": "2026-08-25T13:26:00Z"
     },
     {
       "login": "rainhan99",
@@ -1363,6 +1372,15 @@
       "latestContributionAt": "2026-08-03T07:50:44Z"
     },
     {
+      "login": "gaoruiqiang2017",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/26794805?v=4",
+      "profileUrl": "https://github.com/gaoruiqiang2017",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-25T11:28:46Z",
+      "latestContributionAt": "2026-08-25T14:15:41Z"
+    },
+    {
       "login": "gdzhu8023",
       "avatarUrl": "https://avatars.githubusercontent.com/u/21006156?v=4",
       "profileUrl": "https://github.com/gdzhu8023",
@@ -1597,15 +1615,6 @@
       "latestContributionAt": "2026-08-16T03:21:22Z"
     },
     {
-      "login": "octo-patch",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/266937838?v=4",
-      "profileUrl": "https://github.com/octo-patch",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-30T10:58:25Z",
-      "latestContributionAt": "2026-07-30T15:05:13Z"
-    },
-    {
       "login": "OctoBored",
       "avatarUrl": "https://avatars.githubusercontent.com/u/212877535?v=4",
       "profileUrl": "https://github.com/OctoBored",
@@ -1813,6 +1822,15 @@
       "latestContributionAt": "2026-08-18T04:47:53Z"
     },
     {
+      "login": "wzlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/35476126?v=4",
+      "profileUrl": "https://github.com/wzlove",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-25T11:23:05Z",
+      "latestContributionAt": "2026-08-25T14:34:04Z"
+    },
+    {
       "login": "xcstatus",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40375067?v=4",
       "profileUrl": "https://github.com/xcstatus",
@@ -1973,6 +1991,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
+    },
+    {
+      "login": "octo-patch",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/266937838?v=4",
+      "profileUrl": "https://github.com/octo-patch",
+      "commits": 0,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-30T10:58:25Z",
+      "latestContributionAt": "2026-07-30T15:05:13Z"
     }
   ]
 }

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-06T23:53:35.775Z",
-  "stars": 13507,
+  "generatedAt": "2026-08-07T18:46:06.990Z",
+  "stars": 13631,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2828,
+      "commits": 2845,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 467,
-      "mergedPullRequests": 467,
+      "commits": 472,
+      "mergedPullRequests": 472,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-06T18:40:50Z"
+      "latestContributionAt": "2026-08-07T09:06:19Z"
     },
     {
       "login": "eryajf",
@@ -34,10 +34,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 81,
-      "mergedPullRequests": 69,
+      "commits": 82,
+      "mergedPullRequests": 70,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-06T18:56:27Z"
+      "latestContributionAt": "2026-08-07T05:43:42Z"
     },
     {
       "login": "serenez",
@@ -52,19 +52,19 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 54,
-      "mergedPullRequests": 54,
+      "commits": 55,
+      "mergedPullRequests": 55,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-06T19:24:25Z"
+      "latestContributionAt": "2026-08-07T09:06:04Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 49,
-      "mergedPullRequests": 49,
+      "commits": 50,
+      "mergedPullRequests": 50,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-06T09:09:15Z"
+      "latestContributionAt": "2026-08-07T07:31:45Z"
     },
     {
       "login": "Illuminated2020",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-08-07T07:57:46Z"
+    },
+    {
       "login": "gggaiitx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
       "profileUrl": "https://github.com/gggaiitx",
@@ -101,15 +110,6 @@
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-07-06T09:30:53Z",
       "latestContributionAt": "2026-07-28T14:39:11Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 27,
-      "mergedPullRequests": 27,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-08-04T18:03:10Z"
     },
     {
       "login": "SuLea-IT",
@@ -139,6 +139,15 @@
       "latestContributionAt": "2026-07-16T17:17:49Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 21,
+      "mergedPullRequests": 21,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-07T09:05:48Z"
+    },
+    {
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
@@ -146,15 +155,6 @@
       "mergedPullRequests": 20,
       "firstContributionAt": "2026-06-09T08:33:11Z",
       "latestContributionAt": "2026-08-06T08:30:20Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 19,
-      "mergedPullRequests": 19,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-06T19:30:52Z"
     },
     {
       "login": "yavon007",
@@ -364,6 +364,15 @@
       "latestContributionAt": "2026-07-16T09:01:10Z"
     },
     {
+      "login": "ChunMengLu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
+      "profileUrl": "https://github.com/ChunMengLu",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-24T07:06:09Z",
+      "latestContributionAt": "2026-08-07T05:43:30Z"
+    },
+    {
       "login": "fraluc06",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67560467?v=4",
       "profileUrl": "https://github.com/fraluc06",
@@ -382,6 +391,15 @@
       "latestContributionAt": "2026-08-02T08:34:50Z"
     },
     {
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-08-07T07:32:16Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -398,15 +416,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-06T11:21:25Z",
       "latestContributionAt": "2026-06-29T03:16:38Z"
-    },
-    {
-      "login": "ChunMengLu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
-      "profileUrl": "https://github.com/ChunMengLu",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-24T07:06:09Z",
-      "latestContributionAt": "2026-08-06T16:13:34Z"
     },
     {
       "login": "CSXFanMeng",
@@ -434,15 +443,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-07-07T10:09:02Z"
     },
     {
       "login": "possebon",
@@ -517,6 +517,15 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-07T07:51:09Z"
+    },
+    {
       "login": "echocde",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
       "profileUrl": "https://github.com/echocde",
@@ -524,6 +533,24 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-06-25T04:51:02Z"
+    },
+    {
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-05T09:25:09Z",
+      "latestContributionAt": "2026-08-07T07:40:13Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-07T05:43:09Z"
     },
     {
       "login": "jthanh8144",
@@ -542,6 +569,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
+    },
+    {
+      "login": "lazyanubis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
+      "profileUrl": "https://github.com/lazyanubis",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-12T06:57:24Z",
+      "latestContributionAt": "2026-08-07T05:45:00Z"
     },
     {
       "login": "polemp",
@@ -634,15 +670,6 @@
       "latestContributionAt": "2026-07-31T08:24:13Z"
     },
     {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-03T07:08:09Z"
-    },
-    {
       "login": "Doracoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9206272?v=4",
       "profileUrl": "https://github.com/Doracoin",
@@ -733,15 +760,6 @@
       "latestContributionAt": "2026-07-13T09:03:34Z"
     },
     {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-06T15:15:17Z"
-    },
-    {
       "login": "JinRudy",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28995387?v=4",
       "profileUrl": "https://github.com/JinRudy",
@@ -749,15 +767,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-08T09:25:42Z",
       "latestContributionAt": "2026-06-09T03:59:49Z"
-    },
-    {
-      "login": "lazyanubis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
-      "profileUrl": "https://github.com/lazyanubis",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-12T06:57:24Z",
-      "latestContributionAt": "2026-08-05T07:29:34Z"
     },
     {
       "login": "lc6464",
@@ -1093,6 +1102,15 @@
       "latestContributionAt": "2026-07-08T10:53:49Z"
     },
     {
+      "login": "ededddy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43884159?v=4",
+      "profileUrl": "https://github.com/ededddy",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T01:12:45Z",
+      "latestContributionAt": "2026-08-07T07:18:32Z"
+    },
+    {
       "login": "ekesaiting",
       "avatarUrl": "https://avatars.githubusercontent.com/u/36790768?v=4",
       "profileUrl": "https://github.com/ekesaiting",
@@ -1172,15 +1190,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T09:27:49Z",
       "latestContributionAt": "2026-07-06T10:21:15Z"
-    },
-    {
-      "login": "HighBigSky",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
-      "profileUrl": "https://github.com/HighBigSky",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-06T06:25:31Z",
-      "latestContributionAt": "2026-08-06T08:29:27Z"
     },
     {
       "login": "huangyemin",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-02T18:21:44.205Z",
-  "stars": 12970,
+  "generatedAt": "2026-08-03T19:23:42.232Z",
+  "stars": 13084,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2750,
+      "commits": 2776,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 433,
-      "mergedPullRequests": 433,
+      "commits": 441,
+      "mergedPullRequests": 441,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-02T11:09:23Z"
+      "latestContributionAt": "2026-08-03T16:37:43Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 120,
-      "mergedPullRequests": 119,
+      "commits": 122,
+      "mergedPullRequests": 121,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-02T08:34:14Z"
+      "latestContributionAt": "2026-08-03T16:46:13Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 76,
-      "mergedPullRequests": 64,
+      "commits": 77,
+      "mergedPullRequests": 65,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-02T14:46:13Z"
+      "latestContributionAt": "2026-08-03T12:59:40Z"
     },
     {
       "login": "serenez",
@@ -175,6 +175,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-03T12:25:01Z"
+    },
+    {
       "login": "juvevood",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1421513?v=4",
       "profileUrl": "https://github.com/juvevood",
@@ -182,15 +191,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-02T01:02:01Z"
     },
     {
       "login": "SpencerZhang",
@@ -283,6 +283,15 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-03T08:58:21Z"
+    },
+    {
       "login": "tianyifeng-druid",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
       "profileUrl": "https://github.com/tianyifeng-druid",
@@ -301,15 +310,6 @@
       "latestContributionAt": "2026-05-11T14:10:01Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-07-30T17:57:40Z"
-    },
-    {
       "login": "dbin0123",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18297300?v=4",
       "profileUrl": "https://github.com/dbin0123",
@@ -326,6 +326,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-17T05:09:05Z",
       "latestContributionAt": "2026-07-01T11:05:45Z"
+    },
+    {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-03T06:34:07Z"
     },
     {
       "login": "ZionLin2016",
@@ -364,15 +373,6 @@
       "latestContributionAt": "2026-08-02T08:34:50Z"
     },
     {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-07-29T12:33:34Z"
-    },
-    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -380,6 +380,15 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
+    },
+    {
+      "login": "aiLi0617",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
+      "profileUrl": "https://github.com/aiLi0617",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-06-19T14:50:55Z",
+      "latestContributionAt": "2026-08-03T17:38:30Z"
     },
     {
       "login": "Caisin",
@@ -454,6 +463,15 @@
       "latestContributionAt": "2026-07-12T13:30:37Z"
     },
     {
+      "login": "zhuhaoh",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/88836213?v=4",
+      "profileUrl": "https://github.com/zhuhaoh",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-06T10:48:19Z",
+      "latestContributionAt": "2026-08-03T08:59:34Z"
+    },
+    {
       "login": "zorohu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24402746?v=4",
       "profileUrl": "https://github.com/zorohu",
@@ -470,15 +488,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
-    },
-    {
-      "login": "aiLi0617",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
-      "profileUrl": "https://github.com/aiLi0617",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-06-19T14:50:55Z",
-      "latestContributionAt": "2026-07-27T15:52:40Z"
     },
     {
       "login": "ChunMengLu",
@@ -553,15 +562,6 @@
       "latestContributionAt": "2026-04-30T09:48:13Z"
     },
     {
-      "login": "zhuhaoh",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/88836213?v=4",
-      "profileUrl": "https://github.com/zhuhaoh",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-06T10:48:19Z",
-      "latestContributionAt": "2026-07-08T16:45:29Z"
-    },
-    {
       "login": "Michaelxwb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34806714?v=4",
       "profileUrl": "https://github.com/Michaelxwb",
@@ -616,6 +616,15 @@
       "latestContributionAt": "2026-07-31T08:24:13Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-03T07:08:09Z"
+    },
+    {
       "login": "Doracoin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/9206272?v=4",
       "profileUrl": "https://github.com/Doracoin",
@@ -668,6 +677,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-13T23:36:43Z",
       "latestContributionAt": "2026-07-26T16:37:41Z"
+    },
+    {
+      "login": "ijevin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
+      "profileUrl": "https://github.com/ijevin",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-30T05:45:30Z",
+      "latestContributionAt": "2026-08-03T08:58:47Z"
     },
     {
       "login": "IT-SDJ",
@@ -731,6 +749,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-09T10:09:16Z",
       "latestContributionAt": "2026-07-10T05:27:11Z"
+    },
+    {
+      "login": "possebon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
+      "profileUrl": "https://github.com/possebon",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-02T17:09:52Z",
+      "latestContributionAt": "2026-08-02T19:42:40Z"
     },
     {
       "login": "rainhan99",
@@ -868,6 +895,15 @@
       "latestContributionAt": "2026-06-06T01:15:09Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-03T13:29:24Z"
+    },
+    {
       "login": "athoune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/74048?v=4",
       "profileUrl": "https://github.com/athoune",
@@ -922,6 +958,15 @@
       "latestContributionAt": "2026-05-10T12:53:40Z"
     },
     {
+      "login": "CGerAJ",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/20548301?v=4",
+      "profileUrl": "https://github.com/CGerAJ",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-01T10:52:08Z",
+      "latestContributionAt": "2026-08-03T08:05:57Z"
+    },
+    {
       "login": "chrstphe",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10966918?v=4",
       "profileUrl": "https://github.com/chrstphe",
@@ -965,15 +1010,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-02T07:45:55Z",
       "latestContributionAt": "2026-07-02T08:37:21Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-07-31T06:55:23Z"
     },
     {
       "login": "digyear",
@@ -1039,6 +1075,15 @@
       "latestContributionAt": "2026-07-05T11:38:51Z"
     },
     {
+      "login": "fuuulstack",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38742225?v=4",
+      "profileUrl": "https://github.com/fuuulstack",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-23T06:23:37Z",
+      "latestContributionAt": "2026-08-03T07:50:44Z"
+    },
+    {
       "login": "gdzhu8023",
       "avatarUrl": "https://avatars.githubusercontent.com/u/21006156?v=4",
       "profileUrl": "https://github.com/gdzhu8023",
@@ -1075,6 +1120,15 @@
       "latestContributionAt": "2026-07-06T10:21:15Z"
     },
     {
+      "login": "holmesin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
+      "profileUrl": "https://github.com/holmesin",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-03T12:29:55Z",
+      "latestContributionAt": "2026-08-03T16:46:28Z"
+    },
+    {
       "login": "huangyemin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11872262?v=4",
       "profileUrl": "https://github.com/huangyemin",
@@ -1109,15 +1163,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-16T10:33:05Z",
       "latestContributionAt": "2026-06-16T10:52:02Z"
-    },
-    {
-      "login": "ijevin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
-      "profileUrl": "https://github.com/ijevin",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-30T05:45:30Z",
-      "latestContributionAt": "2026-07-30T09:16:39Z"
     },
     {
       "login": "imhyuk-huno",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-30T20:24:13.247Z",
-  "stars": 17473,
+  "generatedAt": "2026-08-31T22:17:45.069Z",
+  "stars": 17575,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3310,
+      "commits": 3322,
       "mergedPullRequests": 23,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-30T05:30:01Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 644,
-      "mergedPullRequests": 644,
+      "commits": 658,
+      "mergedPullRequests": 658,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-29T19:05:11Z"
+      "latestContributionAt": "2026-08-31T17:59:02Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 191,
-      "mergedPullRequests": 190,
+      "commits": 198,
+      "mergedPullRequests": 197,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-30T04:26:07Z"
+      "latestContributionAt": "2026-08-31T17:17:23Z"
     },
     {
       "login": "q396921921",
@@ -52,19 +52,28 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 74,
-      "mergedPullRequests": 74,
+      "commits": 77,
+      "mergedPullRequests": 77,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-28T08:51:34Z"
+      "latestContributionAt": "2026-08-31T15:49:01Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 66,
-      "mergedPullRequests": 66,
+      "commits": 69,
+      "mergedPullRequests": 69,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-27T02:55:20Z"
+      "latestContributionAt": "2026-08-31T17:18:00Z"
+    },
+    {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 59,
+      "mergedPullRequests": 59,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-31T18:12:56Z"
     },
     {
       "login": "serenez",
@@ -74,15 +83,6 @@
       "mergedPullRequests": 55,
       "firstContributionAt": "2026-04-30T04:27:54Z",
       "latestContributionAt": "2026-07-20T15:31:27Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 47,
-      "mergedPullRequests": 47,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-29T16:47:45Z"
     },
     {
       "login": "onceMisery",
@@ -106,10 +106,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 36,
-      "mergedPullRequests": 36,
+      "commits": 39,
+      "mergedPullRequests": 39,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-25T07:15:42Z"
+      "latestContributionAt": "2026-08-31T16:34:12Z"
     },
     {
       "login": "xddcode",
@@ -211,6 +211,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-31T07:57:16Z"
+    },
+    {
       "login": "AndrewDi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
       "profileUrl": "https://github.com/AndrewDi",
@@ -227,15 +236,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-28T03:11:35Z"
     },
     {
       "login": "DASungta",
@@ -391,6 +391,15 @@
       "latestContributionAt": "2026-08-13T11:25:08Z"
     },
     {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-31T17:19:47Z"
+    },
+    {
       "login": "xKrah",
       "avatarUrl": "https://avatars.githubusercontent.com/u/23560682?v=4",
       "profileUrl": "https://github.com/xKrah",
@@ -454,13 +463,13 @@
       "latestContributionAt": "2026-08-26T05:52:42Z"
     },
     {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
+      "login": "xiaou61",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
+      "profileUrl": "https://github.com/xiaou61",
       "commits": 6,
       "mergedPullRequests": 6,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-29T17:34:00Z"
+      "firstContributionAt": "2026-08-14T09:19:51Z",
+      "latestContributionAt": "2026-08-31T14:29:16Z"
     },
     {
       "login": "ZionLin2016",
@@ -598,6 +607,15 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-08-31T16:22:03Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -623,15 +641,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-05T16:45:23Z",
       "latestContributionAt": "2026-07-12T13:30:37Z"
-    },
-    {
-      "login": "xiaou61",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
-      "profileUrl": "https://github.com/xiaou61",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-14T09:19:51Z",
-      "latestContributionAt": "2026-08-28T04:36:37Z"
     },
     {
       "login": "xzxlove",
@@ -758,15 +767,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
-    },
-    {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-08-28T06:27:56Z"
     },
     {
       "login": "ordinary-s",
@@ -1192,6 +1192,15 @@
       "latestContributionAt": "2026-06-06T01:15:09Z"
     },
     {
+      "login": "andystenhe",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16678274?v=4",
+      "profileUrl": "https://github.com/andystenhe",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T04:15:28Z",
+      "latestContributionAt": "2026-08-31T14:55:42Z"
+    },
+    {
       "login": "athoune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/74048?v=4",
       "profileUrl": "https://github.com/athoune",
@@ -1444,6 +1453,15 @@
       "latestContributionAt": "2026-07-03T16:58:52Z"
     },
     {
+      "login": "guoziyangnb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/136451743?v=4",
+      "profileUrl": "https://github.com/guoziyangnb",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T12:46:35Z",
+      "latestContributionAt": "2026-08-31T15:46:03Z"
+    },
+    {
       "login": "Hank076",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3490170?v=4",
       "profileUrl": "https://github.com/Hank076",
@@ -1469,6 +1487,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-27T12:10:39Z",
       "latestContributionAt": "2026-07-28T18:40:46Z"
+    },
+    {
+      "login": "hhktony",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1276702?v=4",
+      "profileUrl": "https://github.com/hhktony",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-30T07:26:17Z",
+      "latestContributionAt": "2026-08-31T17:19:12Z"
     },
     {
       "login": "hieptuanle",
@@ -1867,6 +1894,15 @@
       "latestContributionAt": "2026-06-19T16:13:09Z"
     },
     {
+      "login": "wangfengxiang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31534139?v=4",
+      "profileUrl": "https://github.com/wangfengxiang",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T09:52:03Z",
+      "latestContributionAt": "2026-08-31T16:21:10Z"
+    },
+    {
       "login": "wfion",
       "avatarUrl": "https://avatars.githubusercontent.com/u/85852251?v=4",
       "profileUrl": "https://github.com/wfion",
@@ -1892,6 +1928,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wojiukankan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32760220?v=4",
+      "profileUrl": "https://github.com/wojiukankan",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-31T11:36:26Z",
+      "latestContributionAt": "2026-08-31T16:19:59Z"
     },
     {
       "login": "wu-zhao-min",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-03T19:23:42.232Z",
-  "stars": 13084,
+  "generatedAt": "2026-08-04T19:23:43.773Z",
+  "stars": 13194,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2776,
+      "commits": 2794,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,10 +16,10 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 441,
-      "mergedPullRequests": 441,
+      "commits": 444,
+      "mergedPullRequests": 444,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-03T16:37:43Z"
+      "latestContributionAt": "2026-08-04T17:10:58Z"
     },
     {
       "login": "eryajf",
@@ -35,9 +35,9 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
       "commits": 77,
-      "mergedPullRequests": 65,
+      "mergedPullRequests": 66,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-03T12:59:40Z"
+      "latestContributionAt": "2026-08-04T18:59:52Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 44,
-      "mergedPullRequests": 44,
+      "commits": 46,
+      "mergedPullRequests": 46,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-02T14:45:33Z"
+      "latestContributionAt": "2026-08-04T17:02:21Z"
     },
     {
       "login": "Illuminated2020",
@@ -103,6 +103,15 @@
       "latestContributionAt": "2026-07-28T14:39:11Z"
     },
     {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 27,
+      "mergedPullRequests": 27,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-08-04T18:03:10Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-04-30T05:56:34Z",
       "latestContributionAt": "2026-07-10T10:15:25Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 25,
-      "mergedPullRequests": 25,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-07-31T08:27:06Z"
     },
     {
       "login": "rarnu",
@@ -247,6 +247,24 @@
       "latestContributionAt": "2026-08-02T01:04:30Z"
     },
     {
+      "login": "dienaso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
+      "profileUrl": "https://github.com/dienaso",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-24T03:23:39Z",
+      "latestContributionAt": "2026-08-04T05:02:31Z"
+    },
+    {
+      "login": "guoyongchang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
+      "profileUrl": "https://github.com/guoyongchang",
+      "commits": 8,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-07-30T02:45:51Z",
+      "latestContributionAt": "2026-08-04T18:59:20Z"
+    },
+    {
       "login": "amwps290",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
       "profileUrl": "https://github.com/amwps290",
@@ -254,24 +272,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-07-21T05:32:24Z",
       "latestContributionAt": "2026-07-31T14:31:51Z"
-    },
-    {
-      "login": "dienaso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
-      "profileUrl": "https://github.com/dienaso",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-07-30T13:10:20Z"
-    },
-    {
-      "login": "guoyongchang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
-      "profileUrl": "https://github.com/guoyongchang",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-30T02:45:51Z",
-      "latestContributionAt": "2026-07-31T13:22:32Z"
     },
     {
       "login": "czs208112",
@@ -769,6 +769,15 @@
       "latestContributionAt": "2026-07-13T09:51:52Z"
     },
     {
+      "login": "rihkddd",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
+      "profileUrl": "https://github.com/rihkddd",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-30T13:25:21Z",
+      "latestContributionAt": "2026-08-04T17:09:59Z"
+    },
+    {
       "login": "Sanjeever",
       "avatarUrl": "https://avatars.githubusercontent.com/u/78210374?v=4",
       "profileUrl": "https://github.com/Sanjeever",
@@ -1192,6 +1201,24 @@
       "latestContributionAt": "2026-07-17T08:32:50Z"
     },
     {
+      "login": "jean3690",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188204999?v=4",
+      "profileUrl": "https://github.com/jean3690",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T02:43:43Z",
+      "latestContributionAt": "2026-08-04T05:01:50Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-04T11:05:05Z"
+    },
+    {
       "login": "kcheng007",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3156606?v=4",
       "profileUrl": "https://github.com/kcheng007",
@@ -1345,13 +1372,13 @@
       "latestContributionAt": "2026-06-07T18:07:00Z"
     },
     {
-      "login": "rihkddd",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
-      "profileUrl": "https://github.com/rihkddd",
+      "login": "Rson9",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/118523711?v=4",
+      "profileUrl": "https://github.com/Rson9",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-30T13:25:21Z",
-      "latestContributionAt": "2026-07-30T19:09:19Z"
+      "firstContributionAt": "2026-08-03T06:58:44Z",
+      "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
       "login": "shenmo7192",
@@ -1577,6 +1604,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
+    },
+    {
+      "login": "TangTangH",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
+      "profileUrl": "https://github.com/TangTangH",
+      "commits": 0,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T04:55:17Z",
+      "latestContributionAt": "2026-08-04T18:59:34Z"
     }
   ]
 }

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-11T18:54:53.020Z",
-  "stars": 14124,
+  "generatedAt": "2026-08-12T18:54:53.390Z",
+  "stars": 14288,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2914,
+      "commits": 2960,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 506,
-      "mergedPullRequests": 506,
+      "commits": 513,
+      "mergedPullRequests": 513,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-11T16:12:03Z"
+      "latestContributionAt": "2026-08-12T18:10:52Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 143,
-      "mergedPullRequests": 142,
+      "commits": 145,
+      "mergedPullRequests": 144,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-11T18:20:06Z"
+      "latestContributionAt": "2026-08-12T18:10:38Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 88,
-      "mergedPullRequests": 76,
+      "commits": 89,
+      "mergedPullRequests": 77,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-11T16:19:58Z"
+      "latestContributionAt": "2026-08-12T11:34:01Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 59,
-      "mergedPullRequests": 59,
+      "commits": 62,
+      "mergedPullRequests": 62,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-11T16:09:02Z"
+      "latestContributionAt": "2026-08-12T13:05:14Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 54,
-      "mergedPullRequests": 54,
+      "commits": 55,
+      "mergedPullRequests": 55,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-11T16:41:31Z"
+      "latestContributionAt": "2026-08-12T04:36:14Z"
     },
     {
       "login": "onceMisery",
@@ -94,6 +94,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-12T10:24:01Z"
+    },
+    {
       "login": "xddcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
       "profileUrl": "https://github.com/xddcode",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-07-06T09:30:53Z",
       "latestContributionAt": "2026-07-28T14:39:11Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 26,
-      "mergedPullRequests": 26,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-11T13:34:50Z"
     },
     {
       "login": "SuLea-IT",
@@ -274,6 +274,15 @@
       "latestContributionAt": "2026-08-04T05:02:31Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-12T18:12:10Z"
+    },
+    {
       "login": "aiLi0617",
       "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
       "profileUrl": "https://github.com/aiLi0617",
@@ -281,6 +290,15 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
+    },
+    {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-12T04:37:01Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -301,6 +319,15 @@
       "latestContributionAt": "2026-08-11T13:33:16Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-12T12:42:45Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -310,13 +337,13 @@
       "latestContributionAt": "2026-07-29T16:27:55Z"
     },
     {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
       "commits": 7,
       "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-03T08:58:21Z"
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-12T05:35:03Z"
     },
     {
       "login": "xKrah",
@@ -337,13 +364,22 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
       "commits": 6,
       "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-08T02:40:34Z"
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-08-12T14:22:34Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-12T12:15:58Z"
     },
     {
       "login": "luoianun",
@@ -371,15 +407,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-11T18:05:55Z"
     },
     {
       "login": "antwa",
@@ -416,24 +443,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-08-05T09:25:09Z",
       "latestContributionAt": "2026-08-10T10:51:45Z"
-    },
-    {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-08-07T07:32:16Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-09T17:11:26Z"
     },
     {
       "login": "ZhonFortune",
@@ -641,6 +650,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
       "login": "Michaelxwb",
@@ -1462,15 +1480,6 @@
       "latestContributionAt": "2026-06-27T13:44:36Z"
     },
     {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-07-20T16:10:42Z"
-    },
-    {
       "login": "Quinlevi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24589232?v=4",
       "profileUrl": "https://github.com/Quinlevi",
@@ -1606,15 +1615,6 @@
       "latestContributionAt": "2026-07-06T04:57:27Z"
     },
     {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-10T10:22:17Z"
-    },
-    {
       "login": "xcstatus",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40375067?v=4",
       "profileUrl": "https://github.com/xcstatus",
@@ -1730,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-22T13:57:59Z",
       "latestContributionAt": "2026-07-22T14:20:42Z"
+    },
+    {
+      "login": "zhwq1216",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/9948390?v=4",
+      "profileUrl": "https://github.com/zhwq1216",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T05:21:37Z",
+      "latestContributionAt": "2026-08-12T03:51:32Z"
     },
     {
       "login": "zouchao",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-23T18:20:19.981Z",
-  "stars": 16310,
+  "generatedAt": "2026-08-24T18:31:37.649Z",
+  "stars": 16418,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3178,
+      "commits": 3205,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,55 +16,55 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 590,
-      "mergedPullRequests": 590,
+      "commits": 606,
+      "mergedPullRequests": 606,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-22T17:39:23Z"
+      "latestContributionAt": "2026-08-24T16:10:23Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 166,
-      "mergedPullRequests": 165,
+      "commits": 170,
+      "mergedPullRequests": 169,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-22T18:53:52Z"
+      "latestContributionAt": "2026-08-24T12:36:58Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 97,
-      "mergedPullRequests": 85,
+      "commits": 98,
+      "mergedPullRequests": 86,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-21T02:36:18Z"
+      "latestContributionAt": "2026-08-24T12:28:13Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 88,
-      "mergedPullRequests": 88,
+      "commits": 90,
+      "mergedPullRequests": 90,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-23T04:25:45Z"
+      "latestContributionAt": "2026-08-24T10:34:50Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 68,
-      "mergedPullRequests": 68,
+      "commits": 70,
+      "mergedPullRequests": 70,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-22T07:41:21Z"
+      "latestContributionAt": "2026-08-24T12:31:36Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 62,
-      "mergedPullRequests": 62,
+      "commits": 64,
+      "mergedPullRequests": 64,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-22T04:58:28Z"
+      "latestContributionAt": "2026-08-24T12:32:20Z"
     },
     {
       "login": "serenez",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 45,
-      "mergedPullRequests": 43,
+      "commits": 46,
+      "mergedPullRequests": 44,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-23T04:23:46Z"
+      "latestContributionAt": "2026-08-24T10:35:18Z"
     },
     {
       "login": "Illuminated2020",
@@ -97,10 +97,19 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
+      "commits": 35,
+      "mergedPullRequests": 35,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-24T05:31:48Z"
+    },
+    {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
       "commits": 34,
       "mergedPullRequests": 34,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-20T07:14:20Z"
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-24T12:28:25Z"
     },
     {
       "login": "xddcode",
@@ -110,15 +119,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-07-10T06:34:09Z",
       "latestContributionAt": "2026-08-20T02:23:08Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 29,
-      "mergedPullRequests": 29,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-23T10:08:18Z"
     },
     {
       "login": "gggaiitx",
@@ -229,6 +229,15 @@
       "latestContributionAt": "2026-08-20T08:04:22Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-24T05:29:24Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-17T03:22:35Z",
       "latestContributionAt": "2026-07-20T08:54:52Z"
-    },
-    {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 12,
-      "mergedPullRequests": 12,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-23T04:24:47Z"
     },
     {
       "login": "mr-dadong",
@@ -263,6 +263,15 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-18T04:43:31Z"
+    },
+    {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-24T10:58:15Z"
     },
     {
       "login": "guoyongchang",
@@ -317,15 +326,6 @@
       "mergedPullRequests": 10,
       "firstContributionAt": "2026-06-16T09:58:42Z",
       "latestContributionAt": "2026-07-02T06:03:20Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-19T12:23:17Z"
     },
     {
       "login": "aiLi0617",
@@ -490,6 +490,15 @@
       "latestContributionAt": "2026-08-18T15:17:24Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-24T05:26:09Z"
+    },
+    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -571,6 +580,15 @@
       "latestContributionAt": "2026-08-19T18:26:56Z"
     },
     {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-24T05:08:37Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -587,15 +605,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-22T04:43:40Z",
       "latestContributionAt": "2026-07-31T05:54:26Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-22T17:40:51Z"
     },
     {
       "login": "wuxiemian",
@@ -731,15 +740,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
-    },
-    {
-      "login": "lizzzzz777",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
-      "profileUrl": "https://github.com/lizzzzz777",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-14T01:26:28Z",
-      "latestContributionAt": "2026-08-18T02:51:50Z"
     },
     {
       "login": "polemp",
@@ -947,6 +947,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-05-02T02:18:47Z",
       "latestContributionAt": "2026-08-15T06:41:17Z"
+    },
+    {
+      "login": "klinge1011",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
+      "profileUrl": "https://github.com/klinge1011",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-21T12:23:37Z",
+      "latestContributionAt": "2026-08-24T07:10:10Z"
     },
     {
       "login": "lc6464",
@@ -1469,15 +1478,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-23T09:40:04Z",
       "latestContributionAt": "2026-07-28T17:29:20Z"
-    },
-    {
-      "login": "klinge1011",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34301334?v=4",
-      "profileUrl": "https://github.com/klinge1011",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-21T12:23:37Z",
-      "latestContributionAt": "2026-08-22T07:41:17Z"
     },
     {
       "login": "koco-co",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-22T18:20:43.168Z",
-  "stars": 16247,
+  "generatedAt": "2026-08-23T18:20:19.981Z",
+  "stars": 16310,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3161,
+      "commits": 3178,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,7 +16,7 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 588,
+      "commits": 590,
       "mergedPullRequests": 590,
       "firstContributionAt": "2026-06-22T06:10:59Z",
       "latestContributionAt": "2026-08-22T17:39:23Z"
@@ -25,10 +25,10 @@
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 163,
-      "mergedPullRequests": 163,
+      "commits": 166,
+      "mergedPullRequests": 165,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-22T17:40:22Z"
+      "latestContributionAt": "2026-08-22T18:53:52Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,10 +43,10 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 87,
-      "mergedPullRequests": 87,
+      "commits": 88,
+      "mergedPullRequests": 88,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-22T04:52:54Z"
+      "latestContributionAt": "2026-08-23T04:25:45Z"
     },
     {
       "login": "CN-Scars",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 44,
-      "mergedPullRequests": 42,
+      "commits": 45,
+      "mergedPullRequests": 43,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-22T07:41:14Z"
+      "latestContributionAt": "2026-08-23T04:23:46Z"
     },
     {
       "login": "Illuminated2020",
@@ -112,6 +112,15 @@
       "latestContributionAt": "2026-08-20T02:23:08Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 29,
+      "mergedPullRequests": 29,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-23T10:08:18Z"
+    },
+    {
       "login": "gggaiitx",
       "avatarUrl": "https://avatars.githubusercontent.com/u/62124152?v=4",
       "profileUrl": "https://github.com/gggaiitx",
@@ -128,15 +137,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 26,
-      "mergedPullRequests": 28,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-22T17:39:54Z"
     },
     {
       "login": "SuLea-IT",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 12,
+      "mergedPullRequests": 12,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-08-23T04:24:47Z"
+    },
+    {
       "login": "mr-dadong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
       "profileUrl": "https://github.com/mr-dadong",
@@ -245,15 +254,6 @@
       "mergedPullRequests": 12,
       "firstContributionAt": "2026-08-17T07:04:42Z",
       "latestContributionAt": "2026-08-20T14:11:49Z"
-    },
-    {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-13T07:26:45Z"
     },
     {
       "login": "dienaso",
@@ -589,6 +589,15 @@
       "latestContributionAt": "2026-07-31T05:54:26Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-22T17:40:51Z"
+    },
+    {
       "login": "wuxiemian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29685283?v=4",
       "profileUrl": "https://github.com/wuxiemian",
@@ -641,15 +650,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 3,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-22T17:40:51Z"
     },
     {
       "login": "BabyLy233",
@@ -1856,6 +1856,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-17T03:34:26Z",
       "latestContributionAt": "2026-08-17T06:57:27Z"
+    },
+    {
+      "login": "Xinbeok",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/174566968?v=4",
+      "profileUrl": "https://github.com/Xinbeok",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-23T09:06:00Z",
+      "latestContributionAt": "2026-08-23T10:29:36Z"
     },
     {
       "login": "YangYuS8",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-16T18:20:13.205Z",
-  "stars": 15086,
+  "generatedAt": "2026-08-17T18:30:19.040Z",
+  "stars": 15319,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3046,
+      "commits": 3057,
       "mergedPullRequests": 16,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-15T04:08:41Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 547,
-      "mergedPullRequests": 547,
+      "commits": 555,
+      "mergedPullRequests": 555,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-16T18:09:50Z"
+      "latestContributionAt": "2026-08-17T11:40:40Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 152,
-      "mergedPullRequests": 151,
+      "commits": 153,
+      "mergedPullRequests": 152,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-16T17:51:19Z"
+      "latestContributionAt": "2026-08-17T06:58:48Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -58,6 +58,15 @@
       "latestContributionAt": "2026-08-13T11:31:18Z"
     },
     {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 59,
+      "mergedPullRequests": 59,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-17T06:52:01Z"
+    },
+    {
       "login": "serenez",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38424953?v=4",
       "profileUrl": "https://github.com/serenez",
@@ -65,15 +74,6 @@
       "mergedPullRequests": 55,
       "firstContributionAt": "2026-04-30T04:27:54Z",
       "latestContributionAt": "2026-07-20T15:31:27Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 57,
-      "mergedPullRequests": 57,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-16T06:39:43Z"
     },
     {
       "login": "onceMisery",
@@ -220,6 +220,15 @@
       "latestContributionAt": "2026-08-14T09:47:55Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-17T05:11:58Z"
+    },
+    {
       "login": "DASungta",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
       "profileUrl": "https://github.com/DASungta",
@@ -263,15 +272,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-02T16:19:01Z",
       "latestContributionAt": "2026-07-27T14:47:00Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-14T14:56:29Z"
     },
     {
       "login": "chenhbb",
@@ -472,6 +472,24 @@
       "latestContributionAt": "2026-07-08T16:35:34Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-17T08:31:45Z"
+    },
+    {
+      "login": "azens",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
+      "profileUrl": "https://github.com/azens",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-17T06:34:18Z",
+      "latestContributionAt": "2026-08-17T07:54:14Z"
+    },
+    {
       "login": "Caisin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25792786?v=4",
       "profileUrl": "https://github.com/Caisin",
@@ -524,6 +542,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
+    },
+    {
+      "login": "jthanh8144",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
+      "profileUrl": "https://github.com/jthanh8144",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-15T03:09:27Z",
+      "latestContributionAt": "2026-08-17T06:53:34Z"
     },
     {
       "login": "soddygo",
@@ -580,24 +607,6 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-16T07:34:03Z"
-    },
-    {
-      "login": "azens",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
-      "profileUrl": "https://github.com/azens",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-17T06:34:18Z",
-      "latestContributionAt": "2026-08-15T06:59:05Z"
-    },
-    {
       "login": "BabyLy233",
       "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
       "profileUrl": "https://github.com/BabyLy233",
@@ -623,15 +632,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-15T02:08:13Z",
       "latestContributionAt": "2026-08-16T07:33:49Z"
-    },
-    {
-      "login": "jthanh8144",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
-      "profileUrl": "https://github.com/jthanh8144",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-15T03:09:27Z",
-      "latestContributionAt": "2026-07-16T10:21:11Z"
     },
     {
       "login": "kkk000111999",
@@ -740,6 +740,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-26T03:33:01Z",
       "latestContributionAt": "2026-07-01T08:35:48Z"
+    },
+    {
+      "login": "bigFish0124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
+      "profileUrl": "https://github.com/bigFish0124",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-11T08:46:27Z",
+      "latestContributionAt": "2026-08-17T03:20:29Z"
     },
     {
       "login": "bigliangzao",
@@ -1138,15 +1147,6 @@
       "latestContributionAt": "2026-05-21T02:24:47Z"
     },
     {
-      "login": "bigFish0124",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
-      "profileUrl": "https://github.com/bigFish0124",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-11T08:46:27Z",
-      "latestContributionAt": "2026-08-11T13:31:45Z"
-    },
-    {
       "login": "BlueSkyXN",
       "avatarUrl": "https://avatars.githubusercontent.com/u/63384277?v=4",
       "profileUrl": "https://github.com/BlueSkyXN",
@@ -1489,6 +1489,15 @@
       "latestContributionAt": "2026-07-28T15:18:13Z"
     },
     {
+      "login": "luojiyin1987",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6524977?v=4",
+      "profileUrl": "https://github.com/luojiyin1987",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-17T02:51:45Z",
+      "latestContributionAt": "2026-08-17T07:10:31Z"
+    },
+    {
       "login": "ManjusriBuddha",
       "avatarUrl": "https://avatars.githubusercontent.com/u/55905747?v=4",
       "profileUrl": "https://github.com/ManjusriBuddha",
@@ -1739,6 +1748,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-27T13:49:30Z",
       "latestContributionAt": "2026-07-28T19:18:06Z"
+    },
+    {
+      "login": "xiaoyaoqilan",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/155608604?v=4",
+      "profileUrl": "https://github.com/xiaoyaoqilan",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-17T03:34:26Z",
+      "latestContributionAt": "2026-08-17T06:57:27Z"
     },
     {
       "login": "YangYuS8",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-05T19:21:57.639Z",
-  "stars": 13317,
+  "generatedAt": "2026-08-06T23:53:35.775Z",
+  "stars": 13507,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2808,
+      "commits": 2828,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 459,
-      "mergedPullRequests": 459,
+      "commits": 467,
+      "mergedPullRequests": 467,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-05T15:58:32Z"
+      "latestContributionAt": "2026-08-06T18:40:50Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 126,
-      "mergedPullRequests": 125,
+      "commits": 132,
+      "mergedPullRequests": 131,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-05T16:55:36Z"
+      "latestContributionAt": "2026-08-06T18:41:28Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 80,
-      "mergedPullRequests": 68,
+      "commits": 81,
+      "mergedPullRequests": 69,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-05T07:52:20Z"
+      "latestContributionAt": "2026-08-06T18:56:27Z"
     },
     {
       "login": "serenez",
@@ -52,19 +52,19 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 52,
-      "mergedPullRequests": 52,
+      "commits": 54,
+      "mergedPullRequests": 54,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-05T15:58:22Z"
+      "latestContributionAt": "2026-08-06T19:24:25Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 47,
-      "mergedPullRequests": 47,
+      "commits": 49,
+      "mergedPullRequests": 49,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-05T06:51:14Z"
+      "latestContributionAt": "2026-08-06T09:09:15Z"
     },
     {
       "login": "Illuminated2020",
@@ -142,10 +142,19 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
+      "commits": 20,
+      "mergedPullRequests": 20,
+      "firstContributionAt": "2026-06-09T08:33:11Z",
+      "latestContributionAt": "2026-08-06T08:30:20Z"
+    },
+    {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
       "commits": 19,
       "mergedPullRequests": 19,
-      "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-07-21T08:59:03Z"
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-06T19:30:52Z"
     },
     {
       "login": "yavon007",
@@ -164,15 +173,6 @@
       "mergedPullRequests": 16,
       "firstContributionAt": "2026-06-17T08:11:49Z",
       "latestContributionAt": "2026-06-26T10:48:46Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 16,
-      "mergedPullRequests": 16,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-05T01:48:04Z"
     },
     {
       "login": "jischeng",
@@ -238,6 +238,15 @@
       "latestContributionAt": "2026-07-27T14:47:00Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 10,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-06T15:16:00Z"
+    },
+    {
       "login": "chenhbb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
       "profileUrl": "https://github.com/chenhbb",
@@ -256,15 +265,6 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 9,
-      "mergedPullRequests": 9,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-05T03:37:57Z"
-    },
-    {
       "login": "dienaso",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
       "profileUrl": "https://github.com/dienaso",
@@ -272,6 +272,15 @@
       "mergedPullRequests": 9,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-04T05:02:31Z"
+    },
+    {
+      "login": "aiLi0617",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
+      "profileUrl": "https://github.com/aiLi0617",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-06-19T14:50:55Z",
+      "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
       "login": "czs208112",
@@ -301,6 +310,15 @@
       "latestContributionAt": "2026-07-31T08:23:56Z"
     },
     {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-06T06:00:09Z"
+    },
+    {
       "login": "xKrah",
       "avatarUrl": "https://avatars.githubusercontent.com/u/23560682?v=4",
       "profileUrl": "https://github.com/xKrah",
@@ -328,15 +346,6 @@
       "latestContributionAt": "2026-07-01T11:05:45Z"
     },
     {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-08-03T06:34:07Z"
-    },
-    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -344,15 +353,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
-    },
-    {
-      "login": "aiLi0617",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
-      "profileUrl": "https://github.com/aiLi0617",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-06-19T14:50:55Z",
-      "latestContributionAt": "2026-08-05T17:12:31Z"
     },
     {
       "login": "antwa",
@@ -400,6 +400,15 @@
       "latestContributionAt": "2026-06-29T03:16:38Z"
     },
     {
+      "login": "ChunMengLu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
+      "profileUrl": "https://github.com/ChunMengLu",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-07-24T07:06:09Z",
+      "latestContributionAt": "2026-08-06T16:13:34Z"
+    },
+    {
       "login": "CSXFanMeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
       "profileUrl": "https://github.com/CSXFanMeng",
@@ -418,6 +427,15 @@
       "latestContributionAt": "2026-06-26T09:45:45Z"
     },
     {
+      "login": "James-Leong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
+      "profileUrl": "https://github.com/James-Leong",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-06-08T17:32:08Z",
+      "latestContributionAt": "2026-08-06T04:13:57Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -425,6 +443,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-02T15:29:53Z",
       "latestContributionAt": "2026-07-07T10:09:02Z"
+    },
+    {
+      "login": "possebon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
+      "profileUrl": "https://github.com/possebon",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-02T17:09:52Z",
+      "latestContributionAt": "2026-08-06T19:35:19Z"
     },
     {
       "login": "soddygo",
@@ -490,15 +517,6 @@
       "latestContributionAt": "2026-05-06T04:09:26Z"
     },
     {
-      "login": "ChunMengLu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
-      "profileUrl": "https://github.com/ChunMengLu",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-24T07:06:09Z",
-      "latestContributionAt": "2026-07-30T10:19:40Z"
-    },
-    {
       "login": "echocde",
       "avatarUrl": "https://avatars.githubusercontent.com/u/70051971?v=4",
       "profileUrl": "https://github.com/echocde",
@@ -506,15 +524,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-06-25T04:51:02Z"
-    },
-    {
-      "login": "James-Leong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
-      "profileUrl": "https://github.com/James-Leong",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-06-08T17:32:08Z",
-      "latestContributionAt": "2026-07-23T16:56:05Z"
     },
     {
       "login": "jthanh8144",
@@ -688,6 +697,15 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
+      "login": "holmesin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
+      "profileUrl": "https://github.com/holmesin",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-03T12:29:55Z",
+      "latestContributionAt": "2026-08-06T15:33:29Z"
+    },
+    {
       "login": "ijevin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
       "profileUrl": "https://github.com/ijevin",
@@ -713,6 +731,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-12T13:29:00Z",
       "latestContributionAt": "2026-07-13T09:03:34Z"
+    },
+    {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-06T15:15:17Z"
     },
     {
       "login": "JinRudy",
@@ -769,15 +796,6 @@
       "latestContributionAt": "2026-07-10T05:27:11Z"
     },
     {
-      "login": "possebon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
-      "profileUrl": "https://github.com/possebon",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-02T17:09:52Z",
-      "latestContributionAt": "2026-08-02T19:42:40Z"
-    },
-    {
       "login": "rainhan99",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16128160?v=4",
       "profileUrl": "https://github.com/rainhan99",
@@ -803,6 +821,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-01T15:04:40Z",
       "latestContributionAt": "2026-06-09T04:06:39Z"
+    },
+    {
+      "login": "TangTangH",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
+      "profileUrl": "https://github.com/TangTangH",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-04T04:55:17Z",
+      "latestContributionAt": "2026-08-06T06:09:21Z"
     },
     {
       "login": "togls",
@@ -895,6 +922,15 @@
       "latestContributionAt": "2026-05-05T09:30:42Z"
     },
     {
+      "login": "2090230619-syq",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/268813423?v=4",
+      "profileUrl": "https://github.com/2090230619-syq",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T02:22:08Z",
+      "latestContributionAt": "2026-08-06T04:41:24Z"
+    },
+    {
       "login": "adntian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2285733?v=4",
       "profileUrl": "https://github.com/adntian",
@@ -983,6 +1019,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-06T12:18:47Z"
     },
     {
       "login": "cl1107",
@@ -1129,13 +1174,13 @@
       "latestContributionAt": "2026-07-06T10:21:15Z"
     },
     {
-      "login": "holmesin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
-      "profileUrl": "https://github.com/holmesin",
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-03T12:29:55Z",
-      "latestContributionAt": "2026-08-03T16:46:28Z"
+      "firstContributionAt": "2026-08-06T06:25:31Z",
+      "latestContributionAt": "2026-08-06T08:29:27Z"
     },
     {
       "login": "huangyemin",
@@ -1208,15 +1253,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-04T02:43:43Z",
       "latestContributionAt": "2026-08-04T05:01:50Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-04T11:05:05Z"
     },
     {
       "login": "kcheng007",
@@ -1316,6 +1352,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-14T11:25:31Z",
       "latestContributionAt": "2026-07-28T20:32:27Z"
+    },
+    {
+      "login": "monellin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17845081?v=4",
+      "profileUrl": "https://github.com/monellin",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T06:29:13Z",
+      "latestContributionAt": "2026-08-06T18:19:46Z"
     },
     {
       "login": "octo-patch",
@@ -1442,15 +1487,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
-    },
-    {
-      "login": "TangTangH",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
-      "profileUrl": "https://github.com/TangTangH",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-04T04:55:17Z",
-      "latestContributionAt": "2026-08-04T18:59:34Z"
     },
     {
       "login": "Tssshhhh",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-09T18:31:28.680Z",
-  "stars": 13772,
+  "generatedAt": "2026-08-10T18:48:33.509Z",
+  "stars": 13956,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2866,
+      "commits": 2885,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 489,
-      "mergedPullRequests": 489,
+      "commits": 499,
+      "mergedPullRequests": 499,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-09T15:24:37Z"
+      "latestContributionAt": "2026-08-10T16:53:43Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 135,
-      "mergedPullRequests": 134,
+      "commits": 139,
+      "mergedPullRequests": 138,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-09T06:14:09Z"
+      "latestContributionAt": "2026-08-10T15:02:38Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -40,6 +40,15 @@
       "latestContributionAt": "2026-08-09T17:06:44Z"
     },
     {
+      "login": "CN-Scars",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
+      "profileUrl": "https://github.com/CN-Scars",
+      "commits": 58,
+      "mergedPullRequests": 58,
+      "firstContributionAt": "2026-05-30T10:02:05Z",
+      "latestContributionAt": "2026-08-10T15:02:43Z"
+    },
+    {
       "login": "serenez",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38424953?v=4",
       "profileUrl": "https://github.com/serenez",
@@ -49,31 +58,22 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
-      "login": "CN-Scars",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
-      "profileUrl": "https://github.com/CN-Scars",
-      "commits": 56,
-      "mergedPullRequests": 56,
-      "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-08T03:08:18Z"
-    },
-    {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 50,
-      "mergedPullRequests": 50,
+      "commits": 52,
+      "mergedPullRequests": 52,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-07T07:31:45Z"
+      "latestContributionAt": "2026-08-10T10:27:04Z"
     },
     {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 40,
-      "mergedPullRequests": 38,
+      "commits": 41,
+      "mergedPullRequests": 39,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-09T06:24:10Z"
+      "latestContributionAt": "2026-08-10T15:45:43Z"
     },
     {
       "login": "Illuminated2020",
@@ -121,6 +121,15 @@
       "latestContributionAt": "2026-07-10T10:15:25Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 24,
+      "mergedPullRequests": 24,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-10T18:12:22Z"
+    },
+    {
       "login": "rarnu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/209014?v=4",
       "profileUrl": "https://github.com/rarnu",
@@ -137,15 +146,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-26T03:29:22Z",
       "latestContributionAt": "2026-07-16T17:17:49Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 22,
-      "mergedPullRequests": 22,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-08T02:37:59Z"
     },
     {
       "login": "ptma",
@@ -400,6 +400,15 @@
       "latestContributionAt": "2026-06-30T17:35:07Z"
     },
     {
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-05T09:25:09Z",
+      "latestContributionAt": "2026-08-10T10:51:45Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -427,6 +436,15 @@
       "latestContributionAt": "2026-07-08T16:35:34Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-10T11:25:46Z"
+    },
+    {
       "login": "Caisin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/25792786?v=4",
       "profileUrl": "https://github.com/Caisin",
@@ -452,15 +470,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-09T07:54:46Z",
       "latestContributionAt": "2026-06-26T09:45:45Z"
-    },
-    {
-      "login": "HighBigSky",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
-      "profileUrl": "https://github.com/HighBigSky",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-05T09:25:09Z",
-      "latestContributionAt": "2026-08-08T02:38:08Z"
     },
     {
       "login": "James-Leong",
@@ -589,6 +598,15 @@
       "latestContributionAt": "2026-07-29T12:48:40Z"
     },
     {
+      "login": "rihkddd",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
+      "profileUrl": "https://github.com/rihkddd",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-30T13:25:21Z",
+      "latestContributionAt": "2026-08-10T16:08:18Z"
+    },
+    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -623,15 +641,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-06T07:06:32Z",
       "latestContributionAt": "2026-07-07T02:34:32Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-05T03:17:02Z"
     },
     {
       "login": "asdlem",
@@ -830,15 +839,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-12T05:47:37Z",
       "latestContributionAt": "2026-07-13T09:51:52Z"
-    },
-    {
-      "login": "rihkddd",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/2656576?v=4",
-      "profileUrl": "https://github.com/rihkddd",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-30T13:25:21Z",
-      "latestContributionAt": "2026-08-04T17:09:59Z"
     },
     {
       "login": "Sanjeever",
@@ -1046,6 +1046,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
+    },
+    {
+      "login": "chenow9",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/302014081?v=4",
+      "profileUrl": "https://github.com/chenow9",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-06T04:32:47Z",
+      "latestContributionAt": "2026-08-10T02:54:27Z"
     },
     {
       "login": "cl1107",
@@ -1264,6 +1273,15 @@
       "latestContributionAt": "2026-07-24T13:11:18Z"
     },
     {
+      "login": "JcEvoX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/74612426?v=4",
+      "profileUrl": "https://github.com/JcEvoX",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-10T11:37:11Z",
+      "latestContributionAt": "2026-08-10T15:38:10Z"
+    },
+    {
       "login": "JeaceLiu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31269749?v=4",
       "profileUrl": "https://github.com/JeaceLiu",
@@ -1480,6 +1498,15 @@
       "latestContributionAt": "2026-07-30T09:16:18Z"
     },
     {
+      "login": "solarhell",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10279583?v=4",
+      "profileUrl": "https://github.com/solarhell",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-10T07:32:03Z",
+      "latestContributionAt": "2026-08-10T10:26:11Z"
+    },
+    {
       "login": "srako",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18043224?v=4",
       "profileUrl": "https://github.com/srako",
@@ -1550,6 +1577,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-10T10:22:17Z"
     },
     {
       "login": "xcstatus",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-25T18:31:47.394Z",
-  "stars": 16575,
+  "generatedAt": "2026-08-26T19:42:14.179Z",
+  "stars": 16698,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3245,
+      "commits": 3267,
       "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-25T16:07:31Z"
@@ -16,55 +16,55 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 615,
-      "mergedPullRequests": 615,
+      "commits": 629,
+      "mergedPullRequests": 629,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-25T16:27:28Z"
+      "latestContributionAt": "2026-08-26T13:31:55Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 172,
-      "mergedPullRequests": 171,
+      "commits": 175,
+      "mergedPullRequests": 174,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-25T14:00:26Z"
-    },
-    {
-      "login": "Abeautifulsnow",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
-      "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 98,
-      "mergedPullRequests": 86,
-      "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-24T12:28:13Z"
+      "latestContributionAt": "2026-08-26T14:04:42Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 91,
-      "mergedPullRequests": 91,
+      "commits": 99,
+      "mergedPullRequests": 99,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-25T14:36:40Z"
+      "latestContributionAt": "2026-08-26T14:07:35Z"
+    },
+    {
+      "login": "Abeautifulsnow",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
+      "profileUrl": "https://github.com/Abeautifulsnow",
+      "commits": 99,
+      "mergedPullRequests": 87,
+      "firstContributionAt": "2026-05-06T03:16:57Z",
+      "latestContributionAt": "2026-08-26T06:09:09Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 72,
-      "mergedPullRequests": 72,
+      "commits": 73,
+      "mergedPullRequests": 73,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-25T15:57:02Z"
+      "latestContributionAt": "2026-08-26T07:49:49Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 64,
-      "mergedPullRequests": 64,
+      "commits": 65,
+      "mergedPullRequests": 65,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-24T12:32:20Z"
+      "latestContributionAt": "2026-08-26T06:44:20Z"
     },
     {
       "login": "serenez",
@@ -85,6 +85,15 @@
       "latestContributionAt": "2026-08-24T10:35:18Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 40,
+      "mergedPullRequests": 40,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-26T09:47:15Z"
+    },
+    {
       "login": "Illuminated2020",
       "avatarUrl": "https://avatars.githubusercontent.com/u/95458741?v=4",
       "profileUrl": "https://github.com/Illuminated2020",
@@ -92,15 +101,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-12T09:13:51Z",
       "latestContributionAt": "2026-05-12T09:22:36Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 36,
-      "mergedPullRequests": 36,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-25T14:51:27Z"
     },
     {
       "login": "mapan0424",
@@ -247,6 +247,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 12,
+      "mergedPullRequests": 12,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-26T13:38:10Z"
+    },
+    {
       "login": "mr-dadong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
       "profileUrl": "https://github.com/mr-dadong",
@@ -263,15 +272,6 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-18T04:43:31Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-24T10:58:15Z"
     },
     {
       "login": "guoyongchang",
@@ -436,6 +436,15 @@
       "latestContributionAt": "2026-08-08T03:04:17Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-26T05:52:42Z"
+    },
+    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -497,15 +506,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-08-14T01:26:28Z",
       "latestContributionAt": "2026-08-25T06:46:25Z"
-    },
-    {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-24T05:26:09Z"
     },
     {
       "login": "wbean",
@@ -751,6 +751,15 @@
       "latestContributionAt": "2026-08-07T05:45:00Z"
     },
     {
+      "login": "ordinary-s",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
+      "profileUrl": "https://github.com/ordinary-s",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-18T11:36:48Z",
+      "latestContributionAt": "2026-08-26T14:00:04Z"
+    },
+    {
       "login": "polemp",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48376445?v=4",
       "profileUrl": "https://github.com/polemp",
@@ -994,15 +1003,6 @@
       "latestContributionAt": "2026-07-10T05:27:11Z"
     },
     {
-      "login": "ordinary-s",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
-      "profileUrl": "https://github.com/ordinary-s",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-18T11:36:48Z",
-      "latestContributionAt": "2026-08-25T13:26:00Z"
-    },
-    {
       "login": "rainhan99",
       "avatarUrl": "https://avatars.githubusercontent.com/u/16128160?v=4",
       "profileUrl": "https://github.com/rainhan99",
@@ -1226,6 +1226,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-06T04:32:47Z",
       "latestContributionAt": "2026-08-10T02:54:27Z"
+    },
+    {
+      "login": "Cherrs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6745593?v=4",
+      "profileUrl": "https://github.com/Cherrs",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-25T09:42:47Z",
+      "latestContributionAt": "2026-08-26T05:21:51Z"
     },
     {
       "login": "cl1107",
@@ -1525,6 +1534,15 @@
       "latestContributionAt": "2026-08-05T01:49:14Z"
     },
     {
+      "login": "LDQONJ",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/128981031?v=4",
+      "profileUrl": "https://github.com/LDQONJ",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-26T02:32:37Z",
+      "latestContributionAt": "2026-08-26T06:43:53Z"
+    },
+    {
       "login": "leic4u",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32786903?v=4",
       "profileUrl": "https://github.com/leic4u",
@@ -1712,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-09T07:01:29Z",
       "latestContributionAt": "2026-06-09T08:23:14Z"
+    },
+    {
+      "login": "StaravenX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
+      "profileUrl": "https://github.com/StaravenX",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-26T11:48:56Z",
+      "latestContributionAt": "2026-08-26T13:37:29Z"
     },
     {
       "login": "sunny0826",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-10T18:48:33.509Z",
-  "stars": 13956,
+  "generatedAt": "2026-08-11T18:54:53.020Z",
+  "stars": 14124,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2885,
+      "commits": 2914,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 499,
-      "mergedPullRequests": 499,
+      "commits": 506,
+      "mergedPullRequests": 506,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-10T16:53:43Z"
+      "latestContributionAt": "2026-08-11T16:12:03Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 139,
-      "mergedPullRequests": 138,
+      "commits": 143,
+      "mergedPullRequests": 142,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-10T15:02:38Z"
+      "latestContributionAt": "2026-08-11T18:20:06Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 84,
-      "mergedPullRequests": 72,
+      "commits": 88,
+      "mergedPullRequests": 76,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-09T17:06:44Z"
+      "latestContributionAt": "2026-08-11T16:19:58Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 58,
-      "mergedPullRequests": 58,
+      "commits": 59,
+      "mergedPullRequests": 59,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-10T15:02:43Z"
+      "latestContributionAt": "2026-08-11T16:09:02Z"
     },
     {
       "login": "serenez",
@@ -61,10 +61,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 52,
-      "mergedPullRequests": 52,
+      "commits": 54,
+      "mergedPullRequests": 54,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-10T10:27:04Z"
+      "latestContributionAt": "2026-08-11T16:41:31Z"
     },
     {
       "login": "onceMisery",
@@ -112,6 +112,15 @@
       "latestContributionAt": "2026-07-28T14:39:11Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 26,
+      "mergedPullRequests": 26,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-11T13:34:50Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 30,
       "firstContributionAt": "2026-04-30T05:56:34Z",
       "latestContributionAt": "2026-07-10T10:15:25Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 24,
-      "mergedPullRequests": 24,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-10T18:12:22Z"
     },
     {
       "login": "rarnu",
@@ -151,10 +151,10 @@
       "login": "ptma",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1761883?v=4",
       "profileUrl": "https://github.com/ptma",
-      "commits": 20,
-      "mergedPullRequests": 20,
+      "commits": 21,
+      "mergedPullRequests": 21,
       "firstContributionAt": "2026-06-09T08:33:11Z",
-      "latestContributionAt": "2026-08-06T08:30:20Z"
+      "latestContributionAt": "2026-08-11T05:05:26Z"
     },
     {
       "login": "yavon007",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-11T07:00:25Z"
+    },
+    {
       "login": "guoyongchang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
       "profileUrl": "https://github.com/guoyongchang",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-02T16:19:01Z",
       "latestContributionAt": "2026-07-27T14:47:00Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-06T15:16:00Z"
     },
     {
       "login": "chenhbb",
@@ -292,6 +292,15 @@
       "latestContributionAt": "2026-08-09T16:07:12Z"
     },
     {
+      "login": "wang-zhengxin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
+      "profileUrl": "https://github.com/wang-zhengxin",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-22T06:48:07Z",
+      "latestContributionAt": "2026-08-11T13:33:16Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -308,15 +317,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-03T08:58:21Z"
-    },
-    {
-      "login": "wang-zhengxin",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32348572?v=4",
-      "profileUrl": "https://github.com/wang-zhengxin",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-22T06:48:07Z",
-      "latestContributionAt": "2026-08-06T06:00:09Z"
     },
     {
       "login": "xKrah",
@@ -371,6 +371,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-03T09:51:57Z",
       "latestContributionAt": "2026-07-10T11:27:07Z"
+    },
+    {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-11T18:05:55Z"
     },
     {
       "login": "antwa",
@@ -434,15 +443,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-10T11:25:46Z"
     },
     {
       "login": "Caisin",
@@ -542,6 +542,24 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-04T09:11:57Z",
       "latestContributionAt": "2026-05-06T04:09:26Z"
+    },
+    {
+      "login": "BabyLy233",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
+      "profileUrl": "https://github.com/BabyLy233",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-07-14T07:55:34Z",
+      "latestContributionAt": "2026-08-11T08:55:53Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-11T13:32:15Z"
     },
     {
       "login": "difagume",
@@ -677,15 +695,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
-    },
-    {
-      "login": "cheshireez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
-      "profileUrl": "https://github.com/cheshireez",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-06T10:14:50Z",
-      "latestContributionAt": "2026-08-08T03:33:38Z"
     },
     {
       "login": "cwatanab",
@@ -1012,15 +1021,6 @@
       "latestContributionAt": "2026-06-30T09:34:14Z"
     },
     {
-      "login": "BabyLy233",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/79321988?v=4",
-      "profileUrl": "https://github.com/BabyLy233",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-14T07:55:34Z",
-      "latestContributionAt": "2026-07-14T11:03:42Z"
-    },
-    {
       "login": "baizhi958216",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46777503?v=4",
       "profileUrl": "https://github.com/baizhi958216",
@@ -1028,6 +1028,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-21T01:48:37Z",
       "latestContributionAt": "2026-05-21T02:24:47Z"
+    },
+    {
+      "login": "bigFish0124",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315702762?v=4",
+      "profileUrl": "https://github.com/bigFish0124",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T08:46:27Z",
+      "latestContributionAt": "2026-08-11T13:31:45Z"
     },
     {
       "login": "BlueSkyXN",
@@ -1118,6 +1127,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T09:14:47Z",
       "latestContributionAt": "2026-07-08T10:53:49Z"
+    },
+    {
+      "login": "easton-shi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/215789663?v=4",
+      "profileUrl": "https://github.com/easton-shi",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-08T07:21:44Z",
+      "latestContributionAt": "2026-08-11T05:05:04Z"
     },
     {
       "login": "ededddy",
@@ -1568,6 +1586,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-22T12:39:46Z",
       "latestContributionAt": "2026-07-22T15:52:15Z"
+    },
+    {
+      "login": "wilyan09007",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/77467499?v=4",
+      "profileUrl": "https://github.com/wilyan09007",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-11T06:09:28Z",
+      "latestContributionAt": "2026-08-11T13:37:32Z"
     },
     {
       "login": "wnyr",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,34 +1,34 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-29T01:23:22.980Z",
-  "stars": 17282,
+  "generatedAt": "2026-08-29T20:17:46.770Z",
+  "stars": 17401,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3302,
-      "mergedPullRequests": 18,
+      "commits": 3306,
+      "mergedPullRequests": 19,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-25T16:07:31Z"
+      "latestContributionAt": "2026-08-29T19:54:16Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 641,
-      "mergedPullRequests": 641,
+      "commits": 644,
+      "mergedPullRequests": 644,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-28T09:16:56Z"
+      "latestContributionAt": "2026-08-29T19:05:11Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 183,
-      "mergedPullRequests": 182,
+      "commits": 187,
+      "mergedPullRequests": 186,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-28T09:19:40Z"
+      "latestContributionAt": "2026-08-29T19:05:44Z"
     },
     {
       "login": "q396921921",
@@ -76,6 +76,15 @@
       "latestContributionAt": "2026-07-20T15:31:27Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 47,
+      "mergedPullRequests": 47,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-29T16:47:45Z"
+    },
+    {
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
@@ -83,15 +92,6 @@
       "mergedPullRequests": 44,
       "firstContributionAt": "2026-06-10T14:19:43Z",
       "latestContributionAt": "2026-08-24T10:35:18Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 44,
-      "mergedPullRequests": 44,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-28T07:30:09Z"
     },
     {
       "login": "Illuminated2020",
@@ -107,7 +107,7 @@
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
       "commits": 36,
-      "mergedPullRequests": 36,
+      "mergedPullRequests": 37,
       "firstContributionAt": "2026-07-17T05:42:50Z",
       "latestContributionAt": "2026-08-25T07:15:42Z"
     },
@@ -454,6 +454,15 @@
       "latestContributionAt": "2026-08-26T05:52:42Z"
     },
     {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-29T17:34:00Z"
+    },
+    {
       "login": "ZionLin2016",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24632648?v=4",
       "profileUrl": "https://github.com/ZionLin2016",
@@ -499,6 +508,15 @@
       "latestContributionAt": "2026-08-18T15:17:24Z"
     },
     {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-29T19:57:03Z"
+    },
+    {
       "login": "lizzzzz777",
       "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
       "profileUrl": "https://github.com/lizzzzz777",
@@ -515,15 +533,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-22T07:12:37Z",
       "latestContributionAt": "2026-08-13T11:24:49Z"
-    },
-    {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-27T02:55:06Z"
     },
     {
       "login": "ZhonFortune",
@@ -587,15 +596,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-19T18:26:56Z"
     },
     {
       "login": "soddygo",
@@ -1444,6 +1444,15 @@
       "latestContributionAt": "2026-06-01T10:04:58Z"
     },
     {
+      "login": "Hanwn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/30523763?v=4",
+      "profileUrl": "https://github.com/Hanwn",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-29T01:18:22Z",
+      "latestContributionAt": "2026-08-29T17:11:09Z"
+    },
+    {
       "login": "heyrmi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/42892759?v=4",
       "profileUrl": "https://github.com/heyrmi",
@@ -1721,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-03T06:58:44Z",
       "latestContributionAt": "2026-08-04T06:23:45Z"
+    },
+    {
+      "login": "s1oopX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/185045939?v=4",
+      "profileUrl": "https://github.com/s1oopX",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-29T11:49:11Z",
+      "latestContributionAt": "2026-08-29T17:02:01Z"
     },
     {
       "login": "shnno13",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-07T18:46:06.990Z",
-  "stars": 13631,
+  "generatedAt": "2026-08-08T18:28:50.496Z",
+  "stars": 13727,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2845,
+      "commits": 2854,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 472,
-      "mergedPullRequests": 472,
+      "commits": 479,
+      "mergedPullRequests": 479,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-07T09:06:19Z"
+      "latestContributionAt": "2026-08-08T03:36:58Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 132,
-      "mergedPullRequests": 131,
+      "commits": 134,
+      "mergedPullRequests": 133,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-06T18:41:28Z"
+      "latestContributionAt": "2026-08-08T03:33:47Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 82,
-      "mergedPullRequests": 70,
+      "commits": 83,
+      "mergedPullRequests": 71,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-07T05:43:42Z"
+      "latestContributionAt": "2026-08-08T04:00:51Z"
     },
     {
       "login": "serenez",
@@ -52,10 +52,10 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 55,
-      "mergedPullRequests": 55,
+      "commits": 56,
+      "mergedPullRequests": 56,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-07T09:06:04Z"
+      "latestContributionAt": "2026-08-08T03:08:18Z"
     },
     {
       "login": "onenewcode",
@@ -142,10 +142,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 21,
-      "mergedPullRequests": 21,
+      "commits": 22,
+      "mergedPullRequests": 22,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-07T09:05:48Z"
+      "latestContributionAt": "2026-08-08T02:37:59Z"
     },
     {
       "login": "ptma",
@@ -337,6 +337,15 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-08T02:40:34Z"
+    },
+    {
       "login": "luoianun",
       "avatarUrl": "https://avatars.githubusercontent.com/u/20828060?v=4",
       "profileUrl": "https://github.com/luoianun",
@@ -344,6 +353,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-17T05:09:05Z",
       "latestContributionAt": "2026-07-01T11:05:45Z"
+    },
+    {
+      "login": "possebon",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
+      "profileUrl": "https://github.com/possebon",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-02T17:09:52Z",
+      "latestContributionAt": "2026-08-08T03:04:17Z"
     },
     {
       "login": "ZionLin2016",
@@ -380,15 +398,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-01T08:26:41Z",
       "latestContributionAt": "2026-06-30T17:35:07Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-02T08:34:50Z"
     },
     {
       "login": "jeeinn",
@@ -436,6 +445,15 @@
       "latestContributionAt": "2026-06-26T09:45:45Z"
     },
     {
+      "login": "HighBigSky",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
+      "profileUrl": "https://github.com/HighBigSky",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-05T09:25:09Z",
+      "latestContributionAt": "2026-08-08T02:38:08Z"
+    },
+    {
       "login": "James-Leong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
       "profileUrl": "https://github.com/James-Leong",
@@ -445,13 +463,13 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
-      "login": "possebon",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
-      "profileUrl": "https://github.com/possebon",
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
       "commits": 4,
       "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-02T17:09:52Z",
-      "latestContributionAt": "2026-08-06T19:35:19Z"
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-08T03:56:32Z"
     },
     {
       "login": "soddygo",
@@ -533,24 +551,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-10T13:16:26Z",
       "latestContributionAt": "2026-06-25T04:51:02Z"
-    },
-    {
-      "login": "HighBigSky",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113153113?v=4",
-      "profileUrl": "https://github.com/HighBigSky",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-05T09:25:09Z",
-      "latestContributionAt": "2026-08-07T07:40:13Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-07T05:43:09Z"
     },
     {
       "login": "jthanh8144",
@@ -659,6 +659,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
+    },
+    {
+      "login": "cheshireez",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
+      "profileUrl": "https://github.com/cheshireez",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-06T10:14:50Z",
+      "latestContributionAt": "2026-08-08T03:33:38Z"
     },
     {
       "login": "cwatanab",
@@ -1028,15 +1037,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
-    },
-    {
-      "login": "cheshireez",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/32764974?v=4",
-      "profileUrl": "https://github.com/cheshireez",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-06T10:14:50Z",
-      "latestContributionAt": "2026-08-06T12:18:47Z"
     },
     {
       "login": "cl1107",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-08T18:28:50.496Z",
-  "stars": 13727,
+  "generatedAt": "2026-08-09T18:31:28.680Z",
+  "stars": 13772,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2854,
+      "commits": 2866,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 479,
-      "mergedPullRequests": 479,
+      "commits": 489,
+      "mergedPullRequests": 489,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-08T03:36:58Z"
+      "latestContributionAt": "2026-08-09T15:24:37Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 134,
-      "mergedPullRequests": 133,
+      "commits": 135,
+      "mergedPullRequests": 134,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-08T03:33:47Z"
+      "latestContributionAt": "2026-08-09T06:14:09Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 83,
-      "mergedPullRequests": 71,
+      "commits": 84,
+      "mergedPullRequests": 72,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-08T04:00:51Z"
+      "latestContributionAt": "2026-08-09T17:06:44Z"
     },
     {
       "login": "serenez",
@@ -67,6 +67,15 @@
       "latestContributionAt": "2026-08-07T07:31:45Z"
     },
     {
+      "login": "onceMisery",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
+      "profileUrl": "https://github.com/onceMisery",
+      "commits": 40,
+      "mergedPullRequests": 38,
+      "firstContributionAt": "2026-06-10T14:19:43Z",
+      "latestContributionAt": "2026-08-09T06:24:10Z"
+    },
+    {
       "login": "Illuminated2020",
       "avatarUrl": "https://avatars.githubusercontent.com/u/95458741?v=4",
       "profileUrl": "https://github.com/Illuminated2020",
@@ -74,15 +83,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-05-12T09:13:51Z",
       "latestContributionAt": "2026-05-12T09:22:36Z"
-    },
-    {
-      "login": "onceMisery",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
-      "profileUrl": "https://github.com/onceMisery",
-      "commits": 39,
-      "mergedPullRequests": 37,
-      "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-05T09:25:22Z"
     },
     {
       "login": "lexmin0412",
@@ -283,6 +283,15 @@
       "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
+      "login": "tianyifeng-druid",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
+      "profileUrl": "https://github.com/tianyifeng-druid",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-06-21T01:57:56Z",
+      "latestContributionAt": "2026-08-09T16:07:12Z"
+    },
+    {
       "login": "czs208112",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7848823?v=4",
       "profileUrl": "https://github.com/czs208112",
@@ -299,15 +308,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-03T08:58:21Z"
-    },
-    {
-      "login": "tianyifeng-druid",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/67090734?v=4",
-      "profileUrl": "https://github.com/tianyifeng-druid",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-06-21T01:57:56Z",
-      "latestContributionAt": "2026-07-31T08:23:56Z"
     },
     {
       "login": "wang-zhengxin",
@@ -409,6 +409,15 @@
       "latestContributionAt": "2026-08-07T07:32:16Z"
     },
     {
+      "login": "Jinmoli",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
+      "profileUrl": "https://github.com/Jinmoli",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-28T08:01:08Z",
+      "latestContributionAt": "2026-08-09T17:11:26Z"
+    },
+    {
       "login": "ZhonFortune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/160460068?v=4",
       "profileUrl": "https://github.com/ZhonFortune",
@@ -461,15 +470,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "Jinmoli",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
-      "profileUrl": "https://github.com/Jinmoli",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-28T08:01:08Z",
-      "latestContributionAt": "2026-08-08T03:56:32Z"
     },
     {
       "login": "soddygo",
@@ -641,6 +641,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-26T03:33:01Z",
       "latestContributionAt": "2026-07-01T08:35:48Z"
+    },
+    {
+      "login": "azens",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
+      "profileUrl": "https://github.com/azens",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-17T06:34:18Z",
+      "latestContributionAt": "2026-08-09T11:51:12Z"
     },
     {
       "login": "bigliangzao",
@@ -841,6 +850,15 @@
       "latestContributionAt": "2026-06-09T04:06:39Z"
     },
     {
+      "login": "shenmo7192",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/47873776?v=4",
+      "profileUrl": "https://github.com/shenmo7192",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-13T10:58:52Z",
+      "latestContributionAt": "2026-08-09T15:33:24Z"
+    },
+    {
       "login": "TangTangH",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
       "profileUrl": "https://github.com/TangTangH",
@@ -983,15 +1001,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-14T12:51:26Z",
       "latestContributionAt": "2026-06-14T14:53:10Z"
-    },
-    {
-      "login": "azens",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/14170526?v=4",
-      "profileUrl": "https://github.com/azens",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-17T06:34:18Z",
-      "latestContributionAt": "2026-07-21T14:56:39Z"
     },
     {
       "login": "B022MC",
@@ -1172,6 +1181,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-01T08:54:31Z",
       "latestContributionAt": "2026-06-01T10:04:58Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-09T16:37:35Z"
     },
     {
       "login": "heyrmi",
@@ -1435,15 +1453,6 @@
       "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
-      "login": "shenmo7192",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/47873776?v=4",
-      "profileUrl": "https://github.com/shenmo7192",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-13T10:58:52Z",
-      "latestContributionAt": "2026-07-13T11:45:02Z"
-    },
-    {
       "login": "shnno13",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14847218?v=4",
       "profileUrl": "https://github.com/shnno13",
@@ -1505,6 +1514,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-08T15:20:59Z",
       "latestContributionAt": "2026-07-08T16:32:53Z"
+    },
+    {
+      "login": "tyloryang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/38744951?v=4",
+      "profileUrl": "https://github.com/tyloryang",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-09T08:11:27Z",
+      "latestContributionAt": "2026-08-09T15:28:02Z"
     },
     {
       "login": "Wakanlolz",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-19T18:25:41.468Z",
-  "stars": 15899,
+  "generatedAt": "2026-08-20T18:30:31.659Z",
+  "stars": 16032,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3092,
+      "commits": 3119,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 568,
-      "mergedPullRequests": 568,
+      "commits": 575,
+      "mergedPullRequests": 575,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-19T07:08:32Z"
+      "latestContributionAt": "2026-08-20T13:38:21Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 156,
-      "mergedPullRequests": 156,
+      "commits": 160,
+      "mergedPullRequests": 159,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-19T18:16:26Z"
+      "latestContributionAt": "2026-08-20T17:15:46Z"
     },
     {
       "login": "Abeautifulsnow",
@@ -43,28 +43,28 @@
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 78,
-      "mergedPullRequests": 79,
+      "commits": 86,
+      "mergedPullRequests": 86,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-19T17:59:26Z"
+      "latestContributionAt": "2026-08-20T14:23:37Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 66,
-      "mergedPullRequests": 66,
+      "commits": 67,
+      "mergedPullRequests": 67,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-18T18:04:01Z"
+      "latestContributionAt": "2026-08-20T00:47:05Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 59,
-      "mergedPullRequests": 59,
+      "commits": 60,
+      "mergedPullRequests": 60,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-13T11:31:18Z"
+      "latestContributionAt": "2026-08-20T10:25:12Z"
     },
     {
       "login": "serenez",
@@ -97,19 +97,19 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 31,
-      "mergedPullRequests": 31,
+      "commits": 34,
+      "mergedPullRequests": 34,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-19T17:52:44Z"
+      "latestContributionAt": "2026-08-20T07:14:20Z"
     },
     {
       "login": "xddcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
       "profileUrl": "https://github.com/xddcode",
-      "commits": 29,
-      "mergedPullRequests": 29,
+      "commits": 30,
+      "mergedPullRequests": 30,
       "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-08-19T17:51:58Z"
+      "latestContributionAt": "2026-08-20T02:23:08Z"
     },
     {
       "login": "gggaiitx",
@@ -166,6 +166,15 @@
       "latestContributionAt": "2026-08-13T03:40:23Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 19,
+      "mergedPullRequests": 19,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-20T12:42:46Z"
+    },
+    {
       "login": "yavon007",
       "avatarUrl": "https://avatars.githubusercontent.com/u/27227092?v=4",
       "profileUrl": "https://github.com/yavon007",
@@ -173,15 +182,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-05-02T20:43:01Z",
       "latestContributionAt": "2026-05-20T08:10:15Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 16,
-      "mergedPullRequests": 16,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-19T07:49:27Z"
     },
     {
       "login": "linjianlin",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-20T10:50:22Z"
+    },
+    {
       "login": "juvevood",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1421513?v=4",
       "profileUrl": "https://github.com/juvevood",
@@ -211,13 +220,13 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
       "commits": 13,
       "mergedPullRequests": 13,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-18T15:16:33Z"
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-20T08:04:22Z"
     },
     {
       "login": "SpencerZhang",
@@ -229,13 +238,13 @@
       "latestContributionAt": "2026-07-20T08:54:52Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
       "commits": 12,
       "mergedPullRequests": 12,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-14T09:47:55Z"
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-20T14:11:49Z"
     },
     {
       "login": "DASungta",
@@ -326,15 +335,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-19T17:51:12Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -562,6 +562,15 @@
       "latestContributionAt": "2026-08-06T04:13:57Z"
     },
     {
+      "login": "Lan-zk",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
+      "profileUrl": "https://github.com/Lan-zk",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-13T05:20:22Z",
+      "latestContributionAt": "2026-08-19T18:26:56Z"
+    },
+    {
       "login": "soddygo",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13834644?v=4",
       "profileUrl": "https://github.com/soddygo",
@@ -596,6 +605,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-08-01T01:44:32Z",
       "latestContributionAt": "2026-08-18T07:36:37Z"
+    },
+    {
+      "login": "xzxlove",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
+      "profileUrl": "https://github.com/xzxlove",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-13T06:38:59Z",
+      "latestContributionAt": "2026-08-20T12:41:52Z"
     },
     {
       "login": "zhuhaoh",
@@ -652,6 +670,24 @@
       "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
+      "login": "fengyuwusong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
+      "profileUrl": "https://github.com/fengyuwusong",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T06:07:00Z",
+      "latestContributionAt": "2026-08-20T08:33:09Z"
+    },
+    {
+      "login": "funnytime75",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/162818986?v=4",
+      "profileUrl": "https://github.com/funnytime75",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-06-20T08:35:12Z",
+      "latestContributionAt": "2026-08-20T01:28:40Z"
+    },
+    {
       "login": "kir1ito",
       "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
       "profileUrl": "https://github.com/kir1ito",
@@ -668,15 +704,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-27T03:48:16Z",
       "latestContributionAt": "2026-06-28T06:52:25Z"
-    },
-    {
-      "login": "Lan-zk",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/68137514?v=4",
-      "profileUrl": "https://github.com/Lan-zk",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-13T05:20:22Z",
-      "latestContributionAt": "2026-08-15T06:41:42Z"
     },
     {
       "login": "lazyanubis",
@@ -715,6 +742,15 @@
       "latestContributionAt": "2026-08-10T16:08:18Z"
     },
     {
+      "login": "scstc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
+      "profileUrl": "https://github.com/scstc",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-18T10:01:35Z",
+      "latestContributionAt": "2026-08-20T13:01:23Z"
+    },
+    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -731,15 +767,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
-    },
-    {
-      "login": "xzxlove",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
-      "profileUrl": "https://github.com/xzxlove",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-13T06:38:59Z",
-      "latestContributionAt": "2026-08-15T06:44:47Z"
     },
     {
       "login": "Michaelxwb",
@@ -821,15 +848,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T06:54:05Z",
       "latestContributionAt": "2026-07-31T06:38:50Z"
-    },
-    {
-      "login": "funnytime75",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/162818986?v=4",
-      "profileUrl": "https://github.com/funnytime75",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-06-20T08:35:12Z",
-      "latestContributionAt": "2026-06-30T01:14:44Z"
     },
     {
       "login": "gadfly3173",
@@ -985,6 +1003,15 @@
       "latestContributionAt": "2026-08-09T15:33:24Z"
     },
     {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-20T14:12:53Z"
+    },
+    {
       "login": "TangTangH",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
       "profileUrl": "https://github.com/TangTangH",
@@ -1091,15 +1118,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-05-03T18:36:11Z",
       "latestContributionAt": "2026-05-05T09:30:42Z"
-    },
-    {
-      "login": "scstc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
-      "profileUrl": "https://github.com/scstc",
-      "commits": 1,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-18T10:01:35Z",
-      "latestContributionAt": "2026-08-19T18:21:56Z"
     },
     {
       "login": "2090230619-syq",
@@ -1316,15 +1334,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-05T11:00:04Z",
       "latestContributionAt": "2026-07-05T11:38:51Z"
-    },
-    {
-      "login": "fengyuwusong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/16892891?v=4",
-      "profileUrl": "https://github.com/fengyuwusong",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-13T06:07:00Z",
-      "latestContributionAt": "2026-08-13T07:26:30Z"
     },
     {
       "login": "fuuulstack",
@@ -1579,6 +1588,15 @@
       "latestContributionAt": "2026-07-30T15:05:13Z"
     },
     {
+      "login": "OctoBored",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/212877535?v=4",
+      "profileUrl": "https://github.com/OctoBored",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-19T13:26:43Z",
+      "latestContributionAt": "2026-08-20T00:48:49Z"
+    },
+    {
       "login": "Odonno",
       "avatarUrl": "https://avatars.githubusercontent.com/u/6053067?v=4",
       "profileUrl": "https://github.com/Odonno",
@@ -1687,15 +1705,6 @@
       "latestContributionAt": "2026-06-12T03:30:03Z"
     },
     {
-      "login": "sxhjlzl",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
-      "profileUrl": "https://github.com/sxhjlzl",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-19T03:31:47Z",
-      "latestContributionAt": "2026-08-19T07:31:25Z"
-    },
-    {
       "login": "Tssshhhh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109692520?v=4",
       "profileUrl": "https://github.com/Tssshhhh",
@@ -1748,6 +1757,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wu-zhao-min",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/167841690?v=4",
+      "profileUrl": "https://github.com/wu-zhao-min",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-20T03:03:56Z",
+      "latestContributionAt": "2026-08-20T04:24:04Z"
     },
     {
       "login": "wyeye",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-04T19:23:43.773Z",
-  "stars": 13194,
+  "generatedAt": "2026-08-05T19:21:57.639Z",
+  "stars": 13317,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 2794,
+      "commits": 2808,
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-07-30T13:10:01Z"
@@ -16,28 +16,28 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 444,
-      "mergedPullRequests": 444,
+      "commits": 459,
+      "mergedPullRequests": 459,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-04T17:10:58Z"
+      "latestContributionAt": "2026-08-05T15:58:32Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 122,
-      "mergedPullRequests": 121,
+      "commits": 126,
+      "mergedPullRequests": 125,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-03T16:46:13Z"
+      "latestContributionAt": "2026-08-05T16:55:36Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 77,
-      "mergedPullRequests": 66,
+      "commits": 80,
+      "mergedPullRequests": 68,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-04T18:59:52Z"
+      "latestContributionAt": "2026-08-05T07:52:20Z"
     },
     {
       "login": "serenez",
@@ -52,19 +52,19 @@
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 51,
-      "mergedPullRequests": 51,
+      "commits": 52,
+      "mergedPullRequests": 52,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-07-29T19:12:02Z"
+      "latestContributionAt": "2026-08-05T15:58:22Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 46,
-      "mergedPullRequests": 46,
+      "commits": 47,
+      "mergedPullRequests": 47,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-08-04T17:02:21Z"
+      "latestContributionAt": "2026-08-05T06:51:14Z"
     },
     {
       "login": "Illuminated2020",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 37,
-      "mergedPullRequests": 35,
+      "commits": 39,
+      "mergedPullRequests": 37,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-02T08:37:46Z"
+      "latestContributionAt": "2026-08-05T09:25:22Z"
     },
     {
       "login": "lexmin0412",
@@ -166,6 +166,15 @@
       "latestContributionAt": "2026-06-26T10:48:46Z"
     },
     {
+      "login": "mapan0424",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
+      "profileUrl": "https://github.com/mapan0424",
+      "commits": 16,
+      "mergedPullRequests": 16,
+      "firstContributionAt": "2026-07-17T05:42:50Z",
+      "latestContributionAt": "2026-08-05T01:48:04Z"
+    },
+    {
       "login": "jischeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49861575?v=4",
       "profileUrl": "https://github.com/jischeng",
@@ -173,15 +182,6 @@
       "mergedPullRequests": 15,
       "firstContributionAt": "2026-06-24T12:52:59Z",
       "latestContributionAt": "2026-07-29T12:41:10Z"
-    },
-    {
-      "login": "mapan0424",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
-      "profileUrl": "https://github.com/mapan0424",
-      "commits": 15,
-      "mergedPullRequests": 15,
-      "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-03T12:25:01Z"
     },
     {
       "login": "juvevood",
@@ -200,6 +200,15 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-06-17T03:22:35Z",
       "latestContributionAt": "2026-07-20T08:54:52Z"
+    },
+    {
+      "login": "guoyongchang",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
+      "profileUrl": "https://github.com/guoyongchang",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-30T02:45:51Z",
+      "latestContributionAt": "2026-08-05T03:10:15Z"
     },
     {
       "login": "haipengno1",
@@ -229,6 +238,15 @@
       "latestContributionAt": "2026-07-27T14:47:00Z"
     },
     {
+      "login": "chenhbb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
+      "profileUrl": "https://github.com/chenhbb",
+      "commits": 10,
+      "mergedPullRequests": 10,
+      "firstContributionAt": "2026-06-20T07:06:56Z",
+      "latestContributionAt": "2026-08-05T03:36:34Z"
+    },
+    {
       "login": "dal1wg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/91363952?v=4",
       "profileUrl": "https://github.com/dal1wg",
@@ -238,13 +256,13 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
-      "login": "chenhbb",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
-      "profileUrl": "https://github.com/chenhbb",
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
       "commits": 9,
       "mergedPullRequests": 9,
-      "firstContributionAt": "2026-06-20T07:06:56Z",
-      "latestContributionAt": "2026-08-02T01:04:30Z"
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-05T03:37:57Z"
     },
     {
       "login": "dienaso",
@@ -254,24 +272,6 @@
       "mergedPullRequests": 9,
       "firstContributionAt": "2026-07-24T03:23:39Z",
       "latestContributionAt": "2026-08-04T05:02:31Z"
-    },
-    {
-      "login": "guoyongchang",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
-      "profileUrl": "https://github.com/guoyongchang",
-      "commits": 8,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-30T02:45:51Z",
-      "latestContributionAt": "2026-08-04T18:59:20Z"
-    },
-    {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-07-31T14:31:51Z"
     },
     {
       "login": "czs208112",
@@ -346,6 +346,15 @@
       "latestContributionAt": "2026-07-10T11:27:07Z"
     },
     {
+      "login": "aiLi0617",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
+      "profileUrl": "https://github.com/aiLi0617",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-06-19T14:50:55Z",
+      "latestContributionAt": "2026-08-05T17:12:31Z"
+    },
+    {
       "login": "antwa",
       "avatarUrl": "https://avatars.githubusercontent.com/u/5325867?v=4",
       "profileUrl": "https://github.com/antwa",
@@ -380,15 +389,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "aiLi0617",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/76681595?v=4",
-      "profileUrl": "https://github.com/aiLi0617",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-06-19T14:50:55Z",
-      "latestContributionAt": "2026-08-03T17:38:30Z"
     },
     {
       "login": "Caisin",
@@ -580,6 +580,15 @@
       "latestContributionAt": "2026-07-07T02:34:32Z"
     },
     {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-05T03:17:02Z"
+    },
+    {
       "login": "asdlem",
       "avatarUrl": "https://avatars.githubusercontent.com/u/53173237?v=4",
       "profileUrl": "https://github.com/asdlem",
@@ -713,6 +722,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-08T09:25:42Z",
       "latestContributionAt": "2026-06-09T03:59:49Z"
+    },
+    {
+      "login": "lazyanubis",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
+      "profileUrl": "https://github.com/lazyanubis",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-12T06:57:24Z",
+      "latestContributionAt": "2026-08-05T07:29:34Z"
     },
     {
       "login": "lc6464",
@@ -904,15 +922,6 @@
       "latestContributionAt": "2026-06-06T01:15:09Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-03T13:29:24Z"
-    },
-    {
       "login": "athoune",
       "avatarUrl": "https://avatars.githubusercontent.com/u/74048?v=4",
       "profileUrl": "https://github.com/athoune",
@@ -974,15 +983,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-01T10:52:08Z",
       "latestContributionAt": "2026-08-03T08:05:57Z"
-    },
-    {
-      "login": "chrstphe",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/10966918?v=4",
-      "profileUrl": "https://github.com/chrstphe",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-25T08:10:39Z",
-      "latestContributionAt": "2026-07-25T10:41:13Z"
     },
     {
       "login": "cl1107",
@@ -1255,13 +1255,13 @@
       "latestContributionAt": "2026-07-28T16:08:04Z"
     },
     {
-      "login": "lazyanubis",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46840787?v=4",
-      "profileUrl": "https://github.com/lazyanubis",
+      "login": "laosiji66666",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24238046?v=4",
+      "profileUrl": "https://github.com/laosiji66666",
       "commits": 1,
       "mergedPullRequests": 1,
-      "firstContributionAt": "2026-07-12T06:57:24Z",
-      "latestContributionAt": "2026-07-12T14:03:57Z"
+      "firstContributionAt": "2026-08-04T15:56:03Z",
+      "latestContributionAt": "2026-08-05T01:49:14Z"
     },
     {
       "login": "leic4u",
@@ -1444,6 +1444,15 @@
       "latestContributionAt": "2026-06-12T03:30:03Z"
     },
     {
+      "login": "TangTangH",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
+      "profileUrl": "https://github.com/TangTangH",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T04:55:17Z",
+      "latestContributionAt": "2026-08-04T18:59:34Z"
+    },
+    {
       "login": "Tssshhhh",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109692520?v=4",
       "profileUrl": "https://github.com/Tssshhhh",
@@ -1570,6 +1579,15 @@
       "latestContributionAt": "2026-07-16T10:19:44Z"
     },
     {
+      "login": "Yy-702",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/175375032?v=4",
+      "profileUrl": "https://github.com/Yy-702",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-04T09:05:09Z",
+      "latestContributionAt": "2026-08-05T15:57:51Z"
+    },
+    {
       "login": "zergmk2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/698746?v=4",
       "profileUrl": "https://github.com/zergmk2",
@@ -1604,15 +1622,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
-    },
-    {
-      "login": "TangTangH",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/31877158?v=4",
-      "profileUrl": "https://github.com/TangTangH",
-      "commits": 0,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-04T04:55:17Z",
-      "latestContributionAt": "2026-08-04T18:59:34Z"
     }
   ]
 }

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,52 +1,61 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-17T18:30:19.040Z",
-  "stars": 15319,
+  "generatedAt": "2026-08-18T18:29:51.674Z",
+  "stars": 15628,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3057,
-      "mergedPullRequests": 16,
+      "commits": 3074,
+      "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-08-15T04:08:41Z"
+      "latestContributionAt": "2026-08-18T04:05:42Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 555,
-      "mergedPullRequests": 555,
+      "commits": 563,
+      "mergedPullRequests": 563,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-17T11:40:40Z"
+      "latestContributionAt": "2026-08-18T16:34:07Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 153,
-      "mergedPullRequests": 152,
+      "commits": 154,
+      "mergedPullRequests": 153,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-17T06:58:48Z"
+      "latestContributionAt": "2026-08-18T07:23:09Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 91,
-      "mergedPullRequests": 79,
+      "commits": 95,
+      "mergedPullRequests": 83,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-14T10:37:53Z"
+      "latestContributionAt": "2026-08-18T14:04:39Z"
+    },
+    {
+      "login": "q396921921",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
+      "profileUrl": "https://github.com/q396921921",
+      "commits": 71,
+      "mergedPullRequests": 71,
+      "firstContributionAt": "2026-07-20T13:41:21Z",
+      "latestContributionAt": "2026-08-18T17:51:55Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 63,
-      "mergedPullRequests": 63,
+      "commits": 66,
+      "mergedPullRequests": 66,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-14T16:28:12Z"
+      "latestContributionAt": "2026-08-18T18:04:01Z"
     },
     {
       "login": "onenewcode",
@@ -56,15 +65,6 @@
       "mergedPullRequests": 59,
       "firstContributionAt": "2026-06-30T01:53:31Z",
       "latestContributionAt": "2026-08-13T11:31:18Z"
-    },
-    {
-      "login": "q396921921",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
-      "profileUrl": "https://github.com/q396921921",
-      "commits": 59,
-      "mergedPullRequests": 59,
-      "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-17T06:52:01Z"
     },
     {
       "login": "serenez",
@@ -202,6 +202,24 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-18T17:02:41Z"
+    },
+    {
+      "login": "AndrewDi",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
+      "profileUrl": "https://github.com/AndrewDi",
+      "commits": 13,
+      "mergedPullRequests": 13,
+      "firstContributionAt": "2026-08-03T09:45:43Z",
+      "latestContributionAt": "2026-08-18T15:16:33Z"
+    },
+    {
       "login": "SpencerZhang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/1736590?v=4",
       "profileUrl": "https://github.com/SpencerZhang",
@@ -220,15 +238,6 @@
       "latestContributionAt": "2026-08-14T09:47:55Z"
     },
     {
-      "login": "AndrewDi",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
-      "profileUrl": "https://github.com/AndrewDi",
-      "commits": 11,
-      "mergedPullRequests": 11,
-      "firstContributionAt": "2026-08-03T09:45:43Z",
-      "latestContributionAt": "2026-08-17T05:11:58Z"
-    },
-    {
       "login": "DASungta",
       "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
       "profileUrl": "https://github.com/DASungta",
@@ -236,6 +245,15 @@
       "mergedPullRequests": 11,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-13T07:26:45Z"
+    },
+    {
+      "login": "dienaso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
+      "profileUrl": "https://github.com/dienaso",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-07-24T03:23:39Z",
+      "latestContributionAt": "2026-08-18T04:43:31Z"
     },
     {
       "login": "guoyongchang",
@@ -292,13 +310,13 @@
       "latestContributionAt": "2026-07-02T06:03:20Z"
     },
     {
-      "login": "dienaso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
-      "profileUrl": "https://github.com/dienaso",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-08-13T04:40:51Z"
+      "login": "GIWTO",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
+      "profileUrl": "https://github.com/GIWTO",
+      "commits": 9,
+      "mergedPullRequests": 9,
+      "firstContributionAt": "2026-07-25T02:38:05Z",
+      "latestContributionAt": "2026-08-18T03:39:55Z"
     },
     {
       "login": "aiLi0617",
@@ -308,15 +326,6 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
-    },
-    {
-      "login": "GIWTO",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
-      "profileUrl": "https://github.com/GIWTO",
-      "commits": 8,
-      "mergedPullRequests": 8,
-      "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-13T16:22:44Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -364,6 +373,15 @@
       "latestContributionAt": "2026-05-11T14:10:01Z"
     },
     {
+      "login": "antwa",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5325867?v=4",
+      "profileUrl": "https://github.com/antwa",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-13T09:25:38Z",
+      "latestContributionAt": "2026-08-18T02:50:36Z"
+    },
+    {
       "login": "dbin0123",
       "avatarUrl": "https://avatars.githubusercontent.com/u/18297300?v=4",
       "profileUrl": "https://github.com/dbin0123",
@@ -371,6 +389,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
+    },
+    {
+      "login": "hanxuanyu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
+      "profileUrl": "https://github.com/hanxuanyu",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-08-08T05:23:28Z",
+      "latestContributionAt": "2026-08-18T16:30:40Z"
     },
     {
       "login": "jeeinn",
@@ -409,15 +436,6 @@
       "latestContributionAt": "2026-07-10T11:27:07Z"
     },
     {
-      "login": "antwa",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5325867?v=4",
-      "profileUrl": "https://github.com/antwa",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-13T09:25:38Z",
-      "latestContributionAt": "2026-07-16T09:01:10Z"
-    },
-    {
       "login": "ChunMengLu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2115440?v=4",
       "profileUrl": "https://github.com/ChunMengLu",
@@ -454,6 +472,24 @@
       "latestContributionAt": "2026-08-10T10:51:45Z"
     },
     {
+      "login": "jthanh8144",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
+      "profileUrl": "https://github.com/jthanh8144",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-15T03:09:27Z",
+      "latestContributionAt": "2026-08-18T15:17:24Z"
+    },
+    {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-18T15:16:59Z"
+    },
+    {
       "login": "wbean",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2233455?v=4",
       "profileUrl": "https://github.com/wbean",
@@ -470,15 +506,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-06-30T16:59:33Z",
       "latestContributionAt": "2026-07-08T16:35:34Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-17T08:31:45Z"
     },
     {
       "login": "azens",
@@ -526,15 +553,6 @@
       "latestContributionAt": "2026-08-13T14:31:14Z"
     },
     {
-      "login": "hanxuanyu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/21254318?v=4",
-      "profileUrl": "https://github.com/hanxuanyu",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-08T05:23:28Z",
-      "latestContributionAt": "2026-08-14T14:18:29Z"
-    },
-    {
       "login": "James-Leong",
       "avatarUrl": "https://avatars.githubusercontent.com/u/109658865?v=4",
       "profileUrl": "https://github.com/James-Leong",
@@ -542,15 +560,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "jthanh8144",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/80233350?v=4",
-      "profileUrl": "https://github.com/jthanh8144",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-15T03:09:27Z",
-      "latestContributionAt": "2026-08-17T06:53:34Z"
     },
     {
       "login": "soddygo",
@@ -578,6 +587,15 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-05T16:45:23Z",
       "latestContributionAt": "2026-07-12T13:30:37Z"
+    },
+    {
+      "login": "wzlstudy",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
+      "profileUrl": "https://github.com/wzlstudy",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-01T01:44:32Z",
+      "latestContributionAt": "2026-08-18T07:36:37Z"
     },
     {
       "login": "zhuhaoh",
@@ -634,6 +652,15 @@
       "latestContributionAt": "2026-08-16T07:33:49Z"
     },
     {
+      "login": "kir1ito",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
+      "profileUrl": "https://github.com/kir1ito",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-13T10:38:51Z",
+      "latestContributionAt": "2026-08-18T15:05:17Z"
+    },
+    {
       "login": "kkk000111999",
       "avatarUrl": "https://avatars.githubusercontent.com/u/296277678?v=4",
       "profileUrl": "https://github.com/kkk000111999",
@@ -659,6 +686,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
+    },
+    {
+      "login": "lizzzzz777",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
+      "profileUrl": "https://github.com/lizzzzz777",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-14T01:26:28Z",
+      "latestContributionAt": "2026-08-18T02:51:50Z"
     },
     {
       "login": "polemp",
@@ -695,15 +731,6 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-04-30T06:28:17Z",
       "latestContributionAt": "2026-04-30T09:48:13Z"
-    },
-    {
-      "login": "wzlstudy",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
-      "profileUrl": "https://github.com/wzlstudy",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-01T01:44:32Z",
-      "latestContributionAt": "2026-08-12T13:59:53Z"
     },
     {
       "login": "xzxlove",
@@ -895,15 +922,6 @@
       "latestContributionAt": "2026-08-15T06:41:17Z"
     },
     {
-      "login": "kir1ito",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/65323513?v=4",
-      "profileUrl": "https://github.com/kir1ito",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-13T10:38:51Z",
-      "latestContributionAt": "2026-08-14T10:05:36Z"
-    },
-    {
       "login": "lc6464",
       "avatarUrl": "https://avatars.githubusercontent.com/u/64722907?v=4",
       "profileUrl": "https://github.com/lc6464",
@@ -929,15 +947,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T04:57:31Z",
       "latestContributionAt": "2026-08-02T08:35:04Z"
-    },
-    {
-      "login": "lizzzzz777",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/72645313?v=4",
-      "profileUrl": "https://github.com/lizzzzz777",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-14T01:26:28Z",
-      "latestContributionAt": "2026-08-14T10:25:05Z"
     },
     {
       "login": "onlyc0302",
@@ -1597,6 +1606,15 @@
       "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
+      "login": "scstc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
+      "profileUrl": "https://github.com/scstc",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-18T10:01:35Z",
+      "latestContributionAt": "2026-08-18T18:04:14Z"
+    },
+    {
       "login": "shnno13",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14847218?v=4",
       "profileUrl": "https://github.com/shnno13",
@@ -1712,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T03:39:01Z",
       "latestContributionAt": "2026-07-06T04:57:27Z"
+    },
+    {
+      "login": "wyeye",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/51752290?v=4",
+      "profileUrl": "https://github.com/wyeye",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-17T06:30:17Z",
+      "latestContributionAt": "2026-08-18T04:47:53Z"
     },
     {
       "login": "xcstatus",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-18T18:29:51.674Z",
-  "stars": 15628,
+  "generatedAt": "2026-08-19T18:25:41.468Z",
+  "stars": 15899,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3074,
+      "commits": 3092,
       "mergedPullRequests": 17,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-18T04:05:42Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 563,
-      "mergedPullRequests": 563,
+      "commits": 568,
+      "mergedPullRequests": 568,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-18T16:34:07Z"
+      "latestContributionAt": "2026-08-19T07:08:32Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 154,
-      "mergedPullRequests": 153,
+      "commits": 156,
+      "mergedPullRequests": 156,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-18T07:23:09Z"
+      "latestContributionAt": "2026-08-19T18:16:26Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 95,
-      "mergedPullRequests": 83,
+      "commits": 96,
+      "mergedPullRequests": 84,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-18T14:04:39Z"
+      "latestContributionAt": "2026-08-19T07:49:15Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 71,
-      "mergedPullRequests": 71,
+      "commits": 78,
+      "mergedPullRequests": 79,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-08-18T17:51:55Z"
+      "latestContributionAt": "2026-08-19T17:59:26Z"
     },
     {
       "login": "CN-Scars",
@@ -79,10 +79,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 42,
-      "mergedPullRequests": 40,
+      "commits": 43,
+      "mergedPullRequests": 41,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-08-13T16:19:09Z"
+      "latestContributionAt": "2026-08-19T03:10:12Z"
     },
     {
       "login": "Illuminated2020",
@@ -97,10 +97,19 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 30,
-      "mergedPullRequests": 30,
+      "commits": 31,
+      "mergedPullRequests": 31,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-08-15T13:55:55Z"
+      "latestContributionAt": "2026-08-19T17:52:44Z"
+    },
+    {
+      "login": "xddcode",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
+      "profileUrl": "https://github.com/xddcode",
+      "commits": 29,
+      "mergedPullRequests": 29,
+      "firstContributionAt": "2026-07-10T06:34:09Z",
+      "latestContributionAt": "2026-08-19T17:51:58Z"
     },
     {
       "login": "gggaiitx",
@@ -119,15 +128,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "xddcode",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/48708512?v=4",
-      "profileUrl": "https://github.com/xddcode",
-      "commits": 28,
-      "mergedPullRequests": 28,
-      "firstContributionAt": "2026-07-10T06:34:09Z",
-      "latestContributionAt": "2026-08-07T07:57:46Z"
     },
     {
       "login": "SuLea-IT",
@@ -175,6 +175,15 @@
       "latestContributionAt": "2026-05-20T08:10:15Z"
     },
     {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 16,
+      "mergedPullRequests": 16,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-08-19T07:49:27Z"
+    },
+    {
       "login": "linjianlin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46356519?v=4",
       "profileUrl": "https://github.com/linjianlin",
@@ -200,15 +209,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-18T17:02:41Z"
     },
     {
       "login": "AndrewDi",
@@ -313,10 +313,10 @@
       "login": "GIWTO",
       "avatarUrl": "https://avatars.githubusercontent.com/u/40267153?v=4",
       "profileUrl": "https://github.com/GIWTO",
-      "commits": 9,
-      "mergedPullRequests": 9,
+      "commits": 10,
+      "mergedPullRequests": 10,
       "firstContributionAt": "2026-07-25T02:38:05Z",
-      "latestContributionAt": "2026-08-18T03:39:55Z"
+      "latestContributionAt": "2026-08-19T12:23:17Z"
     },
     {
       "login": "aiLi0617",
@@ -326,6 +326,15 @@
       "mergedPullRequests": 8,
       "firstContributionAt": "2026-06-19T14:50:55Z",
       "latestContributionAt": "2026-08-06T18:41:53Z"
+    },
+    {
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-19T17:51:12Z"
     },
     {
       "login": "tianyifeng-druid",
@@ -479,15 +488,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-15T03:09:27Z",
       "latestContributionAt": "2026-08-18T15:17:24Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-18T15:16:59Z"
     },
     {
       "login": "wbean",
@@ -1093,6 +1093,15 @@
       "latestContributionAt": "2026-05-05T09:30:42Z"
     },
     {
+      "login": "scstc",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
+      "profileUrl": "https://github.com/scstc",
+      "commits": 1,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-18T10:01:35Z",
+      "latestContributionAt": "2026-08-19T18:21:56Z"
+    },
+    {
       "login": "2090230619-syq",
       "avatarUrl": "https://avatars.githubusercontent.com/u/268813423?v=4",
       "profileUrl": "https://github.com/2090230619-syq",
@@ -1516,6 +1525,15 @@
       "latestContributionAt": "2026-07-17T03:28:14Z"
     },
     {
+      "login": "Marc-oss-hub",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/315200685?v=4",
+      "profileUrl": "https://github.com/Marc-oss-hub",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-14T18:06:15Z",
+      "latestContributionAt": "2026-08-19T13:16:13Z"
+    },
+    {
       "login": "Max29xD",
       "avatarUrl": "https://avatars.githubusercontent.com/u/85517789?v=4",
       "profileUrl": "https://github.com/Max29xD",
@@ -1606,15 +1624,6 @@
       "latestContributionAt": "2026-08-04T06:23:45Z"
     },
     {
-      "login": "scstc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/17975927?v=4",
-      "profileUrl": "https://github.com/scstc",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-18T10:01:35Z",
-      "latestContributionAt": "2026-08-18T18:04:14Z"
-    },
-    {
       "login": "shnno13",
       "avatarUrl": "https://avatars.githubusercontent.com/u/14847218?v=4",
       "profileUrl": "https://github.com/shnno13",
@@ -1676,6 +1685,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-12T03:18:32Z",
       "latestContributionAt": "2026-06-12T03:30:03Z"
+    },
+    {
+      "login": "sxhjlzl",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
+      "profileUrl": "https://github.com/sxhjlzl",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-08-19T03:31:47Z",
+      "latestContributionAt": "2026-08-19T07:31:25Z"
     },
     {
       "login": "Tssshhhh",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-08-28T01:59:57.384Z",
-  "stars": 17031,
+  "generatedAt": "2026-08-29T01:23:22.980Z",
+  "stars": 17282,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3287,
+      "commits": 3302,
       "mergedPullRequests": 18,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-08-25T16:07:31Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 636,
-      "mergedPullRequests": 636,
+      "commits": 641,
+      "mergedPullRequests": 641,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-08-27T14:25:39Z"
+      "latestContributionAt": "2026-08-28T09:16:56Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 179,
-      "mergedPullRequests": 178,
+      "commits": 183,
+      "mergedPullRequests": 182,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-08-27T09:59:11Z"
+      "latestContributionAt": "2026-08-28T09:19:40Z"
     },
     {
       "login": "q396921921",
@@ -43,19 +43,19 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 102,
-      "mergedPullRequests": 90,
+      "commits": 103,
+      "mergedPullRequests": 91,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-08-27T14:23:13Z"
+      "latestContributionAt": "2026-08-28T04:37:11Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 73,
-      "mergedPullRequests": 73,
+      "commits": 74,
+      "mergedPullRequests": 74,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-08-26T07:49:49Z"
+      "latestContributionAt": "2026-08-28T08:51:34Z"
     },
     {
       "login": "onenewcode",
@@ -88,10 +88,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 42,
-      "mergedPullRequests": 42,
+      "commits": 44,
+      "mergedPullRequests": 44,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-08-27T00:40:28Z"
+      "latestContributionAt": "2026-08-28T07:30:09Z"
     },
     {
       "login": "Illuminated2020",
@@ -202,6 +202,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "amwps290",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
+      "profileUrl": "https://github.com/amwps290",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-07-21T05:32:24Z",
+      "latestContributionAt": "2026-08-28T04:14:04Z"
+    },
+    {
       "login": "AndrewDi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
       "profileUrl": "https://github.com/AndrewDi",
@@ -220,13 +229,13 @@
       "latestContributionAt": "2026-07-21T16:25:09Z"
     },
     {
-      "login": "amwps290",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/18211479?v=4",
-      "profileUrl": "https://github.com/amwps290",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-07-21T05:32:24Z",
-      "latestContributionAt": "2026-08-20T08:04:22Z"
+      "login": "mr-dadong",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
+      "profileUrl": "https://github.com/mr-dadong",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-08-17T07:04:42Z",
+      "latestContributionAt": "2026-08-28T03:11:35Z"
     },
     {
       "login": "DASungta",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 13,
       "firstContributionAt": "2026-07-21T04:15:46Z",
       "latestContributionAt": "2026-08-24T05:29:24Z"
-    },
-    {
-      "login": "mr-dadong",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/102886401?v=4",
-      "profileUrl": "https://github.com/mr-dadong",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-08-17T07:04:42Z",
-      "latestContributionAt": "2026-08-27T09:17:41Z"
     },
     {
       "login": "SpencerZhang",
@@ -409,6 +409,15 @@
       "latestContributionAt": "2026-07-28T19:47:20Z"
     },
     {
+      "login": "difagume",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
+      "profileUrl": "https://github.com/difagume",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-31T04:15:42Z",
+      "latestContributionAt": "2026-08-28T03:12:41Z"
+    },
+    {
       "login": "jeeinn",
       "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
       "profileUrl": "https://github.com/jeeinn",
@@ -461,15 +470,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-24T07:06:09Z",
       "latestContributionAt": "2026-08-07T05:43:30Z"
-    },
-    {
-      "login": "difagume",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/5271339?v=4",
-      "profileUrl": "https://github.com/difagume",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-31T04:15:42Z",
-      "latestContributionAt": "2026-08-15T06:41:54Z"
     },
     {
       "login": "fraluc06",
@@ -625,6 +625,15 @@
       "latestContributionAt": "2026-07-12T13:30:37Z"
     },
     {
+      "login": "xiaou61",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
+      "profileUrl": "https://github.com/xiaou61",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-14T09:19:51Z",
+      "latestContributionAt": "2026-08-28T04:36:37Z"
+    },
+    {
       "login": "xzxlove",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49681654?v=4",
       "profileUrl": "https://github.com/xzxlove",
@@ -749,6 +758,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-12T06:57:24Z",
       "latestContributionAt": "2026-08-07T05:45:00Z"
+    },
+    {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-08-28T06:27:56Z"
     },
     {
       "login": "ordinary-s",
@@ -994,15 +1012,6 @@
       "latestContributionAt": "2026-08-02T08:35:04Z"
     },
     {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-08-27T09:32:57Z"
-    },
-    {
       "login": "onlyc0302",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24369193?v=4",
       "profileUrl": "https://github.com/onlyc0302",
@@ -1037,6 +1046,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-13T10:58:52Z",
       "latestContributionAt": "2026-08-09T15:33:24Z"
+    },
+    {
+      "login": "StaravenX",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
+      "profileUrl": "https://github.com/StaravenX",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-26T11:48:56Z",
+      "latestContributionAt": "2026-08-28T07:29:07Z"
     },
     {
       "login": "TangTangH",
@@ -1109,15 +1127,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-03T06:18:00Z",
       "latestContributionAt": "2026-07-03T11:25:02Z"
-    },
-    {
-      "login": "xiaou61",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
-      "profileUrl": "https://github.com/xiaou61",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-14T09:19:51Z",
-      "latestContributionAt": "2026-08-14T14:46:33Z"
     },
     {
       "login": "yangqinlong",
@@ -1757,15 +1766,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-09T07:01:29Z",
       "latestContributionAt": "2026-06-09T08:23:14Z"
-    },
-    {
-      "login": "StaravenX",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/231610333?v=4",
-      "profileUrl": "https://github.com/StaravenX",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-26T11:48:56Z",
-      "latestContributionAt": "2026-08-26T13:37:29Z"
     },
     {
       "login": "sunny0826",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-06T19:52:45.102Z",
-  "stars": 18128,
+  "generatedAt": "2026-09-07T21:00:44.204Z",
+  "stars": 18212,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3421,
+      "commits": 3430,
       "mergedPullRequests": 26,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-02T10:17:27Z"
@@ -16,37 +16,37 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 711,
-      "mergedPullRequests": 712,
+      "commits": 722,
+      "mergedPullRequests": 723,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-06T16:54:59Z"
+      "latestContributionAt": "2026-09-07T17:43:13Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 221,
-      "mergedPullRequests": 221,
+      "commits": 224,
+      "mergedPullRequests": 224,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-06T18:18:29Z"
+      "latestContributionAt": "2026-09-07T17:47:37Z"
     },
     {
       "login": "q396921921",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37297228?v=4",
       "profileUrl": "https://github.com/q396921921",
-      "commits": 144,
-      "mergedPullRequests": 144,
+      "commits": 147,
+      "mergedPullRequests": 147,
       "firstContributionAt": "2026-07-20T13:41:21Z",
-      "latestContributionAt": "2026-09-06T14:14:30Z"
+      "latestContributionAt": "2026-09-07T15:51:37Z"
     },
     {
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 111,
-      "mergedPullRequests": 99,
+      "commits": 113,
+      "mergedPullRequests": 101,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-04T12:38:26Z"
+      "latestContributionAt": "2026-09-07T14:44:24Z"
     },
     {
       "login": "CN-Scars",
@@ -61,10 +61,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 87,
-      "mergedPullRequests": 87,
+      "commits": 88,
+      "mergedPullRequests": 88,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-06T10:24:45Z"
+      "latestContributionAt": "2026-09-07T06:04:39Z"
     },
     {
       "login": "onenewcode",
@@ -97,10 +97,10 @@
       "login": "mapan0424",
       "avatarUrl": "https://avatars.githubusercontent.com/u/45232878?v=4",
       "profileUrl": "https://github.com/mapan0424",
-      "commits": 44,
-      "mergedPullRequests": 44,
+      "commits": 46,
+      "mergedPullRequests": 46,
       "firstContributionAt": "2026-07-17T05:42:50Z",
-      "latestContributionAt": "2026-09-06T02:52:51Z"
+      "latestContributionAt": "2026-09-07T14:44:30Z"
     },
     {
       "login": "Illuminated2020",
@@ -283,6 +283,15 @@
       "latestContributionAt": "2026-09-02T17:45:09Z"
     },
     {
+      "login": "chenhbb",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
+      "profileUrl": "https://github.com/chenhbb",
+      "commits": 11,
+      "mergedPullRequests": 11,
+      "firstContributionAt": "2026-06-20T07:06:56Z",
+      "latestContributionAt": "2026-09-07T17:21:09Z"
+    },
+    {
       "login": "guoyongchang",
       "avatarUrl": "https://avatars.githubusercontent.com/u/10484506?v=4",
       "profileUrl": "https://github.com/guoyongchang",
@@ -308,15 +317,6 @@
       "mergedPullRequests": 7,
       "firstContributionAt": "2026-04-30T09:05:18Z",
       "latestContributionAt": "2026-05-09T06:42:25Z"
-    },
-    {
-      "login": "chenhbb",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/34821912?v=4",
-      "profileUrl": "https://github.com/chenhbb",
-      "commits": 10,
-      "mergedPullRequests": 10,
-      "firstContributionAt": "2026-06-20T07:06:56Z",
-      "latestContributionAt": "2026-08-05T03:36:34Z"
     },
     {
       "login": "dal1wg",
@@ -571,6 +571,15 @@
       "latestContributionAt": "2026-07-08T16:35:34Z"
     },
     {
+      "login": "zorohu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24402746?v=4",
+      "profileUrl": "https://github.com/zorohu",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-08T02:54:27Z",
+      "latestContributionAt": "2026-09-07T14:50:33Z"
+    },
+    {
       "login": "1320209572",
       "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
       "profileUrl": "https://github.com/1320209572",
@@ -686,15 +695,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-07-06T10:48:19Z",
       "latestContributionAt": "2026-08-03T08:59:34Z"
-    },
-    {
-      "login": "zorohu",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24402746?v=4",
-      "profileUrl": "https://github.com/zorohu",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-08T02:54:27Z",
-      "latestContributionAt": "2026-07-22T04:22:02Z"
     },
     {
       "login": "wu-clan",
@@ -965,6 +965,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-28T10:07:29Z",
       "latestContributionAt": "2026-07-31T03:36:43Z"
+    },
+    {
+      "login": "githubasda",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/86922868?v=4",
+      "profileUrl": "https://github.com/githubasda",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-02T01:23:28Z",
+      "latestContributionAt": "2026-09-07T16:43:46Z"
     },
     {
       "login": "greathaoqi",
@@ -1552,15 +1561,6 @@
       "latestContributionAt": "2026-07-03T16:58:52Z"
     },
     {
-      "login": "githubasda",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/86922868?v=4",
-      "profileUrl": "https://github.com/githubasda",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-02T01:23:28Z",
-      "latestContributionAt": "2026-09-02T07:45:24Z"
-    },
-    {
       "login": "guoziyangnb",
       "avatarUrl": "https://avatars.githubusercontent.com/u/136451743?v=4",
       "profileUrl": "https://github.com/guoziyangnb",
@@ -1676,6 +1676,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T12:23:36Z",
       "latestContributionAt": "2026-07-24T13:11:18Z"
+    },
+    {
+      "login": "jasonchen8068",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37900422?v=4",
+      "profileUrl": "https://github.com/jasonchen8068",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-07T07:06:55Z",
+      "latestContributionAt": "2026-09-07T16:14:09Z"
     },
     {
       "login": "JeaceLiu",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-10T20:20:10.451Z",
-  "stars": 18896,
+  "generatedAt": "2026-09-11T20:20:31.193Z",
+  "stars": 19151,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3495,
+      "commits": 3502,
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-08T11:42:32Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 749,
-      "mergedPullRequests": 750,
+      "commits": 752,
+      "mergedPullRequests": 753,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-10T13:07:41Z"
+      "latestContributionAt": "2026-09-11T13:10:49Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 239,
-      "mergedPullRequests": 239,
+      "commits": 248,
+      "mergedPullRequests": 248,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-10T07:57:28Z"
+      "latestContributionAt": "2026-09-11T15:25:18Z"
     },
     {
       "login": "q396921921",
@@ -43,10 +43,19 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 119,
-      "mergedPullRequests": 107,
+      "commits": 121,
+      "mergedPullRequests": 109,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-10T10:04:06Z"
+      "latestContributionAt": "2026-09-11T11:58:46Z"
+    },
+    {
+      "login": "0verme",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
+      "profileUrl": "https://github.com/0verme",
+      "commits": 92,
+      "mergedPullRequests": 92,
+      "firstContributionAt": "2026-08-15T15:33:44Z",
+      "latestContributionAt": "2026-09-11T02:52:19Z"
     },
     {
       "login": "CN-Scars",
@@ -58,22 +67,13 @@
       "latestContributionAt": "2026-09-09T14:36:34Z"
     },
     {
-      "login": "0verme",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
-      "profileUrl": "https://github.com/0verme",
-      "commits": 91,
-      "mergedPullRequests": 91,
-      "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-09T16:28:41Z"
-    },
-    {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 79,
-      "mergedPullRequests": 79,
+      "commits": 81,
+      "mergedPullRequests": 81,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-10T11:30:23Z"
+      "latestContributionAt": "2026-09-11T08:56:50Z"
     },
     {
       "login": "serenez",
@@ -130,6 +130,15 @@
       "latestContributionAt": "2026-09-04T12:24:32Z"
     },
     {
+      "login": "Eve-z1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
+      "profileUrl": "https://github.com/Eve-z1",
+      "commits": 28,
+      "mergedPullRequests": 28,
+      "firstContributionAt": "2026-09-01T05:03:42Z",
+      "latestContributionAt": "2026-09-11T08:41:26Z"
+    },
+    {
       "login": "lexmin0412",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24385370?v=4",
       "profileUrl": "https://github.com/lexmin0412",
@@ -137,15 +146,6 @@
       "mergedPullRequests": 28,
       "firstContributionAt": "2026-06-09T07:13:22Z",
       "latestContributionAt": "2026-07-17T09:12:32Z"
-    },
-    {
-      "login": "Eve-z1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
-      "profileUrl": "https://github.com/Eve-z1",
-      "commits": 26,
-      "mergedPullRequests": 26,
-      "firstContributionAt": "2026-09-01T05:03:42Z",
-      "latestContributionAt": "2026-09-10T07:57:16Z"
     },
     {
       "login": "SuLea-IT",
@@ -355,6 +355,15 @@
       "latestContributionAt": "2026-08-06T18:41:53Z"
     },
     {
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
+      "commits": 8,
+      "mergedPullRequests": 8,
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-09-11T06:29:25Z"
+    },
+    {
       "login": "sxhjlzl",
       "avatarUrl": "https://avatars.githubusercontent.com/u/12149913?v=4",
       "profileUrl": "https://github.com/sxhjlzl",
@@ -400,15 +409,6 @@
       "latestContributionAt": "2026-08-29T20:17:33Z"
     },
     {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 7,
-      "mergedPullRequests": 7,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-09-10T03:23:57Z"
-    },
-    {
       "login": "Jinmoli",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
       "profileUrl": "https://github.com/Jinmoli",
@@ -443,6 +443,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-07-13T09:25:38Z",
       "latestContributionAt": "2026-08-18T02:50:36Z"
+    },
+    {
+      "login": "CSXFanMeng",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
+      "profileUrl": "https://github.com/CSXFanMeng",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-07-02T10:52:18Z",
+      "latestContributionAt": "2026-09-11T15:20:06Z"
     },
     {
       "login": "dbin0123",
@@ -490,6 +499,15 @@
       "latestContributionAt": "2026-08-08T03:04:17Z"
     },
     {
+      "login": "thailoc-dev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113083148?v=4",
+      "profileUrl": "https://github.com/thailoc-dev",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-09-10T02:47:44Z",
+      "latestContributionAt": "2026-09-11T13:10:04Z"
+    },
+    {
       "login": "xiaou61",
       "avatarUrl": "https://avatars.githubusercontent.com/u/113765024?v=4",
       "profileUrl": "https://github.com/xiaou61",
@@ -515,15 +533,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-24T07:06:09Z",
       "latestContributionAt": "2026-08-07T05:43:30Z"
-    },
-    {
-      "login": "CSXFanMeng",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
-      "profileUrl": "https://github.com/CSXFanMeng",
-      "commits": 5,
-      "mergedPullRequests": 5,
-      "firstContributionAt": "2026-07-02T10:52:18Z",
-      "latestContributionAt": "2026-09-10T04:46:57Z"
     },
     {
       "login": "fraluc06",
@@ -670,6 +679,33 @@
       "latestContributionAt": "2026-07-27T08:11:54Z"
     },
     {
+      "login": "Tara8573",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
+      "profileUrl": "https://github.com/Tara8573",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-08-22T04:03:32Z",
+      "latestContributionAt": "2026-09-11T09:39:31Z"
+    },
+    {
+      "login": "tdog54646",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188939710?v=4",
+      "profileUrl": "https://github.com/tdog54646",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-09-09T03:51:34Z",
+      "latestContributionAt": "2026-09-11T06:14:30Z"
+    },
+    {
+      "login": "thanadon-dev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/71448810?v=4",
+      "profileUrl": "https://github.com/thanadon-dev",
+      "commits": 4,
+      "mergedPullRequests": 4,
+      "firstContributionAt": "2026-09-10T15:27:44Z",
+      "latestContributionAt": "2026-09-11T15:26:30Z"
+    },
+    {
       "login": "wuxiemian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29685283?v=4",
       "profileUrl": "https://github.com/wuxiemian",
@@ -724,6 +760,15 @@
       "latestContributionAt": "2026-09-02T08:56:13Z"
     },
     {
+      "login": "Conastin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37993820?v=4",
+      "profileUrl": "https://github.com/Conastin",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-11T05:36:59Z",
+      "latestContributionAt": "2026-09-11T09:25:20Z"
+    },
+    {
       "login": "domye",
       "avatarUrl": "https://avatars.githubusercontent.com/u/67504754?v=4",
       "profileUrl": "https://github.com/domye",
@@ -758,6 +803,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-20T08:35:12Z",
       "latestContributionAt": "2026-08-20T01:28:40Z"
+    },
+    {
+      "login": "HolyeTyrone",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43714994?v=4",
+      "profileUrl": "https://github.com/HolyeTyrone",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-08T03:33:05Z",
+      "latestContributionAt": "2026-09-11T06:38:34Z"
     },
     {
       "login": "jasonchen8068",
@@ -841,24 +895,6 @@
       "latestContributionAt": "2026-09-02T01:15:10Z"
     },
     {
-      "login": "Tara8573",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
-      "profileUrl": "https://github.com/Tara8573",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-08-22T04:03:32Z",
-      "latestContributionAt": "2026-09-09T14:36:07Z"
-    },
-    {
-      "login": "tdog54646",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/188939710?v=4",
-      "profileUrl": "https://github.com/tdog54646",
-      "commits": 3,
-      "mergedPullRequests": 3,
-      "firstContributionAt": "2026-09-09T03:51:34Z",
-      "latestContributionAt": "2026-09-09T15:53:17Z"
-    },
-    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -893,6 +929,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-07-29T06:58:27Z",
       "latestContributionAt": "2026-09-04T08:52:47Z"
+    },
+    {
+      "login": "zccat",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46469775?v=4",
+      "profileUrl": "https://github.com/zccat",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-10T02:30:30Z",
+      "latestContributionAt": "2026-09-11T04:05:44Z"
     },
     {
       "login": "Michaelxwb",
@@ -947,6 +992,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
+    },
+    {
+      "login": "CHNHJF",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/56990620?v=4",
+      "profileUrl": "https://github.com/CHNHJF",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-11T02:18:22Z",
+      "latestContributionAt": "2026-09-11T08:40:48Z"
     },
     {
       "login": "cwatanab",
@@ -1021,6 +1075,15 @@
       "latestContributionAt": "2026-07-26T16:37:41Z"
     },
     {
+      "login": "hanhvs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/60683892?v=4",
+      "profileUrl": "https://github.com/hanhvs",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-08T02:15:08Z",
+      "latestContributionAt": "2026-09-11T07:41:29Z"
+    },
+    {
       "login": "holmesin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4124547?v=4",
       "profileUrl": "https://github.com/holmesin",
@@ -1028,15 +1091,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-08-03T12:29:55Z",
       "latestContributionAt": "2026-08-06T15:33:29Z"
-    },
-    {
-      "login": "HolyeTyrone",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43714994?v=4",
-      "profileUrl": "https://github.com/HolyeTyrone",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-09-08T03:33:05Z",
-      "latestContributionAt": "2026-09-09T06:44:35Z"
     },
     {
       "login": "ijevin",
@@ -1192,15 +1246,6 @@
       "latestContributionAt": "2026-08-06T06:09:21Z"
     },
     {
-      "login": "thailoc-dev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/113083148?v=4",
-      "profileUrl": "https://github.com/thailoc-dev",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-09-10T02:47:44Z",
-      "latestContributionAt": "2026-09-10T08:18:22Z"
-    },
-    {
       "login": "Tiath",
       "avatarUrl": "https://avatars.githubusercontent.com/u/139197180?v=4",
       "profileUrl": "https://github.com/Tiath",
@@ -1300,13 +1345,13 @@
       "latestContributionAt": "2026-07-29T10:42:44Z"
     },
     {
-      "login": "zccat",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/46469775?v=4",
-      "profileUrl": "https://github.com/zccat",
+      "login": "zouchao",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/1620223?v=4",
+      "profileUrl": "https://github.com/zouchao",
       "commits": 2,
       "mergedPullRequests": 2,
-      "firstContributionAt": "2026-09-10T04:34:56Z",
-      "latestContributionAt": "2026-09-10T09:43:54Z"
+      "firstContributionAt": "2026-06-05T15:39:07Z",
+      "latestContributionAt": "2026-09-11T08:40:12Z"
     },
     {
       "login": "Mukesh-234234",
@@ -1642,15 +1687,6 @@
       "latestContributionAt": "2026-08-31T15:46:03Z"
     },
     {
-      "login": "hanhvs",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/60683892?v=4",
-      "profileUrl": "https://github.com/hanhvs",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-08T02:15:08Z",
-      "latestContributionAt": "2026-09-08T04:13:23Z"
-    },
-    {
       "login": "Hank076",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3490170?v=4",
       "profileUrl": "https://github.com/Hank076",
@@ -1928,6 +1964,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-06T06:29:13Z",
       "latestContributionAt": "2026-08-06T18:19:46Z"
+    },
+    {
+      "login": "New2Niu",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/19551155?v=4",
+      "profileUrl": "https://github.com/New2Niu",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-11T09:28:07Z",
+      "latestContributionAt": "2026-09-11T10:08:24Z"
     },
     {
       "login": "niubinJD",
@@ -2324,15 +2369,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-11T05:21:37Z",
       "latestContributionAt": "2026-08-12T03:51:32Z"
-    },
-    {
-      "login": "zouchao",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/1620223?v=4",
-      "profileUrl": "https://github.com/zouchao",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-06-05T15:39:07Z",
-      "latestContributionAt": "2026-06-05T16:15:53Z"
     },
     {
       "login": "zucchiniEvader",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-08T20:35:26.061Z",
-  "stars": 18404,
+  "generatedAt": "2026-09-09T20:18:01.963Z",
+  "stars": 18669,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3466,
+      "commits": 3487,
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-08T11:42:32Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 728,
-      "mergedPullRequests": 729,
+      "commits": 735,
+      "mergedPullRequests": 736,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-08T11:30:44Z"
+      "latestContributionAt": "2026-09-09T16:42:37Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 228,
-      "mergedPullRequests": 228,
+      "commits": 232,
+      "mergedPullRequests": 232,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-08T16:15:13Z"
+      "latestContributionAt": "2026-09-09T16:29:16Z"
     },
     {
       "login": "q396921921",
@@ -43,37 +43,37 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 116,
-      "mergedPullRequests": 104,
+      "commits": 117,
+      "mergedPullRequests": 105,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-08T14:34:37Z"
+      "latestContributionAt": "2026-09-09T14:36:21Z"
     },
     {
       "login": "CN-Scars",
       "avatarUrl": "https://avatars.githubusercontent.com/u/57054419?v=4",
       "profileUrl": "https://github.com/CN-Scars",
-      "commits": 90,
-      "mergedPullRequests": 90,
+      "commits": 92,
+      "mergedPullRequests": 92,
       "firstContributionAt": "2026-05-30T10:02:05Z",
-      "latestContributionAt": "2026-09-04T17:03:31Z"
+      "latestContributionAt": "2026-09-09T14:36:34Z"
     },
     {
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 89,
-      "mergedPullRequests": 89,
+      "commits": 91,
+      "mergedPullRequests": 91,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-08T04:43:37Z"
+      "latestContributionAt": "2026-09-09T16:28:41Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 73,
-      "mergedPullRequests": 73,
+      "commits": 75,
+      "mergedPullRequests": 75,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-08T03:49:43Z"
+      "latestContributionAt": "2026-09-09T04:04:10Z"
     },
     {
       "login": "serenez",
@@ -175,6 +175,15 @@
       "latestContributionAt": "2026-07-16T17:17:49Z"
     },
     {
+      "login": "Eve-z1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
+      "profileUrl": "https://github.com/Eve-z1",
+      "commits": 20,
+      "mergedPullRequests": 20,
+      "firstContributionAt": "2026-09-01T05:03:42Z",
+      "latestContributionAt": "2026-09-09T15:53:03Z"
+    },
+    {
       "login": "yavon007",
       "avatarUrl": "https://avatars.githubusercontent.com/u/27227092?v=4",
       "profileUrl": "https://github.com/yavon007",
@@ -211,6 +220,15 @@
       "latestContributionAt": "2026-08-30T01:59:24Z"
     },
     {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 15,
+      "mergedPullRequests": 15,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-09-09T14:36:14Z"
+    },
+    {
       "login": "jischeng",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49861575?v=4",
       "profileUrl": "https://github.com/jischeng",
@@ -220,15 +238,6 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
-      "login": "1320209572",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
-      "profileUrl": "https://github.com/1320209572",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-09-01T05:03:42Z",
-      "latestContributionAt": "2026-09-08T14:34:57Z"
-    },
-    {
       "login": "AndrewDi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
       "profileUrl": "https://github.com/AndrewDi",
@@ -236,15 +245,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-08-03T09:45:43Z",
       "latestContributionAt": "2026-08-20T10:50:22Z"
-    },
-    {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-09-08T14:57:02Z"
     },
     {
       "login": "dienaso",
@@ -553,6 +553,15 @@
       "latestContributionAt": "2026-08-25T06:46:25Z"
     },
     {
+      "login": "ordinary-s",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
+      "profileUrl": "https://github.com/ordinary-s",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-08-18T11:36:48Z",
+      "latestContributionAt": "2026-09-09T15:52:55Z"
+    },
+    {
       "login": "Staroon",
       "avatarUrl": "https://avatars.githubusercontent.com/u/26004564?v=4",
       "profileUrl": "https://github.com/Staroon",
@@ -650,15 +659,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-08T17:32:08Z",
       "latestContributionAt": "2026-08-06T04:13:57Z"
-    },
-    {
-      "login": "ordinary-s",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/59008530?v=4",
-      "profileUrl": "https://github.com/ordinary-s",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-08-18T11:36:48Z",
-      "latestContributionAt": "2026-09-05T14:18:04Z"
     },
     {
       "login": "soddygo",
@@ -832,6 +832,24 @@
       "latestContributionAt": "2026-09-02T01:15:10Z"
     },
     {
+      "login": "Tara8573",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
+      "profileUrl": "https://github.com/Tara8573",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-08-22T04:03:32Z",
+      "latestContributionAt": "2026-09-09T14:36:07Z"
+    },
+    {
+      "login": "tdog54646",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/188939710?v=4",
+      "profileUrl": "https://github.com/tdog54646",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-09T03:51:34Z",
+      "latestContributionAt": "2026-09-09T15:53:17Z"
+    },
+    {
       "login": "vergil-lai",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2268937?v=4",
       "profileUrl": "https://github.com/vergil-lai",
@@ -1003,6 +1021,15 @@
       "latestContributionAt": "2026-08-06T15:33:29Z"
     },
     {
+      "login": "HolyeTyrone",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43714994?v=4",
+      "profileUrl": "https://github.com/HolyeTyrone",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-08T03:33:05Z",
+      "latestContributionAt": "2026-09-09T06:44:35Z"
+    },
+    {
       "login": "ijevin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/2133499?v=4",
       "profileUrl": "https://github.com/ijevin",
@@ -1156,15 +1183,6 @@
       "latestContributionAt": "2026-08-06T06:09:21Z"
     },
     {
-      "login": "Tara8573",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/39621793?v=4",
-      "profileUrl": "https://github.com/Tara8573",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-08-22T04:03:32Z",
-      "latestContributionAt": "2026-09-04T06:48:42Z"
-    },
-    {
       "login": "Tiath",
       "avatarUrl": "https://avatars.githubusercontent.com/u/139197180?v=4",
       "profileUrl": "https://github.com/Tiath",
@@ -1280,6 +1298,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-08-06T02:22:08Z",
       "latestContributionAt": "2026-08-06T04:41:24Z"
+    },
+    {
+      "login": "64673a",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/96230516?v=4",
+      "profileUrl": "https://github.com/64673a",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-09T06:04:20Z",
+      "latestContributionAt": "2026-09-09T08:29:32Z"
     },
     {
       "login": "adntian",
@@ -1543,6 +1570,15 @@
       "latestContributionAt": "2026-08-27T09:37:55Z"
     },
     {
+      "login": "fordes123",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/52121395?v=4",
+      "profileUrl": "https://github.com/fordes123",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-09T09:34:27Z",
+      "latestContributionAt": "2026-09-09T16:28:59Z"
+    },
+    {
       "login": "fuuulstack",
       "avatarUrl": "https://avatars.githubusercontent.com/u/38742225?v=4",
       "profileUrl": "https://github.com/fuuulstack",
@@ -1633,15 +1669,6 @@
       "latestContributionAt": "2026-07-06T10:21:15Z"
     },
     {
-      "login": "HolyeTyrone",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/43714994?v=4",
-      "profileUrl": "https://github.com/HolyeTyrone",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-08T03:33:05Z",
-      "latestContributionAt": "2026-09-08T08:46:40Z"
-    },
-    {
       "login": "huangyemin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/11872262?v=4",
       "profileUrl": "https://github.com/huangyemin",
@@ -1703,6 +1730,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-24T12:23:36Z",
       "latestContributionAt": "2026-07-24T13:11:18Z"
+    },
+    {
+      "login": "jamalkamaladdin",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/256541632?v=4",
+      "profileUrl": "https://github.com/jamalkamaladdin",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-09T02:05:04Z",
+      "latestContributionAt": "2026-09-09T04:30:53Z"
     },
     {
       "login": "jasonchen8068",
@@ -2279,6 +2315,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-23T05:56:48Z",
       "latestContributionAt": "2026-06-23T17:44:46Z"
+    },
+    {
+      "login": "Zyuery",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/95332153?v=4",
+      "profileUrl": "https://github.com/Zyuery",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-09T05:04:07Z",
+      "latestContributionAt": "2026-09-09T06:22:07Z"
     },
     {
       "login": "octo-patch",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-09T20:18:01.963Z",
-  "stars": 18669,
+  "generatedAt": "2026-09-10T20:20:10.451Z",
+  "stars": 18896,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3487,
+      "commits": 3495,
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-08T11:42:32Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 735,
-      "mergedPullRequests": 736,
+      "commits": 749,
+      "mergedPullRequests": 750,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-09T16:42:37Z"
+      "latestContributionAt": "2026-09-10T13:07:41Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 232,
-      "mergedPullRequests": 232,
+      "commits": 239,
+      "mergedPullRequests": 239,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-09T16:29:16Z"
+      "latestContributionAt": "2026-09-10T07:57:28Z"
     },
     {
       "login": "q396921921",
@@ -43,10 +43,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 117,
-      "mergedPullRequests": 105,
+      "commits": 119,
+      "mergedPullRequests": 107,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-09T14:36:21Z"
+      "latestContributionAt": "2026-09-10T10:04:06Z"
     },
     {
       "login": "CN-Scars",
@@ -70,10 +70,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 75,
-      "mergedPullRequests": 75,
+      "commits": 79,
+      "mergedPullRequests": 79,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-09T04:04:10Z"
+      "latestContributionAt": "2026-09-10T11:30:23Z"
     },
     {
       "login": "serenez",
@@ -139,6 +139,15 @@
       "latestContributionAt": "2026-07-17T09:12:32Z"
     },
     {
+      "login": "Eve-z1",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
+      "profileUrl": "https://github.com/Eve-z1",
+      "commits": 26,
+      "mergedPullRequests": 26,
+      "firstContributionAt": "2026-09-01T05:03:42Z",
+      "latestContributionAt": "2026-09-10T07:57:16Z"
+    },
+    {
       "login": "SuLea-IT",
       "avatarUrl": "https://avatars.githubusercontent.com/u/105108570?v=4",
       "profileUrl": "https://github.com/SuLea-IT",
@@ -173,15 +182,6 @@
       "mergedPullRequests": 22,
       "firstContributionAt": "2026-06-26T03:29:22Z",
       "latestContributionAt": "2026-07-16T17:17:49Z"
-    },
-    {
-      "login": "Eve-z1",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
-      "profileUrl": "https://github.com/Eve-z1",
-      "commits": 20,
-      "mergedPullRequests": 20,
-      "firstContributionAt": "2026-09-01T05:03:42Z",
-      "latestContributionAt": "2026-09-09T15:53:03Z"
     },
     {
       "login": "yavon007",
@@ -400,6 +400,15 @@
       "latestContributionAt": "2026-08-29T20:17:33Z"
     },
     {
+      "login": "jeeinn",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
+      "profileUrl": "https://github.com/jeeinn",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-07-02T15:29:53Z",
+      "latestContributionAt": "2026-09-10T03:23:57Z"
+    },
+    {
       "login": "Jinmoli",
       "avatarUrl": "https://avatars.githubusercontent.com/u/49105556?v=4",
       "profileUrl": "https://github.com/Jinmoli",
@@ -443,15 +452,6 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-06-11T15:15:39Z",
       "latestContributionAt": "2026-07-28T19:47:20Z"
-    },
-    {
-      "login": "jeeinn",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/13930054?v=4",
-      "profileUrl": "https://github.com/jeeinn",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-07-02T15:29:53Z",
-      "latestContributionAt": "2026-08-12T14:22:34Z"
     },
     {
       "login": "Lan-zk",
@@ -515,6 +515,15 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-24T07:06:09Z",
       "latestContributionAt": "2026-08-07T05:43:30Z"
+    },
+    {
+      "login": "CSXFanMeng",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
+      "profileUrl": "https://github.com/CSXFanMeng",
+      "commits": 5,
+      "mergedPullRequests": 5,
+      "firstContributionAt": "2026-07-02T10:52:18Z",
+      "latestContributionAt": "2026-09-10T04:46:57Z"
     },
     {
       "login": "fraluc06",
@@ -623,15 +632,6 @@
       "mergedPullRequests": 4,
       "firstContributionAt": "2026-06-06T11:21:25Z",
       "latestContributionAt": "2026-06-29T03:16:38Z"
-    },
-    {
-      "login": "CSXFanMeng",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/105690322?v=4",
-      "profileUrl": "https://github.com/CSXFanMeng",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-07-02T10:52:18Z",
-      "latestContributionAt": "2026-08-02T11:35:45Z"
     },
     {
       "login": "Dreamescaper",
@@ -758,6 +758,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-06-20T08:35:12Z",
       "latestContributionAt": "2026-08-20T01:28:40Z"
+    },
+    {
+      "login": "jasonchen8068",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/37900422?v=4",
+      "profileUrl": "https://github.com/jasonchen8068",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-07T07:06:55Z",
+      "latestContributionAt": "2026-09-10T10:04:17Z"
     },
     {
       "login": "kir1ito",
@@ -1183,6 +1192,15 @@
       "latestContributionAt": "2026-08-06T06:09:21Z"
     },
     {
+      "login": "thailoc-dev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/113083148?v=4",
+      "profileUrl": "https://github.com/thailoc-dev",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-10T02:47:44Z",
+      "latestContributionAt": "2026-09-10T08:18:22Z"
+    },
+    {
       "login": "Tiath",
       "avatarUrl": "https://avatars.githubusercontent.com/u/139197180?v=4",
       "profileUrl": "https://github.com/Tiath",
@@ -1280,6 +1298,15 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-22T18:14:03Z",
       "latestContributionAt": "2026-07-29T10:42:44Z"
+    },
+    {
+      "login": "zccat",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/46469775?v=4",
+      "profileUrl": "https://github.com/zccat",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-09-10T04:34:56Z",
+      "latestContributionAt": "2026-09-10T09:43:54Z"
     },
     {
       "login": "Mukesh-234234",
@@ -1741,15 +1768,6 @@
       "latestContributionAt": "2026-09-09T04:30:53Z"
     },
     {
-      "login": "jasonchen8068",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/37900422?v=4",
-      "profileUrl": "https://github.com/jasonchen8068",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-09-07T07:06:55Z",
-      "latestContributionAt": "2026-09-07T16:14:09Z"
-    },
-    {
       "login": "JeaceLiu",
       "avatarUrl": "https://avatars.githubusercontent.com/u/31269749?v=4",
       "profileUrl": "https://github.com/JeaceLiu",
@@ -1793,6 +1811,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-28T12:16:44Z",
       "latestContributionAt": "2026-07-28T16:08:04Z"
+    },
+    {
+      "login": "Lanyujiex",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/15024534?v=4",
+      "profileUrl": "https://github.com/Lanyujiex",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-10T08:45:59Z",
+      "latestContributionAt": "2026-09-10T11:23:29Z"
     },
     {
       "login": "laosiji66666",
@@ -2324,6 +2351,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-09-09T05:04:07Z",
       "latestContributionAt": "2026-09-09T06:22:07Z"
+    },
+    {
+      "login": "lizhian",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/39126397?v=4",
+      "profileUrl": "https://github.com/lizhian",
+      "commits": 0,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-09T09:59:55Z",
+      "latestContributionAt": "2026-09-10T16:52:52Z"
     },
     {
       "login": "octo-patch",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,34 +1,34 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-07T21:00:44.204Z",
-  "stars": 18212,
+  "generatedAt": "2026-09-08T20:35:26.061Z",
+  "stars": 18404,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3430,
-      "mergedPullRequests": 26,
+      "commits": 3466,
+      "mergedPullRequests": 27,
       "firstContributionAt": "2026-04-30T08:14:51Z",
-      "latestContributionAt": "2026-09-02T10:17:27Z"
+      "latestContributionAt": "2026-09-08T11:42:32Z"
     },
     {
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 722,
-      "mergedPullRequests": 723,
+      "commits": 728,
+      "mergedPullRequests": 729,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-07T17:43:13Z"
+      "latestContributionAt": "2026-09-08T11:30:44Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 224,
-      "mergedPullRequests": 224,
+      "commits": 228,
+      "mergedPullRequests": 228,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-07T17:47:37Z"
+      "latestContributionAt": "2026-09-08T16:15:13Z"
     },
     {
       "login": "q396921921",
@@ -43,10 +43,10 @@
       "login": "Abeautifulsnow",
       "avatarUrl": "https://avatars.githubusercontent.com/u/28704977?v=4",
       "profileUrl": "https://github.com/Abeautifulsnow",
-      "commits": 113,
-      "mergedPullRequests": 101,
+      "commits": 116,
+      "mergedPullRequests": 104,
       "firstContributionAt": "2026-05-06T03:16:57Z",
-      "latestContributionAt": "2026-09-07T14:44:24Z"
+      "latestContributionAt": "2026-09-08T14:34:37Z"
     },
     {
       "login": "CN-Scars",
@@ -61,19 +61,19 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 88,
-      "mergedPullRequests": 88,
+      "commits": 89,
+      "mergedPullRequests": 89,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-07T06:04:39Z"
+      "latestContributionAt": "2026-09-08T04:43:37Z"
     },
     {
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 72,
-      "mergedPullRequests": 72,
+      "commits": 73,
+      "mergedPullRequests": 73,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-03T03:56:46Z"
+      "latestContributionAt": "2026-09-08T03:49:43Z"
     },
     {
       "login": "serenez",
@@ -88,10 +88,10 @@
       "login": "onceMisery",
       "avatarUrl": "https://avatars.githubusercontent.com/u/37446017?v=4",
       "profileUrl": "https://github.com/onceMisery",
-      "commits": 47,
-      "mergedPullRequests": 45,
+      "commits": 48,
+      "mergedPullRequests": 46,
       "firstContributionAt": "2026-06-10T14:19:43Z",
-      "latestContributionAt": "2026-09-05T14:22:55Z"
+      "latestContributionAt": "2026-09-08T03:19:24Z"
     },
     {
       "login": "mapan0424",
@@ -220,6 +220,15 @@
       "latestContributionAt": "2026-07-29T12:41:10Z"
     },
     {
+      "login": "1320209572",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
+      "profileUrl": "https://github.com/1320209572",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-09-01T05:03:42Z",
+      "latestContributionAt": "2026-09-08T14:34:57Z"
+    },
+    {
       "login": "AndrewDi",
       "avatarUrl": "https://avatars.githubusercontent.com/u/7589147?v=4",
       "profileUrl": "https://github.com/AndrewDi",
@@ -227,6 +236,15 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-08-03T09:45:43Z",
       "latestContributionAt": "2026-08-20T10:50:22Z"
+    },
+    {
+      "login": "DASungta",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
+      "profileUrl": "https://github.com/DASungta",
+      "commits": 14,
+      "mergedPullRequests": 14,
+      "firstContributionAt": "2026-07-21T04:15:46Z",
+      "latestContributionAt": "2026-09-08T14:57:02Z"
     },
     {
       "login": "dienaso",
@@ -245,15 +263,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-06-29T10:02:55Z",
       "latestContributionAt": "2026-07-21T16:25:09Z"
-    },
-    {
-      "login": "DASungta",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/8896967?v=4",
-      "profileUrl": "https://github.com/DASungta",
-      "commits": 13,
-      "mergedPullRequests": 13,
-      "firstContributionAt": "2026-07-21T04:15:46Z",
-      "latestContributionAt": "2026-08-24T05:29:24Z"
     },
     {
       "login": "SpencerZhang",
@@ -578,15 +587,6 @@
       "mergedPullRequests": 5,
       "firstContributionAt": "2026-07-08T02:54:27Z",
       "latestContributionAt": "2026-09-07T14:50:33Z"
-    },
-    {
-      "login": "1320209572",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/92513238?v=4",
-      "profileUrl": "https://github.com/1320209572",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-09-01T05:03:42Z",
-      "latestContributionAt": "2026-09-02T17:53:31Z"
     },
     {
       "login": "azens",
@@ -1093,6 +1093,15 @@
       "latestContributionAt": "2026-08-02T08:35:04Z"
     },
     {
+      "login": "luojiyin1987",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/6524977?v=4",
+      "profileUrl": "https://github.com/luojiyin1987",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-08-17T02:51:45Z",
+      "latestContributionAt": "2026-09-08T14:37:10Z"
+    },
+    {
       "login": "onlyc0302",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24369193?v=4",
       "profileUrl": "https://github.com/onlyc0302",
@@ -1156,6 +1165,15 @@
       "latestContributionAt": "2026-09-04T06:48:42Z"
     },
     {
+      "login": "Tiath",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/139197180?v=4",
+      "profileUrl": "https://github.com/Tiath",
+      "commits": 2,
+      "mergedPullRequests": 2,
+      "firstContributionAt": "2026-07-21T07:45:25Z",
+      "latestContributionAt": "2026-07-23T09:29:45Z"
+    },
+    {
       "login": "togls",
       "avatarUrl": "https://avatars.githubusercontent.com/u/17137090?v=4",
       "profileUrl": "https://github.com/togls",
@@ -1163,15 +1181,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-07-29T12:10:15Z",
       "latestContributionAt": "2026-07-30T18:01:46Z"
-    },
-    {
-      "login": "TongEc",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/139197180?v=4",
-      "profileUrl": "https://github.com/TongEc",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-07-21T07:45:25Z",
-      "latestContributionAt": "2026-07-23T09:29:45Z"
     },
     {
       "login": "Tssshhhh",
@@ -1570,6 +1579,15 @@
       "latestContributionAt": "2026-08-31T15:46:03Z"
     },
     {
+      "login": "hanhvs",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/60683892?v=4",
+      "profileUrl": "https://github.com/hanhvs",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-08T02:15:08Z",
+      "latestContributionAt": "2026-09-08T04:13:23Z"
+    },
+    {
       "login": "Hank076",
       "avatarUrl": "https://avatars.githubusercontent.com/u/3490170?v=4",
       "profileUrl": "https://github.com/Hank076",
@@ -1613,6 +1631,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-06T09:27:49Z",
       "latestContributionAt": "2026-07-06T10:21:15Z"
+    },
+    {
+      "login": "HolyeTyrone",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/43714994?v=4",
+      "profileUrl": "https://github.com/HolyeTyrone",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-08T03:33:05Z",
+      "latestContributionAt": "2026-09-08T08:46:40Z"
     },
     {
       "login": "huangyemin",
@@ -1750,6 +1777,15 @@
       "latestContributionAt": "2026-08-26T06:43:53Z"
     },
     {
+      "login": "leekeep",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/31622515?v=4",
+      "profileUrl": "https://github.com/leekeep",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-08T00:53:34Z",
+      "latestContributionAt": "2026-09-08T14:35:07Z"
+    },
+    {
       "login": "leic4u",
       "avatarUrl": "https://avatars.githubusercontent.com/u/32786903?v=4",
       "profileUrl": "https://github.com/leic4u",
@@ -1775,15 +1811,6 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-07-28T07:41:12Z",
       "latestContributionAt": "2026-07-28T15:18:13Z"
-    },
-    {
-      "login": "luojiyin1987",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/6524977?v=4",
-      "profileUrl": "https://github.com/luojiyin1987",
-      "commits": 1,
-      "mergedPullRequests": 1,
-      "firstContributionAt": "2026-08-17T02:51:45Z",
-      "latestContributionAt": "2026-08-17T07:10:31Z"
     },
     {
       "login": "ManjusriBuddha",

--- a/docs/data/contributors.json
+++ b/docs/data/contributors.json
@@ -1,13 +1,13 @@
 {
   "repository": "t8y2/dbx",
-  "generatedAt": "2026-09-11T20:20:31.193Z",
-  "stars": 19151,
+  "generatedAt": "2026-09-12T20:02:13.798Z",
+  "stars": 19257,
   "contributors": [
     {
       "login": "t8y2",
       "avatarUrl": "https://avatars.githubusercontent.com/u/77960507?v=4",
       "profileUrl": "https://github.com/t8y2",
-      "commits": 3502,
+      "commits": 3503,
       "mergedPullRequests": 27,
       "firstContributionAt": "2026-04-30T08:14:51Z",
       "latestContributionAt": "2026-09-08T11:42:32Z"
@@ -16,19 +16,19 @@
       "login": "zipg",
       "avatarUrl": "https://avatars.githubusercontent.com/u/4047349?v=4",
       "profileUrl": "https://github.com/zipg",
-      "commits": 752,
-      "mergedPullRequests": 753,
+      "commits": 769,
+      "mergedPullRequests": 768,
       "firstContributionAt": "2026-06-22T06:10:59Z",
-      "latestContributionAt": "2026-09-11T13:10:49Z"
+      "latestContributionAt": "2026-09-12T18:00:10Z"
     },
     {
       "login": "eryajf",
       "avatarUrl": "https://avatars.githubusercontent.com/u/33259379?v=4",
       "profileUrl": "https://github.com/eryajf",
-      "commits": 248,
-      "mergedPullRequests": 248,
+      "commits": 253,
+      "mergedPullRequests": 253,
       "firstContributionAt": "2026-06-08T11:45:45Z",
-      "latestContributionAt": "2026-09-11T15:25:18Z"
+      "latestContributionAt": "2026-09-12T18:11:18Z"
     },
     {
       "login": "q396921921",
@@ -52,10 +52,10 @@
       "login": "0verme",
       "avatarUrl": "https://avatars.githubusercontent.com/u/24986278?v=4",
       "profileUrl": "https://github.com/0verme",
-      "commits": 92,
-      "mergedPullRequests": 92,
+      "commits": 95,
+      "mergedPullRequests": 95,
       "firstContributionAt": "2026-08-15T15:33:44Z",
-      "latestContributionAt": "2026-09-11T02:52:19Z"
+      "latestContributionAt": "2026-09-12T17:41:01Z"
     },
     {
       "login": "CN-Scars",
@@ -70,10 +70,10 @@
       "login": "onenewcode",
       "avatarUrl": "https://avatars.githubusercontent.com/u/94808747?v=4",
       "profileUrl": "https://github.com/onenewcode",
-      "commits": 81,
-      "mergedPullRequests": 81,
+      "commits": 82,
+      "mergedPullRequests": 82,
       "firstContributionAt": "2026-06-30T01:53:31Z",
-      "latestContributionAt": "2026-09-11T08:56:50Z"
+      "latestContributionAt": "2026-09-12T13:59:30Z"
     },
     {
       "login": "serenez",
@@ -193,6 +193,15 @@
       "latestContributionAt": "2026-05-20T08:10:15Z"
     },
     {
+      "login": "dienaso",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
+      "profileUrl": "https://github.com/dienaso",
+      "commits": 16,
+      "mergedPullRequests": 16,
+      "firstContributionAt": "2026-07-24T03:23:39Z",
+      "latestContributionAt": "2026-09-12T17:40:06Z"
+    },
+    {
       "login": "linjianlin",
       "avatarUrl": "https://avatars.githubusercontent.com/u/46356519?v=4",
       "profileUrl": "https://github.com/linjianlin",
@@ -245,15 +254,6 @@
       "mergedPullRequests": 14,
       "firstContributionAt": "2026-08-03T09:45:43Z",
       "latestContributionAt": "2026-08-20T10:50:22Z"
-    },
-    {
-      "login": "dienaso",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/4003733?v=4",
-      "profileUrl": "https://github.com/dienaso",
-      "commits": 14,
-      "mergedPullRequests": 14,
-      "firstContributionAt": "2026-07-24T03:23:39Z",
-      "latestContributionAt": "2026-09-06T07:00:01Z"
     },
     {
       "login": "juvevood",
@@ -418,6 +418,15 @@
       "latestContributionAt": "2026-08-13T11:25:08Z"
     },
     {
+      "login": "Mo-Moore",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
+      "profileUrl": "https://github.com/Mo-Moore",
+      "commits": 7,
+      "mergedPullRequests": 7,
+      "firstContributionAt": "2026-08-27T05:54:45Z",
+      "latestContributionAt": "2026-09-12T09:39:14Z"
+    },
+    {
       "login": "wzlstudy",
       "avatarUrl": "https://avatars.githubusercontent.com/u/54768887?v=4",
       "profileUrl": "https://github.com/wzlstudy",
@@ -481,15 +490,6 @@
       "latestContributionAt": "2026-07-01T11:05:45Z"
     },
     {
-      "login": "Mo-Moore",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/33098900?v=4",
-      "profileUrl": "https://github.com/Mo-Moore",
-      "commits": 6,
-      "mergedPullRequests": 6,
-      "firstContributionAt": "2026-08-27T05:54:45Z",
-      "latestContributionAt": "2026-09-02T06:15:04Z"
-    },
-    {
       "login": "possebon",
       "avatarUrl": "https://avatars.githubusercontent.com/u/257745?v=4",
       "profileUrl": "https://github.com/possebon",
@@ -506,6 +506,15 @@
       "mergedPullRequests": 6,
       "firstContributionAt": "2026-09-10T02:47:44Z",
       "latestContributionAt": "2026-09-11T13:10:04Z"
+    },
+    {
+      "login": "thanadon-dev",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/71448810?v=4",
+      "profileUrl": "https://github.com/thanadon-dev",
+      "commits": 6,
+      "mergedPullRequests": 6,
+      "firstContributionAt": "2026-09-10T15:27:44Z",
+      "latestContributionAt": "2026-09-12T13:42:32Z"
     },
     {
       "login": "xiaou61",
@@ -697,15 +706,6 @@
       "latestContributionAt": "2026-09-11T06:14:30Z"
     },
     {
-      "login": "thanadon-dev",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/71448810?v=4",
-      "profileUrl": "https://github.com/thanadon-dev",
-      "commits": 4,
-      "mergedPullRequests": 4,
-      "firstContributionAt": "2026-09-10T15:27:44Z",
-      "latestContributionAt": "2026-09-11T15:26:30Z"
-    },
-    {
       "login": "wuxiemian",
       "avatarUrl": "https://avatars.githubusercontent.com/u/29685283?v=4",
       "profileUrl": "https://github.com/wuxiemian",
@@ -749,6 +749,15 @@
       "mergedPullRequests": 3,
       "firstContributionAt": "2026-08-06T10:14:50Z",
       "latestContributionAt": "2026-08-11T13:32:15Z"
+    },
+    {
+      "login": "CHNHJF",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/56990620?v=4",
+      "profileUrl": "https://github.com/CHNHJF",
+      "commits": 3,
+      "mergedPullRequests": 3,
+      "firstContributionAt": "2026-09-11T02:18:22Z",
+      "latestContributionAt": "2026-09-12T01:29:05Z"
     },
     {
       "login": "Clarence404",
@@ -992,15 +1001,6 @@
       "mergedPullRequests": 2,
       "firstContributionAt": "2026-06-20T04:19:56Z",
       "latestContributionAt": "2026-06-20T16:04:52Z"
-    },
-    {
-      "login": "CHNHJF",
-      "avatarUrl": "https://avatars.githubusercontent.com/u/56990620?v=4",
-      "profileUrl": "https://github.com/CHNHJF",
-      "commits": 2,
-      "mergedPullRequests": 2,
-      "firstContributionAt": "2026-09-11T02:18:22Z",
-      "latestContributionAt": "2026-09-11T08:40:48Z"
     },
     {
       "login": "cwatanab",
@@ -2018,6 +2018,15 @@
       "mergedPullRequests": 1,
       "firstContributionAt": "2026-06-27T09:12:08Z",
       "latestContributionAt": "2026-06-27T12:03:17Z"
+    },
+    {
+      "login": "PanSHIgg",
+      "avatarUrl": "https://avatars.githubusercontent.com/u/165797598?v=4",
+      "profileUrl": "https://github.com/PanSHIgg",
+      "commits": 1,
+      "mergedPullRequests": 1,
+      "firstContributionAt": "2026-09-12T03:29:36Z",
+      "latestContributionAt": "2026-09-12T09:46:00Z"
     },
     {
       "login": "private20",


### PR DESCRIPTION
## 关联 Issue

Fixes #9183

## 问题

SQL Server 2000 用户连接 DBX 后，仅展开一个数据库节点就会被火绒误报为 SQL 爆破攻击并断开连接。用户实测：保持连接但不展开数据库树超过 5 分钟不会触发，展开一个数据库节点后立即触发。

## 原因

连接建立时已有连接级连接池。旧逻辑在读取数据库节点元数据时，按“连接 ID + 数据库名”重新创建 SQL Server 2000 JDBC Agent 连接，产生额外物理登录会话。

## 修复

- SQL Server 2000 兼容驱动的元数据请求复用连接级连接池。
- 继续通过 Agent 请求级 `setCatalog` 切换目标数据库。
- 同步修正元数据连接重连、异常回收和 pool key 处理。
- 原生 SQL Server 驱动和普通查询连接池行为保持不变。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p dbx-core legacy_sqlserver_metadata_reuses_connection_pool_across_databases --lib`
- `cargo test -p dbx-core sqlserver_ --lib`：231 passed，4 ignored
- `cargo test -p dbx-core metadata_ --lib`：72 passed，3 ignored
- `git diff --check`

## 待人工验证

需要在 SQL Server 2000 + 火绒环境中使用本构建连接数据库，并展开数据库节点，确认不再触发 SQL 爆破拦截。验证通过后再转为可合并状态。